### PR TITLE
Reader: use an enum for conversation follow status

### DIFF
--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -20,10 +20,7 @@ import { mc } from 'lib/analytics';
 import { pageViewForPost } from 'reader/stats';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
-import {
-	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
-	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
-} from 'state/reader/conversations/follow-status';
+import { CONVERSATION_FOLLOW_STATUS } from 'state/reader/conversations/follow-status';
 import { reduxDispatch } from 'lib/redux-bridge';
 
 /**
@@ -157,8 +154,8 @@ function _setBlogPost( post ) {
 	// Send conversation follow status over to Redux
 	if ( post.hasOwnProperty( 'is_following_conversation' ) ) {
 		const followStatus = post.is_following_conversation
-			? CONVERSATION_FOLLOW_STATUS_FOLLOWING
-			: CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING;
+			? CONVERSATION_FOLLOW_STATUS.following
+			: CONVERSATION_FOLLOW_STATUS.not_following;
 		reduxDispatch(
 			bypassDataLayer(
 				updateConversationFollowStatus( {

--- a/client/state/data-layer/wpcom/read/sites/posts/follow/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/follow/test/index.js
@@ -15,7 +15,7 @@ import {
 	followConversation,
 	updateConversationFollowStatus,
 } from 'state/reader/conversations/actions';
-import { CONVERSATION_FOLLOW_STATUS_MUTING } from 'state/reader/conversations/follow-status';
+import { CONVERSATION_FOLLOW_STATUS } from 'state/reader/conversations/follow-status';
 
 describe( 'conversation-follow', () => {
 	describe( 'requestConversationFollow', () => {
@@ -24,7 +24,7 @@ describe( 'conversation-follow', () => {
 			const action = followConversation( { siteId: 123, postId: 456 } );
 			const actionWithRevert = merge( {}, action, {
 				meta: {
-					previousState: CONVERSATION_FOLLOW_STATUS_MUTING,
+					previousState: CONVERSATION_FOLLOW_STATUS.muting,
 				},
 			} );
 			const getState = () => {
@@ -60,7 +60,7 @@ describe( 'conversation-follow', () => {
 				{ dispatch },
 				{
 					payload: { siteId: 123, postId: 456 },
-					meta: { previousState: CONVERSATION_FOLLOW_STATUS_MUTING },
+					meta: { previousState: CONVERSATION_FOLLOW_STATUS.muting },
 				},
 				{ success: true }
 			);
@@ -79,7 +79,7 @@ describe( 'conversation-follow', () => {
 				{ dispatch },
 				{
 					payload: { siteId: 123, postId: 456 },
-					meta: { previousState: CONVERSATION_FOLLOW_STATUS_MUTING },
+					meta: { previousState: CONVERSATION_FOLLOW_STATUS.muting },
 				},
 				{
 					success: false,
@@ -97,7 +97,7 @@ describe( 'conversation-follow', () => {
 					updateConversationFollowStatus( {
 						siteId: 123,
 						postId: 456,
-						followStatus: CONVERSATION_FOLLOW_STATUS_MUTING,
+						followStatus: CONVERSATION_FOLLOW_STATUS.muting,
 					} )
 				)
 			);

--- a/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/posts/mute/test/index.js
@@ -15,7 +15,7 @@ import {
 	muteConversation,
 	updateConversationFollowStatus,
 } from 'state/reader/conversations/actions';
-import { CONVERSATION_FOLLOW_STATUS_FOLLOWING } from 'state/reader/conversations/follow-status';
+import { CONVERSATION_FOLLOW_STATUS } from 'state/reader/conversations/follow-status';
 
 describe( 'conversation-mute', () => {
 	describe( 'requestConversationMute', () => {
@@ -24,7 +24,7 @@ describe( 'conversation-mute', () => {
 			const action = muteConversation( { siteId: 123, postId: 456 } );
 			const actionWithRevert = merge( {}, action, {
 				meta: {
-					previousState: CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+					previousState: CONVERSATION_FOLLOW_STATUS.following,
 				},
 			} );
 			const getState = () => {
@@ -60,7 +60,7 @@ describe( 'conversation-mute', () => {
 				{ dispatch },
 				{
 					payload: { siteId: 123, postId: 456 },
-					meta: { previousState: CONVERSATION_FOLLOW_STATUS_FOLLOWING },
+					meta: { previousState: CONVERSATION_FOLLOW_STATUS.following },
 				},
 				{ success: true }
 			);
@@ -79,7 +79,7 @@ describe( 'conversation-mute', () => {
 				{ dispatch },
 				{
 					payload: { siteId: 123, postId: 456 },
-					meta: { previousState: CONVERSATION_FOLLOW_STATUS_FOLLOWING },
+					meta: { previousState: CONVERSATION_FOLLOW_STATUS.following },
 				},
 				{
 					success: false,
@@ -97,7 +97,7 @@ describe( 'conversation-mute', () => {
 					updateConversationFollowStatus( {
 						siteId: 123,
 						postId: 456,
-						followStatus: CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+						followStatus: CONVERSATION_FOLLOW_STATUS.following,
 					} )
 				)
 			);

--- a/client/state/reader/conversations/follow-status.js
+++ b/client/state/reader/conversations/follow-status.js
@@ -2,6 +2,8 @@
 /**
  * Follow status constants
  */
