### PR TITLE
Update shipping label settings UI after a succesful save

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/label-settings/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/label-settings/actions.js
@@ -59,13 +59,16 @@ export const fetchSettings = siteId => ( dispatch, getState ) => {
 
 export const submit = ( siteId, onSaveSuccess, onSaveFailure ) => ( dispatch, getState ) => {
 	dispatch( setFormMetaProperty( siteId, 'isSaving', true ) );
+	dispatch( setFormMetaProperty( siteId, 'pristine', true ) );
 	api
 		.post( siteId, api.url.accountSettings, getLabelSettingsFormData( getState() ) )
 		.then( onSaveSuccess )
-		.catch( onSaveFailure )
+		.catch( err => {
+			dispatch( setFormMetaProperty( siteId, 'pristine', false ) );
+			return onSaveFailure( err );
+		} )
 		.then( () => {
 			dispatch( setFormMetaProperty( siteId, 'isSaving', false ) );
-			dispatch( setFormMetaProperty( siteId, 'pristine', true ) );
 		} );
 };
 


### PR DESCRIPTION
Steps to reproduce:
* Be in a store without everything configured yet (the `checklist` onboarding state)
* Go to the Shipping Settings page, change anything about the Labels Settings
* Save
* You'll be redirected instantly to the dashboard, and after a few seconds you'll see the "Success" notice
* Go back to the Shipping Settings page

Old behaviour: The Label Settings section reverted to its previous state
New (expected) behaviour: The Label Settings section shows the saved values

The cause was that, when the user navigates away from the Shipping Settings screen, a `componentWillUnmount` hook will be triggered and the Label form will be reset to its "pristine" state.
When saving while in the "Momma" state (dashboard with the checklist), the user is immediately redirected after triggering a `Save`, so the page navigates away before saving is completed and the form is reset.

The fix is doing an optimistic update, meaning that the form is marked as `pristine` as soon as the Save button is clicked. That way the form won't be reset.