### PR TITLE
Sidebar: Add support for second-level sidebar navigation

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -14,7 +14,7 @@
 
 	--sidebar-color: $gray-dark;
 	--sidebar-background: lighten( $gray, 30% );
-	--sidebar-gridicon-fill: $gray;
+	--sidebar-gridicon-fill: darken( $gray, 20% );
 	--sidebar-heading-color: darken( $gray, 10% );
 	--sidebar-footer-button-color: darken( $gray, 10% );
 	--sidebar-menu-link-secondary-text-color: darken( $gray, 20% );

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -101,6 +101,7 @@
 	font-size: 13px;
 	font-weight: 400;
 	line-height: 1.4;
+	transition: transform 0.2s ease-in-out;
 }
 
 .site__domain {

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -101,7 +101,6 @@
 	font-size: 13px;
 	font-weight: 400;
 	line-height: 1.4;
-	transition: transform 0.2s ease-in-out;
 }
 
 .site__domain {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -510,3 +510,30 @@ form.sidebar__button input {
 	}
 }
 
+.sidebar__header-card.card {
+	box-sizing: border-box;
+	height: 46px;
+	padding: 8px 8px 8px 46px;
+	position: relative;
+}
+
+.sidebar__header-card__chevron {
+	position: absolute;
+		top: 10px;
+		left: 18px;
+}
+
+.sidebar__header-card__section-title {
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 1;
+	margin-bottom: 2px;
+	color: $gray-dark;
+}
+
+.sidebar__header-card__site-title {
+	font-size: 13px;
+	color: $gray-text-min;
+	line-height: 1;
+}
+

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -440,6 +440,8 @@ form.sidebar__button input {
 
 .sidebar__region {
 	flex-shrink: 0;
+	transition: all 0.1s ease-in-out;
+	
 	@include breakpoint( ">660px" ) {
 		display: flex;
 		flex-direction: column;
@@ -487,3 +489,24 @@ form.sidebar__button input {
 		fill: $blue-medium;
 	}
 }
+
+.sidebar li.sidebar__sub-sidebar {
+	position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+	transform: translateX( 100% );
+	transition: all 0.1s ease-in-out;
+}
+
+.sidebar.sub-sidebar-showing {
+	.sidebar__region {
+		transform: translateX( -100% );
+	}
+
+	li.sidebar__sub-sidebar {
+		transform: translateX( 0 );
+	}
+}
+

--- a/client/layout/sidebar/sub-sidebar.jsx
+++ b/client/layout/sidebar/sub-sidebar.jsx
@@ -16,6 +16,8 @@ import Card from 'components/card/compact';
 class SubSidebar extends React.Component {
 	static propTypes = {
 		items: PropTypes.func.isRequired,
+		title: PropTypes.func.isRequired,
+		siteTitle: PropTypes.string.isRequired,
 	};
 
 	render() {
@@ -40,8 +42,8 @@ class SubSidebar extends React.Component {
 				<ul className={ classNames( 'sub-sidebar__list', this.props.className ) }>
 					<Card className="sidebar__header-card" onClick={ this.props.resetSubSidebar }>
 						<Gridicon className="sidebar__header-card__chevron" icon="chevron-left" />
-						<h2 className="sidebar__header-card__section-title">Settings</h2>
-						<h3 className="sidebar__header-card__site-title">Sporadic Thoughts</h3>
+						<h2 className="sidebar__header-card__section-title">{ this.props.title() }</h2>
+						<h3 className="sidebar__header-card__site-title">{ this.props.siteTitle }</h3>
 					</Card>
 					{ listItems }
 				</ul>

--- a/client/layout/sidebar/sub-sidebar.jsx
+++ b/client/layout/sidebar/sub-sidebar.jsx
@@ -10,6 +10,8 @@ import classNames from 'classnames';
  */
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
+import Gridicon from 'gridicons';
+import Card from 'components/card/compact';
 
 class SubSidebar extends React.Component {
 	static propTypes = {
@@ -18,7 +20,6 @@ class SubSidebar extends React.Component {
 
 	render() {
 		const items = this.props.items();
-		console.log( 'items:', items );
 
 		if ( !items ) {
 			return(
@@ -37,11 +38,11 @@ class SubSidebar extends React.Component {
 		return(
 			<SidebarMenu className="sidebar__sub-sidebar">
 				<ul className={ classNames( 'sub-sidebar__list', this.props.className ) }>
-				<SidebarItem
-					label="← Back"
-					key="back"
-					onNavigate={ this.props.resetSubSidebar }
-				/>
+					<Card className="sidebar__header-card" onClick={ this.props.resetSubSidebar }>
+						<Gridicon className="sidebar__header-card__chevron" icon="chevron-left" />
+						<h2 className="sidebar__header-card__section-title">Settings</h2>
+						<h3 className="sidebar__header-card__site-title">Sporadic Thoughts</h3>
+					</Card>
 					{ listItems }
 				</ul>
 			</SidebarMenu>

--- a/client/layout/sidebar/sub-sidebar.jsx
+++ b/client/layout/sidebar/sub-sidebar.jsx
@@ -21,7 +21,9 @@ class SubSidebar extends React.Component {
 		console.log( 'items:', items );
 
 		if ( !items ) {
-			return null;
+			return(
+				<SidebarMenu className="sidebar__sub-sidebar" />
+			);
 		}
 
 		const listItems = items.map( ( item ) =>
@@ -33,8 +35,8 @@ class SubSidebar extends React.Component {
 			/>
 		);
 		return(
-			<SidebarMenu>
-				<ul className={ classNames( 'sidebar__sub-sidebar', this.props.className ) }>
+			<SidebarMenu className="sidebar__sub-sidebar">
+				<ul className={ classNames( 'sub-sidebar__list', this.props.className ) }>
 				<SidebarItem
 					label="← Back"
 					key="back"

--- a/client/layout/sidebar/sub-sidebar.jsx
+++ b/client/layout/sidebar/sub-sidebar.jsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import SidebarItem from 'layout/sidebar/item';
+import SidebarMenu from 'layout/sidebar/menu';
+
+class SubSidebar extends React.Component {
+	static propTypes = {
+		items: PropTypes.func.isRequired,
+	};
+
+	render() {
+		const items = this.props.items();
+		console.log( 'items:', items );
+
+		if ( !items ) {
+			return null;
+		}
+
+		const listItems = items.map( ( item ) =>
+			<SidebarItem
+				label={ item.label }
+				link={ item.link }
+				icon={ item.icon }
+				key={ item.link }
+			/>
+		);
+		return(
+			<SidebarMenu>
+				<ul className={ classNames( 'sidebar__sub-sidebar', this.props.className ) }>
+				<SidebarItem
+					label="← Back"
+					key="back"
+					onNavigate={ this.props.resetSubSidebar }
+				/>
+					{ listItems }
+				</ul>
+			</SidebarMenu>
+		);
+	}
+}
+
+export default SubSidebar;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -87,10 +87,9 @@
 .layout {
 	.sidebar,
 	.layout__secondary .site-selector,
-	.current-site,
 	.sidebar__menu {
 		transform: translateX( 0 );
-		transition: all 0.15s cubic-bezier(0.075, 0.820, 0.165, 1.000);
+		transition: all 0.15s ease-in-out;
 	}
 }
 
@@ -110,12 +109,15 @@
 	}
 
 	.layout__secondary .site-selector {
-		opacity: 1;
 		transform: translateX( 272px );
 		pointer-events: auto;
 
 		@include breakpoint( "<660px" ) {
 			transform: translateX( 100% );
+		}
+
+		.search {
+			opacity: 1;
 		}
 	}
 
@@ -123,10 +125,8 @@
 		pointer-events: none;
 	}
 
-	.current-site,
 	.sidebar__menu {
-		opacity: 0;
-		transform: translateX( 64px );
+		transform: translateX( 272px );
 	}
 }
 
@@ -136,8 +136,6 @@
 
 // site selector in the sidebar
 .layout__secondary .site-selector {
-	background: lighten( $gray, 30% );
-	border-right: 1px solid lighten( $gray, 25% );
 	position: fixed;
 		top: 47px;
 		bottom: 0;
@@ -145,11 +143,15 @@
 	width: 272px;
 	overflow: hidden;
 	z-index: z-index( 'root', '.layout__secondary .site-selector' );
-	opacity: 0;
 	pointer-events: none;
 
 	.search {
-		border-bottom: 1px solid lighten( $gray, 20% );
+		//border-bottom: 1px solid lighten( $gray, 20% );
+		margin: 0;
+		height: 46px;
+		border: none;
+		opacity: 0;
+		transition: opacity 0.15s ease-in-out;
 	}
 
 	.site,

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -124,7 +124,7 @@ class CurrentSite extends Component {
 
 				{ selectedSite ? (
 					<div>
-						<Site site={ selectedSite } />
+						<Site compact={ true } site={ selectedSite } />
 					</div>
 				) : (
 					<AllSites />

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -22,6 +22,7 @@ import Gridicon from 'gridicons';
 import SiteNotice from './notice';
 import CartStore from 'lib/cart/store';
 import Count from 'components/count';
+import classnames from 'classnames';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSelectedOrAllSites, getVisibleSites } from 'state/selectors';
@@ -93,6 +94,8 @@ class CurrentSite extends Component {
 	render() {
 		const { selectedSite, translate, anySiteSelected, rtlOn } = this.props;
 
+		let isMultiSite = this.props.siteCount > 1;
+
 		if ( ! anySiteSelected.length ) {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
@@ -113,7 +116,7 @@ class CurrentSite extends Component {
 		}
 
 		return (
-			<Card className="current-site">
+			<Card className={ classnames( 'current-site', isMultiSite ? 'has-multiple-sites' : null ) }>
 				{ selectedSite ? (
 					<div>
 						<Site compact={ true } site={ selectedSite } />
@@ -126,7 +129,7 @@ class CurrentSite extends Component {
 
 				<SiteNotice site={ selectedSite } allSitesPath={ this.props.allSitesPath } />
 
-				{ this.props.siteCount > 1 && (
+				{ isMultiSite && (
 					<span className="current-site__switch-sites">
 						<Button compact borderless onClick={ this.switchSites }>
 							<Gridicon icon={ rtlOn ? 'arrow-right' : 'arrow-left' } size={ 18 } />

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -21,6 +21,7 @@ import Site from 'blocks/site';
 import Gridicon from 'gridicons';
 import SiteNotice from './notice';
 import CartStore from 'lib/cart/store';
+import Count from 'components/count';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSelectedOrAllSites, getVisibleSites } from 'state/selectors';
@@ -113,15 +114,6 @@ class CurrentSite extends Component {
 
 		return (
 			<Card className="current-site">
-				{ this.props.siteCount > 1 && (
-					<span className="current-site__switch-sites">
-						<Button compact borderless onClick={ this.switchSites }>
-							<Gridicon icon={ rtlOn ? 'arrow-right' : 'arrow-left' } size={ 18 } />
-							{ translate( 'Switch Site' ) }
-						</Button>
-					</span>
-				) }
-
 				{ selectedSite ? (
 					<div>
 						<Site compact={ true } site={ selectedSite } />
@@ -133,6 +125,18 @@ class CurrentSite extends Component {
 				<AsyncLoad require="my-sites/current-site/domain-warnings" placeholder={ null } />
 
 				<SiteNotice site={ selectedSite } allSitesPath={ this.props.allSitesPath } />
+
+				{ this.props.siteCount > 1 && (
+					<span className="current-site__switch-sites">
+						<Button compact borderless onClick={ this.switchSites }>
+							<Gridicon icon={ rtlOn ? 'arrow-right' : 'arrow-left' } size={ 18 } />
+							<Count primary count={ this.props.siteCount } />
+							<span className="current-site__switch-sites-label">
+								{ translate( 'Switch Site' ) }
+							</span>
+						</Button>
+					</span>
+				) }
 			</Card>
 		);
 	}

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -8,6 +8,7 @@
 	padding: 0;
 	box-shadow: none;
 	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
+	transition: padding 0.2s ease-in-out;
 
 	&.is-loading {
 		.site-icon {
@@ -24,6 +25,33 @@
 
 			&::before {
 				visibility: hidden;
+			}
+		}
+	}
+
+	&:hover {
+		padding-left: 38px;
+
+		.site__title {
+			transform: translateY( -8px );
+		}
+
+		.current-site__switch-sites {
+			transform: translateX( 0 );
+
+			.gridicon {
+				fill: $blue-medium;
+			}
+
+			.count {
+				opacity: 1;
+			}
+
+			.current-site__switch-sites-label {
+				opacity: 1;
+				//top: 25px;
+				//left: 86px;
+				transform: translate( 0, 0 );
 			}
 		}
 	}
@@ -94,30 +122,50 @@
 }
 
 .current-site__switch-sites {
-	//background: var( --current-site-switch-sites-background );
-	background: $white;
-	//border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
 	display: block;
 	box-sizing: border-box;
 	cursor: pointer;
 	position: absolute;
 		top: 0;
+		right: 0;
+		bottom: 0;
 		left: 0;
-	width: 48px;
-	opacity: 0;
-	transition: all 0.2s ease-in-out;
+	transform: translateX( -8px );
+	transition: opacity 0.2s ease-in-out,
+		transform 0.2s ease-in-out;
 
 	.button {
 		text-align: left;
-		padding: 16px;
+		padding: 0 8px;
 		width: 100%;
-		height: 46px;
-		transform: translateX( -20px );
-		transition: all 0.2s ease-in-out;
+		height: 100%;
 	}
 
-	span {
-		display: none;
+
+	.gridicon {
+		fill: $gray-dark;
+	}
+
+	.count {
+		margin-left: -7px;
+		opacity: 0;
+		transition: opacity 0.2s ease-in-out;
+	}
+
+	.current-site__switch-sites-label {
+		//display: none;
+		position: absolute;
+			//top: 19px;
+			//left: 56px;
+			top: 25px;
+			left: 86px;
+		font-weight: 400;
+		font-size: 12px;
+		color: $gray-text-min;
+		opacity: 0;
+		transform: translate( -30px, -5px );
+		transition: transform 0.2s ease-in-out,
+			opacity 0.2s ease-in-out;
 	}
 
 	@include breakpoint( "<660px" ) {
@@ -125,16 +173,9 @@
 	}
 
 	&:hover {
-		opacity: 1;
-		//background-color: lighten( $sidebar-bg-color, 3% );
-
 		.button.is-borderless:hover,
 		.button.is-borderless:focus {
 			color: $sidebar-text-color;
-		}
-
-		.button {
-			transform: translateX( 0 );
 		}
 	}
 }

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -94,18 +94,30 @@
 }
 
 .current-site__switch-sites {
-	background: var( --current-site-switch-sites-background );
-	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
+	//background: var( --current-site-switch-sites-background );
+	background: $white;
+	//border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
 	display: block;
 	box-sizing: border-box;
 	cursor: pointer;
-	position: relative;
+	position: absolute;
+		top: 0;
+		left: 0;
+	width: 48px;
+	opacity: 0;
+	transition: all 0.2s ease-in-out;
 
 	.button {
 		text-align: left;
 		padding: 16px;
 		width: 100%;
 		height: 46px;
+		transform: translateX( -20px );
+		transition: all 0.2s ease-in-out;
+	}
+
+	span {
+		display: none;
 	}
 
 	@include breakpoint( "<660px" ) {
@@ -113,11 +125,16 @@
 	}
 
 	&:hover {
-		background-color: lighten( $sidebar-bg-color, 3% );
+		opacity: 1;
+		//background-color: lighten( $sidebar-bg-color, 3% );
 
 		.button.is-borderless:hover,
 		.button.is-borderless:focus {
 			color: $sidebar-text-color;
+		}
+
+		.button {
+			transform: translateX( 0 );
 		}
 	}
 }

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -8,10 +8,10 @@
 	padding: 0;
 	box-shadow: none;
 	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
-	transition: padding 0.2s ease-in-out 0.5s;
+	transition: padding 0.15s ease-in-out 0.3s;
 
 	.site__title {
-		transition: transform 0.2s ease-in-out 0.5s;
+		transition: transform 0.15s ease-in-out 0.3s;
 	}
 
 	&.is-loading {
@@ -33,8 +33,12 @@
 		}
 	}
 
-	&:hover {
-		padding-left: 38px;
+	&.has-multiple-sites {
+		padding-left: 16px;
+	}
+
+	&.has-multiple-sites:hover {
+		padding-left: 42px;
 
 		.site__title {
 			transform: translateY( -8px );
@@ -53,8 +57,6 @@
 
 			.current-site__switch-sites-label {
 				opacity: 1;
-				//top: 25px;
-				//left: 86px;
 				transform: translate( 0, 0 );
 			}
 		}
@@ -134,9 +136,9 @@
 		right: 0;
 		bottom: 0;
 		left: 0;
-	transform: translateX( -8px );
-	transition: opacity 0.2s ease-in-out 0.5s,
-		transform 0.2s ease-in-out 0.5s;
+	transform: translateX( 0 );
+	transition: opacity 0.15s ease-in-out 0.3s,
+		transform 0.15s ease-in-out 0.3s;
 
 	.button {
 		text-align: left;
@@ -153,23 +155,20 @@
 	.count {
 		margin-left: -7px;
 		opacity: 0;
-		transition: opacity 0.2s ease-in-out 0.5s;
+		transition: opacity 0.15s ease-in-out 0.3s;
 	}
 
 	.current-site__switch-sites-label {
-		//display: none;
 		position: absolute;
-			//top: 19px;
-			//left: 56px;
 			top: 25px;
-			left: 86px;
+			left: 90px;
 		font-weight: 400;
 		font-size: 12px;
 		color: $gray-text-min;
 		opacity: 0;
 		transform: translate( -30px, -5px );
-		transition: transform 0.2s ease-in-out 0.5s,
-			opacity 0.2s ease-in-out 0.5s;
+		transition: transform 0.15s ease-in-out 0.3s,
+			opacity 0.15s ease-in-out 0.3s;
 	}
 
 	@include breakpoint( "<660px" ) {

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -8,7 +8,11 @@
 	padding: 0;
 	box-shadow: none;
 	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
-	transition: padding 0.2s ease-in-out;
+	transition: padding 0.2s ease-in-out 0.5s;
+
+	.site__title {
+		transition: transform 0.2s ease-in-out 0.5s;
+	}
 
 	&.is-loading {
 		.site-icon {
@@ -131,8 +135,8 @@
 		bottom: 0;
 		left: 0;
 	transform: translateX( -8px );
-	transition: opacity 0.2s ease-in-out,
-		transform 0.2s ease-in-out;
+	transition: opacity 0.2s ease-in-out 0.5s,
+		transform 0.2s ease-in-out 0.5s;
 
 	.button {
 		text-align: left;
@@ -149,7 +153,7 @@
 	.count {
 		margin-left: -7px;
 		opacity: 0;
-		transition: opacity 0.2s ease-in-out;
+		transition: opacity 0.2s ease-in-out 0.5s;
 	}
 
 	.current-site__switch-sites-label {
@@ -164,8 +168,8 @@
 		color: $gray-text-min;
 		opacity: 0;
 		transform: translate( -30px, -5px );
-		transition: transform 0.2s ease-in-out,
-			opacity 0.2s ease-in-out;
+		transition: transform 0.2s ease-in-out 0.5s,
+			opacity 0.2s ease-in-out 0.5s;
 	}
 
 	@include breakpoint( "<660px" ) {
@@ -207,3 +211,4 @@
 		border-radius: 0;
 	}
 }
+

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -27,6 +27,7 @@ import SidebarHeading from 'layout/sidebar/heading';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
+import SubSidebar from 'layout/sidebar/sub-sidebar';
 import StatsSparkline from 'blocks/stats-sparkline';
 import JetpackLogo from 'components/jetpack-logo';
 import { isPlan, isFreeTrial, isPersonal, isPremium, isBusiness } from 'lib/products-values';
@@ -69,6 +70,13 @@ export class MySitesSidebar extends Component {
 		isJetpack: PropTypes.bool,
 		isSiteAutomatedTransfer: PropTypes.bool,
 	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			currentSubSidebar: null,
+		};
+	}
 
 	componentDidMount() {
 		debug( 'The sidebar React component is mounted.' );
@@ -464,8 +472,7 @@ export class MySitesSidebar extends Component {
 			<SidebarItem
 				label={ this.props.translate( 'People' ) }
 				className={ this.itemLinkClass( '/people', 'users' ) }
-				link={ usersLink }
-				onNavigate={ this.onNavigate }
+				onNavigate={ this.loadSubSidebar( 'people' ) }
 				icon="user"
 				preloadSectionName="people"
 			>
@@ -474,9 +481,15 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
+	loadSubSidebar( sectionName ) {
+		return () => {
+			console.log( 'Sidebar.loadSubSidebar', sectionName );
+			this.setState( { currentSubSidebar: sectionName } );
+		};
+	}
+
 	siteSettings() {
 		const { site, canUserManageOptions } = this.props;
-		const siteSettingsLink = '/settings/general' + this.props.siteSuffix;
 
 		if ( site && ! canUserManageOptions ) {
 			return null;
@@ -490,12 +503,13 @@ export class MySitesSidebar extends Component {
 			<SidebarItem
 				label={ this.props.translate( 'Settings' ) }
 				className={ this.itemLinkClass( '/settings', 'settings' ) }
-				link={ siteSettingsLink }
-				onNavigate={ this.onNavigate }
+				onNavigate={ this.loadSubSidebar( 'settings' ) }
 				icon="cog"
 				preloadSectionName="settings"
 				tipTarget="settings"
-			/>
+			>
+				<Gridicon className="sidebar__chevron-right" icon="chevron-right" />
+			</SidebarItem>
 		);
 	}
 
@@ -648,13 +662,46 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
+	subSidebarItems() {
+		// a database of subsidebar items used for prototyping
+		const siteSettingsLink = section => {
+			return '/settings/' + section + this.props.siteSuffix;
+		};
+		const peopleLink = section => {
+			return '/people/' + section + this.props.siteSuffix;
+		};
+		const siteSuffix = this.props.siteSuffix;
+
+		const allItems = {
+			settings: [
+				{ label: 'General', link: siteSettingsLink( 'general' ), icon: 'cog' },
+				{ label: 'Writing', link: siteSettingsLink( 'writing' ), icon: 'cog' },
+				{ label: 'Discussion', link: siteSettingsLink( 'discussion' ), icon: 'cog' },
+			],
+			people: [
+				{ label: 'Team', link: peopleLink( 'team' ), icon: 'cog' },
+				{ label: 'Followers', link: peopleLink( 'followers' ), icon: 'cog' },
+				{ label: 'Email Subscribers', link: peopleLink( 'email-followers' ), icon: 'cog' },
+			],
+		};
+
+		return allItems[ this.state.currentSubSidebar ] || null;
+	}
+
 	render() {
+		const isSubSidebarShowing = !! this.state.currentSubSidebar;
 		return (
-			<Sidebar>
+			<Sidebar className={ isSubSidebarShowing ? 'sub-sidebar-showing' : '' }>
 				<SidebarRegion>
 					<CurrentSite allSitesPath={ this.props.allSitesPath } />
 					{ this.renderSidebarMenus() }
 				</SidebarRegion>
+				<SubSidebar
+					items={ this.subSidebarItems.bind( this ) }
+					resetSubSidebar={ this.loadSubSidebar( null ) }
+				>
+					something
+				</SubSidebar>
 				<SidebarFooter>{ this.addNewSite() }</SidebarFooter>
 			</Sidebar>
 		);

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -681,6 +681,16 @@ export class MySitesSidebar extends Component {
 		return allItems[ this.state.currentSubSidebar ] || null;
 	}
 
+	subSidebarTitles() {
+		// a database of subsidebar titles used for prototyping
+		const titles = {
+			settings: "Settings",
+			people: "People",
+		};
+
+		return titles[ this.state.currentSubSidebar ] || null;
+	}
+
 	render() {
 		const isSubSidebarShowing = !! this.state.currentSubSidebar;
 		return (
@@ -690,6 +700,8 @@ export class MySitesSidebar extends Component {
 				<SubSidebar
 					items={ this.subSidebarItems.bind( this ) }
 					resetSubSidebar={ this.loadSubSidebar( null ) }
+					title={ this.subSidebarTitles.bind( this ) }
+					siteTitle={ this.props.site.title }
 				/>
 				<SidebarFooter>{ this.addNewSite() }</SidebarFooter>
 			</Sidebar>

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -474,6 +474,7 @@ export class MySitesSidebar extends Component {
 				className={ this.itemLinkClass( '/people', 'users' ) }
 				onNavigate={ this.loadSubSidebar( 'people' ) }
 				icon="user"
+				forceInternalLink={ true }
 				preloadSectionName="people"
 			>
 				<SidebarButton href={ addPeopleLink }>{ this.props.translate( 'Add' ) }</SidebarButton>
@@ -505,6 +506,7 @@ export class MySitesSidebar extends Component {
 				className={ this.itemLinkClass( '/settings', 'settings' ) }
 				onNavigate={ this.loadSubSidebar( 'settings' ) }
 				icon="cog"
+				forceInternalLink={ true }
 				preloadSectionName="settings"
 				tipTarget="settings"
 			>

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -694,10 +694,8 @@ export class MySitesSidebar extends Component {
 		const isSubSidebarShowing = !! this.state.currentSubSidebar;
 		return (
 			<Sidebar className={ isSubSidebarShowing ? 'sub-sidebar-showing' : '' }>
-				<SidebarRegion>
-					<CurrentSite allSitesPath={ this.props.allSitesPath } />
-					{ this.renderSidebarMenus() }
-				</SidebarRegion>
+				<CurrentSite allSitesPath={ this.props.allSitesPath } />
+				<SidebarRegion>{ this.renderSidebarMenus() }</SidebarRegion>
 				<SubSidebar
 					items={ this.subSidebarItems.bind( this ) }
 					resetSubSidebar={ this.loadSubSidebar( null ) }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -235,16 +235,16 @@ export class MySitesSidebar extends Component {
 
 		return (
 			<SidebarItem
-				label={ this.props.translate( 'Themes' ) }
+				label={ this.props.translate( 'Customize' ) }
 				tipTarget="themes"
 				className={ this.itemLinkClass( '/themes', 'themes' ) }
-				link={ themesLink }
+				link={ this.props.customizeUrl }
 				onNavigate={ this.onNavigate }
-				icon="themes"
-				preloadSectionName="themes"
+				icon="customize"
+				preloadSectionName="customize"
 			>
-				<SidebarButton href={ this.props.customizeUrl } preloadSectionName="customize">
-					{ this.props.translate( 'Customize' ) }
+				<SidebarButton href={ themesLink } preloadSectionName="themes">
+					{ this.props.translate( 'Themes' ) }
 				</SidebarButton>
 			</SidebarItem>
 		);
@@ -476,15 +476,12 @@ export class MySitesSidebar extends Component {
 				icon="user"
 				forceInternalLink={ true }
 				preloadSectionName="people"
-			>
-				<SidebarButton href={ addPeopleLink }>{ this.props.translate( 'Add' ) }</SidebarButton>
-			</SidebarItem>
+			/>
 		);
 	}
 
 	loadSubSidebar( sectionName ) {
 		return () => {
-			console.log( 'Sidebar.loadSubSidebar', sectionName );
 			this.setState( { currentSubSidebar: sectionName } );
 		};
 	}
@@ -639,23 +636,15 @@ export class MySitesSidebar extends Component {
 					</SidebarMenu>
 				) : null }
 
-				{ !! this.themes() ? (
-					<SidebarMenu>
-						<SidebarHeading>{ this.props.translate( 'Personalize' ) }</SidebarHeading>
-						<ul>{ this.themes() }</ul>
-					</SidebarMenu>
-				) : null }
-
 				{ configuration ? (
 					<SidebarMenu>
 						<SidebarHeading>{ this.props.translate( 'Configure' ) }</SidebarHeading>
 						<ul>
+							{ !! this.themes() ? this.themes() : null }
+							{ this.siteSettings() }
 							{ this.ads() }
-							{ this.sharing() }
 							{ this.users() }
 							{ this.plugins() }
-							{ this.upgrades() }
-							{ this.siteSettings() }
 							{ this.wpAdmin() }
 						</ul>
 					</SidebarMenu>
@@ -677,6 +666,8 @@ export class MySitesSidebar extends Component {
 		const allItems = {
 			settings: [
 				{ label: 'General', link: siteSettingsLink( 'general' ), icon: 'briefcase' },
+				{ label: 'Domains', link: '/domains/manage' + siteSuffix, icon: 'domains' },
+				{ label: 'Sharing', link: '/sharing' + siteSuffix, icon: 'share' },
 				{ label: 'Writing', link: siteSettingsLink( 'writing' ), icon: 'pencil' },
 				{ label: 'Discussion', link: siteSettingsLink( 'discussion' ), icon: 'chat' },
 			],

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -476,7 +476,11 @@ export class MySitesSidebar extends Component {
 				icon="user"
 				forceInternalLink={ true }
 				preloadSectionName="people"
-			/>
+			>
+				<div className="sidebar__chevron-right">
+					<Gridicon icon="chevron-right" />
+				</div>
+			</SidebarItem>
 		);
 	}
 
@@ -507,7 +511,9 @@ export class MySitesSidebar extends Component {
 				preloadSectionName="settings"
 				tipTarget="settings"
 			>
-				<Gridicon className="sidebar__chevron-right" icon="chevron-right" />
+				<div className="sidebar__chevron-right">
+					<Gridicon icon="chevron-right" />
+				</div>
 			</SidebarItem>
 		);
 	}

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -674,14 +674,14 @@ export class MySitesSidebar extends Component {
 
 		const allItems = {
 			settings: [
-				{ label: 'General', link: siteSettingsLink( 'general' ), icon: 'cog' },
-				{ label: 'Writing', link: siteSettingsLink( 'writing' ), icon: 'cog' },
-				{ label: 'Discussion', link: siteSettingsLink( 'discussion' ), icon: 'cog' },
+				{ label: 'General', link: siteSettingsLink( 'general' ), icon: 'briefcase' },
+				{ label: 'Writing', link: siteSettingsLink( 'writing' ), icon: 'pencil' },
+				{ label: 'Discussion', link: siteSettingsLink( 'discussion' ), icon: 'chat' },
 			],
 			people: [
-				{ label: 'Team', link: peopleLink( 'team' ), icon: 'cog' },
-				{ label: 'Followers', link: peopleLink( 'followers' ), icon: 'cog' },
-				{ label: 'Email Subscribers', link: peopleLink( 'email-followers' ), icon: 'cog' },
+				{ label: 'Team', link: peopleLink( 'team' ), icon: 'user' },
+				{ label: 'Followers', link: peopleLink( 'followers' ), icon: 'reader-following' },
+				{ label: 'Email Subscribers', link: peopleLink( 'email-followers' ), icon: 'mail' },
 			],
 		};
 
@@ -699,9 +699,7 @@ export class MySitesSidebar extends Component {
 				<SubSidebar
 					items={ this.subSidebarItems.bind( this ) }
 					resetSubSidebar={ this.loadSubSidebar( null ) }
-				>
-					something
-				</SubSidebar>
+				/>
 				<SidebarFooter>{ this.addNewSite() }</SidebarFooter>
 			</Sidebar>
 		);


### PR DESCRIPTION
WIP: Adding support for second-level sidebar navigation. 

The sidebar has grown a bit uncontrolled in the past. Its organization doesn't always make sense. At the same time, it will need to grow a lot more (and more quickly) in the future, since things like WooCommerce and extensions / plugins bring with them their own settings screens, and so on. 

In this PR we're exploring how we can make the sidebar work with a feature set that is growing through new initiatives and plugins / extensions. 

Further details here: p8FazZ-dI-p2

Current status:

![nested-sidebars](https://user-images.githubusercontent.com/23619/34836944-9733aef2-f6f9-11e7-973a-927c12bd6baf.gif)
