### PR TITLE
Post Revisions: Rework layout of main post revisions containers

### DIFF
--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -1,19 +1,10 @@
 /** @format */
 .editor-diff-viewer {
+	flex: 1;
 	margin: 0;
-	position: absolute;
-	top: 120px;
-	bottom: 72px;
-	left: 0;
-	width: 100%;
-	box-sizing: border-box;
 	padding: 24px 32px 32px 32px;
+	box-sizing: border-box;
 	overflow-y: auto;
-
-	@include breakpoint( '>660px' ) {
-		top: 0;
-		width: calc(100% - 230px);
-	}
 
 	.editor-diff-viewer__title {
 		font-family: $serif;

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -3,21 +3,16 @@
 @import 'components/accordion/style';
 
 .editor-revisions-list {
-	position: absolute;
-	top: 0;
-	right: 0;
+	position: relative;
 	background: $gray-light;
-
-	@include breakpoint( '<660px' ) {
-		left: 0;
-		height: 120px;
-	}
+	flex-basis: 120px;
+	flex-grow: 0;
+	flex-shrink: 0;
 
 	@include breakpoint( '>660px' ) {
 		border-left: 1px solid darken($sidebar-bg-color, 5%);
 		z-index: 1; // Put the list above the action-buttons:before overlay gradient. -shaun
-		width: 230px;
-		bottom: 73px;
+		flex-basis: 230px;
 	}
 }
 
@@ -54,6 +49,10 @@
 	bottom: 0;
 	left: 0;
 	overflow-y: auto;
+
+	@include breakpoint( '<660px' ) {
+		overflow-y: hidden;
+	}
 }
 
 .editor-revisions-list__list {

--- a/client/post-editor/editor-revisions/style.scss
+++ b/client/post-editor/editor-revisions/style.scss
@@ -1,12 +1,19 @@
 /** @format */
 .editor-revisions__dialog {
+	display: flex;
 	padding: 0;
-	overflow-x: hidden;
 }
 
 .editor-revisions__wrapper {
-	height: 100vh;
-	width: 100vw;
+	display: flex;
+	width: 90vw;
+	height: calc(90vh - 73px);
+
+	@include breakpoint( '<660px' ) {
+		flex-direction: column-reverse;
+		width: 100vw;
+		height: calc(100vh - 73px);
+	}
 }
 
 .editor-revisions__wpadmin-link {


### PR DESCRIPTION
## This PR
- adds a rework of the layout of the main post revisions containers
- resolves several cross-browser issues incl. diff content not showing in Safari

## How to test

Repeat the following in Chrome, Safari, Firefox & Edge 
(if you're missing any you could use browserstack.com)

- Use the calypso.live link below or check out locally
- Navigate to or create a post with revisions
- Click on the `History` button to trigger the Post Revisions modal
- The revisions should load including their content
- Open wpcalypso.wordpress.com in a second tab
- Repeat the same process in the second tab as described above
- The visual appearance of tab 1 and tab 2 should basically be identical

## Cross-browser testing

**Chrome**
Everything should look like before. 
In addition, all content should now always stay in the modal, even when resizing erratically.

<img width="1115" alt="screen shot 2017-11-27 at 00 05 45" src="https://user-images.githubusercontent.com/1562646/33253389-c7030b74-d308-11e7-9ad6-5e71e0d7c011.png">

**Safari**
Safari should now always display the diff content after it's been computed. 
No weird hardware acceleration hack needed anymore, it just works. Fixes #20000 .

<img width="1116" alt="screen shot 2017-11-27 at 00 07 10" src="https://user-images.githubusercontent.com/1562646/33253499-5664f548-d309-11e7-95ba-aad276fb6a57.png">

**Firefox**
Surf around, any intermittent glitches observed previously should be gone. 
If you don't spot anything that's a good sign :)

<img width="1116" alt="screen shot 2017-11-27 at 00 06 30" src="https://user-images.githubusercontent.com/1562646/33253511-613e658a-d309-11e7-9e39-85e5bc76a273.png">

**Edge**
Yep, even Edge should look good now. 🎉

<img width="1104" alt="screen shot 2017-11-27 at 00 09 57" src="https://user-images.githubusercontent.com/1562646/33253631-f4828f24-d309-11e7-9167-00bcf67b4f31.png">

