### PR TITLE
Allow some mods to the signup framework from flows and steps

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -111,12 +111,18 @@ export class NavigationLink extends Component {
 
 		if ( this.props.direction === 'back' ) {
 			backGridicon = <Gridicon icon="arrow-left" size={ 18 } />;
-			text = this.props.translate( 'Back' );
+			text =
+				'undefined' !== typeof this.props.labelText
+					? this.props.labelText
+					: this.props.translate( 'Back' );
 		}
 
 		if ( this.props.direction === 'forward' ) {
 			forwardGridicon = <Gridicon icon="arrow-right" size={ 18 } />;
-			text = this.props.translate( 'Skip for now' );
+			text =
+				'undefined' !== typeof this.props.labelText
+					? this.props.labelText
+					: this.props.translate( 'Skip for now' );
 		}
 
 		return (

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -23,10 +23,15 @@ export class NavigationLink extends Component {
 		goToNextStep: PropTypes.func,
 		direction: PropTypes.oneOf( [ 'back', 'forward' ] ),
 		flowName: PropTypes.string.isRequired,
+		labelText: PropTypes.string,
 		positionInFlow: PropTypes.number,
 		previousPath: PropTypes.string,
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string.isRequired,
+	};
+
+	static defaultProps = {
+		labelText: '',
 	};
 
 	/**
@@ -111,18 +116,12 @@ export class NavigationLink extends Component {
 
 		if ( this.props.direction === 'back' ) {
 			backGridicon = <Gridicon icon="arrow-left" size={ 18 } />;
-			text =
-				'undefined' !== typeof this.props.labelText
-					? this.props.labelText
-					: this.props.translate( 'Back' );
+			text = this.props.labelText ? this.props.labelText : this.props.translate( 'Back' );
 		}
 
 		if ( this.props.direction === 'forward' ) {
 			forwardGridicon = <Gridicon icon="arrow-right" size={ 18 } />;
-			text =
-				'undefined' !== typeof this.props.labelText
-					? this.props.labelText
-					: this.props.translate( 'Skip for now' );
+			text = this.props.labelText ? this.props.labelText : this.props.translate( 'Skip for now' );
 		}
 
 		return (

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -104,6 +104,8 @@ export class NavigationLink extends Component {
 	}
 
 	render() {
+		const { translate, labelText } = this.props;
+
 		if (
 			this.props.positionInFlow === 0 &&
 			this.props.direction === 'back' &&
@@ -116,12 +118,12 @@ export class NavigationLink extends Component {
 
 		if ( this.props.direction === 'back' ) {
 			backGridicon = <Gridicon icon="arrow-left" size={ 18 } />;
-			text = this.props.labelText ? this.props.labelText : this.props.translate( 'Back' );
+			text = labelText ? labelText : translate( 'Back' );
 		}
 
 		if ( this.props.direction === 'forward' ) {
 			forwardGridicon = <Gridicon icon="arrow-right" size={ 18 } />;
-			text = this.props.labelText ? this.props.labelText : this.props.translate( 'Skip for now' );
+			text = labelText ? labelText : translate( 'Skip for now' );
 		}
 
 		return (

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -34,6 +34,7 @@ class StepWrapper extends Component {
 				stepSectionName={ this.props.stepSectionName }
 				backUrl={ this.props.backUrl }
 				signupProgress={ this.props.signupProgress }
+				labelText={ this.props.backLabelText }
 			/>
 		);
 	}
@@ -47,6 +48,7 @@ class StepWrapper extends Component {
 					defaultDependencies={ this.props.defaultDependencies }
 					flowName={ this.props.flowName }
 					stepName={ this.props.stepName }
+					labelText={ this.props.skipLabelText }
 				/>
 			);
 		}
@@ -81,23 +83,25 @@ class StepWrapper extends Component {
 	}
 
 	render() {
-		const { stepContent, headerButton } = this.props;
+		const { stepContent, headerButton, hideFormattedHeader, hideBack, hideSkip } = this.props;
 		const classes = classNames( 'step-wrapper', {
 			'is-wide-layout': this.props.isWideLayout,
 		} );
 
 		return (
 			<div className={ classes }>
-				<FormattedHeader headerText={ this.headerText() } subHeaderText={ this.subHeaderText() }>
-					{ headerButton }
-				</FormattedHeader>
+				{ ! hideFormattedHeader && (
+					<FormattedHeader headerText={ this.headerText() } subHeaderText={ this.subHeaderText() }>
+						{ headerButton }
+					</FormattedHeader>
+				) }
 
 				<div className="step-wrapper__content is-animated-content">
 					{ stepContent }
 
 					<div className="step-wrapper__buttons">
-						{ this.renderBack() }
-						{ this.renderSkip() }
+						{ ! hideBack && this.renderBack() }
+						{ ! hideSkip && this.renderSkip() }
 					</div>
 				</div>
 			</div>

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -19,6 +19,9 @@ class StepWrapper extends Component {
 	static propTypes = {
 		shouldHideNavButtons: PropTypes.bool,
 		translate: PropTypes.func.isRequired,
+		hideFormattedHeader: PropTypes.bool,
+		hideBack: PropTypes.bool,
+		hideSkip: PropTypes.bool,
 	};
 
 	renderBack() {


### PR DESCRIPTION
- Allow Back and Skip text to be modified
- Ability to hide the formatted header
- Ability to hide the back and skip buttons individually

Testing Instructions:
1. Load up several Start flows, and ensure the skip and back buttons display and function correctly
2. Load up several Start flows and ensure the formatted headers all appear correctly
