### PR TITLE
Comments: Only show persistence-related bulk actions on old design

### DIFF
--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -32,12 +32,17 @@ import { getSiteComment } from 'state/selectors';
 import { NEWEST_FIRST, OLDEST_FIRST } from '../constants';
 
 const bulkActions = {
-	unapproved: [ 'approve', 'unapprove', 'spam', 'trash' ],
-	approved: [ 'approve', 'unapprove', 'spam', 'trash' ],
+	unapproved: [ 'approve', 'spam', 'trash' ],
+	approved: [ 'unapprove', 'spam', 'trash' ],
 	spam: [ 'approve', 'delete' ],
 	trash: [ 'approve', 'spam', 'delete' ],
 	all: [ 'approve', 'unapprove', 'spam', 'trash' ],
 };
+
+if ( ! isEnabled( 'comments/management/m3-design' ) ) {
+	bulkActions.approved.push( 'approve' );
+	bulkActions.unapproved.push( 'unapprove' );
+}
 
 export class CommentNavigation extends Component {
 	static defaultProps = {


### PR DESCRIPTION
Comments M3 design drops the persistence of `approved`/`unapproved` comments.

In other words, it's not possible anymore to have `approved` comments in the Pending list (and vice versa).
For this reason it doesn't make sense anymore to have the bulk Approve action in the Approved list, and the bulk Unapprove action in the Pending list.

This PR only adds them if the M3 design feature flag is disabled.

### Testing instructions

- Open `/comments`.
- Navigate to the Pending list and activate Bulk Mode: make sure there is no "Unapprove" action.
- Navigate to the Approved list and activate Bulk Mode: make sure there is no "Approve action.
- Now disable the `comments/management/m3-design` feature flag.
- Pending list + Bulk Mode: there still is the "Unapproved" action.
- Approved list + Bulk Mode: there still is the "Approved" action.