### PR TITLE
Data Layer Tests: wait for Nock request to finish before checking its result

### DIFF
--- a/client/state/data-layer/wpcom-http/test/index.js
+++ b/client/state/data-layer/wpcom-http/test/index.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -35,13 +34,7 @@ const getMe = {
 };
 
 describe( '#queueRequest', () => {
-	let dispatch;
-
 	useNock();
-
-	beforeEach( () => {
-		dispatch = spy();
-	} );
 
 	test( 'should call `onSuccess` when a response returns with data', done => {
 		const data = { value: 1 };
@@ -49,13 +42,12 @@ describe( '#queueRequest', () => {
 			.get( '/rest/v1.1/me' )
 			.reply( 200, data );
 
-		http( { dispatch }, getMe );
-
-		setTimeout( () => {
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith( extendAction( succeeder, successMeta( data ) ) );
+		const dispatch = action => {
+			expect( action ).to.be.eql( extendAction( succeeder, successMeta( data ) ) );
 			done();
-		}, 10 );
+		};
+
+		http( { dispatch }, getMe );
 	} );
 
 	test( 'should call `onFailure` when a response returns with an error', done => {
@@ -64,12 +56,11 @@ describe( '#queueRequest', () => {
 			.get( '/rest/v1.1/me' )
 			.replyWithError( error );
 
-		http( { dispatch }, getMe );
-
-		setTimeout( () => {
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith( extendAction( failer, failureMeta( error ) ) );
+		const dispatch = action => {
+			expect( action ).to.be.eql( extendAction( failer, failureMeta( error ) ) );
 			done();
-		}, 10 );
+		};
+
+		http( { dispatch }, getMe );
 	} );
 } );


### PR DESCRIPTION
Fixes intermittent failures in tests like this one: https://circleci.com/gh/Automattic/wp-calypso/74660

Nock processes the request and issues the mocked response as a series of async events (`process.nextTick`, `setImmediate`) and our test code waits for 10ms before assuming that the response arrived and starting to execute asserts. Apparently, the `setTimeout( ..., 10 )` callback can be sometimes executed before the response arrived.

I changed the test code to wait until the `dispatch` mocked function is called, then check the arguments, and then asynchronously finish the test by calling `done`.
