### PR TITLE
Post Editor: Fix wp-admin link to revisions

### DIFF
--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow } from 'lodash';
+import { flow, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -39,8 +39,8 @@ class EditorRevisions extends Component {
 		if ( adminUrl ) {
 			// This is what gets rendered in the sidebar
 			// @TODO take it out (& adminUrl too) when the feature flag is enabled
-			const lastRevision = revisions[ 0 ];
-			const revisionsLink = adminUrl + 'revision.php?revision=' + lastRevision;
+			const lastRevisionId = get( revisions, [ 0, 'id' ], 0 );
+			const revisionsLink = adminUrl + 'revision.php?revision=' + lastRevisionId;
 
 			return (
 				<a


### PR DESCRIPTION
We were concatenating an object to the end of the link instead of the revision id. 

This was missed in #19197 & this uses `_.get` to get the appropriate value.

## To Test

* Load a post in the editor with some revisions w/ the feature flag disabled -- e.g. https://calypso.live/post/yoursitename.wordpress.com/1234?flags=-post-editor/revisions
  * The link to revisions in the `Post Settings | Status` editor sidebar should work identically to the previous stage environment behavior... that is, opens `/wp-admin/revision.php?revision=9999` in a new tab