### PR TITLE
.org Plans: adapt the GA upgrade nudge to pass JP-specific plan constant prop for JP sites

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -38,7 +38,11 @@ import {
 } from 'state/sites/selectors';
 import { isJetpackModuleActive } from 'state/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { FEATURE_GOOGLE_ANALYTICS, PLAN_BUSINESS } from 'lib/plans/constants';
+import {
+	FEATURE_GOOGLE_ANALYTICS,
+	PLAN_BUSINESS,
+	PLAN_JETPACK_BUSINESS,
+} from 'lib/plans/constants';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 
 const validateGoogleAnalyticsCode = code => ! code || code.match( /^UA-\d+-\d+$/i );
@@ -185,7 +189,7 @@ class GoogleAnalyticsForm extends Component {
 						) }
 						event={ 'google_analytics_settings' }
 						feature={ FEATURE_GOOGLE_ANALYTICS }
-						plan={ PLAN_BUSINESS }
+						plan={ siteIsJetpack ? PLAN_JETPACK_BUSINESS : PLAN_BUSINESS }
 						title={ nudgeTitle }
 					/>
 				) : (


### PR DESCRIPTION
Currently, the plan prop in GA banner is hardcoded to pass .com specific plan constant, which is not relevant when in use with JP sites.
This patch adapts it to work for .org plans and pass distinct `plan` feature for either type of plans.

**To test:**
- checkout this branch or use calypso.live
- go to `http://calypso.localhost:3000/settings/traffic/:(jetpack_connected_)site`
- verify that the Banner in the `Google Analytics` section redirects to:
`http://calypso.localhost:3000/plans/:jetpack_connected_site?feature=google-analytics&plan=jetpack_business` (for .org sites)  
and 
`http://calypso.localhost:3000/plans/:site?feature=google-analytics&plan=business-bundle`
(for .com sites).

**Note:** for .org plans the feature will not be highlighted because it is not currently displayed in the menu.
**Context:**  we need it to properly set up downstream .org and .com plans highlight (see https://github.com/Automattic/wp-calypso/pull/20204).