### PR TITLE
Jetpack connect: Fix bad userAlreadyConnected selector

### DIFF
--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -98,7 +98,7 @@ const getAuthAttempts = ( state, slug ) => {
 };
 
 const getUserAlreadyConnected = state => {
-	return get( state, 'jetpackConnectAuthorize.userAlreadyConnected' );
+	return !! getAuthorizationData( state ).userAlreadyConnected;
 };
 
 /**

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -98,7 +98,7 @@ const getAuthAttempts = ( state, slug ) => {
 };
 
 const getUserAlreadyConnected = state => {
-	return !! getAuthorizationData( state ).userAlreadyConnected;
+	return get( getAuthorizationData( state ), 'userAlreadyConnected', false );
 };
 
 /**

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -13,12 +13,15 @@ import {
 	getSessions,
 	getSiteIdFromQueryObject,
 	getSSO,
+	getUserAlreadyConnected,
 	hasExpiredSecretError,
 	hasXmlrpcError,
 	isCalypsoStartedConnection,
 	isRedirectingToWpAdmin,
 	isRemoteSiteOnSitesList,
 } from '../selectors';
+
+const jestExpect = global.expect;
 
 describe( 'selectors', () => {
 	describe( '#getConnectingSite()', () => {
@@ -690,6 +693,28 @@ describe( 'selectors', () => {
 				},
 			};
 			expect( getSiteIdFromQueryObject( state ) ).toBeNull();
+		} );
+	} );
+
+	describe( '#getUserAlreadyConnected()', () => {
+		const makeUserAlreadyConnectedState = result => ( {
+			jetpackConnect: {
+				jetpackConnectAuthorize: {
+					userAlreadyConnected: result,
+				},
+			},
+		} );
+
+		test( 'should return false if state is missing', () => {
+			jestExpect( getUserAlreadyConnected( {} ) ).toBe( false );
+		} );
+
+		test( 'should return the value from state', () => {
+			const falseState = makeUserAlreadyConnectedState( false );
+			jestExpect( getUserAlreadyConnected( falseState ) ).toBe( false );
+
+			const trueState = makeUserAlreadyConnectedState( true );
+			jestExpect( getUserAlreadyConnected( trueState ) ).toBe( true );
 		} );
 	} );
 } );

--- a/client/state/jetpack-connect/test/selectors.js
+++ b/client/state/jetpack-connect/test/selectors.js
@@ -21,8 +21,6 @@ import {
 	isRemoteSiteOnSitesList,
 } from '../selectors';
 
-const jestExpect = global.expect;
-
 describe( 'selectors', () => {
 	describe( '#getConnectingSite()', () => {
 		test( 'should return undefined if user has not started connecting a site', () => {
@@ -706,15 +704,15 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return false if state is missing', () => {
-			jestExpect( getUserAlreadyConnected( {} ) ).toBe( false );
+			expect( getUserAlreadyConnected( {} ) ).toBe( false );
 		} );
 
 		test( 'should return the value from state', () => {
 			const falseState = makeUserAlreadyConnectedState( false );
-			jestExpect( getUserAlreadyConnected( falseState ) ).toBe( false );
+			expect( getUserAlreadyConnected( falseState ) ).toBe( false );
 
 			const trueState = makeUserAlreadyConnectedState( true );
-			jestExpect( getUserAlreadyConnected( trueState ) ).toBe( true );
+			expect( getUserAlreadyConnected( trueState ) ).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR fixes a bug in the Jetpack Connect `getUserAlreadyConnected` selector. The wrong part of the state tree was being selected, and the safety of `lodash.get` actaully hid the bug.

## Testing
1. You can apply the diff below to ensure that `userAlreadyConnected` is always true.
1. The old fashioned way:
   1. Set up a new site
   1. Connect a WordPress.com user
   1. Add a new user to the site
   1. Log in to the site as that user
   1. While logged in to WordPress.com as the already connected user, try to connect with the new site user
   1. You should see the warning below.
1. Following the same steps on `master` should not show the notice.

![fixed](https://user-images.githubusercontent.com/841763/32725892-38b448e2-c877-11e7-8f47-ba36a520bb6c.png)

```diff
diff --git a/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js b/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
index f6fcfc7ac..bd25a376b 100644
--- a/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
@@ -33,7 +33,7 @@ function buildDefaultAuthorizeState() {
 		authorizeSuccess: false,
 		authorizeError: false,
 		timestamp: Date.now(),
-		userAlreadyConnected: false,
+		userAlreadyConnected: true,
 	};
 }
 ```

Discovered while working on #19564 