### PR TITLE
Themes: Fix screenshot photon parameters

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 import { get, isEmpty, isEqual, noop, some } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
+import photon from 'photon';
 
 /**
  * Internal dependencies
@@ -199,6 +200,10 @@ export class Theme extends Component {
 			</span>
 		);
 
+		const width = 340;
+		const themeImgSrc = photon( screenshot, { width } );
+		const themeImgSrcDoubleDpi = photon( screenshot, { width, zoom: 2 } );
+
 		return (
 			<Card className={ themeClass }>
 				{ this.isBeginnerTheme() && (
@@ -214,8 +219,8 @@ export class Theme extends Component {
 						{ screenshot ? (
 							<img
 								className="theme__img"
-								src={ screenshot + '?w=340' }
-								srcSet={ screenshot + '?w=340 1x, ' + screenshot + '?w=680 2x' }
+								src={ themeImgSrc }
+								srcSet={ `${ themeImgSrc } 1x ${ themeImgSrcDoubleDpi } 2x` }
 								onClick={ this.onScreenshotClick }
 								id={ screenshotID }
 							/>

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -200,9 +200,9 @@ export class Theme extends Component {
 			</span>
 		);
 
-		const width = 340;
-		const themeImgSrc = photon( screenshot, { width } );
-		const themeImgSrcDoubleDpi = photon( screenshot, { width, zoom: 2 } );
+		const fit = '479,360';
+		const themeImgSrc = photon( screenshot, { fit } );
+		const themeImgSrcDoubleDpi = photon( screenshot, { fit, zoom: 2 } );
 
 		return (
 			<Card className={ themeClass }>

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Theme rendering with default display buttonContents should match snapshot 1`] = `
+<Card
+  className="theme is-actionable"
+  highlight={false}
+  tagName="div"
+>
+  <div
+    className="theme__content"
+  >
+    <a
+      className="theme__active-focus"
+      onClick={[Function]}
+    >
+      <span />
+    </a>
+    <a>
+      <img
+        className="theme__img"
+        id={null}
+        onClick={[Function]}
+        src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?ssl=1?w=340"
+        srcSet="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?ssl=1?w=340 1x, https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?ssl=1?w=680 2x"
+      />
+    </a>
+    <div
+      className="theme__info"
+    >
+      <h2
+        className="theme__info-title"
+      >
+        Twenty Seventeen
+      </h2>
+      <span
+        className="theme__badge-price theme__badge-price-upgrade"
+      />
+      <ThemeMoreButton
+        active={false}
+        onMoreButtonClick={[Function]}
+        options={
+          Object {
+            "dummyAction": Object {
+              "action": [Function],
+              "label": "Dummy action",
+            },
+          }
+        }
+        themeId="twentyseventeen"
+      />
+    </div>
+  </div>
+</Card>
+`;

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -20,8 +20,8 @@ exports[`Theme rendering with default display buttonContents should match snapsh
         className="theme__img"
         id={null}
         onClick={[Function]}
-        src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?w=340"
-        srcSet="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?w=340 1x https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?w=340&zoom=2 2x"
+        src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360"
+        srcSet="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360 1x https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"
       />
     </a>
     <div

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -20,8 +20,8 @@ exports[`Theme rendering with default display buttonContents should match snapsh
         className="theme__img"
         id={null}
         onClick={[Function]}
-        src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?ssl=1?w=340"
-        srcSet="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?ssl=1?w=340 1x, https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?ssl=1?w=680 2x"
+        src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?w=340"
+        srcSet="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?w=340 1x https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?w=340&zoom=2 2x"
       />
     </a>
     <div

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -72,7 +72,7 @@ describe( 'Theme', () => {
 				const { query } = parse( src, true );
 
 				expect( query ).toMatchObject( {
-					w: expect.stringMatching( /\d+/ ),
+					fit: expect.stringMatching( /\d+,\d+/ ),
 				} );
 			} );
 

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -6,12 +6,14 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
-import { identity } from 'lodash';
 import React from 'react';
-import TestUtils from 'react-dom/test-utils';
 import ReactDom from 'react-dom';
 import sinon from 'sinon';
+import TestUtils from 'react-dom/test-utils';
+import { assert } from 'chai';
+import { identity } from 'lodash';
+import { parse } from 'url';
+import { shallow } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -28,9 +30,10 @@ describe( 'Theme', () => {
 	beforeEach( () => {
 		props = {
 			theme: {
-				id: 'atheme',
-				name: 'Theme name',
-				screenshot: '/theme/screenshot.png',
+				id: 'twentyseventeen',
+				name: 'Twenty Seventeen',
+				screenshot:
+					'https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?ssl=1',
 			},
 			buttonContents: { dummyAction: { label: 'Dummy action', action: sinon.spy() } }, // TODO: test if called when clicked
 			translate: identity,
@@ -54,12 +57,13 @@ describe( 'Theme', () => {
 					'className does not contain "theme is-actionable"'
 				);
 
-				assert( themeNode.getElementsByTagName( 'h2' )[ 0 ].textContent === 'Theme name' );
+				assert( themeNode.getElementsByTagName( 'h2' )[ 0 ].textContent === 'Twenty Seventeen' );
 			} );
 
 			test( 'should render a screenshot', () => {
 				const imgNode = themeNode.getElementsByTagName( 'img' )[ 0 ];
-				assert.include( imgNode.getAttribute( 'src' ), '/theme/screenshot.png' );
+				const src = imgNode.getAttribute( 'src' );
+				assert.include( src, '/screenshot.png' );
 			} );
 
 			test( 'should call onScreenshotClick() on click on screenshot', () => {

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -66,6 +66,16 @@ describe( 'Theme', () => {
 				assert.include( src, '/screenshot.png' );
 			} );
 
+			test( 'should include photon parameters', () => {
+				const imgNode = themeNode.getElementsByTagName( 'img' )[ 0 ];
+				const src = imgNode.getAttribute( 'src' );
+				const { query } = parse( src, true );
+
+				expect( query ).toMatchObject( {
+					w: expect.stringMatching( /\d+/ ),
+				} );
+			} );
+
 			test( 'should call onScreenshotClick() on click on screenshot', () => {
 				const imgNode = themeNode.getElementsByTagName( 'img' )[ 0 ];
 				TestUtils.Simulate.click( imgNode );

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -20,8 +20,8 @@ import { shallow } from 'enzyme';
  */
 import { Theme } from '../';
 
