### PR TITLE
Store Orders: Add a default shipping object when editing orders with no shipping

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -121,7 +121,7 @@ class OrderDetailsTable extends Component {
 
 	onShippingChange = event => {
 		const { order } = this.props;
-		const shippingLine = order.shipping_lines[ 0 ];
+		const shippingLine = order.shipping_lines[ 0 ] || { method_id: 'manual' };
 		const total = event.target.value;
 		this.props.onChange( { shipping_lines: [ { ...shippingLine, total } ] } );
 	};


### PR DESCRIPTION
This fixes an issue where trying to edit the shipping on an order that previously had no shipping costs triggered an API error when saving:

```
"code": "woocommerce_rest_invalid_shipping_item",
"message": "Shipping method ID is required.",
```

Since there is no shipping item to update, the new item doesn't have a method ID. I've fixed this by adding a default `method_id` to be used when no shipping line is found. Eventually we'll update this for creating an order so that the store owner can choose the specific method, but until then this fixes a save-blocking bug.

To test:

- Create an order with no shipping, or delete the shipping off an existing order (in wp-admin)
- Open the order in calypso, click to edit it
- Change the shipping cost from 0
- Save, you should see the success message.