### PR TITLE
Components: Introduce a QueryProfileLinks query component

### DIFF
--- a/client/components/data/query-profile-links/README.md
+++ b/client/components/data/query-profile-links/README.md
@@ -1,0 +1,18 @@
+Query Profile Links
+===========================
+
+`<QueryProfileLinks />` is a React component used to request the profile links of the current user.
+
+## Usage
+
+Render the component without props. It does not accept any children, nor does it render any elements to the page.
+
+```jsx
+import QueryProfileLinks from 'components/data/query-profile-links';
+
+export default () => (
+	<div>
+		<QueryProfileLinks />
+	</div>
+);
+```

--- a/client/components/data/query-profile-links/index.jsx
+++ b/client/components/data/query-profile-links/index.jsx
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestUserProfileLinks } from 'state/profile-links/actions';
+
+class QueryProfileLinks extends Component {
+	static propTypes = {
+		requestUserProfileLinks: PropTypes.func,
+	};
+
+	componentDidMount() {
+		this.props.requestUserProfileLinks();
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect( null, { requestUserProfileLinks } )( QueryProfileLinks );


### PR DESCRIPTION
This PR introduces a `QueryProfileLinks` query component that we can use to request the profile links of the current user.

Contains #20637, which fixes the profile links data layer.

Part of #20241.

To test:
* Checkout this branch
* Drop this component somewhere
* Observe the right actions are being dispatched upon render, along with the expected network request:
  * `USER_PROFILE_LINKS_REQUEST`
  * HTTP request to fetch the profile links
  * `USER_PROFILE_LINKS_RECEIVE` with the profile links