### PR TITLE
Store: Ensure Address.country Exists

### DIFF
--- a/client/extensions/woocommerce/state/sites/settings/general/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/selectors.js
@@ -89,7 +89,7 @@ export const getStoreLocation = ( state, siteId = getSelectedSiteId( state ) ) =
 
 	// WooCommerce uses country to hold both country and state (e.g. US:CT)
 	// let's fix that here
-	if ( address.country.indexOf( ':' ) ) {
+	if ( address.country && address.country.indexOf( ':' ) ) {
 		const parts = address.country.split( ':' );
 		address.country = parts[ 0 ];
 		address.state = parts[ 1 ];


### PR DESCRIPTION
A user contacted support today ( 1026195-hc ) that was stuck on the address screen during the setup screens in the dashboard. I was able to re-create the issue by performing the following steps:

__Steps to Re-create__
1- Create a new AT Site
2- Click Store, start the setup process
3- Once the store has been provisioned, go to WooCommerce settings in `wp-admin`. Set an address for the store - the address tested in this scenario happened to be from Canada... not certain if this affects US addresses or not, but guessing it doesn't matter. Save the settings.
4- Back in the Calypso setup flow, you should now be at the screen to enter a store address. Enter the same address as you did in step 3, click "Let's Go"
5- Note the following error will be thrown in the console:

![store_ _site_title_ _wordpress_com](https://user-images.githubusercontent.com/22080/32807238-1885695c-c944-11e7-8bbe-07bbbfaa60e5.png)

Apply this branch locally, and attempt step 4 again to verify the fix.