### PR TITLE
Jetpack connect: Add and use from selector

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -140,7 +140,7 @@ class LoggedInForm extends Component {
 		} = nextProps.authorizationData;
 
 		if (
-			nextProps.isSso( nextProps ) ||
+			this.isSso( nextProps ) ||
 			this.isWoo( nextProps ) ||
 			this.isFromJpo( nextProps ) ||
 			this.shouldRedirectJetpackStart( nextProps )

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -10,7 +10,7 @@ import debugModule from 'debug';
 import Gridicon from 'gridicons';
 import page from 'page';
 import { connect } from 'react-redux';
-import { get, includes, startsWith } from 'lodash';
+import { includes, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -197,14 +197,13 @@ class LoggedInForm extends Component {
 		return startsWith( from, 'jpo' );
 	}
 
-	isSso( props ) {
+	isSso( { from, queryDataSiteId } = this.props ) {
 		const cookies = cookie.parse( document.cookie );
-		const client_id = get( props, [ 'authorizeData', 'queryObject' ] );
 		return (
-			'sso' === props.from &&
+			'sso' === from &&
 			cookies.jetpack_sso_approved &&
-			client_id &&
-			client_id === cookies.jetpack_sso_approved
+			queryDataSiteId &&
+			queryDataSiteId === cookies.jetpack_sso_approved
 		);
 	}
 
@@ -633,6 +632,7 @@ export default connect(
 			isFetchingAuthorizationSite: isRequestingSite( state, siteId ),
 			isFetchingSites: isRequestingSites( state ),
 			partnerId: getJetpackConnectPartnerId( state ),
+			queryDataSiteId: siteId,
 			redirectAfterAuth: getJetpackConnectRedirectAfterAuth( state ),
 			remoteSiteUrl,
 			siteId,

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -174,12 +174,7 @@ export class LoggedInForm extends Component {
 		const { goBackToWpAdmin, redirectAfterAuth } = this.props;
 		const { from } = this.props;
 
-		if (
-			this.isSso() ||
-			this.isWoo() ||
-			this.isFromJpo() ||
-			this.shouldRedirectJetpackStart( this.props )
-		) {
+		if ( this.isSso() || this.isWoo() || this.isFromJpo() || this.shouldRedirectJetpackStart() ) {
 			debug(
 				'Going back to WP Admin.',
 				'Connection initiated via: ',
@@ -216,7 +211,7 @@ export class LoggedInForm extends Component {
 		return includes( [ 'woocommerce-setup-wizard', 'woocommerce-services' ], from );
 	}
 
-	shouldRedirectJetpackStart( { partnerId } ) {
+	shouldRedirectJetpackStart( { partnerId } = this.props ) {
 		const partnerRedirectFlag = config.isEnabled(
 			'jetpack/connect-redirect-pressable-credential-approval'
 		);

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -71,7 +71,7 @@ const PLANS_PAGE = '/jetpack/connect/plans/';
 const debug = debugModule( 'calypso:jetpack-connect:authorize-form' );
 const PRESSABLE_PARTNER_ID = 49640;
 
-class LoggedInForm extends Component {
+export class LoggedInForm extends Component {
 	static propTypes = {
 		// Connected props
 		authAttempts: PropTypes.number.isRequired,

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -83,7 +83,6 @@ class LoggedInForm extends Component {
 			isRedirectingToWpAdmin: PropTypes.bool,
 			queryObject: PropTypes.shape( {
 				already_authorized: PropTypes.bool,
-				jp_version: PropTypes.string.isRequired,
 				new_user_started_connection: PropTypes.bool,
 			} ).isRequired,
 			siteReceived: PropTypes.bool,

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -95,6 +95,8 @@ export class LoggedInForm extends Component {
 		isAlreadyOnSitesList: PropTypes.bool,
 		isFetchingAuthorizationSite: PropTypes.bool,
 		isFetchingSites: PropTypes.bool,
+		partnerId: PropTypes.number,
+		queryDataSiteId: PropTypes.number,
 		recordTracksEvent: PropTypes.func.isRequired,
 		redirectAfterAuth: PropTypes.string,
 		remoteSiteUrl: PropTypes.string,

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -197,14 +197,19 @@ export class LoggedInForm extends Component {
 		return startsWith( from, 'jpo' );
 	}
 
+	/**
+	 * Check whether this a valid authorized SSO request
+	 *
+	 * @param  {?string} props.from            Where is the request from
+	 * @param  {?number} props.queryDataSiteId Remote site ID
+	 * @return {boolean}                       True if it's a valid SSO request otherwise false
+	 */
 	isSso( { from, queryDataSiteId } = this.props ) {
 		const cookies = cookie.parse( document.cookie );
-		return (
-			'sso' === from &&
-			cookies.jetpack_sso_approved &&
-			queryDataSiteId &&
-			queryDataSiteId === cookies.jetpack_sso_approved
-		);
+		const jetpack_sso_approved = cookies.jetpack_sso_approved
+			? parseInt( cookies.jetpack_sso_approved, 10 )
+			: null;
+		return 'sso' === from && !! queryDataSiteId && queryDataSiteId === jetpack_sso_approved;
 	}
 
 	isWoo( { from } = this.props ) {

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -9,8 +9,8 @@ import debugModule from 'debug';
 import Gridicon from 'gridicons';
 import page from 'page';
 import { connect } from 'react-redux';
+import { includes, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
-import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -73,7 +73,6 @@ const PRESSABLE_PARTNER_ID = 49640;
 class LoggedInForm extends Component {
 	static propTypes = {
 		isSSO: PropTypes.bool,
-		isWoo: PropTypes.bool,
 
 		// Connected props
 		authAttempts: PropTypes.number.isRequired,
@@ -145,7 +144,7 @@ class LoggedInForm extends Component {
 		// Instead, redirect back to admin as soon as we're connected
 		if (
 			nextProps.isSSO ||
-			nextProps.isWoo ||
+			this.isWoo( nextProps ) ||
 			this.isFromJpo( nextProps ) ||
 			this.shouldRedirectJetpackStart( nextProps )
 		) {
@@ -180,7 +179,7 @@ class LoggedInForm extends Component {
 
 		if (
 			this.props.isSSO ||
-			this.props.isWoo ||
+			this.isWoo() ||
 			this.isFromJpo() ||
 			this.shouldRedirectJetpackStart( this.props )
 		) {
@@ -210,6 +209,10 @@ class LoggedInForm extends Component {
 		// a credential approval screen. Otherwise, we need to redirect all other partners back
 		// to wp-admin.
 		return partnerRedirectFlag ? partnerId && PRESSABLE_PARTNER_ID !== partnerId : partnerId;
+	}
+
+	isWoo( { from } = this.props ) {
+		return includes( [ 'woocommerce-setup-wizard', 'woocommerce-services' ], from );
 	}
 
 	handleClickDisclaimer = () => {

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import cookie from 'cookie';
-import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -62,13 +61,6 @@ class JetpackConnectAuthorizeForm extends Component {
 		);
 	}
 
-	isWoo() {
-		const wooSlugs = [ 'woocommerce-setup-wizard', 'woocommerce-services' ];
-		const jetpackConnectSource = get( this.props, 'authorizationRemoteQueryData.from' );
-
-		return includes( wooSlugs, jetpackConnectSource );
-	}
-
 	handleClickHelp = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
 	};
@@ -93,7 +85,7 @@ class JetpackConnectAuthorizeForm extends Component {
 
 	renderForm() {
 		return this.props.isLoggedIn ? (
-			<LoggedInForm isSSO={ this.isSSO() } isWoo={ this.isWoo() } />
+			<LoggedInForm isSSO={ this.isSSO() } />
 		) : (
 			<LoggedOutForm local={ this.props.locale } path={ this.props.path } />
 		);

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -6,7 +6,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import cookie from 'cookie';
 
 /**
  * Internal dependencies
@@ -49,18 +48,6 @@ class JetpackConnectAuthorizeForm extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_authorize_form_view' );
 	}
 
-	isSSO() {
-		const cookies = cookie.parse( document.cookie );
-		const query = this.props.authorizationRemoteQueryData;
-		return (
-			query.from &&
-			'sso' === query.from &&
-			cookies.jetpack_sso_approved &&
-			query.client_id &&
-			query.client_id === cookies.jetpack_sso_approved
-		);
-	}
-
 	handleClickHelp = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
 	};
@@ -85,7 +72,7 @@ class JetpackConnectAuthorizeForm extends Component {
 
 	renderForm() {
 		return this.props.isLoggedIn ? (
-			<LoggedInForm isSSO={ this.isSSO() } />
+			<LoggedInForm />
 		) : (
 			<LoggedOutForm local={ this.props.locale } path={ this.props.path } />
 		);

--- a/client/jetpack-connect/test/__snapshots__/authorize-form.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize-form.js.snap
@@ -7,10 +7,7 @@ exports[`AuthorizeForm should render LoggedInForm when logged in 1`] = `
   <div
     className="jetpack-connect__authorize-form"
   >
-    <Connect(Localized(LoggedInForm))
-      isSSO={false}
-      isWoo={false}
-    />
+    <Connect(Localized(LoggedInForm)) />
   </div>
 </JetpackConnectMainWrapper>
 `;

--- a/client/jetpack-connect/test/auth-logged-in-form.js
+++ b/client/jetpack-connect/test/auth-logged-in-form.js
@@ -1,0 +1,51 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+/**
+ * Internal dependencies
+ */
+import { LoggedInForm } from '../auth-logged-in-form';
+
+describe( 'LoggedOutForm', () => {
+	describe( 'isSso', () => {
+		const isSso = new LoggedInForm().isSso;
+		const queryDataSiteId = 12349876;
+
+		test( 'returns true for valid SSO', () => {
+			document.cookie = `jetpack_sso_approved=${ queryDataSiteId };`;
+			const props = {
+				from: 'sso',
+				queryDataSiteId,
+			};
+			expect( isSso( props ) ).toBe( true );
+		} );
+
+		test( 'returns false with bad from', () => {
+			document.cookie = `jetpack_sso_approved=${ queryDataSiteId };`;
+			const props = {
+				from: 'elsewhere',
+				queryDataSiteId,
+			};
+			expect( isSso( props ) ).toBe( false );
+		} );
+
+		test( 'returns false without approved cookie', () => {
+			document.cookie = 'jetpack_sso_approved=;';
+			const props = {
+				from: 'sso',
+				queryDataSiteId,
+			};
+			expect( isSso( props ) ).toBe( false );
+		} );
+
+		test( 'returns false with no cookie or queryDataSiteId', () => {
+			document.cookie = 'jetpack_sso_approved=;';
+			const props = {
+				from: 'sso',
+				queryDataSiteId: null,
+			};
+			expect( isSso( props ) ).toBe( false );
+		} );
+	} );
+} );

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -114,7 +114,7 @@ const hasExpiredSecretError = function( state ) {
 const getSiteIdFromQueryObject = function( state ) {
 	const authorizationData = getAuthorizationData( state );
 	if ( authorizationData.queryObject && authorizationData.queryObject.client_id ) {
-		return parseInt( authorizationData.queryObject.client_id );
+		return parseInt( authorizationData.queryObject.client_id, 10 );
 	}
 	return null;
 };

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -112,9 +112,9 @@ const hasExpiredSecretError = function( state ) {
 };
 
 const getSiteIdFromQueryObject = function( state ) {
-	const authorizationData = getAuthorizationData( state );
-	if ( authorizationData.queryObject && authorizationData.queryObject.client_id ) {
-		return parseInt( authorizationData.queryObject.client_id, 10 );
+	const queryObject = getAuthorizationRemoteQueryData( state );
+	if ( queryObject && queryObject.client_id ) {
+		return parseInt( queryObject.client_id, 10 );
 	}
 	return null;
 };

--- a/client/state/selectors/get-jetpack-connect-from.js
+++ b/client/state/selectors/get-jetpack-connect-from.js
@@ -1,0 +1,20 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getAuthorizationRemoteQueryData } from 'state/jetpack-connect/selectors';
+
+/**
+ * Returns from information provided as part of Jetpack Connect authorization.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?String}       From string
+ */
+export default function getJetpackConnectFrom( state ) {
+	return get( getAuthorizationRemoteQueryData( state ), 'from', null );
+}

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -49,6 +49,7 @@ export getCurrentUserRegisterDate from './get-current-user-register-date';
 export getImageEditorIsGreaterThanMinimumDimensions from './get-image-editor-is-greater-than-minimum-dimensions';
 export getImageEditorOriginalAspectRatio from './get-image-editor-original-aspect-ratio';
 export getInitialQueryArguments from './get-initial-query-arguments';
+export getJetpackConnectFrom from './get-jetpack-connect-from';
 export getJetpackConnectionStatus from './get-jetpack-connection-status';
 export getJetpackConnectPartnerId from './get-jetpack-connect-partner-id';
 export getJetpackConnectRedirectAfterAuth from './get-jetpack-connect-redirect-after-auth';


### PR DESCRIPTION
This PR adds a selector to the `from` data included in Jetpack Connect authorization.

It also leverages `from` in the AuthLoggedIn component.

It moves `isWoo` and `isSSO` out of the parent and into local methods because they also depend on the data from this selector and are unused in the parent.

### Testing
1. No behavioral changes.
1. Ensure the Woo, SSO, and JPO flows all continue to work.
1. Normal flows should continue to work.