### PR TITLE
Post Revisions: Don't render the fallback link when the flag is disabled & no revisions are present

### DIFF
--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -25,7 +25,7 @@ import QueryPostRevisions from 'components/data/query-post-revisions';
 import QueryUsers from 'components/data/query-users';
 
 class EditorRevisions extends Component {
-	render = () => {
+	render() {
 		const {
 			adminUrl,
 			authorsIds,
@@ -40,6 +40,16 @@ class EditorRevisions extends Component {
 			// This is what gets rendered in the sidebar
 			// @TODO take it out (& adminUrl too) when the feature flag is enabled
 			const lastRevisionId = get( revisions, [ 0, 'id' ], 0 );
+
+			if ( ! lastRevisionId ) {
+				return (
+					<span>
+						<QueryPostRevisions postId={ postId } siteId={ siteId } />
+						<QueryUsers siteId={ siteId } userIds={ authorsIds } />
+					</span>
+				);
+			}
+
 			const revisionsLink = adminUrl + 'revision.php?revision=' + lastRevisionId;
 
 			return (
@@ -77,7 +87,7 @@ class EditorRevisions extends Component {
 				<EditorRevisionsList postId={ postId } revisions={ revisions } siteId={ siteId } />
 			</div>
 		);
-	};
+	}
 }
 
 EditorRevisions.propTypes = {


### PR DESCRIPTION
Since #19197 got merged, we're currently showing `0 revisions` on new posts (& clicking takes you to the post list in wp-admin.

This change only renders the query components which populate redux when there's no revision to link to.

## Before

<img width="281" alt="screen shot 2017-11-14 at 8 54 31 pm" src="https://user-images.githubusercontent.com/1587282/32814760-5af04412-c97e-11e7-88d8-901b15b79ab1.png">

## After 

<img width="275" alt="screen shot 2017-11-14 at 9 57 33 pm" src="https://user-images.githubusercontent.com/1587282/32816478-da37e650-c986-11e7-9903-020d2c261d0f.png">

...

<img width="278" alt="screen shot 2017-11-14 at 10 04 35 pm" src="https://user-images.githubusercontent.com/1587282/32816658-d87571f6-c987-11e7-81c9-7eb114aba9d3.png">

## To Test

* Run with the flag disabled -- `DISABLE_FEATURES=post-editor/revisions npm run start`
* Create a new post
* You should not see `0 revisions` under the `Post Settings | Status` editor sidebar
* Edit & save the post -- The revisions link should appear (after a reload**)

Repeat the above without the flag disabled -- the `History` button & revisions modal behavior should be unaffected by this change.

** known issue: After a new post gets a post ID, the request for revisions comes back empty & the querying component doesn't poll for more