### PR TITLE
Plans: add`Suggested` ribbon to the canonical plans whenever it is passed as a parameter

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -51,13 +51,15 @@ class PlanFeaturesHeader extends Component {
 	}
 
 	renderPlansHeader() {
-		const { planType, popular, newPlan, title, translate } = this.props;
+		const { planType, popular, selectedPlan, newPlan, title, translate } = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
+
 		return (
 			<header className={ headerClasses } onClick={ this.props.onClick }>
-				{ popular && <Ribbon>{ translate( 'Popular' ) }</Ribbon> }
-				{ newPlan && <Ribbon>{ translate( 'New' ) }</Ribbon> }
+				{ planType === selectedPlan && <Ribbon>{ translate( 'Suggested' ) }</Ribbon> }
+				{ popular && ! selectedPlan && <Ribbon>{ translate( 'Popular' ) }</Ribbon> }
+				{ newPlan && ! selectedPlan && <Ribbon>{ translate( 'New' ) }</Ribbon> }
 				{ this.isPlanCurrent() && <Ribbon>{ translate( 'Your Plan' ) }</Ribbon> }
 				<div className="plan-features__header-figure">
 					<PlanIcon plan={ planType } />
@@ -75,12 +77,12 @@ class PlanFeaturesHeader extends Component {
 		const { planType, popular, newPlan, title, audience, translate } = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
+
 		return (
 			<div className="plan-features__header-wrapper">
 				<header className={ headerClasses } onClick={ this.props.onClick }>
-					{ popular && <Ribbon>{ translate( 'Popular' ) }</Ribbon> }
 					{ newPlan && <Ribbon>{ translate( 'New' ) }</Ribbon> }
-
+					{ popular && <Ribbon>{ translate( 'Popular' ) }</Ribbon> }
 					<div className="plan-features__header-text">
 						<h4 className="plan-features__header-title">{ title }</h4>
 						{ audience }

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -51,7 +51,7 @@ class PlanFeaturesHeader extends Component {
 	}
 
 	renderPlansHeader() {
-		const { planType, popular, selectedPlan, newPlan, title, translate } = this.props;
+		const { newPlan, planType, popular, selectedPlan, title, translate } = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -14,10 +14,12 @@ import { connect } from 'react-redux';
  * Internal Dependencies
  **/
 import { localize } from 'i18n-calypso';
+import formatCurrency from 'lib/format-currency';
 import InfoPopover from 'components/info-popover';
-import { isMobile } from 'lib/viewport';
-import Ribbon from 'components/ribbon';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import PlanPrice from 'my-sites/plan-price';
+import Ribbon from 'components/ribbon';
+import PlanIcon from 'components/plans/plan-icon';
 import {
 	PLAN_FREE,
 	PLAN_PREMIUM,
@@ -32,11 +34,10 @@ import {
 	PLAN_PERSONAL,
 	getPlanClass,
 } from 'lib/plans/constants';
-import PlanIcon from 'components/plans/plan-icon';
-import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import formatCurrency from 'lib/format-currency';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isMobile } from 'lib/viewport';
+import { planLevelsMatch } from 'lib/plans/index';
 
 class PlanFeaturesHeader extends Component {
 	render() {
@@ -57,7 +58,9 @@ class PlanFeaturesHeader extends Component {
 
 		return (
 			<header className={ headerClasses } onClick={ this.props.onClick }>
-				{ planType === selectedPlan && <Ribbon>{ translate( 'Suggested' ) }</Ribbon> }
+				{ planLevelsMatch( selectedPlan, planType ) && (
+					<Ribbon>{ translate( 'Suggested' ) }</Ribbon>
+				) }
 				{ popular && ! selectedPlan && <Ribbon>{ translate( 'Popular' ) }</Ribbon> }
 				{ newPlan && ! selectedPlan && <Ribbon>{ translate( 'New' ) }</Ribbon> }
 				{ this.isPlanCurrent() && <Ribbon>{ translate( 'Your Plan' ) }</Ribbon> }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -214,6 +214,7 @@ class PlanFeatures extends Component {
 			isInSignup,
 			siteType,
 			displayJetpackPlans,
+			selectedPlan,
 		} = this.props;
 
 		return map( planProperties, properties => {
@@ -272,6 +273,7 @@ class PlanFeatures extends Component {
 						basePlansPath={ basePlansPath }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 						isInSignup={ isInSignup }
+						selectedPlan={ selectedPlan }
 					/>
 				</td>
 			);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -174,6 +174,7 @@ class PlanFeatures extends Component {
 						basePlansPath={ basePlansPath }
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 						isInSignup={ isInSignup }
+						selectedPlan={ selectedPlan }
 					/>
 					<p className="plan-features__description">{ planConstantObj.getDescription( abtest ) }</p>
 					<PlanFeaturesActions

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -115,14 +115,14 @@ class PlanFeatures extends Component {
 
 	renderMobileView() {
 		const {
+			basePlansPath,
 			canPurchase,
-			translate,
-			planProperties,
 			isInSignup,
 			isLandingPage,
-			site,
-			basePlansPath,
+			planProperties,
 			selectedPlan,
+			site,
+			translate,
 		} = this.props;
 
 		// move any free plan to last place in mobile view
@@ -177,19 +177,19 @@ class PlanFeatures extends Component {
 					/>
 					<p className="plan-features__description">{ planConstantObj.getDescription( abtest ) }</p>
 					<PlanFeaturesActions
+						available={ available }
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }
-						primaryUpgrade={ primaryUpgrade }
-						available={ available }
-						onUpgradeClick={ onUpgradeClick }
 						freePlan={ isFreePlan( planName ) }
-						isPlaceholder={ isPlaceholder }
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
+						isPlaceholder={ isPlaceholder }
 						isPopular={ popular }
+						onUpgradeClick={ onUpgradeClick }
 						planName={ planConstantObj.getTitle() }
 						planType={ planName }
+						primaryUpgrade={ primaryUpgrade }
 						selectedPlan={ selectedPlan }
 					/>
 					<FoldableCard header={ translate( 'Show features' ) } clickableHeader compact>
@@ -208,13 +208,13 @@ class PlanFeatures extends Component {
 
 	renderPlanHeaders() {
 		const {
-			planProperties,
-			site,
 			basePlansPath,
-			isInSignup,
-			siteType,
 			displayJetpackPlans,
+			isInSignup,
+			planProperties,
 			selectedPlan,
+			site,
+			siteType,
 		} = this.props;
 
 		return map( planProperties, properties => {
@@ -257,23 +257,23 @@ class PlanFeatures extends Component {
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesHeader
+						audience={ audience }
+						basePlansPath={ basePlansPath }
+						billingTimeFrame={ billingTimeFrame }
 						current={ current }
 						currencyCode={ currencyCode }
-						popular={ popular }
-						newPlan={ newPlan }
-						title={ planConstantObj.getTitle() }
-						audience={ audience }
-						planType={ planName }
-						rawPrice={ rawPrice }
 						discountPrice={ discountPrice }
-						billingTimeFrame={ billingTimeFrame }
-						isPlaceholder={ isPlaceholder }
-						site={ site }
 						hideMonthly={ hideMonthly }
-						basePlansPath={ basePlansPath }
-						relatedMonthlyPlan={ relatedMonthlyPlan }
 						isInSignup={ isInSignup }
+						isPlaceholder={ isPlaceholder }
+						newPlan={ newPlan }
+						planType={ planName }
+						popular={ popular }
+						rawPrice={ rawPrice }
+						relatedMonthlyPlan={ relatedMonthlyPlan }
+						site={ site }
 						selectedPlan={ selectedPlan }
+						title={ planConstantObj.getTitle() }
 					/>
 				</td>
 			);
@@ -331,20 +331,20 @@ class PlanFeatures extends Component {
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesActions
+						available={ available }
 						canPurchase={ canPurchase }
 						className={ getPlanClass( planName ) }
 						current={ current }
-						available={ available }
-						primaryUpgrade={ primaryUpgrade }
-						planName={ planConstantObj.getTitle() }
-						onUpgradeClick={ onUpgradeClick }
 						freePlan={ isFreePlan( planName ) }
 						isPlaceholder={ isPlaceholder }
 						isPopular={ popular }
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
 						manageHref={ `/plans/my-plan/${ site.slug }` }
+						onUpgradeClick={ onUpgradeClick }
+						planName={ planConstantObj.getTitle() }
 						planType={ planName }
+						primaryUpgrade={ primaryUpgrade }
 						selectedPlan={ selectedPlan }
 					/>
 				</td>


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/20204.

**Context:** Upgrade nudges pass a suggested plan as a parameter, which is used to render upgrade/buy buttons as primary for that plan (see #20204). This patch completes the plan emphasis by adding a `suggested` ribbon component. We also remove `New` (.org plans) and `Popular` (.com plans) ribbon components to display one ribbon at a time.

**To test:**
- use calypso-live or checkout this branch 
- access the Plans page through upgrade Banners or through the urls directly (with or without the `feature` parameter.

  Examples:
*Jetpack sites* `http://calypso.localhost:3000/plans/:jetpack_connected_site?feature=seo-preview-tools&plan=jetpack_business`
*.com sites* `http://calypso.localhost:3000/plans/:site?feature=google-analytics&plan=business-bundle`

- Modify the `plan` parameter and verify that the `suggested` ribbon is placed correctly and not other ribbons appear. Use `{ business-, value_, personal- }bundle` for .com plans and `jetpack_{personal, premium, business }`  for the .org plans.

- verify that it works for mobile

**Visuals:**
`http://calypso.localhost:3000/plans/:jetpack_connected_site?feature=wordads-instant&plan=jetpack_premium`
![screen shot 2017-12-10 at 20 28 02](https://user-images.githubusercontent.com/13561163/33809142-ea0c5332-dde9-11e7-92ca-3a2d5c26bdb1.png)

~*known issue for .org plans:* `monthly/yearly` toggle bug will be merged in parallel https://github.com/Automattic/wp-calypso/pull/20437~ DONE