### PR TITLE
Editor Distractions: remove Masterbar

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -433,3 +433,7 @@ $autobar-height: 20px;
 		flex-grow: 0;
 	}
 }
+
+.is-section-post-editor .masterbar {
+	display: none;
+}

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -5,7 +5,7 @@
 	margin-bottom: 0;
 	transition: 0.3s box-shadow;
 	position: fixed;
-	top: 47px;
+	top: 0;
 	left: 0;
 	right: 0;
 	z-index: z-index( 'root', '.editor-ground-control' );

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -6,7 +6,6 @@
 	border-top: 1px solid darken( $sidebar-bg-color, 5% );
 	border-right: none;
 	box-sizing: border-box;
-	top: 93px;
 	right: $sidebar-width-max;
 	left: auto;
 	transition: all 0.15s cubic-bezier(0.075, 0.82, 0.165, 1);

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -34,7 +34,7 @@
 
 .post-editor__inner {
 	position: relative;
-	top: 47px;
+	top: 0;
 	padding-bottom: 47px;
 }
 


### PR DESCRIPTION
Fixes #20170.

@apeatling wrote:
> Some of the feedback we've received in user interviews has indicated that folks are still writing in wp-admin because we do not have a distraction free mode.
> A chunk of this distraction comes from the masterbar, and almost certainly the notifications menu:

In this PR, we are completely removing WP.com Masterbar when on post/page editor:

![screenshot_2017-11-23 21 45 59_rdjbxl](https://user-images.githubusercontent.com/4988512/33188299-1c314cd6-d099-11e7-9675-ac43fd2d3673.png)

![screenshot_2017-11-23 21 47 01_nomjx5](https://user-images.githubusercontent.com/4988512/33188303-2203d1a6-d099-11e7-8375-9f76d191f88a.png)

## Testing

Navigate to post/page editor and verify that the Masterbar has been correctly removed. Try different browser sizes. Navigate to other parts of Calypso and make sure Masterbar is there.

Is removing and modifying CSS in this way a good approach or should we create a specific selector for a distraction-free editor mode and modify CSS when it's present?