### PR TITLE
Jetpack Connect: Add tracks call to prove route not in use

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -236,6 +236,7 @@ export default {
 		const analyticsBasePath = basePath + '/:site';
 
 		analytics.tracks.recordEvent( 'calypso_plans_view' );
+		analytics.tracks.recordEvent( 'calypso_plans_pre_selection' );
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
 		renderWithReduxStore(


### PR DESCRIPTION
No functional or visual differences.

Checking whether anyone is hitting a route before removing it.
