### PR TITLE
Domains/cctlds: add organization field to fr-form

### DIFF
--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -210,9 +210,10 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 						autoCorrect="off"
 						placeholder={ '' }
 						onChange={ this.handleChangeContactEvent }
-						isError={ Boolean( validationErrors.organization ) }
+						isError={ Boolean( contactDetailsValidationErrors.organization ) }
 					/>
-					{ validationErrors.organization && translate( 'Organization field is required' ) }
+					{ contactDetailsValidationErrors.organization &&
+						renderValidationError( translate( 'Organization field is required' ) ) }
 				</FormFieldset>
 
 				<FormFieldset>

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -196,10 +196,23 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 			renderValidationError( trademarkNumberStrings[ error ] )
 		);
 
+		// Note organization is the level above the other extra fields
+		const organizationValidationStrings = {
+			maxLength: translate( 'Too long, please limit the organization name to 100 characters.' ),
+			not: translate( 'Please use only the characters “{{validCharacters}}”',
+				{ args: { validCharacters: 'a-z A-Z 0-9 . , ( ) @ & \' - [space]' } }
+			),
+			$ref: translate( 'Organization field is required' ),
+		};
+
+		const organizationValidationMessage = map( contactDetailsValidationErrors.organization, error =>
+			renderValidationError( organizationValidationStrings[ error ] )
+		);
+
 		return (
 			<div>
 				<FormFieldset>
-					<FormLabel className="registrant-extra-info__optional" htmlFor="organization">
+					<FormLabel className="registrant-extra-info" htmlFor="organization">
 						{ translate( 'Organization Name' ) }
 					</FormLabel>
 					<FormTextInput
@@ -210,10 +223,9 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 						autoCorrect="off"
 						placeholder={ '' }
 						onChange={ this.handleChangeContactEvent }
-						isError={ Boolean( contactDetailsValidationErrors.organization ) }
+						isError={ Boolean( ! isEmpty( organizationValidationMessage ) ) }
 					/>
-					{ contactDetailsValidationErrors.organization &&
-						renderValidationError( translate( 'Organization field is required' ) ) }
+					{ organizationValidationMessage }
 				</FormFieldset>
 
 				<FormFieldset>

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -90,11 +90,19 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		} );
 	}
 
-	handleChangeEvent = event => {
+	handleChangeContactEvent = event => {
 		const field = event.target.id;
 		const value = this.sanitizeField( event.target.value, field );
 
 		debug( 'Setting ' + field + ' to ' + value );
+		this.props.updateContactDetailsCache( { [ field ]: value } );
+	};
+
+	handleChangeContactExtraEvent = event => {
+		const field = event.target.id;
+		const value = this.sanitizeField( event.target.value, field );
+
+		debug( 'Setting extra.' + field + ' to ' + value );
 		this.props.updateContactDetailsCache( {
 			extra: { [ field ]: value },
 		} );
@@ -119,7 +127,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 							value="individual"
 							id="registrantType"
 							checked={ 'individual' === registrantType }
-							onChange={ this.handleChangeEvent }
+							onChange={ this.handleChangeContactExtraEvent }
 						/>
 						<span>{ translate( 'An individual' ) }</span>
 					</FormLabel>
@@ -129,7 +137,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 							value="organization"
 							id="registrantType"
 							checked={ 'organization' === registrantType }
-							onChange={ this.handleChangeEvent }
+							onChange={ this.handleChangeContactExtraEvent }
 						/>
 						<span>{ translate( 'A company or organization' ) }</span>
 					</FormLabel>
@@ -191,6 +199,23 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		return (
 			<div>
 				<FormFieldset>
+					<FormLabel className="registrant-extra-info__optional" htmlFor="organization">
+						{ translate( 'Organization Name' ) }
+					</FormLabel>
+					<FormTextInput
+						id="organization"
+						value={ contactDetails.organization }
+						autoCapitalize="off"
+						autoComplete="off"
+						autoCorrect="off"
+						placeholder={ '' }
+						onChange={ this.handleChangeContactEvent }
+						isError={ Boolean( validationErrors.organization ) }
+					/>
+					{ validationErrors.organization && translate( 'Organization field is required' ) }
+				</FormFieldset>
+
+				<FormFieldset>
 					<FormLabel className="registrant-extra-info__optional" htmlFor="registrantVatId">
 						{ translate( 'VAT Number' ) }
 						{ this.renderOptional() }
@@ -202,7 +227,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 						autoComplete="off"
 						autoCorrect="off"
 						placeholder={ translate( 'ex. FRXX123456789' ) }
-						onChange={ this.handleChangeEvent }
+						onChange={ this.handleChangeContactExtraEvent }
 						isError={ Boolean( registrantVatIdValidationMessage ) }
 					/>
 					{ registrantVatIdValidationMessage }
@@ -226,7 +251,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 						autoComplete="off"
 						autoCorrect="off"
 						isError={ Boolean( sirenSiretValidationMessage ) }
-						onChange={ this.handleChangeEvent }
+						onChange={ this.handleChangeContactExtraEvent }
 					/>
 					{ sirenSiretValidationMessage }
 				</FormFieldset>
@@ -249,7 +274,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 							comment: 'ex is short for example. The number is the EU trademark number format.',
 						} ) }
 						isError={ ! isEmpty( trademarkNumberValidationMessage ) }
