### PR TITLE
ActionLog: Accept string, regex or function as filter

### DIFF
--- a/client/state/console-dispatch/README.md
+++ b/client/state/console-dispatch/README.md
@@ -61,5 +61,9 @@ actionLog.filter( 'COMMENTS_LIKE' )
 // note that action types will benefit from
 // auto-complete in the console
 actionLog.filter( actionTypes.COMMENTS_LIKE )
+
+// pass a regex to filter matching action types
+actionLog.filter( /^USER/ )
+actionLog.filter( /receive|request$/i )
 ```
 

--- a/client/state/console-dispatch/index.js
+++ b/client/state/console-dispatch/index.js
@@ -1,13 +1,13 @@
 /**
  * Console dispatcher Redux store enhancer
- * 
+ *
  * Inject into the `createStore` enhancer chain in order
  * to provide access to the store directly from the console.
- * 
+ *
  * Will only attach if the `window` variable is available
  * globally. If not it will simply be an empty link in the
  * chain, passing straight through.
- * 
+ *
  * A few helpers have also been attached to the window in
  * order to make debugging and interacting easier. Please
  * see the README for more information.
@@ -33,7 +33,12 @@ const state = {
 
 const actionLog = {
 	clear: () => ( state.actionHistory = [] ),
-	filter: type => state.actionHistory.filter( matchesProperty( 'type', type ) ),
+	filter: typeTest =>
+		state.actionHistory.filter(
+			typeTest instanceof RegExp
+				? ( { type } ) => typeTest.test( type )
+				: matchesProperty( 'type', typeTest )
+		),
 	setSize: size => ( state.historySize = size ),
 	start: () => ( state.shouldRecordActions = true ),
 	stop: () => ( state.shouldRecordActions = false ),

--- a/client/state/console-dispatch/index.js
+++ b/client/state/console-dispatch/index.js
@@ -16,11 +16,6 @@
  */
 
 /**
- * External dependencies
- */
-import { matchesProperty } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import * as actionTypes from 'state/action-types';
@@ -31,14 +26,23 @@ const state = {
 	historySize: 100,
 };
 
+const queryToPredicate = query => {
+	if ( query instanceof RegExp ) {
+		return ( { type } ) => query.test( type );
+	}
+	if ( 'string' === typeof query ) {
+		return ( { type } ) => type === query;
+	}
+	if ( 'function' === typeof query ) {
+		return query;
+	}
+
+	throw new TypeError( 'provide string or RegExp matching `action.type` or a predicate function' );
+};
+
 const actionLog = {
 	clear: () => ( state.actionHistory = [] ),
-	filter: typeTest =>
-		state.actionHistory.filter(
-			typeTest instanceof RegExp
-				? ( { type } ) => typeTest.test( type )
-				: matchesProperty( 'type', typeTest )
-		),
+	filter: query => state.actionHistory.filter( queryToPredicate( query ) ),
 	setSize: size => ( state.historySize = size ),
 	start: () => ( state.shouldRecordActions = true ),
 	stop: () => ( state.shouldRecordActions = false ),

--- a/client/state/console-dispatch/index.js
+++ b/client/state/console-dispatch/index.js
@@ -26,7 +26,7 @@ const state = {
 	historySize: 100,
 };
 
-const queryToPredicate = query => {
+export const queryToPredicate = query => {
 	if ( query instanceof RegExp ) {
 		return ( { type } ) => query.test( type );
 	}

--- a/client/state/console-dispatch/test/index.js
+++ b/client/state/console-dispatch/test/index.js
@@ -1,0 +1,35 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { queryToPredicate } from '..';
+
+describe( 'consoleDispatcher', () => {
+	describe( 'queryToPredicate', () => {
+		test( 'should transform RegExp to arg.type predicate function', () => {
+			const predicate = queryToPredicate( /^MATCH_ME$/ );
+			expect( predicate( { type: 'MATCH_ME' } ) ).toBe( true );
+			expect( predicate( { type: 'DONT_MATCH_ME' } ) ).toBe( false );
+		} );
+
+		test( 'should transform string to arg.type predicate function', () => {
+			const predicate = queryToPredicate( /^MATCH_ME$/ );
+			expect( predicate( { type: 'MATCH_ME' } ) ).toBe( true );
+			expect( predicate( { type: 'DONT_MATCH_ME' } ) ).toBe( false );
+		} );
+
+		test( 'should return a provided function untouched', () => {
+			const predicateReturn = {};
+			const predicate = queryToPredicate( () => predicateReturn );
+			expect( predicate() ).toBe( predicateReturn );
+		} );
+
+		test( 'should throw an Error if unrecognized query is provided', () => {
+			const makeQueryToPredicateThunk = ( ...args ) => () => queryToPredicate( ...args );
+			expect( makeQueryToPredicateThunk() ).toThrow( TypeError );
+			expect( makeQueryToPredicateThunk( 1 ) ).toThrow( TypeError );
+			expect( makeQueryToPredicateThunk( {} ) ).toThrow( TypeError );
+		} );
+	} );
+} );

--- a/client/state/console-dispatch/test/index.js
+++ b/client/state/console-dispatch/test/index.js
@@ -26,10 +26,9 @@ describe( 'consoleDispatcher', () => {
 		} );
 
 		test( 'should throw an Error if unrecognized query is provided', () => {
-			const makeQueryToPredicateThunk = ( ...args ) => () => queryToPredicate( ...args );
-			expect( makeQueryToPredicateThunk() ).toThrow( TypeError );
-			expect( makeQueryToPredicateThunk( 1 ) ).toThrow( TypeError );
-			expect( makeQueryToPredicateThunk( {} ) ).toThrow( TypeError );
+			expect( () => queryToPredicate() ).toThrow( TypeError );
+			expect( () => queryToPredicate( 1 ) ).toThrow( TypeError );
+			expect( () => queryToPredicate( {} ) ).toThrow( TypeError );
 		} );
 	} );
 } );

--- a/client/state/console-dispatch/test/index.js
+++ b/client/state/console-dispatch/test/index.js
@@ -14,7 +14,7 @@ describe( 'consoleDispatcher', () => {
 		} );
 
 		test( 'should transform string to arg.type predicate function', () => {
-			const predicate = queryToPredicate( /^MATCH_ME$/ );
+			const predicate = queryToPredicate( 'MATCH_ME' );
 			expect( predicate( { type: 'MATCH_ME' } ) ).toBe( true );
 			expect( predicate( { type: 'DONT_MATCH_ME' } ) ).toBe( false );
 		} );


### PR DESCRIPTION
This PR allows a regex or predicate function to be passed to `actionLog.filter` as the filter.

* Actions will continue to filter by match types to strings
* Actions will filter by matching the types to regex.
* Actions will be passed to the predicate function for filtering.

When using `actionLog` I find it most useful to find a set of actions. Accepting a regex adds significant flexibility to the `filter`.

## Testing
1. `actionLog.filter` should continue to work as before with action type strings:
   ```js
   actionLog.filter( 'USER_RECEIVE' )
   ```
1. `actionLog.filter` should accept and match a regex on type:
   ```js
   actionLog.filter( /^USER/ )
   actionLog.filter( /receive|request$/i )
   ```
1. `actionLog.filter` should accept a predicate function. This should be functionally equivalent to `actionLog.history.filter()`:
   ```js
   actionLog.filter( ( { meta } ) => !! meta )
   actionLog.history.filter( ( { meta } ) => !! meta )
   ```
1. `actionLog.filter` should error if passed an argument of another type:
   ```js
   actionLog.filter( 1 )
   // Uncaught TypeError: provide string or RegExp matching `action.type` or a predicate function
   ```