### PR TITLE
JP Onboarding: Add Route Whitelist

### DIFF
--- a/client/jetpack-onboarding/index.js
+++ b/client/jetpack-onboarding/index.js
@@ -4,14 +4,17 @@
  */
 import page from 'page';
 import { isEnabled } from 'config';
+import { values } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { onboarding } from './controller';
+import { JETPACK_ONBOARDING_STEPS } from './constants';
 
 export default function() {
 	if ( isEnabled( 'jetpack/onboarding' ) ) {
-		page( '/jetpack/onboarding/:stepName?', onboarding );
+		const validStepNames = values( JETPACK_ONBOARDING_STEPS );
+		page( `/jetpack/onboarding/:stepName(${ validStepNames.join( '|' ) })?`, onboarding );
 	}
 }


### PR DESCRIPTION
To test:

* Verify that all `/jetpack/onboarding/:stepName` routes defined by the following constants still work. (Start at `http://calypso.localhost:3000/jetpack/onboarding` and keep clicking 'Skip for now' to easily flip through them.) https://github.com/Automattic/wp-calypso/blob/bab7fa7a9fdaac77686a793cfbd412e994843289/client/jetpack-onboarding/constants.js#L13-L21
* Verify that an inexistant route, e.g.  `/jetpack/onboarding/:stepName`  gives you a blank screen.
* Compare that to `master`, where you'll get 'We're sorry, but an unexpected error has occurred' (and some errors in the console).

As a follow-up, I'll add some sort of 404 component in a subsequent PR.