### PR TITLE
Activity Log: clear restoreProgress in state tree when dismissing restore error

### DIFF
--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -44,6 +44,7 @@ export const restoreProgress = keyedReducer(
 			[ REWIND_RESTORE ]: startProgress,
 			[ REWIND_RESTORE_DISMISS_PROGRESS ]: stubNull,
 			[ REWIND_RESTORE_UPDATE_PROGRESS ]: updateProgress,
+			[ REWIND_RESTORE_DISMISS ]: stubNull,
 		}
 	)
 );


### PR DESCRIPTION
Previously, when an error occurred during a site restore, an error card was displayed and the dismiss ⨉ button wasn't properly clearing the right entry in state tree. This PR fixes this so now error cards during a restore can be dismissed.

This will later change when the cards are dismissed by marking a restore as dismissed in the server, like it's now done with backups. For the time being, this fixes this current approach.

#### Testing 

An error can be forced as follows:
1. edit `client/my-sites/stats/activity-log/index.jsx`
2. in method `confirmRestore`, replace:
`this.props.rewindRestore( siteId, rewindId );`
with
`this.props.rewindRestore( siteId, '-1' );`
