### PR TITLE
Add/language picker suggested languages

### DIFF
--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { find, includes, map, noop, partial, startsWith } from 'lodash';
+import { find, includes, map, noop, partial, startsWith, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -104,7 +104,7 @@ export class LanguagePickerModal extends PureComponent {
 			// Find the language first by its full code (e.g. en-US), and when it fails
 			// try only the base code (en). Don't add duplicates.
 			const lcLangSlug = langSlug.toLowerCase();
-			let language = find( languages, lang => ( lang.langSlug === lcLangSlug ) );
+			let language = find( languages, lang => lang.langSlug === lcLangSlug );
 
 			if ( ! language ) {
 				language = find( languages, lang => startsWith( lcLangSlug, lang.langSlug + '-' ) );
@@ -117,7 +117,7 @@ export class LanguagePickerModal extends PureComponent {
 		return suggestedLanguages;
 	}
 
-	handleSearch = ( search ) => {
+	handleSearch = search => {
 		this.setState( { search } );
 	};
 
@@ -179,7 +179,8 @@ export class LanguagePickerModal extends PureComponent {
 
 	renderSuggestedLanguages() {
 		const { suggestedLanguages } = this.state;
-		if ( ! suggestedLanguages ) {
+
+		if ( isEmpty( suggestedLanguages ) ) {
 			return null;
 		}
 
@@ -187,7 +188,7 @@ export class LanguagePickerModal extends PureComponent {
 			<div className="language-picker__modal-suggested">
 				<div className="language-picker__modal-suggested-inner">
 					<div className="language-picker__modal-suggested-label">
-						{ this.props.translate( 'Suggested languages: ' ) }
+						{ this.props.translate( 'Suggested languages:' ) }
 					</div>
 					<div className="language-picker__modal-suggested-list">
 						<div className="language-picker__modal-suggested-list-inner">

--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { includes, map, noop, partial } from 'lodash';
+import { find, includes, map, noop, partial, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,15 +19,20 @@ import SectionNavTabs from 'components/section-nav/tabs';
 import SectionNavTabItem from 'components/section-nav/item';
 import Search from 'components/search';
 
-class LanguagePickerModal extends PureComponent {
+export class LanguagePickerModal extends PureComponent {
 	static propTypes = {
 		onSelected: PropTypes.func,
 		onClose: PropTypes.func,
+		isVisible: PropTypes.bool,
+		languages: PropTypes.array.isRequired,
+		selected: PropTypes.string,
 	};
 
 	static defaultProps = {
 		onSelected: noop,
 		onClose: noop,
+		isVisible: false,
+		selected: 'en',
 	};
 
 	constructor( props ) {
@@ -37,6 +42,7 @@ class LanguagePickerModal extends PureComponent {
 			filter: 'popular',
 			search: false,
 			selectedLanguageSlug: this.props.selected,
+			suggestedLanguages: this.getSuggestedLanguages(),
 		};
 	}
 
@@ -44,6 +50,12 @@ class LanguagePickerModal extends PureComponent {
 		if ( nextProps.selected !== this.state.selectedLanguageSlug ) {
 			this.setState( {
 				selectedLanguageSlug: nextProps.selected,
+			} );
+		}
+
+		if ( nextProps.languages !== this.props.languages ) {
+			this.setState( {
+				suggestedLanguages: this.getSuggestedLanguages(),
 			} );
 		}
 	}
@@ -80,7 +92,32 @@ class LanguagePickerModal extends PureComponent {
 		}
 	}
 
-	handleSearch = search => {
+	getSuggestedLanguages() {
+		if ( ! ( typeof navigator === 'object' && 'languages' in navigator ) ) {
+			return null;
+		}
+
+		const { languages } = this.props;
+		const suggestedLanguages = [];
+
+		for ( const langSlug of navigator.languages ) {
+			// Find the language first by its full code (e.g. en-US), and when it fails
+			// try only the base code (en). Don't add duplicates.
+			const lcLangSlug = langSlug.toLowerCase();
+			let language = find( languages, lang => ( lang.langSlug === lcLangSlug ) );
+
+			if ( ! language ) {
+				language = find( languages, lang => startsWith( lcLangSlug, lang.langSlug + '-' ) );
+			}
+			if ( language && ! includes( suggestedLanguages, language ) ) {
+				suggestedLanguages.push( language );
+			}
+		}
+
+		return suggestedLanguages;
+	}
+
+	handleSearch = ( search ) => {
 		this.setState( { search } );
 	};
 
@@ -140,12 +177,32 @@ class LanguagePickerModal extends PureComponent {
 		);
 	};
 
+	renderSuggestedLanguages() {
+		const { suggestedLanguages } = this.state;
+		if ( ! suggestedLanguages ) {
+			return null;
+		}
+
+		return (
+			<div className="language-picker__modal-suggested">
+				<div className="language-picker__modal-suggested-inner">
+					<div className="language-picker__modal-suggested-label">
+						{ this.props.translate( 'Suggested languages: ' ) }
+					</div>
+					<div className="language-picker__modal-suggested-list">
+						<div className="language-picker__modal-suggested-list-inner">
+							{ map( suggestedLanguages, this.renderLanguageItem ) }
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
 	render() {
 		const { isVisible, translate } = this.props;
 
 		if ( ! isVisible ) {
-			// Render nothing at all if the modal is not visible
-			// <Dialog isVisible={ false }> still renders a lot of useless elements
 			return null;
 		}
 
@@ -179,6 +236,7 @@ class LanguagePickerModal extends PureComponent {
 					/>
 				</SectionNav>
 				{ this.renderLanguageList() }
+				{ this.renderSuggestedLanguages() }
 			</Dialog>
 		);
 	}

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -137,30 +137,33 @@
 	}
 }
 
+.language-picker__modal-item {
+	display: inline-block;
+	white-space: nowrap;
+	overflow: hidden;
+}
+
 .language-picker__modal-list {
 	box-sizing: border-box;
 	width: 100%;
 	overflow-y: auto;
 	padding: 8px 16px;
 	flex: auto;
-}
 
-.language-picker__modal-item {
-	display: inline-block;
-	width: 100%;
-	white-space: nowrap;
-	overflow: hidden;
+	.language-picker__modal-item {
+		width: 100%;
 
-	@include breakpoint( ">480px") {
-		width: 50%;
-	}
+		@include breakpoint( ">480px") {
+			width: 50%;
+		}
 
-	@include breakpoint( ">660px" ) {
-		width: 33%;
-	}
+		@include breakpoint( ">660px" ) {
+			width: 33%;
+		}
 
-	@include breakpoint( ">960px" ) {
-		width: 25%;
+		@include breakpoint( ">960px" ) {
+			width: 25%;
+		}
 	}
 }
 
@@ -173,5 +176,39 @@
 	&.is-selected {
 		background: $blue-medium;
 		color: $white;
+	}
+}
+
+.language-picker__modal-suggested {
+	flex: none;
+	background: $gray-light;
+	border-top: 1px solid lighten( $gray, 30% );
+	padding: 8px 16px;
+
+	.language-picker__modal-suggested-inner {
+		display: flex;
+		overflow: hidden;
+	}
+
+	.language-picker__modal-suggested-label {
+		flex: none;
+		padding: 4px 8px;
+		white-space: nowrap;
+	}
+
+	.language-picker__modal-suggested-list {
+		flex: 1 1 0px;
+		height: 0;
+	}
+
+	.language-picker__modal-suggested-list-inner {
+		display: flex;
+		flex-wrap: wrap;
+	}
+
+	.language-picker__modal-item {
+		flex: none;
+		width: auto;
+		margin-left: 16px;
 	}
 }

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -10,9 +10,9 @@
 	height: 64px;
 	align-items: stretch;
 	cursor: pointer;
-	transition: border-color .15s ease-in-out;
+	transition: border-color 150ms ease-in-out;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoint( '<660px' ) {
 		width: 100%;
 	}
 
@@ -30,7 +30,7 @@
 		}
 	}
 
-	&:not([disabled]):hover {
+	&:not( [disabled] ):hover {
 		&,
 		.language-picker__icon {
 			border-color: lighten( $gray, 10% );
@@ -41,7 +41,7 @@
 		.language-picker__icon-inner {
 			width: 30px;
 			height: 30px;
-			animation: pulse-light 0.8s ease-in-out infinite;
+			animation: pulse-light 800ms ease-in-out infinite;
 		}
 
 		.language-picker__name-inner {
@@ -50,6 +50,7 @@
 			background-color: lighten( $gray, 30% );
 		}
 	}
+
 }
 
 .language-picker__icon {
@@ -60,13 +61,13 @@
 	justify-content: center;
 	flex: none;
 	border-right: 1px solid lighten( $gray, 20% );
-	transition: border-color .15s ease-in-out;
+	transition: border-color 150ms ease-in-out;
 }
 
 .language-picker__icon-inner {
 	text-transform: uppercase;
 	font-weight: 700;
-	line-height: 1.0;
+	line-height: 1;
 }
 
 .language-picker__name {
@@ -102,7 +103,7 @@
 		display: flex;
 		flex-direction: column;
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			top: 5%;
 			bottom: 5%;
 			left: 5%;
@@ -110,7 +111,7 @@
 			width: 90%;
 		}
 
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			left: 12.5%;
 			right: 12.5%;
 			width: 75%;
@@ -153,15 +154,15 @@
 	.language-picker__modal-item {
 		width: 100%;
 
-		@include breakpoint( ">480px") {
+		@include breakpoint( '>480px' ) {
 			width: 50%;
 		}
 
-		@include breakpoint( ">660px" ) {
+		@include breakpoint( '>660px' ) {
 			width: 33%;
 		}
 
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			width: 25%;
 		}
 	}
@@ -184,6 +185,20 @@
 	background: $gray-light;
 	border-top: 1px solid lighten( $gray, 30% );
 	padding: 8px 16px;
+	z-index: 1;
+	position: relative;
+
+	&::before {
+		content: '';
+		display: block;
+		position: absolute;
+		bottom: 100%;
+		left: 16px;
+		right: 16px;
+		height: 24px;
+		background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, white 100%);
+		margin-bottom: 1px;
+	}
 
 	.language-picker__modal-suggested-inner {
 		display: flex;
@@ -197,7 +212,7 @@
 	}
 
 	.language-picker__modal-suggested-list {
-		flex: 1 1 0px;
+		flex: 1 1 0;
 		height: 0;
 	}
 

--- a/client/components/language-picker/test/__snapshots__/modal.js.snap
+++ b/client/components/language-picker/test/__snapshots__/modal.js.snap
@@ -1,0 +1,128 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LanguagePickerModal should render 1`] = `
+<Dialog
+  additionalClassNames="language-picker__modal"
+  buttons={
+    Array [
+      Object {
+        "action": "cancel",
+        "label": "Cancel",
+      },
+      Object {
+        "action": "confirm",
+        "isPrimary": true,
+        "label": "Select Language",
+        "onClick": [Function],
+      },
+    ]
+  }
+  isVisible={true}
+  leaveTimeout={200}
+  onClose={[Function]}
+  onClosed={[Function]}
+>
+  <SectionNav
+    allowDropdown={true}
+    onMobileNavPanelOpen={[Function]}
+    selectedText="Popular languages"
+  >
+    <NavTabs
+      hasSiblingControls={false}
+    >
+      <NavItem
+        key="popular"
+        onClick={[Function]}
+        selected={true}
+      >
+        Popular languages
+      </NavItem>
+      <NavItem
+        onClick={[Function]}
+        selected={false}
+      >
+        All languages
+      </NavItem>
+    </NavTabs>
+    <Search
+      autoFocus={false}
+      compact={false}
+      delaySearch={false}
+      delayTimeout={300}
+      disableAutocorrect={false}
+      disabled={false}
+      fitsContainer={true}
+      hideClose={false}
+      hideOpenIcon={false}
+      isOpen={false}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onSearch={[Function]}
+      onSearchChange={[Function]}
+      onSearchClose={[Function]}
+      onSearchOpen={[Function]}
+      pinned={true}
+      placeholder="Search languages…"
+      searching={false}
+    />
+  </SectionNav>
+  <div
+    className="language-picker__modal-list"
+  >
+    <div
+      className="language-picker__modal-item"
+      key="en"
+      onClick={[Function]}
+    >
+      <span
+        className="language-picker__modal-text is-selected"
+      >
+        English
+      </span>
+    </div>
+    <div
+      className="language-picker__modal-item"
+      key="it"
+      onClick={[Function]}
+    >
+      <span
+        className="language-picker__modal-text"
+      >
+        Italiano
+      </span>
+    </div>
+  </div>
+  <div
+    className="language-picker__modal-suggested"
+  >
+    <div
+      className="language-picker__modal-suggested-inner"
+    >
+      <div
+        className="language-picker__modal-suggested-label"
+      >
+        Suggested languages: 
+      </div>
+      <div
+        className="language-picker__modal-suggested-list"
+      >
+        <div
+          className="language-picker__modal-suggested-list-inner"
+        >
+          <div
+            className="language-picker__modal-item"
+            key="en"
+            onClick={[Function]}
+          >
+            <span
+              className="language-picker__modal-text is-selected"
+            >
+              English
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</Dialog>
+`;

--- a/client/components/language-picker/test/__snapshots__/modal.js.snap
+++ b/client/components/language-picker/test/__snapshots__/modal.js.snap
@@ -101,7 +101,7 @@ exports[`LanguagePickerModal should render 1`] = `
       <div
         className="language-picker__modal-suggested-label"
       >
-        Suggested languages: 
+        Suggested languages:
       </div>
       <div
         className="language-picker__modal-suggested-list"

--- a/client/components/language-picker/test/modal.js
+++ b/client/components/language-picker/test/modal.js
@@ -41,6 +41,12 @@ describe( 'LanguagePickerModal', () => {
 				value: 35,
 				wpLocale: 'it_IT',
 			},
+			{
+				langSlug: 'en-gb',
+				name: 'English (UK)',
+				value: 482,
+				wpLocale: 'en_GB',
+			},
 		],
 		selected: 'en',
 		translate: identity,
@@ -53,38 +59,91 @@ describe( 'LanguagePickerModal', () => {
 	} );
 
 	describe( 'suggested languages', () => {
-		const browserLanguages = [ 'en-AU', 'en', 'en-US', 'it' ];
+		const browserLanguages = [ 'en-GB', 'en', 'en-US', 'en-AU', 'it' ];
 		let _navigator;
 
-		beforeAll( () => {
+		beforeEach( () => {
 			_navigator = global.navigator;
 			Object.defineProperty( global.navigator, 'languages', {
 				get: () => browserLanguages,
+				configurable: true,
 			} );
 		} );
 
-		afterAll( () => {
+		afterEach( () => {
 			global.navigator = _navigator;
 		} );
 
-		test( 'should return browser languages that appear in WordPress.com supported languages', () => {
-			const wrapper = shallow( <LanguagePickerModal { ...defaultProps } /> );
-
-			expect( wrapper.instance().getSuggestedLanguages() ).toEqual( [
-				defaultProps.languages[ 0 ],
-				defaultProps.languages[ 2 ],
-			] );
-		} );
-
-		test( 'should render a list of suggested languages', () => {
+		test( 'should render a list of suggested (WordPress.com-supported) languages', () => {
 			const wrapper = shallow( <LanguagePickerModal { ...defaultProps } /> );
 			const suggestedLanguagesTexts = wrapper.find(
 				'.language-picker__modal-suggested-list .language-picker__modal-text'
 			);
 
-			expect( suggestedLanguagesTexts ).toHaveLength( 2 );
-			expect( suggestedLanguagesTexts.at( 0 ).text() ).toEqual( 'English' );
-			expect( suggestedLanguagesTexts.at( 1 ).text() ).toEqual( 'Italiano' );
+			expect( suggestedLanguagesTexts ).toHaveLength( 3 );
+			expect( suggestedLanguagesTexts.at( 0 ).text() ).toEqual( 'English (UK)' );
+			expect( suggestedLanguagesTexts.at( 1 ).text() ).toEqual( 'English' );
+			expect( suggestedLanguagesTexts.at( 2 ).text() ).toEqual( 'Italiano' );
+		} );
+
+		test( 'should not render when there are no suggested languages', () => {
+			Object.defineProperty( global.navigator, 'languages', {
+				get: () => [],
+				configurable: true,
+			} );
+			const wrapper = shallow( <LanguagePickerModal { ...defaultProps } /> );
+
+			expect(
+				wrapper.find( '.language-picker__modal-suggested-list .language-picker__modal-text' )
+			).toHaveLength( 0 );
+		} );
+
+		test( 'getSuggestedLanguages() should return correct, WordPress.com-supported languages from navigator.languages', () => {
+			const wrapper = shallow( <LanguagePickerModal { ...defaultProps } /> );
+
+			[
+				{
+					navigatorLanguages: [ 'en-US' ],
+					expectedSuggestedLanguages: [ defaultProps.languages[ 0 ] ],
+				},
+				// we'll show en-GB because it's a WordPress.com language, and en-US for en-AU because it's a variant of en
+				{
+					navigatorLanguages: [ 'en-GB', 'en-AU' ],
+					expectedSuggestedLanguages: [ defaultProps.languages[ 3 ], defaultProps.languages[ 0 ] ],
+				},
+				{
+					navigatorLanguages: [ 'en' ],
+					expectedSuggestedLanguages: [ defaultProps.languages[ 0 ] ],
+				},
+				{
+					navigatorLanguages: [ 'it' ],
+					expectedSuggestedLanguages: [ defaultProps.languages[ 2 ] ],
+				},
+				{
+					navigatorLanguages: [ 'it', 'en-US' ],
+					expectedSuggestedLanguages: [ defaultProps.languages[ 2 ], defaultProps.languages[ 0 ] ],
+				},
+				{
+					navigatorLanguages: [ 'it', 'en' ],
+					expectedSuggestedLanguages: [ defaultProps.languages[ 2 ], defaultProps.languages[ 0 ] ],
+				},
+				{
+					navigatorLanguages: [ 'cs', 'it', 'en-US' ],
+					expectedSuggestedLanguages: [
+						defaultProps.languages[ 1 ],
+						defaultProps.languages[ 2 ],
+						defaultProps.languages[ 0 ],
+					],
+				},
+			].forEach( item => {
+				Object.defineProperty( global.navigator, 'languages', {
+					get: () => item.navigatorLanguages,
+					configurable: true,
+				} );
+				expect( wrapper.instance().getSuggestedLanguages() ).toEqual(
+					item.expectedSuggestedLanguages
+				);
+			} );
 		} );
 	} );
 } );

--- a/client/components/language-picker/test/modal.js
+++ b/client/components/language-picker/test/modal.js
@@ -1,0 +1,90 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { identity, noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { LanguagePickerModal } from '../modal';
+
+describe( 'LanguagePickerModal', () => {
+	const defaultProps = {
+		onSelected: noop,
+		onClose: noop,
+		isVisible: true,
+		languages: [
+			{
+				langSlug: 'en',
+				name: 'English',
+				popular: 1,
+				value: 1,
+				wpLocale: 'en_US',
+			},
+			{
+				langSlug: 'cs',
+				name: 'Čeština',
+				value: 11,
+				wpLocale: 'cs_CZ',
+			},
+			{
+				langSlug: 'it',
+				name: 'Italiano',
+				popular: 8,
+				value: 35,
+				wpLocale: 'it_IT',
+			},
+		],
+		selected: 'en',
+		translate: identity,
+	};
+
+	test( 'should render', () => {
+		const wrapper = shallow( <LanguagePickerModal { ...defaultProps } /> );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	describe( 'suggested languages', () => {
+		const browserLanguages = [ 'en-AU', 'en', 'en-US', 'it' ];
+		let _navigator;
+
+		beforeAll( () => {
+			_navigator = global.navigator;
+			Object.defineProperty( global.navigator, 'languages', {
+				get: () => browserLanguages,
+			} );
+		} );
+
+		afterAll( () => {
+			global.navigator = _navigator;
+		} );
+
+		test( 'should return browser languages that appear in WordPress.com supported languages', () => {
+			const wrapper = shallow( <LanguagePickerModal { ...defaultProps } /> );
+
+			expect( wrapper.instance().getSuggestedLanguages() ).toEqual( [
+				defaultProps.languages[ 0 ],
+				defaultProps.languages[ 2 ],
+			] );
+		} );
+
+		test( 'should render a list of suggested languages', () => {
+			const wrapper = shallow( <LanguagePickerModal { ...defaultProps } /> );
+			const suggestedLanguagesTexts = wrapper.find(
+				'.language-picker__modal-suggested-list .language-picker__modal-text'
+			);
+
+			expect( suggestedLanguagesTexts ).toHaveLength( 2 );
+			expect( suggestedLanguagesTexts.at( 0 ).text() ).toEqual( 'English' );
+			expect( suggestedLanguagesTexts.at( 1 ).text() ).toEqual( 'Italiano' );
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR is a continuation of @jsnajdr's work in #13493.

I have rebased, added tests, performed a bit more browser testing, and offered my propitiations to the linting demons.

We're presenting a list of suggested languages based the languages a user has defined in his or her browser settings. If the feature is missing from the browser, we don't show the suggested list, for example, Windows/Internet Explorer [does not yet support](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages) `window.navigator.languages`, the property we're relying on for this feature.

![suggested languages](https://user-images.githubusercontent.com/6458278/33702477-dbf00948-db77-11e7-9b13-d59b7ca95b09.gif)

## Testing instructions:

1. In your browser's preferences, add a few languages, making sure they are supported by WordPress.com.
2. Go to `/me/account`

### Expectations
- "Suggested languages" list should reflect the browser preferences correctly
- Selecting a suggested language will also select the corresponding language in the list