### PR TITLE
Data Layer: Refactor Activity Log to use dispatchRequestEx

### DIFF
--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -11,50 +11,46 @@ import { translate } from 'i18n-calypso';
 import fromApi from './from-api';
 import { ACTIVITY_LOG_REQUEST } from 'state/action-types';
 import { activityLogUpdate } from 'state/activity-log/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 
-export const handleActivityLogRequest = ( { dispatch }, action ) => {
+export const handleActivityLogRequest = action => {
 	const { params = {}, siteId } = action;
 
-	// Clear current logs, this will allow loading placeholders to appear
-	dispatch( activityLogUpdate( siteId, undefined ) );
-
-	dispatch(
-		http(
-			{
-				apiNamespace: 'wpcom/v2',
-				method: 'GET',
-				path: `/sites/${ siteId }/activity`,
-				query: omitBy(
-					{
-						action: params.action,
-						date_end: params.date_end || params.dateEnd,
-						date_start: params.date_start || params.dateStart,
-						group: params.group,
-						name: params.name,
-						number: params.number,
-					},
-					a => a === undefined
-				),
-			},
-			action
-		)
+	return http(
+		{
+			apiNamespace: 'wpcom/v2',
+			method: 'GET',
+			path: `/sites/${ siteId }/activity`,
+			query: omitBy(
+				{
+					action: params.action,
+					date_end: params.date_end || params.dateEnd,
+					date_start: params.date_start || params.dateStart,
+					group: params.group,
+					name: params.name,
+					number: params.number,
+				},
+				a => a === undefined
+			),
+		},
+		action
 	);
 };
 
-export const receiveActivityLog = ( { dispatch }, action, data ) => {
-	dispatch( activityLogUpdate( action.siteId, data, data.totalItems, action.params ) );
-};
+export const receiveActivityLog = ( action, data ) =>
+	activityLogUpdate( action.siteId, data, data.totalItems, action.params );
 
-export const receiveActivityLogError = ( { dispatch } ) => {
-	dispatch( errorNotice( translate( 'Error receiving activity for site.' ) ) );
-};
+export const receiveActivityLogError = () =>
+	errorNotice( translate( 'Error receiving activity for site.' ) );
 
 export default {
 	[ ACTIVITY_LOG_REQUEST ]: [
-		dispatchRequest( handleActivityLogRequest, receiveActivityLog, receiveActivityLogError, {
+		dispatchRequestEx( {
+			fetch: handleActivityLogRequest,
+			onSuccess: receiveActivityLog,
+			onError: receiveActivityLogError,
 			fromApi,
 		} ),
 	],

--- a/client/state/data-layer/wpcom/sites/activity/test/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/test/index.js
@@ -2,9 +2,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-import sinon from 'sinon';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -62,40 +60,30 @@ const SUCCESS_RESPONSE = deepFreeze( {
 } );
 
 describe( 'receiveActivityLog', () => {
-	test( 'should dispatch activity log update action', () => {
-		const dispatch = sinon.spy();
-		receiveActivityLog( { dispatch }, { siteId: SITE_ID }, SUCCESS_RESPONSE );
-		expect( dispatch ).to.have.been.called.once;
-		expect( dispatch.args[ 0 ][ 0 ] )
-			.to.be.an( 'object' )
-			.that.has.keys( [ 'data', 'found', 'query', 'siteId', 'type' ] )
-			.that.includes( {
-				found: 1,
-				type: ACTIVITY_LOG_UPDATE,
-			} );
+	test( 'should return activity log update action', () => {
+		const response = receiveActivityLog( { siteId: SITE_ID }, SUCCESS_RESPONSE );
+		expect( response ).toHaveProperty( 'data' );
+		expect( response ).toHaveProperty( 'query' );
+		expect( response ).toMatchObject( {
+			found: 1,
+			siteId: SITE_ID,
+			type: ACTIVITY_LOG_UPDATE,
+		} );
 	} );
 } );
 
 describe( 'receiveActivityLogError', () => {
-	test( 'should dispatch activity log error action', () => {
-		const dispatch = sinon.spy();
-		receiveActivityLogError( { dispatch } );
-		expect( dispatch ).to.have.been.called.once;
-		expect( dispatch ).to.have.been.calledWith(
+	test( 'should return activity log error action', () =>
+		expect( receiveActivityLogError() ).toEqual(
 			errorNotice( translate( 'Error receiving activity for site.' ), { id: '1' } )
-		);
-	} );
+		) );
 } );
 
 describe( 'handleActivityLogRequest', () => {
-	test( 'should dispatch HTTP action with default when no params are passed', () => {
+	test( 'should return HTTP action with default when no params are passed', () => {
 		const action = activityLogRequest( SITE_ID );
-		const dispatch = sinon.spy();
 
-		handleActivityLogRequest( { dispatch }, action );
-
-		expect( dispatch ).to.have.been.calledTwice;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( handleActivityLogRequest( action ) ).toMatchObject(
 			http(
 				{
 					apiNamespace: 'wpcom/v2',
@@ -108,7 +96,7 @@ describe( 'handleActivityLogRequest', () => {
 		);
 	} );
 
-	test( 'should dispatch HTTP action with provided parameters', () => {
+	test( 'should return HTTP action with provided parameters', () => {
 		const action = activityLogRequest( SITE_ID, {
 			date_end: 1500300000000,
 			date_start: 1500000000000,
@@ -116,12 +104,8 @@ describe( 'handleActivityLogRequest', () => {
 			name: 'post__published',
 			number: 10,
 		} );
-		const dispatch = sinon.spy();
 
-		handleActivityLogRequest( { dispatch }, action );
-
-		expect( dispatch ).to.have.been.calledTwice;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( handleActivityLogRequest( action ) ).toMatchObject(
 			http(
 				{
 					apiNamespace: 'wpcom/v2',
@@ -145,12 +129,8 @@ describe( 'handleActivityLogRequest', () => {
 			dateEnd: 1500300000000,
 			dateStart: 1500000000000,
 		} );
-		const dispatch = sinon.spy();
 
-		handleActivityLogRequest( { dispatch }, action );
-
-		expect( dispatch ).to.have.been.calledTwice;
-		expect( dispatch ).to.have.been.calledWith(
+		expect( handleActivityLogRequest( action ) ).toMatchObject(
 			http(
 				{
 					apiNamespace: 'wpcom/v2',


### PR DESCRIPTION
Since the newer `dispatchRequestEx()` function was added it has provided
a much simpler API into handling actions in the data layer.

This patch does little more than swap out `dispatchRequest()` for its
newer and simpler version, making the necessary changes to adopt the new
API.

This is a precursor to work going on in #20038 and broader Activity Log
development.

**Testing**

There should be no functional or visual changes with this PR.

Open a site with Activity Log enabled and navigate to **Stats** > **Activity**

The list of activity log events should load. Try navigating to previous or later
months and make sure events continue to load. Try blocking the domain in
the network tools panel and make sure that the error message appears when
the request fails to complete.