### PR TITLE
Store: Add data-layer support for single order requests

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -16,7 +16,7 @@ import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 import { clearOrderEdits, editOrder } from 'woocommerce/state/ui/orders/actions';
 import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
-import { fetchOrder, updateOrder } from 'woocommerce/state/sites/orders/actions';
+import { fetchOrder, saveOrder } from 'woocommerce/state/sites/orders/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import {
@@ -82,7 +82,7 @@ class Order extends Component {
 	// Saves changes to the remote site via API
 	saveOrder = () => {
 		const { siteId, order } = this.props;
-		this.props.updateOrder( siteId, order );
+		this.props.saveOrder( siteId, order );
 	};
 
 	render() {
@@ -169,7 +169,7 @@ export default connect(
 	},
 	dispatch =>
 		bindActionCreators(
-			{ clearOrderEdits, editOrder, fetchNotes, fetchOrder, updateOrder },
+			{ clearOrderEdits, editOrder, fetchNotes, fetchOrder, saveOrder },
 			dispatch
 		)
 )( localize( Order ) );

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -26,7 +26,7 @@ import { isOrderFinished } from 'woocommerce/lib/order-status';
 import LabelPurchaseDialog from 'woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal';
 import Notice from 'components/notice';
 import QueryLabels from 'woocommerce/woocommerce-services/components/query-labels';
-import { updateOrder } from 'woocommerce/state/sites/orders/actions';
+import { saveOrder } from 'woocommerce/state/sites/orders/actions';
 import { openPrintingFlow } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 import {
 	getLabels,
@@ -87,7 +87,7 @@ class OrderFulfillment extends Component {
 			return;
 		}
 
-		this.props.updateOrder( site.ID, {
+		this.props.saveOrder( site.ID, {
 			id: order.id,
 			status: 'completed',
 		} );
@@ -265,5 +265,5 @@ export default connect(
 			hasLabelsPaymentMethod,
 		};
 	},
-	dispatch => bindActionCreators( { createNote, updateOrder, openPrintingFlow }, dispatch )
+	dispatch => bindActionCreators( { createNote, saveOrder, openPrintingFlow }, dispatch )
 )( localize( OrderFulfillment ) );

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -17,7 +17,7 @@ import formatCurrency from 'lib/format-currency';
 import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
 import { isOrderFailed, isOrderWaitingPayment } from 'woocommerce/lib/order-status';
 import RefundDialog from './dialog';
-import { updateOrder } from 'woocommerce/state/sites/orders/actions';
+import { saveOrder } from 'woocommerce/state/sites/orders/actions';
 
 class OrderPaymentCard extends Component {
 	static propTypes = {
@@ -31,7 +31,7 @@ class OrderPaymentCard extends Component {
 		} ),
 		siteId: PropTypes.number.isRequired,
 		translate: PropTypes.func.isRequired,
-		updateOrder: PropTypes.func.isRequired,
+		saveOrder: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -93,7 +93,7 @@ class OrderPaymentCard extends Component {
 
 	markAsPaid = () => {
 		const { order, siteId } = this.props;
-		this.props.updateOrder( siteId, { ...order, status: 'processing' } );
+		this.props.saveOrder( siteId, { ...order, status: 'processing' } );
 	};
 
 	toggleDialog = () => {
@@ -127,6 +127,6 @@ class OrderPaymentCard extends Component {
 	}
 }
 
-export default connect( null, dispatch => bindActionCreators( { updateOrder }, dispatch ) )(
+export default connect( null, dispatch => bindActionCreators( { saveOrder }, dispatch ) )(
 	localize( OrderPaymentCard )
 );

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -10,13 +10,22 @@ import qs from 'querystring';
  * Internal dependencies
  */
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { updateOrders, failOrders } from 'woocommerce/state/sites/orders/actions';
+import {
+	failOrder,
+	failOrders,
+	_updateOrder,
+	updateOrders,
+} from 'woocommerce/state/sites/orders/actions';
 import request from 'woocommerce/state/sites/http-request';
-import { WOOCOMMERCE_ORDERS_REQUEST } from 'woocommerce/state/action-types';
+import {
+	WOOCOMMERCE_ORDER_REQUEST,
+	WOOCOMMERCE_ORDERS_REQUEST,
+} from 'woocommerce/state/action-types';
 
 const debug = debugFactory( 'woocommerce:orders' );
 
 export default {
+	[ WOOCOMMERCE_ORDER_REQUEST ]: [ dispatchRequest( requestOrder, receivedOrder, apiError ) ],
 	[ WOOCOMMERCE_ORDERS_REQUEST ]: [ dispatchRequest( requestOrders, receivedOrders, apiError ) ],
 };
 
@@ -42,4 +51,16 @@ export function apiError( { dispatch }, action, error ) {
 	if ( action.failureAction ) {
 		dispatch( { ...action.failureAction, error } );
 	}
+}
+
+export function requestOrder( { dispatch }, action ) {
+	const { siteId, orderId } = action;
+	action.failureAction = failOrder( siteId, orderId );
+
+	dispatch( request( siteId, action ).get( `orders/${ orderId }` ) );
+}
+
+export function receivedOrder( { dispatch }, action, { data } ) {
+	const { siteId, orderId } = action;
+	dispatch( _updateOrder( siteId, orderId, data ) );
 }

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -13,12 +13,17 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import {
 	failOrder,
 	failOrders,
-	_updateOrder,
+	saveOrderError,
+	saveOrderSuccess,
+	updateOrder,
 	updateOrders,
 } from 'woocommerce/state/sites/orders/actions';
 import request from 'woocommerce/state/sites/http-request';
+import { successNotice, errorNotice } from 'state/notices/actions';
+import { translate } from 'i18n-calypso';
 import {
 	WOOCOMMERCE_ORDER_REQUEST,
+	WOOCOMMERCE_ORDER_UPDATE,
 	WOOCOMMERCE_ORDERS_REQUEST,
 } from 'woocommerce/state/action-types';
 
@@ -26,8 +31,19 @@ const debug = debugFactory( 'woocommerce:orders' );
 
 export default {
 	[ WOOCOMMERCE_ORDER_REQUEST ]: [ dispatchRequest( requestOrder, receivedOrder, apiError ) ],
+	[ WOOCOMMERCE_ORDER_UPDATE ]: [
+		dispatchRequest( sendOrder, onOrderSaveSuccess, onOrderSaveFailure ),
+	],
 	[ WOOCOMMERCE_ORDERS_REQUEST ]: [ dispatchRequest( requestOrders, receivedOrders, apiError ) ],
 };
+
+export function apiError( { dispatch }, action, error ) {
+	debug( 'API Error: ', error );
+
+	if ( action.failureAction ) {
+		dispatch( { ...action.failureAction, error } );
+	}
+}
 
 export function requestOrders( { dispatch }, action ) {
 	const { siteId, query } = action;
@@ -45,14 +61,6 @@ export function receivedOrders( { dispatch }, action, { data } ) {
 	dispatch( updateOrders( siteId, query, body, total ) );
 }
 
-export function apiError( { dispatch }, action, error ) {
-	debug( 'API Error: ', error );
-
-	if ( action.failureAction ) {
-		dispatch( { ...action.failureAction, error } );
-	}
-}
-
 export function requestOrder( { dispatch }, action ) {
 	const { siteId, orderId } = action;
 	action.failureAction = failOrder( siteId, orderId );
@@ -62,5 +70,23 @@ export function requestOrder( { dispatch }, action ) {
 
 export function receivedOrder( { dispatch }, action, { data } ) {
 	const { siteId, orderId } = action;
-	dispatch( _updateOrder( siteId, orderId, data ) );
+	dispatch( updateOrder( siteId, orderId, data ) );
+}
+
+export function sendOrder( { dispatch }, action ) {
+	const { siteId, orderId, order } = action;
+	dispatch( request( siteId, action ).post( `orders/${ orderId }`, order ) );
+}
+
+export function onOrderSaveSuccess( { dispatch }, action, { data } ) {
+	const { siteId, orderId } = action;
+	dispatch( successNotice( translate( 'Order saved.' ), { duration: 5000 } ) );
+	dispatch( saveOrderSuccess( siteId, orderId, data ) );
+}
+
+export function onOrderSaveFailure( { dispatch }, action, error ) {
+	const { siteId, orderId } = action;
+	debug( 'API Error: ', error );
+	dispatch( errorNotice( translate( 'Unable to save order.' ), { duration: 5000 } ) );
+	dispatch( saveOrderError( siteId, orderId, error ) );
 }

--- a/client/extensions/woocommerce/state/data-layer/orders/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/test/index.js
@@ -13,17 +13,32 @@ import {
 	failOrders,
 	fetchOrder,
 	fetchOrders,
-	_updateOrder,
+	saveOrder,
+	saveOrderError,
+	saveOrderSuccess,
+	updateOrder,
 	updateOrders,
 } from 'woocommerce/state/sites/orders/actions';
-import { apiError, receivedOrder, receivedOrders, requestOrder, requestOrders } from '../';
+import {
+	apiError,
+	receivedOrder,
+	receivedOrders,
+	requestOrder,
+	requestOrders,
+	onOrderSaveFailure,
+	onOrderSaveSuccess,
+	sendOrder,
+} from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
 	WOOCOMMERCE_ORDER_REQUEST_FAILURE,
 	WOOCOMMERCE_ORDER_REQUEST_SUCCESS,
+	WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
+	WOOCOMMERCE_ORDER_UPDATE_FAILURE,
 	WOOCOMMERCE_ORDERS_REQUEST_FAILURE,
 	WOOCOMMERCE_ORDERS_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
+import { NOTICE_CREATE } from 'state/action-types';
 
 describe( 'handlers', () => {
 	describe( '#requestOrders', () => {
@@ -173,7 +188,7 @@ describe( 'handlers', () => {
 		test( 'should dispatch a success action on a good response', () => {
 			const dispatch = spy();
 			const order = { id: 42, total: '50.00' };
-			const action = _updateOrder( 123, 42, order );
+			const action = updateOrder( 123, 42, order );
 
 			receivedOrder( { dispatch }, action, { data: order } );
 
@@ -194,7 +209,7 @@ describe( 'handlers', () => {
 				data: { status: 404 },
 				message: 'No route was found matching the URL and request method',
 			};
-			const action = _updateOrder( 123, 42, response );
+			const action = updateOrder( 123, 42, response );
 
 			receivedOrder( { dispatch }, action, { data: response } );
 			expect( dispatch ).to.have.been.calledWithMatch(
@@ -202,6 +217,104 @@ describe( 'handlers', () => {
 					type: WOOCOMMERCE_ORDER_REQUEST_FAILURE,
 					siteId: 123,
 					orderId: 42,
+				} )
+			);
+		} );
+	} );
+
+	describe( '#sendOrder', () => {
+		test( 'should dispatch a post action', () => {
+			const dispatch = spy();
+			const order = {
+				id: 1,
+				status: 'completed',
+				total: '50.00',
+			};
+			const action = saveOrder( 123, order );
+			sendOrder( { dispatch }, action );
+
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith(
+				http(
+					{
+						method: 'POST',
+						path: '/jetpack-blogs/123/rest-api/',
+						apiVersion: '1.1',
+						body: {
+							json: true,
+							path: '/wc/v3/orders/1&_method=POST',
+							body: JSON.stringify( { status: 'completed', total: '50.00' } ),
+						},
+						query: {
+							json: true,
+						},
+					},
+					action
+				)
+			);
+		} );
+	} );
+
+	describe( '#onOrderSaveSuccess', () => {
+		test( 'should dispatch a success action on a good response', () => {
+			const dispatch = spy();
+			const order = { id: 42, total: '50.00' };
+			const action = saveOrderSuccess( 123, 42, order );
+
+			onOrderSaveSuccess( { dispatch }, action, { data: order } );
+
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
+					siteId: 123,
+					orderId: 42,
+					order,
+				} )
+			);
+		} );
+
+		test( 'should dispatch a failure action on a bad response', () => {
+			const dispatch = spy();
+			const response = {
+				code: 'rest_no_route',
+				data: { status: 404 },
+				message: 'No route was found matching the URL and request method',
+			};
+			const action = saveOrderSuccess( 123, 42, response );
+
+			onOrderSaveSuccess( { dispatch }, action, { data: response } );
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
+					siteId: 123,
+					orderId: 42,
+					error: response,
+				} )
+			);
+		} );
+	} );
+	describe( '#onOrderSaveFailure', () => {
+		test( 'should dispatch a failure action on a failed orders save', () => {
+			const dispatch = spy();
+			const response = {
+				code: 'rest_no_route',
+				data: { status: 404 },
+				message: 'No route was found matching the URL and request method',
+			};
+			const action = saveOrderError( 123, 1, response );
+
+			onOrderSaveFailure( { dispatch }, action, response );
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: NOTICE_CREATE,
+				} )
+			);
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
+					siteId: 123,
+					orderId: 1,
+					error: response,
 				} )
 			);
 		} );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -18,7 +18,7 @@ import getRates from './get-rates';
 import { getPrintURL } from 'woocommerce/woocommerce-services/lib/pdf-label-utils';
 import { getShippingLabel, getFormErrors, shouldFulfillOrder, shouldEmailDetails } from './selectors';
 import { createNote } from 'woocommerce/state/sites/orders/notes/actions';
-import { updateOrder } from 'woocommerce/state/sites/orders/actions';
+import { saveOrder } from 'woocommerce/state/sites/orders/actions';
 import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
 
 import {
@@ -605,7 +605,7 @@ const pollForLabelsPurchase = ( orderId, siteId, dispatch, getState, labels ) =>
 	dispatch( purchaseLabelResponse( orderId, siteId, labels, false ) );
 
 	if ( shouldFulfillOrder( getState(), orderId, siteId ) ) {
-		dispatch( updateOrder( siteId, {
+		dispatch( saveOrder( siteId, {
 			id: orderId,
 			status: 'completed',
 		} ) );


### PR DESCRIPTION
This PR switches the `fetchOrder` code to use the data-layer to request single orders.

Run the tests:

- npm run test-client client/extensions/woocommerce/state/data-layer/orders/test/index.js
- npm run test-client client/extensions/woocommerce/state/sites/orders/

Make sure it still works in calypso

- View a single order `/store/order/:site/:id`
- Check the order editing flow
- Try with as site with Jetpack disconnected, or wc-api-dev disabled, there is no error state but it shouldn't break calypso

Note: I've created an action `_updateOrder`, which uses a `_` prefix to avoid conflicting with the `updateOrder` action – in a following PR I'll be renaming that to `saveOrder`. I wanted the actions related to fetchOrder & fetchOrders to be consistent.