### PR TITLE
Store Promotions: Save product variation sales.

### DIFF
--- a/client/extensions/woocommerce/app/promotions/fields/currency-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/currency-field.js
@@ -39,7 +39,7 @@ CurrencyField.propTypes = {
 	fieldName: PropTypes.string,
 	explanationText: PropTypes.string,
 	placeholderText: PropTypes.string,
-	value: PropTypes.number,
+	value: PropTypes.string,
 	edit: PropTypes.func,
 	currency: PropTypes.string,
 };

--- a/client/extensions/woocommerce/app/promotions/fields/date-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/date-field.js
@@ -35,7 +35,7 @@ const DateField = ( props ) => {
 DateField.propTypes = {
 	fieldName: PropTypes.string,
 	explanationText: PropTypes.string,
-	value: PropTypes.number,
+	value: PropTypes.string,
 	edit: PropTypes.func,
 };
 

--- a/client/extensions/woocommerce/app/promotions/fields/percent-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/percent-field.js
@@ -42,7 +42,7 @@ PercentField.propTypes = {
 	fieldName: PropTypes.string,
 	explanationText: PropTypes.string,
 	placeholderText: PropTypes.string,
-	value: PropTypes.number,
+	value: PropTypes.string,
 	edit: PropTypes.func,
 };
 

--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/applies-to-filtered-list.js
@@ -291,7 +291,7 @@ function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
 	const siteId = ( site ? site.ID : null );
 	const productsLoading = areProductsLoading( state, siteId );
-	const products = getAllProducts( state );
+	const products = ( productsLoading ? null : getAllProducts( state, siteId ) );
 	const productCategories = getProductCategories( state, {}, siteId );
 
 	// TODO: This is temporary, as it's not used anymore.

--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/index.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/index.js
@@ -104,9 +104,10 @@ class PromotionAppliesToField extends React.Component {
 		this.initializeValue( appliesToType );
 	};
 
-	onProductIdChange = ( productId ) => {
+	onProductIdChange = ( productId, parentId ) => {
 		const { edit } = this.props;
 		edit( 'appliesTo', { productIds: [ productId ] } );
+		edit( 'parentId', parentId );
 	};
 
 	onProductIdsChange = ( productIds ) => {

--- a/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/index.js
+++ b/client/extensions/woocommerce/app/promotions/fields/promotion-applies-to-field/index.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import { concat } from 'lodash';
 
 /**
  * Internal dependencies
@@ -104,15 +105,13 @@ class PromotionAppliesToField extends React.Component {
 		this.initializeValue( appliesToType );
 	};
 
-	onProductIdChange = ( productId, parentId ) => {
+	onProductIdsChange = ( productIds, parentId ) => {
 		const { edit } = this.props;
-		edit( 'appliesTo', { productIds: [ productId ] } );
-		edit( 'parentId', parentId );
-	};
 
-	onProductIdsChange = ( productIds ) => {
-		const { edit } = this.props;
-		edit( 'appliesTo', { productIds } );
+		edit( 'appliesTo', { productIds: concat( [], productIds ) } );
+		if ( parentId ) {
+			edit( 'parentId', parentId );
+		}
 	};
 
 	renderProducts = ( appliesTo, singular ) => {
@@ -121,7 +120,7 @@ class PromotionAppliesToField extends React.Component {
 		return (
 			<ProductSearch
 				value={ productIds }
-				onChange={ ( singular ? this.onProductIdChange : this.onProductIdsChange ) }
+				onChange={ this.onProductIdsChange }
 				singular={ singular }
 			/>
 		);

--- a/client/extensions/woocommerce/app/promotions/fields/text-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/text-field.js
@@ -36,7 +36,7 @@ TextField.propTypes = {
 	fieldName: PropTypes.string,
 	explanationText: PropTypes.string,
 	placeholderText: PropTypes.string,
-	value: PropTypes.number,
+	value: PropTypes.string,
 	edit: PropTypes.func,
 };
 

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -91,8 +91,8 @@ class ProductSearch extends Component {
 		this.props.onChange( newValue );
 	};
 
-	onProductRadio = productId => {
-		this.props.onChange( productId );
+	onProductRadio = ( productId, parentId ) => {
+		this.props.onChange( productId, parentId );
 	};
 
 	renderSearch = () => {

--- a/client/extensions/woocommerce/components/product-search/row.js
+++ b/client/extensions/woocommerce/components/product-search/row.js
@@ -123,7 +123,8 @@ class ProductSearchRow extends Component {
 			} );
 			const variationId = get( matchingVariations, '[0].id', false );
 			if ( variationId && ! this.isSelected( variationId ) ) {
-				this.props.onChange( variationId );
+				const { product } = this.props;
+				this.props.onChange( variationId, product.id );
 			}
 			if ( typeof callback === 'function' ) {
 				callback();

--- a/client/extensions/woocommerce/state/data-layer/product-variations/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-variations/index.js
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-
-import { isNumber } from 'lodash';
+import { isNumber, isUndefined, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -91,8 +90,17 @@ export function handleProductVariationUpdate( store, action ) {
 		dispatchWithProps( dispatch, getState, successAction, props );
 	};
 
+	const data = mapValues( variation, value => {
+		// JSON doesn't allow undefined,
+		// so change it to empty string for properties to be removed.
+		if ( isUndefined( value ) ) {
+			return '';
+		}
+		return value;
+	} );
+
 	const endpoint = 'products/' + productId + '/variations/' + variation.id;
-	store.dispatch( put( siteId, endpoint, variation, updatedAction, failureAction ) );
+	store.dispatch( put( siteId, endpoint, data, updatedAction, failureAction ) );
 }
 
 export function handleProductVariationDelete( store, action ) {

--- a/client/extensions/woocommerce/state/data-layer/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { omitBy } from 'lodash';
+import { isUndefined, mapValues, omitBy } from 'lodash';
 import qs from 'querystring';
 import warn from 'lib/warn';
 
@@ -100,8 +100,17 @@ export function handleProductUpdate( { dispatch }, action ) {
 		return;
 	}
 
+	const data = mapValues( product, value => {
+		// JSON doesn't allow undefined,
+		// so change it to empty string for properties to be removed.
+		if ( isUndefined( value ) ) {
+			return '';
+		}
+		return value;
+	} );
+
 	const updatedSuccessAction = updatedAction( siteId, action, successAction, product );
-	dispatch( put( siteId, 'products/' + product.id, product, updatedSuccessAction, failureAction ) );
+	dispatch( put( siteId, 'products/' + product.id, data, updatedSuccessAction, failureAction ) );
 }
 
 export function handleProductRequest( { dispatch }, action ) {

--- a/client/extensions/woocommerce/state/sites/promotions/handlers.js
+++ b/client/extensions/woocommerce/state/sites/promotions/handlers.js
@@ -5,7 +5,7 @@
  */
 
 import debugFactory from 'debug';
-import { isUndefined } from 'lodash';
+import { isNumber, isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,7 +18,10 @@ import {
 	deleteCoupon,
 } from 'woocommerce/state/sites/coupons/actions';
 import { fetchProducts, updateProduct } from 'woocommerce/state/sites/products/actions';
-import { fetchProductVariations } from 'woocommerce/state/sites/product-variations/actions';
+import {
+	fetchProductVariations,
+	updateProductVariation,
+} from 'woocommerce/state/sites/product-variations/actions';
 import {
 	WOOCOMMERCE_COUPONS_UPDATED,
 	WOOCOMMERCE_PRODUCTS_REQUEST_SUCCESS,
@@ -101,8 +104,7 @@ export function promotionCreate( { dispatch }, action ) {
 
 	switch ( promotion.type ) {
 		case 'product_sale':
-			const product = createProductUpdateFromPromotion( promotion );
-			dispatch( updateProduct( siteId, product, action.successAction, action.failureAction ) );
+			updateProductSale( dispatch, siteId, promotion, action.successAction, action.failureAction );
 			break;
 		case 'fixed_cart':
 		case 'fixed_product':
@@ -119,12 +121,7 @@ export function promotionUpdate( { dispatch }, action ) {
 
 	switch ( promotion.type ) {
 		case 'product_sale':
-			const product = createProductUpdateFromPromotion( promotion );
-			if ( product.id !== promotion.productId ) {
-				// This product sale is changing product, so remove it from the previous one.
-				dispatch( clearProductSale( siteId, promotion.productId, null, action.failureAction ) );
-			}
-			dispatch( updateProduct( siteId, product, action.successAction, action.failureAction ) );
+			updateProductSale( dispatch, siteId, promotion, action.successAction, action.failureAction );
 			break;
 		case 'fixed_cart':
 		case 'fixed_product':
@@ -141,9 +138,7 @@ export function promotionDelete( { dispatch }, action ) {
 
 	switch ( promotion.type ) {
 		case 'product_sale':
-			dispatch(
-				clearProductSale( siteId, promotion.productId, action.successAction, action.failureAction )
-			);
+			clearProductSale( dispatch, siteId, promotion, action.successAction, action.failureAction );
 			break;
 		case 'fixed_cart':
 		case 'fixed_product':
@@ -156,13 +151,34 @@ export function promotionDelete( { dispatch }, action ) {
 	}
 }
 
-function clearProductSale( siteId, productId, successAction, failureAction ) {
-	const productUpdateData = {
+function updateProductSale( dispatch, siteId, promotion, successAction, failureAction ) {
+	const { parentId } = promotion;
+	const data = createProductUpdateFromPromotion( promotion );
+
+	if ( data.id !== promotion.productId && isNumber( promotion.productId ) ) {
+		clearProductSale( dispatch, siteId, promotion, null, failureAction );
+	}
+
+	if ( parentId ) {
+		dispatch( updateProductVariation( siteId, parentId, data, successAction, failureAction ) );
+	} else {
+		dispatch( updateProduct( siteId, data, successAction, failureAction ) );
+	}
+}
+
+function clearProductSale( dispatch, siteId, promotion, successAction, failureAction ) {
+	const { parentId, productId } = promotion;
+
+	const data = {
 		id: productId,
 		sale_price: '',
 		date_on_sale_from: null,
 		date_on_sale_to: null,
 	};
 
-	return updateProduct( siteId, productUpdateData, successAction, failureAction );
+	if ( parentId ) {
+		dispatch( updateProductVariation( siteId, productId, data, successAction, failureAction ) );
+	} else {
+		dispatch( updateProduct( siteId, data, successAction, failureAction ) );
+	}
 }


### PR DESCRIPTION
This adds the necessary code to allow saving of product variation sales.

@ryelle I'm adding you specifically because I added an extra parameter to the callback for product search selection, in order to get the parent product id of a variation when it's selected for a single list. I thought about adding it for a checkbox multi-select, but it gets more complicated for that.

To test:
1. Create a new promotion of type "Individual Product Sale"
2. Select a variation of a product, set sale price, and save.
3. From promotions list, select the sale you created.
4. Change the sale price, save.
5. Change the variation to another variation, save.

Additional test steps:
- Try to remove an optional parameter, like end date, etc.