### PR TITLE
Framework: Removed sites-list dependency from lib/posts/actions.js take 2

### DIFF
--- a/client/components/update-post-status/index.js
+++ b/client/components/update-post-status/index.js
@@ -135,7 +135,7 @@ const updatePostStatus = WrappedComponent =>
 
 						if ( typeof window === 'object' && window.confirm( strings[ type ].deleteWarning ) ) {
 							// eslint-disable-line no-alert
-							PostActions.trash( post, setNewStatus );
+							PostActions.trash( site, post, setNewStatus );
 						} else {
 							this.resetState();
 						}

--- a/client/components/update-post-status/index.js
+++ b/client/components/update-post-status/index.js
@@ -8,11 +8,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flow, once } from 'lodash';
+import { flow, get, once } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { getSite } from 'state/sites/selectors';
 import UpdateTemplate from './update-template';
 import PostActions from 'lib/posts/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
@@ -48,7 +49,15 @@ const getStrings = once( translate => ( {
 	},
 } ) );
 
-const enhance = flow( localize, connect( null, { recordGoogleEvent } ) );
+const enhance = flow(
+	localize,
+	connect(
+		( state, props ) => ( {
+			site: getSite( state, get( props, 'post.site_ID' ) ),
+		} ),
+		{ recordGoogleEvent }
+	)
+);
 
 const updatePostStatus = WrappedComponent =>
 	enhance(
@@ -95,6 +104,7 @@ const updatePostStatus = WrappedComponent =>
 			};
 
 			updatePostStatus = status => {
+				const { site } = this.props;
 				const post = this.props.post || this.props.page;
 				let previousStatus = null;
 
@@ -138,7 +148,7 @@ const updatePostStatus = WrappedComponent =>
 							updated: true,
 						} );
 						previousStatus = post.status;
-						PostActions.trash( post, setNewStatus );
+						PostActions.trash( post, setNewStatus, site );
 						return;
 
 					case 'restore':
@@ -148,7 +158,7 @@ const updatePostStatus = WrappedComponent =>
 							updated: true,
 						} );
 						previousStatus = 'trash';
-						PostActions.restore( post, setNewStatus );
+						PostActions.restore( post, setNewStatus, site );
 						return;
 
 					default:
@@ -157,12 +167,17 @@ const updatePostStatus = WrappedComponent =>
 							updatedStatus: 'updating',
 							updated: true,
 						} );
-						PostActions.update( post, { status }, ( error, resultPost ) => {
-							if ( ! setNewStatus( error, resultPost ) ) {
-								return;
-							}
-							setTimeout( this.resetState, RESET_TIMEOUT_MS );
-						} );
+						PostActions.update(
+							post,
+							{ status },
+							( error, resultPost ) => {
+								if ( ! setNewStatus( error, resultPost ) ) {
+									return;
+								}
+								setTimeout( this.resetState, RESET_TIMEOUT_MS );
+							},
+							site
+						);
 				}
 			};
 

--- a/client/components/update-post-status/index.js
+++ b/client/components/update-post-status/index.js
@@ -148,7 +148,7 @@ const updatePostStatus = WrappedComponent =>
 							updated: true,
 						} );
 						previousStatus = post.status;
-						PostActions.trash( post, setNewStatus, site );
+						PostActions.trash( site, post, setNewStatus );
 						return;
 
 					case 'restore':
@@ -158,7 +158,7 @@ const updatePostStatus = WrappedComponent =>
 							updated: true,
 						} );
 						previousStatus = 'trash';
-						PostActions.restore( post, setNewStatus, site );
+						PostActions.restore( site, post, setNewStatus );
 						return;
 
 					default:
@@ -167,17 +167,12 @@ const updatePostStatus = WrappedComponent =>
 							updatedStatus: 'updating',
 							updated: true,
 						} );
