### PR TITLE
Poller: Only fetch on startup if leading is true

### DIFF
--- a/client/lib/data-poller/poller.js
+++ b/client/lib/data-poller/poller.js
@@ -17,7 +17,6 @@ function Poller( dataStore, fetcher, options ) {
 	_id++;
 
 	this.paused = false;
-	this.initialized = false;
 
 	this.startOnFirstChange = this.startOnFirstChange.bind( this );
 	this.stopOnNoChangeListeners = this.stopOnNoChangeListeners.bind( this );
@@ -43,14 +42,6 @@ function Poller( dataStore, fetcher, options ) {
 	if ( this.dataStore.listeners( 'change' ).length > 0 ) {
 		this.start();
 	}
-
-	// Defer setting initialized until stack is cleared
-	setTimeout(
-		function() {
-			this.initialized = true;
-		}.bind( this ),
-		0
-	);
 }
 
 Poller.prototype.start = function() {
@@ -61,7 +52,7 @@ Poller.prototype.start = function() {
 
 	if ( ! this.timer ) {
 		debug( 'Starting poller for %o', this.dataStore );
-		if ( this.leading || this.initialized ) {
+		if ( this.leading ) {
 			fetch();
 		}
 		this.timer = setInterval( fetch, this.interval );


### PR DESCRIPTION
Currently, we also fetch if initialized is true, but that's generally always true given that most usage is through lib/data-poller, which assumes implicit starts via the startOnFirstChange handler.

To test, pull up http://calypso.localhost:3000 with the network panel open. You should see a first request to the `read/following` api and possibly a few requests for more pages, but no requests with both `before` and `after` parameters set. After a minute, you should see another request _with_ before and after params.

Currently you see that request almost immediately after the first request returns.