### PR TITLE
Jetpack connect: Fix interval routes

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -35,7 +35,7 @@ import {
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from 'lib/plans/constants';
-import { retrievePlan, storePlan } from './persistence-utils';
+import { storePlan } from './persistence-utils';
 
 /**
  * Module variables
@@ -129,9 +129,7 @@ export default {
 		debug( 'entered connect flow with params %o', params );
 
 		const planSlug = getPlanSlugFromFlowType( type, interval );
-		if ( planSlug && ! retrievePlan() ) {
-			storePlan( planSlug );
-		}
+		planSlug && storePlan( planSlug );
 
 		analytics.pageView.record( pathname, analyticsPageTitle );
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -89,7 +89,7 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 		},
 	};
 
-	return planSlugs[ interval ][ type ] || '';
+	return get( planSlugs, [ interval, type ], '' );
 };
 
 export default {

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -146,7 +146,7 @@ class JetpackConnectMain extends Component {
 	}
 
 	checkUrl( url ) {
-		return this.props.checkUrl( url, !! this.props.getJetpackSiteByUrl( url ), this.props.type );
+		return this.props.checkUrl( url, !! this.props.getJetpackSiteByUrl( url ) );
 	}
 
 	handleUrlSubmit = () => {

--- a/client/jetpack-connect/persistence-utils.js
+++ b/client/jetpack-connect/persistence-utils.js
@@ -3,12 +3,11 @@
  * External dependencies
  */
 import cookie from 'cookie';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { FLOW_TYPES, JETPACK_CONNECT_TTL_SECONDS } from 'state/jetpack-connect/constants';
+import { JETPACK_CONNECT_TTL_SECONDS } from 'state/jetpack-connect/constants';
 import { urlToSlug } from 'lib/url';
 
 /**
@@ -43,23 +42,4 @@ export const persistSession = url => {
 export const isCalypsoStartedConnection = siteSlug => {
 	const cookies = cookie.parse( document.cookie );
 	return cookies.jetpack_connect_session_url === urlToSlug( siteSlug );
-};
-
-export const clearFlowType = () => {
-	const options = { path: '/' };
-	document.cookie = cookie.serialize( 'jetpack_connect_session_flowtype', '', options );
-};
-
-export const persistFlowType = flowType => {
-	if ( ! includes( FLOW_TYPES, flowType ) ) {
-		clearFlowType();
-		return;
-	}
-	const options = { path: '/' };
-	document.cookie = cookie.serialize( 'jetpack_connect_session_flowtype', flowType, options );
-};
-
-export const retrieveFlowType = () => {
-	const cookies = cookie.parse( document.cookie );
-	return cookies.jetpack_connect_session_flowtype;
 };

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -12,23 +12,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import {
-	clearPlan,
-	isCalypsoStartedConnection,
-	retrieveFlowType,
-	retrievePlan,
-} from './persistence-utils';
+import { clearPlan, isCalypsoStartedConnection, retrievePlan } from './persistence-utils';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import PlansGrid from './plans-grid';
 import PlansSkipButton from './plans-skip-button';
-import {
-	PLAN_JETPACK_FREE,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_BUSINESS,
-} from 'lib/plans/constants';
+import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { addItem } from 'lib/upgrades/actions';
@@ -226,25 +216,13 @@ class Plans extends Component {
 
 export { Plans as PlansTestComponent };
 
-const getPlanSlug = ( flowType, planSlug ) => {
-	const flowTypeToSlug = {
-		personal: PLAN_JETPACK_PERSONAL,
-		premium: PLAN_JETPACK_PREMIUM,
-		pro: PLAN_JETPACK_BUSINESS,
-	};
-
-	return flowTypeToSlug[ flowType ] || planSlug;
-};
-
 export default connect(
 	state => {
 		const user = getCurrentUser( state );
 		const selectedSite = getSelectedSite( state );
 		const selectedSiteSlug = selectedSite ? selectedSite.slug : '';
 
-		const flowType = retrieveFlowType();
-		const preSelectedPlan = retrievePlan();
-		const selectedPlanSlug = getPlanSlug( flowType, preSelectedPlan );
+		const selectedPlanSlug = retrievePlan();
 		const selectedPlan = getPlanBySlug( state, selectedPlanSlug );
 
 		return {

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -50,12 +50,7 @@ import config from 'config';
 import addQueryArgs from 'lib/route/add-query-args';
 import { externalRedirect } from 'lib/route/path';
 import { urlToSlug } from 'lib/url';
-import {
-	clearFlowType,
-	clearPlan,
-	persistFlowType,
-	persistSession,
-} from 'jetpack-connect/persistence-utils';
+import { clearPlan, persistSession } from 'jetpack-connect/persistence-utils';
 import { JPC_PLANS_PAGE } from './constants';
 
 /**
@@ -82,14 +77,13 @@ export function dismissUrl( url ) {
 	};
 }
 
-export function checkUrl( url, isUrlOnSites, flowType ) {
+export function checkUrl( url, isUrlOnSites ) {
 	return dispatch => {
 		if ( _fetching[ url ] ) {
 			return;
 		}
 		if ( isUrlOnSites ) {
 			persistSession( url );
-			persistFlowType( flowType );
 			dispatch( {
 				type: JETPACK_CONNECT_CHECK_URL,
 				url: url,
@@ -115,7 +109,6 @@ export function checkUrl( url, isUrlOnSites, flowType ) {
 		_fetching[ url ] = true;
 		setTimeout( () => {
 			persistSession( url );
-			persistFlowType( flowType );
 			dispatch( {
 				type: JETPACK_CONNECT_CHECK_URL,
 				url: url,
@@ -561,7 +554,6 @@ export function authorizeSSO( siteId, ssoNonce, siteUrl ) {
 export function completeFlow( site ) {
 	return dispatch => {
 		clearPlan();
-		clearFlowType();
 		dispatch( {
 			type: JETPACK_CONNECT_COMPLETE_FLOW,
 			site,


### PR DESCRIPTION
When landing at a route with an plan and an interval, store the appropriate monthly or yearly plan. For example `/jetpack/connect/premium/monthly` will add the _monthly_ premium plan to the cart after auth.

Also remove unused flow type persistence, and persist the plan type from URL in the controller.

## Testing
* Land at a route with an interval and check that the appropriate monthly/yearly plan is in the cart when reaching the checkout at the end of the flow. For example: `/jetpack/connect/pro/monthly`, `/jetpack/connect/personal/yearly`.
