### PR TITLE
Jetpack connect: Consolidate routes

### DIFF
--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -47,11 +47,10 @@ export default function() {
 	page( '/jetpack/connect/store', controller.plansLanding );
 	page( '/jetpack/connect/store/:interval', controller.plansLanding );
 
-	page( '/jetpack/connect/vaultpress', '/jetpack/connect/store' );
-	page( '/jetpack/connect/vaultpress/:interval', redirectToStoreWithInterval );
-
-	page( '/jetpack/connect/akismet', '/jetpack/connect/store' );
-	page( '/jetpack/connect/akismet/:interval', redirectToStoreWithInterval );
+	page(
+		'/jetpack/connect/:from(akismet|vaultpress)/:interval(yearly|monthly)?',
+		redirectToStoreWithInterval
+	);
 
 	page(
 		'/jetpack/connect/:locale?',

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -38,8 +38,7 @@ export default function() {
 		controller.authorizeForm
 	);
 
-	page( '/jetpack/connect/store', controller.plansLanding );
-	page( '/jetpack/connect/store/:interval', controller.plansLanding );
+	page( '/jetpack/connect/store/:interval(yearly|monthly)?', controller.plansLanding );
 
 	page( '/jetpack/connect/:from(akismet|vaultpress)/:interval(yearly|monthly)?', ( { params } ) =>
 		page.redirect( `/jetpack/connect/store${ params.interval ? '/' + params.interval : '' }` )

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -10,12 +10,6 @@ import page from 'page';
 import controller from './controller';
 import { siteSelection } from 'my-sites/controller';
 
-const redirectToStoreWithInterval = context => {
-	const interval =
-		context && context.params && context.params.interval ? context.params.interval : '';
-	page.redirect( `/jetpack/connect/store/${ interval }` );
-};
-
 export default function() {
 	page(
 		'/jetpack/connect/:type(personal|premium|pro)/:interval(yearly|monthly)?',
@@ -47,9 +41,8 @@ export default function() {
 	page( '/jetpack/connect/store', controller.plansLanding );
 	page( '/jetpack/connect/store/:interval', controller.plansLanding );
 
-	page(
-		'/jetpack/connect/:from(akismet|vaultpress)/:interval(yearly|monthly)?',
-		redirectToStoreWithInterval
+	page( '/jetpack/connect/:from(akismet|vaultpress)/:interval(yearly|monthly)?', ( { params } ) =>
+		page.redirect( `/jetpack/connect/store${ params.interval ? '/' + params.interval : '' }` )
 	);
 
 	page(


### PR DESCRIPTION
Several routes can be merged.


Akismet and Vaultpress routes should redirect to store with interval if provided. Store and interval routes should continue to work. No functional changes with one caveat:

`/jetpack/connect/store` was more permissive before, matching anything as an interval with a final slash `/jetpack/connect/store/whateveryouwant`. This is stricter now.

## Testing
* https://calypso.live/jetpack/connect/store?branch=update/jetpack-connect/merge-routes
* https://calypso.live/jetpack/connect/store/monthly?branch=update/jetpack-connect/merge-routes
* https://calypso.live/jetpack/connect/store/yearly?branch=update/jetpack-connect/merge-routes
* https://calypso.live/jetpack/connect/vaultpress?branch=update/jetpack-connect/merge-routes
* https://calypso.live/jetpack/connect/vaultpress/monthly?branch=update/jetpack-connect/merge-routes
* https://calypso.live/jetpack/connect/vaultpress/yearly?branch=update/jetpack-connect/merge-routes
* https://calypso.live/jetpack/connect/akismet?branch=update/jetpack-connect/merge-routes
* https://calypso.live/jetpack/connect/akismet/monthly?branch=update/jetpack-connect/merge-routes
* https://calypso.live/jetpack/connect/akismet/yearly?branch=update/jetpack-connect/merge-routes