### PR TITLE
Add pressable NUX credentials interstitial

### DIFF
--- a/assets/stylesheets/sections/signup.scss
+++ b/assets/stylesheets/sections/signup.scss
@@ -11,6 +11,9 @@
 @import 'signup/processing-screen/style';
 @import 'signup/step-wrapper/style';
 @import 'signup/steps/about/style';
+@import 'signup/steps/creds-permission/style';
+@import 'signup/steps/creds-confirm/style';
+@import 'signup/steps/creds-complete/style';
 @import 'signup/steps/design-type-with-store/pressable-store/style';
 @import 'signup/steps/design-type-with-store/style';
 @import 'signup/steps/design-type-with-atomic-store/style';

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -248,6 +248,18 @@ const flows = {
 		description: 'Used by `get.blog` users that connect their site to WordPress.com',
 		lastModified: '2016-11-14',
 	},
+
+	'pressable-nux': {
+		steps: [ 'creds-permission', 'creds-confirm', 'creds-complete' ],
+		destination: () => {
+			return '/stats';
+		},
+		description: 'Allow new Pressable users to grant permission to server credentials',
+		lastModified: '2017-11-20',
+		disallowResume: true,
+		allowContinue: false,
+		hideFlowProgress: true,
+	},
 };
 
 if ( config.isEnabled( 'signup/atomic-store-flow' ) ) {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -6,6 +6,9 @@
 
 import config from 'config';
 import AboutStepComponent from 'signup/steps/about';
+import CredsConfirmComponent from 'signup/steps/creds-confirm';
+import CredsCompleteComponent from 'signup/steps/creds-complete';
+import CredsPermissionComponent from 'signup/steps/creds-permission';
 import DesignTypeComponent from 'signup/steps/design-type';
 import DesignTypeWithStoreComponent from 'signup/steps/design-type-with-store';
 import DesignTypeWithAtomicStoreComponent from 'signup/steps/design-type-with-atomic-store';
@@ -25,6 +28,9 @@ import PlansAtomicStoreComponent from 'signup/steps/plans-atomic-store';
 
 export default {
 	about: AboutStepComponent,
+	'creds-confirm': CredsConfirmComponent,
+	'creds-complete': CredsCompleteComponent,
+	'creds-permission': CredsPermissionComponent,
 	'design-type': DesignTypeComponent,
 	'design-type-with-store': DesignTypeWithStoreComponent,
 	'design-type-with-store-nux': DesignTypeWithAtomicStoreComponent,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -247,4 +247,19 @@ export default {
 		],
 		delayApiRequestUntilComplete: true,
 	},
+
+	'creds-complete': {
+		stepName: 'creds-complete',
+		providesDependencies: [],
+	},
+
+	'creds-confirm': {
+		stepName: 'creds-confirm',
+		providesDependencies: [],
+	},
+
+	'creds-permission': {
+		stepName: 'creds-permission',
+		providesDependencies: [],
+	},
 };

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -517,17 +517,19 @@ class Signup extends React.Component {
 		}
 
 		const flow = flows.getFlow( this.props.flowName );
