### PR TITLE
DevDocs: Add showall prop to PostStatus example

### DIFF
--- a/client/blocks/post-status/docs/example.jsx
+++ b/client/blocks/post-status/docs/example.jsx
@@ -33,7 +33,7 @@ function PostStatusExample( { queries, primarySiteId, primarySiteUrl, globalIdBy
 						<h3>{ label }</h3>
 						{ primarySiteId && <QueryPosts siteId={ primarySiteId } query={ query } /> }
 						{ ! globalIdByQueryLabel[ label ] && <em>No matching post found</em> }
-						<PostStatus globalId={ globalIdByQueryLabel[ label ] } />
+						<PostStatus globalId={ globalIdByQueryLabel[ label ] } showAll />
 					</p>
 				);
 			} ) }


### PR DESCRIPTION
This is a quick fix for #20554. It adds the `showall` prop to the PostStatus component displayed in the DevDocs. Following the merge of #20302, this prop is now required to show all post statuses.

### Test
1. Load up this branch.
2. The devdocs example for the post status component pulls from your primary site so you'll want to set a primary site that has a variety of posts (scheduled, pending review, trashed, and sticky) here: http://calypso.localhost:3000/me/account.
3. Once you have the site set with the correct post status, load http://calypso.localhost:3000/devdocs/blocks/post-status.

You should see examples of all post statuses.

### Current
<img width="985" alt="screen shot 2017-12-13 at 7 20 45 am" src="https://user-images.githubusercontent.com/7240478/33943380-2832a45c-dfd6-11e7-8fbf-2651dea9f0f7.png">

### Updated
<img width="989" alt="screen shot 2017-12-13 at 7 21 32 am" src="https://user-images.githubusercontent.com/7240478/33943415-46145e02-dfd6-11e7-8670-127a97cc0d6c.png">