### PR TITLE
Store: Add base page and route for product categories

### DIFF
--- a/client/extensions/woocommerce/app/product-categories/index.js
+++ b/client/extensions/woocommerce/app/product-categories/index.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ActionHeader from 'woocommerce/components/action-header';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import Main from 'components/main';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import SectionNav from 'components/section-nav';
+import Search from 'components/search';
+
+class ProductCategories extends Component {
+
+	render() {
+		const { className, translate, site } = this.props;
+		const classes = classNames( 'product_categories__list', className );
+
+		const productsLabel = translate( 'Products' );
+		const categoriesLabel = translate( 'Categories' );
+
+		return (
+			<Main className={ classes } wideLayout>
+				<ActionHeader breadcrumbs={ [
+					<a href={ getLink( '/store/products/:site/', site ) }>{ productsLabel }</a>,
+					<span>{ categoriesLabel }</span>,
+				] }>
+				</ActionHeader>
+				<SectionNav>
+					<NavTabs label={ translate( 'Products' ) } selectedText={ categoriesLabel }>
+						<NavItem path={ getLink( '/store/products/:site/', site ) }>{ productsLabel }</NavItem>
+						<NavItem path={ getLink( '/store/products/categories/:site/', site ) } selected>
+							{ categoriesLabel }
+						</NavItem>
+					</NavTabs>
+
+					<Search
+						pinned
+						fitsContainer
+						placeholder={ translate( 'Search categories…' ) }
+					/>
+				</SectionNav>
+			</Main>
+		);
+	}
+
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	return {
+		site,
+	};
+}
+
+export default connect( mapStateToProps )( localize( ProductCategories ) );

--- a/client/extensions/woocommerce/app/products/products-list.scss
+++ b/client/extensions/woocommerce/app/products/products-list.scss
@@ -13,7 +13,7 @@
 		margin-top: 16px;
 	}
 
-	.search {
+	.search-card {
 		@include breakpoint( ">660px" ) {
 			margin-top: 58px;
 		}

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -22,6 +22,7 @@ import installActionHandlers from './state/data-layer';
 import Order from './app/order';
 import OrderCreate from './app/order/order-create';
 import Orders from './app/orders';
+import ProductCategories from './app/product-categories';
 import Products from './app/products';
 import ProductCreate from './app/products/product-create';
 import ProductUpdate from './app/products/product-update';
@@ -65,6 +66,12 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-products',
 			documentTitle: translate( 'Edit Product' ),
 			path: '/store/product/:site/:product',
+		},
+		{
+			container: ProductCategories,
+			configKey: 'woocommerce/extension-product-categories',
+			documentTitle: translate( 'Product Categories' ),
+			path: '/store/products/categories/:site',
 		},
 		{
 			container: Orders,

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -111,7 +111,11 @@ class StoreSidebar extends Component {
 		const { site, siteSuffix, translate } = this.props;
 		const link = '/store/products' + siteSuffix;
 		const addLink = '/store/product' + siteSuffix;
-		const selected = this.isItemLinkSelected( [ link, addLink ] );
+		const selected = this.isItemLinkSelected( [
+			link,
+			addLink,
+			'/store/products/categories' + siteSuffix,
+		] );
 		const classes = classNames( {
 			products: true,
 			'is-placeholder': ! site,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -107,6 +107,7 @@
 		"woocommerce/extension-orders-create": false,
 		"woocommerce/extension-orders-edit": false,
 		"woocommerce/extension-products": false,
+		"woocommerce/extension-product-categories": false,
 		"woocommerce/extension-promotions": false,
 		"woocommerce/extension-reviews": false,
 		"woocommerce/extension-settings": false,

--- a/config/development.json
+++ b/config/development.json
@@ -192,6 +192,7 @@
 		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-orders-edit": true,
 		"woocommerce/extension-products": true,
+		"woocommerce/extension-product-categories": true,
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,

--- a/config/production.json
+++ b/config/production.json
@@ -135,6 +135,7 @@
 		"woocommerce/extension-orders-create": false,
 		"woocommerce/extension-orders-edit": false,
 		"woocommerce/extension-products": true,
+		"woocommerce/extension-product-categories": false,
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -142,6 +142,7 @@
 		"woocommerce/extension-orders-create": false,
 		"woocommerce/extension-orders-edit": false,
 		"woocommerce/extension-products": true,
+		"woocommerce/extension-product-categories": false,
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -153,6 +153,7 @@
 		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-orders-edit": true,
 		"woocommerce/extension-products": true,
+		"woocommerce/extension-product-categories": true,
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,


### PR DESCRIPTION
This PR adds a new feature flag, page, and route for product category management. See p90Yrv-9S-p2 for the designs this is based off of.

This PR also updates the products list when `woocommerce/extension-product-categories` is set to true (local dev and wpcalypso), to contain the new `SectionNav` from the design.

Screenshot of new product list header:

<img width="1009" alt="screen shot 2017-11-27 at 3 38 49 pm" src="https://user-images.githubusercontent.com/689165/33295290-7fbc3ba6-d389-11e7-9502-08183d66e4a4.png">

Screenshot of current product categories page:

<img width="997" alt="screen shot 2017-11-27 at 3 38 57 pm" src="https://user-images.githubusercontent.com/689165/33295309-8aa129be-d389-11e7-8529-326aca534eb8.png">

To Test:
* Load up this branch.
* Go to `http://calypso.localhost:3000/store/products/:site` and verify that you see the new SectionNav. Test out the product search to make sure it still works.
* Click to categories, and make sure you end up on `http://calypso.localhost:3000/store/products/categories/:site`. Right now you will only see the breadcrumbs and NavBar.
* Disable `woocommerce/extension-product-categories` in `config/development.json` and restart Calypso (you have to restart to get flag changes to take effect).
* Go to `http://calypso.localhost:3000/store/products/:site` and make sure you see just the search input and now SectionNav. Make sure the search still works.
