### PR TITLE
Jetpack connect: Add partner ID selector

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -15,7 +15,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import FormattedHeader from 'components/formatted-header';
 import SiteCard from './site-card';
 import versionCompare from 'lib/version-compare';
-import { getJetpackConnectJetpackVersion } from 'state/selectors';
+import { getJetpackConnectJetpackVersion, getJetpackConnectPartnerId } from 'state/selectors';
 
 class AuthFormHeader extends Component {
 	getState() {
@@ -37,10 +37,7 @@ class AuthFormHeader extends Component {
 	}
 
 	getPartnerSlug() {
-		const partnerId = parseInt(
-			get( this.props, [ 'authorize', 'queryObject', 'partner_id' ], 0 ),
-			10
-		);
+		const { partnerId } = this.props;
 
 		switch ( partnerId ) {
 			case 51945:
@@ -151,11 +148,11 @@ class AuthFormHeader extends Component {
 }
 
 export default connect( state => {
-	const authorize = getAuthorizationData( state );
 	return {
-		authorize,
+		authorize: getAuthorizationData( state ),
 		isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
 		jetpackVersion: getJetpackConnectJetpackVersion( state ),
+		partnerId: getJetpackConnectPartnerId( state ),
 		user: getCurrentUser( state ),
 	};
 } )( localize( AuthFormHeader ) );

--- a/client/state/selectors/get-jetpack-connect-partner-id.js
+++ b/client/state/selectors/get-jetpack-connect-partner-id.js
@@ -1,0 +1,20 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getAuthorizationRemoteQueryData } from 'state/jetpack-connect/selectors';
+
+/**
+ * Returns the partner ID provided as part of Jetpack Connect authorization.
+ *
+ * @param  {Object} state Global state tree
+ * @return {number}       Partner ID or 0 if none was found.
+ */
+export default function getJetpackConnectPartnerId( state ) {
+	return parseInt( get( getAuthorizationRemoteQueryData( state ), 'partner_id', 0 ), 10 );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -47,6 +47,7 @@ export getCurrentUserRegisterDate from './get-current-user-register-date';
 export getImageEditorIsGreaterThanMinimumDimensions from './get-image-editor-is-greater-than-minimum-dimensions';
 export getImageEditorOriginalAspectRatio from './get-image-editor-original-aspect-ratio';
 export getJetpackConnectionStatus from './get-jetpack-connection-status';
+export getJetpackConnectPartnerId from './get-jetpack-connect-partner-id';
 export getJetpackConnectRedirectAfterAuth from './get-jetpack-connect-redirect-after-auth';
 export getJetpackConnectJetpackVersion from './get-jetpack-connect-jetpack-version';
 export getJetpackCredentials from './get-jetpack-credentials';


### PR DESCRIPTION
This PR creates a dedicated selector to access `partner_id` from connection auth data (`queryObject`).

It uses the new selector in the `AuthFormHeader` component to replace an inline getter.

No behavioral changes

### Testing
1. Authorize flow should remain unchanged
1. Inspect component props and ensure that the partnerId is populated as expected.
1. Manually modify the prop to be `51946` or `49615`, verify that the messaging changes accordingly.