### PR TITLE
Reader: fix tag name vertical alignment in full post

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -481,7 +481,6 @@
 	list-style: none;
 	margin: 0;
 	padding: 0;
-	position: relative;
 	overflow: hidden;
 	white-space: nowrap;
 	width: 100%;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -482,7 +482,6 @@
 	margin: 0;
 	padding: 0;
 	position: relative;
-		top: -2px;
 	overflow: hidden;
 	white-space: nowrap;
 	width: 100%;


### PR DESCRIPTION
I noticed that the tag name text is now positioned slightly too high in full post:

<img width="492" alt="screen shot 2017-11-16 at 14 26 26" src="https://user-images.githubusercontent.com/17325/32896282-8538767e-cada-11e7-8b0c-20216e408258.png">

After this PR:

<img width="498" alt="screen shot 2017-11-16 at 14 26 48" src="https://user-images.githubusercontent.com/17325/32896291-8c8d4a26-cada-11e7-8b00-bcafb48719f5.png">

### To test

Visit a full post with tags, e.g. 

http://calypso.localhost:3000/read/feeds/18743358/posts/1666827920