### PR TITLE
Components: Introduce TileGrid and Tile components

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -218,6 +218,7 @@
 @import 'components/theme/style';
 @import 'components/themes-list/style';
 @import 'components/tinymce/style';
+@import 'components/tile-grid/style';
 @import 'components/title-format-editor/style';
 @import 'components/token-field/style';
 @import 'components/pagination/style';

--- a/client/components/tile-grid/README.md
+++ b/client/components/tile-grid/README.md
@@ -1,0 +1,49 @@
+TileGrid (jsx)
+==========
+
+Component used to declare an area for displaying Tiles — it's the main wrapper that takes care of tile alignment and positioning.
+
+#### Props
+
+* `className`: Add your own class to the grid.
+* `isHidden`: Whether the entire grid should be hidden. Default is `false`.
+
+----------
+
+Tile (jsx)
+==========
+
+Component used to display a clickable tile with an image, call to action and description.
+
+#### Props
+
+* `buttonLabel`: Text of the button.
+* `className`: Add your own class to the tile.
+* `description`: Description text.
+* `href`: URL that the item leads to upon click.
+* `image`: URL of the image.
+* `onClick`: Function, executed when the user clicks the tile,
+
+----------
+
+#### How to use:
+
+```js
+import Tile from 'components/tile-grid/tile';
+import TileGrid from 'components/tile-grid';
+
+class MyExampleComponent extends Component {
+	render() {
+		return (
+			<TileGrid>
+				<Tile
+					buttonLabel={ 'Start with a blog' }
+					description={ 'To share your ideas, stories, and photographs with your followers.' }
+					image={ '/calypso/images/illustrations/type-blog.svg' }
+					href={ 'https://wordpress.com/start' }
+				/>
+			</TileGrid>
+		);
+	}
+}
+```

--- a/client/components/tile-grid/README.md
+++ b/client/components/tile-grid/README.md
@@ -17,6 +17,7 @@ Component used to display a clickable tile with an image, call to action and des
 
 #### Props
 
+* `buttonClassName`: Add your own class to the tile button.
 * `buttonLabel`: Text of the button.
 * `className`: Add your own class to the tile.
 * `description`: Description text.

--- a/client/components/tile-grid/README.md
+++ b/client/components/tile-grid/README.md
@@ -12,7 +12,7 @@ Component used to declare an area for displaying Tiles — it's the main wrapper
 Tile (jsx)
 ==========
 
-Component used to display a clickable tile with an image, call to action and description.
+Component used to display a clickable tile with an image, call to action, and description.
 
 #### Props
 

--- a/client/components/tile-grid/README.md
+++ b/client/components/tile-grid/README.md
@@ -6,7 +6,6 @@ Component used to declare an area for displaying Tiles — it's the main wrapper
 #### Props
 
 * `className`: Add your own class to the grid.
-* `isHidden`: Whether the entire grid should be hidden. Default is `false`.
 
 ----------
 

--- a/client/components/tile-grid/README.md
+++ b/client/components/tile-grid/README.md
@@ -22,7 +22,7 @@ Component used to display a clickable tile with an image, call to action, and de
 * `description`: Description text.
 * `href`: URL that the item leads to upon click.
 * `image`: URL of the image.
-* `onClick`: Function, executed when the user clicks the tile,
+* `onClick`: Function, executed when the user clicks the tile.
 
 ----------
 

--- a/client/components/tile-grid/README.md
+++ b/client/components/tile-grid/README.md
@@ -32,7 +32,7 @@ Component used to display a clickable tile with an image, call to action, and de
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
 
