### PR TITLE
Jetpack Connect: Remove rendundent plan selection function

### DIFF
--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -13,6 +13,7 @@ import page from 'page';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
+import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import PlansGrid from './plans-grid';
 import PlansSkipButton from './plans-skip-button';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -67,7 +68,7 @@ class PlansLanding extends Component {
 			plan: cartItem ? cartItem.product_slug : 'free',
 		} );
 
-		storePlan( cartItem ? cartItem.product_slug : 'free' );
+		storePlan( cartItem ? cartItem.product_slug : PLAN_JETPACK_FREE );
 
 		setTimeout( () => {
 			page.redirect( redirectUrl );

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -68,8 +68,8 @@ class Plans extends Component {
 		if ( props.isAutomatedTransfer ) {
 			this.props.goBackToWpAdmin( props.selectedSite.URL + JETPACK_ADMIN_PATH );
 		}
-		if ( props.selectedPlanSlug ) {
-			this.autoselectPlan( props );
+		if ( props.selectedPlan ) {
+			this.selectPlan( props.selectedPlan );
 		}
 		if ( props.hasPlan || props.notJetpack ) {
 			this.redirect( CALYPSO_PLANS_PAGE );
@@ -110,19 +110,6 @@ class Plans extends Component {
 		page.redirect( path + this.props.selectedSiteSlug );
 		this.redirecting = true;
 		this.props.completeFlow();
-	}
-
-	autoselectPlan( props ) {
-		const { selectedPlan, selectedPlanSlug } = props;
-
-		if ( selectedPlanSlug === PLAN_JETPACK_FREE || selectedPlanSlug === 'free' ) {
-			this.selectFreeJetpackPlan();
-			return;
-		}
-		if ( selectedPlan ) {
-			this.selectPlan( selectedPlan );
-			return;
-		}
 	}
 
 	selectFreeJetpackPlan() {


### PR DESCRIPTION
Remove an unnecessary function to simplify plan selection logic. No visual differences.

This is a non-controversial version of #20366, which changed the flows.

## Testing
* Test pre-selecting a free plan at /jetpack/connect/store
* Test selecting a free plan after connecting at /jetpack/connect
* Test selecting a free plan when coming from wp-admin

All flows should behave as before.
