### PR TITLE
Domains: Remove the option to just fetch the auth code

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
@@ -43,21 +43,6 @@ class Locked extends React.Component {
 		} );
 	};
 
-	requestTransferCode() {
-		const options = {
-			siteId: this.props.selectedSite.ID,
-			domainName: this.props.selectedDomainName,
-			unlock: false,
-			disablePrivacy: false,
-		};
-
-		this.setState( { submitting: true } );
-		requestTransferCode( options, error => {
-			this.setState( { submitting: false } );
-			displayRequestTransferCodeResponseNotice( error, getSelectedDomain( this.props ) );
-		} );
-	}
-
 	isManualTransferRequired() {
 		return getSelectedDomain( this.props ).manualTransferRequired;
 	}
@@ -73,11 +58,6 @@ class Locked extends React.Component {
 			</p>
 		);
 	}
-
-	handleGiveMeTheCodeClick = event => {
-		event.preventDefault();
-		this.requestTransferCode();
-	};
 
 	render() {
 		const { translate } = this.props;
@@ -100,11 +80,6 @@ class Locked extends React.Component {
 								rel="noopener noreferrer"
 							>
 								{ translate( 'Learn More.' ) }
-							</a>
-						</p>
-						<p className="transfer__small-text">
-							<a href="" onClick={ this.handleGiveMeTheCodeClick }>
-								{ translate( 'I just want the transfer code for now.' ) }
 							</a>
 						</p>
 						{ this.isManualTransferRequired() && this.renderManualTransferInfo() }

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/style.scss
@@ -25,7 +25,3 @@
 		color: darken( $gray, 20% );
 	}
 }
-
-.transfer__small-text {
-	font-size: 12px;
-}


### PR DESCRIPTION
We've been giving the option to users to just request the auth code, when they want to transfer out domains, but it seems to be confusing them instead and actually _preventing_ them from transferring out domain. To be able to transfer out the domain, you _need_ to unlock the domain and remove privacy protection. However, by offering the option to just get the auth code, some users
might get confused and think it's enough to transfer out the domain.

### Testing
Before:
<img width="757" alt="screen shot 2017-11-14 at 00 51 03" src="https://user-images.githubusercontent.com/3392497/32757753-648c1660-c8e1-11e7-993d-002bb7450964.png">

After:
<img width="754" alt="screen shot 2017-11-14 at 00 51 20" src="https://user-images.githubusercontent.com/3392497/32757773-7fcae578-c8e1-11e7-96c6-51b14953cb4b.png">

Be sure to test that the only CTA now on that view is still working and allows starting the transfer out process.

cc @kelliepeterson @wensco @ehti 