### PR TITLE
Posts: launch condensed post list view

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { isEnabled } from 'config';
 import { getEditorPath } from 'state/ui/editor/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -118,11 +117,8 @@ class PostItem extends React.Component {
 			'is-placeholder': isPlaceholder,
 		} );
 
-		const arePostsCondensed =
-			isEnabled( 'posts/post-type-list' ) && abtest( 'condensedPostList' ) === 'condensedPosts';
-
+		const arePostsCondensed = isEnabled( 'posts/post-type-list' );
 		const isSiteInfoVisible = arePostsCondensed && isAllSitesModeSelected;
-
 		const isAuthorVisible = arePostsCondensed && this.hasMultipleUsers() && post && post.author;
 
 		const expandedContent = this.renderExpandedContent();

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -91,14 +91,6 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	condensedPostList: {
-		datestamp: '20171113',
-		variations: {
-			condensedPosts: 5,
-			largePosts: 95,
-		},
-		defaultVariation: 'largePosts',
-	},
 	showNewPaymentMethods: {
 		datestamp: '20171115',
 		variations: {

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -19,7 +19,6 @@ import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { isEnabled } from 'config';
 import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { bumpStatGenerator } from './utils';
-import { abtest } from 'lib/abtest';
 
 function PostActionsEllipsisMenuDuplicate( {
 	translate,
@@ -31,13 +30,7 @@ function PostActionsEllipsisMenuDuplicate( {
 } ) {
 	const validStatus = includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], status );
 
-	if (
-		! isEnabled( 'posts/post-type-list' ) ||
-		'condensedPosts' !== abtest( 'condensedPostList' ) ||
-		! canEdit ||
-		! validStatus ||
-		'post' !== type
-	) {
+	if ( ! isEnabled( 'posts/post-type-list' ) || ! canEdit || ! validStatus || 'post' !== type ) {
 		return null;
 	}
 

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
@@ -17,7 +17,6 @@ import { bumpStatGenerator } from './utils';
 import { getPost } from 'state/posts/selectors';
 import { toggleSharePanel } from 'state/ui/post-type-list/actions';
 import { isPublicizeEnabled } from 'state/selectors';
-import { abtest } from 'lib/abtest';
 import config from 'config';
 
 class PostActionsEllipsisMenuShare extends Component {
@@ -47,7 +46,6 @@ class PostActionsEllipsisMenuShare extends Component {
 		const { translate, status, type, isPublicizeEnabled: isPublicizeEnabledForSite } = this.props;
 		if (
 			! config.isEnabled( 'posts/post-type-list' ) ||
-			'condensedPosts' !== abtest( 'condensedPostList' ) ||
 			'publish' !== status ||
 			! isPublicizeEnabledForSite ||
 			'post' !== type

--- a/client/my-sites/posts/post-list-wrapper.jsx
+++ b/client/my-sites/posts/post-list-wrapper.jsx
@@ -12,7 +12,6 @@ import React from 'react';
 import PostList from './post-list';
 import PostTypeList from 'my-sites/post-type-list';
 import config from 'config';
-import { abtest } from 'lib/abtest';
 import { mapPostStatus } from 'lib/route/path';
 
 class PostListWrapper extends React.Component {
@@ -48,8 +47,7 @@ class PostListWrapper extends React.Component {
 	render() {
 		return (
 			<div>
-				{ config.isEnabled( 'posts/post-type-list' ) &&
-				abtest( 'condensedPostList' ) === 'condensedPosts'
+				{ config.isEnabled( 'posts/post-type-list' )
 					? this.renderPostTypeList()
 					: this.renderPostList() }
 			</div>


### PR DESCRIPTION
**This PR enables a feature. After review DO NOT MERGE until the release is coordinated.**

This PR removes the `condensedPostList` AB test, enabling the condensed `/posts/` view for all users. The old `/posts/` view remains in place for Desktop App users, until further testing can be done for the app.

Context: p8F9tW-vh-p2

**Before:** | **After:**
----------- | ----------
<img width="730" alt="condensed-before" src="https://user-images.githubusercontent.com/942359/33886273-049b75cc-df14-11e7-9403-1a619639495f.png"> | <img width="730" alt="condensed-after" src="https://user-images.githubusercontent.com/942359/33886281-0dabd120-df14-11e7-9ea8-82c17e252704.png">

**To Test:**
- Use calypso.live link.
- Navigate to /posts/ screen.
- Verify that condensed post list is shown.
- Verify that condensed post list functions as expected:
 - Clicking title takes user to post
 - Ellipsis menu actions work as expected
 - Posts with likes, views, and comments show glanceable inline stats
 - A free site with more than 10 posts shows an upgrade nudge after the 10th post
 - etc…