### PR TITLE
Activity Log: deactivate Download backup menu item when one is under progress

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -132,7 +132,7 @@ class ActivityLogDay extends Component {
 	 * @returns { object } Button to display.
 	 */
 	renderRewindButton( type = '' ) {
-		const { disableRestore, disableBackup, hideRestore, isToday } = this.props;
+		const { disableRestore, hideRestore, isToday } = this.props;
 
 		if ( hideRestore || isToday ) {
 			return null;
@@ -142,9 +142,7 @@ class ActivityLogDay extends Component {
 			<Button
 				className="activity-log-day__rewind-button"
 				compact
-				disabled={
-					disableBackup || disableRestore || ! this.props.isRewindActive || this.state.rewindHere
-				}
+				disabled={ disableRestore || ! this.props.isRewindActive || this.state.rewindHere }
 				onClick={ this.handleClickRestore }
 				primary={ 'primary' === type }
 			>

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -514,7 +514,7 @@ class ActivityLog extends Component {
 			[ 'queued', 'running' ],
 			get( this.props, [ 'restoreProgress', 'status' ] )
 		);
-		const disableBackup = 0 < get( this.props, [ 'backupProgress', 'percent' ], 0 );
+		const disableBackup = 0 <= get( this.props, [ 'backupProgress', 'progress' ], -Infinity );
 
 		const restoreConfirmDialog = requestedRestoreActivity && (
 			<ActivityLogConfirmDialog


### PR DESCRIPTION
Previously when a backup was created the Download backup menu item was still clickable. This PR amends that and disables it when a backup creation is under progress:

#### Before
<img width="313" alt="captura de pantalla 2017-11-20 a la s 12 20 14" src="https://user-images.githubusercontent.com/1041600/33025641-4b854ac2-cded-11e7-9e90-730da410332b.png">

#### After
<img width="343" alt="captura de pantalla 2017-11-20 a la s 12 07 00" src="https://user-images.githubusercontent.com/1041600/33025574-22dc5de0-cded-11e7-82fd-f63f36510e60.png">
