### PR TITLE
Editor: Connect closeEditorSidebar directly instead of passing as prop

### DIFF
--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -4,14 +4,17 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import { flow } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
 import EditorPostType from 'post-editor/editor-post-type';
+import { closeEditorSidebar } from 'state/ui/editor/sidebar/actions';
 
 const EditorSidebarHeader = ( { closeSidebar, translate } ) => (
 	<div className="editor-sidebar__header">
@@ -33,4 +36,9 @@ EditorSidebarHeader.propTypes = {
 	closeSidebar: PropTypes.func,
 };
 
-export default localize( EditorSidebarHeader );
+export default flow(
+	localize,
+	connect( null, {
+		closeSidebar: closeEditorSidebar,
+	} )
+)( EditorSidebarHeader );

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -3,13 +3,11 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
-import { closeEditorSidebar } from 'state/ui/editor/sidebar/actions';
 import EditorDrawer from 'post-editor/editor-drawer';
 import EditorSidebarHeader from './header';
 import SidebarFooter from 'layout/sidebar/footer';
@@ -48,7 +46,7 @@ export class EditorSidebar extends Component {
 
 		return (
 			<div className="editor-sidebar">
-				<EditorSidebarHeader closeSidebar={ this.props.closeEditorSidebar } />
+				<EditorSidebarHeader />
 				<EditorActionBar isNew={ isNew } post={ post } savedPost={ savedPost } site={ site } />
 				<EditorDrawer
 					site={ site }
@@ -69,7 +67,4 @@ export class EditorSidebar extends Component {
 	}
 }
 
-export default connect( null, {
-	// TODO: connect this closer to its usage
-	closeEditorSidebar,
-} )( EditorSidebar );
+export default EditorSidebar;


### PR DESCRIPTION
### Summary
While working on #19766 I noticed that the `EditorSidebar` component was passing the `closeEditorSidebar` function to the `EditorSidebarHeader` as a prop without benefit. This PR removes the responsibility of connecting and passing this function from the sidebar to the header and gives the responsibility to the header itself.

### Testing
- Open the sidebar using the cog icon button and close it using the <kbd>x</kbd> button.
- The sidebar should open and close as expected.

Warning: This PR seems to be haunted... I've tried opening it a couple of times before and through rebasing I've somehow managed to see the PR close out automatically without any changes / commits. Spooky! 👻 👻 👻  