### PR TITLE
WooCommerce - added label price breakdown (promoting the discount)

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -90,7 +90,6 @@ export const getTotalPriceBreakdown = ( state, orderId, siteId = getSelectedSite
 
 	const { values: selectedRates, available: availableRates } = form.rates;
 	const prices = [];
-	let fee = 0;
 	let discount = 0;
 	let total = 0;
 	for ( const packageId in selectedRates ) {
@@ -107,17 +106,14 @@ export const getTotalPriceBreakdown = ( state, orderId, siteId = getSelectedSite
 				retailRate: foundRate.retail_rate,
 			} );
 
-			const rateFee = foundRate.wcs_fee || 0;
 			discount += foundRate.retail_rate - foundRate.rate;
-			fee += rateFee;
-			total += foundRate.rate + rateFee;
+			total += foundRate.rate;
 		}
 	}
 
 	return prices.length ? {
 		prices,
 		discount: discount,
-		fee,
 		total: total,
 	} : null;
 };

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, isEmpty, isEqual, isFinite, mapValues, some } from 'lodash';
+import { find, get, isEmpty, isEqual, isFinite, mapValues, round, some } from 'lodash';
 import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
@@ -106,7 +106,7 @@ export const getTotalPriceBreakdown = ( state, orderId, siteId = getSelectedSite
 				retailRate: foundRate.retail_rate,
 			} );
 
