### PR TITLE
Reposition close button

### DIFF
--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -164,6 +164,16 @@ export class ChecklistBanner extends Component {
 					<span className="checklist-banner__progress-title">{ translate( 'Site setup' ) }</span>
 					<span className="checklist-banner__progress-desc">
 						{ translate( '%(percentage)s%% completed', { args: { percentage } } ) }
+
+						{ completed === total && (
+							<Button
+								borderless
+								className="checklist-banner__close-mobile"
+								onClick={ this.handleClose }
+							>
+								<Gridicon size={ 24 } icon="cross" color="#87a6bc" />
+							</Button>
+						) }
 					</span>
 					<ProgressBar value={ completed } total={ total } color="#47b766" />
 				</div>

--- a/client/my-sites/stats/checklist-banner/style.scss
+++ b/client/my-sites/stats/checklist-banner/style.scss
@@ -113,11 +113,22 @@
 }
 
 .checklist-banner__close {
-	position: absolute;
-	top: 8px;
-	right: 16px;
+	display: none;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint( '>660px' ) {
+		display: block;
+		position: absolute;
+		top: -5px;
+		right: 5px;
+	}
+}
+
+.checklist-banner__close-mobile {
+	display: inline-block;
+	margin-top: -13px; /* line up with baseline of copy */
+	margin-left: 5px;
+
+	@include breakpoint( '>660px' ) {
 		display: none;
 	}
 }


### PR DESCRIPTION
This PR repositions the close button for the checklist banner and shows the close button on small screens too.

## Before
![screen shot 2017-12-08 at 10 58 57 am](https://user-images.githubusercontent.com/6981253/33775100-4ca000b0-dc0b-11e7-96bc-8b652bac6135.png)

Hidden on mobile

## After
`Desktop`
![image](https://user-images.githubusercontent.com/6981253/33774961-e6251730-dc0a-11e7-9bab-5873ddb80f9a.png)

`Mobile`
![image](https://user-images.githubusercontent.com/6981253/33774991-fabd74da-dc0a-11e7-9b70-3e59fd4bd991.png)


## Test
* Create a new sites
* Visit /stats and mark all tasks complete on the checklist
* View share banner on Stats again

cc @taggon 
