### PR TITLE
Comments: Remove usage of comments tree from CommentList [WIP]

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -21,11 +21,9 @@ import CommentNavigation from 'my-sites/comments/comment-navigation';
 import EmptyContent from 'components/empty-content';
 import Pagination from 'components/pagination';
 import QuerySiteCommentsList from 'components/data/query-site-comments-list';
-import QuerySiteCommentsTree from 'components/data/query-site-comments-tree';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { getSiteCommentsTree, isCommentsTreeInitialized } from 'state/selectors';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
-import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { COMMENTS_PER_PAGE, NEWEST_FIRST } from '../constants';
 
 export class CommentList extends Component {
@@ -102,8 +100,6 @@ export class CommentList extends Component {
 
 	getTotalPages = () => Math.ceil( this.props.comments.length / COMMENTS_PER_PAGE );
 
-	hasCommentJustMovedBackToCurrentStatus = commentId => this.state.lastUndo === commentId;
-
 	isCommentSelected = commentId => !! find( this.state.selectedComments, { commentId } );
 
 	isRequestedPageValid = () => this.getTotalPages() >= this.props.page;
@@ -144,16 +140,7 @@ export class CommentList extends Component {
 	updateLastUndo = commentId => this.setState( { lastUndo: commentId } );
 
 	render() {
-		const {
-			isCommentsTreeSupported,
-			isLoading,
-			isPostView,
-			page,
-			postId,
-			siteId,
-			siteFragment,
-			status,
-		} = this.props;
+		const { isLoading, isPostView, page, postId, siteId, siteFragment, status } = this.props;
 		const { isBulkMode, selectedComments } = this.state;
 
 		const validPage = this.isRequestedPageValid() ? page : 1;
@@ -170,16 +157,12 @@ export class CommentList extends Component {
 		return (
 			<div className="comment-list">
 				<QuerySiteSettings siteId={ siteId } />
-
-				{ ! isCommentsTreeSupported && (
-					<QuerySiteCommentsList
-						number={ 100 }
-						offset={ ( validPage - 1 ) * COMMENTS_PER_PAGE }
-						siteId={ siteId }
-						status={ status }
-					/>
-				) }
-				{ isCommentsTreeSupported && <QuerySiteCommentsTree siteId={ siteId } status={ status } /> }
+				<QuerySiteCommentsList
+					number={ 100 }
+					offset={ ( validPage - 1 ) * COMMENTS_PER_PAGE }
+					siteId={ siteId }
+					status={ status }
+				/>
 
 				{ isPostView && <CommentListHeader postId={ postId } /> }
 
@@ -211,10 +194,6 @@ export class CommentList extends Component {
 							isBulkMode={ isBulkMode }
 							isPostView={ isPostView }
 							isSelected={ this.isCommentSelected( commentId ) }
-							refreshCommentData={
-								isCommentsTreeSupported &&
-								! this.hasCommentJustMovedBackToCurrentStatus( commentId )
-							}
 							toggleSelected={ this.toggleCommentSelected }
 							updateLastUndo={ this.updateLastUndo }
 						/>
@@ -261,8 +240,6 @@ const mapStateToProps = ( state, { postId, siteId, status } ) => {
 	const isLoading = ! isCommentsTreeInitialized( state, siteId, status );
 	return {
 		comments,
-		isCommentsTreeSupported:
-			! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.5' ),
 		isLoading,
 		isPostView,
 		siteId,

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { filter, find, get, isEqual, map, orderBy, slice } from 'lodash';
+import { filter, find, get, isEqual, isNull, map, orderBy, slice } from 'lodash';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 /**
@@ -172,12 +172,14 @@ export class CommentList extends Component {
 			<div className="comment-list">
 				<QuerySiteSettings siteId={ siteId } />
 				<QuerySiteCommentCounts siteId={ siteId } postId={ postId } />
-				<QuerySiteCommentsList
-					number={ COMMENTS_PER_PAGE }
-					offset={ ( validPage - 1 ) * COMMENTS_PER_PAGE }
-					siteId={ siteId }
-					status={ status }
-				/>
+				{ ! isNull( commentsCount ) && (
+					<QuerySiteCommentsList
+						number={ COMMENTS_PER_PAGE }
+						offset={ ( validPage - 1 ) * COMMENTS_PER_PAGE }
+						siteId={ siteId }
+						status={ status }
+					/>
+				) }
 
 				{ isPostView && <CommentListHeader postId={ postId } /> }
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -104,7 +104,7 @@ export class CommentList extends Component {
 		);
 	};
 
-	getTotalPages = () => Math.ceil( this.props.comments.length / COMMENTS_PER_PAGE );
+	getTotalPages = () => Math.ceil( this.props.commentsCount / COMMENTS_PER_PAGE );
 
 	isCommentSelected = commentId => !! find( this.state.selectedComments, { commentId } );
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -173,7 +173,7 @@ export class CommentList extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<QuerySiteCommentCounts siteId={ siteId } postId={ postId } />
 				<QuerySiteCommentsList
-					number={ 100 }
+					number={ COMMENTS_PER_PAGE }
 					offset={ ( validPage - 1 ) * COMMENTS_PER_PAGE }
 					siteId={ siteId }
 					status={ status }

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -20,7 +20,6 @@ import CommentEdit from 'my-sites/comments/comment/comment-edit';
 import CommentHeader from 'my-sites/comments/comment/comment-header';
 import CommentReply from 'my-sites/comments/comment/comment-reply';
 import CommentRepliesList from 'my-sites/comments/comment-replies-list';
-import QueryComment from 'components/data/query-comment';
 import { getMinimumComment } from 'my-sites/comments/comment/utils';
 import { getSiteComment } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -106,7 +105,6 @@ export class Comment extends Component {
 			isPostView,
 			isSelected,
 			redirect,
-			refreshCommentData,
 			updateLastUndo,
 		} = this.props;
 		const { isEditMode, isReplyVisible } = this.state;
@@ -126,11 +124,7 @@ export class Comment extends Component {
 				onKeyDown={ this.keyDownHandler }
 				ref={ this.storeCardRef }
 			>
-				{ refreshCommentData && (
-					<QueryComment commentId={ commentId } siteId={ siteId } forceWpcom />
-				) }
-
-				{ ( ! isEditMode || isLoading ) && (
+				{ ! isEditMode && (
 					<div className="comment__detail">
 						<CommentHeader { ...{ commentId, isBulkMode, isEditMode, isPostView, isSelected } } />
 


### PR DESCRIPTION
Fix #20672 and #20674 
Contribute to #20727

By removing the usage of comments tree, we can drop a bunch of hacks we needed before, such as the whole `hasCommentJustMovedBackToCurrentStatus` and `lastUndo` logic.

This PR works as-is, even before introducing the comment count in data-layer / query component.
Though, it doesn't have accurate comments count yet, and all sites would rely on the fuzzy pagination as it currently happens for JP<5.5 sites only.