### PR TITLE
PostItem: Add action counts to the right of status

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -362,6 +362,7 @@
 @import 'my-sites/post-selector/style';
 @import 'my-sites/post-type-filter/style';
 @import 'my-sites/post-type-list/style';
+@import 'my-sites/post-type-list/post-action-counts/style';
 @import 'my-sites/post-type-list/post-actions-ellipsis-menu/style';
 @import 'my-sites/post-type-list/post-type-post-author/style';
 @import 'my-sites/post-type-list/post-type-site-info/style';

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -32,6 +32,7 @@ import PostTime from 'blocks/post-time';
 import PostStatus from 'blocks/post-status';
 import PostShare from 'blocks/post-share';
 import PostTypeListPostThumbnail from 'my-sites/post-type-list/post-thumbnail';
+import PostActionCounts from 'my-sites/post-type-list/post-action-counts';
 import PostActionsEllipsisMenu from 'my-sites/post-type-list/post-actions-ellipsis-menu';
 import PostTypeSiteInfo from 'my-sites/post-type-list/post-type-site-info';
 import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
@@ -157,8 +158,11 @@ class PostItem extends React.Component {
 								) }
 						</h1>
 						<div className="post-item__meta">
-							<PostTime globalId={ globalId } />
-							<PostStatus globalId={ globalId } />
+							<span className="post-item__meta-time-status">
+								<PostTime globalId={ globalId } />
+								<PostStatus globalId={ globalId } />
+							</span>
+							<PostActionCounts globalId={ globalId } />
 						</div>
 					</div>
 					<PostTypeListPostThumbnail globalId={ globalId } />

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -119,3 +119,7 @@ a.post-item__title-link:visited {
 	margin-top: -3px;
 	margin-right: 2px;
 }
+
+.post-item__meta-time-status {
+	margin-right: 16px;
+}

--- a/client/my-sites/post-type-list/post-action-counts/index.jsx
+++ b/client/my-sites/post-type-list/post-action-counts/index.jsx
@@ -27,8 +27,8 @@ class PostActionCounts extends PureComponent {
 		return (
 			<li>
 				{ translate(
-					'%(count)s comment',
-					'%(count)s comments',
+					'%(count)s Comment',
+					'%(count)s Comments',
 					{
 						count,
 						args: { count: numberFormat( count ) },
@@ -44,8 +44,8 @@ class PostActionCounts extends PureComponent {
 		return (
 			<li>
 				{ translate(
-					'%(count)s like',
-					'%(count)s likes',
+					'%(count)s Like',
+					'%(count)s Likes',
 					{
 						count,
 						args: { count: numberFormat( count ) },
@@ -61,8 +61,8 @@ class PostActionCounts extends PureComponent {
 		return (
 			<li>
 				{ translate(
-					'%(count)s view',
-					'%(count)s views',
+					'%(count)s View',
+					'%(count)s Views',
 					{
 						count,
 						args: { count: numberFormat( count ) },

--- a/client/my-sites/post-type-list/post-action-counts/index.jsx
+++ b/client/my-sites/post-type-list/post-action-counts/index.jsx
@@ -1,0 +1,101 @@
+/* @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import QueryPostStats from 'components/data/query-post-stats';
+import { getNormalizedPost } from 'state/posts/selectors';
+import { getPostStat } from 'state/stats/posts/selectors';
+
+class PostActionCounts extends PureComponent {
+	static propTypes = {
+		globalId: PropTypes.string,
+	};
+
+	renderCommentCount() {
+		const { commentCount: count, numberFormat, translate } = this.props;
+
+		return (
+			<li>
+				{ translate(
+					'%(count)s comment',
+					'%(count)s comments',
+					{
+						count,
+						args: { count: numberFormat( count ) },
+					}
+				) }
+			</li>
+		);
+	}
+
+	renderLikeCount() {
+		const { likeCount: count, numberFormat, translate } = this.props;
+
+		return (
+			<li>
+				{ translate(
+					'%(count)s like',
+					'%(count)s likes',
+					{
+						count,
+						args: { count: numberFormat( count ) },
+					}
+				) }
+			</li>
+		);
+	}
+
+	renderViewCount() {
+		const { viewCount: count, numberFormat, translate } = this.props;
+
+		return (
+			<li>
+				{ translate(
+					'%(count)s view',
+					'%(count)s views',
+					{
+						count,
+						args: { count: numberFormat( count ) },
+					}
+				) }
+			</li>
+		);
+	}
+
+	render() {
+		const { commentCount, likeCount, postId, siteId, viewCount } = this.props;
+
+		return (
+			<ul className="post-action-counts">
+				{ siteId && <QueryPostStats siteId={ siteId } postId={ postId } fields={ [ 'views' ] } /> }
+				{ viewCount > 0 && this.renderViewCount() }
+				{ likeCount > 0 && this.renderLikeCount() }
+				{ commentCount > 0 && this.renderCommentCount() }
+			</ul>
+		);
+	}
+}
+
+export default connect( ( state, { globalId } ) => {
+	const post = getNormalizedPost( state, globalId );
+	const postId = post && post.ID;
+	const siteId = post && post.site_ID;
+
+	return {
+		commentCount: get( post, 'discussion.comment_count', null ),
+		likeCount: get( post, 'like_count', null ),
+		postId,
+		siteId,
+		viewCount: getPostStat( state, siteId, postId, 'views' ),
+	};
+} )( localize( PostActionCounts ) );

--- a/client/my-sites/post-type-list/post-action-counts/style.scss
+++ b/client/my-sites/post-type-list/post-action-counts/style.scss
@@ -1,0 +1,22 @@
+.post-action-counts {
+	display: inline-block;
+	list-style: none;
+	margin: 0;
+	vertical-align: top;
+	line-height: 1;
+}
+
+.post-action-counts li {
+	display: inline;
+
+	&::after {
+		margin: 0 4px;
+		content: "•";
+	}
+
+	&:last-child {
+		&::after {
+			content: "";
+		}
+	}
+}


### PR DESCRIPTION
This PR adds action counts (# of likes, views, and comments) to the right of the post status.

Before:
![image](https://user-images.githubusercontent.com/363749/33561083-413f4a32-d8d7-11e7-9726-8ae4d1ea5894.png)

After:
![image](https://user-images.githubusercontent.com/363749/33561048-294d9302-d8d7-11e7-9b52-cbde8c789adf.png)

Note: this counts are just informational, they will be updated to link to the appropriate section in a future PR.