### PR TITLE
Reader: add ability to apply test blog sticker (admins only)

### DIFF
--- a/client/blocks/reader-post-options-menu/blog-stickers.jsx
+++ b/client/blocks/reader-post-options-menu/blog-stickers.jsx
@@ -20,7 +20,7 @@ class ReaderPostOptionsMenuBlogStickers extends React.Component {
 	};
 
 	render() {
-		const blogStickersOffered = [ 'dont-recommend', 'broken-in-reader' ];
+		const blogStickersOffered = [ 'dont-recommend', 'broken-in-reader', 'a8c-test-blog' ];
 		const { blogId, stickers } = this.props;
 
 		return (


### PR DESCRIPTION
We already have the ability for admins to mark a site 'dont-recommend' or 'broken-in-reader'. This PR adds 'a8c-test-blog' to denote internal test blogs that should not be included in recommendations or search results.

### To test

As an admin, mark a blog with 'a8c-test-blog', and try unmarking it again.

For example, on http://calypso.localhost:3000/read/feeds/55011230:

<img width="293" alt="screen shot 2017-12-05 at 15 21 17" src="https://user-images.githubusercontent.com/17325/33614685-fef4a38a-d9cf-11e7-83e0-f83b1aea7042.png">
