### PR TITLE
Stop dispatching the RECEIVE_DELETED_SITE action to Flux store

### DIFF
--- a/client/lib/sites-list/actions.js
+++ b/client/lib/sites-list/actions.js
@@ -1,51 +1,15 @@
 /** @format */
 
 /**
- * External dependencies
- */
-
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:sites-list:actions' );
-
-/**
  * Internal dependencies
  */
 import Dispatcher from 'dispatcher';
-import wpcom from 'lib/wp';
 
 const SitesListActions = {
 	removeSitesNotices( logs ) {
 		Dispatcher.handleViewAction( {
 			type: 'REMOVE_SITES_NOTICES',
 			logs,
-		} );
-	},
-	deleteSite( site, onComplete ) {
-		Dispatcher.handleViewAction( {
-			type: 'DELETE_SITE',
-			site: site,
-		} );
-
-		debug( 'Deleting site', site );
-
-		wpcom.undocumented().deleteSite( site.ID, function( error ) {
-			if ( error ) {
-				Dispatcher.handleServerAction( {
-					type: 'RECEIVE_DELETED_SITE_ERROR',
-					error,
-				} );
-			} else {
-				SitesListActions.receiveDeletedSite( site );
-			}
-
-			onComplete( error );
-		} );
-	},
-
-	receiveDeletedSite( site ) {
-		Dispatcher.handleServerAction( {
-			type: 'RECEIVE_DELETED_SITE',
-			site,
 		} );
 	},
 };

