### PR TITLE
Jetpack Connect: Hide Plan icons for all devices

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -4,6 +4,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,7 +13,7 @@ import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
-
+import { abtest } from 'lib/abtest';
 /**
  * Constants
  */
@@ -45,8 +46,13 @@ class JetpackPlansGrid extends Component {
 	}
 
 	render() {
+		const hiddenForAll = abtest( 'jetpackHidePlanIconsForAllDevices' ) === 'hide';
+		const mainClassName = classNames( 'jetpack-connect__hide-plan-icons', {
+			'jetpack-connect__hide-plan-icons-large': hiddenForAll,
+		} );
+
 		return (
-			<Main wideLayout className="jetpack-connect__hide-plan-icons">
+			<Main wideLayout className={ mainClassName }>
 				<div className="jetpack-connect__plans">
 					{ this.renderConnectHeader() }
 					<div id="plans">

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -554,6 +554,7 @@
 	}
 }
 
+// TODO: clean-up after the test #20134 is finished
 @media ( min-height: 921px ) {
 	.jetpack-connect__hide-plan-icons-large {
 		.jetpack-connect__plans-nav-buttons {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -553,3 +553,25 @@
 		}
 	}
 }
+
+@media ( min-height: 921px ) {
+	.jetpack-connect__hide-plan-icons-large {
+		.jetpack-connect__plans-nav-buttons {
+			margin-bottom: 0;
+		}
+
+		.jetpack-connect__plans {
+			.plans-wrapper {
+				padding-bottom: 0;
+			}
+
+			.plan-features__graphic {
+				display: none;
+			}
+
+			.plan-features__pricing {
+				padding-top: 16px;
+			}
+		}
+	}
+}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -71,6 +71,15 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
+	jetpackHidePlanIconsForAllDevices: {
+		datestamp: '20171122',
+		variations: {
+			show: 50,
+			hide: 50,
+		},
+		defaultVariation: 'show',
+		allowExistingUsers: true,
+	},
 	skipThemesSelectionModal: {
 		datestamp: '20170904',
 		variations: {


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/19335

This patch sets up an A/B test of the Plan icons presence/absence for larger devices.
For device with height < 920px the icons are hidden based on the results of the previous test.

**To test:**

Checkout this branch:
- for device with height > 920px verify that the Plan icons are not visible at `/jetpack/connect/store` nor the `/jetpack/connect/` ( -> screenshots  ). 

To switch between test categories, please use `localStorage.setItem('ABTests','{"jetpackHidePlanIconsForAllDevices_20171122":"show"}')`, where `show` keeps the icons visible and `hide` excludes them from view.

visuals for hide/show scenarios: 

`/jetpack/connect/store`
![screen shot 2017-11-23 at 10 37 18](https://user-images.githubusercontent.com/13561163/33166368-4a7651b8-d03a-11e7-812e-dfd5df31dca1.png)
![screen shot 2017-11-23 at 10 37 32](https://user-images.githubusercontent.com/13561163/33166370-4aaeaf4a-d03a-11e7-8648-b0f16d19cb0b.png)

`/jetpack/connect`
![screen shot 2017-11-23 at 10 37 01](https://user-images.githubusercontent.com/13561163/33166397-5c681212-d03a-11e7-9bb5-e93c1276b15a.png)
![screen shot 2017-11-23 at 10 36 46](https://user-images.githubusercontent.com/13561163/33166396-5c472c46-d03a-11e7-8901-4a75cce2d302.png)

