### PR TITLE
enable user-bootstrapping when secrets are present

### DIFF
--- a/client/lib/create-config/index.js
+++ b/client/lib/create-config/index.js
@@ -1,10 +1,10 @@
 /**
  * Returns configuration value for given key
- * 
+ *
  * If the requested key isn't defined in the configuration
  * data then this will report the failure with either an
  * error or a console warning.
- * 
+ *
  * When in the 'development' NODE_ENV it will raise an error
  * to crash execution early. However, because many modules
  * call this function in the module-global scope a failure
@@ -13,9 +13,9 @@
  * unwanted behaviors. Therefore if the NODE_ENV is not
  * 'development' we will return `undefined` and log a message
  * to the console instead of halting the execution thread.
- * 
+ *
  * The config files are loaded in sequence: _shared.json, {env}.json, {env}.local.json
- * 
+ *
  *
  * @format
  * @see server/config/parser.js

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -123,7 +123,7 @@
 		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
-		"wpcom-user-bootstrap": false
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"wpcom_signup_id": "39911",

--- a/config/stage.json
+++ b/config/stage.json
@@ -153,7 +153,7 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/store-on-non-atomic-sites": true,
-		"wpcom-user-bootstrap": false
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -164,7 +164,7 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/store-on-non-atomic-sites": true,
-		"wpcom-user-bootstrap": false
+		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",

--- a/server/config/parser.js
+++ b/server/config/parser.js
@@ -58,6 +58,15 @@ module.exports = function( configPath, defaultOpts ) {
 		} );
 	}
 
+	if (
+		! ( secretsPath === realSecretsPath ) &&
+		data.features &&
+		data.features[ 'wpcom-user-bootstrap' ]
+	) {
+		console.error( 'Disabling server-side user-bootstrapping because of a missing secrets.json' );
+		data.features[ 'wpcom-user-bootstrap' ] = false;
+	}
+
 	const serverData = assign( {}, data, getDataFromFile( secretsPath ) );
 	const clientData = assign( {}, data );
 

--- a/server/config/test/__mocks__/fs.js
+++ b/server/config/test/__mocks__/fs.js
@@ -23,6 +23,19 @@ function setValidSecrets() {
 	};
 }
 
+function setEmptySecrets() {
+	mockFiles = {
+		'empty-secrets.json': toJSON( {
+			secret: 'fromempty',
+		} ),
+		'_shared.json': toJSON( {
+			features: {
+				'wpcom-user-bootstrap': true,
+			},
+		} ),
+	};
+}
+
 function setValidEnvFiles() {
 	mockFiles = {
 		'_shared.json': toJSON( {
@@ -56,6 +69,7 @@ function readFileSync( file ) {
 }
 
 fs.__setValidSecrets = setValidSecrets;
+fs.__setEmptySecrets = setEmptySecrets;
 fs.__setValidEnvFiles = setValidEnvFiles;
 fs.existsSync = existsSync;
 fs.readFileSync = readFileSync;

--- a/server/config/test/parser.js
+++ b/server/config/test/parser.js
@@ -66,4 +66,17 @@ describe( 'parser', () => {
 
 		expect( data ).toHaveProperty( 'features.disabledFeature2', true );
 	} );
+
+	test( 'should explicitly set user-bootstrapping to false if there are no real secrets', () => {
+		require( 'fs' ).__setEmptySecrets();
+		const errorSpy = jest.fn();
+		global.console = { error: errorSpy };
+
+		parser = require( 'config/parser' );
+		const { serverData, clientData } = parser( '/valid-path' );
+
+		expect( serverData.features[ 'wpcom-user-bootstrap' ] ).toBe( false );
+		expect( clientData.features[ 'wpcom-user-bootstrap' ] ).toBe( false );
+		expect( errorSpy ).toHaveBeenCalledTimes( 1 );
+	} );
 } );

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -261,7 +261,7 @@ function setUpLoggedInRoute( req, res, next ) {
 		'X-Frame-Options': 'SAMEORIGIN',
 	} );
 
-	const context = ( req.context = getDefaultContext( req ) );
+	req.context = getDefaultContext( req );
 
 	if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
 		const user = require( 'user-bootstrap' );
@@ -313,11 +313,11 @@ function setUpLoggedInRoute( req, res, next ) {
 			const end = new Date().getTime() - start;
 
 			debug( 'Rendering with bootstrapped user object. Fetched in %d ms', end );
-			context.user = data;
+			req.context.user = data;
 
 			if ( data.localeSlug ) {
-				context.lang = data.localeSlug;
-				context.store.dispatch( {
+				req.context.lang = data.localeSlug;
+				req.context.store.dispatch( {
 					type: LOCALE_SET,
 					localeSlug: data.localeSlug,
 				} );
@@ -328,7 +328,7 @@ function setUpLoggedInRoute( req, res, next ) {
 				if ( searchParam ) {
 					res.redirect(
 						'https://' +
-							context.lang +
+							req.context.lang +
 							'.search.wordpress.com/?q=' +
 							encodeURIComponent( searchParam )
 					);
@@ -351,7 +351,6 @@ function setUpLoggedInRoute( req, res, next ) {
 			next();
 		} );
 	} else {
-		req.context = context;
 		next();
 	}
 }

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -304,7 +304,7 @@ function setUpLoggedInRoute( req, res, next ) {
 
 					console.error( 'API Error: ' + errorMessage );
 
-					next();
+					next( error );
 				}
 
 				return;

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -261,7 +261,7 @@ function setUpLoggedInRoute( req, res, next ) {
 		'X-Frame-Options': 'SAMEORIGIN',
 	} );
 
-	const context = getDefaultContext( req );
+	const context = ( req.context = getDefaultContext( req ) );
 
 	if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
 		const user = require( 'user-bootstrap' );
@@ -302,9 +302,9 @@ function setUpLoggedInRoute( req, res, next ) {
 						errorMessage = error.message;
 					}
 
-					console.log( 'API Error: ' + errorMessage );
+					console.error( 'API Error: ' + errorMessage );
 
-					next( error );
+					next();
 				}
 
 				return;
@@ -347,8 +347,6 @@ function setUpLoggedInRoute( req, res, next ) {
 					return;
 				}
 			}
-
-			req.context = context;
 
 			next();
 		} );

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -22,7 +22,7 @@ module.exports = function( authCookieValue, callback ) {
 		authCookieValue = decodeURIComponent( authCookieValue );
 
 		if ( typeof API_KEY !== 'string' ) {
-			throw new Error( 'Unable to boostrap user because of invalid API key in secrets.json' );
+			callback( new Error( 'Unable to boostrap user because of invalid API key in secrets.json' ) );
 		}
 
 		hmac = crypto.createHmac( 'md5', API_KEY );

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -23,6 +23,7 @@ module.exports = function( authCookieValue, callback ) {
 
 		if ( typeof API_KEY !== 'string' ) {
 			callback( new Error( 'Unable to boostrap user because of invalid API key in secrets.json' ) );
+			return;
 		}
 
 		hmac = crypto.createHmac( 'md5', API_KEY );


### PR DESCRIPTION
User bootstrapping was disabled in `staging`, `horizon`, and `wpcalypso` in https://github.com/Automattic/wp-calypso/pull/17849 -- this was intended to be a test and then if successful it would also be disabled in production.  However, issues with localization were discovered in staging.

This PR re-enables user-bootstrapping.  Since it was never disabled in production, this PR should have no effect to users but should ideally unblock React 16.

Next Steps
-----
-  merge r16 upgrade https://github.com/Automattic/wp-calypso/pull/19723
-  merge fix for detecting user location: https://github.com/Automattic/wp-calypso/pull/18971