### PR TITLE
Domains: Inbound Transfer Edit screen

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -66,6 +66,22 @@ function checkInboundTransferStatus( domainName, onComplete ) {
 	} );
 }
 
+function restartInboundTransfer( siteId, domainName, onComplete ) {
+	if ( ! domainName || ! siteId ) {
+		onComplete( null );
+		return;
+	}
+
+	wpcom.undocumented().restartInboundTransfer( siteId, domainName, function( serverError, result ) {
+		if ( serverError ) {
+			onComplete( serverError.error );
+			return;
+		}
+
+		onComplete( null, result );
+	} );
+}
+
 function canRedirect( siteId, domainName, onComplete ) {
 	if ( ! domainName ) {
 		onComplete( new ValidationError( 'empty_query' ) );
@@ -222,4 +238,5 @@ export {
 	isMappedDomain,
 	isRegisteredDomain,
 	isSubdomain,
+	restartInboundTransfer,
 };

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -566,6 +566,24 @@ Undocumented.prototype.getInboundTransferStatus = function( domain, fn ) {
 };
 
 /**
+ * Restarts a failed inbound domain transfer
+ *
+ * @param {int|string} siteId The site ID
+ * @param {string} domain The domain name
+ * @param {Function} fn The callback function
+ * @returns {Promise} A promise that resolves when the request completes
+ * @api public
+ */
+Undocumented.prototype.restartInboundTransfer = function( siteId, domain, fn ) {
+	return this.wpcom.req.get(
+		{
+			path: `/domains/${ encodeURIComponent( domain ) }/inbound-transfer-restart/${ siteId }`,
+		},
+		fn
+	);
+};
+
+/**
  * Determine whether a domain name can be used for Site Redirect
  *
  * @param {int|string} siteId The site ID

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -775,12 +775,13 @@ export class DomainWarnings extends React.PureComponent {
 		let compactMessage = null;
 		let message = translate( 'Transfer in Progress' );
 
+		const domainManagementLink = paths.domainManagementEdit(
+			this.props.selectedSite.slug,
+			domainInTransfer.name
+		);
+
 		const action = (
-			<NoticeAction
-				href={ paths.domainManagementEdit( this.props.selectedSite.slug, domainInTransfer ) }
-			>
-				{ translate( 'Fix' ) }
-			</NoticeAction>
+			<NoticeAction href={ domainManagementLink }>{ translate( 'Fix' ) }</NoticeAction>
 		);
 
 		switch ( domainInTransfer.transferStatus ) {
@@ -802,13 +803,11 @@ export class DomainWarnings extends React.PureComponent {
 				status = 'is-error';
 				compactMessage = translate( 'Domain transfer failed' );
 				message = translate(
-					'The transfer of {{strong}}%(domain)s{{/strong}} has been cancelled. We were unable to ' +
-						'verify the email address and authorization code within 7 days of the transfer request. ' +
-						'If you still want to transfer the domain you can {{a}}try again{{/a}}.',
+					'The transfer of {{strong}}%(domain)s{{/strong}} has failed. {{a}}More info{{/a}}',
 					{
 						components: {
 							strong: <strong />,
-							a: <a href="#" />,
+							a: <a href={ domainManagementLink } />,
 						},
 						args: { domain: domainInTransfer.name },
 					}

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -70,7 +70,7 @@ class Transfer extends React.PureComponent {
 		return (
 			<Card>
 				<div>
-					<p className="edit__transfer-text-fail">{ translate( 'Domain Transfer Failed' ) }</p>
+					<p className="edit__transfer-text-fail">{ translate( 'Domain transfer failed' ) }</p>
 					<p>
 						{ translate(
 							'We were unable to verify the transfer of {{strong}}%(domain)s{{/strong}}. The domain ' +

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -70,7 +70,7 @@ class Transfer extends React.PureComponent {
 		return (
 			<Card>
 				<div>
-					<p className="edit__transfer_text_fail">{ translate( 'Domain Transfer Failed' ) }</p>
+					<p className="edit__transfer-text-fail">{ translate( 'Domain Transfer Failed' ) }</p>
 					<p>
 						{ translate(
 							'We were unable to verify the transfer of {{strong}}%(domain)s{{/strong}}. The domain ' +
@@ -90,7 +90,7 @@ class Transfer extends React.PureComponent {
 					<Button onClick={ this.restartTransfer }>
 						{ this.props.translate( 'Start Transfer Again' ) }
 					</Button>
-					<Button className="edit__transfer_button_margin" href={ support.CALYPSO_CONTACT }>
+					<Button className="edit__transfer-button-margin" href={ support.CALYPSO_CONTACT }>
 						{ this.props.translate( 'Contact Support' ) }
 					</Button>
 				</div>

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -71,6 +71,7 @@ export class List extends React.Component {
 						'pendingGappsTosAcceptanceDomains',
 						'unverifiedDomainsCannotManage',
 						'wrongNSMappedDomains',
+						'transferStatus',
 					] }
 				/>
 			);

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -264,12 +264,12 @@ input[type=radio].domain-management-list-item__radio {
 		}
 	}
 
-	.edit__transfer_text_fail {
+	.edit__transfer-text-fail {
 		font-size: 18px;
 		font-weight: bold;
 	}
 
-	.edit__transfer_button_margin {
+	.edit__transfer-button-margin {
 		margin-left: 15px;
 	}
 }

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -263,6 +263,15 @@ input[type=radio].domain-management-list-item__radio {
 			cursor: pointer;
 		}
 	}
+
+	.edit__transfer_text_fail {
+		font-size: 18px;
+		font-weight: bold;
+	}
+
+	.edit__transfer_button_margin {
+		margin-left: 15px;
+	}
 }
 
 .domain-details-card__property {


### PR DESCRIPTION
Add a screen for failed transfer that allows users to
restart the transfer and contact support.

Update the domain warning.

![failed-edit-screen](https://user-images.githubusercontent.com/1103398/32785779-a66e8650-c952-11e7-9538-dbf7a130e967.png)

Test:
1. Start a domain transfer
2. Fail it on the backend
3. Try restarting
4. Check messaging
5. Try to properly restart the transfer.