### PR TITLE
Allow users to get a magic login link from their username

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -292,7 +292,7 @@ export class LoginForm extends Component {
 										: this.props.translate( 'Change Username' ) }
 								</a>
 							) : (
-								this.props.translate( 'Email Address or Username' )
+								this.props.translate( 'Email Address' )
 							) }
 						</label>
 

--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -20,7 +20,8 @@ import RedirectWhenLoggedIn from 'components/redirect-when-logged-in';
 import { hideMagicLoginRequestForm } from 'state/login/magic-login/actions';
 import { recordPageView } from 'state/analytics/actions';
 
-const nativeLoginUrl = login( { isNative: true } );
+const nativeLoginUrl = login( { isNative: true, twoFactorAuthType: 'link' } );
+
 const lostPasswordURL = addQueryArgs(
 	{
 		action: 'lostpassword',
@@ -36,12 +37,15 @@ class EmailedLoginLinkExpired extends React.Component {
 
 	onClickTryAgainLink = event => {
 		event.preventDefault();
+
 		this.props.hideMagicLoginRequestForm();
+
 		page( nativeLoginUrl );
 	};
 
 	render() {
 		const { translate } = this.props;
+
 		this.props.recordPageView( '/log-in/link/use', 'Login > Link > Expired' );
 
 		return (

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { defer, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -47,6 +47,12 @@ class RequestLoginEmailForm extends React.Component {
 		hideMagicLoginRequestNotice: PropTypes.func.isRequired,
 	};
 
+	componentWillReceiveProps( nextProps ) {
+		if ( ! this.props.requestError && nextProps.requestError ) {
+			defer( () => this.usernameOrEmail && this.usernameOrEmail.focus() );
+		}
+	}
+
 	onUsernameOrEmailFieldChange = event => {
 		this.setState( {
 			usernameOrEmail: event.target.value,
@@ -55,6 +61,10 @@ class RequestLoginEmailForm extends React.Component {
 		if ( this.props.requestError ) {
 			this.props.hideMagicLoginRequestNotice();
 		}
+	};
+
+	saveUsernameOrEmailRef = input => {
+		this.usernameOrEmail = input;
 	};
 
 	onNoticeDismiss = () => {
@@ -139,6 +149,7 @@ class RequestLoginEmailForm extends React.Component {
 							disabled={ isFetching || emailRequested }
 							name="usernameOrEmail"
 							type="text"
+							ref={ this.saveUsernameOrEmailRef }
 							onChange={ this.onUsernameOrEmailFieldChange }
 						/>
 

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -28,7 +28,6 @@ import EmailedLoginLinkSuccessfully from './emailed-login-link-successfully';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormTextInput from 'components/forms/form-text-input';
-import FormInputValidation from 'components/forms/form-input-validation';
 import LoggedOutForm from 'components/logged-out-form';
 import Notice from 'components/notice';
 import { localize } from 'i18n-calypso';
@@ -142,11 +141,6 @@ class RequestLoginEmailForm extends React.Component {
 							type="text"
 							onChange={ this.onUsernameOrEmailFieldChange }
 						/>
-
-						{ requestError &&
-							requestError.field === 'usernameOrEmail' && (
-								<FormInputValidation isError text={ requestError.message } />
-							) }
 
 						<div className="magic-login__form-action">
 							<FormButton primary disabled={ ! submitEnabled }>

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -28,6 +28,7 @@ import EmailedLoginLinkSuccessfully from './emailed-login-link-successfully';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormTextInput from 'components/forms/form-text-input';
+import FormInputValidation from 'components/forms/form-input-validation';
 import LoggedOutForm from 'components/logged-out-form';
 import Notice from 'components/notice';
 import { localize } from 'i18n-calypso';
@@ -47,9 +48,9 @@ class RequestLoginEmailForm extends React.Component {
 		hideMagicLoginRequestNotice: PropTypes.func.isRequired,
 	};
 
-	onEmailAddressFieldChange = event => {
+	onUsernameOrEmailFieldChange = event => {
 		this.setState( {
-			emailAddress: event.target.value,
+			usernameOrEmail: event.target.value,
 		} );
 
 		if ( this.props.requestError ) {
@@ -63,15 +64,15 @@ class RequestLoginEmailForm extends React.Component {
 
 	onSubmit = event => {
 		event.preventDefault();
-		const emailAddress = this.getEmailAddressFromState();
-		if ( ! emailAddress.length ) {
+		const usernameOrEmail = this.getUsernameOrEmailFromState();
+		if ( ! usernameOrEmail.length ) {
 			return;
 		}
-		this.props.fetchMagicLoginRequestEmail( emailAddress );
+		this.props.fetchMagicLoginRequestEmail( usernameOrEmail );
 	};
 
-	getEmailAddressFromState() {
-		return get( this, 'state.emailAddress', '' );
+	getUsernameOrEmailFromState() {
+		return get( this, 'state.usernameOrEmail', '' );
 	}
 
 	render() {
@@ -84,13 +85,15 @@ class RequestLoginEmailForm extends React.Component {
 			translate,
 		} = this.props;
 
-		const emailAddress = this.getEmailAddressFromState();
+		const usernameOrEmail = this.getUsernameOrEmailFromState();
 
 		if ( showCheckYourEmail ) {
+			const emailAddress = usernameOrEmail.indexOf( '@' ) > 0 ? usernameOrEmail : null;
 			return <EmailedLoginLinkSuccessfully emailAddress={ emailAddress } />;
 		}
 
-		const submitEnabled = emailAddress.length && ! isFetching && ! emailRequested && ! requestError;
+		const submitEnabled =
+			usernameOrEmail.length && ! isFetching && ! emailRequested && ! requestError;
 
 		const errorText =
 			typeof requestError === 'string' && requestError.length
@@ -127,7 +130,7 @@ class RequestLoginEmailForm extends React.Component {
 								'with your account to log in instantly without your password.'
 						) }
 					</p>
-					<label htmlFor="emailAddress" className="magic-login__form-label">
+					<label htmlFor="usernameOrEmail" className="magic-login__form-label">
 						{ this.props.translate( 'Email Address' ) }
 					</label>
 					<FormFieldset className="magic-login__email-fields">
@@ -135,10 +138,15 @@ class RequestLoginEmailForm extends React.Component {
 							autoCapitalize="off"
 							autoFocus="true"
 							disabled={ isFetching || emailRequested }
-							name="emailAddress"
-							type="email"
-							onChange={ this.onEmailAddressFieldChange }
+							name="usernameOrEmail"
+							type="text"
+							onChange={ this.onUsernameOrEmailFieldChange }
 						/>
+
+						{ requestError &&
+							requestError.field === 'usernameOrEmail' && (
+								<FormInputValidation isError text={ requestError.message } />
+							) }
 
 						<div className="magic-login__form-action">
 							<FormButton primary disabled={ ! submitEnabled }>

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -3,10 +3,8 @@
 /**
  * External dependencies
  */
-
-import React from 'react';
 import request from 'superagent';
-import { get, omit, defer } from 'lodash';
+import { get, defer } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -49,120 +47,14 @@ import {
 } from 'state/action-types';
 import { getTwoFactorAuthNonce, getTwoFactorUserId } from 'state/login/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
+import {
+	getErrorFromHTTPError,
+	getErrorFromWPCOMError,
+	getSMSMessageFromResponse,
+} from './utils';
 import wpcom from 'lib/wp';
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
 import { recordTracksEvent } from 'state/analytics/actions';
-
-function getSMSMessageFromResponse( response ) {
-	const phoneNumber = get( response, 'body.data.phone_number' );
-	return translate( 'Message sent to phone number ending in %(phoneNumber)s', {
-		args: {
-			phoneNumber,
-		},
-	} );
-}
-
-const errorFields = {
-	empty_password: 'password',
-	empty_two_step_code: 'twoStepCode',
-	empty_username: 'usernameOrEmail',
-	incorrect_password: 'password',
-	invalid_email: 'usernameOrEmail',
-	invalid_two_step_code: 'twoStepCode',
-	invalid_username: 'usernameOrEmail',
-};
-
-/**
- * Retrieves the first error message from the specified HTTP error.
- *
- * @param {Object} httpError HTTP error
- * @returns {{code: string?, message: string, field: string}} an error message and the id of the corresponding field, if not global
- */
-function getErrorFromHTTPError( httpError ) {
-	let field = 'global';
-
-	if ( ! httpError.status ) {
-		return {
-			code: 'network_error',
-			message: httpError.message,
-			field,
-		};
-	}
-
-	const code = get( httpError, 'response.body.data.errors[0].code' );
-
-	if ( code ) {
-		if ( code in errorFields ) {
-			field = errorFields[ code ];
-		} else if ( code === 'admin_login_attempt' ) {
-			const url = addLocaleToWpcomUrl(
-				'https://wordpress.com/wp-login.php?action=lostpassword',
-				getLocaleSlug()
-			);
-
-			return {
-				code,
-				message: (
-					<div>
-						<p>
-							{ translate(
-								'You attempted to login with the username {{em}}admin{{/em}} on WordPress.com.',
-								{ components: { em: <em /> } }
-							) }
-						</p>
-
-						<p>
-							{ translate(
-								'If you were trying to access your self hosted {{a}}WordPress.org{{/a}} site, ' +
-									'try {{strong}}yourdomain.com/wp-admin/{{/strong}} instead.',
-								{
-									components: {
-										a: <a href="http://wordpress.org" target="_blank" rel="noopener noreferrer" />,
-										strong: <strong />,
-									},
-								}
-							) }
-						</p>
-
-						<p>
-							{ translate(
-								'If you can’t remember your WordPress.com username, you can {{a}}reset your password{{/a}} ' +
-									'by providing your email address.',
-								{
-									components: {
-										a: <a href={ url } rel="external" />,
-									},
-								}
-							) }
-						</p>
-					</div>
-				),
-				field,
-			};
-		}
-	}
-
-	let message = get( httpError, 'response.body.data.errors[0].message' );
-
-	if ( ! message ) {
-		message = get( httpError, 'response.body.data', httpError.message );
-	}
-
-	return { code, message, field };
-}
-
-/**
- * Transforms WPCOM error to the error object we use for login purposes
- *
- * @param {Object} wpcomError HTTP error
- * @returns {{message: string, field: string, code: string}} an error message and the id of the corresponding field
- */
-const getErrorFromWPCOMError = wpcomError => ( {
-	message: wpcomError.message,
-	code: wpcomError.error,
-	field: 'global',
-	...omit( wpcomError, [ 'error', 'message', 'field' ] ),
-} );
 
 /**
  * Attempt to login a user.

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -1,6 +1,130 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import React from 'react';
+import { get, omit } from 'lodash';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
+
+export function getSMSMessageFromResponse( response ) {
+	const phoneNumber = get( response, 'body.data.phone_number' );
+
+	return translate( 'Message sent to phone number ending in %(phoneNumber)s', {
+		args: {
+			phoneNumber,
+		},
+	} );
+}
+
+const errorFields = {
+	empty_password: 'password',
+	empty_two_step_code: 'twoStepCode',
+	empty_username: 'usernameOrEmail',
+	incorrect_password: 'password',
+	invalid_email: 'usernameOrEmail',
+	invalid_two_step_code: 'twoStepCode',
+	invalid_username: 'usernameOrEmail',
+};
+
+/**
+ * Retrieves the first error message from the specified HTTP error.
+ *
+ * @param {Object} httpError HTTP error
+ * @returns {{code: string?, message: string, field: string}} an error message and the id of the corresponding field, if not global
+ */
+export function getErrorFromHTTPError( httpError ) {
+	let field = 'global';
+
+	if ( ! httpError.status ) {
+		return {
+			code: 'network_error',
+			message: httpError.message,
+			field,
+		};
+	}
+
+	const code = get( httpError, 'response.body.data.errors[0].code' );
+
+	if ( code ) {
+		if ( code in errorFields ) {
+			field = errorFields[ code ];
+		} else if ( code === 'admin_login_attempt' ) {
+			const url = addLocaleToWpcomUrl(
+				'https://wordpress.com/wp-login.php?action=lostpassword',
+				getLocaleSlug()
+			);
+
+			return {
+				code,
+				message: (
+					<div>
+						<p>
+							{ translate(
+								'You attempted to login with the username {{em}}admin{{/em}} on WordPress.com.',
+								{ components: { em: <em /> } }
+							) }
+						</p>
+
+						<p>
+							{ translate(
+								'If you were trying to access your self hosted {{a}}WordPress.org{{/a}} site, ' +
+									'try {{strong}}yourdomain.com/wp-admin/{{/strong}} instead.',
+								{
+									components: {
+										a: <a href="http://wordpress.org" target="_blank" rel="noopener noreferrer" />,
+										strong: <strong />,
+									},
+								}
+							) }
+						</p>
+
+						<p>
+							{ translate(
+								'If you can’t remember your WordPress.com username, you can {{a}}reset your password{{/a}} ' +
+									'by providing your email address.',
+								{
+									components: {
+										a: <a href={ url } rel="external" />,
+									},
+								}
+							) }
+						</p>
+					</div>
+				),
+				field,
+			};
+		}
+	}
+
+	let message = get( httpError, 'response.body.data.errors[0].message' );
+
+	if ( ! message ) {
+		message = get( httpError, 'response.body.data', httpError.message );
+	}
+
+	return { code, message, field };
+}
+
+/**
+ * Transforms WPCOM error to the error object we use for login purposes
+ *
+ * @param {Object} wpcomError HTTP error
+ * @returns {{message: string, field: string, code: string}} an error message and the id of the corresponding field
+ */
+export const getErrorFromWPCOMError = wpcomError => ( {
+	message: wpcomError.message,
+	code: wpcomError.error,
+	field: 'global',
+	...omit( wpcomError, [ 'error', 'message', 'field' ] ),
+} );
+
+/**
  * Determines whether the user account uses regular authentication by password.
  *
  * @param {String} authAccountType - authentication account type


### PR DESCRIPTION
Require server patch D8603.

This PR updates the magic link request form at `/log-in/link` to allow a username to be given in the email address field.
Email being the preferred choice we don't update the wording for this form.

### Testing Instructions
- Boot this branch locally and sandbox wpcom and public-api
- Go to http://calypso.localhost:3000/log-in/link and enter the username of a passwordless account
- Check that you are met with the correct screen with the following text: `We just emailed you a link. Please check your inbox and click the link to log in.`
- Go to your inbox and click on the login link. If you have setup your sandbox correctly you should be able to use the link for calypso locally and log in.

### Reviews
- [ ] Code
- [ ] Product
