### PR TITLE
Activity log: update support doc links

### DIFF
--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -53,17 +53,14 @@ const ActivityLogConfirmDialog = ( {
 					<Button
 						borderless={ true }
 						className="activity-log-confirm-dialog__more-info-link"
-						href="https://help.vaultpress.com/one-click-restore/"
+						href={ supportLink }
 					>
 						<Gridicon icon="notice" />
 						<span className="activity-log-confirm-dialog__more-info-link-text">
 							{ translate( 'More info' ) }
 						</span>
 					</Button>
-					<HappychatButton
-						className="activity-log-confirm-dialog__more-info-link"
-						href={ supportLink }
-					>
+					<HappychatButton className="activity-log-confirm-dialog__more-info-link">
 						<Gridicon icon="chat" />
 						<span className="activity-log-confirm-dialog__more-info-link-text">
 							{ translate( 'Any Questions?' ) }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -546,7 +546,7 @@ class ActivityLog extends Component {
 				}
 				onClose={ this.dismissRestore }
 				onConfirm={ this.confirmRestore }
-				supportLink="https://help.vaultpress.com/one-click-restore/"
+				supportLink="https://jetpack.com/support/rewind-specific-day-event"
 				title={ translate( 'Rewind Site' ) }
 			>
 				{ translate(
@@ -573,7 +573,7 @@ class ActivityLog extends Component {
 				confirmTitle={ translate( 'Create download' ) }
 				onClose={ this.dismissBackup }
 				onConfirm={ this.confirmDownload }
-				supportLink="https://help.vaultpress.com/one-click-restore/"
+				supportLink="https://jetpack.com/support/backups"
 				title={ translate( 'Create downloadable backup' ) }
 				type={ 'backup' }
 				icon={ 'cloud-download' }


### PR DESCRIPTION
This PR updates links to support docs that were previously in VaultPress site and points them towards the new ones in Jetpack site.