### PR TITLE
Domains: Add logic so users are able to remove domain transfers

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -11,7 +11,13 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isJetpackPlan, isDomainRegistration, isPlan, isTheme } from 'lib/products-values';
+import {
+	isJetpackPlan,
+	isDomainRegistration,
+	isDomainTransfer,
+	isPlan,
+	isTheme,
+} from 'lib/products-values';
 
 function getIncludedDomain( purchase ) {
 	return purchase.includedDomain;
@@ -184,7 +190,24 @@ function isRemovable( purchase ) {
 		return false;
 	}
 
-	return isExpiring( purchase ) || isExpired( purchase );
+	return (
+		isExpiring( purchase ) ||
+		isExpired( purchase ) ||
+		( isDomainTransfer( purchase ) &&
+			! isRefundable( purchase ) &&
+			isPurchaseCancelable( purchase ) )
+	);
+}
+
+/**
+ * Returns the purchase cancelable flag, as opposed to the super weird isCancelable function which
+ * manually checks all kinds of stuff
+ *
+ * @param {Object} purchase - the purchase with which we are concerned
+ * @return {boolean} true if the purchase has cancelable flag, false otherwise
+ */
+function isPurchaseCancelable( purchase ) {
+	return purchase.isCancelable;
 }
 
 /**

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -29,13 +29,7 @@ import previousStep from 'components/marketing-survey/cancel-purchase-form/previ
 import { INITIAL_STEP, FINAL_STEP } from 'components/marketing-survey/cancel-purchase-form/steps';
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
 import { getPurchase, isDataLoading } from '../utils';
-import {
-	isDomainRegistration,
-	isDomainTransfer,
-	isPlan,
-	isGoogleApps,
-	isJetpackPlan,
-} from 'lib/products-values';
+import { isDomainRegistration, isPlan, isGoogleApps, isJetpackPlan } from 'lib/products-values';
 import notices from 'notices';
 import purchasePaths from '../paths';
 import { getPurchasesError } from 'state/purchases/selectors';
@@ -427,10 +421,6 @@ class RemovePurchase extends Component {
 
 		const purchase = getPurchase( this.props );
 		if ( ! isRemovable( purchase ) ) {
-			return null;
-		}
-
-		if ( isDomainTransfer( purchase ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
We were only allowing cancel and refund, while we should allow users to cancel the transfer in w/o refunding.

Fixes: https://github.com/Automattic/wp-calypso/issues/20271

Dependency: D8724-code

Test:
- Create a transfer in
- Try to cancel and refund (it will fail because of a12s 50% discount, don't ask)
  - If you want the this step to work, try testing with a regular user (but hack the feature flag)
- Hack the assembler to set `isRefundable` to `false`
- Try to remove purchase (should work)
