### PR TITLE
PostTypeList: Use Photon URL for post thumbnail

### DIFF
--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -55,13 +55,18 @@ const scaleByFactor = value => value * IMAGE_SCALE_FACTOR;
 
 /**
  * Changes the sizing parameters on a URL. Works for WordPress.com, Photon, and
- * Gravatar images
+ * Gravatar images.
+ *
+ * NOTE: Original query string arguments will be stripped from WordPress.com
+ * and Photon images, and preserved for Gravatar images. If an external image
+ * URL containing query string arguments is passed to this function, it will
+ * return `null`.
  *
  * @param   {String}          imageUrl Original image url
  * @param   {(Number|Object)} resize   Resize pixel width, or object of query
  *                                     arguments (assuming Photon or Gravatar)
  * @param   {?Number}         height   Pixel height if specifying resize width
- * @returns {String}                   Resize image URL
+ * @returns {?String}                  Resized image URL, or `null` if unable to resize
  */
 export default function resizeImageUrl( imageUrl, resize, height ) {
 	if ( 'string' !== typeof imageUrl ) {

--- a/client/lib/resize-image-url/test/index.js
+++ b/client/lib/resize-image-url/test/index.js
@@ -20,11 +20,17 @@ describe( 'resizeImageUrl()', () => {
 		expect( resizeImageUrl( 1 ) ).to.equal( 1 );
 	} );
 
-	test( 'should strip original query params', () => {
+	test( 'should strip original query params (WP.com)', () => {
 		const resizedUrl = resizeImageUrl( imageUrl );
 		expect( resizedUrl ).to.equal(
 			'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg'
 		);
+	} );
+
+	test( 'should strip original query params (Photon)', () => {
+		const original = 'https://i0.wp.com/example.com/foo.png?fit=meh';
+		const resizedUrl = resizeImageUrl( original );
+		expect( resizedUrl ).to.equal( 'https://i0.wp.com/example.com/foo.png' );
 	} );
 
 	test( 'should not attempt to resize non-HTTP protocols', () => {
@@ -113,6 +119,12 @@ describe( 'resizeImageUrl()', () => {
 				const resized = resizeImageUrl( original, 40, 20 );
 				const expected = 'https://i0.wp.com/example.com/foo.png?ssl=1&fit=40%2C20';
 				expect( resized ).to.equal( expected );
+			} );
+
+			test( 'returns null for URLs with query string', () => {
+				const original = 'https://example.com/foo.png?bar=baz';
+				const resized = resizeImageUrl( original, 40, 20 );
+				expect( resized ).to.be.null;
 			} );
 		} );
 	} );

--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -33,8 +33,11 @@ const REGEXP_A8C_HOST = /^([-a-zA-Z0-9_]+\.)*(gravatar\.com|wordpress\.com|wp\.c
  * this, we check the host of the URL against a whitelist, and run the image
  * through photon if the host name does not match.
  *
+ * NOTE: This function will return `null` for external URLs with query strings,
+ * because Photon itself does not support this!
+ *
  * @param  {string} url The URL to secure
- * @return {string}     The secured URL, or null if we couldn't make it safe
+ * @return {?string}    The secured URL, or `null` if we couldn't make it safe
  */
 export default function safeImageUrl( url ) {
 	if ( typeof url !== 'string' ) {

--- a/client/my-sites/post-type-list/post-thumbnail.jsx
+++ b/client/my-sites/post-type-list/post-thumbnail.jsx
@@ -14,6 +14,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import resizeImageUrl from 'lib/resize-image-url';
+import safeImageUrl from 'lib/safe-image-url';
 import { getNormalizedPost } from 'state/posts/selectors';
 
 function PostTypeListPostThumbnail( { thumbnail } ) {
@@ -25,7 +26,7 @@ function PostTypeListPostThumbnail( { thumbnail } ) {
 		<div className={ classes }>
 			{ thumbnail && (
 				<img
-					src={ resizeImageUrl( thumbnail, { h: 80 } ) }
+					src={ resizeImageUrl( safeImageUrl( thumbnail ), { h: 80 } ) }
 					className="post-type-list__post-thumbnail"
 				/>
 			) }


### PR DESCRIPTION
This PR uses `safeImageUrl` in `PostTypeListPostThumbnail` so that the post thumbnails are served through Photon.

To test:

* Make sure you're in the `condensedPosts` part of the `condensedPostList` A/B test using the environment badge in the lower right hand corner of the page.
* Using a Jetpack site, verify that the images in "Blog Posts" are being served from Photon.