### PR TITLE
Update magic link login to support redirects

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -125,7 +125,7 @@ export class LoginForm extends Component {
 			this.props.recordTracksEvent( 'calypso_login_block_login_form_send_magic_link' );
 
 			this.props
-				.fetchMagicLoginRequestEmail( this.state.usernameOrEmail )
+				.fetchMagicLoginRequestEmail( this.state.usernameOrEmail, nextProps.redirectTo )
 				.then( () => {
 					this.props.recordTracksEvent( 'calypso_login_block_login_form_send_magic_link_success' );
 				} )

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -23,7 +23,7 @@ import Card from 'components/card';
 import { fetchMagicLoginRequestEmail } from 'state/login/magic-login/actions';
 import FormPasswordInput from 'components/forms/form-password-input';
 import FormTextInput from 'components/forms/form-text-input';
-import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import {
@@ -418,12 +418,12 @@ export default connect(
 			isFormDisabled: isFormDisabledSelector( state ),
 			isLoggedIn: Boolean( getCurrentUserId( state ) ),
 			oauth2Client: getCurrentOAuth2Client( state ),
-			redirectTo: getCurrentQueryArguments( state ).redirect_to,
+			redirectTo: getInitialQueryArguments( state ).redirect_to,
 			requestError: getRequestError( state ),
 			socialAccountIsLinking: getSocialAccountIsLinking( state ),
 			socialAccountLinkEmail: getSocialAccountLinkEmail( state ),
 			socialAccountLinkService: getSocialAccountLinkService( state ),
-			userEmail: getCurrentQueryArguments( state ).email_address,
+			userEmail: getInitialQueryArguments( state ).email_address,
 		};
 	},
 	{

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
-import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
+import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
 import { loginSocialUser, createSocialUser, createSocialUserFailed } from 'state/login/actions';
 import {
 	getCreatedSocialAccountUsername,
@@ -150,7 +150,7 @@ class SocialLoginForm extends Component {
 
 export default connect(
 	state => ( {
-		redirectTo: getCurrentQueryArguments( state ).redirect_to,
+		redirectTo: getInitialQueryArguments( state ).redirect_to,
 		isSocialAccountCreating: isSocialAccountCreating( state ),
 		bearerToken: getCreatedSocialAccountBearerToken( state ),
 		username: getCreatedSocialAccountUsername( state ),

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -94,7 +94,8 @@ export default {
 		 * It unclutters the address bar & will keep tokens out of tracking pixels.
 		 */
 		if ( context.querystring ) {
-			page.replace( '/log-in/link/use', context.query );
+			page.replace( context.pathname, context.query );
+
 			return;
 		}
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -100,10 +100,15 @@ export default {
 
 		const previousQuery = context.state || {};
 
-		const { client_id, email, token } = previousQuery;
+		const { client_id, email, token, redirect_to } = previousQuery;
 
 		context.primary = (
-			<HandleEmailedLinkForm clientId={ client_id } emailAddress={ email } token={ token } />
+			<HandleEmailedLinkForm
+				clientId={ client_id }
+				emailAddress={ email }
+				token={ token }
+				redirectTo={ redirect_to }
+			/>
 		);
 
 		next();

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -100,15 +100,10 @@ export default {
 
 		const previousQuery = context.state || {};
 
-		const { client_id, email, token, redirect_to } = previousQuery;
+		const { client_id, email, token } = previousQuery;
 
 		context.primary = (
-			<HandleEmailedLinkForm
-				clientId={ client_id }
-				emailAddress={ email }
-				token={ token }
-				redirectTo={ redirect_to }
-			/>
+			<HandleEmailedLinkForm clientId={ client_id } emailAddress={ email } token={ token } />
 		);
 
 		next();

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -18,6 +18,7 @@ import {
 } from 'state/login/magic-login/actions';
 import {
 	isFetchingMagicLoginEmail,
+	getCurrentQueryArguments,
 	getMagicLoginCurrentView,
 	getMagicLoginRequestEmailError,
 	getMagicLoginRequestedEmailSuccessfully,
@@ -39,6 +40,7 @@ class RequestLoginEmailForm extends React.Component {
 		// mapped to state
 		currentUser: PropTypes.object,
 		isFetching: PropTypes.bool,
+		redirectTo: PropTypes.string,
 		requestError: PropTypes.string,
 		showCheckYourEmail: PropTypes.bool,
 		emailRequested: PropTypes.bool,
@@ -74,7 +76,9 @@ class RequestLoginEmailForm extends React.Component {
 
 	onSubmit = event => {
 		event.preventDefault();
+
 		const usernameOrEmail = this.getUsernameOrEmailFromState();
+
 		if ( ! usernameOrEmail.length ) {
 			return;
 		}
@@ -82,7 +86,7 @@ class RequestLoginEmailForm extends React.Component {
 		this.props.recordTracksEvent( 'calypso_login_email_link_submit' );
 
 		this.props
-			.fetchMagicLoginRequestEmail( usernameOrEmail )
+			.fetchMagicLoginRequestEmail( usernameOrEmail, this.props.redirectTo )
 			.then( () => {
 				this.props.recordTracksEvent( 'calypso_login_email_link_success' );
 			} )
@@ -183,6 +187,7 @@ const mapState = state => {
 	return {
 		currentUser: getCurrentUser( state ),
 		isFetching: isFetchingMagicLoginEmail( state ),
+		redirectTo: getCurrentQueryArguments( state ).redirect_to,
 		requestError: getMagicLoginRequestEmailError( state ),
 		showCheckYourEmail: getMagicLoginCurrentView( state ) === CHECK_YOUR_EMAIL_PAGE,
 		emailRequested: getMagicLoginRequestedEmailSuccessfully( state ),

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -18,7 +18,7 @@ import {
 } from 'state/login/magic-login/actions';
 import {
 	isFetchingMagicLoginEmail,
-	getCurrentQueryArguments,
+	getInitialQueryArguments,
 	getMagicLoginCurrentView,
 	getMagicLoginRequestEmailError,
 	getMagicLoginRequestedEmailSuccessfully,
@@ -187,7 +187,7 @@ const mapState = state => {
 	return {
 		currentUser: getCurrentUser( state ),
 		isFetching: isFetchingMagicLoginEmail( state ),
-		redirectTo: getCurrentQueryArguments( state ).redirect_to,
+		redirectTo: getInitialQueryArguments( state ).redirect_to,
 		requestError: getMagicLoginRequestEmailError( state ),
 		showCheckYourEmail: getMagicLoginCurrentView( state ) === CHECK_YOUR_EMAIL_PAGE,
 		emailRequested: getMagicLoginRequestedEmailSuccessfully( state ),

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -43,20 +43,22 @@ class MeSidebar extends React.Component {
 
 		// If user is using en locale, redirect to app promo page on sign out
 		const isEnLocale = currentUser && currentUser.localeSlug === 'en';
-		let redirect = null;
+
+		let redirectTo = null;
+
 		if ( isEnLocale && ! config.isEnabled( 'desktop' ) ) {
-			redirect = '/?apppromo';
+			redirectTo = '/?apppromo';
 		}
 
 		if ( config.isEnabled( 'login/wp-login' ) ) {
-			this.props.logoutUser( redirect ).then(
+			this.props.logoutUser( redirectTo ).then(
 				( { redirect_to } ) => user.clear( () => ( location.href = redirect_to || '/' ) ),
 				// The logout endpoint might fail if the nonce has expired.
 				// In this case, redirect to wp-login.php?action=logout to get a new nonce generated
-				() => userUtilities.logout( redirect )
+				() => userUtilities.logout( redirectTo )
 			);
 		} else {
-			userUtilities.logout( redirect );
+			userUtilities.logout( redirectTo );
 		}
 
 		this.props.recordGoogleEvent( 'Me', 'Clicked on Sidebar Sign Out Link' );

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -53,12 +53,12 @@ import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 
 /**
- * Attempt to login a user.
+ * Logs a user in.
  *
- * @param  {String}    usernameOrEmail    Username or email of the user.
- * @param  {String}    password           Password of the user.
- * @param  {String}    redirectTo         Url to redirect the user to upon successful login
- * @return {Function}                     Action thunk to trigger the login process.
+ * @param  {String}   usernameOrEmail Username or email of the user
+ * @param  {String}   password        Password of the user
+ * @param  {String}   redirectTo      Url to redirect the user to upon successful login
+ * @return {Function}                 A thunk that can be dispatched
  */
 export const loginUser = ( usernameOrEmail, password, redirectTo ) => dispatch => {
 	dispatch( {
@@ -113,11 +113,11 @@ export const loginUser = ( usernameOrEmail, password, redirectTo ) => dispatch =
 };
 
 /**
- * Attempt to login a user when a two factor verification code is sent.
+ * Logs a user in with a two factor verification code.
  *
- * @param  {String}    twoStepCode  Verification code for the user.
- * @param {String}     twoFactorAuthType Two factor authentication method
- * @return {Function}                 Action thunk to trigger the login process.
+ * @param  {String}   twoStepCode       Verification code received by the user
+ * @param  {String}   twoFactorAuthType Two factor authentication method (sms, push ...)
+ * @return {Function}                   A thunk that can be dispatched
  */
 export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAuthType ) => (
 	dispatch,
@@ -170,14 +170,14 @@ export const loginUserWithTwoFactorVerificationCode = ( twoStepCode, twoFactorAu
 };
 
 /**
- * Attempt to login a user with an external social account.
+ * Logs a user in from a third-party social account (Google ...).
  *
- * @param  {Object}    socialInfo   Object containing { service, access_token, id_token }
- *            {String}    service      The external social service name.
- *            {String}    access_token OAuth2 access token provided by the social service.
- *            {String}    id_token     JWT ID token such as the one provided by Google OpenID Connect.
- * @param  {String}    redirectTo   Url to redirect the user to upon successful login
- * @return {Function}               Action thunk to trigger the login process.
+ * @param  {Object}   socialInfo     Object containing { service, access_token, id_token }
+ *           {String}   service      The external social service name
+ *           {String}   access_token OAuth2 access token provided by the social service
+ *           {String}   id_token     JWT ID token such as the one provided by Google OpenID Connect.
+ * @param  {String}   redirectTo     Url to redirect the user to upon successful login
+ * @return {Function}                A thunk that can be dispatched
  */
 export const loginSocialUser = ( socialInfo, redirectTo ) => dispatch => {
 	dispatch( { type: SOCIAL_LOGIN_REQUEST } );
@@ -231,14 +231,14 @@ export const loginSocialUser = ( socialInfo, redirectTo ) => dispatch => {
 };
 
 /**
- * Attempt to create an account with a social service
+ * Creates a WordPress.com account from a third-party social account (Google ...).
  *
- * @param  {Object}    socialInfo   Object containing { service, access_token, id_token }
- *            {String}    service      The external social service name.
- *            {String}    access_token OAuth2 access token provided by the social service.
- *            {String}    id_token     JWT ID token such as the one provided by Google OpenID Connect.
- * @param  {String}    flowName   the name of the signup flow
- * @return {Function}             Action thunk to trigger the login process.
+ * @param  {Object}   socialInfo     Object containing { service, access_token, id_token }
+ *           {String}   service      The external social service name
+ *           {String}   access_token OAuth2 access token provided by the social service
+ *           {String}   id_token     JWT ID token such as the one provided by Google OpenID Connect
+ * @param  {String}   flowName       The name of the current signup flow
+ * @return {Function}                A thunk that can be dispatched
  */
 export const createSocialUser = ( socialInfo, flowName ) => dispatch => {
 	dispatch( {
@@ -274,14 +274,14 @@ export const createSocialUser = ( socialInfo, flowName ) => dispatch => {
 };
 
 /**
- * Attempt to connect the current account with a social service
+ * Connects the current WordPress.com account with a third-party social account (Google ...).
  *
- * @param  {Object}    socialInfo   Object containing { service, access_token, id_token, redirectTo }
- *            {String}    service      The external social service name.
- *            {String}    access_token OAuth2 access token provided by the social service.
- *            {String}    id_token     JWT ID token such as the one provided by Google OpenID Connect.
- * @param  {String}    redirectTo   Url to redirect the user to upon successful login
- * @return {Function}               Action thunk to trigger the login process.
+ * @param  {Object}   socialInfo     Object containing { service, access_token, id_token, redirectTo }
+ *           {String}   service      The external social service name
+ *           {String}   access_token OAuth2 access token provided by the social service
+ *           {String}   id_token     JWT ID token such as the one provided by Google OpenID Connect
+ * @param  {String}   redirectTo     Url to redirect the user to upon successful login
+ * @return {Function}                A thunk that can be dispatched
  */
 export const connectSocialUser = ( socialInfo, redirectTo ) => dispatch => {
 	dispatch( {
@@ -316,10 +316,10 @@ export const connectSocialUser = ( socialInfo, redirectTo ) => dispatch => {
 };
 
 /**
- * Attempt to disconnect the current account with a social service
+ * Disconnects the current WordPress.com account from a third-party social account (Google ...).
  *
- * @param  {String}    socialService    The external social service name.
- * @return {Function}               Action thunk to trigger the login process.
+ * @param  {String}   socialService The social service name
+ * @return {Function}               A thunk that can be dispatched
  */
 export const disconnectSocialUser = socialService => dispatch => {
 	dispatch( {
@@ -359,9 +359,9 @@ export const createSocialUserFailed = ( socialInfo, error ) => ( {
 } );
 
 /**
- * Sends a two factor authentication recovery code to the 2FA user
+ * Sends a two factor authentication recovery code to a user.
  *
- * @return {Function}                Action thunk to trigger the request.
+ * @return {Function} A thunk that can be dispatched
  */
 export const sendSmsCode = () => ( dispatch, getState ) => {
 	dispatch( {
@@ -414,10 +414,10 @@ export const stopPollAppPushAuth = () => ( { type: TWO_FACTOR_AUTHENTICATION_PUS
 export const formUpdate = () => ( { type: LOGIN_FORM_UPDATE } );
 
 /**
- * Attempt to logout a user.
+ * Logs the current user out.
  *
- * @param  {String}    redirectTo         Url to redirect the user to upon successful logout
- * @return {Function}                     Action thunk to trigger the logout process.
+ * @param  {String}   redirectTo Url to redirect the user to upon successful logout
+ * @return {Function}            A thunk that can be dispatched
  */
 export const logoutUser = redirectTo => ( dispatch, getState ) => {
 	dispatch( {
@@ -467,10 +467,10 @@ export const logoutUser = redirectTo => ( dispatch, getState ) => {
 };
 
 /**
- * Retrieves the type of authentication of the account of the specified user.
+ * Retrieves the type of authentication of the account (regular, passwordless ...) of the specified user.
  *
- * @param {String} usernameOrEmail - id of the user
- * @return {Function} an action thunk
+ * @param  {String}   usernameOrEmail Identifier of the user
+ * @return {Function}                 A thunk that can be dispatched
  */
 export const getAuthAccountType = usernameOrEmail => dispatch => {
 	dispatch( recordTracksEvent( 'calypso_login_block_login_form_get_auth_type' ) );
@@ -513,7 +513,7 @@ export const getAuthAccountType = usernameOrEmail => dispatch => {
 /**
  * Resets the type of authentication of the account of the current user.
  *
- * @return {Object} an action that can be dispatched
+ * @return {Object} An action that can be dispatched
  */
 export const resetAuthAccountType = () => ( {
 	type: LOGIN_AUTH_ACCOUNT_TYPE_RESET,

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -84,7 +84,7 @@ export const fetchMagicLoginRequestEmail = email => dispatch => {
 };
 
 // @TODO should this move to `/state/data-layer`..?
-export const fetchMagicLoginAuthenticate = token => dispatch => {
+export const fetchMagicLoginAuthenticate = ( token, redirect_to = null ) => dispatch => {
 	dispatch( { type: MAGIC_LOGIN_REQUEST_AUTH_FETCH } );
 
 	request
@@ -98,6 +98,7 @@ export const fetchMagicLoginAuthenticate = token => dispatch => {
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
 			token,
+			redirect_to,
 		} )
 		.then( response => {
 			dispatch( {

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -58,6 +58,12 @@ export const hideMagicLoginRequestNotice = () => {
 	};
 };
 
+/**
+ * Sends an email with a magic link to the specified email address.
+ *
+ * @param  {String}   email Email address of the user
+ * @return {Function}       A thunk that can be dispatched
+ */
 export const fetchMagicLoginRequestEmail = email => dispatch => {
 	dispatch( { type: MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_FETCH } );
 
@@ -84,7 +90,13 @@ export const fetchMagicLoginRequestEmail = email => dispatch => {
 		} );
 };
 
-// @TODO should this move to `/state/data-layer`..?
+/**
+ * Logs a user in from a token included in a magic link.
+ *
+ * @param  {String}   token      Security token
+ * @param  {String}   redirectTo Url to redirect the user to upon successful login
+ * @return {Function}            A thunk that can be dispatched
+ */
 export const fetchMagicLoginAuthenticate = ( token, redirectTo = null ) => dispatch => {
 	dispatch( { type: MAGIC_LOGIN_REQUEST_AUTH_FETCH } );
 

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -68,6 +68,7 @@ export const fetchMagicLoginRequestEmail = email => dispatch => {
 		} )
 		.then( () => {
 			dispatch( { type: MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_SUCCESS } );
+
 			dispatch( {
 				type: MAGIC_LOGIN_SHOW_CHECK_YOUR_EMAIL_PAGE,
 				email,
@@ -84,7 +85,7 @@ export const fetchMagicLoginRequestEmail = email => dispatch => {
 };
 
 // @TODO should this move to `/state/data-layer`..?
-export const fetchMagicLoginAuthenticate = ( token, redirect_to = null ) => dispatch => {
+export const fetchMagicLoginAuthenticate = ( token, redirectTo = null ) => dispatch => {
 	dispatch( { type: MAGIC_LOGIN_REQUEST_AUTH_FETCH } );
 
 	request
@@ -98,19 +99,21 @@ export const fetchMagicLoginAuthenticate = ( token, redirect_to = null ) => disp
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
 			token,
-			redirect_to,
+			redirect_to: redirectTo,
 		} )
 		.then( response => {
 			dispatch( {
 				type: LOGIN_REQUEST_SUCCESS,
 				data: get( response, 'body.data' ),
 			} );
+
 			dispatch( {
 				type: MAGIC_LOGIN_REQUEST_AUTH_SUCCESS,
 			} );
 		} )
 		.catch( error => {
 			const { status } = error;
+
 			dispatch( {
 				type: MAGIC_LOGIN_REQUEST_AUTH_ERROR,
 				error: status,

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -61,16 +61,18 @@ export const hideMagicLoginRequestNotice = () => {
 /**
  * Sends an email with a magic link to the specified email address.
  *
- * @param  {String}   email Email address of the user
- * @return {Function}       A thunk that can be dispatched
+ * @param  {String}   email      Email address of the user
+ * @param  {String}   redirectTo Url to redirect the user to upon successful login
+ * @return {Function}            A thunk that can be dispatched
  */
-export const fetchMagicLoginRequestEmail = email => dispatch => {
+export const fetchMagicLoginRequestEmail = ( email, redirectTo ) => dispatch => {
 	dispatch( { type: MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_FETCH } );
 
 	return wpcom
 		.undocumented()
 		.requestMagicLoginEmail( {
 			email,
+			redirect_to: redirectTo,
 		} )
 		.then( () => {
 			dispatch( { type: MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_SUCCESS } );
@@ -97,7 +99,7 @@ export const fetchMagicLoginRequestEmail = email => dispatch => {
  * @param  {String}   redirectTo Url to redirect the user to upon successful login
  * @return {Function}            A thunk that can be dispatched
  */
-export const fetchMagicLoginAuthenticate = ( token, redirectTo = null ) => dispatch => {
+export const fetchMagicLoginAuthenticate = ( token, redirectTo ) => dispatch => {
 	dispatch( { type: MAGIC_LOGIN_REQUEST_AUTH_FETCH } );
 
 	request


### PR DESCRIPTION
This pull request, along with the D8759-code server-side patch, updates the magic login flows to support redirects in a similar way than the default login flows. From now on, any `redirect_to` parameter provided in the url will be indeed sent for sanitization to the API, and used to redirect the user to a specific page upon successful login.

#### Testing instructions

1. Run `git checkout update/magic-link-redirect` and start your server, or open a [live branch](https://calypso.live/?branch=update/magic-link-redirect)
2. Follow instructions in D8759-code

#### Reviews

- [ ] Code
- [ ] Product