### PR TITLE
Me: Update ProfileLinksAddWordPressSite to use Redux analytics

### DIFF
--- a/client/me/profile-links-add-wordpress/site.jsx
+++ b/client/me/profile-links-add-wordpress/site.jsx
@@ -3,15 +3,15 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import Site from 'blocks/site';
-import { recordCheckboxEvent } from 'me/event-recorder';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 class ProfileLinksAddWordPressSite extends Component {
 	static propTypes = {
@@ -29,6 +29,13 @@ class ProfileLinksAddWordPressSite extends Component {
 		this.props.onSelect( event, this.getInputName() );
 	};
 
+	getCheckboxEventHandler = checkboxName => event => {
+		const action = 'Clicked ' + checkboxName + ' checkbox';
+		const value = event.target.checked ? 1 : 0;
+
+		this.props.recordGoogleEvent( 'Me', action, 'checked', value );
+	};
+
 	getInputName() {
 		return `site-${ this.props.site.ID }`;
 	}
@@ -40,7 +47,7 @@ class ProfileLinksAddWordPressSite extends Component {
 			<li
 				key={ site.ID }
 				className="profile-links-add-wordpress__item"
-				onClick={ recordCheckboxEvent( 'Add WordPress Site' ) }
+				onClick={ this.getCheckboxEventHandler( 'Add WordPress Site' ) }
 			>
 				<input
 					className="profile-links-add-wordpress__checkbox"
@@ -55,4 +62,6 @@ class ProfileLinksAddWordPressSite extends Component {
 	}
 }
 
-export default ProfileLinksAddWordPressSite;
+export default connect( null, {
+	recordGoogleEvent,
+} )( ProfileLinksAddWordPressSite );


### PR DESCRIPTION
This PR refactors `ProfileLinksAddWordPressSite` to use Redux analytics instead of `eventRecorder`, also sorts some imports. This PR should not introduce any visual changes.

Part of #20053.

To test:
* Checkout this branch
* Login with a user with at least one public site.
* Go to http://calypso.localhost:3000/me/
* Click on the "Add" button in the Profile Links section.
* Click on "Add WordPress Site".
* Verify you can observe the right analytics actions being dispatched when:
  * Any site is being checked.
  * Any site is being unchecked.
* Verify everything else on the profile links works like it did before.