### PR TITLE
lib/warn: do not warn in test env. only dev

### DIFF
--- a/client/lib/warn/README.md
+++ b/client/lib/warn/README.md
@@ -1,0 +1,10 @@
+warn
+======
+warn is a tiny utility function that wraps the browsers `console.warn` 
+so that it only emits in development and test environments.
+
+If you'd like to hide output within a test, you can with:
+
+```javascript
+jest.mock( 'lib/warn', () => () => {} ); 
+```

--- a/client/lib/warn/README.md
+++ b/client/lib/warn/README.md
@@ -1,9 +1,10 @@
 warn
 ======
 warn is a tiny utility function that wraps the browsers `console.warn` 
-so that it only emits in development and test environments.
+so that it does not emit in production.
 
-If you'd like to hide output within a test, you can with:
+If you'd like to hide output within a test, 
+add this line to the top of your test file:
 
 ```javascript
 jest.mock( 'lib/warn', () => () => {} ); 

--- a/client/lib/warn/index.js
+++ b/client/lib/warn/index.js
@@ -1,19 +1,18 @@
-/**
- * /* eslint-disable no-console
- *
- * @format
- */
+/** @format */
+/* eslint-disable no-console */
 
-/**
- * Internal Dependencies
+/*
+ * Wraps console.warn to only emit in development and test environments.
+ *
+ * Many utility libraries in Calypso utilize this to warn about misuse of functions,
+ * For example: stats warns when any tracks events aren't properly formatted (@see lib/analytics)
  */
-import config from 'config';
 
 let warn;
-if ( config( 'env' ) !== 'production' && 'function' === typeof console.warn ) {
-	warn = ( ...args ) => console.warn( ...args );
-} else {
+if ( process.env.NODE_ENV === 'production' || 'function' !== typeof console.warn ) {
 	warn = () => {};
+} else {
+	warn = ( ...args ) => console.warn( ...args );
 }
 
 export default warn;

--- a/client/lib/warn/index.js
+++ b/client/lib/warn/index.js
@@ -1,9 +1,16 @@
-/** @format */
-/* eslint-disable no-console */
+/**
+ * /* eslint-disable no-console
+ *
+ * @format
+ */
+
+/**
+ * Internal Dependencies
+ */
+import config from 'config';
 
 let warn;
-
-if ( process.env.NODE_ENV === 'development' ) {
+if ( config( 'env' ) !== 'production' && 'function' === typeof console.warn ) {
 	warn = ( ...args ) => console.warn( ...args );
 } else {
 	warn = () => {};

--- a/client/lib/warn/index.js
+++ b/client/lib/warn/index.js
@@ -1,16 +1,9 @@
-/**
- * /* eslint-disable no-console
- *
- * @format
- */
-
-/**
- * Internal Dependencies
- */
-import config from 'config';
+/** @format */
+/* eslint-disable no-console */
 
 let warn;
-if ( config( 'env' ) !== 'production' && 'function' === typeof console.warn ) {
+
+if ( process.env.NODE_ENV === 'development' ) {
 	warn = ( ...args ) => console.warn( ...args );
 } else {
 	warn = () => {};

--- a/client/state/reader/watermarks/test/reducer.js
+++ b/client/state/reader/watermarks/test/reducer.js
@@ -7,6 +7,8 @@ import { viewStream } from '../actions';
 import { watermarks } from '../reducer';
 import { DESERIALIZE, SERIALIZE } from 'state/action-types';
 
+jest.mock( 'lib/warn', () => () => {} );
+
 const streamId = 'special-chicken-stream';
 const mark = Date.now();
 


### PR DESCRIPTION
We have a very small lib named `warn`.  The intention is to console.warn in development but not in production. 

Before this PR, `warn` also emits within the test environment, which I don't think should happen. It pollutes the logs with unactionable and usually deliberate failure scenarios. An example of a frequent one is the warning emitted by `withSchemaValidation` while testing the deserialization of reducers.

To test
-----
1. `npm run test`  should pass.
2. should produce warnings: `NODE_ENV=development npm run test-client client/state/reader/watermarks`
3. should not produce warnings: `npm run test-client client/state/reader/watermarks`