### PR TITLE
Domains: site redirect not editable when url contains a subdirectory 

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -26,6 +26,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import TransferData from 'components/data/domain-management/transfer';
 import WhoisData from 'components/data/domain-management/whois';
+import { decodeURIComponentIfValid } from 'lib/url';
 
 const productsList = new ProductsList();
 
@@ -58,7 +59,7 @@ export default {
 				component={ component }
 				context={ pageContext }
 				productsList={ productsList }
-				selectedDomainName={ pageContext.params.domain }
+				selectedDomainName={ decodeURIComponentIfValid( pageContext.params.domain ) }
 			/>,
 			document.getElementById( 'primary' ),
 			pageContext.store
@@ -224,7 +225,7 @@ export default {
 		renderWithReduxStore(
 			<SiteRedirectData
 				component={ DomainManagement.SiteRedirect }
-				selectedDomainName={ pageContext.params.domain }
+				selectedDomainName={ decodeURIComponentIfValid( pageContext.params.domain ) }
 			/>,
 			document.getElementById( 'primary' ),
 			pageContext.store

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';
-
+import { trim, trimEnd } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -84,7 +84,7 @@ class SiteRedirect extends React.Component {
 					page(
 						paths.domainManagementRedirectSettings(
 							this.props.selectedSite.slug,
-							this.state.redirectUrl
+							trim( trimEnd( this.state.redirectUrl, '/' ) )
 						)
 					);
 				}

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -70,6 +70,11 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	font-weight: 600;
+}
+
+.domain-management-header__title {
+	font-weight: normal;
 }
 
 .domain-management-list__notice {

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -70,11 +70,6 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	font-weight: 600;
-}
-
-.domain-management-header__title {
-	font-weight: normal;
 }
 
 .domain-management-list__notice {


### PR DESCRIPTION
This PR ~~partly~~ addresses #18173. ~~By 'partly', I mean that there areas in the backend that require attention.~~

## What this PR does

### It allows the user to edit a redirect that __contains/a/path__.

The problem:
![editing-redirect](https://user-images.githubusercontent.com/6458278/33595097-c008d82e-d9ea-11e7-964b-a2f434a7672c.gif)

To fix this, we're decoding the `domain` component of the url in order for it to [pass an equality check](https://github.com/Automattic/wp-calypso/blob/master/client/lib/domains/index.js#L180).

### It allows a user to return to the __Domain Settings__ page after having edited the redirect

The problem:
![slash-redirect-edit](https://user-images.githubusercontent.com/6458278/33595117-e17baf68-d9ea-11e7-98df-1f8df81688d2.gif)

After the backend receives the new redirect url, it trims and and removes and trailing slashes. This creates a valid Calypso path.

All we're doing here is duplicating that process on the frontend. 

Ideally we want to avoid duplicating this trimming. Either we should:

1. allow trailing slashes, or
2. display an error to the user to the effect that trailing slashes are verboten, or
3. return the modified redirect url in the post response

## What this PR doesn't do

~~Unfortunately the ability to edit a redirect url has **no effect** on the redirect itself.~~

~~This seems to be an issue with the backend and will require ongoing investigation.~~

Edited: __Cache vs Human: Cache:1 – Human: 0.__

From @aidvu :
 > It's updated properly, you just need to open in incognito as redirects are cached. :)

## Testing

1. Create a test site, and go to **Settings > General**. Then click on 'redirect' this site.
2. Register a redirect URL. Make sure it's been set to Primary.
3. In **Domains** click on the newly-created redirect url, then **Redirect Settings**
4. Update site redirect to a URL with a WordPress directory path (something like __awesomeblog.com/tag/articles__ )
5. Go back to **Domains Settings** page by clicking on **<- Back** and attempt to repeat steps 3 and 4, but at step 4 add a trailing slash to the url (e.g., __awesomeblog.com/tag/articles/__)

### Expections
You should be able to edit the redirect url and navigate back to the **Domain Settings** page.
