### PR TITLE
Jetpack connect: Remove redundant thunk actions

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -64,20 +64,16 @@ const remoteInstallPath = '/wp-admin/plugin-install.php?tab=plugin-information&p
 const remoteActivatePath = '/wp-admin/plugins.php';
 
 export function confirmJetpackInstallStatus( status ) {
-	return dispatch => {
-		dispatch( {
-			type: JETPACK_CONNECT_CONFIRM_JETPACK_STATUS,
-			status: status,
-		} );
+	return {
+		type: JETPACK_CONNECT_CONFIRM_JETPACK_STATUS,
+		status: status,
 	};
 }
 
 export function dismissUrl( url ) {
-	return dispatch => {
-		dispatch( {
-			type: JETPACK_CONNECT_DISMISS_URL_STATUS,
-			url: url,
-		} );
+	return {
+		type: JETPACK_CONNECT_DISMISS_URL_STATUS,
+		url: url,
 	};
 }
 

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -35,13 +35,10 @@ describe( 'actions', () => {
 
 	describe( '#confirmJetpackInstallStatus()', () => {
 		test( 'should dispatch confirm status action when called', () => {
-			const spy = jest.fn();
 			const { confirmJetpackInstallStatus } = actions;
 			const jetpackStatus = true;
 
-			confirmJetpackInstallStatus( jetpackStatus )( spy );
-
-			expect( spy ).toHaveBeenCalledWith( {
+			expect( confirmJetpackInstallStatus( jetpackStatus ) ).toEqual( {
 				type: JETPACK_CONNECT_CONFIRM_JETPACK_STATUS,
 				status: jetpackStatus,
 			} );
@@ -50,13 +47,10 @@ describe( 'actions', () => {
 
 	describe( '#dismissUrl()', () => {
 		test( 'should dispatch dismiss url status action when called', () => {
-			const spy = jest.fn();
 			const { dismissUrl } = actions;
 			const url = 'http://example.com';
 
-			dismissUrl( url )( spy );
-
-			expect( spy ).toHaveBeenCalledWith( {
+			expect( dismissUrl( url ) ).toEqual( {
 				type: JETPACK_CONNECT_DISMISS_URL_STATUS,
 				url: url,
 			} );


### PR DESCRIPTION
Some action creators use thunks unnecessarily. This PR removes them.

Mentioned here: https://github.com/Automattic/wp-calypso/pull/20294#discussion_r153581388

## Testing
1. Ensure connect flows continue to work properly.