### PR TITLE
Domains: Show "Free with your plans" for incoming transfer products

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -34,6 +34,7 @@ import {
 	isDomainProduct,
 	isDomainRedemption,
 	isDomainRegistration,
+	isDomainTransfer,
 	isFreeTrial,
 	isFreeWordPressComDomain,
 	isGoogleApps,
@@ -345,7 +346,7 @@ export function hasRenewalItem( cart ) {
  * @returns {boolean} true if there is at least one domain transfer item, false otherwise
  */
 export function hasTransferProduct( cart ) {
-	return some( getAll( cart ), isTransfer );
+	return some( getAll( cart ), isDomainTransfer );
 }
 
 /**
@@ -817,7 +818,7 @@ export function changePrivacyForDomains( cart, domainItems, changeFunction ) {
 	return flow.apply(
 		null,
 		domainItems.map( function( item ) {
-			if ( isTransfer( item ) ) {
+			if ( isDomainTransfer( item ) ) {
 				return changeFunction( domainTransferPrivacy( { domain: item.meta } ) );
 			}
 			return changeFunction( domainPrivacyProtection( { domain: item.meta } ) );
@@ -852,16 +853,6 @@ export function removePrivacyFromAllDomains( cart ) {
  */
 export function isRenewal( cartItem ) {
 	return cartItem.extra && cartItem.extra.purchaseType === 'renewal';
-}
-
-/**
- * Determines whether a cart item is a transfer
- *
- * @param {Object} cartItem - `CartItemValue` object
- * @returns {boolean} true if item is a renewal
- */
-export function isTransfer( cartItem ) {
-	return cartItem.product_slug === domainProductSlugs.TRANSFER_IN;
 }
 
 /**
@@ -989,7 +980,6 @@ export default {
 	guidedTransferItem,
 	isDomainBeingUsedForPlan,
 	isNextDomainFree,
-	isTransfer,
 	hasDomainCredit,
 	hasDomainInCart,
 	hasDomainMapping,

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -257,7 +257,7 @@ export function isDomainTransferPrivacy( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return product.product_slug === 'domain_transfer_privacy';
+	return product.product_slug === domainProductSlugs.TRANSFER_IN_PRIVACY;
 }
 
 export function isCredits( product ) {

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -210,11 +210,7 @@ export function isDomainProduct( product ) {
 	assertValidProduct( product );
 
 	return (
-		isDomainMapping( product ) ||
-		isDomainRegistration( product ) ||
-		isPrivacyProtection( product ) ||
-		isDomainTransfer( product ) ||
-		isDomainTransferPrivacy( product )
+		isDomainMapping( product ) || isDomainRegistration( product ) || isPrivacyProtection( product )
 	);
 }
 
@@ -244,6 +240,13 @@ export function isSiteRedirect( product ) {
 	assertValidProduct( product );
 
 	return product.product_slug === 'offsite_redirect';
+}
+
+export function isDomainTransferProduct( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return isDomainTransfer( product ) || isDomainTransferPrivacy( product );
 }
 
 export function isDomainTransfer( product ) {
@@ -402,6 +405,7 @@ export default {
 	isDomainRegistration,
 	isDomainTransfer,
 	isDomainTransferPrivacy,
+	isDomainTransferProduct,
 	isDotComPlan,
 	isEnterprise,
 	isFreeJetpackPlan,

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -27,7 +27,7 @@ import {
 	PLAN_CHARGEBACK,
 	PLAN_MONTHLY_PERIOD,
 } from 'lib/plans/constants';
-import { isTransfer } from 'lib/cart-values/cart-items';
+import { domainProductSlugs } from 'lib/domains/constants';
 
 import schema from './schema.json';
 
@@ -250,7 +250,7 @@ export function isDomainTransfer( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return isTransfer( product );
+	return product.product_slug === domainProductSlugs.TRANSFER_IN;
 }
 
 export function isDomainTransferPrivacy( product ) {

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -210,7 +210,11 @@ export function isDomainProduct( product ) {
 	assertValidProduct( product );
 
 	return (
-		isDomainMapping( product ) || isDomainRegistration( product ) || isPrivacyProtection( product )
+		isDomainMapping( product ) ||
+		isDomainRegistration( product ) ||
+		isPrivacyProtection( product ) ||
+		isDomainTransfer( product ) ||
+		isDomainTransferPrivacy( product )
 	);
 }
 
@@ -247,6 +251,13 @@ export function isDomainTransfer( product ) {
 	assertValidProduct( product );
 
 	return isTransfer( product );
+}
+
+export function isDomainTransferPrivacy( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return product.product_slug === 'domain_transfer_privacy';
 }
 
 export function isCredits( product ) {
@@ -390,6 +401,7 @@ export default {
 	isDomainRedemption,
 	isDomainRegistration,
 	isDomainTransfer,
+	isDomainTransferPrivacy,
 	isDotComPlan,
 	isEnterprise,
 	isFreeJetpackPlan,

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -15,6 +15,7 @@ import { canRemoveFromCart, cartItems } from 'lib/cart-values';
 import {
 	isCredits,
 	isDomainProduct,
+	isDomainTransferProduct,
 	isGoogleApps,
 	isTheme,
 	isMonthly,
@@ -50,7 +51,11 @@ export class CartItem extends React.Component {
 			return this.getFreeTrialPrice();
 		}
 
-		if ( cartItems.hasDomainCredit( cart ) && isDomainProduct( cartItem ) && cartItem.cost === 0 ) {
+		if (
+			cartItems.hasDomainCredit( cart ) &&
+			( isDomainProduct( cartItem ) || isDomainTransferProduct( cartItem ) ) &&
+			cartItem.cost === 0
+		) {
 			return this.getDomainPlanPrice( cartItem );
 		}
 

--- a/client/my-sites/checkout/checkout/privacy-protection.jsx
+++ b/client/my-sites/checkout/checkout/privacy-protection.jsx
@@ -38,9 +38,12 @@ class PrivacyProtection extends Component {
 
 	render() {
 		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart );
+		const domainTransfers = cartItems.getDomainTransfers( this.props.cart );
 		const { translate } = this.props;
 		const numberOfDomainRegistrations = domainRegistrations.length;
-		const hasOneFreePrivacy = this.hasDomainPartOfPlan() && numberOfDomainRegistrations === 1;
+		const hasOneFreePrivacy =
+			this.hasDomainPartOfPlan() &&
+			( numberOfDomainRegistrations === 1 || domainTransfers.length === 1 );
 
 		return (
 			<div>


### PR DESCRIPTION
Incoming transfers are also free with a plan, so this PR should display the "Free with your plan" notice next to the Domain Transfer and Domain Transfer Privacy products in the cart.

before:
<img width="273" alt="screen shot 2017-11-22 at 15 20 13" src="https://user-images.githubusercontent.com/1355045/33149340-14a1a8ba-cfd8-11e7-83fe-bd634ce86722.png">

after:
<img width="274" alt="screen shot 2017-11-22 at 22 54 31" src="https://user-images.githubusercontent.com/1355045/33149397-409f94ea-cfd8-11e7-9152-7f5aec513943.png">

Also I've fixed the Privacy Protection card on the checkout screen:
<img width="722" alt="screen shot 2017-11-22 at 22 55 00" src="https://user-images.githubusercontent.com/1355045/33149402-46e1b77a-cfd8-11e7-9d51-362c28134dde.png">


