### PR TITLE
Me: Use Redux analytics in AddProfileLinksButtons

### DIFF
--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -5,6 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import createReactClass from 'create-react-class';
@@ -13,14 +14,14 @@ import Gridicon from 'gridicons';
 // Internal dependencies
 import Button from 'components/button';
 import observe from 'lib/mixins/data-observe';
-import eventRecorder from 'me/event-recorder';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 const AddProfileLinksButtons = createReactClass( {
 	displayName: 'AddProfileLinksButtons',
 
-	mixins: [ observe( 'userProfileLinks' ), eventRecorder ],
+	mixins: [ observe( 'userProfileLinks' ) ],
 
 	propTypes: {
 		showingForm: PropTypes.bool,
@@ -39,6 +40,20 @@ const AddProfileLinksButtons = createReactClass( {
 		};
 	},
 
+	recordClickEvent( action ) {
+		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
+	},
+
+	handleAddWordPressSiteButtonClick() {
+		this.recordClickEvent( 'Add a WordPress Site Button' );
+		this.props.onShowAddWordPress();
+	},
+
+	handleOtherSiteButtonClick() {
+		this.recordClickEvent( 'Add Other Site Button' );
+		this.props.onShowAddOther();
+	},
+
 	render() {
 		return (
 			<div>
@@ -48,17 +63,10 @@ const AddProfileLinksButtons = createReactClass( {
 					position={ this.state.popoverPosition }
 					context={ this.refs && this.refs.popoverMenuButton }
 				>
-					<PopoverMenuItem
-						onClick={ this.recordClickEvent(
-							'Add a WordPress Site Button',
-							this.props.onShowAddWordPress
-						) }
-					>
+					<PopoverMenuItem onClick={ this.handleAddWordPressSiteButtonClick }>
 						{ this.props.translate( 'Add WordPress Site' ) }
 					</PopoverMenuItem>
-					<PopoverMenuItem
-						onClick={ this.recordClickEvent( 'Add Other Site Button', this.props.onShowAddOther ) }
-					>
+					<PopoverMenuItem onClick={ this.handleOtherSiteButtonClick }>
 						{ this.props.translate( 'Add URL' ) }
 					</PopoverMenuItem>
 				</PopoverMenu>
@@ -77,4 +85,6 @@ const AddProfileLinksButtons = createReactClass( {
 	},
 } );
 
-export default localize( AddProfileLinksButtons );
+export default connect( null, {
+	recordGoogleEvent,
+} )( localize( AddProfileLinksButtons ) );

--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -3,13 +3,12 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 import React from 'react';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 // Internal dependencies
 import Button from 'components/button';


### PR DESCRIPTION
This PR refactors `AddProfileLinksButtons ` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove the usage of `eventRecorder`.
* Sort some imports 🔤 .

This PR should not introduce any visual changes.

Part of #20053.

To test:
* Checkout this branch.
* Go to http://calypso.localhost:3000/me/
* Click the **Add** button in the **Profile Links** section.
* Verify you can observe the right analytics action being dispatched when you:
  * Click the **Add WordPress Site** popover menu item
  * Click the **Add URL** popover menu item
* Verify everything else in the profile links section works like it did before.

Note: Clicking on the **Add** button will trigger a React warning, but it's not related and a fix for it is coming in #20292.