### PR TITLE
Add rollover effect to checklist task

### DIFF
--- a/client/components/checklist/checklist-task.jsx
+++ b/client/components/checklist/checklist-task.jsx
@@ -92,7 +92,7 @@ export class ChecklistTask extends PureComponent {
 					<ScreenReaderText>
 						{ completed ? translate( 'Mark as uncompleted' ) : translate( 'Mark as completed' ) }
 					</ScreenReaderText>
-					{ completed && <Gridicon icon="checkmark" size={ 18 } /> }
+					{ <Gridicon icon="checkmark" size={ 18 } /> }
 				</span>
 			</Card>
 		);

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -117,6 +117,28 @@
 		border-radius: 16px;
 		background: $white;
 		cursor: pointer;
+
+		.gridicons-checkmark {
+			display: none;
+			fill: $white;
+			position: absolute;
+			top: -1px;
+			left: 1px;
+		}
+
+		&:hover {
+			background: $alert-green;
+			border-color: $alert-green;
+
+			.gridicons-checkmark {
+				display: block;
+			}
+		}
+
+		&:active {
+			background: $blue-medium;
+			border-color: $blue-medium;
+		}
 	}
 
 	&-primary {
@@ -191,17 +213,14 @@
 			font-size: 14px;
 		}
 
+		.gridicons-checkmark {
+			display: block;
+		}
+
 		.checklist__task-description,
 		.checklist__task-duration,
 		.checklist__task-secondary {
 			display: none;
-		}
-
-		.gridicons-checkmark {
-			position: absolute;
-			top: -1px;
-			left: 1px;
-			fill: $white;
 		}
 	}
 

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -206,6 +206,10 @@
 			top: 13px;
 			background: $alert-green;
 			border-color: $alert-green;
+
+			&:hover {
+				cursor: default;
+			}
 		}
 
 		.checklist__task-title {


### PR DESCRIPTION
This PR adds a hover effect to the checklist task to make it clearer to people that they can mark a task complete. 

## Screenshot
![roll-over](https://user-images.githubusercontent.com/6981253/33682698-4d61dc92-da96-11e7-975c-5958f2b87997.gif)

## Testing
* Create a new site
* Visit /checklist/[new-site-url]
* Roll your mouse over the empty circles next to task title.

@taggon can you take a look?