### PR TITLE
PrivacyPolicy: set the effective date rightly

### DIFF
--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -59,11 +59,15 @@ class PrivacyPolicyBanner extends Component {
 	};
 
 	getDescription( date ) {
+		if ( ! date ) {
+			return null;
+		}
+
 		const { moment, translate } = this.props;
 
 		return translate( "We're updating our privacy policy on %(date)s.", {
 			args: {
-				date: moment( date ).format( 'LL' ),
+				date: moment.utc( date ).format( 'LL' ),
 			},
 		} );
 	}
@@ -94,8 +98,8 @@ class PrivacyPolicyBanner extends Component {
 		}
 
 		// check if the current policy is under the notification period.
-		const notifyFrom = moment( get( privacyPolicy, 'notification_period.from' ) );
-		const notifyTo = moment( get( privacyPolicy, 'notification_period.to' ) );
+		const notifyFrom = moment.utc( get( privacyPolicy, 'notification_period.from' ) );
+		const notifyTo = moment.utc( get( privacyPolicy, 'notification_period.to' ) );
 
 		if (
 			( ! notifyFrom.isBefore() || ! notifyTo.isAfter() ) &&
@@ -118,7 +122,7 @@ class PrivacyPolicyBanner extends Component {
 				{ showPrivacyPolicyBanner && (
 					<Banner
 						callToAction={ translate( 'Learn More' ) }
-						description={ this.getDescription( privacyPolicy.modified ) }
+						description={ this.getDescription( privacyPolicy.effective_date ) }
 						disableHref={ true }
 						icon="pages"
 						onClick={ this.openPrivacyPolicyDialog }

--- a/client/state/privacy-policy/schema.js
+++ b/client/state/privacy-policy/schema.js
@@ -17,6 +17,10 @@ export const privacyPolicySchema = {
 			id: {
 				type: 'string',
 			},
+			effective_date: {
+				type: 'string',
+				description: 'Effective date of the document.',
+			},
 			modified: {
 				type: 'string',
 				description: 'Modification date of the document.',


### PR DESCRIPTION
This PR changes the way to define the effective date of the privacy policy.
Before to this, the date gets from the `modified` field of the response body. Now instead, the date gets from the `effective_date` field. 


The effective_date defines the date in the Banner description:
![image](https://user-images.githubusercontent.com/77539/33505766-8284732c-d6cb-11e7-93c8-da36e2320724.png)

Also, the dates create using `utc()` moment method.

### Testing

After applying the patch

1) Go to the stat page of your testing site
`http://calypso.localhost:3000/stats/day/<testing-site>/`

2) Enable the feature testing flag via `url`:
`http://calypso.localhost:3000/stats/day/<testing-site>/?flags=privacy-policy/test`

3) The date that banner shows should be ` January 3, 2018.`

just FYI, the data gets from the privacy-policy endpoint response:

![image](https://user-images.githubusercontent.com/77539/33605205-77993686-d997-11e7-833d-9378090de2e2.png)
