### PR TITLE
Comments: Comment Actions refactor

### DIFF
--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -25,6 +25,8 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 
 export class Comment extends Component {
 	static propTypes = {
+		siteId: PropTypes.number,
+		postId: PropTypes.number,
 		commentId: PropTypes.number,
 		isBulkMode: PropTypes.bool,
 		isPersistent: PropTypes.bool,
@@ -85,6 +87,8 @@ export class Comment extends Component {
 
 	render() {
 		const {
+			siteId,
+			postId,
 			commentId,
 			commentIsPending,
 			isBulkMode,
@@ -92,7 +96,6 @@ export class Comment extends Component {
 			isPostView,
 			isSelected,
 			refreshCommentData,
-			siteId,
 			updateLastUndo,
 		} = this.props;
 		const { isEditMode, isReplyVisible } = this.state;
@@ -125,7 +128,7 @@ export class Comment extends Component {
 
 						{ ! isBulkMode && (
 							<CommentActions
-								{ ...{ commentId, updateLastUndo } }
+								{ ...{ siteId, postId, commentId, updateLastUndo } }
 								toggleEditMode={ this.toggleEditMode }
 								toggleReply={ this.toggleReply }
 							/>
@@ -148,10 +151,11 @@ const mapStateToProps = ( state, { commentId } ) => {
 	const comment = getSiteComment( state, siteId, commentId );
 	const commentStatus = get( comment, 'status' );
 	return {
+		siteId,
+		postId: get( comment, 'post.ID' ),
 		commentIsPending: 'unapproved' === commentStatus,
 		isLoading: isUndefined( comment ),
 		minimumComment: getMinimumComment( comment ),
-		siteId,
 	};
 };
 


### PR DESCRIPTION
This PR makes some small changes on `CommentActions` and `Comment`:

- Removes some duplication by passing `siteId` and `postId` down from `Comment`
- Moves `siteId, `postId` and `commentId` to the top of lists.
- Action creators take parameters from `ownProps`, reducing the number of parameters on dispatchable functions.
- Removes unnecessary `delete` function.
- Thanks to the magic of Prettier, some lines of core are removed.

How to test:

Click like crazy on the actions on any comment. There should be no regressions.