### PR TITLE
Plugin: Single plugin view fix

### DIFF
--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -149,13 +149,12 @@ const SinglePlugin = createReactClass( {
 	},
 
 	pluginExists( plugin ) {
-		if ( this.isFetching() ) {
-			return 'unknown';
-		}
 		if ( plugin && plugin.fetched ) {
 			return true;
 		}
-
+		if ( this.isFetching() ) {
+			return 'unknown';
+		}
 		const sites = this.props.sites;
 
 		// If the plugin has at least one site then we know it exists


### PR DESCRIPTION
Fix loading order. 
Currently when you load plugin and the navigate to a single plugin that has been loaded already you end up in a state where the placeholders are showing up permanently.

This PR fixes this.  

