### PR TITLE
Post Type List: Fix vertical alignment of post-meta

### DIFF
--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -100,7 +100,6 @@ a.post-item__title-link:visited {
 
 .post-item__meta {
 	font-size: 12px;
-	line-height: 14px;
 	color: $gray-text-min;
 }
 
@@ -108,7 +107,6 @@ a.post-item__title-link:visited {
 .post-item__meta .post-status,
 .post-item__meta .post-status__text {
 	margin-bottom: 0;
-	vertical-align: top;
 }
 
 .post-item__meta .post-status {
@@ -118,7 +116,6 @@ a.post-item__title-link:visited {
 .post-item__meta .post-status__icon {
 	width: 14px;
 	height: 14px;
-	margin-top: -3px;
 	margin-right: 2px;
 }
 

--- a/client/blocks/post-status/style.scss
+++ b/client/blocks/post-status/style.scss
@@ -4,17 +4,9 @@
 	display: inline-block;
 }
 
-.post-status__icon,
-.post-status__text {
-	vertical-align: middle;
-}
-
 .post-status__icon {
 	margin-right: 8px;
-}
-
-.post-status__text {
-	line-height: 1;
+	vertical-align: text-top;
 }
 
 .post-status.is-pending {

--- a/client/my-sites/post-type-list/post-action-counts/style.scss
+++ b/client/my-sites/post-type-list/post-action-counts/style.scss
@@ -2,8 +2,6 @@
 	display: inline-block;
 	list-style: none;
 	margin: 0;
-	vertical-align: top;
-	line-height: 1;
 }
 
 .post-action-counts li {


### PR DESCRIPTION
Cleans-up the vertical alignment of components in `post-item__meta` to give more vertical space between the title and meta.

**Before:** | **After:**
----------- | ----------
<img width="729" alt="before" src="https://user-images.githubusercontent.com/942359/33890096-369ff2ee-df20-11e7-9f01-caf1e173b3e9.png"> | <img width="730" alt="after" src="https://user-images.githubusercontent.com/942359/33890101-3c196908-df20-11e7-9e52-4cb38117c51d.png">

**To test:**
- Use calypso.live link.
- Set the `condensedPost` variant of the `condensedPostList` AB test.
- Check the vertical spacing between the title and post meta.
- Verify the alignment for PostStatus icon (e.g. sticky posts).
- Verify the alignment for glanceable post stats (when stats are available).
- Smile at the Zen of Whitespace.
