### PR TITLE
Do not allow ellipsis menu when Rewind state is not active

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -59,6 +59,7 @@ class ActivityLogDay extends Component {
 		backupConfirmDialog: PropTypes.element,
 		siteId: PropTypes.number,
 		tsEndOfSiteDay: PropTypes.number.isRequired,
+		rewindState: PropTypes.object,
 
 		// Connected props
 		isToday: PropTypes.bool.isRequired,
@@ -173,6 +174,7 @@ class ActivityLogDay extends Component {
 			backupConfirmDialog,
 			siteId,
 			tsEndOfSiteDay,
+			rewindState,
 		} = this.props;
 
 		const rewindHere = this.state.rewindHere;
@@ -193,7 +195,7 @@ class ActivityLogDay extends Component {
 			<ActivityLogItem
 				className={ hasBreak ? 'is-before-dialog' : '' }
 				applySiteOffset={ applySiteOffset }
-				disableRestore={ disableRestore }
+				disableRestore={ disableRestore || 'active' !== rewindState.state }
 				disableBackup={ disableBackup }
 				hideRestore={ hideRestore }
 				log={ log }

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -59,7 +59,6 @@ class ActivityLogDay extends Component {
 		backupConfirmDialog: PropTypes.element,
 		siteId: PropTypes.number,
 		tsEndOfSiteDay: PropTypes.number.isRequired,
-		rewindState: PropTypes.object,
 
 		// Connected props
 		isToday: PropTypes.bool.isRequired,
@@ -174,7 +173,6 @@ class ActivityLogDay extends Component {
 			backupConfirmDialog,
 			siteId,
 			tsEndOfSiteDay,
-			rewindState,
 		} = this.props;
 
 		const rewindHere = this.state.rewindHere;
@@ -195,7 +193,7 @@ class ActivityLogDay extends Component {
 			<ActivityLogItem
 				className={ hasBreak ? 'is-before-dialog' : '' }
 				applySiteOffset={ applySiteOffset }
-				disableRestore={ disableRestore || 'active' !== rewindState.state }
+				disableRestore={ disableRestore }
 				disableBackup={ disableBackup }
 				hideRestore={ hideRestore }
 				log={ log }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -683,7 +683,9 @@ class ActivityLog extends Component {
 											backupConfirmDialog={ backupConfirmDialog }
 											disableRestore={ disableRestore }
 											disableBackup={ disableBackup }
-											hideRestore={ ! rewindEnabledByConfig || ! isPressable }
+											hideRestore={
+												! rewindEnabledByConfig || ! isPressable || 'active' !== rewindState.state
+											}
 											isRewindActive={ isRewindActive }
 											logs={ events }
 											requestDialog={ this.handleRequestDialog }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -527,10 +527,9 @@ class ActivityLog extends Component {
 			);
 		}
 
-		const disableRestore = includes(
-			[ 'queued', 'running' ],
-			get( this.props, [ 'restoreProgress', 'status' ] )
-		);
+		const disableRestore =
+			includes( [ 'queued', 'running' ], get( this.props, [ 'restoreProgress', 'status' ] ) ) ||
+			'active' !== rewindState.state;
 		const disableBackup = 0 <= get( this.props, [ 'backupProgress', 'progress' ], -Infinity );
 
 		const restoreConfirmDialog = requestedRestoreActivity && (
@@ -691,7 +690,6 @@ class ActivityLog extends Component {
 											siteId={ siteId }
 											tsEndOfSiteDay={ start.valueOf() }
 											isToday={ isToday }
-											rewindState={ rewindState }
 										/>
 									);
 							}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -683,9 +683,7 @@ class ActivityLog extends Component {
 											backupConfirmDialog={ backupConfirmDialog }
 											disableRestore={ disableRestore }
 											disableBackup={ disableBackup }
-											hideRestore={
-												! rewindEnabledByConfig || ! isPressable || 'active' !== rewindState.state
-											}
+											hideRestore={ ! rewindEnabledByConfig || ! isPressable }
 											isRewindActive={ isRewindActive }
 											logs={ events }
 											requestDialog={ this.handleRequestDialog }
@@ -693,6 +691,7 @@ class ActivityLog extends Component {
 											siteId={ siteId }
 											tsEndOfSiteDay={ start.valueOf() }
 											isToday={ isToday }
+											rewindState={ rewindState }
 										/>
 									);
 							}


### PR DESCRIPTION
Currently, we do not discriminate when we show the ellipsis (Rewind) menu on activity log items. We should hide this menu if we do not have credentials, otherwise rewinds will (silently) fail.

Testing instructions:
- Observe the ellipsis menu on a site with credentials.
- Revoke the creds and make sure the ellipsis menu is gone.