### PR TITLE
State: Update profile links items reducer to default to null

### DIFF
--- a/client/state/profile-links/reducer.js
+++ b/client/state/profile-links/reducer.js
@@ -20,7 +20,7 @@ import {
 	USER_PROFILE_LINKS_RESET_ERRORS,
 } from 'state/action-types';
 
-export const items = createReducer( [], {
+export const items = createReducer( null, {
 	[ USER_PROFILE_LINKS_RECEIVE ]: ( state, { profileLinks } ) => profileLinks,
 	[ USER_PROFILE_LINKS_DELETE_SUCCESS ]: ( state, { linkSlug } ) =>
 		reject( state, { link_slug: linkSlug } ),

--- a/client/state/profile-links/test/reducer.js
+++ b/client/state/profile-links/test/reducer.js
@@ -35,8 +35,17 @@ describe( 'reducer', () => {
 	];
 
 	describe( 'items', () => {
-		test( 'should default to an empty array', () => {
+		test( 'should default to null', () => {
 			const state = items( undefined, {} );
+			expect( state ).toBeNull();
+		} );
+
+		test( 'should set profile links to empty array when user has no profile links', () => {
+			const state = items( undefined, {
+				type: USER_PROFILE_LINKS_RECEIVE,
+				profileLinks: [],
+			} );
+
 			expect( state ).toEqual( [] );
 		} );
 


### PR DESCRIPTION
This PR updates the profile links items reducer to default to `null` instead of empty array. This will allow to differentiate between "no profile links" and "profile links have not been loaded yet".

Part of #20241.

To test:
* Checkout this branch
* Verify all user profile links still tests pass:

```
npm run test-client client/state/profile-links
```