### PR TITLE
Run lodash codemods to cleanup modular imports

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -6,13 +6,12 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { map, forEach, head, includes, keys } from 'lodash';
+import { find, forEach, head, includes, keys, map } from 'lodash';
 import debugModule from 'debug';
 import classNames from 'classnames';
 import i18n, { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { find } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -5,11 +5,10 @@
  */
 
 import debugFactory from 'debug';
-import { assign, defer, isEmpty, isNull, omitBy, pick, startsWith } from 'lodash';
+import { assign, defer, get, isEmpty, isNull, omitBy, pick, startsWith } from 'lodash';
 import async from 'async';
 import { parse as parseURL } from 'url';
 import page from 'page';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -5,8 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import some from 'lodash/some';
-import noop from 'lodash/noop';
+import { noop, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 

--- a/client/my-sites/domains/components/domain-form-fieldsets/eu-address-fieldset.jsx
+++ b/client/my-sites/domains/components/domain-form-fieldsets/eu-address-fieldset.jsx
@@ -5,8 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import identity from 'lodash/identity';
-import noop from 'lodash/noop';
+import { identity, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/domains/components/domain-form-fieldsets/g-apps-fieldset.jsx
+++ b/client/my-sites/domains/components/domain-form-fieldsets/g-apps-fieldset.jsx
@@ -5,8 +5,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import identity from 'lodash/identity';
-import noop from 'lodash/noop';
+import { identity, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/domains/components/domain-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/my-sites/domains/components/domain-form-fieldsets/region-address-fieldsets.jsx
@@ -6,9 +6,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import identity from 'lodash/identity';
-import noop from 'lodash/noop';
-import includes from 'lodash/includes';
+import { identity, includes, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/domains/components/domain-form-fieldsets/uk-address-fieldset.jsx
+++ b/client/my-sites/domains/components/domain-form-fieldsets/uk-address-fieldset.jsx
@@ -5,8 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import identity from 'lodash/identity';
-import noop from 'lodash/noop';
+import { identity, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/domains/components/domain-form-fieldsets/us-address-fieldset.jsx
+++ b/client/my-sites/domains/components/domain-form-fieldsets/us-address-fieldset.jsx
@@ -5,8 +5,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import identity from 'lodash/identity';
-import noop from 'lodash/noop';
+import { identity, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/domains/components/form/hidden-input.jsx
+++ b/client/my-sites/domains/components/form/hidden-input.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
-import isEmpty from 'lodash/isEmpty';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Just normal maintenance

Note to those whose code this changes: we are no longer importing the modular lodash functions.

There should be no functional or visual changes here.

**Testing**

Just smoke test the affected files. This should be quite safe of a change.