### PR TITLE
Comments: unwrap object matching shorthands

### DIFF
--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -49,7 +49,7 @@ const changePage = path => pageNumber => {
 };
 
 export const siteComments = context => {
-	const { params, path, query, store } = context;
+	const { params, path, query } = context;
 	const siteFragment = route.getSiteFragment( path );
 
 	if ( ! siteFragment ) {
@@ -71,11 +71,12 @@ export const siteComments = context => {
 			status={ status }
 		/>,
 		'primary',
-		store
+		context.store
 	);
 };
 
-export const postComments = ( { params, path, query, store } ) => {
+export const postComments = context => {
+	const { params, path, query } = context;
 	const siteFragment = route.getSiteFragment( path );
 
 	if ( ! siteFragment ) {
@@ -103,11 +104,12 @@ export const postComments = ( { params, path, query, store } ) => {
 			status={ status }
 		/>,
 		'primary',
-		store
+		context.store
 	);
 };
 
-export const comment = ( { query, params, path, store } ) => {
+export const comment = context => {
+	const { params, path, query } = context;
 	const siteFragment = route.getSiteFragment( path );
 	const commentId = sanitizeInt( params.comment );
 
@@ -122,7 +124,7 @@ export const comment = ( { query, params, path, store } ) => {
 	renderWithReduxStore(
 		<CommentView { ...{ action, commentId, siteFragment } } />,
 		'primary',
-		store
+		context.store
 	);
 };
 


### PR DESCRIPTION
Unwrap object matching shorthands to `context` for clarity and easier codemodding. 
Single-tree-rendering codemod will need `context` object inside the middleware and it's unable to handle object matching shorthands.

Follow up for #19685 where I missed these few. 

Unlike before, I'm also accessing `store` directly via `context.store` so that we don't have to remove `store` variable separately after running the single-tree-rendering codemod for this file. The codemod will make it unnecessary to have store variable here altogether.

### Testing

Confirm different comment sections work:
- `/comments/all/:site`
- `/comments/all/:site/:post`
- `/comments/all/:site/:comment`