### PR TITLE
Remove the code that cleaned up bash-only Git hooks

### DIFF
--- a/bin/install-if-deps-outdated.js
+++ b/bin/install-if-deps-outdated.js
@@ -32,17 +32,4 @@ if ( needsInstall() ) {
 		process.exit( installResult );
 	}
 	fs.utimesSync( 'node_modules', Date.now(), Date.now() );
-
-	// Cleanup old Githooks (remove in a few months from June 2017)
-	const path = require( 'path' );
-	const rm = file => fs.existsSync( file ) && fs.unlinkSync( file );
-	rm( path.join( '.git', 'hooks', 'pre-push' ) );
-	rm( path.join( '.git', 'hooks', 'pre-commit' ) );
-	rm( path.join( 'bin', 'pre-push' ) );
-	rm( path.join( 'bin', 'pre-commit' ) );
-	process.exit( spawnSync( 'npm', [ 'run', 'install' ], {
-		shell: true,
-		stdio: 'inherit',
-		cwd: path.join( 'node_modules', 'husky' ),
-	} ).status );
 }


### PR DESCRIPTION
Fixes #19991

During the transitional period when the `Makefile` build system was replaced by `npm` scripts, the old, `bash`-based Git hooks were still installed in many dev machines.

A patch was added to the `install-if-deps-updated` script to remove them and install the new, `husky`-based ones. Since that happened in June, I believe that every dev has already run `npm start` at least once since then, so that code is safe to remove.

cc/ @sirreal