### PR TITLE
Store: Fix Console Warnings

### DIFF
--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -37,7 +37,7 @@ function renderViewButton( product, translate ) {
 function renderTrashButton( onTrash, product, isBusy, translate ) {
 	return (
 		onTrash && (
-			<Button borderless scary onClick={ onTrash }>
+			<Button borderless scary onClick={ onTrash ? onTrash : undefined }>
 				<Gridicon icon="trash" />
 				<span>{ translate( 'Delete' ) } </span>
 			</Button>
@@ -54,7 +54,12 @@ function renderSaveButton( onSave, product, isBusy, translate ) {
 
 	return (
 		saveExists && (
-			<Button primary onClick={ onSave } disabled={ saveDisabled } busy={ isBusy }>
+			<Button
+				primary
+				onClick={ onSave ? onSave : undefined }
+				disabled={ saveDisabled }
+				busy={ isBusy }
+			>
 				{ saveLabel }
 			</Button>
 		)

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
@@ -80,7 +80,11 @@ class FormClickToEditInput extends Component {
 					autoFocus
 					className="form-click-to-edit-input__input"
 				/>
-				<Button borderless onClick={ this.editEnd } aria-label={ this.props.updateAriaLabel }>
+				<Button
+					borderless
+					onClick={ this.editEnd ? this.editEnd : undefined }
+					aria-label={ this.props.updateAriaLabel }
+				>
 					<Gridicon icon="checkmark" />
 				</Button>
 			</span>
@@ -95,12 +99,19 @@ class FormClickToEditInput extends Component {
 		} );
 		return (
 			<span className={ classes }>
-				<span className="form-click-to-edit-input__text" onClick={ ! disabled && this.editStart }>
+				<span
+					className="form-click-to-edit-input__text"
+					onClick={ ! disabled && this.editStart ? this.editStart : undefined }
+				>
 					{ value || placeholder }
 				</span>
 
 				{ ! disabled && (
-					<Button borderless onClick={ this.editStart } aria-label={ editAriaLabel }>
+					<Button
+						borderless
+						onClick={ this.editStart ? this.ediStart : undefined }
+						aria-label={ editAriaLabel }
+					>
 						<Gridicon icon="pencil" />
 					</Button>
 				) }


### PR DESCRIPTION
Fixes #20418

Since the React upgrade, there have been some warnings thrown in the console on the Store Products pages - this branch seeks to fix that.

__To Test__
- Visit a Product Page for an existing product
- Very if no warnings are thrown in the console
- Edit the product slug, and click Update. Verify items are updated/saved as expected.