### PR TITLE
Store Orders: Add helper to convert order object to the format expected by API

### DIFF
--- a/client/extensions/woocommerce/lib/currency/index.js
+++ b/client/extensions/woocommerce/lib/currency/index.js
@@ -22,3 +22,22 @@ export function getCurrencyFormatDecimal( number, currency = 'USD' ) {
 	}
 	return Math.round( number * Math.pow( 10, precision ) ) / Math.pow( 10, precision );
 }
+
+/**
+ * Get the string representation of a floating point number to the precision used by a given currency.
+ * This is different from `formatCurrency` by not returning the currency symbol.
+ *
+ * @param {Number|String} number A floating point number (or integer), or string that converts to a number
+ * @param {String} currency A 3-character currency label, e.g. 'GBP' – see `getCurrencyDefaults`
+ * @return {String} The original number rounded to a decimal point
+ */
+export function getCurrencyFormatString( number, currency = 'USD' ) {
+	const { precision } = getCurrencyDefaults( currency );
+	if ( 'number' !== typeof number ) {
+		number = parseFloat( number );
+	}
+	if ( isNaN( number ) ) {
+		return '';
+	}
+	return number.toFixed( precision );
+}

--- a/client/extensions/woocommerce/lib/currency/test/index.js
+++ b/client/extensions/woocommerce/lib/currency/test/index.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { getCurrencyFormatDecimal } from '../index';
+import { getCurrencyFormatDecimal, getCurrencyFormatString } from '../index';
 
 describe( 'getCurrencyFormatDecimal', () => {
 	it( 'should be a function', () => {
@@ -41,5 +41,39 @@ describe( 'getCurrencyFormatDecimal', () => {
 		expect( getCurrencyFormatDecimal( 'abc', 'USD' ) ).to.eql( 0 );
 		expect( getCurrencyFormatDecimal( false, 'USD' ) ).to.eql( 0 );
 		expect( getCurrencyFormatDecimal( null, 'USD' ) ).to.eql( 0 );
+	} );
+} );
+
+describe( 'getCurrencyFormatString', () => {
+	it( 'should be a function', () => {
+		expect( getCurrencyFormatString ).to.be.a( 'function' );
+	} );
+
+	it( 'should round a number to 2 decimal places in USD', () => {
+		expect( getCurrencyFormatString( 9.49258, 'USD' ) ).to.eql( '9.49' );
+		expect( getCurrencyFormatString( 30, 'USD' ) ).to.eql( '30.00' );
+		expect( getCurrencyFormatString( 3.0002, 'USD' ) ).to.eql( '3.00' );
+	} );
+
+	it( 'should round a number to 2 decimal places in GBP', () => {
+		expect( getCurrencyFormatString( 8.9272, 'GBP' ) ).to.eql( '8.93' );
+		expect( getCurrencyFormatString( 11, 'GBP' ) ).to.eql( '11.00' );
+		expect( getCurrencyFormatString( 7.0002, 'GBP' ) ).to.eql( '7.00' );
+	} );
+
+	it( 'should round a number to 0 decimal places in JPY', () => {
+		expect( getCurrencyFormatString( 1239.88, 'JPY' ) ).to.eql( '1240' );
+		expect( getCurrencyFormatString( 1500, 'JPY' ) ).to.eql( '1500' );
+		expect( getCurrencyFormatString( 33715.02, 'JPY' ) ).to.eql( '33715' );
+	} );
+
+	it( 'should correctly convert and round a string', () => {
+		expect( getCurrencyFormatString( '19.80', 'USD' ) ).to.eql( '19.80' );
+	} );
+
+	it( "should return empty string when given an input that isn't a number", () => {
+		expect( getCurrencyFormatString( 'abc', 'USD' ) ).to.eql( '' );
+		expect( getCurrencyFormatString( false, 'USD' ) ).to.eql( '' );
+		expect( getCurrencyFormatString( null, 'USD' ) ).to.eql( '' );
 	} );
 } );

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -9,7 +9,12 @@ import { omitBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { DEFAULT_QUERY, getNormalizedOrdersQuery, removeTemporaryIds } from './utils';
+import {
+	DEFAULT_QUERY,
+	getNormalizedOrdersQuery,
+	removeTemporaryIds,
+	transformOrderForApi,
+} from './utils';
 import { areOrdersLoaded, areOrdersLoading, isOrderLoaded, isOrderLoading } from './selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import request from '../request';
@@ -136,7 +141,7 @@ export const updateOrder = ( siteId, { id: orderId, ...order } ) => ( dispatch, 
 		siteId = getSelectedSiteId( state );
 	}
 
-	order = removeTemporaryIds( order );
+	order = transformOrderForApi( removeTemporaryIds( order ) );
 
 	const updateAction = {
 		type: WOOCOMMERCE_ORDER_UPDATE,

--- a/client/extensions/woocommerce/state/sites/orders/utils.js
+++ b/client/extensions/woocommerce/state/sites/orders/utils.js
@@ -2,7 +2,12 @@
 /**
  * External dependencies
  */
-import { omitBy, isNumber, omit } from 'lodash';
+import { forEach, isEmpty, isNumber, omit, omitBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrencyFormatDecimal, getCurrencyFormatString } from 'woocommerce/lib/currency';
 
 export const DEFAULT_QUERY = {
 	page: 1,
@@ -57,4 +62,101 @@ export function removeTemporaryIds( order ) {
 	}
 
 	return newOrder;
+}
+
+/**
+ * Convert all order values to the type expected by the API
+ *
+ * @param  {Object} order  Order object
+ * @return {Object}        Order object, with no temporary IDs
+ */
+export function transformOrderForApi( order ) {
+	const totalsAndTaxes = [
+		'cart_tax',
+		'discount_total',
+		'discount_tax',
+		'shipping_total',
+		'shipping_tax',
+		'total',
+		'total_tax',
+	];
+	forEach( totalsAndTaxes, key => {
+		order[ key ] = getCurrencyFormatString( order[ key ], order.currency );
+	} );
+
+	const transformOrderData = ( data, strings = [], prices = [], integers = [], floats = [] ) => {
+		return data.map( line => {
+			forEach( strings, key => {
+				if ( isNumber( line[ key ] ) || line[ key ] ) {
+					line[ key ] = line[ key ].toString();
+				}
+			} );
+			forEach( prices, key => {
+				if ( isNumber( line[ key ] ) || line[ key ] ) {
+					line[ key ] = getCurrencyFormatString( line[ key ], order.currency );
+				}
+			} );
+			forEach( integers, key => {
+				if ( isNumber( line[ key ] ) || line[ key ] ) {
+					line[ key ] = parseInt( line[ key ] );
+				}
+			} );
+			forEach( floats, key => {
+				if ( isNumber( line[ key ] ) || line[ key ] ) {
+					line[ key ] = getCurrencyFormatDecimal( line[ key ], order.currency );
+				}
+			} );
+			return line;
+		} );
+	};
+
+	// line_items
+	if ( ! isEmpty( order.line_items ) ) {
+		order.line_items = transformOrderData(
+			order.line_items,
+			[ 'name', 'tax_class' ],
+			[ 'subtotal', 'subtotal_tax', 'total', 'total_tax' ],
+			[ 'product_id', 'variation_id', 'quantity' ],
+			[ 'price' ]
+		);
+	}
+
+	// shipping_lines
+	if ( ! isEmpty( order.shipping_lines ) ) {
+		order.shipping_lines = transformOrderData(
+			order.shipping_lines,
+			[ 'method_title', 'method_id' ],
+			[ 'total', 'total_tax' ]
+		);
+	}
+
+	// fee_lines
+	if ( ! isEmpty( order.fee_lines ) ) {
+		order.fee_lines = transformOrderData(
+			order.fee_lines,
+			[ 'name', 'tax_class', 'tax_status' ],
+			[ 'total', 'total_tax' ]
+		);
+	}
+
+	// coupon_lines
+	if ( ! isEmpty( order.coupon_lines ) ) {
+		order.coupon_lines = transformOrderData(
+			order.coupon_lines,
+			[ 'code' ],
+			[ 'discount', 'discount_tax' ]
+		);
+	}
+
+	//refunds
+	if ( ! isEmpty( order.refunds ) ) {
+		order.refunds = transformOrderData( order.refunds, [ 'reason' ], [ 'total' ] );
+	}
+
+	// Remove the email if it's set to an empty string (considered "invalid" on API).
+	if ( order.billing && order.billing.email === '' ) {
+		delete order.billing.email;
+	}
+
+	return order;
 }

--- a/client/extensions/woocommerce/state/sites/orders/utils.js
+++ b/client/extensions/woocommerce/state/sites/orders/utils.js
@@ -81,7 +81,9 @@ export function transformOrderForApi( order ) {
 		'total_tax',
 	];
 	forEach( totalsAndTaxes, key => {
-		order[ key ] = getCurrencyFormatString( order[ key ], order.currency );
+		if ( isNumber( order[ key ] ) || order[ key ] ) {
+			order[ key ] = getCurrencyFormatString( order[ key ], order.currency );
+		}
 	} );
 
 	const transformOrderData = ( data, strings = [], prices = [], integers = [], floats = [] ) => {


### PR DESCRIPTION
As of WP 4.9, API requests are being deeply validated against the defined schema. This increased checking means we need to make sure the values we pass into the API are the correct type. This PR introduces a helper function `transformOrderForApi` which runs over the order object before it's sent to the API and converts various fields to the expected types. For example, we use floating point numbers for almost all prices, so that we can do math correctly, but the API expects strings for these fields.

To this end I've also introduced `getCurrencyFormatString`, which works like `getCurrencyFormatDecimal` but returns a string.

**To test**

I've included tests for `getCurrencyFormatString` &  `transformOrderForApi`, you can run those with:

`npm run test-client client/extensions/woocommerce`

To test the API saving itself, edit and save an order 

- Edit an order
- Delete a product
- Add a new product
- Add a fee
- Change the shipping value
- Save, and hopefully see the success message 🙂 