### PR TITLE
Plans: add button highlighting to the Plans page upon redirection from nudges *on mobile*

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -122,6 +122,7 @@ class PlanFeatures extends Component {
 			isLandingPage,
 			site,
 			basePlansPath,
+			selectedPlan,
 		} = this.props;
 
 		// move any free plan to last place in mobile view
@@ -189,6 +190,7 @@ class PlanFeatures extends Component {
 						isPopular={ popular }
 						planName={ planConstantObj.getTitle() }
 						planType={ planName }
+						selectedPlan={ selectedPlan }
 					/>
 					<FoldableCard header={ translate( 'Show features' ) } clickableHeader compact>
 						{ this.renderMobileFeatures( features ) }


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/20204, which highlights selected plan buttons for non-mobile views. 

Here we complete make it work for mobile.

**to test:** follow the instructions in #20204 for small screens