### PR TITLE
WooCommerce - Not allowing creation of boxes with 0 as a dimension

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/packages/input-filters.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/input-filters.js
@@ -41,8 +41,8 @@ const checkDimension = dimension => {
 		return '';
 	}
 
-	if ( dimension < 0 ) {
-		return '0';
+	if ( 0 >= dimension ) {
+		return '';
 	}
 
 	return dimension;


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/723

To test:
* in shipping settings, attempt to add package with 0 as one of the dimensions
* saving of the package should fail with an error