### PR TITLE
.org Plans: improve Copy in the Media banner and bring back feature highlighting

### DIFF
--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -24,6 +24,7 @@ import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 import {
 	PLAN_JETPACK_PREMIUM,
+	FEATURE_VIDEO_CDN_LIMITED,
 	FEATURE_VIDEO_UPLOADS,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
 	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
@@ -150,7 +151,7 @@ class MediaSettings extends Component {
 						'Get high-speed video hosting without ads, watermarks, or throttling.'
 					) }
 					event={ 'jetpack_video_settings' }
-					feature={ FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM }
+					feature={ FEATURE_VIDEO_CDN_LIMITED }
 					plan={ PLAN_JETPACK_PREMIUM }
 					title={ translate( 'Enable video hosting by upgrading to Jetpack Premium' ) }
 				/>

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -148,12 +148,14 @@ class MediaSettings extends Component {
 			! isVideoPressAvailable && (
 				<Banner
 					description={ translate(
-						'Get high-speed video hosting without ads, watermarks, or throttling.'
+						'Get high-speed, high-resolution video hosting without ads or watermarks.'
 					) }
 					event={ 'jetpack_video_settings' }
 					feature={ FEATURE_VIDEO_CDN_LIMITED }
 					plan={ PLAN_JETPACK_PREMIUM }
-					title={ translate( 'Enable video hosting by upgrading to Jetpack Premium' ) }
+					title={ translate(
+						'Host video right on your site! Upgrade to Jetpack Premium to get started'
+					) }
 				/>
 			)
 		);

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -146,10 +146,13 @@ class MediaSettings extends Component {
 		return (
 			! isVideoPressAvailable && (
 				<Banner
+					description={ translate(
+						'Get high-speed video hosting without ads, watermarks, or throttling.'
+					) }
 					event={ 'jetpack_video_settings' }
 					feature={ FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM }
 					plan={ PLAN_JETPACK_PREMIUM }
-					title={ translate( 'Host fast, high-quality, ad-free video.' ) }
+					title={ translate( 'Enable video hosting by upgrading to Jetpack Premium' ) }
 				/>
 			)
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/20226

Included:
- highlighting the `13GB Video Storage` feature in Jetpack Premium plan 
- improving the Copy in the nudge in `https://wordpress.com/settings/traffic/:jetpack_site`, which redirects to it

**To test:**
- checkout this branch or use calypso.live
- verify that the improved copy is visible in Media section at `http://calypso.localhost:3000/settings/writing/:jetpack_site` (see below) ...
- and redirects to `http://calypso.localhost:3000/plans/:jetpack_site?feature=video-cdn-limited&plan=jetpack_premium` with `13GB Video Storage` highlighted (see below)

**Visuals:**
![screen shot 2017-12-10 at 22 22 30](https://user-images.githubusercontent.com/13561163/33810598-a56f7c08-ddfe-11e7-8822-19d8688101f5.png)
![screen shot 2017-12-10 at 22 59 35](https://user-images.githubusercontent.com/13561163/33810600-a6e6fcfa-ddfe-11e7-8aeb-4532761eb2c4.png)
