### PR TITLE
Jetpack connect: Move anon tracking to logged-out-form

### DIFF
--- a/client/jetpack-connect/auth-logged-out-form.jsx
+++ b/client/jetpack-connect/auth-logged-out-form.jsx
@@ -36,7 +36,10 @@ import WpcomLoginForm from 'signup/wpcom-login-form';
 import { createAccount as createAccountAction } from 'state/jetpack-connect/actions';
 import { getAuthorizationData } from 'state/jetpack-connect/selectors';
 import { login } from 'lib/paths';
-import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
+import {
+	recordTracksEvent as recordTracksEventAction,
+	setTracksAnonymousUserId as setTracksAnonymousUserIdAction,
+} from 'state/analytics/actions';
 
 const debug = debugFactory( 'calypso:jetpack-connect:authorize-form' );
 
@@ -58,6 +61,11 @@ class LoggedOutForm extends Component {
 	};
 
 	componentDidMount() {
+		// set anonymous ID for cross-system analytics
+		const { tracksUi, tracksUt } = this.props.authQuery;
+		if ( 'anon' === tracksUt && tracksUi ) {
+			this.props.setTracksAnonymousUserId( tracksUi );
+		}
 		this.props.recordTracksEvent( 'calypso_jpc_signup_view' );
 	}
 
@@ -146,7 +154,8 @@ export default connect(
 		authorizationData: getAuthorizationData( state ),
 	} ),
 	{
-		recordTracksEvent: recordTracksEventAction,
 		createAccount: createAccountAction,
+		recordTracksEvent: recordTracksEventAction,
+		setTracksAnonymousUserId: setTracksAnonymousUserIdAction,
 	}
 )( localize( LoggedOutForm ) );

--- a/client/jetpack-connect/authorize-form.jsx
+++ b/client/jetpack-connect/authorize-form.jsx
@@ -15,7 +15,7 @@ import LoggedOutForm from './auth-logged-out-form';
 import MainWrapper from './main-wrapper';
 import { authQueryPropTypes } from './utils';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { recordTracksEvent, setTracksAnonymousUserId } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class JetpackConnectAuthorizeForm extends Component {
 	static propTypes = {
@@ -24,15 +24,9 @@ class JetpackConnectAuthorizeForm extends Component {
 		// Connected props
 		isLoggedIn: PropTypes.bool.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
-		setTracksAnonymousUserId: PropTypes.func.isRequired,
 	};
 
 	componentWillMount() {
-		// set anonymous ID for cross-system analytics
-		const { tracksUi, tracksUt } = this.props.authQuery;
-		if ( 'anon' === tracksUt && tracksUi ) {
-			this.props.setTracksAnonymousUserId( tracksUi );
-		}
 		this.props.recordTracksEvent( 'calypso_jpc_authorize_form_view' );
 	}
 
@@ -67,8 +61,5 @@ export default connect(
 	state => ( {
 		isLoggedIn: !! getCurrentUserId( state ),
 	} ),
-	{
-		recordTracksEvent,
-		setTracksAnonymousUserId,
-	}
+	{ recordTracksEvent }
 )( localize( JetpackConnectAuthorizeForm ) );


### PR DESCRIPTION
This PR moves the anonymous id setting for tracks into the logged out form. It should not be necessary when a user is logged in.

Part of preparation for removing the parent authorize form which just wraps logged-in and logged-out forms.

## Testing

I'm not sure how this tracking works. I expect in production we're firing this event and it's ignored after a user is logged in.

1. Start logged out
1. Connect a new site
1. When you arrive at the Jetpack Connect step
   1. Verify the anonymousId:
      ```js
      actionLog.filter( actionTypes.ANALYTICS_TRACKS_ANONID_SET )
      ```
   1. Log in with an existing user
1. After logging in, you'll arrive back at the authorize step
1. Verify that there is an even associating the anonId with a new id. Look for a request like this:
   ```
   http://pixel.wp.com/t.gif?_en=_aliasUser&anonId=SOMEBIGID&_ui=123456ANUMERICID&_ut=wpcom
   ```
1. Verify that future tracks use the new id is used in future tracks events. Look for this param:
   ```
   _ui:123456ANUMERICID
   ```