### PR TITLE
Sites: improve memoization of the getSites selector

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -5,7 +5,6 @@
  */
 
 import {
-	assign,
 	compact,
 	every,
 	filter,
@@ -68,36 +67,44 @@ export const getSiteBySlug = createSelector(
 );
 
 /**
- * Returns a normalized site object by its ID. Intends to replicate
- * the site object returned from the legacy `sites-list` module.
- *
+ * Memoization cache for the `getSite` selector
+ */
+let getSiteCache = new WeakMap();
+
+/**
+ * Returns a normalized site object by its ID or site slug.
  *
  * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
+ * @param  {Number|String}  siteIdOrSlug Site ID or site slug
  * @return {?Object}        Site object
  */
-export const getSite = createSelector(
-	( state, siteId ) => {
-		let site =
-			getRawSite( state, siteId ) ||
-			// Support for non-ID site retrieval
-			// Replaces SitesList#getSite
-			getSiteBySlug( state, siteId );
+export function getSite( state, siteIdOrSlug ) {
+	const rawSite = getRawSite( state, siteIdOrSlug ) || getSiteBySlug( state, siteIdOrSlug );
+	if ( ! rawSite ) {
+		return null;
+	}
 
-		if ( ! site ) {
-			return null;
-		}
+	// Use the rawSite object itself as a WeakMap key
+	const cachedSite = getSiteCache.get( rawSite );
+	if ( cachedSite ) {
+		return cachedSite;
+	}
 
-		// To avoid mutating the original site object, create a shallow clone
-		// before assigning computed properties
-		site = { ...site };
-		assign( site, getSiteComputedAttributes( state, siteId ) );
-		assign( site, getJetpackComputedAttributes( state, siteId ) );
+	const site = {
+		...rawSite,
+		...getSiteComputedAttributes( state, rawSite.ID ),
+		...getJetpackComputedAttributes( state, rawSite.ID ),
+	};
 
-		return site;
-	},
-	state => [ state.sites.items, state.currentUser.capabilities ]
-);
+	// Once the `rawSite` object becomes outdated, i.e., state gets updated with a newer version
+	// and no more references are held, the key will be automatically removed from the WeakMap.
+	getSiteCache.set( rawSite, site );
+	return site;
+}
+
+getSite.clearCache = () => {
+	getSiteCache = new WeakMap();
+};
 
 export function getJetpackComputedAttributes( state, siteId ) {
 	if ( ! isJetpackSite( state, siteId ) ) {


### PR DESCRIPTION
A selector implemented using `createSelector` that has a `state.sites.items` dependenant will clear the memoization cache on every update of `state.sites.items`, even if only one site out of hundreds got updated and the rest are identical objects. That's inefficient. On a repeated `getSite( state, id )`, new site object will be computed, not `===`-identical to the old one, and many components that depend on it will do an unneeded rerender.

This patch rewrites the `getSite` selector to memoize a site object in a `WeakMap` cache until the source `rawSite` object really changes.

The selector no longer depends on `state.currentUser.capabilities`, as that is a structure that fully depends on `state.sites.items` and is populated and changed only by actions that change `state.sites.items` at the same time.

There are awesome performance benefits when doing `SitesList.sync` during initial load. Executing the function is 3 times faster (1100ms to 350ms) and the number of rerenders is more than 10 times smaller (4700 to 380).

Fixes a big part of #19446.

**How to test:**
1. Put some `console.log` statements with timings around the `this.sync( data );` in the `fetch` method in `client/lib/sites-list/list.js`.
2. Reload the page and check the timings with and without patch.
3. The "sympathy" step that avoids rehydrating the state from local storage has a big impact on the timing, too, so watch out for it.
