### PR TITLE
Show site selection for checklist when site slug is not present.

### DIFF
--- a/client/my-sites/checklist/index.js
+++ b/client/my-sites/checklist/index.js
@@ -9,9 +9,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { navigation, siteSelection } from 'my-sites/controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { show } from './controller';
 
 export default function() {
-	page( '/checklist/:domain?', siteSelection, navigation, show );
+	page( '/checklist', siteSelection, sites );
+	page( '/checklist/:site_id', siteSelection, navigation, show );
 }


### PR DESCRIPTION
There is currently no intention to show onboarding tasks for all of a user's sites.

This change will result in the site selector being displayed if a site slug is not present in the url.

# Testing

* visit `/checklist`
* you should see the site selection
* choose a site
* you should see the checklist for the specified site