### PR TITLE
Framework: prettier reformat files

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -124,7 +124,8 @@ export class LoginForm extends Component {
 		if ( ! this.props.hasAccountTypeLoaded && isPasswordlessAccount( nextProps.accountType ) ) {
 			this.props.recordTracksEvent( 'calypso_login_block_login_form_send_magic_link' );
 
-			this.props.fetchMagicLoginRequestEmail( this.state.usernameOrEmail )
+			this.props
+				.fetchMagicLoginRequestEmail( this.state.usernameOrEmail )
 				.then( () => {
 					this.props.recordTracksEvent( 'calypso_login_block_login_form_send_magic_link_success' );
 				} )
@@ -150,7 +151,7 @@ export class LoginForm extends Component {
 	isFullView() {
 		const { accountType, hasAccountTypeLoaded, socialAccountIsLinking } = this.props;
 
-		return socialAccountIsLinking || hasAccountTypeLoaded && isRegularAccount( accountType );
+		return socialAccountIsLinking || ( hasAccountTypeLoaded && isRegularAccount( accountType ) );
 	}
 
 	isPasswordView() {
@@ -179,7 +180,8 @@ export class LoginForm extends Component {
 
 		this.props.recordTracksEvent( 'calypso_login_block_login_form_submit' );
 
-		this.props.loginUser( usernameOrEmail, password, redirectTo )
+		this.props
+			.loginUser( usernameOrEmail, password, redirectTo )
 			.then( () => {
 				this.props.recordTracksEvent( 'calypso_login_block_login_form_success' );
 
@@ -282,17 +284,16 @@ export class LoginForm extends Component {
 
 						<label htmlFor="usernameOrEmail">
 							{ this.isPasswordView() ? (
-									<a href="#" className="login__form-change-username" onClick={ this.resetView }>
-										<Gridicon icon="arrow-left" size={ 18 } />
+								<a href="#" className="login__form-change-username" onClick={ this.resetView }>
+									<Gridicon icon="arrow-left" size={ 18 } />
 
-										{ includes( this.state.usernameOrEmail, '@' )
-											? this.props.translate( 'Change Email Address' )
-											: this.props.translate( 'Change Username' )
-										}
-									</a>
-								)
-								: this.props.translate( 'Email Address or Username' )
-							}
+									{ includes( this.state.usernameOrEmail, '@' )
+										? this.props.translate( 'Change Email Address' )
+										: this.props.translate( 'Change Username' ) }
+								</a>
+							) : (
+								this.props.translate( 'Email Address or Username' )
+							) }
 						</label>
 
 						<FormTextInput
@@ -313,12 +314,12 @@ export class LoginForm extends Component {
 								<FormInputValidation isError text={ requestError.message } />
 							) }
 
-						<div className={ classNames( 'login__form-password', {
-							'is-hidden': this.isUsernameOrEmailView(),
-						} ) }>
-							<label htmlFor="password">
-								{ this.props.translate( 'Password' ) }
-							</label>
+						<div
+							className={ classNames( 'login__form-password', {
+								'is-hidden': this.isUsernameOrEmailView(),
+							} ) }
+						>
+							<label htmlFor="password">{ this.props.translate( 'Password' ) }</label>
 
 							<FormPasswordInput
 								autoCapitalize="off"

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -95,25 +95,21 @@ class Site extends React.Component {
 					data-tip-target={ this.props.tipTarget }
 					target={ this.props.externalLink && '_blank' }
 					title={
-						this.props.homeLink ? (
-							translate( 'View site %(domain)s', {
-								args: { domain: site.domain },
-							} )
-						) : (
-							site.domain
-						)
+						this.props.homeLink
+							? translate( 'View site %(domain)s', {
+									args: { domain: site.domain },
+								} )
+							: site.domain
 					}
 					onClick={ this.onSelect }
 					onMouseEnter={ this.onMouseEnter }
 					onMouseLeave={ this.onMouseLeave }
 					aria-label={
-						this.props.homeLink ? (
-							translate( 'View site %(domain)s', {
-								args: { domain: site.domain },
-							} )
-						) : (
-							site.domain
-						)
+						this.props.homeLink
+							? translate( 'View site %(domain)s', {
+									args: { domain: site.domain },
+								} )
+							: site.domain
 					}
 				>
 					<SiteIcon site={ site } size={ this.props.compact ? 24 : 32 } />

--- a/client/layout/guided-tours/tours/main-tour.js
+++ b/client/layout/guided-tours/tours/main-tour.js
@@ -45,12 +45,12 @@ export const MainTour = makeTour(
 			<p>
 				{ translate(
 					"{{strong}}Need a hand?{{/strong}} We'd love to show you around the place, " +
-											'and give you some ideas for what to do next.',
-						{
-							components: {
-								strong: <strong />,
+						'and give you some ideas for what to do next.',
+					{
+						components: {
+							strong: <strong />,
 						},
-							}
+					}
 				) }
 			</p>
 			<ButtonRow>
@@ -63,12 +63,12 @@ export const MainTour = makeTour(
 			<p>
 				{ translate(
 					"{{strong}}First things first.{{/strong}} Up here, you'll find tools for managing " +
-											"your site's content and design.",
-						{
-							components: {
-								strong: <strong />,
+						"your site's content and design.",
+					{
+						components: {
+							strong: <strong />,
 						},
-							}
+					}
 				) }
 			</p>
 			<Continue click icon="my-sites" step="sidebar" target="my-sites" />
@@ -94,22 +94,18 @@ export const MainTour = makeTour(
 			when={ isSelectedSitePreviewable }
 			scrollContainer=".sidebar__region"
 		>
-			<p>
-				{ translate( 'Want to take a look at your site?' ) }
-			</p>
+			<p>{ translate( 'Want to take a look at your site?' ) }</p>
 			<Continue click step="view-site" target="sitePreview">
 				{ translate( 'Click {{strong}}View Site{{/strong}} to continue.', {
-						components: {
-							strong: <strong />,
-						},
+					components: {
+						strong: <strong />,
+					},
 				} ) }
 			</Continue>
 		</Step>
 
 		<Step name="view-site" placement="center" when={ isSelectedSitePreviewable }>
-			<p>
-				{ translate( 'This is what your site looks like to visitors.' ) }
-			</p>
+			<p>{ translate( 'This is what your site looks like to visitors.' ) }</p>
 			<ButtonRow>
 				<Next step="themes" />
 				<Quit />
@@ -128,12 +124,12 @@ export const MainTour = makeTour(
 			<p>
 				{ translate(
 					'Change your {{strong}}Theme{{/strong}} to choose a new layout, or {{strong}}Customize{{/strong}} ' +
-											"your theme's colors, fonts, and more.",
-						{
-							components: {
-								strong: <strong />,
+						"your theme's colors, fonts, and more.",
+					{
+						components: {
+							strong: <strong />,
 						},
-							}
+					}
 				) }
 			</p>
 			<ButtonRow>
@@ -146,11 +142,11 @@ export const MainTour = makeTour(
 			<p>
 				{ translate(
 					"{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around.",
-				{
+					{
 						components: {
 							strong: <strong />,
 						},
-						}
+					}
 				) }
 			</p>
 			<ButtonRow>

--- a/client/state/data-layer/wpcom/index.js
+++ b/client/state/data-layer/wpcom/index.js
@@ -46,7 +46,7 @@ export const handlers = mergeHandlers(
 	timezones,
 	users,
 	usersAuthOptions,
-	videos,
+	videos
 );
 
 export default handlers;

--- a/client/state/data-layer/wpcom/users/auth-options/index.js
+++ b/client/state/data-layer/wpcom/users/auth-options/index.js
@@ -44,9 +44,7 @@ export const receiveSuccess = ( { dispatch }, action, data ) => {
 		},
 	} );
 
-	dispatch(
-		recordTracksEvent( 'calypso_login_block_login_form_get_auth_type_success' )
-	);
+	dispatch( recordTracksEvent( 'calypso_login_block_login_form_get_auth_type_success' ) );
 };
 
 export const receiveError = ( { dispatch }, action, error ) => {
@@ -72,7 +70,7 @@ export const receiveError = ( { dispatch }, action, error ) => {
 const getAuthAccountTypeRequest = dispatchRequest(
 	getAuthAccountType,
 	receiveSuccess,
-	receiveError,
+	receiveError
 );
 
 export default {

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -585,9 +585,7 @@ export const logoutUser = redirectTo => ( dispatch, getState ) => {
  * @return {Function} an action thunk
  */
 export const getAuthAccountType = usernameOrEmail => dispatch => {
-	dispatch(
-		recordTracksEvent( 'calypso_login_block_login_form_get_auth_type' )
-	);
+	dispatch( recordTracksEvent( 'calypso_login_block_login_form_get_auth_type' ) );
 
 	dispatch( {
 		type: LOGIN_AUTH_ACCOUNT_TYPE_REQUEST,

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -82,7 +82,7 @@ export const fetchMagicLoginRequestEmail = email => dispatch => {
 };
 
 // @TODO should this move to `/state/data-layer`..?
-export const fetchMagicLoginAuthenticate = ( token ) => dispatch => {
+export const fetchMagicLoginAuthenticate = token => dispatch => {
 	dispatch( { type: MAGIC_LOGIN_REQUEST_AUTH_FETCH } );
 
 	request


### PR DESCRIPTION
Results from running `npm run reformat-files`

Seems like a few more formatting issues cropped up since last cleanup 🍂  (#19911).

These files were modified _before_ [previous update](https://github.com/Automattic/wp-calypso/pull/19519) to Prettier 1.7 and merged _after_ Prettier update.

I started seeing these again since I'm running a codemod touching a lot of files.

## Testing

Confirm login, main-tour and Calypso in general lints/works.