### PR TITLE
Checkout: Adjust Jetpack checkout link to plans dashboard

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -567,7 +567,7 @@ class JetpackThankYouCard extends Component {
 						} ) }
 						href={ buttonUrl }
 					>
-						{ translate( 'Configure your plan' ) }
+						{ translate( 'Explore your plan' ) }
 					</a>
 					{ this.renderLiveChatButton() }
 				</div>

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -567,7 +567,7 @@ class JetpackThankYouCard extends Component {
 						} ) }
 						href={ buttonUrl }
 					>
-						{ translate( 'Visit your site' ) }
+						{ translate( 'Configure your plan' ) }
 					</a>
 					{ this.renderLiveChatButton() }
 				</div>
@@ -657,7 +657,7 @@ export default connect(
 			selectedSite: getSite( state, siteId ),
 			isRequestingSites: isRequestingSites( state ),
 			siteId,
-			jetpackAdminPageUrl: getSiteAdminUrl( state, siteId, 'admin.php?page=jetpack' ),
+			jetpackAdminPageUrl: getSiteAdminUrl( state, siteId, 'admin.php?page=jetpack#/plans' ),
 			remoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, siteId ),
 			planFeatures,
 			planClass,


### PR DESCRIPTION
Main goal here is to enable the user to configure their plan. They just bought something, rather than saying "visit your site", which they presumably know how to do, link them to the dashboard page that let's them configure any features that they just bought. We don't know which exact features they bought, but we know there is something on that page which they probably want to do.

This is the screen we would switch to linking them to:

![screen shot 2017-12-08 at 12 46 41 pm](https://user-images.githubusercontent.com/820871/33782456-0ded85da-dc16-11e7-9997-62214ed7f676.png)

Here is the screen we are changing:

<img width="716" alt="screen shot 2017-12-07 at 3 53 58 pm" src="https://user-images.githubusercontent.com/820871/33782811-504f3cce-dc17-11e7-8092-d91f98e5f8b2.png">

I'm not 100% sure that "Configure your plan" is the right language. I could also see the two buttons being: "visit your site" (linking to front end to make sure nothing is broken) and "configure your plan" (or "configure your plan features"). I'm not sure what would make me want to ask for support at this point. The Plans page does also have a button for asking for support.
