### PR TITLE
Jetpack Onboarding: Add contact form step tiles

### DIFF
--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -9,7 +9,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
+import Main from 'components/main';
+import Tile from 'components/tile-grid/tile';
+import TileGrid from 'components/tile-grid';
 
 class JetpackOnboardingContactFormStep extends React.PureComponent {
 	render() {
@@ -17,7 +21,21 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'Would you like to get started with a Contact Us page?' );
 
-		return <FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />;
+		return (
+			<Main>
+				<DocumentHead title={ translate( 'Contact Form ‹ Jetpack Onboarding' ) } />
+
+				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+
+				<TileGrid>
+					<Tile
+						buttonLabel={ 'Add a contact form' }
+						description={ 'Not sure? You can skip this step and add a contact form later.' }
+						image={ '/calypso/images/illustrations/contact-us.svg' }
+					/>
+				</TileGrid>
+			</Main>
+		);
 	}
 }
 

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -29,8 +29,10 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 
 				<TileGrid>
 					<Tile
-						buttonLabel={ 'Add a contact form' }
-						description={ 'Not sure? You can skip this step and add a contact form later.' }
+						buttonLabel={ translate( 'Add a contact form' ) }
+						description={ translate(
+							'Not sure? You can skip this step and add a contact form later.'
+						) }
 						image={ '/calypso/images/illustrations/contact-us.svg' }
 					/>
 				</TileGrid>


### PR DESCRIPTION
This PR introduces the UI bits of the Contact Form step, using the new `TileGrid` / `Tile` components:

**Desktop**
![](https://cldup.com/mu40s-xeGF.png)

**Mobile**
![](https://cldup.com/neYjOqDqqx.png)

Tile is not yet clickable, we'll take care of that in the next iteration when we connect the step to Redux. Just to clarify, this is also the reason why on mobile the tile doesn't have a link indicator.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/onboarding/contact-form
* Verify the tile grid looks as shown on the preview above (test on desktop and mobile).