### PR TITLE
Components: avoid synchronous layout reflows in SectionNavTabs

### DIFF
--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -16,6 +16,7 @@ import { debounce } from 'lodash';
 import DropdownItem from 'components/select-dropdown/item';
 import SelectDropdown from 'components/select-dropdown';
 import viewport from 'lib/viewport';
+import afterLayoutFlush from 'lib/after-layout-flush';
 
 /**
  * Internal Variables
@@ -42,18 +43,20 @@ class NavTabs extends Component {
 	};
 
 	componentDidMount() {
-		this.setDropdown();
-		this.debouncedAfterResize = debounce( this.setDropdown, 300 );
-
-		window.addEventListener( 'resize', this.debouncedAfterResize );
+		this.setDropdownAfterLayoutFlush();
+		window.addEventListener( 'resize', this.setDropdownDebounced );
 	}
 
 	componentDidUpdate() {
-		this.setDropdown();
+		this.setDropdownAfterLayoutFlush();
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'resize', this.debouncedAfterResize );
+		window.removeEventListener( 'resize', this.setDropdownDebounced );
+		// cancel the debounced `setDropdown` calls that might be already scheduled.
+		// see https://lodash.com/docs/4.17.4#debounce to learn about the `cancel` method.
+		this.setDropdownDebounced.cancel();
+		this.setDropdownAfterLayoutFlush.cancel();
 	}
 
 	render() {
@@ -151,6 +154,14 @@ class NavTabs extends Component {
 			} );
 		}
 	};
+
+	setDropdownDebounced = debounce( this.setDropdown, 300 );
+
+	// setDropdown reads element sizes from DOM. If called synchronously in the middle of a React
+	// update, it causes a synchronous layout reflow, doing the layout two or more times instead
+	// of just once after all the DOM writes are finished. Prevent that by scheduling the call
+	// just *after* the next layout flush.
+	setDropdownAfterLayoutFlush = afterLayoutFlush( this.setDropdown );
 
 	keyHandler = event => {
 		switch ( event.keyCode ) {

--- a/client/lib/after-layout-flush/README.md
+++ b/client/lib/after-layout-flush/README.md
@@ -1,0 +1,62 @@
+`afterLayoutFlush`
+=================
+
+This module exports a function that creates a wrapper to invoke a function as soon as possible
+after the next layout flush.At that time, it is very unlikely that the DOM has been written to
+since the last layout and it should be safe to read from DOM without causing a synchronous reflow,
+i.e., cheaply and without any performance hit.
+
+Inspired by a MDN article about [Firefox performance best practices](https://developer.mozilla.org/en-US/Firefox/Performance_best_practices_for_Firefox_fe_engineers)
+
+## Usage
+
+Very useful to read from up-to-date DOM after a React component is updated:
+
+```js
+class NavTabs extends Component {
+	state = {
+		isDropdown: false
+	};
+
+	setDropdown = () => {
+		// measure the rendered elements to determine style. Reads from DOM (!)
+		const isDropdown = this.containerEl.offsetWidth < this.tabsEl.offsetWidth;
+		if ( this.state.isDropdown !== isDropdown ) {
+			this.setState( { isDropDown } );
+		}
+	}
+
+	// postpone reading from DOM after all DOM writes are done and layout is flushed
+	setDropdownAfterLayout = afterLayoutFlush( this.setDropdown );
+
+	componentDidMount() {
+		// check the rendered element sizes after mount, but wait until after layout
+		this.setDropdownAfterLayout();
+	}
+
+	componentDidUpdate() {
+		// check the rendered element sizes after update, but wait until after layout
+		this.setDropdownAfterLayout();
+	}
+
+	componentWillUnmount() {
+		// cancel the `setDropdown` calls that are potentially scheduled to be executed.
+		// Prevents calling the method on an already unmounted component.
+		this.setDropdownAfterLayout.cancel();
+	}
+
+	render() {
+		// render inner element with a className that depends on `state.isDropdown`
+		return (
+			<div ref={ el => this.containerEl = el }>
+				<div
+					className={ this.state.isDropdown ? 'dropdown' : 'tabs' }
+					ref={ el => this.tabsEl = el }
+				>
+				 { this.props.children }
+				</div>
+			</div>
+		);
+	}
+}
+```

--- a/client/lib/after-layout-flush/index.js
+++ b/client/lib/after-layout-flush/index.js
@@ -1,0 +1,69 @@
+/** @format */
+
+/**
+ * Creates a delayed function that invokes `func` as soon as possible after the next layout
+ * flush. At that time, it is very unlikely that the DOM has been written to since the last
+ * layout and it should be safe to read from DOM without causing a synchronous reflow, i.e.,
+ * cheaply and without any performance hit.
+ *
+ * The returned wrapped function comes with a `cancel` method that cancels the delayed invocations.
+ *
+ * Inspired by the Firefox performance best practices MDN article at:
+ * https://developer.mozilla.org/en-US/Firefox/Performance_best_practices_for_Firefox_fe_engineers
+ *
+ * @param {Function} func The function to be invoked after the layout flush
+ * @returns {Function} Returns the new delayed function
+ */
+export default function afterLayoutFlush( func ) {
+	let rafHandle = undefined;
+	let timeoutHandle = undefined;
+
+	const scheduleRAF = rafFunc => () => {
+		// if a RAF is already scheduled and not yet executed, don't schedule another one
+		if ( rafHandle !== undefined ) {
+			return;
+		}
+
+		rafHandle = requestAnimationFrame( () => {
+			// clear the handle to signal that the scheduled RAF has been executed
+			rafHandle = undefined;
+			rafFunc();
+		} );
+	};
+
+	const scheduleTimeout = timeoutFunc => () => {
+		// If a timeout is already scheduled and not yet executed, don't schedule another one.
+		// Multiple `requestAnimationFrame` handlers can be scheduled and executed before the
+		// browser decides to finally execute the timeout handler.
+		if ( timeoutHandle !== undefined ) {
+			return;
+		}
+
+		timeoutHandle = setTimeout( () => {
+			// clear the handle to signal that the timeout handler has been executed
+			timeoutHandle = undefined;
+			timeoutFunc();
+		}, 0 );
+	};
+
+	// if RAF is not supported (in Node.js test environment), the wrapped function
+	// will only set a timeout.
+	let wrappedFunc = scheduleTimeout( func );
+	if ( typeof requestAnimationFrame === 'function' ) {
+		wrappedFunc = scheduleRAF( wrappedFunc );
+	}
+
+	wrappedFunc.cancel = () => {
+		if ( rafHandle !== undefined ) {
+			cancelAnimationFrame( rafHandle );
+			rafHandle = undefined;
+		}
+
+		if ( timeoutHandle !== undefined ) {
+			clearTimeout( timeoutHandle );
+			timeoutHandle = undefined;
+		}
+	};
+
+	return wrappedFunc;
+}


