### PR TITLE
Make sure credentials form and respective network calls only happen if Rewind is active

### DIFF
--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -20,13 +20,15 @@ import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import FormSecurity from 'my-sites/site-settings/form-security';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import { isRewindActive } from 'state/selectors';
 import JetpackDevModeNotice from 'my-sites/site-settings/jetpack-dev-mode-notice';
 import JetpackMonitor from 'my-sites/site-settings/form-jetpack-monitor';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import Placeholder from 'my-sites/site-settings/placeholder';
 import Backups from 'my-sites/site-settings/jetpack-credentials';
+import QueryRewindStatus from 'components/data/query-rewind-status';
 
-const SiteSettingsSecurity = ( { site, siteId, siteIsJetpack, translate } ) => {
+const SiteSettingsSecurity = ( { rewindActive, site, siteId, siteIsJetpack, translate } ) => {
 	if ( ! site ) {
 		return <Placeholder />;
 	}
@@ -62,11 +64,12 @@ const SiteSettingsSecurity = ( { site, siteId, siteIsJetpack, translate } ) => {
 
 	return (
 		<Main className="settings-security__main site-settings">
+			<QueryRewindStatus siteId={ siteId } />
 			<DocumentHead title={ translate( 'Site Settings' ) } />
 			<JetpackDevModeNotice />
 			<SidebarNavigation />
 			<SiteSettingsNavigation site={ site } section="security" />
-			{ config.isEnabled( 'jetpack/credentials' ) && <Backups /> }
+			{ config.isEnabled( 'jetpack/credentials' ) && rewindActive && <Backups /> }
 			<JetpackMonitor />
 			<FormSecurity />
 		</Main>
@@ -74,6 +77,7 @@ const SiteSettingsSecurity = ( { site, siteId, siteIsJetpack, translate } ) => {
 };
 
 SiteSettingsSecurity.propTypes = {
+	rewindActive: PropTypes.bool,
 	site: PropTypes.object,
 	siteId: PropTypes.number,
 	siteIsJetpack: PropTypes.bool,
@@ -82,7 +86,9 @@ SiteSettingsSecurity.propTypes = {
 export default connect( state => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
+
 	return {
+		rewindActive: isRewindActive( state, siteId ),
 		site,
 		siteId,
 		siteIsJetpack: isJetpackSite( state, siteId ),

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -64,7 +64,9 @@ const SiteSettingsSecurity = ( { rewindActive, site, siteId, siteIsJetpack, tran
 
 	return (
 		<Main className="settings-security__main site-settings">
-			<QueryRewindStatus siteId={ siteId } />
+			{ config.isEnabled( 'jetpack/activity-log/rewind' ) && (
+				<QueryRewindStatus siteId={ siteId } />
+			) }
 			<DocumentHead title={ translate( 'Site Settings' ) } />
 			<JetpackDevModeNotice />
 			<SidebarNavigation />


### PR DESCRIPTION
Currently, the credentials form will show for all Jetpack sites. This is incorrect behavior for a number of reasons, but currently it's important that only Pressable users see the form. In order to rectify this, while also making the form available for testing on non-Pressable sites, we should wall off the form and associated network requests for credentials to only sites where `isRewindActive` is true.

**Testing instructions:**
- Make sure the form at Settings > Security is visible for a Pressable site.
- Make sure the form at Settings > Security is visible for a non-Pressable site that has Rewind active.
- Make sure the form is hidden and no network requests are made to `/get-credentials` on a site without Rewind active.