### PR TITLE
Keyed Reducer: make serialize/deserialize default global actions

### DIFF
--- a/client/state/reader/watermarks/reducer.js
+++ b/client/state/reader/watermarks/reducer.js
@@ -8,7 +8,7 @@ import { max } from 'lodash';
 /**
  * Internal dependencies
  */
-import { READER_VIEW_STREAM, DESERIALIZE } from 'state/action-types';
+import { READER_VIEW_STREAM } from 'state/action-types';
 import { createReducer, keyedReducer } from 'state/utils';
 import schema from './watermark-schema';
 
@@ -20,8 +20,7 @@ export const watermarks = keyedReducer(
 			[ READER_VIEW_STREAM ]: ( state, action ) => max( [ +state, +action.mark ] ),
 		},
 		schema
-	),
-	[ DESERIALIZE ]
+	)
 );
 
 watermarks.hasCustomPersistence = true;

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -364,23 +364,44 @@ describe( 'utils', () => {
 			const counter = ( state = 0, { type } ) => {
 				switch ( type ) {
 					case 'INC':
+					case 'INC_ALL':
 						return state + 1;
-					case 'DESERIALIZE':
-						return parseInt( state, 16 );
-					case 'SERIALIZE':
-						return state.toString( 16 );
 					default:
 						return state;
 				}
 			};
 
-			const keyed = keyedReducer( 'id', counter, [ 'DESERIALIZE', 'SERIALIZE' ] );
+			const keyed = keyedReducer( 'id', counter, [ 'INC_ALL' ] );
 
 			const prev = { 14: 5, 23: 19 };
 
 			expect( keyed( prev, { type: 'INC', id: 14 } ) ).to.eql( { 14: 6, 23: 19 } );
-			expect( keyed( prev, { type: 'SERIALIZE' } ) ).to.eql( { 14: '5', 23: '13' } );
-			expect( keyed( prev, { type: 'DESERIALIZE' } ) ).to.eql( { 14: 5, 23: 25 } );
+			expect( keyed( prev, { type: 'INC_ALL' } ) ).to.eql( { 14: 6, 23: 20 } );
+		} );
+
+		test( 'should have SERIALIZE and DESERIALIZE as default global actions', () => {
+			const chickenReducer = ( state = '', { type } ) => {
+				switch ( type ) {
+					case 'SET_CHICKEN':
+						return 'chicken';
+					case 'SERIALIZE':
+						return 'serialized chicken';
+					case 'DESERIALIZE':
+						return 'deserialized chicken';
+					default:
+						return state;
+				}
+			};
+
+			const keyed = keyedReducer( 'id', chickenReducer );
+			const prev = { 1: 'chicken' };
+
+			expect( keyed( prev, { type: 'SET_CHICKEN', id: 2 } ) ).to.eql( {
+				1: 'chicken',
+				2: 'chicken',
+			} );
+			expect( keyed( prev, { type: 'SERIALIZE' } ) ).to.eql( { 1: 'serialized chicken' } );
+			expect( keyed( prev, { type: 'DESERIALIZE' } ) ).to.eql( { 1: 'deserialized chicken' } );
 		} );
 
 		test( 'should not apply global actions if not whitelisted', () => {
@@ -397,7 +418,7 @@ describe( 'utils', () => {
 				}
 			};
 
-			const keyed = keyedReducer( 'id', counter );
+			const keyed = keyedReducer( 'id', counter, [] );
 
 			const prev = { 14: 5, 23: 19 };
 

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -48,7 +48,7 @@ export function isValidStateWithSchema( state, schema ) {
  * Note! This will only apply the supplied reducer to
  * the item referenced by the supplied key in the action.
  *
- * If no key exists whose name matches the given keyName
+ * If no key exists whose name matches the given lodash style keyPath
  * then this super-reducer will abort and return the
  * previous state.
  *
@@ -58,7 +58,7 @@ export function isValidStateWithSchema( state, schema ) {
  * These will apply to every item in the collection
  * and they may not have the necessary key: for
  * example, the DESERIALIZE and SERIALIZE actions
- * may apply to all items.
+ * may apply to all items and are included by default.
  *
  * @example
  * const age = ( state = 0, action ) =>
@@ -93,20 +93,20 @@ export function isValidStateWithSchema( state, schema ) {
  *
  * // now every item can decide what to do for persistence
  *
- * @param {string} keyName lodash-style path to the key in action referencing item in state map
+ * @param {string} keyPath lodash-style path to the key in action referencing item in state map
  * @param {Function} reducer applied to referenced item in state map
  * @param {Array} globalActions set of types which apply to every item in the collection
  * @return {Function} super-reducer applying reducer over map of keyed items
  */
-export const keyedReducer = ( keyName, reducer, globalActions ) => {
+export const keyedReducer = ( keyPath, reducer, globalActions = [ SERIALIZE, DESERIALIZE ] ) => {
 	// some keys are invalid
-	if ( 'string' !== typeof keyName ) {
+	if ( 'string' !== typeof keyPath ) {
 		throw new TypeError(
 			`Key name passed into ``keyedReducer`` must be a string but I detected a ${ typeof keyName }`
 		);
 	}
 
-	if ( ! keyName.length ) {
+	if ( ! keyPath.length ) {
 		throw new TypeError(
 			'Key name passed into `keyedReducer` must have a non-zero length but I detected an empty string'
 		);
@@ -129,7 +129,7 @@ export const keyedReducer = ( keyName, reducer, globalActions ) => {
 		}
 
 		// don't allow coercion of key name: null => 0
-		const itemKey = get( action, keyName, undefined );
+		const itemKey = get( action, keyPath, undefined );
 
 		// if the action doesn't contain a valid reference
 		// then return without any updates


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/19119, @dmsnell introduced the concept of a "global action" to keyed reducers. A global action is one meant to be run against all of the keys in the reducer even if not specified by the keyPath.  The primary usecase for this is for SERIALIZE/DESERIALIZE actions which you generally want to apply to the whole collection.

This PR:
1.  Makes `SERIALIZE` and `DESERIALIZE` global actions by default
2. Renames`keyName`  to `keyPath` since it was converted to a [lodash-style path](https://github.com/Automattic/wp-calypso/pull/18805)

To test:
---
1. New behavior should be covered well enough with unit tests