### PR TITLE
Activity Log: replace help link with a HappyChat button

### DIFF
--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -13,7 +13,10 @@ import { isUndefined } from 'lodash';
  */
 import ActivityLogBanner from './index';
 import Button from 'components/button';
+import HappychatButton from 'components/happychat/button';
+import Gridicon from 'gridicons';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { dismissRewindRestoreProgress as dismissRewindRestoreProgressAction } from 'state/activity-log/actions';
 
 class ErrorBanner extends PureComponent {
@@ -64,7 +67,15 @@ class ErrorBanner extends PureComponent {
 			: this.props.closeDialog( 'backup' );
 
 	render() {
-		const { errorCode, failureReason, timestamp, translate, downloadId } = this.props;
+		const {
+			errorCode,
+			failureReason,
+			timestamp,
+			translate,
+			downloadId,
+			trackHappyChatBackup,
+			trackHappyChatRestore,
+		} = this.props;
 		const strings = isUndefined( downloadId )
 			? {
 					title: translate( 'Problem restoring your site' ),
@@ -103,9 +114,15 @@ class ErrorBanner extends PureComponent {
 					{ translate( 'Try again' ) }
 				</Button>
 				{ '  ' }
-				<Button href="https://help.vaultpress.com/restore-tips-troubleshooting-steps/">
-					{ translate( 'Get help' ) }
-				</Button>
+				<HappychatButton
+					className="activity-log-confirm-dialog__more-info-link"
+					onClick={ isUndefined( downloadId ) ? trackHappyChatRestore : trackHappyChatBackup }
+				>
+					<Gridicon icon="chat" />
+					<span className="activity-log-confirm-dialog__more-info-link-text">
+						{ translate( 'Get help' ) }
+					</span>
+				</HappychatButton>
 			</ActivityLogBanner>
 		);
 	}
@@ -113,4 +130,6 @@ class ErrorBanner extends PureComponent {
 
 export default connect( null, {
 	dismissRewindRestoreProgress: dismissRewindRestoreProgressAction,
+	trackHappyChatBackup: () => recordTracksEvent( 'calypso_activitylog_error_banner_backup' ),
+	trackHappyChatRestore: () => recordTracksEvent( 'calypso_activitylog_error_banner_restore' ),
 } )( localize( ErrorBanner ) );

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -19,6 +19,11 @@ import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { dismissRewindRestoreProgress as dismissRewindRestoreProgressAction } from 'state/activity-log/actions';
 
+const happyChatBackupTracking = () =>
+	recordTracksEvent( 'calypso_activitylog_error_banner_backup' );
+const happyChatRestoreTracking = () =>
+	recordTracksEvent( 'calypso_activitylog_error_banner_restore' );
+
 class ErrorBanner extends PureComponent {
 	static propTypes = {
 		errorCode: PropTypes.string.isRequired,
@@ -113,7 +118,6 @@ class ErrorBanner extends PureComponent {
 				<Button primary onClick={ this.handleClickRestart }>
 					{ translate( 'Try again' ) }
 				</Button>
-				{ '  ' }
 				<HappychatButton
 					className="activity-log-confirm-dialog__more-info-link"
 					onClick={ isUndefined( downloadId ) ? trackHappyChatRestore : trackHappyChatBackup }
@@ -130,6 +134,6 @@ class ErrorBanner extends PureComponent {
 
 export default connect( null, {
 	dismissRewindRestoreProgress: dismissRewindRestoreProgressAction,
-	trackHappyChatBackup: () => recordTracksEvent( 'calypso_activitylog_error_banner_backup' ),
-	trackHappyChatRestore: () => recordTracksEvent( 'calypso_activitylog_error_banner_restore' ),
+	trackHappyChatBackup: happyChatBackupTracking,
+	trackHappyChatRestore: happyChatRestoreTracking,
 } )( localize( ErrorBanner ) );

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -19,11 +19,6 @@ import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { dismissRewindRestoreProgress as dismissRewindRestoreProgressAction } from 'state/activity-log/actions';
 
-const happyChatBackupTracking = () =>
-	recordTracksEvent( 'calypso_activitylog_error_banner_backup' );
-const happyChatRestoreTracking = () =>
-	recordTracksEvent( 'calypso_activitylog_error_banner_restore' );
-
 class ErrorBanner extends PureComponent {
 	static propTypes = {
 		errorCode: PropTypes.string.isRequired,
@@ -134,6 +129,6 @@ class ErrorBanner extends PureComponent {
 
 export default connect( null, {
 	dismissRewindRestoreProgress: dismissRewindRestoreProgressAction,
-	trackHappyChatBackup: happyChatBackupTracking,
-	trackHappyChatRestore: happyChatRestoreTracking,
+	trackHappyChatBackup: () => recordTracksEvent( 'calypso_activitylog_error_banner_backup' ),
+	trackHappyChatRestore: () => recordTracksEvent( 'calypso_activitylog_error_banner_restore' ),
 } )( localize( ErrorBanner ) );

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -119,11 +119,11 @@ class ErrorBanner extends PureComponent {
 					{ translate( 'Try again' ) }
 				</Button>
 				<HappychatButton
-					className="activity-log-confirm-dialog__more-info-link"
+					className="activity-log-banner__error-happychat activity-log-confirm-dialog__more-info-link"
 					onClick={ isUndefined( downloadId ) ? trackHappyChatRestore : trackHappyChatBackup }
 				>
 					<Gridicon icon="chat" />
-					<span className="activity-log-confirm-dialog__more-info-link-text">
+					<span className="activity-log-banner__error-happychat-text activity-log-confirm-dialog__more-info-link-text">
 						{ translate( 'Get help' ) }
 					</span>
 				</HappychatButton>

--- a/client/my-sites/stats/activity-log-banner/style.scss
+++ b/client/my-sites/stats/activity-log-banner/style.scss
@@ -82,3 +82,10 @@
 		$bar-color 72%
 	);
 }
+
+// HappyChat button in error banner
+.button.is-primary + .activity-log-confirm-dialog__more-info-link {
+	margin-left: 16px;
+	display: inline-block;
+	vertical-align: text-top;
+}


### PR DESCRIPTION
Fixes #20475

This PR replaces the previous button linking to VP docs with a HappyChat button stylized like the one in the confirmation dialogs.
It also adds tracking when user clicks HappyChat from a backup error separately from a restore error.