### PR TITLE
Comments: Decrease list updates

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { each, filter, find, get, map, orderBy, size, slice, uniq } from 'lodash';
+import { each, filter, find, get, isEqual, map, orderBy, size, slice, uniq } from 'lodash';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 /**
@@ -86,6 +86,9 @@ export class CommentList extends Component {
 			} );
 		}
 	}
+
+	shouldComponentUpdate = ( nextProps, nextState ) =>
+		! isEqual( this.props, nextProps ) || ! isEqual( this.state, nextState );
 
 	changePage = page => {
 		const { recordChangePage, changePage } = this.props;

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import { get, includes, isUndefined, map } from 'lodash';
+import { get, includes, isEqual, isUndefined, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -51,6 +51,8 @@ export class CommentNavigation extends Component {
 		status: 'unapproved',
 		sortOrder: NEWEST_FIRST,
 	};
+
+	shouldComponentUpdate = nextProps => ! isEqual( this.props, nextProps );
 
 	bulkDeletePermanently = () => {
 		const { setBulkStatus, translate } = this.props;


### PR DESCRIPTION
Follow up to #20098
Contribute to #20030

Decrease the amount of renders of the `CommentList` and `CommentNavigation` components.

This is how the first load renders changed:

| Component | Current | Deep Comparison |
| --- | --- | --- |
| `CommentList` | 66 | 26 |
| `CommentNavigation` | 58 | 22 |