### PR TITLE
Comments: fallback to remote site on failed GET

### DIFF
--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -98,7 +98,7 @@ export const requestComment = action => {
 				apiVersion: '1.1',
 				query,
 			},
-			//if we see a force=wpcom, don't retry try dropping the query param to see if the remote has the comment.
+			//if we see ?force=wpcom, on failure, retry against the real site instead.
 			query.force && { retryPolicy: noRetry() }
 		),
 		action
@@ -112,7 +112,8 @@ export const receiveCommentSuccess = ( action, response ) => {
 };
 
 export const receiveCommentError = ( { siteId, commentId, query = {} } ) => {
-	//if we see a force=wpcom, on retry try dropping the query param to see if the remote has the comment.
+	// we can't tell the difference between a network failure and a shadow sync failure
+	// so if the request drops out automatically retry against the real site
 	const { force, ...retryQuery } = query;
 	if ( force === 'wpcom' ) {
 		return requestCommentAction( { siteId, commentId, query: retryQuery } );


### PR DESCRIPTION
Part of #20027, sometimes the Jetpack shadow site isn't correctly synced with the remote. Newly transferred Atomic sites may throw errors when fetching comments. This PR updates the error handler to dispatch a new comment request without the force=wpcom parameter.

~~We can force hitting a shadow site with ?force=wpcom. 
This adds a policy to the data layer that removes this parameter on the second try.
@dmsnell let me know what you think. If it's too much of a corner case, I can move this behavior up a layer.~~

### Testing Instructions
- Modify the path in requestComment() to something like: `/sites/${ siteId }/commentz/${ commentId }`. This will make all get requests fail
- Navigate to /comments and select a Jetpack site
- Note that the first attempt has a force=wpcom param, and the retry does not. Note that the retry will use the default retry policy so, if we have a single failing comment, we'll see:
```
firstrequest?force=wpcom
secondrequest
thirdrequest
fourthrequest
```