### PR TITLE
Add UK ccTLDs to Calypso

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -88,7 +88,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 		// Add defaults to redux state to make accepting default values work.
 		const neededRequiredDetails = difference(
 			[ 'lang', 'legalType', 'ciraAgreementAccepted' ],
-			keys( this.props.contactDetailsExtra )
+			keys( this.props.contactDetails.extra )
 		);
 
 		// Bail early as we already have the details from a previous purchase.

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -9,18 +9,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
-import {
-	castArray,
-	defaults,
-	get,
-	identity,
-	isEmpty,
-	isString,
-	map,
-	noop,
-	set,
-	toUpper,
-} from 'lodash';
+import { defaults, get, identity, isEmpty, isString, map, noop, set, toUpper } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,6 +23,7 @@ import FormRadio from 'components/forms/form-radio';
 import FormTextInput from 'components/forms/form-text-input';
 import FormInputValidation from 'components/forms/form-input-validation';
 import validateContactDetails from './fr-validate-contact-details';
+import disableSubmitButton from './with-contact-details-validation';
 
 const debug = debugFactory( 'calypso:domains:registrant-extra-info' );
 let defaultRegistrantType;
@@ -152,14 +142,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 
 				{ 'organization' === registrantType && this.renderOrganizationFields() }
 
-				{ formIsValid
-					? this.props.children
-					: map( castArray( this.props.children ), ( child, index ) =>
-							React.cloneElement( child, {
-								disabled: child.props.className.match( /submit-button/ ) || child.props.disabled,
-								key: index,
-							} )
-						) }
+				{ formIsValid ? this.props.children : disableSubmitButton( this.props.children ) }
 			</form>
 		);
 	}

--- a/client/components/domains/registrant-extra-info/index.jsx
+++ b/client/components/domains/registrant-extra-info/index.jsx
@@ -11,12 +11,14 @@ import { keys, filter } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
-import fr from './fr-form';
 import ca from './ca-form';
