### PR TITLE
Update: Use proper module export in pages/helpers

### DIFF
--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -1,78 +1,56 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { assign, forEach, groupBy, includes, map, reduce, sortBy } from 'lodash';
 
 // Helpers used by sortPagesHierarchically but not exposed externally
 const sortByMenuOrder = list => sortBy( list, 'menu_order' );
 const getParentId = page => page.parent && page.parent.ID;
 
-export default {
-	editLinkForPage: function( page, site ) {
-		if ( ! ( page && page.ID ) || ! ( site && site.ID ) ) {
-			return null;
-		}
+export const editLinkForPage = ( { ID: pageId } = {}, { ID: siteId, slug } = {} ) =>
+	pageId && siteId ? `/page/${ slug }/${ pageId }` : null;
 
-		return '/page/' + site.slug + '/' + page.ID;
-	},
+export const statsLinkForPage = ( { ID: pageId } = {}, { ID: siteId, slug } ) =>
+	pageId && siteId ? `/stats/post/${ pageId }/${ slug }` : null;
 
-	statsLinkForPage: function( page, site ) {
-		if ( ! ( page && page.ID ) || ! ( site && site.ID ) ) {
-			return null;
-		}
+// TODO: switch all usage of this function to `isFrontPage` in `state/pages/selectors`
+export const isFrontPage = ( { ID: pageId } = {}, { options } = {} ) =>
+	pageId && options && options.page_on_front === pageId;
 
-		return '/stats/post/' + page.ID + '/' + site.slug;
-	},
+export const sortPagesHierarchically = pages => {
+	const pageIds = map( pages, 'ID' );
 
-	// TODO: switch all usage of this function to `isFrontPage` in `state/pages/selectors`
-	isFrontPage: function( page, site ) {
-		if ( ! page || ! page.ID || ! site || ! site.options ) {
-			return false;
-		}
-		return site.options.page_on_front === page.ID;
-	},
-
-	sortPagesHierarchically: function( pages ) {
-		const pageIds = map( pages, 'ID' );
-
-		const pagesByParent = reduce(
-			groupBy( pages, getParentId ),
-			( result, list, parentId ) => {
-				if (
-					! parentId ||
-					parentId === 'false' ||
-					! includes( pageIds, parseInt( parentId, 10 ) )
-				) {
-					// If we don't have the parent in our list, promote the page to "top level"
-					result.false = sortByMenuOrder( ( result.false || [] ).concat( list ) );
-					return result;
-				}
-
-				result[ parentId ] = sortByMenuOrder( list );
+	const pagesByParent = reduce(
+		groupBy( pages, getParentId ),
+		( result, list, parentId ) => {
+			if ( ! parentId || parentId === 'false' || ! includes( pageIds, parseInt( parentId, 10 ) ) ) {
+				// If we don't have the parent in our list, promote the page to "top level"
+				result.false = sortByMenuOrder( ( result.false || [] ).concat( list ) );
 				return result;
-			},
-			{}
-		);
+			}
 
-		const sortedPages = [];
+			result[ parentId ] = sortByMenuOrder( list );
+			return result;
+		},
+		{}
+	);
 
-		const insertChildren = ( pageId, indentLevel ) => {
-			const children = pagesByParent[ pageId ] || [];
+	const sortedPages = [];
 
-			forEach( children, child => {
-				sortedPages.push( assign( {}, child, { indentLevel } ) );
-				insertChildren( child.ID, indentLevel + 1 );
-			} );
-		};
+	const insertChildren = ( pageId, indentLevel ) => {
+		const children = pagesByParent[ pageId ] || [];
 
-		forEach( pagesByParent.false, topLevelPage => {
-			sortedPages.push( topLevelPage );
-			insertChildren( topLevelPage.ID, 1 );
+		forEach( children, child => {
+			sortedPages.push( assign( {}, child, { indentLevel } ) );
+			insertChildren( child.ID, indentLevel + 1 );
 		} );
+	};
 
-		return sortedPages;
-	},
+	forEach( pagesByParent.false, topLevelPage => {
+		sortedPages.push( topLevelPage );
+		insertChildren( topLevelPage.ID, 1 );
+	} );
+
+	return sortedPages;
 };

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -21,7 +21,7 @@ import Gridicon from 'gridicons';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import SiteIcon from 'blocks/site-icon';
-import helpers from '../helpers';
+import { editLinkForPage, statsLinkForPage } from '../helpers';
 import utils from 'lib/posts/utils';
 import classNames from 'classnames';
 import MenuSeparator from 'components/popover/menu-separator';
@@ -133,7 +133,7 @@ class Page extends Component {
 		// This is technically if you can edit the current page, not the parent.
 		// Capabilities are not exposed on the parent page.
 		const parentHref = utils.userCan( 'edit_post', this.props.page )
-			? helpers.editLinkForPage( page.parent, site )
+			? editLinkForPage( page.parent, site )
 			: page.parent.URL;
 		const parentLink = <a href={ parentHref }>{ parentTitle }</a>;
 
@@ -256,7 +256,7 @@ class Page extends Component {
 
 	statsPage = () => {
 		this.props.recordStatsPage();
-		pageRouter( helpers.statsLinkForPage( this.props.page, this.props.site ) );
+		pageRouter( statsLinkForPage( this.props.page, this.props.site ) );
 	};
 
 	getStatsItem() {
@@ -274,7 +274,7 @@ class Page extends Component {
 
 	editPage = () => {
 		this.props.recordEditPage();
-		pageRouter( helpers.editLinkForPage( this.props.page, this.props.site ) );
+		pageRouter( editLinkForPage( this.props.page, this.props.site ) );
 	};
 
 	getPageStatusInfo() {
@@ -403,7 +403,7 @@ class Page extends Component {
 				<div className="page__main">
 					<a
 						className="page__title"
-						href={ canEdit ? helpers.editLinkForPage( page, site ) : page.URL }
+						href={ canEdit ? editLinkForPage( page, site ) : page.URL }
 						title={
 							canEdit
 								? translate( 'Edit %(title)s', { textOnly: true, args: { title: page.title } } )


### PR DESCRIPTION
@see #18838

In this PR the exports for `my-sites/pages/helpers` is switched to use
proper named export syntax and imports that were previously using the
non-spec-compliant destructuring import syntax have been rewritten
accordingly.

While working in the helpers file I also reduced some logic in the
functions. We need to confirm that the logic changes don't change
behavior.

There should be no functional or visual changes in this change.

**Testing**

Testing should mostly focus on verifyin the logic reductions. It appears
as though the only times these functions should return `null` is maybe
when no site is selected or when we're still waiting to populate state.

Test from the **Pages** page in **My Sites**