### PR TITLE
Fix: Activity Log rendering issue: `isDiscarded`

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -162,14 +162,12 @@ class ActivityLogDay extends Component {
 			disableRestore,
 			disableBackup,
 			hideRestore,
-			isDiscardedPerspective,
 			isToday,
 			logs,
 			requestedRestoreActivityId,
 			requestedBackupId,
 			requestDialog,
 			restoreConfirmDialog,
-			rewindEvents,
 			backupConfirmDialog,
 			siteId,
 			tsEndOfSiteDay,
@@ -184,7 +182,7 @@ class ActivityLogDay extends Component {
 				( tsEndOfSiteDay <= activityTs && activityTs < tsEndOfSiteDay + DAY_IN_MILLISECONDS )
 		);
 
-		const events = classifyEvents( rewriteStream( logs, rewindEvents, isDiscardedPerspective ), {
+		const events = classifyEvents( logs, {
 			backupId: requestedBackupId,
 			rewindId: requestedRestoreActivityId,
 		} );
@@ -237,16 +235,16 @@ class ActivityLogDay extends Component {
 
 export default localize(
 	connect(
-		( state, { siteId } ) => {
+		( state, { logs, siteId } ) => {
 			const requestedRewind = getRequestedRewind( state, siteId );
+			const rewindEvents = getRewindEvents( state, siteId );
 			const isDiscardedPerspective = requestedRewind
 				? new Date( ms( getActivityLog( state, siteId, requestedRewind ).activityTs ) )
 				: undefined;
 
 			return {
-				isDiscardedPerspective,
+				logs: rewriteStream( logs, rewindEvents, isDiscardedPerspective ),
 				requestedRewind,
-				rewindEvents: getRewindEvents( state, siteId ),
 			};
 		},
 		( dispatch, { logs, tsEndOfSiteDay, moment } ) => ( {


### PR DESCRIPTION
Whether an event in the activity log appears discarded depends on a
runtime calculation from a given perspective and depends also on all of
the events which occur after the one in question.

When updates pour in from the server and add to the locally-stored
events we have to recalculate and update the display of those events,
even if the only value that changes is `isDiscarded`

Unfortunately when I originally added in the calculation I did it from
within the `render()` function, which has worke dfine so far. Every time
something happened which impacted this property the React components
would also update as a result of that same "something." This meant that
`isDiscarded` would update automatically as a side-effect of that
re-render instead of as a primary thing.

As soon as we started polling for updated information and tried to get
the events to redraw after a rewind finishes we noticed that the
discarded attribute wasn't changing and it appeared as if the component
wasn't redrawing.

The reason for this is that when the `connect()`ed component compares
its incoming props it sees no changs and never redraws.

In this change we move the calculation into `connect()` so that the prop
comparison occurs _after_ getting information out of state and
recalculating the `isDiscarded` property. This will force re-renders
whenever one of those calculated properties changes as well and fix the
issue.

As this is a costly operation we should loop back soon and cache it.

**Testing**

Can't really test right now because another bug is obscuring the fix
that this would bring in. However, if you are watching
**My Sites** > **Stats** > **Activity** and a new event pops in which
is a restore event then it should update existing events.