### PR TITLE
Activity Log - Add credentials notice when needed

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -402,6 +402,7 @@
 @import 'my-sites/stats/activity-log/style';
 @import 'my-sites/stats/activity-log-banner/style';
 @import 'my-sites/stats/activity-log-confirm-dialog/style';
+@import 'my-sites/stats/activity-log-credentials-notice/style';
 @import 'my-sites/stats/activity-log-day/style';
 @import 'my-sites/stats/activity-log-item/style';
 @import 'my-sites/stats/all-time/style';

--- a/client/my-sites/stats/activity-log-credentials-notice/index.jsx
+++ b/client/my-sites/stats/activity-log-credentials-notice/index.jsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import Gridicon from 'gridicons';
+import {
+	getSelectedSiteId,
+	getSelectedSite,
+} from 'state/ui/selectors';
+
+class ActivityLogCredentialsNotice extends Component {
+	render() {
+		const {
+			selectedSite,
+			translate,
+		} = this.props;
+
+		const credsUrl = '/settings/security/' + selectedSite.slug;
+
+		return (
+			<CompactCard
+				highlight="info"
+				href={ credsUrl }
+				className="activity-log-credentials-notice"
+			>
+				<span className="activity-log-credentials-notice__icon">
+					<Gridicon icon="history" size={ 24 } />
+				</span>
+				<span className="activity-log-credentials-notice__text">
+					{ translate(
+						'Add your credentials to enable backups and security scanning for your site.'
+					) }
+				</span>
+			</CompactCard>
+		);
+	}
+}
+
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			selectedSite: getSelectedSite( state, siteId ),
+			siteId,
+		};
+	}
+)( localize( ActivityLogCredentialsNotice ) );

