### PR TITLE
SEO Site Verification: Replace Immutable with native Set

### DIFF
--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -6,7 +6,6 @@
 
 import React, { Component } from 'react';
 import notices from 'notices';
-import { Set } from 'immutable';
 import { connect } from 'react-redux';
 import { get, includes, isString, omit, partial, pickBy } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -48,7 +47,7 @@ class SiteVerification extends Component {
 
 	state = {
 		...this.stateForSite( this.props.site ),
-		dirtyFields: Set(),
+		dirtyFields: new Set(),
 		invalidatedSiteObject: this.props.site,
 	};
 
@@ -75,7 +74,7 @@ class SiteVerification extends Component {
 			this.refreshSite();
 			this.setState( {
 				isSubmittingForm: false,
-				dirtyFields: Set(),
+				dirtyFields: new Set(),
 			} );
 		}
 
@@ -91,7 +90,7 @@ class SiteVerification extends Component {
 				{
 					...this.stateForSite( nextSite ),
 					invalidatedSiteObject: nextSite,
-					dirtyFields: Set(),
+					dirtyFields: new Set(),
 				},
 				this.refreshSite
 			);
@@ -102,7 +101,7 @@ class SiteVerification extends Component {
 		};
 
 		// Don't update state for fields the user has edited
-		nextState = omit( nextState, dirtyFields.toArray() );
+		nextState = omit( nextState, [ ...dirtyFields ] );
 
 		this.setState( {
 			...nextState,
@@ -167,8 +166,6 @@ class SiteVerification extends Component {
 
 	handleVerificationCodeChange( serviceCode ) {
 		return event => {
-			const { dirtyFields } = this.state;
-
 			if ( ! this.state.hasOwnProperty( serviceCode ) ) {
 				return;
 			}
@@ -182,11 +179,14 @@ class SiteVerification extends Component {
 				return;
 			}
 
+			const dirtyFields = new Set( this.state.dirtyFields );
+			dirtyFields.add( serviceCode );
+
 			this.setState( {
 				invalidCodes: [],
 				showPasteError: false,
 				[ serviceCode ]: event.target.value,
-				dirtyFields: dirtyFields.add( serviceCode ),
+				dirtyFields,
 			} );
 		};
 	}


### PR DESCRIPTION
Previously we were using an Immutable.js Set to store the dirty
fields on the SEO form so we could know which fields to update.

We don't need Immutable though and if we can get rid of our references
to it then we'll be able to drop a large dependency from Calypso.

**Testing**

This should involve no functional or visual changes.

It affects saving and updating fields in the SEO Traffic form.
We need to try updating subsets of fields, hit save, then make
sure they operate as we expect. These are specifically the
fields under **Site Verification Services**

Once we have started changing the values for any given field in
the settings page we should be hitting the code changed in this
PR. I would greatly appreciate some help just changing settings
and seeing what if anything goes bad.