### PR TITLE
Store: Fix Bug with Category Names with apostrophes

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -32,7 +32,10 @@ const ProductFormCategoriesCard = ( {
 	const handleChange = categoryNames => {
 		const newCategories = compact(
 			categoryNames.map( name => {
-				const category = find( productCategories, { name: escape( name ) } );
+				const escapedCategoryName = escape( name );
+				const category = find( productCategories, cat => {
+					return escape( cat.name ) === escapedCategoryName;
+				} );
 
 				if ( ! category ) {
 					// Add a new product category to the creates list.


### PR DESCRIPTION
Fixes #20545

@kellychoffman worked with a user today on a support ticket that was not able to update an existing product after adding an existing product category name to the product. 

The error message being shown was:

https://cdn-pro.dprcdn.net/files/acc_540165/kpkTLP

I ssp'ed as the user and verified the bug, and noticed it was only happening on category names that had apostrophes in their names. The API request that was failing was a POST to `/wc/v3/products/categories` and the error returned was:

`“term_exists”,“message”:“A term with the name provided already exists with this parent.”`

So it was attempting to create the same product category name, even though it already existed. This branch fixes the issue by updating the category matching logic to `escape()` the existing category names to compare against the category inputs from the category token field.

__To Test__
- Ensure you have a product category setup with an apostrophe in its' name.
- Edit an existing product, and add the product category that has the apostrophe
- Click Update, verify the edits saved properly, hard refresh and confirm the new category is showing as expected