### PR TITLE
Activity Log: don't query downloadable backups if Rewind isn't active for the site

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -597,7 +597,7 @@ class ActivityLog extends Component {
 			<Main wideLayout>
 				{ rewindEnabledByConfig && <QueryRewindStatus siteId={ siteId } /> }
 				<QueryActivityLog siteId={ siteId } { ...logRequestQuery } />
-				{ siteId && <QueryRewindBackupStatus siteId={ siteId } /> }
+				{ siteId && isRewindActive && <QueryRewindBackupStatus siteId={ siteId } /> }
 				<QuerySiteSettings siteId={ siteId } />
 				<QueryJetpackCredentials siteId={ siteId } />
 				<StatsFirstView />


### PR DESCRIPTION
Without this PR, when the page loads on a site that doesn't have Rewind active, the following notice shows up, since the check for backup creation status is fired unrestrictedly:

<img width="724" alt="captura de pantalla 2017-11-23 a la s 20 18 17" src="https://user-images.githubusercontent.com/1041600/33190438-7c1ca64e-d08b-11e7-80e0-8318652ef74f.png">

This PR verifies that Rewind is active before checking for backup status:

<img width="722" alt="captura de pantalla 2017-11-23 a la s 20 18 24" src="https://user-images.githubusercontent.com/1041600/33190439-7ebb5e04-d08b-11e7-8f90-86285126ca04.png">

props @oskosk for finding this issue
