### PR TITLE
Posts: memoize results of normalizePostForDisplay, avoid cloneDeep in posts reducer

### DIFF
--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { cloneDeep, difference, get, isEqual, map, omit, reduce, values } from 'lodash';
+import { clone, difference, get, isEqual, map, omit, reduce, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -251,9 +251,8 @@ export default class QueryManager {
 				if ( ! item || ! isEqual( mergedItem, item ) ) {
 					// Did not exist previously or has changed
 					if ( memo === this.data.items ) {
-						// Create a copy of memo, as we don't want to mutate the
-						// original items set
-						memo = cloneDeep( memo );
+						// Create a copy of memo, as we don't want to mutate the original items set
+						memo = clone( memo );
 					}
 
 					memo[ receivedItemKey ] = mergedItem;
@@ -357,7 +356,7 @@ export default class QueryManager {
 						if ( ! updatedItem || ! this.constructor.matches( query, updatedItem ) ) {
 							// Create a copy of the original details to avoid mutating
 							if ( memo[ queryKey ] === queryDetails ) {
-								memo[ queryKey ] = cloneDeep( queryDetails );
+								memo[ queryKey ] = clone( queryDetails );
 							}
 
 							// Omit item by slicing previous and next
@@ -377,7 +376,7 @@ export default class QueryManager {
 
 						// Create a copy of the original details to avoid mutating
 						if ( memo[ queryKey ] === queryDetails ) {
-							memo[ queryKey ] = cloneDeep( queryDetails );
+							memo[ queryKey ] = clone( queryDetails );
 						}
 
 						// Increment found count for query

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -133,6 +133,12 @@ export function mergeIgnoringArrays( object, ...sources ) {
 }
 
 /**
+ * Memoization cache for `normalizePostForDisplay`. If an identical `post` object was
+ * normalized before, retrieve the normalized value from cache instead of recomputing.
+ */
+const normalizePostCache = new WeakMap();
+
+/**
  * Returns a normalized post object given its raw form. A normalized post
  * includes common transformations to prepare the post for display.
  *
@@ -144,7 +150,13 @@ export function normalizePostForDisplay( post ) {
 		return null;
 	}
 
-	return normalizeDisplayFlow( cloneDeep( post ) );
+	let normalizedPost = normalizePostCache.get( post );
+	if ( ! normalizedPost ) {
+		// `normalizeDisplayFlow` mutates its argument properties -- hence deep clone is needed
+		normalizedPost = normalizeDisplayFlow( cloneDeep( post ) );
+		normalizePostCache.set( post, normalizedPost );
+	}
+	return normalizedPost;
 }
 
 /**


### PR DESCRIPTION
Makes two related performance improvements when rendering `PostTypeList` on the `/posts/:siteId?` and adding new results when infinite-scrolling:

Memoize the return value of `normalizePostForDisplay`. This function is called at least 3 times for each post in the list (twice in the `getSitePostsForQueryIgnoringPage` selector, once in `connect` call of `blocks/post-item` component) when anything (like a new page of results) is added to the list.

The return value is memoized in a `WeakMap` and automatically removed when the source `post` object from the state is GCed. The memoization also preserves the exact equality of input and ouput: if `p1 === p2` then `normalize(p1) === normalize(p2)`. This helps React avoid a huge number of rerenders.

The second improvement is in the `QueryManager.receive` method: when updating state that has shape `[post1,post2,post3]` don't create a deep clone. That creates a new copy of `post1` that is not strictly equal to the previous one, forces a redundant rerender of every item of the post list, and defeats the above memoization of `normalizePostForDisplay`.

Instead, create a shallow copy of the array, as is the custom when doing any other update of a Redux state in a reducer.

**How to test:**
Add `console.time` calls around the dispatches of `receivePosts` and `POSTS_REQUEST_SUCCESS` when receiving a posts query result. This measures the time spent in the reducer (improved in #19895) and also the time spent calling all the `react-redux` listeners, `mapStateToProps` calls and React updates of the rendered post list.

Then go to `/posts/:siteId` of a site with many posts (I test on `a8ckudos` or `testmanyposts`) and scroll down the list to load more results. Watch the timings in console.

I was measuring with #19895 already applied. Before the patch, a typical dispatch took 2.4s to 3.2s. After the patch, it's down to 100ms to 200ms -- more than 10 times improvement.
