### PR TITLE
Add registrar and registrar's IANA ID to tracks event

### DIFF
--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -48,8 +48,9 @@ class TransferDomainPrecheck extends React.PureComponent {
 
 	onClick = () => {
 		const { domain, supportsPrivacy } = this.props;
+		const { registrar, registrarIanaId } = this.state;
 
-		this.props.recordContinueButtonClick( domain );
+		this.props.recordContinueButtonClick( domain, registrar, registrarIanaId );
 
 		this.props.setValid( domain, supportsPrivacy );
 	};
@@ -76,6 +77,8 @@ class TransferDomainPrecheck extends React.PureComponent {
 				privacy: result.privacy,
 				unlocked: result.unlocked,
 				loading: false,
+				registrar: result.registrar,
+				registrarIanaId: result.registrar_iana_id,
 			} );
 		} );
 	};
@@ -354,8 +357,12 @@ class TransferDomainPrecheck extends React.PureComponent {
 const recordNextStep = ( domain_name, show_step ) =>
 	recordTracksEvent( 'calypso_transfer_domain_precheck_step_change', { domain_name, show_step } );
 
-const recordContinueButtonClick = domain_name =>
-	recordTracksEvent( 'calypso_transfer_domain_precheck_continue_click', { domain_name } );
+const recordContinueButtonClick = ( domain_name, registrar, registrarIanaId ) =>
+	recordTracksEvent( 'calypso_transfer_domain_precheck_continue_click', {
+		domain_name,
+		registrar,
+		registrarIanaId,
+	} );
 
 export default connect( null, {
 	recordNextStep,

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -48,9 +48,9 @@ class TransferDomainPrecheck extends React.PureComponent {
 
 	onClick = () => {
 		const { domain, supportsPrivacy } = this.props;
-		const { registrar, registrarIanaId } = this.state;
+		const { losingRegistrar, losingRegistrarIanaId } = this.state;
 
-		this.props.recordContinueButtonClick( domain, registrar, registrarIanaId );
+		this.props.recordContinueButtonClick( domain, losingRegistrar, losingRegistrarIanaId );
 
 		this.props.setValid( domain, supportsPrivacy );
 	};

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -33,6 +33,8 @@ class TransferDomainPrecheck extends React.PureComponent {
 		privacy: false,
 		email: '',
 		loading: true,
+		losingRegistrar: '',
+		losingRegistrarIanaId: '',
 		currentStep: 1,
 	};
 

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -77,8 +77,8 @@ class TransferDomainPrecheck extends React.PureComponent {
 				privacy: result.privacy,
 				unlocked: result.unlocked,
 				loading: false,
-				registrar: result.registrar,
-				registrarIanaId: result.registrar_iana_id,
+				losingRegistrar: result.registrar,
+				losingRegistrarIanaId: result.registrar_iana_id,
 			} );
 		} );
 	};
@@ -357,11 +357,11 @@ class TransferDomainPrecheck extends React.PureComponent {
 const recordNextStep = ( domain_name, show_step ) =>
 	recordTracksEvent( 'calypso_transfer_domain_precheck_step_change', { domain_name, show_step } );
 
-const recordContinueButtonClick = ( domain_name, registrar, registrarIanaId ) =>
+const recordContinueButtonClick = ( domain_name, losing_registrar, losing_registrar_iana_id ) =>
 	recordTracksEvent( 'calypso_transfer_domain_precheck_continue_click', {
 		domain_name,
-		registrar,
-		registrarIanaId,
+		losing_registrar,
+		losing_registrar_iana_id,
 	} );
 
 export default connect( null, {


### PR DESCRIPTION
This PR adds the registrar and registrar's IANA ID to the tracks event that is recorded for an inbound transfer domain when the "Continue" button is clicked on the pre-check page.

Dependent on D8762-code

To test this, start a new transfer, click "Continue" on the precheck screen.
Make sure that the tracks event shows the registrar and it's IANA ID in the event properties.