### PR TITLE
Fix a typo: "upgrade`_plan" -> "upgrade_plan"

### DIFF
--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -188,7 +188,7 @@ export class SignupProcessingScreen extends Component {
 
 	handleClickUpgradeButton = () => {
 		this.handleClick(
-			'upgrade`_plan',
+			'upgrade_plan',
 			this.state.siteSlug ? `/plans/${ this.state.siteSlug }` : ''
 		);
 	};


### PR DESCRIPTION
The first string argument should not contain a backtick symbol.