### PR TITLE
LikeButton: fix React warning about an onClick handler being 'false'

### DIFF
--- a/client/blocks/like-button/button.jsx
+++ b/client/blocks/like-button/button.jsx
@@ -113,7 +113,7 @@ class LikeButton extends PureComponent {
 				{
 					href,
 					className: classNames( containerClasses ),
-					onClick: ! isLink && this.toggleLiked,
+					onClick: ! isLink ? this.toggleLiked : null,
 				},
 				isNull
 			),


### PR DESCRIPTION
React doesn't like event handlers having a boolean value. `undefined` is recommended. This patch removes the warning by setting the value to `null`, which causes the `onClick` prop to be not passed at all because `omit(..., isNull)`.

**How to test:**
Before applying the patch:
1. Go to `/posts/some.site.blog` in development mode
2. Scroll down the list to display a few `LikeButton`s
3. Check that the console contains a warning:
<img width="975" alt="onclick-false-warning" src="https://user-images.githubusercontent.com/664258/33505698-b968aa18-d6ec-11e7-9760-322074324551.png">

After the patch:
- check that the warning disappeared