### PR TITLE
.org Plans: persist feature and plan url parameters upon changes of the yearly/monthly toggle

### DIFF
--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -47,7 +47,7 @@ const PlanFeaturesActions = ( {
 		{
 			'is-current': current,
 			'is-primary': selectedPlan
-				? planType === selectedPlan
+				? planType === selectedPlan || planType === selectedPlan.concat( '_monthly' )
 				: ( primaryUpgrade && ! isPlaceholder ) || isPopular,
 		},
 		className

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -18,6 +18,7 @@ import Button from 'components/button';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPlanClass, isMonthly } from 'lib/plans/constants';
+import { planLevelsMatch } from 'lib/plans/index';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 const PlanFeaturesActions = ( {
@@ -47,7 +48,7 @@ const PlanFeaturesActions = ( {
 		{
 			'is-current': current,
 			'is-primary': selectedPlan
-				? planType === selectedPlan || planType === selectedPlan.concat( '_monthly' )
+				? planLevelsMatch( selectedPlan, planType )
 				: ( primaryUpgrade && ! isPlaceholder ) || isPopular,
 		},
 		className

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -347,14 +347,13 @@ class PlansFeaturesMain extends Component {
 
 	constructPath( plansUrl, intervalType ) {
 		const { selectedFeature, selectedPlan, site } = this.props;
-		const path = addQueryArgs(
+		return addQueryArgs(
 			{
 				feature: selectedFeature,
 				plan: selectedPlan,
 			},
 			plansLink( plansUrl, site, intervalType )
 		);
-		return path;
 	}
 
 	getIntervalTypeToggle() {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -345,15 +345,20 @@ class PlansFeaturesMain extends Component {
 		);
 	}
 
+	constructPath( plansUrl, intervalType ) {
+		const { selectedFeature, selectedPlan, site } = this.props;
+		const path = addQueryArgs(
+			{
+				feature: selectedFeature,
+				plan: selectedPlan,
+			},
+			plansLink( plansUrl, site, intervalType )
+		);
+		return path;
+	}
+
 	getIntervalTypeToggle() {
-		const {
-			basePlansPath,
-			intervalType,
-			selectedFeature,
-			selectedPlan,
-			site,
-			translate,
-		} = this.props;
+		const { basePlansPath, intervalType, translate } = this.props;
 		const segmentClasses = classNames( 'plan-features__interval-type', 'price-toggle' );
 
 		let plansUrl = '/plans';
@@ -366,26 +371,14 @@ class PlansFeaturesMain extends Component {
 			<SegmentedControl compact className={ segmentClasses } primary={ true }>
 				<SegmentedControlItem
 					selected={ intervalType === 'monthly' }
-					path={ addQueryArgs(
-						{
-							feature: selectedFeature,
-							plan: selectedPlan,
-						},
-						plansLink( plansUrl, site, 'monthly' )
-					) }
+					path={ this.constructPath( plansUrl, 'monthly' ) }
 				>
 					{ translate( 'Monthly billing' ) }
 				</SegmentedControlItem>
 
 				<SegmentedControlItem
 					selected={ intervalType === 'yearly' }
-					path={ addQueryArgs(
-						{
-							feature: selectedFeature,
-							plan: selectedPlan,
-						},
-						plansLink( plansUrl, site, 'yearly' )
-					) }
+					path={ this.constructPath( plansUrl, 'yearly' ) }
 				>
 					{ translate( 'Yearly billing' ) }
 				</SegmentedControlItem>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -27,6 +27,7 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 } from 'lib/plans/constants';
+import { addQueryArgs } from 'lib/url';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import FAQ from 'components/faq';
@@ -345,10 +346,18 @@ class PlansFeaturesMain extends Component {
 	}
 
 	getIntervalTypeToggle() {
-		const { translate, intervalType, site, basePlansPath } = this.props;
+		const {
+			basePlansPath,
+			intervalType,
+			selectedFeature,
+			selectedPlan,
+			site,
+			translate,
+		} = this.props;
 		const segmentClasses = classNames( 'plan-features__interval-type', 'price-toggle' );
 
 		let plansUrl = '/plans';
+
 		if ( basePlansPath ) {
 			plansUrl = basePlansPath;
 		}
@@ -357,14 +366,26 @@ class PlansFeaturesMain extends Component {
 			<SegmentedControl compact className={ segmentClasses } primary={ true }>
 				<SegmentedControlItem
 					selected={ intervalType === 'monthly' }
-					path={ plansLink( plansUrl, site, 'monthly' ) }
+					path={ addQueryArgs(
+						{
+							feature: selectedFeature,
+							plan: selectedPlan,
+						},
+						plansLink( plansUrl, site, 'monthly' )
+					) }
 				>
 					{ translate( 'Monthly billing' ) }
 				</SegmentedControlItem>
 
 				<SegmentedControlItem
 					selected={ intervalType === 'yearly' }
-					path={ plansLink( plansUrl, site, 'yearly' ) }
+					path={ addQueryArgs(
+						{
+							feature: selectedFeature,
+							plan: selectedPlan,
+						},
+						plansLink( plansUrl, site, 'yearly' )
+					) }
 				>
 					{ translate( 'Yearly billing' ) }
 				</SegmentedControlItem>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/20195

**Context:**
We are improving the landing view of the Plans pages when redirected from upgrade nudges. To this end, we pass `feature` and `plan` parameters (the latter included in #20204 ) in the url of the landing Plans page to highlight the selected feature and emphasize the corresponding plan (primary buttons and soon, a ribbon component). 

**Issue this patch fixes:** `yearly/monthly` toggle removes the parameters from the url, and thus any emphasis on the plan and/or feature. 

**To test:** 
- checkout this branch or use calypso.live
- select any feature and plan to be added to the url of the plans page or use upgrade nudges for redirection
e.g.
`http://calypso.localhost:3000/plans/:jetpack_connected_site?feature=seo-preview-tools`
`http://calypso.localhost:3000/plans/:jetpack_connected_site?feature=google-analytics&plan=jetpack_business`

- verify that switching between the `monthly` and `yearly` views does not change the plan emphasis nor the feature highlight (whenever present).