### PR TITLE
Request the checklist for the new site on props change.

### DIFF
--- a/client/components/data/query-site-checklist/index.js
+++ b/client/components/data/query-site-checklist/index.js
@@ -20,7 +20,7 @@ class QuerySiteChecklist extends Component {
 	};
 
 	componentWillMount() {
-		this.request();
+		this.request( this.props.siteId );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -28,11 +28,13 @@ class QuerySiteChecklist extends Component {
 			return;
 		}
 
-		this.request();
+		this.request( nextProps.siteId );
 	}
 
-	request() {
-		this.props.requestSiteChecklist( this.props.siteId );
+	request( siteId ) {
+		if ( siteId ) {
+			this.props.requestSiteChecklist( siteId );
+		}
 	}
 
 	render() {


### PR DESCRIPTION
This fixes a bug when switching between sites while viewing the `checklist/<domain>` route.

The problem was the when changing props, a request would be issued for the previous and not the new site 😒 

# Testing

For a user with multiple sites:

* visit `/checklist/<domain>` for one site
* switch to another site
* you should see the network request for the checklist tasks for the new site