### PR TITLE
Jetpack Onboarding: Add initial base form styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -245,6 +245,7 @@
 @import 'devdocs/style';
 @import 'jetpack-connect/style';
 @import 'jetpack-connect/jetpack-new-site/style';
+@import 'jetpack-onboarding/style';
 @import 'layout/guided-tours/style';
 @import 'components/happychat/style';
 @import 'components/happychat/agent-w/style';

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import Main from 'components/main';
 import Wizard from 'components/wizard';
 import {
 	JETPACK_ONBOARDING_COMPONENTS as COMPONENTS,
@@ -29,12 +30,14 @@ class JetpackOnboardingMain extends React.PureComponent {
 		const { stepName, steps } = this.props;
 
 		return (
-			<Wizard
-				basePath="/jetpack/onboarding"
-				components={ COMPONENTS }
-				steps={ steps }
-				stepName={ stepName }
-			/>
+			<Main className="jetpack-onboarding">
+				<Wizard
+					basePath="/jetpack/onboarding"
+					components={ COMPONENTS }
+					steps={ steps }
+					stepName={ stepName }
+				/>
+			</Main>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -21,7 +21,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 		const subHeaderText = translate( 'Would you like to get started with a Contact Us page?' );
 
 		return (
-			<div>
+			<Fragment>
 				<DocumentHead title={ translate( 'Contact Form ‹ Jetpack Onboarding' ) } />
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
@@ -35,7 +35,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 						image={ '/calypso/images/illustrations/contact-us.svg' }
 					/>
 				</TileGrid>
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
  */
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
-import Main from 'components/main';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
 
@@ -22,7 +21,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 		const subHeaderText = translate( 'Would you like to get started with a Contact Us page?' );
 
 		return (
-			<Main>
+			<div>
 				<DocumentHead title={ translate( 'Contact Form ‹ Jetpack Onboarding' ) } />
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
@@ -36,7 +35,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 						image={ '/calypso/images/illustrations/contact-us.svg' }
 					/>
 				</TileGrid>
-			</Main>
+			</div>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
  */
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
-import Main from 'components/main';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
 
@@ -22,7 +21,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 		const subHeaderText = translate( 'What should visitors see on your homepage?' );
 
 		return (
-			<Main>
+			<div>
 				<DocumentHead title={ translate( 'Homepage ‹ Jetpack Onboarding' ) } />
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
@@ -41,7 +40,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 						image={ '/calypso/images/illustrations/homepage-static.svg' }
 					/>
 				</TileGrid>
-			</Main>
+			</div>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -21,7 +21,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 		const subHeaderText = translate( 'What should visitors see on your homepage?' );
 
 		return (
-			<div>
+			<Fragment>
 				<DocumentHead title={ translate( 'Homepage ‹ Jetpack Onboarding' ) } />
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
@@ -40,7 +40,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 						image={ '/calypso/images/illustrations/homepage-static.svg' }
 					/>
 				</TileGrid>
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -40,7 +40,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 		);
 
 		return (
-			<div>
+			<Fragment>
 				<DocumentHead title={ translate( 'Site Title ‹ Jetpack Onboarding' ) } />
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
@@ -65,7 +65,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 						</Button>
 					</form>
 				</Card>
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -17,7 +17,6 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
-import Main from 'components/main';
 
 class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	state = {
@@ -41,11 +40,11 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 		);
 
 		return (
-			<Main>
+			<div>
 				<DocumentHead title={ translate( 'Site Title ‹ Jetpack Onboarding' ) } />
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
-				<Card>
+				<Card className="steps__form">
 					<form>
 						<FormFieldset>
 							<FormLabel htmlFor="title">{ translate( 'Site Title' ) }</FormLabel>
@@ -66,7 +65,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 						</Button>
 					</form>
 				</Card>
-			</Main>
+			</div>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
  */
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
-import Main from 'components/main';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
 
@@ -22,7 +21,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 		const subHeaderText = translate( 'What kind of site do you need? Choose an option below:' );
 
 		return (
-			<Main>
+			<div>
 				<DocumentHead title={ translate( 'Site Type ‹ Jetpack Onboarding' ) } />
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
@@ -43,7 +42,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 						image={ '/calypso/images/illustrations/type-business.svg' }
 					/>
 				</TileGrid>
-			</Main>
+			</div>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -21,7 +21,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 		const subHeaderText = translate( 'What kind of site do you need? Choose an option below:' );
 
 		return (
-			<div>
+			<Fragment>
 				<DocumentHead title={ translate( 'Site Type ‹ Jetpack Onboarding' ) } />
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
@@ -42,7 +42,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 						image={ '/calypso/images/illustrations/type-business.svg' }
 					/>
 				</TileGrid>
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -1,0 +1,15 @@
+.jetpack-onboarding {
+	.steps__form {
+		max-width: 320px;
+
+		.form-textarea {
+			resize: vertical;
+		}
+
+		.button {
+			display: block;
+			text-align: center;
+			width: 100%;
+		}
+	}
+}


### PR DESCRIPTION
This PR is a follow up to #20566: moves the `<Main />` usage from the steps to the main JPO component, and introduces some very basic styles that we can use for narrow cards with forms in the JPO flows.

The style updates consist of:

* Narrowing the form cards to match the design prototypes
* Updating the textareas to resize only vertically
* Updating the form buttons to take the entire horizontal space.

Currently, we have built only the Site Title step, so updates can be demonstrated there:

Before:
![](https://cldup.com/A0Xq-BseLx.png)

After:
![](https://cldup.com/2FjVXaf1C9.png)

To test:
* Checkout this branch.
* Go to http://calypso.localhost:3000/jetpack/onboarding/site-title
* Verify it looks as shown on the "After" preview.