### PR TITLE
Promotions: Fix 20417, prop types

### DIFF
--- a/client/extensions/woocommerce/app/promotions/fields/checkbox-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/checkbox-field.js
@@ -35,12 +35,12 @@ const CheckboxField = ( props ) => {
 	);
 };
 
-CheckboxField.PropTypes = {
-	fieldName: PropTypes.string.isRequired,
+CheckboxField.propTypes = {
+	fieldName: PropTypes.string,
 	explanationText: PropTypes.string,
 	placeholderText: PropTypes.string,
 	value: PropTypes.bool,
-	edit: PropTypes.func.isRequired,
+	edit: PropTypes.func,
 };
 
 export default CheckboxField;

--- a/client/extensions/woocommerce/app/promotions/fields/currency-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/currency-field.js
@@ -35,13 +35,13 @@ const CurrencyField = ( props ) => {
 	);
 };
 
-CurrencyField.PropTypes = {
-	fieldName: PropTypes.string.isRequired,
+CurrencyField.propTypes = {
+	fieldName: PropTypes.string,
 	explanationText: PropTypes.string,
 	placeholderText: PropTypes.string,
 	value: PropTypes.number,
-	edit: PropTypes.func.isRequired,
-	currency: PropTypes.string.isRequired,
+	edit: PropTypes.func,
+	currency: PropTypes.string,
 };
 
 export default CurrencyField;

--- a/client/extensions/woocommerce/app/promotions/fields/date-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/date-field.js
@@ -32,11 +32,11 @@ const DateField = ( props ) => {
 	);
 };
 
-DateField.PropTypes = {
-	fieldName: PropTypes.string.isRequired,
+DateField.propTypes = {
+	fieldName: PropTypes.string,
 	explanationText: PropTypes.string,
 	value: PropTypes.number,
-	edit: PropTypes.func.isRequired,
+	edit: PropTypes.func,
 };
 
 export default localize( DateField );

--- a/client/extensions/woocommerce/app/promotions/fields/form-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/form-field.js
@@ -77,8 +77,8 @@ const FormField = ( {
 	);
 };
 
-FormField.PropTypes = {
-	fieldName: PropTypes.string.isRequired,
+FormField.propTypes = {
+	fieldName: PropTypes.string,
 	labelText: PropTypes.string,
 	explanationText: PropTypes.string,
 	isRequired: PropTypes.bool,

--- a/client/extensions/woocommerce/app/promotions/fields/number-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/number-field.js
@@ -43,14 +43,14 @@ const NumberField = ( props ) => {
 	);
 };
 
-NumberField.PropTypes = {
-	fieldName: PropTypes.string.isRequired,
+NumberField.propTypes = {
+	fieldName: PropTypes.string,
 	explanationText: PropTypes.string,
 	placeholderText: PropTypes.string,
 	value: PropTypes.number,
 	minValue: PropTypes.number,
 	maxValue: PropTypes.number,
-	edit: PropTypes.func.isRequired,
+	edit: PropTypes.func,
 };
 
 export default NumberField;

--- a/client/extensions/woocommerce/app/promotions/fields/percent-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/percent-field.js
@@ -38,12 +38,12 @@ const PercentField = ( props ) => {
 	);
 };
 
-PercentField.PropTypes = {
-	fieldName: PropTypes.string.isRequired,
+PercentField.propTypes = {
+	fieldName: PropTypes.string,
 	explanationText: PropTypes.string,
 	placeholderText: PropTypes.string,
 	value: PropTypes.number,
-	edit: PropTypes.func.isRequired,
+	edit: PropTypes.func,
 };
 
 export default PercentField;

--- a/client/extensions/woocommerce/app/promotions/fields/text-field.js
+++ b/client/extensions/woocommerce/app/promotions/fields/text-field.js
@@ -32,12 +32,12 @@ const TextField = ( props ) => {
 	);
 };
 
-TextField.PropTypes = {
-	fieldName: PropTypes.string.isRequired,
+TextField.propTypes = {
+	fieldName: PropTypes.string,
 	explanationText: PropTypes.string,
 	placeholderText: PropTypes.string,
 	value: PropTypes.number,
-	edit: PropTypes.func.isRequired,
+	edit: PropTypes.func,
 };
 
 export default TextField;

--- a/client/extensions/woocommerce/app/promotions/promotion-form-card.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form-card.js
@@ -64,9 +64,9 @@ const PromotionFormCard = ( {
 	);
 };
 
-PromotionFormCard.PropTypes = {
+PromotionFormCard.propTypes = {
 	siteId: PropTypes.number.isRequired,
-	currency: PropTypes.string.isRequired,
+	currency: PropTypes.string,
 	promotion: PropTypes.shape( {
 		id: PropTypes.isRequired,
 		type: PropTypes.string.isRequired,

--- a/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-form-type-card.js
@@ -73,7 +73,7 @@ const PromotionFormTypeCard = ( {
 	);
 };
 
-PromotionFormTypeCard.PropTypes = {
+PromotionFormTypeCard.propTypes = {
 	siteId: PropTypes.number,
 	promotion: PropTypes.shape( {
 		id: PropTypes.isRequired,

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-list.js
@@ -152,7 +152,7 @@ const ShippingZoneLocationList = ( {
 	);
 };
 
-ShippingZoneLocationList.PropTypes = {
+ShippingZoneLocationList.propTypes = {
 	siteId: PropTypes.number,
 };
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-name.js
@@ -77,7 +77,7 @@ const ShippingZoneName = ( {
 	);
 };
 
-ShippingZoneName.PropTypes = {
+ShippingZoneName.propTypes = {
 	siteId: PropTypes.number,
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/predefined-packages.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/predefined-packages.js
@@ -106,7 +106,7 @@ const PredefinedPackages = ( {
 	return <div>{ renderContent() }</div>;
 };
 
-PredefinedPackages.PropTypes = {
+PredefinedPackages.propTypes = {
 	siteId: PropTypes.number.isRequired,
 	toggleAll: PropTypes.func.isRequired,
 	togglePackage: PropTypes.func.isRequired,


### PR DESCRIPTION
Fixes #20417 

This fixes some warnings for component prop types specifically on the
promotions fields.

To Test:

1. Open JS dev console
2. Start and view promotions pages.
3. Ensure no propTypes-related warnings appear.