### PR TITLE
Domains: prevent phone country code input from throwing TypeError

### DIFF
--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -255,8 +255,13 @@ export function toE164( inputNumber, country ) {
 }
 
 export function toIcannFormat( inputNumber, country ) {
+	if ( ! country ) {
+		return inputNumber;
+	}
+
 	const { nationalNumber } = processNumber( inputNumber, country ),
 		countryCode = country.countryDialCode || country.dialCode,
 		dialCode = country.countryDialCode && country.regionCode ? country.regionCode : '';
+
 	return '+' + countryCode + '.' + dialCode + nationalNumber;
 }

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -256,6 +256,10 @@ export class DomainDetailsForm extends PureComponent {
 			value,
 		} );
 
+		if ( ! countries[ countryCode ] ) {
+			return;
+		}
+
 		this.setState( {
 			phoneCountryCode: countryCode,
 		} );


### PR DESCRIPTION
`toIcannFormat` requires a valid country object from our countries list, so we must ensure we send that + that it handles situations without more gracefully

Fixes #20650