### PR TITLE
[WIP] Try ajv instead of is-my-json-valid for JSON Schema validation

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1378,11 +1378,11 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-### https://github.com/mafintosh/is-my-json-valid
+### https://github.com/epoberezkin/ajv
 ```
 The MIT License (MIT)
 
-Copyright (c) 2014 Mathias Buus
+Copyright (c) 2015 Evgeny Poberezkin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1391,16 +1391,16 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ### https://github.com/d3/d3

--- a/client/components/domains/registrant-extra-info/fr-schema.json
+++ b/client/components/domains/registrant-extra-info/fr-schema.json
@@ -24,7 +24,8 @@
 						}
 					},
 					"organization": { "$ref": "#/definitions/empty" }
-				}
+				},
+				"formField": "organization"
 			}
 		}
 	},

--- a/client/components/domains/registrant-extra-info/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/fr-validate-contact-details.js
@@ -4,87 +4,45 @@
  * External dependencies
  */
 
-import { isEmpty, isString, reduce, update } from 'lodash';
-import validatorFactory from 'is-my-json-valid';
+import { reduce, update } from 'lodash';
+import Ajv from 'ajv';
 import debugFactory from 'debug';
+import draft04 from 'ajv/lib/refs/json-schema-draft-04.json';
 
 /**
  * Internal dependencies
  */
 import validationSchema from './fr-schema';
 
-const validate = validatorFactory( validationSchema, { greedy: true } );
 const debug = debugFactory( 'calypso:components:domains:registrant-extra-info:validation' );
 
-// is-my-json-valid uses customized messages, but the actual rule name seems
-// more intuitive
-// See http://json-schema.org/latest/json-schema-validation.html#rfc.section.6
-// Notes:
-// - Looks like is-my-json-valid does not handle contains
-// - `items` doesn't get it's own message, it just adds an index to the path
-//   e.g. If you validate `{ even: [ 0, 1, 2, 3 ] }`` using the schema
-//   `{ properties: { even: { items: { multipleOf: 2 } } } }` you get errors
-//   with field 'data.even.1' and `data.even.2`.
-// - patternProperties is similar to items, but less readable.
-const reverseMessageMap = {
-	'is required': 'required',
-	'is the wrong type': 'type',
-	'has additional items': 'additionalItems',
-	'must be unique': 'uniqueItems',
-	'must be an enum value': 'enum',
-	'dependencies not set': 'dependencies',
-	'has additional properties': 'additionalProperties',
-	'referenced schema does not match': '$ref',
-	'negative schema matches': 'not',
-	'pattern mismatch': 'pattern',
-	'no schemas match': 'anyOf',
-	'no (or more than one) schemas match': 'oneOf',
-	'has a remainder': 'multipleOf',
-	'has more properties than allowed': 'maxProperties',
-	'has less properties than allowed': 'minProperties',
-	'has more items than allowed': 'maxItems',
-	'has less items than allowed': 'minItems',
-	'has longer length than allowed': 'maxLength',
-	'has less length than allowed': 'minLength',
-	'is less than minimum': 'minimum', // also might be exclusiveMaximum
-	'is more than maximum': 'maximum', // also might be exclusiveMinimum
-};
+const ajv = new Ajv( { messages: false } );
+ajv.addMetaSchema( draft04 );
+const validate = ajv.compile( validationSchema );
 
