### PR TITLE
Save DNT alongside `calypso_stats_blocked` to figure out how well the 2 overlap

### DIFF
--- a/server/boot/index.js
+++ b/server/boot/index.js
@@ -81,7 +81,13 @@ function setup() {
 	// loaded when we detect stats blockers - see lib/analytics/index.js
 	app.get( '/nostats.js', function( request, response ) {
 		const analytics = require( '../lib/analytics' );
-		analytics.tracks.recordEvent( 'calypso_stats_blocked', {}, request );
+		analytics.tracks.recordEvent(
+			'calypso_stats_blocked',
+			{
+				do_not_track: request.headers.dnt,
+			},
+			request
+		);
 		response.setHeader( 'content-type', 'application/javascript' );
 		response.end( "console.log('Stats are disabled');" );
 	} );


### PR DESCRIPTION
This is to gather another datapoint in the quest to architect a proper opt-out mechanism.

Using server-side DNT (`request.headers.dnt`) instead of passing the client-side (`navigator.doNotTrack`) one to figure out if we see any discrepancies between the two which could also influence a bit the implementation of a proper opt-out mechanism.