### PR TITLE
Site Settings: adjust  the`plan` prop in the SEO Banner to use Jetpack-specific constant

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -57,7 +57,7 @@ import { activateModule } from 'state/jetpack/modules/actions';
 import { isBusiness, isEnterprise, isJetpackBusiness } from 'lib/products-values';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { getPlugins } from 'state/plugins/installed/selectors';
-import { FEATURE_SEO_PREVIEW_TOOLS, PLAN_BUSINESS } from 'lib/plans/constants';
+import { FEATURE_SEO_PREVIEW_TOOLS, PLAN_JETPACK_BUSINESS } from 'lib/plans/constants';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import QuerySiteSettings from 'components/data/query-site-settings';
@@ -405,7 +405,7 @@ export class SeoForm extends React.Component {
 						) }
 						event={ 'calypso_seo_settings_upgrade_nudge' }
 						feature={ FEATURE_SEO_PREVIEW_TOOLS }
-						plan={ PLAN_BUSINESS }
+						plan={ PLAN_JETPACK_BUSINESS }
 						title={ nudgeTitle }
 					/>
 				) }


### PR DESCRIPTION
Currently we use `PLAN_BUSINESS` constant as a prop in the Jetpack upgrade Banner. 
Here we change it to the Jetpack specific one `PLAN_JETPACK_BUSINESS`.

Preparatory step for https://github.com/Automattic/wp-calypso/pull/20204

**To test:**
This does not introduce any changes to the behavior:
- `/settings/traffic/:jetpack_connected_site` is the only occurrence of the SEO Banner
- it redirects to `/plans/:site` and the `plan` prop is not used in the `Plan` component at the moment