### PR TITLE
Comments: edit action for single comment view

### DIFF
--- a/client/components/data/moderate-comment/index.jsx
+++ b/client/components/data/moderate-comment/index.jsx
@@ -54,6 +54,7 @@ class ModerateComment extends Component {
 			! commentId ||
 			! newStatus ||
 			newStatus === currentStatus ||
+			'edit' === newStatus ||
 			'delete' === newStatus
 		) {
 			return;

--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, isUndefined } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,7 +43,6 @@ export class CommentView extends Component {
 			commentId,
 			action,
 			canModerateComments,
-			isLoading,
 			redirectToPostView,
 			translate,
 		} = this.props;
@@ -80,7 +79,7 @@ export class CommentView extends Component {
 						refreshCommentData={ true }
 						redirect={ redirectToPostView }
 						isPostView={ true }
-						isEditMode={ canModerateComments && 'edit' === action && ! isLoading }
+						isEditMode={ canModerateComments && 'edit' === action }
 					/>
 				) }
 				{ canModerateComments && <CommentPermalink { ...{ siteId, commentId } } /> }
@@ -102,7 +101,6 @@ const mapStateToProps = ( state, ownProps ) => {
 		siteId,
 		postId,
 		canModerateComments,
-		isLoading: isUndefined( comment ),
 		redirectToPostView: redirectToPostView( postId ),
 	};
 };

--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
+import { get, isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,6 +43,7 @@ export class CommentView extends Component {
 			commentId,
 			action,
 			canModerateComments,
+			isLoading,
 			redirectToPostView,
 			translate,
 		} = this.props;
@@ -79,6 +80,7 @@ export class CommentView extends Component {
 						refreshCommentData={ true }
 						redirect={ redirectToPostView }
 						isPostView={ true }
+						isEditMode={ canModerateComments && 'edit' === action && ! isLoading }
 					/>
 				) }
 				{ canModerateComments && <CommentPermalink { ...{ siteId, commentId } } /> }
@@ -100,6 +102,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		siteId,
 		postId,
 		canModerateComments,
+		isLoading: isUndefined( comment ),
 		redirectToPostView: redirectToPostView( postId ),
 	};
 };

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -40,17 +40,21 @@ export class Comment extends Component {
 		updateLastUndo: PropTypes.func,
 	};
 
-	state = {
-		isEditMode: false,
-		isReplyVisible: false,
-	};
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			isEditMode: props.isEditMode,
+			isReplyVisible: false,
+		};
+	}
 
 	componentWillReceiveProps( nextProps ) {
-		const { isBulkMode: wasBulkMode, isEditMode: forceEditMode } = this.props;
+		const { isBulkMode: wasBulkMode } = this.props;
 		const { isBulkMode } = nextProps;
 
 		this.setState( ( { isEditMode, isReplyVisible } ) => ( {
-			isEditMode: forceEditMode || ( wasBulkMode !== isBulkMode ? false : isEditMode ),
+			isEditMode: wasBulkMode !== isBulkMode ? false : isEditMode,
 			isReplyVisible: wasBulkMode !== isBulkMode ? false : isReplyVisible,
 		} ) );
 	}
@@ -126,7 +130,7 @@ export class Comment extends Component {
 					<QueryComment commentId={ commentId } siteId={ siteId } forceWpcom />
 				) }
 
-				{ ! isEditMode && (
+				{ ( ! isEditMode || isLoading ) && (
 					<div className="comment__detail">
 						<CommentHeader { ...{ commentId, isBulkMode, isEditMode, isPostView, isSelected } } />
 
@@ -144,9 +148,10 @@ export class Comment extends Component {
 					</div>
 				) }
 
-				{ isEditMode && (
-					<CommentEdit { ...{ commentId } } toggleEditMode={ this.toggleEditMode } />
-				) }
+				{ isEditMode &&
+					! isLoading && (
+						<CommentEdit { ...{ commentId } } toggleEditMode={ this.toggleEditMode } />
+					) }
 
 				{ isPostView &&
 					isEnabled( 'comments/management/threaded-view' ) && (

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -30,6 +30,7 @@ export class Comment extends Component {
 		siteId: PropTypes.number,
 		postId: PropTypes.number,
 		commentId: PropTypes.number,
+		isEditMode: PropTypes.bool,
 		isBulkMode: PropTypes.bool,
 		isPostView: PropTypes.bool,
 		isSelected: PropTypes.bool,
@@ -45,11 +46,11 @@ export class Comment extends Component {
 	};
 
 	componentWillReceiveProps( nextProps ) {
-		const { isBulkMode: wasBulkMode } = this.props;
+		const { isBulkMode: wasBulkMode, isEditMode: forceEditMode } = this.props;
 		const { isBulkMode } = nextProps;
 
 		this.setState( ( { isEditMode, isReplyVisible } ) => ( {
-			isEditMode: wasBulkMode !== isBulkMode ? false : isEditMode,
+			isEditMode: forceEditMode || ( wasBulkMode !== isBulkMode ? false : isEditMode ),
 			isReplyVisible: wasBulkMode !== isBulkMode ? false : isReplyVisible,
 		} ) );
 	}

--- a/client/my-sites/comments/controller.js
+++ b/client/my-sites/comments/controller.js
@@ -29,11 +29,13 @@ const sanitizeQueryAction = action => {
 
 	const validActions = {
 		approve: 'approved',
+		edit: 'edit',
 		unapprove: 'unapproved',
 		trash: 'trash',
 		spam: 'spam',
 		delete: 'delete',
 	};
+
 	return validActions.hasOwnProperty( action.toLowerCase() )
 		? validActions[ action.toLowerCase() ]
 		: null;


### PR DESCRIPTION
Part of #17221

Depends on:
https://github.com/Automattic/jetpack/pull/8069/
D8002-code

This PR adds support for _edit_ actions on the single comment view, so the _edit_ links on WordPress.com site's frontend could be pointed to Calypso.

To test:

* Navigate to a comment by clicking on the comment timestamp
* Add `?action=edit` to the URL

What to expect:

The page should show a loading placeholder and once the comment data is loaded, the edit form should show with the comment data loaded.
There should be no regressions on the site or post views.