### PR TITLE
Remove post ID collisions debug code

### DIFF
--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -31,12 +31,12 @@ import {
 	POSTS_REQUEST_SUCCESS,
 	POSTS_REQUEST_FAILURE,
 } from 'state/action-types';
+import { mc } from 'lib/analytics';
 
 /**
  * Module constants
  */
 const debug = debugFactory( 'calypso:posts:actions' );
-const mc = global.document && global.document.documentElement && require( 'lib/analytics' ).mc;
 
 /**
  * Returns an action object to be used in signalling that a post object has
@@ -73,7 +73,7 @@ export function receivePosts( posts ) {
 export function requestSitePosts( siteId, query = {} ) {
 	if ( ! siteId ) {
 		debug( 'requestSitePosts called without siteId', { siteId, query } );
-		mc && mc.bumpStat( 'calypso_missing_site_id', 'requestSitePosts' );
+		mc.bumpStat( 'calypso_missing_site_id', 'requestSitePosts' );
 		return null;
 	}
 

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -31,7 +31,7 @@ import {
 	POSTS_REQUEST_SUCCESS,
 	POSTS_REQUEST_FAILURE,
 } from 'state/action-types';
-import { mc } from 'lib/analytics';
+import { bumpStat } from 'state/analytics/actions';
 
 /**
  * Module constants
@@ -72,9 +72,8 @@ export function receivePosts( posts ) {
  */
 export function requestSitePosts( siteId, query = {} ) {
 	if ( ! siteId ) {
-		debug( 'requestSitePosts called without siteId', { siteId, query } );
-		mc.bumpStat( 'calypso_missing_site_id', 'requestSitePosts' );
-		return null;
+		debug( 'requestSitePosts called with invalid siteId', { siteId, query } );
+		return bumpStat( 'calypso_request_site_posts_error', 'invalid_site_id' );
 	}
 
 	return requestPosts( siteId, query );

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import debugFactory from 'debug';
+
 import { isNumber, toArray } from 'lodash';
 
 /**
@@ -31,12 +31,6 @@ import {
 	POSTS_REQUEST_SUCCESS,
 	POSTS_REQUEST_FAILURE,
 } from 'state/action-types';
-import { bumpStat } from 'state/analytics/actions';
-
-/**
- * Module constants
- */
-const debug = debugFactory( 'calypso:posts:actions' );
 
 /**
  * Returns an action object to be used in signalling that a post object has
@@ -72,8 +66,11 @@ export function receivePosts( posts ) {
  */
 export function requestSitePosts( siteId, query = {} ) {
 	if ( ! siteId ) {
-		debug( 'requestSitePosts called with invalid siteId', { siteId, query } );
-		return bumpStat( 'calypso_request_site_posts_error', 'invalid_site_id' );
+		console.warn( // eslint-disable-line no-console
+			'requestSitePosts called with invalid siteId',
+			{ siteId, query }
+		);
+		return null;
 	}
 
 	return requestPosts( siteId, query );

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -66,10 +66,6 @@ export function receivePosts( posts ) {
  */
 export function requestSitePosts( siteId, query = {} ) {
 	if ( ! siteId ) {
-		console.warn( // eslint-disable-line no-console
-			'requestSitePosts called with invalid siteId',
-			{ siteId, query }
-		);
 		return null;
 	}
 

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import { isNumber, toArray } from 'lodash';
 
 /**

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import debugFactory from 'debug';
+
 import {
 	get,
 	set,
@@ -53,12 +53,6 @@ import {
 	normalizePostForState,
 } from './utils';
 import { itemsSchema, queriesSchema, allSitesQueriesSchema } from './schema';
-import { mc } from 'lib/analytics';
-
-/**
- * Module constants
- */
-const debug = debugFactory( 'calypso:posts:reducer' );
 
 /**
  * Tracks all known post objects, indexed by post global ID.
@@ -165,8 +159,9 @@ export function queryRequests( state = {}, action ) {
 export const queries = ( () => {
 	function applyToManager( state, siteId, method, createDefault, ...args ) {
 		if ( ! siteId ) {
-			debug( 'state.posts.queries#applyToManager called without siteId', { siteId, method, args } );
-			mc.bumpStat( 'calypso_missing_site_id', 'state.posts.queries' );
+			// TODO remove me after testing and before merge
+			// eslint-disable-next-line no-console
+			console.warn( 'applyToManager called without siteId' );
 			return state;
 		}
 

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -53,12 +53,12 @@ import {
 	normalizePostForState,
 } from './utils';
 import { itemsSchema, queriesSchema, allSitesQueriesSchema } from './schema';
+import { mc } from 'lib/analytics';
 
 /**
  * Module constants
  */
 const debug = debugFactory( 'calypso:posts:reducer' );
-const mc = global.document && global.document.documentElement && require( 'lib/analytics' ).mc;
 
 /**
  * Tracks all known post objects, indexed by post global ID.
@@ -166,7 +166,7 @@ export const queries = ( () => {
 	function applyToManager( state, siteId, method, createDefault, ...args ) {
 		if ( ! siteId ) {
 			debug( 'state.posts.queries#applyToManager called without siteId', { siteId, method, args } );
-			mc && mc.bumpStat( 'calypso_missing_site_id', 'state.posts.queries' );
+			mc.bumpStat( 'calypso_missing_site_id', 'state.posts.queries' );
 			return state;
 		}
 

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import {
 	get,
 	set,

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -159,9 +159,6 @@ export function queryRequests( state = {}, action ) {
 export const queries = ( () => {
 	function applyToManager( state, siteId, method, createDefault, ...args ) {
 		if ( ! siteId ) {
-			// TODO remove me after testing and before merge
-			// eslint-disable-next-line no-console
-			console.warn( 'applyToManager called without siteId' );
 			return state;
 		}
 

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import { filter, find, has, get, includes, isEqual, omit, some } from 'lodash';
 import createSelector from 'lib/create-selector';
 import moment from 'moment-timezone';

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -85,9 +85,6 @@ export const getNormalizedPost = createSelector(
  */
 export const getSitePosts = createSelector( ( state, siteId ) => {
 	if ( ! siteId ) {
-		// TODO remove me after testing and before merge
-		// eslint-disable-next-line no-console
-		console.warn( 'getSitePosts called without siteId' );
 		return null;
 	}
 
@@ -109,9 +106,6 @@ export const getSitePosts = createSelector( ( state, siteId ) => {
  */
 export const getSitePost = createSelector( ( state, siteId, postId ) => {
 	if ( ! siteId ) {
-		// TODO remove me after testing and before merge
-		// eslint-disable-next-line no-console
-		console.warn( 'getSitePost called without siteId' );
 		return null;
 	}
 
@@ -309,9 +303,6 @@ export const isRequestingPostsForQueryIgnoringPage = createSelector(
  */
 export function isRequestingSitePost( state, siteId, postId ) {
 	if ( ! siteId ) {
-		// TODO remove me after testing and before merge
-		// eslint-disable-next-line no-console
-		console.warn( 'isRequestingSitePost called without siteId' );
 		return null;
 	}
 

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -24,12 +24,12 @@ import { decodeURIIfValid } from 'lib/url';
 import { getSite } from 'state/sites/selectors';
 import { DEFAULT_POST_QUERY, DEFAULT_NEW_POST_VALUES } from './constants';
 import { addQueryArgs } from 'lib/route';
+import { mc } from 'lib/analytics';
 
 /**
  * Module constants
  */
 const debug = debugFactory( 'calypso:posts:selectors' );
-const mc = global.document && global.document.documentElement && require( 'lib/analytics' ).mc;
 
 /**
  * Returns the PostsQueryManager from the state tree for a given site ID (or
@@ -115,7 +115,7 @@ export const getSitePosts = createSelector( ( state, siteId ) => {
 export const getSitePost = createSelector( ( state, siteId, postId ) => {
 	if ( ! siteId ) {
 		debug( 'getSitePost called without siteId', { siteId, postId } );
-		mc && mc.bumpStat( 'calypso_missing_site_id', 'getSitePost' );
+		mc.bumpStat( 'calypso_missing_site_id', 'getSitePost' );
 		return null;
 	}
 
@@ -314,7 +314,7 @@ export const isRequestingPostsForQueryIgnoringPage = createSelector(
 export function isRequestingSitePost( state, siteId, postId ) {
 	if ( ! siteId ) {
 		debug( 'isRequestingSitePost called without siteId', { siteId, postId } );
-		mc && mc.bumpStat( 'calypso_missing_site_id', 'isRequestingSitePost' );
+		mc.bumpStat( 'calypso_missing_site_id', 'isRequestingSitePost' );
 		return null;
 	}
 

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import debugFactory from 'debug';
+
 import { filter, find, has, get, includes, isEqual, omit, some } from 'lodash';
 import createSelector from 'lib/create-selector';
 import moment from 'moment-timezone';
@@ -24,12 +24,6 @@ import { decodeURIIfValid } from 'lib/url';
 import { getSite } from 'state/sites/selectors';
 import { DEFAULT_POST_QUERY, DEFAULT_NEW_POST_VALUES } from './constants';
 import { addQueryArgs } from 'lib/route';
-import { mc } from 'lib/analytics';
-
-/**
- * Module constants
- */
-const debug = debugFactory( 'calypso:posts:selectors' );
 
 /**
  * Returns the PostsQueryManager from the state tree for a given site ID (or
@@ -91,8 +85,9 @@ export const getNormalizedPost = createSelector(
  */
 export const getSitePosts = createSelector( ( state, siteId ) => {
 	if ( ! siteId ) {
-		debug( 'getSitePosts called without siteId', { siteId } );
-		mc.bumpStat( 'calypso_missing_site_id', 'getSitePosts' );
+		// TODO remove me after testing and before merge
+		// eslint-disable-next-line no-console
+		console.warn( 'getSitePosts called without siteId' );
 		return null;
 	}
 
@@ -114,8 +109,9 @@ export const getSitePosts = createSelector( ( state, siteId ) => {
  */
 export const getSitePost = createSelector( ( state, siteId, postId ) => {
 	if ( ! siteId ) {
-		debug( 'getSitePost called without siteId', { siteId, postId } );
-		mc.bumpStat( 'calypso_missing_site_id', 'getSitePost' );
+		// TODO remove me after testing and before merge
+		// eslint-disable-next-line no-console
+		console.warn( 'getSitePost called without siteId' );
 		return null;
 	}
 
@@ -313,8 +309,9 @@ export const isRequestingPostsForQueryIgnoringPage = createSelector(
  */
 export function isRequestingSitePost( state, siteId, postId ) {
 	if ( ! siteId ) {
-		debug( 'isRequestingSitePost called without siteId', { siteId, postId } );
-		mc.bumpStat( 'calypso_missing_site_id', 'isRequestingSitePost' );
+		// TODO remove me after testing and before merge
+		// eslint-disable-next-line no-console
+		console.warn( 'isRequestingSitePost called without siteId' );
 		return null;
 	}
 


### PR DESCRIPTION
Follow-up to #18998.  Removes debug information left in place after merge to track down any remaining issues.

Wait until at least 2017-12-13 to merge this, and investigate any activity in these mc stats first.