### PR TITLE
Add Incoming Transfers Privacy Section on the checkout page

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -530,6 +530,16 @@ export function domainTransfer( properties ) {
 }
 
 /**
+ * Creates a new shopping cart item for an incoming domain transfer privacy.
+ *
+ * @param {Object} properties - list of properties
+ * @returns {Object} the new item as `CartItemValue` object
+ */
+export function domainTransferPrivacy( properties ) {
+	return domainItem( domainProductSlugs.TRANSFER_IN_PRIVACY, properties.domain, properties.source );
+}
+
+/**
  * Retrieves all the G Suite items in the specified shopping cart.
  * Out-dated name Google Apps is still used here for consistency in naming.
  *
@@ -663,6 +673,16 @@ export function getDomainRegistrations( cart ) {
 }
 
 /**
+ * Retrieves all the domain registration items in the specified shopping cart.
+ *
+ * @param {Object} cart - cart as `CartValue` object
+ * @returns {Object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
+ */
+export function getDomainIncomingTransfers( cart ) {
+	return filter( getAll( cart ), { product_slug: 'domain_transfer' } );
+}
+
+/**
  * Retrieves all the domain mapping items in the specified shopping cart.
  *
  * @param {Object} cart - cart as `CartValue` object
@@ -780,6 +800,22 @@ export function getDomainRegistrationsWithoutPrivacy( cart ) {
 }
 
 /**
+ * Retrieves the domain incoming transfer items in the specified shopping cart that do not have corresponding
+ * private incoming transfer item.
+ *
+ * @param {Object} cart - cart as `CartValue` object
+ * @returns {Object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
+ */
+export function getDomainIncomingTransfersWithoutPrivacy( cart ) {
+	return getDomainRegistrations( cart ).filter( function( cartItem ) {
+		return ! some( cart.products, {
+			meta: cartItem.meta,
+			product_slug: 'domain_transfer_privacy',
+		} );
+	} );
+}
+
+/**
  * Changes presence of a privacy protection for the given domain cart items.
  *
  * @param {Object} cart - cart as `CartValue` object
@@ -792,6 +828,23 @@ export function changePrivacyForDomains( cart, domainItems, changeFunction ) {
 		null,
 		domainItems.map( function( item ) {
 			return changeFunction( domainPrivacyProtection( { domain: item.meta } ) );
+		} )
+	);
+}
+
+/**
+ * Changes presence of a privacy protection for the given domain transfer cart items.
+ *
+ * @param {Object} cart - cart as `CartValue` object
+ * @param {Object[]} domainItems - the list of `CartItemValue` objects for domain registrations
+ * @param {Function} changeFunction - the function that adds/removes the privacy protection to a shopping cart
+ * @returns {Function} the function that adds/removes privacy protections from the shopping cart
+ */
+export function changePrivacyForDomainTransfers( cart, domainItems, changeFunction ) {
+	return flow.apply(
+		null,
+		domainItems.map( function( item ) {
+			return changeFunction( domainTransferPrivacy( { domain: item.meta } ) );
 		} )
 	);
 }

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -673,16 +673,6 @@ export function getDomainRegistrations( cart ) {
 }
 
 /**
- * Retrieves all the domain registration items in the specified shopping cart.
- *
- * @param {Object} cart - cart as `CartValue` object
- * @returns {Object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
- */
-export function getDomainIncomingTransfers( cart ) {
-	return filter( getAll( cart ), { product_slug: 'domain_transfer' } );
-}
-
-/**
  * Retrieves all the domain mapping items in the specified shopping cart.
  *
  * @param {Object} cart - cart as `CartValue` object
@@ -810,7 +800,7 @@ export function getDomainTransfersWithoutPrivacy( cart ) {
 	return getDomainTransfers( cart ).filter( function( cartItem ) {
 		return ! some( cart.products, {
 			meta: cartItem.meta,
-			product_slug: 'domain_transfer_privacy',
+			product_slug: domainProductSlugs.TRANSFER_IN_PRIVACY,
 		} );
 	} );
 }

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -806,8 +806,8 @@ export function getDomainRegistrationsWithoutPrivacy( cart ) {
  * @param {Object} cart - cart as `CartValue` object
  * @returns {Object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
-export function getDomainIncomingTransfersWithoutPrivacy( cart ) {
-	return getDomainRegistrations( cart ).filter( function( cartItem ) {
+export function getDomainTransfersWithoutPrivacy( cart ) {
+	return getDomainTransfers( cart ).filter( function( cartItem ) {
 		return ! some( cart.products, {
 			meta: cartItem.meta,
 			product_slug: 'domain_transfer_privacy',
@@ -827,34 +827,31 @@ export function changePrivacyForDomains( cart, domainItems, changeFunction ) {
 	return flow.apply(
 		null,
 		domainItems.map( function( item ) {
+			if ( isTransfer( item ) ) {
+				return changeFunction( domainTransferPrivacy( { domain: item.meta } ) );
+			}
 			return changeFunction( domainPrivacyProtection( { domain: item.meta } ) );
 		} )
 	);
 }
 
-/**
- * Changes presence of a privacy protection for the given domain transfer cart items.
- *
- * @param {Object} cart - cart as `CartValue` object
- * @param {Object[]} domainItems - the list of `CartItemValue` objects for domain registrations
- * @param {Function} changeFunction - the function that adds/removes the privacy protection to a shopping cart
- * @returns {Function} the function that adds/removes privacy protections from the shopping cart
- */
-export function changePrivacyForDomainTransfers( cart, domainItems, changeFunction ) {
-	return flow.apply(
-		null,
-		domainItems.map( function( item ) {
-			return changeFunction( domainTransferPrivacy( { domain: item.meta } ) );
-		} )
+export function addPrivacyToAllDomains( cart ) {
+	return changePrivacyForDomains(
+		cart,
+		[
+			...getDomainRegistrationsWithoutPrivacy( cart ),
+			...getDomainTransfersWithoutPrivacy( cart ),
+		],
+		add
 	);
 }
 
-export function addPrivacyToAllDomains( cart ) {
-	return changePrivacyForDomains( cart, getDomainRegistrationsWithoutPrivacy( cart ), add );
-}
-
 export function removePrivacyFromAllDomains( cart ) {
-	return changePrivacyForDomains( cart, getDomainRegistrations( cart ), remove );
+	return changePrivacyForDomains(
+		cart,
+		[ ...getDomainRegistrations( cart ), ...getDomainTransfers( cart ) ],
+		remove
+	);
 }
 
 /**
@@ -987,6 +984,7 @@ export default {
 	getDomainRegistrationsWithoutPrivacy,
 	getDomainRegistrationTld,
 	getDomainTransfers,
+	getDomainTransfersWithoutPrivacy,
 	getGoogleApps,
 	getIncludedDomain,
 	getItemForPlan,

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -964,6 +964,7 @@ export default {
 	domainRedemption,
 	domainRegistration,
 	domainTransfer,
+	domainTransferPrivacy,
 	fillGoogleAppsRegistrationData,
 	findFreeTrial,
 	getAll,

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -64,6 +64,7 @@ const dnsTemplates = {
 
 const domainProductSlugs = {
 	TRANSFER_IN: 'domain_transfer',
+	TRANSFER_IN_PRIVACY: 'domain_transfer_privacy',
 };
 
 export default {

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -318,8 +318,11 @@ export class DomainDetailsForm extends PureComponent {
 		return cartItems.hasOnlyDomainRegistrationsWithPrivacySupport( this.props.cart );
 	}
 
-	allDomainRegistrationsHavePrivacy() {
-		return cartItems.getDomainRegistrationsWithoutPrivacy( this.props.cart ).length === 0;
+	allProductsHavePrivacy() {
+		return (
+			cartItems.getDomainRegistrationsWithoutPrivacy( this.props.cart ).length === 0 &&
+			cartItems.getDomainTransfersWithoutPrivacy( this.props.cart ).length === 0
+		);
 	}
 
 	renderSubmitButton() {
@@ -341,7 +344,7 @@ export class DomainDetailsForm extends PureComponent {
 	renderPrivacySection() {
 		return (
 			<PrivacyProtection
-				allDomainsHavePrivacy={ this.allDomainRegistrationsHavePrivacy() }
+				checkPrivacyRadio={ this.allProductsHavePrivacy() }
 				cart={ this.props.cart }
 				countriesList={ countriesList }
 				disabled={ formState.isSubmitButtonDisabled( this.state.form ) }

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -588,11 +588,14 @@ export class DomainDetailsForm extends PureComponent {
 			title = this.props.translate( 'Domain Contact Information' );
 		}
 
+		const renderPrivacy =
+			( cartItems.hasDomainRegistration( this.props.cart ) &&
+				this.allDomainRegistrationsSupportPrivacy() ) ||
+			cartItems.hasTransferProduct( this.props.cart );
+
 		return (
 			<div>
-				{ cartItems.hasDomainRegistration( this.props.cart ) &&
-					this.allDomainRegistrationsSupportPrivacy() &&
-					this.renderPrivacySection() }
+				{ renderPrivacy && this.renderPrivacySection() }
 				<PaymentBox currentPage={ this.state.currentStep } classSet={ classSet } title={ title }>
 					{ this.renderCurrentForm() }
 				</PaymentBox>

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -318,7 +318,7 @@ export class DomainDetailsForm extends PureComponent {
 		return cartItems.hasOnlyDomainRegistrationsWithPrivacySupport( this.props.cart );
 	}
 
-	allProductsHavePrivacy() {
+	allDomainItemsHavePrivacy() {
 		return (
 			cartItems.getDomainRegistrationsWithoutPrivacy( this.props.cart ).length === 0 &&
 			cartItems.getDomainTransfersWithoutPrivacy( this.props.cart ).length === 0
@@ -344,7 +344,7 @@ export class DomainDetailsForm extends PureComponent {
 	renderPrivacySection() {
 		return (
 			<PrivacyProtection
-				checkPrivacyRadio={ this.allProductsHavePrivacy() }
+				checkPrivacyRadio={ this.allDomainItemsHavePrivacy() }
 				cart={ this.props.cart }
 				countriesList={ countriesList }
 				disabled={ formState.isSubmitButtonDisabled( this.state.form ) }

--- a/client/my-sites/checkout/checkout/privacy-protection.jsx
+++ b/client/my-sites/checkout/checkout/privacy-protection.jsx
@@ -67,7 +67,7 @@ class PrivacyProtection extends Component {
 								<FormRadio
 									value="private"
 									id="registrantType"
-									checked={ this.props.allDomainsHavePrivacy }
+									checked={ this.props.checkPrivacyRadio }
 									onChange={ this.enablePrivacy }
 								/>
 								<p className="checkout__privacy-protection-radio-text">
@@ -111,7 +111,7 @@ class PrivacyProtection extends Component {
 								<FormRadio
 									value="public"
 									id="registrantType"
-									checked={ ! this.props.allDomainsHavePrivacy }
+									checked={ ! this.props.checkPrivacyRadio }
 									onChange={ this.disablePrivacy }
 								/>
 								<p className="checkout__privacy-protection-radio-text">

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -77,6 +77,12 @@ export class TransferDomain extends Component {
 			} )
 		);
 
+		upgradesActions.addItem(
+			cartItems.domainTransferPrivacy( {
+				domain,
+			} )
+		);
+
 		page( '/checkout/' + selectedSiteSlug );
 	};
 

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -71,17 +71,21 @@ export class TransferDomain extends Component {
 
 		this.setState( { errorMessage: null } );
 
-		upgradesActions.addItem(
+		const transferItems = [];
+
+		transferItems.push(
 			cartItems.domainTransfer( {
 				domain,
 			} )
 		);
 
-		upgradesActions.addItem(
+		transferItems.push(
 			cartItems.domainTransferPrivacy( {
 				domain,
 			} )
 		);
+
+		upgradesActions.addItems( transferItems );
 
 		page( '/checkout/' + selectedSiteSlug );
 	};


### PR DESCRIPTION
Introducint a new Incoming Transfer Privacy product, which will allow us to track the privacy for incoming transfers and will greatly simplify how we handle incoming transfers.

We have to handle 2 things:

[x] show the Privacy Section in the checkout page
[x] add/remove the new Transfer Privacy product on radio button click

In order to test apply D8350-code, sandbox your API and try adding an incoming transfer and see how it looks when you add or remove the privacy