### PR TITLE
Stats: add Tracks events to actions available after publishing post/page

### DIFF
--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import { withoutHttp } from 'lib/url';
 import ClipboardButton from 'components/forms/clipboard-button';
 import FormTextInput from 'components/forms/form-text-input';
@@ -54,6 +55,7 @@ class ClipboardButtonInputExport extends React.Component {
 				isCopied: false,
 			} );
 		}, 4000 );
+		analytics.tracks.recordEvent( 'calypso_editor_clipboard_button_url_copy' );
 	};
 
 	render() {

--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -87,9 +87,8 @@ class ClipboardButtonInputExport extends React.Component {
 	}
 }
 
-const wpcomEditorToolbarWebPreviewClipboardUrlButtonClick = () => {
+const wpcomEditorToolbarWebPreviewClipboardUrlButtonClick = () =>
 	composeAnalytics( recordTracksEvent( 'calypso_editor_clipboard_url_button_click', {} ) );
-};
 
 export default connect( null, {
 	wpcomEditorToolbarWebPreviewClipboardUrlButtonClick,

--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -17,7 +17,7 @@ import { connect } from 'react-redux';
 import { withoutHttp } from 'lib/url';
 import ClipboardButton from 'components/forms/clipboard-button';
 import FormTextInput from 'components/forms/form-text-input';
-import { composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
+import recordTracksEvent from 'state/analytics/actions';
 
 class ClipboardButtonInputExport extends React.Component {
 	constructor( props ) {
@@ -56,7 +56,7 @@ class ClipboardButtonInputExport extends React.Component {
 				isCopied: false,
 			} );
 		}, 4000 );
-		this.props.wpcomEditorToolbarWebPreviewClipboardUrlButtonClick();
+		this.props.recordTracksEvent( 'calypso_editor_clipboard_url_button_click' );
 	};
 
 	render() {
@@ -87,9 +87,6 @@ class ClipboardButtonInputExport extends React.Component {
 	}
 }
 
-const wpcomEditorToolbarWebPreviewClipboardUrlButtonClick = () =>
-	composeAnalytics( recordTracksEvent( 'calypso_editor_clipboard_url_button_click', {} ) );
-
 export default connect( null, {
-	wpcomEditorToolbarWebPreviewClipboardUrlButtonClick,
+	recordTracksEvent,
 } )( localize( ClipboardButtonInputExport ) );

--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -17,7 +17,7 @@ import { connect } from 'react-redux';
 import { withoutHttp } from 'lib/url';
 import ClipboardButton from 'components/forms/clipboard-button';
 import FormTextInput from 'components/forms/form-text-input';
-import recordTracksEvent from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class ClipboardButtonInputExport extends React.Component {
 	constructor( props ) {
@@ -66,7 +66,15 @@ class ClipboardButtonInputExport extends React.Component {
 		return (
 			<span className={ classes }>
 				<FormTextInput
-					{ ...omit( this.props, 'className', 'hideHttp', 'moment', 'numberFormat', 'translate' ) }
+					{ ...omit(
+						this.props,
+						'className',
+						'hideHttp',
+						'moment',
+						'numberFormat',
+						'translate',
+						'recordTracksEvent'
+					) }
 					value={ hideHttp ? withoutHttp( value ) : value }
 					type="text"
 					selectOnFocus

--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -9,14 +9,15 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { omit } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import { withoutHttp } from 'lib/url';
 import ClipboardButton from 'components/forms/clipboard-button';
 import FormTextInput from 'components/forms/form-text-input';
+import { composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 
 class ClipboardButtonInputExport extends React.Component {
 	constructor( props ) {
@@ -55,7 +56,7 @@ class ClipboardButtonInputExport extends React.Component {
 				isCopied: false,
 			} );
 		}, 4000 );
-		analytics.tracks.recordEvent( 'calypso_editor_clipboard_button_url_copy' );
+		this.props.wpcomEditorToolbarWebPreviewClipboardUrlButtonClick();
 	};
 
 	render() {
@@ -86,4 +87,10 @@ class ClipboardButtonInputExport extends React.Component {
 	}
 }
 
-export default localize( ClipboardButtonInputExport );
+const wpcomEditorToolbarWebPreviewClipboardUrlButtonClick = () => {
+	composeAnalytics( recordTracksEvent( 'calypso_editor_clipboard_url_button_click', {} ) );
+};
+
+export default connect( null, {
+	wpcomEditorToolbarWebPreviewClipboardUrlButtonClick,
+} )( localize( ClipboardButtonInputExport ) );

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -8,16 +8,17 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { partial } from 'lodash';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
 import ClipboardButtonInput from 'components/clipboard-button-input';
+import { composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 
 const possibleDevices = [ 'computer', 'tablet', 'phone' ];
 
@@ -53,12 +54,12 @@ class PreviewToolbar extends Component {
 		showSEO: true,
 	};
 
-	handleWebPreviewExternalClick = () => {
-		analytics.tracks.recordEvent( 'calypso_editor_preview_toolbar_external_click' );
+	handleEditorWebPreviewExternalClick = () => {
+		this.props.wpcomEditorToolbarWebPreviewExternalClick();
 	};
 
-	handleClosePreview = () => {
-		analytics.tracks.recordEvent( 'calypso_editor_preview_close_click' );
+	handleEditorWebPreviewClose = () => {
+		this.props.wpcomEditorToolbarWebPreviewClose();
 		this.props.onClose();
 	};
 
@@ -102,7 +103,7 @@ class PreviewToolbar extends Component {
 						aria-label={ translate( 'Close preview' ) }
 						className="web-preview__close"
 						data-tip-target="web-preview__close"
-						onClick={ this.handleClosePreview }
+						onClick={ this.handleEditorWebPreviewClose }
 					>
 						<Gridicon icon={ isModalWindow ? 'cross' : 'arrow-left' } />
 					</Button>
@@ -147,7 +148,7 @@ class PreviewToolbar extends Component {
 							href={ externalUrl || previewUrl }
 							target="_blank"
 							rel="noopener noreferrer"
-							onClick={ this.handleWebPreviewExternalClick }
+							onClick={ this.handleEditorWebPreviewExternalClick }
 						>
 							<Gridicon icon="external" />
 						</Button>
@@ -159,4 +160,15 @@ class PreviewToolbar extends Component {
 	}
 }
 
-export default localize( PreviewToolbar );
+const wpcomEditorToolbarWebPreviewExternalClick = () => {
+	composeAnalytics( recordTracksEvent( 'calypso_editor_preview_toolbar_external_click', {} ) );
+};
+
+const wpcomEditorToolbarWebPreviewClose = () => {
+	composeAnalytics( recordTracksEvent( 'calypso_editor_preview_close_click', {} ) );
+};
+
+export default connect( null, {
+	wpcomEditorToolbarWebPreviewExternalClick,
+	wpcomEditorToolbarWebPreviewClose,
+} )( localize( PreviewToolbar ) );

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -57,6 +57,11 @@ class PreviewToolbar extends Component {
 		analytics.tracks.recordEvent( 'calypso_editor_preview_toolbar_external_click' );
 	};
 
+	handleClosePreview = () => {
+		analytics.tracks.recordEvent( 'calypso_editor_preview_close_click' );
+		this.props.onClose();
+	};
+
 	constructor( props ) {
 		super();
 
@@ -74,7 +79,6 @@ class PreviewToolbar extends Component {
 			editUrl,
 			externalUrl,
 			isModalWindow,
-			onClose,
 			onEdit,
 			previewUrl,
 			setDeviceViewport,
@@ -87,12 +91,6 @@ class PreviewToolbar extends Component {
 			translate,
 		} = this.props;
 
-		// @todo: having trouble adding a Tracks event to the onClose event (see **HERE**)
-		// function handleClosePreview() {
-		// 	onClose;
-		// 	analytics.tracks.recordEvent( 'calypso_editor_preview_close_click' );
-		// }
-
 		const selectedDevice = this.devices[ currentDevice ];
 		const devicesToShow = showSEO ? possibleDevices.concat( 'seo' ) : possibleDevices;
 
@@ -104,7 +102,7 @@ class PreviewToolbar extends Component {
 						aria-label={ translate( 'Close preview' ) }
 						className="web-preview__close"
 						data-tip-target="web-preview__close"
-						onClick={ onClose } // **HERE**
+						onClick={ this.handleClosePreview }
 					>
 						<Gridicon icon={ isModalWindow ? 'cross' : 'arrow-left' } />
 					</Button>

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -18,7 +18,7 @@ import Button from 'components/button';
 import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
 import ClipboardButtonInput from 'components/clipboard-button-input';
-import recordTracksEvent from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const possibleDevices = [ 'computer', 'tablet', 'phone' ];
 

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -12,6 +12,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import SelectDropdown from 'components/select-dropdown';
@@ -52,6 +53,10 @@ class PreviewToolbar extends Component {
 		showSEO: true,
 	};
 
+	handleWebPreviewExternalClick = () => {
+		analytics.tracks.recordEvent( 'calypso_editor_preview_toolbar_external_click' );
+	};
+
 	constructor( props ) {
 		super();
 
@@ -82,6 +87,12 @@ class PreviewToolbar extends Component {
 			translate,
 		} = this.props;
 
+		// @todo: having trouble adding a Tracks event to the onClose event (see **HERE**)
+		// function handleClosePreview() {
+		// 	onClose;
+		// 	analytics.tracks.recordEvent( 'calypso_editor_preview_close_click' );
+		// }
+
 		const selectedDevice = this.devices[ currentDevice ];
 		const devicesToShow = showSEO ? possibleDevices.concat( 'seo' ) : possibleDevices;
 
@@ -93,7 +104,7 @@ class PreviewToolbar extends Component {
 						aria-label={ translate( 'Close preview' ) }
 						className="web-preview__close"
 						data-tip-target="web-preview__close"
-						onClick={ onClose }
+						onClick={ onClose } // **HERE**
 					>
 						<Gridicon icon={ isModalWindow ? 'cross' : 'arrow-left' } />
 					</Button>
@@ -138,6 +149,7 @@ class PreviewToolbar extends Component {
 							href={ externalUrl || previewUrl }
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ this.handleWebPreviewExternalClick }
 						>
 							<Gridicon icon="external" />
 						</Button>

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -160,13 +160,11 @@ class PreviewToolbar extends Component {
 	}
 }
 
-const wpcomEditorToolbarWebPreviewExternalClick = () => {
+const wpcomEditorToolbarWebPreviewExternalClick = () =>
 	composeAnalytics( recordTracksEvent( 'calypso_editor_preview_toolbar_external_click', {} ) );
-};
 
-const wpcomEditorToolbarWebPreviewClose = () => {
+const wpcomEditorToolbarWebPreviewClose = () =>
 	composeAnalytics( recordTracksEvent( 'calypso_editor_preview_close_click', {} ) );
-};
 
 export default connect( null, {
 	wpcomEditorToolbarWebPreviewExternalClick,

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -18,7 +18,7 @@ import Button from 'components/button';
 import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
 import ClipboardButtonInput from 'components/clipboard-button-input';
-import { composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
+import recordTracksEvent from 'state/analytics/actions';
 
 const possibleDevices = [ 'computer', 'tablet', 'phone' ];
 
@@ -55,11 +55,11 @@ class PreviewToolbar extends Component {
 	};
 
 	handleEditorWebPreviewExternalClick = () => {
-		this.props.wpcomEditorToolbarWebPreviewExternalClick();
+		this.props.recordTracksEvent( 'calypso_editor_preview_toolbar_external_click' );
 	};
 
 	handleEditorWebPreviewClose = () => {
-		this.props.wpcomEditorToolbarWebPreviewClose();
+		this.props.recordTracksEvent( 'calypso_editor_preview_close_click' );
 		this.props.onClose();
 	};
 
@@ -160,13 +160,6 @@ class PreviewToolbar extends Component {
 	}
 }
 
-const wpcomEditorToolbarWebPreviewExternalClick = () =>
-	composeAnalytics( recordTracksEvent( 'calypso_editor_preview_toolbar_external_click', {} ) );
-
-const wpcomEditorToolbarWebPreviewClose = () =>
-	composeAnalytics( recordTracksEvent( 'calypso_editor_preview_close_click', {} ) );
-
 export default connect( null, {
-	wpcomEditorToolbarWebPreviewExternalClick,
-	wpcomEditorToolbarWebPreviewClose,
+	recordTracksEvent,
 } )( localize( PreviewToolbar ) );

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import Notice from 'components/notice';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
@@ -33,6 +34,14 @@ export class EditorNotice extends Component {
 		status: PropTypes.string,
 		onDismissClick: PropTypes.func,
 		error: PropTypes.object,
+	};
+
+	handlePillExternalClick = () => {
+		analytics.tracks.recordEvent( 'calypso_editor_pill_site_external_click' );
+	};
+
+	handlePillAddAnotherPagePromptClick = () => {
+		analytics.tracks.recordEvent( 'calypso_editor_pill_add_another_page_prompt_click' );
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -112,11 +121,21 @@ export class EditorNotice extends Component {
 					return translate( 'Page published on {{siteLink/}}! {{a}}Add another page{{/a}}', {
 						components: {
 							siteLink: (
-								<a href={ site.URL } target="_blank" rel="noopener noreferrer">
+								<a
+									href={ site.URL }
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ this.handlePillExternalClick }
+								>
 									{ site.title }
 								</a>
 							),
-							a: <a href={ `/page/${ site.slug }` } />,
+							a: (
+								<a
+									href={ `/page/${ site.slug }` }
+									onClick={ this.handlePillAddAnotherPagePromptClick }
+								/>
+							),
 						},
 						comment:
 							'Editor: Message displayed when a page is published, with a link to the site it was published on.',
@@ -128,7 +147,12 @@ export class EditorNotice extends Component {
 						args: { typeLabel },
 						components: {
 							siteLink: (
-								<a href={ site.URL } target="_blank" rel="noopener noreferrer">
+								<a
+									href={ site.URL }
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ this.handlePillExternalClick }
+								>
 									{ site.title }
 								</a>
 							),
@@ -141,7 +165,12 @@ export class EditorNotice extends Component {
 				return translate( 'Post published on {{siteLink/}}!', {
 					components: {
 						siteLink: (
-							<a href={ site.URL } target="_blank" rel="noopener noreferrer">
+							<a
+								href={ site.URL }
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ this.handlePillExternalClick }
+							>
 								{ site.title }
 							</a>
 						),
@@ -167,7 +196,12 @@ export class EditorNotice extends Component {
 					return translate( 'Page scheduled on {{siteLink/}}! {{a}}Add another page{{/a}}', {
 						components: {
 							siteLink: (
-								<a href={ site.URL } target="_blank" rel="noopener noreferrer">
+								<a
+									href={ site.URL }
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ this.handlePillExternalClick }
+								>
 									{ site.title }
 								</a>
 							),
@@ -183,7 +217,12 @@ export class EditorNotice extends Component {
 						args: { typeLabel },
 						components: {
 							siteLink: (
-								<a href={ site.URL } target="_blank" rel="noopener noreferrer">
+								<a
+									href={ site.URL }
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ this.handlePillExternalClick }
+								>
 									{ site.title }
 								</a>
 							),
@@ -196,7 +235,12 @@ export class EditorNotice extends Component {
 				return translate( 'Post scheduled on {{siteLink/}}!', {
 					components: {
 						siteLink: (
-							<a href={ site.URL } target="_blank" rel="noopener noreferrer">
+							<a
+								href={ site.URL }
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ this.handlePillExternalClick }
+							>
 								{ site.title }
 							</a>
 						),
@@ -247,7 +291,12 @@ export class EditorNotice extends Component {
 					return translate( 'Page updated on {{siteLink/}}! {{a}}Add another page{{/a}}', {
 						components: {
 							siteLink: (
-								<a href={ site.URL } target="_blank" rel="noopener noreferrer">
+								<a
+									href={ site.URL }
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ this.handlePillExternalClick }
+								>
 									{ site.title }
 								</a>
 							),
@@ -263,7 +312,12 @@ export class EditorNotice extends Component {
 						args: { typeLabel },
 						components: {
 							siteLink: (
-								<a href={ site.URL } target="_blank" rel="noopener noreferrer">
+								<a
+									href={ site.URL }
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ this.handlePillExternalClick }
+								>
 									{ site.title }
 								</a>
 							),
@@ -276,7 +330,12 @@ export class EditorNotice extends Component {
 				return translate( 'Post updated on {{siteLink/}}!', {
 					components: {
 						siteLink: (
-							<a href={ site.URL } target="_blank" rel="noopener noreferrer">
+							<a
+								href={ site.URL }
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ this.handlePillExternalClick }
+							>
 								{ site.title }
 							</a>
 						),

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -360,13 +360,11 @@ export class EditorNotice extends Component {
 	}
 }
 
-const wpcomEditorToolbarWebPreviewPillExternalClick = () => {
+const wpcomEditorToolbarWebPreviewPillExternalClick = () =>
 	composeAnalytics( recordTracksEvent( 'calypso_editor_pill_site_external_click', {} ) );
-};
 
-const wpcomEditorToolbarWebPreviewAddPagePromptClick = () => {
+const wpcomEditorToolbarWebPreviewAddPagePromptClick = () =>
 	composeAnalytics( recordTracksEvent( 'calypso_editor_pill_add_page_prompt_click', {} ) );
-};
 
 export default connect(
 	state => {

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -21,7 +21,7 @@ import { getPostType } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { isMobile } from 'lib/viewport';
-import { composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
+import recordTracksEvent from 'state/analytics/actions';
 
 export class EditorNotice extends Component {
 	static propTypes = {
@@ -37,11 +37,11 @@ export class EditorNotice extends Component {
 	};
 
 	handlePillExternalClick = () => {
-		this.props.wpcomEditorToolbarWebPreviewPillExternalClick();
+		this.props.recordTracksEvent( 'calypso_editor_pill_site_external_click' );
 	};
 
-	handlePillAddAnotherPagePromptClick = () => {
-		this.props.wpcomEditorToolbarWebPreviewAddPagePromptClick();
+	handlePillAddPagePromptClick = () => {
+		this.props.recordTracksEvent( 'calypso_editor_pill_add_page_prompt_click' );
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -131,10 +131,7 @@ export class EditorNotice extends Component {
 								</a>
 							),
 							a: (
-								<a
-									href={ `/page/${ site.slug }` }
-									onClick={ this.handlePillAddAnotherPagePromptClick }
-								/>
+								<a href={ `/page/${ site.slug }` } onClick={ this.handlePillAddPagePromptClick } />
 							),
 						},
 						comment:
@@ -360,12 +357,6 @@ export class EditorNotice extends Component {
 	}
 }
 
-const wpcomEditorToolbarWebPreviewPillExternalClick = () =>
-	composeAnalytics( recordTracksEvent( 'calypso_editor_pill_site_external_click', {} ) );
-
-const wpcomEditorToolbarWebPreviewAddPagePromptClick = () =>
-	composeAnalytics( recordTracksEvent( 'calypso_editor_pill_add_page_prompt_click', {} ) );
-
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
@@ -383,7 +374,6 @@ export default connect(
 	},
 	{
 		setLayoutFocus,
-		wpcomEditorToolbarWebPreviewPillExternalClick,
-		wpcomEditorToolbarWebPreviewAddPagePromptClick,
+		recordTracksEvent,
 	}
 )( localize( EditorNotice ) );

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -21,7 +21,7 @@ import { getPostType } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { isMobile } from 'lib/viewport';
-import recordTracksEvent from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 export class EditorNotice extends Component {
 	static propTypes = {

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -13,7 +13,6 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import Notice from 'components/notice';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
@@ -22,6 +21,7 @@ import { getPostType } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { isMobile } from 'lib/viewport';
+import { composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 
 export class EditorNotice extends Component {
 	static propTypes = {
@@ -37,11 +37,11 @@ export class EditorNotice extends Component {
 	};
 
 	handlePillExternalClick = () => {
-		analytics.tracks.recordEvent( 'calypso_editor_pill_site_external_click' );
+		this.props.wpcomEditorToolbarWebPreviewPillExternalClick();
 	};
 
 	handlePillAddAnotherPagePromptClick = () => {
-		analytics.tracks.recordEvent( 'calypso_editor_pill_add_another_page_prompt_click' );
+		this.props.wpcomEditorToolbarWebPreviewAddPagePromptClick();
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -360,6 +360,14 @@ export class EditorNotice extends Component {
 	}
 }
 
+const wpcomEditorToolbarWebPreviewPillExternalClick = () => {
+	composeAnalytics( recordTracksEvent( 'calypso_editor_pill_site_external_click', {} ) );
+};
+
+const wpcomEditorToolbarWebPreviewAddPagePromptClick = () => {
+	composeAnalytics( recordTracksEvent( 'calypso_editor_pill_add_page_prompt_click', {} ) );
+};
+
 export default connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
@@ -375,5 +383,9 @@ export default connect(
 			typeObject: getPostType( state, siteId, post.type ),
 		};
 	},
-	{ setLayoutFocus }
+	{
+		setLayoutFocus,
+		wpcomEditorToolbarWebPreviewPillExternalClick,
+		wpcomEditorToolbarWebPreviewAddPagePromptClick,
+	}
 )( localize( EditorNotice ) );

--- a/client/post-editor/editor-notice/test/__snapshots__/index.jsx.snap
+++ b/client/post-editor/editor-notice/test/__snapshots__/index.jsx.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditorNotice should display custom post type view label 1`] = `
+<div
+  className="editor-notice is-global"
+>
+  <Localized(Notice)
+    showDismiss={true}
+    status="is-success"
+    text={
+      Array [
+        "Post published on ",
+        <a
+          href="https://example.wordpress.com"
+          onClick={[Function]}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Example Site
+        </a>,
+        "!",
+      ]
+    }
+  />
+</div>
+`;
+
+exports[`EditorNotice should display publish success for page 1`] = `
+<div
+  className="editor-notice is-global"
+>
+  <Localized(Notice)
+    showDismiss={true}
+    status="is-success"
+    text={
+      Array [
+        "Page published on ",
+        <a
+          href="https://example.wordpress.com"
+          onClick={[Function]}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Example Site
+        </a>,
+        "! ",
+        <a
+          href="/page/example.wordpress.com"
+          onClick={[Function]}
+        >
+          Add another page
+        </a>,
+      ]
+    }
+  />
+</div>
+`;

--- a/client/post-editor/editor-notice/test/index.jsx
+++ b/client/post-editor/editor-notice/test/index.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
+import { expect as chaiExpect } from 'chai';
 import { shallow } from 'enzyme';
 import { translate } from 'i18n-calypso';
 import React from 'react';
@@ -17,7 +17,7 @@ describe( 'EditorNotice', () => {
 	test( 'should not render a notice if no message is specified', () => {
 		const wrapper = shallow( <EditorNotice /> );
 
-		expect( wrapper ).to.not.have.descendants( Notice );
+		chaiExpect( wrapper ).to.not.have.descendants( Notice );
 	} );
 
 	test( 'should display an no content error message if recognized', () => {
@@ -30,13 +30,13 @@ describe( 'EditorNotice', () => {
 			/>
 		);
 
-		expect( wrapper.find( Notice ) )
+		chaiExpect( wrapper.find( Notice ) )
 			.to.have.prop( 'text' )
 			.equal( "You haven't written anything yet!" );
-		expect( wrapper.find( Notice ) )
+		chaiExpect( wrapper.find( Notice ) )
 			.to.have.prop( 'status' )
 			.equal( 'is-error' );
-		expect( wrapper.find( Notice ) ).to.have.prop( 'showDismiss' ).be.true;
+		chaiExpect( wrapper.find( Notice ) ).to.have.prop( 'showDismiss' ).be.true;
 	} );
 
 	test( 'should display a fallback error message', () => {
@@ -50,14 +50,14 @@ describe( 'EditorNotice', () => {
 			/>
 		);
 
-		expect( wrapper ).to.have.descendants( Notice );
-		expect( wrapper.find( Notice ) )
+		chaiExpect( wrapper ).to.have.descendants( Notice );
+		chaiExpect( wrapper.find( Notice ) )
 			.to.have.prop( 'text' )
 			.equal( 'Publishing of post failed.' );
-		expect( wrapper.find( Notice ) )
+		chaiExpect( wrapper.find( Notice ) )
 			.to.have.prop( 'status' )
 			.equal( 'is-error' );
-		expect( wrapper.find( Notice ) ).to.have.prop( 'showDismiss' ).be.true;
+		chaiExpect( wrapper.find( Notice ) ).to.have.prop( 'showDismiss' ).be.true;
 	} );
 
 	test( 'should display publish success for page', () => {
@@ -75,21 +75,8 @@ describe( 'EditorNotice', () => {
 			/>
 		);
 
-		expect( wrapper.find( Notice ) )
-			.to.have.prop( 'text' )
-			.eql(
-				translate( 'Page published on {{siteLink/}}! {{a}}Add another page{{/a}}', {
-					components: {
-						siteLink: (
-							<a href="https://example.wordpress.com" target="_blank" rel="noopener noreferrer">
-								Example Site
-							</a>
-						),
-						a: <a href="/page/example.wordpress.com" />,
-					},
-				} )
-			);
-		expect( wrapper.find( Notice ) )
+		expect( wrapper ).toMatchSnapshot();
+		chaiExpect( wrapper.find( Notice ) )
 			.to.have.prop( 'status' )
 			.equal( 'is-success' );
 	} );
@@ -113,20 +100,8 @@ describe( 'EditorNotice', () => {
 			/>
 		);
 
-		expect( wrapper.find( Notice ) )
-			.to.have.prop( 'text' )
-			.eql(
-				translate( 'Post published on {{siteLink/}}!', {
-					components: {
-						siteLink: (
-							<a href="https://example.wordpress.com" target="_blank" rel="noopener noreferrer">
-								Example Site
-							</a>
-						),
-					},
-				} )
-			);
-		expect( wrapper.find( Notice ) )
+		expect( wrapper ).toMatchSnapshot();
+		chaiExpect( wrapper.find( Notice ) )
 			.to.have.prop( 'status' )
 			.equal( 'is-success' );
 	} );


### PR DESCRIPTION
Adding stat tracking for actions available after a user publishes/updates a post/page. This is helpful for us to understand what user's are doing after they finishing publishing.