### PR TITLE
Wrap long post titles without spaces in the post list

### DIFF
--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -61,6 +61,8 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	position: relative;
 	width: 100%;
 	margin-right: auto;
+	word-break: break-all;
+	word-wrap: break-word;
 
 	padding: 16px 0;
 	.post-item__card.is-mini & {

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -70,18 +70,6 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	}
 }
 
-.post-item__info {
-	display: flex;
-	flex-wrap: wrap;
-	overflow: hidden;
-	&::after {
-		@include long-content-fade(
-			$color: $post-item-background-color,
-			$size: 30px
-		);
-	}
-}
-
 .post-item__title {
 	@extend %content-font;
 	margin-bottom: 2px;

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -59,7 +59,7 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 
 .post-item__detail {
 	position: relative;
-	width: 100%;
+	width: calc( 100% - 50px );
 	margin-right: auto;
 	word-break: break-word;
 	word-wrap: break-word;

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -61,7 +61,7 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	position: relative;
 	width: 100%;
 	margin-right: auto;
-	word-break: break-all;
+	word-break: break-word;
 	word-wrap: break-word;
 
 	padding: 16px 0;

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -23,7 +23,7 @@
 	align-self: stretch;
 	overflow: hidden;
 
-	margin: 8px 0;
+	margin: 8px 0 8px 8px;
 	.post-item__card.is-mini & {
 		margin: 0;
 	}


### PR DESCRIPTION
This pull request fixes how long post titles without spaces are displayed in the post list.

Before:

![chrome-before](https://user-images.githubusercontent.com/1017839/32923235-ce05a41a-cb36-11e7-9fd7-1f5bcd8d7998.png)

After:

Chrome:

![chrome-after](https://user-images.githubusercontent.com/1017839/32923240-d54b47fc-cb36-11e7-9343-dd5838d4ca1a.png)

Safari:

![safari-after](https://user-images.githubusercontent.com/1017839/32923249-de363f8e-cb36-11e7-82b0-33e53adbb811.png)

Firefox:

![firefox-after](https://user-images.githubusercontent.com/1017839/32923254-e2dd578e-cb36-11e7-8595-6a378c761c50.png)

MS Edge:

![edge-after](https://user-images.githubusercontent.com/1017839/32923272-eff7759e-cb36-11e7-9f6e-7aa646768d0f.png)

IE11:

![ie11-after](https://user-images.githubusercontent.com/1017839/32923277-f6df6c22-cb36-11e7-8541-22c9914d871f.png)

To test:

- checkout branch
- make sure you are part of the condensed post list ab test
- navigate to the post list
- create a post with a long title without spaces
- verify that the title wraps correctly, and that the action menu is usable (visible, clickable)