### PR TITLE
Fix incorrect year on images being uploaded in media library

### DIFF
--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { moment, translate } from 'i18n-calypso';
-import { clone, filter, findIndex, noop } from 'lodash';
+import { clone, filter, findIndex, min, noop } from 'lodash';
 import ReactDom from 'react-dom';
 import React from 'react';
 
@@ -158,16 +158,15 @@ export class MediaLibraryList extends React.Component {
 		const itemDate = new Date( date );
 		const currentDate = new Date();
 
-		if ( itemDate.getYear() === currentDate.getYear() ) {
-			return moment( date ).format( 'MMM DD' );
+		if ( itemDate.getFullYear() === currentDate.getFullYear() ) {
+			return moment( date ).format( 'MMM D' );
 		}
 
-		return moment( date ).format( 'MMM DD, YYYY' );
+		return moment( date ).format( 'MMM D, YYYY' );
 	};
 
-	getItemGroup = item => {
-		return item.date.slice( 0, 10 );
-	};
+	getItemGroup = item =>
+		min( [ item.date.slice( 0, 10 ), moment( new Date() ).format( 'YYYY-MM-DD' ) ] );
 
 	renderItem = item => {
 		var index = findIndex( this.props.media, { ID: item.ID } ),


### PR DESCRIPTION
Fixes incorrect year being displayed above images that are being uploaded in the media library as described in #19804.  
The issue is resolved by replacing any future dates with the current one when grouping items by date.

**Note:** As for the reason why the temporary dates are set to a future value - it might be to keep the items at the top of the list while they're being uploaded.

![screen shot 2017-11-16 at 15 16 54](https://user-images.githubusercontent.com/8056203/32897076-f708a062-cae4-11e7-958f-58eb634b9c2c.png)

# Testing

- Go to `/media` and make sure you have at least one item with today's date in the library.
- Add a few media items and make sure they appear in the same group while they're being uploaded.