### PR DESCRIPTION
After component update or window resize, `SectionNavTabs` checks the DOM element sizes and decides if it should switch between the "tabs" and "dropdown" views. This happens synchronously in `componentDidMount`/`DidUpdate` while React is processing updates and can force a synchronous layout flush before React does all the DOM writes it wants to do. Layout is then done twice and more.

This patch postpones the DOM check after the next layout -- by registering a `requestAnimationFrame` callback (executed right before the next layout) and then calling `setTimeout(0)` from it (executed as soon after the next layout as possible).

I learned about this technique in this [MDN article about Firefox frontend-perf best practices](https://developer.mozilla.org/en-US/Firefox/Performance_best_practices_for_Firefox_fe_engineers).

**How to test:**
1. Go to `/posts/:siteId` for some site with a lot of posts
2. Scroll down to force loading more posts
3. Record a performance profile during this process in Chrome Devtools

Without the patch, you'll see a profile like this:
<img width="882" alt="sync-layout" src="https://user-images.githubusercontent.com/664258/33031481-acbcefc6-ce1e-11e7-8d20-1548de2607b8.png">
Notice the sync layout done in the middle of a React update, followed immediately by more React updates. It takes 13ms for me, 10% of the time it takes to add a new page of results to the posts list.

With the patch, the sync layout should disappear.

This should improve performance of dispatching the `POSTS_RECEIVE` action. Partially by avoiding the layout and partially by postponing part of the work into its own event loop tick. This avoids clogging the event loop and gets us closer to the ideal 60fps.
