### PR TITLE
Reader: tag streams should only have placeholders until we confirm the existence of the tag

### DIFF
--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -92,7 +92,7 @@ class ReaderStream extends React.Component {
 		transformStreamItems: PropTypes.func,
 		isMain: PropTypes.bool,
 		intro: PropTypes.object,
-		forcePlaceholders: PropTypes.boolean,
+		forcePlaceholders: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -450,7 +450,7 @@ class ReaderStream extends React.Component {
 
 	render() {
 		const { forcePlaceholders, postsStore: store } = this.props;
-		let { items, isFetchingPage } = this.state;
+		let { items, isFetchingNextPage } = this.state;
 
 		const hasNoPosts =
 			store.isLastPage() && ( ! this.state.posts || this.state.posts.length === 0 );
@@ -459,7 +459,7 @@ class ReaderStream extends React.Component {
 		// trick an infinite list to showing placeholders
 		if ( forcePlaceholders ) {
 			items = [];
-			isFetchingPage = true;
+			isFetchingNextPage = true;
 		}
 
 		if ( hasNoPosts || store.hasRecentError( 'invalid_tag' ) ) {
@@ -475,7 +475,7 @@ class ReaderStream extends React.Component {
 					className="reader__content"
 					items={ items }
 					lastPage={ this.state.isLastPage }
-					fetchingNextPage={ isFetchingPage }
+					fetchingNextPage={ isFetchingNextPage }
 					guessedItemHeight={ GUESSED_POST_HEIGHT }
 					fetchNextPage={ this.fetchNextPage }
 					getItemRef={ this.getPostRef }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -92,6 +92,7 @@ class ReaderStream extends React.Component {
 		transformStreamItems: PropTypes.func,
 		isMain: PropTypes.bool,
 		intro: PropTypes.object,
+		forcePlaceholders: PropTypes.boolean,
 	};
 
 	static defaultProps = {
@@ -109,6 +110,7 @@ class ReaderStream extends React.Component {
 		isMain: true,
 		useCompactCards: false,
 		intro: null,
+		forcePlaceholders: false,
 	};
 
 	getStateFromStores( props = this.props ) {
@@ -447,9 +449,18 @@ class ReaderStream extends React.Component {
 	};
 
 	render() {
-		const store = this.props.postsStore,
-			hasNoPosts = store.isLastPage() && ( ! this.state.posts || this.state.posts.length === 0 );
+		const { forcePlaceholders, postsStore: store } = this.props;
+		let { items, isFetchingPage } = this.state;
+
+		const hasNoPosts =
+			store.isLastPage() && ( ! this.state.posts || this.state.posts.length === 0 );
 		let body, showingStream;
+
+		// trick an infinite list to showing placeholders
+		if ( forcePlaceholders ) {
+			items = [];
+			isFetchingPage = true;
+		}
 
 		if ( hasNoPosts || store.hasRecentError( 'invalid_tag' ) ) {
 			body = this.props.emptyContent;
@@ -462,9 +473,9 @@ class ReaderStream extends React.Component {
 				<InfiniteList
 					ref={ c => ( this._list = c ) }
 					className="reader__content"
-					items={ this.state.items }
+					items={ items }
 					lastPage={ this.state.isLastPage }
-					fetchingNextPage={ this.state.isFetchingNextPage }
+					fetchingNextPage={ isFetchingPage }
 					guessedItemHeight={ GUESSED_POST_HEIGHT }
 					fetchNextPage={ this.fetchNextPage }
 					getItemRef={ this.getPostRef }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -132,6 +132,7 @@ class TagStream extends React.Component {
 				listName={ this.state.title }
 				emptyContent={ emptyContent }
 				showFollowInHeader={ true }
+				forcePlaceholders={ ! tag } // if tag hasn't loaded yet, then make everything a placeholder
 			>
 				<QueryReaderFollowedTags />
 				<QueryReaderTag tag={ this.props.decodedTagSlug } />


### PR DESCRIPTION
Tag streams should only have placeholders until we confirm the existence of the tag (but we eagerly load posts in case it does exist).

Part of https://github.com/Automattic/wp-calypso/issues/20705.
