### PR TITLE
Change misleading text describing free themes on free/personal plan

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1044,7 +1044,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_FREE_THEMES ]: {
 		getSlug: () => FEATURE_FREE_THEMES,
-		getTitle: () => i18n.translate( 'Hundreds of Free Themes' ),
+		getTitle: () => i18n.translate( '100+ Free Themes' ),
 		getDescription: () =>
 			i18n.translate(
 				'Access to a wide range of professional theme templates ' +


### PR DESCRIPTION
It has been pointed out by users that 117 themes cannot really be described as “Hundreds of free themes” as mentioned in our Personal Plan description.

# Testing

Visit `/plans` for a site and confirm the text change to '100+ Free Themes'