-			discount += foundRate.retail_rate - foundRate.rate;
+			discount += round( foundRate.retail_rate - foundRate.rate, 2 );
 			total += foundRate.rate;
 		}
 	}

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -75,7 +75,7 @@ export const getForm = ( state, orderId, siteId = getSelectedSiteId( state ) ) =
 };
 
 /**
- * Returns a breakdown of the total price for selected labels in form of { prices, discount, fee, total }
+ * Returns a breakdown of the total price for selected labels in form of { prices, discount, total }
  * @param {Object} state global state tree
  * @param {Number} orderId order Id
  * @param {Number} siteId site Id
@@ -94,11 +94,6 @@ export const getTotalPriceBreakdown = ( state, orderId, siteId = getSelectedSite
 	let total = 0;
 	for ( const packageId in selectedRates ) {
 		const packageRates = get( availableRates, [ packageId, 'rates' ], false );
-		//if retail_rate is not set on any rate, then the selector should return null
-		if ( ! packageRates || ! packageRates.length || ! isFinite( packageRates[ 0 ].retail_rate ) ) {
-			return null;
-		}
-
 		const foundRate = find( packageRates, [ 'service_id', selectedRates[ packageId ] ] );
 		if ( foundRate ) {
 			prices.push( {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -22,7 +22,7 @@ import { confirmPrintLabel, purchaseLabel, exitPrintingFlow } from 'woocommerce/
 import {
 	getShippingLabel,
 	isLoaded,
-	getRatesTotal,
+	getTotalPriceBreakdown,
 	getFormErrors,
 	canPurchase,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
@@ -140,6 +140,7 @@ const mapStateToProps = ( state, { orderId, siteId } ) => {
 	const loaded = isLoaded( state, orderId, siteId );
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
 	const storeOptions = loaded ? shippingLabel.storeOptions : {};
+	const priceBreakdown = getTotalPriceBreakdown( state, orderId, siteId );
 	return {
 		loaded,
 		form: loaded && shippingLabel.form,
@@ -148,7 +149,7 @@ const mapStateToProps = ( state, { orderId, siteId } ) => {
 		currency_symbol: storeOptions.currency_symbol,
 		errors: loaded && getFormErrors( state, orderId, siteId ),
 		canPurchase: loaded && canPurchase( state, orderId, siteId ),
-		ratesTotal: getRatesTotal( state, orderId, siteId )
+		ratesTotal: priceBreakdown ? priceBreakdown.total : 0,
 	};
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -18,6 +18,7 @@ import PackagesStep from './packages-step';
 import RatesStep from './rates-step';
 import Sidebar from './sidebar';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import formatCurrency from 'lib/format-currency';
 import { confirmPrintLabel, purchaseLabel, exitPrintingFlow } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 import {
 	getShippingLabel,
@@ -46,14 +47,13 @@ const PurchaseDialog = ( props ) => {
 		const noNativePDFSupport = ( 'addon' === getPDFSupport() );
 
 		if ( props.canPurchase ) {
-			const currencySymbol = props.storeOptions.currency_symbol;
 			const ratesTotal = props.ratesTotal;
 
 			if ( noNativePDFSupport ) {
-				return translate( 'Buy (%(currencySymbol)s%(ratesTotal)s)', { args: { currencySymbol, ratesTotal } } );
+				return translate( 'Buy (%s)', { args: [ formatCurrency( ratesTotal, 'USD' ) ] } );
 			}
 
-			return translate( 'Buy & Print (%(currencySymbol)s%(ratesTotal)s)', { args: { currencySymbol, ratesTotal } } );
+			return translate( 'Buy & Print (%s)', { args: [ formatCurrency( ratesTotal, 'USD' ) ] } );
 		}
 
 		if ( noNativePDFSupport ) {
@@ -78,7 +78,7 @@ const PurchaseDialog = ( props ) => {
 			primary
 			busy={ props.form.isSubmitting }>
 			{ getPurchaseButtonLabel() }
-		</Button> )
+		</Button> ),
 	];
 
 	const onClose = () => props.exitPrintingFlow( props.orderId, props.siteId, false );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import formatCurrency from 'lib/format-currency';
 import {
-	getPriceBreakdown,
+	getTotalPriceBreakdown,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 
 const PriceSummary = ( { priceBreakdown, translate } ) => {
@@ -50,7 +50,7 @@ PriceSummary.propTypes = {
 };
 
 export default connect( ( state, { orderId, siteId } ) => {
-	const priceBreakdown = getPriceBreakdown( state, orderId, siteId );
+	const priceBreakdown = getTotalPriceBreakdown( state, orderId, siteId );
 	return {
 		priceBreakdown,
 	};

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { map, sum } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -21,7 +20,7 @@ const PriceSummary = ( { priceBreakdown, translate } ) => {
 		return null;
 	}
 
-	const renderService = ( itemName, itemCost, key, isTotal ) => {
+	const renderRow = ( itemName, itemCost, key, isTotal ) => {
 		const className = classNames( 'label-purchase-modal__price-item', {
 			'label-purchase-modal__price-item-total': isTotal,
 		} );
@@ -33,15 +32,14 @@ const PriceSummary = ( { priceBreakdown, translate } ) => {
 		);
 	};
 
-	const retailSum = sum( map( priceBreakdown, 'retailRate' ) );
-	const total = sum( map( priceBreakdown, 'rate' ) );
-	const discount = total - retailSum;
+	const { prices, fee, discount, total } = priceBreakdown;
 
 	return (
 		<Card>
-			{ priceBreakdown.map( ( service, index ) => renderService( service.title, service.retailRate, index ) ) }
-			{ 0 > discount ? renderService( translate( 'Your discount' ), discount, 'discount' ) : null }
-			{ renderService( translate( 'Total' ), total, 'total', true ) }
+			{ prices.map( ( service, index ) => renderRow( service.title, service.retailRate, index ) ) }
+			{ 0 < fee ? renderRow( translate( 'Labels fee' ), fee, 'fee' ) : null }
+			{ 0 < discount ? renderRow( translate( 'Your discount' ), -discount, 'discount' ) : null }
+			{ renderRow( translate( 'Total' ), total, 'total', true ) }
 		</Card>
 	);
 };

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { map, sum } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import formatCurrency from 'lib/format-currency';
+import {
+	getPriceBreakdown,
+} from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+
+const PriceSummary = ( { priceBreakdown, translate } ) => {
+	if ( ! priceBreakdown ) {
+		return null;
+	}
+
+	const renderService = ( itemName, itemCost, key, isTotal ) => {
+		const className = classNames( 'label-purchase-modal__price-item', {
+			'label-purchase-modal__price-item-total': isTotal,
+		} );
+		return (
+			<div key={ key } className={ className }>
+				<div className="label-purchase-modal__price-item-name">{ itemName }</div>
+				<div>{ formatCurrency( itemCost, 'USD' ) }</div>
+			</div>
+		);
+	};
+
+	const retailSum = sum( map( priceBreakdown, 'retailRate' ) );
+	const total = sum( map( priceBreakdown, 'rate' ) );
+	const discount = total - retailSum;
+
+	return (
+		<Card>
+			{ priceBreakdown.map( ( service, index ) => renderService( service.title, service.retailRate, index ) ) }
+			{ 0 > discount ? renderService( translate( 'Your discount' ), discount, 'discount' ) : null }
+			{ renderService( translate( 'Total' ), total, 'total', true ) }
+		</Card>
+	);
+};
+
+PriceSummary.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	orderId: PropTypes.number.isRequired,
+};
+
+export default connect( ( state, { orderId, siteId } ) => {
+	const priceBreakdown = getPriceBreakdown( state, orderId, siteId );
+	return {
+		priceBreakdown,
+	};
+} )( localize( PriceSummary ) );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -39,8 +39,28 @@ class PriceSummary extends Component {
 		}
 	};
 
-	renderRow = ( itemName, itemCost, key, isTotal, isDiscount ) => {
+	renderDiscountExplanation = () => {
 		const { translate } = this.props;
+		return (
+			<div className="label-purchase-modal__price-item-help">
+				<Gridicon
+					ref={ this.setTooltipContext }
+					icon="help-outline"
+					onMouseEnter={ this.showTooltip }
+					onMouseLeave={ this.hideTooltip }
+					size={ 18 } />
+				<Tooltip
+					className="label-purchase-modal__price-item-tooltip is-dialog-visible"
+					isVisible={ this.state.tooltipVisible }
+					context={ this.state.tooltipContext } >
+				{ translate( 'WooCommerce Services gives you access to USPS ' +
+					'Commercial Pricing, which is discounted over Retail rates.' ) }
+				</Tooltip>
+			</div>
+		);
+	};
+
+	renderRow = ( itemName, itemCost, key, isTotal, isDiscount ) => {
 		const className = classNames( 'label-purchase-modal__price-item', {
 			'label-purchase-modal__price-item-total': isTotal,
 		} );
@@ -49,22 +69,7 @@ class PriceSummary extends Component {
 				<div className="label-purchase-modal__price-item-name">
 					{ itemName }
 				</div>
-				{ isDiscount &&
-					<div className="label-purchase-modal__price-item-help">
-						<Gridicon
-							ref={ this.setTooltipContext }
-							icon="help-outline"
-							onMouseEnter={ this.showTooltip }
-							onMouseLeave={ this.hideTooltip }
-							size={ 18 } />
-						<Tooltip
-							className="label-purchase-modal__price-item-tooltip is-dialog-visible"
-							isVisible={ this.state.tooltipVisible }
-							context={ this.state.tooltipContext } >
-						{ translate( 'WooCommerce Services gives you access to USPS ' +
-							'Commercial Pricing, which is discounted over Retail rates.' ) }
-						</Tooltip>
-					</div> }
+				{ isDiscount && this.renderDiscountExplanation() }
 				<div className="label-purchase-modal__price-item-amount">{ formatCurrency( itemCost, 'USD' ) }</div>
 			</div>
 		);

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -86,7 +86,7 @@ class PriceSummary extends Component {
 			</Card>
 		);
 	}
-};
+}
 
 PriceSummary.propTypes = {
 	siteId: PropTypes.number.isRequired,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -32,12 +32,11 @@ const PriceSummary = ( { priceBreakdown, translate } ) => {
 		);
 	};
 
-	const { prices, fee, discount, total } = priceBreakdown;
+	const { prices, discount, total } = priceBreakdown;
 
 	return (
 		<Card>
 			{ prices.map( ( service, index ) => renderRow( service.title, service.retailRate, index ) ) }
-			{ 0 < fee ? renderRow( translate( 'Labels fee' ), fee, 'fee' ) : null }
 			{ 0 < discount ? renderRow( translate( 'Your discount' ), -discount, 'discount' ) : null }
 			{ renderRow( translate( 'Total' ), total, 'total', true ) }
 		</Card>

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -19,7 +19,7 @@ import {
 	getShippingLabel,
 	isLoaded,
 	getFormErrors,
-	getRatesTotal,
+	getTotalPriceBreakdown,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
 
@@ -133,12 +133,13 @@ const mapStateToProps = ( state, { orderId, siteId } ) => {
 	const loaded = isLoaded( state, orderId, siteId );
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
 	const storeOptions = loaded ? shippingLabel.storeOptions : {};
+	const priceBreakdown = getTotalPriceBreakdown( state, orderId, siteId );
 	return {
 		...shippingLabel.form.rates,
 		form: shippingLabel.form,
 		currencySymbol: storeOptions.currency_symbol,
 		errors: loaded && getFormErrors( state, orderId, siteId ).rates,
-		ratesTotal: getRatesTotal( state, orderId, siteId ),
+		ratesTotal: priceBreakdown ? priceBreakdown.total : 0,
 		allPackages: getAllPackageDefinitions( state, siteId ),
 	};
 };

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -112,7 +112,6 @@ const RatesStep = ( props ) => {
 				selectedRates={ values }
 				availableRates={ available }
 				updateRate={ updateRateHandler }
-				currencySymbol={ currencySymbol }
 				errors={ errors } />
 		</StepContainer>
 	);

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -13,6 +13,7 @@ import { find, get, isEmpty } from 'lodash';
  */
 import ShippingRates from './list';
 import StepContainer from '../step-container';
