### PR TITLE
Build: Do not remove local node_modules when building docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .vscode
 build
 node_modules
+npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "build-devdocs:components-usage-stats:_env": "node server/devdocs/bin/generate-components-usage-stats.js \"client/**/*.js\" \"client/**/*.jsx\" \"!**/docs/**\" \"!**/test/**\" \"!**/docs-example/**\"",
     "build-devdocs:index": "npm run -s env -- npm run -s build-devdocs:index:_env",
     "build-devdocs:index:_env": "node server/devdocs/bin/generate-devdocs-index \"**/*.md\" \".github/**.md\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
-    "prebuild-docker": "npm run -s distclean && ( touch env-config.sh || type nul >> env-config.sh )",
+    "prebuild-docker": "npm run -s clean && ( touch env-config.sh || type nul >> env-config.sh )",
     "build-docker": "docker build -t wp-calypso .",
     "prebuild-server": "mkdirp build",
     "build-server": "npm run -s env -- webpack --display-error-details --config webpack.config.node.js",


### PR DESCRIPTION
The `.dockerignore` excludes `node_modules` from copy:

https://github.com/Automattic/wp-calypso/blob/2ed4bd06e8d2136ccedba9cd259f33074bdcfb58/.dockerignore#L4

Docker performs `npm install --prod` as part of the build:

https://github.com/Automattic/wp-calypso/blob/2ed4bd06e8d2136ccedba9cd259f33074bdcfb58/Dockerfile#L30

Removing `node_modules` from local environment via `distclean` only serves to make subsequent work with the repo more painful, requiring a reinstall.

This PR changes the `prebuild-docker` script to run `clean` over `distclean`, the only difference being the removal of `node_modules`:

https://github.com/Automattic/wp-calypso/blob/80d182c5c0932711fa82de58a520a5769db62bbf/package.json#L196

https://github.com/Automattic/wp-calypso/blob/80d182c5c0932711fa82de58a520a5769db62bbf/package.json#L203

**Update**

I've also added `npm-debug.log*` to `.dockerignore` after seeing its inclusion (https://github.com/Automattic/wp-calypso/pull/19801#issuecomment-344624349).

## Testing
1. `npm run build-docker`
1. Ensure build completes successfully and the result is functionally the same as current builds.
1. `node_modules` should not be removed from your local environment.