### PR TITLE
Store: Settings: Display: Notices: Add read-only view of settings

### DIFF
--- a/client/extensions/woocommerce/app/settings/display/display-header.js
+++ b/client/extensions/woocommerce/app/settings/display/display-header.js
@@ -6,7 +6,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,7 +13,6 @@ import { localize } from 'i18n-calypso';
  */
 import ActionHeader from 'woocommerce/components/action-header';
 import { getLink } from 'woocommerce/lib/nav-utils';
-import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import SettingsNavigation from '../navigation';
 
 const SettingsDisplayHeader = ( { translate, site } ) => {
@@ -34,13 +32,7 @@ SettingsDisplayHeader.propTypes = {
 	site: PropTypes.shape( {
 		slug: PropTypes.string,
 	} ),
+	translate: PropTypes.func,
 };
 
-function mapStateToProps( state ) {
-	const site = getSelectedSiteWithFallback( state );
-	return {
-		site,
-	};
-}
-
-export default connect( mapStateToProps )( localize( SettingsDisplayHeader ) );
+export default localize( SettingsDisplayHeader );

--- a/client/extensions/woocommerce/app/settings/display/display-header.js
+++ b/client/extensions/woocommerce/app/settings/display/display-header.js
@@ -1,0 +1,46 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ActionHeader from 'woocommerce/components/action-header';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import SettingsNavigation from '../navigation';
+
+const SettingsDisplayHeader = ( { translate, site } ) => {
+	const breadcrumbs = [
+		<a href={ getLink( '/store/settings/:site/', site ) }>{ translate( 'Settings' ) }</a>,
+		<span>{ translate( 'Display' ) }</span>,
+	];
+	return (
+		<div>
+			<ActionHeader breadcrumbs={ breadcrumbs } />
+			<SettingsNavigation activeSection="display" />
+		</div>
+	);
+};
+
+SettingsDisplayHeader.propTypes = {
+	site: PropTypes.shape( {
+		slug: PropTypes.string,
+	} ),
+};
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	return {
+		site,
+	};
+}
+
+export default connect( mapStateToProps )( localize( SettingsDisplayHeader ) );

--- a/client/extensions/woocommerce/app/settings/display/display-notice-preview.js
+++ b/client/extensions/woocommerce/app/settings/display/display-notice-preview.js
@@ -33,7 +33,7 @@ const SettingsDisplayNoticePreview = ( { translate, value } ) => {
 				</div>
 			</BrowserFrame>
 			<p className="display__notice-preview-caveat">
-				{ translate( 'Caveat: Styling dependent on theme' ) }
+				{ translate( 'Note: Overall look may vary based on theme.' ) }
 			</p>
 		</div>
 	);

--- a/client/extensions/woocommerce/app/settings/display/display-notice-preview.js
+++ b/client/extensions/woocommerce/app/settings/display/display-notice-preview.js
@@ -5,23 +5,36 @@
  */
 
 import React from 'react';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import BrowserFrame from 'woocommerce/components/browser-frame';
+import { decodeEntities } from 'lib/formatting';
+import striptags from 'striptags';
 
