### PR TITLE
Comments: Load CSS asynchronously

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -326,10 +326,7 @@
 @import 'my-sites/ads/style';
 @import 'my-sites/all-sites/style';
 @import 'my-sites/all-sites-icon/style';
-@import 'my-sites/comment/style';
-@import 'my-sites/comments/style';
-@import 'my-sites/comments/comment/style';
-@import 'my-sites/comments/comment-replies-list/style';
+@import 'my-sites/checklist/checklist-show/style';
 @import 'my-sites/current-site/style';
 @import 'my-sites/customize/style';
 @import 'my-sites/domain-tip/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -326,7 +326,6 @@
 @import 'my-sites/ads/style';
 @import 'my-sites/all-sites/style';
 @import 'my-sites/all-sites-icon/style';
-@import 'my-sites/checklist/checklist-show/style';
 @import 'my-sites/current-site/style';
 @import 'my-sites/customize/style';
 @import 'my-sites/domain-tip/style';

--- a/assets/stylesheets/sections/comments.scss
+++ b/assets/stylesheets/sections/comments.scss
@@ -1,0 +1,11 @@
+/** @format */
+@import '../shared/colors';
+@import '../shared/functions/z-index';
+@import '../shared/mixins/breakpoints';
+@import '../shared/mixins/placeholder';
+@import '../shared/typography';
+
+@import 'my-sites/comment/style';
+@import 'my-sites/comments/style';
+@import 'my-sites/comments/comment/style';
+@import 'my-sites/comments/comment-replies-list/style';

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -157,6 +157,8 @@ class ManageMenu extends PureComponent {
 		let preload;
 		if ( includes( [ 'post', 'page' ], menuItem.name ) ) {
 			preload = 'posts-pages';
+		} else if ( 'comments' === menuItem.name ) {
+			preload = 'comments';
 		} else {
 			preload = 'posts-custom';
 		}

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -408,6 +408,7 @@ sections.push( {
 	module: 'my-sites/comments',
 	group: 'sites',
 	secondary: true,
+	css: 'comments',
 } );
 
 sections.push( {


### PR DESCRIPTION
Context: p4TIVU-85u-p2

Move the Comments Management CSS away from the main bundle into the on-demand sections.

I expected it to be harder, and instead the hardest thing has been typing the word "asynchronously" without looking it up.

Looped in @scruffian to make sure I didn't miss anything.

### Testing instructions

Open `/comments` on this branch and on stage: navigate around (site view, post view, single comment view; bulk mode, reply, edit) and make sure both versions look the same.