### PR TITLE
Activity Log: fix React warning about a missing key

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -398,7 +398,7 @@ class ActivityLog extends Component {
 			downloadId,
 		} = progress;
 		return (
-			<div>
+			<div key={ `end-banner-${ restoreId || downloadId }` }>
 				<QueryActivityLog siteId={ siteId } />
 				{ errorCode ? (
 					<ErrorBanner


### PR DESCRIPTION
Fixes this React warning: Warning: Each child in an array or iterator should have a unique “key” prop. Check the render method of `ActivityLog`. 
Which was related to this since it's pushed into an array in `renderActionProgress()`