### PR TITLE
JP site settings: remove translate call from WP path placeholder

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -117,7 +117,7 @@ export class CredentialsForm extends Component {
 						<FormTextInput
 							name="port"
 							id="server-port"
-							placeholder={ translate( '22' ) }
+							placeholder="22"
 							value={ get( this.state.form, 'port', '' ) }
 							onChange={ this.handleFieldChange }
 							disabled={ formIsSubmitting }

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -162,7 +162,7 @@ export class CredentialsForm extends Component {
 					<FormTextInput
 						name="abspath"
 						id="wordpress-path"
-						placeholder={ translate( '/public_html/wordpress-site/' ) }
+						placeholder="/public_html/wordpress-site/"
 						value={ get( this.state.form, 'abspath', '' ) }
 						onChange={ this.handleFieldChange }
 						disabled={ formIsSubmitting }


### PR DESCRIPTION
There's no value in having this path placeholder translated.