### PR TITLE
Purchases: Payment Settings button broken for domains

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -427,7 +427,6 @@ class ManagePurchase extends Component {
 		}
 		const { selectedSite, selectedSiteId, selectedPurchase, isPurchaseTheme } = this.props;
 		const classes = 'manage-purchase';
-		const purchase = getPurchase( this.props );
 
 		let editCardDetailsPath = false;
 		if (
@@ -446,7 +445,7 @@ class ManagePurchase extends Component {
 				) }
 				<Main className={ classes }>
 					<HeaderCake onClick={ goToList }>{ titles.managePurchase }</HeaderCake>
-					{ ! isDomainTransfer( purchase ) && (
+					{
 						<PurchaseNotice
 							isDataLoading={ isDataLoading( this.props ) }
 							handleRenew={ this.handleRenew }
@@ -454,7 +453,7 @@ class ManagePurchase extends Component {
 							selectedPurchase={ selectedPurchase }
 							editCardDetailsPath={ editCardDetailsPath }
 						/>
-					) }
+					}
 					{ this.renderPurchaseDetail() }
 				</Main>
 			</span>

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -26,6 +26,7 @@ import {
 	isRenewable,
 	showCreditCardExpiringWarning,
 } from 'lib/purchases';
+import { isDomainTransfer } from 'lib/products-values';
 import { getPurchase, getSelectedSite } from '../utils';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
@@ -230,6 +231,10 @@ class PurchaseNotice extends Component {
 
 	render() {
 		if ( this.props.isDataLoading ) {
+			return null;
+		}
+
+		if ( isDomainTransfer( getPurchase( this.props ) ) ) {
 			return null;
 		}
 

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**


### PR DESCRIPTION
Fix payment settings button. It was broken because of the
transfer check which should go inside notices.

Test:
- Go to Domains in Calypso
- Open a registered domain
- Click Payment Settings
- Make sure no errors/purchase displayed properly

Fixes: https://github.com/Automattic/wp-calypso/issues/20274