### PR TITLE
Domains checkout: Remove regional address fields abtest

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -100,16 +100,6 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	domainsCheckoutLocalizedAddresses: {
-		datestamp: '20171025',
-		variations: {
-			showLocalizedAddressFormats: 50,
-			showDefaultAddressFormat: 50,
-		},
-		defaultVariation: 'showDefaultAddressFormat',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	buttonsColorOnPostSignup: {
 		datestamp: '20171108',
 		variations: {

--- a/client/my-sites/domains/components/domain-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/my-sites/domains/components/domain-form-fieldsets/region-address-fieldsets.jsx
@@ -20,7 +20,6 @@ import UsAddressFieldset from './us-address-fieldset';
 import EuAddressFieldset from './eu-address-fieldset';
 import UkAddressFieldset from './uk-address-fieldset';
 import { Input, HiddenInput } from 'my-sites/domains/components/form';
-import { abtest } from 'lib/abtest';
 
 export class RegionAddressFieldsets extends Component {
 	static propTypes = {
@@ -46,11 +45,7 @@ export class RegionAddressFieldsets extends Component {
 	getRegionAddressFieldset() {
 		const { countryCode, hasCountryStates } = this.props;
 
-		// we want to measure the impact of these variations on successful checkout purchases
-		const showDefaultAddressFormat =
-			abtest( 'domainsCheckoutLocalizedAddresses' ) === 'showDefaultAddressFormat';
-
-		if ( ! showDefaultAddressFormat && ! hasCountryStates ) {
+		if ( ! hasCountryStates ) {
 			if ( includes( CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES, countryCode ) ) {
 				return <EuAddressFieldset { ...this.props } />;
 			}

--- a/client/my-sites/domains/components/domain-form-fieldsets/test/region-address-fieldsets.js
+++ b/client/my-sites/domains/components/domain-form-fieldsets/test/region-address-fieldsets.js
@@ -22,9 +22,7 @@ import {
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
 } ) );
-jest.mock( 'lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
+
 describe( 'Region Address Fieldsets', () => {
 	const defaultProps = {
 		getFieldProps: name => ( {


### PR DESCRIPTION
A small PR is to remove the AB test, as the statistical period for testing the effectiveness of regional form fields is complete.

Original implementation: #19088

Regional variations, measured by completed purchases, performed only slightly better for the country codes we looked at (IE, GB, DE, FR, PL, PT, AT), suggesting that it is an innocuous addition, even a teensy, marginal improvement.