### PR TITLE
Fix Theme Showcase server-side redirects

### DIFF
--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -74,6 +74,7 @@ function getEnhancedContext( req, res ) {
 		protocol: req.protocol,
 		host: req.headers.host,
 		redirect: res.redirect.bind( res ),
+		res,
 	} );
 }
 


### PR DESCRIPTION
Fixes #20423 and #20416.

The `res` field in the iso-router, which is used for theme routes server-side redirects, was removed in #19319. This PR reinstates it to fix broken theme redirects.

# Testing
* Server-side hits on `/design` should redirect to `/themes`
* Server-side hits on, for example, `/themes/mood` should redirect to `/theme/mood`
