### PR TITLE
External media: disabling sources with large images for site icon

### DIFF
--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -23,6 +23,11 @@ export class MediaLibraryDataSource extends Component {
 	static propTypes = {
 		source: PropTypes.string.isRequired,
 		onSourceChange: PropTypes.func.isRequired,
+		disabledSources: PropTypes.array,
+	};
+
+	static defaultProps = {
+		disabledSources: [],
 	};
 
 	constructor( props ) {
@@ -54,12 +59,14 @@ export class MediaLibraryDataSource extends Component {
 	}
 
 	renderMenuItems( sources ) {
-		return sources.map( item => (
-			<PopoverMenuItem action={ item.value } key={ item.value } onClick={ this.changeSource }>
-				{ item.icon }
-				{ item.label }
-			</PopoverMenuItem>
-		) );
+		return sources
+			.filter( item => -1 === this.props.disabledSources.indexOf( item.value ) )
+			.map( item => (
+				<PopoverMenuItem action={ item.value } key={ item.value } onClick={ this.changeSource }>
+					{ item.icon }
+					{ item.label }
+				</PopoverMenuItem>
+			) );
 	}
 
 	render() {

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -20,6 +20,11 @@ import PlanStorage from 'blocks/plan-storage';
 import FilterItem from './filter-item';
 import DataSource from './data-source';
 
+// These source supply very large images, and there are instances such as
+// the site icon editor, where we want to disable them because the editor
+// can't handle the large images.
+const largeImageSources = [ 'pexels' ];
+
 export class MediaLibraryFilterBar extends Component {
 	static propTypes = {
 		basePath: PropTypes.string,
@@ -34,6 +39,7 @@ export class MediaLibraryFilterBar extends Component {
 		translate: PropTypes.func,
 		post: PropTypes.bool,
 		isConnected: PropTypes.bool,
+		disableLargeImageSources: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -46,6 +52,7 @@ export class MediaLibraryFilterBar extends Component {
 		source: '',
 		post: false,
 		isConnected: true,
+		disableLargeImageSources: false,
 	};
 
 	getSearchPlaceholderText() {
@@ -167,7 +174,11 @@ export class MediaLibraryFilterBar extends Component {
 		// Dropdown is disabled when viewing any external data source
 		return (
 			<div className="media-library__filter-bar">
-				<DataSource source={ this.props.source } onSourceChange={ this.props.onSourceChange } />
+				<DataSource
+					source={ this.props.source }
+					onSourceChange={ this.props.onSourceChange }
+					disabledSources={ this.props.disableLargeImageSources ? largeImageSources : [] }
+				/>
 
 				<SectionNav
 					selectedText={ this.getFilterLabel( this.props.filter ) }

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -62,6 +62,7 @@ class MediaLibrary extends Component {
 		single: PropTypes.bool,
 		scrollable: PropTypes.bool,
 		postId: PropTypes.number,
+		disableLargeImageSources: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -70,6 +71,7 @@ class MediaLibrary extends Component {
 		onScaleChange: () => {},
 		scrollable: false,
 		source: '',
+		disableLargeImageSources: false,
 	};
 
 	componentWillMount() {
@@ -206,6 +208,7 @@ class MediaLibrary extends Component {
 					onSearch={ this.doSearch }
 					isConnected={ isConnected( this.props ) }
 					post={ !! this.props.postId }
+					disableLargeImageSources={ this.props.disableLargeImageSources }
 				/>
 				{ content }
 			</div>

--- a/client/my-sites/media-library/test/data-source.jsx
+++ b/client/my-sites/media-library/test/data-source.jsx
@@ -1,0 +1,60 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import { noop } from 'lodash';
+import React from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import MediaLibraryDataSource from 'my-sites/media-library/data-source';
+import { createReduxStore } from 'state';
+
+// we need to check the correct children are rendered, so this mocks the
+// PopoverMenu component with one that simply renders the children
+jest.mock( 'components/popover/menu', () => {
+	return props => <div>{ props.children }</div>;
+} );
+// only enable the external-media options, enabling everything causes an
+// electron related build error
+jest.mock( 'config', () => {
+	const config = () => 'development';
+	config.isEnabled = property => property.startsWith( 'external-media' );
+	return config;
+} );
+
+describe( 'MediaLibraryDataSource', () => {
+	describe( 'render data sources', () => {
+		test( 'does not exclude any data sources by default', () => {
+			const store = createReduxStore();
+			const wrapper = mount(
+				<ReduxProvider store={ store }>
+					<MediaLibraryDataSource source={ '' } onSourceChange={ noop } />
+				</ReduxProvider>
+			);
+			expect( wrapper.find( 'button[action="google_photos"]' ) ).to.have.length( 1 );
+		} );
+
+		test( 'excludes data sources listed in disabledSources', () => {
+			const store = createReduxStore();
+			const wrapper = mount(
+				<ReduxProvider store={ store }>
+					<MediaLibraryDataSource
+						source={ '' }
+						onSourceChange={ noop }
+						disabledSources={ [ 'google_photos' ] }
+					/>
+				</ReduxProvider>
+			);
+			expect( wrapper.find( 'button[action="google_photos"]' ) ).to.have.length( 0 );
+		} );
+	} );
+} );

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -332,6 +332,7 @@ class SiteIconSetting extends Component {
 							labels={ {
 								confirm: translate( 'Continue' ),
 							} }
+							disableLargeImageSources={ true }
 							single
 						/>
 					</MediaLibrarySelectedData>


### PR DESCRIPTION
Setting the site icon with images that are very big (4k quality, 20mb+)
can cause the browser to hang when editing the image.

This change allows us to tell the media library's data sources to
exclude a list of sources, and adds a prop that excludes the images
we've listed as having large images that aren't suitable for
setting the site icon.

# Testing

Go to the site icon setting. Make sure you can still set the icon using Google Photos.

Additionally, you can add `google_photos` to the list of large image sources
in `client/my-sites/media-library/filter-bar.jsx` and it should disappear as an option
when setting the site icon.