### PR TITLE
Jetpack connect: Make selected plan a connected prop

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -133,10 +133,10 @@ class Plans extends Component {
 	}
 
 	autoselectPlan( props ) {
-		const { selectFreeJetpackPlan, selectedPlan, selectedPlanSlug } = props;
+		const { selectedPlan, selectedPlanSlug } = props;
 
 		if ( selectedPlanSlug === PLAN_JETPACK_FREE || selectedPlanSlug === 'free' ) {
-			selectFreeJetpackPlan();
+			this.selectFreeJetpackPlan();
 			return;
 		}
 		if ( selectedPlan ) {

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -20,11 +20,8 @@ import PlansSkipButton from './plans-skip-button';
 import {
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
 	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -32,7 +29,7 @@ import { addItem } from 'lib/upgrades/actions';
 import { selectPlanInAdvance, goBackToWpAdmin, completeFlow } from 'state/jetpack-connect/actions';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
-import { isRequestingPlans, getPlanBySlug } from 'state/plans/selectors';
+import { getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import {
 	canCurrentUser,
@@ -73,13 +70,12 @@ class Plans extends Component {
 	componentWillReceiveProps = nextProps => {
 		const propsToCompare = [
 			'canPurchasePlans',
-			'flowType',
 			'hasPlan',
 			'isAutomatedTransfer',
 			'isCalypsoStartedConnection',
-			'isRequestingPlans',
 			'notJetpack',
 			'selectedPlan',
+			'selectedPlanSlug',
 		];
 
 		if ( ! isEqual( pick( this.props, propsToCompare ), pick( nextProps, propsToCompare ) ) ) {
@@ -92,8 +88,8 @@ class Plans extends Component {
 			this.props.goBackToWpAdmin( props.selectedSite.URL + JETPACK_ADMIN_PATH );
 			return true;
 		}
-		if ( this.hasPreSelectedPlan( props ) ) {
-			this.autoselectPlan();
+		if ( props.selectedPlanSlug ) {
+			this.autoselectPlan( props );
 			return true;
 		}
 		if ( props.hasPlan || props.notJetpack ) {
@@ -121,10 +117,6 @@ class Plans extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
 	};
 
-	isFlowTypePaid( flowType ) {
-		return flowType === 'pro' || flowType === 'premium' || flowType === 'personal';
-	}
-
 	redirectToWpAdmin( props ) {
 		const { redirectAfterAuth } = props;
 		if ( redirectAfterAuth ) {
@@ -140,62 +132,16 @@ class Plans extends Component {
 		this.props.completeFlow();
 	}
 
-	hasPreSelectedPlan( props ) {
-		if ( this.isFlowTypePaid( props.flowType ) ) {
-			return true;
-		}
+	autoselectPlan( props ) {
+		const { selectFreeJetpackPlan, selectedPlan, selectedPlanSlug } = props;
 
-		return !! props.selectedPlan;
-	}
-
-	autoselectPlan() {
-		if ( this.props.flowType === 'personal' || this.props.selectedPlan === PLAN_JETPACK_PERSONAL ) {
-			const plan = this.props.getPlanBySlug( PLAN_JETPACK_PERSONAL );
-			if ( plan ) {
-				this.selectPlan( plan );
-				return;
-			}
+		if ( selectedPlanSlug === PLAN_JETPACK_FREE || selectedPlanSlug === 'free' ) {
+			selectFreeJetpackPlan();
+			return;
 		}
-		if ( this.props.selectedPlan === PLAN_JETPACK_PERSONAL_MONTHLY ) {
-			const plan = this.props.getPlanBySlug( PLAN_JETPACK_PERSONAL_MONTHLY );
-			if ( plan ) {
-				this.selectPlan( plan );
-				return;
-			}
-		}
-		if ( this.props.flowType === 'pro' || this.props.selectedPlan === PLAN_JETPACK_BUSINESS ) {
-			const plan = this.props.getPlanBySlug( PLAN_JETPACK_BUSINESS );
-			if ( plan ) {
-				this.selectPlan( plan );
-				return;
-			}
-		}
-		if ( this.props.selectedPlan === PLAN_JETPACK_BUSINESS_MONTHLY ) {
-			const plan = this.props.getPlanBySlug( PLAN_JETPACK_BUSINESS_MONTHLY );
-			if ( plan ) {
-				this.selectPlan( plan );
-				return;
-			}
-		}
-		if ( this.props.flowType === 'premium' || this.props.selectedPlan === PLAN_JETPACK_PREMIUM ) {
-			const plan = this.props.getPlanBySlug( PLAN_JETPACK_PREMIUM );
-			if ( plan ) {
-				this.selectPlan( plan );
-				return;
-			}
-		}
-		if (
-			this.props.flowType === 'premium' ||
-			this.props.selectedPlan === PLAN_JETPACK_PREMIUM_MONTHLY
-		) {
-			const plan = this.props.getPlanBySlug( PLAN_JETPACK_PREMIUM_MONTHLY );
-			if ( plan ) {
-				this.selectPlan( plan );
-				return;
-			}
-		}
-		if ( this.props.selectedPlan === 'free' || this.props.selectedPlan === PLAN_JETPACK_FREE ) {
-			this.selectFreeJetpackPlan();
+		if ( selectedPlan ) {
+			this.selectPlan( selectedPlan );
+			return;
 		}
 	}
 
@@ -246,12 +192,13 @@ class Plans extends Component {
 			isAutomatedTransfer,
 			isRtlLayout,
 			notJetpack,
+			selectedPlanSlug,
 			selectedSite,
 			translate,
 		} = this.props;
 
 		if (
-			this.hasPreSelectedPlan( this.props ) ||
+			selectedPlanSlug ||
 			notJetpack ||
 			! canPurchasePlans ||
 			false !== hasPlan ||
@@ -291,31 +238,39 @@ class Plans extends Component {
 
 export { Plans as PlansTestComponent };
 
+const getPlanSlug = ( flowType, planSlug ) => {
+	const flowTypeToSlug = {
+		personal: PLAN_JETPACK_PERSONAL,
+		premium: PLAN_JETPACK_PREMIUM,
+		pro: PLAN_JETPACK_BUSINESS,
+	};
+
+	return flowTypeToSlug[ flowType ] || planSlug;
+};
+
 export default connect(
 	state => {
 		const user = getCurrentUser( state );
 		const selectedSite = getSelectedSite( state );
 		const selectedSiteSlug = selectedSite ? selectedSite.slug : '*';
 
-		const selectedPlan =
+		const flowType = getFlowType( state, selectedSiteSlug );
+		const preSelectedPlan =
 			getSiteSelectedPlan( state, selectedSiteSlug ) || getGlobalSelectedPlan( state );
-		const searchPlanBySlug = planSlug => {
-			return getPlanBySlug( state, planSlug );
-		};
+		const selectedPlanSlug = getPlanSlug( flowType, preSelectedPlan );
+		const selectedPlan = getPlanBySlug( state, selectedPlanSlug );
 
 		return {
 			selectedSite,
 			selectedSiteSlug,
 			selectedPlan,
+			selectedPlanSlug,
 			isAutomatedTransfer: selectedSite ? isSiteAutomatedTransfer( state, selectedSite.ID ) : null,
 			redirectAfterAuth: getJetpackConnectRedirectAfterAuth( state ),
 			userId: user ? user.ID : null,
 			canPurchasePlans: selectedSite
 				? canCurrentUser( state, selectedSite.ID, 'manage_options' )
 				: true,
-			flowType: getFlowType( state, selectedSiteSlug ),
-			isRequestingPlans: isRequestingPlans( state ),
-			getPlanBySlug: searchPlanBySlug,
 			calypsoStartedConnection: isCalypsoStartedConnection( state, selectedSiteSlug ),
 			isRtlLayout: isRtl( state ),
 			hasPlan: selectedSite ? isCurrentPlanPaid( state, selectedSite.ID ) : null,


### PR DESCRIPTION
Currently we are using `isRequestingPlans` to determine whether plans data is available so we can add any pre-selected plan (a selection in `/jetpack/connect/store` or flow type param from the url such as `/pro`) to the cart. This is unreliable, as the plan data is not available until after `isRequestingPlans` has finished toggling.

This PR makes `selectedPlanSlug` and `selectedPlan` (which now contains a plan that can be added to the cart) connected props, meaning we can reliably add the plan to the cart and redirect when they update.

## Testing
1. Check that selecting a plan at `/jetpack/connect/store` (including free) redirects past the plans page after site auth
1. Check that using a flow type url `/jetpack/connect/(pro|premium|personal)` redirects past the plans page to the checkout after auth
