### PR TITLE
Components: Fix onClick assignment when not disabled

### DIFF
--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -55,7 +55,7 @@ export default class extends React.PureComponent {
 					icon="cross-small"
 					size={ 24 }
 					className="token-field__remove-token"
-					onClick={ ! this.props.disabled && this._onClickRemove }
+					onClick={ ! this.props.disabled ? this._onClickRemove : undefined }
 				/>
 				{ tooltip && (
 					<Tooltip

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -55,7 +55,7 @@ export default class extends React.PureComponent {
 					icon="cross-small"
 					size={ 24 }
 					className="token-field__remove-token"
-					onClick={ ! this.props.disabled ? this._onClickRemove : undefined }
+					onClick={ ! this.props.disabled ? this._onClickRemove : null }
 				/>
 				{ tooltip && (
 					<Tooltip


### PR DESCRIPTION
This PR fixes the case where we incorrectly assign a `false` to `onClick` in the `Token` field if `this.props.disabled` is `true`. Using React 16 this throws a warning:

![](https://cldup.com/cxchRM-L-P.png)

This PR fixes that case, providing `undefined` instead of `false` in that case.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/devdocs/design/token-fields
* Verify the warning is gone.
* Verify removal of tokens still works properly.