### PR TITLE
Store NUX: disallow for mapped domains

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -223,7 +223,6 @@ class DomainSearchResults extends React.Component {
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 						isSignupStep={ this.props.isSignupStep }
 						cart={ this.props.cart }
-						show={ this.props.siteDesignType }
 					/>
 				);
 

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -27,6 +27,8 @@ import { getTld } from 'lib/domains';
 import { domainAvailability } from 'lib/domains/constants';
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import { TRANSFER_IN } from 'state/current-user/constants';
+import { getDesignType } from 'state/signup/steps/design-type/selectors';
+import { DESIGN_TYPE_STORE } from 'signup/constants';
 
 class DomainSearchResults extends React.Component {
 	static propTypes = {
@@ -212,7 +214,7 @@ class DomainSearchResults extends React.Component {
 				);
 			}, this );
 
-			if ( this.props.offerUnavailableOption ) {
+			if ( this.props.offerUnavailableOption && this.props.siteDesignType !== DESIGN_TYPE_STORE ) {
 				unavailableOffer = (
 					<DomainMappingSuggestion
 						onButtonClick={ this.props.onClickMapping }
@@ -221,6 +223,7 @@ class DomainSearchResults extends React.Component {
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 						isSignupStep={ this.props.isSignupStep }
 						cart={ this.props.cart }
+						show={ this.props.siteDesignType }
 					/>
 				);
 
@@ -257,6 +260,7 @@ const mapStateToProps = state => {
 	return {
 		isSiteOnPaidPlan: isSiteOnPaidPlan( state, selectedSiteId ),
 		transferInAllowed: currentUserHasFlag( state, TRANSFER_IN ),
+		siteDesignType: getDesignType( state ),
 	};
 };
 

--- a/client/components/domains/example-domain-suggestions/index.jsx
+++ b/client/components/domains/example-domain-suggestions/index.jsx
@@ -13,6 +13,8 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getDesignType } from 'state/signup/steps/design-type/selectors';
+import { DESIGN_TYPE_STORE } from 'signup/constants';
 
 class DomainSuggestionsExample extends React.Component {
 	static propTypes = {
@@ -20,7 +22,9 @@ class DomainSuggestionsExample extends React.Component {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { translate, siteDesignType } = this.props;
+
+		const showDomainMappingOption = siteDesignType !== DESIGN_TYPE_STORE;
 
 		/* eslint-disable max-len */
 		return (
@@ -30,11 +34,13 @@ class DomainSuggestionsExample extends React.Component {
 						'A domain name is what people type into their browser to visit your site.'
 					) }
 				</p>
-				<p className="example-domain-suggestions__mapping-information">
-					<a onClick={ this.props.recordClick } href={ this.props.mapDomainUrl }>
-						{ translate( 'Already own a domain?' ) }
-					</a>
-				</p>
+				{ showDomainMappingOption && (
+					<p className="example-domain-suggestions__mapping-information">
+						<a onClick={ this.props.recordClick } href={ this.props.mapDomainUrl }>
+							{ translate( 'Already own a domain?' ) }
+						</a>
+					</p>
+				) }
 				<div className="example-domain-suggestions__browser">
 					<svg width="295" height="102" viewBox="0 0 295 102" xmlns="http://www.w3.org/2000/svg">
 						<title>Example Browser</title>
@@ -67,6 +73,11 @@ class DomainSuggestionsExample extends React.Component {
 const recordClick = () =>
 	recordTracksEvent( 'calypso_example_domain_suggestions_mapping_link_click' );
 
-export default connect( null, {
-	recordClick,
-} )( localize( DomainSuggestionsExample ) );
+export default connect(
+	state => ( {
+		siteDesignType: getDesignType( state ),
+	} ),
+	{
+		recordClick,
+	}
+)( localize( DomainSuggestionsExample ) );


### PR DESCRIPTION
Today, I noticed a lot of failed Store NUX transfers. @jhnstn took a deeper look and discovered that most of the failures are for domain mappings. Since our customers can't map a domain during the signup process (and it might be technically impossible to do since changing name servers can take up to 24 hours), we are disabling the domain mapping option for Store NUX in this PR.

## Testing

1. Start signup at `/start` and go through Store NUX.
2. When on domains step, verify that you don't see the "already own a domain?" option;
3. Type in a domain you own (or any custom domain which is already taken) and verify you don't see the suggestion to map the domain as the last item in the suggested domains list;
4. Navigate back to the site design type selection and try any other flow than Store NUX: can you map a domain? Does it work for non-store NUX flows?