### PR TITLE
Signup: Set up an A/B test for Checklist Thank You screen.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -326,6 +326,7 @@
 @import 'my-sites/ads/style';
 @import 'my-sites/all-sites/style';
 @import 'my-sites/all-sites-icon/style';
+@import 'my-sites/checklist/checklist-thank-you/style';
 @import 'my-sites/current-site/style';
 @import 'my-sites/customize/style';
 @import 'my-sites/domain-tip/style';

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -109,4 +109,22 @@ export default {
 		},
 		defaultVariation: 'control',
 	},
+	checklistThankYouForFreeUser: {
+		datestamp: '20171204',
+		variations: {
+			show: 50,
+			hide: 50,
+		},
+		defaultVariation: 'hide',
+		allowExistingUsers: true,
+	},
+	checklistThankYouForPaidUser: {
+		datestamp: '20171204',
+		variations: {
+			show: 50,
+			hide: 50,
+		},
+		defaultVariation: 'hide',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/checklist/checklist-thank-you/index.jsx
+++ b/client/my-sites/checklist/checklist-thank-you/index.jsx
@@ -1,0 +1,106 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { connect } from 'react-redux';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import Checklist from 'components/checklist';
+import DocumentHead from 'components/data/document-head';
+import FormattedHeader from 'components/formatted-header';
+import Main from 'components/main';
+import QuerySiteChecklist from 'components/data/query-site-checklist';
+import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteChecklist } from 'state/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import { onboardingTasks, urlForTask } from 'my-sites/checklist/onboardingChecklist';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+export class ChecklistThankYou extends PureComponent {
+	static propTypes = {
+		tasks: PropTypes.array,
+		siteId: PropTypes.number,
+		siteSlug: PropTypes.string,
+		receiptId: PropTypes.number,
+	};
+
+	handleAction = taskId => {
+		const { siteSlug, tasks, track } = this.props;
+		const url = urlForTask( taskId, siteSlug );
+		if ( url && tasks.length ) {
+			const status = tasks[ taskId ] ? 'complete' : 'incomplete';
+			track( 'calypso_checklist_task_start', {
+				checklist_name: 'thank_you',
+				step_name: taskId,
+				status,
+			} );
+
+			page( url );
+		}
+	};
+
+	handleToggle = taskId => {
+		const { siteId, tasks, update } = this.props;
+
+		if ( tasks && ! tasks[ taskId ] ) {
+			update( siteId, taskId );
+		}
+	};
+
+	render() {
+		const { siteId, tasks } = this.props;
+		const title = this.props.receiptId
+			? 'Thank you for your purchase!'
+			: 'Your site has been created!';
+
+		return (
+			<Main className={ classnames( 'checklist-thank-you', this.props.className ) }>
+				<DocumentHead title="Thank you" />
+				<div className="checklist-thank-you__container">
+					<div className="checklist-thank-you__header">
+						<img
+							src="/calypso/images/signup/confetti.svg"
+							className="checklist-thank-you__confetti"
+						/>
+						<FormattedHeader
+							headerText={ title }
+							subHeaderText={
+								"Now that your site has been created, it's time to get it ready for you to share. " +
+								"We've prepared a list of things that will help you get there quickly."
+							}
+						/>
+					</div>
+					{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
+					<Checklist
+						isLoading={ ! tasks.length }
+						tasks={ tasks }
+						onAction={ this.handleAction }
+						onToggle={ this.handleToggle }
+					/>
+				</div>
+			</Main>
+		);
+	}
+}
+
+const mapStateToProps = state => {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSiteSlug( state, siteId );
+	const siteChecklist = getSiteChecklist( state, siteId );
+	const tasks = siteChecklist ? onboardingTasks( siteChecklist.tasks ) : [];
+
+	return { siteId, siteSlug, tasks };
+};
+const mapDispatchToProps = {
+	track: recordTracksEvent,
+	update: requestSiteChecklistTaskUpdate,
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( ChecklistThankYou );

--- a/client/my-sites/checklist/checklist-thank-you/style.scss
+++ b/client/my-sites/checklist/checklist-thank-you/style.scss
@@ -1,0 +1,16 @@
+/** @format */
+.checklist-thank-you__container {
+	max-width: 720px;
+	margin: 0 auto;
+
+	.checklist {
+		text-align: left;
+		margin-top: 54px;
+	}
+}
+
+.checklist-thank-you__confetti {
+	display: block;
+	width: 360px;
+	margin: 0 auto;
+}

--- a/client/my-sites/checklist/controller/index.jsx
+++ b/client/my-sites/checklist/controller/index.jsx
@@ -5,14 +5,29 @@
  */
 
 import React from 'react';
+import ReactDom from 'react-dom';
 
 /**
  * Internal Dependencies
  */
 
+import { renderWithReduxStore } from 'lib/react-helpers';
+import { setSection } from 'state/ui/actions';
 import ChecklistShow from '../checklist-show';
+import ChecklistThankYou from '../checklist-thank-you';
 
 export function show( context, next ) {
 	context.primary = <ChecklistShow />;
 	next();
+}
+
+export function thankYou( context ) {
+	const { params, store } = context;
+	store.dispatch( setSection( { name: 'checklist-thank-you' }, { hasSidebar: false } ) );
+	renderWithReduxStore(
+		<ChecklistThankYou receiptId={ params.receiptId ? Number( params.receiptId ) : 0 } />,
+		'primary',
+		store
+	);
+	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 }

--- a/client/my-sites/checklist/index.js
+++ b/client/my-sites/checklist/index.js
@@ -10,7 +10,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
-import { show } from './controller';
+import { show, thankYou } from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -18,5 +18,6 @@ export default function() {
 	if ( config.isEnabled( 'onboarding-checklist' ) ) {
 		page( '/checklist', siteSelection, sites, makeLayout, clientRender );
 		page( '/checklist/:site_id', siteSelection, navigation, show, makeLayout, clientRender );
+		page( '/checklist/thank-you/:site/:receiptId?', siteSelection, thankYou );
 	}
 }

--- a/client/state/selectors/is-eligible-for-checkout-to-checklist.js
+++ b/client/state/selectors/is-eligible-for-checkout-to-checklist.js
@@ -1,0 +1,42 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get, some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSite } from 'state/sites/selectors';
+import { cartItems } from 'lib/cart-values';
+import { isBusiness, isJetpackPlan } from 'lib/products-values';
+import config from 'config';
+
+/**
+ * @param {Object} state Global state tree
+ * @param {Number} siteId Site ID
+ * @param {Object} cart object
+ * @return {Boolean} True if current user is able to see the checklist after checkout
+ */
+export default function isEligibleForCheckoutToChecklist( state, siteId, cart ) {
+	const site = getSite( state, siteId );
+	const designType = get( site, 'options.design_type' );
+	const createdAt = get( site, 'options.created_at' );
+	const isNewSite = createdAt && Date.now() - Date.parse( createdAt ) < 30 * 60000; // within 30 mins
+
+	if ( ! config.isEnabled( 'onboarding-checklist' ) ) {
+		return false;
+	}
+
+	return (
+		isNewSite &&
+		'blog' === designType &&
+		cartItems.hasPlan( cart ) &&
+		! some( cartItems.getAll( cart ), isDotcomBusinessPlan )
+	);
+}
+
+function isDotcomBusinessPlan( product ) {
+	return isBusiness( product ) && ! isJetpackPlan( product );
+}


### PR DESCRIPTION
This PR sets up an A/B test for new thank you screen that shows the onboarding checklist.

**Note:** The test is currently available in the **development** environment only.
**Note:** The checklist shows up only when you explicitly pick up "Start with a blog" on `/start/design-type`, `/start/design-type-with-store`, or `/start/design-type-with-store-nux`.

## Test Plan

### Site on Free Plan

1. Set `checklistThankYouForFreeUser` test to `show` to activate it.
2. Create a new _blog_ type website on the free plan.

### Site on Paid Plan

1. Set `checklistThankYouForPaidUser` test to `show` to activate it.
2. Create a new _blog_ type website on any paid plan.

In both above cases, you should be able to see the checklist at the end of the signup flow as below:
![screen shot 2017-12-05 at 22 34 45](https://user-images.githubusercontent.com/212034/33609715-8d1487d4-da0c-11e7-8122-2bec59fb6ffc.png)

In the free and paid plan cases, the title will be `Your site has been created!` and `Thank you for your purchase!`, respectively.

cc @markryall @fditrapani 