### PR TITLE
Comments Redesign: Add the edit mode

### DIFF
--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -41,6 +41,7 @@ const commentActions = {
 export class CommentActions extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
+		toggleEditMode: PropTypes.func,
 		toggleReply: PropTypes.func,
 		updateLastUndo: PropTypes.func,
 	};
@@ -151,7 +152,13 @@ export class CommentActions extends Component {
 	};
 
 	render() {
-		const { commentIsApproved, commentIsLiked, toggleReply, translate } = this.props;
+		const {
+			commentIsApproved,
+			commentIsLiked,
+			toggleEditMode,
+			toggleReply,
+			translate,
+		} = this.props;
 
 		return (
 			<div className="comment__actions">
@@ -211,6 +218,17 @@ export class CommentActions extends Component {
 					>
 						<Gridicon icon={ commentIsLiked ? 'star' : 'star-outline' } />
 						<span>{ commentIsLiked ? translate( 'Liked' ) : translate( 'Like' ) }</span>
+					</Button>
+				) }
+
+				{ this.hasAction( 'edit' ) && (
+					<Button
+						borderless
+						className="comment__action comment__action-pencil"
+						onClick={ toggleEditMode }
+					>
+						<Gridicon icon="pencil" />
+						<span>{ translate( 'Edit' ) }</span>
 					</Button>
 				) }
 

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -1,0 +1,202 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import { get, pick } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import FormButton from 'components/forms/form-button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextarea from 'components/forms/form-textarea';
+import FormTextInput from 'components/forms/form-text-input';
+import InfoPopover from 'components/info-popover';
+import { decodeEntities } from 'lib/formatting';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
+import { editComment } from 'state/comments/actions';
+import { removeNotice, successNotice } from 'state/notices/actions';
+import { getSiteComment } from 'state/selectors';
+import { getSiteSlug, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+export class CommentEdit extends Component {
+	static propTypes = {
+		commentId: PropTypes.number,
+		toggleEditMode: PropTypes.func,
+	};
+
+	state = {
+		authorDisplayName: '',
+		authorUrl: '',
+		commentContent: '',
+	};
+
+	componentWillMount() {
+		const { authorDisplayName, authorUrl, commentContent } = this.props;
+		this.setState( { authorDisplayName, authorUrl, commentContent } );
+	}
+
+	setAuthorDisplayNameValue = event => this.setState( { authorDisplayName: event.target.value } );
+
+	setAuthorUrlValue = event => this.setState( { authorUrl: event.target.value } );
+
+	setCommentContentValue = event => this.setState( { commentContent: event.target.value } );
+
+	showNotice = () => {
+		const { translate } = this.props;
+
+		this.props.removeNotice( 'comment-notice' );
+
+		const previousCommentData = pick( this.props, [
+			'authorDisplayName',
+			'authorUrl',
+			'commentContent',
+		] );
+
+		const noticeOptions = {
+			button: translate( 'Undo' ),
+			id: 'comment-notice',
+			isPersistent: true,
+			onClick: this.undo( previousCommentData ),
+		};
+
+		this.props.successNotice( translate( 'Your comment has been updated.' ), noticeOptions );
+	};
+
+	submitEdit = () => {
+		const { postId, siteId, toggleEditMode } = this.props;
+
+		this.props.editComment( siteId, postId, this.state );
+
+		this.showNotice();
+
+		toggleEditMode();
+	};
+
+	undo = previousCommentData => () => {
+		const { postId, siteId } = this.props;
+		this.props.editComment( siteId, postId, previousCommentData );
+		this.props.removeNotice( 'comment-notice' );
+	};
+
+	render() {
+		const {
+			isAuthorRegistered,
+			isEditCommentSupported,
+			siteSlug,
+			toggleEditMode,
+			translate,
+		} = this.props;
+		const { authorDisplayName, authorUrl, commentContent } = this.state;
+
+		return (
+			<div className="comment__edit">
+				<FormFieldset>
+					<FormLabel htmlFor="author">{ translate( 'Name' ) }</FormLabel>
+					{ isAuthorRegistered && (
+						<InfoPopover>
+							{ translate( "This user is registered, the name can't be edited." ) }
+						</InfoPopover>
+					) }
+					<FormTextInput
+						disabled={ ! isEditCommentSupported || isAuthorRegistered }
+						id="author"
+						onChange={ this.setAuthorDisplayNameValue }
+						value={ authorDisplayName }
+					/>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel htmlFor="author_url">{ translate( 'URL' ) }</FormLabel>
+					{ isAuthorRegistered && (
+						<InfoPopover>
+							{ translate( "This user is registered, the URL can't be edited." ) }
+						</InfoPopover>
+					) }
+					<FormTextInput
+						disabled={ ! isEditCommentSupported || isAuthorRegistered }
+						id="author_url"
+						onChange={ this.setAuthorUrlValue }
+						value={ authorUrl }
+					/>
+				</FormFieldset>
+
+				<FormTextarea
+					disabled={ ! isEditCommentSupported }
+					onChange={ this.setCommentContentValue }
+					value={ commentContent }
+				/>
+
+				{ ! isEditCommentSupported && (
+					<p className="comment__edit-jetpack-update-notice">
+						<Gridicon icon="notice-outline" />
+						{ translate( 'Comment editing requires a newer version of Jetpack.' ) }
+						<a
+							className="comment__edit-jetpack-update-notice-link"
+							href={ `/plugins/jetpack/${ siteSlug }` }
+						>
+							{ translate( 'Update Now' ) }
+						</a>
+					</p>
+				) }
+
+				<div className="comment__edit-buttons">
+					<FormButton compact disabled={ ! isEditCommentSupported } onClick={ this.submitEdit }>
+						{ translate( 'Save' ) }
+					</FormButton>
+					<FormButton compact isPrimary={ false } onClick={ toggleEditMode } type="button">
+						{ translate( 'Cancel' ) }
+					</FormButton>
+				</div>
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = ( state, { commentId } ) => {
+	const siteId = getSelectedSiteId( state );
+	const isEditCommentSupported =
+		! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' );
+	const comment = getSiteComment( state, siteId, commentId );
+	const authorDisplayName = decodeEntities( get( comment, 'author.name' ) );
+	const isAuthorRegistered = 0 !== get( comment, 'author.ID' );
+	return {
+		authorDisplayName,
+		authorUrl: get( comment, 'author.URL', '' ),
+		commentContent: get( comment, 'raw_content' ),
+		isAuthorRegistered,
+		isEditCommentSupported,
+		postId: get( comment, 'post.ID' ),
+		siteId,
+		siteSlug: getSiteSlug( state, siteId ),
+	};
+};
+
+const mapDispatchToProps = ( dispatch, { commentId } ) => ( {
+	editComment: ( siteId, postId, comment ) =>
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_edit' ),
+					bumpStat( 'calypso_comment_management', 'comment_updated' )
+				),
+				editComment( siteId, postId, commentId, comment )
+			)
+		),
+	removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),
+	successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentEdit ) );

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -103,54 +103,58 @@ export class CommentEdit extends Component {
 
 		return (
 			<div className="comment__edit">
-				<FormFieldset>
-					<FormLabel htmlFor="author">{ translate( 'Name' ) }</FormLabel>
-					{ isAuthorRegistered && (
-						<InfoPopover>
-							{ translate( "This user is registered, the name can't be edited." ) }
-						</InfoPopover>
-					) }
-					<FormTextInput
-						disabled={ ! isEditCommentSupported || isAuthorRegistered }
-						id="author"
-						onChange={ this.setAuthorDisplayNameValue }
-						value={ authorDisplayName }
+				<div className="comment__edit-header">{ translate( 'Edit Comment' ) }</div>
+
+				<div className="comment__edit-wrapper">
+					<FormFieldset>
+						<FormLabel htmlFor="author">{ translate( 'Name' ) }</FormLabel>
+						{ isAuthorRegistered && (
+							<InfoPopover>
+								{ translate( "This user is registered, the name can't be edited." ) }
+							</InfoPopover>
+						) }
+						<FormTextInput
+							disabled={ ! isEditCommentSupported || isAuthorRegistered }
+							id="author"
+							onChange={ this.setAuthorDisplayNameValue }
+							value={ authorDisplayName }
+						/>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="author_url">{ translate( 'URL' ) }</FormLabel>
+						{ isAuthorRegistered && (
+							<InfoPopover>
+								{ translate( "This user is registered, the URL can't be edited." ) }
+							</InfoPopover>
+						) }
+						<FormTextInput
+							disabled={ ! isEditCommentSupported || isAuthorRegistered }
+							id="author_url"
+							onChange={ this.setAuthorUrlValue }
+							value={ authorUrl }
+						/>
+					</FormFieldset>
+
+					<FormTextarea
+						disabled={ ! isEditCommentSupported }
+						onChange={ this.setCommentContentValue }
+						value={ commentContent }
 					/>
-				</FormFieldset>
 
-				<FormFieldset>
-					<FormLabel htmlFor="author_url">{ translate( 'URL' ) }</FormLabel>
-					{ isAuthorRegistered && (
-						<InfoPopover>
-							{ translate( "This user is registered, the URL can't be edited." ) }
-						</InfoPopover>
+					{ ! isEditCommentSupported && (
+						<p className="comment__edit-jetpack-update-notice">
+							<Gridicon icon="notice-outline" />
+							{ translate( 'Comment editing requires a newer version of Jetpack.' ) }
+							<a
+								className="comment__edit-jetpack-update-notice-link"
+								href={ `/plugins/jetpack/${ siteSlug }` }
+							>
+								{ translate( 'Update Now' ) }
+							</a>
+						</p>
 					) }
-					<FormTextInput
-						disabled={ ! isEditCommentSupported || isAuthorRegistered }
-						id="author_url"
-						onChange={ this.setAuthorUrlValue }
-						value={ authorUrl }
-					/>
-				</FormFieldset>
-
-				<FormTextarea
-					disabled={ ! isEditCommentSupported }
-					onChange={ this.setCommentContentValue }
-					value={ commentContent }
-				/>
-
-				{ ! isEditCommentSupported && (
-					<p className="comment__edit-jetpack-update-notice">
-						<Gridicon icon="notice-outline" />
-						{ translate( 'Comment editing requires a newer version of Jetpack.' ) }
-						<a
-							className="comment__edit-jetpack-update-notice-link"
-							href={ `/plugins/jetpack/${ siteSlug }` }
-						>
-							{ translate( 'Update Now' ) }
-						</a>
-					</p>
-				) }
+				</div>
 
 				<div className="comment__edit-buttons">
 					<FormButton compact disabled={ ! isEditCommentSupported } onClick={ this.submitEdit }>

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -26,6 +26,7 @@ import {
 	withAnalytics,
 } from 'state/analytics/actions';
 import { editComment } from 'state/comments/actions';
+import { getCurrentUserId } from 'state/current-user/selectors';
 import { removeNotice, successNotice } from 'state/notices/actions';
 import { getSiteComment } from 'state/selectors';
 import { getSiteSlug, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
@@ -93,7 +94,7 @@ export class CommentEdit extends Component {
 
 	render() {
 		const {
-			isAuthorRegistered,
+			isAuthorEditable,
 			isEditCommentSupported,
 			siteSlug,
 			toggleEditMode,
@@ -108,13 +109,13 @@ export class CommentEdit extends Component {
 				<div className="comment__edit-wrapper">
 					<FormFieldset>
 						<FormLabel htmlFor="author">{ translate( 'Name' ) }</FormLabel>
-						{ isAuthorRegistered && (
+						{ isAuthorEditable && (
 							<InfoPopover>
 								{ translate( "This user is registered, the name can't be edited." ) }
 							</InfoPopover>
 						) }
 						<FormTextInput
-							disabled={ ! isEditCommentSupported || isAuthorRegistered }
+							disabled={ ! isEditCommentSupported || isAuthorEditable }
 							id="author"
 							onChange={ this.setAuthorDisplayNameValue }
 							value={ authorDisplayName }
@@ -123,13 +124,13 @@ export class CommentEdit extends Component {
 
 					<FormFieldset>
 						<FormLabel htmlFor="author_url">{ translate( 'URL' ) }</FormLabel>
-						{ isAuthorRegistered && (
+						{ isAuthorEditable && (
 							<InfoPopover>
 								{ translate( "This user is registered, the URL can't be edited." ) }
 							</InfoPopover>
 						) }
 						<FormTextInput
-							disabled={ ! isEditCommentSupported || isAuthorRegistered }
+							disabled={ ! isEditCommentSupported || isAuthorEditable }
 							id="author_url"
 							onChange={ this.setAuthorUrlValue }
 							value={ authorUrl }
@@ -175,12 +176,14 @@ const mapStateToProps = ( state, { commentId } ) => {
 		! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' );
 	const comment = getSiteComment( state, siteId, commentId );
 	const authorDisplayName = decodeEntities( get( comment, 'author.name' ) );
-	const isAuthorRegistered = 0 !== get( comment, 'author.ID' );
+	const authorId = get( comment, 'author.ID' );
+	const isAuthorEditable = 0 !== authorId && getCurrentUserId( state ) !== authorId;
+
 	return {
 		authorDisplayName,
 		authorUrl: get( comment, 'author.URL', '' ),
 		commentContent: get( comment, 'raw_content' ),
-		isAuthorRegistered,
+		isAuthorEditable,
 		isEditCommentSupported,
 		postId: get( comment, 'post.ID' ),
 		siteId,

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -154,15 +154,15 @@ export class CommentEdit extends Component {
 							</a>
 						</p>
 					) }
-				</div>
 
-				<div className="comment__edit-buttons">
-					<FormButton compact disabled={ ! isEditCommentSupported } onClick={ this.submitEdit }>
-						{ translate( 'Save' ) }
-					</FormButton>
-					<FormButton compact isPrimary={ false } onClick={ toggleEditMode } type="button">
-						{ translate( 'Cancel' ) }
-					</FormButton>
+					<div className="comment__edit-buttons">
+						<FormButton compact disabled={ ! isEditCommentSupported } onClick={ this.submitEdit }>
+							{ translate( 'Save' ) }
+						</FormButton>
+						<FormButton compact isPrimary={ false } onClick={ toggleEditMode } type="button">
+							{ translate( 'Cancel' ) }
+						</FormButton>
+					</div>
 				</div>
 			</div>
 		);

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -69,6 +69,13 @@ export class Comment extends Component {
 		}
 	};
 
+	toggleEditMode = () =>
+		this.setState( ( { isEditMode } ) => ( {
+			isEditMode: ! isEditMode,
+			isExpanded: ! isEditMode,
+			isReplyVisible: false,
+		} ) );
+
 	toggleExpanded = () => {
 		if ( ! this.props.isLoading && ! this.state.isEditMode ) {
 			this.setState( ( { isExpanded } ) => ( {
@@ -105,6 +112,7 @@ export class Comment extends Component {
 		const classes = classNames( 'comment', {
 			'is-bulk-mode': isBulkMode,
 			'is-collapsed': ! isExpanded,
+			'is-edit-mode': isEditMode,
 			'is-expanded': isExpanded,
 			'is-placeholder': isLoading,
 			'is-pending': commentIsPending,
@@ -135,6 +143,7 @@ export class Comment extends Component {
 						{ showActions && (
 							<CommentActions
 								{ ...{ commentId, updateLastUndo } }
+								toggleEditMode={ this.toggleEditMode }
 								toggleReply={ this.toggleReply }
 							/>
 						) }

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -15,6 +15,7 @@ import { get, isUndefined } from 'lodash';
 import Card from 'components/card';
 import CommentActions from 'my-sites/comments/comment/comment-actions';
 import CommentContent from 'my-sites/comments/comment/comment-content';
+import CommentEdit from 'my-sites/comments/comment/comment-edit';
 import CommentHeader from 'my-sites/comments/comment/comment-header';
 import CommentReply from 'my-sites/comments/comment/comment-reply';
 import QueryComment from 'components/data/query-comment';
@@ -150,6 +151,10 @@ export class Comment extends Component {
 
 						{ isExpanded && ! isBulkMode && <CommentReply { ...{ commentId, isReplyVisible } } /> }
 					</div>
+				) }
+
+				{ isEditMode && (
+					<CommentEdit { ...{ commentId } } toggleEditMode={ this.toggleEditMode } />
 				) }
 			</Card>
 		);

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -472,6 +472,23 @@
 		display: inline-block;
 		margin-left: 4px;
 	}
+
+	.comment__edit-jetpack-update-notice {
+		color: $alert-red;
+		margin-left: 8px;
+		margin-right: 8px;
+
+		.gridicon {
+			margin-right: 4px;
+			vertical-align: middle;
+		}
+	}
+
+	.comment__edit-jetpack-update-notice-link {
+		color: $alert-red;
+		margin-left: 4px;
+		text-decoration: underline;
+	}
 }
 
 .comment__edit-header {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -445,6 +445,51 @@
 	}
 }
 
+// Comment Edit Block
+
+.comment__edit {
+	.form-fieldset {
+		padding: 0 8px;
+		width: 50%;
+	}
+
+	.form-textarea {
+		margin: 0px 8px 20px 8px;
+		transition: none;
+		width: 100%;
+	}
+
+	label {
+		display: inline-block;
+	}
+
+	input[type='text'],
+	textarea {
+		font-size: 14px;
+	}
+
+	.info-popover {
+		display: inline-block;
+		margin-left: 4px;
+	}
+}
+
+.comment__edit-header {
+	border-bottom: 1px solid lighten($gray, 30%);
+	padding: 12px 16px;
+}
+
+.comment__edit-wrapper {
+	display: flex;
+	flex-wrap: wrap;
+	padding: 16px 8px 0 8px;
+}
+
+.comment__edit-buttons {
+	overflow: hidden; // lazy clearfix
+	padding: 0 16px 16px 16px;
+}
+
 // Collapsed View
 
 .card.comment.is-collapsed {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -503,8 +503,8 @@
 }
 
 .comment__edit-buttons {
-	overflow: hidden; // lazy clearfix
-	padding: 0 16px 16px 16px;
+	padding: 0 8px 16px 8px;
+	width: 100%;
 }
 
 // Collapsed View

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -471,6 +471,7 @@
 	.info-popover {
 		display: inline-block;
 		margin-left: 4px;
+		vertical-align: middle;
 	}
 
 	.comment__edit-jetpack-update-notice {


### PR DESCRIPTION
Context and mock up: p3fqKv-5W1-p2

Add the `CommentEdit` component to the new `Comment` design.
It already has the notice and undo logic as introduced in #19644.

Please point out but also disregard any odd behaviours wrt the collapse/expand logic: it's being worked actively in #19560. Once this PR merges, that will be rebased and it will take care of them.

| Edit Supported | Edit Unsupported |
| --- | --- |
| <img width="732" alt="screen shot 2017-11-10 at 13 13 49" src="https://user-images.githubusercontent.com/2070010/32660612-7c3ffea2-c61b-11e7-9c1d-ee434eaf8b0d.png"> | <img width="739" alt="screen shot 2017-11-10 at 13 31 05" src="https://user-images.githubusercontent.com/2070010/32660613-7c5f915e-c61b-11e7-9276-14e260196844.png"> |

### Testing instructions

Checkout this branch and run it with
`ENABLE_FEATURES=comments/management/m3-design npm start`