### PR TITLE
Test: Disable CommonJS to find esmodule problems

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -28,14 +28,5 @@
 				}
 			}
 		]
-	],
-	"env": {
-		"test": {
-			"plugins": [
-				[ "transform-builtin-extend", {
-					"globals": [ "Error" ]
-				} ],
-			]
-		}
-	}
+	]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,12 @@ const shouldMinify = process.env.hasOwnProperty( 'MINIFY_JS' )
 	: ! isDevelopment;
 const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
 
+const babelConfig = JSON.parse( fs.readFileSync( './.babelrc', { encoding: 'utf8' } ) );
+
+babelConfig.presets[ 0 ][ 1 ].modules = false;
+babelConfig.plugins = _.without( babelConfig.plugins, 'add-module-exports' );
+
+
 /**
  * This function scans the /client/extensions directory in order to generate a map that looks like this:
  * {
@@ -63,22 +69,19 @@ function getAliasesForExtensions() {
 
 const babelLoader = {
 	loader: 'babel-loader',
-	options: {
-		cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
-		cacheIdentifier: cacheIdentifier,
-		plugins: [
-			[
-				path.join(
-					__dirname,
-					'server',
-					'bundler',
-					'babel',
-					'babel-plugin-transform-wpcalypso-async'
-				),
-				{ async: config.isEnabled( 'code-splitting' ) },
-			],
-		],
-	},
+	options: Object.assign(
+		{},
+		babelConfig,
+		{
+			babelrc: false,
+			cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
+			cacheIdentifier: cacheIdentifier,
+			plugins: [ [
+				path.join( __dirname, 'server', 'bundler', 'babel', 'babel-plugin-transform-wpcalypso-async' ),
+				{ async: config.isEnabled( 'code-splitting' ) }
+			] ].concat( babelConfig.plugins )
+		}
+	)
 };
 
 const webpackConfig = {


### PR DESCRIPTION
**Do not merge**

This PR can be used to find problematic `import` and `export` statements that are a result of Babel's spec-non-compliant syntax.

Primarily this stems from places where we have

```js
export default { a, b, c }
```

and

```js
import { b } from 'module'
```

We are only permitted to import named modules in esmodule specs but Babel allows us to destructure on import of the default export. We need to update these occurrences before we can turn off CommonJS compilation.