### PR TITLE
Comments: Disable persistence if M3 design is enabled

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -235,10 +235,12 @@ export class CommentList extends Component {
 			this.setState( { lastUndo: null } );
 		}
 
-		if ( doPersist ) {
-			this.updatePersistedComments( commentId, isUndo );
-		} else {
-			this.removeFromPersistedComments( commentId );
+		if ( ! isEnabled( 'comments/management/m3-design' ) ) {
+			if ( doPersist ) {
+				this.updatePersistedComments( commentId, isUndo );
+			} else {
+				this.removeFromPersistedComments( commentId );
+			}
 		}
 
 		this.props.removeNotice( `comment-notice-${ commentId }` );
@@ -475,7 +477,6 @@ export class CommentList extends Component {
 								commentId={ commentId }
 								key={ `comment-${ siteId }-${ commentId }` }
 								isBulkMode={ isBulkEdit }
-								isPersistent={ this.isCommentPersisted( commentId ) }
 								isPostView={ isPostView }
 								isSelected={ this.isCommentSelected( commentId ) }
 								refreshCommentData={

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -29,7 +29,6 @@ export class Comment extends Component {
 		postId: PropTypes.number,
 		commentId: PropTypes.number,
 		isBulkMode: PropTypes.bool,
-		isPersistent: PropTypes.bool,
 		isPostView: PropTypes.bool,
 		isSelected: PropTypes.bool,
 		refreshCommentData: PropTypes.bool,


### PR DESCRIPTION
Fix #19976

Disable comment persistence on bulk `approved`/`unapproved` toggling if the M3 design is enabled.

### Testing instructions

- Open `/comments` and navigate to the Approved list.
- Enter Bulk Mode and select one or more comments.
- Hit "Unapprove".
- Make sure that the selected comments disappear.
- Now navigate to the Pending list.
- The previously selected comments should be there.
- Try bulk selecting them, and re-approving them
- Make sure they disappear (and "reappear" in the Approved list).