### PR TITLE
Comments Redesign: Improve Comment component tabindex

### DIFF
--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -184,9 +184,9 @@ export class CommentNavigation extends Component {
 						</ButtonGroup>
 					</CommentNavigationTab>
 					<CommentNavigationTab className="comment-navigation__close-bulk">
-						<a onClick={ toggleBulkEdit }>
+						<Button borderless onClick={ toggleBulkEdit } tabIndex="0">
 							<Gridicon icon="cross" />
-						</a>
+						</Button>
 					</CommentNavigationTab>
 				</SectionNav>
 			);

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -171,6 +171,7 @@ export class CommentActions extends Component {
 							'is-approved': commentIsApproved,
 						} ) }
 						onClick={ this.toggleApproved }
+						tabIndex="0"
 					>
 						<Gridicon icon={ commentIsApproved ? 'checkmark-circle' : 'checkmark' } />
 						<span>{ commentIsApproved ? translate( 'Approved' ) : translate( 'Approve' ) }</span>
@@ -182,6 +183,7 @@ export class CommentActions extends Component {
 						borderless
 						className="comment__action comment__action-spam"
 						onClick={ this.setSpam }
+						tabIndex="0"
 					>
 						<Gridicon icon="spam" />
 						<span>{ translate( 'Spam' ) }</span>
@@ -193,6 +195,7 @@ export class CommentActions extends Component {
 						borderless
 						className="comment__action comment__action-trash"
 						onClick={ this.setTrash }
+						tabIndex="0"
 					>
 						<Gridicon icon="trash" />
 						<span>{ translate( 'Trash' ) }</span>
@@ -204,6 +207,7 @@ export class CommentActions extends Component {
 						borderless
 						className="comment__action comment__action-delete"
 						onClick={ this.delete }
+						tabIndex="0"
 					>
 						<Gridicon icon="trash" />
 						<span>{ translate( 'Delete Permanently' ) }</span>
@@ -217,6 +221,7 @@ export class CommentActions extends Component {
 							'is-liked': commentIsLiked,
 						} ) }
 						onClick={ this.toggleLike }
+						tabIndex="0"
 					>
 						<Gridicon icon={ commentIsLiked ? 'star' : 'star-outline' } />
 						<span>{ commentIsLiked ? translate( 'Liked' ) : translate( 'Like' ) }</span>
@@ -228,6 +233,7 @@ export class CommentActions extends Component {
 						borderless
 						className="comment__action comment__action-pencil"
 						onClick={ toggleEditMode }
+						tabIndex="0"
 					>
 						<Gridicon icon="pencil" />
 						<span>{ translate( 'Edit' ) }</span>
@@ -239,6 +245,7 @@ export class CommentActions extends Component {
 						borderless
 						className="comment__action comment__action-reply"
 						onClick={ toggleReply }
+						tabIndex="0"
 					>
 						<Gridicon icon="reply" />
 						<span>{ translate( 'Reply' ) }</span>

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -90,11 +90,15 @@ export class CommentAuthor extends Component {
 					<div className="comment__author-info-element">
 						<span className="comment__date">
 							{ isEnabled( 'comments/management/comment-view' ) ? (
-								<a href={ commentUrl } title={ formattedDate }>
+								<a href={ commentUrl } tabIndex={ isBulkMode ? -1 : 0 } title={ formattedDate }>
 									{ relativeDate }
 								</a>
 							) : (
-								<ExternalLink href={ commentUrl } title={ formattedDate }>
+								<ExternalLink
+									href={ commentUrl }
+									tabIndex={ isBulkMode ? -1 : 0 }
+									title={ formattedDate }
+								>
 									{ relativeDate }
 								</ExternalLink>
 							) }
@@ -102,7 +106,7 @@ export class CommentAuthor extends Component {
 						{ authorUrl && (
 							<span className="comment__author-url">
 								<span className="comment__author-url-separator">&middot;</span>
-								<ExternalLink href={ authorUrl }>
+								<ExternalLink href={ authorUrl } tabIndex={ isBulkMode ? -1 : 0 }>
 									<Emojify>{ urlToDomainAndPath( authorUrl ) }</Emojify>
 								</ExternalLink>
 							</span>

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -42,7 +42,7 @@ export class CommentContent extends Component {
 			<div className="comment__in-reply-to">
 				{ isBulkMode && <Gridicon icon="reply" size={ 18 } /> }
 				<span>{ translate( 'In reply to:' ) }</span>
-				<a href={ commentUrl } onClick={ this.trackDeepReaderLinkClick }>
+				<a href={ commentUrl } onClick={ this.trackDeepReaderLinkClick } tabIndex="0">
 					<Emojify>{ parentCommentContent }</Emojify>
 				</a>
 			</div>

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -42,7 +42,11 @@ export class CommentContent extends Component {
 			<div className="comment__in-reply-to">
 				{ isBulkMode && <Gridicon icon="reply" size={ 18 } /> }
 				<span>{ translate( 'In reply to:' ) }</span>
-				<a href={ commentUrl } onClick={ this.trackDeepReaderLinkClick } tabIndex="0">
+				<a
+					href={ commentUrl }
+					onClick={ this.trackDeepReaderLinkClick }
+					tabIndex={ isBulkMode ? -1 : 0 }
+				>
 					<Emojify>{ parentCommentContent }</Emojify>
 				</a>
 			</div>

--- a/client/my-sites/comments/comment/comment-header.jsx
+++ b/client/my-sites/comments/comment/comment-header.jsx
@@ -22,9 +22,9 @@ export class CommentHeader extends PureComponent {
 		return (
 			<div className="comment__header">
 				{ isBulkMode && (
-					<label className="comment__bulk-select">
-						<FormCheckbox checked={ isSelected } />
-					</label>
+					<span className="comment__bulk-select">
+						<FormCheckbox checked={ isSelected } tabIndex="0" />
+					</span>
 				) }
 
 				<CommentAuthor { ...{ commentId, isBulkMode, isPostView } } />

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -32,7 +32,7 @@ const CommentPostLink = ( {
 
 		<Gridicon icon={ isBulkMode ? 'chevron-right' : 'posts' } size={ 18 } />
 
-		<a href={ `/comments/${ status }/${ siteSlug }/${ postId }` }>
+		<a href={ `/comments/${ status }/${ siteSlug }/${ postId }` } tabIndex={ isBulkMode ? -1 : 0 }>
 			{ postTitle.trim() || translate( 'Untitled' ) }
 		</a>
 	</div>

--- a/client/my-sites/comments/comment/comment-reply.jsx
+++ b/client/my-sites/comments/comment/comment-reply.jsx
@@ -13,6 +13,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import AutoDirection from 'components/auto-direction';
+import Button from 'components/button';
 import { decodeEntities } from 'lib/formatting';
 import {
 	bumpStat,
@@ -160,9 +161,16 @@ export class CommentReply extends Component {
 					/>
 				</AutoDirection>
 
-				<button className={ buttonClasses } disabled={ ! hasReplyContent } onClick={ this.submit }>
+				<Button
+					borderless
+					className={ buttonClasses }
+					compact
+					disabled={ ! hasReplyContent }
+					onClick={ this.submit }
+					tabIndex="0"
+				>
 					{ translate( 'Send' ) }
-				</button>
+				</Button>
 			</form>
 		);
 	}

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -117,7 +117,6 @@ export class Comment extends Component {
 				onClick={ isBulkMode ? this.toggleSelected : false }
 				onKeyDown={ this.keyDownHandler }
 				ref={ this.storeCardRef }
-				tabIndex="0"
 			>
 				{ refreshCommentData && (
 					<QueryComment commentId={ commentId } siteId={ siteId } forceWpcom />

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -398,14 +398,13 @@
 	}
 }
 
-.comment__reply-submit {
+.comment__reply-submit.button.is-compact.is-borderless {
 	color: $gray;
-	font-size: 12px;
 	font-weight: 600;
 	padding: 4px;
 	position: absolute;
 	right: 28px;
-	top: 12px;
+	top: 13px;
 	text-transform: uppercase;
 
 	&.is-active {

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -67,10 +67,11 @@
 .comment-navigation__close-bulk {
 	margin-left: auto;
 	padding: 0;
-	a {
-		cursor: pointer;
-		display: inline-block;
+	button.is-borderless {
 		padding: 10px 16px;
+		.gridicon {
+			top: 4px;
+		}
 	}
 }
 


### PR DESCRIPTION
Fix #19777

Improve the `Comment` component tabindex handling.

### Testing instructions

Open `/comments` and, navigating via `tab`, make sure that:

- The `Comment` card is not highlightable anymore
- When in "normal view mode", and all internal links are highlighted in this order:
  - Date
  - Author URL
  - (optional) User Info (note: links and buttons inside the `Popover` are not part of this order!)
  - (optional) Post Title
  - (optional) In Reply To (note: currently bugged)
  - (optional) all links in the comment content
  - All the Actions
    - By entering Reply Mode, the form is automatically highlighted
    - After inserting some content, the next tab is the Send button
- When in Bulk Mode:
  - Is it now possible to highlight and activate via keyboard the Close Bulk Mode button
  - No link or button in the `Comment` card is highlightable
  - Only the checkbox is highlightable
  - Via mouse, the `Comment` card is still highlightable and it's still possible to select the comment by clicking anywhere on it

### A note on Safari

The original issue reported that `Comment`'s tabindex is broken on Safari.
Actually... that's not true.
It works on Safari exactly like on Chrome, just... tab navigation on Safari is opt-in.

<img width="767" alt="screen shot 2017-11-23 at 11 38 19" src="https://user-images.githubusercontent.com/2070010/33171250-75c93502-d043-11e7-96da-1d766a6fe0c6.png">

Nevertheless, `Comment` tabindex could definitely use an improvement, so the issue is still valid.