### PR TITLE
PostRevisions: Move closeDialog prop directly to dialog.jsx

### DIFF
--- a/client/post-editor/editor-ground-control/history-button.jsx
+++ b/client/post-editor/editor-ground-control/history-button.jsx
@@ -11,21 +11,16 @@ import { flow } from 'lodash';
 /**
  * Internal dependencies
  */
-import { closePostRevisionsDialog, openPostRevisionsDialog } from 'state/posts/revisions/actions';
+import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
 
 import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
 
-const HistoryButton = ( { loadRevision, postId, siteId, closeDialog, openDialog, translate } ) => (
+const HistoryButton = ( { loadRevision, postId, siteId, openDialog, translate } ) => (
 	<div className="editor-ground-control__history">
 		<button className="editor-ground-control__history-button button is-link" onClick={ openDialog }>
 			{ translate( 'History' ) }
 		</button>
-		<EditorRevisionsDialog
-			onClose={ closeDialog }
-			loadRevision={ loadRevision }
-			postId={ postId }
-			siteId={ siteId }
-		/>
+		<EditorRevisionsDialog loadRevision={ loadRevision } postId={ postId } siteId={ siteId } />
 	</div>
 );
 
@@ -33,7 +28,6 @@ HistoryButton.PropTypes = {
 	loadRevision: PropTypes.func.isRequired,
 
 	// connected to dispatch
-	closePostRevisionsDialog: PropTypes.func.isRequired,
 	openPostRevisionsDialog: PropTypes.func.isRequired,
 
 	// localize
@@ -43,7 +37,6 @@ HistoryButton.PropTypes = {
 export default flow(
 	localize,
 	connect( null, {
-		closeDialog: closePostRevisionsDialog,
 		openDialog: openPostRevisionsDialog,
 	} )
 )( HistoryButton );

--- a/client/post-editor/editor-revisions/dialog.jsx
+++ b/client/post-editor/editor-revisions/dialog.jsx
@@ -6,7 +6,7 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { get, flow, noop } from 'lodash';
+import { get, flow } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,7 +26,6 @@ class PostRevisionsDialog extends PureComponent {
 		 * @TODO untangle & reduxify
 		 */
 		loadRevision: PropTypes.func.isRequired,
-		onClose: PropTypes.func,
 
 		// connected to state
 		isVisible: PropTypes.bool.isRequired,
@@ -37,10 +36,6 @@ class PostRevisionsDialog extends PureComponent {
 
 		// localize
 		translate: PropTypes.func.isRequired,
-	};
-
-	static defaultProps = {
-		onClose: noop,
 	};
 
 	componentWillMount() {
@@ -93,14 +88,14 @@ class PostRevisionsDialog extends PureComponent {
 	};
 
 	render() {
-		const { isVisible, onClose } = this.props;
+		const { isVisible, closeDialog } = this.props;
 
 		return (
 			<Dialog
 				buttons={ this.dialogButtons() }
 				className="editor-revisions__dialog"
 				isVisible={ isVisible }
-				onClose={ onClose }
+				onClose={ closeDialog }
 			>
 				<EditorRevisions />
 			</Dialog>


### PR DESCRIPTION
### Summary
This PR aims to move `closeDialog` function to be connected directly in the dialog itself rather than passed down in an effort to make this component less coupled.

### Testing
- Open a post in the editor that has history
- Click the 'history' button
- Note that the dialog opens
- Click close button in the dialog
- Note that the dialog closes
- Click the 'history' button to open again
- Use the <kbd>esc</kbd> key
- Note that the dialog closes again
- Click the 'history' button to open once more
- 'load' a revision
- Note that the dialog closes again
