### PR TITLE
Update single-tree-render codemod: unmountComponentAtNode

### DIFF
--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -256,6 +256,24 @@ export default function transformer( file, api ) {
 		.replaceWith( ensureNextMiddleware )
 		.forEach( transformReactDomRender );
 
+	// Find if `reactDom` is used
+	const reactDomDefs = root.find( j.MemberExpression, {
+		object: {
+			name: 'ReactDom',
+		},
+	} );
+
+	// Remove stranded `reactDom` imports
+	if ( ! reactDomDefs.size() ) {
+		root
+			.find( j.ImportDeclaration, {
+				source: {
+					value: 'react-dom',
+				},
+			} )
+			.remove();
+	}
+
 	// Transform `renderWithReduxStore()` to `context.primary/secondary`
 	root
 		.find( j.CallExpression, {

--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -7,13 +7,16 @@
  *
  * Transforms `renderWithReduxStore()` to `context.primary/secondary`.
  *
- * Adds `context` to params in middlewares when using `ReactDom.render()`.
+ * Adds `context` to params in middlewares when needed
  *
  * Adds `next` to params and `next()` to body in middlewares when using
  *   `ReactDom.render()` or `renderWithReduxStore()`.
  *
  * Adds `makeLayout` and `clientRender` to `page()` route definitions and
  *   accompanying import statement.
+ *
+ * Removes:
+ *   ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
  */
 
 /**
@@ -325,17 +328,9 @@ export default function transformer( file, api ) {
 	}
 
 	/**
-  	 * Transform `ReactDom.unmountComponentAtNode()` CallExpressions.
-  	 *
-  	 * @example
-	 * Input:
+  	 * Removes:
 	 * ```
 	 * ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-	 * ```
-	 *
-	 * Output:
-	 * ```
-	 * context.secondary = null;
 	 * ```
 	 */
 	root
@@ -353,19 +348,7 @@ export default function transformer( file, api ) {
 		.forEach( p => {
 			return _.get( p, 'value.arguments[0].arguments.value' ) === 'secondary';
 		} )
-		.replaceWith( p => {
-			// Returns `context.secondary = null`
-			return j.expressionStatement(
-				j.assignmentExpression(
-					'=',
-					j.memberExpression( j.identifier( 'context' ), j.identifier( 'secondary' ) ),
-					j.literal( null )
-				)
-			);
-		} )
-		.closest( j.Function )
-		.replaceWith( ensureContextMiddleware )
-		.replaceWith( ensureNextMiddleware );
+		.remove();
 
 	// Add makeLayout and clientRender middlewares to route definitions
 	const routeDefs = root

--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -16,7 +16,10 @@
  *   accompanying import statement.
  *
  * Removes:
- *   ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+ *   `ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );`
+ *
+ * Removes:
+ *   Un-used ReactDom imports.
  */
 
 /**
@@ -346,6 +349,7 @@ export default function transformer( file, api ) {
 			},
 		} )
 		.forEach( p => {
+			// Requires `document.getElementById( 'secondary' )`
 			return _.get( p, 'value.arguments[0].arguments.value' ) === 'secondary';
 		} )
 		.remove();

--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -295,14 +295,14 @@ export default function transformer( file, api ) {
 		.replaceWith( ensureNextMiddleware )
 		.forEach( transformReactDomRender );
 
-	// Find if `reactDom` is used
+	// Find if `ReactDom` is used
 	const reactDomDefs = root.find( j.MemberExpression, {
 		object: {
 			name: 'ReactDom',
 		},
 	} );
 
-	// Remove stranded `reactDom` imports
+	// Remove stranded `react-dom` imports
 	if ( ! reactDomDefs.size() ) {
 		const importReactDom = root.find( j.ImportDeclaration, {
 			specifiers: [

--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -86,19 +86,19 @@ export default function transformer( file, api ) {
 	/**
 	 * Removes imports maintaining any comments above them
 	 *
-	 * @param {object} collection Collection containing at least one node. Comment is preserved only from first node.
+	 * @param {object} collection Collection containing at least one node. Comments are preserved only from first node.
 	 */
 	function removeImport( collection ) {
 		const node = collection.nodes()[ 0 ];
 
-		// Find out if import had comment above it
-		const comment = _.get( node, 'comments[0]', false );
+		// Find out if import had comments above it
+		const comments = _.get( node, 'comments', [] );
 
 		// Remove import (and any comments with it)
 		collection.remove();
 
 		// Put back that removed comment (if any)
-		if ( comment ) {
+		if ( comments.length ) {
 			const isRemovedExternal = isExternal( node );
 
 			// Find internal dependencies and place comment above first one
@@ -109,7 +109,7 @@ export default function transformer( file, api ) {
 				} )
 				.at( 0 )
 				.replaceWith( p => {
-					p.value.comments = [ comment ];
+					p.value.comments = p.value.comments ? p.value.comments.concat( comments ) : comments;
 					return p.value;
 				} );
 		}

--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -373,10 +373,8 @@ export default function transformer( file, api ) {
 				},
 			},
 		} )
-		.filter( p => {
-			// Requires `document.getElementById( 'secondary' )`
-			return _.get( p, 'value.arguments[0].arguments.value' ) === 'secondary';
-		} )
+		// Ensures we remove only nodes containing `document.getElementById( 'secondary' )`
+		.filter( p => _.get( p, 'value.arguments[0].arguments[0].value' ) === 'secondary' )
 		.remove();
 
 	// Add makeLayout and clientRender middlewares to route definitions

--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -355,7 +355,7 @@ export default function transformer( file, api ) {
 				},
 			},
 		} )
