### PR TITLE
Free photo library: add free photo library using Pexels data source

### DIFF
--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -44,6 +44,19 @@ if ( config.isEnabled( 'external-media' ) ) {
 		),
 		cmd: 'googleAddMedia',
 	} );
+	if ( config.isEnabled( 'external-free-photo-library' ) ) {
+		menuItems.push( {
+			name: 'insert_from_pexels',
+			item: (
+				<GridiconButton
+					icon="add-image"
+					label={ i18n.translate( 'Free photo library' ) }
+					e2e="stock-media-pexels"
+				/>
+			),
+			cmd: 'pexelsAddMedia',
+		} );
+	}
 }
 
 menuItems.push( {

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -439,6 +439,15 @@ function mediaButton( editor ) {
 		} );
 	} );
 
+	editor.addCommand( 'pexelsAddMedia', () => {
+		initMediaModal();
+
+		renderModal( {
+			visible: true,
+			source: 'pexels',
+		} );
+	} );
+
 	editor.addButton( 'wpcom_add_media', {
 		classes: 'btn wpcom-icon-button media',
 		cmd: 'wpcomAddMedia',

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -94,6 +94,12 @@ MediaActions.fetchNextPage = function( siteId ) {
 	if ( ! query.source ) {
 		wpcom.site( siteId ).mediaList( query, mediaReceived );
 	} else {
+		if ( 'pexels' === query.source ) {
+			// Pexels limits the number of API calls per month, and if we had the default
+			// limit of 20 media items, it taskes at least 2 API calls to fill the first page
+			// with results. This saves us some of those API calls.
+			query.number = 40;
+		}
 		wpcom.undocumented().externalMediaList( query, mediaReceived );
 	}
 };

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -202,7 +202,7 @@ class MediaLibraryContent extends React.Component {
 		page( `/sharing/${ this.props.site.slug }` );
 	};
 
-	renderExternalMedia() {
+	renderGooglePhotosConnect() {
 		const connectMessage = this.props.translate(
 			'To show Photos from Google, you need to connect your Google account.'
 		);
@@ -219,6 +219,15 @@ class MediaLibraryContent extends React.Component {
 		);
 	}
 
+	renderConnectExternalMedia() {
+		const { source } = this.props;
+		switch ( source ) {
+			case 'google_photos':
+				return this.renderGooglePhotosConnect();
+		}
+		return null;
+	}
+
 	getThumbnailType() {
 		if ( this.props.source !== '' ) {
 			return MEDIA_IMAGE_THUMBNAIL;
@@ -229,6 +238,10 @@ class MediaLibraryContent extends React.Component {
 		}
 
 		return MEDIA_IMAGE_PHOTON;
+	}
+
+	needsToBeConnected() {
+		return this.props.source !== '' && ! this.props.isConnected;
 	}
 
 	renderMediaList() {
@@ -242,8 +255,8 @@ class MediaLibraryContent extends React.Component {
 			);
 		}
 
-		if ( this.props.source !== '' && ! this.props.isConnected ) {
-			return this.renderExternalMedia();
+		if ( this.needsToBeConnected() ) {
+			return this.renderConnectExternalMedia();
 		}
 
 		return (
@@ -273,7 +286,7 @@ class MediaLibraryContent extends React.Component {
 	}
 
 	renderHeader() {
-		if ( ! this.props.isConnected ) {
+		if ( ! this.props.isConnected && this.needsToBeConnected() ) {
 			return null;
 		}
 

--- a/client/my-sites/media-library/content.scss
+++ b/client/my-sites/media-library/content.scss
@@ -29,3 +29,8 @@
 	margin: 0 auto;
 	text-align: center;
 }
+
+.media-library__pexels-attribution {
+	display: inline-block;
+	margin-right: 1em;
+}

--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -76,6 +76,13 @@ export class MediaLibraryDataSource extends Component {
 				icon: <Gridicon icon="image" size={ 24 } />,
 			},
 		];
+		if ( config.isEnabled( 'external-free-photo-library' ) ) {
+			sources.push( {
+				value: 'pexels',
+				label: translate( 'Free photo library' ),
+				icon: <Gridicon icon="add-image" size={ 24 } />,
+			} );
+		}
 		const currentSelected = find( sources, item => item.value === source );
 		const classes = classnames( {
 			button: true,

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -111,16 +111,30 @@ class MediaLibraryExternalHeader extends React.Component {
 		);
 	}
 
+	renderPexelsAttribution() {
+		const { translate } = this.props;
+		const attribution = translate( 'Free photos provided by {{a}}Pexels{{/a}}', {
+			components: {
+				a: <a href="http://www.pexels.com/" rel="noopener noreferrer" target="_blank" />,
+			},
+		} );
+		return <span className="media-library__pexels-attribution">{ attribution }</span>;
+	}
+
 	renderCard() {
-		const { onMediaScaleChange, translate, canCopy } = this.props;
+		const { onMediaScaleChange, translate, canCopy, source } = this.props;
 
 		return (
 			<Card className="media-library__header">
-				<Button compact disabled={ this.state.fetching } onClick={ this.handleClick }>
-					<Gridicon icon="refresh" size={ 24 } />
+				{ 'pexels' === source && this.renderPexelsAttribution() }
 
-					{ translate( 'Refresh' ) }
-				</Button>
+				{ 'pexels' !== source && (
+					<Button compact disabled={ this.state.fetching } onClick={ this.handleClick }>
+						<Gridicon icon="refresh" size={ 24 } />
+
+						{ translate( 'Refresh' ) }
+					</Button>
+				) }
 
 				{ canCopy && this.renderCopyButton() }
 

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -54,6 +54,10 @@ export class MediaLibraryFilterBar extends Component {
 			return translate( 'Search your Google library…' );
 		}
 
+		if ( 'pexels' === source ) {
+			return translate( 'Search for free photos…' );
+		}
+
 		switch ( filter ) {
 			case 'this-post':
 				return translate( 'Search media uploaded to this post…' );

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -29,10 +29,19 @@ import {
 } from 'state/sharing/keyring/selectors';
 import { requestKeyringConnections } from 'state/sharing/keyring/actions';
 
+// External media sources that do not need a user to connect them
+// should be listed here.
+const noConnectionNeeded = [ 'pexels' ];
+
 const isConnected = props =>
-	props.source === '' || some( props.connectedServices, item => item.service === props.source );
+	noConnectionNeeded.indexOf( props.source ) !== -1 ||
+	props.source === '' ||
+	some( props.connectedServices, item => item.service === props.source );
 const needsKeyring = props =>
-	! props.isRequesting && props.source !== '' && props.connectedServices.length === 0;
+	noConnectionNeeded.indexOf( props.source ) === -1 &&
+	! props.isRequesting &&
+	props.source !== '' &&
+	props.connectedServices.length === 0;
 
 class MediaLibrary extends Component {
 	static propTypes = {

--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -32,6 +32,12 @@ class MediaLibraryListNoContent extends Component {
 			} );
 		}
 
+		if ( 'pexels' === source ) {
+			return translate( 'Use the search above to find free photos!', {
+				comment: 'Media no results',
+			} );
+		}
+
 		switch ( filter ) {
 			case 'this-post':
 				return translate( 'There are no media items uploaded to this post.', {
@@ -76,7 +82,7 @@ class MediaLibraryListNoContent extends Component {
 					{ this.props.translate( 'Upload Media' ) }
 				</UploadButton>
 			);
-		} else if ( this.props.source ) {
+		} else if ( 'google_photos' === this.props.source ) {
 			line = this.props.translate( 'New photos may take a few minutes to appear.' );
 		}
 

--- a/client/my-sites/media-library/test/index.jsx
+++ b/client/my-sites/media-library/test/index.jsx
@@ -48,27 +48,33 @@ describe( 'MediaLibrary', () => {
 		test( 'is issued when component mounted and viewing an external source', () => {
 			getItem( 'google_photos' );
 
-			expect( requestStub ).to.have.been.calledOnce;
+			expect( requestStub.callCount ).to.equal( 1 );
 		} );
 
 		test( 'is not issued when component mounted and viewing wordpress', () => {
 			getItem( '' );
 
-			expect( requestStub ).to.have.not.been.notCalled;
+			expect( requestStub.callCount ).to.equal( 0 );
 		} );
 
 		test( 'is issued when component source changes and now viewing an external source', () => {
 			const library = getItem( '' );
 
 			library.setProps( { source: 'google_photos' } );
-			expect( requestStub ).to.have.been.calledOnce;
+			expect( requestStub.callCount ).to.equal( 1 );
 		} );
 
 		test( 'is not issued when component source changes and not viewing an external source', () => {
 			const library = getItem( '' );
 
 			library.setProps( { source: '' } );
-			expect( requestStub ).to.have.not.been.notCalled;
+			expect( requestStub.callCount ).to.equal( 0 );
+		} );
+
+		test( 'is not issued when the external source does not need user connection', () => {
+			getItem( 'pexels' );
+
+			expect( requestStub.callCount ).to.equal( 0 );
 		} );
 	} );
 } );

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -429,6 +429,14 @@ export class EditorHtmlToolbar extends Component {
 		} );
 	};
 
+	openPexelsModal = () => {
+		this.setState( {
+			showInsertContentMenu: false,
+			showMediaModal: true,
+			source: 'pexels',
+		} );
+	};
+
 	closeMediaModal = () => {
 		this.setState( { showMediaModal: false } );
 	};
@@ -505,6 +513,16 @@ export class EditorHtmlToolbar extends Component {
 					>
 						<Gridicon icon="add-image" />
 						<span data-e2e-insert-type="google-media">{ translate( 'Media from Google' ) }</span>
+					</div>
+				) }
+
+				{ config.isEnabled( 'external-free-photo-library' ) && (
+					<div
+						className="editor-html-toolbar__insert-content-dropdown-item"
+						onClick={ this.openPexelsModal }
+					>
+						<Gridicon icon="add-image" />
+						<span data-e2e-insert-type="pexels">{ translate( 'Free photo library' ) }</span>
 					</div>
 				) }
 

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -32,6 +32,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"external-media": true,
+		"external-free-photo-library": true,
 		"fluid-width": true,
 		"help": true,
 		"help/courses": true,

--- a/config/development.json
+++ b/config/development.json
@@ -59,6 +59,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"external-media": true,
+		"external-free-photo-library": true,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -34,6 +34,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"external-media": true,
+		"external-free-photo-library": true,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -32,6 +32,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"external-media": true,
+		"external-free-photo-library": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -34,6 +34,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"external-media": true,
+		"external-free-photo-library": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -34,6 +34,7 @@
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
 		"external-media": true,
+		"external-free-photo-library": true,
 		"guided-tours/design-showcase-welcome": true,
 		"guided-tours/site-title": true,
 		"guided-tours/theme-sheet-welcome": true,


### PR DESCRIPTION
Adds a new data source for pexels, a stock image service.

WPCOM API has been rolled out, so this should just work.

Some code has been moved around to allow data sources that don't require the user to connect them.

Testing: Go to insert media, you should see "Insert stock images from Pexels". Click it, search for images, and insert them. They should be copied to your media library in the same way as Google Photos.