### PR TITLE
Persistence: unify methods for adding schemata to reducers and update docs

### DIFF
--- a/client/state/README.md
+++ b/client/state/README.md
@@ -218,7 +218,7 @@ age( 23, { type: DESERIALIZE } ) === 23
 ```
 
 ### combineReducers( reducersObject )
-This has the same api as redux's famous combineReducers function. The only addition is that 
-each reducer is wrapped with `withSchemaValidation` which will perform validation on `DESERIALIZE`
-actions if a schema is present.  It returns initialState on both `SERIALIZE` and `DESERIALIZE` 
-if a schema is not present.
+This has a compatible function signature with redux's famous combineReducers function.
+The only addition is that each reducer is wrapped with `withSchemaValidation` which will perform
+validation on `DESERIALIZE` actions if a schema is present. It returns initialState on
+both `SERIALIZE` and `DESERIALIZE` if a schema is not present.

--- a/client/state/README.md
+++ b/client/state/README.md
@@ -17,6 +17,18 @@ const store = createReduxStore();
 
 All the application information and data in Calypso should go through this data flow. When you are creating a new module with new data requirements, you should add them to this global store.
 
+## Persistence
+When Calypso boots up it loads the last-known state out of persistent storage in the browser.
+If that state was saved from an old version of the reducer code it could be incompatible with the new state model.
+Over the course of time we've developed multiple ways for enforcing that the browser storage contains data
+of a compatible shape before deserializing.
+
+The first method was adding a json-schema as the third argument to `createReducer()`. This is now deprecated.
+A better method for adding a schema takes advantage of the fact that we have implemented our own version
+of `combineReducers()` that will check each reducer for a schema property and ensure the data shape is correct
+on deserialization.
+
+
 ## Utilities
 
 `state/utils.js` contains a number of helper utilities you may find useful in implementing your state subtree:
@@ -182,22 +194,11 @@ const hexNumbers = keyedReducer( 'counterId', hexPersister, [ DESERIALIZE, SERIA
 hexNumbers.hasCustomPersistence = true;
 ```
 
-### Persistence
-When Calypso boots up it loads the last-known state out of persistent storage in the browser.
-If that state was saved from an old version of the reducer code it could be incompatible with the new state model.
-Over the course of time we've developed multiple ways for enforcing that the browser storage contains data
-of a compatible shape before deserializing.
-
-The first method was adding a json-schema as the third argument to `createReducer()`. This is now deprecated.
-A better method for adding a schema takes advantage of the fact that we have implemented our own version
-of `combineReducers()` that will check each reducer for a schema property and ensure the data shape is correct
-on deserialization.
-
-#### withSchemaValidation( schema, reducer )
+### withSchemaValidation( schema, reducer )
 This helper takes in both a schema and a reducer and then produces a new reducer that
 conditionally loads the persisted state if it's shape is valid.
 
-##### Example
+#### Example
 
 ```js
 function ageReducer( state = 0, action ) {
@@ -216,7 +217,7 @@ age( -5, { type: DESERIALIZE } ) === 0
 age( 23, { type: DESERIALIZE } ) === 23
 ```
 
-#### combineReducers( reducersObject )
+### combineReducers( reducersObject )
 This has the same api as redux's famous combineReducers function. The only addition is that 
 each reducer is wrapped with `withSchemaValidation` which will perform validation on `DESERIALIZE`
 actions if a schema is present.  It returns initialState on both `SERIALIZE` and `DESERIALIZE` 

--- a/client/state/README.md
+++ b/client/state/README.md
@@ -188,14 +188,14 @@ If that state was saved from an old version of the reducer code it could be inco
 Over the course of time we've developed multiple ways for enforcing that the browser storage contains data
 of a compatible shape before deserializing.
 
-The first method was adding a json-schema as the third argument to `createReducer()`. This is now a deprecated
-method because it is relatively constrained in that it requires `createReducer()` to be the outermost function.
-The latest method for adding a schema takes advantage of the fact that we have implemented our own version
-of `combineReducers()` that will check each reducer for a schema property and ensure the data conforms on
-deserialization.
+The first method was adding a json-schema as the third argument to `createReducer()`. This is now deprecated.
+A better method for adding a schema takes advantage of the fact that we have implemented our own version
+of `combineReducers()` that will check each reducer for a schema property and ensure the data shape is correct
+on deserialization.
 
 #### withSchemaValidation( schema, reducer )
-This helper produces takes in a schema and a reducer and producers a new reducer that conditionally load the persisted state only if it's valid.
+This helper takes in both a schema and a reducer and then produces a new reducer that
+conditionally loads the persisted state if it's shape is valid.
 
 ##### Example
 
