### PR TITLE
Update/store save order data layer

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -16,7 +16,7 @@ import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 import { clearOrderEdits, editOrder } from 'woocommerce/state/ui/orders/actions';
 import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
-import { fetchOrder, updateOrder } from 'woocommerce/state/sites/orders/actions';
+import { fetchOrder, saveOrder } from 'woocommerce/state/sites/orders/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import {
@@ -82,7 +82,7 @@ class Order extends Component {
 	// Saves changes to the remote site via API
 	saveOrder = () => {
 		const { siteId, order } = this.props;
-		this.props.updateOrder( siteId, order );
+		this.props.saveOrder( siteId, order );
 	};
 
 	render() {
@@ -169,7 +169,7 @@ export default connect(
 	},
 	dispatch =>
 		bindActionCreators(
-			{ clearOrderEdits, editOrder, fetchNotes, fetchOrder, updateOrder },
+			{ clearOrderEdits, editOrder, fetchNotes, fetchOrder, saveOrder },
 			dispatch
 		)
 )( localize( Order ) );

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -26,7 +26,7 @@ import { isOrderFinished } from 'woocommerce/lib/order-status';
 import LabelPurchaseDialog from 'woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal';
 import Notice from 'components/notice';
 import QueryLabels from 'woocommerce/woocommerce-services/components/query-labels';
-import { updateOrder } from 'woocommerce/state/sites/orders/actions';
+import { saveOrder } from 'woocommerce/state/sites/orders/actions';
 import { openPrintingFlow } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 import {
 	getLabels,
@@ -87,7 +87,7 @@ class OrderFulfillment extends Component {
 			return;
 		}
 
-		this.props.updateOrder( site.ID, {
+		this.props.saveOrder( site.ID, {
 			id: order.id,
 			status: 'completed',
 		} );
@@ -265,5 +265,5 @@ export default connect(
 			hasLabelsPaymentMethod,
 		};
 	},
-	dispatch => bindActionCreators( { createNote, updateOrder, openPrintingFlow }, dispatch )
+	dispatch => bindActionCreators( { createNote, saveOrder, openPrintingFlow }, dispatch )
 )( localize( OrderFulfillment ) );

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -17,7 +17,7 @@ import formatCurrency from 'lib/format-currency';
 import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
 import { isOrderFailed, isOrderWaitingPayment } from 'woocommerce/lib/order-status';
 import RefundDialog from './dialog';
-import { updateOrder } from 'woocommerce/state/sites/orders/actions';
+import { saveOrder } from 'woocommerce/state/sites/orders/actions';
 
 class OrderPaymentCard extends Component {
 	static propTypes = {
@@ -31,7 +31,7 @@ class OrderPaymentCard extends Component {
 		} ),
 		siteId: PropTypes.number.isRequired,
 		translate: PropTypes.func.isRequired,
-		updateOrder: PropTypes.func.isRequired,
+		saveOrder: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -93,7 +93,7 @@ class OrderPaymentCard extends Component {
 
 	markAsPaid = () => {
 		const { order, siteId } = this.props;
-		this.props.updateOrder( siteId, { ...order, status: 'processing' } );
+		this.props.saveOrder( siteId, { ...order, status: 'processing' } );
 	};
 
 	toggleDialog = () => {
@@ -127,6 +127,6 @@ class OrderPaymentCard extends Component {
 	}
 }
 
-export default connect( null, dispatch => bindActionCreators( { updateOrder }, dispatch ) )(
+export default connect( null, dispatch => bindActionCreators( { saveOrder }, dispatch ) )(
 	localize( OrderPaymentCard )
 );

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -15,7 +15,7 @@ import {
 	failOrders,
 	saveOrderError,
 	saveOrderSuccess,
-	_updateOrder,
+	updateOrder,
 	updateOrders,
 } from 'woocommerce/state/sites/orders/actions';
 import request from 'woocommerce/state/sites/http-request';
@@ -70,7 +70,7 @@ export function requestOrder( { dispatch }, action ) {
 
 export function receivedOrder( { dispatch }, action, { data } ) {
 	const { siteId, orderId } = action;
-	dispatch( _updateOrder( siteId, orderId, data ) );
+	dispatch( updateOrder( siteId, orderId, data ) );
 }
 
 export function sendOrder( { dispatch }, action ) {

--- a/client/extensions/woocommerce/state/data-layer/orders/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/test/index.js
@@ -16,7 +16,7 @@ import {
 	saveOrder,
 	saveOrderError,
 	saveOrderSuccess,
-	_updateOrder,
+	updateOrder,
 	updateOrders,
 } from 'woocommerce/state/sites/orders/actions';
 import {
@@ -188,7 +188,7 @@ describe( 'handlers', () => {
 		test( 'should dispatch a success action on a good response', () => {
 			const dispatch = spy();
 			const order = { id: 42, total: '50.00' };
-			const action = _updateOrder( 123, 42, order );
+			const action = updateOrder( 123, 42, order );
 
 			receivedOrder( { dispatch }, action, { data: order } );
 
@@ -209,7 +209,7 @@ describe( 'handlers', () => {
 				data: { status: 404 },
 				message: 'No route was found matching the URL and request method',
 			};
-			const action = _updateOrder( 123, 42, response );
+			const action = updateOrder( 123, 42, response );
 
 			receivedOrder( { dispatch }, action, { data: response } );
 			expect( dispatch ).to.have.been.calledWithMatch(

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -78,7 +78,7 @@ export const failOrder = ( siteId, orderId, error = false ) => {
 	};
 };
 
-export const _updateOrder = ( siteId, orderId, order ) => {
+export const updateOrder = ( siteId, orderId, order ) => {
 	// This passed through the API layer successfully, but failed at the remote site.
 	if ( 'undefined' === typeof order.id ) {
 		return failOrder( siteId, orderId, order );

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -14,11 +14,6 @@ import {
 	transformOrderForApi,
 } from './utils';
 import { getOrderStatusGroup } from 'woocommerce/lib/order-status';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import request from '../request';
-import { setError } from '../status/wc-api/actions';
-import { successNotice, errorNotice } from 'state/notices/actions';
-import { translate } from 'i18n-calypso';
 import {
 	WOOCOMMERCE_ORDER_REQUEST,
 	WOOCOMMERCE_ORDER_REQUEST_FAILURE,
@@ -96,40 +91,34 @@ export const _updateOrder = ( siteId, orderId, order ) => {
 	};
 };
 
-export const updateOrder = ( siteId, { id: orderId, ...order } ) => ( dispatch, getState ) => {
-	const state = getState();
-	if ( ! siteId ) {
-		siteId = getSelectedSiteId( state );
-	}
-
+export const saveOrder = ( siteId, { id: orderId, ...order } ) => {
 	order = transformOrderForApi( removeTemporaryIds( order ) );
-
-	const updateAction = {
+	return {
 		type: WOOCOMMERCE_ORDER_UPDATE,
 		siteId,
 		orderId,
+		order,
 	};
-	dispatch( updateAction );
+};
 
-	return request( siteId )
-		.post( `orders/${ orderId }`, order )
-		.then( data => {
-			dispatch( successNotice( translate( 'Order saved.' ), { duration: 5000 } ) );
-			dispatch( {
-				type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
-				siteId,
-				orderId,
-				order: data,
-			} );
-		} )
-		.catch( error => {
-			dispatch( setError( siteId, updateAction, error ) );
-			dispatch( errorNotice( translate( 'Unable to save order.' ), { duration: 5000 } ) );
-			dispatch( {
-				type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
-				siteId,
-				orderId,
-				error,
-			} );
-		} );
+export const saveOrderError = ( siteId, orderId, error = false ) => {
+	return {
+		type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
+		siteId,
+		orderId,
+		error,
+	};
+};
+
+export const saveOrderSuccess = ( siteId, orderId, order = {} ) => {
+	// This passed through the API layer successfully, but failed at the remote site.
+	if ( 'undefined' === typeof order.id ) {
+		return saveOrderError( siteId, orderId, order );
+	}
+	return {
+		type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
+		siteId,
+		orderId,
+		order,
+	};
 };

--- a/client/extensions/woocommerce/state/sites/orders/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/actions.js
@@ -16,7 +16,7 @@ import {
 	saveOrder,
 	saveOrderError,
 	saveOrderSuccess,
-	_updateOrder,
+	updateOrder,
 	updateOrders,
 } from '../actions';
 import order from './fixtures/order';
@@ -87,7 +87,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should return a success action with orders list when request completes', () => {
-			const action = _updateOrder( siteId, orderId, order );
+			const action = updateOrder( siteId, orderId, order );
 			expect( action ).to.eql( {
 				type: WOOCOMMERCE_ORDER_REQUEST_SUCCESS,
 				siteId: '123',

--- a/client/extensions/woocommerce/state/sites/orders/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/actions.js
@@ -4,8 +4,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { omit } from 'lodash';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -15,13 +13,14 @@ import {
 	failOrders,
 	fetchOrder,
 	fetchOrders,
+	saveOrder,
+	saveOrderError,
+	saveOrderSuccess,
 	_updateOrder,
-	updateOrder,
 	updateOrders,
 } from '../actions';
 import order from './fixtures/order';
 import orders from './fixtures/orders';
-import useNock from 'test/helpers/use-nock';
 import {
 	WOOCOMMERCE_ORDER_REQUEST,
 	WOOCOMMERCE_ORDER_REQUEST_FAILURE,
@@ -109,74 +108,39 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#updateOrder()', () => {
-		const siteId = '123';
+		const siteId = 123;
 		const updatedOrder = {
 			id: 40,
 			status: 'completed',
 		};
 
-		useNock( nock => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( {
-					path: '/wc/v3/orders/40&_method=post',
-					json: true,
-					body: omit( updatedOrder, 'id' ),
-				} )
-				.reply( 200, {
-					data: order,
-				} )
-				.post( '/rest/v1.1/jetpack-blogs/234/rest-api/' )
-				.query( {
-					path: '/wc/v3/orders/invalid&_method=post',
-					json: true,
-					body: omit( updatedOrder, 'id' ),
-				} )
-				.reply( 404, {
-					data: {
-						message: 'No route was found matching the URL and request method',
-						error: 'rest_no_route',
-					},
-				} );
-		} );
-
 		test( 'should dispatch an action', () => {
-			const getState = () => ( {} );
-			const dispatch = spy();
-			updateOrder( siteId, updatedOrder )( dispatch, getState );
-			expect( dispatch ).to.have.been.calledWith( {
+			const action = saveOrder( siteId, updatedOrder );
+			expect( action ).to.eql( {
 				type: WOOCOMMERCE_ORDER_UPDATE,
-				siteId,
+				siteId: 123,
 				orderId: 40,
+				order: { status: 'completed' },
 			} );
 		} );
 
 		test( 'should dispatch a success action with the order when request completes', () => {
-			const getState = () => ( {} );
-			const dispatch = spy();
-			const response = updateOrder( siteId, updatedOrder )( dispatch, getState );
-
-			return response.then( () => {
-				expect( dispatch ).to.have.been.calledWith( {
-					type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
-					siteId,
-					orderId: 40,
-					order,
-				} );
+			const action = saveOrderSuccess( siteId, 40, updatedOrder );
+			expect( action ).to.eql( {
+				type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
+				siteId: 123,
+				orderId: 40,
+				order: { id: 40, status: 'completed' },
 			} );
 		} );
 
 		test( 'should dispatch a failure action with the error when a the request fails', () => {
-			const getState = () => ( {} );
-			const dispatch = spy();
-			const response = updateOrder( 234, { id: 'invalid' } )( dispatch, getState );
-
-			return response.then( () => {
-				expect( dispatch ).to.have.been.calledWithMatch( {
-					type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
-					siteId: 234,
-				} );
+			const action = saveOrderError( 234, 1, 'Error object' );
+			expect( action ).to.eql( {
+				type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
+				siteId: 234,
+				orderId: 1,
+				error: 'Error object',
 			} );
 		} );
 	} );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -18,7 +18,7 @@ import getRates from './get-rates';
 import { getPrintURL } from 'woocommerce/woocommerce-services/lib/pdf-label-utils';
 import { getShippingLabel, getFormErrors, shouldFulfillOrder, shouldEmailDetails } from './selectors';
 import { createNote } from 'woocommerce/state/sites/orders/notes/actions';
-import { updateOrder } from 'woocommerce/state/sites/orders/actions';
+import { saveOrder } from 'woocommerce/state/sites/orders/actions';
 import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
 
 import {
@@ -605,7 +605,7 @@ const pollForLabelsPurchase = ( orderId, siteId, dispatch, getState, labels ) =>
 	dispatch( purchaseLabelResponse( orderId, siteId, labels, false ) );
 
 	if ( shouldFulfillOrder( getState(), orderId, siteId ) ) {
-		dispatch( updateOrder( siteId, {
+		dispatch( saveOrder( siteId, {
 			id: orderId,
 			status: 'completed',
 		} ) );


### PR DESCRIPTION
This PR switches the `updateOrders` code to use the data-layer to request orders. It also renames the action to `saveOrders`.

**Run the tests:**

- npm run test-client client/extensions/woocommerce/state/data-layer/orders/test/index.js
- npm run test-client client/extensions/woocommerce/state/sites/orders/

**Make sure it still works in calypso**

- View an order, and toggle on editing
- Make a change, save & watch for success notice, editing state should switch off and your updated order displays
- Save an invalid value to test errors: change your billing email to `a@b.c` & save
- Open an order that's pending payment, click "Mark as Paid", should see success notice & see status change
- Click the Submit Refund button and grant a refund, should see success notice, and see refund value appear in totals section
- Click the "Fulfill without printing a label" link on an unfulfilled order & mark fulfilled. Should see success notice & see status change.