### PR TITLE
Comments: Avoid redirect if page number is missing

### DIFF
--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -58,10 +58,7 @@ export const siteComments = context => {
 
 	const status = mapPendingStatusToUnapproved( params.status );
 
-	const pageNumber = sanitizeInt( query.page );
-	if ( ! pageNumber ) {
-		return changePage( path )( 1 );
-	}
+	const pageNumber = sanitizeInt( query.page ) || 1;
 
 	renderWithReduxStore(
 		<CommentsManagement
@@ -90,10 +87,7 @@ export const postComments = context => {
 		return page.redirect( `/comments/${ params.status }/${ siteFragment }` );
 	}
 
-	const pageNumber = sanitizeInt( query.page );
-	if ( ! pageNumber ) {
-		return changePage( path )( 1 );
-	}
+	const pageNumber = sanitizeInt( query.page ) || 1;
 
 	renderWithReduxStore(
 		<CommentsManagement


### PR DESCRIPTION
Fix #19971

Currently, if the `?page` query param is missing, we force-add it with a redirect.
This screws with the browser history, with a good old loop involved:

- User loads `/comments/all`
- Missing page! Redirect to `/comments/all?page=1`
- User hits browser's back button.
- Try to open `/comments/all`.
- Missing page! Redirect to `comments/all?page=1`.

This PR removes the redirect, and defaults the page number to 1 if the query param is missing.

### Testing instruction

- Open `/comments`.
- Make sure that when opening a list (in both site and post view) there is no `?page=1` appended to the URL. (Note: when changing page with the pagination buttons at the bottom of the page, it's totally fine to have `?page=1`)
- Try using the browser's back button and make sure it's never stuck in a redirect loop.