### PR TITLE
Popover: align icon and text label

### DIFF
--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -211,6 +211,10 @@
 		vertical-align: bottom;
 		margin-right: 8px;
 	}
+	.gridicons-cloud-download {
+		position: relative;
+		top: 2px;
+	}
 	&.is-compact {
 		padding: 6px 12px;
 		font-size: 11px;


### PR DESCRIPTION
This PR seeks to solve a vertical alignment issue in the items found in a popover menu, between each item and its icon:

#### Before
<img width="220" alt="captura de pantalla 2017-11-13 a la s 14 16 56" src="https://user-images.githubusercontent.com/1041600/32739110-ac26c27c-c87d-11e7-8271-fe5ea062b471.png">


#### After
<img width="231" alt="captura de pantalla 2017-11-15 a la s 15 58 49" src="https://user-images.githubusercontent.com/1041600/32854661-1dae4ca2-ca1e-11e7-98cc-4264f67fd2de.png">
