### PR TITLE
Plugins: fix wrong click handler for info-popovers

### DIFF
--- a/client/components/info-popover/README.md
+++ b/client/components/info-popover/README.md
@@ -60,8 +60,12 @@ that can trigger the opening and closing of the InfoPopover then you need to pas
 
 ```js
 handleAction( event ) {
-	this.refs && this.refs.infoPop._onClick( event );
+	this.infoPopoverRef.handleClick( event );
 },
+
+setInfoPopoverRef = c => {
+	this.infoPopoverRef = c;
+};
 
 render() {
 	return (
@@ -69,7 +73,7 @@ render() {
 			<label onClick={ this.handleAction } ref="moreInfoLabel">More Info</label>
 			<InfoPopover
 				position="bottom left"
-				ref="infoPop"
+				ref="{ this.setInfoPopoverRef }"
 				className="more-info"
 				gaEventCategory="Reader"
 				popoverName="More info in the reader"

--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -18,8 +18,12 @@ class PluginAction extends React.Component {
 		if ( ! this.props.disabledInfo ) {
 			this.props.action();
 		} else {
-			this.refs.infoPopover._onClick( event );
+			this.infoPopoverRef.handleClick( event );
 		}
+	};
+
+	setInfoPopoverRef = c => {
+		this.infoPopoverRef = c;
 	};
 
 	renderLabel = () => {
@@ -47,7 +51,7 @@ class PluginAction extends React.Component {
 				position="bottom left"
 				popoverName={ 'Plugin Action Disabled' + this.props.label }
 				gaEventCategory="Plugins"
-				ref="infoPopover"
+				ref={ this.setInfoPopoverRef }
 				ignoreContext={ this.refs && this.refs.disabledInfoLabel }
 			>
 				{ this.props.disabledInfo }

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -85,7 +85,11 @@ export class PluginInstallButton extends Component {
 	};
 
 	togglePopover = event => {
-		this.refs.infoPopover._onClick( event );
+		this.infoPopoverRef.handleClick( event );
+	};
+
+	setInfoPopoverRef = c => {
+		this.infoPopoverRef = c;
 	};
 
 	getDisabledInfo() {
@@ -169,7 +173,7 @@ export class PluginInstallButton extends Component {
 					position="bottom left"
 					popoverName={ 'Plugin Action Disabled Install' }
 					gaEventCategory="Plugins"
-					ref="infoPopover"
+					ref={ this.setInfoPopoverRef }
 					ignoreContext={ this.refs && this.refs.disabledInfoLabel }
 				>
 					<div>
@@ -228,7 +232,7 @@ export class PluginInstallButton extends Component {
 							position="bottom left"
 							popoverName={ 'Plugin Action Disabled Install' }
 							gaEventCategory="Plugins"
-							ref="infoPopover"
+							ref={ this.setInfoPopoverRef }
 							ignoreContext={ this.refs && this.refs.disabledInfoLabel }
 						>
 							{ this.getDisabledInfo() }


### PR DESCRIPTION
Cleaning up two small onClick bugs.

- Call `infoPopover.handleClick` instead of non-existing `infoPopover._onClick`. It got [removed here](https://github.com/Automattic/wp-calypso/commit/68a743c078939a910e4b030164a4c960a30878de#diff-f74441966e16090bbef51b3ba1f55d53L74).
- Fixes deprecated way to refer components, [as complained by eslint](https://github.com/yannickcr/eslint-plugin-react/blob/41d9809c430a0ea0651a4c011f83b25b71f8c779/docs/rules/no-string-refs.md).
- Updates docs for info-popover component.

I'm new to React so please check if that `ref` fix really is as it should be. :-)

## Test
(Compare between wordpress.com and localhost)

### Plugin manager
- Have a WP site connected to Calypso either with `define( 'DISALLOW_FILE_MODS', true );` or a plugin which isn't in WP plugin repo.
- Go to https://wordpress.com/plugins/manage/:site
- Click "Autoupdates disabled" text 
    ![image](https://user-images.githubusercontent.com/87168/33521377-19310f52-d7d9-11e7-86d3-929b1034bd28.png)
- Boom!
    ![image](https://user-images.githubusercontent.com/87168/33521468-0ebfbbde-d7db-11e7-8345-acd85f07d749.png)

### Plugin browser
- This is trickier as you need to have a jetpack site in "unreachable" state
- Go to https://wordpress.com/plugins/akismet
- Click "Site unreachable" text
   ![image](https://user-images.githubusercontent.com/87168/33521498-d0399bcc-d7db-11e7-9060-e2b99f1470d8.png)
- 💥 
    ![image](https://user-images.githubusercontent.com/87168/33521506-0a34bb22-d7dc-11e7-8bab-43ed3b8d42ef.png)