### PR TITLE
Single-tree-rendering codemod: don't transform routes with redirects

### DIFF
--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -429,7 +429,7 @@ export default function transformer( file, api ) {
 			return (
 				p.value.arguments.length > 1 &&
 				p.value.arguments[ 0 ].value !== '*' &&
-				[ 'Identifier', 'MemberExpression' ].indexOf( lastArgument.type ) > -1 &&
+				[ 'Identifier', 'MemberExpression', 'CallExpression' ].indexOf( lastArgument.type ) > -1 &&
 				! isRedirectMiddleware( lastArgument )
 			);
 		} )


### PR DESCRIPTION
_Related to PR #19494 "Single tree-rendering-issues"_

Stops single-tree-rendering codemod from adding `makeLayout` and `clientRender` middlewares to route definitions which end with redirects, such as:

- `() => page.redirect( '/' )`
- `/page` (string Literal)
- `/` (string Literal)

# Testing
```bash
npm run codemod single-tree-rendering \
 client/reader/index.js \
 client/reader/conversations/index.js \
 client/reader/recommendations/index.js \
 client/extensions/zoninator/index.js \
 client/post-editor/index.js \
 client/me/purchases/index.js \
 client/boot/common.js
```

→ Routes with `page.redirect()` in them don't get transformed in `client/post-editor/index.js`, `client/me/purchases/index.js` and `client/boot/common.js`

→ Routes ending to `renderTab()` or `sites` get `makeLayout/clientRender` appended to them in `client/extensions/zoninator/index.js`

→ Routes with strings as last arguments won't get transformed and no 'controller' import is added in `client/reader/recommendations/index.js`

→ Routes with `'/'` as a last argument won't get transformed in `client/reader/conversations/index.js` and `client/reader/index.js`