### PR TITLE
Added size to JetpackLogo in new site view

### DIFF
--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -92,7 +92,7 @@ class JetpackNewSite extends Component {
 							</div>
 						</Card>
 						<Card className="jetpack-new-site__jetpack-site">
-							<JetpackLogo />
+							<JetpackLogo size={ 72 } />
 							<h3 className="jetpack-new-site__card-title">
 								{ this.props.translate( 'Add an existing WordPress site with Jetpack' ) }
 							</h3>


### PR DESCRIPTION
### To test
Go to http://calypso.localhost:3000/jetpack/new?ref=calypso-selector
(or the Calypso live version)

#### Before
![image](https://user-images.githubusercontent.com/1123119/33952710-e4b077c6-dfef-11e7-88fb-73356085e35e.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/33952661-c3064f38-dfef-11e7-826a-d92918b872d5.png)
