### PR TITLE
Reader: add Tracks events for conversation follow and mute

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -27,6 +27,7 @@ import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
 import ConversationFollowButton from 'blocks/conversation-follow-button';
 import { shouldShowConversationFollowButton } from 'blocks/conversation-follow-button/helper';
+import { COMMENT_LIST } from 'reader/follow-button/follow-sources';
 
 /**
  * PostCommentList, as the name would suggest, displays a list of comments for a post.
@@ -398,6 +399,8 @@ class PostCommentList extends React.Component {
 						className="comments__conversation-follow-button"
 						siteId={ siteId }
 						postId={ postId }
+						post={ this.props.post }
+						followSource={ COMMENT_LIST }
 					/>
 				) }
 				{ ( this.props.showCommentCount || showViewMoreComments ) && (

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -27,7 +27,6 @@ import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
 import ConversationFollowButton from 'blocks/conversation-follow-button';
 import { shouldShowConversationFollowButton } from 'blocks/conversation-follow-button/helper';
-import { COMMENT_LIST } from 'reader/follow-button/follow-sources';
 
 /**
  * PostCommentList, as the name would suggest, displays a list of comments for a post.
@@ -60,6 +59,7 @@ class PostCommentList extends React.Component {
 		showNestingReplyArrow: PropTypes.bool,
 		showConversationFollowButton: PropTypes.bool,
 		commentsFilter: PropTypes.string,
+		followSource: PropTypes.string,
 
 		// To display comments with a different status but not fetch them
 		// e.g. Reader full post view showing unapproved comments made to a moderated site
@@ -359,6 +359,7 @@ class PostCommentList extends React.Component {
 			commentsTree,
 			showFilters,
 			commentCount,
+			followSource,
 		} = this.props;
 		const {
 			haveEarlierCommentsToFetch,
@@ -400,7 +401,7 @@ class PostCommentList extends React.Component {
 						siteId={ siteId }
 						postId={ postId }
 						post={ this.props.post }
-						followSource={ COMMENT_LIST }
+						followSource={ followSource }
 					/>
 				) }
 				{ ( this.props.showCommentCount || showViewMoreComments ) && (

--- a/client/blocks/conversation-follow-button/index.jsx
+++ b/client/blocks/conversation-follow-button/index.jsx
@@ -16,6 +16,7 @@ import { connect } from 'react-redux';
 import ConversationFollowButton from './button';
 import { isFollowingReaderConversation } from 'state/selectors';
 import { followConversation, muteConversation } from 'state/reader/conversations/actions';
+import { recordTrackForPost } from 'reader/stats';
 
 class ConversationFollowButtonContainer extends Component {
 	static propTypes = {
@@ -23,6 +24,8 @@ class ConversationFollowButtonContainer extends Component {
 		postId: PropTypes.number.isRequired,
 		onFollowToggle: PropTypes.func,
 		tagName: PropTypes.oneOfType( [ PropTypes.string, PropTypes.func ] ),
+		post: PropTypes.object, // for stats only
+		followSource: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -30,11 +33,17 @@ class ConversationFollowButtonContainer extends Component {
 	};
 
 	handleFollowToggle = isRequestingFollow => {
-		const { siteId, postId } = this.props;
+		const { siteId, postId, post, followSource } = this.props;
 
 		if ( isRequestingFollow ) {
+			recordTrackForPost( 'calypso_reader_conversations_post_followed', post, {
+				follow_source: followSource,
+			} );
 			this.props.followConversation( { siteId, postId } );
 		} else {
+			recordTrackForPost( 'calypso_reader_conversations_post_muted', post, {
+				follow_source: followSource,
+			} );
 			this.props.muteConversation( { siteId, postId } );
 		}
 

--- a/client/blocks/conversation-follow-button/index.jsx
+++ b/client/blocks/conversation-follow-button/index.jsx
@@ -7,7 +7,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop } from 'lodash';
+import { assign, noop } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -16,7 +16,8 @@ import { connect } from 'react-redux';
 import ConversationFollowButton from './button';
 import { isFollowingReaderConversation } from 'state/selectors';
 import { followConversation, muteConversation } from 'state/reader/conversations/actions';
-import { recordTrackForPost } from 'reader/stats';
+import { getTracksPropertiesForPost } from 'reader/stats';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class ConversationFollowButtonContainer extends Component {
 	static propTypes = {
@@ -35,15 +36,18 @@ class ConversationFollowButtonContainer extends Component {
 	handleFollowToggle = isRequestingFollow => {
 		const { siteId, postId, post, followSource } = this.props;
 
+		const tracksProperties = assign( getTracksPropertiesForPost( post ), {
+			follow_source: followSource,
+		} );
+
 		if ( isRequestingFollow ) {
-			recordTrackForPost( 'calypso_reader_conversations_post_followed', post, {
-				follow_source: followSource,
-			} );
+			this.props.recordTracksEvent(
+				'calypso_reader_conversations_post_followed',
+				tracksProperties
+			);
 			this.props.followConversation( { siteId, postId } );
 		} else {
-			recordTrackForPost( 'calypso_reader_conversations_post_muted', post, {
-				follow_source: followSource,
-			} );
+			this.props.recordTracksEvent( 'calypso_reader_conversations_post_muted', tracksProperties );
 			this.props.muteConversation( { siteId, postId } );
 		}
 
@@ -72,5 +76,6 @@ export default connect(
 	{
 		followConversation,
 		muteConversation,
+		recordTracksEvent,
 	}
 )( ConversationFollowButtonContainer );

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -71,6 +71,7 @@ import { showSelectedPost } from 'reader/utils';
 import Emojify from 'components/emojify';
 import config from 'config';
 import { COMMENTS_FILTER_ALL } from 'blocks/comments/comments-filters';
+import { READER_FULL_POST } from 'reader/follow-button/follow-sources';
 
 export class FullPostView extends React.Component {
 	static propTypes = {
@@ -454,6 +455,7 @@ export class FullPostView extends React.Component {
 										maxDepth={ 1 }
 										commentsFilterDisplay={ COMMENTS_FILTER_ALL }
 										showConversationFollowButton={ true }
+										followSource={ READER_FULL_POST }
 									/>
 								) }
 							</div>

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -30,6 +30,7 @@ import { getReaderTeams } from 'state/selectors';
 import ReaderPostOptionsMenuBlogStickers from './blog-stickers';
 import ConversationFollowButton from 'blocks/conversation-follow-button';
 import { shouldShowConversationFollowButton } from 'blocks/conversation-follow-button/helper';
+import { READER_POST_OPTIONS_MENU } from 'reader/follow-button/follow-sources';
 
 class ReaderPostOptionsMenu extends React.Component {
 	static propTypes = {
@@ -174,6 +175,8 @@ class ReaderPostOptionsMenu extends React.Component {
 							tagName={ PopoverMenuItem }
 							siteId={ siteId }
 							postId={ postId }
+							post={ post }
+							followSource={ READER_POST_OPTIONS_MENU }
 						/>
 					) }
 

--- a/client/reader/follow-button/follow-sources.jsx
+++ b/client/reader/follow-button/follow-sources.jsx
@@ -1,6 +1,5 @@
 /** @format */
 /* Follow Source Constants */
