### PR TITLE
UI: Change wording on free themes to make it more accurate

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -769,7 +769,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_FREE_THEMES_SIGNUP ]: {
 		getSlug: () => FEATURE_FREE_THEMES_SIGNUP,
-		getTitle: () => i18n.translate( 'Hundreds of free themes' ),
+		getTitle: () => i18n.translate( '100+ Free Themes' ),
 	},
 
 	[ FEATURE_WP_SUBDOMAIN_SIGNUP ]: {


### PR DESCRIPTION
Reported at 1209919-hc and p5uIfZ-88h-p2 cc: @nagpai  @anneforbush 

When visiting http://wordpress.com/pricing we see one of the features of the free and personal plan is having hundreds of themes available. This is misleading as there are only 117 at the moment.

Changed the "Hundreds of free themes" string to "100+ Free Themes" as per @anneforbush comment on p5uIfZ-88h-p2

<img width="256" alt="screen shot 2017-12-06 at 16 29 28" src="https://user-images.githubusercontent.com/3812076/33654501-e72077f6-daa2-11e7-817a-2b0fd987ef37.png">
