### PR TITLE
Updated propType of revisionChanges prop

### DIFF
--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -88,7 +88,7 @@ EditorRevisionsListItem.propTypes = {
 
 	// connected to state
 	isMultiUserSite: PropTypes.bool.isRequired,
-	revisionChanges: PropTypes.array.isRequired,
+	revisionChanges: PropTypes.object.isRequired,
 
 	// connected to dispatcher
 	selectPostRevision: PropTypes.func.isRequired,


### PR DESCRIPTION
The selector `getPostRevisionChanges` returns an object now and we need to update the `revisionChanges` propType for the EditorRevisionsListItem accordingly.

## How to test

Run the branch locally, open the revisions modal and check that there is no propType warning for revisionChanges present in the console anymore.