### PR TITLE
_wip_ improve performance of conversation tool

### DIFF
--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -96,7 +96,6 @@ export default function createSelector(
 	const memoizedSelector = function( state, ...args ) {
 		const cacheKey = getCacheKey( state, ...args );
 		const currentDependants = [].concat( getDependants( state, ...args ) );
-
 		const prevDependents = dependentsPerKey.get( cacheKey );
 
 		if ( ! memo.has( cacheKey ) || ! shallowEqual( currentDependants, prevDependents ) ) {

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -100,10 +100,7 @@ export default function createSelector(
 	return Object.assign(
 		function( state, ...args ) {
 			const cacheKey = getCacheKey( state, ...args );
-			let currentDependants = getDependants( state, ...args );
-			if ( ! Array.isArray( currentDependants ) ) {
-				currentDependants = [ currentDependants ];
-			}
+			const currentDependants = [].concat( getDependants( state, ...args ) );
 
 			let prevDependents;
 			// @TODO: I've uncovered a bug in lru. this should not be necessary.
@@ -115,7 +112,7 @@ export default function createSelector(
 				prevDependents = false;
 			}
 
-			if ( prevDependents && ! shallowEqual( currentDependants, prevDependents ) ) {
+			if ( ! shallowEqual( currentDependants, prevDependents ) ) {
 				memoizedSelector.cache.delete( cacheKey );
 			}
 			try {

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -105,15 +105,14 @@ export default function createSelector(
 				currentDependants = [ currentDependants ];
 			}
 
-			let prevDependent = false;
+			let prevDependents;
 			try {
-				prevDependent = dependentsPerKey.get( cacheKey );
-			} catch ( e ) {}
+				prevDependents = dependentsPerKey.get( cacheKey );
+			} catch ( e ) {
+				prevDependents = false;
+			}
 
-			if (
-				prevDependent &&
-				! shallowEqual( currentDependants, dependentsPerKey.get( cacheKey ) )
-			) {
+			if ( prevDependents && ! shallowEqual( currentDependants, prevDependents ) ) {
 				memoizedSelector.cache.delete( cacheKey );
 			}
 			try {

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import shallowEqual from 'react-pure-render/shallowEqual';
+import { castArray } from 'lodash';
 
 /**
  * Constants
@@ -95,7 +96,7 @@ export default function createSelector(
 
 	const memoizedSelector = function( state, ...args ) {
 		const cacheKey = getCacheKey( state, ...args );
-		const currentDependants = [].concat( getDependants( state, ...args ) );
+		const currentDependants = castArray( getDependants( state, ...args ) );
 		const prevDependents = dependentsPerKey.get( cacheKey );
 
 		if ( ! memo.has( cacheKey ) || ! shallowEqual( currentDependants, prevDependents ) ) {

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -101,8 +101,8 @@ export default function createSelector(
 
 		if ( ! memo.has( cacheKey ) || ! shallowEqual( currentDependants, prevDependents ) ) {
 			memo.set( cacheKey, selector( state, ...args ) );
+			dependentsPerKey.set( cacheKey, currentDependants );
 		}
-		dependentsPerKey.set( cacheKey, currentDependants );
 
 		return memo.get( cacheKey );
 	};

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -106,6 +106,9 @@ export default function createSelector(
 			}
 
 			let prevDependents;
+			// @TODO: I've uncovered a bug in lru. this should not be necessary.
+			// willl resolve this with the package maintainer.
+			// see very similar: https://github.com/chriso/lru/issues/19
 			try {
 				prevDependents = dependentsPerKey.get( cacheKey );
 			} catch ( e ) {

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -88,6 +88,7 @@ describe( 'index', () => {
 		getSitePosts( state, 1, [] );
 
 		/* eslint-disable no-console */
+		// @TODO: make the warn happen only 3 times
 		expect( console.warn ).to.have.been.callCount( 6 );
 		/* eslint-enable no-console */
 	} );
@@ -196,6 +197,7 @@ describe( 'index', () => {
 				[ post2.global_ID ]: post2,
 			},
 		};
+
 		expect( getPostByIdWithData( nextState, post1.global_ID ) ).to.eql( {
 			...post1,
 			withData: true,

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -145,7 +145,7 @@ describe( 'index', () => {
 					ID: 841,
 					site_ID: 2916284,
 					global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
-					title: 'Hello WorldChanged',
+					title: 'Hello Next World',
 				},
 				'6c831c187ffef321eb43a67761a525a3': {
 					ID: 413,
@@ -161,7 +161,7 @@ describe( 'index', () => {
 				ID: 841,
 				site_ID: 2916284,
 				global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
-				title: 'Hello WorldChanged',
+				title: 'Hello Next World',
 			},
 		] );
 		expect( selector ).to.have.been.calledTwice;

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -27,11 +27,7 @@ describe( 'index', () => {
 	} );
 
 	beforeEach( () => {
-		getSitePosts.memoizedSelector.cache.clear();
-	} );
-
-	test( 'should expose its memoized function', () => {
-		expect( getSitePosts.memoizedSelector ).to.be.a( 'function' );
+		getSitePosts.cache.clear();
 	} );
 
 	test( 'should create a function which returns the expected value when called', () => {
@@ -88,8 +84,7 @@ describe( 'index', () => {
 		getSitePosts( state, 1, [] );
 
 		/* eslint-disable no-console */
-		// @TODO: make the warn happen only 3 times
-		expect( console.warn ).to.have.been.callCount( 6 );
+		expect( console.warn ).to.have.been.calledThrice;
 		/* eslint-enable no-console */
 	} );
 
@@ -318,8 +313,7 @@ describe( 'index', () => {
 
 		getSitePostsWithCustomGetCacheKey( { posts: {} }, 2916284 );
 
-		expect( getSitePostsWithCustomGetCacheKey.memoizedSelector.cache.has( 'CUSTOM2916284' ) ).to.be
-			.true;
+		expect( getSitePostsWithCustomGetCacheKey.cache.has( 'CUSTOM2916284' ) ).true;
 	} );
 
 	test( 'should call dependant state getter with arguments', () => {

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -30,6 +30,10 @@ describe( 'index', () => {
 		getSitePosts.cache.clear();
 	} );
 
+	test( 'should expose its cache', () => {
+		expect( getSitePosts.cache instanceof Map ).ok;
+	} );
+
 	test( 'should create a function which returns the expected value when called', () => {
 		const state = {
 			posts: {

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -125,7 +125,7 @@ describe( 'index', () => {
 		expect( selector ).to.have.been.calledTwice;
 	} );
 
-	test( 'should bust the cache when watched state changes and cacheKey is in the map', () => {
+	test( 'should bust the cache when watched state changes', () => {
 		const currentState = {
 			posts: {
 				'3d097cb7c5473c169bba0eb8e3c6cb64': {

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -125,6 +125,19 @@ describe( 'index', () => {
 		expect( selector ).to.have.been.calledTwice;
 	} );
 
+	test( 'should pass the value of the dependent as the last argument to the selector', () => {
+		const post1 = { global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64' };
+		const currentState = {
+			posts: {
+				[ post1.global_ID ]: post1,
+			},
+		};
+		const spy = sinon.spy();
+		const memoizedSelector = createSelector( spy, ( state, postId ) => state.posts[ postId ] );
+		memoizedSelector( currentState, post1.global_ID );
+		expect( spy ).calledWithExactly( currentState, post1.global_ID, post1 );
+	} );
+
 	test( 'should bust the cache when watched state changes', () => {
 		const currentState = {
 			posts: {

--- a/client/state/document-head/test/selectors.js
+++ b/client/state/document-head/test/selectors.js
@@ -19,7 +19,7 @@ import {
 
 describe( 'selectors', () => {
 	beforeEach( () => {
-		getDocumentHeadFormattedTitle.memoizedSelector.cache.clear();
+		getDocumentHeadFormattedTitle.cache.clear();
 	} );
 
 	describe( '#getDocumentHeadTitle()', () => {

--- a/client/state/notices/test/selectors.js
+++ b/client/state/notices/test/selectors.js
@@ -13,7 +13,7 @@ import { getNotices } from '../selectors';
 describe( 'selectors', () => {
 	describe( 'getNotices()', () => {
 		beforeEach( () => {
-			getNotices.memoizedSelector.cache.clear();
+			getNotices.cache.clear();
 		} );
 
 		test( 'should return an array of notices', () => {

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -38,14 +38,14 @@ import { userState } from 'state/selectors/test/fixtures/user-state';
 
 describe( 'selectors', () => {
 	beforeEach( () => {
-		getSitePosts.memoizedSelector.cache.clear();
-		getSitePost.memoizedSelector.cache.clear();
-		getSitePostsForQueryIgnoringPage.memoizedSelector.cache.clear();
-		isRequestingSitePostsForQueryIgnoringPage.memoizedSelector.cache.clear();
-		getNormalizedPost.memoizedSelector.cache.clear();
-		getSitePostsForQuery.memoizedSelector.cache.clear();
-		getSitePostsForQueryIgnoringPage.memoizedSelector.cache.clear();
-		isPostPublished.memoizedSelector.cache.clear();
+		getSitePosts.cache.clear();
+		getSitePost.cache.clear();
+		getSitePostsForQueryIgnoringPage.cache.clear();
+		isRequestingSitePostsForQueryIgnoringPage.cache.clear();
+		getNormalizedPost.cache.clear();
+		getSitePostsForQuery.cache.clear();
+		getSitePostsForQueryIgnoringPage.cache.clear();
+		isPostPublished.cache.clear();
 	} );
 
 	describe( '#getPost()', () => {
@@ -929,7 +929,7 @@ describe( 'selectors', () => {
 
 	describe( '#getEditedPost()', () => {
 		beforeEach( () => {
-			getEditedPost.memoizedSelector.cache.clear();
+			getEditedPost.cache.clear();
 		} );
 
 		test( 'should return the original post if no revisions exist on site', () => {
@@ -1621,7 +1621,7 @@ describe( 'selectors', () => {
 
 	describe( 'isEditedPostDirty()', () => {
 		beforeEach( () => {
-			isEditedPostDirty.memoizedSelector.cache.clear();
+			isEditedPostDirty.cache.clear();
 		} );
 
 		test( 'should return false if there are no edits for the post', () => {

--- a/client/state/selectors/test/get-site-slugs-for-upcoming-transactions.js
+++ b/client/state/selectors/test/get-site-slugs-for-upcoming-transactions.js
@@ -12,7 +12,7 @@ import { getSiteSlugsForUpcomingTransactions } from '../';
 
 describe( 'getSiteSlugsForUpcomingTransactions()', () => {
 	beforeEach( () => {
-		getSiteSlugsForUpcomingTransactions.memoizedSelector.cache.clear();
+		getSiteSlugsForUpcomingTransactions.cache.clear();
 	} );
 
 	test( 'should return slugs for sites with transactions only', () => {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -72,9 +72,9 @@ describe( 'selectors', () => {
 	const stateWithNoItems = createStateWithItems( {} );
 
 	beforeEach( () => {
-		getSite.memoizedSelector.cache.clear();
-		getSiteCollisions.memoizedSelector.cache.clear();
-		getSiteBySlug.memoizedSelector.cache.clear();
+		getSite.cache.clear();
+		getSiteCollisions.cache.clear();
+		getSiteBySlug.cache.clear();
 	} );
 
 	describe( '#getRawSite()', () => {

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -23,10 +23,10 @@ import { userState } from 'state/selectors/test/fixtures/user-state';
 
 describe( 'selectors', () => {
 	beforeEach( () => {
-		getSiteStatsPostStreakData.memoizedSelector.cache.clear();
-		getSiteStatsMaxPostsByDay.memoizedSelector.cache.clear();
-		getSiteStatsTotalPostsForStreakQuery.memoizedSelector.cache.clear();
-		getSiteStatsNormalizedData.memoizedSelector.cache.clear();
+		getSiteStatsPostStreakData.cache.clear();
+		getSiteStatsMaxPostsByDay.cache.clear();
+		getSiteStatsTotalPostsForStreakQuery.cache.clear();
+		getSiteStatsNormalizedData.cache.clear();
 	} );
 
 	describe( 'isRequestingSiteStatsForQuery()', () => {

--- a/client/state/terms/test/selectors.js
+++ b/client/state/terms/test/selectors.js
@@ -22,8 +22,8 @@ import TermQueryManager from 'lib/query-manager/term';
 
 describe( 'selectors', () => {
 	beforeEach( () => {
-		getTermsForQuery.memoizedSelector.cache.clear();
-		getTermsForQueryIgnoringPage.memoizedSelector.cache.clear();
+		getTermsForQuery.cache.clear();
+		getTermsForQueryIgnoringPage.cache.clear();
 	} );
 
 	describe( 'isRequestingTermsForQuery()', () => {

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -86,10 +86,10 @@ const sidekick = {
 
 describe( 'themes selectors', () => {
 	beforeEach( () => {
-		getTheme.memoizedSelector.cache.clear();
-		getThemesForQuery.memoizedSelector.cache.clear();
-		getThemesForQueryIgnoringPage.memoizedSelector.cache.clear();
-		isRequestingThemesForQueryIgnoringPage.memoizedSelector.cache.clear();
+		getTheme.cache.clear();
+		getThemesForQuery.cache.clear();
+		getThemesForQueryIgnoringPage.cache.clear();
+		isRequestingThemesForQueryIgnoringPage.cache.clear();
 	} );
 
 	describe( '#getTheme()', () => {


### PR DESCRIPTION
_wip_

things to explore:
1. per key cache invalidation for selectors
2. extracting commentsToShow calculation from postcomments
3. reducing the sheer number of components rendered
4. whatever comes up in profiling