### PR TITLE
Build: Cache chown node_modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN        bash /tmp/env-config.sh
 COPY       ./package.json ./npm-shrinkwrap.json /calypso/
 RUN        true \
            && npm install --production \
+           && chown -R nobody node_modules \
            && rm -rf /root/.npm \
            && true
 
@@ -55,7 +56,7 @@ RUN        touch node_modules
 ARG        commit_sha=(unknown)
 RUN        true \
            && CALYPSO_ENV=production COMMIT_SHA=$commit_sha npm run build \
-           && chown -R nobody /calypso \
+           && find . -not -path './node_modules/*' -print0 | xargs -0 chown nobody \
            && true
 
 USER       nobody

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Automattic"
 WORKDIR    /calypso
 
 
+ENV        CONTAINER 'docker'
 ENV        NODE_PATH=/calypso/server:/calypso/client
 
 # Build a "base" layer

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,5 +60,8 @@ RUN        true \
            && find . -not -path './node_modules/*' -print0 | xargs -0 chown nobody \
            && true
 
+# Print files, just for testing
+RUN        find . -not -user nobody | wc -l
+
 USER       nobody
 CMD        NODE_ENV=production node build/bundle.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,5 @@ RUN        true \
            && find . -not -path './node_modules/*' -print0 | xargs -0 chown nobody \
            && true
 
-# Print files, just for testing
-RUN        find . -not -user nobody | wc -l
-
 USER       nobody
 CMD        NODE_ENV=production node build/bundle.js

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -271,7 +271,7 @@ if ( config.isEnabled( 'webpack/persistent-caching' ) ) {
 if ( shouldMinify ) {
 	webpackConfig.plugins.push(
 		new UglifyJsPlugin( {
-			cache: true,
+			cache: 'docker' !== process.env.CONTAINER,
 			parallel: true,
 			uglifyOptions: { ecma: 5 },
 			sourceMap: Boolean( process.env.SOURCEMAP ),


### PR DESCRIPTION
The single most time consuming step in current Docker builds is `chown -R`. This is necessarily one of the final steps, which is especially painful because this layer will almost never be reused from cache.

This PR mitigates the issue with a few changes:

1. Add a `CONTAINER='docker'` environment variable which can be read to differentiate when operating in a container.
1. `chown` `node_modules` early in the build in the same step as `npm install`. This layer can frequently be reused and caches the time-consuming `chown`.
1. Use `find`, `chown` and `xargs` together to avoid repeating `chown` on `node_modules` and only operate on necessary files.

An additional commit is included to demonstrate that files have correctly been changed to `nobody` owner. This must be removed before merge (9dc388a79bb379ad6b55d5f4953a1a32e78f55fe).

My initial testing sees the final `chown` dropping _minutes_ 🎉 

## Testing
1. Use this branch
1. Build docker image: `npm run build-docker`
1. Observe the output of the find command, should be `0` (indicating there are no files not owned by `nobody` as expected).
   ```
   Step 14/16 : RUN        find . -not -user nobody | wc -l
    ---> Running in ccfb5a811916
   0
   ```
1. Make a change to a source file in `client`.
1. Build docker image: `npm run build-docker` (use `time npm run build-docker` if you want to compare build times).
1. Several cached layers should be reused, the first uncached layer should be the build:
   ```
   Step 13/16 : RUN        true            && CALYPSO_ENV=production COMMIT_SHA=$commit_sha npm run build            && find . -not -path './node_modules/*' -print0 | xargs -0 chown nobody            && true
    ---> Running in ccd4758d782b

   > wp-calypso@0.17.0 prebuild /calypso
   > npm run -s install-if-deps-outdated


   > wp-calypso@0.17.0 build /calypso
   > npm run build-css && run-p -s build-devdocs:* build-server build-client-if-prod build-client-if-desktop
   ```
1. Observe the output of the find command, should be `0` (indicating there are no files not owned by `nobody` as expected).
   ```
   Step 14/16 : RUN        find . -not -user nobody | wc -l
    ---> Running in ccfb5a811916
   0
   ```
1. Compare the same process with Docker before these changes. The build appears to hang with no output during the `chown` step. Speed should be significantly better with the changes included.
1. Ensure that the produced images continue to behave as expected: `npm run docker`.
1. Ensure other builds continue to behave as expected, for example with `npm start`.

See https://github.com/Automattic/wp-calypso/pull/19962#issuecomment-349923547
/cc @samouri 