### PR TITLE
Reset the shipping label state after updating the order

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -59,6 +59,9 @@ import {
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_EMAIL_DETAILS,
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_FULFILL_ORDER,
 } from '../action-types';
+import {
+	WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
+} from 'woocommerce/state/action-types';
 import getBoxDimensions from 'woocommerce/woocommerce-services/lib/utils/get-box-dimensions';
 import initializeLabelsState from 'woocommerce/woocommerce-services/lib/initialize-labels-state';
 
@@ -771,6 +774,11 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_CLOSE_DETAILS_DIALOG ] = ( state )
 	return { ...state,
 		detailsDialog: null,
 	};
+};
+
+// Reset the state when the order changes
+reducers[ WOOCOMMERCE_ORDER_UPDATE_SUCCESS ] = () => {
+	return initializeLabelsState();
 };
 
 export default keyedReducer( 'orderId', ( state = initializeLabelsState(), action ) => {


### PR DESCRIPTION
Fixes #19619

This is the simplest solution to #19619. It provides the same level of functionallity as WP-Admin: When the order is updated, the whole "Shipping Labels" state will reset. That means that the new, fresh order data will be re-fetched from the WordPress site.

A deeper integration between the Calypso state (origin address, order contents, order address, store currency...) and the Shipping Label components would be better, but that's a much bigger can of worms, specially now that the shipping Labels UI must work as part of Calypso, and as a stand-alone metabox on WP-Admin.

@ryelle You said that when you updated the "Shipping Address" and refreshed the page, the old address still was fetched from `wc/connect/label/:id`. We aren't doing any caching in the server, could you please double-check if that happens?

To test:
* Go to an order.
* Edit the order, change the shipping address and/or the items in that order.
* Save the changes.
* Notice that the "Print label & fulfill" button is back to its "Loading..." placeholder state. When it finishes loading, the order info in the modal will be correctly updated.