### PR TITLE
Don't show error messagee when there is exact match for mapped domain

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -31,6 +31,7 @@ import { TRANSFER_IN } from 'state/current-user/constants';
 class DomainSearchResults extends React.Component {
 	static propTypes = {
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
+		lastDomainIsTransferrable: PropTypes.bool,
 		lastDomainStatus: PropTypes.string,
 		lastDomainSearched: PropTypes.string,
 		cart: PropTypes.object,
@@ -53,7 +54,13 @@ class DomainSearchResults extends React.Component {
 	};
 
 	renderDomainAvailability() {
-		const { availableDomain, lastDomainStatus, lastDomainSearched: domain, translate } = this.props;
+		const {
+			availableDomain,
+			lastDomainIsTransferrable,
+			lastDomainStatus,
+			lastDomainSearched: domain,
+			translate,
+		} = this.props;
 		const availabilityElementClasses = classNames( {
 			'domain-search-results__domain-is-available': availableDomain,
 			'domain-search-results__domain-not-available': ! availableDomain,
@@ -124,6 +131,7 @@ class DomainSearchResults extends React.Component {
 				if (
 					this.props.transferInAllowed &&
 					! this.props.isSignupStep &&
+					lastDomainIsTransferrable &&
 					includes( [ MAPPABLE, MAPPED ], lastDomainStatus )
 				) {
 					availabilityElement = (

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -59,7 +59,7 @@ class DomainSearchResults extends React.Component {
 			'domain-search-results__domain-not-available': ! availableDomain,
 		} );
 		const suggestions = this.props.suggestions || [];
-		const { MAPPABLE, UNKNOWN } = domainAvailability;
+		const { MAPPABLE, MAPPED, UNKNOWN } = domainAvailability;
 
 		let availabilityElement, domainSuggestionElement, offer;
 
@@ -85,26 +85,28 @@ class DomainSearchResults extends React.Component {
 			);
 		} else if (
 			suggestions.length !== 0 &&
-			includes( [ MAPPABLE, UNKNOWN ], lastDomainStatus ) &&
+			includes( [ MAPPABLE, MAPPED, UNKNOWN ], lastDomainStatus ) &&
 			this.props.products.domain_map
 		) {
 			const components = { a: <a href="#" onClick={ this.handleAddMapping } />, small: <small /> };
 
-			if ( isNextDomainFree( this.props.cart ) ) {
-				offer = translate(
-					'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for free.{{/small}}',
-					{ args: { domain }, components }
-				);
-			} else if ( ! this.props.domainsWithPlansOnly || this.props.isSiteOnPaidPlan ) {
-				offer = translate(
-					'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for %(cost)s.{{/small}}',
-					{ args: { domain, cost: this.props.products.domain_map.cost_display }, components }
-				);
-			} else {
-				offer = translate(
-					'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} with WordPress.com Premium.{{/small}}',
-					{ args: { domain }, components }
-				);
+			if ( lastDomainStatus !== MAPPED ) {
+				if ( isNextDomainFree( this.props.cart ) ) {
+					offer = translate(
+						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for free.{{/small}}',
+						{ args: { domain }, components }
+					);
+				} else if ( ! this.props.domainsWithPlansOnly || this.props.isSiteOnPaidPlan ) {
+					offer = translate(
+						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for %(cost)s.{{/small}}',
+						{ args: { domain, cost: this.props.products.domain_map.cost_display }, components }
+					);
+				} else {
+					offer = translate(
+						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} with WordPress.com Premium.{{/small}}',
+						{ args: { domain }, components }
+					);
+				}
 			}
 
 			const domainUnavailableMessage =
@@ -119,7 +121,11 @@ class DomainSearchResults extends React.Component {
 						} );
 
 			if ( this.props.offerUnavailableOption ) {
-				if ( this.props.transferInAllowed && ! this.props.isSignupStep ) {
+				if (
+					this.props.transferInAllowed &&
+					! this.props.isSignupStep &&
+					includes( [ MAPPABLE, MAPPED ], lastDomainStatus )
+				) {
 					availabilityElement = (
 						<Card className="domain-search-results__transfer-card" highlight="info">
 							<div className="domain-search-results__transfer-card-copy">

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -97,23 +97,21 @@ class DomainSearchResults extends React.Component {
 		) {
 			const components = { a: <a href="#" onClick={ this.handleAddMapping } />, small: <small /> };
 
-			if ( lastDomainStatus !== MAPPED ) {
-				if ( isNextDomainFree( this.props.cart ) ) {
-					offer = translate(
-						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for free.{{/small}}',
-						{ args: { domain }, components }
-					);
-				} else if ( ! this.props.domainsWithPlansOnly || this.props.isSiteOnPaidPlan ) {
-					offer = translate(
-						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for %(cost)s.{{/small}}',
-						{ args: { domain, cost: this.props.products.domain_map.cost_display }, components }
-					);
-				} else {
-					offer = translate(
-						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} with WordPress.com Premium.{{/small}}',
-						{ args: { domain }, components }
-					);
-				}
+			if ( isNextDomainFree( this.props.cart ) ) {
+				offer = translate(
+					'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for free.{{/small}}',
+					{ args: { domain }, components }
+				);
+			} else if ( ! this.props.domainsWithPlansOnly || this.props.isSiteOnPaidPlan ) {
+				offer = translate(
+					'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for %(cost)s.{{/small}}',
+					{ args: { domain, cost: this.props.products.domain_map.cost_display }, components }
+				);
+			} else {
+				offer = translate(
+					'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} with WordPress.com Premium.{{/small}}',
+					{ args: { domain }, components }
+				);
 			}
 
 			const domainUnavailableMessage =
@@ -151,7 +149,7 @@ class DomainSearchResults extends React.Component {
 							</div>
 						</Card>
 					);
-				} else {
+				} else if ( lastDomainStatus !== MAPPED ) {
 					availabilityElement = (
 						<Notice status="is-warning" showDismiss={ false }>
 							{ domainUnavailableMessage } { offer }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -753,6 +753,9 @@ class RegisterDomainStep extends React.Component {
 	};
 
 	showValidationErrorMessage( domain, error ) {
+		if ( this.props.transferInAllowed && includes( [ domainAvailability.MAPPED ], error ) ) {
+			return;
+		}
 		const { message, severity } = getAvailabilityNotice( domain, error );
 		this.setState( { notice: message, noticeSeverity: severity } );
 	}


### PR DESCRIPTION
With incoming transfer we need to allow for mapped domains to be transferred in with us. This means that we should no longer show an error message when someone got an exact match for a mapped domain. We also want to show the "If you purchased this domain elsewhere you can transfer it in..." card for mapped domains.