### PR TITLE
Signup: Hide domain upgrade screen in the plan signup flows.

### DIFF
--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -169,10 +169,6 @@ export class SignupProcessingScreen extends Component {
 				);
 	}
 
-	currentFlowIncludesDomainStep() {
-		return this.props.flowSteps.indexOf( 'domains' ) !== -1;
-	}
-
 	handleClick( ctaName, redirectTo = '' ) {
 		if ( ! this.props.loginHandler ) {
 			return;
@@ -292,8 +288,9 @@ export class SignupProcessingScreen extends Component {
 	render() {
 		if (
 			! this.state.hasPaidSubscription &&
-			this.currentFlowIncludesDomainStep() &&
-			! this.props.useOAuth2Layout
+			! this.props.useOAuth2Layout &&
+			this.props.flowSteps.indexOf( 'domains' ) !== -1 &&
+			this.props.flowSteps.indexOf( 'plans' ) !== -1
 		) {
 			return this.renderUpgradeScreen();
 		}


### PR DESCRIPTION
From the bug report:
> Hey Taegon, I noticed a bug in the plan signup flow (`/start/business`, `start/personal`, `start/premium`). We're showing the domain upgrade screen for these users if they pick a plan before signup and choose a .wordpress domain. I've attached a screenshot. We shouldn't be showing the domain upgrade screen if someone has already picked a plan.

This will show the old-school processing screen instead of domain upgrade nudge in the plan signup flows.

## Test plan

1. Create a new website on one of the signup flows (`/start/business`, `start/personal`, `start/premium`).
2. You should not see the domain upgrade screen like below:
![domain-upgrade](https://user-images.githubusercontent.com/212034/32839056-6f393a5e-ca56-11e7-8ee0-5d93ff4fd390.png)

cc @fditrapani 
