### PR TITLE
State: Fix data layer of profile links

### DIFF
--- a/client/state/data-layer/wpcom/me/settings/profile-links/delete/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/delete/index.js
@@ -14,42 +14,36 @@ import {
 /**
  * Dispatches a request to delete a profile link for the current user
  *
- * @param   {Function} dispatch Redux dispatcher
- * @param   {Object}   action   Redux action
+ * @param   {Object} action Redux action
  * @returns {Object} Dispatched http action
  */
-export const deleteUserProfileLink = ( { dispatch }, action ) =>
-	dispatch(
-		http(
-			{
-				apiVersion: '1.1',
-				method: 'POST',
-				path: '/me/settings/profile-links/' + action.linkSlug + '/delete',
-			},
-			action
-		)
+export const deleteUserProfileLink = action =>
+	http(
+		{
+			apiVersion: '1.1',
+			method: 'POST',
+			path: '/me/settings/profile-links/' + action.linkSlug + '/delete',
+		},
+		action
 	);
 
 /**
  * Dispatches a user profile links deletion success action when the request succeeded.
  *
- * @param   {Function} dispatch Redux dispatcher
- * @param   {Object}   action   Redux action
+ * @param   {Object} action Redux action
  * @returns {Object} Dispatched user profile links delete success action
  */
-export const handleDeleteSuccess = ( { dispatch }, { linkSlug } ) =>
-	dispatch( deleteUserProfileLinkSuccess( linkSlug ) );
+export const handleDeleteSuccess = ( { linkSlug } ) => deleteUserProfileLinkSuccess( linkSlug );
 
 /**
  * Dispatches a user profile links deletion error action when the request failed.
  *
- * @param   {Function} dispatch Redux dispatcher
- * @param   {Object}   action   Redux action
- * @param   {Object}   error    Error returned
+ * @param   {Object} action Redux action
+ * @param   {Object} error  Error returned
  * @returns {Object} Dispatched user profile links delete error action
  */
-export const handleDeleteError = ( { dispatch }, { linkSlug }, error ) =>
-	dispatch( deleteUserProfileLinkError( linkSlug, error ) );
+export const handleDeleteError = ( { linkSlug }, error ) =>
+	deleteUserProfileLinkError( linkSlug, error );
 
 export default {
 	[ USER_PROFILE_LINKS_DELETE ]: [

--- a/client/state/data-layer/wpcom/me/settings/profile-links/delete/test/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/delete/test/index.js
@@ -11,21 +11,18 @@ import {
 } from 'state/profile-links/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
+const linkSlug = 'https-wordpress-com';
 const error = {
 	status: 403,
 	message: 'An active access token must be used to query information about the current user.',
 };
 
 describe( 'deleteUserProfileLink()', () => {
-	test( 'should dispatch a POST HTTP request to the delete user profile link endpoint', () => {
-		const dispatch = jest.fn();
-		const linkSlug = 'https-wordpress-com';
+	test( 'should return an action for POST HTTP request to the delete user profile link endpoint', () => {
 		const action = deleteUserProfileLinkAction( linkSlug );
+		const testAction = deleteUserProfileLink( action );
 
-		deleteUserProfileLink( { dispatch }, action );
-
-		expect( dispatch ).toHaveBeenCalledTimes( 1 );
-		expect( dispatch ).toHaveBeenCalledWith(
+		expect( testAction ).toEqual(
 			http(
 				{
 					apiVersion: '1.1',
@@ -39,25 +36,17 @@ describe( 'deleteUserProfileLink()', () => {
 } );
 
 describe( 'handleDeleteSuccess()', () => {
-	test( 'should dispatch user profile links delete success action', () => {
-		const dispatch = jest.fn();
-		const linkSlug = 'https-wordpress-com';
+	test( 'should return a user profile links delete success action', () => {
+		const action = handleDeleteSuccess( { linkSlug } );
 
-		handleDeleteSuccess( { dispatch }, { linkSlug } );
-
-		expect( dispatch ).toHaveBeenCalledTimes( 1 );
-		expect( dispatch ).toHaveBeenCalledWith( deleteUserProfileLinkSuccess( linkSlug ) );
+		expect( action ).toEqual( deleteUserProfileLinkSuccess( linkSlug ) );
 	} );
 } );
 
 describe( 'handleDeleteError()', () => {
-	test( 'should dispatch user profile links add error action', () => {
-		const dispatch = jest.fn();
-		const linkSlug = 'https-wordpress-com';
+	test( 'should return a user profile links add error action', () => {
+		const action = handleDeleteError( { linkSlug }, error );
 
-		handleDeleteError( { dispatch }, { linkSlug }, error );
-
-		expect( dispatch ).toHaveBeenCalledTimes( 1 );
-		expect( dispatch ).toHaveBeenCalledWith( deleteUserProfileLinkError( linkSlug, error ) );
+		expect( action ).toEqual( deleteUserProfileLinkError( linkSlug, error ) );
 	} );
 } );

--- a/client/state/data-layer/wpcom/me/settings/profile-links/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/index.js
@@ -13,38 +13,34 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { USER_PROFILE_LINKS_REQUEST } from 'state/action-types';
 import { receiveUserProfileLinks } from 'state/profile-links/actions';
-import { newHandler } from './new';
-import { deleteHandler } from './delete';
+import newHandler from './new';
+import deleteHandler from './delete';
 
 /**
  * Dispatches a request to fetch profile links of the current user
  *
- * @param   {Function} dispatch Redux dispatcher
- * @param   {Object}   action   Redux action
+ * @param   {Object} action Redux action
  * @returns {Object} Dispatched http action
  */
-export const requestUserProfileLinks = ( { dispatch }, action ) =>
-	dispatch(
-		http(
-			{
-				apiVersion: '1.1',
-				method: 'GET',
-				path: '/me/settings/profile-links',
-			},
-			action
-		)
+export const requestUserProfileLinks = action =>
+	http(
+		{
+			apiVersion: '1.1',
+			method: 'GET',
+			path: '/me/settings/profile-links',
+		},
+		action
 	);
 
 /**
  * Dispatches a user profile links receive action when the request succeeded.
  *
- * @param   {Function} dispatch Redux dispatcher
- * @param   {Object}   action   Redux action
- * @param   {Array}    data     Response from the endpoint
+ * @param   {Object} action Redux action
+ * @param   {Array}  data   Response from the endpoint
  * @returns {Object} Dispatched user profile links receive action
  */
-export const handleRequestSuccess = ( { dispatch }, action, { profile_links } ) =>
-	dispatch( receiveUserProfileLinks( profile_links ) );
+export const handleRequestSuccess = ( action, { profile_links } ) =>
+	receiveUserProfileLinks( profile_links );
 
 const requestHandler = {
 	[ USER_PROFILE_LINKS_REQUEST ]: [

--- a/client/state/data-layer/wpcom/me/settings/profile-links/new/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/new/index.js
@@ -17,23 +17,20 @@ import {
 /**
  * Dispatches a request to add profile links for the current user
  *
- * @param   {Function} dispatch Redux dispatcher
- * @param   {Object}   action   Redux action
+ * @param   {Object} action Redux action
  * @returns {Object} Dispatched http action
  */
-export const addUserProfileLinks = ( { dispatch }, action ) =>
-	dispatch(
-		http(
-			{
-				apiVersion: '1.2',
-				method: 'POST',
-				path: '/me/settings/profile-links/new',
-				body: {
-					links: action.profileLinks,
-				},
+export const addUserProfileLinks = action =>
+	http(
+		{
+			apiVersion: '1.2',
+			method: 'POST',
+			path: '/me/settings/profile-links/new',
+			body: {
+				links: action.profileLinks,
 			},
-			action
-		)
+		},
+		action
 	);
 
 /**
@@ -42,35 +39,33 @@ export const addUserProfileLinks = ( { dispatch }, action ) =>
  * - duplicate links
  * - malformed links
  *
- * @param   {Function} dispatch Redux dispatcher
- * @param   {Object}   action   Redux action
- * @param   {Array}    data     Response from the endpoint
+ * @param   {Object} action Redux action
+ * @param   {Array}  data   Response from the endpoint
  * @returns {Object} Dispatched user profile links add action
  */
-export const handleAddSuccess = ( { dispatch }, action, data ) => {
-	dispatch( addUserProfileLinksSuccess( data.profile_links ) );
+export const handleAddSuccess = ( action, data ) => {
+	const actions = [ addUserProfileLinksSuccess( action.profileLinks ) ];
 
 	if ( data.duplicate ) {
-		return dispatch( addUserProfileLinksDuplicate( data.duplicate ) );
+		actions.push( addUserProfileLinksDuplicate( data.duplicate ) );
+	} else if ( data.malformed ) {
+		actions.push( addUserProfileLinksMalformed( data.malformed ) );
+	} else {
+		actions.push( receiveUserProfileLinks( data.profile_links ) );
 	}
 
-	if ( data.malformed ) {
-		return dispatch( addUserProfileLinksMalformed( data.malformed ) );
-	}
-
-	return dispatch( receiveUserProfileLinks( data.profile_links ) );
+	return actions;
 };
 
 /**
  * Dispatches a user profile links add error action when the request failed.
  *
- * @param   {Function} dispatch Redux dispatcher
- * @param   {Object}   action   Redux action
- * @param   {Object}   error    Error returned
+ * @param   {Object} action Redux action
+ * @param   {Object} error  Error returned
  * @returns {Object} Dispatched user profile links add error action
  */
-export const handleAddError = ( { dispatch }, { profileLinks }, error ) =>
-	dispatch( addUserProfileLinksError( profileLinks, error ) );
+export const handleAddError = ( { profileLinks }, error ) =>
+	addUserProfileLinksError( profileLinks, error );
 
 export default {
 	[ USER_PROFILE_LINKS_ADD ]: [

--- a/client/state/data-layer/wpcom/me/settings/profile-links/new/test/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/new/test/index.js
@@ -32,14 +32,11 @@ const error = {
 };
 
 describe( 'addUserProfileLinks()', () => {
-	test( 'should dispatch a POST HTTP request to the users new profile links endpoint', () => {
-		const dispatch = jest.fn();
+	test( 'should return an action for POST HTTP request to the users new profile links endpoint', () => {
 		const action = addUserProfileLinksAction( profileLinks );
+		const testAction = addUserProfileLinks( action );
 
-		addUserProfileLinks( { dispatch }, action );
-
-		expect( dispatch ).toHaveBeenCalledTimes( 1 );
-		expect( dispatch ).toHaveBeenCalledWith(
+		expect( testAction ).toEqual(
 			http(
 				{
 					apiVersion: '1.2',
@@ -56,53 +53,48 @@ describe( 'addUserProfileLinks()', () => {
 } );
 
 describe( 'handleAddSuccess()', () => {
-	test( 'should dispatch user profile links add success and receive actions', () => {
-		const dispatch = jest.fn();
+	const successAction = addUserProfileLinksSuccess( profileLinks );
+
+	test( 'should return user profile links add success and receive actions', () => {
 		const data = { profile_links: profileLinks };
+		const actions = handleAddSuccess( successAction, data );
 
-		handleAddSuccess( { dispatch }, null, data );
-
-		expect( dispatch ).toHaveBeenCalledTimes( 2 );
-		expect( dispatch ).toHaveBeenCalledWith( addUserProfileLinksSuccess( profileLinks ) );
-		expect( dispatch ).toHaveBeenCalledWith( receiveUserProfileLinks( profileLinks ) );
+		expect( actions ).toHaveLength( 2 );
+		expect( actions[ 0 ] ).toEqual( successAction );
+		expect( actions[ 1 ] ).toEqual( receiveUserProfileLinks( profileLinks ) );
 	} );
 
-	test( 'should dispatch user profile links add success and duplicate actions', () => {
-		const dispatch = jest.fn();
+	test( 'should return user profile links add success and duplicate actions', () => {
 		const data = {
 			profile_links: [ profileLinks[ 0 ] ],
 			duplicate: [ profileLinks[ 1 ] ],
 		};
+		const duplicateAction = addUserProfileLinksDuplicate( data.duplicate );
+		const actions = handleAddSuccess( { profileLinks }, data );
 
-		handleAddSuccess( { dispatch }, null, data );
-
-		expect( dispatch ).toHaveBeenCalledTimes( 2 );
-		expect( dispatch ).toHaveBeenCalledWith( addUserProfileLinksSuccess( data.profile_links ) );
-		expect( dispatch ).toHaveBeenCalledWith( addUserProfileLinksDuplicate( data.duplicate ) );
+		expect( actions ).toHaveLength( 2 );
+		expect( actions[ 0 ] ).toEqual( successAction );
+		expect( actions[ 1 ] ).toEqual( duplicateAction );
 	} );
 
-	test( 'should dispatch user profile links add success and malformed actions', () => {
-		const dispatch = jest.fn();
+	test( 'should return user profile links add success and malformed actions', () => {
 		const data = {
 			profile_links: [ profileLinks[ 0 ] ],
 			malformed: [ profileLinks[ 1 ] ],
 		};
+		const malformedAction = addUserProfileLinksMalformed( data.malformed );
+		const actions = handleAddSuccess( { profileLinks }, data );
 
-		handleAddSuccess( { dispatch }, null, data );
-
-		expect( dispatch ).toHaveBeenCalledTimes( 2 );
-		expect( dispatch ).toHaveBeenCalledWith( addUserProfileLinksSuccess( data.profile_links ) );
-		expect( dispatch ).toHaveBeenCalledWith( addUserProfileLinksMalformed( data.malformed ) );
+		expect( actions ).toHaveLength( 2 );
+		expect( actions[ 0 ] ).toEqual( successAction );
+		expect( actions[ 1 ] ).toEqual( malformedAction );
 	} );
 } );
 
 describe( 'handleAddError()', () => {
-	test( 'should dispatch user profile links add error action', () => {
-		const dispatch = jest.fn();
+	test( 'should return a user profile links add error action', () => {
+		const action = handleAddError( { profileLinks }, error );
 
-		handleAddError( { dispatch }, { profileLinks }, error );
-
-		expect( dispatch ).toHaveBeenCalledTimes( 1 );
-		expect( dispatch ).toHaveBeenCalledWith( addUserProfileLinksError( profileLinks, error ) );
+		expect( action ).toEqual( addUserProfileLinksError( profileLinks, error ) );
 	} );
 } );

--- a/client/state/data-layer/wpcom/me/settings/profile-links/test/index.js
+++ b/client/state/data-layer/wpcom/me/settings/profile-links/test/index.js
@@ -21,13 +21,10 @@ const profileLinks = [
 ];
 
 describe( 'requestUserProfileLinks()', () => {
-	test( 'should dispatch HTTP request to fetch the users profile links endpoint', () => {
-		const dispatch = jest.fn();
+	test( 'should return an action for HTTP request to fetch the users profile links endpoint', () => {
+		const action = requestUserProfileLinks();
 
-		requestUserProfileLinks( { dispatch } );
-
-		expect( dispatch ).toHaveBeenCalledTimes( 1 );
-		expect( dispatch ).toHaveBeenCalledWith(
+		expect( action ).toEqual(
 			http( {
 				apiVersion: '1.1',
 				method: 'GET',
@@ -38,13 +35,10 @@ describe( 'requestUserProfileLinks()', () => {
 } );
 
 describe( 'handleRequestSuccess()', () => {
-	test( 'should dispatch user profile links receive action', () => {
-		const dispatch = jest.fn();
+	test( 'should return a user profile links receive action', () => {
+		const action = handleRequestSuccess( null, { profile_links: profileLinks } );
 
-		handleRequestSuccess( { dispatch }, null, { profile_links: profileLinks } );
-
-		expect( dispatch ).toHaveBeenCalledTimes( 1 );
-		expect( dispatch ).toHaveBeenCalledWith( {
+		expect( action ).toEqual( {
 			type: USER_PROFILE_LINKS_RECEIVE,
 			profileLinks,
 		} );


### PR DESCRIPTION
It seems when we migrated the profile links data layer to use `dispatchRequestEx`, we didn't account for all of the changes we needed to do (having to return actions vs. dispatching them). This PR fixes that. A great benefit is that it simplifies the code quite a bit.

Necessary for #20241.

To test:
* Checkout this branch
* Verify all data layer profile links tests pass: `npm run test-client client/state/data-layer/wpcom/me/settings/profile-links/`
* Load some random page in Calypso, for example the Reader: http://calypso.localhost:3000/
* Verify the expected actions are being dispatched accordingly after each of the following:
  * Try fetching all profile links by typing the following in your console: `dispatch( { type: 'USER_PROFILE_LINKS_REQUEST' } )`
  * Try adding a profile link by typing the following in your console: `dispatch( { type: 'USER_PROFILE_LINKS_ADD', profileLinks: [ { title: 'WordPress.org',
value: 'https://wordpress.org/' } ] } )`
  * Try deleting that profile link by typing the following in your console: `dispatch( { type: 'USER_PROFILE_LINKS_DELETE', linkSlug: 'https-wordpress-org' } )`
