### PR TITLE
Stats Period Nav: introduce new prop to hide the previous month arrow

### DIFF
--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -10,6 +10,7 @@ import { flowRight } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -19,6 +20,11 @@ import { recordGoogleEvent as recordGoogleEventAction } from 'state/analytics/ac
 class StatsPeriodNavigation extends PureComponent {
 	static propTypes = {
 		onPeriodChange: PropTypes.func,
+		hidePreviousArrow: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		hidePreviousArrow: false,
 	};
 
 	handleClickNext = () => {
@@ -43,7 +49,7 @@ class StatsPeriodNavigation extends PureComponent {
 	};
 
 	render() {
-		const { children, date, moment, period, url } = this.props;
+		const { children, date, moment, period, url, hidePreviousArrow } = this.props;
 
 		const isToday = moment( date ).isSame( moment(), period );
 		const previousDay = moment( date )
@@ -55,13 +61,17 @@ class StatsPeriodNavigation extends PureComponent {
 
 		return (
 			<div className="stats-period-navigation">
-				<a
-					className="stats-period-navigation__previous"
-					href={ `${ url }?startDate=${ previousDay }` }
-					onClick={ this.handleClickPrevious }
-				>
-					<Gridicon icon="arrow-left" size={ 18 } />
-				</a>
+				{
+					<a
+						className={ classNames( 'stats-period-navigation__previous', {
+							'is-disabled': hidePreviousArrow,
+						} ) }
+						href={ `${ url }?startDate=${ previousDay }` }
+						onClick={ this.handleClickPrevious }
+					>
+						<Gridicon icon="arrow-left" size={ 18 } />
+					</a>
+				}
 				<div className="stats-period-navigation__children">{ children }</div>
 				{ ! isToday && (
 					<a


### PR DESCRIPTION
In preparation for a feature in Activity Log described in https://github.com/Automattic/wp-calypso/issues/17287, this PR introduces a new prop `hidePreviousArrow` that when set to `true`, will hide the arrow pointing to the previous month:

<img width="787" alt="captura de pantalla 2017-11-24 a la s 18 46 24" src="https://user-images.githubusercontent.com/1041600/33224395-cd475d2c-d147-11e7-8ab5-bea7a24aa914.png">
