### PR TITLE
Store Orders: Initialize state when the dialog is opened

### DIFF
--- a/client/extensions/woocommerce/app/order/order-customer/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-customer/dialog.js
@@ -66,14 +66,27 @@ class CustomerAddressDialog extends Component {
 		updateAddress: noop,
 	};
 
-	constructor( props ) {
-		super( props );
-		this.state = {
-			address: props.address,
-			phoneCountry: 'US',
-			emailValidMessage: false,
-		};
+	state = {};
+
+	componentDidMount() {
+		this.initializeState();
 	}
+
+	componentDidUpdate( prevProps ) {
+		// Modal was just opened
+		if ( this.props.isVisible && ! prevProps.isVisible ) {
+			this.initializeState();
+		}
+	}
+
+	initializeState = () => {
+		const { address = {} } = this.props;
+		this.setState( {
+			address,
+			phoneCountry: address.country || 'US',
+			emailValidMessage: false,
+		} );
+	};
 
 	updateAddress = () => {
 		this.props.updateAddress( this.state.address );
@@ -176,6 +189,10 @@ class CustomerAddressDialog extends Component {
 	render() {
 		const { isBilling, isVisible, translate } = this.props;
 		const { address, emailValidMessage } = this.state;
+		if ( ! address ) {
+			return null;
+		}
+
 		const dialogButtons = [
 			<Button onClick={ this.closeDialog }>{ translate( 'Close' ) }</Button>,
 			<Button primary onClick={ this.updateAddress } disabled={ !! emailValidMessage }>


### PR DESCRIPTION
Fixes #19902 – This PR updates the dialog component to re-initialize state from the props when the modal is opened, not just once it's mounted. The issue mentioned was because the current shipping address is set once when mounted, and even though the props sent to the dialog have updated, the component doesn't re-set the address in state. This new update changes the way the state is initialized, so that it's reset whenever the dialog opens.

**To test**

- View an order: `/store/order/:yoursite/:orderid`
- Click on "Edit order"
- Edit billing details, make some changes and make sure that Copy changes to shipping is checked
- Edit shipping details, make sure the dialog has the new changes copied from the billing step