-						PostActions.update(
-							post,
-							{ status },
-							( error, resultPost ) => {
-								if ( ! setNewStatus( error, resultPost ) ) {
-									return;
-								}
-								setTimeout( this.resetState, RESET_TIMEOUT_MS );
-							},
-							site
-						);
+						PostActions.update( site, post, { status }, ( error, resultPost ) => {
+							if ( ! setNewStatus( error, resultPost ) ) {
+								return;
+							}
+							setTimeout( this.resetState, RESET_TIMEOUT_MS );
+						} );
 				}
 			};
 

--- a/client/components/update-post-status/index.js
+++ b/client/components/update-post-status/index.js
@@ -53,7 +53,7 @@ const enhance = flow(
 	localize,
 	connect(
 		( state, props ) => ( {
-			site: getSite( state, get( props, 'post.site_ID' ) ),
+			site: getSite( state, get( props, [ props.page ? 'page' : 'post', 'site_ID' ] ) ),
 		} ),
 		{ recordGoogleEvent }
 	)

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -209,7 +209,10 @@ PostActions = {
 				}
 			);
 		} else {
-			PostActions.saveEdited( site, null, null, callback, { recordSaveEvent: false } );
+			PostActions.saveEdited( site, null, null, callback, {
+				recordSaveEvent: false,
+				autosave: true,
+			} );
 		}
 	},
 

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -410,7 +410,7 @@ PostActions = {
 	update: function( site, post, attributes, callback ) {
 		var postHandle = wpcom.site( post.site_ID ).post( post.ID );
 
-		postHandle.update( attributes, PostActions.receiveUpdate.bind( site, null, callback ) );
+		postHandle.update( attributes, PostActions.receiveUpdate.bind( null, site, callback ) );
 	},
 
 	/**
@@ -424,7 +424,7 @@ PostActions = {
 	trash: function( site, post, callback ) {
 		var postHandle = wpcom.site( post.site_ID ).post( post.ID );
 
-		postHandle.delete( PostActions.receiveUpdate.bind( site, null, callback ) );
+		postHandle.delete( PostActions.receiveUpdate.bind( null, site, callback ) );
 	},
 
 	/**
@@ -437,7 +437,7 @@ PostActions = {
 	restore: function( site, post, callback ) {
 		var postHandle = wpcom.site( post.site_ID ).post( post.ID );
 
-		postHandle.restore( PostActions.receiveUpdate.bind( site, null, callback ) );
+		postHandle.restore( PostActions.receiveUpdate.bind( null, site, callback ) );
 	},
 
 	queryPosts: function( options, postListStoreId = 'default' ) {

--- a/client/lib/posts/test/actions.js
+++ b/client/lib/posts/test/actions.js
@@ -19,7 +19,12 @@ import Dispatcher from 'dispatcher';
 
 jest.mock( 'lib/localforage', () => require( 'lib/localforage/localforage-bypass' ) );
 jest.mock( 'lib/wp', () => require( './mocks/lib/wp' ) );
-
+const sampleSite = {
+	ID: 123,
+	jetpack: false,
+	slug: 'example.wordpress.com',
+	URL: 'https://example.wordpress.com',
+};
 describe( 'actions', () => {
 	let sandbox;
 
@@ -176,7 +181,7 @@ describe( 'actions', () => {
 			const spy = sandbox.spy();
 			sandbox.stub( PostEditStore, 'hasContent' ).returns( false );
 
-			PostActions.saveEdited( null, {}, spy );
+			PostActions.saveEdited( null, {}, spy, sampleSite );
 
 			defer( () => {
 				expect( spy ).to.have.been.calledOnce;
@@ -192,7 +197,7 @@ describe( 'actions', () => {
 			sandbox.stub( PostEditStore, 'hasContent' ).returns( true );
 			sandbox.stub( PostEditStore, 'getChangedAttributes' ).returns( {} );
 
-			PostActions.saveEdited( null, {}, spy );
+			PostActions.saveEdited( null, {}, spy, sampleSite );
 
 			defer( () => {
 				expect( spy ).to.have.been.calledOnce;
@@ -224,25 +229,30 @@ describe( 'actions', () => {
 			};
 			sandbox.stub( PostEditStore, 'getChangedAttributes' ).returns( changedAttributes );
 
-			PostActions.saveEdited( null, {}, ( error, data ) => {
-				const normalizedAttributes = {
-					ID: 777,
-					site_ID: 123,
-					author: 3,
-					title: 'OMG Unicorns',
-					terms: {},
-				};
+			PostActions.saveEdited(
+				null,
+				{},
+				( error, data ) => {
+					const normalizedAttributes = {
+						ID: 777,
+						site_ID: 123,
+						author: 3,
+						title: 'OMG Unicorns',
+						terms: {},
+					};
 
-				expect( Dispatcher.handleViewAction ).to.have.been.calledTwice;
-				expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
-					error: null,
-					post: normalizedAttributes,
-					type: 'RECEIVE_POST_BEING_EDITED',
-				} );
-				expect( error ).to.be.null;
-				expect( data ).to.eql( normalizedAttributes );
-				done();
-			} );
+					expect( Dispatcher.handleViewAction ).to.have.been.calledTwice;
+					expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
+						error: null,
+						post: normalizedAttributes,
+						type: 'RECEIVE_POST_BEING_EDITED',
+					} );
+					expect( error ).to.be.null;
+					expect( data ).to.eql( normalizedAttributes );
+					done();
+				},
+				sampleSite
+			);
 		} );
 	} );
 } );

--- a/client/lib/posts/test/actions.js
+++ b/client/lib/posts/test/actions.js
@@ -181,7 +181,7 @@ describe( 'actions', () => {
 			const spy = sandbox.spy();
 			sandbox.stub( PostEditStore, 'hasContent' ).returns( false );
 
-			PostActions.saveEdited( null, {}, spy, sampleSite );
+			PostActions.saveEdited( sampleSite, null, {}, spy );
 
 			defer( () => {
 				expect( spy ).to.have.been.calledOnce;
@@ -197,7 +197,7 @@ describe( 'actions', () => {
 			sandbox.stub( PostEditStore, 'hasContent' ).returns( true );
 			sandbox.stub( PostEditStore, 'getChangedAttributes' ).returns( {} );
 
-			PostActions.saveEdited( null, {}, spy, sampleSite );
+			PostActions.saveEdited( sampleSite, null, {}, spy );
 
 			defer( () => {
 				expect( spy ).to.have.been.calledOnce;
@@ -229,30 +229,25 @@ describe( 'actions', () => {
 			};
 			sandbox.stub( PostEditStore, 'getChangedAttributes' ).returns( changedAttributes );
 
-			PostActions.saveEdited(
-				null,
-				{},
-				( error, data ) => {
-					const normalizedAttributes = {
-						ID: 777,
-						site_ID: 123,
-						author: 3,
-						title: 'OMG Unicorns',
-						terms: {},
-					};
+			PostActions.saveEdited( sampleSite, null, {}, ( error, data ) => {
+				const normalizedAttributes = {
+					ID: 777,
+					site_ID: 123,
+					author: 3,
+					title: 'OMG Unicorns',
+					terms: {},
+				};
 
-					expect( Dispatcher.handleViewAction ).to.have.been.calledTwice;
-					expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
-						error: null,
-						post: normalizedAttributes,
-						type: 'RECEIVE_POST_BEING_EDITED',
-					} );
-					expect( error ).to.be.null;
-					expect( data ).to.eql( normalizedAttributes );
-					done();
-				},
-				sampleSite
-			);
+				expect( Dispatcher.handleViewAction ).to.have.been.calledTwice;
+				expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
+					error: null,
+					post: normalizedAttributes,
+					type: 'RECEIVE_POST_BEING_EDITED',
+				} );
+				expect( error ).to.be.null;
+				expect( data ).to.eql( normalizedAttributes );
+				done();
+			} );
 		} );
 	} );
 } );

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -89,7 +89,7 @@ class Draft extends Component {
 		}.bind( this );
 
 		if ( utils.userCan( 'delete_post', this.props.post ) ) {
-			actions.trash( this.props.post, updateStatus, this.props.site );
+			actions.trash( this.props.site, this.props.post, updateStatus );
 		}
 	};
 
@@ -115,7 +115,7 @@ class Draft extends Component {
 		}.bind( this );
 
 		if ( utils.userCan( 'delete_post', this.props.post ) ) {
-			actions.restore( this.props.post, updateStatus, this.props.site );
+			actions.restore( this.props.site, this.props.post, updateStatus );
 		}
 	};
 

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -89,7 +89,7 @@ class Draft extends Component {
 		}.bind( this );
 
 		if ( utils.userCan( 'delete_post', this.props.post ) ) {
-			actions.trash( this.props.post, updateStatus );
+			actions.trash( this.props.post, updateStatus, this.props.site );
 		}
 	};
 
@@ -115,7 +115,7 @@ class Draft extends Component {
 		}.bind( this );
 
 		if ( utils.userCan( 'delete_post', this.props.post ) ) {
-			actions.restore( this.props.post, updateStatus );
+			actions.restore( this.props.post, updateStatus, this.props.site );
 		}
 	};
 

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -239,7 +239,7 @@ export default {
 				analytics.pageView.record( '/' + postType, gaTitle + ' > New' );
 			} else if ( postID ) {
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-				actions.startEditingExisting( siteId, postID, site );
+				actions.startEditingExisting( site, postID );
 				analytics.pageView.record( '/' + postType + '/:blogid/:postid', gaTitle + ' > Edit' );
 			} else {
 				const postOptions = { type: postType };
@@ -255,7 +255,7 @@ export default {
 				}
 
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-				actions.startEditingNew( siteId, postOptions, site );
+				actions.startEditingNew( site, postOptions );
 				analytics.pageView.record( '/' + postType, gaTitle + ' > New' );
 			}
 		}

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -26,6 +26,7 @@ import { decodeEntities } from 'lib/formatting';
 import PostEditor from './post-editor';
 import { startEditingPost, stopEditingPost } from 'state/ui/editor/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSite } from 'state/sites/selectors';
 import { getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
 import { editPost } from 'state/posts/actions';
 import wpcom from 'lib/wp';
@@ -210,6 +211,7 @@ export default {
 		const postToCopyId = context.query.copy;
 
 		function startEditing( siteId ) {
+			const site = getSite( context.store.getState(), siteId );
 			const isCopy = context.query.copy ? true : false;
 			context.store.dispatch( startEditingPost( siteId, isCopy ? null : postID, postType ) );
 
@@ -237,7 +239,7 @@ export default {
 				analytics.pageView.record( '/' + postType, gaTitle + ' > New' );
 			} else if ( postID ) {
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-				actions.startEditingExisting( siteId, postID );
+				actions.startEditingExisting( siteId, postID, site );
 				analytics.pageView.record( '/' + postType + '/:blogid/:postid', gaTitle + ' > Edit' );
 			} else {
 				const postOptions = { type: postType };
@@ -253,7 +255,7 @@ export default {
 				}
 
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-				actions.startEditingNew( siteId, postOptions );
+				actions.startEditingNew( siteId, postOptions, site );
 				analytics.pageView.record( '/' + postType, gaTitle + ' > New' );
 			}
 		}

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -25,8 +25,7 @@ import analytics from 'lib/analytics';
 import { decodeEntities } from 'lib/formatting';
 import PostEditor from './post-editor';
 import { startEditingPost, stopEditingPost } from 'state/ui/editor/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSite } from 'state/sites/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
 import { editPost } from 'state/posts/actions';
 import wpcom from 'lib/wp';
@@ -211,7 +210,7 @@ export default {
 		const postToCopyId = context.query.copy;
 
 		function startEditing( siteId ) {
-			const site = getSite( context.store.getState(), siteId );
+			const site = getSelectedSite( context.store.getState() );
 			const isCopy = context.query.copy ? true : false;
 			context.store.dispatch( startEditingPost( siteId, isCopy ? null : postID, postType ) );
 

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -25,7 +25,8 @@ import analytics from 'lib/analytics';
 import { decodeEntities } from 'lib/formatting';
 import PostEditor from './post-editor';
 import { startEditingPost, stopEditingPost } from 'state/ui/editor/actions';
-import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSite } from 'state/sites/selectors';
 import { getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
 import { editPost } from 'state/posts/actions';
 import wpcom from 'lib/wp';
@@ -210,7 +211,7 @@ export default {
 		const postToCopyId = context.query.copy;
 
 		function startEditing( siteId ) {
-			const site = getSelectedSite( context.store.getState() );
+			const site = getSite( context.store.getState(), siteId );
 			const isCopy = context.query.copy ? true : false;
 			context.store.dispatch( startEditingPost( siteId, isCopy ? null : postID, postType ) );
 

--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -42,17 +42,13 @@ class EditorDeletePost extends React.Component {
 		this.setState( { isTrashing: true } );
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		actions.trash(
-			this.props.post,
-			error => {
-				this.setState( { isTrashing: false } );
+		actions.trash( this.props.site, this.props.post, error => {
+			this.setState( { isTrashing: false } );
 
-				if ( this.props.onTrashingPost ) {
-					this.props.onTrashingPost( error );
-				}
-			},
-			this.props.site
-		);
+			if ( this.props.onTrashingPost ) {
+				this.props.onTrashingPost( error );
+			}
+		} );
 	};
 
 	onSendToTrash = () => {

--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -8,6 +8,8 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import classnames from 'classnames';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -17,6 +19,7 @@ import actions from 'lib/posts/actions';
 import accept from 'lib/accept';
 import utils from 'lib/posts/utils';
 import Button from 'components/button';
+import { getSite } from 'state/sites/selectors';
 
 class EditorDeletePost extends React.Component {
 	static displayName = 'EditorDeletePost';
@@ -39,13 +42,17 @@ class EditorDeletePost extends React.Component {
 		this.setState( { isTrashing: true } );
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		actions.trash( this.props.post, error => {
-			this.setState( { isTrashing: false } );
+		actions.trash(
+			this.props.post,
+			error => {
+				this.setState( { isTrashing: false } );
 
-			if ( this.props.onTrashingPost ) {
-				this.props.onTrashingPost( error );
-			}
-		} );
+				if ( this.props.onTrashingPost ) {
+					this.props.onTrashingPost( error );
+				}
+			},
+			this.props.site
+		);
 	};
 
 	onSendToTrash = () => {
@@ -101,4 +108,6 @@ class EditorDeletePost extends React.Component {
 	}
 }
 
-export default localize( EditorDeletePost );
+export default connect( ( state, props ) => ( {
+	site: getSite( state, get( props, 'post.site_ID' ) ),
+} ) )( localize( EditorDeletePost ) );

--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -9,7 +9,6 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -19,7 +18,7 @@ import actions from 'lib/posts/actions';
 import accept from 'lib/accept';
 import utils from 'lib/posts/utils';
 import Button from 'components/button';
-import { getSite } from 'state/sites/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 
 class EditorDeletePost extends React.Component {
 	static displayName = 'EditorDeletePost';
@@ -104,6 +103,6 @@ class EditorDeletePost extends React.Component {
 	}
 }
 
-export default connect( ( state, props ) => ( {
-	site: getSite( state, get( props, 'post.site_ID' ) ),
+export default connect( state => ( {
+	site: getSelectedSite( state ),
 } ) )( localize( EditorDeletePost ) );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -629,7 +629,7 @@ export const PostEditor = createReactClass( {
 		}
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		actions.autosave( callback );
+		actions.autosave( callback, this.props.selectedSite );
 
 		// If debounced / throttled autosave was pending, consider it flushed
 		this.throttledAutosave.cancel();
@@ -727,7 +727,9 @@ export const PostEditor = createReactClass( {
 				if ( 'function' === typeof callback ) {
 					callback( error );
 				}
-			}.bind( this )
+			}.bind( this ),
+			null,
+			this.props.selectedSite
 		);
 
 		this.setState( { isSaving: true } );
@@ -787,7 +789,7 @@ export const PostEditor = createReactClass( {
 		if ( status === 'publish' ) {
 			// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 			actions.edit( { content: this.editor.getContent() } );
-			actions.autosave( previewPost );
+			actions.autosave( previewPost, this.props.selectedSite );
 		} else {
 			this.onSave( null, previewPost );
 		}
@@ -892,7 +894,9 @@ export const PostEditor = createReactClass( {
 				} else {
 					this.onPublishSuccess();
 				}
-			}.bind( this )
+			}.bind( this ),
+			null,
+			this.props.selectedSite
 		);
 
 		this.setState( {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -629,7 +629,7 @@ export const PostEditor = createReactClass( {
 		}
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		actions.autosave( callback, this.props.selectedSite );
+		actions.autosave( this.props.selectedSite, callback );
 
 		// If debounced / throttled autosave was pending, consider it flushed
 		this.throttledAutosave.cancel();
@@ -715,6 +715,7 @@ export const PostEditor = createReactClass( {
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.saveEdited(
+			this.props.selectedSite,
 			edits,
 			{ isConfirmationSidebarEnabled: this.props.isConfirmationSidebarEnabled },
 			function( error ) {
@@ -727,9 +728,7 @@ export const PostEditor = createReactClass( {
 				if ( 'function' === typeof callback ) {
 					callback( error );
 				}
-			}.bind( this ),
-			null,
-			this.props.selectedSite
+			}.bind( this )
 		);
 
 		this.setState( { isSaving: true } );
@@ -789,7 +788,7 @@ export const PostEditor = createReactClass( {
 		if ( status === 'publish' ) {
 			// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 			actions.edit( { content: this.editor.getContent() } );
-			actions.autosave( previewPost, this.props.selectedSite );
+			actions.autosave( this.props.selectedSite, previewPost );
 		} else {
 			this.onSave( null, previewPost );
 		}
@@ -886,6 +885,7 @@ export const PostEditor = createReactClass( {
 		edits.content = this.editor.getContent();
 
 		actions.saveEdited(
+			this.props.selectedSite,
 			edits,
 			{ isConfirmationSidebarEnabled: this.props.isConfirmationSidebarEnabled },
 			function( error ) {
@@ -894,9 +894,7 @@ export const PostEditor = createReactClass( {
 				} else {
 					this.onPublishSuccess();
 				}
-			}.bind( this ),
-			null,
-			this.props.selectedSite
+			}.bind( this )
 		);
 
 		this.setState( {


### PR DESCRIPTION
This is a take 2 of https://github.com/Automattic/wp-calypso/pull/16017, unfortunately, that version had a bug that affected pages (not posts) and while doing the tests on staging I found it and had to revert. The PR removes sites-list from posts/actions. Also, makes some actions receive site object and makes all the required components pass it.
This is required to allow the removal of sites-list from other parts of lib/posts.

The only file change since the approval is update-post-status/index.js.

To test:
Create a new post, publish it, revert to draft, move to trash, restore it, delete permanently, change it, autosave it etc...
Do the same for pages.
Everything that changes posts and/or pages should be exhaustively tested to make sure the functionality was not broken.
Execute the automated tests in lib posts:
npm run test-client client/lib/posts