### PR TITLE
Store Orders: Use the data-layer for fetching orders

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -70,8 +70,7 @@ class ManageOrdersView extends Component {
 		const oldSiteId = site ? site.ID : null;
 
 		if ( oldSiteId !== newSiteId ) {
-			newProps.siteId = newSiteId;
-			this.fetchData( newProps );
+			this.fetchData( { ...newProps, siteId: newSiteId } );
 		}
 	}
 

--- a/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-orders-view.js
@@ -57,14 +57,10 @@ class ManageOrdersView extends Component {
 	};
 
 	componentDidMount() {
-		const { site } = this.props;
+		const { ordersLoaded, site } = this.props;
 
 		if ( site && site.ID ) {
-			this.props.fetchOrders( site.ID );
-			// TODO This check can be removed when we launch reviews.
-			if ( config.isEnabled( 'woocommerce/extension-reviews' ) ) {
-				this.props.fetchReviews( site.ID, { status: 'pending' } );
-			}
+			this.fetchData( { siteId: site.ID, ordersLoaded } );
 		}
 	}
 
@@ -74,13 +70,20 @@ class ManageOrdersView extends Component {
 		const oldSiteId = site ? site.ID : null;
 
 		if ( oldSiteId !== newSiteId ) {
-			this.props.fetchOrders( newSiteId );
-			// TODO This check can be removed when we launch reviews.
-			if ( config.isEnabled( 'woocommerce/extension-reviews' ) ) {
-				this.props.fetchReviews( newSiteId, { status: 'pending' } );
-			}
+			newProps.siteId = newSiteId;
+			this.fetchData( newProps );
 		}
 	}
