### PR TITLE
Posts: Pre-load editor when hovering post controls

### DIFF
--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -17,9 +17,14 @@ import Gridicon from 'gridicons';
  */
 import { isEnabled } from 'config';
 import { ga } from 'lib/analytics';
+import { preload } from 'sections-preload';
 import { userCan } from 'lib/posts/utils';
 import { isPublicizeEnabled } from 'state/selectors';
 import { getSiteSlug, isSitePreviewable } from 'state/sites/selectors';
+
+function preloadEditor() {
+	preload( 'post-editor' );
+}
 
 const edit = () => ga.recordEvent( 'Posts', 'Clicked Edit Post' );
 const copy = () => ga.recordEvent( 'Posts', 'Clicked Copy Post' );
@@ -54,6 +59,7 @@ const getAvailableControls = props => {
 			href: editURL,
 			icon: 'pencil',
 			onClick: edit,
+			onMouseOver: preloadEditor,
 			text: translate( 'Edit' ),
 		} );
 	}
@@ -136,6 +142,7 @@ const getAvailableControls = props => {
 			href: `/post/${ siteSlug }?copy=${ post.ID }`,
 			icon: 'clipboard',
 			onClick: copy,
+			onMouseOver: preloadEditor,
 			text: translate( 'Copy' ),
 		} );
 	}
@@ -173,6 +180,7 @@ const getControlElements = controls =>
 				className={ `post-controls__${ control.className }` }
 				href={ control.href }
 				onClick={ control.disabled ? noop : control.onClick }
+				onMouseOver={ control.onMouseOver ? control.onMouseOver : noop }
 				target={ control.target ? control.target : null }
 			>
 				<Gridicon icon={ control.icon } size={ 18 } />


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/19396 that fixes an annoying flash of unstyled content that would otherwise happen when the editor loads. It does so by making sure the `post-editor` section is pre-loaded when the user moves their mouse over the `Edit` and `Copy` options located below each post on the [`Blog Posts` page](https://wordpress.com/posts):
 
<img width="425" alt="screenshot" src="https://user-images.githubusercontent.com/594356/33019973-c8ebff06-cdfc-11e7-8890-c131fb714441.png">

#### Testing instructions
 
1. Run `git checkout fix/blog-posts-edit-preload` and start your server, or open a [live branch](https://calypso.live/?branch=fix/blog-posts-edit-preload)
2. Open the [`Blog Posts` page](http://calypso.localhost:3000/posts) in a new tab
3. Click the `Edit` action below any existing post
4. Assert that the editor loads with the correct styles applied right away
5. Open the `Blog Posts` page again in another tab
6. Click the `More` action below any existing post
7. Click the `Copy` action that has appeared
8. Assert that the editor loads with the correct styles applied right away
