### PR TITLE
WooCommerce - Checking package dimensions before fetching rates

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, isEmpty, isEqual, isNaN, isNumber, map, mapValues, sum } from 'lodash';
+import { find, get, isEmpty, isEqual, isFinite, map, mapValues, some, sum } from 'lodash';
 import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
@@ -152,15 +152,17 @@ const getPackagesErrors = ( values ) => mapValues( values, ( pckg ) => {
 		errors.box_id = translate( 'Please select a package' );
 	}
 
-	if ( isNaN( pckg.weight ) || ! isNumber( pckg.weight ) || 0 >= pckg.weight ) {
+	const isInvalidDimension = ( dimension ) => ( ! isFinite( dimension ) || 0 >= dimension );
+
+	if ( isInvalidDimension( pckg.weight ) ) {
 		errors.weight = translate( 'Invalid weight' );
 	}
 
-	const hasInvalidDimensions = [
+	const hasInvalidDimensions = some( [
 		pckg.length,
 		pckg.width,
 		pckg.height,
-	].reduce( ( result, dimension ) => ( result || isNaN( dimension ) || ! isNumber( dimension ) || 0 >= dimension ), false );
+	], isInvalidDimension );
 	if ( hasInvalidDimensions ) {
 		errors.dimensions = translate( 'Package dimensions must be greater than zero' );
 	}

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, isEmpty, isEqual, map, mapValues, sum } from 'lodash';
+import { find, get, isEmpty, isEqual, isNaN, isNumber, map, mapValues, sum } from 'lodash';
 import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
@@ -152,8 +152,17 @@ const getPackagesErrors = ( values ) => mapValues( values, ( pckg ) => {
 		errors.box_id = translate( 'Please select a package' );
 	}
 
-	if ( ! pckg.weight || 'number' !== typeof pckg.weight || 0 > pckg.weight ) {
+	if ( isNaN( pckg.weight ) || ! isNumber( pckg.weight ) || 0 >= pckg.weight ) {
 		errors.weight = translate( 'Invalid weight' );
+	}
+
+	const hasInvalidDimensions = [
+		pckg.length,
+		pckg.width,
+		pckg.height,
+	].reduce( ( result, dimension ) => ( result || isNaN( dimension ) || ! isNumber( dimension ) || 0 >= dimension ), false );
+	if ( hasInvalidDimensions ) {
+		errors.dimensions = translate( 'Package dimensions must be greater than zero' );
 	}
 
 	return errors;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/index.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
+import { find, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,8 +39,6 @@ const PackagesStep = ( props ) => {
 	const packageIds = Object.keys( selected );
 	const itemsCount = packageIds.reduce( ( result, pId ) => ( result + selected[ pId ].items.length ), 0 );
 	const totalWeight = packageIds.reduce( ( result, pId ) => ( result + selected[ pId ].weight ), 0 );
-	const isValidWeight = packageIds.reduce( ( result, pId ) => ( result && 0 < selected[ pId ].weight ), true );
-	const isValidPackageType = packageIds.reduce( ( result, pId ) => ( result && 'not_selected' !== selected[ pId ].box_id ), true );
 	const isValidPackages = 0 < packageIds.length;
 
 	const getContainerState = () => {
@@ -50,17 +49,11 @@ const PackagesStep = ( props ) => {
 			};
 		}
 
-		if ( ! isValidPackageType ) {
+		const errorPackage = find( errors, ( pckg ) => ( ! isEmpty( pckg ) ) );
+		if ( errorPackage ) {
 			return {
 				isError: true,
-				summary: translate( 'Please select a package type' ),
-			};
-		}
-
-		if ( ! isValidWeight ) {
-			return {
-				isError: true,
-				summary: translate( 'Weight not entered' ),
+				summary: errorPackage[ Object.keys( errorPackage )[ 0 ] ],
 			};
 		}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-info.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/package-info.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
 import { isEmpty, map, some } from 'lodash';
@@ -122,12 +123,14 @@ const PackageInfo = ( props ) => {
 
 	const renderPackageSelect = () => {
 		if ( isIndividualPackage ) {
+			const dimensionsClass = classNames( { 'is-error': pckgErrors.dimensions } );
 			return ( <div>
 				<div className="packages-step__package-items-header">
 					<FormLegend>{ translate( 'Individually Shipped Item' ) }</FormLegend>
 				</div>
 				<span className="packages-step__package-item-description">{ translate( 'Item Dimensions' ) } - </span>
-				<span>{ renderPackageDimensions( pckg, dimensionUnit ) }</span>
+				<span className={ dimensionsClass }>{ renderPackageDimensions( pckg, dimensionUnit ) }</span>
+				{ pckgErrors.dimensions && <FieldError text={ pckgErrors.dimensions } /> }
 			</div> );
 		}
 
@@ -136,7 +139,7 @@ const PackageInfo = ( props ) => {
 				<div className="packages-step__package-items-header">
 					<FormLegend>{ translate( 'Shipping Package' ) }</FormLegend>
 				</div>
-				<FormSelect onChange={ packageOptionChange } value={ pckg.box_id } isError={ pckgErrors.box_id }>
+				<FormSelect onChange={ packageOptionChange } value={ pckg.box_id } isError={ pckgErrors.box_id || pckgErrors.dimensions }>
 					<option value={ 'not_selected' } key={ 'not_selected' }>{ translate( 'Please select a package' ) }</option> )
 					{ map( packageGroups, ( group, groupId ) => {
 						if ( isEmpty( group.definitions ) ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1239

To test:
* create a product that has one or more dimensions set to 0 or less
* place an order for that product
* when printing a label, move the product to individual package
* an error should appear and no rates should be fetched