### PR TITLE
Editor: hide the masterbar in the editor

### DIFF
--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -46,7 +46,7 @@
 		& > .mce-toolbar-grp,
 		&:after {
 			position: fixed;
-				top: 94px;
+				top: 47px;
 			border-top-width: 0;
 			border-left-width: 0;
 			border-right-width: 0;

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -95,47 +95,27 @@
 	display: flex;
 }
 
-.web-preview__close.button,
-a.web-preview__external.button {
-	color: $gray;
-	padding: 6px 10px;
-
-	cursor: pointer;
-
+.web-preview__close.button {
+	border-right: 1px solid lighten( $gray, 25% );
+	padding: 6px 32px;
+	color: $blue-wordpress;
 	border-radius: 0;
 
 	&:hover {
-		color: $gray-dark;
-	}
-}
-
-.web-preview__close.button {
-	border-right: 1px solid lighten( $gray, 25% );
-
-	.gridicon {
-		top: 4px;
+		color: $blue-medium;
 	}
 }
 
 a.web-preview__external.button {
-	.gridicon {
-		top: 6px;
-	}
+	margin: 3px 8px;
+	min-width: 120px;
+	text-align: center;
 }
 
 .web-preview__edit.button {
-	color: $gray;
-	border: none;
-	padding: 6px 12px;
-
-	&:visited {
-		color: $gray;
-	}
-
-	&:hover {
-		color: $gray-dark;
-	}
-
+	margin: 3px 0;
+	min-width: 100px;
+	text-align: center;
 }
 
 .web-preview__toolbar-actions {

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -126,7 +126,6 @@ a.web-preview__external.button {
 .web-preview__toolbar-actions {
 	margin-left: auto;
 	display: flex;
-	flex-wrap: wrap;
 	justify-content: flex-end;
 
 	@include breakpoint( ">960px" ) {

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -97,9 +97,14 @@
 
 .web-preview__close.button {
 	border-right: 1px solid lighten( $gray, 25% );
-	padding: 6px 32px;
+	padding: 6px 16px;
+	min-width: 80px;
 	color: $blue-wordpress;
 	border-radius: 0;
+
+	@include breakpoint( ">960px" ) {
+		padding: 6px 32px;
+	}
 
 	&:hover {
 		color: $blue-medium;

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -105,7 +105,7 @@ class PreviewToolbar extends Component {
 						data-tip-target="web-preview__close"
 						onClick={ this.handleEditorWebPreviewClose }
 					>
-						<Gridicon icon={ isModalWindow ? 'cross' : 'arrow-left' } />
+						{ isModalWindow ? <Gridicon icon="cross" /> : translate( 'Done' ) }
 					</Button>
 				) }
 				{ showDeviceSwitcher && (
@@ -137,20 +137,19 @@ class PreviewToolbar extends Component {
 				) }
 				<div className="web-preview__toolbar-actions">
 					{ showEdit && (
-						<Button borderless className="web-preview__edit" href={ editUrl } onClick={ onEdit }>
-							<Gridicon icon="pencil" /> { translate( 'Edit' ) }
+						<Button className="web-preview__edit" href={ editUrl } onClick={ onEdit }>
+							{ translate( 'Edit' ) }
 						</Button>
 					) }
 					{ showExternal && (
 						<Button
-							borderless
+							primary
 							className="web-preview__external"
 							href={ externalUrl || previewUrl }
-							target="_blank"
 							rel="noopener noreferrer"
 							onClick={ this.handleEditorWebPreviewExternalClick }
 						>
-							<Gridicon icon="external" />
+							{ translate( 'Visit' ) }
 						</Button>
 					) }
 					<div className="web-preview__toolbar-tray">{ this.props.children }</div>

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -105,7 +105,7 @@ class PreviewToolbar extends Component {
 						data-tip-target="web-preview__close"
 						onClick={ this.handleEditorWebPreviewClose }
 					>
-						{ isModalWindow ? <Gridicon icon="cross" /> : translate( 'Done' ) }
+						{ translate( 'Close' ) }
 					</Button>
 				) }
 				{ showDeviceSwitcher && (
@@ -146,10 +146,11 @@ class PreviewToolbar extends Component {
 							primary
 							className="web-preview__external"
 							href={ externalUrl || previewUrl }
+							target={ isModalWindow ? '_blank' : null }
 							rel="noopener noreferrer"
 							onClick={ this.handleEditorWebPreviewExternalClick }
 						>
-							{ translate( 'Visit' ) }
+							{ translate( 'Visit Site' ) }
 						</Button>
 					) }
 					<div className="web-preview__toolbar-tray">{ this.props.children }</div>

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -462,7 +462,8 @@ $autobar-height: 20px;
 	opacity: 0;
 	pointer-events: none;
 
-	.masterbar__item {
+	.masterbar__item,
+	.masterbar__toggle-drafts {
 		transform: translateY( -48px );
 	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -75,7 +75,7 @@ $autobar-height: 20px;
 	padding: 0 15px;
 	text-decoration: none;
 	cursor: default;
-	transition: all 150ms ease-in;
+	transition: all 0.2s ease-in-out;
 
 	&:visited {
 		color: var( --masterbar-color );
@@ -453,9 +453,10 @@ $autobar-height: 20px;
 	}
 }
 
+// Editor Transition
 .masterbar {
 	opacity: 1;
-	transition: opacity 0.2s ease-out;
+	transition: opacity 0.3s ease-in-out;
 }
 .is-section-post-editor .masterbar {
 	opacity: 0;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -454,49 +454,14 @@ $autobar-height: 20px;
 }
 
 .masterbar {
-	transform: translateY( 0 );
-	transition: transform 0.6s linear;
-	transition-delay: 0.25s;
+	opacity: 1;
+	transition: opacity 0.2s ease-out;
 }
 .is-section-post-editor .masterbar {
-	transform: translateY( -100% );
-}
-
-// Transition in Editor
-// This should go somewhere else -shaun
-.post-editor,
-.post-editor__content {
 	opacity: 0;
-}
+	pointer-events: none;
 
-.is-section-post-editor .post-editor {
-	animation: 0.3s linear 0.25s 1 forwards editor-entrance;
-	//animation-delay: 1s;
-}
-
-.is-section-post-editor .post-editor__content {
-	animation: 0.3s linear 0.5s 1 forwards content-entrance;
-	//animation-delay: 2s;
-}
-
-@keyframes editor-entrance {
-	0% {
-		opacity: 0;
-		top: 40px;
-	}
-	100% {
-		opacity: 1;
-		top: 0;
-	}
-}
-
-@keyframes content-entrance {
-	0% {
-		opacity: 0;
-		//transform: translateY( 50px );
-	}
-	100% {
-		opacity: 1;
-		//transform: translateY( 0 );
+	.masterbar__item {
+		transform: translateY( -48px );
 	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -452,3 +452,7 @@ $autobar-height: 20px;
 		flex-grow: 0;
 	}
 }
+
+.is-section-post-editor .masterbar {
+	display: none;
+}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -454,5 +454,14 @@ $autobar-height: 20px;
 }
 
 .is-section-post-editor .masterbar {
-	display: none;
+	animation: 0.4s ease-out 0s 1 forwards masterbar__editor-hide;
+}
+
+@keyframes masterbar__editor-hide {
+	0% {
+		transform: translateY(0);
+	}
+	100% {
+		transform: translateY(-100%);
+	}
 }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -453,15 +453,50 @@ $autobar-height: 20px;
 	}
 }
 
+.masterbar {
+	transform: translateY( 0 );
+	transition: transform 0.6s linear;
+	transition-delay: 0.25s;
+}
 .is-section-post-editor .masterbar {
-	animation: 0.4s ease-out 0s 1 forwards masterbar__editor-hide;
+	transform: translateY( -100% );
 }
 
-@keyframes masterbar__editor-hide {
+// Transition in Editor
+// This should go somewhere else -shaun
+.post-editor,
+.post-editor__content {
+	opacity: 0;
+}
+
+.is-section-post-editor .post-editor {
+	animation: 0.3s linear 0.25s 1 forwards editor-entrance;
+	//animation-delay: 1s;
+}
+
+.is-section-post-editor .post-editor__content {
+	animation: 0.3s linear 0.5s 1 forwards content-entrance;
+	//animation-delay: 2s;
+}
+
+@keyframes editor-entrance {
 	0% {
-		transform: translateY(0);
+		opacity: 0;
+		top: 40px;
 	}
 	100% {
-		transform: translateY(-100%);
+		opacity: 1;
+		top: 0;
+	}
+}
+
+@keyframes content-entrance {
+	0% {
+		opacity: 0;
+		//transform: translateY( 50px );
+	}
+	100% {
+		opacity: 1;
+		//transform: translateY( 0 );
 	}
 }

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -7,6 +7,11 @@
 	margin-bottom: 24px;
 	padding: 12px 16px;
 
+	// This seems totally broken on mobile, and just, like an abandoned idea for a UI.
+	@include breakpoint( "<660px" ) {
+		display: none;
+	}
+
 	@include breakpoint( "<660px" ) {
 		margin-bottom: 8px;
 	}

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -37,6 +37,7 @@
 	border-right: none;
 	box-sizing: border-box;
 	position: fixed;
+	top: 0;
 	left: auto;
 	right: -$sidebar-width-max;
 	z-index: z-index('root', '.editor-confirmation-sidebar__sidebar');
@@ -64,7 +65,7 @@
 			height: auto;
 			width: 100%;
 			position: fixed;
-			top: 47px;
+			top: 0;
 			right: auto;
 			left: 0;
 			transform: none;
@@ -97,7 +98,8 @@
 	border-color: darken($alert-green, 20%);
 	color: $white;
 
-	padding: 7px 22px;
+	padding: 7px 24px;
+	min-width: 120px;
 	margin: 4px 0 4px 12px;
 
 	&:hover,

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -298,9 +298,9 @@ export class EditorGroundControl extends PureComponent {
 					className="editor-ground-control__back"
 					href={ '' }
 					onClick={ this.onBackButtonClick }
-					aria-label={ translate( 'Done' ) }
+					aria-label={ translate( 'Close' ) }
 				>
-					{ translate( 'Done' ) }
+					{ translate( 'Close' ) }
 				</Button>
 				<Site
 					compact

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -21,7 +21,6 @@ import siteUtils from 'lib/site/utils';
 import { recordEvent, recordStat } from 'lib/posts/stats';
 import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import Button from 'components/button';
-import EditorPostType from 'post-editor/editor-post-type';
 import HistoryButton from 'post-editor/editor-ground-control/history-button';
 
 export class EditorGroundControl extends PureComponent {
@@ -123,10 +122,6 @@ export class EditorGroundControl extends PureComponent {
 	}
 
 	getPreviewLabel() {
-		if ( postUtils.isPublished( this.props.savedPost ) && this.props.site.jetpack ) {
-			return this.props.translate( 'View' );
-		}
-
 		return this.props.translate( 'Preview' );
 	}
 
@@ -253,24 +248,18 @@ export class EditorGroundControl extends PureComponent {
 			<div className="editor-ground-control__action-buttons">
 				<Button
 					borderless
+					className="editor-ground-control__toggle-sidebar"
+					onClick={ this.props.toggleSidebar }
+				>
+					<Gridicon icon="cog" />
+				</Button>
+				<Button
 					className="editor-ground-control__preview-button"
 					disabled={ ! this.isPreviewEnabled() }
 					onClick={ this.onPreviewButtonClick }
 					tabIndex={ 4 }
 				>
-					<Gridicon icon="visible" />{' '}
 					<span className="editor-ground-control__button-label">{ this.getPreviewLabel() }</span>
-				</Button>
-				<Button
-					borderless
-					className="editor-ground-control__toggle-sidebar"
-					onClick={ this.props.toggleSidebar }
-				>
-					<Gridicon icon="cog" />
-					<span className="editor-ground-control__button-label">
-						{' '}
-						<EditorPostType isSettings />
-					</span>
 				</Button>
 				<div className="editor-ground-control__publish-button">
 					<EditorPublishButton
@@ -309,9 +298,9 @@ export class EditorGroundControl extends PureComponent {
 					className="editor-ground-control__back"
 					href={ '' }
 					onClick={ this.onBackButtonClick }
-					aria-label={ translate( 'Go back' ) }
+					aria-label={ translate( 'Done' ) }
 				>
-					<Gridicon icon="arrow-left" />
+					{ translate( 'Done' ) }
 				</Button>
 				<Site
 					compact

--- a/client/post-editor/editor-ground-control/quick-save-buttons.jsx
+++ b/client/post-editor/editor-ground-control/quick-save-buttons.jsx
@@ -1,0 +1,100 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import postUtils from 'lib/posts/utils';
+import { isEnabled } from 'config';
+import HistoryButton from 'post-editor/editor-ground-control/history-button';
+import { recordEvent, recordStat } from 'lib/posts/stats';
+
+const QuickSaveButtons = ( {
+	isSaving,
+	isSaveBlocked,
+	isDirty,
+	hasContent,
+	loadRevision,
+	post,
+	translate,
+	onSave,
+	showRevisions = true,
+} ) => {
+	const onSaveButtonClick = () => {
+		onSave();
+		const eventLabel = postUtils.isPage( post )
+			? 'Clicked Save Page Button'
+			: 'Clicked Save Post Button';
+		recordEvent( eventLabel );
+		recordStat( 'save_draft_clicked' );
+	};
+
+	const isSaveAvailable =
+		! isSaving &&
+		! isSaveBlocked &&
+		isDirty &&
+		hasContent &&
+		!! post &&
+		! postUtils.isPublished( post );
+
+	const showingStatusLabel = isSaving || ( post && post.ID && ! postUtils.isPublished( post ) );
+	const showingSaveStatus = isSaveAvailable || showingStatusLabel;
+	const hasRevisions =
+		showRevisions &&
+		isEnabled( 'post-editor/revisions' ) &&
+		postUtils.deviceSupportsRevisions() &&
+		get( post, 'revisions.length' );
+
+	if ( ! ( showingSaveStatus || hasRevisions ) ) {
+		return null;
+	}
+
+	return (
+		<div className="editor-ground-control__quick-save">
+			{ hasRevisions && <HistoryButton loadRevision={ loadRevision } /> }
+			{ showingSaveStatus && (
+				<div className="editor-ground-control__status">
+					{ isSaveAvailable && (
+						<button
+							className="editor-ground-control__save button is-link"
+							onClick={ onSaveButtonClick }
+							tabIndex={ 3 }
+						>
+							{ translate( 'Save' ) }
+						</button>
+					) }
+					{ ! isSaveAvailable &&
+						showingStatusLabel && (
+							<span
+								className="editor-ground-control__save-status"
+								data-e2e-status={ isSaving ? 'Saving…' : 'Saved' }
+							>
+								{ isSaving ? translate( 'Saving…' ) : translate( 'Saved' ) }
+							</span>
+						) }
+				</div>
+			) }
+		</div>
+	);
+};
+
+QuickSaveButtons.propTypes = {
+	isSaving: PropTypes.bool,
+	isSaveBlocked: PropTypes.bool,
+	isDirty: PropTypes.bool,
+	hasContent: PropTypes.bool,
+	loadRevision: PropTypes.func.isRequired,
+	post: PropTypes.object,
+	onSave: PropTypes.func,
+
+	// localize
+	translate: PropTypes.func,
+};
+
+export default localize( QuickSaveButtons );

--- a/client/post-editor/editor-ground-control/quick-save-buttons.jsx
+++ b/client/post-editor/editor-ground-control/quick-save-buttons.jsx
@@ -15,6 +15,20 @@ import { isEnabled } from 'config';
 import HistoryButton from 'post-editor/editor-ground-control/history-button';
 import { recordEvent, recordStat } from 'lib/posts/stats';
 
+export const isSaveAvailableFn = ( {
+	isSaving = false,
+	isSaveBlocked = false,
+	isDirty = false,
+	hasContent = false,
+	post = null,
+} ) =>
+	! isSaving &&
+	! isSaveBlocked &&
+	isDirty &&
+	hasContent &&
+	!! post &&
+	! postUtils.isPublished( post );
+
 const QuickSaveButtons = ( {
 	isSaving,
 	isSaveBlocked,
@@ -35,13 +49,13 @@ const QuickSaveButtons = ( {
 		recordStat( 'save_draft_clicked' );
 	};
 
-	const isSaveAvailable =
-		! isSaving &&
-		! isSaveBlocked &&
-		isDirty &&
-		hasContent &&
-		!! post &&
-		! postUtils.isPublished( post );
+	const isSaveAvailable = isSaveAvailableFn( {
+		isSaving,
+		isSaveBlocked,
+		isDirty,
+		hasContent,
+		post,
+	} );
 
 	const showingStatusLabel = isSaving || ( post && post.ID && ! postUtils.isPublished( post ) );
 	const showingSaveStatus = isSaveAvailable || showingStatusLabel;
@@ -95,6 +109,14 @@ QuickSaveButtons.propTypes = {
 
 	// localize
 	translate: PropTypes.func,
+};
+
+QuickSaveButtons.defaultProps = {
+	hasContent: false,
+	isDirty: false,
+	isSaveBlocked: false,
+	isSaving: false,
+	post: null,
 };
 
 export default localize( QuickSaveButtons );

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -5,7 +5,7 @@
 	margin-bottom: 0;
 	transition: 0.3s box-shadow;
 	position: fixed;
-	top: 47px;
+	top: 0;
 	left: 0;
 	right: 0;
 	z-index: z-index( 'root', '.editor-ground-control' );
@@ -94,7 +94,7 @@
 }
 
 .editor-ground-control__action-buttons .button.is-borderless svg {
-	top: 7px;
+	top: 4px;
 }
 
 .editor-ground-control__preview-button {
@@ -103,15 +103,18 @@
 }
 
 .editor-ground-control__toggle-sidebar {
-	margin-right: 8px;
-	border-radius: 0;
+	margin: 3px 8px 3px 0;
+	height: 40px;
+	line-height: 1;
 }
 
-.focus-sidebar .editor-ground-control__toggle-sidebar:hover,
+.focus-sidebar .editor-ground-control__toggle-sidebar:hover {
+	background: #efefef;
+}
 .focus-sidebar .editor-ground-control__toggle-sidebar:focus,
 .focus-sidebar .editor-ground-control__toggle-sidebar {
-	color: $blue-medium;
-	box-shadow: inset 0 -3px $blue-medium;
+	color: $white;
+	background: #333;
 }
 
 .editor-ground-control__toggle-sidebar.button.is-borderless,
@@ -239,9 +242,14 @@
 
 .editor-ground-control__back.button.is-borderless {
 	border-right: 1px solid lighten( $gray, 25% );
-	padding: 6px 10px;
+	padding: 6px 20px;
 	height: 46px;
 	border-radius: 0;
+	color: $blue-medium;
+
+	&:hover {
+		color: $blue-light;
+	}
 
 	.gridicon {
 		top: 4px;

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -79,17 +79,17 @@
 	margin-left: auto;
 	align-items: center;
 	display: flex;
-	flex-wrap: wrap;
+	//flex-wrap: wrap;
 	padding: 0 12px;
 	line-height: 32px;
 }
 
 .editor-ground-control__action-buttons .button.is-borderless {
-	padding: 0 12px;
+	padding: 0 8px;
 	line-height: 46px;
 
-	@include breakpoint( "<480px" ) {
-		padding: 0 4px;
+	@include breakpoint( ">660px" ) {
+		padding: 0 12px;
 	}
 }
 
@@ -100,8 +100,12 @@
 .editor-ground-control__preview-button {
 	display: block;
 	flex-grow: 1;
-	padding: 7px 16px;
-	min-width: 100px;
+	padding: 7px 12px;
+
+	@include breakpoint( ">660px" ) {
+		min-width: 100px;
+		padding: 7px 16px;
+	}
 }
 
 .editor-ground-control__toggle-sidebar {
@@ -110,6 +114,7 @@
 	line-height: 1;
 	transition: all 0.15s ease-in-out;
 }
+
 .editor-ground-control__toggle-sidebar svg {
 	transition: transform 0.3s ease-in-out;
 }
@@ -138,21 +143,17 @@
 .editor-ground-control__publish-button {
 	flex-grow: 1;
 	display: flex;
-	margin: 0 8px;
-	min-width: 120px;
-
-	@include breakpoint( "<480px" ) {
-		margin: 0;
-	}
 }
 
 .editor-ground-control .editor-publish-button {
 	border-radius: 4px;
-	padding: 7px 16px;
-	flex-grow: 1;
+	padding: 7px 12px;
+	margin: 0 0 0 8px;
 
-	@include breakpoint( "<480px" ) {
-		padding: 7px 10px;
+	@include breakpoint( ">660px" ) {
+		min-width: 120px;
+		padding: 7px 16px;
+		margin: 0 8px;
 	}
 }
 
@@ -251,10 +252,15 @@
 
 .editor-ground-control__back.button.is-borderless {
 	border-right: 1px solid lighten( $gray, 25% );
-	padding: 6px 32px;
+	padding: 6px 16px;
+	min-width: 80px;
 	height: 46px;
 	border-radius: 0;
 	color: $blue-wordpress;
+
+	@include breakpoint( ">960px" ) {
+		padding: 6px 32px;
+	}
 
 	&:hover {
 		color: $blue-medium;
@@ -266,10 +272,6 @@
 }
 
 .editor-ground-control__button-label {
-	@include breakpoint( "<960px" ) {
-		display: none;
-	}
-
 	.post-status {
 		display: none;
 	}

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -100,21 +100,34 @@
 .editor-ground-control__preview-button {
 	display: block;
 	flex-grow: 1;
+	padding: 7px 16px;
+	min-width: 100px;
 }
 
 .editor-ground-control__toggle-sidebar {
 	margin: 3px 8px 3px 0;
-	height: 40px;
+	height: 38px;
 	line-height: 1;
+	transition: all 0.15s ease-in-out;
+}
+.editor-ground-control__toggle-sidebar svg {
+	transition: transform 0.3s ease-in-out;
 }
 
-.focus-sidebar .editor-ground-control__toggle-sidebar:hover {
-	background: #efefef;
+.editor-ground-control__toggle-sidebar:hover,
+.editor-ground-control__toggle-sidebar:focus {
+	background: $gray-light;
 }
+
+.focus-sidebar .editor-ground-control__toggle-sidebar:hover,
 .focus-sidebar .editor-ground-control__toggle-sidebar:focus,
 .focus-sidebar .editor-ground-control__toggle-sidebar {
 	color: $white;
-	background: #333;
+	background: $gray-dark;
+}
+
+.focus-sidebar .editor-ground-control__toggle-sidebar svg {
+	transform: rotate( 45deg );
 }
 
 .editor-ground-control__toggle-sidebar.button.is-borderless,
@@ -125,7 +138,8 @@
 .editor-ground-control__publish-button {
 	flex-grow: 1;
 	display: flex;
-	margin: 0 12px;
+	margin: 0 8px;
+	min-width: 120px;
 
 	@include breakpoint( "<480px" ) {
 		margin: 0;
@@ -133,14 +147,9 @@
 }
 
 .editor-ground-control .editor-publish-button {
-	border-radius: 4px 0 0 4px;
-	flex-grow: 1;
-	padding: 5px 14px 7px;
-}
-
-.editor-ground-control .editor-publish-button {
 	border-radius: 4px;
 	padding: 7px 16px;
+	flex-grow: 1;
 
 	@include breakpoint( "<480px" ) {
 		padding: 7px 10px;
@@ -242,13 +251,13 @@
 
 .editor-ground-control__back.button.is-borderless {
 	border-right: 1px solid lighten( $gray, 25% );
-	padding: 6px 20px;
+	padding: 6px 32px;
 	height: 46px;
 	border-radius: 0;
-	color: $blue-medium;
+	color: $blue-wordpress;
 
 	&:hover {
-		color: $blue-light;
+		color: $blue-medium;
 	}
 
 	.gridicon {

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -58,8 +58,25 @@
 	border-left: 1px solid lighten( $gray, 25% );
 	display: flex;
 
+	// Hide the ground-control save buttons on mobile
 	@include breakpoint( "<660px" ) {
-		border-left: none;
+		display: none;
+	}
+}
+
+// Inline save buttons for mobile
+.post-editor__site .editor-ground-control__quick-save {
+	border-left: none;
+	display: none;
+
+	.editor-ground-control__save,
+	.editor-ground-control__save-status {
+		display: block;
+		padding: 12px 16px;
+	}
+
+	@include breakpoint( "<660px" ) {
+		display: block;
 	}
 }
 
@@ -79,7 +96,6 @@
 	margin-left: auto;
 	align-items: center;
 	display: flex;
-	//flex-wrap: wrap;
 	padding: 0 12px;
 	line-height: 32px;
 }
@@ -192,10 +208,6 @@
 }
 
 .editor-ground-control__email-verification-notice {
-	@include breakpoint( "<660px" ) {
-		display: none;
-	}
-
 	font-size: 13px;
 	padding: 8px 8px 8px 40px;
 	background: white;
@@ -206,7 +218,7 @@
 	fill: $blue-wordpress;
 	position: absolute;
 	z-index: 1;
-	right: 4px;
+	right: 16px;
 	top: 40px;
 	border-radius: 2px;
 	box-shadow: 0 1px 4px rgba($gray-dark, 0.2);;

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -14,6 +14,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { EditorGroundControl } from '../';
+import { isSaveAvailableFn } from '../quick-save-buttons';
 
 jest.mock( 'blocks/site', () => require( 'components/empty-component' ) );
 jest.mock( 'components/card', () => require( 'components/empty-component' ) );
@@ -68,50 +69,6 @@ describe( 'EditorGroundControl', () => {
 		} );
 	} );
 
-	describe( '#isSaveAvailable()', () => {
-		test( 'should return false if form is saving', () => {
-			var tree = shallow( <EditorGroundControl isSaving /> ).instance();
-
-			expect( tree.isSaveAvailable() ).to.be.false;
-		} );
-
-		test( 'should return false if saving is blocked', () => {
-			var tree = shallow( <EditorGroundControl isSaveBlocked /> ).instance();
-
-			expect( tree.isSaveAvailable() ).to.be.false;
-		} );
-
-		test( 'should return false if post does not exist', () => {
-			var tree = shallow(
-				<EditorGroundControl isSaving={ false } hasContent isDirty />
-			).instance();
-
-			expect( tree.isSaveAvailable() ).to.be.false;
-		} );
-
-		test( 'should return true if dirty and post has content and post is not published', () => {
-			var tree = shallow(
-				<EditorGroundControl isSaving={ false } post={ {} } hasContent isDirty />
-			).instance();
-
-			expect( tree.isSaveAvailable() ).to.be.true;
-		} );
-
-		test( 'should return false if dirty, but post has no content', () => {
-			var tree = shallow( <EditorGroundControl isSaving={ false } isDirty /> ).instance();
-
-			expect( tree.isSaveAvailable() ).to.be.false;
-		} );
-
-		test( 'should return false if dirty and post is published', () => {
-			var tree = shallow(
-				<EditorGroundControl isSaving={ false } post={ { status: 'publish' } } isDirty />
-			).instance();
-
-			expect( tree.isSaveAvailable() ).to.be.false;
-		} );
-	} );
-
 	describe( '#isPreviewEnabled()', () => {
 		test( 'should return true if post is not empty', () => {
 			var tree = shallow( <EditorGroundControl post={ {} } isNew hasContent isDirty /> ).instance();
@@ -141,6 +98,37 @@ describe( 'EditorGroundControl', () => {
 			var tree = shallow( <EditorGroundControl post={ {} } hasContent={ false } /> ).instance();
 
 			expect( tree.isPreviewEnabled() ).to.be.false;
+		} );
+	} );
+} );
+
+describe( 'QuickSaveButtons', () => {
+	describe( '#isSaveAvailableFn()', () => {
+		test( 'should return false if form is saving', () => {
+			expect( isSaveAvailableFn( { isSaving: true } ) ).to.be.false;
+		} );
+
+		test( 'should return false if saving is blocked', () => {
+			expect( isSaveAvailableFn( { isSaveBlocked: true } ) ).to.be.false;
+		} );
+
+		test( 'should return false if post does not exist', () => {
+			expect( isSaveAvailableFn( { isSaving: false, hasContent: true, isDirty: true } ) ).to.be
+				.false;
+		} );
+
+		test( 'should return true if dirty and post has content and post is not published', () => {
+			expect( isSaveAvailableFn( { isSaving: false, post: {}, hasContent: true, isDirty: true } ) )
+				.to.be.true;
+		} );
+
+		test( 'should return false if dirty, but post has no content', () => {
+			expect( isSaveAvailableFn( { isSaving: false, isDirty: true } ) ).to.be.false;
+		} );
+
+		test( 'should return false if dirty and post is published', () => {
+			expect( isSaveAvailableFn( { isSaving: false, post: { status: 'publish' }, isDirty: true } ) )
+				.to.be.false;
 		} );
 	} );
 } );

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -43,12 +43,16 @@ const MOCK_SITE = {
 
 describe( 'EditorGroundControl', () => {
 	describe( '#getPreviewLabel()', () => {
-		test( 'should return View if the site is a Jetpack site and the post is published', () => {
+		test( 'should return Preview if the site is a Jetpack site and the post is published', () => {
+			// getPreviewLabel should always return "Preview" since it's the label for the Preview button
+			// (as opposed to directly visiting your site outside of Calypso)
+			// previously, this test checked for two different possible labels
+			// now leaving this here to ensure that it returns "Preview" in different situations
 			var tree = shallow(
 				<EditorGroundControl savedPost={ { status: 'publish' } } site={ { jetpack: true } } />
 			).instance();
 
-			expect( tree.getPreviewLabel() ).to.equal( 'View' );
+			expect( tree.getPreviewLabel() ).to.equal( 'Preview' );
 		} );
 
 		test( 'should return Preview if the post was not originally published', () => {

--- a/client/post-editor/editor-notice/style.scss
+++ b/client/post-editor/editor-notice/style.scss
@@ -31,11 +31,11 @@
 		z-index: z-index('root', '.web-preview .editor-notice');
 
 		@include breakpoint( '>660px' ) {
-			top: 47px + 49px + 16px;
+			top: 49px + 16px;
 		}
 
 		@include breakpoint( '>960px' ) {
-			top: 47px + 49px + 24px;
+			top: 49px + 24px;
 		}
 
 		.notice {

--- a/client/post-editor/editor-preview/style.scss
+++ b/client/post-editor/editor-preview/style.scss
@@ -22,13 +22,3 @@
 		visibility: visible;
     }
 }
-
-.editor-preview .web-preview__close.button,
-.editor-preview a.web-preview__external.button,
-.editor-preview .web-preview__edit.button {
-	color: $gray-text-min;
-
-	&:hover {
-		color: $gray-dark;
-	}
-}

--- a/client/post-editor/editor-preview/style.scss
+++ b/client/post-editor/editor-preview/style.scss
@@ -8,13 +8,13 @@
 	display: none;
 	opacity: 0;
 	position: fixed;
-		top: 47px;
+		top: 0;
 		right: 0;
 		left: 0;
 		z-index: z-index( 'root', '.editor-preview' );
 	transition: opacity 0.3s ease-in-out;
 	width: 100%;
-	height: calc( 100% - 47px );
+	height: 100%;
 
 	&.is-visible {
 		display: flex;

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -6,7 +6,6 @@
 	border-top: 1px solid darken( $sidebar-bg-color, 5% );
 	border-right: none;
 	box-sizing: border-box;
-	top: 93px;
 	right: $sidebar-width-max;
 	left: auto;
 	transition: all 0.15s cubic-bezier(0.075, 0.82, 0.165, 1);

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -67,6 +67,7 @@ import EditorGroundControl from 'post-editor/editor-ground-control';
 import { isWithinBreakpoint } from 'lib/viewport';
 import { isSitePreviewable } from 'state/sites/selectors';
 import { removep } from 'lib/formatting';
+import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-buttons';
 
 export const PostEditor = createReactClass( {
 	displayName: 'PostEditor',
@@ -349,7 +350,20 @@ export const PostEditor = createReactClass( {
 									homeLink={ true }
 									externalLink={ true }
 								/>
-								<StatusLabel post={ this.state.savedPost } />
+								{ ( this.state.isDirty || this.props.dirty ) && (
+									<QuickSaveButtons
+										isSaving={ this.state.isSaving }
+										isSaveBlocked={ this.isSaveBlocked() }
+										isDirty={ this.state.isDirty || this.props.dirty }
+										hasContent={ this.state.hasContent }
+										loadRevision={ this.loadRevision }
+										post={ this.state.post }
+										onSave={ this.onSave }
+									/>
+								) }
+								{ ! ( this.state.isDirty || this.props.dirty ) && (
+									<StatusLabel post={ this.state.savedPost } />
+								) }
 							</div>
 							<div className="post-editor__inner-content">
 								<FeaturedImage

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -34,7 +34,6 @@
 
 .post-editor__inner {
 	position: relative;
-	top: 47px;
 	padding-bottom: 47px;
 }
 

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -68,6 +68,7 @@
 
 .post-editor__site {
 	display:  flex;
+	margin-bottom: 16px;
 	background: lighten( $gray, 30% );
 
 	@include breakpoint( ">660px" ) {


### PR DESCRIPTION
This is another attempt at fixing #20170. Also includes a few further design tweaks from @shaunandrews. 

This PR removes the Masterbar from the editor, with the intention of making a more focused (and less distracting) experience. Here's a list of changes introduce:

- Transitions the Masterbar out of view when entering the editor.
- Replaces the small arrow Gridicon with a larger "Close" label for both the editor and the preview.
- Replaces the Gridicon+Label for Preview with a secondary button.
- Replaces the external icon in the preview with a primary action button labeled "Visit Site". This new button will open the site in the current tab, unless you're viewing the preview while writing a post.
- Moves the quick-save status/button out of ground-control on smaller screens. This allows for larger preview and publish buttons on mobile, while still allowing for manual saving.
- Small position change the email verification notice to point to the center of the larger publish button.

Here's a gif of the latest, showing the desktop behavior of the new minimal editor:

![minimal editor](https://user-images.githubusercontent.com/191598/33631223-e6ca4ee2-d9d7-11e7-86a4-75323745ebcb.gif)