### PR TITLE
Domains: Fix react warning in fr-form

### DIFF
--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -156,12 +156,12 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 					? this.props.children
 					: map(
 							castArray( this.props.children ),
-							child =>
-								child.props.className.match( /submit-button/ )
-									? React.cloneElement( child, {
-											disabled: true,
-										} )
-									: child
+							( child, index ) =>
+									React.cloneElement( child, {
+										disabled: child.props.className.match( /submit-button/ ) ||
+											child.props.disabled,
+										key: index,
+									} )
 						) }
 			</form>
 		);


### PR DESCRIPTION
This PR fixes a react warning issued when the validation fails on the fr-form by adding a key to the cloned children:
![checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/33155625-c946ed38-d03d-11e7-8510-d41dea9bc67d.jpg)

Testing Instructions:
1) Add a .fr domain and fill out the main form to get to the fr-form.
2) Edit one of the fields to be invalid (e.g. make the SIREN/SIRET longer or shorter)
3) Check for the warning in the console.

As we're touching it, we should also double-checking that the `Continue to Checkout` button is enabled/disabled correctly and still works.
![checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/33155848-ceeec272-d03f-11e7-8ef2-17564f629d89.jpg)

Aside: Those low-priority warnings come from [i18n-calypso](https://github.com/Automattic/i18n-calypso/blob/master/lib/localize/index.js#L20) where we're doing it deliberately so that that module does not require transpilation https://github.com/Automattic/i18n-calypso/pull/44, and a [notifications-panel template](https://github.com/Automattic/notifications-panel/blob/412906109b002271ee4c882f4a0d67bff032abdc/src/templates/gridicons.jsx#L10) (where I'm guessing we haven't fixed it because it's working perfectly well).