### PR TITLE
Do not QueryJetpackCredentials unless isRewindActive is true

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -599,7 +599,7 @@ class ActivityLog extends Component {
 				<QueryActivityLog siteId={ siteId } { ...logRequestQuery } />
 				{ siteId && isRewindActive && <QueryRewindBackupStatus siteId={ siteId } /> }
 				<QuerySiteSettings siteId={ siteId } />
-				<QueryJetpackCredentials siteId={ siteId } />
+				{ isRewindActive && <QueryJetpackCredentials siteId={ siteId } /> }
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />


### PR DESCRIPTION
We should not Query for credentials on the Activity Log page unless a site is flagged with `isRewindActive=true`.

**Testing instructions:**
Visit the activity log page for a non-rewind site. You should not receive the following error:

![screen shot 2017-11-27 at 11 08 32 am](https://user-images.githubusercontent.com/5528445/33276339-52903d9c-d363-11e7-9824-656a9cf14248.png)
