### PR TITLE
Jetpack Onboarding: Autofocus first field in Site Title step

### DIFF
--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -48,7 +48,12 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 					<form>
 						<FormFieldset>
 							<FormLabel htmlFor="title">{ translate( 'Site Title' ) }</FormLabel>
-							<FormTextInput id="title" onChange={ this.setTitle } value={ this.state.title } />
+							<FormTextInput
+								id="title"
+								onChange={ this.setTitle }
+								value={ this.state.title }
+								autoFocus
+							/>
 						</FormFieldset>
 
 						<FormFieldset>


### PR DESCRIPTION
This PR updates the Site Title step to auto focus the first field when the user first lands on it.

Idea borrowed from #17653 and #17654 (hat tip @ashleighaxios)

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/onboarding/site-title
* Verify the Site Title field gets automatically focused.