### PR TITLE
Update: Use proper export syntax in current user constants

### DIFF
--- a/client/state/current-user/constants.js
+++ b/client/state/current-user/constants.js
@@ -1,5 +1,4 @@
 /** @format */
-export default {
-	DOMAINS_WITH_PLANS_ONLY: 'calypso_domains_with_plans_only',
-	TRANSFER_IN: 'calypso_transfer_in',
-};
+
+export const DOMAINS_WITH_PLANS_ONLY = 'calypso_domains_with_plans_only';
+export const TRANSFER_IN = 'calypso_transfer_in';


### PR DESCRIPTION
@see #18838

In this PR the exports for `current-user/constants` are updated to use
named exports instead of the non-spec-compliant destructuring import
which Babel allows.

There should be no functional or visual changes in this PR.

Existing imports were using the named import syntax already so this
should be a very minor and low-risk PR.

**Testing**

Should fail on build. Smoke test via domains settings/purchases with an
account having domains-with-plans-only flag set.