### PR TITLE
Domains: the store should be updated after submitting new WHOIS contact details

### DIFF
--- a/client/lib/domains/whois/reducer.js
+++ b/client/lib/domains/whois/reducer.js
@@ -10,6 +10,7 @@ import update from 'immutability-helper';
  * Internal dependencies
  */
 import { action as ActionTypes } from 'lib/upgrades/constants';
+import { findRegistrantWhois } from 'lib/domains/whois/utils';
 
 const initialDomainState = {
 	data: null,
@@ -55,6 +56,7 @@ function reducer( state, payload ) {
 		case ActionTypes.WHOIS_FETCH_COMPLETED:
 			state = updateDomainState( state, action.domainName, {
 				data: action.data,
+				registrantContactDetails: findRegistrantWhois( action.data ),
 				hasLoadedFromServer: true,
 				isFetching: false,
 				needsUpdate: false,
@@ -63,6 +65,10 @@ function reducer( state, payload ) {
 		case ActionTypes.WHOIS_UPDATE_COMPLETED:
 			state = updateDomainState( state, action.domainName, {
 				needsUpdate: true,
+				registrantContactDetails: {
+					...state.registrantContactDetails,
+					...action.registrantContactDetails,
+				},
 			} );
 			break;
 	}

--- a/client/lib/domains/whois/test/store.js
+++ b/client/lib/domains/whois/test/store.js
@@ -11,6 +11,7 @@ import { expect } from 'chai';
 import WhoisStore from './../store';
 import Dispatcher from 'dispatcher';
 import { action as ActionTypes } from 'lib/upgrades/constants';
+import { whoisType } from '../constants';
 
 describe( 'store', () => {
 	const DOMAIN_NAME = 'domain.name';
@@ -61,9 +62,12 @@ describe( 'store', () => {
 	} );
 
 	test( 'should return contact data when fetching domain data completed', () => {
-		const data = {
-			org: 'My Company, LLC',
-		};
+		const data = [
+			{
+				org: 'My Company, LLC',
+				type: whoisType.REGISTRANT,
+			},
+		];
 
 		Dispatcher.handleServerAction( {
 			type: ActionTypes.WHOIS_FETCH_COMPLETED,
@@ -73,6 +77,7 @@ describe( 'store', () => {
 
 		expect( WhoisStore.getByDomainName( DOMAIN_NAME ) ).to.be.eql( {
 			data,
+			registrantContactDetails: data[ 0 ],
 			hasLoadedFromServer: true,
 			isFetching: false,
 			needsUpdate: false,
@@ -80,12 +85,18 @@ describe( 'store', () => {
 	} );
 
 	test( 'should return latest whois data when domain data received twice', () => {
-		const data = {
+		const data = [
+			{
 				org: 'My First Company, LLC',
+				type: whoisType.REGISTRANT,
 			},
-			anotherData = {
+		];
+		const anotherData = [
+			{
 				org: 'My Second Company, LLC',
-			};
+				type: whoisType.REGISTRANT,
+			},
+		];
 
 		Dispatcher.handleServerAction( {
 			type: ActionTypes.WHOIS_FETCH_COMPLETED,
@@ -99,16 +110,25 @@ describe( 'store', () => {
 		} );
 
 		expect( WhoisStore.getByDomainName( DOMAIN_NAME ).data ).to.be.equal( anotherData );
+		expect( WhoisStore.getByDomainName( DOMAIN_NAME ).registrantContactDetails ).to.be.equal(
+			anotherData[ 0 ]
+		);
 	} );
 
 	test( 'should contain whois data for given domain equal to received from server action', () => {
-		const ANOTHER_DOMAIN_NAME = 'another-domain.name',
-			data = {
+		const ANOTHER_DOMAIN_NAME = 'another-domain.name';
+		const data = [
+			{
 				org: 'My First Company, LLC',
+				type: whoisType.REGISTRANT,
 			},
-			anotherData = {
+		];
+		const anotherData = [
+			{
 				org: 'My Second Company, LLC',
-			};
+				type: whoisType.REGISTRANT,
+			},
+		];
 
 		Dispatcher.handleServerAction( {
 			type: ActionTypes.WHOIS_FETCH_COMPLETED,
@@ -122,15 +142,28 @@ describe( 'store', () => {
 		} );
 
 		expect( WhoisStore.getByDomainName( DOMAIN_NAME ).data ).to.be.equal( data );
+		expect( WhoisStore.getByDomainName( DOMAIN_NAME ).registrantContactDetails ).to.be.equal(
+			data[ 0 ]
+		);
 		expect( WhoisStore.getByDomainName( ANOTHER_DOMAIN_NAME ).data ).to.equal( anotherData );
+		expect( WhoisStore.getByDomainName( ANOTHER_DOMAIN_NAME ).registrantContactDetails ).to.equal(
+			anotherData[ 0 ]
+		);
 	} );
 
-	test( 'should return enabled needsUpdate flag when domain WHOIS update completed', () => {
+	test( 'should return enabled needsUpdate flag and new registrantContactDetails when domain WHOIS update completed', () => {
+		const registrantContactDetails = {
+			Willie: 'Nelson',
+		};
 		Dispatcher.handleServerAction( {
 			type: ActionTypes.WHOIS_UPDATE_COMPLETED,
 			domainName: DOMAIN_NAME,
+			registrantContactDetails,
 		} );
 
 		expect( WhoisStore.getByDomainName( DOMAIN_NAME ).needsUpdate ).to.be.true;
+		expect( WhoisStore.getByDomainName( DOMAIN_NAME ).registrantContactDetails ).to.be.eql(
+			registrantContactDetails
+		);
 	} );
 } );

--- a/client/lib/domains/whois/test/utils.js
+++ b/client/lib/domains/whois/test/utils.js
@@ -1,0 +1,43 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { findRegistrantWhois, findPrivacyServiceWhois } from '../utils';
+import { whoisType } from '../constants';
+
+describe( 'utils', () => {
+	const whoisData = [
+		{
+			org: 'The best company',
+			type: whoisType.REGISTRANT,
+		},
+		{
+			org: 'Privacy R US',
+			type: whoisType.PRIVACY_SERVICE,
+		},
+	];
+
+	describe( 'findRegistrantWhois', () => {
+		test( 'should return undefined when not registrant object found ', () => {
+			expect( findRegistrantWhois( [] ) ).to.be.undefined;
+		} );
+		test( 'should return registrant object from Whois data ', () => {
+			expect( findRegistrantWhois( whoisData ) ).to.be.eql( whoisData[ 0 ] );
+		} );
+	} );
+
+	describe( 'findPrivacyServiceWhois', () => {
+		test( 'should return undefined when not registrant object found ', () => {
+			expect( findPrivacyServiceWhois( [] ) ).to.be.undefined;
+		} );
+		test( 'should return privacy service object from Whois data ', () => {
+			expect( findPrivacyServiceWhois( whoisData ) ).to.be.eql( whoisData[ 1 ] );
+		} );
+	} );
+} );

--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -167,6 +167,11 @@ function fetchDomains( siteId ) {
 		} );
 }
 
+/**
+ * Gets the current WHOIS data for `domainName` from the backend
+ *
+ * @param {String} domainName - current domain name
+ */
 function fetchWhois( domainName ) {
 	const whois = WhoisStore.getByDomainName( domainName );
 
@@ -195,12 +200,21 @@ function fetchWhois( domainName ) {
 	} );
 }
 
+/**
+ * Posts new WHOIS contact information data for `domainName` to the backend
+ *
+ * @param {String} domainName - current domain name
+ * @param {Object} contactInformation - contact information to be sent
+ * @param {Boolean} transferLock - state of opt-out of the 60-day transfer lock checkbox
+ * @param {Function} onComplete - callback after HTTP action
+ */
 function updateWhois( domainName, contactInformation, transferLock, onComplete ) {
 	wpcom.updateWhois( domainName, contactInformation, transferLock, ( error, data ) => {
 		if ( ! error ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.WHOIS_UPDATE_COMPLETED,
 				domainName,
+				registrantContactDetails: contactInformation,
 			} );
 
 			// For WWD the update may take longer
@@ -209,6 +223,7 @@ function updateWhois( domainName, contactInformation, transferLock, onComplete )
 				Dispatcher.handleServerAction( {
 					type: ActionTypes.WHOIS_UPDATE_COMPLETED,
 					domainName,
+					registrantContactDetails: contactInformation,
 				} );
 			}, 60000 );
 		}

--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -20,7 +20,7 @@ import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
 import paths from 'my-sites/domains/paths';
 import { getSelectedDomain } from 'lib/domains';
-import { findRegistrantWhois, findPrivacyServiceWhois } from 'lib/domains/whois/utils';
+import { findPrivacyServiceWhois } from 'lib/domains/whois/utils';
 
 class ContactsPrivacy extends React.PureComponent {
 	static propTypes = {
@@ -40,10 +40,10 @@ class ContactsPrivacy extends React.PureComponent {
 		const { hasPrivacyProtection, privateDomain, privacyAvailable, currentUserCanManage } = domain;
 		const contactInformation = privateDomain
 			? findPrivacyServiceWhois( this.props.whois.data )
-			: findRegistrantWhois( this.props.whois.data );
+			: this.props.whois.registrantContactDetails;
 
 		return (
-			<Main className="domain-management-contacts-privacy">
+			<Main className="contacts-privacy">
 				<Header onClick={ this.goToEdit } selectedDomainName={ this.props.selectedDomainName }>
 					{ privacyAvailable ? translate( 'Contacts and Privacy' ) : translate( 'Contacts' ) }
 				</Header>

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -43,6 +43,11 @@ class EditContactInfoFormCard extends React.Component {
 		selectedDomain: PropTypes.object.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		currentUser: PropTypes.object.isRequired,
+		needsUpdate: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		needsUpdate: false,
 	};
 
 	constructor( props ) {

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -43,11 +43,6 @@ class EditContactInfoFormCard extends React.Component {
 		selectedDomain: PropTypes.object.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		currentUser: PropTypes.object.isRequired,
-		needsUpdate: PropTypes.bool,
-	};
-
-	static defaultProps = {
-		needsUpdate: false,
 	};
 
 	constructor( props ) {

--- a/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
@@ -22,7 +22,6 @@ import Header from 'my-sites/domains/domain-management/components/header';
 import Main from 'components/main';
 import paths from 'my-sites/domains/paths';
 import { getSelectedDomain } from 'lib/domains';
-import { findRegistrantWhois } from 'lib/domains/whois/utils';
 import SectionHeader from 'components/section-header';
 import { registrar as registrarNames } from 'lib/domains/constants';
 
@@ -40,7 +39,7 @@ class EditContactInfo extends React.Component {
 		}
 
 		return (
-			<Main className="domain-management-edit-contact-info">
+			<Main className="edit-contact-info">
 				<Header
 					onClick={ this.goToContactsPrivacy }
 					selectedDomainName={ this.props.selectedDomainName }
@@ -76,7 +75,7 @@ class EditContactInfo extends React.Component {
 			<div>
 				<SectionHeader label={ this.props.translate( 'Edit Contact Info' ) } />
 				<EditContactInfoFormCard
-					contactInformation={ findRegistrantWhois( this.props.whois.data ) }
+					contactInformation={ this.props.whois.registrantContactDetails }
 					selectedDomain={ getSelectedDomain( this.props ) }
 					selectedSite={ this.props.selectedSite }
 				/>


### PR DESCRIPTION
This PR address Issue: #16239 **After updating, the WHOIS store is not automatically updated**

### What this PR does
When first arriving at the WHOIS contact details form, the submit is disabled in order to prevent submission of duplicate WHOIS contact details.

<img width="589" alt="disabled button" src="https://user-images.githubusercontent.com/6458278/33643572-116c0714-da94-11e7-9c1f-6d3107011425.png">

After a user changes and submits these details however, the store isn't being updated. As as result, any equality check on the new vs. existing values will return a result of `hasChanged`.

The quick fix is to add a new property to the whois store - `registrantContactDetails` - that we can update after a successful whois update, and with which we can do a comparison update without performing another fetch of the whois details from the server. (Thanks @klimeryk for the idea.)

`registrantContactDetails` is essentially duplicating the data already returned, but I'd rather not merge form data into the domain whois data array. It seems messy. 

Furthermore, `registrantContactDetails` has one unique purpose, that is, to act as the store for the whois contact form.

### Testing

1. Edit the contact details (Organization is enough) of your WordPress-registered domain
2. Submit

#### Expectation
The submit button should be disabled until you once again change the form values.

