### PR TITLE
Domains: Incoming Transfers: Add UI feedback for domain lock status

### DIFF
--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -177,6 +177,11 @@
 	&.transfer-domain-step__locked {
 		color: $alert-red;
 	}
+
+	&.transfer-domain-step__refresh {
+		color: $blue-wordpress;
+		cursor: pointer;
+	}
 }
 
 .transfer-domain-step__admin-email {

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -128,10 +128,6 @@
 		justify-content: space-between;
 	}
 
-	.button {
-		margin-top: 20px;
-	}
-
 	&.is-expanded {
 		align-items: flex-start;
 
@@ -154,12 +150,24 @@
 	}
 }
 
+.transfer-domain-step__section-action {
+	align-items: center;
+	display: flex;
+	margin-top: 20px;
+}
+
 .transfer-domain-step__lock-status {
 	font-size: 12px;
-	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	margin-left: 10px;
 
-	svg {
-		padding-right: 4px;
+	.gridicon {
+		margin-right: 2px;
+	}
+
+	&.transfer-domain-step__checking {
+		color: $gray;
 	}
 
 	&.transfer-domain-step__unlocked {

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -90,18 +90,21 @@ class TransferDomainPrecheck extends React.PureComponent {
 					<div className="transfer-domain-step__section-text">
 						<div className="transfer-domain-step__section-heading">
 							<strong>{ heading }</strong>
-							{ lockStatus }
+							{ isStepFinished && lockStatus }
 						</div>
 						{ isAtCurrentStep && (
 							<div>
 								<div className="transfer-domain-step__section-message">{ message }</div>
-								<Button
-									compact
-									onClick={ unlocked ? this.showNextStep : this.refreshStatus }
-									disabled={ loading }
-								>
-									{ buttonText }
-								</Button>
+								<div className="transfer-domain-step__section-action">
+									<Button
+										compact
+										onClick={ unlocked ? this.showNextStep : this.refreshStatus }
+										busy={ loading }
+									>
+										{ buttonText }
+									</Button>
+									{ lockStatus }
+								</div>
 							</div>
 						) }
 					</div>
@@ -121,24 +124,33 @@ class TransferDomainPrecheck extends React.PureComponent {
 			? translate( 'Your domain is unlocked at your current registrar.' )
 			: translate(
 					"Your domain is locked to prevent unauthorized transfers. You'll need to unlock " +
-						'it at your current domiain provider before we can move it. {{a}}Here are instructions for unlocking it{{/a}}',
+						'it at your current domiain provider before we can move it. {{a}}Here are instructions for unlocking it{{/a}}. ' +
+						'It might take a few minutes for any changes to take effect.',
 					{
 						components: {
 							a: <a href="#" rel="noopener noreferrer" />,
 						},
 					}
 				);
-		const buttonText = loading ? translate( 'Checking…' ) : translate( "I've unlocked my domain" );
+		const buttonText = translate( "I've unlocked my domain" );
 
-		const lockStatus = unlocked ? (
-			<div className="transfer-domain-step__lock-status transfer-domain-step__unlocked">
-				<Gridicon icon="checkmark" size={ 12 } />
-				<span>{ translate( 'Unlocked' ) }</span>
-			</div>
-		) : (
-			<div className="transfer-domain-step__lock-status transfer-domain-step__locked">
-				<Gridicon icon="cross" size={ 12 } />
-				<span>{ translate( 'Locked' ) }</span>
+		let lockStatusClasses = unlocked
+			? 'transfer-domain-step__lock-status transfer-domain-step__unlocked'
+			: 'transfer-domain-step__lock-status transfer-domain-step__locked';
+
+		let lockStatusIcon = unlocked ? 'checkmark' : 'cross';
+		let lockStatusText = unlocked ? translate( 'Unlocked' ) : translate( 'Locked' );
+
+		if ( loading ) {
+			lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__checking';
+			lockStatusIcon = 'sync';
+			lockStatusText = 'Checking…';
+		}
+
+		const lockStatus = (
+			<div className={ lockStatusClasses }>
+				<Gridicon icon={ lockStatusIcon } size={ 12 } />
+				<span>{ lockStatusText }</span>
 			</div>
 		);
 

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -124,7 +124,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 			? translate( 'Your domain is unlocked at your current registrar.' )
 			: translate(
 					"Your domain is locked to prevent unauthorized transfers. You'll need to unlock " +
-						'it at your current domiain provider before we can move it. {{a}}Here are instructions for unlocking it{{/a}}. ' +
+						'it at your current domain provider before we can move it. {{a}}Here are instructions for unlocking it{{/a}}. ' +
 						'It might take a few minutes for any changes to take effect.',
 					{
 						components: {


### PR DESCRIPTION
Fixes #20063. There's no feedback for the user in the UI when the domain is still locked and `I've unlocked my domain` is clicked. The button just re-enabled without anything else changing. This made it unclear to the user that anything was actually happening.

Bouncing some ideas around with @klimeryk we came up with this solution. It moves the `Locked` status next to the button to make it more visible, and changes it to `Checking...`. Now when we're checking the lock status the user can see the feedback and clearly know it's been refreshed rather than just broken.

I've also added a line in the description copy to set an expectation that it might take a few minutes for the lock status to update after making changes at the registrar.

![lock status check](https://user-images.githubusercontent.com/448298/33098500-9bfc52d6-cedb-11e7-8ded-19a00116b5bf.gif)

![email refresh](https://user-images.githubusercontent.com/1103398/33134609-7fc7c562-cfa0-11e7-8916-8cd1c08145e7.png)

#### Testing

1. Start at `/domains/add/transfer` and select a site.
2. Enter a domain that is currently locked at the registrar.
3. On the pre-check screen, click I've unlocked my domain.
4. Assert the interaction looks like the screenshot above.