### PR TITLE
Jetpack Onboarding: Add site type step tiles

### DIFF
--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -29,17 +29,17 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 
 				<TileGrid>
 					<Tile
-						buttonLabel={ 'Personal site' }
-						description={
+						buttonLabel={ translate( 'Personal site' ) }
+						description={ translate(
 							'To share your ideas, stories, photographs, or creative projects with your followers.'
-						}
+						) }
 						image={ '/calypso/images/illustrations/type-personal.svg' }
 					/>
 					<Tile
-						buttonLabel={ 'Business site' }
-						description={
+						buttonLabel={ translate( 'Business site' ) }
+						description={ translate(
 							'To promote your business, organization, or brand, sell products or services, or connect with your audience.'
-						}
+						) }
 						image={ '/calypso/images/illustrations/type-business.svg' }
 					/>
 				</TileGrid>

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -9,7 +9,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
+import Main from 'components/main';
+import Tile from 'components/tile-grid/tile';
+import TileGrid from 'components/tile-grid';
 
 class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 	render() {
@@ -17,7 +21,30 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'What kind of site do you need? Choose an option below:' );
 
-		return <FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />;
+		return (
+			<Main>
+				<DocumentHead title={ translate( 'Jetpack Onboarding' ) } />
+
+				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+
+				<TileGrid>
+					<Tile
+						buttonLabel={ 'Personal site' }
+						description={
+							'To share your ideas, stories, photographs, or creative projects with your followers.'
+						}
+						image={ '/calypso/images/illustrations/type-personal.svg' }
+					/>
+					<Tile
+						buttonLabel={ 'Business site' }
+						description={
+							'To promote your business, organization, or brand, sell products or services, or connect with your audience.'
+						}
+						image={ '/calypso/images/illustrations/type-business.svg' }
+					/>
+				</TileGrid>
+			</Main>
+		);
 	}
 }
 

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -23,7 +23,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 
 		return (
 			<Main>
-				<DocumentHead title={ translate( 'Jetpack Onboarding' ) } />
+				<DocumentHead title={ translate( 'Site Type ‹ Jetpack Onboarding' ) } />
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 


### PR DESCRIPTION
This PR introduces the UI bits of the Site Type step, using the new `TileGrid` / `Tile` components:

**Desktop**
![](https://cldup.com/oIrNnRO4cL.png)

**Mobile**
![](https://cldup.com/uSvxO__uh8.png)

They're not yet clickable, we'll take care of that in the next iteration when we connect the step to Redux. Just to clarify, this is also the reason why on mobile the tiles don't have a link indicator.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/onboarding/site-type
* Verify the tile grid looks as shown on the preview above (test on desktop and mobile).