### PR TITLE
Webpack Build: allow for explicitly setting js minifcation to true or…

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,9 @@ const config = require( './server/config' );
 const calypsoEnv = config( 'env_id' );
 const bundleEnv = config( 'env' );
 const isDevelopment = bundleEnv === 'development';
+const shouldMinify = process.env.hasOwnProperty( 'MINIFY_JS' )
+	? process.env.MINIFY_JS
+	: ! isDevelopment;
 
 /**
  * This function scans the /client/extensions directory in order to generate a map that looks like this:
@@ -248,7 +251,7 @@ if ( config.isEnabled( 'webpack/persistent-caching' ) ) {
 	);
 }
 
-if ( ! isDevelopment ) {
+if ( shouldMinify ) {
 	webpackConfig.devtool = 'cheap-module-source-map';
 	webpackConfig.plugins.push(
 		new UglifyJsPlugin( {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,7 @@ const calypsoEnv = config( 'env_id' );
 const bundleEnv = config( 'env' );
 const isDevelopment = bundleEnv === 'development';
 const shouldMinify = process.env.hasOwnProperty( 'MINIFY_JS' )
-	? process.env.MINIFY_JS
+	? process.env.MINIFY_JS === 'true'
 	: ! isDevelopment;
 
 /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -252,7 +252,6 @@ if ( config.isEnabled( 'webpack/persistent-caching' ) ) {
 }
 
 if ( shouldMinify ) {
-	webpackConfig.devtool = 'cheap-module-source-map';
 	webpackConfig.plugins.push(
 		new UglifyJsPlugin( {
 			cache: true,


### PR DESCRIPTION
This PR introduces a new env variable `MINIFY_JS`.  
When present, the flag will determine whether or not webpack minifies the bundles.
When absent, minify everywhere except development.

This PR is necessary because it looks like our wp-desktop circle ci containers don't have enough ram: https://github.com/Automattic/wp-calypso/pull/19918

