### PR TITLE
Site picker: Do not scroll to top when canceling a site switch

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -180,7 +180,7 @@ class SiteSelector extends Component {
 
 	onSiteSelect = ( event, siteId ) => {
 		const handledByHost = this.props.onSiteSelect( siteId );
-		this.props.onClose( event );
+		this.props.onClose( event, siteId );
 
 		const node = ReactDom.findDOMNode( this.refs.selector );
 		if ( node ) {

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -49,16 +49,18 @@ class SitePicker extends React.Component {
 		}
 	}
 
-	onClose = event => {
+	onClose = ( event, selectedSiteId ) => {
 		if ( event.key === 'Escape' ) {
 			this.closePicker();
 		} else {
 			// We use setNext here, because on mobile we want to show sidebar
 			// instead of Stats page after picking a site
 			this.props.setNextLayoutFocus( 'sidebar' );
-			this.scrollToTop();
+			if ( selectedSiteId ) {
+				this.scrollToTop();
+			}
 		}
-		this.props.onClose( event );
+		this.props.onClose( event, selectedSiteId );
 	};
 
 	scrollToTop = () => {
@@ -66,15 +68,17 @@ class SitePicker extends React.Component {
 		window.scrollTo( 0, 0 );
 	};
 
-	closePicker = () => {
+	closePicker = selectedSiteId => {
 		if ( this.props.currentLayoutFocus === 'sites' ) {
 			this.props.setLayoutFocus( 'sidebar' );
-			this.scrollToTop();
+			if ( selectedSiteId ) {
+				this.scrollToTop();
+			}
 		}
 	};
 
 	handleClickOutside = () => {
-		this.closePicker();
+		this.closePicker( null );
 	};
 
 	render() {


### PR DESCRIPTION
When opening the site picker then canceling the site switch, we should not scroll back to the top of the current section because this breaks the context of what the user is currently doing.

This is achieved in this PR by passing the selected site ID through to the necessary `onClose` and `closePicker` callbacks.  Note that selecting all sites is handled via a truthy value ([`ALL_SITES`](https://github.com/Automattic/wp-calypso/blob/6c3fe89670c5ed979f9055db6c476968ab3f244d/client/components/site-selector/index.jsx#L37)), so the same logic works.

### To test

Verify that selecting a site (or all sites) scrolls to the top of the current section, as before.  This is perhaps best tested in stats or in the `PostTypeList` with the Redux state already primed (after switching several times).

Verify that opening the site picker then closing it (via Escape or some other method) does not cause the current section to scroll to the top.

### Open questions

When re-selecting the same site as the current site from the site picker, the current section will still be scrolled to the top.  I think this is OK, but what do you think?  We could change this, but it would take a bit of extra logic (pass the current site ID as a connected prop, compare it to the selected site ID, and be sure to handle all-sites mode correctly).