### PR TITLE
Login: Adds a data attribute to magic link for e2e tests

### DIFF
--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -138,7 +138,12 @@ export class LoginLinks extends React.Component {
 		}
 
 		return (
-			<a href="#" key="magic-login-link" onClick={ this.handleMagicLoginLinkClick }>
+			<a
+				href="#"
+				key="magic-login-link"
+				data-e2e-link="magic-login-link"
+				onClick={ this.handleMagicLoginLinkClick }
+			>
 				{ this.props.translate( 'Email me a login link' ) }
 			</a>
 		);


### PR DESCRIPTION
Adds a data attribute to the magic link on the logon page

No changed functionality

Testing Instructions

1. Visit https://calypso.live/log-in?branch=add/magic-link-data-attribute in a new window
2. Check the magic link button has a `data-e2e-link` property of `magic-login-link`
