### PR TITLE
Store: Settings: Notices: Add redux

### DIFF
--- a/client/extensions/woocommerce/state/sites/settings/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/actions.js
@@ -12,7 +12,7 @@ import {
 	WOOCOMMERCE_SETTINGS_BATCH_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
 
-const doInitialSetupSuccess = ( siteId, data ) => {
+const settingsBatchRequestSuccess = ( siteId, data ) => {
 	return {
 		type: WOOCOMMERCE_SETTINGS_BATCH_REQUEST_SUCCESS,
 		siteId,
@@ -119,7 +119,7 @@ export const doInitialSetup = (
 	return request( siteId )
 		.post( 'settings/batch', { update } )
 		.then( data => {
-			dispatch( doInitialSetupSuccess( siteId, data ) );
+			dispatch( settingsBatchRequestSuccess( siteId, data ) );
 			if ( successAction ) {
 				dispatch( successAction( data ) );
 			}
@@ -130,14 +130,6 @@ export const doInitialSetup = (
 				dispatch( failureAction( err ) );
 			}
 		} );
-};
-
-const setAddressSuccess = ( siteId, data ) => {
-	return {
-		type: WOOCOMMERCE_SETTINGS_BATCH_REQUEST_SUCCESS,
-		siteId,
-		data,
-	};
 };
 
 export const setAddress = (
@@ -196,7 +188,54 @@ export const setAddress = (
 	return request( siteId )
 		.post( 'settings/batch', { update } )
 		.then( data => {
-			dispatch( setAddressSuccess( siteId, data ) );
+			dispatch( settingsBatchRequestSuccess( siteId, data ) );
+			if ( successAction ) {
+				dispatch( successAction( data ) );
+			}
+		} )
+		.catch( err => {
+			dispatch( setError( siteId, updateAction, err ) );
+			if ( failureAction ) {
+				dispatch( failureAction( err ) );
+			}
+		} );
+};
+
+export const updateStoreNoticeSettings = (
+	siteId,
+	enabled,
+	notice,
+	successAction,
+	failureAction
+) => ( dispatch, getState ) => {
+	const state = getState();
+	if ( ! siteId ) {
+		siteId = getSelectedSiteId( state );
+	}
+	const updateAction = {
+		type: WOOCOMMERCE_SETTINGS_BATCH_REQUEST,
+		siteId,
+	};
+
+	dispatch( updateAction );
+
+	const update = [
+		{
+			group_id: 'general',
+			id: 'woocommerce_demo_store',
+			value: enabled ? 'yes' : 'no',
+		},
+		{
+			group_id: 'general',
+			id: 'woocommerce_demo_store_notice',
+			value: notice,
+		},
+	];
+
+	return request( siteId )
+		.post( 'settings/batch', { update } )
+		.then( data => {
+			dispatch( settingsBatchRequestSuccess( siteId, data ) );
 			if ( successAction ) {
 				dispatch( successAction( data ) );
 			}

--- a/client/extensions/woocommerce/state/sites/settings/general/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/selectors.js
@@ -118,9 +118,6 @@ export const isStoreNoticeEnabled = ( state, siteId = getSelectedSiteId( state )
 	if ( ! noticeEnabled ) {
 		return false;
 	}
-	if ( ! ( 'value' in noticeEnabled ) ) {
-		return false;
-	}
 	return 'yes' === noticeEnabled.value;
 };
 
@@ -130,8 +127,5 @@ export const getStoreNotice = ( state, siteId = getSelectedSiteId( state ) ) => 
 	if ( ! notice ) {
 		return null;
 	}
-	if ( ! ( 'value' in notice ) ) {
-		return null;
-	}
-	return notice.value;
+	return notice.value || null;
 };

--- a/client/extensions/woocommerce/state/sites/settings/general/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/selectors.js
@@ -111,3 +111,27 @@ export const areTaxCalculationsEnabled = ( state, siteId = getSelectedSiteId( st
 	}
 	return 'yes' === taxesEnabled.value;
 };
+
+export const isStoreNoticeEnabled = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const generalSettings = getRawGeneralSettings( state, siteId );
+	const noticeEnabled = find( generalSettings, { id: 'woocommerce_demo_store' } );
+	if ( ! noticeEnabled ) {
+		return false;
+	}
+	if ( ! ( 'value' in noticeEnabled ) ) {
+		return false;
+	}
+	return 'yes' === noticeEnabled.value;
+};
+
+export const getStoreNotice = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const generalSettings = getRawGeneralSettings( state, siteId );
+	const notice = find( generalSettings, { id: 'woocommerce_demo_store_notice' } );
+	if ( ! notice ) {
+		return null;
+	}
+	if ( ! ( 'value' in notice ) ) {
+		return null;
+	}
+	return notice.value;
+};

--- a/client/extensions/woocommerce/state/sites/settings/general/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/test/actions.js
@@ -4,12 +4,19 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { spy } from 'sinon';
 
 /**
  * Internal dependencies
  */
 import { fetchSettingsGeneral } from '../actions';
-import { WOOCOMMERCE_SETTINGS_GENERAL_REQUEST } from 'woocommerce/state/action-types';
+import { updateStoreNoticeSettings } from '../../actions';
+import useNock from 'test/helpers/use-nock';
+import {
+	WOOCOMMERCE_SETTINGS_BATCH_REQUEST,
+	WOOCOMMERCE_SETTINGS_BATCH_REQUEST_SUCCESS,
+	WOOCOMMERCE_SETTINGS_GENERAL_REQUEST,
+} from 'woocommerce/state/action-types';
 
 describe( 'actions', () => {
 	describe( '#fetchSettingsGeneral()', () => {
@@ -17,6 +24,62 @@ describe( 'actions', () => {
 		test( 'should return an action', () => {
 			const action = fetchSettingsGeneral( siteId );
 			expect( action ).to.eql( { type: WOOCOMMERCE_SETTINGS_GENERAL_REQUEST, siteId } );
+		} );
+	} );
+
+	describe( '#updateStoreNoticeSettings()', () => {
+		const siteId = '123';
+		const settingsPayload = [
+			{
+				id: 'woocommerce_demo_store',
+				value: 'no',
+			},
+			{
+				id: 'woocommerce_demo_store_notice',
+				value: 'test store notice',
+			},
+		];
+
+		useNock( nock => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
+				.query( {
+					path: '/wc/v3/settings/batch&_method=post',
+					json: true,
+					body: { update: settingsPayload },
+				} )
+				.reply( 200, {
+					data: {
+						update: settingsPayload,
+					},
+				} );
+		} );
+
+		test( 'should dispatch an action', () => {
+			const getState = () => ( {} );
+			const dispatch = spy();
+			updateStoreNoticeSettings( siteId )( dispatch, getState );
+			expect( dispatch ).to.have.been.calledWith( {
+				type: WOOCOMMERCE_SETTINGS_BATCH_REQUEST,
+				siteId,
+			} );
+		} );
+
+		test( 'should dispatch a success action with settings information when request completes', () => {
+			const getState = () => ( {} );
+			const dispatch = spy();
+			const response = updateStoreNoticeSettings( siteId )( dispatch, getState );
+
+			return response.then( () => {
+				expect( dispatch ).to.have.been.calledWith( {
+					type: WOOCOMMERCE_SETTINGS_BATCH_REQUEST_SUCCESS,
+					siteId,
+					data: {
+						update: settingsPayload,
+					},
+				} );
+			} );
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/state/sites/settings/general/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/test/selectors.js
@@ -12,6 +12,8 @@ import {
 	areSettingsGeneralLoaded,
 	areSettingsGeneralLoading,
 	getPaymentCurrencySettings,
+	getStoreNotice,
+	isStoreNoticeEnabled,
 } from '../selectors';
 import { LOADING } from 'woocommerce/state/constants';
 
@@ -48,13 +50,27 @@ const currencySetting = {
 	default: 'GBP',
 	value: 'USD',
 };
+const noticeEnabledSetting = {
+	id: 'woocommerce_demo_store',
+	label: 'Store notice',
+	type: 'checkbox',
+	default: 'no',
+	value: 'yes',
+};
+const noticeSetting = {
+	id: 'woocommerce_demo_store_notice',
+	label: 'Store notice text',
+	type: 'textarea',
+	default: 'This is a demo store for testing purposes &mdash; no orders shall be fulfilled.',
+	value: 'Sale runs through Wednesday, December 13, 2017!',
+};
 const loadedState = {
 	extensions: {
 		woocommerce: {
 			sites: {
 				123: {
 					settings: {
-						general: [ currencySetting ],
+						general: [ currencySetting, noticeEnabledSetting, noticeSetting ],
 					},
 				},
 			},
@@ -117,6 +133,34 @@ describe( 'selectors', () => {
 
 		test( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( getPaymentCurrencySettings( loadedStateWithUi ) ).to.eql( currencySetting );
+		} );
+	} );
+
+	describe( '#isStoreNoticeEnabled', () => {
+		test( 'should be false when woocommerce state is not available', () => {
+			expect( isStoreNoticeEnabled( preInitializedState, 123 ) ).to.be.false;
+		} );
+
+		test( 'should be false when settings are currently being fetched.', () => {
+			expect( isStoreNoticeEnabled( loadingState, 123 ) ).to.be.false;
+		} );
+
+		test( 'should be true when settings are loaded.', () => {
+			expect( isStoreNoticeEnabled( loadedState, 123 ) ).to.be.true;
+		} );
+	} );
+
+	describe( '#getStoreNotice', () => {
+		test( 'should be null when woocommerce state is not available', () => {
+			expect( getStoreNotice( preInitializedState, 123 ) ).to.be.null;
+		} );
+
+		test( 'should be null when settings are currently being fetched.', () => {
+			expect( getStoreNotice( loadingState, 123 ) ).to.be.null;
+		} );
+
+		test( 'should get the store notice from state.', () => {
+			expect( getStoreNotice( loadedState, 123 ) ).to.eql( noticeSetting.value );
 		} );
 	} );
 } );


### PR DESCRIPTION
Partially addresses #20623 

Adds selectors to extract store notice settings from redux state. Part of the overall effort to add store notices to settings and the dashboard. Also renamed `doInitialSetupSuccess` to `settingsBatchRequestSuccess` to be more accurate about what the success action does.

To test:
* `npm run test-client client/extensions/woocommerce` and ensure all tests pass