### PR TITLE
Store NUX: update flow name if flow changed

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -384,11 +384,6 @@ class Signup extends React.Component {
 		// redirect the user to the next step
 		scrollPromise.then( () => {
 			if ( ! this.isEveryStepSubmitted() ) {
-				if ( flowName !== this.props.flowName ) {
-					// if flow is being changed, tell SignupFlowController about the change and save
-					// a new value of `signupFlowName` to local storage.
-					this.signupFlowController.changeFlowName( flowName );
-				}
 				page( utils.getStepUrl( flowName, stepName, stepSectionName, this.props.locale ) );
 			} else if ( this.isEveryStepSubmitted() ) {
 				this.goToFirstInvalidStep();

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -201,7 +201,7 @@ class Signup extends React.Component {
 		this.recordStep();
 	}
 
-	componentWillReceiveProps( { signupDependencies, stepName } ) {
+	componentWillReceiveProps( { signupDependencies, stepName, flowName } ) {
 		const urlPath = location.href;
 		const query = url.parse( urlPath, true ).query;
 
@@ -215,6 +215,10 @@ class Signup extends React.Component {
 
 		if ( query.plans ) {
 			this.setState( { plans: true } );
+		}
+
+		if ( this.props.flowName !== flowName ) {
+			this.signupFlowController.changeFlowName( flowName );
 		}
 
 		this.checkForCartItems( signupDependencies );


### PR DESCRIPTION
In Store NUX, after selecting "store" as site type, we redirect to the `store-nux` signup flow. When navigating back using browser back button, the flow changes back to the original one. However, `SignupFlowController` retains the `store-nux` flow name instead of updating to the original flow name. That creates discrepancies between what the signup dependency store is expecting and what is provided.

In this PR, we update the signup flow controller's `flowName` when a different flow name is detected.

## Testing

Make sure to test all the possible variations of site types, going back and forward in the flow, reloading the page, etc.