### PR TITLE
Site Settings: Fix logic issue that did not show holiday snow for simple sites

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -459,7 +459,7 @@ const connectComponent = connect(
 		return {
 			siteIsJetpack,
 			siteSlug: getSelectedSiteSlug( state ),
-			supportsHolidaySnowOption: siteIsJetpack && isJetpackMinimumVersion( state, siteId, '4.0' ),
+			supportsHolidaySnowOption: ! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '4.0' ),
 		};
 	},
 	null,


### PR DESCRIPTION
Fixes #20395 

When holiday snow was originally added, it included [this conditional](https://github.com/Automattic/wp-calypso/pull/1210/files#diff-bd0c17b929dd30cb6cd54259cfc10ed8R389) to only show holiday snow on Jetpack sites that supported the option:

```js
if ( site.jetpack && site.versionCompare( '4.0', '<' ) ) {
  return null;
}
```

In this case, if we were managing a simple site, the conditional would return false, so we would skip past it and continue to render the option.

In cfd4c1f31014af9ccb54327e6638741b0df61745, as we updated site settings to use redux instead of sites-list, we modified that logic to be:

```js
supportsHolidaySnowOption: siteIsJetpack && isJetpackMinimumVersion( state, siteId, '4.0' )
```

In this conditional, simple sites will always evaluate to false for the first condition, so holiday snow will not appear for simple sites.

We can change this by using a logic gate:

```js
! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '4.0' )
```

In this case, simple sites will evaluate to true, and we short-circuit and don't evaluate the `isMinimumJetpackVersion` call. But, if the site is a Jetpack site, we then check if it has the minimum version as well.