### PR TITLE
Concierge Chats: Require a Business site for access

### DIFF
--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -11,7 +11,7 @@ import React from 'react';
 import ConciergeMain from './main';
 
 const concierge = ( context, next ) => {
-	context.primary = React.createElement( ConciergeMain, {} );
+	context.primary = React.createElement( ConciergeMain, { siteSlug: context.params.siteSlug } );
 	next();
 };
 

--- a/client/me/concierge/index.js
+++ b/client/me/concierge/index.js
@@ -15,6 +15,6 @@ import { makeLayout, render as clientRender } from 'controller';
 
 export default () => {
 	if ( config.isEnabled( 'concierge-chats' ) ) {
-		page( '/me/concierge', controller.concierge, makeLayout, clientRender );
+		page( '/me/concierge/:siteSlug', controller.concierge, makeLayout, clientRender );
 	}
 };

--- a/client/me/concierge/info-step.js
+++ b/client/me/concierge/info-step.js
@@ -12,18 +12,20 @@ import PropTypes from 'prop-types';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import PrimaryHeader from './primary-header';
+import Site from 'blocks/site';
 
 class InfoStep extends Component {
 	static propTypes = {
 		onComplete: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
 	};
 
 	render() {
 		return (
 			<div>
 				<PrimaryHeader />
-				<CompactCard>
-					Here is the first step where the customer gives us their information
+				<CompactCard className="concierge__site-block">
+					<Site siteId={ this.props.siteId } />
 				</CompactCard>
 				<CompactCard>
 					<Button onClick={ this.props.onComplete }>Continue to calendar</Button>

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -25,6 +25,7 @@ import ConfirmationStep from './confirmation-step';
 import InfoStep from './info-step';
 import Main from 'components/main';
 import Skeleton from './skeleton';
+import Upsell from './upsell';
 import QueryConciergeShifts from 'components/data/query-concierge-shifts';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -61,14 +62,14 @@ class ConciergeMain extends Component {
 		}
 
 		if ( site.plan.product_slug !== PLAN_BUSINESS ) {
-			return <div>TODO: Show a better message for non-business sites</div>;
+			return <Upsell site={ site } />;
 		}
 
 		// We have shift data and this is a business site — show the signup steps
 		return (
 			<CurrentStep
 				shifts={ shifts }
-				siteId={ site.ID }
+				site={ site }
 				onComplete={ this.goToNextStep }
 				onBack={ this.goToPreviousStep }
 			/>

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -26,8 +26,12 @@ import InfoStep from './info-step';
 import Main from 'components/main';
 import Skeleton from './skeleton';
 import QueryConciergeShifts from 'components/data/query-concierge-shifts';
+import QuerySites from 'components/data/query-sites';
+import QuerySitePlans from 'components/data/query-site-plans';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
 import { getConciergeShifts } from 'state/selectors';
 import { WPCOM_CONCIERGE_SCHEDULE_ID } from './constants';
+import { getSite } from 'state/sites/selectors';
 
 const STEP_COMPONENTS = [ InfoStep, CalendarStep, ConfirmationStep ];
 
@@ -48,32 +52,49 @@ class ConciergeMain extends Component {
 		this.setState( { currentStep: this.state.currentStep + 1 } );
 	};
 
-	render() {
+	getDisplayComponent = () => {
+		const { shifts, site } = this.props;
 		const CurrentStep = STEP_COMPONENTS[ this.state.currentStep ];
-		const { shifts } = this.props;
+
+		if ( ! shifts || ! site || ! site.plan ) {
+			return <Skeleton />;
+		}
+
+		if ( site.plan.product_slug !== PLAN_BUSINESS ) {
+			return <div>TODO: Show a better message for non-business sites</div>;
+		}
+
+		// We have shift data and this is a business site — show the signup steps
+		return (
+			<CurrentStep
+				shifts={ shifts }
+				siteId={ site.ID }
+				onComplete={ this.goToNextStep }
+				onBack={ this.goToPreviousStep }
+			/>
+		);
+	};
+
+	render() {
+		const { site } = this.props;
 
 		// TODO:
 		// render the shifts for real.
 		return (
 			<Main>
 				<QueryConciergeShifts scheduleId={ WPCOM_CONCIERGE_SCHEDULE_ID } />
-				{ shifts ? (
-					<CurrentStep
-						shifts={ shifts }
-						onComplete={ this.goToNextStep }
-						onBack={ this.goToPreviousStep }
-					/>
-				) : (
-					<Skeleton />
-				) }
+				<QuerySites />
+				{ site && <QuerySitePlans siteId={ site.ID } /> }
+				{ this.getDisplayComponent() }
 			</Main>
 		);
 	}
 }
 
 export default connect(
-	state => ( {
+	( state, props ) => ( {
 		shifts: getConciergeShifts( state ),
+		site: getSite( state, props.siteSlug ),
 	} ),
 	{ getConciergeShifts }
 )( ConciergeMain );

--- a/client/me/concierge/skeleton.js
+++ b/client/me/concierge/skeleton.js
@@ -17,7 +17,7 @@ class Skeleton extends Component {
 		return (
 			<div>
 				<PrimaryHeader />
-				<CompactCard>
+				<CompactCard className="concierge__site-block">
 					<SitePlaceholder />
 				</CompactCard>
 			</div>

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -1,5 +1,10 @@
 /** @format */
 
+.concierge__site-block .site__content {
+	// Override the site block's padding to use the containing card's padding instead
+	padding: 0;
+}
+
 .concierge__calendar-card.is-expanded {
 	background: lighten($gray, 36%);
 }

--- a/client/me/concierge/upsell.js
+++ b/client/me/concierge/upsell.js
@@ -5,6 +5,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -20,6 +21,7 @@ class Upsell extends Component {
 	};
 
 	render() {
+		const { translate } = this.props;
 		return (
 			<div>
 				<PrimaryHeader />
@@ -27,9 +29,11 @@ class Upsell extends Component {
 					<Site siteId={ this.props.site.ID } />
 				</CompactCard>
 				<CompactCard>
-					<p>Only sites on a Business Plan are eligible for a concierge site setup chat.</p>
+					<p>
+						{ translate( 'Only sites on a Business Plan are eligible for a site setup chat.' ) }
+					</p>
 					<Button href={ `/plans/${ this.props.site.slug }` } primary>
-						Upgrade to Business
+						{ translate( 'Upgrade to Business' ) }
 					</Button>
 				</CompactCard>
 			</div>
@@ -37,4 +41,4 @@ class Upsell extends Component {
 	}
 }
 
-export default Upsell;
+export default localize( Upsell );

--- a/client/me/concierge/upsell.js
+++ b/client/me/concierge/upsell.js
@@ -14,9 +14,8 @@ import CompactCard from 'components/card/compact';
 import PrimaryHeader from './primary-header';
 import Site from 'blocks/site';
 
-class InfoStep extends Component {
+class Upsell extends Component {
 	static propTypes = {
-		onComplete: PropTypes.func.isRequired,
 		site: PropTypes.object.isRequired,
 	};
 
@@ -28,14 +27,14 @@ class InfoStep extends Component {
 					<Site siteId={ this.props.site.ID } />
 				</CompactCard>
 				<CompactCard>
-					<p>
-						<em>TODO: Add form questions here</em>
-					</p>
-					<Button onClick={ this.props.onComplete }>Continue to calendar</Button>
+					<p>Only sites on a Business Plan are eligible for a concierge site setup chat.</p>
+					<Button href={ `/plans/${ this.props.site.slug }` } primary>
+						Upgrade to Business
+					</Button>
 				</CompactCard>
 			</div>
 		);
 	}
 }
 
-export default InfoStep;
+export default Upsell;


### PR DESCRIPTION
This PR limits Concierge Chat scheduler access to Business sites. You are now required to pass a site slug in the URL to note which site you're asking about, e.g. `/me/concierge/mysite.com`.

### How to test

#### Business site
- Pick one of you Business plan sites and pass the slug into the URL: `http://calypso.localhost:3000/me/concierge/[biz site url]`
- You should see the scheduler come up with your site listed at the top of the first step:
    <img width="790" alt="screen shot 2017-12-12 at 3 57 39 pm" src="https://user-images.githubusercontent.com/518059/33910682-386357b2-df55-11e7-993d-be5c19409305.png">

#### Non-business site
- Pick a non-Business plan site and pass the slug into the URL: `http://calypso.localhost:3000/me/concierge/[free site url]`
- You should see the screen come up with a call-to-action to upgrade:
    <img width="774" alt="screen shot 2017-12-13 at 8 10 07 am" src="https://user-images.githubusercontent.com/518059/33942986-4d1801ca-dfdd-11e7-950e-7dae3b279a99.png">
