### PR TITLE
Activity Log - Updated formatting and styles of the server credentials form

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -96,7 +96,7 @@ export class CredentialsForm extends Component {
 
 				<div className="credentials-form__row">
 					<FormFieldset className="credentials-form__server-address">
-						<FormLabel hrmlFor="host-address">{ translate( 'Server Address' ) }</FormLabel>
+						<FormLabel htmlFor="host-address">{ translate( 'Server Address' ) }</FormLabel>
 						<FormTextInput
 							name="host"
 							id="host-address"
@@ -187,7 +187,9 @@ export class CredentialsForm extends Component {
 								className="credentials-form__private-key"
 							/>
 							<p className="form-setting-explanation">
-								This field is only required if your host uses key based authentication.
+								{ translate(
+									'This field is only required if your host uses key based authentication.'
+								) }
 							</p>
 						</div>
 					) }

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -78,158 +78,136 @@ export class CredentialsForm extends Component {
 		const { showPrivateKeyField, formErrors } = this.state;
 
 		return (
-			<FormFieldset className="credentials-form">
-				<table>
-					<tbody>
-						<tr>
-							<td colSpan="2" className="credentials-form__protocol-field">
-								<FormLabel>
-									<div>{ translate( 'Credential Type' ) }</div>
-									<FormSelect
-										name="protocol"
-										value={ get( this.state.form, 'protocol', 'ssh' ) }
-										onChange={ this.handleFieldChange }
-										disabled={ formIsSubmitting }
-									>
-										<option value="ssh">{ translate( 'SSH' ) }</option>
-										<option value="sftp">{ translate( 'SFTP' ) }</option>
-										<option value="ftp">{ translate( 'FTP' ) }</option>
-									</FormSelect>
-								</FormLabel>
-							</td>
-						</tr>
-						<tr>
-							<td className="credentials-form__host-field">
-								<FormLabel>
-									<div>{ translate( 'Server Address' ) }</div>
-									<FormTextInput
-										name="host"
-										placeholder={ translate( 'yoursite.com' ) }
-										value={ get( this.state.form, 'host', '' ) }
-										onChange={ this.handleFieldChange }
-										disabled={ formIsSubmitting }
-										isError={ !! formErrors.host }
-									/>
-									{ formErrors.host && (
-										<FormInputValidation isError={ true } text={ formErrors.host } />
-									) }
-								</FormLabel>
-							</td>
-							<td className="credentials-form__port-field">
-								<FormLabel>
-									<div>{ translate( 'Port Number' ) }</div>
-									<FormTextInput
-										name="port"
-										placeholder={ translate( '22' ) }
-										value={ get( this.state.form, 'port', '' ) }
-										onChange={ this.handleFieldChange }
-										disabled={ formIsSubmitting }
-										isError={ !! formErrors.port }
-									/>
-									{ formErrors.port && (
-										<FormInputValidation isError={ true } text={ formErrors.port } />
-									) }
-								</FormLabel>
-							</td>
-						</tr>
-						<tr>
-							<td colSpan="2" className="credentials-form__user-field">
-								<FormLabel>
-									<div>{ translate( 'Username' ) }</div>
-									<FormTextInput
-										name="user"
-										placeholder={ translate( 'username' ) }
-										value={ get( this.state.form, 'user', '' ) }
-										onChange={ this.handleFieldChange }
-										disabled={ formIsSubmitting }
-										isError={ !! formErrors.user }
-									/>
-									{ formErrors.user && (
-										<FormInputValidation isError={ true } text={ formErrors.user } />
-									) }
-								</FormLabel>
-							</td>
-						</tr>
-						<tr>
-							<td colSpan="2" className="credentials-form__pass-field">
-								<FormLabel>
-									<div>{ translate( 'Password' ) }</div>
-									<FormPasswordInput
-										name="pass"
-										placeholder={ translate( 'password' ) }
-										value={ get( this.state.form, 'pass', '' ) }
-										onChange={ this.handleFieldChange }
-										disabled={ formIsSubmitting }
-										isError={ !! formErrors.pass }
-									/>
-									{ formErrors.pass && (
-										<FormInputValidation isError={ true } text={ formErrors.pass } />
-									) }
-								</FormLabel>
-							</td>
-						</tr>
-						<tr>
-							<td colSpan="2" className="credentials-form__abspath-field">
-								<FormLabel>
-									<div>{ translate( 'Upload Path' ) }</div>
-									<FormTextInput
-										name="abspath"
-										placeholder={ translate( '/public_html' ) }
-										value={ get( this.state.form, 'abspath', '' ) }
-										onChange={ this.handleFieldChange }
-										disabled={ formIsSubmitting }
-										isError={ !! formErrors.abspath }
-									/>
-									{ formErrors.abspath && (
-										<FormInputValidation isError={ true } text={ formErrors.abspath } />
-									) }
-								</FormLabel>
-							</td>
-						</tr>
-						<tr>
-							<td colSpan="2" className="credentials-form__kpri-field">
-								<FormLabel>
-									<div>{ translate( 'Private Key' ) }</div>
-									<Button disabled={ formIsSubmitting } onClick={ this.togglePrivateKeyField }>
-										{ showPrivateKeyField
-											? translate( 'Hide Private Key' )
-											: translate( 'Show Private Key' ) }
-									</Button>
-									{ showPrivateKeyField && (
-										<div>
-											<FormTextArea
-												name="kpri"
-												value={ get( this.state.form, 'kpri', '' ) }
-												onChange={ this.handleFieldChange }
-												disabled={ formIsSubmitting }
-											/>
-											<p className="credentials-form__private-key-description">
-												This field is only required if your host uses key based authentication.
-											</p>
-										</div>
-									) }
-								</FormLabel>
-							</td>
-						</tr>
-						<tr>
-							<td colSpan="2">
-								<Button primary disabled={ formIsSubmitting } onClick={ this.handleSubmit }>
-									{ translate( 'Save' ) }
-								</Button>
-								{ this.props.showCancelButton && (
-									<Button
-										disabled={ formIsSubmitting }
-										onClick={ onCancel }
-										className="credentials-form__cancel-button"
-									>
-										{ translate( 'Cancel' ) }
-									</Button>
-								) }
-							</td>
-						</tr>
-					</tbody>
-				</table>
-			</FormFieldset>
+			<div>
+				<FormFieldset>
+					<FormLabel htmlFor="protocol-type">{ translate( 'Credential Type' ) }</FormLabel>
+					<FormSelect
+						name="protocol"
+						id="protocol-type"
+						value={ get( this.state.form, 'protocol', 'ssh' ) }
+						onChange={ this.handleFieldChange }
+						disabled={ formIsSubmitting }
+					>
+						<option value="ssh">{ translate( 'SSH' ) }</option>
+						<option value="sftp">{ translate( 'SFTP' ) }</option>
+						<option value="ftp">{ translate( 'FTP' ) }</option>
+					</FormSelect>
+				</FormFieldset>
+
+				<div className="credentials-form__row">
+					<FormFieldset className="credentials-form__server-address">
+						<FormLabel hrmlFor="host-address">{ translate( 'Server Address' ) }</FormLabel>
+						<FormTextInput
+							name="host"
+							id="host-address"
+							placeholder={ translate( 'yoursite.com' ) }
+							value={ get( this.state.form, 'host', '' ) }
+							onChange={ this.handleFieldChange }
+							disabled={ formIsSubmitting }
+							isError={ !! formErrors.host }
+						/>
+						{ formErrors.host && <FormInputValidation isError={ true } text={ formErrors.host } /> }
+					</FormFieldset>
+
+					<FormFieldset className="credentials-form__port-number">
+						<FormLabel htmlFor="server-port">{ translate( 'Port Number' ) }</FormLabel>
+						<FormTextInput
+							name="port"
+							id="server-port"
+							placeholder={ translate( '22' ) }
+							value={ get( this.state.form, 'port', '' ) }
+							onChange={ this.handleFieldChange }
+							disabled={ formIsSubmitting }
+							isError={ !! formErrors.port }
+						/>
+						{ formErrors.port && <FormInputValidation isError={ true } text={ formErrors.port } /> }
+					</FormFieldset>
+				</div>
+
+				<div className="credentials-form__row">
+					<FormFieldset className="credentials-form__username">
+						<FormLabel htmlFor="server-username">{ translate( 'Username' ) }</FormLabel>
+						<FormTextInput
+							name="user"
+							id="server-username"
+							placeholder={ translate( 'username' ) }
+							value={ get( this.state.form, 'user', '' ) }
+							onChange={ this.handleFieldChange }
+							disabled={ formIsSubmitting }
+							isError={ !! formErrors.user }
+						/>
+						{ formErrors.user && <FormInputValidation isError={ true } text={ formErrors.user } /> }
+					</FormFieldset>
+
+					<FormFieldset className="credentials-form__password">
+						<FormLabel htmlFor="server-password">{ translate( 'Password' ) }</FormLabel>
+						<FormPasswordInput
+							name="pass"
+							id="server-password"
+							placeholder={ translate( 'password' ) }
+							value={ get( this.state.form, 'pass', '' ) }
+							onChange={ this.handleFieldChange }
+							disabled={ formIsSubmitting }
+							isError={ !! formErrors.pass }
+						/>
+						{ formErrors.pass && <FormInputValidation isError={ true } text={ formErrors.pass } /> }
+					</FormFieldset>
+				</div>
+
+				<FormFieldset>
+					<FormLabel htmlFor="wordpress-path">{ translate( 'Upload Path' ) }</FormLabel>
+					<FormTextInput
+						name="abspath"
+						id="wordpress-path"
+						placeholder={ translate( '/public_html/wordpress-site/' ) }
+						value={ get( this.state.form, 'abspath', '' ) }
+						onChange={ this.handleFieldChange }
+						disabled={ formIsSubmitting }
+						isError={ !! formErrors.abspath }
+					/>
+					{ formErrors.abspath && (
+						<FormInputValidation isError={ true } text={ formErrors.abspath } />
+					) }
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLabel>{ translate( 'Private Key' ) }</FormLabel>
+					<Button disabled={ formIsSubmitting } onClick={ this.togglePrivateKeyField }>
+						{ showPrivateKeyField
+							? translate( 'Hide Private Key' )
+							: translate( 'Show Private Key' ) }
+					</Button>
+					{ showPrivateKeyField && (
+						<div>
+							<FormTextArea
+								name="kpri"
+								value={ get( this.state.form, 'kpri', '' ) }
+								onChange={ this.handleFieldChange }
+								disabled={ formIsSubmitting }
+								className="credentials-form__private-key"
+							/>
+							<p className="form-setting-explanation">
+								This field is only required if your host uses key based authentication.
+							</p>
+						</div>
+					) }
+				</FormFieldset>
+
+				<FormFieldset>
+					<Button primary disabled={ formIsSubmitting } onClick={ this.handleSubmit }>
+						{ translate( 'Save' ) }
+					</Button>
+					{ this.props.showCancelButton && (
+						<Button
+							disabled={ formIsSubmitting }
+							onClick={ onCancel }
+							className="credentials-form__cancel-button"
+						>
+							{ translate( 'Cancel' ) }
+						</Button>
+					) }
+				</FormFieldset>
+			</div>
 		);
 	}
 }

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/style.scss
@@ -1,6 +1,10 @@
 .credentials-form__row {
 	display: flex;
 	flex-wrap: wrap;
+
+	.form-fieldset:last-child {
+		margin-bottom: 24px;
+	}
 }
 
 .credentials-form__server-address,

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/style.scss
@@ -1,32 +1,28 @@
-.credentials-form .form-label {
-	margin-bottom: 15px;
+.credentials-form__row {
+	display: flex;
+	flex-wrap: wrap;
 }
 
-.credentials-form__host-field {
-	width: 70%;
+.credentials-form__server-address,
+.credentials-form__username,
+.credentials-form__password {
+	flex: 1 0 240px;
 }
 
-.credentials-form__port-field {
-	width: 25%;
-	padding-left: 5%;
+.credentials-form__server-address,
+.credentials-form__username {
+	margin-right: 16px;
 }
 
-.credentials-form__port-field .form-input-validation {
-	padding: 0;
-	margin-top: 5px;
+.credentials-form__port-number {
+	flex: 0 0 160px;
 }
 
-.credentials-form__port-field .form-input-validation .gridicon {
-	display: none;
+.credentials-form__private-key {
+	margin-top: 16px;
 }
 
 .credentials-form__cancel-button {
 	float: right;
 	margin-right: 15px;
-}
-
-.credentials-form__private-key-description {
-	font-weight: normal;
-	font-style: italic;
-	color: $gray;
 }

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/style.scss
@@ -1,3 +1,9 @@
+.jetpack-credentials {
+	.form-fieldset {
+		width: 100%;
+	}
+}
+
 .credentials-form__row {
 	display: flex;
 	flex-wrap: wrap;
@@ -7,19 +13,21 @@
 	}
 }
 
-.credentials-form__server-address,
-.credentials-form__username,
-.credentials-form__password {
-	flex: 1 0 240px;
-}
+@include breakpoint( ">960px" ) {
+	.credentials-form__server-address,
+	.credentials-form__username,
+	.credentials-form__password {
+		flex: 1 0 240px;
+	}
 
-.credentials-form__server-address,
-.credentials-form__username {
-	margin-right: 16px;
-}
+	.credentials-form__server-address,
+	.credentials-form__username {
+		margin-right: 16px;
+	}
 
-.credentials-form__port-number {
-	flex: 0 0 160px;
+	.credentials-form__port-number {
+		flex: 0 0 160px;
+	}
 }
 
 .credentials-form__private-key {


### PR DESCRIPTION
#### Changes
* Rearranged the way the FormLabel was wrapping the components to match how it was used elsewhere in settings.
* Removed the table layout
* Added `div`s for the two rows of fields and styles to give them appropriate widths at appropriate sizes
* Adjusted spacing of buttons
* Added spacing to private key textarea

#### To test
1. Go to calypso Security settings for a Jetpack site
2. In the top `Backups and restores` group, Click the big plus
3. Fill out the form
4. Try to break the form
5. Resize the window a bit

#### Before
![image](https://user-images.githubusercontent.com/1123119/32971830-5d1e7a30-cbac-11e7-9a4b-ade1e4caa90c.png)
![image](https://user-images.githubusercontent.com/1123119/32971818-4bbf1e3e-cbac-11e7-9743-65238a91c9d3.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/32971733-e5aaed76-cbab-11e7-86bf-dad3da1b55bf.png)
![image](https://user-images.githubusercontent.com/1123119/32971739-eb439f44-cbab-11e7-858e-ee6d715f5fa0.png)
