### PR TITLE
Updated checklist sharing options

### DIFF
--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -94,15 +94,7 @@ export class ChecklistBanner extends Component {
 
 	renderShareButtons() {
 		const { siteSlug, translate } = this.props;
-		const socialMedia = [
-			'wordpress',
-			'facebook',
-			'twitter',
-			'google-plus',
-			'linkedin',
-			'tumblr',
-			'pinterest',
-		];
+		const socialMedia = [ 'facebook', 'twitter', 'linkedin', 'google-plus', 'pinterest' ];
 
 		return (
 			<div className="checklist-banner__actions">


### PR DESCRIPTION
This PR updates the checklist sharing options because I don't know what I was thinking when I first created the list. One of the checklist tasks is to write your first blog post, asking them to write another after they complete the list doesn't make sense. 


![image](https://user-images.githubusercontent.com/6981253/33773532-3ae59326-dc06-11e7-8707-c258c5479357.png)

cc @taggon 