### PR TITLE
Components: Cleanup eventRecorder mention from LanguagePicker readme

### DIFF
--- a/client/components/language-picker/README.md
+++ b/client/components/language-picker/README.md
@@ -74,6 +74,4 @@ in the `value` and `onChange` props of the component. Possible values are `value
 
 `onChange` - **optional** Handler called when the selected value is changed
 
-`onClick` - **optional** Handler called when the picker is clicked on. Useful for hooking
-in telemetry, e.g., the `eventRecorder.recordClickEvent` method.
-------------
+`onClick` - **optional** Handler called when the picker is clicked on.


### PR DESCRIPTION
This PR removes a mention of `eventRecorder` in the README of the `LanguagePicker` component.

Part of #20053.

No testing needed, just verify the sanity of this change.