### PR TITLE
Post Revisions: Use the same context for title as aria label

### DIFF
--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -28,6 +28,20 @@ class EditorRevisionsListItem extends PureComponent {
 		const authorName = get( revision, 'author.display_name' );
 		const added = get( revisionChanges, 'summary.added' );
 		const removed = get( revisionChanges, 'summary.removed' );
+		const titles = {
+			added:
+				added &&
+				translate( '%(changes)d word added', '%(changes)d words added', {
+					args: { changes: added },
+					count: added,
+				} ),
+			removed:
+				removed &&
+				translate( '%(changes)d word removed', '%(changes)d words removed', {
+					args: { changes: removed },
+					count: removed,
+				} ),
+		};
 
 		return (
 			<button
@@ -46,10 +60,8 @@ class EditorRevisionsListItem extends PureComponent {
 					{ added > 0 && (
 						<span
 							className="editor-revisions-list__additions"
-							aria-label={ translate( '%(changes)d word added', '%(changes)d words added', {
-								args: { changes: added },
-								count: added,
-							} ) }
+							aria-label={ titles.added }
+							title={ titles.added }
 						>
 							<b>+</b>
 							{ added }
@@ -59,10 +71,8 @@ class EditorRevisionsListItem extends PureComponent {
 					{ removed > 0 && (
 						<span
 							className="editor-revisions-list__deletions"
-							aria-label={ translate( '%(changes)d word removed', '%(changes)d words removed', {
-								args: { changes: removed },
-								count: removed,
-							} ) }
+							aria-label={ titles.removed }
+							title={ titles.removed }
 						>
 							<b>-</b>
 							{ removed }


### PR DESCRIPTION
There has been some discussion of reinstating the word "words" after the iconographic indication of the count of added and removed words.

This simply adds the contextual information we're already putting in the `aria-label` attribute & repeats it as a `title` -- so hovering over reveals that the #s pertain to words.

## Screencap
https://cloudup.com/cHQog3mxQCj