### PR TITLE
Jetpack connect: Cleanup JPAuthorize reducer

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -51,8 +51,6 @@ const CALYPSO_PLANS_PAGE = '/plans/my-plan/';
 const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';
 
 class Plans extends Component {
-	static defaultProps = { siteSlug: '*' };
-
 	static propTypes = {
 		// Connected props
 		isAutomatedTransfer: PropTypes.bool, // null indicates unknown

--- a/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
@@ -59,11 +59,10 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 			return Object.assign( {}, state, { authorizationCode: action.data.code } );
 
 		case JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST:
-			const updateQueryObject = omit( state.queryObject, '_wp_nonce', 'secret', 'scope' );
-			return Object.assign( {}, omit( state, 'queryObject' ), {
+			return Object.assign( {}, state, {
 				siteReceived: true,
 				isAuthorizing: false,
-				queryObject: updateQueryObject,
+				queryObject: omit( state.queryObject, '_wp_nonce', 'secret', 'scope' ),
 			} );
 
 		case JETPACK_CONNECT_QUERY_SET:

--- a/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
@@ -48,6 +48,7 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 				isRedirectingToWpAdmin: false,
 				autoAuthorize: false,
 			} );
+
 		case JETPACK_CONNECT_AUTHORIZE_RECEIVE:
 			if ( isEmpty( action.error ) && action.data ) {
 				const { plans_url } = action.data;
@@ -65,8 +66,10 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 				authorizeSuccess: false,
 				autoAuthorize: false,
 			} );
+
 		case JETPACK_CONNECT_AUTHORIZE_LOGIN_COMPLETE:
 			return Object.assign( {}, state, { authorizationCode: action.data.code } );
+
 		case JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST:
 			const updateQueryObject = omit( state.queryObject, '_wp_nonce', 'secret', 'scope' );
 			return Object.assign( {}, omit( state, 'queryObject' ), {
@@ -74,19 +77,20 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 				isAuthorizing: false,
 				queryObject: updateQueryObject,
 			} );
+
 		case JETPACK_CONNECT_QUERY_SET:
 			const queryObject = Object.assign( {}, action.queryObject );
 			const shouldAutoAuthorize = includes(
 				[ 'woocommerce-services-auto-authorize', 'woocommerce-setup-wizard' ],
 				queryObject.from
 			);
-			const additionalQueryArgs = shouldAutoAuthorize ? { autoAuthorize: true } : {};
 			return Object.assign(
 				{},
 				buildDefaultAuthorizeState(),
 				{ queryObject },
-				additionalQueryArgs
+				shouldAutoAuthorize && { autoAuthorize: true }
 			);
+
 		case JETPACK_CONNECT_CREATE_ACCOUNT:
 			return Object.assign( {}, state, {
 				isAuthorizing: true,
@@ -94,6 +98,7 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 				authorizeError: false,
 				autoAuthorize: true,
 			} );
+
 		case JETPACK_CONNECT_CREATE_ACCOUNT_RECEIVE:
 			if ( ! isEmpty( action.error ) ) {
 				return Object.assign( {}, state, {
@@ -111,28 +116,37 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 				userData: action.userData,
 				bearerToken: action.data.bearer_token,
 			} );
+
 		case SITE_REQUEST_FAILURE:
 			if (
 				state.queryObject &&
 				state.queryObject.client_id &&
-				parseInt( state.queryObject.client_id ) === action.siteId
+				parseInt( state.queryObject.client_id, 10 ) === action.siteId
 			) {
 				return Object.assign( {}, state, { clientNotResponding: true } );
 			}
 			return state;
+
 		case JETPACK_CONNECT_USER_ALREADY_CONNECTED:
 			return Object.assign( {}, state, { userAlreadyConnected: true } );
+
 		case JETPACK_CONNECT_REDIRECT_XMLRPC_ERROR_FALLBACK_URL:
 			return Object.assign( {}, state, { isRedirectingToWpAdmin: true } );
+
 		case JETPACK_CONNECT_REDIRECT_WP_ADMIN:
 			return Object.assign( {}, state, { isRedirectingToWpAdmin: true } );
+
 		case JETPACK_CONNECT_COMPLETE_FLOW:
 			return {};
+
 		case DESERIALIZE:
 			return ! isStale( state.timestamp, JETPACK_CONNECT_AUTHORIZE_TTL ) ? state : {};
+
 		case SERIALIZE:
 			return state;
 	}
+
 	return state;
 }
+
 jetpackConnectAuthorize.hasCustomPersistence = true;

