### PR TITLE
PostItem: link action counts and add comments to ellipsis menu

### DIFF
--- a/client/my-sites/post-type-list/post-action-counts/index.jsx
+++ b/client/my-sites/post-type-list/post-action-counts/index.jsx
@@ -15,7 +15,8 @@ import { get } from 'lodash';
 import QueryPostStats from 'components/data/query-post-stats';
 import { getNormalizedPost } from 'state/posts/selectors';
 import { getPostStat } from 'state/stats/posts/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
+import { canCurrentUser } from 'state/selectors';
+import { getSiteSlug, isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
 
 class PostActionCounts extends PureComponent {
 	static propTypes = {
@@ -23,7 +24,11 @@ class PostActionCounts extends PureComponent {
 	};
 
 	renderCommentCount() {
-		const { commentCount: count, numberFormat, postId, siteSlug, translate } = this.props;
+		const { commentCount: count, numberFormat, postId, showComments, siteSlug, translate } = this.props;
+
+		if ( count < 1 || ! showComments ) {
+			return null;
+		}
 
 		return (
 			<li>
@@ -42,7 +47,11 @@ class PostActionCounts extends PureComponent {
 	}
 
 	renderLikeCount() {
-		const { likeCount: count, numberFormat, postId, siteSlug, translate } = this.props;
+		const { likeCount: count, numberFormat, postId, showLikes, siteSlug, translate } = this.props;
+
+		if ( count < 1 || ! showLikes ) {
+			return null;
+		}
 
 		return (
 			<li>
@@ -61,7 +70,11 @@ class PostActionCounts extends PureComponent {
 	}
 
 	renderViewCount() {
-		const { viewCount: count, numberFormat, postId, siteSlug, translate } = this.props;
+		const { viewCount: count, numberFormat, postId, showViews, siteSlug, translate } = this.props;
+
+		if ( count < 1 || ! showViews ) {
+			return null;
+		}
 
 		return (
 			<li>
@@ -80,14 +93,14 @@ class PostActionCounts extends PureComponent {
 	}
 
 	render() {
-		const { commentCount, likeCount, postId, siteId, viewCount } = this.props;
+		const { postId, siteId } = this.props;
 
 		return (
 			<ul className="post-action-counts">
 				{ siteId && <QueryPostStats siteId={ siteId } postId={ postId } fields={ [ 'views' ] } /> }
-				{ viewCount > 0 && this.renderViewCount() }
-				{ likeCount > 0 && this.renderLikeCount() }
-				{ commentCount > 0 && this.renderCommentCount() }
+				{ this.renderViewCount() }
+				{ this.renderLikeCount() }
+				{ this.renderCommentCount() }
 			</ul>
 		);
 	}
@@ -98,10 +111,25 @@ export default connect( ( state, { globalId } ) => {
 	const postId = post && post.ID;
 	const siteId = post && post.site_ID;
 
+	const isJetpack = isJetpackSite( state, siteId );
+
+	const showComments =
+		( ! isJetpack || isJetpackModuleActive( state, siteId, 'comments' ) ) &&
+		post &&
+		post.discussion &&
+		post.discussion.comments_open;
+	const showLikes = ! isJetpack || isJetpackModuleActive( state, siteId, 'likes' );
+	const showViews =
+		canCurrentUser( state, siteId, 'view_stats' ) &&
+		( ! isJetpack || isJetpackModuleActive( state, siteId, 'stats' ) );
+
 	return {
 		commentCount: get( post, 'discussion.comment_count', null ),
 		likeCount: get( post, 'like_count', null ),
 		postId,
+		showComments,
+		showLikes,
+		showViews,
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 		viewCount: getPostStat( state, siteId, postId, 'views' ),

--- a/client/my-sites/post-type-list/post-action-counts/index.jsx
+++ b/client/my-sites/post-type-list/post-action-counts/index.jsx
@@ -15,6 +15,7 @@ import { get } from 'lodash';
 import QueryPostStats from 'components/data/query-post-stats';
 import { getNormalizedPost } from 'state/posts/selectors';
 import { getPostStat } from 'state/stats/posts/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 
 class PostActionCounts extends PureComponent {
 	static propTypes = {
@@ -22,18 +23,20 @@ class PostActionCounts extends PureComponent {
 	};
 
 	renderCommentCount() {
-		const { commentCount: count, numberFormat, translate } = this.props;
+		const { commentCount: count, numberFormat, postId, siteSlug, translate } = this.props;
 
 		return (
 			<li>
-				{ translate(
-					'%(count)s Comment',
-					'%(count)s Comments',
-					{
-						count,
-						args: { count: numberFormat( count ) },
-					}
-				) }
+				<a href={ `/comments/all/${ siteSlug }/${ postId }` }>
+					{ translate(
+						'%(count)s Comment',
+						'%(count)s Comments',
+						{
+							count,
+							args: { count: numberFormat( count ) },
+						}
+					) }
+				</a>
 			</li>
 		);
 	}
@@ -96,6 +99,7 @@ export default connect( ( state, { globalId } ) => {
 		likeCount: get( post, 'like_count', null ),
 		postId,
 		siteId,
+		siteSlug: getSiteSlug( state, siteId ),
 		viewCount: getPostStat( state, siteId, postId, 'views' ),
 	};
 } )( localize( PostActionCounts ) );

--- a/client/my-sites/post-type-list/post-action-counts/index.jsx
+++ b/client/my-sites/post-type-list/post-action-counts/index.jsx
@@ -17,10 +17,21 @@ import { getNormalizedPost } from 'state/posts/selectors';
 import { getPostStat } from 'state/stats/posts/selectors';
 import { canCurrentUser } from 'state/selectors';
 import { getSiteSlug, isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class PostActionCounts extends PureComponent {
 	static propTypes = {
 		globalId: PropTypes.string,
+	};
+
+	onActionClick = ( action ) => () => {
+		const { recordTracksEvent: record, type } = this.props;
+
+		record( 'calypso_post_list_action_click', {
+			action,
+			postType: type,
+			context: 'action_counts',
+		} );
 	};
 
 	renderCommentCount() {
@@ -32,7 +43,7 @@ class PostActionCounts extends PureComponent {
 
 		return (
 			<li>
-				<a href={ `/comments/all/${ siteSlug }/${ postId }` }>
+				<a href={ `/comments/all/${ siteSlug }/${ postId }` } onClick={ this.onActionClick( 'comments' ) } >
 					{ translate(
 						'%(count)s Comment',
 						'%(count)s Comments',
@@ -55,7 +66,7 @@ class PostActionCounts extends PureComponent {
 
 		return (
 			<li>
-				<a href={ `/stats/post/${ postId }/${ siteSlug }` }>
+				<a href={ `/stats/post/${ postId }/${ siteSlug }` } onClick={ this.onActionClick( 'likes' ) } >
 					{ translate(
 						'%(count)s Like',
 						'%(count)s Likes',
@@ -78,7 +89,7 @@ class PostActionCounts extends PureComponent {
 
 		return (
 			<li>
-				<a href={ `/stats/post/${ postId }/${ siteSlug }` }>
+				<a href={ `/stats/post/${ postId }/${ siteSlug }` } onClick={ this.onActionClick( 'stats' ) } >
 					{ translate(
 						'%(count)s View',
 						'%(count)s Views',
@@ -132,6 +143,7 @@ export default connect( ( state, { globalId } ) => {
 		showViews,
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
+		type: get( post, 'type', 'unknown' ),
 		viewCount: getPostStat( state, siteId, postId, 'views' ),
 	};
-} )( localize( PostActionCounts ) );
+}, { recordTracksEvent } )( localize( PostActionCounts ) );

--- a/client/my-sites/post-type-list/post-action-counts/index.jsx
+++ b/client/my-sites/post-type-list/post-action-counts/index.jsx
@@ -42,35 +42,39 @@ class PostActionCounts extends PureComponent {
 	}
 
 	renderLikeCount() {
-		const { likeCount: count, numberFormat, translate } = this.props;
+		const { likeCount: count, numberFormat, postId, siteSlug, translate } = this.props;
 
 		return (
 			<li>
-				{ translate(
-					'%(count)s Like',
-					'%(count)s Likes',
-					{
-						count,
-						args: { count: numberFormat( count ) },
-					}
-				) }
+				<a href={ `/stats/post/${ postId }/${ siteSlug }` }>
+					{ translate(
+						'%(count)s Like',
+						'%(count)s Likes',
+						{
+							count,
+							args: { count: numberFormat( count ) },
+						}
+					) }
+				</a>
 			</li>
 		);
 	}
 
 	renderViewCount() {
-		const { viewCount: count, numberFormat, translate } = this.props;
+		const { viewCount: count, numberFormat, postId, siteSlug, translate } = this.props;
 
 		return (
 			<li>
-				{ translate(
-					'%(count)s View',
-					'%(count)s Views',
-					{
-						count,
-						args: { count: numberFormat( count ) },
-					}
-				) }
+				<a href={ `/stats/post/${ postId }/${ siteSlug }` }>
+					{ translate(
+						'%(count)s View',
+						'%(count)s Views',
+						{
+							count,
+							args: { count: numberFormat( count ) },
+						}
+					) }
+				</a>
 			</li>
 		);
 	}

--- a/client/my-sites/post-type-list/post-action-counts/style.scss
+++ b/client/my-sites/post-type-list/post-action-counts/style.scss
@@ -20,3 +20,14 @@
 		}
 	}
 }
+
+.post-action-counts li a,
+.post-action-counts li a:active,
+.post-action-counts li a:visited
+ {
+	color: $gray-text-min;
+
+	&:hover {
+		text-decoration: underline;
+	}
+}

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/comments.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/comments.jsx
@@ -1,0 +1,71 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PopoverMenuItem from 'components/popover/menu-item';
+import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
+import { bumpStatGenerator } from './utils';
+import { getNormalizedPost } from 'state/posts/selectors';
+import { getSiteSlug, isJetpackModuleActive } from 'state/sites/selectors';
+
+class PostActionsEllipsisMenuComments extends PureComponent {
+	static propTypes = {
+		globalId: PropTypes.string,
+	};
+
+	render() {
+		const { bumpStat, isModuleActive, postId, siteSlug, status, translate } = this.props;
+
+		if ( ! isModuleActive || 'publish' !== status ) {
+			return null;
+		}
+
+		return (
+			<PopoverMenuItem
+				href={ `/comments/all/${ siteSlug }/${ postId }` }
+				icon="comment"
+				onClick={ bumpStat }
+			>
+				{ translate( 'Comments', { context: 'noun' } ) }
+			</PopoverMenuItem>
+		);
+	}
+}
+
+const mapStateToProps = ( state, { globalId } ) => {
+	const post = getNormalizedPost( state, globalId );
+	const postId = post && post.ID;
+	const siteId = post && post.site_ID;
+
+	return {
+		isModuleActive: false !== isJetpackModuleActive( state, post.site_ID, 'comments' ),
+		postId,
+		siteSlug: getSiteSlug( state, siteId ),
+		status: post.status,
+		type: post.type,
+	};
+};
+
+const mapDispatchToProps = { bumpAnalyticsStat };
+
+const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const bumpStat = bumpStatGenerator(
+		stateProps.type,
+		'comments',
+		dispatchProps.bumpAnalyticsStat
+	);
+	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
+};
+
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )(
+	localize( PostActionsEllipsisMenuComments )
+);

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/comments.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/comments.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
-import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
+import { bumpStat as bumpAnalyticsStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { getNormalizedPost } from 'state/posts/selectors';
 import { getSiteSlug, isJetpackModuleActive } from 'state/sites/selectors';
@@ -55,13 +55,14 @@ const mapStateToProps = ( state, { globalId } ) => {
 	};
 };
 
-const mapDispatchToProps = { bumpAnalyticsStat };
+const mapDispatchToProps = { bumpAnalyticsStat, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 	const bumpStat = bumpStatGenerator(
 		stateProps.type,
 		'comments',
-		dispatchProps.bumpAnalyticsStat
+		dispatchProps.bumpAnalyticsStat,
+		dispatchProps.recordTracksEvent
 	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/index.jsx
@@ -13,6 +13,7 @@ import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuSeparator from 'components/popover/menu-separator';
 import PostActionsEllipsisMenuEdit from './edit';
 import PostActionsEllipsisMenuStats from './stats';
+import PostActionsEllipsisMenuComments from './comments';
 import PostActionsEllipsisMenuPublish from './publish';
 import PostActionsEllipsisMenuShare from './share';
 import PostActionsEllipsisMenuTrash from './trash';
@@ -28,6 +29,7 @@ export default function PostActionsEllipsisMenu( { globalId, includeDefaultActio
 			<PostActionsEllipsisMenuEdit key="edit" />,
 			<PostActionsEllipsisMenuView key="view" />,
 			<PostActionsEllipsisMenuStats key="stats" />,
+			<PostActionsEllipsisMenuComments key="comments" />,
 			<PostActionsEllipsisMenuPublish key="publish" />,
 			<PostActionsEllipsisMenuShare key="share" />,
 			<PostActionsEllipsisMenuRestore key="restore" />,

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/stats.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PopoverMenuItem from 'components/popover/menu-item';
-import { bumpStat as bumpAnalyticsStat } from 'state/analytics/actions';
+import { bumpStat as bumpAnalyticsStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
 import { getSiteSlug, isJetpackModuleActive } from 'state/sites/selectors';
 import { getPost } from 'state/posts/selectors';
@@ -65,10 +65,15 @@ const mapStateToProps = ( state, { globalId } ) => {
 	};
 };
 
-const mapDispatchToProps = { bumpAnalyticsStat };
+const mapDispatchToProps = { bumpAnalyticsStat, recordTracksEvent };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
-	const bumpStat = bumpStatGenerator( stateProps.type, 'stats', dispatchProps.bumpAnalyticsStat );
+	const bumpStat = bumpStatGenerator(
+		stateProps.type,
+		'stats',
+		dispatchProps.bumpAnalyticsStat,
+		dispatchProps.recordTracksEvent
+	);
 	return Object.assign( {}, ownProps, stateProps, dispatchProps, { bumpStat } );
 };
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/utils.js
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/utils.js
@@ -1,4 +1,4 @@
-export function bumpStatGenerator( type, name, bumpStat ) {
+export function bumpStatGenerator( type, name, bumpStat, recordTracksEvent = null ) {
 	return () => {
 		let group;
 		if ( ! type ) {
@@ -9,5 +9,12 @@ export function bumpStatGenerator( type, name, bumpStat ) {
 			group = 'calypso_' + type + '_actions';
 		}
 		bumpStat( group, name );
+		if ( recordTracksEvent ) {
+			recordTracksEvent( 'calypso_post_list_action_click', {
+				action: name,
+				postType: type,
+				context: 'ellipsis_menu',
+			} );
+		}
 	};
 }


### PR DESCRIPTION
This PR links action counts to an appropriate destination (stats or comments) and adds "Comments" to the ellipsis menu.

Before:
![image](https://user-images.githubusercontent.com/363749/33738291-734bc1d4-db5e-11e7-8dfd-51ebbf568884.png)

After:

![image](https://user-images.githubusercontent.com/363749/33738260-587bd22c-db5e-11e7-882d-e007db019f55.png)


To test:
* checkout branch and `npm start` or use calypso.live link below
* Ensure that you're in the `condensedPosts` bucket of the `condensedPostList` experiment by setting your AB test using the environment badge.
* Visit "Blog Posts". Make sure that clicking on comment counts takes you to the comment management page. Make sure that clicking on views or likes takes you to stats.
* Make sure that comments appears in the ellipsis menu if comments are enabled.