### PR TITLE
Framework: add error boundaries to Devdocs

### DIFF
--- a/client/devdocs/docs-example/error.jsx
+++ b/client/devdocs/docs-example/error.jsx
@@ -1,0 +1,14 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const DocsExampleError = () => (
+	<div className="docs-example__error">
+		<p>Oops! There was a problem loading this example. Check the browser console.</p>
+	</div>
+);
+
+export default DocsExampleError;

--- a/client/devdocs/docs-example/wrapper.jsx
+++ b/client/devdocs/docs-example/wrapper.jsx
@@ -7,6 +7,11 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import DocsExampleError from 'devdocs/docs-example/error';
+
 const renderTitle = ( unique, name, url ) =>
 	unique ? (
 		<h2 className="docs-example__wrapper-header-title">{ name }</h2>
@@ -23,6 +28,14 @@ class DocsExampleWrapper extends Component {
 		url: PropTypes.string.isRequired,
 	};
 
+	state = {
+		hasError: false,
+	};
+
+	componentDidCatch() {
+		this.setState( { hasError: true } );
+	}
+
 	render() {
 		const { children, name, unique, url } = this.props;
 
@@ -34,7 +47,9 @@ class DocsExampleWrapper extends Component {
 			>
 				<div className="docs-example__wrapper-header">{ renderTitle( unique, name, url ) }</div>
 				<div className="docs-example__wrapper-content">
-					<span className="docs-example__wrapper-content-centering">{ children }</span>
+					<span className="docs-example__wrapper-content-centering">
+						{ this.state.hasError ? <DocsExampleError /> : children }
+					</span>
 				</div>
 			</div>
 		);


### PR DESCRIPTION
This PR takes advantage of React 16's error boundaries in devdocs:

https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html

If a component example breaks, it will no longer break the rest of the documentation.

### To test

Visit http://calypso.localhost:3000/devdocs/design and sabotage the code for one of the component examples. 

Ensure you see an 'oops' message for the broken component and that other examples still work.