### PR TITLE
WooCommerce - Fixed labels form validation before rates are fetched

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -183,6 +183,7 @@ const tryGetLabelRates = ( orderId, siteId, dispatch, getState ) => {
 	} = formState;
 
 	return getRates( orderId, siteId, dispatch, origin.values, destination.values, map( packages.selected, convertToApiPackage ) )
+		.then( () => expandFirstErroneousStep( orderId, siteId, dispatch, getState ) )
 		.catch( ( error ) => {
 			console.error( error );
 			dispatch( NoticeActions.errorNotice( error.toString() ) );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { every, fill, find, first, flatten, includes, isEqual, map, noop, pick } from 'lodash';
+import { every, fill, find, first, flatten, includes, isEqual, map, noop, omit, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -170,7 +170,7 @@ export const clearAvailableRates = ( orderId, siteId ) => {
 const tryGetLabelRates = ( orderId, siteId, dispatch, getState ) => {
 	const state = getState();
 	const errors = getFormErrors( state, orderId, siteId );
-	if ( hasNonEmptyLeaves( errors ) ) {
+	if ( hasNonEmptyLeaves( omit( errors, 'rates' ) ) ) {
 		expandFirstErroneousStep( orderId, siteId, dispatch, getState );
 		return;
 	}

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -112,7 +112,7 @@ const waitForAllPromises = ( promises ) => {
  *
  * @returns {String} erroneous step name or null
  */
-const getNextErroneousStep = ( form, errors, currentStepIndex = 0 ) => {
+const getFirstErroneousStep = ( form, errors, currentStepIndex = 0 ) => {
 	if ( currentStepIndex >= FORM_STEPS.length ) {
 		return null;
 	}
@@ -136,14 +136,14 @@ const getNextErroneousStep = ( form, errors, currentStepIndex = 0 ) => {
 				return 'rates';
 			}
 	}
-	return getNextErroneousStep( form, errors, currentStepIndex + 1 );
+	return getFirstErroneousStep( form, errors, currentStepIndex + 1 );
 };
 
 const expandFirstErroneousStep = ( orderId, siteId, dispatch, getState ) => {
 	const shippingLabel = getShippingLabel( getState(), orderId, siteId );
 	const form = shippingLabel.form;
 
-	const step = getNextErroneousStep( form, getFormErrors( getState(), orderId, siteId ) );
+	const step = getFirstErroneousStep( form, getFormErrors( getState(), orderId, siteId ) );
 	if ( step && ! form[ step ].expanded ) {
 		dispatch( toggleStep( orderId, siteId, step ) );
 	}

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -68,8 +68,6 @@ import {
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_FULFILL_ORDER,
 } from '../action-types.js';
 
-const FORM_STEPS = [ 'origin', 'destination', 'packages', 'rates' ];
-
 export const fetchLabelsData = ( orderId, siteId ) => ( dispatch ) => {
 	dispatch( { type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_IS_FETCHING, orderId, siteId, isFetching: true } );
 
@@ -105,38 +103,31 @@ const waitForAllPromises = ( promises ) => {
 };
 
 /**
- * Recursively checks the form for errors and returns a step with an error in it or null
+ * Checks the form for errors and returns a step with an error in it or null
  * @param {Object} form the form
  * @param {Object} errors error tree
  * @param {Number} currentStepIndex (optional) index of the step where the check should start, defaults to 0
  *
  * @returns {String} erroneous step name or null
  */
-const getFirstErroneousStep = ( form, errors, currentStepIndex = 0 ) => {
-	if ( currentStepIndex >= FORM_STEPS.length ) {
-		return null;
+const getFirstErroneousStep = ( form, errors ) => {
+	if ( ! form.origin.isNormalized || ! isEqual( form.origin.values, form.origin.normalized ) ) {
+		return 'origin';
 	}
 
-	const stepToCheck = FORM_STEPS[ currentStepIndex ];
-	switch ( stepToCheck ) {
-		case 'origin':
-			if ( ! form.origin.isNormalized || ! isEqual( form.origin.values, form.origin.normalized ) ) {
-				return 'origin';
-			}
-		case 'destination':
-			if ( ! form.destination.isNormalized || ! isEqual( form.destination.values, form.destination.normalized ) ) {
-				return 'destination';
-			}
-		case 'packages':
-			if ( hasNonEmptyLeaves( errors.packages ) ) {
-				return 'packages';
-			}
-		case 'rates':
-			if ( hasNonEmptyLeaves( errors.rates ) ) {
-				return 'rates';
-			}
+	if ( ! form.destination.isNormalized || ! isEqual( form.destination.values, form.destination.normalized ) ) {
+		return 'destination';
 	}
-	return getFirstErroneousStep( form, errors, currentStepIndex + 1 );
+
+	if ( hasNonEmptyLeaves( errors.packages ) ) {
+		return 'packages';
+	}
+
+	if ( hasNonEmptyLeaves( errors.rates ) ) {
+		return 'rates';
+	}
+
+	return null;
 };
 
 const expandFirstErroneousStep = ( orderId, siteId, dispatch, getState ) => {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
@@ -71,6 +71,17 @@ const AddressFields = ( props ) => {
 	const getPhoneNumber = ( value ) => getPlainPhoneNumber( value, getValue( 'country' ) );
 	const updatePhoneValue = ( value ) => props.updateAddressValue( orderId, siteId, group, 'phone', getPhoneNumber( value ) );
 	const submitAddressForNormalizationHandler = () => props.submitAddressForNormalization( orderId, siteId, group );
+	const getAddressError = () => {
+		if ( fieldErrors.address ) {
+			return fieldErrors.address;
+		}
+
+		if ( ! isNormalized ) {
+			return translate( 'Address needs to be validated' );
+		}
+
+		return null;
+	};
 
 	return (
 		<div>
@@ -102,7 +113,7 @@ const AddressFields = ( props ) => {
 				value={ getValue( 'address' ) }
 				updateValue={ updateValue( 'address' ) }
 				className="address-step__address-1"
-				error={ fieldErrors.address } />
+				error={ getAddressError() } />
 			<TextField
 				id={ getId( 'address_2' ) }
 				value={ getValue( 'address_2' ) }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
@@ -71,17 +71,6 @@ const AddressFields = ( props ) => {
 	const getPhoneNumber = ( value ) => getPlainPhoneNumber( value, getValue( 'country' ) );
 	const updatePhoneValue = ( value ) => props.updateAddressValue( orderId, siteId, group, 'phone', getPhoneNumber( value ) );
 	const submitAddressForNormalizationHandler = () => props.submitAddressForNormalization( orderId, siteId, group );
-	const getAddressError = () => {
-		if ( fieldErrors.address ) {
-			return fieldErrors.address;
-		}
-
-		if ( ! isNormalized ) {
-			return translate( 'Address needs to be validated' );
-		}
-
-		return null;
-	};
 
 	return (
 		<div>
@@ -113,7 +102,7 @@ const AddressFields = ( props ) => {
 				value={ getValue( 'address' ) }
 				updateValue={ updateValue( 'address' ) }
 				className="address-step__address-1"
-				error={ getAddressError() } />
+				error={ fieldErrors.address } />
 			<TextField
 				id={ getId( 'address_2' ) }
 				value={ getValue( 'address_2' ) }
@@ -155,7 +144,7 @@ const AddressFields = ( props ) => {
 			<StepConfirmationButton
 				disabled={ hasNonEmptyLeaves( errors ) || normalizationInProgress }
 				onClick={ submitAddressForNormalizationHandler } >
-					{ translate( 'Use this address' ) }
+					{ translate( 'Validate address' ) }
 			</StepConfirmationButton>
 		</div>
 	);

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
@@ -57,7 +57,7 @@ const getNormalizationStatus = ( { normalizationInProgress, errors, isNormalized
 	if ( normalizationInProgress ) {
 		return { isProgress: true };
 	}
-	if ( hasNonEmptyLeaves( errors ) || ( isNormalized && ! normalized ) ) {
+	if ( hasNonEmptyLeaves( errors ) || ( isNormalized && ! normalized ) || ! isNormalized ) {
 		return { isError: true };
 	}
 	if ( isNormalized ) {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
@@ -38,6 +38,9 @@ const renderSummary = ( {
 	if ( hasNonEmptyLeaves( errors ) || ( isNormalized && ! normalized ) ) {
 		return translate( 'Invalid address' );
 	}
+	if ( ! isNormalized ) {
+		return translate( "You've edited the address, please revalidate it for accurate rates" );
+	}
 	const { countriesData } = storeOptions;
 	const { city, postcode, state, country } = ( normalized && selectNormalized ) ? normalized : values;
 	// Summary format: "city, state  postcode [, country]"


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/969

In addition to fixing the error above, I also cleaned up the code. Previously each step was checking for errors in the subsequent steps before fetching the rates (assuming that if the packages step is submitted, then address steps are valid). This resulted in a lot of inconsistent code duplication. Now the whole form is checked before the rates request is dispatched.

To test:
* open the label printing modal
* delete the origin ZIP code
* instead of submitting the address, collapse the step card
* open the packages step, select packages and click "Use these packages"
* the origin step should be expanded, and no rates should be fetched
* should also work for the destination step, and should not fetch the rates unless the normalization result was accepted