### PR TITLE
Domains: Don't allow users to set transfer as primary domain

### DIFF
--- a/client/lib/domains/assembler.js
+++ b/client/lib/domains/assembler.js
@@ -23,6 +23,7 @@ function createDomainObjects( dataTransferObject ) {
 		return {
 			autoRenewalMoment: domain.auto_renewal_date && i18n.moment( domain.auto_renewal_date ),
 			currentUserCanManage: domain.current_user_can_manage,
+			canSetAsPrimary: domain.can_set_as_primary,
 			domainLockingAvailable: domain.domain_locking_available,
 			expirationMoment: domain.expiry && i18n.moment( domain.expiry ),
 			expired: domain.expired,

--- a/client/lib/domains/test/assembler.js
+++ b/client/lib/domains/test/assembler.js
@@ -36,6 +36,7 @@ describe( 'assembler', () => {
 		redirectDomainObject = {
 			autoRenewalMoment: undefined,
 			currentUserCanManage: undefined,
+			canSetAsPrimary: undefined,
 			domainLockingAvailable: undefined,
 			expirationMoment: undefined,
 			expired: undefined,

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -387,9 +387,7 @@ export class List extends React.Component {
 				<ListItem
 					key={ index + domain.name }
 					domain={ domain }
-					enableSelection={
-						this.state.changePrimaryDomainModeEnabled && domain.type !== type.TRANSFER
-					}
+					enableSelection={ this.state.changePrimaryDomainModeEnabled && domain.canSetAsPrimary }
 					isSelected={ index === this.state.primaryDomainIndex }
 					selectionIndex={ index }
 					busy={ this.state.settingPrimaryDomain && index === this.state.primaryDomainIndex }

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -387,7 +387,9 @@ export class List extends React.Component {
 				<ListItem
 					key={ index + domain.name }
 					domain={ domain }
-					enableSelection={ this.state.changePrimaryDomainModeEnabled }
+					enableSelection={
+						this.state.changePrimaryDomainModeEnabled && domain.type !== type.TRANSFER
+					}
 					isSelected={ index === this.state.primaryDomainIndex }
 					selectionIndex={ index }
 					busy={ this.state.settingPrimaryDomain && index === this.state.primaryDomainIndex }


### PR DESCRIPTION
Transfers aren't working and setting them would break the site.

Fixes: https://github.com/Automattic/wp-calypso/issues/19947