### PR TITLE
Remove "Learn more" link until we actually have a support page.

### DIFF
--- a/client/my-sites/domains/domain-management/components/email-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/email-verification/index.jsx
@@ -21,7 +21,8 @@ class EmailVerificationCard extends React.Component {
 	static propTypes = {
 		changeEmailHref: PropTypes.string,
 		contactEmail: PropTypes.string.isRequired,
-		verificationExplanation: PropTypes.array.isRequired,
+		verificationExplanation: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] )
+			.isRequired,
 		resendVerification: PropTypes.func.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSiteSlug: PropTypes.string.isRequired,

--- a/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
@@ -52,6 +52,10 @@ class InboundTransferEmailVerificationCard extends React.Component {
 	render() {
 		const { selectedDomainName, selectedSiteSlug, translate } = this.props;
 		const { loading, contactEmail } = this.state;
+		const verificationExplanation = translate(
+			'We need to check your contact information to make sure you can be reached. Please verify your ' +
+			'details using the email we sent you to begin transferring the domain to WordPress.com.'
+		);
 
 		if ( loading ) {
 			return null;
@@ -60,22 +64,7 @@ class InboundTransferEmailVerificationCard extends React.Component {
 		return (
 			<EmailVerificationCard
 				contactEmail={ contactEmail }
-				verificationExplanation={ translate(
-					'We need to check your contact information to make sure you can be reached. Please verify your ' +
-						'details using the email we sent you to begin transferring the domain to WordPress.com. ' +
-						'{{learnMoreLink}}Learn more.{{/learnMoreLink}}',
-					{
-						components: {
-							learnMoreLink: (
-								<a
-									href="http://support.wordpress.com"
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					}
-				) }
+				verificationExplanation={ verificationExplanation }
 				resendVerification={ resendInboundTransferEmail }
 				selectedDomainName={ selectedDomainName }
 				selectedSiteSlug={ selectedSiteSlug }


### PR DESCRIPTION
Since we don't actually have a support page for inbound transfer email verification yet, I have removed the link from the verification message. We should add it back in once we have a support page.

To test, use this branch and check that the email verification notice doesn't show the "Learn more" link.

Note: This PR also allows both `string` and `array` for the `verificationExplanation` `PropTypes` now since `translate` will return just a `string` when no additional options are passed to it.