### PR TITLE
Post Editor: Reinstate guard against scrolling the window

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -51,6 +51,7 @@ import { editPost, receivePost, savePostSuccess } from 'state/posts/actions';
 import { getEditedPostValue, getPostEdits, isEditedPostDirty } from 'state/posts/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { hasBrokenSiteUserConnection, editedPostHasContent } from 'state/selectors';
+import { NESTED_SIDEBAR_NONE } from 'state/ui/editor/sidebar/constants';
 import EditorConfirmationSidebar from 'post-editor/editor-confirmation-sidebar';
 import EditorDocumentHead from 'post-editor/editor-document-head';
 import EditorPostTypeUnsupported from 'post-editor/editor-post-type-unsupported';
@@ -148,12 +149,17 @@ export const PostEditor = createReactClass( {
 		} );
 	},
 
-	componentDidUpdate() {
-		// NOTE: Make sure we scroll back to the top AND trigger a scroll
-		// event no matter the scroll position we're coming from.
-		// ( used to force-reset TinyMCE toolbar )
-		window.scrollTo( 0, 1 );
-		window.scrollTo( 0, 0 );
+	componentDidUpdate( prevProps ) {
+		if (
+			prevProps.nestedSidebarTarget !== NESTED_SIDEBAR_NONE &&
+			this.props.nestedSidebarTarget === NESTED_SIDEBAR_NONE
+		) {
+			// NOTE: Make sure we scroll back to the top AND trigger a scroll
+			// event no matter the scroll position we're coming from.
+			// ( used to force-reset TinyMCE toolbar )
+			window.scrollTo( 0, 1 );
+			window.scrollTo( 0, 0 );
+		}
 	},
 
 	componentWillUpdate( nextProps, nextState ) {


### PR DESCRIPTION
In #19197, this guard was inadvertently removed resulting in scrolls every time the editor updates.

We will probably be able to do away with the `componentDidUpdate` lifecycle method altogether, but this is a quick fix.

The conditional is [reinstated](https://github.com/Automattic/wp-calypso/blob/6419f56e2d6416ddccae6708f6cd68c2e85e1d8b/client/post-editor/post-editor.jsx#L162-L165) from the previous behavior, but in actuality probably never evaluates truthy.

## To Test

* Edit a post
* Append a lot of text such that the screen scrolls
* Save and move about the editor
* The window should not unexpectedly jump to the top