### PR TITLE
PostTypeList: Do not show redundant statuses.

### DIFF
--- a/client/blocks/post-status/README.md
+++ b/client/blocks/post-status/README.md
@@ -25,3 +25,23 @@ function MyPost() {
 </table>
 
 The global ID of the post. If omitted or the associated post cannot be found in global state, the component returns null.
+
+### `showAll`
+
+<table>
+	<tr><th>Type</th><td>Bool</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Default</th><td>false</td></tr>
+</table>
+
+If true, statuses will be shown for scheduled, trashed, drafted, and published posts.
+
+### `showIcon`
+
+<table>
+	<tr><th>Type</th><td>Bool</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Default</th><td>true</td></tr>
+</table>
+
+If false, an icon will not be displayed along with the status text.

--- a/client/blocks/post-status/index.jsx
+++ b/client/blocks/post-status/index.jsx
@@ -31,11 +31,11 @@ export function PostStatus( { translate, post, showAll, showIcon = true } ) {
 		text = translate( 'Pending Review' );
 		classModifier = 'is-pending';
 		icon = 'aside';
-	} else if ( 'future' === status ) {
+	} else if ( showAll && 'future' === status ) {
 		text = translate( 'Scheduled' );
 		classModifier = 'is-scheduled';
 		icon = 'calendar';
-	} else if ( 'trash' === status ) {
+	} else if ( showAll && 'trash' === status ) {
 		text = translate( 'Trashed' );
 		classModifier = 'is-trash';
 		icon = 'trash';

--- a/client/blocks/post-status/test/index.jsx
+++ b/client/blocks/post-status/test/index.jsx
@@ -59,36 +59,138 @@ describe( 'PostStatus', () => {
 			} );
 
 			describe( 'future', () => {
-				test( 'should render the primary components', () => {
-					const PostStatusComponent = (
-						<PostStatus post={ { sticky: false, status: 'future' } } translate={ identity } />
-					);
-					const wrapper = shallow( PostStatusComponent );
+				describe( 'showAll', () => {
+					test( 'should render the primary components', () => {
+						const PostStatusComponent = (
+							<PostStatus
+								post={ { sticky: false, status: 'future' } }
+								showAll
+								translate={ identity }
+							/>
+						);
+						const wrapper = shallow( PostStatusComponent );
 
-					expect( wrapper ).to.have.descendants( 'span' );
-					expect( wrapper ).to.have.className( 'is-scheduled' );
-					expect( wrapper.childAt( 0 ).is( Gridicon ) ).to.be.true;
-					expect( wrapper.childAt( 0 ) ).to.have.prop( 'icon', 'calendar' );
-					expect( wrapper.childAt( 1 ) )
-						.to.have.tagName( 'span' )
-						.to.have.text( 'Scheduled' );
+						expect( wrapper ).to.have.descendants( 'span' );
+						expect( wrapper ).to.have.className( 'is-scheduled' );
+						expect( wrapper.childAt( 0 ).is( Gridicon ) ).to.be.true;
+						expect( wrapper.childAt( 0 ) ).to.have.prop( 'icon', 'calendar' );
+						expect( wrapper.childAt( 1 ) )
+							.to.have.tagName( 'span' )
+							.to.have.text( 'Scheduled' );
+					} );
+				} );
+
+				describe( 'not showAll', () => {
+					test( 'should be empty', () => {
+						const PostStatusComponent = (
+							<PostStatus post={ { sticky: false, status: 'future' } } translate={ identity } />
+						);
+						const wrapper = shallow( PostStatusComponent );
+
+						expect( wrapper ).to.be.empty;
+					} );
 				} );
 			} );
 
 			describe( 'trash', () => {
-				test( 'should render the primary components', () => {
-					const PostStatusComponent = (
-						<PostStatus post={ { sticky: false, status: 'trash' } } translate={ identity } />
-					);
-					const wrapper = shallow( PostStatusComponent );
+				describe( 'showAll', () => {
+					test( 'should render the primary components', () => {
+						const PostStatusComponent = (
+							<PostStatus
+								post={ { sticky: false, status: 'trash' } }
+								showAll
+								translate={ identity }
+							/>
+						);
+						const wrapper = shallow( PostStatusComponent );
 
-					expect( wrapper ).to.have.descendants( 'span' );
-					expect( wrapper ).to.have.className( 'is-trash' );
-					expect( wrapper.childAt( 0 ).is( Gridicon ) ).to.be.true;
-					expect( wrapper.childAt( 0 ) ).to.have.prop( 'icon', 'trash' );
-					expect( wrapper.childAt( 1 ) )
-						.to.have.tagName( 'span' )
-						.to.have.text( 'Trashed' );
+						expect( wrapper ).to.have.descendants( 'span' );
+						expect( wrapper ).to.have.className( 'is-trash' );
+						expect( wrapper.childAt( 0 ).is( Gridicon ) ).to.be.true;
+						expect( wrapper.childAt( 0 ) ).to.have.prop( 'icon', 'trash' );
+						expect( wrapper.childAt( 1 ) )
+							.to.have.tagName( 'span' )
+							.to.have.text( 'Trashed' );
+					} );
+				} );
+
+				describe( 'not showAll', () => {
+					test( 'should be empty', () => {
+						const PostStatusComponent = (
+							<PostStatus post={ { sticky: false, status: 'trash' } } translate={ identity } />
+						);
+						const wrapper = shallow( PostStatusComponent );
+
+						expect( wrapper ).to.be.empty;
+					} );
+				} );
+			} );
+
+			describe( 'draft', () => {
+				describe( 'showAll', () => {
+					test( 'should render the primary components', () => {
+						const PostStatusComponent = (
+							<PostStatus
+								post={ { sticky: false, status: 'draft' } }
+								showAll
+								translate={ identity }
+							/>
+						);
+						const wrapper = shallow( PostStatusComponent );
+
+						expect( wrapper ).to.have.descendants( 'span' );
+						expect( wrapper ).to.have.className( 'is-draft' );
+						expect( wrapper.childAt( 0 ).is( Gridicon ) ).to.be.true;
+						expect( wrapper.childAt( 0 ) ).to.have.prop( 'icon', 'aside' );
+						expect( wrapper.childAt( 1 ) )
+							.to.have.tagName( 'span' )
+							.to.have.text( 'Draft' );
+					} );
+				} );
+
+				describe( 'not showAll', () => {
+					test( 'should be empty', () => {
+						const PostStatusComponent = (
+							<PostStatus post={ { sticky: false, status: 'draft' } } translate={ identity } />
+						);
+						const wrapper = shallow( PostStatusComponent );
+
+						expect( wrapper ).to.be.empty;
+					} );
+				} );
+			} );
+
+			describe( 'publish', () => {
+				describe( 'showAll', () => {
+					test( 'should render the primary components', () => {
+						const PostStatusComponent = (
+							<PostStatus
+								post={ { sticky: false, status: 'publish' } }
+								showAll
+								translate={ identity }
+							/>
+						);
+						const wrapper = shallow( PostStatusComponent );
+
+						expect( wrapper ).to.have.descendants( 'span' );
+						expect( wrapper ).to.have.className( 'is-published' );
+						expect( wrapper.childAt( 0 ).is( Gridicon ) ).to.be.true;
+						expect( wrapper.childAt( 0 ) ).to.have.prop( 'icon', 'aside' );
+						expect( wrapper.childAt( 1 ) )
+							.to.have.tagName( 'span' )
+							.to.have.text( 'Published' );
+					} );
+				} );
+
+				describe( 'not showAll', () => {
+					test( 'should be empty', () => {
+						const PostStatusComponent = (
+							<PostStatus post={ { sticky: false, status: 'publish' } } translate={ identity } />
+						);
+						const wrapper = shallow( PostStatusComponent );
+
+						expect( wrapper ).to.be.empty;
+					} );
 				} );
 			} );
 


### PR DESCRIPTION
This PR updates the `PostStatus` component such that, unless the `showAll` prop is present, statuses of scheduled, trashed, drafted, and published will not be shown. Previous to this PR, only drafted and published were excluded.

These statuses were redundant within the `PostTypeList` as the only way to view posts with these statuses was to select those statuses from the `SectionNav`.

Before:

![image](https://user-images.githubusercontent.com/363749/33340535-f7ed8432-d441-11e7-8bcb-d5228f9818a0.png)

After:

![image](https://user-images.githubusercontent.com/363749/33340571-14b42c38-d442-11e7-85ba-d20be927684b.png)


To test:

* Apply PR or test via the Calypso.live link below.
* Add yourself to the AB test for condensed post list by entering the following in your browser's console: `localStorage.setItem( 'ABTests', '{"condensedPostList_20171113": "condensedPosts"}' );`
* Visit the Blog Posts page and verify that for any scheduled or trashed posts the status no longer appears to the right of the timestamp.
