### PR TITLE
Domains: Update some copy and styles

### DIFF
--- a/client/components/domains/domain-transfer-suggestion/index.jsx
+++ b/client/components/domains/domain-transfer-suggestion/index.jsx
@@ -38,7 +38,7 @@ class DomainTransferSuggestion extends React.Component {
 						} ) }
 					</h3>
 					<p>
-						{ translate( "Transfer or map it to use it as your site's address.", {
+						{ translate( "You can use it as your site's address.", {
 							context: 'Upgrades: Register domain description',
 							comment: 'Explains how you could use an existing domain name with your site.',
 						} ) }

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -120,7 +120,6 @@
 		p {
 			color: darken( $gray, 10% );
 			font-size: 14px;
-			max-width: 500px;
 		}
 	}
 

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -145,6 +145,7 @@
 .transfer-domain-step__options {
 	label {
 		color: darken( $gray, 20% );
+		font-size: 15px;
 	}
 
 	legend {

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -30,6 +30,12 @@
 	}
 }
 
+.transfer-domain-step__title {
+	.formatted-header {
+		margin: 10px 0;
+	}
+}
+
 .transfer-domain-step__domain-description {
 	font-size: 16px;
 	margin-bottom: 20px;

--- a/client/components/domains/transfer-domain-step/transfer-domain-options.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-options.jsx
@@ -18,6 +18,7 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
+import FormattedHeader from 'components/formatted-header';
 import { getProductsList } from 'state/products-list/selectors';
 
 class TransferDomainOptions extends React.PureComponent {
@@ -61,19 +62,28 @@ class TransferDomainOptions extends React.PureComponent {
 		this.toggle( 'dnsImport', event.target.checked );
 	};
 
+	getHeader() {
+		const { translate } = this.props;
+
+		return (
+			<Card compact={ true } className="transfer-domain-step__title">
+				<FormattedHeader
+					headerText={ translate( 'Choose the settings you want to transfer.' ) }
+					subHeaderText={ translate(
+						'Make sure the everything will be configured the way you want it.'
+					) }
+				/>
+			</Card>
+		);
+	}
+
 	render() {
 		const cost = get( this.props.products, 'private_whois.cost_display', null );
 		const { translate } = this.props;
 
-		const headerLabel = translate(
-			"You have a few options for how to set up your domain once it's transferred. " +
-				'Review these options and choose the ones that apply to ensure that everything is ' +
-				'configured the way you want it.'
-		);
-
 		return (
 			<div className="transfer-domain-step__options">
-				<Card compact={ true }>{ headerLabel }</Card>
+				{ this.getHeader() }
 				<Card>
 					<FormFieldset>
 						<FormLabel>

--- a/client/components/domains/transfer-domain-step/transfer-domain-options.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-options.jsx
@@ -143,7 +143,11 @@ class TransferDomainOptions extends React.PureComponent {
 
 					<div className="transfer-domain-step__continue">
 						<div />
-						<Button className="transfer-domain-step__in-card" onClick={ this.onClick }>
+						<Button
+							className="transfer-domain-step__in-card"
+							onClick={ this.onClick }
+							primary={ true }
+						>
 							{ translate( 'Continue' ) }
 						</Button>
 					</div>

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -102,9 +102,14 @@ class TransferDomainPrecheck extends React.PureComponent {
 			: translate(
 					"You'll need to unlock the domain at your current registrar before we can move it."
 				);
-		const explanation = translate(
-			'Your current domain provider has locked the domain to prevent unauthorized transfers.'
-		);
+		const explanation = unlocked
+			? translate(
+					'Domain providers place a lock on domains to prevent unauthorized transfers. Yours is ' +
+						"unlocked and ready to transfer. We'll automatically lock it after the transfer completes."
+				)
+			: translate(
+					'Your current domain provider has locked the domain to prevent unauthorized transfers.'
+				);
 
 		const button = unlocked ? (
 			<div className="transfer-domain-step__unlocked">

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -177,12 +177,15 @@ class TransferDomainPrecheck extends React.PureComponent {
 	}
 
 	getHeader() {
-		const { translate } = this.props;
+		const { translate, domain } = this.props;
 
 		return (
 			<Card compact={ true } className="transfer-domain-step__title">
 				<FormattedHeader
-					headerText={ translate( "Let's get your domain ready to transfer." ) }
+					headerText={ translate( "Let's get {{strong}}%(domain)s{{/strong}} ready to transfer.", {
+						args: { domain },
+						components: { strong: <strong /> },
+					} ) }
 					subHeaderText={ translate(
 						'Log into your current registrar to complete a few preliminary steps.'
 					) }

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -16,6 +16,7 @@ import Gridicon from 'gridicons';
 import Button from 'components/button';
 import FoldableCard from 'components/foldable-card';
 import Card from 'components/card';
+import FormattedHeader from 'components/formatted-header';
 import { checkInboundTransferStatus } from 'lib/domains';
 import support from 'lib/url/support';
 
@@ -175,16 +176,27 @@ class TransferDomainPrecheck extends React.PureComponent {
 		return this.getSection( heading, message, explanation, 3 );
 	}
 
+	getHeader() {
+		const { translate } = this.props;
+
+		return (
+			<Card compact={ true } className="transfer-domain-step__title">
+				<FormattedHeader
+					headerText={ translate( "Let's get your domain ready to transfer." ) }
+					subHeaderText={ translate(
+						'Log into your current registrar to complete a few preliminary steps.'
+					) }
+				/>
+			</Card>
+		);
+	}
+
 	render() {
 		const { translate } = this.props;
-		const headerLabel = translate(
-			"Let's get your domain ready to transfer. " +
-				'Log into your current registrar to complete a few preliminary steps.'
-		);
 
 		return (
 			<div className="transfer-domain-step__precheck">
-				<Card compact={ true }>{ headerLabel }</Card>
+				{ this.getHeader() }
 				{ this.getStatusMessage() }
 				{ this.getPrivacyMessage() }
 				{ this.getEppMessage() }


### PR DESCRIPTION
This PR fixes and tweaks some things in the incoming transfers flow:

* Small tweaks to styles.
* Small copy updates throughout the flow.
* Improves hierarchy of precheck and options pages by adding a header element.

Before | After
------------ | -------------
<img width="749" alt="screen shot 2017-11-16 at 16 18 12" src="https://user-images.githubusercontent.com/448298/32917317-c9074940-caec-11e7-8b3a-b5009da88e69.png"> | <img width="740" alt="screen shot 2017-11-16 at 16 20 33" src="https://user-images.githubusercontent.com/448298/32917312-c481dc6e-caec-11e7-9344-aa40a94868ce.png">


#### Testing
Go through the flow of transferring a domain into your account:

* Add a domain to your site from /domains/manage/:site or via sidebar.
* Search for a domain that's already taken or click to use a domain you already own.
* Input a domain you own. Make sure it takes you to the precheck screen.
* Unlock your domain, click Check Again. Make sure the status is properly picked.
* Check the e-mail shown as the admin email.
* Proceed to Options screen.
* Assert things don't look broken.