### PR TITLE
JP Onboarding: Add Site Title Step

### DIFF
--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -14,8 +14,8 @@ import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
-import FormTextInput from 'components/forms/form-text-input';
 import FormTextarea from 'components/forms/form-textarea';
+import FormTextInput from 'components/forms/form-text-input';
 import Main from 'components/main';
 
 class JetpackOnboardingSiteTitleStep extends React.PureComponent {

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -9,9 +9,29 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
+import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextarea from 'components/forms/form-textarea';
+import Main from 'components/main';
 
 class JetpackOnboardingSiteTitleStep extends React.PureComponent {
+	state = {
+		description: '',
+		title: '',
+	};
+
+	setDescription = event => {
+		this.setState( { description: event.target.value } );
+	};
+
+	setTitle = event => {
+		this.setState( { title: event.target.value } );
+	};
+
 	render() {
 		const { translate } = this.props;
 		const headerText = translate( "Let's get started." );
@@ -19,7 +39,27 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 			'First up, what would you like to name your site and have as its public description?'
 		);
 
-		return <FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />;
+		return (
+			<Main>
+				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+
+				<Card>
+					<form>
+						<FormFieldset>
+							<FormLabel>{ translate( 'Site Title' ) }</FormLabel>
+							<FormTextInput onChange={ this.setTitle } value={ this.state.title } />
+
+							<FormLabel>{ translate( 'Site Description' ) }</FormLabel>
+							<FormTextarea onChange={ this.setDescription } value={ this.state.description } />
+
+							<Button href={ this.props.getForwardUrl() } primary>
+								{ translate( 'Next Step' ) }
+							</Button>
+						</FormFieldset>
+					</form>
+				</Card>
+			</Main>
+		);
 	}
 }
 

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -41,6 +42,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 
 		return (
 			<Main>
+				<DocumentHead title={ translate( 'Site Title ‹ Jetpack Onboarding' ) } />
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<Card>

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -46,16 +46,22 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 				<Card>
 					<form>
 						<FormFieldset>
-							<FormLabel>{ translate( 'Site Title' ) }</FormLabel>
-							<FormTextInput onChange={ this.setTitle } value={ this.state.title } />
-
-							<FormLabel>{ translate( 'Site Description' ) }</FormLabel>
-							<FormTextarea onChange={ this.setDescription } value={ this.state.description } />
-
-							<Button href={ this.props.getForwardUrl() } primary>
-								{ translate( 'Next Step' ) }
-							</Button>
+							<FormLabel htmlFor="title">{ translate( 'Site Title' ) }</FormLabel>
+							<FormTextInput id="title" onChange={ this.setTitle } value={ this.state.title } />
 						</FormFieldset>
+
+						<FormFieldset>
+							<FormLabel htmlFor="description">{ translate( 'Site Description' ) }</FormLabel>
+							<FormTextarea
+								id="description"
+								onChange={ this.setDescription }
+								value={ this.state.description }
+							/>
+						</FormFieldset>
+
+						<Button href={ this.props.getForwardUrl() } primary>
+							{ translate( 'Next Step' ) }
+						</Button>
 					</form>
 				</Card>
 			</Main>


### PR DESCRIPTION
Simple, basic form controls shamelessly stolen from @tyxla's https://github.com/Automattic/wp-calypso/pull/20360/files#diff-fa91e4354b079c7e175b77785da39666 and simplified further.

This uses component state instead of `redux-form` (because two form controls don't seem to warrant the extra complexity). It also doesn't do anything yet, i.e. it doesn't store the changes made anywhere, nor does it propagate them to the site. Rationale: I wanted this PR to be as uncontroversial as possible, adding the possibly more controversial bits (i.e. anything related to Redux actions) in a follow-up PR.

![image](https://user-images.githubusercontent.com/96308/33671942-3d1de73c-daa9-11e7-84c8-d4f1469a5bd7.png)


To test:
* http://calypso.localhost:3000/jetpack/onboarding/site-title
* Verify that you can enter text into both fields (and that no console errors are displayed)
* Verify that the 'Next Step' button takes you to http://calypso.localhost:3000/jetpack/onboarding/site-type