### PR TITLE
Hide checklist on staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -88,7 +88,7 @@
 		"nps-survey/dev-trigger": false,
 		"nps-survey/notice": true,
 		"olark": true,
-		"onboarding-checklist": true,
+		"onboarding-checklist": false,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
The checklist banner was accidentally shipped to our staging environment. This PR hides it for now until we're ready to share it with the company.

cc @taggon 