### PR TITLE
Store: Add additional selectors for getting product category info independent of pagination

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/product-categories/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-categories/index.js
@@ -82,12 +82,14 @@ export function handleProductCategoriesSuccess( { dispatch }, action, { data } )
 	}
 
 	const total = headers[ 'X-WP-Total' ];
+	const totalPages = headers[ 'X-WP-TotalPages' ];
 
 	dispatch( {
 		type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_SUCCESS,
 		siteId,
 		data: body,
 		total,
+		totalPages,
 		query,
 	} );
 }

--- a/client/extensions/woocommerce/state/data-layer/product-categories/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-categories/test/index.js
@@ -73,6 +73,7 @@ describe( 'handlers', () => {
 					status: 200,
 					headers: {
 						'X-WP-Total': 1,
+						'X-WP-TotalPages': 1,
 					},
 				},
 			};
@@ -89,6 +90,7 @@ describe( 'handlers', () => {
 				siteId,
 				data: cats,
 				total: 1,
+				totalPages: 1,
 				query: {},
 			} );
 		} );

--- a/client/extensions/woocommerce/state/sites/product-categories/README.md
+++ b/client/extensions/woocommerce/state/sites/product-categories/README.md
@@ -12,7 +12,7 @@ An optional query can be provided. See https://woocommerce.github.io/woocommerce
 
 ## Reducer
 
-Product categories are saved on a per-site basis. All categories are collected in `items`, and there is a query => ID mapping in `queries`. `isQueryLoading` indicates which queries are being requested. `isQueryError` indicates if a query returned an error. `total` tracks the total number of categories, mapped by queries.
+Product categories are saved on a per-site basis. All categories are collected in `items`, and there is a query => ID mapping in `queries`. `isQueryLoading` indicates which queries are being requested. `isQueryError` indicates if a query returned an error. `total` tracks the total number of categories, mapped by queries. `totalPages` returns the total number of results pages for a query.
 
 ```js
 {
@@ -49,6 +49,9 @@ Product categories are saved on a per-site basis. All categories are collected i
 		"total": {
 			'{}': 10,
 		}
+		"totalPages": {
+			'{}': 2,
+		}
 	}
 }
 ```
@@ -74,3 +77,15 @@ Gets a requested product category object from the current state, or null if not 
 ### `getTotalProductCategories( state, query: object, siteId: number )`
 
 Gets the total number of product categories available on a site for a query. Optional `siteId`, will default to the currently selected site.
+
+### `getProductCategoriesLastPage( state, query: object, siteId: number )`
+
+Returns the last page number of results for a query. Optional `siteId`, will default to the currently selected site.
+
+### `areProductCategoriesLoadingIgnoringPage( state, query: object, siteId: number )`
+
+Similar to `areProductCategoriesLoading`, this selector returns if a given request is being loaded for a query, ignoring the page parameter -- meaning this will return if there is a pending request for a certain query on any page of results. Optional `siteId`, will default to the currently selected site.
+
+### `getProductCategoriesIgnoringPage( state, query: object, siteId: number )`
+
+Similar to `getProductCategories`, this selector returns all results from a particular query, across all loaded pages. Optional `siteId`, will default to the currently selected site.

--- a/client/extensions/woocommerce/state/sites/product-categories/reducer.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/reducer.js
@@ -111,10 +111,27 @@ export function total( state = {}, action ) {
 	return state;
 }
 
+/**
+ * Tracks the total number of pages for the current query.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function totalPages( state = 0, action ) {
+	if ( WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_SUCCESS === action.type && action.data ) {
+		const query = getSerializedProductCategoriesQuery( omit( action.query, 'page' ) );
+		return Object.assign( {}, state, { [ query ]: action.totalPages } );
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	isQueryLoading,
 	isQueryError,
 	items,
 	queries,
 	total,
+	totalPages,
 } );

--- a/client/extensions/woocommerce/state/sites/product-categories/reducer.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/reducer.js
@@ -118,7 +118,7 @@ export function total( state = {}, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function totalPages( state = 0, action ) {
+export function totalPages( state = {}, action ) {
 	if ( WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_SUCCESS === action.type && action.data ) {
 		const query = getSerializedProductCategoriesQuery( omit( action.query, 'page' ) );
 		return Object.assign( {}, state, { [ query ]: action.totalPages } );

--- a/client/extensions/woocommerce/state/sites/product-categories/reducer.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/reducer.js
@@ -102,7 +102,7 @@ export function queries( state = {}, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function total( state = 0, action ) {
+export function total( state = {}, action ) {
 	if ( WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_SUCCESS === action.type && action.data ) {
 		const query = getSerializedProductCategoriesQuery( omit( action.query, 'page' ) );
 		return Object.assign( {}, state, { [ query ]: action.total } );

--- a/client/extensions/woocommerce/state/sites/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/selectors.js
@@ -178,7 +178,11 @@ export const getProductCategoriesLastPage = (
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Boolean}       Returns true if currently requesting product categories for a query, excluding all known queried pages.
  */
