### PR TITLE
Components: Fix TileGrid clipping CTA text on mobile

### DIFF
--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -146,7 +146,7 @@
 		background: none;
 		text-align: left;
 		font-size: 16px;
-		line-height: 1.2;
+		line-height: 1.4;
 		border: 0;
 		padding: 0;
 		text-transform: none;


### PR DESCRIPTION
This PR fixes the `Tile` CTA text clipping on mobile. Fixes #17575.

Before:
![](https://cldup.com/RMYkmlcf4L.jpg)

After:
![](https://cldup.com/bwFdOedNlW.jpg)

To test:
* On mobile, go to https://calypso.live/jetpack/onboarding/homepage?branch=fix/components-tile-grid-mobile-cta-lh
* Verify text is no longer clipped.
