### PR TITLE
My Purchases: fix Giropay and Bancontact logos

### DIFF
--- a/client/components/payment-logo/style.scss
+++ b/client/components/payment-logo/style.scss
@@ -37,18 +37,22 @@
 		}
 	}
 
-  	&.is-ideal {
+	&.is-ideal {
 		background-image: url( '/calypso/images/upgrades/ideal.svg' );
 		height: 30px;
 	}
 
 	&.is-giropay {
 		background-image: url( '/calypso/images/upgrades/giropay.svg' );
-		height: 60px;
+		background-size: 60px auto;
+		width: 60px;
+		height: 20px;
 	}
 
 	&.is-bancontact {
-		background-image: url( '/calypso/images/upgrades/is-bancontact.svg' );
-		height: 60px;
+		background-image: url( '/calypso/images/upgrades/bancontact.svg' );
+		height: 20px;
+		background-size: 100px auto;
+		width: 100px;
 	}
 }


### PR DESCRIPTION
The logos are currently too small and badly positioned on the my-purchases screen. 

Example:
<img width="552" alt="screen shot 2017-11-16 at 11 45 27" src="https://user-images.githubusercontent.com/844866/32885164-5678fbc0-cac5-11e7-8f86-93aa64d7b67f.png">

This fixes it for both Giropay and Bancontact
After (Giropay):
<img width="498" alt="screen shot 2017-11-16 at 11 51 33" src="https://user-images.githubusercontent.com/844866/32885181-6bc040d8-cac5-11e7-956c-402960d13b53.png">

After (Bancontact):
<img width="400" alt="screen shot 2017-11-16 at 11 58 23" src="https://user-images.githubusercontent.com/844866/32885193-7aca3b42-cac5-11e7-88fa-898dfefc232f.png">

