### PR TITLE
Domains: Fix "Go Back" Header for Add new transfer

### DIFF
--- a/client/components/domains/map-domain-step/style.scss
+++ b/client/components/domains/map-domain-step/style.scss
@@ -62,6 +62,7 @@ input.map-domain-step__external-domain {
 	margin: 10px 0 0 0;
 
 	@include breakpoint( ">660px" ) {
+		min-width: 80px;
 		flex-grow: 0;
 		margin: 0 0 0 10px;
 	}

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -33,11 +33,13 @@ import { getSelectedSite } from 'state/ui/selectors';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import TransferDomainPrecheck from './transfer-domain-precheck';
 import support from 'lib/url/support';
+import HeaderCake from 'components/header-cake';
 
 class TransferDomainStep extends React.Component {
 	static propTypes = {
 		products: PropTypes.object.isRequired,
 		cart: PropTypes.object,
+		goBack: PropTypes.func,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		initialQuery: PropTypes.string,
 		analyticsSection: PropTypes.string.isRequired,
@@ -188,6 +190,14 @@ class TransferDomainStep extends React.Component {
 		);
 	}
 
+	goBack = () => {
+		if ( this.state.domain ) {
+			this.setState( { domain: null } );
+		} else {
+			this.props.goBack();
+		}
+	};
+
 	render() {
 		let content;
 		const { domain } = this.state;
@@ -198,7 +208,14 @@ class TransferDomainStep extends React.Component {
 			content = this.addTransfer();
 		}
 
-		return <div className="transfer-domain-step">{ content }</div>;
+		return (
+			<div className="transfer-domain-step">
+				<HeaderCake onClick={ this.goBack }>
+					{ this.props.translate( 'Use My Own Domain' ) }
+				</HeaderCake>
+				<div>{ content }</div>
+			</div>
+		);
 	}
 
 	domainRegistrationUpsell() {

--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -29,7 +29,7 @@ function FormattedHeader( { headerText, subHeaderText } ) {
 }
 
 FormattedHeader.propTypes = {
-	headerText: PropTypes.string,
+	headerText: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
 	subHeaderText: PropTypes.node,
 };
 

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -7,12 +7,10 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import HeaderCake from 'components/header-cake';
 import TransferDomainStep from 'components/domains/transfer-domain-step';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import { cartItems } from 'lib/cart-values';
@@ -35,7 +33,6 @@ export class TransferDomain extends Component {
 		selectedSite: PropTypes.object,
 		selectedSiteId: PropTypes.number,
 		selectedSiteSlug: PropTypes.string,
-		translate: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -105,29 +102,20 @@ export class TransferDomain extends Component {
 	}
 
 	render() {
-		const {
-			cart,
-			domainsWithPlansOnly,
-			initialQuery,
-			productsList,
-			selectedSite,
-			translate,
-		} = this.props;
+		const { cart, domainsWithPlansOnly, initialQuery, productsList, selectedSite } = this.props;
 
 		const { errorMessage } = this.state;
 
 		return (
 			<span>
 				<QueryProductsList />
-
-				<HeaderCake onClick={ this.goBack }>{ translate( 'Use My Own Domain' ) }</HeaderCake>
-
 				{ errorMessage && <Notice status="is-error" text={ errorMessage } /> }
 
 				<TransferDomainStep
 					basePath={ this.props.basePath }
 					cart={ cart }
 					domainsWithPlansOnly={ domainsWithPlansOnly }
+					goBack={ this.goBack }
 					initialQuery={ initialQuery }
 					products={ productsList }
 					selectedSite={ selectedSite }
@@ -147,4 +135,4 @@ export default connect( state => ( {
 	domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 	isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
 	productsList: getProductsList( state ),
-} ) )( localize( TransferDomain ) );
+} ) )( TransferDomain );


### PR DESCRIPTION
Go Back on add new transfer screen would always send you
back to domain search. It should return you to the add domain
for transfer screen if you were on precheck.

Also fix Map It screen button width as it was shown as "A.."

Test:
- Go to Add Domain
- Use a domain I own
- Try adding your domain
- On pre-check screen click back
- Make sure you're back on domain input for transfer
- Click back again
- Make sure you're on add domain screen

Fixes: https://github.com/Automattic/wp-calypso/issues/19912