### PR TITLE
Reader: tweak search placeholder text

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -48,7 +48,7 @@ const FollowingStream = props => {
 					autoFocus={ false }
 					delaySearch={ true }
 					delayTimeout={ 500 }
-					placeholder={ props.translate( 'Search billions of WordPress.com posts…' ) }
+					placeholder={ props.translate( 'Search billions of WordPress posts…' ) }
 				/>
 			</CompactCard>
 			<div className="search-stream__blank-suggestions">

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -126,7 +126,7 @@ class SearchStream extends React.Component {
 
 		let searchPlaceholderText = this.props.searchPlaceholderText;
 		if ( ! searchPlaceholderText ) {
-			searchPlaceholderText = translate( 'Search billions of WordPress.com posts…' );
+			searchPlaceholderText = translate( 'Search billions of WordPress posts…' );
 		}
 
 		const documentTitle = translate( '%s ‹ Reader', {


### PR DESCRIPTION
Earlier this year @tyxla suggested changing our search placeholder text from:

"Search billions of WordPress.com sites"

to 

"Search billions of WordPress sites"

His reasoning was:

> ...from a user point of view I find it a little confusing that we’re saying “WordPress.com posts” there, but we include posts from WordPress.org sites too. We often have the need to explain users the difference between WP.com and WP.org, and I think this is a confusion point that we could avoid.
> 
> Maybe it makes sense to change this to “Search billions of WordPress posts…” (ditching the .com part)?
> 

As we're now including some Jetpack sites in our search index, I think this change makes a lot of sense.

### To test

Visit http://calypso.localhost:3000/read/search and http://calypso.localhost:3000. Verify that the search placeholders read "Search billions of WordPress sites".
