### PR TITLE
Store: Add ability to add/edit BACS account info.

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
@@ -54,14 +54,14 @@ class PaymentMethodBACS extends Component {
 
 	constructor( props ) {
 		super( props );
-
+		const { iban, bic } = this.getAccountData( props );
 		this.state = {
-			showInternational: false,
+			showInternational: ( iban && iban.length ) || ( bic && bic.length ),
 		};
 	}
 
-	getAccountData = () => {
-		const { method: { settings } } = this.props;
+	getAccountData = props => {
+		const { method: { settings } } = props || this.props;
 		const accountData = get( settings, [ 'accounts', 'value' ] );
 
 		return accountData.length

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
@@ -1,0 +1,182 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormLegend from 'components/forms/form-legend';
+import FormTextarea from 'components/forms/form-textarea';
+import FormTextInput from 'components/forms/form-text-input';
+
+class PaymentMethodBACS extends Component {
+	static propTypes = {
+		method: PropTypes.shape( {
+			settings: PropTypes.shape( {
+				title: PropTypes.shape( {
+					id: PropTypes.string.isRequired,
+					label: PropTypes.string.isRequired,
+					type: PropTypes.string.isRequired,
+					value: PropTypes.string.isRequired,
+				} ),
+				accounts: PropTypes.shape( {
+					id: PropTypes.string.isRequired,
+					value: PropTypes.array.isRequired,
+				} ),
+			} ),
+		} ),
+		translate: PropTypes.func.isRequired,
+		onCancel: PropTypes.func.isRequired,
+		onEditField: PropTypes.func.isRequired,
+		onDone: PropTypes.func.isRequired,
+	};
+
+	getAccountData = () => {
+		const { method: { settings } } = this.props;
+
+		// The API _should_ always return this, but just being safe.
+		const accountData = get(
+			settings,
+			[ 'accounts', 'value' ],
+			[
+				{
+					account_name: '',
+					account_number: '',
+					bank_name: '',
+					bic: '',
+					iban: '',
+					sort_code: '',
+				},
+			]
+		);
+
+		return accountData.length ? accountData[ 0 ] : {};
+	};
+
+	onEditFieldHandler = e => {
+		this.props.onEditField( e.target.name, e.target.value );
+	};
+
+	onEditAccountHandler = e => {
+		const newValue = {};
+		newValue[ e.target.name ] = e.target.value;
+		const newAccount = Object.assign( {}, this.getAccountData(), newValue );
+		this.props.onEditField( 'accounts', [ newAccount ] );
+	};
+
+	buttons = [
+		{ action: 'cancel', label: this.props.translate( 'Cancel' ), onClick: this.props.onCancel },
+		{
+			action: 'save',
+			label: this.props.translate( 'Done' ),
+			onClick: this.props.onDone,
+			isPrimary: true,
+		},
+	];
+
+	render() {
+		const { method, method: { settings }, translate } = this.props;
+		const accountData = this.getAccountData();
+		return (
+			<Dialog
+				additionalClassNames="payments__dialog woocommerce"
+				buttons={ this.buttons }
+				isVisible
+			>
+				<FormFieldset className="payments__method-edit-field-container">
+					<FormLabel>{ translate( 'Title' ) }</FormLabel>
+					<FormTextInput
+						name="title"
+						onChange={ this.onEditFieldHandler }
+						value={ settings.title.value }
+					/>
+				</FormFieldset>
+				<FormFieldset className="payments__method-edit-field-container">
+					<FormLabel>{ translate( 'Instructions for customer at checkout' ) }</FormLabel>
+					<FormTextarea
+						name="description"
+						onChange={ this.onEditFieldHandler }
+						value={ method.description }
+						placeholder={ translate( 'Make your payment directly into our bank account.' ) }
+					/>
+				</FormFieldset>
+				<FormFieldset className="payments__method-edit-field-container">
+					<FormLabel>
+						{ translate( 'Instructions for customer in order email notification' ) }
+					</FormLabel>
+					<FormTextarea
+						name="instructions"
+						onChange={ this.onEditFieldHandler }
+						value={ settings.instructions.value }
+						placeholder={ translate( 'Use these bank account details…' ) }
+					/>
+				</FormFieldset>
+				<FormFieldset className="payments__method-edit-field-container">
+					<FormLegend>
+						{ translate( 'Account Details', { note: 'Fieldset legend for bank account details' } ) }
+					</FormLegend>
+					<FormFieldset className="payments__method-edit-field-container">
+						<FormLabel>{ translate( 'Account Name' ) }</FormLabel>
+						<FormTextInput
+							name="account_name"
+							onChange={ this.onEditAccountHandler }
+							value={ accountData.account_name }
+						/>
+					</FormFieldset>
+					<FormFieldset className="payments__method-edit-field-container">
+						<FormLabel>{ translate( 'Account Number' ) }</FormLabel>
+						<FormTextInput
+							name="account_number"
+							onChange={ this.onEditAccountHandler }
+							value={ accountData.account_number }
+						/>
+					</FormFieldset>
+					<FormFieldset className="payments__method-edit-field-container">
+						<FormLabel>{ translate( 'Bank Name' ) }</FormLabel>
+						<FormTextInput
+							name="bank_name"
+							onChange={ this.onEditAccountHandler }
+							value={ accountData.bank_name }
+						/>
+					</FormFieldset>
+					<FormFieldset className="payments__method-edit-field-container">
+						<FormLabel>{ translate( 'Routing Number' ) }</FormLabel>
+						<FormTextInput
+							name="sort_code"
+							onChange={ this.onEditAccountHandler }
+							value={ accountData.sort_code }
+						/>
+					</FormFieldset>
+					<FormFieldset className="payments__method-edit-field-container">
+						<FormLabel>{ translate( 'IBAN' ) }</FormLabel>
+						<FormTextInput
+							name="iban"
+							onChange={ this.onEditAccountHandler }
+							value={ accountData.iban }
+						/>
+					</FormFieldset>
+					<FormFieldset className="payments__method-edit-field-container">
+						<FormLabel>{ translate( 'BIC / Swift' ) }</FormLabel>
+						<FormTextInput
+							name="bic"
+							onChange={ this.onEditAccountHandler }
+							value={ accountData.bic }
+						/>
+					</FormFieldset>
+				</FormFieldset>
+			</Dialog>
+		);
+	}
+}
+
+export default localize( PaymentMethodBACS );

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
@@ -62,7 +62,7 @@ class PaymentMethodBACS extends Component {
 
 	getAccountData = props => {
 		const { method: { settings } } = props || this.props;
-		const accountData = get( settings, [ 'accounts', 'value' ] );
+		const accountData = get( settings, [ 'accounts', 'value' ], [] );
 
 		return accountData.length
 			? accountData[ 0 ]

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
@@ -17,6 +17,7 @@ import Dialog from 'components/dialog';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextarea from 'components/forms/form-textarea';
 import FormPasswordInput from 'components/forms/form-password-input';
 import FormTextInput from 'components/forms/form-text-input';
@@ -134,6 +135,9 @@ class PaymentMethodBACS extends Component {
 						onChange={ this.onEditAccountHandler }
 						value={ accountData.account_name }
 					/>
+					<FormSettingExplanation>
+						{ translate( 'This is for your reference' ) }
+					</FormSettingExplanation>
 				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container">
 					<FormLabel>{ translate( 'Bank Name' ) }</FormLabel>
@@ -166,7 +170,7 @@ class PaymentMethodBACS extends Component {
 							checked={ showInternational }
 							onChange={ this.updateInternationalVisibility }
 						/>
-						{ translate( 'Edit International Account Options' ) }
+						{ translate( 'I want to offer BACS payment as an option to international customers' ) }
 					</FormLabel>
 				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container is-international-option">
@@ -176,6 +180,9 @@ class PaymentMethodBACS extends Component {
 						onChange={ this.onEditAccountHandler }
 						value={ accountData.iban }
 					/>
+					<FormSettingExplanation>
+						{ translate( 'You can obtain your IBAN number from your bank' ) }
+					</FormSettingExplanation>
 				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container is-international-option">
 					<FormLabel>{ translate( 'BIC / Swift' ) }</FormLabel>

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -29,6 +29,7 @@ import FormLabel from 'components/forms/form-label';
 import { hasStripeKeyPairForMode } from './stripe/payment-method-stripe-utils';
 import ListItem from 'woocommerce/components/list/list-item';
 import ListItemField from 'woocommerce/components/list/list-item-field';
+import PaymentMethodBACS from './payment-method-bacs';
 import PaymentMethodEditDialog from './payment-method-edit-dialog';
 import PaymentMethodEditFormToggle from './payment-method-edit-form-toggle';
 import PaymentMethodPaypal from './payment-method-paypal';
@@ -144,6 +145,18 @@ class PaymentMethodItem extends Component {
 				/>
 			);
 		}
+
+		if ( method.id === 'bacs' ) {
+			return (
+				<PaymentMethodBACS
+					method={ currentlyEditingMethod }
+					onCancel={ this.onCancel }
+					onEditField={ this.onEditField }
+					onDone={ this.onDone }
+				/>
+			);
+		}
+
 		return (
 			<PaymentMethodEditDialog
 				method={ currentlyEditingMethod }

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-list.js
@@ -53,11 +53,6 @@ class SettingsPaymentsMethodList extends Component {
 
 	renderMethodItem = method => {
 		const { site } = this.props;
-		// Disable BACS and Cheque payment for now until #16630 and #16629 are fixed.
-		if ( 'bacs' === method.id ) {
-			return null;
-		}
-
 		return <PaymentMethodItem method={ method } key={ method.title } site={ site } />;
 	};
 

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -19,6 +19,20 @@
 			}
 		}
 	}
+
+	.is-international-option {
+		display: none;
+	}
+
+	&.show-international-options {
+		.is-international-option {
+			display: block;
+		}
+	}
+}
+
+.payments__edit-international-options-checkbox {
+	margin-right: 8px;
 }
 
 .payments__address-currency-container {


### PR DESCRIPTION
This closes #16630. Currently the BACS payment type is hidden on the settings screen due to not exposing the requisite fields to add bank account information. Now that we have added the ability to do so via the API via `wc-calypso-bridge`, this branch adds in the form fields to enable editing bank account data.

One 🔑  difference between this and `wp-admin` is we only allow the management of one bank account via the calypso interface. If the need arises, we could always revisit this choice in the future.

__Design__
I have just added in a new `<fieldset>` with a `<legend>` for the Account details - it looks a little rough at the moment, and I'm not sure we need to have the Account Details bit, but hopefully @jameskoster or @kellychoffman can chime in on that part:

![payment_settings_ _timmy_s_flies_ _wordpress_com](https://user-images.githubusercontent.com/22080/33226207-5a027946-d13d-11e7-90a9-18626f6fa8c3.png)

__To Test__
- Visit your store settings page http://calypso.localhost:3000/store/settings/low-value-long-named-domain.blog and note that the BACS option ( Bank Account ) is now shown
- Click manage, and fill in some form fields for account details and click Done
- Save the settings, hard refresh, and verify all your changes have persisted