### PR TITLE
Condensed Posts: Enable for 5% of English-speaking users

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import { isEnabled } from 'config';
 import { getEditorPath } from 'state/ui/editor/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -119,10 +120,12 @@ class PostItem extends React.Component {
 			'has-wrapped-title': wrapTitle,
 		} );
 
-		const isSiteInfoVisible = isEnabled( 'posts/post-type-list' ) && isAllSitesModeSelected;
+		const arePostsCondensed =
+			isEnabled( 'posts/post-type-list' ) && abtest( 'condensedPostList' ) === 'condensedPosts';
 
-		const isAuthorVisible =
-			isEnabled( 'posts/post-type-list' ) && this.hasMultipleUsers() && post && post.author;
+		const isSiteInfoVisible = arePostsCondensed && isAllSitesModeSelected;
+
+		const isAuthorVisible = arePostsCondensed && this.hasMultipleUsers() && post && post.author;
 
 		const expandedContent = this.renderExpandedContent();
 
@@ -146,16 +149,16 @@ class PostItem extends React.Component {
 								</a>
 							) }
 							{ ! isPlaceholder &&
-							externalPostLink && (
-								<ExternalLink
-									icon={ true }
-									href={ postUrl }
-									target="_blank"
-									className="post-item__title-link"
-								>
-									{ title || translate( 'Untitled' ) }
-								</ExternalLink>
-							) }
+								externalPostLink && (
+									<ExternalLink
+										icon={ true }
+										href={ postUrl }
+										target="_blank"
+										className="post-item__title-link"
+									>
+										{ title || translate( 'Untitled' ) }
+									</ExternalLink>
+								) }
 						</h1>
 						<div className="post-item__meta">
 							<PostTime globalId={ globalId } />

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -117,4 +117,13 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	condensedPostList: {
+		datestamp: '20171113',
+		variations: {
+			condensedPosts: 5,
+			largePosts: 95,
+		},
+		defaultVariation: 'largePosts',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -19,6 +19,7 @@ import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { isEnabled } from 'config';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
+import { abtest } from 'lib/abtest';
 
 function PostActionsEllipsisMenuDuplicate( {
 	translate,
@@ -30,7 +31,13 @@ function PostActionsEllipsisMenuDuplicate( {
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
 
-	if ( ! isEnabled( 'posts/post-type-list' ) || ! canEdit || ! validStatus || 'post' !== type ) {
+	if (
+		! isEnabled( 'posts/post-type-list' ) ||
+		'condensedPosts' !== abtest( 'condensedPostList' ) ||
+		! canEdit ||
+		! validStatus ||
+		'post' !== type
+	) {
 		return null;
 	}
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
@@ -17,6 +17,7 @@ import { bumpStatGenerator } from './utils';
 import { getPost } from 'state/posts/selectors';
 import { toggleSharePanel } from 'state/ui/post-type-list/actions';
 import { isPublicizeEnabled } from 'state/selectors';
+import { abtest } from 'lib/abtest';
 import config from 'config';
 
 class PostActionsEllipsisMenuShare extends Component {
@@ -46,6 +47,7 @@ class PostActionsEllipsisMenuShare extends Component {
 		const { translate, status, type, isPublicizeEnabled: isPublicizeEnabledForSite } = this.props;
 		if (
 			! config.isEnabled( 'posts/post-type-list' ) ||
+			'condensedPosts' !== abtest( 'condensedPostList' ) ||
 			'publish' !== status ||
 			! isPublicizeEnabledForSite ||
 			'post' !== type

--- a/client/my-sites/posts/post-list-wrapper.jsx
+++ b/client/my-sites/posts/post-list-wrapper.jsx
@@ -12,6 +12,7 @@ import React from 'react';
 import PostList from './post-list';
 import PostTypeList from 'my-sites/post-type-list';
 import config from 'config';
+import { abtest } from 'lib/abtest';
 import { mapPostStatus } from 'lib/route/path';
 
 class PostListWrapper extends React.Component {
@@ -54,7 +55,8 @@ class PostListWrapper extends React.Component {
 	render() {
 		return (
 			<div>
-				{ config.isEnabled( 'posts/post-type-list' )
+				{ config.isEnabled( 'posts/post-type-list' ) &&
+				abtest( 'condensedPostList' ) === 'condensedPosts'
 					? this.renderPostTypeList()
 					: this.renderPostList() }
 			</div>

--- a/config/development.json
+++ b/config/development.json
@@ -133,7 +133,7 @@
 		"post-editor/image-editor": true,
 		"post-editor/media-advanced": false,
 		"post-editor/revisions": true,
-		"posts/post-type-list": false,
+		"posts/post-type-list": true,
 		"posts/post-type-list/bulk-edit": false,
 		"press-this": true,
 		"privacy-policy": true,

--- a/config/production.json
+++ b/config/production.json
@@ -86,6 +86,7 @@
 		"post-editor/author-selector": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
+		"posts/post-type-list": true,
 		"press-this": true,
 		"preview-layout": true,
 		"publicize-preview": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -90,6 +90,7 @@
 		"plans/jetpack-config-v2": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
+		"posts/post-type-list": true,
 		"press-this": true,
 		"preview-layout": true,
 		"publicize-preview": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -98,6 +98,7 @@
 		"post-editor/image-editor": true,
 		"post-editor/preview-scroll-to-content": true,
 		"post-editor/revisions": true,
+		"posts/post-type-list": true,
 		"press-this": true,
 		"preview-layout": true,
 		"publicize-preview": true,


### PR DESCRIPTION
**This PR enables a feature. After review DO NOT MERGE until the release is coordinated.**

This PR enables the feature-flag `posts/post-type-list` in development, wpcalypso, staging, and production and additionally gates the feature behind the abtest `condensedPostList`, showing it to 5% of English-speaking users (`condensedPosts`) with the other 95% of users receiving the current post format (`largePosts`).

Context: p8F9tW-vh-p2

Before (or with abtest value of `largePosts`):

![image](https://user-images.githubusercontent.com/363749/32669903-bba5e570-c607-11e7-846d-c0f80782a220.png)


After (when in the `condensedPosts` group):

![image](https://user-images.githubusercontent.com/363749/32670027-1148612e-c608-11e7-97ad-71f02e13fcce.png)
