### PR TITLE
 Jetpack connect: Prompt for login at /plans with site

### DIFF
--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -7,10 +7,14 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import userFactory from 'lib/user';
 import * as controller from './controller';
 import { siteSelection } from 'my-sites/controller';
 
 export default function() {
+	const user = userFactory();
+	const isLoggedOut = ! user.get();
+
 	page(
 		'/jetpack/connect/:type(personal|premium|pro)/:interval(yearly|monthly)?',
 		controller.connect
@@ -45,6 +49,12 @@ export default function() {
 		( { params } ) =>
 			page.redirect( `/jetpack/connect/store${ params.interval ? '/' + params.interval : '' }` )
 	);
+
+	if ( isLoggedOut ) {
+		page( '/jetpack/connect/plans/:interval(yearly|monthly)?/:site', ( { path } ) =>
+			page.redirect( `/log-in?redirect_to=${ path }` )
+		);
+	}
 
 	page(
 		'/jetpack/connect/plans/:interval(yearly|monthly)?/:site',

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -9,6 +9,7 @@ import page from 'page';
  */
 import userFactory from 'lib/user';
 import * as controller from './controller';
+import { login } from 'lib/paths';
 import { siteSelection } from 'my-sites/controller';
 
 export default function() {
@@ -52,7 +53,7 @@ export default function() {
 
 	if ( isLoggedOut ) {
 		page( '/jetpack/connect/plans/:interval(yearly|monthly)?/:site', ( { path } ) =>
-			page.redirect( `/log-in?redirect_to=${ path }` )
+			page.redirect( login( { isNative: true, redirectTo: path } ) )
 		);
 	}
 


### PR DESCRIPTION
Partially addresses #18266.

When arriving logged-out at /jetpack/connect/plans/:site, redirect to the login page before coming back to the plans route.

## Testing
Logged-out:
* Hit route `/jetpack/connect/plans/:site`
* You should be taken to the login screen
* After logging in, you could be redirected back to `/jetpack/connect/plans/:site`
* Depending on :site, this may redirect elsewhere. A jetpack site with no plan should stay at `/jetpack/connect/plans/:site`