### PR TITLE
Post revisions: Make diff content visible on MS Edge Win 10

### DIFF
--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -37,7 +37,7 @@ class EditorDiffViewer extends PureComponent {
 		);
 		const thisNodeHeight = get( thisNode, 'offsetHeight', 0 );
 		const offset = Math.max( 0, get( diffNode, 'offsetTop', 0 ) - thisNodeHeight / 2 );
-		thisNode.scrollTo( 0, offset );
+		thisNode.scrollTop = offset;
 	};
 
 	componentDidMount() {


### PR DESCRIPTION
## This PR
- fixes an issue that caused Diff content to not be visible on MS Edge Win 10

The Issue was caused by using [`window.scrollTo`](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo) on an element. Webkit based browsers and Firefox auto-correct the behavior and allow the use of `window.scrollTo` on an element as well. IE/Edge, on the other hand, is less forgiving. So in Edge, this caused an error that stopped further execution and thus prevented the revision content from being displayed. The straightforward solution to the problem is to use [`Element.scrollTop`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop) instead.

## How to test

- Open the latest version of the Edge browser on Windows 10
(Tip: If you don't have a local version you can use our browserstack.com account.)
- Navigate to or create a post with revisions
- Click on the `History` button to trigger the Post Revisions modal
- The revisions should load including their content
- It should look like the After state, not like the before state
- The revision content window should scroll to the first revised word

Next:
- Open the latest version of Chrome on Mac OS X or Windows
- Proceed in this browser with the same process as described above
- Open wpcalypso.wordpress.com in a second tab
- Repeat the same process in the second tab as described above
- The behavior in tab 1 and tab 2 should be identical

**Before**

<img width="773" alt="msedge-win10-snapshot-1-running-2017-11-21-09-58-51 1" src="https://user-images.githubusercontent.com/1562646/33196427-ac81dca0-d0a4-11e7-9985-a568448fa83f.png">

**After**

<img width="1270" alt="screen shot 2017-11-23 at 23 01 16" src="https://user-images.githubusercontent.com/1562646/33196444-c2ec6ece-d0a4-11e7-8a83-db91b7675c47.png">
