### PR TITLE
Store NUX: enable for 99% of all users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -20,11 +20,12 @@ export default {
 	signupAtomicStoreVsPressable: {
 		datestamp: '20171101',
 		variations: {
-			atomic: 10,
-			pressable: 90,
+			atomic: 99,
+			pressable: 1,
 		},
-		defaultVariation: 'pressable',
+		defaultVariation: 'atomic',
 		allowExistingUsers: true,
+		localeTargets: 'any',
 	},
 	businessPlanDescriptionAT: {
 		datestamp: '20170605',


### PR DESCRIPTION
When we launched Store NUX, we enabled it only to 10% of all users coming to the signup flows.

In this PR, we are opening it up to 99% of all users. 1% will still see the old Pressable flow.

What is more, we are also enabling it for all user locales (by setting `localeTargets` to `'any'`). While that probably doesn't matter right now as Store NUX is only enabled for US/CA people, in the future, when we will open it to people from other countries, we would need set that anyways and it's better to set it now so we don't forget about it in the future.