### PR TITLE
Add Happychat button to credentials setup flow footer

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
@@ -12,7 +12,7 @@ import CompactCard from 'components/card/compact';
 import Gridicon from 'gridicons';
 import Popover from 'components/popover';
 import HappychatButton from 'components/happychat/button';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
 class SetupFooter extends Component {
 	componentWillMount() {
@@ -22,8 +22,6 @@ class SetupFooter extends Component {
 	togglePopover = () => this.setState( { showPopover: ! this.state.showPopover } );
 
 	storePopoverLink = ref => this.popoverLink = ref;
-
-	happychatEvent = () => this.props.recordTracksEvent( 'rewind_credentials_get_help', {} );
 
 	render() {
 		const { translate } = this.props;
@@ -40,7 +38,7 @@ class SetupFooter extends Component {
 				</a>
 				<HappychatButton
 					className="credentials-setup-flow__happychat-button"
-					onClick={ this.happychatEvent }
+					onClick={ this.props.happychatEvent }
 				>
 					<Gridicon icon="chat" />
 					<span className="credentials-setup-flow__happychat-button-text">
@@ -65,5 +63,7 @@ class SetupFooter extends Component {
 }
 
 export default connect( null, {
-	recordTracksEvent,
+	happychatEvent: withAnalytics(
+		recordTracksEvent( 'rewind_credentials_get_help', {} )
+	),
 } )( localize( SetupFooter ) );

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
@@ -12,7 +12,7 @@ import CompactCard from 'components/card/compact';
 import Gridicon from 'gridicons';
 import Popover from 'components/popover';
 import HappychatButton from 'components/happychat/button';
-import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class SetupFooter extends Component {
 	componentWillMount() {
@@ -63,7 +63,5 @@ class SetupFooter extends Component {
 }
 
 export default connect( null, {
-	happychatEvent: withAnalytics(
-		recordTracksEvent( 'rewind_credentials_get_help', {} )
-	),
+	happychatEvent: () => recordTracksEvent( 'rewind_credentials_get_help', {} ),
 } )( localize( SetupFooter ) );

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,6 +12,7 @@ import CompactCard from 'components/card/compact';
 import Gridicon from 'gridicons';
 import Popover from 'components/popover';
 import HappychatButton from 'components/happychat/button';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class SetupFooter extends Component {
 	componentWillMount() {
@@ -21,11 +23,12 @@ class SetupFooter extends Component {
 
 	storePopoverLink = ref => this.popoverLink = ref;
 
+	happychatEvent = () => this.props.recordTracksEvent( 'rewind_credentials_get_help', {} );
+
 	render() {
 		const { translate } = this.props;
 
 		return (
-
 			<CompactCard className="credentials-setup-flow__footer">
 				<a
 					onClick={ this.togglePopover }
@@ -35,7 +38,10 @@ class SetupFooter extends Component {
 					<Gridicon icon="help" size={ 18 } className="credentials-setup-flow__footer-popover-icon" />
 					{ translate( 'Why do I need this?' ) }
 				</a>
-				<HappychatButton className="credentials-setup-flow__happychat-button" >
+				<HappychatButton
+					className="credentials-setup-flow__happychat-button"
+					onClick={ this.happychatEvent }
+				>
 					<Gridicon icon="chat" />
 					<span className="credentials-setup-flow__happychat-button-text">
 						{ translate( 'Get help' ) }
@@ -58,4 +64,6 @@ class SetupFooter extends Component {
 	}
 }
 
-export default localize( SetupFooter );
+export default connect( null, {
+	recordTracksEvent,
+} )( localize( SetupFooter ) );

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 import CompactCard from 'components/card/compact';
 import Gridicon from 'gridicons';
 import Popover from 'components/popover';
+import HappychatButton from 'components/happychat/button';
 
 class SetupFooter extends Component {
 	componentWillMount() {
@@ -34,6 +35,12 @@ class SetupFooter extends Component {
 					<Gridicon icon="help" size={ 18 } className="credentials-setup-flow__footer-popover-icon" />
 					{ translate( 'Why do I need this?' ) }
 				</a>
+				<HappychatButton className="credentials-setup-flow__happychat-button" >
+					<Gridicon icon="chat" />
+					<span className="credentials-setup-flow__happychat-button-text">
+						{ translate( 'Get help' ) }
+					</span>
+				</HappychatButton>
 				<Popover
 					context={ this.popoverLink }
 					isVisible={ this.state.showPopover }

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
@@ -55,3 +55,14 @@
 	top: 3px;
 	left: -6px;
 }
+
+.credentials-setup-flow__happychat-button.is-borderless {
+	padding: 0;
+	margin-left: 2rem;
+	margin-top: -4px;
+	color: $blue-wordpress;
+}
+
+.credentials-setup-flow__happychat-button-text {
+	margin-left: 6px;
+}

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
@@ -63,6 +63,10 @@
 	color: $blue-wordpress;
 }
 
+.credentials-setup-flow__happychat-button.is-borderless:hover {
+	color: $link-highlight;
+}
+
 .credentials-setup-flow__happychat-button-text {
 	margin-left: 6px;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/20382

**Testing instructions:**
- I'm not 100% sure of the correct way to test this locally (to ensure that HappyChat appears active so the button will display) - however, if necessary, you can force the button to appear by forging `isChatAvailable` and setting it to `true` in button.jsx.
- Once HappyChat is available, ensure the button appears in the credentials setup footer, and ensure that clicking it activates the chat window.