### PR TITLE
Changed the order activity log code structure for cross-project usages

### DIFF
--- a/client/extensions/woocommerce/app/order/order-activity-log/events.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log/events.js
@@ -1,0 +1,126 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { localize, moment } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { keys, last, sortBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isActivityLogLoaded,
+	getActivityLogEvents,
+} from 'woocommerce/state/sites/orders/activity-log/selectors';
+import OrderEvent from './event';
+import OrderEventsByDay from './day';
+
+function getSortedEvents( events ) {
+	const eventsByDay = {};
+	events.forEach( event => {
+		const day = moment( event.timestamp ).format( 'YYYYMMDD' );
+		if ( eventsByDay[ day ] ) {
+			eventsByDay[ day ].push( event );
+		} else {
+			eventsByDay[ day ] = [ event ];
+		}
+	} );
+
+	keys( eventsByDay ).forEach( day => {
+		eventsByDay[ day ] = sortBy( eventsByDay[ day ], [ 'timestamp', 'key' ] ).reverse();
+	} );
+	return eventsByDay;
+}
+
+class OrderEvents extends Component {
+	static propTypes = {
+		orderId: PropTypes.number.isRequired,
+		siteId: PropTypes.number.isRequired,
+	};
+
+	componentWillMount() {
+		this.setState( { openDay: last( keys( this.props.eventsByDay ) ) } );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		const newOpenDay = last( keys( nextProps.eventsByDay ) );
+		//if a new latest day has been appended, open it
+		if ( ! this.props.eventsByDay[ newOpenDay ] ) {
+			this.setState( { openDay: newOpenDay } );
+		}
+	}
+
+	toggleOpenDay = date => {
+		this.setState( () => ( { openDay: date } ) );
+	};
+
+	renderNotes = () => {
+		const { days, eventsByDay, translate } = this.props;
+		if ( ! days.length ) {
+			return <p>{ translate( 'No activity yet' ) }</p>;
+		}
+
+		return (
+			<div>
+				{ days.map( day => {
+					const events = eventsByDay[ day ];
+					return (
+						<OrderEventsByDay
+							key={ day }
+							count={ events.length }
+							date={ day }
+							isOpen={ day === this.state.openDay }
+							onClick={ this.toggleOpenDay }
+						>
+							{ events.map( event => (
+								<OrderEvent
+									key={ `${ event.type }-${ event.key }` }
+									event={ event }
+									orderId={ this.props.orderId }
+									siteId={ this.props.siteId }
+								/>
+							) ) }
+						</OrderEventsByDay>
+					);
+				} ) }
+			</div>
+		);
+	};
+
+	renderPlaceholder = () => {
+		const noop = () => {};
+		const placeholderClassName = 'is-placeholder';
+		return (
+			<div className={ placeholderClassName }>
+				<OrderEventsByDay count={ 0 } date="" isOpen={ true } index={ 1 } onClick={ noop }>
+					<OrderEvent />
+				</OrderEventsByDay>
+			</div>
+		);
+	};
+
+	render() {
+		return this.props.isLoaded ? this.renderNotes() : this.renderPlaceholder();
+	}
+}
+
+export default connect( ( state, props ) => {
+	const orderId = props.orderId || false;
+
+	const isLoaded = isActivityLogLoaded( state, orderId );
+	const events = getActivityLogEvents( state, orderId );
+
+	const eventsByDay = events.length ? getSortedEvents( events ) : {};
+	const days = eventsByDay ? keys( eventsByDay ) : [];
+	days.sort().reverse();
+
+	return {
+		isLoaded,
+		days,
+		events,
+		eventsByDay,
+	};
+} )( localize( OrderEvents ) );

