### PR TITLE
Fix the issues I found while adding tracks events for incoming transfers

### DIFF
--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -44,6 +44,7 @@ class DomainSuggestion extends React.Component {
 			<div
 				className={ classes }
 				onClick={ this.props.onButtonClick }
+				data-tracks-button-click-source={ this.props.tracksButtonClickSource }
 				role="button"
 				data-e2e-domain={ this.props.domain }
 			>
@@ -51,12 +52,7 @@ class DomainSuggestion extends React.Component {
 					{ children }
 					{ ! hidePrice && <DomainProductPrice rule={ priceRule } price={ price } /> }
 				</div>
-				<Button
-					borderless
-					onClick={ this.props.onButtonClick }
-					data-tracks-button-click-source={ this.props.tracksButtonClickSource }
-					className="domain-suggestion__action"
-				>
+				<Button borderless className="domain-suggestion__action">
 					{ this.props.buttonContent }
 				</Button>
 				<Gridicon className="domain-suggestion__chevron" icon="chevron-right" />

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -756,7 +756,7 @@ class RegisterDomainStep extends React.Component {
 	goToTransferDomainStep = event => {
 		event.preventDefault();
 
-		const source = event.target.dataset.tracksButtonClickSource;
+		const source = event.currentTarget.dataset.tracksButtonClickSource;
 
 		this.props.recordTransferDomainButtonClick( this.props.analyticsSection, source );
 

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -149,7 +149,7 @@ class TransferDomainStep extends React.Component {
 							placeholder={ translate( 'example.com' ) }
 							onBlur={ this.save }
 							onChange={ this.setSearchQuery }
-							onClick={ this.recordInputFocus }
+							onFocus={ this.recordInputFocus }
 							autoFocus
 						/>
 					</div>


### PR DESCRIPTION
There were 2 issues I found while working on https://github.com/Automattic/wp-calypso/pull/20635

1. The `recordInputFocus` was not fired when you click on the input - I've fixed that by using the correct event `onFocus`
2. When clicking on the "Yes, I own this domain" two events were recorded instead of one. The issue here was that `onButtonClick` was set once for the entire `div` and once for the `Button` component so because of event propagation it was triggered twice. I've fixed that by leaving only the `div` onClick event and fixing the `goToTransferDomainStep` to use the `currentTarget` element instead of `target` so that we're recording the proper `source` value.

In order to test:

1. Click(focus) on the input in "Use my own domain" step and check that there the correct event is recorded in Redux inspector
2. Click on the "I already own a domain" card or the "Use a domain I own" link or on the "Yes, I own this domain" and check if the Analytics event will be recorded only once in Redux inspector