### PR TITLE
PostRevisions: Show placeholders for incoming revision items

### DIFF
--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, filter, isEqual, pickBy, without, omit } from 'lodash';
+import { assign, filter, get, isEqual, pickBy, without, omit } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:posts:post-edit-store' );
 import emitter from 'lib/mixins/emitter';
@@ -34,6 +34,8 @@ var _initialRawContent = null,
 	_rawContent = null,
 	_savedPost = null,
 	PostEditStore;
+
+let _revisionIds = [];
 
 function resetState() {
 	debug( 'Reset state' );
@@ -92,6 +94,7 @@ function updatePost( post ) {
 	_post = _savedPost;
 	_isNew = false;
 	_loadingError = null;
+	_revisionIds = get( post, 'revisions', _revisionIds );
 
 	// To ensure that edits made while an update is inflight are not lost, we need to apply them to the updated post.
 	_queue.forEach( function( change ) {
@@ -372,6 +375,10 @@ PostEditStore = {
 
 	isLoading: function() {
 		return _isLoading;
+	},
+
+	getRevisionIds: function() {
+		return _revisionIds;
 	},
 
 	isAutosaving: function() {

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -76,6 +76,20 @@
 	display: inline;
 }
 
+.editor-revisions-list__revision-placeholder {
+	display: block;
+	padding: 8px 16px;
+	border-bottom: 1px solid #d9e3ea;
+	border-right: 1px solid #d9e3ea;
+
+	&:before {
+		content: '';
+		display: block;
+		height: 43px;
+		@include placeholder(23%);
+	}
+}
+
 .editor-revisions-list__load-revision {
 	width: 100%;
 }


### PR DESCRIPTION
### Summary
This PR aims to give a more pleasant experience when opening the revisions modal, particularly when opening for the second time, after making edits in between.

### Current State
Currently when the modal is opened for a second time, with revisions being made since the first open, there are a couple of visual issues resulting from state changing between opening the modal and revisions data being fetched soon after.

Let's say there were 18 revisions shown the last time the modal was opened and 3 revisions have since been made.
When the modal is opened again those 18 revisions from earlier will be shown, no more, no less.
In the background, `<QueryPostRevisions />` will initiate a fetch and will respond with 21 in total, updating the redux state. It's only at that point that the modal will reflect those changes.

As a side effect, we select the 'latest' revision on opening the modal and so number 18 will be selected rather than the true latest, 21.

### Testing
Properly testing this will be quite a long run - sorry in advance!

- First, make up to around 20 revisions (We'll be reaching the limit @ 25).
- Open the revisions modal...
  - You should initially see a placeholder state with one 'placeholder item' in list.
  - Those placeholders should be replaced one the content has loaded.
- Close the revisions modal
- make 4 revisions, taking us to 24 revisions in total
- Open the revisions modal again
  - This time, you should see 4 'placeholder items' in the list, with the previous revisions underneath them.
  - Those placeholders should be individually replaced with the actual revision items.
  - The diff it's self should also be shown in place of the content placeholder.
  - The selection should not be set to first non-placeholder revision, but it should wait and select the latest revision one data has been received for that item.
- Finally, make at least 2 more revisions, pushing the total to 26 or more.
  - Even though the maximum of 25 revision are reached, those final revisions that you made should show as placeholders, as above.