### PR TITLE
Conversations: Don't notify user with update pill when they made the new comment inside Conversations

### DIFF
--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -117,20 +117,6 @@ export function receivePage( id, error, data ) {
 }
 
 export function receiveUpdates( id, error, data ) {
-	if ( ! error && data && data.posts ) {
-		forEach( data.posts, post => {
-			if ( post.comments ) {
-				// conversations!
-				reduxDispatch( {
-					type: COMMENTS_RECEIVE,
-					siteId: post.site_ID,
-					postId: post.ID,
-					comments: post.comments,
-				} );
-			}
-		} );
-	}
-
 	Dispatcher.handleServerAction( {
 		type: ActionType.RECEIVE_UPDATES,
 		id,

--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -16,7 +16,6 @@ import feedPostListCache from './feed-stream-cache';
 import wpcom from 'lib/wp';
 import { reduxDispatch } from 'lib/redux-bridge';
 import { COMMENTS_RECEIVE } from 'state/action-types';
-import FeedPostStore from 'lib/feed-post-store';
 
 function getNextPageParams( store ) {
 	const params = {
@@ -118,20 +117,6 @@ export function receivePage( id, error, data ) {
 }
 
 export function receiveUpdates( id, error, data ) {
-	// if conversations, then update the comments on the post
-	if ( data.posts && data.posts[ 0 ] && data.posts[ 0 ].comments ) {
-		forEach( data.posts, post => {
-			const postKey = { blogId: post.site_ID, postId: post.ID };
-			FeedPostStoreActions.receivePost(
-				null,
-				{
-					...FeedPostStore.get( postKey ),
-					...post,
-				},
-				postKey
-			);
-		} );
-	}
 	Dispatcher.handleServerAction( {
 		type: ActionType.RECEIVE_UPDATES,
 		id,

--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -16,6 +16,7 @@ import feedPostListCache from './feed-stream-cache';
 import wpcom from 'lib/wp';
 import { reduxDispatch } from 'lib/redux-bridge';
 import { COMMENTS_RECEIVE } from 'state/action-types';
+import FeedPostStore from 'lib/feed-post-store';
 
 function getNextPageParams( store ) {
 	const params = {
@@ -117,6 +118,20 @@ export function receivePage( id, error, data ) {
 }
 
 export function receiveUpdates( id, error, data ) {
+	// if conversations, then update the comments on the post
+	if ( data.posts && data.posts[ 0 ] && data.posts[ 0 ].comments ) {
+		forEach( data.posts, post => {
+			const postKey = { blogId: post.site_ID, postId: post.ID };
+			FeedPostStoreActions.receivePost(
+				null,
+				{
+					...FeedPostStore.get( postKey ),
+					...post,
+				},
+				postKey
+			);
+		} );
+	}
 	Dispatcher.handleServerAction( {
 		type: ActionType.RECEIVE_UPDATES,
 		id,

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -28,6 +28,8 @@ import PollerPool from 'lib/data-poller';
 import { setLastStoreId } from 'reader/controller-helper';
 import * as stats from 'reader/stats';
 import { keyToString, keysAreEqual } from './post-key';
+import { reduxDispatch } from 'lib/redux-bridge';
+import { COMMENTS_RECEIVE } from 'state/action-types';
 
 const debug = debugFactory( 'calypso:feed-store:post-list-store' );
 
@@ -522,6 +524,20 @@ export default class FeedStream {
 				to: this.pendingDateAfter,
 			} );
 		}
+		forEach( this.pendingPostKeys, postKey => {
+			// TODO: make this actually dispatch the right comments instead of
+			// ids to the comments
+			if ( postKey.comments ) {
+				// conversations!
+				console.error( 'acceptUpdates', postKey );
+				reduxDispatch( {
+					type: COMMENTS_RECEIVE,
+					siteId: postKey.blogId,
+					postId: postKey.postId,
+					comments: postKey.comments,
+				} );
+			}
+		} );
 
 		this.postKeys = uniqBy( this.pendingPostKeys.concat( this.postKeys ), postKey =>
 			keyToString( postKey )

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -153,6 +153,10 @@ export default class FeedStream {
 		return this.pendingPostKeys.length;
 	}
 
+	getPendingPostKeys() {
+		return this.pendingPostKeys;
+	}
+
 	getSelectedPostKey() {
 		if ( this.selectedIndex >= 0 && this.selectedIndex < this.postKeys.length ) {
 			return this.postKeys[ this.selectedIndex ];

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -561,6 +561,7 @@ export default class FeedStream {
 			this.selectedIndex = -1;
 		}
 		this.pendingPostKeys = [];
+		this.pendingComments.clear();
 		this.pendingDateAfter = null;
 		this.emitChange();
 	}

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -13,6 +13,7 @@ import {
 	some,
 	defer,
 	uniqBy,
+	startsWith,
 } from 'lodash';
 import moment from 'moment';
 import debugFactory from 'debug';
@@ -27,7 +28,9 @@ import { action as ActionTypes } from './constants';
 import PollerPool from 'lib/data-poller';
 import { setLastStoreId } from 'reader/controller-helper';
 import * as stats from 'reader/stats';
+import * as reduxBridge from 'lib/redux-bridge';
 import { keyToString, keysAreEqual } from './post-key';
+import { getCommentById } from 'state/comments/selectors';
 
 const debug = debugFactory( 'calypso:feed-store:post-list-store' );
 
@@ -417,6 +420,12 @@ export default class FeedStream {
 	}
 
 	filterNewPosts( posts ) {
+		// filter out posts whose only comments are ones we already have
+		console.error( posts );
+		if ( startsWith( this.id, 'conversations' ) ) {
+			console.error( posts );
+			// posts = filter( posts, post => !! getCommentById( reduxBridge.getState(), { siteId: post.site_ID, commentId:  })
+		}
 		const postById = this.postById;
 		posts = filter( posts, post => {
 			return ! postById.has( keyToString( this.keyMaker( post ) ) );
@@ -429,7 +438,6 @@ export default class FeedStream {
 		if ( id !== this.id ) {
 			return;
 		}
-
 		debug( 'receiving page in %s', this.id );
 
 		this._isFetchingNextPage = false;
@@ -457,6 +465,7 @@ export default class FeedStream {
 			return;
 		}
 
+		console.error( id, data, 'hiiiiii', posts );
 		const postKeys = this.filterNewPosts( posts );
 
 		if ( postKeys.length ) {

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -525,16 +525,14 @@ export default class FeedStream {
 			} );
 		}
 		forEach( this.pendingPostKeys, postKey => {
-			// TODO: make this actually dispatch the right comments instead of
-			// ids to the comments
+			// conversations!
 			if ( postKey.comments ) {
-				// conversations!
-				console.error( 'acceptUpdates', postKey );
+				const post = FeedPostStore.get( postKey );
 				reduxDispatch( {
 					type: COMMENTS_RECEIVE,
-					siteId: postKey.blogId,
-					postId: postKey.postId,
-					comments: postKey.comments,
+					siteId: post.site_ID,
+					postId: post.ID,
+					comments: post.comments,
 				} );
 			}
 		} );

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -13,7 +13,6 @@ import {
 	some,
 	defer,
 	uniqBy,
-	startsWith,
 } from 'lodash';
 import moment from 'moment';
 import debugFactory from 'debug';
@@ -28,9 +27,7 @@ import { action as ActionTypes } from './constants';
 import PollerPool from 'lib/data-poller';
 import { setLastStoreId } from 'reader/controller-helper';
 import * as stats from 'reader/stats';
-import * as reduxBridge from 'lib/redux-bridge';
 import { keyToString, keysAreEqual } from './post-key';
-import { getCommentById } from 'state/comments/selectors';
 
 const debug = debugFactory( 'calypso:feed-store:post-list-store' );
 
@@ -420,12 +417,6 @@ export default class FeedStream {
 	}
 
 	filterNewPosts( posts ) {
-		// filter out posts whose only comments are ones we already have
-		console.error( posts );
-		if ( startsWith( this.id, 'conversations' ) ) {
-			console.error( posts );
-			// posts = filter( posts, post => !! getCommentById( reduxBridge.getState(), { siteId: post.site_ID, commentId:  })
-		}
 		const postById = this.postById;
 		posts = filter( posts, post => {
 			return ! postById.has( keyToString( this.keyMaker( post ) ) );
@@ -438,6 +429,7 @@ export default class FeedStream {
 		if ( id !== this.id ) {
 			return;
 		}
+
 		debug( 'receiving page in %s', this.id );
 
 		this._isFetchingNextPage = false;
@@ -465,7 +457,6 @@ export default class FeedStream {
 			return;
 		}
 
-		console.error( id, data, 'hiiiiii', posts );
 		const postKeys = this.filterNewPosts( posts );
 
 		if ( postKeys.length ) {

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -530,8 +530,8 @@ export default class FeedStream {
 				const post = FeedPostStore.get( postKey );
 				reduxDispatch( {
 					type: COMMENTS_RECEIVE,
-					siteId: post.site_ID,
-					postId: post.ID,
+					siteId: postKey.blogId,
+					postId: postKey.postId,
 					comments: post.comments,
 				} );
 			}

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -75,7 +75,7 @@ function conversationsPager( params ) {
 function filterConversationsPosts( posts ) {
 	// turn the new ones into post keys
 	const newPosts = map( posts, this.keyMaker );
-	return filter( newPosts, post => {
+	const filteredNewPosts = filter( newPosts, post => {
 		// only keep things that we don't have or things that have new comments
 		if ( ! this.postById.has( keyToString( post ) ) ) {
 			return true; // new new
@@ -91,6 +91,17 @@ function filterConversationsPosts( posts ) {
 		}
 		return true;
 	} );
+
+	return filteredNewPosts;
+
+	// @todo: partition posts into those with new comments that only the user has commented on, and others
+	// maybe use lodash partion?
+}
+
+// Works similarly to acceptUpdates() in FeedStream
+// - takes postKeys array
+function acceptNewPostsWithoutNotification() {
+	// @todo
 }
 
 function addMetaToNextPageFetch( params ) {
@@ -351,6 +362,7 @@ export default function feedStoreFactory( storeId ) {
 		} );
 		// monkey patching is the best patching
 		store.filterNewPosts = filterConversationsPosts;
+		store.acceptNewPostsWithoutNotification = acceptNewPostsWithoutNotification;
 	} else if ( storeId === 'conversations-a8c' ) {
 		store = new FeedStream( {
 			id: storeId,
@@ -364,6 +376,7 @@ export default function feedStoreFactory( storeId ) {
 
 		// monkey patching is the best patching
 		store.filterNewPosts = filterConversationsPosts;
+		store.acceptNewPostsWithoutNotification = acceptNewPostsWithoutNotification;
 	} else if ( storeId === 'a8c' ) {
 		store = new FeedStream( {
 			id: storeId,

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -14,8 +14,6 @@ import FeedStreamCache from './feed-stream-cache';
 import analytics from 'lib/analytics';
 import wpcom from 'lib/wp';
 import { keyToString, keysAreEqual } from './post-key';
-import * as reduxBridge from 'lib/redux-bridge';
-import { getCommentById } from 'state/comments/selectors';
 
 const wpcomUndoc = wpcom.undocumented();
 
@@ -90,21 +88,6 @@ function filterConversationsPosts( posts ) {
 
 		// .comments are arrays of comment IDs
 		if ( isEqual( existingPost.comments, post.comments ) ) {
-			return false;
-		}
-
-		// Discard posts for which we have all the comments in Redux already.
-		// This means that comments from the current user won't trigger an update pill.
-		const reduxState = reduxBridge.getState();
-		const commentsInRedux = filter( post.comments, commentId => {
-			return !! getCommentById( {
-				state: reduxState,
-				siteId: post.blogId,
-				commentId,
-			} );
-		} );
-
-		if ( isEqual( post.comments, commentsInRedux ) ) {
 			return false;
 		}
 

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -75,7 +75,7 @@ function conversationsPager( params ) {
 function filterConversationsPosts( posts ) {
 	// turn the new ones into post keys
 	const newPosts = map( posts, this.keyMaker );
-	const filteredNewPosts = filter( newPosts, post => {
+	return filter( newPosts, post => {
 		// only keep things that we don't have or things that have new comments
 		if ( ! this.postById.has( keyToString( post ) ) ) {
 			return true; // new new
@@ -93,8 +93,6 @@ function filterConversationsPosts( posts ) {
 
 		return true;
 	} );
-
-	return filteredNewPosts;
 }
 
 function addMetaToNextPageFetch( params ) {

--- a/client/lib/feed-stream-store/paged-stream.js
+++ b/client/lib/feed-stream-store/paged-stream.js
@@ -118,6 +118,10 @@ export default class PagedStream {
 		return 0;
 	}
 
+	getPendingPostKeys() {
+		return this.pendingPostKeys;
+	}
+
 	getSelectedPostKey() {
 		if ( this.selectedIndex >= 0 && this.selectedIndex < this.postKeys.length ) {
 			return this.postKeys[ this.selectedIndex ];

--- a/client/lib/redux-bridge/index.js
+++ b/client/lib/redux-bridge/index.js
@@ -14,10 +14,3 @@ export function reduxDispatch( ...args ) {
 	}
 	reduxStore.dispatch( ...args );
 }
-
-export function getState() {
-	if ( reduxStore ) {
-		return reduxStore.getState();
-	}
-	return undefined;
-}

--- a/client/lib/redux-bridge/index.js
+++ b/client/lib/redux-bridge/index.js
@@ -14,3 +14,10 @@ export function reduxDispatch( ...args ) {
 	}
 	reduxStore.dispatch( ...args );
 }
+
+export function getState() {
+	if ( reduxStore ) {
+		return reduxStore.getState();
+	}
+	return undefined;
+}

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -143,6 +143,7 @@ class ReaderStream extends React.Component {
 			posts,
 			recs,
 			updateCount: store.getUpdateCount(),
+			pendingPostKeys: store.getPendingPostKeys(),
 			selectedPostKey: store.getSelectedPostKey(),
 			isFetchingNextPage: store.isFetchingNextPage && store.isFetchingNextPage(),
 			isLastPage: store.isLastPage(),
@@ -484,7 +485,11 @@ class ReaderStream extends React.Component {
 						</MobileBackToSidebar>
 					) }
 
-				<UpdateNotice count={ this.state.updateCount } onClick={ this.showUpdates } />
+				<UpdateNotice
+					count={ this.state.updateCount }
+					onClick={ this.showUpdates }
+					pendingPostKeys={ this.state.pendingPostKeys }
+				/>
 				{ this.props.children }
 				{ showingStream && this.state.posts.length ? this.props.intro : null }
 				{ body }

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -33,14 +33,16 @@ class UpdateNotice extends React.PureComponent {
 		let { count } = this.props;
 		const { pendingPostKeys } = this.props;
 
+		// ugly hack for conversations to hide the pill if none of the comments
+		// are actually new
 		if ( isConversations ) {
 			let newComments = 0;
-			forEach( pendingPostKeys, post => {
-				if ( post.comments ) {
-					const commentsToKeep = filter( post.comments, commentId => {
+			forEach( pendingPostKeys, postKey => {
+				if ( postKey.comments ) {
+					const commentsToKeep = filter( postKey.comments, commentId => {
 						const c = getCommentById( {
 							state: this.props.state,
-							siteId: post.blogId,
+							siteId: postKey.blogId,
 							commentId: commentId,
 						} );
 						return ! c;
@@ -56,6 +58,7 @@ class UpdateNotice extends React.PureComponent {
 			}
 			count = newComments;
 		}
+
 		const counterClasses = classnames( {
 			'reader-update-notice': true,
 			'is-active': this.props.count > 0,

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -50,7 +50,7 @@ export const getCommentById = ( { state, commentId, siteId } ) => {
 	}
 
 	const commentsForSite = flatMap(
-		filter( state.comments && state.comments.items, ( comment, key ) => {
+		filter( get( state, 'comments.items', [] ), ( comment, key ) => {
 			return deconstructStateKey( key ).siteId === siteId;
 		} )
 	);

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -23,7 +23,7 @@ import {
  */
 import createSelector from 'lib/create-selector';
 import { fetchStatusInitialState } from './reducer';
-import { getStateKey, deconstructStateKey } from './utils';
+import { getStateKey, deconstructStateKey, getErrorKey } from './utils';
 
 /***
  * Gets comment items for post
@@ -44,8 +44,9 @@ export const getDateSortedPostComments = createSelector(
 );
 
 export const getCommentById = ( { state, commentId, siteId } ) => {
-	if ( get( state, 'comments.errors', {} )[ `${ siteId }-${ commentId }` ] ) {
-		return state.comments.errors[ `${ siteId }-${ commentId }` ];
+	const errorKey = getErrorKey( siteId, commentId );
+	if ( get( state, 'comments.errors', {} )[ errorKey ] ) {
+		return state.comments.errors[ errorKey ];
 	}
 
 	const commentsForSite = flatMap(

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -43,21 +43,18 @@ export const getDateSortedPostComments = createSelector(
 	state => [ state.comments.items ]
 );
 
-export const getCommentById = createSelector(
-	( { state, commentId, siteId } ) => {
-		if ( get( state, 'comments.errors', {} )[ `${ siteId }-${ commentId }` ] ) {
-			return state.comments.errors[ `${ siteId }-${ commentId }` ];
-		}
+export const getCommentById = ( { state, commentId, siteId } ) => {
+	if ( get( state, 'comments.errors', {} )[ `${ siteId }-${ commentId }` ] ) {
+		return state.comments.errors[ `${ siteId }-${ commentId }` ];
+	}
 
-		const commentsForSite = flatMap(
-			filter( state.comments && state.comments.items, ( comment, key ) => {
-				return deconstructStateKey( key ).siteId === siteId;
-			} )
-		);
-		return find( commentsForSite, comment => commentId === comment.ID );
-	},
-	( { state } ) => [ state.comments.items, state.comments.errors ]
-);
+	const commentsForSite = flatMap(
+		filter( state.comments && state.comments.items, ( comment, key ) => {
+			return deconstructStateKey( key ).siteId === siteId;
+		} )
+	);
+	return find( commentsForSite, comment => commentId === comment.ID );
+};
 
 export const getCommentErrors = state => {
 	return state.comments.errors;


### PR DESCRIPTION
This PR avoids triggering the 'x new posts' update pill if the only new comment was written by the current user inside Conversations.

Fixes: https://github.com/Automattic/wp-calypso/issues/18846

### To test

In http://calypso.localhost:3000/read/conversations, write a new comment. Ensure that you don't see the update pill afterwards.

Then write a comment on the same thread from a different browser window + user. Ensure that you _do_ see the update pill.