-export function areProductCategoriesLoadingIgnoringPage( state, query, siteId ) {
+export function areProductCategoriesLoadingIgnoringPage(
+	state,
+	query = {},
+	siteId = getSelectedSiteId( state )
+) {
 	const lastPage = getProductCategoriesLastPage( state, query, siteId );
 	if ( null === lastPage ) {
 		return false;

--- a/client/extensions/woocommerce/state/sites/product-categories/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/reducer.js
@@ -16,7 +16,7 @@ import {
 	WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_SUCCESS,
 	WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_FAILURE,
 } from 'woocommerce/state/action-types';
-import { isQueryLoading, isQueryError, items, queries, total } from '../reducer';
+import { isQueryLoading, isQueryError, items, queries, total, totalPages } from '../reducer';
 import reducer from 'woocommerce/state/sites/reducer';
 
 const cats = [
@@ -64,6 +64,7 @@ describe( 'reducer', () => {
 					page: 1,
 				},
 				total: 2,
+				totalPages: 1,
 				data: [],
 			};
 			const newState = isQueryLoading( { '{}': true }, action );
@@ -89,6 +90,7 @@ describe( 'reducer', () => {
 					page: 1,
 				},
 				total: 2,
+				totalPages: 1,
 				data: cats,
 			};
 
@@ -130,6 +132,7 @@ describe( 'reducer', () => {
 					page: 1,
 				},
 				total: 2,
+				totalPages: 1,
 				dat: cats,
 			};
 			const newState = isQueryError( undefined, action );
@@ -164,6 +167,7 @@ describe( 'reducer', () => {
 					page: 1,
 				},
 				total: 3,
+				totalPages: 1,
 				data: cats,
 			};
 			const newState = items( undefined, action );
@@ -179,6 +183,7 @@ describe( 'reducer', () => {
 					page: 2,
 				},
 				total: 2,
+				totalPages: 2,
 				data: [ anotherCat ],
 			};
 			const originalState = deepFreeze( keyBy( cats, 'id' ) );
@@ -226,6 +231,7 @@ describe( 'reducer', () => {
 					page: 1,
 				},
 				total: 1,
+				totalPages: 1,
 				data: cats,
 			};
 			const newState = queries( undefined, action );
@@ -240,6 +246,7 @@ describe( 'reducer', () => {
 					page: 2,
 				},
 				total: 2,
+				totalPages: 2,
 				data: [ anotherCat ],
 			};
 			const originalState = deepFreeze( { '{}': [ 10 ] } );
@@ -275,6 +282,7 @@ describe( 'reducer', () => {
 					page: 1,
 				},
 				total: 2,
+				totalPages: 1,
 				data: cats,
 			};
 			const newState = total( undefined, action );
@@ -292,6 +300,41 @@ describe( 'reducer', () => {
 			};
 			const originalState = deepFreeze( { '{}': 2 } );
 			const newState = total( originalState, action );
+			expect( newState ).to.eql( originalState );
+		} );
+	} );
+	describe( 'totalPages', () => {
+		test( 'should have no change by default', () => {
+			const newState = totalPages( undefined, {} );
+			expect( newState ).to.eql( 0 );
+		} );
+
+		test( 'should store the total number of pages when a request loads', () => {
+			const action = {
+				type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_SUCCESS,
+				siteId: 123,
+				query: {
+					page: 1,
+				},
+				total: 2,
+				totalPages: 1,
+				data: cats,
+			};
+			const newState = totalPages( undefined, action );
+			expect( newState ).to.eql( { '{}': 1 } );
+		} );
+
+		test( 'should do nothing on a failure', () => {
+			const action = {
+				type: WOOCOMMERCE_PRODUCT_CATEGORIES_REQUEST_FAILURE,
+				siteId: 123,
+				query: {
+					page: 1,
+				},
+				error: '',
+			};
+			const originalState = deepFreeze( { '{}': 2 } );
+			const newState = totalPages( originalState, action );
 			expect( newState ).to.eql( originalState );
 		} );
 	} );

--- a/client/extensions/woocommerce/state/sites/product-categories/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/reducer.js
@@ -306,7 +306,7 @@ describe( 'reducer', () => {
 	describe( 'totalPages', () => {
 		test( 'should have no change by default', () => {
 			const newState = totalPages( undefined, {} );
-			expect( newState ).to.eql( 0 );
+			expect( newState ).to.eql( {} );
 		} );
 
 		test( 'should store the total number of pages when a request loads', () => {

--- a/client/extensions/woocommerce/state/sites/product-categories/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/reducer.js
@@ -264,7 +264,7 @@ describe( 'reducer', () => {
 	describe( 'total', () => {
 		test( 'should have no change by default', () => {
 			const newState = total( undefined, {} );
-			expect( newState ).to.eql( 0 );
+			expect( newState ).to.eql( {} );
 		} );
 
 		test( 'should store the total number of categories when a request loads', () => {

--- a/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
@@ -14,6 +14,9 @@ import {
 	areProductCategoriesLoaded,
 	areProductCategoriesLoading,
 	getTotalProductCategories,
+	getProductCategoriesLastPage,
+	areProductCategoriesLoadingIgnoringPage,
+	getProductCategoriesIgnoringPage,
 } from '../selectors';
 
 const preInitializedState = {
@@ -33,6 +36,17 @@ const loadingState = {
 						},
 					},
 				},
+				345: {
+					productCategories: {
+						isQueryLoading: {
+							'{}': false,
+							'{"page":2}': true,
+						},
+						totalPages: {
+							'{}': 2,
+						},
+					},
+				},
 			},
 		},
 	},
@@ -44,6 +58,9 @@ const loadedState = {
 			sites: {
 				123: {
 					productCategories: {
+						isQueryLoading: {
+							'{}': false,
+						},
 						items: {
 							1: { id: 1, name: 'cat1', slug: 'cat-1' },
 							2: { id: 2, name: 'cat2', slug: 'cat-2' },
@@ -54,18 +71,31 @@ const loadedState = {
 						total: {
 							'{}': 2,
 						},
+						totalPages: {
+							'{}': 1,
+						},
 					},
 				},
 				345: {
 					productCategories: {
+						isQueryLoading: {
+							'{}': false,
+							'{"page":2}': false,
+						},
 						items: {
 							3: { id: 3, name: 'cat3', slug: 'cat-3' },
 							4: { id: 4, name: 'cat4', slug: 'cat-4' },
+							5: { id: 5, name: 'cat5', slug: 'cat-5' },
+							6: { id: 6, name: 'cat6', slug: 'cat-6' },
 						},
 						queries: {
 							'{}': [ 3, 4 ],
+							'{"page":2}': [ 5, 6 ],
 						},
 						total: {
+							'{}': 4,
+						},
+						totalPages: {
 							'{}': 2,
 						},
 					},
@@ -192,6 +222,65 @@ describe( 'selectors', () => {
 
 		test( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( getTotalProductCategories( loadedStateWithUi ) ).to.eql( 2 );
+		} );
+	} );
+
+	describe( '#getProductCategoriesLastPage', () => {
+		test( 'should be null (default) when woocommerce state is not available.', () => {
+			expect( getProductCategoriesLastPage( preInitializedState, {}, 123 ) ).to.eql( null );
+		} );
+
+		test( 'should be null (default) when categories are loading.', () => {
+			expect( getProductCategoriesLastPage( loadingState, {}, 123 ) ).to.eql( null );
+		} );
+
+		test( 'should be 2, the set total, if the categories are loaded.', () => {
+			expect( getProductCategoriesLastPage( loadedState, {}, 345 ) ).to.eql( 2 );
+		} );
+
+		test( 'should be null (default) when categories are loaded only for a different site.', () => {
+			expect( getProductCategoriesLastPage( loadedState, {}, 456 ) ).to.eql( null );
+		} );
+	} );
+
+	describe( '#areProductCategoriesLoadingIgnoringPage', () => {
+		test( 'should be false when state is not available.', () => {
+			expect( areProductCategoriesLoadingIgnoringPage( preInitializedState, {}, 123 ) ).to.be.false;
+		} );
+
+		test( 'should be true when categories are currently being fetched.', () => {
+			expect( areProductCategoriesLoadingIgnoringPage( loadingState, {}, 345 ) ).to.be.true;
+		} );
+
+		test( 'should be false when categories are loaded.', () => {
+			expect( areProductCategoriesLoadingIgnoringPage( loadedState, {}, 123 ) ).to.be.false;
+		} );
+
+		test( 'should be false when categories are loaded only for a different site.', () => {
+			expect( areProductCategoriesLoadingIgnoringPage( loadedState, {}, 456 ) ).to.be.false;
+		} );
+	} );
+
+	describe( '#getProductCategoriesIgnoringPage()', () => {
+		test( 'should return an empty array if data is not available.', () => {
+			expect( getProductCategoriesIgnoringPage( preInitializedState, {}, 123 ) ).to.eql( [] );
+		} );
+
+		test( 'should return an empty array if data is still loading.', () => {
+			expect( getProductCategoriesIgnoringPage( loadingState, {}, 324 ) ).to.eql( [] );
+		} );
+
+		test( 'should gET ALL product categories from specified site', () => {
+			expect( getProductCategoriesIgnoringPage( loadedState, {}, 123 ) ).to.eql( [
+				{ id: 1, name: 'cat1', slug: 'cat-1' },
+				{ id: 2, name: 'cat2', slug: 'cat-2' },
+			] );
+			expect( getProductCategoriesIgnoringPage( loadedState, {}, 345 ) ).to.eql( [
+				{ id: 3, name: 'cat3', slug: 'cat-3' },
+				{ id: 4, name: 'cat4', slug: 'cat-4' },
+				{ id: 5, name: 'cat5', slug: 'cat-5' },
+				{ id: 6, name: 'cat6', slug: 'cat-6' },
+			] );
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/test/selectors.js
@@ -252,6 +252,11 @@ describe( 'selectors', () => {
 			expect( areProductCategoriesLoadingIgnoringPage( loadingState, {}, 345 ) ).to.be.true;
 		} );
 
+		test( 'should be true when categories are currently being fetched, and passed a page parameter.', () => {
+			expect( areProductCategoriesLoadingIgnoringPage( loadingState, { page: 1 }, 345 ) ).to.be
+				.true;
+		} );
+
 		test( 'should be false when categories are loaded.', () => {
 			expect( areProductCategoriesLoadingIgnoringPage( loadedState, {}, 123 ) ).to.be.false;
 		} );
@@ -270,12 +275,18 @@ describe( 'selectors', () => {
 			expect( getProductCategoriesIgnoringPage( loadingState, {}, 324 ) ).to.eql( [] );
 		} );
 
-		test( 'should gET ALL product categories from specified site', () => {
+		test( 'should get all product categories from specified site', () => {
 			expect( getProductCategoriesIgnoringPage( loadedState, {}, 123 ) ).to.eql( [
 				{ id: 1, name: 'cat1', slug: 'cat-1' },
 				{ id: 2, name: 'cat2', slug: 'cat-2' },
 			] );
 			expect( getProductCategoriesIgnoringPage( loadedState, {}, 345 ) ).to.eql( [
+				{ id: 3, name: 'cat3', slug: 'cat-3' },
+				{ id: 4, name: 'cat4', slug: 'cat-4' },
+				{ id: 5, name: 'cat5', slug: 'cat-5' },
+				{ id: 6, name: 'cat6', slug: 'cat-6' },
+			] );
+			expect( getProductCategoriesIgnoringPage( loadedState, { page: 1 }, 345 ) ).to.eql( [
 				{ id: 3, name: 'cat3', slug: 'cat-3' },
 				{ id: 4, name: 'cat4', slug: 'cat-4' },
 				{ id: 5, name: 'cat5', slug: 'cat-5' },


### PR DESCRIPTION
This PR is a follow-up to #20420, and adds some additional selectors.

These additional selectors are patterned off of some of the [core term/taxonomy](https://github.com/Automattic/wp-calypso/blob/5f15f3365213253724ca0d8798c6cb8160f00bc9/client/state/terms/selectors.js) selectors. They provide a way to get result and loading state data for all requests made against a specific query. Put another way, if multiple pages of results are loaded, these selectors give us easy access to the loaded product categories, without having to use selectors against each page of results manually. I'm using this to build out #20295.

To Test:

* Make sure all tests pass: `npm run test-client client/extensions/woocommerce/state/`
* You can also spot check promotions and product management per #20420, but this PR shouldn't affect anything since it just adds additional selectors.