### PR TITLE
Data Layer: use wpcom library to generate WPCOM_HTTP_REQUEST actions

### DIFF
--- a/client/state/data-layer/wpcom-http/actions.js
+++ b/client/state/data-layer/wpcom-http/actions.js
@@ -44,14 +44,14 @@ export const http = (
 	},
 	action = null
 ) => {
-	const version = apiNamespace ? { apiNamespace } : { apiVersion };
-
 	return {
 		type: WPCOM_HTTP_REQUEST,
 		body,
 		method,
 		path,
-		query: { ...query, ...version },
+		apiVersion,
+		apiNamespace,
+		query,
 		formData,
 		onSuccess: onSuccess || action,
 		onFailure: onFailure || action,

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { compact, get } from 'lodash';
+import qs from 'qs';
 
 /**
  * Internal dependencies
@@ -16,24 +16,6 @@ import {
 	processInbound as inboundProcessor,
 	processOutbound as outboundProcessor,
 } from './pipeline';
-
-/**
- * Returns the appropriate fetcher in wpcom given the request method
- *
- * fetcherMap :: String -> (Params -> Query -> [Body] -> Promise)
- *
- * @param {string} method name of HTTP method for request
- * @returns {Function} the fetcher
- */
-const fetcherMap = method =>
-	get(
-		{
-			GET: wpcom.req.get.bind( wpcom.req ),
-			POST: wpcom.req.post.bind( wpcom.req ),
-		},
-		method,
-		null
-	);
 
 export const successMeta = ( data, headers ) => ( { meta: { dataLayer: { data, headers } } } );
 export const failureMeta = ( error, headers ) => ( { meta: { dataLayer: { error, headers } } } );
@@ -48,38 +30,51 @@ export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch 
 		return;
 	}
 
-	const { body, formData, method: rawMethod, onProgress, path, query = {} } = action;
+	const {
+		method: rawMethod,
+		path,
+		apiVersion,
+		apiNamespace,
+		body,
+		query: rawQuery,
+		formData,
+		onProgress,
+	} = action;
 
 	const method = rawMethod.toUpperCase();
+	const query = typeof rawQuery === 'string' ? rawQuery : qs.stringify( rawQuery );
 
-	const request = fetcherMap( method )(
-		...compact( [
-			{ path, formData },
-			{ ...query }, // wpcom mutates the query so hand it a copy
-			method === 'POST' && body,
-			( error, data, headers ) => {
-				const {
-					failures,
-					nextData,
-					nextError,
-					nextHeaders,
-					shouldAbort,
-					successes,
-				} = processInbound( action, { dispatch }, data, error, headers );
+	const request = wpcom.request(
+		{
+			method,
+			path,
+			apiVersion,
+			apiNamespace,
+			query,
+			formData,
+			body,
+		},
+		( error, data, headers ) => {
+			const { failures, nextData, nextError, nextHeaders, shouldAbort, successes } = processInbound(
+				action,
+				{ dispatch },
+				data,
+				error,
+				headers
+			);
 
-				if ( true === shouldAbort ) {
-					return null;
-				}
+			if ( true === shouldAbort ) {
+				return null;
+			}
 
-				return !! nextError
-					? failures.forEach( handler =>
-							dispatch( extendAction( handler, failureMeta( nextError, nextHeaders ) ) )
-						)
-					: successes.forEach( handler =>
-							dispatch( extendAction( handler, successMeta( nextData, nextHeaders ) ) )
-						);
-			},
-		] )
+			return !! nextError
+				? failures.forEach( handler =>
+						dispatch( extendAction( handler, failureMeta( nextError, nextHeaders ) ) )
+					)
+				: successes.forEach( handler =>
+						dispatch( extendAction( handler, successMeta( nextData, nextHeaders ) ) )
+					);
+		}
 	);
 
 	if ( 'POST' === method && onProgress ) {

--- a/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
+++ b/client/state/data-layer/wpcom-http/pipeline/remove-duplicate-gets/index.js
@@ -52,8 +52,10 @@ const isGetRequest = request => 'GET' === get( request, 'method', '' ).toUpperCa
  * @param {Object<String, *>} query GET query string
  * @returns {String} unique key up to duplicate request descriptions
  */
-export const buildKey = ( { path, apiNamespace, apiVersion, query } ) =>
-	JSON.stringify( [ path, apiNamespace, apiVersion, sortBy( toPairs( query ), head ) ] );
+export const buildKey = ( { path, apiNamespace, apiVersion, query } ) => {
+	const queryKey = typeof query === 'string' ? query : sortBy( toPairs( query ), head );
+	return JSON.stringify( [ path, apiNamespace, apiVersion, queryKey ] );
+};
 
 /**
  * Joins a responder action into a unique list of responder actions

--- a/client/state/data-layer/wpcom-http/wpcom.js
+++ b/client/state/data-layer/wpcom-http/wpcom.js
@@ -1,0 +1,21 @@
+/**
+ * @format
+ */
+
+/**
+ * Internal dependencies
+ */
+import wpcomUndocumented from 'lib/wpcom-undocumented';
+import { http } from './actions';
+
+export default wpcomUndocumented( ( request, fn ) => {
+	let action;
+	fn( a => ( action = a ) );
+	return http( request, action );
+} );
+
+/*
+ * Creates a callback that can be passed to `wpcom` handlers and allow to pass
+ * `action` object to them.
+ */
+export const returnAction = action => cb => cb( action );

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -22,8 +22,8 @@ import {
 	receiveDeleteProduct,
 } from 'state/simple-payments/product-list/actions';
 import { metaKeyToSchemaKeyMap, metadataSchema } from 'state/simple-payments/product-list/schema';
-import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx, TransformerError } from 'state/data-layer/wpcom-http/utils';
+import wpcom, { returnAction } from 'state/data-layer/wpcom-http/wpcom';
 import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
 import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
 import formatCurrency from 'lib/format-currency';
@@ -146,13 +146,10 @@ const deleteProduct = ( { siteId }, deletedPost ) => receiveDeleteProduct( siteI
 
 export const handleProductGet = dispatchRequestEx( {
 	fetch: action =>
-		http(
-			{
-				method: 'GET',
-				path: `/sites/${ action.siteId }/posts/${ action.productId }`,
-			},
-			action
-		),
+		wpcom
+			.site( action.siteId )
+			.post( action.productId )
+			.get( returnAction( action ) ),
 	fromApi: customPostToProduct,
 	onSuccess: addOrUpdateProduct,
 	onError: noop,
@@ -160,16 +157,12 @@ export const handleProductGet = dispatchRequestEx( {
 
 export const handleProductList = dispatchRequestEx( {
 	fetch: action =>
-		http(
+		wpcom.site( action.siteId ).postsList(
 			{
-				method: 'GET',
-				path: `/sites/${ action.siteId }/posts`,
-				query: {
-					type: SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
-					status: 'publish',
-				},
+				type: SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
+				status: 'publish',
 			},
-			action
+			returnAction( action )
 		),
 	fromApi: customPostsToProducts,
 	onSuccess: replaceProductList,
@@ -178,14 +171,9 @@ export const handleProductList = dispatchRequestEx( {
 
 export const handleProductListAdd = dispatchRequestEx( {
 	fetch: action =>
-		http(
-			{
-				method: 'POST',
-				path: `/sites/${ action.siteId }/posts/new`,
-				body: productToCustomPost( action.product ),
-			},
-			action
-		),
+		wpcom
+			.site( action.siteId )
+			.addPost( productToCustomPost( action.product ), returnAction( action ) ),
 	fromApi: customPostToProduct,
 	onSuccess: addOrUpdateProduct,
 	onError: noop,
@@ -193,14 +181,10 @@ export const handleProductListAdd = dispatchRequestEx( {
 
 export const handleProductListEdit = dispatchRequestEx( {
 	fetch: action =>
-		http(
-			{
-				method: 'POST',
-				path: `/sites/${ action.siteId }/posts/${ action.productId }`,
-				body: productToCustomPost( action.product ),
-			},
-			action
-		),
+		wpcom
+			.site( action.siteId )
+			.post( action.productId )
+			.update( productToCustomPost( action.product ), returnAction( action ) ),
 	fromApi: customPostToProduct,
 	onSuccess: addOrUpdateProduct,
 	onError: noop,
@@ -208,13 +192,10 @@ export const handleProductListEdit = dispatchRequestEx( {
 
 export const handleProductListDelete = dispatchRequestEx( {
 	fetch: action =>
-		http(
-			{
-				method: 'POST',
-				path: `/sites/${ action.siteId }/posts/${ action.productId }/delete`,
-			},
-			action
-		),
+		wpcom
+			.site( action.siteId )
+			.post( action.productId )
+			.del( returnAction( action ) ),
 	onSuccess: deleteProduct,
 	onError: noop,
 } );


### PR DESCRIPTION
Here is an experiment that creates a `wpcom` handler that doesn't directly issue network requests, but just returns a `WPCOM_HTTP_ACTION` object to be dispatched later.

Allows to replace low level code like:
```js
dispatch(
  http(
    {
      method: 'POST',
      path: `/sites/${ action.siteId }/posts/${ action.productId }`,
      body: productToCustomPost( action.product ),
    },
    action
  )
)
```
with:
```js
import wpcom, { returnAction } from 'state/data-layer/wpcom-http/wpcom';

dispatch(
  wpcom
    .site( action.siteId )
    .post( action.productId )
    .update( productToCustomPost( action.product ), returnAction( action ) )
)
```
The `wpcom` library already knows all the URLs and API namespaces and request formats. Let's leverage it to generate data layer actions.

`wpcom` can be instantiated with any `requestHandler` that actually executes the request. In our case, instead of sending something over network, our handler just returns a `WPCOM_HTTP_REQUEST` handler.

The `wpcom` API expects a callback function that's supposed to be called when the request is completed. I slightly abuse this callback to pass extra arguments like `action` or possibly optional arguments like `retryPolicy`. Handling request completion doesn't have any meaning in this case.

Thoughts?