+import formatCurrency from 'lib/format-currency';
 import { hasNonEmptyLeaves } from 'woocommerce/woocommerce-services/lib/utils/tree';
 import { toggleStep, updateRate } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 import {
@@ -23,9 +24,13 @@ import {
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
 
-const ratesSummary = ( selectedRates, availableRates, total, currencySymbol, packagesSaved, translate ) => {
+const ratesSummary = ( selectedRates, availableRates, total, packagesSaved, translate ) => {
 	if ( ! packagesSaved ) {
 		return translate( 'Unsaved changes made to packages' );
+	}
+
+	if ( ! total ) {
+		return '';
 	}
 
 	const packageIds = Object.keys( selectedRates );
@@ -38,11 +43,10 @@ const ratesSummary = ( selectedRates, availableRates, total, currencySymbol, pac
 		const rateInfo = find( packageRates, [ 'service_id', selectedRate ] );
 
 		if ( rateInfo ) {
-			return translate( '%(serviceName)s: %(currencySymbol)s%(rate).2f', {
+			return translate( '%(serviceName)s: %(rate)s', {
 				args: {
 					serviceName: rateInfo.title,
-					rate: rateInfo.rate,
-					currencySymbol,
+					rate: formatCurrency( rateInfo.rate, 'USD' ),
 				},
 			} );
 		}
@@ -51,10 +55,9 @@ const ratesSummary = ( selectedRates, availableRates, total, currencySymbol, pac
 	}
 
 	// Otherwise, just show the total
-	return translate( 'Total rate: %(currencySymbol)s%(total)s', {
+	return translate( 'Total rate: %(total)s', {
 		args: {
-			total,
-			currencySymbol,
+			total: formatCurrency( total, 'USD' ),
 		},
 	} );
 };
@@ -87,13 +90,12 @@ const RatesStep = ( props ) => {
 		allPackages,
 		values,
 		available,
-		currencySymbol,
 		errors,
 		expanded,
 		ratesTotal,
 		translate,
 	} = props;
-	const summary = ratesSummary( values, available, ratesTotal, currencySymbol, form.packages.saved, translate );
+	const summary = ratesSummary( values, available, ratesTotal, form.packages.saved, translate );
 
 	const toggleStepHandler = () => props.toggleStep( orderId, siteId, 'rates' );
 	const updateRateHandler = ( packageId, value ) => props.updateRate( orderId, siteId, packageId, value );
@@ -123,7 +125,6 @@ RatesStep.propTypes = {
 	form: PropTypes.object.isRequired,
 	values: PropTypes.object.isRequired,
 	available: PropTypes.object.isRequired,
-	currencySymbol: PropTypes.string.isRequired,
 	errors: PropTypes.object.isRequired,
 	toggleStep: PropTypes.func.isRequired,
 	updateRate: PropTypes.func.isRequired,
@@ -132,12 +133,10 @@ RatesStep.propTypes = {
 const mapStateToProps = ( state, { orderId, siteId } ) => {
 	const loaded = isLoaded( state, orderId, siteId );
 	const shippingLabel = getShippingLabel( state, orderId, siteId );
-	const storeOptions = loaded ? shippingLabel.storeOptions : {};
 	const priceBreakdown = getTotalPriceBreakdown( state, orderId, siteId );
 	return {
 		...shippingLabel.form.rates,
 		form: shippingLabel.form,
-		currencySymbol: storeOptions.currency_symbol,
 		errors: loaded && getFormErrors( state, orderId, siteId ).rates,
 		ratesTotal: priceBreakdown ? priceBreakdown.total : 0,
 		allPackages: getAllPackageDefinitions( state, siteId ),

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -56,7 +56,8 @@ export const ShippingRates = ( {
 		const formError = errors.form && errors.form[ pckgId ];
 
 		packageRates.forEach( ( rateObject ) => {
-			valuesMap[ rateObject.service_id ] = rateObject.title + ' (' + formatCurrency( rateObject.rate, 'USD' ) + ')';
+			valuesMap[ rateObject.service_id ] =
+				rateObject.title + ' (' + formatCurrency( rateObject.rate + ( rateObject.wcs_fee || 0 ), 'USD' ) + ')';
 		} );
 
 		const onRateUpdate = ( value ) => updateRate( pckgId, value );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -13,6 +13,7 @@ import FieldError from 'woocommerce/woocommerce-services/components/field-error'
 import Dropdown from 'woocommerce/woocommerce-services/components/dropdown';
 import Notice from 'components/notice';
 import getPackageDescriptions from '../packages-step/get-package-descriptions';
+import formatCurrency from 'lib/format-currency';
 
 const renderRateNotice = ( translate ) => {
 	return (
@@ -32,7 +33,6 @@ export const ShippingRates = ( {
 		selectedPackages,
 		allPackages,
 		updateRate,
-		currencySymbol,
 		errors,
 		shouldShowRateNotice,
 		translate,
@@ -56,7 +56,7 @@ export const ShippingRates = ( {
 		const formError = errors.form && errors.form[ pckgId ];
 
 		packageRates.forEach( ( rateObject ) => {
-			valuesMap[ rateObject.service_id ] = rateObject.title + ' (' + currencySymbol + Number( rateObject.rate ).toFixed( 2 ) + ')';
+			valuesMap[ rateObject.service_id ] = rateObject.title + ' (' + formatCurrency( rateObject.rate, 'USD' ) + ')';
 		} );
 
 		const onRateUpdate = ( value ) => updateRate( pckgId, value );
@@ -101,7 +101,6 @@ ShippingRates.propTypes = {
 	selectedPackages: PropTypes.object.isRequired,
 	allPackages: PropTypes.object.isRequired,
 	updateRate: PropTypes.func.isRequired,
-	currencySymbol: PropTypes.string.isRequired,
 	errors: PropTypes.object.isRequired,
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/list.js
@@ -57,7 +57,7 @@ export const ShippingRates = ( {
 
 		packageRates.forEach( ( rateObject ) => {
 			valuesMap[ rateObject.service_id ] =
-				rateObject.title + ' (' + formatCurrency( rateObject.rate + ( rateObject.wcs_fee || 0 ), 'USD' ) + ')';
+				rateObject.title + ' (' + formatCurrency( rateObject.rate, 'USD' ) + ')';
 		} );
 
 		const onRateUpdate = ( value ) => updateRate( pckgId, value );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/sidebar.js
@@ -14,6 +14,7 @@ import { getPaperSizes } from 'woocommerce/woocommerce-services/lib/pdf-label-ut
 import Dropdown from 'woocommerce/woocommerce-services/components/dropdown';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
+import PriceSummary from './price-summary';
 import {
 	setEmailDetailsOption,
 	setFulfillOrderOption,
@@ -36,6 +37,7 @@ const Sidebar = ( props ) => {
 
 	return (
 		<div className="label-purchase-modal__sidebar">
+			<PriceSummary siteId={ siteId } orderId={ orderId } />
 			<Dropdown
 				id={ 'paper_size' }
 				valuesMap={ getPaperSizes( form.origin.values.country ) }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -117,3 +117,17 @@
 .label-purchase-modal__step-title {
 	margin: 0 0 0 8px;
 }
+
+.label-purchase-modal__price-item {
+	display: flex;
+	margin-bottom: 8px;
+
+	&.label-purchase-modal__price-item-total {
+		font-weight: bold;
+		margin-bottom: 0;
+	}
+}
+
+.label-purchase-modal__price-item-name {
+	flex-grow: 1;
+}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -128,6 +128,16 @@
 	}
 }
 
-.label-purchase-modal__price-item-name {
+.label-purchase-modal__price-item-help {
+	color: lighten( $gray, 10% );
+	cursor: help;
+
+	svg {
+		margin-top: 2px;
+	}
+}
+
+.label-purchase-modal__price-item-amount {
 	flex-grow: 1;
+	text-align: right;
 }


### PR DESCRIPTION
Work in progress

Fixes #19935

Adds label price breakdown:
<img width="1538" alt="screen shot 2017-12-01 at 16 42 27" src="https://user-images.githubusercontent.com/800604/33493113-fe25e00c-d6b6-11e7-9a1e-9f09cbd20c1b.png">

To test:
* in the label purchase modal, select a rate, or rates for multiple boxes
* verify that the component appears and that it's behaviour is correct
* verify that all the prices shown throughout the modal are correct (total on the purchase button, prices next to the rates)