--- a/client/lib/sites-list/index.js
+++ b/client/lib/sites-list/index.js
@@ -17,9 +17,6 @@ export default function() {
 		_sites.dispatchToken = Dispatcher.register( function( payload ) {
 			const action = payload.action;
 			switch ( action.type ) {
-				case 'RECEIVE_DELETED_SITE':
-					_sites.removeSite( action.site );
-					break;
 				case 'FETCH_SITES':
 					_sites.fetch(); // refetch the sites from .com
 					break;

--- a/client/lib/user/index.js
+++ b/client/lib/user/index.js
@@ -23,9 +23,6 @@ export default function() {
 User.dispatchToken = Dispatcher.register( function( payload ) {
 	var action = payload.action;
 	switch ( action.type ) {
-		case 'RECEIVE_DELETED_SITE':
-			_user.decrementSiteCount();
-			break;
 		case InvitesActionTypes.INVITE_ACCEPTED:
 			if ( [ 'follower', 'viewer' ].indexOf( action.invite.role ) === -1 ) {
 				_user.incrementSiteCount();

--- a/client/lib/user/index.js
+++ b/client/lib/user/index.js
@@ -24,31 +24,12 @@ User.dispatchToken = Dispatcher.register( function( payload ) {
 	var action = payload.action;
 	switch ( action.type ) {
 		case 'RECEIVE_DELETED_SITE':
-			decrementSiteCount();
-			_user.fetch();
+			_user.decrementSiteCount();
 			break;
 		case InvitesActionTypes.INVITE_ACCEPTED:
 			if ( [ 'follower', 'viewer' ].indexOf( action.invite.role ) === -1 ) {
-				incrementSiteCount();
+				_user.incrementSiteCount();
 			}
 			break;
 	}
 } );
-
-function decrementSiteCount() {
-	var data = _user.get(),
-		attributes = {
-			visible_site_count: data.visible_site_count - 1,
-			site_count: data.site_count - 1,
-		};
-	_user.set( attributes );
-}
-
-function incrementSiteCount() {
-	const data = _user.get(),
-		attributes = {
-			visible_site_count: data.visible_site_count + 1,
-			site_count: data.site_count + 1,
-		};
-	_user.set( attributes );
-}

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { isEqual } from 'lodash';
+import { entries, isEqual } from 'lodash';
 import store from 'store';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:user' );
@@ -254,21 +254,19 @@ User.prototype.sendVerificationEmail = function( fn ) {
 };
 
 User.prototype.set = function( attributes ) {
-	var changed = false,
-		computedAttributes = userUtils.getComputedAttributes( attributes );
+	let changed = false;
 
-	attributes = Object.assign( {}, attributes, computedAttributes );
-
-	for ( var prop in attributes ) {
-		if ( attributes.hasOwnProperty( prop ) && ! isEqual( attributes[ prop ], this.data[ prop ] ) ) {
-			this.data[ prop ] = attributes[ prop ];
+	for ( const [ attrName, attrValue ] of entries( attributes ) ) {
+		if ( ! isEqual( attrValue, this.data[ attrName ] ) ) {
+			this.data[ attrName ] = attrValue;
 			changed = true;
 		}
 	}
 
 	if ( changed ) {
-		this.emit( 'change' );
+		Object.assign( this.data, userUtils.getComputedAttributes( this.data ) );
 		store.set( 'wpcom_user', this.data );
+		this.emit( 'change' );
 	}
 
 	return changed;

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -272,6 +272,28 @@ User.prototype.set = function( attributes ) {
 	return changed;
 };
 
+User.prototype.decrementSiteCount = function() {
+	const user = this.get();
+	if ( user ) {
+		this.set( {
+			visible_site_count: user.visible_site_count - 1,
+			site_count: user.site_count - 1,
+		} );
+	}
+	this.fetch();
+};
+
+User.prototype.incrementSiteCount = function() {
+	const user = this.get();
+	if ( user ) {
+		return this.set( {
+			visible_site_count: user.visible_site_count + 1,
+			site_count: user.site_count + 1,
+		} );
+	}
+	this.fetch();
+};
+
 /**
  * Called every VERIFICATION_POLL_INTERVAL milliseconds
  * if the email is not verified.

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -36,7 +36,6 @@ import Main from 'components/main';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
-import { receiveDeletedSite as receiveDeletedSiteDeprecated } from 'lib/sites-list/actions';
 import { receiveDeletedSite } from 'state/sites/actions';
 import { refreshSitePlans } from 'state/sites/plans/actions';
 import SelectDropdown from 'components/select-dropdown';
@@ -125,11 +124,6 @@ class ConfirmCancelDomain extends React.Component {
 			const { isDomainOnlySite, translate, selectedSite } = this.props;
 
 			if ( isDomainOnlySite ) {
-				// Removing the domain from a domain-only site results
-				// in the site being deleted entirely. We need to call
-				// `receiveDeletedSiteDeprecated` here because the site
-				// exists in `sites-list` as well as the global store.
-				receiveDeletedSiteDeprecated( selectedSite );
 				this.props.receiveDeletedSite( selectedSite.ID );
 				this.props.setAllSitesSelected();
 			}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -39,7 +39,6 @@ import isHappychatAvailable from 'state/happychat/selectors/is-happychat-availab
 import FormSectionHeading from 'components/forms/form-section-heading';
 import userFactory from 'lib/user';
 import { isDomainOnlySite as isDomainOnly } from 'state/selectors';
-import { receiveDeletedSite as receiveDeletedSiteDeprecated } from 'lib/sites-list/actions';
 import { receiveDeletedSite } from 'state/sites/actions';
 import { setAllSitesSelected } from 'state/ui/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -204,11 +203,6 @@ class RemovePurchase extends Component {
 			} else {
 				if ( isDomainRegistration( purchase ) ) {
 					if ( isDomainOnlySite ) {
-						// Removing the domain from a domain-only site results
-						// in the site being deleted entirely. We need to call
-						// `receiveDeletedSiteDeprecated` here because the site
-						// exists in `sites-list` as well as the global store.
-						receiveDeletedSiteDeprecated( selectedSite );
 						this.props.receiveDeletedSite( selectedSite.ID );
 						this.props.setAllSitesSelected();
 					}

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -13,8 +13,10 @@ import debugFactory from 'debug';
 import config from 'config';
 import {
 	ANALYTICS_SUPER_PROPS_UPDATE,
+	JETPACK_DISCONNECT_RECEIVE,
 	NOTIFICATIONS_PANEL_TOGGLE,
 	SELECTED_SITE_SET,
+	SITE_DELETE_RECEIVE,
 	SITE_RECEIVE,
 	SITES_RECEIVE,
 	SITES_UPDATE,
@@ -24,6 +26,7 @@ import {
 } from 'state/action-types';
 import analytics from 'lib/analytics';
 import cartStore from 'lib/cart/store';
+import userFactory from 'lib/user';
 import {
 	isNotificationsOpen,
 	hasSitePendingAutomatedTransfer,
@@ -35,6 +38,7 @@ import keyboardShortcuts from 'lib/keyboard-shortcuts';
 import { fetchAutomatedTransferStatus } from 'state/automated-transfer/actions';
 
 const debug = debugFactory( 'calypso:state:middleware' );
+const user = userFactory();
 
 /**
  * Module variables
@@ -236,6 +240,11 @@ const handler = ( dispatch, action, getState ) => {
 			return;
 		case SELECTED_SITE_UNSUBSCRIBE:
 			removeSelectedSitesChangeListener( dispatch, action );
+			return;
+
+		case SITE_DELETE_RECEIVE:
+		case JETPACK_DISCONNECT_RECEIVE:
+			user.decrementSiteCount();
 			return;
 	}
 };


### PR DESCRIPTION
Removes the `RECEIVE_DELETED_SITE` Flux actions and makes sure that it's completely replaced by Redux's `SITE_DELETE_RECEIVE`.

There's some preparatory work in `lib/user` in the first two commits: fixing a bug when calling `User.prototype.set` and making `decrementSiteCount` and `incrementSiteCount` available as methods.

Then we can finally remove the `RECEIVE_DELETED_SITE`. The only nontrivial bit is adding a handler to `lib/middleware` to notify the `User` object about site count change. It replaces the equivalent code in the Flux dispatcher.

We also update the site counts in `User` on `JETPACK_DISCONNECT_RECEIVE`. It was a bug that this code was previously missing.

**How to test:**
Delete sites by various methods:
- disconnect a Jetpack site
- remove a domain-only purchase
- cancel a domain-only domain (without a site other than the placeholder one)

Check that the site list in the sidebar and the visible site count in the "All My Sites" box get updated correctly.

Check also the data in `state.sites.items` and in `state.users[currentUserId]`.