### PR TITLE
Update/enable primacy policy on production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -92,6 +92,7 @@
 		"posts/post-type-list": true,
 		"press-this": true,
 		"preview-layout": true,
+		"privacy-policy": true,
 		"publicize-preview": true,
 		"push-notifications": true,
 		"reader": true,


### PR DESCRIPTION
This PR enables the Banner of the privacy policy on production. Let's keep the flag until getting more feedback about its performance.

### Testing
We've been testing this feature in the others environments so now it just matters to enable it.