### PR TITLE
Store Orders: Add order status checks to editable sections

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -16,7 +16,7 @@ import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 import { clearOrderEdits, editOrder } from 'woocommerce/state/ui/orders/actions';
 import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
-import { fetchOrder } from 'woocommerce/state/sites/orders/actions';
+import { fetchOrder, updateOrder } from 'woocommerce/state/sites/orders/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import {
@@ -30,7 +30,7 @@ import Main from 'components/main';
 import OrderCustomer from './order-customer';
 import OrderDetails from './order-details';
 import OrderActivityLog from './order-activity-log';
-import { updateOrder } from 'woocommerce/state/sites/orders/actions';
+import { ProtectFormGuard } from 'lib/protect-form';
 
 class Order extends Component {
 	componentDidMount() {
@@ -136,6 +136,7 @@ class Order extends Component {
 
 				<div className="order__container">
 					<LabelsSetupNotice />
+					{ isEditing && <ProtectFormGuard isChanged={ hasOrderEdits } /> }
 					<OrderDetails orderId={ orderId } />
 					<OrderActivityLog orderId={ orderId } siteId={ site.ID } />
 					<OrderCustomer orderId={ orderId } />

--- a/client/extensions/woocommerce/app/order/order-customer/index.js
+++ b/client/extensions/woocommerce/app/order/order-customer/index.js
@@ -17,6 +17,7 @@ import Card from 'components/card';
 import CustomerAddressDialog from './dialog';
 import { editOrder } from 'woocommerce/state/ui/orders/actions';
 import { isCurrentlyEditingOrder, getOrderWithEdits } from 'woocommerce/state/ui/orders/selectors';
+import { isOrderFinished } from 'woocommerce/lib/order-status';
 import getAddressViewFormat from 'woocommerce/lib/get-address-view-format';
 import { getOrder } from 'woocommerce/state/sites/orders/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -85,6 +86,7 @@ class OrderCustomerInfo extends Component {
 		}
 
 		const { billing, shipping } = order;
+		const isEditable = isEditing && ! isOrderFinished( order.status );
 
 		return (
 			<div className="order-customer">
@@ -94,7 +96,7 @@ class OrderCustomerInfo extends Component {
 						<div className="order-customer__billing">
 							<h3 className="order-customer__billing-details">
 								{ translate( 'Billing Details' ) }
-								{ isEditing ? (
+								{ isEditable ? (
 									<Button
 										compact
 										className="order-customer__edit-link"
@@ -121,7 +123,7 @@ class OrderCustomerInfo extends Component {
 						<div className="order-customer__shipping">
 							<h3 className="order-customer__shipping-details">
 								{ translate( 'Shipping Details' ) }
-								{ isEditing ? (
+								{ isEditable ? (
 									<Button
 										compact
 										className="order-customer__edit-link"

--- a/client/extensions/woocommerce/app/order/order-details/index.js
+++ b/client/extensions/woocommerce/app/order/order-details/index.js
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import { editOrder } from 'woocommerce/state/ui/orders/actions';
 import { isCurrentlyEditingOrder, getOrderWithEdits } from 'woocommerce/state/ui/orders/selectors';
+import { isOrderEditable } from 'woocommerce/lib/order-status';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getOrder } from 'woocommerce/state/sites/orders/selectors';
 import OrderCreated from '../order-created';
@@ -64,7 +65,12 @@ class OrderDetails extends Component {
 		const { isEditing, order, site } = this.props;
 		if ( isEditing ) {
 			return (
-				<OrderDetailsTable order={ order } site={ site } isEditing onChange={ this.updateOrder } />
+				<OrderDetailsTable
+					order={ order }
+					site={ site }
+					isEditing={ isOrderEditable( order.status ) }
+					onChange={ this.updateOrder }
+				/>
 			);
 		}
 


### PR DESCRIPTION
This PR wraps up all the features for editing orders 🎉  See #15681

Currently all orders are fully editable, no matter the order status. Obviously you don't want to be able to add products to an already-shipped order, so this PR adds in the status checks for editing the line items and billing/shipping addresses. It also adds the form guard to prevent the user from accidentally leaving a page with pending edits.

So you can edit products on any order that hasn't been paid, and edit addressed on any order that hasn't been shipped yet. A full table of functionality + status can be found at this comment: https://github.com/Automattic/wp-calypso/issues/15681#issuecomment-343226901

_Note:_ Editing the shipping fee is in another PR #19641, so I haven't left any testing instructions here – but it will also only be possible before the order is paid for.

**To test**

- Open a pending order, check that you can add, edit, & delete products, add & delete fees, edit the customer addresses
- Open an on-hold order, check that all the same functionality is there
- Open a processing order, check that you can only edit addresses
- Open a completed order, check that you can only edit the order status
- Open a cancelled, refunded, or failed order, check that you can only edit the order status