### PR TITLE
Rewind: Make some changes to contextual help footer on credentials form

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
@@ -10,58 +10,47 @@ import { localize } from 'i18n-calypso';
  */
 import CompactCard from 'components/card/compact';
 import Gridicon from 'gridicons';
-import Popover from 'components/popover';
 import HappychatButton from 'components/happychat/button';
 import { recordTracksEvent } from 'state/analytics/actions';
+import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 
 class SetupFooter extends Component {
 	componentWillMount() {
 		this.setState( { showPopover: false } );
 	}
 
-	togglePopover = () => this.setState( { showPopover: ! this.state.showPopover } );
-
-	storePopoverLink = ref => this.popoverLink = ref;
-
 	render() {
-		const { translate } = this.props;
+		const { happychatAvailable, translate } = this.props;
 
 		return (
 			<CompactCard className="credentials-setup-flow__footer">
-				<a
-					onClick={ this.togglePopover }
-					ref={ this.storePopoverLink }
-					className="credentials-setup-flow__footer-popover-link"
-				>
-					<Gridicon icon="help" size={ 18 } className="credentials-setup-flow__footer-popover-icon" />
-					{ translate( 'Why do I need this?' ) }
-				</a>
-				<HappychatButton
-					className="credentials-setup-flow__happychat-button"
-					onClick={ this.props.happychatEvent }
-				>
-					<Gridicon icon="chat" />
-					<span className="credentials-setup-flow__happychat-button-text">
-						{ translate( 'Get help' ) }
-					</span>
-				</HappychatButton>
-				<Popover
-					context={ this.popoverLink }
-					isVisible={ this.state.showPopover }
-					onClose={ this.togglePopover }
-					className="credentials-setup-flow__footer-popover"
-					position="top"
-				>
-					{ translate(
-						'These credentials are used to perform automatic actions ' +
-						'on your server including backups and restores.'
-					) }
-				</Popover>
+				{ happychatAvailable
+					? <HappychatButton
+						className="credentials-setup-flow__happychat-button"
+						onClick={ this.props.happychatEvent }
+					>
+						<Gridicon icon="chat" />
+						<span className="credentials-setup-flow__happychat-button-text">
+							{ translate( 'Get help' ) }
+						</span>
+					</HappychatButton>
+					: <a href="/help/contact" className="credentials-setup-flow__help-button">
+						<Gridicon icon="help" />
+						<span className="credentials-setup-flow__help-button-text">
+							{ translate( 'Get help' ) }
+						</span>
+					</a>
+				}
+
 			</CompactCard>
 		);
 	}
 }
 
-export default connect( null, {
+export default connect( state => {
+	return {
+		happychatAvailable: isHappychatAvailable( state ),
+	};
+}, {
 	happychatEvent: () => recordTracksEvent( 'rewind_credentials_get_help', {} ),
 } )( localize( SetupFooter ) );

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
@@ -47,10 +47,12 @@ class SetupFooter extends Component {
 	}
 }
 
-export default connect( state => {
-	return {
-		happychatAvailable: isHappychatAvailable( state ),
-	};
-}, {
-	happychatEvent: () => recordTracksEvent( 'rewind_credentials_get_help', {} ),
-} )( localize( SetupFooter ) );
+const mapStateToProps = state => ( {
+	isHappychatAvailable: isHappychatAvailable( state ),
+} );
+
+const mapDispatchToProps = () => ( {
+	happychatEvent: () => recordTracksEvent( 'rewind_credentials_get_help' ),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( SetupFooter ) );

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
@@ -70,3 +70,9 @@
 .credentials-setup-flow__happychat-button-text {
 	margin-left: 6px;
 }
+
+.credentials-setup-flow__help-button-text {
+	position: relative;
+	top: -6px;
+	left: 6px;
+}


### PR DESCRIPTION
- Remove gnarly "Why do I need this" button on credentials form
- Show "Get Help" button even if Happychat is not available

**Testing instructions:**
- Ensure the "Why do I need this" button is removed from the credentials input footer
- Ensure that the "Get Help" button is available even when Happychat is unavailable, and make sure it links to `/help/contact` in this case.
