### PR TITLE
Store Products: Hide warn in product test

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/products/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/products/test/index.js
@@ -6,6 +6,8 @@
 import { expect } from 'chai';
 import { spy, match } from 'sinon';
 
+jest.mock( 'lib/warn', () => () => {} );
+
 /**
  * Internal dependencies
  */


### PR DESCRIPTION
The product data layer test was causing a warning to be kicked out in an
otherwise successful test.

To Test:
1. `npm run test-client client/extensions/woocommerce/state/data-layer/products`
2. Ensure no warnings in console and test runs successfully.