-const SettingsDisplayNoticePreview = ( { value } ) => {
+const SettingsDisplayNoticePreview = ( { translate, value } ) => {
+	const notice = striptags( decodeEntities( value ) );
+
 	return (
 		<div className="display__notice-preview">
+			<h4>{ translate( 'Preview' ) }</h4>
 			<BrowserFrame>
-				<div className="display__notice-preview-notice">{ value }</div>
+				<div className="display__notice-preview-notice">{ notice }</div>
 				<div className="display__notice-preview-content">
-					<div className="display__notice-preview-content-primary" />
-					<div className="display__notice-preview-content-secondary" />
+					<div className="display__notice-preview-content-primary">
+						<div />
+					</div>
+					<div className="display__notice-preview-content-secondary">
+						<div />
+					</div>
 				</div>
 			</BrowserFrame>
+			<p className="display__notice-preview-caveat">
+				{ translate( 'Caveat: Styling dependent on theme' ) }
+			</p>
 		</div>
 	);
 };
@@ -30,4 +43,4 @@ SettingsDisplayNoticePreview.propTypes = {
 	value: PropTypes.string,
 };
 
-export default SettingsDisplayNoticePreview;
+export default localize( SettingsDisplayNoticePreview );

--- a/client/extensions/woocommerce/app/settings/display/display-notice-preview.js
+++ b/client/extensions/woocommerce/app/settings/display/display-notice-preview.js
@@ -1,0 +1,33 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import BrowserFrame from 'woocommerce/components/browser-frame';
+
+const SettingsDisplayNoticePreview = ( { value } ) => {
+	return (
+		<div className="display__notice-preview">
+			<BrowserFrame>
+				<div className="display__notice-preview-notice">{ value }</div>
+				<div className="display__notice-preview-content">
+					<div className="display__notice-preview-content-primary" />
+					<div className="display__notice-preview-content-secondary" />
+				</div>
+			</BrowserFrame>
+		</div>
+	);
+};
+
+SettingsDisplayNoticePreview.propTypes = {
+	value: PropTypes.string,
+};
+
+export default SettingsDisplayNoticePreview;

--- a/client/extensions/woocommerce/app/settings/display/display-notice.js
+++ b/client/extensions/woocommerce/app/settings/display/display-notice.js
@@ -1,0 +1,107 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { areSettingsGeneralLoaded } from 'woocommerce/state/sites/settings/general/selectors';
+import Card from 'components/card';
+import CompactTinyMCE from 'woocommerce/components/compact-tinymce';
+import ExtendedHeader from 'woocommerce/components/extended-header';
+import FormCheckbox from 'components/forms/form-checkbox';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
+import SettingsDisplayNoticePreview from './display-notice-preview';
+
+class SettingsDisplayNotice extends Component {
+	static propTypes = {
+		settingsGeneralLoaded: PropTypes.bool,
+		siteId: PropTypes.number.isRequired,
+	};
+
+	renderPlaceholder = () => {
+		return (
+			<div>
+				<div className="display__notice-enabled-container placeholder" />
+				<div className="display__notice-wysiwyg">
+					<div className="display__notice-editor-container placeholder" />
+					<div className="display__notice-preview-container placeholder" />
+				</div>
+			</div>
+		);
+	};
+
+	renderForm = () => {
+		const { translate } = this.props;
+
+		// TODO - hook up to woocommerce_demo_store (boolean) and woocommerce_demo_store_notice (string) in state
+		const storeNoticeEnabled = true;
+		const storeNotice =
+			'This is a demo store for testing purposes only &ndash; no orders shall be fulfilled.';
+
+		return (
+			<div>
+				<FormFieldset className="display__notice-enabled-container">
+					<FormLabel>
+						<FormCheckbox
+							checked={ storeNoticeEnabled }
+							name="storeNoticeEnabled"
+							onChange={ noop }
+						/>
+						<span>{ translate( 'Display the store notice' ) }</span>
+					</FormLabel>
+				</FormFieldset>
+				<div className="display__notice-wysiwyg">
+					<div className="display__notice-editor-container">
+						<h4>{ translate( 'Store notice content' ) }</h4>
+						<CompactTinyMCE initialValue={ storeNotice } onContentsChange={ noop } />
+					</div>
+					<div className="display__notice-preview-container">
+						<h4>{ translate( 'Preview' ) }</h4>
+						<SettingsDisplayNoticePreview value={ storeNotice } />
+					</div>
+				</div>
+			</div>
+		);
+	};
+
+	render = () => {
+		const { settingsGeneralLoaded, siteId, translate } = this.props;
+		return (
+			<div className="display__notice">
+				<ExtendedHeader
+					label={ translate( 'Store Notice' ) }
+					description={ translate(
+						'Display a site-wide notice to inform / engage with customers or highlight promotions.'
+					) }
+				/>
+				<Card className="display__notice-card">
+					{ settingsGeneralLoaded ? this.renderForm() : this.renderPlaceholder() }
+				</Card>
+				<QuerySettingsGeneral siteId={ siteId } />
+			</div>
+		);
+	};
+}
+
+function mapStateToProps( state, ownProps ) {
+	const { siteId } = ownProps;
+
+	const settingsGeneralLoaded = areSettingsGeneralLoaded( state, siteId );
+
+	return {
+		settingsGeneralLoaded,
+	};
+}
+
+export default localize( connect( mapStateToProps )( SettingsDisplayNotice ) );

--- a/client/extensions/woocommerce/app/settings/display/display-notice.js
+++ b/client/extensions/woocommerce/app/settings/display/display-notice.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -24,9 +23,24 @@ import QuerySettingsGeneral from 'woocommerce/components/query-settings-general'
 import SettingsDisplayNoticePreview from './display-notice-preview';
 
 class SettingsDisplayNotice extends Component {
+	constructor( props ) {
+		super( props );
+
+		// TODO - hook up to woocommerce_demo_store (boolean) and woocommerce_demo_store_notice (string) from redux
+		this.state = {
+			storeNoticeEnabled: true,
+			storeNotice: 'Buy a <a href="#">whoosit</a> today &ndash; you are going to love it.',
+		};
+	}
+
 	static propTypes = {
 		settingsGeneralLoaded: PropTypes.bool,
 		siteId: PropTypes.number.isRequired,
+		translate: PropTypes.func,
+	};
+
+	onContentsChange = storeNotice => {
+		this.setState( { storeNotice } );
 	};
 
 	renderPlaceholder = () => {
@@ -41,13 +55,30 @@ class SettingsDisplayNotice extends Component {
 		);
 	};
 
+	possiblyRenderWYSIWYG = () => {
+		const { translate } = this.props;
+		const { storeNoticeEnabled, storeNotice } = this.state;
+
+		if ( ! storeNoticeEnabled ) {
+			return null;
+		}
+
+		return (
+			<div className="display__notice-wysiwyg">
+				<div className="display__notice-editor-container">
+					<h4>{ translate( 'Store notice content' ) }</h4>
+					<CompactTinyMCE initialValue={ storeNotice } onContentsChange={ this.onContentsChange } />
+				</div>
+				<div className="display__notice-preview-container">
+					<SettingsDisplayNoticePreview value={ storeNotice } />
+				</div>
+			</div>
+		);
+	};
+
 	renderForm = () => {
 		const { translate } = this.props;
-
-		// TODO - hook up to woocommerce_demo_store (boolean) and woocommerce_demo_store_notice (string) in state
-		const storeNoticeEnabled = true;
-		const storeNotice =
-			'This is a demo store for testing purposes only &ndash; no orders shall be fulfilled.';
+		const { storeNoticeEnabled } = this.state;
 
 		return (
 			<div>
@@ -61,16 +92,7 @@ class SettingsDisplayNotice extends Component {
 						<span>{ translate( 'Display the store notice' ) }</span>
 					</FormLabel>
 				</FormFieldset>
-				<div className="display__notice-wysiwyg">
-					<div className="display__notice-editor-container">
-						<h4>{ translate( 'Store notice content' ) }</h4>
-						<CompactTinyMCE initialValue={ storeNotice } onContentsChange={ noop } />
-					</div>
-					<div className="display__notice-preview-container">
-						<h4>{ translate( 'Preview' ) }</h4>
-						<SettingsDisplayNoticePreview value={ storeNotice } />
-					</div>
-				</div>
+				{ this.possiblyRenderWYSIWYG() }
 			</div>
 		);
 	};

--- a/client/extensions/woocommerce/app/settings/display/index.js
+++ b/client/extensions/woocommerce/app/settings/display/index.js
@@ -1,0 +1,53 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import Main from 'components/main';
+import SettingsDisplayNotice from './display-notice';
+import SettingsDisplayHeader from './display-header';
+
+class SettingsDisplay extends Component {
+	static propTypes = {
+		className: PropTypes.string,
+		siteId: PropTypes.number,
+	};
+
+	render = () => {
+		const { className, siteId } = this.props;
+
+		return (
+			<Main className={ classNames( 'settings-display', className ) } wideLayout>
+				<SettingsDisplayHeader siteId={ siteId } />
+				<SettingsDisplayNotice siteId={ siteId } />
+			</Main>
+		);
+	};
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const siteId = site ? site.ID : null;
+
+	return {
+		site,
+		siteId,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators( {}, dispatch );
+}
+export default connect( mapStateToProps, mapDispatchToProps )( localize( SettingsDisplay ) );

--- a/client/extensions/woocommerce/app/settings/display/index.js
+++ b/client/extensions/woocommerce/app/settings/display/index.js
@@ -22,15 +22,19 @@ import SettingsDisplayHeader from './display-header';
 class SettingsDisplay extends Component {
 	static propTypes = {
 		className: PropTypes.string,
+		site: PropTypes.shape( {
+			slug: PropTypes.string,
+		} ),
 		siteId: PropTypes.number,
+		translate: PropTypes.func,
 	};
 
 	render = () => {
-		const { className, siteId } = this.props;
+		const { className, site, siteId } = this.props;
 
 		return (
 			<Main className={ classNames( 'settings-display', className ) } wideLayout>
-				<SettingsDisplayHeader siteId={ siteId } />
+				<SettingsDisplayHeader site={ site } />
 				<SettingsDisplayNotice siteId={ siteId } />
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/settings/display/style.scss
+++ b/client/extensions/woocommerce/app/settings/display/style.scss
@@ -1,0 +1,62 @@
+.display__notice {
+	.display__notice-card {
+		.display__notice-enabled-container {
+			margin-bottom: 18px;
+
+			&.placeholder {
+				height: 36px;
+				width: 60%;
+				@include placeholder();
+			}
+		}
+
+		.display__notice-wysiwyg {
+			display: flex;
+			flex-direction: column;
+
+			@include breakpoint( ">960px" ) {
+				flex-direction: row;
+			}
+
+			h4 {
+				font-weight: 600;
+				margin-bottom: 8px;
+			}
+
+			.display__notice-editor-container {
+				flex-basis: 60%;
+
+				&.placeholder {
+					height: 144px;
+					@include placeholder();
+				}
+			}
+
+			.display__notice-preview-container {
+				flex-basis: 40%;
+				margin-left: 0;
+				margin-top: 18px;
+				min-width: 0;
+
+				@include breakpoint( ">960px" ) {
+					margin-left: 18px;
+					margin-top: 0;
+				}
+
+				.display__notice-preview-notice {
+					background-color: $blue-dark;
+					color: $white;
+					overflow: hidden;
+					padding: 8px;
+					text-overflow: ellipsis;
+					white-space: nowrap;
+				}
+
+				&.placeholder {
+					height: 144px;
+					@include placeholder();
+				}
+			}
+		}
+	}
+}

--- a/client/extensions/woocommerce/app/settings/display/style.scss
+++ b/client/extensions/woocommerce/app/settings/display/style.scss
@@ -27,7 +27,7 @@
 				flex-basis: 60%;
 
 				&.placeholder {
-					height: 144px;
+					height: 322px;
 					@include placeholder();
 				}
 			}
@@ -52,8 +52,39 @@
 					white-space: nowrap;
 				}
 
+				.display__notice-preview-content {
+					display: flex;
+					overflow-y: hidden;
+
+					.display__notice-preview-content-primary {
+						flex-basis: 30%;
+
+						div {
+							background-color: $gray;
+							height: 320px;
+							margin: 16px;
+						}
+					}
+
+					.display__notice-preview-content-secondary {
+						flex-basis: 70%;
+
+						div {
+							background-color: $gray;
+							height: 320px;
+							margin: 16px 16px 16px 0;
+						}
+					}
+				}
+
+				.display__notice-preview-caveat {
+					color: $gray;
+					font-style: italic;
+					margin-top: 8px;
+				}
+
 				&.placeholder {
-					height: 144px;
+					height: 275px;
 					@include placeholder();
 				}
 			}

--- a/client/extensions/woocommerce/app/settings/display/style.scss
+++ b/client/extensions/woocommerce/app/settings/display/style.scss
@@ -39,7 +39,7 @@
 				min-width: 0;
 
 				@include breakpoint( ">960px" ) {
-					margin-left: 18px;
+					margin-left: 32px;
 					margin-top: 0;
 				}
 
@@ -60,7 +60,7 @@
 						flex-basis: 30%;
 
 						div {
-							background-color: $gray;
+							background-color: $gray-light;
 							height: 320px;
 							margin: 16px;
 						}
@@ -70,7 +70,7 @@
 						flex-basis: 70%;
 
 						div {
-							background-color: $gray;
+							background-color: $gray-light;
 							height: 320px;
 							margin: 16px 16px 16px 0;
 						}

--- a/client/extensions/woocommerce/app/settings/navigation.js
+++ b/client/extensions/woocommerce/app/settings/navigation.js
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import NavItem from 'components/section-nav/item';
@@ -41,6 +42,14 @@ export const SettingsNavigation = ( { site, activeSection, translate } ) => {
 			title: translate( 'Email' ),
 		},
 	];
+
+	if ( config.isEnabled( 'woocommerce/extension-settings-display' ) ) {
+		items.push( {
+			id: 'display',
+			path: '/store/settings/display/:site',
+			title: translate( 'Display' ),
+		} );
+	}
 
 	const section = find( items, { id: activeSection } );
 	return (

--- a/client/extensions/woocommerce/components/browser-frame/index.js
+++ b/client/extensions/woocommerce/components/browser-frame/index.js
@@ -1,0 +1,26 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+
+const BrowserFrame = ( { children } ) => {
+	return (
+		<div className="browser-frame">
+			<div className="browser-frame__title-bar">
+				<div className="browser-frame__title-bar-button" />
+				<div className="browser-frame__title-bar-button" />
+				<div className="browser-frame__title-bar-button" />
+			</div>
+			<div className="browser-frame__document">{ children }</div>
+		</div>
+	);
+};
+
+export default BrowserFrame;

--- a/client/extensions/woocommerce/components/browser-frame/index.js
+++ b/client/extensions/woocommerce/components/browser-frame/index.js
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -21,6 +22,10 @@ const BrowserFrame = ( { children } ) => {
 			<div className="browser-frame__document">{ children }</div>
 		</div>
 	);
+};
+
+BrowserFrame.propTypes = {
+	children: PropTypes.oneOfType( [ PropTypes.arrayOf( PropTypes.node ), PropTypes.node ] ),
 };
 
 export default BrowserFrame;

--- a/client/extensions/woocommerce/components/browser-frame/style.scss
+++ b/client/extensions/woocommerce/components/browser-frame/style.scss
@@ -1,0 +1,30 @@
+.browser-frame {
+	background-color: $white;
+	border: 1px solid $gray;
+	border-radius: 8px;
+	overflow: hidden;
+
+	.browser-frame__title-bar {
+		align-items: center;
+		background-color: $gray;
+		display: flex;
+		flex-direction: row;
+		height: 32px;
+		width: 100%;
+
+		.browser-frame__title-bar-button {
+			background-color: $white;
+			border-radius: 4px;
+			border: 1px solid $white;
+			height: 8px;
+			margin-left: 8px;
+			overflow: hidden;
+			width: 8px;
+		}
+	}
+
+	.browser-frame__document {
+		height: 180px;
+		width: 100%;
+	}
+}

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -30,8 +30,9 @@ import Promotions from './app/promotions';
 import PromotionCreate from './app/promotions/promotion-create';
 import PromotionUpdate from './app/promotions/promotion-update';
 import Reviews from './app/reviews';
-import SettingsPayments from './app/settings/payments';
+import SettingsDisplay from './app/settings/display';
 import SettingsEmail from './app/settings/email';
+import SettingsPayments from './app/settings/payments';
 import SettingsTaxes from './app/settings/taxes';
 import Shipping from './app/settings/shipping';
 import ShippingZone from './app/settings/shipping/shipping-zone';
@@ -168,6 +169,12 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-settings-email',
 			documentTitle: translate( 'Email' ),
 			path: '/store/settings/email/:site/:setup?',
+		},
+		{
+			container: SettingsDisplay,
+			configKey: 'woocommerce/extension-settings-display',
+			documentTitle: translate( 'Display' ),
+			path: '/store/settings/display/:site',
 		},
 	];
 

--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -210,6 +210,11 @@ class StoreSidebar extends Component {
 			'/store/settings/taxes',
 			'/store/settings/email',
 		];
+
+		if ( config.isEnabled( 'woocommerce/extension-settings-display' ) ) {
+			childLinks.push( '/store/settings/display' );
+		}
+
 		const selected = this.isItemLinkSelected( [ link, ...childLinks ] );
 		const classes = classNames( {
 			settings: true,

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -12,6 +12,7 @@
 	@import 'app/order/order-activity-log/style';
 	@import 'app/order/order-payment/style';
 	@import 'app/orders/style';
+	@import 'app/settings/display/style';
 	@import 'app/settings/payments/style';
 	@import 'app/settings/payments/stripe/style';
 	@import 'app/settings/email/mailchimp/style';
@@ -29,6 +30,7 @@
 	@import 'components/action-header/style';
 	@import 'components/address-view/style';
 	@import 'components/basic-widget/style';
+	@import 'components/browser-frame/style';
 	@import 'components/bulk-select/style';
 	@import 'components/compact-tinymce/style';
 	@import 'components/dashboard-widget/style';

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -114,6 +114,7 @@
 		"woocommerce/extension-promotions": false,
 		"woocommerce/extension-reviews": false,
 		"woocommerce/extension-settings": false,
+		"woocommerce/extension-settings-display": false,
 		"woocommerce/extension-settings-email": false,
 		"woocommerce/extension-settings-email-generic": false,
 		"woocommerce/extension-settings-payments": false,

--- a/config/development.json
+++ b/config/development.json
@@ -196,6 +196,7 @@
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
+		"woocommerce/extension-settings-display": true,
 		"woocommerce/extension-settings-email": true,
 		"woocommerce/extension-settings-email-generic": true,
 		"woocommerce/extension-settings-payments": true,

--- a/config/production.json
+++ b/config/production.json
@@ -140,6 +140,7 @@
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
+		"woocommerce/extension-settings-display": false,
 		"woocommerce/extension-settings-email": true,
 		"woocommerce/extension-settings-email-generic": false,
 		"woocommerce/extension-settings-payments": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -145,6 +145,7 @@
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
+		"woocommerce/extension-settings-display": false,
 		"woocommerce/extension-settings-email": true,
 		"woocommerce/extension-settings-email-generic": false,
 		"woocommerce/extension-settings-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -159,6 +159,7 @@
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
+		"woocommerce/extension-settings-display": false,
 		"woocommerce/extension-settings-email": true,
 		"woocommerce/extension-settings-email-generic": false,
 		"woocommerce/extension-settings-payments": true,


### PR DESCRIPTION
Ready to test

Partially addresses #20623 

To test:
* Navigate to http://calypso.localhost:3000/store/settings/display/{DOMAIN}
* You should see (static) content similar to the following
* Make sure the navigation and placeholdering works too
* You can change the text in the editor and see changes in the preview
* Responsive design too for narrow devices
* This is read-only - next PR connects redux and saving

<img width="634" alt="screen shot 2017-12-13 at 11 15 45 am" src="https://user-images.githubusercontent.com/1595739/33957705-428d37ce-dff7-11e7-9924-fdadfc28bc9a.png">

<img width="1393" alt="screen shot 2017-12-13 at 11 15 21 am" src="https://user-images.githubusercontent.com/1595739/33957706-42a8be5e-dff7-11e7-860d-18f0f2dcb87c.png">
