### PR TITLE
WooCommerce: Update auto authorization from slug

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -210,7 +210,7 @@ export class LoggedInForm extends Component {
 	}
 
 	isWoo( { from } = this.props ) {
-		return includes( [ 'woocommerce-setup-wizard', 'woocommerce-services' ], from );
+		return includes( [ 'woocommerce-services-auto-authorize', 'woocommerce-setup-wizard' ], from );
 	}
 
 	shouldRedirectJetpackStart( { partnerId } = this.props ) {


### PR DESCRIPTION
This from slug appears to have been updated in
https://github.com/Automattic/woocommerce-services/pull/1114 but remains
out of date here.

This PR updates the slug according to https://github.com/Automattic/woocommerce-services/pull/1114

Thanks to @marcinbot via https://github.com/Automattic/wp-calypso/pull/19956#issuecomment-347905765

## Testing
See https://github.com/Automattic/woocommerce-services/pull/1114