### PR TITLE
Jetpack Connect: Use DocumentHead instead of setDocumentHeadTitle

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -7,7 +7,6 @@ import ReactDom from 'react-dom';
 import Debug from 'debug';
 import page from 'page';
 import { get, isEmpty } from 'lodash';
-import { translate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -27,7 +26,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { JETPACK_CONNECT_QUERY_SET } from 'state/action-types';
 import { renderWithReduxStore } from 'lib/react-helpers';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
 
 /**
@@ -178,8 +176,6 @@ export default {
 
 		removeSidebar( context );
 
-		context.store.dispatch( setTitle( translate( 'Plans', { textOnly: true } ) ) );
-
 		analytics.tracks.recordEvent( 'calypso_plans_view' );
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
@@ -209,9 +205,6 @@ export default {
 		}
 
 		removeSidebar( context );
-
-		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-		context.store.dispatch( setTitle( translate( 'Plans', { textOnly: true } ) ) );
 
 		analytics.tracks.recordEvent( 'calypso_plans_view' );
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -5,11 +5,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import page from 'page';
 
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
@@ -84,7 +86,7 @@ class PlansLanding extends Component {
 	};
 
 	render() {
-		const { basePlansPath, interval, requestingSites, site } = this.props;
+		const { basePlansPath, interval, requestingSites, site, translate } = this.props;
 
 		// We're redirecting in componentDidMount if the site is already connected
 		// so don't bother rendering any markup if this is the case
@@ -94,6 +96,8 @@ class PlansLanding extends Component {
 
 		return (
 			<div>
+				<DocumentHead title={ translate( 'Plans' ) } />
+
 				<QueryPlans />
 
 				<PlansGrid
@@ -130,4 +134,4 @@ export default connect(
 		recordTracksEvent,
 		selectPlanInAdvance,
 	}
-)( PlansLanding );
+)( localize( PlansLanding ) );

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
@@ -267,6 +268,7 @@ class Plans extends Component {
 
 		return (
 			<div>
+				<DocumentHead title={ translate( 'Plans' ) } />
 				<QueryPlans />
 				{ selectedSite && <QuerySitePlans siteId={ selectedSite.ID } /> }
 				<PlansGrid

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -4,7 +4,7 @@ exports[`Plans should render empty with a paid plan 1`] = `<components--data--qu
 
 exports[`Plans should render with a paid plan with showFirst prop 1`] = `
 <div>
-  <Connect(DocumentHead)
+  <components--data--document-head
     title="Plans"
   />
   <components--data--query-plans />
@@ -167,7 +167,7 @@ exports[`Plans should render with a paid plan with showFirst prop 1`] = `
 
 exports[`Plans should render with no plan (free) 1`] = `
 <div>
-  <Connect(DocumentHead)
+  <components--data--document-head
     title="Plans"
   />
   <components--data--query-plans />

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -4,6 +4,9 @@ exports[`Plans should render empty with a paid plan 1`] = `<components--data--qu
 
 exports[`Plans should render with a paid plan with showFirst prop 1`] = `
 <div>
+  <Connect(DocumentHead)
+    title="Plans"
+  />
   <components--data--query-plans />
   <components--data--query-site-plans
     siteId={1234567}
@@ -164,6 +167,9 @@ exports[`Plans should render with a paid plan with showFirst prop 1`] = `
 
 exports[`Plans should render with no plan (free) 1`] = `
 <div>
+  <Connect(DocumentHead)
+    title="Plans"
+  />
   <components--data--query-plans />
   <components--data--query-site-plans
     siteId={1234567}

--- a/client/jetpack-connect/test/plans.js
+++ b/client/jetpack-connect/test/plans.js
@@ -16,6 +16,7 @@ import QueryPlans from 'components/data/query-plans';
 import { DEFAULT_PROPS, SELECTED_SITE, SITE_PLAN_PRO } from './lib/plans';
 import { PlansTestComponent as Plans } from '../plans';
 
+jest.mock( 'components/data/document-head', () => 'components--data--document-head' );
 jest.mock( 'components/data/query-plans', () => 'components--data--query-plans' );
 jest.mock( 'components/data/query-site-plans', () => 'components--data--query-site-plans' );
 jest.mock( 'jetpack-connect/happychat-button', () => 'jetpack-connect--happychat-button' );


### PR DESCRIPTION
This PR cleans up a couple usages of the obsolete `setDocumentHeadTitle` in favor of using `<DocumentHead />` in the corresponding components. There should be no visual, functional or behavioral changes at all.

To test:
* Checkout this branch
* Go to `/jetpack/connect/` and connect a Jetpack site.
* Verify the title changes to **Plans** properly when you see the plans page.
* Go to `/jetpack/connect/store`.
* Verify the title is **Plans**.