### PR TITLE
Checkout: Not rendering <SectionNav /> when no content for it exists

### DIFF
--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -20,7 +20,7 @@ import SectionHeader from 'components/section-header';
 import analytics from 'lib/analytics';
 import cartValues from 'lib/cart-values';
 
-class PaymentBox extends PureComponent {
+export class PaymentBox extends PureComponent {
 	constructor() {
 		super();
 		this.handlePaymentMethodChange = this.handlePaymentMethodChange.bind( this );
@@ -143,13 +143,17 @@ class PaymentBox extends PureComponent {
 				} )
 			: translate( 'Loading…' );
 
+		const paymentMethods = this.getPaymentMethods();
+
 		return (
 			<div className="checkout__payment-box-container" key={ this.props.currentPage }>
 				{ this.props.title ? <SectionHeader label={ this.props.title } /> : null }
 
-				<SectionNav selectedText={ titleText }>
-					<NavTabs>{ this.getPaymentMethods() }</NavTabs>
-				</SectionNav>
+				{ paymentMethods && (
+					<SectionNav selectedText={ titleText }>
+						<NavTabs>{ paymentMethods }</NavTabs>
+					</SectionNav>
+				) }
 
 				<Card className={ cardClass }>
 					<div className="checkout__box-padding">

--- a/client/my-sites/checkout/checkout/test/payment-box.js
+++ b/client/my-sites/checkout/checkout/test/payment-box.js
@@ -1,0 +1,38 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { PaymentBox } from '../payment-box';
+
+jest.mock( 'lib/cart-values', () => ( {
+	isPaymentMethodEnabled: jest.fn( false ),
+} ) );
+
+describe( 'PaymentBox', () => {
+	const defaultProps = {
+		cart: {},
+		title: 'Hoi!',
+		currentPaymentMethod: 'credit-card',
+		paymentMethods: [ 'paypal', 'credit-card' ],
+		currentPage: 'mainForm',
+		translate: identity,
+	};
+
+	test( 'should not render paymethods SectionNav when there are no payment methods', () => {
+		const wrapper = shallow( <PaymentBox { ...defaultProps } /> );
+		expect( wrapper.find( 'SectionNav' ) ).toHaveLength( 1 );
+		wrapper.setProps( { paymentMethods: null } );
+		expect( wrapper.find( 'SectionNav' ) ).toHaveLength( 0 );
+	} );
+} );


### PR DESCRIPTION
## What this PR does
During checkout, we render a list of payment methods in a `<SectionNav />`, and display it in mobile view. See **Pay with Credit Card or debit card** at the top of the screenshot:

<img width="383" alt="screen shot 2017-11-28 at 5 30 58 pm" src="https://user-images.githubusercontent.com/6458278/33305604-07943f54-d463-11e7-8183-a7c93f4aa9c8.png">

When on the domain details form page however, we don't yet specify payment methods. We attempt to render `<SectionNav />` with `null` nevertheless. The result is an empty list of NavTabs and a persistent __Loading...__ message.

<img width="357" alt="screen shot 2017-11-28 at 5 04 58 pm" src="https://user-images.githubusercontent.com/6458278/33305776-91fd63c8-d463-11e7-9bcc-9a98a08be9a9.png">

The fix is just to check whether the prop `paymentMethods` exists before rendering `<SectionNav />`.

### Steps for testing this PR
1. Place a domain in your cart and head to the checkout
2. At the domains detail form page, resize the viewport to the mobile breakpoint (or use Chrome's emulator )
3. Fill out the form and continue to the credit card form.

#### Expected
__At step 2__: The empty nav list and the __Loading...__  message should not be present. 
__At step 3__: The collapsible nav list should display the regular payment methods 


