### PR TITLE
Stop dispatching DISCONNECT_SITE action to SitesList Flux store

### DIFF
--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -21,12 +21,10 @@ import {
 	recordTracksEvent as recordTracksEventAction,
 } from 'state/analytics/actions';
 import { disconnect } from 'state/jetpack/connection/actions';
-import { disconnectedSite as disconnectedSiteDeprecated } from 'lib/sites-list/actions';
 import { setAllSitesSelected } from 'state/ui/actions';
 import { successNotice, errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
-import { getSitePlanSlug } from 'state/sites/selectors';
 import { getPlanClass } from 'lib/plans/constants';
-import { getSite, getSiteSlug, getSiteTitle } from 'state/sites/selectors';
+import { getSiteSlug, getSiteTitle, getSitePlanSlug } from 'state/sites/selectors';
 
 class DisconnectJetpack extends PureComponent {
 	static propTypes = {
@@ -39,7 +37,6 @@ class DisconnectJetpack extends PureComponent {
 		stayConnectedHref: PropTypes.string,
 		// Connected props
 		plan: PropTypes.string,
-		site: PropTypes.object,
 		siteSlug: PropTypes.string,
 		siteTitle: PropTypes.string,
 		setAllSitesSelected: PropTypes.func,
@@ -157,7 +154,6 @@ class DisconnectJetpack extends PureComponent {
 	disconnectJetpack = () => {
 		const {
 			onDisconnectClick,
-			site,
 			siteId,
 			siteTitle,
 			translate,
@@ -185,11 +181,6 @@ class DisconnectJetpack extends PureComponent {
 
 		disconnectSite( siteId ).then(
 			() => {
-				// Removing the domain from a domain-only site results
-				// in the site being deleted entirely. We need to call
-				// `disconnectedSiteDeprecated` here because the site
-				// exists in `sites-list` as well as the global store.
-				disconnectedSiteDeprecated( site );
 				this.props.setAllSitesSelected();
 				removeInfoNotice( notice.noticeId );
 				showSuccessNotice(
@@ -280,7 +271,6 @@ export default connect(
 
 		return {
 			plan: planClass,
-			site: getSite( state, siteId ),
 			siteSlug: getSiteSlug( state, siteId ),
 			siteTitle: getSiteTitle( state, siteId ),
 		};

--- a/client/lib/sites-list/actions.js
+++ b/client/lib/sites-list/actions.js
@@ -20,14 +20,6 @@ const SitesListActions = {
 			logs,
 		} );
 	},
-	// A way to remove a Disconnected Site from the old list store
-	disconnectedSite( site ) {
-		Dispatcher.handleViewAction( {
-			type: 'DISCONNECT_SITE',
-			site,
-		} );
-	},
-
 	deleteSite( site, onComplete ) {
 		Dispatcher.handleViewAction( {
 			type: 'DELETE_SITE',

--- a/client/lib/sites-list/index.js
+++ b/client/lib/sites-list/index.js
@@ -18,7 +18,6 @@ export default function() {
 		_sites.dispatchToken = Dispatcher.register( function( payload ) {
 			const action = payload.action;
 			switch ( action.type ) {
-				case 'DISCONNECT_SITE':
 				case 'RECEIVE_DELETED_SITE':
 					_sites.removeSite( action.site );
 					break;


### PR DESCRIPTION
The `sites-list` flux store no longer needs to be updated. The disconnected site is removed from the Redux state by the `JETPACK_DISCONNECT_RECEIVE` action.

**How to test:**
1. Disconnect a Jetpack site while having your Redux devtools open
2. Check that a `JETPACK_DISCONNECT_RECEIVE` action was dispatched and that it removed the disconnected site from `state.sites.items`.
3. Check that two notices were displayed while disconnecting: an info notice that the disconnect is in progress, and a success notice that it has finished. 