### PR TITLE
Me: Use Redux analytics instead of eventRecorder in ConnectedApplicationItem

### DIFF
--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -3,9 +3,7 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -19,40 +17,35 @@ import Button from 'components/button';
 import FoldableCard from 'components/foldable-card';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-const ConnectedApplicationItem = createReactClass( {
-	displayName: 'ConnectedApplicationItem',
+class ConnectedApplicationItem extends React.Component {
+	static defaultProps = {
+		isPlaceholder: false,
+	};
 
-	getInitialState: function() {
-		return {
-			showDetail: false,
-		};
-	},
+	state = {
+		showDetail: false,
+	};
 
-	getDefaultProps: function() {
-		return {
-			isPlaceholder: false,
-		};
-	},
-
-	recordClickEvent( action, label = null ) {
+	recordClickEvent = ( action, label = null ) => {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action, label );
-	},
+	};
 
-	getClickHandler( action ) {
+	getClickHandler = action => {
 		return () => this.recordClickEvent( action );
-	},
+	};
 
-	disconnect: function( event ) {
+	disconnect = event => {
 		if ( this.props.isPlaceholder ) {
 			return;
 		}
+
 		const { connection: { title, ID } } = this.props;
 		event.stopPropagation();
 		this.recordClickEvent( 'Disconnect Connected Application Link', title );
 		this.props.revoke( ID );
-	},
+	};
 
-	renderAccessScopeBadge: function() {
+	renderAccessScopeBadge() {
 		const { connection: { scope, site } } = this.props;
 		var meta = '';
 
@@ -71,9 +64,9 @@ const ConnectedApplicationItem = createReactClass( {
 		if ( meta.length ) {
 			return <span className="connected-application-item__meta">{ meta }</span>;
 		}
-	},
+	}
 
-	renderScopeMessage: function() {
+	renderScopeMessage() {
 		const { connection: { scope, site } } = this.props;
 		var message;
 		if ( ! this.props.connection ) {
@@ -124,9 +117,9 @@ const ConnectedApplicationItem = createReactClass( {
 				<p className="connected-application-item__connection-detail-description">{ message }</p>
 			</div>
 		);
-	},
+	}
 
-	renderDetail: function() {
+	renderDetail() {
 		const { connection: { URL, authorized, permissions } } = this.props;
 		if ( this.props.isPlaceholder ) {
 			return;
@@ -170,18 +163,18 @@ const ConnectedApplicationItem = createReactClass( {
 				</ul>
 			</div>
 		);
-	},
+	}
 
-	header: function() {
+	header() {
 		return (
 			<div className="connected-application-item__header">
 				<ConnectedApplicationIcon image={ this.props.connection.icon } />
 				<h3>{ this.props.connection.title }</h3>
 			</div>
 		);
-	},
+	}
 
-	summary: function() {
+	summary() {
 		return (
 			<div>
 				{ this.props.isPlaceholder ? (
@@ -195,9 +188,9 @@ const ConnectedApplicationItem = createReactClass( {
 				) }
 			</div>
 		);
-	},
+	}
 
-	render: function() {
+	render() {
 		let classes = classNames( {
 			'connected-application-item': true,
 			'is-placeholder': this.props.isPlaceholder,
@@ -215,8 +208,8 @@ const ConnectedApplicationItem = createReactClass( {
 				{ this.renderDetail() }
 			</FoldableCard>
 		);
-	},
-} );
+	}
+}
 
 export default connect( null, {
 	recordGoogleEvent,

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -4,17 +4,17 @@
  * External dependencies
  */
 import React from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import ConnectedApplicationIcon from 'me/connected-application-icon';
-import safeProtocolUrl from 'lib/safe-protocol-url';
 import Button from 'components/button';
+import ConnectedApplicationIcon from 'me/connected-application-icon';
 import FoldableCard from 'components/foldable-card';
+import safeProtocolUrl from 'lib/safe-protocol-url';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class ConnectedApplicationItem extends React.Component {

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -165,7 +165,7 @@ class ConnectedApplicationItem extends React.Component {
 		);
 	}
 
-	header() {
+	renderHeader() {
 		return (
 			<div className="connected-application-item__header">
 				<ConnectedApplicationIcon image={ this.props.connection.icon } />
@@ -174,7 +174,7 @@ class ConnectedApplicationItem extends React.Component {
 		);
 	}
 
-	summary() {
+	renderSummary() {
 		return (
 			<div>
 				{ this.props.isPlaceholder ? (
@@ -198,9 +198,9 @@ class ConnectedApplicationItem extends React.Component {
 
 		return (
 			<FoldableCard
-				header={ this.header() }
-				summary={ this.summary() }
-				expandedSummary={ this.summary() }
+				header={ this.renderHeader() }
+				summary={ this.renderSummary() }
+				expandedSummary={ this.renderSummary() }
 				clickableHeader
 				compact
 				className={ classes }

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -8,8 +8,6 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:connected-application-item' );
 import classNames from 'classnames';
 
 /**
@@ -23,14 +21,6 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 
 const ConnectedApplicationItem = createReactClass( {
 	displayName: 'ConnectedApplicationItem',
-
-	componentDidMount: function() {
-		debug( this.constructor.displayName + ' React component is mounted.' );
-	},
-
-	componentWillUnmount: function() {
-		debug( this.constructor.displayName + ' React component is unmounting.' );
-	},
 
 	getInitialState: function() {
 		return {

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import createReactClass from 'create-react-class';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:connected-application-item' );
@@ -14,17 +15,14 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import eventRecorder from 'me/event-recorder';
 import ConnectedApplicationIcon from 'me/connected-application-icon';
 import safeProtocolUrl from 'lib/safe-protocol-url';
-import analytics from 'lib/analytics';
 import Button from 'components/button';
 import FoldableCard from 'components/foldable-card';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 const ConnectedApplicationItem = createReactClass( {
 	displayName: 'ConnectedApplicationItem',
-
-	mixins: [ eventRecorder ],
 
 	componentDidMount: function() {
 		debug( this.constructor.displayName + ' React component is mounted.' );
@@ -46,13 +44,21 @@ const ConnectedApplicationItem = createReactClass( {
 		};
 	},
 
+	recordClickEvent( action, label = null ) {
+		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action, label );
+	},
+
+	getClickHandler( action ) {
+		return () => this.recordClickEvent( action );
+	},
+
 	disconnect: function( event ) {
 		if ( this.props.isPlaceholder ) {
 			return;
 		}
 		const { connection: { title, ID } } = this.props;
 		event.stopPropagation();
-		analytics.ga.recordEvent( 'Me', 'Clicked on Disconnect Connected Application Link', title );
+		this.recordClickEvent( 'Disconnect Connected Application Link', title );
 		this.props.revoke( ID );
 	},
 
@@ -103,7 +109,7 @@ const ConnectedApplicationItem = createReactClass( {
 								target="_blank"
 								rel="noopener noreferrer"
 								href={ safeProtocolUrl( this.props.connection.site.site_URL ) }
-								onClick={ this.recordClickEvent( 'Connected Application Scope Blog Link' ) }
+								onClick={ this.getClickHandler( 'Connected Application Scope Blog Link' ) }
 							/>
 						),
 					},
@@ -142,7 +148,7 @@ const ConnectedApplicationItem = createReactClass( {
 				<p>
 					<a
 						href={ safeProtocolUrl( URL ) }
-						onClick={ this.recordClickEvent( 'Connected Application Website Link' ) }
+						onClick={ this.getClickHandler( 'Connected Application Website Link' ) }
 						target="_blank"
 						rel="noopener noreferrer"
 					>
@@ -222,4 +228,6 @@ const ConnectedApplicationItem = createReactClass( {
 	},
 } );
 
-export default localize( ConnectedApplicationItem );
+export default connect( null, {
+	recordGoogleEvent,
+} )( localize( ConnectedApplicationItem ) );


### PR DESCRIPTION
This PR refactors `ConnectedApplicationItem ` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove all mixins, specifically `eventRecorder`.
* Convert from `createReactClass` to a `React.Component`.
* Remove some unnecessary debug code.
* Sort some imports 🔤 .
* Rename some rendering methods to be prepended with `render*`.

This PR should not introduce any visual changes.

Part of #20053.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me/security/connected-applications
* Verify you can observe the right analytics action being dispatched when you:
  * Click the link of an application website
  * Click the link within application scope (you can use an app that specifies a particular user in the scope)
  * Click the disconnect button of an application.
* Verify everything else in the connected applications page works like it did before.