### PR TITLE
Build: No redundant npm installs on docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,27 @@ RUN        true \
            && rm -rf /root/.npm \
            && true
 
+# Build a "files" layer
+#
+# This layer is populated with up-to-date files from
+# Calypso development.
+#
+# If package.json and npm-shrinkwrap are unchanged,
+# `install-if-deps-outdated` should require no action.
+# However, time is being spent in the build step on
+# `install-if-deps-outdated`. This is because in the
+# following COPY, the npm-shrinkwrap mtime is being
+# updated, which is confusing `install-if-deps-outdated`.
+# Touch after copy to ensure that this layer will
+# not trigger additional install as part of the build
+# in the following step.
+COPY       . /calypso/
+RUN        touch npm-shrinkwrap.json node_modules
+
 # Build the final layer
 #
 # This contains built environments of Calypso. It will
 # change any time any of the Calypso source-code changes.
-COPY       . /calypso/
 RUN        true \
            && CALYPSO_ENV=production npm run build \
            && chown -R nobody /calypso \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN        true \
 # not trigger additional install as part of the build
 # in the following step.
 COPY       . /calypso/
-RUN        touch npm-shrinkwrap.json node_modules
+RUN        touch node_modules
 
 # Build the final layer
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN        true \
            && rm -rf /root/.npm \
            && true
 
-# Build a "files" layer
+# Build a "source" layer
 #
 # This layer is populated with up-to-date files from
 # Calypso development.


### PR DESCRIPTION
I've noticed that our `install-if-deps-outdated` script often _does work_ when we build with Docker. This takes time and should be completely redundant after the `npm install --prod` step. If `npm-shrinkwrap.json` or `package.json` are modified, the docker image should be updated via an earlier layer. When the build step is reached, no installation should be necessary.

I inspected the `install-if-deps-outdated`, and it relies on the modification times of `npm-shrinkwrap.json` and `node_modules`.

https://github.com/Automattic/wp-calypso/blob/381850c162716063edc8785e5b45a58c796dc4ee/bin/install-if-deps-outdated.js#L16-L24

I believe this test is being thrown off by a subsequent `COPY`, overwriting the updated `npm-shrinkrarp` and affecting it's modification time.

https://github.com/Automattic/wp-calypso/blob/381850c162716063edc8785e5b45a58c796dc4ee/Dockerfile#L28-L38

This PR simply adds a `touch` to `npm-shrinkwrap.json` and `node_modules` to ensure that `install-if-deps-outdated` does not attempt install on build.

## Testing
* See https://github.com/Automattic/wp-calypso/pull/19796#issuecomment-345628115 for instructions on reliably reproducing the redundant install.
* Use `npm run build-docker`
* Confirm that time is spent in the `install-if-deps-outdated` step on `master`.
* Confirm that no time is spent in the `install-if-deps-outdated` step on this branch.
* Ensure that the produced image is correct (`npm run docker`).