### PR TITLE
App Banner: Reduce time out from a year to a month

### DIFF
--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -13,7 +13,7 @@ export const READER = 'reader';
 export const STATS = 'stats';
 export const ALLOWED_SECTIONS = [ EDITOR, NOTES, READER, STATS ];
 export const ONE_WEEK_IN_MILLISECONDS = 604800000;
-export const ONE_MONTH_IN_MILLISECONDS = 2419200000;
+export const ONE_MONTH_IN_MILLISECONDS = 2419200000; // 28 days
 
 export function getAppBannerData( translate, sectionName ) {
 	switch ( sectionName ) {

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -70,11 +70,11 @@ export function getNewDismissTimes( dismissedSection, currentDismissTimes ) {
 		ALLOWED_SECTIONS,
 		( result, section ) => {
 			if ( section === dismissedSection ) {
-				// Dismiss selected section for a year.
+				// Dismiss selected section for a month.
 				result[ section ] = aMonthFromNow;
 			} else {
 				// Dismiss all other sections for a week, but make sure that we preserve previous dismiss time
-				// if it was longer than that (e.g. if other section was also dismissed for a year).
+				// if it was longer than that (e.g. if other section was also dismissed for a month).
 				result[ section ] =
 					get( currentDismissTimes, section, -Infinity ) > aWeekFromNow
 						? get( currentDismissTimes, section )

--- a/client/blocks/app-banner/utils.js
+++ b/client/blocks/app-banner/utils.js
@@ -13,7 +13,7 @@ export const READER = 'reader';
 export const STATS = 'stats';
 export const ALLOWED_SECTIONS = [ EDITOR, NOTES, READER, STATS ];
 export const ONE_WEEK_IN_MILLISECONDS = 604800000;
-export const ONE_YEAR_IN_MILLISECONDS = 31540000000;
+export const ONE_MONTH_IN_MILLISECONDS = 2419200000;
 
 export function getAppBannerData( translate, sectionName ) {
 	switch ( sectionName ) {
@@ -64,14 +64,14 @@ export function getCurrentSection( currentSection, isNotesOpen ) {
 export function getNewDismissTimes( dismissedSection, currentDismissTimes ) {
 	const currentTime = Date.now();
 	const aWeekFromNow = currentTime + ONE_WEEK_IN_MILLISECONDS;
-	const aYearFromNow = currentTime + ONE_YEAR_IN_MILLISECONDS;
+	const aMonthFromNow = currentTime + ONE_MONTH_IN_MILLISECONDS;
 
 	return reduce(
 		ALLOWED_SECTIONS,
 		( result, section ) => {
 			if ( section === dismissedSection ) {
 				// Dismiss selected section for a year.
-				result[ section ] = aYearFromNow;
+				result[ section ] = aMonthFromNow;
 			} else {
 				// Dismiss all other sections for a week, but make sure that we preserve previous dismiss time
 				// if it was longer than that (e.g. if other section was also dismissed for a year).


### PR DESCRIPTION
Fixes #20626 

Seeing the banner once a month shouldn't be too annoying. This also gives the apps two releases in between each timeout.

The value is simply `ONE_WEEK_IN_MILLISECONDS * 4`

## Testing instructions

Unfortunately I'm not aware of how to change the clock on Chrome itself, so not sure how to verify the timeout is correct. No logic is changed however, so it should behave exactly as before.