### PR TITLE
Sharing & comments: unwrap object matching shorthands

### DIFF
--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -29,30 +29,30 @@ const changePage = path => pageNumber => {
 	return page( addQueryArgs( { page: pageNumber }, path ) );
 };
 
-export const siteComments = ( { params, path, query, store } ) => {
-	const siteFragment = route.getSiteFragment( path );
+export const siteComments = context => {
+	const siteFragment = route.getSiteFragment( context.path );
 
 	if ( ! siteFragment ) {
 		return page.redirect( '/comments/all' );
 	}
 
-	const status = mapPendingStatusToUnapproved( params.status );
+	const status = mapPendingStatusToUnapproved( context.params.status );
 
-	const pageNumber = sanitizeInt( query.page );
+	const pageNumber = sanitizeInt( context.query.page );
 	if ( ! pageNumber ) {
-		return changePage( path )( 1 );
+		return changePage( context.path )( 1 );
 	}
 
 	renderWithReduxStore(
 		<CommentsManagement
-			basePath={ path }
-			changePage={ changePage( path ) }
+			basePath={ context.path }
+			changePage={ changePage( context.path ) }
 			page={ pageNumber }
 			siteFragment={ siteFragment }
 			status={ status }
 		/>,
 		'primary',
-		store
+		context.store
 	);
 };
 

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -30,29 +30,30 @@ const changePage = path => pageNumber => {
 };
 
 export const siteComments = context => {
-	const siteFragment = route.getSiteFragment( context.path );
+	const { params, path, query, store } = context;
+	const siteFragment = route.getSiteFragment( path );
 
 	if ( ! siteFragment ) {
 		return page.redirect( '/comments/all' );
 	}
 
-	const status = mapPendingStatusToUnapproved( context.params.status );
+	const status = mapPendingStatusToUnapproved( params.status );
 
-	const pageNumber = sanitizeInt( context.query.page );
+	const pageNumber = sanitizeInt( query.page );
 	if ( ! pageNumber ) {
-		return changePage( context.path )( 1 );
+		return changePage( path )( 1 );
 	}
 
 	renderWithReduxStore(
 		<CommentsManagement
-			basePath={ context.path }
-			changePage={ changePage( context.path ) }
+			basePath={ path }
+			changePage={ changePage( path ) }
 			page={ pageNumber }
 			siteFragment={ siteFragment }
 			status={ status }
 		/>,
 		'primary',
-		context.store
+		store
 	);
 };
 

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -25,7 +25,7 @@ const analyticsPageTitle = 'Sharing';
 
 export const layout = context => {
 	const site = sites().getSelectedSite();
-	const { contentComponent, path } = context;
+	const { contentComponent, path, store } = context;
 
 	if ( site && ! site.settings && utils.userCan( 'manage_options', site ) ) {
 		site.fetchSettings();
@@ -34,7 +34,7 @@ export const layout = context => {
 	renderWithReduxStore(
 		createElement( Sharing, { contentComponent, path } ),
 		document.getElementById( 'primary' ),
-		context.store
+		store
 	);
 };
 

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -25,13 +25,14 @@ const analyticsPageTitle = 'Sharing';
 
 export const layout = context => {
 	const site = sites().getSelectedSite();
+	const { contentComponent, path } = context;
 
 	if ( site && ! site.settings && utils.userCan( 'manage_options', site ) ) {
 		site.fetchSettings();
 	}
 
 	renderWithReduxStore(
-		createElement( Sharing, { contentComponent: context.contentComponent, path: context.path } ),
+		createElement( Sharing, { contentComponent, path } ),
 		document.getElementById( 'primary' ),
 		context.store
 	);

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -23,7 +23,7 @@ import utils from 'lib/site/utils';
 
 const analyticsPageTitle = 'Sharing';
 
-export const layout = ( { contentComponent, path, store } ) => {
+export const layout = context => {
 	const site = sites().getSelectedSite();
 
 	if ( site && ! site.settings && utils.userCan( 'manage_options', site ) ) {
@@ -31,9 +31,9 @@ export const layout = ( { contentComponent, path, store } ) => {
 	}
 
 	renderWithReduxStore(
-		createElement( Sharing, { contentComponent, path } ),
+		createElement( Sharing, { contentComponent: context.contentComponent, path: context.path } ),
 		document.getElementById( 'primary' ),
-		store
+		context.store
 	);
 };
 


### PR DESCRIPTION
Unwrap object matching shorthands to `context` for clarity and easier codemodding.

I stumbled upon these two files when working on [single-tree-rendering codemod (#19494)](https://github.com/Automattic/wp-calypso/pull/19494). Codemod will need `context` object inside the middleware.

Instead of making the codemod work for these two, I'm making these two to work for the codemod. 💪

Codemod will then turn these into something like this:
```js
export const layout = ( context, next ) => {
  context.primary = ...
  next();
}
```

### Testing

Confirm that both pages work:
- /comments/all/:domain
- /sharing/:domain