### PR TITLE
External media sources: allow sources to not have date grouping

### DIFF
--- a/client/components/sorted-grid/index.jsx
+++ b/client/components/sorted-grid/index.jsx
@@ -45,15 +45,20 @@ class SortedGrid extends PureComponent {
 	renderLabels( row ) {
 		return (
 			<div key={ `header_${ row.id }` } className="sorted-grid__header">
-				{ map( row.groups, ( count, group ) => (
-					<Label
-						key={ `group_${ group }` }
-						text={ this.props.getGroupLabel( group ) }
-						itemsCount={ count }
-						itemsPerRow={ this.props.itemsPerRow }
-						lastInRow={ last( keys( row.groups ) ) === group }
-					/>
-				) ) }
+				{ map( row.groups, ( count, group ) => {
+					const labelText = this.props.getGroupLabel( group );
+					return (
+						'' !== labelText && (
+							<Label
+								key={ `group_${ group }` }
+								text={ this.props.getGroupLabel( group ) }
+								itemsCount={ count }
+								itemsPerRow={ this.props.itemsPerRow }
+								lastInRow={ last( keys( row.groups ) ) === group }
+							/>
+						)
+					);
+				} ) }
 			</div>
 		);
 	}

--- a/client/components/sorted-grid/test/index.jsx
+++ b/client/components/sorted-grid/test/index.jsx
@@ -1,0 +1,44 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import Label from '../label';
+import React from 'react';
+
+describe( 'SortedGrid', () => {
+	let SortedGrid;
+	const nullfunc = () => {};
+	const getItemGroup = () => 'item-group';
+
+	beforeAll( () => {
+		SortedGrid = require( '../' );
+	} );
+
+	test( 'should not render labels if the group label is an empty string', () => {
+		const wrapper = shallow(
+			<SortedGrid
+				getItemGroup={ getItemGroup }
+				getGroupLabel={ nullfunc }
+				context={ false }
+				items={ [] }
+				itemsPerRow={ 6 }
+				lastPage={ true }
+				fetchingNextPage={ false }
+				guessedItemHeight={ 64 }
+				fetchNextPage={ nullfunc }
+				getItemRef={ nullfunc }
+				renderItem={ nullfunc }
+				renderLoadingPlaceholders={ nullfunc }
+				renderTrailingItems={ nullfunc }
+				className="test__sortedgrid"
+			/>
+		);
+		expect( wrapper.find( Label ) ).to.have.length( 0 );
+	} );
+} );

--- a/client/lib/media/list-store.js
+++ b/client/lib/media/list-store.js
@@ -127,7 +127,7 @@ function isQuerySame( siteId, query ) {
 }
 
 function sourceHasDate( source ) {
-	const sourcesWithoutDate = [];
+	const sourcesWithoutDate = [ 'pexels' ];
 	return -1 === sourcesWithoutDate.indexOf( source );
 }
 

--- a/client/lib/media/list-store.js
+++ b/client/lib/media/list-store.js
@@ -126,6 +126,11 @@ function isQuerySame( siteId, query ) {
 	);
 }
 
