### PR TITLE
Post Revisions: Fix safari rendering bug

### DIFF
--- a/client/post-editor/editor-revisions/style.scss
+++ b/client/post-editor/editor-revisions/style.scss
@@ -2,6 +2,8 @@
 .editor-revisions__dialog {
 	padding: 0;
 	overflow-x: hidden;
+	// Enable GPU acceleration to solve Safari rendering bug (see issue #20000)
+	transform: translate3d(0, 0, 0);
 }
 
 .editor-revisions__wrapper {


### PR DESCRIPTION
## This PR

- fixes issue https://github.com/Automattic/wp-calypso/issues/20000
- (see issue for a detailed description)

## How to test

- Navigate to a post with revisions in Safari 
- Click the History button
- The Post Revisions modal should load as expected