-						onChange={ this.handleChangeEvent }
+						onChange={ this.handleChangeContactExtraEvent }
 					/>
 					{ trademarkNumberValidationMessage }
 				</FormFieldset>

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -199,9 +199,9 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		// Note organization is the level above the other extra fields
 		const organizationValidationStrings = {
 			maxLength: translate( 'Too long, please limit the organization name to 100 characters.' ),
-			not: translate( 'Please use only the characters “{{validCharacters}}”',
-				{ args: { validCharacters: 'a-z A-Z 0-9 . , ( ) @ & \' - [space]' } }
-			),
+			not: translate( 'Please use only the characters “%(validCharacters)s”', {
+				args: { validCharacters: "a-z A-Z 0-9 . , ( ) @ & ' - [space]" },
+			} ),
 			$ref: translate( 'Organization field is required' ),
 		};
 

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -212,7 +212,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		return (
 			<div>
 				<FormFieldset>
-					<FormLabel className="registrant-extra-info" htmlFor="organization">
+					<FormLabel className="registrant-extra-info__organization" htmlFor="organization">
 						{ translate( 'Organization Name' ) }
 					</FormLabel>
 					<FormTextInput

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -9,7 +9,18 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
-import { castArray, defaults, get, identity, isEmpty, isString, map, noop, toUpper } from 'lodash';
+import {
+	castArray,
+	defaults,
+	get,
+	identity,
+	isEmpty,
+	isString,
+	map,
+	noop,
+	set,
+	toUpper,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -90,22 +101,18 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		} );
 	}
 
-	handleChangeContactEvent = event => {
-		const field = event.target.id;
-		const value = this.sanitizeField( event.target.value, field );
-
+	updateContactDetails( field, value ) {
+		const sanitizedValue = this.sanitizeField( field, value );
 		debug( 'Setting ' + field + ' to ' + value );
-		this.props.updateContactDetailsCache( { [ field ]: value } );
+		this.props.updateContactDetailsCache( set( {}, field, sanitizedValue ) );
+	}
+
+	handleChangeContactEvent = event => {
+		this.updateContactDetails( event.target.id, event.target.value );
 	};
 
 	handleChangeContactExtraEvent = event => {
-		const field = event.target.id;
-		const value = this.sanitizeField( event.target.value, field );
-
-		debug( 'Setting extra.' + field + ' to ' + value );
-		this.props.updateContactDetailsCache( {
-			extra: { [ field ]: value },
-		} );
+		this.updateContactDetails( `extra.${ event.target.id }`, event.target.value );
 	};
 
 	render() {
@@ -303,7 +310,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		);
 	}
 
