### PR TITLE
Make sure `resizeImageUrl` uses photon when object `resize` param is passed in

### DIFF
--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -79,22 +79,23 @@ export default function resizeImageUrl( imageUrl, resize, height ) {
 
 	parsedUrl.query = omit( parsedUrl.query, SIZE_PARAMS );
 
+	const service = findKey(
+		SERVICE_HOSTNAME_PATTERNS,
+		String.prototype.match.bind( parsedUrl.hostname )
+	);
+
 	if ( 'number' === typeof resize ) {
-		const service = findKey(
-			SERVICE_HOSTNAME_PATTERNS,
-			String.prototype.match.bind( parsedUrl.hostname )
-		);
 		if ( 'gravatar' === service ) {
 			resize = { s: resize };
 		} else {
 			resize = height > 0 ? { fit: [ resize, height ].join() } : { w: resize };
-
-			// External URLs are made "safe" (i.e. passed through Photon), so
-			// recurse with an assumed set of query arguments for Photon
-			if ( ! service ) {
-				return resizeImageUrl( safeImageUrl( imageUrl ), resize );
-			}
 		}
+	}
+
+	// External URLs are made "safe" (i.e. passed through Photon), so
+	// recurse with an assumed set of query arguments for Photon
+	if ( ! service ) {
+		return resizeImageUrl( safeImageUrl( imageUrl ), resize );
 	}
 
 	// Map sizing parameters, multiplying their values by the scale factor

--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -94,8 +94,9 @@ export default function resizeImageUrl( imageUrl, resize, height ) {
 
 	// External URLs are made "safe" (i.e. passed through Photon), so
 	// recurse with an assumed set of query arguments for Photon
-	if ( ! service ) {
-		return resizeImageUrl( safeImageUrl( imageUrl ), resize );
+	const safeUrl = safeImageUrl( imageUrl );
+	if ( ! service && safeUrl !== imageUrl ) {
+		return resizeImageUrl( safeUrl, resize );
 	}
 
 	// Map sizing parameters, multiplying their values by the scale factor

--- a/client/post-editor/media-modal/test/markup.js
+++ b/client/post-editor/media-modal/test/markup.js
@@ -158,7 +158,7 @@ describe( 'markup', () => {
 				);
 
 				expect( value ).to.equal(
-					'<img src="http://example.com/image.png?w=1024" width="1024" height="410" class="alignnone size-large wp-image-1"/>'
+					'<img src="https://i2.wp.com/example.com/image.png?w=1024" width="1024" height="410" class="alignnone size-large wp-image-1"/>'
 				);
 			} );
 
@@ -183,7 +183,7 @@ describe( 'markup', () => {
 				);
 
 				expect( value ).to.equal(
-					'<img src="http://example.com/image.png?w=410" width="410" height="1024" class="alignnone size-large wp-image-1"/>'
+					'<img src="https://i2.wp.com/example.com/image.png?w=410" width="410" height="1024" class="alignnone size-large wp-image-1"/>'
 				);
 			} );
 


### PR DESCRIPTION
**WIP: DO NOT MERGE**

This PR shows one way that `resizeImageUrl` could be updated to support using photon when an object `resize` param is passed in (currently, it only uses photon when a number `resize` param is passed in).

This update improves the data usage and rendering performance of `PostTypeList`.

As `resizeImageUrl` is also used in Reader and Woo Commerce Stripe payment code, those areas should be regression tested as well.