### PR TITLE
Simple Payments: Improve error messages

### DIFF
--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -82,18 +82,22 @@ const validate = ( values, props ) => {
 	const errors = {};
 
 	if ( ! values.title ) {
-		errors.title = translate( 'This cannot be empty.' );
+		errors.title = translate(
+			"People need to know what they're paying for! Please add a brief title."
+		);
 	}
 
 	if ( ! values.price ) {
-		errors.price = translate( 'Price cannot be empty.' );
+		errors.price = translate( 'Everything comes with a price tag these days. Add yours here.' );
 	} else if ( parseFloat( values.price ) === NaN ) {
 		errors.price = translate( 'Invalid price' );
 	} else if ( parseFloat( values.price ) < 0 ) {
-		errors.price = translate( 'Price cannot be negative.' );
+		errors.price = translate( "Your price is negative — now that doesn't sound right, does it?" );
 	} else if ( decimalPlaces( values.price ) > precision ) {
 		if ( precision === 0 ) {
-			errors.price = translate( 'Price cannot have decimal places.' );
+			errors.price = translate(
+				"We know every penny counts, but prices can't contain decimal values."
+			);
 		} else {
 			const countDecimal = translate(
 				'%(precision)d decimal place',
@@ -112,7 +116,9 @@ const validate = ( values, props ) => {
 	}
 
 	if ( ! values.email ) {
-		errors.email = translate( 'Email address cannot be empty.' );
+		errors.email = translate(
+			'We want to make sure payments reach you, so please add an email address.'
+		);
 	} else if ( ! emailValidator.validate( values.email ) ) {
 		errors.email = translate( '%(email)s is not a valid email address.', {
 			args: { email: values.email },

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -82,18 +82,18 @@ const validate = ( values, props ) => {
 	const errors = {};
 
 	if ( ! values.title ) {
-		errors.title = translate( 'This can not be empty.' );
+		errors.title = translate( 'This cannot be empty.' );
 	}
 
 	if ( ! values.price ) {
-		errors.price = translate( 'Price can not be empty.' );
+		errors.price = translate( 'Price cannot be empty.' );
 	} else if ( parseFloat( values.price ) === NaN ) {
 		errors.price = translate( 'Invalid price' );
 	} else if ( parseFloat( values.price ) < 0 ) {
-		errors.price = translate( 'Price can not be negative.' );
+		errors.price = translate( 'Price cannot be negative.' );
 	} else if ( decimalPlaces( values.price ) > precision ) {
 		if ( precision === 0 ) {
-			errors.price = translate( 'Price can not have decimal places.' );
+			errors.price = translate( 'Price cannot have decimal places.' );
 		} else {
 			const countDecimal = translate(
 				'%(precision)d decimal place',
@@ -105,14 +105,14 @@ const validate = ( values, props ) => {
 					},
 				}
 			);
-			errors.price = translate( 'Price can not have more than %(countDecimal)s.', {
+			errors.price = translate( 'Price cannot have more than %(countDecimal)s.', {
 				args: { countDecimal },
 			} );
 		}
 	}
 
 	if ( ! values.email ) {
-		errors.email = translate( 'Email address can not be empty.' );
+		errors.email = translate( 'Email address cannot be empty.' );
 	} else if ( ! emailValidator.validate( values.email ) ) {
 		errors.email = translate( '%(email)s is not a valid email address.', {
 			args: { email: values.email },


### PR DESCRIPTION
The use of "can not" is grammatically incorrect in this context. It should be "cannot".