### PR TITLE
Post Revisions: Increase the max # of characters to diff

### DIFF
--- a/client/state/selectors/get-post-revision-changes.js
+++ b/client/state/selectors/get-post-revision-changes.js
@@ -14,7 +14,7 @@ import createSelector from 'lib/create-selector';
 import { countDiffWords, diffWords } from 'lib/text-utils';
 import getPostRevisions from 'state/selectors/get-post-revisions';
 
-const MAX_DIFF_CONTENT_LENGTH = 20000;
+const MAX_DIFF_CONTENT_LENGTH = 50000;
 
 const diffKey = ( key, obj1, obj2 ) =>
 	map( diffWords( get( obj1, key, '' ), get( obj2, key, '' ) ), change =>

--- a/client/state/selectors/test/get-post-revision-changes.js
+++ b/client/state/selectors/test/get-post-revision-changes.js
@@ -215,7 +215,7 @@ describe( 'getPostRevisionChanges', () => {
 				{ count: 1, added: true, value: 'of' },
 				{ count: 1, value: ' ' },
 				{ count: 1, removed: true, value: 'title' },
-				{ count: 1, added: true, value: '19961' },
+				{ count: 1, added: true, value: '49961' },
 			],
 		} );
 	} );

--- a/client/state/selectors/test/get-post-revision-changes.js
+++ b/client/state/selectors/test/get-post-revision-changes.js
@@ -10,8 +10,8 @@ import { expect } from 'chai';
 import getPostRevisionChanges from '../get-post-revision-changes';
 
 describe( 'getPostRevisionChanges', () => {
-	const x20k = 'x'.repeat( 20000 );
-	const x19921 = 'x'.repeat( 19921 );
+	const x50k = 'x'.repeat( 50000 );
+	const x49921 = 'x'.repeat( 49921 );
 
 	const outOfOrderState = {
 		posts: {
@@ -60,7 +60,7 @@ describe( 'getPostRevisionChanges', () => {
 								author: 2,
 								date: '2017-11-14T12:13:12Z',
 								content: 'This revision has a really long title',
-								title: x20k,
+								title: x50k,
 							},
 							18: {
 								id: 19,
@@ -73,7 +73,7 @@ describe( 'getPostRevisionChanges', () => {
 								id: 19,
 								author: 2,
 								date: '2017-11-14T12:13:14Z',
-								content: x20k,
+								content: x50k,
 								title: 'This revision has really long content',
 							},
 							20: {
@@ -87,8 +87,8 @@ describe( 'getPostRevisionChanges', () => {
 								id: 21,
 								author: 2,
 								date: '2017-11-15T14:16:12Z',
-								content: x19921,
-								title: 'This revision has total length of 19961',
+								content: x49921,
+								title: 'This revision has total length of 49961',
 							},
 						},
 					},
@@ -199,7 +199,7 @@ describe( 'getPostRevisionChanges', () => {
 				{
 					count: 1,
 					added: true,
-					value: x19921,
+					value: x49921,
 				},
 			],
 			summary: { added: 4, removed: 4 },


### PR DESCRIPTION
This bumps the cutoff from 20000 to 50000.  Meaning:

We will now compute and display differences between revisions totaling 2.5 times more data (between the two titles and raw content).

This should (hopefully) cover most usage while still preventing giant posts from hanging the client.

## To Test

* Progressively create a post (or page) with a lot of content (around 25000 characters long)
* Save / Update often
* Diffs should be calculated and displayed in a performant fashion up until the post reaches ~ 25k chars (as computed by `String.prototype.length`)
  * After that, it should fall back to just showing the title & content of the specified revision.