### PR TITLE
Activity log: check restore status from server

### DIFF
--- a/client/components/data/query-rewind-restore-status/index.js
+++ b/client/components/data/query-rewind-restore-status/index.js
@@ -18,6 +18,19 @@ class QueryRewindRestoreStatus extends Component {
 		siteId: PropTypes.number.isRequired,
 	};
 
+	componentWillMount() {
+		// We want to run this only once: when the page is loaded. In such case, there is not known restore Id.
+		// If there's a restore Id here it means this was mounted during an action requesting progress for a
+		// specific restore Id, so we will do nothing here,since it will be handled by the <Interval /> below.
+		if ( ! this.props.restoreId ) {
+			const { siteId } = this.props;
+
+			if ( siteId ) {
+				this.props.getRewindRestoreProgress( siteId );
+			}
+		}
+	}
+
 	query = () => {
 		const { restoreId, siteId } = this.props;
 		if ( siteId && restoreId ) {

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -30,6 +30,7 @@ import QueryRewindState from 'components/data/query-rewind-state';
 import QueryRewindStatus from 'components/data/query-rewind-status';
 import QuerySiteSettings from 'components/data/query-site-settings'; // For site time offset
 import QueryRewindBackupStatus from 'components/data/query-rewind-backup-status';
+import QueryRewindRestoreStatus from 'components/data/query-rewind-restore-status';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsFirstView from '../stats-first-view';
 import StatsNavigation from 'blocks/stats-navigation';
@@ -600,6 +601,7 @@ class ActivityLog extends Component {
 				<QueryRewindState siteId={ siteId } />
 				<QueryActivityLog siteId={ siteId } { ...logRequestQuery } />
 				{ siteId && isRewindActive && <QueryRewindBackupStatus siteId={ siteId } /> }
+				{ siteId && isRewindActive && <QueryRewindRestoreStatus siteId={ siteId } /> }
 				<QuerySiteSettings siteId={ siteId } />
 				{ isRewindActive && <QueryJetpackCredentials siteId={ siteId } /> }
 				<StatsFirstView />


### PR DESCRIPTION
This PR:
- [ ] performs a restore status check on page load. It's done without the restore Id, so it will return the last restore object
- [ ] the ⨉ allows to mark a restore as dismissed in the server