+		const showProgressIndicator = 'pressable-nux' === this.props.flowName ? false : true;
 
 		return (
 			<span>
 				<DocumentHead title={ this.pageTitle() } />
-				{ ! this.state.loadingScreenStartTime && (
-					<FlowProgressIndicator
-						positionInFlow={ this.positionInFlow() }
-						flowLength={ flow.steps.length }
-						flowName={ this.props.flowName }
-					/>
-				) }
+				{ ! this.state.loadingScreenStartTime &&
+					showProgressIndicator && (
+						<FlowProgressIndicator
+							positionInFlow={ this.positionInFlow() }
+							flowLength={ flow.steps.length }
+							flowName={ this.props.flowName }
+						/>
+					) }
 				<ReactCSSTransitionGroup
 					className="signup__steps"
 					transitionName="signup__step"

--- a/client/signup/steps/creds-complete/index.jsx
+++ b/client/signup/steps/creds-complete/index.jsx
@@ -1,0 +1,71 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import StepWrapper from 'signup/step-wrapper';
+import Card from 'components/card';
+
+class CredsCompleteStep extends Component {
+	static propTypes = {
+		flowName: PropTypes.string,
+		goToNextStep: PropTypes.func.isRequired,
+		positionInFlow: PropTypes.number,
+		signupProgress: PropTypes.array,
+		stepName: PropTypes.string,
+	};
+
+	renderStepContent = () => {
+		const { translate, wpAdminUrl } = this.props;
+
+		return (
+			<Card className="creds-complete__card">
+				<h3 className="creds-complete__title">{ translate( 'Your site is set up and ready!' ) }</h3>
+				<img className="creds-complete__image" src="/calypso/images/upgrades/thank-you.svg" />
+				<p className="creds-complete__description">
+					{ translate(
+						'Your site is backing up because your site is set up with Jetpack Premium plan at ' +
+							'no additional cost to you. Finish setting up Jetpack and your site is ready to be ' +
+							'transformed into the site of your dreams.'
+					) }
+				</p>
+				<a className="creds-complete__button" href={ wpAdminUrl }>
+					{ translate( 'Continue' ) }
+				</a>
+			</Card>
+		);
+	};
+
+	render() {
+		return (
+			<StepWrapper
+				flowName={ this.props.flowName }
+				stepName={ this.props.stepName }
+				positionInFlow={ this.props.positionInFlow }
+				signupProgress={ this.props.signupProgress }
+				stepContent={ this.renderStepContent() }
+				goToNextStep={ this.skipStep }
+				hideFormattedHeader={ true }
+				hideBack={ true }
+				hideSkip={ true }
+			/>
+		);
+	}
+}
+
+export default connect( ( state, ownProps ) => {
+	const blogId = get( ownProps, [ 'initialContext', 'query', 'blogid' ], 0 );
+	const blogUrl = get( state, [ 'sites', 'items', blogId, 'URL' ], false );
+
+	return {
+		wpAdminUrl: blogUrl ? blogUrl + '/wp-admin/' : false,
+	};
+}, null )( localize( CredsCompleteStep ) );

--- a/client/signup/steps/creds-complete/style.scss
+++ b/client/signup/steps/creds-complete/style.scss
@@ -1,0 +1,28 @@
+.creds-complete__card {
+	text-align: center;
+	max-width: 640px;
+	padding: 4rem;
+	margin-top: 1px;
+	padding-bottom: 3rem;
+}
+
+.creds-complete__title {
+	display: inline-block;
+	font-size: 2.5rem;
+	font-weight: 300;
+	letter-spacing: .15rem;
+	color: $gray-text;
+}
+
+.creds-complete__image {
+	max-width: 140px;
+	display: block;
+	margin: 2rem auto;
+}
+
+.creds-complete__description {
+	color: $gray-text-min;
+	font-size: 1.4rem;
+	font-weight: 100;
+	line-height: 2.5rem;
+} 

--- a/client/signup/steps/creds-confirm/index.jsx
+++ b/client/signup/steps/creds-confirm/index.jsx
@@ -39,10 +39,6 @@ class CredsConfirmStep extends Component {
 		this.props.goToStep( 'creds-complete' );
 	};
 
-	contactSupport = () => {
-		// open happychat
-	};
-
 	renderStepContent = () => {
 		const { translate } = this.props;
 
@@ -56,7 +52,6 @@ class CredsConfirmStep extends Component {
 							'support staff is available to answer any questions you might have.'
 					) }
 				</p>
-				<Button onClick={ this.contactSupport }>{ translate( 'Contact support' ) }</Button>
 				<Button primary onClick={ this.shareCredentials }>
 					{ translate( 'Share credentials' ) }
 				</Button>

--- a/client/signup/steps/creds-confirm/index.jsx
+++ b/client/signup/steps/creds-confirm/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
 import StepWrapper from 'signup/step-wrapper';
 import Card from 'components/card';
 import Button from 'components/button';
+import SignupActions from 'lib/signup/actions';
 import { autoConfigCredentials } from 'state/jetpack/credentials/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -35,7 +36,14 @@ class CredsConfirmStep extends Component {
 
 	shareCredentials = () => {
 		this.autoConfigCredentials();
+
 		this.props.recordTracksEvent( 'calypso_pressable_nux_credentials_share', {} );
+
+		SignupActions.submitSignupStep( {
+			processingMessage: this.props.translate( 'Setting up your site' ),
+			stepName: this.props.stepName,
+		} );
+
 		this.props.goToStep( 'creds-complete' );
 	};
 

--- a/client/signup/steps/creds-confirm/index.jsx
+++ b/client/signup/steps/creds-confirm/index.jsx
@@ -1,0 +1,87 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import StepWrapper from 'signup/step-wrapper';
+import Card from 'components/card';
+import Button from 'components/button';
+import { autoConfigCredentials } from 'state/jetpack/credentials/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+class CredsConfirmStep extends Component {
+	static propTypes = {
+		flowName: PropTypes.string,
+		goToNextStep: PropTypes.func.isRequired,
+		positionInFlow: PropTypes.number,
+		signupProgress: PropTypes.array,
+		stepName: PropTypes.string,
+	};
+
+	autoConfigCredentials = () =>
+		this.props.autoConfigCredentials( this.props.initialContext.query.blogid );
+
+	skipStep = () => {
+		this.props.recordTracksEvent( 'calypso_pressable_nux_credentials_skip', {} );
+		this.props.goToNextStep();
+	};
+
+	shareCredentials = () => {
+		this.autoConfigCredentials();
+		this.props.recordTracksEvent( 'calypso_pressable_nux_credentials_share', {} );
+		this.props.goToStep( 'creds-complete' );
+	};
+
+	contactSupport = () => {
+		// open happychat
+	};
+
+	renderStepContent = () => {
+		const { translate } = this.props;
+
+		return (
+			<Card className="creds-confirm__card">
+				<h3 className="creds-confirm__title">{ translate( 'Are you sure?' ) }</h3>
+				<img className="creds-confirm__image" src="/calypso/images/illustrations/security.svg" />
+				<p className="creds-confirm__description">
+					{ translate(
+						"If you don't share credentials with Jetpack, your site won't be backed up. Our " +
+							'support staff is available to answer any questions you might have.'
+					) }
+				</p>
+				<Button onClick={ this.contactSupport }>{ translate( 'Contact support' ) }</Button>
+				<Button primary onClick={ this.shareCredentials }>
+					{ translate( 'Share credentials' ) }
+				</Button>
+			</Card>
+		);
+	};
+
+	render() {
+		return (
+			<StepWrapper
+				flowName={ this.props.flowName }
+				stepName={ this.props.stepName }
+				positionInFlow={ this.props.positionInFlow }
+				signupProgress={ this.props.signupProgress }
+				stepContent={ this.renderStepContent() }
+				goToNextStep={ this.skipStep }
+				hideFormattedHeader={ true }
+				skipLabelText="Skip"
+				hideBack={ true }
+			/>
+		);
+	}
+}
+
+export default connect( null, {
+	autoConfigCredentials,
+	recordTracksEvent,
+} )( localize( CredsConfirmStep ) );

