### PR TITLE
Store NUX: enable on prod

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -111,6 +111,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
+		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,


### PR DESCRIPTION
In this PR, we are launching Store NUX for prod 🚀 

## Testing

In order to test, you need to be from US/CA (use VPN if not) and be in the `signupAtomicStoreVsPressable` abtest with `"atomic"` variation. You can have that with:

```
localStorage.setItem( 'ABTests', '{"signupAtomicStoreVsPressable_20171101":"atomic"}' );
```

Then, start the signup flow (`/start`) and select "store" as the site design type. After going through the signup flow, you should have an Atomic site with Woo pre-installed and be presented with a screen to set up your Woo store in Calypso.