### PR TITLE
Jetpack connect: Use same redirect logic throughout plans component lifecycle

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -23,8 +23,6 @@ import Plans from './plans';
 import PlansLanding from './plans-landing';
 import route from 'lib/route';
 import userFactory from 'lib/user';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
 import { JETPACK_CONNECT_QUERY_SET } from 'state/action-types';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
@@ -197,16 +195,9 @@ export default {
 	},
 
 	plansSelection( context ) {
-		const state = context.store.getState();
-		const siteId = getSelectedSiteId( state );
-		const isJetpack = isJetpackSite( state, siteId );
 		const analyticsPageTitle = 'Plans';
 		const basePath = route.sectionify( context.path );
 		const analyticsBasePath = basePath + '/:site';
-
-		if ( ! isJetpack ) {
-			return;
-		}
 
 		removeSidebar( context );
 

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -234,13 +234,9 @@ class Plans extends Component {
 			! this.props.canPurchasePlans ||
 			this.props.hasPlan
 		) {
-			return (
-				<div>
-					<QueryPlans />
-					{ selectedSite && <QuerySitePlans siteId={ selectedSite.ID } /> }
-				</div>
-			);
+			return <QueryPlans />;
 		}
+
 		const helpButtonLabel = translate( 'Need help?' );
 
 		return (

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -37,6 +37,7 @@ import {
 	canCurrentUser,
 	getJetpackConnectRedirectAfterAuth,
 	isRtl,
+	isSiteAutomatedTransfer,
 	isSiteOnPaidPlan,
 } from 'state/selectors';
 import {
@@ -46,7 +47,7 @@ import {
 	isCalypsoStartedConnection,
 } from 'state/jetpack-connect/selectors';
 import { mc } from 'lib/analytics';
-import { isSiteAutomatedTransfer } from 'state/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 const CALYPSO_PLANS_PAGE = '/plans/my-plan/';
@@ -72,6 +73,7 @@ class Plans extends Component {
 			'hasPlan',
 			'canPurchasePlans',
 			'isCalypsoStartedConnection',
+			'notJetpack',
 		];
 
 		if ( ! isEqual( pick( this.props, propsToCompare ), pick( nextProps, propsToCompare ) ) ) {
@@ -92,7 +94,7 @@ class Plans extends Component {
 			this.autoselectPlan();
 			return true;
 		}
-		if ( props.hasPlan ) {
+		if ( props.hasPlan || props.notJetpack ) {
 			this.redirect( CALYPSO_PLANS_PAGE );
 			return true;
 		}
@@ -227,11 +229,20 @@ class Plans extends Component {
 	};
 
 	render() {
-		const { interval, isRtlLayout, selectedSite, translate, flowType, selectedPlan } = this.props;
+		const {
+			flowType,
+			interval,
+			isRtlLayout,
+			notJetpack,
+			selectedSite,
+			translate,
+			selectedPlan,
+		} = this.props;
 
 		if (
 			this.isFlowTypePaid( flowType ) ||
 			!! selectedPlan ||
+			notJetpack ||
 			! this.props.canPurchasePlans ||
 			this.props.hasPlan
 		) {
@@ -297,6 +308,7 @@ export default connect(
 			calypsoStartedConnection: isCalypsoStartedConnection( state, selectedSiteSlug ),
 			isRtlLayout: isRtl( state ),
 			hasPlan: selectedSite && isSiteOnPaidPlan( state, selectedSite.ID ),
+			notJetpack: ! ( selectedSite && isJetpackSite( state, selectedSite.ID ) ),
 		};
 	},
 	{

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -230,8 +230,11 @@ class Plans extends Component {
 
 	render() {
 		const {
+			canPurchasePlans,
+			hasPlan,
 			flowType,
 			interval,
+			isAutomatedTransfer,
 			isRtlLayout,
 			notJetpack,
 			selectedPlan,
@@ -243,8 +246,9 @@ class Plans extends Component {
 			this.isFlowTypePaid( flowType ) ||
 			!! selectedPlan ||
 			notJetpack ||
-			! this.props.canPurchasePlans ||
-			this.props.hasPlan
+			! canPurchasePlans ||
+			hasPlan ||
+			isAutomatedTransfer
 		) {
 			return <QueryPlans />;
 		}

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -66,14 +66,14 @@ class Plans extends Component {
 
 	componentWillReceiveProps = nextProps => {
 		const propsToCompare = [
-			'isAutomatedTransfer',
-			'selectedPlan',
-			'isRequestingPlans',
+			'canPurchasePlans',
 			'flowType',
 			'hasPlan',
-			'canPurchasePlans',
+			'isAutomatedTransfer',
 			'isCalypsoStartedConnection',
+			'isRequestingPlans',
 			'notJetpack',
+			'selectedPlan',
 		];
 
 		if ( ! isEqual( pick( this.props, propsToCompare ), pick( nextProps, propsToCompare ) ) ) {
@@ -234,9 +234,9 @@ class Plans extends Component {
 			interval,
 			isRtlLayout,
 			notJetpack,
+			selectedPlan,
 			selectedSite,
 			translate,
-			selectedPlan,
 		} = this.props;
 
 		if (

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -86,11 +86,7 @@ class Plans extends Component {
 			this.props.goBackToWpAdmin( props.selectedSite.URL + JETPACK_ADMIN_PATH );
 			return true;
 		}
-		if ( !! props.selectedPlan ) {
-			this.autoselectPlan();
-			return true;
-		}
-		if ( this.isFlowTypePaid( props.flowType ) ) {
+		if ( this.hasPreSelectedPlan( props ) ) {
 			this.autoselectPlan();
 			return true;
 		}
@@ -136,6 +132,14 @@ class Plans extends Component {
 	redirect( path ) {
 		page.redirect( path + this.props.selectedSiteSlug );
 		this.props.completeFlow();
+	}
+
+	hasPreSelectedPlan( props ) {
+		if ( this.isFlowTypePaid( props.flowType ) ) {
+			return true;
+		}
+
+		return !! props.selectedPlan;
 	}
 
 	autoselectPlan() {
@@ -232,19 +236,16 @@ class Plans extends Component {
 		const {
 			canPurchasePlans,
 			hasPlan,
-			flowType,
 			interval,
 			isAutomatedTransfer,
 			isRtlLayout,
 			notJetpack,
-			selectedPlan,
 			selectedSite,
 			translate,
 		} = this.props;
 
 		if (
-			this.isFlowTypePaid( flowType ) ||
-			!! selectedPlan ||
+			this.hasPreSelectedPlan( this.props ) ||
 			notJetpack ||
 			! canPurchasePlans ||
 			hasPlan ||

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -62,12 +62,7 @@ class Plans extends Component {
 	redirecting = false;
 
 	componentDidMount() {
-		if ( this.props.isAutomatedTransfer && ! this.redirecting && this.props.selectedSite ) {
-			this.redirecting = true;
-			this.props.goBackToWpAdmin( this.props.selectedSite.URL + JETPACK_ADMIN_PATH );
-		} else if ( this.hasPreSelectedPlan() ) {
-			this.autoselectPlan();
-		} else {
+		if ( ! this.maybeRedirect() ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_view', {
 				user: this.props.userId,
 			} );
@@ -75,28 +70,35 @@ class Plans extends Component {
 	}
 
 	componentDidUpdate() {
-		if ( this.props.isAutomatedTransfer && ! this.redirecting && this.props.selectedSite ) {
-			this.redirecting = true;
-			this.props.goBackToWpAdmin( this.props.selectedSite.URL + JETPACK_ADMIN_PATH );
-		}
+		this.maybeRedirect();
+	}
 
-		if ( this.props.hasPlan && ! this.redirecting ) {
-			this.redirecting = true;
-			this.redirect( CALYPSO_PLANS_PAGE );
+	maybeRedirect = () => {
+		if ( this.props.isAutomatedTransfer ) {
+			this.props.goBackToWpAdmin( this.props.selectedSite.URL + JETPACK_ADMIN_PATH );
+			return true;
 		}
-		if ( ! this.props.canPurchasePlans && ! this.redirecting ) {
-			this.redirecting = true;
+		if ( this.hasPreSelectedPlan() ) {
+			this.autoselectPlan();
+			return true;
+		}
+		if ( this.props.hasPlan ) {
+			this.redirect( CALYPSO_PLANS_PAGE );
+			return true;
+		}
+		if ( ! this.props.canPurchasePlans ) {
 			if ( this.props.isCalypsoStartedConnection ) {
 				this.redirect( CALYPSO_REDIRECTION_PAGE );
 			} else {
 				this.redirectToWpAdmin();
 			}
+			return true;
 		}
-
-		if ( ! this.props.isRequestingPlans && this.isFlowTypePaid() && ! this.redirecting ) {
-			return this.autoselectPlan();
+		if ( this.isFlowTypePaid() ) {
+			this.autoselectPlan();
+			return true;
 		}
-	}
+	};
 
 	handleSkipButtonClick = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_skip_button_click' );

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -98,6 +98,7 @@ class Plans extends Component {
 			this.autoselectPlan();
 			return true;
 		}
+		return false;
 	};
 
 	handleSkipButtonClick = () => {


### PR DESCRIPTION
_Updated_ and _mounted_ lifecycle events in the Jetpack connect `<Plans/>` component had a mix and match of redirect logic. For example, the existence of a pre-selected plan was only being checked on mount, not on prop updates, yet the plans data necessary for adding a product to the cart may not yet be loaded at mount.

This PR ensures the same logic is used throughout the lifecycle. It also ends the use of any `isRedirecting` state, instead checking for changes in props.

### Testing
All with the route `/jetpack/connect/plans/{site}`
1. Check that the `calypso_jpc_plans_view` tracks event only fires if there is no redirect
1. Atomic sites should go back to wp-admin (according to the existing code)
1. Pre-selected plans, for example `/jetpack/connect/pro`, or a selection from `jetpack/connect/store` should skip plans page and go straight to the checkout
1. Sites with a plan already should go to main calypso /plans page
1. Non-jetpack sites should go to main calypso /plans page
1. Users unable to purchase a plan should be sent back to wp-admin

Also, all the flows involving the plans page should work as before, see PCYsg-dek-p2
