### PR TITLE
Privacy Policy Banner: Style policy text for a better readability

### DIFF
--- a/client/blocks/privacy-policy-banner/style.scss
+++ b/client/blocks/privacy-policy-banner/style.scss
@@ -45,3 +45,8 @@
 	padding-top: 10px;
 	padding-bottom: 10px;
 }
+
+.privacy-policy-banner__dialog-body h3 {
+	font-weight: bold;
+	margin: 1.5em 0;
+}

--- a/client/blocks/privacy-policy-banner/style.scss
+++ b/client/blocks/privacy-policy-banner/style.scss
@@ -42,11 +42,11 @@
 .privacy-policy-banner__dialog-body {
 	overflow-y: auto;
 	height: 320px;
-	padding-top: 10px;
-	padding-bottom: 10px;
+	padding-top: 24px;
 }
 
-.privacy-policy-banner__dialog-body h3 {
+.privacy-policy-banner__dialog-body h3,
+.privacy-policy-banner__dialog-body h4 {
 	font-weight: bold;
 	margin: 1.5em 0;
 }


### PR DESCRIPTION
The privacy text inside the modal is hard to read since there is no useful style attached to the HTML tags used there.

![screen shot 2017-12-04 at 14 45 07](https://user-images.githubusercontent.com/908665/33558467-cd15955a-d901-11e7-8997-a7386da94193.png)

There are two thing that improves the readability.
- [x] Add styles to `h3`
- [x] Add `p` tag to each paragraph