### PR TITLE
Me: Update ApplicationPasswordsItem to use Redux analytics and React.Component

### DIFF
--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -6,7 +6,6 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import Gridicon from 'gridicons';
@@ -69,6 +68,7 @@ class ApplicationPasswordsItem extends React.Component {
 	}
 }
 
-export default connect( null, dispatch =>
-	bindActionCreators( { errorNotice, recordGoogleEvent }, dispatch )
-)( localize( ApplicationPasswordsItem ) );
+export default connect( null, {
+	errorNotice,
+	recordGoogleEvent,
+} )( localize( ApplicationPasswordsItem ) );

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -41,7 +41,8 @@ class ApplicationPasswordsItem extends React.Component {
 	}
 
 	render() {
-		var password = this.props.password;
+		const password = this.props.password;
+
 		return (
 			<li className="application-password-item__password" key={ password.ID }>
 				<div className="application-password-item__details">

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -11,19 +11,17 @@ import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:application-password-item' );
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { recordGoogleEvent } from 'state/analytics/actions';
 import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-import eventRecorder from 'me/event-recorder';
 import { errorNotice } from 'state/notices/actions';
 import Button from 'components/button';
 
 const ApplicationPasswordsItem = createReactClass( {
 	displayName: 'ApplicationPasswordsItem',
-
-	mixins: [ eventRecorder ],
 
 	componentDidMount: function() {
 		debug( this.displayName + ' React component is mounted.' );
@@ -37,6 +35,11 @@ const ApplicationPasswordsItem = createReactClass( {
 		return {
 			removingPassword: false,
 		};
+	},
+
+	handleRemovePasswordButtonClick() {
+		this.props.recordGoogleEvent( 'Me', 'Clicked on Remove Application Password Button' );
+		this.removeApplicationPassword();
 	},
 
 	removeApplicationPassword: function() {
@@ -72,10 +75,7 @@ const ApplicationPasswordsItem = createReactClass( {
 				<Button
 					borderless
 					className="application-password-item__revoke"
-					onClick={ this.recordClickEvent(
-						'Remove Application Password Button',
-						this.removeApplicationPassword
-					) }
+					onClick={ this.handleRemovePasswordButtonClick }
 				>
 					<Gridicon icon="cross" />
 				</Button>
@@ -84,6 +84,6 @@ const ApplicationPasswordsItem = createReactClass( {
 	},
 } );
 
-export default connect( null, dispatch => bindActionCreators( { errorNotice }, dispatch ) )(
-	localize( ApplicationPasswordsItem )
-);
+export default connect( null, dispatch =>
+	bindActionCreators( { errorNotice, recordGoogleEvent }, dispatch )
+)( localize( ApplicationPasswordsItem ) );

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -5,7 +5,6 @@
  */
 
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -18,21 +17,17 @@ import Gridicon from 'gridicons';
 import { errorNotice } from 'state/notices/actions';
 import Button from 'components/button';
 
-const ApplicationPasswordsItem = createReactClass( {
-	displayName: 'ApplicationPasswordsItem',
+class ApplicationPasswordsItem extends React.Component {
+	state = {
+		removingPassword: false,
+	};
 
-	getInitialState: function() {
-		return {
-			removingPassword: false,
-		};
-	},
-
-	handleRemovePasswordButtonClick() {
+	handleRemovePasswordButtonClick = () => {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on Remove Application Password Button' );
 		this.removeApplicationPassword();
-	},
+	};
 
-	removeApplicationPassword: function() {
+	removeApplicationPassword() {
 		this.setState( { removingPassword: true } );
 
 		this.props.appPasswordsData.revoke(
@@ -48,9 +43,9 @@ const ApplicationPasswordsItem = createReactClass( {
 				}
 			}.bind( this )
 		);
-	},
+	}
 
-	render: function() {
+	render() {
 		var password = this.props.password;
 		return (
 			<li className="application-password-item__password" key={ password.ID }>
@@ -71,8 +66,8 @@ const ApplicationPasswordsItem = createReactClass( {
 				</Button>
 			</li>
 		);
-	},
-} );
+	}
+}
 
 export default connect( null, dispatch =>
 	bindActionCreators( { errorNotice, recordGoogleEvent }, dispatch )

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -3,18 +3,17 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
-import { recordGoogleEvent } from 'state/analytics/actions';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { errorNotice } from 'state/notices/actions';
 import Button from 'components/button';
+import { errorNotice } from 'state/notices/actions';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 class ApplicationPasswordsItem extends React.Component {
 	state = {

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -28,19 +28,16 @@ class ApplicationPasswordsItem extends React.Component {
 	removeApplicationPassword() {
 		this.setState( { removingPassword: true } );
 
-		this.props.appPasswordsData.revoke(
-			parseInt( this.props.password.ID, 10 ),
-			function( error ) {
-				if ( error && 'unknown_application_password' !== error.error ) {
-					this.setState( { removingPassword: false } );
-					this.props.errorNotice(
-						this.props.translate(
-							'The application password was not successfully deleted. Please try again.'
-						)
-					);
-				}
-			}.bind( this )
-		);
+		this.props.appPasswordsData.revoke( parseInt( this.props.password.ID, 10 ), error => {
+			if ( error && 'unknown_application_password' !== error.error ) {
+				this.setState( { removingPassword: false } );
+				this.props.errorNotice(
+					this.props.translate(
+						'The application password was not successfully deleted. Please try again.'
+					)
+				);
+			}
+		} );
 	}
 
 	render() {

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -7,8 +7,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:application-password-item' );
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { recordGoogleEvent } from 'state/analytics/actions';
@@ -22,14 +20,6 @@ import Button from 'components/button';
 
 const ApplicationPasswordsItem = createReactClass( {
 	displayName: 'ApplicationPasswordsItem',
-
-	componentDidMount: function() {
-		debug( this.displayName + ' React component is mounted.' );
-	},
-
-	componentWillUnmount: function() {
-		debug( this.displayName + ' React component is unmounting.' );
-	},
 
 	getInitialState: function() {
 		return {


### PR DESCRIPTION
This PR refactors `ApplicationPasswordsItem` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove all mixins, specifically `eventRecorder`.
* Convert from `createReactClass` to a `React.Component`.
* Remove some unnecessary debug code.
* Cleanup unnecessary `bindActionCreators`
* Sort some imports 🔤 
* Get rid of `.bind( this )` in favor of using arrow functions
* Use `const`/`let` instead of `var`

This PR should not introduce any visual changes.

Part of #20053.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/me/security/two-step
* If you don't have any application passwords you can delete, create a new one.
* Make sure your `ga` debug is enabled: `localStorage.debug = 'calypso:analytics:ga,calypso:analytics:utils'`
* Verify you can observe the right analytics action being dispatched when clicking the "X" button to remove the application password.
* Verify everything else in the Application Passwords section works like it did before.