### PR TITLE
 People: turn of auto-correct for username field when adding a user

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -158,16 +158,27 @@ class TokenField extends PureComponent {
 	};
 
 	_renderInput = () => {
-		const { autoCapitalize, autoComplete, id, maxLength, value, placeholder } = this.props;
+		const {
+			autoCapitalize,
+			autoComplete,
+			autoCorrect,
+			id,
+			maxLength,
+			placeholder,
+			spellCheck,
+			value,
+		} = this.props;
 
 		let props = {
 			autoCapitalize,
 			autoComplete,
+			autoCorrect,
 			disabled: this.props.disabled,
 			hasFocus: this.state.tokenInputHasFocus,
 			id,
 			key: 'input',
 			onBlur: this._onBlur,
+			spellCheck,
 			value: this.state.incompleteTokenValue,
 		};
 

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -317,6 +317,8 @@ class InvitePeople extends React.Component {
 								tokenizeOnSpace
 								autoCapitalize="none"
 								autoComplete="off"
+								autoCorrect="off"
+								spellCheck="false"
 								maxLength={ 10 }
 								value={ this.getTokensWithStatus() }
 								onChange={ this.onTokensChange }


### PR DESCRIPTION
Previously when inviting a user to a site, the username / email address field would auto-correct in Safari on macOS. This PR turns that off. 

To test:
- go to http://calypso.localhost:3000/people/new/SITE_URL
- make sure that auto-correct is off when entering a username or email address

Previously:

<img width="231" alt="screen shot 2017-12-13 at 3 55 11 pm" src="https://user-images.githubusercontent.com/23619/33944989-08fba262-e01e-11e7-85fe-803f7bcb9775.png">

Now:

<img width="302" alt="screen shot 2017-12-13 at 3 54 59 pm" src="https://user-images.githubusercontent.com/23619/33944993-0d80dc6c-e01e-11e7-8959-f4fdc91115d5.png">
