### PR TITLE
Activity Log: hide previous month arrown when there are no more logs

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -430,7 +430,7 @@ class ActivityLog extends Component {
 				onPeriodChange={ position === 'bottom' ? this.handlePeriodChangeBottom : changePeriod }
 				period="month"
 				url={ `/stats/activity/${ slug }` }
-				hidePreviousArrow={ monthStartTs <= oldestItemTs }
+				hidePreviousArrow={ 0 === oldestItemTs || monthStartTs <= oldestItemTs }
 			>
 				<DatePicker isActivity={ true } period="month" date={ startOfMonth } query={ query } />
 			</StatsPeriodNavigation>

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -430,7 +430,7 @@ class ActivityLog extends Component {
 				onPeriodChange={ position === 'bottom' ? this.handlePeriodChangeBottom : changePeriod }
 				period="month"
 				url={ `/stats/activity/${ slug }` }
-				hidePreviousArrow={ Infinity === oldestItemTs || monthStartTs <= oldestItemTs }
+				hidePreviousArrow={ monthStartTs <= oldestItemTs }
 			>
 				<DatePicker isActivity={ true } period="month" date={ startOfMonth } query={ query } />
 			</StatsPeriodNavigation>

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -57,6 +57,7 @@ import {
 	getRewindState,
 	getSiteGmtOffset,
 	getSiteTimezoneValue,
+	getOldestItemTs,
 } from 'state/selectors';
 
 const flushEmptyDays = days => [
@@ -409,25 +410,27 @@ class ActivityLog extends Component {
 	}
 
 	renderMonthNavigation( position ) {
-		const { logs, slug } = this.props;
-		const startOfMonth = this.getStartMoment().startOf( 'month' );
-		const query = {
-			period: 'month',
-			date: startOfMonth.format( 'YYYY-MM-DD' ),
-		};
+		const { logs } = this.props;
 
 		if ( position === 'bottom' && ( ! isNull( logs ) && isEmpty( logs ) ) ) {
 			return null;
 		}
 
+		const { slug, changePeriod, oldestItemTs } = this.props;
+		const startOfMonth = this.getStartMoment().startOf( 'month' );
+		const monthStartTs = startOfMonth.clone().valueOf();
+		const query = {
+			period: 'month',
+			date: startOfMonth.format( 'YYYY-MM-DD' ),
+		};
+
 		return (
 			<StatsPeriodNavigation
 				date={ startOfMonth }
-				onPeriodChange={
-					position === 'bottom' ? this.handlePeriodChangeBottom : this.props.changePeriod
-				}
+				onPeriodChange={ position === 'bottom' ? this.handlePeriodChangeBottom : changePeriod }
 				period="month"
 				url={ `/stats/activity/${ slug }` }
+				hidePreviousArrow={ monthStartTs <= oldestItemTs }
 			>
 				<DatePicker isActivity={ true } period="month" date={ startOfMonth } query={ query } />
 			</StatsPeriodNavigation>
@@ -637,6 +640,7 @@ export default connect(
 			siteTitle: getSiteTitle( state, siteId ),
 			slug: getSiteSlug( state, siteId ),
 			timezone,
+			oldestItemTs: getOldestItemTs( state, siteId ),
 		};
 	},
 	{

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -430,7 +430,7 @@ class ActivityLog extends Component {
 				onPeriodChange={ position === 'bottom' ? this.handlePeriodChangeBottom : changePeriod }
 				period="month"
 				url={ `/stats/activity/${ slug }` }
-				hidePreviousArrow={ 0 === oldestItemTs || monthStartTs <= oldestItemTs }
+				hidePreviousArrow={ Infinity === oldestItemTs || monthStartTs <= oldestItemTs }
 			>
 				<DatePicker isActivity={ true } period="month" date={ startOfMonth } query={ query } />
 			</StatsPeriodNavigation>

--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -91,13 +91,14 @@ export function activityLogRequest( siteId, params ) {
 	};
 }
 
-export function activityLogUpdate( siteId, data, found, query ) {
+export function activityLogUpdate( siteId, data, found, oldestItemTs, query ) {
 	return {
 		type: ACTIVITY_LOG_UPDATE,
-		data,
-		query,
 		siteId,
+		data,
 		found,
+		oldestItemTs,
+		query,
 	};
 }
 

--- a/client/state/activity-log/log/reducer.js
+++ b/client/state/activity-log/log/reducer.js
@@ -1,6 +1,11 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { isNull } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import ActivityQueryManager from 'lib/query-manager/activity';
@@ -29,10 +34,10 @@ export const logItem = ( state = undefined, { type, data, found, query } ) => {
 export const logItems = keyedReducer( 'siteId', logItem, [ DESERIALIZE, SERIALIZE ] );
 logItems.hasCustomPersistence = true;
 
-export const oldestItemTs = keyedReducer( 'siteId', ( state = 0, action ) => {
+export const oldestItemTs = keyedReducer( 'siteId', ( state = Infinity, action ) => {
 	switch ( action.type ) {
 		case ACTIVITY_LOG_UPDATE:
-			return 0 < action.oldestItemTs ? action.oldestItemTs : state;
+			return isNull( action.oldestItemTs ) ? state : Math.min( action.oldestItemTs, state );
 
 		default:
 			return state;

--- a/client/state/activity-log/log/reducer.js
+++ b/client/state/activity-log/log/reducer.js
@@ -1,11 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { isNull } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import ActivityQueryManager from 'lib/query-manager/activity';
@@ -37,7 +32,7 @@ logItems.hasCustomPersistence = true;
 export const oldestItemTs = keyedReducer( 'siteId', ( state = Infinity, action ) => {
 	switch ( action.type ) {
 		case ACTIVITY_LOG_UPDATE:
-			return isNull( action.oldestItemTs ) ? state : Math.min( action.oldestItemTs, state );
+			return null === action.oldestItemTs ? state : Math.min( action.oldestItemTs, state );
 
 		default:
 			return state;

--- a/client/state/activity-log/log/reducer.js
+++ b/client/state/activity-log/log/reducer.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { get, merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,21 +8,18 @@ import { ACTIVITY_LOG_UPDATE, DESERIALIZE, SERIALIZE } from 'state/action-types'
 import { isValidStateWithSchema, keyedReducer } from 'state/utils';
 import { logItemsSchema } from './schema';
 
-export const logItem = ( state = undefined, { type, data, found, oldestItemTs, query } ) => {
+export const logItem = ( state = undefined, { type, data, found, query } ) => {
 	switch ( type ) {
 		case ACTIVITY_LOG_UPDATE:
-			return merge(
-				( state || new ActivityQueryManager() ).receive( data, { found, oldestItemTs, query } ),
-				{ oldestItemTs: 0 < oldestItemTs ? oldestItemTs : get( state, 'oldestItemTs', 0 ) }
-			);
+			return ( state || new ActivityQueryManager() ).receive( data, { found, query } );
 
 		case DESERIALIZE:
 			return isValidStateWithSchema( state, logItemsSchema )
-				? merge( new ActivityQueryManager( state.data, state.options ), { oldestItemTs } )
+				? new ActivityQueryManager( state.data, state.options )
 				: undefined;
 
 		case SERIALIZE:
-			return { data: state.data, options: state.options, oldestItemTs };
+			return { data: state.data, options: state.options };
 
 		default:
 			return state;

--- a/client/state/activity-log/log/reducer.js
+++ b/client/state/activity-log/log/reducer.js
@@ -35,3 +35,13 @@ export const logItem = ( state = undefined, { type, data, found, oldestItemTs, q
 
 export const logItems = keyedReducer( 'siteId', logItem, [ DESERIALIZE, SERIALIZE ] );
 logItems.hasCustomPersistence = true;
+
+export const oldestItemTs = keyedReducer( 'siteId', ( state = 0, action ) => {
+	switch ( action.type ) {
+		case ACTIVITY_LOG_UPDATE:
+			return 0 < action.oldestItemTs ? action.oldestItemTs : state;
+
+		default:
+			return state;
+	}
+} );

--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -87,5 +87,8 @@ export const logItemsSchema = {
 				},
 			},
 		},
+		oldestItemTs: {
+			type: [ 'null', 'integer' ],
+		},
 	},
 };

--- a/client/state/activity-log/log/test/reducer.js
+++ b/client/state/activity-log/log/test/reducer.js
@@ -4,6 +4,7 @@
  */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
+import { merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,7 +35,9 @@ const ACTIVITY_ITEM = deepFreeze( {
 } );
 
 const populateQueryManager = ( data = [], query = {} ) =>
-	new ActivityQueryManager().receive( data, { found: data.length, query } );
+	merge( new ActivityQueryManager().receive( data, { found: data.length, query } ), {
+		oldestItemTs: 1234567,
+	} );
 
 describe( 'reducer', () => {
 	useSandbox( sandbox => {
@@ -56,6 +59,7 @@ describe( 'reducer', () => {
 				data,
 				found: data.length,
 				query: {},
+				oldestItemTs: 1234567,
 			} );
 
 			expect( state ).to.eql( {
@@ -67,7 +71,7 @@ describe( 'reducer', () => {
 			const original = deepFreeze( {
 				[ SITE_ID ]: populateQueryManager( [ ACTIVITY_ITEM ], {} ),
 			} );
-			const state = logItems( original, { type: SERIALIZE } );
+			const state = logItems( original, { type: SERIALIZE, oldestItemTs: 1234567 } );
 
 			expect( state ).to.eql( original );
 		} );
@@ -84,10 +88,11 @@ describe( 'reducer', () => {
 					options: {
 						itemKey: 'activityId',
 					},
+					oldestItemTs: 1234567,
 				},
 			} );
 
-			const state = logItems( original, { type: DESERIALIZE } );
+			const state = logItems( original, { type: DESERIALIZE, oldestItemTs: 1234567 } );
 
 			expect( state ).to.eql( original );
 		} );
@@ -107,9 +112,10 @@ describe( 'reducer', () => {
 					options: {
 						itemKey: 'activityId',
 					},
+					oldestItemTs: 1234567,
 				},
 			} );
-			const state = logItems( original, { type: DESERIALIZE } );
+			const state = logItems( original, { type: DESERIALIZE, oldestItemTs: 1234567 } );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/state/activity-log/log/test/reducer.js
+++ b/client/state/activity-log/log/test/reducer.js
@@ -4,7 +4,6 @@
  */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-import { merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,9 +34,7 @@ const ACTIVITY_ITEM = deepFreeze( {
 } );
 
 const populateQueryManager = ( data = [], query = {} ) =>
-	merge( new ActivityQueryManager().receive( data, { found: data.length, query } ), {
-		oldestItemTs: 1234567,
-	} );
+	new ActivityQueryManager().receive( data, { found: data.length, query } );
 
 describe( 'reducer', () => {
 	useSandbox( sandbox => {
@@ -59,7 +56,6 @@ describe( 'reducer', () => {
 				data,
 				found: data.length,
 				query: {},
-				oldestItemTs: 1234567,
 			} );
 
 			expect( state ).to.eql( {
@@ -71,7 +67,7 @@ describe( 'reducer', () => {
 			const original = deepFreeze( {
 				[ SITE_ID ]: populateQueryManager( [ ACTIVITY_ITEM ], {} ),
 			} );
-			const state = logItems( original, { type: SERIALIZE, oldestItemTs: 1234567 } );
+			const state = logItems( original, { type: SERIALIZE } );
 
 			expect( state ).to.eql( original );
 		} );
@@ -88,11 +84,10 @@ describe( 'reducer', () => {
 					options: {
 						itemKey: 'activityId',
 					},
-					oldestItemTs: 1234567,
 				},
 			} );
 
-			const state = logItems( original, { type: DESERIALIZE, oldestItemTs: 1234567 } );
+			const state = logItems( original, { type: DESERIALIZE } );
 
 			expect( state ).to.eql( original );
 		} );
@@ -112,10 +107,9 @@ describe( 'reducer', () => {
 					options: {
 						itemKey: 'activityId',
 					},
-					oldestItemTs: 1234567,
 				},
 			} );
-			const state = logItems( original, { type: DESERIALIZE, oldestItemTs: 1234567 } );
+			const state = logItems( original, { type: DESERIALIZE } );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/state/activity-log/reducer.js
+++ b/client/state/activity-log/reducer.js
@@ -4,13 +4,14 @@
  */
 import { combineReducers } from 'state/utils';
 import { activationRequesting } from './activation/reducer';
-import { logItems } from './log/reducer';
+import { logItems, oldestItemTs } from './log/reducer';
 import { restoreProgress, restoreRequest } from './restore/reducer';
 import { backupRequest, backupProgress } from './backup/reducer';
 
 export default combineReducers( {
 	activationRequesting,
 	logItems,
+	oldestItemTs,
 	restoreProgress,
 	restoreRequest,
 	backupProgress,

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -20,13 +20,15 @@ export const DEFAULT_GRIDICON = 'info-outline';
 /**
  * Transforms API response into array of activities
  *
- * @param  {object} apiResponse                      API response body
- * @param  {array}  apiResponse.current.orderedItems Array of item objects
- * @return {array}                                   Array of proccessed item objects
+ * @param  {object} apiResponse API response body
+ * @return {object}             Object with an entry for proccessed item objects and another for oldest item timestamp
  */
 export function transformer( apiResponse ) {
-	const orderedItems = get( apiResponse, [ 'current', 'orderedItems' ], [] );
-	return map( orderedItems, processItem );
+	return {
+		items: map( get( apiResponse, [ 'current', 'orderedItems' ], [] ), processItem ),
+		oldestItemTs: get( apiResponse, [ 'oldestItemTs' ], 0 ),
+		totalItems: get( apiResponse, [ 'totalItems' ], 0 ),
+	};
 }
 
 /**

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -24,10 +24,11 @@ export const DEFAULT_GRIDICON = 'info-outline';
  * @return {object}             Object with an entry for proccessed item objects and another for oldest item timestamp
  */
 export function transformer( apiResponse ) {
+	const orderedItems = get( apiResponse, [ 'current', 'orderedItems' ], [] );
 	return {
-		items: map( get( apiResponse, [ 'current', 'orderedItems' ], [] ), processItem ),
-		oldestItemTs: get( apiResponse, [ 'oldestItemTs' ], 0 ),
-		totalItems: get( apiResponse, [ 'totalItems' ], 0 ),
+		items: map( orderedItems, processItem ),
+		oldestItemTs: get( apiResponse, [ 'oldestItemTs' ], Infinity ),
+		totalItems: get( apiResponse, [ 'totalItems' ], orderedItems.length ),
 	};
 }
 

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -69,7 +69,7 @@ export const continuePolling = ( { dispatch }, action ) => {
 			return;
 		}
 
-		const data = fromApi( rawData );
+		const data = fromApi( rawData ).items;
 
 		const newestDate = data.reduce(
 			( newest, { activityTs } ) => Math.max( newest, activityTs ),
@@ -131,8 +131,15 @@ export const handleActivityLogRequest = action => {
 	);
 };
 
-export const receiveActivityLog = ( action, data ) =>
-	activityLogUpdate( action.siteId, data, data.totalItems, action.params );
+export const receiveActivityLog = ( action, data ) => {
+	return activityLogUpdate(
+		action.siteId,
+		data.items,
+		data.totalItems,
+		data.oldestItemTs,
+		action.params
+	);
+};
 
 export const receiveActivityLogError = () =>
 	errorNotice( translate( 'Error receiving activity for site.' ) );

--- a/client/state/data-layer/wpcom/sites/activity/schema.json
+++ b/client/state/data-layer/wpcom/sites/activity/schema.json
@@ -11,6 +11,7 @@
 		"summary": { "type": "string" },
 		"totalItems": { "type": "integer" },
 		"totalPages": { "type": "integer" },
+		"oldestItemTs": { "type": "integer" },
 		"type": { "type": "string" },
 		"current": {
 			"type": "object",

--- a/client/state/selectors/get-oldest-item-ts.js
+++ b/client/state/selectors/get-oldest-item-ts.js
@@ -1,0 +1,16 @@
+/** @format *
+ /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns an Activity log.
+ *
+ * @param  {Object}        state      Global state tree
+ * @param  {number|string} siteId     The site ID
+ * @return {number}                  Timestamp of oldest logged event, otherwise 0.
+ */
+export default function getOldestItemTs( state, siteId ) {
+	return get( state, [ 'activityLog', 'logItems', siteId, 'oldestItemTs' ], 0 );
+}

--- a/client/state/selectors/get-oldest-item-ts.js
+++ b/client/state/selectors/get-oldest-item-ts.js
@@ -7,10 +7,10 @@ import { get } from 'lodash';
 /**
  * Returns an Activity log.
  *
- * @param  {Object}        state      Global state tree
- * @param  {number|string} siteId     The site ID
- * @return {number}                  Timestamp of oldest logged event, otherwise 0.
+ * @param  {Object}        state  Global state tree
+ * @param  {number|string} siteId The site ID
+ * @return {number}               Timestamp of oldest logged event, otherwise 0.
  */
 export default function getOldestItemTs( state, siteId ) {
-	return get( state, [ 'activityLog', 'logItems', siteId, 'oldestItemTs' ], 0 );
+	return get( state, [ 'activityLog', 'oldestItemTs', siteId ], 0 );
 }

--- a/client/state/selectors/get-oldest-item-ts.js
+++ b/client/state/selectors/get-oldest-item-ts.js
@@ -9,8 +9,8 @@ import { get } from 'lodash';
  *
  * @param  {Object}        state  Global state tree
  * @param  {number|string} siteId The site ID
- * @return {number}               Timestamp of oldest logged event, otherwise 0.
+ * @return {number}               Timestamp of oldest logged event, otherwise Infinity.
  */
 export default function getOldestItemTs( state, siteId ) {
-	return get( state, [ 'activityLog', 'oldestItemTs', siteId ], 0 );
+	return get( state, [ 'activityLog', 'oldestItemTs', siteId ], Infinity );
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/17287

~~Depends on D9010-code~~ It's committed.

This PR seeks to hide the arrow to go to a previous month when there are no more events to show.

- the new prop `oldestItemTs` returned by the `/sites/$site/activity` endpoint modified in D9010 was added to the state tree in `activityLog.logItems.$site.oldestItemTs`

- the timestamp of oldest logged event is compared to the start timestamp of the month currently being displayed to hide the arrow for a previous month

In my site, the oldest logged event is on June. Previously, it was showing like this, and the arrow allowed to go to any previous month even if there wasn't events. That was confusing because it looked like there was activity in some older month:

<img width="830" alt="captura de pantalla 2017-12-27 a la s 19 13 44" src="https://user-images.githubusercontent.com/1041600/34394749-160dab22-eb3a-11e7-9149-26f98f88c3ce.png">

With this PR, it no longer shows the arrow:

<img width="699" alt="captura de pantalla 2017-12-27 a la s 19 12 09" src="https://user-images.githubusercontent.com/1041600/34394728-ef09d424-eb39-11e7-9a17-910f0540344d.png">
