### PR TITLE
Store NUX: disable on prod

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -111,7 +111,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
-		"signup/atomic-store-flow": true,
+		"signup/atomic-store-flow": false,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,


### PR DESCRIPTION
@jhnstn identified an issue with Store NUX which might be causing problems for our customers to create and pay for a site.

We are disabling it on prod and going to fix.