### PR TITLE
New user segmenting flow

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -72,6 +72,13 @@ const flows = {
 		},
 	},
 
+	segment: {
+		steps: [ 'about', 'domains', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'A new signup flow for segmenting our users',
+		lastModified: '2017-11-11',
+	},
+
 	premium: {
 		steps: [ 'design-type', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -5,6 +5,7 @@
  */
 
 import config from 'config';
+import AboutStepComponent from 'signup/steps/about';
 import DesignTypeComponent from 'signup/steps/design-type';
 import DesignTypeWithStoreComponent from 'signup/steps/design-type-with-store';
 import DesignTypeWithAtomicStoreComponent from 'signup/steps/design-type-with-atomic-store';
@@ -23,6 +24,7 @@ import PlansStepWithoutFreePlan from 'signup/steps/plans-without-free';
 import PlansAtomicStoreComponent from 'signup/steps/plans-atomic-store';
 
 export default {
+	about: AboutStepComponent,
 	'design-type': DesignTypeComponent,
 	'design-type-with-store': DesignTypeWithStoreComponent,
 	'design-type-with-store-nux': DesignTypeWithAtomicStoreComponent,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -107,6 +107,11 @@ export default {
 		delayApiRequestUntilComplete: true,
 	},
 
+	about: {
+		stepName: 'about',
+		providesDependencies: [ 'themeSlugWithRepo', 'siteTitle' ],
+	},
+
 	user: {
 		stepName: 'user',
 		apiRequestFunction: stepActions.createAccount,

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import StepWrapper from 'signup/step-wrapper';
+import SignupActions from 'lib/signup/actions';
+import { setSiteTitle } from 'state/signup/steps/site-title/actions';
+import { setDesignType } from 'state/signup/steps/design-type/actions';
+import Card from 'components/card';
+import Button from 'components/button';
+
+class AboutStep extends Component {
+	handleSubmit = event => {
+		event.preventDefault();
+		const { goToNextStep, stepName, translate } = this.props;
+
+		//Replace with user inputs
+		const siteName = 'Site name';
+		const themeRepo = 'pub/radcliffe-2';
+		const designType = 'blog';
+
+		this.props.setSiteTitle( siteName );
+		this.props.setDesignType( designType );
+
+		SignupActions.submitSignupStep(
+			{
+				processingMessage: translate( 'Collecting your information' ),
+				stepName: stepName,
+				themeRepo,
+				siteName,
+			},
+			[],
+			{ themeSlugWithRepo: themeRepo, siteTitle: siteName }
+		);
+
+		goToNextStep();
+	};
+
+	renderContent() {
+		const { translate } = this.props;
+
+		return (
+			<div>
+				<Card>Form contents will go here.</Card>
+				<form onSubmit={ this.handleSubmit }>
+					<Button primary={ true } type="submit">
+						{ translate( 'Continue' ) }
+					</Button>
+				</form>
+			</div>
+		);
+	}
+
+	render() {
+		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
+
+		return (
+			<StepWrapper
+				flowName={ flowName }
+				stepName={ stepName }
+				positionInFlow={ positionInFlow }
+				headerText={ translate( 'Let’s create a site' ) }
+				subHeaderText={ translate(
+					'Please answer these questions so we can help you make the site you need.'
+				) }
+				signupProgress={ signupProgress }
+				stepContent={ this.renderContent() }
+			/>
+		);
+	}
+}
+
+export default connect( null, { setSiteTitle, setDesignType } )( localize( AboutStep ) );


### PR DESCRIPTION
This PR gets the basic flow setup for our new user segmenting step outlined here: p5XAZ9-1Cn-p2.

## Testing
* Visit `/start/segment`
* Press `Continue`
* Complete signup to see a new site with Radcliffe 2 theme and Site name instead of Site Titlte.

@markryall can you take a look?