### PR TITLE
Speed up the "rm.js" command to use the native "rm -rf" command

### DIFF
--- a/bin/rm.js
+++ b/bin/rm.js
@@ -29,7 +29,7 @@ const deleteFolderRecursive = ( dir ) => {
 	if ( 'win32' === os.platform() ) {
 		spawnSync( 'rd', [ '/S', '/Q', path.normalize( dir ) ], { shell: true } );
 	} else {
-		spawnSync( 'rm', [ '-rf', path ] );
+		spawnSync( 'rm', [ '-rf', dir ] );
 	}
 };
 

--- a/bin/rm.js
+++ b/bin/rm.js
@@ -14,8 +14,9 @@
  */
 
 const fs = require( 'fs' );
+const path = require( 'path' );
 const os = require( 'os' );
-const exec = require( 'child_process' ).execSync;
+const spawnSync = require( 'child_process' ).spawnSync;
 
 if ( process.argv.length < 3 ) {
 	process.exit( 1 );
@@ -24,9 +25,12 @@ if ( process.argv.length < 3 ) {
 const target = process.argv[ 2 ];
 const extensions = process.argv.slice( 3 );
 
-const deleteFolderRecursive = ( path ) => {
-	const rm = 'win32' === os.platform() ? 'rd /S /Q' : 'rm -rf';
-	exec( rm + ' ' + path );
+const deleteFolderRecursive = ( dir ) => {
+	if ( 'win32' === os.platform() ) {
+		spawnSync( 'rd', [ '/S', '/Q', path.normalize( dir ) ], { shell: true } );
+	} else {
+		spawnSync( 'rm', [ '-rf', path ] );
+	}
 };
 
 const deleteFiles = ( path, extensions ) => {

--- a/bin/rm.js
+++ b/bin/rm.js
@@ -14,6 +14,8 @@
  */
 
 const fs = require( 'fs' );
+const os = require( 'os' );
+const exec = require( 'child_process' ).execSync;
 
 if ( process.argv.length < 3 ) {
 	process.exit( 1 );
@@ -23,15 +25,8 @@ const target = process.argv[ 2 ];
 const extensions = process.argv.slice( 3 );
 
 const deleteFolderRecursive = ( path ) => {
-	fs.readdirSync( path ).forEach( ( file ) => {
-		const curPath = path + '/' + file;
-		if( fs.lstatSync( curPath ).isDirectory() ) {
-			deleteFolderRecursive( curPath );
-		} else {
-			fs.unlinkSync( curPath );
-		}
-	} );
-	fs.rmdirSync( path );
+	const rm = 'win32' === os.platform() ? 'rd /S /Q' : 'rm -rf';
+	exec( rm + ' ' + path );
 };
 
 const deleteFiles = ( path, extensions ) => {


### PR DESCRIPTION
When deleting large directories (*ejem* `node_modules` *ejem*), the `bin/rm.js` script took a lot to finish, because it deleted all the files in de directory recursively using `nodeJS` APIs.
I've replaced it for a simple `rm -rf` command (or its Windows equivalent).

I've tested it in Windows and it works fine, but I didn't notice any speed increase (as expected, `rd` is also slow on a raw console). I only need a reviewer in Linux / OSX.

To test this, run `npm run distclean`, realize that it doesn't take +30 seconds, and check that the whole `node_modules` and generated `public/` files had been deleted.