### PR TITLE
i18n: Fix getLocaleFromPath for paths with queries

### DIFF
--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -101,6 +101,10 @@ describe( 'utils', () => {
 				'es'
 			);
 		} );
+
+		test( 'shoule correctly handle paths with query string', () => {
+			assert.equal( getLocaleFromPath( '/start/es?query=string' ), 'es' );
+		} );
 	} );
 
 	describe( '#getLanguage', () => {

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -102,7 +102,7 @@ describe( 'utils', () => {
 			);
 		} );
 
-		test( 'shoule correctly handle paths with query string', () => {
+		test( 'should correctly handle paths with query string', () => {
 			assert.equal( getLocaleFromPath( '/start/es?query=string' ), 'es' );
 		} );
 	} );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -50,8 +50,8 @@ const i18nUtils = {
 	 * @return {string|undefined} The locale slug if present or undefined
 	 */
 	getLocaleFromPath: function( path ) {
-		const parts = getPathParts( path );
-		const locale = parts.pop();
+		const urlParts = parse( path );
+		const locale = getPathParts( urlParts.pathname ).pop();
 
 		return 'undefined' === typeof i18nUtils.getLanguage( locale ) ? undefined : locale;
 	},


### PR DESCRIPTION
Adds a test and corrects parsing for paths including query strings.

Discovered via https://github.com/Automattic/wp-calypso/pull/20406#issuecomment-348963831

## Testing
1. Tests pass