### PR TITLE
Add site goal question to survey

### DIFF
--- a/assets/stylesheets/sections/signup.scss
+++ b/assets/stylesheets/sections/signup.scss
@@ -10,6 +10,7 @@
 @import 'signup/navigation-link/style';
 @import 'signup/processing-screen/style';
 @import 'signup/step-wrapper/style';
+@import 'signup/steps/about/style';
 @import 'signup/steps/design-type-with-store/pressable-store/style';
 @import 'signup/steps/design-type-with-store/style';
 @import 'signup/steps/design-type-with-atomic-store/style';

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -26,16 +26,20 @@ import Button from 'components/button';
 import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import FormFieldset from 'components/forms/form-fieldset';
+import FormInputCheckbox from 'components/forms/form-checkbox';
 
 class AboutStep extends Component {
 	componentWillMount() {
 		this.formStateController = new formState.Controller( {
-			fieldNames: [ 'siteTitle' ],
+			fieldNames: [ 'siteTitle', 'siteGoals' ],
 			validatorFunction: noop,
 			onNewState: this.setFormState,
 			hideFieldErrorsOnChange: true,
 			initialState: {
 				siteTitle: {
+					value: '',
+				},
+				siteGoals: {
 					value: '',
 				},
 			},
@@ -93,28 +97,101 @@ class AboutStep extends Component {
 		goToNextStep();
 	};
 
+	renderGoalCheckboxes() {
+		return (
+			<div className="about__checkboxes">
+				<FormLabel htmlFor="share" className="about__checkbox-option">
+					<FormInputCheckbox
+						name="siteGoals"
+						id="share"
+						onChange={ this.handleChangeEvent }
+						value="Share ideas, experiences, updates, reviews, stories, videos, or photos"
+						className="about__checkbox"
+					/>
+					<span className="about__checkbox-label">
+						Share ideas, experiences, updates, reviews, stories, videos, or photos
+					</span>
+				</FormLabel>
+
+				<FormLabel htmlFor="promote" className="about__checkbox-option">
+					<FormInputCheckbox
+						name="siteGoals"
+						id="promote"
+						onChange={ this.handleChangeEvent }
+						value="Promote your business, skills, organization, or events"
+						className="about__checkbox"
+					/>
+					<span className="about__checkbox-label">
+						Promote your business, skills, organization, or events
+					</span>
+				</FormLabel>
+
+				<FormLabel htmlFor="educate" className="about__checkbox-option">
+					<FormInputCheckbox
+						name="siteGoals"
+						id="educate"
+						onChange={ this.handleChangeEvent }
+						value="Offer education, training, or mentoring"
+						className="about__checkbox"
+					/>
+					<span className="about__checkbox-label">Offer education, training, or mentoring</span>
+				</FormLabel>
+
+				<FormLabel htmlFor="sell" className="about__checkbox-option">
+					<FormInputCheckbox
+						name="siteGoals"
+						id="sell"
+						onChange={ this.handleChangeEvent }
+						value="Sell products or collect payments"
+						className="about__checkbox"
+					/>
+					<span className="about__checkbox-label">Sell products or collect payments</span>
+				</FormLabel>
+
+				<FormLabel htmlFor="showcase" className="about__checkbox-option">
+					<FormInputCheckbox
+						name="siteGoals"
+						id="showcase"
+						onChange={ this.handleChangeEvent }
+						value="Showcase your portfolio"
+						className="about__checkbox"
+					/>
+					<span className="about__checkbox-label">Showcase your portfolio</span>
+				</FormLabel>
+			</div>
+		);
+	}
+
 	renderContent() {
 		const { translate, siteTitle } = this.props;
 
 		return (
-			<form onSubmit={ this.handleSubmit }>
-				<Card>
-					<FormFieldset>
-						<FormLabel htmlFor="siteTitle">What would you like to name your site?</FormLabel>
-						<FormTextInput
-							id="siteTitle"
-							name="siteTitle"
-							placeholder="eg: Mel's Diner, Stevie’s Blog, Vail Renovations"
-							defaultValue={ siteTitle }
-							onChange={ this.handleChangeEvent }
-						/>
-					</FormFieldset>
-				</Card>
+			<div className="about__wrapper">
+				<form onSubmit={ this.handleSubmit }>
+					<Card>
+						<FormFieldset>
+							<FormLabel htmlFor="siteTitle">What would you like to name your site?</FormLabel>
+							<FormTextInput
+								id="siteTitle"
+								name="siteTitle"
+								placeholder="eg: Mel's Diner, Stevie’s Blog, Vail Renovations"
+								defaultValue={ siteTitle }
+								onChange={ this.handleChangeEvent }
+							/>
+						</FormFieldset>
 
-				<Button primary={ true } type="submit">
-					{ translate( 'Continue' ) }
-				</Button>
-			</form>
+						<FormFieldset>
+							<FormLabel>What’s the primary goal you have for your site?</FormLabel>
+							{ this.renderGoalCheckboxes() }
+						</FormFieldset>
+					</Card>
+					<div className="about__submit-wrapper">
+						<Button primary={ true } type="submit">
+							{ translate( 'Continue' ) }
+						</Button>
+					</div>
+				</form>
+			</div>
 		);
 	}
 

--- a/client/signup/steps/about/style.scss
+++ b/client/signup/steps/about/style.scss
@@ -1,0 +1,34 @@
+.about__wrapper {
+	max-width: 550px;
+	margin: 0 auto;
+}
+
+.about__checkboxes {
+	border: 1px solid lighten( $gray, 20% );
+	border-radius: 3px;
+}
+
+.about__checkbox-option {
+	border-top: 1px solid lighten( $gray, 20% );
+	color: darken( $gray, 20% );
+	display: block;
+	font-weight: normal;
+	margin: 0;
+	padding: 15px;
+
+	&:first-child {
+		border-top: 0;
+	}
+}
+
+.about__checkbox {
+	margin-right: 10px;
+}
+
+.about__checkbox-label {
+	display: inline-block;
+}
+
+.about__submit-wrapper {
+	text-align: center;
+}


### PR DESCRIPTION
A continuation of https://github.com/Automattic/wp-calypso/pull/19693. This PR adds a site goal field to the new user segmenting screen (more info here: p5XAZ9-1Cn-P2). Capturing and storing the data from this field seems to be a little complicated so I'd like to do that in a separate PR. 

![image](https://user-images.githubusercontent.com/6981253/33092816-46c6687c-cec9-11e7-90dc-4637a08d6569.png)

## Testing
* Visit `http://calypso.localhost:3000/start/segment/about`
* Toggle checkboxes on and off by clicking the checkbox or labels besides them

@taggon @markryall can you take a look?

