### PR TITLE
Codemods: add support for codemod debugging

### DIFF
--- a/bin/codemods/README.md
+++ b/bin/codemods/README.md
@@ -67,6 +67,25 @@ If you're developing your own transformations, it may be useful to know you can 
 ./node_modules/.bin/jscodeshift -t transformation.js [target files]
 ```
 
+## How to debug codemods
+
+If you are a codemod author, you may want to debug your codemod using the Chrome debugger. Then
+run the codemod script with a `--debugger` parameter:
+```bash
+npm run codemod -- --debugger my-transform client/target.js
+```
+This will run `jscodeshift` in a Node process with activated debugger server and will break on the
+first statement. That allows you to connect with Chrome and run the codemod script. (internally,
+the `--inspect-brk` command line option is passed to Node)
+
+`jscodeshift` will be run in a mode where it doesn't spawn child worker processes, but will execute
+everything in one Node process -- the one that's being debugged. (internally, the `--run-in-band`
+command line option is passed to `jscodeshift`)
+
+You can now connect to the running Node process from Chrome by opening the `chrome:inspect` page and
+selecting your local Node process from the list. Refer to the
+[official Node debugging guide](https://nodejs.org/en/docs/inspector/) if you run into any trouble.
+
 ## List of available transformations
 
 ### 5to6-codemod scripts ([docs](https://github.com/5to6/5to6-codemod#transforms))


### PR DESCRIPTION
I wanted to debug a codemod script today and found it's not easy. Node needs to be run with `--inspect` and `--debug-brk` parameters. That spawns a debugger server and breaks on first statement. `jscodeshift` must be prevented from spawning worker processes by running it with `--run-in-band` option. Otherwise, the transform will run in a process different from the one we are debugging.

This PR adds a `--debugger` option to the `run` script.

**How to test:**
1. Run `npm run codemod -- --debugger transform-name target-name`
2. Open the `chrome-devtools://` link you see in terminal in Chrome
3. Enjoy the Chrome debugger paused on the first statement -- set breakpoints, put `debugger` statements in your code... and run.

I don't know how Node debugging works in editors like VS Code. Maybe @blowery could help with making the debugging work in these?

Some links where I found valuable advice:
- https://medium.com/@paul_irish/debugging-node-js-nightlies-with-chrome-devtools-7c4a1b95ae27
- https://github.com/facebook/jscodeshift/issues/223
