### PR TITLE
Data Layer: Add `getRequest()` selector and persist previous state

### DIFF
--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -96,6 +96,7 @@ export const makeParser = ( schema, schemaOptions = {}, transformer = identity )
 	// the actual parser
 	return data => transform( validate( data ) );
 };
+
 const getRequestStatus = action => {
 	if ( undefined !== getError( action ) ) {
 		return 'failure';
@@ -115,20 +116,18 @@ export const getRequestKey = fullAction => {
 	return requestKey ? requestKey : deterministicStringify( action );
 };
 
-export const getRequest = ( state, key ) => state.dataRequests[ key ] || {};
-
 export const requestsReducerItem = (
 	state = null,
 	{ meta: { dataLayer: { lastUpdated, pendingSince, status } = {} } = {} }
-) => Object.assign( { status }, lastUpdated && { lastUpdated }, pendingSince && { pendingSince } );
+) =>
+	Object.assign(
+		{ ...state },
+		{ status },
+		lastUpdated && { lastUpdated },
+		pendingSince && { pendingSince }
+	);
 
 export const reducer = keyedReducer( 'meta.dataLayer.requestKey', requestsReducerItem );
-
-export const isRequestLoading = ( state, action ) =>
-	getRequest( state, getRequestKey( action ) ).status === 'pending';
-
-export const hasRequestLoaded = ( state, action ) =>
-	getRequest( state, getRequestKey( action ) ).lastUpdated > -Infinity;
 
 /**
  * Tracks the state of network activity for a given request type

--- a/client/state/selectors/get-request.js
+++ b/client/state/selectors/get-request.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import { getRequest, getRequestKey } from 'state/data-layer/wpcom-http/utils';
+import { getRequestKey } from 'state/data-layer/wpcom-http/utils';
 
 /**
  * Returns meta information about data requests going through the data layer
@@ -12,7 +12,7 @@ import { getRequest, getRequestKey } from 'state/data-layer/wpcom-http/utils';
  * @returns {*} metadata about request
  */
 export default ( state, action ) => {
-	const data = getRequest( state, getRequestKey( action ) );
+	const data = state.dataRequests[ getRequestKey( action ) ] || {};
 
 	return {
 		...data,

--- a/client/state/selectors/get-request.js
+++ b/client/state/selectors/get-request.js
@@ -1,0 +1,22 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { getRequest, getRequestKey } from 'state/data-layer/wpcom-http/utils';
+
+/**
+ * Returns meta information about data requests going through the data layer
+ *
+ * @param {Object} state Redux state
+ * @param {Object} action data request action
+ * @returns {*} metadata about request
+ */
+export default ( state, action ) => {
+	const data = getRequest( state, getRequestKey( action ) );
+
+	return {
+		...data,
+		hasLoaded: data.lastUpdated > -Infinity,
+		isLoading: data.status === 'pending',
+	};
+};

--- a/client/state/selectors/index.js
+++ b/client/state/selectors/index.js
@@ -115,6 +115,7 @@ export getReaderTags from './get-reader-tags';
 export getReaderTeams from './get-reader-teams';
 export getReaderWatermark from './get-reader-watermark';
 export getRegistrantWhois from './get-registrant-whois';
+export getRequest from './get-request';
 export getRequestedRewind from './get-requested-rewind';
 export getRestoreError from './get-restore-error';
 export getRestoreProgress from './get-restore-progress';

--- a/client/state/selectors/test/get-request.js
+++ b/client/state/selectors/test/get-request.js
@@ -1,0 +1,65 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import getRequest from '../get-request';
+import { getRequestKey } from 'state/data-layer/wpcom-http/utils';
+
+test( 'should return default state even before initialization', () => {
+	const state = { dataRequests: {} };
+
+	expect( getRequest( state, { type: 'DUMMY_REQUEST' } ) ).toEqual( {
+		hasLoaded: false,
+		isLoading: false,
+	} );
+} );
+
+test( 'should indicate no data initialization when no `lastUpdated` exists', () => {
+	const action = { type: 'DUMMY_REQUEST' };
+	const requestKey = getRequestKey( action );
+	const state = { dataRequests: { [ requestKey ]: {} } };
+
+	expect( getRequest( state, action ) ).toHaveProperty( 'hasLoaded', false );
+} );
+
+test( 'should indicate data initialization when `lastUpdated` exists', () => {
+	const action = { type: 'DUMMY_REQUEST' };
+	const requestKey = getRequestKey( action );
+	const state = { dataRequests: { [ requestKey ]: { lastUpdated: 1518 } } };
+
+	expect( getRequest( state, action ) ).toHaveProperty( 'hasLoaded', true );
+} );
+
+test( 'should indicate loading when status is pending', () => {
+	const action = { type: 'DUMMY_REQUEST' };
+	const requestKey = getRequestKey( action );
+	const state = { dataRequests: { [ requestKey ]: { status: 'pending' } } };
+
+	expect( getRequest( state, action ) ).toHaveProperty( 'isLoading', true );
+} );
+
+test( "should indicate not loading if status isn't pending", () => {
+	const action = { type: 'DUMMY_REQUEST' };
+	const requestKey = getRequestKey( action );
+	const state = status => ( { dataRequests: { [ requestKey ]: { status } } } );
+
+	[ 'success', 'failure', undefined, null ].forEach( status =>
+		expect( getRequest( state( status ), action ) ).toHaveProperty( 'isLoading', false )
+	);
+} );
+
+test( 'should not hide any stored properties in state', () => {
+	const action = { type: 'DUMMY_REQUEST' };
+	const requestKey = getRequestKey( action );
+	const state = {
+		dataRequests: { [ requestKey ]: { pendingSince: 1500, status: 'success', lastUpdated: 2000 } },
+	};
+
+	expect( getRequest( state, action ) ).toEqual( {
+		hasLoaded: true,
+		isLoading: false,
+		lastUpdated: 2000,
+		pendingSince: 1500,
+		status: 'success',
+	} );
+} );


### PR DESCRIPTION
@see #20038

Adds selector to get current request information out of state.
Additionally, has the data layer keep track of previous request state as
new updates occur. This turned out to be important for making inferences
like `hasReceivedDataAtAll()` when a current request is pending.

**Testing**

Since nothing is using this yet it's mainly a code review here.