### PR TITLE
Codemods: add link to more resources in docs

### DIFF
--- a/bin/codemods/README.md
+++ b/bin/codemods/README.md
@@ -28,6 +28,8 @@ export default function transformer( file, api ) {
 A nifty tool to explore AST structures is [AST explorer](https://astexplorer.net/).
 You can choose "recast" as a parser and "jscodeshift" from "Transform" menu.
 
+For more, check [an awesome list of jscodeshift resources and tips](https://github.com/sejoker/awesome-jscodeshift).
+
 ## How to run our codemods
 
 It's easy! Our codemod script uses the following CLI:


### PR DESCRIPTION
Just a quickie: 

add a link to [awesome-jscodeshift](https://github.com/sejoker/awesome-jscodeshift) in codemods readme. 

The list is full of very helpful material such as great examples for common codemodding tasks and patterns. 📜 