### PR TITLE
Removed unnecessary sites-list mock in validation store tests.

### DIFF
--- a/client/lib/media/test/validation-store.js
+++ b/client/lib/media/test/validation-store.js
@@ -6,14 +6,9 @@ import { expect } from 'chai';
 import { assign } from 'lodash';
 import sinon from 'sinon';
 
-jest.mock( 'lib/sites-list', () => () => ( {
-	getSite: () => ( {
-		options: {
-			allowed_file_types: [ 'gif', 'pdf', 'avi' ],
-			max_upload_size: 1024,
-		},
-	} ),
-} ) );
+/**
+ * Internal dependencies
+ */
 import { site } from './fixtures/site';
 
 /**


### PR DESCRIPTION
During sites-list removal from media validation store in https://github.com/Automattic/wp-calypso/pull/15641, the removal of sites-list mock from tests was missed.

To test:
This PR just changes a test file so executing automated tests and verifying tests are passing as expected should be enough.