### PR TITLE
Comments: Prevent the vertical resize of the edit textarea

### DIFF
--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -424,6 +424,7 @@
 
 	.form-textarea {
 		margin: 0px 8px 20px 8px;
+		resize: vertical;
 		transition: none;
 		width: 100%;
 	}


### PR DESCRIPTION
Fix #19968

Prevent the vertical resize of the edit textarea.

### Testing instructions

- Open `/comments`.
- Enter in the Edit Mode of a comment.
- Try resizing the content textarea: it should only resize vertically.