### PR TITLE
Domains: Update precheck copy when we can't get admin email

### DIFF
--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -179,15 +179,13 @@ class TransferDomainPrecheck extends React.PureComponent {
 		const isStepFinished = currentStep > step;
 
 		const heading = translate( 'Verify we can get in touch.' );
-		const message = translate(
-			"We'll send an email to {{strong}}%(email)s{{/strong}} to start the transfer process. Make sure " +
-				"you have access to that address. Don't recognize it? Then you have privacy protection enabled. " +
-				"You'll need to log in to your current domain provider and {{a}}turn it off{{/a}} before we start. " +
-				"Don't worry, you can re-enable it once the transfer is done.",
+		let message = translate(
+			"We'll send an important email to start the transfer process. Log in to your current domain provider " +
+				"to check your domain's contact information. Make sure you have access to the email address and " +
+				'privacy protection is turned off. {{a}}Here’s how to do that{{/a}}. ' +
+				'Don’t worry, you can re-enable it once the transfer is done.',
 			{
-				args: { email },
 				components: {
-					strong: <strong className="transfer-domain-step__admin-email" />,
 					a: (
 						<a
 							href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY }
@@ -198,7 +196,31 @@ class TransferDomainPrecheck extends React.PureComponent {
 				},
 			}
 		);
-		const buttonText = translate( 'I can access this email address' );
+		let buttonText = translate( 'I can access the email address' );
+
+		if ( email ) {
+			message = translate(
+				"We'll send an email to {{strong}}%(email)s{{/strong}} to start the transfer process. Make sure " +
+					"you have access to that address. Don't recognize it? Then you have privacy protection enabled. " +
+					"You'll need to log in to your current domain provider and {{a}}turn it off{{/a}} before we start. " +
+					"Don't worry, you can re-enable it once the transfer is done.",
+				{
+					args: { email },
+					components: {
+						strong: <strong className="transfer-domain-step__admin-email" />,
+						a: (
+							<a
+								href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY }
+								rel="noopener noreferrer"
+								target="_blank"
+							/>
+						),
+					},
+				}
+			);
+
+			buttonText = translate( 'I can access this email address' );
+		}
 
 		const statusClasses = loading
 			? 'transfer-domain-step__lock-status transfer-domain-step__checking'

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -182,8 +182,8 @@ class TransferDomainPrecheck extends React.PureComponent {
 		let message = translate(
 			"We'll send an important email to start the transfer process. Log in to your current domain provider " +
 				"to check your domain's contact information. Make sure you have access to the email address and " +
-				'privacy protection is turned off. {{a}}Here’s how to do that{{/a}}. ' +
-				'Don’t worry, you can re-enable it once the transfer is done.',
+				"privacy protection is turned off. {{a}}Here's how to do that{{/a}}. " +
+				"Don't worry, you can re-enable it once the transfer is done.",
 			{
 				components: {
 					a: (

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -180,12 +180,15 @@ class TransferDomainPrecheck extends React.PureComponent {
 
 		const heading = translate( 'Verify we can get in touch.' );
 		let message = translate(
-			"We'll send an important email to start the transfer process. Log in to your current domain provider " +
-				"to check your domain's contact information. Make sure you have access to the email address and " +
-				"privacy protection is turned off. {{a}}Here's how to do that{{/a}}. " +
-				"Don't worry, you can re-enable it once the transfer is done.",
+			"Make sure you have access to the email address on your domain's contact information with privacy " +
+				"protection turned off. We couldn't get the email address on file and we need to send an important " +
+				'email to start the transfer process.' +
+				'{{br/}}{{br/}}' +
+				'Log in to your current domain provider to check your contact information and make sure privacy ' +
+				"is disabled. {{a}}Here's how to do that{{/a}}. Don't worry, you can turn it on once the transfer is done.",
 			{
 				components: {
+					br: <br />,
 					a: (
 						<a
 							href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY }
@@ -200,14 +203,17 @@ class TransferDomainPrecheck extends React.PureComponent {
 
 		if ( email ) {
 			message = translate(
-				"We'll send an email to {{strong}}%(email)s{{/strong}} to start the transfer process. Make sure " +
-					"you have access to that address. Don't recognize it? Then you have privacy protection enabled. " +
-					"You'll need to log in to your current domain provider and {{a}}turn it off{{/a}} before we start. " +
-					"Don't worry, you can re-enable it once the transfer is done.",
+				"Make sure you have access to the email address on your domain's contact information with privacy " +
+					"protection turned off. We'll send an email to {{strong}}%(email)s{{/strong}} to start the " +
+					"transfer process. Don't recognize that address? Then you might have privacy protection enabled." +
+					'{{br/}}{{br/}}' +
+					'Log in to your current domain provider to check your contact information and make sure privacy ' +
+					"is disabled. {{a}}Here's how to do that{{/a}}. Don't worry, you can turn it on once the transfer is done.",
 				{
 					args: { email },
 					components: {
 						strong: <strong className="transfer-domain-step__admin-email" />,
+						br: <br />,
 						a: (
 							<a
 								href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY }


### PR DESCRIPTION
If we cannot get admin email, show a different copy to the user.

Test:
- Go to `Domains -> Add`
- Use your own domain
- Pick a domain for transfer, hardcode the email in Calypso to `null`.
- Make sure you see the alternative message