### PR TITLE
Jetpack Connect: Always hide plan icons for small devices

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
-import { abtest } from 'lib/abtest';
 
 /**
  * Constants
@@ -46,11 +45,8 @@ class JetpackPlansGrid extends Component {
 	}
 
 	render() {
-		const mainClassName =
-			abtest( 'jetpackHidePlanIconsOnMobile' ) === 'hide' && 'jetpack-connect__hide-plan-icons';
-
 		return (
-			<Main wideLayout className={ mainClassName }>
+			<Main wideLayout className="jetpack-connect__hide-plan-icons">
 				<div className="jetpack-connect__plans">
 					{ this.renderConnectHeader() }
 					<div id="plans">

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -70,15 +70,6 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	jetpackHidePlanIconsOnMobile: {
-		datestamp: '20171031',
-		variations: {
-			show: 50,
-			hide: 50,
-		},
-		defaultVariation: 'show',
-		allowExistingUsers: true,
-	},
 	skipThemesSelectionModal: {
 		datestamp: '20170904',
 		variations: {


### PR DESCRIPTION
This PR stops the test that we introduced in #19335, and releases the challenger to 100% of the users - plan icons will now be hidden for all users with small devices.

To test:

* Checkout this branch
* Test the following steps with a device with height > 920px.
  * Go to `/jetpack/connect/store`
  * Verify you see no visual changes.
  * Go to `/jetpack/connect/`
  * Connect your Jetpack site and reach the plans page.
  * Verify you see no visual changes.
* Test the following steps with a device with height < 920px.
  * Go to `/jetpack/connect/store`
  * Verify the plan icons are hidden.
  * Go to `/jetpack/connect/`
  * Connect your Jetpack site and reach the plans page.
  * Verify the plan icons are hidden.