### PR TITLE
Store Orders: Fetch notes when the edit-state is toggled off

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -43,19 +43,20 @@ class Order extends Component {
 	}
 
 	componentWillReceiveProps( newProps ) {
-		if ( newProps.orderId !== this.props.orderId || newProps.siteId !== this.props.siteId ) {
+		const { orderId: oldOrderId, siteId: oldSiteId } = this.props;
+		const { orderId: newOrderId, siteId: newSiteId } = newProps;
+		if ( newOrderId !== oldOrderId || newSiteId !== oldSiteId ) {
 			// New order or site should clear any pending edits
-			this.props.clearOrderEdits( this.props.siteId );
+			this.props.clearOrderEdits( oldSiteId );
 			// And fetch the new order's info
-			this.props.fetchOrder( newProps.siteId, newProps.orderId );
-			this.props.fetchNotes( newProps.siteId, newProps.orderId );
-		} else if (
-			newProps.order &&
-			this.props.order &&
-			newProps.order.status !== this.props.order.status
-		) {
-			// A status change should force a notes refresh
-			this.props.fetchNotes( newProps.siteId, newProps.orderId, true );
+			this.props.fetchOrder( newSiteId, newOrderId );
+			this.props.fetchNotes( newSiteId, newOrderId );
+			return;
+		}
+
+		if ( this.props.isEditing && ! newProps.isEditing ) {
+			// Leaving edit state should re-fetch notes
+			this.props.fetchNotes( newSiteId, newOrderId, true );
 		}
 	}
 


### PR DESCRIPTION
Fixes #19909 – When an order is saved with a new status, it should create a new note in the Activity Log. This happens, but the Activity Log is not refreshed after save so it's not immediately visible. This PR updates the refresh code so that the notes are re-fetched after leaving the edit mode. This also fixes a bug where changing the status while in edit-state would re-fetch the notes, even though there hasn't been a saved change.

**To Test**

- Starting at URL: `/store/orders/:site`
- Select an order
- Click the Edit Order button
- Make a status change, like On Hold -> Cancelled
- The Activity Log should _not_ refresh now
- Click Save Order
- The Activity Log _should_ refresh now, and include the status change