### PR TITLE
Post Type List: update bulk edit styling

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -106,6 +106,7 @@ class PostItem extends React.Component {
 			globalId,
 			isAllSitesModeSelected,
 			translate,
+			multiSelectEnabled,
 		} = this.props;
 
 		const title = post ? post.title : null;
@@ -162,7 +163,7 @@ class PostItem extends React.Component {
 						</div>
 					</div>
 					<PostTypeListPostThumbnail globalId={ globalId } />
-					<PostActionsEllipsisMenu globalId={ globalId } />
+					{ ! multiSelectEnabled && <PostActionsEllipsisMenu globalId={ globalId } /> }
 				</div>
 				{ expandedContent }
 			</div>

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -141,7 +141,10 @@ class PostItem extends React.Component {
 						</div>
 						<h1 className="post-item__title">
 							{ ! externalPostLink && (
-								<a href={ isPlaceholder ? null : postUrl } className="post-item__title-link">
+								<a
+									href={ isPlaceholder || multiSelectEnabled ? null : postUrl }
+									className="post-item__title-link"
+								>
 									{ title || translate( 'Untitled' ) }
 								</a>
 							) }
@@ -149,7 +152,7 @@ class PostItem extends React.Component {
 								externalPostLink && (
 									<ExternalLink
 										icon={ true }
-										href={ postUrl }
+										href={ multiSelectEnabled ? null : postUrl }
 										target="_blank"
 										className="post-item__title-link"
 									>

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -41,14 +41,14 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 .post-item__select {
 	align-self: stretch;
 	display: flex;
-	align-items: center;
+	align-items: start;
 	cursor: pointer;
 
 	&:hover .form-checkbox {
 		border-color: lighten( $gray, 10% );
 	}
 
-	padding: 0 16px;
+	padding: 16px 16px 0;
 	margin-left: -16px;
 
 	@include breakpoint( ">480px" ) {

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -7,7 +7,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { compact, find, includes, reduce } from 'lodash';
@@ -122,18 +121,14 @@ const PostTypeFilter = createReactClass( {
 			return null;
 		}
 
-		const {
-			translate,
-			isMultiSelectEnabled: isMultiSelectButtonEnabled,
-			toggleMultiSelect: onMultiSelectClick,
-		} = this.props;
-
-		const classes = classnames( 'post-type-filter__multi-select-button', {
-			'is-enabled': isMultiSelectButtonEnabled,
-		} );
+		const { translate, toggleMultiSelect: onMultiSelectClick } = this.props;
 
 		return (
-			<Button className={ classes } compact onClick={ onMultiSelectClick }>
+			<Button
+				className="post-type-filter__multi-select-button"
+				compact
+				onClick={ onMultiSelectClick }
+			>
 				<Gridicon icon="list-checkmark" />
 				<span className="post-type-filter__multi-select-button-text">
 					{ translate( 'Bulk Edit' ) }
@@ -143,9 +138,20 @@ const PostTypeFilter = createReactClass( {
 	},
 
 	render() {
-		const { authorToggleHidden, jetpack, query, siteId, statusSlug } = this.props;
+		const {
+			authorToggleHidden,
+			jetpack,
+			query,
+			siteId,
+			statusSlug,
+			isMultiSelectEnabled: isMultiSelectButtonEnabled,
+		} = this.props;
 
 		if ( ! query ) {
+			return null;
+		}
+
+		if ( isMultiSelectButtonEnabled ) {
 			return null;
 		}
 

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -133,10 +133,10 @@ const PostTypeFilter = createReactClass( {
 		} );
 
 		return (
-			<Button className={ classes } borderless onClick={ onMultiSelectClick }>
+			<Button className={ classes } compact onClick={ onMultiSelectClick }>
 				<Gridicon icon="list-checkmark" />
 				<span className="post-type-filter__multi-select-button-text">
-					{ translate( 'Select' ) }
+					{ translate( 'Bulk Edit' ) }
 				</span>
 			</Button>
 		);

--- a/client/my-sites/post-type-filter/style.scss
+++ b/client/my-sites/post-type-filter/style.scss
@@ -8,9 +8,12 @@
 
 	@include breakpoint( "<480px" ) {
 		position: absolute;
-		top: 0;
+		top: 8px;
 		right: 50px;
-		height: 46px;
 		padding: 12px 8px 10px;
+
+		& .post-type-filter__multi-select-button-text {
+			display: none;
+		}
 	}
 }

--- a/client/my-sites/post-type-filter/style.scss
+++ b/client/my-sites/post-type-filter/style.scss
@@ -4,46 +4,13 @@
 }
 
 .post-type-filter__multi-select-button {
-	display: block;
-	height: 50px;
+	background-color: $gray-light;
 
-	&.button.is-borderless { // for specificity
-		color: $blue-wordpress;
-
-		&:hover {
-			color: $link-highlight;
-		}
-
-		// Vertical padding is 26px (height - gridicon height - border)
-		// Bottom padding should be 2px less due to border
-		padding: 14px 8px 12px;
-
-		border-bottom: 2px solid transparent;
-		border-radius: 0;
-
-		&.is-enabled {
-			border-bottom-color: $gray-dark;
-			color: $gray-dark;
-		}
-
-		& .gridicon {
-			// TODO why is this necessary?
-			top: 2px;
-			padding-right: 4px;
-		}
-
-		@include breakpoint( "<480px" ) {
-			position: absolute;
-			top: 0;
-			right: 50px;
-			height: 46px;
-			padding: 12px 8px 10px;
-		}
-	}
-
-	// TODO why is this necessary?
-	& .post-type-filter__multi-select-button-text {
-		vertical-align: top;
-		line-height: 24px;
+	@include breakpoint( "<480px" ) {
+		position: absolute;
+		top: 0;
+		right: 50px;
+		height: 46px;
+		padding: 12px 8px 10px;
 	}
 }

--- a/client/my-sites/post-type-list/bulk-edit-bar.jsx
+++ b/client/my-sites/post-type-list/bulk-edit-bar.jsx
@@ -17,6 +17,8 @@ import {
 	isMultiSelectEnabled,
 	getSelectedPostsCount,
 } from 'state/ui/post-type-list/selectors';
+import { toggleMultiSelect } from 'state/ui/post-type-list/actions';
+import Gridicon from 'gridicons';
 
 class PostTypeBulkEditBar extends React.Component {
 	onEdit() {
@@ -36,6 +38,7 @@ class PostTypeBulkEditBar extends React.Component {
 			multiSelectEnabled,
 			selectedPostsCount,
 			translate,
+			toggleMultiSelect: onMultiSelectClick,
 		} = this.props;
 
 		if ( ! multiSelectEnabled ) {
@@ -59,6 +62,13 @@ class PostTypeBulkEditBar extends React.Component {
 				>
 					{ translate( 'Delete' ) }
 				</Button>
+				<Button
+					className="post-type-list__bulk-edit-bar-close"
+					borderless
+					onClick={ onMultiSelectClick }
+				>
+					<Gridicon icon="cross" />
+				</Button>
 			</Card>
 		);
 	}
@@ -70,5 +80,5 @@ export default connect(
 			multiSelectEnabled: isMultiSelectEnabled( state ),
 			selectedPostsCount: getSelectedPostsCount( state ),
 		};
-	}
+	}, { toggleMultiSelect }
 )( localize( PostTypeBulkEditBar ) );

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -1,8 +1,7 @@
 .post-type-list__bulk-edit-bar {
 	display: flex;
 	align-items: center;
-	padding-top: 8px;
-	padding-bottom: 8px;
+	padding: 8px 16px;
 
 	.count {
 		display: inline-block;

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -13,6 +13,20 @@
 		line-height: 14px;
 		margin-left: 8px;
 	}
+
+	.post-type-list__bulk-edit-bar-close {
+		width: 50px;
+		height: 100%;
+		margin: 0;
+		position: absolute;
+			top: 0;
+			right: 0;
+		line-height: 1;
+
+		.gridicon {
+			top: 4px;
+		}
+	}
 }
 
 .post-type-list__post-thumbnail-wrapper {


### PR DESCRIPTION
This PR updates the styling of the bulk edit mode for the post list behind the `posts/post-type-list/bulk-edit` flag. Along with some style edits, it replaces the `SectionNav` with the `BulkEditBar` when in multi-select mode, changes the wording and style of the "Bulk Edit" toggle, and disables clicking on post titles while in multi-select mode.

**Screenshots:**
<img width="870" alt="bulk-edit-toggle" src="https://user-images.githubusercontent.com/942359/33396425-78b98118-d516-11e7-8909-8f81ec9825c9.png">
<img width="870" alt="bulk-edit-bar" src="https://user-images.githubusercontent.com/942359/33396426-78d0ac80-d516-11e7-831b-5a00953e193d.png">

**To test:**
- Check out branch and `ENABLE_FEATURES=posts/post-type-list,posts/post-type-list/bulk-edit npm start`.
- Navigate to `/posts/` for a single site.
- Make sure that the Bulk Edit button is in the `SectionNav`, styled correctly, and when clicked, replaced with the `BulkEditBar`.
- Make sure that post titles can't be clicked when in bulk edit mode.
- Make sure that the "X" in the `BulkEditBar` returns the SectionNav with bulk edit mode off.