### PR TITLE
Conversations: improve caterpillar label

### DIFF
--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -121,8 +121,8 @@ class ConversationCaterpillarComponent extends React.Component {
 					className="conversation-caterpillar__count"
 					onClick={ this.handleTickle }
 					title={ translate(
-						'View %(count)s more comment for this post',
-						'View %(count)s more comments for this post',
+						'View %(count)s comment for this post',
+						'View %(count)s comments for this post',
 						{
 							count: +commentCount,
 							args: {
@@ -133,7 +133,7 @@ class ConversationCaterpillarComponent extends React.Component {
 				>
 					{ commentCount > 1 &&
 						uniqueAuthorsCount > 1 &&
-						translate( '%(count)d more comments from %(commenterName)s and others', {
+						translate( '%(count)d comments from %(commenterName)s and others', {
 							args: {
 								commenterName: lastAuthorName,
 								count: commentCount,
@@ -141,14 +141,14 @@ class ConversationCaterpillarComponent extends React.Component {
 						} ) }
 					{ commentCount > 1 &&
 						uniqueAuthorsCount === 1 &&
-						translate( '%(count)d more comments from %(commenterName)s', {
+						translate( '%(count)d comments from %(commenterName)s', {
 							args: {
 								commenterName: lastAuthorName,
 								count: commentCount,
 							},
 						} ) }
 					{ commentCount === 1 &&
-						translate( '1 more comment from %(commenterName)s', {
+						translate( '1 comment from %(commenterName)s', {
 							args: {
 								commenterName: lastAuthorName,
 							},

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -87,6 +87,7 @@ class ConversationCaterpillarComponent extends React.Component {
 			filter( uniqueAuthors, 'avatar_URL' ),
 			MAX_GRAVATARS_TO_DISPLAY
 		);
+		const uniqueAuthorsCount = size( uniqueAuthors );
 		const displayedAuthorsCount = size( displayedAuthors );
 		const lastAuthorName = get( last( displayedAuthors ), 'name' );
 		const gravatarSmallScreenThreshold = MAX_GRAVATARS_TO_DISPLAY / 2;
@@ -119,33 +120,39 @@ class ConversationCaterpillarComponent extends React.Component {
 				<button
 					className="conversation-caterpillar__count"
 					onClick={ this.handleTickle }
-					title={
-						commentCount > 1
-							? translate( 'View comments from %(commenterName)s and %(count)d more', {
-									args: {
-										commenterName: lastAuthorName,
-										count: commentCount - 1,
-									},
-								} )
-							: translate( 'View comment from %(commenterName)s', {
-									args: {
-										commenterName: lastAuthorName,
-									},
-								} )
-					}
+					title={ translate(
+						'View %(count)s more comments for this post',
+						'View %(count)s more comment for this post',
+						{
+							count: +commentCount,
+							args: {
+								count: commentCount,
+							},
+						}
+					) }
 				>
-					{ commentCount > 1
-						? translate( '%(commenterName)s and %(count)d more', {
-								args: {
-									commenterName: lastAuthorName,
-									count: commentCount - 1,
-								},
-							} )
-						: translate( '%(commenterName)s commented', {
-								args: {
-									commenterName: lastAuthorName,
-								},
-							} ) }
+					{ commentCount > 1 &&
+						uniqueAuthorsCount > 1 &&
+						translate( '%(count)d more comments from %(commenterName)s and others', {
+							args: {
+								commenterName: lastAuthorName,
+								count: commentCount,
+							},
+						} ) }
+					{ commentCount > 1 &&
+						uniqueAuthorsCount === 1 &&
+						translate( '%(count)d more comments from %(commenterName)s', {
+							args: {
+								commenterName: lastAuthorName,
+								count: commentCount,
+							},
+						} ) }
+					{ commentCount === 1 &&
+						translate( '1 more comment from %(commenterName)s', {
+							args: {
+								commenterName: lastAuthorName,
+							},
+						} ) }
 				</button>
 			</div>
 		);

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -121,8 +121,8 @@ class ConversationCaterpillarComponent extends React.Component {
 					className="conversation-caterpillar__count"
 					onClick={ this.handleTickle }
 					title={ translate(
-						'View %(count)s more comments for this post',
 						'View %(count)s more comment for this post',
+						'View %(count)s more comments for this post',
 						{
 							count: +commentCount,
 							args: {


### PR DESCRIPTION
From a usability point of view, I think there are two problems with the current caterpillar label:
- it implies that there are _x_ more authors to expand, not _x_ more comments
- it does not suggest that you can interact with the caterpillar to expand those comments

I've attempted to address both in this PR. Feedback welcome!

Before:

<img width="277" alt="screen shot 2017-12-07 at 11 18 57" src="https://user-images.githubusercontent.com/17325/33712775-8b4a5de0-db40-11e7-97a7-4ebacf4518fb.png">
<img width="248" alt="screen shot 2017-12-07 at 11 19 06" src="https://user-images.githubusercontent.com/17325/33712777-8b7c3b1c-db40-11e7-970b-024a10fd86c8.png">

After:

<img width="416" alt="screen shot 2017-12-07 at 11 19 29" src="https://user-images.githubusercontent.com/17325/33712786-8fb9505c-db40-11e7-9432-72e5085a982b.png">
<img width="316" alt="screen shot 2017-12-07 at 11 19 18" src="https://user-images.githubusercontent.com/17325/33712785-8f7f16da-db40-11e7-977d-841605dbbf97.png">

### To test

Visit http://calypso.localhost:3000/read/conversations.
