### PR TITLE
Community Translator: Disable

### DIFF
--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -51,6 +51,10 @@ var injectUrl,
  */
 const communityTranslatorJumpstart = {
 	isEnabled() {
+		if ( ! config.isEnabled( 'community-translator' ) ) {
+			return false;
+		}
+
 		const currentUser = user.get();
 
 		if ( ! currentUser || 'en' === currentUser.localeSlug || ! currentUser.localeSlug ) {

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -151,7 +151,7 @@ const Account = createReactClass( {
 		const { translate } = this.props;
 		const userLocale = this.getUserSetting( 'language' );
 		const showTranslator = userLocale && userLocale !== 'en';
-		if ( showTranslator ) {
+		if ( config.isEnabled( 'community-translator' ) && showTranslator ) {
 			return (
 				<FormFieldset>
 					<FormLegend>{ translate( 'Community Translator' ) }</FormLegend>


### PR DESCRIPTION
The translator is currently broken. Disabling while we investigate.
See #20534 

This is done by reverting commit 0b9887cd11820bf8fde0b4d9c24ca0e9cad85c8a, to add the feature checks back in (since the feature is undefined in the config, it will not be available).

*Testing*:
Use a locale other than English. Make sure that the option to enable the translator does not appear in your user settings. If you've previously enabled that option, the translator toggle button should not be visible anymore.
 