### PR TITLE
Conversations: fix infinite request loop for failed comments

### DIFF
--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -25,6 +25,7 @@ import ConversationCaterpillar from 'blocks/conversation-caterpillar';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import PostCommentFormRoot from 'blocks/comments/form-root';
 import { requestPostComments, requestComment, setActiveReply } from 'state/comments/actions';
+import { getErrorKey } from 'state/comments/utils';
 
 /**
  * ConversationsCommentList is the component that represents all of the comments for a conversations-stream
@@ -125,7 +126,7 @@ export class ConversationCommentList extends React.Component {
 			Object.keys( this.getCommentsToShow() )
 		);
 		inaccessible
-			.filter( commentId => ! commentErrors[ `${ siteId }-${ commentId }` ] )
+			.filter( commentId => ! commentErrors[ getErrorKey( siteId, commentId ) ] )
 			.forEach( commentId => {
 				nextProps.requestComment( {
 					commentId,

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -19,6 +19,7 @@ import {
 	getExpansionsForPost,
 	getHiddenCommentsForPost,
 	getPostCommentsTree,
+	getCommentErrors,
 } from 'state/comments/selectors';
 import ConversationCaterpillar from 'blocks/conversation-caterpillar';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
@@ -109,7 +110,7 @@ export class ConversationCommentList extends React.Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		const { hiddenComments, commentsTree, siteId } = nextProps;
+		const { hiddenComments, commentsTree, siteId, commentErrors } = nextProps;
 
 		// if we are running low on comments to expand then fetch more
 		if ( size( hiddenComments ) < FETCH_NEW_COMMENTS_THRESHOLD ) {
@@ -123,12 +124,14 @@ export class ConversationCommentList extends React.Component {
 			commentsTree,
 			Object.keys( this.getCommentsToShow() )
 		);
-		inaccessible.forEach( commentId => {
-			nextProps.requestComment( {
-				commentId,
-				siteId,
+		inaccessible
+			.filter( commentId => ! commentErrors[ `${ siteId }-${ commentId }` ] )
+			.forEach( commentId => {
+				nextProps.requestComment( {
+					commentId,
+					siteId,
+				} );
 			} );
-		} );
 	}
 
 	getParentId = ( commentsTree, childId ) =>
@@ -277,6 +280,7 @@ const ConnectedConversationCommentList = connect(
 				siteId,
 				postId,
 			} ),
+			commentErrors: getCommentErrors( state ),
 		};
 	},
 	{ requestPostComments, requestComment, setActiveReply }

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -43,7 +43,7 @@ import {
 	POST_COMMENT_DISPLAY_TYPES,
 } from './constants';
 import trees from './trees/reducer';
-import { getStateKey } from './utils';
+import { getStateKey, getErrorKey } from './utils';
 
 const getCommentDate = ( { date } ) => new Date( date );
 
@@ -295,8 +295,8 @@ export const totalCommentsCount = createReducer(
 export const errors = createReducer(
 	{},
 	{
-		[ COMMENTS_RECEIVE_ERROR ]: ( state, action ) => {
-			const key = `${ action.siteId }-${ action.commentId }`;
+		[ COMMENTS_RECEIVE_ERROR ]: ( state, { siteId, commentId } ) => {
+			const key = getErrorKey( siteId, commentId );
 
 			if ( state[ key ] ) {
 				return state;
@@ -307,8 +307,8 @@ export const errors = createReducer(
 				[ key ]: { error: true },
 			};
 		},
-		[ COMMENTS_WRITE_ERROR ]: ( state, action ) => {
-			const key = `${ action.siteId }-${ action.commentId }`;
+		[ COMMENTS_WRITE_ERROR ]: ( state, { siteId, commentId } ) => {
+			const key = getErrorKey( siteId, commentId );
 
 			if ( state[ key ] ) {
 				return state;

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -56,12 +56,13 @@ export const getCommentById = createSelector(
 		);
 		return find( commentsForSite, comment => commentId === comment.ID );
 	},
-	( { state } ) => [
-		state.comments.items,
-		get( state.comments, 'items' ),
-		get( state.comments, 'errors' ),
-	]
+	( { state } ) => [ state.comments.items, state.comments.errors ]
 );
+
+export const getCommentErrors = state => {
+	return state.comments.errors;
+};
+
 /***
  * Get total number of comments on the server for a given post
  * @param {Object} state redux state

--- a/client/state/comments/utils.js
+++ b/client/state/comments/utils.js
@@ -6,3 +6,5 @@ export const deconstructStateKey = key => {
 	const [ siteId, postId ] = key.split( '-' );
 	return { siteId: +siteId, postId: +postId };
 };
+
+export const getErrorKey = ( siteId, commentId ) => `${ siteId }-${ commentId }`;


### PR DESCRIPTION
**summary**
this pr teaches `ConversationList` component when a comment isn't worth fetching because it has already come back as an error
- it introduces a new getErrors selector for `state.comments.errors`. The conversations list component takes advantage of it.
- it adds a check before launching a `requestComment` to see it has already come back as an error

fixes: https://github.com/Automattic/wp-calypso/pull/19867

To Test
------
1. unit tests should all pass.
2. follow the conversation at this post: http://wordpress.com/read/blogs/69263930/posts/324 
  2.1 open up network console and filter by `57?`. 
  2.2 You should see the request made only 4 times because of the automated retries instead of ∞ times as you would on master right now.