### PR TITLE
Activity Log: show message when a backup is ready and user hasn't downloaded it yet

### DIFF
--- a/client/components/data/query-rewind-backup-status/index.js
+++ b/client/components/data/query-rewind-backup-status/index.js
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import Interval, { EVERY_SECOND } from 'lib/interval';
-import { getRewindBackupProgress as getBackupProgress } from 'state/activity-log/actions';
+import { getRewindBackupProgress } from 'state/activity-log/actions';
 
 class QueryRewindBackupStatus extends Component {
 	static propTypes = {
@@ -19,11 +19,24 @@ class QueryRewindBackupStatus extends Component {
 		siteId: PropTypes.number.isRequired,
 	};
 
+	componentWillMount() {
+		// We want to run this only once: when the page is loaded. In such case, there is not known download Id.
+		// If there's a download Id here it means this was mounted during an action requesting progress for a
+		// specific download Id, so we will do nothing here,since it will be handled by the <Interval /> below.
+		if ( ! this.props.downloadId ) {
+			const { siteId } = this.props;
+
+			if ( siteId ) {
+				this.props.getRewindBackupProgress( siteId );
+			}
+		}
+	}
+
 	query = () => {
 		const { downloadId, siteId } = this.props;
 
 		if ( siteId && downloadId ) {
-			this.props.getBackupProgress( siteId, downloadId );
+			this.props.getRewindBackupProgress( siteId );
 		}
 	};
 
@@ -32,4 +45,4 @@ class QueryRewindBackupStatus extends Component {
 	}
 }
 
-export default connect( null, { getBackupProgress } )( QueryRewindBackupStatus );
+export default connect( null, { getRewindBackupProgress } )( QueryRewindBackupStatus );

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -6,6 +6,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,9 +20,14 @@ class ErrorBanner extends PureComponent {
 	static propTypes = {
 		errorCode: PropTypes.string.isRequired,
 		failureReason: PropTypes.string.isRequired,
-		requestDialog: PropTypes.func.isRequired,
+		closeDialog: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
-		timestamp: PropTypes.string.isRequired,
+		timestamp: PropTypes.string,
+		downloadId: PropTypes.number,
+		requestedRestoreActivityId: PropTypes.number,
+		createBackup: PropTypes.func,
+		rewindRestore: PropTypes.func,
+		rewindId: PropTypes.number,
 
 		// connect
 		dismissRewindRestoreProgress: PropTypes.func.isRequired,
@@ -33,31 +39,72 @@ class ErrorBanner extends PureComponent {
 	static defaultProps = {
 		errorCode: '',
 		failureReason: '',
+		downloadId: undefined,
+		requestedRestoreActivityId: undefined,
 	};
 
-	handleClickRestart = () => this.props.requestDialog( this.props.timestamp, 'status', 'restore' );
+	handleClickRestart = () => {
+		const {
+			siteId,
+			downloadId,
+			requestedRestoreActivityId,
+			rewindRestore,
+			createBackup,
+		} = this.props;
+		if ( requestedRestoreActivityId ) {
+			rewindRestore( siteId, requestedRestoreActivityId );
+		} else if ( downloadId ) {
+			createBackup( siteId, downloadId );
+		}
+	};
 
-	handleDismiss = () => this.props.dismissRewindRestoreProgress( this.props.siteId );
+	handleDismiss = () =>
+		isEmpty( this.props.downloadId )
+			? this.props.closeDialog( 'restore' )
+			: this.props.closeDialog( 'backup' );
 
 	render() {
-		const { errorCode, failureReason, timestamp, translate } = this.props;
+		const { errorCode, failureReason, timestamp, translate, downloadId } = this.props;
+		const strings = isEmpty( downloadId )
+			? {
+					title: translate( 'Problem restoring your site' ),
+					details: translate( 'We came across a problem while trying to restore your site.' ),
+				}
+			: {
+					title: translate( 'Problem creating a backup' ),
+					details: (
+						<span>
+							{ translate( 'We came across a problem creating a backup for your site.' ) }
+							<br />
+							<code>{ errorCode }</code>
+						</span>
+					),
+				};
 
 		return (
 			<ActivityLogBanner
 				isDismissable
 				onDismissClick={ this.handleDismiss }
 				status="error"
-				title={ translate( 'Problem restoring your site' ) }
+				title={ strings.title }
 			>
 				<TrackComponentView
 					eventName="calypso_activitylog_errorbanner_impression"
-					eventProperties={ {
-						error_code: errorCode,
-						failure_reason: failureReason,
-						restore_to: timestamp,
-					} }
+					eventProperties={
+						isEmpty( downloadId )
+							? {
+									error_code: errorCode,
+									failure_reason: failureReason,
+									restore_to: timestamp,
+								}
+							: {
+									error_code: 'backup',
+									failure_reason: 'backup failed',
+									download_id: downloadId,
+								}
+					}
 				/>
-				<p>{ translate( 'We came across a problem while trying to restore your site.' ) }</p>
+				<p>{ strings.details }</p>
 				<Button primary onClick={ this.handleClickRestart }>
 					{ translate( 'Try again' ) }
 				</Button>

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -47,6 +47,7 @@ class SuccessBanner extends PureComponent {
 		timestamp: PropTypes.string,
 		backupUrl: PropTypes.string,
 		downloadCount: PropTypes.number,
+		downloadId: PropTypes.number,
 
 		// connect
 		dismissRestoreProgress: PropTypes.func.isRequired,
@@ -60,7 +61,7 @@ class SuccessBanner extends PureComponent {
 
 	handleDismiss = () =>
 		this.props.backupUrl
-			? this.props.dismissBackupProgress( this.props.siteId )
+			? this.props.dismissBackupProgress( this.props.siteId, this.props.downloadId )
 			: this.props.dismissRestoreProgress( this.props.siteId );
 
 	trackDownload = () =>

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -283,15 +283,13 @@ export function rewindBackup( siteId, rewindId ) {
 /**
  * Check progress of backup creation for the a given download id.
  *
- * @param  {string|number} siteId     The site ID
- * @param  {number}        downloadId Id of the backup being created.
- * @return {object}                   Action object
+ * @param  {string|number} siteId The site ID
+ * @return {object}               Action object
  */
-export function getRewindBackupProgress( siteId, downloadId ) {
+export function getRewindBackupProgress( siteId ) {
 	return {
 		type: REWIND_BACKUP_PROGRESS_REQUEST,
 		siteId,
-		downloadId,
 	};
 }
 
@@ -315,27 +313,31 @@ export function updateRewindBackupProgress( siteId, downloadId, progress ) {
 /**
  * Update the status of the backup creation when it errors.
  *
- * @param  {string|number} siteId The site ID
- * @param  {string}        error  Error code
- * @return {object}               Action object
+ * @param  {string|number} siteId     The site ID
+ * @param  {number}        downloadId Id of the backup being created.
+ * @param  {object}        error      Info about downloadable backup and error.
+ * @return {object}                   Action object
  */
-export function rewindBackupUpdateError( siteId, error ) {
+export function rewindBackupUpdateError( siteId, downloadId, error ) {
 	return {
 		type: REWIND_BACKUP_UPDATE_ERROR,
 		siteId,
-		error,
+		downloadId,
+		...error,
 	};
 }
 
 /**
  * Remove success banner.
  *
- * @param  {string|number} siteId The site ID
- * @return {object}               Action object
+ * @param  {string|number} siteId     The site ID
+ * @param  {number}        downloadId Id of the backup being dismissed.
+ * @return {object}                   Action object
  */
-export function dismissRewindBackupProgress( siteId ) {
+export function dismissRewindBackupProgress( siteId, downloadId ) {
 	return {
 		type: REWIND_BACKUP_DISMISS_PROGRESS,
 		siteId,
+		downloadId,
 	};
 }

--- a/client/state/activity-log/backup/reducer.js
+++ b/client/state/activity-log/backup/reducer.js
@@ -8,6 +8,7 @@ import {
 	REWIND_BACKUP_REQUEST,
 	REWIND_BACKUP_DISMISS_PROGRESS,
 	REWIND_BACKUP_UPDATE_PROGRESS,
+	REWIND_BACKUP_UPDATE_ERROR,
 } from 'state/action-types';
 import { keyedReducer } from 'state/utils';
 
@@ -54,7 +55,17 @@ export const backupProgress = keyedReducer( 'siteId', ( state = undefined, actio
 				url: action.url,
 			};
 
+		case REWIND_BACKUP_UPDATE_ERROR:
+			return {
+				backupPoint: action.backupPoint,
+				downloadId: action.downloadId,
+				backupError: action.error,
+				rewindId: action.rewindId,
+				startedAt: action.startedAt,
+			};
+
 		case REWIND_BACKUP_DISMISS_PROGRESS:
+		case REWIND_BACKUP_DISMISS:
 			return null;
 
 		default:

--- a/client/state/data-layer/wpcom/activity-log/rewind/downloads/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/downloads/index.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 
-import debugFactory from 'debug';
 import { pick } from 'lodash';
 
 /**
@@ -14,8 +13,6 @@ import { REWIND_BACKUP } from 'state/action-types';
 import { rewindBackupUpdateError, getRewindBackupProgress } from 'state/activity-log/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-
-const debug = debugFactory( 'calypso:data-layer:activity-log:rewind:to' );
 
 const createBackup = ( { dispatch }, action ) => {
 	dispatch(
@@ -40,10 +37,8 @@ const fromApi = data => ( {
 export const receiveBackupSuccess = ( { dispatch }, { siteId }, apiData ) => {
 	const { downloadId } = fromApi( apiData );
 	if ( downloadId ) {
-		debug( 'Request restore success, restore id:', downloadId );
-		dispatch( getRewindBackupProgress( siteId, downloadId ) );
+		dispatch( getRewindBackupProgress( siteId ) );
 	} else {
-		debug( 'Request restore response missing restore_id' );
 		dispatch(
 			rewindBackupUpdateError( siteId, {
 				status: 'finished',
@@ -54,8 +49,7 @@ export const receiveBackupSuccess = ( { dispatch }, { siteId }, apiData ) => {
 	}
 };
 
-export const receiveBackupError = ( { dispatch }, { siteId, timestamp }, error ) => {
-	debug( 'Request restore fail', error );
+export const receiveBackupError = ( { dispatch }, { siteId }, error ) => {
 	dispatch( rewindBackupUpdateError( siteId, pick( error, [ 'error', 'status', 'message' ] ) ) );
 };
 

--- a/client/state/data-layer/wpcom/sites/rewind/downloads/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/downloads/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
+import { isEmpty, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,8 +11,8 @@ import { translate } from 'i18n-calypso';
 import { errorNotice } from 'state/notices/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { REWIND_BACKUP_PROGRESS_REQUEST } from 'state/action-types';
-import { updateRewindBackupProgress } from 'state/activity-log/actions';
+import { REWIND_BACKUP_PROGRESS_REQUEST, REWIND_BACKUP_DISMISS_PROGRESS } from 'state/action-types';
+import { updateRewindBackupProgress, rewindBackupUpdateError } from 'state/activity-log/actions';
 
 /** @type {Number} how many ms between polls for same data */
 const POLL_INTERVAL = 1500;
@@ -47,16 +48,18 @@ const fetchProgress = ( { dispatch }, action ) => {
 			{
 				method: 'GET',
 				apiNamespace: 'wpcom/v2',
-				path: `/sites/${ action.siteId }/rewind/downloads/${ action.downloadId }`,
-				body: {
-					downloadId: action.downloadId,
-				},
+				path: `/sites/${ action.siteId }/rewind/downloads`,
 			},
 			action
 		)
 	);
 };
 
+/**
+ * Parse and merge response data for backup creation status with defaults.
+ * @param   {object} data The data received from API response.
+ * @returns {object}      Parsed response data.
+ */
 const fromApi = data => ( {
 	backupPoint: data.backupPoint,
 	downloadId: +data.downloadId,
@@ -66,11 +69,37 @@ const fromApi = data => ( {
 	downloadCount: +data.downloadCount,
 	validUntil: data.validUntil,
 	url: data.url,
+	error: data.error,
 } );
 
-export const updateProgress = ( { dispatch }, { siteId, downloadId }, data ) =>
-	dispatch( updateRewindBackupProgress( siteId, downloadId, data ) );
+/**
+ * When requesting the status of a backup creation, an array with a single element is returned.
+ * This single element contains the information about the latest backup creation progress.
+ * If an error property was found, it will display an error card stating it.
+ * Otherwise the backup creation progress will be updated.
+ *
+ * @param {function} dispatch Method to trigger a state change.
+ * @param {number}   siteId   Id of the site for the one we're creating a backup.
+ * @param {object}   apiData  Data returned by a successful response.
+ */
+export const updateProgress = ( { dispatch }, { siteId }, apiData ) => {
+	const [ latestDownloadableBackup ] = apiData;
+	if ( ! isEmpty( latestDownloadableBackup ) ) {
+		const data = fromApi( latestDownloadableBackup );
+		dispatch(
+			get( data, [ 'error' ], false )
+				? rewindBackupUpdateError( siteId, data.downloadId, data )
+				: updateRewindBackupProgress( siteId, data.downloadId, data )
+		);
+	}
+};
 
+/**
+ * If the backup creation progress request fails, an error notice will be shown.
+ *
+ * @param   {function} dispatch Method to trigger a state change.
+ * @returns {function}          The dispatched action.
+ */
 export const announceError = ( { dispatch } ) =>
 	dispatch(
 		errorNotice(
@@ -78,10 +107,61 @@ export const announceError = ( { dispatch } ) =>
 		)
 	);
 
+/**
+ * Mark a specific downloadable backup record as dismissed.
+ * This has the effect that subsequent calls to /sites/%site_id%/rewind/downloads won't return the download.
+ *
+ * @param   {function} dispatch Method to trigger a state change.
+ * @param   {object}   action   Changeset to update state.
+ * @returns {function}          The dispatched action.
+ */
+export const dismissBackup = ( { dispatch }, action ) =>
+	dispatch(
+		http(
+			{
+				method: 'POST',
+				apiNamespace: 'wpcom/v2',
+				path: `/sites/${ action.siteId }/rewind/downloads/${ action.downloadId }`,
+				body: {
+					dismissed: true,
+				},
+			},
+			action
+		)
+	);
+
+/**
+ * If a dismiss request fails, an error notice will be shown.
+ *
+ * @param {function} dispatch Method to trigger a state change.
+ * @returns {function} The dispatched action.
+ */
+export const backupDismissFailed = ( { dispatch } ) =>
+	dispatch( errorNotice( translate( 'Dismissing backup failed. Please reload and try again.' ) ) );
+
+/**
+ * Parse and merge response data for backup dismiss result with defaults.
+ *
+ * @param   {object} data   The data received from API response.
+ * @returns {object} Parsed response data.
+ */
+const fromBackupDismiss = data => {
+	if ( ! data.dismissed ) {
+		throw false;
+	}
+	return {
+		downloadId: +data.download_id,
+		dismissed: data.is_dismissed,
+	};
+};
+
 export default {
 	[ REWIND_BACKUP_PROGRESS_REQUEST ]: [
-		dispatchRequest( fetchProgress, updateProgress, announceError, {
-			fromApi,
+		dispatchRequest( fetchProgress, updateProgress, announceError ),
+	],
+	[ REWIND_BACKUP_DISMISS_PROGRESS ]: [
+		dispatchRequest( dismissBackup, null, backupDismissFailed, {
+			fromApi: fromBackupDismiss,
 		} ),
 	],
 };


### PR DESCRIPTION
#### Progress update from server
Previously the status of a backup creation was only displayed right after the process started. If you reloaded the page or checked in another browser, it was no longer displayed because its progress or final status wasn't fetch from browser again.

This PR solves this by introducing a new endpoint check on page load that will load the relevant data about the backup creation process.

#### Dismiss success card
Since previously the status was checked from state and not endpoint, once a success card was dismissed, it was removed from state and it was never shown again. Since with this PR the status if fetch from the server, the success card shows up over and over unless we dismiss it from server.

This PR introduces a method to dismiss the backups from server when the ⨉ button is clicked in the success card. **This requires the code in D8415**. To fully test this PR, apply it to your com sandbox.

#### Testing

1. create a downloadable backup
2. while it's being created
    - reload the page. You should see the progress card again.
    - check in another browser. You should see the progress card again.
3. once it ends successfully and you see the success card, reload
4. the success card should be displayed even if you download it
5. click the ⨉ to dismiss the success card, reload
6. the success card should no longer be displayed