### PR TITLE
Sidebar: Fix Media menu item not clickable with RTL languages

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -222,6 +222,7 @@ form.sidebar__button input {
 	bottom: -10px;
 	right: -10px;
 	left: -10px;
+	width: 100%;
 }
 
 // Selected Menu


### PR DESCRIPTION
This pull request fixes the `Media` menu item that is no longer clickable if the locale is set to any RTL language. This is because the `Add` button container would take more (invisible) space than it should, and being on top of the menu item would intercept any click:
 
<img width="738" alt="screenshot" src="https://user-images.githubusercontent.com/594356/32827226-b9e0d5c8-c9eb-11e7-900b-7405c72feb28.png">
 
#### Testing instructions
 
1. Run `git checkout fix/media-menu-sidebar` and start your server, or open a [live branch](https://calypso.live/?branch=fix/media-menu-sidebar)
2. Open the [`My Site` page](http://calypso.localhost:3000/stats/day) while the locale is set to Hebrew, or any other RTL languge
3. Click the `Media` menu item in the sidebar
4. Assert that you are redirected to the [`Media` page](http://calypso.localhost:3000/media)
5. Click the `Add` button in front of the `Media` menu item
6. Assert that you are presented with a file dialog
7. Repeat steps #2 to #6 with the locale set to English, or any other LTR language

#### Reviews
 
- [x] Code
- [x] Product