### PR TITLE
Comments: wrap preformatted blocks

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -414,6 +414,10 @@ a.comments__comment-username {
 		margin: 8px 0 16px;
 		padding: 8px 16px;
 	}
+
+	pre {
+		white-space: pre-wrap;
+	}
 }
 
 // Actions for Individual Comments


### PR DESCRIPTION
When a comment contains a `<pre>`, we don't currently apply any wrapping on long lines. This PR adds `white-space: pre-wrap;` to `<pre>` elements inside comment content.

Before:

<img width="759" alt="screen shot 2017-11-16 at 16 23 17" src="https://user-images.githubusercontent.com/17325/32905237-44e253c6-caf1-11e7-8f51-38da00f341b0.png">

After:

<img width="759" alt="screen shot 2017-11-16 at 16 58 28" src="https://user-images.githubusercontent.com/17325/32905246-48738ad2-caf1-11e7-8268-fca21a1aef24.png">

### To test

Create a new comment containing a `<pre>` element and a long string within.