### PR TITLE
Popover Component: correct changing positions 

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -133,8 +133,9 @@ class Popover extends Component {
 			return null;
 		}
 
-		this.debug( 'Update position after inject DOM' );
-		this.setPosition();
+		this.debug( 'Update position after render completes' );
+
+		setTimeout( () => this.setPosition(), 0 );
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/19666

This patch wraps a function which updates Popover DOM container in `componentDidUpdate` lifecycle method in a `setTimeout` callback, so that we read off positioning after it finished rendering.

**To test:**
 I believe the issue persists across different sections and setting, mobile or not, so please test on any popover occurrence in Calypso. In particular, we should not see https://github.com/Automattic/wp-calypso/issues/19666 on the Plans page `https://wordpress.com/plans/:site`.
- opening, closing and re-opening should not move the component outside of the page view ( or anywhere else :) )
- it should work when changing screen size

**Note**: 
it seems to work for other issues where popovers were wrongly positioned 
https://github.com/Automattic/wp-calypso/issues/9007
https://github.com/Automattic/wp-calypso/issues/13602
https://github.com/Automattic/wp-calypso/issues/14580

This does not fix the vertical scroll problem, where popovers move into top/bottom margins following their context ( IMO it is CSS fix and is a separate issue ) :
step 1:
![screen shot 2017-11-19 at 23 13 50](https://user-images.githubusercontent.com/13561163/32997114-df34447e-cd8b-11e7-8273-b964c93dd33e.png)
step2:
![screen shot 2017-11-19 at 23 14 01](https://user-images.githubusercontent.com/13561163/32997120-e59a5c36-cd8b-11e7-9d51-1b18853094b1.png)
