### PR TITLE
Editor Notice: Update messaging and post-publish preview.

### DIFF
--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 
 /**
@@ -26,6 +26,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 export class EditorNotice extends Component {
 	static propTypes = {
 		translate: PropTypes.func,
+		moment: PropTypes.func,
 		siteId: PropTypes.number,
 		site: PropTypes.object,
 		type: PropTypes.string,
@@ -70,7 +71,7 @@ export class EditorNotice extends Component {
 
 	getText( key ) {
 		/* eslint-disable max-len */
-		const { translate, type, typeObject, site, postUrl, postDate } = this.props;
+		const { translate, type, typeObject, site, postUrl, postDate, moment } = this.props;
 		const formattedPostDate = moment( postDate ).format( 'lll' );
 		const typeLabel = typeObject && typeObject.labels.singular_name;
 

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { localize, moment } from 'i18n-calypso';
 import classNames from 'classnames';
 
 /**
@@ -35,6 +35,7 @@ export class EditorNotice extends Component {
 		onDismissClick: PropTypes.func,
 		error: PropTypes.object,
 		postUrl: PropTypes.string,
+		postDate: PropTypes.string,
 	};
 
 	handlePillExternalClick = () => {
@@ -69,7 +70,8 @@ export class EditorNotice extends Component {
 
 	getText( key ) {
 		/* eslint-disable max-len */
