### PR TITLE
Comments Redesign: Fix pending style in bulk edit mode

### DIFF
--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -484,6 +484,9 @@
 		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten($gray, 20%);
 		z-index: z-index('root', '.card.comment.is-bulk-mode:hover');
 	}
+	&.is-pending:hover {
+		box-shadow: inset 4px 0 0 0 $alert-yellow, 0 0 0 1px $gray, 0 2px 4px lighten($gray, 20%);
+	}
 
 	a {
 		color: $gray-text-min;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -235,6 +235,7 @@
 }
 
 .comment__content-preview {
+	max-height: 42px;
 	overflow: hidden;
 	position: relative;
 
@@ -257,6 +258,7 @@
 }
 
 @supports (-webkit-line-clamp: 2) {
+	.comment .comment__content-preview,
 	.comment.is-pending .comment__content-preview {
 		display: -webkit-box;
 		-webkit-box-orient: vertical;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -248,9 +248,16 @@
 		width: 30%;
 	}
 }
+.comment.is-pending .comment__content-preview:after {
+	background: linear-gradient(
+		to right,
+		rgba(mix($alert-yellow, $white, 8.5%), 0),
+		rgba(mix($alert-yellow, $white, 8.5%), 1) 50%
+	);
+}
 
 @supports (-webkit-line-clamp: 2) {
-	.comment__content-preview {
+	.comment.is-pending .comment__content-preview {
 		display: -webkit-box;
 		-webkit-box-orient: vertical;
 		-webkit-line-clamp: 2;


### PR DESCRIPTION
This fixes some regressions of the Comments M3 design to old visual bugs in Bulk Edit Mode.

On browsers that don't support `line-clamp`, we apply a white gradient overlay to cut off the text in excess.
This PR sets a yellow overlay for pending comments to match their background color.

| Before | After |
| --- | --- |
| <img width="387" alt="screen shot 2017-11-14 at 16 54 01" src="https://user-images.githubusercontent.com/2070010/32793181-22e05fe2-c95d-11e7-9962-3e2b8320976c.png"> | <img width="388" alt="screen shot 2017-11-14 at 16 54 06" src="https://user-images.githubusercontent.com/2070010/32793193-283e8978-c95d-11e7-8b33-49c0f38f1845.png"> |

This also fixes a small glitch where the pending left border was lost on hover.

| Before | After |
| --- | --- |
| <img width="609" alt="screen shot 2017-11-14 at 17 06 56" src="https://user-images.githubusercontent.com/2070010/32793639-6e2d22f4-c95e-11e7-9b4b-1d6c1fb1abff.png"> | <img width="610" alt="screen shot 2017-11-14 at 17 06 34" src="https://user-images.githubusercontent.com/2070010/32793644-7288de88-c95e-11e7-8c01-c725f572e30c.png"> |

### Testing instructions

- Open `/comments/all` on Firefox.
- Switch to Bulk Edit Mode.
- Make sure that pending comments have a yellow gradient (and of course that non-pending comments have a white gradient instead).
- Open `/comments/pending` on any browser (including Firefox of course).
- Hover those comments and make sure they keep their big left yellow border.