### PR TITLE
Comments: update getPostCommentsTree to optionally filter others' pending comments

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -27,6 +27,7 @@ import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
 import ConversationFollowButton from 'blocks/conversation-follow-button';
 import { shouldShowConversationFollowButton } from 'blocks/conversation-follow-button/helper';
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 /**
  * PostCommentList, as the name would suggest, displays a list of comments for a post.
@@ -478,29 +479,33 @@ class PostCommentList extends React.Component {
 }
 
 export default connect(
-	( state, ownProps ) => ( {
-		commentsTree: getPostCommentsTree(
-			state,
-			ownProps.post.site_ID,
-			ownProps.post.ID,
-			ownProps.commentsFilterDisplay ? ownProps.commentsFilterDisplay : ownProps.commentsFilter
-		),
-		commentsFetchingStatus: commentsFetchingStatus(
-			state,
-			ownProps.post.site_ID,
-			ownProps.post.ID,
-			ownProps.commentCount
-		),
-		initialComment: getCommentById( {
-			state,
-			siteId: ownProps.post.site_ID,
-			commentId: ownProps.startingCommentId,
-		} ),
-		activeReplyCommentId: getActiveReplyCommentId( {
-			state,
-			siteId: ownProps.post.site_ID,
-			postId: ownProps.post.ID,
-		} ),
-	} ),
+	( state, ownProps ) => {
+		const authorId = getCurrentUserId( state );
+		return {
+			commentsTree: getPostCommentsTree(
+				state,
+				ownProps.post.site_ID,
+				ownProps.post.ID,
+				ownProps.commentsFilterDisplay ? ownProps.commentsFilterDisplay : ownProps.commentsFilter,
+				authorId
+			),
+			commentsFetchingStatus: commentsFetchingStatus(
+				state,
+				ownProps.post.site_ID,
+				ownProps.post.ID,
+				ownProps.commentCount
+			),
+			initialComment: getCommentById( {
+				state,
+				siteId: ownProps.post.site_ID,
+				commentId: ownProps.startingCommentId,
+			} ),
+			activeReplyCommentId: getActiveReplyCommentId( {
+				state,
+				siteId: ownProps.post.site_ID,
+				postId: ownProps.post.ID,
+			} ),
+		};
+	},
 	{ requestPostComments, requestComment, setActiveReply }
 )( PostCommentList );

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -26,6 +26,7 @@ import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import PostCommentFormRoot from 'blocks/comments/form-root';
 import { requestPostComments, requestComment, setActiveReply } from 'state/comments/actions';
 import { getErrorKey } from 'state/comments/utils';
+import { getCurrentUserId } from 'state/current-user/selectors';
 
 /**
  * ConversationsCommentList is the component that represents all of the comments for a conversations-stream
@@ -276,12 +277,12 @@ export class ConversationCommentList extends React.Component {
 const ConnectedConversationCommentList = connect(
 	( state, ownProps ) => {
 		const { site_ID: siteId, ID: postId, discussion } = ownProps.post;
-
+		const authorId = getCurrentUserId( state );
 		return {
 			siteId,
 			postId,
 			sortedComments: getDateSortedPostComments( state, siteId, postId ),
-			commentsTree: getPostCommentsTree( state, siteId, postId, 'all' ),
+			commentsTree: getPostCommentsTree( state, siteId, postId, 'all', authorId ),
 			commentsFetchingStatus:
 				commentsFetchingStatus( state, siteId, postId, discussion.comment_count ) || {},
 			expansions: getExpansionsForPost( state, siteId, postId ),

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -102,15 +102,22 @@ export const getPostOldestCommentDate = createSelector( ( state, siteId, postId 
  * @param {Number} siteId site identification
  * @param {Number} postId site identification
  * @param {String} status String representing the comment status to show. Defaults to 'approved'.
+ * @param {Number} authorId - when specified we only return pending comments that match this id
  * @return {Object} comments tree, and in addition a children array
  */
 export const getPostCommentsTree = createSelector(
-	( state, siteId, postId, status = 'approved' ) => {
+	( state, siteId, postId, status = 'approved', authorId ) => {
 		const allItems = getPostCommentItems( state, siteId, postId );
-		const items =
-			status !== 'all'
-				? filter( allItems, item => item.isPlaceholder || item.status === status )
-				: allItems;
+		const items = filter( allItems, item => {
+			//only return pending comments that match the comment author
+			if ( authorId && item.status === 'unapproved' && get( item, 'author.ID' ) !== authorId ) {
+				return false;
+			}
+			if ( status !== 'all' ) {
+				return item.isPlaceholder || item.status === status;
+			}
+			return true;
+		} );
 
 		// separate out root comments from comments that have parents
 		const [ roots, children ] = partition( items, item => item.parent === false );

--- a/client/state/comments/test/__snapshots__/selectors.js.snap
+++ b/client/state/comments/test/__snapshots__/selectors.js.snap
@@ -1,5 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`selectors #getPostCommentsTree filters other pending posts 1`] = `
+Object {
+  "1": Object {
+    "children": Array [
+      3,
+    ],
+    "data": Object {
+      "ID": 1,
+      "author": Object {
+        "ID": 1,
+      },
+      "date": "2016-01-31T10:07:18-08:00",
+      "i_like": true,
+      "like_count": 5,
+      "parent": false,
+      "status": "unapproved",
+    },
+  },
+  "3": Object {
+    "children": Array [],
+    "data": Object {
+      "ID": 3,
+      "author": Object {
+        "ID": 1,
+      },
+      "contiguous": true,
+      "date": "2017-01-31T10:07:18-08:00",
+      "i_like": false,
+      "like_count": 0,
+      "parent": Object {
+        "ID": 1,
+      },
+      "status": "approved",
+    },
+  },
+  "4": Object {
+    "children": Array [],
+    "data": Object {
+      "ID": 4,
+      "author": Object {
+        "ID": 1,
+      },
+      "contiguous": true,
+      "date": "2015-01-29T10:07:18-08:00",
+      "i_like": false,
+      "like_count": 0,
+      "parent": Object {
+        "ID": 2,
+      },
+      "status": "approved",
+    },
+  },
+  "children": Array [
+    1,
+  ],
+}
+`;
+
 exports[`selectors #getPostCommentsTree should return the tree structure 1`] = `
 Object {
   "1": Object {
@@ -8,10 +66,14 @@ Object {
     ],
     "data": Object {
       "ID": 1,
+      "author": Object {
+        "ID": 1,
+      },
       "date": "2016-01-31T10:07:18-08:00",
       "i_like": true,
       "like_count": 5,
       "parent": false,
+      "status": "unapproved",
     },
   },
   "2": Object {
@@ -20,16 +82,23 @@ Object {
     ],
     "data": Object {
       "ID": 2,
+      "author": Object {
+        "ID": 2,
+      },
       "date": "2016-01-29T10:07:18-08:00",
       "i_like": false,
       "like_count": 456,
       "parent": false,
+      "status": "unapproved",
     },
   },
   "3": Object {
     "children": Array [],
     "data": Object {
       "ID": 3,
+      "author": Object {
+        "ID": 1,
+      },
       "contiguous": true,
       "date": "2017-01-31T10:07:18-08:00",
       "i_like": false,
@@ -37,12 +106,16 @@ Object {
       "parent": Object {
         "ID": 1,
       },
+      "status": "approved",
     },
   },
   "4": Object {
     "children": Array [],
     "data": Object {
       "ID": 4,
+      "author": Object {
+        "ID": 1,
+      },
       "contiguous": true,
       "date": "2015-01-29T10:07:18-08:00",
       "i_like": false,
@@ -50,6 +123,7 @@ Object {
       "parent": Object {
         "ID": 2,
       },
+      "status": "approved",
     },
   },
   "children": Array [

--- a/client/state/comments/test/selectors.js
+++ b/client/state/comments/test/selectors.js
@@ -20,9 +20,27 @@ const state = {
 					i_like: false,
 					contiguous: true,
 					like_count: 0,
+					status: 'approved',
+					author: { ID: 1 },
 				},
-				{ ID: 1, parent: false, date: '2016-01-31T10:07:18-08:00', i_like: true, like_count: 5 },
-				{ ID: 2, parent: false, date: '2016-01-29T10:07:18-08:00', i_like: false, like_count: 456 },
+				{
+					ID: 1,
+					parent: false,
+					date: '2016-01-31T10:07:18-08:00',
+					i_like: true,
+					like_count: 5,
+					status: 'unapproved',
+					author: { ID: 1 },
+				},
+				{
+					ID: 2,
+					parent: false,
+					date: '2016-01-29T10:07:18-08:00',
+					i_like: false,
+					like_count: 456,
+					status: 'unapproved',
+					author: { ID: 2 },
+				},
 				{
 					ID: 4,
 					parent: { ID: 2 },
@@ -30,6 +48,8 @@ const state = {
 					i_like: false,
 					contiguous: true,
 					like_count: 0,
+					status: 'approved',
+					author: { ID: 1 },
 				},
 			],
 		},
@@ -133,6 +153,11 @@ describe( 'selectors', () => {
 	describe( '#getPostCommentsTree', () => {
 		test( 'should return the tree structure', () => {
 			const tree = getPostCommentsTree( state, 1, 1, 'all' );
+			expect( tree ).toMatchSnapshot();
+		} );
+
+		test( 'filters other pending posts', () => {
+			const tree = getPostCommentsTree( state, 1, 1, 'all', 1 );
 			expect( tree ).toMatchSnapshot();
 		} );
 


### PR DESCRIPTION
Fixes #19989 

Currently the `getPostCommentsTree` selector assumes that pending items populated in `state.comments.items` belong to the current user. This can cause some visual oddities when we

1. Visit /comments
2. Select a site with comments
3. Click on the post title to filter to the comment post specific view
4. Unapprove a comment authored by someone else (or if you already have one)
5. Without refreshing the page visit the reader. Try clicking on "View Post" in the header cake:
![screen shot 2017-12-07 at 5 25 32 pm](https://user-images.githubusercontent.com/1270189/33746700-b2561bb2-db73-11e7-9e5b-8b1ac3329b5b.png)

In master we see "Your comment is awaiting moderation" text for other authors.
![32969561-71cba3ac-cb9a-11e7-9484-5729ed7a890d](https://user-images.githubusercontent.com/1270189/33746646-66d2639e-db73-11e7-8998-5e37551e4880.png)

The reader and conversations only shows pending comments if the current user authored them.

To address this, I've updated the signature of `getPostCommentsTree` so we can optionally filter out pending comments that were authored by other people.

### Testing Instructions

1. Visit /comments
2. Select a site with comments
3. Click on the post title to filter to the comment post specific view
4. Unapprove a comment authored by someone else (or if you already have one)
5. Without refreshing the page visit the reader. Try clicking on "View Post" in the header cake.
Verify that we only see approved and your pending comments in the reader/conversations.
