### PR TITLE
WooCommerce - Fixed package modal styles

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/package-dialog.js
@@ -136,6 +136,7 @@ const AddPackageDialog = props => {
 			<FormSectionHeading>{ heading }</FormSectionHeading>
 			{ showSegmentedControl && (
 				<SegmentedControl
+					primary
 					className="packages__mode-select"
 					initialSelected={ mode }
 					onSelect={ switchMode }

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -4,10 +4,17 @@
 		float:left;
 	}
 
+	&:nth-child(1) {
+		width: 100%;
+		@include breakpoint( '>660px' ) {
+			width: 50%;
+		}
+	}
+
 	&:nth-child(2) {
 		width: 100%;
 		@include breakpoint( '>660px' ) {
-			width: 54%;
+			width: 50%;
 		}
 	}
 
@@ -25,10 +32,20 @@
 }
 
 &.packages__add-edit-dialog {
-	max-width: 600px;
+	height: 90%;
+	width: 90%;
 
 	.form-setting-explanation {
 		display: inline-block;
+	}
+
+	.dialog__content {
+		flex-grow: 1;
+	}
+
+	@include breakpoint( '>660px' ) {
+		width: 610px;
+		height: 610px;
 	}
 }
 


### PR DESCRIPTION
Fixes #19858 

* segmented control should have primary style
* the dialog has fixed width

![nov-17-2017 12-30-15](https://user-images.githubusercontent.com/800604/32947347-567c3866-cb93-11e7-9122-44bfe5ba2030.gif)
