### PR TITLE
Codemods: single tree rendering - drop makeNavigation

### DIFF
--- a/bin/codemods/src/single-tree-rendering.js
+++ b/bin/codemods/src/single-tree-rendering.js
@@ -419,24 +419,6 @@ export default function transformer( file, api ) {
 		}
 	}
 
-	// Replace `navigation` with `makeNavigation` in:
-	// `import { navigation } from 'my-sites/controller'`
-	const importMySitesController = root
-		.find( j.ImportDeclaration, {
-			source: {
-				value: 'my-sites/controller',
-			},
-		} )
-		.filter( p => p.value.specifiers.some( n => n.local.name === 'navigation' ) )
-		.replaceWith( p => {
-			p.value.specifiers = p.value.specifiers.map( specifier => {
-				return specifier.local.name === 'navigation'
-					? j.importSpecifier( j.identifier( 'makeNavigation' ) )
-					: specifier;
-			} );
-			return p.value;
-		} );
-
 	// Add makeLayout and clientRender middlewares to route definitions
 	const routeDefs = root
 		.find( j.CallExpression, {
@@ -455,14 +437,6 @@ export default function transformer( file, api ) {
 			);
 		} )
 		.forEach( p => {
-			// Replace `navigation` with `makeNavigation` for files which had
-			// `import { navigation } from 'my-sites/controller'`
-			if ( importMySitesController.size() ) {
-				p.value.arguments = p.value.arguments.map( argument => {
-					return argument.name === 'navigation' ? j.identifier( 'makeNavigation' ) : argument;
-				} );
-			}
-
 			p.value.arguments.push( j.identifier( 'makeLayout' ) );
 			p.value.arguments.push( j.identifier( 'clientRender' ) );
 		} );


### PR DESCRIPTION
_Part of [single tree rendering project](https://github.com/Automattic/wp-calypso/projects/53)._

Reverse #19998:

Don't transform `navigation` middlewares imported from `my-sites/controller` to `makeNavigation` middlewares.

This will simplify the codemod a bit (something it really needs, we'll be less likely hit regressions with less logic).

There were quite a few of `navigation` and `sites` middlewares to be transformed to `makeNavigation` and `makeSites`, but not so many other way around. I decided to stick to middlewares without `make` word in front of them.

When running the codemod, simply clean out `makeNavigation` (and `makeSites`) middlewares manually.

### Testing

```bash
npm run codemod single-tree-rendering \
 ./client/extensions/wp-super-cache/index.js \
 ./client/my-sites/types/index.js \
 ./client/my-sites/comments/index.js \
 ./client/post-editor/index.js
```

→ In results `navigation`, `makeNavigation` middlewares remain untouched.