-export const COMMENT_LIST = 'comment-list';
 export const IN_STREAM_RECOMMENDATION = 'in-stream-recommendation';
 export const EMPTY_SEARCH_RECOMMENDATIONS = 'empty-search-rec';
 export const SEARCH_RESULTS = 'search-results';
@@ -11,6 +10,7 @@ export const READER_FEED_SEARCH = 'reader-feed-search-result';
 export const READER_FOLLOWING_MANAGE_URL_INPUT = 'reader-following-manage-url-input';
 export const READER_FOLLOWING_MANAGE_SEARCH_RESULT = 'reader-following-manage-search-result';
 export const READER_FOLLOWING_MANAGE_RECOMMENDATION = 'reader-following-manage-recommendation';
+export const READER_FULL_POST = 'reader-full-post';
 export const READER_POST_OPTIONS_MENU = 'reader-post-options-menu';
 export const TAG_PAGE = 'reader-tag-page';
 export const DISCOVER_POST = 'reader-discover-post';

--- a/client/reader/follow-button/follow-sources.jsx
+++ b/client/reader/follow-button/follow-sources.jsx
@@ -1,5 +1,6 @@
 /** @format */
 /* Follow Source Constants */
+export const COMMENT_LIST = 'comment-list';
 export const IN_STREAM_RECOMMENDATION = 'in-stream-recommendation';
 export const EMPTY_SEARCH_RECOMMENDATIONS = 'empty-search-rec';
 export const SEARCH_RESULTS = 'search-results';
