### PR TITLE
StickyPanel: avoid jumpy scrolling by correctly measuring sticky-panel elem height

### DIFF
--- a/client/components/sticky-panel/style.scss
+++ b/client/components/sticky-panel/style.scss
@@ -1,3 +1,9 @@
+.sticky-panel {
+	// Force a new block formatting context to prevent margin collapsing. It's needed for
+	// correct measurement of `.sticky_panel__content` height and setting the spacer height.
+	overflow: hidden;
+}
+
 .sticky-panel__content {
 	position: relative;
 }


### PR DESCRIPTION
Fixes a bug in `StickyPanel` with the following steps to reproduce:
1. Go to `/stats/some.site.blog`
2. Under the chart, there is a "Stats for December 6" header that lets you switch back and forth between time periods. If you scroll down enough, the header becomes a sticky panel on top of the view -- it's always visible.

The buggy behavior is: at the moment when the header switches between sticky and non-sticky mode, there is a visible jump of the content below it. If the height of the viewport is in certain value range, you can trigger a loop where the header switches between sticky and non-sticky and the scroll position jumps up and down. The following GIF tries to capture that, but apparently Droplr doesn't have enough FPS to show it well:
![stats-jumpy-scroll](https://user-images.githubusercontent.com/664258/33676362-dccfeed6-dab5-11e7-8325-0a5b42d369ab.gif)

**Why it happens and how it's fixed:**
When the `sticky-panel` element is being switched to a sticky mode, its content that's inline inside the scrolled content gets replaced with a spacer of a certain height. The real content gets a `position: fixed` style and is displayed outside the flow. The spacer keeps the dimensions of the scrolled content the same and ensures that scrolling is smooth.

However, in some cases, the `sticky-panel` content has margins that don't count into the element height because of [margin collapsing](https://developer.mozilla.org/cs/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing):
<img width="507" alt="sticky-panel-margins" src="https://user-images.githubusercontent.com/664258/33676436-03f7f47c-dab6-11e7-961c-7f8476d943e6.png">
The spacer element doesn't have these margins and it's height is smaller than it should be.

I'm fixing this bug by adding a `overflow: hidden` style to the `.sticky-panel` rule. It forces creating of a new [block formatting context](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context) and that disables the margin collapsing. The spacer element height will be now correct, because it includes the margins.

An even better fix would be to use `display: flow-root`, but that's an experimental property not supported by all browsers.

**How to test:**
- test that scrolling in the stats page is really fixed
- test that other usages of `StickyPanel` (media library, store, ...) are not broken
