### PR TITLE
Me: Update ProfileLink to use Redux analytics and React.Component

### DIFF
--- a/client/me/profile-link/index.jsx
+++ b/client/me/profile-link/index.jsx
@@ -3,26 +3,22 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import classNames from 'classnames';
+import createReactClass from 'create-react-class';
 import Gridicon from 'gridicons';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import safeProtocolUrl from 'lib/safe-protocol-url';
-import eventRecorder from 'me/event-recorder';
-import { withoutHttp } from 'lib/url';
 import Button from 'components/button';
+import safeProtocolUrl from 'lib/safe-protocol-url';
+import { recordGoogleEvent } from 'state/analytics/actions';
+import { withoutHttp } from 'lib/url';
 
-export default createReactClass( {
-	displayName: 'ProfileLink',
-
-	mixins: [ eventRecorder ],
-
+const ProfileLink = createReactClass( {
 	getDefaultProps() {
 		return {
 			imageSize: 100,
@@ -40,13 +36,26 @@ export default createReactClass( {
 		slug: PropTypes.string.isRequired,
 	},
 
+	recordClickEvent( action ) {
+		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
+	},
+
+	getClickHandler( action ) {
+		return () => this.recordClickEvent( action );
+	},
+
+	handleRemoveButtonClick() {
+		this.recordClickEvent( 'Remove Link Next to Site' );
+		this.props.onRemoveLink();
+	},
+
 	renderRemove() {
 		return (
 			<Button
 				borderless
 				icon
 				className="profile-link__remove"
-				onClick={ this.recordClickEvent( 'Remove Link Next to Site', this.props.onRemoveLink ) }
+				onClick={ this.handleRemoveButtonClick }
 			>
 				<Gridicon icon="cross" />
 			</Button>
@@ -76,7 +85,7 @@ export default createReactClass( {
 						className="profile-link__image-link"
 						target="_blank"
 						rel="noopener noreferrer"
-						onClick={ this.recordClickEvent( 'Profile Links Site Images Link' ) }
+						onClick={ this.getClickHandler( 'Profile Links Site Images Link' ) }
 					>
 						<img className="profile-link__image" src={ imageSrc } />
 					</a>
@@ -85,7 +94,7 @@ export default createReactClass( {
 					href={ linkHref }
 					target="_blank"
 					rel="noopener noreferrer"
-					onClick={ this.recordClickEvent( 'Profile Links Site Link' ) }
+					onClick={ this.getClickHandler( 'Profile Links Site Link' ) }
 				>
 					<span className="profile-link__title">{ this.props.title }</span>
 					<span className="profile-link__url">{ withoutHttp( this.props.url ) }</span>
@@ -96,3 +105,7 @@ export default createReactClass( {
 		);
 	},
 } );
+
+export default connect( null, {
+	recordGoogleEvent,
+} )( ProfileLink );

--- a/client/me/profile-link/index.jsx
+++ b/client/me/profile-link/index.jsx
@@ -5,7 +5,6 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import createReactClass from 'create-react-class';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -18,36 +17,34 @@ import safeProtocolUrl from 'lib/safe-protocol-url';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { withoutHttp } from 'lib/url';
 
-const ProfileLink = createReactClass( {
-	getDefaultProps() {
-		return {
-			imageSize: 100,
-			title: '',
-			url: '',
-			slug: '',
-			isPlaceholder: false,
-		};
-	},
+class ProfileLink extends React.Component {
+	static defaultProps = {
+		imageSize: 100,
+		title: '',
+		url: '',
+		slug: '',
+		isPlaceholder: false,
+	};
 
-	propTypes: {
+	static propTypes = {
 		imageSize: PropTypes.number,
 		title: PropTypes.string.isRequired,
 		url: PropTypes.string.isRequired,
 		slug: PropTypes.string.isRequired,
-	},
+	};
 
-	recordClickEvent( action ) {
+	recordClickEvent = action => {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
-	},
+	};
 
-	getClickHandler( action ) {
+	getClickHandler = action => {
 		return () => this.recordClickEvent( action );
-	},
+	};
 
-	handleRemoveButtonClick() {
+	handleRemoveButtonClick = () => {
 		this.recordClickEvent( 'Remove Link Next to Site' );
 		this.props.onRemoveLink();
-	},
+	};
 
 	renderRemove() {
 		return (
@@ -60,7 +57,7 @@ const ProfileLink = createReactClass( {
 				<Gridicon icon="cross" />
 			</Button>
 		);
-	},
+	}
 
 	render() {
 		const classes = classNames( {
@@ -103,8 +100,8 @@ const ProfileLink = createReactClass( {
 				{ this.props.isPlaceholder ? null : this.renderRemove() }
 			</li>
 		);
-	},
-} );
+	}
+}
 
 export default connect( null, {
 	recordGoogleEvent,


### PR DESCRIPTION
This PR refactors `ProfileLink` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove all mixins, specifically `eventRecorder`.
* Convert from `createReactClass` to a `React.Component`.
* Sort some imports.

This PR should not introduce any visual changes.

Part of #20053.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me
* Insert several profile links to your profile.
* Verify you can observe the right analytics actions being dispatched when:
  * The image of the site is clicked
  * The URL/description of the site is clicked
  * The remove button of a site is clicked.
* Verify everything else on the profile links works like it did before.