+import fr from './fr-form';
+import uk from './uk-form';
 
 const tldSpecificForms = {
 	ca,
 	fr,
+	uk,
 };
 
 const enabledTldForms = filter( keys( tldSpecificForms ), tld =>
@@ -28,7 +30,8 @@ export const tldsWithAdditionalDetailsForms = enabledTldForms;
 export default class DomainDetailsForm extends PureComponent {
 	render() {
 		const { tld, ...props } = this.props;
-		const TldSpecificForm = tldSpecificForms[ tld ];
+		const topLevelOfTld = tld.substring( tld.lastIndexOf( '.' ) + 1 );
+		const TldSpecificForm = tldSpecificForms[ topLevelOfTld ];
 
 		if ( ! TldSpecificForm ) {
 			throw new Error( 'unrecognized tld in extra info form:', tld );

--- a/client/components/domains/registrant-extra-info/test/index.js
+++ b/client/components/domains/registrant-extra-info/test/index.js
@@ -11,6 +11,7 @@ import React from 'react';
  */
 import RegistrantExtraInfoCaForm from '../ca-form';
 import RegistrantExtraInfoFrForm from '../fr-form';
+import RegistrantExtraInfoUkForm from '../uk-form';
 import RegistrantExtraInfoForm from '../index';
 
 jest.mock( 'store', () => ( { get: () => {}, set: () => {} } ) );
@@ -29,5 +30,13 @@ describe( 'Switcher Form', () => {
 
 		expect( wrapper.find( RegistrantExtraInfoCaForm ) ).to.have.length( 1 );
 		expect( wrapper.find( RegistrantExtraInfoFrForm ) ).to.have.length( 0 );
+	} );
+
+	test( 'should render correct form for uk', () => {
+		const wrapper = shallow( <RegistrantExtraInfoForm tld="uk" /> );
+
+		expect( wrapper.find( RegistrantExtraInfoCaForm ) ).to.have.length( 0 );
+		expect( wrapper.find( RegistrantExtraInfoFrForm ) ).to.have.length( 0 );
+		expect( wrapper.find( RegistrantExtraInfoUkForm ) ).to.have.length( 1 );
 	} );
 } );

--- a/client/components/domains/registrant-extra-info/test/uk-form.js
+++ b/client/components/domains/registrant-extra-info/test/uk-form.js
@@ -1,0 +1,114 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { RegistrantExtraInfoUkForm } from '../uk-form';
+import FormInputValidation from 'components/forms/form-input-validation';
+
+const mockProps = {
+	step: 'uk',
+	translate: identity,
+	updateContactDetailsCache: identity,
+};
+
+describe( 'uk-form', () => {
+	describe( 'Validation Errors', () => {
+		test( 'should render the correct registation errors', () => {
+			const testProps = {
+				...mockProps,
+				contactDetails: { extra: { registrantType: 'LLP' } },
+				validationErrors: {
+					extra: {
+						registrationNumber: [ 'testErrorCode' ],
+					},
+				},
+			};
+
+			const wrapper = shallow( <RegistrantExtraInfoUkForm { ...testProps } /> );
+			const error = wrapper.find( FormInputValidation );
+			expect( error.props() ).toHaveProperty( 'text', 'There was a problem with this field.' );
+		} );
+
+		test( 'should render multiple registation errors', () => {
+			const testProps = {
+				...mockProps,
+				contactDetails: { extra: { registrantType: 'LLP' } },
+				validationErrors: {
+					extra: {
+						registrationNumber: [ 'testErrorCode', 'testErrorCode' ],
+						tradingName: [ 'testErrorCode' ],
+					},
+				},
+			};
+
+			const wrapper = shallow( <RegistrantExtraInfoUkForm { ...testProps } /> );
+			const error = wrapper.find( FormInputValidation );
+			expect( error ).toHaveProperty( 'length', 3 );
+		} );
+
+		test( 'should convert error code to user-facing string', () => {
+			const testProps = {
+				...mockProps,
+				contactDetails: { extra: { registrantType: 'LLP' } },
+				validationErrors: {
+					extra: {
+						registrationNumber: [ 'dotukRegistrationNumberFormat' ],
+					},
+				},
+			};
+
+			const wrapper = shallow( <RegistrantExtraInfoUkForm { ...testProps } /> );
+			const error = wrapper.find( FormInputValidation );
+			expect( error.props() ).toHaveProperty(
+				'text',
+				'A Company Registration Number is 8 numerals, or 2 letters followed by 6 numerals (e.g. AB123456 or 12345678).'
+			);
+		} );
+
+		test( 'Should disable submit button with validation errors', () => {
+			const testProps = {
+				...mockProps,
+				contactDetails: { extra: { registrantType: 'LLP' } },
+				validationErrors: {
+					extra: {
+						registrationNumber: [ 'dotukRegistrationNumberFormat' ],
+					},
+				},
+			};
+
+			const wrapper = shallow(
+				<RegistrantExtraInfoUkForm { ...testProps }>
+					<button className="test__hush-eslint .submit-button" />
+				</RegistrantExtraInfoUkForm>
+			);
+
+			expect( wrapper.find( 'button' ).prop( 'disabled' ) ).toBe( true );
+		} );
+
+		test( 'Should not disable submit button with irrelevant validation errors', () => {
+			const testProps = {
+				...mockProps,
+				contactDetails: { extra: { registrantType: 'IND' } },
+				validationErrors: {
+					extra: {
+						registrationNumber: [ 'dotukRegistrationNumberFormat' ],
+					},
+				},
+			};
+
+			const wrapper = shallow(
+				<RegistrantExtraInfoUkForm { ...testProps }>
+					<button className="test__hush-eslint .submit-button" />
+				</RegistrantExtraInfoUkForm>
+			);
+			expect( wrapper.find( 'button' ).prop( 'disabled' ) ).toBe( undefined );
+		} );
+	} );
+} );

--- a/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
+++ b/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
@@ -1,0 +1,172 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { difference, identity, set } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { ValidatedRegistrantExtraInfoUkForm } from '../uk-form';
+
+const mockProps = {
+	translate: identity,
+	updateContactDetailsCache: identity,
+};
+
+describe( 'uk-form validation', () => {
+	const validTradingName = 'A valid trading name';
+	const validRegistrationNumber = 'AB123456';
+
+	const allRegistrantTypes = [
+		'CRC',
+		'FCORP',
+		'FIND',
+		'FOTHER',
+		'GOV',
+		'IND',
+		'IP',
+		'LLP',
+		'LTD',
+		'OTHER',
+		'PLC',
+		'PTNR',
+		'RCHAR',
+		'SCH',
+		'STAT',
+		'STRA',
+	];
+
+	// see http://domains.opensrs.guide/docs/tld#section-uk
+	const needsRegistrationNumber = [ 'LTD', 'PLC', 'LLP', 'IP', 'SCH', 'RCHAR' ];
+
+	const needsTradingName = [
+		'LTD',
+		'PLC',
+		'LLP',
+		'IP',
+		'RCHAR',
+		'FCORP',
+		'OTHER',
+		'FOTHER',
+		'STRA',
+	];
+
+	describe( 'registrationNumber field', () => {
+		test( 'should be required for some values of registrantType', () => {
+			const testContactDetails = {
+				extra: {
+					registrantType: 'LLP',
+					tradingName: validTradingName,
+				},
+			};
+
+			needsRegistrationNumber.forEach( registrantType => {
+				const wrapper = shallow(
+					<ValidatedRegistrantExtraInfoUkForm
+						{ ...mockProps }
+						contactDetails={ set( testContactDetails, 'extra.registrantType', registrantType ) }
+					/>
+				);
+
+				expect( wrapper.props() ).toHaveProperty( 'validationErrors', {
+					extra: { registrationNumber: [ 'dotukRegistrantTypeRequiresRegistrationNumber' ] },
+				} );
+			} );
+		} );
+
+		test( 'should not be required for other values of registrantType', () => {
+			const testContactDetails = {
+				extra: {
+					registrantType: 'LLP',
+					tradingName: validTradingName,
+				},
+			};
+
+			difference( allRegistrantTypes, needsRegistrationNumber ).forEach( registrantType => {
+				const wrapper = shallow(
+					<ValidatedRegistrantExtraInfoUkForm
+						{ ...mockProps }
+						contactDetails={ set( testContactDetails, 'extra.registrantType', registrantType ) }
+					/>
+				);
+
+				expect( wrapper.props() ).toHaveProperty( 'validationErrors', {} );
+			} );
+		} );
+
+		test( 'should reject bad formats', () => {
+			const testContactDetails = {
+				extra: {
+					registrantType: 'LLP',
+					tradingName: validTradingName,
+				},
+			};
+
+			const badFormats = [ '124', 'OC38599', '066566879', 'OCABCDEF', '054025OC' ];
+
+			badFormats.forEach( registrationNumber => {
+				const wrapper = shallow(
+					<ValidatedRegistrantExtraInfoUkForm
+						{ ...mockProps }
+						contactDetails={ set(
+							testContactDetails,
+							'extra.registrationNumber',
+							registrationNumber
+						) }
+					/>
+				);
+
+				expect( wrapper.props() ).toHaveProperty( 'validationErrors.extra.registrationNumber' );
+			} );
+		} );
+	} );
+
+	describe( 'tradingName', () => {
+		test( 'should be required for some values of registrantType', () => {
+			const testContactDetails = {
+				extra: {
+					registrantType: 'LLP',
+					registrationNumber: validRegistrationNumber,
+					tradingName: '',
+				},
+			};
+
+			needsTradingName.forEach( registrantType => {
+				const wrapper = shallow(
+					<ValidatedRegistrantExtraInfoUkForm
+						{ ...mockProps }
+						contactDetails={ set( testContactDetails, 'extra.registrantType', registrantType ) }
+					/>
+				);
+
+				expect( wrapper.props() ).toHaveProperty( 'validationErrors', {
+					extra: { tradingName: [ 'dotukRegistrantTypeRequiresTradingName' ] },
+				} );
+			} );
+		} );
+
+		test( 'should not be required for other values of registrantType', () => {
+			difference( allRegistrantTypes, needsTradingName ).forEach( registrantType => {
+				const testContactDetails = {
+					extra: {
+						registrantType,
+						registrationNumber: validRegistrationNumber,
+						tradingName: '',
+					},
+				};
+
+				const wrapper = shallow(
+					<ValidatedRegistrantExtraInfoUkForm
+						{ ...mockProps }
+						contactDetails={ testContactDetails }
+					/>
+				);
+
+				expect( wrapper.props() ).toHaveProperty( 'validationErrors', {} );
+			} );
+		} );
+	} );
+} );

--- a/client/components/domains/registrant-extra-info/uk-form.jsx
+++ b/client/components/domains/registrant-extra-info/uk-form.jsx
@@ -1,0 +1,251 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { camelCase, difference, filter, get, includes, isEmpty, keys, map, pick } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getContactDetailsCache } from 'state/selectors';
+import { updateContactDetailsCache } from 'state/domains/management/actions';
+import FormInputValidation from 'components/forms/form-input-validation';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
+import FormTextInput from 'components/forms/form-text-input';
+import WithContactDetailsValidation, {
+	disableSubmitButton,
+} from './with-contact-details-validation';
+import contactDetailsUkSchema from './uk-schema';
+
+const defaultValues = {
+	registrantType: 'IND',
+};
+
+export class RegistrantExtraInfoUkForm extends React.PureComponent {
+	static propTypes = {
+		contactDetails: PropTypes.object.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+		const { translate } = props;
+		const registrantTypes = {
+			IND: translate( 'Individual' ),
+			FIND: translate( 'Foreign Individual' ),
+			STRA: translate( 'UK Sole Trader', {
+				comment: 'Refers to UK legal concept of self-employment/sole proprietorship',
+			} ),
+			PTNR: translate( 'UK Partnership' ),
+			LLP: translate( 'UK Limited Liability Partnership' ),
+			CRC: translate( 'UK Corporation by Royal Charter' ),
+			FCORP: translate( 'Non-UK Corporation' ),
+			IP: translate( 'UK Industrial/Provident Registered Company' ),
+			LTD: translate( 'UK Limited Company' ),
+			PLC: translate( 'UK Public Limited Company' ),
+			SCH: translate( 'UK School' ),
+			GOV: translate( 'UK Government Body' ),
+			RCHAR: translate( 'UK Registered Charity' ),
+			STAT: translate( 'UK Statutory Body' ),
+			OTHER: translate( 'UK Entity that does not fit another category' ),
+			FOTHER: translate( 'Non-UK Entity that does not fit another category' ),
+		};
+		this.registrantTypeOptions = map( registrantTypes, ( text, optionValue ) => (
+			<option value={ optionValue } key={ optionValue }>
+				{ text }
+			</option>
+		) );
+		this.errorMessages = {
+			dotukRegistrationNumberFormat: translate(
+				'A Company Registration Number is 8 numerals, or 2 letters followed by 6 numerals (e.g. AB123456 or 12345678).'
+			),
+			dotukRegistrantTypeRequiresRegistrationNumber: translate(
+				'A registration number is required for this registrant type.'
+			),
+			dotukRegistrantTypeRequiresTradingName: translate(
+				'A trading name is required for this registrant type.'
+			),
+		};
+	}
+
+	componentWillMount() {
+		// Add defaults to redux state to make accepting default values work.
+		const neededRequiredDetails = difference(
+			[ 'registrantType' ],
+			keys( this.props.contactDetails.extra )
+		);
+
+		// Bail early as we already have the details from a previous purchase.
+		if ( isEmpty( neededRequiredDetails ) ) {
+			return;
+		}
+
+		this.props.updateContactDetailsCache( {
+			extra: pick( defaultValues, neededRequiredDetails ),
+		} );
+	}
+
+	handleChangeEvent = event => {
+		this.props.updateContactDetailsCache( {
+			extra: { [ camelCase( event.target.id ) ]: event.target.value },
+		} );
+	};
+
+	isTradingNameRequired( registrantType ) {
+		return includes(
+			[ 'LTD', 'PLC', 'LLP', 'IP', 'RCHAR', 'FCORP', 'OTHER', 'FOTHER', 'STRA' ],
+			registrantType
+		);
+	}
+
+	isRegistrationNumberRequired( registrantType ) {
+		return includes( [ 'LTD', 'PLC', 'LLP', 'IP', 'SCH', 'RCHAR' ], registrantType );
+	}
+
+	renderTradingNameField() {
+		const { contactDetails, translate } = this.props;
+		const tradingName = get( contactDetails, [ 'extra', 'tradingName' ], '' );
+		const tradingNameErrors = get( this.props.validationErrors, [ 'extra', 'tradingName' ], [] );
+		const isError = ! isEmpty( tradingNameErrors );
+
+		return (
+			<div>
+				<FormFieldset>
+					<FormLabel className="registrant-extra-info__trading-name" htmlFor="trading-name">
+						{ translate( 'Trading Name' ) }
+					</FormLabel>
+					<FormTextInput
+						id="trading-name"
+						value={ tradingName }
+						autoCapitalize="off"
+						autoComplete="off"
+						autoCorrect="off"
+						placeholder={ '' }
+						onChange={ this.handleChangeEvent }
+						isError={ isError }
+					/>
+					{ map( tradingNameErrors, this.renderValidationError ) }
+				</FormFieldset>
+			</div>
+		);
+	}
+
+	renderRegistrationNumberField() {
+		const { contactDetails, translate } = this.props;
+		const registrationNumber = get( contactDetails, [ 'extra', 'registrationNumber' ], '' );
+		const registrationNumberErrors = get(
+			this.props.validationErrors,
+			[ 'extra', 'registrationNumber' ],
+			[]
+		);
+
+		const isError = ! isEmpty( registrationNumberErrors );
+
+		return (
+			<div>
+				<FormFieldset>
+					<FormLabel
+						className="registrant-extra-info__registration-number"
+						htmlFor="registration-number"
+					>
+						{ translate( 'Registration Number' ) }
+					</FormLabel>
+					<FormTextInput
+						id="registration-number"
+						value={ registrationNumber }
+						autoCapitalize="off"
+						autoComplete="off"
+						autoCorrect="off"
+						placeholder={ '' }
+						onChange={ this.handleChangeEvent }
+						isError={ isError }
+					/>
+					{ map( registrationNumberErrors, this.renderValidationError ) }
+				</FormFieldset>
+			</div>
+		);
+	}
+
+	errorMessageFromCode( errorCode ) {
+		return (
+			this.errorMessages[ errorCode ] ||
+			this.props.translate( 'There was a problem with this field.' )
+		);
+	}
+
+	renderValidationError = errorCode => {
+		return (
+			<FormInputValidation
+				isError
+				key={ errorCode }
+				text={ this.errorMessageFromCode( errorCode ) }
+			/>
+		);
+	};
+
+	render() {
+		const { translate, validationErrors } = this.props;
+		const { registrantType } = {
+			...defaultValues,
+			...this.props.contactDetails.extra,
+		};
+
+		const relevantExtraFields = filter( [
+			this.isTradingNameRequired( registrantType ) && 'tradingName',
+			this.isRegistrationNumberRequired( registrantType ) && 'registrationNumber',
+		] );
+		const relevantErrors = pick( ( validationErrors || {} ).extra, relevantExtraFields );
+		const isValid = isEmpty( relevantErrors );
+
+		return (
+			<form className="registrant-extra-info__form">
+				<p className="registrant-extra-info__form-desciption">
+					{ translate( 'Almost done! We need some extra details to register your %(tld)s domain.', {
+						args: { tld: '.uk' },
+					} ) }
+				</p>
+				<FormFieldset>
+					<FormLabel htmlFor="registrant-type">
+						{ translate(
+							'Choose the option that best describes your presence in the United Kingdom:'
+						) }
+					</FormLabel>
+					<FormSelect
+						id="registrant-type"
+						value={ registrantType }
+						className="registrant-extra-info__form-registrant-type"
+						onChange={ this.handleChangeEvent }
+					>
+						{ this.registrantTypeOptions }
+					</FormSelect>
+				</FormFieldset>
+
+				{ this.isTradingNameRequired( registrantType ) && this.renderTradingNameField() }
+
+				{ this.isRegistrationNumberRequired( registrantType ) &&
+					this.renderRegistrationNumberField() }
+				{ isValid ? this.props.children : disableSubmitButton( this.props.children ) }
+			</form>
+		);
+	}
+}
+
+export const ValidatedRegistrantExtraInfoUkForm = WithContactDetailsValidation(
+	contactDetailsUkSchema,
+	RegistrantExtraInfoUkForm
+);
+
+export default connect(
+	state => ( {
+		contactDetails: getContactDetailsCache( state ),
+	} ),
+	{ updateContactDetailsCache }
+)( localize( ValidatedRegistrantExtraInfoUkForm ) );

--- a/client/components/domains/registrant-extra-info/uk-schema.json
+++ b/client/components/domains/registrant-extra-info/uk-schema.json
@@ -1,0 +1,104 @@
+{
+	"id": "\/contact-validation\/contact-validation\/uk",
+	"errorCode": "dotukValidation",
+	"$comment": "See http:\/\/domains.opensrs.guide\/docs\/tld#section-uk",
+	"type": "object",
+	"properties": {
+		"extra": {
+			"allOf": [
+				{
+					"errorCode": "dotukRegistrantTypeRequiresRegistrationNumber",
+					"errorField": "extra.registrationNumber",
+					"anyOf": [
+						{
+							"properties": {
+								"registrationNumber": {
+									"minLength": 1
+								}
+							},
+							"required": [
+								"registrationNumber"
+							]
+						},
+						{
+							"not": {
+								"properties": {
+									"registrantType": {
+										"enum": [
+											"IP",
+											"LLP",
+											"LTD",
+											"PLC",
+											"RCHAR",
+											"SCH"
+										]
+									}
+								}
+							}
+						}
+					]
+				},
+				{
+					"errorCode": "dotukRegistrantTypeRequiresTradingName",
+					"errorField": "extra.tradingName",
+					"anyOf": [
+						{
+							"properties": {
+								"tradingName": {
+									"minLength": 1
+								}
+							},
+						"required": [
+								"tradingName"
+							]
+						},
+						{
+							"not": {
+								"properties": {
+									"registrantType": {
+										"enum": [
+											"LTD",
+											"PLC",
+											"LLP",
+											"IP",
+											"RCHAR",
+											"FCORP",
+											"OTHER",
+											"FOTHER",
+											"STRA"
+										]
+									}
+								}
+							}
+						}
+					]
+				},
+				{
+					"properties": {
+						"registrationNumber": {
+							"errorCode": "dotukRegistrationNumberFormat",
+							"pattern": "^[a-zA-Z0-9]{2}[0-9]{6}$"
+						}
+					}
+				}
+			],
+			"required": [
+				"registrantType"
+			]
+		},
+		"organization": {
+			"minimumLength": 4
+		}
+	},
+	"patternProperties": {
+		"^address": {
+			"errorCode": "dotukNoPoBox",
+			"not": {
+				"pattern": "\\b[Pp](?:[Oo][Ss][Tt])?\\.? ?[Oo](?:[Ff][Ff][Ii][Cc][Ee])?\\.? ?[Bb](?:[Oo][Xx])? ?#?[0-9]{1,5}"
+			}
+		}
+	},
+	"required": [
+		"extra"
+	]
+}

--- a/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
+++ b/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
@@ -1,0 +1,102 @@
+/**
+ * Extrenal dependencies
+ *
+ * @format
+ */
+
+import React, { Component } from 'react';
+import validatorFactory from 'is-my-json-valid';
+import { castArray, get, isEmpty, map, reduce, replace, set } from 'lodash';
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:domains:with-contact-details-validation' );
+
+/**
+ * Internal dependencies
+ */
+
+export function disableSubmitButton( children ) {
+	if ( isEmpty( children ) ) {
+		return children;
+	}
+
+	return map( castArray( children ), ( child, index ) =>
+		React.cloneElement( child, {
+			disabled: !! child.props.className.match( /submit-button/ ) || child.props.disabled,
+			key: index,
+		} )
+	);
+}
+
+export function interpretIMJVError( error, schema ) {
+	let explicitPath, errorCode;
+
+	if ( schema ) {
+		// Search up the schema for an explicit errorField & message
+		const path = [ ...castArray( error.schemaPath ) ];
+
+		do {
+			const node = get( schema, path, {} );
+			errorCode = errorCode || node.errorCode;
+			explicitPath = explicitPath || node.errorField;
+		} while ( path.pop() && ! ( explicitPath && errorCode ) );
+	}
+
+	// use field from error
+	const inferredPath = replace( error.field, /^data\./, '' );
+
+	return {
+		errorCode: errorCode || error.message,
+		path: explicitPath || inferredPath,
+	};
+}
+
+/*
+ * @returns errors by field, like: { 'extra.field: name, errors: [ string ] }
+ */
+export function formatIMJVErrors( errors, schema ) {
+	return reduce(
+		errors,
+		( accumulatedErrors, error ) => {
+			// scan for errorField and errorCode at or above the failed rule
+			const details = interpretIMJVError( error, schema );
+
+			const { path, errorCode } = details;
+
+			// TODO: get localize user facing strings
+			const message = errorCode;
+
+			const previousErrorsForField = get( accumulatedErrors, path, [] );
+
+			return set( accumulatedErrors, path, [ ...previousErrorsForField, message ] );
+		},
+		{}
+	);
+}
+
+const WithContactDetailsValidation = ( schema, WrappedComponent ) => {
+	return class FormWithValidation extends Component {
+		validate = validatorFactory( schema, { greedy: true, verbose: true } );
+
+		validateContactDetails() {
+			const isValid = this.validate( this.props.contactDetails );
+
+			if ( isValid ) {
+				debug( 'data is valid' );
+				return {};
+			}
+
+			// TODO: error codes => localized strings
+			const result = formatIMJVErrors( this.validate.errors, schema );
+
+			return result;
+		}
+
+		render() {
+			return (
+				<WrappedComponent { ...this.props } validationErrors={ this.validateContactDetails() } />
+			);
+		}
+	};
+};
+
+export default WithContactDetailsValidation;

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -26,6 +26,7 @@
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
+		"domains/cctlds/uk": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/development.json
+++ b/config/development.json
@@ -52,6 +52,7 @@
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
+		"domains/cctlds/uk": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -27,6 +27,7 @@
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
+		"domains/cctlds/uk": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/production.json
+++ b/config/production.json
@@ -26,6 +26,7 @@
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
+		"domains/cctlds/uk": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -28,6 +28,7 @@
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
+		"domains/cctlds/uk": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -28,6 +28,8 @@
 		"dev/test-helper": true,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
+		"domains/cctlds/fr": true,
+		"domains/cctlds/uk": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
Adds UK ccTLD functionality to Calypso - use D8785-code [already committed] on the backend.

The TLD remains behind a feature flag server-side and we will launch to testing in that state.