### PR TITLE
Comments: Fix incorrect onClick default value

### DIFF
--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -113,7 +113,7 @@ export class Comment extends Component {
 		return (
 			<Card
 				className={ classes }
-				onClick={ isBulkMode ? this.toggleSelected : false }
+				onClick={ isBulkMode ? this.toggleSelected : undefined }
 				onKeyDown={ this.keyDownHandler }
 				ref={ this.storeCardRef }
 			>


### PR DESCRIPTION
Fix a warning introduced with the upgrade to React 16, about an `onClick` prop that accidentally defaulted to `false` instead of `undefined`.

<img width="770" alt="screen shot 2017-12-04 at 11 54 08" src="https://user-images.githubusercontent.com/2070010/33551620-ddfbb024-d8e9-11e7-998d-fca275807998.png">

There is no change in behaviour, but for completeness sake, just try to enable Bulk Edit mode in the Comments Management section, and select a comment by clicking anywhere on the card (and not only on the checkbox).