--- a/client/extensions/woocommerce/app/order/order-activity-log/index.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log/index.js
@@ -2,42 +2,17 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
-import { connect } from 'react-redux';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { keys, last, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import {
-	isActivityLogLoaded,
-	getActivityLogEvents,
-} from 'woocommerce/state/sites/orders/activity-log/selectors';
 import Card from 'components/card';
+import OrderEvents from './events';
 import CreateOrderNote from './new-note';
-import OrderEvent from './event';
-import OrderEventsByDay from './day';
 import SectionHeader from 'components/section-header';
-
-function getSortedEvents( events ) {
-	const eventsByDay = {};
-	events.forEach( event => {
-		const day = moment( event.timestamp ).format( 'YYYYMMDD' );
-		if ( eventsByDay[ day ] ) {
-			eventsByDay[ day ].push( event );
-		} else {
-			eventsByDay[ day ] = [ event ];
-		}
-	} );
-
-	keys( eventsByDay ).forEach( day => {
-		eventsByDay[ day ] = sortBy( eventsByDay[ day ], [ 'timestamp', 'key' ] ).reverse();
-	} );
-	return eventsByDay;
-}
 
 class OrderActivityLog extends Component {
 	static propTypes = {
@@ -45,71 +20,14 @@ class OrderActivityLog extends Component {
 		siteId: PropTypes.number.isRequired,
 	};
 
-	componentWillMount() {
-		this.setState( { openDay: last( keys( this.props.eventsByDay ) ) } );
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		const newOpenDay = last( keys( nextProps.eventsByDay ) );
-		//if a new latest day has been appended, open it
-		if ( ! this.props.eventsByDay[ newOpenDay ] ) {
-			this.setState( { openDay: newOpenDay } );
-		}
-	}
-
-	toggleOpenDay = date => {
-		this.setState( () => ( { openDay: date } ) );
-	};
-
-	renderNotes = () => {
-		const { days, eventsByDay, translate } = this.props;
-		if ( ! days.length ) {
-			return <p>{ translate( 'No activity yet' ) }</p>;
-		}
-
-		return days.map( day => {
-			const events = eventsByDay[ day ];
-			return (
-				<OrderEventsByDay
-					key={ day }
-					count={ events.length }
-					date={ day }
-					isOpen={ day === this.state.openDay }
-					onClick={ this.toggleOpenDay }
-				>
-					{ events.map( event => (
-						<OrderEvent
-							key={ `${ event.type }-${ event.key }` }
-							event={ event }
-							orderId={ this.props.orderId }
-							siteId={ this.props.siteId }
-						/>
-					) ) }
-				</OrderEventsByDay>
-			);
-		} );
-	};
-
-	renderPlaceholder = () => {
-		const noop = () => {};
-		return (
-			<OrderEventsByDay count={ 0 } date="" isOpen={ true } index={ 1 } onClick={ noop }>
-				<OrderEvent />
-			</OrderEventsByDay>
-		);
-	};
-
 	render() {
-		const { isLoaded, orderId, siteId, translate } = this.props;
-		const classes = classNames( {
-			'is-placeholder': ! isLoaded,
-		} );
+		const { orderId, siteId, translate } = this.props;
 
 		return (
 			<div className="order-activity-log">
 				<SectionHeader label={ translate( 'Activity Log' ) } />
-				<Card className={ classes }>
-					{ isLoaded ? this.renderNotes() : this.renderPlaceholder() }
+				<Card>
+					<OrderEvents orderId={ orderId } siteId={ siteId } />
 					<CreateOrderNote orderId={ orderId } siteId={ siteId } />
 				</Card>
 			</div>
@@ -117,20 +35,4 @@ class OrderActivityLog extends Component {
 	}
 }
 
-export default connect( ( state, props ) => {
-	const orderId = props.orderId || false;
-
-	const isLoaded = isActivityLogLoaded( state, orderId );
-	const events = getActivityLogEvents( state, orderId );
-
-	const eventsByDay = events.length ? getSortedEvents( events ) : {};
-	const days = eventsByDay ? keys( eventsByDay ) : [];
-	days.sort().reverse();
-
-	return {
-		isLoaded,
-		days,
-		events,
-		eventsByDay,
-	};
-} )( localize( OrderActivityLog ) );
+export default localize( OrderActivityLog );

--- a/client/extensions/woocommerce/woocommerce-services/lib/utils/get-product-link.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/utils/get-product-link.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { getLink } from 'woocommerce/lib/nav-utils';
+
+/**
+ * Given the product id and site, returns url of the product edit page
+ * @param {String} productId - product id
+ * @param {Object} site - site
+ * @returns {String} - url of the product edit page
+ */
+export default ( productId, site ) => {
+	return getLink( '/store/product/:site/' + productId, site );
+};

--- a/client/extensions/woocommerce/woocommerce-services/state/label-settings/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/label-settings/actions.js
@@ -58,7 +58,7 @@ export const fetchSettings = siteId => ( dispatch, getState ) => {
 };
 
 export const submit = ( siteId, onSaveSuccess, onSaveFailure ) => ( dispatch, getState ) => {
-	dispatch( setFormMetaProperty( 'isSaving', true ) );
+	dispatch( setFormMetaProperty( siteId, 'isSaving', true ) );
 	api
 		.post( siteId, api.url.accountSettings, getLabelSettingsFormData( getState() ) )
 		.then( onSaveSuccess )

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -182,14 +182,13 @@ const getLabelRates = ( orderId, siteId, dispatch, getState, handleResponse ) =>
 
 export const openPrintingFlow = ( orderId, siteId ) => (
 	dispatch,
-	getState,
-	getErrors = getFormErrors
+	getState
 ) => {
 	const state = getShippingLabel( getState(), orderId, siteId );
 	const storeOptions = state.storeOptions;
 	let form = state.form;
 	const { origin, destination } = form;
-	const errors = getErrors( getState(), orderId, siteId );
+	const errors = getFormErrors( getState(), orderId, siteId );
 	const promisesQueue = [];
 
 	if ( ! origin.ignoreValidation &&

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/actions.js
@@ -13,6 +13,7 @@ import {
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP,
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW,
  } from '../../action-types';
+import * as selectors from '../selectors';
 
 const orderId = 1;
 const siteId = 123456;
@@ -64,25 +65,6 @@ function createGetStateFn( newProps = { origin: {}, destination: {} } ) {
 	};
 }
 
-function createGetFormErrorsFn( opts = {} ) {
-	const errors = {};
-	const defaultError = {
-		address: 'This address is not recognized. Please try another.',
-	};
-
-	if ( opts.setOriginError ) {
-		errors.origin = defaultError;
-	}
-
-	if ( opts.setDestinationError ) {
-		errors.destination = defaultError;
-	}
-
-	return function() {
-		return errors;
-	};
-}
-
 describe( 'Shipping label Actions', () => {
 	describe( '#openPrintingFlow', () => {
 		nock( 'https://public-api.wordpress.com:443' )
@@ -103,10 +85,7 @@ describe( 'Shipping label Actions', () => {
 
 			openPrintingFlow( orderId, siteId )(
 				dispatchSpy,
-				createGetStateFn( { origin: { ignoreValidation: true } } ),
-				createGetFormErrorsFn(
-					{ setOriginError: false, setDestinationError: false }
-				)
+				createGetStateFn( { origin: { ignoreValidation: true } } )
 			);
 
 			it( 'toggle origin', () => {
@@ -132,12 +111,11 @@ describe( 'Shipping label Actions', () => {
 		describe( 'origin errors exist', () => {
 			const dispatchSpy = sinon.spy();
 
+			const errorStub = sinon.stub( selectors, 'getFormErrors' ).returns( { origin: true } );
+
 			openPrintingFlow( orderId, siteId )(
 				dispatchSpy,
-				createGetStateFn(),
-				createGetFormErrorsFn(
-					{ setOriginError: true, setDestinationError: false }
-				)
+				createGetStateFn()
 			);
 
 			it( 'toggles origin', () => {
@@ -155,6 +133,8 @@ describe( 'Shipping label Actions', () => {
 					type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW, orderId, siteId,
 				} ) ).to.equal( true );
 			} );
+
+			errorStub.restore();
 		} );
 
 		describe( 'destination validation ignored', () => {
@@ -164,10 +144,7 @@ describe( 'Shipping label Actions', () => {
 				dispatchSpy,
 				createGetStateFn( {
 					destination: { ignoreValidation: true },
-				} ),
-				createGetFormErrorsFn(
-					{ setOriginError: false, setDestinationError: false }
-				)
+				} )
 			);
 
 			it( 'toggle destination', () => {
@@ -190,12 +167,11 @@ describe( 'Shipping label Actions', () => {
 		describe( 'destination errors exist', () => {
 			const dispatchSpy = sinon.spy();
 
+			const errorStub = sinon.stub( selectors, 'getFormErrors' ).returns( { destination: true } );
+
 			openPrintingFlow( orderId, siteId )(
 				dispatchSpy,
-				createGetStateFn(),
-				createGetFormErrorsFn(
-					{ setOriginError: false, setDestinationError: true }
-				)
+				createGetStateFn()
 			);
 
 			it( 'toggle destination', () => {
@@ -213,6 +189,8 @@ describe( 'Shipping label Actions', () => {
 					type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW, orderId, siteId,
 				} ) ).to.equal( true );
 			} );
+
+			errorStub.restore();
 		} );
 
 		nock.cleanAll();

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -18,6 +18,7 @@ import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import PaymentMethod, { getPaymentMethodTitle } from './label-payment-method';
+import { getOrigin } from 'woocommerce/lib/nav-utils';
 
 class ShippingLabels extends Component {
 	componentWillMount() {
@@ -123,7 +124,7 @@ class ShippingLabels extends Component {
 			<div>
 				<p className="label-settings__credit-card-description">{ description }</p>
 				{ paymentMethods.map( renderPaymentMethod ) }
-				<Button href="/me/billing" target="_blank" compact>
+				<Button href={ getOrigin() + '/me/purchases/add-credit-card' } target="_blank" compact>
 					{ buttonLabel }
 				</Button>
 			</div>

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
@@ -129,7 +129,7 @@ const AddPackageDialog = props => {
 	return (
 		<Dialog
 			isVisible={ showModal }
-			additionalClassNames="packages__add-edit-dialog woocommerce"
+			additionalClassNames="packages__add-edit-dialog woocommerce wcc-root"
 			onClose={ onClose }
 			buttons={ buttons }
 		>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-details-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-details-modal.js
@@ -25,7 +25,7 @@ const DetailsDialog = ( props ) => {
 
 	return (
 		<Dialog
-			additionalClassNames="label-details-modal woocommerce"
+			additionalClassNames="label-details-modal woocommerce wcc-root"
 			isVisible={ isVisible }
 			onClose={ onClose }
 			buttons={ buttons }>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -93,7 +93,7 @@ const PurchaseDialog = ( props ) => {
 
 	return (
 		<Dialog
-			additionalClassNames="woocommerce label-purchase-modal"
+			additionalClassNames="woocommerce label-purchase-modal wcc-root"
 			isVisible={ props.showPurchaseDialog }
 			onClose={ onClose }
 			buttons={ buttons } >

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/add-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/add-item.js
@@ -90,14 +90,14 @@ const AddItemDialog = ( props ) => {
 				onClickOutside={ onClose }
 				onClose={ onClose }
 				buttons={ buttons }
-				additionalClassNames="wcc-root packages-step__dialog" >
+				additionalClassNames="wcc-root woocommerce packages-step__dialog" >
 			<FormSectionHeading>{ translate( 'Add item' ) }</FormSectionHeading>
 			<div className="packages-step__dialog-body">
 				<p>
 					{ translate( 'Which items would you like to add to {{pckg/}}?', {
 						components: {
 							pckg: getPackageNameElement( openedPackageId ),
-						}
+						},
 					} ) }
 				</p>
 				{ itemOptions }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/item-info.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/item-info.js
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import { getLink } from 'woocommerce/lib/nav-utils';
+import getProductLink from 'woocommerce/woocommerce-services/lib/utils/get-product-link';
 import { getSite } from 'state/sites/selectors';
 import { openItemMove } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 
@@ -29,7 +29,7 @@ const ItemInfo = ( props ) => {
 
 	const productLink = item.url
 		? <a
-			href={ getLink( '/store/product/:site/' + item.product_id, site ) }
+			href={ getProductLink( item.product_id, site ) }
 			target="_blank"
 			rel="noopener noreferrer">
 			{ item.name }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/list.js
@@ -19,6 +19,7 @@ import {
 	isLoaded,
 	getFormErrors,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
 
 const PackageList = ( props ) => {
 	const { orderId, siteId, selected, all, errors, packageId, translate } = props;
@@ -99,7 +100,7 @@ const mapStateToProps = ( state, { orderId, siteId } ) => {
 		errors,
 		packageId: shippingLabel.openedPackageId,
 		selected: shippingLabel.form.packages.selected,
-		all: shippingLabel.form.packages.all,
+		all: getAllPackageDefinitions( state, siteId ),
 	};
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/move-item.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/move-item.js
@@ -15,10 +15,11 @@ import FormRadio from 'components/forms/form-radio';
 import FormLabel from 'components/forms/form-label';
 import getPackageDescriptions from './get-package-descriptions';
 import FormSectionHeading from 'components/forms/form-section-heading';
-import { getLink } from 'woocommerce/lib/nav-utils';
+import getProductLink from 'woocommerce/woocommerce-services/lib/utils/get-product-link';
 import { getSite } from 'state/sites/selectors';
 import { closeItemMove, setTargetPackage, moveItem } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 import { getShippingLabel } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
 
 const MoveItemDialog = ( props ) => {
 	const {
@@ -31,7 +32,7 @@ const MoveItemDialog = ( props ) => {
 		openedPackageId,
 		selected,
 		all,
-		translate
+		translate,
 	} = props;
 
 	if ( -1 === movedItemIndex || ! showItemMoveDialog ) {
@@ -53,7 +54,7 @@ const MoveItemDialog = ( props ) => {
 	const openedPackage = selected[ openedPackageId ];
 	const items = openedPackage.items;
 	const item = items[ movedItemIndex ];
-	const itemUrl = getLink( '/store/product/:site/' + item.product_id, site );
+	const itemUrl = getProductLink( item.product_id, site );
 	const itemLink = <a href={ itemUrl } target="_blank" rel="noopener noreferrer">{ item.name }</a>;
 	let desc;
 
@@ -120,7 +121,7 @@ const MoveItemDialog = ( props ) => {
 				onClickOutside={ onClose }
 				onClose={ onClose }
 				buttons={ buttons }
-				additionalClassNames="wcc-root packages-step__dialog" >
+				additionalClassNames="wcc-root woocommerce packages-step__dialog" >
 			<FormSectionHeading>{ translate( 'Move item' ) }</FormSectionHeading>
 			<div className="packages-step__dialog-body">
 				<p>{ desc }</p>
@@ -155,7 +156,7 @@ const mapStateToProps = ( state, { orderId, siteId } ) => {
 		targetPackageId: shippingLabel.targetPackageId,
 		openedPackageId: shippingLabel.openedPackageId,
 		selected: shippingLabel.form.packages.selected,
-		all: shippingLabel.form.packages.all,
+		all: getAllPackageDefinitions( state, siteId ),
 	};
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
@@ -1,28 +1,10 @@
-&.dialog.card.packages-step__dialog {
-	top: -46px;
+.packages-step__dialog-package-option {
+	font-weight: normal;
+	margin-bottom: 10px;
+}
 
-	@include breakpoint( ">480px" ) {
-		top: 10%;
-		right: calc(50% - 200px);
-		bottom: 10%;
-		left: calc(50% - 200px);
-		width: 400px;
-	}
-
-	.packages-step__dialog-package-option {
-		font-weight: normal;
-		margin-bottom: 10px;
-	}
-
-	.packages-step__dialog-package-name {
-		font-weight: bold;
-	}
-
-	.packages-step__dialog-body {
-		@include breakpoint( "<480px" ) {
-			padding: 0 16px;
-		}
-	}
+.packages-step__dialog-package-name {
+	font-weight: bold;
 }
 
 .packages-step__contents {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
@@ -43,11 +43,11 @@ const Sidebar = ( props ) => {
 				value={ paperSize }
 				updateValue={ onPaperSizeChange }
 				error={ errors.paperSize } />
-			<FormLabel>
+			<FormLabel className="label-purchase-modal__option-email-customer">
 				<FormCheckbox checked={ emailDetails } onChange={ onEmailDetailsChange } />
 				<span>{ translate( 'Email shipment details to the customer' ) }</span>
 			</FormLabel>
-			<FormLabel>
+			<FormLabel className="label-purchase-modal__option-mark-order-fulfilled">
 				<FormCheckbox checked={ fulfillOrder } onChange={ onFulfillOrderChange } />
 				<span>{ translate( 'Mark the order as fulfilled' ) }</span>
 			</FormLabel>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-refund-modal.js
@@ -17,7 +17,7 @@ import { isLoaded, getShippingLabel } from 'woocommerce/woocommerce-services/sta
 import formatCurrency from 'lib/format-currency';
 
 const RefundDialog = ( props ) => {
-	const { orderId, siteId, refundDialog, created, refundableAmount, currency, labelId, translate, moment } = props;
+	const { orderId, siteId, refundDialog, createdDate, refundableAmount, currency, labelId, translate, moment } = props;
 
 	const getRefundableAmount = () => {
 		return formatCurrency( refundableAmount, currency );
@@ -40,7 +40,7 @@ const RefundDialog = ( props ) => {
 
 	return (
 		<Dialog
-			additionalClassNames="label-refund-modal woocommerce"
+			additionalClassNames="label-refund-modal woocommerce wcc-root"
 			isVisible={ Boolean( refundDialog && refundDialog.labelId === labelId ) }
 			onClose={ onClose }
 			buttons={ buttons }>
@@ -53,7 +53,7 @@ const RefundDialog = ( props ) => {
 			</p>
 			<dl>
 				<dt>{ translate( 'Purchase date' ) }</dt>
-				<dd>{ moment( created ).format( 'MMMM Do YYYY, h:mm a' ) }</dd>
+				<dd>{ moment( createdDate ).format( 'MMMM Do YYYY, h:mm a' ) }</dd>
 
 				<dt>{ translate( 'Amount eligible for refund' ) }</dt>
 				<dd>{ getRefundableAmount() }</dd>
@@ -66,7 +66,7 @@ RefundDialog.propTypes = {
 	siteId: PropTypes.number.isRequired,
 	orderId: PropTypes.number.isRequired,
 	refundDialog: PropTypes.object,
-	created: PropTypes.number,
+	createdDate: PropTypes.number,
 	refundableAmount: PropTypes.number,
 	currency: PropTypes.string,
 	labelId: PropTypes.number,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-reprint-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-reprint-modal.js
@@ -41,7 +41,7 @@ const ReprintDialog = ( props ) => {
 			isVisible={ Boolean( reprintDialog && reprintDialog.labelId === labelId ) }
 			onClose={ onClose }
 			buttons={ buttons }
-			additionalClassNames="label-reprint-modal woocommerce">
+			additionalClassNames="label-reprint-modal woocommerce wcc-root">
 			<FormSectionHeading>
 				{ translate( 'Reprint shipping label' ) }
 			</FormSectionHeading>


### PR DESCRIPTION
Moves parts of the `OrderActivityLog` code to a separate file, so it can be imported and used by the WCS plugin in WP-Admin. See https://github.com/Automattic/woocommerce-services/pull/1216#issuecomment-343538724

To test:
* everything should work as before in Calypso

CC @Automattic/hydra 