### PR TITLE
Invites: Remove Immutable.js from invites-sent

### DIFF
--- a/client/lib/invites/reducers/invites-sent.js
+++ b/client/lib/invites/reducers/invites-sent.js
@@ -5,7 +5,7 @@
 import { action as ActionTypes } from 'lib/invites/constants';
 
 export const initialState = {
-	success: {},
+	successes: {},
 	errors: {},
 };
 
@@ -23,8 +23,8 @@ export const reducer = ( state = initialState, { action: { type, data, formId } 
 		case ActionTypes.RECEIVE_SENDING_INVITES_SUCCESS:
 			return {
 				...state,
-				success: {
-					...state.success,
+				successes: {
+					...state.successes,
 					[ formId ]: data,
 				},
 			};

--- a/client/lib/invites/reducers/invites-sent.js
+++ b/client/lib/invites/reducers/invites-sent.js
@@ -1,30 +1,35 @@
 /** @format */
-
-/**
- * External dependencies
- */
-
-import { fromJS } from 'immutable';
-
 /**
  * Internal dependencies
  */
 import { action as ActionTypes } from 'lib/invites/constants';
 
-const initialState = fromJS( {
+export const initialState = {
 	success: {},
 	errors: {},
-} );
-
-const reducer = ( state = initialState, payload ) => {
-	const { action } = payload;
-	switch ( action.type ) {
-		case ActionTypes.RECEIVE_SENDING_INVITES_SUCCESS:
-			return state.setIn( [ 'success', action.formId ], action.data );
-		case ActionTypes.RECEIVE_SENDING_INVITES_ERROR:
-			return state.setIn( [ 'error', action.formId ], action.data );
-	}
-	return state;
 };
 
-export { initialState, reducer };
+export const reducer = ( state = initialState, { action: { type, data, formId } } ) => {
+	switch ( type ) {
+		case ActionTypes.RECEIVE_SENDING_INVITES_ERROR:
+			return {
+				...state,
+				errors: {
+					...state.errors,
+					[ formId ]: data,
+				},
+			};
+
+		case ActionTypes.RECEIVE_SENDING_INVITES_SUCCESS:
+			return {
+				...state,
+				success: {
+					...state.success,
+					[ formId ]: data,
+				},
+			};
+
+		default:
+			return state;
+	}
+};

--- a/client/lib/invites/stores/invites-sent.js
+++ b/client/lib/invites/stores/invites-sent.js
@@ -8,7 +8,7 @@ import { reducer, initialState } from 'lib/invites/reducers/invites-sent';
 
 const InvitesSentStore = createReducerStore( reducer, initialState );
 
-InvitesSentStore.getSuccess = formId => InvitesSentStore.get().success[ formId ];
-InvitesSentStore.getErrors = formId => InvitesSentStore.get().error[ formId ];
+InvitesSentStore.getSuccess = formId => InvitesSentStore.get().successes[ formId ];
+InvitesSentStore.getErrors = formId => InvitesSentStore.get().errors[ formId ];
 
 export default InvitesSentStore;

--- a/client/lib/invites/stores/invites-sent.js
+++ b/client/lib/invites/stores/invites-sent.js
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
@@ -9,7 +8,7 @@ import { reducer, initialState } from 'lib/invites/reducers/invites-sent';
 
 const InvitesSentStore = createReducerStore( reducer, initialState );
 
-InvitesSentStore.getSuccess = formId => InvitesSentStore.get().getIn( [ 'success', formId ] );
-InvitesSentStore.getErrors = formId => InvitesSentStore.get().getIn( [ 'error', formId ] );
+InvitesSentStore.getSuccess = formId => InvitesSentStore.get().success[ formId ];
+InvitesSentStore.getErrors = formId => InvitesSentStore.get().error[ formId ];
 
 export default InvitesSentStore;

--- a/client/lib/store/index.js
+++ b/client/lib/store/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
 import Dispatcher from 'dispatcher';
 import emitter from 'lib/mixins/emitter';
 
@@ -27,8 +25,8 @@ import emitter from 'lib/mixins/emitter';
  * @return {Object} Store built from reducer.
  */
 export const createReducerStore = ( reducer, initialState = {}, waitFor = [] ) => {
-	let state = initialState,
-		ReducerStore = {};
+	let state = initialState;
+	const ReducerStore = {};
 
 	emitter( ReducerStore );
 


### PR DESCRIPTION
Previously we were using Immutable.js for managing the state in the
invites Flux store. It's big though and we don't need it and these
modules don't even take that much advantage of it.

This patch is part of a series to remove Immutable.js from all of the
invites subsystem.

**Testing**

There should be no functional or visual changes in this PR.

**My Sites** > **People**

This affects the indications surrounding inviting people to a site.
We need to invite people and make sure that the form updates to tell
us that the invitation has been sent as well as fake a failure and make
sure that it indicates the failure properly.