### PR TITLE
Reduxify: receive invite accepted success

### DIFF
--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -103,7 +103,7 @@ export function acceptInvite( invite, callback ) {
 			invite,
 		} );
 		wpcom.undocumented().acceptInvite( invite, ( error, data ) => {
-			Dispatcher.handleViewAction( {
+			dispatch( {
 				type: error
 					? ActionTypes.RECEIVE_INVITE_ACCEPTED_ERROR
 					: ActionTypes.RECEIVE_INVITE_ACCEPTED_SUCCESS,

--- a/client/lib/sites-list/index.js
+++ b/client/lib/sites-list/index.js
@@ -4,7 +4,6 @@
  * Internal dependencies
  */
 
-import { action as InvitesActionTypes } from 'lib/invites/constants';
 import SitesList from './list';
 import PollerPool from 'lib/data-poller';
 import Dispatcher from 'dispatcher';
@@ -21,11 +20,6 @@ export default function() {
 				case 'DISCONNECT_SITE':
 				case 'RECEIVE_DELETED_SITE':
 					_sites.removeSite( action.site );
-					break;
-				case InvitesActionTypes.RECEIVE_INVITE_ACCEPTED_SUCCESS:
-					if ( [ 'follower', 'viewer' ].indexOf( action.invite.role ) === -1 ) {
-						_sites.sync( action.data );
-					}
 					break;
 				case 'FETCH_SITES':
 					_sites.fetch(); // refetch the sites from .com

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -4,18 +4,7 @@
  * External dependencies
  */
 
-import {
-	pick,
-	omit,
-	merge,
-	get,
-	includes,
-	reduce,
-	isEqual,
-	stubFalse,
-	stubTrue,
-	find,
-} from 'lodash';
+import { pick, omit, merge, get, includes, reduce, isEqual, stubFalse, stubTrue } from 'lodash';
 
 /**
  * Internal dependencies
@@ -238,19 +227,19 @@ export function items( state = {}, action ) {
 				return state;
 			}
 
-			const siteId = get( invite, 'site.ID', null );
+			return reduce(
+				data.sites,
+				( memo, site ) => {
+					if ( memo === state ) {
+						memo = { ...state };
+					}
 
-			if ( ! siteId || state[ siteId ] ) {
-				return state;
-			}
+					memo[ site.ID ] = pick( site, VALID_SITE_KEYS );
 
-			const site = find( data.sites, receivedSite => receivedSite.ID === siteId );
-			const transformedSite = pick( site, VALID_SITE_KEYS );
-
-			return {
-				...state,
-				[ siteId ]: transformedSite,
-			};
+					return memo;
+				},
+				state
+			);
 		}
 	}
 

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -230,15 +230,11 @@ export function items( state = {}, action ) {
 			return reduce(
 				data.sites,
 				( memo, site ) => {
-					if ( memo === state ) {
-						memo = { ...state };
-					}
-
 					memo[ site.ID ] = pick( site, VALID_SITE_KEYS );
 
 					return memo;
 				},
-				state
+				{}
 			);
 		}
 	}

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -4,7 +4,18 @@
  * External dependencies
  */
 
-import { pick, omit, merge, get, includes, reduce, isEqual, stubFalse, stubTrue } from 'lodash';
+import {
+	pick,
+	omit,
+	merge,
+	get,
+	includes,
+	reduce,
+	isEqual,
+	stubFalse,
+	stubTrue,
+	find,
+} from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,6 +51,7 @@ import {
 	THEME_ACTIVATE_SUCCESS,
 	WORDADS_SITE_APPROVE_REQUEST_SUCCESS,
 } from 'state/action-types';
+import { action as InvitesActionTypes } from 'lib/invites/constants';
 import { sitesSchema } from './schema';
 import { combineReducers, createReducer, keyedReducer } from 'state/utils';
 
@@ -213,6 +225,32 @@ export function items( state = {}, action ) {
 			}
 
 			return state;
+		}
+
+		case InvitesActionTypes.RECEIVE_INVITE_ACCEPTED_SUCCESS: {
+			const { invite, data } = action;
+
+			if ( ! invite || ! data || ! data.sites ) {
+				return state;
+			}
+
+			if ( invite.role === 'follower' || invite.role === 'viewer' ) {
+				return state;
+			}
+
+			const siteId = get( invite, 'site.ID', null );
+
+			if ( ! siteId || state[ siteId ] ) {
+				return state;
+			}
+
+			const site = find( data.sites, receivedSite => receivedSite.ID === siteId );
+			const transformedSite = pick( site, VALID_SITE_KEYS );
+
+			return {
+				...state,
+				[ siteId ]: transformedSite,
+			};
 		}
 	}
 


### PR DESCRIPTION
Part of the sites-list removal project.

Currently, if you accept an invite to some site, it's handled by `SitesList`. In this PR, we are modifying the Redux `sites.items` reducer to handle the `RECEIVE_INVITE_ACCEPTED_SUCCESS` case and add the invited site to the state tree.

## Testing

You need to have two users with two sites. With the first account, go to `/people/new/<site>` and invite your other account by typing in its email address. Go to your email inbox and copy the link to the accept invitation link. Open incognito window, log in with your second account. Now, in the incognito window, open new tab and paste the invitation link. Change `https://wordpress.com....` to `http://calypso.localhost:3000..` and open the page. It should show the "accept invitation" form. Hit accept and wait till you are added to the site.

## Notes

After accepting an invitation, Calypso sidebar doesn't have all the items/links as it normally does. Only after a brief period of time it appears. The same happened with the original `SitesList` approach except the fact that in that approach, general All Sites view is shown and in the new approach, the invited site is shown (but without any links). [Video of how it works](http://cld.wthms.co/Esoy1G)

Do you think showing the general All Sites view would be better?

