### PR TITLE
Activity Log: allow to restart a failed restore and backup

### DIFF
--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -24,7 +24,7 @@ class ErrorBanner extends PureComponent {
 		siteId: PropTypes.number.isRequired,
 		timestamp: PropTypes.string,
 		downloadId: PropTypes.number,
-		requestedRestoreActivityId: PropTypes.number,
+		requestedRestoreActivityId: PropTypes.string,
 		createBackup: PropTypes.func,
 		rewindRestore: PropTypes.func,
 

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -27,7 +27,6 @@ class ErrorBanner extends PureComponent {
 		requestedRestoreActivityId: PropTypes.number,
 		createBackup: PropTypes.func,
 		rewindRestore: PropTypes.func,
-		rewindId: PropTypes.number,
 
 		// connect
 		dismissRewindRestoreProgress: PropTypes.func.isRequired,
@@ -50,10 +49,9 @@ class ErrorBanner extends PureComponent {
 			requestedRestoreActivityId,
 			rewindRestore,
 			createBackup,
-			rewindId,
 		} = this.props;
-		if ( requestedRestoreActivityId || rewindId ) {
-			rewindRestore( siteId, rewindId ? rewindId : requestedRestoreActivityId );
+		if ( requestedRestoreActivityId ) {
+			rewindRestore( siteId, requestedRestoreActivityId );
 		} else if ( downloadId ) {
 			createBackup( siteId, downloadId );
 		}

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -51,9 +51,10 @@ class ErrorBanner extends PureComponent {
 			createBackup,
 		} = this.props;
 		if ( downloadId ) {
-			createBackup( siteId, downloadId );
-		} else if ( requestedRestoreActivityId ) {
-			rewindRestore( siteId, requestedRestoreActivityId );
+			return createBackup( siteId, downloadId );
+		}
+		if ( requestedRestoreActivityId ) {
+			return rewindRestore( siteId, requestedRestoreActivityId );
 		}
 	};
 

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -6,7 +6,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
+import { isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -50,34 +50,28 @@ class ErrorBanner extends PureComponent {
 			rewindRestore,
 			createBackup,
 		} = this.props;
-		if ( requestedRestoreActivityId ) {
-			rewindRestore( siteId, requestedRestoreActivityId );
-		} else if ( downloadId ) {
+		if ( downloadId ) {
 			createBackup( siteId, downloadId );
+		} else if ( requestedRestoreActivityId ) {
+			rewindRestore( siteId, requestedRestoreActivityId );
 		}
 	};
 
 	handleDismiss = () =>
-		isEmpty( this.props.downloadId )
+		isUndefined( this.props.downloadId )
 			? this.props.closeDialog( 'restore' )
 			: this.props.closeDialog( 'backup' );
 
 	render() {
 		const { errorCode, failureReason, timestamp, translate, downloadId } = this.props;
-		const strings = isEmpty( downloadId )
+		const strings = isUndefined( downloadId )
 			? {
 					title: translate( 'Problem restoring your site' ),
 					details: translate( 'We came across a problem while trying to restore your site.' ),
 				}
 			: {
 					title: translate( 'Problem creating a backup' ),
-					details: (
-						<span>
-							{ translate( 'We came across a problem creating a backup for your site.' ) }
-							<br />
-							<code>{ errorCode }</code>
-						</span>
-					),
+					details: translate( 'We came across a problem creating a backup for your site.' ),
 				};
 
 		return (
@@ -90,7 +84,7 @@ class ErrorBanner extends PureComponent {
 				<TrackComponentView
 					eventName="calypso_activitylog_errorbanner_impression"
 					eventProperties={
-						isEmpty( downloadId )
+						isUndefined( downloadId )
 							? {
 									error_code: errorCode,
 									failure_reason: failureReason,

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -50,9 +50,10 @@ class ErrorBanner extends PureComponent {
 			requestedRestoreActivityId,
 			rewindRestore,
 			createBackup,
+			rewindId,
 		} = this.props;
-		if ( requestedRestoreActivityId ) {
-			rewindRestore( siteId, requestedRestoreActivityId );
+		if ( requestedRestoreActivityId || rewindId ) {
+			rewindRestore( siteId, rewindId ? rewindId : requestedRestoreActivityId );
 		} else if ( downloadId ) {
 			createBackup( siteId, downloadId );
 		}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -215,7 +215,7 @@ class ActivityLog extends Component {
 				// 'success',
 				// 'success-with-errors',
 			] ).isRequired,
-			timestamp: PropTypes.string.isRequired,
+			timestamp: PropTypes.string,
 		} ),
 		backupProgress: PropTypes.object,
 		changePeriod: PropTypes.func,

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -375,7 +375,15 @@ class ActivityLog extends Component {
 	 * @returns {object}                 Card showing progress.
 	 */
 	getProgressBanner( siteId, actionProgress, action ) {
-		const { percent, progress, restoreId, downloadId, status, timestamp } = actionProgress;
+		const {
+			percent,
+			progress,
+			restoreId,
+			downloadId,
+			status,
+			timestamp,
+			rewindId,
+		} = actionProgress;
 		return (
 			<ProgressBanner
 				key={ `progress-${ restoreId || downloadId }` }
@@ -385,7 +393,7 @@ class ActivityLog extends Component {
 				downloadId={ downloadId }
 				siteId={ siteId }
 				status={ status }
-				timestamp={ timestamp }
+				timestamp={ timestamp || rewindId }
 				action={ action }
 			/>
 		);

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -410,7 +410,7 @@ class ActivityLog extends Component {
 			downloadId,
 			rewindId,
 		} = progress;
-		const { requestedRestoreActivityId } = this.props;
+		const requestedRestoreActivityId = this.props.requestedRestoreActivityId || rewindId;
 		return (
 			<div key={ `end-banner-${ restoreId || downloadId }` }>
 				<QueryActivityLog siteId={ siteId } />
@@ -419,7 +419,6 @@ class ActivityLog extends Component {
 						key={ `error-${ restoreId || downloadId }` }
 						errorCode={ errorCode || backupError }
 						downloadId={ downloadId }
-						rewindId={ rewindId }
 						requestedRestoreActivityId={ requestedRestoreActivityId }
 						failureReason={ failureReason }
 						createBackup={ this.props.createBackup }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -441,7 +441,7 @@ class ActivityLog extends Component {
 						key={ `success-${ restoreId || downloadId }` }
 						applySiteOffset={ this.applySiteOffset }
 						siteId={ siteId }
-						timestamp={ timestamp }
+						timestamp={ rewindId }
 						downloadId={ downloadId }
 						backupUrl={ url }
 						downloadCount={ downloadCount }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -215,7 +215,7 @@ class ActivityLog extends Component {
 				// 'success',
 				// 'success-with-errors',
 			] ).isRequired,
-			timestamp: PropTypes.string,
+			rewindId: PropTypes.string.isRequired,
 		} ),
 		backupProgress: PropTypes.object,
 		changePeriod: PropTypes.func,

--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -21,11 +21,12 @@ const startProgress = ( state, { timestamp } ) => ( {
 	percent: 0,
 	status: 'queued',
 	timestamp,
+	rewindId: -Infinity,
 } );
 
 const updateProgress = (
 	state,
-	{ errorCode, failureReason, message, percent, restoreId, status, timestamp }
+	{ errorCode, failureReason, message, percent, restoreId, status, timestamp, rewindId }
 ) => ( {
 	errorCode,
 	failureReason,
@@ -34,6 +35,7 @@ const updateProgress = (
 	restoreId,
 	status,
 	timestamp,
+	rewindId,
 } );
 
 export const restoreProgress = keyedReducer(

--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -21,7 +21,7 @@ const startProgress = ( state, { timestamp } ) => ( {
 	percent: 0,
 	status: 'queued',
 	timestamp,
-	rewindId: -Infinity,
+	rewindId: '',
 } );
 
 const updateProgress = (

--- a/client/state/activity-log/restore/schema.js
+++ b/client/state/activity-log/restore/schema.js
@@ -13,7 +13,7 @@ export const restoreProgressSchema = {
 				restoreId: { type: 'integer' },
 				status: { type: 'string' },
 				timestamp: { type: 'integer' },
-				rewindId: { type: 'number' },
+				rewindId: { type: 'string' },
 			},
 		},
 	},

--- a/client/state/activity-log/restore/schema.js
+++ b/client/state/activity-log/restore/schema.js
@@ -13,6 +13,7 @@ export const restoreProgressSchema = {
 				restoreId: { type: 'integer' },
 				status: { type: 'string' },
 				timestamp: { type: 'integer' },
+				rewindId: { type: 'number' },
 			},
 		},
 	},

--- a/client/state/activity-log/restore/test/reducer.js
+++ b/client/state/activity-log/restore/test/reducer.js
@@ -39,6 +39,7 @@ describe( 'restoreProgress', () => {
 			percent: 0,
 			status: 'queued',
 			timestamp: TIMESTAMP,
+			rewindId: '',
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -61,6 +61,7 @@ export const fromApi = ( {
 		message = '',
 		percent = 0,
 		status = '',
+		rewind_id = -Infinity,
 	} = {},
 } ) => ( {
 	errorCode: error_code,
@@ -68,6 +69,7 @@ export const fromApi = ( {
 	message,
 	percent: +percent,
 	status,
+	rewindId: +rewind_id,
 } );
 
 export const updateProgress = ( { dispatch }, { siteId, restoreId, timestamp }, data ) =>

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -61,7 +61,7 @@ export const fromApi = ( {
 		message = '',
 		percent = 0,
 		status = '',
-		rewind_id = -Infinity,
+		rewind_id = '',
 	} = {},
 } ) => ( {
 	errorCode: error_code,
@@ -69,7 +69,7 @@ export const fromApi = ( {
 	message,
 	percent: +percent,
 	status,
-	rewindId: +rewind_id,
+	rewindId: rewind_id,
 } );
 
 export const updateProgress = ( { dispatch }, { siteId, restoreId, timestamp }, data ) =>

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
@@ -25,6 +25,7 @@ const FINISHED_RESPONSE = deepFreeze( {
 		message: '',
 		percent: 100,
 		status: 'finished',
+		rewindId: -Infinity,
 	},
 } );
 
@@ -38,6 +39,7 @@ describe( 'receiveRestoreProgress', () => {
 			message: '',
 			percent: 100,
 			status: 'finished',
+			rewindId: -Infinity,
 		} );
 		expect( dispatch ).to.have.been.calledWith( expectedAction );
 	} );

--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/test/index.js
@@ -25,7 +25,7 @@ const FINISHED_RESPONSE = deepFreeze( {
 		message: '',
 		percent: 100,
 		status: 'finished',
-		rewindId: -Infinity,
+		rewindId: '',
 	},
 } );
 
@@ -39,7 +39,7 @@ describe( 'receiveRestoreProgress', () => {
 			message: '',
 			percent: 100,
 			status: 'finished',
-			rewindId: -Infinity,
+			rewindId: '',
 		} );
 		expect( dispatch ).to.have.been.calledWith( expectedAction );
 	} );


### PR DESCRIPTION
Previously, after an error, the Try again button didn't work in the error dialog.
This PR:
- fixes restore restart by using the restore rewind Id that is now returned by the restore status endpoint during an error message to restart the restore
- fixes backup restart solving an issue that caused a backup restart to trigger a restore instead
- fixes dates in progress, error and success banners
