### PR TITLE
Store: Update Payment Method Title when changed

### DIFF
--- a/client/extensions/woocommerce/state/ui/payments/methods/selectors.js
+++ b/client/extensions/woocommerce/state/ui/payments/methods/selectors.js
@@ -76,6 +76,11 @@ export const getPaymentMethodsWithEdits = ( state, siteId = getSelectedSiteId( s
 				method.description = update[ updateKey ].value;
 				return;
 			}
+			if ( 'title' === updateKey ) {
+				// Edits to title need to update base title attribute
+				// and settings value too, thus no return here.
+				method.title = update[ updateKey ].value;
+			}
 			method.settings[ updateKey ] = {
 				...method.settings[ updateKey ],
 				value: update[ updateKey ].value,

--- a/client/extensions/woocommerce/state/ui/payments/methods/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/payments/methods/test/selectors.js
@@ -87,6 +87,23 @@ describe( 'selectors', () => {
 			] );
 		} );
 
+		test( 'when title is edited, the base title attribute and settings value should both be updated', () => {
+			siteState.paymentMethods = [
+				{ id: 1, title: 'chicken', settings: { title: { value: 'chicken' } } },
+				{ id: 2, title: 'ribs', settings: { title: { value: 'ribs' } } },
+			];
+			uiState.methods = {
+				creates: [],
+				updates: [ { id: 2, title: { value: 'yummy ribs' } } ],
+				deletes: [],
+				currentlyEditingId: null,
+			};
+			expect( getPaymentMethodsWithEdits( state ) ).to.deep.equal( [
+				{ id: 1, title: 'chicken', settings: { title: { value: 'chicken' } } },
+				{ id: 2, title: 'yummy ribs', settings: { title: { value: 'yummy ribs' } } },
+			] );
+		} );
+
 		test( 'should apply the enabled "edits" changes to the method list', () => {
 			siteState.paymentMethods = [
 				{ id: 1, enabled: false, settings: { name: { value: 'Method1' } } },


### PR DESCRIPTION
Fixes #20217 

Currently when you make a change to a Payment Method title from `/store/settings/SITE` page, the new payment method title is not shown until/if you save and hard refresh the page.

![method-name-no-update](https://user-images.githubusercontent.com/22080/33225197-e770c3de-d127-11e7-9143-b9b00b74556b.gif)

__To Test__
- Visit a site settings page, and click "Setup" on the check payment method ( or "Manage" if enabled )
- Change the title of the payment method, and click the "Done" button in the dialog
- Verify the new title is shown on the Settings page