### PR TITLE
SEO Settings: Replace Immutable with native Set

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -1,12 +1,9 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { connect } from 'react-redux';
-import { Set } from 'immutable';
 import {
 	get,
 	includes,
@@ -99,7 +96,7 @@ export class SeoForm extends React.Component {
 		// from overwriting local stateful edits that
 		// are in progress and haven't yet been saved
 		// to the server
-		dirtyFields: Set(),
+		dirtyFields: new Set(),
 		invalidatedSiteObject: this.props.selectedSite,
 	};
 
@@ -133,7 +130,7 @@ export class SeoForm extends React.Component {
 					...stateForSite( nextSite ),
 					seoTitleFormats: nextProps.storedTitleFormats,
 					invalidatedSiteObject: nextSite,
-					dirtyFields: Set(),
+					dirtyFields: new Set(),
 				},
 				this.refreshCustomTitles
 			);
@@ -145,10 +142,13 @@ export class SeoForm extends React.Component {
 		};
 
 		if ( ! isFetchingSite ) {
+			const nextDirtyFields = new Set( dirtyFields );
+			nextDirtyFields.delete( 'seoTitleFormats' );
+
 			nextState = {
 				...nextState,
 				seoTitleFormats: nextProps.storedTitleFormats,
-				dirtyFields: dirtyFields.delete( 'seoTitleFormats' ),
+				dirtyFields: nextDirtyFields,
 			};
 		}
 
@@ -157,32 +157,33 @@ export class SeoForm extends React.Component {
 		}
 
 		// Don't update state for fields the user has edited
-		nextState = omit( nextState, dirtyFields.toArray() );
+		nextState = omit( nextState, Array.from( dirtyFields ) );
 
-		this.setState( {
-			...nextState,
-		} );
+		this.setState( nextState );
 	}
 
 	handleMetaChange = ( { target: { value: frontPageMetaDescription } } ) => {
-		const { dirtyFields } = this.state;
+		const dirtyFields = new Set( this.state.dirtyFields );
+		dirtyFields.add( 'frontPageMetaDescription' );
 
 		// Don't allow html tags in the input field
 		const hasHtmlTagError = anyHtmlTag.test( frontPageMetaDescription );
 
 		this.setState(
-			Object.assign( { hasHtmlTagError }, ! hasHtmlTagError && { frontPageMetaDescription }, {
-				dirtyFields: dirtyFields.add( 'frontPageMetaDescription' ),
-			} )
+			Object.assign(
+				{ dirtyFields, hasHtmlTagError },
+				! hasHtmlTagError && { frontPageMetaDescription }
+			)
 		);
 	};
 
 	updateTitleFormats = seoTitleFormats => {
-		const { dirtyFields } = this.state;
+		const dirtyFields = new Set( this.state.dirtyFields );
+		dirtyFields.add( 'seoTitleFormats' );
 
 		this.setState( {
 			seoTitleFormats,
-			dirtyFields: dirtyFields.add( 'seoTitleFormats' ),
+			dirtyFields,
 		} );
 	};
 


### PR DESCRIPTION
Previously we were using an `Immutable.js` `Set` to store the dirty
fields on the SEO form so we could know which fields to update.

We don't need Immutable though and if we can get rid of our references
to it then we'll be able to drop a large dependency from Calypso.

**Testing**

This should involve no functional or visual changes.

It affects saving and updating fields in the SEO _Traffic_ form.
We need to try updating subsets of fields, hit save, then make
sure they operate as we expect.

Once we have started changing the values for any given field in
the settings page we should be hitting the code changed in this
PR. I would greatly appreciate some help just changing settings
and seeing what if anything goes bad.