### PR TITLE
Activity Log: add a Get help button in success banner

### DIFF
--- a/client/my-sites/stats/activity-log-banner/style.scss
+++ b/client/my-sites/stats/activity-log-banner/style.scss
@@ -89,3 +89,11 @@
 	display: inline-block;
 	vertical-align: text-top;
 }
+
+// Got it and HappyChat button in success banner
+.activity-log-banner__success-gotit {
+	margin-left: 8px;
+}
+.activity-log-banner__success-happychat {
+	margin-left: 16px;
+}

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -12,6 +12,8 @@ import { localize } from 'i18n-calypso';
  */
 import ActivityLogBanner from './index';
 import Button from 'components/button';
+import HappychatButton from 'components/happychat/button';
+import Gridicon from 'gridicons';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSiteUrl } from 'state/selectors';
@@ -70,42 +72,53 @@ class SuccessBanner extends PureComponent {
 		} );
 
 	render() {
-		const { applySiteOffset, moment, siteUrl, timestamp, translate, backupUrl } = this.props;
+		const {
+			applySiteOffset,
+			moment,
+			siteUrl,
+			timestamp,
+			translate,
+			backupUrl,
+			trackHappyChatBackup,
+			trackHappyChatRestore,
+		} = this.props;
 		const date = applySiteOffset( moment.utc( ms( timestamp ) ) ).format( 'LLLL' );
 		const params = backupUrl
 			? {
-					title: translate( 'Your backup is now available for download' ),
-					icon: 'cloud-download',
-					track: (
-						<TrackComponentView eventName="calypso_activitylog_backup_successbanner_impression" />
-					),
-					taskFinished: translate( 'We successfully created a backup of your site to %s!', {
-						args: date,
-					} ),
-					actionButton: (
-						<Button href={ backupUrl } onClick={ this.trackDownload } primary>
-							{ translate( 'Download' ) }
-						</Button>
-					),
-				}
+				title: translate( 'Your backup is now available for download' ),
+				icon: 'cloud-download',
+				track: (
+					<TrackComponentView eventName="calypso_activitylog_backup_successbanner_impression" />
+				),
+				taskFinished: translate( 'We successfully created a backup of your site to %s!', {
+					args: date,
+				} ),
+				actionButton: (
+					<Button href={ backupUrl } onClick={ this.trackDownload } primary>
+						{ translate( 'Download' ) }
+					</Button>
+				),
+				trackHappyChat: trackHappyChatBackup,
+			}
 			: {
-					title: translate( 'Your site has been successfully restored' ),
-					icon: 'history',
-					track: (
-						<TrackComponentView
-							eventName="calypso_activitylog_restore_successbanner_impression"
-							eventProperties={ { restore_to: timestamp } }
-						/>
-					),
-					taskFinished: translate( 'We successfully restored your site back to %s!', {
-						args: date,
-					} ),
-					actionButton: (
-						<Button href={ siteUrl } primary>
-							{ translate( 'View site' ) }
-						</Button>
-					),
-				};
+				title: translate( 'Your site has been successfully restored' ),
+				icon: 'history',
+				track: (
+					<TrackComponentView
+						eventName="calypso_activitylog_restore_successbanner_impression"
+						eventProperties={ { restore_to: timestamp } }
+					/>
+				),
+				taskFinished: translate( 'We successfully restored your site back to %s!', {
+					args: date,
+				} ),
+				actionButton: (
+					<Button href={ siteUrl } primary>
+						{ translate( 'View site' ) }
+					</Button>
+				),
+				trackHappyChat: trackHappyChatRestore,
+			};
 		return (
 			<ActivityLogBanner
 				isDismissable
@@ -122,6 +135,15 @@ class SuccessBanner extends PureComponent {
 						{ translate( 'Thanks, got it!' ) }
 					</Button>
 				) }
+				<HappychatButton
+					className="activity-log-banner__success-happychat activity-log-confirm-dialog__more-info-link"
+					onClick={ params.trackHappyChat }
+				>
+					<Gridicon icon="chat" />
+					<span className="activity-log-banner__success-happychat-text activity-log-confirm-dialog__more-info-link-text">
+						{ translate( 'Get help' ) }
+					</span>
+				</HappychatButton>
 			</ActivityLogBanner>
 		);
 	}
@@ -135,5 +157,7 @@ export default connect(
 		dismissRestoreProgress: dismissRewindRestoreProgress,
 		dismissBackupProgress: dismissRewindBackupProgress,
 		recordTracksEvent: recordTracksEvent,
+		trackHappyChatBackup: () => recordTracksEvent( 'calypso_activitylog_success_banner_backup' ),
+		trackHappyChatRestore: () => recordTracksEvent( 'calypso_activitylog_success_banner_restore' ),
 	}
 )( localize( SuccessBanner ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/18374

This PR introduces a new **Get help** button once a restore or backup ends successfully. The reason for this is that the restore or backup might not be what users expected so we give them a chance to get help regarding this issue.

<img width="511" alt="captura de pantalla 2017-12-08 a la s 18 04 33" src="https://user-images.githubusercontent.com/1041600/33785169-a7c281fc-dc42-11e7-871f-9fd350a65964.png">

<img width="531" alt="captura de pantalla 2017-12-08 a la s 17 52 54" src="https://user-images.githubusercontent.com/1041600/33784740-ac7f0096-dc40-11e7-90e1-707943cfcd80.png">
