### PR TITLE
Jetpack connect: Show available plans instead of current plan

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -37,7 +37,7 @@ import { mc } from 'lib/analytics';
 import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
-const CALYPSO_PLANS_PAGE = '/plans/my-plan/';
+const CALYPSO_PLANS_PAGE = '/plans/';
 const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';
 
 class Plans extends Component {


### PR DESCRIPTION
Partially addresses #18266.

When landing at `wordpress.com/jetpack/connect/plans/:site` with a non-jetpack or already-connected site, redirect to `wordpress.com/plans/:site` instead of `wordpress.com/my-plan/:site`.

This works for all types of sites, and is a quicker path to upgrades.

## Testing
* Try `/jetpack/connect/plans/:site` with a non-jetpack or already-connected site.

Expected: should be redirected to `/plans`.