### PR TITLE
Store: Stats: Avoid requesting all Jetpack plugins

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -14,18 +14,15 @@ import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
 import Intervals from './intervals';
 import FollowersCount from 'blocks/followers-count';
-import { isPluginActive, isSiteAutomatedTransfer } from 'state/selectors';
+import { isSiteAutomatedTransfer, isSiteStore } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { navItems, intervals as intervalConstants } from './constants';
-import { getJetpackSites } from 'state/selectors';
-import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 
 class StatsNavigation extends Component {
 	static propTypes = {
 		interval: PropTypes.oneOf( intervalConstants.map( i => i.value ) ),
 		isJetpack: PropTypes.bool,
 		isStore: PropTypes.bool,
-		jetPackSites: PropTypes.array,
 		selectedItem: PropTypes.oneOf( Object.keys( navItems ) ).isRequired,
 		siteId: PropTypes.number,
 		slug: PropTypes.string,
@@ -44,14 +41,13 @@ class StatsNavigation extends Component {
 	};
 
 	render() {
-		const { isJetpack, slug, selectedItem, interval, jetPackSites } = this.props;
+		const { slug, selectedItem, interval } = this.props;
 		const { label, showIntervals, path } = navItems[ selectedItem ];
 		const slugPath = slug ? `/${ slug }` : '';
 		const pathTemplate = `${ path }/{{ interval }}${ slugPath }`;
 		return (
 			<div className="stats-navigation">
 				<SectionNav selectedText={ label }>
-					{ isJetpack && <QueryJetpackPlugins siteIds={ jetPackSites.map( site => site.ID ) } /> }
 					<NavTabs label={ 'Stats' } selectedText={ label }>
 						{ Object.keys( navItems )
 							.filter( this.isValidItem )
@@ -78,12 +74,10 @@ class StatsNavigation extends Component {
 }
 
 export default connect( ( state, { siteId } ) => {
-	const isJetpack = isJetpackSite( state, siteId );
 	return {
-		isJetpack,
-		jetPackSites: getJetpackSites( state ),
+		isJetpack: isJetpackSite( state, siteId ),
 		isAtomic: isSiteAutomatedTransfer( state, siteId ),
-		isStore: isJetpack && isPluginActive( state, siteId, 'woocommerce' ),
+		isStore: isSiteStore( state, siteId ),
 		siteId,
 	};
 } )( StatsNavigation );

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -32,7 +32,6 @@ import SitePlaceholder from 'blocks/site/placeholder';
 import Search from 'components/search';
 import SiteSelectorAddSite from './add-site';
 import searchSites from 'components/search-sites';
-import { isPluginActive } from 'state/selectors';
 
 const ALL_SITES = 'ALL_SITES';
 
@@ -463,7 +462,7 @@ const navigateToSite = ( siteId, { allSitesPath, allSitesSingleUser, siteBasePat
 		}
 
 		if ( path.match( /^\/store\/stats\// ) ) {
-			const isStore = site.jetpack && isPluginActive( state, site.ID, 'woocommerce' );
+			const isStore = site.jetpack && site.options && site.options.woocommerce_is_active;
 			if ( ! isStore ) {
 				path = '/stats/day';
 			}

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -84,7 +84,7 @@ SitesList.prototype.fetch = function() {
 			fields:
 				'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
 			options:
-				'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset,signup_is_store,has_pending_automated_transfer', //eslint-disable-line max-len
+				'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset,signup_is_store,has_pending_automated_transfer,woocommerce_is_active', //eslint-disable-line max-len
 		},
 		function( error, data ) {
 			if ( error ) {

--- a/client/state/selectors/is-site-store.js
+++ b/client/state/selectors/is-site-store.js
@@ -1,0 +1,24 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { isJetpackSite } from 'state/sites/selectors';
+/**
+ * Returns true if site is Jetpack and has WooCommerce plugin set to active. Otherwise false
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether site is an Jetpack and has WooCommerce active
+ */
+export default function isSiteStore( state, siteId ) {
+	return (
+		isJetpackSite( state, siteId ) &&
+		get( state, [ 'sites', 'items', siteId, 'options', 'woocommerce_is_active' ], null )
+	);
+}

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -103,7 +103,7 @@ export function requestSites() {
 				fields:
 					'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
 				options:
-					'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset,is_wpcom_store,signup_is_store,has_pending_automated_transfer', //eslint-disable-line max-len
+					'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset,is_wpcom_store,signup_is_store,has_pending_automated_transfer,woocommerce_is_active', //eslint-disable-line max-len
 			} )
 			.then( response => {
 				dispatch( receiveSites( response.sites ) );


### PR DESCRIPTION
### Problem
All Jetpack sites are queried to see what plugins are available and if WooCommerce is active. This causes many requests if the user has many Jetpack sites.

### Fix 
Instead of querying all sites' plugins, use `options.woocommerce_is_active` from the `/me/sites` endpoint to figure out which sites are stores.

I've also pulled the logic out to a selector.

### Test
1. Load `/stats/day` and ensure `plugins` aren't queried on the Network tab
2. Switch sites to a Store (Jetpack and WooCommerce activated)
3. Make sure the "Store" tab is visible
4. Make sure the "Store" tab is not visible on non-store sites
5. Go back to a store and click the "Store" tab
6. When switching from Store to another store, make sure the active "Store" tab is persisted
7. When switching from Store to non-store, make sure the active tab is now "Traffic"

Fixes https://github.com/Automattic/wp-calypso/issues/20129