### PR TITLE
Post Type List: Only allow bulk selection and editing in single site mode.

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -118,7 +118,7 @@ const PostTypeFilter = createReactClass( {
 	},
 
 	renderMultiSelectButton() {
-		if ( ! isEnabled( 'posts/post-type-list/bulk-edit' ) ) {
+		if ( ! isEnabled( 'posts/post-type-list/bulk-edit' ) || ! this.props.siteId ) {
 			return null;
 		}
 

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -62,7 +62,7 @@ class PostsMain extends React.Component {
 				<SidebarNavigation />
 				<div className="posts__primary">
 					<PostTypeFilter query={ query } siteId={ siteId } statusSlug={ statusSlug } />
-					<PostTypeBulkEditBar />
+					{ siteId && <PostTypeBulkEditBar /> }
 					<PostListWrapper { ...this.props } />
 				</div>
 			</Main>


### PR DESCRIPTION
This PR hides the ability to bulk select/edit posts from the "All My Sites" blog posts screen. The bulk select/edit functionality is only available behind the `posts/post-type-list/bulk-edit` feature flag.

**Bulk select/edit toggled 'on':**
<img width="1044" alt="screen shot 2017-11-22 at 2 17 11 pm" src="https://user-images.githubusercontent.com/942359/33145837-e9e654d8-cf8f-11e7-8df6-c83ed182fca5.png">

**To test:**
- Check out the branch and run `ENABLE_FEATURES=posts/post-type-list/bulk-edit npm start`.
- Navigate to the /posts/ screen for a single site
- Make sure that the "Select" toggle is available in the section nav, and that clicking it renders the `PostTypeBulkEditBar` and checkboxes beside the post titles.
- Navigate to /my/posts/ to view the posts for all of your sites
- Make sure that the "Select" toggle is not available in the section nav.