### PR TITLE
Polyfill for all supported browser in Calypso for DNT

### DIFF
--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -17,7 +17,13 @@ const debug = debugFactory( 'calypso:analytics:utils' );
  * @returns {Boolean} true if Do Not Track is enabled in the user's browser.
  */
 export function doNotTrack() {
-	const result = '1' === navigator.doNotTrack;
+	const result = Boolean(
+		window &&
+			// Internet Explorer 11 uses window.doNotTrack rather than navigator.doNotTrack.
+			// Safari 7.1.3+ uses window.doNotTrack rather than navigator.doNotTrack.
+			// MDN ref: https://developer.mozilla.org/en-US/docs/Web/API/navigator/doNotTrack#Browser_compatibility
+			( window.doNotTrack === '1' || ( window.navigator && window.navigator.doNotTrack === '1' ) )
+	);
 	debug( `Do Not Track: ${ result }` );
 	return result;
 }


### PR DESCRIPTION
We're currently not recognising any DNT folks coming from Edge/IE. This is an attempt at fixing it. On top of more closely following what the current code was set out to do, it will allow us to get a better figure on how many folks have DNT enabled in Calypso which is currently used to design a full on opt-out of tracking mechanism.

Since Calypso is only supporting recent browsers, we don't have to import a full-on DNT polyfill [like this one](https://github.com/jhobz/dnt-polyfill/blob/master/index.js). I kept most of the comments though if we ever want to revisit it in a couple of years and remove it once Edge / IE fixes it 🤞 
