### PR TITLE
Fix `Cannot read property 'rtl' of undefined` error while SSRing `/log-in/invalid-locale`

### DIFF
--- a/client/state/selectors/is-rtl.js
+++ b/client/state/selectors/is-rtl.js
@@ -20,5 +20,11 @@ export default function isRtl( state ) {
 		return null;
 	}
 
-	return Boolean( getLanguage( localeSlug ).rtl );
+	const language = getLanguage( localeSlug );
+
+	if ( ! language ) {
+		return null;
+	}
+
+	return Boolean( language.rtl );
 }


### PR DESCRIPTION
This PR fixes a 500 error happening when trying to render the log in page with an invalid locale. For instance:
https://wpcalypso.wordpress.com/log-in/index.php

This is the error printed in this case:
```
TypeError: Cannot read property 'rtl' of undefined
    at isRtl (/Users/tug/Work/Automattic/wp-calypso/build/webpack:/client/state/selectors/is-rtl.js:23:18)
    at serverRender (/Users/tug/Work/Automattic/wp-calypso/build/webpack:/server/render/index.js:147:22)
    at Layer.handle [as handle_request] (/Users/tug/Work/Automattic/wp-calypso/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/tug/Work/Automattic/wp-calypso/node_modules/express/lib/router/route.js:131:13)
    at /Users/tug/Work/Automattic/wp-calypso/build/webpack:/server/isomorphic-routing/index.js:53:4
```

### Testing Instructions
- Boot the branch
- Navigate to http://calypso.localhost:3000/log-in/wp-login.php
- Ensure that the login page is rendered with the default locale (english)

### Reviews
- [ ] Product
- [x] Code
