### PR TITLE
Post Revisions: Disable the feature on mobile user agents

### DIFF
--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -7,7 +7,7 @@
 import url from 'url';
 import i18n from 'i18n-calypso';
 import moment from 'moment-timezone';
-import { includes } from 'lodash';
+import { includes, memoize } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,6 +21,17 @@ import { getFeaturedImageId } from './utils-ssr-ready';
 
 var utils = {
 	getFeaturedImageId,
+
+	/**
+	 * This is a stop-gap measure to prevent performance issues on mobile clients.
+	 * @TODO remove references to this function once:
+	 *   * diffing is fast on mobile devices
+	 *   * diffing is calculated on the server
+	 * ...whichever comes first :)
+	 */
+	deviceSupportsRevisions: memoize(
+		() => global.navigator && navigator.userAgent && ! navigator.userAgent.match( /mobile/i )
+	),
 
 	getEditURL: function( post, site ) {
 		let basePath = '';

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -151,7 +151,7 @@ export class EditPostStatus extends Component {
 						<Gridicon icon="undo" size={ 18 } /> { translate( 'Revert to draft' ) }
 					</Button>
 				) }
-				{ ! isEnabled( 'post-editor/revisions' ) && (
+				{ ! ( isEnabled( 'post-editor/revisions' ) && postUtils.deviceSupportsRevisions() ) && (
 					<EditorRevisionsLegacyLink
 						adminUrl={ adminUrl }
 						revisionsFromPostObj={ get( this.props, 'post.revisions' ) }

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -206,7 +206,10 @@ export class EditorGroundControl extends PureComponent {
 		const isSaveAvailable = this.isSaveAvailable();
 		const showingStatusLabel = this.shouldShowStatusLabel();
 		const showingSaveStatus = isSaveAvailable || showingStatusLabel;
-		const hasRevisions = isEnabled( 'post-editor/revisions' ) && get( post, 'revisions.length' );
+		const hasRevisions =
+			isEnabled( 'post-editor/revisions' ) &&
+			postUtils.deviceSupportsRevisions() &&
+			get( post, 'revisions.length' );
 
 		if ( ! ( showingSaveStatus || hasRevisions ) ) {
 			return;


### PR DESCRIPTION
Until we can figure out a way to make the revisions feature [more performant on mobile devices](https://github.com/Automattic/wp-calypso/pull/20076#issuecomment-346483500), this change will naively revert back to the previous behavior (a link to wp-admin in the `Post Settings | Status` sidebar) whenever a user agent with `mobile` in it is presented.

I'll grant this is suboptimal, but this will enable us to get the feature in front of more users for general feedback while we work around the resource constraints on mobile devices.

## To Test

* Run this branch
* In a desktop browser, open a post in the editor that has revisions (i.e. one you see the `History` button on in the stage env)
  * You should see the `History` button & no `# revisions` link in the sidebar
* Open the dev tools (following instructions are Chrome-specific)
* Enable the "Device toolbar" & choose any standard device
* Reload the Editor
  * You should **not** see the History button & **should** see the `# revisions` link in the sidebar