### PR TITLE
Post Revisions: Remove round corners from revisions list items

### DIFF
--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -85,6 +85,7 @@
 .editor-revisions-list__button {
 	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
 	border-right: 1px solid darken($sidebar-bg-color, 5%);
+	border-radius: 0;
 	color: $gray-dark;
 	cursor: pointer;
 	text-align: left;


### PR DESCRIPTION

## This PR
- removes the round corners from the revisions list items

## How to test

- Use the calypso.live link below or check out locally
- Navigate to or create a post with revisions
- Click on the `History` button to trigger the Post Revisions modal
- The post revisions list items shouldn't have round corners anymore 
(see screenshot of **after** state below for comparison)

**Before**

<img width="218" alt="screen shot 2017-11-28 at 00 40 24" src="https://user-images.githubusercontent.com/1562646/33305801-35769e64-d3d5-11e7-9b3e-8ba405d3b8db.png">

**After**

<img width="217" alt="screen shot 2017-11-28 at 00 41 03" src="https://user-images.githubusercontent.com/1562646/33305804-3c94e67e-d3d5-11e7-969c-7eda46fa0f9d.png">
