### PR TITLE
Offline dev environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ Dockerfile
 .vscode
 /.babel-cache
 /build
+/cached-requests.json
 /node_modules
 /public/*.css
 /public/*.css.map

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ test-results*.xml
 /calypso-strings.pot
 cover.html
 .test.log
+
+cached-requests.json

--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -56,8 +56,10 @@ if ( config.isEnabled( 'support-user' ) ) {
 	wpcom = wpcomSupport( wpcom );
 }
 
-// expose wpcom global var only in development
-if ( 'development' === config( 'env' ) ) {
+if ( 'development' === process.env.NODE_ENV ) {
+	require( './offline-library' ).makeOffline( wpcom );
+
+	// expose wpcom global var only in development
 	const wpcomPKG = require( 'wpcom/package' );
 	window.wpcom = wpcom;
 	window.wpcom.__version = wpcomPKG.version;

--- a/client/lib/wp/offline-library/README.md
+++ b/client/lib/wp/offline-library/README.md
@@ -1,0 +1,80 @@
+# Offline Library
+
+The purpose of this module is to facilitate offline-development of Calypso.
+Under normal operations Calypso requires a working connection to the internet
+in order to boot. This can be frustrating to those wanting to work on it while
+on a plane, while hiking in the mountains, while waiting for dinner at a
+restaurant without WiFi available, while driving, or in many other offline scenarios.
+
+Being able to develop the product while offline brings a number of advantages to
+the developer workflow and can improve our ability to deterministically test and
+automate important metrics.
+
+Although this module limits its scope to requests made through `wpcom.js`, it enables
+a workable offline environment in which to test.
+
+## Overview
+
+Working offline isn't automated. There are a number of challenging issues to resolve
+before Calypso can work as intended offline. Thankfully, for development purposes we
+can reach a reasonable approximation of offline by caching network requests and
+replaying them when requested. An offline cache also allows us to hand-craft specific
+network responses in order to test specific circumstances in the application.
+
+> This module is only loaded in a local development environment and only runs when
+> specifically requested via config flags or from the query string of the initial
+> app load.
+
+Working offline thus involves two steps: _priming the cache_ and then _activating the
+cache_.
+
+### Priming the cache
+
+We will be performing the most basic and naive approach of offline support: caching
+network requests, including their authentication. _Priming_ is the process of
+pre-loading the network requests we anticipate using while offline. If we don't
+prime a given request then it will fail at runtime when offline.
+
+The easiest way to get started is to load Calypso with the priming flag set in the
+browser path's query string. Make sure that you are connected to the internet when
+loading this page.
+
+```
+http://calypso.localhost:3000/?wpcom_priming=1
+```
+
+Once the application loads, start navigating around and using whatever functionality
+you expect to work with later. You can save changes in the editor, load feed posts,
+open site settings, read notifications, and any activity. Every request will be
+recorded in memory.
+
+When finished priming, we need to save this request cache so we can load it later.
+From the development tools for your browser, open the console and run `saveRequests()`.
+
+`saveRequests()` should compile a JSON document of primed requests that you can save
+to `cached-requests.json` in the project root of Calypso.
+
+### Activating the cache
+
+Once saved, the `cached-requests.json` file contains all of the information necessary
+to fake network requests. It is organized by request path; feel free to examine or
+modify it before using it.
+
+We will activate the cache much like we primed it. The easiest way is to include the
+flag in the browser path's query string on the initial page load. You can disconnect
+from your network at this point.
+
+```
+http://calypso.localhost:3000/?wpcom_offline=1
+```
+
+Requests should serve identically as when they were primed. If you primed a `POST`
+request then you should be able to replay it as long as the parameters and body themselves
+are identical. Sometimes we may have to undo changes after priming in order to bring the
+state back into a place where we can replay the original requests (such as when editing posts).
+
+## Notes
+
+Because this is flagged behind the local development environment this should never appear
+in the production bundle. It should also not load unless specifically requested. When it
+_does_ run it may pull in many megabtyes of data via the `require()` which loads the cache.

--- a/client/lib/wp/offline-library/index.js
+++ b/client/lib/wp/offline-library/index.js
@@ -1,0 +1,98 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import stringify from 'json-stable-stringify';
+
+const readCache = () => {
+	try {
+		return require( '../../../../cached-requests.json' );
+	} catch ( e ) {
+		return {};
+	}
+};
+
+const saveRequests = requests => {
+	const requestData = {};
+
+	requests.forEach( ( value, key ) => {
+		const path = JSON.parse( key ).path;
+
+		if ( ! requestData.hasOwnProperty( path ) ) {
+			requestData[ path ] = {};
+		}
+
+		requestData[ path ][ key ] = value;
+	} );
+
+	const file = new Blob( [ JSON.stringify( requestData, null, 2 ) ], {
+		type: 'application/json',
+	} );
+
+	const url = URL.createObjectURL( file );
+	window.open( url );
+};
+
+export const makeOffline = wpcom => {
+	const location = window.location;
+	const primingRequested = /[&?]wpcom_prime_cache=1/.test( location );
+	const offlineRequested = /[&?]wpcom_offline=1/.test( location );
+
+	if ( ! primingRequested && ! offlineRequested ) {
+		return wpcom;
+	}
+
+	// eslint-disable-next-line no-console
+	primingRequested && console.log( 'Priming wpcom request cache' );
+
+	// eslint-disable-next-line no-console
+	offlineRequested && console.log( 'Delivering wpcom requests from cache' );
+
+	const request = wpcom.request.bind( wpcom );
+	const requests = new Map();
+
+	const storedRequests = readCache();
+	Object.keys( storedRequests ).forEach( path => {
+		Object.keys( storedRequests[ path ] ).forEach( key => {
+			requests.set( key, storedRequests[ path ][ key ] );
+		} );
+	} );
+
+	window.saveRequests = () => saveRequests( requests );
+
+	Object.defineProperty( wpcom, 'request', {
+		value: ( params, callback ) => {
+			if ( offlineRequested ) {
+				const stored = requests.get( stringify( params ) );
+
+				if ( undefined === callback ) {
+					if ( undefined === stored ) {
+						return Promise.reject( new Error( 'Network inaccessible' ) );
+					}
+
+					return undefined === stored[ 0 ] || null === stored[ 0 ]
+						? Promise.reject( stored[ 0 ] )
+						: Promise.resolve( ...stored.slice( 1 ) );
+				}
+
+				if ( undefined === stored ) {
+					callback( new Error( 'Network inaccessible' ) );
+				} else {
+					callback( ...stored );
+				}
+
+				return new XMLHttpRequest();
+			}
+
+			if ( ! primingRequested ) {
+				return request( params, callback );
+			}
+
+			return request( params, ( ...args ) => {
+				requests.set( stringify( params ), args );
+
+				return callback( ...args );
+			} );
+		},
+	} );
+};

--- a/client/lib/wp/offline-library/index.js
+++ b/client/lib/wp/offline-library/index.js
@@ -35,7 +35,7 @@ const saveRequests = requests => {
 
 export const makeOffline = wpcom => {
 	const location = window.location;
-	const primingRequested = /[&?]wpcom_prime_cache=1/.test( location );
+	const primingRequested = /[&?]wpcom_priming=1/.test( location );
 	const offlineRequested = /[&?]wpcom_offline=1/.test( location );
 
 	if ( ! primingRequested && ! offlineRequested ) {
@@ -45,8 +45,12 @@ export const makeOffline = wpcom => {
 	// eslint-disable-next-line no-console
 	primingRequested && console.log( 'Priming wpcom request cache' );
 
-	// eslint-disable-next-line no-console
-	offlineRequested && console.log( 'Delivering wpcom requests from cache' );
+	offlineRequested &&
+		// eslint-disable-next-line no-console
+		console.log(
+			'Delivering wpcom requests from cache\n' +
+				'Run `saveRequests()` in the developer console to save cache file.'
+		);
 
 	const request = wpcom.request.bind( wpcom );
 	const requests = new Map();

--- a/client/lib/wp/offline-library/index.js
+++ b/client/lib/wp/offline-library/index.js
@@ -102,7 +102,7 @@ export const makeOffline = wpcom => {
 				}
 
 				// make sure we still return an XHR
-				// this is the expected behavior of wpcom.js requestk
+				// this is the expected behavior of wpcom.js request
 				return new XMLHttpRequest();
 			}
 

--- a/client/lib/wp/offline-library/index.js
+++ b/client/lib/wp/offline-library/index.js
@@ -7,7 +7,7 @@ import stringify from 'json-stable-stringify';
 const readCache = () => {
 	try {
 		// load from the project root
-		return require( 'cached-requests.json' );
+		return require( '../../../../cached-requests.json' );
 	} catch ( e ) {
 		return {};
 	}
@@ -44,15 +44,17 @@ export const makeOffline = wpcom => {
 		return wpcom;
 	}
 
-	// eslint-disable-next-line no-console
-	! offlineRequested && primingRequested && console.log( 'Priming wpcom request cache' );
+	! offlineRequested &&
+		primingRequested &&
+		// eslint-disable-next-line no-console
+		console.log(
+			'Priming wpcom request cache\n' +
+				'Run `saveRequests()` in the developer console to save cache file.'
+		);
 
 	offlineRequested &&
 		// eslint-disable-next-line no-console
-		console.log(
-			'Delivering wpcom requests from cache\n' +
-				'Run `saveRequests()` in the developer console to save cache file.'
-		);
+		console.log( 'Delivering wpcom requests from cache' );
 
 	const request = wpcom.request.bind( wpcom );
 	const requests = new Map();


### PR DESCRIPTION
Use to prime a request cache, save it, then operate within Calypso out of that cache offline

See [README](https://github.com/Automattic/wp-calypso/blob/3fbf57365aa9817995c056f68bc2b725beec965c/client/lib/wp/offline-library/README.md) for explanation and usage instructions.

> This should only work in a local dev environment and in no other environments.

**Testing**

Load Calypso with the `?wpcom_priming=1` query string flag. Play around, visit various pages, open settings, open a post in the editor, view different Reader feeds, make a settings change, etc…

Open the dev tools console and run `saveRequests()`. Store the file in the project root directory as `cached-requests.json`.

Turn off your network connection then reload Calypso this time with `?wpcom_offline=1`. You should b able to do the same things you did during the priming run.

Reload Calypso without any of the flags and it should work as normal.