### PR TITLE
Remove sites-list from TinyMCEDropZone

### DIFF
--- a/client/components/tinymce/plugins/media/drop-zone.jsx
+++ b/client/components/tinymce/plugins/media/drop-zone.jsx
@@ -6,7 +6,6 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { noop } from 'lodash';
 import { connect } from 'react-redux';
 
@@ -23,27 +22,21 @@ import MediaValidationStore from 'lib/media/validation-store';
 import markup from 'post-editor/media-modal/markup';
 import { getSelectedSite } from 'state/ui/selectors';
 
-const TinyMCEDropZone = createReactClass( {
-	displayName: 'TinyMCEDropZone',
-
-	propTypes: {
+class TinyMCEDropZone extends React.Component {
+	static propTypes = {
 		editor: PropTypes.object,
 		onInsertMedia: PropTypes.func,
 		onRenderModal: PropTypes.func,
-	},
+	};
 
-	getInitialState() {
-		return {
-			isDragging: false,
-		};
-	},
+	static defaultProps = {
+		onInsertMedia: noop,
+		onRenderModal: noop,
+	};
 
-	getDefaultProps() {
-		return {
-			onInsertMedia: noop,
-			onRenderModal: noop,
-		};
-	},
+	state = {
+		isDragging: false,
+	};
 
 	componentDidMount() {
 		const { editor } = this.props;
@@ -51,7 +44,7 @@ const TinyMCEDropZone = createReactClass( {
 		window.addEventListener( 'dragleave', this.stopDragging );
 		editor.dom.bind( editor.getWin(), 'dragleave', this.stopDragging );
 		editor.dom.bind( editor.getWin(), 'dragover', this.fakeDragEnterIfNecessary );
-	},
+	}
 
 	componentWillUnmount() {
 		const { editor } = this.props;
@@ -59,9 +52,9 @@ const TinyMCEDropZone = createReactClass( {
 		window.removeEventListener( 'dragleave', this.stopDragging );
 		editor.dom.unbind( editor.getWin(), 'dragleave', this.stopDragging );
 		editor.dom.unbind( editor.getWin(), 'dragover', this.fakeDragEnterIfNecessary );
-	},
+	}
 
-	redirectEditorDragEvent( event ) {
+	redirectEditorDragEvent = event => {
 		// When an item is dragged over the iframe container, we need to copy
 		// and dispatch the event to the parent window. We use the CustomEvent
 		// constructor rather than MouseEvent because MouseEvent may lose some
@@ -72,9 +65,9 @@ const TinyMCEDropZone = createReactClass( {
 		this.setState( {
 			isDragging: true,
 		} );
-	},
+	};
 
-	fakeDragEnterIfNecessary( event ) {
+	fakeDragEnterIfNecessary = event => {
 		// It was found that Chrome only triggered the `dragenter` event on
 		// every odd drag over the iframe element. The logic here ensures that
 		// if the more frequent `dragover` event occurs while not aware of a
@@ -88,15 +81,15 @@ const TinyMCEDropZone = createReactClass( {
 				type: 'dragenter',
 			} )
 		);
-	},
+	};
 
-	stopDragging() {
+	stopDragging = () => {
 		this.setState( {
 			isDragging: false,
 		} );
-	},
+	};
 
-	insertMedia() {
+	insertMedia = () => {
 		const { site, onInsertMedia, onRenderModal } = this.props;
 
 		if ( ! site ) {
@@ -124,7 +117,7 @@ const TinyMCEDropZone = createReactClass( {
 		}
 
 		analytics.mc.bumpStat( 'editor_upload_via', 'editor_drop' );
-	},
+	};
 
 	render() {
 		const { site } = this.props;
@@ -141,8 +134,8 @@ const TinyMCEDropZone = createReactClass( {
 				onAddMedia={ this.insertMedia }
 			/>
 		);
-	},
-} );
+	}
+}
 
 export default connect( state => ( {
 	site: getSelectedSite( state ),

--- a/client/components/tinymce/plugins/media/drop-zone.jsx
+++ b/client/components/tinymce/plugins/media/drop-zone.jsx
@@ -8,12 +8,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { noop } from 'lodash';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import observe from 'lib/mixins/data-observe';
 import PostActions from 'lib/posts/actions';
 import MediaDropZone from 'my-sites/media-library/drop-zone';
 import MediaActions from 'lib/media/actions';
@@ -21,15 +21,13 @@ import MediaUtils from 'lib/media/utils';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import MediaValidationStore from 'lib/media/validation-store';
 import markup from 'post-editor/media-modal/markup';
+import { getSelectedSite } from 'state/ui/selectors';
 
-export default createReactClass( {
+const TinyMCEDropZone = createReactClass( {
 	displayName: 'TinyMCEDropZone',
-
-	mixins: [ observe( 'sites' ) ],
 
 	propTypes: {
 		editor: PropTypes.object,
-		sites: PropTypes.object,
 		onInsertMedia: PropTypes.func,
 		onRenderModal: PropTypes.func,
 	},
@@ -99,8 +97,7 @@ export default createReactClass( {
 	},
 
 	insertMedia() {
-		const { sites, onInsertMedia, onRenderModal } = this.props;
-		const site = sites.getSelectedSite();
+		const { site, onInsertMedia, onRenderModal } = this.props;
 
 		if ( ! site ) {
 			return;
@@ -130,8 +127,7 @@ export default createReactClass( {
 	},
 
 	render() {
-		const { sites } = this.props;
-		const site = sites.getSelectedSite();
+		const { site } = this.props;
 
 		if ( ! site ) {
 			return null;
@@ -147,3 +143,7 @@ export default createReactClass( {
 		);
 	},
 } );
+
+export default connect( state => ( {
+	site: getSelectedSite( state ),
+} ) )( TinyMCEDropZone );

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -17,7 +17,6 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import SiteListFactory from 'lib/sites-list';
 import PostActions from 'lib/posts/actions';
 import PostEditStore from 'lib/posts/post-edit-store';
 import * as MediaConstants from 'lib/media/constants';
@@ -40,9 +39,8 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 /**
  * Module variables
  */
-const REGEXP_IMG = /<img\s[^>]*\/?>/gi,
-	SIZE_ORDER = [ 'thumbnail', 'medium', 'large', 'full' ],
-	sites = SiteListFactory();
+const REGEXP_IMG = /<img\s[^>]*\/?>/gi;
+const SIZE_ORDER = [ 'thumbnail', 'medium', 'large', 'full' ];
 
 let lastDirtyImage = null,
 	numOfImagesToUpdate = null;
@@ -125,7 +123,6 @@ function mediaButton( editor ) {
 		renderWithReduxStore(
 			<TinyMCEDropZone
 				editor={ editor }
-				sites={ sites }
 				onInsertMedia={ insertMedia }
 				onRenderModal={ renderModal }
 			/>,


### PR DESCRIPTION
**1st commit:**
Remove sites-list from `TinyMCEDropZone`. Use `getSelectedSite` Redux selector instead.

**2nd commit:**
Convert TinyMCEDropZone to ES6 class. The `observe` mixin was just removed in the previous commit, so there's nothing left to stop us from ES6-ifying.

**How to test:**
1. Start editing a post.
2. Drop an image into it.
3. Verify that the image was uploaded, inserted into the post, and added to the site's media library.
