### PR TITLE
Plans: Display different tooltip message when upgrading between paid plans.

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -106,7 +106,7 @@ class PlanFeaturesHeader extends Component {
 		const price = formatCurrency( rawPrice, currencyCode );
 
 		return translate(
-			'We’ll deduct the cost of your current plan from the full price (%(price)s)',
+			"We'll deduct the cost of your current plan from the full price (%(price)s) for the next 12 months.",
 			{ args: { price } }
 		);
 	}

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -36,6 +36,7 @@ import PlanIcon from 'components/plans/plan-icon';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import formatCurrency from 'lib/format-currency';
 
 class PlanFeaturesHeader extends Component {
 	render() {
@@ -95,13 +96,27 @@ class PlanFeaturesHeader extends Component {
 		);
 	}
 
+	getDiscountTooltipMessage() {
+		const { currencyCode, currentSitePlan, translate, rawPrice } = this.props;
+
+		if ( currentSitePlan.productSlug === PLAN_FREE ) {
+			return translate( 'Price for the next 12 months' );
+		}
+
+		const price = formatCurrency( rawPrice, currencyCode );
+
+		return translate(
+			'We’ll deduct the cost of your current plan from the full price (%(price)s)',
+			{ args: { price } }
+		);
+	}
+
 	getBillingTimeframe() {
 		const {
 			billingTimeFrame,
 			discountPrice,
 			isPlaceholder,
 			site,
-			translate,
 			isSiteAT,
 			hideMonthly,
 			isInSignup,
@@ -131,7 +146,7 @@ class PlanFeaturesHeader extends Component {
 								className="plan-features__header-tip-info"
 								position={ isMobile() ? 'top' : 'bottom left' }
 							>
-								{ translate( 'Price for the next 12 months' ) }
+								{ this.getDiscountTooltipMessage() }
 							</InfoPopover>
 						) }
 				</p>

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -272,11 +272,6 @@ $plan-features-sidebar-width: 272px;
 	display: inline-block;
 }
 
-.popover.plan-features__header-tip-info .popover__inner {
-	white-space: nowrap;
-	max-width: 500px;
-}
-
 .plan-features__price {
 	&.is-placeholder {
 		@include placeholder( 23% );

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -274,6 +274,7 @@ $plan-features-sidebar-width: 272px;
 
 .popover.plan-features__header-tip-info .popover__inner {
 	white-space: nowrap;
+	max-width: 500px;
 }
 
 .plan-features__price {
@@ -429,7 +430,7 @@ $plan-features-sidebar-width: 272px;
  }
 
 
-/*= Plans in Signup 
+/*= Plans in Signup
 ========================================*/
 
 .price-toggle {


### PR DESCRIPTION
The current message 'Price for the next 12 months' to explain the discount on the paid plans page for users who are upgrading from one paid plan to another is confusing to users.

From

<img width="309" alt="screen shot 2017-11-21 at 5 35 03 pm" src="https://user-images.githubusercontent.com/1926/33059986-5b151de6-cee2-11e7-9f99-faa4f160f655.png">

To

<img width="362" alt="screen shot 2017-11-22 at 1 57 10 pm" src="https://user-images.githubusercontent.com/1926/33109435-43d8b0ec-cf8d-11e7-8bf6-a4121e839deb.png">

# Testing

* view the plans page for a site on a personal/premium paid plan.
* Verify that the discount message is 'We'll deduct the cost of your current plan from the full price ([price for new plan in user currency]) for the next 12 months.'
* view the plans page for a site on free plan with custom domain.
* verify that the tooltip message is 'Price for the next 12 months'