### PR TITLE
Revert compact notice alignment

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -217,7 +217,6 @@ a.notice__action {
 		.notice__icon {
 			width: 18px;
 			height: 18px;
-			align-self: center;
 			margin: 0;
 		}
 


### PR DESCRIPTION
@drw158 this reverts the alignment of the compact notice icon that you added. It's in conflict with the notice styles I just merged.

Before:

![before](https://cldup.com/clgIrhx26g.png)

After: 

![after](https://cldup.com/INJftfG94k-3000x3000.png)