### PR TITLE
Post Revisions: Update title diff height

### DIFF
--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -22,7 +22,7 @@
 		font-weight: 600;
 		margin: 0 0 24px 0;
 		height: auto;
-		line-height: 1.2;
+		line-height: 1.425;
 	}
 }
 


### PR DESCRIPTION
## This PR

fixes an issue where the diff highlighting would overlap on multiline titles 

## How to test

- Click the calypso.live link below or check out the branch locally
- Edit a post that has revisions
- Change the title to a very long title
- Click on the History button
- The title in the revision diff should look like the state that you can see in the after state below 

**Before:**

<img width="1177" alt="screen shot 2017-11-20 at 18 14 27" src="https://user-images.githubusercontent.com/1562646/33048273-a60b71a6-ce1f-11e7-9c06-d01cac4ec142.png">

**After:**

<img width="1177" alt="screen shot 2017-11-20 at 18 13 37" src="https://user-images.githubusercontent.com/1562646/33048287-b2b3b986-ce1f-11e7-855e-caef221176bb.png">