@@ -218,5 +218,6 @@ age( 23, { type: DESERIALIZE } ) === 23
 
 #### combineReducers( reducersObject )
 This has the same api as redux's famous combineReducers function. The only addition is that 
-each reducer is wrapped with `withSchemaValidation` which validates on `DESERIALIZE` if a schema is present and
-returns initial state on both `SERIALIZE` and `DESERIALIZE` if a schema is not present.
+each reducer is wrapped with `withSchemaValidation` which will perform validation on `DESERIALIZE`
+actions if a schema is present.  It returns initialState on both `SERIALIZE` and `DESERIALIZE` 
+if a schema is not present.

--- a/client/state/README.md
+++ b/client/state/README.md
@@ -192,7 +192,7 @@ hexNumbers.hasCustomPersistence = true;
 
 ### withSchemaValidation( schema, reducer )
 This helper takes in both a schema and a reducer and then produces a new reducer that
-conditionally loads the persisted state if it's shape is valid.
+conditionally loads the persisted state if its shape is valid.
 
 #### Example
 
@@ -214,5 +214,5 @@ age( 23, { type: DESERIALIZE } ) === 23
 ### combineReducers( reducersObject )
 A wrapper around Redux's `combineReducers()` which shares an identical function signature.
 The only addition is that each reducer is wrapped with `withSchemaValidation` which will perform
-validation on `DESERIALIZE` actions if a schema is present. It returns initialState on
+validation on `DESERIALIZE` actions if a schema is present. It returns `initialState` on
 both `SERIALIZE` and `DESERIALIZE` if a schema is not present.

--- a/client/state/README.md
+++ b/client/state/README.md
@@ -108,19 +108,15 @@ We are provided the opportunity to make straightforward tests without complicate
 #### Example
 
 ```js
-function age( state = 0, action ) {
-	if ( GROW === action.type ) {
-		return state + 1 
-	}
-	return state;
-}
+const age = ( state = 0, action ) =>
+	GROW === action.type
+		? state + 1 
+		: state;
 
-function title( state = 'grunt', action ) {
-	if ( PROMOTION === action.type ) {
-		return action.title
-	}
-	return state;
-}
+const title = ( state = 'grunt', action ) =>
+	PROMOTION === action.type
+		? action.title
+		: state;
 
 const userReducer = combineReducers( {
     age,
@@ -201,12 +197,10 @@ conditionally loads the persisted state if it's shape is valid.
 #### Example
 
 ```js
-function ageReducer( state = 0, action ) {
-	if ( GROW === action.type ) {
-		return state + 1;
-	}
-	return state;
-}
+const ageReducer = ( state = 0, action ) =>
+	GROW === action.type
+		? state + 1
+		: state;
 
 const schema = { type: 'number', minimum: 0 }
 

--- a/client/state/README.md
+++ b/client/state/README.md
@@ -19,7 +19,7 @@ All the application information and data in Calypso should go through this data 
 
 ## Persistence
 When Calypso boots up it loads the last-known state out of persistent storage in the browser.
-If that state was saved from an old version of the reducer code it could be incompatible with the new state model.
+If that state were saved from an old version of the reducer code it could be incompatible with the new state model.
 Over the course of time we've developed multiple ways for enforcing that the browser storage contains data
 of a compatible shape before deserializing.
 
