### PR TITLE
Jetpack connect: Don't flash plans for Atomic/hasPlan

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -254,8 +254,8 @@ class Plans extends Component {
 			this.hasPreSelectedPlan( this.props ) ||
 			notJetpack ||
 			! canPurchasePlans ||
-			hasPlan ||
-			isAutomatedTransfer
+			false !== hasPlan ||
+			false !== isAutomatedTransfer
 		) {
 			return <QueryPlans />;
 		}

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import page from 'page';
 import { connect } from 'react-redux';
 import { get, isEqual, pick } from 'lodash';
@@ -38,7 +39,6 @@ import {
 	getJetpackConnectRedirectAfterAuth,
 	isRtl,
 	isSiteAutomatedTransfer,
-	isSiteOnPaidPlan,
 } from 'state/selectors';
 import {
 	getFlowType,
@@ -47,7 +47,7 @@ import {
 	isCalypsoStartedConnection,
 } from 'state/jetpack-connect/selectors';
 import { mc } from 'lib/analytics';
-import { isJetpackSite } from 'state/sites/selectors';
+import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 const CALYPSO_PLANS_PAGE = '/plans/my-plan/';
@@ -55,6 +55,12 @@ const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';
 
 class Plans extends Component {
 	static defaultProps = { siteSlug: '*' };
+
+	static propTypes = {
+		// Connected props
+		isAutomatedTransfer: PropTypes.bool, // null indicates unknown
+		hasPlan: PropTypes.bool, // null indicates unknown
+	};
 
 	componentDidMount() {
 		if ( ! this.maybeRedirect( this.props ) ) {
@@ -301,7 +307,7 @@ export default connect(
 			selectedSite,
 			selectedSiteSlug,
 			selectedPlan,
-			isAutomatedTransfer: selectedSite ? isSiteAutomatedTransfer( state, selectedSite.ID ) : false,
+			isAutomatedTransfer: selectedSite ? isSiteAutomatedTransfer( state, selectedSite.ID ) : null,
 			redirectAfterAuth: getJetpackConnectRedirectAfterAuth( state ),
 			userId: user ? user.ID : null,
 			canPurchasePlans: selectedSite
@@ -312,7 +318,7 @@ export default connect(
 			getPlanBySlug: searchPlanBySlug,
 			calypsoStartedConnection: isCalypsoStartedConnection( state, selectedSiteSlug ),
 			isRtlLayout: isRtl( state ),
-			hasPlan: selectedSite && isSiteOnPaidPlan( state, selectedSite.ID ),
+			hasPlan: selectedSite ? isCurrentPlanPaid( state, selectedSite.ID ) : null,
 			notJetpack: ! ( selectedSite && isJetpackSite( state, selectedSite.ID ) ),
 		};
 	},

--- a/client/jetpack-connect/test/plans.js
+++ b/client/jetpack-connect/test/plans.js
@@ -30,6 +30,20 @@ describe( 'Plans', () => {
 		expect( wrapper.find( QueryPlans ) ).toHaveLength( 1 );
 	} );
 
+	test( 'should render empty with unknown plan', () => {
+		const wrapper = shallow( <Plans { ...DEFAULT_PROPS } hasPlan={ null } /> );
+
+		expect( wrapper.find( PlansGrid ) ).toHaveLength( 0 );
+		expect( wrapper.find( QueryPlans ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should render empty with unknown Atomic', () => {
+		const wrapper = shallow( <Plans { ...DEFAULT_PROPS } isAutomatedTransfer={ null } /> );
+
+		expect( wrapper.find( PlansGrid ) ).toHaveLength( 0 );
+		expect( wrapper.find( QueryPlans ) ).toHaveLength( 1 );
+	} );
+
 	test( 'should render empty with a paid plan', () => {
 		const wrapper = shallow(
 			<Plans
@@ -44,8 +58,8 @@ describe( 'Plans', () => {
 		expect( wrapper.find( QueryPlans ) ).toHaveLength( 1 );
 	} );
 
-	test( 'should redirect on update from free to paid plan', () => {
-		const wrapper = mount( <Plans { ...DEFAULT_PROPS } /> );
+	test( 'should redirect when hasPlan is loaded', () => {
+		const wrapper = mount( <Plans { ...DEFAULT_PROPS } hasPlan={ null } selectedSite={ null } /> );
 
 		const redirect = ( wrapper.instance().redirect = jest.fn() );
 


### PR DESCRIPTION
This PR fixes a "flash" of the plans page before redirection.

/cc @ebinnion @johnHackworth via p1HpG7-4D7-p2 #comment-23256

## Testing
1. Visit `/jetpack/connect/plans/:SITE_SLUG` with a Jetpack site on a paid plan. You should be redirected to `/plans/:SITE_SLUG` without seeing a flash of the plans page.
1. Repeat with an Atomic site except the redirection will be to WP Admin.
1. Repeat with a fresh connection, you should see the plans page.
1. Repeat with a connected site on the Free plan, you should see the plans page.