### PR TITLE
Jetpack Connect: Hide plan icons for all devices 

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -4,7 +4,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,7 +13,6 @@ import Banner from 'components/banner';
 import Main from 'components/main';
 import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
-import { abtest } from 'lib/abtest';
 /**
  * Constants
  */
@@ -71,13 +69,8 @@ class JetpackPlansGrid extends Component {
 	}
 
 	render() {
-		const hiddenForAll = abtest( 'jetpackHidePlanIconsForAllDevices' ) === 'hide';
-		const mainClassName = classNames( 'jetpack-connect__hide-plan-icons', {
-			'jetpack-connect__hide-plan-icons-large': hiddenForAll,
-		} );
-
 		return (
-			<Main wideLayout className={ mainClassName }>
+			<Main wideLayout className="jetpack-connect__hide-plan-icons">
 				<div className="jetpack-connect__plans">
 					{ this.renderBlackFridayOffer() }
 					{ this.renderConnectHeader() }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -532,47 +532,22 @@
 	text-align: center;
 }
 
-@media ( max-height: 920px ) {
-	.jetpack-connect__hide-plan-icons {
-		.jetpack-connect__plans-nav-buttons {
-			margin-bottom: 0;
-		}
-
-		.jetpack-connect__plans {
-			.plans-wrapper {
-				padding-bottom: 0;
-			}
-
-			.plan-features__graphic {
-				display: none;
-			}
-
-			.plan-features__pricing {
-				padding-top: 16px;
-			}
-		}
+.jetpack-connect__hide-plan-icons {
+	.jetpack-connect__plans-nav-buttons {
+		margin-bottom: 0;
 	}
-}
 
-// TODO: clean-up after the test #20134 is finished
-@media ( min-height: 921px ) {
-	.jetpack-connect__hide-plan-icons-large {
-		.jetpack-connect__plans-nav-buttons {
-			margin-bottom: 0;
+	.jetpack-connect__plans {
+		.plans-wrapper {
+			padding-bottom: 0;
 		}
 
-		.jetpack-connect__plans {
-			.plans-wrapper {
-				padding-bottom: 0;
-			}
+		.plan-features__graphic {
+			display: none;
+		}
 
-			.plan-features__graphic {
-				display: none;
-			}
-
-			.plan-features__pricing {
-				padding-top: 16px;
-			}
+		.plan-features__pricing {
+			padding-top: 16px;
 		}
 	}
 }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -63,15 +63,6 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	jetpackHidePlanIconsForAllDevices: {
-		datestamp: '20171122',
-		variations: {
-			show: 50,
-			hide: 50,
-		},
-		defaultVariation: 'show',
-		allowExistingUsers: true,
-	},
 	skipThemesSelectionModal: {
 		datestamp: '20170904',
 		variations: {


### PR DESCRIPTION
This PR stops the test introduced in #20134, and releases the challenger to 100% of the users.
Plan icons are removed for **ALL** devices at JP connection.

**To test:**
 * Checkout this branch
* For all device sizes (with height > 920px and <= 920px) verify that the icons are not visible at:
  * `/jetpack/connect/store`
  * `/jetpack/connect/` (after connecting the Jetpack site and reaching the plans page.)