### PR TITLE
Track events for submitting magic link requests from the `/log-in/link` form

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -131,7 +131,7 @@ export class LoginForm extends Component {
 				} )
 				.catch( error => {
 					this.props.recordTracksEvent( 'calypso_login_block_login_form_send_magic_link_failure', {
-						error_code: error.code,
+						error_code: error.error,
 						error_message: error.message,
 					} );
 				} );

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -23,6 +23,7 @@ import {
 	getMagicLoginRequestedEmailSuccessfully,
 } from 'state/selectors';
 import { CHECK_YOUR_EMAIL_PAGE } from 'state/login/magic-login/constants';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 import EmailedLoginLinkSuccessfully from './emailed-login-link-successfully';
 import FormButton from 'components/forms/form-button';
@@ -77,7 +78,20 @@ class RequestLoginEmailForm extends React.Component {
 		if ( ! usernameOrEmail.length ) {
 			return;
 		}
-		this.props.fetchMagicLoginRequestEmail( usernameOrEmail );
+
+		this.props.recordTracksEvent( 'calypso_login_email_link_submit' );
+
+		this.props
+			.fetchMagicLoginRequestEmail( usernameOrEmail )
+			.then( () => {
+				this.props.recordTracksEvent( 'calypso_login_email_link_success' );
+			} )
+			.catch( error => {
+				this.props.recordTracksEvent( 'calypso_login_email_link_failure', {
+					error_code: error.code,
+					error_message: error.message,
+				} );
+			} );
 	};
 
 	getUsernameOrEmailFromState() {
@@ -178,6 +192,7 @@ const mapState = state => {
 const mapDispatch = {
 	fetchMagicLoginRequestEmail,
 	hideMagicLoginRequestNotice,
+	recordTracksEvent,
 };
 
 export default connect( mapState, mapDispatch )( localize( RequestLoginEmailForm ) );

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -88,7 +88,7 @@ class RequestLoginEmailForm extends React.Component {
 			} )
 			.catch( error => {
 				this.props.recordTracksEvent( 'calypso_login_email_link_failure', {
-					error_code: error.code,
+					error_code: error.error,
 					error_message: error.message,
 				} );
 			} );

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -78,6 +78,8 @@ export const fetchMagicLoginRequestEmail = email => dispatch => {
 				type: MAGIC_LOGIN_REQUEST_LOGIN_EMAIL_ERROR,
 				error: error.message,
 			} );
+
+			return Promise.reject( error );
 		} );
 };
 


### PR DESCRIPTION
This PR adds 3 events for `/log-in/link` similar to the existings `calypso_login_block_login_form_send_magic_link`, `calypso_login_block_login_form_send_magic_link_success`, `calypso_login_block_login_form_send_magic_link_failure` events emitted on the `/log-in` form for passwordless accounts.

This is the 3 new events:
- `calypso_login_email_link_submit`
- `calypso_login_email_link_success`
- `calypso_login_email_link_failure`

It also fixes `calypso_login_block_login_form_send_magic_link_failure` which was never emitted because the `fetchMagicLoginRequestEmail` was never rejected.
 
### Testing Instructions
- Checkout and boot the branch
- Go to http://calypso.localhost:3000/log-in/link
- Open devtools and paste the following into the console: `localStorage.debug = 'calypso:analytics:tracks'`
- Enter a valid email for a WordPress.com account you have (doesn't need to be a passwordless account).
- Check on devtools that the events `calypso_login_email_link_submit`, `calypso_login_email_link_success` are emitted and each have the props `error_code` and `error_message` defined.
```
calypso:analytics:tracks Record event "calypso_login_email_link_submit" called with props Object
calypso:analytics:tracks Recording event "calypso_login_email_link_submit" with actual props Object
calypso:analytics:tracks Record event "calypso_login_email_link_success" called with props Object
calypso:analytics:tracks Recording event "calypso_login_email_link_success" with actual props Object
```
- Enter an unknown email and check that `calypso_login_email_link_submit` and `calypso_login_email_link_failure` are emitted each have the props `error_code` and `error_message` defined.
```
calypso:analytics:tracks Record event "calypso_login_email_link_submit" called with props Object
calypso:analytics:tracks Recording event "calypso_login_email_link_submit" with actual props Object
calypso:analytics:tracks Record event "calypso_login_email_link_failure" called with props Object
calypso:analytics:tracks Recording event "calypso_login_email_link_failure" with actual props Object
```

### Reviews
- [ ] Code
- [ ] Product