### PR TITLE
Reader: remove un-used post-not-found

### DIFF
--- a/client/blocks/reader-full-post/README.md
+++ b/client/blocks/reader-full-post/README.md
@@ -8,7 +8,6 @@ The "new" reader full post component
 - `blogId`: The blog id for the post
 - `postId`: The post id
 - `onClose`: An onClose event handler function
-- `onPostNotFound` : A Post not found handler function
 
 *optional*
 - `referral`: An object containing a `blogId` and `postId`

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -509,7 +509,6 @@ export default class FullPostFluxContainer extends React.Component {
 		blogId: PropTypes.string,
 		postId: PropTypes.string.isRequired,
 		onClose: PropTypes.func.isRequired,
-		onPostNotFound: PropTypes.func.isRequired,
 		referral: PropTypes.object,
 	};
 

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -3,34 +3,17 @@
  * External Dependencies
  */
 import React from 'react';
-import i18n from 'i18n-calypso';
 import page from 'page';
 import { defer } from 'lodash';
 
 /**
  * Internal Dependencies
  */
-import FeedError from 'reader/feed-error';
-import { setPageTitle, trackPageLoad } from 'reader/controller-helper';
+import { trackPageLoad } from 'reader/controller-helper';
 import AsyncLoad from 'components/async-load';
 import { renderWithReduxStore } from 'lib/react-helpers';
 
 const analyticsPageTitle = 'Reader';
-
-function renderPostNotFound() {
-	const sidebarAndPageTitle = i18n.translate( 'Post not found' );
-
-	setPageTitle( context, sidebarAndPageTitle );
-
-	renderWithReduxStore(
-		<FeedError
-			sidebarTitle={ sidebarAndPageTitle }
-			message={ i18n.translate( 'Post Not Found' ) }
-		/>,
-		document.getElementById( 'primary' ),
-		context.store
-	);
-}
 
 const scrollTopIfNoHash = () =>
 	defer( () => {
@@ -61,7 +44,6 @@ export function blogPost( context ) {
 			onClose={ function() {
 				page.back( context.lastRoute || '/' );
 			} }
-			onPostNotFound={ renderPostNotFound }
 		/>,
 		document.getElementById( 'primary' ),
 		context.store
@@ -88,7 +70,6 @@ export function feedPost( context ) {
 			postId={ postId }
 			onClose={ closer }
 			referralStream={ context.lastRoute }
-			onPostNotFound={ renderPostNotFound }
 		/>,
 		document.getElementById( 'primary' ),
 		context.store


### PR DESCRIPTION
- Removes un-used `onPostNotFound` prop from `reader-full-post` block.
- Removes un-used `renderPostNotFound` function from `reader/full-post` controller.

Reader's "not found" errors are these days handled [directly in the block](https://github.com/Automattic/wp-calypso/blob/fix/reader-remove-unused-post-not-found/client/blocks/reader-full-post/index.jsx#L287).

Ref https://github.com/Automattic/wp-calypso/pull/19494#discussion_r153052147

### Test
Check "post not found" routes continue working, e.g.: 
- http://calypso.localhost:3000/read/blogs/1/posts/123 (blog nor post exist)
- http://calypso.localhost:3000/read/feeds/1/posts/123 (blog nor post exist)
- http://calypso.localhost:3000/read/feeds/45339984/posts/123 (blog exists, post doesn't)
