### PR TITLE
Docs: remove instructions to run webpack-dasboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can try out the user-side of Calypso on [WordPress.com](https://wordpress.co
 1.	Make sure you have `git`, `node`, and `npm` installed.
 2.	Clone this repository locally.
 3.	Add `127.0.0.1 calypso.localhost` to your local `hosts` file.
-4.	Execute `npm start` or `npm run dashboard` (for a more visually-oriented interface) from the root directory of the repository.
+4.	Execute `npm start` from the root directory of the repository.
 5.	Open [`calypso.localhost:3000`](http://calypso.localhost:3000/) in your browser.
 
 Need more detailed installation instructions? [We have them](docs/install.md).

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@ You can install Calypso directly on your machine by following the next steps, or
 1.	Check that you have all prerequisites (Git, Node, NPM). See [below](install.md#prerequisites) for more details. Pay close attention to software versions.
 2.	Clone this repository locally.
 3.	Add `127.0.0.1 calypso.localhost` to your local `hosts` file.
-4.	Execute `npm start` or `npm run dashboard` (for a more visually-oriented interface) from the root directory of the repository.
+4.	Execute `npm start` from the root directory of the repository.
 5.	Open [`calypso.localhost:3000`](http://calypso.localhost:3000/) in your browser.
 
 ## Prerequisites


### PR DESCRIPTION
Remove instructions that were left behind when `webpack-dashboard` was removed in Automattic/wp-calypso@df5f18867c751831b9946950e45fbc0635546af6 (https://github.com/Automattic/wp-calypso/pull/20612).