### PR TITLE
Post Revisions: Add tests for the getPostRevisionChanges selector

### DIFF
--- a/client/state/data-layer/wpcom/posts/revisions/test/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/test/index.js
@@ -4,13 +4,12 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { cloneDeep, forEach, map } from 'lodash';
+import { cloneDeep, map } from 'lodash';
 import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
 import { fetchPostRevisions, normalizeRevision, receiveSuccess, receiveError } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
@@ -150,15 +149,6 @@ describe( '#receiveSuccess', () => {
 		receiveSuccess( { dispatch }, action, successfulPostRevisionsResponse );
 
 		const expectedRevisions = cloneDeep( normalizedPostRevisions );
-		if ( isEnabled( 'post-editor/revisions' ) ) {
-			forEach( expectedRevisions, revision => {
-				revision.summary = { added: 6, removed: 0 };
-				revision.changes = {
-					content: [ { added: true, count: 9, value: '<p>Lorem ipsum</p>' } ],
-					title: [ { added: true, count: 7, value: 'Sed nobis ab earum' } ],
-				};
-			} );
-		}
 
 		expect( dispatch ).to.have.callCount( 2 );
 		expect( dispatch ).to.have.been.calledWith( receivePostRevisionsSuccess( 12345678, 10 ) );

--- a/client/state/selectors/get-post-revision-changes.js
+++ b/client/state/selectors/get-post-revision-changes.js
@@ -30,7 +30,7 @@ const getCombinedLength = list =>
 
 const getPostRevisionChanges = createSelector(
 	( state, siteId, postId, revisionId ) => {
-		const noChanges = { content: [], summary: [], title: [] };
+		const noChanges = { content: [], summary: {}, title: [] };
 		if ( ! isEnabled( 'post-editor/revisions' ) ) {
 			return noChanges;
 		}

--- a/client/state/selectors/test/get-post-revision-changes.js
+++ b/client/state/selectors/test/get-post-revision-changes.js
@@ -1,0 +1,222 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getPostRevisionChanges from '../get-post-revision-changes';
+
+describe( 'getPostRevisionChanges', () => {
+	const x20k = 'x'.repeat( 20000 );
+	const x19921 = 'x'.repeat( 19921 );
+
+	const outOfOrderState = {
+		posts: {
+			revisions: {
+				revisions: {
+					12345678: {
+						10: {
+							// NOTE: those are voluntarily out of order,
+							// to test that we're selecting the right
+							// base revision when computing changes.
+							13: {
+								id: 13,
+								date: '2017-04-21T13:13:13Z',
+								content: 'World',
+								title: '',
+							},
+							11: {
+								id: 11,
+								date: '2017-04-21T11:11:11Z',
+								content: 'Hello World',
+								title: 'Test Title',
+							},
+							12: {
+								id: 12,
+								author: 2,
+								date: '2017-04-21T12:12:12Z',
+								content: 'Hello',
+								title: 'Test',
+							},
+							15: {
+								id: 15,
+								author: 2,
+								date: '2017-04-22T12:12:12Z',
+								content: '',
+								title: '',
+							},
+							16: {
+								id: 16,
+								author: 2,
+								date: '2017-04-22T12:13:12Z',
+								content: 'L&#8217;usage d&#8217;un instrument savant',
+								title: 'Foo &amp; Baz',
+							},
+							17: {
+								id: 17,
+								author: 2,
+								date: '2017-11-14T12:13:12Z',
+								content: 'This revision has a really long title',
+								title: x20k,
+							},
+							18: {
+								id: 19,
+								author: 2,
+								date: '2017-11-15T12:13:13Z',
+								content: 'x',
+								title: 'This revision has short content & title',
+							},
+							19: {
+								id: 19,
+								author: 2,
+								date: '2017-11-14T12:13:14Z',
+								content: x20k,
+								title: 'This revision has really long content',
+							},
+							20: {
+								id: 20,
+								author: 2,
+								date: '2017-11-15T14:15:12Z',
+								content: 'x',
+								title: 'This revision has short content & title',
+							},
+							21: {
+								id: 21,
+								author: 2,
+								date: '2017-11-15T14:16:12Z',
+								content: x19921,
+								title: 'This revision has total length of 19961',
+							},
+						},
+					},
+				},
+			},
+		},
+		users: {
+			items: {},
+		},
+	};
+
+	const noChanges = {
+		content: [],
+		summary: {},
+		title: [],
+	};
+
+	test( 'should return an empty array for content, summary, & title if the revision is not found', () => {
+		expect( getPostRevisionChanges( outOfOrderState, 12345678, 10, 14 ) ).to.eql( noChanges );
+	} );
+
+	test( 'should compute diff changes based on revision dates', () => {
+		expect( getPostRevisionChanges( outOfOrderState, 12345678, 10, 12 ) ).to.eql( {
+			content: [
+				{
+					count: 1,
+					value: 'Hello',
+				},
+				{
+					count: 2,
+					removed: true,
+					value: ' World',
+				},
+			],
+			summary: { added: 0, removed: 2 },
+			title: [
+				{
+					count: 1,
+					value: 'Test',
+				},
+				{
+					count: 2,
+					removed: true,
+					value: ' Title',
+				},
+			],
+		} );
+	} );
+
+	test( 'should compute diff changes for the oldest revision available against a clean slate', () => {
+		expect( getPostRevisionChanges( outOfOrderState, 12345678, 10, 11 ) ).to.eql( {
+			content: [
+				{
+					count: 3,
+					added: true,
+					value: 'Hello World',
+				},
+			],
+			summary: { added: 4, removed: 0 },
+			title: [
+				{
+					count: 3,
+					added: true,
+					value: 'Test Title',
+				},
+			],
+		} );
+	} );
+
+	test( 'should properly decode HTML entities', () => {
+		expect( getPostRevisionChanges( outOfOrderState, 12345678, 10, 16 ) ).to.eql( {
+			content: [
+				{
+					count: 11,
+					added: true,
+					value: 'L’usage d’un instrument savant',
+				},
+			],
+			summary: { added: 6, removed: 0 },
+			title: [
+				{
+					count: 5,
+					added: true,
+					value: 'Foo & Baz',
+				},
+			],
+		} );
+	} );
+
+	test( 'should return noChanges for really long titles', () => {
+		expect( getPostRevisionChanges( outOfOrderState, 12345678, 10, 17 ) ).to.eql( {
+			...noChanges,
+			tooLong: true,
+		} );
+	} );
+
+	test( 'should return noChanges for really long content', () => {
+		expect( getPostRevisionChanges( outOfOrderState, 12345678, 10, 19 ) ).to.eql( {
+			...noChanges,
+			tooLong: true,
+		} );
+	} );
+
+	test( 'should return changes for nearly too long content', () => {
+		expect( getPostRevisionChanges( outOfOrderState, 12345678, 10, 21 ) ).to.eql( {
+			content: [
+				{ count: 1, removed: true, value: 'x' },
+				{
+					count: 1,
+					added: true,
+					value: x19921,
+				},
+			],
+			summary: { added: 4, removed: 4 },
+			title: [
+				{ count: 6, value: 'This revision has ' },
+				{ count: 1, removed: true, value: 'short' },
+				{ count: 1, added: true, value: 'total' },
+				{ count: 1, value: ' ' },
+				{ count: 1, removed: true, value: 'content' },
+				{ count: 1, added: true, value: 'length' },
+				{ count: 1, value: ' ' },
+				{ count: 1, removed: true, value: '&' },
+				{ count: 1, added: true, value: 'of' },
+				{ count: 1, value: ' ' },
+				{ count: 1, removed: true, value: 'title' },
+				{ count: 1, added: true, value: '19961' },
+			],
+		} );
+	} );
+} );

--- a/config/test.json
+++ b/config/test.json
@@ -82,6 +82,7 @@
 		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/media-advanced": true,
+		"post-editor/revisions": true,
 		"press-this": true,
 		"publicize-preview": true,
 		"reader": true,


### PR DESCRIPTION
Targeted at #19072 / `fix/multiple-revision-diffs`.

This enables the flag in the test environment & adds back the selector test pulled out of that branch.

It also fixes a minor issue of returning the invalid data type for `summary` when returning "no changes".

Pull out the `receiveSuccess` annotations as well.

## To Test: 

* `npm run test-client client/state/selectors/test/get-post-revision-changes.js`
* `npm run test-client client/state/data-layer/wpcom/posts/revisions/test/index.js`