@@ -218,7 +218,7 @@ age( 23, { type: DESERIALIZE } ) === 23
 ```
 
 ### combineReducers( reducersObject )
-This has a compatible function signature with redux's famous combineReducers function.
+A wrapper around Redux's `combineReducers()` which shares an identical function signature.
 The only addition is that each reducer is wrapped with `withSchemaValidation` which will perform
 validation on `DESERIALIZE` actions if a schema is present. It returns initialState on
 both `SERIALIZE` and `DESERIALIZE` if a schema is not present.

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -21,7 +21,7 @@ import {
  * Internal dependencies
  */
 import PostQueryManager from 'lib/query-manager/post';
-import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import {
 	EDITOR_START,
 	EDITOR_STOP,
@@ -281,15 +281,12 @@ export const queries = ( () => {
 				return mapValues( state, ( { data, options } ) => ( { data, options } ) );
 			},
 			[ DESERIALIZE ]: state => {
-				if ( ! isValidStateWithSchema( state, queriesSchema ) ) {
-					return {};
-				}
-
 				return mapValues( state, ( { data, options } ) => {
 					return new PostQueryManager( data, options );
 				} );
 			},
-		}
+		},
+		queriesSchema
 	);
 } )();
 

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -21,7 +21,7 @@ import {
  * Internal dependencies
  */
 import PostQueryManager from 'lib/query-manager/post';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
 import {
 	EDITOR_START,
 	EDITOR_STOP,
@@ -281,14 +281,18 @@ export const queries = ( () => {
 				return mapValues( state, ( { data, options } ) => ( { data, options } ) );
 			},
 			[ DESERIALIZE ]: state => {
+				if ( ! isValidStateWithSchema( state, queriesSchema ) ) {
+					return {};
+				}
+
 				return mapValues( state, ( { data, options } ) => {
 					return new PostQueryManager( data, options );
 				} );
 			},
-		},
-		queriesSchema
+		}
 	);
 } )();
+queries.hasCustomPersistence = true;
 
 /**
  * Returns the updated editor posts state after an action has been dispatched.

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -12,17 +12,15 @@ import {
 	READER_FEED_REQUEST_SUCCESS,
 	READER_FEED_REQUEST_FAILURE,
 	READER_FEED_UPDATE,
-	DESERIALIZE,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer, withSchemaValidation } from 'state/utils';
 import { decodeEntities } from 'lib/formatting';
 import { itemsSchema } from './schema';
 import { safeLink } from 'lib/post-normalizer/utils';
 
 const actionMap = {
 	[ SERIALIZE ]: handleSerialize,
-	[ DESERIALIZE ]: handleDeserialize,
 	[ READER_FEED_REQUEST_SUCCESS ]: handleRequestSuccess,
 	[ READER_FEED_REQUEST_FAILURE ]: handleRequestFailure,
 	[ READER_FEED_UPDATE ]: handleFeedUpdate,
@@ -35,13 +33,6 @@ function defaultHandler( state ) {
 function handleSerialize( state ) {
 	// remove errors from the serialized state
 	return omitBy( state, 'is_error' );
-}
-
-function handleDeserialize( state ) {
-	if ( isValidStateWithSchema( state, itemsSchema ) ) {
-		return state;
-	}
-	return {};
 }
 
 function handleRequestFailure( state, action ) {
@@ -84,10 +75,10 @@ function handleFeedUpdate( state, action ) {
 	return assign( {}, state, keyBy( feeds, 'feed_ID' ) );
 }
 
-export function items( state = {}, action ) {
+export const items = withSchemaValidation( itemsSchema, function( state = {}, action ) {
 	const handler = actionMap[ action.type ] || defaultHandler;
 	return handler( state, action );
-}
+} );
 
 export function queuedRequests( state = {}, action ) {
 	switch ( action.type ) {

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -12,17 +12,15 @@ import {
 	READER_SITE_REQUEST_SUCCESS,
 	READER_SITE_REQUEST_FAILURE,
 	READER_SITE_UPDATE,
-	DESERIALIZE,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer, withSchemaValidation } from 'state/utils';
 import { readerSitesSchema } from './schema';
 import { withoutHttp } from 'lib/url';
 import { decodeEntities } from 'lib/formatting';
 
 const actionMap = {
 	[ SERIALIZE ]: handleSerialize,
-	[ DESERIALIZE ]: handleDeserialize,
 	[ READER_SITE_REQUEST_SUCCESS ]: handleRequestSuccess,
 	[ READER_SITE_REQUEST_FAILURE ]: handleRequestFailure,
 	[ READER_SITE_UPDATE ]: handleSiteUpdate,
@@ -35,13 +33,6 @@ function defaultHandler( state ) {
 function handleSerialize( state ) {
 	// remove errors from the serialized state
 	return omitBy( state, 'is_error' );
-}
-
-function handleDeserialize( state ) {
-	if ( isValidStateWithSchema( state, readerSitesSchema ) ) {
-		return state;
-	}
-	return {};
 }
 
 function handleRequestFailure( state, action ) {
@@ -102,11 +93,10 @@ function handleSiteUpdate( state, action ) {
 	return assign( {}, state, keyBy( sites, 'ID' ) );
 }
 
-export function items( state = {}, action ) {
+export const items = withSchemaValidation( readerSitesSchema, ( state = {}, action ) => {
 	const handler = actionMap[ action.type ] || defaultHandler;
 	return handler( state, action );
-}
-items.hasCustomPersistence = true;
+} );
 
 export function queuedRequests( state = {}, action ) {
 	switch ( action.type ) {

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -18,7 +18,7 @@ import {
 	TERMS_REQUEST_SUCCESS,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import TermQueryManager from 'lib/query-manager/term';
 import { getSerializedTermsQuery } from './utils';
 import { queriesSchema } from './schema';
@@ -103,17 +103,14 @@ export const queries = createReducer(
 			} );
 		},
 		[ DESERIALIZE ]: state => {
-			if ( ! isValidStateWithSchema( state, queriesSchema ) ) {
-				return {};
-			}
-
 			return mapValues( state, taxonomies => {
 				return mapValues( taxonomies, ( { data, options } ) => {
 					return new TermQueryManager( data, options );
 				} );
 			} );
 		},
-	}
+	},
+	queriesSchema
 );
 
 export default combineReducers( {

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -18,7 +18,7 @@ import {
 	TERMS_REQUEST_SUCCESS,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
 import TermQueryManager from 'lib/query-manager/term';
 import { getSerializedTermsQuery } from './utils';
 import { queriesSchema } from './schema';
@@ -103,15 +103,19 @@ export const queries = createReducer(
 			} );
 		},
 		[ DESERIALIZE ]: state => {
+			if ( ! isValidStateWithSchema( state, queriesSchema ) ) {
+				return {};
+			}
+
 			return mapValues( state, taxonomies => {
 				return mapValues( taxonomies, ( { data, options } ) => {
 					return new TermQueryManager( data, options );
 				} );
 			} );
 		},
-	},
-	queriesSchema
+	}
 );
+queries.hasCustomPersistence = true;
 
 export default combineReducers( {
 	queries,

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -343,6 +343,7 @@ export const queries = ( () => {
 		}
 	);
 } )();
+queries.hasCustomPersistence = true;
 
 /**
  * Returns the updated themes last query state.

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -380,12 +380,15 @@ export const itemsSchema = {
 A JSON Schema must be provided if the subtree chooses to persist state. If we find that our persisted data doesn't
 match our described data shape, we should throw it out and rebuild that section of the tree with our default state.
 
-When using `createReducer` util you can pass a schema as a third param and all that will be handled for you.
+You can add a schema property to any reducer:
 ```javascript
 export const items = createReducer( defaultState, {
 	[THEMES_RECEIVE]: ( state, action ) => // ...
-}, itemsSchema );
+} );
+items.schema = itemsSchema;
 ```
+Note: we used to encourage passing in `itemsSchema` as a third parameter to createReducer.
+This is now deprecated because it is less flexible than adding a schema directly to any reducer.
 
 If you are not satisfied with the default handling, it is possible to implement your own `SERIALIZE` and
 `DESERIALIZE` action handlers in your reducers to customize data persistence. Always use a schema with your custom
@@ -393,7 +396,7 @@ handlers to avoid data shape errors.
 
 ### Opt-in to Persistence ( [#13542](https://github.com/Automattic/wp-calypso/pull/13542) )
 
-If we choose not to use `createReducer` we can opt-in to persistence by adding a schema as a property on the reducer.
+We can opt-in to persistence by adding a schema as a property on the reducer.
 We do this by combining all of our reducers using `combineReducers` from `state/utils` at every level of the tree instead
 of [combineReducers](http://redux.js.org/docs/api/combineReducers.html) from `redux`. Each reducer is then wrapped with
 `withSchemaValidation` which returns a wrapped reducer that validates on `DESERIALIZE` if a schema is present and

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -333,7 +333,7 @@ export const itemsSchema = {
 ```
 
 In order to [opt-in](https://github.com/Automattic/wp-calypso/pull/13542) to persistence,
-A JSON Schema must be provided as a property of the reducer.
+a JSON Schema must be provided as a property of the reducer.
 If we find that the shape of the persisted data doesn't match the schema, we throw it out
 and rebuild that section of the tree with its default state.
 


### PR DESCRIPTION
**summary**
Right now we have multiple ways of adding and validating schemas to reducers.  Since the addition of what I'd consider the most flexible method,  `thingReducer.schema = thingSchema`, I think it will be beneficial for us to unify both docs and implementation under a single method.

**changes in this pr**
1. modify some documentation functions to be friendlier to newcomers (remove ternaries, use classic `function` over arrow functions)
2. modify implementation of `createReducer()` to use `withSchemaValidation` under the hood.
3. update docs to no longer recommend passing schema as third argument to createReducer and label that as deprecated
4. [new] update docs to remove section about ImmutableJS and serialize/deserialize action types.

**faq**
Q: What makes `reducer.schema` better than `createReducer()`?
A: you can easily add schema validation to any reducer. not just those created with createReducer.

**Open question**
Is the most graceful way to test deserialization for reducers with `schema` to manually wrap the reducer with `withSchemaValidation` inside of the test file? Could we do jest magic to automatically run it on all reducers within a test environment?

