### PR TITLE
Add site title guided tour

### DIFF
--- a/client/layout/guided-tours/config-elements/index.js
+++ b/client/layout/guided-tours/config-elements/index.js
@@ -11,6 +11,7 @@ export Link from './link';
 export makeTour from './make-tour';
 export Next from './next';
 export Quit from './quit';
+export SiteLink from './site-link';
 export Step from './step';
 export Tour from './tour';
 export LinkQuit from './link-quit';

--- a/client/layout/guided-tours/config-elements/site-link.js
+++ b/client/layout/guided-tours/config-elements/site-link.js
@@ -14,10 +14,12 @@ import PropTypes from 'prop-types';
 import contextTypes from '../context-types';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
+import Button from 'components/button';
 
 class SiteLink extends Component {
 	static propTypes = {
 		href: PropTypes.string,
+		isButton: PropTypes.boolean,
 	};
 
 	static contextTypes = contextTypes;
@@ -29,11 +31,19 @@ class SiteLink extends Component {
 	};
 
 	render() {
-		const { children, href, siteSlug } = this.props;
+		const { children, href, siteSlug, isButton } = this.props;
 		const siteHref = href.replace( ':site', siteSlug );
 
+		if ( isButton ) {
+			return (
+				<Button primary onClick={ this.onClick } href={ siteHref }>
+					{ children }
+				</Button>
+			);
+		}
+
 		return (
-			<a onClick={ this.onClick } href={ siteHref }>
+			<a onClick={ this.onClick } href={ siteHref } className="config-elements__text-link">
 				{ children }
 			</a>
 		);

--- a/client/layout/guided-tours/config-elements/site-link.js
+++ b/client/layout/guided-tours/config-elements/site-link.js
@@ -19,7 +19,11 @@ import Button from 'components/button';
 class SiteLink extends Component {
 	static propTypes = {
 		href: PropTypes.string,
-		isButton: PropTypes.boolean,
+		isButton: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		isButton: false,
 	};
 
 	static contextTypes = contextTypes;

--- a/client/layout/guided-tours/config-elements/site-link.js
+++ b/client/layout/guided-tours/config-elements/site-link.js
@@ -1,0 +1,51 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import contextTypes from '../context-types';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+
+class SiteLink extends Component {
+	static propTypes = {
+		href: PropTypes.string,
+	};
+
+	static contextTypes = contextTypes;
+
+	onClick = event => {
+		this.props.onClick && this.props.onClick( event );
+		const { quit, tour, tourVersion, step, isLastStep } = this.context;
+		quit( { tour, tourVersion, step, isLastStep } );
+	};
+
+	render() {
+		const { children, href, siteSlug } = this.props;
+		const siteHref = href.replace( ':site', siteSlug );
+
+		return (
+			<a onClick={ this.onClick } href={ siteHref }>
+				{ children }
+			</a>
+		);
+	}
+}
+
+const mapStateToProps = state => {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSiteSlug( state, siteId );
+	return { siteId, siteSlug };
+};
+
+const mapDispatchToProps = null;
+
+export default connect( mapStateToProps, mapDispatchToProps )( SiteLink );

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -12,6 +12,7 @@ import { SimplePaymentsTour } from 'layout/guided-tours/tours/simple-payments-to
 import { EditorBasicsTour } from 'layout/guided-tours/tours/editor-basics-tour';
 import { MediaBasicsTour } from 'layout/guided-tours/tours/media-basics-tour';
 import { SimplePaymentsEndOfYearGuide } from 'layout/guided-tours/tours/simple-payments-end-of-year-guide';
+import { SiteTitleTour } from 'layout/guided-tours/tours/site-title-tour';
 
 export default combineTours( {
 	main: MainTour,
@@ -21,4 +22,5 @@ export default combineTours( {
 	gdocsIntegrationTour: GDocsIntegrationTour,
 	simplePaymentsTour: SimplePaymentsTour,
 	simplePaymentsEndOfYearGuide: SimplePaymentsEndOfYearGuide,
+	siteTitle: SiteTitleTour,
 } );

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -12,9 +12,10 @@ import { SimplePaymentsTour } from 'layout/guided-tours/tours/simple-payments-to
 import { EditorBasicsTour } from 'layout/guided-tours/tours/editor-basics-tour';
 import { MediaBasicsTour } from 'layout/guided-tours/tours/media-basics-tour';
 import { SimplePaymentsEndOfYearGuide } from 'layout/guided-tours/tours/simple-payments-end-of-year-guide';
-import { SiteTitleTour } from 'layout/guided-tours/tours/site-title-tour';
+import { ChecklistSiteTitleTour } from 'layout/guided-tours/tours/checklist-site-title-tour';
 
 export default combineTours( {
+	checklistSiteTitle: ChecklistSiteTitleTour,
 	main: MainTour,
 	editorBasicsTour: EditorBasicsTour,
 	mediaBasicsTour: MediaBasicsTour,
@@ -22,5 +23,4 @@ export default combineTours( {
 	gdocsIntegrationTour: GDocsIntegrationTour,
 	simplePaymentsTour: SimplePaymentsTour,
 	simplePaymentsEndOfYearGuide: SimplePaymentsEndOfYearGuide,
-	siteTitle: SiteTitleTour,
 } );

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -134,6 +134,10 @@ a.config-elements__text-link,
 	&:hover {
 		text-decoration: none;
 	}
+
+	&:visited {
+		color: $white;
+	}
 }
 
 

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -41,6 +41,29 @@
 		position: relative;
 		top: 3px;
 	}
+
+	.tours__title {
+		font-size: 140%;
+	    font-weight: 300;
+	    display: flex;
+	    align-items: center;
+	    color: $white;
+	    margin-bottom: 10px;
+	}
+
+	.tours__completed-icon-wrapper {
+		background: $alert-green;
+		border-radius: 100%;
+		display: inline-block;
+		margin-right: 10px;
+		width: 25px;
+		height: 25px;
+	}
+
+	.tours__completed-icon {
+		margin-top: -10px;
+		margin-left: 2px;
+	}
 }
 
 .card.guided-tours__step-first {
@@ -85,6 +108,9 @@
 }
 
 .guided-tours__choice-button-row {
+	display: flex;
+	align-items: center;
+
 	.button {
 		width: 48%;
 	}
@@ -100,6 +126,16 @@
 		border: none;
 	}
 }
+
+a.config-elements__text-link,
+.config-elements__text-link {
+	color: $white;
+
+	&:hover {
+		text-decoration: none;
+	}
+}
+
 
 .guided-tours__single-button-row {
 	.button {
@@ -117,7 +153,7 @@
 	color: lighten( $gray, 10 );
 	margin-bottom: 0;
 	font-style: italic;
-	line-height: 24px;
+	line-height: 1.3em;
 	min-height: 24px;
 
 	.external-link {

--- a/client/layout/guided-tours/tours/checklist-site-title-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour.js
@@ -1,0 +1,68 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { translate } from 'i18n-calypso';
+import { noop } from 'lodash';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ButtonRow,
+	Continue,
+	makeTour,
+	Next,
+	SiteLink,
+	Step,
+	Tour,
+} from 'layout/guided-tours/config-elements';
+
+export const ChecklistSiteTitleTour = makeTour(
+	<Tour name="checklistSiteTitle" version="20171205" path="/non-existent-route" when={ noop }>
+		<Step name="init" target="site-title-input" arrow="top-left" placement="below">
+			<p>
+				{ translate(
+					"Update the {{b}}Site Title{{/b}} field with a descriptive name to let your visitors know which site they're visiting.",
+					{
+						components: { b: <strong /> },
+					}
+				) }
+			</p>
+			<ButtonRow>
+				<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
+				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+			</ButtonRow>
+		</Step>
+
+		<Step name="click-save" target="settings-site-profile-save" arrow="top-left" placement="below">
+			<Continue target="settings-site-profile-save" step="finish" click>
+				{ translate(
+					'Almost done — every time you make a change, it needs to be saved. ' +
+						"Let's save your changes and then see what's next on our list."
+				) }
+			</Continue>
+		</Step>
+
+		<Step name="finish" placement="right">
+			<h1 className="tours__title">
+				<span className="tours__completed-icon-wrapper">
+					<Gridicon icon="checkmark" className="tours__completed-icon" />
+				</span>
+				{ translate( 'Good job, looks great!' ) }
+			</h1>
+			<p>
+				{ translate(
+					"Your changes have been saved. Let's move on and see what's next on our checklist."
+				) }
+			</p>
+			<SiteLink isButton="true" href={ '/checklist/:site' }>
+				{ translate( 'Return to the checklist' ) }
+			</SiteLink>
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/checklist-site-title-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour.js
@@ -24,7 +24,15 @@ import {
 
 export const ChecklistSiteTitleTour = makeTour(
 	<Tour name="checklistSiteTitle" version="20171205" path="/non-existent-route" when={ noop }>
-		<Step name="init" target="site-title-input" arrow="top-left" placement="below">
+		<Step
+			name="init"
+			target="site-title-input"
+			arrow="top-left"
+			placement="below"
+			style={ {
+				animationDelay: '0.7s',
+			} }
+		>
 			<p>
 				{ translate(
 					"Update the {{b}}Site Title{{/b}} field with a descriptive name to let your visitors know which site they're visiting.",

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -15,57 +15,24 @@ import Gridicon from 'gridicons';
 import {
 	ButtonRow,
 	Continue,
-	Link,
 	makeTour,
 	Next,
 	Quit,
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
-import {
-	hasSelectedSiteDefaultSiteTitle,
-	isUserOlderThan,
-	isEnabled,
-	canUserEditSettingsOfSelectedSite,
-	isAbTestInVariant,
-} from 'state/ui/guided-tours/contexts';
+import { canUserEditSettingsOfSelectedSite } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
-
-const TWO_DAYS_IN_MILLISECONDS = 2 * 1000 * 3600 * 24;
 
 export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
-		version="20161207"
+		version="20171205"
 		path="/stats"
-		when={ and(
-			isEnabled( 'guided-tours/site-title' ),
-			isDesktop,
-			hasSelectedSiteDefaultSiteTitle,
-			canUserEditSettingsOfSelectedSite,
-			isUserOlderThan( TWO_DAYS_IN_MILLISECONDS ),
-			isAbTestInVariant( 'siteTitleTour', 'enabled' )
-		) }
+		when={ and( isDesktop, canUserEditSettingsOfSelectedSite ) }
 	>
-		<Step name="init" placement="right" next="click-settings">
-			<p>
-				{ translate(
-					"Hey there! We noticed you haven't changed the title of your site yet. Want to change it?"
-				) }
-			</p>
-			<p>
-				{ translate(
-					'The site title appears in places like the top of your web browser and in search results.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="click-settings">{ translate( 'Yes, please!' ) }</Next>
-				<Quit>{ translate( 'No, thanks.' ) }</Quit>
-			</ButtonRow>
-		</Step>
-
 		<Step
-			name="click-settings"
+			name="init"
 			target="settings"
 			arrow="left-top"
 			placement="beside"
@@ -73,7 +40,7 @@ export const SiteTitleTour = makeTour(
 			shouldScrollTo
 		>
 			<Continue target="settings" step="site-title-input" click>
-				{ translate( 'Click {{strong}}{{icon/}} Settings{{/strong}} to continue.', {
+				{ translate( 'Click {{strong}}{{icon/}} Settings{{/strong}} to get started.', {
 					components: {
 						icon: <Gridicon icon="cog" />,
 						strong: <strong />,
@@ -89,20 +56,7 @@ export const SiteTitleTour = makeTour(
 				) }
 			</p>
 			<ButtonRow>
-				<Next step="site-tagline-input">{ translate( 'Looks Good!' ) }</Next>
-				<Quit>{ translate( 'Cancel' ) }</Quit>
-			</ButtonRow>
-		</Step>
-
-		<Step name="site-tagline-input" target="site-tagline-input" arrow="top-left" placement="below">
-			<p>
-				{ translate(
-					"While you're at it, why not add a tagline? It should explain what your site is about in a few words. " +
-						'It usually appears right below your site title.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="click-save">{ translate( 'Great!' ) }</Next>
+				<Next step="click-save">{ translate( 'Looks Good!' ) }</Next>
 				<Quit>{ translate( 'Cancel' ) }</Quit>
 			</ButtonRow>
 		</Step>
@@ -127,9 +81,6 @@ export const SiteTitleTour = makeTour(
 			<ButtonRow>
 				<Quit primary>{ translate( "We're all done!" ) }</Quit>
 			</ButtonRow>
-			<Link href="https://en.support.wordpress.com/start">
-				{ translate( 'Learn more about WordPress.com' ) }
-			</Link>
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -7,7 +7,6 @@
 import React from 'react';
 import { translate } from 'i18n-calypso';
 import { overEvery as and } from 'lodash';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -22,34 +21,15 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 import { canUserEditSettingsOfSelectedSite } from 'state/ui/guided-tours/contexts';
-import { isDesktop } from 'lib/viewport';
 
 export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
 		version="20171205"
 		path="/stats"
-		when={ and( isDesktop, canUserEditSettingsOfSelectedSite ) }
+		when={ and( canUserEditSettingsOfSelectedSite ) }
 	>
-		<Step
-			name="init"
-			target="settings"
-			arrow="left-top"
-			placement="beside"
-			scrollContainer=".sidebar__region"
-			shouldScrollTo
-		>
-			<Continue target="settings" step="site-title-input" click>
-				{ translate( 'Click {{strong}}{{icon/}} Settings{{/strong}} to get started.', {
-					components: {
-						icon: <Gridicon icon="cog" />,
-						strong: <strong />,
-					},
-				} ) }
-			</Continue>
-		</Step>
-
-		<Step name="site-title-input" target="site-title-input" arrow="top-left" placement="below">
+		<Step name="init" target="site-title-input" arrow="top-left" placement="below">
 			<p>
 				{ translate(
 					'You can change the site title here. A good title can help others find your site.'

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -27,7 +27,7 @@ export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
 		version="20171205"
-		path="/checklist"
+		path="/non-existent-route"
 		when={ and( canUserEditSettingsOfSelectedSite ) }
 	>
 		<Step name="init" target="site-title-input" arrow="top-left" placement="below">

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -15,60 +15,121 @@ import Gridicon from 'gridicons';
 import {
 	ButtonRow,
 	Continue,
+	Link,
 	makeTour,
 	Next,
-	SiteLink,
+	Quit,
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
-import { canUserEditSettingsOfSelectedSite } from 'state/ui/guided-tours/contexts';
+import {
+	hasSelectedSiteDefaultSiteTitle,
+	isUserOlderThan,
+	isEnabled,
+	canUserEditSettingsOfSelectedSite,
+	isAbTestInVariant,
+} from 'state/ui/guided-tours/contexts';
+import { isDesktop } from 'lib/viewport';
+
+const TWO_DAYS_IN_MILLISECONDS = 2 * 1000 * 3600 * 24;
 
 export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
-		version="20171205"
-		path="/non-existent-route"
-		when={ and( canUserEditSettingsOfSelectedSite ) }
+		version="20161207"
+		path="/stats"
+		when={ and(
+			isEnabled( 'guided-tours/site-title' ),
+			isDesktop,
+			hasSelectedSiteDefaultSiteTitle,
+			canUserEditSettingsOfSelectedSite,
+			isUserOlderThan( TWO_DAYS_IN_MILLISECONDS ),
+			isAbTestInVariant( 'siteTitleTour', 'enabled' )
+		) }
 	>
-		<Step name="init" target="site-title-input" arrow="top-left" placement="below">
+		<Step name="init" placement="right" next="click-settings">
 			<p>
 				{ translate(
-					"Update the {{b}}Site Title{{/b}} field with a descriptive name to let your visitors know which site they're visiting.",
+					"Hey there! We noticed you haven't changed the title of your site yet. Want to change it?"
+				) }
+			</p>
+			<p>
+				{ translate(
+					'The site title appears in places like the top of your web browser and in search results.'
+				) }
+			</p>
+			<ButtonRow>
+				<Next step="click-settings">{ translate( 'Yes, please!' ) }</Next>
+				<Quit>{ translate( 'No, thanks.' ) }</Quit>
+			</ButtonRow>
+		</Step>
+
+		<Step
+			name="click-settings"
+			target="settings"
+			arrow="left-top"
+			placement="beside"
+			scrollContainer=".sidebar__region"
+			shouldScrollTo
+		>
+			<Continue target="settings" step="site-title-input" click>
+				{ translate( 'Click {{strong}}{{icon/}} Settings{{/strong}} to continue.', {
+					components: {
+						icon: <Gridicon icon="cog" />,
+						strong: <strong />,
+					},
+				} ) }
+			</Continue>
+		</Step>
+
+		<Step name="site-title-input" target="site-title-input" arrow="top-left" placement="below">
+			<p>
+				{ translate(
+					'You can change the site title here. A good title can help others find your site.'
+				) }
+			</p>
+			<ButtonRow>
+				<Next step="site-tagline-input">{ translate( 'Looks Good!' ) }</Next>
+				<Quit>{ translate( 'Cancel' ) }</Quit>
+			</ButtonRow>
+		</Step>
+
+		<Step name="site-tagline-input" target="site-tagline-input" arrow="top-left" placement="below">
+			<p>
+				{ translate(
+					"While you're at it, why not add a tagline? It should explain what your site is about in a few words. " +
+						'It usually appears right below your site title.'
+				) }
+			</p>
+			<ButtonRow>
+				<Next step="click-save">{ translate( 'Great!' ) }</Next>
+				<Quit>{ translate( 'Cancel' ) }</Quit>
+			</ButtonRow>
+		</Step>
+
+		<Step name="click-save" target="settings-site-profile-save" arrow="top-right" placement="below">
+			<Continue target="settings-site-profile-save" step="finish" click>
+				{ translate( "Don't forget to save your changes." ) }
+			</Continue>
+		</Step>
+
+		<Step name="finish" placement="center">
+			<p>
+				{ translate(
+					"{{strong}}That's it!{{/strong}} Your visitors can now easily identify your website by its title.",
 					{
-						components: { b: <strong /> },
+						components: {
+							strong: <strong />,
+						},
 					}
 				) }
 			</p>
 			<ButtonRow>
-				<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+				<Quit primary>{ translate( "We're all done!" ) }</Quit>
 			</ButtonRow>
-		</Step>
-
-		<Step name="click-save" target="settings-site-profile-save" arrow="top-left" placement="below">
-			<Continue target="settings-site-profile-save" step="finish" click>
-				{ translate(
-					'Almost done — every time you make a change, it needs to be saved. ' +
-						"Let's save your changes and then see what's next on our list."
-				) }
-			</Continue>
-		</Step>
-
-		<Step name="finish" placement="right">
-			<h1 className="tours__title">
-				<span className="tours__completed-icon-wrapper">
-					<Gridicon icon="checkmark" className="tours__completed-icon" />
-				</span>
-				{ translate( 'Good job, looks great!' ) }
-			</h1>
-			<p>
-				{ translate(
-					"Your changes have been saved. Let's move on and see what's next on our checklist."
-				) }
-			</p>
-			<SiteLink isButton="true" href={ '/checklist/:site' }>
-				{ translate( 'Return to the checklist' ) }
-			</SiteLink>
+			<Link href="https://en.support.wordpress.com/start">
+				{ translate( 'Learn more about WordPress.com' ) }
+			</Link>
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -45,27 +45,30 @@ export const SiteTitleTour = makeTour(
 			</ButtonRow>
 		</Step>
 
-		<Step name="click-save" target="settings-site-profile-save" arrow="top-right" placement="below">
+		<Step name="click-save" target="settings-site-profile-save" arrow="top-left" placement="below">
 			<Continue target="settings-site-profile-save" step="finish" click>
 				{ translate(
-					'Almost done - every time you make a change, it needs to be saved. ' +
+					'Almost done — every time you make a change, it needs to be saved. ' +
 						"Let's save your changes and then see what's next on our list."
 				) }
 			</Continue>
 		</Step>
 
-		<Step name="finish" placement="center">
-			<p>
-				<Gridicon icon="checkmark" /> { translate( 'Good job, looks great!' ) }
-			</p>
+		<Step name="finish" placement="right">
+			<h1 className="tours__title">
+				<span className="tours__completed-icon-wrapper">
+					<Gridicon icon="checkmark" className="tours__completed-icon" />
+				</span>
+				{ translate( 'Good job, looks great!' ) }
+			</h1>
 			<p>
 				{ translate(
 					"Your changes have been saved. Let's move on and see what's next on our checklist."
 				) }
 			</p>
-			<ButtonRow>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
-			</ButtonRow>
+			<SiteLink isButton="true" href={ '/checklist/:site' }>
+				{ translate( 'Return to the checklist' ) }
+			</SiteLink>
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -7,6 +7,7 @@
 import React from 'react';
 import { translate } from 'i18n-calypso';
 import { overEvery as and } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -16,7 +17,7 @@ import {
 	Continue,
 	makeTour,
 	Next,
-	Quit,
+	SiteLink,
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
@@ -26,40 +27,44 @@ export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
 		version="20171205"
-		path="/stats"
+		path="/checklist"
 		when={ and( canUserEditSettingsOfSelectedSite ) }
 	>
 		<Step name="init" target="site-title-input" arrow="top-left" placement="below">
 			<p>
 				{ translate(
-					'You can change the site title here. A good title can help others find your site.'
+					"Update the {{b}}Site Title{{/b}} field with a descriptive name to let your visitors know which site they're visiting.",
+					{
+						components: { b: <strong /> },
+					}
 				) }
 			</p>
 			<ButtonRow>
-				<Next step="click-save">{ translate( 'Looks Good!' ) }</Next>
-				<Quit>{ translate( 'Cancel' ) }</Quit>
+				<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
+				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 			</ButtonRow>
 		</Step>
 
 		<Step name="click-save" target="settings-site-profile-save" arrow="top-right" placement="below">
 			<Continue target="settings-site-profile-save" step="finish" click>
-				{ translate( "Don't forget to save your changes." ) }
+				{ translate(
+					'Almost done - every time you make a change, it needs to be saved. ' +
+						"Let's save your changes and then see what's next on our list."
+				) }
 			</Continue>
 		</Step>
 
 		<Step name="finish" placement="center">
 			<p>
+				<Gridicon icon="checkmark" /> { translate( 'Good job, looks great!' ) }
+			</p>
+			<p>
 				{ translate(
-					"{{strong}}That's it!{{/strong}} Your visitors can now easily identify your website by its title.",
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
+					"Your changes have been saved. Let's move on and see what's next on our checklist."
 				) }
 			</p>
 			<ButtonRow>
-				<Quit primary>{ translate( "We're all done!" ) }</Quit>
+				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 			</ButtonRow>
 		</Step>
 	</Tour>

--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -42,10 +42,11 @@ class ChecklistShow extends PureComponent {
 				status,
 			} );
 
+			if ( url ) {
+				page( url );
+			}
 			if ( tour ) {
 				requestTour( tour );
-			} else {
-				page( url );
 			}
 		}
 	};

--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -21,23 +21,32 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteChecklist } from 'state/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
-import { onboardingTasks, urlForTask } from '../onboardingChecklist';
+import { onboardingTasks, tourForTask, urlForTask } from '../onboardingChecklist';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { createNotice } from 'state/notices/actions';
+import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 
 class ChecklistShow extends PureComponent {
 	onAction = id => {
-		const { siteSlug, siteChecklist, track } = this.props;
+		const { requestTour, siteSlug, siteChecklist, track } = this.props;
+
+		const tour = tourForTask( id );
 		const url = urlForTask( id, siteSlug );
-		if ( url && siteChecklist && siteChecklist.tasks ) {
+
+		if ( siteChecklist && siteChecklist.tasks && ( url || tour ) ) {
 			const status = siteChecklist.tasks[ id ] ? 'complete' : 'incomplete';
+
 			track( 'calypso_checklist_task_start', {
 				checklist_name: 'new_blog',
 				step_name: id,
 				status,
 			} );
 
-			page( url );
+			if ( tour ) {
+				requestTour( tour );
+			} else {
+				page( url );
+			}
 		}
 	};
 
@@ -83,9 +92,11 @@ const mapStateToProps = state => {
 	const siteSlug = getSiteSlug( state, siteId );
 	return { siteId, siteSlug, siteChecklist };
 };
+
 const mapDispatchToProps = {
 	track: recordTracksEvent,
 	notify: createNotice,
+	requestTour: requestGuidedTour,
 	update: requestSiteChecklistTaskUpdate,
 };
 

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -37,7 +37,7 @@ const tasks = {
 		duration: '1 min',
 		completedTitle: 'You updated your site title',
 		completedButtonText: 'Edit',
-		url: '/settings/general/$siteSlug',
+		url: '/checklist/$siteSlug?tour=siteTitle',
 		image: '/calypso/images/stats/tasks/personalize-your-site.svg',
 	},
 	blogdescription_set: {

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -37,8 +37,8 @@ const tasks = {
 		duration: '1 min',
 		completedTitle: 'You updated your site title',
 		completedButtonText: 'Edit',
-		url: '/checklist/$siteSlug?tour=siteTitle',
 		image: '/calypso/images/stats/tasks/personalize-your-site.svg',
+		tour: 'siteTitle',
 	},
 	blogdescription_set: {
 		title: 'Create a tagline',
@@ -128,6 +128,13 @@ export const urlForTask = ( id, siteSlug ) => {
 	const task = tasks[ id ];
 	if ( task && task.url ) {
 		return task.url.replace( '$siteSlug', siteSlug );
+	}
+};
+
+export const tourForTask = id => {
+	const task = tasks[ id ];
+	if ( task ) {
+		return task.tour;
 	}
 };
 

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -39,7 +39,7 @@ const tasks = {
 		completedButtonText: 'Edit',
 		url: '/settings/general/$siteSlug',
 		image: '/calypso/images/stats/tasks/personalize-your-site.svg',
-		tour: 'siteTitle',
+		tour: 'checklistSiteTitle',
 	},
 	blogdescription_set: {
 		title: 'Create a tagline',

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -37,6 +37,7 @@ const tasks = {
 		duration: '1 min',
 		completedTitle: 'You updated your site title',
 		completedButtonText: 'Edit',
+		url: '/settings/general/$siteSlug',
 		image: '/calypso/images/stats/tasks/personalize-your-site.svg',
 		tour: 'siteTitle',
 	},

--- a/client/state/ui/guided-tours/actions.js
+++ b/client/state/ui/guided-tours/actions.js
@@ -33,6 +33,10 @@ export function nextGuidedTourStep( { tour, stepName } ) {
 	};
 }
 
+export function requestGuidedTour( tour ) {
+	return nextGuidedTourStep( { tour, stepName: 'init' } );
+}
+
 // TODO(mcsf): come up with a much better (read: safer) solution
 //
 // The way we persist which tours have been seen by the user is subject to


### PR DESCRIPTION
This PR reintroduces a simplified version of the site title guided tour for use with the checklist.

# Testing

* Create a new site
* Visit the `/checklist/<site>` page
* Click on the 'Do It' button for the site title task
* Verify that the following steps appear in the tour:

![site-title-tour](https://user-images.githubusercontent.com/1926/33981466-2765d400-e101-11e7-90fb-8e9562b09a36.gif)

This tour should appear every time you click the task regardless of whether it has been completed