### PR TITLE
Refined the styles of security status label in settings

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/style.scss
@@ -9,14 +9,13 @@
 .jetpack-credentials__connected {
 	float: right;
 	background: $alert-green;
-	padding: 0 8px;
-	margin: -4px;
-	font-size: 1.3rem;
+	padding: 4px 8px;
+	border-radius: 2px;
+	font-size: 12px;
 	color: $white;
 }
 
 .jetpack-credentials__connected-checkmark {
-	position: relative;
-	top: 3px;
-	margin-right: 3px;
+	vertical-align: top;
+	margin-right: 4px;
 }


### PR DESCRIPTION
#### Before
<img width="661" alt="image" src="https://user-images.githubusercontent.com/1123119/32866356-84b32d04-ca24-11e7-99ac-384d9fc396fc.png">


#### After
<img width="660" alt="image" src="https://user-images.githubusercontent.com/1123119/32866310-525df6c2-ca24-11e7-98ec-fcc4472fc49f.png">
