### PR TITLE
Purchases: Update TransactionsHeader to use Redux analytics and React.Component

### DIFF
--- a/client/me/billing-history/transactions-header.jsx
+++ b/client/me/billing-history/transactions-header.jsx
@@ -93,7 +93,7 @@ class TransactionsHeader extends React.Component {
 	}
 
 	renderDatePopover() {
-		var isVisible = 'date' === this.state.activePopover,
+		const isVisible = 'date' === this.state.activePopover,
 			classes = classNames( {
 				'filter-popover': true,
 				'is-popped': isVisible,
@@ -102,7 +102,7 @@ class TransactionsHeader extends React.Component {
 				return this.props.moment().subtract( n, 'months' );
 			}, this ),
 			monthPickers = previousMonths.map( function( month, index ) {
-				var analyticsEvent = 'Current Month';
+				let analyticsEvent = 'Current Month';
 
 				if ( 1 === index ) {
 					analyticsEvent = '1 Month Before';
@@ -165,7 +165,7 @@ class TransactionsHeader extends React.Component {
 	}
 
 	togglePopover( name ) {
-		var activePopover;
+		let activePopover;
 		if ( this.state.activePopover === name ) {
 			activePopover = '';
 		} else {
@@ -176,11 +176,9 @@ class TransactionsHeader extends React.Component {
 	}
 
 	renderDatePicker( titleKey, titleTranslated, date, analyticsEvent ) {
-		var filter = { date: date },
-			isSelected,
-			classes;
-
-		var currentDate = this.props.filter.date || {};
+		const filter = { date: date };
+		const currentDate = this.props.filter.date || {};
+		let isSelected;
 
 		if ( date.newest ) {
 			isSelected = date.newest === currentDate.newest;
@@ -192,7 +190,7 @@ class TransactionsHeader extends React.Component {
 			isSelected = false;
 		}
 
-		classes = classNames( {
+		const classes = classNames( {
 			'transactions-header__date-picker': true,
 			selected: isSelected,
 		} );
@@ -227,7 +225,7 @@ class TransactionsHeader extends React.Component {
 	}
 
 	renderAppsPopover() {
-		var isVisible = 'apps' === this.state.activePopover,
+		const isVisible = 'apps' === this.state.activePopover,
 			classes = classNames( {
 				'filter-popover': true,
 				'is-popped': isVisible,
@@ -268,7 +266,7 @@ class TransactionsHeader extends React.Component {
 	}
 
 	renderAppPicker( title, app, analyticsEvent ) {
-		var filter = { app: app },
+		const filter = { app: app },
 			classes = classNames( {
 				'app-picker': true,
 				selected: app === this.props.filter.app,

--- a/client/me/billing-history/transactions-header.jsx
+++ b/client/me/billing-history/transactions-header.jsx
@@ -225,14 +225,14 @@ class TransactionsHeader extends React.Component {
 	}
 
 	renderAppsPopover() {
-		const isVisible = 'apps' === this.state.activePopover,
-			classes = classNames( {
-				'filter-popover': true,
-				'is-popped': isVisible,
-			} ),
-			appPickers = this.getApps().map( function( app ) {
-				return this.renderAppPicker( app, app, 'Specific App' );
-			}, this );
+		const isVisible = 'apps' === this.state.activePopover;
+		const classes = classNames( {
+			'filter-popover': true,
+			'is-popped': isVisible,
+		} );
+		const appPickers = this.getApps().map( function( app ) {
+			return this.renderAppPicker( app, app, 'Specific App' );
+		}, this );
 
 		return (
 			<div className={ classes }>
@@ -266,11 +266,11 @@ class TransactionsHeader extends React.Component {
 	}
 
 	renderAppPicker( title, app, analyticsEvent ) {
-		const filter = { app: app },
-			classes = classNames( {
-				'app-picker': true,
-				selected: app === this.props.filter.app,
-			} );
+		const filter = { app };
+		const classes = classNames( {
+			'app-picker': true,
+			selected: app === this.props.filter.app,
+		} );
 
 		return (
 			<tr

--- a/client/me/billing-history/transactions-header.jsx
+++ b/client/me/billing-history/transactions-header.jsx
@@ -6,75 +6,72 @@
 import React from 'react';
 import classNames from 'classnames';
 import closest from 'component-closest';
-import createReactClass from 'create-react-class';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { last, map, range, uniq } from 'lodash';
 import { localize } from 'i18n-calypso';
-import { recordGoogleEvent } from 'state/analytics/actions';
 
 /**
  * Internal dependencies
  */
 import tableRows from './table-rows';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
-const TransactionsHeader = createReactClass( {
-	getInitialState: function() {
-		return {
-			activePopover: '',
-			searchValue: '',
-		};
-	},
+class TransactionsHeader extends React.Component {
+	state = {
+		activePopover: '',
+		searchValue: '',
+	};
 
-	preventEnterKeySubmission: function( event ) {
+	preventEnterKeySubmission = event => {
 		event.preventDefault();
-	},
+	};
 
-	componentWillMount: function() {
+	componentWillMount() {
 		document.body.addEventListener( 'click', this.closePopoverIfClickedOutside );
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		document.body.removeEventListener( 'click', this.closePopoverIfClickedOutside );
-	},
+	}
 
-	recordClickEvent( action ) {
+	recordClickEvent = action => {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
-	},
+	};
 
 	getDatePopoverItemClickHandler( analyticsEvent, filter ) {
 		return () => {
 			this.recordClickEvent( 'Date Popover Item: ' + analyticsEvent );
 			this.handlePickerSelection( filter );
 		};
-	},
+	}
 
 	getAppPopoverItemClickHandler( analyticsEvent, filter ) {
 		return () => {
 			this.recordClickEvent( 'App Popover Item: ' + analyticsEvent );
 			this.handlePickerSelection( filter );
 		};
-	},
+	}
 
-	handleDatePopoverLinkClick() {
+	handleDatePopoverLinkClick = () => {
 		this.recordClickEvent( 'Toggle Date Popover in Billing History' );
 		this.togglePopover( 'date' );
-	},
+	};
 
-	handleAppsPopoverLinkClick() {
+	handleAppsPopoverLinkClick = () => {
 		this.recordClickEvent( 'Toggle Apps Popover in Billing History' );
 		this.togglePopover( 'apps' );
-	},
+	};
 
-	closePopoverIfClickedOutside: function( event ) {
+	closePopoverIfClickedOutside = event => {
 		if ( closest( event.target, 'thead' ) ) {
 			return;
 		}
 
 		this.setState( { activePopover: '' } );
-	},
+	};
 
-	render: function() {
+	render() {
 		return (
 			<thead>
 				<tr className="billing-history__header-row">
@@ -88,14 +85,14 @@ const TransactionsHeader = createReactClass( {
 				</tr>
 			</thead>
 		);
-	},
+	}
 
-	setFilter: function( filter ) {
+	setFilter( filter ) {
 		this.setState( { activePopover: '' } );
 		this.props.onNewFilter( filter );
-	},
+	}
 
-	renderDatePopover: function() {
+	renderDatePopover() {
 		var isVisible = 'date' === this.state.activePopover,
 			classes = classNames( {
 				'filter-popover': true,
@@ -165,9 +162,9 @@ const TransactionsHeader = createReactClass( {
 				</div>
 			</div>
 		);
-	},
+	}
 
-	togglePopover: function( name ) {
+	togglePopover( name ) {
 		var activePopover;
 		if ( this.state.activePopover === name ) {
 			activePopover = '';
@@ -176,9 +173,9 @@ const TransactionsHeader = createReactClass( {
 		}
 
 		this.setState( { activePopover: activePopover } );
-	},
+	}
 
-	renderDatePicker: function( titleKey, titleTranslated, date, analyticsEvent ) {
+	renderDatePicker( titleKey, titleTranslated, date, analyticsEvent ) {
 		var filter = { date: date },
 			isSelected,
 			classes;
@@ -214,22 +211,22 @@ const TransactionsHeader = createReactClass( {
 				</td>
 			</tr>
 		);
-	},
+	}
 
-	handlePickerSelection: function( filter ) {
+	handlePickerSelection( filter ) {
 		this.setFilter( filter );
 		this.setState( { searchValue: '' } );
-	},
+	}
 
-	getFilterCount: function( filter ) {
+	getFilterCount( filter ) {
 		if ( ! this.props.transactions ) {
 			return;
 		}
 
 		return tableRows.filter( this.props.transactions, filter ).length;
-	},
+	}
 
-	renderAppsPopover: function() {
+	renderAppsPopover() {
 		var isVisible = 'apps' === this.state.activePopover,
 			classes = classNames( {
 				'filter-popover': true,
@@ -264,13 +261,13 @@ const TransactionsHeader = createReactClass( {
 				</div>
 			</div>
 		);
-	},
+	}
 
-	getApps: function() {
+	getApps() {
 		return uniq( map( this.props.transactions, 'service' ) );
-	},
+	}
 
-	renderAppPicker: function( title, app, analyticsEvent ) {
+	renderAppPicker( title, app, analyticsEvent ) {
 		var filter = { app: app },
 			classes = classNames( {
 				'app-picker': true,
@@ -287,8 +284,8 @@ const TransactionsHeader = createReactClass( {
 				<td className="transactions-header__count">{ this.getFilterCount( filter ) }</td>
 			</tr>
 		);
-	},
-} );
+	}
+}
 
 export default connect( null, {
 	recordGoogleEvent,

--- a/client/me/billing-history/transactions-header.jsx
+++ b/client/me/billing-history/transactions-header.jsx
@@ -176,7 +176,7 @@ class TransactionsHeader extends React.Component {
 	}
 
 	renderDatePicker( titleKey, titleTranslated, date, analyticsEvent ) {
-		const filter = { date: date };
+		const filter = { date };
 		const currentDate = this.props.filter.date || {};
 		let isSelected;
 

--- a/client/me/billing-history/transactions-header.jsx
+++ b/client/me/billing-history/transactions-header.jsx
@@ -3,26 +3,22 @@
 /**
  * External dependencies
  */
-
+import React from 'react';
+import classNames from 'classnames';
+import closest from 'component-closest';
+import createReactClass from 'create-react-class';
+import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 import { last, map, range, uniq } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
-import React from 'react';
-import createReactClass from 'create-react-class';
-import closest from 'component-closest';
-import classNames from 'classnames';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 /**
  * Internal dependencies
  */
 import tableRows from './table-rows';
-import eventRecorder from 'me/event-recorder';
 
 const TransactionsHeader = createReactClass( {
-	displayName: 'TransactionsHeader',
-
-	mixins: [ eventRecorder ],
-
 	getInitialState: function() {
 		return {
 			activePopover: '',
@@ -40,6 +36,34 @@ const TransactionsHeader = createReactClass( {
 
 	componentWillUnmount: function() {
 		document.body.removeEventListener( 'click', this.closePopoverIfClickedOutside );
+	},
+
+	recordClickEvent( action ) {
+		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
+	},
+
+	getDatePopoverItemClickHandler( analyticsEvent, filter ) {
+		return () => {
+			this.recordClickEvent( 'Date Popover Item: ' + analyticsEvent );
+			this.handlePickerSelection( filter );
+		};
+	},
+
+	getAppPopoverItemClickHandler( analyticsEvent, filter ) {
+		return () => {
+			this.recordClickEvent( 'App Popover Item: ' + analyticsEvent );
+			this.handlePickerSelection( filter );
+		};
+	},
+
+	handleDatePopoverLinkClick() {
+		this.recordClickEvent( 'Toggle Date Popover in Billing History' );
+		this.togglePopover( 'date' );
+	},
+
+	handleAppsPopoverLinkClick() {
+		this.recordClickEvent( 'Toggle Apps Popover in Billing History' );
+		this.togglePopover( 'apps' );
 	},
 
 	closePopoverIfClickedOutside: function( event ) {
@@ -101,10 +125,7 @@ const TransactionsHeader = createReactClass( {
 			<div className={ classes }>
 				<strong
 					className="filter-popover-toggle date-toggle"
-					onClick={ this.recordClickEvent(
-						'Toggle Date Popover in Billing History',
-						this.togglePopover.bind( this, 'date' )
-					) }
+					onClick={ this.handleDatePopoverLinkClick }
 				>
 					{ this.props.translate( 'Date' ) }
 					<Gridicon icon="chevron-down" size={ 18 } />
@@ -185,10 +206,7 @@ const TransactionsHeader = createReactClass( {
 			<tr
 				key={ titleKey }
 				className={ classes }
-				onClick={ this.recordClickEvent(
-					'Date Popover Item: ' + analyticsEvent,
-					this.handlePickerSelection.bind( this, filter )
-				) }
+				onClick={ this.getDatePopoverItemClickHandler( analyticsEvent, filter ) }
 			>
 				<td className="descriptor">{ titleTranslated }</td>
 				<td className="transactions-header__count">
@@ -225,10 +243,7 @@ const TransactionsHeader = createReactClass( {
 			<div className={ classes }>
 				<strong
 					className="filter-popover-toggle app-toggle"
-					onClick={ this.recordClickEvent(
-						'Toggle Apps Popover in Billing History',
-						this.togglePopover.bind( this, 'apps' )
-					) }
+					onClick={ this.handleAppsPopoverLinkClick }
 				>
 					{ this.props.translate( 'All Apps' ) }
 					<Gridicon icon="chevron-down" size={ 18 } />
@@ -266,10 +281,7 @@ const TransactionsHeader = createReactClass( {
 			<tr
 				key={ app }
 				className={ classes }
-				onClick={ this.recordClickEvent(
-					'App Popover Item: ' + analyticsEvent,
-					this.handlePickerSelection.bind( this, filter )
-				) }
+				onClick={ this.getAppPopoverItemClickHandler( analyticsEvent, filter ) }
 			>
 				<td className="descriptor">{ title }</td>
 				<td className="transactions-header__count">{ this.getFilterCount( filter ) }</td>
@@ -278,4 +290,6 @@ const TransactionsHeader = createReactClass( {
 	},
 } );
 
-export default localize( TransactionsHeader );
+export default connect( null, {
+	recordGoogleEvent,
+} )( localize( TransactionsHeader ) );


### PR DESCRIPTION
This PR refactors `TransactionsHeader` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove all mixins, specifically `eventRecorder`.
* Convert from `createReactClass` to a `React.Component`.
* Sort some imports.
* Update `var` usages to `let` or `const`.

This PR should not introduce any visual changes.

Part of #20053.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me/purchases/billing
* Verify you can observe the right analytics actions being dispatched when:
  * The "Date" popover is expanded/collapsed
  * The "All Apps" popover is expanded/collapsed
  * Any item from the "Date" popover is selected
  * Any item from the "All Apps" popover is selected
* Verify everything else on the purchases list page works like it did before.