### PR TITLE
My Sites: Remove noticons

### DIFF
--- a/assets/stylesheets/shared/_welcome.scss
+++ b/assets/stylesheets/shared/_welcome.scss
@@ -30,11 +30,6 @@
 		display: block;
 		padding: 14px 8px;
 
-		.noticon {
-			font-size: 32px;
-			line-height: 32px;
-		}
-
 		// Focus state
 		&:focus {
 			outline: none;

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -215,7 +216,9 @@ export class CartItem extends React.Component {
 		if ( canRemoveFromCart( this.props.cart, this.props.cartItem ) ) {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
-				<button className="remove-item noticon noticon-close" onClick={ this.removeFromCart } />
+				<button className="remove-item" onClick={ this.removeFromCart }>
+					<Gridicon icon="cross-small" />
+				</button>
 			);
 			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		}

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -75,7 +75,6 @@
 			background: transparent;
 			padding: 0;
 			margin: 0;
-			font-size: 25px;
 			pointer-events: auto;
 			position: absolute;
 			right: 0;

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -18,6 +18,7 @@ import moment from 'moment';
 import { themeActivated } from 'state/themes/actions';
 import analytics from 'lib/analytics';
 import { loadTrackingTool } from 'state/analytics/actions';
+import WordPressLogo from 'components/wordpress-logo';
 import Card from 'components/card';
 import ChargebackDetails from './chargeback-details';
 import CheckoutThankYouFeaturesHeader from './features-header';
@@ -278,7 +279,7 @@ class CheckoutThankYou extends React.Component {
 		if ( ! purchases.length && ! failedPurchases.length && ! this.isGenericReceipt() ) {
 			// disabled because we use global loader icon
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
-			return <div className="wpcom-site__logo noticon noticon-wordpress" />;
+			return <WordPressLogo className="wpcom-site__logo" />;
 			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		}
 

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -267,7 +267,7 @@ class Draft extends Component {
 				<div className="draft__actions">
 					<p className="post-relative-time-status">
 						<span className="time">
-							<span className="noticon noticon-time" />
+							<Gridicon icon="time" size={ 18 } />
 							<span className="time-text" />
 						</span>
 					</p>
@@ -296,10 +296,12 @@ class Draft extends Component {
 		return (
 			<div className="draft__all-actions">
 				<PostRelativeTimeStatus post={ this.props.post } includeEditLink={ true } />
-				<span
-					className="draft__actions-toggle noticon noticon-ellipsis"
+				<Gridicon
+					className="draft__actions-toggle"
 					onClick={ this.togglePopoverMenu }
 					ref="popoverMenuButton"
+					icon="ellipsis"
+					size={ 18 }
 				/>
 				<PopoverMenu
 					isVisible={ this.state.showPopoverMenu }

--- a/client/my-sites/sharing/buttons/preview-placeholder.jsx
+++ b/client/my-sites/sharing/buttons/preview-placeholder.jsx
@@ -32,7 +32,10 @@ class SharingButtonsPreviewPlaceholder extends React.Component {
 
 					<div className="sharing-buttons-preview__reblog-like">
 						<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__like">
-							<Gridicon icon="star" size={ 18 } />
+							// 16 is used in the preview to match the buttons on the frontend of the website.
+							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+							<Gridicon icon="star" size={ 16 } />
+							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 							{ this.props.translate( 'Like' ) }
 						</a>
 						<div className="sharing-buttons-preview__fake-user">

--- a/client/my-sites/sharing/buttons/preview-placeholder.jsx
+++ b/client/my-sites/sharing/buttons/preview-placeholder.jsx
@@ -5,8 +5,8 @@
  */
 
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -32,7 +32,7 @@ class SharingButtonsPreviewPlaceholder extends React.Component {
 
 					<div className="sharing-buttons-preview__reblog-like">
 						<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__like">
-							<span className="noticon noticon-like" />
+							<Gridicon icon="star" size={ 18 } />
 							{ this.props.translate( 'Like' ) }
 						</a>
 						<div className="sharing-buttons-preview__fake-user">

--- a/client/my-sites/sharing/buttons/preview-placeholder.jsx
+++ b/client/my-sites/sharing/buttons/preview-placeholder.jsx
@@ -32,8 +32,8 @@ class SharingButtonsPreviewPlaceholder extends React.Component {
 
 					<div className="sharing-buttons-preview__reblog-like">
 						<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__like">
-							// 16 is used in the preview to match the buttons on the frontend of the website.
 							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+							{ /* 16 is used in the preview to match the buttons on the frontend of the website. */ }
 							<Gridicon icon="star" size={ 16 } />
 							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 							{ this.props.translate( 'Like' ) }

--- a/client/my-sites/sharing/buttons/preview.jsx
+++ b/client/my-sites/sharing/buttons/preview.jsx
@@ -8,6 +8,7 @@ import { filter, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -123,7 +124,10 @@ class SharingButtonsPreview extends React.Component {
 		if ( this.props.showReblog ) {
 			return (
 				<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__reblog">
-					<span className="noticon noticon-reblog" />
+					// 16 is used in the preview to match the buttons on the frontend of the website.
+					{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+					<Gridicon icon="reblog" size={ 16 } />
+					{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 					{ this.props.translate( 'Reblog' ) }
 				</a>
 			);
@@ -135,7 +139,10 @@ class SharingButtonsPreview extends React.Component {
 			return (
 				<span>
 					<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__like">
-						<span className="noticon noticon-like" />
+						// 16 is used in the preview to match the buttons on the frontend of the website.
+						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+						<Gridicon icon="star" size={ 16 } />
+						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						{ this.props.translate( 'Like' ) }
 					</a>
 					<div className="sharing-buttons-preview__fake-user">

--- a/client/my-sites/sharing/buttons/preview.jsx
+++ b/client/my-sites/sharing/buttons/preview.jsx
@@ -120,12 +120,13 @@ class SharingButtonsPreview extends React.Component {
 		);
 	};
 
+	// 16 is used in the preview to match the buttons on the frontend of the website.
 	getReblogButtonElement = () => {
 		if ( this.props.showReblog ) {
 			return (
 				<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__reblog">
-					// 16 is used in the preview to match the buttons on the frontend of the website.
 					{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+					{ /* 16 is used in the preview to match the buttons on the frontend of the website. */ }
 					<Gridicon icon="reblog" size={ 16 } />
 					{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 					{ this.props.translate( 'Reblog' ) }
@@ -139,8 +140,8 @@ class SharingButtonsPreview extends React.Component {
 			return (
 				<span>
 					<a className="sharing-buttons-preview-button is-enabled style-icon-text sharing-buttons-preview__like">
-						// 16 is used in the preview to match the buttons on the frontend of the website.
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
+						{ /* 16 is used in the preview to match the buttons on the frontend of the website. */ }
 						<Gridicon icon="star" size={ 16 } />
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						{ this.props.translate( 'Like' ) }

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -670,15 +670,11 @@
 	}
 }
 
-.sharing-buttons-preview__reblog .noticon,
-.sharing-buttons-preview__like .noticon {
+.sharing-buttons-preview__reblog .gridicon,
+.sharing-buttons-preview__like .gridicon {
 	vertical-align: top;
-	margin: 3px 4px 0 0;
-	color: $blue-medium;
-}
-
-.sharing-buttons-preview__like .noticon {
-	margin: 3px 2px 0 -1px;
+	margin: 2px 4px 0 0;
+	fill: $blue-medium;
 }
 
 .sharing-buttons-preview__fake-user {

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -673,7 +673,7 @@
 .sharing-buttons-preview__reblog .gridicon,
 .sharing-buttons-preview__like .gridicon {
 	vertical-align: top;
-	margin: 2px 4px 0 0;
+	margin: 3px 4px 0 0;
 	fill: $blue-medium;
 }
 

--- a/client/my-sites/welcome/welcome.jsx
+++ b/client/my-sites/welcome/welcome.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -47,7 +48,7 @@ export default class extends React.Component {
 			return (
 				<div className={ welcomeClassName }>
 					<a href="#" className="close-button" onClick={ this.close }>
-						<span className="noticon noticon-close" />
+						<Gridicon icon="cross" />
 					</a>
 					{ this.props.children }
 				</div>


### PR DESCRIPTION
Context: noticons is deprecated and this is an effort to remove a few instances.

This PR replaces noticons with gridicons in My Sites, if the noticon is **not** being displayed via css (e.g. :before elements)

I found these instances by searching for `noticon` on Github and filtering by jsx files.

**Icons and icon placement might be slightly off, but I am prioritizing removal of noticons versus getting an exact 1:1 replacement. For example, the icon might be positioned slightly off, or we might not have an exact match for the icon.**

# Visual changes

Sharing button preview

Before|After
---|---
![screen shot 2017-11-13 at 2 18 17 pm](https://user-images.githubusercontent.com/618551/32747208-a2cc2c30-c87d-11e7-83d2-8c8e158ccc01.png)|![screen shot 2017-11-13 at 11 27 21 am](https://user-images.githubusercontent.com/618551/32747188-92efb1ce-c87d-11e7-99a8-335a0aa71fc9.png)


# Affected areas:

- Welcome component (client/my-sites/welcome)
- Sharing button preview (client/my-sites/sharing)
- Draft component (client/my-sites/draft)
- Checkout card (client/my-sites/checkout/cart/cart-item.jsx)
- Checkout thank you (client/my-sites/checkout/checkout-thank-you/index.jsx)

# What to test:

- [ ]  Welcome component: I don't think this is being used
- [x]  Sharing button preview
- [ ]  Draft component: I don't think this is being used
- [x]  Checkout card (client/my-sites/checkout/cart/cart-item.jsx)
- [ ]  Checkout thank you can't figure out how to test

# I need help testing the following pieces:
### Welcome component

I could only fine one place it's being used:
https://github.com/Automattic/wp-calypso/blob/5f15f3365213253724ca0d8798c6cb8160f00bc9/client/layout/index.jsx#L27

I can't figure out how to test it.

### Draft component

Are we using this anymore?

https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/draft/index.jsx

### Check out thank you

I don't know how to test this. As far as I can tell, the icon is a receipt placeholder?

https://github.com/Automattic/wp-calypso/blob/a5b337ce7ae5d11ca1e05e2576bec32dd37e2a4d/client/my-sites/checkout/checkout-thank-you/index.jsx#L279

