### PR TITLE
Devdocs: Fix component names

### DIFF
--- a/client/components/checklist/docs/example.jsx
+++ b/client/components/checklist/docs/example.jsx
@@ -13,6 +13,8 @@ import { find } from 'lodash';
 import Checklist from '../';
 
 export default class ChecklistExample extends Component {
+	static displayName = 'Checklist';
+
 	state = {
 		showPlaceholder: false,
 		tasks: [

--- a/client/components/notice/docs/example.jsx
+++ b/client/components/notice/docs/example.jsx
@@ -13,7 +13,7 @@ import NoticeAction from 'components/notice/notice-action';
 import Notice from 'components/notice';
 
 class Notices extends React.PureComponent {
-	static displayName = 'Notices';
+	static displayName = 'Notice';
 
 	state = {
 		compactNotices: false,

--- a/client/components/notice/docs/example.jsx
+++ b/client/components/notice/docs/example.jsx
@@ -13,6 +13,8 @@ import NoticeAction from 'components/notice/notice-action';
 import Notice from 'components/notice';
 
 class Notices extends React.PureComponent {
+	static displayName = 'Notices';
+
 	state = {
 		compactNotices: false,
 	};

--- a/client/components/payment-logo/docs/example.jsx
+++ b/client/components/payment-logo/docs/example.jsx
@@ -12,6 +12,8 @@ import React from 'react';
 import PaymentLogo from '../index';
 
 class PaymentLogoExamples extends React.PureComponent {
+	static displayName = 'PaymentLogo';
+
 	render() {
 		return (
 			<div>

--- a/client/components/rating/docs/example.jsx
+++ b/client/components/rating/docs/example.jsx
@@ -12,6 +12,8 @@ import React from 'react';
 import Rating from 'components/rating';
 
 export default class RatingExample extends React.PureComponent {
+	static displayName = 'Rating';
+
 	render() {
 		return <Rating rating={ 70 } size={ 48 } />;
 	}


### PR DESCRIPTION
Some components were displayed as 't'. It's because of JS minification. Need to set `displayName`.