### PR TITLE
State: Introduce getProfileLinksErrorType selector

### DIFF
--- a/client/state/selectors/get-profile-links-error-type.js
+++ b/client/state/selectors/get-profile-links-error-type.js
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns the type of the last profile links request error, or null if there's no error.
+ * Can be one of 'duplicate', 'malformed', 'other' or `null`.
+ *
+ * @param {Object} state Global state tree
+ * @return {?String}     Error type.
+ */
+export default function getProfileLinksErrorType( state ) {
+	if ( get( state, [ 'profileLinks', 'errors', 'duplicate' ], false ) ) {
+		return 'duplicate';
+	}
+
+	if ( get( state, [ 'profileLinks', 'errors', 'malformed' ], false ) ) {
+		return 'malformed';
+	}
+
+	if ( get( state, [ 'profileLinks', 'errors', 'error' ], false ) ) {
+		return 'other';
+	}
+
+	return null;
+}

--- a/client/state/selectors/test/get-profile-links-error-type.js
+++ b/client/state/selectors/test/get-profile-links-error-type.js
@@ -1,0 +1,65 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { getProfileLinksErrorType } from 'state/selectors';
+
+describe( 'getProfileLinksErrorType()', () => {
+	const profileLinks = [
+		{
+			link_slug: 'wordpress-org',
+			title: 'WordPress.org',
+			value: 'https://wordpress.org/',
+		},
+	];
+
+	test( 'should return null if there are no errors from the last profile links request', () => {
+		const state = {
+			profileLinks: {
+				errors: {},
+			},
+		};
+
+		expect( getProfileLinksErrorType( state ) ).toEqual( null );
+	} );
+
+	test( 'should return "duplicate" if there are duplicates in the last profile links request', () => {
+		const state = {
+			profileLinks: {
+				errors: {
+					duplicate: profileLinks,
+				},
+			},
+		};
+
+		expect( getProfileLinksErrorType( state ) ).toEqual( 'duplicate' );
+	} );
+
+	test( 'should return "malformed" if there are malformed links in the last profile links request', () => {
+		const state = {
+			profileLinks: {
+				errors: {
+					malformed: profileLinks,
+				},
+			},
+		};
+
+		expect( getProfileLinksErrorType( state ) ).toEqual( 'malformed' );
+	} );
+
+	test( 'should return "other" if there is another error in the last profile links request', () => {
+		const state = {
+			profileLinks: {
+				errors: {
+					error: {
+						status: 403,
+						message:
+							'An active access token must be used to query information about the current user.',
+					},
+				},
+			},
+		};
+
+		expect( getProfileLinksErrorType( state ) ).toEqual( 'other' );
+	} );
+} );


### PR DESCRIPTION
This PR introduces a `getProfileLinksErrorType ` selector, which will return the type of the current error from the last profile links request, or `null` if there is no error. This is all we need to reproduce the current user profile links behavior with Redux.

Part of #20241.

To test:
* Checkout this branch
* Verify the tests pass:

```
npm run test-client client/state/selectors/test/get-profile-links-error-type.js
```