### PR TITLE
Add woo styles to magic link screen

### DIFF
--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -208,7 +208,8 @@
 		text-align: center;
 	}
 
-	.wp-login__main.main, .magic-login.main {
+	.wp-login__main.main,
+	.magic-login.main {
 		max-width: 778px;
 	}
 
@@ -307,15 +308,5 @@
 	// Signup styles
 	.signup__step {
 		background: linear-gradient( to bottom, #e6e6e6, transparent );
-	}
-
-	.signup-processing__content:after {
-		background-image: url( '/calypso/images/woo/ninja-joy.svg' );
-		content: '';
-		height: 100px;
-		left: 50%;
-		position: absolute;
-		top: 33px;
-		width: 69px;
 	}
 }

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -164,7 +164,8 @@
 		}
 	}
 
-	.login__form {
+	.login__form,
+	.magic-login {
 		.button {
 			float: none;
 			margin: 0;
@@ -202,11 +203,12 @@
 	}
 
 	.login__form-action,
-	.login__social-buttons {
+	.login__social-buttons,
+	.magic-login__form-action {
 		text-align: center;
 	}
 
-	.wp-login__main.main {
+	.wp-login__main.main, .magic-login.main {
 		max-width: 778px;
 	}
 
@@ -221,6 +223,7 @@
 	}
 
 	.wp-login__container,
+	.magic-login,
 	.step-wrapper {
 		background: #fff;
 		border: 1px solid #d3d3d3;


### PR DESCRIPTION
This PR fixes the styles issues we have on the magic link screen for the customized woocommerce flow.
It also fixes https://github.com/Automattic/wp-calypso/issues/20233.

#### Before
![image](https://user-images.githubusercontent.com/230230/33328353-146d212c-d45a-11e7-84d3-e30292cd07ee.png)

#### After
![image](https://user-images.githubusercontent.com/230230/33328429-494db546-d45a-11e7-9d75-e9257f822fd9.png)


### Testing Instructions
- Boot this branch locally
- Navigate to http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D03920c4715d28a42f08a909782ce4f5c%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1
- Click on "Email me a login link" at the bottom of the page
- Assert that the styling is fixed and that the page works as expected
- Navigate to http://calypso.localhost:3000/start/wpcc?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Ded9ba3862a5ac355d3cef079c17fff13%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login&oauth2_client_id=50916
- Sign up for a new account and ensure that Hiro (the old woo mascot) is not visible anymore on the processing screen

### Reviews
- [ ] Product
- [ ] Code
