### PR TITLE
WooCommerce - Allowing the WCS plugin to control the label modal country dropdown state

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/initialize-labels-state/index.js
@@ -5,23 +5,25 @@ import { isEmpty, mapValues } from 'lodash';
 
 /**
  * Parses the data passed from the backed into a Redux state to be used in the label purchase flow
- * @param {Object} formData form data
- * @param {Object} labelsData labels data
- * @param {string} paperSize selected paper size
- * @param {Object} storeOptions store options (weight/dimensions units etc)
- * @param {Number} paymentMethod selected payment method
- * @param {Number} numPaymentMethods number of payments methods stored with the jetpack master account
- * @param {Bool} enabled checks if labels were enabled in the settings
+ * @param {Object} data data to initialize the labels state from
  * @returns {Object} labels Redux state
  */
-export default ( formData, labelsData, paperSize, storeOptions, paymentMethod, numPaymentMethods, enabled ) => {
-	if ( ! formData ) {
+export default ( data ) => {
+	if ( ! data ) {
 		return {
 			loaded: false,
 			isFetching: false,
 			error: false,
 		};
 	}
+
+	const {
+		formData,
+		labelsData,
+		paperSize,
+		storeOptions,
+		canChangeCountries,
+	} = data;
 
 	// The phone field is never prefilled, so if it's present it means the address is fully valid
 	const hasOriginAddress = Boolean( formData.origin.phone );
@@ -31,12 +33,9 @@ export default ( formData, labelsData, paperSize, storeOptions, paymentMethod, n
 		loaded: true,
 		isFetching: false,
 		error: false,
-		enabled,
 		refreshedLabelStatus: false,
 		labels: labelsData || [],
 		paperSize,
-		paymentMethod,
-		numPaymentMethods,
 		storeOptions,
 		fulfillOrder: true,
 		emailDetails: true,
@@ -51,7 +50,7 @@ export default ( formData, labelsData, paperSize, storeOptions, paymentMethod, n
 				ignoreValidation: hasOriginAddress ? null : mapValues( formData.origin, () => true ),
 				selectNormalized: true,
 				normalizationInProgress: false,
-				allowChangeCountry: false,
+				allowChangeCountry: Boolean( canChangeCountries ),
 			},
 			destination: {
 				values: formData.destination,
@@ -62,7 +61,7 @@ export default ( formData, labelsData, paperSize, storeOptions, paymentMethod, n
 				ignoreValidation: hasDestinationAddress ? null : mapValues( formData.destination, () => true ),
 				selectNormalized: true,
 				normalizationInProgress: false,
-				allowChangeCountry: false,
+				allowChangeCountry: Boolean( canChangeCountries ),
 			},
 			packages: {
 				all: formData.all_packages,

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -74,18 +74,12 @@ export const fetchLabelsData = ( orderId, siteId ) => ( dispatch ) => {
 	dispatch( { type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_IS_FETCHING, orderId, siteId, isFetching: true } );
 
 	api.get( siteId, api.url.orderLabels( orderId ) )
-		.then( ( { formData, labelsData, paperSize, storeOptions, paymentMethod, numPaymentMethods, enabled } ) => {
+		.then( ( data ) => {
 			dispatch( {
 				type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_INIT,
 				siteId,
 				orderId,
-				formData,
-				labelsData,
-				paperSize,
-				storeOptions,
-				paymentMethod,
-				numPaymentMethods,
-				enabled,
+				...data,
 			} );
 		} )
 		.catch( ( error ) => {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -73,10 +73,10 @@ const generateUniqueBoxId = ( keyBase, boxIds ) => {
 const reducers = {};
 
 reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_INIT ] =
-	( state, { formData, labelsData, paperSize, storeOptions, paymentMethod, numPaymentMethods, enabled } ) => {
+	( state, actionData ) => {
 		return {
 			...state,
-			...initializeLabelsState( formData, labelsData, paperSize, storeOptions, paymentMethod, numPaymentMethods, enabled ),
+			...initializeLabelsState( omit( actionData, 'type', 'siteId' ) ),
 		};
 	};
 


### PR DESCRIPTION
Related to https://github.com/Automattic/woocommerce-services/pull/1148

Allows the plugin's PHP code to control whether the country dropdown on the label modal is enabled. This change should be backwards compatible, i.e. the current release on the plugin should still work after this change to Calypso is released.

To test:
On Calypso:
* nothing should change with the current plugin release - the country dropdown should still be disabled when purchasing the labels

On WCS:
* checkout https://github.com/Automattic/woocommerce-services/pull/1148
* `npm link` to this branch of Calypso
* the country dropdown should allow you to select US or Puerto Rico