### PR TITLE
Show the ActivityLogCredentialsNotice only if Rewind is active

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -603,7 +603,7 @@ class ActivityLog extends Component {
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />
-				{ ! hasMainCredentials && <ActivityLogCredentialsNotice /> }
+				{ isRewindActive && ! hasMainCredentials && <ActivityLogCredentialsNotice /> }
 				{ this.renderErrorMessage() }
 				{ hasFirstBackup && this.renderMonthNavigation() }
 				{ this.renderActionProgress() }


### PR DESCRIPTION
As the title states, we only want the ActivityLogCredentialsNotice to show if a site is Rewind-enabled. For sites that are rewind-ineligible or have Rewind turned off, we should not show the credentials nag.

**Testing instructions:**
- View the activity log for a site that does not have Rewind enabled. Make sure the credentials nag *doesn't* show.
- View the activity log for a site with Rewind enabled but no credentials. Make sure the credentials nag *does* show.