### PR TITLE
Reader: fix import/export buttons in Manage Following for Firefox

### DIFF
--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -24,12 +24,14 @@ export default class PopoverMenuItem extends Component {
 		focusOnHover: PropTypes.bool,
 		onMouseOver: PropTypes.func,
 		isExternalLink: PropTypes.bool,
+		itemComponent: PropTypes.oneOfType( [ PropTypes.func, PropTypes.string ] ),
 	};
 
 	static defaultProps = {
 		isSelected: false,
 		focusOnHover: true,
 		onMouseOver: noop,
+		itemComponent: 'button',
 	};
 
 	handleMouseOver = event => {
@@ -56,10 +58,12 @@ export default class PopoverMenuItem extends Component {
 			'is-selected': isSelected,
 		} );
 
-		let ItemComponent = href ? 'a' : 'button';
+		let ItemComponent = this.props.itemComponent;
 		if ( isExternalLink && href ) {
 			ItemComponent = ExternalLink;
 			itemProps.icon = true;
+		} else if ( href ) {
+			ItemComponent = 'a';
 		}
 
 		return (

--- a/client/components/popover/test/menu-item.jsx
+++ b/client/components/popover/test/menu-item.jsx
@@ -1,0 +1,34 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PopoverMenuItem from 'components/popover/menu-item';
+import ExternalLink from 'components/external-link';
+
+describe( 'PopoverMenuItem', () => {
+	test( 'should be a button by default', () => {
+		const wrapper = shallow( <PopoverMenuItem /> );
+		expect( wrapper.type() ).toEqual( 'button' );
+	} );
+
+	test( 'should be a div if the itemComponent prop is provided', () => {
+		const wrapper = shallow( <PopoverMenuItem itemComponent={ 'div' } /> );
+		expect( wrapper.type() ).toEqual( 'div' );
+	} );
+
+	test( 'should be a anchor if the href prop is set', () => {
+		const wrapper = shallow( <PopoverMenuItem href={ 'xyz' } /> );
+		expect( wrapper.type() ).toEqual( 'a' );
+	} );
+
+	test( 'should be an ExternalLink if the isExternalLink prop is true and the href prop is set', () => {
+		const wrapper = shallow( <PopoverMenuItem isExternalLink={ true } href={ 'xyz' } /> );
+		expect( wrapper.type() ).toEqual( ExternalLink );
+	} );
+} );

--- a/client/components/popover/test/menu-item.jsx
+++ b/client/components/popover/test/menu-item.jsx
@@ -22,7 +22,7 @@ describe( 'PopoverMenuItem', () => {
 		expect( wrapper.type() ).toEqual( 'div' );
 	} );
 
-	test( 'should be a anchor if the href prop is set', () => {
+	test( 'should be a link if the href prop is set', () => {
 		const wrapper = shallow( <PopoverMenuItem href={ 'xyz' } /> );
 		expect( wrapper.type() ).toEqual( 'a' );
 	} );

--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -113,10 +113,16 @@ class FollowingManageSubscriptions extends Component {
 					</div>
 					<div className="following-manage__subscriptions-import-export">
 						<EllipsisMenu toggleTitle={ translate( 'More' ) } position="bottom">
-							<PopoverMenuItem className="following-manage__subscriptions-import-export-menu-item">
+							<PopoverMenuItem
+								className="following-manage__subscriptions-import-export-menu-item"
+								itemComponent="div"
+							>
 								<ReaderImportButton />
 							</PopoverMenuItem>
-							<PopoverMenuItem className="following-manage__subscriptions-import-export-menu-item">
+							<PopoverMenuItem
+								className="following-manage__subscriptions-import-export-menu-item"
+								itemComponent="div"
+							>
 								<ReaderExportButton />
 							</PopoverMenuItem>
 						</EllipsisMenu>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/20146.

In Firefox, the import and export buttons do not respond:

![33160881-35ee77ee-d020-11e7-967f-527c1df8557f](https://user-images.githubusercontent.com/17325/33181221-4cd8dcdc-d067-11e7-8bb2-7a5d78dbdac1.png)

This is because Firefox does not seem to fire `onClick` events in child elements of a button:

https://stackoverflow.com/questions/26402033/missing-click-event-for-span-inside-button-element-on-firefox

This PR works around this by allowing a custom element to be specified for the parent `PopoverMenuItem`. Switching to a `div` instead of a `button` solves the issue.

### To test

Visit http://calypso.localhost:3000/following/manage in Firefox and ensure that you can import and export feeds.
