### PR TITLE
Domains: Update Manage Purchase for transfer-ins

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -59,6 +59,7 @@ import {
 	isDomainProduct,
 	isDomainRegistration,
 	isDomainMapping,
+	isDomainTransfer,
 	isTheme,
 } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
@@ -288,7 +289,7 @@ class ManagePurchase extends Component {
 			);
 		}
 
-		if ( isDomainProduct( purchase ) ) {
+		if ( isDomainProduct( purchase ) || isDomainTransfer( purchase ) ) {
 			return (
 				<div className="manage-purchase__plan-icon">
 					<Gridicon icon="domains" size={ 54 } />
@@ -325,6 +326,11 @@ class ManagePurchase extends Component {
 						domain: selectedSite.domain,
 					},
 				}
+			);
+		} else if ( isDomainTransfer( purchase ) ) {
+			description = translate(
+				'Transfers an existing domain from another provider to WordPress.com, ' +
+					'helping you manage your site and domain in one place.'
 			);
 		}
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -427,6 +427,7 @@ class ManagePurchase extends Component {
 		}
 		const { selectedSite, selectedSiteId, selectedPurchase, isPurchaseTheme } = this.props;
 		const classes = 'manage-purchase';
+		const purchase = getPurchase( this.props );
 
 		let editCardDetailsPath = false;
 		if (
@@ -445,13 +446,15 @@ class ManagePurchase extends Component {
 				) }
 				<Main className={ classes }>
 					<HeaderCake onClick={ goToList }>{ titles.managePurchase }</HeaderCake>
-					<PurchaseNotice
-						isDataLoading={ isDataLoading( this.props ) }
-						handleRenew={ this.handleRenew }
-						selectedSite={ selectedSite }
-						selectedPurchase={ selectedPurchase }
-						editCardDetailsPath={ editCardDetailsPath }
-					/>
+					{ ! isDomainTransfer( purchase ) && (
+						<PurchaseNotice
+							isDataLoading={ isDataLoading( this.props ) }
+							handleRenew={ this.handleRenew }
+							selectedSite={ selectedSite }
+							selectedPurchase={ selectedPurchase }
+							editCardDetailsPath={ editCardDetailsPath }
+						/>
+					) }
 					{ this.renderPurchaseDetail() }
 				</Main>
 			</span>

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -28,7 +28,7 @@ import {
 	paymentLogoType,
 } from 'lib/purchases';
 import { isMonthly } from 'lib/plans/constants';