--- a/client/my-sites/stats/activity-log-credentials-notice/index.jsx
+++ b/client/my-sites/stats/activity-log-credentials-notice/index.jsx
@@ -18,16 +18,14 @@ import {
 class ActivityLogCredentialsNotice extends Component {
 	render() {
 		const {
-			selectedSite,
+			selectedSite: { slug },
 			translate,
 		} = this.props;
-
-		const credsUrl = '/settings/security/' + selectedSite.slug;
 
 		return (
 			<CompactCard
 				highlight="info"
-				href={ credsUrl }
+				href={ `/settings/security/${ slug }` }
 				className="activity-log-credentials-notice"
 			>
 				<span className="activity-log-credentials-notice__icon">

--- a/client/my-sites/stats/activity-log-credentials-notice/style.scss
+++ b/client/my-sites/stats/activity-log-credentials-notice/style.scss
@@ -1,3 +1,8 @@
+.activity-log-credentials-notice {
+	display: flex;
+	align-items: center;
+}
+
 .activity-log-credentials-notice .card__link-indicator,
 .activity-log-credentials-notice.card:hover .card__link-indicator {
 	color: $blue-wordpress;
@@ -13,15 +18,10 @@
 
 .activity-log-credentials-notice__icon .gridicon {
 	color: #fff;
-	margin-left: 6px;
-	margin-top: 6px;
+	margin: 6px;
 }
 
 .activity-log-credentials-notice__text {
 	color: $gray-dark;
-	font-weight: 600;
-	font-size: 1.6rem;
-	margin-left: 2rem;
-	position: relative;
-	top: -6px;
+	margin-left: 16px;
 }

--- a/client/my-sites/stats/activity-log-credentials-notice/style.scss
+++ b/client/my-sites/stats/activity-log-credentials-notice/style.scss
@@ -1,0 +1,27 @@
+.activity-log-credentials-notice .card__link-indicator,
+.activity-log-credentials-notice.card:hover .card__link-indicator {
+	color: $blue-wordpress;
+}
+
+.activity-log-credentials-notice__icon {
+	display: inline-block;
+	width: 36px;
+	height: 36px;
+	border-radius: 50%;
+	background: $blue-wordpress;
+}
+
+.activity-log-credentials-notice__icon .gridicon {
+	color: #fff;
+	margin-left: 6px;
+	margin-top: 6px;
+}
+
+.activity-log-credentials-notice__text {
+	color: $gray-dark;
+	font-weight: 600;
+	font-size: 1.6rem;
+	margin-left: 2rem;
+	position: relative;
+	top: -6px;
+}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -16,14 +16,13 @@ import { first, get, groupBy, includes, isEmpty, isNull, last, range } from 'lod
  */
 import ActivityLogBanner from '../activity-log-banner';
 import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
+import ActivityLogCredentialsNotice from '../activity-log-credentials-notice';
 import ActivityLogDay from '../activity-log-day';
 import ActivityLogDayPlaceholder from '../activity-log-day/placeholder';
 import ActivityLogRewindToggle from './activity-log-rewind-toggle';
-import CompactCard from 'components/card/compact';
 import DatePicker from 'my-sites/stats/stats-date-picker';
 import EmptyContent from 'components/empty-content';
 import ErrorBanner from '../activity-log-banner/error-banner';
-import Gridicon from 'gridicons';
 import JetpackColophon from 'components/jetpack-colophon';
 import Main from 'components/main';
 import ProgressBanner from '../activity-log-banner/progress-banner';
@@ -37,7 +36,7 @@ import StatsNavigation from 'blocks/stats-navigation';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import SuccessBanner from '../activity-log-banner/success-banner';
 import { adjustMoment, getActivityLogQuery, getStartMoment } from './utils';
-import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import {
@@ -496,7 +495,6 @@ class ActivityLog extends Component {
 			requestedRestoreActivityId,
 			requestedBackup,
 			requestedBackupId,
-			selectedSite,
 			siteId,
 			slug,
 			startDate,
@@ -589,8 +587,6 @@ class ActivityLog extends Component {
 			.utc()
 			.startOf( 'day' );
 
-		const credsUrl = '/settings/security/' + selectedSite.slug;
-
 		return (
 			<Main wideLayout>
 				{ rewindEnabledByConfig && <QueryRewindStatus siteId={ siteId } /> }
@@ -603,22 +599,7 @@ class ActivityLog extends Component {
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />
-				{ ! hasMainCredentials && (
-					<CompactCard
-						highlight="info"
-						href={ credsUrl }
-						className="activity-log__credentials-notice"
-					>
-						<span className="activity-log__credentials-notice-icon">
-							<Gridicon icon="history" size={ 24 } />
-						</span>
-						<span className="activity-log__credentials-notice-text">
-							{ translate(
-								'Add your credentials to enable backups and security scanning for your site.'
-							) }
-						</span>
-					</CompactCard>
-				) }
+				{ ! hasMainCredentials && <ActivityLogCredentialsNotice /> }
 				{ this.renderErrorMessage() }
 				{ hasFirstBackup && this.renderMonthNavigation() }
 				{ this.renderActionProgress() }
@@ -738,7 +719,6 @@ export default connect(
 			restoreProgress: getRestoreProgress( state, siteId ),
 			backupProgress: getBackupProgress( state, siteId ),
 			rewindStatusError: getRewindStatusError( state, siteId ),
-			selectedSite: getSelectedSite( state, siteId ),
 			siteId,
 			siteTitle: getSiteTitle( state, siteId ),
 			slug: getSiteSlug( state, siteId ),

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -46,3 +46,31 @@
 	font-size: 12px;
 	color: $gray-text-min;
 }
+
+.activity-log__credentials-notice .card__link-indicator,
+.activity-log__credentials-notice.card:hover .card__link-indicator {
+	color: $blue-wordpress;
+}
+
+.activity-log__credentials-notice-icon {
+	display: inline-block;
+	width: 36px;
+	height: 36px;
+	border-radius: 50%;
+	background: $blue-wordpress;
+}
+
+.activity-log__credentials-notice-icon .gridicon {
+	color: #fff;
+	margin-left: 6px;
+	margin-top: 6px;
+}
+
+.activity-log__credentials-notice-text {
+	color: $gray-dark;
+	font-weight: 600;
+	font-size: 1.6rem;
+	margin-left: 2rem;
+	position: relative;
+	top: -6px;
+}

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -46,31 +46,3 @@
 	font-size: 12px;
 	color: $gray-text-min;
 }
-
-.activity-log__credentials-notice .card__link-indicator,
-.activity-log__credentials-notice.card:hover .card__link-indicator {
-	color: $blue-wordpress;
-}
-
-.activity-log__credentials-notice-icon {
-	display: inline-block;
-	width: 36px;
-	height: 36px;
-	border-radius: 50%;
-	background: $blue-wordpress;
-}
-
-.activity-log__credentials-notice-icon .gridicon {
-	color: #fff;
-	margin-left: 6px;
-	margin-top: 6px;
-}
-
-.activity-log__credentials-notice-text {
-	color: $gray-dark;
-	font-weight: 600;
-	font-size: 1.6rem;
-	margin-left: 2rem;
-	position: relative;
-	top: -6px;
-}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/19615

Testing Instructions:
1. Load the activity log on a Pressable site which has not previously had credentials configured.
2. Observe the following notice above the activity log:

![screen shot 2017-11-16 at 1 35 33 pm](https://user-images.githubusercontent.com/5528445/32908913-0d76bfe4-cad3-11e7-9c52-77abd953c4d6.png)

3. Click the card to take you to the settings page, autoconfigure your credentials, and navigate back to the activity log.
4. Verify the notice is now hidden.