+
+	fetchData = ( { siteId, ordersLoaded } ) => {
+		if ( ! ordersLoaded ) {
+			this.props.fetchOrders( siteId );
+		}
+		// TODO This check can be removed when we launch reviews.
+		if ( config.isEnabled( 'woocommerce/extension-reviews' ) ) {
+			this.props.fetchReviews( siteId, { status: 'pending' } );
+		}
+	};
 
 	possiblyRenderProcessOrdersWidget = () => {
 		const { site, orders, ordersRevenue, currency } = this.props;

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -16,7 +16,7 @@ import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 import { clearOrderEdits, editOrder } from 'woocommerce/state/ui/orders/actions';
 import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
-import { fetchOrder, updateOrder } from 'woocommerce/state/sites/orders/actions';
+import { fetchOrder, saveOrder } from 'woocommerce/state/sites/orders/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import {
@@ -86,7 +86,7 @@ class Order extends Component {
 	saveOrder = () => {
 		const { siteId, order } = this.props;
 		recordTrack( 'calypso_woocommerce_order_edit_save' );
-		this.props.updateOrder( siteId, order );
+		this.props.saveOrder( siteId, order );
 	};
 
 	render() {
@@ -173,7 +173,7 @@ export default connect(
 	},
 	dispatch =>
 		bindActionCreators(
-			{ clearOrderEdits, editOrder, fetchNotes, fetchOrder, updateOrder },
+			{ clearOrderEdits, editOrder, fetchNotes, fetchOrder, saveOrder },
 			dispatch
 		)
 )( localize( Order ) );

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -26,7 +26,7 @@ import { isOrderFinished } from 'woocommerce/lib/order-status';
 import LabelPurchaseDialog from 'woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal';
 import Notice from 'components/notice';
 import QueryLabels from 'woocommerce/woocommerce-services/components/query-labels';
-import { updateOrder } from 'woocommerce/state/sites/orders/actions';
+import { saveOrder } from 'woocommerce/state/sites/orders/actions';
 import { openPrintingFlow } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 import {
 	getLabels,
@@ -87,7 +87,7 @@ class OrderFulfillment extends Component {
 			return;
 		}
 
-		this.props.updateOrder( site.ID, {
+		this.props.saveOrder( site.ID, {
 			id: order.id,
 			status: 'completed',
 		} );
@@ -265,5 +265,5 @@ export default connect(
 			hasLabelsPaymentMethod,
 		};
 	},
-	dispatch => bindActionCreators( { createNote, updateOrder, openPrintingFlow }, dispatch )
+	dispatch => bindActionCreators( { createNote, saveOrder, openPrintingFlow }, dispatch )
 )( localize( OrderFulfillment ) );

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -17,7 +17,7 @@ import formatCurrency from 'lib/format-currency';
 import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
 import { isOrderFailed, isOrderWaitingPayment } from 'woocommerce/lib/order-status';
 import RefundDialog from './dialog';
-import { updateOrder } from 'woocommerce/state/sites/orders/actions';
+import { saveOrder } from 'woocommerce/state/sites/orders/actions';
 
 class OrderPaymentCard extends Component {
 	static propTypes = {
@@ -31,7 +31,7 @@ class OrderPaymentCard extends Component {
 		} ),
 		siteId: PropTypes.number.isRequired,
 		translate: PropTypes.func.isRequired,
-		updateOrder: PropTypes.func.isRequired,
+		saveOrder: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -93,7 +93,7 @@ class OrderPaymentCard extends Component {
 
 	markAsPaid = () => {
 		const { order, siteId } = this.props;
-		this.props.updateOrder( siteId, { ...order, status: 'processing' } );
+		this.props.saveOrder( siteId, { ...order, status: 'processing' } );
 	};
 
 	toggleDialog = () => {
@@ -127,6 +127,6 @@ class OrderPaymentCard extends Component {
 	}
 }
 
-export default connect( null, dispatch => bindActionCreators( { updateOrder }, dispatch ) )(
+export default connect( null, dispatch => bindActionCreators( { saveOrder }, dispatch ) )(
 	localize( OrderPaymentCard )
 );

--- a/client/extensions/woocommerce/lib/order-status/index.js
+++ b/client/extensions/woocommerce/lib/order-status/index.js
@@ -63,6 +63,24 @@ export function getOrderStatusList() {
 }
 
 /**
+ * Return a list of statuses from a given calypso label "group"
+ *
+ * @param {String} status Calypso version of status label
+ * @return {String} A comma-separated list of WC core statuses matching this group
+ */
+export function getOrderStatusGroup( status ) {
+	// Convert URL status to status group
+	if ( ORDER_UNPAID === status ) {
+		return statusWaitingPayment.join( ',' );
+	} else if ( ORDER_UNFULFILLED === status ) {
+		return statusWaitingFulfillment.join( ',' );
+	} else if ( ORDER_COMPLETED === status ) {
+		return statusFinished.join( ',' );
+	}
+	return status;
+}
+
+/**
  * Checks if this status (from an order) is in the "waiting for payment" group
  *
  * @param {String} status Order status

--- a/client/extensions/woocommerce/state/data-layer/index.js
+++ b/client/extensions/woocommerce/state/data-layer/index.js
@@ -8,6 +8,7 @@ import { mergeHandlers } from 'state/action-watchers/utils';
 import { addHandlers } from 'state/data-layer/extensions-middleware';
 import actionList from './action-list';
 import coupons from '../sites/coupons/handlers';
+import orders from './orders';
 import paymentMethods from './payment-methods';
 import products from './products';
 import productVariations from './product-variations';
@@ -28,6 +29,7 @@ const debug = debugFactory( 'woocommerce:errors' );
 const handlers = mergeHandlers(
 	actionList,
 	coupons,
+	orders,
 	paymentMethods,
 	productCategories,
 	products,

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -1,0 +1,45 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import { omitBy } from 'lodash';
+import qs from 'querystring';
+
+/**
+ * Internal dependencies
+ */
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { updateOrders, failOrders } from 'woocommerce/state/sites/orders/actions';
+import request from 'woocommerce/state/sites/http-request';
+import { WOOCOMMERCE_ORDERS_REQUEST } from 'woocommerce/state/action-types';
+
+const debug = debugFactory( 'woocommerce:orders' );
+
+export default {
+	[ WOOCOMMERCE_ORDERS_REQUEST ]: [ dispatchRequest( requestOrders, receivedOrders, apiError ) ],
+};
+
+export function requestOrders( { dispatch }, action ) {
+	const { siteId, query } = action;
+	const queryString = qs.stringify( omitBy( query, val => '' === val ) );
+
+	dispatch( request( siteId, action ).getWithHeaders( `orders?${ queryString }` ) );
+}
+
+export function receivedOrders( { dispatch }, action, { data } ) {
+	const { siteId, query } = action;
+	const { body, headers } = data;
+	const total = Number( headers[ 'X-WP-Total' ] );
+
+	dispatch( updateOrders( siteId, query, body, total ) );
+}
+
+export function apiError( { dispatch }, action, error ) {
+	debug( 'API Error: ', error );
+	dispatch( failOrders( action.siteId, action.params ) );
+
+	if ( action.failureAction ) {
+		dispatch( action.failureAction );
+	}
+}

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -37,7 +37,7 @@ export function receivedOrders( { dispatch }, action, { data } ) {
 
 export function apiError( { dispatch }, action, error ) {
 	debug( 'API Error: ', error );
-	dispatch( failOrders( action.siteId, action.params ) );
+	dispatch( failOrders( action.siteId, action.params, error ) );
 
 	if ( action.failureAction ) {
 		dispatch( action.failureAction );

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -10,15 +10,40 @@ import qs from 'querystring';
  * Internal dependencies
  */
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { updateOrders, failOrders } from 'woocommerce/state/sites/orders/actions';
+import {
+	failOrder,
+	failOrders,
+	saveOrderError,
+	saveOrderSuccess,
+	updateOrder,
+	updateOrders,
+} from 'woocommerce/state/sites/orders/actions';
 import request from 'woocommerce/state/sites/http-request';
-import { WOOCOMMERCE_ORDERS_REQUEST } from 'woocommerce/state/action-types';
+import { successNotice, errorNotice } from 'state/notices/actions';
+import { translate } from 'i18n-calypso';
+import {
+	WOOCOMMERCE_ORDER_REQUEST,
+	WOOCOMMERCE_ORDER_UPDATE,
+	WOOCOMMERCE_ORDERS_REQUEST,
+} from 'woocommerce/state/action-types';
 
 const debug = debugFactory( 'woocommerce:orders' );
 
 export default {
+	[ WOOCOMMERCE_ORDER_REQUEST ]: [ dispatchRequest( requestOrder, receivedOrder, apiError ) ],
+	[ WOOCOMMERCE_ORDER_UPDATE ]: [
+		dispatchRequest( sendOrder, onOrderSaveSuccess, onOrderSaveFailure ),
+	],
 	[ WOOCOMMERCE_ORDERS_REQUEST ]: [ dispatchRequest( requestOrders, receivedOrders, apiError ) ],
 };
+
+export function apiError( { dispatch }, action, error ) {
+	debug( 'API Error: ', error );
+
+	if ( action.failureAction ) {
+		dispatch( { ...action.failureAction, error } );
+	}
+}
 
 export function requestOrders( { dispatch }, action ) {
 	const { siteId, query } = action;
@@ -36,10 +61,32 @@ export function receivedOrders( { dispatch }, action, { data } ) {
 	dispatch( updateOrders( siteId, query, body, total ) );
 }
 
-export function apiError( { dispatch }, action, error ) {
-	debug( 'API Error: ', error );
+export function requestOrder( { dispatch }, action ) {
+	const { siteId, orderId } = action;
+	action.failureAction = failOrder( siteId, orderId );
 
-	if ( action.failureAction ) {
-		dispatch( { ...action.failureAction, error } );
-	}
+	dispatch( request( siteId, action ).get( `orders/${ orderId }` ) );
+}
+
+export function receivedOrder( { dispatch }, action, { data } ) {
+	const { siteId, orderId } = action;
+	dispatch( updateOrder( siteId, orderId, data ) );
+}
+
+export function sendOrder( { dispatch }, action ) {
+	const { siteId, orderId, order } = action;
+	dispatch( request( siteId, action ).post( `orders/${ orderId }`, order ) );
+}
+
+export function onOrderSaveSuccess( { dispatch }, action, { data } ) {
+	const { siteId, orderId } = action;
+	dispatch( successNotice( translate( 'Order saved.' ), { duration: 5000 } ) );
+	dispatch( saveOrderSuccess( siteId, orderId, data ) );
+}
+
+export function onOrderSaveFailure( { dispatch }, action, error ) {
+	const { siteId, orderId } = action;
+	debug( 'API Error: ', error );
+	dispatch( errorNotice( translate( 'Unable to save order.' ), { duration: 5000 } ) );
+	dispatch( saveOrderError( siteId, orderId, error ) );
 }

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -23,6 +23,7 @@ export default {
 export function requestOrders( { dispatch }, action ) {
 	const { siteId, query } = action;
 	const queryString = qs.stringify( omitBy( query, val => '' === val ) );
+	action.failureAction = failOrders( siteId, query );
 
 	dispatch( request( siteId, action ).getWithHeaders( `orders?${ queryString }` ) );
 }
@@ -37,9 +38,8 @@ export function receivedOrders( { dispatch }, action, { data } ) {
 
 export function apiError( { dispatch }, action, error ) {
 	debug( 'API Error: ', error );
-	dispatch( failOrders( action.siteId, action.params, error ) );
 
 	if ( action.failureAction ) {
-		dispatch( action.failureAction );
+		dispatch( { ...action.failureAction, error } );
 	}
 }

--- a/client/extensions/woocommerce/state/data-layer/orders/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/test/index.js
@@ -8,13 +8,37 @@ import { spy, match } from 'sinon';
 /**
  * Internal dependencies
  */
-import { fetchOrders, updateOrders, failOrders } from 'woocommerce/state/sites/orders/actions';
-import { apiError, requestOrders, receivedOrders } from '../';
+import {
+	failOrder,
+	failOrders,
+	fetchOrder,
+	fetchOrders,
+	saveOrder,
+	saveOrderError,
+	saveOrderSuccess,
+	updateOrder,
+	updateOrders,
+} from 'woocommerce/state/sites/orders/actions';
+import {
+	apiError,
+	receivedOrder,
+	receivedOrders,
+	requestOrder,
+	requestOrders,
+	onOrderSaveFailure,
+	onOrderSaveSuccess,
+	sendOrder,
+} from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
+	WOOCOMMERCE_ORDER_REQUEST_FAILURE,
+	WOOCOMMERCE_ORDER_REQUEST_SUCCESS,
+	WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
+	WOOCOMMERCE_ORDER_UPDATE_FAILURE,
 	WOOCOMMERCE_ORDERS_REQUEST_FAILURE,
 	WOOCOMMERCE_ORDERS_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
+import { NOTICE_CREATE } from 'state/action-types';
 
 describe( 'handlers', () => {
 	describe( '#requestOrders', () => {
@@ -111,6 +135,186 @@ describe( 'handlers', () => {
 					type: WOOCOMMERCE_ORDERS_REQUEST_FAILURE,
 					siteId: 123,
 					query: {},
+				} )
+			);
+		} );
+
+		test( 'apiError should dispatch a failure action on a failed single order request', () => {
+			const dispatch = spy();
+			const response = {
+				code: 'rest_no_route',
+				data: { status: 404 },
+				message: 'No route was found matching the URL and request method',
+			};
+			const action = { failureAction: failOrder( 123, 42 ) };
+
+			apiError( { dispatch }, action, { data: response } );
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_ORDER_REQUEST_FAILURE,
+					siteId: 123,
+					orderId: 42,
+				} )
+			);
+		} );
+	} );
+
+	describe( '#requestOrder', () => {
+		test( 'should dispatch a get action', () => {
+			const dispatch = spy();
+			const action = fetchOrder( 123, 42 );
+			requestOrder( { dispatch }, action );
+
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith(
+				http(
+					{
+						method: 'GET',
+						path: '/jetpack-blogs/123/rest-api/',
+						apiVersion: '1.1',
+						body: null,
+						query: {
+							json: true,
+							path: '/wc/v3/orders/42&_method=GET',
+						},
+					},
+					action
+				)
+			);
+		} );
+	} );
+
+	describe( '#receivedOrder', () => {
+		test( 'should dispatch a success action on a good response', () => {
+			const dispatch = spy();
+			const order = { id: 42, total: '50.00' };
+			const action = updateOrder( 123, 42, order );
+
+			receivedOrder( { dispatch }, action, { data: order } );
+
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_ORDER_REQUEST_SUCCESS,
+					siteId: 123,
+					orderId: 42,
+					order,
+				} )
+			);
+		} );
+
+		test( 'should dispatch a failure action on a bad response', () => {
+			const dispatch = spy();
+			const response = {
+				code: 'rest_no_route',
+				data: { status: 404 },
+				message: 'No route was found matching the URL and request method',
+			};
+			const action = updateOrder( 123, 42, response );
+
+			receivedOrder( { dispatch }, action, { data: response } );
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_ORDER_REQUEST_FAILURE,
+					siteId: 123,
+					orderId: 42,
+				} )
+			);
+		} );
+	} );
+
+	describe( '#sendOrder', () => {
+		test( 'should dispatch a post action', () => {
+			const dispatch = spy();
+			const order = {
+				id: 1,
+				status: 'completed',
+				total: '50.00',
+			};
+			const action = saveOrder( 123, order );
+			sendOrder( { dispatch }, action );
+
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith(
+				http(
+					{
+						method: 'POST',
+						path: '/jetpack-blogs/123/rest-api/',
+						apiVersion: '1.1',
+						body: {
+							json: true,
+							path: '/wc/v3/orders/1&_method=POST',
+							body: JSON.stringify( { status: 'completed', total: '50.00' } ),
+						},
+						query: {
+							json: true,
+						},
+					},
+					action
+				)
+			);
+		} );
+	} );
+
+	describe( '#onOrderSaveSuccess', () => {
+		test( 'should dispatch a success action on a good response', () => {
+			const dispatch = spy();
+			const order = { id: 42, total: '50.00' };
+			const action = saveOrderSuccess( 123, 42, order );
+
+			onOrderSaveSuccess( { dispatch }, action, { data: order } );
+
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
+					siteId: 123,
+					orderId: 42,
+					order,
+				} )
+			);
+		} );
+
+		test( 'should dispatch a failure action on a bad response', () => {
+			const dispatch = spy();
+			const response = {
+				code: 'rest_no_route',
+				data: { status: 404 },
+				message: 'No route was found matching the URL and request method',
+			};
+			const action = saveOrderSuccess( 123, 42, response );
+
+			onOrderSaveSuccess( { dispatch }, action, { data: response } );
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
+					siteId: 123,
+					orderId: 42,
+					error: response,
+				} )
+			);
+		} );
+	} );
+	describe( '#onOrderSaveFailure', () => {
+		test( 'should dispatch a failure action on a failed orders save', () => {
+			const dispatch = spy();
+			const response = {
+				code: 'rest_no_route',
+				data: { status: 404 },
+				message: 'No route was found matching the URL and request method',
+			};
+			const action = saveOrderError( 123, 1, response );
+
+			onOrderSaveFailure( { dispatch }, action, response );
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: NOTICE_CREATE,
+				} )
+			);
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
+					siteId: 123,
+					orderId: 1,
+					error: response,
 				} )
 			);
 		} );

