### PR TITLE
External media sources: filter out new media items for all external sources

### DIFF
--- a/client/lib/media/list-store.js
+++ b/client/lib/media/list-store.js
@@ -149,10 +149,10 @@ MediaListStore.isItemMatchingQuery = function( siteId, item ) {
 		matches = item.title && -1 !== item.title.toLowerCase().indexOf( query.search.toLowerCase() );
 	}
 
-	if ( query.source === 'google_photos' && matches ) {
+	if ( !! query.source && matches ) {
 		// On uploading external images, the stores will receive the CREATE_MEDIA_ITEM  event
 		// and will update the list of media including the new one, but we don't want this new media
-		// to be shown in the google photos list - hence the filtering.
+		// to be shown in the external source's list - hence the filtering.
 		//
 		// One use case where this happened was:
 		//


### PR DESCRIPTION
On uploading external images, the stores will receive the
CREATE_MEDIA_ITEM  event and will update the list of media
including the new one, but we don't want this new media
to be shown in the external source's list.

This change filters out those new media items for all
external sources, not just the `google_photos` source.
This is in preparation for adding another external
source of media for stock photos.

Testing:

Go to site icon settings and open google modal.
Select an image and tap continue.
Cancel the editing process and you'll be send back to the google modal.
You should not see any duplicated images, or new media items.
