### PR TITLE
Checkout: adding error class to phone input field element

### DIFF
--- a/client/components/forms/form-phone-media-input/index.jsx
+++ b/client/components/forms/form-phone-media-input/index.jsx
@@ -8,7 +8,9 @@ import React from 'react';
 import classnames from 'classnames';
 import { omit } from 'lodash';
 
-/** Internal dependencies */
+/**
+ * Internal dependencies
+ */
 import PhoneInput from 'components/phone-input';
 import FormLabel from 'components/forms/form-label';
 import FormInputValidation from 'components/forms/form-input-validation';
@@ -25,20 +27,16 @@ export default class extends React.Component {
 	setPhoneInput = ref => ( this.phoneInput = ref );
 
 	render() {
-		const classes = classnames( this.props.className, {
-			'is-error': this.props.isError,
-		} );
-
 		return (
 			<div className={ classnames( this.props.additionalClasses, 'phone' ) }>
 				<div>
 					<FormLabel htmlFor={ this.props.name }>{ this.props.label }</FormLabel>
 					<PhoneInput
 						{ ...omit( this.props, [ 'className', 'countryCode' ] ) }
-						ref="input"
 						setComponentReference={ this.setPhoneInput }
 						countryCode={ this.props.countryCode.toUpperCase() }
-						className={ classes }
+						className={ this.props.className }
+						isError={ this.props.isError }
 					/>
 				</div>
 				{ this.props.errorMessage && (

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -243,6 +243,7 @@ class PhoneInput extends React.PureComponent {
 					name={ this.props.name }
 					ref={ this.setNumberInputRef }
 					type="tel"
+					className={ this.props.isError && 'is-error' }
 				/>
 				<div className="phone-input__select-container">
 					<div className="phone-input__select-inner-container">


### PR DESCRIPTION
The `is-error` CSS class is normally applied _directly_ to form fields in order change the field's border to red.

`<PhoneInput />` however, applied the CSS class not the form field element, but to its parent resulting no change in border color when the field's value contains an error.

<img width="711" alt="screen shot 2017-11-13 at 3 50 39 pm" src="https://user-images.githubusercontent.com/6458278/32710276-fbd8f6de-c88a-11e7-9c98-bf8e0f950121.png">

This PR passes `isError` down to `<PhoneInput />`, and adds `is-error` class to the input field when `isError === true`.

<img width="716" alt="screen shot 2017-11-13 at 3 51 03 pm" src="https://user-images.githubusercontent.com/6458278/32710325-5f93adfe-c88b-11e7-930d-86a0c3a99355.png">

## Testing
### Steps
1. Place a domain in your cart and head to checkout.
2. In the domain details form, enter an invalid or blank value for 'Phone'.

### Expected behaviour
The field's border should turn red.


