### PR TITLE
Me: Use Redux analytics instead of eventRecorder in Security2faBackupCodes

### DIFF
--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -19,7 +19,7 @@ import Security2faBackupCodesPrompt from 'me/security-2fa-backup-codes-prompt';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-class Security2faBackupCodes extends Component {
+class Security2faBackupCodes extends React.Component {
 	constructor( props ) {
 		super( props );
 		const printed = this.props.userSettings.getSetting( 'two_step_backup_codes_printed' );

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -5,7 +5,6 @@
  */
 
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -21,27 +20,26 @@ import Security2faBackupCodesList from 'me/security-2fa-backup-codes-list';
 import Notice from 'components/notice';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-const Security2faBackupCodes = createReactClass( {
-	displayName: 'Security2faBackupCodes',
+class Security2faBackupCodes extends Component {
+	constructor( props ) {
+		super( props );
+		const printed = this.props.userSettings.getSetting( 'two_step_backup_codes_printed' );
 
-	getInitialState: function() {
-		var printed = this.props.userSettings.getSetting( 'two_step_backup_codes_printed' );
-
-		return {
-			printed: printed,
+		this.state = {
+			printed,
 			verified: printed,
 			showPrompt: ! printed,
 			backupCodes: [],
 			generatingCodes: false,
 		};
-	},
+	}
 
-	handleGenerateButtonClick() {
+	handleGenerateButtonClick = () => {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on Generate New Backup Codes Button' );
 		this.onGenerate();
-	},
+	};
 
-	onGenerate: function() {
+	onGenerate = () => {
 		this.setState( {
 			generatingCodes: true,
 			verified: false,
@@ -49,9 +47,9 @@ const Security2faBackupCodes = createReactClass( {
 		} );
 
 		twoStepAuthorization.backupCodes( this.onRequestComplete );
-	},
+	};
 
-	onRequestComplete: function( error, data ) {
+	onRequestComplete = ( error, data ) => {
 		if ( error ) {
 			this.setState( {
 				lastError: this.props.translate(
@@ -65,24 +63,24 @@ const Security2faBackupCodes = createReactClass( {
 			backupCodes: data.codes,
 			generatingCodes: false,
 		} );
-	},
+	};
 
-	onNextStep: function() {
+	onNextStep = () => {
 		this.setState( {
 			backupCodes: [],
 			printed: true,
 		} );
-	},
+	};
 
-	onVerified: function() {
+	onVerified = () => {
 		this.setState( {
 			printed: true,
 			verified: true,
 			showPrompt: false,
 		} );
-	},
+	};
 
-	renderStatus: function() {
+	renderStatus() {
 		if ( ! this.state.printed ) {
 			return (
 				<Notice
@@ -111,9 +109,9 @@ const Security2faBackupCodes = createReactClass( {
 				text={ this.props.translate( 'Backup codes have been verified' ) }
 			/>
 		);
-	},
+	}
 
-	renderList: function() {
+	renderList() {
 		return (
 			<Security2faBackupCodesList
 				backupCodes={ this.state.backupCodes }
@@ -122,9 +120,9 @@ const Security2faBackupCodes = createReactClass( {
 				showList
 			/>
 		);
-	},
+	}
 
-	renderPrompt: function() {
+	renderPrompt() {
 		return (
 			<div>
 				<p>
@@ -140,9 +138,9 @@ const Security2faBackupCodes = createReactClass( {
 				{ this.state.showPrompt && <Security2faBackupCodesPrompt onSuccess={ this.onVerified } /> }
 			</div>
 		);
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<div className="security-2fa-backup-codes">
 				<SectionHeader label={ this.props.translate( 'Backup Codes' ) }>
@@ -161,8 +159,8 @@ const Security2faBackupCodes = createReactClass( {
 				</Card>
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default connect( null, {
 	recordGoogleEvent,

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:me:security:2fa-backup-codes' );
 
@@ -17,15 +18,13 @@ import Security2faBackupCodesPrompt from 'me/security-2fa-backup-codes-prompt';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
 import Card from 'components/card';
-import eventRecorder from 'me/event-recorder';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import Security2faBackupCodesList from 'me/security-2fa-backup-codes-list';
 import Notice from 'components/notice';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 const Security2faBackupCodes = createReactClass( {
 	displayName: 'Security2faBackupCodes',
-
-	mixins: [ eventRecorder ],
 
 	componentDidMount: function() {
 		debug( this.constructor.displayName + ' React component is mounted.' );
@@ -45,6 +44,11 @@ const Security2faBackupCodes = createReactClass( {
 			backupCodes: [],
 			generatingCodes: false,
 		};
+	},
+
+	handleGenerateButtonClick() {
+		this.props.recordGoogleEvent( 'Me', 'Clicked on Generate New Backup Codes Button' );
+		this.onGenerate();
 	},
 
 	onGenerate: function() {
@@ -155,7 +159,7 @@ const Security2faBackupCodes = createReactClass( {
 					<Button
 						compact
 						disabled={ this.state.generatingCodes || !! this.state.backupCodes.length }
-						onClick={ this.recordClickEvent( 'Generate New Backup Codes Button', this.onGenerate ) }
+						onClick={ this.handleGenerateButtonClick }
 					>
 						{ this.props.translate( 'Generate New Backup Codes' ) }
 					</Button>
@@ -170,4 +174,6 @@ const Security2faBackupCodes = createReactClass( {
 	},
 } );
 
-export default localize( Security2faBackupCodes );
+export default connect( null, {
+	recordGoogleEvent,
+} )( localize( Security2faBackupCodes ) );

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -8,8 +8,6 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:me:security:2fa-backup-codes' );
 
 /**
  * Internal dependencies
@@ -25,14 +23,6 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 
 const Security2faBackupCodes = createReactClass( {
 	displayName: 'Security2faBackupCodes',
-
-	componentDidMount: function() {
-		debug( this.constructor.displayName + ' React component is mounted.' );
-	},
-
-	componentWillUnmount: function() {
-		debug( this.constructor.displayName + ' React component will unmount.' );
-	},
 
 	getInitialState: function() {
 		var printed = this.props.userSettings.getSetting( 'two_step_backup_codes_printed' );

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -3,21 +3,20 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import Security2faBackupCodesPrompt from 'me/security-2fa-backup-codes-prompt';
-import SectionHeader from 'components/section-header';
 import Button from 'components/button';
 import Card from 'components/card';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import Security2faBackupCodesList from 'me/security-2fa-backup-codes-list';
 import Notice from 'components/notice';
+import SectionHeader from 'components/section-header';
+import Security2faBackupCodesList from 'me/security-2fa-backup-codes-list';
+import Security2faBackupCodesPrompt from 'me/security-2fa-backup-codes-prompt';
+import twoStepAuthorization from 'lib/two-step-authorization';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class Security2faBackupCodes extends Component {

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -35,10 +35,7 @@ class Security2faBackupCodes extends React.Component {
 
 	handleGenerateButtonClick = () => {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on Generate New Backup Codes Button' );
-		this.onGenerate();
-	};
 
-	onGenerate = () => {
 		this.setState( {
 			generatingCodes: true,
 			verified: false,


### PR DESCRIPTION
This PR refactors `Security2faBackupCodes ` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove all mixins, specifically `eventRecorder`.
* Convert from `createReactClass` to a `React.Component`.
* Remove some unnecessary debug code.
* Sort some imports 🔤 .

This PR should not introduce any visual changes.

Part of #20053.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me/security/two-step
* Verify you can observe the right analytics action being dispatched when the **Generate New Backup Codes** button is clicked.
* Verify everything else in the backup codes section works like it did before.