### PR TITLE
Purchases: Add word-break so long domains do not break layout

### DIFF
--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -108,6 +108,11 @@
 }
 
 .billing-history__service-name {
+	small,
+	strong {
+		word-break: break-word;
+	}
+
 	strong {
 		font-weight: normal;
 	}

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -108,10 +108,8 @@
 }
 
 .billing-history__service-name {
-	small,
-	strong {
-		word-break: break-word;
-	}
+	hyphens: auto;
+	overflow-wrap: break-word;
 
 	strong {
 		font-weight: normal;


### PR DESCRIPTION
This PR makes it so that long domains do not break layout on `/me/purchases/billing`

Long domains break the columns because they're unable to break, "pushing" other columns and breaking layout. This PR adds `break-word` on the domain container so that they can break and column layout is respected.

## Screens

Left after, before right:

![after-before-a](https://user-images.githubusercontent.com/841763/33066135-c65500e0-ceaa-11e7-8e9f-66f30698fa33.png)

![after-before-b](https://user-images.githubusercontent.com/841763/33066134-c62884a2-ceaa-11e7-9da5-fe08107e1798.png)

Found while reviewing #20048