### PR TITLE
Jetpack Onboarding: Add homepage step tiles

### DIFF
--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -29,13 +29,15 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 
 				<TileGrid>
 					<Tile
-						buttonLabel={ 'Recent news or updates' }
-						description={ 'We can pull the latest information into your homepage for you.' }
+						buttonLabel={ translate( 'Recent news or updates' ) }
+						description={ translate(
+							'We can pull the latest information into your homepage for you.'
+						) }
 						image={ '/calypso/images/illustrations/homepage-news.svg' }
 					/>
 					<Tile
-						buttonLabel={ 'A static welcome page' }
-						description={ 'Have your homepage stay the same as time goes on.' }
+						buttonLabel={ translate( 'A static welcome page' ) }
+						description={ translate( 'Have your homepage stay the same as time goes on.' ) }
 						image={ '/calypso/images/illustrations/homepage-static.svg' }
 					/>
 				</TileGrid>

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -9,7 +9,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
+import Main from 'components/main';
+import Tile from 'components/tile-grid/tile';
+import TileGrid from 'components/tile-grid';
 
 class JetpackOnboardingHomepageStep extends React.PureComponent {
 	render() {
@@ -17,7 +21,26 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'What should visitors see on your homepage?' );
 
-		return <FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />;
+		return (
+			<Main>
+				<DocumentHead title={ translate( 'Homepage ‹ Jetpack Onboarding' ) } />
+
+				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+
+				<TileGrid>
+					<Tile
+						buttonLabel={ 'Recent news or updates' }
+						description={ 'We can pull the latest information into your homepage for you.' }
+						image={ '/calypso/images/illustrations/homepage-news.svg' }
+					/>
+					<Tile
+						buttonLabel={ 'A static welcome page' }
+						description={ 'Have your homepage stay the same as time goes on.' }
+						image={ '/calypso/images/illustrations/homepage-static.svg' }
+					/>
+				</TileGrid>
+			</Main>
+		);
 	}
 }
 


### PR DESCRIPTION
This PR introduces the UI bits of the Homepage step, using the new `TileGrid` / `Tile` components:

**Desktop**
![](https://cldup.com/UtRMA6Kzv3.png)

**Mobile**
![](https://cldup.com/P6Fiq6IGJe.png)

They're not yet clickable, we'll take care of that in the next iteration when we connect the step to Redux. Just to clarify, this is also the reason why on mobile the tiles don't have a link indicator.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/onboarding/homepage
* Verify the tile grid looks as shown on the preview above (test on desktop and mobile).