### PR TITLE
Themes: fix close search button width

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -52,6 +52,7 @@
 			flex: 0 0 auto;
 			color: darken( $gray, 30% );
 			align-items: center;
+			width: 50px;
 		}
 	}
 


### PR DESCRIPTION
Fixes width of "close search" button at theme search.

Before:
![image](https://user-images.githubusercontent.com/87168/33459876-5f2d2aa0-d634-11e7-8fea-0cdbce505cc5.png)

After:
![image](https://user-images.githubusercontent.com/87168/33459869-57ec1f08-d634-11e7-83f0-c917d2329fbc.png)

Width 50px I picked from [search element](https://github.com/Automattic/wp-calypso/blob/fix/theme-search-close-btn/client/components/search/style.scss#L28).

## Test

See http://calypso.localhost:3000/themes/:site?s=Fixed before and after the fix and confirm close button looks ok in different screen sizes. On very small screen sizes close button is hidden.