### PR TITLE
Sign Up: remove signupSurvey a/b test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -9,14 +9,6 @@ export default {
 		},
 		defaultVariation: 'singlePurchaseFlow',
 	},
-	signupSurveyStep: {
-		datestamp: '20170329',
-		variations: {
-			showSurveyStep: 20,
-			hideSurveyStep: 80,
-		},
-		defaultVariation: 'hideSurveyStep',
-	},
 	signupAtomicStoreVsPressable: {
 		datestamp: '20171101',
 		variations: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -10,7 +10,6 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
@@ -439,7 +438,7 @@ const Flows = {
 	 * @param {String} flowName The current flow
 	 * @param {String} stepName The step that is being completed right now
 	 */
-	preloadABTestVariationsForStep( flowName, stepName ) {
+	preloadABTestVariationsForStep() {
 		/**
 		 * In cases where the flow is being resumed, the flow must not be changed from what the user
 		 * has seen before.
@@ -455,15 +454,10 @@ const Flows = {
 		 * If there is need to test the first step in a flow,
 		 * the best way to do it is to check for:
 		 *
-		 * 	if ( '' === stepName ) { ... }
+		 * 	if ( 'main' === flowName && '' === stepName ) { ... }
 		 *
 		 * This will be fired at the beginning of the signup flow.
 		 */
-		if ( 'main' === flowName ) {
-			if ( '' === stepName ) {
-				abtest( 'signupSurveyStep' );
-			}
-		}
 	},
 
 	/**
@@ -480,11 +474,8 @@ const Flows = {
 	 */
 	getABTestFilteredFlow( flowName, flow ) {
 		// Only do this on the main flow
-		if ( 'main' === flowName ) {
-			if ( abtest( 'signupSurveyStep' ) === 'showSurveyStep' ) {
-				return Flows.insertStepIntoFlow( 'survey', flow );
-			}
-		}
+		// if ( 'main' === flowName ) {
+		// }
 
 		return flow;
 	},

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -202,10 +202,6 @@ class DesignTypeWithAtomicStoreStep extends Component {
 			return translate( 'Create your WordPress Store' );
 		}
 
-		if ( abtest( 'signupSurveyStep' ) === 'showSurveyStep' ) {
-			return "We're excited to hear more about your project.";
-		}
-
 		return translate( 'Hello! Let’s create your new site.' );
 	}
 

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -19,7 +19,6 @@ import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
 import PressableStoreStep from './pressable-store';
 import { BlogImage, PageImage, GridImage, StoreImage } from '../design-type-with-store/type-images';
-import { abtest } from 'lib/abtest';
 import { setDesignType } from 'state/signup/steps/design-type/actions';
 
 import { getThemeForDesignType } from 'signup/utils';
@@ -177,10 +176,6 @@ class DesignTypeWithStoreStep extends Component {
 
 		if ( this.state.showStore ) {
 			return translate( 'Create your WordPress Store' );
-		}
-
-		if ( abtest( 'signupSurveyStep' ) === 'showSurveyStep' ) {
-			return "We're excited to hear more about your project.";
 		}
 
 		return translate( 'Hello! Let’s create your new site.' );


### PR DESCRIPTION
Slightly updated version of #19365

This just removes the a/b test and any reference to it.

The step can remain (as it has been reinstated in the past).