### PR TITLE
State: Introduce isSiteInProfileLinks selector

### DIFF
--- a/client/state/selectors/is-site-in-profile-links.js
+++ b/client/state/selectors/is-site-in-profile-links.js
@@ -1,0 +1,35 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getProfileLinks } from 'state/selectors';
+
+/**
+ * Whether the site with the domain in question is currently in the user's profile links.
+ * Will return null if profile links have not been loaded yet.
+ *
+ * @param {Object}   state      Global state tree
+ * @param {String}   siteDomain Site domain
+ * @return {Boolean}            True if the site is in the user's profile links, false otherwise.
+ */
+export default createSelector(
+	( state, siteDomain ) => {
+		const profileLinks = getProfileLinks( state );
+		if ( profileLinks === null ) {
+			return null;
+		}
+
+		return some( profileLinks, profileLink => {
+			// the regex below is used to strip any leading scheme from the profileLink's URL
+			return siteDomain === profileLink.value.replace( /^.*:\/\//, '' );
+		} );
+	},
+	state => [ state.profileLinks.items ]
+);

--- a/client/state/selectors/is-site-in-profile-links.js
+++ b/client/state/selectors/is-site-in-profile-links.js
@@ -17,7 +17,7 @@ import { getProfileLinks } from 'state/selectors';
  *
  * @param {Object}   state      Global state tree
  * @param {String}   siteDomain Site domain
- * @return {Boolean}            True if the site is in the user's profile links, false otherwise.
+ * @return {?Boolean}           True if the site is in the user's profile links, false otherwise.
  */
 export default createSelector(
 	( state, siteDomain ) => {

--- a/client/state/selectors/is-site-in-profile-links.js
+++ b/client/state/selectors/is-site-in-profile-links.js
@@ -31,5 +31,5 @@ export default createSelector(
 			return siteDomain === profileLink.value.replace( /^.*:\/\//, '' );
 		} );
 	},
-	state => [ state.profileLinks.items ]
+	[ getProfileLinks ]
 );

--- a/client/state/selectors/test/is-site-in-profile-links.js
+++ b/client/state/selectors/test/is-site-in-profile-links.js
@@ -1,0 +1,46 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { isSiteInProfileLinks } from 'state/selectors';
+
+describe( 'isSiteInProfileLinks()', () => {
+	const profileLinks = [
+		{
+			link_slug: 'wordpress-org',
+			title: 'WordPress.org',
+			value: 'https://wordpress.org',
+		},
+	];
+
+	test( 'should return null if profile links have not been received yet', () => {
+		const state = {
+			profileLinks: {
+				items: null,
+			},
+		};
+
+		expect( isSiteInProfileLinks( state, 'wordpress.org' ) ).toEqual( null );
+	} );
+
+	test( 'should return false if site is not in profile links', () => {
+		const state = {
+			profileLinks: {
+				items: profileLinks,
+			},
+		};
+
+		expect( isSiteInProfileLinks( state, 'wordpress.com' ) ).toBe( false );
+	} );
+
+	test( 'should return true if site is in profile links', () => {
+		const state = {
+			profileLinks: {
+				items: profileLinks,
+			},
+		};
+
+		expect( isSiteInProfileLinks( state, 'wordpress.org' ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
This PR introduces a `isSiteInProfileLinks` selector, which will return `true` if a site domain is found in the profile links, `false` if not, and `null` if profile links have not been loaded yet.

Contains #20609, which improves the profile links items reducer default state and #20610, which introduces the `getProfileLinks` selector. 

Part of #20241.

To test:
* Checkout this branch
* Verify the tests pass:

```
npm run test-client client/state/selectors/test/is-site-in-profile-links.js
```