### PR TITLE
Editor: move History link to after Save link

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -214,7 +214,6 @@ export class EditorGroundControl extends PureComponent {
 
 		return (
 			<div className="editor-ground-control__quick-save">
-				{ hasRevisions && <HistoryButton loadRevision={ loadRevision } /> }
 				{ showingSaveStatus && (
 					<div className="editor-ground-control__status">
 						{ isSaveAvailable && (
@@ -237,6 +236,7 @@ export class EditorGroundControl extends PureComponent {
 							) }
 					</div>
 				) }
+				{ hasRevisions && <HistoryButton loadRevision={ loadRevision } /> }
 			</div>
 		);
 	}


### PR DESCRIPTION
Fixes #20001 

**Before**

![location](https://user-images.githubusercontent.com/128826/32999478-2365eb9a-cdee-11e7-9837-0a02adba6a41.gif)

**After**

![location new](https://user-images.githubusercontent.com/128826/32999480-293574be-cdee-11e7-81e4-4e00c6cb7a62.gif)

Testing Instructions

1. Open a new or existing post
2. Click save to create revisions
3. See that History link appears and functions
