### PR TITLE
Comments: enable sorting in staging environment

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -26,7 +26,7 @@
 		"code-splitting": true,
 		"comments/management": true,
 		"comments/management/jetpack-5.5": false,
-		"comments/management/sorting": false,
+		"comments/management/sorting": true,
 		"desktop-promo": true,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,


### PR DESCRIPTION
Enables comment sorting in staging environment.

### Testing instructions 

- You can follow the testing instructions in the PR that introduced the feature #18176.