### PR TITLE
Comments: delete querystring action update

### DIFF
--- a/client/components/data/moderate-comment/index.jsx
+++ b/client/components/data/moderate-comment/index.jsx
@@ -28,6 +28,7 @@ class ModerateComment extends Component {
 		newStatus: PropTypes.string,
 		currentStatus: PropTypes.string,
 		updateCommentStatus: PropTypes.func.isRequired,
+		redirectToPostView: PropTypes.func.isRequired,
 		destroyComment: PropTypes.func.isRequired,
 	};
 
@@ -54,6 +55,7 @@ class ModerateComment extends Component {
 		commentId,
 		newStatus,
 		currentStatus,
+		redirectToPostView,
 		updateCommentStatus,
 		destroyComment,
 	} ) {
@@ -63,6 +65,7 @@ class ModerateComment extends Component {
 
 		if ( 'delete' === newStatus ) {
 			destroyComment();
+			redirectToPostView( postId );
 			return;
 		}
 

--- a/client/components/data/moderate-comment/index.jsx
+++ b/client/components/data/moderate-comment/index.jsx
@@ -17,7 +17,7 @@ import {
 	recordTracksEvent,
 	withAnalytics,
 } from 'state/analytics/actions';
-import { changeCommentStatus, deleteComment } from 'state/comments/actions';
+import { changeCommentStatus } from 'state/comments/actions';
 import { getSiteComment } from 'state/selectors';
 
 class ModerateComment extends Component {
@@ -28,8 +28,6 @@ class ModerateComment extends Component {
 		newStatus: PropTypes.string,
 		currentStatus: PropTypes.string,
 		updateCommentStatus: PropTypes.func.isRequired,
-		redirectToPostView: PropTypes.func.isRequired,
-		destroyComment: PropTypes.func.isRequired,
 	};
 
 	componentDidMount() {
@@ -49,23 +47,15 @@ class ModerateComment extends Component {
 		this.moderate( nextProps );
 	}
 
-	moderate( {
-		siteId,
-		postId,
-		commentId,
-		newStatus,
-		currentStatus,
-		redirectToPostView,
-		updateCommentStatus,
-		destroyComment,
-	} ) {
-		if ( ! siteId || ! postId || ! commentId || ! newStatus || newStatus === currentStatus ) {
-			return;
-		}
-
-		if ( 'delete' === newStatus ) {
-			destroyComment();
-			redirectToPostView( postId );
+	moderate( { siteId, postId, commentId, newStatus, currentStatus, updateCommentStatus } ) {
+		if (
+			! siteId ||
+			! postId ||
+			! commentId ||
+			! newStatus ||
+			newStatus === currentStatus ||
+			'delete' === newStatus
+		) {
 			return;
 		}
 
@@ -96,16 +86,6 @@ const mapDispatchToProps = ( dispatch, { siteId, postId, commentId, newStatus } 
 					bumpStat( 'calypso_comment_management', 'comment_status_changed_to_' + newStatus )
 				),
 				changeCommentStatus( siteId, postId, commentId, newStatus )
-			)
-		),
-	destroyComment: () =>
-		dispatch(
-			withAnalytics(
-				composeAnalytics(
-					recordTracksEvent( 'calypso_comment_management_delete' ),
-					bumpStat( 'calypso_comment_management', 'comment_deleted' )
-				),
-				deleteComment( siteId, postId, commentId )
 			)
 		),
 } );

--- a/client/my-sites/comment/comment-delete-warning.jsx
+++ b/client/my-sites/comment/comment-delete-warning.jsx
@@ -1,0 +1,71 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { isUndefined } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
+import { deleteComment } from 'state/comments/actions';
+import { getSiteComment } from 'state/selectors';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+
+const CommentDeleteWarning = ( { isLoading, destroyComment, translate } ) =>
+	! isLoading && (
+		<Notice
+			status="is-warning"
+			showDismiss={ false }
+			text={ translate( 'Delete this comment permanently?' ) }
+		>
+			<NoticeAction icon="trash" onClick={ destroyComment }>
+				{ 'Delete Permanently' }
+			</NoticeAction>
+		</Notice>
+	);
+
+CommentDeleteWarning.propTypes = {
+	siteId: PropTypes.number,
+	postId: PropTypes.number,
+	commentId: PropTypes.number.isRequired,
+	destroyComment: PropTypes.func.isRequired,
+	redirectToPostView: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ( state, { siteId, commentId } ) => {
+	const comment = getSiteComment( state, siteId, commentId );
+
+	return {
+		isLoading: isUndefined( comment ),
+	};
+};
+
+const mapDispatchToProps = ( dispatch, { siteId, postId, commentId, redirectToPostView } ) => ( {
+	destroyComment: () => {
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_comment_management_delete' ),
+					bumpStat( 'calypso_comment_management', 'comment_deleted' )
+				),
+				deleteComment( siteId, postId, commentId )
+			)
+		);
+
+		redirectToPostView();
+	},
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentDeleteWarning ) );

--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -17,6 +17,7 @@ import DocumentHead from 'components/data/document-head';
 import ModerateComment from 'components/data/moderate-comment';
 import Comment from 'my-sites/comments/comment';
 import CommentPermalink from 'my-sites/comment/comment-permalink';
+import CommentDeleteWarning from 'my-sites/comment/comment-delete-warning';
 import CommentListHeader from 'my-sites/comments/comment-list/comment-list-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { preventWidows } from 'lib/formatting';
@@ -55,6 +56,9 @@ export class CommentView extends Component {
 						{ ...{ siteId, postId, commentId, newStatus: action, redirectToPostView } }
 					/>
 				) }
