### PR TITLE
Comments Redesign: Improve edit popover copy

### DIFF
--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -110,7 +110,7 @@ export class CommentEdit extends Component {
 						<FormLabel htmlFor="author">{ translate( 'Name' ) }</FormLabel>
 						{ isAuthorRegistered && (
 							<InfoPopover>
-								{ translate( "This user is registered, the name can't be edited." ) }
+								{ translate( "This user is registered; the name can't be edited." ) }
 							</InfoPopover>
 						) }
 						<FormTextInput
@@ -125,7 +125,7 @@ export class CommentEdit extends Component {
 						<FormLabel htmlFor="author_url">{ translate( 'URL' ) }</FormLabel>
 						{ isAuthorRegistered && (
 							<InfoPopover>
-								{ translate( "This user is registered, the URL can't be edited." ) }
+								{ translate( "This user is registered; the URL can't be edited." ) }
 							</InfoPopover>
 						) }
 						<FormTextInput


### PR DESCRIPTION
Fix #19975

Replace
`This user is registered, the name/URL can’t be edited.`
with
`This user is registered; the name/URL can’t be edited.`

Testing instructions

- Open `/comment`.
- Find a comment by a registered .com user, and enter its Edit Mode.
- Open the info popover of both the name and URL fields.
- Make sure they use semicolons instead of commas.