### PR TITLE
Stat: ChecklistBanner: Truncate decimals

### DIFF
--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -137,7 +137,7 @@ export class ChecklistBanner extends Component {
 	render() {
 		const { completed, total, translate, siteId } = this.props;
 		const task = this.getNextTask();
-		const percentage = ( completed / Math.max( total, 1 ) * 100 ).toFixed( 1 );
+		const percentage = Math.round( completed / total * 100 );
 
 		if ( this.state.closed ) {
 			return null;


### PR DESCRIPTION
We probably don't need to show decimal points for the progress gauge.

## How to Test

Create a new website and move to `/stats` page of the site. The number on the progress gauge should be an integer as follows.

### Before
<img width="961" alt="before" src="https://user-images.githubusercontent.com/212034/33884283-70f6d43c-df82-11e7-8810-69599ce311bd.png">

### After
<img width="961" alt="after" src="https://user-images.githubusercontent.com/212034/33884287-76bebc90-df82-11e7-81af-32855d4427e0.png">

cc @fditrapani @markryall 

