### PR TITLE
Post Revisions: Add loading placeholders to post revisions

### DIFF
--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -7,6 +7,7 @@
 import React, { PureComponent } from 'react';
 import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 
@@ -49,8 +50,11 @@ class EditorDiffViewer extends PureComponent {
 
 	render() {
 		const { revisionChanges } = this.props;
+		const classes = classNames( 'editor-diff-viewer', {
+			'is-loading': ! revisionChanges.title.length,
+		} );
 		return (
-			<div className="editor-diff-viewer">
+			<div className={ classes }>
 				<h1 className="editor-diff-viewer__title">
 					<EditorDiffChanges changes={ revisionChanges.title } />
 				</h1>

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -9,7 +9,7 @@ import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { get, has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -51,7 +51,7 @@ class EditorDiffViewer extends PureComponent {
 	render() {
 		const { revisionChanges } = this.props;
 		const classes = classNames( 'editor-diff-viewer', {
-			'is-loading': ! revisionChanges.title.length,
+			'is-loading': ! has( revisionChanges, 'title[0].value' ),
 		} );
 		return (
 			<div className={ classes }>

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -26,6 +26,13 @@
 	}
 }
 
+.editor-diff-viewer.is-loading .editor-diff-viewer__title {
+	display: inline-block;
+	width: 50%;
+	height: 38px;
+	@include placeholder(23%);
+}
+
 .editor-diff-viewer__content {
 	font-family: $serif;
 	font-size: 15px;
@@ -33,6 +40,27 @@
 	padding: 0;
 	background: transparent;
 	overflow-y: hidden;
+}
+
+.editor-diff-viewer.is-loading .editor-diff-viewer__content {
+	&:before,
+	&:after {
+		content: '';
+		display: block;
+		width: 100%;
+		height: 20px;
+		margin-top: 6px;
+		@include placeholder(23%);
+	}
+
+	&:before {
+		width: 75%;
+	}
+
+	&:after {
+		margin-bottom: 36px;
+		box-shadow: 0px 26px 0px 0px lighten($gray, 23%);
+	}
 }
 
 .editor-diff-viewer__additions {

--- a/client/post-editor/editor-revisions-list/header.jsx
+++ b/client/post-editor/editor-revisions-list/header.jsx
@@ -4,17 +4,13 @@
  * External dependencies
  */
 
-import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 const EditorRevisionsListHeader = ( { numRevisions, translate } ) => {
-	const classes = classNames( 'editor-revisions-list__header', {
-		'editor-revisions-list__loading-placeholder': ! numRevisions,
-	} );
 	return (
-		<div className={ classes }>
+		<div className="editor-revisions-list__header">
 			{ !! numRevisions &&
 				translate( '%(revisions)d revision', '%(revisions)d revisions', {
 					count: numRevisions,

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -105,8 +105,11 @@ class EditorRevisionsList extends PureComponent {
 
 	render() {
 		const { revisions, selectedRevisionId, siteId } = this.props;
+		const classes = classNames( 'editor-revisions-list', {
+			'is-loading': ! revisions.length,
+		} );
 		return (
-			<div className="editor-revisions-list">
+			<div className={ classes }>
 				<EditorRevisionsListHeader numRevisions={ revisions.length } />
 				<div className="editor-revisions-list__scroller">
 					<ul className="editor-revisions-list__list">

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -8,7 +8,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { findIndex, get, head, map } from 'lodash';
+import { findIndex, get, head, isEmpty, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -106,7 +106,7 @@ class EditorRevisionsList extends PureComponent {
 	render() {
 		const { revisions, selectedRevisionId, siteId } = this.props;
 		const classes = classNames( 'editor-revisions-list', {
-			'is-loading': ! revisions.length,
+			'is-loading': isEmpty( revisions ),
 		} );
 		return (
 			<div className={ classes }>

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -22,12 +22,28 @@
 }
 
 .editor-revisions-list__header {
+	$editor-revisions-list-header-height: 46px;
+	$editor-revisions-list-header-font-size: 16px;
 	padding: 0 16px;
-	height: 46px;
-	line-height: 46px;
+	height: $editor-revisions-list-header-height;
+	line-height: $editor-revisions-list-header-height;
 	color: $gray-text-min;
 	background: $white;
 	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
+
+	.editor-revisions-list.is-loading & {
+		position: relative;
+
+		&:before {
+			content: '';
+			display: block;
+			position: absolute;
+			top: ($editor-revisions-list-header-height - $editor-revisions-list-header-font-size) / 2;
+			width: 50%;
+			height: $editor-revisions-list-header-font-size;
+			@include placeholder(23%);
+		}
+	}
 }
 
 // Scrollable Box for Revisions List
@@ -48,6 +64,13 @@
 		display: inline;
 		white-space: nowrap;
 	}
+
+	&:before {
+		content: '';
+		display: block;
+		box-sizing: border-box;
+		@include placeholder(23%);
+	}
 }
 
 .editor-revisions-list__revision {
@@ -59,6 +82,7 @@
 }
 
 // Individual Revision List Item
+.editor-revisions-list.is-loading .editor-revisions-list__list:before,
 .editor-revisions-list__button {
 	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
 	border-right: 1px solid darken($sidebar-bg-color, 5%);

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -99,7 +99,9 @@
 		border-right: none;
 		min-height: 60px;
 	}
+}
 
+.editor-revisions-list__button {
 	&:hover {
 		background: $accordion-background-hover;
 	}

--- a/client/post-editor/editor-revisions/style.scss
+++ b/client/post-editor/editor-revisions/style.scss
@@ -27,10 +27,6 @@
 	}
 }
 
-.editor-revisions-list__loading-placeholder {
-	@include placeholder(23%);
-}
-
 body.showing-post-revisions-dialog {
 	// Prevent scrolling the editor contents below the dialog
 	overflow-y: hidden;


### PR DESCRIPTION
## This PR
- adds loading placeholders to the post revisions modal

![ezgif com-video-to-gif 4](https://user-images.githubusercontent.com/1562646/32862357-7c5d69a0-ca1d-11e7-93a0-9f995aa45512.gif)

## How to test
1.) Click on the calypso.live link in the comments below.
2.) Go to a post with revisions or create a new post and save revisions.
3.) Click on the History button (see gif above)
4.) Verify that the loading states look like in the gif above
5.) Profit