-class MyExampleComponent extends Component {
+class MyExampleComponent extends PureComponent {
 	render() {
 		return (
 			<TileGrid>

--- a/client/components/tile-grid/docs/example.jsx
+++ b/client/components/tile-grid/docs/example.jsx
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,7 +24,7 @@ class TileGridExample extends PureComponent {
 					buttonLabel={ 'Start with a blog' }
 					description={ 'To share your ideas, stories, and photographs with your followers.' }
 					image={ '/calypso/images/illustrations/type-blog.svg' }
-					onClick={ noop }
+					onClick={ () => console.log( 'Clicked on the Blog tile' ) }
 				/>
 				<Tile
 					buttonLabel={ 'Start with a website' }
@@ -33,7 +32,6 @@ class TileGridExample extends PureComponent {
 						'To promote your business, organization, or brand and connect with your audience.'
 					}
 					image={ '/calypso/images/illustrations/type-website.svg' }
-					onClick={ noop }
 				/>
 				<Tile
 					buttonLabel={ 'Start with a portfolio' }

--- a/client/components/tile-grid/docs/example.jsx
+++ b/client/components/tile-grid/docs/example.jsx
@@ -1,0 +1,55 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Tile from 'components/tile-grid/tile';
+import TileGrid from 'components/tile-grid';
+
+/**
+ * Main
+ */
+class TileGridExample extends PureComponent {
+	static displayName = 'TileGrid';
+
+	render() {
+		return (
+			<TileGrid>
+				<Tile
+					buttonLabel={ 'Start with a blog' }
+					description={ 'To share your ideas, stories, and photographs with your followers.' }
+					image={ '/calypso/images/illustrations/type-blog.svg' }
+					onClick={ noop }
+				/>
+				<Tile
+					buttonLabel={ 'Start with a website' }
+					description={
+						'To promote your business, organization, or brand and connect with your audience.'
+					}
+					image={ '/calypso/images/illustrations/type-website.svg' }
+					onClick={ noop }
+				/>
+				<Tile
+					buttonLabel={ 'Start with a portfolio' }
+					description={ 'To present your creative projects in a visual showcase.' }
+					image={ '/calypso/images/illustrations/type-portfolio.svg' }
+					href="#"
+				/>
+				<Tile
+					buttonLabel={ 'Start with an online store' }
+					description={ 'To sell your products or services and accept payments.' }
+					image={ '/calypso/images/illustrations/type-e-commerce.svg' }
+					href="#"
+				/>
+			</TileGrid>
+		);
+	}
+}
+
+export default TileGridExample;

--- a/client/components/tile-grid/index.jsx
+++ b/client/components/tile-grid/index.jsx
@@ -1,0 +1,32 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export default class extends React.PureComponent {
+	static propTypes = {
+		className: PropTypes.string,
+		isHidden: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		isHidden: false,
+	};
+
+	render() {
+		const { children, className, isHidden } = this.props;
+		const gridClassName = classNames(
+			'tile-grid',
+			{
+				'is-hidden': isHidden,
+			},
+			className
+		);
+
+		return <div className={ gridClassName }>{ children }</div>;
+	}
+}

--- a/client/components/tile-grid/index.jsx
+++ b/client/components/tile-grid/index.jsx
@@ -10,22 +10,11 @@ import classNames from 'classnames';
 export default class extends React.PureComponent {
 	static propTypes = {
 		className: PropTypes.string,
-		isHidden: PropTypes.bool,
-	};
-
-	static defaultProps = {
-		isHidden: false,
 	};
 
 	render() {
-		const { children, className, isHidden } = this.props;
-		const gridClassName = classNames(
-			'tile-grid',
-			{
-				'is-hidden': isHidden,
-			},
-			className
-		);
+		const { children, className } = this.props;
+		const gridClassName = classNames( 'tile-grid', className );
 
 		return <div className={ gridClassName }>{ children }</div>;
 	}

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -36,10 +36,6 @@
 		}
 	}
 
-	&.is-clickable {
-		cursor: pointer;
-	}
-
 	&:active {
 		.tile-grid__cta {
 			color: $blue-dark;
@@ -60,7 +56,7 @@
 		}
 	}
 
-	&:last-of-type {
+	&:last-child {
 		margin-bottom: 20px;
 		border: 1px solid lighten( $gray, 20% );
 		border-bottom-right-radius: 6px;
@@ -72,35 +68,17 @@
 		}
 	}
 
+	&.is-card-link {
+		padding-right: 0;
+	}
+
 	a, svg {
 		display: block;
 		width: 100%; // Safari fix
 	}
-}
 
-.tile-grid__item-link {
-	padding-right: 40px;
-	display: block;
-	box-sizing: border-box;
-
-	&:after {
-		content: '';
-		display: block;
-		width: 8px; //Match the size of the cta copy
-		height: 8px; //Match the size of the cta copy
-		position: absolute;
-		top: 20px;
-		right: 15px;
-		border-top: 2px solid lighten( $gray, 20% );
-		border-right: 2px solid lighten( $gray, 20% );
-		transform: rotate(45deg);
-	}
-
-	@include breakpoint( ">480px" ) {
-		padding-right: 0;
-		&:after {
-			display: none;
-		}
+	.card__link-indicator {
+		display: none;
 	}
 }
 

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -1,0 +1,163 @@
+.tile-grid {
+	margin: 0 auto;
+	display: flex;
+	flex-flow: row wrap;
+	justify-content: center;
+	max-width: 640px;
+
+	opacity: 1;
+	filter: blur( 0 );
+	transform: translateZ( 0 ) translateX( 0 );
+	transition: 0.5s ease-in-out opacity, 0.5s ease-in-out filter, 0.5s ease-in-out transform;
+
+	&.is-hidden {
+		pointer-events: none;
+		transform: translateZ( 0 ) translateX( -25% );
+		opacity: 0;
+	}
+}
+
+.tile-grid__item {
+	transition: all 100ms ease-in-out;
+	position: relative;
+	border: 1px solid lighten( $gray, 20% );
+	border-bottom: 0;
+	margin: 0 10px;
+
+	@include breakpoint( "<480px" ) {
+		box-shadow: none; //inherited from .card, remove for mobile only
+	}
+
+	@include breakpoint( ">480px" ) {
+		padding: 0;
+		margin-bottom: 20px;
+		width: 230px;
+		max-width: 300px;
+		text-align: center;
+		flex-grow: 1;
+		border: 0;
+
+		&:hover {
+			box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
+		}
+	}
+
+	&.is-clickable {
+		cursor: pointer;
+	}
+
+	&:active {
+		.tile-grid__cta {
+			color: $blue-dark;
+		}
+
+		.tile-grid__item-link:after {
+			border-top-color: $blue-dark;
+			border-right-color: $blue-dark;
+		}
+	}
+
+	&:first-child {
+		border-top-right-radius: 6px;
+		border-top-left-radius: 6px;
+
+		@include breakpoint( ">480px" ) {
+			border-radius: 0;
+		}
+	}
+
+	&:last-of-type {
+		margin-bottom: 20px;
+		border: 1px solid lighten( $gray, 20% );
+		border-bottom-right-radius: 6px;
+		border-bottom-left-radius: 6px;
+
+		@include breakpoint( ">480px" ) {
+			border-radius: 0;
+			border: 0;
+		}
+	}
+
+	a, svg {
+		display: block;
+		width: 100%; // Safari fix
+	}
+}
+
+.tile-grid__item-link {
+	padding-right: 40px;
+	display: block;
+	box-sizing: border-box;
+
+	&:after {
+		content: '';
+		display: block;
+		width: 8px; //Match the size of the cta copy
+		height: 8px; //Match the size of the cta copy
+		position: absolute;
+		top: 20px;
+		right: 15px;
+		border-top: 2px solid lighten( $gray, 20% );
+		border-right: 2px solid lighten( $gray, 20% );
+		transform: rotate(45deg);
+	}
+
+	@include breakpoint( ">480px" ) {
+		padding-right: 0;
+		&:after {
+			display: none;
+		}
+	}
+}
+
+.tile-grid__image {
+	display: none;
+
+	@include breakpoint( ">480px" ) {
+		display: block;
+	}
+
+	img {
+		display: block;
+		margin: 10% auto 4%;
+		width: 85%;
+	}
+}
+
+@include breakpoint( ">480px" ) {
+	.tile-grid__item-copy {
+		padding: 15px;
+		border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+	}
+}
+
+.tile-grid__item-label {
+	color: $blue-wordpress;
+	padding: 0;
+	position: relative;
+}
+
+.tile-grid__item-description {
+	margin: 0;
+	color: $gray;
+	font-size: 13px;
+	line-height: 1.5;
+
+	@include breakpoint( ">480px" ) {
+		margin-top: 10px;
+	}
+}
+
+.button.tile-grid__cta {
+	color: $blue-wordpress;
+
+	@include breakpoint( "<480px" ) {
+		background: none;
+		font-size: 1.1em;
+		border: 0;
+		padding: 0;
+		text-transform: none;
+		margin: 0;
+		line-height: 1.1em;
+	}
+}

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -79,6 +79,18 @@
 
 	.card__link-indicator {
 		display: none;
+
+		@include breakpoint( "<480px" ) {
+			display: block;
+			width: 8px; //Match the size of the cta copy
+			height: 8px; //Match the size of the cta copy
+			position: absolute;
+			top: 20px;
+			right: 15px;
+			border-top: 2px solid lighten( $gray, 20% );
+			border-right: 2px solid lighten( $gray, 20% );
+			transform: rotate(45deg);
+		}
 	}
 }
 

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -9,12 +9,6 @@
 	filter: blur( 0 );
 	transform: translateZ( 0 ) translateX( 0 );
 	transition: 0.5s ease-in-out opacity, 0.5s ease-in-out filter, 0.5s ease-in-out transform;
-
-	&.is-hidden {
-		pointer-events: none;
-		transform: translateZ( 0 ) translateX( -25% );
-		opacity: 0;
-	}
 }
 
 .tile-grid__item {

--- a/client/components/tile-grid/tile.jsx
+++ b/client/components/tile-grid/tile.jsx
@@ -34,33 +34,23 @@ export default class extends React.PureComponent {
 			image,
 			onClick,
 		} = this.props;
-		const isClickable = href || onClick;
-		const TileElement = isClickable ? 'a' : 'span';
-		const tileClassName = classNames(
-			'tile-grid__item',
-			{
-				'is-clickable': isClickable,
-			},
-			className
-		);
+		const tileClassName = classNames( 'tile-grid__item', className );
 
 		return (
-			<Card className={ tileClassName }>
-				<TileElement className="tile-grid__item-link" href={ href } onClick={ onClick }>
-					{ image && (
-						<div className="tile-grid__image">
-							<img src={ image } />
-						</div>
-					) }
-					<div className="tile-grid__item-copy">
-						{ buttonLabel && (
-							<Button className={ classNames( 'tile-grid__cta', buttonClassName ) } compact>
-								{ buttonLabel }
-							</Button>
-						) }
-						{ description && <p className="tile-grid__item-description">{ description }</p> }
+			<Card className={ tileClassName } href={ href } onClick={ onClick }>
+				{ image && (
+					<div className="tile-grid__image">
+						<img src={ image } />
 					</div>
-				</TileElement>
+				) }
+				<div className="tile-grid__item-copy">
+					{ buttonLabel && (
+						<Button className={ classNames( 'tile-grid__cta', buttonClassName ) } compact>
+							{ buttonLabel }
+						</Button>
+					) }
+					{ description && <p className="tile-grid__item-description">{ description }</p> }
+				</div>
 			</Card>
 		);
 	}

--- a/client/components/tile-grid/tile.jsx
+++ b/client/components/tile-grid/tile.jsx
@@ -1,0 +1,58 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+
+export default class extends React.PureComponent {
+	static propTypes = {
+		buttonLabel: PropTypes.string,
+		className: PropTypes.string,
+		description: PropTypes.string,
+		href: PropTypes.string,
+		image: PropTypes.string,
+		onClick: PropTypes.func,
+	};
+
+	render() {
+		const { buttonLabel, className, description, href, image, onClick } = this.props;
+		const isClickable = href || onClick;
+		const TileElement = isClickable ? 'a' : 'span';
+		const tileClassName = classNames(
+			'tile-grid__item',
+			{
+				'is-clickable': isClickable,
+			},
+			className
+		);
+
+		return (
+			<Card className={ tileClassName }>
+				<TileElement className="tile-grid__item-link" href={ href } onClick={ onClick }>
+					{ image && (
+						<div className="tile-grid__image">
+							<img src={ image } />
+						</div>
+					) }
+					<div className="tile-grid__item-copy">
+						{ buttonLabel && (
+							<Button className="tile-grid__cta" compact>
+								{ buttonLabel }
+							</Button>
+						) }
+						{ description && <p className="tile-grid__item-description">{ description }</p> }
+					</div>
+				</TileElement>
+			</Card>
+		);
+	}
+}

--- a/client/components/tile-grid/tile.jsx
+++ b/client/components/tile-grid/tile.jsx
@@ -15,6 +15,7 @@ import Card from 'components/card';
 
 export default class extends React.PureComponent {
 	static propTypes = {
+		buttonClassName: PropTypes.string,
 		buttonLabel: PropTypes.string,
 		className: PropTypes.string,
 		description: PropTypes.string,
@@ -24,7 +25,15 @@ export default class extends React.PureComponent {
 	};
 
 	render() {
-		const { buttonLabel, className, description, href, image, onClick } = this.props;
+		const {
+			buttonClassName,
+			buttonLabel,
+			className,
+			description,
+			href,
+			image,
+			onClick,
+		} = this.props;
 		const isClickable = href || onClick;
 		const TileElement = isClickable ? 'a' : 'span';
 		const tileClassName = classNames(
@@ -45,7 +54,7 @@ export default class extends React.PureComponent {
 					) }
 					<div className="tile-grid__item-copy">
 						{ buttonLabel && (
-							<Button className="tile-grid__cta" compact>
+							<Button className={ classNames( 'tile-grid__cta', buttonClassName ) } compact>
 								{ buttonLabel }
 							</Button>
 						) }

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -81,6 +81,7 @@ import Spinner from 'components/spinner/docs/example';
 import SpinnerButton from 'components/spinner-button/docs/example';
 import SpinnerLine from 'components/spinner-line/docs/example';
 import Suggestions from 'components/suggestions/docs/example';
+import TileGrid from 'components/tile-grid/docs/example';
 import TimeSince from 'components/time-since/docs/example';
 import Timezone from 'components/timezone/docs/example';
 import TokenFields from 'components/token-field/docs/example';
@@ -187,6 +188,7 @@ class DesignAssets extends React.Component {
 					<SpinnerButton searchKeywords="loading input submit" />
 					<SpinnerLine searchKeywords="loading" />
 					<Suggestions />
+					<TileGrid />
 					<TimeSince />
 					<Timezone />
 					<TokenFields />


### PR DESCRIPTION
It seems we're using quite a lot of clickable tiles in the signup process, and now we'll be using them for Jetpack Onboarding too. Because of this, it makes sense to abstract them to a separate component family, so we can reuse them accordingly. This would help reduce the code duplication that happens in the signup flows currently.

### Preview
**Desktop**
![](https://cldup.com/RCDaT2Irep.png)

**Mobile**
![](https://cldup.com/p9NCNqeTTo.png)

### To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/devdocs/design/tile-grid
* Verify the grid and the tiles look good as on the preview
* Compare with `/signup/start`, the grid and the tiles should work the same way.
* Test on mobile, verify it works and looks as shown on the preview.