-		const { translate, type, typeObject, site, postUrl } = this.props;
+		const { translate, type, typeObject, site, postUrl, postDate } = this.props;
+		const formattedPostDate = moment( postDate ).format( 'lll' );
 		const typeLabel = typeObject && typeObject.labels.singular_name;
 
 		switch ( key ) {
@@ -191,60 +193,25 @@ export class EditorNotice extends Component {
 				}
 
 				if ( 'page' === type ) {
-					return translate( 'Page scheduled on {{siteLink/}}! {{a}}Add another page{{/a}}', {
-						components: {
-							siteLink: (
-								<a
-									href={ site.URL }
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={ this.handlePillExternalClick }
-								>
-									{ site.title }
-								</a>
-							),
-							a: <a href={ `/page/${ site.slug }` } />,
-						},
+					return translate( 'Page scheduled for %(formattedPostDate)s.', {
+						args: { formattedPostDate },
 						comment:
-							'Editor: Message displayed when a page is scheduled, with a link to the site it was scheduled on.',
+							'Editor: Message displayed when a page is scheduled, with the scheduled date and time.',
 					} );
 				}
 
 				if ( 'post' !== type && typeLabel ) {
-					return translate( '%(typeLabel)s scheduled on {{siteLink/}}!', {
-						args: { typeLabel },
-						components: {
-							siteLink: (
-								<a
-									href={ site.URL }
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={ this.handlePillExternalClick }
-								>
-									{ site.title }
-								</a>
-							),
-						},
+					return translate( '%(typeLabel)s scheduled for %(formattedPostDate)s.', {
+						args: { typeLabel, formattedPostDate },
 						comment:
-							'Editor: Message displayed when a post of a custom type is scheduled, with a link to the site it was scheduled on.',
+							'Editor: Message displayed when a post of a custom type is scheduled, with the scheduled date and time.',
 					} );
 				}
 
-				return translate( 'Post scheduled on {{siteLink/}}!', {
-					components: {
-						siteLink: (
-							<a
-								href={ site.URL }
-								target="_blank"
-								rel="noopener noreferrer"
-								onClick={ this.handlePillExternalClick }
-							>
-								{ site.title }
-							</a>
-						),
-					},
+				return translate( 'Post scheduled for %(formattedPostDate)s.', {
+					args: { formattedPostDate },
 					comment:
-						'Editor: Message displayed when a post is scheduled, with a link to the site it was scheduled on.',
+						'Editor: Message displayed when a post is scheduled, with the scheduled date and time.',
 				} );
 
 			case 'publishedPrivately':
@@ -347,6 +314,7 @@ export default connect(
 			type: post.type,
 			typeObject: getPostType( state, siteId, post.type ),
 			postUrl: post.URL || null,
+			postDate: post.date || null,
 		};
 	},
 	{

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -34,6 +34,7 @@ export class EditorNotice extends Component {
 		status: PropTypes.string,
 		onDismissClick: PropTypes.func,
 		error: PropTypes.object,
+		postUrl: PropTypes.string,
 	};
 
 	handlePillExternalClick = () => {
@@ -370,6 +371,7 @@ export default connect(
 			site: getSelectedSite( state ),
 			type: post.type,
 			typeObject: getPostType( state, siteId, post.type ),
+			postUrl: post.URL || null,
 		};
 	},
 	{

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -286,43 +286,27 @@ export class EditorNotice extends Component {
 				}
 
 				if ( 'page' === type ) {
-					return translate( 'Page updated on {{siteLink/}}! {{a}}Add another page{{/a}}', {
+					return translate( 'Page updated. {{postLink}}Visit page{{/postLink}}.', {
 						components: {
-							siteLink: (
-								<a
-									href={ site.URL }
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={ this.handlePillExternalClick }
-								>
-									{ site.title }
-								</a>
-							),
-							a: <a href={ `/page/${ site.slug }` } />,
+							postLink: <a href={ postUrl } onClick={ this.handlePillExternalClick } />,
 						},
 						comment:
-							'Editor: Message displayed when a page is updated, with a link to the site it was updated on.',
+							'Editor: Message displayed when a page is updated, with a link to the updated page.',
 					} );
 				}
 
 				if ( 'post' !== type && typeLabel ) {
-					return translate( '%(typeLabel)s updated on {{siteLink/}}!', {
-						args: { typeLabel },
-						components: {
-							siteLink: (
-								<a
-									href={ site.URL }
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={ this.handlePillExternalClick }
-								>
-									{ site.title }
-								</a>
-							),
-						},
-						comment:
-							'Editor: Message displayed when a post of a custom type is updated, with a link to the site it was updated on.',
-					} );
+					return translate(
+						'%(typeLabel)s updated. {{postLink}}Visit %(typeLabel)s{{/postLink}}.',
+						{
+							args: { typeLabel },
+							components: {
+								postLink: <a href={ postUrl } onClick={ this.handlePillExternalClick } />,
+							},
+							comment:
+								'Editor: Message displayed when a post of a custom type is updated, with a link to the updated post.',
+						}
+					);
 				}
 
 				return translate( 'Post updated. {{postLink}}Visit post{{/postLink}}.', {

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -69,7 +69,7 @@ export class EditorNotice extends Component {
 
 	getText( key ) {
 		/* eslint-disable max-len */
-		const { translate, type, typeObject, site } = this.props;
+		const { translate, type, typeObject, site, postUrl } = this.props;
 		const typeLabel = typeObject && typeObject.labels.singular_name;
 
 		switch ( key ) {
@@ -325,21 +325,12 @@ export class EditorNotice extends Component {
 					} );
 				}
 
-				return translate( 'Post updated on {{siteLink/}}!', {
+				return translate( 'Post updated. {{postLink}}Visit post{{/postLink}}.', {
 					components: {
-						siteLink: (
-							<a
-								href={ site.URL }
-								target="_blank"
-								rel="noopener noreferrer"
-								onClick={ this.handlePillExternalClick }
-							>
-								{ site.title }
-							</a>
-						),
+						postLink: <a href={ postUrl } onClick={ this.handlePillExternalClick } />,
 					},
 					comment:
-						'Editor: Message displayed when a post is updated, with a link to the site it was updated on.',
+						'Editor: Message displayed when a post is updated, with a link to the updated post.',
 				} );
 		}
 		/* eslint-enable max-len */

--- a/client/post-editor/editor-notice/index.jsx
+++ b/client/post-editor/editor-notice/index.jsx
@@ -193,7 +193,7 @@ export class EditorNotice extends Component {
 				}
 
 				if ( 'page' === type ) {
-					return translate( 'Page scheduled for %(formattedPostDate)s.', {
+					return translate( 'Page scheduled for %(formattedPostDate)s!', {
 						args: { formattedPostDate },
 						comment:
 							'Editor: Message displayed when a page is scheduled, with the scheduled date and time.',
@@ -201,14 +201,14 @@ export class EditorNotice extends Component {
 				}
 
 				if ( 'post' !== type && typeLabel ) {
-					return translate( '%(typeLabel)s scheduled for %(formattedPostDate)s.', {
+					return translate( '%(typeLabel)s scheduled for %(formattedPostDate)s!', {
 						args: { typeLabel, formattedPostDate },
 						comment:
 							'Editor: Message displayed when a post of a custom type is scheduled, with the scheduled date and time.',
 					} );
 				}
 
-				return translate( 'Post scheduled for %(formattedPostDate)s.', {
+				return translate( 'Post scheduled for %(formattedPostDate)s!', {
 					args: { formattedPostDate },
 					comment:
 						'Editor: Message displayed when a post is scheduled, with the scheduled date and time.',
@@ -253,7 +253,7 @@ export class EditorNotice extends Component {
 				}
 
 				if ( 'page' === type ) {
-					return translate( 'Page updated. {{postLink}}Visit page{{/postLink}}.', {
+					return translate( 'Page updated! {{postLink}}Visit page{{/postLink}}.', {
 						components: {
 							postLink: <a href={ postUrl } onClick={ this.handlePillExternalClick } />,
 						},
@@ -264,7 +264,7 @@ export class EditorNotice extends Component {
 
 				if ( 'post' !== type && typeLabel ) {
 					return translate(
-						'%(typeLabel)s updated. {{postLink}}Visit %(typeLabel)s{{/postLink}}.',
+						'%(typeLabel)s updated! {{postLink}}Visit %(typeLabel)s{{/postLink}}.',
 						{
 							args: { typeLabel },
 							components: {
@@ -276,7 +276,7 @@ export class EditorNotice extends Component {
 					);
 				}
 
-				return translate( 'Post updated. {{postLink}}Visit post{{/postLink}}.', {
+				return translate( 'Post updated! {{postLink}}Visit post{{/postLink}}.', {
 					components: {
 						postLink: <a href={ postUrl } onClick={ this.handlePillExternalClick } />,
 					},

--- a/client/post-editor/editor-notice/test/index.jsx
+++ b/client/post-editor/editor-notice/test/index.jsx
@@ -4,7 +4,7 @@
  */
 import { expect as chaiExpect } from 'chai';
 import { shallow } from 'enzyme';
-import { translate } from 'i18n-calypso';
+import { translate, moment } from 'i18n-calypso';
 import React from 'react';
 
 /**
@@ -15,7 +15,7 @@ import Notice from 'components/notice';
 
 describe( 'EditorNotice', () => {
 	test( 'should not render a notice if no message is specified', () => {
-		const wrapper = shallow( <EditorNotice /> );
+		const wrapper = shallow( <EditorNotice moment={ moment } /> );
 
 		chaiExpect( wrapper ).to.not.have.descendants( Notice );
 	} );
@@ -24,6 +24,7 @@ describe( 'EditorNotice', () => {
 		const wrapper = shallow(
 			<EditorNotice
 				translate={ translate }
+				moment={ moment }
 				status="is-error"
 				message="publishFailure"
 				error={ new Error( 'NO_CONTENT' ) }
@@ -43,6 +44,7 @@ describe( 'EditorNotice', () => {
 		const wrapper = shallow(
 			<EditorNotice
 				translate={ translate }
+				moment={ moment }
 				type="post"
 				status="is-error"
 				message="publishFailure"
@@ -64,6 +66,7 @@ describe( 'EditorNotice', () => {
 		const wrapper = shallow(
 			<EditorNotice
 				translate={ translate }
+				moment={ moment }
 				message="published"
 				status="is-success"
 				type="page"
@@ -85,6 +88,7 @@ describe( 'EditorNotice', () => {
 		const wrapper = shallow(
 			<EditorNotice
 				translate={ translate }
+				moment={ moment }
 				type="jetpack-portfolio"
 				typeObject={ {
 					labels: {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import tinyMce from 'tinymce/tinymce';
 import { v4 as uuid } from 'uuid';
-import { parse as parseUrl } from 'url';
 
 /**
  * Internal dependencies
@@ -43,7 +42,6 @@ import {
 	getEditorPostId,
 	getEditorPath,
 	isConfirmationSidebarEnabled,
-	isEditorOnlyRouteInHistory,
 } from 'state/ui/editor/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { editPost, receivePost, savePostSuccess } from 'state/posts/actions';
@@ -67,7 +65,7 @@ import Site from 'blocks/site';
 import StatusLabel from 'post-editor/editor-status-label';
 import EditorGroundControl from 'post-editor/editor-ground-control';
 import { isWithinBreakpoint } from 'lib/viewport';
-import { isSitePreviewable, getSiteDomain } from 'state/sites/selectors';
+import { isSitePreviewable } from 'state/sites/selectors';
 import { removep } from 'lib/formatting';
 
 export const PostEditor = createReactClass( {
@@ -1019,18 +1017,6 @@ export const PostEditor = createReactClass( {
 				message,
 			};
 
-			const referrer = get( window, 'document.referrer', '' );
-			const referrerDomain = parseUrl( referrer ).hostname;
-			const shouldReturnToSite =
-				'updated' === message &&
-				this.props.isEditorOnlyRouteInHistory &&
-				referrerDomain === this.props.selectedSiteDomain;
-
-			if ( shouldReturnToSite ) {
-				window.location.href = this.getExternalUrl();
-				return;
-			}
-
 			window.scrollTo( 0, 0 );
 
 			if ( this.props.isSitePreviewable && isNotPrivateOrIsConfirmed && 'published' === message ) {
@@ -1346,7 +1332,6 @@ const enhance = flow(
 				postId,
 				type,
 				selectedSite: getSelectedSite( state ),
-				selectedSiteDomain: getSiteDomain( state, siteId ),
 				editorModePreference: getPreference( state, 'editor-mode' ),
 				editorSidebarPreference: getPreference( state, 'editor-sidebar' ) || 'open',
 				editPath: getEditorPath( state, siteId, postId ),
@@ -1356,7 +1341,6 @@ const enhance = flow(
 				layoutFocus: getCurrentLayoutFocus( state ),
 				hasBrokenPublicizeConnection: hasBrokenSiteUserConnection( state, siteId, userId ),
 				isSitePreviewable: isSitePreviewable( state, siteId ),
-				isEditorOnlyRouteInHistory: isEditorOnlyRouteInHistory( state ),
 				isConfirmationSidebarEnabled: isConfirmationSidebarEnabled( state, siteId ),
 			};
 		},

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1033,7 +1033,7 @@ export const PostEditor = createReactClass( {
 
 			window.scrollTo( 0, 0 );
 
-			if ( this.props.isSitePreviewable && isNotPrivateOrIsConfirmed ) {
+			if ( this.props.isSitePreviewable && isNotPrivateOrIsConfirmed && 'published' === message ) {
 				this.setState( { isPostPublishPreview: true } );
 				this.iframePreview();
 			}

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -12,7 +12,6 @@ import { get } from 'lodash';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import { getPreference } from 'state/preferences/selectors';
-import { getActionLog } from 'state/ui/action-log/selectors';
 
 /**
  * Returns the current editor post ID, or `null` if a new post.
@@ -109,18 +108,4 @@ export function getEditorPath( state, siteId, postId, defaultType = 'post' ) {
  */
 export function isConfirmationSidebarEnabled( state, siteId ) {
 	return getPreference( state, 'editorConfirmationDisabledSites' ).indexOf( siteId ) === -1;
-}
-
-/**
- * Returns whether the Editor is the only route that exists in the history.
- *
- * @param  {Object}  state     Global state tree
- * @return {Boolean}           Whether or not Editor is the only route in the history
- */
-export function isEditorOnlyRouteInHistory( state ) {
-	const routeSets = getActionLog( state ).filter( entry => 'ROUTE_SET' === entry.type );
-
-	return (
-		1 === routeSets.length && !! get( routeSets[ 0 ], 'path', '' ).match( /^\/(post|page|edit)\// )
-	);
 }

--- a/client/state/ui/editor/test/selectors.js
+++ b/client/state/ui/editor/test/selectors.js
@@ -13,7 +13,6 @@ import {
 	isEditorNewPost,
 	getEditorNewPostPath,
 	getEditorPath,
-	isEditorOnlyRouteInHistory,
 } from '../selectors';
 import PostQueryManager from 'lib/query-manager/post';
 
@@ -324,42 +323,6 @@ describe( 'selectors', () => {
 			);
 
 			expect( path ).to.equal( '/edit/jetpack-portfolio/example.wordpress.com' );
-		} );
-	} );
-
-	describe( 'isEditorOnlyRouteInHistory()', () => {
-		test( 'should return true when Editor is the only route in history', () => {
-			const isOnlyRoute = isEditorOnlyRouteInHistory( {
-				ui: {
-					actionLog: [
-						{
-							type: 'ROUTE_SET',
-							path: '/post/example.com/123',
-						},
-					],
-				},
-			} );
-
-			expect( isOnlyRoute ).to.be.true;
-		} );
-
-		test( 'should return false when Editor is not the only route in history', () => {
-			const isOnlyRoute = isEditorOnlyRouteInHistory( {
-				ui: {
-					actionLog: [
-						{
-							type: 'ROUTE_SET',
-							path: '/',
-						},
-						{
-							type: 'ROUTE_SET',
-							path: '/post/example.com/123',
-						},
-					],
-				},
-			} );
-
-			expect( isOnlyRoute ).to.be.false;
 		} );
 	} );
 } );


### PR DESCRIPTION
This updates the messaging in the `EditorNotice` for updated and scheduled posts, pages, and CPTs. It additionally only fires the post preview for newly published posts (no longer updated, or scheduled posts).

Fixes: #20171
Discussion: p8FazZ-D2-p2

**To test:**
- Open the calypso.live link.
- Add a new post. 
- Schedule it for a future date.
- Make sure that the preview is not shown and success notice reads "Post scheduled for {timestamp}!"
- Edit an existing post and click "update".
- Make sure that the preview is not shown and the success notice reads "Post updated! Visit post." (with a link to the post).
- Publish a new post.
- Make sure that the preview is shown and the success notice reads "Post published on {Site Title}!" (with a link to the site).
- Rinse and repeat for pages and CPTs - the same behavior with the correct post type reflected in the messaging.