--- a/client/signup/steps/creds-confirm/style.scss
+++ b/client/signup/steps/creds-confirm/style.scss
@@ -1,0 +1,32 @@
+.creds-confirm__card {
+	text-align: center;
+	max-width: 640px;
+	padding: 4rem;
+	margin-top: 1px;
+	padding-bottom: 3rem;
+}
+
+.creds-confirm__title {
+	display: inline-block;
+	font-size: 2.5rem;
+	font-weight: 300;
+	letter-spacing: .15rem;
+	color: $gray-text;
+}
+
+.creds-confirm__description {
+	color: $gray-text-min;
+	font-size: 1.5rem;
+	font-weight: 100;
+	line-height: 2.5rem;
+}
+
+.creds-confirm__image {
+	max-width: 200px;
+	display: block;
+	margin: 2rem auto;
+}
+
+.creds-confirm .button.is-primary {
+	margin-left: 1rem;
+} 

--- a/client/signup/steps/creds-permission/index.jsx
+++ b/client/signup/steps/creds-permission/index.jsx
@@ -14,6 +14,7 @@ import StepWrapper from 'signup/step-wrapper';
 import Card from 'components/card';
 import Button from 'components/button';
 import QuerySites from 'components/data/query-sites';
+import SignupActions from 'lib/signup/actions';
 import { autoConfigCredentials } from 'state/jetpack/credentials/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -33,7 +34,14 @@ class CredsPermissionStep extends Component {
 
 	shareCredentials = () => {
 		this.autoConfigCredentials();
+		
 		this.props.recordTracksEvent( 'calypso_pressable_nux_credentials_share', {} );
+		
+		SignupActions.submitSignupStep( {
+			processingMessage: this.props.translate( 'Setting up your site' ),
+			stepName: this.props.stepName,
+		} );
+
 		this.props.goToStep( 'creds-complete' );
 	};
 

