### PR TITLE
Process values from site goals

### DIFF
--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -99,6 +99,7 @@ class AboutStep extends Component {
 		//Inputs
 		const siteTitleInput = formState.getFieldValue( this.state.form, 'siteTitle' );
 		const siteGoalsInput = formState.getFieldValue( this.state.form, 'siteGoals' );
+		const siteGoalsArray = siteGoalsInput.split( ',' );
 
 		//Site Title
 		if ( siteTitleInput !== '' ) {
@@ -115,10 +116,12 @@ class AboutStep extends Component {
 		themeRepo = getThemeForSiteGoals( siteGoalsInput );
 		designType = getSiteTypeForSiteGoals( siteGoalsInput );
 
-		this.props.recordTracksEvent( 'calypso_signup_actions_user_input', {
-			field: 'Site goals',
-			value: siteGoalsInput,
-		} );
+		for ( let i = 0; i < siteGoalsArray.length; i++ ) {
+			this.props.recordTracksEvent( 'calypso_signup_actions_user_input', {
+				field: 'Site goal: ' + siteGoalsArray[ i ],
+				value: true,
+			} );
+		}
 
 		//SET SITETYPE
 		this.props.setDesignType( designType );

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -21,6 +21,7 @@ import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { setSiteGoals } from 'state/signup/steps/site-goals/actions';
 import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getThemeForSiteGoals, getSiteTypeForSiteGoals } from 'signup/utils';
 
 //Form components
 import Card from 'components/card';
@@ -91,9 +92,9 @@ class AboutStep extends Component {
 		const { goToNextStep, stepName, translate } = this.props;
 
 		//Defaults
-		const themeRepo = 'pub/radcliffe-2',
-			designType = 'blog';
-		let siteTitleValue = 'Site Title';
+		let themeRepo = 'pub/radcliffe-2',
+			designType = 'blog',
+			siteTitleValue = 'Site Title';
 
 		//Inputs
 		const siteTitleInput = formState.getFieldValue( this.state.form, 'siteTitle' );
@@ -111,6 +112,15 @@ class AboutStep extends Component {
 
 		//Site Goals
 		this.props.setSiteGoals( siteGoalsInput );
+		themeRepo = getThemeForSiteGoals( siteGoalsInput );
+		designType = getSiteTypeForSiteGoals( siteGoalsInput );
+
+		this.props.recordTracksEvent( 'calypso_signup_actions_user_input', {
+			field: 'Site goals',
+			value: siteGoalsInput,
+		} );
+
+		//SET SITETYPE
 		this.props.setDesignType( designType );
 
 		SignupActions.submitSignupStep(

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -118,8 +118,8 @@ class AboutStep extends Component {
 
 		for ( let i = 0; i < siteGoalsArray.length; i++ ) {
 			this.props.recordTracksEvent( 'calypso_signup_actions_user_input', {
-				field: 'Site goal: ' + siteGoalsArray[ i ],
-				value: true,
+				field: 'Site goals',
+				value: siteGoalsArray[ i ],
 			} );
 		}
 

--- a/client/signup/steps/about/style.scss
+++ b/client/signup/steps/about/style.scss
@@ -19,6 +19,11 @@
 	&:first-child {
 		border-top: 0;
 	}
+
+	&:hover {
+		cursor: pointer;
+		background: $gray-light;
+	}
 }
 
 .about__checkbox {

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -145,6 +145,46 @@ function getThemeForDesignType( designType ) {
 	}
 }
 
+function getThemeForSiteGoals( siteGoals ) {
+	const siteGoalsValue = siteGoals.split( ',' );
+
+	if ( siteGoalsValue.indexOf( 'sell' ) !== -1 ) {
+		return 'pub/dara';
+	}
+
+	if ( siteGoalsValue.indexOf( 'promote' ) !== -1 ) {
+		return 'pub/radcliffe-2';
+	}
+
+	if ( siteGoalsValue.indexOf( 'educate' ) !== -1 ) {
+		return 'pub/twentyfifteen';
+	}
+
+	if ( siteGoalsValue.indexOf( 'showcase' ) !== -1 ) {
+		return 'pub/altofocus';
+	}
+
+	return 'pub/independent-publisher-2';
+}
+
+function getSiteTypeForSiteGoals( siteGoals ) {
+	const siteGoalsValue = siteGoals.split( ',' );
+
+	if ( siteGoalsValue.indexOf( 'sell' ) !== -1 ) {
+		return 'store';
+	}
+
+	if ( siteGoalsValue.indexOf( 'promote' ) !== -1 ) {
+		return 'page';
+	}
+
+	if ( siteGoalsValue.indexOf( 'showcase' ) !== -1 ) {
+		return 'portfolio';
+	}
+
+	return 'blog';
+}
+
 function canResumeFlow( flowName, progress ) {
 	const flow = flows.getFlow( flowName );
 	const flowStepsInProgressStore = filter(
@@ -170,4 +210,6 @@ export default {
 	getDestination: getDestination,
 	mergeFormWithValue: mergeFormWithValue,
 	getThemeForDesignType: getThemeForDesignType,
+	getThemeForSiteGoals: getThemeForSiteGoals,
+	getSiteTypeForSiteGoals: getSiteTypeForSiteGoals,
 };


### PR DESCRIPTION
A continuation of https://github.com/Automattic/wp-calypso/pull/20122 and https://github.com/Automattic/wp-calypso/pull/9693. This PR takes the users input from the site goal and sets a theme, picks a site type, and records the inputs as events in Tracks (more details here: p5XAZ9-1Cn-p). 

![image](https://user-images.githubusercontent.com/6981253/33182028-50ca95be-d040-11e7-9310-5db18a627f1d.png)

## Testing
**Case 1:**
* Visit `/start/segment`
* Select `Sell products or collect payments` and any other option
* Complete signup with `Dara` theme selected

**Case 2:**
* Visit `/start/segment`
* Select `Promote your business, skills, organization, or events` and any other option except `Sell products or collect payments`
* Complete signup with `Radcliffe 2` theme selected

**Case 3:**
* Visit `/start/segment`
* Select `Offer education, training, or mentoring` and any other option except `Sell products or collect payments` and `Promote your business, skills, organization, or events`
* Complete signup with `Twenty Fifteen` theme selected

**Case 4:**
* Visit `/start/segment`
* Select `Showcase your portfolio` and `Share ideas, experiences, updates, reviews, stories, videos, or photos`
* Complete signup with `Altofocus` theme selected

**Case 5:**
* Visit `/start/segment`
* Select only `Share ideas, experiences, updates, reviews, stories, videos, or photos`
* Complete signup with `Independent Publisher 2` theme selected

cc @markryall @taggon 