### PR TITLE
Refactor plugin route middlewares

### DIFF
--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -61,15 +61,26 @@ export default function() {
 			page( '/plugins/upload/:site_id', siteSelection, navigation, pluginsController.upload );
 		}
 
-		page( '/plugins', siteSelection, navigation, pluginsController.browsePlugins );
+		page(
+			'/plugins/:category(featured|new|popular)?',
+			siteSelection,
+			navigation,
+			pluginsController.browsePlugins
+		);
+
+		page(
+			'/plugins/:category(featured|new|popular)/:site',
+			siteSelection,
+			navigation,
+			pluginsController.browsePlugins
+		);
 
 		page(
 			'/plugins/manage/:site?',
 			siteSelection,
 			navigation,
 			ifSimpleSiteThenRedirectTo( '/plugins' ),
-			pluginsController.plugins,
-			sites
+			pluginsController.pluginList
 		);
 
 		page(
@@ -77,16 +88,14 @@ export default function() {
 			siteSelection,
 			navigation,
 			pluginsController.jetpackCanUpdate,
-			pluginsController.plugins,
-			sites
+			pluginsController.pluginList
 		);
 
 		page(
 			'/plugins/:plugin/:site_id?',
 			siteSelection,
 			navigation,
-			pluginsController.maybeBrowsePlugins,
-			pluginsController.plugin
+			pluginsController.browsePluginsOrPlugin
 		);
 
 		page(


### PR DESCRIPTION
### 1. Remove un-used `sites` middleware
Site selector (i.e. `sites middleware`) is never needed since these routes work just fine for multi sites. It's just on the way if we want to add more middlewares in the chain after it. Ref https://github.com/Automattic/wp-calypso/pull/19494#discussion_r153247278


### 2. Refactor middlewares to support `next()`
I initially hit issues with these routes when trying to append two new middlewares at the end of each route definition:
```js
page(
  '/plugins/:plugin/:site_id?',
  siteSelection,
  navigation,
  pluginsController.maybeBrowsePlugins,
  pluginsController.plugin,
  makeLayout,
  clientRender
);
```

`maybeBrowsePlugins` middleware was built assuming it could the last middleware in the chain, so adding `next()` inside it would leave me stuck with `plugin` middleware.


### 3. Move some of the route logic to route definitions file, out of controller
This just makes understanding the module easier. Previously logic for these categories was inside `maybeBrowsePlugins` middleware — now renamed to `browsePluginsOrPlugin`  — ideas for a better name?

I'm adding two new routes:
- `/plugins/:category(featured|new|popular)?` (will catch also `/plugins`)
- `/plugins/:category(featured|new|popular)/:site`

I would've liked to have just `/plugins/:category(featured|new|popular)?/:site?` (both params optional) but that breaks other routes (e.g. `/plugins/woocommerce`) as it becomes kind of "catch it all".

### 4. Rename `plugins` middleware to `pluginList`
...so that it matches better `PluginListComponent` and doesn't confuse with `browsePlugins` middleware and `PluginBrowser` component.

I think it could be even better to have it called `pluginManagement` as that's what it is while "list" sounds very generic.


## Testing
Routes for plugins are rather complicated so test with care please. 💥 

Ensure this all works when "All My Sites" option is selected as well single site.

- Ensure browsing both plugin catalog works:
  - http://calypso.localhost:3000/plugins
  - http://calypso.localhost:3000/plugins/:site
  - http://calypso.localhost:3000/plugins/new
  - http://calypso.localhost:3000/plugins/new/:site

- Ensure plugin manager works:
  - http://calypso.localhost:3000/plugins/updates
  - http://calypso.localhost:3000/plugins/updates/:site
  - http://calypso.localhost:3000/plugins/manage
  - http://calypso.localhost:3000/plugins/manage/:site
  - http://calypso.localhost:3000/plugins/jetpack/eligibility/:site

- Ensure you can open a single plugin
  - http://calypso.localhost:3000/plugins/woocommerce
  - http://calypso.localhost:3000/plugins/woocommerce/:site

- Ensure [`jetpackCanUpdate `](https://github.com/Automattic/wp-calypso/blob/d9b7c42a37109873b882a25d177a06dc1e51b474/client/my-sites/plugins/controller.js#L222-L241) middleware still works and shows either autoupdate toggle or "Autoupdates disabled" text for Jetpack sites:
  - http://calypso.localhost:3000/plugins/manage/:site
    ![image](https://user-images.githubusercontent.com/87168/33390042-69fe5726-d53d-11e7-8b1d-86ee30ca94fe.png)
  - You can quickly switch [`canJetpackSiteUpdateFiles()`](https://github.com/Automattic/wp-calypso/blob/master/client/state/sites/selectors.js#L634-L671) to return `false`, or set `define( 'DISALLOW_FILE_MODS', true );` at your local WP setup.