### PR TITLE
esmodules: Update my-sites controller for named exports/imports

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -13,10 +13,9 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import App from './app';
-import controller from 'my-sites/controller';
 import Dashboard from './app/dashboard';
 import EmptyContent from 'components/empty-content';
-import { navigation, siteSelection } from 'my-sites/controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import installActionHandlers from './state/data-layer';
 import Order from './app/order';
@@ -221,7 +220,7 @@ export default function() {
 	} );
 
 	// Add pages that use my-sites navigation instead
-	page( '/store/stats/:type/:unit', controller.siteSelection, controller.sites );
+	page( '/store/stats/:type/:unit', siteSelection, sites );
 	page( '/store/stats/:type/:unit/:site', siteSelection, navigation, StatsController );
 
 	page( '/store/*', notFoundError );

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -8,7 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import controller from './controller';
-import sitesController from 'my-sites/controller';
+import { siteSelection } from 'my-sites/controller';
 
 const redirectToStoreWithInterval = context => {
 	const interval =
@@ -61,13 +61,8 @@ export default function() {
 		controller.connect
 	);
 
-	page( '/jetpack/connect/plans/:site', sitesController.siteSelection, controller.plansSelection );
-
-	page(
-		'/jetpack/connect/plans/:interval/:site',
-		sitesController.siteSelection,
-		controller.plansSelection
-	);
+	page( '/jetpack/connect/plans/:site', siteSelection, controller.plansSelection );
+	page( '/jetpack/connect/plans/:interval/:site', siteSelection, controller.plansSelection );
 
 	page( '/jetpack/sso/:siteId?/:ssoNonce?', controller.sso );
 	page( '/jetpack/sso/*', controller.sso );

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import config from 'config';
 import page from 'page';
 
@@ -12,7 +11,7 @@ import page from 'page';
  */
 import billingController from 'me/billing-history/controller';
 import meController from 'me/controller';
-import sitesController from 'my-sites/controller';
+import { siteSelection } from 'my-sites/controller';
 import controller from './controller';
 import paths from './paths';
 
@@ -34,7 +33,7 @@ export default function() {
 		paths.managePurchase(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		sitesController.siteSelection,
+		siteSelection,
 		controller.managePurchase
 	);
 
@@ -42,7 +41,7 @@ export default function() {
 		paths.cancelPurchase(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		sitesController.siteSelection,
+		siteSelection,
 		controller.cancelPurchase
 	);
 
@@ -50,7 +49,7 @@ export default function() {
 		paths.cancelPrivacyProtection(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		sitesController.siteSelection,
+		siteSelection,
 		controller.cancelPrivacyProtection
 	);
 
@@ -58,7 +57,7 @@ export default function() {
 		paths.confirmCancelDomain(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		sitesController.siteSelection,
+		siteSelection,
 		controller.confirmCancelDomain
 	);
 
@@ -66,7 +65,7 @@ export default function() {
 		paths.addCardDetails(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		sitesController.siteSelection,
+		siteSelection,
 		controller.addCardDetails
 	);
 
@@ -74,7 +73,7 @@ export default function() {
 		paths.editCardDetails(),
 		meController.sidebar,
 		controller.noSitesMessage,
-		sitesController.siteSelection,
+		siteSelection,
 		controller.editCardDetails
 	);
 

--- a/client/my-sites/ads/index.js
+++ b/client/my-sites/ads/index.js
@@ -1,24 +1,17 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import controller from 'my-sites/controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import adsController from './controller';
 
 export default function() {
-	page( '/ads', controller.siteSelection, controller.sites );
+	page( '/ads', siteSelection, sites );
 	page( '/ads/:site_id', adsController.redirect );
-	page(
-		'/ads/:section/:site_id',
-		controller.siteSelection,
-		controller.navigation,
-		adsController.layout
-	);
+	page( '/ads/:section/:site_id', siteSelection, navigation, adsController.layout );
 }

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -1,64 +1,58 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import controller from 'my-sites/controller';
+import { noSite, siteSelection } from 'my-sites/controller';
 import checkoutController from './controller';
 import SiftScience from 'lib/siftscience';
 
 export default function() {
 	SiftScience.recordUser();
 
-	page(
-		'/checkout/thank-you/no-site/:receiptId?',
-		controller.noSite,
-		checkoutController.checkoutThankYou
-	);
+	page( '/checkout/thank-you/no-site/:receiptId?', noSite, checkoutController.checkoutThankYou );
 
 	page(
 		'/checkout/thank-you/:site/:receiptId?',
-		controller.siteSelection,
+		siteSelection,
 		checkoutController.checkoutThankYou
 	);
 
 	page(
 		'/checkout/thank-you/:site/:receiptId/with-gsuite/:gsuiteReceiptId',
-		controller.siteSelection,
+		siteSelection,
 		checkoutController.checkoutThankYou
 	);
 
 	page(
 		'/checkout/features/:feature/:domain/:plan_name?',
-		controller.siteSelection,
+		siteSelection,
 		checkoutController.checkout
 	);
 
 	page(
 		'/checkout/thank-you/features/:feature/:site/:receiptId?',
-		controller.siteSelection,
+		siteSelection,
 		checkoutController.checkoutThankYou
 	);
 
-	page( '/checkout/no-site', controller.noSite, checkoutController.sitelessCheckout );
+	page( '/checkout/no-site', noSite, checkoutController.sitelessCheckout );
 
-	page( '/checkout/:domain/:product?', controller.siteSelection, checkoutController.checkout );
+	page( '/checkout/:domain/:product?', siteSelection, checkoutController.checkout );
 
 	page(
 		'/checkout/:product/renew/:purchaseId/:domain',
-		controller.siteSelection,
+		siteSelection,
 		checkoutController.checkout
 	);
 
 	page(
 		'/checkout/:site/with-gsuite/:domain/:receiptId?',
-		controller.siteSelection,
+		siteSelection,
 		checkoutController.gsuiteNudge
 	);
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -21,7 +21,6 @@ import {
 	isJetpackModuleActive,
 	isJetpackSite,
 	isRequestingSites,
-	getPrimaryDomainBySiteId,
 } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { setSelectedSiteId, setSection, setAllSitesSelected } from 'state/ui/actions';
@@ -35,6 +34,7 @@ import analytics from 'lib/analytics';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import {
+	getPrimaryDomainBySiteId,
 	getPrimarySiteId,
 	getSiteId,
 	getSites,

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -21,6 +21,7 @@ import {
 	isJetpackModuleActive,
 	isJetpackSite,
 	isRequestingSites,
+	getPrimaryDomainBySiteId,
 } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { setSelectedSiteId, setSection, setAllSitesSelected } from 'state/ui/actions';
@@ -59,7 +60,6 @@ import {
 import SitesComponent from 'my-sites/sites';
 import { isATEnabled } from 'lib/automated-transfer';
 import { warningNotice } from 'state/notices/actions';
-import { getPrimaryDomainBySiteId } from 'state/selectors';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.
@@ -296,235 +296,233 @@ function showMissingPrimaryError( currentUser, dispatch ) {
 	}
 }
 
-export default {
-	// Clears selected site from global redux state
-	noSite( context, next ) {
-		context.store.dispatch( setSelectedSiteId( null ) );
-		return next();
-	},
+// Clears selected site from global redux state
+export function noSite( context, next ) {
+	context.store.dispatch( setSelectedSiteId( null ) );
+	return next();
+}
 
-	/*
-	 * Set up site selection based on last URL param and/or handle no-sites error cases
-	 */
-	siteSelection( context, next ) {
-		const { getState, dispatch } = getStore( context );
-		const siteFragment = context.params.site || route.getSiteFragment( context.path );
-		const basePath = route.sectionify( context.path, siteFragment );
-		const currentUser = user.get();
-		const hasOneSite = currentUser.visible_site_count === 1;
-		const allSitesPath = route.sectionify( context.path, siteFragment );
-		const primaryId = getPrimarySiteId( getState() );
-		const primary = getSite( getState(), primaryId ) || '';
+/*
+ * Set up site selection based on last URL param and/or handle no-sites error cases
+ */
+export function siteSelection( context, next ) {
+	const { getState, dispatch } = getStore( context );
+	const siteFragment = context.params.site || route.getSiteFragment( context.path );
+	const basePath = route.sectionify( context.path, siteFragment );
+	const currentUser = user.get();
+	const hasOneSite = currentUser.visible_site_count === 1;
+	const allSitesPath = route.sectionify( context.path, siteFragment );
+	const primaryId = getPrimarySiteId( getState() );
+	const primary = getSite( getState(), primaryId ) || '';
 
-		const redirectToPrimary = () => {
-			let redirectPath = `${ context.pathname }/${ primary.slug }`;
+	const redirectToPrimary = () => {
+		let redirectPath = `${ context.pathname }/${ primary.slug }`;
 
-			redirectPath = context.querystring
-				? `${ redirectPath }?${ context.querystring }`
-				: redirectPath;
+		redirectPath = context.querystring
+			? `${ redirectPath }?${ context.querystring }`
+			: redirectPath;
 
-			page.redirect( redirectPath );
-		};
+		page.redirect( redirectPath );
+	};
 
-		if ( currentUser && currentUser.site_count === 0 ) {
-			renderEmptySites( context );
-			return analytics.pageView.record( basePath, sitesPageTitleForAnalytics + ' > No Sites' );
-		}
+	if ( currentUser && currentUser.site_count === 0 ) {
+		renderEmptySites( context );
+		return analytics.pageView.record( basePath, sitesPageTitleForAnalytics + ' > No Sites' );
+	}
 
-		if ( currentUser && currentUser.visible_site_count === 0 ) {
-			renderNoVisibleSites( context );
-			return analytics.pageView.record(
-				basePath,
-				`${ sitesPageTitleForAnalytics } > All Sites Hidden`
-			);
-		}
-
-		// Ignore the user account settings page
-		if ( /^\/settings\/account/.test( context.path ) ) {
-			return next();
-		}
-
-		/**
-		 * If the user has only one site, redirect to the single site
-		 * context instead of rendering the all-site views.
-		 *
-		 * Note: The redirectToPrimary function will be continually executed
-		 * by repeatedly querying /stats/day/undefined until the /sites
-		 * endpoint has returned.
-		 */
-		if ( hasOneSite && ! siteFragment ) {
-			const hasInitialized = getSites( getState() ).length;
-			if ( hasInitialized ) {
-				if ( primary ) {
-					redirectToPrimary();
-				} else {
-					// If the primary site does not exist, skip redirect
-					// and display a useful error notification
-					showMissingPrimaryError( currentUser, dispatch );
-				}
-				return;
-			}
-			dispatch( {
-				type: SITES_ONCE_CHANGED,
-				listener: redirectToPrimary,
-			} );
-		}
-
-		// If the path fragment does not resemble a site, set all sites to visible
-		if ( ! siteFragment ) {
-			dispatch( setAllSitesSelected() );
-			return next();
-		}
-
-		const siteId = getSiteId( getState(), siteFragment );
-		if ( siteId ) {
-			dispatch( setSelectedSiteId( siteId ) );
-			const selectionComplete = onSelectedSiteAvailable( context );
-
-			// if there was a redirect, we should terminate processing of next routes
-			// and let the redirect proceed
-			if ( ! selectionComplete ) {
-				return;
-			}
-		} else {
-			// if sites has fresh data and siteId is invalid
-			// redirect to allSitesPath
-			if ( ! isRequestingSites( getState() ) ) {
-				return page.redirect( allSitesPath );
-			}
-
-			let waitingNotice;
-			let freshSiteId;
-			const selectOnSitesChange = () => {
-				// if sites have loaded, but siteId is invalid, redirect to allSitesPath
-				freshSiteId = getSiteId( getState(), siteFragment );
-				dispatch( setSelectedSiteId( freshSiteId ) );
-				if ( getSite( getState(), freshSiteId ) ) {
-					onSelectedSiteAvailable( context );
-					if ( waitingNotice ) {
-						notices.removeNotice( waitingNotice );
-					}
-				} else if ( currentUser.visible_site_count !== getVisibleSites( getState() ).length ) {
-					waitingNotice = notices.info( i18n.translate( 'Finishing set up…' ), {
-						showDismiss: false,
-					} );
-					dispatch( {
-						type: SITES_ONCE_CHANGED,
-						listener: selectOnSitesChange,
-					} );
-					dispatch( requestSites() );
-				} else {
-					page.redirect( allSitesPath );
-				}
-			};
-			// Otherwise, check when sites has loaded
-			dispatch( {
-				type: SITES_ONCE_CHANGED,
-				listener: selectOnSitesChange,
-			} );
-		}
-		next();
-	},
-
-	jetpackModuleActive( moduleId, redirect ) {
-		return function( context, next ) {
-			const { getState } = getStore( context );
-			const siteId = getSelectedSiteId( getState() );
-			const isJetpack = isJetpackSite( getState(), siteId );
-			const isModuleActive = isJetpackModuleActive( getState(), siteId, moduleId );
-
-			if ( ! isJetpack ) {
-				return next();
-			}
-
-			if ( isModuleActive || false === redirect ) {
-				next();
-			} else {
-				page.redirect( 'string' === typeof redirect ? redirect : '/stats' );
-			}
-		};
-	},
-
-	makeNavigation: function( context, next ) {
-		context.secondary = createNavigation( context );
-		next();
-	},
-
-	navigation: function( context, next ) {
-		// Render the My Sites navigation in #secondary
-		renderWithReduxStore(
-			createNavigation( context ),
-			document.getElementById( 'secondary' ),
-			context.store
+	if ( currentUser && currentUser.visible_site_count === 0 ) {
+		renderNoVisibleSites( context );
+		return analytics.pageView.record(
+			basePath,
+			`${ sitesPageTitleForAnalytics } > All Sites Hidden`
 		);
-		next();
-	},
+	}
 
-	jetPackWarning( context, next ) {
+	// Ignore the user account settings page
+	if ( /^\/settings\/account/.test( context.path ) ) {
+		return next();
+	}
+
+	/**
+	 * If the user has only one site, redirect to the single site
+	 * context instead of rendering the all-site views.
+	 *
+	 * Note: The redirectToPrimary function will be continually executed
+	 * by repeatedly querying /stats/day/undefined until the /sites
+	 * endpoint has returned.
+	 */
+	if ( hasOneSite && ! siteFragment ) {
+		const hasInitialized = getSites( getState() ).length;
+		if ( hasInitialized ) {
+			if ( primary ) {
+				redirectToPrimary();
+			} else {
+				// If the primary site does not exist, skip redirect
+				// and display a useful error notification
+				showMissingPrimaryError( currentUser, dispatch );
+			}
+			return;
+		}
+		dispatch( {
+			type: SITES_ONCE_CHANGED,
+			listener: redirectToPrimary,
+		} );
+	}
+
+	// If the path fragment does not resemble a site, set all sites to visible
+	if ( ! siteFragment ) {
+		dispatch( setAllSitesSelected() );
+		return next();
+	}
+
+	const siteId = getSiteId( getState(), siteFragment );
+	if ( siteId ) {
+		dispatch( setSelectedSiteId( siteId ) );
+		const selectionComplete = onSelectedSiteAvailable( context );
+
+		// if there was a redirect, we should terminate processing of next routes
+		// and let the redirect proceed
+		if ( ! selectionComplete ) {
+			return;
+		}
+	} else {
+		// if sites has fresh data and siteId is invalid
+		// redirect to allSitesPath
+		if ( ! isRequestingSites( getState() ) ) {
+			return page.redirect( allSitesPath );
+		}
+
+		let waitingNotice;
+		let freshSiteId;
+		const selectOnSitesChange = () => {
+			// if sites have loaded, but siteId is invalid, redirect to allSitesPath
+			freshSiteId = getSiteId( getState(), siteFragment );
+			dispatch( setSelectedSiteId( freshSiteId ) );
+			if ( getSite( getState(), freshSiteId ) ) {
+				onSelectedSiteAvailable( context );
+				if ( waitingNotice ) {
+					notices.removeNotice( waitingNotice );
+				}
+			} else if ( currentUser.visible_site_count !== getVisibleSites( getState() ).length ) {
+				waitingNotice = notices.info( i18n.translate( 'Finishing set up…' ), {
+					showDismiss: false,
+				} );
+				dispatch( {
+					type: SITES_ONCE_CHANGED,
+					listener: selectOnSitesChange,
+				} );
+				dispatch( requestSites() );
+			} else {
+				page.redirect( allSitesPath );
+			}
+		};
+		// Otherwise, check when sites has loaded
+		dispatch( {
+			type: SITES_ONCE_CHANGED,
+			listener: selectOnSitesChange,
+		} );
+	}
+	next();
+}
+
+export function jetpackModuleActive( moduleId, redirect ) {
+	return function( context, next ) {
 		const { getState } = getStore( context );
-		const Main = require( 'components/main' );
-		const JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' );
-		const basePath = route.sectionify( context.path );
-		const selectedSite = getSelectedSite( getState() );
+		const siteId = getSelectedSiteId( getState() );
+		const isJetpack = isJetpackSite( getState(), siteId );
+		const isModuleActive = isJetpackModuleActive( getState(), siteId, moduleId );
 
-		if ( selectedSite && selectedSite.jetpack && ! isATEnabled( selectedSite ) ) {
-			renderWithReduxStore(
-				<Main>
-					<JetpackManageErrorPage template="noDomainsOnJetpack" siteId={ selectedSite.ID } />
-				</Main>,
-				document.getElementById( 'primary' ),
-				context.store
-			);
+		if ( ! isJetpack ) {
+			return next();
+		}
 
-			analytics.pageView.record( basePath, '> No Domains On Jetpack' );
-		} else {
+		if ( isModuleActive || false === redirect ) {
 			next();
+		} else {
+			page.redirect( 'string' === typeof redirect ? redirect : '/stats' );
 		}
-	},
+	};
+}
 
-	sites( context ) {
-		const { dispatch } = getStore( context );
-		if ( context.query.verified === '1' ) {
-			notices.success(
-				i18n.translate(
-					"Email verified! Now that you've confirmed your email address you can publish posts on your blog."
-				)
-			);
-		}
-		/**
-		 * Sites is rendered on #primary but it doesn't expect a sidebar to exist
-		 */
-		removeSidebar( context );
-		dispatch( setLayoutFocus( 'content' ) );
+export function makeNavigation( context, next ) {
+	context.secondary = createNavigation( context );
+	next();
+}
 
+export function navigation( context, next ) {
+	// Render the My Sites navigation in #secondary
+	renderWithReduxStore(
+		createNavigation( context ),
+		document.getElementById( 'secondary' ),
+		context.store
+	);
+	next();
+}
+
+export function jetPackWarning( context, next ) {
+	const { getState } = getStore( context );
+	const Main = require( 'components/main' );
+	const JetpackManageErrorPage = require( 'my-sites/jetpack-manage-error-page' );
+	const basePath = route.sectionify( context.path );
+	const selectedSite = getSelectedSite( getState() );
+
+	if ( selectedSite && selectedSite.jetpack && ! isATEnabled( selectedSite ) ) {
 		renderWithReduxStore(
-			createSitesComponent( context ),
+			<Main>
+				<JetpackManageErrorPage template="noDomainsOnJetpack" siteId={ selectedSite.ID } />
+			</Main>,
 			document.getElementById( 'primary' ),
 			context.store
 		);
-	},
 
-	/**
-	 * Middleware that adds the site selector screen to the layout
-	 * without rendering the layout. For use with isomorphic routing
-	 * @see {@link https://github.com/Automattic/wp-calypso/blob/master/docs/isomorphic-routing.md }
-	 *
-	 * To show the site selector screen using traditional multi-tree
-	 * layout, use the sites() middleware above.
-	 *
-	 * @param {object} context -- Middleware context
-	 * @param {function} next -- Call next middleware in chain
-	 */
-	makeSites( context, next ) {
-		context.store.dispatch( setLayoutFocus( 'content' ) );
-		context.store.dispatch(
-			setSection( {
-				group: 'sites',
-				secondary: false,
-			} )
-		);
-
-		context.primary = createSitesComponent( context );
+		analytics.pageView.record( basePath, '> No Domains On Jetpack' );
+	} else {
 		next();
-	},
-};
+	}
+}
+
+export function sites( context ) {
+	const { dispatch } = getStore( context );
+	if ( context.query.verified === '1' ) {
+		notices.success(
+			i18n.translate(
+				"Email verified! Now that you've confirmed your email address you can publish posts on your blog."
+			)
+		);
+	}
+	/**
+	 * Sites is rendered on #primary but it doesn't expect a sidebar to exist
+	 */
+	removeSidebar( context );
+	dispatch( setLayoutFocus( 'content' ) );
+
+	renderWithReduxStore(
+		createSitesComponent( context ),
+		document.getElementById( 'primary' ),
+		context.store
+	);
+}
+
+/**
+ * Middleware that adds the site selector screen to the layout
+ * without rendering the layout. For use with isomorphic routing
+ * @see {@link https://github.com/Automattic/wp-calypso/blob/master/docs/isomorphic-routing.md }
+ *
+ * To show the site selector screen using traditional multi-tree
+ * layout, use the sites() middleware above.
+ *
+ * @param {object} context -- Middleware context
+ * @param {function} next -- Call next middleware in chain
+ */
+export function makeSites( context, next ) {
+	context.store.dispatch( setLayoutFocus( 'content' ) );
+	context.store.dispatch(
+		setSection( {
+			group: 'sites',
+			secondary: false,
+		} )
+	);
+
+	context.primary = createSitesComponent( context );
+	next();
+}

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -1,36 +1,34 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import controller from 'my-sites/controller';
+import { jetPackWarning, navigation, siteSelection, sites } from 'my-sites/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
 import SiftScience from 'lib/siftscience';
 import config from 'config';
 import paths from './paths';
 
-function registerMultiPage( { paths, handlers } ) {
-	paths.forEach( path => page( path, ...handlers ) );
+function registerMultiPage( { paths: givenPaths, handlers } ) {
+	givenPaths.forEach( path => page( path, ...handlers ) );
 }
 
 function getCommonHandlers(
 	{ noSitePath = paths.domainManagementRoot(), warnIfJetpack = true } = {}
 ) {
-	const handlers = [ controller.siteSelection, controller.navigation ];
+	const handlers = [ siteSelection, navigation ];
 
 	if ( noSitePath ) {
 		handlers.push( domainsController.redirectIfNoSite( noSitePath ) );
 	}
 
 	if ( warnIfJetpack ) {
-		handlers.push( controller.jetPackWarning );
+		handlers.push( jetPackWarning );
 	}
 
 	return handlers;
@@ -39,7 +37,7 @@ function getCommonHandlers(
 export default function() {
 	SiftScience.recordUser();
 
-	page( paths.domainManagementEmail(), controller.siteSelection, controller.sites );
+	page( paths.domainManagementEmail(), siteSelection, sites );
 
 	registerMultiPage( {
 		paths: [
@@ -120,7 +118,7 @@ export default function() {
 		domainManagementController.domainManagementTransferToOtherSite
 	);
 
-	page( paths.domainManagementRoot(), controller.siteSelection, controller.sites );
+	page( paths.domainManagementRoot(), siteSelection, sites );
 
 	page(
 		paths.domainManagementList( ':site' ),
@@ -149,101 +147,101 @@ export default function() {
 	if ( config.isEnabled( 'upgrades/domain-search' ) ) {
 		page(
 			'/domains/add',
-			controller.siteSelection,
+			siteSelection,
 			domainsController.domainsAddHeader,
 			domainsController.redirectToAddMappingIfVipSite(),
-			controller.jetPackWarning,
-			controller.sites
+			jetPackWarning,
+			sites
 		);
 
 		page(
 			'/domains/add/mapping',
-			controller.siteSelection,
+			siteSelection,
 			domainsController.domainsAddHeader,
-			controller.jetPackWarning,
-			controller.sites
+			jetPackWarning,
+			sites
 		);
 
 		page(
 			'/domains/add/transfer',
-			controller.siteSelection,
+			siteSelection,
 			domainsController.domainsAddHeader,
-			controller.jetPackWarning,
-			controller.sites
+			jetPackWarning,
+			sites
 		);
 
 		page(
 			'/domains/add/site-redirect',
-			controller.siteSelection,
+			siteSelection,
 			domainsController.domainsAddRedirectHeader,
-			controller.jetPackWarning,
-			controller.sites
+			jetPackWarning,
+			sites
 		);
 
 		page(
 			'/domains/add/:domain',
-			controller.siteSelection,
-			controller.navigation,
+			siteSelection,
+			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
 			domainsController.redirectToAddMappingIfVipSite(),
-			controller.jetPackWarning,
+			jetPackWarning,
 			domainsController.domainSearch
 		);
 
 		page(
 			'/domains/add/suggestion/:suggestion/:domain',
-			controller.siteSelection,
-			controller.navigation,
+			siteSelection,
+			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
 			domainsController.redirectToAddMappingIfVipSite(),
-			controller.jetPackWarning,
+			jetPackWarning,
 			domainsController.domainSearch
 		);
 
 		page(
 			'/domains/add/:registerDomain/google-apps/:domain',
-			controller.siteSelection,
-			controller.navigation,
+			siteSelection,
+			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
-			controller.jetPackWarning,
+			jetPackWarning,
 			domainsController.googleAppsWithRegistration
 		);
 
 		page(
 			'/domains/add/mapping/:domain',
-			controller.siteSelection,
-			controller.navigation,
+			siteSelection,
+			navigation,
 			domainsController.redirectIfNoSite( '/domains/add/mapping' ),
-			controller.jetPackWarning,
+			jetPackWarning,
 			domainsController.mapDomain
 		);
 
 		page(
 			'/domains/add/site-redirect/:domain',
-			controller.siteSelection,
-			controller.navigation,
+			siteSelection,
+			navigation,
 			domainsController.redirectIfNoSite( '/domains/add/site-redirect' ),
-			controller.jetPackWarning,
+			jetPackWarning,
 			domainsController.siteRedirect
 		);
 
 		page(
 			'/domains/add/transfer/:domain',
-			controller.siteSelection,
-			controller.navigation,
+			siteSelection,
+			navigation,
 			domainsController.redirectIfNoSite( '/domains/add/transfer' ),
-			controller.jetPackWarning,
+			jetPackWarning,
 			domainsController.transferDomain
 		);
 	}
 
-	page( '/domains', controller.siteSelection, controller.sites );
+	page( '/domains', siteSelection, sites );
 
 	page(
 		'/domains/:site',
-		controller.siteSelection,
-		controller.navigation,
-		controller.jetPackWarning,
+		siteSelection,
+		navigation,
+		jetPackWarning,
 		domainManagementController.domainManagementIndex
 	);
 }

--- a/client/my-sites/index.js
+++ b/client/my-sites/index.js
@@ -9,8 +9,8 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from './controller';
+import { siteSelection, sites } from './controller';
 
 export default function() {
-	page( '/sites/:sitesFilter?', controller.siteSelection, controller.sites );
+	page( '/sites/:sitesFilter?', siteSelection, sites );
 }

--- a/client/my-sites/media/index.js
+++ b/client/my-sites/media/index.js
@@ -9,18 +9,13 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from 'my-sites/controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import mediaController from './controller';
 import config from 'config';
 
 export default function() {
 	if ( config.isEnabled( 'manage/media' ) ) {
-		page( '/media', controller.siteSelection, controller.sites );
-		page(
-			'/media/:filter?/:domain',
-			controller.siteSelection,
-			controller.navigation,
-			mediaController.media
-		);
+		page( '/media', siteSelection, sites );
+		page( '/media/:filter?/:domain', siteSelection, navigation, mediaController.media );
 	}
 }

--- a/client/my-sites/pages/index.js
+++ b/client/my-sites/pages/index.js
@@ -1,25 +1,18 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import controller from 'my-sites/controller';
+import { navigation, siteSelection } from 'my-sites/controller';
 import pagesController from './controller';
 import config from 'config';
 
 export default function() {
 	if ( config.isEnabled( 'manage/pages' ) ) {
-		page(
-			'/pages/:status?/:domain?',
-			controller.siteSelection,
-			controller.navigation,
-			pagesController.pages
-		);
+		page( '/pages/:status?/:domain?', siteSelection, navigation, pagesController.pages );
 	}
 }

--- a/client/my-sites/paladin/index.js
+++ b/client/my-sites/paladin/index.js
@@ -9,18 +9,13 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from 'my-sites/controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import paladinController from './controller';
 import config from 'config';
 
 export default function() {
 	if ( config.isEnabled( 'paladin' ) ) {
-		page( '/paladin', controller.siteSelection, controller.sites );
-		page(
-			'/paladin/:domain',
-			controller.siteSelection,
-			controller.navigation,
-			paladinController.activate
-		);
+		page( '/paladin', siteSelection, sites );
+		page( '/paladin/:domain', siteSelection, navigation, paladinController.activate );
 	}
 }

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -1,27 +1,25 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import controller from 'my-sites/controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import config from 'config';
 import peopleController from './controller';
 
 export default function() {
 	if ( config.isEnabled( 'manage/people' ) ) {
 		[ 'team', 'followers', 'email-followers', 'viewers' ].forEach( function( filter ) {
-			page( '/people/' + filter, controller.siteSelection, controller.sites );
+			page( '/people/' + filter, siteSelection, sites );
 			page(
 				'/people/' + filter + '/:site_id',
 				peopleController.enforceSiteEnding,
-				controller.siteSelection,
-				controller.navigation,
+				siteSelection,
+				navigation,
 				peopleController.people.bind( null, filter )
 			);
 		} );
@@ -29,20 +27,20 @@ export default function() {
 		page(
 			'/people/new/:site_id',
 			peopleController.enforceSiteEnding,
-			controller.siteSelection,
-			controller.navigation,
+			siteSelection,
+			navigation,
 			peopleController.invitePeople
 		);
 
 		page(
 			'/people/edit/:site_id/:user_login',
 			peopleController.enforceSiteEnding,
-			controller.siteSelection,
-			controller.navigation,
+			siteSelection,
+			navigation,
 			peopleController.person
 		);
 
 		// Anything else is unexpected and should be redirected to the default people management URL: /people/team
-		page( '/people/(.*)?', controller.siteSelection, peopleController.redirectToTeam );
+		page( '/people/(.*)?', siteSelection, peopleController.redirectToTeam );
 	}
 }

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -1,77 +1,27 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import controller from 'my-sites/controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import plansController from './controller';
 import currentPlanController from './current-plan/controller';
 
 export default function() {
-	page( '/plans', controller.siteSelection, controller.sites );
-
-	page(
-		'/plans/compare',
-		controller.siteSelection,
-		controller.navigation,
-		plansController.redirectToPlans
-	);
-
-	page(
-		'/plans/compare/:domain',
-		controller.siteSelection,
-		controller.navigation,
-		plansController.redirectToPlans
-	);
-
-	page(
-		'/plans/features',
-		controller.siteSelection,
-		controller.navigation,
-		plansController.redirectToPlans
-	);
-
-	page(
-		'/plans/features/:domain',
-		controller.siteSelection,
-		controller.navigation,
-		plansController.redirectToPlans
-	);
-
+	page( '/plans', siteSelection, sites );
+	page( '/plans/compare', siteSelection, navigation, plansController.redirectToPlans );
+	page( '/plans/compare/:domain', siteSelection, navigation, plansController.redirectToPlans );
+	page( '/plans/features', siteSelection, navigation, plansController.redirectToPlans );
+	page( '/plans/features/:domain', siteSelection, navigation, plansController.redirectToPlans );
 	page( '/plans/features/:feature/:domain', plansController.features );
-
-	page(
-		'/plans/my-plan',
-		controller.siteSelection,
-		controller.sites,
-		controller.navigation,
-		currentPlanController.currentPlan
-	);
-
-	page(
-		'/plans/my-plan/:site',
-		controller.siteSelection,
-		controller.navigation,
-		currentPlanController.currentPlan
-	);
-
-	page(
-		'/plans/select/:plan/:domain',
-		controller.siteSelection,
-		plansController.redirectToCheckout
-	);
+	page( '/plans/my-plan', siteSelection, sites, navigation, currentPlanController.currentPlan );
+	page( '/plans/my-plan/:site', siteSelection, navigation, currentPlanController.currentPlan );
+	page( '/plans/select/:plan/:domain', siteSelection, plansController.redirectToCheckout );
 
 	// This route renders the plans page for both WPcom and Jetpack sites.
-	page(
-		'/plans/:intervalType?/:site',
-		controller.siteSelection,
-		controller.navigation,
-		plansController.plans
-	);
+	page( '/plans/:intervalType?/:site', siteSelection, navigation, plansController.plans );
 }

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -1,15 +1,13 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import controller from 'my-sites/controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import config from 'config';
 import pluginsController from './controller';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -27,9 +25,9 @@ const ifSimpleSiteThenRedirectTo = path => ( context, next ) => {
 
 export default function() {
 	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
-		page( '/plugins/setup', controller.siteSelection, pluginsController.setupPlugins );
+		page( '/plugins/setup', siteSelection, pluginsController.setupPlugins );
 
-		page( '/plugins/setup/:site', controller.siteSelection, pluginsController.setupPlugins );
+		page( '/plugins/setup/:site', siteSelection, pluginsController.setupPlugins );
 	}
 
 	if ( config.isEnabled( 'manage/plugins' ) ) {
@@ -59,54 +57,44 @@ export default function() {
 		} );
 
 		if ( config.isEnabled( 'manage/plugins/upload' ) ) {
-			page( '/plugins/upload', controller.sites );
-			page(
-				'/plugins/upload/:site_id',
-				controller.siteSelection,
-				controller.navigation,
-				pluginsController.upload
-			);
+			page( '/plugins/upload', sites );
+			page( '/plugins/upload/:site_id', siteSelection, navigation, pluginsController.upload );
 		}
 
-		page(
-			'/plugins',
-			controller.siteSelection,
-			controller.navigation,
-			pluginsController.browsePlugins
-		);
+		page( '/plugins', siteSelection, navigation, pluginsController.browsePlugins );
 
 		page(
 			'/plugins/manage/:site?',
-			controller.siteSelection,
-			controller.navigation,
+			siteSelection,
+			navigation,
 			ifSimpleSiteThenRedirectTo( '/plugins' ),
 			pluginsController.plugins.bind( null, 'all' ),
-			controller.sites
+			sites
 		);
 
 		[ 'active', 'inactive', 'updates' ].forEach( filter =>
 			page(
 				`/plugins/${ filter }/:site_id?`,
-				controller.siteSelection,
-				controller.navigation,
+				siteSelection,
+				navigation,
 				pluginsController.jetpackCanUpdate.bind( null, filter ),
 				pluginsController.plugins.bind( null, filter ),
-				controller.sites
+				sites
 			)
 		);
 
 		page(
 			'/plugins/:plugin/:site_id?',
-			controller.siteSelection,
-			controller.navigation,
+			siteSelection,
+			navigation,
 			pluginsController.maybeBrowsePlugins,
 			pluginsController.plugin
 		);
 
 		page(
 			'/plugins/:plugin/eligibility/:site_id',
-			controller.siteSelection,
-			controller.navigation,
+			siteSelection,
+			navigation,
 			pluginsController.eligibility
 		);
 

--- a/client/my-sites/posts/index.js
+++ b/client/my-sites/posts/index.js
@@ -9,14 +9,9 @@ import page from 'page';
 /**
  * Internal Dependencies
  */
-import controller from 'my-sites/controller';
+import { navigation, siteSelection } from 'my-sites/controller';
 import postsController from './controller';
 
 export default function() {
-	page(
-		'/posts/:author?/:status?/:domain?',
-		controller.siteSelection,
-		controller.navigation,
-		postsController.posts
-	);
+	page( '/posts/:author?/:status?/:domain?', siteSelection, navigation, postsController.posts );
 }

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -1,109 +1,89 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
 import config from 'config';
-import mySitesController from 'my-sites/controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import controller from 'my-sites/site-settings/controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
 import { reasonComponents as reasons } from './disconnect-site';
 
 export default function() {
-	page( '/settings', mySitesController.siteSelection, controller.redirectToGeneral );
+	page( '/settings', siteSelection, controller.redirectToGeneral );
 	page(
 		'/settings/general/:site_id',
-		mySitesController.siteSelection,
-		mySitesController.navigation,
+		siteSelection,
+		navigation,
 		settingsController.setScroll,
 		settingsController.siteSettings,
 		controller.general
 	);
 
-	page(
-		'/settings/import/:site_id',
-		mySitesController.siteSelection,
-		mySitesController.navigation,
-		controller.importSite
-	);
+	page( '/settings/import/:site_id', siteSelection, navigation, controller.importSite );
 
 	if ( config.isEnabled( 'manage/export/guided-transfer' ) ) {
 		page(
 			'/settings/export/guided/:host_slug?/:site_id',
-			mySitesController.siteSelection,
-			mySitesController.navigation,
+			siteSelection,
+			navigation,
 			controller.guidedTransfer
 		);
 	}
 
-	page(
-		'/settings/export/:site_id',
-		mySitesController.siteSelection,
-		mySitesController.navigation,
-		controller.exportSite
-	);
+	page( '/settings/export/:site_id', siteSelection, navigation, controller.exportSite );
 
 	page(
 		'/settings/delete-site/:site_id',
-		mySitesController.siteSelection,
-		mySitesController.navigation,
+		siteSelection,
+		navigation,
 		settingsController.setScroll,
 		controller.deleteSite
 	);
 
 	const reasonSlugs = Object.keys( reasons );
-	page(
-		`/settings/disconnect-site/:step(${ [ ...reasonSlugs, 'confirm' ].join( '|' ) })?`,
-		mySitesController.sites
-	);
+	page( `/settings/disconnect-site/:step(${ [ ...reasonSlugs, 'confirm' ].join( '|' ) })?`, sites );
 
 	page(
 		`/settings/disconnect-site/:reason(${ reasonSlugs.join( '|' ) })?/:site_id`,
-		mySitesController.siteSelection,
+		siteSelection,
 		settingsController.setScroll,
 		controller.disconnectSite
 	);
 
 	page(
 		'/settings/disconnect-site/confirm/:site_id',
-		mySitesController.siteSelection,
+		siteSelection,
 		settingsController.setScroll,
 		controller.disconnectSiteConfirm
 	);
 
 	page(
 		'/settings/start-over/:site_id',
-		mySitesController.siteSelection,
-		mySitesController.navigation,
+		siteSelection,
+		navigation,
 		settingsController.setScroll,
 		controller.startOver
 	);
 	page(
 		'/settings/theme-setup/:site_id',
-		mySitesController.siteSelection,
-		mySitesController.navigation,
+		siteSelection,
+		navigation,
 		settingsController.setScroll,
 		controller.themeSetup
 	);
 
 	page(
 		'/settings/manage-connection/:site_id',
-		mySitesController.siteSelection,
-		mySitesController.navigation,
+		siteSelection,
+		navigation,
 		settingsController.setScroll,
 		controller.manageConnection
 	);
 
-	page(
-		'/settings/:section',
-		controller.legacyRedirects,
-		mySitesController.siteSelection,
-		mySitesController.sites
-	);
+	page( '/settings/:section', controller.legacyRedirects, siteSelection, sites );
 }

--- a/client/my-sites/site-settings/settings-discussion/index.js
+++ b/client/my-sites/site-settings/settings-discussion/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
@@ -11,13 +9,13 @@ import page from 'page';
  */
 import controller from './controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
-import mySitesController from 'my-sites/controller';
+import { navigation, siteSelection } from 'my-sites/controller';
 
 export default function() {
 	page(
 		'/settings/discussion/:site_id',
-		mySitesController.siteSelection,
-		mySitesController.navigation,
+		siteSelection,
+		navigation,
 		settingsController.siteSettings,
 		controller.discussion
 	);

--- a/client/my-sites/site-settings/settings-security/index.js
+++ b/client/my-sites/site-settings/settings-security/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
@@ -11,13 +9,13 @@ import page from 'page';
  */
 import controller from './controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
-import mySitesController from 'my-sites/controller';
+import { navigation, siteSelection } from 'my-sites/controller';
 
 export default function() {
 	page(
 		'/settings/security/:site_id',
-		mySitesController.siteSelection,
-		mySitesController.navigation,
+		siteSelection,
+		navigation,
 		settingsController.setScroll,
 		settingsController.siteSettings,
 		controller.security

--- a/client/my-sites/site-settings/settings-traffic/index.js
+++ b/client/my-sites/site-settings/settings-traffic/index.js
@@ -1,16 +1,14 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
 import controller from './controller';
-import mySitesController from 'my-sites/controller';
+import { navigation, siteSelection } from 'my-sites/controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
 
 const redirectToTrafficSection = context => {
@@ -20,8 +18,8 @@ const redirectToTrafficSection = context => {
 export default function() {
 	page(
 		'/settings/traffic/:site_id',
-		mySitesController.siteSelection,
-		mySitesController.navigation,
+		siteSelection,
+		navigation,
 		settingsController.siteSettings,
 		controller.traffic
 	);

--- a/client/my-sites/site-settings/settings-writing/index.js
+++ b/client/my-sites/site-settings/settings-writing/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
@@ -12,13 +10,13 @@ import page from 'page';
 import config from 'config';
 import controller from './controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
-import mySitesController from 'my-sites/controller';
+import { navigation, siteSelection } from 'my-sites/controller';
 
 export default function() {
 	page(
 		'/settings/writing/:site_id',
-		mySitesController.siteSelection,
-		mySitesController.navigation,
+		siteSelection,
+		navigation,
 		settingsController.siteSettings,
 		controller.writing
 	);
@@ -26,8 +24,8 @@ export default function() {
 	if ( config.isEnabled( 'manage/site-settings/categories' ) ) {
 		page(
 			'/settings/taxonomies/:taxonomy/:site_id',
-			mySitesController.siteSelection,
-			mySitesController.navigation,
+			siteSelection,
+			navigation,
 			settingsController.setScroll,
 			controller.taxonomies
 		);

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -1,141 +1,54 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import controller from 'my-sites/controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import statsController from './controller';
 import config from 'config';
 
 export default function() {
 	if ( config.isEnabled( 'jetpack/activity-log' ) ) {
-		page(
-			'/stats/activity/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.activityLog
-		);
+		page( '/stats/activity/:site_id', siteSelection, navigation, statsController.activityLog );
 	}
 	if ( config.isEnabled( 'manage/stats' ) ) {
 		// Stat Overview Page
-		page( '/stats', controller.siteSelection, controller.navigation, statsController.overview );
-		page( '/stats/day', controller.siteSelection, controller.navigation, statsController.overview );
-		page(
-			'/stats/week',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.overview
-		);
-		page(
-			'/stats/month',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.overview
-		);
-		page(
-			'/stats/year',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.overview
-		);
+		page( '/stats', siteSelection, navigation, statsController.overview );
+		page( '/stats/day', siteSelection, navigation, statsController.overview );
+		page( '/stats/week', siteSelection, navigation, statsController.overview );
+		page( '/stats/month', siteSelection, navigation, statsController.overview );
+		page( '/stats/year', siteSelection, navigation, statsController.overview );
 
 		// Stat Insights Page
-		page(
-			'/stats/insights/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.insights
-		);
+		page( '/stats/insights/:site_id', siteSelection, navigation, statsController.insights );
 
 		// Stat Site Pages
-		page(
-			'/stats/day/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.site
-		);
-		page(
-			'/stats/week/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.site
-		);
-		page(
-			'/stats/month/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.site
-		);
-		page(
-			'/stats/year/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.site
-		);
+		page( '/stats/day/:site_id', siteSelection, navigation, statsController.site );
+		page( '/stats/week/:site_id', siteSelection, navigation, statsController.site );
+		page( '/stats/month/:site_id', siteSelection, navigation, statsController.site );
+		page( '/stats/year/:site_id', siteSelection, navigation, statsController.site );
 
 		// Stat Summary Pages
-		page(
-			'/stats/:module/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.summary
-		);
-		page(
-			'/stats/day/:module/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.summary
-		);
-		page(
-			'/stats/week/:module/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.summary
-		);
-		page(
-			'/stats/month/:module/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.summary
-		);
-		page(
-			'/stats/year/:module/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.summary
-		);
+		page( '/stats/:module/:site_id', siteSelection, navigation, statsController.summary );
+		page( '/stats/day/:module/:site_id', siteSelection, navigation, statsController.summary );
+		page( '/stats/week/:module/:site_id', siteSelection, navigation, statsController.summary );
+		page( '/stats/month/:module/:site_id', siteSelection, navigation, statsController.summary );
+		page( '/stats/year/:module/:site_id', siteSelection, navigation, statsController.summary );
 
 		// Stat Single Post Page
-		page(
-			'/stats/post/:post_id/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.post
-		);
-		page(
-			'/stats/page/:post_id/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.post
-		);
+		page( '/stats/post/:post_id/:site_id', siteSelection, navigation, statsController.post );
+		page( '/stats/page/:post_id/:site_id', siteSelection, navigation, statsController.post );
 
 		// Stat Follows Page
-		page(
-			'/stats/follows/comment/:site_id',
-			controller.siteSelection,
-			controller.navigation,
-			statsController.follows
-		);
+		page( '/stats/follows/comment/:site_id', siteSelection, navigation, statsController.follows );
 		page(
 			'/stats/follows/comment/:page_num/:site_id',
-			controller.siteSelection,
-			controller.navigation,
+			siteSelection,
+			navigation,
 			statsController.follows
 		);
 
@@ -147,10 +60,10 @@ export default function() {
 		// Anything else should require site-selection
 		page(
 			'/stats/(.*)',
-			controller.siteSelection,
-			controller.navigation,
+			siteSelection,
+			navigation,
 			statsController.redirectToDefaultSitePage,
-			controller.sites
+			sites
 		);
 	}
 }

--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -1,33 +1,31 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import sitesController from 'my-sites/controller';
+import { siteSelection, sites } from 'my-sites/controller';
 import controller from './controller';
 import config from 'config';
 
 export default function() {
-	page( '/post', controller.pressThis, sitesController.siteSelection, sitesController.sites );
+	page( '/post', controller.pressThis, siteSelection, sites );
 	page( '/post/new', () => page.redirect( '/post' ) ); // redirect from beep-beep-boop
-	page( '/post/:site?/:post?', sitesController.siteSelection, controller.post );
+	page( '/post/:site?/:post?', siteSelection, controller.post );
 	page.exit( '/post/:site?/:post?', controller.exitPost );
 
-	page( '/page', sitesController.siteSelection, sitesController.sites );
+	page( '/page', siteSelection, sites );
 	page( '/page/new', () => page.redirect( '/page' ) ); // redirect from beep-beep-boop
-	page( '/page/:site?/:post?', sitesController.siteSelection, controller.post );
+	page( '/page/:site?/:post?', siteSelection, controller.post );
 	page.exit( '/page/:site?/:post?', controller.exitPost );
 
 	if ( config.isEnabled( 'manage/custom-post-types' ) ) {
-		page( '/edit/:type', sitesController.siteSelection, sitesController.sites );
+		page( '/edit/:type', siteSelection, sites );
 		page( '/edit/:type/new', context => page.redirect( `/edit/${ context.params.type }` ) );
-		page( '/edit/:type/:site?/:post?', sitesController.siteSelection, controller.post );
+		page( '/edit/:type/:site?/:post?', siteSelection, controller.post );
 		page.exit( '/edit/:type/:site?/:post?', controller.exitPost );
 	}
 }

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -4,7 +4,7 @@ After learning a bit about the values of the project, let’s get a taste of the
 
 First [get setup with Calypso locally](../install.md) if you haven't already.
 
-Load [http://calypso.localhost:3000](http://calypso.localhost:3000/) in your browser. 
+Load [http://calypso.localhost:3000](http://calypso.localhost:3000/) in your browser.
 
 For this example to work, you need to have signed into WordPress **and** have already set up at least one site.
 
@@ -69,7 +69,7 @@ export default Controller;
 
 ### 4. Set up the route
 
-The next step is to create the main file for your section, called `index.js` within `hello-world`.  
+The next step is to create the main file for your section, called `index.js` within `hello-world`.
 Run the following command to create the file:
 
 ```
@@ -87,11 +87,11 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import controller from 'my-sites/controller';
+import { navigation, siteSelection } from 'my-sites/controller';
 import helloWorldController from './controller';
 
 export default () => {
-	page( '/hello-world/:domain?', controller.siteSelection, controller.navigation, helloWorldController.helloWorld );
+	page( '/hello-world/:domain?', siteSelection, navigation, helloWorldController.helloWorld );
 };
 ```
 
@@ -220,7 +220,7 @@ That's it. Please check out the [CSS/Sass Coding Guidelines](../coding-guideline
 
 ### 3. Hook up controller
 
-Time to hook this up with our controller function. Open `/hello-world/controller.js`.  
+Time to hook this up with our controller function. Open `/hello-world/controller.js`.
 Import ReactDom, React and your new component at the top of the file:
 
 ```javascript
@@ -254,6 +254,6 @@ In the `Main` constant we are getting our main jsx file for our section. We then
 
 ### Ok, ready?
 
-Run `npm start` if it wasn't already running, and load [http://calypso.localhost:3000/hello-world](http://calypso.localhost:3000/hello-world) in your browser. You should see "Hello, World!" on the page next to the sidebar. And since we added `controller.siteSelection` in our initial route setup, changing a site in the sidebar should also work for your hello-world section. Happy _calypsoing_!
+Run `npm start` if it wasn't already running, and load [http://calypso.localhost:3000/hello-world](http://calypso.localhost:3000/hello-world) in your browser. You should see "Hello, World!" on the page next to the sidebar. And since we added `siteSelection` in our initial route setup, changing a site in the sidebar should also work for your hello-world section. Happy _calypsoing_!
 
 Previous: [Values](0-values.md) Next: [The Technology Behind Calypso](tech-behind-calypso.md)


### PR DESCRIPTION
@see #18838

This is meant to be a prerparatory part of #18838 or at least a
part/chunk of that PR in order to make it smaller and easier to
review and test and evaluate.

Many of our modules were importing the default export value from
the `my-sites` controller and calling methods off of that default

```js
import controller from 'my-sites/controller';

page( '/path', controller.siteNavigation );
```

With the controller exporting this large object as its default export
and with the other modules importing it in its entirety it meant that
these other modules would depend on importing the entire controller
module even though they may only need a small fraction of it.

Using named imports and exports gets us closer to the point where we
can stop transpiling our modules into CommonJS modules before sending
them to Webpack. When that happens (after this and other PRs merge)
then Webpack will start "tree-shaking" our build, meaning that it
will only pull in these statically-defined imports instead of the
referenced modules in their entirety.

> Note: I created this PR by hand, not with a codemod, so everything
should be simple in the changes.

There should be no functional or visual changes in this PR

**Testing**

Smoke test calypso and attempt to navigate around in the sections touched
by this patch. These changes affect thee way we are routing through `page()`
so we want to verify that we didn't accidentally break URL path mapping.
None of the changes _should_ have broken anything, so if they do it's probably
a typo or I missed some things that needed to change.