### PR TITLE
Store Orders: Add analytics for tracking edit, save, & cancel actions

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -13,6 +13,7 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import ActionHeader from 'woocommerce/components/action-header';
+import analytics from 'lib/analytics';
 import Button from 'components/button';
 import { clearOrderEdits, editOrder } from 'woocommerce/state/ui/orders/actions';
 import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
@@ -68,6 +69,7 @@ class Order extends Component {
 	// Put this order into the editing state
 	toggleEditing = () => {
 		const { siteId, orderId } = this.props;
+		analytics.tracks.recordEvent( 'calypso_woocommerce_order_edit_start' );
 		if ( siteId ) {
 			this.props.editOrder( siteId, { id: orderId } );
 		}
@@ -76,12 +78,14 @@ class Order extends Component {
 	// Clear this order's edits, takes it out of edit state
 	cancelEditing = () => {
 		const { siteId } = this.props;
+		analytics.tracks.recordEvent( 'calypso_woocommerce_order_edit_cancel' );
 		this.props.clearOrderEdits( siteId );
 	};
 
 	// Saves changes to the remote site via API
 	saveOrder = () => {
 		const { siteId, order } = this.props;
+		analytics.tracks.recordEvent( 'calypso_woocommerce_order_edit_save' );
 		this.props.updateOrder( siteId, order );
 	};
 

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -13,7 +13,6 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import ActionHeader from 'woocommerce/components/action-header';
-import analytics from 'lib/analytics';
 import Button from 'components/button';
 import { clearOrderEdits, editOrder } from 'woocommerce/state/ui/orders/actions';
 import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
@@ -32,6 +31,7 @@ import OrderCustomer from './order-customer';
 import OrderDetails from './order-details';
 import OrderActivityLog from './order-activity-log';
 import { ProtectFormGuard } from 'lib/protect-form';
+import { recordTrack } from 'woocommerce/lib/analytics';
 
 class Order extends Component {
 	componentDidMount() {
@@ -69,7 +69,7 @@ class Order extends Component {
 	// Put this order into the editing state
 	toggleEditing = () => {
 		const { siteId, orderId } = this.props;
-		analytics.tracks.recordEvent( 'calypso_woocommerce_order_edit_start' );
+		recordTrack( 'calypso_woocommerce_order_edit_start' );
 		if ( siteId ) {
 			this.props.editOrder( siteId, { id: orderId } );
 		}
@@ -78,14 +78,14 @@ class Order extends Component {
 	// Clear this order's edits, takes it out of edit state
 	cancelEditing = () => {
 		const { siteId } = this.props;
-		analytics.tracks.recordEvent( 'calypso_woocommerce_order_edit_cancel' );
+		recordTrack( 'calypso_woocommerce_order_edit_cancel' );
 		this.props.clearOrderEdits( siteId );
 	};
 
 	// Saves changes to the remote site via API
 	saveOrder = () => {
 		const { siteId, order } = this.props;
-		analytics.tracks.recordEvent( 'calypso_woocommerce_order_edit_save' );
+		recordTrack( 'calypso_woocommerce_order_edit_save' );
 		this.props.updateOrder( siteId, order );
 	};
 


### PR DESCRIPTION
This PR introduces 3 new events to track when users enter & leave the edit state:

- `calypso_woocommerce_order_edit_start`
- `calypso_woocommerce_order_edit_cancel`
- `calypso_woocommerce_order_edit_save`

**To Test**

- Toggle on debug in console: `localStorage.setItem('debug', 'calypso:analytics:*');`
- Reload the page
- View an order, click "Edit Order" to enable editing state
- You should see the event in console, with a prefix `calypso:analytics:tracks`
- Click cancel, this should also fire an event
- Toggle editing back on (see event)
- Make a change to enable the save button, click Save
- See the event in console