### PR TITLE
Post Revisions: Hide scrollbars on post revisions

### DIFF
--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -32,15 +32,16 @@
 	white-space: pre-wrap;
 	padding: 0;
 	background: transparent;
+	overflow-y: hidden;
 }
 
 .editor-diff-viewer__additions {
-	background: lighten( $blue-wordpress, 58% );
+	background: lighten($blue-wordpress, 58%);
 	border-bottom: 2px solid $blue-wordpress;
 }
 
 .editor-diff-viewer__deletions {
-	background: lighten( $alert-red, 38% );
+	background: lighten($alert-red, 38%);
 	border-bottom: 2px solid $alert-red;
 	text-decoration: line-through;
 }

--- a/client/post-editor/editor-revisions/style.scss
+++ b/client/post-editor/editor-revisions/style.scss
@@ -1,6 +1,7 @@
 /** @format */
 .editor-revisions__dialog {
 	padding: 0;
+	overflow-x: hidden;
 }
 
 .editor-revisions__wrapper {


### PR DESCRIPTION
## This PR
- fixes an issue where unwanted scrollbars would appear in the post revisions modal

## How to test

1. Open https://calypso.live/?branch=update/post-revisions-modal-scrollbars in Firefox
2. Navigate to a post with revisions
3. Click on History to open the post revisions modal
4. Confirm that the scrollbars described in **Before** below are gone
5. Confirm that everything else in the revisions modal still works as expected

**Before**

For the before state see the [following comment](https://github.com/Automattic/wp-calypso/pull/19197#issuecomment-343162928).

**After**

<img width="1108" alt="screen shot 2017-11-13 at 22 42 31" src="https://user-images.githubusercontent.com/1562646/32763245-24c320e0-c8c4-11e7-8f0e-633eb99033a1.png">

