### PR TITLE
Plan upgrades: improve the Copy in the SEO/GA nudge banners

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -123,6 +123,10 @@ class GoogleAnalyticsForm extends Component {
 			siteIsJetpack &&
 			siteSupportsIPAnonymization;
 
+		const nudgeTitle = siteIsJetpack
+			? translate( 'Enable Google Analytics by upgrading to Jetpack Professional' )
+			: translate( 'Enable Google Analytics by upgrading to the Business plan' );
+
 		return (
 			<form id="site-settings" onSubmit={ handleSubmitForm }>
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
@@ -176,7 +180,7 @@ class GoogleAnalyticsForm extends Component {
 						event={ 'google_analytics_settings' }
 						feature={ FEATURE_GOOGLE_ANALYTICS }
 						plan={ PLAN_BUSINESS }
-						title={ translate( 'Enable Google Analytics by upgrading to Jetpack Professional' ) }
+						title={ nudgeTitle }
 					/>
 				) : (
 					<Card className="analytics-settings site-settings__analytics-settings">

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -173,16 +173,16 @@ class GoogleAnalyticsForm extends Component {
 						description={
 							siteIsJetpack
 								? translate(
-										'Upgrade to the Professional Plan and include your own analytics tracking ID.'
+										"Add your unique tracking ID to monitor your site's performance in Google Analytics."
 									)
 								: translate(
-										'Upgrade to the Business Plan and include your own analytics tracking ID.'
+										"Add your unique tracking ID to monitor your site's performance in Google Analytics."
 									)
 						}
 						event={ 'google_analytics_settings' }
 						feature={ FEATURE_GOOGLE_ANALYTICS }
 						plan={ PLAN_BUSINESS }
-						title={ translate( 'Add Google Analytics' ) }
+						title={ translate( 'Enable Google Analytics by upgrading to Jetpack Professional' ) }
 					/>
 				) : (
 					<Card className="analytics-settings site-settings__analytics-settings">

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -170,15 +170,9 @@ class GoogleAnalyticsForm extends Component {
 
 				{ showUpgradeNudge ? (
 					<Banner
-						description={
-							siteIsJetpack
-								? translate(
-										"Add your unique tracking ID to monitor your site's performance in Google Analytics."
-									)
-								: translate(
-										"Add your unique tracking ID to monitor your site's performance in Google Analytics."
-									)
-						}
+						description={ translate(
+							"Add your unique tracking ID to monitor your site's performance in Google Analytics."
+						) }
 						event={ 'google_analytics_settings' }
 						feature={ FEATURE_GOOGLE_ANALYTICS }
 						plan={ PLAN_BUSINESS }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -313,8 +313,8 @@ export class SeoForm extends React.Component {
 		const jetpackUpdateUrl = getJetpackPluginUrl( slug );
 
 		const nudgeTitle = siteIsJetpack
-			? translate( 'Enable SEO Tools features by upgrading to Jetpack Professional' )
-			: translate( 'Enable SEO Tools features by upgrading to the Business Plan' );
+			? translate( 'Enable SEO Tools by upgrading to Jetpack Professional' )
+			: translate( 'Enable SEO Tools by upgrading to Jetpack Business' );
 
 		const seoSubmitButton = (
 			<Button
@@ -401,7 +401,7 @@ export class SeoForm extends React.Component {
 				{ ! this.props.hasAdvancedSEOFeature && (
 					<Banner
 						description={ translate(
-							'Adds tools to optimize your site for search engines and social media sharing.'
+							'Get tools to optimize your site for improved performance in search engine results.'
 						) }
 						event={ 'calypso_seo_settings_upgrade_nudge' }
 						feature={ FEATURE_ADVANCED_SEO }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -314,7 +314,7 @@ export class SeoForm extends React.Component {
 
 		const nudgeTitle = siteIsJetpack
 			? translate( 'Enable SEO Tools by upgrading to Jetpack Professional' )
-			: translate( 'Enable SEO Tools by upgrading to Jetpack Business' );
+			: translate( 'Enable SEO Tools by upgrading to the Business plan' );
 
 		const seoSubmitButton = (
 			<Button


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/20064

- Edit fixes to the Plan upgrade Banner nudges for *non-Pro JP connected* and *non-Business .com* sites ( banners are not displayed otherwise )

**To test:**
1. `wordpress.com/settings/traffic/:site`, where `:site` is one of the ☝️ 
2. scroll down to the nudge Banner and verify that the view coincides with:

- for connected non-Pro JP sites:

![screen shot 2017-11-22 at 19 42 36](https://user-images.githubusercontent.com/13561163/33144385-1cd369da-cfbd-11e7-9b07-db63d2c40c00.png)

- for non-Business .com sites:

![screen shot 2017-11-22 at 19 40 41](https://user-images.githubusercontent.com/13561163/33144329-f96861f8-cfbc-11e7-9ac5-aabbb54f81cc.png)


