### PR TITLE
Rewind: Introduce notes-formatted visual block

### DIFF
--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -1,0 +1,68 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export const FormattedBlock = ( { content = {} } ) => {
+	const { siteId, children, commentId, name, postId, text = null, type } = content;
+
+	if ( 'string' === typeof content ) {
+		return content;
+	}
+
+	if ( undefined === type && ! children ) {
+		return text;
+	}
+
+	const descent = children.map( ( child, key ) => (
+		<FormattedBlock key={ key } content={ child } />
+	) );
+
+	switch ( type ) {
+		case 'comment':
+			return (
+				<a href={ `/read/blogs/${ siteId }/posts/${ postId }#comment-${ commentId }` }>
+					{ descent }
+				</a>
+			);
+
+		case 'filepath':
+			return (
+				<div>
+					<code>{ descent }</code>
+				</div>
+			);
+
+		case 'person':
+			return (
+				<a href={ `/people/edit/${ siteId }/${ name }` }>
+					<strong>{ descent }</strong>
+				</a>
+			);
+
+		case 'plugin':
+			return <a href={ `/plugins/${ name }/${ siteId }` }>{ descent }</a>;
+
+		case 'post':
+			return (
+				<a href={ `/read/blogs/${ siteId }/posts/${ postId }` }>
+					<em>{ descent }</em>
+				</a>
+			);
+
+		case 'theme':
+			return (
+				<a href={ content.url } target="_blank" rel="noopener noreferrer">
+					<strong>
+						<em>{ descent }</em>
+					</strong>
+				</a>
+			);
+
+		default:
+			return descent;
+	}
+};
+
+export default FormattedBlock;

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -16,6 +16,7 @@ import ActivityActor from './activity-actor';
 import ActivityIcon from './activity-icon';
 import EllipsisMenu from 'components/ellipsis-menu';
 import FoldableCard from 'components/foldable-card';
+import FormattedBlock from 'components/notes-formatted-block';
 import PopoverMenuItem from 'components/popover/menu-item';
 
 const stopPropagation = event => event.stopPropagation();
@@ -64,31 +65,8 @@ class ActivityLogItem extends Component {
 
 	handleClickBackup = () => this.props.requestDialog( this.props.log.activityId, 'item', 'backup' );
 
-	//
-	// TODO: Descriptions are temporarily disabled and this method is not called.
-	// Rich descriptions will be added after designs have been prepared for all types of activity.
-	//
-	renderDescription() {
-		const { log, moment, translate, applySiteOffset } = this.props;
-		const { activityName, activityTs } = log;
-
-		return (
-			<div>
-				<div>
-					{ translate( 'An event "%(eventName)s" occurred at %(date)s', {
-						args: {
-							date: applySiteOffset( moment.utc( activityTs ) ).format( 'LLL' ),
-							eventName: activityName,
-						},
-					} ) }
-				</div>
-				<div className="activity-log-item__id">ID { activityTs }</div>
-			</div>
-		);
-	}
-
 	renderHeader() {
-		const { applySiteOffset, log, moment } = this.props;
+		const { log } = this.props;
 		const { activityDescription, activityTitle } = log;
 
 		return (
@@ -101,68 +79,9 @@ class ActivityLogItem extends Component {
 				) }
 				{ activityDescription && (
 					<div className="activity-log-item__description">
-						{ activityDescription.map( ( part, key ) => {
-							if ( 'string' === typeof part ) {
-								return part;
-							}
-
-							const { siteId, children, commentId, name, postId, type } = part;
-
-							switch ( type ) {
-								case 'comment':
-									return (
-										<a
-											key={ key }
-											href={ `/read/blogs/${ siteId }/posts/${ postId }#comment-${ commentId }` }
-										>
-											{ children }
-										</a>
-									);
-
-								case 'filepath':
-									return (
-										<div>
-											<code>{ children }</code>
-										</div>
-									);
-
-								case 'person':
-									return (
-										<a key={ key } href={ `/people/edit/${ siteId }/${ name }` }>
-											<strong>{ children }</strong>
-										</a>
-									);
-
-								case 'plugin':
-									return (
-										<a key={ key } href={ `/plugins/${ name }/${ siteId }` }>
-											{ children }
-										</a>
-									);
-
-								case 'post':
-									return (
-										<a key={ key } href={ `/read/blogs/${ siteId }/posts/${ postId }` }>
-											<em>{ children }</em>
-										</a>
-									);
-
-								case 'theme':
-									return (
-										<a key={ key } href={ part.url } target="_blank" rel="noopener noreferrer">
-											<strong>
-												<em>{ children }</em>
-											</strong>
-										</a>
-									);
-
-								case 'time':
-									return applySiteOffset( moment.utc( part.time ) ).format( part.format );
-
-								default:
-									return children;
-							}
-						} ) }
+						{ activityDescription.map( ( part, key ) => (
+							<FormattedBlock key={ key } content={ part } />
+						) ) }
 					</div>
 				) }
 			</div>
@@ -204,18 +123,8 @@ class ActivityLogItem extends Component {
 		);
 	}
 
-	renderTime() {
-		const { moment, log, applySiteOffset } = this.props;
-
-		return (
-			<div className="activity-log-item__time">
-				{ applySiteOffset( moment.utc( log.activityTs ) ).format( 'LT' ) }
-			</div>
-		);
-	}
-
 	render() {
-		const { className, log } = this.props;
+		const { applySiteOffset, className, log, moment } = this.props;
 		const { activityIcon, activityIsDiscarded, activityStatus } = log;
 
 		const classes = classNames( 'activity-log-item', className, {
@@ -225,7 +134,9 @@ class ActivityLogItem extends Component {
 		return (
 			<div className={ classes }>
 				<div className="activity-log-item__type">
-					{ this.renderTime() }
+					<div className="activity-log-item__time">
+						{ applySiteOffset( moment.utc( log.activityTs ) ).format( 'LT' ) }
+					</div>
 					<ActivityIcon activityIcon={ activityIcon } activityStatus={ activityStatus } />
 				</div>
 				<FoldableCard


### PR DESCRIPTION
As we start to introduce formatting into the Activity Log events we need
to transform their API format, attributed text, into React components.

In #19537 we pulled in code from the experimental notifications panel
rewrite in order to parse and transform the data. There were a few minor
issues left over from there including the fact that we _need_ a
recursive render and only had a linear one.

This patch introduces a separate component which can call itself in
order to add the recursive descent into rendering these formatted
objects. It also fixes a few issues that would have been there had
we already started sending the formatted summaries.

**Testing**

Need to apply D8335 and sandbox `public-api.wordpress.com` then open
a site with **Activity Log** enabled and view the events. Find an event of a
type formatted in D8335 and make sure it displays with formatting, also
that it doesn't crash Calypso.

cc: @Automattic/lannister because there are opportunities for overlap in
notifications panel code.