### PR TITLE
Fix theme purchase at signup

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -110,6 +110,8 @@ export default {
 			stepName = utils.getStepName( context.params ),
 			stepSectionName = utils.getStepSectionName( context.params );
 
+		const { query } = initialContext;
+
 		analytics.pageView.record(
 			basePath,
 			basePageTitle + ' > Start > ' + flowName + ' > ' + stepName
@@ -122,6 +124,8 @@ export default {
 			initialContext,
 			locale: utils.getLocale( context.params ),
 			flowName: flowName,
+			queryObject: query,
+			refParameter: query && query.ref,
 			stepName: stepName,
 			stepSectionName: stepSectionName,
 		} );


### PR DESCRIPTION
Fixes #20717

<img width="306" alt="screen shot 2017-12-12 at 17 13 22" src="https://user-images.githubusercontent.com/7767559/33899195-aa123060-df62-11e7-87ad-e34aa89c1ff1.png">


PR #18557 renamed the `queryObject` prop passed to the signup components to `initialContext`. There are still some uses of `queryObject`. This change fixes the the signup-with-theme flow that takes the chosen theme details from the `queryObject` prop.

@Tug you probably want to take a look at the remaining uses of `queryObject` in signup.

## Testing

Follow steps in #20717
