### PR TITLE
JP Onboarding: Connect Site Title Step to Redux

### DIFF
--- a/client/jetpack-onboarding/index.js
+++ b/client/jetpack-onboarding/index.js
@@ -9,15 +9,17 @@ import { values } from 'lodash';
 /**
  * Internal dependencies
  */
-import { onboarding } from './controller';
 import { JETPACK_ONBOARDING_STEPS } from './constants';
+import { onboarding } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { siteSelection } from '../my-sites/controller';
 
 export default function() {
 	if ( isEnabled( 'jetpack/onboarding' ) ) {
 		const validStepNames = values( JETPACK_ONBOARDING_STEPS );
 		page(
-			`/jetpack/onboarding/:stepName(${ validStepNames.join( '|' ) })?`,
+			`/jetpack/onboarding/:stepName(${ validStepNames.join( '|' ) })?/:site?`,
+			siteSelection,
 			onboarding,
 			makeLayout,
 			clientRender

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -5,6 +5,7 @@
  */
 import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -17,12 +18,20 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
+import QuerySiteSettings from 'components/data/query-site-settings';
+import { saveSiteSettings } from 'state/site-settings/actions';
+import { getSiteSettings } from 'state/site-settings/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 class JetpackOnboardingSiteTitleStep extends React.PureComponent {
-	state = {
-		description: '',
-		title: '',
-	};
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			description: props.siteSettings.blogname,
+			title: props.siteSettings.blogdescription,
+		};
+	}
 
 	setDescription = event => {
 		this.setState( { description: event.target.value } );
@@ -33,7 +42,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { siteId, translate } = this.props;
 		const headerText = translate( "Let's get started." );
 		const subHeaderText = translate(
 			'First up, what would you like to name your site and have as its public description?'
@@ -41,6 +50,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 
 		return (
 			<Fragment>
+				<QuerySiteSettings siteId={ siteId } />
 				<DocumentHead title={ translate( 'Site Title ‹ Jetpack Onboarding' ) } />
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
@@ -75,4 +85,14 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	}
 }
 
-export default localize( JetpackOnboardingSiteTitleStep );
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			siteId,
+			siteSettings: getSiteSettings( state, siteId ),
+		};
+	},
+	{ saveSiteSettings }
+)( localize( JetpackOnboardingSiteTitleStep ) );

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -20,17 +20,22 @@ import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { saveSiteSettings } from 'state/site-settings/actions';
-import { getSiteSettings } from 'state/site-settings/selectors';
+import { getSiteSettings, isRequestingSiteSettings } from 'state/site-settings/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 class JetpackOnboardingSiteTitleStep extends React.PureComponent {
-	constructor( props ) {
-		super( props );
+	state = {
+		description: '',
+		title: '',
+	};
 
-		this.state = {
-			description: props.siteSettings.blogname,
-			title: props.siteSettings.blogdescription,
-		};
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.isRequesting && ! nextProps.isRequesting ) {
+			this.setState( {
+				title: nextProps.siteSettings.blogname,
+				description: nextProps.siteSettings.blogdescription,
+			} );
+		}
 	}
 
 	setDescription = event => {
@@ -42,7 +47,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	};
 
 	render() {
-		const { siteId, translate } = this.props;
+		const { isRequesting, siteId, translate } = this.props;
 		const headerText = translate( "Let's get started." );
 		const subHeaderText = translate(
 			'First up, what would you like to name your site and have as its public description?'
@@ -59,16 +64,18 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 						<FormFieldset>
 							<FormLabel htmlFor="title">{ translate( 'Site Title' ) }</FormLabel>
 							<FormTextInput
+								autoFocus
+								disabled={ isRequesting }
 								id="title"
 								onChange={ this.setTitle }
 								value={ this.state.title }
-								autoFocus
 							/>
 						</FormFieldset>
 
 						<FormFieldset>
 							<FormLabel htmlFor="description">{ translate( 'Site Description' ) }</FormLabel>
 							<FormTextarea
+								disabled={ isRequesting }
 								id="description"
 								onChange={ this.setDescription }
 								value={ this.state.description }
@@ -90,6 +97,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
+			isRequesting: isRequestingSiteSettings( state, siteId ),
 			siteId,
 			siteSettings: getSiteSettings( state, siteId ),
 		};

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -46,6 +46,13 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 		this.setState( { title: event.target.value } );
 	};
 
+	submit = () => {
+		this.props.saveSiteSettings( this.props.siteId, {
+			blogname: this.state.title,
+			blogdescription: this.state.description,
+		} );
+	};
+
 	render() {
 		const { isRequesting, siteId, translate } = this.props;
 		const headerText = translate( "Let's get started." );
@@ -82,7 +89,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 							/>
 						</FormFieldset>
 
-						<Button href={ this.props.getForwardUrl() } primary>
+						<Button href={ this.props.getForwardUrl() } onClick={ this.submit } primary>
 							{ translate( 'Next Step' ) }
 						</Button>
 					</form>


### PR DESCRIPTION
Allow the user to actually set site title and description.

Proposal/RFC. Some notes:
* I've added the site slug explicitly to the route. Even tho we cannot rely on the current `siteSelection`/ `getSelectedSiteId` technique that we employ for _connected_ JP sites in case of unconnected ones, it makes sense to explicitly include the site slug in the route, since a user could have more than one JP sites, and we need to know for which one they're going thru the Onboarding flow.
* This obviously can only work for connected sites as of yet. However, for those, we can use existing selectors and actions from Redux state (`state/site-settings`).
* This means changes are applied immediately upon clicking 'Next Step' (as opposed to e.g. carrying them along and only applying them after the user has finished the JPO flow).
* This has the advantage that the user can navigate back (after navigation is fixed, see testing notes), find the input fields prepopulated with the readily changed values, and can modify them again (e.g. to fix a typo). That's good UX I think.
* This also means we'll have to add logic for the unconnected case. Hopefully we can come up with a generic solution that we can scale to other settings, too. One option would be to extend actions (and selectors/reducers?) to accept not only a site ID (which is a concept inherent to connected sites) but also a site slug, and use whatever auth technique to communicate with the site directly, i.e. bypassing WP.com.

To test:

* Navigate to http://calypso.localhost:3000/jetpack/onboarding/site-title/:site (Note you need to specify a site now!)
* Wait for the form to load. Verify the input fields are prepopulated with the current title and description of the JP site.
* Change title and/or description, click 'Next Step'. Check the site (frontend or wp-admin) and verify that changes have been applied.
* Careful, the 'Back' and 'Skip for now' navigation links don't work right now because of the route change that now includes the site slug!