### PR TITLE
Respect the sites prop of AllSites and use list of all sites only as a default

### DIFF
--- a/client/my-sites/all-sites/index.jsx
+++ b/client/my-sites/all-sites/index.jsx
@@ -91,6 +91,7 @@ class AllSites extends Component {
 	}
 }
 
-export default connect( state => ( {
-	sites: getSites( state ),
-} ) )( localize( AllSites ) );
+export default connect( ( state, props ) => {
+	const { sites = getSites( state ) } = props;
+	return { sites };
+} )( localize( AllSites ) );


### PR DESCRIPTION
If the list of sites is explicitly specified (`<AllSites sites={[...]}/>`), don't override it with the list of all sites from Redux (`getSites( state )`).

Fixes a bug reported by @enejb in https://github.com/Automattic/wp-calypso/pull/20514#issuecomment-350872394