### PR TITLE
Store: UX improvements to ProductSearch component

### DIFF
--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -18,7 +18,13 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import NoResults from 'my-sites/no-results';
 import Search from 'components/search';
 import ProductSearchRow from './row';
-import { addProductId, isProductSelected, productContainsString, removeProductId } from './utils';
+import {
+	addProductId,
+	areVariationsSelected,
+	isProductSelected,
+	productContainsString,
+	removeProductId,
+} from './utils';
 
 class ProductSearch extends Component {
 	static propTypes = {
@@ -64,7 +70,9 @@ class ProductSearch extends Component {
 			products &&
 			products.filter( product => {
 				return (
-					productContainsString( product, searchFilter ) || isProductSelected( value, product.id )
+					productContainsString( product, searchFilter ) ||
+					isProductSelected( value, product.id ) ||
+					areVariationsSelected( value, product )
 				);
 			} )
 		);

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -6,13 +6,16 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import { areProductsLoading, getAllProducts } from 'woocommerce/state/sites/products/selectors';
 import { fetchProducts } from 'woocommerce/state/sites/products/actions';
-import { getAllProducts } from 'woocommerce/state/sites/products/selectors';
+import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import NoResults from 'my-sites/no-results';
 import Search from 'components/search';
 import ProductSearchRow from './row';
 import { addProductId, isProductSelected, productContainsString, removeProductId } from './utils';
@@ -33,19 +36,19 @@ class ProductSearch extends Component {
 	}
 
 	componentDidMount() {
-		const { siteId } = this.props;
+		const { siteId, query } = this.props;
 
 		if ( siteId ) {
-			this.props.fetchProducts( siteId, { offset: 0, per_page: 50 } );
+			this.props.fetchProducts( siteId, query );
 		}
 	}
 
 	componentWillReceiveProps( newProps ) {
 		const { siteId: oldSiteId } = this.props;
-		const { siteId: newSiteId } = newProps;
+		const { siteId: newSiteId, query } = newProps;
 
 		if ( oldSiteId !== newSiteId ) {
-			this.props.fetchProducts( newSiteId, { offset: 0, per_page: 50 } );
+			this.props.fetchProducts( newSiteId, query );
 		}
 	}
 
@@ -88,8 +91,47 @@ class ProductSearch extends Component {
 		return <Search value={ this.state.searchFilter } onSearch={ this.onSearch } />;
 	};
 
+	renderNoProducts = () => {
+		const { translate, site } = this.props;
+		const text = translate( "You don't have any products yet – {{a}}Add product{{/a}}", {
+			components: {
+				a: <a href={ getLink( '/store/product/:site/', site ) } />,
+			},
+		} );
+		return (
+			<div className="product-search__list">
+				<div className="product-search__row is-empty">
+					<div className="product-search__row-item">
+						<NoResults text={ text } image="/calypso/images/pages/illustration-pages.svg" />
+					</div>
+				</div>
+			</div>
+		);
+	};
+
+	renderPlaceholder = () => {
+		return (
+			<div className="product-search__list">
+				<div className="product-search__row is-placeholder">
+					<div className="product-search__row-item">
+						<input type="checkbox" disabled />
+						<span className="product-search__list-image is-thumb-placeholder" />
+						<span className="product-search__row-title" />
+					</div>
+				</div>
+			</div>
+		);
+	};
+
 	renderList = () => {
-		const { singular, value } = this.props;
+		const { isLoading, products, singular, value } = this.props;
+		if ( isLoading ) {
+			return this.renderPlaceholder();
+		}
+		if ( ! products.length ) {
+			return this.renderNoProducts();
+		}
+
 		const filteredProducts = this.getFilteredProducts() || [];
 		const renderFunc = product => {
 			const onChange = singular ? this.onProductRadio : this.onProductCheckbox;
@@ -121,12 +163,17 @@ export default connect(
 	state => {
 		const site = getSelectedSiteWithFallback( state );
 		const siteId = site ? site.ID : null;
+		const query = { per_page: 50, offset: 0 };
 		const products = getAllProducts( state, siteId );
+		const isLoading = areProductsLoading( state, query, siteId );
 
 		return {
+			isLoading,
+			site, // Needed for getLink
 			siteId,
+			query,
 			products,
 		};
 	},
 	dispatch => bindActionCreators( { fetchProducts }, dispatch )
-)( ProductSearch );
+)( localize( ProductSearch ) );

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -101,7 +101,7 @@ class ProductSearch extends Component {
 
 	renderNoProducts = () => {
 		const { translate, site } = this.props;
-		const text = translate( "You don't have any products yet – {{a}}Add product{{/a}}", {
+		const text = translate( "You don't have any products yet – {{a}}Add a product{{/a}}", {
 			components: {
 				a: <a href={ getLink( '/store/product/:site/', site ) } />,
 			},

--- a/client/extensions/woocommerce/components/product-search/row.js
+++ b/client/extensions/woocommerce/components/product-search/row.js
@@ -24,7 +24,7 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/general/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getVariationsForProduct } from 'woocommerce/state/sites/product-variations/selectors';
-import { isProductSelected, isVariableProduct } from './utils';
+import { areVariationsSelected, isProductSelected, isVariableProduct } from './utils';
 import ProductVariations from './variations';
 
 class ProductSearchRow extends Component {
@@ -142,18 +142,8 @@ class ProductSearchRow extends Component {
 	};
 
 	areAnySelected = () => {
-		const { product, singular } = this.props;
-		const { variations } = this.state;
-		if ( singular && variations[ 0 ] ) {
-			return this.isSelected( product.id ) || this.isSelected( variations[ 0 ].id );
-		}
-		return reduce(
-			variations,
-			( result, variation ) => {
-				return result || this.isSelected( variation.id );
-			},
-			this.isSelected( product.id )
-		);
+		const { product } = this.props;
+		return this.isSelected( product.id ) || areVariationsSelected( this.props.value, product );
 	};
 
 	renderSelectedVariations = () => {

--- a/client/extensions/woocommerce/components/product-search/row.js
+++ b/client/extensions/woocommerce/components/product-search/row.js
@@ -75,7 +75,6 @@ class ProductSearchRow extends Component {
 		const selectedIds = intersection( newProps.value, newProps.product.variations );
 		const selectedVariations = selectedIds.map( id => find( newProps.variations, { id } ) );
 		this.setState( {
-			showForm: Boolean( selectedIds.length ),
 			variations: filter( selectedVariations ) || [],
 		} );
 	}
@@ -91,16 +90,7 @@ class ProductSearchRow extends Component {
 		// This handler can be on the label, or button with the label, so we
 		// stop propagation to avoid immediate open-then-close behavior.
 		event.stopPropagation();
-		this.setState( prevState => {
-			// Open form
-			if ( ! prevState.showForm ) {
-				return { showForm: true };
-			}
-			// Only close form if nothing's selected
-			if ( prevState.showForm && ! this.areAnySelected() ) {
-				return { showForm: false };
-			}
-		} );
+		this.setState( prevState => ( { showForm: ! prevState.showForm } ) );
 	};
 
 	updateItem = ( attributes, callback ) => {
@@ -164,7 +154,9 @@ class ProductSearchRow extends Component {
 		return (
 			<div className="product-search__variation-selections-and-form">
 				{ this.renderSelectedVariations() }
-				<ProductVariations product={ this.props.product } onChange={ this.updateItem } />
+				{ this.state.showForm && (
+					<ProductVariations product={ this.props.product } onChange={ this.updateItem } />
+				) }
 			</div>
 		);
 	};

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -30,7 +30,21 @@
 				border-bottom: 0;
 			}
 
-			label {
+			&.is-placeholder .product-search__row-item,
+			&.is-empty .product-search__row-item {
+				cursor: default;
+			}
+
+			&.is-placeholder span {
+				@include placeholder();
+
+				&.product-search__row-title {
+					width: 100px;
+				}
+			}
+
+			label,
+			.product-search__row-item {
 				width: 100%;
 				display: flex;
 				align-items: center;

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -61,7 +61,7 @@
 				width: 32px;
 				overflow: hidden;
 				position: relative;
-				margin: 0 12px;
+				margin: 0 12px 0 15px;
 
 				&.is-thumb-placeholder {
 					background: $gray-light;
@@ -82,8 +82,12 @@
 				width: 16px;
 			}
 
+			.form-checkbox {
+				margin-left: 7px;
+			}
+
 			.form-checkbox + .product-search__list-image {
-				margin-left: 26px;
+				margin-left: 22px;
 			}
 
 			.button {
@@ -99,7 +103,9 @@
 		border-top: 1px solid $gray-light;
 
 		label.form-label {
-			padding: 12px 32px;
+			.form-checkbox + .product-search__list-image {
+				margin-left: 38px;
+			}
 		}
 
 		&:empty {
@@ -108,7 +114,7 @@
 	}
 
 	.product-search__variations {
-		padding: 16px 16px 16px 74px;
+		padding: 16px 16px 16px 77px;
 		border-top: 1px solid $gray-light;
 
 		.form-legend {

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -98,23 +98,22 @@
 		background: lighten( $gray, 35% );
 		border-top: 1px solid $gray-light;
 
+		label.form-label {
+			padding: 12px 32px;
+		}
+
 		&:empty {
 			border: 0;
 		}
 	}
 
 	.product-search__variations {
-		padding: 16px;
-		padding-left: 58px;
+		padding: 16px 16px 16px 74px;
 		border-top: 1px solid $gray-light;
-
-		.notice {
-			margin-bottom: 16px;
-		}
 
 		.form-legend {
 			font-weight: 400;
-			margin: 0;
+			margin: 0 0 16px;
 		}
 
 		.product-search__variation-fields {

--- a/client/extensions/woocommerce/components/product-search/test/utils.js
+++ b/client/extensions/woocommerce/components/product-search/test/utils.js
@@ -1,0 +1,170 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	addProductId,
+	removeProductId,
+	isProductSelected,
+	productContainsString,
+	isVariableProduct,
+} from '../utils';
+
+describe( 'addProductId', () => {
+	it( 'should be a function', () => {
+		expect( addProductId ).to.be.a( 'function' );
+	} );
+
+	it( 'should add a single product', () => {
+		expect( addProductId( undefined, 2 ) ).to.eql( [ 2 ] );
+		expect( addProductId( [], 2 ) ).to.eql( [ 2 ] );
+		expect( addProductId( [ 1 ], 2 ) ).to.eql( [ 1, 2 ] );
+	} );
+
+	it( 'should add a list of products', () => {
+		expect( addProductId( undefined, [ 3, 4 ] ) ).to.eql( [ 3, 4 ] );
+		expect( addProductId( [], [ 3, 4 ] ) ).to.eql( [ 3, 4 ] );
+		expect( addProductId( [ 1, 2 ], [ 3, 4 ] ) ).to.eql( [ 1, 2, 3, 4 ] );
+	} );
+
+	it( 'should not duplicate a product already in the list', () => {
+		expect( addProductId( [ 1, 2 ], 2 ) ).to.eql( [ 1, 2 ] );
+		expect( addProductId( [ 1, 2 ], [ 2, 3 ] ) ).to.eql( [ 1, 2, 3 ] );
+	} );
+} );
+
+describe( 'removeProductId', () => {
+	it( 'should be a function', () => {
+		expect( removeProductId ).to.be.a( 'function' );
+	} );
+
+	it( 'should remove a single product', () => {
+		expect( removeProductId( [ 1, 2, 3 ], 2 ) ).to.eql( [ 1, 3 ] );
+		expect( removeProductId( [ 2 ], 2 ) ).to.eql( [] );
+	} );
+
+	it( 'should remove a list of products', () => {
+		expect( removeProductId( [ 1, 2, 3 ], [ 1, 3 ] ) ).to.eql( [ 2 ] );
+		expect( removeProductId( [ 1, 2 ], [ 1, 2 ] ) ).to.eql( [] );
+	} );
+
+	it( 'should remove products that exist in the list, and ignore others', () => {
+		expect( removeProductId( [ 1, 2, 3 ], [ 1, 5 ] ) ).to.eql( [ 2, 3 ] );
+		expect( removeProductId( [], 2 ) ).to.eql( [] );
+	} );
+} );
+
+describe( 'isProductSelected', () => {
+	it( 'should be a function', () => {
+		expect( isProductSelected ).to.be.a( 'function' );
+	} );
+
+	it( 'should be true if the product is selected', () => {
+		expect( isProductSelected( 2, 2 ) ).to.be.true;
+		expect( isProductSelected( [ 1, 2, 3 ], 2 ) ).to.be.true;
+	} );
+
+	it( 'should be false if the product is not selected', () => {
+		expect( isProductSelected( 3, 2 ) ).to.be.false;
+		expect( isProductSelected( [ 1, 3, 4 ], 2 ) ).to.be.false;
+		expect( isProductSelected( [], 2 ) ).to.be.false;
+	} );
+
+	it( 'should be false if the value is not valid', () => {
+		expect( isProductSelected( false, 2 ) ).to.be.false;
+		expect( isProductSelected( null, 2 ) ).to.be.false;
+	} );
+} );
+
+describe( 'productContainsString', () => {
+	it( 'should be a function', () => {
+		expect( productContainsString ).to.be.a( 'function' );
+	} );
+
+	it( 'should return true if the string exists in the product, regardless of case', () => {
+		const product = {
+			name: 'Test Product Hello World',
+			attributes: [
+				{
+					options: [ 'Red', 'Yellow' ],
+					variation: true,
+				},
+				{
+					options: [ 'Small', 'Large' ],
+					variation: true,
+				},
+			],
+		};
+		expect( productContainsString( product, 'World' ) ).to.be.true;
+		expect( productContainsString( product, 'Red' ) ).to.be.true;
+		expect( productContainsString( product, 'Small' ) ).to.be.true;
+		expect( productContainsString( product, 'hello' ) ).to.be.true;
+		expect( productContainsString( product, 'large' ) ).to.be.true;
+	} );
+
+	it( 'should return false if the string does not exist in the product', () => {
+		const product = {
+			name: 'Test Product Hello World',
+			attributes: [
+				{
+					options: [ 'Red', 'Yellow' ],
+					variation: true,
+				},
+				{
+					options: [ 'Small', 'Large' ],
+					variation: true,
+				},
+			],
+		};
+		expect( productContainsString( product, 'Foo' ) ).to.be.false;
+		expect( productContainsString( product, 'Blue' ) ).to.be.false;
+		expect( productContainsString( product, 'Medium' ) ).to.be.false;
+	} );
+
+	it( 'should return false if the string does not exist in selectable variations', () => {
+		const product = {
+			name: 'Test Product Hello World',
+			attributes: [
+				{
+					options: [ 'Blue', 'Green' ],
+					variation: false,
+				},
+			],
+		};
+		expect( productContainsString( product, 'Blue' ) ).to.be.false;
+	} );
+} );
+
+describe( 'isVariableProduct', () => {
+	it( 'should be a function', () => {
+		expect( isVariableProduct ).to.be.a( 'function' );
+	} );
+
+	it( 'should return true if the product is variable', () => {
+		const product = {
+			type: 'variable',
+		};
+		expect( isVariableProduct( product ) ).to.be.true;
+	} );
+
+	it( 'should return false if the product is a variation', () => {
+		const product = {
+			type: 'variable',
+			isVariation: true,
+		};
+		expect( isVariableProduct( product ) ).to.be.false;
+	} );
+
+	it( 'should return false if the product is simple', () => {
+		const product = {
+			type: 'simple',
+		};
+		expect( isVariableProduct( product ) ).to.be.false;
+	} );
+} );

--- a/client/extensions/woocommerce/components/product-search/test/utils.js
+++ b/client/extensions/woocommerce/components/product-search/test/utils.js
@@ -12,6 +12,7 @@ import {
 	addProductId,
 	removeProductId,
 	isProductSelected,
+	areVariationsSelected,
 	productContainsString,
 	isVariableProduct,
 } from '../utils';
@@ -79,6 +80,30 @@ describe( 'isProductSelected', () => {
 	it( 'should be false if the value is not valid', () => {
 		expect( isProductSelected( false, 2 ) ).to.be.false;
 		expect( isProductSelected( null, 2 ) ).to.be.false;
+	} );
+} );
+
+describe( 'areVariationsSelected', () => {
+	it( 'should be a function', () => {
+		expect( areVariationsSelected ).to.be.a( 'function' );
+	} );
+
+	it( 'should be false if there are no variations', () => {
+		const product = {
+			variations: [],
+		};
+		expect( areVariationsSelected( 2, product ) ).to.be.false;
+		expect( areVariationsSelected( [], product ) ).to.be.false;
+		expect( areVariationsSelected( [ 1, 2, 3 ], product ) ).to.be.false;
+	} );
+
+	it( 'should be true if any variations are selected', () => {
+		const product = {
+			variations: [ 5, 6, 7 ],
+		};
+		expect( areVariationsSelected( 6, product ) ).to.be.true;
+		expect( areVariationsSelected( [ 1, 2, 5 ], product ) ).to.be.true;
+		expect( areVariationsSelected( [ 5, 6 ], product ) ).to.be.true;
 	} );
 } );
 

--- a/client/extensions/woocommerce/components/product-search/utils.js
+++ b/client/extensions/woocommerce/components/product-search/utils.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { difference, filter, isArray, uniq } from 'lodash';
+import { difference, filter, intersection, isArray, uniq } from 'lodash';
 
 /**
  * Check if a string is found in a product name or attribute option
@@ -41,6 +41,24 @@ export function isProductSelected( value = [], productId ) {
 		return -1 !== value.indexOf( productId );
 	}
 	return value === productId;
+}
+
+/**
+ * Check if any variations of a product are selected
+ *
+ * @param {Array} value An array of existing values
+ * @param {Object} product The product to check
+ * @return {Boolean} Whether any variations exist in the values list
+ */
+export function areVariationsSelected( value = [], product ) {
+	const variations = product.variations;
+	if ( ! variations.length ) {
+		return false;
+	}
+	if ( isArray( value ) && value.length ) {
+		return !! intersection( value, variations ).length;
+	}
+	return -1 !== variations.indexOf( value );
 }
 
 /**

--- a/client/extensions/woocommerce/components/product-search/utils.js
+++ b/client/extensions/woocommerce/components/product-search/utils.js
@@ -5,6 +5,13 @@
  */
 import { difference, filter, isArray, uniq } from 'lodash';
 
+/**
+ * Check if a string is found in a product name or attribute option
+ *
+ * @param {Object} product A given product to search
+ * @param {String} textString A string to search for
+ * @return {Boolean} Whether the string was found in the product
+ */
 export function productContainsString( product, textString ) {
 	const matchString = textString.trim().toLocaleLowerCase();
 
@@ -22,6 +29,13 @@ export function productContainsString( product, textString ) {
 	return false;
 }
 
+/**
+ * Check if a string is found in a product name or attribute option
+ *
+ * @param {Array} value An array of existing values
+ * @param {Number} productId The product ID to search for
+ * @return {Boolean} Whether the product ID exists in the list of values
+ */
 export function isProductSelected( value = [], productId ) {
 	if ( isArray( value ) && value.length ) {
 		return -1 !== value.indexOf( productId );
@@ -29,17 +43,37 @@ export function isProductSelected( value = [], productId ) {
 	return value === productId;
 }
 
+/**
+ * Check if a product is `variable` (has selectable variations)
+ *
+ * @param {Object} product A product to check
+ * @return {Boolean} Whether the product has variations
+ */
 export function isVariableProduct( product ) {
 	return 'variable' === product.type && ! product.isVariation;
 }
 
+/**
+ * Add a product ID (or list of IDs) to a list of values
+ *
+ * @param {Array} value An array of existing values
+ * @param {Number|Array} productId The product ID(s) to add
+ * @return {Array} Updated list of values
+ */
 export function addProductId( value = [], productId ) {
 	if ( isArray( productId ) ) {
 		return uniq( [ ...value, ...productId ] );
 	}
-	return [ ...value, productId ];
+	return uniq( [ ...value, productId ] );
 }
 
+/**
+ * Remove a product ID (or list of IDs) from a list of values
+ *
+ * @param {Array} value An array of existing values
+ * @param {Number|Array} productId The product ID(s) to remove
+ * @return {Array} Updated list of values
+ */
 export function removeProductId( value = [], productId ) {
 	if ( isArray( productId ) ) {
 		return difference( value, productId );

--- a/client/extensions/woocommerce/components/product-search/variations.js
+++ b/client/extensions/woocommerce/components/product-search/variations.js
@@ -51,13 +51,12 @@ class ProductVariations extends Component {
 
 	renderAttribute = attribute => {
 		const { translate } = this.props;
+		const fieldId = kebabCase( attribute.name );
 		return (
-			<div className="product-search__variation-field" key={ attribute.id }>
-				<FormLabel htmlFor={ `select-${ kebabCase( attribute.name ) }` }>
-					{ attribute.name }
-				</FormLabel>
+			<div className="product-search__variation-field" key={ fieldId }>
+				<FormLabel htmlFor={ `select-${ fieldId }` }>{ attribute.name }</FormLabel>
 				<FormSelect
-					id={ `select-${ kebabCase( attribute.name ) }` }
+					id={ `select-${ fieldId }` }
 					onChange={ this.onChange( attribute.name ) }
 					value={ this.state[ attribute.name ] }
 				>

--- a/client/extensions/woocommerce/components/product-search/variations.js
+++ b/client/extensions/woocommerce/components/product-search/variations.js
@@ -86,7 +86,7 @@ class ProductVariations extends Component {
 			<div className="product-search__variations">
 				<FormFieldset>
 					<FormLegend>
-						{ translate( '%(product)s has variations. Choose a specific customization to select.', {
+						{ translate( '%(product)s has variations. Choose a specific variation to add.', {
 							args: { product: product.name },
 						} ) }
 					</FormLegend>

--- a/client/extensions/woocommerce/components/product-search/variations.js
+++ b/client/extensions/woocommerce/components/product-search/variations.js
@@ -14,7 +14,6 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
 import FormSelect from 'components/forms/form-select';
-import Notice from 'components/notice';
 
 // Use a constant for the default attribute state.
 const DEFAULT_ATTR = 'any';
@@ -88,12 +87,9 @@ class ProductVariations extends Component {
 			<div className="product-search__variations">
 				<FormFieldset>
 					<FormLegend>
-						<Notice showDismiss={ false }>
-							{ translate(
-								'%(product)s has variations. Choose a specific customization to select.',
-								{ args: { product: product.name } }
-							) }
-						</Notice>
+						{ translate( '%(product)s has variations. Choose a specific customization to select.', {
+							args: { product: product.name },
+						} ) }
 					</FormLegend>
 					<div className="product-search__variation-fields">
 						{ attributes.map( this.renderAttribute ) }


### PR DESCRIPTION
This PR follows up on the feedback I received in the "Add Products" & `ProductSearch` PRs. I've added unit tests for the `product-search/utils` functions, and also made the suggested UX improvements. Specifically, this PR does the following:

- Add a view for a store with no products, I also added a placeholder view while products are loading
- The notice should just be converted to plain text.
- Indent variations below products
- "Select variations" button should hide the form when clicked again
- Always show all selected products (including variations) when searching

The loading placeholder
![placeholder](https://user-images.githubusercontent.com/541093/32675397-d9bb33fe-c624-11e7-953d-90068890437b.png)

No products placeholder. The link takes you to the add product screen
![no-products](https://user-images.githubusercontent.com/541093/32675398-d9d56ac6-c624-11e7-8d4a-432db40c6dfa.png)

Searching with variations selected, all selected products stay visible even if they don't match the search:
<img width="707" alt="selected-search" src="https://user-images.githubusercontent.com/541093/32675396-d9a634cc-c624-11e7-9b73-46f3bde85a78.png">

I was also finally able to duplicate the issue @jameskoster & @timmyc encountered when trying to add variations (I think), and have fixed that as well. Let me know if this doesn't fix the issue, so we can try to get to the bottom of it.

Not in this PR: disabling already-selected attributes. The way the components + product/variations objects are set up, this isn't a quick fix. If it's deemed high-value enough I can implement it in another PR.

**To test**

- View an order, click "Edit Order"
- Open the add product dialog by clicking "+ Add Product"
- Select some products
- Click into variations and selecting specific variations
- Search for specific products or variation terms
- Add these to your order and make sure the correct products and variations are added
- Save and verify the update