### PR TITLE
Domains: Fix Back button for domain transfer purchase

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -235,7 +235,9 @@ class CheckoutThankYou extends React.Component {
 				return page( `/plans/my-plan/${ site }` );
 			} else if (
 				purchases.some( isDomainProduct ) ||
-				purchases.some( isDomainRedemption || purchases.some( isSiteRedirect ) )
+				purchases.some( isDomainTransfer ) ||
+				purchases.some( isDomainRedemption ) ||
+				purchases.some( isSiteRedirect )
 			) {
 				return page( domainsPaths.domainManagementList( this.props.selectedSite.slug ) );
 			} else if ( purchases.some( isGoogleApps ) ) {


### PR DESCRIPTION
Back button link was set to stats page. It should take the user to the domain management screen.

Test:
- Purchase a domain transfer
- Make sure link leads back to domain list

Fixes: https://github.com/Automattic/wp-calypso/issues/19906