### PR TITLE
Editor: don't unbind events from already removed DOM element

### DIFF
--- a/client/components/tinymce/plugins/media/drop-zone.jsx
+++ b/client/components/tinymce/plugins/media/drop-zone.jsx
@@ -47,11 +47,7 @@ class TinyMCEDropZone extends React.Component {
 	}
 
 	componentWillUnmount() {
-		const { editor } = this.props;
-		editor.dom.unbind( editor.getWin(), 'dragenter', this.redirectEditorDragEvent );
 		window.removeEventListener( 'dragleave', this.stopDragging );
-		editor.dom.unbind( editor.getWin(), 'dragleave', this.stopDragging );
-		editor.dom.unbind( editor.getWin(), 'dragover', this.fakeDragEnterIfNecessary );
 	}
 
 	redirectEditorDragEvent = event => {


### PR DESCRIPTION
Fixes #20470.

When Editor is rendered, it also renders a few plugins such as support for media and dropping files (`drop-zone`). The drop-zone `media` plugin [adds some event listeners](https://github.com/Automattic/wp-calypso/blob/master/client/components/tinymce/plugins/media/drop-zone.jsx#L43) to the editor's iframe when it's rendered. Then, when the editor is being unmounted, the `media` plugin [listens to this](https://github.com/Automattic/wp-calypso/blob/master/client/components/tinymce/plugins/media/plugin.jsx#L886) and unmounts all the sub-plugins (such as `drop-zone`) which in turn calls the [componentWillUnmount](https://github.com/Automattic/wp-calypso/blob/master/client/components/tinymce/plugins/media/drop-zone.jsx#L51) of drop-zone. There, we try to unbind the event listeners from the editor's iframe to clean them up.

What happens, however, is that [editor's iframe](https://www.tinymce.com/docs/api/tinymce/tinymce.editor/#getwin) no longer exists in DOM at that point. For some reason, either the editor's `onRemove` hook is called after the iframe is removed from DOM or `ReactDom.unmountComponentAtNode` calls the `componentWillUnmount` asynchronously.

I was trying to find some docs about whether React changed something about this in the version 16 but didn't find anything relevant. So why didn't we get this error before if nothing changed in React 16? I think it could be because of the new [error handling in React 16](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html). It looks like the error happens in the editor iframe itself (it breaks inside `tinymce.js`, not in `drop-zone.jsx`) and maybe browsers were not propagating the error to the main console but React 16 error handling is. Not sure.

So, how to fix? Well, if the editor's iframe is already removed from DOM at the point of calling the `componentWillUnmount` of `drop-zone`, we [don't even need](https://stackoverflow.com/questions/12528049/if-a-dom-element-is-removed-are-its-listeners-also-removed-from-memory) to remove any event listeners. Therefore, in this PR, I'm just removing the calls to `editor.dom.unbind` in `componentWillUnmount` of the `drop-zone` media plugin.

## Testing

You can verify that the event listeners are removed automatically by removing the editor iframe by adding a `console.log` statement to [redirectEditorDragEvent](https://github.com/Automattic/wp-calypso/blob/master/client/components/tinymce/plugins/media/drop-zone.jsx#L57) and navigating to a post, then back, then to post again, back, etc and see if the event is triggered multiple times on one `dragenter` in editor.

Or, you can put a conditional breakpoint in `app:///./node_modules/tinymce/tinymce.js` line `11333` that if `target === null` and it will reveal that `editor.getWin()` returns `null` (the `target`) at that point in code execution.

