### PR TITLE
Popover Menu Item: add ExternalLink support (2nd try)

### DIFF
--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -44,7 +44,14 @@ export default class PopoverMenuItem extends Component {
 
 	render() {
 		const { children, className, href, icon, isSelected, isExternalLink } = this.props;
-		const itemProps = omit( this.props, 'icon', 'focusOnHover', 'isSelected', 'isExternalLink' );
+		const itemProps = omit(
+			this.props,
+			'icon',
+			'focusOnHover',
+			'isSelected',
+			'isExternalLink',
+			'className'
+		);
 		const classes = classnames( 'popover__menu-item', className, {
 			'is-selected': isSelected,
 		} );

--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -10,6 +10,11 @@ import classnames from 'classnames';
 import { noop, omit } from 'lodash';
 import Gridicon from 'gridicons';
 
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'components/external-link';
+
 export default class PopoverMenuItem extends Component {
 	static propTypes = {
 		href: PropTypes.string,
@@ -18,6 +23,7 @@ export default class PopoverMenuItem extends Component {
 		icon: PropTypes.string,
 		focusOnHover: PropTypes.bool,
 		onMouseOver: PropTypes.func,
+		isExternalLink: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -26,7 +32,7 @@ export default class PopoverMenuItem extends Component {
 		onMouseOver: noop,
 	};
 
-	handleMouseOver = ( event ) => {
+	handleMouseOver = event => {
 		const { focusOnHover } = this.props;
 
 		if ( focusOnHover ) {
@@ -37,19 +43,25 @@ export default class PopoverMenuItem extends Component {
 	};
 
 	render() {
-		const { children, className, href, icon, isSelected } = this.props;
+		const { children, className, href, icon, isSelected, isExternalLink } = this.props;
+		const itemProps = omit( this.props, 'icon', 'focusOnHover', 'isSelected', 'isExternalLink' );
 		const classes = classnames( 'popover__menu-item', className, {
 			'is-selected': isSelected,
 		} );
-		const ItemComponent = href ? 'a' : 'button';
+
+		let ItemComponent = href ? 'a' : 'button';
+		if ( isExternalLink && href ) {
+			ItemComponent = ExternalLink;
+			itemProps.icon = true;
+		}
 
 		return (
 			<ItemComponent
 				role="menuitem"
 				onMouseOver={ this.handleMouseOver }
 				tabIndex="-1"
-				{ ...omit( this.props, 'icon', 'focusOnHover', 'isSelected' ) }
 				className={ classes }
+				{ ...itemProps }
 			>
 				{ icon && <Gridicon icon={ icon } size={ 18 } /> }
 				{ children }

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -200,11 +200,6 @@
 		border: 0;
 	}
 
-	// Menu Items with Icons
-	&.has-icon {
-		padding-left: 42px;
-	}
-
 	// with gridicons
 	.gridicon {
 		color: lighten( $gray, 10 );
@@ -214,6 +209,9 @@
 	.gridicons-cloud-download {
 		position: relative;
 		top: 2px;
+	}
+	.gridicons-external {
+		top: 0;
 	}
 	&.is-compact {
 		padding: 6px 12px;

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -56,7 +56,7 @@ class PostActionsEllipsisMenuView extends Component {
 	};
 
 	render() {
-		const { translate, status, previewUrl } = this.props;
+		const { translate, status, previewUrl, isPreviewable } = this.props;
 		if ( ! previewUrl ) {
 			return null;
 		}
@@ -68,6 +68,7 @@ class PostActionsEllipsisMenuView extends Component {
 				icon="visible"
 				target="_blank"
 				rel="noopener noreferrer"
+				isExternalLink={ ! isPreviewable }
 			>
 				{ includes( [ 'publish', 'private' ], status )
 					? translate( 'View', { context: 'verb' } )


### PR DESCRIPTION
_The original PR (#20023) was reverted in #20104 after causing issues in the Reader._

This PR adds an optional `ExternalLink` prop for popover menu items. It also applies it to the "View" link in the `PostTypeList` ellipsis menu for sites that are not preview-able.

**Screenshot:**
<img width="260" alt="screencapture_at_mon_nov_13_14_18_05_est_2017" src="https://user-images.githubusercontent.com/942359/33051313-53e1b1ca-ce37-11e7-91fc-c98e39565357.png">

**To test:**
- Checkout branch or run from calypso.live link.
- Run `ENABLE_FEATURES=posts/post-type-list npm start`.
- Navigate to the `/posts/` screen for a preview-able site (Jetpack w/https or dotcom).
- Make sure that the "View" action in the ellipsis menu for a post _does not_ have the external link icon, and that clicking the link shows the web preview.
- Navigate to the `/posts/` screen for a site that isn't preview-able (Jetpack w/o https).
- Make sure that the "View" action in the ellipsis menu for a post has the external link icon, and that clicking the link opens the post in a new tab.
- **Navigate to the Reader and click the ellipsis menus for a site you follow - make sure that the green/blue follow icons are rendering correctly**