### PR TITLE
Plans: re-enable true/false visibility parameter in feature components of Plans

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -369,7 +369,11 @@ class PlanFeatures extends Component {
 			? feature.getDescription( abtest, this.props.domainName )
 			: null;
 		return (
-			<PlanFeaturesItem key={ index } description={ description } hideInfoPopover={ false }>
+			<PlanFeaturesItem
+				key={ index }
+				description={ description }
+				hideInfoPopover={ feature.hideInfoPopover }
+			>
 				<span className="plan-features__item-info">
 					<span className="plan-features__item-title">{ feature.getTitle() }</span>
 				</span>


### PR DESCRIPTION
`hideInfoPopover` is a parameter of `PlanFeaturesItem`, which governs component's visibility. 
It was hardcoded for the purpose of  running tests and this patch re-enables its original functionality.

**to test**:
- Starting at URL: https://wordpress.com/plans/:site, where :site is a connected Jetpack site
- verify that `Marketing Automation` and `Concierge Setup` have `i` icon invisible, which is a consequence of the flag turned on:
https://github.com/Automattic/wp-calypso/blob/b855b7a8a7e9f6a24e4fc87e8fe251cfd10603fd/client/lib/plans/constants.js#L1333
and
https://github.com/Automattic/wp-calypso/blob/b855b7a8a7e9f6a24e4fc87e8fe251cfd10603fd/client/lib/plans/constants.js#L1339
![screen shot 2017-11-10 at 16 59 28](https://user-images.githubusercontent.com/13561163/32666793-ef643d5e-c638-11e7-9265-fff2ff93701f.png)

**context**: 
https://github.com/Automattic/wp-calypso/issues/19581#issuecomment-343227225