### PR TITLE
Settings: Add media styles to settings bundle

### DIFF
--- a/assets/stylesheets/sections/site-settings.scss
+++ b/assets/stylesheets/sections/site-settings.scss
@@ -27,3 +27,4 @@
 @import 'my-sites/site-settings/theme-setup/style';
 @import 'my-sites/site-settings/theme-setup-dialog/style';
 @import 'post-editor/media-modal/style';
+@import './media';


### PR DESCRIPTION
In #18921, the styles for the media library were removed from [`_components.scss`](https://github.com/Automattic/wp-calypso/blob/master/assets/stylesheets/_components.scss), which is loaded on every route. Instead, a specific [`/media` section](https://github.com/Automattic/wp-calypso/blob/master/assets/stylesheets/sections/media.scss) was created. This ended up breaking the styles on the site icon loader under `/settings` because the media styles haven't loaded yet (unless you visit the media library specifically or edit a post first).

This fixes the issue by re-importing the styles for the media library into the setting section.

### To test
1. Load this branch.
2. On a clear cache, visit http://calypso.localhost:3000/settings/general/
3. Click the "Change" button on Site Icon to change the site icon.

The media library should work correctly. You can compare this to wordpress.com/settings/general on a clear cache. In the live view, you'll find that the styles are broken for the media library.

### Previous

<img width="1928" alt="screen shot 2017-12-12 at 2 29 34 pm" src="https://user-images.githubusercontent.com/7240478/33909445-e80d1c1e-df48-11e7-844c-bf454bf40a2f.png">

### Updated

<img width="1922" alt="screen shot 2017-12-12 at 2 30 33 pm" src="https://user-images.githubusercontent.com/7240478/33909482-098e47f0-df49-11e7-8f3e-2b58ea11465f.png">


Fixes: #20702.