### PR TITLE
Fix misaligned logo in payments box section when using Firefox

### DIFF
--- a/client/my-sites/checkout/checkout/credits-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credits-payment-box.jsx
@@ -33,22 +33,24 @@ class CreditsPaymentBox extends React.Component {
 		return (
 			<form onSubmit={ this.props.onSubmit }>
 				<div className="payment-box-section">
-					<h6>{ this.props.translate( 'WordPress.com Credits' ) }</h6>
+					<div className="checkout__payment-box-section-content">
+						<h6>{ this.props.translate( 'WordPress.com Credits' ) }</h6>
 
-					<span>
-						{ this.props.translate(
-							'You have {{strong}}%(credits)s %(currency)s in Credits{{/strong}} available.',
-							{
-								args: {
-									credits: cart.credits,
-									currency: cart.currency,
-								},
-								components: {
-									strong: <strong />,
-								},
-							}
-						) }
-					</span>
+						<span>
+							{ this.props.translate(
+								'You have {{strong}}%(credits)s %(currency)s in Credits{{/strong}} available.',
+								{
+									args: {
+										credits: cart.credits,
+										currency: cart.currency,
+									},
+									components: {
+										strong: <strong />,
+									},
+								}
+							) }
+						</span>
+					</div>
 				</div>
 
 				<TermsOfService />

--- a/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
@@ -27,22 +27,24 @@ class FreeCartPaymentBox extends React.Component {
 		return (
 			<form onSubmit={ this.props.onSubmit }>
 				<div className="payment-box-section">
-					<h6>
-						{ cart.has_bundle_credit
-							? this.props.translate( 'You have a free domain credit!' )
-							: this.props.translate( "Woohoo! You don't owe us anything!" ) }
-					</h6>
+					<div className="checkout__payment-box-section-content">
+						<h6>
+							{ cart.has_bundle_credit
+								? this.props.translate( 'You have a free domain credit!' )
+								: this.props.translate( "Woohoo! You don't owe us anything!" ) }
+						</h6>
 
-					<span>
-						{ cart.has_bundle_credit
-							? this.props.translate(
-									'You get one free domain with your subscription to %(productName)s. Time to celebrate!',
-									{ args: { productName: this.getProductName() } }
-								)
-							: this.props.translate(
-									'Just complete checkout to add these upgrades to your site.'
-								) }
-					</span>
+						<span>
+							{ cart.has_bundle_credit
+								? this.props.translate(
+										'You get one free domain with your subscription to %(productName)s. Time to celebrate!',
+										{ args: { productName: this.getProductName() } }
+									)
+								: this.props.translate(
+										'Just complete checkout to add these upgrades to your site.'
+									) }
+						</span>
+					</div>
 				</div>
 
 				<TermsOfService />

--- a/client/my-sites/checkout/checkout/free-trial-confirmation-box.js
+++ b/client/my-sites/checkout/checkout/free-trial-confirmation-box.js
@@ -21,17 +21,20 @@ class FreeTrialConfirmationBox extends React.Component {
 		return (
 			<form onSubmit={ this.props.onSubmit }>
 				<div className="payment-box-section">
-					<h6>
-						{ this.props.translate( 'Get started with %(productName)s', {
-							args: { productName: this.getProductName() },
-						} ) }
-					</h6>
+					<div className="checkout__payment-box-section-content">
+						<h6>
+							{ this.props.translate( 'Get started with %(productName)s', {
+								args: { productName: this.getProductName() },
+							} ) }
+						</h6>
 
-					<span>
-						{ this.props.translate(
-							'Enjoy your free trial with no strings attached: your site will simply revert to the free plan when the period is over.'
-						) }
-					</span>
+						<span>
+							{ this.props.translate(
+								'Enjoy your free trial with no strings attached: your site will simply revert to the ' +
+									'free plan when the period is over.'
+							) }
+						</span>
+					</div>
 				</div>
 
 				<TermsOfService />

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -457,36 +457,31 @@
 	// -----------------------------------
 	.credits-payment-box {
 		.payment-box-section {
+			align-items: center;
 			box-sizing: border-box;
-			min-height: 91px;
-			padding: 20px 20px 20px 80px;
-			position: relative;
 			display: flex;
-			flex-direction: column;
-			justify-content: center;
+			min-height: 91px;
+			padding: 20px 20px 20px 0;
 
 			&::before {
 				color: $blue-medium;
-				left: 10px;
-				position: absolute;
+				margin: 0 10px;
 				@include noticon( '\f205', 60px );
 				@include breakpoint( '>660px' ) {
-					left: 20px;
+					margin: 0 20px;
 				}
 			}
 
-			> h6 {
-				color: $blue-medium;
-				font-size: 18px;
-			}
+			.checkout__payment-box-section-content {
+				> h6 {
+					color: $blue-medium;
+					font-size: 18px;
+				}
 
-			> span {
-				color: darken( $gray, 10% );
-				font-size: 15px;
-			}
-
-			@include breakpoint( '>660px' ) {
-				padding-left: 100px;
+				> span {
+					color: darken( $gray, 10% );
+					font-size: 15px;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What this is

Fixes #19741.

Firefox incorrectly positions the WordPress logo when checking out with free credits.

This seems to be because Firefox renders a `position: absolute` element within a `display: flex` element as if it were not absolutely positioned.

The workaround is to avoid the need for `position: absolute` by introducing a wrapper `<div>`.

Before:

<img width="1392" alt="screen shot 2017-11-29 at 12 15 08" src="https://user-images.githubusercontent.com/612155/33352839-f88b4cf4-d4fe-11e7-99f5-7ddefacd0d1a.png">

After:

<img width="1392" alt="screen shot 2017-11-29 at 12 13 48" src="https://user-images.githubusercontent.com/612155/33352844-fd27cd50-d4fe-11e7-9493-3ea057b7f4a1.png">

## How to test

1. Start with an account that has free credits (Network Admin > Store Admin > Credit Balance) or a free domain credit.
1. Go to https://wordpress.com/ > My Sites > Plans or Domains.
1. Add something to the shopping cart.
1. Continue with the purchase flow until you see the Secure Payment page.
1. Look for the W logo. Check that it looks OK in various browsers and at various viewport sizes.

cc. @tellyworth @designsimply @jeremeylduvall 