### PR TITLE
Comments Redesign: Decrease components updates

### DIFF
--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
-import { get, includes, isUndefined, noop } from 'lodash';
+import { get, includes, isEqual, isUndefined, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -50,6 +50,8 @@ export class CommentActions extends Component {
 	static defaultProps = {
 		updateLastUndo: noop,
 	};
+
+	shouldComponentUpdate = nextProps => ! isEqual( this.props, nextProps );
 
 	delete = () => {
 		if (

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
-import { get } from 'lodash';
+import { get, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,6 +28,8 @@ export class CommentAuthor extends Component {
 		isBulkMode: PropTypes.bool,
 		isPostView: PropTypes.bool,
 	};
+
+	shouldComponentUpdate = nextProps => ! isEqual( this.props, nextProps );
 
 	commentHasLink = () => {
 		if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import ReactDom from 'react-dom';
-import { get, isUndefined } from 'lodash';
+import { get, isEqual, isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -51,6 +51,9 @@ export class Comment extends Component {
 			isReplyVisible: wasBulkMode !== isBulkMode ? false : isReplyVisible,
 		} ) );
 	}
+
+	shouldComponentUpdate = ( nextProps, nextState ) =>
+		! isEqual( this.props, nextProps ) || ! isEqual( this.state, nextState );
 
 	storeCardRef = card => ( this.commentCard = card );
 


### PR DESCRIPTION
This is an attempt at reducing the admittedly huge amount of renders some of the new `Comment` components do, as found out by @rodrigoi.

It is a totally empirical approach: I simply counted how many renders every involved component did at first load, and I've found 3 big offenders.
I've then tried extending `PureComponent` (just for fun apparently), and finally forcing a deep props and state comparison on `shouldComponentUpdate`.

This is how the first load renders changed:

| Component | Current | PureComponent | Deep Comparison |
| --- | --- | --- | --- |
| `Comment` | 124 | 47 | 3 |
| `CommentAuthor` | 44 | 45 | 4 |
| `CommentActions` | 46 | 43 | 3 |