### PR TITLE
Store: Fix store address setup for CA addresses by using the correct `find`

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/pre-setup-view.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { every, includes, isEmpty, keys, pick, trim } from 'lodash';
+import { every, find, includes, isEmpty, keys, pick, trim } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**


### PR DESCRIPTION
While testing the sign-up flow I found a regression (?) where the state and country were not getting passed correctly for addresses in Canada during setup. The other address components worked fine.

See p1510864468000387-slack-store-on-wpcom

It looks like we were using the syntax of lodash find, but not importing it. This PR fixes that so [this check](https://github.com/Automattic/wp-calypso/blob/master/client/extensions/woocommerce/app/dashboard/pre-setup-view.js#L152) works correctly.

To Test:
* Reset your address/setup flags, and trash existing products, to make sure you get the address view (set_store_address_during_initial_setup).
* Test with an CA & Alberta for your address. After finishing the setup steps, go to shipping settings and make sure you see the correct address present.
* Reset and test again with CA & any other province. Make sure you see the correct address on shipping settings.