### PR TITLE
Post Revisions: Don't compute or display diffs when the amount of content is too large

### DIFF
--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -13,7 +13,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getPostRevisionChanges } from 'state/selectors';
+import { getPostRevision, getPostRevisionChanges } from 'state/selectors';
 import EditorDiffChanges from './changes';
 
 class EditorDiffViewer extends PureComponent {
@@ -48,17 +48,22 @@ class EditorDiffViewer extends PureComponent {
 	}
 
 	render() {
-		const { revisionChanges } = this.props;
-		if ( revisionChanges.tooLong ) {
-			return <div className="editor-diff-viewer">TOO LONG!</div>;
-		}
+		const { revision, revisionChanges } = this.props;
 		return (
 			<div className="editor-diff-viewer">
 				<h1 className="editor-diff-viewer__title">
-					<EditorDiffChanges changes={ revisionChanges.title } />
+					{ revisionChanges.tooLong ? (
+						revision.title
+					) : (
+						<EditorDiffChanges changes={ revisionChanges.title } />
+					) }
 				</h1>
 				<pre className="editor-diff-viewer__content">
-					<EditorDiffChanges changes={ revisionChanges.content } />
+					{ revisionChanges.tooLong ? (
+						revision.content
+					) : (
+						<EditorDiffChanges changes={ revisionChanges.content } />
+					) }
 				</pre>
 			</div>
 		);
@@ -66,5 +71,6 @@ class EditorDiffViewer extends PureComponent {
 }
 
 export default connect( ( state, { siteId, postId, selectedRevisionId } ) => ( {
+	revision: getPostRevision( state, siteId, postId, selectedRevisionId, 'display' ),
 	revisionChanges: getPostRevisionChanges( state, siteId, postId, selectedRevisionId ),
 } ) )( EditorDiffViewer );

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -49,6 +49,9 @@ class EditorDiffViewer extends PureComponent {
 
 	render() {
 		const { revisionChanges } = this.props;
+		if ( revisionChanges.tooLong ) {
+			return <div className="editor-diff-viewer">TOO LONG!</div>;
+		}
 		return (
 			<div className="editor-diff-viewer">
 				<h1 className="editor-diff-viewer__title">

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -104,7 +104,7 @@ class EditorRevisionsList extends PureComponent {
 	};
 
 	render() {
-		const { revisions, selectedRevisionId, siteId } = this.props;
+		const { postId, revisions, selectedRevisionId, siteId } = this.props;
 		return (
 			<div className="editor-revisions-list">
 				<EditorRevisionsListHeader numRevisions={ revisions.length } />
@@ -116,7 +116,11 @@ class EditorRevisionsList extends PureComponent {
 							} );
 							return (
 								<li className={ itemClasses } key={ revision.id }>
-									<EditorRevisionsListItem revision={ revision } siteId={ siteId } />
+									<EditorRevisionsListItem
+										postId={ postId }
+										revision={ revision }
+										siteId={ siteId }
+									/>
 								</li>
 							);
 						} ) }

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -27,7 +27,12 @@ class EditorRevisionsList extends PureComponent {
 		selectedRevisionId: PropTypes.number,
 	};
 
-	trySelectingTimeout = null;
+	trySelectingInterval = null;
+
+	selectRevision = revisionId => {
+		clearInterval( this.trySelectingInterval );
+		this.props.selectPostRevision( revisionId );
+	};
 
 	trySelectingFirstRevision = () => {
 		const { revisions } = this.props;
@@ -38,17 +43,8 @@ class EditorRevisionsList extends PureComponent {
 		if ( ! firstRevision.id ) {
 			return;
 		}
-		this.props.selectPostRevision( firstRevision.id );
+		this.selectRevision( firstRevision.id );
 	};
-
-	componentWillReceiveProps( { selectedRevisionId } ) {
-		if (
-			! this.trySelectingTimeout &&
-			( ! selectedRevisionId || ! this.props.selectedRevisionId )
-		) {
-			this.trySelectingTimeout = setTimeout( this.trySelectingFirstRevision, 300 );
-		}
-	}
 
 	componentDidMount() {
 		// Make sure that scroll position in the editor is not preserved.
@@ -56,11 +52,17 @@ class EditorRevisionsList extends PureComponent {
 
 		KeyboardShortcuts.on( 'move-selection-up', this.selectNextRevision );
 		KeyboardShortcuts.on( 'move-selection-down', this.selectPreviousRevision );
+
+		if ( ! this.props.selectedRevisionId ) {
+			this.trySelectingInterval = setInterval( this.trySelectingFirstRevision, 500 );
+		}
 	}
 
 	componentWillUnmount() {
 		KeyboardShortcuts.off( 'move-selection-up', this.selectNextRevision );
 		KeyboardShortcuts.off( 'move-selection-down', this.selectPreviousRevision );
+
+		clearInterval( this.trySelectingInterval );
 	}
 
 	componentDidUpdate() {
@@ -95,12 +97,12 @@ class EditorRevisionsList extends PureComponent {
 
 	selectNextRevision = () => {
 		const { nextRevisionId } = this.props;
-		nextRevisionId && this.props.selectPostRevision( nextRevisionId );
+		nextRevisionId && this.selectRevision( nextRevisionId );
 	};
 
 	selectPreviousRevision = () => {
 		const { prevRevisionId } = this.props;
-		prevRevisionId && this.props.selectPostRevision( prevRevisionId );
+		prevRevisionId && this.selectRevision( prevRevisionId );
 	};
 
 	render() {

--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -13,6 +13,7 @@ import { flow, get } from 'lodash';
 /**
  * Internal dependencies
  */
+import { getPostRevisionChanges } from 'state/selectors';
 import { selectPostRevision } from 'state/posts/revisions/actions';
 import { isSingleUserSite } from 'state/sites/selectors';
 import PostTime from 'reader/post-time';
@@ -23,10 +24,10 @@ class EditorRevisionsListItem extends PureComponent {
 	};
 
 	render() {
-		const { revision, isMultiUserSite, translate } = this.props;
+		const { revision, revisionChanges, isMultiUserSite, translate } = this.props;
 		const authorName = get( revision, 'author.display_name' );
-		const added = get( revision, 'summary.added' );
-		const removed = get( revision, 'summary.removed' );
+		const added = get( revisionChanges, 'summary.added' );
+		const removed = get( revisionChanges, 'summary.removed' );
 
 		return (
 			<button
@@ -81,11 +82,13 @@ class EditorRevisionsListItem extends PureComponent {
 }
 
 EditorRevisionsListItem.propTypes = {
+	postId: PropTypes.number,
 	revision: PropTypes.object.isRequired,
 	siteId: PropTypes.number.isRequired,
 
 	// connected to state
 	isMultiUserSite: PropTypes.bool.isRequired,
+	revisionChanges: PropTypes.array.isRequired,
 
 	// connected to dispatcher
 	selectPostRevision: PropTypes.func.isRequired,
@@ -97,8 +100,9 @@ EditorRevisionsListItem.propTypes = {
 export default flow(
 	localize,
 	connect(
-		( state, { siteId } ) => ( {
+		( state, { postId, revision, siteId } ) => ( {
 			isMultiUserSite: ! isSingleUserSite( state, siteId ),
+			revisionChanges: getPostRevisionChanges( state, siteId, postId, revision.id ),
 		} ),
 		{ selectPostRevision }
 	)

--- a/client/state/selectors/get-post-revision-changes.js
+++ b/client/state/selectors/get-post-revision-changes.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { findIndex, get, isUndefined, map, reduce, omitBy } from 'lodash';
+import { findIndex, get, isUndefined, map, omitBy, reduce } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/state/selectors/get-post-revision-changes.js
+++ b/client/state/selectors/get-post-revision-changes.js
@@ -13,7 +13,7 @@ import createSelector from 'lib/create-selector';
 import { countDiffWords, diffWords } from 'lib/text-utils';
 import getPostRevisions from 'state/selectors/get-post-revisions';
 
-const MAX_DIFF_WORDS = 10000;
+const MAX_DIFF_CONTENT_LENGTH = 10000;
 
 const diffKey = ( key, obj1, obj2 ) =>
 	map( diffWords( get( obj1, key, '' ), get( obj2, key, '' ) ), change =>
@@ -39,7 +39,7 @@ const getPostRevisionChanges = createSelector(
 		const previousRevision = get( orderedRevisions, [ revisionIndex + 1 ], {} );
 		const combinedLength = getCombinedLength( [ previousRevision, revision ] );
 
-		if ( combinedLength > MAX_DIFF_WORDS ) {
+		if ( combinedLength > MAX_DIFF_CONTENT_LENGTH ) {
 			return { content: [], title: [], tooLong: true };
 		}
 		const title = diffKey( 'title', previousRevision, revision );

--- a/client/state/selectors/get-post-revision-changes.js
+++ b/client/state/selectors/get-post-revision-changes.js
@@ -4,13 +4,28 @@
  * External dependencies
  */
 
-import { findIndex } from 'lodash';
+import { findIndex, get, isUndefined, map, reduce, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
+import { countDiffWords, diffWords } from 'lib/text-utils';
 import getPostRevisions from 'state/selectors/get-post-revisions';
+
+const MAX_DIFF_WORDS = 10000;
+
+const diffKey = ( key, obj1, obj2 ) =>
+	map( diffWords( get( obj1, key, '' ), get( obj2, key, '' ) ), change =>
+		omitBy( change, isUndefined )
+	);
+
+const getCombinedLength = list =>
+	reduce(
+		list,
+		( sum, r ) => ( sum += get( r, 'title.length', 0 ) + get( r, 'content.length', 0 ) ),
+		0
+	);
 
 const getPostRevisionChanges = createSelector(
 	( state, siteId, postId, revisionId ) => {
@@ -19,7 +34,23 @@ const getPostRevisionChanges = createSelector(
 		if ( revisionIndex === -1 ) {
 			return { content: [], title: [] };
 		}
-		return orderedRevisions[ revisionIndex ].changes;
+
+		const revision = orderedRevisions[ revisionIndex ];
+		const previousRevision = get( orderedRevisions, [ revisionIndex + 1 ], {} );
+		const combinedLength = getCombinedLength( [ previousRevision, revision ] );
+
+		if ( combinedLength > MAX_DIFF_WORDS ) {
+			return { content: [], title: [], tooLong: true };
+		}
+		const title = diffKey( 'title', previousRevision, revision );
+		const content = diffKey( 'content', previousRevision, revision );
+		const summary = countDiffWords( title.concat( content ) );
+
+		return {
+			content,
+			summary,
+			title,
+		};
 	},
 	state => [ state.posts.revisions.revisions ]
 );

--- a/client/state/selectors/get-post-revision-changes.js
+++ b/client/state/selectors/get-post-revision-changes.js
@@ -32,7 +32,7 @@ const getPostRevisionChanges = createSelector(
 		const orderedRevisions = getPostRevisions( state, siteId, postId, 'display' );
 		const revisionIndex = findIndex( orderedRevisions, { id: revisionId } );
 		if ( revisionIndex === -1 ) {
-			return { content: [], title: [] };
+			return { content: [], summary: [], title: [] };
 		}
 
 		const revision = orderedRevisions[ revisionIndex ];
@@ -40,7 +40,7 @@ const getPostRevisionChanges = createSelector(
 		const combinedLength = getCombinedLength( [ previousRevision, revision ] );
 
 		if ( combinedLength > MAX_DIFF_CONTENT_LENGTH ) {
-			return { content: [], title: [], tooLong: true };
+			return { content: [], summary: [], title: [], tooLong: true };
 		}
 		const title = diffKey( 'title', previousRevision, revision );
 		const content = diffKey( 'content', previousRevision, revision );


### PR DESCRIPTION
Note: this PR is targeting `fix/multiple-revision-diffs` aka #19072.

Perform the diff in the selector so it is memoized by `createSelector` & can be used in both the list item & the diff view.

In progress.