### PR TITLE
Signup: G Suite Nudge should subscribe to site URL changes

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -149,18 +149,22 @@ export default {
 		const selectedSite =
 			getSelectedSite( state ) || getSiteBySlug( state, site ) || getSiteBySlug( state, domain );
 
-		const handleAddGoogleApps = googleAppsCartItem => {
+		if ( ! selectedSite ) {
+			return null;
+		}
+
+		const handleAddGoogleApps = ( googleAppsCartItem, siteSlug ) => {
 			googleAppsCartItem.extra = {
 				...googleAppsCartItem.extra,
 				receipt_for_domain: receiptId,
 			};
 
 			upgradesActions.addItem( googleAppsCartItem );
-			page( `/checkout/${ site }` );
+			page( `/checkout/${ siteSlug }` );
 		};
 
-		const handleClickSkip = () => {
-			page( `/checkout/thank-you/${ site }/${ receiptId }` );
+		const handleClickSkip = siteSlug => {
+			page( `/checkout/thank-you/${ siteSlug }/${ receiptId }` );
 		};
 
 		renderWithReduxStore(
@@ -168,7 +172,7 @@ export default {
 				domain={ domain }
 				productsList={ productsList }
 				receiptId={ Number( receiptId ) }
-				selectedSite={ selectedSite }
+				selectedSiteId={ selectedSite.ID }
 				onAddGoogleApps={ handleAddGoogleApps }
 				onClickSkip={ handleClickSkip }
 			/>,

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -6,7 +6,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,17 +16,26 @@ import { localize } from 'i18n-calypso';
 import DocumentHead from 'components/data/document-head';
 import GoogleAppsDialog from 'components/upgrades/google-apps/google-apps-dialog';
 import Main from 'components/main';
+import { getSite } from 'state/sites/selectors';
 
 export class GsuiteNudge extends React.Component {
 	static propTypes = {
+		domain: PropTypes.string.isRequired,
 		receiptId: PropTypes.number.isRequired,
 		productsList: PropTypes.object.isRequired,
-		selectedSite: PropTypes.object.isRequired,
+		selectedSiteId: PropTypes.number.isRequired,
+	};
+
+	handleClickSkip = () => {
+		this.props.onClickSkip( this.props.siteSlug );
+	};
+
+	handleAddGoogleApps = googleAppsCartItem => {
+		this.props.onAddGoogleApps( googleAppsCartItem, this.props.siteSlug );
 	};
 
 	render() {
-		const { selectedSite, translate } = this.props;
-		const siteTitle = ( selectedSite && selectedSite.name ) || '';
+		const { siteTitle, translate } = this.props;
 
 		return (
 			<Main className="gsuite-nudge">
@@ -36,13 +47,18 @@ export class GsuiteNudge extends React.Component {
 				<GoogleAppsDialog
 					domain={ this.props.domain }
 					productsList={ this.props.productsList }
-					onClickSkip={ this.props.onClickSkip }
-					onAddGoogleApps={ this.props.onAddGoogleApps }
-					selectedSite={ selectedSite }
+					onClickSkip={ this.handleClickSkip }
+					onAddGoogleApps={ this.handleAddGoogleApps }
 				/>
 			</Main>
 		);
 	}
 }
 
-export default localize( GsuiteNudge );
+export default connect( ( state, props ) => {
+	const selectedSite = getSite( state, props.selectedSiteId );
+	return {
+		siteSlug: get( selectedSite, 'slug', '' ),
+		siteTitle: get( selectedSite, 'name', '' ),
+	};
+} )( localize( GsuiteNudge ) );


### PR DESCRIPTION
During Store Signup, when the site is going to have a custom domain, the site slug can change from the initial `something.wordpress.com` to the one with the custom domain, e.g., `something.blog`. Navigation links like `/checkout/thank-you/something.wordpress.org` become invalid and must be updated to `/checkout/thank-you/something.blog`.

This patch updates the `GsuiteNudge` component to subscribe to the Redux store and always use the most up-to-date site URL when navigating away from the component. The site URL can change (and get updated in the Redux state) while the user is looking at the nudge screen.

Without this patch, the links may become stale, breaking the navigation flow. See #19590 for more details about this bug and the history of its discovery.

There are few small drive-by fixes:
- if the `selectedSite` happens to be `null` (when there's a wrong site slug or domain in the URL), don't render anything. Prevents reference errors when accessing properties of a `null` object.
- don't pass a `selectedSite` prop to `GoogleAppsDialog` -- it doesn't need it.
- improve proptypes of the `GsuiteNudge`.

**How to test:**
Follow the steps to reproduce described in https://github.com/Automattic/wp-calypso/pull/19590#issuecomment-343229248 and verify that the bug has disappeared.