### PR TITLE
Comments: allow moderation to post authors

### DIFF
--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -39,6 +39,7 @@ const commentActions = {
 
 export class CommentActions extends Component {
 	static propTypes = {
+		canModerateComment: PropTypes.bool,
 		siteId: PropTypes.number,
 		postId: PropTypes.number,
 		commentId: PropTypes.number,
@@ -156,6 +157,7 @@ export class CommentActions extends Component {
 
 	render() {
 		const {
+			canModerateComment,
 			commentIsApproved,
 			commentIsLiked,
 			toggleEditMode,
@@ -173,6 +175,7 @@ export class CommentActions extends Component {
 						} ) }
 						onClick={ this.toggleApproved }
 						tabIndex="0"
+						disabled={ ! canModerateComment }
 					>
 						<Gridicon icon={ commentIsApproved ? 'checkmark-circle' : 'checkmark' } />
 						<span>{ commentIsApproved ? translate( 'Approved' ) : translate( 'Approve' ) }</span>
@@ -185,6 +188,7 @@ export class CommentActions extends Component {
 						className="comment__action comment__action-spam"
 						onClick={ this.setSpam }
 						tabIndex="0"
+						disabled={ ! canModerateComment }
 					>
 						<Gridicon icon="spam" />
 						<span>{ translate( 'Spam' ) }</span>
@@ -197,6 +201,7 @@ export class CommentActions extends Component {
 						className="comment__action comment__action-trash"
 						onClick={ this.setTrash }
 						tabIndex="0"
+						disabled={ ! canModerateComment }
 					>
 						<Gridicon icon="trash" />
 						<span>{ translate( 'Trash' ) }</span>
@@ -209,6 +214,7 @@ export class CommentActions extends Component {
 						className="comment__action comment__action-delete"
 						onClick={ this.delete }
 						tabIndex="0"
+						disabled={ ! canModerateComment }
 					>
 						<Gridicon icon="trash" />
 						<span>{ translate( 'Delete Permanently' ) }</span>
@@ -235,6 +241,7 @@ export class CommentActions extends Component {
 						className="comment__action comment__action-pencil"
 						onClick={ toggleEditMode }
 						tabIndex="0"
+						disabled={ ! canModerateComment }
 					>
 						<Gridicon icon="pencil" />
 						<span>{ translate( 'Edit' ) }</span>
@@ -262,6 +269,7 @@ const mapStateToProps = ( state, { siteId, commentId } ) => {
 	const commentStatus = get( comment, 'status' );
 
 	return {
+		canModerateComment: get( comment, 'post.can_manage_comments', false ),
 		commentIsApproved: 'approved' === commentStatus,
 		commentIsLiked: get( comment, 'i_like' ),
 		commentStatus,

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -229,6 +229,7 @@ export class CommentActions extends Component {
 						} ) }
 						onClick={ this.toggleLike }
 						tabIndex="0"
+						disabled={ ! canModerateComment && ! commentIsApproved }
 					>
 						<Gridicon icon={ commentIsLiked ? 'star' : 'star-outline' } />
 						<span>{ commentIsLiked ? translate( 'Liked' ) : translate( 'Like' ) }</span>
@@ -254,6 +255,7 @@ export class CommentActions extends Component {
 						className="comment__action comment__action-reply"
 						onClick={ toggleReply }
 						tabIndex="0"
+						disabled={ ! canModerateComment && ! commentIsApproved }
 					>
 						<Gridicon icon="reply" />
 						<span>{ translate( 'Reply' ) }</span>
@@ -269,7 +271,7 @@ const mapStateToProps = ( state, { siteId, commentId } ) => {
 	const commentStatus = get( comment, 'status' );
 
 	return {
-		canModerateComment: get( comment, 'post.can_manage_comments', false ),
+		canModerateComment: get( comment, 'can_moderate', false ),
 		commentIsApproved: 'approved' === commentStatus,
 		commentIsLiked: get( comment, 'i_like' ),
 		commentStatus,

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -357,6 +357,14 @@
 	}
 }
 
+.button[disabled].is-borderless.comment__action.is-approved {
+	color: lighten($gray, 30%);
+}
+
+.button[disabled].is-borderless.comment__action:hover {
+	color: lighten($gray, 30%);
+}
+
 // Comment Reply Block
 
 .comment__reply {

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -113,7 +113,7 @@ export class CommentsManagement extends Component {
 const mapStateToProps = ( state, { siteFragment } ) => {
 	const siteId = getSiteId( state, siteFragment );
 	const isJetpack = isJetpackSite( state, siteId );
-	const canModerateComments = canCurrentUser( state, siteId, 'moderate_comments' );
+	const canModerateComments = canCurrentUser( state, siteId, 'edit_posts' );
 	const showJetpackUpdateScreen =
 		isJetpack &&
 		! isJetpackMinimumVersion( state, siteId, '5.5' ) &&

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -107,7 +107,7 @@ class ManageMenu extends PureComponent {
 			{
 				name: 'comments',
 				label: this.props.translate( 'Comments' ),
-				capability: 'moderate_comments',
+				capability: 'edit_posts',
 				queryable: true,
 				config: 'comments/management',
 				link: '/comments',


### PR DESCRIPTION
Closes: https://github.com/Automattic/wp-calypso/issues/19978

Depends on: D8703-code

Previously we were hiding the comments management section from post authors, which was not matching what wp-admin does. Furthermore, after allowing authors to view all the comments, this will disable the comment management action buttons for comments that belong to posts that they haven't authored.

### Testing instructions:

1. Apply D8703-code and sandbox the API.
2. Add a user with `Author` capability to your test blog.
3. Write a post with that test user and add some comments to it.
4. Navigate to `comments/all` and verify that `Author` test user can manage all of the comments for this post.
5. Repeat step 3 while using `Admininistrator` test account. 
6. The test user with `Author` role shouldn't be able to manage comments for this post.
7. Switch the user role of `Author` test user to `Contributor`.
8. This user should still see the comments management section but shouldn't be able to manage any comments (even the ones that have been authored by them).
9. Verify that `Admininistrator` and `Editor` roles can still manage all of the site's comments.
10. Repeat testing steps for Jetpack sites. :)

### Visual changes

![screenshot from 2017-12-08 17-08-26](https://user-images.githubusercontent.com/1182160/33774147-92f67060-dc3a-11e7-8760-4b1b78b6d0f1.png)
