### PR TITLE
Redirect /jetpack/connect/plan (no site) to /store

### DIFF
--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -44,14 +44,15 @@ export default function() {
 		page.redirect( `/jetpack/connect/store${ params.interval ? '/' + params.interval : '' }` )
 	);
 
+	page( '/jetpack/connect/plans', '/jetpack/connect/store' );
+	page( '/jetpack/connect/plans/:site', siteSelection, controller.plansSelection );
+	page( '/jetpack/connect/plans/:interval/:site', siteSelection, controller.plansSelection );
+
 	page(
 		'/jetpack/connect/:locale?',
 		controller.redirectWithoutLocaleifLoggedIn,
 		controller.connect
 	);
-
-	page( '/jetpack/connect/plans/:site', siteSelection, controller.plansSelection );
-	page( '/jetpack/connect/plans/:interval/:site', siteSelection, controller.plansSelection );
 
 	page( '/jetpack/sso/:siteId?/:ssoNonce?', controller.sso );
 	page( '/jetpack/sso/*', controller.sso );

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -40,13 +40,18 @@ export default function() {
 
 	page( '/jetpack/connect/store/:interval(yearly|monthly)?', controller.plansLanding );
 
-	page( '/jetpack/connect/:from(akismet|vaultpress)/:interval(yearly|monthly)?', ( { params } ) =>
-		page.redirect( `/jetpack/connect/store${ params.interval ? '/' + params.interval : '' }` )
+	page(
+		'/jetpack/connect/:_(akismet|plans|vaultpress)/:interval(yearly|monthly)?',
+		( { params } ) =>
+			page.redirect( `/jetpack/connect/store${ params.interval ? '/' + params.interval : '' }` )
 	);
 
-	page( '/jetpack/connect/plans', '/jetpack/connect/store' );
 	page( '/jetpack/connect/plans/:site', siteSelection, controller.plansSelection );
-	page( '/jetpack/connect/plans/:interval/:site', siteSelection, controller.plansSelection );
+	page(
+		'/jetpack/connect/plans/:interval(yearly|monthly)?/:site',
+		siteSelection,
+		controller.plansSelection
+	);
 
 	page(
 		'/jetpack/connect/:locale?',

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -46,7 +46,6 @@ export default function() {
 			page.redirect( `/jetpack/connect/store${ params.interval ? '/' + params.interval : '' }` )
 	);
 
-	page( '/jetpack/connect/plans/:site', siteSelection, controller.plansSelection );
 	page(
 		'/jetpack/connect/plans/:interval(yearly|monthly)?/:site',
 		siteSelection,


### PR DESCRIPTION
Partially addresses #18266.

Arrival at `wordpress.com/jetpack/connect/plans`:

**Before**
<img width="1219" alt="screen shot 2017-12-06 at 13 27 48" src="https://user-images.githubusercontent.com/7767559/33663841-6879cbd2-da89-11e7-8b8a-27f9c1beefbd.png">

**After**
<img width="1220" alt="screen shot 2017-12-06 at 13 28 14" src="https://user-images.githubusercontent.com/7767559/33663857-6ed75eae-da89-11e7-85aa-8d06e553b939.png">

Customers arriving at the `/jetpack/connect/plan` route will now see the plan selection screen instead of a box to enter site url.

Note that the URL box was shown previously because `jetpack/connect/plans` with no site was matching the route `jetpack/connect/:locale`.

## Testing
* Check that `/jetpack/connect/plans` now redirects to `/jetpack/connect/store`
* Check that `/jetpack/connect/plans/:site` works as before

