### PR TITLE
Store: Promotions: Invalidate spaces as coupon code

### DIFF
--- a/client/extensions/woocommerce/app/promotions/promotion-validations.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-validations.js
@@ -16,7 +16,7 @@ import { isEmpty, isUndefined } from 'lodash';
  * @return { string } Returns a validation error, or undefined if none.
  */
 export function validateCouponCode( fieldName, promotion, currency, showEmpty ) {
-	if ( showEmpty && isEmpty( promotion.couponCode ) ) {
+	if ( showEmpty && isEmpty( promotion.couponCode.trim() ) ) {
 		return translate( 'Enter a coupon code so your customers can access this promotion.' );
 	}
 }

--- a/client/extensions/woocommerce/state/sites/coupons/handlers.js
+++ b/client/extensions/woocommerce/state/sites/coupons/handlers.js
@@ -124,11 +124,5 @@ function isValidCouponsArray( coupons ) {
 }
 
 function isValidCoupon( coupon ) {
-	return (
-		coupon &&
-		coupon.id &&
-		'number' === typeof coupon.id &&
-		coupon.code &&
-		'string' === typeof coupon.code
-	);
+	return coupon && coupon.id && 'number' === typeof coupon.id && 'string' === typeof coupon.code;
 }


### PR DESCRIPTION
### Problem
Saving a promotion with a Coupon Code consisting of a string with only spaces cause the UI to freeze up. Not sure why anyone would do that, but I was trying to break the validation.

### Cause
At some point, the coupon code string is trimmed before being saved to the database. When the coupons return from the API, a `coupon.code = ''` cause invalidation of all the coupons.
https://github.com/Automattic/wp-calypso/blob/52fa35e47e16b737a2dbe54147bf78b348b03d50/client/extensions/woocommerce/state/sites/coupons/handlers.js#L126-L134

### Fix
trim the input string in validation.

### Test
Try entering a Coupon Code of "    ". Watch the UI error show on an attempt to save.

Separately, the validity of the individual coupons could be evaluated at the UI level. This way all valid coupons can be displayed and a user friendly error shown for an invalid error. Or simply omitted altogether.