### PR TITLE
Comments Clean Up: Move bulk logic from CommentList to CommentNavigation

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { each, filter, find, get, isEqual, map, orderBy, size, slice, uniq } from 'lodash';
+import { each, filter, find, get, isEqual, map, orderBy, slice, uniq } from 'lodash';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 /**

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -457,7 +457,7 @@ export class CommentList extends Component {
 					isBulkEdit={ isBulkEdit }
 					isSelectedAll={ this.isSelectedAll() }
 					postId={ postId }
-					selectedCount={ size( selectedComments ) }
+					selectedComments={ selectedComments }
 					setBulkStatus={ this.setBulkStatus }
 					setSortOrder={ this.setSortOrder }
 					sortOrder={ this.state.sortOrder }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -362,7 +362,7 @@ export class CommentList extends Component {
 	};
 
 	toggleBulkEdit = () => {
-		this.setState( ( { isBulkEdit } ) => ( { isBulkEdit: ! isBulkEdit } ) );
+		this.setState( ( { isBulkEdit } ) => ( { isBulkEdit: ! isBulkEdit, selectedComments: [] } ) );
 	};
 
 	toggleCommentLike = comment => {

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -342,13 +342,12 @@ const mapStateToProps = ( state, { commentsPage, siteId } ) => {
 };
 
 const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
-	changeStatus: ( postId, commentId, status, analytics = { alsoUnlike: false, isUndo: false } ) =>
+	changeStatus: ( postId, commentId, status, analytics = { alsoUnlike: false } ) =>
 		dispatch(
 			withAnalytics(
 				composeAnalytics(
 					recordTracksEvent( 'calypso_comment_management_change_status', {
 						also_unlike: analytics.alsoUnlike,
-						is_undo: analytics.isUndo,
 						previous_status: analytics.previousStatus,
 						status,
 					} ),

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -47,7 +47,7 @@ if ( ! isEnabled( 'comments/management/m3-design' ) ) {
 export class CommentNavigation extends Component {
 	static defaultProps = {
 		isSelectedAll: false,
-		selectedCount: 0,
+		selectedComments: [],
 		status: 'unapproved',
 		sortOrder: NEWEST_FIRST,
 	};
@@ -118,7 +118,7 @@ export class CommentNavigation extends Component {
 			isCommentsTreeSupported,
 			isSelectedAll,
 			query,
-			selectedCount,
+			selectedComments,
 			setBulkStatus,
 			setSortOrder,
 			sortOrder,
@@ -128,6 +128,7 @@ export class CommentNavigation extends Component {
 		} = this.props;
 
 		const navItems = this.getNavItems();
+		const selectedCount = selectedComments.length;
 
 		if ( isBulkEdit ) {
 			return (

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -381,11 +381,9 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 		),
 	recordChangeFilter: status =>
 		dispatch(
-			withAnalytics(
-				composeAnalytics(
-					recordTracksEvent( 'calypso_comment_management_change_filter', { status } ),
-					bumpStat( 'calypso_comment_management', 'change_filter_to_' + status )
-				)
+			composeAnalytics(
+				recordTracksEvent( 'calypso_comment_management_change_filter', { status } ),
+				bumpStat( 'calypso_comment_management', 'change_filter_to_' + status )
 			)
 		),
 	removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -108,9 +108,11 @@ export class CommentNavigation extends Component {
 
 	setBulkStatus = newStatus => () => {
 		const {
-			deletePermanently,
 			changeStatus,
+			deletePermanently,
+			recordBulkAction,
 			selectedComments,
+			status: queryStatus,
 			toggleBulkEdit,
 			unlike,
 		} = this.props;
@@ -125,6 +127,12 @@ export class CommentNavigation extends Component {
 			if ( alsoUnlike ) {
 				unlike( postId, commentId );
 			}
+			recordBulkAction(
+				newStatus,
+				selectedComments.length,
+				queryStatus,
+				!! postId ? 'post' : 'site'
+			);
 			this.showBulkNotice( newStatus );
 			toggleBulkEdit();
 		} );
@@ -356,6 +364,18 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 					bumpStat( 'calypso_comment_management', 'comment_deleted' )
 				),
 				deleteComment( siteId, postId, commentId, { showSuccessNotice: true } )
+			)
+		),
+	recordBulkAction: ( action, count, fromList, view = 'site' ) =>
+		dispatch(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_comment_management_bulk_action', {
+					action,
+					count,
+					from_list: fromList,
+					view,
+				} ),
+				bumpStat( 'calypso_comment_management', 'bulk_action' )
 			)
 		),
 	recordChangeFilter: status =>

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -110,10 +110,11 @@ export class CommentNavigation extends Component {
 		const {
 			changeStatus,
 			deletePermanently,
+			postId: isPostView,
 			recordBulkAction,
 			selectedComments,
 			status: queryStatus,
-			toggleBulkEdit,
+			toggleBulkMode,
 			unlike,
 		} = this.props;
 		this.props.removeNotice( 'comment-notice' );
@@ -127,15 +128,15 @@ export class CommentNavigation extends Component {
 			if ( alsoUnlike ) {
 				unlike( postId, commentId );
 			}
-			recordBulkAction(
-				newStatus,
-				selectedComments.length,
-				queryStatus,
-				!! postId ? 'post' : 'site'
-			);
-			this.showBulkNotice( newStatus );
-			toggleBulkEdit();
 		} );
+		recordBulkAction(
+			newStatus,
+			selectedComments.length,
+			queryStatus,
+			!! isPostView ? 'post' : 'site'
+		);
+		this.showBulkNotice( newStatus );
+		toggleBulkMode();
 	};
 
 	showBulkNotice = newStatus => {
@@ -179,7 +180,7 @@ export class CommentNavigation extends Component {
 			doSearch,
 			hasSearch,
 			hasComments,
-			isBulkEdit,
+			isBulkMode,
 			isCommentsTreeSupported,
 			isSelectedAll,
 			query,
@@ -187,14 +188,14 @@ export class CommentNavigation extends Component {
 			setSortOrder,
 			sortOrder,
 			status: queryStatus,
-			toggleBulkEdit,
+			toggleBulkMode,
 			translate,
 		} = this.props;
 
 		const navItems = this.getNavItems();
 		const selectedCount = selectedComments.length;
 
-		if ( isBulkEdit ) {
+		if ( isBulkMode ) {
 			return (
 				<SectionNav className="comment-navigation is-bulk-edit">
 					<CommentNavigationTab className="comment-navigation__bulk-count">
@@ -256,7 +257,7 @@ export class CommentNavigation extends Component {
 						</ButtonGroup>
 					</CommentNavigationTab>
 					<CommentNavigationTab className="comment-navigation__close-bulk">
-						<Button borderless onClick={ toggleBulkEdit } tabIndex="0">
+						<Button borderless onClick={ toggleBulkMode } tabIndex="0">
 							<Gridicon icon="cross" />
 						</Button>
 					</CommentNavigationTab>
@@ -304,7 +305,7 @@ export class CommentNavigation extends Component {
 						) }
 
 					{ hasComments && (
-						<Button compact onClick={ toggleBulkEdit }>
+						<Button compact onClick={ toggleBulkMode }>
 							{ translate( 'Bulk Edit' ) }
 						</Button>
 					) }


### PR DESCRIPTION
This PR contributes to #20727

With the new comments design, `CommentList` does not manage the comments actions anymore.
In order to remove completely all actions logic from the list, this PR moves the bulk system away from it and into `CommentNavigation`, as close to the buttons as possible.

## Testing instructions

- Enable the analytics debugging: `localStorage.setItem('debug', 'calypso:analytics:*');`.
- Open `/comments`.
- Change list filters and make sure there is an analytics tracking for it.
- Click on Bulk Edit and make sure it toggles the bulk mode.
- Select a bunch of comments and apply any actions.
- Make sure all the selected comments' statuses are changed accordingly.
- Make sure there is an analytics tracking for the bulk action, and one for each affected comment.
- Select a bunch of comments, move them to spam or trash, and bulk delete them.
- Make sure all the selected comments are permanently deleted.
- Make sure there is an analytics tracking for the bulk delete, and one for each affected comment.