### PR TITLE
Post Revisions: Use revisions in map of revision id to revision object instead of a sorted list

### DIFF
--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -14,7 +14,7 @@ import { flow, get } from 'lodash';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import {
 	getPostRevisions,
-	getPostRevisionsDiff,
+	getPostRevisionsComparisons,
 	getPostRevisionsAuthorsId,
 	getPostRevisionsSelectedRevisionId,
 } from 'state/selectors';
@@ -82,23 +82,9 @@ export default flow(
 		const postId = getEditorPostId( state );
 		const siteId = getSelectedSiteId( state );
 
-		const revisions = getPostRevisions( state, siteId, postId, 'display' );
+		const revisions = getPostRevisions( state, siteId, postId );
 		const selectedRevisionId = getPostRevisionsSelectedRevisionId( state );
-
-		// @TODO move comparisons to a cached selector
-		const comparisons = {};
-		for ( let i = 0; i < revisions.length; i++ ) {
-			const revisionId = get( revisions, [ i, 'id' ], 0 );
-			const nextRevisionId = revisionId && get( revisions, [ i - 1, 'id' ] );
-			const prevRevisionId = revisionId && get( revisions, [ i + 1, 'id' ] );
-
-			comparisons[ revisionId ] = {
-				diff: getPostRevisionsDiff( state, siteId, postId, prevRevisionId, revisionId ),
-				nextRevisionId,
-				prevRevisionId,
-			};
-		}
-
+		const comparisons = getPostRevisionsComparisons( state, siteId, postId );
 		const selectedDiff = get( comparisons, [ selectedRevisionId, 'diff' ], {} );
 
 		return {

--- a/client/state/posts/revisions/test/reducer.js
+++ b/client/state/posts/revisions/test/reducer.js
@@ -22,8 +22,8 @@ import {
 	SELECTED_SITE_SET,
 } from 'state/action-types';
 
-const TEST_SITE_ID = 999999;
-const TEST_POST_ID = 1776;
+const TEST_SITE_ID = 138211384;
+const TEST_POST_ID = 165;
 
 describe( 'reducer', () => {
 	test( 'should include expected keys in return value', () => {
@@ -39,19 +39,79 @@ describe( 'reducer', () => {
 		const validState = deepFreeze( {
 			[ TEST_SITE_ID ]: {
 				[ TEST_POST_ID ]: {
-					'100:109': {
-						diff: {
-							todo: 'fix this shape',
+					revisions: {
+						168: {
+							post_date_gmt: '2017-12-12 18:24:37Z',
+							post_modified_gmt: '2017-12-12 18:24:37Z',
+							post_author: '20416304',
+							id: 168,
+							post_content: 'This is a super cool test!\nOh rly? Ya rly',
+							post_excerpt: '',
+							post_title: 'Yet Another Awesome Test Post!',
 						},
-						from: 100,
-						to: 109,
+						167: {
+							post_date_gmt: '2017-12-12 18:24:28Z',
+							post_modified_gmt: '2017-12-12 18:24:28Z',
+							post_author: '20416304',
+							id: 167,
+							post_content: 'This is a super cool test!\nOh rly? Ya rly',
+							post_excerpt: '',
+							post_title: 'Yet Another Test Post',
+						},
+						166: {
+							post_date_gmt: '2017-12-12 18:24:18Z',
+							post_modified_gmt: '2017-12-12 18:24:18Z',
+							post_author: '20416304',
+							id: 166,
+							post_content: 'This is a super cool test!',
+							post_excerpt: '',
+							post_title: 'Yet Another Test Post',
+						},
 					},
-					'110:111': {
+
+					'0:166': {
+						from: 0,
+						to: 166,
 						diff: {
-							todo: 'fix this shape',
+							post_title: [
+								{ op: 'del', value: '' },
+								{ op: 'add', value: 'Yet Another Test Post' },
+								{ op: 'copy', value: '\n' },
+							],
+							post_content: [
+								{ op: 'add', value: 'This is a super cool test!' },
+								{ op: 'copy', value: '\n' },
+							],
+							totals: { del: 0, add: 10 },
 						},
-						from: 110,
-						to: 111,
+					},
+					'167:168': {
+						from: 167,
+						to: 168,
+						diff: {
+							post_title: [
+								{ op: 'copy', value: 'Yet Another' },
+								{ op: 'add', value: ' Awesome' },
+								{ op: 'copy', value: ' Test Post' },
+								{ op: 'add', value: '!' },
+								{ op: 'copy', value: '\n' },
+							],
+							post_content: [ { op: 'copy', value: 'This is a super cool test!\nOh rly? Ya rly' } ],
+							totals: { add: 1 },
+						},
+					},
+					'166:167': {
+						from: 166,
+						to: 167,
+						diff: {
+							post_title: [ { op: 'copy', value: 'Yet Another Test Post' } ],
+							post_content: [
+								{ op: 'copy', value: 'This is a super cool test!\n' },
+								{ op: 'add', value: 'Oh rly? Ya rly' },
+								{ op: 'copy', value: '\n' },
+							],
+							totals: { add: 4 },
+						},
 					},
 				},
 			},
@@ -72,6 +132,155 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( validState );
+		} );
+
+		test( 'should merge diff & revisions', () => {
+			const state = diffs( validState, {
+				type: POST_REVISIONS_RECEIVE,
+				siteId: TEST_SITE_ID,
+				postId: TEST_POST_ID,
+				diffs: {
+					'168:169': {
+						from: 168,
+						to: 169,
+						diff: {
+							post_title: [ { op: 'copy', value: 'Yet Another Awesome Test Post!' } ],
+							post_content: [
+								{ op: 'copy', value: 'This is a super ' },
+								{ op: 'add', value: 'duper ' },
+								{ op: 'copy', value: 'cool test!\nOh rly? Ya rly' },
+							],
+							totals: { add: 1 },
+						},
+					},
+				},
+				revisions: {
+					169: {
+						post_date_gmt: '2017-12-14 18:24:37Z',
+						post_modified_gmt: '2017-12-14 18:24:37Z',
+						post_author: '20416304',
+						id: 169,
+						post_content: 'This is a super duper cool test!\nOh rly? Ya rly',
+						post_excerpt: '',
+						post_title: 'Yet Another Awesome Test Post!',
+					},
+					168: {
+						post_date_gmt: '2017-12-12 18:24:37Z',
+						post_modified_gmt: '2017-12-12 18:24:37Z',
+						post_author: '20416304',
+						id: 168,
+						post_content: 'This is a super cool test!\nOh rly? Ya rly',
+						post_excerpt: '',
+						post_title: 'Yet Another Awesome Test Post!',
+					},
+				},
+			} );
+
+			expect( state ).to.eql( {
+				[ TEST_SITE_ID ]: {
+					[ TEST_POST_ID ]: {
+						revisions: {
+							169: {
+								post_date_gmt: '2017-12-14 18:24:37Z',
+								post_modified_gmt: '2017-12-14 18:24:37Z',
+								post_author: '20416304',
+								id: 169,
+								post_content: 'This is a super duper cool test!\nOh rly? Ya rly',
+								post_excerpt: '',
+								post_title: 'Yet Another Awesome Test Post!',
+							},
+							168: {
+								post_date_gmt: '2017-12-12 18:24:37Z',
+								post_modified_gmt: '2017-12-12 18:24:37Z',
+								post_author: '20416304',
+								id: 168,
+								post_content: 'This is a super cool test!\nOh rly? Ya rly',
+								post_excerpt: '',
+								post_title: 'Yet Another Awesome Test Post!',
+							},
+							167: {
+								post_date_gmt: '2017-12-12 18:24:28Z',
+								post_modified_gmt: '2017-12-12 18:24:28Z',
+								post_author: '20416304',
+								id: 167,
+								post_content: 'This is a super cool test!\nOh rly? Ya rly',
+								post_excerpt: '',
+								post_title: 'Yet Another Test Post',
+							},
+							166: {
+								post_date_gmt: '2017-12-12 18:24:18Z',
+								post_modified_gmt: '2017-12-12 18:24:18Z',
+								post_author: '20416304',
+								id: 166,
+								post_content: 'This is a super cool test!',
+								post_excerpt: '',
+								post_title: 'Yet Another Test Post',
+							},
+						},
+
+						'168:169': {
+							from: 168,
+							to: 169,
+							diff: {
+								post_title: [ { op: 'copy', value: 'Yet Another Awesome Test Post!' } ],
+								post_content: [
+									{ op: 'copy', value: 'This is a super ' },
+									{ op: 'add', value: 'duper ' },
+									{ op: 'copy', value: 'cool test!\nOh rly? Ya rly' },
+								],
+								totals: { add: 1 },
+							},
+						},
+
+						'167:168': {
+							from: 167,
+							to: 168,
+							diff: {
+								post_title: [
+									{ op: 'copy', value: 'Yet Another' },
+									{ op: 'add', value: ' Awesome' },
+									{ op: 'copy', value: ' Test Post' },
+									{ op: 'add', value: '!' },
+									{ op: 'copy', value: '\n' },
+								],
+								post_content: [
+									{ op: 'copy', value: 'This is a super cool test!\nOh rly? Ya rly' },
+								],
+								totals: { add: 1 },
+							},
+						},
+						'166:167': {
+							from: 166,
+							to: 167,
+							diff: {
+								post_title: [ { op: 'copy', value: 'Yet Another Test Post' } ],
+								post_content: [
+									{ op: 'copy', value: 'This is a super cool test!\n' },
+									{ op: 'add', value: 'Oh rly? Ya rly' },
+									{ op: 'copy', value: '\n' },
+								],
+								totals: { add: 4 },
+							},
+						},
+						'0:166': {
+							from: 0,
+							to: 166,
+							diff: {
+								post_title: [
+									{ op: 'del', value: '' },
+									{ op: 'add', value: 'Yet Another Test Post' },
+									{ op: 'copy', value: '\n' },
+								],
+								post_content: [
+									{ op: 'add', value: 'This is a super cool test!' },
+									{ op: 'copy', value: '\n' },
+								],
+								totals: { del: 0, add: 10 },
+							},
+						},
+					},
+				},
+			} );
 		} );
 	} );
 

--- a/client/state/selectors/get-post-revision.js
+++ b/client/state/selectors/get-post-revision.js
@@ -3,19 +3,16 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
-import { getPostRevisions } from 'state/selectors';
 
 const getPostRevision = createSelector(
-	( state, siteId, postId, revisionId ) => {
-		const revisions = getPostRevisions( state, siteId, postId );
-		return find( revisions, { id: revisionId } ) || null;
-	},
+	( state, siteId, postId, revisionId ) =>
+		get( state.posts.revisions.diffs, [ siteId, postId, 'revisions', revisionId ], null ),
 	state => [ state.posts.revisions.diffs ]
 );
 

--- a/client/state/selectors/get-post-revisions-comparisons.js
+++ b/client/state/selectors/get-post-revisions-comparisons.js
@@ -1,0 +1,34 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getPostRevisions, getPostRevisionsDiff } from 'state/selectors';
+
+const getPostRevisionsComparisons = createSelector(
+	( state, siteId, postId ) => {
+		const revisions = getPostRevisions( state, siteId, postId );
+
+		const comparisons = {};
+		for ( let i = 0; i < revisions.length; i++ ) {
+			const revisionId = get( revisions, [ i, 'id' ], 0 );
+			const nextRevisionId = revisionId && get( revisions, [ i - 1, 'id' ] );
+			const prevRevisionId = revisionId && get( revisions, [ i + 1, 'id' ] );
+
+			comparisons[ revisionId ] = {
+				diff: getPostRevisionsDiff( state, siteId, postId, prevRevisionId, revisionId ),
+				nextRevisionId,
+				prevRevisionId,
+			};
+		}
+		return comparisons;
+	},
+	state => [ state.posts.revisions.diffs ]
+);
+
+export default getPostRevisionsComparisons;

--- a/client/state/selectors/get-post-revisions.js
+++ b/client/state/selectors/get-post-revisions.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { get, orderBy } from 'lodash';
+import { get, orderBy, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,12 +12,13 @@ import { get, orderBy } from 'lodash';
 import createSelector from 'lib/create-selector';
 
 const getPostRevisions = createSelector(
-	( state, siteId, postId ) =>
-		orderBy(
-			get( state.posts.revisions.diffs, [ siteId, postId, 'revisions' ], {} ),
-			'date',
+	( state, siteId, postId ) => {
+		return orderBy(
+			values( get( state.posts.revisions.diffs, [ siteId, postId, 'revisions' ], {} ) ),
+			'post_modified_gmt',
 			'desc'
-		),
+		);
+	},
 	state => [ state.posts.revisions.diffs ]
 );
 

--- a/client/state/selectors/test/get-post-revisions-comparisons.js
+++ b/client/state/selectors/test/get-post-revisions-comparisons.js
@@ -1,0 +1,117 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getPostRevisionsComparisons from 'state/selectors/get-post-revisions-comparisons';
+
+describe( 'getPostRevisionsComparisons', () => {
+	test( 'should return an empty object if there are no revisions in the state for `siteId, postId`', () => {
+		expect(
+			getPostRevisionsComparisons(
+				{
+					posts: {
+						revisions: {
+							12345678: {
+								10: {
+									revisions: {},
+								},
+							},
+						},
+					},
+				},
+				12345678,
+				10
+			)
+		).to.eql( {} );
+	} );
+
+	test( 'should return a map of revision id to its valid (sequential) comparisons for `siteId, postId`', () => {
+		const selection = getPostRevisionsComparisons(
+			{
+				posts: {
+					revisions: {
+						diffs: {
+							12345678: {
+								10: {
+									'0:13': {
+										diff: {
+											post_content: [ { op: 'add', value: 'older content' } ],
+											post_title: [ { op: 'add', value: 'post title' } ],
+											totals: { add: 4 },
+										},
+										from: 0,
+										to: 13,
+									},
+									'13:22': {
+										diff: {
+											post_content: [
+												{ op: 'copy', value: 'post title' },
+												{ op: 'add', value: '\n\nand newer' },
+											],
+											post_title: [ { op: 'copy', value: 'post title' } ],
+											totals: { add: 2 },
+										},
+										from: 13,
+										to: 22,
+									},
+									revisions: {
+										13: {
+											post_date_gmt: '2017-11-15 18:13:49Z',
+											post_modified_gmt: '2017-11-15 18:13:49Z',
+											post_author: '20416304',
+											id: 13,
+											post_content: 'older content',
+											post_excerpt: '',
+											post_title: 'test post',
+										},
+										22: {
+											post_date_gmt: '2017-12-13 00:12:10Z',
+											post_modified_gmt: '2017-12-13 00:12:10Z',
+											post_author: '20416304',
+											id: 22,
+											post_content: 'older content\n\nand newer!',
+											post_excerpt: '',
+											post_title: 'test post',
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			12345678,
+			10
+		);
+
+		expect( selection ).to.eql( {
+			13: {
+				diff: {
+					post_content: [ { op: 'add', value: 'older content' } ],
+					post_title: [ { op: 'add', value: 'post title' } ],
+					totals: { add: 4 },
+				},
+				nextRevisionId: 22,
+				prevRevisionId: undefined,
+			},
+			22: {
+				diff: {
+					post_content: [
+						{ op: 'copy', value: 'post title' },
+						{ op: 'add', value: '\n\nand newer' },
+					],
+					post_title: [ { op: 'copy', value: 'post title' } ],
+					totals: { add: 2 },
+				},
+				nextRevisionId: undefined,
+				prevRevisionId: 13,
+			},
+		} );
+	} );
+} );

--- a/client/state/selectors/test/get-post-revisions.js
+++ b/client/state/selectors/test/get-post-revisions.js
@@ -17,11 +17,9 @@ describe( 'getPostRevisions', () => {
 				{
 					posts: {
 						revisions: {
-							diffs: {
-								12345678: {
-									10: {
-										revisions: {},
-									},
+							12345678: {
+								10: {
+									revisions: {},
 								},
 							},
 						},
@@ -33,7 +31,7 @@ describe( 'getPostRevisions', () => {
 		).to.eql( [] );
 	} );
 
-	test( 'should return an array of post revisions', () => {
+	test( 'should return a sorted array of revisions', () => {
 		expect(
 			getPostRevisions(
 				{
@@ -42,15 +40,26 @@ describe( 'getPostRevisions', () => {
 							diffs: {
 								12345678: {
 									10: {
-										revisions: [
-											{
-												'11:12': {
-													id: 11,
-													post_author: 99499,
-													post_title: 'Badman <img onerror= />',
-												},
+										revisions: {
+											168: {
+												post_date_gmt: '2017-12-12 18:24:37Z',
+												post_modified_gmt: '2017-12-12 18:24:37Z',
+												post_author: '20416304',
+												id: 168,
+												post_content: 'This is a super cool test!\nOh rly? Ya rly',
+												post_excerpt: '',
+												post_title: 'Yet Another Awesome Test Post!',
 											},
-										],
+											169: {
+												post_date_gmt: '2017-12-14 18:24:37Z',
+												post_modified_gmt: '2017-12-14 18:24:37Z',
+												post_author: '20416304',
+												id: 169,
+												post_content: 'This is a super duper cool test!\nOh rly? Ya rly',
+												post_excerpt: '',
+												post_title: 'Yet Another Awesome Test Post!',
+											},
+										},
 									},
 								},
 							},
@@ -65,11 +74,22 @@ describe( 'getPostRevisions', () => {
 			)
 		).to.eql( [
 			{
-				'11:12': {
-					id: 11,
-					post_author: 99499,
-					post_title: 'Badman <img onerror= />',
-				},
+				post_date_gmt: '2017-12-14 18:24:37Z',
+				post_modified_gmt: '2017-12-14 18:24:37Z',
+				post_author: '20416304',
+				id: 169,
+				post_content: 'This is a super duper cool test!\nOh rly? Ya rly',
+				post_excerpt: '',
+				post_title: 'Yet Another Awesome Test Post!',
+			},
+			{
+				post_date_gmt: '2017-12-12 18:24:37Z',
+				post_modified_gmt: '2017-12-12 18:24:37Z',
+				post_author: '20416304',
+				id: 168,
+				post_content: 'This is a super cool test!\nOh rly? Ya rly',
+				post_excerpt: '',
+				post_title: 'Yet Another Awesome Test Post!',
 			},
 		] );
 	} );


### PR DESCRIPTION
Note, this is targeting the branch in #20573.  We can merge there once the API diff is deployed.

## To Test

### Manual

* Apply patch in D8780
* Sandbox the API
* Run this branch
* The history feature should "still work"

### Automated

`npm run test-client:watch client/state/posts/revisions client/state/selectors/test/*revision*`