### PR TITLE
Comments Redesign: Improve back navigation

### DIFF
--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -31,6 +31,7 @@ export class CommentView extends Component {
 		commentId: PropTypes.number.isRequired,
 		action: PropTypes.string,
 		canModerateComments: PropTypes.bool.isRequired,
+		onBack: PropTypes.func,
 		redirectToPostView: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
@@ -42,6 +43,7 @@ export class CommentView extends Component {
 			commentId,
 			action,
 			canModerateComments,
+			onBack,
 			redirectToPostView,
 			translate,
 		} = this.props;
@@ -59,7 +61,7 @@ export class CommentView extends Component {
 				{ 'delete' === action && (
 					<CommentDeleteWarning { ...{ siteId, postId, commentId, redirectToPostView } } />
 				) }
-				<CommentListHeader { ...{ postId } } />
+				<CommentListHeader { ...{ onBack, postId } } />
 				{ ! canModerateComments && (
 					<EmptyContent
 						title={ preventWidows(

--- a/client/my-sites/comments/comment-list/comment-list-header.jsx
+++ b/client/my-sites/comments/comment-list/comment-list-header.jsx
@@ -19,9 +19,10 @@ import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/a
 import { getSiteComments } from 'state/selectors';
 import { getSitePost } from 'state/posts/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 
 export const CommentListHeader = ( {
+	onBack,
 	postDate,
 	postId,
 	postTitle,
@@ -29,7 +30,6 @@ export const CommentListHeader = ( {
 	recordReaderArticleOpened,
 	site,
 	siteId,
-	siteSlug,
 	translate,
 } ) => {
 	const formattedDate = postDate
@@ -47,8 +47,8 @@ export const CommentListHeader = ( {
 				actionIcon="visible"
 				actionOnClick={ recordReaderArticleOpened }
 				actionText={ translate( 'View Post' ) }
-				backHref={ `/comments/all/${ siteSlug }` }
 				alwaysShowActionText
+				onClick={ onBack }
 			>
 				<div className="comment-list__header-title">
 					{ translate( 'Comments on {{span}}%(postTitle)s{{/span}}', {
@@ -65,7 +65,6 @@ export const CommentListHeader = ( {
 const mapStateToProps = ( state, { postId } ) => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
-	const siteSlug = getSelectedSiteSlug( state );
 	const post = getSitePost( state, siteId, postId );
 	const postDate = get( post, 'date' );
 	const postTitle = decodeEntities(
@@ -83,7 +82,6 @@ const mapStateToProps = ( state, { postId } ) => {
 		postUrl: isJetpack ? get( post, 'URL' ) : `/read/blogs/${ siteId }/posts/${ postId }`,
 		site,
 		siteId,
-		siteSlug,
 	};
 };
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -51,6 +51,7 @@ export class CommentList extends Component {
 		comments: PropTypes.array,
 		deleteComment: PropTypes.func,
 		likeComment: PropTypes.func,
+		onBack: PropTypes.func,
 		recordBulkAction: PropTypes.func,
 		recordChangePage: PropTypes.func,
 		replyComment: PropTypes.func,
@@ -416,6 +417,7 @@ export class CommentList extends Component {
 			isCommentsTreeSupported,
 			isLoading,
 			isPostView,
+			onBack,
 			page,
 			postId,
 			siteBlacklist,
@@ -450,7 +452,7 @@ export class CommentList extends Component {
 				) }
 				{ isCommentsTreeSupported && <QuerySiteCommentsTree siteId={ siteId } status={ status } /> }
 
-				{ isPostView && <CommentListHeader postId={ postId } /> }
+				{ isPostView && <CommentListHeader onBack={ onBack } postId={ postId } /> }
 
 				<CommentNavigation
 					commentsPage={ commentsPage }

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -12,16 +12,16 @@ import { get, isEqual } from 'lodash';
 /**
  * Internal dependencies
  */
+import CommentLink from 'my-sites/comments/comment/comment-link';
 import CommentPostLink from 'my-sites/comments/comment/comment-post-link';
 import Emojify from 'components/emojify';
 import ExternalLink from 'components/external-link';
 import Gravatar from 'components/gravatar';
 import Tooltip from 'components/tooltip';
-import { isEnabled } from 'config';
 import { decodeEntities } from 'lib/formatting';
 import { urlToDomainAndPath } from 'lib/url';
 import { getSiteComment } from 'state/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 export class CommentAuthor extends Component {
 	static propTypes = {
@@ -59,25 +59,14 @@ export class CommentAuthor extends Component {
 			authorAvatarUrl,
 			authorDisplayName,
 			authorUrl,
-			commentDate,
 			commentId,
 			commentType,
-			commentUrl,
 			gravatarUser,
 			isBulkMode,
 			isPostView,
-			moment,
 			translate,
 		} = this.props;
 		const { isLinkTooltipVisible } = this.state;
-
-		const formattedDate = moment( commentDate ).format( 'll LT' );
-
-		const relativeDate = moment()
-			.subtract( 1, 'month' )
-			.isBefore( commentDate )
-			? moment( commentDate ).fromNow()
-			: moment( commentDate ).format( 'll' );
 
 		return (
 			<div className="comment__author">
@@ -115,19 +104,7 @@ export class CommentAuthor extends Component {
 
 					<div className="comment__author-info-element">
 						<span className="comment__date">
-							{ isEnabled( 'comments/management/comment-view' ) ? (
-								<a href={ commentUrl } tabIndex={ isBulkMode ? -1 : 0 } title={ formattedDate }>
-									{ relativeDate }
-								</a>
-							) : (
-								<ExternalLink
-									href={ commentUrl }
-									tabIndex={ isBulkMode ? -1 : 0 }
-									title={ formattedDate }
-								>
-									{ relativeDate }
-								</ExternalLink>
-							) }
+							<CommentLink { ...{ commentId, isBulkMode } } />
 						</span>
 						{ authorUrl && (
 							<span className="comment__author-url">
@@ -146,7 +123,6 @@ export class CommentAuthor extends Component {
 
 const mapStateToProps = ( state, { commentId } ) => {
 	const siteId = getSelectedSiteId( state );
-	const siteSlug = getSelectedSiteSlug( state );
 	const comment = getSiteComment( state, siteId, commentId );
 	const authorAvatarUrl = get( comment, 'author.avatar_URL' );
 	const authorDisplayName = decodeEntities( get( comment, 'author.name' ) );
@@ -157,11 +133,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 		authorDisplayName,
 		authorUrl: get( comment, 'author.URL', '' ),
 		commentContent: get( comment, 'content' ),
-		commentDate: get( comment, 'date' ),
 		commentType: get( comment, 'type', 'comment' ),
-		commentUrl: isEnabled( 'comments/management/comment-view' )
-			? `/comment/${ siteSlug }/${ commentId }`
-			: get( comment, 'URL' ),
 		gravatarUser,
 	};
 };

--- a/client/my-sites/comments/comment/comment-link.jsx
+++ b/client/my-sites/comments/comment/comment-link.jsx
@@ -1,0 +1,93 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import page from 'page';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'components/external-link';
+import { isEnabled } from 'config';
+import { getSiteComment } from 'state/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+
+export class CommentLink extends PureComponent {
+	static propTypes = {
+		commentId: PropTypes.number,
+		isBulkMode: PropTypes.bool,
+	};
+
+	getFormattedDate = () => this.props.moment( this.props.commentDate ).format( 'll LT' );
+
+	getRelativeDate = () => {
+		const { commentDate, moment } = this.props;
+		return moment()
+			.subtract( 1, 'month' )
+			.isBefore( commentDate )
+			? moment( commentDate ).fromNow()
+			: moment( commentDate ).format( 'll' );
+	};
+
+	handleClick = event => {
+		if ( ! window ) {
+			return;
+		}
+		event.preventDefault();
+		window.scrollTo( 0, 0 );
+
+		const { commentId, siteSlug } = this.props;
+		const path = get( window, 'history.state.path' );
+
+		const newPath =
+			-1 !== path.indexOf( '#' )
+				? path.replace( /[#].*/, `#comment-${ commentId }` )
+				: `${ path }#comment-${ commentId }`;
+
+		window.history.replaceState( { ...window.history.state, path: newPath }, null );
+
+		page( `/comment/${ siteSlug }/${ commentId }` );
+	};
+
+	render() {
+		const { commentId, commentUrl, isBulkMode, siteSlug } = this.props;
+
+		return isEnabled( 'comments/management/comment-view' ) ? (
+			<a
+				href={ `/comment/${ siteSlug }/${ commentId }` }
+				onClick={ this.handleClick }
+				tabIndex={ isBulkMode ? -1 : 0 }
+				title={ this.getFormattedDate() }
+			>
+				{ this.getRelativeDate() }
+			</a>
+		) : (
+			<ExternalLink
+				href={ commentUrl }
+				tabIndex={ isBulkMode ? -1 : 0 }
+				title={ this.getFormattedDate() }
+			>
+				{ this.getRelativeDate() }
+			</ExternalLink>
+		);
+	}
+}
+
+const mapStateToProps = ( state, { commentId } ) => {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
+	const comment = getSiteComment( state, siteId, commentId );
+
+	return {
+		commentDate: get( comment, 'date' ),
+		commentUrl: get( comment, 'URL' ),
+		siteSlug,
+	};
+};
+
+export default connect( mapStateToProps )( localize( CommentLink ) );

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -26,21 +26,21 @@ export class CommentPostLink extends PureComponent {
 	};
 
 	handleClick = event => {
+		if ( ! window ) {
+			return;
+		}
 		event.preventDefault();
+		window.scrollTo( 0, 0 );
 
 		const { commentId, postId, siteSlug, status } = this.props;
+		const path = get( window, 'history.state.path' );
 
-		if ( window ) {
-			window.scrollTo( 0, 0 );
-		}
+		const newPath =
+			-1 !== path.indexOf( '#' )
+				? path.replace( /[#].*/, `#comment-${ commentId }` )
+				: `${ path }#comment-${ commentId }`;
 
-		window.history.replaceState(
-			{
-				...window.history.state,
-				path: window.history.state.path.replace( /[#].*/, `#comment-${ commentId }` ),
-			},
-			null
-		);
+		window.history.replaceState( { ...window.history.state, path: newPath }, null );
 
 		page( `/comments/${ status }/${ siteSlug }/${ postId }` );
 	};

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -2,7 +2,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
@@ -17,26 +18,46 @@ import { getSiteComment } from 'state/selectors';
 import { getSitePost } from 'state/posts/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
-const CommentPostLink = ( {
-	isBulkMode,
-	isPostTitleLoaded,
-	postId,
-	postTitle,
-	siteId,
-	siteSlug,
-	status,
-	translate,
-} ) => (
-	<div className="comment__post-link">
-		{ ! isPostTitleLoaded && <QueryPosts siteId={ siteId } postId={ postId } /> }
+export class CommentPostLink extends PureComponent {
+	static propTypes = {
+		commentId: PropTypes.number,
+		isBulkMode: PropTypes.bool,
+	};
 
-		<Gridicon icon={ isBulkMode ? 'chevron-right' : 'posts' } size={ 18 } />
+	handleClick = () => {
+		if ( window ) {
+			window.scrollTo( 0, 0 );
+		}
+	};
 
-		<a href={ `/comments/${ status }/${ siteSlug }/${ postId }` } tabIndex={ isBulkMode ? -1 : 0 }>
-			{ postTitle.trim() || translate( 'Untitled' ) }
-		</a>
-	</div>
-);
+	render() {
+		const {
+			isBulkMode,
+			isPostTitleLoaded,
+			postId,
+			postTitle,
+			siteId,
+			siteSlug,
+			status,
+			translate,
+		} = this.props;
+		return (
+			<div className="comment__post-link">
+				{ ! isPostTitleLoaded && <QueryPosts siteId={ siteId } postId={ postId } /> }
+
+				<Gridicon icon={ isBulkMode ? 'chevron-right' : 'posts' } size={ 18 } />
+
+				<a
+					onClick={ this.handleClick }
+					href={ `/comments/${ status }/${ siteSlug }/${ postId }` }
+					tabIndex={ isBulkMode ? -1 : 0 }
+				>
+					{ postTitle.trim() || translate( 'Untitled' ) }
+				</a>
+			</div>
+		);
+	}
+}
 
 const mapStateToProps = ( state, { commentId } ) => {
 	const siteId = getSelectedSiteId( state );

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -63,8 +63,8 @@ export class CommentPostLink extends PureComponent {
 				<Gridicon icon={ isBulkMode ? 'chevron-right' : 'posts' } size={ 18 } />
 
 				<a
-					onClick={ this.handleClick }
 					href={ `/comments/${ status }/${ siteSlug }/${ postId }` }
+					onClick={ this.handleClick }
 					tabIndex={ isBulkMode ? -1 : 0 }
 				>
 					{ postTitle.trim() || translate( 'Untitled' ) }

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -34,7 +34,13 @@ export class CommentPostLink extends PureComponent {
 			window.scrollTo( 0, 0 );
 		}
 
-		window.history.replaceState( null, null, `#comment-${ commentId }` );
+		window.history.replaceState(
+			{
+				...window.history.state,
+				path: window.history.state.path.replace( /[#].*/, `#comment-${ commentId }` ),
+			},
+			null
+		);
 
 		page( `/comments/${ status }/${ siteSlug }/${ postId }` );
 	};

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import page from 'page';
 import { get } from 'lodash';
 
 /**
@@ -24,10 +25,18 @@ export class CommentPostLink extends PureComponent {
 		isBulkMode: PropTypes.bool,
 	};
 
-	handleClick = () => {
+	handleClick = event => {
+		event.preventDefault();
+
+		const { commentId, postId, siteSlug, status } = this.props;
+
 		if ( window ) {
 			window.scrollTo( 0, 0 );
 		}
+
+		window.history.replaceState( null, null, `#comment-${ commentId }` );
+
+		page( `/comments/${ status }/${ siteSlug }/${ postId }` );
 	};
 
 	render() {

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -24,6 +24,10 @@ import { getMinimumComment } from 'my-sites/comments/comment/utils';
 import { getSiteComment } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
+// Adjust the comment card `offsetTop` to avoid being covered by the masterbar.
+// 56px = 48px (masterbar height) + 8px (comment card vertical margin)
+const COMMENT_SCROLL_TOP_MARGIN = 56;
+
 export class Comment extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,
@@ -70,7 +74,7 @@ export class Comment extends Component {
 			`#comment-${ commentId }` === window.location.hash
 		) {
 			const commentNode = ReactDom.findDOMNode( this.commentCard );
-			const commentOffsetTop = commentNode.offsetTop - 56;
+			const commentOffsetTop = commentNode.offsetTop - COMMENT_SCROLL_TOP_MARGIN;
 			scrollTo( {
 				x: 0,
 				y: commentOffsetTop,

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -71,19 +71,17 @@ export class Comment extends Component {
 		) {
 			const commentNode = ReactDom.findDOMNode( this.commentCard );
 			const commentOffsetTop = commentNode.offsetTop - 56;
-			window.requestAnimationFrame( () =>
-				scrollTo( {
-					x: 0,
-					y: commentOffsetTop,
-					duration: 1,
-					onComplete: () => {
-						if ( commentOffsetTop !== window.scrollY ) {
-							window.scrollTo( 0, commentOffsetTop );
-						}
-						onScrollToComment();
-					},
-				} )
-			);
+			scrollTo( {
+				x: 0,
+				y: commentOffsetTop,
+				duration: 1,
+				onComplete: () => {
+					if ( commentOffsetTop !== window.scrollY ) {
+						window.scrollTo( 0, commentOffsetTop );
+					}
+					onScrollToComment();
+				},
+			} );
 		}
 
 		this.setState( ( { isEditMode, isReplyVisible } ) => ( {

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -29,9 +29,13 @@ export class Comment extends Component {
 		siteId: PropTypes.number,
 		postId: PropTypes.number,
 		commentId: PropTypes.number,
+		hasScrolledToComment: PropTypes.bool,
 		isBulkMode: PropTypes.bool,
+		isLoadedAll: PropTypes.bool,
 		isPostView: PropTypes.bool,
 		isSelected: PropTypes.bool,
+		onCommentLoad: PropTypes.func,
+		onScrollToComment: PropTypes.func,
 		redirect: PropTypes.func,
 		refreshCommentData: PropTypes.bool,
 		toggleSelected: PropTypes.func,
@@ -39,19 +43,29 @@ export class Comment extends Component {
 	};
 
 	state = {
-		hasScrolled: false,
 		isEditMode: false,
 		isReplyVisible: false,
 	};
 
 	componentWillReceiveProps( nextProps ) {
 		const { isBulkMode: wasBulkMode } = this.props;
-		const { commentId, isBulkMode, isLoading } = nextProps;
-		const { hasScrolled } = this.state;
+		const {
+			commentId,
+			hasScrolledToComment,
+			isBulkMode,
+			isLoadedAll,
+			isLoading,
+			onCommentLoad,
+			onScrollToComment,
+		} = nextProps;
+
+		if ( ! isLoading ) {
+			onCommentLoad( commentId );
+		}
 
 		if (
-			! hasScrolled &&
-			! isLoading &&
+			! hasScrolledToComment &&
+			isLoadedAll &&
 			!! window &&
 			`#comment-${ commentId }` === window.location.hash
 		) {
@@ -61,12 +75,12 @@ export class Comment extends Component {
 				scrollTo( {
 					x: 0,
 					y: commentOffsetTop,
-					duration: 300,
+					duration: 1,
 					onComplete: () => {
 						if ( commentOffsetTop !== window.scrollY ) {
 							window.scrollTo( 0, commentOffsetTop );
 						}
-						this.setState( { hasScrolled: true } );
+						onScrollToComment();
 					},
 				} )
 			);

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import ReactDom from 'react-dom';
-import { get, isEqual, isUndefined } from 'lodash';
+import { get, isEqual, isUndefined, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -44,6 +44,10 @@ export class Comment extends Component {
 		refreshCommentData: PropTypes.bool,
 		toggleSelected: PropTypes.func,
 		updateLastUndo: PropTypes.func,
+	};
+
+	static defaultProps = {
+		onCommentLoad: noop,
 	};
 
 	state = {

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -48,6 +48,10 @@ const changePage = path => pageNumber => {
 	return page( addQueryArgs( { page: pageNumber }, path ) );
 };
 
+const handleBackButton = ( context, siteFragment ) => () => {
+	page.back( context.lastRoute || `/comments/all/${ siteFragment }` );
+};
+
 export const siteComments = context => {
 	const { params, path, query } = context;
 	const siteFragment = route.getSiteFragment( path );
@@ -92,6 +96,7 @@ export const postComments = context => {
 	renderWithReduxStore(
 		<CommentsManagement
 			changePage={ changePage( path ) }
+			onBack={ handleBackButton( context, siteFragment ) }
 			page={ pageNumber }
 			postId={ postId }
 			siteFragment={ siteFragment }

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -17,6 +17,8 @@ import CommentView from 'my-sites/comment/main';
 import { removeNotice } from 'state/notices/actions';
 import { getNotices } from 'state/notices/selectors';
 
+let lastRoute = null;
+
 const mapPendingStatusToUnapproved = status => ( 'pending' === status ? 'unapproved' : status );
 
 const sanitizeInt = number => {
@@ -48,8 +50,15 @@ const changePage = path => pageNumber => {
 	return page( addQueryArgs( { page: pageNumber }, path ) );
 };
 
-const handleBackButton = ( context, siteFragment ) => () => {
+const handleBackButton = ( context, siteFragment ) => () =>
 	page.back( context.lastRoute || `/comments/all/${ siteFragment }` );
+
+export const updateLastRoute = ( context, next ) => {
+	if ( lastRoute ) {
+		context.lastRoute = lastRoute;
+	}
+	lastRoute = context.canonicalPath;
+	next();
 };
 
 export const siteComments = context => {

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -132,7 +132,10 @@ export const comment = context => {
 		page.redirect( `/comments/all/${ siteFragment }/${ postId }` );
 
 	renderWithReduxStore(
-		<CommentView { ...{ action, commentId, siteFragment, redirectToPostView } } />,
+		<CommentView
+			{ ...{ action, commentId, siteFragment, redirectToPostView } }
+			onBack={ handleBackButton( context, siteFragment ) }
+		/>,
 		'primary',
 		context.store
 	);

--- a/client/my-sites/comments/index.js
+++ b/client/my-sites/comments/index.js
@@ -8,7 +8,14 @@ import page from 'page';
  * Internal dependencies
  */
 import { siteSelection, navigation, sites } from 'my-sites/controller';
-import { clearCommentNotices, comment, postComments, redirect, siteComments } from './controller';
+import {
+	clearCommentNotices,
+	comment,
+	postComments,
+	redirect,
+	siteComments,
+	updateLastRoute,
+} from './controller';
 import config from 'config';
 
 export default function() {
@@ -22,6 +29,7 @@ export default function() {
 			'/comments/:status(all|pending|approved|spam|trash)/:site',
 			siteSelection,
 			navigation,
+			updateLastRoute,
 			siteComments
 		);
 
@@ -31,13 +39,14 @@ export default function() {
 				'/comments/:status(all|pending|approved|spam|trash)/:site/:post',
 				siteSelection,
 				navigation,
+				updateLastRoute,
 				postComments
 			);
 		}
 
 		// Comment View
 		if ( config.isEnabled( 'comments/management/comment-view' ) ) {
-			page( '/comment/:site/:comment', siteSelection, navigation, comment );
+			page( '/comment/:site/:comment', siteSelection, navigation, updateLastRoute, comment );
 		}
 
 		// Redirect

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -30,6 +30,7 @@ import { infoNotice } from 'state/notices/actions';
 export class CommentsManagement extends Component {
 	static propTypes = {
 		comments: PropTypes.array,
+		onBack: PropTypes.func,
 		page: PropTypes.number,
 		postId: PropTypes.number,
 		showPermissionError: PropTypes.bool,
@@ -54,9 +55,10 @@ export class CommentsManagement extends Component {
 	render() {
 		const {
 			changePage,
-			showJetpackUpdateScreen,
+			onBack,
 			page,
 			postId,
+			showJetpackUpdateScreen,
 			showPermissionError,
 			siteId,
 			siteFragment,
@@ -97,6 +99,7 @@ export class CommentsManagement extends Component {
 					! showPermissionError && (
 						<CommentList
 							changePage={ changePage }
+							onBack={ onBack }
 							order={ 'desc' }
 							page={ page }
 							postId={ postId }


### PR DESCRIPTION
Fix #19972
Partly fix #20300

## The issue

The Comments Management section has 3 different views: the site list, the post list, and the comment list.
While users can load all of these views directly, what happens when I navigate from site to post to comment and then back again?
Currently nothing really: the Back button of both post and comment views are hardcoded to redirect to the site view.
This is clearly not good.

An easy answer would be to simply use the browser's back feature. Though, this would likely mean losing the previous view's scroll position, which is quite important when working with long lists.
Let's keep track of which comment we clicked to open the post view!

## The fix

For conciseness, this PR only touches the site → post → site flow. If this is approved, I'll apply it to the comment view as well (it requires creating a new lengthy-ish component).

So: when we click on the `CommentPostLink`, instead of simply moving to the post view, we perform a bunch of new things:
- First and foremost: we scroll to the top of the page to avoid changing view while staying scrolled down.
- Then we replace the current browser's history state by adding a `#comment-${ commentId }` hash.
- Then we move to the post view.

The post view Back button is now wired up with `page` back function instead of having an arbitrary `href`.
Clicking on it, will in fact go to the previous page, which was modified with the `#comment-${ commentId }` hash.

Upon landing back to the site view, giving an `id="comment-${ commentId }` to the `Comment` elements is unfortunately not enough because of how React renders components.
(I still gave the `id` to the `Comment` elements for likely overkill backward compatibility.)

Instead, we wait for the `Comment` component to be fully loaded and, if we haven't scrolled yet, we obtain its node's `offsetTop` value, and (animate) scroll to that.
If for any reasons this scroll is not quite right, we force another quick scroll, which should be enough.

## Testing instructions

1

- Open `/comments`.
- Click on the post link of a comment "below the fold".
- Click on the `HeaderCake`'s Back button.
- The site view should be scrolled to the previously clicked comment.

2

- Do the same with the browser's Back button: it should have the same behaviour.

3

- Open directly a post view (e.g. `/comments/all/example.wordpress.com/12345`).
- The back button should now redirect to the site view (e.g. `/comments/all/example.wordpress.com`).

4

- Open `/comments`.
- Click on a post link of a comment "below the fold".
- Change list filter (e.g. from Approved to Spam).
- Click on either the `HeaderCake` or browser Back button.
- It should open the previous list filter (e.g. from Spam back to Approved).
- Click Back again.
- It should open the site view scrolled to the previously clicked comment.