### PR TITLE
Jetpack connect: Allow plans route without a site slug

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -204,7 +204,7 @@ export default {
 		const basePath = route.sectionify( context.path );
 		const analyticsBasePath = basePath + '/:site';
 
-		if ( ! isJetpack ) {
+		if ( siteId && ! isJetpack ) {
 			return;
 		}
 
@@ -223,6 +223,7 @@ export default {
 					destinationType={ context.params.destinationType }
 					basePlansPath={ '/jetpack/connect/plans' }
 					interval={ context.params.interval }
+					showFirst={ ! siteId }
 				/>
 			</CheckoutData>,
 			document.getElementById( 'primary' ),

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -55,14 +55,14 @@ export default function() {
 	page( '/jetpack/connect/akismet', '/jetpack/connect/store' );
 	page( '/jetpack/connect/akismet/:interval', redirectToStoreWithInterval );
 
+	page( '/jetpack/connect/plans/:site?', siteSelection, controller.plansSelection );
+	page( '/jetpack/connect/plans/:interval/:site', siteSelection, controller.plansSelection );
+
 	page(
 		'/jetpack/connect/:locale?',
 		controller.redirectWithoutLocaleifLoggedIn,
 		controller.connect
 	);
-
-	page( '/jetpack/connect/plans/:site', siteSelection, controller.plansSelection );
-	page( '/jetpack/connect/plans/:interval/:site', siteSelection, controller.plansSelection );
 
 	page( '/jetpack/sso/:siteId?/:ssoNonce?', controller.sso );
 	page( '/jetpack/sso/*', controller.sso );

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -249,6 +249,7 @@ class Plans extends Component {
 			cartItem ? cartItem.product_slug : 'free',
 			this.props.siteSlug
 		);
+		page.redirect( '/jetpack/connect' );
 	};
 
 	render() {
@@ -323,7 +324,7 @@ export default connect(
 			calypsoStartedConnection: isCalypsoStartedConnection( state, selectedSiteSlug ),
 			redirectingToWpAdmin: isRedirectingToWpAdmin( state ),
 			isRtlLayout: isRtl( state ),
-			hasPlan: isSiteOnPaidPlan( state, selectedSite.ID ),
+			hasPlan: selectedSite && isSiteOnPaidPlan( state, selectedSite.ID ),
 		};
 	},
 	{


### PR DESCRIPTION
Proof-of-concept, do not merge.

Allows `jetpack/connect/plans` at the start of the connection process. Stores selected plan and moves on to url entry. Makes use of an existing prop `showFirst` that looks like it was in place for the (unused?) `jetpack/connect/choose` route.

Logged-out suffers from existing bug where stored plan is not persisted across the login.

Probably never merge this PR, but use it to inform some refactoring where we simplify the redirection and plan storing logic so that the plans step can be used at any point in the connection process.

/cc @sirreal 