### PR TITLE
AB Test: remove country code limits from the payment methods tests.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -133,6 +133,5 @@ export default {
 		},
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
-		countryCodeTargets: [ 'DE', 'BE' ],
 	},
 };


### PR DESCRIPTION
 The test is only initiated if the user is [eligible](https://github.com/Automattic/wp-calypso/blob/80d182c5c0932711fa82de58a520a5769db62bbf/client/my-sites/checkout/checkout/checkout.jsx#L471,) for the payment method (=in the correct country) so it's redundant to check in here too. 

Additionally, it's possible that `getCurrentUserCountryCode` (used for the ab test toggle) is returning the wrong value (see for example#17849) on user bootstrap, while `getGeoCountryShort` used in `getCurrentUserPaymentMethods` is more trustworthy.

