### PR TITLE
Store: Remove BETA from store nav item

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -414,7 +414,7 @@ export class MySitesSidebar extends Component {
 		return (
 			isCountryAllowed && (
 				<SidebarItem
-					label={ translate( 'Store (BETA)' ) }
+					label={ translate( 'Store' ) }
 					link={ storeLink }
 					onNavigate={ this.trackStoreClick }
 					icon="cart"


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/19388

Now that Store is open to new users, its time to remove the BETA label. 🎉