### PR TITLE
Jetpack Onboarding: Hide Wizard navigation on the Summary step

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -36,6 +36,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 					components={ COMPONENTS }
 					steps={ steps }
 					stepName={ stepName }
+					hideNavigation={ stepName === STEPS.SUMMARY }
 				/>
 			</Main>
 		);


### PR DESCRIPTION
This PR hides the navigation (basically the Back button) on the last Summary step.

Fixes #17652

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/onboarding/summary
* Verify you no longer see the navigation.