### PR TITLE
Store NUX: re-enable on prod

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -111,7 +111,7 @@
 		"signup/domain-first-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,
-		"signup/atomic-store-flow": false,
+		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
 		"standalone-site-preview": true,


### PR DESCRIPTION
We had to disable Store NUX on prod (more info: #20123). We fixed the issue in #20127 and are re-enabling the new flow on prod.