### PR TITLE
Comments Redesign: Remove margins under 660px

### DIFF
--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -4,7 +4,7 @@
 
 .card.comment {
 	font-size: 14px;
-	margin: 10px auto;
+	margin: 0 auto;
 	padding: 0;
 
 	.accessible-focus &:focus {
@@ -18,8 +18,8 @@
 			0 1px 2px lighten($gray, 30%);
 	}
 
-	@include breakpoint( '<660px' ) {
-		margin: 0 auto;
+	@include breakpoint( '>660px' ) {
+		margin: 10px auto;
 	}
 }
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -18,7 +18,7 @@
 			0 1px 2px lighten($gray, 30%);
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint( '<660px' ) {
 		margin: 0 auto;
 	}
 }


### PR DESCRIPTION
The `Comment` vertical margin must be removed on small screens.
Previously though, they were removed at the `<960px` breakpoint, which was too wide.

This PR replaces it with a mobile-first approach: starting with no margins, and gaining them at `>660px`, which is the correct breakpoint.