### PR TITLE
State: Introduce getProfileLinks selector

### DIFF
--- a/client/state/selectors/get-profile-links.js
+++ b/client/state/selectors/get-profile-links.js
@@ -4,7 +4,7 @@
  * Returns all profile links of the current user.
  *
  * @param {Object}  state  Global state tree
- * @return {Object}        Profile links
+ * @return {?Array}        Profile links
  */
 export default function getProfileLinks( state ) {
 	return state.profileLinks.items;

--- a/client/state/selectors/get-profile-links.js
+++ b/client/state/selectors/get-profile-links.js
@@ -1,0 +1,11 @@
+/** @format */
+
+/**
+ * Returns all profile links of the current user.
+ *
+ * @param {Object}  state  Global state tree
+ * @return {Object}        Profile links
+ */
+export default function getProfileLinks( state ) {
+	return state.profileLinks.items;
+}

--- a/client/state/selectors/test/get-profile-links.js
+++ b/client/state/selectors/test/get-profile-links.js
@@ -1,0 +1,48 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getProfileLinks } from 'state/selectors';
+
+describe( 'getProfileLinks()', () => {
+	const profileLinks = [
+		{
+			link_slug: 'wordpress-org',
+			title: 'WordPress.org',
+			value: 'https://wordpress.org/',
+		},
+		{
+			link_slug: 'wordpress-com',
+			title: 'WordPress.com',
+			value: 'https://wordpress.com/',
+		},
+	];
+
+	test( 'should return null if profile links have not been received yet', () => {
+		const state = {
+			profileLinks: {
+				items: null,
+			},
+		};
+		expect( getProfileLinks( state ) ).toEqual( null );
+	} );
+
+	test( 'should return empty array if current user has no profile links', () => {
+		const state = {
+			profileLinks: {
+				items: [],
+			},
+		};
+		expect( getProfileLinks( state ) ).toEqual( [] );
+	} );
+
+	test( 'should return the profile links of the current user', () => {
+		const state = {
+			profileLinks: {
+				items: profileLinks,
+			},
+		};
+		expect( getProfileLinks( state ) ).toEqual( profileLinks );
+	} );
+} );


### PR DESCRIPTION
This PR introduces a `getProfileLinks` selector, which will return all profile links of the current user. 

Contains #20609, which improves the profile links items reducer default state. 

Part of #20241.

To test:
* Checkout this branch
* Verify the tests pass:

```
npm run test-client client/state/selectors/test/get-profile-links.js
```