### PR TITLE
Fix Domains .FR validation type error

### DIFF
--- a/client/components/domains/registrant-extra-info/fr-schema.json
+++ b/client/components/domains/registrant-extra-info/fr-schema.json
@@ -98,9 +98,11 @@
 								{ "$ref": "#/definitions/empty" }
 							]
 						}
-					}
+					},
+					"required": [ "registrantType" ]
 				}
-			}
+			},
+			"required": [ "extra" ]
 		}
 	],
 	"note": "We'll want to fetch this through the API, where wpcom.undocumented already has `mapKeysRecursively()` & `camelCase()`"

--- a/client/components/domains/registrant-extra-info/fr-schema.json
+++ b/client/components/domains/registrant-extra-info/fr-schema.json
@@ -15,6 +15,7 @@
 			"not": {
 				"properties": {
 					"extra": {
+						"type": "object",
 						"properties": {
 							"registrantType": {
 								"type": "string",

--- a/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
@@ -25,11 +25,21 @@ describe( 'validateContactDetails', () => {
 		email: 'test@example.com',
 		phone: '+1.2506382995',
 		extra: {
+			registrantType: 'individual',
 			sirenSiret: '123456789',
 			registrantVatId: 'FRXX123456789',
 			trademarkNumber: '123456789',
 		},
 	};
+
+	function contactWithExtraProperty( property, value ) {
+		return Object.assign( {}, contactDetails, {
+			extra: {
+				...contactDetails.extra,
+				[ property ]: value,
+			},
+		} );
+	}
 
 	test( 'should accept valid example data (sanity check)', () => {
 		expect( validateContactDetails( contactDetails ) ).to.eql( {} );
@@ -38,8 +48,7 @@ describe( 'validateContactDetails', () => {
 	test( 'should handle missing extra', () => {
 		const testDetails = omit( contactDetails, 'extra' );
 
-		expect(	validateContactDetails( testDetails ) )
-			.to.have.property( 'extra' );
+		expect( validateContactDetails( testDetails ) ).to.have.property( 'extra' );
 	} );
 
 	test( 'should handle null extra', () => {
@@ -47,8 +56,7 @@ describe( 'validateContactDetails', () => {
 			extra: null,
 		} );
 
-		expect( validateContactDetails( testDetails ) )
-			.to.have.property( 'extra' );
+		expect( validateContactDetails( testDetails ) ).to.have.property( 'extra' );
 	} );
 
 	// validateContactDetails data
@@ -139,7 +147,7 @@ describe( 'validateContactDetails', () => {
 	describe( 'SIREN/SIRET', () => {
 		test( 'should accept all real SIRET examples', () => {
 			realSiretNumbers.forEach( ( [ sirenSiret ] ) => {
-				const testDetails = Object.assign( {}, contactDetails, { extra: { sirenSiret } } );
+				const testDetails = contactWithExtraProperty( 'sirenSiret', sirenSiret );
 
 				const result = validateContactDetails( testDetails );
 				expect( result, `expected to accept '${ sirenSiret }'` ).to.eql( {} );
@@ -165,7 +173,7 @@ describe( 'validateContactDetails', () => {
 		} );
 
 		test( 'should accept an empty value', () => {
-			const testDetails = Object.assign( {}, contactDetails, { extra: { sirenSiret: '' } } );
+			const testDetails = contactWithExtraProperty( 'sirenSiret', '' );
 
 			const result = validateContactDetails( testDetails );
 			expect( result ).to.eql( {} );
@@ -229,7 +237,7 @@ describe( 'validateContactDetails', () => {
 			];
 
 			vatPatterns.forEach( ( [ registrantVatId ] ) => {
-				const testDetails = Object.assign( {}, contactDetails, { extra: { registrantVatId } } );
+				const testDetails = contactWithExtraProperty( 'registrantVatId', registrantVatId );
 
 				const result = validateContactDetails( testDetails );
 				expect( result, `expected to accept '${ registrantVatId }'` ).to.eql( {} );
@@ -248,7 +256,7 @@ describe( 'validateContactDetails', () => {
 		} );
 
 		test( 'should accept an empty value', () => {
-			const testDetails = Object.assign( {}, contactDetails, { extra: { registrantVatId: '' } } );
+			const testDetails = contactWithExtraProperty( 'registrantVatId', '' );
 
 			const result = validateContactDetails( testDetails );
 			expect( result ).to.eql( {} );
@@ -271,7 +279,7 @@ describe( 'validateContactDetails', () => {
 
 		test( 'should accept all good trademark examples', () => {
 			goodTrademarkNumbers.forEach( ( [ trademarkNumber ] ) => {
-				const testDetails = Object.assign( {}, contactDetails, { extra: { trademarkNumber } } );
+				const testDetails = contactWithExtraProperty( 'trademarkNumber', trademarkNumber );
 
 				const result = validateContactDetails( testDetails );
 				expect( result, `expected to accept '${ trademarkNumber }'` ).to.eql( {} );
@@ -290,7 +298,7 @@ describe( 'validateContactDetails', () => {
 		} );
 
 		test( 'should accept an empty value', () => {
-			const testDetails = Object.assign( {}, contactDetails, { extra: { trademarkNumber: '' } } );
+			const testDetails = contactWithExtraProperty( 'trademarkNumber', '' );
 
 			const result = validateContactDetails( testDetails );
 			expect( result ).to.eql( {} );

--- a/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
@@ -35,6 +35,22 @@ describe( 'validateContactDetails', () => {
 		expect( validateContactDetails( contactDetails ) ).to.eql( {} );
 	} );
 
+	test( 'should handle missing extra', () => {
+		const testDetails = omit( contactDetails, 'extra' );
+
+		expect(	validateContactDetails( testDetails ) )
+			.to.have.property( 'extra' );
+	} );
+
+	test( 'should handle null extra', () => {
+		const testDetails = Object.assign( {}, contactDetails, {
+			extra: null,
+		} );
+
+		expect( validateContactDetails( testDetails ) )
+			.to.have.property( 'extra' );
+	} );
+
 	// validateContactDetails data
 	const realSiretNumbers = [
 		[ '77575187800015' ],


### PR DESCRIPTION
This PR fixes  issue #20270, where .FR domains cannot be impossible to purchase.

The type error is coming out of the `validate()` call generated by `is-my-json-valid` ( called from here: https://github.com/Automattic/wp-calypso/blob/8d708e40e9112a1e4cccd23fc9d72d3a5ea50b98/client/components/domains/registrant-extra-info/fr-validate-contact-details.js#L66)

We're looking at an implementation detail/optimization in `is-my-json-valid`, and the actual fix is adding `"type": "object"` to the organization ref sub-schema. Without this property, the generated validator function looks like this:
```
    if (data !== undefined) {
      if (data.extra !== undefined) {
        if (data.extra.registrantType !== undefined) {
```
So a null value explodes.

Adding the `type` property adds a `typeof` check after the check for `undefined`, and bails out on failure, protecting the rest of the function.

The rest of the change flows from adding the tests - the missing case should fail because `registrantType` is required, so I've fixed that oversight.

I don't think wrapping the whole thing in a `try/catch` is indicated yet, but I'm thinking about it now.
