### PR TITLE
Comments Clean Up: Remove all unnecessary methods from CommentList

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -409,25 +409,23 @@ export class CommentList extends Component {
 					transitionLeaveTimeout={ 150 }
 					transitionName="comment-list__transition"
 				>
-					{ isEnabled( 'comments/management/m3-design' ) &&
-						map( commentsPage, commentId => (
-							<Comment
-								commentId={ commentId }
-								key={ `comment-${ siteId }-${ commentId }` }
-								isBulkMode={ isBulkMode }
-								isPostView={ isPostView }
-								isSelected={ this.isCommentSelected( commentId ) }
-								refreshCommentData={
-									isCommentsTreeSupported &&
-									! this.hasCommentJustMovedBackToCurrentStatus( commentId )
-								}
-								toggleSelected={ this.toggleCommentSelected }
-								updateLastUndo={ this.updateLastUndo }
-							/>
-						) ) }
+					{ map( commentsPage, commentId => (
+						<Comment
+							commentId={ commentId }
+							key={ `comment-${ siteId }-${ commentId }` }
+							isBulkMode={ isBulkMode }
+							isPostView={ isPostView }
+							isSelected={ this.isCommentSelected( commentId ) }
+							refreshCommentData={
+								isCommentsTreeSupported &&
+								! this.hasCommentJustMovedBackToCurrentStatus( commentId )
+							}
+							toggleSelected={ this.toggleCommentSelected }
+							updateLastUndo={ this.updateLastUndo }
+						/>
+					) ) }
 
-					{ isEnabled( 'comments/management/m3-design' ) &&
-						showPlaceholder && <Comment commentId={ 0 } key="comment-detail-placeholder" /> }
+					{ showPlaceholder && <Comment commentId={ 0 } key="comment-detail-placeholder" /> }
 
 					{ showEmptyContent && (
 						<EmptyContent

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -15,15 +15,6 @@ import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
  * Internal dependencies
  */
 import { isEnabled } from 'config';
-import {
-	changeCommentStatus,
-	deleteComment,
-	editComment,
-	likeComment,
-	replyComment,
-	unlikeComment,
-} from 'state/comments/actions';
-import { removeNotice, successNotice } from 'state/notices/actions';
 import Comment from 'my-sites/comments/comment';
 import CommentListHeader from 'my-sites/comments/comment-list/comment-list-header';
 import CommentNavigation from 'my-sites/comments/comment-navigation';
@@ -33,28 +24,19 @@ import QuerySiteCommentsList from 'components/data/query-site-comments-list';
 import QuerySiteCommentsTree from 'components/data/query-site-comments-tree';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { getSiteCommentsTree, isCommentsTreeInitialized } from 'state/selectors';
-import {
-	bumpStat,
-	composeAnalytics,
-	recordTracksEvent,
-	withAnalytics,
-} from 'state/analytics/actions';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { COMMENTS_PER_PAGE, NEWEST_FIRST } from '../constants';
 
 export class CommentList extends Component {
 	static propTypes = {
-		changeCommentStatus: PropTypes.func,
 		changePage: PropTypes.func,
 		comments: PropTypes.array,
-		deleteComment: PropTypes.func,
-		likeComment: PropTypes.func,
 		recordChangePage: PropTypes.func,
 		replyComment: PropTypes.func,
 		siteId: PropTypes.number,
 		status: PropTypes.string,
 		translate: PropTypes.func,
-		unlikeComment: PropTypes.func,
 	};
 
 	state = {
@@ -91,19 +73,6 @@ export class CommentList extends Component {
 		this.setState( { selectedComments: [] } );
 
 		changePage( page );
-	};
-
-	deleteCommentPermanently = ( commentId, postId ) => {
-		this.props.removeNotice( `comment-notice-${ commentId }` );
-
-		this.props.deleteComment( commentId, postId );
-	};
-
-	editComment = ( commentId, postId, commentData, undoCommentData, showNotice = true ) => {
-		this.props.editComment( commentId, postId, commentData );
-		if ( showNotice ) {
-			this.showEditNotice( commentId, postId, undoCommentData );
-		}
 	};
 
 	getComments = () => orderBy( this.props.comments, null, this.state.sortOrder );
@@ -146,60 +115,6 @@ export class CommentList extends Component {
 		return selectedComments.length && selectedComments.length === visibleComments.length;
 	};
 
-	replyComment = ( commentText, parentComment ) => {
-		const { translate } = this.props;
-		const { commentId: parentCommentId, postId, status } = parentComment;
-		const alsoApprove = 'approved' !== status;
-
-		this.props.removeNotice( `comment-notice-${ parentCommentId }` );
-
-		const noticeMessage = alsoApprove
-			? translate( 'Comment approved and reply submitted.' )
-			: translate( 'Reply submitted.' );
-
-		const noticeOptions = {
-			duration: 5000,
-			id: `comment-notice-${ parentCommentId }`,
-			isPersistent: true,
-		};
-
-		if ( alsoApprove ) {
-			this.setCommentStatus( parentComment, 'approved', { showNotice: false } );
-		}
-
-		this.props.successNotice( noticeMessage, noticeOptions );
-		this.props.replyComment( commentText, postId, parentCommentId, { alsoApprove } );
-	};
-
-	setCommentStatus = ( comment, status, options = { isUndo: false, showNotice: true } ) => {
-		const { commentId, postId, isLiked, status: previousStatus } = comment;
-		const { isUndo, showNotice } = options;
-		const alsoUnlikeComment = isLiked && 'approved' !== status;
-
-		if ( isUndo ) {
-			this.setState( { lastUndo: commentId } );
-		} else {
-			this.setState( { lastUndo: null } );
-		}
-
-		this.props.removeNotice( `comment-notice-${ commentId }` );
-
-		if ( showNotice ) {
-			this.showNotice( comment, status );
-		}
-
-		this.props.changeCommentStatus( commentId, postId, status, {
-			alsoUnlike: alsoUnlikeComment,
-			isUndo,
-			previousStatus,
-		} );
-
-		// If the comment is not approved anymore, also remove the like
-		if ( alsoUnlikeComment ) {
-			this.props.unlikeComment( commentId, postId );
-		}
-	};
-
 	setSortOrder = order => () => {
 		this.setState( {
 			sortOrder: order,
@@ -207,88 +122,8 @@ export class CommentList extends Component {
 		} );
 	};
 
-	showEditNotice = ( commentId, postId, undoCommentData ) => {
-		const { translate } = this.props;
-
-		const message = translate( 'Your comment has been updated.' );
-
-		const noticeOptions = {
-			button: translate( 'Undo' ),
-			duration: 5000,
-			id: `comment-notice-${ commentId }`,
-			isPersistent: true,
-			onClick: () => {
-				this.editComment( commentId, postId, undoCommentData, false );
-				this.props.removeNotice( `comment-notice-${ commentId }` );
-			},
-		};
-
-		this.props.successNotice( message, noticeOptions );
-	};
-
-	showNotice = ( comment, newStatus ) => {
-		const { translate } = this.props;
-		const { commentId, isLiked: previousIsLiked, postId, status: previousStatus } = comment;
-
-		const message = get(
-			{
-				approved: translate( 'Comment approved.' ),
-				unapproved: translate( 'Comment unapproved.' ),
-				spam: translate( 'Comment marked as spam.' ),
-				trash: translate( 'Comment moved to trash.' ),
-			},
-			newStatus
-		);
-
-		if ( ! message ) {
-			return;
-		}
-
-		const noticeOptions = {
-			button: translate( 'Undo' ),
-			duration: 5000,
-			id: `comment-notice-${ commentId }`,
-			isPersistent: true,
-			onClick: () => {
-				const updatedComment = {
-					...comment,
-					status: newStatus,
-				};
-				this.setCommentStatus( updatedComment, previousStatus, {
-					isUndo: true,
-					showNotice: false,
-				} );
-				if ( previousIsLiked ) {
-					this.props.likeComment( commentId, postId );
-				} else if ( ! previousIsLiked && 'approved' !== previousStatus ) {
-					this.props.unlikeComment( commentId, postId );
-				}
-			},
-		};
-
-		this.props.successNotice( message, noticeOptions );
-	};
-
 	toggleBulkMode = () => {
 		this.setState( ( { isBulkMode } ) => ( { isBulkMode: ! isBulkMode, selectedComments: [] } ) );
-	};
-
-	toggleCommentLike = comment => {
-		const { commentId, isLiked, postId, status } = comment;
-
-		if ( isLiked ) {
-			this.props.unlikeComment( commentId, postId );
-			return;
-		}
-
-		const alsoApprove = 'unapproved' === status;
-
-		this.props.likeComment( commentId, postId, { alsoApprove } );
-
-		if ( alsoApprove ) {
-			this.props.removeNotice( `comment-notice-${ commentId }` );
-			this.setCommentStatus( comment, 'approved', { showNotice: true } );
-		}
 	};
 
 	toggleCommentSelected = comment => {
@@ -434,96 +269,12 @@ const mapStateToProps = ( state, { postId, siteId, status } ) => {
 	};
 };
 
-const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
-	changeCommentStatus: (
-		commentId,
-		postId,
-		status,
-		analytics = { alsoUnlike: false, isUndo: false }
-	) =>
-		dispatch(
-			withAnalytics(
-				composeAnalytics(
-					recordTracksEvent( 'calypso_comment_management_change_status', {
-						also_unlike: analytics.alsoUnlike,
-						is_undo: analytics.isUndo,
-						previous_status: analytics.previousStatus,
-						status,
-					} ),
-					bumpStat( 'calypso_comment_management', 'comment_status_changed_to_' + status )
-				),
-				changeCommentStatus( siteId, postId, commentId, status )
-			)
-		),
-
-	successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
-
-	deleteComment: ( commentId, postId, options = { showSuccessNotice: true } ) =>
-		dispatch(
-			withAnalytics(
-				composeAnalytics(
-					recordTracksEvent( 'calypso_comment_management_delete' ),
-					bumpStat( 'calypso_comment_management', 'comment_deleted' )
-				),
-				deleteComment( siteId, postId, commentId, options )
-			)
-		),
-
-	editComment: ( commentId, postId, comment ) =>
-		dispatch(
-			withAnalytics(
-				composeAnalytics(
-					recordTracksEvent( 'calypso_comment_management_edit' ),
-					bumpStat( 'calypso_comment_management', 'comment_updated' )
-				),
-				editComment( siteId, postId, commentId, comment )
-			)
-		),
-
-	likeComment: ( commentId, postId, analytics = { alsoApprove: false } ) =>
-		dispatch(
-			withAnalytics(
-				composeAnalytics(
-					recordTracksEvent( 'calypso_comment_management_like', {
-						also_approve: analytics.alsoApprove,
-					} ),
-					bumpStat( 'calypso_comment_management', 'comment_liked' )
-				),
-				likeComment( siteId, postId, commentId )
-			)
-		),
-
+const mapDispatchToProps = dispatch => ( {
 	recordChangePage: ( page, total ) =>
 		dispatch(
 			composeAnalytics(
 				recordTracksEvent( 'calypso_comment_management_change_page', { page, total } ),
 				bumpStat( 'calypso_comment_management', 'change_page' )
-			)
-		),
-
-	removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),
-
-	replyComment: ( commentText, postId, parentCommentId, analytics = { alsoApprove: false } ) =>
-		dispatch(
-			withAnalytics(
-				composeAnalytics(
-					recordTracksEvent( 'calypso_comment_management_reply', {
-						also_approve: analytics.alsoApprove,
-					} ),
-					bumpStat( 'calypso_comment_management', 'comment_reply' )
-				),
-				replyComment( commentText, siteId, postId, parentCommentId )
-			)
-		),
-
-	unlikeComment: ( commentId, postId ) =>
-		dispatch(
-			withAnalytics(
-				composeAnalytics(
-					recordTracksEvent( 'calypso_comment_management_unlike' ),
-					bumpStat( 'calypso_comment_management', 'comment_unliked' )
-				),
-				unlikeComment( siteId, postId, commentId )
 			)
 		),
 } );


### PR DESCRIPTION
Contribute to #20727

Wait and rebase after #20738

Remove all action and persistence methods, related to `CommentDetail` which is now obsolete, from `CommentList`.

## Testing instructions

Smoke test `/comments`!