### PR TITLE
Conversations: fix intro box overflow in IE

### DIFF
--- a/client/reader/conversations/style.scss
+++ b/client/reader/conversations/style.scss
@@ -36,7 +36,7 @@
 
 	.conversations__intro-copy {
 		display: flex;
-		flex: 1 1 0;
+		flex: 1 1 auto;
 		flex-direction: column;
 		font-size: 16px;
 		justify-content: center;

--- a/client/reader/conversations/style.scss
+++ b/client/reader/conversations/style.scss
@@ -42,10 +42,10 @@
 		justify-content: center;
 		margin-left: 24px;
 		padding: 10px 0;
+		width: 100%;
 	}
 
 	.conversations__intro-copy-hidden {
-
 		@include breakpoint( "<660px" ) {
 			display: none;
 			visibility: hidden;


### PR DESCRIPTION
Similar to https://github.com/Automattic/wp-calypso/pull/20384.

Before: 

<img width="1392" alt="screen shot 2017-12-07 at 16 46 33" src="https://user-images.githubusercontent.com/17325/33727642-8957fa9e-db70-11e7-992a-3782e36082d7.png">

After:

<img width="1392" alt="screen shot 2017-12-07 at 17 11 12" src="https://user-images.githubusercontent.com/17325/33728436-4a8bb2cc-db72-11e7-8268-a657522244ac.png">


