### PR TITLE
Post Revisions: Maintain the selector's cache if everything stays the same

### DIFF
--- a/client/state/selectors/get-post-revision-changes.js
+++ b/client/state/selectors/get-post-revision-changes.js
@@ -58,7 +58,9 @@ const getPostRevisionChanges = createSelector(
 			title,
 		};
 	},
-	state => [ state.posts.revisions.revisions ]
+	( state, siteId, postId, revisionId ) => [
+		get( state, [ 'posts.revisions.revisions', siteId, postId, revisionId ] ),
+	]
 );
 
 export default getPostRevisionChanges;


### PR DESCRIPTION
Make the cache more specific to the item in revisions.

Hits the cache until the revision changes.

TODO: also tie it to the revision comparing against (the "previous" revision)