### PR TITLE
Add site tagline guided tour for checklist

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -13,10 +13,12 @@ import { EditorBasicsTour } from 'layout/guided-tours/tours/editor-basics-tour';
 import { MediaBasicsTour } from 'layout/guided-tours/tours/media-basics-tour';
 import { SimplePaymentsEndOfYearGuide } from 'layout/guided-tours/tours/simple-payments-end-of-year-guide';
 import { ChecklistSiteIconTour } from 'layout/guided-tours/tours/checklist-site-icon-tour';
+import { ChecklistSiteTaglineTour } from 'layout/guided-tours/tours/checklist-site-tagline-tour';
 import { ChecklistSiteTitleTour } from 'layout/guided-tours/tours/checklist-site-title-tour';
 
 export default combineTours( {
 	checklistSiteIcon: ChecklistSiteIconTour,
+	checklistSiteTagline: ChecklistSiteTaglineTour,
 	checklistSiteTitle: ChecklistSiteTitleTour,
 	main: MainTour,
 	editorBasicsTour: EditorBasicsTour,

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -25,4 +25,5 @@ export default combineTours( {
 	gdocsIntegrationTour: GDocsIntegrationTour,
 	simplePaymentsTour: SimplePaymentsTour,
 	simplePaymentsEndOfYearGuide: SimplePaymentsEndOfYearGuide,
+	siteTitle: SiteTitleTour,
 } );

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -27,5 +27,4 @@ export default combineTours( {
 	gdocsIntegrationTour: GDocsIntegrationTour,
 	simplePaymentsTour: SimplePaymentsTour,
 	simplePaymentsEndOfYearGuide: SimplePaymentsEndOfYearGuide,
-	siteTitle: SiteTitleTour,
 } );

--- a/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
@@ -1,0 +1,68 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { translate } from 'i18n-calypso';
+import { noop } from 'lodash';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import {
+	ButtonRow,
+	Continue,
+	makeTour,
+	Next,
+	SiteLink,
+	Step,
+	Tour,
+} from 'layout/guided-tours/config-elements';
+
+export const ChecklistSiteTaglineTour = makeTour(
+	<Tour name="checklistSiteTagline" version="20171205" path="/non-existent-route" when={ noop }>
+		<Step name="init" target="site-tagline-input" arrow="top-left" placement="below">
+			<p>
+				{ translate(
+					'First impressions last - a tagline tells visitors what your site is all about without ' +
+						'having to read all your content. Enter a short descriptive phrase about your site into ' +
+						'the {{b}}Site Tagline{{/b}} field.',
+					{ components: { b: <strong /> } }
+				) }
+			</p>
+			<ButtonRow>
+				<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
+				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+			</ButtonRow>
+		</Step>
+
+		<Step name="click-save" target="settings-site-profile-save" arrow="top-left" placement="below">
+			<Continue target="settings-site-profile-save" step="finish" click>
+				{ translate(
+					"Almost done — press {{b}}Save Settings{{/b}} to save your changes and then see what's next on our list.",
+					{ components: { b: <strong /> } }
+				) }
+			</Continue>
+		</Step>
+
+		<Step name="finish" placement="right">
+			<h1 className="tours__title">
+				<span className="tours__completed-icon-wrapper">
+					<Gridicon icon="checkmark" className="tours__completed-icon" />
+				</span>
+				{ translate( 'Way to go!' ) }
+			</h1>
+			<p>
+				{ translate(
+					"Your tagline has been saved! Let's move on and see what's next on our checklist."
+				) }
+			</p>
+			<SiteLink isButton="true" href={ '/checklist/:site' }>
+				{ translate( 'Return to the checklist' ) }
+			</SiteLink>
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
@@ -24,7 +24,15 @@ import {
 
 export const ChecklistSiteTaglineTour = makeTour(
 	<Tour name="checklistSiteTagline" version="20171205" path="/non-existent-route" when={ noop }>
-		<Step name="init" target="site-tagline-input" arrow="top-left" placement="below">
+		<Step
+			name="init"
+			target="site-tagline-input"
+			arrow="top-left"
+			placement="below"
+			style={ {
+				animationDelay: '0.7s',
+			} }
+		>
 			<p>
 				{ translate(
 					'First impressions last - a tagline tells visitors what your site is all about without ' +

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -15,57 +15,24 @@ import Gridicon from 'gridicons';
 import {
 	ButtonRow,
 	Continue,
-	Link,
 	makeTour,
 	Next,
 	Quit,
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
-import {
-	hasSelectedSiteDefaultSiteTitle,
-	isUserOlderThan,
-	isEnabled,
-	canUserEditSettingsOfSelectedSite,
-	isAbTestInVariant,
-} from 'state/ui/guided-tours/contexts';
+import { canUserEditSettingsOfSelectedSite } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
-
-const TWO_DAYS_IN_MILLISECONDS = 2 * 1000 * 3600 * 24;
 
 export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
-		version="20161207"
+		version="20171205"
 		path="/stats"
-		when={ and(
-			isEnabled( 'guided-tours/site-title' ),
-			isDesktop,
-			hasSelectedSiteDefaultSiteTitle,
-			canUserEditSettingsOfSelectedSite,
-			isUserOlderThan( TWO_DAYS_IN_MILLISECONDS ),
-			isAbTestInVariant( 'siteTitleTour', 'enabled' )
-		) }
+		when={ and( isDesktop, canUserEditSettingsOfSelectedSite ) }
 	>
-		<Step name="init" placement="right" next="click-settings">
-			<p>
-				{ translate(
-					"Hey there! We noticed you haven't changed the title of your site yet. Want to change it?"
-				) }
-			</p>
-			<p>
-				{ translate(
-					'The site title appears in places like the top of your web browser and in search results.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="click-settings">{ translate( 'Yes, please!' ) }</Next>
-				<Quit>{ translate( 'No, thanks.' ) }</Quit>
-			</ButtonRow>
-		</Step>
-
 		<Step
-			name="click-settings"
+			name="init"
 			target="settings"
 			arrow="left-top"
 			placement="beside"
@@ -73,7 +40,7 @@ export const SiteTitleTour = makeTour(
 			shouldScrollTo
 		>
 			<Continue target="settings" step="site-title-input" click>
-				{ translate( 'Click {{strong}}{{icon/}} Settings{{/strong}} to continue.', {
+				{ translate( 'Click {{strong}}{{icon/}} Settings{{/strong}} to get started.', {
 					components: {
 						icon: <Gridicon icon="cog" />,
 						strong: <strong />,
@@ -89,20 +56,7 @@ export const SiteTitleTour = makeTour(
 				) }
 			</p>
 			<ButtonRow>
-				<Next step="site-tagline-input">{ translate( 'Looks Good!' ) }</Next>
-				<Quit>{ translate( 'Cancel' ) }</Quit>
-			</ButtonRow>
-		</Step>
-
-		<Step name="site-tagline-input" target="site-tagline-input" arrow="top-left" placement="below">
-			<p>
-				{ translate(
-					"While you're at it, why not add a tagline? It should explain what your site is about in a few words. " +
-						'It usually appears right below your site title.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="click-save">{ translate( 'Great!' ) }</Next>
+				<Next step="click-save">{ translate( 'Looks Good!' ) }</Next>
 				<Quit>{ translate( 'Cancel' ) }</Quit>
 			</ButtonRow>
 		</Step>
@@ -127,9 +81,6 @@ export const SiteTitleTour = makeTour(
 			<ButtonRow>
 				<Quit primary>{ translate( "We're all done!" ) }</Quit>
 			</ButtonRow>
-			<Link href="https://en.support.wordpress.com/start">
-				{ translate( 'Learn more about WordPress.com' ) }
-			</Link>
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -7,7 +7,6 @@
 import React from 'react';
 import { translate } from 'i18n-calypso';
 import { overEvery as and } from 'lodash';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -22,34 +21,15 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 import { canUserEditSettingsOfSelectedSite } from 'state/ui/guided-tours/contexts';
-import { isDesktop } from 'lib/viewport';
 
 export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
 		version="20171205"
 		path="/stats"
-		when={ and( isDesktop, canUserEditSettingsOfSelectedSite ) }
+		when={ and( canUserEditSettingsOfSelectedSite ) }
 	>
-		<Step
-			name="init"
-			target="settings"
-			arrow="left-top"
-			placement="beside"
-			scrollContainer=".sidebar__region"
-			shouldScrollTo
-		>
-			<Continue target="settings" step="site-title-input" click>
-				{ translate( 'Click {{strong}}{{icon/}} Settings{{/strong}} to get started.', {
-					components: {
-						icon: <Gridicon icon="cog" />,
-						strong: <strong />,
-					},
-				} ) }
-			</Continue>
-		</Step>
-
-		<Step name="site-title-input" target="site-title-input" arrow="top-left" placement="below">
+		<Step name="init" target="site-title-input" arrow="top-left" placement="below">
 			<p>
 				{ translate(
 					'You can change the site title here. A good title can help others find your site.'

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -27,7 +27,7 @@ export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
 		version="20171205"
-		path="/checklist"
+		path="/non-existent-route"
 		when={ and( canUserEditSettingsOfSelectedSite ) }
 	>
 		<Step name="init" target="site-title-input" arrow="top-left" placement="below">

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -15,60 +15,121 @@ import Gridicon from 'gridicons';
 import {
 	ButtonRow,
 	Continue,
+	Link,
 	makeTour,
 	Next,
-	SiteLink,
+	Quit,
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
-import { canUserEditSettingsOfSelectedSite } from 'state/ui/guided-tours/contexts';
+import {
+	hasSelectedSiteDefaultSiteTitle,
+	isUserOlderThan,
+	isEnabled,
+	canUserEditSettingsOfSelectedSite,
+	isAbTestInVariant,
+} from 'state/ui/guided-tours/contexts';
+import { isDesktop } from 'lib/viewport';
+
+const TWO_DAYS_IN_MILLISECONDS = 2 * 1000 * 3600 * 24;
 
 export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
-		version="20171205"
-		path="/non-existent-route"
-		when={ and( canUserEditSettingsOfSelectedSite ) }
+		version="20161207"
+		path="/stats"
+		when={ and(
+			isEnabled( 'guided-tours/site-title' ),
+			isDesktop,
+			hasSelectedSiteDefaultSiteTitle,
+			canUserEditSettingsOfSelectedSite,
+			isUserOlderThan( TWO_DAYS_IN_MILLISECONDS ),
+			isAbTestInVariant( 'siteTitleTour', 'enabled' )
+		) }
 	>
-		<Step name="init" target="site-title-input" arrow="top-left" placement="below">
+		<Step name="init" placement="right" next="click-settings">
 			<p>
 				{ translate(
-					"Update the {{b}}Site Title{{/b}} field with a descriptive name to let your visitors know which site they're visiting.",
+					"Hey there! We noticed you haven't changed the title of your site yet. Want to change it?"
+				) }
+			</p>
+			<p>
+				{ translate(
+					'The site title appears in places like the top of your web browser and in search results.'
+				) }
+			</p>
+			<ButtonRow>
+				<Next step="click-settings">{ translate( 'Yes, please!' ) }</Next>
+				<Quit>{ translate( 'No, thanks.' ) }</Quit>
+			</ButtonRow>
+		</Step>
+
+		<Step
+			name="click-settings"
+			target="settings"
+			arrow="left-top"
+			placement="beside"
+			scrollContainer=".sidebar__region"
+			shouldScrollTo
+		>
+			<Continue target="settings" step="site-title-input" click>
+				{ translate( 'Click {{strong}}{{icon/}} Settings{{/strong}} to continue.', {
+					components: {
+						icon: <Gridicon icon="cog" />,
+						strong: <strong />,
+					},
+				} ) }
+			</Continue>
+		</Step>
+
+		<Step name="site-title-input" target="site-title-input" arrow="top-left" placement="below">
+			<p>
+				{ translate(
+					'You can change the site title here. A good title can help others find your site.'
+				) }
+			</p>
+			<ButtonRow>
+				<Next step="site-tagline-input">{ translate( 'Looks Good!' ) }</Next>
+				<Quit>{ translate( 'Cancel' ) }</Quit>
+			</ButtonRow>
+		</Step>
+
+		<Step name="site-tagline-input" target="site-tagline-input" arrow="top-left" placement="below">
+			<p>
+				{ translate(
+					"While you're at it, why not add a tagline? It should explain what your site is about in a few words. " +
+						'It usually appears right below your site title.'
+				) }
+			</p>
+			<ButtonRow>
+				<Next step="click-save">{ translate( 'Great!' ) }</Next>
+				<Quit>{ translate( 'Cancel' ) }</Quit>
+			</ButtonRow>
+		</Step>
+
+		<Step name="click-save" target="settings-site-profile-save" arrow="top-right" placement="below">
+			<Continue target="settings-site-profile-save" step="finish" click>
+				{ translate( "Don't forget to save your changes." ) }
+			</Continue>
+		</Step>
+
+		<Step name="finish" placement="center">
+			<p>
+				{ translate(
+					"{{strong}}That's it!{{/strong}} Your visitors can now easily identify your website by its title.",
 					{
-						components: { b: <strong /> },
+						components: {
+							strong: <strong />,
+						},
 					}
 				) }
 			</p>
 			<ButtonRow>
-				<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+				<Quit primary>{ translate( "We're all done!" ) }</Quit>
 			</ButtonRow>
-		</Step>
-
-		<Step name="click-save" target="settings-site-profile-save" arrow="top-left" placement="below">
-			<Continue target="settings-site-profile-save" step="finish" click>
-				{ translate(
-					'Almost done — every time you make a change, it needs to be saved. ' +
-						"Let's save your changes and then see what's next on our list."
-				) }
-			</Continue>
-		</Step>
-
-		<Step name="finish" placement="right">
-			<h1 className="tours__title">
-				<span className="tours__completed-icon-wrapper">
-					<Gridicon icon="checkmark" className="tours__completed-icon" />
-				</span>
-				{ translate( 'Good job, looks great!' ) }
-			</h1>
-			<p>
-				{ translate(
-					"Your changes have been saved. Let's move on and see what's next on our checklist."
-				) }
-			</p>
-			<SiteLink isButton="true" href={ '/checklist/:site' }>
-				{ translate( 'Return to the checklist' ) }
-			</SiteLink>
+			<Link href="https://en.support.wordpress.com/start">
+				{ translate( 'Learn more about WordPress.com' ) }
+			</Link>
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -45,27 +45,30 @@ export const SiteTitleTour = makeTour(
 			</ButtonRow>
 		</Step>
 
-		<Step name="click-save" target="settings-site-profile-save" arrow="top-right" placement="below">
+		<Step name="click-save" target="settings-site-profile-save" arrow="top-left" placement="below">
 			<Continue target="settings-site-profile-save" step="finish" click>
 				{ translate(
-					'Almost done - every time you make a change, it needs to be saved. ' +
+					'Almost done — every time you make a change, it needs to be saved. ' +
 						"Let's save your changes and then see what's next on our list."
 				) }
 			</Continue>
 		</Step>
 
-		<Step name="finish" placement="center">
-			<p>
-				<Gridicon icon="checkmark" /> { translate( 'Good job, looks great!' ) }
-			</p>
+		<Step name="finish" placement="right">
+			<h1 className="tours__title">
+				<span className="tours__completed-icon-wrapper">
+					<Gridicon icon="checkmark" className="tours__completed-icon" />
+				</span>
+				{ translate( 'Good job, looks great!' ) }
+			</h1>
 			<p>
 				{ translate(
 					"Your changes have been saved. Let's move on and see what's next on our checklist."
 				) }
 			</p>
-			<ButtonRow>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
-			</ButtonRow>
+			<SiteLink isButton="true" href={ '/checklist/:site' }>
+				{ translate( 'Return to the checklist' ) }
+			</SiteLink>
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -7,6 +7,7 @@
 import React from 'react';
 import { translate } from 'i18n-calypso';
 import { overEvery as and } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -16,7 +17,7 @@ import {
 	Continue,
 	makeTour,
 	Next,
-	Quit,
+	SiteLink,
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
@@ -26,40 +27,44 @@ export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
 		version="20171205"
-		path="/stats"
+		path="/checklist"
 		when={ and( canUserEditSettingsOfSelectedSite ) }
 	>
 		<Step name="init" target="site-title-input" arrow="top-left" placement="below">
 			<p>
 				{ translate(
-					'You can change the site title here. A good title can help others find your site.'
+					"Update the {{b}}Site Title{{/b}} field with a descriptive name to let your visitors know which site they're visiting.",
+					{
+						components: { b: <strong /> },
+					}
 				) }
 			</p>
 			<ButtonRow>
-				<Next step="click-save">{ translate( 'Looks Good!' ) }</Next>
-				<Quit>{ translate( 'Cancel' ) }</Quit>
+				<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
+				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 			</ButtonRow>
 		</Step>
 
 		<Step name="click-save" target="settings-site-profile-save" arrow="top-right" placement="below">
 			<Continue target="settings-site-profile-save" step="finish" click>
-				{ translate( "Don't forget to save your changes." ) }
+				{ translate(
+					'Almost done - every time you make a change, it needs to be saved. ' +
+						"Let's save your changes and then see what's next on our list."
+				) }
 			</Continue>
 		</Step>
 
 		<Step name="finish" placement="center">
 			<p>
+				<Gridicon icon="checkmark" /> { translate( 'Good job, looks great!' ) }
+			</p>
+			<p>
 				{ translate(
-					"{{strong}}That's it!{{/strong}} Your visitors can now easily identify your website by its title.",
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
+					"Your changes have been saved. Let's move on and see what's next on our checklist."
 				) }
 			</p>
 			<ButtonRow>
-				<Quit primary>{ translate( "We're all done!" ) }</Quit>
+				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 			</ButtonRow>
 		</Step>
 	</Tour>

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -37,7 +37,6 @@ const tasks = {
 		duration: '1 min',
 		completedTitle: 'You updated your site title',
 		completedButtonText: 'Edit',
-		url: '/checklist/$siteSlug?tour=siteTitle',
 		image: '/calypso/images/stats/tasks/personalize-your-site.svg',
 		tour: 'checklistSiteTitle',
 	},

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -37,6 +37,7 @@ const tasks = {
 		duration: '1 min',
 		completedTitle: 'You updated your site title',
 		completedButtonText: 'Edit',
+		url: '/settings/general/$siteSlug',
 		image: '/calypso/images/stats/tasks/personalize-your-site.svg',
 		tour: 'checklistSiteTitle',
 	},

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -37,7 +37,7 @@ const tasks = {
 		duration: '1 min',
 		completedTitle: 'You updated your site title',
 		completedButtonText: 'Edit',
-		url: '/settings/general/$siteSlug',
+		url: '/checklist/$siteSlug?tour=siteTitle',
 		image: '/calypso/images/stats/tasks/personalize-your-site.svg',
 		tour: 'checklistSiteTitle',
 	},

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -49,6 +49,7 @@ const tasks = {
 		completedButtonText: 'Change',
 		url: '/settings/general/$siteSlug',
 		image: '/calypso/images/stats/tasks/create-tagline.svg',
+		tour: 'checklistSiteTagline',
 	},
 	contact_page_updated: {
 		title: 'Personalize your Contact page',


### PR DESCRIPTION
This PR adds a guided tour triggered from the onboarding checklist.

# Testing

* Create a new site
* Visit `/checklist/<domain>` for your site
* Click 'Do It' for the site tagline task (whether completed or not - the tour should show)
* Verify that the following steps appear in the tour:

![site-tagline-tour](https://user-images.githubusercontent.com/1926/33923515-bcdfdb7a-e025-11e7-9b37-d57cd0a29b27.gif)
