### PR TITLE
My Plans: add Jetpack Search (Beta)

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -174,7 +174,7 @@ class ProductPurchaseFeaturesList extends Component {
 				onClick={ this.props.recordBusinessOnboardingClick }
 				link="https://calendly.com/jetpack/concierge"
 			/>,
-			<JetpackSearch selectedSite={ selectedSite } key="jetpackBackupSecurity" />,
+			<JetpackSearch selectedSite={ selectedSite } key="jetpackSearch" />,
 			<MonetizeSite selectedSite={ selectedSite } key="monetizeSiteFeature" />,
 			<GoogleAnalyticsStats selectedSite={ selectedSite } key="googleAnalyticsStatsFeature" />,
 			<JetpackWordPressCom selectedSite={ selectedSite } key="jetpackWordPressCom" />,

--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -89,7 +89,7 @@ class ProductPurchaseFeaturesList extends Component {
 			isWordadsInstantActivationEligible( selectedSite ) ? (
 				<MonetizeSite selectedSite={ selectedSite } key="monetizeSiteFeature" />
 			) : null,
-			<JetpackSearch selectedSite={ selectedSite } key="jetpackBackupSecurity" />,
+			<JetpackSearch selectedSite={ selectedSite } key="jetpackSearch" />,
 			<GoogleVouchers selectedSite={ selectedSite } key="googleVouchersFeature" />,
 			<GoogleAnalyticsStats selectedSite={ selectedSite } key="googleAnalyticsStatsFeature" />,
 			<AdvertisingRemoved isBusinessPlan key="advertisingRemovedFeature" />,

--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -39,6 +39,7 @@ import JetpackAntiSpam from './jetpack-anti-spam';
 import JetpackPublicize from './jetpack-publicize';
 import JetpackVideo from './jetpack-video';
 import JetpackBackupSecurity from './jetpack-backup-security';
+import JetpackSearch from './jetpack-search';
 import JetpackReturnToDashboard from './jetpack-return-to-dashboard';
 import JetpackWordPressCom from './jetpack-wordpress-com';
 import { isEnabled } from 'config';
@@ -77,23 +78,24 @@ class ProductPurchaseFeaturesList extends Component {
 				hasDomainCredit={ planHasDomainCredit }
 				key="customDomainFeature"
 			/>,
-			<AdvertisingRemoved isBusinessPlan key="advertisingRemovedFeature" />,
-			<GoogleVouchers selectedSite={ selectedSite } key="googleVouchersFeature" />,
-			<CustomizeTheme selectedSite={ selectedSite } key="customizeThemeFeature" />,
 			<BusinessOnboarding
 				key="businessOnboarding"
 				onClick={ this.props.recordBusinessOnboardingClick }
 				link="https://calendly.com/wordpressdotcom/wordpress-com-business-site-setup/"
 			/>,
-			<VideoAudioPosts selectedSite={ selectedSite } key="videoAudioPostsFeature" />,
-			<GoogleAnalyticsStats selectedSite={ selectedSite } key="googleAnalyticsStatsFeature" />,
-			<FindNewTheme selectedSite={ selectedSite } key="findNewThemeFeature" />,
 			isEnabled( 'manage/plugins/upload' ) ? (
 				<UploadPlugins selectedSite={ selectedSite } key="uploadPluginsFeature" />
 			) : null,
 			isWordadsInstantActivationEligible( selectedSite ) ? (
 				<MonetizeSite selectedSite={ selectedSite } key="monetizeSiteFeature" />
 			) : null,
+			<JetpackSearch selectedSite={ selectedSite } key="jetpackBackupSecurity" />,
+			<GoogleVouchers selectedSite={ selectedSite } key="googleVouchersFeature" />,
+			<GoogleAnalyticsStats selectedSite={ selectedSite } key="googleAnalyticsStatsFeature" />,
+			<AdvertisingRemoved isBusinessPlan key="advertisingRemovedFeature" />,
+			<CustomizeTheme selectedSite={ selectedSite } key="customizeThemeFeature" />,
+			<VideoAudioPosts selectedSite={ selectedSite } key="videoAudioPostsFeature" />,
+			<FindNewTheme selectedSite={ selectedSite } key="findNewThemeFeature" />,
 		];
 	}
 
@@ -143,11 +145,11 @@ class ProductPurchaseFeaturesList extends Component {
 
 		return [
 			<MonetizeSite selectedSite={ selectedSite } key="monetizeSiteFeature" />,
+			<JetpackWordPressCom selectedSite={ selectedSite } key="jetpackWordPressCom" />,
 			<JetpackBackupSecurity key="jetpackBackupSecurity" />,
 			<JetpackAntiSpam key="jetpackAntiSpam" />,
 			<JetpackPublicize key="jetpackPublicize" />,
 			<JetpackVideo key="jetpackVideo" />,
-			<JetpackWordPressCom selectedSite={ selectedSite } key="jetpackWordPressCom" />,
 			<JetpackReturnToDashboard selectedSite={ selectedSite } key="jetpackReturnToDashboard" />,
 		];
 	}
@@ -156,9 +158,9 @@ class ProductPurchaseFeaturesList extends Component {
 		const { selectedSite } = this.props;
 
 		return [
+			<JetpackWordPressCom selectedSite={ selectedSite } key="jetpackWordPressCom" />,
 			<JetpackBackupSecurity key="jetpackBackupSecurity" />,
 			<JetpackAntiSpam key="jetpackAntiSpam" />,
-			<JetpackWordPressCom selectedSite={ selectedSite } key="jetpackWordPressCom" />,
 			<JetpackReturnToDashboard selectedSite={ selectedSite } key="jetpackReturnToDashboard" />,
 		];
 	}
@@ -172,14 +174,15 @@ class ProductPurchaseFeaturesList extends Component {
 				onClick={ this.props.recordBusinessOnboardingClick }
 				link="https://calendly.com/jetpack/concierge"
 			/>,
-			<FindNewTheme selectedSite={ selectedSite } key="findNewThemeFeature" />,
-			<JetpackBackupSecurity key="jetpackBackupSecurity" />,
+			<JetpackSearch selectedSite={ selectedSite } key="jetpackBackupSecurity" />,
 			<MonetizeSite selectedSite={ selectedSite } key="monetizeSiteFeature" />,
 			<GoogleAnalyticsStats selectedSite={ selectedSite } key="googleAnalyticsStatsFeature" />,
-			<JetpackAntiSpam key="jetpackAntiSpam" />,
-			<JetpackPublicize key="jetpackPublicize" />,
-			<JetpackVideo key="jetpackVideo" />,
 			<JetpackWordPressCom selectedSite={ selectedSite } key="jetpackWordPressCom" />,
+			<FindNewTheme selectedSite={ selectedSite } key="findNewThemeFeature" />,
+			<JetpackVideo key="jetpackVideo" />,
+			<JetpackPublicize key="jetpackPublicize" />,
+			<JetpackBackupSecurity key="jetpackBackupSecurity" />,
+			<JetpackAntiSpam key="jetpackAntiSpam" />,
 			<JetpackReturnToDashboard selectedSite={ selectedSite } key="jetpackReturnToDashboard" />,
 		];
 	}

