### PR TITLE
Jetpack Connect: Move QueryUserConnection to auth logged in form

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -10,7 +10,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getAuthorizationData, isRemoteSiteOnSitesList } from 'state/jetpack-connect/selectors';
+import { getAuthorizationData } from 'state/jetpack-connect/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import FormattedHeader from 'components/formatted-header';
 import SiteCard from './site-card';
@@ -125,12 +125,7 @@ class AuthFormHeader extends Component {
 			return null;
 		}
 
-		return (
-			<SiteCard
-				queryObject={ get( this.props, [ 'authorize', 'queryObject' ], {} ) }
-				isAlreadyOnSitesList={ !! this.props.isAlreadyOnSitesList }
-			/>
-		);
+		return <SiteCard queryObject={ get( this.props, [ 'authorize', 'queryObject' ], {} ) } />;
 	}
 
 	render() {
@@ -150,7 +145,6 @@ class AuthFormHeader extends Component {
 export default connect( state => {
 	return {
 		authorize: getAuthorizationData( state ),
-		isAlreadyOnSitesList: isRemoteSiteOnSitesList( state ),
 		jetpackVersion: getJetpackConnectJetpackVersion( state ),
 		partnerId: getJetpackConnectPartnerId( state ),
 		user: getCurrentUser( state ),

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -30,6 +30,7 @@ import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import QueryUserConnection from 'components/data/query-user-connection';
 import Spinner from 'components/spinner';
 import userUtilities from 'lib/user/utils';
 import { decodeEntities } from 'lib/formatting';
@@ -599,6 +600,10 @@ export class LoggedInForm extends Component {
 	render() {
 		return (
 			<div className="jetpack-connect__logged-in-form">
+				<QueryUserConnection
+					siteId={ this.props.siteId }
+					siteIsOnSitesList={ this.props.isAlreadyOnSitesList }
+				/>
 				<AuthFormHeader />
 				<Card>
 					<Gravatar user={ this.props.user } size={ 64 } />

--- a/client/jetpack-connect/site-card.jsx
+++ b/client/jetpack-connect/site-card.jsx
@@ -10,7 +10,6 @@ import urlModule from 'url';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import QueryUserConnection from 'components/data/query-user-connection';
 import Site from 'blocks/site';
 import safeImageUrl from 'lib/safe-image-url';
 import { decodeEntities } from 'lib/formatting';
@@ -22,13 +21,11 @@ class SiteCard extends Component {
 			blogname: PropTypes.string.isRequired,
 			home_url: PropTypes.string.isRequired,
 			site_url: PropTypes.string.isRequired,
-			client_id: PropTypes.string.isRequired,
 		} ).isRequired,
-		isAlreadyOnSitesList: PropTypes.bool,
 	};
 
 	render() {
-		const { site_icon, blogname, home_url, site_url, client_id } = this.props.queryObject;
+		const { site_icon, blogname, home_url, site_url } = this.props.queryObject;
 		const safeIconUrl = site_icon ? safeImageUrl( site_icon ) : false;
 		const siteIcon = safeIconUrl ? { img: safeIconUrl } : false;
 		const url = decodeEntities( home_url );
@@ -46,10 +43,6 @@ class SiteCard extends Component {
 
 		return (
 			<CompactCard className="jetpack-connect__site">
-				<QueryUserConnection
-					siteId={ parseInt( client_id ) }
-					siteIsOnSitesList={ this.props.isAlreadyOnSitesList }
-				/>
 				<Site site={ site } />
 			</CompactCard>
 		);


### PR DESCRIPTION
While working on #20406, this QueryComponent deep in the tree was noticed.

This PR lifts the Query Component into the logged in authorize form. This means we won't attempt to query when the user is logged out and it makes the props required by the query component more readily available.

## Testing

It's helpful to set:
```js
localStorage.debug = 'calypso:jetpack-connect:actions'
```

1. Start the auth flow logged out, ensure everything continues to work normally.
1. Start the auth flow logged in, ensure that the queries continue to fire as expected.

When starting auth logged in with a new site that's not connected, expect to see:

```
checking that site is accessible
user is not connected Error: API calls to this blog have been disabled.
```