### PR TITLE
Reader: Fix intro overflow in IE

### DIFF
--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -76,7 +76,7 @@
 
 .following__intro .following__intro-copy {
 	display: flex;
-	flex: 1 1 0;
+	flex: 1 1 0px;
 	flex-direction: column;
 	font-size: 18px;
 	justify-content: center;


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/20071

**Before:**
![ie11-intro-box](https://user-images.githubusercontent.com/942359/33086109-b1ab7728-ceb4-11e7-9662-c4e52c886e68.png)

**After:**
![screenshot 2017-11-30 14 20 05](https://user-images.githubusercontent.com/4924246/33458192-1dd7f2e2-d5da-11e7-90c2-99f9d8566787.png)

IE isn't able to interpret flex-basis values without a unit correctly.
