### PR TITLE
Plans: adjust plan buttons highlighting on the Plans page when redirected from upgrade nudges

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -25,6 +25,7 @@ import {
 	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_PREMIUM_MONTHLY,
 } from 'lib/plans/constants';
+import { addQueryArgs } from 'lib/url';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { getValidFeatureKeys } from 'lib/plans';
@@ -65,20 +66,18 @@ class Banner extends Component {
 	};
 
 	getHref() {
-		const { feature, href, plan, siteSlug } = this.props;
+		const { feature, plan, siteSlug } = this.props;
 
-		//rewrite using addQueryArgs
-		if ( ! href && siteSlug ) {
-			if ( feature && plan ) {
-				return `/plans/${ siteSlug }?feature=${ feature }&plan=${ plan }`;
-			}
-			if ( feature ) {
-				return `/plans/${ siteSlug }?feature=${ feature }`;
-			}
-			if ( plan ) {
-				return `/plans/${ siteSlug }?plan=${ plan }`;
-			}
-		}
+		const baseUrl = `/plans/${ siteSlug }`;
+
+		const href = addQueryArgs(
+			{
+				feature: feature,
+				plan: plan,
+			},
+			baseUrl
+		);
+
 		return href;
 	}
 

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -69,11 +69,32 @@ class Banner extends Component {
 		const { feature, plan, siteSlug } = this.props;
 
 		const baseUrl = `/plans/${ siteSlug }`;
+		let selectedPlan = 'Personal';
+		switch ( plan ) {
+			case 'jetpack_business':
+				selectedPlan = 'Professional';
+				break;
+			case 'jetpack_premium':
+				selectedPlan = 'Premium';
+				break;
+			case 'jetpack_personal':
+				selectedPlan = 'Personal';
+				break;
+			case 'business-bundle':
+				selectedPlan = 'Business';
+				break;
+			case 'value_bundle':
+				selectedPlan = 'Premium';
+				break;
+			case 'personal_bundle':
+				selectedPlan = 'Personal';
+				break;
+		}
 
 		const href = addQueryArgs(
 			{
 				feature: feature,
-				plan: plan,
+				plan: selectedPlan,
 			},
 			baseUrl
 		);

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -65,13 +65,19 @@ class Banner extends Component {
 	};
 
 	getHref() {
-		const { href, feature, siteSlug } = this.props;
+		const { feature, href, plan, siteSlug } = this.props;
 
+		//rewrite using addQueryArgs
 		if ( ! href && siteSlug ) {
+			if ( feature && plan ) {
+				return `/plans/${ siteSlug }?feature=${ feature }&plan=${ plan }`;
+			}
 			if ( feature ) {
 				return `/plans/${ siteSlug }?feature=${ feature }`;
 			}
-			return `/plans/${ siteSlug }`;
+			if ( plan ) {
+				return `/plans/${ siteSlug }?plan=${ plan }`;
+			}
 		}
 		return href;
 	}

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -68,35 +68,12 @@ class Banner extends Component {
 	getHref() {
 		const { feature, plan, siteSlug } = this.props;
 
-		const baseUrl = `/plans/${ siteSlug }`;
-		let selectedPlan = 'Personal';
-		switch ( plan ) {
-			case 'jetpack_business':
-				selectedPlan = 'Professional';
-				break;
-			case 'jetpack_premium':
-				selectedPlan = 'Premium';
-				break;
-			case 'jetpack_personal':
-				selectedPlan = 'Personal';
-				break;
-			case 'business-bundle':
-				selectedPlan = 'Business';
-				break;
-			case 'value_bundle':
-				selectedPlan = 'Premium';
-				break;
-			case 'personal_bundle':
-				selectedPlan = 'Personal';
-				break;
-		}
-
 		const href = addQueryArgs(
 			{
-				feature: feature,
-				plan: selectedPlan,
+				feature,
+				plan,
 			},
-			baseUrl
+			`/plans/${ siteSlug }`
 		);
 
 		return href;

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -66,16 +66,21 @@ class Banner extends Component {
 	};
 
 	getHref() {
-		const { feature, plan, siteSlug } = this.props;
+		const { feature, href, plan, siteSlug } = this.props;
 
-		const href = addQueryArgs(
-			{
-				feature,
-				plan,
-			},
-			`/plans/${ siteSlug }`
-		);
-
+		if ( ! href && siteSlug ) {
+			const baseUrl = `/plans/${ siteSlug }`;
+			if ( feature || plan ) {
+				return addQueryArgs(
+					{
+						feature,
+						plan,
+					},
+					baseUrl
+				);
+			}
+			return baseUrl;
+		}
 		return href;
 	}
 

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -21,33 +21,56 @@ import { getPlanClass, isMonthly } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 const PlanFeaturesActions = ( {
+	available = true,
 	canPurchase,
 	className,
-	available = true,
+	currentSitePlan,
 	current = false,
-	primaryUpgrade = false,
 	freePlan = false,
-	onUpgradeClick = noop,
+	manageHref,
+	isLandingPage,
 	isPlaceholder = false,
 	isPopular,
 	isInSignup,
-	translate,
-	manageHref,
-	isLandingPage,
+	onUpgradeClick = noop,
 	planName,
-	currentSitePlan,
 	planType,
+	primaryUpgrade = false,
+	selectedPlan,
 	recordTracksEvent: trackTracksEvent,
+	translate,
 } ) => {
+	const decodeSelectedPlan = () => {
+		if ( selectedPlan === 'jetpack_business' ) {
+			selectedPlan = 'Professional';
+		}
+		if ( selectedPlan === 'jetpack_premium' ) {
+			selectedPlan = 'Premium';
+		}
+		if ( selectedPlan === 'jetpack_personal' ) {
+			selectedPlan = 'Personal';
+		}
+	};
+	decodeSelectedPlan();
+
 	let upgradeButton;
-	const classes = classNames(
-		'plan-features__actions-button',
-		{
-			'is-current': current,
-			'is-primary': ( primaryUpgrade && ! isPlaceholder ) || isPopular,
-		},
-		className
-	);
+	const classes = selectedPlan
+		? classNames(
+				'plan-features__actions-button',
+				{
+					'is-current': current,
+					'is-primary': planName === selectedPlan,
+				},
+				className
+			)
+		: classNames(
+				'plan-features__actions-button',
+				{
+					'is-current': current,
+					'is-primary': ( primaryUpgrade && ! isPlaceholder ) || isPopular,
+				},
+				className
+			);
 
 	if ( current && ! isInSignup ) {
 		upgradeButton = (
@@ -105,16 +128,17 @@ const PlanFeaturesActions = ( {
 };
 
 PlanFeaturesActions.propTypes = {
+	available: PropTypes.bool,
 	canPurchase: PropTypes.bool.isRequired,
 	className: PropTypes.string,
-	primaryUpgrade: PropTypes.bool,
 	current: PropTypes.bool,
-	available: PropTypes.bool,
-	onUpgradeClick: PropTypes.func,
 	freePlan: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
 	isLandingPage: PropTypes.bool,
+	onUpgradeClick: PropTypes.func,
 	planType: PropTypes.string,
+	primaryUpgrade: PropTypes.bool,
+	selectedPlan: PropTypes.string,
 };
 
 export default connect(

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -40,19 +40,6 @@ const PlanFeaturesActions = ( {
 	recordTracksEvent: trackTracksEvent,
 	translate,
 } ) => {
-	const decodeSelectedPlan = () => {
-		if ( selectedPlan === 'jetpack_business' ) {
-			selectedPlan = 'Professional';
-		}
-		if ( selectedPlan === 'jetpack_premium' ) {
-			selectedPlan = 'Premium';
-		}
-		if ( selectedPlan === 'jetpack_personal' ) {
-			selectedPlan = 'Personal';
-		}
-	};
-	decodeSelectedPlan();
-
 	let upgradeButton;
 	const classes = selectedPlan
 		? classNames(

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -42,23 +42,16 @@ const PlanFeaturesActions = ( {
 } ) => {
 	let upgradeButton;
 
-	const classes = selectedPlan
-		? classNames(
-				'plan-features__actions-button',
-				{
-					'is-current': current,
-					'is-primary': planType === selectedPlan,
-				},
-				className
-			)
-		: classNames(
-				'plan-features__actions-button',
-				{
-					'is-current': current,
-					'is-primary': ( primaryUpgrade && ! isPlaceholder ) || isPopular,
-				},
-				className
-			);
+	const classes = classNames(
+		'plan-features__actions-button',
+		{
+			'is-current': current,
+			'is-primary': selectedPlan
+				? planType === selectedPlan
+				: ( primaryUpgrade && ! isPlaceholder ) || isPopular,
+		},
+		className
+	);
 
 	if ( current && ! isInSignup ) {
 		upgradeButton = (

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -41,6 +41,7 @@ const PlanFeaturesActions = ( {
 	translate,
 } ) => {
 	let upgradeButton;
+
 	const classes = selectedPlan
 		? classNames(
 				'plan-features__actions-button',

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -47,7 +47,7 @@ const PlanFeaturesActions = ( {
 				'plan-features__actions-button',
 				{
 					'is-current': current,
-					'is-primary': planName === selectedPlan,
+					'is-primary': planType === selectedPlan,
 				},
 				className
 			)

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -297,7 +297,14 @@ class PlanFeatures extends Component {
 	}
 
 	renderTopButtons() {
-		const { canPurchase, isLandingPage, planProperties, isInSignup, site } = this.props;
+		const {
+			canPurchase,
+			isInSignup,
+			isLandingPage,
+			planProperties,
+			selectedPlan,
+			site,
+		} = this.props;
 
 		return map( planProperties, properties => {
 			const {
@@ -334,6 +341,7 @@ class PlanFeatures extends Component {
 						isLandingPage={ isLandingPage }
 						manageHref={ `/plans/my-plan/${ site.slug }` }
 						planType={ planName }
+						selectedPlan={ selectedPlan }
 					/>
 				</td>
 			);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -416,7 +416,14 @@ class PlanFeatures extends Component {
 	}
 
 	renderBottomButtons() {
-		const { canPurchase, planProperties, isInSignup, isLandingPage, site } = this.props;
+		const {
+			canPurchase,
+			isInSignup,
+			isLandingPage,
+			planProperties,
+			site,
+			selectedPlan,
+		} = this.props;
 
 		return map( planProperties, properties => {
 			const {
@@ -437,20 +444,21 @@ class PlanFeatures extends Component {
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesActions
+						available={ available }
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }
-						available={ available }
-						primaryUpgrade={ primaryUpgrade }
-						planName={ planConstantObj.getTitle() }
-						onUpgradeClick={ onUpgradeClick }
 						freePlan={ isFreePlan( planName ) }
-						isPlaceholder={ isPlaceholder }
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
+						isPlaceholder={ isPlaceholder }
 						isPopular={ popular }
 						manageHref={ `/plans/my-plan/${ site.slug }` }
+						planName={ planConstantObj.getTitle() }
 						planType={ planName }
+						primaryUpgrade={ primaryUpgrade }
+						onUpgradeClick={ onUpgradeClick }
+						selectedPlan={ selectedPlan }
 					/>
 				</td>
 			);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -456,24 +456,25 @@ class PlanFeatures extends Component {
 }
 
 PlanFeatures.propTypes = {
+	basePlansPath: PropTypes.string,
 	canPurchase: PropTypes.bool.isRequired,
+	displayJetpackPlans: PropTypes.bool,
+	isInSignup: PropTypes.bool,
 	onUpgradeClick: PropTypes.func,
 	// either you specify the plans prop or isPlaceholder prop
 	plans: PropTypes.array,
 	planProperties: PropTypes.array,
-	isInSignup: PropTypes.bool,
-	basePlansPath: PropTypes.string,
 	selectedFeature: PropTypes.string,
+	selectedPlan: PropTypes.string,
 	site: PropTypes.object,
-	displayJetpackPlans: PropTypes.bool,
 };
 
 PlanFeatures.defaultProps = {
-	onUpgradeClick: noop,
-	isInSignup: false,
 	basePlansPath: null,
-	site: {},
 	displayJetpackPlans: false,
+	isInSignup: false,
+	site: {},
+	onUpgradeClick: noop,
 };
 
 export default connect(

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -123,15 +123,16 @@ class PlansFeaturesMain extends Component {
 		return (
 			<div className="plans-features-main__group" data-e2e-plans="wpcom">
 				<PlanFeatures
-					plans={ plans }
-					onUpgradeClick={ onUpgradeClick }
+					basePlansPath={ basePlansPath }
+					displayJetpackPlans={ displayJetpackPlans }
+					domainName={ domainName }
 					isInSignup={ isInSignup }
 					isLandingPage={ isLandingPage }
-					basePlansPath={ basePlansPath }
+					onUpgradeClick={ onUpgradeClick }
+					plans={ plans }
+					selectedPlan={ selectedPlan }
 					selectedFeature={ selectedFeature }
 					site={ site }
-					domainName={ domainName }
-					displayJetpackPlans={ displayJetpackPlans }
 				/>
 			</div>
 		);

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -40,16 +40,17 @@ import SegmentedControlItem from 'components/segmented-control/item';
 class PlansFeaturesMain extends Component {
 	getPlanFeatures() {
 		const {
-			site,
-			intervalType,
-			onUpgradeClick,
-			hideFreePlan,
-			isInSignup,
-			isLandingPage,
 			basePlansPath,
-			selectedFeature,
 			displayJetpackPlans,
 			domainName,
+			hideFreePlan,
+			intervalType,
+			isInSignup,
+			isLandingPage,
+			onUpgradeClick,
+			selectedFeature,
+			selectedPlan,
+			site,
 		} = this.props;
 
 		const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
@@ -66,15 +67,16 @@ class PlansFeaturesMain extends Component {
 			return (
 				<div className="plans-features-main__group" data-e2e-plans="jetpack">
 					<PlanFeatures
-						plans={ jetpackPlans }
-						selectedFeature={ selectedFeature }
-						onUpgradeClick={ onUpgradeClick }
+						basePlansPath={ basePlansPath }
+						displayJetpackPlans={ displayJetpackPlans }
+						domainName={ domainName }
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
-						basePlansPath={ basePlansPath }
+						onUpgradeClick={ onUpgradeClick }
+						plans={ jetpackPlans }
+						selectedFeature={ selectedFeature }
+						selectedPlan={ selectedPlan }
 						site={ site }
-						domainName={ domainName }
-						displayJetpackPlans={ displayJetpackPlans }
 					/>
 				</div>
 			);
@@ -93,15 +95,16 @@ class PlansFeaturesMain extends Component {
 			return (
 				<div className="plans-features-main__group" data-e2e-plans="jetpack">
 					<PlanFeatures
-						plans={ jetpackPlans }
-						selectedFeature={ selectedFeature }
-						onUpgradeClick={ onUpgradeClick }
+						basePlansPath={ basePlansPath }
+						displayJetpackPlans={ displayJetpackPlans }
+						domainName={ domainName }
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
-						basePlansPath={ basePlansPath }
+						onUpgradeClick={ onUpgradeClick }
+						plans={ jetpackPlans }
+						selectedFeature={ selectedFeature }
+						selectedPlan={ selectedPlan }
 						site={ site }
-						domainName={ domainName }
-						displayJetpackPlans={ displayJetpackPlans }
 					/>
 				</div>
 			);

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -391,22 +391,23 @@ class PlansFeaturesMain extends Component {
 }
 
 PlansFeaturesMain.propTypes = {
-	site: PropTypes.object,
+	basePlansPath: PropTypes.string,
+	displayJetpackPlans: PropTypes.bool.isRequired,
+	hideFreePlan: PropTypes.bool,
+	intervalType: PropTypes.string,
 	isInSignup: PropTypes.bool,
 	isLandingPage: PropTypes.bool,
-	basePlansPath: PropTypes.string,
-	intervalType: PropTypes.string,
 	onUpgradeClick: PropTypes.func,
-	hideFreePlan: PropTypes.bool,
-	showFAQ: PropTypes.bool,
 	selectedFeature: PropTypes.string,
-	displayJetpackPlans: PropTypes.bool.isRequired,
+	selectedPlan: PropTypes.string,
+	showFAQ: PropTypes.bool,
+	site: PropTypes.object,
 };
 
 PlansFeaturesMain.defaultProps = {
 	basePlansPath: null,
-	intervalType: 'yearly',
 	hideFreePlan: false,
+	intervalType: 'yearly',
 	site: {},
 	showFAQ: true,
 };

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -26,6 +26,7 @@ export default {
 					intervalType={ context.params.intervalType }
 					destinationType={ context.params.destinationType }
 					selectedFeature={ context.query.feature }
+					selectedPlan={ context.query.plan }
 				/>
 			</CheckoutData>,
 			document.getElementById( 'primary' ),

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -98,11 +98,12 @@ class Plans extends React.Component {
 						/>
 
 						<PlansFeaturesMain
-							site={ selectedSite }
-							intervalType={ this.props.intervalType }
-							hideFreePlan={ true }
-							selectedFeature={ this.props.selectedFeature }
 							displayJetpackPlans={ displayJetpackPlans }
+							hideFreePlan={ true }
+							intervalType={ this.props.intervalType }
+							selectedFeature={ this.props.selectedFeature }
+							selectedPlan={ this.props.selectedPlan }
+							site={ selectedSite }
 						/>
 					</div>
 				</Main>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/17609

First iteration to address ☝️ 

This patch highlights `the Top and Button buttons` of a plan on the Plans page, which a given upgrade nudge points to. 

Currently when redirected from upgrade Banners, the url contains a parameter for the feature the Banner advertises for, which is subsequently highlighted on the Plans page (if constants are well set). Here, we add a `plan` parameter to carry over the information of the `plan` the feature belongs to ( or one we want to stand out irrespective of the feature itself ).

**To test:**
- use calypso-live or checkout this branch 
- access the Plans page through upgrade Banners or through the urls directly

Examples:
*Jetpack sites*
`http://calypso.localhost:3000/plans/:jetpack_connected_site?feature=seo-preview-tools&plan=jetpack_business`
.com sites
`http://calypso.localhost:3000/plans/:com_site?feature=google-analytics&plan=business-bundle`

- try removing either of the parameters or mix match them and verify that the ones included in the url have the desirable effect (highlighting feature and/or plan). Use `{ business, value, personal }-bundle` for .com plans and `jetpack_{personal, premium, business }`  for the .org plans.

**Visuals:**
`http://calypso.localhost:3000/plans/:jetpack_connected_site?feature=wordads-instant&plan=jetpack_premium`
![screen shot 2017-11-30 at 12 07 30](https://user-images.githubusercontent.com/13561163/33427910-3e342726-d5c7-11e7-9599-300d751980ab.png)

**Notes:**
*Extra changes:* For better or worse I alphabetized the props of most components I modified. Hope it does not obscure the readability (too much...)

*Known issue:* `monthly/yearly` toggle fix for .org plans is an immediate follow-up to this PR: https://github.com/Automattic/wp-calypso/pull/20437

*Note on feature highlighting:*  if it does not work for a given banner, it means that either a feature is a sub-feature of the one currently displayed on the Plans page and thus not highlighted, or we should adapt constants in the relevant Banner for it to be recognized ( e.g. https://github.com/Automattic/wp-calypso/pull/20263,  https://github.com/Automattic/wp-calypso/pull/20446 ). Opening an issue is a great idea here :)

**Follow-up:**
- make it work for mobile
- add a `Suggested` ribbon to the plan we want to emphasize (and remove the `New` ...? )
