### PR TITLE
Jetpack Onboarding: add Summary site content

### DIFF
--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -9,6 +9,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
+import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
@@ -19,7 +21,17 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 			'You enabled Jetpack and unlocked dozens of website-bolstering features. Continue preparing your site below.'
 		);
 
-		return <FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />;
+		const siteRedirectHref = '/jetpack/onboarding/site-title';
+
+		return (
+			<div className="steps__summary">
+				<DocumentHead title={ translate( 'Summary ‹ Jetpack Onboarding' ) } />
+				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+				<Button href={ siteRedirectHref } primary>
+					{ translate( 'Visit your site' ) }
+				</Button>
+			</div>
+		);
 	}
 }
 

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -19,7 +19,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	renderCompleted = () => {
 		const { translate } = this.props;
 		const stepsCompleted = [
-			translate( 'Site title & Description' ),
+			translate( 'Site Title & Description' ),
 			translate( 'Type of Site' ),
 			translate( 'Type of Homepage' ),
 			translate( 'Contact Us Form' ),

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -3,8 +3,10 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
+import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +16,43 @@ import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
+	renderCompleted = () => {
+		const { translate } = this.props;
+		const stepsCompleted = [
+			translate( 'Site title & description' ),
+			translate( 'Type of Site' ),
+			translate( 'Type of Homepage' ),
+			translate( 'Contact Us Form' ),
+			translate( 'Jetpack Connection' ),
+		];
+
+		return map( stepsCompleted, ( fieldLabel, fieldName ) => (
+			<div id={ fieldName } className="steps__summary-column entry completed">
+				<Gridicon icon="chevron-down" size={ 12 } />
+				{ fieldLabel }
+			</div>
+		) );
+	};
+
+	renderTodo = () => {
+		const { translate } = this.props;
+		const stepsTodo = [
+			translate( 'Choose a Theme' ),
+			translate( 'Add a Site Address' ),
+			translate( 'Add a Store' ),
+			translate( 'Start a Blog' ),
+		];
+
+		// TODO: adapt when we have more info + it will differ for different steps
+		const siteRedirectHref = '#';
+
+		return map( stepsTodo, ( fieldLabel, fieldName ) => (
+			<div id={ fieldName } className="steps__summary-column entry todo">
+				<a href={ siteRedirectHref }>{ fieldLabel }</a>
+			</div>
+		) );
+	};
+
 	render() {
 		const { translate } = this.props;
 		const headerText = translate( 'Congratulations! Your site is on its way.' );
@@ -21,16 +60,29 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 			'You enabled Jetpack and unlocked dozens of website-bolstering features. Continue preparing your site below.'
 		);
 
-		const siteRedirectHref = '/jetpack/onboarding/site-title';
+		// TODO: adapt when we have more info
+		const buttonRedirectHref = '#';
 
 		return (
-			<div className="steps__summary">
+			<Fragment>
 				<DocumentHead title={ translate( 'Summary ‹ Jetpack Onboarding' ) } />
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
-				<Button href={ siteRedirectHref } primary>
-					{ translate( 'Visit your site' ) }
-				</Button>
-			</div>
+				<div className="steps__summary-columns">
+					<div className="steps__summary-column">
+						{ translate( "Steps you've completed:" ) }
+						{ this.renderCompleted() }
+					</div>
+					<div className="steps__summary-column">
+						{ translate( 'Continue your site setup:' ) }
+						{ this.renderTodo() }
+					</div>
+				</div>
+				<div className="steps__button-group">
+					<Button href={ buttonRedirectHref } primary>
+						{ translate( 'Visit your site' ) }
+					</Button>
+				</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -19,16 +19,16 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	renderCompleted = () => {
 		const { translate } = this.props;
 		const stepsCompleted = [
-			translate( 'Site title & description' ),
+			translate( 'Site title & Description' ),
 			translate( 'Type of Site' ),
 			translate( 'Type of Homepage' ),
 			translate( 'Contact Us Form' ),
 			translate( 'Jetpack Connection' ),
 		];
 
-		return map( stepsCompleted, ( fieldLabel, fieldName ) => (
-			<div id={ fieldName } className="steps__summary-column entry completed">
-				<Gridicon icon="chevron-down" size={ 12 } />
+		return map( stepsCompleted, ( fieldLabel, fieldIndex ) => (
+			<div key={ fieldIndex } className="steps__summary-entry completed">
+				<Gridicon icon="checkmark" size={ 18 } />
 				{ fieldLabel }
 			</div>
 		) );
@@ -46,8 +46,8 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 		// TODO: adapt when we have more info + it will differ for different steps
 		const siteRedirectHref = '#';
 
-		return map( stepsTodo, ( fieldLabel, fieldName ) => (
-			<div id={ fieldName } className="steps__summary-column entry todo">
+		return map( stepsTodo, ( fieldLabel, fieldIndex ) => (
+			<div key={ fieldIndex } className="steps__summary-entry todo">
 				<a href={ siteRedirectHref }>{ fieldLabel }</a>
 			</div>
 		) );
@@ -67,13 +67,14 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 			<Fragment>
 				<DocumentHead title={ translate( 'Summary ‹ Jetpack Onboarding' ) } />
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+
 				<div className="steps__summary-columns">
 					<div className="steps__summary-column">
-						{ translate( "Steps you've completed:" ) }
+						<h3 className="steps__summary-heading">{ translate( "Steps you've completed:" ) }</h3>
 						{ this.renderCompleted() }
 					</div>
 					<div className="steps__summary-column">
-						{ translate( 'Continue your site setup:' ) }
+						<h3 className="steps__summary-heading">{ translate( 'Continue your site setup:' ) }</h3>
 						{ this.renderTodo() }
 					</div>
 				</div>

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -13,6 +13,17 @@
 		}
 	}
 
+	.steps__summary {
+		.button {
+			position: relative;
+			left: 43%;
+
+			@include breakpoint( '<480px' ) {
+				left: 34%;
+			}
+		}
+	}
+
 	.steps__button-group {
 		text-align: center;
 

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -14,54 +14,46 @@
 	}
 
 	.steps__summary-columns {
-			display: flex;
-			flex-flow: row wrap;
-			align-items: flex-start;
+	display: flex;
+	justify-content: center;
+	font-size: 14px;
+	margin-top: 30px;
 
-			margin-top: 30px;
-
-			@media ( max-width: 700px ) {
-				margin-top: 0;
-			}
+	@include breakpoint( '<480px' ) {
+		display: block;
+		text-align: center;
 		}
+	}
 
 	.steps__summary-column {
-		flex: 1;
-		justify-content: center;
-		flex-direction: column;
-		text-align: center;
-		margin-bottom: 40px;
-		flex-wrap: wrap;
+		margin: 0 60px 20px;
+
+		@include breakpoint( '<480px' ) {
+			display: inline-block;
+			text-align: left;
+		}
+	}
+
+	.steps__summary-heading {
 		font-weight: bold;
-		margin-top: 20px;
+		margin-bottom: 20px;
+	}
+
+	.steps__summary-entry {
 		margin-bottom: 20px;
 
-		@media ( max-width: 700px ) {
-			flex: 1 100%;
-			margin-bottom: 15px;
+		.gridicon {
+			position: relative;
+			top: 3px;
+			margin-right: 12px;
 		}
 
-		.entry {
-			font-weight: normal;
-			text-align: left;
-			padding-left: 90px;
-
-			@include breakpoint( '<480px' ) {
-				padding-left: 110px;
-			}
-			
-			.completed {
-				color: $gray;
-			}
-
-			.todo {
-				color: $blue-medium;
-			}
+		&.completed {
+			color: $gray;
 		}
 
-		.gridicons-chevron-down {
-			top: -3px;
-			margin-right: 5px;
+		&.todo {
+			color: $blue-medium;
 		}
 	}
 

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -13,14 +13,55 @@
 		}
 	}
 
-	.steps__summary {
-		.button {
-			position: relative;
-			left: 43%;
+	.steps__summary-columns {
+			display: flex;
+			flex-flow: row wrap;
+			align-items: flex-start;
+
+			margin-top: 30px;
+
+			@media ( max-width: 700px ) {
+				margin-top: 0;
+			}
+		}
+
+	.steps__summary-column {
+		flex: 1;
+		justify-content: center;
+		flex-direction: column;
+		text-align: center;
+		margin-bottom: 40px;
+		flex-wrap: wrap;
+		font-weight: bold;
+		margin-top: 20px;
+		margin-bottom: 20px;
+
+		@media ( max-width: 700px ) {
+			flex: 1 100%;
+			margin-bottom: 15px;
+		}
+
+		.entry {
+			font-weight: normal;
+			text-align: left;
+			padding-left: 90px;
 
 			@include breakpoint( '<480px' ) {
-				left: 34%;
+				padding-left: 110px;
 			}
+			
+			.completed {
+				color: $gray;
+			}
+
+			.todo {
+				color: $blue-medium;
+			}
+		}
+
+		.gridicons-chevron-down {
+			top: -3px;
+			margin-right: 5px;
 		}
 	}
 


### PR DESCRIPTION
Add skeleton content to the Summary site of the Jetpack Onboarding flow.

![screen shot 2017-12-12 at 23 29 38](https://user-images.githubusercontent.com/13561163/33914028-1a673140-df94-11e7-94eb-73e473cfb8ae.png)

It is a template version and eventually we'll be displaying the elements marked as completed and suggestions dynamically.

**To test:**
- checkout this branch
- go to `http://calypso.localhost:3000/jetpack/onboarding/summary`
- verify you see the layout and looks good for different viewports


