### PR TITLE
External media: Force reset the query on external copy

### DIFF
--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -161,11 +161,7 @@ export class EditorMediaModal extends Component {
 			},
 			() => {
 				// Reset the query so that we're adding the new media items to the correct
-				// list, with no external source. Previously, this would have been done
-				// for us as React would push the updated source to all child components
-				// before executing this callback, but in React 16 that behaviour changed,
-				// so we need to do this in the callback to ensure that things show up
-				// where they're supposed to.
+				// list, with no external source.
 				MediaActions.setQuery( site.ID, {} );
 				MediaActions.addExternal( site, selectedMedia, originalSource );
 			}

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -160,9 +160,13 @@ export class EditorMediaModal extends Component {
 				search: undefined,
 			},
 			() => {
-				// Copy the selected item from the external source. Note we pass the actual media data as we need this to generate
-				// transient placeholders. This is done after the state changes so our transients and external items appear
-				// in the WordPress library that we've just switched to
+				// Reset the query so that we're adding the new media items to the correct
+				// list, with no external source. Previously, this would have been done
+				// for us as React would push the updated source to all child components
+				// before executing this callback, but in React 16 that behaviour changed,
+				// so we need to do this in the callback to ensure that things show up
+				// where they're supposed to.
+				MediaActions.setQuery( site.ID, {} );
 				MediaActions.addExternal( site, selectedMedia, originalSource );
 			}
 		);


### PR DESCRIPTION
The upgrade to React 16 changed how callbacks are called when using them with `setState`. We can't rely on the child components on the media library modifying the query before the callback is called any more, so when we copy multiple items from an external source, we force the reset in the callback before doing the copy.

Testing

Edit / create a blog post. Insert multiple images from Google Photos. You should see the media library switch back to your WP library, and show the newly copied images. The images should be selected, allowing you to insert them in your blog post.