### PR TITLE
Revert: Popover Menu Item: add ExternalLink support (#20023)

### DIFF
--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -10,11 +10,6 @@ import classnames from 'classnames';
 import { noop, omit } from 'lodash';
 import Gridicon from 'gridicons';
 
-/**
- * Internal dependencies
- */
-import ExternalLink from 'components/external-link';
-
 export default class PopoverMenuItem extends Component {
 	static propTypes = {
 		href: PropTypes.string,
@@ -23,7 +18,6 @@ export default class PopoverMenuItem extends Component {
 		icon: PropTypes.string,
 		focusOnHover: PropTypes.bool,
 		onMouseOver: PropTypes.func,
-		isExternalLink: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -32,7 +26,7 @@ export default class PopoverMenuItem extends Component {
 		onMouseOver: noop,
 	};
 
-	handleMouseOver = event => {
+	handleMouseOver = ( event ) => {
 		const { focusOnHover } = this.props;
 
 		if ( focusOnHover ) {
@@ -43,25 +37,19 @@ export default class PopoverMenuItem extends Component {
 	};
 
 	render() {
-		const { children, className, href, icon, isSelected, isExternalLink } = this.props;
-		const itemProps = omit( this.props, 'icon', 'focusOnHover', 'isSelected', 'isExternalLink' );
+		const { children, className, href, icon, isSelected } = this.props;
 		const classes = classnames( 'popover__menu-item', className, {
 			'is-selected': isSelected,
 		} );
-
-		let ItemComponent = href ? 'a' : 'button';
-		if ( isExternalLink && href ) {
-			ItemComponent = ExternalLink;
-			itemProps.icon = true;
-		}
+		const ItemComponent = href ? 'a' : 'button';
 
 		return (
 			<ItemComponent
 				role="menuitem"
 				onMouseOver={ this.handleMouseOver }
 				tabIndex="-1"
+				{ ...omit( this.props, 'icon', 'focusOnHover', 'isSelected' ) }
 				className={ classes }
-				{ ...itemProps }
 			>
 				{ icon && <Gridicon icon={ icon } size={ 18 } /> }
 				{ children }

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -200,6 +200,11 @@
 		border: 0;
 	}
 
+	// Menu Items with Icons
+	&.has-icon {
+		padding-left: 42px;
+	}
+
 	// with gridicons
 	.gridicon {
 		color: lighten( $gray, 10 );
@@ -209,9 +214,6 @@
 	.gridicons-cloud-download {
 		position: relative;
 		top: 2px;
-	}
-	.gridicons-external {
-		top: 0;
 	}
 	&.is-compact {
 		padding: 6px 12px;

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -56,7 +56,7 @@ class PostActionsEllipsisMenuView extends Component {
 	};
 
 	render() {
-		const { translate, status, previewUrl, isPreviewable } = this.props;
+		const { translate, status, previewUrl } = this.props;
 		if ( ! previewUrl ) {
 			return null;
 		}
@@ -68,7 +68,6 @@ class PostActionsEllipsisMenuView extends Component {
 				icon="visible"
 				target="_blank"
 				rel="noopener noreferrer"
-				isExternalLink={ ! isPreviewable }
 			>
 				{ includes( [ 'publish', 'private' ], status )
 					? translate( 'View', { context: 'verb' } )


### PR DESCRIPTION
Some changes to the `Popover` component in #20023 broken the Reader post options menu.

Before this revert:

<img width="342" alt="screen shot 2017-11-22 at 14 18 19" src="https://user-images.githubusercontent.com/17325/33132156-b05e3086-cf90-11e7-88a4-adc3b36b0d77.png">

After this revert:

<img width="309" alt="screen shot 2017-11-22 at 14 17 36" src="https://user-images.githubusercontent.com/17325/33132160-b3ad1874-cf90-11e7-91c6-39bd0a99ed95.png">

### To test

Try the post options menu on a Reader post card at http://calypso.localhost:3000.

Check out the component in Devdocs and verify that all looks well:

http://calypso.localhost:3000/devdocs/design/popover