### PR TITLE
Use state machine to determine whether we should show the "Creds Needed" banner

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -604,7 +604,7 @@ class ActivityLog extends Component {
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />
-				{ 'awaiting_credentials' === rewindState.state && <ActivityLogCredentialsNotice /> }
+				{ 'awaitingCredentials' === rewindState.state && <ActivityLogCredentialsNotice /> }
 				{ this.renderErrorMessage() }
 				{ hasFirstBackup && this.renderMonthNavigation() }
 				{ this.renderActionProgress() }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -63,7 +63,7 @@ import {
 	isRewindActive as isRewindActiveSelector,
 	getRequestedBackup,
 	getBackupProgress,
-	hasMainCredentials,
+	getRewindState,
 } from 'state/selectors';
 
 /**
@@ -492,7 +492,6 @@ class ActivityLog extends Component {
 		const {
 			canViewActivityLog,
 			hasFirstBackup,
-			hasMainCredentials, // eslint-disable-line no-shadow
 			isPressable,
 			isRewindActive,
 			logRequestQuery,
@@ -503,6 +502,7 @@ class ActivityLog extends Component {
 			requestedRestoreActivityId,
 			requestedBackup,
 			requestedBackupId,
+			rewindState,
 			siteId,
 			slug,
 			translate,
@@ -604,7 +604,7 @@ class ActivityLog extends Component {
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />
-				{ isRewindActive && ! hasMainCredentials && <ActivityLogCredentialsNotice /> }
+				{ 'awaiting_credentials' === rewindState.state && <ActivityLogCredentialsNotice /> }
 				{ this.renderErrorMessage() }
 				{ hasFirstBackup && this.renderMonthNavigation() }
 				{ this.renderActionProgress() }
@@ -710,7 +710,6 @@ export default connect(
 			canViewActivityLog: canCurrentUser( state, siteId, 'manage_options' ),
 			gmtOffset,
 			hasFirstBackup: ! isEmpty( getRewindStartDate( state, siteId ) ),
-			hasMainCredentials: hasMainCredentials( state, siteId ),
 			isRewindActive: isRewindActiveSelector( state, siteId ),
 			logRequestQuery,
 			logs: getActivityLogs(
@@ -725,6 +724,7 @@ export default connect(
 			restoreProgress: getRestoreProgress( state, siteId ),
 			backupProgress: getBackupProgress( state, siteId ),
 			requestData: { logs: getRequest( state, activityLogRequest( siteId, logRequestQuery ) ) },
+			rewindState: getRewindState( state, siteId ),
 			rewindStatusError: getRewindStatusError( state, siteId ),
 			siteId,
 			siteTitle: getSiteTitle( state, siteId ),

--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -1,5 +1,10 @@
 /** @format */
 
+/**
+ * External dependencies
+ */
+import { camelCase } from 'lodash';
+
 const transformCredential = data =>
 	Object.assign(
 		{
@@ -26,7 +31,7 @@ const transformRestore = data =>
 export const transformApi = data =>
 	Object.assign(
 		{
-			state: data.state,
+			state: camelCase( data.state ),
 			lastUpdated: new Date( data.last_updated * 1000 ),
 		},
 		data.credentials && { credentials: data.credentials.map( transformCredential ) },

--- a/client/state/selectors/get-rewind-state.js
+++ b/client/state/selectors/get-rewind-state.js
@@ -1,0 +1,18 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { get } from 'lodash';
+
+/**
+ * Get the entire Rewind state object.
+ *
+ * @param {Object} state Global state tree
+ * @param {number|string} siteId the site ID
+ * @return {Object} Rewind state object
+ */
+export default function getRewindState( state, siteId ) {
+	return get( state.rewind, siteId, {} );
+}

--- a/client/state/selectors/get-rewind-state.js
+++ b/client/state/selectors/get-rewind-state.js
@@ -14,5 +14,7 @@ import { get } from 'lodash';
  * @return {Object} Rewind state object
  */
 export default function getRewindState( state, siteId ) {
-	return get( state.rewind, siteId, {} );
+	return get( state.rewind, siteId, {
+		state: 'uninitialized',
+	} );
 }


### PR DESCRIPTION
Instead of depending on a successful network request to hide the banner, we are depending on the state machine to only show the banner when the request has succeeded and we are in an `awaiting_credentials` state.

Testing instructions:
On a Pressable site, provision and revoke credentials, checking the Activity Log during steps to ensure the banner shows when appropriate.