### PR TITLE
Post Revisions: Revert "Fix safari rendering bug"

### DIFF
--- a/client/post-editor/editor-revisions/style.scss
+++ b/client/post-editor/editor-revisions/style.scss
@@ -2,8 +2,6 @@
 .editor-revisions__dialog {
 	padding: 0;
 	overflow-x: hidden;
-	// Enable GPU acceleration to solve Safari rendering bug (see issue #20000)
-	transform: translate3d(0, 0, 0);
 }
 
 .editor-revisions__wrapper {


### PR DESCRIPTION
This reverts commit 1af705ee6096e026206ef736916b10907862b849.

## How to test

Navigate to post revisions modal in Chrome. It should look as expected again without this white gap at the bottom:

<img width="1325" alt="wrapper-styling-no-bueno" src="https://user-images.githubusercontent.com/1562646/33195296-f7ecbbb4-d09b-11e7-85d5-3087cd39ff20.png">