--- a/client/extensions/woocommerce/state/data-layer/orders/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/test/index.js
@@ -101,14 +101,9 @@ describe( 'handlers', () => {
 				data: { status: 404 },
 				message: 'No route was found matching the URL and request method',
 			};
-			const action = failOrders( 123, {}, response, 2 );
-			const data = {
-				status: 404,
-				body: response,
-				headers: [],
-			};
+			const action = { failureAction: failOrders( 123, {}, response ) };
 
-			apiError( { dispatch }, action, { data } );
+			apiError( { dispatch }, action, { data: response } );
 			expect( dispatch ).to.have.been.calledWithMatch(
 				match( {
 					type: WOOCOMMERCE_ORDERS_REQUEST_FAILURE,

--- a/client/extensions/woocommerce/state/data-layer/orders/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/test/index.js
@@ -76,7 +76,7 @@ describe( 'handlers', () => {
 				data: { status: 404 },
 				message: 'No route was found matching the URL and request method',
 			};
-			const action = updateOrders( 123, {}, response, 2 );
+			const action = updateOrders( 123, {}, response );
 			const data = {
 				status: 404,
 				body: response,
@@ -88,6 +88,8 @@ describe( 'handlers', () => {
 				match( {
 					type: WOOCOMMERCE_ORDERS_REQUEST_FAILURE,
 					siteId: 123,
+					query: {},
+					error: response,
 				} )
 			);
 		} );

--- a/client/extensions/woocommerce/state/data-layer/orders/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/test/index.js
@@ -1,0 +1,121 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy, match } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { fetchOrders, updateOrders, failOrders } from 'woocommerce/state/sites/orders/actions';
+import { apiError, requestOrders, receivedOrders } from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	WOOCOMMERCE_ORDERS_REQUEST_FAILURE,
+	WOOCOMMERCE_ORDERS_REQUEST_SUCCESS,
+} from 'woocommerce/state/action-types';
+
+describe( 'handlers', () => {
+	describe( '#requestOrders', () => {
+		test( 'should dispatch a get action', () => {
+			const dispatch = spy();
+			const action = fetchOrders( 123, {} );
+			requestOrders( { dispatch }, action );
+
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith(
+				http(
+					{
+						method: 'GET',
+						path: '/jetpack-blogs/123/rest-api/',
+						apiVersion: '1.1',
+						body: null,
+						query: {
+							json: true,
+							path: '/wc/v3/orders&page=1&per_page=50&status=any&_envelope&_method=GET',
+						},
+					},
+					action
+				)
+			);
+		} );
+	} );
+
+	describe( '#receivedOrders', () => {
+		test( 'should dispatch a success action on a good response', () => {
+			const dispatch = spy();
+			const orders = [ { id: 1, total: '50.00' }, { id: 2, total: '12.50' } ];
+			const data = {
+				status: 200,
+				body: orders,
+				headers: {
+					'X-WP-TotalPages': 1,
+					'X-WP-Total': 2,
+				},
+			};
+			const action = updateOrders( 123, {}, orders, 2 );
+
+			receivedOrders( { dispatch }, action, { data } );
+
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_ORDERS_REQUEST_SUCCESS,
+					siteId: 123,
+					orders,
+					query: {},
+					total: 2,
+				} )
+			);
+		} );
+
+		test( 'should dispatch a failure action on a bad response', () => {
+			const dispatch = spy();
+			const response = {
+				code: 'rest_no_route',
+				data: { status: 404 },
+				message: 'No route was found matching the URL and request method',
+			};
+			const action = updateOrders( 123, {}, response, 2 );
+			const data = {
+				status: 404,
+				body: response,
+				headers: [],
+			};
+
+			receivedOrders( { dispatch }, action, { data } );
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_ORDERS_REQUEST_FAILURE,
+					siteId: 123,
+				} )
+			);
+		} );
+	} );
+
+	describe( '#apiError', () => {
+		test( 'apiError should dispatch a failure action on a failed orders request', () => {
+			const dispatch = spy();
+			const response = {
+				code: 'rest_no_route',
+				data: { status: 404 },
+				message: 'No route was found matching the URL and request method',
+			};
+			const action = failOrders( 123, {}, response, 2 );
+			const data = {
+				status: 404,
+				body: response,
+				headers: [],
+			};
+
+			apiError( { dispatch }, action, { data } );
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_ORDERS_REQUEST_FAILURE,
+					siteId: 123,
+					query: {},
+				} )
+			);
+		} );
+	} );
+} );

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -13,13 +13,7 @@ import {
 	removeTemporaryIds,
 	transformOrderForApi,
 } from './utils';
