### PR TITLE
Post Share: adjust padding to match PostItem

### DIFF
--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -62,6 +62,11 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	padding: 0 16px 16px;
 	@include breakpoint( ">480px" ) {
 		padding: 0 24px 16px;
+
+		//TODO Clean-up after PostTypeList is used for /posts/
+		.post-type-list & {
+			padding: 0 16px 16px;
+		}
 	}
 }
 
@@ -75,6 +80,11 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	margin: 0 16px 16px;
 	@include breakpoint( ">480px" ) {
 		margin: 0 24px 16px;
+
+		//TODO Clean-up after PostTypeList is used for /posts/
+		.post-type-list & {
+			margin: 0 16px 16px;
+		}
 	}
 
 	.post-share__share-button {
@@ -111,9 +121,19 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	margin: 0 16px 16px;
 	@include breakpoint( ">480px" ) {
 		margin: 0 24px 16px;
+
+		//TODO Clean-up after PostTypeList is used for /posts/
+		.post-type-list & {
+			margin: 0 16px 16px;
+		}
 	}
 	@include breakpoint( ">960px" ) {
 		margin: 0 24px 16px 0;
+
+		//TODO Clean-up after PostTypeList is used for /posts/
+		.post-type-list & {
+			margin: 0 16px 16px 0;
+		}
 	}
 }
 
@@ -265,6 +285,11 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	@include breakpoint( ">480px" ) {
 		margin-right: 24px;
 		margin-left: 24px;
+
+		//TODO Clean-up after PostTypeList is used for /posts/
+		.post-type-list & {
+			margin: 6 24px 0;
+		}
 	}
 }
 
@@ -310,6 +335,11 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	@include breakpoint( ">480px" ) {
 		margin-bottom: 1px;
 		padding: 16px 24px;
+
+		//TODO Clean-up after PostTypeList is used for /posts/
+		.post-type-list & {
+			padding: 16px;
+		}
 	}
 
 	&::after {

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -283,6 +283,10 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	}
 }
 
+.post-share__actions-list-upgrade-nudge.has-call-to-action .banner__action {
+	margin-right: 0;
+}
+
 .post-share .post-share__footer-nav {
 	margin: 0;
 	box-shadow: none;


### PR DESCRIPTION
Brings padding of `PostShare` in alignment with `PostItem`.

**Before:** | **After:**
------------ | -------------
<img width="669" alt="share-upgrade-before" src="https://user-images.githubusercontent.com/942359/33679957-24f0039a-da8e-11e7-8a83-e5a35342d203.png"> | <img width="675" alt="share-upgrade-after" src="https://user-images.githubusercontent.com/942359/33679970-2dcfd8be-da8e-11e7-8ebe-73af79795d8b.png">
<img width="670" alt="share-form-before" src="https://user-images.githubusercontent.com/942359/33679984-3499030a-da8e-11e7-9389-6225c8ed9e2a.png"> | <img width="669" alt="share-form-after" src="https://user-images.githubusercontent.com/942359/33679989-39720ebc-da8e-11e7-9267-98a615990fca.png">

**To test:**
- Use the calypso.live link.
- Set the `CondensedPostList` AB test to the `condensedPosts` variant.
- Visit an upgraded site's `/posts/` list.
- Click "share" in the ellipsis popover menu.
- Verify the left/right padding.
- Visit a free site's `/posts/` list,
- Click "share" in the ellipsis popover menu.
- Verify the left/right padding.