-		.forEach( p => {
+		.filter( p => {
 			// Requires `document.getElementById( 'secondary' )`
 			return _.get( p, 'value.arguments[0].arguments.value' ) === 'secondary';
 		} )

--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -295,33 +295,6 @@ export default function transformer( file, api ) {
 		.replaceWith( ensureNextMiddleware )
 		.forEach( transformReactDomRender );
 
-	// Find if `ReactDom` is used
-	const reactDomDefs = root.find( j.MemberExpression, {
-		object: {
-			name: 'ReactDom',
-		},
-	} );
-
-	// Remove stranded `react-dom` imports
-	if ( ! reactDomDefs.size() ) {
-		const importReactDom = root.find( j.ImportDeclaration, {
-			specifiers: [
-				{
-					local: {
-						name: 'ReactDom',
-					},
-				},
-			],
-			source: {
-				value: 'react-dom',
-			},
-		} );
-
-		if ( importReactDom.size() ) {
-			removeImport( importReactDom );
-		}
-	}
-
 	// Transform `renderWithReduxStore()` to `context.primary/secondary`
 	root
 		.find( j.CallExpression, {
@@ -376,6 +349,33 @@ export default function transformer( file, api ) {
 		// Ensures we remove only nodes containing `document.getElementById( 'secondary' )`
 		.filter( p => _.get( p, 'value.arguments[0].arguments[0].value' ) === 'secondary' )
 		.remove();
+
+	// Find if `ReactDom` is used
+	const reactDomDefs = root.find( j.MemberExpression, {
+		object: {
+			name: 'ReactDom',
+		},
+	} );
+
+	// Remove stranded `react-dom` imports
+	if ( ! reactDomDefs.size() ) {
+		const importReactDom = root.find( j.ImportDeclaration, {
+			specifiers: [
+				{
+					local: {
+						name: 'ReactDom',
+					},
+				},
+			],
+			source: {
+				value: 'react-dom',
+			},
+		} );
+
+		if ( importReactDom.size() ) {
+			removeImport( importReactDom );
+		}
+	}
 
 	// Add makeLayout and clientRender middlewares to route definitions
 	const routeDefs = root

--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -273,6 +273,13 @@ export default function transformer( file, api ) {
 	if ( ! reactDomDefs.size() ) {
 		root
 			.find( j.ImportDeclaration, {
+				specifiers: [
+					{
+						local: {
+							name: 'ReactDom',
+						},
+					},
+				],
 				source: {
 					value: 'react-dom',
 				},

--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -101,10 +101,11 @@ export default function transformer( file, api ) {
 		if ( comments.length ) {
 			const isRemovedExternal = isExternal( node );
 
-			// Find internal dependencies and place comment above first one
+			// Find remaining external or internal dependencies and place comments above first one
 			root
 				.find( j.ImportDeclaration )
 				.filter( p => {
+					// Look for only imports that are same type as the removed import was
 					return isExternal( p.value ) === isRemovedExternal;
 				} )
 				.at( 0 )


### PR DESCRIPTION
_Related to PR #19494 "Single tree-rendering-issues"_

Removes instances of:
```js
ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
```
...but only if that `secondary` element selector present; we only care about un-mounting the sidebar. There's no need to sniff target element's name since there are no `unmountComponentAtNode`'s for `primary` element in the codebase, apart from [this workaround](https://github.com/Automattic/wp-calypso/blob/master/client/boot/project/wordpress-com.js#L275), which will be removed manually.

Codemod also removes un-used ReactDom imports (preserving comments above them).

## Testing
#### 1. Removing correct `unmountComponentAtNode`s
```bash
npm run codemod single-tree-rendering \
./client/post-editor/controller.js \
./client/my-sites/checkout/controller.jsx \
./client/jetpack-connect/controller.js
```
→ Removes `ReactDom.unmountComponentAtNode()`

#### 2. Shouldn't remove all `unmountComponentAtNode`s
```bash
npm run codemod single-tree-rendering ./client/lib/accept/index.js
```
→ Doesn't remove `ReactDom.unmountComponentAtNode()` because it doesn't have `secondary` element selector.

#### 3. Removes imports
```bash
npm run codemod single-tree-rendering ./client/my-sites/customize/controller.js
```
→ Stranded reactDom import is removed.


#### 4. Doesn't remove all imports
```bash
npm run codemod single-tree-rendering ./client/my-sites/plugins/plugin-list-header/index.jsx
```
→ Does not remove `import { findDOMNode } from 'react-dom';`

#### 5. Doesn't remove comments above removed imports
```bash
npm run codemod single-tree-rendering \
./client/auth/controller.js \
./client/me/happychat/index.jsx \
./client/my-sites/plans/current-plan/controller.jsx
```
→ Comments are preserved while imports are removed under them