### PR TITLE
Me: Update ProfileLinksAddOther to use Redux analytics and React.Component 

### DIFF
--- a/client/me/profile-links-add-other/index.jsx
+++ b/client/me/profile-links-add-other/index.jsx
@@ -3,23 +3,22 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import createReactClass from 'create-react-class';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormTextInput from 'components/forms/form-text-input';
-import FormButton from 'components/forms/form-button';
-import eventRecorder from 'me/event-recorder';
 import Notice from 'components/notice';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 const ProfileLinksAddOther = createReactClass( {
 	displayName: 'ProfileLinksAddOther',
-	mixins: [ eventRecorder ],
 
 	getInitialState() {
 		return {
@@ -59,6 +58,24 @@ const ProfileLinksAddOther = createReactClass( {
 		return false;
 	},
 
+	recordClickEvent( action ) {
+		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
+	},
+
+	getClickHandler( action ) {
+		return () => this.recordClickEvent( action );
+	},
+
+	getFocusHandler( action ) {
+		return () => this.props.recordGoogleEvent( 'Me', 'Focused on ' + action );
+	},
+
+	handleCancelButtonClick( event ) {
+		event.preventDefault();
+		this.recordClickEvent( 'Cancel Other Site Button' );
+		this.props.onCancel();
+	},
+
 	onSubmit( event ) {
 		event.preventDefault();
 
@@ -78,11 +95,6 @@ const ProfileLinksAddOther = createReactClass( {
 			],
 			this.onSubmitResponse
 		);
-	},
-
-	onCancel( event ) {
-		event.preventDefault();
-		this.props.onCancel();
 	},
 
 	onSubmitResponse( error, data ) {
@@ -139,7 +151,7 @@ const ProfileLinksAddOther = createReactClass( {
 					<FormTextInput
 						className="profile-links-add-other__value"
 						placeholder={ this.props.translate( 'Enter a URL' ) }
-						onFocus={ this.recordFocusEvent( 'Add Other Site URL Field' ) }
+						onFocus={ this.getFocusHandler( 'Add Other Site URL Field' ) }
 						name="value"
 						value={ this.state.value }
 						onChange={ this.handleChange }
@@ -147,7 +159,7 @@ const ProfileLinksAddOther = createReactClass( {
 					<FormTextInput
 						className="profile-links-add-other__title"
 						placeholder={ this.props.translate( 'Enter a description' ) }
-						onFocus={ this.recordFocusEvent( 'Add Other Site Description Field' ) }
+						onFocus={ this.getFocusHandler( 'Add Other Site Description Field' ) }
 						name="title"
 						value={ this.state.title }
 						onChange={ this.handleChange }
@@ -155,14 +167,14 @@ const ProfileLinksAddOther = createReactClass( {
 					<FormButton
 						className="profile-links-add-other__add"
 						disabled={ this.getFormDisabled() }
-						onClick={ this.recordClickEvent( 'Save Other Site Button' ) }
+						onClick={ this.getClickHandler( 'Save Other Site Button' ) }
 					>
 						{ this.props.translate( 'Add Site' ) }
 					</FormButton>
 					<FormButton
 						className="profile-links-add-other__cancel"
 						isPrimary={ false }
-						onClick={ this.recordClickEvent( 'Cancel Other Site Button', this.onCancel ) }
+						onClick={ this.handleCancelButtonClick }
 					>
 						{ this.props.translate( 'Cancel' ) }
 					</FormButton>
@@ -177,4 +189,6 @@ const ProfileLinksAddOther = createReactClass( {
 	},
 } );
 
-export default localize( ProfileLinksAddOther );
+export default connect( null, {
+	recordGoogleEvent,
+} )( localize( ProfileLinksAddOther ) );

--- a/client/me/profile-links-add-other/index.jsx
+++ b/client/me/profile-links-add-other/index.jsx
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -17,16 +16,12 @@ import FormTextInput from 'components/forms/form-text-input';
 import Notice from 'components/notice';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-const ProfileLinksAddOther = createReactClass( {
-	displayName: 'ProfileLinksAddOther',
-
-	getInitialState() {
-		return {
-			title: '',
-			value: '',
-			lastError: false,
-		};
-	},
+class ProfileLinksAddOther extends React.Component {
+	state = {
+		title: '',
+		value: '',
+		lastError: false,
+	};
 
 	// As the user types, the component state changes thanks to the LinkedStateMixin.
 	// This function, called in render, validates their input on each state change
@@ -56,27 +51,32 @@ const ProfileLinksAddOther = createReactClass( {
 		}
 
 		return false;
-	},
+	}
 
-	recordClickEvent( action ) {
+	recordClickEvent = action => {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
-	},
+	};
 
-	getClickHandler( action ) {
+	getClickHandler = action => {
 		return () => this.recordClickEvent( action );
-	},
+	};
 
-	getFocusHandler( action ) {
+	getFocusHandler = action => {
 		return () => this.props.recordGoogleEvent( 'Me', 'Focused on ' + action );
-	},
+	};
 
-	handleCancelButtonClick( event ) {
+	handleCancelButtonClick = event => {
 		event.preventDefault();
 		this.recordClickEvent( 'Cancel Other Site Button' );
 		this.props.onCancel();
-	},
+	};
 
-	onSubmit( event ) {
+	handleChange = e => {
+		const { name, value } = e.currentTarget;
+		this.setState( { [ name ]: value } );
+	};
+
+	onSubmit = event => {
 		event.preventDefault();
 
 		// When the form's submit button is disabled, the form's onSubmit does not
@@ -95,9 +95,9 @@ const ProfileLinksAddOther = createReactClass( {
 			],
 			this.onSubmitResponse
 		);
-	},
+	};
 
-	onSubmitResponse( error, data ) {
+	onSubmitResponse = ( error, data ) => {
 		if ( error ) {
 			this.setState( {
 				lastError: this.props.translate( 'Unable to add link right now. Please try again later.' ),
@@ -115,13 +115,13 @@ const ProfileLinksAddOther = createReactClass( {
 		} else {
 			this.props.onSuccess();
 		}
-	},
+	};
 
-	clearLastError() {
+	clearLastError = () => {
 		this.setState( {
 			lastError: false,
 		} );
-	},
+	};
 
 	possiblyRenderError() {
 		if ( ! this.state.lastError ) {
@@ -136,7 +136,7 @@ const ProfileLinksAddOther = createReactClass( {
 				text={ this.state.lastError }
 			/>
 		);
-	},
+	}
 
 	render() {
 		return (
@@ -181,13 +181,8 @@ const ProfileLinksAddOther = createReactClass( {
 				</FormFieldset>
 			</form>
 		);
-	},
-
-	handleChange( e ) {
-		const { name, value } = e.currentTarget;
-		this.setState( { [ name ]: value } );
-	},
-} );
+	}
+}
 
 export default connect( null, {
 	recordGoogleEvent,


### PR DESCRIPTION
This PR refactors `ProfileLinksAddOther` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove all mixins, specifically `eventRecorder`.
* Convert from `createReactClass` to a `React.Component`.
* Sort some imports.

This PR should not introduce any visual changes.

Part of #20053.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me
* Click on the "Add" button in the Profile Links section.
* Click on "Add URL".
* Verify you can observe the right analytics actions being dispatched when:
  * The URL field is focused
  * The description field is focused
  * The cancel button is clicked
  * The save button is clicked
* Verify everything else on the profile links like it did before.