### PR TITLE
Post Type List: Increase click target for titles

### DIFF
--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -81,6 +81,7 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 a.post-item__title-link,
 a.post-item__title-link:visited {
 	color: $gray-dark;
+	display: block;
 
 	&:hover {
 		color: darken( $gray, 20% );
@@ -93,6 +94,7 @@ a.post-item__title-link:visited {
 
 	.post-item__panel.is-placeholder & {
 		@include placeholder;
+		display: inline-block;
 	}
 }
 


### PR DESCRIPTION
Increases the click target for post titles in the condensed post list.

**Before:**
<img width="748" alt="click-target-before" src="https://user-images.githubusercontent.com/942359/33666982-971dc558-da69-11e7-8c6f-0acf020c3ba8.png">

**After:**
<img width="760" alt="click-target-after" src="https://user-images.githubusercontent.com/942359/33667006-a3c691b8-da69-11e7-8d12-438f5739325a.png">

**To test:**
- Use the calypso.live link.
- Set the `CondensedPostList` AB test to the `condensedPosts` variant.
- Make sure that the click area fills the post title h1 block and doesn't break layouts on desktop or mobile, with and without featured images.