### PR TITLE
People : use defaultValue instead of value in search text field

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -360,7 +360,7 @@ class Search extends Component {
 						className={ inputClass }
 						placeholder={ placeholder }
 						role="search"
-						value={ searchValue }
+						defaultValue={ searchValue }
 						ref="searchInput"
 						onInput={
 							this.onChange


### PR DESCRIPTION
use defaultValue instead of value.

![searching-issue](https://user-images.githubusercontent.com/26810472/33314722-8813ae9e-d454-11e7-8b27-6a53cff80b13.png)

To overcome the error We use defaultValue instead of value.

Testing Instruction.

- Update changes
- Search team member or theme or media.

Thanks
