### PR TITLE
Post Revisions: Fix site selector issue

### DIFF
--- a/client/components/data/query-users/README.md
+++ b/client/components/data/query-users/README.md
@@ -43,4 +43,4 @@ The site ID for which we request post revisions.
 	<tr><th>Required</th><td>No</td></tr>
 </table>
 
-Limit result set to specific IDs.
+Limit result set to specific IDs. The userIds will be filtered to exclude the current user in order to only request data that is not present yet, as well as to preserve the current user state.

--- a/client/components/data/query-users/index.jsx
+++ b/client/components/data/query-users/index.jsx
@@ -12,10 +12,12 @@ import shallowEqual from 'react-pure-render/shallowEqual';
 /**
  * Internal dependencies
  */
+import { getCurrentUserId } from 'state/current-user/selectors';
 import { requestUsers } from 'state/users/actions';
 
 class QueryUsers extends Component {
 	static propTypes = {
+		currentUserId: PropTypes.number,
 		requestUsers: PropTypes.func,
 		siteId: PropTypes.number,
 		userIds: PropTypes.arrayOf( PropTypes.number ),
@@ -37,7 +39,11 @@ class QueryUsers extends Component {
 	}
 
 	request() {
-		this.props.requestUsers( this.props.siteId, this.props.userIds );
+		const { siteId, userIds, currentUserId } = this.props;
+		if ( userIds.length ) {
+			const requestIds = userIds.filter( id => id !== currentUserId );
+			this.props.requestUsers( siteId, requestIds );
+		}
 	}
 
 	render() {
@@ -45,4 +51,6 @@ class QueryUsers extends Component {
 	}
 }
 
-export default connect( () => ( {} ), { requestUsers } )( QueryUsers );
+export default connect( state => ( { currentUserId: getCurrentUserId( state ) } ), {
+	requestUsers,
+} )( QueryUsers );

--- a/client/components/data/query-users/index.jsx
+++ b/client/components/data/query-users/index.jsx
@@ -40,10 +40,10 @@ class QueryUsers extends Component {
 
 	request() {
 		const { siteId, userIds, currentUserId } = this.props;
+		// Ensure that we only request the authors whose information we're lacking, not the current user.
+		const requestIds = userIds.filter( id => id !== currentUserId );
 		// Only request users if a list of user Ids is provided. Otherwise, all users would be requested incl. the current user.
-		if ( userIds.length ) {
-			// Ensure that we only request the authors whose information we're lacking, not the current user.
-			const requestIds = userIds.filter( id => id !== currentUserId );
+		if ( requestIds.length ) {
 			this.props.requestUsers( siteId, requestIds );
 		}
 	}

--- a/client/components/data/query-users/index.jsx
+++ b/client/components/data/query-users/index.jsx
@@ -40,7 +40,9 @@ class QueryUsers extends Component {
 
 	request() {
 		const { siteId, userIds, currentUserId } = this.props;
+		// Only request users if a list of user Ids is provided. Otherwise, all users would be requested incl. the current user.
 		if ( userIds.length ) {
+			// Ensure that we only request the authors whose information we're lacking, not the current user.
 			const requestIds = userIds.filter( id => id !== currentUserId );
 			this.props.requestUsers( siteId, requestIds );
 		}


### PR DESCRIPTION
## This PR
- aims to fix an issue where the site selector was broken after opening the revisions modal

The issue was caused by `QueryUsers` requesting all users that are authors. This works perfectly fine as long as the current user is not an author. If the current user is one of the authors, it would fetch the current user's info from the endpoint as well and just overwrites the user, dropping all other state for the current user in the process. This caused information like e.g. `siteCount` not being available to the site-selector, which resulted in the `is-large` modifier class not being set on the site-selector, which in turn resulted in the visual issue identified.

## How to test

- Use the calypso.live link below or check out locally
- Navigate to a post you have contributed to or create a post with revisions
- Click on the `History` button to trigger the Post Revisions modal
- If there are authors other than yourself, the author names should appear in the corresponding post revisions list items. It should be identical to the behavior observed on wpcalypso.
- Close the Post Revisions modal via clicking the `cancel` button
- In the blog post overview page click `Switch Site` in the top left
- The site selector should appear like visible in the **after** state in the screenshot below


**Before**

<img width="274" alt="screen shot 2017-11-28 at 09 07 47" src="https://user-images.githubusercontent.com/1562646/33326842-a998946e-d41b-11e7-985e-da74f7d0e0cd.png">

**After**

<img width="273" alt="screen shot 2017-11-28 at 09 07 21" src="https://user-images.githubusercontent.com/1562646/33326848-af6f3e42-d41b-11e7-89b3-7c8c4e590271.png">


