### PR TITLE
Change placeholder in Rewind credentials form host field

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -103,7 +103,7 @@ export class CredentialsForm extends Component {
 						<FormTextInput
 							name="host"
 							id="host-address"
-							placeholder={ translate( 'yoursite.com' ) }
+							placeholder={ translate( 'YourGroovyDomain.com' ) }
 							value={ get( this.state.form, 'host', '' ) }
 							onChange={ this.handleFieldChange }
 							disabled={ formIsSubmitting }


### PR DESCRIPTION
We should not be using `yoursite.com` as a placeholder here. Updated to `YourGroovyDomain.com` instead.