### PR TITLE
Site Selector: fix bug with highlighted site refs

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -99,15 +99,23 @@ class SiteSelector extends Component {
 
 	scrollToHighlightedSite() {
 		const selectorElement = ReactDom.findDOMNode( this.refs.selector );
-		if ( selectorElement ) {
-			const highlightedSiteElement = ReactDom.findDOMNode( this.refs.highlightedSite );
-			if ( highlightedSiteElement ) {
-				scrollIntoView( highlightedSiteElement, selectorElement, {
-					onlyScrollIfNeeded: true,
-				} );
-			} else {
-				selectorElement.scrollTop = 0;
-			}
+
+		if ( ! selectorElement ) {
+			return;
+		}
+
+		if ( ! this.highlightedSiteRef ) {
+			selectorElement.scrollTop = 0;
+
+			return;
+		}
+
+		const highlightedSiteElement = ReactDom.findDOMNode( this.highlightedSiteRef );
+
+		if ( highlightedSiteElement ) {
+			scrollIntoView( highlightedSiteElement, selectorElement, {
+				onlyScrollIfNeeded: true,
+			} );
 		}
 	}
 
@@ -293,11 +301,20 @@ class SiteSelector extends Component {
 		return siteElements;
 	}
 
+	setHighlightedSiteRef = isHighlighted => component => {
+		if ( isHighlighted && component ) {
+			this.highlightedSiteRef = component;
+		} else if ( isHighlighted ) {
+			this.highlightedSiteRef = null;
+		}
+	};
+
 	renderAllSites() {
 		if ( this.props.showAllSites && ! this.props.sitesFound && this.props.allSitesPath ) {
 			this.visibleSites.push( ALL_SITES );
 
 			const isHighlighted = this.isHighlighted( ALL_SITES );
+
 			return (
 				<AllSites
 					key="selector-all-sites"
@@ -306,7 +323,7 @@ class SiteSelector extends Component {
 					onMouseEnter={ this.onAllSitesHover }
 					isHighlighted={ isHighlighted }
 					isSelected={ this.isSelected( ALL_SITES ) }
-					ref={ isHighlighted ? 'highlightedSite' : null }
+					ref={ this.setHighlightedSiteRef( isHighlighted ) }
 				/>
 			);
 		}
@@ -320,6 +337,7 @@ class SiteSelector extends Component {
 		this.visibleSites.push( site.ID );
 
 		const isHighlighted = this.isHighlighted( site.ID );
+
 		return (
 			<Site
 				site={ site }
@@ -329,7 +347,7 @@ class SiteSelector extends Component {
 				onMouseEnter={ this.onSiteHover }
 				isHighlighted={ isHighlighted }
 				isSelected={ this.isSelected( site ) }
-				ref={ isHighlighted ? 'highlightedSite' : null }
+				ref={ this.setHighlightedSiteRef( isHighlighted ) }
 			/>
 		);
 	}


### PR DESCRIPTION
Today, I noticed a bug with `SiteSelector`: if you have two sites which end in numbers (like `lamostytransfer1280.blog` and `lamostytransfer1281.blog`) and you type in `80` or `81` into site selector, then select the site and then open site selector and remove the numbers, it will break Calypso: http://cld.wthms.co/bHCnSh.

@rachelmcr reported that: "I get the error when I clear any search that’s 4 characters or less (regardless of whether it’s letters or numbers)" and @bperson "I get a similar React error: “Unable to find node on an unmounted component.” if I clear the text from the switch site filter input ( by clicking on the right cross )".

It's not 100% deterministic and sometimes doesn't happen but I could reproduce it pretty reliably.

The error is about using `ReactDom.findDOMNode` on an already unmounted React component. When using keyboard or mouse navigation to scroll through sites in `SiteSelector`, we were assigning the `this.refs.highlightedSite` with the currently highlighted site. It's necessary to have a ref to this component because when we navigate the list with keyboard (arrow down or up), we want the items to move (with `scrollIntoView`). This was introduced in #5808 by @marekhrabe.

We could fix it by wrapping `ReactDom.findDOMNode` in a `try...catch`. However, I think we should not use `findDOMNode` on unmounted components and also using string refs through `this.refs` is deprecated. Therefore, I decided to fix it by adding a fn `setHighlightedSiteRef` which will assign the currently selected site component into the `this.highlightedSiteRef` class property. If the currently selected component is being unmounted , we assign `null` so we prevent the error.

## Testing

Play with the `SiteSelector`: try to repro the original bug, try using keyboard navigation (it should move the list when navigating to a site that's not currently visible).