+function sourceHasDate( source ) {
+	const sourcesWithoutDate = [];
+	return -1 === sourcesWithoutDate.indexOf( source );
+}
+
 MediaListStore.isItemMatchingQuery = function( siteId, item ) {
 	var query, matches;
 
@@ -291,7 +296,13 @@ MediaListStore.dispatchToken = Dispatcher.register( function( payload ) {
 			}
 
 			receivePage( action.siteId, action.data.media );
-			sortItemsByDate( action.siteId );
+			// either, no query (so no external source), or there is a query and the source has date data
+			if (
+				action.query === undefined ||
+				( action.query !== undefined && sourceHasDate( action.query.source ) )
+			) {
+				sortItemsByDate( action.siteId );
+			}
 			MediaListStore.emit( 'change' );
 			break;
 

--- a/client/lib/media/test/list-store.js
+++ b/client/lib/media/test/list-store.js
@@ -171,6 +171,25 @@ describe( 'MediaListStore', () => {
 			expect( MediaListStore.getAllIds( DUMMY_SITE_ID ) ).to.eql( [ 20, 10 ] );
 		} );
 
+		test( 'should not sort media if the source is marked as not having a date', () => {
+			const media = [
+				DUMMY_MEDIA_OBJECT,
+				assign( {}, DUMMY_MEDIA_OBJECT, { ID: 20, date: '2015-06-19T11:36:09-04:00' } ),
+			];
+			const query = { number: 2, source: 'pexels' };
+
+			MediaStore.get.restore();
+			dispatchSetQuery( { query } );
+
+			sandbox.stub( MediaStore, 'get', function( siteId, postId ) {
+				return find( media, { ID: postId } );
+			} );
+
+			dispatchReceiveMediaItems( { data: { media: media }, query } );
+
+			expect( MediaListStore.getAllIds( DUMMY_SITE_ID ) ).to.eql( [ 10, 20 ] );
+		} );
+
 		test( 'should return undefined for a fetching site', () => {
 			dispatchFetchMedia();
 

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -233,8 +233,15 @@ export class MediaLibraryList extends React.Component {
 		return null;
 	};
 
+	sourceIsUngrouped( source ) {
+		const ungroupedSources = [];
+		return -1 !== ungroupedSources.indexOf( source );
+	}
+
 	render() {
 		var onFetchNextPage;
+		let getItemGroup = this.getItemGroup;
+		let getGroupLabel = this.getGroupLabel;
 
 		if ( this.props.filterRequiresUpgrade ) {
 			return <ListPlanUpgradeNudge filter={ this.props.filter } site={ this.props.site } />;
@@ -255,11 +262,18 @@ export class MediaLibraryList extends React.Component {
 			this.props.mediaOnFetchNextPage();
 		}.bind( this );
 
+		// some sources aren't grouped beyond anything but the source, so set the
+		// getItemGroup function to return the source, and no label.
+		if ( this.sourceIsUngrouped( this.props.source ) ) {
+			getItemGroup = () => this.props.source;
+			getGroupLabel = () => '';
+		}
+
 		return (
 			<SortedGrid
 				ref={ this.setListContext }
-				getItemGroup={ this.getItemGroup }
-				getGroupLabel={ this.getGroupLabel }
+				getItemGroup={ getItemGroup }
+				getGroupLabel={ getGroupLabel }
 				context={ this.props.scrollable ? this.state.listContext : false }
 				items={ this.props.media || [] }
 				itemsPerRow={ this.getItemsPerRow() }

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -234,7 +234,7 @@ export class MediaLibraryList extends React.Component {
 	};
 
 	sourceIsUngrouped( source ) {
-		const ungroupedSources = [];
+		const ungroupedSources = [ 'pexels' ];
 		return -1 !== ungroupedSources.indexOf( source );
 	}
 

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -184,6 +184,33 @@ describe( 'MediaLibraryList item selection', () => {
 		} );
 	} );
 
+	describe( 'ungrouped sources', () => {
+		const getList = ( media, source ) => {
+			return mount(
+				<MediaList
+					filterRequiresUpgrade={ false }
+					site={ { ID: DUMMY_SITE_ID } }
+					media={ media }
+					mediaScale={ 0.24 }
+					source={ source }
+					single
+				/>
+			)
+				.find( MediaList )
+				.instance();
+		};
+
+		test( 'should have no group label for an ungrouped source', () => {
+			const grid = getList( fixtures.media, 'pexels' ).render();
+			expect( grid.props.getGroupLabel() ).to.equal( '' );
+		} );
+
+		test( 'should use the source name as the item group for an ungrouped source', () => {
+			const grid = getList( fixtures.media, 'pexels' ).render();
+			expect( grid.props.getItemGroup() ).to.equal( 'pexels' );
+		} );
+	} );
+
 	describe( 'google photos', () => {
 		let largeLibrary = [];
 


### PR DESCRIPTION
To support the coming `pexels` data source, which does not have any
date data, this changes allows us to disable date grouping and
ordering for individual media sources. We need to do this because
the existing behaviour groups by date, then orders by ID, but
for a stock image service like Pexels, we need to consume the
data in the order it gets delivered to us, because Pexels sorts
the data itself.

If we disable date grouping and ordering for a source, the
group label will be empty. This change also stops labels
rendering if the label is empty, so we don't have redundant
grey lines when there is no grouping.

Testing:

The media library should work exactly as it did before.
If you want to see how it looks with no ordering or date grouping, you
can add `google_photos` to `sourcesWithoutDate` and `ungroupedSources`,
or take a look at this handy screenshot of it in action on the add/stock-image-search
branch!

![nogrouping](https://user-images.githubusercontent.com/3314354/33636707-4adeaefe-da15-11e7-93a3-3496e27558a2.png)
