### PR TITLE
Me: Remove eventRecorder from ProfileLinks

### DIFF
--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -18,14 +18,13 @@ import AddProfileLinksButtons from 'me/profile-links/add-buttons';
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import Notice from 'components/notice';
-import eventRecorder from 'me/event-recorder';
 import ProfileLinksAddWordPress from 'me/profile-links-add-wordpress';
 import ProfileLinksAddOther from 'me/profile-links-add-other';
 
 const ProfileLinks = createReactClass( {
 	displayName: 'ProfileLinks',
 
-	mixins: [ observe( 'userProfileLinks' ), eventRecorder ],
+	mixins: [ observe( 'userProfileLinks' ) ],
 
 	componentDidMount() {
 		this.props.userProfileLinks.getProfileLinks();


### PR DESCRIPTION
This PR removes `eventRecorder` from `ProfileLinks`, because it appears that it's not used at all.

Part of #20053.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me
* Verify everything else on the profile page like it did before.
* Verify the `ProfileLinks` uses no `record*` methods and no `record*` methods are being passed to nested components.