### PR TITLE
 PostItem: Remove unused props

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -145,16 +145,16 @@ class PostItem extends React.Component {
 								</a>
 							) }
 							{ ! isPlaceholder &&
-								externalPostLink && (
-									<ExternalLink
-										icon={ true }
-										href={ postUrl }
-										target="_blank"
-										className="post-item__title-link"
-									>
-										{ title || translate( 'Untitled' ) }
-									</ExternalLink>
-								) }
+							externalPostLink && (
+								<ExternalLink
+									icon={ true }
+									href={ postUrl }
+									target="_blank"
+									className="post-item__title-link"
+								>
+									{ title || translate( 'Untitled' ) }
+								</ExternalLink>
+							) }
 						</h1>
 						<div className="post-item__meta">
 							<PostTime globalId={ globalId } />

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -106,8 +106,6 @@ class PostItem extends React.Component {
 			globalId,
 			isAllSitesModeSelected,
 			translate,
-			largeTitle,
-			wrapTitle,
 		} = this.props;
 
 		const title = post ? post.title : null;
@@ -116,8 +114,6 @@ class PostItem extends React.Component {
 		const panelClasses = classnames( 'post-item__panel', className, {
 			'is-untitled': ! title,
 			'is-placeholder': isPlaceholder,
-			'has-large-title': largeTitle,
-			'has-wrapped-title': wrapTitle,
 		} );
 
 		const arePostsCondensed =
@@ -188,8 +184,6 @@ PostItem.propTypes = {
 	compact: PropTypes.bool,
 	isCurrentSharePanelOpen: PropTypes.bool,
 	hideSharePanel: PropTypes.func,
-	largeTitle: PropTypes.bool,
-	wrapTitle: PropTypes.bool,
 };
 
 export default connect(

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -36,10 +36,7 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	align-items: center;
 	padding: 0 16px;
 
-	min-height: 84px;
-	&.has-large-title {
-		min-height: 89px;
-	}
+	min-height: 89px;
 
 	@include breakpoint( ">480px" ) {
 		padding: 0 24px;
@@ -76,14 +73,6 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	.post-item__card.is-mini & {
 		padding: 12px 0;
 	}
-
-	.post-item__panel:not( .has-wrapped-title ) & {
-		overflow: hidden;
-		&::after {
-			@include long-content-fade( $size: 40px );
-			right: 0;
-		}
-	}
 }
 
 .post-item__info {
@@ -102,15 +91,8 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	@extend %content-font;
 	margin-bottom: 2px;
 	font-weight: 700;
-
-	.post-item__panel.has-large-title & {
-		font-size: 20px;
-		line-height: 1.2;
-	}
-
-	.post-item__panel:not( .has-wrapped-title ) & {
-		white-space: nowrap;
-	}
+	font-size: 20px;
+	line-height: 1.2;
 }
 
 a.post-item__title-link,

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -41,8 +41,6 @@ class PostTypeList extends Component {
 	static propTypes = {
 		// Props
 		query: PropTypes.object,
-		largeTitles: PropTypes.bool,
-		wrapTitles: PropTypes.bool,
 		scrollContainer: PropTypes.object,
 
 		// Connected props
@@ -184,7 +182,7 @@ class PostTypeList extends Component {
 	}
 
 	renderPlaceholder() {
-		return <PostItem key="placeholder" largeTitle={ this.props.largeTitles } />;
+		return <PostItem key="placeholder" />;
 	}
 
 	renderPost( post ) {
@@ -195,8 +193,6 @@ class PostTypeList extends Component {
 			<PostItem
 				key={ globalId }
 				globalId={ globalId }
-				largeTitle={ this.props.largeTitles }
-				wrapTitle={ this.props.wrapTitles }
 				singleUserQuery={ query && !! query.author }
 			/>
 		);

--- a/client/my-sites/posts/post-list-wrapper.jsx
+++ b/client/my-sites/posts/post-list-wrapper.jsx
@@ -42,21 +42,18 @@ class PostListWrapper extends React.Component {
 			query.meta = 'counts';
 		}
 
-		return (
-			<PostTypeList
-				query={ query }
-				scrollContainer={ document.body }
-			/>
-		);
+		return <PostTypeList query={ query } scrollContainer={ document.body } />;
 	}
 
 	render() {
 		return (
 			<div>
 				{ config.isEnabled( 'posts/post-type-list' ) &&
-				abtest( 'condensedPostList' ) === 'condensedPosts'
-					? this.renderPostTypeList()
-					: this.renderPostList() }
+				abtest( 'condensedPostList' ) === 'condensedPosts' ? (
+					this.renderPostTypeList()
+				) : (
+					this.renderPostList()
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/posts/post-list-wrapper.jsx
+++ b/client/my-sites/posts/post-list-wrapper.jsx
@@ -45,8 +45,6 @@ class PostListWrapper extends React.Component {
 		return (
 			<PostTypeList
 				query={ query }
-				largeTitles={ true }
-				wrapTitles={ true }
 				scrollContainer={ document.body }
 			/>
 		);

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -88,7 +88,7 @@ class PostList extends PureComponent {
 
 		return (
 			<div>
-				<QueryPosts siteId={ siteId } query={ query } largeTitles={ true } wrapTitles={ true } />
+				<QueryPosts siteId={ siteId } query={ query } />
 				<ConnectedPosts
 					incrementPage={ this.incrementPage }
 					pathname={ context.pathname }

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -36,8 +36,6 @@ function Types( { siteId, query, postType, postTypeSupported, userCanEdit } ) {
 					<PostTypeList
 						key="list"
 						query={ userCanEdit ? query : null }
-						largeTitles={ true }
-						wrapTitles={ true }
 						scrollContainer={ document.body }
 					/>,
 				] }

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -31,14 +31,14 @@ function Types( { siteId, query, postType, postTypeSupported, userCanEdit } ) {
 			<PageViewTracker path={ siteId ? '/types/:site' : '/types' } title="Custom Post Type" />
 			<SidebarNavigation />
 			{ false !== userCanEdit &&
-				false !== postTypeSupported && [
-					<PostTypeFilter key="filter" query={ userCanEdit ? query : null } />,
-					<PostTypeList
-						key="list"
-						query={ userCanEdit ? query : null }
-						scrollContainer={ document.body }
-					/>,
-				] }
+			false !== postTypeSupported && [
+				<PostTypeFilter key="filter" query={ userCanEdit ? query : null } />,
+				<PostTypeList
+					key="list"
+					query={ userCanEdit ? query : null }
+					scrollContainer={ document.body }
+				/>,
+			] }
 			{ false === postTypeSupported && <PostTypeUnsupported type={ query.type } /> }
 			{ false === userCanEdit && <PostTypeForbidden /> }
 		</Main>


### PR DESCRIPTION
This PR removes the following props and CSS classes present in the posts listing for custom post types and for the [`condensedPostList` A/B test](https://github.com/Automattic/wp-calypso/pull/19676):

- `<PostItem largeTitle={ true } wrapTitle={ true } />`
- `<PostTypeList largeTitles={ true } wrapTitles={ true } />`
- `<QueryPosts largeTitles={ true } wrapTitles={ true } />` (This never did anything.)
- `.post-item__panel.has-large-title` and `.post-item__panel.has-wrapped-title`

These were introduced in https://github.com/Automattic/wp-calypso/pull/17550, but as of https://github.com/Automattic/wp-calypso/pull/19112 there are no other uses of `PostItem` or `PostTypeList`, so they are now unneeded (the props always have the value `true` and the CSS classes are always present).

To test, confirm no visual changes and no errors introduced by this PR.  You can also run some commands to check the codebase before and after the changes here:

```sh
# Verify no more uses of the props to be removed
git ls-files | xargs grep -Pi '(wrap|wrapped|large)-?title'
# Verify no unexpected uses of <PostItem> or <PostTypeList>
git ls-files | xargs grep -P '<(PostItem|PostTypeList)\b'
```

It may be easiest to review this PR one commit at a time - the second commit contains some unrelated formatting-only changes that our `calypso-prettier` formatter thinks should be applied.  As noted in the message for the second commit, I think it is better to stick to the conventions of our automatic formatter, and seek to change those conventions separately if there are issues.