--- a/client/signup/steps/creds-permission/index.jsx
+++ b/client/signup/steps/creds-permission/index.jsx
@@ -1,0 +1,83 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import StepWrapper from 'signup/step-wrapper';
+import Card from 'components/card';
+import Button from 'components/button';
+import QuerySites from 'components/data/query-sites';
+import { autoConfigCredentials } from 'state/jetpack/credentials/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+class CredsPermissionStep extends Component {
+	static propTypes = {
+		flowName: PropTypes.string,
+		goToNextStep: PropTypes.func.isRequired,
+		positionInFlow: PropTypes.number,
+		signupProgress: PropTypes.array,
+		stepName: PropTypes.string,
+	};
+
+	autoConfigCredentials = () =>
+		this.props.autoConfigCredentials( this.props.initialContext.query.blogid );
+
+	skipStep = () => this.props.goToNextStep();
+
+	shareCredentials = () => {
+		this.autoConfigCredentials();
+		this.props.recordTracksEvent( 'calypso_pressable_nux_credentials_share', {} );
+		this.props.goToStep( 'creds-complete' );
+	};
+
+	renderStepContent = () => {
+		const { translate } = this.props;
+
+		return (
+			<Card className="creds-permission__card">
+				<QuerySites />
+				<h3 className="creds-permission__title">{ translate( 'Start backing up your site' ) }</h3>
+				<img className="creds-permission__image" src="/calypso/images/illustrations/security.svg" />
+				<p className="creds-permission__description">
+					{ translate(
+						'Jetpack, a plugin already on your site, can back up and secure your site at no ' +
+							'extra cost to you thanks to our partnership with Pressable. To start backing up ' +
+							"your site, we need the credentials for your site's server. Do you want to give " +
+							"Jetpack access to your host's server to perform backups?"
+					) }
+				</p>
+				<Button primary onClick={ this.shareCredentials }>
+					{ translate( 'Share credentials' ) }
+				</Button>
+			</Card>
+		);
+	};
+
+	render() {
+		return (
+			<StepWrapper
+				flowName={ this.props.flowName }
+				stepName={ this.props.stepName }
+				positionInFlow={ this.props.positionInFlow }
+				signupProgress={ this.props.signupProgress }
+				stepContent={ this.renderStepContent() }
+				goToNextStep={ this.skipStep }
+				hideFormattedHeader={ true }
+				skipLabelText="Skip"
+				hideBack={ true }
+			/>
+		);
+	}
+}
+
+export default connect( null, {
+	autoConfigCredentials,
+	recordTracksEvent,
+} )( localize( CredsPermissionStep ) );

--- a/client/signup/steps/creds-permission/index.jsx
+++ b/client/signup/steps/creds-permission/index.jsx
@@ -34,9 +34,9 @@ class CredsPermissionStep extends Component {
 
 	shareCredentials = () => {
 		this.autoConfigCredentials();
-		
+
 		this.props.recordTracksEvent( 'calypso_pressable_nux_credentials_share', {} );
-		
+
 		SignupActions.submitSignupStep( {
 			processingMessage: this.props.translate( 'Setting up your site' ),
 			stepName: this.props.stepName,

--- a/client/signup/steps/creds-permission/style.scss
+++ b/client/signup/steps/creds-permission/style.scss
@@ -1,0 +1,32 @@
+.creds-permission__card {
+	text-align: center;
+	max-width: 640px;
+	padding: 4rem;
+	margin-top: 1px;
+	padding-bottom: 3rem;
+}
+
+.creds-permission__title {
+	display: inline-block;
+	font-size: 2.5rem;
+	font-weight: 300;
+	letter-spacing: .15rem;
+	color: $gray-text;
+}
+
+.creds-permission__description {
+	color: $gray-text-min;
+	font-size: 1.35rem;
+	font-weight: 100;
+	line-height: 2.5rem;
+}
+
+.creds-permission__image {
+	max-width: 200px;
+	display: block;
+	margin: 2rem auto;
+}
+
+.creds-permission .button {
+	font-weight: 100;
+}


### PR DESCRIPTION
Adds a flow to signup framework which allows new Pressable users to authorize credentials during onboarding.

**Testing Instructions:**
1. Load up http://calypso.localhost:3000/start/pressable-nux?blogid=123456789 and substitute 123456789 with a Pressable hosted blog ID.
2. Ensure the flow works logically and all navigations work as expected.
3. Make sure your credentials are actually auto-configured by visiting Settings > Security after the flow.