### PR TITLE
Editor: Only diff revisions with feature flag active

### DIFF
--- a/client/state/data-layer/wpcom/posts/revisions/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/index.js
@@ -9,6 +9,7 @@ import { flow, forEach, get, map, mapKeys, mapValues, omit, pick } from 'lodash'
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import { countDiffWords, diffWords } from 'lib/text-utils';
 import { POST_REVISIONS_REQUEST } from 'state/action-types';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
@@ -77,11 +78,13 @@ export const receiveError = ( { dispatch }, { siteId, postId }, rawError ) =>
 export const receiveSuccess = ( { dispatch }, { siteId, postId }, revisions ) => {
 	const normalizedRevisions = map( revisions, normalizeRevision );
 
-	forEach( normalizedRevisions, ( revision, index ) => {
-		revision.changes = countDiffWords(
-			diffWords( get( normalizedRevisions, [ index + 1, 'content' ], '' ), revision.content )
-		);
-	} );
+	if ( isEnabled( 'post-editor/revisions' ) ) {
+		forEach( normalizedRevisions, ( revision, index ) => {
+			revision.changes = countDiffWords(
+				diffWords( get( normalizedRevisions, [ index + 1, 'content' ], '' ), revision.content )
+			);
+		} );
+	}
 
 	dispatch( receivePostRevisionsSuccess( siteId, postId ) );
 	dispatch( receivePostRevisions( siteId, postId, normalizedRevisions ) );

--- a/client/state/data-layer/wpcom/posts/revisions/test/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/test/index.js
@@ -10,6 +10,7 @@ import sinon from 'sinon';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import { fetchPostRevisions, normalizeRevision, receiveSuccess, receiveError } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
@@ -149,9 +150,11 @@ describe( '#receiveSuccess', () => {
 		receiveSuccess( { dispatch }, action, successfulPostRevisionsResponse );
 
 		const expectedRevisions = cloneDeep( normalizedPostRevisions );
-		forEach( expectedRevisions, revision => {
-			revision.changes = { added: 2, removed: 0 };
-		} );
+		if ( isEnabled( 'post-editor/revisions' ) ) {
+			forEach( expectedRevisions, revision => {
+				revision.changes = { added: 2, removed: 0 };
+			} );
+		}
 
 		expect( dispatch ).to.have.callCount( 2 );
 		expect( dispatch ).to.have.been.calledWith( receivePostRevisionsSuccess( 12345678, 10 ) );


### PR DESCRIPTION
We have all the functionality for new Revisions UI behind the feature flag except one place, we didn't think of and this exact place was causing troubles in production lately. 

This PR is a hotfix that will hide the diffing logic behind the flag. 

Before testing: 
- this PR cannot be tested on calypso.live because it runs in development mode
- you can test this on a calypso.localhost if you disable `post-editor/revisions` feature flag in `config/development.json` and rebuild everything

To test:
- make a post/page with 10000 words and save it
- Reload the editor page after saving and try to interact with the editor (clicking buttons, selecting text)
- Without this PR (for example, testing directly on WordPress.com), you should experience total unresponsiveness of the UI for up to a minute. No buttons would work, no hover states, clicking does nothing
- With this PR, the lag should be gone

Fixes #19745 