### PR TITLE
Components: Add TimeSince component (based on Reader/PostTime)

### DIFF
--- a/client/components/time-since/README.md
+++ b/client/components/time-since/README.md
@@ -1,0 +1,20 @@
+# Time Since
+
+Shows a date relative to now in a human friendly format.
+Updates the display as time progresses.
+
+## Examples
+
+Under a minute:
+`Just now`
+
+Under a week:
+`20h ago`
+`5d ago`
+
+Over a week:
+`Oct 30, 2017`
+
+## Props
+
+- `date`: Date, The date to show

--- a/client/components/time-since/index.jsx
+++ b/client/components/time-since/index.jsx
@@ -1,0 +1,53 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import smartSetState from 'lib/react-smart-set-state';
+import ticker from 'lib/ticker';
+import humanDate from 'lib/human-date';
+
+export default class TimeSince extends PureComponent {
+	smartSetState = smartSetState;
+
+	componentWillMount() {
+		this.update();
+	}
+
+	componentDidMount() {
+		ticker.on( 'tick', this.update );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		this.update( nextProps.date );
+	}
+
+	componentWillUnmount() {
+		ticker.off( 'tick', this.update );
+	}
+
+	update = date => {
+		date = date || this.props.date;
+		this.smartSetState( {
+			humanDate: humanDate( date ),
+			fullDate: moment( date ).format( 'llll' ),
+		} );
+	};
+
+	render() {
+		return (
+			<time
+				className={ this.props.className }
+				dateTime={ this.props.date }
+				title={ this.state.fullDate }
+			>
+				{ this.state.humanDate }
+			</time>
+		);
+	}
+}

--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -15,7 +15,7 @@ import { flow, get } from 'lodash';
  */
 import { selectPostRevision } from 'state/posts/revisions/actions';
 import { isSingleUserSite } from 'state/sites/selectors';
-import PostTime from 'reader/post-time';
+import TimeSince from 'components/time-since';
 
 class EditorRevisionsListItem extends PureComponent {
 	selectRevision = () => {
@@ -35,7 +35,7 @@ class EditorRevisionsListItem extends PureComponent {
 				type="button"
 			>
 				<span className="editor-revisions-list__date">
-					<PostTime date={ revision.date } />
+					<TimeSince date={ revision.date } />
 				</span>
 
 				{ authorName &&

--- a/client/reader/post-time/index.jsx
+++ b/client/reader/post-time/index.jsx
@@ -3,48 +3,17 @@
  * External dependencies
  */
 import React from 'react';
-import { PureComponent } from 'react';
-import moment from 'moment';
+import { PropTypes } from 'prop-types';
+
 /**
  * Internal dependencies
  */
-import smartSetState from 'lib/react-smart-set-state';
-import ticker from 'lib/ticker';
-import humanDate from 'lib/human-date';
+import TimeSince from 'components/time-since';
 
-export default class PostTime extends PureComponent {
-	smartSetState = smartSetState;
+const PostTime = ( { className, date } ) => <TimeSince className={ className } date={ date } />;
 
-	componentWillMount() {
-		this.update();
-	}
+PostTime.propTypes = {
+	date: PropTypes.string.isRequired,
+};
 
-	componentDidMount() {
-		ticker.on( 'tick', this.update );
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		this.update( nextProps.date );
-	}
-
-	componentWillUnmount() {
-		ticker.off( 'tick', this.update );
-	}
-
-	update = date => {
-		date = date || this.props.date;
-		this.smartSetState( {
-			humanDate: humanDate( date ),
-			fullDate: moment( date ).format( 'llll' ),
-		} );
-	};
-
-	render() {
-		const date = this.props.date;
-		return (
-			<time className={ this.props.className } dateTime={ date } title={ this.state.fullDate }>
-				{ this.state.humanDate }
-			</time>
-		);
-	}
-}
+export default PostTime;


### PR DESCRIPTION
### Summary
I noticed that we're referring to `reader/post-time` in `editor-revisions-list/item.jsx`.
This works fine but, to me, crossing modules like this is a flag that the underlying code should be bumped out of the original module in to a more sharable position.
For this reason, this pulls out that component in to the `/components` directory.

This will be followed up with work to better show the time in the revision list items :)

Note: As it stands, `reader/post-time` is essentially just an alias to `TimeSince` - Happy to go either of two ways: Replace all refs to `reader/post-time` with `TimeSince` directly, or leave it as is.

### Testing
- Post Revisions
  - Open a post with revisions in the editor
  - Click the history button to open the revisions modal
  - Note that the revision list items show a human readable time

- Reader
  - Go to the reader, 
  - Note that the items in the posts feed displays a human readable time
  - Click through to a post
  - Note that the time is again shown in a human readable time in the post view