### PR TITLE
Components: Fix card link indicator in Tile for mobile

### DIFF
--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -70,6 +70,10 @@
 
 	&.is-card-link {
 		padding-right: 0;
+
+		@include breakpoint( "<480px" ) {
+			padding-right: 40px;
+		}
 	}
 
 	a, svg {
@@ -90,6 +94,7 @@
 			border-top: 2px solid lighten( $gray, 20% );
 			border-right: 2px solid lighten( $gray, 20% );
 			transform: rotate(45deg);
+			color: #fff;
 		}
 	}
 }

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -89,8 +89,9 @@
 			width: 8px; //Match the size of the cta copy
 			height: 8px; //Match the size of the cta copy
 			position: absolute;
-			top: 20px;
+			top: 50%;
 			right: 15px;
+			margin-top: -6px;
 			border-top: 2px solid lighten( $gray, 20% );
 			border-right: 2px solid lighten( $gray, 20% );
 			transform: rotate(45deg);

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -142,8 +142,9 @@
 
 	@include breakpoint( "<480px" ) {
 		background: none;
+		text-align: left;
 		font-size: 16px;
-		line-height: 18px;
+		line-height: 1.2;
 		border: 0;
 		padding: 0;
 		text-transform: none;

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -142,11 +142,11 @@
 
 	@include breakpoint( "<480px" ) {
 		background: none;
-		font-size: 1.1em;
+		font-size: 16px;
+		line-height: 18px;
 		border: 0;
 		padding: 0;
 		text-transform: none;
 		margin: 0;
-		line-height: 1.1em;
 	}
 }

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -20,6 +20,7 @@
 
 	@include breakpoint( "<480px" ) {
 		box-shadow: none; //inherited from .card, remove for mobile only
+		width: 100%;
 	}
 
 	@include breakpoint( ">480px" ) {


### PR DESCRIPTION
This PR fixes the card link indicator for linked `Tile` components for mobile devices. This should not affect larger devices at all.

Before:
![](https://cldup.com/rbLcPTY_R2.png)

After:
![](https://cldup.com/P9IhHBznTa.png)

To test:
* Checkout this branch
* On mobile, go to http://calypso.localhost:3000/devdocs/design/tile-grid
* Verify the link indicator appears properly, as on the "After" preview.
* Verify there are no visual changes for desktop devices.