### PR TITLE
Editor: Prevent blank screen when pressing back button

### DIFF
--- a/client/components/tinymce/plugins/media/drop-zone.jsx
+++ b/client/components/tinymce/plugins/media/drop-zone.jsx
@@ -48,10 +48,12 @@ class TinyMCEDropZone extends React.Component {
 
 	componentWillUnmount() {
 		const { editor } = this.props;
-		editor.dom.unbind( editor.getWin(), 'dragenter', this.redirectEditorDragEvent );
 		window.removeEventListener( 'dragleave', this.stopDragging );
-		editor.dom.unbind( editor.getWin(), 'dragleave', this.stopDragging );
-		editor.dom.unbind( editor.getWin(), 'dragover', this.fakeDragEnterIfNecessary );
+		if ( editor.getWin() ) {
+			editor.dom.unbind( editor.getWin(), 'dragenter', this.redirectEditorDragEvent );
+			editor.dom.unbind( editor.getWin(), 'dragleave', this.stopDragging );
+			editor.dom.unbind( editor.getWin(), 'dragover', this.fakeDragEnterIfNecessary );
+		}
 	}
 
 	redirectEditorDragEvent = event => {


### PR DESCRIPTION
## This PR
- prevents an issue where a blank screen was showing after the back button was pressed
- fixes #20484 reported by @shaunandrews 

## Issue & fix
The issue was caused by an error being thrown in `TinyMCEDropZone`. On `componentWillUnmount` there are three `editor.dom.unbind(editor.getWin(), 'event', this.replaceEvent )` calls that try to unbind attached events. This fails as `editor.dom.win`, which the functions are trying to get via `editor.getWin()`, is `null` at the point the functions are being called.

The reason `editor.dom.win` is `null`, is that the `componentWillUnmount` function in `TinyMCEDropZone` gets called after the editor has already been removed via the `destroyEditor()` (see `tinymce/index.js`). At that point, there is probably no need anymore to unbind any events. 

Not sure if there are other `TinyMCEDropZone` use cases where the editor doesn't get destroyed or gets removed after `TinyMCEDropZone`. Therefore going to fix this issue by wrapping the unbind functions in a check for `editor.dom.win` being available.

## How to test

1. Use the calypso.live link below or check out locally
2. Go to: https://wordpress.com/view/yoursitename
3. Click the write button in the Masterbar
4. Once the editor loads, click the back arrow in the top-left
5. You should be back at the `/view/` screen

**Before** 

<img width="800" alt="screen shot 2017-12-04 at 20 15 24" src="https://user-images.githubusercontent.com/1562646/33585010-1ade8b60-d930-11e7-98a2-bfab6da04858.png">


**After**

![screen shot 2017-12-04 at 20 14 38](https://user-images.githubusercontent.com/1562646/33584988-042bb654-d930-11e7-9e02-56b07f399a8e.png)

