### PR TITLE
Reader: remove feature flag for reader/following-manage-refresh

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -143,7 +143,6 @@
 		"reader": true,
 		"reader/conversations": true,
 		"reader/following-intro": true,
-		"reader/following-manage-refresh": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,
 		"reader/nesting-arrow": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -93,7 +93,6 @@
 		"reader": true,
 		"reader/conversations": false,
 		"reader/following-intro": true,
-		"reader/following-manage-refresh": true,
 		"reader/nesting-arrow": true,
 		"reader/related-posts": true,
 		"reader/search": true,

--- a/config/production.json
+++ b/config/production.json
@@ -99,7 +99,6 @@
 		"reader": true,
 		"reader/conversations": false,
 		"reader/following-intro": true,
-		"reader/following-manage-refresh": true,
 		"reader/full-errors": false,
 		"reader/nesting-arrow": true,
 		"reader/tags-with-elasticsearch": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -102,7 +102,6 @@
 		"reader": true,
 		"reader/conversations": true,
 		"reader/following-intro": true,
-		"reader/following-manage-refresh": true,
 		"reader/full-errors": true,
 		"reader/nesting-arrow": true,
 		"reader/recommendations/posts": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -109,7 +109,6 @@
 		"reader/conversations": true,
 		"reader/following-intro": true,
 		"reader/full-errors": true,
-		"reader/following-manage-refresh": true,
 		"reader/nesting-arrow": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,


### PR DESCRIPTION
Removed redundant feature flag `reader/following-manage-refresh`.

### To test

Ensure http://calypso.localhost:3000/following/manage still works.