### PR TITLE
Jetpack Connect: Move SSO cookie read/write into utils module

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -5,7 +5,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import addQueryArgs from 'lib/route/add-query-args';
-import cookie from 'cookie';
 import debugModule from 'debug';
 import Gridicon from 'gridicons';
 import page from 'page';
@@ -36,11 +35,11 @@ import userUtilities from 'lib/user/utils';
 import { decodeEntities } from 'lib/formatting';
 import { externalRedirect } from 'lib/route/path';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { isCalypsoStartedConnection, isSsoApproved } from './persistence-utils';
 import { isRequestingSite, isRequestingSites } from 'state/sites/selectors';
 import { login } from 'lib/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
-import { isCalypsoStartedConnection } from './persistence-utils';
 import {
 	authorize as authorizeAction,
 	goBackToWpAdmin as goBackToWpAdminAction,
@@ -202,11 +201,7 @@ export class LoggedInForm extends Component {
 	 * @return {boolean}                       True if it's a valid SSO request otherwise false
 	 */
 	isSso( { from, queryDataSiteId } = this.props ) {
-		const cookies = cookie.parse( document.cookie );
-		const jetpack_sso_approved = cookies.jetpack_sso_approved
-			? parseInt( cookies.jetpack_sso_approved, 10 )
-			: null;
-		return 'sso' === from && !! queryDataSiteId && queryDataSiteId === jetpack_sso_approved;
+		return 'sso' === from && isSsoApproved( queryDataSiteId );
 	}
 
 	isWoo( { from } = this.props ) {

--- a/client/jetpack-connect/persistence-utils.js
+++ b/client/jetpack-connect/persistence-utils.js
@@ -43,3 +43,16 @@ export const isCalypsoStartedConnection = siteSlug => {
 	const cookies = cookie.parse( document.cookie );
 	return cookies.jetpack_connect_session_url === urlToSlug( siteSlug );
 };
+
+export const persistSsoApproved = siteId => {
+	const options = {
+		maxAge: 300,
+		path: '/',
+	};
+	document.cookie = cookie.serialize( 'jetpack_sso_approved', siteId, options );
+};
+
+export const isSsoApproved = siteId => {
+	const cookies = cookie.parse( document.cookie );
+	return siteId === parseInt( cookies.jetpack_sso_approved, 10 );
+};

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import cookie from 'cookie';
 import debugModule from 'debug';
 import Gridicon from 'gridicons';
 import React, { Component } from 'react';
@@ -38,6 +37,7 @@ import SitePlaceholder from 'blocks/site/placeholder';
 import { decodeEntities } from 'lib/formatting';
 import { getSSO } from 'state/jetpack-connect/selectors';
 import { login } from 'lib/paths';
+import { persistSsoApproved } from './persistence-utils';
 import { validateSSONonce, authorizeSSO } from 'state/jetpack-connect/actions';
 
 /*
@@ -76,11 +76,8 @@ class JetpackSsoForm extends Component {
 
 		const { siteId, ssoNonce } = this.props;
 		const siteUrl = get( this.props, 'blogDetails.URL' );
-		const cookieOptions = {
-			maxAge: 300,
-			path: '/',
-		};
-		document.cookie = cookie.serialize( 'jetpack_sso_approved', siteId, cookieOptions );
+
+		persistSsoApproved( siteId );
 
 		debug( 'Approving sso' );
 		this.props.authorizeSSO( siteId, ssoNonce, siteUrl );


### PR DESCRIPTION
No functional or visual differences.

Separates persistence concerns from SSO logic.

## Testing

* Test as per #11119. You can keep an eye on the `jetpack_sso_approved` cookie value in Chrome's _Application_ tab.
* [Unit tests](https://github.com/Automattic/wp-calypso/blob/master/client/jetpack-connect/test/auth-logged-in-form.js)
