### PR TITLE
Activity Log: fix bug in `isDiscarded::rewriteStream`

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -19,7 +19,7 @@ import ActivityLogItem from '../activity-log-item';
 import Button from 'components/button';
 import FoldableCard from 'components/foldable-card';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getActivityLog, getRequestedRewind } from 'state/selectors';
+import { getActivityLog, getRequestedRewind, getRewindEvents } from 'state/selectors';
 import { ms, rewriteStream } from 'state/activity-log/log/is-discarded';
 
 /**
@@ -200,6 +200,7 @@ class ActivityLogDay extends Component {
 			requestedBackupId,
 			requestDialog,
 			restoreConfirmDialog,
+			rewindEvents,
 			backupConfirmDialog,
 			siteId,
 			tsEndOfSiteDay,
@@ -215,7 +216,7 @@ class ActivityLogDay extends Component {
 		);
 
 		const rewindButton = this.renderRewindButton( hasConfirmDialog ? '' : 'primary' );
-		const events = classifyEvents( rewriteStream( logs, isDiscardedPerspective ), {
+		const events = classifyEvents( rewriteStream( logs, rewindEvents, isDiscardedPerspective ), {
 			backupId: requestedBackupId,
 			rewindId: requestedRestoreActivityId,
 		} );
@@ -279,6 +280,7 @@ export default localize(
 			return {
 				isDiscardedPerspective,
 				requestedRewind,
+				rewindEvents: getRewindEvents( state, siteId ),
 			};
 		},
 		( dispatch, { logs, tsEndOfSiteDay, moment } ) => ( {

--- a/client/state/activity-log/log/is-discarded/README.md
+++ b/client/state/activity-log/log/is-discarded/README.md
@@ -29,7 +29,7 @@ The simplest way to use this is to pass in a list of activity log events to the
 built in helper method, `rewriteStream`.
 
 ```js
-const log = rewriteStream( getActivityLogs( … ) )
+const log = rewriteStream( getActivityLogs( … ), getRewindEvents( … ) )
 ```
 
 Of course, this _is_ just a helper around the two more fundamental bits: one
@@ -48,7 +48,7 @@ We just have to pass in the timestamp from the mid-stream event which we will
 use as our point of observation.
 
 ```js
-const log = rewriteStream( getActivityLogs( … ), selectedEvent.activityTs )
+const log = rewriteStream( getActivityLogs( … ), getRewindEvents( … ), selectedEvent.activityTs )
 ```
 
 Obviously every event newer than the mid-stream event will be discarded because

--- a/client/state/activity-log/log/is-discarded/index.js
+++ b/client/state/activity-log/log/is-discarded/index.js
@@ -71,9 +71,8 @@ export const makeIsDiscarded = ( rewinds, viewFrom ) => {
 	return isDiscarded;
 };
 
-export const rewriteStream = ( events, viewFrom = Date.now() ) => {
-	const rewinds = getRewinds( events ).filter( ( [ rp ] ) => rp <= viewFrom );
-	const isDiscarded = makeIsDiscarded( rewinds, viewFrom );
+export const rewriteStream = ( events, rewinds, viewFrom = Date.now() ) => {
+	const isDiscarded = makeIsDiscarded( rewinds.filter( ( [ rp ] ) => rp <= viewFrom ), viewFrom );
 
 	return events.map( event => ( {
 		...event,

--- a/client/state/selectors/get-rewind-events.js
+++ b/client/state/selectors/get-rewind-events.js
@@ -1,0 +1,30 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get, values } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getRewinds } from 'state/activity-log/log/is-discarded';
+
+/**
+ * Returns all events which represent rewind operations
+ * from the activity log for a given site
+ *
+ * @param {Object} state Redux state
+ * @param {Number} siteId requested site
+ * @returns {?Array<Object>} list of rewind events
+ */
+export const getRewindEvents = ( state, siteId ) => {
+	const siteEvents = get( state, [ 'activityLog', 'logItems', siteId, 'data', 'items' ] );
+
+	if ( ! siteEvents ) {
+		return null;
+	}
+
+	return getRewinds( values( siteEvents ) );
+};
+
+export default getRewindEvents;

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -118,6 +118,7 @@ export getRegistrantWhois from './get-registrant-whois';
 export getRequestedRewind from './get-requested-rewind';
 export getRestoreError from './get-restore-error';
 export getRestoreProgress from './get-restore-progress';
+export getRewindEvents from './get-rewind-events';
 export getBackupProgress from './get-backup-progress';
 export getRequestedBackup from './get-requested-backup';
 export getRewindStartDate from './get-rewind-start-date';


### PR DESCRIPTION
Previously when calculating the `isDiscarded` property for an event we
were relying on `rewriteStream()` to perform all the calculations. As
stated in its documentation, "we need to know all restore operation
timestamps and their associated backup event timestamps from the oldest
event under examination until the point in time form which we are
calculating isDiscarded." Unfortunately, we weren't providing this
information and so there was an error in the values displayed.

Imagine looking at a day of events with only a few events in it. We were
sending these few events to `rewriteStream()` which itself extracted the
rewind events from that stream. The problem is that the applicable
rewind events didn't exist inside of the given events; they existed
outside of the time range. Further, the `logs` property passed down the
React hierarchy was selected using the given query from the display,
meaning that we would end up missing rewind events that fall outside of
the current display query.

To fix this I have created a new selector which returns all known rewind
events for a given site from `state`. Now, no matter from where the
calculation is called we will need to pass in the rewind events as a
second parameter to `rewriteStream()` and those calculations should be
as reliable as Calypso can provide. We may note at this point that if we
are missing newer data then the results could still be wrong.

**Testing**
Find a site with Activity Log enabled (betterjetpackxp.mystagingwebsite.com)
and navigate to **Stats** > **Activity**. If there are days with events that
should be discarded from rewinds on other days then these should not be
marked as discarded in **master** but _should_ be discarded in this branch.

**Before**
![discardedbroken mov](https://user-images.githubusercontent.com/5431237/33085207-0a6b3edc-ceb2-11e7-82d8-9aee2f80693e.gif)

**After**
![discardedworking mov](https://user-images.githubusercontent.com/5431237/33085203-07efddac-ceb2-11e7-88b6-c88ee576a2ec.gif)
