### PR TITLE
External media: allow sources that do not need connecting or keyring

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -202,7 +202,7 @@ class MediaLibraryContent extends React.Component {
 		page( `/sharing/${ this.props.site.slug }` );
 	};
 
-	renderExternalMedia() {
+	renderGooglePhotosConnect() {
 		const connectMessage = this.props.translate(
 			'To show Photos from Google, you need to connect your Google account.'
 		);
@@ -219,6 +219,15 @@ class MediaLibraryContent extends React.Component {
 		);
 	}
 
+	renderConnectExternalMedia() {
+		const { source } = this.props;
+		switch ( source ) {
+			case 'google_photos':
+				return this.renderGooglePhotosConnect();
+		}
+		return null;
+	}
+
 	getThumbnailType() {
 		if ( this.props.source !== '' ) {
 			return MEDIA_IMAGE_THUMBNAIL;
@@ -229,6 +238,10 @@ class MediaLibraryContent extends React.Component {
 		}
 
 		return MEDIA_IMAGE_PHOTON;
+	}
+
+	needsToBeConnected() {
+		return this.props.source !== '' && ! this.props.isConnected;
 	}
 
 	renderMediaList() {
@@ -242,8 +255,8 @@ class MediaLibraryContent extends React.Component {
 			);
 		}
 
-		if ( this.props.source !== '' && ! this.props.isConnected ) {
-			return this.renderExternalMedia();
+		if ( this.needsToBeConnected() ) {
+			return this.renderConnectExternalMedia();
 		}
 
 		return (
@@ -273,7 +286,7 @@ class MediaLibraryContent extends React.Component {
 	}
 
 	renderHeader() {
-		if ( ! this.props.isConnected ) {
+		if ( ! this.props.isConnected && this.needsToBeConnected() ) {
 			return null;
 		}
 

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -29,10 +29,19 @@ import {
 } from 'state/sharing/keyring/selectors';
 import { requestKeyringConnections } from 'state/sharing/keyring/actions';
 
+// External media sources that do not need a user to connect them
+// should be listed here.
+const noConnectionNeeded = [];
+
 const isConnected = props =>
-	props.source === '' || some( props.connectedServices, item => item.service === props.source );
+	noConnectionNeeded.indexOf( props.source ) !== -1 ||
+	props.source === '' ||
+	some( props.connectedServices, item => item.service === props.source );
 const needsKeyring = props =>
-	! props.isRequesting && props.source !== '' && props.connectedServices.length === 0;
+	noConnectionNeeded.indexOf( props.source ) === -1 &&
+	! props.isRequesting &&
+	props.source !== '' &&
+	props.connectedServices.length === 0;
 
 class MediaLibrary extends Component {
 	static propTypes = {

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -31,7 +31,7 @@ import { requestKeyringConnections } from 'state/sharing/keyring/actions';
 
 // External media sources that do not need a user to connect them
 // should be listed here.
-const noConnectionNeeded = [];
+const noConnectionNeeded = [ 'pexels' ];
 
 const isConnected = props =>
 	noConnectionNeeded.indexOf( props.source ) !== -1 ||

--- a/client/my-sites/media-library/test/index.jsx
+++ b/client/my-sites/media-library/test/index.jsx
@@ -48,27 +48,33 @@ describe( 'MediaLibrary', () => {
 		test( 'is issued when component mounted and viewing an external source', () => {
 			getItem( 'google_photos' );
 
-			expect( requestStub ).to.have.been.calledOnce;
+			expect( requestStub.callCount ).to.equal( 1 );
 		} );
 
 		test( 'is not issued when component mounted and viewing wordpress', () => {
 			getItem( '' );
 
-			expect( requestStub ).to.have.not.been.notCalled;
+			expect( requestStub.callCount ).to.equal( 0 );
 		} );
 
 		test( 'is issued when component source changes and now viewing an external source', () => {
 			const library = getItem( '' );
 
 			library.setProps( { source: 'google_photos' } );
-			expect( requestStub ).to.have.been.calledOnce;
+			expect( requestStub.callCount ).to.equal( 1 );
 		} );
 
 		test( 'is not issued when component source changes and not viewing an external source', () => {
 			const library = getItem( '' );
 
 			library.setProps( { source: '' } );
-			expect( requestStub ).to.have.not.been.notCalled;
+			expect( requestStub.callCount ).to.equal( 0 );
+		} );
+
+		test( 'is not issued when the external source does not need user connection', () => {
+			getItem( 'pexels' );
+
+			expect( requestStub.callCount ).to.equal( 0 );
 		} );
 	} );
 } );


### PR DESCRIPTION
In preparation for using the Pexels API to give us a free
photo library, we need to be able to list external media
sources that do not use keyring and do not need the
user to connect them.

Testing:

The media library should work exactly as before, but to make sure,
disconnect your Google Photos account, then try using your
Google Photos library. You should be asked to connect it.