### PR TITLE
Domains checkout: cannot focus on invalid organization field

### DIFF
--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -381,7 +381,7 @@ export class DomainDetailsForm extends PureComponent {
 						count: this.getNumberOfDomainRegistrations(),
 					}
 				) }
-				{ ...this.getFieldProps( 'organization' ) }
+				{ ...this.getFieldProps( 'organization', true ) }
 			/>
 		);
 	}


### PR DESCRIPTION
## The problem

Because we aren't passing down an `inputRef` callback to `<HiddenInput />`, the parent component is unable to focus on the field.

### Steps to replicate:
1. Select a domain to purchase and go to the checkout
2. Fill out the form with valid values except for the **organization field**, whose value should be `111` or something equally invalid.
3. Submit form.

Result:

<img width="773" alt="screen shot 2017-11-22 at 2 45 54 pm" src="https://user-images.githubusercontent.com/6458278/33109232-7aac71f6-cf94-11e7-85c4-f028a21c658a.png">

## The solution
Passing `true` to `this.getFieldProps` will ensure that a valid  `inputRef` callback is set as a prop.

Thanks to @deBhal for flagging this as an issue. 👍 
