### PR TITLE
External media: Allow attribution and refresh button flags

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -301,6 +301,8 @@ class MediaLibraryContent extends React.Component {
 					onSourceChange={ this.props.onSourceChange }
 					selectedItems={ this.props.selectedItems }
 					sticky={ ! this.props.scrollable }
+					hasAttribution={ 'pexels' === this.props.source }
+					hasRefreshButton={ 'pexels' !== this.props.source }
 				/>
 			);
 		}

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -31,6 +31,8 @@ class MediaLibraryExternalHeader extends React.Component {
 		selectedItems: PropTypes.array,
 		onSourceChange: PropTypes.func,
 		sticky: PropTypes.bool,
+		hasAttribution: PropTypes.bool,
+		hasRefreshButton: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -112,15 +114,17 @@ class MediaLibraryExternalHeader extends React.Component {
 	}
 
 	renderCard() {
-		const { onMediaScaleChange, translate, canCopy } = this.props;
+		const { onMediaScaleChange, translate, canCopy, hasRefreshButton } = this.props;
 
 		return (
 			<Card className="media-library__header">
-				<Button compact disabled={ this.state.fetching } onClick={ this.handleClick }>
-					<Gridicon icon="refresh" size={ 24 } />
+				{ hasRefreshButton && (
+					<Button compact disabled={ this.state.fetching } onClick={ this.handleClick }>
+						<Gridicon icon="refresh" size={ 24 } />
 
-					{ translate( 'Refresh' ) }
-				</Button>
+						{ translate( 'Refresh' ) }
+					</Button>
+				) }
 
 				{ canCopy && this.renderCopyButton() }
 


### PR DESCRIPTION
In preparation for merging the free photo library work,
we need to be able to enable an attribution element, and
disable the refresh button.

This change adds `hasAttribution` and `hasRefreshButton`
props to the MediaLibraryExternalHeader, and MediaLibraryContent
sets the appropriately.

# Testing

Load the media library, select Google Photos, and make sure the
refresh button still appears.