### PR TITLE
Domains: Add busy state when restarting a failed incoming transfer

### DIFF
--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -80,12 +80,13 @@ class Transfer extends React.PureComponent {
 		return (
 			<Card>
 				<div>
-					<p className="edit__transfer-text-fail">{ translate( 'Domain transfer failed' ) }</p>
+					<h2 className="edit__transfer-text-fail">{ translate( 'Domain transfer failed' ) }</h2>
 					<p>
 						{ translate(
-							'We were unable to verify the transfer of {{strong}}%(domain)s{{/strong}}. The domain ' +
-								'authorization code from you current registrar was not provided to initiate the transfer. ' +
-								'{{a}}Learn More{{/a}}.',
+							'We were unable to complete the transfer of {{strong}}%(domain)s{{/strong}}. It could be ' +
+								'a number of things that caused the transfer to fail like an invalid or missing authorization code, ' +
+								'the domain is still locked, or your current domain provider denied the transfer. ' +
+								'{{a}}Visit our support article{{/a}} for more detailed information about why it may have failed.',
 							{
 								components: {
 									strong: <strong />,
@@ -97,10 +98,13 @@ class Transfer extends React.PureComponent {
 					</p>
 				</div>
 				<div>
-					<Button onClick={ this.restartTransfer }>
+					<Button className="edit__transfer-button-fail" onClick={ this.restartTransfer }>
 						{ this.props.translate( 'Start Transfer Again' ) }
 					</Button>
-					<Button className="edit__transfer-button-margin" href={ support.CALYPSO_CONTACT }>
+					<Button
+						className="edit__transfer-button-fail edit__transfer-button-fail-margin"
+						href={ support.CALYPSO_CONTACT }
+					>
 						{ this.props.translate( 'Contact Support' ) }
 					</Button>
 				</div>

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -27,6 +27,10 @@ import VerticalNavItem from 'components/vertical-nav/item';
 import { cancelPurchase as cancelPurchaseLink } from 'me/purchases/paths';
 
 class Transfer extends React.PureComponent {
+	state = {
+		isRestartingTransfer: false,
+	};
+
 	render() {
 		const { domain } = this.props;
 		let content = this.getDomainDetailsCard();
@@ -56,6 +60,7 @@ class Transfer extends React.PureComponent {
 
 	restartTransfer = () => {
 		const { domain, selectedSite, translate } = this.props;
+		this.toggleRestartState();
 
 		restartInboundTransfer( selectedSite.ID, domain.name, ( error, result ) => {
 			if ( result ) {
@@ -74,8 +79,13 @@ class Transfer extends React.PureComponent {
 		} );
 	};
 
+	toggleRestartState() {
+		this.setState( { isRestartingTransfer: ! this.state.isRestartingTransfer } );
+	}
+
 	getCancelledContent() {
 		const { domain, translate } = this.props;
+		const { isRestartingTransfer } = this.state;
 
 		return (
 			<Card>
@@ -98,8 +108,15 @@ class Transfer extends React.PureComponent {
 					</p>
 				</div>
 				<div>
-					<Button className="edit__transfer-button-fail" onClick={ this.restartTransfer }>
-						{ this.props.translate( 'Start Transfer Again' ) }
+					<Button
+						className="edit__transfer-button-fail"
+						onClick={ this.restartTransfer }
+						busy={ isRestartingTransfer }
+						disabled={ isRestartingTransfer }
+					>
+						{ isRestartingTransfer
+							? translate( 'Restarting Transfer…' )
+							: translate( 'Start Transfer Again' ) }
 					</Button>
 					<Button
 						className="edit__transfer-button-fail edit__transfer-button-fail-margin"

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -75,6 +75,7 @@ class Transfer extends React.PureComponent {
 						duration: 5000,
 					}
 				);
+				this.toggleRestartState();
 			}
 		} );
 	};

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -266,11 +266,25 @@ input[type=radio].domain-management-list-item__radio {
 
 	.edit__transfer-text-fail {
 		font-size: 18px;
-		font-weight: bold;
+		font-weight: 500;
 	}
 
-	.edit__transfer-button-margin {
-		margin-left: 15px;
+	.edit__transfer-button-fail {
+		display: block;
+		margin: 10px 0;
+		text-align: center;
+		width: 100%;
+
+		@include breakpoint( '>480px' ) {
+			display: inline-block;
+			width: auto;
+		}
+	}
+
+	@include breakpoint( '>480px' ) {
+		.edit__transfer-button-fail-margin {
+			margin-left: 15px;
+		}
 	}
 }
 

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -275,6 +275,11 @@ input[type=radio].domain-management-list-item__radio {
 		text-align: center;
 		width: 100%;
 
+		&.is-busy:disabled {
+			border-color: lighten( $gray, 20% );
+			color: darken( $gray, 20% );
+		}
+
 		@include breakpoint( '>480px' ) {
 			display: inline-block;
 			width: auto;


### PR DESCRIPTION
Fixes #20259 by adding a busy state to the `Start Transfer Again` button. I've also disabled the button to prevent multiple clicks. This PR also cleans up some of the styles and updates the copy. Since we don't know the exact cause of the failed transfer I made the message more general with some possible reasons.

<img width="739" alt="screen shot 2017-11-28 at 21 13 33" src="https://user-images.githubusercontent.com/448298/33354764-689ef4dc-d482-11e7-8e26-fa533c4beef7.png">

#### Testing

1. If you have a failed domain transfer, go to the corresponding domain edit card.
2. Verify the card looks like the screenshot above.
3. Click `Start Transfer Again` and assert you see the busy state.
4. If you don't have a failed domain transfer, start a new incoming domain transfer.
5. Decline the transfer via the link in the FOA email.
6. View the domain edit card for the domain transfer you just declined, complete steps 2-3 above.