### PR TITLE
Rewind: Use data layer state awareness

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -602,14 +602,13 @@ class ActivityLog extends Component {
 				{ hasFirstBackup && this.renderMonthNavigation() }
 				{ this.renderActionProgress() }
 				{ ! isRewindActive && !! isPressable && <ActivityLogRewindToggle siteId={ siteId } /> }
-				{ requestData.logs.isLoading &&
-					! requestData.logs.hasLoaded && (
-						<section className="activity-log__wrapper">
-							<ActivityLogDayPlaceholder />
-							<ActivityLogDayPlaceholder />
-							<ActivityLogDayPlaceholder />
-						</section>
-					) }
+				{ ! requestData.logs.hasLoaded && (
+					<section className="activity-log__wrapper">
+						<ActivityLogDayPlaceholder />
+						<ActivityLogDayPlaceholder />
+						<ActivityLogDayPlaceholder />
+					</section>
+				) }
 				{ requestData.logs.hasLoaded &&
 					isEmpty( logs ) && (
 						<EmptyContent

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -36,6 +36,7 @@ import StatsNavigation from 'blocks/stats-navigation';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import SuccessBanner from '../activity-log-banner/success-banner';
 import { adjustMoment, getActivityLogQuery, getStartMoment } from './utils';
+import { activityLogRequest } from 'state/activity-log/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
@@ -51,6 +52,7 @@ import {
 	canCurrentUser,
 	getActivityLog,
 	getActivityLogs,
+	getRequest,
 	getRequestedRewind,
 	getRestoreProgress,
 	getRewindStatusError,
@@ -484,21 +486,20 @@ class ActivityLog extends Component {
 	render() {
 		const {
 			canViewActivityLog,
-			gmtOffset,
 			hasFirstBackup,
 			hasMainCredentials, // eslint-disable-line no-shadow
 			isPressable,
 			isRewindActive,
+			logRequestQuery,
 			logs,
 			moment,
+			requestData,
 			requestedRestoreActivity,
 			requestedRestoreActivityId,
 			requestedBackup,
 			requestedBackupId,
 			siteId,
 			slug,
-			startDate,
-			timezone,
 			translate,
 		} = this.props;
 
@@ -590,10 +591,7 @@ class ActivityLog extends Component {
 		return (
 			<Main wideLayout>
 				{ rewindEnabledByConfig && <QueryRewindStatus siteId={ siteId } /> }
-				<QueryActivityLog
-					siteId={ siteId }
-					{ ...getActivityLogQuery( { gmtOffset, startDate, timezone } ) }
-				/>
+				<QueryActivityLog siteId={ siteId } { ...logRequestQuery } />
 				<QuerySiteSettings siteId={ siteId } />
 				<QueryJetpackCredentials siteId={ siteId } />
 				<StatsFirstView />
@@ -604,14 +602,15 @@ class ActivityLog extends Component {
 				{ hasFirstBackup && this.renderMonthNavigation() }
 				{ this.renderActionProgress() }
 				{ ! isRewindActive && !! isPressable && <ActivityLogRewindToggle siteId={ siteId } /> }
-				{ isNull( logs ) && (
-					<section className="activity-log__wrapper">
-						<ActivityLogDayPlaceholder />
-						<ActivityLogDayPlaceholder />
-						<ActivityLogDayPlaceholder />
-					</section>
-				) }
-				{ ! isNull( logs ) &&
+				{ requestData.logs.isLoading &&
+					! requestData.logs.hasLoaded && (
+						<section className="activity-log__wrapper">
+							<ActivityLogDayPlaceholder />
+							<ActivityLogDayPlaceholder />
+							<ActivityLogDayPlaceholder />
+						</section>
+					) }
+				{ requestData.logs.hasLoaded &&
 					isEmpty( logs ) && (
 						<EmptyContent
 							title={ translate( 'No activity for %s', {
@@ -700,6 +699,7 @@ export default connect(
 		const timezone = getSiteTimezoneValue( state, siteId );
 		const requestedRestoreActivityId = getRequestedRewind( state, siteId );
 		const requestedBackupId = getRequestedBackup( state, siteId );
+		const logRequestQuery = getActivityLogQuery( { gmtOffset, startDate, timezone } );
 
 		return {
 			canViewActivityLog: canCurrentUser( state, siteId, 'manage_options' ),
@@ -707,6 +707,7 @@ export default connect(
 			hasFirstBackup: ! isEmpty( getRewindStartDate( state, siteId ) ),
 			hasMainCredentials: hasMainCredentials( state, siteId ),
 			isRewindActive: isRewindActiveSelector( state, siteId ),
+			logRequestQuery,
 			logs: getActivityLogs(
 				state,
 				siteId,
@@ -718,6 +719,7 @@ export default connect(
 			requestedBackupId,
 			restoreProgress: getRestoreProgress( state, siteId ),
 			backupProgress: getBackupProgress( state, siteId ),
+			requestData: { logs: getRequest( state, activityLogRequest( siteId, logRequestQuery ) ) },
 			rewindStatusError: getRewindStatusError( state, siteId ),
 			siteId,
 			siteTitle: getSiteTitle( state, siteId ),

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -85,6 +85,11 @@ export function activityLogRequest( siteId, params ) {
 		type: ACTIVITY_LOG_REQUEST,
 		params,
 		siteId,
+		meta: {
+			dataLayer: {
+				trackRequest: true,
+			},
+		},
 	};
 }
 


### PR DESCRIPTION
> ~Depends on #20079~ (merged)

This is part of a bigger project to update the state mechanisms for Activity Log events.

Activity Log events are currently stored in a `QueryManager()` and are paged by month.
The presence of events in a given month is inferred by a tri-state for the queried month;
that is, if the results are `null` we assume we haven't gathered them yet but if they are
an empty list then we assume we _have_ fetched them but there are no actual events.

This works well during initial page loads but it also depends on clearing out the state in
order to show loading indicators. This clearing results in an unexpected flash of data and
correspondingly means that we are over-fetching data.

In this PR we're using the new request tracking inside the data layer to more granularly
know about when requests are in progress. As a first step to the bigger refactoring we
will use the request tracking information to indicate loading states instead of the inferred
values. As we continue to expand our use of the activity log this will be more important
because events are intrinsically placed along a timeline but not intrinsically placed into
month buckets; searching and filtering will depend on operating efficiently outside of
these classifications.

I took several approach in this code to build up to what is here so far:
 - passing data out of the query component via a callback was simple and kept the concerns well isolated. the parent component could do whatever if wanted with the request state changes. unfortunately the parent component didn't know to re-render on those state changes and so I was somehow losing them. because this approach also suffers from hiding data relationships I abandoned it.
 - passing data down as props to the children of the query component made the props and data relationships explicit and also addressed the re-rendering issue, but I found that it was an inappropriate parent/child relationship. I really wanted the props to be send to the parent of the query component but that meant I needed to wrap the parent entirely vs leaving the query component inside the parent's `render()` function. although I think this approach is more ideal, it needs work before it's practical. I'd like to explore creating a wrapper so we can use our query components as the selectors and the requesters in a way we expect inside of `connect()`

This final approach is a bit more verbose and smashes together some implementation-details, though they were actually there already before.

There is a **behavioral change** in here that's purely a result of a _choice_ and not a requirement in this PR: only show the fading placeholders on the initial load. I found the placeholders to be awkward when mixed in with the list of events when we stop clearing out the state on every month navigation or page load.

---

There are a few small fixes to the request tracking that I discovered only after using this API. Namely I realized that we need to continue to track `lastUpdated` even when currently waiting for a request to finish.

I've added a new selector, `getRequest()` but I hope to split this off into a separate PR, just as the above change.