### PR TITLE
Add Email Settings UI to Store.

### DIFF
--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
@@ -7,29 +7,39 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import ListItem from 'woocommerce/components/list/list-item';
+import ListItemField from 'woocommerce/components/list/list-item-field';
 
-const CustomerNotification = ( { item, checked, onToggle } ) => (
-	<Card className="components__notification-component">
-		<span className="components__notification-component-title" >
-			<FormLabel>
-				{ item.title }
-			</FormLabel>
-			<FormSettingExplanation>
-				{ item.subtitle }
-			</FormSettingExplanation>
-		</span>
-		<span className="components__notification-component-toggle">
-		<CompactFormToggle
-				checked={ checked }
-				onChange={ onToggle }
-				id={ item.field }
-			/>
-		</span>
-	</Card>
+const CustomerNotification = ( { item, checked, onToggle, isPlaceholder } ) => (
+	<ListItem className="components__notification-component">
+		<ListItemField className="components__notification-component-title" >
+			{ ! isPlaceholder
+				? <FormLabel>
+					{ item.title }
+				</FormLabel>
+				: <p className="components__notification-placeholder-title" />
+			}
+			{ ! isPlaceholder
+				? <FormSettingExplanation>
+					{ item.subtitle }
+				</FormSettingExplanation>
+				: <p className="components__notification-placeholder-title" />
+			}
+		</ListItemField>
+		<ListItemField className="components__notification-component-toggle">
+			{ ! isPlaceholder
+				? <CompactFormToggle
+					checked={ checked }
+					onChange={ onToggle }
+					id={ item.field }
+				/>
+				: <p className="components__notification-placeholder-toggle" />
+			}
+		</ListItemField>
+	</ListItem>
 );
 
 CustomerNotification.propTypes = {

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
@@ -7,12 +7,13 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
 const CustomerNotification = ( { item, checked, onToggle } ) => (
-	<div className="components__notification-component">
+	<Card className="components__notification-component">
 		<span className="components__notification-component-title" >
 			<FormLabel>
 				{ item.title }
@@ -21,16 +22,15 @@ const CustomerNotification = ( { item, checked, onToggle } ) => (
 				{ item.subtitle }
 			</FormSettingExplanation>
 		</span>
-		<span className="components__notifcation-component-toggle" >
-			<CompactFormToggle
+		<span className="components__notification-component-toggle">
+		<CompactFormToggle
 				checked={ checked }
 				onChange={ onToggle }
 				id={ item.field }
 			/>
 		</span>
-	</div>
+	</Card>
 );
-
 
 CustomerNotification.propTypes = {
 	checked: PropTypes.bool,

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+const CustomerNotification = ( { item, checked, onToggle } ) => (
+	<FormFieldset>
+		<FormLabel>
+			{ item.field }
+		</FormLabel>
+		<FormSettingExplanation>
+			{ item.subtitle }
+		</FormSettingExplanation>
+		<CompactFormToggle
+			checked={ checked }
+			onChange={ onToggle }
+			id={ item.field }
+		/>
+	</FormFieldset>
+);
+
+CustomerNotification.propTypes = {
+	checked: PropTypes.bool,
+	item: PropTypes.object,
+	onToggle: PropTypes.func.isRequired,
+};
+
+export default CustomerNotification ;

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
@@ -8,25 +8,29 @@ import React from 'react';
  * Internal dependencies
  */
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
 const CustomerNotification = ( { item, checked, onToggle } ) => (
-	<FormFieldset>
-		<FormLabel>
-			{ item.field }
-		</FormLabel>
-		<FormSettingExplanation>
-			{ item.subtitle }
-		</FormSettingExplanation>
-		<CompactFormToggle
-			checked={ checked }
-			onChange={ onToggle }
-			id={ item.field }
-		/>
-	</FormFieldset>
+	<div className="components__notification-component">
+		<span className="components__notification-component-title" >
+			<FormLabel>
+				{ item.title }
+			</FormLabel>
+			<FormSettingExplanation>
+				{ item.subtitle }
+			</FormSettingExplanation>
+		</span>
+		<span className="components__notifcation-component-toggle" >
+			<CompactFormToggle
+				checked={ checked }
+				onChange={ onToggle }
+				id={ item.field }
+			/>
+		</span>
+	</div>
 );
+
 
 CustomerNotification.propTypes = {
 	checked: PropTypes.bool,

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
@@ -15,18 +15,18 @@ import ListItemField from 'woocommerce/components/list/list-item-field';
 
 const CustomerNotification = ( { item, checked, onToggle, isPlaceholder } ) => (
 	<ListItem className="components__notification-component-item">
-		<ListItemField>
+		<ListItemField className="components__notification-component-title-long">
 			{ ! isPlaceholder
 				? <FormLabel>
 					{ item.title }
 				</FormLabel>
-				: <p className="components__notification-placeholder-title" />
+				: <p className="components__is-placeholder" />
 			}
 			{ ! isPlaceholder
 				? <FormSettingExplanation>
 					{ item.subtitle }
 				</FormSettingExplanation>
-				: <p className="components__notification-placeholder-title" />
+				: <p className="components__is-placeholder" />
 			}
 		</ListItemField>
 		<ListItemField className="components__notification-component-toggle">
@@ -36,7 +36,7 @@ const CustomerNotification = ( { item, checked, onToggle, isPlaceholder } ) => (
 					onChange={ onToggle }
 					id={ item.field }
 				/>
-				: <p className="components__notification-placeholder-toggle" />
+				: <p className="components__is-placeholder" />
 			}
 		</ListItemField>
 	</ListItem>

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
@@ -14,8 +14,8 @@ import ListItem from 'woocommerce/components/list/list-item';
 import ListItemField from 'woocommerce/components/list/list-item-field';
 
 const CustomerNotification = ( { item, checked, onToggle, isPlaceholder } ) => (
-	<ListItem className="components__notification-component">
-		<ListItemField className="components__notification-component-title" >
+	<ListItem className="components__notification-component-item">
+		<ListItemField>
 			{ ! isPlaceholder
 				? <FormLabel>
 					{ item.title }

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -21,24 +21,22 @@ const InternalNotification = ( { item, recipient, checked, onToggle, onChange, i
 				? <FormLabel>
 					{ item.title }
 				</FormLabel>
-				: <p className="components__notification-placeholder-title" />
+				: <p className="components__is-placeholder" />
 			}
 			{ ! isPlaceholder
 				? <FormSettingExplanation>
 					{ item.subtitle }
 				</FormSettingExplanation>
-				: <p className="components__notification-placeholder-title" />
+				: <p className="components__is-placeholder" />
 			}
 		</ListItemField>
 		<ListItemField className="components__notification-component-input" >
-			{ ! isPlaceholder
-				? <FormTextInput
+				<FormTextInput
+					className={ isPlaceholder ? 'components__is-placeholder' : null }
 					name={ item.field }
 					onChange={ onChange }
 					value={ recipient }
 				/>
-				: <p className="components__notification-placeholder-input" />
-			}
 		</ListItemField>
 		<ListItemField className="components__notification-component-toggle">
 			{ ! isPlaceholder
@@ -47,7 +45,7 @@ const InternalNotification = ( { item, recipient, checked, onToggle, onChange, i
 					onChange={ onToggle }
 					id={ item.field }
 				/>
-				: <p className="components__notification-placeholder-toggle" />
+				: <p className="components__is-placeholder" />
 			}
 		</ListItemField>
 	</ListItem>

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -15,7 +15,7 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
 const InternalNotification = ( { item, recipient, checked, onToggle, onChange, isPlaceholder } ) => (
-	<ListItem className="components__notification-component">
+	<ListItem className="components__notification-component-item">
 		<ListItemField className="components__notification-component-title" >
 			{ ! isPlaceholder
 				? <FormLabel>
@@ -30,10 +30,9 @@ const InternalNotification = ( { item, recipient, checked, onToggle, onChange, i
 				: <p className="components__notification-placeholder-title" />
 			}
 		</ListItemField>
-		<ListItemField>
+		<ListItemField className="components__notification-component-input" >
 			{ ! isPlaceholder
 				? <FormTextInput
-					className="components__notification-component-input"
 					name={ item.field }
 					onChange={ onChange }
 					value={ recipient }

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -7,13 +7,14 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
 const InternalNotification = ( { item, recipient, checked, onToggle, onChange } ) => (
-	<div className="components__notification-component">
+	<Card className="components__notification-component">
 		<span className="components__notification-component-title" >
 			<FormLabel>
 				{ item.title }
@@ -35,7 +36,7 @@ const InternalNotification = ( { item, recipient, checked, onToggle, onChange } 
 				id={ item.field }
 			/>
 		</span>
-	</div>
+	</Card>
 );
 
 InternalNotification.propTypes = {

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormTextInput from 'components/forms/form-text-input';
+import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+const InternalNotification = ( { item, recipient, checked, onToggle, onChange } ) => (
+	<FormFieldset>
+		<FormLabel>
+			{ item.field }
+		</FormLabel>
+		<FormSettingExplanation>
+			{ item.subtitle }
+		</FormSettingExplanation>
+		<FormTextInput
+			name={ item.name }
+			onChange={ onChange }
+			value={ recipient }
+		/>
+		<CompactFormToggle
+			checked={ checked }
+			onChange={ onToggle }
+			id={ item.field }
+		/>
+	</FormFieldset>
+);
+
+InternalNotification.propTypes = {
+	checked: PropTypes.bool,
+	recipient: PropTypes.string,
+	item: PropTypes.object,
+	onToggle: PropTypes.func.isRequired,
+	onChange: PropTypes.func.isRequired,
+};
+
+export default InternalNotification ;

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -8,30 +8,34 @@ import React from 'react';
  * Internal dependencies
  */
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import FormFieldset from 'components/forms/form-fieldset';
 import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
 const InternalNotification = ( { item, recipient, checked, onToggle, onChange } ) => (
-	<FormFieldset>
-		<FormLabel>
-			{ item.field }
-		</FormLabel>
-		<FormSettingExplanation>
-			{ item.subtitle }
-		</FormSettingExplanation>
+	<div className="components__notification-component">
+		<span className="components__notification-component-title" >
+			<FormLabel>
+				{ item.title }
+			</FormLabel>
+			<FormSettingExplanation>
+				{ item.subtitle }
+			</FormSettingExplanation>
+		</span>
 		<FormTextInput
-			name={ item.name }
+			className="components__notification-component-input"
+			name={ item.field }
 			onChange={ onChange }
 			value={ recipient }
 		/>
-		<CompactFormToggle
-			checked={ checked }
-			onChange={ onToggle }
-			id={ item.field }
-		/>
-	</FormFieldset>
+		<span className="components__notification-component-toggle">
+			<CompactFormToggle
+				checked={ checked }
+				onChange={ onToggle }
+				id={ item.field }
+			/>
+		</span>
+	</div>
 );
 
 InternalNotification.propTypes = {

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -7,36 +7,51 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
+import ListItem from 'woocommerce/components/list/list-item';
+import ListItemField from 'woocommerce/components/list/list-item-field';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
-const InternalNotification = ( { item, recipient, checked, onToggle, onChange } ) => (
-	<Card className="components__notification-component">
-		<span className="components__notification-component-title" >
-			<FormLabel>
-				{ item.title }
-			</FormLabel>
-			<FormSettingExplanation>
-				{ item.subtitle }
-			</FormSettingExplanation>
-		</span>
-		<FormTextInput
-			className="components__notification-component-input"
-			name={ item.field }
-			onChange={ onChange }
-			value={ recipient }
-		/>
-		<span className="components__notification-component-toggle">
-			<CompactFormToggle
-				checked={ checked }
-				onChange={ onToggle }
-				id={ item.field }
-			/>
-		</span>
-	</Card>
+const InternalNotification = ( { item, recipient, checked, onToggle, onChange, isPlaceholder } ) => (
+	<ListItem className="components__notification-component">
+		<ListItemField className="components__notification-component-title" >
+			{ ! isPlaceholder
+				? <FormLabel>
+					{ item.title }
+				</FormLabel>
+				: <p className="components__notification-placeholder-title" />
+			}
+			{ ! isPlaceholder
+				? <FormSettingExplanation>
+					{ item.subtitle }
+				</FormSettingExplanation>
+				: <p className="components__notification-placeholder-title" />
+			}
+		</ListItemField>
+		<ListItemField>
+			{ ! isPlaceholder
+				? <FormTextInput
+					className="components__notification-component-input"
+					name={ item.field }
+					onChange={ onChange }
+					value={ recipient }
+				/>
+				: <p className="components__notification-placeholder-input" />
+			}
+		</ListItemField>
+		<ListItemField className="components__notification-component-toggle">
+			{ ! isPlaceholder
+				? <CompactFormToggle
+					checked={ checked }
+					onChange={ onToggle }
+					id={ item.field }
+				/>
+				: <p className="components__notification-placeholder-toggle" />
+			}
+		</ListItemField>
+	</ListItem>
 );
 
 InternalNotification.propTypes = {

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FormFieldset from 'components/forms/form-fieldset';
+import FormTextInput from 'components/forms/form-text-input';
+import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+const NotificationsOrigin = ( { item, recipient, onChange } ) => (
+	<FormFieldset>
+		<FormLabel>
+			{ item.field }
+		</FormLabel>
+		<FormTextInput
+			name={ item.name }
+			onChange={ onChange }
+			value={ recipient }
+		/>
+		<FormSettingExplanation>
+			{ item.subtitle }
+		</FormSettingExplanation>
+	</FormFieldset>
+);
+
+NotificationsOrigin.propTypes = {
+	checked: PropTypes.bool,
+	recipient: PropTypes.string,
+	item: PropTypes.object,
+	onToggle: PropTypes.func.isRequired,
+	onChange: PropTypes.func.isRequired,
+};
+
+export default NotificationsOrigin ;

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
@@ -15,7 +15,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
 const NotificationsOrigin = ( { item, recipient, onChange } ) => (
 	<ListItem>
-		<ListItemField>
+		<ListItemField className="components__notification-origin">
 			<FormLabel>
 				{ item.title }
 			</FormLabel>

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
@@ -15,10 +15,10 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 const NotificationsOrigin = ( { item, recipient, onChange } ) => (
 	<FormFieldset>
 		<FormLabel>
-			{ item.field }
+			{ item.title }
 		</FormLabel>
 		<FormTextInput
-			name={ item.name }
+			name={ item.field }
 			onChange={ onChange }
 			value={ recipient }
 		/>
@@ -29,10 +29,8 @@ const NotificationsOrigin = ( { item, recipient, onChange } ) => (
 );
 
 NotificationsOrigin.propTypes = {
-	checked: PropTypes.bool,
 	recipient: PropTypes.string,
 	item: PropTypes.object,
-	onToggle: PropTypes.func.isRequired,
 	onChange: PropTypes.func.isRequired,
 };
 

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
@@ -13,20 +13,27 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
-const NotificationsOrigin = ( { item, recipient, onChange } ) => (
+const NotificationsOrigin = ( { item, recipient, onChange, isPlaceholder } ) => (
 	<ListItem>
 		<ListItemField className="components__notification-origin">
-			<FormLabel>
-				{ item.title }
-			</FormLabel>
+			{ ! isPlaceholder
+				? <FormLabel>
+					{ item.title }
+				</FormLabel>
+				: <p className="components__is-placeholder" />
+			}
 			<FormTextInput
+				className={ isPlaceholder ? 'components__is-placeholder' : null }
 				name={ item.field }
 				onChange={ onChange }
 				value={ recipient }
 			/>
-			<FormSettingExplanation>
-				{ item.subtitle }
-			</FormSettingExplanation>
+			{ ! isPlaceholder
+				? <FormSettingExplanation>
+					{ item.subtitle }
+				</FormSettingExplanation>
+				: <p className="components__is-placeholder" />
+			}
 		</ListItemField>
 	</ListItem>
 );

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
@@ -7,25 +7,28 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import FormFieldset from 'components/forms/form-fieldset';
+import ListItem from 'woocommerce/components/list/list-item';
+import ListItemField from 'woocommerce/components/list/list-item-field';
 import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
 const NotificationsOrigin = ( { item, recipient, onChange } ) => (
-	<FormFieldset>
-		<FormLabel>
-			{ item.title }
-		</FormLabel>
-		<FormTextInput
-			name={ item.field }
-			onChange={ onChange }
-			value={ recipient }
-		/>
-		<FormSettingExplanation>
-			{ item.subtitle }
-		</FormSettingExplanation>
-	</FormFieldset>
+	<ListItem>
+		<ListItemField>
+			<FormLabel>
+				{ item.title }
+			</FormLabel>
+			<FormTextInput
+				name={ item.field }
+				onChange={ onChange }
+				value={ recipient }
+			/>
+			<FormSettingExplanation>
+				{ item.subtitle }
+			</FormSettingExplanation>
+		</ListItemField>
+	</ListItem>
 );
 
 NotificationsOrigin.propTypes = {

--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { bindActionCreators } from 'redux';
-import { localize } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -28,32 +28,31 @@ import NotificationsOrigin from './components/notifications-origin';
 const fromName =
 	{
 		field: 'woocommerce_email_from_address',
-		title: '',
-		subtitle: '',
+		title: translate( 'From name' ),
+		subtitle: translate( 'Emails will appear in recipients inpboxses \'from\' this name.' ),
 	};
-
 const fromAddress =
 	{
 		field: 'woocommerce_email_from_name',
-		title: '',
-		subtitle: '',
+		title: translate( 'From address' ),
+		subtitle: translate( 'If recipients reply to store emails they will be sent to this address.' ),
 	};
 
 const internalNotifications = [
 	{
 		field: 'email_new_order',
-		title: '',
-		subtitle: '',
+		title: translate( 'New order' ),
+		subtitle: translate( 'Sent when a new order is received.' ),
 	},
 	{
 		field: 'email_cancelled_order',
-		title: '',
-		subtitle: '',
+		title: translate( 'Cancelled order' ),
+		subtitle: translate( 'Sent when a new order is marked \'cancelled\'.' ),
 	},
 	{
 		field: 'email_failed_order',
-		title: '',
-		subtitle: '',
+		title: translate( 'Failed order' ),
+		subtitle: translate( 'Sent when a new order is marked \'failed\'.' ),
 	},
 ];
 
@@ -61,28 +60,28 @@ const internalNotifications = [
 const customerNotifications = [
 	{
 		field: 'email_customer_on_hold_order',
-		title: '',
-		subtitle: '',
+		title: translate( 'Order pending payment' ),
+		subtitle: translate( 'Sent when an order is marked \'payment pending\'.' ),
 	},
 	{
 		field: 'email_customer_processing_order',
-		title: '',
-		subtitle: '',
+		title: translate( 'Processing order' ),
+		subtitle: translate( 'Sent when an order is marked \'payment processing\'.' ),
 	},
 	{
 		field: 'email_customer_completed_order',
-		title: '',
-		subtitle: '',
+		title: translate( 'Completed order' ),
+		subtitle: translate( 'Sent when an order is marked \'paid in full\'.' ),
 	},
 	{
 		field: 'email_customer_refunded_order',
-		title: '',
-		subtitle: '',
+		title: translate( 'Refunded order' ),
+		subtitle: translate( 'Sent when an order is marked \'payment refunded\'.' ),
 	},
 	{
 		field: 'email_customer_new_account',
-		title: '',
-		subtitle: '',
+		title: translate( 'Refunded order' ),
+		subtitle: translate( 'Sent when an order is marked \'payment refunded\'.' ),
 	},
 ];
 >>>>>>> Add first pass of email settings UI
@@ -147,7 +146,12 @@ class Settings extends React.Component {
 				</div>
 				<div className="email-settings__internal-notifications">
 					<Card className="email-settings__internal-notifications-title">
-						Internal notifications
+						<div className="email-settings__section-title-text">
+							{ translate( 'Internal notifications' ) }
+						</div>
+						<div className="email-settings__section-subtitle-text">
+							{ translate( 'Email notifications sent to store staff.' ) }
+						</div>
 					</Card>
 					<Card className="email-settings__internal-notifications-legend">
 						<span>
@@ -182,7 +186,12 @@ class Settings extends React.Component {
 				</div>
 				<div className="email-settings__customer-notifications">
 					<Card className="email-settings__customer-notifications-title">
-						Customer notifications
+					<div className="email-settings__section-title-text">
+							{ translate( 'Customer notifications' ) }
+						</div>
+						<div className="email-settings__section-subtitle-text">
+							{ translate( 'Email notifications sent to your customers.' ) }
+						</div>
 					</Card>
 					<Card className="email-settings__customer-notifications-legend">
 						<span>
@@ -241,4 +250,4 @@ function mapDispatchToProps( dispatch ) {
 	);
 }
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( Settings ) );
+export default connect( mapStateToProps, mapDispatchToProps )( Settings );

--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -16,10 +16,13 @@ import {
 	areEmailSettingsLoading,
 	areEmailSettingsLoaded,
 } from 'woocommerce/state/sites/settings/email/selectors';
-import Card from 'components/card';
 import CustomerNotification from './components/customer-notification';
+import ExtendedHeader from 'woocommerce/components/extended-header';
 import InternalNotification from './components/internal-notification';
 import NotificationsOrigin from './components/notifications-origin';
+import List from 'woocommerce/components/list/list';
+import ListHeader from 'woocommerce/components/list/list-header';
+import ListItemField from 'woocommerce/components/list/list-item-field';
 
 const fromName =
 	{
@@ -110,114 +113,89 @@ class Settings extends React.Component {
 		undefined;
 	}
 
+	renderInternalNotification = ( item, index ) => {
+		const { settings, loaded } = this.props;
+		return <InternalNotification
+			key={ index }
+			item={ item }
+			checked={ 'yes' === ( loaded && settings[ item.field ].enabled ) }
+			recipient={ loaded ? settings[ item.field ].recipient : '' }
+			isPlaceholder={ ! loaded }
+			onToggle={ this.notificationsToggle }
+			onChange={ this.recipientsChange }
+		/>;
+	}
+
+	renderCustomerNotification = ( item, index ) => {
+		const { settings, loaded } = this.props;
+		return <CustomerNotification
+			key={ index }
+			item={ item }
+			isPlaceholder={ ! loaded }
+			checked={ 'yes' === ( loaded && settings[ item.field ].enabled ) }
+			onToggle={ this.notificationsToggle }
+		/>;
+	}
+
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	render() {
-		const { loading, loaded, settings } = this.props;
-		const waiting = ! loaded || loading;
+		const { loaded, settings } = this.props;
 
 		return (
 			<div className="email-settings__container">
-				<div className="email-settings__origin">
-					<Card className="email-settings__origin-title">
-						Origin
-					</Card>
-					<Card className="email-settings__origin-settings">
-						{ waiting && <p className="email-settings__loading" /> }
-						{ loaded && <NotificationsOrigin
-								item={ fromName }
-								recipient={ settings.email[ fromName.field ] }
-								onChange={ this.recipientsChange }
-							/> }
-						{ waiting && <p className="email-settings__loading" /> }
-						{ loaded && <NotificationsOrigin
-								item={ fromAddress }
-								recipient={ settings.email[ fromAddress.field ] }
-								onChange={ this.recipientsChange }
-							/> }
-					</Card>
-				</div>
+				<List className="email-settings__origin">
+					<ExtendedHeader
+						label={ translate( 'Origin' ) }
+					/>
+					<NotificationsOrigin
+						item={ fromName }
+						isPlaceholder={ ! loaded }
+						recipient={ loaded ? settings.email[ fromName.field ] : '' }
+						onChange={ this.recipientsChange }
+					/>
+					<NotificationsOrigin
+						item={ fromAddress }
+						isPlaceholder={ ! loaded }
+						recipient={ loaded ? settings.email[ fromAddress.field ] : '' }
+						onChange={ this.recipientsChange }
+					/>
+				</List>
 				<div className="email-settings__internal-notifications">
-					<Card className="email-settings__internal-notifications-title">
-						<div className="email-settings__section-title-text">
-							{ translate( 'Internal notifications' ) }
-						</div>
-						<div className="email-settings__section-subtitle-text">
-							{ translate( 'Email notifications sent to store staff.' ) }
-						</div>
-					</Card>
-					<Card className="email-settings__internal-notifications-legend">
-						<span className="email-settings__internal-notifications-legend-option">
-							Email
-						</span>
-						<span className="email-settings__internal-notifications-legend-input">
-							Recipients (comma separated)
-						</span>
-						<span className="email-settings__internal-notifications-legend-toggle">
-							Enabled
-						</span>
-					</Card>
-					{
-						waiting &&
-							<Card className="email-settings__loading-card" >
-								{ internalNotifications.map( ( item, index ) => {
-									return <p key={ index } className="email-settings__loading" />;
-								} ) }
-							</Card>
-					}
-					{
-						loaded &&
-							<Card className="email-settings__internal-notifications-settings">
-								{ internalNotifications.map( ( item, index ) => {
-									return <InternalNotification
-										key={ index }
-										item={ item }
-										checked={ 'yes' === settings[ item.field ].enabled }
-										recipient={ settings[ item.field ].recipient }
-										onToggle={ this.notificationsToggle }
-										onChange={ this.recipientsChange }
-									/>;
-								} ) }
-							</Card>
-					}
+					<ExtendedHeader
+						label={ translate( 'Internal notifications' ) }
+						description={ translate( 'Email notifications sent to store staff.' ) }
+					/>
+					<List>
+						<ListHeader>
+							<ListItemField className="shipping-zone__location-title">
+								{ translate( 'Email' ) }
+							</ListItemField>
+							<ListItemField className="shipping-zone__location-summary">
+								{ translate( 'Recipients (comma separated)' ) }
+							</ListItemField>
+							<ListItemField className="shipping-zone__location-summary">
+								{ translate( 'Enabled' ) }
+							</ListItemField>
+						</ListHeader>
+						{ internalNotifications.map( this.renderInternalNotification ) }
+					</List>
 				</div>
 				<div className="email-settings__customer-notifications">
-					<Card className="email-settings__customer-notifications-title">
-					<div className="email-settings__section-title-text">
-							{ translate( 'Customer notifications' ) }
-						</div>
-						<div className="email-settings__section-subtitle-text">
-							{ translate( 'Email notifications sent to your customers.' ) }
-						</div>
-					</Card>
-					<Card className="email-settings__customer-notifications-legend">
-						<span className="email-settings__internal-notifications-legend-option">
-							Email
-						</span>
-						<span className="email-settings__internal-notifications-legend-toggle">
-							Enabled
-						</span>
-					</Card>
-					{
-						waiting &&
-							<Card className="email-settings__loading-card" >
-								{ customerNotifications.map( ( item, index ) => {
-									return <p key={ index } className="email-settings__loading" />;
-								} ) }
-							</Card>
-					}
-					{
-						loaded &&
-							<Card className="email-settings__customer-notifications-settings">
-								{ customerNotifications.map( ( item, index ) => {
-									return <CustomerNotification
-										key={ index }
-										item={ item }
-										checked={ 'yes' === settings[ item.field ].enabled }
-										onToggle={ this.notificationsToggle }
-									/>;
-								} ) }
-							</Card>
-					}
+					<ExtendedHeader
+						label={ translate( 'Customer notifications' ) }
+						description={ translate( 'Email notifications sent to your customers.' ) }
+					/>
+					<List>
+						<ListHeader>
+							<ListItemField className="shipping-zone__location-title">
+								{ translate( 'Email' ) }
+							</ListItemField>
+							<ListItemField className="shipping-zone__location-summary">
+								{ translate( 'Enabled' ) }
+							</ListItemField>
+						</ListHeader>
+						{ customerNotifications.map( this.renderCustomerNotification ) }
+					</List>
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -28,7 +28,7 @@ const fromName =
 	{
 		field: 'woocommerce_email_from_address',
 		title: translate( 'From name' ),
-		subtitle: translate( 'Emails will appear in recipients inpboxses \'from\' this name.' ),
+		subtitle: translate( 'Emails will appear in recipients inboxes \'from\' this name.' ),
 	};
 const fromAddress =
 	{
@@ -79,16 +79,12 @@ const customerNotifications = [
 	},
 	{
 		field: 'email_customer_new_account',
-		title: translate( 'Refunded order' ),
-		subtitle: translate( 'Sent when an order is marked \'payment refunded\'.' ),
+		title: translate( 'New account' ),
+		subtitle: translate( 'Sent when customers sign up via checkout or account page.' ),
 	},
 ];
 
 class Settings extends React.Component {
-
-	constructor( props ) {
-		super( props );
-	}
 
 	fetchSettings = ( props ) => {
 		const { siteId, fetchSettings } = props;

--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -143,7 +143,7 @@ class Settings extends React.Component {
 
 		return (
 			<div className="email-settings__container">
-				<List className="email-settings__origin">
+				<List>
 					<ExtendedHeader
 						label={ translate( 'Origin' ) }
 					/>
@@ -160,37 +160,37 @@ class Settings extends React.Component {
 						onChange={ this.recipientsChange }
 					/>
 				</List>
-				<div className="email-settings__internal-notifications">
+				<div>
 					<ExtendedHeader
 						label={ translate( 'Internal notifications' ) }
 						description={ translate( 'Email notifications sent to store staff.' ) }
 					/>
 					<List>
 						<ListHeader>
-							<ListItemField className="shipping-zone__location-title">
+							<ListItemField className="components__notification-component-title">
 								{ translate( 'Email' ) }
 							</ListItemField>
-							<ListItemField className="shipping-zone__location-summary">
+							<ListItemField className="components__notification-component-input">
 								{ translate( 'Recipients (comma separated)' ) }
 							</ListItemField>
-							<ListItemField className="shipping-zone__location-summary">
+							<ListItemField className="components__notification-component-toggle-label">
 								{ translate( 'Enabled' ) }
 							</ListItemField>
 						</ListHeader>
 						{ internalNotifications.map( this.renderInternalNotification ) }
 					</List>
 				</div>
-				<div className="email-settings__customer-notifications">
+				<div>
 					<ExtendedHeader
 						label={ translate( 'Customer notifications' ) }
 						description={ translate( 'Email notifications sent to your customers.' ) }
 					/>
 					<List>
 						<ListHeader>
-							<ListItemField className="shipping-zone__location-title">
+							<ListItemField>
 								{ translate( 'Email' ) }
 							</ListItemField>
-							<ListItemField className="shipping-zone__location-summary">
+							<ListItemField>
 								{ translate( 'Enabled' ) }
 							</ListItemField>
 						</ListHeader>

--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -24,18 +24,18 @@ import List from 'woocommerce/components/list/list';
 import ListHeader from 'woocommerce/components/list/list-header';
 import ListItemField from 'woocommerce/components/list/list-item-field';
 
-const fromName =
+const originNotifications = [
 	{
 		field: 'woocommerce_email_from_address',
 		title: translate( 'From name' ),
 		subtitle: translate( 'Emails will appear in recipients inboxes \'from\' this name.' ),
-	};
-const fromAddress =
+	},
 	{
 		field: 'woocommerce_email_from_name',
 		title: translate( 'From address' ),
 		subtitle: translate( 'If recipients reply to store emails they will be sent to this address.' ),
-	};
+	},
+];
 
 const internalNotifications = [
 	{
@@ -109,25 +109,36 @@ class Settings extends React.Component {
 		undefined;
 	}
 
+	renderOriginNotification = ( item, index ) => {
+		const { settings, loaded, loading } = this.props;
+		return <NotificationsOrigin
+			key={ index }
+			item={ item }
+			isPlaceholder={ loading }
+			recipient={ loaded ? settings.email[ item.field ] : '' }
+			onChange={ this.recipientsChange }
+		/>;
+	}
+
 	renderInternalNotification = ( item, index ) => {
-		const { settings, loaded } = this.props;
+		const { settings, loaded, loading } = this.props;
 		return <InternalNotification
 			key={ index }
 			item={ item }
 			checked={ 'yes' === ( loaded && settings[ item.field ].enabled ) }
 			recipient={ loaded ? settings[ item.field ].recipient : '' }
-			isPlaceholder={ ! loaded }
+			isPlaceholder={ loading }
 			onToggle={ this.notificationsToggle }
 			onChange={ this.recipientsChange }
 		/>;
 	}
 
 	renderCustomerNotification = ( item, index ) => {
-		const { settings, loaded } = this.props;
+		const { settings, loaded, loading } = this.props;
 		return <CustomerNotification
 			key={ index }
 			item={ item }
-			isPlaceholder={ ! loaded }
+			isPlaceholder={ loading }
 			checked={ 'yes' === ( loaded && settings[ item.field ].enabled ) }
 			onToggle={ this.notificationsToggle }
 		/>;
@@ -135,26 +146,13 @@ class Settings extends React.Component {
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	render() {
-		const { loaded, settings } = this.props;
-
 		return (
 			<div className="email-settings__container">
+				<ExtendedHeader
+					label={ translate( 'Origin' ) }
+				/>
 				<List>
-					<ExtendedHeader
-						label={ translate( 'Origin' ) }
-					/>
-					<NotificationsOrigin
-						item={ fromName }
-						isPlaceholder={ ! loaded }
-						recipient={ loaded ? settings.email[ fromName.field ] : '' }
-						onChange={ this.recipientsChange }
-					/>
-					<NotificationsOrigin
-						item={ fromAddress }
-						isPlaceholder={ ! loaded }
-						recipient={ loaded ? settings.email[ fromAddress.field ] : '' }
-						onChange={ this.recipientsChange }
-					/>
+					{ originNotifications.map( this.renderOriginNotification ) }
 				</List>
 				<div>
 					<ExtendedHeader

--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -12,10 +12,6 @@ import { connect } from 'react-redux';
  */
 import { fetchEmailSettings } from 'woocommerce/state/sites/settings/email/actions';
 import {
-<<<<<<< HEAD
-	fetchEmailSettings,
-} from 'woocommerce/state/sites/settings/email/actions';
-=======
 	getEmailSettings,
 	areEmailSettingsLoading,
 	areEmailSettingsLoaded,
@@ -84,7 +80,6 @@ const customerNotifications = [
 		subtitle: translate( 'Sent when an order is marked \'payment refunded\'.' ),
 	},
 ];
->>>>>>> Add first pass of email settings UI
 
 class Settings extends React.Component {
 
@@ -111,13 +106,10 @@ class Settings extends React.Component {
 		undefined;
 	}
 
-<<<<<<< HEAD
-=======
 	recipientsChange = () => {
 		undefined;
 	}
 
->>>>>>> Add first pass of email settings UI
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	render() {
 		const { loading, loaded, settings } = this.props;
@@ -154,35 +146,39 @@ class Settings extends React.Component {
 						</div>
 					</Card>
 					<Card className="email-settings__internal-notifications-legend">
-						<span>
+						<span className="email-settings__internal-notifications-legend-option">
 							Email
 						</span>
-						<span>
+						<span className="email-settings__internal-notifications-legend-input">
 							Recipients (comma separated)
 						</span>
-						<span>
+						<span className="email-settings__internal-notifications-legend-toggle">
 							Enabled
 						</span>
 					</Card>
-					<Card className="email-settings__internal-notifications-settings">
 					{
-							internalNotifications.map( ( item, index ) => {
-								if ( waiting ) {
+						waiting &&
+							<Card className="email-settings__loading-card" >
+								{ internalNotifications.map( ( item, index ) => {
 									return <p key={ index } className="email-settings__loading" />;
-								}
-								return (
-									<InternalNotification
+								} ) }
+							</Card>
+					}
+					{
+						loaded &&
+							<Card className="email-settings__internal-notifications-settings">
+								{ internalNotifications.map( ( item, index ) => {
+									return <InternalNotification
 										key={ index }
 										item={ item }
 										checked={ 'yes' === settings[ item.field ].enabled }
 										recipient={ settings[ item.field ].recipient }
 										onToggle={ this.notificationsToggle }
 										onChange={ this.recipientsChange }
-									/>
-								);
-							} )
-						}
-					</Card>
+									/>;
+								} ) }
+							</Card>
+					}
 				</div>
 				<div className="email-settings__customer-notifications">
 					<Card className="email-settings__customer-notifications-title">
@@ -194,30 +190,34 @@ class Settings extends React.Component {
 						</div>
 					</Card>
 					<Card className="email-settings__customer-notifications-legend">
-						<span>
+						<span className="email-settings__internal-notifications-legend-option">
 							Email
 						</span>
-						<span>
+						<span className="email-settings__internal-notifications-legend-toggle">
 							Enabled
 						</span>
 					</Card>
-					<Card className="email-settings__customer-notifications-settings">
-						{
-							customerNotifications.map( ( item, index ) => {
-								if ( waiting ) {
+					{
+						waiting &&
+							<Card className="email-settings__loading-card" >
+								{ customerNotifications.map( ( item, index ) => {
 									return <p key={ index } className="email-settings__loading" />;
-								}
-								return (
-									<CustomerNotification
+								} ) }
+							</Card>
+					}
+					{
+						loaded &&
+							<Card className="email-settings__customer-notifications-settings">
+								{ customerNotifications.map( ( item, index ) => {
+									return <CustomerNotification
 										key={ index }
 										item={ item }
 										checked={ 'yes' === settings[ item.field ].enabled }
 										onToggle={ this.notificationsToggle }
-									/>
-								);
-							} )
-						}
-					</Card>
+									/>;
+								} ) }
+							</Card>
+					}
 				</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -10,30 +10,206 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { fetchEmailSettings } from 'woocommerce/state/sites/settings/email/actions';
 import {
+<<<<<<< HEAD
 	fetchEmailSettings,
 } from 'woocommerce/state/sites/settings/email/actions';
+=======
+	getEmailSettings,
+	areEmailSettingsLoading,
+	areEmailSettingsLoaded,
+} from 'woocommerce/state/sites/settings/email/selectors';
+import Card from 'components/card';
+import CustomerNotification from './components/customer-notification';
+import InternalNotification from './components/internal-notification';
+import NotificationsOrigin from './components/notifications-origin';
+
+const fromName =
+	{
+		field: 'woocommerce_email_from_address',
+		title: '',
+		subtitle: '',
+	};
+
+const fromAddress =
+	{
+		field: 'woocommerce_email_from_name',
+		title: '',
+		subtitle: '',
+	};
+
+const internalNotifications = [
+	{
+		field: 'email_new_order',
+		title: '',
+		subtitle: '',
+	},
+	{
+		field: 'email_cancelled_order',
+		title: '',
+		subtitle: '',
+	},
+	{
+		field: 'email_failed_order',
+		title: '',
+		subtitle: '',
+	},
+];
+
+// id enabled
+const customerNotifications = [
+	{
+		field: 'email_customer_on_hold_order',
+		title: '',
+		subtitle: '',
+	},
+	{
+		field: 'email_customer_processing_order',
+		title: '',
+		subtitle: '',
+	},
+	{
+		field: 'email_customer_completed_order',
+		title: '',
+		subtitle: '',
+	},
+	{
+		field: 'email_customer_refunded_order',
+		title: '',
+		subtitle: '',
+	},
+	{
+		field: 'email_customer_new_account',
+		title: '',
+		subtitle: '',
+	},
+];
+>>>>>>> Add first pass of email settings UI
 
 class Settings extends React.Component {
 
+	constructor( props ) {
+		super( props );
+	}
+
+	fetchSettings = ( props ) => {
+		const { siteId, fetchSettings } = props;
+		siteId && fetchSettings( siteId );
+	}
+
 	componentDidMount = () => {
-		const { siteId, fetchEmailSettings: fetch } = this.props;
-		siteId && fetch( siteId );
+		this.fetchSettings( this.props );
 	};
 
 	componentWillReceiveProps = newProps => {
-		if ( newProps.siteId === this.props.siteId ) {
-			return;
+		if ( newProps.siteId !== this.props.siteId ) {
+			this.fetchSettings( newProps );
 		}
+	};
 
-		const { siteId, fetchEmailSettings: fetch } = newProps;
-		siteId && fetch( siteId );
+	notificationsToggle = () => {
+		undefined;
 	}
 
+<<<<<<< HEAD
+=======
+	recipientsChange = () => {
+		undefined;
+	}
+
+>>>>>>> Add first pass of email settings UI
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	render() {
+		const { loading, loaded, settings } = this.props;
+		const waiting = ! loaded || loading;
+
 		return (
 			<div className="email-settings__container">
+				<div className="email-settings__origin">
+					<Card className="email-settings__origin-title">
+						Origin
+					</Card>
+					<Card className="email-settings__origin-settings">
+						{ waiting && <p className="email-settings__loading" /> }
+						{ loaded && <NotificationsOrigin
+								item={ fromName }
+								recipient={ settings.email[ fromName.field ] }
+								onChange={ this.recipientsChange }
+							/> }
+						{ waiting && <p className="email-settings__loading" /> }
+						{ loaded && <NotificationsOrigin
+								item={ fromAddress }
+								recipient={ settings.email[ fromAddress.field ] }
+								onChange={ this.recipientsChange }
+							/> }
+					</Card>
+				</div>
+				<div className="email-settings__internal-notifications">
+					<Card className="email-settings__internal-notifications-title">
+						Internal notifications
+					</Card>
+					<Card className="email-settings__internal-notifications-legend">
+						<span>
+							Email
+						</span>
+						<span>
+							Recipients (comma separated)
+						</span>
+						<span>
+							Enabled
+						</span>
+					</Card>
+					<Card className="email-settings__internal-notifications-settings">
+					{
+							internalNotifications.map( ( item, index ) => {
+								if ( waiting ) {
+									return <p key={ index } className="email-settings__loading" />;
+								}
+								return (
+									<InternalNotification
+										key={ index }
+										item={ item }
+										checked={ 'yes' === settings[ item.field ].enabled }
+										recipient={ settings[ item.field ].recipient }
+										onToggle={ this.notificationsToggle }
+										onChange={ this.recipientsChange }
+									/>
+								);
+							} )
+						}
+					</Card>
+				</div>
+				<div className="email-settings__customer-notifications">
+					<Card className="email-settings__customer-notifications-title">
+						Customer notifications
+					</Card>
+					<Card className="email-settings__customer-notifications-legend">
+						<span>
+							Email
+						</span>
+						<span>
+							Enabled
+						</span>
+					</Card>
+					<Card className="email-settings__customer-notifications-settings">
+						{
+							customerNotifications.map( ( item, index ) => {
+								if ( waiting ) {
+									return <p key={ index } className="email-settings__loading" />;
+								}
+								return (
+									<CustomerNotification
+										key={ index }
+										item={ item }
+										checked={ 'yes' === settings[ item.field ].enabled }
+										onToggle={ this.notificationsToggle }
+									/>
+								);
+							} )
+						}
+					</Card>
+				</div>
 			</div>
 		);
 	}
@@ -42,15 +218,27 @@ class Settings extends React.Component {
 
 Settings.propTypes = {
 	siteId: PropTypes.number.isRequired,
+	fetchSettings: PropTypes.func.isRequired,
+	settings: PropTypes.object,
+	loading: PropTypes.bool,
 };
+
+function mapStateToProps( state, props ) {
+	return {
+		settings: areEmailSettingsLoaded( state, props.siteId )
+			? getEmailSettings( state, props.siteId ) : {},
+		loading: areEmailSettingsLoading( state, props.siteId ),
+		loaded: areEmailSettingsLoaded( state, props.siteId ),
+	};
+}
 
 function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
-			fetchEmailSettings,
+			fetchSettings: fetchEmailSettings,
 		},
 		dispatch
 	);
 }
 
-export default connect( null, mapDispatchToProps )( localize( Settings ) );
+export default connect( mapStateToProps, mapDispatchToProps )( localize( Settings ) );

--- a/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
@@ -5,6 +5,10 @@
 		width: 50%;
 	}
 
+	.components__notification-component-title-long {
+		width: 80%;
+	}
+
 	.components__notification-component-input {
 		padding-left: 0px;
 		padding-right: 0px;
@@ -13,6 +17,7 @@
 	}
 
 	.components__notification-component-toggle {
+		height: 58px;
 		width: 80px;
 	}
 
@@ -40,6 +45,18 @@
 		input {
 			width: 75%;
 		}
+	}
+
+	.components__is-placeholder {
+		@include placeholder();
+		padding: 0px;
+		margin: 0px 0px 4px 0px;
+		pointer-events: none;
+		background: $white;
+		animation: loading-fade 1.6s ease-in-out infinite;
+		background-color: lighten( $gray, 25% );
+		color: transparent;
+		cursor: default;
 	}
 
 }

--- a/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
@@ -1,0 +1,15 @@
+.email-settings__origin {
+	padding: 0px;
+}
+
+.email-settings__origin-title,
+.email-settings__internal-notifications-title,
+.email-settings__customer-notifications-title {
+	margin-bottom: 0px;
+}
+
+.email-settings__internal-notifications-legend,
+.email-settings__customer-notifications-legend {
+	margin-bottom: 0px;
+	background: $gray-light;
+}

--- a/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
@@ -1,128 +1,28 @@
-.email-settings__origin {
-	padding: 0px;
-}
-
-.email-settings__internal-notifications,
-.email-settings__customer-notifications {
-	padding: 0px;
-}
-
-.email-settings__origin-title,
-.email-settings__internal-notifications-title,
-.email-settings__customer-notifications-title {
-	margin-bottom: 0px;
-}
-
-.email-settings__internal-notifications-legend,
-.email-settings__customer-notifications-legend {
-	margin-bottom: 0px;
-	background: $gray-light;
-}
-
-.email-settings__section-title-text {
-	font-size: 18px;
-	font-weight: 500;
-	padding-bottom: 4px;
-}
-
-.email-settings__section-subtitle-text {
-	color: $gray-text-min;
-	font-size: 12px;
-	line-height: 18px;
-	padding-bottom: 4px;
-}
-.email-settings__customer-notifications-settings,
-.email-settings__internal-notifications-settings {
-	display: flex;
-	flex-direction: column;
-	padding: 0px;
-}
-
-.components__notification-component {
-	display: flex;
-	align-items: center;
-	margin: 0px;
-	padding: 0px;
-}
 
 .components__notification-component-title {
-	width: 300px;
-	flex-grow: 0;
-	padding: 24px;
+	width: 50%;
 }
 
-.email-settings__internal-notifications-legend,
-.email-settings__customer-notifications-legend {
-	display: flex;
-	flex-direction: row;
-	padding: 16px 0;
-	align-items: center;
-	font-weight: 600;
-	&:not( :last-child ) {
-		border-bottom: 1px solid lighten( $gray, 20% );
-	}
-}
-
-.email-settings__customer-notifications-legend-option,
-.email-settings__internal-notifications-legend-option {
-	padding: 12px 24px 12px 24px;
-	width: 300px;
-}
-
-.email-settings__internal-notifications-legend-input {
-	padding: 12px 24px 12px 0px;
-	flex-grow: 1;
+.components__notification-component-input.list-item-field {
+	padding-left: 0px;
+	padding-right: 0px;
 	flex-shrink: 1;
-}
- 
-
-.components__notification-component-input {
-	max-width: 240px;
-	flex-grow: 1;
-	flex-shrink: 1;
-}
-
-.email-settings__internal-notifications-legend-toggle {
-	flex-grow: 1;
-	text-align: right;
-	padding: 12px 24px 12px 24px;
+	width: 40%;
 }
 
 .components__notification-component-toggle {
-	flex-grow: 1;
-	.form-toggle__label {
-		float: right;
-		padding-right: 24px;
-		padding-left: 24px;
-	}
+	width: 80px;
 }
 
-.email-settings__loading-card {
-	margin: 0px 0px 16px 0px;
-	padding-bottom: 0px;
+.components__notification-component-toggle-label.list-item-field {
+	width: 80px;
+	padding-left: 6px;
 }
 
-.components__notification-placeholder-input,
-.components__notification-placeholder-toggle,
-.components__notification-placeholder-title {
-	@include placeholder();
-	pointer-events: none;
-	background: $white;
-	height: 14px;
-	animation: loading-fade 1.6s ease-in-out infinite;
-	background-color: lighten( $gray, 25% );
+.components__notification-component-item.list-item {
+	flex-wrap: nowrap;
 }
 
-.components__notification-placeholder-toggle {
-	width: 24px;
-	margin-right: 24px;
-	float: right;
-}
-
-.components__notification-placeholder-title {
-	width: 300px;
-}
-
-.components__notification-placeholder-input {
-	width: 240px; 
+.components__notification-origin {
+	width: 75%;
 }

--- a/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
@@ -2,6 +2,11 @@
 	padding: 0px;
 }
 
+.email-settings__internal-notifications,
+.email-settings__customer-notifications {
+	padding: 0px;
+}
+
 .email-settings__origin-title,
 .email-settings__internal-notifications-title,
 .email-settings__customer-notifications-title {
@@ -41,32 +46,35 @@
 }
 
 .components__notification-component-title {
-	min-width: 300px;
+	width: 300px;
 	flex-grow: 0;
 	padding: 24px;
 }
 
 .email-settings__internal-notifications-legend,
 .email-settings__customer-notifications-legend {
-	padding: 0px;
 	display: flex;
+	flex-direction: row;
+	padding: 16px 0;
+	align-items: center;
+	font-weight: 600;
+	&:not( :last-child ) {
+		border-bottom: 1px solid lighten( $gray, 20% );
+	}
 }
 
 .email-settings__customer-notifications-legend-option,
 .email-settings__internal-notifications-legend-option {
 	padding: 12px 24px 12px 24px;
-	min-width: 300px;
-	flex-grow: 1;
-	flex-shrink: 1;
+	width: 300px;
 }
 
 .email-settings__internal-notifications-legend-input {
-	padding: 12px 24px 12px 24px;
-	max-width: 240px;
+	padding: 12px 24px 12px 0px;
 	flex-grow: 1;
 	flex-shrink: 1;
 }
-
+ 
 
 .components__notification-component-input {
 	max-width: 240px;
@@ -75,6 +83,7 @@
 }
 
 .email-settings__internal-notifications-legend-toggle {
+	flex-grow: 1;
 	text-align: right;
 	padding: 12px 24px 12px 24px;
 }
@@ -83,7 +92,8 @@
 	flex-grow: 1;
 	.form-toggle__label {
 		float: right;
-		padding-right: 12px;
+		padding-right: 24px;
+		padding-left: 24px;
 	}
 }
 
@@ -92,11 +102,27 @@
 	padding-bottom: 0px;
 }
 
-.email-settings__loading {
+.components__notification-placeholder-input,
+.components__notification-placeholder-toggle,
+.components__notification-placeholder-title {
 	@include placeholder();
 	pointer-events: none;
 	background: $white;
 	height: 14px;
 	animation: loading-fade 1.6s ease-in-out infinite;
 	background-color: lighten( $gray, 25% );
+}
+
+.components__notification-placeholder-toggle {
+	width: 24px;
+	margin-right: 24px;
+	float: right;
+}
+
+.components__notification-placeholder-title {
+	width: 300px;
+}
+
+.components__notification-placeholder-input {
+	width: 240px; 
 }

--- a/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
@@ -1,28 +1,45 @@
 
-.components__notification-component-title {
-	width: 50%;
-}
+.email-settings__container{
 
-.components__notification-component-input.list-item-field {
-	padding-left: 0px;
-	padding-right: 0px;
-	flex-shrink: 1;
-	width: 40%;
-}
+	.components__notification-component-title {
+		width: 50%;
+	}
 
-.components__notification-component-toggle {
-	width: 80px;
-}
+	.components__notification-component-input {
+		padding-left: 0px;
+		padding-right: 0px;
+		flex-shrink: 1;
+		width: 40%;
+	}
 
-.components__notification-component-toggle-label.list-item-field {
-	width: 80px;
-	padding-left: 6px;
-}
+	.components__notification-component-toggle {
+		width: 80px;
+	}
 
-.components__notification-component-item.list-item {
-	flex-wrap: nowrap;
-}
+	.components__notification-component-toggle-label {
+		width: 80px;
+		padding-left: 6px;
+	}
 
-.components__notification-origin {
-	width: 75%;
+	.list-header {
+		background: lighten( $gray, 35% );
+	}
+
+	.list-header + .list-item {
+		border-top: 0;
+	}
+
+	.components__notification-component-item {
+		flex-wrap: nowrap;
+		align-items: center;
+		border-top: 1px solid $border-ultra-light-gray;
+	}
+
+	.components__notification-origin {
+		width: 100%;
+		input {
+			width: 75%;
+		}
+	}
+
 }

--- a/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
@@ -36,21 +36,67 @@
 .components__notification-component {
 	display: flex;
 	align-items: center;
+	margin: 0px;
+	padding: 0px;
 }
 
 .components__notification-component-title {
 	min-width: 300px;
 	flex-grow: 0;
-	flex-shrink: 1;
 	padding: 24px;
 }
 
-.components__notification-component-input {
-	width: auto;
+.email-settings__internal-notifications-legend,
+.email-settings__customer-notifications-legend {
+	padding: 0px;
+	display: flex;
+}
+
+.email-settings__customer-notifications-legend-option,
+.email-settings__internal-notifications-legend-option {
+	padding: 12px 24px 12px 24px;
+	min-width: 300px;
 	flex-grow: 1;
+	flex-shrink: 1;
+}
+
+.email-settings__internal-notifications-legend-input {
+	padding: 12px 24px 12px 24px;
+	max-width: 240px;
+	flex-grow: 1;
+	flex-shrink: 1;
+}
+
+
+.components__notification-component-input {
+	max-width: 240px;
+	flex-grow: 1;
+	flex-shrink: 1;
+}
+
+.email-settings__internal-notifications-legend-toggle {
+	text-align: right;
+	padding: 12px 24px 12px 24px;
 }
 
 .components__notification-component-toggle {
-	//float: right;
-	flex-grow: 0;
+	flex-grow: 1;
+	.form-toggle__label {
+		float: right;
+		padding-right: 12px;
+	}
+}
+
+.email-settings__loading-card {
+	margin: 0px 0px 16px 0px;
+	padding-bottom: 0px;
+}
+
+.email-settings__loading {
+	@include placeholder();
+	pointer-events: none;
+	background: $white;
+	height: 14px;
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background-color: lighten( $gray, 25% );
 }

--- a/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
@@ -13,3 +13,44 @@
 	margin-bottom: 0px;
 	background: $gray-light;
 }
+
+.email-settings__section-title-text {
+	font-size: 18px;
+	font-weight: 500;
+	padding-bottom: 4px;
+}
+
+.email-settings__section-subtitle-text {
+	color: $gray-text-min;
+	font-size: 12px;
+	line-height: 18px;
+	padding-bottom: 4px;
+}
+.email-settings__customer-notifications-settings,
+.email-settings__internal-notifications-settings {
+	display: flex;
+	flex-direction: column;
+	padding: 0px;
+}
+
+.components__notification-component {
+	display: flex;
+	align-items: center;
+}
+
+.components__notification-component-title {
+	min-width: 300px;
+	flex-grow: 0;
+	flex-shrink: 1;
+	padding: 24px;
+}
+
+.components__notification-component-input {
+	width: auto;
+	flex-grow: 1;
+}
+
+.components__notification-component-toggle {
+	//float: right;
+	flex-grow: 0;
+}

--- a/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
@@ -9,9 +9,18 @@
 		width: 80%;
 	}
 
+	.components__notification-component-title,
+	.components__notification-component-title-long {
+		.form-setting-explanation {
+			margin-top: 0;
+		}
+
+		.form-label {
+			margin-bottom: 0;
+		}
+	}
+
 	.components__notification-component-input {
-		padding-left: 0px;
-		padding-right: 0px;
 		flex-shrink: 1;
 		width: 40%;
 	}
@@ -21,9 +30,14 @@
 		width: 80px;
 	}
 
-	.components__notification-component-toggle-label {
-		width: 80px;
-		padding-left: 6px;
+	.components__notification-component-toggle-label,
+	.components__notification-component-toggle {
+		width: 100px;
+		text-align: center;
+	}
+
+	.form-toggle__label .form-toggle__label-content {
+		margin-left: 0;
 	}
 
 	.list-header {
@@ -42,9 +56,6 @@
 
 	.components__notification-origin {
 		width: 100%;
-		input {
-			width: 75%;
-		}
 	}
 
 	.components__is-placeholder {

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/index.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/index.js
@@ -1,6 +1,9 @@
 /**
  * External dependencies
+ *
+ * @format
  */
+
 import { connect } from 'react-redux';
 import { filter, matches } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -12,7 +15,10 @@ import React from 'react';
  */
 import { getPlugins, isRequestingForSites } from 'state/plugins/installed/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { mailChimpSettings, isRequestingSettings } from 'woocommerce/state/sites/settings/mailchimp/selectors';
+import {
+	mailChimpSettings,
+	isRequestingSettings,
+} from 'woocommerce/state/sites/settings/mailchimp/selectors';
 import MailChimpGettingStarted from './getting-started';
 import MailChimpSetup from './setup-mailchimp';
 import MailChimpDashboard from './mailchimp_dashboard';
@@ -30,40 +36,48 @@ class MailChimp extends React.Component {
 
 	startWizard = () => {
 		this.setState( { setupWizardStarted: true } );
-	}
+	};
 
-	closeWizard = ( status ) => {
+	closeWizard = status => {
 		this.setState( { setupWizardStarted: false, wizardCompleted: 'wizard-completed' === status } );
-	}
+	};
 
 	closeSetupFinishNotice = () => {
 		this.setState( { wizardCompleted: false } );
-	}
+	};
 
 	render() {
-		const { dashboardView, hasMailChimp, isRequestingMailChimpSettings,
-			isRequestingPlugins, onChange, siteId, site, settings } = this.props;
+		const {
+			dashboardView,
+			hasMailChimp,
+			isRequestingMailChimpSettings,
+			isRequestingPlugins,
+			onChange,
+			siteId,
+			site,
+			settings,
+		} = this.props;
 		const { setupWizardStarted } = this.state;
-		const isRequestingData = ( isRequestingMailChimpSettings || isRequestingPlugins );
-		const mailChimpIsReady = ! isRequestingData &&
-			( settings && settings.active_tab === 'sync' );
-		const gettingStarted = ! setupWizardStarted && ! isRequestingData &&
-			( settings && settings.active_tab !== 'sync' );
+		const isRequestingData = isRequestingMailChimpSettings || isRequestingPlugins;
+		const mailChimpIsReady = ! isRequestingData && ( settings && settings.active_tab === 'sync' );
+		const gettingStarted =
+			! setupWizardStarted && ! isRequestingData && ( settings && settings.active_tab !== 'sync' );
 
 		// Special case for store dashboard where we want to only show MailChimpGetingStarted in case
 		// when user has not finished settup. We show nothing in other cases.
 		if ( dashboardView ) {
 			return (
 				<div className="mailchimp">
-					{ ( ! isRequestingMailChimpSettings ) && ( settings && settings.active_tab !== 'sync' ) &&
-						<MailChimpGettingStarted
-							siteId={ siteId }
-							site={ site }
-							isPlaceholder={ isRequestingData }
-							onClick={ this.startWizard }
-							redirectToSettings
-						/>
-					}
+					{ ! isRequestingMailChimpSettings &&
+						( settings && settings.active_tab !== 'sync' ) && (
+							<MailChimpGettingStarted
+								siteId={ siteId }
+								site={ site }
+								isPlaceholder={ isRequestingData }
+								onClick={ this.startWizard }
+								redirectToSettings
+							/>
+						) }
 				</div>
 			);
 		}
@@ -72,28 +86,30 @@ class MailChimp extends React.Component {
 			<div className="mailchimp">
 				<QueryJetpackPlugins siteIds={ [ siteId ] } />
 				<QueryMailChimpSettings siteId={ siteId } />
-				{ ( isRequestingData || gettingStarted ) &&
+				{ ( isRequestingData || gettingStarted ) && (
 					<MailChimpGettingStarted
 						siteId={ siteId }
 						site={ site }
 						isPlaceholder={ isRequestingData }
 						onClick={ this.startWizard }
 					/>
-				}
-				{ mailChimpIsReady &&
+				) }
+				{ mailChimpIsReady && (
 					<MailChimpDashboard
 						siteId={ siteId }
 						wizardCompleted={ this.state.wizardCompleted }
 						onChange={ onChange }
-						onNoticeExit={ this.closeSetupFinishNotice } /> }
-				{ setupWizardStarted &&
+						onNoticeExit={ this.closeSetupFinishNotice }
+					/>
+				) }
+				{ setupWizardStarted && (
 					<MailChimpSetup
-							hasMailChimp={ hasMailChimp }
-							settings={ settings }
-							siteId={ siteId }
-							onClose={ this.closeWizard }
-						/>
-				}
+						hasMailChimp={ hasMailChimp }
+						settings={ settings }
+						siteId={ siteId }
+						onClose={ this.closeWizard }
+					/>
+				) }
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/state/sites/product-categories/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/reducer.js
@@ -274,7 +274,6 @@ describe( 'reducer', () => {
 			expect( newState ).to.eql( {} );
 		} );
 
-<<<<<<< HEAD
 		test( 'should store the total number of categories when a request loads', () => {
 			const action = {
 				type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_SUCCESS,
@@ -302,53 +301,6 @@ describe( 'reducer', () => {
 			const originalState = deepFreeze( { '{}': 2 } );
 			const newState = total( originalState, action );
 			expect( newState ).to.eql( originalState );
-=======
-	test( 'should not affect other state trees', () => {
-		const siteId = 123;
-		const state = {
-			[ siteId ]: {
-				paymentMethods: {},
-				productCategories: 'LOADING',
-				settings: { general: {}, products: {}, stripeConnectAccount: {}, tax: {} },
-				shippingZones: {},
-				products: {},
-			},
-		};
-		const action = {
-			type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_SUCCESS,
-			data: [],
-			siteId,
-		};
-
-		const newState = reducer( state, action );
-		expect( newState[ siteId ] ).to.exist;
-		expect( newState[ siteId ].productCategories ).to.eql( [] );
-		expect( newState[ siteId ].settings ).to.eql( {
-			general: {},
-			products: {},
-			stripeConnectAccount: {},
-			tax: {},
-			mailchimp: {
-				settings: {},
-				settingsRequest: false,
-				settingsRequestError: false,
-				syncStatus: {},
-				syncStatusRequest: false,
-				syncStatusRequestError: false,
-				resyncRequest: false,
-				resyncRequestError: false,
-				apiKeySubmit: false,
-				apiKeySubmitError: false,
-				storeInfoSubmit: false,
-				storeInfoSubmitError: false,
-				listsRequest: false,
-				listsRequestError: false,
-				newsletterSettingsSubmit: false,
-				newsletterSettingsSubmitError: false,
-				saveSettings: false,
-			},
-			email: null,
->>>>>>> Fix tests.
 		} );
 	} );
 	describe( 'totalPages', () => {

--- a/client/extensions/woocommerce/state/sites/product-categories/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/reducer.js
@@ -274,6 +274,7 @@ describe( 'reducer', () => {
 			expect( newState ).to.eql( {} );
 		} );
 
+<<<<<<< HEAD
 		test( 'should store the total number of categories when a request loads', () => {
 			const action = {
 				type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_SUCCESS,
@@ -301,6 +302,53 @@ describe( 'reducer', () => {
 			const originalState = deepFreeze( { '{}': 2 } );
 			const newState = total( originalState, action );
 			expect( newState ).to.eql( originalState );
+=======
+	test( 'should not affect other state trees', () => {
+		const siteId = 123;
+		const state = {
+			[ siteId ]: {
+				paymentMethods: {},
+				productCategories: 'LOADING',
+				settings: { general: {}, products: {}, stripeConnectAccount: {}, tax: {} },
+				shippingZones: {},
+				products: {},
+			},
+		};
+		const action = {
+			type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_SUCCESS,
+			data: [],
+			siteId,
+		};
+
+		const newState = reducer( state, action );
+		expect( newState[ siteId ] ).to.exist;
+		expect( newState[ siteId ].productCategories ).to.eql( [] );
+		expect( newState[ siteId ].settings ).to.eql( {
+			general: {},
+			products: {},
+			stripeConnectAccount: {},
+			tax: {},
+			mailchimp: {
+				settings: {},
+				settingsRequest: false,
+				settingsRequestError: false,
+				syncStatus: {},
+				syncStatusRequest: false,
+				syncStatusRequestError: false,
+				resyncRequest: false,
+				resyncRequestError: false,
+				apiKeySubmit: false,
+				apiKeySubmitError: false,
+				storeInfoSubmit: false,
+				storeInfoSubmitError: false,
+				listsRequest: false,
+				listsRequestError: false,
+				newsletterSettingsSubmit: false,
+				newsletterSettingsSubmitError: false,
+				saveSettings: false,
+			},
+			email: null,
+>>>>>>> Fix tests.
 		} );
 	} );
 	describe( 'totalPages', () => {

--- a/client/extensions/woocommerce/state/sites/settings/email/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { setWith } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { createReducer } from 'state/utils';
@@ -14,6 +19,10 @@ export default createReducer( null, {
 	},
 
 	[ WOOCOMMERCE_EMAIL_SETTINGS_REQUEST_SUCCESS ]: ( state, { data } ) => {
-		return data;
+		const options = {};
+		data.forEach( function( option ) {
+			setWith( options, [ option.group_id, option.id ], option.value, Object );
+		} );
+		return options;
 	},
 } );

--- a/client/extensions/woocommerce/state/sites/settings/email/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/selectors.js
@@ -4,7 +4,7 @@
  * @format
  */
 
-import { get, isArray } from 'lodash';
+import { get, isObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,7 +27,7 @@ export const getEmailSettings = ( state, siteId = getSelectedSiteId( state ) ) =
  * @return {boolean} Whether the email settings have been successfully loaded from the server
  */
 export const areEmailSettingsLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return isArray( getEmailSettings( state, siteId ) );
+	return isObject( getEmailSettings( state, siteId ) );
 };
 
 /**

--- a/client/extensions/woocommerce/state/sites/settings/email/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/test/reducer.js
@@ -29,15 +29,49 @@ describe( 'reducer', () => {
 
 	test( 'should store data from the action', () => {
 		const siteId = 123;
-		const settings = [ {}, {} ];
+		const settings = [
+			{
+				id: 'woocommerce_email_from_name',
+				value: '',
+				group_id: 'email',
+			},
+			{
+				id: 'woocommerce_email_from_address',
+				value: 'test@test.com',
+				group_id: 'email',
+			},
+			{
+				id: 'enabled',
+				value: 'yes',
+				group_id: 'email_new_order',
+			},
+			{
+				id: 'recipient',
+				value: 'admin_1@test.com',
+				group_id: 'email_new_order',
+			},
+		];
+
+		const expectedResult = {
+			email: {
+				woocommerce_email_from_name: '',
+				woocommerce_email_from_address: 'test@test.com',
+			},
+			email_new_order: {
+				enabled: 'yes',
+				recipient: 'admin_1@test.com',
+			},
+		};
+
 		const action = {
 			type: WOOCOMMERCE_EMAIL_SETTINGS_REQUEST_SUCCESS,
 			siteId,
 			data: settings,
 		};
+
 		const newState = reducer( {}, action );
 		expect( newState[ siteId ] ).to.exist;
 		expect( newState[ siteId ].settings ).to.exist;
-		expect( newState[ siteId ].settings.email ).to.deep.equal( settings );
+		expect( newState[ siteId ].settings.email ).to.deep.equal( expectedResult );
 	} );
 } );

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -14,6 +14,7 @@
 	@import 'app/settings/payments/style';
 	@import 'app/settings/payments/stripe/style';
 	@import 'app/settings/email/mailchimp/style';
+	@import 'app/settings/email/email-settings/style';
 	@import 'app/products/product-form';
 	@import 'app/products/products-list';
 	@import 'app/promotions/style';


### PR DESCRIPTION
### Information.

This implements UI for https://github.com/Automattic/wp-calypso/issues/15040

In this PR UI only presents options that are set  in woocommerce plugin. Settings values and enabling will be added in another PR ( this is behind flag so not visible in prod ).  This will allow style adjustment and work on mobile version. 

This required https://github.com/Automattic/wc-calypso-bridge/pull/8 to work which should be merged soon.

This branch was rebranched out of `add/email-settings-redux` and will be reabased after it will be merged.

How it looks:

![image](https://user-images.githubusercontent.com/17271089/33075699-9f9f87e8-ceca-11e7-9ff2-490937d88800.png)
