### PR TITLE
PostRevisions: Allow format override to show time next to date

### DIFF
--- a/client/components/time-since/README.md
+++ b/client/components/time-since/README.md
@@ -18,3 +18,4 @@ Over a week:
 ## Props
 
 - `date`: Date, The date to show
+- `defaultFormat`: String, Override the formatting of dates older than 1 week.

--- a/client/components/time-since/README.md
+++ b/client/components/time-since/README.md
@@ -18,4 +18,4 @@ Over a week:
 ## Props
 
 - `date`: Date, The date to show
-- `defaultFormat`: String, Override the formatting of dates older than 1 week.
+- `dateFormat`: String, Override the formatting of dates older than 1 week.

--- a/client/components/time-since/index.jsx
+++ b/client/components/time-since/index.jsx
@@ -32,9 +32,11 @@ export default class TimeSince extends PureComponent {
 	}
 
 	update = date => {
+		const { defaultFormat } = this.props;
 		date = date || this.props.date;
+
 		this.smartSetState( {
-			humanDate: humanDate( date ),
+			humanDate: humanDate( date, defaultFormat ),
 			fullDate: moment( date ).format( 'llll' ),
 		} );
 	};

--- a/client/components/time-since/index.jsx
+++ b/client/components/time-since/index.jsx
@@ -32,11 +32,11 @@ export default class TimeSince extends PureComponent {
 	}
 
 	update = date => {
-		const { defaultFormat } = this.props;
+		const { dateFormat } = this.props;
 		date = date || this.props.date;
 
 		this.smartSetState( {
-			humanDate: humanDate( date, defaultFormat ),
+			humanDate: humanDate( date, dateFormat ),
 			fullDate: moment( date ).format( 'llll' ),
 		} );
 	};

--- a/client/lib/human-date/index.js
+++ b/client/lib/human-date/index.js
@@ -8,7 +8,7 @@ import i18n from 'i18n-calypso';
 
 const MILLIS_IN_MINUTE = 60 * 1000;
 
-export default function humanDate( dateOrMoment ) {
+export default function humanDate( dateOrMoment, defaultFormat = 'll' ) {
 	const now = i18n.moment();
 	dateOrMoment = i18n.moment( dateOrMoment );
 
@@ -51,5 +51,5 @@ export default function humanDate( dateOrMoment ) {
 		} );
 	}
 
-	return dateOrMoment.format( 'll' );
+	return dateOrMoment.format( defaultFormat );
 }

--- a/client/lib/human-date/index.js
+++ b/client/lib/human-date/index.js
@@ -8,7 +8,7 @@ import i18n from 'i18n-calypso';
 
 const MILLIS_IN_MINUTE = 60 * 1000;
 
-export default function humanDate( dateOrMoment, defaultFormat = 'll' ) {
+export default function humanDate( dateOrMoment, dateFormat = 'll' ) {
 	const now = i18n.moment();
 	dateOrMoment = i18n.moment( dateOrMoment );
 
@@ -51,5 +51,5 @@ export default function humanDate( dateOrMoment, defaultFormat = 'll' ) {
 		} );
 	}
 
-	return dateOrMoment.format( defaultFormat );
+	return dateOrMoment.format( dateFormat );
 }

--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -35,7 +35,7 @@ class EditorRevisionsListItem extends PureComponent {
 				type="button"
 			>
 				<span className="editor-revisions-list__date">
-					<TimeSince date={ revision.date } />
+					<TimeSince date={ revision.date } defaultFormat="lll" />
 				</span>
 
 				{ authorName &&

--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -35,7 +35,7 @@ class EditorRevisionsListItem extends PureComponent {
 				type="button"
 			>
 				<span className="editor-revisions-list__date">
-					<TimeSince date={ revision.date } defaultFormat="lll" />
+					<TimeSince date={ revision.date } dateFormat="lll" />
 				</span>
 
 				{ authorName &&


### PR DESCRIPTION
### Summary
This PR adds the ability to define a `defaultFormat` prop to `humanDate` & `TimeSince`, allowing us to add the time to post-revision list items.
I've named it `defaultFormat` as it's the format given to the value returned when none of the 'less-than x' conditions are met in `humanDate` - open to changing this naming though.

### Testing
- Open a post with revisions in the editor
- Click the 'history' button.
- Note that revisions older than a week now display the time along the date.