### PR TITLE
Change default theme for Business sites

### DIFF
--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -153,7 +153,7 @@ function getThemeForSiteGoals( siteGoals ) {
 	}
 
 	if ( siteGoalsValue.indexOf( 'promote' ) !== -1 ) {
-		return 'pub/radcliffe-2';
+		return 'pub/dara';
 	}
 
 	if ( siteGoalsValue.indexOf( 'educate' ) !== -1 ) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6981253/33355691-8a5c5638-d486-11e7-8ca7-ce67fa910c4d.png)

The `Radcliffe 2` headstart script doesn't appear to be working correctly so I created this PR to change the default theme for business sites to `Dara`.

## Test
* Create a new site from `/start/segment`
* Check the `Promote your business, skills, organization, or events` checkbox under `What’s the primary goal you have for your site?`
* Press `Continue`
* Complete signup and find `Dara` as your default theme

@markryall can you take a look?