### PR TITLE
Editor: Cleanup unused is-secondary class

### DIFF
--- a/client/post-editor/editor-drawer-well/index.jsx
+++ b/client/post-editor/editor-drawer-well/index.jsx
@@ -48,9 +48,7 @@ class EditorDrawerWell extends Component {
 						className="editor-drawer-well__placeholder"
 					>
 						{ icon && <Gridicon icon={ icon } className="editor-drawer-well__icon" /> }
-						<span className="editor-drawer-well__button button is-secondary is-compact">
-							{ label }
-						</span>
+						<span className="editor-drawer-well__button button is-compact">{ label }</span>
 					</button>
 				) }
 				{ this.props.customDropZone }

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -214,7 +214,7 @@ class EditorSharingPublicizeOptions extends React.Component {
 						</span>
 					</p>
 					<button
-						className="editor-sharing__jetpack-modules-button button is-secondary"
+						className="editor-sharing__jetpack-modules-button button"
 						onClick={ this.jetpackModulePopup }
 					>
 						{ this.props.translate( 'View Module Settings' ) }


### PR DESCRIPTION
This PR removes all usages of the `is-secondary` class throughout Calypso, as we're not using these classes for anything anymore. 

Seems like we're not using it for anything, so it can be removed without any harm.

To test:
* Checkout this branch.
* Verify we're not using the `is-secondary` class for anything anymore.