### PR TITLE
Me: Use Redux analytics instead of eventRecorder in Security2faSetupBackupCodes 

### DIFF
--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -9,8 +9,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:me:security:2fa-setup-backup-codes' );
 
 /**
  * Internal dependencies
@@ -30,12 +28,7 @@ const Security2faSetupBackupCodes = createReactClass( {
 	},
 
 	componentDidMount: function() {
-		debug( this.constructor.displayName + ' React component is mounted.' );
 		twoStepAuthorization.backupCodes( this.onRequestComplete );
-	},
-
-	componentWillUnmount: function() {
-		debug( this.constructor.displayName + ' React component will unmount.' );
 	},
 
 	getInitialState: function() {

--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -56,12 +56,11 @@ class Security2faSetupBackupCodes extends React.Component {
 	};
 
 	possiblyRenderError() {
-		var errorMessage;
 		if ( ! this.state.lastError ) {
 			return;
 		}
 
-		errorMessage = this.props.translate(
+		const errorMessage = this.props.translate(
 			'There was an error retrieving back up codes. Please {{supportLink}}contact support{{/supportLink}}',
 			{
 				components: {

--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -3,20 +3,19 @@
 /**
  * External dependencies
  */
-
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import React from 'react';
 
 /**
  * Internal dependencies
  */
+import Notice from 'components/notice';
 import Security2faBackupCodesList from 'me/security-2fa-backup-codes-list';
 import Security2faProgress from 'me/security-2fa-progress';
-import twoStepAuthorization from 'lib/two-step-authorization';
 import support from 'lib/url/support';
-import Notice from 'components/notice';
+import twoStepAuthorization from 'lib/two-step-authorization';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class Security2faSetupBackupCodes extends React.Component {

--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -5,6 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import createReactClass from 'create-react-class';
@@ -17,14 +18,12 @@ const debug = debugFactory( 'calypso:me:security:2fa-setup-backup-codes' );
 import Security2faBackupCodesList from 'me/security-2fa-backup-codes-list';
 import Security2faProgress from 'me/security-2fa-progress';
 import twoStepAuthorization from 'lib/two-step-authorization';
-import eventRecorder from 'me/event-recorder';
 import support from 'lib/url/support';
 import Notice from 'components/notice';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 const Security2faSetupBackupCodes = createReactClass( {
 	displayName: 'Security2faSetupBackupCodes',
-
-	mixins: [ eventRecorder ],
 
 	propTypes: {
 		onFinished: PropTypes.func.isRequired,
@@ -44,6 +43,10 @@ const Security2faSetupBackupCodes = createReactClass( {
 			backupCodes: [],
 			lastError: false,
 		};
+	},
+
+	getClickHandler( action ) {
+		return () => this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
 	},
 
 	onRequestComplete: function( error, data ) {
@@ -78,7 +81,7 @@ const Security2faSetupBackupCodes = createReactClass( {
 					supportLink: (
 						<a
 							href={ support.CALYPSO_CONTACT }
-							onClick={ this.recordClickEvent( 'No Backup Codes Contact Support Link' ) }
+							onClick={ this.getClickHandler( 'No Backup Codes Contact Support Link' ) }
 						/>
 					),
 				},
@@ -121,4 +124,6 @@ const Security2faSetupBackupCodes = createReactClass( {
 	},
 } );
 
-export default localize( Security2faSetupBackupCodes );
+export default connect( null, {
+	recordGoogleEvent,
+} )( localize( Security2faSetupBackupCodes ) );

--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies
@@ -20,29 +19,25 @@ import support from 'lib/url/support';
 import Notice from 'components/notice';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-const Security2faSetupBackupCodes = createReactClass( {
-	displayName: 'Security2faSetupBackupCodes',
+class Security2faSetupBackupCodes extends React.Component {
+	state = {
+		backupCodes: [],
+		lastError: false,
+	};
 
-	propTypes: {
+	static propTypes = {
 		onFinished: PropTypes.func.isRequired,
-	},
+	};
 
-	componentDidMount: function() {
+	componentDidMount() {
 		twoStepAuthorization.backupCodes( this.onRequestComplete );
-	},
+	}
 
-	getInitialState: function() {
-		return {
-			backupCodes: [],
-			lastError: false,
-		};
-	},
-
-	getClickHandler( action ) {
+	getClickHandler = action => {
 		return () => this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
-	},
+	};
 
-	onRequestComplete: function( error, data ) {
+	onRequestComplete = ( error, data ) => {
 		if ( error ) {
 			this.setState( {
 				lastError: this.props.translate(
@@ -55,13 +50,13 @@ const Security2faSetupBackupCodes = createReactClass( {
 		this.setState( {
 			backupCodes: data.codes,
 		} );
-	},
+	};
 
-	onFinished: function() {
+	onFinished = () => {
 		this.props.onFinished();
-	},
+	};
 
-	possiblyRenderError: function() {
+	possiblyRenderError() {
 		var errorMessage;
 		if ( ! this.state.lastError ) {
 			return;
@@ -82,9 +77,9 @@ const Security2faSetupBackupCodes = createReactClass( {
 		);
 
 		return <Notice showDismiss={ false } status="is-error" text={ errorMessage } />;
-	},
+	}
 
-	renderList: function() {
+	renderList() {
 		if ( this.state.lastError ) {
 			return null;
 		}
@@ -96,9 +91,9 @@ const Security2faSetupBackupCodes = createReactClass( {
 				showList
 			/>
 		);
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<div>
 				<Security2faProgress step={ 3 } />
@@ -114,8 +109,8 @@ const Security2faSetupBackupCodes = createReactClass( {
 				{ this.renderList() }
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default connect( null, {
 	recordGoogleEvent,


### PR DESCRIPTION
This PR refactors `Security2faSetupBackupCodes ` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove all mixins, specifically `eventRecorder`.
* Convert from `createReactClass` to a `React.Component`.
* Remove some unnecessary debug code.
* Sort some imports 🔤 .
* Remove `var` usages in favor of `const`/`let`.

This PR should not introduce any visual changes.

Part of #20053.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me/security/two-step
* Disable two step auth if it's enabled.
* Apply the following diff to your Calypso (see below)
* Refresh the page.
* Start the two-step auth setup process.
* On the last step where the codes are generated, verify the right analytics events are tracked when clicking the support link on the failure screen.
* Verify everything else in the backup codes / two factor auth process works like it did before.

Diff to make backup code generation fail:
```
diff --git a/client/lib/two-step-authorization/index.js b/client/lib/two-step-authorization/index.js
index cc0e2732a7..af89d9dbc6 100644
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -153,6 +153,8 @@ TwoStepAuthorization.prototype.sendSMSCode = function( callback ) {
  * Fetches a new set of backup codes by calling /me/two-step/backup-codes/new
  */
 TwoStepAuthorization.prototype.backupCodes = function( callback ) {
+       callback( 'Some error' );
+       return;
        wpcom.me().backupCodes(
                function( error, data ) {
                        if ( error ) {
```