### PR TITLE
Sites-List Removal: Sharing Controller

### DIFF
--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -22,7 +22,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { canCurrentUser, isJetpackModuleActive } from 'state/selectors';
 import { getSiteSettings } from 'state/site-settings/selectors';
 import { requestSiteSettings } from 'state/site-settings/actions';
-import { reduxDispatch } from 'lib/redux-bridge/index';
 import { isJetpackSite, getSiteSlug, getSiteOption } from 'state/sites/selectors';
 import versionCompare from 'lib/version-compare';
 
@@ -36,7 +35,7 @@ export const layout = context => {
 	const siteSettings = getSiteSettings( state, siteId );
 
 	if ( siteId && ! siteSettings && canCurrentUser( state, siteId, 'manage_options' ) ) {
-		reduxDispatch( requestSiteSettings( siteId ) );
+		store.dispatch( requestSiteSettings( siteId ) );
 	}
 
 	renderWithReduxStore(

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -20,15 +20,23 @@ import SharingButtons from './buttons/buttons';
 import SharingConnections from './connections/connections';
 import sites from 'lib/sites-list';
 import utils from 'lib/site/utils';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { canCurrentUser } from 'state/selectors';
+import { getSiteSettings } from 'state/site-settings/selectors';
+import { requestSiteSettings } from 'state/site-settings/actions';
+import { reduxDispatch } from 'lib/redux-bridge/index';
 
 const analyticsPageTitle = 'Sharing';
 
 export const layout = context => {
-	const site = sites().getSelectedSite();
 	const { contentComponent, path, store } = context;
+	const state = store.getState();
 
-	if ( site && ! site.settings && utils.userCan( 'manage_options', site ) ) {
-		site.fetchSettings();
+	const siteId = getSelectedSiteId( state );
+	const siteSettings = getSiteSettings( state, siteId );
+
+	if ( siteId && ! siteSettings && canCurrentUser( state, siteId, 'manage_options' ) ) {
+		reduxDispatch( requestSiteSettings( siteId ) );
 	}
 
 	renderWithReduxStore(

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -20,8 +20,6 @@ import SharingButtons from './buttons/buttons';
 import SharingConnections from './connections/connections';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { canCurrentUser, isJetpackModuleActive } from 'state/selectors';
-import { getSiteSettings } from 'state/site-settings/selectors';
-import { requestSiteSettings } from 'state/site-settings/actions';
 import { isJetpackSite, getSiteSlug, getSiteOption } from 'state/sites/selectors';
 import versionCompare from 'lib/version-compare';
 
@@ -29,14 +27,6 @@ const analyticsPageTitle = 'Sharing';
 
 export const layout = context => {
 	const { contentComponent, path, store } = context;
-	const state = store.getState();
-
-	const siteId = getSelectedSiteId( state );
-	const siteSettings = getSiteSettings( state, siteId );
-
-	if ( siteId && ! siteSettings && canCurrentUser( state, siteId, 'manage_options' ) ) {
-		store.dispatch( requestSiteSettings( siteId ) );
-	}
 
 	renderWithReduxStore(
 		createElement( Sharing, { contentComponent, path } ),


### PR DESCRIPTION
In this PR, we are removing sites-list from `my-sites/sharing/controller` file.

## Testing

Navigate to `/sharing/<site>` and clear app caches. Reload the page and try playing with it – working as before?
