### PR TITLE
Jetpack connect: Speed up /store route if no site supplied

### DIFF
--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -85,11 +85,11 @@ class PlansLanding extends Component {
 	};
 
 	render() {
-		const { basePlansPath, interval, requestingSites, site } = this.props;
+		const { basePlansPath, interval, requestingSites, site, url } = this.props;
 
 		// We're redirecting in componentDidMount if the site is already connected
 		// so don't bother rendering any markup if this is the case
-		if ( site || requestingSites ) {
+		if ( url && ( site || requestingSites ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
Only wait for sites to load if a site param is passed.

## Testing
* Check that /jetpack/connect/store route works as before, with and without a `?site=...` param
* See #18627 for more detailed testing instructions
