### PR TITLE
Reader sites: use statusCode rather than code to find errors with a 410

### DIFF
--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -46,7 +46,7 @@ function handleDeserialize( state ) {
 
 function handleRequestFailure( state, action ) {
 	// 410 means site moved. site used to be wpcom but is no longer
-	if ( action.error && action.error.code !== 410 ) {
+	if ( action.error && action.error.statusCode !== 410 ) {
 		return state;
 	}
 

--- a/client/state/reader/sites/test/reducer.js
+++ b/client/state/reader/sites/test/reducer.js
@@ -179,11 +179,11 @@ describe( 'reducer', () => {
 					{},
 					{
 						type: READER_SITE_REQUEST_FAILURE,
-						error: { code: 410 },
+						error: { statusCode: 410 },
 						payload: { ID: 666 },
 					}
 				)
-			).to.deep.equal( { 666: { ID: 666, is_error: true, error: { code: 410 } } } );
+			).to.deep.equal( { 666: { ID: 666, is_error: true, error: { statusCode: 410 } } } );
 		} );
 
 		test( 'should overwrite an existing entry on receiving a new feed', () => {
@@ -204,7 +204,7 @@ describe( 'reducer', () => {
 			expect(
 				items( startingState, {
 					type: READER_SITE_REQUEST_FAILURE,
-					error: { code: 500 },
+					error: { statusCode: 500 },
 					payload: { ID: 666 },
 				} )
 			).to.deep.equal( startingState );

--- a/client/state/selectors/get-reader-follows.js
+++ b/client/state/selectors/get-reader-follows.js
@@ -36,7 +36,7 @@ const getReaderFollows = createSelector(
 		const withoutErrors = reject(
 			withSiteAndFeed,
 			item =>
-				( item.site && item.site.is_error && item.site.error.code === 410 ) ||
+				( item.site && item.site.is_error && item.site.error.statusCode === 410 ) ||
 				( item.feed && item.feed.is_error )
 		);
 		return withoutErrors;


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/18142 we added handling for sites which had been deleted. The API returns a 410 in those cases.

After also adding a 410 response to the `/read/sites/:site` endpoint (in patch D8246), I noticed that my error didn't contain a `code` key:

<img width="588" alt="screen shot 2017-11-15 at 16 02 18" src="https://user-images.githubusercontent.com/17325/32847187-347bc47a-ca21-11e7-8018-52b3850e8889.png">

...but it does have both `status` and `statusCode` with the 410 value.

This PR switches to use `statusCode` to find sites that have been deleted.

(@samouri do you recall which endpoint may have provided the `error.code`, in case we need to check for both?)