@@ -10,5 +11,6 @@ export const READER_FEED_SEARCH = 'reader-feed-search-result';
 export const READER_FOLLOWING_MANAGE_URL_INPUT = 'reader-following-manage-url-input';
 export const READER_FOLLOWING_MANAGE_SEARCH_RESULT = 'reader-following-manage-search-result';
 export const READER_FOLLOWING_MANAGE_RECOMMENDATION = 'reader-following-manage-recommendation';
+export const READER_POST_OPTIONS_MENU = 'reader-post-options-menu';
 export const TAG_PAGE = 'reader-tag-page';
 export const DISCOVER_POST = 'reader-discover-post';

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -166,20 +166,7 @@ export const recordTracksRailcarInteract = partial(
 );
 
 export function recordTrackForPost( eventName, post = {}, additionalProps = {}, options ) {
-	recordTrack(
-		eventName,
-		assign(
-			{
-				blog_id: ! post.is_external && post.site_ID > 0 ? post.site_ID : undefined,
-				post_id: ! post.is_external && post.ID > 0 ? post.ID : undefined,
-				feed_id: post.feed_ID > 0 ? post.feed_ID : undefined,
-				feed_item_id: post.feed_item_ID > 0 ? post.feed_item_ID : undefined,
-				is_jetpack: post.is_jetpack,
-			},
-			additionalProps
-		),
-		options
-	);
+	recordTrack( eventName, assign( getTracksPropertiesForPost( post ), additionalProps ), options );
 	if ( post.railcar && tracksRailcarEventWhitelist.has( eventName ) ) {
 		// check for overrides for the railcar
 		recordTracksRailcarInteract(
@@ -190,6 +177,16 @@ export function recordTrackForPost( eventName, post = {}, additionalProps = {}, 
 	} else if ( process.env.NODE_ENV !== 'production' && post.railcar ) {
 		console.warn( 'Consider whitelisting reader track', eventName ); //eslint-disable-line no-console
 	}
+}
+
+export function getTracksPropertiesForPost( post = {} ) {
+	return {
+		blog_id: ! post.is_external && post.site_ID > 0 ? post.site_ID : undefined,
+		post_id: ! post.is_external && post.ID > 0 ? post.ID : undefined,
+		feed_id: post.feed_ID > 0 ? post.feed_ID : undefined,
+		feed_item_id: post.feed_item_ID > 0 ? post.feed_item_ID : undefined,
+		is_jetpack: post.is_jetpack,
+	};
 }
 
 export function recordTrackWithRailcar( eventName, railcar, eventProperties ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/18598:

> Add the Tracks event calypso_reader_conversations_post_followed and calypso_reader_conversations_post_muted whenever a user follows/mutes a post. Followed posts appear in the Conversations Tool.

Todo: 
- [x] switch to use Redux analytics malarkey (like https://github.com/Automattic/wp-calypso/pull/16816)
- [x] switch comments follow source to READER_FULL_POST (pass as prop)

## To test

Enable analytics debugging in your console with:

```js
localStorage.setItem('debug', 'calypso:analytics*');
```

Ensure that the `calypso_reader_conversations_post_followed` and `calypso_reader_conversations_post_muted` events are fired when following or unfollowing a conversation respectively.

Test in both full post and in the post options menu. Make sure the `follow_source` key reflects where you followed the conversation from (`reader-full-post` or `reader-post-options-menu`).