### PR TITLE
Reader: fix Discover site attribution icon

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -24,12 +24,7 @@ import { fetchPost } from 'lib/feed-post-store/actions';
 import ReaderFullPostHeader from './header';
 import AuthorCompactProfile from 'blocks/author-compact-profile';
 import LikeButton from 'reader/like-button';
-import {
-	isDiscoverPost,
-	isDiscoverSitePick,
-	getSourceFollowUrl,
-	getSiteUrl,
-} from 'reader/discover/helper';
+import { isDiscoverPost, isDiscoverSitePick } from 'reader/discover/helper';
 import DiscoverSiteAttribution from 'reader/discover/site-attribution';
 import DailyPostButton from 'blocks/daily-post-button';
 import { isDailyPostChallengeOrPrompt } from 'blocks/daily-post-button/helper';
@@ -398,13 +393,7 @@ export class FullPostView extends React.Component {
 								! isDiscoverPost( post ) && (
 									<PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
 								) }
-							{ isDiscoverSitePick( post ) && (
-								<DiscoverSiteAttribution
-									attribution={ post.discover_metadata.attribution }
-									siteUrl={ getSiteUrl( post ) }
-									followUrl={ getSourceFollowUrl( post ) }
-								/>
-							) }
+							{ isDiscoverSitePick( post ) && <DiscoverSiteAttribution post={ post } /> }
 							{ isDailyPostChallengeOrPrompt( post ) && (
 								<DailyPostButton post={ post } site={ site } />
 							) }

