### PR TITLE
Reintroduce delete button on credentials form

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
@@ -72,6 +72,7 @@ class CredentialsConfigured extends Component {
 							className="credentials-configured__revoke-button"
 							borderless={ true }
 							onClick={ this.handleRevoke }
+							scary={ true }
 						>
 							<Gridicon
 								className="credentials-configured__revoke-icon"

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
@@ -90,7 +90,7 @@ class CredentialsConfigured extends Component {
 
 		if ( isPressable ) {
 			return (
-				<CompactCard className="credentials-configured" onClick={ this.toggleRevoking }>
+				<CompactCard className="credentials-configured" onClick={ this.toggleRevoking } href="#">
 					<Gridicon
 						icon="checkmark-circle"
 						size={ 48 }

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
@@ -36,7 +36,6 @@
 }
 
 .credentials-configured__revoke-button.is-borderless {
-	color: $alert-red;
 	margin-right: 2rem;
 	position: relative;
 	top: -5px;

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
@@ -13,6 +13,7 @@
 	display: inline-block;
 	vertical-align: middle;
 	width: 85%;
+	color: $gray-dark;
 }
 
 .credentials-configured__header-gridicon {

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -18,6 +18,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextArea from 'components/forms/form-textarea';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormPasswordInput from 'components/forms/form-password-input';
+import Gridicon from 'gridicons';
 
 export class CredentialsForm extends Component {
 	state = {
@@ -208,6 +209,17 @@ export class CredentialsForm extends Component {
 							className="credentials-form__cancel-button"
 						>
 							{ translate( 'Cancel' ) }
+						</Button>
+					) }
+					{ this.props.showDeleteButton && (
+						<Button
+							borderless={ true }
+							disabled={ formIsSubmitting }
+							onClick={ this.handleDelete }
+							className="credentials-form__delete-button"
+						>
+							<Gridicon icon="trash" size={ 18 } />
+							{ translate( 'Delete' ) }
 						</Button>
 					) }
 				</FormFieldset>

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/style.scss
@@ -34,8 +34,12 @@
 	margin-top: 16px;
 }
 
-.credentials-form__delete-button,
 .credentials-form__cancel-button {
 	float: right;
 	margin-right: 15px;
+}
+
+.credentials-form__delete-button.button.is-borderless {
+	color: $alert-red;
+	float: left;
 }


### PR DESCRIPTION
As title states, the delete credentials button was never added to the CredentialsForm component due to a merge conflict. This PR adds it. It also reintroduces the Chevron on the CredentialsConfigured view for Autoconfigured credentials.

Testing instructions:
- View the Credentials form for a non-Pressable site. Ensure the Delete button shows.
- Ensure the delete button works and credentials are deleted.
- For a Pressable site with autoconfigured credentials, ensure the chevron is present and you can click through to revoke.

![screen shot 2017-11-28 at 3 11 44 pm](https://user-images.githubusercontent.com/5528445/33342130-08ac2a46-d44f-11e7-8571-ec1b1899d6ba.png)

![screen shot 2017-11-28 at 3 30 47 pm](https://user-images.githubusercontent.com/5528445/33342742-21602c98-d451-11e7-8e48-03a966fe3167.png)
