### PR TITLE
Store Orders: Enable editing on staging & production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -133,7 +133,7 @@
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-orders-create": false,
-		"woocommerce/extension-orders-edit": false,
+		"woocommerce/extension-orders-edit": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -140,7 +140,7 @@
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
 		"woocommerce/extension-orders-create": false,
-		"woocommerce/extension-orders-edit": false,
+		"woocommerce/extension-orders-edit": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,


### PR DESCRIPTION
Fixes #15681 🎉  This PR opens order editing to staging & production. It is already enabled on wpcalypso and development.

~Note: waiting on deployment of an API fix.~ Ready!