-import { isDomainRegistration } from 'lib/products-values';
+import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
@@ -67,7 +67,7 @@ class PurchaseMeta extends Component {
 		const period =
 			productSlug && isMonthly( productSlug ) ? translate( 'month' ) : translate( 'year' );
 
-		if ( isOneTimePurchase( purchase ) ) {
+		if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
 			return translate(
 				'%(currencySymbol)s%(amount)f %(currencyCode)s {{period}}(one-time){{/period}}',
 				{
@@ -216,7 +216,7 @@ class PurchaseMeta extends Component {
 		const purchase = getPurchase( this.props );
 		const { translate } = this.props;
 
-		if ( isOneTimePurchase( purchase ) ) {
+		if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
 			return null;
 		}
 
@@ -288,6 +288,20 @@ class PurchaseMeta extends Component {
 		);
 	}
 
+	renderExpiration() {
+		const purchase = getPurchase( this.props );
+		if ( isDomainTransfer( purchase ) ) {
+			return null;
+		}
+
+		return (
+			<li>
+				<em className="manage-purchase__detail-label">{ this.renderRenewsOrExpiresOnLabel() }</em>
+				<span className="manage-purchase__detail">{ this.renderRenewsOrExpiresOn() }</span>
+			</li>
+		);
+	}
+
 	renderPlaceholder() {
 		return (
 			<ul className="manage-purchase__meta">
@@ -316,12 +330,7 @@ class PurchaseMeta extends Component {
 						<em className="manage-purchase__detail-label">{ translate( 'Price' ) }</em>
 						<span className="manage-purchase__detail">{ this.renderPrice() }</span>
 					</li>
-					<li>
-						<em className="manage-purchase__detail-label">
-							{ this.renderRenewsOrExpiresOnLabel() }
-						</em>
-						<span className="manage-purchase__detail">{ this.renderRenewsOrExpiresOn() }</span>
-					</li>
+					{ this.renderExpiration() }
 					{ this.renderPaymentDetails() }
 				</ul>
 				{ this.renderContactSupportToRenewMessage() }

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -23,7 +23,13 @@ import {
 	purchaseType,
 	showCreditCardExpiringWarning,
 } from 'lib/purchases';
-import { isDomainProduct, isGoogleApps, isPlan, isTheme } from 'lib/products-values';
+import {
+	isDomainProduct,
+	isDomainTransfer,
+	isGoogleApps,
+	isPlan,
+	isTheme,
+} from 'lib/products-values';
 import Notice from 'components/notice';
 import PlanIcon from 'components/plans/plan-icon';
 import Gridicon from 'gridicons';
@@ -145,7 +151,7 @@ class PurchaseItem extends Component {
 		}
 
 		let icon;
-		if ( isDomainProduct( purchase ) ) {
+		if ( isDomainProduct( purchase ) || isDomainTransfer( purchase ) ) {
 			icon = 'domains';
 		} else if ( isTheme( purchase ) ) {
 			icon = 'themes';

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -29,7 +29,13 @@ import previousStep from 'components/marketing-survey/cancel-purchase-form/previ
 import { INITIAL_STEP, FINAL_STEP } from 'components/marketing-survey/cancel-purchase-form/steps';
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
 import { getPurchase, isDataLoading } from '../utils';
-import { isDomainRegistration, isPlan, isGoogleApps, isJetpackPlan } from 'lib/products-values';
+import {
+	isDomainRegistration,
+	isDomainTransfer,
+	isPlan,
+	isGoogleApps,
+	isJetpackPlan,
+} from 'lib/products-values';
 import notices from 'notices';
 import purchasePaths from '../paths';
 import { getPurchasesError } from 'state/purchases/selectors';
@@ -421,6 +427,10 @@ class RemovePurchase extends Component {
 
 		const purchase = getPurchase( this.props );
 		if ( ! isRemovable( purchase ) ) {
+			return null;
+		}
+
+		if ( isDomainTransfer( purchase ) ) {
 			return null;
 		}
 

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -18,6 +18,7 @@ import {
 	isOneTimePurchase,
 	isPaidWithCreditCard,
 } from 'lib/purchases';
+import { isDomainTransfer } from 'lib/products-values';
 
 // TODO: Remove these property-masking functions in favor of accessing the props directly
 function getPurchase( props ) {
@@ -81,7 +82,10 @@ function canEditPaymentDetails( purchase ) {
 		return false;
 	}
 	return (
-		! isExpired( purchase ) && ! isOneTimePurchase( purchase ) && ! isIncludedWithPlan( purchase )
+		! isExpired( purchase ) &&
+		! isOneTimePurchase( purchase ) &&
+		! isIncludedWithPlan( purchase ) &&
+		! isDomainTransfer( purchase )
 	);
 }
 

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -43,7 +43,7 @@ class Transfer extends React.PureComponent {
 				{ content }
 				<VerticalNav>
 					<VerticalNavItem path={ path }>
-						{ this.props.translate( 'Cancel Domain Transfer' ) }
+						{ this.props.translate( 'Cancel Transfer' ) }
 					</VerticalNavItem>
 				</VerticalNav>
 			</div>

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -22,6 +22,9 @@ import support from 'lib/url/support';
 import { restartInboundTransfer } from 'lib/domains';
 import { fetchDomains } from 'lib/upgrades/actions';
 import { errorNotice, successNotice } from 'state/notices/actions';
+import VerticalNav from 'components/vertical-nav';
+import VerticalNavItem from 'components/vertical-nav/item';
+import { cancelPurchase as cancelPurchaseLink } from 'me/purchases/paths';
 
 class Transfer extends React.PureComponent {
 	render() {
@@ -32,10 +35,17 @@ class Transfer extends React.PureComponent {
 			content = this.getCancelledContent();
 		}
 
+		const path = cancelPurchaseLink( this.props.selectedSite.slug, domain.subscriptionId );
+
 		return (
 			<div className="edit__domain-details-card">
 				<Header domain={ domain } />
 				{ content }
+				<VerticalNav>
+					<VerticalNavItem path={ path }>
+						{ this.props.translate( 'Cancel Domain Transfer' ) }
+					</VerticalNavItem>
+				</VerticalNav>
 			</div>
 		);
 	}


### PR DESCRIPTION
Update the Manage Purchase component when we're
looking at a Transfer In subscription.

- Hide remove product option.
- Allow self cancel/refund.
- Hide expiration and payment method.

Looks:
![manage](https://user-images.githubusercontent.com/1103398/32920869-5d3ed23e-cb2b-11e7-843c-2286cf26e7ac.png)

Add a 'Cancel Domain Transfer' in Domain Management for
Transfer Ins that links to the cancel and refund manage purchase screen.

Fixes: https://github.com/Automattic/wp-calypso/issues/19914

Dependency: D8336-code
