### PR TITLE
PostTypeList: Fix content jumps in IE11

### DIFF
--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -1,21 +1,10 @@
 .posts.main {
 	display: block;
 	max-width: 720px;
-
-	@include breakpoint( ">1280px" ) {
-		display: flex;
-		max-width: 1440px;
-		justify-content: center;
-	}
 }
 
 .posts__primary {
-	flex-grow: 1;
 	max-width: 720px;
-
-	@include breakpoint( ">1280px" ) {
-		min-width: 520px;
-	}
 }
 
 .posts__list {


### PR DESCRIPTION
The loading state of the `PostTypeList` contains a placeholder item that somehow breaks IE11's layout engine at screen widths larger than 1280px:

### Before

> ![2017-11-17t21 13 28 0800](https://user-images.githubusercontent.com/227022/32949018-33a9cbc0-cbdc-11e7-8336-8e90a20548f5.png)

The related CSS switches the display of the posts section to `flex` at this wide breakpoint.  The specific rule that causes the error is `max-width: 1440px` but these CSS rules can simply be removed, avoiding the issue:  they are a holdover from the drafts list where the posts list would have a two-column layout on wide screens.  As of #19112 this functionality is no longer present.

### After

> ![2017-11-17t21 09 22 0800](https://user-images.githubusercontent.com/227022/32949032-43d91cda-cbdc-11e7-8363-806adfce48b1.png)

### To test

Verify that the `PostTypeList` and the `master` posts list display correctly during and after loading in IE11 and other browsers as well.

If you need to reproduce the loading state on the `PostTypeList`, you can use this patch:

```diff
diff --git a/client/my-sites/post-type-list/index.jsx b/client/my-sites/post-type-list/index.jsx
index 8f0cdf3..a590223 100644
--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -212,12 +212,7 @@ class PostTypeList extends Component {
 					range( 1, maxRequestedPage + 1 ).map( page => (
 						<QueryPosts key={ `query-${ page }` } siteId={ siteId } query={ { ...query, page } } />
 					) ) }
-				{ posts && posts.map( this.renderPost ) }
-				{ isLoadedAndEmpty && (
-					<PostTypeListEmptyContent type={ query.type } status={ query.status } />
-				) }
-				{ this.renderMaxPagesNotice() }
-				{ this.hasListFullyLoaded() ? this.renderListEnd() : this.renderPlaceholder() }
+				{ this.renderPlaceholder() }
 			</div>
 		);
 	}
```