### PR TITLE
Jetpack black friday promotion banner

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -4,11 +4,12 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
+import { localize, moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import Banner from 'components/banner';
 import Main from 'components/main';
 import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
@@ -44,10 +45,34 @@ class JetpackPlansGrid extends Component {
 		return <FormattedHeader headerText={ headerText } subHeaderText={ subheaderText } />;
 	}
 
+	renderBlackFridayOffer() {
+		const { translate } = this.props;
+
+		const startDate = new Date( 'Nov 24 2017 00:00:00 GMT' );
+		const endDate = new Date( 'Nov 27 2017 23:59:59 GMT-8' );
+
+		if ( moment().isBetween( startDate, endDate ) ) {
+			return (
+				<Banner
+					callToAction={ translate( 'Get the coupon code' ) }
+					title={ '' }
+					description={ translate(
+						'Our Black Friday sale is going on now. Take up to 60% off all plans through November 27.'
+					) }
+					dismissTemporary={ true }
+					href={ 'https://jetpack.com/black-friday/' }
+					target={ '_blank' }
+				/>
+			);
+		}
+		return null;
+	}
+
 	render() {
 		return (
 			<Main wideLayout className="jetpack-connect__hide-plan-icons">
 				<div className="jetpack-connect__plans">
+					{ this.renderBlackFridayOffer() }
 					{ this.renderConnectHeader() }
 					<div id="plans">
 						<PlansFeaturesMain

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -4,7 +4,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -46,7 +46,7 @@ class JetpackPlansGrid extends Component {
 	}
 
 	renderBlackFridayOffer() {
-		const { translate } = this.props;
+		const { translate, moment } = this.props;
 
 		const startDate = new Date( 'Nov 24 2017 00:00:00 GMT' );
 		const endDate = new Date( 'Nov 27 2017 23:59:59 GMT-8' );

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -62,6 +62,7 @@ class JetpackPlansGrid extends Component {
 					dismissTemporary={ true }
 					href={ 'https://jetpack.com/black-friday/' }
 					target={ '_blank' }
+					event={ 'calypso_jpc_blackfriday_click' }
 				/>
 			);
 		}


### PR DESCRIPTION
This PR adds a banner informing the users of our black friday jetpack plans promotion. 

![image](https://user-images.githubusercontent.com/1554855/33137756-19374c88-cfa9-11e7-9146-55b605b61f18.png)

It just adds a banner on top of the JPC plans page, with a link to the jetpack.com promotion page.
All this code should just be removed on November 28. The promotion runs between UTC time Nov 24 00:00:00 and UTC-8 Nov 27 23:59:59.

How to test
=======

1. Change the date of your computer to any date between the valid dates
2. Connect a site up to the point you get to the plans page (or directly go to http://calypso.localhost:3000/jetpack/connect/plans/[already_connected_site_slug]
3. Make sure that you see the banner. Click on it and make sure it opens the promotion page in a new tab
4. Change the date of your computer to one after the end date
5. Test again. Make sure you don't see the banner anymore