### PR TITLE
Build: make sure we process css fully before building client

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "autoprefixer": "postcss -r --use autoprefixer",
     "postcss": "postcss -r -u postcss-custom-properties -u autoprefixer -c postcss.config.json",
     "prebuild": "npm run -s install-if-deps-outdated",
-    "build": "run-p -s build-devdocs:* build-server build-client-if-prod build-client-if-desktop build-css",
+    "build": "npm run build-css && run-p -s build-devdocs:* build-server build-client-if-prod build-client-if-desktop",
     "build-css": "run-p -s build-css:*",
     "build-css:debug": "node-sass --include-path client --source-map \"public/style-debug.css.map\" assets/stylesheets/style.scss public/style-debug.css && npm run -s postcss -- public/style-debug.css && rtlcss public/style-debug.css public/style-debug-rtl.css",
     "build-css:directly": "node-sass --include-path client assets/stylesheets/directly.scss public/directly.css && npm run -s autoprefixer -- public/directly.css",


### PR DESCRIPTION
This PR fixes an issue where we would see two different hashes for a given css section. In our scripts `build-client-if-prod` was run in parallel with `build-css` this often meant that when we were building client, when we hit https://github.com/Automattic/wp-calypso/blob/master/server/bundler/loader.js#L215 we would create a hash using css content that wasn't fully transformed.

I've updated build to finish building css first, before launching the other commands in parallel.

Before:
![screen-shot-2017-11-30-at-1-51-57-pm](https://user-images.githubusercontent.com/1270189/33462849-0010fe42-d5ef-11e7-8e10-9168f0397dd7.png)

After:
![screen shot 2017-11-30 at 5 11 26 pm](https://user-images.githubusercontent.com/1270189/33463298-a7a82066-d5f1-11e7-9e93-eb30f85a93cf.png)

See related #20374

### Testing Instructions
- Build a new docker image with this branch, and start it up. (PCYsg-5XR-p2)
- `npm run build-docker`
- `npm run docker`
- With the container running and your hosts file updated, visit http://wpcalypso.wordpress.com
- Navigate to http://wpcalypso.wordpress.com/post
- Select a site
- Note in network tools that we only see a single hash for post-editor.css
- Verify that the hash matches when hovering over the "write" button in the masterbar.