### PR TITLE
Site-settings: correct the positioning of the Plan label in the sidebar 

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -23,3 +23,7 @@
 .notouch .sidebar__menu li.stats:hover:not(.selected) a:first-child:after  {
 	background: none;
 }
+
+.sidebar__menu-link-secondary-text {
+	top: 13px;
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/18893

This solution is based on a quick style fix. A more solid and sustainable in the long run solution is a follow-up, where we aim to extend and use the same component as the remaining sidebar entries. 

This patch should work on mobile as-is because it adds the `top` property to the existing styling, which takes care of the responsive behavior ( it is defined in the component we will use in the follow-up ). 

**To test:**
On any site with `My Sites` sidebar visible verify that:
- Plan label is aligned inside the Plan entry
- it follows the behavior of the parent component: text is blue "on hover" and white "on selection"
- works for a variety of screen-sizes