### PR TITLE
Comments Redesign: Fix "In Reply To" line

### DIFF
--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
-import { get, isEmpty, noop } from 'lodash';
+import { get, noop } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -131,7 +131,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 		commentContent: get( comment, 'content' ),
 		commentIsPending: 'unapproved' === get( comment, 'status' ),
 		isJetpack,
-		isParentCommentLoaded: 0 === parentCommentId || !! parentCommentContent,
+		isParentCommentLoaded: ! parentCommentId || !! parentCommentContent,
 		parentCommentContent,
 		parentCommentId,
 		parentCommentUrl,


### PR DESCRIPTION
Fix #19973

The new `Comment` component has an "In Reply To" line which, if the comment is a reply, is populated with the parent comment's content, and linked to the parent comment permalink (on JP) or to the parent comment in the Reader (on .com).

*The "In Reply To" line, for those unfamiliar with it:*
<img width="536" alt="screen shot 2017-11-23 at 12 51 28" src="https://user-images.githubusercontent.com/2070010/33173720-227baf2e-d04d-11e7-9713-74f41013bfd5.png">

Though, all of my tests were incidentally performed on replies with parent comments in the same page of their replies.
This means that the parent comments were loaded "for free" in the state, and the "In Reply To" line worked flawlessly.

By testing on a larger amount of comments, I've started noticing that the "In Reply To" line weren't populated as reliably.
The reason is of course because the parent comment wasn't in the same page anymore, and therefore not loaded.

This PR adds a query component that fetches the parent comment, only if it's not already loaded in state.

It also fixes another issue on the "In Reply To" line link that linked to the comment, and not its parent as intended.
It also adds a new case in the `parentCommentUrl` creation, that links to the comment specific view if its feature flag is enabled.

### Testing instructions

- Open `/comments` on a site with plenty of comments, where a reply and its parent comment aren't in the same page.
- Make sure that the "In Reply To" line is populated correctly with the parent comment's content.
- Make sure that, if more replies to the same comment are in the same page, there is only 1 network request for the parent comment.