### PR TITLE
Jetpack Connect: Use query param redirectAfterAuth in plans

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -515,7 +515,7 @@ export class LoggedInForm extends Component {
 			return `/start/pressable-nux?blogid=${ siteId }`;
 		}
 
-		return addQueryArgs( { redirectAfterAuth }, PLANS_PAGE + siteSlug );
+		return addQueryArgs( { redirect: redirectAfterAuth }, PLANS_PAGE + siteSlug );
 	}
 
 	renderFooterLinks() {

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -4,7 +4,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import addQueryArgs from 'lib/route/add-query-args';
 import debugModule from 'debug';
 import Gridicon from 'gridicons';
 import page from 'page';
@@ -15,6 +14,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import addQueryArgs from 'lib/route/add-query-args';
 import AuthFormHeader from './auth-form-header';
 import Button from 'components/button';
 import Card from 'components/card';
@@ -505,7 +505,7 @@ export class LoggedInForm extends Component {
 	}
 
 	getRedirectionTarget() {
-		const { partnerId, siteId, siteSlug } = this.props;
+		const { partnerId, redirectAfterAuth, siteId, siteSlug } = this.props;
 
 		// Redirect sites hosted on Pressable with a partner plan to some URL.
 		if (
@@ -515,7 +515,7 @@ export class LoggedInForm extends Component {
 			return `/start/pressable-nux?blogid=${ siteId }`;
 		}
 
-		return PLANS_PAGE + siteSlug;
+		return addQueryArgs( { redirectAfterAuth }, PLANS_PAGE + siteSlug );
 	}
 
 	renderFooterLinks() {

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -242,7 +242,7 @@ export function plansSelection( context ) {
 				context={ context }
 				destinationType={ context.params.destinationType }
 				interval={ context.params.interval }
-				redirectAfterAuth={ context.query.redirectAfterAuth }
+				queryRedirect={ context.query.redirect }
 			/>
 		</CheckoutData>,
 		document.getElementById( 'primary' ),

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -238,10 +238,11 @@ export function plansSelection( context ) {
 	renderWithReduxStore(
 		<CheckoutData>
 			<Plans
+				basePlansPath={ '/jetpack/connect/plans' }
 				context={ context }
 				destinationType={ context.params.destinationType }
-				basePlansPath={ '/jetpack/connect/plans' }
 				interval={ context.params.interval }
+				redirectAfterAuth={ context.query.redirectAfterAuth }
 			/>
 		</CheckoutData>,
 		document.getElementById( 'primary' ),

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -27,12 +27,7 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-import {
-	canCurrentUser,
-	getJetpackConnectRedirectAfterAuth,
-	isRtl,
-	isSiteAutomatedTransfer,
-} from 'state/selectors';
+import { canCurrentUser, isRtl, isSiteAutomatedTransfer } from 'state/selectors';
 import { mc } from 'lib/analytics';
 import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
 
@@ -42,6 +37,8 @@ const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';
 
 class Plans extends Component {
 	static propTypes = {
+		redirectAfterAuth: PropTypes.string,
+
 		// Connected props
 		isAutomatedTransfer: PropTypes.bool, // null indicates unknown
 		hasPlan: PropTypes.bool, // null indicates unknown
@@ -218,7 +215,6 @@ export default connect(
 			selectedPlan,
 			selectedPlanSlug,
 			isAutomatedTransfer: selectedSite ? isSiteAutomatedTransfer( state, selectedSite.ID ) : null,
-			redirectAfterAuth: getJetpackConnectRedirectAfterAuth( state ),
 			userId: user ? user.ID : null,
 			canPurchasePlans: selectedSite
 				? canCurrentUser( state, selectedSite.ID, 'manage_options' )

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -37,7 +37,7 @@ const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';
 
 class Plans extends Component {
 	static propTypes = {
-		redirectAfterAuth: PropTypes.string,
+		queryRedirect: PropTypes.string,
 
 		// Connected props
 		isAutomatedTransfer: PropTypes.bool, // null indicates unknown
@@ -91,9 +91,9 @@ class Plans extends Component {
 	};
 
 	redirectToWpAdmin() {
-		const { redirectAfterAuth } = this.props;
-		if ( redirectAfterAuth ) {
-			this.props.goBackToWpAdmin( redirectAfterAuth );
+		const { queryRedirect } = this.props;
+		if ( queryRedirect ) {
+			this.props.goBackToWpAdmin( queryRedirect );
 			this.redirecting = true;
 			this.props.completeFlow();
 		} else if ( this.props.selectedSite ) {


### PR DESCRIPTION
This PR moves a stateful part of the plans page to depend on a URL param. This is motivated by changes in #20406 which aim to remove a dependency on redux state for data that is available in the query string.

## Testing
1. Visit `/jetpack/connect/plans?redirectAfterAuth=SOMEREDIRECTION` and ensure it behaves as expected. You should be able to see the prop on the react component by inspecting with dev tools.
1. During the auth flow, ensure that `redirectAfterAuth` is correctly passed from the auth step to the plans page via the URL.