### PR TITLE
Extensions: WP Job Manager: Add HeaderCake

### DIFF
--- a/client/extensions/wp-job-manager/components/navigation/index.jsx
+++ b/client/extensions/wp-job-manager/components/navigation/index.jsx
@@ -13,9 +13,11 @@ import { find, flowRight, get, values } from 'lodash';
 /**
  * Internal dependencies
  */
+import HeaderCake from 'components/header-cake';
 import SectionNav from 'components/section-nav';
 import SectionNavTabs from 'components/section-nav/tabs';
 import SectionNavTabItem from 'components/section-nav/item';
+import { addSiteFragment } from 'lib/route/path';
 import sectionsModule from 'sections';
 import { Tabs } from '../../constants';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -58,10 +60,22 @@ class Navigation extends Component {
 	}
 
 	render() {
+		const { siteSlug, translate } = this.props;
+
 		return (
-			<SectionNav selectedText="Settings">
-				<SectionNavTabs>{ values( Tabs ).map( tab => this.renderTabItem( tab ) ) }</SectionNavTabs>
-			</SectionNav>
+			<div>
+				<HeaderCake
+					backText={ translate( 'Plugin Overview' ) }
+					backHref={ siteSlug && addSiteFragment( '/plugins/wp-job-manager', siteSlug ) }
+				>
+					WP Job Manager
+				</HeaderCake>
+				<SectionNav selectedText="Settings">
+					<SectionNavTabs>
+						{ values( Tabs ).map( tab => this.renderTabItem( tab ) ) }
+					</SectionNavTabs>
+				</SectionNav>
+			</div>
 		);
 	}
 }


### PR DESCRIPTION
To indicate in which extension section the user currently is, as discussed at p4TIVU-7v4-p2.

![image](https://user-images.githubusercontent.com/96308/32720809-ed0d0ddc-c864-11e7-9f99-c2a4f5e60f24.png)

To test:
* Land at http://calypso.localhost:3000/extensions/wp-job-manager/<yourJPsite>
* The 'Plugin Overview' link will take you to http://calypso.localhost:3000/plugins/wp-job-manager/<yourJPsite>