### PR TITLE
Plugins: always redirect to plugin browser when no jetpack sites

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -186,15 +186,9 @@ function renderProvisionPlugins( context ) {
 }
 
 const controller = {
-	plugins( context, next ) {
+	plugins( context ) {
 		const { pluginFilter: filter = 'all' } = context.params;
-		const siteUrl = route.getSiteFragment( context.path );
 		const basePath = route.sectionify( context.path ).replace( '/' + filter, '' );
-
-		// bail if no site is selected and the user has no Jetpack sites.
-		if ( ! siteUrl && ! hasJetpackSites( context.store.getState() ) ) {
-			return next();
-		}
 
 		context.params.pluginFilter = filter;
 		notices.clearNotices( 'notices' );
@@ -252,6 +246,24 @@ const controller = {
 				return;
 			}
 		}
+		next();
+	},
+
+	redirectSimpleSitesToPluginBrowser( context, next ) {
+		const site = getSelectedSite( context.store.getState() );
+
+		// Selected site is not a Jetpack site
+		if ( site && ! site.jetpack ) {
+			page.redirect( `/plugins/${ site.slug }` );
+			return;
+		}
+
+		//  None of the other sites are Jetpack sites
+		if ( ! hasJetpackSites( context.store.getState() ) ) {
+			page.redirect( '/plugins' );
+			return;
+		}
+
 		next();
 	},
 

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -259,7 +259,7 @@ const controller = {
 		}
 
 		//  None of the other sites are Jetpack sites
-		if ( ! hasJetpackSites( context.store.getState() ) ) {
+		if ( ! site && ! hasJetpackSites( context.store.getState() ) ) {
 			page.redirect( '/plugins' );
 			return;
 		}

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -11,17 +11,6 @@ import { navigation, siteSelection, sites } from 'my-sites/controller';
 import config from 'config';
 import pluginsController from './controller';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSite } from 'state/ui/selectors';
-
-const ifSimpleSiteThenRedirectTo = path => ( context, next ) => {
-	const site = getSelectedSite( context.store.getState() );
-
-	if ( site && ! site.jetpack ) {
-		page.redirect( `${ path }/${ site.slug }` );
-	}
-
-	next();
-};
 
 export default function() {
 	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
@@ -67,18 +56,17 @@ export default function() {
 			'/plugins/manage/:site?',
 			siteSelection,
 			navigation,
-			ifSimpleSiteThenRedirectTo( '/plugins' ),
-			pluginsController.plugins,
-			sites
+			pluginsController.redirectSimpleSitesToPluginBrowser,
+			pluginsController.plugins
 		);
 
 		page(
 			'/plugins/:pluginFilter(active|inactive|updates)/:site_id?',
 			siteSelection,
 			navigation,
+			pluginsController.redirectSimpleSitesToPluginBrowser,
 			pluginsController.jetpackCanUpdate,
-			pluginsController.plugins,
-			sites
+			pluginsController.plugins
 		);
 
 		page(


### PR DESCRIPTION
Currently `/plugins/manage/:site` redirects to `/plugins/:site` if selected site is a simple non-jetpack site (i.e. the site has no plugins to manage).

Accessing `/plugins/manage` or `/plugins/:pluginFilter(active|inactive|updates)` (without selected site) however would show user a site selector even when none of the sites on the list is a Jetpack site. Selecting anything from that list would then redirect users first to `/plugins/manage/:site` and then again to `/plugins/:site`.

With this change accessing anything under `/plugins/manage/*` and having only non jetpack sites will redirect directly to `/plugins` and no list selector is never needed.

Previously accessing `/plugins/:pluginFilter(active|inactive|updates)/:nonJetpackSite` would show "No plugins ..." page, although such route should not even be accessible.

With this change that route will be redirected to `/plugins/:nonJetpackSite`

If user has Jetpack enabled site(s), they never see the site selector anyway because plugin manager works with "All sites" selected.

Thus site selector middleware `sites` is no more needed and can be removed.

This came up during [discussion](https://github.com/Automattic/wp-calypso/pull/20312#issuecomment-348683546) at previous attempt to remove `sites` middlewares.

# Testing
Sorry, this got a bit complicated... :-)

### With 2+ non-Jetpack sites and 0 jetpack sites

- http://calypso.localhost:3000/plugins/manage
 →
**Before:** site selector → /plugins/:selectedSite
**With PR:** /plugins

- http://calypso.localhost:3000/plugins/inactive
- http://calypso.localhost:3000/plugins/active
- http://calypso.localhost:3000/plugins/updates
 →
**Before:** site selector → /plugins/:filter/:selectedSite ("No plugins ..." page)
**With PR:** /plugins

- http://calypso.localhost:3000/plugins/manage/:site
 →
**Before:** /plugins/:site
**With PR:** /plugins/:site


- http://calypso.localhost:3000/plugins/inactive/:site
- http://calypso.localhost:3000/plugins/active/:site
- http://calypso.localhost:3000/plugins/updates/:site
 →
**Before:** "No plugins ..." page
**With PR:** /plugins/:site

### With 1+ jetpack sites

Ensure this all works when "All My Sites" option is selected as well single site.

- Ensure browsing plugins works:
  - http://calypso.localhost:3000/plugins
  - http://calypso.localhost:3000/plugins/:jetpacksite
  - http://calypso.localhost:3000/plugins/new
  - http://calypso.localhost:3000/plugins/new/:jetpacksite

- Ensure plugin manager works:
  - http://calypso.localhost:3000/plugins/updates
  - http://calypso.localhost:3000/plugins/updates/:jetpacksite
  - http://calypso.localhost:3000/plugins/manage
  - http://calypso.localhost:3000/plugins/manage/:jetpacksite
  - http://calypso.localhost:3000/plugins/jetpack/eligibility/:jetpacksite

- Ensure you can open a single plugin
  - http://calypso.localhost:3000/plugins/woocommerce
  - http://calypso.localhost:3000/plugins/woocommerce/:jetpacksite
