### PR TITLE
Domains: Open transfer support links in new tab

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -130,7 +130,13 @@ class TransferDomainStep extends React.Component {
 									'you can manage your domain and site in the same place. {{a}}Learn More{{/a}}',
 								{
 									components: {
-										a: <a href={ support.INCOMING_DOMAIN_TRANSFER } rel="noopener noreferrer" />,
+										a: (
+											<a
+												href={ support.INCOMING_DOMAIN_TRANSFER }
+												rel="noopener noreferrer"
+												target="_blank"
+											/>
+										),
 									},
 								}
 							) }
@@ -174,6 +180,7 @@ class TransferDomainStep extends React.Component {
 							className="transfer-domain-step__map-help"
 							href={ support.MAP_EXISTING_DOMAIN }
 							rel="noopener noreferrer"
+							target="_blank"
 						>
 							<Gridicon icon="help" size={ 18 } />
 						</a>

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -138,6 +138,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 								<a
 									href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK }
 									rel="noopener noreferrer"
+									target="_blank"
 								/>
 							),
 						},
@@ -188,6 +189,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 						<a
 							href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY }
 							rel="noopener noreferrer"
+							target="_blank"
 						/>
 					),
 				},
@@ -226,6 +228,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 						<a
 							href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_AUTH_CODE }
 							rel="noopener noreferrer"
+							target="_blank"
 						/>
 					),
 				},
@@ -276,7 +279,13 @@ class TransferDomainPrecheck extends React.PureComponent {
 									'Need help? {{a}}Get in touch with one of our Happiness Engineers{{/a}}.',
 								{
 									components: {
-										a: <a href={ support.CALYPSO_CONTACT } rel="noopener noreferrer" />,
+										a: (
+											<a
+												href={ support.CALYPSO_CONTACT }
+												rel="noopener noreferrer"
+												target="_blank"
+											/>
+										),
 									},
 								}
 							) }

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -152,6 +152,7 @@ function getAvailabilityNotice( domain, error ) {
 							<a
 								href={ support.INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
 								rel="noopener noreferrer"
+								target="_blank"
 							/>
 						),
 					},

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -808,6 +808,7 @@ export class DomainWarnings extends React.PureComponent {
 								<a
 									href={ support.INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
 									rel="noopener noreferrer"
+									target="_blank"
 								/>
 							),
 						},

--- a/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
@@ -80,6 +80,7 @@ class InboundTransferEmailVerificationCard extends React.Component {
 								<a
 									href={ support.INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
 									rel="noopener noreferrer"
+									target="_blank"
 								/>
 							),
 							strong: <strong />,

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -101,7 +101,13 @@ class Transfer extends React.PureComponent {
 							{
 								components: {
 									strong: <strong />,
-									a: <a href={ support.INCOMING_DOMAIN_TRANSFER_STATUSES_FAILED } />,
+									a: (
+										<a
+											href={ support.INCOMING_DOMAIN_TRANSFER_STATUSES_FAILED }
+											rel="noopener noreferrer"
+											target="_blank"
+										/>
+									),
 								},
 								args: { domain: domain.name },
 							}


### PR DESCRIPTION
As we don't completely support returning to the previous state from a fresh page load, open these links in new tab.

Fixes: https://github.com/Automattic/wp-calypso/issues/20338