### PR TITLE
Update: Use proper module exports in cart-analytics

### DIFF
--- a/client/lib/cart/store/cart-analytics.js
+++ b/client/lib/cart/store/cart-analytics.js
@@ -13,7 +13,7 @@ import analytics from 'lib/analytics';
 import { cartItems } from 'lib/cart-values';
 import { recordAddToCart } from 'lib/analytics/ad-tracking';
 
-function recordEvents( previousCart, nextCart ) {
+export function recordEvents( previousCart, nextCart ) {
 	const previousItems = cartItems.getAll( previousCart ),
 		nextItems = cartItems.getAll( nextCart );
 
@@ -21,7 +21,7 @@ function recordEvents( previousCart, nextCart ) {
 	each( difference( previousItems, nextItems ), recordRemoveEvent );
 }
 
-function removeNestedProperties( cartItem ) {
+export function removeNestedProperties( cartItem ) {
 	return omit( cartItem, [ 'extra' ] );
 }
 
@@ -33,8 +33,3 @@ function recordAddEvent( cartItem ) {
 function recordRemoveEvent( cartItem ) {
 	analytics.tracks.recordEvent( 'calypso_cart_product_remove', removeNestedProperties( cartItem ) );
 }
-
-export default {
-	recordEvents,
-	removeNestedProperties,
-};

--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { assign, flow, flowRight, partialRight } from 'lodash';
 
 /**
@@ -13,7 +11,7 @@ import { action as UpgradesActionTypes } from 'lib/upgrades/constants';
 import emitter from 'lib/mixins/emitter';
 import cartSynchronizer from './cart-synchronizer';
 import PollerPool from 'lib/data-poller';
-import cartAnalytics from './cart-analytics';
+import { recordEvents } from './cart-analytics';
 import productsListFactory from 'lib/products-list';
 const productsList = productsListFactory();
 import Dispatcher from 'dispatcher';
@@ -22,13 +20,13 @@ import wp from 'lib/wp';
 
 const wpcom = wp.undocumented();
 
-var _cartKey = null,
-	_synchronizer = null,
-	_poller = null;
+let _cartKey = null;
+let _synchronizer = null;
+let _poller = null;
 
-var CartStore = {
+const CartStore = {
 	get: function() {
-		var value = hasLoadedFromServer() ? _synchronizer.getLatestValue() : {};
+		const value = hasLoadedFromServer() ? _synchronizer.getLatestValue() : {};
 
 		return assign( {}, value, {
 			hasLoadedFromServer: hasLoadedFromServer(),
@@ -73,18 +71,16 @@ function emitChange() {
 }
 
 function update( changeFunction ) {
-	var wrappedFunction, previousCart, nextCart;
-
-	wrappedFunction = flowRight(
+	const wrappedFunction = flowRight(
 		partialRight( fillInAllCartItemAttributes, productsList.get() ),
 		changeFunction
 	);
 
-	previousCart = CartStore.get();
-	nextCart = wrappedFunction( previousCart );
+	const previousCart = CartStore.get();
+	const nextCart = wrappedFunction( previousCart );
 
 	_synchronizer.update( wrappedFunction );
-	cartAnalytics.recordEvents( previousCart, nextCart );
+	recordEvents( previousCart, nextCart );
 }
 
 function disable() {


### PR DESCRIPTION
@see #18838

This PR updates the export and import syntax around cart-analytics so
that we're not using the non-spec-compliant destructuring import.

After the patch we're using named exports and named imports.

**Testing**

There should be no functional or visual changes in this PR.

If it has an error it would likely fail to build. To be extra sure we can use
the cart; maybe purchase something…