### PR TITLE
Editor: Remove redundant "is_shown" class on content

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -363,7 +363,7 @@ export const PostEditor = createReactClass( {
 								/>
 								<StatusLabel post={ this.state.savedPost } />
 							</div>
-							<div className={ 'post-editor__inner-content is-shown' }>
+							<div className="post-editor__inner-content">
 								<FeaturedImage
 									site={ site }
 									post={ this.state.post }

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -267,11 +267,3 @@
 		max-height: 400px;
 	}
 }
-
-.post-editor__inner-content {
-	display: none;
-
-	&.is-shown {
-		display: block;
-	}
-}


### PR DESCRIPTION
### Summary
Previously, `post-editor__inner-content` required a `is-shown` class to enable it to be hidden when the revision diff view was shown in it's place.
Since the revisions will now be shown in a modal there is no need to keep this class around and no reason to keep the `display:none`/`display:block` styling.

### Testing
- Open a post in the editor
- Make sure that the editor content is shown