### PR TITLE
Store AddressView: Update empty display, fix issue saving default state/country

### DIFF
--- a/client/extensions/woocommerce/app/order/order-customer/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-customer/dialog.js
@@ -4,6 +4,8 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 import emailValidator from 'email-validator';
 import { get, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -12,8 +14,13 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import AddressView from 'woocommerce/components/address-view';
+import {
+	areSettingsGeneralLoaded,
+	getStoreLocation,
+} from 'woocommerce/state/sites/settings/general/selectors';
 import Button from 'components/button';
 import Dialog from 'components/dialog';
+import { fetchSettingsGeneral } from 'woocommerce/state/sites/settings/general/actions';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormInputValidation from 'components/forms/form-input-validation';
@@ -70,6 +77,16 @@ class CustomerAddressDialog extends Component {
 		this.initializeState();
 	}
 
+	componentWillMount() {
+		this.fetchData( this.props );
+	}
+
+	componentWillReceiveProps( newProps ) {
+		if ( newProps.siteId !== this.props.siteId ) {
+			this.fetchData( newProps );
+		}
+	}
+
 	componentDidUpdate( prevProps ) {
 		// Modal was just opened
 		if ( this.props.isVisible && ! prevProps.isVisible ) {
@@ -78,12 +95,27 @@ class CustomerAddressDialog extends Component {
 	}
 
 	initializeState = () => {
-		const { address = {} } = this.props;
+		const { address = {}, defaultCountry, defaultState } = this.props;
+		if ( ! address.country ) {
+			address.country = defaultCountry;
+		}
+		if ( ! address.state ) {
+			address.state = defaultState;
+		}
 		this.setState( {
 			address,
-			phoneCountry: address.country || 'US',
+			phoneCountry: address.country || defaultCountry,
 			emailValidMessage: false,
 		} );
+	};
+
+	fetchData = ( { siteId, areSettingsLoaded } ) => {
+		if ( ! siteId ) {
+			return;
+		}
+		if ( ! areSettingsLoaded ) {
+			this.props.fetchSettingsGeneral( siteId );
+		}
 	};
 
 	updateAddress = () => {
@@ -242,4 +274,16 @@ class CustomerAddressDialog extends Component {
 	}
 }
 
-export default localize( CustomerAddressDialog );
+export default connect(
+	state => {
+		const address = getStoreLocation( state );
+		const areSettingsLoaded = areSettingsGeneralLoaded( state );
+
+		return {
+			areSettingsLoaded,
+			defaultCountry: address.country,
+			defaultState: address.state,
+		};
+	},
+	dispatch => bindActionCreators( { fetchSettingsGeneral }, dispatch )
+)( localize( CustomerAddressDialog ) );

--- a/client/extensions/woocommerce/app/order/order-customer/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-customer/dialog.js
@@ -145,12 +145,13 @@ class CustomerAddressDialog extends Component {
 		}
 		this.setState( prevState => {
 			const { address } = prevState;
-			const newState = { ...address, [ name ]: value };
-			// If country changed, we should also reset the state
+			const newState = { address: { ...address, [ name ]: value } };
+			// If country changed, we should also reset the state & phoneCountry
 			if ( 'country' === name ) {
-				newState.state = '';
+				newState.address.state = '';
+				newState.phoneCountry = value;
 			}
-			return { address: newState };
+			return newState;
 		} );
 	};
 

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -4,10 +4,10 @@
  * External dependencies
  */
 
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { find, isEmpty, trim } from 'lodash';
+import { every, find, isEmpty, trim } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 
@@ -190,22 +190,45 @@ class AddressView extends Component {
 		);
 	};
 
-	renderStatic = () => {
-		const { name, street, street2, city, state, postcode, country } = this.props.address;
+	renderStreetAddress = ( { street, street2 } ) => {
+		if ( ! street && ! street2 ) {
+			return null;
+		}
+		return (
+			<Fragment>
+				<p>{ street }</p>
+				{ street2 && <p>{ street2 }</p> }
+			</Fragment>
+		);
+	};
 
+	renderCityAddress = ( { city, state, postcode } ) => {
+		if ( ! city && ! state && ! postcode ) {
+			return null;
+		}
+		return (
+			<p>
+				{ city && <span className="address-view__city">{ city }, </span> }
+				{ state && <span className="address-view__state">{ state } &nbsp;</span> }
+				{ postcode && <span className="address-view__postcode">{ postcode }</span> }
+			</p>
+		);
+	};
+
+	renderStatic = () => {
+		if ( every( this.props.address, isEmpty ) ) {
+			return null;
+		}
+
+		const { name, country } = this.props.address;
 		const countryData = find( getCountries(), { code: country } );
 
 		return (
 			<div className="address-view__fields-static">
-				<p className="address-view__address-name">{ name }</p>
-				<p>{ street }</p>
-				{ street2 && <p>{ street2 }</p> }
-				<p>
-					{ city && <span className="address-view__city">{ city }</span> }
-					, { state && <span className="address-view__state">{ state }</span> }
-					&nbsp; { postcode && <span className="address-view__postcode">{ postcode }</span> }
-				</p>
-				<p>{ countryData ? countryData.name : country }</p>
+				{ name && <p className="address-view__address-name">{ name }</p> }
+				{ this.renderStreetAddress( this.props.address ) }
+				{ this.renderCityAddress( this.props.address ) }
+				{ country && <p>{ countryData ? countryData.name : country }</p> }
 			</div>
 		);
 	};

--- a/client/extensions/woocommerce/components/form-location-select/states.js
+++ b/client/extensions/woocommerce/components/form-location-select/states.js
@@ -125,6 +125,7 @@ export default connect(
 
 		return {
 			areSettingsLoaded,
+			country,
 			isLoaded,
 			locationsList,
 			siteId,


### PR DESCRIPTION
This PR updates a few things in the AddressView component.

- Fix a bug where if you left the default state or country in the address, they wouldn't be saved
- Correctly labels "Province" when your store country is Canada
- Now updates the phone country flag on the phone number input when the country is changed
- Check for address data before displaying markup in the static state

Before (note the stray comma):
<img width="268" alt="before" src="https://user-images.githubusercontent.com/541093/33738683-0fa2830c-db68-11e7-9c93-be4b7b42f331.png">

After:
<img width="268" alt="after" src="https://user-images.githubusercontent.com/541093/33738684-0fb22c76-db68-11e7-861b-c32d462cded5.png">

**To Test**

- Create an empty order by visiting wp-admin, Orders > Add New. Save the order without editing anything.
- View that order in calypso by visiting `/store/order/:site/:orderId`
- The billing details & shipping details will be empty, but nothing should look broken (see before/after above)
- Flip to edit state by clicking "Edit Order"
- Open the address modal by clicking Edit next to "Billing Details"
- The state, country, and phone flag should reflect your store address
- Add a name, street, etc but don't change country or state
- Click "Save", verify that the Billing Details includes state & country
- Re-open the modal, change the country, verify that the phone country flag changes
- Cancel your changes
- Go change your store address to Canada
- Go back to edit the order & open the address dialog (address should still be empty, you didn't save the order)
- Verify that the country, state, and phone flag are all Canadian, and the "state" label should correctly read "Province"

