### PR TITLE
Store Orders: Enable saving of new orders

### DIFF
--- a/client/extensions/woocommerce/app/order/create.js
+++ b/client/extensions/woocommerce/app/order/create.js
@@ -55,12 +55,12 @@ class Order extends Component {
 		const { site, siteId, order, translate } = this.props;
 		const onSuccess = ( dispatch, orderId ) => {
 			dispatch(
-				successNotice( translate( 'Order saved.' ), { duration: 5000, displayOnNextPage: true } )
+				successNotice( translate( 'Order created.' ), { duration: 5000, displayOnNextPage: true } )
 			);
 			page.redirect( getLink( `/store/order/:site/${ orderId }`, site ) );
 		};
 		const onFailure = dispatch => {
-			dispatch( errorNotice( translate( 'Unable to save order.' ), { duration: 5000 } ) );
+			dispatch( errorNotice( translate( 'Unable to create order.' ), { duration: 5000 } ) );
 		};
 
 		this.props.saveOrder( siteId, order, onSuccess, onFailure );

--- a/client/extensions/woocommerce/app/order/create.js
+++ b/client/extensions/woocommerce/app/order/create.js
@@ -73,7 +73,7 @@ class Order extends Component {
 						primary
 						onClick={ this.saveOrder }
 						busy={ isSaving }
-						disabled={ ! hasOrderEdits }
+						disabled={ ! hasOrderEdits || isSaving }
 					>
 						{ translate( 'Save Order' ) }
 					</Button>

--- a/client/extensions/woocommerce/app/order/create.js
+++ b/client/extensions/woocommerce/app/order/create.js
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -15,6 +16,7 @@ import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 import { clearOrderEdits, editOrder } from 'woocommerce/state/ui/orders/actions';
 import { saveOrder } from 'woocommerce/state/sites/orders/actions';
+import { errorNotice, successNotice } from 'state/notices/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import {
@@ -50,8 +52,18 @@ class Order extends Component {
 
 	// Saves changes to the remote site via API
 	saveOrder = () => {
-		const { siteId, order } = this.props;
-		this.props.saveOrder( siteId, order );
+		const { site, siteId, order, translate } = this.props;
+		const onSuccess = ( dispatch, orderId ) => {
+			dispatch(
+				successNotice( translate( 'Order saved.' ), { duration: 5000, displayOnNextPage: true } )
+			);
+			page.redirect( getLink( `/store/order/:site/${ orderId }`, site ) );
+		};
+		const onFailure = dispatch => {
+			dispatch( errorNotice( translate( 'Unable to save order.' ), { duration: 5000 } ) );
+		};
+
+		this.props.saveOrder( siteId, order, onSuccess, onFailure );
 	};
 
 	render() {

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -128,7 +128,7 @@ class Order extends Component {
 				primary
 				onClick={ this.saveOrder }
 				busy={ isSaving }
-				disabled={ ! hasOrderEdits }
+				disabled={ ! hasOrderEdits || isSaving }
 			>
 				{ translate( 'Save Order' ) }
 			</Button>,

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -15,6 +15,7 @@ import React, { Component } from 'react';
 import ActionHeader from 'woocommerce/components/action-header';
 import Button from 'components/button';
 import { clearOrderEdits, editOrder } from 'woocommerce/state/ui/orders/actions';
+import { errorNotice, successNotice } from 'state/notices/actions';
 import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
 import { fetchOrder, saveOrder } from 'woocommerce/state/sites/orders/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
@@ -84,9 +85,16 @@ class Order extends Component {
 
 	// Saves changes to the remote site via API
 	saveOrder = () => {
-		const { siteId, order } = this.props;
+		const { siteId, order, translate } = this.props;
+		const onSuccess = dispatch => {
+			dispatch( successNotice( translate( 'Order saved.' ), { duration: 5000 } ) );
+		};
+		const onFailure = dispatch => {
+			dispatch( errorNotice( translate( 'Unable to save order.' ), { duration: 5000 } ) );
+		};
+
 		recordTrack( 'calypso_woocommerce_order_edit_save' );
-		this.props.saveOrder( siteId, order );
+		this.props.saveOrder( siteId, order, onSuccess, onFailure );
 	};
 
 	render() {

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { isNumber, omitBy } from 'lodash';
+import { isFinite, omitBy } from 'lodash';
 import qs from 'querystring';
 
 /**
@@ -73,7 +73,7 @@ export function receivedOrder( { dispatch }, action, { data } ) {
 
 export function sendOrder( { dispatch }, action ) {
 	const { siteId, orderId, order } = action;
-	if ( isNumber( orderId ) ) {
+	if ( isFinite( orderId ) ) {
 		dispatch( request( siteId, action ).post( `orders/${ orderId }`, order ) );
 	} else {
 		dispatch( request( siteId, action ).post( 'orders', order ) );

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { omitBy } from 'lodash';
+import { isNumber, omitBy } from 'lodash';
 import qs from 'querystring';
 
 /**
@@ -75,7 +75,11 @@ export function receivedOrder( { dispatch }, action, { data } ) {
 
 export function sendOrder( { dispatch }, action ) {
 	const { siteId, orderId, order } = action;
-	dispatch( request( siteId, action ).post( `orders/${ orderId }`, order ) );
+	if ( isNumber( orderId ) ) {
+		dispatch( request( siteId, action ).post( `orders/${ orderId }`, order ) );
+	} else {
+		dispatch( request( siteId, action ).post( 'orders', order ) );
+	}
 }
 
 export function onOrderSaveSuccess( { dispatch }, action, { data } ) {

--- a/client/extensions/woocommerce/state/data-layer/orders/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/index.js
@@ -19,8 +19,6 @@ import {
 	updateOrders,
 } from 'woocommerce/state/sites/orders/actions';
 import request from 'woocommerce/state/sites/http-request';
-import { successNotice, errorNotice } from 'state/notices/actions';
-import { translate } from 'i18n-calypso';
 import {
 	WOOCOMMERCE_ORDER_REQUEST,
 	WOOCOMMERCE_ORDER_UPDATE,
@@ -84,13 +82,18 @@ export function sendOrder( { dispatch }, action ) {
 
 export function onOrderSaveSuccess( { dispatch }, action, { data } ) {
 	const { siteId, orderId } = action;
-	dispatch( successNotice( translate( 'Order saved.' ), { duration: 5000 } ) );
+	// Make sure we have a success function, and a new order ID
+	if ( 'function' === typeof action.onSuccess && 'undefined' !== typeof data.id ) {
+		action.onSuccess( dispatch, data.id );
+	}
 	dispatch( saveOrderSuccess( siteId, orderId, data ) );
 }
 
 export function onOrderSaveFailure( { dispatch }, action, error ) {
 	const { siteId, orderId } = action;
+	if ( 'function' === typeof action.onFailure ) {
+		action.onFailure( dispatch );
+	}
 	debug( 'API Error: ', error );
-	dispatch( errorNotice( translate( 'Unable to save order.' ), { duration: 5000 } ) );
 	dispatch( saveOrderError( siteId, orderId, error ) );
 }

--- a/client/extensions/woocommerce/state/data-layer/orders/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/test/index.js
@@ -323,7 +323,24 @@ describe( 'handlers', () => {
 				} )
 			);
 		} );
+
+		test( 'should call the onSuccess callback for a successful orders save', () => {
+			const dispatch = spy();
+			const order = { id: 42, total: '50.00' };
+			const action = saveOrderSuccess( 123, 42, order );
+			action.onSuccess = localDispatch => {
+				localDispatch( { type: NOTICE_CREATE, notice: {} } );
+			};
+
+			onOrderSaveSuccess( { dispatch }, action, { data: order } );
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: NOTICE_CREATE,
+				} )
+			);
+		} );
 	} );
+
 	describe( '#onOrderSaveFailure', () => {
 		test( 'should dispatch a failure action on a failed orders save', () => {
 			const dispatch = spy();
@@ -337,15 +354,30 @@ describe( 'handlers', () => {
 			onOrderSaveFailure( { dispatch }, action, response );
 			expect( dispatch ).to.have.been.calledWithMatch(
 				match( {
-					type: NOTICE_CREATE,
-				} )
-			);
-			expect( dispatch ).to.have.been.calledWithMatch(
-				match( {
 					type: WOOCOMMERCE_ORDER_UPDATE_FAILURE,
 					siteId: 123,
 					orderId: 1,
 					error: response,
+				} )
+			);
+		} );
+
+		test( 'should call the onFailure callback for a failed orders save', () => {
+			const dispatch = spy();
+			const response = {
+				code: 'rest_no_route',
+				data: { status: 404 },
+				message: 'No route was found matching the URL and request method',
+			};
+			const action = saveOrderError( 123, 1, response );
+			action.onFailure = localDispatch => {
+				localDispatch( { type: NOTICE_CREATE, notice: {} } );
+			};
+
+			onOrderSaveFailure( { dispatch }, action, response );
+			expect( dispatch ).to.have.been.calledWithMatch(
+				match( {
+					type: NOTICE_CREATE,
 				} )
 			);
 		} );

--- a/client/extensions/woocommerce/state/data-layer/orders/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/test/index.js
@@ -223,7 +223,7 @@ describe( 'handlers', () => {
 	} );
 
 	describe( '#sendOrder', () => {
-		test( 'should dispatch a post action', () => {
+		test( 'should dispatch a post action to this order ID', () => {
 			const dispatch = spy();
 			const order = {
 				id: 1,
@@ -244,6 +244,37 @@ describe( 'handlers', () => {
 							json: true,
 							path: '/wc/v3/orders/1&_method=POST',
 							body: JSON.stringify( { status: 'completed', total: '50.00' } ),
+						},
+						query: {
+							json: true,
+						},
+					},
+					action
+				)
+			);
+		} );
+
+		test( 'should dispatch a post action to the generic orders endpoint', () => {
+			const dispatch = spy();
+			const order = {
+				id: { placeholder: 'order_id' },
+				status: 'processing',
+				total: '25.00',
+			};
+			const action = saveOrder( 123, order );
+			sendOrder( { dispatch }, action );
+
+			expect( dispatch ).to.have.been.calledOnce;
+			expect( dispatch ).to.have.been.calledWith(
+				http(
+					{
+						method: 'POST',
+						path: '/jetpack-blogs/123/rest-api/',
+						apiVersion: '1.1',
+						body: {
+							json: true,
+							path: '/wc/v3/orders&_method=POST',
+							body: JSON.stringify( { status: 'processing', total: '25.00' } ),
 						},
 						query: {
 							json: true,

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { isArray } from 'lodash';
+import { isArray, noop } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -91,7 +91,12 @@ export const updateOrder = ( siteId, orderId, order ) => {
 	};
 };
 
-export const saveOrder = ( siteId, { id: orderId, ...order }, onSuccess, onFailure ) => {
+export const saveOrder = (
+	siteId,
+	{ id: orderId, ...order },
+	onSuccess = noop,
+	onFailure = noop
+) => {
 	order = transformOrderForApi( removeTemporaryIds( order ) );
 	return {
 		type: WOOCOMMERCE_ORDER_UPDATE,

--- a/client/extensions/woocommerce/state/sites/orders/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/actions.js
@@ -91,13 +91,15 @@ export const updateOrder = ( siteId, orderId, order ) => {
 	};
 };
 
-export const saveOrder = ( siteId, { id: orderId, ...order } ) => {
+export const saveOrder = ( siteId, { id: orderId, ...order }, onSuccess, onFailure ) => {
 	order = transformOrderForApi( removeTemporaryIds( order ) );
 	return {
 		type: WOOCOMMERCE_ORDER_UPDATE,
 		siteId,
 		orderId,
 		order,
+		onFailure,
+		onSuccess,
 	};
 };
 

--- a/client/extensions/woocommerce/state/sites/orders/reducer.js
+++ b/client/extensions/woocommerce/state/sites/orders/reducer.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { isNumber, keyBy, omit } from 'lodash';
+import { isFinite, keyBy, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -78,7 +78,7 @@ export function isQueryLoading( state = {}, action ) {
  * @return {Object}        Updated state
  */
 export function isUpdating( state = {}, action ) {
-	const orderId = isNumber( action.orderId ) ? action.orderId : JSON.stringify( action.orderId );
+	const orderId = isFinite( action.orderId ) ? action.orderId : JSON.stringify( action.orderId );
 	switch ( action.type ) {
 		case WOOCOMMERCE_ORDER_UPDATE:
 		case WOOCOMMERCE_ORDER_UPDATE_SUCCESS:

--- a/client/extensions/woocommerce/state/sites/orders/reducer.js
+++ b/client/extensions/woocommerce/state/sites/orders/reducer.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { keyBy, omit } from 'lodash';
+import { isNumber, keyBy, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -78,12 +78,13 @@ export function isQueryLoading( state = {}, action ) {
  * @return {Object}        Updated state
  */
 export function isUpdating( state = {}, action ) {
+	const orderId = isNumber( action.orderId ) ? action.orderId : JSON.stringify( action.orderId );
 	switch ( action.type ) {
 		case WOOCOMMERCE_ORDER_UPDATE:
 		case WOOCOMMERCE_ORDER_UPDATE_SUCCESS:
 		case WOOCOMMERCE_ORDER_UPDATE_FAILURE:
 			return Object.assign( {}, state, {
-				[ action.orderId ]: WOOCOMMERCE_ORDER_UPDATE === action.type,
+				[ orderId ]: WOOCOMMERCE_ORDER_UPDATE === action.type,
 			} );
 		default:
 			return state;
@@ -105,7 +106,7 @@ export function items( state = {}, action ) {
 			return Object.assign( {}, state, orders );
 		case WOOCOMMERCE_ORDER_REQUEST_SUCCESS:
 		case WOOCOMMERCE_ORDER_UPDATE_SUCCESS:
-			orders = { [ action.orderId ]: action.order };
+			orders = { [ action.order.id ]: action.order };
 			return Object.assign( {}, state, orders );
 		default:
 			return state;

--- a/client/extensions/woocommerce/state/sites/orders/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/selectors.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { get, filter, omit, sumBy } from 'lodash';
+import { filter, get, isNumber, omit, sumBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -101,6 +101,9 @@ export const isOrderLoading = ( state, orderId, siteId = getSelectedSiteId( stat
  * @return {boolean} Whether this order is currently being updated on the server
  */
 export const isOrderUpdating = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
+	if ( ! isNumber( orderId ) ) {
+		orderId = JSON.stringify( orderId );
+	}
 	const isUpdating = get( state, [
 		'extensions',
 		'woocommerce',

--- a/client/extensions/woocommerce/state/sites/orders/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/selectors.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { filter, get, isNumber, omit, sumBy } from 'lodash';
+import { filter, get, isFinite, omit, sumBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -101,7 +101,7 @@ export const isOrderLoading = ( state, orderId, siteId = getSelectedSiteId( stat
  * @return {boolean} Whether this order is currently being updated on the server
  */
 export const isOrderUpdating = ( state, orderId, siteId = getSelectedSiteId( state ) ) => {
-	if ( ! isNumber( orderId ) ) {
+	if ( ! isFinite( orderId ) ) {
 		orderId = JSON.stringify( orderId );
 	}
 	const isUpdating = get( state, [

--- a/client/extensions/woocommerce/state/sites/orders/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/actions.js
@@ -107,7 +107,7 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( '#updateOrder()', () => {
+	describe( '#saveOrder()', () => {
 		const siteId = 123;
 		const updatedOrder = {
 			id: 40,
@@ -141,6 +141,35 @@ describe( 'actions', () => {
 				siteId: 234,
 				orderId: 1,
 				error: 'Error object',
+			} );
+		} );
+	} );
+
+	describe( '#saveOrder() - new order', () => {
+		const siteId = 123;
+		const newOrder = {
+			id: { placeholder: 'order_1' },
+			status: 'processing',
+		};
+
+		test( 'should dispatch an action', () => {
+			const action = saveOrder( siteId, newOrder );
+			expect( action ).to.eql( {
+				type: WOOCOMMERCE_ORDER_UPDATE,
+				siteId: 123,
+				orderId: { placeholder: 'order_1' },
+				order: { status: 'processing' },
+			} );
+		} );
+
+		test( 'should dispatch a success action with the order when request completes', () => {
+			const updatedOrder = { ...newOrder, id: 42 };
+			const action = saveOrderSuccess( siteId, { placeholder: 'order_1' }, updatedOrder );
+			expect( action ).to.eql( {
+				type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
+				siteId: 123,
+				orderId: { placeholder: 'order_1' },
+				order: { id: 42, status: 'processing' },
 			} );
 		} );
 	} );

--- a/client/extensions/woocommerce/state/sites/orders/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/actions.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -115,12 +116,14 @@ describe( 'actions', () => {
 		};
 
 		test( 'should dispatch an action', () => {
-			const action = saveOrder( siteId, updatedOrder );
+			const action = saveOrder( siteId, updatedOrder, noop, noop );
 			expect( action ).to.eql( {
 				type: WOOCOMMERCE_ORDER_UPDATE,
 				siteId: 123,
 				orderId: 40,
 				order: { status: 'completed' },
+				onFailure: noop,
+				onSuccess: noop,
 			} );
 		} );
 
@@ -153,12 +156,14 @@ describe( 'actions', () => {
 		};
 
 		test( 'should dispatch an action', () => {
-			const action = saveOrder( siteId, newOrder );
+			const action = saveOrder( siteId, newOrder, noop, noop );
 			expect( action ).to.eql( {
 				type: WOOCOMMERCE_ORDER_UPDATE,
 				siteId: 123,
 				orderId: { placeholder: 'order_1' },
 				order: { status: 'processing' },
+				onFailure: noop,
+				onSuccess: noop,
 			} );
 		} );
 

--- a/client/extensions/woocommerce/state/sites/orders/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/orders/test/reducer.js
@@ -148,6 +148,27 @@ describe( 'reducer', () => {
 			const newState = isUpdating( { 45: true }, action );
 			expect( newState ).to.eql( { 45: false } );
 		} );
+
+		test( 'should store that a new order is being created', () => {
+			const action = {
+				type: WOOCOMMERCE_ORDER_UPDATE,
+				siteId: 123,
+				orderId: { placeholder: 'order_2' },
+			};
+			const newState = isUpdating( undefined, action );
+			expect( newState ).to.eql( { '{"placeholder":"order_2"}': true } );
+		} );
+
+		test( 'should show that a new order is created after success', () => {
+			const action = {
+				type: WOOCOMMERCE_ORDER_UPDATE_SUCCESS,
+				siteId: 123,
+				orderId: { placeholder: 'order_2' },
+				order,
+			};
+			const newState = isUpdating( { '{"placeholder":"order_2"}': true }, action );
+			expect( newState ).to.eql( { '{"placeholder":"order_2"}': false } );
+		} );
 	} );
 
 	describe( 'items', () => {

--- a/client/extensions/woocommerce/state/sites/orders/utils.js
+++ b/client/extensions/woocommerce/state/sites/orders/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { forEach, isEmpty, isNumber, omit, omitBy } from 'lodash';
+import { forEach, isEmpty, isFinite, omit, omitBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -57,7 +57,7 @@ export function removeTemporaryIds( order ) {
 	for ( const type of [ 'line_items', 'fee_lines', 'coupon_lines', 'shipping_lines' ] ) {
 		if ( order[ type ] ) {
 			newOrder[ type ] = order[ type ].map( item => {
-				if ( ! isNumber( item.id ) ) {
+				if ( ! isFinite( item.id ) ) {
 					return omit( item, 'id' );
 				}
 				return item;
@@ -85,7 +85,7 @@ export function transformOrderForApi( order ) {
 		'total_tax',
 	];
 	forEach( totalsAndTaxes, key => {
-		if ( isNumber( order[ key ] ) || order[ key ] ) {
+		if ( isFinite( order[ key ] ) || order[ key ] ) {
 			order[ key ] = getCurrencyFormatString( order[ key ], order.currency );
 		}
 	} );
@@ -93,22 +93,22 @@ export function transformOrderForApi( order ) {
 	const transformOrderData = ( data, strings = [], prices = [], integers = [], floats = [] ) => {
 		return data.map( line => {
 			forEach( strings, key => {
-				if ( isNumber( line[ key ] ) || line[ key ] ) {
+				if ( isFinite( line[ key ] ) || line[ key ] ) {
 					line[ key ] = line[ key ].toString();
 				}
 			} );
 			forEach( prices, key => {
-				if ( isNumber( line[ key ] ) || line[ key ] ) {
+				if ( isFinite( line[ key ] ) || line[ key ] ) {
 					line[ key ] = getCurrencyFormatString( line[ key ], order.currency );
 				}
 			} );
 			forEach( integers, key => {
-				if ( isNumber( line[ key ] ) || line[ key ] ) {
+				if ( isFinite( line[ key ] ) || line[ key ] ) {
 					line[ key ] = parseInt( line[ key ] );
 				}
 			} );
 			forEach( floats, key => {
-				if ( isNumber( line[ key ] ) || line[ key ] ) {
+				if ( isFinite( line[ key ] ) || line[ key ] ) {
 					line[ key ] = getCurrencyFormatDecimal( line[ key ], order.currency );
 				}
 			} );


### PR DESCRIPTION
When saving a new order, the order needs to be sent to a generic `/orders` endpoint (rather than the `orders/:id` endpoint for updating). This PR updates `sendOrder` to be context-aware, if the order saved has a placeholder ID, it's sent to the ID-less creation endpoint.

Two other changes in this PR:

- Enable UPDATE actions to save placeholder orders, so that we can check the isSaving status of new orders
- Switch to passing onSuccess and onFailure callbacks through the `saveOrder` function, so that we can trigger different behavior after saving a new order vs updating an existing one – the major difference being new orders need a page redirect, existing orders don't.

**To test**

- Visit `/store/order/:site` to create an order
- Fill out some info - nothing is required yet, I think, so fill in as much or as little as you want
- Save your order
- Should redirect to the single view of your just-created order, with a success message
- Trigger an error state by deactivating wc-api-dev (or interfering with the API in some other way)
- Try to save, you should see an error notice and your changes should stay on screen in the pending edit state

Make sure the tests still pass:

`npm run test-client client/extensions/woocommerce`

See #15679 