### PR TITLE
Update user_URL input to use HTML5 url input type

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -506,6 +506,7 @@ const Account = createReactClass( {
 						disabled={ this.getDisabledState() }
 						id="user_URL"
 						name="user_URL"
+						type="url"
 						onFocus={ this.recordFocusEvent( 'Web Address Field' ) }
 						value={ this.getUserSetting( 'user_URL' ) || '' }
 						onChange={ this.updateUserSettingInput }


### PR DESCRIPTION
#973 reports that users can save non-urls in the Web Address field

![screenshot](https://cloud.githubusercontent.com/assets/260253/7165641/aacfc426-e35d-11e4-948d-b3b724d2c07f.png)

This PR proposes updating this field to use the [HTML5 url input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/url), which provides validation natively in the browser.