### PR TITLE
Login: Add client app identifier to all Tracks events

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -27,7 +27,7 @@ import {
 } from 'state/login/selectors';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import { isWooOAuth2Client } from 'lib/oauth2-clients';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import VerificationCodeForm from './two-factor-authentication/verification-code-form';
 import WaitingTwoFactorNotificationApproval from './two-factor-authentication/waiting-notification-approval';
 import { login } from 'lib/paths';

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -34,7 +34,7 @@ import {
 } from 'state/login/actions';
 import { login } from 'lib/paths';
 import { preventWidows } from 'lib/formatting';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import {
 	getAuthAccountType as getAuthAccountTypeSelector,
 	getRequestError,

--- a/client/blocks/login/social-connect-prompt.jsx
+++ b/client/blocks/login/social-connect-prompt.jsx
@@ -22,7 +22,7 @@ import {
 	getRedirectTo,
 } from 'state/login/selectors';
 import { connectSocialUser } from 'state/login/actions';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 
 class SocialConnectPrompt extends Component {
 	static propTypes = {

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -21,7 +21,7 @@ import {
 	getCreatedSocialAccountBearerToken,
 	isSocialAccountCreating,
 } from 'state/login/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import WpcomLoginForm from 'signup/wpcom-login-form';
 import { InfoNotice } from 'blocks/global-notice';
 import { login } from 'lib/paths';

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -15,7 +15,7 @@ import page from 'page';
 import Card from 'components/card';
 import { localize } from 'i18n-calypso';
 import { isTwoFactorAuthTypeSupported } from 'state/login/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { sendSmsCode } from 'state/login/actions';
 import { login } from 'lib/paths';
 

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -22,7 +22,7 @@ import Card from 'components/card';
 import { localize } from 'i18n-calypso';
 import { loginUserWithTwoFactorVerificationCode } from 'state/login/actions';
 import { getTwoFactorAuthRequestError } from 'state/login/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { sendSmsCode, formUpdate } from 'state/login/actions';
 import TwoFactorActions from './two-factor-actions';
 

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -20,10 +20,9 @@ import FormLabel from 'components/forms/form-label';
 import FormInputValidation from 'components/forms/form-input-validation';
 import Card from 'components/card';
 import { localize } from 'i18n-calypso';
-import { loginUserWithTwoFactorVerificationCode } from 'state/login/actions';
 import { getTwoFactorAuthRequestError } from 'state/login/selectors';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
-import { sendSmsCode, formUpdate } from 'state/login/actions';
+import { formUpdate, loginUserWithTwoFactorVerificationCode, sendSmsCode } from 'state/login/actions';
 import TwoFactorActions from './two-factor-actions';
 
 class VerificationCodeForm extends Component {
@@ -44,8 +43,8 @@ class VerificationCodeForm extends Component {
 	};
 
 	componentDidMount() {
+		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { isDisabled: false }, () => {
-			// eslint-disable-line react/no-did-mount-set-state
 			this.input.focus();
 		} );
 	}

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -35,7 +35,7 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import { mergeFormWithValue } from 'signup/utils';
 import SocialSignupForm from './social';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { createSocialUserFailed } from 'state/login/actions';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -18,7 +18,7 @@ import { noop } from 'lodash';
 import GoogleIcon from 'components/social-icons/google';
 import Popover from 'components/popover';
 import { preventWidows } from 'lib/formatting';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { isFormDisabled } from 'state/login/selectors';
 
 class GoogleLoginButton extends Component {

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -18,7 +18,7 @@ import WPLogin from './wp-login';
 import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 
 const enhanceContextWithLogin = context => {

--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -18,7 +18,7 @@ import addQueryArgs from 'lib/route/add-query-args';
 import EmptyContent from 'components/empty-content';
 import RedirectWhenLoggedIn from 'components/redirect-when-logged-in';
 import { hideMagicLoginRequestForm } from 'state/login/magic-login/actions';
-import { recordPageView } from 'state/analytics/actions';
+import { recordPageViewWithClientId as recordPageView } from 'state/analytics/actions';
 
 const nativeLoginUrl = login( { isNative: true, twoFactorAuthType: 'link' } );
 

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -17,7 +17,7 @@ import { login } from 'lib/paths';
 import Card from 'components/card';
 import RedirectWhenLoggedIn from 'components/redirect-when-logged-in';
 import { hideMagicLoginRequestForm } from 'state/login/magic-login/actions';
-import { recordPageView } from 'state/analytics/actions';
+import { recordPageViewWithClientId as recordPageView } from 'state/analytics/actions';
 import Gridicon from 'gridicons';
 
 class EmailedLoginLinkSuccessfully extends React.Component {

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -36,10 +36,10 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 		const line = [
 			emailAddress
 				? translate( 'We just emailed a link to %(emailAddress)s.', {
-						args: {
-							emailAddress,
-						},
-					} )
+					args: {
+						emailAddress,
+					},
+				} )
 				: translate( 'We just emailed you a link.' ),
 			' ',
 			translate( 'Please check your inbox and click the link to log in.' ),

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -34,7 +34,7 @@ import {
 } from 'state/selectors';
 import { getTwoFactorNotificationSent, isTwoFactorEnabled } from 'state/login/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 
 const user = userFactory();
 

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -19,7 +19,10 @@ import { login } from 'lib/paths';
 import { CHECK_YOUR_EMAIL_PAGE } from 'state/login/magic-login/constants';
 import { getMagicLoginCurrentView } from 'state/selectors';
 import { hideMagicLoginRequestForm } from 'state/login/magic-login/actions';
-import { recordPageView, recordTracksEvent } from 'state/analytics/actions';
+import {
+	recordTracksEventWithClientId as recordTracksEvent,
+	recordPageViewWithClientId as recordPageView,
+} from 'state/analytics/actions';
 import Main from 'components/main';
 import RequestLoginEmailForm from './request-login-email-form';
 import GlobalNotices from 'components/global-notices';

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -23,7 +23,7 @@ import {
 	getMagicLoginRequestedEmailSuccessfully,
 } from 'state/selectors';
 import { CHECK_YOUR_EMAIL_PAGE } from 'state/login/magic-login/constants';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 
 import EmailedLoginLinkSuccessfully from './emailed-login-link-successfully';
 import FormButton from 'components/forms/form-button';

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -23,7 +23,7 @@ import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import Main from 'components/main';
 import LocaleSuggestions from 'components/locale-suggestions';
 import LoginBlock from 'blocks/login';
-import { recordPageView } from 'state/analytics/actions';
+import { recordPageViewWithClientId as recordPageView } from 'state/analytics/actions';
 import GlobalNotices from 'components/global-notices';
 import notices from 'notices';
 import PrivateSite from './private-site';

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -20,7 +20,10 @@ import safeProtocolUrl from 'lib/safe-protocol-url';
 import ExternalLink from 'components/external-link';
 import Gridicon from 'gridicons';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { recordPageView, recordTracksEvent } from 'state/analytics/actions';
+import {
+	recordTracksEventWithClientId as recordTracksEvent,
+	recordPageViewWithClientId as recordPageView,
+} from 'state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'state/login/magic-login/actions';
 import { login } from 'lib/paths';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -28,9 +28,9 @@ const mergedMetaData = ( a, b ) => [
 const joinAnalytics = ( analytics, action ) =>
 	isFunction( action )
 		? dispatch => {
-				dispatch( analytics );
-				dispatch( action );
-			}
+			dispatch( analytics );
+			dispatch( action );
+		}
 		: merge( {}, action, { meta: { analytics: mergedMetaData( analytics, action ) } } );
 
 export const composeAnalytics = ( ...analytics ) => ( {

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -132,7 +132,13 @@ const withClientId = actionCreator => ( ...args ) => ( dispatch, getState ) => {
 	const clientId = getCurrentOAuth2ClientId( getState() );
 
 	if ( clientId ) {
-		set( action, 'meta.analytics[0].payload.client_id', clientId );
+		set(
+			action,
+			action.type === ANALYTICS_EVENT_RECORD
+				? 'meta.analytics[0].payload.properties.client_id'
+				: 'meta.analytics[0].payload.client_id',
+			clientId
+		);
 	}
 
 	return dispatch( action );

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -33,7 +33,7 @@ const eventServices = {
 
 const pageViewServices = {
 	ga: ( { url, title } ) => analytics.ga.recordPageView( url, title ),
-	default: ( { url, title } ) => analytics.pageView.record( url, title ),
+	default: ( { url, title, ...params } ) => analytics.pageView.record( url, title, params ),
 };
 
 const loadTrackingTool = ( trackingTool, state ) => {

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -31,11 +31,13 @@ const eventServices = {
 	adwords: ( { properties } ) => trackCustomAdWordsRemarketingEvent( properties ),
 };
 
-const PAGE_VIEW_PARAMS = [ 'client_id' ];
+// Whitelists specific parameters to avoid polluting page view events
+const PAGE_VIEW_SERVICES_ALLOWED_PARAMS = [ 'client_id' ];
+
 const pageViewServices = {
 	ga: ( { url, title } ) => analytics.ga.recordPageView( url, title ),
 	default: ( { url, title, ...params } ) =>
-		analytics.pageView.record( url, title, pick( params, PAGE_VIEW_PARAMS ) ),
+		analytics.pageView.record( url, title, pick( params, PAGE_VIEW_SERVICES_ALLOWED_PARAMS ) ),
 };
 
 const loadTrackingTool = ( trackingTool, state ) => {

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -4,7 +4,7 @@
  * @format
  */
 
-import { has, invoke } from 'lodash';
+import { has, invoke, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,9 +31,11 @@ const eventServices = {
 	adwords: ( { properties } ) => trackCustomAdWordsRemarketingEvent( properties ),
 };
 
+const PAGE_VIEW_PARAMS = [ 'client_id' ];
 const pageViewServices = {
 	ga: ( { url, title } ) => analytics.ga.recordPageView( url, title ),
-	default: ( { url, title, ...params } ) => analytics.pageView.record( url, title, params ),
+	default: ( { url, title, ...params } ) =>
+		analytics.pageView.record( url, title, pick( params, PAGE_VIEW_PARAMS ) ),
 };
 
 const loadTrackingTool = ( trackingTool, state ) => {

--- a/client/state/analytics/test/actions.js
+++ b/client/state/analytics/test/actions.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { flowRight, set } from 'lodash';
+import { flowRight } from 'lodash';
 import { spy } from 'sinon';
 
 /**

--- a/client/state/analytics/test/actions.js
+++ b/client/state/analytics/test/actions.js
@@ -110,20 +110,23 @@ describe( 'middleware', () => {
 					hello: 'world',
 				},
 			];
+
 			const tracksEvent = recordTracksEvent( ...props );
 			const thunk = recordTracksEventWithClientId( ...props );
+
+			let dispatchedEvent;
+			const dispatch = ( createdAction ) => dispatchedEvent = createdAction;
+
 			const clientId = 123;
+			const getState = () => ( {
+				ui: { oauth2Clients: { currentClientId: clientId } },
+			} );
 
-			thunk(
-				event => {
-					set( tracksEvent, 'meta.analytics[0].payload.properties.client_id', clientId );
+			thunk( dispatch, getState );
 
-					expect( event ).to.eql( tracksEvent );
-				},
-				() => ( {
-					ui: { oauth2Clients: { currentClientId: clientId } },
-				} )
-			);
+			tracksEvent.meta.analytics[ 0 ].payload.properties.client_id = clientId;
+
+			expect( dispatchedEvent ).to.eql( tracksEvent );
 		} );
 
 		test( 'should create page view event with client id', () => {
@@ -133,20 +136,23 @@ describe( 'middleware', () => {
 					hello: 'world',
 				},
 			];
-			const clientId = 123;
+
 			const pageViewEvent = recordPageView( ...props );
 			const thunk = recordPageViewWithClientId( ...props );
 
-			thunk(
-				event => {
-					set( pageViewEvent, 'meta.analytics[0].payload.client_id', clientId );
+			let dispatchedEvent;
+			const dispatch = ( createdAction ) => dispatchedEvent = createdAction;
 
-					expect( event ).to.eql( pageViewEvent );
-				},
-				() => ( {
-					ui: { oauth2Clients: { currentClientId: clientId } },
-				} )
-			);
+			const clientId = 123;
+			const getState = () => ( {
+				ui: { oauth2Clients: { currentClientId: clientId } },
+			} );
+
+			thunk( dispatch, getState );
+
+			pageViewEvent.meta.analytics[ 0 ].payload.client_id = clientId;
+
+			expect( dispatchedEvent ).to.eql( pageViewEvent );
 		} );
 	} );
 } );

--- a/client/state/analytics/test/actions.js
+++ b/client/state/analytics/test/actions.js
@@ -116,7 +116,7 @@ describe( 'middleware', () => {
 
 			thunk(
 				event => {
-					set( tracksEvent, 'meta.analytics[0].payload.client_id', clientId );
+					set( tracksEvent, 'meta.analytics[0].payload.properties.client_id', clientId );
 
 					expect( event ).to.eql( tracksEvent );
 				},

--- a/client/state/data-layer/wpcom/users/auth-options/index.js
+++ b/client/state/data-layer/wpcom/users/auth-options/index.js
@@ -16,7 +16,7 @@ import {
 	LOGIN_AUTH_ACCOUNT_TYPE_REQUEST_FAILURE,
 } from 'state/action-types';
 import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 
 export const getAuthAccountType = ( { dispatch }, action ) => {
 	const { usernameOrEmail } = action;

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -47,14 +47,10 @@ import {
 } from 'state/action-types';
 import { getTwoFactorAuthNonce, getTwoFactorUserId } from 'state/login/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
-import {
-	getErrorFromHTTPError,
-	getErrorFromWPCOMError,
-	getSMSMessageFromResponse,
-} from './utils';
+import { getErrorFromHTTPError, getErrorFromWPCOMError, getSMSMessageFromResponse } from './utils';
 import wpcom from 'lib/wp';
 import { addLocaleToWpcomUrl, getLocaleSlug } from 'lib/i18n-utils';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Attempt to login a user.

--- a/client/state/ui/oauth2-clients/reducer.js
+++ b/client/state/ui/oauth2-clients/reducer.js
@@ -15,11 +15,11 @@ import { ROUTE_SET } from 'state/action-types';
 export const currentClientId = createReducer( null, {
 	[ ROUTE_SET ]: ( state, { path, query } ) => {
 		if ( startsWith( path, '/log-in' ) ) {
-			return +query.client_id || state;
+			return query.client_id ? Number( query.client_id ) : state;
 		}
 
 		if ( startsWith( path, '/start/wpcc' ) ) {
-			return +query.oauth2_client_id || state;
+			return query.oauth2_client_id ? Number( query.oauth2_client_id ) : state;
 		}
 
 		return state;

--- a/client/state/ui/oauth2-clients/reducer.js
+++ b/client/state/ui/oauth2-clients/reducer.js
@@ -15,11 +15,11 @@ import { ROUTE_SET } from 'state/action-types';
 export const currentClientId = createReducer( null, {
 	[ ROUTE_SET ]: ( state, { path, query } ) => {
 		if ( startsWith( path, '/log-in' ) ) {
-			return query.client_id || state;
+			return +query.client_id || state;
 		}
 
 		if ( startsWith( path, '/start/wpcc' ) ) {
-			return query.oauth2_client_id || state;
+			return +query.oauth2_client_id || state;
 		}
 
 		return state;


### PR DESCRIPTION
This pull request adds a `client_id` property to all Tracks events fired by login pages. This property refers to the identifier of the OAuth client app that initiated the login flow, and will allow us to segment login events per app in Tracks. 

#### Testing instructions

You can check that Track events are correctly triggered by executing the following command in your browser's console, and then reloading the page:

```
localStorage.setItem( 'debug', 'calypso:analytics:tracks' );
```

1. Run `git checkout update/login-tracking` and start your server, or open a [live branch](https://calypso.live/?branch=update/login-tracking)

##### Default login

2. Open the [`Login` page](http://calypso.localhost:3000/log-in) in an incognito window
3. Assert that you can still log in, and that all events are fired without any `client_id` property

##### Social login

2. Open the [`Login` page](http://calypso.localhost:3000/log-in) in an incognito window
3. Click on the `Continue with Google` button
4. Assert that you can still log in, and that all events are fired without any `client_id` property

<img width="627" alt="screen shot 2017-12-12 at 11 58 02" src="https://user-images.githubusercontent.com/326402/33881013-c4eb0f12-df33-11e7-9a02-11113e55cb45.png">

##### Magic login

2. Open the [`Magic Login` page](http://calypso.localhost:3000/log-in/link) in an incognito window
3. Assert that you can still log in, and that all events are fired without any `client_id` property

##### WooCommerce

2. Open the WooCommerce [`Home` page](https://woocommerce.com/) in an incognito window
3. Click the `SIGN IN WITH WORDPRESS.COM` link in the header
4. Replace https://wordpress.com with http://calypso.localhost:3000 in the address bar, and reload
5. Repeat all steps from default, social, and magic login flows
6. Assert that this time all events are fired **with** a `client_id` property set to `50916`

<img width="620" alt="screen shot 2017-12-12 at 11 56 10" src="https://user-images.githubusercontent.com/326402/33880949-92e0cd90-df33-11e7-904a-2f18660e1c6a.png">


##### Other OAuth apps

2. Open the Akismet [`Home` page](https://akismet.com/) in an incognito window
3. Click the `Sign In` button in the header
4. Replace https://wordpress.com with http://calypso.localhost:3000 in the address bar, and reload
5. Repeat all steps from default, social, and magic login flows
6. Assert that this time all events are fired **with** a `client_id` property set to `973`

#### Reviews

- [ ] Code
- [ ] Product