### PR TITLE
Activity Log: amend backup/rewind success cards

### DIFF
--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -71,16 +71,22 @@ class SuccessBanner extends PureComponent {
 	render() {
 		const { applySiteOffset, moment, siteUrl, timestamp, translate, backupUrl } = this.props;
 		const date = applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' );
+		const params = backupUrl
+			? {
+					title: translate( 'Your backup is now available for download' ),
+					icon: 'cloud-download',
+				}
+			: {
+					title: translate( 'Your site has been successfully restored' ),
+					icon: 'history',
+				};
 		return (
 			<ActivityLogBanner
 				isDismissable
 				onDismissClick={ this.handleDismiss }
 				status="success"
-				title={
-					backupUrl
-						? translate( 'Your backup has been successfully created' )
-						: translate( 'Your site has been successfully restored' )
-				}
+				title={ params.title }
+				icon={ params.icon }
 			>
 				{ backupUrl ? (
 					<TrackComponentView eventName="calypso_activitylog_backup_successbanner_impression" />
@@ -95,15 +101,13 @@ class SuccessBanner extends PureComponent {
 				{
 					<p>
 						{ backupUrl
-							? translate( 'We successfully restored your site back to %s!', { args: date } )
-							: translate( 'We successfully created a backup of your site as of %s!', {
-									args: date,
-								} ) }
+							? translate( 'We successfully created a backup of your site to %s!', { args: date } )
+							: translate( 'We successfully restored your site back to %s!', { args: date } ) }
 					</p>
 				}
 				{ backupUrl ? (
 					<Button href={ backupUrl } onClick={ this.trackDownload } primary>
-						{ translate( 'Download your backup' ) }
+						{ translate( 'Download' ) }
 					</Button>
 				) : (
 					<Button href={ siteUrl } primary>
@@ -111,7 +115,9 @@ class SuccessBanner extends PureComponent {
 					</Button>
 				) }
 				{ '  ' }
-				<Button onClick={ this.handleDismiss }>{ translate( 'Thanks, got it!' ) }</Button>
+				{ ! backupUrl && (
+					<Button onClick={ this.handleDismiss }>{ translate( 'Thanks, got it!' ) }</Button>
+				) }
 			</ActivityLogBanner>
 		);
 	}


### PR DESCRIPTION
This is a branch off https://github.com/Automattic/wp-calypso/pull/19675 to quickly introduce some visual updates without waiting for the resolution of the whole PR regarding its data side.

#### Changes

- fix texts in success cards. While the title was ok, the body content was previously reversed
- adds icons: cloud download for backup, history for rewind
- remove "Got it" button in backup card based on [Michael's feedback](https://github.com/Automattic/wp-calypso/pull/19675#issuecomment-343602442).

#### Testing

1. Rewind a site. Make sure the icon and text in success card is correct.
2. Create a downloadable backup. Make sure the icon and text in success card is correct.