### PR TITLE
Reader: fix display of subscriber count for feeds with an associated WordPress site

### DIFF
--- a/client/state/reader/sites/actions.js
+++ b/client/state/reader/sites/actions.js
@@ -14,6 +14,7 @@ import {
 	READER_SITE_REQUEST_FAILURE,
 	READER_SITE_UPDATE,
 } from 'state/action-types';
+import { fields } from './fields';
 
 export function requestSite( siteId ) {
 	return function( dispatch ) {
@@ -27,22 +28,7 @@ export function requestSite( siteId ) {
 			.undocumented()
 			.readSite( {
 				site: siteId,
-				fields: [
-					'ID',
-					'name',
-					'title',
-					'URL',
-					'icon',
-					'is_jetpack',
-					'description',
-					'is_private',
-					'feed_ID',
-					'feed_URL',
-					'capabilities',
-					'prefer_feed',
-					'subscribers_count',
-					'options', // have to include this to get options at all
-				].join( ',' ),
+				fields: fields.join( ',' ),
 				options: [ 'is_mapped_domain', 'unmapped_url', 'is_redirect' ].join( ',' ),
 			} )
 			.then(

--- a/client/state/reader/sites/actions.js
+++ b/client/state/reader/sites/actions.js
@@ -40,6 +40,7 @@ export function requestSite( siteId ) {
 					'feed_URL',
 					'capabilities',
 					'prefer_feed',
+					'subscribers_count',
 					'options', // have to include this to get options at all
 				].join( ',' ),
 				options: [ 'is_mapped_domain', 'unmapped_url', 'is_redirect' ].join( ',' ),

--- a/client/state/reader/sites/fields.js
+++ b/client/state/reader/sites/fields.js
@@ -1,0 +1,16 @@
+export const fields = [
+	'ID',
+	'name',
+	'title',
+	'URL',
+	'icon',
+	'is_jetpack',
+	'description',
+	'is_private',
+	'feed_ID',
+	'feed_URL',
+	'capabilities',
+	'prefer_feed',
+	'subscribers_count',
+	'options', // have to include this to get options at all
+];

--- a/client/state/reader/sites/test/actions.js
+++ b/client/state/reader/sites/test/actions.js
@@ -15,6 +15,7 @@ import {
 	READER_SITE_REQUEST_FAILURE,
 } from 'state/action-types';
 import useNock from 'test/helpers/use-nock';
+import { fields } from '../fields';
 
 describe( 'actions', () => {
 	describe( 'a valid fetch', () => {
@@ -25,21 +26,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.get( '/rest/v1.1/read/sites/1' )
 				.query( {
-					fields: [
-						'ID',
-						'name',
-						'title',
-						'URL',
-						'icon',
-						'is_jetpack',
-						'description',
-						'is_private',
-						'feed_ID',
-						'feed_URL',
-						'capabilities',
-						'prefer_feed',
-						'options', // have to include this to get options at all
-					].join( ',' ),
+					fields: fields.join( ',' ),
 					options: [ 'is_mapped_domain', 'unmapped_url', 'is_redirect' ].join( ',' ),
 				} )
 				.reply( 200, {


### PR DESCRIPTION
In the Reader feed header, we generally prefer the site's subscriber count over the feed's, because it's generally more accurate.

Unfortunately, at some point we stopped fetching the `subscriber_count` from the `/read/site/:site` endpoint so we've been displaying the feed count always.

<img width="241" alt="screen shot 2017-11-17 at 15 26 48" src="https://user-images.githubusercontent.com/17325/32954706-c3cbca9a-cbab-11e7-8680-0dc6fd72923e.png">

### To test

Visit this feed stream:

http://calypso.localhost:3000/read/feeds/75221723

....and ensure the follower count is around 1000. Compare with:

http://wpcalypso.wordpress.com/read/feeds/75221723

...where it's around 500.