-export const CONVERSATION_FOLLOW_STATUS_FOLLOWING = 'F';
-export const CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING = null;
-export const CONVERSATION_FOLLOW_STATUS_MUTING = 'M';
+export const CONVERSATION_FOLLOW_STATUS = {
+	following: 'F',
+	not_following: null,
+	muting: 'M',
+};

--- a/client/state/reader/conversations/follow-status.js
+++ b/client/state/reader/conversations/follow-status.js
@@ -2,8 +2,8 @@
 /**
  * Follow status constants
  */
-export const CONVERSATION_FOLLOW_STATUS = {
+export const CONVERSATION_FOLLOW_STATUS = Object.freeze( {
 	following: 'F',
 	not_following: null,
 	muting: 'M',
-};
+} );

--- a/client/state/reader/conversations/reducer.js
+++ b/client/state/reader/conversations/reducer.js
@@ -13,11 +13,7 @@ import {
 	READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
 	READER_POSTS_RECEIVE,
 } from 'state/action-types';
-import {
-	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
-	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
-	CONVERSATION_FOLLOW_STATUS_MUTING,
-} from './follow-status';
+import { CONVERSATION_FOLLOW_STATUS } from './follow-status';
 import { combineReducers, createReducer } from 'state/utils';
 import { itemsSchema } from './schema';
 import { key } from './utils';
@@ -33,13 +29,13 @@ export const items = createReducer(
 				[ key(
 					action.payload.siteId,
 					action.payload.postId
-				) ]: CONVERSATION_FOLLOW_STATUS_FOLLOWING,
+				) ]: CONVERSATION_FOLLOW_STATUS.following,
 			} );
 			return newState;
 		},
 		[ READER_CONVERSATION_MUTE ]: ( state, action ) => {
 			const newState = assign( {}, state, {
-				[ key( action.payload.siteId, action.payload.postId ) ]: CONVERSATION_FOLLOW_STATUS_MUTING,
+				[ key( action.payload.siteId, action.payload.postId ) ]: CONVERSATION_FOLLOW_STATUS.muting,
 			} );
 			return newState;
 		},
