### PR TITLE
Add a/b test for new user segment step

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -127,4 +127,12 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	signupSiteSegmentStep: {
+		datestamp: '20170329',
+		variations: {
+			control: 50,
+			variant: 50,
+		},
+		defaultVariation: 'control',
+	},
 };

--- a/client/lib/signup/hint-data.js
+++ b/client/lib/signup/hint-data.js
@@ -22,7 +22,6 @@ export const hints = [
 	'Allergies',
 	'Animals',
 	'Animation',
-	'Animation',
 	'Anime',
 	'Antiques',
 	'Anxiety',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -336,7 +336,7 @@ function filterDesignTypeInFlow( flowName, flow ) {
 		return;
 	}
 
-	if ( abtest( 'signupSiteSegmentStep' ) === 'variant' ) {
+	if ( includes( flow.steps, 'design-type' ) && abtest( 'signupSiteSegmentStep' ) === 'variant' ) {
 		return replaceStepInFlow( flow, 'design-type', 'about' );
 	}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -13,7 +13,7 @@ import i18n from 'i18n-calypso';
 import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
-
+import { abtest } from 'lib/abtest';
 const user = userFactory();
 
 function getCheckoutUrl( dependencies ) {
@@ -334,6 +334,10 @@ function replaceStepInFlow( flow, oldStepName, newStepName ) {
 function filterDesignTypeInFlow( flowName, flow ) {
 	if ( ! flow ) {
 		return;
+	}
+
+	if ( abtest( 'signupSiteSegmentStep' ) === 'variant' ) {
+		return replaceStepInFlow( flow, 'design-type', 'about' );
 	}
 
 	if ( config.isEnabled( 'signup/atomic-store-flow' ) ) {

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -109,7 +109,7 @@ export default {
 
 	about: {
 		stepName: 'about',
-		providesDependencies: [ 'themeSlugWithRepo', 'siteTitle' ],
+		providesDependencies: [ 'designType', 'themeSlugWithRepo', 'siteTitle', 'surveyQuestion' ],
 	},
 
 	user: {

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -292,11 +292,14 @@ class AboutStep extends Component {
 			{
 				processingMessage: translate( 'Collecting your information' ),
 				stepName: stepName,
-				themeRepo,
-				siteTitleValue,
 			},
 			[],
-			{ themeSlugWithRepo: themeRepo, siteTitle: siteTitleValue }
+			{
+				themeSlugWithRepo: themeRepo,
+				siteTitle: siteTitleValue,
+				designType: designType,
+				surveyQuestion: siteTopicInput,
+			}
 		);
 
 		goToNextStep();


### PR DESCRIPTION
This PR creates an A/B test for our new site segment screen outlined here: p5XAZ9-1Cn-p2.

## Testing new user
![image](https://user-images.githubusercontent.com/6981253/33446464-1e0dd292-d5ce-11e7-9011-f309b7b00ceb.png)

`variant`
* Visit `/start` either logged out or in an incognito window
* Ensure a/b test `signupSiteSegmentStep` is set to `variant`
* You should see the new sign up screen pictured above with the last experience question.

`control`
* Visit `/start` either logged out or in an incognito window
* Ensure a/b test `signupSiteSegmentStep` is set to `control`
* You should see [this existing signup screen](https://user-images.githubusercontent.com/1119271/33447501-bfc4e0c0-d5c0-11e7-9765-90341ac3e645.png).

## Testing existing user
![image](https://user-images.githubusercontent.com/6981253/33446811-3fe22a7a-d5cf-11e7-93e4-89ee8f77b72e.png)

* Visit `/start` logged in to an existing account
* Ensure a/b test `signupSiteSegmentStep` is set to `variant`
* You should see the new sign up screen pictured above **without** the last experience question.

@markryall and @taggon can you take a look?