### PR TITLE
Domain Transfer: implement i2 design of precheck screen

### DIFF
--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -30,6 +30,12 @@
 	}
 }
 
+.transfer-domain-step__title {
+	.formatted-header {
+		margin: 10px 0;
+	}
+}
+
 .transfer-domain-step__domain-description {
 	font-size: 16px;
 	margin-bottom: 20px;
@@ -62,78 +68,83 @@
 	top: 2px;
 }
 
-.transfer-domain-step__precheck, .transfer-domain-step__options {
-	.foldable-card.card {
-		margin-bottom: 0;
+.transfer-domain-step__section-heading-number {
+	width: 28px;
+	height: 28px;
+	line-height: 28px;
+	border-radius: 50%;
+	border: 1px solid lighten( $gray, 20% );
+	background-color: $gray-light;
+	color: darken( $gray, 20% );
+	font-size: 18px;
+	text-align: center;
+	margin-right: 15px;
+	flex-shrink: 0;
+}
 
-		&.is-expanded {
-			margin-top: 0;
-		}
-	}
+.transfer-domain-step__section-heading {
+	font-size: 16px;
+}
 
-	.transfer-domain-step__section {
-		display: flex;
-	}
+.transfer-domain-step__section {
+	align-items: center;
+	display: flex;
+	padding: 5px 0;
 
-	.transfer-domain-step__unlocked {
-		color: $alert-green;
-
-		svg {
-			padding-right: 4px;
-		}
-	}
-
-	.transfer-domain-step__section-heading-number {
-		width: 28px;
-		height: 28px;
-		line-height: 28px;
-		border-radius: 50%;
-		border: 1px solid lighten( $gray, 20% );
-		background-color: $gray-light;
-		color: darken( $gray, 20% );
-		font-size: 18px;
-		text-align: center;
-		margin-right: 15px;
-		flex-shrink: 0;
+	.transfer-domain-step__section-text {
+		flex-basis: 100%;
 	}
 
 	.transfer-domain-step__section-heading {
-		font-size: 16px;
+		color: darken( $gray, 20% );
 	}
 
-	.transfer-domain-step__section-explanation {
-		margin-left: 48px;
+	.button {
+		margin-top: 20px;
 	}
 
-	.transfer-domain-step__continue {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
+	&.is-expanded {
+		align-items: flex-start;
 
-		button {
-			flex-shrink: 0;
-			margin-left: 15px;
+		.transfer-domain-step__section-heading {
+			color: $gray-dark;
 		}
 	}
+}
 
-	.transfer-domain-step__continue-text {
-		p {
-			color: darken( $gray, 10% );
-			font-size: 14px;
-			max-width: 500px;
-		}
+.transfer-domain-step__lock-status {
+	float: right;
+	font-size: 12px;
+
+	svg {
+		padding-right: 4px;
 	}
 
-	.section-header {
+	&.transfer-domain-step__unlocked {
+		color: $alert-green;
+	}
+
+	&.transfer-domain-step__locked {
+		color: $alert-red;
+	}
+}
+
+.transfer-domain-step__continue-text {
+	p {
+		color: darken( $gray, 10% );
 		font-size: 14px;
+		max-width: 500px;
 	}
+}
 
-	.hide-secondary {
-		span {
-			&.foldable-card__secondary {
-				flex: 0 1;
-			}
-		}
+.transfer-domain-step__continue {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+
+	button {
+		flex-shrink: 0;
+		margin-left: 15px;
 	}
 }
 

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -36,6 +36,7 @@
 	justify-content: space-between;
 
 	.formatted-header {
+		flex-basis: 100%;
 		margin: 10px 0;
 		text-align: left;
 	}
@@ -173,7 +174,6 @@
 	p {
 		color: darken( $gray, 10% );
 		font-size: 14px;
-		max-width: 500px;
 	}
 }
 

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -31,8 +31,36 @@
 }
 
 .transfer-domain-step__title {
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
+
 	.formatted-header {
 		margin: 10px 0;
+		text-align: left;
+	}
+
+	.formatted-header__title,
+	.formatted-header__subtitle {
+		padding: 0;
+	}
+
+	.transfer-domain-step__illustration {
+		display: none;
+		margin-left: 20px;
+		max-width: 140px;
+
+		@include breakpoint( '>480px' ) {
+			display: block;
+		}
+
+		@include breakpoint( '>660px' ) {
+			display: none;
+		}
+
+		@include breakpoint( '>960px' ) {
+			display: block;
+		}
 	}
 }
 

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -82,10 +82,6 @@
 	flex-shrink: 0;
 }
 
-.transfer-domain-step__section-heading {
-	font-size: 16px;
-}
-
 .transfer-domain-step__section {
 	align-items: center;
 	display: flex;
@@ -97,6 +93,10 @@
 
 	.transfer-domain-step__section-heading {
 		color: darken( $gray, 20% );
+		align-items: center;
+		display: flex;
+		font-size: 16px;
+		justify-content: space-between;
 	}
 
 	.button {
@@ -110,10 +110,22 @@
 			color: $gray-dark;
 		}
 	}
+
+	&.is-complete {
+		.transfer-domain-step__section-heading-number {
+			background: none;
+			border: none;
+			color: $alert-green;
+
+			.gridicon {
+				margin-left: -4px;
+				margin-top: -4px;
+			}
+		}
+	}
 }
 
 .transfer-domain-step__lock-status {
-	float: right;
 	font-size: 12px;
 
 	svg {

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -55,6 +55,10 @@ class TransferDomainPrecheck extends React.PureComponent {
 				return;
 			}
 
+			if ( result.unlocked ) {
+				this.showNextStep();
+			}
+
 			this.setState( {
 				email: result.admin_email,
 				privacy: result.privacy,
@@ -69,7 +73,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 	};
 
 	getSection( heading, message, buttonText, position, lockStatus ) {
-		const { currentStep } = this.state;
+		const { currentStep, loading, unlocked } = this.state;
 		const sectionClasses = classNames( 'transfer-domain-step__section', {
 			'is-expanded': position === currentStep,
 			'is-complete': position < currentStep,
@@ -90,7 +94,11 @@ class TransferDomainPrecheck extends React.PureComponent {
 						{ position === currentStep && (
 							<div>
 								<div className="transfer-domain-step__section-message">{ message }</div>
-								<Button compact onClick={ this.showNextStep }>
+								<Button
+									compact
+									onClick={ unlocked ? this.showNextStep : this.refreshStatus }
+									disabled={ loading }
+								>
 									{ buttonText }
 								</Button>
 							</div>
@@ -103,7 +111,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 
 	getStatusMessage() {
 		const { translate } = this.props;
-		const { unlocked } = this.state;
+		const { unlocked, loading } = this.state;
 
 		const heading = unlocked
 			? translate( 'Domain is unlocked.' )
@@ -114,7 +122,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 					"Your domain is locked to prevent unauthorized transfers. You'll need to unlock " +
 						'it before we can move it.'
 				);
-		const buttonText = translate( "I've unlocked my domain" );
+		const buttonText = loading ? translate( 'Checking…' ) : translate( "I've unlocked my domain" );
 
 		const lockStatus = unlocked ? (
 			<div className="transfer-domain-step__lock-status transfer-domain-step__unlocked">

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -185,6 +185,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 
 	render() {
 		const { translate } = this.props;
+		const { unlocked, currentStep } = this.state;
 
 		return (
 			<div className="transfer-domain-step__precheck">
@@ -206,7 +207,11 @@ class TransferDomainPrecheck extends React.PureComponent {
 							) }
 						</p>
 					</div>
-					<Button disabled={ ! this.state.unlocked } onClick={ this.onClick } primary={ true }>
+					<Button
+						disabled={ ! unlocked || currentStep < 4 }
+						onClick={ this.onClick }
+						primary={ true }
+					>
 						{ translate( 'Continue' ) }
 					</Button>
 				</Card>

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -72,15 +72,16 @@ class TransferDomainPrecheck extends React.PureComponent {
 		this.setState( { currentStep: this.state.currentStep + 1 } );
 	};
 
-	getSection( heading, message, buttonText, position, lockStatus ) {
+	getSection( heading, message, buttonText, step, lockStatus ) {
 		const { currentStep, loading, unlocked } = this.state;
+		const isAtCurrentStep = step === currentStep;
+		const isStepFinished = currentStep > step;
 		const sectionClasses = classNames( 'transfer-domain-step__section', {
-			'is-expanded': position === currentStep,
-			'is-complete': position < currentStep,
+			'is-expanded': isAtCurrentStep,
+			'is-complete': isStepFinished,
 		} );
 
-		const sectionIcon =
-			currentStep > position ? <Gridicon icon="checkmark-circle" size={ 36 } /> : position;
+		const sectionIcon = isStepFinished ? <Gridicon icon="checkmark-circle" size={ 36 } /> : step;
 
 		return (
 			<Card compact>
@@ -91,7 +92,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 							<strong>{ heading }</strong>
 							{ lockStatus }
 						</div>
-						{ position === currentStep && (
+						{ isAtCurrentStep && (
 							<div>
 								<div className="transfer-domain-step__section-message">{ message }</div>
 								<Button

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -72,10 +72,11 @@ class TransferDomainPrecheck extends React.PureComponent {
 		const { currentStep } = this.state;
 		const sectionClasses = classNames( 'transfer-domain-step__section', {
 			'is-expanded': position === currentStep,
+			'is-complete': position < currentStep,
 		} );
 
 		const sectionIcon =
-			currentStep > position ? <Gridicon icon="checkmark-circle" size={ 24 } /> : position;
+			currentStep > position ? <Gridicon icon="checkmark-circle" size={ 36 } /> : position;
 
 		return (
 			<Card compact>

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -120,7 +120,12 @@ class TransferDomainPrecheck extends React.PureComponent {
 			? translate( 'Your domain is unlocked at your current registrar.' )
 			: translate(
 					"Your domain is locked to prevent unauthorized transfers. You'll need to unlock " +
-						'it before we can move it.'
+						'it at your current domiain provider before we can move it. {{a}}Here are instructions for unlocking it{{/a}}',
+					{
+						components: {
+							a: <a href="#" rel="noopener noreferrer" />,
+						},
+					}
 				);
 		const buttonText = loading ? translate( 'Checking…' ) : translate( "I've unlocked my domain" );
 
@@ -146,11 +151,15 @@ class TransferDomainPrecheck extends React.PureComponent {
 		const heading = translate( 'Verify we can get in touch.' );
 		const message = translate(
 			"We'll send an email to {{strong}}%(email)s{{/strong}} to start the transfer process. Make sure " +
-				"you have access to that address. Don't recognize it? Then you have privacy protection, " +
-				"and you'll need to turn it off before we start.",
+				"you have access to that address. Don't recognize it? Then you have privacy protection enabled. " +
+				"You'll need to log in to your current domain provider and {{a}}turn it off{{/a}} before we start. " +
+				"Don't worry, you can re-enable it once the transfer is done.",
 			{
 				args: { email },
-				components: { strong: <strong /> },
+				components: {
+					strong: <strong />,
+					a: <a href="#" rel="noopener noreferrer" />,
+				},
 			}
 		);
 		const buttonText = translate( 'I can access this email address' );
@@ -166,7 +175,12 @@ class TransferDomainPrecheck extends React.PureComponent {
 			'A domain authorization code is a unique code linked only to your domain — kind of like a ' +
 				"password for your domain. Log in to your current registrar to get one. We'll send you an email " +
 				'with a link to enter it and officially okay the transfer. We call it a domain authorization code, ' +
-				'but it might be called a secret code, auth code, or EPP code.'
+				'but it might be called a secret code, auth code, or EPP code. {{a}}Learn more{{/a}}.',
+				{
+					components: {
+						a: <a href="#" rel="noopener noreferrer" />,
+					},
+				}
 		);
 		const buttonText = translate( 'I have my authorization code' );
 
@@ -205,7 +219,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 					<div className="transfer-domain-step__continue-text">
 						<p>
 							{ translate(
-								'Note: These changes can take up to 20 minutes to take effect. ' +
+								'Note: These changes can take some time to take effect. ' +
 									'Need help? {{a}}Get in touch with one of our Happiness Engineers{{/a}}.',
 								{
 									components: {

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -176,11 +176,11 @@ class TransferDomainPrecheck extends React.PureComponent {
 				"password for your domain. Log in to your current registrar to get one. We'll send you an email " +
 				'with a link to enter it and officially okay the transfer. We call it a domain authorization code, ' +
 				'but it might be called a secret code, auth code, or EPP code. {{a}}Learn more{{/a}}.',
-				{
-					components: {
-						a: <a href="#" rel="noopener noreferrer" />,
-					},
-				}
+			{
+				components: {
+					a: <a href="#" rel="noopener noreferrer" />,
+				},
+			}
 		);
 		const buttonText = translate( 'I have my authorization code' );
 
@@ -200,6 +200,10 @@ class TransferDomainPrecheck extends React.PureComponent {
 					subHeaderText={ translate(
 						'Log into your current registrar to complete a few preliminary steps.'
 					) }
+				/>
+				<img
+					className="transfer-domain-step__illustration"
+					src={ '/calypso/images/illustrations/migrating-host-diy.svg' }
 				/>
 			</Card>
 		);


### PR DESCRIPTION
This PR updates the precheck screen in the domain transfer flow to a version that tested better. It adds a chronological process to the precheck to reduce some cognitive overhead for the user. Each step is more focused and less overwhelming.

![image](https://user-images.githubusercontent.com/448298/32955960-826fb8e8-cb85-11e7-9222-9f6347c08e01.png)

![image](https://user-images.githubusercontent.com/448298/32956278-576d0596-cb86-11e7-9da7-b0a18aa250ff.png)

#### Testing

1. Start at `/domains/add/transfer` and select a site to transfer a domain.
2. Enter a domain that's locked.
3. **Assert it looks like the screenshot above.**
4. Unlock the domain at the current registrar.
5. Click `I've unlocked my domain`.
6. **Assert the button changes to `Checking...` and moves you to step 2.**
7. Click through the remaining steps.
8. **Assert the `Continue` button becomes enabled after all 3 steps are completed.**
9. Click `Back` in the header to go back to enter a new domain.
10. Enter the same domain that's still unlocked.
11. **Assert the first step is automatically completed when the page loads.**
12. Try it again in mobile viewports to make sure it all looks ok.

TODO

- [x] Color and size checkmark icons
- [x] Don't enable `Continue` until all steps are green
- [x] If locked: change text of button and make clicking that refresh status
- [x] If unlocked on page load, automatically advance to step 2 and mark step 1 complete
