### PR TITLE
Update: Use proper module exports in countries-list

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -17,7 +15,7 @@ import { camelCase, forOwn, kebabCase, mapKeys, values } from 'lodash';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import CreditCardFormFields from 'components/credit-card-form-fields';
-import CountriesList from 'lib/countries-list';
+import { forPayments as countriesList } from 'lib/countries-list';
 import FormButton from 'components/forms/form-button';
 import formState from 'lib/form-state';
 import notices from 'notices';
@@ -26,7 +24,6 @@ import ValidationErrorList from 'notices/validation-error-list';
 import wpcomFactory from 'lib/wp';
 import support from 'lib/url/support';
 
-const countriesList = CountriesList.forPayments();
 const wpcom = wpcomFactory.undocumented();
 
 const CreditCardForm = createReactClass( {

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -35,14 +35,9 @@ import FormTextInputWithAction from 'components/forms/form-text-input-with-actio
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import FormToggle from 'components/forms/form-toggle';
 import PhoneInput from 'components/phone-input';
-
-/**
- * Internal dependencies
- */
-import { forSms } from 'lib/countries-list';
+import { forSms as countriesList } from 'lib/countries-list';
 import { CURRENCIES } from 'lib/format-currency/currencies';
 
-const countriesList = forSms();
 const currencyList = entries( CURRENCIES ).map( ( [ code ] ) => ( { code } ) );
 const visualCurrencyList = entries( CURRENCIES ).map( ( [ code, { symbol } ] ) => ( {
 	code,

--- a/client/extensions/woocommerce/app/order/order-create/customer-card.js
+++ b/client/extensions/woocommerce/app/order/order-create/customer-card.js
@@ -21,8 +21,7 @@ import FormLegend from 'components/forms/form-legend';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import FormTextInput from 'components/forms/form-text-input';
 // @todo Update this to use our store countries list
-import countriesListBuilder from 'lib/countries-list';
-const countriesList = countriesListBuilder.forPayments();
+import { forPayments as countriesList } from 'lib/countries-list';
 
 class OrderCustomerCard extends Component {
 	static propTypes = {

--- a/client/extensions/woocommerce/app/order/order-customer/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-customer/dialog.js
@@ -22,10 +22,8 @@ import FormLegend from 'components/forms/form-legend';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import FormTextInput from 'components/forms/form-text-input';
 import getAddressViewFormat from 'woocommerce/lib/get-address-view-format';
-
 // @todo Update this to use our store countries list
-import countriesListBuilder from 'lib/countries-list';
-const countriesList = countriesListBuilder.forPayments();
+import { forPayments as countriesList } from 'lib/countries-list';
 
 class CustomerAddressDialog extends Component {
 	static propTypes = {

--- a/client/lib/countries-list/README.md
+++ b/client/lib/countries-list/README.md
@@ -8,13 +8,19 @@ The `countries-list` module provides access to localized list of countries as re
 The list of supported countries for domain registrations can be retrieved with:
 
 ```js
-var countriesList = require( 'lib/countries-list' ).forDomainRegistrations();
+import { forDomainRegistrations as countriesList } from 'lib/countries-list';
 ```
 
 The list of supported countries for payments can be retrieved with:
 
 ```js
-var countriesList = require( 'lib/countries-list' ).forPayments();
+import { forPayments as countriesList } from 'lib/countries-list';
+```
+
+The list of supported countries for SMS can be retrieved with:
+
+```js
+import { forSms as countriesList } from 'lib/countries-list';
 ```
 
 ## Methods

--- a/client/lib/countries-list/index.js
+++ b/client/lib/countries-list/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 import inherits from 'inherits';
 import store from 'store';
@@ -165,18 +163,6 @@ SmsCountriesList.prototype.requestFromEndpoint = function( fn ) {
 	return wpcom.getSmsSupportedCountries( fn );
 };
 
-const domainRegistrationCountriesList = new DomainRegistrationCountriesList();
-const paymentCountriesList = new PaymentCountriesList();
-const smsCountriesList = new SmsCountriesList();
-
-export default {
-	forDomainRegistrations: function() {
-		return domainRegistrationCountriesList;
-	},
-	forPayments: function() {
-		return paymentCountriesList;
-	},
-	forSms: function() {
-		return smsCountriesList;
-	},
-};
+export const forDomainRegistrations = new DomainRegistrationCountriesList();
+export const forPayments = new PaymentCountriesList();
+export const forSms = new SmsCountriesList();

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -23,10 +21,9 @@ import Security2faProgress from 'me/security-2fa-progress';
 import analytics from 'lib/analytics';
 import observe from 'lib/mixins/data-observe';
 import { protectForm } from 'lib/protect-form';
-import { forSms } from 'lib/countries-list';
+import { forSms as countriesList } from 'lib/countries-list';
 
 const debug = debugFactory( 'calypso:me:security:2fa-sms-settings' );
-const countriesList = forSms();
 
 const Security2faSMSSettings = createReactClass( {
 	displayName: 'Security2faSMSSettings',

--- a/client/me/security-account-recovery/edit-phone.jsx
+++ b/client/me/security-account-recovery/edit-phone.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -16,11 +14,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormPhoneInput from 'components/forms/form-phone-input';
 import FormInputValidation from 'components/forms/form-input-validation';
 import Buttons from './buttons';
-
-/**
- * Internal dependencies
- */
-var countriesList = require( 'lib/countries-list' ).forSms();
+import { forSms as countriesList } from 'lib/countries-list';
 
 class SecurityAccountRecoveryRecoveryPhoneEdit extends React.Component {
 	static displayName = 'SecurityAccountRecoveryRecoveryPhoneEdit';
@@ -42,11 +36,7 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends React.Component {
 	};
 
 	render() {
-		var validation = null,
-			havePhone = ! isEmpty( this.props.storedPhone );
-		if ( this.state.validation ) {
-			validation = <FormInputValidation isError text={ this.state.validation } />;
-		}
+		const havePhone = ! isEmpty( this.props.storedPhone );
 
 		return (
 			<div>
@@ -60,7 +50,9 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends React.Component {
 						} }
 						onChange={ this.onChange }
 					/>
-					{ validation }
+					{ this.state.validation && (
+						<FormInputValidation isError text={ this.state.validation } />
+					) }
 				</FormFieldset>
 
 				<Buttons
@@ -106,7 +98,7 @@ class SecurityAccountRecoveryRecoveryPhoneEdit extends React.Component {
 	};
 
 	onSave = () => {
-		var phoneNumber = this.state.phoneNumber;
+		const phoneNumber = this.state.phoneNumber;
 
 		if ( ! phoneNumber.isValid ) {
 			this.setState( {

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -38,7 +36,7 @@ import { CountrySelect, Input, HiddenInput } from 'my-sites/domains/components/f
 import PrivacyProtection from './privacy-protection';
 import PaymentBox from './payment-box';
 import { cartItems } from 'lib/cart-values';
-import { forDomainRegistrations as countriesListForDomainRegistrations } from 'lib/countries-list';
+import { forDomainRegistrations as countriesList } from 'lib/countries-list';
 import analytics from 'lib/analytics';
 import formState from 'lib/form-state';
 import {
@@ -64,8 +62,7 @@ import notices from 'notices';
 import support from 'lib/url/support';
 
 const debug = debugFactory( 'calypso:my-sites:upgrades:checkout:domain-details' );
-const wpcom = wp.undocumented(),
-	countriesList = countriesListForDomainRegistrations();
+const wpcom = wp.undocumented();
 
 export class DomainDetailsForm extends PureComponent {
 	constructor( props, context ) {

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -24,7 +22,7 @@ import storeTransactions from 'lib/store-transactions';
 import analytics from 'lib/analytics';
 import TransactionStepsMixin from './transaction-steps-mixin';
 import upgradesActions from 'lib/upgrades/actions';
-import countriesList from 'lib/countries-list';
+import { forPayments as countriesListForPayments } from 'lib/countries-list';
 import debugFactory from 'debug';
 import cartValues, { isPaidForFullyInCredits, isFree, cartItems } from 'lib/cart-values';
 import Notice from 'components/notice';
@@ -35,7 +33,6 @@ import PaymentBox from './payment-box';
  * Module variables
  */
 const { hasFreeTrial } = cartItems;
-const countriesListForPayments = countriesList.forPayments();
 const debug = debugFactory( 'calypso:checkout:payment' );
 
 const SecurePaymentForm = createReactClass( {

--- a/client/my-sites/domains/components/domain-form-fieldsets/g-apps-fieldset.jsx
+++ b/client/my-sites/domains/components/domain-form-fieldsets/g-apps-fieldset.jsx
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */
@@ -12,9 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { CountrySelect, Input } from 'my-sites/domains/components/form';
-import { forDomainRegistrations as countriesListForDomainRegistrations } from 'lib/countries-list';
-
-const countriesList = countriesListForDomainRegistrations();
+import { forDomainRegistrations as countriesList } from 'lib/countries-list';
 
 export class GAppsFieldset extends Component {
 	static propTypes = {

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { deburr, endsWith, get, includes, isEqual, keys, omit, pick, snakeCase } from 'lodash';
@@ -24,7 +22,7 @@ import FormInput from 'my-sites/domains/components/form/input';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
 import ValidationErrorList from 'notices/validation-error-list';
-import countriesListBuilder from 'lib/countries-list';
+import { forDomainRegistrations as countriesList } from 'lib/countries-list';
 import formState from 'lib/form-state';
 import notices from 'notices';
 import paths from 'my-sites/domains/paths';
@@ -37,7 +35,6 @@ import DesignatedAgentNotice from 'my-sites/domains/domain-management/components
 import Dialog from 'components/dialog';
 import { getCurrentUser } from 'state/current-user/selectors';
 
-const countriesList = countriesListBuilder.forDomainRegistrations();
 const wpcom = wp.undocumented();
 
 class EditContactInfoFormCard extends React.Component {


### PR DESCRIPTION
@see #18838

This PR updates the export and import syntax around `lib/countries-list`
so that we're not using the non-spec-compliant destructuring import.

After the patch we're using named exports and named imports.

**Testing**

There should be no functional or visual changes in this PR.

If it has an error it would likely fail to build.
Other than that we can check payment forms, GApps fields,
and 2fa forms to make sure that the countries in the
countries list are working as expected.

Unknown to me is why the original exports were functions which
had to be called to get the underlying values instead of just
directly exporting those functions (late-binding in a sense).
Since the underlying exports were declared as `const` already
there's no chance they could have been re-bound, thus eliminating
any kind of chance for behavioral changes on the late binding
import statements.