### PR TITLE
Post Type List: use short format in PostTime

### DIFF
--- a/client/blocks/post-time/index.jsx
+++ b/client/blocks/post-time/index.jsx
@@ -25,8 +25,8 @@ function getDisplayedTimeFromPost( moment, post ) {
 	const { status, modified, date } = post;
 	const time = moment( includes( [ 'draft', 'pending' ], status ) ? modified : date );
 	if ( time.isBefore( moment().subtract( 7, 'days' ) ) ) {
-		// Like "August 30, 2017 4:46 PM" in English locale
-		return time.format( 'LLL' );
+		// Like "Mar 15, 2013 6:23 PM" in English locale
+		return time.format( 'lll' );
 	}
 
 	// Like "3 days ago" in English locale

--- a/client/blocks/post-time/test/index.jsx
+++ b/client/blocks/post-time/test/index.jsx
@@ -32,7 +32,7 @@ describe( 'PostTime', () => {
 		const wrapper = shallow( <PostTime post={ post } moment={ moment } /> );
 
 		const text = wrapper.text();
-		expect( text ).to.equal( moment( post.modified ).format( 'LLL' ) );
+		expect( text ).to.equal( moment( post.modified ).format( 'lll' ) );
 	} );
 
 	test( 'should use the modified date if the post status is pending', () => {
@@ -45,7 +45,7 @@ describe( 'PostTime', () => {
 		const wrapper = shallow( <PostTime post={ post } moment={ moment } /> );
 
 		const text = wrapper.text();
-		expect( text ).to.equal( moment( post.modified ).format( 'LLL' ) );
+		expect( text ).to.equal( moment( post.modified ).format( 'lll' ) );
 	} );
 
 	test( 'should use the actual date if the post status is not pending/draft', () => {
@@ -58,7 +58,7 @@ describe( 'PostTime', () => {
 		const wrapper = shallow( <PostTime post={ post } moment={ moment } /> );
 
 		const text = wrapper.text();
-		expect( text ).to.equal( moment( post.date ).format( 'LLL' ) );
+		expect( text ).to.equal( moment( post.date ).format( 'lll' ) );
 	} );
 
 	test( 'should use a human-readable approximation for recent dates', () => {


### PR DESCRIPTION
Adjusts the `PostTime` component to abbreviate month names to save space in the condensed post list.

**Before:**
<img width="661" alt="post-time-before" src="https://user-images.githubusercontent.com/942359/33675391-64a5b0ce-da80-11e7-94fd-4ced230a5d8e.png">

**After:**
<img width="661" alt="post-time-after" src="https://user-images.githubusercontent.com/942359/33675406-6d45401e-da80-11e7-8e0b-0744174da0c1.png">

**To test:**
- Use the calypso.live link.
- Set the `CondensedPostList` AB test to the `condensedPosts` variant.
- Make sure that the post date's month is abbreviated.