### PR TITLE
Jetpack Onboarding: Add WooCommerce step basic UI

### DIFF
--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import FormattedHeader from 'components/formatted-header';
-import Main from 'components/main';
 
 class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 	render() {
@@ -22,14 +21,14 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 		);
 
 		return (
-			<Main>
+			<Fragment>
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<div className="steps__button-group">
 					<Button primary>{ translate( 'Yes, I am' ) }</Button>
 					<Button>{ translate( 'Not right now' ) }</Button>
 				</div>
-			</Main>
+			</Fragment>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -9,7 +9,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import FormattedHeader from 'components/formatted-header';
+import Main from 'components/main';
 
 class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 	render() {
@@ -19,7 +21,16 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 			"We'll set you up with WooCommerce for all of your online selling needs."
 		);
 
-		return <FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />;
+		return (
+			<Main>
+				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+
+				<div className="steps__button-group">
+					<Button primary>{ translate( 'Yes, I am' ) }</Button>
+					<Button>{ translate( 'Not right now' ) }</Button>
+				</div>
+			</Main>
+		);
 	}
 }
 

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -12,4 +12,12 @@
 			width: 100%;
 		}
 	}
+
+	.steps__button-group {
+		text-align: center;
+
+		.button {
+			margin: 0 8px 20px;
+		}
+	}
 }


### PR DESCRIPTION
This PR introduces the UI bits of the WooCommerce step:

**Desktop**
![](https://cldup.com/012pyp1b5r.png)

**Mobile**
![](https://cldup.com/D-k1EEP90f.png)

They're not yet clickable, we'll take care of that in the next iteration when we connect the step to Redux. 

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/onboarding/woocommerce
* Verify the page looks as shown on the preview above (test on desktop and mobile).