### PR TITLE
Comments: use API data to detect links

### DIFF
--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -39,17 +39,6 @@ export class CommentAuthor extends Component {
 
 	storeLinkIndicatorRef = icon => ( this.hasLinkIndicator = icon );
 
-	commentHasLink = () => {
-		if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {
-			const parser = new DOMParser();
-			const commentDom = parser.parseFromString( this.props.commentContent, 'text/html' );
-
-			return !! commentDom.getElementsByTagName( 'a' ).length;
-		}
-
-		return false;
-	};
-
 	hideLinkTooltip = () => this.setState( { isLinkTooltipVisible: false } );
 
 	showLinkTooltip = () => this.setState( { isLinkTooltipVisible: true } );
@@ -64,6 +53,7 @@ export class CommentAuthor extends Component {
 			commentType,
 			commentUrl,
 			gravatarUser,
+			hasLink,
 			isBulkMode,
 			isPostView,
 			moment,
@@ -91,7 +81,7 @@ export class CommentAuthor extends Component {
 
 				<div className="comment__author-info">
 					<div className="comment__author-info-element">
-						{ this.commentHasLink() && (
+						{ hasLink && (
 							<span
 								onMouseEnter={ this.showLinkTooltip }
 								onMouseLeave={ this.hideLinkTooltip }
@@ -163,6 +153,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 			? `/comment/${ siteSlug }/${ commentId }`
 			: get( comment, 'URL' ),
 		gravatarUser,
+		hasLink: get( comment, 'contains_links', false ),
 	};
 };
 

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -153,7 +153,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 			? `/comment/${ siteSlug }/${ commentId }`
 			: get( comment, 'URL' ),
 		gravatarUser,
-		hasLink: get( comment, 'contains_links', false ),
+		hasLink: get( comment, 'has_link', false ),
 	};
 };
 

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -43,7 +43,7 @@ import {
 	POST_COMMENT_DISPLAY_TYPES,
 } from './constants';
 import trees from './trees/reducer';
-import { getStateKey, getErrorKey } from './utils';
+import { getStateKey, getErrorKey, commentHasLink } from './utils';
 
 const getCommentDate = ( { date } ) => new Date( date );
 
@@ -116,6 +116,7 @@ export function items( state = {}, action ) {
 			const comments = map( action.comments, _comment => ( {
 				..._comment,
 				contiguous: ! action.commentById,
+				has_link: commentHasLink( _comment.content, _comment.has_link ),
 			} ) );
 			const allComments = unionBy( state[ stateKey ], comments, 'ID' );
 			return {

--- a/client/state/comments/utils.js
+++ b/client/state/comments/utils.js
@@ -8,3 +8,19 @@ export const deconstructStateKey = key => {
 };
 
 export const getErrorKey = ( siteId, commentId ) => `${ siteId }-${ commentId }`;
+
+export const commentHasLink = ( commentContent, apiSuppliedValue ) => {
+	// In case API provides value for has_link, skip parsing and return it instead.
+	if ( typeof apiSuppliedValue !== 'undefined' ) {
+		return apiSuppliedValue;
+	}
+
+	if ( typeof DOMParser !== 'undefined' && DOMParser.prototype.parseFromString ) {
+		const parser = new DOMParser();
+		const commentDom = parser.parseFromString( commentContent, 'text/html' );
+
+		return !! commentDom.getElementsByTagName( 'a' ).length;
+	}
+
+	return false;
+};


### PR DESCRIPTION
Depends on: D8733-code

Previously we were parsing comment's HTML content on client to determine if it contains URLs. Now this functionality is moved to API endpoint. If API doesn't provide the value, it will be calculated on client side. Additionally, this client side check has been moved to reducer in order to avoid calculating it on each render.

### Testing instructions

1. Apply D8733-code to your sandbox.
2. Navigate to `/comments/all`.
3. Verify that link indicator is displayed for comments that have links.
4. Verify that link indicator is not present for comments that don't contain links.