### PR TITLE
PostRevisions: Ensure placeholder is not shown on dialog close

### DIFF
--- a/client/post-editor/editor-revisions/dialog.jsx
+++ b/client/post-editor/editor-revisions/dialog.jsx
@@ -15,7 +15,7 @@ import { getPostRevisionsSelectedRevision, isPostRevisionsDialogVisible } from '
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { closePostRevisionsDialog } from 'state/posts/revisions/actions';
+import { closePostRevisionsDialog, selectPostRevision } from 'state/posts/revisions/actions';
 import EditorRevisions from 'post-editor/editor-revisions';
 import Dialog from 'components/dialog';
 
@@ -45,6 +45,7 @@ class PostRevisionsDialog extends PureComponent {
 
 	componentWillMount() {
 		this.toggleBodyClass( { isVisible: this.props.isVisible } );
+		this.props.selectPostRevision( null );
 	}
 
 	componentWillUpdate( { isVisible } ) {
@@ -116,6 +117,6 @@ export default flow(
 			revision: getPostRevisionsSelectedRevision( state ),
 			siteId: getSelectedSiteId( state ),
 		} ),
-		{ recordTracksEvent, closeDialog: closePostRevisionsDialog }
+		{ recordTracksEvent, closeDialog: closePostRevisionsDialog, selectPostRevision }
 	)
 )( PostRevisionsDialog );

--- a/client/state/posts/revisions/reducer.js
+++ b/client/state/posts/revisions/reducer.js
@@ -58,7 +58,6 @@ export function selection( state = {}, action ) {
 			return { ...state, revisionId: action.revisionId };
 		}
 		case POST_EDIT:
-		case POST_REVISIONS_DIALOG_CLOSE:
 		case SELECTED_SITE_SET: {
 			return { ...state, revisionId: null };
 		}

--- a/client/state/posts/revisions/test/reducer.js
+++ b/client/state/posts/revisions/test/reducer.js
@@ -310,20 +310,6 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		test( 'should clear selection when closing dialog', () => {
-			const state = selection(
-				deepFreeze( {
-					revisionId: 1776,
-				} ),
-				{
-					type: POST_REVISIONS_DIALOG_CLOSE,
-				}
-			);
-			expect( state ).to.eql( {
-				revisionId: null,
-			} );
-		} );
-
 		test( 'should clear selection when editing post', () => {
 			const state = selection(
 				deepFreeze( {


### PR DESCRIPTION
### Summary
This PR looks to fix an issue observed when closing the revisions dialog, where the placeholder elements are rendered for a flash during the time between clicking close (deselects the selected revision) and the modal finishing its close transition.

### Testing
- Go to the editor, looking at a post with revisions.
- Open and close the modal
- Note that there is a placeholder state on opening the modal but not when closing.