### PR TITLE
Domains: Show error message if a domain is pending transfer

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -45,6 +45,7 @@ const domainAvailability = {
 	BLACKLISTED: 'blacklisted_domain',
 	MAPPED: 'mapped_domain',
 	RECENTLY_UNMAPPED: 'recently_mapped',
+	TRANSFER_PENDING: 'transfer_pending',
 	UNKOWN_ACTIVE: 'unknown_active_domain_with_wpcom',
 };
 

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -140,6 +140,16 @@ function getAvailabilityNotice( domain, error ) {
 			);
 			break;
 
+		case domainAvailability.TRANSFER_PENDING:
+			message = translate(
+				'{{strong}}%(domain)s{{/strong}} is already connected to a WordPress.com site.',
+				{
+					args: { domain },
+					components: { strong: <strong /> },
+				}
+			);
+			break;
+
 		default:
 			message = translate(
 				'Sorry, there was a problem processing your request. Please try again in a few minutes.'

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -142,10 +142,19 @@ function getAvailabilityNotice( domain, error ) {
 
 		case domainAvailability.TRANSFER_PENDING:
 			message = translate(
-				'{{strong}}%(domain)s{{/strong}} is already connected to a WordPress.com site.',
+				"{{strong}}%(domain)s{{/strong}} is pending transfer and can't be connected to WordPress.com right now. " +
+					'{{a}}Learn more{{/a}}.',
 				{
 					args: { domain },
-					components: { strong: <strong /> },
+					components: {
+						strong: <strong />,
+						a: (
+							<a
+								href={ support.INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
+								rel="noopener noreferrer"
+							/>
+						),
+					},
 				}
 			);
 			break;


### PR DESCRIPTION
If a domain is pending incoming transfer, don't allow additional mapping/transfers for it.

- Calypso -> Domains -> Add
- Search for andrija.me
- See message that it's already connected to wp.com

Dependency: D8511-code