### PR TITLE
Domains: Use full list of WPCOM nameservers

### DIFF
--- a/client/lib/domains/nameservers/index.js
+++ b/client/lib/domains/nameservers/index.js
@@ -8,7 +8,7 @@
 import update from 'immutability-helper';
 import { every, reject } from 'lodash';
 
-const WPCOM_DEFAULTS = [ 'ns1.wordpress.com', 'ns2.wordpress.com' ];
+const WPCOM_DEFAULTS = [ 'ns1.wordpress.com', 'ns2.wordpress.com', 'ns3.wordpress.com' ];
 
 function isWpcomDefaults( nameservers ) {
 	if ( nameservers.length === 0 ) {


### PR DESCRIPTION
All three should be set, not just two.

Related discussion on P2: p99Zz8-9i-p2.

### Testing
Go to Domains -> custom domain -> Name Servers and DNS and toggle the nameservers. Try setting custom ones, then WPCOM ones, etc. Verify that the correct values are save (especially when it comes to the default WPCOM ones).