### PR TITLE
Checkout: using `classnames` to add class to input field

### DIFF
--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -243,7 +243,7 @@ class PhoneInput extends React.PureComponent {
 					name={ this.props.name }
 					ref={ this.setNumberInputRef }
 					type="tel"
-					className={ this.props.isError && 'is-error' }
+					className={ classnames( { 'is-error': this.props.isError } ) }
 				/>
 				<div className="phone-input__select-container">
 					<div className="phone-input__select-inner-container">


### PR DESCRIPTION
A small PR to address @klimeryk's comments in #19695.

Using `classnames` prevents the stringification of false values, that is, it avoids the following:

```
<!-- where this.props.isError is null/undefined/false -->
<input class="false" />
```
`classnames` won't render the attribute at all if the condition isn't satisfied.


