### PR TITLE
Update checklist banner styles

### DIFF
--- a/client/my-sites/stats/checklist-banner/style.scss
+++ b/client/my-sites/stats/checklist-banner/style.scss
@@ -77,6 +77,8 @@
 
 .checklist-banner__title {
 	font-size: 26px;
+	line-height: 1.2em;
+	margin-bottom: 10px;
 }
 
 .checklist-banner__description {


### PR DESCRIPTION
This PR adds some CSS adjustments to reduce the line height of a the checklist banner title when the text spans over two lines. 

## Before
![screen shot 2017-12-11 at 12 55 17 pm](https://user-images.githubusercontent.com/6981253/33845889-e2156dba-de72-11e7-86b6-a15db69d5654.png)

## After
![screen shot 2017-12-11 at 12 55 06 pm](https://user-images.githubusercontent.com/6981253/33845897-e6b838c0-de72-11e7-91db-c1bd45846556.png)

## Testing
* Create a new site and then visit the stats screen.
* Use the inspector to add more copy to the title so that it spans across multiple lines.

cc @taggon 
 