### PR TITLE
JP Onboarding: add `Business Address` flow step

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -3,15 +3,33 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
+import Card from 'components/card';
+import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
 
 class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
+	state = {
+		city: '',
+		name: '',
+		stateLoc: '',
+		street: '',
+		zip: '',
+	};
+
+	setInput = field => event => {
+		this.setState( { [ field ]: event.target.value } );
+	};
+
 	render() {
 		const { translate } = this.props;
 		const headerText = translate( 'Add a business address.' );
@@ -19,7 +37,45 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 			'Enter your business address to have a map added to your website.'
 		);
 
-		return <FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />;
+		const fields = [
+			[ 'city', 'City' ],
+			[ 'name', 'Business Name' ],
+			[ 'stateLoc', 'State' ],
+			[ 'street', 'Street Address' ],
+			[ 'zip', 'ZIP Code' ],
+		];
+		const formFields = fields.map( ( [ field, fieldText ] ) => {
+			return (
+				<FormFieldset key={ field }>
+					<FormLabel htmlFor={ field }>
+						{ translate( ' %(title)s ', {
+							textOnly: true,
+							args: { title: fieldText },
+						} ) }
+					</FormLabel>
+					<FormTextInput
+						id={ field }
+						onChange={ this.setInput( field ) }
+						value={ this.state.field }
+					/>
+				</FormFieldset>
+			);
+		} );
+		return (
+			<Fragment>
+				<DocumentHead title={ translate( 'Business Address ‹ Jetpack Onboarding' ) } />
+				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+
+				<Card className="steps__form">
+					<form>
+						{ formFields }
+						<Button href={ this.props.getForwardUrl() } primary>
+							{ translate( 'Next Step' ) }
+						</Button>
+					</form>
+				</Card>
+			</Fragment>
+		);
 	}
 }
 

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -59,6 +59,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 									id={ field }
 									onChange={ this.getChangeHandler( field ) }
 									value={ this.state[ field ] }
+									autoFocus={ field === 'name' }
 								/>
 							</FormFieldset>
 						) ) }

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -21,12 +21,12 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 	state = {
 		city: '',
 		name: '',
-		stateLoc: '',
+		stateName: '',
 		street: '',
 		zip: '',
 	};
 
-	setInput = field => event => {
+	getChangeHandler = field => event => {
 		this.setState( { [ field ]: event.target.value } );
 	};
 
@@ -37,30 +37,14 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 			'Enter your business address to have a map added to your website.'
 		);
 
-		const fields = [
-			[ 'city', 'City' ],
-			[ 'name', 'Business Name' ],
-			[ 'stateLoc', 'State' ],
-			[ 'street', 'Street Address' ],
-			[ 'zip', 'ZIP Code' ],
-		];
-		const formFields = fields.map( ( [ field, fieldText ] ) => {
-			return (
-				<FormFieldset key={ field }>
-					<FormLabel htmlFor={ field }>
-						{ translate( ' %(title)s ', {
-							textOnly: true,
-							args: { title: fieldText },
-						} ) }
-					</FormLabel>
-					<FormTextInput
-						id={ field }
-						onChange={ this.setInput( field ) }
-						value={ this.state.field }
-					/>
-				</FormFieldset>
-			);
-		} );
+		const fields = {
+			name: translate( 'Business Name' ),
+			street: translate( 'Street Address' ),
+			city: translate( 'City' ),
+			stateName: translate( 'State' ),
+			zip: translate( 'ZIP Code' ),
+		};
+
 		return (
 			<Fragment>
 				<DocumentHead title={ translate( 'Business Address ‹ Jetpack Onboarding' ) } />
@@ -68,7 +52,16 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 
 				<Card className="steps__form">
 					<form>
-						{ formFields }
+						{ Object.keys( fields ).map( field => (
+							<FormFieldset key={ field }>
+								<FormLabel htmlFor={ field }>{ fields[ field ] }</FormLabel>
+								<FormTextInput
+									id={ field }
+									onChange={ this.getChangeHandler( field ) }
+									value={ this.state[ field ] }
+								/>
+							</FormFieldset>
+						) ) }
 						<Button href={ this.props.getForwardUrl() } primary>
 							{ translate( 'Next Step' ) }
 						</Button>

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
-
+import { map } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -30,20 +30,26 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		this.setState( { [ field ]: event.target.value } );
 	};
 
-	render() {
-		const { translate } = this.props;
-		const headerText = translate( 'Add a business address.' );
-		const subHeaderText = translate(
-			'Enter your business address to have a map added to your website.'
-		);
+	fields = this.getFields();
 
-		const fields = {
+	getFields() {
+		const { translate } = this.props;
+
+		return {
 			name: translate( 'Business Name' ),
 			street: translate( 'Street Address' ),
 			city: translate( 'City' ),
 			stateName: translate( 'State' ),
 			zip: translate( 'ZIP Code' ),
 		};
+	}
+
+	render() {
+		const { translate } = this.props;
+		const headerText = translate( 'Add a business address.' );
+		const subHeaderText = translate(
+			'Enter your business address to have a map added to your website.'
+		);
 
 		return (
 			<Fragment>
@@ -52,14 +58,14 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 
 				<Card className="steps__form">
 					<form>
-						{ Object.keys( fields ).map( field => (
-							<FormFieldset key={ field }>
-								<FormLabel htmlFor={ field }>{ fields[ field ] }</FormLabel>
+						{ map( this.fields, ( fieldLabel, fieldName ) => (
+							<FormFieldset key={ fieldName }>
+								<FormLabel htmlFor={ fieldName }>{ fieldLabel }</FormLabel>
 								<FormTextInput
-									id={ field }
-									onChange={ this.getChangeHandler( field ) }
-									value={ this.state[ field ] }
-									autoFocus={ field === 'name' }
+									id={ fieldName }
+									onChange={ this.getChangeHandler( fieldName ) }
+									value={ this.state[ fieldName ] }
+									autoFocus={ fieldName === 'name' }
 								/>
 							</FormFieldset>
 						) ) }


### PR DESCRIPTION
It is a bare-bones front-end structure to build upon and does not deal with storing/managing data.
The latter will be included in the follow-up.

**To test**:
start at http://calypso.localhost:3000/jetpack/onboarding/business-address and verify that
 -  it is possible to input text in the fields without errors
 -  the `Next Step` button redirects to the `woocommerce` step

**Visuals**

![screen shot 2017-12-13 at 12 38 39](https://user-images.githubusercontent.com/13561163/33939251-5b4d5f9a-e002-11e7-8503-06580bace3bc.png)
