### PR TITLE
Activity Log: Insert ellipsis menu on failed backup/restore items with links to help and chat

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -100,7 +100,7 @@ class ActivityLogItem extends Component {
 			log: { activityIsRewindable, activityName },
 		} = this.props;
 
-		if ( 'rewind__error' === activityName ) {
+		if ( 'rewind__error' === activityName || 'rewind__backup_error' === activityName ) {
 			return (
 				<EllipsisMenu onClick={ stopPropagation } position="bottom right">
 					<PopoverMenuItem icon="help" href="https://jetpack.com/support/activity-log/">

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -103,15 +103,18 @@ class ActivityLogItem extends Component {
 		if ( 'rewind__error' === activityName ) {
 			return (
 				<EllipsisMenu onClick={ stopPropagation } position="bottom right">
-					<PopoverMenuItem icon="help" href="http://jetpack.com/support/activity-log/">
+					<PopoverMenuItem icon="help" href="https://jetpack.com/support/activity-log/">
 						{ translate( 'Learn more' ) }
 					</PopoverMenuItem>
-					{ this.props.isChatActive &&
-						this.props.isChatAvailable && (
-							<PopoverMenuItem icon="chat" onClick={ this.props.openChat }>
-								{ translate( 'Get help' ) }
-							</PopoverMenuItem>
-						) }
+					{ this.props.isChatActive && this.props.isChatAvailable ? (
+						<PopoverMenuItem icon="chat" onClick={ this.props.openChat }>
+							{ translate( 'Get help' ) }
+						</PopoverMenuItem>
+					) : (
+						<PopoverMenuItem icon="chat" href="https://wordpress.com/me/contact">
+							{ translate( 'Get help' ) }
+						</PopoverMenuItem>
+					) }
 				</EllipsisMenu>
 			);
 		}


### PR DESCRIPTION
First attempt to solve https://github.com/Automattic/wp-calypso/issues/20385

- Inserts the ellipsis menu on AL items named `rewind__error` or `rewind__backup_error`
- Adds an option to the menu titled "Learn More" which links to [https://jetpack.com/support/activity-log/](https://jetpack.com/support/activity-log/). 
- Adds a "Get help" item which opens a chat window when Happychat is available, and links to `/me/contact` when Happychat is not available.

![screen shot 2017-12-08 at 10 49 55 am](https://user-images.githubusercontent.com/5528445/33773443-e3a30fb2-dc05-11e7-8ad9-3e03e404c678.png)

![screen shot 2017-12-08 at 10 49 59 am](https://user-images.githubusercontent.com/5528445/33773445-e5ddd230-dc05-11e7-8971-fbedc31d6673.png)

Testing Instructions coming soon. This is a work in progress.