### PR TITLE
Domains: Call the correct version of the domains endpoint

### DIFF
--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -148,21 +148,23 @@ function fetchDomains( siteId ) {
 		siteId,
 	} );
 
-	wpcom.site( siteId ).domains( function( error, data ) {
-		if ( error ) {
-			Dispatcher.handleServerAction( {
-				type: ActionTypes.DOMAINS_FETCH_FAILED,
-				siteId,
-				error,
-			} );
-		} else {
+	wpcom
+		.site( siteId )
+		.domains()
+		.then( data => {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.DOMAINS_FETCH_COMPLETED,
 				siteId,
 				domains: domainsAssembler.createDomainObjects( data.domains ),
 			} );
-		}
-	} );
+		} )
+		.catch( error => {
+			Dispatcher.handleServerAction( {
+				type: ActionTypes.DOMAINS_FETCH_FAILED,
+				siteId,
+				error,
+			} );
+		} );
 }
 
 function fetchWhois( domainName ) {

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -86,18 +86,8 @@ function UndocumentedSite( id, wpcom ) {
 	this._id = id;
 }
 
-UndocumentedSite.prototype.domains = function( callback ) {
-	return this.wpcom.req.get( `/sites/${ this._id }/domains`, { apiVersion: '1.2' }, function(
-		error,
-		response
-	) {
-		if ( error ) {
-			callback( error );
-			return;
-		}
-
-		callback( null, response );
-	} );
+UndocumentedSite.prototype.domains = function() {
+	return this.wpcom.req.get( `/sites/${ this._id }/domains`, { apiVersion: '1.2' } );
 };
 
 UndocumentedSite.prototype.postFormatsList = function( callback ) {

--- a/client/state/sites/domains/actions.js
+++ b/client/state/sites/domains/actions.js
@@ -6,12 +6,13 @@
 
 import debugFactory from 'debug';
 import { map } from 'lodash';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { createSiteDomainObject } from './assembler';
-import wpcom from 'lib/wp';
+import wp from 'lib/wp';
 import {
 	SITE_DOMAINS_RECEIVE,
 	SITE_DOMAINS_REQUEST,
@@ -23,8 +24,7 @@ import {
  * Module vars
  */
 const debug = debugFactory( 'calypso:state:sites:domains:actions' );
-const errorMessage =
-	'There was a problem fetching site domains. Please try again later or contact support.';
+const wpcom = wp.undocumented();
 
 /**
  * Action creator function
@@ -116,14 +116,19 @@ export function fetchSiteDomains( siteId ) {
 
 		return wpcom
 			.site( siteId )
-			.domainsList()
+			.domains()
 			.then( data => {
 				const { domains = [] } = data;
 				dispatch( domainsRequestSuccessAction( siteId ) );
 				dispatch( domainsReceiveAction( siteId, domains ) );
 			} )
-			.catch( ( error = errorMessage ) => {
-				const message = error instanceof Error ? error.message : error;
+			.catch( error => {
+				const message =
+					error instanceof Error
+						? error.message
+						: translate(
+								'There was a problem fetching site domains. Please try again later or contact support.'
+							);
 
 				dispatch( domainsRequestFailureAction( siteId, message ) );
 			} );

--- a/client/state/sites/domains/test/actions.js
+++ b/client/state/sites/domains/test/actions.js
@@ -63,7 +63,7 @@ describe( 'actions', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.get( `/rest/v1.1/sites/${ siteId }/domains` )
+				.get( `/rest/v1.2/sites/${ siteId }/domains` )
 				.reply( 200, wpcomResponse );
 		} );
 
@@ -87,7 +87,7 @@ describe( 'actions', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.get( `/rest/v1.1/sites/${ siteId }/domains` )
+				.get( `/rest/v1.2/sites/${ siteId }/domains` )
 				.reply( 403, wpcomErrorResponse );
 		} );
 


### PR DESCRIPTION
We fire two requests to `/sites/:siteId/domains` (because some stuff has not been moved to Redux yet), and one request goes to v1.1, while the other to v1.2. Both should go to the newer endpoint - which returns a non-localized dates (which caused https://github.com/Automattic/wp-calypso/issues/13301 and were fixed in https://github.com/Automattic/wp-calypso/pull/13365).

This causes us to pass date in a custom format (`June 12, 2016`) to moment.js and subsequently this warning:
```
Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged and will be removed in an upcoming major release. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.
Arguments: 
[0] _isAMomentObject: true, _isUTC: false, _useUTC: false, _l: undefined, _i: April 18, 2018, _f: undefined, _strict: undefined, _locale: [object Object]
Error
```

### Testing
Switch to domain management where you have any custom domains. Notice that there's no warnings in the console and that all requests to `/sites/:siteId/domains` go to the `v1.2` endpoint.