### PR TITLE
Store: Prevent trim error when saving new promotions

### DIFF
--- a/client/extensions/woocommerce/app/promotions/promotion-create.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-create.js
@@ -128,7 +128,7 @@ class PromotionCreate extends React.Component {
 
 		const getSuccessNotice = () => {
 			return successNotice(
-				translate( '%(promotion)s promotion successfully created.', {
+				translate( 'Promotion successfully created.', {
 					args: { promotion: promotion.name },
 				} ),
 				{

--- a/client/extensions/woocommerce/app/promotions/promotion-validations.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-validations.js
@@ -16,7 +16,8 @@ import { isEmpty, isUndefined } from 'lodash';
  * @return { string } Returns a validation error, or undefined if none.
  */
 export function validateCouponCode( fieldName, promotion, currency, showEmpty ) {
-	if ( showEmpty && isEmpty( promotion.couponCode.trim() ) ) {
+	const couponCode = promotion.couponCode || '';
+	if ( showEmpty && isEmpty( couponCode.trim() ) ) {
 		return translate( 'Enter a coupon code so your customers can access this promotion.' );
 	}
 }


### PR DESCRIPTION
See #20505.

I think there is a different solution to this, because it seems like `promotion.couponCode` and `promotion.name` should both be present below, but they are not when saving a new promotion. 

This is a temporary fix so that the create form doesn't error out with a blank page like it is right now. I've also temporarily changed the success message, because otherwise it just comes out as `promotion successfully created.`. 

To Test:
* Create a new promotion
* Save, and make sure you are redirected back to the promotions list