### PR TITLE
PostTypeList: Increase pixel threshold before next page of posts is loaded

### DIFF
--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -33,9 +33,6 @@ import UpgradeNudge from 'my-sites/upgrade-nudge';
 /**
  * Constants
  */
-// When this many pixels or less are below the viewport, begin loading the next
-// page of items.
-const LOAD_NEXT_PAGE_THRESHOLD_PIXELS = 400;
 // The maximum number of pages of results that can be displayed in "All My
 // Sites" (API endpoint limitation).
 const MAX_ALL_SITES_PAGES = 10;
@@ -154,11 +151,14 @@ class PostTypeList extends Component {
 		const scrollTop = this.getScrollTop();
 		const { scrollHeight, clientHeight } = scrollContainer;
 		const pixelsBelowViewport = scrollHeight - scrollTop - clientHeight;
+		// When the currently loaded list has this many pixels or less
+		// remaining below the viewport, begin loading the next page of items.
+		const thresholdPixels = Math.max( clientHeight, 400 );
 		if (
 			typeof scrollTop !== 'number' ||
 			typeof scrollHeight !== 'number' ||
 			typeof clientHeight !== 'number' ||
-			pixelsBelowViewport > LOAD_NEXT_PAGE_THRESHOLD_PIXELS
+			pixelsBelowViewport > thresholdPixels
 		) {
 			return;
 		}


### PR DESCRIPTION
To try to improve scrolling performance in the `PostTypeList` during infinite scroll, let's load the next page of posts sooner as the user scrolls through the list.  Further performance improvements in this area are also ongoing (see https://github.com/Automattic/wp-calypso/pull/20560 for example).

Previously, we would begin loading the next page of items when the currently loaded list has 400 pixels of content (or less) remaining below the viewport.  I played around with a few different values, and it seems to work well to load the next page when there is one full viewport's worth of content (or less) remaining below the screen.  It makes sense for this threshold to be based on the viewport height, and that value is already available for us to use.

We should also keep the previous value of 400 as a minimum threshold for very short viewports.