### PR TITLE
Activity Log: dismiss backup creation success card when the ⨉ is clicked

### DIFF
--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -15,7 +15,10 @@ import Button from 'components/button';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSiteUrl } from 'state/selectors';
-import { dismissRewindRestoreProgress as dismissRewindRestoreProgressAction } from 'state/activity-log/actions';
+import {
+	dismissRewindRestoreProgress,
+	dismissRewindBackupProgress,
+} from 'state/activity-log/actions';
 
 /**
  * Normalize timestamp values
@@ -46,7 +49,8 @@ class SuccessBanner extends PureComponent {
 		downloadCount: PropTypes.number,
 
 		// connect
-		dismissRewindRestoreProgress: PropTypes.func.isRequired,
+		dismissRestoreProgress: PropTypes.func.isRequired,
+		dismissBackupProgress: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 
 		// localize
@@ -54,7 +58,10 @@ class SuccessBanner extends PureComponent {
 		translate: PropTypes.func.isRequired,
 	};
 
-	handleDismiss = () => this.props.dismissRewindRestoreProgress( this.props.siteId );
+	handleDismiss = () =>
+		this.props.backupUrl
+			? this.props.dismissBackupProgress( this.props.siteId )
+			: this.props.dismissRestoreProgress( this.props.siteId );
 
 	trackDownload = () =>
 		this.props.recordTracksEvent( 'calypso_activitylog_backup_download', {
@@ -115,7 +122,8 @@ export default connect(
 		siteUrl: getSiteUrl( state, siteId ),
 	} ),
 	{
-		dismissRewindRestoreProgress: dismissRewindRestoreProgressAction,
+		dismissRestoreProgress: dismissRewindRestoreProgress,
+		dismissBackupProgress: dismissRewindBackupProgress,
 		recordTracksEvent: recordTracksEvent,
 	}
 )( localize( SuccessBanner ) );

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -27,6 +27,7 @@ import {
 	REWIND_BACKUP_PROGRESS_REQUEST,
 	REWIND_BACKUP_UPDATE_ERROR,
 	REWIND_BACKUP_UPDATE_PROGRESS,
+	REWIND_BACKUP_DISMISS_PROGRESS,
 } from 'state/action-types';
 
 /**
@@ -289,6 +290,14 @@ export function getRewindBackupProgress( siteId, downloadId ) {
 	};
 }
 
+/**
+ * Update the status of the backup creation with its progress.
+ *
+ * @param  {string|number} siteId     The site ID
+ * @param  {number}        downloadId Id of the backup being created.
+ * @param  {number}        progress   Number from 0 to 100 that indicates the progress of the backup creation.
+ * @return {object}                   Action object
+ */
 export function updateRewindBackupProgress( siteId, downloadId, progress ) {
 	return {
 		type: REWIND_BACKUP_UPDATE_PROGRESS,
@@ -298,10 +307,30 @@ export function updateRewindBackupProgress( siteId, downloadId, progress ) {
 	};
 }
 
+/**
+ * Update the status of the backup creation when it errors.
+ *
+ * @param  {string|number} siteId The site ID
+ * @param  {string}        error  Error code
+ * @return {object}               Action object
+ */
 export function rewindBackupUpdateError( siteId, error ) {
 	return {
 		type: REWIND_BACKUP_UPDATE_ERROR,
 		siteId,
 		error,
+	};
+}
+
+/**
+ * Remove success banner.
+ *
+ * @param  {string|number} siteId The site ID
+ * @return {object}               Action object
+ */
+export function dismissRewindBackupProgress( siteId ) {
+	return {
+		type: REWIND_BACKUP_DISMISS_PROGRESS,
+		siteId,
 	};
 }


### PR DESCRIPTION
Currently the backup creation dialog is not removed when the ⨉ is clicked. This PR solves this by dispatching the necessary action.

![dismiss](https://user-images.githubusercontent.com/1041600/32667830-993a8d2a-c61a-11e7-9ad3-ab23b6b0809a.gif)

#### Testing

1. initiate a backup creation
2. once it's finished, click the ⨉. The card should be dismissed.