### PR TITLE
Analytics: Correct non-compliant default import obj destructure

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -46,9 +46,10 @@ import {
 	getGlobalSelectedPlan,
 	isCalypsoStartedConnection,
 } from 'state/jetpack-connect/selectors';
-import { mc } from 'lib/analytics';
+import analytics from 'lib/analytics';
 import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
 
+const { mc } = analytics;
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 const CALYPSO_PLANS_PAGE = '/plans/my-plan/';
 const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';

--- a/client/layout/community-translator/invitation.jsx
+++ b/client/layout/community-translator/invitation.jsx
@@ -13,7 +13,9 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import invitationUtils from './invitation-utils';
-import { ga as googleAnalytics } from 'lib/analytics';
+import analytics from 'lib/analytics';
+
+const { ga: googleAnalytics } = analytics;
 
 class CommunityTranslatorInvitation extends React.Component {
 	static displayName = 'CommunityTranslatorInvitation';

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -12,7 +12,7 @@ import { defer } from 'lodash';
 /**
  * Internal dependencies
  */
-import { tracks } from 'lib/analytics';
+import analytics from 'lib/analytics';
 import AllTours from 'layout/guided-tours/config';
 import QueryPreferences from 'components/data/query-preferences';
 import RootChild from 'components/root-child';
@@ -24,6 +24,8 @@ import {
 	quitGuidedTour,
 	resetGuidedToursHistory,
 } from 'state/ui/guided-tours/actions';
+
+const { tracks } = analytics;
 
 class GuidedTours extends Component {
 	shouldComponentUpdate( nextProps ) {

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -16,7 +16,7 @@ import emitter from 'lib/mixins/emitter';
 import { runFastRules, runSlowRules } from 'state/reader/posts/normalization-rules';
 import { action as FeedPostActionType } from './constants';
 import { action as FeedStreamActionType } from 'lib/feed-stream-store/constants';
-import { mc } from 'lib/analytics';
+import analytics from 'lib/analytics';
 import { pageViewForPost } from 'reader/stats';
 import { updateConversationFollowStatus } from 'state/reader/conversations/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
@@ -31,8 +31,8 @@ import { reduxDispatch } from 'lib/redux-bridge';
  */
 const debug = debugModule( 'calypso:feed-post-store' );
 
-let _posts = {},
-	_postsForBlogs = {};
+let _posts = {};
+let _postsForBlogs = {};
 
 function blogKey( postKey ) {
 	return postKey.blogId + '-' + postKey.postId;
@@ -325,7 +325,10 @@ function markPostSeen( post, site ) {
 		if ( site && site.ID ) {
 			if ( site.is_private || ! isAdmin ) {
 				pageViewForPost( site.ID, site.URL, post.ID, site.is_private );
-				mc.bumpStat( 'reader_pageviews', site.is_private ? 'private_view' : 'public_view' );
+				analytics.mc.bumpStat(
+					'reader_pageviews',
+					site.is_private ? 'private_view' : 'public_view'
+				);
 			}
 		}
 	}

--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -16,11 +16,12 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import { isEnabled } from 'config';
-import { ga } from 'lib/analytics';
+import analytics from 'lib/analytics';
 import { userCan } from 'lib/posts/utils';
 import { isPublicizeEnabled } from 'state/selectors';
 import { getSiteSlug, isSitePreviewable } from 'state/sites/selectors';
 
+const { ga } = analytics;
 const edit = () => ga.recordEvent( 'Posts', 'Clicked Edit Post' );
 const copy = () => ga.recordEvent( 'Posts', 'Clicked Copy Post' );
 const viewStats = () => ga.recordEvent( 'Posts', 'Clicked View Post Stats' );

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -12,7 +12,7 @@ import { translate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import notices from 'notices';
-import { pageView } from 'lib/analytics';
+import analytics from 'lib/analytics';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import { sectionify } from 'lib/route';
 import Sharing from './main';
@@ -21,6 +21,7 @@ import SharingConnections from './connections/connections';
 import sites from 'lib/sites-list';
 import utils from 'lib/site/utils';
 
+const { pageView } = analytics;
 const analyticsPageTitle = 'Sharing';
 
 export const layout = context => {

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -13,7 +13,7 @@ import { some } from 'lodash';
  */
 import DeleteSiteWarningDialog from 'my-sites/site-settings/delete-site-warning-dialog';
 import config from 'config';
-import { tracks } from 'lib/analytics';
+import analytics from 'lib/analytics';
 import { localize } from 'i18n-calypso';
 import SectionHeader from 'components/section-header';
 import SiteToolsLink from './link';
@@ -28,7 +28,7 @@ import {
 import notices from 'notices';
 
 const trackDeleteSiteOption = option => {
-	tracks.recordEvent( 'calypso_settings_delete_site_options', {
+	analytics.tracks.recordEvent( 'calypso_settings_delete_site_options', {
 		option: option,
 	} );
 };

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -24,7 +24,7 @@ import DropdownItem from 'components/select-dropdown/item';
 import touchDetect from 'lib/touch-detect';
 import postActions from 'lib/posts/actions';
 import { recordEvent, recordStat } from 'lib/posts/stats';
-import { tracks } from 'lib/analytics';
+import analytics from 'lib/analytics';
 import accept from 'lib/accept';
 import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -104,7 +104,7 @@ class EditorVisibility extends React.Component {
 		if ( this.getVisibility() !== newVisibility ) {
 			recordStat( 'visibility-set-' + newVisibility );
 			recordEvent( 'Changed visibility', newVisibility );
-			tracks.recordEvent( 'calypso_editor_visibility_set', {
+			analytics.tracks.recordEvent( 'calypso_editor_visibility_set', {
 				context: this.props.context,
 				visibility: newVisibility,
 			} );

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -8,8 +8,9 @@ import debugFactory from 'debug';
 /**
  * Internal Dependencies
  */
-import { mc, ga, tracks } from 'lib/analytics';
+import analytics from 'lib/analytics';
 
+const { mc, ga, tracks } = analytics;
 const debug = debugFactory( 'calypso:reader:stats' );
 
 export function recordAction( action ) {

--- a/client/state/analytics/test/middleware.js
+++ b/client/state/analytics/test/middleware.js
@@ -19,8 +19,11 @@ import {
 	setTracksAnonymousUserId,
 } from '../actions';
 import { dispatcher as dispatch } from '../middleware.js';
-import { spy as mockAnalytics } from 'lib/analytics';
-import { spy as mockAdTracking } from 'lib/analytics/ad-tracking';
+import analytics from 'lib/analytics';
+import adTracking from 'lib/analytics/ad-tracking';
+
+const { spy: mockAnalytics } = analytics;
+const { spy: mockAdTracking } = adTracking;
 
 jest.mock( 'lib/analytics', () => {
 	const analyticsSpy = require( 'sinon' ).spy();

--- a/client/state/reader/posts/test/actions.js
+++ b/client/state/reader/posts/test/actions.js
@@ -9,10 +9,11 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import * as actions from '../actions';
-import { tracks } from 'lib/analytics';
+import analytics from 'lib/analytics';
 import { READER_POSTS_RECEIVE } from 'state/action-types';
 import wp from 'lib/wp';
 
+const { tracks } = analytics;
 const undocumented = wp.undocumented;
 
 jest.mock( 'lib/analytics', () => ( {


### PR DESCRIPTION
The lib/analytics module exports and object as default. Destructuring
this object in an import is non-compliant and creates errors as soon as
a named export is added to lib/analytics.

Correct to import the object then use destructuring assignments to
access the properties, or access them directly.

No functional changes.

See #20119. Required for #20236

## Testing
1. Look for more incorrect usage. Here's what I've used:
   ```sh
   $ ack "\}\s*from\s*["'"'"']lib/analytics/?(?:index(?:\.jsx?)?)?["'"'"']" client server
   ```
1. Visually inspect the changes for correctness.
1. Ensure there are no behavioral changes in the modified files.
