### PR TITLE
Add the "preview PDF" URL logic

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/api/url.js
+++ b/client/extensions/woocommerce/woocommerce-services/api/url.js
@@ -6,4 +6,5 @@ export const getLabelRates = orderId => `connect/label/${ orderId }/rates`;
 export const labelStatus = ( orderId, labelId ) => `connect/label/${ orderId }/${ labelId }`;
 export const labelRefund = ( orderId, labelId ) => `connect/label/${ orderId }/${ labelId }/refund`;
 export const labelsPrint = () => 'connect/label/print';
+export const labelsTestPrint = () => 'connect/label/preview';
 export const addressNormalization = () => 'connect/normalize-address';

--- a/client/extensions/woocommerce/woocommerce-services/lib/pdf-label-utils/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/lib/pdf-label-utils/index.js
@@ -41,7 +41,7 @@ export const getPaperSizes = country =>
 		{}
 	);
 
-export const getPrintURL = ( siteId, paperSize, labels ) => {
+const _getPDFURL = ( paperSize, labels, baseUrl ) => {
 	if ( ! PAPER_SIZES[ paperSize ] ) {
 		throw new Error( `Invalid paper size: ${ paperSize }` );
 	}
@@ -54,5 +54,14 @@ export const getPrintURL = ( siteId, paperSize, labels ) => {
 		).join( ',' ),
 		json: true,
 	};
-	return api.url.labelsPrint() + '?' + querystring.stringify( params );
+
+	return baseUrl + '?' + querystring.stringify( params );
+};
+
+export const getPrintURL = ( paperSize, labels ) => {
+	return _getPDFURL( paperSize, labels, api.url.labelsPrint() );
+};
+
+export const getPreviewURL = ( paperSize, labels ) => {
+	return _getPDFURL( paperSize, labels, api.url.labelTestPrint() );
 };

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -532,7 +532,7 @@ const pollForLabelsPurchase = ( orderId, siteId, dispatch, getState, labels ) =>
 		labelId: label.label_id,
 	} ) );
 	const state = getShippingLabel( getState(), orderId, siteId );
-	const printUrl = getPrintURL( siteId, state.paperSize, labelsToPrint );
+	const printUrl = getPrintURL( state.paperSize, labelsToPrint );
 	let hasError = false;
 
 	api.get( siteId, printUrl )
@@ -755,7 +755,7 @@ export const confirmRefund = ( orderId, siteId ) => ( dispatch, getState ) => {
 export const openReprintDialog = ( orderId, siteId, labelId ) => ( dispatch, getState ) => {
 	dispatch( { type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_REPRINT_DIALOG, labelId, orderId, siteId } );
 	const shippingLabel = getShippingLabel( getState(), orderId, siteId );
-	const printUrl = getPrintURL( siteId, shippingLabel.paperSize, [ { labelId } ] );
+	const printUrl = getPrintURL( shippingLabel.paperSize, [ { labelId } ] );
 
 	api.get( siteId, printUrl )
 		.then( ( fileData ) => {


### PR DESCRIPTION
At the moment, the "fake PDF URL" is only needed by the plugin, to print a "test label" in the self-help section. But it's much cleaner to only have the PDF URL building logic in one repo.

This should have absolutely no effect in any existing functionality, is just a refactor. There will be an accompanying PR in `woocommerce-services` that makes use of this code.