-jest.mock( 'components/popover/menu', () => require( 'components/empty-component' ) );
-jest.mock( 'components/popover/menu-item', () => require( 'components/empty-component' ) );
+jest.mock( 'components/popover/menu', () => 'components--popover--menu' );
+jest.mock( 'components/popover/menu-item', () => 'components--popover--menu-item' );
 jest.mock( 'lib/user', () => () => {} );
 
 describe( 'Theme', () => {
@@ -94,6 +94,11 @@ describe( 'Theme', () => {
 
 				assert( more.length === 1, 'More button container not found' );
 				assert( more[ 0 ].getElementsByTagName( 'button' ).length === 1, 'More button not found' );
+			} );
+
+			test( 'should match snapshot', () => {
+				const rendered = shallow( <Theme { ...props } /> );
+				expect( rendered ).toMatchSnapshot();
 			} );
 		} );
 


### PR DESCRIPTION
The `Theme` component is loading full-size screenshots, loading unnecessarily large images.

The images are meant to be resized, but a query parameter is naively added resulting in an incorrect query: `?ssl=1?w=340` which parses to `{ ssl: "1?w=340" }`.

This PR adds tests to detect the issue and uses the https://github.com/Automattic/photon.js lib to correctly generate the parameters. The final commit is optional, but rather than use a hardcoded `width`, it proposes `fit` with the largest fit I have been able to observe by viewing `https://wordpress.com/themes` with device width `479px`.

See the [photon docs](https://developer.wordpress.com/docs/photon/api/).

## Questions

* Is `fit` appropriate for this case?
* Are theme screenshot dimensions reliable?
* Is `479x360` an appropriate size?

## Screens

### Before
![big-thumbnail](https://user-images.githubusercontent.com/841763/32888193-c0ea9332-cac6-11e7-984e-2e1e36516140.png)

### After
![better](https://user-images.githubusercontent.com/841763/32888267-ffff696c-cac6-11e7-9d0b-80bb1be8ac61.png)

## Testing
* Tests should pass
* Visit https://calypso.live/themes?branch=fix/theme/bad-photon-url-params and ensure that images have appropriate quality but are no larger than expected (`479 x 360`).

Found while testing #18726