### PR TITLE
Data Layer: Allow dispatchRequestEx to return array of actions

### DIFF
--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -220,7 +220,7 @@ export const dispatchRequestEx = options => {
 		// create the low-level action we want to dispatch
 		const requestAction = createRequestAction( options, action );
 		// dispatch the low level action (if any was created) and return the result
-		return requestAction ? store.dispatch( requestAction ) : undefined;
+		return requestAction ? [].concat( requestAction ).forEach( store.dispatch ) : undefined;
 	};
 };
 

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -219,8 +219,17 @@ export const dispatchRequestEx = options => {
 	return ( store, action ) => {
 		// create the low-level action we want to dispatch
 		const requestAction = createRequestAction( options, action );
+
 		// dispatch the low level action (if any was created) and return the result
-		return requestAction ? [].concat( requestAction ).forEach( store.dispatch ) : undefined;
+		if ( ! requestAction ) {
+			return;
+		}
+
+		if ( Array.isArray( requestAction ) ) {
+			return requestAction.map( store.dispatch );
+		}
+
+		return store.dispatch( requestAction );
 	};
 };
 


### PR DESCRIPTION
Many data layer handlers want to dispatch multiple actions in response
to watched actinos and network activity. The new API introduced in
`dispatchRequestEx()` is quite convenient for cutting out the noise and
burden when writing these handlers, but it's not obvious how to dispatch
multiple actions.

In this patch I am proposing that we allow handlers to not only return a
single action to dispatch but also an array of actions, each of which
should be dispatched.