--- a/client/blocks/site-icon/index.jsx
+++ b/client/blocks/site-icon/index.jsx
@@ -27,6 +27,7 @@ function SiteIcon( { siteId, site, iconUrl, size, imgSize, isTransientIcon } ) {
 	const classes = classNames( 'site-icon', {
 		'is-blank': ! iconSrc,
 		'is-transient': isTransientIcon,
+		'has-icon': !! iconSrc,
 	} );
 
 	const style = {

--- a/client/blocks/site-icon/index.jsx
+++ b/client/blocks/site-icon/index.jsx
@@ -27,7 +27,6 @@ function SiteIcon( { siteId, site, iconUrl, size, imgSize, isTransientIcon } ) {
 	const classes = classNames( 'site-icon', {
 		'is-blank': ! iconSrc,
 		'is-transient': isTransientIcon,
-		'has-icon': !! iconSrc,
 	} );
 
 	const style = {

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { get } from 'lodash';
 import path from 'path';
@@ -17,6 +18,8 @@ import { getLinkProps } from './helper';
 import { recordFollowToggle, recordSiteClick } from './stats';
 import { getSiteUrl, getSourceFollowUrl, getSourceData } from 'reader/discover/helper';
 import SiteIcon from 'blocks/site-icon';
+import { getSite } from 'state/reader/sites/selectors';
+import QueryReaderSite from 'components/data/query-reader-site';
 
 class DiscoverSiteAttribution extends React.Component {
 	static propTypes = {
@@ -28,11 +31,11 @@ class DiscoverSiteAttribution extends React.Component {
 	onFollowToggle = isFollowing => recordFollowToggle( isFollowing, this.props.siteUrl );
 
 	render() {
-		const { post } = this.props;
+		const { post, site } = this.props;
 		const attribution = get( post, 'discover_metadata.attribution' );
 		const siteUrl = getSiteUrl( post );
 		const followUrl = getSourceFollowUrl( post );
-		const { blogId } = getSourceData( post );
+		const { blogId: siteId } = getSourceData( post );
 		const classes = classNames( 'discover-attribution is-site', {
 			'is-missing-avatar': ! attribution.avatar_url,
 		} );
@@ -47,7 +50,7 @@ class DiscoverSiteAttribution extends React.Component {
 
 		return (
 			<div className={ classes }>
-				{ avatarUrl ? (
+				{ avatarUrl && (
 					<img
 						className="gravatar"
 						src={ encodeURI( attribution.avatar_url ) }
@@ -55,9 +58,9 @@ class DiscoverSiteAttribution extends React.Component {
 						width="20"
 						height="20"
 					/>
-				) : (
-					<SiteIcon siteId={ blogId } size={ 20 } />
 				) }
+				{ ! avatarUrl && siteId && <QueryReaderSite siteId={ siteId } /> }
+				{ ! avatarUrl && <SiteIcon site={ site } size={ 20 } /> }
 				<span>
 					<a
 						{ ...siteLinkProps }
@@ -80,4 +83,9 @@ class DiscoverSiteAttribution extends React.Component {
 	}
 }
 
-export default DiscoverSiteAttribution;
+export default connect( ( state, ownProps ) => {
+	const { blogId: siteId } = getSourceData( ownProps.post );
+	return {
+		site: getSite( state, siteId ),
+	};
+} )( DiscoverSiteAttribution );

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -36,9 +36,6 @@ class DiscoverSiteAttribution extends React.Component {
 		const siteUrl = getSiteUrl( post );
 		const followUrl = getSourceFollowUrl( post );
 		const { blogId: siteId } = getSourceData( post );
-		const classes = classNames( 'discover-attribution is-site', {
-			'is-missing-avatar': ! attribution.avatar_url,
-		} );
 		const siteLinkProps = getLinkProps( siteUrl );
 		const siteClasses = classNames( 'discover-attribution__blog ignore-click' );
 
@@ -48,8 +45,9 @@ class DiscoverSiteAttribution extends React.Component {
 			avatarUrl = null;
 		}
 
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<div className={ classes }>
+			<div className="discover__attribution is-site">
 				{ avatarUrl && (
 					<img
 						className="gravatar"
@@ -80,6 +78,7 @@ class DiscoverSiteAttribution extends React.Component {
 				) }
 			</div>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -6,8 +6,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { get } from 'lodash';
-import path from 'path';
+import { get, endsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -41,7 +40,7 @@ class DiscoverSiteAttribution extends React.Component {
 
 		let avatarUrl = attribution.avatar_url;
 		// Drop default avatar
-		if ( path.basename( avatarUrl ) === 'defaultavatar.png' ) {
+		if ( endsWith( avatarUrl, 'defaultavatar.png' ) ) {
 			avatarUrl = null;
 		}
 
@@ -57,7 +56,7 @@ class DiscoverSiteAttribution extends React.Component {
 						height="20"
 					/>
 				) }
-				{ ! avatarUrl && siteId && <QueryReaderSite siteId={ siteId } /> }
+				{ ! avatarUrl && siteId && ! site && <QueryReaderSite siteId={ siteId } /> }
 				{ ! avatarUrl && <SiteIcon site={ site } size={ 20 } /> }
 				<span>
 					<a

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -58,7 +58,7 @@ class DiscoverSiteAttribution extends React.Component {
 				) }
 				{ ! avatarUrl && siteId && ! site && <QueryReaderSite siteId={ siteId } /> }
 				{ ! avatarUrl && <SiteIcon site={ site } size={ 20 } /> }
-				<span>
+				<span className="discover-attribution__site-title">
 					<a
 						{ ...siteLinkProps }
 						className={ siteClasses }

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -46,7 +46,7 @@ class DiscoverSiteAttribution extends React.Component {
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<div className="discover__attribution is-site">
+			<div className="discover-attribution is-site">
 				{ avatarUrl && (
 					<img
 						className="gravatar"

--- a/client/reader/discover/style.scss
+++ b/client/reader/discover/style.scss
@@ -46,11 +46,16 @@
 		margin-right: 6px;
 	}
 
-	.gridicons-globe {
-		vertical-align: text-bottom;
-		background-color: lighten( $gray, 20% );
-		color: $white;
+	.site-icon {
 		margin-right: 6px;
+		float: left;
+	}
+
+	.site-icon:not(.has-icon) {
+		background: lighten( $gray, 20% );
+		.gridicon {
+			color: $white;
+		}
 	}
 
 	.follow-button {

--- a/client/reader/discover/style.scss
+++ b/client/reader/discover/style.scss
@@ -49,13 +49,14 @@
 	.site-icon {
 		margin-right: 6px;
 		float: left;
-	}
-
-	.site-icon:not(.has-icon) {
 		background: lighten( $gray, 20% );
 		.gridicon {
 			color: $white;
 		}
+	}
+
+	.site-icon:not(.is-blank) {
+		background: inherit;
 	}
 
 	.follow-button {

--- a/client/reader/discover/style.scss
+++ b/client/reader/discover/style.scss
@@ -19,12 +19,7 @@
 		max-height: 13px * 1.6;
 		overflow: hidden;
 		position: relative;
-		width: calc( 100% - 95px );
-
-		&::after {
-			@include long-content-fade( $size: 35px );
-
-		}
+		max-width: calc( 100% - 95px );
 	}
 
 	.gravatar {

--- a/client/reader/discover/style.scss
+++ b/client/reader/discover/style.scss
@@ -6,6 +6,8 @@
 	position: relative;
 	margin-top: 13px;
 	margin-bottom: 8px;
+	display: flex;
+	align-items: center;
 
 	&.is-site {
 		margin-top: 15px;
@@ -27,7 +29,6 @@
 	.gravatar {
 		background: $gray-light;
 		position: relative;
-			top: 6px;
 		margin: 1px 6px 1px 0;
 	}
 
@@ -48,7 +49,6 @@
 
 	.site-icon {
 		margin-right: 6px;
-		float: left;
 		background: lighten( $gray, 20% );
 		.gridicon {
 			color: $white;
@@ -63,10 +63,8 @@
 		position: static;
 		border: none;
 		padding: 0;
-		vertical-align: text-bottom;
 		color: lighten( $gray, 10% );
 		font-size: 13px;
-		line-height: 16px;
 		background: transparent;
 		float: none;
 

--- a/client/reader/discover/style.scss
+++ b/client/reader/discover/style.scss
@@ -1,16 +1,30 @@
 .is-reader-page .discover-attribution {
+	align-items: flex-start;
+	display: flex;
+	color: $gray;
 	font-size: 13px;
 	font-family: $sans;
-	text-transform: lowercase;
-	color: $gray;
-	position: relative;
-	margin-top: 13px;
 	margin-bottom: 8px;
-	display: flex;
-	align-items: center;
+	margin-top: 13px;
+	position: relative;
+	text-transform: lowercase;
 
 	&.is-site {
 		margin-top: 15px;
+	}
+
+	.discover-attribution__site-title {
+		flex-shrink: 0;
+		line-height: 1.6;
+		max-height: 13px * 1.6;
+		overflow: hidden;
+		position: relative;
+		width: calc( 100% - 95px );
+
+		&::after {
+			@include long-content-fade( $size: 35px );
+
+		}
 	}
 
 	.gravatar {
@@ -48,13 +62,14 @@
 	}
 
 	.follow-button {
-		position: static;
-		border: none;
-		padding: 0;
-		color: lighten( $gray, 10% );
-		font-size: 13px;
 		background: transparent;
+		border: 0;
+		color: lighten( $gray, 10% );
 		float: none;
+		font-size: 13px;
+		padding: 0;
+		position: relative;
+			top: -1px;
 
 		&.is-following {
 			color: $alert-green;

--- a/client/reader/discover/style.scss
+++ b/client/reader/discover/style.scss
@@ -13,19 +13,6 @@
 		margin-top: 15px;
 	}
 
-	.gridicons-arrow-right {
-		height: 12px;
-		width: 12px;
-		fill: $white;
-		background: $gray;
-		padding: 4px;
-		border-radius: 100%;
-		position: relative;
-			top: 6px;
-		margin-right: 6px;
-
-	}
-
 	.gravatar {
 		background: $gray-light;
 		position: relative;
@@ -50,6 +37,7 @@
 	.site-icon {
 		margin-right: 6px;
 		background: lighten( $gray, 20% );
+
 		.gridicon {
 			color: $white;
 		}


### PR DESCRIPTION
Fixes #19798, in which @kjellr notes that we are displaying a default WordPress site icon for the Discover attribution line in full post, even in cases where we appear to have the right site icon elsewhere in Reader.

<img width="314" alt="32838828-41099eb0-c9e0-11e7-9196-fd820b759ad0" src="https://user-images.githubusercontent.com/17325/33213329-0c9468fe-d11f-11e7-97b6-9ad537a886fa.png">

This PR introduces two changes:
- discard the default avatar if is provided by the API
- fallback to the site icon if we don't have an avatar

The resulting selection order for site avatars is:

1. Discover attribution avatar URL (unless it's the default avatar)
2. Site icon
3. Globe gridicon

### To test

Here's a post with an attribution avatar (should display as before):

http://calypso.localhost:3000/read/blogs/53424024/posts/30475

<img width="288" alt="screen shot 2017-11-24 at 15 08 18" src="https://user-images.githubusercontent.com/17325/33215870-5458b44c-d129-11e7-890e-d22dc5c4271d.png">

Here are two posts with a site icon used as fallback:

http://calypso.localhost:3000/read/blogs/53424024/posts/30360
http://calypso.localhost:3000/read/blogs/53424024/posts/29663

<img width="333" alt="screen shot 2017-11-24 at 15 09 06" src="https://user-images.githubusercontent.com/17325/33215898-72087b6c-d129-11e7-8b85-49189230c53c.png">

And finally, here's a post with neither an attribution avatar nor a site icon:

http://calypso.localhost:3000/read/blogs/53424024/posts/29632

<img width="259" alt="screen shot 2017-11-24 at 15 09 45" src="https://user-images.githubusercontent.com/17325/33215915-86ac5b74-d129-11e7-9198-c7abe37f096e.png">



