### PR TITLE
Masterbar: add Tracks events for write / draft clicks, My Sites, Reader, Me

### DIFF
--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -63,6 +63,11 @@ class PreviewToolbar extends Component {
 		this.props.onClose();
 	};
 
+	handleEditorWebPreviewEdit = () => {
+		this.props.recordTracksEvent( 'calypso_editor_preview_edit_click' );
+		this.props.onEdit();
+	};
+
 	constructor( props ) {
 		super();
 
@@ -80,7 +85,6 @@ class PreviewToolbar extends Component {
 			editUrl,
 			externalUrl,
 			isModalWindow,
-			onEdit,
 			previewUrl,
 			setDeviceViewport,
 			showClose,
@@ -137,7 +141,7 @@ class PreviewToolbar extends Component {
 				) }
 				<div className="web-preview__toolbar-actions">
 					{ showEdit && (
-						<Button className="web-preview__edit" href={ editUrl } onClick={ onEdit }>
+						<Button className="web-preview__edit" href={ editUrl } onClick={ this.handleEditorWebPreviewEdit }>
 							{ translate( 'Edit' ) }
 						</Button>
 					) }

--- a/client/layout/masterbar/drafts.jsx
+++ b/client/layout/masterbar/drafts.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import Popover from 'components/popover';
 import Count from 'components/count';
@@ -50,6 +51,11 @@ class MasterbarDrafts extends Component {
 
 	closeDrafts = () => {
 		this.setState( { showDrafts: false } );
+	};
+
+	draftClicked = () => {
+		this.props.recordTracksEvent( 'calypso_masterbar_publish_draft_clicked', {} );
+		this.closeDrafts();
 	};
 
 	render() {
@@ -116,7 +122,7 @@ class MasterbarDrafts extends Component {
 				post={ draft }
 				siteId={ site && site.ID }
 				showAuthor={ site && ! site.single_user_site && ! this.props.userId }
-				onTitleClick={ this.closeDrafts }
+				onTitleClick={ this.draftClicked }
 			/>
 		);
 	}
@@ -142,5 +148,6 @@ export default connect( state => {
 		draftsQuery: draftsQuery,
 		draftCount: myPostCounts && myPostCounts.draft,
 		selectedSite: site,
+		recordTracksEvent,
 	};
 } )( localize( MasterbarDrafts ) );

--- a/client/layout/masterbar/drafts.jsx
+++ b/client/layout/masterbar/drafts.jsx
@@ -153,7 +153,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => ( {
 	recordDraftSelected: () => {
-		dispatch( recordTracksEvent( 'calypso_masterbar_publish_button_draft_selected' ) );
+		dispatch( recordTracksEvent( 'calypso_masterbar_draft_selected' ) );
 	},
 } );
 

--- a/client/layout/masterbar/drafts.jsx
+++ b/client/layout/masterbar/drafts.jsx
@@ -54,7 +54,7 @@ class MasterbarDrafts extends Component {
 	};
 
 	draftClicked = () => {
-		this.props.recordTracksEvent( 'calypso_masterbar_publish_draft_clicked', {} );
+		this.props.recordDraftSelected();
 		this.closeDrafts();
 	};
 
@@ -128,7 +128,7 @@ class MasterbarDrafts extends Component {
 	}
 }
 
