### PR TITLE
Discover: replace noticon with gridicon

### DIFF
--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -5,6 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -48,7 +49,7 @@ class DiscoverSiteAttribution extends React.Component {
 						height="20"
 					/>
 				) : (
-					<span className="noticon noticon-website" />
+					<Gridicon icon="globe" size={ 18 } />
 				) }
 				<span>
 					<a

--- a/client/reader/discover/style.scss
+++ b/client/reader/discover/style.scss
@@ -46,9 +46,8 @@
 		margin-right: 6px;
 	}
 
-	.noticon {
-		font-size: 20px;
-		height: 20px;
+	.gridicons-globe {
+		vertical-align: text-bottom;
 		background-color: lighten( $gray, 20% );
 		color: $white;
 		margin-right: 6px;


### PR DESCRIPTION
Context: noticons is deprecated and this is an effort to remove a few instances.

This PR replaces noticons with gridicons in the Reader, if the noticon is **not** being displayed via css (e.g. :before elements)

I found these instances by searching for `noticon` on Github and filtering by jsx files.

**Icons and icon placement might be slightly off, but I am prioritizing removal of noticons versus getting an exact 1:1 replacement. For example, the icon might be positioned slightly off, or we might not have an exact match for the icon.**

# Visual changes

Before|After
---|---
![discover before](https://user-images.githubusercontent.com/618551/32807876-fd3b4aa0-c956-11e7-8bf8-1f1a781c7ba7.png)|![discover after](https://user-images.githubusercontent.com/618551/32807862-f3d76494-c956-11e7-893f-65b321d9c3aa.png)

# Affected areas:

- Discover (client/reader/discover/site-attribution.jsx)

# What to test:

Look in Discover for a site that does not have an avatar. The fallback image in the site attribution should be the gridicon globe icon. I had to force the fallback image to show. I did not find a site with no avatar set.