### PR TITLE
Hide Rewind Status Error message in the Activity Log when Rewind is not active

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -448,9 +448,9 @@ class ActivityLog extends Component {
 			return null;
 		}
 
-		const { rewindStatusError, translate } = this.props;
+		const { isRewindActive, rewindStatusError, translate } = this.props;
 
-		if ( rewindStatusError ) {
+		if ( isRewindActive && rewindStatusError ) {
 			return (
 				<ActivityLogBanner status="error" icon={ null }>
 					{ translate( 'Rewind error: %s', { args: rewindStatusError.message } ) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/20327

As the issue describes, we shouldn't be showing the Rewind status error message for sites that do not have Rewind active. It appears that this message should only show for sites with Rewind active that have an access issue on the back end. This PR simply hides the message if Rewind is not active.

**Testing instructions:**
1. Visit the activity log for a site that does not have an appropriate Jetpack plan. You should see the error message as described in https://github.com/Automattic/wp-calypso/issues/20327.
2. Apply this PR and ensure that the error message is hidden.