--- a/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
@@ -73,7 +73,6 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 				queryObject.from
 			);
 			return Object.assign(
-				{},
 				{
 					queryObject: {},
 					isAuthorizing: false,

--- a/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
@@ -26,18 +26,6 @@ import {
 import { isStale } from '../utils';
 import { JETPACK_CONNECT_AUTHORIZE_TTL } from '../constants';
 
-function buildDefaultAuthorizeState() {
-	return {
-		queryObject: {},
-		isAuthorizing: false,
-		authorizeSuccess: false,
-		authorizeError: false,
-		timestamp: Date.now(),
-		userAlreadyConnected: false,
-		autoAuthorize: false,
-	};
-}
-
 export default function jetpackConnectAuthorize( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_AUTHORIZE:
@@ -86,7 +74,15 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 			);
 			return Object.assign(
 				{},
-				buildDefaultAuthorizeState(),
+				{
+					queryObject: {},
+					isAuthorizing: false,
+					authorizeSuccess: false,
+					authorizeError: false,
+					timestamp: Date.now(),
+					userAlreadyConnected: false,
+					autoAuthorize: false,
+				},
 				{ queryObject },
 				shouldAutoAuthorize && { autoAuthorize: true }
 			);

--- a/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
@@ -66,14 +66,13 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 			} );
 
 		case JETPACK_CONNECT_QUERY_SET:
-			const queryObject = Object.assign( {}, action.queryObject );
 			const shouldAutoAuthorize = includes(
 				[ 'woocommerce-services-auto-authorize', 'woocommerce-setup-wizard' ],
-				queryObject.from
+				action.queryObject.from
 			);
 			return Object.assign(
 				{
-					queryObject: {},
+					queryObject: action.queryObject,
 					isAuthorizing: false,
 					authorizeSuccess: false,
 					authorizeError: false,
@@ -81,7 +80,6 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 					userAlreadyConnected: false,
 					autoAuthorize: false,
 				},
-				{ queryObject },
 				shouldAutoAuthorize && { autoAuthorize: true }
 			);
 

--- a/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
@@ -29,7 +29,7 @@ import { JETPACK_CONNECT_AUTHORIZE_TTL } from '../constants';
 export default function jetpackConnectAuthorize( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_AUTHORIZE:
-			return Object.assign( {}, omit( state, 'userData', 'bearerToken' ), {
+			return Object.assign( omit( state, 'userData', 'bearerToken' ), {
 				isAuthorizing: true,
 				authorizeSuccess: false,
 				authorizeError: false,

--- a/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
@@ -2,7 +2,7 @@
 /**
  * External dependencis
  */
-import { includes, isEmpty, omit } from 'lodash';
+import { get, includes, isEmpty, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -68,11 +68,11 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 		case JETPACK_CONNECT_QUERY_SET:
 			const shouldAutoAuthorize = includes(
 				[ 'woocommerce-services-auto-authorize', 'woocommerce-setup-wizard' ],
-				action.queryObject.from
+				get( action, [ 'queryObject', 'from' ] )
 			);
 			return Object.assign(
 				{
-					queryObject: action.queryObject,
+					queryObject: action.queryObject || {},
 					isAuthorizing: false,
 					authorizeSuccess: false,
 					authorizeError: false,
@@ -106,15 +106,11 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 				authorizeError: false,
 				autoAuthorize: true,
 				userData: action.userData,
-				bearerToken: action.data.bearer_token,
+				bearerToken: get( action, [ 'data', 'bearer_token' ] ),
 			} );
 
 		case SITE_REQUEST_FAILURE:
-			if (
-				state.queryObject &&
-				state.queryObject.client_id &&
-				parseInt( state.queryObject.client_id, 10 ) === action.siteId
-			) {
+			if ( parseInt( get( state, [ 'queryObject', 'client_id' ], 0 ), 10 ) === action.siteId ) {
 				return Object.assign( {}, state, { clientNotResponding: true } );
 			}
 			return state;

--- a/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
@@ -148,10 +148,13 @@ describe( '#jetpackConnectAuthorize()', () => {
 		} );
 
 		expect( state ).toMatchObject( {
-			queryObject: {},
-			isAuthorizing: false,
-			authorizeSuccess: false,
 			authorizeError: false,
+			authorizeSuccess: false,
+			autoAuthorize: false,
+			isAuthorizing: false,
+			queryObject: {},
+			timestamp: expect.any( Number ),
+			userAlreadyConnected: false,
 		} );
 	} );
 


### PR DESCRIPTION
Lots of cleanup that doesn't fit into another PR

No functional changes

## Testing
1. Flows continue to work as before (test Jetpack e2e)
1. Visually verify no functional changes
1. Test passing unchanged