### PR TITLE
Post Editor: Reinstate styles lost on the wp-admin Revisions link

### DIFF
--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -44,7 +44,7 @@ class EditorRevisions extends Component {
 
 			return (
 				<a
-					className="editor-revisions"
+					className="editor-revisions__wpadmin-link"
 					href={ revisionsLink }
 					target="_blank"
 					rel="noopener noreferrer"

--- a/client/post-editor/editor-revisions/style.scss
+++ b/client/post-editor/editor-revisions/style.scss
@@ -8,6 +8,24 @@
 	width: 100vw;
 }
 
+.editor-revisions__wpadmin-link {
+	color: $gray-text;
+	cursor: pointer;
+	display: block;
+	font-size: 13px;
+	margin: 0 0 -16px;
+	padding: 16px 0;
+	text-align: left;
+	width: calc(100% + 32px);
+
+	.gridicon {
+		color: $gray-text;
+		margin-left: -2px;
+		margin-right: 8px;
+		vertical-align: bottom;
+	}
+}
+
 .editor-revisions-list__loading-placeholder {
 	@include placeholder(23%);
 }


### PR DESCRIPTION
This was missed in #19197 & just adds styles back to a more precisely-named class.

See [prior version](https://github.com/Automattic/wp-calypso/blob/4da70defac9d7edc70261d93ad6a03cacea98790/client/post-editor/editor-revisions/style.scss#L2-L16) of the css.

## To Test

* Load a post in the editor with some revisions -- i.e.  https://calypso.live/post/yoursitename.wordpress.com/1234
  * Layout & styling should be unaffected for the revisions modal & editor otherwise
* Repeat the above w/ the feature flag disabled -- add the following to the end of the URL: `?flags=-post-editor/revisions`
  * The layout of the Revisions portion in the `Post Settings | Status` editor sidebar should look like it did before #19197 was merged (see below)

### Desired layout

<img width="152" alt="screen shot 2017-11-13 at 6 13 01 pm" src="https://user-images.githubusercontent.com/1587282/32754357-63ec4880-c89e-11e7-944e-a9677446c2dc.png">

### Erroneous layout

<img width="186" alt="screen shot 2017-11-13 at 6 12 06 pm" src="https://user-images.githubusercontent.com/1587282/32755160-f7d3d808-c8a1-11e7-8f5a-0ecc264771d4.png">

