### PR TITLE
Notices: compact notice icon alignment

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -212,6 +212,8 @@ a.notice__action {
 		.notice__icon {
 			width: 18px;
 			height: 18px;
+			align-self: center;
+			margin: 0;
 		}
 	}
 


### PR DESCRIPTION
Fixing something from the new dark notices, introduced in #17796 

We need vertically center the icons on compact notices. Otherwise, the
margin on the icon pushes it out of alignment.

This should only affect compact notices

Before:

![screen shot 2017-11-16 at 12 19 33 pm](https://user-images.githubusercontent.com/618551/32908182-6bc0be8e-cac8-11e7-9bb0-b5cfcc88340e.png)
![screen shot 2017-11-16 at 12 16 27 pm](https://user-images.githubusercontent.com/618551/32908186-6e4420c4-cac8-11e7-8a34-fc168641911b.png)


After:

![screen shot 2017-11-16 at 12 12 00 pm](https://user-images.githubusercontent.com/618551/32908197-79679abc-cac8-11e7-8f41-0e1893449901.png)
![screen shot 2017-11-16 at 12 10 04 pm](https://user-images.githubusercontent.com/618551/32908282-bb33bdc2-cac8-11e7-9c27-3dc4778d8697.png)

--- 

As a result, the icon is centered on multi-line compact notices. Not ideal, but a good tradeoff:

![screen shot 2017-11-16 at 12 10 40 pm](https://user-images.githubusercontent.com/618551/32908381-ffd01444-cac8-11e7-9eb9-bbc9f8f59394.png)

---

## Please test:

Any compact notice

- /plugins (update/error notices)
- /domains




