### PR TITLE
Add spacing to progress bar

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -25,6 +25,7 @@
 		flex-direction: row;
 		font-size: 14px;
 		white-space: nowrap;
+		margin-bottom: 5px;
 	}
 
 	&-progress-text {


### PR DESCRIPTION
The checklist progress bar could use a little space above it. This PR adds some space to give it a little room to breath.

## Before
![image](https://user-images.githubusercontent.com/6981253/33920917-b117da28-df8e-11e7-9dcf-321e7d00b879.png)

## After
![image](https://user-images.githubusercontent.com/6981253/33920887-89cb86b8-df8e-11e7-91e7-17f619d17318.png)

cc @taggon 
