### PR TITLE
Themes: Omit redundant 1x srcset

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -220,7 +220,7 @@ export class Theme extends Component {
 							<img
 								className="theme__img"
 								src={ themeImgSrc }
-								srcSet={ `${ themeImgSrc } 1x ${ themeImgSrcDoubleDpi } 2x` }
+								srcSet={ `${ themeImgSrcDoubleDpi } 2x` }
 								onClick={ this.onScreenshotClick }
 								id={ screenshotID }
 							/>

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -21,7 +21,7 @@ exports[`Theme rendering with default display buttonContents should match snapsh
         id={null}
         onClick={[Function]}
         src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360"
-        srcSet="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360 1x https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"
+        srcSet="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"
       />
     </a>
     <div


### PR DESCRIPTION
#19893 attempted to fix theme parameters, but incorrectly removed a comma (`,`) as the `srcset` separator.

It turns out that when using pixel density descriptors and `src` attribute is included, there's no need to include the `1x` `srcset` at all.

> If child has a src attribute whose value is not the empty string and source set does not contain an image source with a pixel density descriptor value of 1, and no image source with a width descriptor, append child's src attribute value to source set.

https://html.spec.whatwg.org/multipage/images.html#update-the-source-set

Also see MDN for a more digestable description of `srcset`: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-srcset

This PR fixes errors with the `srcset` that were seen in production by ommitting the `1x` `srcset` entirely.

## Output

### Before

```html
<img class="theme__img" src="https://i1.wp.com/s0.wp.com/wp-content/themes/pub/radcliffe-2/screenshot.png?fit=479%2C360" srcset="https://i1.wp.com/s0.wp.com/wp-content/themes/pub/radcliffe-2/screenshot.png?fit=479%2C360 1x https://i1.wp.com/s0.wp.com/wp-content/themes/pub/radcliffe-2/screenshot.png?fit=479%2C360&amp;zoom=2 2x" id="theme__firstscreenshot" data-reactid="171">
```

### After

```html
<img class="theme__img" src="https://i1.wp.com/s0.wp.com/wp-content/themes/pub/radcliffe-2/screenshot.png?fit=479%2C360" srcset="https://i1.wp.com/s0.wp.com/wp-content/themes/pub/radcliffe-2/screenshot.png?fit=479%2C360&amp;zoom=2 2x" id="theme__firstscreenshot" data-reactid="172">
```

## Testing
1. Confirm you see no `srcset` errors: https://calypso.live/themes?branch=fix/19893-bad-srcset