### PR TITLE
Comments Redesign: Decrease re-fetches

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -477,12 +477,9 @@ export class CommentList extends Component {
 								commentId={ commentId }
 								key={ `comment-${ siteId }-${ commentId }` }
 								isBulkMode={ isBulkEdit }
+								isCommentsTreeSupported={ isCommentsTreeSupported }
 								isPostView={ isPostView }
 								isSelected={ this.isCommentSelected( commentId ) }
-								refreshCommentData={
-									isCommentsTreeSupported &&
-									! this.hasCommentJustMovedBackToCurrentStatus( commentId )
-								}
 								toggleSelected={ this.toggleCommentSelected }
 								updateLastUndo={ this.updateLastUndo }
 							/>

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -29,6 +29,7 @@ export class Comment extends Component {
 		postId: PropTypes.number,
 		commentId: PropTypes.number,
 		isBulkMode: PropTypes.bool,
+		isCommentsTreeSupported: PropTypes.bool,
 		isPostView: PropTypes.bool,
 		isSelected: PropTypes.bool,
 		refreshCommentData: PropTypes.bool,
@@ -147,7 +148,7 @@ export class Comment extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { commentId } ) => {
+const mapStateToProps = ( state, { commentId, isCommentsTreeSupported } ) => {
 	const siteId = getSelectedSiteId( state );
 	const comment = getSiteComment( state, siteId, commentId );
 	const commentStatus = get( comment, 'status' );
@@ -157,6 +158,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 		commentIsPending: 'unapproved' === commentStatus,
 		isLoading: isUndefined( comment ),
 		minimumComment: getMinimumComment( comment ),
+		refreshCommentData: isCommentsTreeSupported && isUndefined( comment ),
 	};
 };
 


### PR DESCRIPTION
This approach is likely too aggressive but I wanted to spark a discussion.

The current behaviour of Comments Management (for sites that support the comments tree: .com and JP > 5.5) is: fetch fresh data every time the comment mounts.
Which is roughly: on first load, on change page, on change filter, on change sorting.

This PR instead limits the fetches to only those comments that are not already in state.

The pro is obvious; the con is that any changes on comments happening in a different tab/ browser/user won't "propagate".

Though, since comments are not cached, a simple reload is enough to fetch from scratch.
(Basically the same behaviour of wp-admin - unless there's some polling going on there?).