### PR TITLE
Analytics: Export props by name

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -513,4 +513,9 @@ const analytics = {
 	},
 };
 emitter( analytics );
+
 export default analytics;
+export const ga = analytics.ga;
+export const mc = analytics.mc;
+export const pageView = analytics.pageView;
+export const tracks = analytics.tracks;


### PR DESCRIPTION
We're using non-compliant default object destructuring imports, which breaks as soon as you add a named import.

This PR makes the destructured properties that are in use from the exported from the default `analytics` object available as named exports from the `lib/analytics` module, bringing our usage into compliance.

Required for #20236 (more info there).

Alternative #20247 and #20237 