### PR TITLE
Domains: Enable Transfer button if TLD present

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -115,6 +115,7 @@ class TransferDomainStep extends React.Component {
 			? this.props.products.domain_map.cost_display
 			: null;
 		const { translate } = this.props;
+		const { searchQuery } = this.state;
 
 		return (
 			<div>
@@ -141,7 +142,7 @@ class TransferDomainStep extends React.Component {
 						<FormTextInputWithAffixes
 							prefix="http://"
 							type="text"
-							value={ this.state.searchQuery }
+							value={ searchQuery }
 							placeholder={ translate( 'example.com' ) }
 							onBlur={ this.save }
 							onChange={ this.setSearchQuery }
@@ -150,7 +151,7 @@ class TransferDomainStep extends React.Component {
 						/>
 					</div>
 					<button
-						disabled={ this.state.searchQuery.length === 0 }
+						disabled={ ! getTld( searchQuery ) }
 						className="transfer-domain-step__go button is-primary"
 						onClick={ this.recordGoButtonClick }
 					>


### PR DESCRIPTION
Don't enable the transfer domain button if the input doesn't resemble a domain. Which means, has a dot and a letter after it.

Test:
- Go to http://calypso.localhost:3000/domains/add/transfer
- Start typing
- Make sure button isn't enabled before you enter something that looks like a domain

Fixes: https://github.com/Automattic/wp-calypso/issues/20337