### PR TITLE
QueryManager: make post sorting faster and call it less often

### DIFF
--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -344,6 +344,7 @@ export default class QueryManager {
 				const shouldAdjustFoundCount = ! isReceivedQueryKey;
 
 				const query = this.constructor.QueryKey.parse( queryKey );
+				let needsSort = false;
 				items.forEach( receivedItem => {
 					// Find item in known data for query
 					const receivedItemKey = receivedItem[ this.options.itemKey ];
@@ -389,10 +390,14 @@ export default class QueryManager {
 							receivedItemKey
 						);
 
-						// Re-sort the set
-						this.constructor.sort( memo[ queryKey ].itemKeys, nextItems, query );
+						// The itemKeys will need to be re-sorted after all items are processed
+						needsSort = true;
 					}
 				} );
+
+				if ( needsSort ) {
+					this.constructor.sort( memo[ queryKey ].itemKeys, nextItems, query );
+				}
 
 				isModified = isModified || memo[ queryKey ] !== queryDetails;
 				return memo;

--- a/client/lib/query-manager/post/index.js
+++ b/client/lib/query-manager/post/index.js
@@ -141,12 +141,12 @@ export default class PostQueryManager extends PaginatedQueryManager {
 				break;
 
 			case 'modified':
-				order = moment( postA.modified ).diff( postB.modified );
+				order = new Date( postA.modified ) - new Date( postB.modified );
 				break;
 
 			case 'date':
 			default:
-				order = moment( postA.date ).diff( postB.date );
+				order = new Date( postA.date ) - new Date( postB.date );
 		}
 
 		// Default to descending order, opposite sign of ordered result


### PR DESCRIPTION
Two performance improvements when dispatching the `POSTS_RECEIVE` action with a page of new post query results:

When calling `QueryManager.receive` with a list of new items, sort the new `itemKey` list only once after all items are processed. When receiving posts, there are typically 20 posts on a page. Instead of sorting the list 20 times, we now sort it only once. On a blog with 10k+ posts, calling the reducer with a `POSTS_RECEIVE` action now takes 180ms instead of 3.1s.

Don't use `moment` when comparing dates in `PostQueryManager.compare` and compare `new Date` instances instead. Makes the sort two orders of magnitude faster: on a list of 10k posts, the sort now takes 3ms instead of the original 180ms.

Overall, the reducer for `POSTS_RECEIVE` is now 1000 times faster. Tested on the a8ckudos blog with the `condensedPostList` AB test set to `condensedPosts`.

**How to test:**
Go to a blog with many posts (`testmanyposts`, `a8ckudos`, ...) and show the list of posts at `/posts/:siteId`. Scroll down to load more items into the infinite list. Check if the UI is responsive while loading and whether it reacts to click. Before the patch, it would freeze for many seconds. After the patch, it's much better (although not ideal -- more perf patches will follow).