### PR TITLE
Jetpack connect: Remove getJetpackPlanSelected selector

### DIFF
--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -140,19 +140,6 @@ const hasExpiredSecretError = function( state ) {
 	);
 };
 
-const getJetpackPlanSelected = function( state ) {
-	const selectedPlans = state.jetpackConnect.jetpackConnectSelectedPlans;
-	const siteUrl = getAuthorizationRemoteQueryData( state ).site;
-
-	if ( siteUrl ) {
-		const siteSlug = urlToSlug( siteUrl );
-		if ( selectedPlans && selectedPlans[ siteSlug ] ) {
-			return selectedPlans[ siteSlug ];
-		}
-	}
-	return false;
-};
-
 const getSiteSelectedPlan = function( state, siteSlug ) {
 	return (
 		state.jetpackConnect.jetpackConnectSelectedPlans &&
@@ -189,7 +176,6 @@ export default {
 	getJetpackSiteByUrl,
 	hasXmlrpcError,
 	hasExpiredSecretError,
-	getJetpackPlanSelected,
 	getSiteSelectedPlan,
 	getGlobalSelectedPlan,
 	getAuthAttempts,


### PR DESCRIPTION
This selector appears to be completely unused. _Rip it out_

Discovered while reviewing #20105

## Testing
* Search for usage
* Run connection e2e connect test