-function ruleNameFromMessage( message ) {
-	return (
-		reverseMessageMap[ message ] ||
-		( isString( message ) && message.match( /^must be (.*) format$/ ) && 'format' ) ||
-		message
-	);
-}
+const schemaPathFilterRegex = /anyOf\/\d+/;
 
 /*
  * @returns errors by field, like: { 'extra.field: name, errors: [ string ] }
  */
 export default function validateContactDetails( contactDetails ) {
 	// Populate validate.errors
-	validate( contactDetails );
-	validate.errors && debug( validate.errors );
+	const valid = validate( contactDetails );
+	valid && debug( validate.errors );
 
 	return reduce(
 		validate.errors,
-		( accumulatedErrors, { field, message } ) => {
-			// Drop 'data.' prefix
-			const path = String( field )
-				.split( '.' )
-				.slice( 1 );
+		( accumulatedErrors, { dataPath, keyword, schemaPath } ) => {
+			// Drop '.' prefix
+			const path = dataPath.slice( 1 );
 
-			// In order to capture the relationship between the organization
-			// and extra.individualType fields, the rule ends up in the root
-			// path.
-			// We've only got one such case at the moment, so we can insert this
-			// hack, but if we need to tell multiple such rules apart, we're
-			// going to need to add a some magic to map schemas to fields
-			const correctedPath = isEmpty( path ) ? [ 'organization' ] : path;
+			if ( schemaPathFilterRegex.test( schemaPath ) ) {
+				return accumulatedErrors;
+			}
 
-			const appendThisMessage = before => [ ...( before || [] ), ruleNameFromMessage( message ) ];
+			const appendThisMessage = before => [ ...( before || [] ), keyword ];
 
-			return update( accumulatedErrors, correctedPath, appendThisMessage );
+			return update( accumulatedErrors, path, appendThisMessage );
 		},
 		{}
 	);

--- a/client/components/domains/registrant-extra-info/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/fr-validate-contact-details.js
@@ -16,7 +16,7 @@ import validationSchema from './fr-schema';
 
 const debug = debugFactory( 'calypso:components:domains:registrant-extra-info:validation' );
 
-const ajv = new Ajv( { messages: false, extendRefs: true, verbose: true } );
+const ajv = new Ajv( { messages: false, extendRefs: true, verbose: true, allErrors: true } );
 ajv.addMetaSchema( draft04 );
 const validate = ajv.compile( validationSchema );
 

--- a/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
@@ -246,8 +246,7 @@ describe( 'validateContactDetails', () => {
 
 		test( 'should reject SIRET for VAT', () => {
 			realSiretNumbers.forEach( ( [ registrantVatId ] ) => {
-				const testDetails = Object.assign( {}, contactDetails, { extra: { registrantVatId } } );
-
+				const testDetails = contactWithExtraProperty( 'registrantVatId', registrantVatId );
 				const result = validateContactDetails( testDetails );
 				expect( result, `expected to reject '${ registrantVatId }'` )
 					.to.have.property( 'extra' )
@@ -288,7 +287,7 @@ describe( 'validateContactDetails', () => {
 
 		test( 'should reject our bad SIRET examples', () => {
 			badTrademarkNumbers.forEach( ( [ trademarkNumber ] ) => {
-				const testDetails = Object.assign( {}, contactDetails, { extra: { trademarkNumber } } );
+				const testDetails = contactWithExtraProperty( 'trademarkNumber', trademarkNumber );
 
 				const result = validateContactDetails( testDetails );
 				expect( result, `expected to reject '${ trademarkNumber }'` )

--- a/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
@@ -114,6 +114,16 @@ describe( 'validateContactDetails', () => {
 				const result = validateContactDetails( testDetails );
 				expect( result ).to.have.property( 'organization' );
 			} );
+
+			test( 'should report multiple problems', () => {
+				const testDetails = Object.assign( {}, organizationDetails, {
+					organization: 'No' + repeat( '!!!!!!!!!', 11 ),
+				} );
+
+				const result = validateContactDetails( testDetails );
+				expect( result ).to.have.property( 'organization' )
+					.with.members( [ 'not', 'maxLength' ] );
+			} );
 		} );
 
 		describe( 'with registrantType: individual', () => {

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/modal-errors.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/modal-errors.js
@@ -5,9 +5,12 @@
  */
 
 import { memoize, omitBy, reduce, some, trim } from 'lodash';
-import validator from 'is-my-json-valid';
+import Ajv from 'ajv';
+import draft04 from 'ajv/lib/refs/json-schema-draft-04.json';
+const ajv = new Ajv( { messages: false, extendRefs: true, verbose: true, allErrors: true } );
+ajv.addMetaSchema( draft04 );
 
-const memoizedValidator = memoize( schema => validator( schema, { greedy: true } ) );
+const memoizedValidator = memoize( schema => ajv.compile( schema ) );
 
 const processErrors = errors => {
 	return reduce(

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -6,7 +6,10 @@
  * External dependencies
  */
 import { concat, filter, find, map, get, sortBy, takeRight } from 'lodash';
-import validator from 'is-my-json-valid';
+import Ajv from 'ajv';
+import draft04 from 'ajv/lib/refs/json-schema-draft-04.json';
+const validator = new Ajv();
+validator.addMetaSchema( draft04 );
 
 /**
  * Internal dependencies
@@ -91,7 +94,7 @@ const timelineEvent = ( state = {}, action ) => {
 	return state;
 };
 
-const validateTimeline = validator( timelineSchema );
+const validateTimeline = validator.compile( timelineSchema );
 const sortTimeline = timeline => sortBy( timeline, event => parseInt( event.timestamp, 10 ) );
 
 /**

--- a/client/state/reader/feeds/test/schema.js
+++ b/client/state/reader/feeds/test/schema.js
@@ -3,7 +3,14 @@
  * External dependencies
  */
 import { assert } from 'chai';
-import validate from 'is-my-json-valid';
+import Ajv from 'ajv';
+import draft04 from 'ajv/lib/refs/json-schema-draft-04.json';
+// validateSchema: false because of these errors:
+// data.patternProperties['^[0-9a-z]+$'].properties['image'].type should be equal to one of the allowed values
+// data.patternProperties['^[0-9a-z]+$'].properties['image'].type[1] should be equal to one of the allowed values
+// data.patternProperties['^[0-9a-z]+$'].properties['image'].type should match some schema in anyOf
+const ajv = new Ajv( { validateSchema: false } );
+ajv.addMetaSchema( draft04 );
 
 /**
  * Internal dependencies
@@ -13,7 +20,7 @@ import { itemsSchema } from '../schema';
 describe( 'schema', () => {
 	let validator;
 	beforeEach( () => {
-		validator = validate( itemsSchema );
+		validator = ajv.compile( itemsSchema );
 	} );
 
 	test( 'should validate the basic object', () => {

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -4,7 +4,9 @@
  * External dependencies
  */
 
-import validator from 'is-my-json-valid';
+import Ajv from 'ajv';
+import draft04 from 'ajv/lib/refs/json-schema-draft-04.json';
+
 import {
 	flow,
 	get,
@@ -19,15 +21,18 @@ import {
 } from 'lodash';
 import { combineReducers as combine } from 'redux'; // eslint-disable-line wpcalypso/import-no-redux-combine-reducers
 import LRU from 'lru-cache';
-
 /**
  * Internal dependencies
  */
 import { DESERIALIZE, SERIALIZE } from './action-types';
 import warn from 'lib/warn';
 
+const ajv = new Ajv( { verbose: true, validateSchema: false } );
+ajv.addMetaSchema( draft04 );
+
 export function isValidStateWithSchema( state, schema ) {
-	const validate = validator( schema );
+	// I wonder if the Ajv instance caches the schemas
+	const validate = ajv.compile( schema );
 	const valid = validate( state );
 	if ( ! valid ) {
 		warn( 'state validation failed for state:', state, 'with reason:', validate.errors );

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "> 1%"
   ],
   "dependencies": {
+    "ajv": "5.4.0",
     "assets-webpack-plugin": "3.5.1",
     "async": "0.9.0",
     "autoprefixer": "6.3.5",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "immutable": "3.7.6",
     "imports-loader": "0.6.5",
     "inherits": "2.0.1",
-    "is-my-json-valid": "2.13.1",
     "jquery": "1.11.3",
     "json-loader": "0.5.4",
     "json-stable-stringify": "1.0.1",


### PR DESCRIPTION
#### What's wrong with `is-my-json-valid`?

`is-my-json-valid` is excellent in terms of pass/fail, but it's pretty terse with it's results. In particular, it would be super nice if we could reliably get back to the rule that failed, because that way we could add any meta-data we might need.

I ran into this adding a rule to the `.fr` domain contact validation schema that says "if the `registrantType` is `organization`, then the `organization` field cannot be empty". That's no problem to validate with JSON schema, but we need to associate a failed result with the right field on the form.

Up until now, all the validation I've done has been simple enough to fit into a `properties` that matches the data itself so it's been easy enough to put messages in the right place (I did have to rearrange rules a couple of times to disambiguate them, but nothing worth ripping out the library yet).

However, once a rule involves more than one property it's intrinsically ambiguous which field is the wrong one (maybe both). In the `.fr` `organization` case, I had to add logic in the validation result handling that says roughly "if it doesn't have a field, associate it with the `organization` field". That works, but only once, and it's an ugly hack.

What I want to be able to do is specify in the rule itself which field it belongs to. If we can get back to the rule from the failure, this is as simple as adding another property to the rule itself, like `field: organization`, and taking that to mean "If this fails, show the error next to the `organization` field". ( We're already using this approach on the back end to facilitate i18n r165250-wpcom ).

The awesome thing is that we can use that same trick for any extra data we turn out to need. We could add the user visible error message to the rule, or we could add a severity. We could even decide that we'd like a sort of inheritance for some properties, and search up the schema's tree for them.

But we can't do that with `is-my-json-valid`, because it doesn't tell us clearly where the problem occurred. There are several related issues (https://github.com/mafintosh/is-my-json-valid/issues/38, https://github.com/mafintosh/is-my-json-valid/issues/39, https://github.com/mafintosh/is-my-json-valid/issues/22).

I've put together a runnable example of the problem:
```js
import Ajv from 'ajv';
import draft04 from 'ajv/lib/refs/json-schema-draft-04.json';
const ajv = new Ajv();
ajv.addMetaSchema( draft04 );

import IMJV from 'is-my-json-valid';

const ravenSchema =
	{ "not": {
			"properties": {
				"animal": { "enum": [ "raven" ] },
				"color": {
					"not": {
						"enum": [ "black" ] } } } } };
const doveSchema =
	{	"whatever we want": "here it is",
		"not": {
			"properties": {
				"animal": { "enum": [ "dove" ] },
				"color": {
					"not": {
						"enum": [ "white" ] } } } } };

const birdsSchema = {
	"id": "birds",
	"allOf": [
		ravenSchema,
		doveSchema,
	],
};

const badRaven = { animal: 'raven', color: 'rainbow' };
const badDove = { animal: 'dove', color: 'pink' };

const imjvValidate = IMJV( birdsSchema, { greedy: true, verbose: true } );
const ajvValidate = ajv.compile( birdsSchema );

console.log( ( imjvValidate( badRaven ), imjvValidate.errors ) );
// [ { field: 'data', message: 'negative schema matches' } ]
console.log( ( imjvValidate( badDove ), imjvValidate.errors ) );
// [ { field: 'data', message: 'negative schema matches' } ]

console.log( ( ajvValidate( badRaven ), ajvValidate.errors ) );
// [ { keyword: 'not',
//     dataPath: '',
//     schemaPath: '#/allOf/0/not',
//     params: {},
//     message: 'should NOT be valid' } ]

console.log( ( ajvValidate( badDove ), ajvValidate.errors ) );
// [ { keyword: 'not',
//     dataPath: '',
//     schemaPath: '#/allOf/1/not',
//     params: {},
//     message: 'should NOT be valid' } ]

import { dropRight, get, last } from 'lodash';
const failedRule = get(
	birdsSchema,
	dropRight( last( ajvValidate.errors ).schemaPath.slice( 2 ).split( '/' ) )
);
console.log( JSON.stringify( failedRule ) );
//  {"whatever we want":"here it is","not":{"properties":{"animal":{"enum":["dove"]},"color":{"not":{"enum":["white"]}}}}}
```

While this example is a little contrived, you can see that `is-my-json-valid` returns exactly the same result `imjvValidate( badRaven )` and `imjvValidate( badDove )`, meaning _we can't tell what failed_.

`ajv` adds the criticial information we need in the `schemaPath` to tell the two failures apart as well as find that rule in the schema.

#### Why ajv?

- Most correct
- super fast
- great docs
- easy to get up and running
- MIT Licence
- Not too big ( 116k minimized )
- 29M downloads last month (!)
- https://github.com/epoberezkin/ajv-i18n (we won't even use it, but I'm stoked it exists ;) )

There are a lot of other options, but ajv seems to be a pretty clear standout.

`djv` has  great stats too, but I found it a bit challenging to use. By default it returns a fairly uninformative string, and changing that involves passing in an error handling callback that seems to return a string to get evaluated in a context that contains the information you need, but the documentation on that aspect is not very helpful. I get the impression it would do what we need it to with some extra effort, but I don't see a compelling reason to follow the rougher path here.

https://github.com/bugventure/jsen has good stats and good looking docs, but it performs worse than is-my-json-valid on the benchmarks, so not as attractive, but if we're going to do some rigorous testing we should probably include it.