### PR TITLE
Components: Fix CSS for phone input field

### DIFF
--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -243,7 +243,9 @@ class PhoneInput extends React.PureComponent {
 					name={ this.props.name }
 					ref={ this.setNumberInputRef }
 					type="tel"
-					className={ classnames( { 'is-error': this.props.isError } ) }
+					className={ classnames( 'phone-input__number-input', {
+						'is-error': this.props.isError,
+					} ) }
 				/>
 				<div className="phone-input__select-container">
 					<div className="phone-input__select-inner-container">

--- a/client/components/phone-input/style.scss
+++ b/client/components/phone-input/style.scss
@@ -65,7 +65,8 @@ select.phone-input__country-select {
 .phone-input {
 	position: relative;
 	width: 100%;
-	input {
+
+	.phone-input__number-input {
 		padding-left: 70px;
 	}
 }


### PR DESCRIPTION
The default CSS for `input[type="tel"]` was overriding the CSS for the phone input component.

Test:
- Buy a domain
- Go to Checkout
- Check phone input field
---------------
- Go to devdocs -> Components
- Check the phone input field

Fixes: https://github.com/Automattic/wp-calypso/issues/20335