### PR TITLE
Make domain name suggestions tabbable (#19194)

### DIFF
--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -13,6 +13,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import DomainProductPrice from 'components/domains/domain-product-price';
+import Button from 'components/button';
 
 class DomainSuggestion extends React.Component {
 	static propTypes = {
@@ -50,7 +51,13 @@ class DomainSuggestion extends React.Component {
 					{ children }
 					{ ! hidePrice && <DomainProductPrice rule={ priceRule } price={ price } /> }
 				</div>
-				<div className="domain-suggestion__action">{ this.props.buttonContent }</div>
+				<Button
+					borderless
+					onClick={ this.props.onButtonClick }
+					className="domain-suggestion__action"
+				>
+					{ this.props.buttonContent }
+				</Button>
 				<Gridicon className="domain-suggestion__chevron" icon="chevron-right" />
 			</div>
 		);

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -104,7 +104,7 @@
 	}
 }
 
-.domain-suggestion__action {
+.button.domain-suggestion__action {
 	flex: 1 0 auto;
 	min-width: 66px;
 	text-align: center;


### PR DESCRIPTION
When setting up a new site via /start/domains/, user should be able to tab through the list of suggested domains.
Originally tried adding a tabindex="0" property and a focus state to the domain suggestion div, but it was suggested to convert the "Select" button divs to actual buttons for native tabbing behavior instead.

This requires user to press tab twice before the first domain suggestion gains focus.

cc: @gwwar @alisterscott 