### PR TITLE
Components: ShareButton: URL parameters should be encoded.

### DIFF
--- a/client/components/share-button/index.jsx
+++ b/client/components/share-button/index.jsx
@@ -33,8 +33,8 @@ export default class ShareButton extends PureComponent {
 	getUrl() {
 		const template = services[ this.props.service ].url;
 		const args = {
-			URL: this.props.url,
-			TITLE: this.props.title,
+			URL: encodeURIComponent( this.props.url ),
+			TITLE: encodeURIComponent( this.props.title ),
 			SITE_SLUG: this.props.siteSlug,
 		};
 


### PR DESCRIPTION
The URL parameters that passed to ShareButton should be encoded.

## How to test
1. You need to install React Devtools([chrome](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en), [firefox](https://addons.mozilla.org/en-US/firefox/addon/react-devtools/)) first.
2. Open `/devdocs/design/share-button` and select the twitter share button in the dev tool.
3. Replace `and` with `&` in the `title` prop.
![test-plan](https://user-images.githubusercontent.com/212034/33469562-ef87874a-d6a6-11e7-97e6-effed527c2e5.png)
4. Click on the button.
5. The message in the new share window should be `Share your thoughts & ideas on WordPress.com`. It has to contain `&` symbol.