-import { isOrderLoaded, isOrderLoading } from './selectors';
 import { getOrderStatusGroup } from 'woocommerce/lib/order-status';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import request from '../request';
-import { setError } from '../status/wc-api/actions';
-import { successNotice, errorNotice } from 'state/notices/actions';
-import { translate } from 'i18n-calypso';
 import {
 	WOOCOMMERCE_ORDER_REQUEST,
 	WOOCOMMERCE_ORDER_REQUEST_FAILURE,
@@ -67,81 +61,64 @@ export const updateOrders = ( siteId, query = {}, orders = [], total = 0 ) => {
 	};
 };
 
-export const fetchOrder = ( siteId, orderId, refresh = false ) => ( dispatch, getState ) => {
-	const state = getState();
-	if ( ! siteId ) {
-		siteId = getSelectedSiteId( state );
-	}
-	if ( isOrderLoading( state, orderId, siteId ) ) {
-		return;
-	}
-	// Bail if the order is loaded, and we don't want to force a refresh
-	if ( ! refresh && isOrderLoaded( state, orderId, siteId ) ) {
-		return;
-	}
-
-	const fetchAction = {
+export const fetchOrder = ( siteId, orderId ) => {
+	return {
 		type: WOOCOMMERCE_ORDER_REQUEST,
 		siteId,
 		orderId,
 	};
-	dispatch( fetchAction );
-
-	return request( siteId )
-		.get( `orders/${ orderId }` )
-		.then( order => {
-			dispatch( {
-				type: WOOCOMMERCE_ORDER_REQUEST_SUCCESS,
-				siteId,
-				orderId,
-				order,
-			} );
-		} )
-		.catch( error => {
-			dispatch( setError( siteId, fetchAction, error ) );
-			dispatch( {
-				type: WOOCOMMERCE_ORDER_REQUEST_FAILURE,
-				siteId,
-				orderId,
-				error,
-			} );
-		} );
 };
 
-export const updateOrder = ( siteId, { id: orderId, ...order } ) => ( dispatch, getState ) => {
-	const state = getState();
-	if ( ! siteId ) {
-		siteId = getSelectedSiteId( state );
+export const failOrder = ( siteId, orderId, error = false ) => {
+	return {
+		type: WOOCOMMERCE_ORDER_REQUEST_FAILURE,
+		siteId,
+		orderId,
+		error,
+	};
+};
+
+export const updateOrder = ( siteId, orderId, order ) => {
+	// This passed through the API layer successfully, but failed at the remote site.
+	if ( 'undefined' === typeof order.id ) {
+		return failOrder( siteId, orderId, order );
 	}
+	return {
+		type: WOOCOMMERCE_ORDER_REQUEST_SUCCESS,
+		siteId,
+		orderId,
+		order,
+	};
+};
 
+export const saveOrder = ( siteId, { id: orderId, ...order } ) => {
 	order = transformOrderForApi( removeTemporaryIds( order ) );
-
-	const updateAction = {
+	return {
 		type: WOOCOMMERCE_ORDER_UPDATE,
 		siteId,
 		orderId,
+		order,
 	};
-	dispatch( updateAction );
+};
 
-	return request( siteId )
-		.post( `orders/${ orderId }`, order )
-		.then( data => {
-			dispatch( successNotice( translate( 'Order saved.' ), { duration: 5000 } ) );
-			dispatch( {
-				type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
-				siteId,
-				orderId,
-				order: data,
-			} );
-		} )
-		.catch( error => {
-			dispatch( setError( siteId, updateAction, error ) );
-			dispatch( errorNotice( translate( 'Unable to save order.' ), { duration: 5000 } ) );
-			dispatch( {
-				type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
-				siteId,
-				orderId,
-				error,
-			} );
-		} );
+export const saveOrderError = ( siteId, orderId, error = false ) => {
+	return {
+		type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
+		siteId,
+		orderId,
+		error,
+	};
+};
+
+export const saveOrderSuccess = ( siteId, orderId, order = {} ) => {
+	// This passed through the API layer successfully, but failed at the remote site.
+	if ( 'undefined' === typeof order.id ) {
+		return saveOrderError( siteId, orderId, order );
+	}
+	return {
+		type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
+		siteId,
+		orderId,
+		order,
+	};
 };

--- a/client/extensions/woocommerce/state/sites/orders/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/actions.js
@@ -4,16 +4,23 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { omit } from 'lodash';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
  */
-import { fetchOrder, updateOrders, failOrders, fetchOrders, updateOrder } from '../actions';
+import {
+	failOrder,
+	failOrders,
+	fetchOrder,
+	fetchOrders,
+	saveOrder,
+	saveOrderError,
+	saveOrderSuccess,
+	updateOrder,
+	updateOrders,
+} from '../actions';
 import order from './fixtures/order';
 import orders from './fixtures/orders';
-import useNock from 'test/helpers/use-nock';
 import {
 	WOOCOMMERCE_ORDER_REQUEST,
 	WOOCOMMERCE_ORDER_REQUEST_FAILURE,
@@ -68,160 +75,72 @@ describe( 'actions', () => {
 
 	describe( '#fetchOrder()', () => {
 		const siteId = '123';
+		const orderId = '40';
 
-		useNock( nock => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/orders/40&_method=get', json: true } )
-				.reply( 200, {
-					data: order,
-				} )
-				.get( '/rest/v1.1/jetpack-blogs/234/rest-api/' )
-				.query( { path: '/wc/v3/orders/invalid&_method=get', json: true } )
-				.reply( 404, {
-					data: {
-						message: 'No route was found matching the URL and request method',
-						error: 'rest_no_route',
-						status: 400,
-					},
-				} );
-		} );
-
-		test( 'should dispatch an action', () => {
-			const getState = () => ( {} );
-			const dispatch = spy();
-			fetchOrder( siteId, 40 )( dispatch, getState );
-			expect( dispatch ).to.have.been.calledWith( {
+		test( 'should return an action', () => {
+			const action = fetchOrder( siteId, orderId );
+			expect( action ).to.eql( {
 				type: WOOCOMMERCE_ORDER_REQUEST,
-				siteId,
-				orderId: 40,
+				siteId: '123',
+				orderId: '40',
 			} );
 		} );
 
-		test( 'should dispatch a success action with the order when request completes', () => {
-			const getState = () => ( {} );
-			const dispatch = spy();
-			const response = fetchOrder( siteId, 40 )( dispatch, getState );
-
-			return response.then( () => {
-				expect( dispatch ).to.have.been.calledWith( {
-					type: WOOCOMMERCE_ORDER_REQUEST_SUCCESS,
-					siteId,
-					orderId: 40,
-					order,
-				} );
+		test( 'should return a success action with orders list when request completes', () => {
+			const action = updateOrder( siteId, orderId, order );
+			expect( action ).to.eql( {
+				type: WOOCOMMERCE_ORDER_REQUEST_SUCCESS,
+				siteId: '123',
+				orderId: '40',
+				order,
 			} );
 		} );
 
-		test( 'should dispatch a failure action with the error when a the request fails', () => {
-			const getState = () => ( {} );
-			const dispatch = spy();
-			const response = fetchOrder( 234, 'invalid' )( dispatch, getState );
-
-			return response.then( () => {
-				expect( dispatch ).to.have.been.calledWithMatch( {
-					type: WOOCOMMERCE_ORDER_REQUEST_FAILURE,
-					siteId: 234,
-				} );
+		test( 'should return a failure action with the error when a the request fails', () => {
+			const action = failOrder( siteId, orderId, { code: 'rest_no_route' } );
+			expect( action ).to.eql( {
+				type: WOOCOMMERCE_ORDER_REQUEST_FAILURE,
+				siteId: '123',
+				orderId: '40',
+				error: { code: 'rest_no_route' },
 			} );
-		} );
-
-		test( 'should not dispatch if orders are already loading for this site', () => {
-			const getState = () => ( {
-				extensions: {
-					woocommerce: {
-						sites: {
-							123: {
-								orders: {
-									isQueryLoading: {},
-									isLoading: {
-										40: true,
-									},
-									items: {},
-									queries: {},
-									total: {},
-								},
-							},
-						},
-					},
-				},
-			} );
-			const dispatch = spy();
-			fetchOrder( 123, 40 )( dispatch, getState );
-			expect( dispatch ).to.not.have.been.called;
 		} );
 	} );
 
 	describe( '#updateOrder()', () => {
-		const siteId = '123';
+		const siteId = 123;
 		const updatedOrder = {
 			id: 40,
 			status: 'completed',
 		};
 
-		useNock( nock => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( {
-					path: '/wc/v3/orders/40&_method=post',
-					json: true,
-					body: omit( updatedOrder, 'id' ),
-				} )
-				.reply( 200, {
-					data: order,
-				} )
-				.post( '/rest/v1.1/jetpack-blogs/234/rest-api/' )
-				.query( {
-					path: '/wc/v3/orders/invalid&_method=post',
-					json: true,
-					body: omit( updatedOrder, 'id' ),
-				} )
-				.reply( 404, {
-					data: {
-						message: 'No route was found matching the URL and request method',
-						error: 'rest_no_route',
-					},
-				} );
-		} );
-
 		test( 'should dispatch an action', () => {
-			const getState = () => ( {} );
-			const dispatch = spy();
-			updateOrder( siteId, updatedOrder )( dispatch, getState );
-			expect( dispatch ).to.have.been.calledWith( {
+			const action = saveOrder( siteId, updatedOrder );
+			expect( action ).to.eql( {
 				type: WOOCOMMERCE_ORDER_UPDATE,
-				siteId,
+				siteId: 123,
 				orderId: 40,
+				order: { status: 'completed' },
 			} );
 		} );
 
 		test( 'should dispatch a success action with the order when request completes', () => {
-			const getState = () => ( {} );
-			const dispatch = spy();
-			const response = updateOrder( siteId, updatedOrder )( dispatch, getState );
-
-			return response.then( () => {
-				expect( dispatch ).to.have.been.calledWith( {
-					type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
-					siteId,
-					orderId: 40,
-					order,
-				} );
+			const action = saveOrderSuccess( siteId, 40, updatedOrder );
+			expect( action ).to.eql( {
+				type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
+				siteId: 123,
+				orderId: 40,
+				order: { id: 40, status: 'completed' },
 			} );
 		} );
 
 		test( 'should dispatch a failure action with the error when a the request fails', () => {
-			const getState = () => ( {} );
-			const dispatch = spy();
-			const response = updateOrder( 234, { id: 'invalid' } )( dispatch, getState );
-
-			return response.then( () => {
-				expect( dispatch ).to.have.been.calledWithMatch( {
-					type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
-					siteId: 234,
-				} );
+			const action = saveOrderError( 234, 1, 'Error object' );
+			expect( action ).to.eql( {
+				type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
+				siteId: 234,
+				orderId: 1,
+				error: 'Error object',
 			} );
 		} );
 	} );

--- a/client/extensions/woocommerce/state/sites/orders/utils.js
+++ b/client/extensions/woocommerce/state/sites/orders/utils.js
@@ -8,6 +8,7 @@ import { forEach, isEmpty, isNumber, omit, omitBy } from 'lodash';
  * Internal dependencies
  */
 import { getCurrencyFormatDecimal, getCurrencyFormatString } from 'woocommerce/lib/currency';
+import { getOrderStatusGroup } from 'woocommerce/lib/order-status';
 
 export const DEFAULT_QUERY = {
 	page: 1,
@@ -24,6 +25,9 @@ export const DEFAULT_QUERY = {
  * @return {Object}       Normalized orders query
  */
 export function getNormalizedOrdersQuery( query ) {
+	if ( query.status ) {
+		query.status = getOrderStatusGroup( query.status );
+	}
 	return omitBy( query, ( value, key ) => DEFAULT_QUERY[ key ] === value );
 }
 

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -42,38 +42,33 @@ class StoreSidebar extends Component {
 		const { productsLoaded, site } = this.props;
 
 		if ( site && site.ID ) {
-			this.props.fetchSetupChoices( site.ID );
-			this.props.fetchOrders( site.ID );
-
-			// TODO This check can be removed when we launch reviews.
-			if ( config.isEnabled( 'woocommerce/extension-reviews' ) ) {
-				this.props.fetchReviews( site.ID, { status: 'pending' } );
-			}
-
-			if ( ! productsLoaded ) {
-				this.props.fetchProducts( site.ID, { page: 1 } );
-			}
+			this.fetchData( { siteId: site.ID, productsLoaded } );
 		}
 	};
 
 	componentWillReceiveProps = newProps => {
-		const { productsLoaded, site } = this.props;
+		const { site } = this.props;
 
 		const newSiteId = newProps.site ? newProps.site.ID : null;
 		const oldSiteId = site ? site.ID : null;
 
 		if ( newSiteId && oldSiteId !== newSiteId ) {
-			this.props.fetchSetupChoices( newSiteId );
-			this.props.fetchOrders( newSiteId );
+			newProps.siteId = newSiteId;
+			this.fetchData( newProps );
+		}
+	};
 
-			// TODO This check can be removed when we launch reviews.
-			if ( config.isEnabled( 'woocommerce/extension-reviews' ) ) {
-				this.props.fetchReviews( newSiteId, { status: 'pending' } );
-			}
+	fetchData = ( { siteId, productsLoaded } ) => {
+		this.props.fetchSetupChoices( siteId );
+		this.props.fetchOrders( siteId );
 
-			if ( ! productsLoaded ) {
-				this.props.fetchProducts( newSiteId, { page: 1 } );
-			}
+		// TODO This check can be removed when we launch reviews.
+		if ( config.isEnabled( 'woocommerce/extension-reviews' ) ) {
+			this.props.fetchReviews( siteId, { status: 'pending' } );
+		}
+
+		if ( ! productsLoaded ) {
+			this.props.fetchProducts( siteId, { page: 1 } );
 		}
 	};
 

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -53,8 +53,7 @@ class StoreSidebar extends Component {
 		const oldSiteId = site ? site.ID : null;
 
 		if ( newSiteId && oldSiteId !== newSiteId ) {
-			newProps.siteId = newSiteId;
-			this.fetchData( newProps );
+			this.fetchData( { ...newProps, siteId: newSiteId } );
 		}
 	};
 

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -18,7 +18,7 @@ import getRates from './get-rates';
 import { getPrintURL } from 'woocommerce/woocommerce-services/lib/pdf-label-utils';
 import { getFirstErroneousStep, getShippingLabel, getFormErrors, shouldFulfillOrder, shouldEmailDetails } from './selectors';
 import { createNote } from 'woocommerce/state/sites/orders/notes/actions';
-import { updateOrder } from 'woocommerce/state/sites/orders/actions';
+import { saveOrder } from 'woocommerce/state/sites/orders/actions';
 import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
 
 import {
@@ -591,7 +591,7 @@ const pollForLabelsPurchase = ( orderId, siteId, dispatch, getState, labels ) =>
 						}
 
 						if ( shouldFulfillOrder( getState(), orderId, siteId ) ) {
-							dispatch( updateOrder( siteId, {
+							dispatch( saveOrder( siteId, {
 								id: orderId,
 								status: 'completed',
 							} ) );


### PR DESCRIPTION
This PR switches the `fetchOrders` code to use the data-layer to request orders.

**Run the tests:**

- npm run test-client client/extensions/woocommerce/state/data-layer/orders/test/index.js
- npm run test-client client/extensions/woocommerce/state/sites/orders/

**Make sure it still works in calypso**

- Visit the orders list `/store/orders/:site`
- View list, switch between statuses, ensure all orders load as expected
- Try with as site with Jetpack disconnected, or wc-api-dev disabled, to replicate loading errors, and make sure the "nothing found" screen loads in (this is not ideal, we should handle the error somehow, but this behavior matches production)