### PR TITLE
Domains: Incoming Transfers: Fix small screen display issues

### DIFF
--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -181,10 +181,21 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
+	flex-direction: column;
 
 	button {
 		flex-shrink: 0;
-		margin-left: 15px;
+		margin-top: 15px;
+		width: 100%;
+	}
+
+	@include breakpoint( '>660px' ) {
+		flex-direction: row;
+
+		button {
+			margin: 0 0 0 15px;
+			width: auto;
+		}
 	}
 }
 

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -156,6 +156,7 @@
 
 .transfer-domain-step__lock-status {
 	font-size: 12px;
+	flex-shrink: 0;
 
 	svg {
 		padding-right: 4px;

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -171,6 +171,13 @@
 	}
 }
 
+.transfer-domain-step__admin-email {
+	hyphens: auto;
+	overflow-wrap: break-word;
+	word-break: break-word;
+	word-wrap: break-word;
+}
+
 .transfer-domain-step__continue-text {
 	p {
 		color: darken( $gray, 10% );

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -158,7 +158,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 			{
 				args: { email },
 				components: {
-					strong: <strong />,
+					strong: <strong className="transfer-domain-step__admin-email" />,
 					a: <a href="#" rel="noopener noreferrer" />,
 				},
 			}


### PR DESCRIPTION
Fixes #19907 

There were multiple display issues reported for small viewports. This PR fixes them.

Before | After
------------ | -------------
![image](https://user-images.githubusercontent.com/448298/33079892-bc493b30-cea4-11e7-946a-ce275164915c.png) | <img width="275" alt="screen shot 2017-11-21 at 09 56 40" src="https://user-images.githubusercontent.com/448298/33079903-c317a9ce-cea4-11e7-8032-31563c529ecc.png">
<img width="372" alt="screen shot 2017-11-21 at 10 15 16" src="https://user-images.githubusercontent.com/448298/33079960-ea82f8e2-cea4-11e7-955c-621f3d28891c.png"> | <img width="394" alt="screen shot 2017-11-21 at 10 09 31" src="https://user-images.githubusercontent.com/448298/33079915-c8aa9e00-cea4-11e7-8444-4c6c13e1a95c.png">
![image](https://user-images.githubusercontent.com/12596797/32959463-b0ab280a-cb8f-11e7-97ee-5a7da42968fc.png) | <img width="375" alt="screen shot 2017-11-21 at 10 13 07" src="https://user-images.githubusercontent.com/448298/33079995-fbb02950-cea4-11e7-8e9d-cdb46397e595.png">

#### Testing

* Make your browser viewport `<480px`.
* Start at `/domains/add/transfer` and select a site.
* Type in a domain that is unlocked and has a long privacy protection email.
* Assert the screen looks like the screenshots above.