### PR TITLE
Concierge Chats: Update the data layer handlers for the up-coming changes.

### DIFF
--- a/client/me/concierge/constants.js
+++ b/client/me/concierge/constants.js
@@ -1,0 +1,1 @@
+export const WPCOM_CONCIERGE_SCHEDULE_ID = 1;

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -27,6 +27,7 @@ import Main from 'components/main';
 import Skeleton from './skeleton';
 import QueryConciergeShifts from 'components/data/query-concierge-shifts';
 import { getConciergeShifts } from 'state/selectors';
+import { WPCOM_CONCIERGE_SCHEDULE_ID } from './constants';
 
 const STEP_COMPONENTS = [ InfoStep, CalendarStep, ConfirmationStep ];
 
@@ -52,11 +53,10 @@ class ConciergeMain extends Component {
 		const { shifts } = this.props;
 
 		// TODO:
-		// 1. pass in the real scheduleId for WP.com concierge schedule.
-		// 2. render the shifts for real.
+		// render the shifts for real.
 		return (
 			<Main>
-				<QueryConciergeShifts scheduleId={ 123 } />
+				<QueryConciergeShifts scheduleId={ WPCOM_CONCIERGE_SCHEDULE_ID } />
 				{ shifts ? (
 					<CurrentStep
 						shifts={ shifts }

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
@@ -7,10 +7,9 @@ import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import responseSchema from './schema';
 
 export const transformShift = shift => ( {
+	id: shift.id,
 	beginTimestamp: shift.begin_timestamp,
 	endTimestamp: shift.end_timestamp,
-	scheduleId: shift.schedule_id,
-	description: shift.description,
 } );
 
 export const transform = response => response.map( transformShift );

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/schema.json
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/schema.json
@@ -3,15 +3,14 @@
 	"items": {
 		"type": "object",
 		"required": [
+			"id",
 			"begin_timestamp",
-			"end_timestamp",
-			"schedule_id"
+			"end_timestamp"
 		],
 		"properties": {
+			"id": { "type": "string" },
 			"begin_timestamp": { "type": "integer" },
-			"end_timestamp": { "type": "integer" },
-			"schedule_id": { "type": "integer" },
-			"description": { "type": "string" }
+			"end_timestamp": { "type": "integer" }
 		}
 	}
 }

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/test/from-api.js
@@ -9,18 +9,16 @@ import fromApi, { transformShift } from '../from-api';
 describe( 'transformShift()', () => {
 	test( 'should pick out expected fields and make the keys camelCase.', () => {
 		const mockShift = {
+			id: 'some-id',
 			begin_timestamp: 100,
 			end_timestamp: 200,
-			schedule_id: 999,
-			description: 'an example',
 			not_going_to_take_this: 'should ignore this one',
 		};
 
 		expect( transformShift( mockShift ) ).toEqual( {
+			id: mockShift.id,
 			beginTimestamp: mockShift.begin_timestamp,
 			endTimestamp: mockShift.end_timestamp,
-			scheduleId: mockShift.schedule_id,
-			description: mockShift.description,
 		} );
 	} );
 } );
@@ -29,31 +27,29 @@ describe( 'fromApi()', () => {
 	test( 'should validate and transform the data successfully.', () => {
 		const validResponse = [
 			{
+				id: 'shift-id-1',
 				begin_timestamp: 100,
 				end_timestamp: 200,
-				schedule_id: 999,
 				description: 'shift 1',
 			},
 			{
+				id: 'shift-id-2',
 				begin_timestamp: 300,
 				end_timestamp: 400,
-				schedule_id: 999,
 				description: 'shift 2',
 			},
 		];
 
 		const expectedResult = [
 			{
+				id: validResponse[ 0 ].id,
 				beginTimestamp: validResponse[ 0 ].begin_timestamp,
 				endTimestamp: validResponse[ 0 ].end_timestamp,
-				scheduleId: validResponse[ 0 ].schedule_id,
-				description: validResponse[ 0 ].description,
 			},
 			{
+				id: validResponse[ 1 ].id,
 				beginTimestamp: validResponse[ 1 ].begin_timestamp,
 				endTimestamp: validResponse[ 1 ].end_timestamp,
-				scheduleId: validResponse[ 1 ].schedule_id,
-				description: validResponse[ 1 ].description,
 			},
 		];
 		expect( fromApi( validResponse ) ).toEqual( expectedResult );
@@ -63,10 +59,9 @@ describe( 'fromApi()', () => {
 		const invalidateCall = () => {
 			const invalidFieldTypes = [
 				{
+					id: 'xxx',
 					begin_timestamp: 'haha',
 					end_timestamp: 200,
-					schedule_id: null,
-					description: 'so wrong',
 				},
 			];
 
@@ -80,9 +75,8 @@ describe( 'fromApi()', () => {
 		const invalidateMissingBeginTimestamp = () => {
 			const invalidResponse = [
 				{
+					id: 'just-an-id',
 					end_timestamp: 400,
-					schedule_id: 999,
-					description: 'wrong',
 				},
 			];
 
@@ -96,9 +90,9 @@ describe( 'fromApi()', () => {
 		const invalidateMissingEndTimestamp = () => {
 			const invalidResponse = [
 				{
-					begin_timestamp: 'haha',
+					id: 'just-an-id',
+					begin_timestamp: 333,
 					schedule_id: 999,
-					description: 'wrong',
 				},
 			];
 
@@ -108,13 +102,12 @@ describe( 'fromApi()', () => {
 		expect( invalidateMissingEndTimestamp ).toThrowError( SchemaError );
 	} );
 
-	test( 'should invalidate missing schedule_id.', () => {
+	test( 'should invalidate missing id.', () => {
 		const invalidateMissingScheduleId = () => {
 			const invalidResponse = [
 				{
-					begin_timestamp: 'haha',
+					begin_timestamp: 333,
 					end_timestamp: 400,
-					description: 'wrong',
 				},
 			];
 


### PR DESCRIPTION
## Summary
This PR updates the data layer handlers of the endpoint `GET /concierge/schedule/{id}/shifts` to match the up-coming changes from D8346 and D8347.

## Test Plan
`npm run test-client concierge` should pass.

