### PR TITLE
Jetpack Connect: Simplify free plan selection code

### DIFF
--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -13,6 +13,7 @@ import page from 'page';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
+import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import PlansGrid from './plans-grid';
 import PlansSkipButton from './plans-skip-button';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -67,7 +68,7 @@ class PlansLanding extends Component {
 			plan: cartItem ? cartItem.product_slug : 'free',
 		} );
 
-		storePlan( cartItem ? cartItem.product_slug : 'free' );
+		storePlan( cartItem ? cartItem.product_slug : PLAN_JETPACK_FREE );
 
 		setTimeout( () => {
 			page.redirect( redirectUrl );


### PR DESCRIPTION
Send free plans through the checkout to eliminate the special case.

This changes the flow by leaving users who arrived from wp-admin and selected a free plan at the plan page in Calypso instead of back at wp-admin. This makes free plans consistent with paid plans.