### PR TITLE
Me: Remove icon prop from Button in ProfileLink

### DIFF
--- a/client/me/profile-link/index.jsx
+++ b/client/me/profile-link/index.jsx
@@ -48,12 +48,7 @@ class ProfileLink extends React.Component {
 
 	renderRemove() {
 		return (
-			<Button
-				borderless
-				icon
-				className="profile-link__remove"
-				onClick={ this.handleRemoveButtonClick }
-			>
+			<Button borderless className="profile-link__remove" onClick={ this.handleRemoveButtonClick }>
 				<Gridicon icon="cross" />
 			</Button>
 		);


### PR DESCRIPTION
This PR removes the `icon` prop that is unnecessarily being passed to a `<Button />` in `<ProfileLink />`. This removes the following React warning that started appearing since we migrated to React 16:

![](https://cldup.com/uMIlCJ9IXg.png)

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me
* Verify the warning does not appear anymore
* Verify there are no visual/functional changes.