### PR TITLE
Domains: don't show wpcom and .blog subdomains at the same time.

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -145,6 +145,8 @@ class RegisterDomainStep extends React.Component {
 		onSave: noop,
 		onAddMapping: noop,
 		onAddDomain: noop,
+		includeDotBlogSubdomain: true,
+		surveyVertical: 'a8c.12',
 	};
 
 	constructor( props ) {
@@ -429,15 +431,16 @@ class RegisterDomainStep extends React.Component {
 					);
 				},
 				callback => {
-					const suggestionQuantity = this.props.includeWordPressDotCom
-						? SUGGESTION_QUANTITY - 1
-						: SUGGESTION_QUANTITY;
+					const suggestionQuantity =
+						this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain
+							? SUGGESTION_QUANTITY - 1
+							: SUGGESTION_QUANTITY;
 
 					const query = {
 						query: domain,
 						quantity: suggestionQuantity,
 						include_wordpressdotcom: false,
-						include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
+						include_dotblogsubdomain: false,
 						tld_weight_overrides: this.getTldWeightOverrides(),
 						vendor: searchVendor,
 						vertical: this.props.surveyVertical,
@@ -534,12 +537,14 @@ class RegisterDomainStep extends React.Component {
 			}
 		);
 
-		if ( this.props.includeWordPressDotCom ) {
+		if ( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain ) {
+			const includeWordPressDotCom =
+				this.props.surveyVertical && this.props.includeDotBlogSubdomain ? false : true;
 			const subdomainQuery = {
 				query: domain,
 				quantity: 1,
-				include_wordpressdotcom: true,
-				include_dotblogsubdomain: false,
+				include_wordpressdotcom: includeWordPressDotCom,
+				include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
 				tld_weight_overrides: null,
 				vendor: 'wpcom',
 				vertical: this.props.surveyVertical,
@@ -671,7 +676,7 @@ class RegisterDomainStep extends React.Component {
 
 		let suggestions = reject( this.state.searchResults, matchesSearchedDomain );
 
-		if ( this.props.includeWordPressDotCom ) {
+		if ( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain ) {
 			if ( this.state.loadingSubdomainResults && ! this.state.loadingResults ) {
 				suggestions.unshift( { is_placeholder: true } );
 			} else if ( this.state.subdomainSearchResults && this.state.subdomainSearchResults.length ) {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -145,8 +145,6 @@ class RegisterDomainStep extends React.Component {
 		onSave: noop,
 		onAddMapping: noop,
 		onAddDomain: noop,
-		includeDotBlogSubdomain: true,
-		surveyVertical: 'a8c.12',
 	};
 
 	constructor( props ) {


### PR DESCRIPTION
Depends on D8778-code

Apply the patch, build this branch and browse to: http://calypso.localhost:3000/start/subdomain?vertical=a8c.12

When you get to the domain suggestions page, select the .blog subdomain.

Repeat the process using the same search term on the suggestions page. You should get a .blog subdomain suggestion with a number appended to it.