### PR TITLE
Store: Record page views for store paths.

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -12,6 +12,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import App from './app';
 import Dashboard from './app/dashboard';
 import EmptyContent from 'components/empty-content';
@@ -174,6 +175,22 @@ function addStorePage( storePage, storeNavigation ) {
 		const component = React.createElement( storePage.container, { params: context.params } );
 		const appProps =
 			( storePage.documentTitle && { documentTitle: storePage.documentTitle } ) || {};
+
+		let analyticsPath = storePage.path;
+		const { filter } = context.params;
+		if ( filter ) {
+			analyticsPath = analyticsPath.replace( ':filter', filter );
+		}
+
+		let analyticsPageTitle = 'Store';
+		if ( storePage.documentTitle ) {
+			analyticsPageTitle += ` > ${ storePage.documentTitle }`;
+		} else {
+			analyticsPageTitle += ' > Dashboard';
+		}
+
+		analytics.pageView.record( analyticsPath, analyticsPageTitle );
+
 		renderWithReduxStore(
 			React.createElement( App, appProps, component ),
 			document.getElementById( 'primary' ),


### PR DESCRIPTION
In our last meeting (p90Yrv-qc-p2), the following question was asked:

> Do we need page tracking in tracks? Stats has it. Does Calypso already track that information?

It turns out there is a utility for this `analytics.pageView.record`, but we need to be calling it in the store code ([example for the job manager code](https://github.com/Automattic/wp-calypso/blob/5f15f3365213253724ca0d8798c6cb8160f00bc9/client/extensions/wp-job-manager/app/controller.js#L39)). 

This PR adds the necessary code to track page views on store routes.

To Test:
* Load up this branch in your browser, and open the developer console.
* Enter `localStorage.setItem('debug', 'calypso:analytics:*');`(per the [README](https://github.com/Automattic/wp-calypso/blob/281e4d53e828266c63ba67498fa3f683c3299c21/client/lib/analytics/README.md#analytics)).
* Navigate to some store routes, and make sure the `calypso_page_view` event is fired. Navigate between routes, and make sure the path is present in the debug.