### PR TITLE
Jetpack connect: Add Jetpack version selector

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -15,6 +15,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import FormattedHeader from 'components/formatted-header';
 import SiteCard from './site-card';
 import versionCompare from 'lib/version-compare';
+import { getJetpackConnectJetpackVersion } from 'state/selectors';
 
 class AuthFormHeader extends Component {
 	getState() {
@@ -122,8 +123,8 @@ class AuthFormHeader extends Component {
 	}
 
 	getSiteCard() {
-		const version = get( this.props, [ 'authorize', 'queryObject', 'jp_version' ], '0.1' );
-		if ( ! versionCompare( version, '4.0.3', '>' ) ) {
+		const { jetpackVersion } = this.props;
+		if ( ! versionCompare( jetpackVersion, '4.0.3', '>' ) ) {
 			return null;
 		}
 
@@ -153,7 +154,8 @@ export default connect( state => {
 	const authorize = getAuthorizationData( state );
 	return {
 		authorize,
-		user: getCurrentUser( state ),
 		isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
+		jetpackVersion: getJetpackConnectJetpackVersion( state ),
+		user: getCurrentUser( state ),
 	};
 } )( localize( AuthFormHeader ) );

--- a/client/state/selectors/get-jetpack-connect-jetpack-version.js
+++ b/client/state/selectors/get-jetpack-connect-jetpack-version.js
@@ -1,0 +1,20 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getAuthorizationRemoteQueryData } from 'state/jetpack-connect/selectors';
+
+/**
+ * Returns Jetpack plugin version provided as part of Jetpack Connect authorization.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?String}       Version string
+ */
+export default function getJetpackConnectJetpackVersion( state ) {
+	return get( getAuthorizationRemoteQueryData( state ), 'jp_version', null );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -48,6 +48,7 @@ export getImageEditorIsGreaterThanMinimumDimensions from './get-image-editor-is-
 export getImageEditorOriginalAspectRatio from './get-image-editor-original-aspect-ratio';
 export getJetpackConnectionStatus from './get-jetpack-connection-status';
 export getJetpackConnectRedirectAfterAuth from './get-jetpack-connect-redirect-after-auth';
+export getJetpackConnectJetpackVersion from './get-jetpack-connect-jetpack-version';
 export getJetpackCredentials from './get-jetpack-credentials';
 export getJetpackJumpstartStatus from './get-jetpack-jumpstart-status';
 export getJetpackModule from './get-jetpack-module';


### PR DESCRIPTION
This PR creates a dedicated selector to access `jp_version` from connection auth data (`queryObject`).

It uses the new selector in the `AuthFormHeader` component to replace an inline getter.

No behavioral changes

### Testing
1. Authorize flow should remain unchanged
1. Inspect component props and ensure that the jetpackVersion is populated as expected.
1. Manually modify the prop to be `null`, verify that the version check fails and the site card is hidden.