### PR TITLE
Editor: Revisions: Add support for other post types

### DIFF
--- a/client/state/data-layer/wpcom/posts/revisions/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/index.js
@@ -18,6 +18,11 @@ import {
 	receivePostRevisionsFailure,
 } from 'state/posts/revisions/actions';
 
+const KNOWN_POST_TYPES = {
+	post: 'posts',
+	page: 'pages',
+};
+
 /**
  * Normalize a WP REST API Post Revisions resource for consumption in Calypso
  *
@@ -87,7 +92,7 @@ export const receiveSuccess = ( { dispatch }, { siteId, postId }, revisions ) =>
  */
 export const fetchPostRevisions = ( { dispatch }, action ) => {
 	const { siteId, postId, postType } = action;
-	const resourceName = postType === 'page' ? 'pages' : 'posts';
+	const resourceName = KNOWN_POST_TYPES[ postType ] ? KNOWN_POST_TYPES[ postType ] : postType;
 	dispatch(
 		http(
 			{

--- a/client/state/data-layer/wpcom/posts/revisions/test/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/test/index.js
@@ -139,6 +139,28 @@ describe( '#fetchPostRevisions', () => {
 			)
 		);
 	} );
+
+	test( 'should dispatch HTTP request to corresponding revisions endpoint for other post types', () => {
+		const action = requestPostRevisions( 12345678, 10, 'jetpack-portfolio' );
+		const dispatch = sinon.spy();
+
+		fetchPostRevisions( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledOnce;
+		expect( dispatch ).to.have.been.calledWith(
+			http(
+				{
+					method: 'GET',
+					path: '/sites/12345678/jetpack-portfolio/10/revisions',
+					query: {
+						apiNamespace: 'wp/v2',
+						context: 'edit',
+					},
+				},
+				action
+			)
+		);
+	} );
 } );
 
 describe( '#receiveSuccess', () => {


### PR DESCRIPTION
Our code was previously hardcoded to only support post types `post` and `page` but the support in API was ready for other types too. This PR allows it and adds a test case for the API call.

Test:
- **Test with wpcom simple site**
- Make a post with other post type than `post` or `page`. Portfolio is the most convenient one, as it comes right with Jetpack and supports tracking revisions
- Save few edits, until "History" button appears
- Click "History"
- Make sure revisions load for you
