### PR TITLE
DevDocs: Fix: ConversationCommentList example occurs an error while rendering.

### DIFF
--- a/client/blocks/conversations/docs/example.jsx
+++ b/client/blocks/conversations/docs/example.jsx
@@ -18,6 +18,7 @@ const ConversationCommentListExample = () => {
 	return (
 		<div className="design-assets__group">
 			<ConversationCommentList
+				commentsFetchingStatus={ {} }
 				commentsTree={ commentsTree }
 				blogId={ 123 }
 				postId={ 12 }


### PR DESCRIPTION
This [line of code at](https://github.com/Automattic/wp-calypso/commit/7c4f2b3ef2c12f9f8d865c4b41042591eccb34a2#diff-27bdbf2360c213094ee0784e459c5e29R214) 7c4f2b3ef2c12f9f8d865c4b41042591eccb34a2 assumes that `commentsFetchingStatus` prop is always an object. However, the example passes nothing to the prop and an error occurred while rendering. The console may display the following error:
```
TypeError: Cannot read property 'haveEarlierCommentsToFetch' of undefined
```

Currently the `/devdocs/blocks` shows nothing but error messages due to this bug.

cc @samouri 