### PR TITLE
Enable popup flow for google sign in in safari private mode

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -134,12 +134,8 @@ export class LoginForm extends Component {
 		// If calypso is loaded in a popup, we don't want to open a second popup for social login
 		// let's use the redirect flow instead in that case
 		const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
-		// also disable the popup flow for all safari versions
-		// See https://github.com/google/google-api-javascript-client/issues/297#issuecomment-333869742
-		const isSafari =
-			typeof window !== 'undefined' && /^(?!.*chrome).*safari/i.test( window.navigator.userAgent );
 		// disable for oauth2 flows for now
-		return ! oauth2Client && ( isPopup || isSafari );
+		return ! oauth2Client && isPopup;
 	}
 
 	savePasswordRef = input => {

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -40,11 +40,7 @@ class SocialSignupForm extends Component {
 		// If calypso is loaded in a popup, we don't want to open a second popup for social signup
 		// let's use the redirect flow instead in that case
 		const isPopup = typeof window !== 'undefined' && window.opener && window.opener !== window;
-		// also disable the popup flow for all safari versions
-		// See https://github.com/google/google-api-javascript-client/issues/297#issuecomment-333869742
-		const isSafari =
-			typeof window !== 'undefined' && /^(?!.*chrome).*safari/i.test( window.navigator.userAgent );
-		return isPopup || isSafari;
+		return isPopup;
 	}
 
 	render() {


### PR DESCRIPTION
Trying to enable again the popup flow (instead of oauth2 redirect) for safari private browsing, after it was fixed on google's side. See https://github.com/google/google-api-javascript-client/issues/297#issuecomment-344456095

### Testing Instructions
- Load https://calypso.live/log-in?branch=update/safari-popup from a safari private window
- Click on Continue with Google
- Assert that a popup opens and that entering valid credentials logs you in to WordPress.com

### Reviews
- [ ] Code
- [ ] Product