### PR TITLE
CreateSelector: Add`cachePerKey` flag

### DIFF
--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -31,14 +31,13 @@ const VALID_ARG_TYPES = [ 'number', 'boolean', 'string' ];
 const DEFAULT_GET_DEPENDANTS = state => state;
 
 /**
- * At runtime, assigns a function which returns a cache key for the memoized
- * selector function, given a state object and a variable set of arguments. In
- * development mode, this warns when the memoized selector is passed a complex
+ * In development mode, this warns when the memoized selector is passed a complex
  * object argument, as these cannot be depended upon as reliable cache keys.
+ * Note that the underlying function is created at runtime depending on the environment
  *
  * @type {Function} Function returning cache key for memoized selector
  */
-const DEFAULT_GET_CACHE_KEY = ( () => {
+const warnAgainstComplexArguments = ( () => {
 	let warn, includes;
 	if ( 'production' !== process.env.NODE_ENV ) {
 		// Webpack can optimize bundles if it can detect that a block will
@@ -46,22 +45,30 @@ const DEFAULT_GET_CACHE_KEY = ( () => {
 		// these debugging modules will be excluded from the production build.
 		warn = require( 'lib/warn' );
 		includes = require( 'lodash/includes' );
-	} else {
-		return ( state, ...args ) => args.join();
 	}
 
-	return ( state, ...args ) => {
+	return ( ...args ) => {
 		const hasInvalidArg = args.some( arg => {
 			return arg && ! includes( VALID_ARG_TYPES, typeof arg );
 		} );
 
 		if ( hasInvalidArg ) {
-			warn( 'Do not pass complex objects as arguments for a memoized selector' );
+			warn(
+				'Do not pass complex objects as arguments for a memoized selector,' +
+					' as these can not be depended upon as reliable cache keys.'
+			);
 		}
-
-		return args.join();
 	};
 } )();
+
+/**
+ * Returns a function to be used as the default cache key resolver in _.memoize.
+ * It simply ignores the 'state' argument and joins all others.
+ *
+ * @param  {Object}    state Current state object
+ * @returns {Function} Function returning cache key for memoized selector
+ */
+const DEFAULT_GET_CACHE_KEY = ( state, ...args ) => args.join();
 
 /**
  * Given an array of getDependants functions, returns a single function which,
@@ -97,6 +104,8 @@ export default function createSelector(
 
 	return Object.assign(
 		function( state, ...args ) {
+			warnAgainstComplexArguments( ...args );
+
 			let currentDependants = getDependants( state, ...args );
 			if ( ! Array.isArray( currentDependants ) ) {
 				currentDependants = [ currentDependants ];

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -89,12 +89,10 @@ const makeSelectorFromArray = dependants => ( state, ...args ) =>
  * @param  {Boolean}             cachePerKey   Flag whether caching should happen per key
  * @return {Function}                          Memoized selector
  */
-export default function createSelector(
-	selector,
-	getDependants = DEFAULT_GET_DEPENDANTS,
-	getCacheKey = DEFAULT_GET_CACHE_KEY,
-	cachePerKey
-) {
+export default function createSelector( selector, getDependants, getCacheKey, cachePerKey ) {
+	getDependants = getDependants || DEFAULT_GET_DEPENDANTS;
+	getCacheKey = getCacheKey || DEFAULT_GET_CACHE_KEY;
+
 	const memoizedSelector = memoize( selector, getCacheKey );
 	let lastDependants = cachePerKey ? {} : null;
 

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -1,4 +1,5 @@
 /** @format */
+/* eslint-disable no-console */
 /**
  * External dependencies
  */
@@ -74,20 +75,43 @@ describe( 'index', () => {
 		expect( selector ).to.have.been.calledOnce;
 	} );
 
-	test( 'should warn against complex arguments in development mode', () => {
-		const state = { posts: {} };
+	describe( 'warning against complex arguments in development mode', () => {
+		test( 'should warn against objects being passed', () => {
+			const state = { posts: {} };
 
-		getSitePosts( state, 1 );
-		getSitePosts( state, '' );
-		getSitePosts( state, 'foo' );
-		getSitePosts( state, true );
-		getSitePosts( state, null );
-		getSitePosts( state, undefined );
-		getSitePosts( state, {} );
-		getSitePosts( state, [] );
-		getSitePosts( state, 1, [] );
+			getSitePosts( state, {} );
 
-		expect( console.warn ).to.have.been.calledThrice;
+			expect( console.warn ).to.have.been.calledOnce;
+		} );
+
+		test( 'should warn against arrays being passed', () => {
+			const state = { posts: {} };
+
+			getSitePosts( state, [] );
+
+			expect( console.warn ).to.have.been.calledOnce;
+		} );
+
+		test( 'should warn against arrays being passed amoungst mixed arguments', () => {
+			const state = { posts: {} };
+
+			getSitePosts( state, 1, [] );
+
+			expect( console.warn ).to.have.been.calledOnce;
+		} );
+
+		test( 'should not warn against numbers, bools, nils or strings being passed', () => {
+			const state = { posts: {} };
+
+			getSitePosts( state, 1 );
+			getSitePosts( state, '' );
+			getSitePosts( state, 'foo' );
+			getSitePosts( state, true );
+			getSitePosts( state, null );
+			getSitePosts( state, undefined );
+
+			expect( console.warn ).not.to.have.been.called;
+		} );
 	} );
 
 	test( 'should return the expected value of differing arguments', () => {

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -316,7 +316,7 @@ describe( 'index', () => {
 			const memoizedSelector = createSelector(
 				( state, x, y, z ) => state[ x ][ y ][ z ],
 				state => state.a.b,
-				( state, ...args ) => args.join(),
+				null,
 				true
 			);
 			const state = {

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -301,6 +301,16 @@ describe( 'index', () => {
 			.true;
 	} );
 
+	describe( 'when no custom cache key generating function is given', () => {
+		test( 'should to create a default key by joining args', () => {
+			const memoizedSelector = createSelector( selector );
+
+			memoizedSelector( {}, 'a', 'b', 'c', 1, 2, 3 );
+
+			expect( memoizedSelector.memoizedSelector.cache.has( 'a,b,c,1,2,3' ) ).to.be.true;
+		} );
+	} );
+
 	test( 'should call dependant state getter with arguments', () => {
 		const getDeps = sinon.spy();
 		const memoizedSelector = createSelector( () => null, getDeps );


### PR DESCRIPTION
While investigating improvements to be made to the caching of post revisions I noticed that each time the selector was called with different dependants the entire cache for the selector was invalidated.

To demonstrate:
```js
const someSelector = createSelector(
  ( state, x, y, z ) => state[ x ][ y ][ z ],
  state => state.a.b
);
const state = {
  a: {
    b: {
	c: 'cc',
        d: 'dd',
    },
  },
};

someSelector( state, 'a', 'b', 'c' ) // returns 'cc'
someSelector( state, 'a', 'b', 'd' ) // returns 'dd'
```
That's fine and expected.
But what if the `getDependants` is looking at something that only applies to the given arguments of a particular selection?
Here we're depending on the current and previous revisions in order to diff between them.
```js
const getRevisionChanges = createSelector(
  ( state, x, y, revisionId ) => {
    const currentRevision = state[ x ][ y ][ revisionId ];
    const previousRevision = getPreviousRevision( currentRevision );

    return differenceBetween( currentRevision, previousRevision );
  },
  [ state => -currentRevision-, state => -previousRevision- ]
);

getRevisionChanges( state, siteId, postId, 1234 ) // works out and returns the diff
// diff is held in cache under the cacheKey of `{siteId},{postId},1234` ✅

// Now we call getRevisionChanges to select the diff of 1235
getRevisionChanges( state, siteId, postId, 1234 ) // works out and returns the diff
// diff is held in cache under the cacheKey of `{siteId},{postId},1235` ✅
// The problem is, during this process the whole cache gets invalidated before `{siteId},{postId},1235` is cached.
// So the `{siteId},{postId},1234` value is cleared. ❌

// Imagine now that there are 20 revisions, calling the selection for each one is expensive.
// In the above case each selection would invalidate all previous values, rendering the caching worthless.
```

This PR seeks to avoid invalidating the entire cache of a given selector by allowing a flag to passed called `cachePerKey` which changes the behaviour so that each key will be invalidated on an individual basis - if the dependants differ from one set of arguments to another, no invalidation. If the dependants differ on the same set of arguments only then will the value for that cache key by invalidated.

### Testing
Right now there should be no change to the apps behaviour, no regressions.
Theres also no implementation of this new flag - running the unit tests are the only way to test this new behaviour.

### TODO
Before merging I plan to add to the docs to explain this flag :)