### PR TITLE
Touch node_modules once npm install completes

### DIFF
--- a/bin/install-if-deps-outdated.js
+++ b/bin/install-if-deps-outdated.js
@@ -31,6 +31,7 @@ if ( needsInstall() ) {
 	if ( installResult ) {
 		process.exit( installResult );
 	}
+	fs.utimesSync( 'node_modules', Date.now(), Date.now() );
 
 	// Cleanup old Githooks (remove in a few months from June 2017)
 	const path = require( 'path' );


### PR DESCRIPTION
For some reasons, install-if-deps-outdated.js keep trying to re-install
modules for me. Appearently npm-shrinkwrap.json has a newer mtime, but
dependencies remain unchanged so nothing is updated after npm install.

I am fixing this by always touch the node_modules directory ourselves,
when npm install completes without an error.