### PR TITLE
Purchases: Update BillingReceipt to use Redux analytics and React.Component

### DIFF
--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -3,9 +3,7 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -18,23 +16,16 @@ import { isSendingBillingReceiptEmail } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { sendBillingReceiptEmail as sendBillingReceiptEmailAction } from 'state/billing-transactions/actions';
 
-const BillingHistoryTable = createReactClass( {
-	displayName: 'BillingHistoryTable',
-
-	emailReceipt( receiptId, event ) {
-		event.preventDefault();
-		this.props.sendBillingReceiptEmail( receiptId );
-	},
-
-	recordClickEvent( eventAction ) {
+class BillingHistoryTable extends React.Component {
+	recordClickEvent = eventAction => {
 		this.props.recordGoogleEvent( 'Me', eventAction );
-	},
+	};
 
-	handleReceiptLinkClick() {
+	handleReceiptLinkClick = () => {
 		return this.recordClickEvent( 'View Receipt in Billing History' );
-	},
+	};
 
-	getEmailReceiptLinkClickHandler( receiptId ) {
+	getEmailReceiptLinkClickHandler = receiptId => {
 		const { sendBillingReceiptEmail } = this.props;
 
 		return event => {
@@ -42,9 +33,9 @@ const BillingHistoryTable = createReactClass( {
 			this.recordClickEvent( 'Email Receipt in Billing History' );
 			sendBillingReceiptEmail( receiptId );
 		};
-	},
+	};
 
-	renderEmailAction( receiptId ) {
+	renderEmailAction = receiptId => {
 		const { translate } = this.props;
 
 		if ( this.props.sendingBillingReceiptEmail( receiptId ) ) {
@@ -56,9 +47,9 @@ const BillingHistoryTable = createReactClass( {
 				{ translate( 'Email Receipt' ) }
 			</a>
 		);
-	},
+	};
 
-	renderTransaction( transaction ) {
+	renderTransaction = transaction => {
 		const { translate } = this.props;
 
 		return (
@@ -73,7 +64,7 @@ const BillingHistoryTable = createReactClass( {
 				{ this.renderEmailAction( transaction.id ) }
 			</div>
 		);
-	},
+	};
 
 	render() {
 		const { translate } = this.props;
@@ -96,8 +87,8 @@ const BillingHistoryTable = createReactClass( {
 				transactionRenderer={ this.renderTransaction }
 			/>
 		);
-	},
-} );
+	}
+}
 
 export default connect(
 	state => {

--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -10,8 +10,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import TransactionsTable from './transactions-table';
 import purchasesPaths from 'me/purchases/paths';
+import TransactionsTable from './transactions-table';
 import { isSendingBillingReceiptEmail } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { sendBillingReceiptEmail as sendBillingReceiptEmailAction } from 'state/billing-transactions/actions';


### PR DESCRIPTION
This PR refactors `BillingHistoryTable` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove all mixins, specifically `eventRecorder`.
* Convert from `createReactClass` to a `React.Component`.
* Sort some imports 🔤 .

This PR should not introduce any visual changes.

Part of #20053.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me/purchases/billing
* Verify you can observe the right analytics actions being dispatched when:
  * The **View Receipt** link of a particular purchase is clicked
  * The **Email Receipt** link of a particular purchase is clicked
* Verify everything else on the purchases list page works like it did before.