### PR TITLE
Post Revisions: Reconcile styling & placement of History & Save buttons

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -214,6 +214,7 @@ export class EditorGroundControl extends PureComponent {
 
 		return (
 			<div className="editor-ground-control__quick-save">
+				{ hasRevisions && <HistoryButton loadRevision={ loadRevision } /> }
 				{ showingSaveStatus && (
 					<div className="editor-ground-control__status">
 						{ isSaveAvailable && (
@@ -236,7 +237,6 @@ export class EditorGroundControl extends PureComponent {
 							) }
 					</div>
 				) }
-				{ hasRevisions && <HistoryButton loadRevision={ loadRevision } /> }
 			</div>
 		);
 	}

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -156,9 +156,9 @@
 	display: none;
 }
 
+.editor-ground-control__history-button.button.is-link,
 .editor-ground-control__save.button.is-link,
 .editor-ground-control__save-status {
-	text-decoration: underline;
 	font-size: 13px;
 }
 


### PR DESCRIPTION
## This PR
- makes styling of the History & Save buttons consistent
- swaps around the position of the History & Save buttons

## How to test
1.) Click `Write` and start a new post
2.) Compare to expected states outlined below when adding new content to the post

**Expected:**

_Unsaved State_
<img width="294" alt="screen shot 2017-11-13 at 20 04 47" src="https://user-images.githubusercontent.com/1562646/32759720-96184478-c8b0-11e7-8a6b-3a91ef95fb54.png">

_Saving... once hitting Save_
<img width="315" alt="screen shot 2017-11-13 at 20 05 03" src="https://user-images.githubusercontent.com/1562646/32759725-9e04c33c-c8b0-11e7-8121-ed2029866224.png">

_Saved_
<img width="311" alt="screen shot 2017-11-13 at 20 04 29" src="https://user-images.githubusercontent.com/1562646/32759732-a6732914-c8b0-11e7-88b6-576b666f8a19.png">

No save button when editing existing posts
<img width="329" alt="screen shot 2017-11-13 at 20 06 14" src="https://user-images.githubusercontent.com/1562646/32759739-ac56244e-c8b0-11e7-9dbc-af5a06eea475.png">


## Reasoning behind visual updates

/pasted from Slack

```
Not sure there's a good solution to the "push to the right" issue. While we could size the save element so it always takes up enough space to host the largest of the save button states, this looks odd. Especially once you look at other languages where the three states vary considerably in length. Then suddenly there's a huge gap between Save and History.

So there might be only two real options: a) flip the button positions (History first, then save) or b) leave it as it is.

Personally, I'd flip the positions around. The Save grabs more attention when it's on the right, which imo makes sense given that it's the one that's used more often. In addition, it's more consistent with the Edit existing state where there is no save button atm.
```