### PR TITLE
Store: Package modal: ensure max weight is greater than package weight.

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/packages/modal-errors.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/modal-errors.js
@@ -43,12 +43,20 @@ const checkAndConvertNumber = value => {
 };
 
 const preProcessPackageData = ( data, boxNames ) => {
+	const boxWeight = checkAndConvertNumber( data.box_weight );
+	let maxWeight = checkAndConvertNumber( data.max_weight );
+
+	// Ensure that max weight exceeds the weight of the empty package.
+	if ( boxWeight && maxWeight && maxWeight <= boxWeight ) {
+		maxWeight = null;
+	}
+
 	const result = {
 		name: checkDuplicateName( data.name, boxNames ),
 		inner_dimensions: data.inner_dimensions,
 		outer_dimensions: checkNullOrWhitespace( data.outer_dimensions ),
-		box_weight: checkAndConvertNumber( data.box_weight ),
-		max_weight: checkAndConvertNumber( data.max_weight ),
+		box_weight: boxWeight,
+		max_weight: maxWeight,
 	};
 
 	return omitBy( result, value => null === value );


### PR DESCRIPTION
Fixes #20644.

Enforces a max weight greater than the weight of the empty package. Note that this does not provide a more informative error message than the existing "invalid value".

To test:
* Edit or add a package
* Enter a max weight equal to or less than the package weight
* Verify the validation fails
* Enter a max weight greater than the package weight
* Verify the max weight field passes validation