### PR TITLE
Editor: enhance Location Selector for more granular selection (7459)

### DIFF
--- a/client/post-editor/editor-location/index.jsx
+++ b/client/post-editor/editor-location/index.jsx
@@ -18,11 +18,6 @@ import EditorLocationSearch from './search';
 import EditorLocationMap from './map';
 import Notice from 'components/notice';
 
-/**
- * Module variables
- */
-// const GOOGLE_MAPS_BASE_URL = 'https://maps.google.com/maps/api/staticmap?';
-
 class EditorLocation extends React.Component {
 	static displayName = 'EditorLocation';
 

--- a/client/post-editor/editor-location/index.jsx
+++ b/client/post-editor/editor-location/index.jsx
@@ -87,6 +87,7 @@ class EditorLocation extends React.Component {
 	};
 
 	onSearchSelect = result => {
+		this.resetError();
 		PostActions.updateMetadata( {
 			geo_latitude: result.geometry.location.lat,
 			geo_longitude: result.geometry.location.lng,

--- a/client/post-editor/editor-location/index.jsx
+++ b/client/post-editor/editor-location/index.jsx
@@ -7,7 +7,6 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import qs from 'querystring';
 
 /**
  * Internal dependencies
@@ -16,12 +15,13 @@ import PostActions from 'lib/posts/actions';
 import EditorDrawerWell from 'post-editor/editor-drawer-well';
 import { recordEvent, recordStat } from 'lib/posts/stats';
 import EditorLocationSearch from './search';
+import EditorLocationMap from './map';
 import Notice from 'components/notice';
 
 /**
  * Module variables
  */
-const GOOGLE_MAPS_BASE_URL = 'https://maps.google.com/maps/api/staticmap?';
+// const GOOGLE_MAPS_BASE_URL = 'https://maps.google.com/maps/api/staticmap?';
 
 class EditorLocation extends React.Component {
 	static displayName = 'EditorLocation';
@@ -29,7 +29,7 @@ class EditorLocation extends React.Component {
 	static propTypes = {
 		label: PropTypes.string,
 		coordinates: function( props, propName ) {
-			var prop = props[ propName ];
+			const prop = props[ propName ];
 			if (
 				prop &&
 				( ! Array.isArray( prop ) || 2 !== prop.length || 2 !== prop.filter( Number ).length )
@@ -103,19 +103,17 @@ class EditorLocation extends React.Component {
 			return;
 		}
 
-		const src =
-			GOOGLE_MAPS_BASE_URL +
-			qs.stringify( {
-				markers: this.props.coordinates.join( ',' ),
-				zoom: 8,
-				size: '400x300',
-			} );
-
-		return <img src={ src } className="editor-location__map" />;
+		return (
+			<EditorLocationMap
+				coordinates={ this.props.coordinates }
+				onError={ this.onGeolocateFailure }
+				onSelect={ this.onSearchSelect }
+			/>
+		);
 	};
 
 	render() {
-		var error, buttonText;
+		let error, buttonText;
 
 		if ( this.state.error ) {
 			error = (

--- a/client/post-editor/editor-location/map.jsx
+++ b/client/post-editor/editor-location/map.jsx
@@ -62,10 +62,11 @@ export default class extends React.Component {
 	}
 
 	componentDidUpdate() {
-		if ( this.map && this.props.coordinates ) {
+		const { coordinates } = this.props;
+		if ( this.map && coordinates.length > 1 ) {
 			this.setMarker( {
-				lat: this.props.coordinates[ 0 ],
-				lng: this.props.coordinates[ 1 ],
+				lat: coordinates[ 0 ],
+				lng: coordinates[ 1 ],
 			} );
 		}
 	}

--- a/client/post-editor/editor-location/map.jsx
+++ b/client/post-editor/editor-location/map.jsx
@@ -1,0 +1,111 @@
+/** @format */
+/* global google */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import qs from 'querystring';
+
+export default class extends React.Component {
+	static displayName = 'EditorLocationMap';
+
+	mapRef = undefined;
+	map = undefined;
+	marker = undefined;
+
+	static propTypes = {
+		coordinates: PropTypes.array,
+		onError: PropTypes.func,
+		onSelect: PropTypes.func,
+	};
+
+	static defaultProps = {
+		coordinates: [],
+		onError: () => {},
+		onSelect: () => {},
+	};
+
+	componentDidMount() {
+		// Connect the initMap() function within this class to the global window
+		// context, so Google Maps can invoke it
+		window.initMap = this.initMap.bind( this );
+
+		const src =
+			'https://maps.googleapis.com/maps/api/js?' +
+			qs.stringify( {
+				key: 'INSERT-API-KEY-HERE',
+				callback: 'initMap',
+			} );
+
+		// Asynchronously load the Google Maps script, passing in the callback reference.
+		// This dumps the `google` var into the global scope, which is not fun, but the only way.
+		loadJS( src );
+	}
+
+	initMap() {
+		const markerPosition = {
+			lat: this.props.coordinates[ 0 ],
+			lng: this.props.coordinates[ 1 ],
+		};
+
+		this.map = new google.maps.Map( this.mapRef, {
+			zoom: 12,
+			center: markerPosition,
+		} );
+
+		// This event listener will call setMarker() when the map is clicked.
+		this.map.addListener( 'click', event => {
+			this.setMarker( event.latLng );
+		} );
+
+		// Adds a marker at the center of the map.
+		this.setMarker( markerPosition );
+	}
+
+	// Adds a marker to the map
+	setMarker( location ) {
+		this.deleteMarker();
+
+		this.marker = new google.maps.Marker( {
+			position: location,
+			map: this.map,
+		} );
+
+		this.props.onSelect( {
+			geometry: {
+				location: {
+					lat: typeof location.lat === 'function' ? location.lat() : location.lat,
+					lng: typeof location.lng === 'function' ? location.lng() : location.lng,
+				},
+			},
+		} );
+	}
+
+	// Deletes all markers in the array by removing references to them.
+	deleteMarker() {
+		if ( this.marker ) {
+			this.marker.setMap( null );
+			this.marker = undefined;
+		}
+	}
+
+	render() {
+		const mapRef = el => ( this.mapRef = el );
+		return (
+			<div>
+				<div ref={ mapRef } style={ { maxWidth: 400, height: 300 } } />
+			</div>
+		);
+	}
+}
+
+function loadJS( src ) {
+	const ref = window.document.getElementsByTagName( 'script' )[ 0 ];
+	const script = window.document.createElement( 'script' );
+	script.src = src;
+	script.async = true;
+	ref.parentNode.insertBefore( script, ref );
+}

--- a/client/post-editor/editor-location/map.jsx
+++ b/client/post-editor/editor-location/map.jsx
@@ -94,9 +94,7 @@ export default class extends React.Component {
 	render() {
 		const mapRef = el => ( this.mapRef = el );
 		return (
-			<div>
-				<div ref={ mapRef } style={ { maxWidth: 400, height: 300 } } />
-			</div>
+			<div ref={ mapRef } style={ { maxWidth: 400, height: 300 } } />
 		);
 	}
 }


### PR DESCRIPTION
This adds an embedded Google Map to the post editor sidebar to allow for more granular location selection. Clicking the map sets the geolocation for the post.

This is for issue #7459 and still a work in progress. Opening this PR for feedback.

One thing I'm not sure about is how to handle the API key. Anyone running it locally would have to use their own, as putting an API key directly in the source is a bad idea. I'm thinking the build process for the official Calypso release would need to include an Automattic API key, but I don't know how that would be handled.

Here's a gif of this in action:

![google-map-enhanced-location](https://user-images.githubusercontent.com/136891/33040746-04b52c76-ce0a-11e7-93ba-0e1ddb757f4c.gif)
