### PR TITLE
Post Revisions: Fix History Button propTypes

### DIFF
--- a/client/post-editor/editor-ground-control/history-button.jsx
+++ b/client/post-editor/editor-ground-control/history-button.jsx
@@ -24,7 +24,7 @@ const HistoryButton = ( { loadRevision, postId, siteId, openDialog, translate } 
 	</div>
 );
 
-HistoryButton.PropTypes = {
+HistoryButton.propTypes = {
 	loadRevision: PropTypes.func.isRequired,
 
 	// connected to dispatch


### PR DESCRIPTION
I'm seeing this in the console:
> Warning: Component HistoryButton declared `PropTypes` instead of `propTypes`. Did you misspell the property assignment?

This just changes `PropTypes` to `propTypes`.

## To Test

* Make sure revisions "work"
* Make sure supplied propTypes are valid & no warnings are generated.