### PR TITLE
Update/happychat/extract selectors

### DIFF
--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -18,7 +18,7 @@ import classnames from 'classnames';
  */
 import viewport from 'lib/viewport';
 import { getHappychatAuth } from 'state/happychat/utils';
-import { hasUnreadMessages } from 'state/happychat/selectors';
+import hasUnreadMessages from 'state/happychat/selectors/has-unread-messages';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import isHappychatConnectionUninitialized from 'state/happychat/selectors/is-happychat-connection-uninitialized';

--- a/client/components/happychat/composer.jsx
+++ b/client/components/happychat/composer.jsx
@@ -14,11 +14,10 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { sendMessage } from 'state/happychat/connection/actions';
+import { sendMessage, sendTyping, sendNotTyping } from 'state/happychat/connection/actions';
 import { setCurrentMessage } from 'state/happychat/ui/actions';
-import { sendTyping, sendNotTyping } from 'state/happychat/connection/actions';
 import getCurrentMessage from 'state/happychat/selectors/get-happychat-current-message';
-import { canUserSendMessages } from 'state/happychat/selectors';
+import canUserSendMessages from 'state/happychat/selectors/can-user-send-messages';
 import scrollbleed from './scrollbleed';
 
 const sendThrottledTyping = throttle(

--- a/client/state/happychat/middleware-calypso.js
+++ b/client/state/happychat/middleware-calypso.js
@@ -28,7 +28,7 @@ import {
 	SITE_SETTINGS_SAVE_SUCCESS,
 } from 'state/action-types';
 import { sendEvent, sendLog, sendPreferences } from 'state/happychat/connection/actions';
-import { getGroups } from './selectors';
+import getGroups from 'state/happychat/selectors/get-groups';
 import getSkills from 'state/happychat/selectors/get-skills';
 import isHappychatChatAssigned from 'state/happychat/selectors/is-happychat-chat-assigned';
 import isHappychatClientConnected from 'state/happychat/selectors/is-happychat-client-connected';

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -1,29 +1,20 @@
 /** @format */
+
 /**
  * External dependencies
  */
-import { get, includes, last } from 'lodash';
+import { get, last } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import {
-	HAPPYCHAT_GROUP_WPCOM,
-	HAPPYCHAT_GROUP_JPOP,
-	HAPPYCHAT_CHAT_STATUS_ABANDONED,
-	HAPPYCHAT_CHAT_STATUS_BLOCKED,
-	HAPPYCHAT_CHAT_STATUS_DEFAULT,
-	HAPPYCHAT_CHAT_STATUS_MISSED,
-	HAPPYCHAT_CHAT_STATUS_PENDING,
-} from './constants';
+import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from './constants';
 import { isEnabled } from 'config';
 import { isJetpackSite, getSite } from 'state/sites/selectors';
 import { isATEnabled } from 'lib/automated-transfer';
 import { getSectionName } from 'state/ui/selectors';
 import getHappychatTimeline from 'state/happychat/selectors/get-happychat-timeline';
-import getHappychatChatStatus from 'state/happychat/selectors/get-happychat-chat-status';
-import isHappychatClientConnected from 'state/happychat/selectors/is-happychat-client-connected';
 import getLostFocusTimestamp from 'state/happychat/selectors/get-lostfocus-timestamp';
 
 /**
@@ -54,26 +45,6 @@ export const getGroups = ( state, siteId ) => {
 	}
 	return groups;
 };
-
-/**
- * Returns true if the user should be able to send messages to operators based on
- * chat status. For example new chats and ongoing chats should be able to send messages,
- * but blocked or pending chats should not.
- * @param {Object} state - global redux state
- * @return {Boolean} Whether the user is able to send messages
- */
-export const canUserSendMessages = state =>
-	isHappychatClientConnected( state ) &&
-	! includes(
-		[
-			HAPPYCHAT_CHAT_STATUS_BLOCKED,
-			HAPPYCHAT_CHAT_STATUS_DEFAULT,
-			HAPPYCHAT_CHAT_STATUS_PENDING,
-			HAPPYCHAT_CHAT_STATUS_MISSED,
-			HAPPYCHAT_CHAT_STATUS_ABANDONED,
-		],
-		getHappychatChatStatus( state )
-	);
 
 export const hasUnreadMessages = createSelector(
 	state => {

--- a/client/state/happychat/selectors.js
+++ b/client/state/happychat/selectors.js
@@ -1,21 +1,13 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { get, last } from 'lodash';
-
-/**
  * Internal dependencies
  */
-import createSelector from 'lib/create-selector';
 import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from './constants';
 import { isEnabled } from 'config';
 import { isJetpackSite, getSite } from 'state/sites/selectors';
 import { isATEnabled } from 'lib/automated-transfer';
 import { getSectionName } from 'state/ui/selectors';
-import getHappychatTimeline from 'state/happychat/selectors/get-happychat-timeline';
-import getLostFocusTimestamp from 'state/happychat/selectors/get-lostfocus-timestamp';
 
 /**
  * Grab the group or groups for happychat based on siteId
@@ -45,19 +37,3 @@ export const getGroups = ( state, siteId ) => {
 	}
 	return groups;
 };
-
-export const hasUnreadMessages = createSelector(
-	state => {
-		const lastMessageTimestamp = get( last( getHappychatTimeline( state ) ), 'timestamp' );
-		const lostFocusAt = getLostFocusTimestamp( state );
-
-		return (
-			typeof lastMessageTimestamp === 'number' &&
-			typeof lostFocusAt === 'number' &&
-			// Message timestamps are reported in seconds. We need to multiply by 1000 to convert
-			// to milliseconds, so we can compare it to other JS-generated timestamps
-			lastMessageTimestamp * 1000 >= lostFocusAt
-		);
-	},
-	[ getHappychatTimeline, getLostFocusTimestamp ]
-);

--- a/client/state/happychat/selectors/can-user-send-messages.js
+++ b/client/state/happychat/selectors/can-user-send-messages.js
@@ -1,0 +1,40 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	HAPPYCHAT_CHAT_STATUS_ABANDONED,
+	HAPPYCHAT_CHAT_STATUS_BLOCKED,
+	HAPPYCHAT_CHAT_STATUS_DEFAULT,
+	HAPPYCHAT_CHAT_STATUS_MISSED,
+	HAPPYCHAT_CHAT_STATUS_PENDING,
+} from 'state/happychat/constants';
+
+import getHappychatChatStatus from 'state/happychat/selectors/get-happychat-chat-status';
+import isHappychatClientConnected from 'state/happychat/selectors/is-happychat-client-connected';
+
+/**
+ * Returns true if the user should be able to send messages to operators based on
+ * chat status. For example new chats and ongoing chats should be able to send messages,
+ * but blocked or pending chats should not.
+ * @param {Object} state - global redux state
+ * @return {Boolean} Whether the user is able to send messages
+ */
+export default state =>
+	isHappychatClientConnected( state ) &&
+	! includes(
+		[
+			HAPPYCHAT_CHAT_STATUS_BLOCKED,
+			HAPPYCHAT_CHAT_STATUS_DEFAULT,
+			HAPPYCHAT_CHAT_STATUS_PENDING,
+			HAPPYCHAT_CHAT_STATUS_MISSED,
+			HAPPYCHAT_CHAT_STATUS_ABANDONED,
+		],
+		getHappychatChatStatus( state )
+	);

--- a/client/state/happychat/selectors/get-groups.js
+++ b/client/state/happychat/selectors/get-groups.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from './constants';
+import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from 'state/happychat/constants';
 import { isEnabled } from 'config';
 import { isJetpackSite, getSite } from 'state/sites/selectors';
 import { isATEnabled } from 'lib/automated-transfer';
@@ -15,7 +15,7 @@ import { getSectionName } from 'state/ui/selectors';
  * @param {int} siteId The site id, if no siteId is present primary siteId will be used
  * @returns {array} of groups for site Id
  */
-export const getGroups = ( state, siteId ) => {
+export default ( state, siteId ) => {
 	const groups = [];
 
 	// For Jetpack Connect we need to direct chat users to the JPOP group, to account for cases

--- a/client/state/happychat/selectors/get-skills.js
+++ b/client/state/happychat/selectors/get-skills.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import { HAPPYCHAT_SKILL_PRODUCT, HAPPYCHAT_SKILL_LANGUAGE } from 'state/happychat/constants';
-import { getGroups } from 'state/happychat/selectors';
+import getGroups from 'state/happychat/selectors/get-groups';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 
 /**

--- a/client/state/happychat/selectors/has-unread-messages.js
+++ b/client/state/happychat/selectors/has-unread-messages.js
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get, last } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import getHappychatTimeline from 'state/happychat/selectors/get-happychat-timeline';
+import getLostFocusTimestamp from 'state/happychat/selectors/get-lostfocus-timestamp';
+
+export default createSelector(
+	state => {
+		const lastMessageTimestamp = get( last( getHappychatTimeline( state ) ), 'timestamp' );
+		const lostFocusAt = getLostFocusTimestamp( state );
+
+		return (
+			typeof lastMessageTimestamp === 'number' &&
+			typeof lostFocusAt === 'number' &&
+			// Message timestamps are reported in seconds. We need to multiply by 1000 to convert
+			// to milliseconds, so we can compare it to other JS-generated timestamps
+			lastMessageTimestamp * 1000 >= lostFocusAt
+		);
+	},
+	[ getHappychatTimeline, getLostFocusTimestamp ]
+);

--- a/client/state/happychat/selectors/test/can-user-send-messages.js
+++ b/client/state/happychat/selectors/test/can-user-send-messages.js
@@ -1,0 +1,90 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import {
+	HAPPYCHAT_CHAT_STATUS_ABANDONED,
+	HAPPYCHAT_CHAT_STATUS_ASSIGNED,
+	HAPPYCHAT_CHAT_STATUS_ASSIGNING,
+	HAPPYCHAT_CHAT_STATUS_BLOCKED,
+	HAPPYCHAT_CHAT_STATUS_CLOSED,
+	HAPPYCHAT_CHAT_STATUS_DEFAULT,
+	HAPPYCHAT_CHAT_STATUS_NEW,
+	HAPPYCHAT_CHAT_STATUS_MISSED,
+	HAPPYCHAT_CHAT_STATUS_PENDING,
+	HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED,
+	HAPPYCHAT_CONNECTION_STATUS_CONNECTED,
+} from 'state/happychat/constants';
+import canUserSendMessages from '../can-user-send-messages';
+
+describe( 'selectors', () => {
+	describe( '#canUserSendMessages', () => {
+		const messagingDisabledChatStatuses = [
+			HAPPYCHAT_CHAT_STATUS_ABANDONED,
+			HAPPYCHAT_CHAT_STATUS_BLOCKED,
+			HAPPYCHAT_CHAT_STATUS_DEFAULT,
+			HAPPYCHAT_CHAT_STATUS_MISSED,
+			HAPPYCHAT_CHAT_STATUS_PENDING,
+		];
+		const messagingEnabledChatStatuses = [
+			HAPPYCHAT_CHAT_STATUS_ASSIGNED,
+			HAPPYCHAT_CHAT_STATUS_ASSIGNING,
+			HAPPYCHAT_CHAT_STATUS_CLOSED,
+			HAPPYCHAT_CHAT_STATUS_NEW,
+		];
+
+		test( 'should return false if Happychat is not connected', () => {
+			const state = deepFreeze( {
+				happychat: {
+					connection: { status: HAPPYCHAT_CONNECTION_STATUS_UNINITIALIZED },
+					chat: { status: HAPPYCHAT_CHAT_STATUS_NEW },
+				},
+			} );
+			expect( canUserSendMessages( state ) ).toBeFalsy();
+		} );
+
+		test( "should return false if Happychat is connected but the chat status doesn't allow messaging", () => {
+			messagingDisabledChatStatuses.forEach( status => {
+				const state = deepFreeze( {
+					happychat: {
+						connection: { status: HAPPYCHAT_CONNECTION_STATUS_CONNECTED },
+						chat: { status },
+					},
+				} );
+				expect( canUserSendMessages( state ) ).toBeFalsy();
+			} );
+		} );
+
+		test( 'should return true if Happychat is connected and the chat status allows messaging', () => {
+			messagingEnabledChatStatuses.forEach( status => {
+				const state = deepFreeze( {
+					happychat: {
+						connection: { status: HAPPYCHAT_CONNECTION_STATUS_CONNECTED },
+						chat: { status },
+					},
+				} );
+				expect( canUserSendMessages( state ) ).toBeTruthy();
+			} );
+		} );
+
+		test( 'should return true even when isAvailable is false', () => {
+			// This test is here to prevent a code regression — isAvailable is supposed to
+			// determine whether Happychat is capable of starting new chats, and should not be
+			// a factor when determining if a user should be able to send messages to the service.
+			const state = deepFreeze( {
+				happychat: {
+					connection: { status: HAPPYCHAT_CONNECTION_STATUS_CONNECTED },
+					chat: { status: HAPPYCHAT_CHAT_STATUS_NEW },
+					isAvailable: false,
+				},
+			} );
+			expect( canUserSendMessages( state ) ).toBeTruthy();
+		} );
+	} );
+} );

--- a/client/state/happychat/selectors/test/get-groups.js
+++ b/client/state/happychat/selectors/test/get-groups.js
@@ -1,18 +1,13 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
-import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from '../constants';
-import { getGroups } from '../selectors';
 import { isEnabled } from 'config';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from 'state/happychat/constants';
 import { userState } from 'state/selectors/test/fixtures/user-state';
+import getGroups from '../get-groups';
 
 describe( 'selectors', () => {
 	describe( '#getGroups()', () => {
@@ -44,7 +39,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getGroups( state, siteId ) ).to.eql( [ HAPPYCHAT_GROUP_WPCOM ] );
+			expect( getGroups( state, siteId ) ).toMatchObject( [ HAPPYCHAT_GROUP_WPCOM ] );
 		} );
 
 		test( 'should return default group for no siteId', () => {
@@ -59,7 +54,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getGroups( state, siteId ) ).to.eql( [ HAPPYCHAT_GROUP_WPCOM ] );
+			expect( getGroups( state, siteId ) ).toMatchObject( [ HAPPYCHAT_GROUP_WPCOM ] );
 		} );
 
 		test( 'should return JPOP group for jetpack paid sites', () => {
@@ -88,7 +83,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getGroups( state, siteId ) ).to.eql( [ HAPPYCHAT_GROUP_JPOP ] );
+			expect( getGroups( state, siteId ) ).toMatchObject( [ HAPPYCHAT_GROUP_JPOP ] );
 		} );
 
 		test( 'should return WPCOM for AT sites group for jetpack site', () => {
@@ -115,7 +110,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( getGroups( state, siteId ) ).to.eql( [ HAPPYCHAT_GROUP_WPCOM ] );
+			expect( getGroups( state, siteId ) ).toMatchObject( [ HAPPYCHAT_GROUP_WPCOM ] );
 		} );
 
 		if ( isEnabled( 'jetpack/happychat' ) ) {
@@ -134,7 +129,7 @@ describe( 'selectors', () => {
 					},
 				};
 
-				expect( getGroups( state ) ).to.eql( [ HAPPYCHAT_GROUP_JPOP ] );
+				expect( getGroups( state ) ).toMatchObject( [ HAPPYCHAT_GROUP_JPOP ] );
 			} );
 		} else {
 			test.skip( 'should not return JPOP group if within the jetpackConnect section' );

--- a/client/state/happychat/selectors/test/has-unread-messages.js
+++ b/client/state/happychat/selectors/test/has-unread-messages.js
@@ -1,0 +1,59 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import hasUnreadMessages from '../has-unread-messages';
+
+// Simulate the time Feb 27, 2017 05:25 UTC
+const NOW = 1488173100125;
+
+describe( 'selectors', () => {
+	describe( '#hasUnreadMessages', () => {
+		const ONE_MINUTE = 1000 * 60;
+		const FIVE_MINUTES = ONE_MINUTE * 5;
+
+		// Need to convert timestamps to seconds, instead of milliseconds, because
+		// that's what the Happychat service provides
+		const timeline = [
+			{ timestamp: ( NOW - FIVE_MINUTES ) / 1000 },
+			{ timestamp: ( NOW - ONE_MINUTE ) / 1000 },
+			{ timestamp: NOW / 1000 },
+		];
+
+		test( 'returns false if Happychat is focused', () => {
+			const state = deepFreeze( {
+				happychat: {
+					chat: { timeline },
+					ui: { lostFocusAt: null },
+				},
+			} );
+			expect( hasUnreadMessages( state ) ).toBeFalsy();
+		} );
+
+		test( 'returns false if there are no new messages since the Happychat was blurred', () => {
+			const state = deepFreeze( {
+				happychat: {
+					chat: { timeline },
+					ui: { lostFocusAt: NOW + ONE_MINUTE },
+				},
+			} );
+			expect( hasUnreadMessages( state ) ).toBeFalsy();
+		} );
+
+		test( 'returns true if there are one or more messages after Happychat was blurred', () => {
+			const state = deepFreeze( {
+				happychat: {
+					chat: { timeline },
+					ui: { lostFocusAt: NOW - ONE_MINUTE - ONE_MINUTE },
+				},
+			} );
+			expect( hasUnreadMessages( state ) ).toBeTruthy();
+		} );
+	} );
+} );

--- a/client/state/happychat/test/middleware-calypso.js
+++ b/client/state/happychat/test/middleware-calypso.js
@@ -17,7 +17,7 @@ import getSkills from 'state/happychat/selectors/get-skills';
 import { selectSiteId } from 'state/help/actions';
 import { setRoute } from 'state/ui/actions';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
-import { getGroups } from 'state/happychat/selectors';
+import getGroups from 'state/happychat/selectors/get-groups';
 import { sendPreferences } from 'state/happychat/connection/actions';
 import {
 	HAPPYCHAT_CHAT_STATUS_ASSIGNED,

--- a/client/state/happychat/test/selectors.js
+++ b/client/state/happychat/test/selectors.js
@@ -4,64 +4,17 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
 import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from '../constants';
-import { hasUnreadMessages, getGroups } from '../selectors';
+import { getGroups } from '../selectors';
 import { isEnabled } from 'config';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
 import { userState } from 'state/selectors/test/fixtures/user-state';
 
-// Simulate the time Feb 27, 2017 05:25 UTC
-const NOW = 1488173100125;
-
 describe( 'selectors', () => {
-	describe( '#hasUnreadMessages', () => {
-		const ONE_MINUTE = 1000 * 60;
-		const FIVE_MINUTES = ONE_MINUTE * 5;
-
-		// Need to convert timestamps to seconds, instead of milliseconds, because
-		// that's what the Happychat service provides
-		const timeline = [
-			{ timestamp: ( NOW - FIVE_MINUTES ) / 1000 },
-			{ timestamp: ( NOW - ONE_MINUTE ) / 1000 },
-			{ timestamp: NOW / 1000 },
-		];
-
-		test( 'returns false if Happychat is focused', () => {
-			const state = deepFreeze( {
-				happychat: {
-					chat: { timeline },
-					ui: { lostFocusAt: null },
-				},
-			} );
-			expect( hasUnreadMessages( state ) ).to.be.false;
-		} );
-
-		test( 'returns false if there are no new messages since the Happychat was blurred', () => {
-			const state = deepFreeze( {
-				happychat: {
-					chat: { timeline },
-					ui: { lostFocusAt: NOW + ONE_MINUTE },
-				},
-			} );
-			expect( hasUnreadMessages( state ) ).to.be.false;
-		} );
-
-		test( 'returns true if there are one or more messages after Happychat was blurred', () => {
-			const state = deepFreeze( {
-				happychat: {
-					chat: { timeline },
-					ui: { lostFocusAt: NOW - ONE_MINUTE - ONE_MINUTE },
-				},
-			} );
-			expect( hasUnreadMessages( state ) ).to.be.true;
-		} );
-	} );
-
 	describe( '#getGroups()', () => {
 		let _window; // Keep a copy of the original window if any
 		const uiState = {

--- a/client/state/happychat/test/selectors.js
+++ b/client/state/happychat/test/selectors.js
@@ -10,18 +10,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import { HAPPYCHAT_GROUP_WPCOM, HAPPYCHAT_GROUP_JPOP } from '../constants';
-import {
-	HAPPYCHAT_CHAT_STATUS_ABANDONED,
-	HAPPYCHAT_CHAT_STATUS_ASSIGNED,
-	HAPPYCHAT_CHAT_STATUS_ASSIGNING,
-	HAPPYCHAT_CHAT_STATUS_BLOCKED,
-	HAPPYCHAT_CHAT_STATUS_CLOSED,
-	HAPPYCHAT_CHAT_STATUS_DEFAULT,
-	HAPPYCHAT_CHAT_STATUS_NEW,
-	HAPPYCHAT_CHAT_STATUS_MISSED,
-	HAPPYCHAT_CHAT_STATUS_PENDING,
-} from 'state/happychat/constants';
-import { canUserSendMessages, hasUnreadMessages, getGroups } from '../selectors';
+import { hasUnreadMessages, getGroups } from '../selectors';
 import { isEnabled } from 'config';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
 import { userState } from 'state/selectors/test/fixtures/user-state';
@@ -30,70 +19,6 @@ import { userState } from 'state/selectors/test/fixtures/user-state';
 const NOW = 1488173100125;
 
 describe( 'selectors', () => {
-	describe( '#canUserSendMessages', () => {
-		const messagingDisabledChatStatuses = [
-			HAPPYCHAT_CHAT_STATUS_ABANDONED,
-			HAPPYCHAT_CHAT_STATUS_BLOCKED,
-			HAPPYCHAT_CHAT_STATUS_DEFAULT,
-			HAPPYCHAT_CHAT_STATUS_MISSED,
-			HAPPYCHAT_CHAT_STATUS_PENDING,
-		];
-		const messagingEnabledChatStatuses = [
-			HAPPYCHAT_CHAT_STATUS_ASSIGNED,
-			HAPPYCHAT_CHAT_STATUS_ASSIGNING,
-			HAPPYCHAT_CHAT_STATUS_CLOSED,
-			HAPPYCHAT_CHAT_STATUS_NEW,
-		];
-
-		test( 'should return false if Happychat is not connected', () => {
-			const state = deepFreeze( {
-				happychat: {
-					connection: { status: 'uninitialized' },
-					chat: { status: HAPPYCHAT_CHAT_STATUS_NEW },
-				},
-			} );
-			expect( canUserSendMessages( state ) ).to.be.false;
-		} );
-
-		test( "should return false if Happychat is connected but the chat status doesn't allow messaging", () => {
-			messagingDisabledChatStatuses.forEach( status => {
-				const state = deepFreeze( {
-					happychat: {
-						connection: { status: 'connected' },
-						chat: { status },
-					},
-				} );
-				expect( canUserSendMessages( state ) ).to.be.false;
-			} );
-		} );
-
-		test( 'should return true if Happychat is connected and the chat status allows messaging', () => {
-			messagingEnabledChatStatuses.forEach( status => {
-				const state = deepFreeze( {
-					happychat: {
-						connection: { status: 'connected' },
-						chat: { status },
-					},
-				} );
-				expect( canUserSendMessages( state ) ).to.be.true;
-			} );
-		} );
-
-		test( 'should return true even when isAvailable is false', () => {
-			// This test is here to prevent a code regression — isAvailable is supposed to
-			// determine whether Happychat is capable of starting new chats, and should not be
-			// a factor when determining if a user should be able to send messages to the service.
-			const state = deepFreeze( {
-				happychat: {
-					connection: { status: 'connected' },
-					chat: { status: HAPPYCHAT_CHAT_STATUS_NEW },
-					isAvailable: false,
-				},
-			} );
-			expect( canUserSendMessages( state ) ).to.be.true;
-		} );
-	} );
-
 	describe( '#hasUnreadMessages', () => {
 		const ONE_MINUTE = 1000 * 60;
 		const FIVE_MINUTES = ONE_MINUTE * 5;

--- a/client/state/happychat/utils.js
+++ b/client/state/happychat/utils.js
@@ -5,7 +5,7 @@
  */
 import wpcom from 'lib/wp';
 import config from 'config';
-import { getGroups } from 'state/happychat/selectors';
+import getGroups from 'state/happychat/selectors/get-groups';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 import { getHelpSelectedSite } from 'state/help/selectors';
 import getSkills from 'state/happychat/selectors/get-skills';


### PR DESCRIPTION
Master issue https://github.com/Automattic/wp-calypso/issues/18670

This PR extracts the 3 remaining selectors from `state/happychat/selectors.js` to its own file.
