### PR TITLE
People & Plugins: use regepx for routes

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -37,8 +37,8 @@ export default {
 		next();
 	},
 
-	people( filter, context ) {
-		renderPeopleList( filter, context );
+	people( context ) {
+		renderPeopleList( context );
 	},
 
 	invitePeople( context ) {
@@ -59,8 +59,11 @@ function redirectToTeam( context ) {
 	page.redirect( '/people/team' );
 }
 
-function renderPeopleList( filter, context ) {
-	context.store.dispatch( setTitle( i18n.translate( 'People', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+function renderPeopleList( context ) {
+	const filter = context.params.filter;
+
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( i18n.translate( 'People', { textOnly: true } ) ) );
 
 	renderWithReduxStore(
 		React.createElement( PeopleList, {

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -13,16 +13,15 @@ import peopleController from './controller';
 
 export default function() {
 	if ( config.isEnabled( 'manage/people' ) ) {
-		[ 'team', 'followers', 'email-followers', 'viewers' ].forEach( function( filter ) {
-			page( '/people/' + filter, siteSelection, sites );
-			page(
-				'/people/' + filter + '/:site_id',
-				peopleController.enforceSiteEnding,
-				siteSelection,
-				navigation,
-				peopleController.people.bind( null, filter )
-			);
-		} );
+		page( '/people/:filter(team|followers|email-followers|viewers)', siteSelection, sites );
+
+		page(
+			'/people/:filter(team|followers|email-followers|viewers)/:site_id',
+			peopleController.enforceSiteEnding,
+			siteSelection,
+			navigation,
+			peopleController.people
+		);
 
 		page(
 			'/people/new/:site_id',

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -187,17 +187,16 @@ function renderProvisionPlugins( context ) {
 
 const controller = {
 	plugins( context, next ) {
-		context.params.pluginFilter = context.params.pluginFilter || 'all';
+		const { pluginFilter: filter = 'all' } = context.params;
 		const siteUrl = route.getSiteFragment( context.path );
-		const basePath = route
-			.sectionify( context.path )
-			.replace( '/' + context.params.pluginFilter, '' );
+		const basePath = route.sectionify( context.path ).replace( '/' + filter, '' );
 
 		// bail if no site is selected and the user has no Jetpack sites.
 		if ( ! siteUrl && ! hasJetpackSites( context.store.getState() ) ) {
 			return next();
 		}
 
+		context.params.pluginFilter = filter;
 		notices.clearNotices( 'notices' );
 		renderPluginList( context, basePath );
 	},

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -186,16 +186,18 @@ function renderProvisionPlugins( context ) {
 }
 
 const controller = {
-	plugins( filter, context, next ) {
+	plugins( context, next ) {
+		context.params.pluginFilter = context.params.pluginFilter || 'all';
 		const siteUrl = route.getSiteFragment( context.path );
-		const basePath = route.sectionify( context.path ).replace( '/' + filter, '' );
+		const basePath = route
+			.sectionify( context.path )
+			.replace( '/' + context.params.pluginFilter, '' );
 
 		// bail if no site is selected and the user has no Jetpack sites.
 		if ( ! siteUrl && ! hasJetpackSites( context.store.getState() ) ) {
 			return next();
 		}
 
-		context.params.pluginFilter = filter;
 		notices.clearNotices( 'notices' );
 		renderPluginList( context, basePath );
 	},
@@ -233,11 +235,11 @@ const controller = {
 		renderWithReduxStore( <PluginUpload />, document.getElementById( 'primary' ), context.store );
 	},
 
-	jetpackCanUpdate( filter, context, next ) {
+	jetpackCanUpdate( context, next ) {
 		const selectedSites = getSelectedOrAllSitesWithPlugins( context.store.getState() );
 		let redirectToPlugins = false;
 
-		if ( 'updates' === filter && selectedSites.length ) {
+		if ( 'updates' === context.params.pluginFilter && selectedSites.length ) {
 			redirectToPlugins = ! some( selectedSites, function( site ) {
 				return site && site.jetpack && site.canUpdateFiles;
 			} );

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -68,19 +68,17 @@ export default function() {
 			siteSelection,
 			navigation,
 			ifSimpleSiteThenRedirectTo( '/plugins' ),
-			pluginsController.plugins.bind( null, 'all' ),
+			pluginsController.plugins,
 			sites
 		);
 
-		[ 'active', 'inactive', 'updates' ].forEach( filter =>
-			page(
-				`/plugins/${ filter }/:site_id?`,
-				siteSelection,
-				navigation,
-				pluginsController.jetpackCanUpdate.bind( null, filter ),
-				pluginsController.plugins.bind( null, filter ),
-				sites
-			)
+		page(
+			'/plugins/:pluginFilter(active|inactive|updates)/:site_id?',
+			siteSelection,
+			navigation,
+			pluginsController.jetpackCanUpdate,
+			pluginsController.plugins,
+			sites
 		);
 
 		page(


### PR DESCRIPTION
Make route definitions tad bit more readable by using regexp and get rid of `.bind()` in middlewares.

This will also make running single-tree-rendering codemod on these files easier, as these route definitions would look just like any other route definitions (without that `bind()`).

### Test

Check everything works well via:

`/people`
  → change between "team", "followers", "email followers" and "viewers". If viewers isn't visible, just append it to URL.

`/plugins/manage`
`/plugins/manage/:site`
  → change between "all", "active", "inactive" & "updates".