### PR TITLE
Store Orders: Enforce a positive quantity on products when editing

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -112,7 +112,7 @@ class OrderDetailsTable extends Component {
 		}
 		const index = findIndex( order.line_items, { id } );
 		// A zero quantity does strange things with the price, so we'll force 1
-		const quantity = parseInt( event.target.value ) || 1;
+		const quantity = Math.abs( event.target.value ) || 1;
 		const subtotal = getOrderItemCost( order, id ) * quantity;
 		const total = subtotal;
 		const newItem = { ...item, quantity, subtotal, total };


### PR DESCRIPTION
Fixes #19908 – This removes the ability to enter a negative quantity of an item.

To test

- Edit an "Awaiting Payment" order
- Try to enter a negative value in the quantity input
- You shouldn't be able to, either by arrow keys or trying to enter a `-` in the input. It will flip the value to positive, or not let you enter the character.