### PR TITLE
Components: Omit itemComponent prop from PopoverMenuItem

### DIFF
--- a/client/components/popover/menu-item.jsx
+++ b/client/components/popover/menu-item.jsx
@@ -52,7 +52,8 @@ export default class PopoverMenuItem extends Component {
 			'focusOnHover',
 			'isSelected',
 			'isExternalLink',
-			'className'
+			'className',
+			'itemComponent'
 		);
 		const classes = classnames( 'popover__menu-item', className, {
 			'is-selected': isSelected,


### PR DESCRIPTION
This PR fixes a case where `PopoverMenuItem` items receive an unexpected prop, which triggers the following React warning:

![](https://cldup.com/nslV6WmZkR.png)

Seems to have been introduced in #20162.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me
* Click on the **Add** button in the **Profile Links** section.
* Verify you no longer see the React warning from the screenshot.