### PR TITLE
Activity Log: remove notice pointing that Rewind is only available in Pressable sites

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -432,17 +432,7 @@ class ActivityLog extends Component {
 			return null;
 		}
 
-		const { isPressable, rewindStatusError, translate } = this.props;
-
-		// Do not match null
-		// FIXME: This is for internal testing
-		if ( false === isPressable ) {
-			return (
-				<ActivityLogBanner status="info" icon={ null }>
-					{ translate( 'Rewind is currently only available for Pressable sites' ) }
-				</ActivityLogBanner>
-			);
-		}
+		const { rewindStatusError, translate } = this.props;
 
 		if ( rewindStatusError ) {
 			return (


### PR DESCRIPTION
Removing this notice according to the convo at p1511387282000241-slack.

It's not necessary since non Pressable sites won't see the rewind buttons and menu items but they can see Activity Log.