### PR TITLE
PostRevisions: Add translation contexts to "minor" and "cancel"

### DIFF
--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -70,7 +70,9 @@ class EditorRevisionsListItem extends PureComponent {
 
 					{ added === 0 &&
 						removed === 0 && (
-							<span className="editor-revisions-list__minor-changes">{ translate( 'minor' ) }</span>
+							<span className="editor-revisions-list__minor-changes">
+								{ translate( 'minor', { context: 'post revisions: minor changes' } ) }
+							</span>
 						) }
 				</div>
 			</button>

--- a/client/post-editor/editor-revisions/dialog.jsx
+++ b/client/post-editor/editor-revisions/dialog.jsx
@@ -85,7 +85,7 @@ class PostRevisionsDialog extends PureComponent {
 				compact: true,
 				disabled: ! ( revision && postId && siteId ),
 				isPrimary: true,
-				label: translate( 'Load' ),
+				label: translate( 'Load', { context: 'Load revision in editor' } ),
 				onClick: this.onLoadClick,
 			},
 		];


### PR DESCRIPTION
### Summary

This PR aims to address the ambiguous translations pointed out here: https://github.com/Automattic/wp-calypso/pull/19197#pullrequestreview-76354363 by adding context parameters to each case.

### Testing
No testing necessary, please just check that each is improved and that the messages given are useful :)