### PR TITLE
Build: Include a default env-config.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,6 @@ node_modules
 test-results*.xml
 /stats.json
 
-# script used during docker build that is specific to the environment
-env-config.sh
-
 # added during build
 /config/secrets.json
 

--- a/package.json
+++ b/package.json
@@ -186,7 +186,6 @@
     "build-devdocs:components-usage-stats:_env": "node server/devdocs/bin/generate-components-usage-stats.js \"client/**/*.js\" \"client/**/*.jsx\" \"!**/docs/**\" \"!**/test/**\" \"!**/docs-example/**\"",
     "build-devdocs:index": "npm run -s env -- npm run -s build-devdocs:index:_env",
     "build-devdocs:index:_env": "node server/devdocs/bin/generate-devdocs-index \"**/*.md\" \".github/**.md\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
-    "prebuild-docker": "touch env-config.sh || type nul >> env-config.sh",
     "build-docker": "docker build -t wp-calypso .",
     "prebuild-server": "mkdirp build",
     "build-server": "npm run -s env -- webpack --display-error-details --config webpack.config.node.js",


### PR DESCRIPTION
As a [pre-build](https://github.com/Automattic/wp-calypso/blob/master/package.json#L189) step to the docker build we create a file `env-config.sh` with `touch`.
It would be nice if we didn't need to rely upon an npm pre-build step to build Calypso with docker.
That way we don't need to invoke the build through npm, making Calypso more portable.

**current**
`docker build -t wpcalypso .` fails.

**after**
the build should succeed.


Note: another possibility would be to touch the file as a step within the Dockerfile
