### PR TITLE
Site settings / jetpack sync: tidy up visually broken notifications

### DIFF
--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -83,7 +83,7 @@ class JetpackSyncPanel extends React.Component {
 		if ( syncStatusErrorCount >= SYNC_STATUS_ERROR_NOTICE_THRESHOLD ) {
 			const adminUrl = get( this.props, 'site.options.admin_url' );
 			errorNotice = (
-				<Notice isCompact status="is-error" className="jetpack-sync-panel__error-notice">
+				<Notice isCompact status="is-error">
 					{ translate( '%(site)s is unresponsive.', {
 						args: {
 							site: get( this.props, 'site.name' ),
@@ -101,7 +101,7 @@ class JetpackSyncPanel extends React.Component {
 			);
 		} else if ( syncRequestError ) {
 			errorNotice = (
-				<Notice isCompact status="is-error" className="jetpack-sync-panel__error-notice">
+				<Notice isCompact status="is-error">
 					{ syncRequestError.message
 						? syncRequestError.message
 						: translate( 'There was an error scheduling a full sync.' ) }
@@ -148,11 +148,7 @@ class JetpackSyncPanel extends React.Component {
 			return null;
 		}
 
-		return (
-			<Notice isCompact className="jetpack-sync-panel__status-notice">
-				{ text }
-			</Notice>
-		);
+		return <div className="jetpack-sync-panel__status-notice">{ text }</div>;
 	};
 
 	renderProgressBar = () => {
@@ -170,12 +166,7 @@ class JetpackSyncPanel extends React.Component {
 				<div className="jetpack-sync-panel__action">
 					{ translate(
 						'Jetpack Sync keeps your WordPress.com dashboard up to date. ' +
-							'Data is sent from your site to the WordPress.com dashboard regularly to provide a faster experience. ',
-						{
-							components: {
-								strong: <strong />,
-							},
-						}
+							'Data is sent from your site to the WordPress.com dashboard regularly to provide a faster experience. '
 					) }
 
 					{ ! this.shouldDisableSync() &&

--- a/client/my-sites/site-settings/jetpack-sync-panel/style.scss
+++ b/client/my-sites/site-settings/jetpack-sync-panel/style.scss
@@ -1,24 +1,13 @@
 .jetpack-sync-panel__action {
 	font-style: italic;
+	margin-bottom: 16px;
 }
 
 .jetpack-sync-panel .progress-bar {
 	margin-top: 8px;
 }
 
-.jetpack-sync-panel .notice {
-	margin-top: 16px;
-}
-
 .jetpack-sync-panel__status-notice {
-	background: none;
 	color: $gray-text-min;
-}
-
-.jetpack-sync-panel .jetpack-sync-panel__status-notice .notice__content {
-	padding-left: 0;
-}
-
-.jetpack-sync-panel__status-notice .notice__icon {
-	display: none;
+	font-size: 12px;
 }


### PR DESCRIPTION
1. Fix visually broken sync notification. Fixes #20356
1. Remove un-used `strong` from that _"Jetpack Sync keeps your WordPress..."_ paragraph. The text [was modified a while back](https://github.com/Automattic/wp-calypso/commit/66faed3383633ade1c11f715dc216eac7f24ad74).
1. Remove non-used `jetpack-sync-panel__error-notice` class

## Screenshots

<p align="center">👈 Before / After 👉</p>

![image](https://user-images.githubusercontent.com/87168/33449315-108e2c5a-d611-11e7-88a0-94a40f9e5312.png)

![image](https://user-images.githubusercontent.com/87168/33449422-63ae80ce-d611-11e7-9d0e-49772d041ede.png)

![image](https://user-images.githubusercontent.com/87168/33449770-72e6bdf8-d612-11e7-8c54-85980205d4bd.png)

I moved the margin CSS rule appearing between notices and _"Jetpack Sync keeps..."_-paragraph from `.notice` to the paragraph element. As a result there is a very short time on page load when empty space under the paragraph is bigger than it was before (screenshot below). When data loads and notice appears it goes back to normal. This is because new "last synced" message isn't `.notice` anymore so I would've needed another `margin-top` rule. Like this CSS is easier to read.

![image](https://user-images.githubusercontent.com/87168/33450667-37797a50-d615-11e7-8a0b-268382d889a7.png)


## Test
1. Have a jetpack connected site
1. Open `/settings/manage-connection/:site`
1. See "synced" notification under "Data synchronization" ✅ 
1. Set your site to error-state (e.g. put it offline or something)
1. Hit "initiate a sync manually", observe error appear ✅ 
1. Put your site back online
1. Refresh and hit "sync manually" again to see progress bar ✅ 