-	sanitizeField( value, field ) {
+	sanitizeField( field, value ) {
 		return ( this.sanitizeFunctions[ field ] || identity )( value );
 	}
 }

--- a/client/components/domains/registrant-extra-info/fr-schema.json
+++ b/client/components/domains/registrant-extra-info/fr-schema.json
@@ -35,6 +35,11 @@
 		{
 			"type": "object",
 			"properties": {
+				"organization": {
+					"type": "string",
+					"not": { "pattern": "[^a-zA-Z0-9.,()@&' -]" },
+					"maxLength": 100
+				},
 				"extra": {
 					"type": "object",
 					"properties": {

--- a/client/components/domains/registrant-extra-info/fr-schema.json
+++ b/client/components/domains/registrant-extra-info/fr-schema.json
@@ -11,9 +11,8 @@
 				}
 			]
 		},
-		"organizationRequiredForIndividualTypeOrganization": {
+		"organizationIsRequiredWhenRegistrantTypeIsOrganization": {
 			"not": {
-				"comment": "",
 				"properties": {
 					"extra": {
 						"properties": {
@@ -31,7 +30,7 @@
 
 	"type": "object",
 	"allOf": [
-		{ "$ref": "#/definitions/organizationRequiredForIndividualTypeOrganization" },
+		{ "$ref": "#/definitions/organizationIsRequiredWhenRegistrantTypeIsOrganization" },
 		{
 			"type": "object",
 			"properties": {

--- a/client/components/domains/registrant-extra-info/fr-schema.json
+++ b/client/components/domains/registrant-extra-info/fr-schema.json
@@ -9,70 +9,93 @@
 					"maxLength": 0
 				}
 			]
-		}
-	},
-
-	"type": "object",
-	"properties": {
-		"extra": {
-			"type": "object",
-			"properties": {
-				"sirenSiret": {
-					"type": "string",
-					"pattern": "^[0-9]*$",
-					"anyOf": [
-						{ "minLength": 9, "maxLength": 9 },
-						{ "minLength": 14, "maxLength": 14 },
-						{ "$ref": "#/definitions/empty" }
-					]
-				},
-				"registrantType": {
-					"enum": [ "individual", "organization" ]
-				},
-				"registrantVatId": {
-					"type": "string",
-					"anyOf": [
-						{ "pattern": "^(AT)U[0-9]{8}$" },
-						{ "pattern": "^(BE)0[0-9]{9}$" },
-						{ "pattern": "^(BG)[0-9]{9,10}$" },
-						{ "pattern": "^(CY)[0-9]{8}L$" },
-						{ "pattern": "^(CZ)[0-9]{8,10}$" },
-						{ "pattern": "^(DE)[0-9]{9}$" },
-						{ "pattern": "^(DK)[0-9]{8}$" },
-						{ "pattern": "^(EE)[0-9]{9}$" },
-						{ "pattern": "^(EL|GR)[0-9]{9}$" },
-						{ "pattern": "^(ES)[0-9A-Z][0-9]{7}[0-9A-Z]$" },
-						{ "pattern": "^(FI)[0-9]{8}$" },
-						{ "pattern": "^(FR)[0-9A-Z]{2}[0-9]{9}$" },
-						{ "pattern": "^(GB)([0-9]{9}([0-9]{3})?|(GD|HA)[0-9]{3})$" },
-						{ "pattern": "^(HR)[0-9]{11}$" },
-						{ "pattern": "^(HU)[0-9]{8}$" },
-						{ "pattern": "^(IE)([0-9][0-9A-Z+*][0-9]{5}[A-Z]|[0-9]{7}[0-9A-Z]{1,2})$" },
-						{ "pattern": "^(IT)[0-9]{11}$" },
-						{ "pattern": "^(LT)[0-9]{9}([0-9]{3})?$" },
-						{ "pattern": "^(LU)[0-9]{8}$" },
-						{ "pattern": "^(LV)[0-9]{11}$" },
-						{ "pattern": "^(MT)[0-9]{8}$" },
-						{ "pattern": "^(NL)[0-9]{9}B[0-9]{2}$" },
-						{ "pattern": "^(PL)[0-9]{10}$" },
-						{ "pattern": "^(PT)[0-9]{9}$" },
-						{ "pattern": "^(RO)[0-9]{2,10}$" },
-						{ "pattern": "^(SE)[0-9]{12}$" },
-						{ "pattern": "^(SI)[0-9]{8}$" },
-						{ "pattern": "^(SK)[0-9]{10}$" },
-						{ "$ref": "#/definitions/empty" }
-					]
-				},
-				"trademarkNumber": {
-					"pattern": "^[0-9]*$",
-					"maxLength": 9,
-					"oneOf": [
-						{ "minLength": 9 },
-						{ "$ref": "#/definitions/empty" }
-					]
+		},
+		"organizationRequiredForIndividualTypeOrganization": {
+			"not": {
+				"comment": "",
+				"properties": {
+					"extra": {
+						"properties": {
+							"registrantType": {
+								"type": "string",
+								"enum": [ "organization" ]
+							}
+						}
+					},
+					"organization": { "$ref": "#/definitions/empty" }
 				}
 			}
 		}
 	},
+
+	"type": "object",
+	"allOf": [
+		{ "$ref": "#/definitions/organizationRequiredForIndividualTypeOrganization" },
+		{
+			"type": "object",
+			"properties": {
+				"extra": {
+					"type": "object",
+					"properties": {
+						"sirenSiret": {
+							"type": "string",
+							"pattern": "^[0-9]*$",
+							"anyOf": [
+								{ "minLength": 9, "maxLength": 9 },
+								{ "minLength": 14, "maxLength": 14 },
+								{ "$ref": "#/definitions/empty" }
+							]
+						},
+						"registrantType": {
+							"type": "string",
+							"enum": [ "individual", "organization" ]
+						},
+						"registrantVatId": {
+							"type": "string",
+							"anyOf": [
+								{ "pattern": "^(AT)U[0-9]{8}$" },
+								{ "pattern": "^(BE)0[0-9]{9}$" },
+								{ "pattern": "^(BG)[0-9]{9,10}$" },
+								{ "pattern": "^(CY)[0-9]{8}L$" },
+								{ "pattern": "^(CZ)[0-9]{8,10}$" },
+								{ "pattern": "^(DE)[0-9]{9}$" },
+								{ "pattern": "^(DK)[0-9]{8}$" },
+								{ "pattern": "^(EE)[0-9]{9}$" },
+								{ "pattern": "^(EL|GR)[0-9]{9}$" },
+								{ "pattern": "^(ES)[0-9A-Z][0-9]{7}[0-9A-Z]$" },
+								{ "pattern": "^(FI)[0-9]{8}$" },
+								{ "pattern": "^(FR)[0-9A-Z]{2}[0-9]{9}$" },
+								{ "pattern": "^(GB)([0-9]{9}([0-9]{3})?|(GD|HA)[0-9]{3})$" },
+								{ "pattern": "^(HR)[0-9]{11}$" },
+								{ "pattern": "^(HU)[0-9]{8}$" },
+								{ "pattern": "^(IE)([0-9][0-9A-Z+*][0-9]{5}[A-Z]|[0-9]{7}[0-9A-Z]{1,2})$" },
+								{ "pattern": "^(IT)[0-9]{11}$" },
+								{ "pattern": "^(LT)[0-9]{9}([0-9]{3})?$" },
+								{ "pattern": "^(LU)[0-9]{8}$" },
+								{ "pattern": "^(LV)[0-9]{11}$" },
+								{ "pattern": "^(MT)[0-9]{8}$" },
+								{ "pattern": "^(NL)[0-9]{9}B[0-9]{2}$" },
+								{ "pattern": "^(PL)[0-9]{10}$" },
+								{ "pattern": "^(PT)[0-9]{9}$" },
+								{ "pattern": "^(RO)[0-9]{2,10}$" },
+								{ "pattern": "^(SE)[0-9]{12}$" },
+								{ "pattern": "^(SI)[0-9]{8}$" },
+								{ "pattern": "^(SK)[0-9]{10}$" },
+								{ "$ref": "#/definitions/empty" }
+							]
+						},
+						"trademarkNumber": {
+							"pattern": "^[0-9]*$",
+							"maxLength": 9,
+							"oneOf": [
+								{ "minLength": 9 },
+								{ "$ref": "#/definitions/empty" }
+							]
+						}
+					}
+				}
+			}
+		}
+	],
 	"note": "We'll want to fetch this through the API, where wpcom.undocumented already has `mapKeysRecursively()` & `camelCase()`"
 }

--- a/client/components/domains/registrant-extra-info/fr-schema.json
+++ b/client/components/domains/registrant-extra-info/fr-schema.json
@@ -1,5 +1,6 @@
 {
 	"id": "/contact-validation/fr",
+	"$schema": "http://json-schema.org/draft-04/schema",
 	"definitions": {
 		"empty": {
 			"anyOf": [

--- a/client/components/domains/registrant-extra-info/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/fr-validate-contact-details.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { isString, reduce, update } from 'lodash';
+import { isEmpty, isString, reduce, update } from 'lodash';
 import validatorFactory from 'is-my-json-valid';
 import debugFactory from 'debug';
 
@@ -74,9 +74,17 @@ export default function validateContactDetails( contactDetails ) {
 				.split( '.' )
 				.slice( 1 );
 
+			// In order to capture the relationship between the organization
+			// and extra.individualType fields, the rule ends up in the root
+			// path.
+			// We've only got one such case at the moment, so we can insert this
+			// hack, but if we need to tell multiple such rules apart, we're
+			// going to need to add a some magic to map schemas to fields
+			const correctedPath = isEmpty( path ) ? [ 'organization' ] : path;
+
 			const appendThisMessage = before => [ ...( before || [] ), ruleNameFromMessage( message ) ];
 
-			return update( accumulatedErrors, path, appendThisMessage );
+			return update( accumulatedErrors, correctedPath, appendThisMessage );
 		},
 		{}
 	);

--- a/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
@@ -49,6 +49,59 @@ describe( 'validateContactDetails', () => {
 		[ '33445848600019' ],
 	];
 
+	describe( 'organization', () => {
+		describe( 'with registrantType: organization', () => {
+			const organizationDetails = Object.assign( {}, contactDetails, {
+				extra: { registrantType: 'organization' },
+			} );
+
+			test( 'should accept an organization data', () => {
+				expect( validateContactDetails( organizationDetails ) ).to.eql( {} );
+			} );
+
+			test( 'should be required', () => {
+				const testDetails = omit( organizationDetails, 'organization' );
+
+				const result = validateContactDetails( testDetails );
+				expect( result ).to.have.property( 'organization' );
+			} );
+
+			test( 'should not be empty', () => {
+				const testDetails = Object.assign( {}, organizationDetails, { organization: '' } );
+
+				const result = validateContactDetails( testDetails );
+				expect( result ).to.have.property( 'organization' );
+			} );
+		} );
+
+		describe( 'with registrantType: individual', () => {
+			const individualDetails = Object.assign( {}, contactDetails, {
+				extra: { registrantType: 'individual' },
+			} );
+
+			test( 'should accept missing organization', () => {
+				const testDetails = omit( individualDetails, 'organization' );
+
+				const result = validateContactDetails( testDetails );
+				expect( result ).to.eql( {} );
+			} );
+
+			test( 'should accept null organization', () => {
+				const testDetails = Object.assign( {}, individualDetails, { organization: '' } );
+
+				const result = validateContactDetails( testDetails );
+				expect( result ).to.eql( {} );
+			} );
+
+			test( 'should accept empty organization', () => {
+				const testDetails = Object.assign( {}, individualDetails, { organization: '' } );
+
+				const result = validateContactDetails( testDetails );
+				expect( result ).to.eql( {} );
+			} );
+		} );
+	} );
+
 	describe( 'SIREN/SIRET', () => {
 		test( 'should accept all real SIRET examples', () => {
 			realSiretNumbers.forEach( ( [ sirenSiret ] ) => {

--- a/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
@@ -55,11 +55,11 @@ describe( 'validateContactDetails', () => {
 				extra: { registrantType: 'organization' },
 			} );
 
-			test( 'should accept an organization data', () => {
+			test( 'should accept an organization', () => {
 				expect( validateContactDetails( organizationDetails ) ).to.eql( {} );
 			} );
 
-			test( 'should be required', () => {
+			test( 'should not be missing', () => {
 				const testDetails = omit( organizationDetails, 'organization' );
 
 				const result = validateContactDetails( testDetails );

--- a/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { omit } from 'lodash';
+import { omit, repeat } from 'lodash';
 
 /**
  * Internal dependencies
@@ -68,6 +68,24 @@ describe( 'validateContactDetails', () => {
 
 			test( 'should not be empty', () => {
 				const testDetails = Object.assign( {}, organizationDetails, { organization: '' } );
+
+				const result = validateContactDetails( testDetails );
+				expect( result ).to.have.property( 'organization' );
+			} );
+
+			test( 'should reject long strings', () => {
+				const testDetails = Object.assign( {}, organizationDetails, {
+					organization: repeat( '0123456789', 11 ),
+				} );
+
+				const result = validateContactDetails( testDetails );
+				expect( result ).to.have.property( 'organization' );
+			} );
+
+			test( 'should reject invalid characters', () => {
+				const testDetails = Object.assign( {}, organizationDetails, {
+					organization: 'No bangs, please!',
+				} );
 
 				const result = validateContactDetails( testDetails );
 				expect( result ).to.have.property( 'organization' );


### PR DESCRIPTION
This PR adds an organization field to the ccTLD forms to address a problem with validating the `organization` field where the organization field on the first form is required only if the `registrantType` is set to `organization` on the second form (T553-code).

By adding the organization field to the tld forms, we can give the user the opportunity to fix the problem.

There are several things we want to check:
1) The new field is hooked up to the state correctly
 - Any value from the initial form is carried over
 - Changing the form updates the state (visible in redux devtools at `State > domains > management > items > _contactDetailsCache` )
- The changed value is sent to the back end ( visible in the payload of the api call to https://public-api.wordpress.com/rest/v1.1/me/transactions )
2) Validation
- The user should not be able to submit the form with an empty field
- Validation errors should show if the `organization` field is empty while the `registrantType` is set to `organization`
- Non-alphanumeric characters are not permitted in the Organization field
-  Match other validation that happens on the back end (length <= 100)
3) Tests should run and pass
4) ~Punted: `.ca`~

![fr-organization-validation-2](https://user-images.githubusercontent.com/5952255/33110887-af025d2e-cf96-11e7-8f86-e6ef1e4599a9.gif)

Discussion:
Both the length and characters could be enforced by a sanitizing function, but I pulled the character sanitizing out and replaced it with the validation message because it's easier to understand. I'm particularly worried about this in the context of international input. A user that's trying to type Asian characters will get an empty field with no explanation.

I've punted `.ca` because there are quite involved rules around it implemented on the back end, so I think I'm going to have to take a different approach so I thought I'd push that out into a different PR.