### PR TITLE
Post Revisions: Pull the wp-admin link out into a component

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -16,7 +17,7 @@ import Gridicon from 'gridicons';
 import { isEnabled } from 'config';
 import Button from 'components/button';
 import FormToggle from 'components/forms/form-toggle/compact';
-import EditorRevisions from 'post-editor/editor-revisions';
+import EditorRevisionsLegacyLink from 'post-editor/editor-revisions/legacy-link';
 import postUtils from 'lib/posts/utils';
 import InfoPopover from 'components/info-popover';
 import siteUtils from 'lib/site/utils';
@@ -151,7 +152,12 @@ export class EditPostStatus extends Component {
 						<Gridicon icon="undo" size={ 18 } /> { translate( 'Revert to draft' ) }
 					</Button>
 				) }
-				{ ! isEnabled( 'post-editor/revisions' ) && <EditorRevisions adminUrl={ adminUrl } /> }
+				{ ! isEnabled( 'post-editor/revisions' ) && (
+					<EditorRevisionsLegacyLink
+						adminUrl={ adminUrl }
+						revisionsFromPostObj={ get( this.props, 'post.revisions' ) }
+					/>
+				) }
 			</div>
 		);
 	}

--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -4,10 +4,9 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow, get } from 'lodash';
+import { flow } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,40 +25,7 @@ import QueryUsers from 'components/data/query-users';
 
 class EditorRevisions extends Component {
 	render = () => {
-		const {
-			adminUrl,
-			authorsIds,
-			postId,
-			revisions,
-			selectedRevisionId,
-			siteId,
-			translate,
-		} = this.props;
-
-		if ( adminUrl ) {
-			// This is what gets rendered in the sidebar
-			// @TODO take it out (& adminUrl too) when the feature flag is enabled
-			const lastRevisionId = get( revisions, [ 0, 'id' ], 0 );
-			const revisionsLink = adminUrl + 'revision.php?revision=' + lastRevisionId;
-
-			return (
-				<a
-					className="editor-revisions__wpadmin-link"
-					href={ revisionsLink }
-					target="_blank"
-					rel="noopener noreferrer"
-					aria-label={ translate( 'Open list of revisions' ) }
-				>
-					<QueryPostRevisions postId={ postId } siteId={ siteId } />
-					<QueryUsers siteId={ siteId } userIds={ authorsIds } />
-					<Gridicon icon="history" size={ 18 } />
-					{ translate( '%(revisions)d revision', '%(revisions)d revisions', {
-						count: revisions.length,
-						args: { revisions: revisions.length },
-					} ) }
-				</a>
-			);
-		}
+		const { authorsIds, postId, revisions, selectedRevisionId, siteId } = this.props;
 
 		return (
 			<div className="editor-revisions__wrapper">
@@ -81,9 +47,6 @@ class EditorRevisions extends Component {
 }
 
 EditorRevisions.propTypes = {
-	// @TODO adminUrl exists for sidebar fallback UI -- remove when that's taken out
-	adminUrl: PropTypes.string,
-
 	// connected
 	authorsIds: PropTypes.array.isRequired,
 	postId: PropTypes.number.isRequired,

--- a/client/post-editor/editor-revisions/legacy-link.jsx
+++ b/client/post-editor/editor-revisions/legacy-link.jsx
@@ -1,0 +1,51 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+import Gridicon from 'gridicons';
+
+class EditorRevisionsLegacyLink extends PureComponent {
+	static propTypes = {
+		adminUrl: PropTypes.string,
+		revisionsFromPostObj: PropTypes.array,
+
+		//localize
+		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		revisionsFromPostObj: [],
+	};
+
+	render() {
+		const { adminUrl, translate, revisionsFromPostObj } = this.props;
+		const lastRevisionId = get( revisionsFromPostObj, 0, 0 );
+
+		if ( ! ( adminUrl && lastRevisionId ) ) {
+			return null;
+		}
+		const revisionsLink = adminUrl + 'revision.php?revision=' + lastRevisionId;
+
+		return (
+			<a
+				className="editor-revisions__wpadmin-link"
+				href={ revisionsLink }
+				target="_blank"
+				rel="noopener noreferrer"
+				aria-label={ translate( 'Open list of revisions' ) }
+			>
+				<Gridicon icon="history" size={ 18 } />
+				{ translate( '%(revisions)d revision', '%(revisions)d revisions', {
+					count: revisionsFromPostObj.length,
+					args: { revisions: revisionsFromPostObj.length },
+				} ) }
+			</a>
+		);
+	}
+}
+
+export default localize( EditorRevisionsLegacyLink );


### PR DESCRIPTION
For the previous revisions link in the sidebar, fall back to using the list of revision IDs from the post object in the editor instead of querying & pulling them out of redux.

This fixes the underlying issue in #19745 which was initially addressed in #19791.
Specifically, there's no need to have the front-end query revisions when it will not be able to use them because the feature is behind a flag.

## To Test

* Run with the flag disabled -- `DISABLE_FEATURES=post-editor/revisions npm run start`
* Create a new post
* You should not see `0 revisions` under the `Post Settings | Status` editor sidebar
* Edit & save the post -- The revisions link should appear & show the revisions count

Repeat the above **without** the flag disabled -- the `History` button & revisions modal behavior behind the flag should be unaffected by this change.