### PR TITLE
Domains: Poperly handle 'empty_results' error from the backend

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -41,6 +41,7 @@ class DomainSearchResults extends React.Component {
 		selectedSite: PropTypes.object,
 		availableDomain: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		suggestions: PropTypes.array,
+		isLoadingSuggestions: PropTypes.bool.isRequired,
 		placeholderQuantity: PropTypes.number.isRequired,
 		buttonLabel: PropTypes.string,
 		mappingSuggestionLabel: PropTypes.string,
@@ -203,7 +204,7 @@ class DomainSearchResults extends React.Component {
 		let suggestionElements;
 		let unavailableOffer;
 
-		if ( this.props.suggestions.length ) {
+		if ( ! this.props.isLoadingSuggestions && this.props.suggestions ) {
 			suggestionElements = this.props.suggestions.map( function( suggestion, i ) {
 				if ( suggestion.is_placeholder ) {
 					return <DomainSuggestion.Placeholder key={ 'suggestion-' + i } />;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -207,11 +207,9 @@ class RegisterDomainStep extends React.Component {
 
 		if ( error && error.error ) {
 			//don't modify global state
-			const domainError = new Error();
-			domainError.code = error.error;
 			const queryObject = getQueryObject( nextProps );
 			if ( queryObject ) {
-				this.showValidationErrorMessage( queryObject.query, domainError );
+				this.showValidationErrorMessage( queryObject.query, error.error );
 			}
 		}
 	}
@@ -469,8 +467,7 @@ class RegisterDomainStep extends React.Component {
 							if ( error && error.statusCode === 503 ) {
 								this.props.onDomainsAvailabilityChange( false );
 							} else if ( error && error.error ) {
-								error.code = error.error;
-								this.showValidationErrorMessage( domain, error.code );
+								this.showValidationErrorMessage( domain, error.error );
 							}
 
 							const analyticsResults = [
@@ -577,8 +574,7 @@ class RegisterDomainStep extends React.Component {
 					if ( error && error.statusCode === 503 ) {
 						this.props.onDomainsAvailabilityChange( false );
 					} else if ( error && error.error ) {
-						error.code = error.error;
-						this.showValidationErrorMessage( domain, error );
+						this.showValidationErrorMessage( domain, error.error );
 					}
 
 					const analyticsResults = [
@@ -591,6 +587,11 @@ class RegisterDomainStep extends React.Component {
 						-1,
 						this.props.analyticsSection
 					);
+
+					this.setState( {
+						subdomainSearchResults: [],
+						loadingSubdomainResults: false,
+					} );
 				} );
 		}
 	};
@@ -695,7 +696,7 @@ class RegisterDomainStep extends React.Component {
 				);
 			}
 
-			suggestions = this.props.defaultSuggestions;
+			suggestions = this.props.defaultSuggestions || [];
 		}
 
 		return (
@@ -713,6 +714,7 @@ class RegisterDomainStep extends React.Component {
 				onClickTransfer={ this.goToTransferDomainStep }
 				tracksButtonClickSource="exact-match-top"
 				suggestions={ suggestions }
+				isLoadingSuggestions={ this.state.loadingResults }
 				products={ this.props.products }
 				selectedSite={ this.props.selectedSite }
 				offerUnavailableOption={ this.props.offerUnavailableOption }

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -32,6 +32,7 @@ const domainAvailability = {
 	AVAILABLE: 'available',
 	BLACKLISTED: 'blacklisted_domain',
 	EMPTY_QUERY: 'empty_query',
+	EMPTY_RESULTS: 'empty_results',
 	FORBIDDEN: 'forbidden_domain',
 	FORBIDDEN_SUBDOMAIN: 'forbidden_subdomain',
 	INVALID: 'invalid_domain',

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -163,6 +163,7 @@ function getAvailabilityNotice( domain, error, site ) {
 		case domainAvailability.PURCHASES_DISABLED:
 		case domainAvailability.TLD_NOT_SUPPORTED:
 		case domainAvailability.UNKNOWN:
+		case domainAvailability.EMPTY_RESULTS:
 			// unavailable domains are displayed in the search results, not as a notice OR
 			// domain registrations are closed, in which case it is handled in parent
 			message = null;


### PR DESCRIPTION
In some rare cases, it's possible we won't be able to generate any suggestions for a query. It might be because many (or all) TLDs are in maintenance mode, for example. In those cases, the backend returns an error, `empty_results`. We need to handle that case explicitly - otherwise, a generic, confusing error is shown to the user.

### Testing
Before:
<img width="998" alt="screen shot 2017-12-03 at 05 23 50" src="https://user-images.githubusercontent.com/3392497/33522493-45502874-d7ee-11e7-86e2-f4377212d73b.png">

After:
no error is shown ;)

How to test:
Best to hack the backend to return a `WP_Error` when needed:
* Return `empty_result` for all calls to `/suggestions` - no errors should be shown on the frontend. It's a super-edge case that should not happen, but 🤷‍♂️ 
* Return `empty_result` only for call to domainsbot, not the wpcom subdomain suggestion.
* Return `empty_result` for the wpcom subdomain suggestion - the rest of the suggestions should be displayed, but the subdomain suggestion should not remain in the loading state (this was broken before this PR).
* Same as previous point, but a different error (very rare, but technically can happen). Should display the error, wpcom subdomain suggestion should not be in loading state.