### PR TITLE
Me: Use Redux analytics instead of eventRecorder in ProfileLinksAddWordPress

### DIFF
--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -15,10 +15,10 @@ import { pickBy, map } from 'lodash';
 import config from 'config';
 import FormButton from 'components/forms/form-button';
 import Notice from 'components/notice';
-import { recordClickEvent } from 'me/event-recorder';
+import ProfileLinksAddWordPressSite from './site';
 import { getPublicSites } from 'state/selectors';
 import { getSite } from 'state/sites/selectors';
-import ProfileLinksAddWordPressSite from './site';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 const addProfileLinks = ( inputs, userProfileLinks, callback ) => ( dispatch, getState ) => {
 	const links = pickBy(
@@ -48,6 +48,29 @@ class ProfileLinksAddWordPress extends Component {
 		const updates = {};
 		updates[ event.target.name ] = event.target.checked;
 		this.setState( updates );
+	};
+
+	recordClickEvent = action => {
+		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
+	};
+
+	getClickHandler = action => {
+		return () => this.recordClickEvent( action );
+	};
+
+	handleCancelButtonClick = event => {
+		this.recordClickEvent( 'Cancel Add WordPress Sites Button' );
+		this.onCancel( event );
+	};
+
+	handleJetpackLinkClick = event => {
+		this.recordClickEvent( 'Jetpack Link in Profile Links' );
+		this.onJetpackMe( event );
+	};
+
+	handleCreateSiteButtonClick = event => {
+		this.recordClickEvent( 'Create Sites Button in Profile Links' );
+		this.onCreateSite( event );
 	};
 
 	onSelect = ( event, inputName ) => {
@@ -164,14 +187,14 @@ class ProfileLinksAddWordPress extends Component {
 				{ this.possiblyRenderError() }
 				<FormButton
 					disabled={ 0 === checkedCount ? true : false }
-					onClick={ recordClickEvent( 'Add WordPress Sites Button' ) }
+					onClick={ this.getClickHandler( 'Add WordPress Sites Button' ) }
 				>
 					{ translate( 'Add Site', 'Add Sites', { count: checkedCount } ) }
 				</FormButton>
 				<FormButton
 					className="profile-links-add-wordpress__cancel"
 					isPrimary={ false }
-					onClick={ recordClickEvent( 'Cancel Add WordPress Sites Button', this.onCancel ) }
+					onClick={ this.handleCancelButtonClick }
 				>
 					{ translate( 'Cancel' ) }
 				</FormButton>
@@ -195,25 +218,20 @@ class ProfileLinksAddWordPress extends Component {
 									<a
 										href="#"
 										className="profile-links-add-wordpress__jetpack-link"
-										onClick={ recordClickEvent(
-											'Jetpack Link in Profile Links',
-											this.onJetpackMe
-										) }
+										onClick={ this.handleJetpackLinkClick }
 									/>
 								),
 							},
 						}
 					) }
 				</p>
-				<FormButton
-					onClick={ recordClickEvent( 'Create Sites Button in Profile Links', this.onCreateSite ) }
-				>
+				<FormButton onClick={ this.handleCreateSiteButtonClick }>
 					{ translate( 'Create Site' ) }
 				</FormButton>
 				<FormButton
 					className="profile-links-add-wordpress__cancel"
 					isPrimary={ false }
-					onClick={ recordClickEvent( 'Cancel Add WordPress Sites Button', this.onCancel ) }
+					onClick={ this.handleCancelButtonClick }
 				>
 					{ translate( 'Cancel' ) }
 				</FormButton>
@@ -238,5 +256,6 @@ export default connect(
 	} ),
 	{
 		addProfileLinks,
+		recordGoogleEvent,
 	}
 )( localize( ProfileLinksAddWordPress ) );


### PR DESCRIPTION
This PR refactors `ProfileLinksAddWordPress` to use Redux analytics instead of `eventRecorder`. No visual changes should be introduced by this PR.

Part of #20053.

To test:
* Checkout this branch
* Login with a user with 1 or more public sites.
  * Go to http://calypso.localhost:3000/me
  * Click on the "Add" button in the Profile Links section.
  * Click on "Add WordPress Site".
  * Verify you can observe the right analytics actions being dispatched when:
    * 1 or more sites are being added (the Add Sites button is clicked).
    * The "Cancel" button is clicked.
  * Verify everything else on the profile links like it did before.
* Login with a user with no public sites.
  * Go to http://calypso.localhost:3000/me
  * Click on the "Add" button in the Profile Links section.
  * Click on "Add WordPress Site".
  * Verify you can observe the right analytics actions being dispatched when:
    * The Jetpack link is clicked.
    * The "Create Site" button is clicked.
  * Verify everything else on the profile links like it did before.