### PR TITLE
Domains: Incoming Transfers Tracks events

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -242,7 +242,10 @@ class DomainSearchResults extends React.Component {
 
 				if ( this.props.transferInAllowed && ! this.props.isSignupStep ) {
 					unavailableOffer = (
-						<DomainTransferSuggestion onButtonClick={ this.props.onClickTransfer } />
+						<DomainTransferSuggestion
+							onButtonClick={ this.props.onClickTransfer }
+							tracksButtonClickSource="search-suggestions-bottom"
+						/>
 					);
 				}
 			}

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -152,7 +152,15 @@ class DomainSearchResults extends React.Component {
 							</div>
 							<div className="domain-search-results__transfer-card-link">
 								{ translate( '{{a}}Yes, I own this domain{{/a}}', {
-									components: { a: <a href="#" onClick={ this.props.onClickTransfer } /> },
+									components: {
+										a: (
+											<a
+												href="#"
+												onClick={ this.props.onClickTransfer }
+												data-tracks-button-click-source={ this.props.tracksButtonClickSource }
+											/>
+										),
+									},
 								} ) }
 							</div>
 						</Card>

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -54,6 +54,7 @@ class DomainSuggestion extends React.Component {
 				<Button
 					borderless
 					onClick={ this.props.onButtonClick }
+					data-tracks-button-click-source={ this.props.tracksButtonClickSource }
 					className="domain-suggestion__action"
 				>
 					{ this.props.buttonContent }

--- a/client/components/domains/domain-transfer-suggestion/index.jsx
+++ b/client/components/domains/domain-transfer-suggestion/index.jsx
@@ -28,6 +28,7 @@ class DomainTransferSuggestion extends React.Component {
 				extraClasses="is-visible domain-transfer-suggestion"
 				buttonContent={ buttonContent }
 				onButtonClick={ this.props.onButtonClick }
+				tracksButtonClickSource={ this.props.tracksButtonClickSource }
 				hidePrice={ true }
 			>
 				<div className="domain-transfer-suggestion__domain-description">

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -635,7 +635,7 @@ class RegisterDomainStep extends React.Component {
 				domainUnavailableSuggestion = (
 					<DomainTransferSuggestion
 						onButtonClick={ this.goToTransferDomainStep }
-						tracksButtonClickSource="default-card"
+						tracksButtonClickSource="initial-suggestions-bottom"
 					/>
 				);
 			}
@@ -699,7 +699,7 @@ class RegisterDomainStep extends React.Component {
 				onClickMapping={ this.goToMapDomainStep }
 				onAddTransfer={ this.props.onAddTransfer }
 				onClickTransfer={ this.goToTransferDomainStep }
-				tracksButtonClickSource="search-result-card"
+				tracksButtonClickSource="exact-match-top"
 				suggestions={ suggestions }
 				products={ this.props.products }
 				selectedSite={ this.props.selectedSite }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -633,7 +633,10 @@ class RegisterDomainStep extends React.Component {
 
 			if ( this.props.transferInAllowed && ! this.props.isSignupStep ) {
 				domainUnavailableSuggestion = (
-					<DomainTransferSuggestion onButtonClick={ this.goToTransferDomainStep } />
+					<DomainTransferSuggestion
+						onButtonClick={ this.goToTransferDomainStep }
+						tracksButtonClickSource="default-card"
+					/>
 				);
 			}
 		}
@@ -696,6 +699,7 @@ class RegisterDomainStep extends React.Component {
 				onClickMapping={ this.goToMapDomainStep }
 				onAddTransfer={ this.props.onAddTransfer }
 				onClickTransfer={ this.goToTransferDomainStep }
+				tracksButtonClickSource="search-result-card"
 				suggestions={ suggestions }
 				products={ this.props.products }
 				selectedSite={ this.props.selectedSite }
@@ -752,7 +756,9 @@ class RegisterDomainStep extends React.Component {
 	goToTransferDomainStep = event => {
 		event.preventDefault();
 
-		this.props.recordTransferDomainButtonClick( this.props.analyticsSection );
+		const source = event.target.dataset.tracksButtonClickSource;
+
+		this.props.recordTransferDomainButtonClick( this.props.analyticsSection, source );
 
 		page( this.getTransferDomainUrl() );
 	};
@@ -776,10 +782,10 @@ const recordMapDomainButtonClick = section =>
 		recordTracksEvent( 'calypso_domain_search_results_mapping_button_click', { section } )
 	);
 
-const recordTransferDomainButtonClick = section =>
+const recordTransferDomainButtonClick = ( section, source ) =>
 	composeAnalytics(
 		recordGoogleEvent( 'Domain Search', 'Clicked "Use a Domain I own" Button' ),
-		recordTracksEvent( 'calypso_domain_search_results_transfer_button_click', { section } )
+		recordTracksEvent( 'calypso_domain_search_results_transfer_button_click', { section, source } )
 	);
 
 const recordSearchFormSubmit = ( searchBoxValue, section, timeDiffFromLastSearch, count, vendor ) =>

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -20,12 +20,6 @@ import { domainAvailability } from 'lib/domains/constants';
 import { getAvailabilityNotice } from 'lib/domains/registration/availability-messages';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
 import { getCurrentUser } from 'state/current-user/selectors';
-import {
-	recordAddDomainButtonClickInMapDomain,
-	recordFormSubmitInMapDomain,
-	recordInputFocusInMapDomain,
-	recordGoButtonClickInMapDomain,
-} from 'state/domains/actions';
 import Notice from 'components/notice';
 import Card from 'components/card';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
@@ -258,7 +252,7 @@ class TransferDomainStep extends React.Component {
 	}
 
 	registerSuggestedDomain = () => {
-		this.props.recordAddDomainButtonClickInMapDomain(
+		this.props.recordAddDomainButtonClickInTransferDomain(
 			this.state.suggestion.domain_name,
 			this.props.analyticsSection
 		);
@@ -267,11 +261,11 @@ class TransferDomainStep extends React.Component {
 	};
 
 	recordInputFocus = () => {
-		this.props.recordInputFocusInMapDomain( this.state.searchQuery );
+		this.props.recordInputFocusInTransferDomain( this.state.searchQuery );
 	};
 
 	recordGoButtonClick = () => {
-		this.props.recordGoButtonClickInMapDomain(
+		this.props.recordGoButtonClickInTransferDomain(
 			this.state.searchQuery,
 			this.props.analyticsSection
 		);
@@ -285,7 +279,7 @@ class TransferDomainStep extends React.Component {
 		event.preventDefault();
 
 		const domain = getFixedDomainSearch( this.state.searchQuery );
-		this.props.recordFormSubmitInMapDomain( this.state.searchQuery );
+		this.props.recordFormSubmitInTransferDomain( this.state.searchQuery );
 		this.setState( { suggestion: null, notice: null } );
 
 		checkDomainAvailability( domain, ( error, result ) => {
@@ -331,6 +325,21 @@ class TransferDomainStep extends React.Component {
 	};
 }
 
+const recordAddDomainButtonClickInTransferDomain = ( domain_name, section ) =>
+	recordTracksEvent( 'calypso_transfer_domain_add_suggested_domain_click', {
+		domain_name,
+		section,
+	} );
+
+const recordFormSubmitInTransferDomain = domain_name =>
+	recordTracksEvent( 'calypso_transfer_domain_form_submit', { domain_name } );
+
+const recordInputFocusInTransferDomain = domain_name =>
+	recordTracksEvent( 'calypso_transfer_domain_input_focus', { domain_name } );
+
+const recordGoButtonClickInTransferDomain = ( domain_name, section ) =>
+	recordTracksEvent( 'calypso_transfer_domain_go_click', { domain_name, section } );
+
 const recordMapDomainButtonClick = section =>
 	composeAnalytics(
 		recordGoogleEvent( 'Transfer Domain', 'Clicked "Map it" Button' ),
@@ -343,10 +352,10 @@ export default connect(
 		selectedSite: getSelectedSite( state ),
 	} ),
 	{
-		recordAddDomainButtonClickInMapDomain,
-		recordFormSubmitInMapDomain,
-		recordInputFocusInMapDomain,
-		recordGoButtonClickInMapDomain,
+		recordAddDomainButtonClickInTransferDomain,
+		recordFormSubmitInTransferDomain,
+		recordInputFocusInTransferDomain,
+		recordGoButtonClickInTransferDomain,
 		recordMapDomainButtonClick,
 	}
 )( localize( TransferDomainStep ) );

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -333,8 +333,8 @@ class TransferDomainStep extends React.Component {
 
 const recordMapDomainButtonClick = section =>
 	composeAnalytics(
-		recordGoogleEvent( 'Domain Search', 'Clicked "Map it" Button' ),
-		recordTracksEvent( 'calypso_domain_search_results_mapping_button_click', { section } )
+		recordGoogleEvent( 'Transfer Domain', 'Clicked "Map it" Button' ),
+		recordTracksEvent( 'calypso_transfer_domain_mapping_button_click', { section } )
 	);
 
 export default connect(


### PR DESCRIPTION
* Fixed all events on the initial Incoming Transfer screen to be `calypso_transfer_domain_` prefixed
* Added `source` to `calypso_domain_search_results_transfer_button_click` event so that we can track where the button was clicked from. Source can be one of `initial-suggestions-bottom`, `search-suggestions-bottom` or `exact-match-top`
* New `calypso_transfer_domain_mapping_button_click` to measure how many people go to mapping

In order to test - open up Redux Inspector and filter out `ANALYTICS_` events only, then check that the events are recorded on the different actions.

Known bugs:
* `calypso_domain_search_results_transfer_button_click` is recorded twice, no idea why but it has been broken even before I touched it
* `recordInputFocusInTransferDomain` was also not working. I guess because the component overrides the `onClick` prop. We should probably use onFocus instead?
