### PR TITLE
Jetpack connect: Refine plans redirect logic

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -71,7 +71,7 @@ class Plans extends Component {
 		if ( this.props.selectedPlan ) {
 			this.selectPlan( this.props.selectedPlan );
 		}
-		if ( this.props.hasPlan || this.props.notJetpack ) {
+		if ( this.props.hasPlan === true || this.props.notJetpack === true ) {
 			this.redirect( CALYPSO_PLANS_PAGE );
 		}
 		if ( ! this.props.canPurchasePlans ) {
@@ -164,7 +164,7 @@ class Plans extends Component {
 		if (
 			this.redirecting ||
 			selectedPlanSlug ||
-			notJetpack ||
+			false !== notJetpack ||
 			! canPurchasePlans ||
 			false !== hasPlan ||
 			false !== isAutomatedTransfer
@@ -226,7 +226,7 @@ export default connect(
 			calypsoStartedConnection: isCalypsoStartedConnection( selectedSiteSlug ),
 			isRtlLayout: isRtl( state ),
 			hasPlan: selectedSite ? isCurrentPlanPaid( state, selectedSite.ID ) : null,
-			notJetpack: ! ( selectedSite && isJetpackSite( state, selectedSite.ID ) ),
+			notJetpack: selectedSite ? ! isJetpackSite( state, selectedSite.ID ) : null,
 		};
 	},
 	{

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -50,7 +50,7 @@ class Plans extends Component {
 	redirecting = false;
 
 	componentDidMount() {
-		this.maybeRedirect( this.props );
+		this.maybeRedirect();
 		if ( ! this.redirecting ) {
 			this.props.recordTracksEvent( 'calypso_jpc_plans_view', {
 				user: this.props.userId,
@@ -71,14 +71,14 @@ class Plans extends Component {
 		if ( this.props.selectedPlan ) {
 			this.selectPlan( this.props.selectedPlan );
 		}
-		if ( this.props.hasPlan === true || this.props.notJetpack === true ) {
+		if ( this.props.hasPlan || this.props.notJetpack ) {
 			this.redirect( CALYPSO_PLANS_PAGE );
 		}
 		if ( ! this.props.canPurchasePlans ) {
 			if ( this.props.isCalypsoStartedConnection ) {
 				this.redirect( CALYPSO_REDIRECTION_PAGE );
 			} else {
-				this.redirectToWpAdmin( this.props );
+				this.redirectToWpAdmin();
 			}
 		}
 	}
@@ -122,7 +122,7 @@ class Plans extends Component {
 		if ( this.props.calypsoStartedConnection ) {
 			this.redirect( CALYPSO_REDIRECTION_PAGE );
 		} else {
-			this.redirectToWpAdmin( this.props );
+			this.redirectToWpAdmin();
 		}
 	}
 

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -58,30 +58,30 @@ class Plans extends Component {
 		}
 	}
 
-	componentWillReceiveProps = nextProps => {
+	componentDidUpdate() {
 		if ( ! this.redirecting ) {
-			this.maybeRedirect( nextProps );
+			this.maybeRedirect();
 		}
-	};
+	}
 
-	maybeRedirect = props => {
-		if ( props.isAutomatedTransfer ) {
-			this.props.goBackToWpAdmin( props.selectedSite.URL + JETPACK_ADMIN_PATH );
+	maybeRedirect() {
+		if ( this.props.isAutomatedTransfer ) {
+			this.props.goBackToWpAdmin( this.props.selectedSite.URL + JETPACK_ADMIN_PATH );
 		}
-		if ( props.selectedPlan ) {
-			this.selectPlan( props.selectedPlan );
+		if ( this.props.selectedPlan ) {
+			this.selectPlan( this.props.selectedPlan );
 		}
-		if ( props.hasPlan || props.notJetpack ) {
+		if ( this.props.hasPlan || this.props.notJetpack ) {
 			this.redirect( CALYPSO_PLANS_PAGE );
 		}
-		if ( ! props.canPurchasePlans ) {
-			if ( props.isCalypsoStartedConnection ) {
+		if ( ! this.props.canPurchasePlans ) {
+			if ( this.props.isCalypsoStartedConnection ) {
 				this.redirect( CALYPSO_REDIRECTION_PAGE );
 			} else {
-				this.redirectToWpAdmin( props );
+				this.redirectToWpAdmin( this.props );
 			}
 		}
-	};
+	}
 
 	handleSkipButtonClick = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_skip_button_click' );
@@ -93,14 +93,14 @@ class Plans extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_help_link_click' );
 	};
 
-	redirectToWpAdmin( props ) {
-		const { redirectAfterAuth } = props;
+	redirectToWpAdmin() {
+		const { redirectAfterAuth } = this.props;
 		if ( redirectAfterAuth ) {
-			props.goBackToWpAdmin( redirectAfterAuth );
+			this.props.goBackToWpAdmin( redirectAfterAuth );
 			this.redirecting = true;
 			this.props.completeFlow();
-		} else if ( props.selectedSite ) {
-			this.props.goBackToWpAdmin( props.selectedSite.URL + JETPACK_ADMIN_PATH );
+		} else if ( this.props.selectedSite ) {
+			this.props.goBackToWpAdmin( this.props.selectedSite.URL + JETPACK_ADMIN_PATH );
 			this.redirecting = true;
 			this.props.completeFlow();
 		}

--- a/client/jetpack-connect/test/lib/plans.js
+++ b/client/jetpack-connect/test/lib/plans.js
@@ -249,6 +249,7 @@ export const DEFAULT_PROPS = {
 	isRequestingPlans: false,
 	isRtlLayout: false,
 	jetpackConnectAuthorize: {},
+	notJetpack: false,
 	recordTracksEvent: noop,
 	redirectingToWpAdmin: false,
 	selectedSite: SELECTED_SITE,

--- a/client/jetpack-connect/test/plans.js
+++ b/client/jetpack-connect/test/plans.js
@@ -68,7 +68,24 @@ describe( 'Plans', () => {
 			selectedSite: { ...SELECTED_SITE, plan: SITE_PLAN_PRO },
 		} );
 
-		expect( redirect.mock.calls.length ).toBe( 1 );
+		expect( redirect.mock.calls ).toHaveLength( 1 );
+
+		wrapper.unmount();
+	} );
+
+	test( 'should redirect if notJetpack', () => {
+		const wrapper = mount(
+			<Plans { ...DEFAULT_PROPS } hasPlan={ null } selectedSite={ null } notJetpack={ null } />
+		);
+
+		const redirect = ( wrapper.instance().redirect = jest.fn() );
+
+		wrapper.setProps( {
+			notJetpack: true,
+			selectedSite: { ...SELECTED_SITE, plan: SITE_PLAN_PRO },
+		} );
+
+		expect( redirect.mock.calls ).toHaveLength( 1 );
 
 		wrapper.unmount();
 	} );
@@ -90,7 +107,7 @@ describe( 'Plans', () => {
 			/>
 		);
 
-		expect( goBackToWpAdmin.mock.calls.length ).toBe( 1 );
+		expect( goBackToWpAdmin.mock.calls ).toHaveLength( 1 );
 
 		wrapper.unmount();
 	} );


### PR DESCRIPTION
This PR does two things. It may help to look at the two individual commits when reviewing.

**1) Use `componentDidUpdate` instead of `componentWillReceiveProps` as the lifecycle method we will trigger redirects from**

This is because `nextProps` were not properly being passed to all subsequent functions, meaning old props were being used. An example of this was redirecting to the calypso plans page without the current site slug.

**2) Tighten the logic for the `notJetpack` prop, giving it a `null` state like other props to signify not yet known**

This allows us to delay any redirect for sites that are not jetpack until the site is fully loaded.

## Testing

* Test the `/jetpack/connect/plans/:site` route with non-jetpack sites and jetpack sites that already have a plan. In particular, clear all local state before hitting the route.

You should be correctly redirected to the calypso /plans page **for that site**. Note that it can take a long time if you have a lot of sites connected. We need to add some kind of placeholder/loading-indicator for this case.

* In addition, the regular connect flow can be tested, both from /jetpack/connect and wp-admin, making sure that the plans page appears allowing you to select a plan.
