### PR TITLE
Editor: Revert "Editor Distractions: remove Masterbar"

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -433,7 +433,3 @@ $autobar-height: 20px;
 		flex-grow: 0;
 	}
 }
-
-.is-section-post-editor .masterbar {
-	display: none;
-}

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -5,7 +5,7 @@
 	margin-bottom: 0;
 	transition: 0.3s box-shadow;
 	position: fixed;
-	top: 0;
+	top: 47px;
 	left: 0;
 	right: 0;
 	z-index: z-index( 'root', '.editor-ground-control' );

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -6,6 +6,7 @@
 	border-top: 1px solid darken( $sidebar-bg-color, 5% );
 	border-right: none;
 	box-sizing: border-box;
+	top: 93px;
 	right: $sidebar-width-max;
 	left: auto;
 	transition: all 0.15s cubic-bezier(0.075, 0.82, 0.165, 1);

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -34,7 +34,7 @@
 
 .post-editor__inner {
 	position: relative;
-	top: 0;
+	top: 47px;
 	padding-bottom: 47px;
 }
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#20174 because after publishing, we get a double bar. We can clear this up and re-enable on Monday.