### PR TITLE
Jetpack connect: Fix flash of plans grid

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -107,11 +107,13 @@ class Plans extends Component {
 		const { redirectAfterAuth } = props;
 		if ( redirectAfterAuth ) {
 			props.goBackToWpAdmin( redirectAfterAuth );
+			this.redirecting = true;
+			this.props.completeFlow();
 		} else if ( props.selectedSite ) {
 			this.props.goBackToWpAdmin( props.selectedSite.URL + JETPACK_ADMIN_PATH );
+			this.redirecting = true;
+			this.props.completeFlow();
 		}
-		this.redirecting = true;
-		this.props.completeFlow();
 	}
 
 	redirect( path ) {

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import page from 'page';
 import { connect } from 'react-redux';
-import { get, isEqual, pick } from 'lodash';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -51,16 +51,17 @@ const CALYPSO_PLANS_PAGE = '/plans/my-plan/';
 const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';
 
 class Plans extends Component {
-	static defaultProps = { siteSlug: '*' };
-
 	static propTypes = {
 		// Connected props
 		isAutomatedTransfer: PropTypes.bool, // null indicates unknown
 		hasPlan: PropTypes.bool, // null indicates unknown
 	};
 
+	redirecting = false;
+
 	componentDidMount() {
-		if ( ! this.maybeRedirect( this.props ) ) {
+		this.maybeRedirect( this.props );
+		if ( ! this.redirecting ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_view', {
 				user: this.props.userId,
 			} );
@@ -68,17 +69,7 @@ class Plans extends Component {
 	}
 
 	componentWillReceiveProps = nextProps => {
-		const propsToCompare = [
-			'canPurchasePlans',
-			'hasPlan',
-			'isAutomatedTransfer',
-			'isCalypsoStartedConnection',
-			'notJetpack',
-			'selectedPlan',
-			'selectedPlanSlug',
-		];
-
-		if ( ! isEqual( pick( this.props, propsToCompare ), pick( nextProps, propsToCompare ) ) ) {
+		if ( ! this.redirecting ) {
 			this.maybeRedirect( nextProps );
 		}
 	};
@@ -86,15 +77,12 @@ class Plans extends Component {
 	maybeRedirect = props => {
 		if ( props.isAutomatedTransfer ) {
 			this.props.goBackToWpAdmin( props.selectedSite.URL + JETPACK_ADMIN_PATH );
-			return true;
 		}
 		if ( props.selectedPlanSlug ) {
 			this.autoselectPlan( props );
-			return true;
 		}
 		if ( props.hasPlan || props.notJetpack ) {
 			this.redirect( CALYPSO_PLANS_PAGE );
-			return true;
 		}
 		if ( ! props.canPurchasePlans ) {
 			if ( props.isCalypsoStartedConnection ) {
@@ -102,9 +90,7 @@ class Plans extends Component {
 			} else {
 				this.redirectToWpAdmin( props );
 			}
-			return true;
 		}
-		return false;
 	};
 
 	handleSkipButtonClick = () => {
@@ -124,11 +110,13 @@ class Plans extends Component {
 		} else if ( props.selectedSite ) {
 			this.props.goBackToWpAdmin( props.selectedSite.URL + JETPACK_ADMIN_PATH );
 		}
+		this.redirecting = true;
 		this.props.completeFlow();
 	}
 
 	redirect( path ) {
 		page.redirect( path + this.props.selectedSiteSlug );
+		this.redirecting = true;
 		this.props.completeFlow();
 	}
 
@@ -160,7 +148,6 @@ class Plans extends Component {
 	}
 
 	selectPlan = cartItem => {
-		const checkoutPath = `/checkout/${ this.props.selectedSite.slug }`;
 		clearPlan();
 
 		if ( ! cartItem || cartItem.product_slug === PLAN_JETPACK_FREE ) {
@@ -179,7 +166,7 @@ class Plans extends Component {
 
 		addItem( cartItem );
 		this.props.completeFlow();
-		page.redirect( checkoutPath );
+		this.redirect( '/checkout/' );
 	};
 
 	render() {
@@ -196,6 +183,7 @@ class Plans extends Component {
 		} = this.props;
 
 		if (
+			this.redirecting ||
 			selectedPlanSlug ||
 			notJetpack ||
 			! canPurchasePlans ||


### PR DESCRIPTION
Prevent the plans grid from briefly flashing up when passing through the plans stage of the jetpack connect flow with a preselected plan.

Uses a boolean `redirecting` flag to prevent rendering, and as a simpler way to guard against checking for redirects on subsequent prop changes.

## Testing
* When pre-selecting any option at `/jetpack/connect/store`, or using a flow such as `/jetpack/connect/premium`, you should be taken directly from the auth step to the checkout without seeing the plans grid at all
* All other connection flows should remain unchanged
