### PR TITLE
Store - Only showing the labels on qualifying orders

### DIFF
--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -166,7 +166,7 @@ class OrderFulfillment extends Component {
 	shouldShowLabels() {
 		const { labelsLoaded, labelsEnabled, order, storeAddress, hasLabelsPaymentMethod } = this.props;
 
-		if ( ! wcsEnabled || ! labelsLoaded ) {
+		if ( ! labelsLoaded ) {
 			return false;
 		}
 

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -143,6 +143,10 @@ class OrderFulfillment extends Component {
 
 	isAddressValidForLabels( address ) {
 		const { labelCountriesData } = this.props;
+		if ( ! labelCountriesData ) {
+			return false;
+		}
+
 		const countryData = labelCountriesData[ address.country ];
 
 		//country not supported

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -270,3 +270,12 @@ export const canPurchase = createSelector(
 export const areLabelsFullyLoaded = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	return isLoaded( state, orderId, siteId ) && areSettingsLoaded( state, siteId ) && arePackagesLoaded( state, siteId );
 };
+
+export const getCountriesData = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
+	if ( ! isLoaded( state, orderId, siteId ) ) {
+		return null;
+	}
+
+	const shippingLabel = getShippingLabel( state, orderId, siteId );
+	return shippingLabel.storeOptions.countriesData;
+};

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/test/selectors.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { getRatesErrors } from '../selectors';
+import { getRatesErrors, getCountriesData } from '../selectors';
 
 describe( '#getRatesErrors', () => {
 	// when there are selected rates
@@ -284,6 +284,51 @@ describe( '#getRatesErrors', () => {
 					box_2: 'Please choose a rate',
 				} );
 			} );
+		} );
+	} );
+} );
+
+describe( 'Shipping label selectors', () => {
+	const siteId = 1;
+	const orderId = 1;
+	const getFullState = ( labelsState ) => (
+		{
+			extensions: {
+				woocommerce: {
+					woocommerceServices: {
+						[ siteId ]: {
+							shippingLabel: {
+								[ orderId ]: labelsState,
+							},
+						},
+					},
+				},
+			},
+		}
+	);
+
+	it( 'getCountriesData - returns null if labels not loaded', () => {
+		const state = getFullState( { loaded: false } );
+		const result = getCountriesData( state, orderId, siteId );
+		expect( result ).to.eql( null );
+	} );
+
+	it( 'getCountriesData - returns the countries data if they exist', () => {
+		const state = getFullState( {
+			loaded: true,
+			storeOptions: {
+				countriesData: {
+					US: {
+						CA: 'California',
+					},
+				},
+			},
+		} );
+		const result = getCountriesData( state, orderId, siteId );
+		expect( result ).to.eql( {
+			US: {
+				CA: 'California',
+			},
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #20517 

To test: the labels button should not be shown if
* the store is not located in the US or PR
* the customer address is not in the US or PR
* the customer is located in AA, AE or AP states