### PR TITLE
Domains: Strengthen the transferrable check

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -270,6 +270,7 @@ class TransferDomainStep extends React.Component {
 					return;
 				case domainAvailability.MAPPABLE:
 				case domainAvailability.MAPPED:
+				case domainAvailability.UNKNOWN:
 					if ( get( result, 'transferrable', error ) === true ) {
 						this.setState( { domain } );
 						return;


### PR DESCRIPTION
Make sure only TLDs allowed for registration can be transferred in.
Otherwise, show a notice that they can map it instead.

Made it on top of https://github.com/Automattic/wp-calypso/pull/19497. Once that is merged, just last commit.

Depends on D8251-code.