### PR TITLE
Fire tracks events when checklist tasks are started

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -21,11 +21,18 @@ import { getSiteChecklist } from 'state/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import { onboardingTasks, urlForTask } from '../onboardingChecklist';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class ChecklistShow extends PureComponent {
 	onAction = id => {
-		const url = urlForTask( id, this.props.siteSlug );
+		const { siteSlug, track } = this.props;
+		const url = urlForTask( id, siteSlug );
 		if ( url ) {
+			track( 'calypso_checklist_task_start', {
+				checklist_name: 'new_blog',
+				step_name: id,
+			} );
+
 			page( url );
 		}
 	};
@@ -60,6 +67,6 @@ const mapStateToProps = state => {
 	const siteSlug = getSiteSlug( state, siteId );
 	return { siteId, siteSlug, siteChecklist };
 };
-const mapDispatchToProps = null;
+const mapDispatchToProps = { track: recordTracksEvent };
 
 export default connect( mapStateToProps, mapDispatchToProps )( ChecklistShow );

--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -25,12 +25,14 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 class ChecklistShow extends PureComponent {
 	onAction = id => {
-		const { siteSlug, track } = this.props;
+		const { siteSlug, siteChecklist, track } = this.props;
 		const url = urlForTask( id, siteSlug );
-		if ( url ) {
+		if ( url && siteChecklist && siteChecklist.tasks ) {
+			const status = siteChecklist.tasks[ id ] ? 'complete' : 'incomplete';
 			track( 'calypso_checklist_task_start', {
 				checklist_name: 'new_blog',
 				step_name: id,
+				status,
 			} );
 
 			page( url );


### PR DESCRIPTION
# Testing

* create a new site
* enable tracks debugging: `localStorage.setItem('debug', 'calypso:analytics:tracks');`
* browse to `/checklist`
* click on a few checklist 'Do It' buttons
* Verify that a `calypso_checklist_task_start` tracks event is fired