### PR TITLE
Fix stats and comments back buttons

### DIFF
--- a/client/my-sites/comments/comment-list/comment-list-header.jsx
+++ b/client/my-sites/comments/comment-list/comment-list-header.jsx
@@ -16,10 +16,14 @@ import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { decodeEntities, stripHTML } from 'lib/formatting';
 import { gmtOffset, timezone } from 'lib/site/utils';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
-import { getSiteComments } from 'state/selectors';
+import { getSiteComments, hasNavigated } from 'state/selectors';
 import { getSitePost } from 'state/posts/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+
+function goBack() {
+	window.history.back();
+}
 
 export const CommentListHeader = ( {
 	postDate,
@@ -30,6 +34,7 @@ export const CommentListHeader = ( {
 	site,
 	siteId,
 	siteSlug,
+	navigated,
 	translate,
 } ) => {
 	const formattedDate = postDate
@@ -37,6 +42,9 @@ export const CommentListHeader = ( {
 		: '';
 
 	const title = postTitle.trim() || translate( 'Untitled' );
+
+	const shouldUseHistoryBack = window.history.length > 1 && navigated;
+	const backHref = ! shouldUseHistoryBack ? `/comments/all/${ siteSlug }` : null;
 
 	return (
 		<div className="comment-list__header">
@@ -47,7 +55,8 @@ export const CommentListHeader = ( {
 				actionIcon="visible"
 				actionOnClick={ recordReaderArticleOpened }
 				actionText={ translate( 'View Post' ) }
-				backHref={ `/comments/all/${ siteSlug }` }
+				onClick={ shouldUseHistoryBack && goBack }
+				backHref={ backHref }
 				alwaysShowActionText
 			>
 				<div className="comment-list__header-title">
@@ -76,6 +85,7 @@ const mapStateToProps = ( state, { postId } ) => {
 		)
 	);
 	const isJetpack = isJetpackSite( state, siteId );
+	const navigated = hasNavigated( state );
 
 	return {
 		postDate,
@@ -84,6 +94,7 @@ const mapStateToProps = ( state, { postId } ) => {
 		site,
 		siteId,
 		siteSlug,
+		navigated,
 	};
 };
 

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -33,6 +33,7 @@ import Button from 'components/button';
 import WebPreview from 'components/web-preview';
 import { getSiteSlug, isJetpackSite, isSitePreviewable } from 'state/sites/selectors';
 import { getSitePost, isRequestingSitePost, getPostPreviewUrl } from 'state/posts/selectors';
+import { hasNavigated } from 'state/selectors';
 
 class StatsPostDetail extends Component {
 	static propTypes = {
@@ -48,6 +49,7 @@ class StatsPostDetail extends Component {
 		siteSlug: PropTypes.string,
 		showViewLink: PropTypes.bool,
 		previewUrl: PropTypes.string,
+		hasNavigated: PropTypes.bool,
 	};
 
 	state = {
@@ -55,10 +57,13 @@ class StatsPostDetail extends Component {
 	};
 
 	goBack = () => {
-		const pathParts = this.props.path.split( '/' );
-		const defaultBack = '/stats/' + pathParts[ pathParts.length - 1 ];
+		if ( window.history.length > 1 && this.props.hasNavigated ) {
+			window.history.back();
+			return;
+		}
 
-		page( this.props.context.prevPath || defaultBack );
+		const pathParts = this.props.path.split( '/' );
+		page( '/stats/' + pathParts[ pathParts.length - 1 ] );
 	};
 
 	componentDidMount() {
@@ -201,6 +206,7 @@ const connectComponent = connect( ( state, { postId } ) => {
 		siteSlug: getSiteSlug( state, siteId ),
 		showViewLink: ! isJetpack && isPreviewable,
 		previewUrl: getPostPreviewUrl( state, siteId, postId ),
+		hasNavigated: hasNavigated( state ),
 		siteId,
 	};
 } );

--- a/client/state/selectors/has-navigated.js
+++ b/client/state/selectors/has-navigated.js
@@ -1,0 +1,16 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { filter } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getActionLog } from 'state/ui/action-log/selectors';
+import { ROUTE_SET } from 'state/action-types';
+
+export default function hasNavigated( state ) {
+	return filter( getActionLog( state ), { type: ROUTE_SET } ).length > 1;
+}

--- a/client/state/selectors/test/has-navigated.js
+++ b/client/state/selectors/test/has-navigated.js
@@ -15,7 +15,7 @@ describe( 'hasNavigated()', () => {
 	test( 'should return false if only one ROUTE_SET has occurred', () => {
 		const state = { ui: { actionLog: [ { type: ROUTE_SET, path: 'a' } ] } };
 
-		expect( hasNavigated( state ).to.be.false );
+		expect( hasNavigated( state ) ).to.be.false;
 	} );
 
 	test( 'should return true if more than one ROUTE_SET has occurred', () => {
@@ -23,6 +23,6 @@ describe( 'hasNavigated()', () => {
 			ui: { actionLog: [ { type: ROUTE_SET, path: 'a' }, { type: ROUTE_SET, path: 'b' } ] },
 		};
 
-		expect( hasNavigated( state ).to.be.true );
+		expect( hasNavigated( state ) ).to.be.true;
 	} );
 } );

--- a/client/state/selectors/test/has-navigated.js
+++ b/client/state/selectors/test/has-navigated.js
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { hasNavigated } from 'state/selectors';
+import { ROUTE_SET } from 'state/action-types';
+
+describe( 'hasNavigated()', () => {
+	test( 'should return false if only one ROUTE_SET has occurred', () => {
+		const state = { ui: { actionLog: [ { type: ROUTE_SET, path: 'a' } ] } };
+
+		expect( hasNavigated( state ).to.be.false );
+	} );
+
+	test( 'should return true if more than one ROUTE_SET has occurred', () => {
+		const state = {
+			ui: { actionLog: [ { type: ROUTE_SET, path: 'a' }, { type: ROUTE_SET, path: 'b' } ] },
+		};
+
+		expect( hasNavigated( state ).to.be.true );
+	} );
+} );


### PR DESCRIPTION
This PR fixes the Back button for the post stats and post comments pages.

To test, click on the "Stats" action or comments icon for a post (current posts list), or the "Stats" or "Comments" action menu items for Condensed Post List and verify that the Back button on the stats/comments page takes you back to the post list.

Verify that when navigating from other sections (such as the main stats/comments page) that the Back button works properly as well.

### Acceptance criteria

1.
- Given a user who navigated to the stats for a post
- When the user clicks on "Back"
- Then the user navigates to where they were before they navigated to the stats for a post

2.
- Given a user who directly loaded the stats page for a post
- When the user clicks on "Back"
- Then the user navigates to the main stats page for the site that the post belongs to (current behavior)

3.
- Given a user who navigated to the comments for a post
- When the user clicks on "Back"
- Then the user navigates to where they were before they navigated to the comments for a post

4.
- Given a user who directly loaded the comments page for a post
- When the user clicks on "Back"
- Then the user navigates to the main comments page for the site that the post belongs to (current behavior)