### PR TITLE
Themes: Turn ThanksModal into React.Component

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -3,10 +3,8 @@
 /**
  * External dependencies
  */
-
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import React from 'react';
-import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import page from 'page';
 import { translate } from 'i18n-calypso';
@@ -32,10 +30,8 @@ import { clearActivated } from 'state/themes/actions';
 import { getSite, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
-const ThanksModal = createReactClass( {
-	displayName: 'ThanksModal',
-
-	propTypes: {
+class ThanksModal extends Component {
+	static propTypes = {
 		// Where is the modal being used?
 		source: PropTypes.oneOf( [ 'details', 'list', 'upload' ] ).isRequired,
 		// Connected props
@@ -54,35 +50,35 @@ const ThanksModal = createReactClass( {
 		isThemeWpcom: PropTypes.bool.isRequired,
 		siteId: PropTypes.number,
 		visitSiteUrl: PropTypes.string,
-	},
+	};
 
-	onCloseModal() {
+	onCloseModal = () => {
 		this.props.clearActivated( this.props.siteId );
 		this.setState( { show: false } );
-	},
+	};
 
-	trackClick( eventName, verb ) {
+	trackClick = ( eventName, verb ) => {
 		trackClick( 'current theme', eventName, verb );
-	},
+	};
 
-	visitSite() {
+	visitSite = () => {
 		this.trackClick( 'visit site' );
 		page( this.props.visitSiteUrl );
-	},
+	};
 
-	goBack() {
+	goBack = () => {
 		this.trackClick( 'go back' );
 		this.onCloseModal();
-	},
+	};
 
-	onLinkClick( link ) {
+	onLinkClick = link => {
 		return () => {
 			this.onCloseModal();
 			this.trackClick( link, 'click' );
 		};
-	},
+	};
 
-	renderBody() {
+	renderBody = () => {
 		return (
 			<ul>
 				<li>
@@ -91,25 +87,25 @@ const ThanksModal = createReactClass( {
 				<li>{ this.renderSupportInfo() }</li>
 			</ul>
 		);
-	},
+	};
 
-	renderThemeInfo() {
+	renderThemeInfo = () => {
 		return translate( '{{a}}Learn more about{{/a}} this theme.', {
 			components: {
 				a: <a href={ this.props.detailsUrl } onClick={ this.onLinkClick( 'theme info' ) } />,
 			},
 		} );
-	},
+	};
 
-	renderCustomizeInfo() {
+	renderCustomizeInfo = () => {
 		return translate( '{{a}}Customize{{/a}} this design.', {
 			components: {
 				a: <a href={ this.props.customizeUrl } onClick={ this.onLinkClick( 'customize' ) } />,
 			},
 		} );
-	},
+	};
 
-	renderSupportInfo() {
+	renderSupportInfo = () => {
 		const { author_uri: authorUri } = this.props.currentTheme;
 
 		if ( this.props.forumUrl ) {
@@ -129,9 +125,9 @@ const ThanksModal = createReactClass( {
 		}
 
 		return null;
-	},
+	};
 
-	renderContent() {
+	renderContent = () => {
 		const { name: themeName, author: themeAuthor } = this.props.currentTheme;
 
 		return (
@@ -147,15 +143,15 @@ const ThanksModal = createReactClass( {
 				{ this.renderBody() }
 			</div>
 		);
-	},
+	};
 
-	renderLoading() {
+	renderLoading = () => {
 		return (
 			<div className="themes__thanks-modal-loading">
 				<PulsingDot active={ true } />
 			</div>
 		);
-	},
+	};
 
 	render() {
 		const { currentTheme, hasActivated, isActivating } = this.props;
@@ -183,8 +179,8 @@ const ThanksModal = createReactClass( {
 				{ hasActivated && currentTheme ? this.renderContent() : this.renderLoading() }
 			</Dialog>
 		);
-	},
-} );
+	}
+}
 
 export default connect(
 	state => {

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -34,7 +34,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 
 const ThanksModal = createReactClass( {
 	displayName: 'ThanksModal',
-	trackClick: trackClick.bind( null, 'current theme' ),
 
 	propTypes: {
 		// Where is the modal being used?
@@ -60,6 +59,10 @@ const ThanksModal = createReactClass( {
 	onCloseModal() {
 		this.props.clearActivated( this.props.siteId );
 		this.setState( { show: false } );
+	},
+
+	trackClick( eventName, verb ) {
+		trackClick( 'current theme', eventName, verb );
 	},
 
 	visitSite() {


### PR DESCRIPTION
This wasn't previously codemodded since `trackClick` wasn't an actual method that the codemod could handle.

To test:
* Verify that the Thanks Modal (after activating a theme) still works
* Verify that `trackClick` still works
  * It's supposed to fire a `Themes` Google Analytics event, but that doesn't seem to be happening -- even in `master`, so it's not a regression.
  * To verify it is really called, apply the patch found further below. Then, verify you see the `trackClick helper` message in the console in the following cases:
    * Click on 'Go Back'
    * Click on 'Visit Site'
    * Click on any link in the Thanks Modal

```diff
diff --git a/client/my-sites/themes/helpers.js b/client/my-sites/themes/helpers.js
index 858fa24..716f542 100644
--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -15,6 +15,7 @@ import { sectionify } from 'lib/route/path';
 
 export function trackClick( componentName, eventName, verb = 'click' ) {
        const stat = `${ componentName } ${ eventName } ${ verb }`;
+       console.log( 'trackClick helper', titlecase( stat ) )
        analytics.ga.recordEvent( 'Themes', titlecase( stat ) );
 }
 ```