### PR TITLE
Store Orders: Updates to refund field validations

### DIFF
--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -36,6 +36,10 @@
 	.order-payment__item-total {
 		text-align: right;
 	}
+
+	.notice {
+		float: left;
+	}
 }
 
 .order-payment__container {


### PR DESCRIPTION
Fixes #18674, #19022 – This PR does a few things around validation of refund values:

- Moves the validation check to run whenever the refund value is changed, so that we can disable the refund button on invalid values (rather than waiting for the user to click "refund" then yell at them).
- Moves the invalid refund notice into the buttons area in the dialog, so that it's always visible.
- Update the code run on quantity, fee, and shipping input to all use the same validation code, to unify behavior among inputs
- Add ScreenReaderText to label the Fee and Quantity inputs

cc @jameskoster @kellychoffman to review the new notice location

For cases where the refunded value is too high:

<img width="665" alt="screen shot 2017-12-05 at 12 50 25 pm" src="https://user-images.githubusercontent.com/541093/33622125-e4ccda8c-d9ba-11e7-85c7-c405926db7dd.png">

And for cases where the refund is zero:

<img width="663" alt="screen shot 2017-12-05 at 12 50 15 pm" src="https://user-images.githubusercontent.com/541093/33622126-e4dec4f4-d9ba-11e7-9127-0c50d6d84d15.png">

**To Test**

- View a paid order, click "Submit Refund"
- Change the shipping & any fees to zero
- Refund button should change to disabled
- Change shipping to a valid value
- The refund button will be enabled again
- Change shipping to a value greater than your order total
- The refund button will switch back to disabled
- Try changing any values to invalid values: letters, negative values, etc – it should prevent the changes from happening