### PR TITLE
MySitesSidebar: remove pure=false option when connecting to Redux store

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -726,6 +726,6 @@ function mapStateToProps( state ) {
 }
 
 // TODO: make this pure when sites can be retrieved from the Redux state
-export default connect( mapStateToProps, { setNextLayoutFocus, setLayoutFocus }, null, {
-	pure: false,
-} )( localize( MySitesSidebar ) );
+export default connect( mapStateToProps, { setNextLayoutFocus, setLayoutFocus } )(
+	localize( MySitesSidebar )
+);


### PR DESCRIPTION
The option was added at a time when the component was using `sites-list`. Since then, it's been converted into getting all site data from Redux, but the option was not removed.

Saves quite a lot of rerenders of the `MySitesSidebar` component.

I discovered this small fix when profiling the Calypso freeze in #19446.