--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-search.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-search.jsx
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import PurchaseDetail from 'components/purchase-detail';
+
+export default localize( ( { selectedSite, translate } ) => {
+	return (
+		<div className="product-purchase-features-list__item">
+			<PurchaseDetail
+				icon="search"
+				title={ translate( 'Search (Beta)' ) }
+				description={ translate(
+					'Replace the default WordPress search with better results that will help your users find what they are looking for.'
+				) }
+				buttonText={ translate( 'Configure Search' ) }
+				href={ '/settings/traffic/' + selectedSite.slug }
+			/>
+		</div>
+	);
+} );

--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-search.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-search.jsx
@@ -20,9 +20,9 @@ export default localize( ( { selectedSite, translate } ) => {
 				title={ translate( 'Search (Beta)' ) }
 				description={ translate(
 					'Replace the default WordPress search with better results ' +
-						'that will help your users find what they are looking for.'
+						'and filtering that will help your users find what they are looking for.'
 				) }
-				buttonText={ translate( 'Configure Search' ) }
+				buttonText={ translate( 'Enable Search in Traffic Settings' ) }
 				href={ '/settings/traffic/' + selectedSite.slug }
 			/>
 		</div>

--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-search.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-search.jsx
@@ -19,7 +19,8 @@ export default localize( ( { selectedSite, translate } ) => {
 				icon="search"
 				title={ translate( 'Search (Beta)' ) }
 				description={ translate(
-					'Replace the default WordPress search with better results that will help your users find what they are looking for.'
+					'Replace the default WordPress search with better results ' +
+						'that will help your users find what they are looking for.'
 				) }
 				buttonText={ translate( 'Configure Search' ) }
 				href={ '/settings/traffic/' + selectedSite.slug }

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -8,12 +8,12 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { overSome } from 'lodash';
+import { overSome, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import SectionHeader from 'components/section-header';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -22,6 +22,7 @@ import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import untrailingslashit from 'lib/route/untrailingslashit';
 import {
 	getJetpackModule,
 	isActivatingJetpackModule,
@@ -69,7 +70,7 @@ class Search extends Component {
 
 		return (
 			<FormSettingExplanation>
-				{ translate( 'Your site is using enhanced search powered by Elasticsearch.' ) }
+				{ translate( 'Also add the Jetpack Search widget to your sidebar to add search filters.' ) }
 			</FormSettingExplanation>
 		);
 	}
@@ -108,7 +109,9 @@ class Search extends Component {
 				<JetpackModuleToggle
 					siteId={ siteId }
 					moduleSlug="search"
-					label={ translate( 'Enable site-wide search powered by Elasticsearch' ) }
+					label={ translate(
+						'Replace WordPress built-in search with an improved search experience (Beta)'
+					) }
 					disabled={ isRequestingSettings || isSavingSettings }
 				/>
 
@@ -118,7 +121,14 @@ class Search extends Component {
 	}
 
 	render() {
-		const { siteId, siteIsJetpack, enableFeature, translate } = this.props;
+		const {
+			siteId,
+			site,
+			siteIsJetpack,
+			enableFeature,
+			searchModuleActive,
+			translate,
+		} = this.props;
 
 		// for now, don't even show upgrade nudge
 		if ( ! enableFeature ) {
@@ -130,15 +140,23 @@ class Search extends Component {
 			return null;
 		}
 
+		let widgetURL = get( site, 'options.admin_url', '' );
+		if ( widgetURL ) {
+			widgetURL = untrailingslashit( widgetURL ) + '/widgets.php';
+		}
+
 		return (
 			<div>
 				{ siteId && <QueryJetpackConnection siteId={ siteId } /> }
 
 				<SectionHeader label={ translate( 'Search' ) } />
 
-				<Card className="search__card site-settings__traffic-settings">
+				<CompactCard className="search__card site-settings__traffic-settings">
 					{ siteIsJetpack ? this.renderJetpackSettings() : this.renderWpcomSettings() }
-				</Card>
+				</CompactCard>
+				{ searchModuleActive && (
+					<CompactCard href={ widgetURL }>{ translate( 'Add Jetpack Search Widget' ) }</CompactCard>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -70,7 +70,7 @@ class Search extends Component {
 
 		return (
 			<FormSettingExplanation>
-				{ translate( 'Also add the Jetpack Search widget to your sidebar to add search filters.' ) }
+				{ translate( 'Add the Jetpack Search widget to your sidebar to add search filters.' ) }
 			</FormSettingExplanation>
 		);
 	}

--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -103,12 +103,12 @@ const SiteSettingsTraffic = ( {
 				isRequestingSettings={ isRequestingSettings }
 				fields={ fields }
 			/>
+			{ site && <SiteVerification /> }
 			<Search
 				isSavingSettings={ isSavingSettings }
 				isRequestingSettings={ isRequestingSettings }
 				fields={ fields }
 			/>
-			{ site && <SiteVerification /> }
 		</Main>
 	);
 };


### PR DESCRIPTION
This adds Search (Beta) as a feature to the WP.com Business and Jetpack Business plans, but only after the user has already purchased it. The link takes the user to the traffic settings to configure it. We don't seem to have a way to link directly to the settings box (I tried adding an id and couldn't get it to work).

I have also reordered the features to try and put the features that require configuration at the top. Things like anti-spam, backups, etc move down lower because there is nothing to do even though they are top line features. Discussion welcome, see also the recent walk through on jetpackp2.

Note that the layout isn't actual in order on a desktop because it becomes two columns. So Jetpack Pro would look like this:

![screen shot 2017-12-08 at 4 51 17 pm](https://user-images.githubusercontent.com/820871/33789751-37155ea2-dc38-11e7-81c5-4c139387f070.png)

Maybe for a "beta" this is too prominent?
