### PR TITLE
Analytics: Add debugging to disallowed analytics

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -412,7 +412,7 @@ const analytics = {
 			}
 		},
 
-		recordPageView: makeSafeDebuggableGoogleAnalyticsFunc( function recordPageView(
+		recordPageView: makeGoogleAnalyticsTrackingFunction( function recordPageView(
 			urlPath,
 			pageTitle
 		) {
@@ -428,7 +428,7 @@ const analytics = {
 			} );
 		} ),
 
-		recordEvent: makeSafeDebuggableGoogleAnalyticsFunc( function recordEvent(
+		recordEvent: makeGoogleAnalyticsTrackingFunction( function recordEvent(
 			category,
 			action,
 			label,
@@ -449,7 +449,7 @@ const analytics = {
 			window.ga( 'send', 'event', category, action, label, value );
 		} ),
 
-		recordTiming: makeSafeDebuggableGoogleAnalyticsFunc( function recordTiming(
+		recordTiming: makeGoogleAnalyticsTrackingFunction( function recordTiming(
 			urlPath,
 			eventType,
 			duration,
@@ -519,7 +519,7 @@ const analytics = {
  * @param  {Function} func Google Analytics tracking function
  * @return {Function}      Wrapped function
  */
-function makeSafeDebuggableGoogleAnalyticsFunc( func ) {
+function makeGoogleAnalyticsTrackingFunction( func ) {
 	return function( ...args ) {
 		if ( ! isGoogleAnalyticsAllowed() ) {
 			gaDebug( '[Disallowed] analytics %s( %o )', func.name, args );

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -528,7 +528,7 @@ function makeGoogleAnalyticsTrackingFunction( func ) {
 
 		analytics.ga.initialize();
 
-		func.call( args );
+		func.apply( null, args );
 	};
 }
 

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -412,13 +412,10 @@ const analytics = {
 			}
 		},
 
-		recordPageView: function( urlPath, pageTitle ) {
-			if ( ! isGoogleAnalyticsAllowed() ) {
-				return;
-			}
-
-			analytics.ga.initialize();
-
+		recordPageView: makeSafeDebuggableGoogleAnalyticsFunc( function recordPageView(
+			urlPath,
+			pageTitle
+		) {
 			gaDebug( 'Recording Page View ~ [URL: ' + urlPath + '] [Title: ' + pageTitle + ']' );
 
 			// Set the current page so all GA events are attached to it.
@@ -429,15 +426,14 @@ const analytics = {
 				page: urlPath,
 				title: pageTitle,
 			} );
-		},
+		} ),
 
-		recordEvent: function( category, action, label, value ) {
-			if ( ! isGoogleAnalyticsAllowed() ) {
-				return;
-			}
-
-			analytics.ga.initialize();
-
+		recordEvent: makeSafeDebuggableGoogleAnalyticsFunc( function recordEvent(
+			category,
+			action,
+			label,
+			value
+		) {
 			let debugText = 'Recording Event ~ [Category: ' + category + '] [Action: ' + action + ']';
 
 			if ( 'undefined' !== typeof label ) {
@@ -451,19 +447,18 @@ const analytics = {
 			gaDebug( debugText );
 
 			window.ga( 'send', 'event', category, action, label, value );
-		},
+		} ),
 
-		recordTiming: function( urlPath, eventType, duration, triggerName ) {
-			if ( ! isGoogleAnalyticsAllowed() ) {
-				return;
-			}
-
-			analytics.ga.initialize();
-
+		recordTiming: makeSafeDebuggableGoogleAnalyticsFunc( function recordTiming(
+			urlPath,
+			eventType,
+			duration,
+			triggerName
+		) {
 			gaDebug( 'Recording Timing ~ [URL: ' + urlPath + '] [Duration: ' + duration + ']' );
 
 			window.ga( 'send', 'timing', urlPath, eventType, duration, triggerName );
-		},
+		} ),
 	},
 
 	// HotJar tracking
@@ -512,5 +507,30 @@ const analytics = {
 		window._tkq.push( [ 'clearIdentity' ] );
 	},
 };
+
+/**
+ * Wrap Google Analytics with debugging, possible analytics supression, and initialization
+ *
+ * This method will display debug output if Google Analytics is suppresed, otherwise it will
+ * initialize and call the Google Analytics function it is passed.
+ *
+ * @see isGoogleAnalyticsAllowed
+ *
+ * @param  {Function} func Google Analytics tracking function
+ * @return {Function}      Wrapped function
+ */
+function makeSafeDebuggableGoogleAnalyticsFunc( func ) {
+	return function( ...args ) {
+		if ( ! isGoogleAnalyticsAllowed() ) {
+			gaDebug( '[Disallowed] analytics %s( %o )', func.name, args );
+			return;
+		}
+
+		analytics.ga.initialize();
+
+		func.call( args );
+	};
+}
+
 emitter( analytics );
 export default analytics;

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -528,7 +528,7 @@ function makeGoogleAnalyticsTrackingFunction( func ) {
 
 		analytics.ga.initialize();
 
-		func.apply( null, args );
+		func( ...args );
 	};
 }
 

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -519,7 +519,7 @@ const analytics = {
  * @param  {Function} func Google Analytics tracking function
  * @return {Function}      Wrapped function
  */
-function makeGoogleAnalyticsTrackingFunction( func ) {
+export function makeGoogleAnalyticsTrackingFunction( func ) {
 	return function( ...args ) {
 		if ( ! isGoogleAnalyticsAllowed() ) {
 			gaDebug( '[Disallowed] analytics %s( %o )', func.name, args );

--- a/client/lib/analytics/test/google-analytics.js
+++ b/client/lib/analytics/test/google-analytics.js
@@ -1,0 +1,31 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+/**
+ * Internal dependencies
+ */
+import { makeGoogleAnalyticsTrackingFunction } from '../';
+
+jest.mock( 'config', () => key => {
+	const config = {
+		google_analytics_enabled: true,
+		google_analytics_key: 'foobar',
+	};
+	return config[ key ];
+} );
+jest.mock( 'lib/analytics/ad-tracking', () => ( {
+	retarget: () => {},
+} ) );
+jest.mock( 'lib/load-script', () => require( './mocks/lib/load-script' ) );
+
+describe( 'analytics.ga', () => {
+	describe( 'makeGoogleAnalyticsTrackingFunction', () => {
+		test( 'calls the wrapped function with passed arguments when enabled', () => {
+			const wrapped = jest.fn();
+			makeGoogleAnalyticsTrackingFunction( wrapped )( 'a', 'b', 'c' );
+
+			expect( wrapped ).toHaveBeenCalledWith( 'a', 'b', 'c' );
+		} );
+	} );
+} );


### PR DESCRIPTION
It's a real pain to test Google Analytics because it may be silently disabled in certain circumstances (config, donottrack, personally identifying information PII).

This PR wraps GA tracking functions to provide debug output when GA is disabled.
It also DRYs some shared logic.

Examples of difficult debugging: #20048 #19995

## Screens

### Disallowed (dev env, donottrack, etc.)

![disallowed](https://user-images.githubusercontent.com/841763/33150015-01a89580-cfd2-11e7-8604-9045894887f3.png)


### Allowed (no change)

![allowed](https://user-images.githubusercontent.com/841763/33149917-c2589042-cfd1-11e7-9ccf-00350f8064bd.png)


## Testing
1. `localStorage.debug = 'calypso:analytics:ga,calypso:analytics:utils'`.
1. Observe disallowed events (https://calypso.live/?branch=add/google-analytics-debug).
1. Run in allowed context, you'll need to test locally enabling via config (see patch below).
1. Observe allowed events (no change).

To enable on dev:

```patch
diff --git a/config/development.json b/config/development.json
index 07a63755dc..30a97d99cf 100644
--- a/config/development.json
+++ b/config/development.json
@@ -16,7 +16,7 @@
 	"boom_analytics_enabled": false,
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "development",
-	"google_analytics_enabled": false,
+	"google_analytics_enabled": true,
 	"google_analytics_key": "UA-10673494-15",
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
```