### PR TITLE
Domains: Simplify the bundled cart items price check

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -36,6 +36,7 @@ import {
 	isDomainRedemption,
 	isDomainRegistration,
 	isDomainTransfer,
+	isBundled,
 	isFreeTrial,
 	isFreeWordPressComDomain,
 	isGoogleApps,
@@ -246,8 +247,7 @@ export function hasPlan( cart ) {
  */
 export function hasOnlyBundledDomainProducts( cart ) {
 	return (
-		cart &&
-		every( [ ...getDomainRegistrations( cart ), ...getDomainTransfers( cart ) ], 'is_bundled' )
+		cart && every( [ ...getDomainRegistrations( cart ), ...getDomainTransfers( cart ) ], isBundled )
 	);
 }
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -238,6 +238,19 @@ export function hasPlan( cart ) {
 	return cart && some( getAll( cart ), isPlan );
 }
 
+/**
+ * Does the cart contain only bundled domains and transfers
+ *
+ * @param {Object} cart - cart as `CartValue` object
+ * @return {Boolean} true if there are only bundled domains and transfers
+ */
+export function hasOnlyBundledDomainProducts( cart ) {
+	return (
+		cart &&
+		every( [ ...getDomainRegistrations( cart ), ...getDomainTransfers( cart ) ], 'is_bundled' )
+	);
+}
+
 export function hasPremiumPlan( cart ) {
 	return some( getAll( cart ), isPremium );
 }
@@ -995,6 +1008,7 @@ export default {
 	hasOnlyProductsOf,
 	hasOnlyRenewalItems,
 	hasPlan,
+	hasOnlyBundledDomainProducts,
 	hasPremiumPlan,
 	hasProduct,
 	hasRenewableSubscription,

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -263,6 +263,13 @@ export function isDomainTransferPrivacy( product ) {
 	return product.product_slug === domainProductSlugs.TRANSFER_IN_PRIVACY;
 }
 
+export function isBundled( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return !! product.is_bundled;
+}
+
 export function isCredits( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
@@ -406,6 +413,7 @@ export default {
 	isDomainTransfer,
 	isDomainTransferPrivacy,
 	isDomainTransferProduct,
+	isBundled,
 	isDotComPlan,
 	isEnterprise,
 	isFreeJetpackPlan,

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -12,15 +12,7 @@ import { connect } from 'react-redux';
  */
 import analytics from 'lib/analytics';
 import { canRemoveFromCart, cartItems } from 'lib/cart-values';
-import {
-	isCredits,
-	isDomainProduct,
-	isDomainTransferProduct,
-	isGoogleApps,
-	isTheme,
-	isMonthly,
-	isPlan,
-} from 'lib/products-values';
+import { isCredits, isGoogleApps, isTheme, isMonthly, isPlan } from 'lib/products-values';
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import * as upgradesActions from 'lib/upgrades/actions';
@@ -41,7 +33,7 @@ export class CartItem extends React.Component {
 	};
 
 	price() {
-		const { cart, cartItem, translate } = this.props;
+		const { cartItem, translate } = this.props;
 
 		if ( typeof cartItem.cost === 'undefined' ) {
 			return translate( 'Loading price' );
@@ -51,11 +43,7 @@ export class CartItem extends React.Component {
 			return this.getFreeTrialPrice();
 		}
 
-		if (
-			cartItems.hasDomainCredit( cart ) &&
-			( isDomainProduct( cartItem ) || isDomainTransferProduct( cartItem ) ) &&
-			cartItem.cost === 0
-		) {
+		if ( cartItem.is_bundled && cartItem.cost === 0 ) {
 			return this.getDomainPlanPrice( cartItem );
 		}
 

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -12,7 +12,14 @@ import { connect } from 'react-redux';
  */
 import analytics from 'lib/analytics';
 import { canRemoveFromCart, cartItems } from 'lib/cart-values';
-import { isCredits, isGoogleApps, isTheme, isMonthly, isPlan } from 'lib/products-values';
+import {
+	isCredits,
+	isGoogleApps,
+	isTheme,
+	isMonthly,
+	isPlan,
+	isBundled,
+} from 'lib/products-values';
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import * as upgradesActions from 'lib/upgrades/actions';
@@ -43,7 +50,7 @@ export class CartItem extends React.Component {
 			return this.getFreeTrialPrice();
 		}
 
-		if ( cartItem.is_bundled && cartItem.cost === 0 ) {
+		if ( isBundled( cartItem ) && cartItem.cost === 0 ) {
 			return this.getDomainPlanPrice( cartItem );
 		}
 

--- a/client/my-sites/checkout/checkout/privacy-protection.jsx
+++ b/client/my-sites/checkout/checkout/privacy-protection.jsx
@@ -38,12 +38,9 @@ class PrivacyProtection extends Component {
 
 	render() {
 		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart );
-		const domainTransfers = cartItems.getDomainTransfers( this.props.cart );
+		const freeWithPlan = cartItems.hasOnlyBundledDomainProducts( this.props.cart );
 		const { translate } = this.props;
 		const numberOfDomainRegistrations = domainRegistrations.length;
-		const hasOneFreePrivacy =
-			this.hasDomainPartOfPlan() &&
-			( numberOfDomainRegistrations === 1 || domainTransfers.length === 1 );
 
 		return (
 			<div>
@@ -87,7 +84,7 @@ class PrivacyProtection extends Component {
 									</span>
 									<span
 										className={ classnames( 'checkout__privacy-protection-radio-price-text', {
-											'free-with-plan': hasOneFreePrivacy,
+											'free-with-plan': freeWithPlan,
 										} ) }
 									>
 										{ translate( '%(cost)s/year', '%(cost)s per domain/year', {
@@ -95,7 +92,7 @@ class PrivacyProtection extends Component {
 											count: numberOfDomainRegistrations,
 										} ) }
 									</span>
-									{ hasOneFreePrivacy && (
+									{ freeWithPlan && (
 										<span className="checkout__privacy-protection-free-text">
 											{ translate( 'Free with your plan' ) }
 										</span>


### PR DESCRIPTION
Instead of doing a bunch of complicated checks to show the "Free with your plan" note we should just check the cartItem `is_bundled` property. We're doing this because plan can be bundled with domain, privacy, transfer and we don't want to replicate the logic for those in both the backend and Calypso.

This PR depends on D8594-code