### PR TITLE
Add: transfer a site to another user

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -398,6 +398,7 @@
 @import 'my-sites/site-settings/jetpack-credentials/credentials-configured/style';
 @import 'my-sites/site-settings/jetpack-credentials/credentials-form/style';
 @import 'my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style';
+@import 'my-sites/site-settings/transfer-site-to-user/style';
 @import 'my-sites/importer/style';
 @import 'blocks/site/style';
 @import 'my-sites/sites/style';

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -21,6 +21,7 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 import SiteSettingsMain from 'my-sites/site-settings/main';
 import StartOver from './start-over';
 import ThemeSetup from './theme-setup';
+import TransferSiteToUser from './transfer-site-to-user';
 import ManageConnection from './manage-connection';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -100,6 +101,10 @@ const controller = {
 			context,
 			<AsyncLoad require="my-sites/guided-transfer" hostSlug={ context.params.host_slug } />
 		);
+	},
+
+	transferSiteToUser( context ) {
+		renderPage( context, <TransferSiteToUser /> );
 	},
 
 	deleteSite( context ) {

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -50,6 +50,11 @@ function canDeleteSite( state, siteId ) {
 	return true;
 }
 
+function canTransferSite( state, siteId ) {
+	// Use same capability logic as per site deletion
+	return canDeleteSite( state, siteId );
+}
+
 function renderPage( context, component ) {
 	renderWithReduxStore( component, document.getElementById( 'primary' ), context.store );
 }
@@ -59,13 +64,13 @@ const controller = {
 		page.redirect( '/settings/general' );
 	},
 
-	redirectIfCantDeleteSite( context ) {
+	redirectIfCantPerformAction( context, canPerformAction ) {
 		const state = context.store.getState();
 		const dispatch = context.store.dispatch;
 		const siteId = getSelectedSiteId( state );
 		const siteSlug = getSelectedSiteSlug( state );
 
-		if ( siteId && ! canDeleteSite( state, siteId ) ) {
+		if ( siteId && ! canPerformAction( state, siteId ) ) {
 			return page.redirect( '/settings/general/' + siteSlug );
 		}
 
@@ -76,7 +81,7 @@ const controller = {
 					const updatedState = context.store.getState();
 					const updatedSiteId = getSelectedSiteId( updatedState );
 					const updatedSiteSlug = getSelectedSiteSlug( updatedState );
-					if ( ! canDeleteSite( updatedState, updatedSiteId ) ) {
+					if ( ! canPerformAction( updatedState, updatedSiteId ) ) {
 						return page.redirect( '/settings/general/' + updatedSiteSlug );
 					}
 				},
@@ -104,14 +109,14 @@ const controller = {
 	},
 
 	transferSiteToUser( context ) {
+		const redirectIfCantTransferSite = controller.redirectIfCantPerformAction;
+		redirectIfCantTransferSite( context, canTransferSite );
 		renderPage( context, <TransferSiteToUser /> );
 	},
 
 	deleteSite( context ) {
-		const redirectIfCantDeleteSite = controller.redirectIfCantDeleteSite;
-
-		redirectIfCantDeleteSite( context );
-
+		const redirectIfCantDeleteSite = controller.redirectIfCantPerformAction;
+		redirectIfCantDeleteSite( context, canDeleteSite );
 		renderPage( context, <DeleteSite path={ context.path } /> );
 	},
 
@@ -129,10 +134,8 @@ const controller = {
 	},
 
 	startOver( context ) {
-		const redirectIfCantDeleteSite = controller.redirectIfCantDeleteSite;
-
-		redirectIfCantDeleteSite( context );
-
+		const redirectIfCantDeleteSite = controller.redirectIfCantPerformAction;
+		redirectIfCantDeleteSite( context, canDeleteSite );
 		renderPage( context, <StartOver path={ context.path } /> );
 	},
 

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -42,6 +42,7 @@ export default function() {
 			'/settings/transfer-to-user/:site_id',
 			siteSelection,
 			navigation,
+			settingsController.setScroll,
 			controller.transferSiteToUser
 		);
 	}

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -37,6 +37,15 @@ export default function() {
 
 	page( '/settings/export/:site_id', siteSelection, navigation, controller.exportSite );
 
+	if ( config.isEnabled( 'manage/site-settings/transfer-to-user' ) ) {
+		page(
+			'/settings/transfer-to-user/:site_id',
+			siteSelection,
+			navigation,
+			controller.transferSiteToUser
+		);
+	}
+
 	page(
 		'/settings/delete-site/:site_id',
 		siteSelection,
@@ -69,6 +78,7 @@ export default function() {
 		settingsController.setScroll,
 		controller.startOver
 	);
+
 	page(
 		'/settings/theme-setup/:site_id',
 		siteSelection,

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -54,6 +54,7 @@ class SiteTools extends Component {
 			showChangeAddress,
 			showDeleteContent,
 			showDeleteSite,
+			showTransferSiteToUser,
 			showThemeSetup,
 			showManageConnection,
 		} = this.props;
@@ -61,6 +62,7 @@ class SiteTools extends Component {
 		const changeAddressLink = `/domains/manage/${ siteSlug }`;
 		const themeSetupLink = `/settings/theme-setup/${ siteSlug }`;
 		const startOverLink = `/settings/start-over/${ siteSlug }`;
+		const transferSiteToUserLink = `/settings/transfer-to-user/${ siteSlug }`;
 		const deleteSiteLink = `/settings/delete-site/${ siteSlug }`;
 		const manageConnectionLink = `/settings/manage-connection/${ siteSlug }`;
 
@@ -72,6 +74,8 @@ class SiteTools extends Component {
 			"Keep your site's address and current theme, but remove all posts, " +
 				'pages, and media so you can start fresh.'
 		);
+		const transferSiteToUser = translate( 'Transfer your site' );
+		const transferSiteToUserText = 'Transfer your site to another user.';
 		const deleteSite = translate( 'Delete your site permanently' );
 		const deleteSiteText = translate(
 			"Delete all your posts, pages, media, and data, and give up your site's address."
@@ -120,6 +124,13 @@ class SiteTools extends Component {
 						onClick={ this.trackStartOver }
 						title={ startOver }
 						description={ startOverText }
+					/>
+				) }
+				{ showTransferSiteToUser && (
+					<SiteToolsLink
+						href={ transferSiteToUserLink }
+						title={ transferSiteToUser }
+						description={ transferSiteToUserText }
 					/>
 				) }
 				{ showDeleteSite && (
@@ -196,6 +207,7 @@ export default connect( state => {
 		showChangeAddress: ! isJetpack && ! isVip,
 		showThemeSetup: config.isEnabled( 'settings/theme-setup' ) && ! isJetpack && ! isVip,
 		showDeleteContent: ! isJetpack && ! isVip,
+		showTransferSiteToUser: ! isJetpack && ! isVip,
 		showDeleteSite: ( ! isJetpack || isAtomic ) && ! isVip && sitePurchasesLoaded,
 		showManageConnection: isJetpack && ! isAtomic,
 	};

--- a/client/my-sites/site-settings/transfer-site-to-user/domain-transfer-instructions.jsx
+++ b/client/my-sites/site-settings/transfer-site-to-user/domain-transfer-instructions.jsx
@@ -46,7 +46,7 @@ class DomainTransferInstructions extends PureComponent {
 						{ translate( 'Cancel' ) }
 					</Button>
 					<Button className="transfer-site-to-user__continue">
-						{ translate( 'Transfer Your Domain' ) }
+						{ translate( 'Transfer Domain' ) }
 						<Gridicon icon="chevron-right" size={ 48 } />
 					</Button>
 				</ActionPanelFooter>

--- a/client/my-sites/site-settings/transfer-site-to-user/domain-transfer-instructions.jsx
+++ b/client/my-sites/site-settings/transfer-site-to-user/domain-transfer-instructions.jsx
@@ -24,6 +24,7 @@ import { getSiteDomain } from 'state/sites/selectors';
 class DomainTransferInstructions extends PureComponent {
 	static propTypes = {
 		selectedSiteDomain: PropTypes.string,
+		onCancel: PropTypes.func,
 		translate: PropTypes.func,
 	};
 
@@ -37,7 +38,10 @@ class DomainTransferInstructions extends PureComponent {
 					<p>{ translate( 'You must transfer your domain first!' ) }</p>
 				</ActionPanelBody>
 				<ActionPanelFooter>
-					<Button className="transfer-site-to-user__cancel is-scary">
+					<Button
+						onClick={ this.props.onCancel }
+						className="transfer-site-to-user__cancel is-scary"
+					>
 						<Gridicon icon="cross" size={ 48 } />
 						{ translate( 'Cancel' ) }
 					</Button>

--- a/client/my-sites/site-settings/transfer-site-to-user/domain-transfer-instructions.jsx
+++ b/client/my-sites/site-settings/transfer-site-to-user/domain-transfer-instructions.jsx
@@ -1,0 +1,60 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import ActionPanel from 'my-sites/site-settings/action-panel';
+import ActionPanelTitle from 'my-sites/site-settings/action-panel/title';
+import ActionPanelBody from 'my-sites/site-settings/action-panel/body';
+import ActionPanelFooter from 'my-sites/site-settings/action-panel/footer';
+import Button from 'components/button';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteDomain } from 'state/sites/selectors';
+
+class DomainTransferInstructions extends PureComponent {
+	static propTypes = {
+		selectedSiteDomain: PropTypes.string,
+		translate: PropTypes.func,
+	};
+
+	render() {
+		const translate = this.props.translate;
+
+		return (
+			<ActionPanel>
+				<ActionPanelBody>
+					<ActionPanelTitle>{ translate( 'Your Site Has A Domain' ) }</ActionPanelTitle>
+					<p>{ translate( 'You must transfer your domain first!' ) }</p>
+				</ActionPanelBody>
+				<ActionPanelFooter>
+					<Button className="transfer-site-to-user__cancel is-scary">
+						<Gridicon icon="cross" size={ 48 } />
+						{ translate( 'Cancel' ) }
+					</Button>
+					<Button className="transfer-site-to-user__continue">
+						{ translate( 'Transfer Your Domain' ) }
+						<Gridicon icon="chevron-right" size={ 48 } />
+					</Button>
+				</ActionPanelFooter>
+			</ActionPanel>
+		);
+	}
+}
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		selectedSiteDomain: getSiteDomain( state, siteId ),
+	};
+} )( localize( DomainTransferInstructions ) );

--- a/client/my-sites/site-settings/transfer-site-to-user/index.jsx
+++ b/client/my-sites/site-settings/transfer-site-to-user/index.jsx
@@ -4,19 +4,28 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
  */
+import DomainTransferInstructions from './domain-transfer-instructions';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
-import TransferSiteToUserWarning from './warning';
+import SiteTransferWarning from './site-transfer-warning';
 
 class TransferSiteToUser extends React.Component {
+	static propTypes = {
+		siteSlug: PropTypes.string.isRequired,
+		currentPlan: PropTypes.object,
+		translate: PropTypes.func,
+	};
+
 	constructor( props ) {
 		super( props );
 		this.state = {
@@ -24,22 +33,30 @@ class TransferSiteToUser extends React.Component {
 		};
 
 		this.renderBody = this.renderBody.bind( this );
-		this.renderWarning = this.renderWarning.bind( this );
+		this.renderSiteTransferWarning = this.renderSiteTransferWarning.bind( this );
 		this.acknowlegeWarning = this.acknowlegeWarning.bind( this );
+		this.renderDomainTransferInstructions = this.renderDomainTransferInstructions.bind( this );
 	}
 
 	renderBody() {
 		if ( ! this.state.warningAcknowledged ) {
-			return this.renderWarning();
+			return this.renderSiteTransferWarning();
+		}
+		if ( this.props.currentPlan.isDomainUpgrade ) {
+			return this.renderDomainTransferInstructions();
 		}
 	}
 
-	renderWarning() {
-		return <TransferSiteToUserWarning onAcknowledged={ this.acknowlegeWarning } />;
+	renderSiteTransferWarning() {
+		return <SiteTransferWarning onAcknowledged={ this.acknowlegeWarning } />;
 	}
 
 	acknowlegeWarning() {
 		this.setState( { warningAcknowledged: true } );
+	}
+
+	renderDomainTransferInstructions() {
+		return <DomainTransferInstructions />;
 	}
 
 	render() {
@@ -61,5 +78,6 @@ export default connect( state => {
 
 	return {
 		siteSlug: getSiteSlug( state, siteId ),
+		currentPlan: getCurrentPlan( state, siteId ),
 	};
 } )( localize( TransferSiteToUser ) );

--- a/client/my-sites/site-settings/transfer-site-to-user/index.jsx
+++ b/client/my-sites/site-settings/transfer-site-to-user/index.jsx
@@ -10,9 +10,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
-import { successNotice, errorNotice } from 'state/notices/actions';
+import TransferSiteToUserWarning from './warning';
 
 class TransferSiteToUser extends React.Component {
 	constructor( props ) {
@@ -20,11 +22,23 @@ class TransferSiteToUser extends React.Component {
 	}
 
 	render() {
-		return <Main className="transfer-site-to-user" />;
+		const { siteSlug, translate } = this.props;
+
+		return (
+			<Main className="transfer-site-to-user">
+				<HeaderCake backHref={ '/settings/general/' + siteSlug }>
+					<h1>{ translate( 'Transfer Your Site' ) }</h1>
+				</HeaderCake>
+				<TransferSiteToUserWarning />
+			</Main>
+		);
 	}
 }
 
-export default connect( state => ( { currentUser: getCurrentUser( state ) } ), {
-	successNotice,
-	errorNotice,
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteSlug: getSiteSlug( state, siteId ),
+	};
 } )( localize( TransferSiteToUser ) );

--- a/client/my-sites/site-settings/transfer-site-to-user/index.jsx
+++ b/client/my-sites/site-settings/transfer-site-to-user/index.jsx
@@ -1,0 +1,30 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import { getCurrentUser } from 'state/current-user/selectors';
+import Main from 'components/main';
+import { successNotice, errorNotice } from 'state/notices/actions';
+
+class TransferSiteToUser extends React.Component {
+	constructor( props ) {
+		super( props );
+	}
+
+	render() {
+		return <Main className="transfer-site-to-user" />;
+	}
+}
+
+export default connect( state => ( { currentUser: getCurrentUser( state ) } ), {
+	successNotice,
+	errorNotice,
+} )( localize( TransferSiteToUser ) );

--- a/client/my-sites/site-settings/transfer-site-to-user/index.jsx
+++ b/client/my-sites/site-settings/transfer-site-to-user/index.jsx
@@ -19,6 +19,27 @@ import TransferSiteToUserWarning from './warning';
 class TransferSiteToUser extends React.Component {
 	constructor( props ) {
 		super( props );
+		this.state = {
+			warningAcknowledged: false,
+		};
+
+		this.renderBody = this.renderBody.bind( this );
+		this.renderWarning = this.renderWarning.bind( this );
+		this.acknowlegeWarning = this.acknowlegeWarning.bind( this );
+	}
+
+	renderBody() {
+		if ( ! this.state.warningAcknowledged ) {
+			return this.renderWarning();
+		}
+	}
+
+	renderWarning() {
+		return <TransferSiteToUserWarning onAcknowledged={ this.acknowlegeWarning } />;
+	}
+
+	acknowlegeWarning() {
+		this.setState( { warningAcknowledged: true } );
 	}
 
 	render() {
@@ -29,7 +50,7 @@ class TransferSiteToUser extends React.Component {
 				<HeaderCake backHref={ '/settings/general/' + siteSlug }>
 					<h1>{ translate( 'Transfer Your Site' ) }</h1>
 				</HeaderCake>
-				<TransferSiteToUserWarning />
+				{ this.renderBody() }
 			</Main>
 		);
 	}

--- a/client/my-sites/site-settings/transfer-site-to-user/index.jsx
+++ b/client/my-sites/site-settings/transfer-site-to-user/index.jsx
@@ -34,7 +34,7 @@ class TransferSiteToUser extends React.Component {
 
 		this.renderBody = this.renderBody.bind( this );
 		this.renderSiteTransferWarning = this.renderSiteTransferWarning.bind( this );
-		this.acknowlegeWarning = this.acknowlegeWarning.bind( this );
+		this.toggleWarning = this.toggleWarning.bind( this );
 		this.renderDomainTransferInstructions = this.renderDomainTransferInstructions.bind( this );
 	}
 
@@ -48,15 +48,17 @@ class TransferSiteToUser extends React.Component {
 	}
 
 	renderSiteTransferWarning() {
-		return <SiteTransferWarning onAcknowledged={ this.acknowlegeWarning } />;
+		return <SiteTransferWarning onAcknowledged={ this.toggleWarning } />;
 	}
 
-	acknowlegeWarning() {
-		this.setState( { warningAcknowledged: true } );
+	toggleWarning() {
+		this.setState( {
+			warningAcknowledged: ! this.state.warningAcknowledged,
+		} );
 	}
 
 	renderDomainTransferInstructions() {
-		return <DomainTransferInstructions />;
+		return <DomainTransferInstructions onCancel={ this.toggleWarning } />;
 	}
 
 	render() {

--- a/client/my-sites/site-settings/transfer-site-to-user/site-transfer-warning.jsx
+++ b/client/my-sites/site-settings/transfer-site-to-user/site-transfer-warning.jsx
@@ -22,7 +22,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteDomain } from 'state/sites/selectors';
 import userSettings from 'lib/user-settings';
 
-class TransferSiteToUserWarning extends PureComponent {
+class SiteTransferWarning extends PureComponent {
 	static propTypes = {
 		selectedSiteDomain: PropTypes.string,
 		currentUserEmail: PropTypes.string,
@@ -46,7 +46,7 @@ class TransferSiteToUserWarning extends PureComponent {
 					<p>
 						{ translate(
 							'Transferring a site cannot be undone. Please read the following actions that will ' +
-								'take place when you transfer this blog:'
+								'take place when you transfer this site:'
 						) }
 					</p>
 					<ul>
@@ -95,4 +95,4 @@ export default connect( state => {
 		selectedSiteDomain: getSiteDomain( state, siteId ),
 		currentUserEmail: userSettings.getSetting( 'user_email' ),
 	};
-} )( localize( TransferSiteToUserWarning ) );
+} )( localize( SiteTransferWarning ) );

--- a/client/my-sites/site-settings/transfer-site-to-user/style.scss
+++ b/client/my-sites/site-settings/transfer-site-to-user/style.scss
@@ -1,0 +1,5 @@
+.button {
+    .transfer-site-to-user__cancel {
+        margin-right: 15px;
+    }
+}

--- a/client/my-sites/site-settings/transfer-site-to-user/style.scss
+++ b/client/my-sites/site-settings/transfer-site-to-user/style.scss
@@ -1,5 +1,5 @@
 .button {
-    .transfer-site-to-user__cancel {
+    &.transfer-site-to-user__cancel {
         margin-right: 15px;
     }
 }

--- a/client/my-sites/site-settings/transfer-site-to-user/warning.jsx
+++ b/client/my-sites/site-settings/transfer-site-to-user/warning.jsx
@@ -4,7 +4,8 @@
  * External dependencies
  */
 
-import React from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
@@ -17,68 +18,80 @@ import ActionPanelTitle from 'my-sites/site-settings/action-panel/title';
 import ActionPanelBody from 'my-sites/site-settings/action-panel/body';
 import ActionPanelFooter from 'my-sites/site-settings/action-panel/footer';
 import Button from 'components/button';
-import support from 'lib/url/support';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteDomain } from 'state/sites/selectors';
 import userSettings from 'lib/user-settings';
 
-const TransferSiteToUserWarning = ( { translate, selectedSiteDomain, currentUserEmail } ) => {
-	const transOpts = {
-		args: {
-			domain: selectedSiteDomain,
-			email: currentUserEmail,
-		},
+class TransferSiteToUserWarning extends PureComponent {
+	static propTypes = {
+		selectedSiteDomain: PropTypes.string,
+		currentUserEmail: PropTypes.string,
+		onAcknowledged: PropTypes.func,
+		translate: PropTypes.func,
 	};
 
-	return (
-		<ActionPanel>
-			<ActionPanelBody>
-				<ActionPanelTitle>{ translate( 'Transfer Your Site' ) }</ActionPanelTitle>
-				<p>
-					{ translate(
-						'Transferring a site cannot be undone. ' +
-							'Please read the following actions that will ' +
-							'take place when you transfer this blog:'
-					) }
-				</p>
-				<ul>
-					<li>{ translate( 'You will be removed as owner of ' + '%(domain)s', transOpts ) }</li>
-					<li>
+	render() {
+		const translate = this.props.translate;
+		const transOpts = {
+			args: {
+				domain: this.props.selectedSiteDomain,
+				email: this.props.currentUserEmail,
+			},
+		};
+
+		return (
+			<ActionPanel>
+				<ActionPanelBody>
+					<ActionPanelTitle>{ translate( 'Transfer Your Site' ) }</ActionPanelTitle>
+					<p>
 						{ translate(
-							'You will not be able to access ' + '%(domain)s unless allowed by the new owner',
+							'Transferring a site cannot be undone. ' +
+								'Please read the following actions that will ' +
+								'take place when you transfer this blog:'
+						) }
+					</p>
+					<ul>
+						<li>{ translate( 'You will be removed as owner of ' + '%(domain)s', transOpts ) }</li>
+						<li>
+							{ translate(
+								'You will not be able to access ' + '%(domain)s unless allowed by the new owner',
+								transOpts
+							) }
+						</li>
+						<li>
+							{ translate(
+								'Your posts on %(domain)s ' +
+									'will be transferred to the new owner and ' +
+									'will no longer be authored by your account.',
+								transOpts
+							) }
+						</li>
+					</ul>
+					<p>
+						{ translate(
+							'Note that you will be sent a ' +
+								'confirmation email to %(email)s before ' +
+								'the above actions are performed.',
 							transOpts
 						) }
-					</li>
-					<li>
-						{ translate(
-							'Your posts on %(domain)s ' +
-								'will be transferred to the new owner and ' +
-								'will no longer be authored by your account.',
-							transOpts
-						) }
-					</li>
-				</ul>
-				<p>
-					{ translate(
-						'Note that you will be sent a ' +
-							'confirmation email to %(email)s before ' +
-							'the above actions are performed.',
-						transOpts
-					) }
-				</p>
-				<p>
-					{ translate( 'Please make sure this is what you want ' + 'to do before continuing!' ) }
-				</p>
-			</ActionPanelBody>
-			<ActionPanelFooter>
-				<Button href={ support.EMPTY_SITE } className="transfer-site-to-user__continue is-scary">
-					{ translate( 'Continue' ) }
-					<Gridicon icon="chevron-right" size={ 48 } />
-				</Button>
-			</ActionPanelFooter>
-		</ActionPanel>
-	);
-};
+					</p>
+					<p>
+						{ translate( 'Please make sure this is what you want ' + 'to do before continuing!' ) }
+					</p>
+				</ActionPanelBody>
+				<ActionPanelFooter>
+					<Button
+						onClick={ this.props.onAcknowledged }
+						className="transfer-site-to-user__continue is-scary"
+					>
+						{ translate( 'Continue' ) }
+						<Gridicon icon="chevron-right" size={ 48 } />
+					</Button>
+				</ActionPanelFooter>
+			</ActionPanel>
+		);
+	}
+}
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );

--- a/client/my-sites/site-settings/transfer-site-to-user/warning.jsx
+++ b/client/my-sites/site-settings/transfer-site-to-user/warning.jsx
@@ -45,23 +45,21 @@ class TransferSiteToUserWarning extends PureComponent {
 					<ActionPanelTitle>{ translate( 'Transfer Your Site' ) }</ActionPanelTitle>
 					<p>
 						{ translate(
-							'Transferring a site cannot be undone. ' +
-								'Please read the following actions that will ' +
+							'Transferring a site cannot be undone. Please read the following actions that will ' +
 								'take place when you transfer this blog:'
 						) }
 					</p>
 					<ul>
-						<li>{ translate( 'You will be removed as owner of ' + '%(domain)s', transOpts ) }</li>
+						<li>{ translate( 'You will be removed as owner of %(domain)s', transOpts ) }</li>
 						<li>
 							{ translate(
-								'You will not be able to access ' + '%(domain)s unless allowed by the new owner',
+								'You will not be able to access %(domain)s unless allowed by the new owner',
 								transOpts
 							) }
 						</li>
 						<li>
 							{ translate(
-								'Your posts on %(domain)s ' +
-									'will be transferred to the new owner and ' +
+								'Your posts on %(domain)s will be transferred to the new owner and ' +
 									'will no longer be authored by your account.',
 								transOpts
 							) }
@@ -69,15 +67,12 @@ class TransferSiteToUserWarning extends PureComponent {
 					</ul>
 					<p>
 						{ translate(
-							'Note that you will be sent a ' +
-								'confirmation email to %(email)s before ' +
+							'Note that you will be sent a confirmation email to %(email)s before ' +
 								'the above actions are performed.',
 							transOpts
 						) }
 					</p>
-					<p>
-						{ translate( 'Please make sure this is what you want ' + 'to do before continuing!' ) }
-					</p>
+					<p>{ translate( 'Please make sure this is what you want to do before continuing!' ) }</p>
 				</ActionPanelBody>
 				<ActionPanelFooter>
 					<Button

--- a/client/my-sites/site-settings/transfer-site-to-user/warning.jsx
+++ b/client/my-sites/site-settings/transfer-site-to-user/warning.jsx
@@ -20,7 +20,7 @@ import Button from 'components/button';
 import support from 'lib/url/support';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteDomain } from 'state/sites/selectors';
-import getUserSetting from 'state/selectors/get-user-setting';
+import userSettings from 'lib/user-settings';
 
 const TransferSiteToUserWarning = ( { translate, selectedSiteDomain, currentUserEmail } ) => {
 	const transOpts = {
@@ -71,9 +71,9 @@ const TransferSiteToUserWarning = ( { translate, selectedSiteDomain, currentUser
 				</p>
 			</ActionPanelBody>
 			<ActionPanelFooter>
-				<Button href={ support.EMPTY_SITE }>
+				<Button href={ support.EMPTY_SITE } className="transfer-site-to-user__continue is-scary">
 					{ translate( 'Continue' ) }
-					<Gridicon icon="external" size={ 48 } />
+					<Gridicon icon="chevron-right" size={ 48 } />
 				</Button>
 			</ActionPanelFooter>
 		</ActionPanel>
@@ -85,6 +85,6 @@ export default connect( state => {
 
 	return {
 		selectedSiteDomain: getSiteDomain( state, siteId ),
-		currentUserEmail: getUserSetting( state, 'user_email' ),
+		currentUserEmail: userSettings.getSetting( 'user_email' ),
 	};
 } )( localize( TransferSiteToUserWarning ) );

--- a/client/my-sites/site-settings/transfer-site-to-user/warning.jsx
+++ b/client/my-sites/site-settings/transfer-site-to-user/warning.jsx
@@ -1,0 +1,90 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import ActionPanel from 'my-sites/site-settings/action-panel';
+import ActionPanelTitle from 'my-sites/site-settings/action-panel/title';
+import ActionPanelBody from 'my-sites/site-settings/action-panel/body';
+import ActionPanelFooter from 'my-sites/site-settings/action-panel/footer';
+import Button from 'components/button';
+import support from 'lib/url/support';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteDomain } from 'state/sites/selectors';
+import getUserSetting from 'state/selectors/get-user-setting';
+
+const TransferSiteToUserWarning = ( { translate, selectedSiteDomain, currentUserEmail } ) => {
+	const transOpts = {
+		args: {
+			domain: selectedSiteDomain,
+			email: currentUserEmail,
+		},
+	};
+
+	return (
+		<ActionPanel>
+			<ActionPanelBody>
+				<ActionPanelTitle>{ translate( 'Transfer Your Site' ) }</ActionPanelTitle>
+				<p>
+					{ translate(
+						'Transferring a site cannot be undone. ' +
+							'Please read the following actions that will ' +
+							'take place when you transfer this blog:'
+					) }
+				</p>
+				<ul>
+					<li>{ translate( 'You will be removed as owner of ' + '%(domain)s', transOpts ) }</li>
+					<li>
+						{ translate(
+							'You will not be able to access ' + '%(domain)s unless allowed by the new owner',
+							transOpts
+						) }
+					</li>
+					<li>
+						{ translate(
+							'Your posts on %(domain)s ' +
+								'will be transferred to the new owner and ' +
+								'will no longer be authored by your account.',
+							transOpts
+						) }
+					</li>
+				</ul>
+				<p>
+					{ translate(
+						'Note that you will be sent a ' +
+							'confirmation email to %(email)s before ' +
+							'the above actions are performed.',
+						transOpts
+					) }
+				</p>
+				<p>
+					{ translate( 'Please make sure this is what you want ' + 'to do before continuing!' ) }
+				</p>
+			</ActionPanelBody>
+			<ActionPanelFooter>
+				<Button href={ support.EMPTY_SITE }>
+					{ translate( 'Continue' ) }
+					<Gridicon icon="external" size={ 48 } />
+				</Button>
+			</ActionPanelFooter>
+		</ActionPanel>
+	);
+};
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		selectedSiteDomain: getSiteDomain( state, siteId ),
+		currentUserEmail: getUserSetting( state, 'user_email' ),
+	};
+} )( localize( TransferSiteToUserWarning ) );

--- a/config/development.json
+++ b/config/development.json
@@ -99,6 +99,7 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
+		"manage/site-settings/transfer-to-user": true,
 		"manage/stats": true,
 		"manage/stats/podcasts": true,
 		"manage/themes": true,


### PR DESCRIPTION
The following is a feature that enables users to transfer their site to another user. This feature currently exists in wp-admin, but not yet in Calypso.

This is very much a work in progress, as we explore how the UI should behave, and how the workflow could be improved over the existing implementation.

The current big picture workflow is as follows:

- Rather than transferring the site to an arbitrary user (either by username or email address - which is the current process), the user to which the site is being transferred to should be an existing admin of the site. The process should direct users to instructions on how to do that, if they don't know already.
- If the site has a domain feature attached, that we direct the user to the domain transfer process first before allowing them to proceed further with the site transfer. This would improve the existing process where if a domain feature is attached to a site, a support ticket is created.
- Once the user (transferer) has selected the admin (transferee) they wish to transfer the site to, a confirmation email will be sent to the transferer asking them to confirm the transfer.