### PR TITLE
Domains: Prevent mapping of a still active domain

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -45,6 +45,7 @@ const domainAvailability = {
 	BLACKLISTED: 'blacklisted_domain',
 	MAPPED: 'mapped_domain',
 	RECENTLY_UNMAPPED: 'recently_mapped',
+	UNKOWN_ACTIVE: 'unknown_active_domain_with_wpcom',
 };
 
 const dnsTemplates = {

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -123,6 +123,13 @@ function getAvailabilityNotice( domain, error ) {
 			);
 			break;
 
+		case domainAvailability.UNKOWN_ACTIVE:
+			message = translate(
+				'This domain is still active and is not available to map yet. ' +
+					'Please try again later or contact support.'
+			);
+			break;
+
 		case domainAvailability.EMPTY_QUERY:
 			message = translate( 'Please enter a domain name or keyword.' );
 			break;


### PR DESCRIPTION
Domain might not have any active subscriptions or domain mapping records, but it should still not be possible to map it.

### Testing
Requires `D6392-code` on the backend.

Verify that all normal cases still work as previously:
* Verify that you can still map a valid domain.
* Verify that you can still register an available domain.
* Verify that you can still renew both a mapped domain and a registered domain.

Verify that you cannot map a domain that is:
* Registered with us.
* But does not have active subscriptions and no domain_mapping record.

An error should be displayed:
<img width="758" alt="screen shot 2017-11-24 at 23 04 01" src="https://user-images.githubusercontent.com/3392497/33224683-79df7c9e-d16c-11e7-8863-20c1f4ff60d4.png">

<img width="754" alt="screen shot 2017-11-24 at 22 55 55" src="https://user-images.githubusercontent.com/3392497/33224697-969e489c-d16c-11e7-8dee-4fcbc2bdfeec.png">
