### PR TITLE
Comments: Restore permanent delete confirmation

### DIFF
--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
-import { get, includes, noop } from 'lodash';
+import { get, includes, isUndefined, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -49,6 +49,15 @@ export class CommentActions extends Component {
 
 	static defaultProps = {
 		updateLastUndo: noop,
+	};
+
+	delete = () => {
+		if (
+			isUndefined( window ) ||
+			window.confirm( this.props.translate( 'Delete this comment permanently?' ) )
+		) {
+			this.props.deletePermanently();
+		}
 	};
 
 	hasAction = action => includes( commentActions[ this.props.commentStatus ], action );
@@ -192,7 +201,7 @@ export class CommentActions extends Component {
 					<Button
 						borderless
 						className="comment__action comment__action-delete"
-						onClick={ this.props.deletePermanently }
+						onClick={ this.delete }
 					>
 						<Gridicon icon="trash" />
 						<span>{ translate( 'Delete Permanently' ) }</span>


### PR DESCRIPTION
Fix a M4 design regression where we accidentally removed the `window.confirm` dialog upon permanent delete.

### Testing instruction

- Head over to `comments/`.
- Trash (or spam) a comment.
- Change filter status to Trash.
- Permanently delete the comment.
- Make sure there is a `window.confirm` dialog asking:
> Delete this comment permanently?