### PR TITLE
Posts: Fix saving and publishing drafts copies

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -344,7 +344,7 @@ PostActions = {
 			type: 'EDIT_POST_SAVE',
 		} );
 
-		postHandle = wpcom.site( site.ID ).post( post.ID );
+		postHandle = wpcom.site( post.site_ID ).post( post.ID );
 		query = {
 			context: 'edit',
 			apiVersion: '1.2',

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -344,7 +344,7 @@ PostActions = {
 			type: 'EDIT_POST_SAVE',
 		} );
 
-		postHandle = wpcom.site( post.site_ID ).post( post.ID );
+		postHandle = wpcom.site( site.ID ).post( post.ID );
 		query = {
 			context: 'edit',
 			apiVersion: '1.2',

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -130,9 +130,9 @@ function getPressThisContent( query ) {
 // - (Flux) startEditingNew: to set the editor content;
 // - (Redux) editPost: to set every other attribute (in particular, to update the Category Selector, terms can only be set via Redux);
 // - (Flux) edit: to reliably show the updated post attributes before (auto)saving.
-function startEditingPostCopy( siteId, postToCopyId, context ) {
+function startEditingPostCopy( site, postToCopyId, context ) {
 	wpcom
-		.site( siteId )
+		.site( site.ID )
 		.post( postToCopyId )
 		.get( { context: 'edit' } )
 		.then( postToCopy => {
@@ -166,12 +166,12 @@ function startEditingPostCopy( siteId, postToCopyId, context ) {
 				title: postAttributes.title,
 			};
 
-			actions.startEditingNew( siteId, {
+			actions.startEditingNew( site, {
 				content: postToCopy.content,
 				title: postToCopy.title,
 				type: postToCopy.type,
 			} );
-			context.store.dispatch( editPost( siteId, null, reduxPostAttributes ) );
+			context.store.dispatch( editPost( site.ID, null, reduxPostAttributes ) );
 			actions.edit( postAttributes );
 
 			/**
@@ -235,7 +235,7 @@ export default {
 			// so kick it off here to minimize time spent waiting for it to load
 			// in the view components
 			if ( postToCopyId ) {
-				startEditingPostCopy( siteId, postToCopyId, context );
+				startEditingPostCopy( site, postToCopyId, context );
 				analytics.pageView.record( '/' + postType, gaTitle + ' > New' );
 			} else if ( postID ) {
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified


### PR DESCRIPTION
Fix #20668

Fix a regression introduced with #20328 and caused by not replacing `siteId` with `site` in the  `startEditingNew` call fired when creating a copy of a post.

cc @jorgefilipecosta in case we missed something else! 🙂 

## Testing instructions

- Pick a draft in the posts or pages list.
- Click on the "More" action and then on "Copy".
- Make some changes and click on Save.
- The draft should be saved correctly (no error notice should pop up).
- Try again with another copy, but this time waiting for the Autosave instead.
- Now with another copy, try publishing it immediately (before the autosave).
- The copy should be published correctly.