### PR TITLE
Stop dispatching JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST to Sites List Flux store

### DIFF
--- a/client/lib/sites-list/index.js
+++ b/client/lib/sites-list/index.js
@@ -5,7 +5,6 @@
  */
 
 import { action as InvitesActionTypes } from 'lib/invites/constants';
-import { JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST } from 'state/action-types';
 import SitesList from './list';
 import PollerPool from 'lib/data-poller';
 import Dispatcher from 'dispatcher';
@@ -27,9 +26,6 @@ export default function() {
 					if ( [ 'follower', 'viewer' ].indexOf( action.invite.role ) === -1 ) {
 						_sites.sync( action.data );
 					}
-					break;
-				case JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST:
-					_sites.sync( action.data );
 					break;
 				case 'FETCH_SITES':
 					_sites.fetch(); // refetch the sites from .com

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -16,7 +16,6 @@ import page from 'page';
 import wpcom from 'lib/wp';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { receiveDeletedSite, receiveSite } from 'state/sites/actions';
-import Dispatcher from 'dispatcher';
 import {
 	JETPACK_CONNECT_CHECK_URL,
 	JETPACK_CONNECT_CHECK_URL_RECEIVE,
@@ -446,10 +445,6 @@ export function authorize( queryObject ) {
 					sites: data.sites,
 				} );
 				dispatch( {
-					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST,
-					data: data,
-				} );
-				Dispatcher.handleViewAction( {
 					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST,
 					data: data,
 				} );


### PR DESCRIPTION
The action updates the sites list with the newly connected Jetpack site by calling `SitesList.sync()`. That's already covered in Redux by dispatching `SITES_RECEIVE` with the same data. We no longer need to update the Flux store.

**How to test:**
1. Connect a Jetpack site in Calypso and have your Redux devtools open.
2. After successfully connecting, check that action `SITES_RECEIVE` was dispatched and that it added the newly connected site to `state.sites.items`. Check also that `JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST` was dispatched, too, and did change the state in `state.jetpackConnect.jetpackConnectAuthorize`.