### PR TITLE
Cart: Include transfers in the getTlds check

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -254,21 +254,15 @@ export function hasDomainCredit( cart ) {
  * @returns {Boolean} - Whether or not the cart contains a domain with that TLD
  */
 export function hasTld( cart, tld ) {
-	return some( concat( getDomainRegistrations( cart ), getDomainTransfers( cart ) ), function(
-		cartItem
-	) {
-		return getTld( cartItem.meta ) === tld;
-	} );
+	const domains = concat( getDomainRegistrations( cart ), getDomainTransfers( cart ) );
+
+	return some( domains, cartItem => getTld( cartItem.meta ) === tld );
 }
 
 export function getTlds( cart ) {
-	return uniq(
-		map( concat( getDomainRegistrations( cart ), getDomainTransfers( cart ) ), function(
-			cartItem
-		) {
-			return getTld( cartItem.meta );
-		} )
-	);
+	const domains = concat( getDomainRegistrations( cart ), getDomainTransfers( cart ) );
+
+	return uniq( map( domains, cartItem => getTld( cartItem.meta ) ) );
 }
 
 /**

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -19,8 +19,6 @@ import {
 	merge,
 	reject,
 	some,
-	trimStart,
-	tail,
 	uniq,
 } from 'lodash';
 
@@ -52,6 +50,7 @@ import {
 } from 'lib/products-values';
 import sortProducts from 'lib/products-values/sort';
 import { PLAN_PERSONAL } from 'lib/plans/constants';
+import { getTld } from 'lib/domains';
 import { domainProductSlugs } from 'lib/domains/constants';
 
 import {
@@ -255,25 +254,21 @@ export function hasDomainCredit( cart ) {
  * @returns {Boolean} - Whether or not the cart contains a domain with that TLD
  */
 export function hasTld( cart, tld ) {
-	return some( getDomainRegistrations( cart ), function( cartItem ) {
-		return getDomainRegistrationTld( cartItem ) === '.' + tld;
+	return some( concat( getDomainRegistrations( cart ), getDomainTransfers( cart ) ), function(
+		cartItem
+	) {
+		return getTld( cartItem.meta ) === tld;
 	} );
 }
 
 export function getTlds( cart ) {
 	return uniq(
-		map( getDomainRegistrations( cart ), function( cartItem ) {
-			return trimStart( getDomainRegistrationTld( cartItem ), '.' );
+		map( concat( getDomainRegistrations( cart ), getDomainTransfers( cart ) ), function(
+			cartItem
+		) {
+			return getTld( cartItem.meta );
 		} )
 	);
-}
-
-export function getDomainRegistrationTld( cartItem ) {
-	if ( ! isDomainRegistration( cartItem ) ) {
-		throw new Error( 'This function only works on domain registration cart ' + 'items.' );
-	}
-
-	return '.' + tail( cartItem.meta.split( '.' ) ).join( '.' );
 }
 
 /**
@@ -968,7 +963,6 @@ export default {
 	getDomainPriceRule,
 	getDomainRegistrations,
 	getDomainRegistrationsWithoutPrivacy,
-	getDomainRegistrationTld,
 	getDomainTransfers,
 	getDomainTransfersWithoutPrivacy,
 	getGoogleApps,

--- a/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
@@ -15,6 +15,7 @@ const debug = debugFactory( 'calypso:my-sites:upgrades:checkout:transaction-step
  */
 import analytics from 'lib/analytics';
 import adTracking from 'lib/analytics/ad-tracking';
+import { getTld } from 'lib/domains';
 import { cartItems } from 'lib/cart-values';
 import { displayError, clear } from 'lib/upgrades/notices';
 import upgradesActions from 'lib/upgrades/actions';
@@ -130,7 +131,7 @@ const TransactionStepsMixin = {
 
 		cartItems.getDomainRegistrations( cart ).forEach( function( cartItem ) {
 			analytics.tracks.recordEvent( 'calypso_domain_registration', {
-				domain_tld: cartItems.getDomainRegistrationTld( cartItem ),
+				domain_tld: getTld( cartItem.meta ),
 				success: success,
 			} );
 		} );


### PR DESCRIPTION
We want to also get the transfer-in TLDs here so we can show the TLD specific forms if someone is trying to transfer in a domain.
Reuse `getTld` which is better than the one in `cartItems`.

Test:
- Try to transfer in a .fr domain
- Go to checkout
- Make sure you're seeing the TLD specific form and you can initiate the transfer