### PR TITLE
Performance: Optimize `SitesList.markCollisions`

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -6,7 +6,7 @@
 
 import debugModule from 'debug';
 import store from 'store';
-import { assign, find, isEmpty, some } from 'lodash';
+import { assign, find, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -167,28 +167,23 @@ SitesList.prototype.createSiteObject = function( site ) {
 		return Site( site );
 	}
 };
+
 /**
  * Marks collisions between .com sites and Jetpack sites that have the same URL
  * Add the hasConflict attribute to .com sites that collide with Jetpack sites.
  *
  * @api private
  *
+ * @param {Object[]} sites mix of site objects
  */
 SitesList.prototype.markCollisions = function( sites ) {
-	sites.forEach( function( site, index, collisions ) {
-		var hasCollision;
+	const jetpackDomains = new Set();
 
-		if ( ! site.jetpack ) {
-			hasCollision = some( collisions, function( someSite ) {
-				return (
-					someSite.jetpack &&
-					site.ID !== someSite.ID &&
-					withoutHttp( site.URL ) === withoutHttp( someSite.URL )
-				);
-			} );
-			if ( hasCollision ) {
-				site.hasConflict = true;
-			}
+	sites.forEach( site => site.jetpack && jetpackDomains.add( withoutHttp( site.URL ) ) );
+
+	sites.forEach( site => {
+		if ( ! site.jetpack && jetpackDomains.has( withoutHttp( site.URL ) ) ) {
+			site.hasConflict = true;
 		}
 	} );
 };

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -18,8 +18,7 @@ import Searchable from 'lib/mixins/searchable';
 import Emitter from 'lib/mixins/emitter';
 import { isPlan } from 'lib/products-values';
 import userUtils from 'lib/user/utils';
-import { withoutHttp } from 'lib/url';
-
+import { markCollisions } from './utils';
 const debug = debugModule( 'calypso:sites-list' );
 
 /**
@@ -168,25 +167,7 @@ SitesList.prototype.createSiteObject = function( site ) {
 	}
 };
 
-/**
- * Marks collisions between .com sites and Jetpack sites that have the same URL
- * Add the hasConflict attribute to .com sites that collide with Jetpack sites.
- *
- * @api private
- *
- * @param {Object[]} sites mix of site objects
- */
-SitesList.prototype.markCollisions = function( sites ) {
-	const jetpackDomains = new Set();
-
-	sites.forEach( site => site.jetpack && jetpackDomains.add( withoutHttp( site.URL ) ) );
-
-	sites.forEach( site => {
-		if ( ! site.jetpack && jetpackDomains.has( withoutHttp( site.URL ) ) ) {
-			site.hasConflict = true;
-		}
-	} );
-};
+SitesList.prototype.markCollisions = markCollisions;
 
 /**
  * Parse data return from the API

--- a/client/lib/sites-list/test/list.js
+++ b/client/lib/sites-list/test/list.js
@@ -1,0 +1,74 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { markCollisions } from '../utils';
+
+describe( 'markCollisions', () => {
+	test( 'should mark non-Jetpack sites as conflicting by domain', () => {
+		const sites = [ { URL: 'https://example.com', jetpack: true }, { URL: 'https://example.com' } ];
+
+		markCollisions( sites );
+
+		expect( sites[ 0 ] ).not.toHaveProperty( 'hasConflict' );
+		expect( sites[ 1 ] ).toHaveProperty( 'hasConflict', true );
+	} );
+
+	test( 'should not depend on input ordering', () => {
+		const sites = [ { URL: 'https://example.com' }, { URL: 'https://example.com', jetpack: true } ];
+
+		markCollisions( sites );
+
+		expect( sites[ 0 ] ).toHaveProperty( 'hasConflict', true );
+		expect( sites[ 1 ] ).not.toHaveProperty( 'hasConflict' );
+	} );
+
+	test( 'should not mark collisions from only non-Jetpack sites', () => {
+		const sites = [ { URL: 'https://example.com' }, { URL: 'https://example.com' } ];
+
+		markCollisions( sites );
+
+		expect( sites[ 0 ] ).not.toHaveProperty( 'hasConflict' );
+		expect( sites[ 1 ] ).not.toHaveProperty( 'hasConflict' );
+	} );
+
+	test( 'should not mark collisions from only Jetpack sites', () => {
+		const sites = [
+			{ URL: 'https://example.com', jetpack: true },
+			{ URL: 'https://example.com', jetpack: true },
+		];
+
+		markCollisions( sites );
+
+		expect( sites[ 0 ] ).not.toHaveProperty( 'hasConflict' );
+		expect( sites[ 1 ] ).not.toHaveProperty( 'hasConflict' );
+	} );
+
+	test( 'should ignore http/https differences', () => {
+		const sites = [ { URL: 'https://example.com', jetpack: true }, { URL: 'http://example.com' } ];
+
+		markCollisions( sites );
+
+		expect( sites[ 0 ] ).not.toHaveProperty( 'hasConflict' );
+		expect( sites[ 1 ] ).toHaveProperty( 'hasConflict', true );
+	} );
+
+	test( 'should not let cache break new calculations', () => {
+		const before = [
+			{ URL: 'https://example.com', jetpack: true },
+			{ URL: 'https://example.com' },
+		];
+
+		markCollisions( before );
+
+		expect( before[ 0 ] ).not.toHaveProperty( 'hasConflict' );
+		expect( before[ 1 ] ).toHaveProperty( 'hasConflict', true );
+
+		const after = [ { URL: 'https://example.net', jetpack: true }, { URL: 'https://example.com' } ];
+
+		markCollisions( after );
+
+		expect( after[ 0 ] ).not.toHaveProperty( 'hasConflict' );
+		expect( after[ 1 ] ).not.toHaveProperty( 'hasConflict' );
+	} );
+} );

--- a/client/lib/sites-list/utils.js
+++ b/client/lib/sites-list/utils.js
@@ -1,0 +1,39 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { withoutHttp } from 'lib/url';
+
+/**
+ * Marks collisions between .com sites and Jetpack sites that have the same URL
+ * Add the hasConflict attribute to .com sites that collide with Jetpack sites.
+ *
+ * A site collides if it's a non-Jetpack site which
+ * shares the same domain with another Jetpack site
+ *
+ * These occur due to sites _becoming_ Jetpack sites
+ * after they started out otherwise, subsuming the
+ * domain names assigned to the previous site.
+ *
+ * Mutates given input list of sites!
+ *
+ * @api private
+ * @see client/state/sites/selectors#getSiteCollisions
+ * @param {Object[]} sites mix of site objects
+ */
+export function markCollisions( sites ) {
+	const jetpackDomains = new Set();
+
+	sites.forEach( site => site.jetpack && jetpackDomains.add( withoutHttp( site.URL ) ) );
+
+	// no need to iterate; no Jetpack sites means no collisions
+	if ( jetpackDomains.size === 0 ) {
+		return;
+	}
+
+	sites.forEach( site => {
+		if ( ! site.jetpack && jetpackDomains.has( withoutHttp( site.URL ) ) ) {
+			site.hasConflict = true;
+		}
+	} );
+}


### PR DESCRIPTION
In this patch I have rewritten `markCollisions` with performance in
mind. Recently we were investigating freezes in Calypso (#19446) and
noticed that `SitesList.sync()` was getting called over and over again
and that this particular part of that process, a quadric operation in
terms of complexity, was potentially a big part of our CPU usage.

Although I could not reproduce the freezing behavior I went ahead and
tried to refactor this function so that it would remain linear with the
number of sites (well, it's `O( 2 * N )` now because it iterates twice).

The major change is storing the known Jetpack sites by URL in a mutable
map for quick retrieval. A quick pass can add in the jetpack sites then
a second pass can quickly determine if there are non-matching sites
sharing the same URL.

That is to say, we have replaced loop iteration with key lookup.

In my tests this was more than a magnitude in improvement, but overall
insignificant because I was only seeing this function take up 4-5ms on
average to run, plus it only ran a few times. (the function after these
changes was taking about 0.25ms)

If, however, we get into a loop and call this function a few hundred
times (as appears to have happened in a performance trace) then we could
end up shaving off a few hundred milliseconds of freeze time which
_would indeed_ be noticeable.

**Testing**

When I was running this locally I actually compared the two algorithms to
make sure that I was marking the identical set of sites for the old one as
I was with the new one. I removed the code from the checked-in code for
the obvious reason that it doesn't belong in production.

Scan through the list of sites and make sure that their domains look like
they are appropriate. I might lean on @enejb for some help understanding
how to best test this out and what setup we might need (like specific
combinations of sites/jetpack sites).