### PR TITLE
Devdocs: add example for TimeSince

### DIFF
--- a/client/components/time-since/docs/example.jsx
+++ b/client/components/time-since/docs/example.jsx
@@ -1,0 +1,38 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { PureComponent } from 'react';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import TimeSince from 'components/time-since';
+
+const TimeSinceExample = () => {
+	return (
+		<div>
+			<div>
+				<TimeSince
+					date={ moment()
+						.subtract( 5, 'minutes' )
+						.toDate() }
+				/>
+			</div>
+			<div>
+				<TimeSince
+					date={ moment()
+						.subtract( 5, 'months' )
+						.toDate() }
+				/>
+			</div>
+		</div>
+	);
+};
+
+TimeSinceExample.displayName = 'TimeSinceExample';
+
+export default TimeSinceExample;

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -79,6 +79,7 @@ import Spinner from 'components/spinner/docs/example';
 import SpinnerButton from 'components/spinner-button/docs/example';
 import SpinnerLine from 'components/spinner-line/docs/example';
 import Suggestions from 'components/suggestions/docs/example';
+import TimeSince from 'components/time-since/docs/example';
 import Timezone from 'components/timezone/docs/example';
 import TokenFields from 'components/token-field/docs/example';
 import Tooltip from 'components/tooltip/docs/example';
@@ -182,6 +183,7 @@ class DesignAssets extends React.Component {
 					<SpinnerButton searchKeywords="loading input submit" />
 					<SpinnerLine searchKeywords="loading" />
 					<Suggestions />
+					<TimeSince />
 					<Timezone />
 					<TokenFields />
 					<Tooltip />


### PR DESCRIPTION
@spen recently created the `TimeSince` component in #19812, based on the old Reader `PostTime` component.

This PR adds a simple example of the component to Devdocs:

http://calypso.localhost:3000/devdocs/design/time-since

<img width="782" alt="screen shot 2017-11-16 at 14 22 49" src="https://user-images.githubusercontent.com/17325/32895968-a6370076-cad9-11e7-9a74-e70cf87c6874.png">

### To test

Visit the supplied Devdocs link and make sure the example functions correctly (one date from 5 minutes ago, and one date from 5 months ago).

Also ensure that http://calypso.localhost:3000/devdocs/design still displays correctly.