### PR TITLE
Domains: make “Contacts and Privacy” UI header/button dynamic

### DIFF
--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -45,7 +45,7 @@ class ContactsPrivacy extends React.PureComponent {
 		return (
 			<Main className="domain-management-contacts-privacy">
 				<Header onClick={ this.goToEdit } selectedDomainName={ this.props.selectedDomainName }>
-					{ translate( 'Contacts and Privacy' ) }
+					{ privacyAvailable ? translate( 'Contacts and Privacy' ) : translate( 'Contacts' ) }
 				</Header>
 
 				<VerticalNav>

--- a/client/my-sites/domains/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/registered-domain.jsx
@@ -189,6 +189,8 @@ const RegisteredDomain = createReactClass( {
 	},
 
 	contactsPrivacyNavItem() {
+		const { privacyAvailable } = this.props.domain;
+		const { translate } = this.props;
 		const path = paths.domainManagementContactsPrivacy(
 			this.props.selectedSite.slug,
 			this.props.domain.name
@@ -196,7 +198,7 @@ const RegisteredDomain = createReactClass( {
 
 		return (
 			<VerticalNavItem path={ path }>
-				{ this.props.translate( 'Contacts and Privacy' ) }
+				{ privacyAvailable ? translate( 'Contacts and Privacy' ) : translate( 'Contacts' ) }
 			</VerticalNavItem>
 		);
 	},


### PR DESCRIPTION
Improves #19916 -- more needs to be done to that issue in regard to "always private" (eg, .ca) and "always public" (eg .in) UX.

But, this is a step forward.