### PR TITLE
Unify font sizes for posts and pages

### DIFF
--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -84,7 +84,7 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	@extend %content-font;
 	margin-bottom: 2px;
 	font-weight: 700;
-	font-size: 20px;
+	font-size: 18px;
 	line-height: 1.2;
 }
 

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -22,6 +22,7 @@
 	color: $gray-dark;
 	font-weight: bold;
 	font-family: $serif;
+	font-size: 18px;
 	margin-right: 33px;
 
 	&.is-disabled {

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -4,7 +4,7 @@
 	padding: 16px;
 
 	@include breakpoint( ">480px" ) {
-		padding: 16px 24px;	
+		padding: 16px 24px;
 	}
 }
 
@@ -18,12 +18,14 @@
 }
 
 .blog-posts-page__title {
-	display: inline;
+	@extend %content-font;
 	color: $gray-dark;
-	font-weight: bold;
-	font-family: $serif;
+	font-weight: 700;
 	font-size: 18px;
-	margin-right: 33px;
+	line-height: 1.2;
+
+	display: inline;
+	margin-bottom: 2px;
 
 	&.is-disabled {
 		color: $gray;

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -136,6 +136,7 @@
 	color: $gray-dark;
 	font-weight: bold;
 	font-family: $serif;
+	font-size: 18px;
 	margin-right: 33px;
 
 	.gridicon {

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -132,11 +132,13 @@
 
 .page__title,
 .page__title:visited {
-	display: inline;
+	@extend %content-font;
 	color: $gray-dark;
-	font-weight: bold;
-	font-family: $serif;
+	font-weight: 700;
 	font-size: 18px;
+	line-height: 1.2;
+
+	display: inline;
 	margin-right: 33px;
 
 	.gridicon {


### PR DESCRIPTION
This PR unifies the font sizes between the `PostTypeList` (currently shown as the posts list to 5% of English-speaking users) and the pages list (shown to all users).  Previously in https://github.com/Automattic/wp-calypso/pull/17550 we enlarged this font size for the posts list.  We could keep the same 20px size for pages as well, but I think 18px looks good throughout.

| Section | Before | After |
|--|--|--|
| Posts | ![2017-11-22t21 41 23 0800](https://user-images.githubusercontent.com/227022/33130418-46d11cb2-cfce-11e7-8bf0-891fb04d559a.png) | ![2017-11-22t21 41 05 0800](https://user-images.githubusercontent.com/227022/33130422-4d358818-cfce-11e7-87a1-c56dc32f2000.png) |
| Pages | ![2017-11-22t21 40 42 0800](https://user-images.githubusercontent.com/227022/33130441-5e2785f4-cfce-11e7-9356-24e228fd04b5.png) | ![2017-11-22t21 40 20 0800](https://user-images.githubusercontent.com/227022/33130452-673a8c36-cfce-11e7-9da0-af1b41a483ff.png) |
