### PR TITLE
Show "I'll Keep It" instead of "Cancel Now" on first step of cancel flow

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -160,8 +160,8 @@ class CancelPurchaseButton extends Component {
 		} else {
 			buttonsArr =
 				this.state.surveyStep === INITIAL_STEP
-					? [ buttons.cancel, buttons.next ]
-					: [ buttons.cancel, buttons.prev, buttons.next ];
+					? [ buttons.close, buttons.next ]
+					: [ buttons.close, buttons.prev, buttons.next ];
 		}
 
 		return (


### PR DESCRIPTION
This relates to issue #20319

The cancellation flow incorrectly showed the "Cancel Now" (cancel) instead of "I'll Keep It" (close) on the first steps of the cancellation flow.

old:

![screen shot 2017-11-29 at 6 40 14 pm](https://user-images.githubusercontent.com/1926/33365695-c3461cfa-d534-11e7-9de1-c33fa7a3c17c.png)

new:

![screen shot 2017-11-29 at 6 39 33 pm](https://user-images.githubusercontent.com/1926/33365663-ab07ef24-d534-11e7-896d-5a4c6850b2a7.png)

# Testing

* buy a plan with a credit card (do not use credits or you will instead see the remove flow which does not have this problem)
* navigate to `/me/purchases` and select your purchase
* click 'Cancel Subscription and Refund'
* Verify that the first step appears as second of the above screenshots