+				{ 'delete' === action && (
+					<CommentDeleteWarning { ...{ siteId, postId, commentId, redirectToPostView } } />
+				) }
 				<CommentListHeader { ...{ postId } } />
 				{ ! canModerateComments && (
 					<EmptyContent
@@ -67,7 +71,13 @@ export class CommentView extends Component {
 						illustration="/calypso/images/illustrations/illustration-500.svg"
 					/>
 				) }
-				{ canModerateComments && <Comment commentId={ commentId } refreshCommentData={ true } /> }
+				{ canModerateComments && (
+					<Comment
+						commentId={ commentId }
+						refreshCommentData={ true }
+						redirect={ redirectToPostView }
+					/>
+				) }
 				{ canModerateComments && <CommentPermalink { ...{ siteId, commentId } } /> }
 			</Main>
 		);
@@ -75,7 +85,7 @@ export class CommentView extends Component {
 }
 
 const mapStateToProps = ( state, ownProps ) => {
-	const { commentId, siteFragment } = ownProps;
+	const { commentId, redirectToPostView, siteFragment } = ownProps;
 
 	const siteId = getSiteId( state, siteFragment );
 	const comment = getSiteComment( state, siteId, commentId );
@@ -87,6 +97,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		siteId,
 		postId,
 		canModerateComments,
+		redirectToPostView: redirectToPostView( postId ),
 	};
 };
 

--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -30,11 +30,20 @@ export class CommentView extends Component {
 		commentId: PropTypes.number.isRequired,
 		action: PropTypes.string,
 		canModerateComments: PropTypes.bool.isRequired,
+		redirectToPostView: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
 	render() {
-		const { siteId, postId, commentId, action, canModerateComments, translate } = this.props;
+		const {
+			siteId,
+			postId,
+			commentId,
+			action,
+			canModerateComments,
+			redirectToPostView,
+			translate,
+		} = this.props;
 
 		return (
 			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
@@ -42,7 +51,9 @@ export class CommentView extends Component {
 				<PageViewTracker path="/comment/:site" title="Comments" />
 				<DocumentHead title={ translate( 'Comment' ) } />
 				{ canModerateComments && (
-					<ModerateComment { ...{ siteId, postId, commentId, newStatus: action } } />
+					<ModerateComment
+						{ ...{ siteId, postId, commentId, newStatus: action, redirectToPostView } }
+					/>
 				) }
 				<CommentListHeader { ...{ postId } } />
 				{ ! canModerateComments && (

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -45,6 +45,7 @@ export class CommentActions extends Component {
 		toggleEditMode: PropTypes.func,
 		toggleReply: PropTypes.func,
 		updateLastUndo: PropTypes.func,
+		redirect: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -31,6 +31,7 @@ export class Comment extends Component {
 		isBulkMode: PropTypes.bool,
 		isPostView: PropTypes.bool,
 		isSelected: PropTypes.bool,
+		redirect: PropTypes.func,
 		refreshCommentData: PropTypes.bool,
 		toggleSelected: PropTypes.func,
 		updateLastUndo: PropTypes.func,
@@ -97,6 +98,7 @@ export class Comment extends Component {
 			isLoading,
 			isPostView,
 			isSelected,
+			redirect,
 			refreshCommentData,
 			updateLastUndo,
 		} = this.props;
@@ -129,7 +131,7 @@ export class Comment extends Component {
 
 						{ ! isBulkMode && (
 							<CommentActions
-								{ ...{ siteId, postId, commentId, updateLastUndo } }
+								{ ...{ siteId, postId, commentId, redirect, updateLastUndo } }
 								toggleEditMode={ this.toggleEditMode }
 								toggleReply={ this.toggleReply }
 							/>

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -114,9 +114,11 @@ export const comment = context => {
 	}
 
 	const action = sanitizeQueryAction( query.action );
+	const redirectToPostView = postId =>
+		page.redirect( `/comments/all/${ siteFragment }/${ postId }` );
 
 	renderWithReduxStore(
-		<CommentView { ...{ action, commentId, siteFragment } } />,
+		<CommentView { ...{ action, commentId, siteFragment, redirectToPostView } } />,
 		'primary',
 		context.store
 	);

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -114,7 +114,7 @@ export const comment = context => {
 	}
 
 	const action = sanitizeQueryAction( query.action );
-	const redirectToPostView = postId =>
+	const redirectToPostView = postId => () =>
 		page.redirect( `/comments/all/${ siteFragment }/${ postId }` );
 
 	renderWithReduxStore(


### PR DESCRIPTION
Part of #18321

When the comment view receives a `delete` command, it will redirect the user to the post view.

![delete](https://user-images.githubusercontent.com/233601/32808978-de3a3716-c973-11e7-89dd-1dbb8389d74a.gif)

How to test:

* Start Calypso with `ENABLE_FEATURES=comments/management/m3-design npm start`
* Navigate to a comment
* append `?action=delete` to the querystring.
