### PR TITLE
Domains: Clean up UI on incoming transfers

### DIFF
--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -26,23 +26,48 @@
 
 .domain-search-results__transfer-card {
 	display: flex;
-	flex-direction: row;
-	align-items: center;
-	font-size: 17px;
+	flex-direction: column;
+
+	@include breakpoint( '>480px' ) {
+		align-items: center;
+		flex-direction: row;
+	}
 }
 
 .domain-search-results__transfer-card-copy {
+	font-size: 16px;
+
 	p {
-		padding-top: 10px;
 		margin-bottom: 0;
+	}
+
+	@include breakpoint( '>480px' ) {
+		padding-right: 10px;
+	}
+
+	@include breakpoint( '>660px' ) {
+		font-size: 18px;
+
+		p {
+			font-size: 16px;
+		}
 	}
 }
 
 .domain-search-results__transfer-card-link {
-	text-align: right;
-	min-width: 100px;
+	flex-shrink: 0;
+	width: 100%;
 
-	@include breakpoint( '>660px' ) {
-		min-width: 170px;
+	a {
+		display: block;
+		padding: 15px 0 0;
+	}
+
+	@include breakpoint( '>480px' ) {
+		width: auto;
+
+		a {
+			padding: 0;
+		}
 	}
 }

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -27,6 +27,7 @@ import {
 	recordGoButtonClickInMapDomain,
 } from 'state/domains/actions';
 import Notice from 'components/notice';
+import Card from 'components/card';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
@@ -121,12 +122,12 @@ class TransferDomainStep extends React.Component {
 				<form className="transfer-domain-step__form card" onSubmit={ this.handleFormSubmit }>
 					<div className="transfer-domain-step__domain-description">
 						<div className="transfer-domain-step__domain-heading">
-							{ translate( 'Use your own domain for your WordPress.com site.' ) }
+							{ translate( 'Manage your domain and site together on WordPress.com.' ) }
 						</div>
 						<div>
 							{ translate(
-								'Enter the domain you want to transfer to WordPress.com so you can manage your domain and site' +
-									" all in one place. Domains purchases in the last 60 days can't be transferred. {{a}}Learn More{{/a}}",
+								'Transfer your domain from your current provider to WordPress.com so ' +
+									'you can manage your domain and site in the same place. {{a}}Learn More{{/a}}',
 								{
 									components: { a: <a href="#" /> },
 								}
@@ -154,22 +155,28 @@ class TransferDomainStep extends React.Component {
 						{ translate( 'Transfer to WordPress.com' ) }
 					</button>
 					{ this.domainRegistrationUpsell() }
-					<div className="transfer-domain-step__map-option">
-						<p>
-							{ translate(
-								"Don't want to transfer? Keep it at your current domain provider " +
-									'and {{a}}map it{{/a}} for %(cost)s instead.',
-								{
-									args: { cost },
-									components: { a: <a href="#" onClick={ this.goToMapDomainStep } /> },
-								}
-							) }
-							<a href={ support.MAP_EXISTING_DOMAIN } rel="noopener noreferrer">
-								<Gridicon icon="help" size={ 12 } />
-							</a>
-						</p>
-					</div>
 				</form>
+
+				<Card className="transfer-domain-step__map-option">
+					<strong>{ translate( 'Manage your domain and site separately.' ) }</strong>
+					<p>
+						{ translate(
+							'Leave the domain at your current provider and {{a}}manually connect it{{/a}} to ' +
+								'your WordPress.com site for %(cost)s.',
+							{
+								args: { cost },
+								components: { a: <a href="#" onClick={ this.goToMapDomainStep } /> },
+							}
+						) }
+						<a
+							className="transfer-domain-step__map-help"
+							href={ support.MAP_EXISTING_DOMAIN }
+							rel="noopener noreferrer"
+						>
+							<Gridicon icon="help" size={ 18 } />
+						</a>
+					</p>
+				</Card>
 			</div>
 		);
 	}

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -8,7 +8,6 @@
 
 	p {
 		margin-bottom: 0;
-		opacity: 0.7;
 	}
 
 	.domain-product-price {
@@ -33,18 +32,17 @@
 
 .transfer-domain-step__domain-description {
 	font-size: 16px;
-	color: #2e4453;
-	margin-bottom: 10px;
+	margin-bottom: 20px;
 }
 
 .transfer-domain-step__go {
-	margin-top: 10px;
+	margin-top: 20px;
 	margin-bottom: 10px;
 }
 
 .transfer-domain-step__domain-heading {
 	font-size: 18px;
-	font-weight: bold;
+	font-weight: 500;
 	margin-bottom: 10px;
 }
 
@@ -55,8 +53,13 @@
 }
 
 .transfer-domain-step__map-option {
-	font-size: 14px;
-	text-align: center;
+	color: darken( $gray, 20% );
+}
+
+.transfer-domain-step__map-help {
+	color: $gray;
+	position: relative;
+	top: 2px;
 }
 
 .transfer-domain-step__precheck, .transfer-domain-step__options {

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -139,17 +139,18 @@
 
 .transfer-domain-step__options {
 	label {
-		color: $gray;
+		color: darken( $gray, 20% );
 	}
 
 	legend {
 		small {
+			font-size: 14px;
 			padding-left: 10px;
 			color: $blue-wordpress;
 		}
 
 		color: $gray-dark;
 		margin-bottom: 0;
-		font-size: 15px;
+		font-size: 16px;
 	}
 }

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -63,26 +63,20 @@
 }
 
 .transfer-domain-step__precheck, .transfer-domain-step__options {
-	background: white;
+	.foldable-card.card {
+		margin-bottom: 0;
 
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
-
-	div {
-		&.foldable-card.card {
-			margin-bottom: 0;
-
-			&.is-expanded {
-				margin-top: 0;
-			}
+		&.is-expanded {
+			margin-top: 0;
 		}
 	}
 
-	.transfer-domain-step__section-heading {
-		font-weight: 500;
+	.transfer-domain-step__section {
+		display: flex;
 	}
 
 	.transfer-domain-step__unlocked {
-		color: $green-jetpack;
+		color: $alert-green;
 
 		svg {
 			padding-right: 4px;
@@ -90,40 +84,44 @@
 	}
 
 	.transfer-domain-step__section-heading-number {
-		width: 20px;
-		height: 20px;
-		line-height: 20px;
-		display: inline-block;
-		border-radius: 15px;
-		background-color: rgb(68, 68, 68);
-		color: white;
-		font-size: 13px;
+		width: 28px;
+		height: 28px;
+		line-height: 28px;
+		border-radius: 50%;
+		border: 1px solid lighten( $gray, 20% );
+		background-color: $gray-light;
+		color: darken( $gray, 20% );
+		font-size: 18px;
 		text-align: center;
-		margin-right: 5px;
+		margin-right: 15px;
+		flex-shrink: 0;
+	}
+
+	.transfer-domain-step__section-heading {
+		font-size: 16px;
+	}
+
+	.transfer-domain-step__section-explanation {
+		margin-left: 48px;
 	}
 
 	.transfer-domain-step__continue {
-		font-size: 12px;
 		display: flex;
-		flex: 1 0;
 		align-items: center;
 		justify-content: space-between;
 
-		div {
-			padding-left: 20px;
-		}
-
 		button {
-			margin: 20px;
-
-			&.transfer-domain-step__in-card {
-				margin: 0;
-			}
+			flex-shrink: 0;
+			margin-left: 15px;
 		}
 	}
 
-	.foldable-card__content {
-		font-size: 13px;
+	.transfer-domain-step__continue-text {
+		p {
+			color: darken( $gray, 10% );
+			font-size: 14px;
+			max-width: 500px;
+		}
 	}
 
 	.section-header {

--- a/client/components/domains/transfer-domain-step/transfer-domain-options.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-options.jsx
@@ -14,7 +14,6 @@ import { get } from 'lodash';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import SectionHeader from 'components/section-header';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -74,7 +73,7 @@ class TransferDomainOptions extends React.PureComponent {
 
 		return (
 			<div className="transfer-domain-step__options">
-				<SectionHeader>{ headerLabel }</SectionHeader>
+				<Card compact={ true }>{ headerLabel }</Card>
 				<Card>
 					<FormFieldset>
 						<FormLabel>

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -15,7 +15,7 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 import FoldableCard from 'components/foldable-card';
-import SectionHeader from 'components/section-header';
+import Card from 'components/card';
 import { checkInboundTransferStatus } from 'lib/domains';
 import support from 'lib/url/support';
 
@@ -65,13 +65,11 @@ class TransferDomainPrecheck extends React.PureComponent {
 
 	getSection( heading, message, explanation, position, button ) {
 		const header = (
-			<div>
-				<div className="transfer-domain-step__section-heading">
-					<span className="transfer-domain-step__section-heading-number">{ position }</span>
-					{ heading }
-				</div>
+			<div className="transfer-domain-step__section">
+				<span className="transfer-domain-step__section-heading-number">{ position }</span>
 				<div>
-					<small>{ message }</small>
+					<strong className="transfer-domain-step__section-heading">{ heading }</strong>
+					<div className="transfer-domain-step__section-message">{ message }</div>
 				</div>
 			</div>
 		);
@@ -87,7 +85,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 				summary={ button }
 				expandedSummary={ button }
 			>
-				{ explanation }
+				<div className="transfer-domain-step__section-explanation">{ explanation }</div>
 			</FoldableCard>
 		);
 	}
@@ -175,32 +173,34 @@ class TransferDomainPrecheck extends React.PureComponent {
 	render() {
 		const { translate } = this.props;
 		const headerLabel = translate(
-			'Log into your current registrar to complete a few preliminary steps.'
+			"Let's get your domain ready to transfer. " +
+				'Log into your current registrar to complete a few preliminary steps.'
 		);
 
 		return (
 			<div className="transfer-domain-step__precheck">
-				<SectionHeader label={ headerLabel } />
+				<Card compact={ true }>{ headerLabel }</Card>
 				{ this.getStatusMessage() }
 				{ this.getPrivacyMessage() }
 				{ this.getEppMessage() }
-				<div className="transfer-domain-step__continue">
-					<div>
-						{ translate(
-							'Note: These changes can take up to 20 minutes to take effect.{{br/}}' +
-								'Need help? {{a}}Get in touch with one of our Happiness Engineers{{/a}}.',
-							{
-								components: {
-									a: <a href={ support.CALYPSO_CONTACT } rel="noopener noreferrer" />,
-									br: <br />,
-								},
-							}
-						) }
+				<Card className="transfer-domain-step__continue">
+					<div className="transfer-domain-step__continue-text">
+						<p>
+							{ translate(
+								'Note: These changes can take up to 20 minutes to take effect. ' +
+									'Need help? {{a}}Get in touch with one of our Happiness Engineers{{/a}}.',
+								{
+									components: {
+										a: <a href={ support.CALYPSO_CONTACT } rel="noopener noreferrer" />,
+									},
+								}
+							) }
+						</p>
 					</div>
-					<Button disabled={ ! this.state.unlocked } onClick={ this.onClick }>
+					<Button disabled={ ! this.state.unlocked } onClick={ this.onClick } primary={ true }>
 						{ translate( 'Continue' ) }
 					</Button>
-				</div>
+				</Card>
 			</div>
 		);
 	}

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -24,6 +24,7 @@ import {
 } from 'lib/products-values';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { localize } from 'i18n-calypso';
+import { preventWidows } from 'lib/formatting';
 
 class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
@@ -48,7 +49,9 @@ class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( primaryPurchase && isDomainTransfer( primaryPurchase ) ) {
-			return translate( 'Check your email for important information about your transfer.' );
+			return preventWidows(
+				translate( 'Check your email! There are important next steps waiting in your inbox.' )
+			);
 		}
 
 		return translate( 'Congratulations on your purchase!' );
@@ -143,8 +146,9 @@ class CheckoutThankYouHeader extends PureComponent {
 
 		if ( isDomainTransfer( primaryPurchase ) ) {
 			return translate(
-				"We're processing your request to transfer {{strong}}%(domainName)s{{/strong}} to WordPress.com. " +
-					'Be on the lookout for an important mail from us to confirm the transfer.',
+				'We sent an email with an important link. Please open the email and click the link to confirm ' +
+					'that you want to transfer {{strong}}%(domainName)s{{/strong}} to WordPress.com. ' +
+					"The transfer can't complete until you do!",
 				{
 					args: { domainName: primaryPurchase.meta },
 					components: { strong: <strong /> },


### PR DESCRIPTION
This cleans up the UI of the incoming domain transfers flow. It's as close to the design mock-ups as possible without making huge structural changes, with one exception. I changed the structure of the transfer step to bring it in line with the most recent iteration from the M2 work (new sites).

I've also made some responsive display bug fixes for smaller screens.

#### Testing
Go through the flow of transferring a domain into your account:

* Add a domain to your site from `/domains/manage/:site` or via sidebar.
* Search for a domain that's already taken or click to use a domain you already own.
* Input a domain you own. Make sure it takes you to the precheck screen.
* Unlock your domain, click Check Again. Make sure the status is properly picked.
* Check the e-mail shown as the admin email.
* Proceed to Options screen
* Make sure the options work and are submitted properly.
* Checkout and view thank you screen.

Assert the UI looks like the screenshots below.

![image](https://user-images.githubusercontent.com/448298/32863529-d6f0d710-ca29-11e7-9eae-580ba251a0fd.png)

![image](https://user-images.githubusercontent.com/448298/32863537-de3dba1a-ca29-11e7-98e0-c4877772f936.png)

![image](https://user-images.githubusercontent.com/448298/32863549-e5072dae-ca29-11e7-8d58-031d1e284066.png)

![image](https://user-images.githubusercontent.com/448298/32863565-ef0f31b6-ca29-11e7-91f3-be3fd438fb0f.png)

![image](https://user-images.githubusercontent.com/448298/32863577-f55f52da-ca29-11e7-9852-b22ef0b8cfa2.png)

<img width="987" alt="screen shot 2017-11-15 at 17 01 09" src="https://user-images.githubusercontent.com/448298/32863590-03958cc0-ca2a-11e7-8b9d-fd83625a969d.png">

#### Review

- [x] Code
- [x] Product