-export default connect( state => {
+const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const userId = getCurrentUserId( state );
 	const site = getSelectedSite( state );
@@ -148,6 +148,13 @@ export default connect( state => {
 		draftsQuery: draftsQuery,
 		draftCount: myPostCounts && myPostCounts.draft,
 		selectedSite: site,
-		recordTracksEvent,
 	};
-} )( localize( MasterbarDrafts ) );
+};
+
+const mapDispatchToProps = dispatch => ( {
+	recordDraftSelected: () => {
+		dispatch( recordTracksEvent( 'calypso_masterbar_publish_button_draft_selected' ) );
+	},
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( MasterbarDrafts ) );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -13,6 +13,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { recordTracksEvent } from 'state/analytics/actions';
 import Masterbar from './masterbar';
 import Item from './item';
 import Publish from './publish';
@@ -42,11 +43,17 @@ class MasterbarLoggedIn extends React.Component {
 	};
 
 	clickMySites = () => {
+		this.props.recordTracksEvent( 'calypso_masterbar_my_sites_clicked' );
 		this.props.setNextLayoutFocus( 'sidebar' );
 	};
 
 	clickReader = () => {
+		this.props.recordTracksEvent( 'calypso_masterbar_reader_clicked' );
 		this.props.setNextLayoutFocus( 'content' );
+	};
+
+	clickMe = () => {
+		this.props.recordTracksEvent( 'calypso_masterbar_me_clicked' );
 	};
 
 	isActive = section => {
@@ -112,6 +119,7 @@ class MasterbarLoggedIn extends React.Component {
 					tipTarget="me"
 					url="/me"
 					icon="user-circle"
+					onClick={ this.clickMe }
 					isActive={ this.isActive( 'me' ) }
 					className="masterbar__item-me"
 					tooltip={ translate( 'Update your profile, personal settings, and more', {
@@ -167,5 +175,5 @@ export default connect(
 			domainOnlySite,
 		};
 	},
-	{ setNextLayoutFocus }
+	{ setNextLayoutFocus, recordTracksEvent }
 )( localize( MasterbarLoggedIn ) );

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { recordTracksEvent } from 'state/analytics/actions';
 import MasterbarItem from './item';
 import SitesPopover from 'components/sites-popover';
 import paths from 'lib/paths';
@@ -55,6 +56,10 @@ class MasterbarItemNew extends React.Component {
 		}
 	};
 
+	onSiteSelect = () => {
+		this.props.recordTracksEvent( 'calypso_masterbar_publish_write_clicked', {} );
+	};
+
 	getPopoverPosition = () => {
 		if ( viewport.isMobile() ) {
 			return 'bottom';
@@ -90,6 +95,7 @@ class MasterbarItemNew extends React.Component {
 						visible={ this.state.isShowingPopover }
 						context={ this.state.postButtonContext }
 						onClose={ this.toggleSitesPopover.bind( this, false ) }
+						onSiteSelect={ this.onSiteSelect }
 						groups={ true }
 						position={ this.getPopoverPosition() }
 					/>
@@ -101,5 +107,8 @@ class MasterbarItemNew extends React.Component {
 }
 
 export default connect( state => {
-	return { selectedSite: getSelectedSite( state ) };
+	return {
+		selectedSite: getSelectedSite( state ),
+		recordTracksEvent,
+	};
 } )( MasterbarItemNew );

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -56,10 +56,6 @@ class MasterbarItemNew extends React.Component {
 		}
 	};
 
-	onSiteSelect = () => {
-		this.props.recordTracksEvent( 'calypso_masterbar_publish_write_clicked', {} );
-	};
-
 	getPopoverPosition = () => {
 		if ( viewport.isMobile() ) {
 			return 'bottom';
@@ -95,7 +91,7 @@ class MasterbarItemNew extends React.Component {
 						visible={ this.state.isShowingPopover }
 						context={ this.state.postButtonContext }
 						onClose={ this.toggleSitesPopover.bind( this, false ) }
-						onSiteSelect={ this.onSiteSelect }
+						onSiteSelect={ this.props.siteSelected }
 						groups={ true }
 						position={ this.getPopoverPosition() }
 					/>
@@ -106,9 +102,16 @@ class MasterbarItemNew extends React.Component {
 	}
 }
 
-export default connect( state => {
+const mapStateToProps = state => {
 	return {
 		selectedSite: getSelectedSite( state ),
-		recordTracksEvent,
 	};
-} )( MasterbarItemNew );
+};
+
+const mapDispatchToProps = dispatch => ( {
+	siteSelected: () => {
+		dispatch( recordTracksEvent( 'calypso_masterbar_publish_button_write_clicked' ) );
+	},
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( MasterbarItemNew );

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -110,7 +110,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => ( {
 	siteSelected: () => {
-		dispatch( recordTracksEvent( 'calypso_masterbar_publish_button_write_clicked' ) );
+		dispatch( recordTracksEvent( 'calypso_masterbar_write_button_clicked' ) );
 	},
 } );
 


### PR DESCRIPTION
Add Tracks events for when someone clicks "Write" or chooses a draft from the Masterbar, My Sites, Reader, or Me from the Masterbar, or when someone uses the "Edit" button in Preview. 

To test:
- use `localStorage.debug = 'calypso:analytics:tracks'` to check whether the events fire