### PR TITLE
Framework: Fix wrong createSelector usages

### DIFF
--- a/client/state/help/selectors.js
+++ b/client/state/help/selectors.js
@@ -6,9 +6,8 @@
 
 import { getSelectedOrPrimarySiteId } from 'state/selectors';
 import { getSite } from 'state/sites/selectors';
-import createSelector from 'lib/create-selector';
 
-export const getHelpSiteId = createSelector( state => state.help.selectedSiteId );
+export const getHelpSiteId = state => state.help.selectedSiteId;
 
 export const getHelpSelectedSite = state => {
 	const siteId = getHelpSiteId( state ) || getSelectedOrPrimarySiteId( state );

--- a/client/state/selectors/get-current-locale-slug.js
+++ b/client/state/selectors/get-current-locale-slug.js
@@ -16,8 +16,9 @@ import createSelector from 'lib/create-selector';
  * @param {Object} state - global redux state
  * @return {String} current state value
  */
-const getCurrentLocaleSlug = createSelector( state =>
-	get( state, 'ui.language.localeSlug', null )
+const getCurrentLocaleSlug = createSelector(
+	state => get( state, 'ui.language.localeSlug', null ),
+	state => state.ui.language
 );
 
 export default getCurrentLocaleSlug;

--- a/client/state/selectors/get-past-billing-transaction.js
+++ b/client/state/selectors/get-past-billing-transaction.js
@@ -10,7 +10,7 @@ import { find } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import { getPastBillingTransactions } from './';
+import getPastBillingTransactions from './get-past-billing-transactions';
 
 /**
  * Returns a past billing transaction.

--- a/client/state/selectors/is-jetpack-module-unavailable-in-development-mode.js
+++ b/client/state/selectors/is-jetpack-module-unavailable-in-development-mode.js
@@ -10,7 +10,7 @@ import { includes } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import { getJetpackModulesRequiringConnection } from './';
+import getJetpackModulesRequiringConnection from './get-jetpack-modules-requiring-connection';
 
 /**
  * Returns true if the module is unavailable in development mode. False if not.

--- a/client/state/selectors/test/is-rtl.js
+++ b/client/state/selectors/test/is-rtl.js
@@ -12,7 +12,7 @@ import { isRtl } from '../';
 
 describe( 'isRtl()', () => {
 	test( 'should return null if the value is not known', () => {
-		const result = isRtl( {} );
+		const result = isRtl( { ui: { language: {} } } );
 
 		expect( result ).to.be.null;
 	} );


### PR DESCRIPTION
With @spen we discovered huge flaws in our `createSelector` usages. This branch fixes cases where selectors do not provide their dependents and that means selectors cache will be completely flushed every time **anything** changes in state, regardless of its impact on the selector.

There will be more PRs coming and also measures to prevent this from further happening. 

`getHelpSiteId` - no need for caching. It's a pure object lookup
`getCurrentLocaleSlug` - I made it dependant on the parent object of the value

Last two were interesting: They imported another selector to be passed as `getDependants` but the result of the `import` was actually `undefined` because it was part of a circular chain of imports and that just doesn't work (silently :/)