### PR TITLE
Store: Merge duplicate imports from `state/selectors`

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -13,11 +13,14 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { canCurrentUser } from 'state/selectors';
+import {
+	canCurrentUser,
+	isSiteAutomatedTransfer,
+	hasSitePendingAutomatedTransfer,
+} from 'state/selectors';
 import config from 'config';
 import DocumentHead from 'components/data/document-head';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isSiteAutomatedTransfer, hasSitePendingAutomatedTransfer } from 'state/selectors';
 import route from 'lib/route';
 
 class App extends Component {


### PR DESCRIPTION
Somehow we ended up with two imports from `state/selectors` in `app/index.js`; this PR merges the two. There should be no functionality change, though this does touch the AT detection so a good test would be to run through the signup flow again.