### PR TITLE
Me: Use Redux analytics instead of eventRecorder in MeSidebar

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -6,12 +6,9 @@
 
 import React from 'react';
 import createReactClass from 'create-react-class';
-import debugFactory from 'debug';
 import { connect } from 'react-redux';
 import { flow } from 'lodash';
 import { localize } from 'i18n-calypso';
-
-const debug = debugFactory( 'calypso:me:sidebar' );
 
 /**
  * Internal dependencies
@@ -35,10 +32,6 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 
 const MeSidebar = createReactClass( {
 	displayName: 'MeSidebar',
-
-	componentDidMount: function() {
-		debug( 'The MeSidebar React component is mounted.' );
-	},
 
 	onNavigate: function() {
 		this.props.setNextLayoutFocus( 'content' );

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -23,7 +23,6 @@ import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import config from 'config';
 import ProfileGravatar from 'me/profile-gravatar';
-import eventRecorder from 'me/event-recorder';
 import userFactory from 'lib/user';
 const user = userFactory();
 import userUtilities from 'lib/user/utils';
@@ -32,10 +31,10 @@ import purchasesPaths from 'me/purchases/paths';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { logoutUser } from 'state/login/actions';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 const MeSidebar = createReactClass( {
 	displayName: 'MeSidebar',
-	mixins: [ eventRecorder ],
 
 	componentDidMount: function() {
 		debug( 'The MeSidebar React component is mounted.' );
@@ -67,7 +66,7 @@ const MeSidebar = createReactClass( {
 			userUtilities.logout( redirect );
 		}
 
-		this.recordClickEvent( 'Sidebar Sign Out Link' );
+		this.props.recordGoogleEvent( 'Me', 'Clicked on Sidebar Sign Out Link' );
 	},
 
 	render: function() {
@@ -214,6 +213,7 @@ const enhance = flow(
 		} ),
 		{
 			logoutUser,
+			recordGoogleEvent,
 			setNextLayoutFocus,
 		}
 	)

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { connect } from 'react-redux';
 import { flow } from 'lodash';
@@ -12,22 +11,26 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
+import config from 'config';
+import ProfileGravatar from 'me/profile-gravatar';
+import purchasesPaths from 'me/purchases/paths';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarHeading from 'layout/sidebar/heading';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
-import config from 'config';
-import ProfileGravatar from 'me/profile-gravatar';
 import userFactory from 'lib/user';
-const user = userFactory();
 import userUtilities from 'lib/user/utils';
-import Button from 'components/button';
-import purchasesPaths from 'me/purchases/paths';
-import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { logoutUser } from 'state/login/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
+import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
+
+/**
+ * Module variables
+ */
+const user = userFactory();
 
 class MeSidebar extends React.Component {
 	onNavigate = () => {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -5,7 +5,6 @@
  */
 
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import { flow } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -30,15 +29,13 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { logoutUser } from 'state/login/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-const MeSidebar = createReactClass( {
-	displayName: 'MeSidebar',
-
-	onNavigate: function() {
+class MeSidebar extends React.Component {
+	onNavigate = () => {
 		this.props.setNextLayoutFocus( 'content' );
 		window.scrollTo( 0, 0 );
-	},
+	};
 
-	onSignOut: function() {
+	onSignOut = () => {
 		const currentUser = this.props.currentUser;
 
 		// If user is using en locale, redirect to app promo page on sign out
@@ -60,9 +57,9 @@ const MeSidebar = createReactClass( {
 		}
 
 		this.props.recordGoogleEvent( 'Me', 'Clicked on Sidebar Sign Out Link' );
-	},
+	};
 
-	render: function() {
+	render() {
 		const { context, translate } = this.props;
 		const filterMap = {
 			'/me': 'profile',
@@ -179,9 +176,9 @@ const MeSidebar = createReactClass( {
 				<SidebarFooter />
 			</Sidebar>
 		);
-	},
+	}
 
-	renderNextStepsItem: function( selected ) {
+	renderNextStepsItem( selected ) {
 		const { currentUser, translate } = this.props;
 
 		if ( config.isEnabled( 'me/next-steps' ) && currentUser && currentUser.site_count > 0 ) {
@@ -195,8 +192,8 @@ const MeSidebar = createReactClass( {
 				/>
 			);
 		}
-	},
-} );
+	}
+}
 
 const enhance = flow(
 	localize,

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -62,6 +62,22 @@ class MeSidebar extends React.Component {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on Sidebar Sign Out Link' );
 	};
 
+	renderNextStepsItem( selected ) {
+		const { currentUser, translate } = this.props;
+
+		if ( config.isEnabled( 'me/next-steps' ) && currentUser && currentUser.site_count > 0 ) {
+			return (
+				<SidebarItem
+					selected={ selected === 'next' }
+					link="/me/next"
+					label={ translate( 'Next Steps' ) }
+					icon="list-checkmark"
+					onNavigate={ this.onNavigate }
+				/>
+			);
+		}
+	}
+
 	render() {
 		const { context, translate } = this.props;
 		const filterMap = {
@@ -179,22 +195,6 @@ class MeSidebar extends React.Component {
 				<SidebarFooter />
 			</Sidebar>
 		);
-	}
-
-	renderNextStepsItem( selected ) {
-		const { currentUser, translate } = this.props;
-
-		if ( config.isEnabled( 'me/next-steps' ) && currentUser && currentUser.site_count > 0 ) {
-			return (
-				<SidebarItem
-					selected={ selected === 'next' }
-					link="/me/next"
-					label={ translate( 'Next Steps' ) }
-					icon="list-checkmark"
-					onNavigate={ this.onNavigate }
-				/>
-			);
-		}
 	}
 }
 


### PR DESCRIPTION
This PR refactors `MeSidebar ` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove all mixins, specifically `eventRecorder`.
* Convert from `createReactClass` to a `React.Component`.
* Remove some unnecessary debug code.
* Sort some imports 🔤 .
* Reorder some methods.

This PR should not introduce any visual changes.

Part of #20053.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me/
* Verify the right analytics events are tracked when clicking the logout link.
* Navigate to different pages in `/me` and verify everything works properly.
* Verify everything else in the /me sidebar works like it did before.