### PR TITLE
Remove renderPage react-helper

### DIFF
--- a/client/extensions/hello-dolly/index.js
+++ b/client/extensions/hello-dolly/index.js
@@ -11,11 +11,11 @@ import React from 'react';
  * Internal dependencies
  */
 import HelloDollyPage from './hello-dolly-page';
-import { renderPage } from 'lib/react-helpers';
+import { renderWithReduxStore } from 'lib/react-helpers';
 import { navigation, siteSelection } from 'my-sites/controller';
 
 const render = context => {
-	renderPage( context, <HelloDollyPage /> );
+	renderWithReduxStore( <HelloDollyPage />, document.getElementById( 'primary' ), context.store );
 };
 
 export default function() {

--- a/client/lib/react-helpers/index.js
+++ b/client/lib/react-helpers/index.js
@@ -17,10 +17,6 @@ export function concatTitle( ...parts ) {
 	return parts.join( ' › ' );
 }
 
-export function renderPage( context, component ) {
-	renderWithReduxStore( component, document.getElementById( 'primary' ), context.store );
-}
-
 export function recordPageView( path, ...title ) {
 	analytics.pageView.record( path, concatTitle( ...title ) );
 }

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -22,7 +22,7 @@ import NoSitesMessage from 'components/empty-content/no-sites-message';
 import paths from './paths';
 import PurchasesHeader from './purchases-list/header';
 import PurchasesList from './purchases-list';
-import { concatTitle, recordPageView, renderPage } from 'lib/react-helpers';
+import { concatTitle, recordPageView, renderWithReduxStore } from 'lib/react-helpers';
 import { setDocumentHeadTitle } from 'state/document-head/actions';
 import titles from './titles';
 import userFactory from 'lib/user';
@@ -41,16 +41,17 @@ export default {
 
 		recordPurchasesPageView( paths.addCardDetails(), 'Add Card Details' );
 
-		renderPage(
-			context,
-			<AddCardDetails purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
+		renderWithReduxStore(
+			<AddCardDetails purchaseId={ parseInt( context.params.purchaseId, 10 ) } />,
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
 	addCreditCard( context ) {
 		recordPurchasesPageView( paths.addCreditCard(), 'Add Credit Card' );
 
-		renderPage( context, <AddCreditCard /> );
+		renderWithReduxStore( <AddCreditCard />, document.getElementById( 'primary' ), context.store );
 	},
 
 	cancelPrivacyProtection( context ) {
@@ -58,9 +59,10 @@ export default {
 
 		recordPurchasesPageView( paths.cancelPrivacyProtection(), 'Cancel Privacy Protection' );
 
-		renderPage(
-			context,
-			<CancelPrivacyProtection purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
+		renderWithReduxStore(
+			<CancelPrivacyProtection purchaseId={ parseInt( context.params.purchaseId, 10 ) } />,
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -69,9 +71,10 @@ export default {
 
 		recordPurchasesPageView( paths.cancelPurchase(), 'Cancel Purchase' );
 
-		renderPage(
-			context,
-			<CancelPurchase purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
+		renderWithReduxStore(
+			<CancelPurchase purchaseId={ parseInt( context.params.purchaseId, 10 ) } />,
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -80,9 +83,10 @@ export default {
 
 		recordPurchasesPageView( paths.confirmCancelDomain(), 'Confirm Cancel Domain' );
 
-		renderPage(
-			context,
-			<ConfirmCancelDomain purchaseId={ parseInt( context.params.purchaseId, 10 ) } />
+		renderWithReduxStore(
+			<ConfirmCancelDomain purchaseId={ parseInt( context.params.purchaseId, 10 ) } />,
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -91,12 +95,13 @@ export default {
 
 		recordPurchasesPageView( paths.editCardDetails(), 'Edit Card Details' );
 
-		renderPage(
-			context,
+		renderWithReduxStore(
 			<EditCardDetails
 				cardId={ context.params.cardId }
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
-			/>
+			/>,
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -105,7 +110,11 @@ export default {
 
 		recordPurchasesPageView( paths.purchasesRoot() );
 
-		renderPage( context, <PurchasesList noticeType={ context.params.noticeType } /> );
+		renderWithReduxStore(
+			<PurchasesList noticeType={ context.params.noticeType } />,
+			document.getElementById( 'primary' ),
+			context.store
+		);
 	},
 
 	managePurchase( context ) {
@@ -113,12 +122,13 @@ export default {
 
 		recordPurchasesPageView( paths.managePurchase(), 'Manage Purchase' );
 
-		renderPage(
-			context,
+		renderWithReduxStore(
 			<ManagePurchase
 				purchaseId={ parseInt( context.params.purchaseId, 10 ) }
 				destinationType={ context.params.destinationType }
-			/>
+			/>,
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -131,12 +141,13 @@ export default {
 
 		recordPurchasesPageView( context.path, 'No Sites' );
 
-		renderPage(
-			context,
+		renderWithReduxStore(
 			<Main>
 				<PurchasesHeader section={ 'purchases' } />
 				<NoSitesMessage />
-			</Main>
+			</Main>,
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 };

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -21,7 +21,7 @@ import PluginListComponent from './main';
 import PluginComponent from './plugin';
 import PluginBrowser from './plugins-browser';
 import PluginUpload from './plugin-upload';
-import { renderWithReduxStore, renderPage } from 'lib/react-helpers';
+import { renderWithReduxStore } from 'lib/react-helpers';
 import { setSection } from 'state/ui/actions';
 import { getSelectedSite, getSection } from 'state/ui/selectors';
 import { hasJetpackSites, getSelectedOrAllSitesWithPlugins } from 'state/selectors';
@@ -230,7 +230,7 @@ const controller = {
 	},
 
 	upload( context ) {
-		renderPage( context, <PluginUpload /> );
+		renderWithReduxStore( <PluginUpload />, document.getElementById( 'primary' ), context.store );
 	},
 
 	jetpackCanUpdate( filter, context, next ) {


### PR DESCRIPTION
Remove rarely used `renderPage()` helper shortcut from `lib/react-helpers` and use more commonly used `renderWithReduxStore()` helper directly for consistency.

`renderWithReduxStore()` will be transformed to `context.primary = <Element/>;` -format later on [using a codemod](https://github.com/Automattic/wp-calypso/pull/19494). This change will make applying that codemod easier.

## Test

Ensure modified sections work:

- [x] /hello-dolly/:site
- [x] /plugins/upload/:site
- [x] /me/purchases
- [x] /me/purchases/add-credit-card
- [x] /me/purchases/billing
- [x] /me/purchases/billing/:receiptId
- [x] /me/purchases/:site/:purchaseId
- [x] /me/purchases/:site/:purchaseId/cancel
- [x] /me/purchases/:site/:purchaseId/confirm-cancel-domain
- [x] /me/purchases/:site/:purchaseId/cancel-privacy-protection
- [x] /me/purchases/:site/:purchaseId/payment/add
- [x] /me/purchases/:site/:purchaseId/payment/edit/:cardId

--- 
- [x] = tested by at least one person