### PR TITLE
Domains: Reset steps if domain became unlocked in precheck

### DIFF
--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -62,6 +62,11 @@ class TransferDomainPrecheck extends React.PureComponent {
 				this.showNextStep();
 			}
 
+			// Reset steps if domain became locked again
+			if ( ! result.unlocked ) {
+				this.resetSteps();
+			}
+
 			this.setState( {
 				email: result.admin_email,
 				privacy: result.privacy,
@@ -73,6 +78,12 @@ class TransferDomainPrecheck extends React.PureComponent {
 
 	refreshStatusOnly = () => {
 		this.refreshStatus( false );
+	};
+
+	resetSteps = () => {
+		if ( this.state.currentStep !== 1 ) {
+			this.setState( { currentStep: 1 } );
+		}
 	};
 
 	showNextStep = () => {


### PR DESCRIPTION
If the user locked the domain while checking the email, move them back to Status step.

Test:
- Domains -> Add -> Use your own domain
- Use a domain you own which is unlocked
- Go to email verification step
- Lock domain
- Refresh status
- Make sure when you get `unlocked: false` that it went back to step 1