### PR TITLE
ABTests: allow multiple country code targets

### DIFF
--- a/client/lib/abtest/README.md
+++ b/client/lib/abtest/README.md
@@ -34,7 +34,7 @@ There are also several optional configuration settings available:
 
 * `localeTargets` - By default, tests only run on users where the locale is set to English. You can also run for all locales by setting `localeTargets` to 'any', or to an array of a specific locale or locales  `localeTargets: ['de']`
 Don't forget: any test that runs for locales other than English means strings will need to be translated.
-* `countryCodeTarget` - Only run tests for users from a specific country. You'll need to pass the current user country to the abtest method when calling it.
+* `countryCodeTargets` - (array) Only run tests for users from specific countries. You'll need to pass the current user country to the abtest method when calling it.
 * `assignmentMethod` - By default, test variations are assigned using a random number generator. You can also assign test variations using the 'userId'. Using the userId to assign test variations will still assign a random assignment; however, it ensures the user is assigned the same assignment in the event their local storage gets cleared or is compromised. This includes cases where they manually clear their local storage, use multiple devices, or use an incognito window (storageless browser). This assignment method should not be used if a user does not have a userId by the time the AB test starts.
 
 Next, in your code, import the `abtest` method from the `abtest` module:

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -130,12 +130,14 @@ ABTest.prototype.init = function( name, geoLocation ) {
 	this.assignmentMethod = assignmentMethod;
 	this.experimentId = name + '_' + variationDatestamp;
 
-	if ( testConfig.countryCodeTarget ) {
+	if ( testConfig.countryCodeTargets ) {
 		if ( false !== geoLocation ) {
-			this.countryCodeTarget = testConfig.countryCodeTarget;
+			this.countryCodeTargets = testConfig.countryCodeTargets;
 			this.geoLocation = geoLocation;
 		} else {
-			throw new Error( 'Test config has geoTarget, but no geoLocation passed to abtest function' );
+			throw new Error(
+				'Test config has countryCodeTargets, but no geoLocation passed to abtest function'
+			);
 		}
 	}
 
@@ -212,14 +214,16 @@ ABTest.prototype.isEligibleForAbTest = function() {
 		}
 	}
 
-	if ( this.countryCodeTarget && this.countryCodeTarget !== this.geoLocation ) {
-		debug(
-			'%s: geoLocation is %s, test targets %s',
-			this.experimentId,
-			this.geoLocation,
-			this.countryCodeTarget
-		);
-		return false;
+	if ( this.countryCodeTargets ) {
+		if ( this.countryCodeTargets.indexOf( this.geoLocation ) === -1 ) {
+			debug(
+				'%s: geoLocation is %s, test targets: %s',
+				this.experimentId,
+				this.geoLocation,
+				this.countryCodeTargets.join( ', ' )
+			);
+			return false;
+		}
 	}
 
 	if ( this.hasBeenInPreviousSeriesTest() ) {

--- a/client/lib/abtest/test/index.js
+++ b/client/lib/abtest/test/index.js
@@ -52,14 +52,14 @@ jest.mock( 'lib/abtest/active-tests', () => ( {
 		defaultVariation: 'hide',
 		localeTargets: [ 'fr' ],
 	},
-	mockedTestIlCountryCodeTarget: {
+	mockedTestIlInCountryCodeTargets: {
 		datestamp: '20160627',
 		variations: {
 			hide: 50,
 			show: 50,
 		},
 		defaultVariation: 'hide',
-		countryCodeTarget: 'IL',
+		countryCodeTargets: [ 'IL', 'IN' ],
 	},
 	mockedTestAllowExisting: {
 		datestamp: '20160627',
@@ -226,7 +226,7 @@ describe( 'abtest', () => {
 					expect( setSpy ).to.have.been.calledOnce;
 				} );
 			} );
-			describe( 'IL countryCodeTarget only', () => {
+			describe( 'IL/IN countryCodeTargets only', () => {
 				beforeEach( () => {
 					getUserStub.mockReturnValue( {
 						localeSlug: 'en',
@@ -235,22 +235,27 @@ describe( 'abtest', () => {
 				} );
 
 				test( 'should return default and skip store.set for new users with no GeoLocation value', () => {
-					abtest( 'mockedTestIlCountryCodeTarget', null );
+					abtest( 'mockedTestIlInCountryCodeTargets', null );
 					expect( setSpy ).not.to.have.been.called;
 				} );
 				test( 'should throw error if countryCodeTarget is set but geoLocation is not passed', () => {
-					expect( () => abtest( 'mockedTestIlCountryCodeTarget' ) ).to.throw(
-						'Test config has geoTarget, but no geoLocation passed to abtest function'
+					expect( () => abtest( 'mockedTestIlInCountryCodeTargets' ) ).to.throw(
+						'Test config has countryCodeTargets, but no geoLocation passed to abtest function'
 					);
 				} );
 				test( 'should return default and skip store.set for new users not from Israel', () => {
 					const geoLocation = 'US';
-					expect( abtest( 'mockedTestIlCountryCodeTarget', geoLocation ) ).to.equal( 'hide' );
+					expect( abtest( 'mockedTestIlInCountryCodeTargets', geoLocation ) ).to.equal( 'hide' );
 					expect( setSpy ).not.to.have.been.called;
 				} );
 				test( 'should call store.set for new users with from Israel', () => {
 					const geoLocation = 'IL';
-					abtest( 'mockedTestIlCountryCodeTarget', geoLocation );
+					abtest( 'mockedTestIlInCountryCodeTargets', geoLocation );
+					expect( setSpy ).to.have.been.calledOnce;
+				} );
+				test( 'should call store.set for new users with from India', () => {
+					const geoLocation = 'IN';
+					abtest( 'mockedTestIlInCountryCodeTargets', geoLocation );
 					expect( setSpy ).to.have.been.calledOnce;
 				} );
 			} );


### PR DESCRIPTION
This updates the AB Tests library to allow multiple country code targets for a test. 
Required for the AB Test in #19431