### PR TITLE
Hide Activity tab in My Sites > Stats for Atomic sites

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -14,7 +14,7 @@ import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
 import Intervals from './intervals';
 import FollowersCount from 'blocks/followers-count';
-import { isPluginActive } from 'state/selectors';
+import { isPluginActive, isSiteAutomatedTransfer } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { navItems, intervals as intervalConstants } from './constants';
 import { getJetpackSites } from 'state/selectors';
@@ -33,10 +33,10 @@ class StatsNavigation extends Component {
 	};
 
 	isValidItem = item => {
-		const { isStore, isJetpack } = this.props;
+		const { isStore, isAtomic, isJetpack } = this.props;
 		switch ( item ) {
 			case 'activity':
-				return config.isEnabled( 'jetpack/activity-log' ) && isJetpack;
+				return config.isEnabled( 'jetpack/activity-log' ) && isJetpack && ! isAtomic;
 			case 'store':
 				return isStore;
 			default:
@@ -83,6 +83,7 @@ export default connect( ( state, { siteId } ) => {
 	return {
 		isJetpack,
 		jetPackSites: getJetpackSites( state ),
+		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isStore: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
 		siteId,
 	};


### PR DESCRIPTION
The Activity tab should not show in My Sites > Stats for Atomic sites. This PR hides it.

**Testing Instructions**
- Visit the stats page, and observe the Activity tab is present on a non-atomic Activity Log site.
- Visit the stats page for an atomic site (as a non-a11n for good measure) and ensure the Activity tab is hidden.