### PR TITLE
Design: remove en-au and au from prideLanguages and prideLocations

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -50,11 +50,11 @@ const staticFilesUrls = staticFiles.reduce( ( result, file ) => {
 
 // List of browser languages to show pride styling for.
 // Add a '*' element to show the styling for all visitors.
-const prideLanguages = [ 'en-au' ];
+const prideLanguages = [];
 
 // List of geolocated locations to show pride styling for.
 // Geolocation may not be 100% accurate.
-const prideLocations = [ 'au' ];
+const prideLocations = [];
 
 const sections = sectionsModule.get();
 


### PR DESCRIPTION
This PR disables the pride banner for Australian visitors.

**To Test**

Visit the https://calypso.live/?branch=update/disable-pride-for-en-au from an Australian IP or browser set to en-au and ensure the pride toolbar (rainbow) is no longer shown

**Before**

<img width="766" alt="before" src="https://user-images.githubusercontent.com/128826/32823886-7a3ee916-ca2a-11e7-85a5-120d1d8bf621.png">

**After**

<img width="767" alt="after" src="https://user-images.githubusercontent.com/128826/32823893-80533e4c-ca2a-11e7-8ad7-c6ca3ad2f36b.png">