@@ -47,7 +43,7 @@ export const items = createReducer(
 			const stateKey = key( action.payload.siteId, action.payload.postId );
 
 			// If followStatus is null, remove the key from the state map entirely
-			if ( action.payload.followStatus === CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING ) {
+			if ( action.payload.followStatus === CONVERSATION_FOLLOW_STATUS.not_following ) {
 				return omit( state, stateKey );
 			}
 
@@ -66,7 +62,7 @@ export const items = createReducer(
 
 			forEach( action.posts, post => {
 				if ( post.is_following_conversation ) {
-					newState[ key( post.site_ID, post.ID ) ] = CONVERSATION_FOLLOW_STATUS_FOLLOWING;
+					newState[ key( post.site_ID, post.ID ) ] = CONVERSATION_FOLLOW_STATUS.following;
 				}
 			} );
 

--- a/client/state/reader/conversations/schema.js
+++ b/client/state/reader/conversations/schema.js
@@ -1,6 +1,11 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { values } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { CONVERSATION_FOLLOW_STATUS } from './follow-status';
@@ -10,7 +15,7 @@ export const itemsSchema = {
 	type: 'object',
 	patternProperties: {
 		'^[0-9]+-[0-9]+$': {
-			enum: Object.values( CONVERSATION_FOLLOW_STATUS ),
+			enum: values( CONVERSATION_FOLLOW_STATUS ),
 		},
 	},
 	additionalProperties: false,

--- a/client/state/reader/conversations/schema.js
+++ b/client/state/reader/conversations/schema.js
@@ -3,22 +3,14 @@
 /**
  * Internal dependencies
  */
-import {
-	CONVERSATION_FOLLOW_STATUS_FOLLOWING,
-	CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
-	CONVERSATION_FOLLOW_STATUS_MUTING,
-} from './follow-status';
+import { CONVERSATION_FOLLOW_STATUS } from './follow-status';
 
 /* eslint-disable quote-props */
 export const itemsSchema = {
 	type: 'object',
 	patternProperties: {
 		'^[0-9]+-[0-9]+$': {
-			enum: [
-				CONVERSATION_FOLLOW_STATUS_FOLLOWING,
-				CONVERSATION_FOLLOW_STATUS_NOT_FOLLOWING,
-				CONVERSATION_FOLLOW_STATUS_MUTING,
-			],
+			enum: Object.values( CONVERSATION_FOLLOW_STATUS ),
 		},
 	},
 	additionalProperties: false,

--- a/client/state/reader/conversations/test/actions.js
+++ b/client/state/reader/conversations/test/actions.js
@@ -13,7 +13,7 @@ import {
 	muteConversation,
 	updateConversationFollowStatus,
 } from 'state/reader/conversations/actions';
-import { CONVERSATION_FOLLOW_STATUS_MUTING } from 'state/reader/conversations/follow-status';
+import { CONVERSATION_FOLLOW_STATUS } from 'state/reader/conversations/follow-status';
 
 describe( 'actions', () => {
 	describe( '#followConversation', () => {
@@ -41,11 +41,11 @@ describe( 'actions', () => {
 			const action = updateConversationFollowStatus( {
 				siteId: 123,
 				postId: 456,
-				followStatus: CONVERSATION_FOLLOW_STATUS_MUTING,
+				followStatus: CONVERSATION_FOLLOW_STATUS.muting,
 			} );
 			expect( action ).toEqual( {
 				type: READER_CONVERSATION_UPDATE_FOLLOW_STATUS,
-				payload: { siteId: 123, postId: 456, followStatus: CONVERSATION_FOLLOW_STATUS_MUTING },
+				payload: { siteId: 123, postId: 456, followStatus: CONVERSATION_FOLLOW_STATUS.muting },
 			} );
 		} );
 	} );

--- a/client/state/selectors/is-following-reader-conversation.js
+++ b/client/state/selectors/is-following-reader-conversation.js
@@ -11,7 +11,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { key } from 'state/reader/conversations/utils';
-import { CONVERSATION_FOLLOW_STATUS_FOLLOWING } from 'state/reader/conversations/follow-status';
+import { CONVERSATION_FOLLOW_STATUS } from 'state/reader/conversations/follow-status';
 
 /*
  * Get the conversation following status for a given post
@@ -23,6 +23,6 @@ import { CONVERSATION_FOLLOW_STATUS_FOLLOWING } from 'state/reader/conversations
 export default function isFollowingReaderConversation( state, { siteId, postId } ) {
 	return (
 		get( state, [ 'reader', 'conversations', 'items', key( siteId, postId ) ] ) ===
-		CONVERSATION_FOLLOW_STATUS_FOLLOWING
+		CONVERSATION_FOLLOW_STATUS.following
 	);
 }


### PR DESCRIPTION
As suggested by @samouri, use an enum for conversation follow status rather than three individual constants.

https://jaketrent.com/post/expose-enum-props-in-react/

Before: 

```js
CONVERSATION_FOLLOW_STATUS_FOLLOWING
```

After:
```js
CONVERSATION_FOLLOW_STATUS.following
```

I was undecided on whether to capitalize the key too. Feedback welcome.

No functional changes.