### PR TITLE
Codemods: single tree rendering - add makeNavigation

### DIFF
--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -20,6 +20,9 @@
  *
  * Removes:
  *   Un-used ReactDom imports.
+ *
+ * Replaces `navigation` middleware with `makeNavigation` when imported
+ *   from `my-sites/controller`.
  */
 
 /**
@@ -386,11 +389,38 @@ export default function transformer( file, api ) {
 		} )
 		.filter( p => p.value.arguments.length > 1 && p.value.arguments[ 0 ].value !== '*' )
 		.forEach( p => {
+			// Replace `navigation` with `makeNavigation` for files under `/client/my-sites/*`
+			if ( file.path.startsWith( 'client/my-sites/' ) ) {
+				p.value.arguments = p.value.arguments.map( param => {
+					return param.name === 'navigation' ? j.identifier( 'makeNavigation' ) : param;
+				} );
+			}
+
 			p.value.arguments.push( j.identifier( 'makeLayout' ) );
 			p.value.arguments.push( j.identifier( 'clientRender' ) );
 		} );
 
 	if ( routeDefs.size() ) {
+		// Replace `navigation` with `makeNavigation` in:
+		// `import { navigation } from 'my-sites/controller'`
+		// ...at files under `/client/my-sites/*`.
+		if ( file.path.startsWith( 'client/my-sites/' ) ) {
+			root
+				.find( j.ImportDeclaration, {
+					source: {
+						value: 'my-sites/controller',
+					},
+				} )
+				.replaceWith( p => {
+					p.value.specifiers = p.value.specifiers.map( identifier => {
+						return identifier.local.name === 'navigation'
+							? j.importSpecifier( j.identifier( 'makeNavigation' ) )
+							: identifier;
+					} );
+					return p.value;
+				} );
+		}
+
 		root
 			.find( j.ImportDeclaration )
 			.at( -1 )


### PR DESCRIPTION
_Part of [single tree rendering project](https://github.com/Automattic/wp-calypso/projects/53)._

Transforms `navigation` middlewares imported from `my-sites/controller` to `makeNavigation` middlewares.

This:
```js
import { navigation } from 'my-sites/controller';
```
becomes:
```js
import { makeNavigation } from 'my-sites/controller';
```

This:
```js
page('/foo', navigation, foo);
```
becomes:
```js
page('/foo', makeNavigation, foo);
```

The codemod already transforms [`navigation` and `makeNavigation` middlewares](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/controller.js#L447-L460) to be identical so we could do this the other way around as well. Like this we'll keep naming more consistent with `makeLayout` middleware.

After the codemod runs we can remove `navigation` middleware completely.
 
# Test

```bash
npm run codemod single-tree-rendering \
 ./client/extensions/wp-super-cache/index.js \
 ./client/my-sites/types/index.js \
 ./client/my-sites/comments/index.js \
 ./client/post-editor/index.js
```
- In `client/post-editor/index.js` `makeNavigation` does not appear in `import { siteSelection, sites } from 'my-sites/controller';`
- In `client/my-sites/comments/index.js` and `client/extensions/wp-super-cache/index.js` all `navigation`s are replaced by `makeNavigation`.
- Nothing happens in `client/my-sites/types/index.js` (it uses `router()` instead of `page()` and it already uses `makeNavigation`.
