### PR TITLE
Store Services - handling failed fetch state

### DIFF
--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -16,6 +16,7 @@ import { localize } from 'i18n-calypso';
 import { canCurrentUser } from 'state/selectors';
 import config from 'config';
 import DocumentHead from 'components/data/document-head';
+import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isSiteAutomatedTransfer, hasSitePendingAutomatedTransfer } from 'state/selectors';
 import route from 'lib/route';
@@ -84,6 +85,7 @@ class App extends Component {
 		return (
 			<div className={ className }>
 				<DocumentHead title={ documentTitle } />
+				<QueryJetpackPlugins siteIds={ [ siteId ] } />
 				{ children }
 			</div>
 		);

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -16,7 +16,6 @@ import { first } from 'lodash';
  */
 import { createNote } from 'woocommerce/state/sites/orders/notes/actions';
 import Button from 'components/button';
-import config from 'config';
 import Dialog from 'components/dialog';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -43,8 +42,7 @@ import {
 	getStoreLocation,
 	areSettingsGeneralLoaded,
 } from 'woocommerce/state/sites/settings/general/selectors';
-
-const wcsEnabled = config.isEnabled( 'woocommerce/extension-wcservices' );
+import { isWcsEnabled } from 'woocommerce/state/selectors/plugins';
 
 class OrderFulfillment extends Component {
 	static propTypes = {
@@ -182,7 +180,7 @@ class OrderFulfillment extends Component {
 	}
 
 	renderFulfillmentAction() {
-		const { labelsLoaded, labelsError, order, site, translate } = this.props;
+		const { wcsEnabled, labelsLoaded, labelsError, order, site, translate } = this.props;
 		const orderFinished = isOrderFinished( order.status );
 		const labelsLoading = wcsEnabled && ! labelsLoaded;
 
@@ -222,7 +220,7 @@ class OrderFulfillment extends Component {
 	}
 
 	render() {
-		const { order, site, translate } = this.props;
+		const { wcsEnabled, order, site, translate } = this.props;
 		const { errorMessage, showDialog, trackingNumber } = this.state;
 		const dialogClass = 'woocommerce order-fulfillment'; // eslint/css specificity hack
 		if ( ! order ) {
@@ -293,6 +291,7 @@ class OrderFulfillment extends Component {
 
 export default connect(
 	( state, { order, site } ) => {
+		const wcsEnabled = isWcsEnabled( state, site.ID );
 		const labelsLoaded =
 			wcsEnabled &&
 			Boolean( areLabelsFullyLoaded( state, order.id, site.ID ) ) &&
@@ -303,6 +302,7 @@ export default connect(
 		const labelCountriesData = getCountriesData( state, order.id, site.ID );
 
 		return {
+			wcsEnabled,
 			labelsLoaded,
 			labelsError: isLabelDataFetchError( state, order.id, site.ID ),
 			labelsEnabled: areLabelsEnabled( state, site.ID ),

--- a/client/extensions/woocommerce/app/order/order-fulfillment/index.js
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/index.js
@@ -32,6 +32,7 @@ import {
 	getLabels,
 	areLabelsFullyLoaded,
 	getCountriesData,
+	isLabelDataFetchError,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 import {
 	areLabelsEnabled,
@@ -181,7 +182,7 @@ class OrderFulfillment extends Component {
 	}
 
 	renderFulfillmentAction() {
-		const { labelsLoaded, order, site, translate } = this.props;
+		const { labelsLoaded, labelsError, order, site, translate } = this.props;
 		const orderFinished = isOrderFinished( order.status );
 		const labelsLoading = wcsEnabled && ! labelsLoaded;
 
@@ -189,7 +190,7 @@ class OrderFulfillment extends Component {
 			return null;
 		}
 
-		if ( labelsLoading ) {
+		if ( ! labelsError && labelsLoading ) {
 			const buttonClassName = 'is-placeholder';
 			return <Button className={ buttonClassName }>{ translate( 'Fulfill' ) }</Button>;
 		}
@@ -303,6 +304,7 @@ export default connect(
 
 		return {
 			labelsLoaded,
+			labelsError: isLabelDataFetchError( state, order.id, site.ID ),
 			labelsEnabled: areLabelsEnabled( state, site.ID ),
 			labels: getLabels( state, order.id, site.ID ),
 			hasLabelsPaymentMethod,

--- a/client/extensions/woocommerce/app/settings/shipping/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/index.js
@@ -7,21 +7,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import config from 'config';
 import Main from 'components/main';
 import LabelSettings from 'woocommerce/woocommerce-services/views/label-settings';
 import Packages from 'woocommerce/woocommerce-services/views/packages';
 import ShippingHeader from './shipping-header';
 import ShippingOrigin from './shipping-origin';
 import ShippingZoneList from './shipping-zone-list';
+import { getSelectedSite } from 'state/ui/selectors';
+import { isWcsEnabled } from 'woocommerce/state/selectors/plugins';
 
-const Shipping = ( { className } ) => {
-	const wcsEnabled = config.isEnabled( 'woocommerce/extension-wcservices' );
-
+const Shipping = ( { className, wcsEnabled } ) => {
 	return (
 		<Main className={ classNames( 'shipping', className ) } wideLayout>
 			<ShippingHeader />
@@ -37,4 +37,9 @@ Shipping.propTypes = {
 	className: PropTypes.string,
 };
 
-export default Shipping;
+export default connect( state => {
+	const site = getSelectedSite( state );
+	return {
+		wcsEnabled: isWcsEnabled( state, site.ID ),
+	};
+} )( Shipping );

--- a/client/extensions/woocommerce/app/settings/shipping/save-button.js
+++ b/client/extensions/woocommerce/app/settings/shipping/save-button.js
@@ -13,7 +13,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import Button from 'components/button';
 import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import {
@@ -25,6 +24,7 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { createWcsShippingSaveActionList } from 'woocommerce/woocommerce-services/state/actions';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { getActionList } from 'woocommerce/state/action-list/selectors';
+import { isWcsEnabled } from 'woocommerce/state/selectors/plugins';
 
 class ShippingSettingsSaveButton extends Component {
 	componentDidMount = () => {
@@ -47,11 +47,10 @@ class ShippingSettingsSaveButton extends Component {
 	};
 
 	save = () => {
-		if ( ! config.isEnabled( 'woocommerce/extension-wcservices' ) ) {
+		const { translate, wcsEnabled } = this.props;
+		if ( ! wcsEnabled ) {
 			return;
 		}
-
-		const { translate } = this.props;
 
 		const successAction = successNotice( translate( 'Shipping settings saved' ), {
 			duration: 4000,
@@ -82,8 +81,7 @@ class ShippingSettingsSaveButton extends Component {
 	};
 
 	render() {
-		const { translate, loading, site, finishedInitialSetup, isSaving } = this.props;
-		const wcsEnabled = config.isEnabled( 'woocommerce/extension-wcservices' );
+		const { wcsEnabled, translate, loading, site, finishedInitialSetup, isSaving } = this.props;
 
 		if ( loading || ! site ) {
 			return null;
@@ -107,10 +105,12 @@ class ShippingSettingsSaveButton extends Component {
 
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
+	const wcsEnabled = isWcsEnabled( state, site.ID );
 	const loading = areSetupChoicesLoading( state );
 	const finishedInitialSetup = getFinishedInitialSetup( state );
 	return {
 		site,
+		wcsEnabled,
 		finishedInitialSetup,
 		loading,
 		isSaving: Boolean( getActionList( state ) ),

--- a/client/extensions/woocommerce/state/reducer.js
+++ b/client/extensions/woocommerce/state/reducer.js
@@ -3,27 +3,17 @@
 /**
  * Internal dependencies
  */
-
-import config from 'config';
 import { combineReducers } from 'state/utils';
 import ui from './ui/reducer';
 import sites from './sites/reducer';
 import actionList from './action-list/reducer';
 import woocommerceServices from 'woocommerce/woocommerce-services/state/reducer';
 
-const wcsEnabled = config.isEnabled( 'woocommerce/extension-wcservices' );
-
 const reducers = {
 	ui,
 	sites,
 	actionList,
+	woocommerceServices,
 };
 
-export default combineReducers(
-	wcsEnabled
-		? {
-				...reducers,
-				woocommerceServices,
-			}
-		: reducers
-);
+export default combineReducers( reducers );

--- a/client/extensions/woocommerce/state/selectors/plugins.js
+++ b/client/extensions/woocommerce/state/selectors/plugins.js
@@ -1,0 +1,26 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { getSelectedSiteWithFallback } from '../sites/selectors';
+import { getPlugins, isRequestingForSites } from 'state/plugins/installed/selectors';
+
+export const isWcsEnabled = ( state, siteId = getSelectedSiteWithFallback( state ) ) => {
+	if ( ! config.isEnabled( 'woocommerce/extension-wcservices' ) ) {
+		return false;
+	}
+
+	const siteIds = [ siteId ];
+
+	if ( isRequestingForSites( state, siteIds ) ) {
+		return false;
+	}
+
+	const plugins = getPlugins( state, siteIds, 'active' );
+	return Boolean( find( plugins, { slug: 'woocommerce-services' } ) );
+};

--- a/client/extensions/woocommerce/state/selectors/test/plugins.js
+++ b/client/extensions/woocommerce/state/selectors/test/plugins.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import {
+	isWcsEnabled,
+} from '../plugins';
+
+const siteId = 123;
+
+const getState = ( loaded = false, installed = false, active = false ) => {
+	const pluginArray = [];
+	if ( loaded && installed ) {
+		pluginArray.push( {
+			id: 'woocommerce-services/woocommerce-services',
+			slug: 'woocommerce-services',
+			active,
+		} );
+	}
+
+	return {
+		plugins: {
+			installed: {
+				plugins: {
+					[ siteId ]: pluginArray,
+				},
+				isRequesting: {
+					[ siteId ]: ! loaded,
+				},
+			},
+		},
+	};
+};
+
+describe( 'plugins', () => {
+	describe( '#isWcsEnabled', () => {
+		it( 'should be false if WCS is disabled in the config', () => {
+			const configStub = sinon.stub( config, 'isEnabled' );
+			configStub.withArgs( 'woocommerce/extension-wcservices' ).returns( false );
+
+			expect( isWcsEnabled( getState(), siteId ) ).to.be.false;
+			configStub.restore();
+		} );
+
+		it( 'should be false if the plugin list is being requested', () => {
+			expect( isWcsEnabled( getState( false ), siteId ) ).to.be.false;
+		} );
+
+		it( 'should be false if the plugin is not installed', () => {
+			expect( isWcsEnabled( getState( true, false ), siteId ) ).to.be.false;
+		} );
+
+		it( 'should be false if the plugin is not active', () => {
+			expect( isWcsEnabled( getState( true, true, false ), siteId ) ).to.be.false;
+		} );
+
+		it( 'should be true if the plugin is installed and active', () => {
+			expect( isWcsEnabled( getState( true, true, true ), siteId ) ).to.be.true;
+		} );
+	} );
+} );

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
@@ -5,6 +5,7 @@ import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { areOrderNotesLoaded, areOrderNotesLoading, getOrderNotes } from '../notes/selectors';
 import {
+	isError as areShippingLabelsErrored,
 	isLoaded as areShippingLabelsLoaded,
 	isFetching as areShippingLabelsLoading,
 	getLabels,
@@ -52,8 +53,16 @@ export const EVENT_TYPES = {
  * @return {boolean} Whether the activity log for a given order has been successfully loaded from the server.
  */
 export const isActivityLogLoaded = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
-	return areOrderNotesLoaded( state, orderId, siteId ) &&
-		( ! config.isEnabled( 'woocommerce/extension-wcservices' ) || areShippingLabelsLoaded( state, orderId, siteId ) );
+	const notesLoaded = areOrderNotesLoaded( state, orderId, siteId );
+	if ( ! notesLoaded ) {
+		return false;
+	}
+
+	if ( ! config.isEnabled( 'woocommerce/extension-wcservices' ) || areShippingLabelsErrored( state, orderId, siteId ) ) {
+		return true;
+	}
+
+	return areShippingLabelsLoaded( state, orderId, siteId );
 };
 
 /**
@@ -63,10 +72,16 @@ export const isActivityLogLoaded = ( state, orderId, siteId = getSelectedSiteId(
  * @return {boolean} Whether the activity log for a given order is currently being retrieved from the server.
  */
 export const isActivityLogLoading = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
-	if ( config.isEnabled( 'woocommerce/extension-wcservices' ) ) {
-		return areOrderNotesLoading( state, orderId, siteId ) || areShippingLabelsLoading( state, orderId, siteId );
+	const notesLoading = areOrderNotesLoading( state, orderId, siteId );
+	if ( notesLoading ) {
+		return true;
 	}
-	return areOrderNotesLoading( state, orderId, siteId );
+
+	if ( ! config.isEnabled( 'woocommerce/extension-wcservices' ) || areShippingLabelsErrored( state, orderId, siteId ) ) {
+		return false;
+	}
+
+	return areShippingLabelsLoading( state, orderId, siteId );
 };
 
 /**

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { areOrderNotesLoaded, areOrderNotesLoading, getOrderNotes } from '../notes/selectors';
 import {
@@ -10,6 +9,7 @@ import {
 	isFetching as areShippingLabelsLoading,
 	getLabels,
 } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
+import * as plugins from 'woocommerce/state/selectors/plugins';
 
 /*
  * Enum with the types of events that can be displayed in the Order Activity Log
@@ -58,7 +58,7 @@ export const isActivityLogLoaded = ( state, orderId, siteId = getSelectedSiteId(
 		return false;
 	}
 
-	if ( ! config.isEnabled( 'woocommerce/extension-wcservices' ) || areShippingLabelsErrored( state, orderId, siteId ) ) {
+	if ( ! plugins.isWcsEnabled( state, siteId ) || areShippingLabelsErrored( state, orderId, siteId ) ) {
 		return true;
 	}
 
@@ -77,7 +77,7 @@ export const isActivityLogLoading = ( state, orderId, siteId = getSelectedSiteId
 		return true;
 	}
 
-	if ( ! config.isEnabled( 'woocommerce/extension-wcservices' ) || areShippingLabelsErrored( state, orderId, siteId ) ) {
+	if ( ! plugins.isWcsEnabled( state, siteId ) || areShippingLabelsErrored( state, orderId, siteId ) ) {
 		return false;
 	}
 
@@ -101,7 +101,7 @@ export const getActivityLogEvents = ( state, orderId, siteId = getSelectedSiteId
 		content: note.note,
 	} ) );
 
-	if ( config.isEnabled( 'woocommerce/extension-wcservices' ) ) {
+	if ( plugins.isWcsEnabled( state, siteId ) ) {
 		getLabels( state, orderId, siteId ).forEach( ( label, index, allLabels ) => {
 			const labelIndex = allLabels.length - 1 - index;
 			if ( label.refund ) {

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
@@ -14,227 +14,175 @@ import {
 } from '../selectors';
 import config from 'config';
 
-const notesAndLabelsLoadingState = {
+const getState = ( notesState, labelsState ) => ( {
 	extensions: {
 		woocommerce: {
 			sites: {
 				123: {
 					orders: {
-						notes: {
-							isLoading: {
-								45: true,
-							},
-							isSaving: {
-								45: true,
-							},
-							items: {},
-							orders: {},
-						}
+						notes: notesState,
 					},
 				},
 			},
 			woocommerceServices: {
 				123: {
 					shippingLabel: {
-						45: {
-							isFetching: true,
-						}
-					}
-				}
-			}
-		},
-	},
-};
-
-const notesLoadingState = {
-	extensions: {
-		woocommerce: {
-			sites: {
-				123: {
-					orders: {
-						notes: {
-							isLoading: {
-								45: true,
-							},
-							isSaving: {
-								45: true,
-							},
-							items: {},
-							orders: {},
-						}
+						45: labelsState,
 					},
 				},
 			},
-			woocommerceServices: {
-				123: {
-					shippingLabel: {
-						45: {
-							isFetching: false,
-							loaded: true,
-							labels: [],
-						}
-					}
-				}
-			}
 		},
+	},
+} );
+
+const notesLoadingSubtree = {
+	isLoading: {
+		45: true,
+	},
+	isSaving: {
+		45: true,
+	},
+	items: {},
+	orders: {},
+};
+
+const notesLoadedSubtree = {
+	isLoading: {
+		45: false,
+	},
+	isSaving: {
+		45: false,
+	},
+	items: {
+		1: {
+			id: 1,
+			date_created_gmt: 'Mon Sep 18 2017 09:37:51',
+			note: 'Something internal',
+			customer_note: false,
+		},
+		2: {
+			id: 2,
+			date_created_gmt: 'Mon Sep 18 2017 10:37:51',
+			note: 'Something customer-facing',
+			customer_note: true,
+		},
+	},
+	orders: {
+		45: [ 1, 2 ],
 	},
 };
 
-const labelsLoadingState = {
-	extensions: {
-		woocommerce: {
-			sites: {
-				123: {
-					orders: {
-						notes: {
-							isLoading: {
-								45: false,
-							},
-							isSaving: {
-								45: false,
-							},
-							items: {},
-							orders: {
-								45: [],
-							},
-						}
-					},
-				},
+const emptyNotesSubtree = {
+	isLoading: {
+		45: false,
+	},
+	isSaving: {
+		45: false,
+	},
+	items: {},
+	orders: {
+		45: [],
+	},
+};
+
+const labelsLoadingSubtree = {
+	isFetching: true,
+};
+
+const labelsLoadedSubtree = {
+	isFetching: false,
+	loaded: true,
+	labels: [
+		{
+			label_id: 4,
+			refundable_amount: 10,
+			rate: 10,
+			currency: 'CAD',
+			created_date: 4000000,
+			used_date: null,
+			expiry_date: 4500000,
+			product_names: [ 'poutine' ],
+			package_name: 'box',
+			tracking: '12345',
+			carrier_id: 'canada_post',
+			service_name: 'Xpress',
+			refund: {
+				status: 'rejected',
+				request_date: 4100000,
+				refund_date: 4200000,
 			},
-			woocommerceServices: {
-				123: {
-					shippingLabel: {
-						45: {
-							isFetching: true,
-						}
-					}
-				}
-			}
 		},
-	},
-};
-
-const loadedState = {
-	extensions: {
-		woocommerce: {
-			sites: {
-				123: {
-					orders: {
-						notes: {
-							isLoading: {
-								45: false,
-							},
-							isSaving: {
-								45: false,
-							},
-							items: {
-								1: {
-									id: 1,
-									date_created_gmt: 'Mon Sep 18 2017 09:37:51',
-									note: 'Something internal',
-									customer_note: false,
-								},
-								2: {
-									id: 2,
-									date_created_gmt: 'Mon Sep 18 2017 10:37:51',
-									note: 'Something customer-facing',
-									customer_note: true,
-								},
-							},
-							orders: {
-								45: [ 1, 2 ],
-							},
-						}
-					},
-				},
+		{
+			label_id: 3,
+			refundable_amount: 7,
+			rate: 7,
+			currency: 'USD',
+			created_date: 3000000,
+			used_date: null,
+			expiry_date: null,
+			product_names: [ 'Autograph' ],
+			package_name: 'Small Envelope',
+			tracking: '12345',
+			carrier_id: 'usps',
+			service_name: 'First Class',
+			refund: {
+				status: 'complete',
+				request_date: 3100000,
+				refund_date: 3200000,
+				amount: '6.95',
 			},
-			woocommerceServices: {
-				123: {
-					shippingLabel: {
-						45: {
-							isFetching: false,
-							loaded: true,
-							labels: [
-								{
-									label_id: 4,
-									refundable_amount: 10,
-									rate: 10,
-									currency: 'CAD',
-									created_date: 4000000,
-									used_date: null,
-									expiry_date: 4500000,
-									product_names: [ 'poutine' ],
-									package_name: 'box',
-									tracking: '12345',
-									carrier_id: 'canada_post',
-									service_name: 'Xpress',
-									refund: {
-										status: 'rejected',
-										request_date: 4100000,
-										refund_date: 4200000,
-									},
-								},
-								{
-									label_id: 3,
-									refundable_amount: 7,
-									rate: 7,
-									currency: 'USD',
-									created_date: 3000000,
-									used_date: null,
-									expiry_date: null,
-									product_names: [ 'Autograph' ],
-									package_name: 'Small Envelope',
-									tracking: '12345',
-									carrier_id: 'usps',
-									service_name: 'First Class',
-									refund: {
-										status: 'complete',
-										request_date: 3100000,
-										refund_date: 3200000,
-										amount: '6.95',
-									},
-								},
-								{
-									label_id: 2,
-									refundable_amount: 7,
-									rate: 7,
-									currency: 'CAD',
-									created_date: 2000000,
-									used_date: null,
-									expiry_date: 2500000,
-									product_names: [ 'blender' ],
-									package_name: 'regular box',
-									tracking: '12345',
-									carrier_id: 'canada_post',
-									service_name: 'Xpress',
-									refund: {
-										status: 'pending',
-										request_date: 2100000,
-									},
-								},
-								{
-									label_id: 1,
-									refundable_amount: 4.5,
-									rate: 5,
-									currency: 'USD',
-									created_date: 1000000,
-									used_date: 1100000,
-									expiry_date: 1500000,
-									product_names: [ 'bee', 'bee' ],
-									package_name: 'bee box',
-									tracking: '12345',
-									carrier_id: 'usps',
-									service_name: 'First Class',
-								},
-							],
-						}
-					}
-				}
-			}
 		},
-	},
+		{
+			label_id: 2,
+			refundable_amount: 7,
+			rate: 7,
+			currency: 'CAD',
+			created_date: 2000000,
+			used_date: null,
+			expiry_date: 2500000,
+			product_names: [ 'blender' ],
+			package_name: 'regular box',
+			tracking: '12345',
+			carrier_id: 'canada_post',
+			service_name: 'Xpress',
+			refund: {
+				status: 'pending',
+				request_date: 2100000,
+			},
+		},
+		{
+			label_id: 1,
+			refundable_amount: 4.5,
+			rate: 5,
+			currency: 'USD',
+			created_date: 1000000,
+			used_date: 1100000,
+			expiry_date: 1500000,
+			product_names: [ 'bee', 'bee' ],
+			package_name: 'bee box',
+			tracking: '12345',
+			carrier_id: 'usps',
+			service_name: 'First Class',
+		},
+	],
 };
 
+const emptyLabelsSubtree = {
+	isFetching: false,
+	loaded: true,
+	labels: [],
+};
+
+const labelsErrorSubtree = {
+	isFetching: false,
+	loaded: false,
+	error: true,
+};
+
+const notesAndLabelsLoadingState = getState( notesLoadingSubtree, labelsLoadingSubtree );
+const notesLoadingState = getState( notesLoadingSubtree, labelsLoadedSubtree );
+const labelsLoadingState = getState( notesLoadedSubtree, labelsLoadingSubtree );
+const loadedState = getState( notesLoadedSubtree, labelsLoadedSubtree );
 const loadedStateWithUi = { ...loadedState, ui: { selectedSiteId: 123 } };
 
 describe( 'selectors', () => {
@@ -268,6 +216,19 @@ describe( 'selectors', () => {
 		it( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( isActivityLogLoaded( loadedStateWithUi, 45 ) ).to.be.true;
 		} );
+
+		it( 'should be true if labels fetch errors out, but notes were loaded', () => {
+			expect( isActivityLogLoaded( getState( notesLoadedSubtree, labelsErrorSubtree ), 45, 123 ) ).to.be.true;
+		} );
+
+		it( 'should be false if labels fetch errors out, and notes were not loaded', () => {
+			expect( isActivityLogLoaded( getState( notesLoadingSubtree, labelsErrorSubtree ), 45, 123 ) ).to.be.false;
+		} );
+
+		it( 'should be true if WCS is disabled, and notes were loaded', sinon.test( function() {
+			this.stub( config, 'isEnabled' ).withArgs( 'woocommerce/extension-wcservices' ).returns( false );
+			expect( isActivityLogLoaded( getState( notesLoadedSubtree, labelsLoadingState ), 45, 123 ) ).to.be.true;
+		} ) );
 	} );
 
 	describe( '#isActivityLogLoading', () => {
@@ -300,16 +261,24 @@ describe( 'selectors', () => {
 		it( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( isActivityLogLoading( loadedStateWithUi, 45 ) ).to.be.false;
 		} );
+
+		it( 'should be false when notes are loaded and labels errored out', () => {
+			expect( isActivityLogLoading( getState( notesLoadedSubtree, labelsErrorSubtree ), 45, 123 ) ).to.be.false;
+		} );
+
+		it( 'should be true when notes are loading and labels errored out', () => {
+			expect( isActivityLogLoading( getState( notesLoadingSubtree, labelsErrorSubtree ), 45, 123 ) ).to.be.true;
+		} );
 	} );
 
 	describe( '#getActivityLogEvents', () => {
 		it( 'should be empty when notes are currently being fetched for this order.', () => {
 			expect( getActivityLogEvents( notesAndLabelsLoadingState, 45, 123 ) ).to.be.empty;
-			expect( getActivityLogEvents( notesLoadingState, 45, 123 ) ).to.be.empty;
+			expect( getActivityLogEvents( getState( notesLoadingSubtree, emptyLabelsSubtree ), 45, 123 ) ).to.be.empty;
 		} );
 
 		it( 'should be empty when notes are loaded but labels are not.', () => {
-			expect( getActivityLogEvents( labelsLoadingState, 45, 123 ) ).to.be.empty;
+			expect( getActivityLogEvents( getState( emptyNotesSubtree, labelsLoadingSubtree ), 45, 123 ) ).to.be.empty;
 		} );
 
 		it( 'should return just the notes when notes are loaded and the Services extension is disabled.', sinon.test( function() {

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
@@ -12,7 +12,7 @@ import {
 	isActivityLogLoading,
 	getActivityLogEvents,
 } from '../selectors';
-import config from 'config';
+import * as plugins from 'woocommerce/state/selectors/plugins';
 
 const getState = ( notesState, labelsState ) => ( {
 	extensions: {
@@ -186,6 +186,15 @@ const loadedState = getState( notesLoadedSubtree, labelsLoadedSubtree );
 const loadedStateWithUi = { ...loadedState, ui: { selectedSiteId: 123 } };
 
 describe( 'selectors', () => {
+	let wcsEnabledStub;
+	beforeEach( () => {
+		wcsEnabledStub = sinon.stub( plugins, 'isWcsEnabled' ).returns( true );
+	} );
+
+	afterEach( () => {
+		wcsEnabledStub.restore();
+	} );
+
 	describe( '#isActivityLogLoaded', () => {
 		it( 'should be false when notes are currently being fetched for this order.', () => {
 			expect( isActivityLogLoaded( notesAndLabelsLoadingState, 45, 123 ) ).to.be.false;
@@ -196,10 +205,11 @@ describe( 'selectors', () => {
 			expect( isActivityLogLoaded( labelsLoadingState, 45, 123 ) ).to.be.falsy;
 		} );
 
-		it( 'should be true when notes are loaded and the WooCommerce Services extension is disabled.', sinon.test( function() {
-			this.stub( config, 'isEnabled' ).withArgs( 'woocommerce/extension-wcservices' ).returns( false );
+		it( 'should be true when notes are loaded and the WooCommerce Services extension is disabled.', () => {
+			wcsEnabledStub.restore();
+			wcsEnabledStub = sinon.stub( plugins, 'isWcsEnabled' ).returns( false );
 			expect( isActivityLogLoaded( labelsLoadingState, 45, 123 ) ).to.be.true;
-		} ) );
+		} );
 
 		it( 'should be true when notes and labels are loaded for this order.', () => {
 			expect( isActivityLogLoaded( loadedState, 45, 123 ) ).to.be.true;
@@ -225,10 +235,11 @@ describe( 'selectors', () => {
 			expect( isActivityLogLoaded( getState( notesLoadingSubtree, labelsErrorSubtree ), 45, 123 ) ).to.be.false;
 		} );
 
-		it( 'should be true if WCS is disabled, and notes were loaded', sinon.test( function() {
-			this.stub( config, 'isEnabled' ).withArgs( 'woocommerce/extension-wcservices' ).returns( false );
+		it( 'should be true if WCS is disabled, and notes were loaded', () => {
+			wcsEnabledStub.restore();
+			wcsEnabledStub = sinon.stub( plugins, 'isWcsEnabled' ).returns( false );
 			expect( isActivityLogLoaded( getState( notesLoadedSubtree, labelsLoadingState ), 45, 123 ) ).to.be.true;
-		} ) );
+		} );
 	} );
 
 	describe( '#isActivityLogLoading', () => {
@@ -241,10 +252,11 @@ describe( 'selectors', () => {
 			expect( isActivityLogLoading( labelsLoadingState, 45, 123 ) ).to.be.true;
 		} );
 
-		it( 'should be false when notes are loaded and the WooCommerce Services extension is disabled.', sinon.test( function() {
-			this.stub( config, 'isEnabled' ).withArgs( 'woocommerce/extension-wcservices' ).returns( false );
+		it( 'should be false when notes are loaded and the WooCommerce Services extension is disabled.', () => {
+			wcsEnabledStub.restore();
+			wcsEnabledStub = sinon.stub( plugins, 'isWcsEnabled' ).returns( false );
 			expect( isActivityLogLoading( labelsLoadingState, 45, 123 ) ).to.be.false;
-		} ) );
+		} );
 
 		it( 'should be false when notes and labels are loaded for this order.', () => {
 			expect( isActivityLogLoading( loadedState, 45, 123 ) ).to.be.false;
@@ -281,8 +293,9 @@ describe( 'selectors', () => {
 			expect( getActivityLogEvents( getState( emptyNotesSubtree, labelsLoadingSubtree ), 45, 123 ) ).to.be.empty;
 		} );
 
-		it( 'should return just the notes when notes are loaded and the Services extension is disabled.', sinon.test( function() {
-			this.stub( config, 'isEnabled' ).withArgs( 'woocommerce/extension-wcservices' ).returns( false );
+		it( 'should return just the notes when notes are loaded and the Services extension is disabled.', () => {
+			wcsEnabledStub.restore();
+			wcsEnabledStub = sinon.stub( plugins, 'isWcsEnabled' ).returns( false );
 			expect( getActivityLogEvents( loadedState, 45, 123 ) ).to.deep.equal( [
 				{
 					key: 1,
@@ -297,7 +310,7 @@ describe( 'selectors', () => {
 					content: 'Something customer-facing',
 				},
 			] );
-		} ) );
+		} );
 
 		it( 'should return a list of events if everything is loaded.', () => {
 			expect( getActivityLogEvents( loadedState, 45, 123 ) ).to.deep.equal( [

--- a/client/extensions/woocommerce/woocommerce-services/components/labels-setup-notice/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/labels-setup-notice/index.js
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
-import config from 'config';
 import QueryLabelSettings from 'woocommerce/woocommerce-services/components/query-label-settings';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
@@ -19,10 +18,16 @@ import {
 	areLabelsEnabled,
 	getSelectedPaymentMethodId,
 } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
+import { isWcsEnabled } from 'woocommerce/state/selectors/plugins';
 
-const wcsEnabled = config.isEnabled( 'woocommerce/extension-wcservices' );
-
-const LabelsSetupNotice = ( { site, loaded, enabled, hasLabelsPaymentMethod, translate } ) => {
+const LabelsSetupNotice = ( {
+	site,
+	wcsEnabled,
+	loaded,
+	enabled,
+	hasLabelsPaymentMethod,
+	translate,
+} ) => {
 	if ( ! wcsEnabled ) {
 		return null;
 	}
@@ -48,6 +53,7 @@ const LabelsSetupNotice = ( { site, loaded, enabled, hasLabelsPaymentMethod, tra
 export default connect( state => {
 	const site = getSelectedSite( state );
 	return {
+		wcsEnabled: isWcsEnabled( state, site.ID ),
 		site,
 		loaded: areSettingsLoaded( state, site.ID ),
 		enabled: areLabelsEnabled( state, site.ID ),

--- a/client/extensions/woocommerce/woocommerce-services/state/label-settings/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/label-settings/actions.js
@@ -51,7 +51,7 @@ export const fetchSettings = siteId => ( dispatch, getState ) => {
 			dispatch( initForm( siteId, storeOptions, formData, formMeta ) );
 		} )
 		.catch( error => {
-			setFormMetaProperty( siteId, 'isFetchError', true );
+			dispatch( setFormMetaProperty( siteId, 'isFetchError', true ) );
 			console.error( error ); // eslint-disable-line no-console
 		} )
 		.then( () => dispatch( setFormMetaProperty( siteId, 'isFetching', false ) ) );

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -10,8 +10,11 @@ import createSelector from 'lib/create-selector';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { hasNonEmptyLeaves } from 'woocommerce/woocommerce-services/lib/utils/tree';
 import { isValidPhone } from 'woocommerce/woocommerce-services/lib/utils/phone-format';
-import { areSettingsLoaded } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
-import { isLoaded as arePackagesLoaded } from 'woocommerce/woocommerce-services/state/packages/selectors';
+import { areSettingsLoaded, areSettingsErrored } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
+import {
+	isLoaded as arePackagesLoaded,
+	isFetchError as arePackagesErrored,
+} from 'woocommerce/woocommerce-services/state/packages/selectors';
 
 export const getShippingLabel = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	return get( state, [ 'extensions', 'woocommerce', 'woocommerceServices', siteId, 'shippingLabel', orderId ], null );
@@ -280,6 +283,10 @@ export const canPurchase = createSelector(
 
 export const areLabelsFullyLoaded = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
 	return isLoaded( state, orderId, siteId ) && areSettingsLoaded( state, siteId ) && arePackagesLoaded( state, siteId );
+};
+
+export const isLabelDataFetchError = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
+	return isError( state, orderId, siteId ) || areSettingsErrored( state, siteId ) || arePackagesErrored( state, siteId );
 };
 
 export const getCountriesData = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/index.js
@@ -21,7 +21,11 @@ import PackagesListItem from './packages-list-item';
 import QueryPackages from 'woocommerce/woocommerce-services/components/query-packages';
 import * as PackagesActions from '../../state/packages/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getPackagesForm, getAllSelectedPackages } from '../../state/packages/selectors';
+import {
+	getPackagesForm,
+	getAllSelectedPackages,
+	isFetchError,
+} from '../../state/packages/selectors';
 
 class Packages extends Component {
 	renderListHeader = packages => {
@@ -76,7 +80,11 @@ class Packages extends Component {
 	};
 
 	render() {
-		const { isFetching, siteId, allSelectedPackages, translate } = this.props;
+		const { isFetching, fetchError, siteId, allSelectedPackages, translate } = this.props;
+		if ( fetchError ) {
+			return null;
+		}
+
 		const packages = isFetching ? [ {}, {}, {} ] : allSelectedPackages;
 
 		const addPackage = () => this.props.addPackage( siteId );
@@ -130,6 +138,7 @@ export default connect(
 		return {
 			siteId,
 			isFetching: ! form || ! form.packages || form.isFetching,
+			fetchError: isFetchError( state, siteId ),
 			form,
 			allSelectedPackages: getAllSelectedPackages( state, siteId ) || [],
 		};


### PR DESCRIPTION
Fixes #20260 

To test:
* in wp-admin, disable the WooCommerce services plugin
* in Calypso, open the shipping settings page and verify that the requests to the WCS endpoints are made only once, and the components are hidden after the requests error out
* navigate to a fulfilled order and verify that the activity log renders correctly
* navigate to an unfulfilled order and verify that the fulfill button and activity log render
* everything should also work as before when the plugin is enabled