### PR TITLE
Comments: Fix View Post label visibility

### DIFF
--- a/client/components/header-cake/README.md
+++ b/client/components/header-cake/README.md
@@ -23,4 +23,4 @@ The "header cake" component should be used at the top of an item's detail page. 
 * `actionHref` - You can optionally add a button to the right side of the header, this the link on that button
 * `actionIcon` - You can optionally add a button to the right side of the header, this is the Gridicon used
 * `actionOnClick` - You can optionally add a button to the right side of the header, this is called onClick of that button
-* `showActionTextOnMobile` - Force showing the right button text on small screens
+* `alwaysShowActionText` - Force showing the right button text instead of hiding it on small screens

--- a/client/components/header-cake/README.md
+++ b/client/components/header-cake/README.md
@@ -23,3 +23,4 @@ The "header cake" component should be used at the top of an item's detail page. 
 * `actionHref` - You can optionally add a button to the right side of the header, this the link on that button
 * `actionIcon` - You can optionally add a button to the right side of the header, this is the Gridicon used
 * `actionOnClick` - You can optionally add a button to the right side of the header, this is called onClick of that button
+* `showActionTextOnMobile` - Force showing the right button text on small screens

--- a/client/components/header-cake/back.jsx
+++ b/client/components/header-cake/back.jsx
@@ -27,16 +27,16 @@ const HIDE_BACK_CRITERIA = {
 
 class HeaderCakeBack extends Component {
 	static propTypes = {
-		href: PropTypes.string,
 		onClick: PropTypes.func,
+		href: PropTypes.string,
 		text: PropTypes.string,
 		spacer: PropTypes.bool,
 		alwaysShowActionText: PropTypes.bool,
 	};
 
 	static defaultProps = {
-		disabled: false,
 		spacer: false,
+		disabled: false,
 		alwaysShowActionText: false,
 	};
 

--- a/client/components/header-cake/back.jsx
+++ b/client/components/header-cake/back.jsx
@@ -30,14 +30,14 @@ class HeaderCakeBack extends Component {
 		href: PropTypes.string,
 		onClick: PropTypes.func,
 		text: PropTypes.string,
-		showTextOnMobile: PropTypes.bool,
 		spacer: PropTypes.bool,
+		alwaysShowActionText: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		disabled: false,
-		showTextOnMobile: false,
 		spacer: false,
+		alwaysShowActionText: false,
 	};
 
 	state = {
@@ -61,7 +61,7 @@ class HeaderCakeBack extends Component {
 
 	hideText( text ) {
 		if (
-			! this.props.showTextOnMobile &&
+			! this.props.alwaysShowActionText &&
 			( ( this.state.windowWidth <= HIDE_BACK_CRITERIA.windowWidth &&
 				text.length >= HIDE_BACK_CRITERIA.characterLength ) ||
 				this.state.windowWidth <= 300 )

--- a/client/components/header-cake/back.jsx
+++ b/client/components/header-cake/back.jsx
@@ -27,15 +27,17 @@ const HIDE_BACK_CRITERIA = {
 
 class HeaderCakeBack extends Component {
 	static propTypes = {
-		onClick: PropTypes.func,
 		href: PropTypes.string,
+		onClick: PropTypes.func,
 		text: PropTypes.string,
+		showTextOnMobile: PropTypes.bool,
 		spacer: PropTypes.bool,
 	};
 
 	static defaultProps = {
-		spacer: false,
 		disabled: false,
+		showTextOnMobile: false,
+		spacer: false,
 	};
 
 	state = {
@@ -59,9 +61,10 @@ class HeaderCakeBack extends Component {
 
 	hideText( text ) {
 		if (
-			( this.state.windowWidth <= HIDE_BACK_CRITERIA.windowWidth &&
+			! this.props.showTextOnMobile &&
+			( ( this.state.windowWidth <= HIDE_BACK_CRITERIA.windowWidth &&
 				text.length >= HIDE_BACK_CRITERIA.characterLength ) ||
-			this.state.windowWidth <= 300
+				this.state.windowWidth <= 300 )
 		) {
 			return true;
 		}

--- a/client/components/header-cake/index.jsx
+++ b/client/components/header-cake/index.jsx
@@ -24,7 +24,7 @@ export default class HeaderCake extends Component {
 			actionIcon,
 			actionHref,
 			actionOnClick,
-			showActionTextOnMobile,
+			alwaysShowActionText,
 		} = this.props;
 		const classes = classNames( 'header-cake', this.props.className, {
 			'is-compact': this.props.isCompact,
@@ -44,7 +44,7 @@ export default class HeaderCake extends Component {
 						href={ actionHref || backHref }
 						onClick={ actionOnClick }
 						icon={ actionIcon }
-						showTextOnMobile={ showActionTextOnMobile }
+						alwaysShowActionText={ alwaysShowActionText }
 						spacer={ ! actionOnClick }
 					/>
 				) }
@@ -65,10 +65,10 @@ HeaderCake.propTypes = {
 	actionHref: PropTypes.string,
 	actionIcon: PropTypes.string,
 	actionOnClick: PropTypes.func,
-	showActionTextOnMobile: PropTypes.bool,
+	alwaysShowActionText: PropTypes.bool,
 };
 
 HeaderCake.defaultProps = {
 	isCompact: false,
-	showActionTextOnMobile: false,
+	alwaysShowActionText: false,
 };

--- a/client/components/header-cake/index.jsx
+++ b/client/components/header-cake/index.jsx
@@ -24,6 +24,7 @@ export default class HeaderCake extends Component {
 			actionIcon,
 			actionHref,
 			actionOnClick,
+			showActionTextOnMobile,
 		} = this.props;
 		const classes = classNames( 'header-cake', this.props.className, {
 			'is-compact': this.props.isCompact,
@@ -43,6 +44,7 @@ export default class HeaderCake extends Component {
 						href={ actionHref || backHref }
 						onClick={ actionOnClick }
 						icon={ actionIcon }
+						showTextOnMobile={ showActionTextOnMobile }
 						spacer={ ! actionOnClick }
 					/>
 				) }
@@ -63,8 +65,10 @@ HeaderCake.propTypes = {
 	actionHref: PropTypes.string,
 	actionIcon: PropTypes.string,
 	actionOnClick: PropTypes.func,
+	showActionTextOnMobile: PropTypes.bool,
 };
 
 HeaderCake.defaultProps = {
 	isCompact: false,
+	showActionTextOnMobile: false,
 };

--- a/client/my-sites/comments/comment-list/comment-list-header.jsx
+++ b/client/my-sites/comments/comment-list/comment-list-header.jsx
@@ -48,7 +48,7 @@ export const CommentListHeader = ( {
 				actionOnClick={ recordReaderArticleOpened }
 				actionText={ translate( 'View Post' ) }
 				backHref={ `/comments/all/${ siteSlug }` }
-				showActionTextOnMobile
+				alwaysShowActionText
 			>
 				<div className="comment-list__header-title">
 					{ translate( 'Comments on {{span}}%(postTitle)s{{/span}}', {

--- a/client/my-sites/comments/comment-list/comment-list-header.jsx
+++ b/client/my-sites/comments/comment-list/comment-list-header.jsx
@@ -48,6 +48,7 @@ export const CommentListHeader = ( {
 				actionOnClick={ recordReaderArticleOpened }
 				actionText={ translate( 'View Post' ) }
 				backHref={ `/comments/all/${ siteSlug }` }
+				showActionTextOnMobile
 			>
 				<div className="comment-list__header-title">
 					{ translate( 'Comments on {{span}}%(postTitle)s{{/span}}', {

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -94,7 +94,7 @@
 }
 
 @include breakpoint( '<480px' ) {
-	.comment-list__header .header-cake__back.button.is-borderless.is-compact .gridicon {
+	.comment-list__header .header-cake__back.button.is-borderless.is-compact .gridicons-visible {
 		display: block;
 		margin: 0 auto;
 		top: 0;

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -93,6 +93,14 @@
 	white-space: nowrap;
 }
 
+@include breakpoint( '<480px' ) {
+	.comment-list__header .header-cake__back.button.is-borderless.is-compact .gridicon {
+		display: block;
+		margin: 0 auto;
+		top: 0;
+	}
+}
+
 .comment-list .pagination {
 	margin-top: 16px;
 }


### PR DESCRIPTION
Fix #19969

Forces the "View Post" label visibility on small screens by adding a new `showActionTextOnMobile` prop to the `HeaderCake` component.

| Before | After |
| --- | --- |
| <img width="414" alt="screen shot 2017-11-24 at 15 03 29" src="https://user-images.githubusercontent.com/2070010/33215811-06f01470-d129-11e7-9217-fe334b178424.png"> | <img width="416" alt="screen shot 2017-11-24 at 15 05 07" src="https://user-images.githubusercontent.com/2070010/33215810-06d09848-d129-11e7-98b7-aeef3c4b7551.png"> |

### Testing instructions

- Open `/comments`.
- Navigate to the post view by clicking on the post title of a comment.
- Make sure that in the header, the "View Post" label is shown at any screen size.