### PR TITLE
Comments: Delete success notice clears previous notices

### DIFF
--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -222,6 +222,7 @@ export const announceDeleteSuccess = ( { dispatch }, { options } ) => {
 	dispatch(
 		successNotice( translate( 'Comment deleted permanently.' ), {
 			duration: 5000,
+			id: 'comment-notice',
 			isPersistent: true,
 		} )
 	);


### PR DESCRIPTION
Fix #19980

Add an ID to the delete comment success notice to match the Comments Management notices ID.
This way it will replace any possible notice, instead of stacking under it.

### Testing instructions

- Open `/comments` and trash a comment: a "Comment moved to trash" notice will appear.
- Head over to the Trash list.
- Delete that comment.
- Make sure that the "Comment deleted permanently" notice will replace the previous one.