### PR TITLE
Reader: Flush Comment Closed message left

### DIFF
--- a/client/blocks/conversations/style.scss
+++ b/client/blocks/conversations/style.scss
@@ -82,7 +82,6 @@
 
 .conversations__comment-list-ul .comments__form-closed {
 	border-top: 0;
-	padding-left: 42px;
 	padding-top: 0;
 	text-align: left;
 }


### PR DESCRIPTION
This PR removes the left padding that was set for "Comments Closed" message. It needs to be aligned with the top-level comments and the default placement of the grav/comment form.

**Before:**
![screenshot 2017-12-05 14 23 37](https://user-images.githubusercontent.com/4924246/33634324-a1876f2c-d9c8-11e7-93ae-07bbfb691d1f.png)

**After:**
![screenshot 2017-12-05 14 29 22](https://user-images.githubusercontent.com/4924246/33634353-b59a9b10-d9c8-11e7-98aa-7a9dffdeca93.png)

