### PR TITLE
Framework: Update Gridicons to v2.1.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,8435 +1,4176 @@
 {
   "name": "wp-calypso",
   "version": "0.17.0",
-  "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
+    "@types/node": {
+      "version": "8.0.58",
+      "dev": true
+    },
     "5to6-codemod": {
-      "version": "github:5to6/5to6-codemod#60306b71d8dde341e4d4bb968e6fbaf6875e19ae",
+      "version": "1.7.0",
+      "from": "github:5to6/5to6-codemod#v1.7.0",
+      "resolved": "github:5to6/5to6-codemod#60306b71d8dde341e4d4bb968e6fbaf6875e19ae",
       "dev": true,
-      "requires": {
-        "jscodeshift": "0.3.30",
-        "lodash": "4.17.4",
-        "recast": "0.12.9"
-      },
       "dependencies": {
         "ast-types": {
           "version": "0.10.1",
-          "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
           "dev": true
         },
         "esprima": {
           "version": "4.0.0",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
           "dev": true
         },
         "lodash": {
           "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "recast": {
           "version": "0.12.9",
-          "integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
-          "dev": true,
-          "requires": {
-            "ast-types": "0.10.1",
-            "core-js": "2.5.3",
-            "esprima": "4.0.0",
-            "private": "0.1.8",
-            "source-map": "0.6.1"
-          }
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
     },
-    "@types/node": {
-      "version": "8.0.58",
-      "integrity": "sha512-V746iUU7eHNdzQipoACuguDlVhC7IHK8CES1jSkuFt352wwA84BCWPXaGekBd7R5XdNK5ReHONDVKxlL9IreAw==",
-      "dev": true
-    },
-    "JSONStream": {
-      "version": "0.8.4",
-      "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "0.0.5",
-        "through": "2.3.8"
-      }
-    },
     "abab": {
       "version": "1.0.4",
-      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
       "dev": true
     },
     "abbrev": {
-      "version": "1.1.1",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "version": "1.1.1"
     },
     "abstract-leveldown": {
-      "version": "2.6.3",
-      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-      "requires": {
-        "xtend": "4.0.1"
-      }
+      "version": "2.6.3"
     },
     "accepts": {
-      "version": "1.2.13",
-      "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
-      "requires": {
-        "mime-types": "2.1.17",
-        "negotiator": "0.5.3"
-      }
+      "version": "1.2.13"
     },
     "acorn": {
-      "version": "1.2.2",
-      "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ="
+      "version": "1.2.2"
     },
     "acorn-dynamic-import": {
       "version": "2.0.2",
-      "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-      "requires": {
-        "acorn": "4.0.13"
-      },
       "dependencies": {
         "acorn": {
-          "version": "4.0.13",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+          "version": "4.0.13"
         }
       }
     },
     "acorn-globals": {
       "version": "3.1.0",
-      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-      "requires": {
-        "acorn": "4.0.13"
-      },
       "dependencies": {
         "acorn": {
-          "version": "4.0.13",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+          "version": "4.0.13"
         }
       }
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
       }
     },
     "after": {
-      "version": "0.8.1",
-      "integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic="
+      "version": "0.8.1"
     },
     "ajv": {
-      "version": "5.5.1",
-      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
-      "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
-      }
+      "version": "5.5.1"
     },
     "ajv-keywords": {
-      "version": "2.1.1",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+      "version": "2.1.1"
     },
     "align-text": {
-      "version": "0.1.4",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
+      "version": "0.1.4"
     },
     "alter": {
       "version": "0.2.0",
-      "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
-      "dev": true,
-      "requires": {
-        "stable": "0.1.6"
-      }
+      "dev": true
     },
     "amdefine": {
-      "version": "1.0.1",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "version": "1.0.1"
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
     "ansi-gray": {
       "version": "0.1.1",
-      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-      "dev": true,
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
+      "dev": true
     },
     "ansi-html": {
-      "version": "0.0.6",
-      "integrity": "sha1-vajjPdLuHCD1TAjrQFcTy/wO2A4="
+      "version": "0.0.6"
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "version": "2.1.1"
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "version": "2.2.1"
     },
     "ansi-wrap": {
       "version": "0.1.0",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
     "ansicolors": {
       "version": "0.2.1",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=",
       "dev": true
     },
     "anymatch": {
-      "version": "1.3.2",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
-      }
+      "version": "1.3.2"
     },
     "append-transform": {
       "version": "0.4.0",
-      "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-      "dev": true,
-      "requires": {
-        "default-require-extensions": "1.0.0"
-      }
+      "dev": true
     },
     "aproba": {
-      "version": "1.2.0",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "version": "1.2.0"
     },
     "are-we-there-yet": {
       "version": "1.1.4",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3"
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "version": "2.3.3"
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "argparse": {
       "version": "1.0.9",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "1.0.3"
-      }
+      "dev": true
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "requires": {
-        "arr-flatten": "1.1.0"
-      }
+      "version": "2.0.0"
     },
     "arr-flatten": {
-      "version": "1.1.0",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "version": "1.1.0"
     },
     "array-differ": {
       "version": "1.0.0",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
     "array-equal": {
       "version": "1.0.0",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
     "array-filter": {
-      "version": "0.0.1",
-      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+      "version": "0.0.1"
     },
     "array-find-index": {
-      "version": "1.0.2",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+      "version": "1.0.2"
     },
     "array-flatten": {
-      "version": "1.1.1",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+      "version": "1.1.1"
     },
     "array-map": {
-      "version": "0.0.0",
-      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+      "version": "0.0.0"
     },
     "array-reduce": {
-      "version": "0.0.0",
-      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+      "version": "0.0.0"
     },
     "array-union": {
-      "version": "1.0.2",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
+      "version": "1.0.2"
     },
     "array-uniq": {
-      "version": "1.0.3",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+      "version": "1.0.3"
     },
     "array-unique": {
-      "version": "0.2.1",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+      "version": "0.2.1"
     },
     "arraybuffer.slice": {
-      "version": "0.0.6",
-      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
+      "version": "0.0.6"
     },
     "arrify": {
-      "version": "1.0.1",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+      "version": "1.0.1"
     },
     "asap": {
-      "version": "2.0.6",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "version": "2.0.6"
     },
     "asn1": {
-      "version": "0.2.3",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "version": "0.2.3"
     },
     "asn1.js": {
-      "version": "4.9.2",
-      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
-      "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.1",
-        "minimalistic-assert": "1.0.0"
-      }
+      "version": "4.9.2"
     },
     "assert": {
-      "version": "1.4.1",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "requires": {
-        "util": "0.10.3"
-      }
+      "version": "1.4.1"
     },
     "assert-plus": {
-      "version": "1.0.0",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "version": "1.0.0"
     },
     "assertion-error": {
       "version": "1.0.2",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
     "assets-webpack-plugin": {
-      "version": "3.5.1",
-      "integrity": "sha1-kxzg1m1C6I7V5/GNZVIpQ8V6OH0=",
-      "requires": {
-        "camelcase": "1.2.1",
-        "escape-string-regexp": "1.0.3",
-        "lodash.assign": "3.2.0",
-        "lodash.merge": "3.3.2",
-        "mkdirp": "0.5.1"
-      }
+      "version": "3.5.1"
     },
     "ast-traverse": {
       "version": "0.1.1",
-      "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY=",
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.6",
-      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
+      "version": "0.9.6"
     },
     "astral-regex": {
       "version": "1.0.0",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "async": {
-      "version": "0.9.0",
-      "integrity": "sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc="
+      "version": "0.9.0"
     },
     "async-each": {
-      "version": "1.0.1",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+      "version": "1.0.1"
     },
     "async-foreach": {
-      "version": "0.1.3",
-      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
+      "version": "0.1.3"
     },
     "async-kit": {
       "version": "2.2.3",
-      "integrity": "sha1-JkdRonndxfWbQZY4uAWuLEmFj7c=",
       "dev": true,
-      "requires": {
-        "nextgen-events": "0.9.9",
-        "tree-kit": "0.5.26"
-      },
       "dependencies": {
         "nextgen-events": {
           "version": "0.9.9",
-          "integrity": "sha1-OaivxKK4RTiMV+LGu5cWcRmGo6A=",
           "dev": true
         }
       }
     },
     "asynckit": {
-      "version": "0.4.0",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "version": "0.4.0"
     },
     "autoprefixer": {
-      "version": "6.3.5",
-      "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
-      "requires": {
-        "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000782",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "5.2.18",
-        "postcss-value-parser": "3.3.0"
-      }
+      "version": "6.3.5"
     },
     "autosize": {
-      "version": "3.0.15",
-      "integrity": "sha1-in43+vpfQqP0+PEVOn+15jHoyrU="
+      "version": "3.0.15"
     },
     "aws-sign2": {
-      "version": "0.7.0",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "version": "0.7.0"
     },
     "aws4": {
-      "version": "1.6.0",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+      "version": "1.6.0"
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
       "dependencies": {
         "chalk": {
-          "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "version": "1.1.3"
         },
         "supports-color": {
-          "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "version": "2.0.0"
         }
       }
     },
     "babel-core": {
       "version": "6.25.0",
-      "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.2.0",
-        "json5": "0.5.1",
-        "lodash": "4.15.0",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
-      },
       "dependencies": {
         "source-map": {
-          "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.5.7"
         }
       }
     },
     "babel-eslint": {
       "version": "6.1.2",
-      "integrity": "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=",
       "dev": true,
-      "requires": {
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash.assign": "4.2.0",
-        "lodash.pickby": "4.6.0"
-      },
       "dependencies": {
         "lodash.assign": {
           "version": "4.2.0",
-          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
           "dev": true
         }
       }
     },
     "babel-generator": {
       "version": "6.26.0",
-      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.4"
         },
         "source-map": {
-          "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.5.7"
         }
       }
     },
     "babel-helper-bindify-decorators": {
-      "version": "6.24.1",
-      "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.24.1",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-helper-builder-react-jsx": {
-      "version": "6.26.0",
-      "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "esutils": "2.0.2"
-      }
+      "version": "6.26.0"
     },
     "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-helper-define-map": {
       "version": "6.26.0",
-      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
-      },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.4"
         }
       }
     },
     "babel-helper-explode-assignable-expression": {
-      "version": "6.24.1",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-helper-explode-class": {
-      "version": "6.24.1",
-      "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
-      "requires": {
-        "babel-helper-bindify-decorators": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-helper-function-name": {
-      "version": "6.24.1",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-helper-optimise-call-expression": {
-      "version": "6.24.1",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-helper-regex": {
       "version": "6.26.0",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
-      },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.4"
         }
       }
     },
     "babel-helper-remap-async-to-generator": {
-      "version": "6.24.1",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-helper-replace-supers": {
-      "version": "6.24.1",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-helpers": {
-      "version": "6.24.1",
-      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-jest": {
       "version": "21.2.0",
-      "integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-istanbul": "4.1.5",
-        "babel-preset-jest": "21.2.0"
-      }
+      "dev": true
     },
     "babel-loader": {
-      "version": "7.1.1",
-      "integrity": "sha1-uHE0yLEuPkwqlOBUYIW8aAorhIg=",
-      "requires": {
-        "find-cache-dir": "1.0.0",
-        "loader-utils": "1.1.0",
-        "mkdirp": "0.5.1"
-      }
+      "version": "7.1.1"
     },
     "babel-messages": {
-      "version": "6.23.0",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.23.0"
     },
     "babel-plugin-add-module-exports": {
-      "version": "0.2.1",
-      "integrity": "sha1-mumh9KjcZ/DN7E9K7aHkOl/2XiU="
+      "version": "0.2.1"
     },
     "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.22.0"
     },
     "babel-plugin-constant-folding": {
       "version": "1.0.1",
-      "integrity": "sha1-g2HTZMmORJw2kr26Ue/whEKQqo4=",
       "dev": true
     },
     "babel-plugin-dead-code-elimination": {
       "version": "1.0.2",
-      "integrity": "sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U=",
       "dev": true
     },
     "babel-plugin-eval": {
       "version": "1.0.1",
-      "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo=",
       "dev": true
     },
     "babel-plugin-inline-environment-variables": {
       "version": "1.0.1",
-      "integrity": "sha1-H1jOkSB61qgmqL9kX6/mj/X+P/4=",
       "dev": true
     },
     "babel-plugin-istanbul": {
       "version": "4.1.5",
-      "integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
-      "dev": true,
-      "requires": {
-        "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.9.1",
-        "test-exclude": "4.1.1"
-      }
+      "dev": true
     },
     "babel-plugin-jest-hoist": {
       "version": "21.2.0",
-      "integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ==",
       "dev": true
     },
     "babel-plugin-jscript": {
       "version": "1.0.4",
-      "integrity": "sha1-jzQsOCduh6R9X6CovT1etsytj8w=",
       "dev": true
     },
     "babel-plugin-member-expression-literals": {
       "version": "1.0.1",
-      "integrity": "sha1-zF7bD6qNyScXDnTW0cAkQAIWJNM=",
       "dev": true
     },
     "babel-plugin-property-literals": {
       "version": "1.0.1",
-      "integrity": "sha1-AlIwGQAZKYCxwRjv6kjOk6q4MzY=",
       "dev": true
     },
     "babel-plugin-proto-to-assign": {
       "version": "1.0.4",
-      "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
       "dev": true,
-      "requires": {
-        "lodash": "3.10.1"
-      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
       }
     },
     "babel-plugin-react-constant-elements": {
       "version": "1.0.3",
-      "integrity": "sha1-lGc26DeEKcvDSdz/YvUcFDs041o=",
       "dev": true
     },
     "babel-plugin-react-display-name": {
       "version": "1.0.3",
-      "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw=",
       "dev": true
     },
     "babel-plugin-remove-console": {
       "version": "1.0.1",
-      "integrity": "sha1-2PJFVsOgUAXUKqqv0neH9T/wE6c=",
       "dev": true
     },
     "babel-plugin-remove-debugger": {
       "version": "1.0.1",
-      "integrity": "sha1-/S6jzWGkKK0fO5yJiC/0KT6MFMc=",
       "dev": true
     },
     "babel-plugin-runtime": {
       "version": "1.0.7",
-      "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8=",
       "dev": true
     },
     "babel-plugin-syntax-async-functions": {
-      "version": "6.13.0",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+      "version": "6.13.0"
     },
     "babel-plugin-syntax-async-generators": {
-      "version": "6.13.0",
-      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
+      "version": "6.13.0"
     },
     "babel-plugin-syntax-class-constructor-call": {
       "version": "6.18.0",
-      "integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
       "dev": true
     },
     "babel-plugin-syntax-class-properties": {
-      "version": "6.13.0",
-      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+      "version": "6.13.0"
     },
     "babel-plugin-syntax-decorators": {
-      "version": "6.13.0",
-      "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
+      "version": "6.13.0"
     },
     "babel-plugin-syntax-dynamic-import": {
-      "version": "6.18.0",
-      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
+      "version": "6.18.0"
     },
     "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+      "version": "6.13.0"
     },
     "babel-plugin-syntax-export-extensions": {
-      "version": "6.13.0",
-      "integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE="
+      "version": "6.13.0"
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
-      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
       "dev": true
     },
     "babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+      "version": "6.18.0"
     },
     "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+      "version": "6.13.0"
     },
     "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.22.0",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+      "version": "6.22.0"
     },
     "babel-plugin-transform-async-generator-functions": {
-      "version": "6.24.1",
-      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
-      "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-generators": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-async-to-generator": {
-      "version": "6.24.1",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-builtin-extend": {
       "version": "1.1.2",
-      "integrity": "sha1-Xpb+z1i4+h7XTvytiEdbKvPJEW4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-class-constructor-call": {
       "version": "6.24.1",
-      "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-class-constructor-call": "6.18.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-class-properties": {
-      "version": "6.24.1",
-      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-decorators": {
-      "version": "6.24.1",
-      "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
-      "requires": {
-        "babel-helper-explode-class": "6.24.1",
-        "babel-plugin-syntax-decorators": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.22.0",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.22.0",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.26.0",
-      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
-      },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.4"
         }
       }
     },
     "babel-plugin-transform-es2015-classes": {
-      "version": "6.24.1",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.24.1",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.23.0"
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.24.1",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-for-of": {
-      "version": "6.23.0",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.23.0"
     },
     "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-literals": {
-      "version": "6.22.0",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-modules-amd": {
-      "version": "6.24.1",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.0",
-      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
-      "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.26.0"
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.24.1",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-modules-umd": {
-      "version": "6.24.1",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-object-super": {
-      "version": "6.24.1",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.24.1",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.22.0",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.22.0"
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.23.0",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.23.0"
     },
     "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-es3-member-expression-literals": {
       "version": "6.22.0",
-      "integrity": "sha1-cz00RPPsxBvvjtGmpOCWV7iWnrs=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es3-property-literals": {
       "version": "6.22.0",
-      "integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.24.1",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-export-extensions": {
-      "version": "6.22.0",
-      "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
-      "requires": {
-        "babel-plugin-syntax-export-extensions": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.22.0"
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
-      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-imports": {
-      "version": "1.4.1",
-      "integrity": "sha512-o7EqCZFj0pKUUDwYDZLTRSg1wNMN69p31l3Sf1+ujTFjWUq+/plAUJ04kO1kn5oLVaHbwLi2F4jQbIHFTN2t+A==",
-      "requires": {
-        "babel-types": "6.26.0",
-        "lodash.camelcase": "4.3.0",
-        "lodash.kebabcase": "4.1.1",
-        "lodash.snakecase": "4.1.1"
-      }
+      "version": "1.4.1"
     },
     "babel-plugin-transform-object-rest-spread": {
-      "version": "6.26.0",
-      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.26.0"
     },
     "babel-plugin-transform-react-display-name": {
-      "version": "6.25.0",
-      "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.25.0"
     },
     "babel-plugin-transform-react-jsx": {
-      "version": "6.24.1",
-      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
-      "requires": {
-        "babel-helper-builder-react-jsx": "6.26.0",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-transform-regenerator": {
-      "version": "6.26.0",
-      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-      "requires": {
-        "regenerator-transform": "0.10.1"
-      }
+      "version": "6.26.0"
     },
     "babel-plugin-transform-runtime": {
-      "version": "6.23.0",
-      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "version": "6.23.0"
     },
     "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-plugin-undeclared-variables-check": {
       "version": "1.0.2",
-      "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
-      "dev": true,
-      "requires": {
-        "leven": "1.0.2"
-      }
+      "dev": true
     },
     "babel-plugin-undefined-to-void": {
       "version": "1.1.6",
-      "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E=",
       "dev": true
     },
     "babel-polyfill": {
       "version": "6.26.0",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.10.5"
-      },
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.10.5",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
           "dev": true
         }
       }
     },
     "babel-preset-env": {
       "version": "1.6.0",
-      "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.10.0",
-        "invariant": "2.2.2",
-        "semver": "5.4.1"
-      },
       "dependencies": {
         "browserslist": {
-          "version": "2.10.0",
-          "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
-          "requires": {
-            "caniuse-lite": "1.0.30000782",
-            "electron-to-chromium": "1.3.28"
-          }
+          "version": "2.10.0"
         },
         "semver": {
-          "version": "5.4.1",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+          "version": "5.4.1"
         }
       }
     },
     "babel-preset-es2015": {
       "version": "6.24.1",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0"
-      }
+      "dev": true
     },
     "babel-preset-fbjs": {
       "version": "1.0.0",
-      "integrity": "sha1-yXLlybMB1OyeeXH0rsPhSsAXqLA=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es3-member-expression-literals": "6.22.0",
-        "babel-plugin-transform-es3-property-literals": "6.22.0",
-        "babel-plugin-transform-flow-strip-types": "6.22.0",
-        "babel-plugin-transform-object-rest-spread": "6.26.0",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "babel-preset-jest": {
       "version": "21.2.0",
-      "integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-jest-hoist": "21.2.0",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0"
-      }
+      "dev": true
     },
     "babel-preset-stage-1": {
       "version": "6.24.1",
-      "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-class-constructor-call": "6.24.1",
-        "babel-plugin-transform-export-extensions": "6.22.0",
-        "babel-preset-stage-2": "6.24.1"
-      }
+      "dev": true
     },
     "babel-preset-stage-2": {
-      "version": "6.24.1",
-      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
-      "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-decorators": "6.24.1",
-        "babel-preset-stage-3": "6.24.1"
-      }
+      "version": "6.24.1"
     },
     "babel-preset-stage-3": {
-      "version": "6.24.1",
-      "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
-      "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-generator-functions": "6.24.1",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-object-rest-spread": "6.26.0"
-      }
+      "version": "6.24.1"
     },
     "babel-register": {
       "version": "6.24.1",
-      "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
-      "requires": {
-        "babel-core": "6.25.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.15.0",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
-      },
       "dependencies": {
         "source-map": {
-          "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.5.7"
         },
         "source-map-support": {
-          "version": "0.4.18",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "requires": {
-            "source-map": "0.5.7"
-          }
+          "version": "0.4.18"
         }
       }
     },
     "babel-runtime": {
-      "version": "6.26.0",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
-      }
+      "version": "6.26.0"
     },
     "babel-template": {
       "version": "6.26.0",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
-      },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.4"
         }
       }
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      },
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "version": "2.6.9"
         },
         "lodash": {
-          "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.4"
         },
         "ms": {
-          "version": "2.0.0",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "version": "2.0.0"
         }
       }
     },
     "babel-types": {
       "version": "6.26.0",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
-      },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.4"
         }
       }
     },
     "babylon": {
-      "version": "6.18.0",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "version": "6.18.0"
     },
     "backo2": {
-      "version": "1.0.2",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+      "version": "1.0.2"
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "version": "1.0.0"
     },
     "base62": {
-      "version": "0.1.1",
-      "integrity": "sha1-e0F0wvlESXU7EcJlHAg9qEGnsIQ="
+      "version": "0.1.1"
     },
     "base64-arraybuffer": {
-      "version": "0.1.2",
-      "integrity": "sha1-R030qfLaJOBd8xWMOx2zw81GoVQ="
+      "version": "0.1.2"
     },
     "base64-js": {
-      "version": "1.2.1",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+      "version": "1.2.1"
     },
     "base64id": {
       "version": "0.1.0",
-      "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8=",
       "dev": true
     },
     "basic-auth": {
-      "version": "1.0.0",
-      "integrity": "sha1-ERstn/jk5tE2uMhOpeCWy4c1Fjc="
+      "version": "1.0.0"
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
+      "optional": true
     },
     "beeper": {
       "version": "1.1.1",
-      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
     "benchmark": {
-      "version": "1.0.0",
-      "integrity": "sha1-Lx4vpMNZ8REiqhgwgiGOlX45DHM="
+      "version": "1.0.0"
     },
     "better-assert": {
-      "version": "1.0.2",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "requires": {
-        "callsite": "1.0.0"
-      }
+      "version": "1.0.2"
     },
     "big.js": {
-      "version": "3.2.0",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+      "version": "3.2.0"
     },
     "binary-extensions": {
-      "version": "1.11.0",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+      "version": "1.11.0"
     },
     "bindings": {
-      "version": "1.2.1",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+      "version": "1.2.1"
     },
     "bl": {
       "version": "1.2.1",
-      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-      "requires": {
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3"
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "version": "2.3.3"
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "blob": {
-      "version": "0.0.4",
-      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+      "version": "0.0.4"
     },
     "block-stream": {
-      "version": "0.0.9",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "requires": {
-        "inherits": "2.0.1"
-      }
+      "version": "0.0.9"
     },
     "bluebird": {
-      "version": "2.11.0",
-      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+      "version": "2.11.0"
     },
     "bn.js": {
-      "version": "4.11.8",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+      "version": "4.11.8"
     },
     "body-parser": {
       "version": "1.17.2",
-      "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
-      "requires": {
-        "bytes": "2.4.0",
-        "content-type": "1.0.4",
-        "debug": "2.6.7",
-        "depd": "1.1.1",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.15",
-        "on-finished": "2.3.0",
-        "qs": "6.4.0",
-        "raw-body": "2.2.0",
-        "type-is": "1.6.15"
-      },
       "dependencies": {
         "debug": {
-          "version": "2.6.7",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "version": "2.6.7"
         },
         "ms": {
-          "version": "2.0.0",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "version": "2.0.0"
         },
         "qs": {
-          "version": "6.4.0",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+          "version": "6.4.0"
         }
       }
     },
     "boolbase": {
       "version": "1.0.0",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
     "boom": {
-      "version": "4.3.1",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
+      "version": "4.3.1"
     },
     "bounding-client-rect": {
-      "version": "1.0.5",
-      "integrity": "sha1-meLNJgLQfyLqO+7kIFNFBP1EJM8=",
-      "requires": {
-        "get-document": "1.0.0"
-      }
+      "version": "1.0.5"
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
+      "version": "1.1.8"
     },
     "braces": {
-      "version": "1.8.5",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
-      }
+      "version": "1.8.5"
     },
     "breakable": {
       "version": "1.0.0",
-      "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME=",
       "dev": true
     },
     "brorand": {
-      "version": "1.1.0",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+      "version": "1.1.0"
     },
     "browser-filesaver": {
-      "version": "1.1.0",
-      "integrity": "sha1-xmJKvwixzgBmTsRANh775W1LEuY="
+      "version": "1.1.0"
     },
     "browser-resolve": {
       "version": "1.11.2",
-      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
       "dev": true,
-      "requires": {
-        "resolve": "1.1.7"
-      },
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
       }
     },
     "browserify-aes": {
-      "version": "1.1.1",
-      "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
-      "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.1",
-        "safe-buffer": "5.1.1"
-      }
+      "version": "1.1.1"
     },
     "browserify-cipher": {
-      "version": "1.0.0",
-      "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
-      "requires": {
-        "browserify-aes": "1.1.1",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.3"
-      }
+      "version": "1.0.0"
     },
     "browserify-des": {
-      "version": "1.0.0",
-      "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
-      "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.1"
-      }
+      "version": "1.0.0"
     },
     "browserify-rsa": {
-      "version": "4.0.1",
-      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-      "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.5"
-      }
+      "version": "4.0.1"
     },
     "browserify-sign": {
-      "version": "4.0.4",
-      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-      "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.1",
-        "parse-asn1": "5.1.0"
-      }
+      "version": "4.0.4"
     },
     "browserify-zlib": {
-      "version": "0.2.0",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-      "requires": {
-        "pako": "1.0.6"
-      }
+      "version": "0.2.0"
     },
     "browserslist": {
-      "version": "1.3.6",
-      "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
-      "requires": {
-        "caniuse-db": "1.0.30000782"
-      }
+      "version": "1.3.6"
     },
     "bser": {
       "version": "2.0.0",
-      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-      "dev": true,
-      "requires": {
-        "node-int64": "0.4.0"
-      }
+      "dev": true
     },
     "buffer": {
-      "version": "4.9.1",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "requires": {
-        "base64-js": "1.2.1",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
-      }
+      "version": "4.9.1"
     },
     "buffer-xor": {
-      "version": "1.0.3",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+      "version": "1.0.3"
     },
     "builtin-modules": {
-      "version": "1.1.1",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+      "version": "1.1.1"
     },
     "builtin-status-codes": {
-      "version": "3.0.0",
-      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+      "version": "3.0.0"
     },
     "bytes": {
-      "version": "2.4.0",
-      "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+      "version": "2.4.0"
     },
     "cacache": {
       "version": "10.0.1",
-      "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
-      "requires": {
-        "bluebird": "3.5.1",
-        "chownr": "1.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "lru-cache": "4.1.1",
-        "mississippi": "1.3.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.2",
-        "ssri": "5.0.0",
-        "unique-filename": "1.1.0",
-        "y18n": "3.2.1"
-      },
       "dependencies": {
         "bluebird": {
-          "version": "3.5.1",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+          "version": "3.5.1"
         },
         "glob": {
-          "version": "7.1.2",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "version": "7.1.2"
         }
       }
     },
     "caller-path": {
       "version": "0.1.0",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "0.2.0"
-      }
+      "dev": true
     },
     "callsite": {
-      "version": "1.0.0",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+      "version": "1.0.0"
     },
     "callsites": {
       "version": "0.2.0",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "camel-case": {
-      "version": "1.2.2",
-      "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
-      "requires": {
-        "sentence-case": "1.1.3",
-        "upper-case": "1.1.3"
-      }
+      "version": "1.2.2"
     },
     "camelcase": {
-      "version": "1.2.1",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+      "version": "1.2.1"
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
-      },
       "dependencies": {
         "camelcase": {
-          "version": "2.1.1",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+          "version": "2.1.1"
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000782",
-      "integrity": "sha1-2IFbzhV4w1Cs7REyUHMBIF4Pq1M="
+      "version": "1.0.30000783"
     },
     "caniuse-lite": {
-      "version": "1.0.30000782",
-      "integrity": "sha1-W4K4w4XyU0h0XEccpRMgr7G38lQ="
+      "version": "1.0.30000783"
     },
     "cardinal": {
       "version": "1.0.0",
-      "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
-      "dev": true,
-      "requires": {
-        "ansicolors": "0.2.1",
-        "redeyed": "1.0.1"
-      }
+      "dev": true
     },
     "caseless": {
-      "version": "0.12.0",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "version": "0.12.0"
     },
     "cash-touch": {
       "version": "0.2.0",
-      "integrity": "sha1-h8F8D2uTPFda2d00NyyKEUsK6J0=",
       "dev": true,
-      "requires": {
-        "fs-extra": "0.23.1",
-        "lodash": "4.15.0",
-        "vorpal": "1.12.0",
-        "vorpal-autocomplete-fs": "0.0.3"
-      },
       "dependencies": {
         "fs-extra": {
           "version": "0.23.1",
-          "integrity": "sha1-ZhHbpq3yq43Jxp+rN83fiBgVfj0=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
-          }
+          "dev": true
         }
       }
     },
     "center-align": {
-      "version": "0.1.3",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
+      "version": "0.1.3"
     },
     "chai": {
       "version": "3.5.0",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true,
-      "requires": {
-        "assertion-error": "1.0.2",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
-      }
+      "dev": true
     },
     "chai-enzyme": {
       "version": "1.0.0-beta.0",
-      "integrity": "sha512-b2XJjyW1PfnW5a5ZBBcZWZJUhq8CA1kpTyXLf4Nac+EaiTuIyYeYN0Ft0qYoW+clinusKDhvJygiVktjhvvFvg==",
-      "dev": true,
-      "requires": {
-        "html": "1.0.0"
-      }
+      "dev": true
     },
     "chain-function": {
-      "version": "1.0.0",
-      "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
+      "version": "1.0.0"
     },
     "chalk": {
       "version": "1.0.0",
-      "integrity": "sha1-s89O0P9Tl8mcdbj2edsvUoMfltw=",
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.3",
-        "has-ansi": "1.0.3",
-        "strip-ansi": "2.0.1",
-        "supports-color": "1.3.1"
-      },
       "dependencies": {
         "ansi-regex": {
-          "version": "1.1.1",
-          "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
+          "version": "1.1.1"
         },
         "has-ansi": {
-          "version": "1.0.3",
-          "integrity": "sha1-wLWxYV2eOCsP9nFp2We0JeSMpTg=",
-          "requires": {
-            "ansi-regex": "1.1.1",
-            "get-stdin": "4.0.1"
-          }
+          "version": "1.0.3"
         },
         "strip-ansi": {
-          "version": "2.0.1",
-          "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-          "requires": {
-            "ansi-regex": "1.1.1"
-          }
+          "version": "2.0.1"
         },
         "supports-color": {
-          "version": "1.3.1",
-          "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0="
+          "version": "1.3.1"
         }
       }
     },
     "change-case": {
-      "version": "2.3.1",
-      "integrity": "sha1-LE/ePwY7tB0AzWjg1aCdthy+iU8=",
-      "requires": {
-        "camel-case": "1.2.2",
-        "constant-case": "1.1.2",
-        "dot-case": "1.1.2",
-        "is-lower-case": "1.1.3",
-        "is-upper-case": "1.1.2",
-        "lower-case": "1.1.4",
-        "lower-case-first": "1.0.2",
-        "param-case": "1.1.2",
-        "pascal-case": "1.1.2",
-        "path-case": "1.1.2",
-        "sentence-case": "1.1.3",
-        "snake-case": "1.1.2",
-        "swap-case": "1.1.2",
-        "title-case": "1.1.2",
-        "upper-case": "1.1.3",
-        "upper-case-first": "1.1.2"
-      }
+      "version": "2.3.1"
     },
     "character-parser": {
-      "version": "2.2.0",
-      "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
-      "requires": {
-        "is-regex": "1.0.4"
-      }
+      "version": "2.2.0"
     },
     "check-node-version": {
       "version": "2.1.0",
-      "integrity": "sha1-hVZYQs95oJ36jiZnIFde4K7BmD0=",
-      "requires": {
-        "map-values": "1.0.1",
-        "minimist": "1.2.0",
-        "object-filter": "1.0.2",
-        "object.assign": "4.0.4",
-        "run-parallel": "1.1.6",
-        "semver": "5.1.0"
-      },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.0"
         }
       }
     },
     "cheerio": {
       "version": "1.0.0-rc.2",
-      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
-      "dev": true,
-      "requires": {
-        "css-select": "1.2.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.9.2",
-        "lodash": "4.15.0",
-        "parse5": "3.0.3"
-      }
+      "dev": true
     },
     "chokidar": {
       "version": "1.7.0",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.1",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
-      },
       "dependencies": {
         "is-extglob": {
-          "version": "1.0.0",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "version": "1.0.0"
         },
         "is-glob": {
-          "version": "2.0.1",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
+          "version": "2.0.1"
         }
       }
     },
     "chownr": {
-      "version": "1.0.1",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+      "version": "1.0.1"
     },
     "chrono-node": {
-      "version": "1.3.1",
-      "integrity": "sha1-0Nx2Kk2SYFG3UBatY8EAyv+dHYQ=",
-      "requires": {
-        "moment": "2.19.2"
-      }
+      "version": "1.3.1"
     },
     "ci-info": {
       "version": "1.1.2",
-      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
       "dev": true
     },
     "cipher-base": {
-      "version": "1.0.4",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "requires": {
-        "inherits": "2.0.1",
-        "safe-buffer": "5.1.1"
-      }
+      "version": "1.0.4"
     },
     "circular-json": {
       "version": "0.3.3",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "classnames": {
-      "version": "1.1.1",
-      "integrity": "sha1-Lluagh1sn8K5enM8VNnwV43v/8k="
+      "version": "1.1.1"
     },
     "clean-css": {
       "version": "3.4.28",
-      "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
-      "requires": {
-        "commander": "2.8.1",
-        "source-map": "0.4.4"
-      },
       "dependencies": {
         "commander": {
-          "version": "2.8.1",
-          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
+          "version": "2.8.1"
         },
         "source-map": {
-          "version": "0.4.4",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "version": "0.4.4"
         }
       }
     },
     "cli-cursor": {
       "version": "1.0.2",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "1.0.1"
-      }
+      "dev": true
     },
     "cli-table": {
       "version": "0.3.1",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
       "dev": true,
-      "requires": {
-        "colors": "1.0.3"
-      },
       "dependencies": {
         "colors": {
           "version": "1.0.3",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
           "dev": true
         }
       }
     },
     "cli-usage": {
       "version": "0.1.4",
-      "integrity": "sha1-fAHg3HBsI0s5yTODjI4gshdXduI=",
       "dev": true,
-      "requires": {
-        "marked": "0.3.7",
-        "marked-terminal": "1.7.0"
-      },
       "dependencies": {
         "marked": {
           "version": "0.3.7",
-          "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
           "dev": true
         }
       }
     },
     "cli-width": {
       "version": "1.1.1",
-      "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
       "dev": true
     },
     "click-outside": {
-      "version": "2.0.1",
-      "integrity": "sha1-BjEIouSNayBZ0hx84bUpQlEbbf8=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "component-event": "0.1.4",
-        "node-contains": "1.0.0"
-      }
+      "version": "2.0.1"
     },
     "clipboard": {
-      "version": "1.5.3",
-      "integrity": "sha1-unh0tHK4BJ9eAfJgsIU5emb625Q=",
-      "requires": {
-        "good-listener": "1.2.2",
-        "select": "1.1.2",
-        "tiny-emitter": "1.2.0"
-      }
+      "version": "1.5.3"
     },
     "cliui": {
-      "version": "2.1.0",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
-        "wordwrap": "0.0.2"
-      }
+      "version": "2.1.0"
     },
     "clone": {
       "version": "1.0.3",
-      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
       "dev": true
     },
     "clone-regexp": {
       "version": "1.0.0",
-      "integrity": "sha1-6uCiQT9VwJQvgYwin+/OhF1/Oxw=",
-      "dev": true,
-      "requires": {
-        "is-regexp": "1.0.0",
-        "is-supported-regexp-flag": "1.0.0"
-      }
+      "dev": true
     },
     "clone-stats": {
       "version": "0.0.1",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
     },
     "co": {
-      "version": "4.6.0",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "version": "4.6.0"
     },
     "code-point-at": {
-      "version": "1.1.0",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "version": "1.1.0"
     },
     "color-convert": {
-      "version": "1.9.1",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "requires": {
-        "color-name": "1.1.3"
-      }
+      "version": "1.9.1"
     },
     "color-diff": {
       "version": "0.1.7",
-      "integrity": "sha1-bbeM2UgqjkWdQIIer0tQMoPcuOI=",
       "dev": true
     },
     "color-name": {
-      "version": "1.1.3",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "version": "1.1.3"
     },
     "colorguard": {
       "version": "1.2.0",
-      "integrity": "sha1-8/rK9cquuk71RlPZ+yW7cxd8DYQ=",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "color-diff": "0.1.7",
-        "log-symbols": "1.0.2",
-        "object-assign": "4.1.1",
-        "pipetteur": "2.0.3",
-        "plur": "2.1.2",
-        "postcss": "5.2.18",
-        "postcss-reporter": "1.4.1",
-        "text-table": "0.2.0",
-        "yargs": "1.3.3"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "yargs": {
           "version": "1.3.3",
-          "integrity": "sha1-BU3oth8i7v23IHBZ6u+da4P7kxo=",
           "dev": true
         }
       }
     },
     "colors": {
-      "version": "0.6.2",
-      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+      "version": "0.6.2"
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
+      "version": "1.0.5"
     },
     "commander": {
-      "version": "2.3.0",
-      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
+      "version": "2.3.0"
     },
     "commondir": {
-      "version": "1.0.1",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+      "version": "1.0.1"
     },
     "commoner": {
       "version": "0.10.8",
-      "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
       "dev": true,
-      "requires": {
-        "commander": "2.12.2",
-        "detective": "4.7.0",
-        "glob": "5.0.15",
-        "graceful-fs": "4.1.11",
-        "iconv-lite": "0.4.15",
-        "mkdirp": "0.5.1",
-        "private": "0.1.8",
-        "q": "1.5.1",
-        "recast": "0.11.23"
-      },
       "dependencies": {
         "commander": {
           "version": "2.12.2",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
           "dev": true
         },
         "glob": {
           "version": "5.0.15",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "q": {
           "version": "1.5.1",
-          "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
           "dev": true
         }
       }
     },
     "component-bind": {
-      "version": "1.0.0",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+      "version": "1.0.0"
     },
     "component-closest": {
-      "version": "0.1.4",
-      "integrity": "sha1-W3L8UtkGB+dRFcr9w7B+JzSN5xs=",
-      "requires": {
-        "component-matches-selector": "0.1.6"
-      }
+      "version": "0.1.4"
     },
     "component-emitter": {
-      "version": "1.2.0",
-      "integrity": "sha1-zNETqGOI0GSC0D3j/H35hSa6jv4="
+      "version": "1.2.0"
     },
     "component-event": {
-      "version": "0.1.4",
-      "integrity": "sha1-PeePwoeCOBeH4kvyp8U2vwFCybQ="
+      "version": "0.1.4"
     },
     "component-file-picker": {
-      "version": "0.2.1",
-      "integrity": "sha1-FIN/MtcA0Vdew7qqFzzNzyfjTjE=",
-      "requires": {
-        "component-event": "0.1.4"
-      }
+      "version": "0.2.1"
     },
     "component-inherit": {
-      "version": "0.0.3",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+      "version": "0.0.3"
     },
     "component-matches-selector": {
-      "version": "0.1.6",
-      "integrity": "sha1-e2MOBOfgw7ABnzF0n9cK9e2Lly4=",
-      "requires": {
-        "component-query": "0.0.3"
-      }
+      "version": "0.1.6"
     },
     "component-query": {
-      "version": "0.0.3",
-      "integrity": "sha1-B/Sdq3Bx+pYGcl31PmB/RorNqs8="
+      "version": "0.0.3"
     },
     "concat-map": {
-      "version": "0.0.1",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "version": "0.0.1"
     },
     "concat-stream": {
       "version": "1.5.2",
-      "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
-      "requires": {
-        "inherits": "2.0.1",
-        "readable-stream": "2.0.6",
-        "typedarray": "0.0.6"
-      },
       "dependencies": {
         "readable-stream": {
-          "version": "2.0.6",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.1",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
-          }
+          "version": "2.0.6"
         }
       }
     },
     "configstore": {
       "version": "0.3.2",
-      "integrity": "sha1-JeTBbDdoq/dcWmW8YXYfSVBVtFk=",
       "dev": true,
-      "requires": {
-        "graceful-fs": "3.0.11",
-        "js-yaml": "3.10.0",
-        "mkdirp": "0.5.1",
-        "object-assign": "2.1.1",
-        "osenv": "0.1.4",
-        "user-home": "1.1.1",
-        "uuid": "2.0.1",
-        "xdg-basedir": "1.0.1"
-      },
       "dependencies": {
         "graceful-fs": {
           "version": "3.0.11",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "dev": true,
-          "requires": {
-            "natives": "1.1.1"
-          }
+          "dev": true
         },
         "object-assign": {
           "version": "2.1.1",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
           "dev": true
         }
       }
     },
     "console-browserify": {
-      "version": "1.1.0",
-      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "requires": {
-        "date-now": "0.1.4"
-      }
+      "version": "1.1.0"
     },
     "console-control-strings": {
-      "version": "1.1.0",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "version": "1.1.0"
     },
     "constant-case": {
-      "version": "1.1.2",
-      "integrity": "sha1-jsLKW6ND4Aqjjb9OIA/VrJB+/WM=",
-      "requires": {
-        "snake-case": "1.1.2",
-        "upper-case": "1.1.3"
-      }
+      "version": "1.1.2"
     },
     "constantinople": {
       "version": "3.1.0",
-      "integrity": "sha1-dWnKqKo/jVk11i4fqW+fcCzYHHk=",
-      "requires": {
-        "acorn": "3.3.0",
-        "is-expression": "2.1.0"
-      },
       "dependencies": {
         "acorn": {
-          "version": "3.3.0",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+          "version": "3.3.0"
         }
       }
     },
     "constants-browserify": {
-      "version": "1.0.0",
-      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+      "version": "1.0.0"
     },
     "content-disposition": {
-      "version": "0.5.0",
-      "integrity": "sha1-QoT+auBjCHRjnkToCkGMKTQTXp4="
+      "version": "0.5.0"
     },
     "content-type": {
-      "version": "1.0.4",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "version": "1.0.4"
     },
     "content-type-parser": {
       "version": "1.0.2",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.1",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+      "version": "1.5.1"
     },
     "cookie": {
-      "version": "0.1.2",
-      "integrity": "sha1-cv7D0k5Io0Mgc9kMEmQgBQYQBLE="
+      "version": "0.1.2"
     },
     "cookie-parser": {
-      "version": "1.3.2",
-      "integrity": "sha1-UiEcyCyVXXn/DAiJVEB3JOGc9WI=",
-      "requires": {
-        "cookie": "0.1.2",
-        "cookie-signature": "1.0.4"
-      }
+      "version": "1.3.2"
     },
     "cookie-signature": {
-      "version": "1.0.4",
-      "integrity": "sha1-Dt0iKG46ERuaKnDbNj6SXoZ/aso="
+      "version": "1.0.4"
     },
     "cookiejar": {
-      "version": "2.1.1",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+      "version": "2.1.1"
     },
     "copy-concurrently": {
-      "version": "1.0.5",
-      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-      "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
-      }
+      "version": "1.0.5"
     },
     "copy-webpack-plugin": {
       "version": "4.0.1",
-      "integrity": "sha1-lyjjg7lDFgUNDHRjlY8rhcCqggA=",
-      "requires": {
-        "bluebird": "2.11.0",
-        "fs-extra": "0.26.7",
-        "glob": "6.0.4",
-        "is-glob": "3.1.0",
-        "loader-utils": "0.2.17",
-        "lodash": "4.15.0",
-        "minimatch": "3.0.4",
-        "node-dir": "0.1.17"
-      },
       "dependencies": {
         "glob": {
-          "version": "6.0.4",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "version": "6.0.4"
         },
         "loader-utils": {
-          "version": "0.2.17",
-          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
-          }
+          "version": "0.2.17"
         }
       }
     },
     "core-js": {
-      "version": "2.5.3",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+      "version": "2.5.3"
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "version": "1.0.2"
     },
     "cosmiconfig": {
       "version": "3.1.0",
-      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
       "dev": true,
-      "requires": {
-        "is-directory": "0.3.1",
-        "js-yaml": "3.10.0",
-        "parse-json": "3.0.0",
-        "require-from-string": "2.0.1"
-      },
       "dependencies": {
         "parse-json": {
           "version": "3.0.0",
-          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
+          "dev": true
         }
       }
     },
     "crc32": {
-      "version": "0.2.2",
-      "integrity": "sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo="
+      "version": "0.2.2"
     },
     "create-ecdh": {
-      "version": "4.0.0",
-      "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
-      "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
-      }
+      "version": "4.0.0"
     },
     "create-hash": {
-      "version": "1.1.3",
-      "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-      "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.1",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.9"
-      }
+      "version": "1.1.3"
     },
     "create-hmac": {
-      "version": "1.1.6",
-      "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-      "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.1",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.9"
-      }
+      "version": "1.1.6"
     },
     "create-react-class": {
-      "version": "15.6.2",
-      "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
+      "version": "15.6.2"
     },
     "creditcards": {
-      "version": "2.1.2",
-      "integrity": "sha1-XQ9ukRhBctO21X2MXa79EGXHy24=",
-      "requires": {
-        "creditcards-types": "1.6.2",
-        "fast-luhn": "1.0.3",
-        "is-valid-month": "1.0.0",
-        "parse-int": "1.0.2",
-        "parse-year": "1.0.0",
-        "to-camel-case": "1.0.0",
-        "xtend": "4.0.1"
-      }
+      "version": "2.1.2"
     },
     "creditcards-types": {
-      "version": "1.6.2",
-      "integrity": "sha1-W+bKy8rMPiCtI40oeexYYPRn8c0=",
-      "requires": {
-        "xtend": "4.0.1"
-      }
+      "version": "1.6.2"
     },
     "cross-env": {
-      "version": "5.1.1",
-      "integrity": "sha512-Wtvr+z0Z06KO1JxjfRRsPC+df7biIOiuV4iZ73cThjFGkH+ULBZq1MkBdywEcJC4cTDbO6c8IjgRjfswx3YTBA==",
-      "requires": {
-        "cross-spawn": "5.1.0",
-        "is-windows": "1.0.1"
-      }
+      "version": "5.1.1"
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
-      }
+      "version": "5.1.0"
     },
     "cryptiles": {
       "version": "3.1.2",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.2.0"
-      },
       "dependencies": {
         "boom": {
-          "version": "5.2.0",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
+          "version": "5.2.0"
         }
       }
     },
     "crypto-browserify": {
-      "version": "3.12.0",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-      "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.1",
-        "pbkdf2": "3.0.14",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5",
-        "randomfill": "1.0.3"
-      }
+      "version": "3.12.0"
     },
     "css-color-names": {
       "version": "0.0.3",
-      "integrity": "sha1-3gzvFvTYqoIioyDVttfpu62nufY=",
       "dev": true
     },
     "css-rule-stream": {
       "version": "1.1.0",
-      "integrity": "sha1-N4bnGYmD2WWibjGVfgkHjLt3BaI=",
-      "dev": true,
-      "requires": {
-        "css-tokenize": "1.0.1",
-        "duplexer2": "0.0.2",
-        "ldjson-stream": "1.2.1",
-        "through2": "0.6.5"
-      }
+      "dev": true
     },
     "css-select": {
       "version": "1.2.0",
-      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true,
-      "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
-        "domutils": "1.5.1",
-        "nth-check": "1.0.1"
-      }
+      "dev": true
     },
     "css-tokenize": {
       "version": "1.0.1",
-      "integrity": "sha1-RiXLHtohwUOFi3+B1oA8HSb8FL4=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.1",
-        "readable-stream": "1.1.14"
-      }
+      "dev": true
     },
     "css-what": {
       "version": "2.1.0",
-      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
       "dev": true
     },
     "cssom": {
       "version": "0.3.2",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
       "dev": true
     },
     "cssstyle": {
       "version": "0.2.37",
-      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "dev": true,
-      "requires": {
-        "cssom": "0.3.2"
-      }
+      "dev": true
     },
     "currently-unhandled": {
-      "version": "0.4.1",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "requires": {
-        "array-find-index": "1.0.2"
-      }
+      "version": "0.4.1"
     },
     "cwise-compiler": {
       "version": "1.1.3",
-      "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
-      "dev": true,
-      "requires": {
-        "uniq": "1.0.1"
-      }
+      "dev": true
     },
     "cyclist": {
-      "version": "0.2.2",
-      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
+      "version": "0.2.2"
     },
     "d": {
-      "version": "1.0.0",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "requires": {
-        "es5-ext": "0.10.37"
-      }
+      "version": "1.0.0"
     },
     "d3-array": {
-      "version": "1.2.0",
-      "integrity": "sha1-FH0mlyDhdMQFen9CvosPPyulMQg="
+      "version": "1.2.0"
     },
     "d3-collection": {
-      "version": "1.0.4",
-      "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI="
+      "version": "1.0.4"
     },
     "d3-color": {
-      "version": "1.0.3",
-      "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs="
+      "version": "1.0.3"
     },
     "d3-format": {
-      "version": "1.2.1",
-      "integrity": "sha512-U4zRVLDXW61bmqoo+OJ/V687e1T5nVd3TAKAJKgtpZ/P1JsMgyod0y9br+mlQOryTAACdiXI3wCjuERHFNp91w=="
+      "version": "1.2.1"
     },
     "d3-interpolate": {
-      "version": "1.1.6",
-      "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
-      "requires": {
-        "d3-color": "1.0.3"
-      }
+      "version": "1.1.6"
     },
     "d3-path": {
-      "version": "1.0.5",
-      "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q="
+      "version": "1.0.5"
     },
     "d3-scale": {
-      "version": "1.0.6",
-      "integrity": "sha1-vOGdqA06DPQiyVQ64zIghiILNO0=",
-      "requires": {
-        "d3-array": "1.2.0",
-        "d3-collection": "1.0.4",
-        "d3-color": "1.0.3",
-        "d3-format": "1.2.1",
-        "d3-interpolate": "1.1.6",
-        "d3-time": "1.0.8",
-        "d3-time-format": "2.1.1"
-      }
+      "version": "1.0.6"
     },
     "d3-selection": {
-      "version": "1.1.0",
-      "integrity": "sha1-GZhoSJZIj4OcoDchI9o08dMYgJw="
+      "version": "1.1.0"
     },
     "d3-shape": {
-      "version": "1.2.0",
-      "integrity": "sha1-RdAVOPBkuv0F6j1tLLdI/YxB93c=",
-      "requires": {
-        "d3-path": "1.0.5"
-      }
+      "version": "1.2.0"
     },
     "d3-time": {
-      "version": "1.0.8",
-      "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
+      "version": "1.0.8"
     },
     "d3-time-format": {
-      "version": "2.1.1",
-      "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
-      "requires": {
-        "d3-time": "1.0.8"
-      }
+      "version": "2.1.1"
     },
     "dashdash": {
-      "version": "1.14.1",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
+      "version": "1.14.1"
     },
     "dashify": {
       "version": "0.2.2",
-      "integrity": "sha1-agdBWgHJH69KMuONnfunH2HLIP4=",
       "dev": true
     },
     "data-uri-to-buffer": {
       "version": "0.0.3",
-      "integrity": "sha1-GK6XmmoMqZSwYlhTkW0mYruuCxo=",
       "dev": true
     },
     "date-now": {
-      "version": "0.1.4",
-      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+      "version": "0.1.4"
     },
     "dateformat": {
       "version": "2.2.0",
-      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
       "dev": true
     },
     "debug": {
-      "version": "2.2.0",
-      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-      "requires": {
-        "ms": "0.7.1"
-      }
+      "version": "2.2.0"
     },
     "decamelize": {
-      "version": "1.2.0",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "version": "1.2.0"
     },
     "deep-eql": {
       "version": "0.1.3",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
-      "requires": {
-        "type-detect": "0.1.1"
-      },
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
           "dev": true
         }
       }
     },
     "deep-equal": {
-      "version": "1.0.1",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+      "version": "1.0.1"
     },
     "deep-extend": {
-      "version": "0.4.2",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+      "version": "0.4.2"
     },
     "deep-freeze": {
       "version": "0.0.1",
-      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=",
       "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "default-require-extensions": {
       "version": "1.0.0",
-      "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-      "dev": true,
-      "requires": {
-        "strip-bom": "2.0.0"
-      }
+      "dev": true
     },
     "defaults-deep": {
       "version": "0.2.3",
-      "integrity": "sha1-Y+mAg9i+0GNmWf4T8FeMeBqenKE=",
       "dev": true,
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1",
-        "lazy-cache": "0.2.7"
-      },
       "dependencies": {
         "lazy-cache": {
           "version": "0.2.7",
-          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
           "dev": true
         }
       }
     },
     "deferred-leveldown": {
-      "version": "1.2.2",
-      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-      "requires": {
-        "abstract-leveldown": "2.6.3"
-      }
+      "version": "1.2.2"
     },
     "define-properties": {
-      "version": "1.1.2",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
-      }
+      "version": "1.1.2"
     },
     "defined": {
       "version": "1.0.0",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
     "defs": {
       "version": "1.1.1",
-      "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
       "dev": true,
-      "requires": {
-        "alter": "0.2.0",
-        "ast-traverse": "0.1.1",
-        "breakable": "1.0.0",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "simple-fmt": "0.1.0",
-        "simple-is": "0.2.0",
-        "stringmap": "0.2.2",
-        "stringset": "0.2.1",
-        "tryor": "0.1.2",
-        "yargs": "3.27.0"
-      },
       "dependencies": {
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
           "dev": true
         },
         "window-size": {
           "version": "0.1.4",
-          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
           "dev": true
         },
         "yargs": {
           "version": "3.27.0",
-          "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
-          "dev": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
-          }
+          "dev": true
         }
       }
     },
     "del": {
       "version": "2.2.2",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
-      "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
-      },
       "dependencies": {
         "globby": {
           "version": "5.0.0",
-          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "dev": true,
-          "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.0.3",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "pify": {
           "version": "2.3.0",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
     },
     "delayed-stream": {
-      "version": "1.0.0",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "version": "1.0.0"
     },
     "delegate": {
-      "version": "3.2.0",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
+      "version": "3.2.0"
     },
     "delegates": {
-      "version": "1.0.0",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "version": "1.0.0"
     },
     "depd": {
-      "version": "1.1.1",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+      "version": "1.1.1"
     },
     "des.js": {
-      "version": "1.0.0",
-      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-      "requires": {
-        "inherits": "2.0.1",
-        "minimalistic-assert": "1.0.0"
-      }
+      "version": "1.0.0"
     },
     "destroy": {
-      "version": "1.0.3",
-      "integrity": "sha1-tDO0ck5x/YVR2YhRdIUcX8N34sk="
+      "version": "1.0.3"
     },
     "detect-indent": {
-      "version": "4.0.0",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "version": "4.0.0"
     },
     "detect-newline": {
       "version": "2.1.0",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
     "detective": {
       "version": "4.7.0",
-      "integrity": "sha512-4mBqSEdMfBpRAo/DQZnTcAXenpiSIJmVKbCMSotS+SFWWcrP/CKM6iBRPdTiEO+wZhlfEsoZlGqpG6ycl5vTqw==",
       "dev": true,
-      "requires": {
-        "acorn": "5.2.1",
-        "defined": "1.0.0"
-      },
       "dependencies": {
         "acorn": {
           "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
           "dev": true
         }
       }
     },
     "diff": {
-      "version": "3.4.0",
-      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA=="
+      "version": "3.4.0"
     },
     "diffie-hellman": {
-      "version": "5.0.2",
-      "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
-      "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.5"
-      }
+      "version": "5.0.2"
     },
     "discontinuous-range": {
       "version": "1.0.0",
-      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
       "dev": true
     },
     "disparity": {
       "version": "2.0.0",
-      "integrity": "sha1-V92stHMkrl9Y0swNqIbbTOnutxg=",
       "dev": true,
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "diff": "1.4.0"
-      },
       "dependencies": {
         "diff": {
           "version": "1.4.0",
-          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
           "dev": true
         }
       }
     },
     "doctrine": {
-      "version": "2.0.0",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
-      }
+      "version": "2.0.0"
     },
     "doctypes": {
-      "version": "1.1.0",
-      "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
+      "version": "1.1.0"
     },
     "doiuse": {
       "version": "2.6.0",
-      "integrity": "sha1-GJLRC2Gpo1at2/K2FJM+gfi7ODQ=",
       "dev": true,
-      "requires": {
-        "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000782",
-        "css-rule-stream": "1.1.0",
-        "duplexer2": "0.0.2",
-        "jsonfilter": "1.1.2",
-        "ldjson-stream": "1.2.1",
-        "lodash": "4.15.0",
-        "multimatch": "2.1.0",
-        "postcss": "5.2.18",
-        "source-map": "0.4.4",
-        "through2": "0.6.5",
-        "yargs": "3.10.0"
-      },
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
     "dom-helpers": {
-      "version": "2.4.0",
-      "integrity": "sha1-m7SyRfY3NnsfpnAnQnKqKP4Gw2c="
+      "version": "2.4.0"
     },
     "dom-scroll-into-view": {
-      "version": "1.0.1",
-      "integrity": "sha1-Mqu5Lw2P7KYhUWKu9D5LRJq42Zw="
+      "version": "1.0.1"
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
-      "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
-      },
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         }
       }
     },
     "domain-browser": {
-      "version": "1.1.7",
-      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
+      "version": "1.1.7"
     },
     "domelementtype": {
       "version": "1.3.0",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
       "dev": true
     },
     "domhandler": {
       "version": "2.4.1",
-      "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
-      "dev": true,
-      "requires": {
-        "domelementtype": "1.3.0"
-      }
+      "dev": true
     },
     "domutils": {
       "version": "1.5.1",
-      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
-      "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
-      }
+      "dev": true
     },
     "dot-case": {
-      "version": "1.1.2",
-      "integrity": "sha1-HnOCaQDeKNbeVIC8HeMdCEKwa+w=",
-      "requires": {
-        "sentence-case": "1.1.3"
-      }
+      "version": "1.1.2"
     },
     "draft-js": {
-      "version": "0.10.4",
-      "integrity": "sha1-FHdBZCCXyBINjtwjLpUD6Lf7jTU=",
-      "requires": {
-        "fbjs": "0.8.16",
-        "immutable": "3.7.6",
-        "object-assign": "4.1.1"
-      }
+      "version": "0.10.4"
     },
     "duplexer": {
-      "version": "0.1.1",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+      "version": "0.1.1"
     },
     "duplexer2": {
       "version": "0.0.2",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "1.1.14"
-      }
+      "dev": true
     },
     "duplexify": {
       "version": "3.5.1",
-      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
-      "requires": {
-        "end-of-stream": "1.4.0",
-        "inherits": "2.0.1",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
-      },
       "dependencies": {
         "readable-stream": {
           "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          },
           "dependencies": {
             "inherits": {
-              "version": "2.0.3",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "version": "2.0.3"
             }
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
+      "optional": true
     },
     "ee-first": {
-      "version": "1.1.1",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "version": "1.1.1"
     },
     "ejs": {
       "version": "2.5.7",
-      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.28",
-      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4="
+      "version": "1.3.28"
     },
     "elliptic": {
-      "version": "6.4.0",
-      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-      "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.1",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
-      }
+      "version": "6.4.0"
     },
     "email-validator": {
-      "version": "1.0.1",
-      "integrity": "sha1-XJbkysEybHOvA+BDlY4naI7nnwA="
+      "version": "1.0.1"
     },
     "emitter-component": {
-      "version": "1.0.0",
-      "integrity": "sha1-8E3Rj8PcPpp0y8DzELCIZm5MAW8="
+      "version": "1.0.0"
     },
     "emoji-text": {
-      "version": "0.2.6",
-      "integrity": "sha1-kx6DOpj6zJSfPYBX3IqENjyLuPg=",
-      "requires": {
-        "wemoji": "0.1.9"
-      }
+      "version": "0.2.6"
     },
     "emojis-list": {
-      "version": "2.1.0",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+      "version": "2.1.0"
     },
     "encodeurl": {
       "version": "1.0.1",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
       "dev": true
     },
     "encoding": {
-      "version": "0.1.12",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.15"
-      }
+      "version": "0.1.12"
     },
     "end-of-stream": {
-      "version": "1.4.0",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-      "requires": {
-        "once": "1.4.0"
-      }
+      "version": "1.4.0"
     },
     "engine.io": {
       "version": "1.6.8",
-      "integrity": "sha1-3gWga3V+dRdpXgiMewUcR4GfURs=",
       "dev": true,
-      "requires": {
-        "accepts": "1.1.4",
-        "base64id": "0.1.0",
-        "debug": "2.2.0",
-        "engine.io-parser": "1.2.4",
-        "ws": "1.0.1"
-      },
       "dependencies": {
         "accepts": {
           "version": "1.1.4",
-          "integrity": "sha1-1xyW99QdD+2iw4zRToonwEFY30o=",
-          "dev": true,
-          "requires": {
-            "mime-types": "2.0.14",
-            "negotiator": "0.4.9"
-          }
+          "dev": true
         },
         "mime-db": {
           "version": "1.12.0",
-          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
           "dev": true
         },
         "mime-types": {
           "version": "2.0.14",
-          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.12.0"
-          }
+          "dev": true
         },
         "negotiator": {
           "version": "0.4.9",
-          "integrity": "sha1-kuRrbbU8fkIe1koryU8IvnYw3z8=",
           "dev": true
         }
       }
     },
     "engine.io-client": {
       "version": "1.6.8",
-      "integrity": "sha1-bi2xFki0XkBcRrFy6j49rDfMDOs=",
-      "requires": {
-        "component-emitter": "1.1.2",
-        "component-inherit": "0.0.3",
-        "debug": "2.2.0",
-        "engine.io-parser": "1.2.4",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parsejson": "0.0.1",
-        "parseqs": "0.0.2",
-        "parseuri": "0.0.4",
-        "ws": "1.0.1",
-        "xmlhttprequest-ssl": "1.5.1",
-        "yeast": "0.1.2"
-      },
       "dependencies": {
         "component-emitter": {
-          "version": "1.1.2",
-          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+          "version": "1.1.2"
         }
       }
     },
     "engine.io-parser": {
       "version": "1.2.4",
-      "integrity": "sha1-4Il7C/FOeS1M0qWVBVORnFaUjEI=",
-      "requires": {
-        "after": "0.8.1",
-        "arraybuffer.slice": "0.0.6",
-        "base64-arraybuffer": "0.1.2",
-        "blob": "0.0.4",
-        "has-binary": "0.1.6",
-        "utf8": "2.1.0"
-      },
       "dependencies": {
         "has-binary": {
-          "version": "0.1.6",
-          "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
-          "requires": {
-            "isarray": "0.0.1"
-          }
+          "version": "0.1.6"
         },
         "isarray": {
-          "version": "0.0.1",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "version": "0.0.1"
         }
       }
     },
     "enhanced-resolve": {
-      "version": "3.4.1",
-      "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
-      }
+      "version": "3.4.1"
     },
     "entities": {
       "version": "1.1.1",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
       "dev": true
     },
     "enzyme": {
       "version": "3.1.0",
-      "integrity": "sha1-2MqECFeQ+87G7UC63RRHj67kwlo=",
       "dev": true,
-      "requires": {
-        "cheerio": "1.0.0-rc.2",
-        "function.prototype.name": "1.0.3",
-        "is-subset": "0.1.1",
-        "lodash": "4.17.4",
-        "object-is": "1.0.1",
-        "object.assign": "4.0.4",
-        "object.entries": "1.0.4",
-        "object.values": "1.0.4",
-        "raf": "3.4.0",
-        "rst-selector-parser": "2.2.3"
-      },
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         }
       }
     },
     "enzyme-adapter-react-16": {
       "version": "1.0.4",
-      "integrity": "sha512-MCjuwrCE5yhTJxaBhd6zTVdm8T01Ydjys5JaFm9ILkxP7oYb3N4i+nytKlzhI7rVouPdAuUVI8mO5UcEbEFAmw==",
       "dev": true,
-      "requires": {
-        "enzyme-adapter-utils": "1.2.0",
-        "lodash": "4.17.4",
-        "object.assign": "4.0.4",
-        "object.values": "1.0.4",
-        "prop-types": "15.5.10",
-        "react-test-renderer": "16.2.0"
-      },
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         }
       }
     },
     "enzyme-adapter-utils": {
       "version": "1.2.0",
-      "integrity": "sha512-6CeIrmymLWoQgvH5m/ixJLaCsa6pSoWU2nlMeO0nHCZR8LQ+tKzP/jPh4qceTPlB4oFfyMRFeqr0+IryY4gAxg==",
       "dev": true,
-      "requires": {
-        "lodash": "4.17.4",
-        "object.assign": "4.0.4",
-        "prop-types": "15.5.10"
-      },
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         }
       }
     },
     "enzyme-to-json": {
       "version": "3.1.4",
-      "integrity": "sha512-bGXQxsbVdRqn3ebWej90ADH+RmlKXwy4SgMWc1gG4oDKlVHEsu2eP6hMA4zFGMlQqTxgyd1XPcsryo6Ti4YG+Q==",
       "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      },
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         }
       }
     },
     "errno": {
-      "version": "0.1.6",
-      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
-      "requires": {
-        "prr": "1.0.1"
-      }
+      "version": "0.1.6"
     },
     "error-ex": {
-      "version": "1.3.1",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "requires": {
-        "is-arrayish": "0.2.1"
-      }
+      "version": "1.3.1"
     },
     "es-abstract": {
-      "version": "1.10.0",
-      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
-      "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
-      }
+      "version": "1.10.0"
     },
     "es-to-primitive": {
-      "version": "1.1.1",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
-      }
+      "version": "1.1.1"
     },
     "es3ify": {
       "version": "0.1.4",
-      "integrity": "sha1-rZ+l3xrjTz8x4SEbWBiy1RB439E=",
-      "requires": {
-        "esprima-fb": "3001.1.0-dev-harmony-fb",
-        "jstransform": "3.0.0",
-        "through": "2.3.8"
-      },
       "dependencies": {
         "esprima-fb": {
-          "version": "3001.1.0-dev-harmony-fb",
-          "integrity": "sha1-t303q8046gt3Qmu4vCkizmtCZBE="
+          "version": "3001.1.0-dev-harmony-fb"
         }
       }
     },
     "es5-ext": {
-      "version": "0.10.37",
-      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
-      "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
-      }
+      "version": "0.10.37"
     },
     "es6-error": {
-      "version": "4.0.2",
-      "integrity": "sha1-7sXHJurO9Rt/a3PCDbbhsTsGnJg="
+      "version": "4.0.2"
     },
     "es6-iterator": {
-      "version": "2.0.3",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-symbol": "3.1.1"
-      }
+      "version": "2.0.3"
     },
     "es6-map": {
-      "version": "0.1.5",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
+      "version": "0.1.5"
     },
     "es6-promise": {
       "version": "3.3.1",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
       "dev": true
     },
     "es6-set": {
-      "version": "0.1.5",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
+      "version": "0.1.5"
     },
     "es6-symbol": {
-      "version": "3.1.1",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37"
-      }
+      "version": "3.1.1"
     },
     "es6-templates": {
-      "version": "0.2.3",
-      "integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
-      "requires": {
-        "recast": "0.11.23",
-        "through": "2.3.8"
-      }
+      "version": "0.2.3"
     },
     "es6-weak-map": {
-      "version": "2.0.2",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
-      }
+      "version": "2.0.2"
     },
     "escape-html": {
-      "version": "1.0.2",
-      "integrity": "sha1-130y+pjjjC9BroXpJ44ODmuhAiw="
+      "version": "1.0.2"
     },
     "escape-regexp": {
-      "version": "0.0.1",
-      "integrity": "sha1-9EvaEtRbvfnLf4Yu5+SCez3TIlQ="
+      "version": "0.0.1"
     },
     "escape-regexp-component": {
-      "version": "1.0.2",
-      "integrity": "sha1-nGO20LJf8qiMOtvRjFthrMO5+qI="
+      "version": "1.0.2"
     },
     "escape-string-regexp": {
-      "version": "1.0.3",
-      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+      "version": "1.0.3"
     },
     "escodegen": {
       "version": "1.9.0",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
       "dev": true,
-      "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.1",
-        "source-map": "0.5.7"
-      },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true,
           "optional": true
         }
       }
     },
     "escope": {
-      "version": "3.6.0",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
-      }
+      "version": "3.6.0"
     },
     "esformatter": {
       "version": "0.7.3",
-      "integrity": "sha1-p0NztHLt6PNVkgsj391vnV7g6Ko=",
       "dev": true,
-      "requires": {
-        "debug": "0.7.4",
-        "disparity": "2.0.0",
-        "espree": "1.12.3",
-        "glob": "5.0.15",
-        "minimist": "1.2.0",
-        "mout": "1.1.0",
-        "npm-run": "1.1.1",
-        "resolve": "1.5.0",
-        "rocambole": "0.7.0",
-        "rocambole-indent": "2.0.4",
-        "rocambole-linebreak": "1.0.2",
-        "rocambole-node": "1.0.0",
-        "rocambole-token": "1.2.1",
-        "rocambole-whitespace": "1.0.0",
-        "semver": "2.2.1",
-        "stdin": "0.0.1",
-        "strip-json-comments": "0.1.3",
-        "supports-color": "1.3.1",
-        "user-home": "2.0.0"
-      },
       "dependencies": {
         "debug": {
           "version": "0.7.4",
-          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
           "dev": true
         },
         "espree": {
           "version": "1.12.3",
-          "integrity": "sha1-BM7q2pG9oHejjAQMEluhhrE7s8w=",
           "dev": true
         },
         "glob": {
           "version": "5.0.15",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "semver": {
           "version": "2.2.1",
-          "integrity": "sha1-eUEYKz/8xYC/8cF5QqzfeVHA0hM=",
           "dev": true
         },
         "strip-json-comments": {
           "version": "0.1.3",
-          "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ=",
           "dev": true
         },
         "supports-color": {
           "version": "1.3.1",
-          "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0=",
           "dev": true
         },
         "user-home": {
           "version": "2.0.0",
-          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "1.0.2"
-          }
+          "dev": true
         }
       }
     },
     "esformatter-braces": {
       "version": "1.2.1",
-      "integrity": "sha1-c+BxdEat5LsmnO7OtGw3AujB6Cc=",
-      "dev": true,
-      "requires": {
-        "rocambole-token": "1.2.1"
-      }
+      "dev": true
     },
     "esformatter-collapse-objects-a8c": {
       "version": "0.1.0",
-      "integrity": "sha1-vFUbXqZL6bzWgf8DoUHqGOod5rI=",
       "dev": true,
-      "requires": {
-        "defaults-deep": "0.2.3",
-        "rocambole": "0.5.1",
-        "rocambole-token": "1.2.1"
-      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
           "dev": true
         },
         "rocambole": {
           "version": "0.5.1",
-          "integrity": "sha1-MEj2SyOIuN2Okz+a1EPws4mrYI8=",
-          "dev": true,
-          "requires": {
-            "esprima": "2.7.3"
-          }
+          "dev": true
         }
       }
     },
     "esformatter-dot-notation": {
       "version": "1.3.1",
-      "integrity": "sha1-21uqJBQyFOVA+jJ9JV7rBPWxV+A=",
       "dev": true,
-      "requires": {
-        "rocambole": "0.6.0",
-        "rocambole-token": "1.2.1",
-        "unquoted-property-validator": "1.0.2"
-      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
           "dev": true
         },
         "rocambole": {
           "version": "0.6.0",
-          "integrity": "sha1-U08jWih8wX+bBXuVvRHQ8Nw1RSw=",
-          "dev": true,
-          "requires": {
-            "esprima": "2.7.3"
-          }
+          "dev": true
         }
       }
     },
     "esformatter-quotes": {
       "version": "1.0.3",
-      "integrity": "sha1-B0Cv5G30B8jj3heaqZKNs9hZqiA=",
       "dev": true
     },
     "esformatter-semicolons": {
       "version": "1.1.1",
-      "integrity": "sha1-CauHaUwRn67f1a+HM4kz0aFrKSs=",
       "dev": true
     },
     "esformatter-special-bangs": {
       "version": "1.0.1",
-      "integrity": "sha1-JNyzG58DuRJk+xbMbr9bqQjP4tk=",
-      "dev": true,
-      "requires": {
-        "rocambole-token": "1.2.1"
-      }
+      "dev": true
     },
     "eslines": {
       "version": "1.1.0",
-      "integrity": "sha1-eA3YIE5bluBb3I8BUCzVJ1q/xGQ=",
       "dev": true,
-      "requires": {
-        "jest-docblock": "20.0.3",
-        "optionator": "0.8.1"
-      },
       "dependencies": {
         "jest-docblock": {
           "version": "20.0.3",
-          "integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI=",
           "dev": true
         }
       }
     },
     "eslint": {
       "version": "3.8.1",
-      "integrity": "sha1-fQLbRM1ar0+nqkieHwg7qkVDQro=",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "concat-stream": "1.5.2",
-        "debug": "2.2.0",
-        "doctrine": "1.5.0",
-        "escope": "3.6.0",
-        "espree": "3.5.2",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "glob": "7.0.3",
-        "globals": "9.18.0",
-        "ignore": "3.3.5",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.13.1",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.15.0",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.6.1",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "1.0.4",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "cli-width": {
           "version": "2.2.0",
-          "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
           "dev": true
         },
         "doctrine": {
           "version": "1.5.0",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
-          }
+          "dev": true
         },
         "fast-levenshtein": {
           "version": "2.0.6",
-          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
           "dev": true
         },
         "inquirer": {
           "version": "0.12.0",
-          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "1.4.0",
-            "ansi-regex": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "2.2.0",
-            "figures": "1.7.0",
-            "lodash": "4.15.0",
-            "readline2": "1.0.1",
-            "run-async": "0.1.0",
-            "rx-lite": "3.1.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
-          }
+          "dev": true
         },
         "optionator": {
           "version": "0.8.2",
-          "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-          "dev": true,
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
-          }
+          "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
         "strip-json-comments": {
           "version": "1.0.4",
-          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "user-home": {
           "version": "2.0.0",
-          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "1.0.2"
-          }
+          "dev": true
         },
         "wordwrap": {
           "version": "1.0.0",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
       }
     },
     "eslint-config-wpcalypso": {
       "version": "1.2.0",
-      "integrity": "sha1-l3XWQrSD/4e0bF9tlXC1Q5gK16E=",
       "dev": true
     },
     "eslint-eslines": {
       "version": "0.0.6",
-      "integrity": "sha1-9MXWe+pmYx6cXgnK/ZMsbMMAdcM=",
       "dev": true
     },
     "eslint-plugin-jest": {
       "version": "21.2.0",
-      "integrity": "sha512-pe7JWoZiXWHfVCBArxX5o3laRZp24tkBSeIHImJJyX2mDIqzlrXkUGkfbC6tPKER3WbcQ3YxKDMgp8uqt8fjfw==",
       "dev": true
     },
     "eslint-plugin-react": {
       "version": "7.1.0",
-      "integrity": "sha1-J3cKzzn1/UnNCvQIPOWBBOs5DUw=",
-      "dev": true,
-      "requires": {
-        "doctrine": "2.0.0",
-        "has": "1.0.1",
-        "jsx-ast-utils": "1.4.1"
-      }
+      "dev": true
     },
     "eslint-plugin-wpcalypso": {
       "version": "3.4.1",
-      "integrity": "sha512-rHbCINm3qJmCgASUDKdmRiulwt06EcJTy9Hd+MpZMS4o9eFfS23Q1z1bBYVsJ4nFexvWswqcfCsgRQnFPtT5pQ==",
-      "dev": true,
-      "requires": {
-        "requireindex": "1.1.0"
-      }
+      "dev": true
     },
     "esmangle-evaluator": {
-      "version": "1.0.1",
-      "integrity": "sha1-Yg2GbvSGGzMR91dm1SqFcrs8YzY="
+      "version": "1.0.1"
     },
     "espree": {
       "version": "3.5.2",
-      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
-      "requires": {
-        "acorn": "5.2.1",
-        "acorn-jsx": "3.0.1"
-      },
       "dependencies": {
         "acorn": {
           "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
           "dev": true
         }
       }
     },
     "esprima": {
-      "version": "3.1.3",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+      "version": "3.1.3"
     },
     "esrecurse": {
-      "version": "4.2.0",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
-      }
+      "version": "4.2.0"
     },
     "estraverse": {
-      "version": "4.2.0",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+      "version": "4.2.0"
     },
     "estree-walker": {
-      "version": "0.2.1",
-      "integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4="
+      "version": "0.2.1"
     },
     "esutils": {
-      "version": "2.0.2",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "version": "2.0.2"
     },
     "etag": {
-      "version": "1.7.0",
-      "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+      "version": "1.7.0"
     },
     "event-emitter": {
-      "version": "0.3.5",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37"
-      }
+      "version": "0.3.5"
     },
     "event-stream": {
-      "version": "3.3.4",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
-      }
+      "version": "3.3.4"
     },
     "events": {
-      "version": "1.0.2",
-      "integrity": "sha1-dYSdz+k9EPsFfDAFWv29UdBqjiQ="
+      "version": "1.0.2"
     },
     "evp_bytestokey": {
-      "version": "1.0.3",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
-      }
+      "version": "1.0.3"
     },
     "exec-sh": {
       "version": "0.2.1",
-      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
-      "dev": true,
-      "requires": {
-        "merge": "1.2.0"
-      }
+      "dev": true
     },
     "execa": {
-      "version": "0.7.0",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
-      }
+      "version": "0.7.0"
     },
     "execall": {
       "version": "1.0.0",
-      "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
-      "dev": true,
-      "requires": {
-        "clone-regexp": "1.0.0"
-      }
+      "dev": true
     },
     "exenv": {
-      "version": "1.2.2",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+      "version": "1.2.2"
     },
     "exit-hook": {
       "version": "1.1.1",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
-      "version": "0.1.5",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
+      "version": "0.1.5"
     },
     "expand-range": {
-      "version": "1.8.2",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "requires": {
-        "fill-range": "2.2.3"
-      }
+      "version": "1.8.2"
     },
     "expand-template": {
-      "version": "1.1.0",
-      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
+      "version": "1.1.0"
     },
     "expand-year": {
-      "version": "1.0.0",
-      "integrity": "sha1-rd7sCl7fXtVPbAdItkH9SJMCapM=",
-      "requires": {
-        "parse-int": "1.0.2",
-        "zero-fill": "2.2.3"
-      }
+      "version": "1.0.0"
     },
     "expect": {
       "version": "21.2.1",
-      "integrity": "sha512-orfQQqFRTX0jH7znRIGi8ZMR8kTNpXklTTz8+HGTpmTKZo3Occ6JNB5FXMb8cRuiiC/GyDqsr30zUa66ACYlYw==",
       "dev": true,
-      "requires": {
-        "ansi-styles": "3.2.0",
-        "jest-diff": "21.2.1",
-        "jest-get-type": "21.2.0",
-        "jest-matcher-utils": "21.2.1",
-        "jest-message-util": "21.2.1",
-        "jest-regex-util": "21.2.0"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         }
       }
     },
     "exports-loader": {
       "version": "0.6.2",
-      "integrity": "sha1-ChAog42RKukDzJYQcHt4ljFQ2rg=",
-      "requires": {
-        "loader-utils": "0.2.17",
-        "source-map": "0.1.39"
-      },
       "dependencies": {
         "loader-utils": {
-          "version": "0.2.17",
-          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
-          }
+          "version": "0.2.17"
         }
       }
     },
     "express": {
       "version": "4.13.3",
-      "integrity": "sha1-3bLx+0UCvzNZjSsDKwN5YMpsgKM=",
-      "requires": {
-        "accepts": "1.2.13",
-        "array-flatten": "1.1.1",
-        "content-disposition": "0.5.0",
-        "content-type": "1.0.4",
-        "cookie": "0.1.3",
-        "cookie-signature": "1.0.6",
-        "debug": "2.2.0",
-        "depd": "1.0.1",
-        "escape-html": "1.0.2",
-        "etag": "1.7.0",
-        "finalhandler": "0.4.0",
-        "fresh": "0.3.0",
-        "merge-descriptors": "1.0.0",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.0.10",
-        "qs": "4.0.0",
-        "range-parser": "1.0.3",
-        "send": "0.13.0",
-        "serve-static": "1.10.3",
-        "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
-        "vary": "1.0.1"
-      },
       "dependencies": {
         "cookie": {
-          "version": "0.1.3",
-          "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU="
+          "version": "0.1.3"
         },
         "cookie-signature": {
-          "version": "1.0.6",
-          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+          "version": "1.0.6"
         },
         "depd": {
-          "version": "1.0.1",
-          "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
+          "version": "1.0.1"
         }
       }
     },
     "express-useragent": {
-      "version": "1.0.7",
-      "integrity": "sha1-FT3mR+Wl0FxOwbQXJ5Ska8DQeZE="
+      "version": "1.0.7"
     },
     "extend": {
-      "version": "3.0.1",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "3.0.1"
     },
     "extglob": {
       "version": "0.3.2",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "requires": {
-        "is-extglob": "1.0.0"
-      },
       "dependencies": {
         "is-extglob": {
-          "version": "1.0.0",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "version": "1.0.0"
         }
       }
     },
     "extsprintf": {
-      "version": "1.3.0",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "version": "1.3.0"
     },
     "falafel": {
       "version": "1.2.0",
-      "integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
-      "requires": {
-        "acorn": "1.2.2",
-        "foreach": "2.0.5",
-        "isarray": "0.0.1",
-        "object-keys": "1.0.11"
-      },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "version": "0.0.1"
         }
       }
     },
     "fancy-log": {
       "version": "1.3.1",
-      "integrity": "sha1-xKNGK6FK3137q3lzH9OESiBpy7s=",
-      "dev": true,
-      "requires": {
-        "ansi-gray": "0.1.1",
-        "time-stamp": "1.1.0"
-      }
+      "dev": true
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+      "version": "1.0.0"
     },
     "fast-future": {
-      "version": "1.0.2",
-      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
+      "version": "1.0.2"
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.0.0"
     },
     "fast-levenshtein": {
       "version": "1.1.4",
-      "integrity": "sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk=",
       "dev": true
     },
     "fast-luhn": {
-      "version": "1.0.3",
-      "integrity": "sha1-dZyjqYPdoGdC06PPpvZAcFNqQi8="
+      "version": "1.0.3"
     },
     "fastparse": {
-      "version": "1.1.1",
-      "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
+      "version": "1.1.1"
     },
     "fb-watchman": {
       "version": "2.0.0",
-      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-      "dev": true,
-      "requires": {
-        "bser": "2.0.0"
-      }
+      "dev": true
     },
     "fbemitter": {
-      "version": "2.1.1",
-      "integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
-      "requires": {
-        "fbjs": "0.8.16"
-      }
+      "version": "2.1.1"
     },
     "fbjs": {
       "version": "0.8.16",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-      "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.17"
-      },
       "dependencies": {
         "core-js": {
-          "version": "1.2.7",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+          "version": "1.2.7"
         }
       }
     },
     "fbjs-scripts": {
       "version": "0.7.1",
-      "integrity": "sha1-TxFeIY4kPjrdvw7dqsHjxi9wP6w=",
       "dev": true,
-      "requires": {
-        "babel-core": "6.25.0",
-        "babel-preset-fbjs": "1.0.0",
-        "core-js": "1.2.7",
-        "cross-spawn": "3.0.1",
-        "gulp-util": "3.0.8",
-        "object-assign": "4.1.1",
-        "semver": "5.1.0",
-        "through2": "2.0.3"
-      },
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         },
         "cross-spawn": {
           "version": "3.0.1",
-          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.3.0"
-          }
+          "dev": true
         },
         "inherits": {
           "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         },
         "through2": {
           "version": "2.0.3",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          }
+          "dev": true
         }
       }
     },
     "figures": {
       "version": "1.7.0",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
-      },
       "dependencies": {
         "escape-string-regexp": {
           "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         }
       }
     },
     "file-entry-cache": {
       "version": "2.0.0",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
-      "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "filename-regex": {
-      "version": "2.0.1",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+      "version": "2.0.1"
     },
     "fileset": {
       "version": "2.0.3",
-      "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-      "dev": true,
-      "requires": {
-        "glob": "7.0.3",
-        "minimatch": "3.0.4"
-      }
+      "dev": true
     },
     "filesize": {
-      "version": "3.2.1",
-      "integrity": "sha1-oG8cVJftY1gFfEFeU0A/dkwfteY="
+      "version": "3.2.1"
     },
     "fill-range": {
-      "version": "2.2.3",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
-      }
+      "version": "2.2.3"
     },
     "finalhandler": {
-      "version": "0.4.0",
-      "integrity": "sha1-llpS2ejQXSuFdUhUH7ibU6JJfZs=",
-      "requires": {
-        "debug": "2.2.0",
-        "escape-html": "1.0.2",
-        "on-finished": "2.3.0",
-        "unpipe": "1.0.0"
-      }
+      "version": "0.4.0"
     },
     "find-cache-dir": {
-      "version": "1.0.0",
-      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-      "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.1.0",
-        "pkg-dir": "2.0.0"
-      }
+      "version": "1.0.0"
     },
     "find-parent-dir": {
       "version": "0.3.0",
-      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
       "dev": true
     },
     "find-up": {
-      "version": "2.1.0",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "requires": {
-        "locate-path": "2.0.0"
-      }
+      "version": "2.1.0"
     },
     "findup": {
       "version": "0.1.5",
-      "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
-      "requires": {
-        "colors": "0.6.2",
-        "commander": "2.1.0"
-      },
       "dependencies": {
         "commander": {
-          "version": "2.1.0",
-          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
+          "version": "2.1.0"
         }
       }
     },
     "finished": {
       "version": "1.2.2",
-      "integrity": "sha1-QWCOr639ZWg7RqEiC8Sx7D2u3Ng=",
-      "requires": {
-        "ee-first": "1.0.3"
-      },
       "dependencies": {
         "ee-first": {
-          "version": "1.0.3",
-          "integrity": "sha1-bJjECJq+y1p7hcGsRJqmA9Oz2r4="
+          "version": "1.0.3"
         }
       }
     },
     "flag-icon-css": {
-      "version": "2.3.0",
-      "integrity": "sha1-DiCpvfoCB+r1DJ7bigzo/izC5nY="
+      "version": "2.3.0"
     },
     "flat-cache": {
       "version": "1.3.0",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-      "dev": true,
-      "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
-      }
+      "dev": true
     },
     "flatten": {
       "version": "1.0.2",
-      "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
     },
     "flow-parser": {
       "version": "0.61.0",
-      "integrity": "sha1-V9HTO7yPsbk0GYRGSsAy4FTuEIQ=",
       "dev": true
     },
     "flush-write-stream": {
       "version": "1.0.2",
-      "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
-      "requires": {
-        "inherits": "2.0.1",
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "readable-stream": {
           "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          },
           "dependencies": {
             "inherits": {
-              "version": "2.0.3",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "version": "2.0.3"
             }
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "flux": {
       "version": "2.1.1",
-      "integrity": "sha1-LGrGUtQzdIiWhInGWG86/yajjqQ=",
-      "requires": {
-        "fbemitter": "2.1.1",
-        "fbjs": "0.1.0-alpha.7",
-        "immutable": "3.7.6"
-      },
       "dependencies": {
         "core-js": {
-          "version": "1.2.7",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+          "version": "1.2.7"
         },
         "fbjs": {
-          "version": "0.1.0-alpha.7",
-          "integrity": "sha1-rUMIuPIy+zxzYDNJ6nJdHpw5Mjw=",
-          "requires": {
-            "core-js": "1.2.7",
-            "promise": "7.3.1",
-            "whatwg-fetch": "0.9.0"
-          }
+          "version": "0.1.0-alpha.7"
         },
         "whatwg-fetch": {
-          "version": "0.9.0",
-          "integrity": "sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA="
+          "version": "0.9.0"
         }
       }
     },
     "for-in": {
-      "version": "1.0.2",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+      "version": "1.0.2"
     },
     "for-own": {
-      "version": "0.1.5",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "requires": {
-        "for-in": "1.0.2"
-      }
+      "version": "0.1.5"
     },
     "foreach": {
-      "version": "2.0.5",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "version": "2.0.5"
     },
     "foreachasync": {
-      "version": "3.0.0",
-      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
+      "version": "3.0.0"
     },
     "forever-agent": {
-      "version": "0.6.1",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "version": "0.6.1"
     },
     "form-data": {
-      "version": "2.3.1",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
-      }
+      "version": "2.3.1"
     },
     "formatio": {
       "version": "1.1.1",
-      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "dev": true,
-      "requires": {
-        "samsam": "1.1.2"
-      }
+      "dev": true
     },
     "formidable": {
-      "version": "1.1.1",
-      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
+      "version": "1.1.1"
     },
     "forwarded": {
-      "version": "0.1.2",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+      "version": "0.1.2"
     },
     "fresh": {
-      "version": "0.3.0",
-      "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+      "version": "0.3.0"
     },
     "from": {
-      "version": "0.1.7",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+      "version": "0.1.7"
     },
     "from2": {
       "version": "2.3.0",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "requires": {
-        "inherits": "2.0.1",
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "readable-stream": {
           "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          },
           "dependencies": {
             "inherits": {
-              "version": "2.0.3",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "version": "2.0.3"
             }
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "fs-extra": {
-      "version": "0.26.7",
-      "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
-      }
+      "version": "0.26.7"
     },
     "fs-readdir-recursive": {
       "version": "0.1.2",
-      "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk=",
       "dev": true
     },
     "fs-write-stream-atomic": {
-      "version": "1.0.10",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "1.1.14"
-      }
+      "version": "1.0.10"
     },
     "fs.realpath": {
-      "version": "1.0.0",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "version": "1.0.0"
     },
     "fsevents": {
       "version": "1.1.3",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "optional": true,
-      "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
-      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
+          "optional": true
         },
         "ansi-regex": {
-          "version": "2.1.1",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "version": "2.1.1"
         },
         "aproba": {
           "version": "1.1.1",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
+          "optional": true
         },
         "asn1": {
           "version": "0.2.3",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "optional": true
         },
         "balanced-match": {
-          "version": "0.4.2",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+          "version": "0.4.2"
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
+          "optional": true
         },
         "block-stream": {
-          "version": "0.0.9",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "requires": {
-            "inherits": "2.0.3"
-          }
+          "version": "0.0.9"
         },
         "boom": {
-          "version": "2.10.1",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "requires": {
-            "hoek": "2.16.3"
-          }
+          "version": "2.10.1"
         },
         "brace-expansion": {
-          "version": "1.1.7",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
+          "version": "1.1.7"
         },
         "buffer-shims": {
-          "version": "1.0.0",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+          "version": "1.0.0"
         },
         "caseless": {
           "version": "0.12.0",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "optional": true
         },
         "code-point-at": {
-          "version": "1.1.0",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "version": "1.1.0"
         },
         "combined-stream": {
-          "version": "1.0.5",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
+          "version": "1.0.5"
         },
         "concat-map": {
-          "version": "0.0.1",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "version": "0.0.1"
         },
         "console-control-strings": {
-          "version": "1.1.0",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "version": "1.1.0"
         },
         "core-util-is": {
-          "version": "1.0.2",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+          "version": "1.0.2"
         },
         "cryptiles": {
-          "version": "2.0.5",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "requires": {
-            "boom": "2.10.1"
-          }
+          "version": "2.0.5"
         },
         "dashdash": {
           "version": "1.14.1",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "optional": true
             }
           }
         },
         "debug": {
           "version": "2.6.8",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "optional": true
         },
         "deep-extend": {
           "version": "0.4.2",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "optional": true
         },
         "delayed-stream": {
-          "version": "1.0.0",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+          "version": "1.0.0"
         },
         "delegates": {
           "version": "1.0.0",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.2",
-          "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
+          "optional": true
         },
         "extend": {
           "version": "3.0.1",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
           "optional": true
         },
         "extsprintf": {
-          "version": "1.0.2",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+          "version": "1.0.2"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
+          "optional": true
         },
         "fs.realpath": {
-          "version": "1.0.0",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+          "version": "1.0.0"
         },
         "fstream": {
-          "version": "1.0.11",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
+          "version": "1.0.11"
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
+          "optional": true
         },
         "getpass": {
           "version": "0.1.7",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "optional": true
             }
           }
         },
         "glob": {
-          "version": "7.1.2",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "version": "7.1.2"
         },
         "graceful-fs": {
-          "version": "4.1.11",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+          "version": "4.1.11"
         },
         "har-schema": {
           "version": "1.0.5",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
+          "optional": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "hawk": {
-          "version": "3.1.3",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
+          "version": "3.1.3"
         },
         "hoek": {
-          "version": "2.16.3",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+          "version": "2.16.3"
         },
         "http-signature": {
           "version": "1.1.1",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
+          "optional": true
         },
         "inflight": {
-          "version": "1.0.6",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
+          "version": "1.0.6"
         },
         "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3"
         },
         "ini": {
           "version": "1.3.4",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "optional": true
         },
         "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "version": "1.0.0"
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "optional": true
         },
         "isarray": {
-          "version": "1.0.0",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "version": "1.0.0"
         },
         "isstream": {
           "version": "0.1.2",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
+          "optional": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
+          "optional": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
           "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "optional": true
             }
           }
         },
         "mime-db": {
-          "version": "1.27.0",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+          "version": "1.27.0"
         },
         "mime-types": {
-          "version": "2.1.15",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-          "requires": {
-            "mime-db": "1.27.0"
-          }
+          "version": "2.1.15"
         },
         "minimatch": {
-          "version": "3.0.4",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
+          "version": "3.0.4"
         },
         "minimist": {
-          "version": "0.0.8",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "version": "0.0.8"
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "requires": {
-            "minimist": "0.0.8"
-          }
+          "version": "0.5.1"
         },
         "ms": {
           "version": "2.0.0",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
-          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
+          "optional": true
         },
         "nopt": {
           "version": "4.0.1",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
+          "optional": true
         },
         "npmlog": {
           "version": "4.1.0",
-          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
+          "optional": true
         },
         "number-is-nan": {
-          "version": "1.0.1",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "version": "1.0.1"
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
-          "version": "1.4.0",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "requires": {
-            "wrappy": "1.0.2"
-          }
+          "version": "1.4.0"
         },
         "os-homedir": {
           "version": "1.0.2",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
+          "optional": true
         },
         "path-is-absolute": {
-          "version": "1.0.1",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+          "version": "1.0.1"
         },
         "performance-now": {
           "version": "0.2.0",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
           "optional": true
         },
         "process-nextick-args": {
-          "version": "1.0.7",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+          "version": "1.0.7"
         },
         "punycode": {
           "version": "1.4.1",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
           }
         },
         "readable-stream": {
-          "version": "2.2.9",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
+          "version": "2.2.9"
         },
         "request": {
           "version": "2.81.0",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
+          "optional": true
         },
         "rimraf": {
-          "version": "2.6.1",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "requires": {
-            "glob": "7.1.2"
-          }
+          "version": "2.6.1"
         },
         "safe-buffer": {
-          "version": "5.0.1",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+          "version": "5.0.1"
         },
         "semver": {
           "version": "5.3.0",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "sntp": {
-          "version": "1.0.9",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "requires": {
-            "hoek": "2.16.3"
-          }
+          "version": "1.0.9"
         },
         "sshpk": {
           "version": "1.13.0",
-          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
           "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "optional": true
             }
           }
         },
-        "string-width": {
-          "version": "1.0.2",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
         "string_decoder": {
-          "version": "1.0.1",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
+          "version": "1.0.1"
+        },
+        "string-width": {
+          "version": "1.0.2"
         },
         "stringstream": {
           "version": "0.0.5",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "optional": true
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+          "version": "3.0.1"
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
-          "version": "2.2.1",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
+          "version": "2.2.1"
         },
         "tar-pack": {
           "version": "3.4.0",
-          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
+          "optional": true
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
+          "optional": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
+          "optional": true
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "optional": true
         },
         "util-deprecate": {
-          "version": "1.0.2",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+          "version": "1.0.2"
         },
         "uuid": {
           "version": "3.0.1",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
+          "optional": true
         },
         "wrappy": {
-          "version": "1.0.2",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "version": "1.0.2"
         }
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.1",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
-      }
+      "version": "1.0.11"
     },
     "function-bind": {
-      "version": "1.1.1",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.1"
     },
     "function.prototype.name": {
       "version": "1.0.3",
-      "integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "is-callable": "1.1.3"
-      }
+      "dev": true
     },
     "fuse.js": {
-      "version": "2.6.1",
-      "integrity": "sha1-0RjgD5qFn3s1TtT3dAIUJJ4ypXo="
+      "version": "2.6.1"
     },
     "gather-stream": {
-      "version": "1.0.0",
-      "integrity": "sha1-szmUr0V6gRVwDUEPMXczy+egkEs="
+      "version": "1.0.0"
     },
     "gauge": {
-      "version": "2.7.4",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
-      }
+      "version": "2.7.4"
     },
     "gaze": {
-      "version": "1.1.2",
-      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
-      "requires": {
-        "globule": "1.2.0"
-      }
+      "version": "1.1.2"
     },
     "generate-function": {
-      "version": "2.0.0",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+      "version": "2.0.0"
     },
     "generate-object-property": {
-      "version": "1.2.0",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "requires": {
-        "is-property": "1.0.2"
-      }
+      "version": "1.2.0"
     },
     "get-caller-file": {
-      "version": "1.0.2",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+      "version": "1.0.2"
     },
     "get-document": {
-      "version": "1.0.0",
-      "integrity": "sha1-SCG85m8cJMsDMWAr5strEsTwHEs="
+      "version": "1.0.0"
     },
     "get-pixels": {
       "version": "3.3.0",
-      "integrity": "sha1-jZeVvq4YhQuED3SVgbrcBdPjbkE=",
-      "dev": true,
-      "requires": {
-        "data-uri-to-buffer": "0.0.3",
-        "jpeg-js": "0.1.2",
-        "mime-types": "2.1.17",
-        "ndarray": "1.0.18",
-        "ndarray-pack": "1.2.1",
-        "node-bitmap": "0.0.1",
-        "omggif": "1.0.8",
-        "parse-data-uri": "0.2.0",
-        "pngjs": "2.3.1",
-        "request": "2.83.0",
-        "through": "2.3.8"
-      }
+      "dev": true
     },
     "get-src": {
-      "version": "1.0.1",
-      "integrity": "sha1-yhHb5Kk8fzqoXOyV/LCy36qVOe4="
+      "version": "1.0.1"
     },
     "get-stdin": {
-      "version": "4.0.1",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+      "version": "4.0.1"
     },
     "get-stream": {
-      "version": "3.0.0",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+      "version": "3.0.0"
     },
     "get-video-id": {
-      "version": "2.1.4",
-      "integrity": "sha1-lyKhEi4bxlK2lUOIo8jLngv8XBs=",
-      "requires": {
-        "get-src": "1.0.1"
-      }
+      "version": "2.1.4"
     },
     "getpass": {
-      "version": "0.1.7",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
+      "version": "0.1.7"
     },
     "github-from-package": {
-      "version": "0.0.0",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+      "version": "0.0.0"
     },
     "glob": {
       "version": "7.0.3",
-      "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
-      "dev": true,
-      "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.1",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
+      "dev": true
     },
     "glob-base": {
       "version": "0.3.0",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      },
       "dependencies": {
         "is-extglob": {
-          "version": "1.0.0",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "version": "1.0.0"
         },
         "is-glob": {
-          "version": "2.0.1",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
+          "version": "2.0.1"
         }
       }
     },
     "glob-parent": {
       "version": "2.0.0",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "requires": {
-        "is-glob": "2.0.1"
-      },
       "dependencies": {
         "is-extglob": {
-          "version": "1.0.0",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "version": "1.0.0"
         },
         "is-glob": {
-          "version": "2.0.1",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
+          "version": "2.0.1"
         }
       }
     },
     "globals": {
-      "version": "9.18.0",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "version": "9.18.0"
     },
     "globby": {
       "version": "6.1.0",
-      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-      "requires": {
-        "array-union": "1.0.2",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      },
       "dependencies": {
         "glob": {
-          "version": "7.1.2",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "version": "7.1.2"
         },
         "pify": {
-          "version": "2.3.0",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "version": "2.3.0"
         }
       }
     },
     "globjoin": {
       "version": "0.1.4",
-      "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
       "dev": true
     },
     "globule": {
       "version": "1.2.0",
-      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
-      "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4"
-      },
       "dependencies": {
         "glob": {
-          "version": "7.1.2",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "version": "7.1.2"
         },
         "lodash": {
-          "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.4"
         }
       }
     },
     "glogg": {
       "version": "1.0.0",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-      "dev": true,
-      "requires": {
-        "sparkles": "1.0.0"
-      }
+      "dev": true
     },
     "good-listener": {
-      "version": "1.2.2",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "requires": {
-        "delegate": "3.2.0"
-      }
+      "version": "1.2.2"
     },
     "got": {
       "version": "3.3.1",
-      "integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
       "dev": true,
-      "requires": {
-        "duplexify": "3.5.1",
-        "infinity-agent": "2.0.3",
-        "is-redirect": "1.0.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "nested-error-stacks": "1.0.2",
-        "object-assign": "3.0.0",
-        "prepend-http": "1.0.4",
-        "read-all-stream": "3.1.0",
-        "timed-out": "2.0.0"
-      },
       "dependencies": {
         "object-assign": {
           "version": "3.0.0",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
           "dev": true
         }
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "version": "4.1.11"
     },
     "graceful-readlink": {
-      "version": "1.0.1",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+      "version": "1.0.1"
     },
     "graphql": {
       "version": "0.10.1",
-      "integrity": "sha1-dck8LOc661uuLu+1Vajp45w2An0=",
-      "dev": true,
-      "requires": {
-        "iterall": "1.1.3"
-      }
+      "dev": true
     },
     "gridicons": {
-      "version": "2.1.0",
-      "integrity": "sha1-NIVyLWaJ4Mqu62a2ys8VuXJsKSk=",
-      "requires": {
-        "prop-types": "15.5.10"
-      }
+      "version": "2.1.1"
     },
     "growly": {
       "version": "1.3.0",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
     "gulp-util": {
       "version": "3.0.8",
-      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-uniq": "1.0.3",
-        "beeper": "1.1.1",
-        "chalk": "1.0.0",
-        "dateformat": "2.2.0",
-        "fancy-log": "1.3.1",
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash._reescape": "3.0.0",
-        "lodash._reevaluate": "3.0.0",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.template": "3.6.2",
-        "minimist": "1.2.0",
-        "multipipe": "0.1.2",
-        "object-assign": "3.0.0",
-        "replace-ext": "0.0.1",
-        "through2": "2.0.3",
-        "vinyl": "0.5.3"
-      },
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "object-assign": {
           "version": "3.0.0",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         },
         "through2": {
           "version": "2.0.3",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          }
+          "dev": true
         }
       }
     },
     "gulplog": {
       "version": "1.0.0",
-      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "dev": true,
-      "requires": {
-        "glogg": "1.0.0"
-      }
+      "dev": true
     },
     "gzip-size": {
       "version": "3.0.0",
-      "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
-      "dev": true,
-      "requires": {
-        "duplexer": "0.1.1"
-      }
+      "dev": true
     },
     "handlebars": {
       "version": "4.0.11",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.6.4"
-      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "source-map": {
           "version": "0.4.4",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
     "happypack": {
       "version": "4.0.0",
-      "integrity": "sha1-3hdw1HLasz4/MXgqPttOd8xlhjE=",
-      "requires": {
-        "async": "1.5.0",
-        "json-stringify-safe": "5.0.1",
-        "loader-utils": "1.1.0",
-        "serialize-error": "2.1.0"
-      },
       "dependencies": {
         "async": {
-          "version": "1.5.0",
-          "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM="
+          "version": "1.5.0"
         }
       }
     },
     "har-schema": {
-      "version": "2.0.0",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "version": "2.0.0"
     },
     "har-validator": {
-      "version": "5.0.3",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "requires": {
-        "ajv": "5.5.1",
-        "har-schema": "2.0.0"
-      }
+      "version": "5.0.3"
     },
     "hard-source-webpack-plugin": {
       "version": "0.3.12",
-      "integrity": "sha1-upvxzmRegxRrQyTAaJCSdZlyI7U=",
-      "requires": {
-        "bluebird": "3.5.1",
-        "level": "1.7.0",
-        "lodash": "4.15.0",
-        "mkdirp": "0.5.1",
-        "source-list-map": "0.1.8",
-        "source-map": "0.5.7",
-        "webpack-core": "0.6.9",
-        "webpack-sources": "0.1.5"
-      },
       "dependencies": {
         "bluebird": {
-          "version": "3.5.1",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+          "version": "3.5.1"
         },
         "source-map": {
-          "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.5.7"
         }
       }
     },
     "has": {
-      "version": "1.0.1",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "requires": {
-        "function-bind": "1.1.1"
-      }
+      "version": "1.0.1"
     },
     "has-ansi": {
-      "version": "2.0.0",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "version": "2.0.0"
     },
     "has-binary": {
       "version": "0.1.7",
-      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
-      "requires": {
-        "isarray": "0.0.1"
-      },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "version": "0.0.1"
         }
       }
     },
     "has-color": {
       "version": "0.1.7",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
       "dev": true
     },
     "has-cors": {
-      "version": "1.1.0",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+      "version": "1.1.0"
     },
     "has-flag": {
-      "version": "1.0.0",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+      "version": "1.0.0"
     },
     "has-gulplog": {
       "version": "0.1.0",
-      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true,
-      "requires": {
-        "sparkles": "1.0.0"
-      }
+      "dev": true
     },
     "has-unicode": {
-      "version": "2.0.1",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "version": "2.0.1"
     },
     "hash-base": {
-      "version": "2.0.2",
-      "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-      "requires": {
-        "inherits": "2.0.1"
-      }
+      "version": "2.0.2"
     },
     "hash.js": {
       "version": "1.1.3",
-      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-      "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
-      },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3"
         }
       }
     },
     "hawk": {
-      "version": "6.0.2",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
-      }
+      "version": "6.0.2"
     },
     "he": {
-      "version": "0.5.0",
-      "integrity": "sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI="
+      "version": "0.5.0"
     },
     "hmac-drbg": {
-      "version": "1.0.1",
-      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
-      }
+      "version": "1.0.1"
     },
     "hoek": {
-      "version": "4.2.0",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+      "version": "4.2.0"
     },
     "hoist-non-react-statics": {
-      "version": "1.2.0",
-      "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+      "version": "1.2.0"
     },
     "home-or-tmp": {
-      "version": "2.0.0",
-      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "version": "2.0.0"
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "version": "2.5.0"
     },
     "html": {
       "version": "1.0.0",
-      "integrity": "sha1-pUT6nqVJK/s6LMqCEKEL57WvH2E=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.5.2"
-      }
+      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
-      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-      "dev": true,
-      "requires": {
-        "whatwg-encoding": "1.0.3"
-      }
+      "dev": true
     },
     "html-entities": {
-      "version": "1.2.1",
-      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+      "version": "1.2.1"
     },
     "html-loader": {
       "version": "0.4.0",
-      "integrity": "sha1-hB4LT46fD9QgnJTOATNwJh1kEOE=",
-      "requires": {
-        "es6-templates": "0.2.3",
-        "fastparse": "1.1.1",
-        "html-minifier": "1.5.0",
-        "loader-utils": "0.2.17",
-        "object-assign": "4.1.1",
-        "source-map": "0.5.7"
-      },
       "dependencies": {
         "loader-utils": {
-          "version": "0.2.17",
-          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
-          }
+          "version": "0.2.17"
         },
         "source-map": {
-          "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.5.7"
         }
       }
     },
     "html-minifier": {
       "version": "1.5.0",
-      "integrity": "sha1-vrBf2cw0CUWGXBD0Cu30aa9LFTQ=",
-      "requires": {
-        "change-case": "2.3.1",
-        "clean-css": "3.4.28",
-        "commander": "2.9.0",
-        "concat-stream": "1.5.2",
-        "he": "1.0.0",
-        "ncname": "1.0.0",
-        "relateurl": "0.2.7",
-        "uglify-js": "2.6.4"
-      },
       "dependencies": {
         "commander": {
-          "version": "2.9.0",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
+          "version": "2.9.0"
         },
         "he": {
-          "version": "1.0.0",
-          "integrity": "sha1-baWyZdfyw7XkgHSRaODhWdBXKNo="
+          "version": "1.0.0"
         }
       }
     },
     "html-tags": {
       "version": "1.2.0",
-      "integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g=",
       "dev": true
     },
     "htmlparser2": {
       "version": "3.9.2",
-      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "dev": true,
-      "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.1",
-        "domutils": "1.5.1",
-        "entities": "1.1.1",
-        "inherits": "2.0.1",
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "readable-stream": {
           "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          },
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true
             }
           }
         },
         "string_decoder": {
           "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         }
       }
     },
     "http-errors": {
       "version": "1.6.2",
-      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-      "requires": {
-        "depd": "1.1.1",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.4.0"
-      },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3"
         }
       }
     },
     "http-signature": {
-      "version": "1.2.0",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
-      }
+      "version": "1.2.0"
     },
     "https-browserify": {
-      "version": "1.0.0",
-      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+      "version": "1.0.0"
     },
     "husky": {
       "version": "0.13.3",
-      "integrity": "sha1-vCBmCAutyLj+NRbogfW8aKVwUv8=",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "find-parent-dir": "0.3.0",
-        "is-ci": "1.0.10",
-        "normalize-path": "1.0.0"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "normalize-path": {
           "version": "1.0.0",
-          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "i18n-calypso": {
       "version": "1.8.4",
-      "integrity": "sha512-vAEAmvbuytZEs/2d0M4WJYCKtzuCt4L2R7jMg57yO50kCmm5uPIj/9EJadum+MBPU7JgyWzDHH5J8PDr7deW4A==",
-      "requires": {
-        "async": "1.5.2",
-        "commander": "2.12.2",
-        "create-react-class": "15.6.2",
-        "debug": "2.2.0",
-        "globby": "6.1.0",
-        "interpolate-components": "1.1.1",
-        "jed": "1.0.2",
-        "jstimezonedetect": "1.0.5",
-        "lodash.assign": "4.2.0",
-        "lodash.flatten": "4.4.0",
-        "lru": "3.1.0",
-        "moment-timezone": "0.5.11",
-        "react": "16.2.0",
-        "xgettext-js": "1.0.0"
-      },
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+          "version": "1.5.2"
         },
         "commander": {
-          "version": "2.12.2",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+          "version": "2.12.2"
         },
         "lodash.assign": {
-          "version": "4.2.0",
-          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+          "version": "4.2.0"
         }
       }
     },
     "iconv-lite": {
-      "version": "0.4.15",
-      "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
+      "version": "0.4.15"
     },
     "ieee754": {
-      "version": "1.1.8",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+      "version": "1.1.8"
     },
     "iferr": {
-      "version": "0.1.5",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+      "version": "0.1.5"
     },
     "ignore": {
       "version": "3.3.5",
-      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
       "dev": true
     },
     "immediate": {
-      "version": "3.0.6",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+      "version": "3.0.6"
     },
     "immutability-helper": {
-      "version": "2.4.0",
-      "integrity": "sha512-rW/L/56ZMo9NStMK85kFrUFFGy4NeJbCdhfrDHIZrFfxYtuwuxD+dT3mWMcdmrNO61hllc60AeGglCRhfZ1dZw==",
-      "requires": {
-        "invariant": "2.2.2"
-      }
+      "version": "2.4.0"
     },
     "immutable": {
-      "version": "3.7.6",
-      "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
+      "version": "3.7.6"
     },
     "imports-loader": {
       "version": "0.6.5",
-      "integrity": "sha1-rnRlMDHVnjezwvslRKxhrq41MKY=",
-      "requires": {
-        "loader-utils": "0.2.17",
-        "source-map": "0.1.39"
-      },
       "dependencies": {
         "loader-utils": {
-          "version": "0.2.17",
-          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
-          }
+          "version": "0.2.17"
         }
       }
     },
     "imurmurhash": {
-      "version": "0.1.4",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+      "version": "0.1.4"
     },
     "in-publish": {
-      "version": "2.0.0",
-      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
+      "version": "2.0.0"
     },
     "indent-string": {
-      "version": "2.1.0",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "version": "2.1.0"
     },
     "indexes-of": {
       "version": "1.0.1",
-      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
     "indexof": {
-      "version": "0.0.1",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+      "version": "0.0.1"
     },
     "infinity-agent": {
       "version": "2.0.3",
-      "integrity": "sha1-ReDi/3qesDCyfWK3SzdEt6esQhY=",
       "dev": true
     },
     "inflight": {
-      "version": "1.0.6",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
+      "version": "1.0.6"
     },
     "inherits": {
-      "version": "2.0.1",
-      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+      "version": "2.0.1"
     },
     "ini": {
-      "version": "1.3.5",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.5"
     },
     "inline-process-browser": {
-      "version": "1.0.0",
-      "integrity": "sha1-RqYbFT3TybFiSxoAYm7bT39BTyI=",
-      "requires": {
-        "falafel": "1.2.0",
-        "through2": "0.6.5"
-      }
+      "version": "1.0.0"
     },
     "inquirer": {
       "version": "0.11.0",
-      "integrity": "sha1-dEi/qSQJKvMR1HFzu6uZDK4rsCc=",
       "dev": true,
-      "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.0.0",
-        "cli-cursor": "1.0.2",
-        "cli-width": "1.1.1",
-        "figures": "1.7.0",
-        "lodash": "3.10.1",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
-      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
       }
     },
     "interpolate-components": {
-      "version": "1.1.1",
-      "integrity": "sha1-aZ//RdFSXpjHzntxWVkdmStd1t8=",
-      "requires": {
-        "react": "16.2.0",
-        "react-addons-create-fragment": "15.6.2",
-        "react-dom": "16.2.0"
-      }
+      "version": "1.1.1"
     },
     "interpret": {
-      "version": "1.1.0",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+      "version": "1.1.0"
     },
     "invariant": {
-      "version": "2.2.2",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
+      "version": "2.2.2"
     },
     "invert-kv": {
-      "version": "1.0.0",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "version": "1.0.0"
     },
     "iota-array": {
       "version": "1.0.0",
-      "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc=",
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.0.5",
-      "integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c="
+      "version": "1.0.5"
     },
     "irregular-plurals": {
       "version": "1.4.0",
-      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
       "dev": true
     },
     "is-arrayish": {
-      "version": "0.2.1",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "version": "0.2.1"
     },
     "is-binary-path": {
-      "version": "1.0.1",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "requires": {
-        "binary-extensions": "1.11.0"
-      }
+      "version": "1.0.1"
     },
     "is-buffer": {
-      "version": "1.1.6",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "version": "1.1.6"
     },
     "is-builtin-module": {
-      "version": "1.0.0",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "requires": {
-        "builtin-modules": "1.1.1"
-      }
+      "version": "1.0.0"
     },
     "is-callable": {
-      "version": "1.1.3",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+      "version": "1.1.3"
     },
     "is-ci": {
       "version": "1.0.10",
-      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
-      "dev": true,
-      "requires": {
-        "ci-info": "1.1.2"
-      }
+      "dev": true
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "version": "1.0.1"
     },
     "is-directory": {
       "version": "0.3.1",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
     "is-dotfile": {
-      "version": "1.0.3",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+      "version": "1.0.3"
     },
     "is-equal-shallow": {
-      "version": "0.1.3",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
+      "version": "0.1.3"
     },
     "is-expression": {
       "version": "2.1.0",
-      "integrity": "sha1-kb6dR968/vB3l36XIr5tz7RGXvA=",
-      "requires": {
-        "acorn": "3.3.0",
-        "object-assign": "4.1.1"
-      },
       "dependencies": {
         "acorn": {
-          "version": "3.3.0",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+          "version": "3.3.0"
         }
       }
     },
     "is-extendable": {
-      "version": "0.1.1",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+      "version": "0.1.1"
     },
     "is-extglob": {
-      "version": "2.1.1",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+      "version": "2.1.1"
     },
     "is-finite": {
-      "version": "1.0.2",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "version": "1.0.2"
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "version": "1.0.0"
     },
     "is-glob": {
-      "version": "3.1.0",
-      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-      "requires": {
-        "is-extglob": "2.1.1"
-      }
+      "version": "3.1.0"
     },
     "is-integer": {
-      "version": "1.0.7",
-      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
-      "requires": {
-        "is-finite": "1.0.2"
-      }
+      "version": "1.0.7"
     },
     "is-lower-case": {
-      "version": "1.1.3",
-      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
-      "requires": {
-        "lower-case": "1.1.4"
-      }
+      "version": "1.1.3"
     },
     "is-my-json-valid": {
-      "version": "2.13.1",
-      "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "2.0.0",
-        "xtend": "4.0.1"
-      }
+      "version": "2.13.1"
     },
     "is-npm": {
       "version": "1.0.0",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
       "dev": true
     },
     "is-number": {
-      "version": "2.1.0",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "requires": {
-        "kind-of": "3.2.2"
-      }
+      "version": "2.1.0"
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "1.0.1"
-      }
+      "dev": true
     },
     "is-path-inside": {
       "version": "1.0.1",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
+      "dev": true
     },
     "is-posix-bracket": {
-      "version": "0.1.1",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+      "version": "0.1.1"
     },
     "is-primitive": {
-      "version": "2.0.0",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+      "version": "2.0.0"
     },
     "is-promise": {
-      "version": "2.1.0",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+      "version": "2.1.0"
     },
     "is-property": {
-      "version": "1.0.2",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+      "version": "1.0.2"
     },
     "is-redirect": {
       "version": "1.0.0",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.4",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "requires": {
-        "has": "1.0.1"
-      }
+      "version": "1.0.4"
     },
     "is-regexp": {
       "version": "1.0.0",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
     "is-resolvable": {
-      "version": "1.0.0",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
+      "version": "1.0.1",
+      "dev": true
     },
     "is-stream": {
-      "version": "1.1.0",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "version": "1.1.0"
     },
     "is-subset": {
       "version": "0.1.1",
-      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
       "dev": true
     },
     "is-supported-regexp-flag": {
       "version": "1.0.0",
-      "integrity": "sha1-i1IMhfrnolM4LUsCZS4EVXbhO7g=",
       "dev": true
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+      "version": "1.0.1"
     },
     "is-typedarray": {
-      "version": "1.0.0",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "version": "1.0.0"
     },
     "is-upper-case": {
-      "version": "1.1.2",
-      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
-      "requires": {
-        "upper-case": "1.1.3"
-      }
+      "version": "1.1.2"
     },
     "is-utf8": {
-      "version": "0.2.1",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+      "version": "0.2.1"
     },
     "is-valid-month": {
-      "version": "1.0.0",
-      "integrity": "sha1-VgloaRDi2tgOusg/CjSXg0klbJk=",
-      "requires": {
-        "is-integer": "1.0.7"
-      }
+      "version": "1.0.0"
     },
     "is-windows": {
-      "version": "1.0.1",
-      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk="
+      "version": "1.0.1"
     },
     "isarray": {
-      "version": "1.0.0",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "version": "1.0.0"
     },
     "isexe": {
-      "version": "2.0.0",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "version": "2.0.0"
     },
     "isobject": {
-      "version": "2.1.0",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "requires": {
-        "isarray": "1.0.0"
-      }
+      "version": "2.1.0"
     },
     "isomorphic-fetch": {
-      "version": "2.2.1",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
-      }
+      "version": "2.2.1"
     },
     "isstream": {
-      "version": "0.1.2",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "version": "0.1.2"
     },
     "istanbul": {
       "version": "0.4.5",
-      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
-      "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.10.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.0",
-        "wordwrap": "1.0.0"
-      },
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
-          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "escodegen": {
           "version": "1.8.1",
-          "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-          "dev": true,
-          "requires": {
-            "esprima": "2.7.3",
-            "estraverse": "1.9.3",
-            "esutils": "2.0.2",
-            "optionator": "0.8.1",
-            "source-map": "0.2.0"
-          }
+          "dev": true
         },
         "esprima": {
           "version": "2.7.3",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
           "dev": true
         },
         "estraverse": {
           "version": "1.9.3",
-          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
           "dev": true
         },
         "glob": {
           "version": "5.0.15",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "resolve": {
           "version": "1.1.7",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         },
         "source-map": {
           "version": "0.2.0",
-          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "optional": true
         },
         "wordwrap": {
           "version": "1.0.0",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
       }
     },
     "istanbul-api": {
       "version": "1.2.1",
-      "integrity": "sha512-oFCwXvd65amgaPCzqrR+a2XjanS1MvpXN6l/MlMUTv6uiA1NOgGX+I0uyq8Lg3GDxsxPsaP1049krz3hIJ5+KA==",
       "dev": true,
-      "requires": {
-        "async": "2.6.0",
-        "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "1.9.1",
-        "istanbul-lib-report": "1.1.2",
-        "istanbul-lib-source-maps": "1.2.2",
-        "istanbul-reports": "1.1.3",
-        "js-yaml": "3.10.0",
-        "mkdirp": "0.5.1",
-        "once": "1.4.0"
-      },
       "dependencies": {
         "async": {
           "version": "2.6.0",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-          "dev": true,
-          "requires": {
-            "lodash": "4.15.0"
-          }
+          "dev": true
         }
       }
     },
     "istanbul-lib-coverage": {
       "version": "1.1.1",
-      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
       "dev": true
     },
     "istanbul-lib-hook": {
       "version": "1.1.0",
-      "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
-      "dev": true,
-      "requires": {
-        "append-transform": "0.4.0"
-      }
+      "dev": true
     },
     "istanbul-lib-instrument": {
       "version": "1.9.1",
-      "integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
       "dev": true,
-      "requires": {
-        "babel-generator": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.1.1",
-        "semver": "5.4.1"
-      },
       "dependencies": {
         "semver": {
           "version": "5.4.1",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         }
       }
     },
     "istanbul-lib-report": {
       "version": "1.1.2",
-      "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
-      "dev": true,
-      "requires": {
-        "istanbul-lib-coverage": "1.1.1",
-        "mkdirp": "0.5.1",
-        "path-parse": "1.0.5",
-        "supports-color": "3.2.3"
-      }
+      "dev": true
     },
     "istanbul-lib-source-maps": {
       "version": "1.2.2",
-      "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
       "dev": true,
-      "requires": {
-        "debug": "3.1.0",
-        "istanbul-lib-coverage": "1.1.1",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "source-map": "0.5.7"
-      },
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
     },
     "istanbul-reports": {
       "version": "1.1.3",
-      "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
-      "dev": true,
-      "requires": {
-        "handlebars": "4.0.11"
-      }
+      "dev": true
     },
     "iterall": {
       "version": "1.1.3",
-      "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ==",
       "dev": true
     },
     "jed": {
-      "version": "1.0.2",
-      "integrity": "sha1-coueFHXyrvR0fvk+J4cTqEiQQPo="
+      "version": "1.0.2"
     },
     "jest": {
       "version": "21.2.0",
-      "integrity": "sha512-e3okC8X5Ozv5xn6r0iJlLaORK4fT51NBL7eGMS/yPZ2BwIUdAloGHtBZJIoyIXv91hffGxHqBe5MvjlKlcl0Cg==",
       "dev": true,
-      "requires": {
-        "jest-cli": "21.2.1"
-      },
       "dependencies": {
         "ansi-escapes": {
           "version": "3.0.0",
-          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "chalk": {
           "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "cliui": {
           "version": "3.2.0",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          },
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "string-width": {
               "version": "1.0.2",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
+              "dev": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
+              "dev": true
             }
           }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "jest-cli": {
           "version": "21.2.1",
-          "integrity": "sha512-T1BzrbFxDIW/LLYQqVfo94y/hhaj1NzVQkZgBumAC+sxbjMROI7VkihOdxNR758iYbQykL2ZOWUBurFgkQrzdg==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "3.0.0",
-            "chalk": "2.3.0",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "is-ci": "1.0.10",
-            "istanbul-api": "1.2.1",
-            "istanbul-lib-coverage": "1.1.1",
-            "istanbul-lib-instrument": "1.9.1",
-            "istanbul-lib-source-maps": "1.2.2",
-            "jest-changed-files": "21.2.0",
-            "jest-config": "21.2.1",
-            "jest-environment-jsdom": "21.2.1",
-            "jest-haste-map": "21.2.0",
-            "jest-message-util": "21.2.1",
-            "jest-regex-util": "21.2.0",
-            "jest-resolve-dependencies": "21.2.0",
-            "jest-runner": "21.2.1",
-            "jest-runtime": "21.2.1",
-            "jest-snapshot": "21.2.1",
-            "jest-util": "21.2.1",
-            "micromatch": "2.3.11",
-            "node-notifier": "5.1.2",
-            "pify": "3.0.0",
-            "slash": "1.0.0",
-            "string-length": "2.0.0",
-            "strip-ansi": "4.0.0",
-            "which": "1.3.0",
-            "worker-farm": "1.5.2",
-            "yargs": "9.0.1"
-          }
+          "dev": true
         },
         "load-json-file": {
           "version": "2.0.0",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          },
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
           }
         },
         "os-locale": {
           "version": "2.1.0",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
+          "dev": true
         },
         "path-type": {
           "version": "2.0.0",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          },
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
           }
         },
         "read-pkg": {
           "version": "2.0.0",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
+          "dev": true
         },
         "read-pkg-up": {
           "version": "2.0.0",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             }
           }
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
+          "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         },
         "which-module": {
           "version": "2.0.0",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "yargs": {
           "version": "9.0.1",
-          "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
-          }
+          "dev": true
         },
         "yargs-parser": {
           "version": "7.0.0",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          }
+          "dev": true
         }
       }
     },
     "jest-changed-files": {
       "version": "21.2.0",
-      "integrity": "sha512-+lCNP1IZLwN1NOIvBcV5zEL6GENK6TXrDj4UxWIeLvIsIDa+gf6J7hkqsW2qVVt/wvH65rVvcPwqXdps5eclTQ==",
-      "dev": true,
-      "requires": {
-        "throat": "4.1.0"
-      }
+      "dev": true
     },
     "jest-config": {
       "version": "21.2.1",
-      "integrity": "sha512-fJru5HtlD/5l2o25eY9xT0doK3t2dlglrqoGpbktduyoI0T5CwuB++2YfoNZCrgZipTwPuAGonYv0q7+8yDc/A==",
       "dev": true,
-      "requires": {
-        "chalk": "2.3.0",
-        "glob": "7.1.2",
-        "jest-environment-jsdom": "21.2.1",
-        "jest-environment-node": "21.2.1",
-        "jest-get-type": "21.2.0",
-        "jest-jasmine2": "21.2.1",
-        "jest-regex-util": "21.2.0",
-        "jest-resolve": "21.2.0",
-        "jest-util": "21.2.1",
-        "jest-validate": "21.2.1",
-        "pretty-format": "21.2.1"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
     "jest-diff": {
       "version": "21.2.1",
-      "integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
       "dev": true,
-      "requires": {
-        "chalk": "2.3.0",
-        "diff": "3.4.0",
-        "jest-get-type": "21.2.0",
-        "pretty-format": "21.2.1"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
     "jest-docblock": {
       "version": "21.3.0-beta.1",
-      "integrity": "sha512-7d5emoOoIAdt9+pf244zeQVMJnalypT31QbUUSPOUea6khV+IKYHE5gabWrnQ72ScDRrVVXhi7md01clG7aXdg==",
-      "dev": true,
-      "requires": {
-        "detect-newline": "2.1.0"
-      }
+      "dev": true
     },
     "jest-environment-jsdom": {
       "version": "21.2.1",
-      "integrity": "sha512-mecaeNh0eWmzNrUNMWARysc0E9R96UPBamNiOCYL28k7mksb1d0q6DD38WKP7ABffjnXyUWJPVaWRgUOivwXwg==",
-      "dev": true,
-      "requires": {
-        "jest-mock": "21.2.0",
-        "jest-util": "21.2.1",
-        "jsdom": "9.12.0"
-      }
+      "dev": true
     },
     "jest-environment-node": {
       "version": "21.2.1",
-      "integrity": "sha512-R211867wx9mVBVHzrjGRGTy5cd05K7eqzQl/WyZixR/VkJ4FayS8qkKXZyYnwZi6Rxo6WEV81cDbiUx/GfuLNw==",
-      "dev": true,
-      "requires": {
-        "jest-mock": "21.2.0",
-        "jest-util": "21.2.1"
-      }
+      "dev": true
     },
     "jest-file-exists": {
       "version": "17.0.0",
-      "integrity": "sha1-f2Prc6HEOhP0Yb4mF2i0WvLN0Wk=",
       "dev": true
     },
     "jest-get-type": {
       "version": "21.2.0",
-      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
       "dev": true
     },
     "jest-haste-map": {
       "version": "21.2.0",
-      "integrity": "sha512-5LhsY/loPH7wwOFRMs+PT4aIAORJ2qwgbpMFlbWbxfN0bk3ZCwxJ530vrbSiTstMkYLao6JwBkLhCJ5XbY7ZHw==",
       "dev": true,
-      "requires": {
-        "fb-watchman": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-docblock": "21.2.0",
-        "micromatch": "2.3.11",
-        "sane": "2.2.0",
-        "worker-farm": "1.5.2"
-      },
       "dependencies": {
         "jest-docblock": {
           "version": "21.2.0",
-          "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
           "dev": true
         }
       }
     },
     "jest-jasmine2": {
       "version": "21.2.1",
-      "integrity": "sha512-lw8FXXIEekD+jYNlStfgNsUHpfMWhWWCgHV7n0B7mA/vendH7vBFs8xybjQsDzJSduptBZJHqQX9SMssya9+3A==",
       "dev": true,
-      "requires": {
-        "chalk": "2.3.0",
-        "expect": "21.2.1",
-        "graceful-fs": "4.1.11",
-        "jest-diff": "21.2.1",
-        "jest-matcher-utils": "21.2.1",
-        "jest-message-util": "21.2.1",
-        "jest-snapshot": "21.2.1",
-        "p-cancelable": "0.3.0"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
     "jest-junit-reporter": {
       "version": "1.1.0",
-      "integrity": "sha1-iNYAbsE/gt9AxHiCyGQJic3LFDQ=",
-      "dev": true,
-      "requires": {
-        "xml": "1.0.1"
-      }
+      "dev": true
     },
     "jest-matcher-utils": {
       "version": "21.2.1",
-      "integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
       "dev": true,
-      "requires": {
-        "chalk": "2.3.0",
-        "jest-get-type": "21.2.0",
-        "pretty-format": "21.2.1"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
     "jest-matchers": {
       "version": "17.0.3",
-      "integrity": "sha1-iLlTSMkZND24bQjxI1SoZQrn7d8=",
       "dev": true,
-      "requires": {
-        "jest-diff": "17.0.3",
-        "jest-matcher-utils": "17.0.3",
-        "jest-util": "17.0.2"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "jest-diff": {
           "version": "17.0.3",
-          "integrity": "sha1-j7Me+rOzFNe2G3tmsL3qYX7xwC8=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "diff": "3.4.0",
-            "jest-matcher-utils": "17.0.3",
-            "pretty-format": "4.2.3"
-          }
+          "dev": true
         },
         "jest-matcher-utils": {
           "version": "17.0.3",
-          "integrity": "sha1-8Qjkm5VuFSxmJtzAq6hk9Zq3sNM=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "pretty-format": "4.2.3"
-          }
+          "dev": true
         },
         "jest-mock": {
           "version": "17.0.2",
-          "integrity": "sha1-Pf6SIa/ZqmGz2ZkoQIE6NYuy9Ck=",
           "dev": true
         },
         "jest-util": {
           "version": "17.0.2",
-          "integrity": "sha1-n9nagJHpkE+5dtp+TYkSyiaWhjg=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "diff": "3.4.0",
-            "graceful-fs": "4.1.11",
-            "jest-file-exists": "17.0.0",
-            "jest-mock": "17.0.2",
-            "mkdirp": "0.5.1"
-          }
+          "dev": true
         },
         "pretty-format": {
           "version": "4.2.3",
-          "integrity": "sha1-iJTCrIFBnPgBYp2PZjIKJTgNiwU=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "jest-message-util": {
       "version": "21.2.1",
-      "integrity": "sha512-EbC1X2n0t9IdeMECJn2BOg7buOGivCvVNjqKMXTzQOu7uIfLml+keUfCALDh8o4rbtndIeyGU8/BKfoTr/LVDQ==",
       "dev": true,
-      "requires": {
-        "chalk": "2.3.0",
-        "micromatch": "2.3.11",
-        "slash": "1.0.0"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
     "jest-mock": {
       "version": "21.2.0",
-      "integrity": "sha512-aZDfyVf0LEoABWiY6N0d+O963dUQSyUa4qgzurHR3TBDPen0YxKCJ6l2i7lQGh1tVdsuvdrCZ4qPj+A7PievCw==",
       "dev": true
     },
     "jest-regex-util": {
       "version": "21.2.0",
-      "integrity": "sha512-BKQ1F83EQy0d9Jen/mcVX7D+lUt2tthhK/2gDWRgLDJRNOdRgSp1iVqFxP8EN1ARuypvDflRfPzYT8fQnoBQFQ==",
       "dev": true
     },
     "jest-resolve": {
       "version": "21.2.0",
-      "integrity": "sha512-vefQ/Lr+VdNvHUZFQXWtOqHX3HEdOc2MtSahBO89qXywEbUxGPB9ZLP9+BHinkxb60UT2Q/tTDOS6rYc6Mwigw==",
       "dev": true,
-      "requires": {
-        "browser-resolve": "1.11.2",
-        "chalk": "2.3.0",
-        "is-builtin-module": "1.0.0"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
     "jest-resolve-dependencies": {
       "version": "21.2.0",
-      "integrity": "sha512-ok8ybRFU5ScaAcfufIQrCbdNJSRZ85mkxJ1EhUp8Bhav1W1/jv/rl1Q6QoVQHObNxmKnbHVKrfLZbCbOsXQ+bQ==",
-      "dev": true,
-      "requires": {
-        "jest-regex-util": "21.2.0"
-      }
+      "dev": true
     },
     "jest-runner": {
       "version": "21.2.1",
-      "integrity": "sha512-Anb72BOQlHqF/zETqZ2K20dbYsnqW/nZO7jV8BYENl+3c44JhMrA8zd1lt52+N7ErnsQMd2HHKiVwN9GYSXmrg==",
       "dev": true,
-      "requires": {
-        "jest-config": "21.2.1",
-        "jest-docblock": "21.2.0",
-        "jest-haste-map": "21.2.0",
-        "jest-jasmine2": "21.2.1",
-        "jest-message-util": "21.2.1",
-        "jest-runtime": "21.2.1",
-        "jest-util": "21.2.1",
-        "pify": "3.0.0",
-        "throat": "4.1.0",
-        "worker-farm": "1.5.2"
-      },
       "dependencies": {
         "jest-docblock": {
           "version": "21.2.0",
-          "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
           "dev": true
         }
       }
     },
     "jest-runtime": {
       "version": "21.2.1",
-      "integrity": "sha512-6omlpA3+NSE+rHwD0PQjNEjZeb2z+oRmuehMfM1tWQVum+E0WV3pFt26Am0DUfQkkPyTABvxITRjCUclYgSOsA==",
       "dev": true,
-      "requires": {
-        "babel-core": "6.25.0",
-        "babel-jest": "21.2.0",
-        "babel-plugin-istanbul": "4.1.5",
-        "chalk": "2.3.0",
-        "convert-source-map": "1.5.1",
-        "graceful-fs": "4.1.11",
-        "jest-config": "21.2.1",
-        "jest-haste-map": "21.2.0",
-        "jest-regex-util": "21.2.0",
-        "jest-resolve": "21.2.0",
-        "jest-util": "21.2.1",
-        "json-stable-stringify": "1.0.1",
-        "micromatch": "2.3.11",
-        "slash": "1.0.0",
-        "strip-bom": "3.0.0",
-        "write-file-atomic": "2.3.0",
-        "yargs": "9.0.1"
-      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "chalk": {
           "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "cliui": {
           "version": "3.2.0",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
+              "dev": true
             }
           }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "load-json-file": {
           "version": "2.0.0",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
+          "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
+          "dev": true
         },
         "path-type": {
           "version": "2.0.0",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
+          "dev": true
         },
         "pify": {
           "version": "2.3.0",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
+          "dev": true
         },
         "read-pkg-up": {
           "version": "2.0.0",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
+              "dev": true
             }
           }
         },
         "strip-bom": {
           "version": "3.0.0",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         },
         "which-module": {
           "version": "2.0.0",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.3.0",
-          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
-          }
+          "dev": true
         },
         "yargs": {
           "version": "9.0.1",
-          "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
-          }
+          "dev": true
         },
         "yargs-parser": {
           "version": "7.0.0",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          }
+          "dev": true
         }
       }
     },
     "jest-snapshot": {
       "version": "21.2.1",
-      "integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
       "dev": true,
-      "requires": {
-        "chalk": "2.3.0",
-        "jest-diff": "21.2.1",
-        "jest-matcher-utils": "21.2.1",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "pretty-format": "21.2.1"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
     "jest-util": {
       "version": "21.2.1",
-      "integrity": "sha512-r20W91rmHY3fnCoO7aOAlyfC51x2yeV3xF+prGsJAUsYhKeV670ZB8NO88Lwm7ASu8SdH0S+U+eFf498kjhA4g==",
       "dev": true,
-      "requires": {
-        "callsites": "2.0.0",
-        "chalk": "2.3.0",
-        "graceful-fs": "4.1.11",
-        "jest-message-util": "21.2.1",
-        "jest-mock": "21.2.0",
-        "jest-validate": "21.2.1",
-        "mkdirp": "0.5.1"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         },
         "callsites": {
           "version": "2.0.0",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         },
         "chalk": {
           "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
     "jest-validate": {
       "version": "21.2.1",
-      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
       "dev": true,
-      "requires": {
-        "chalk": "2.3.0",
-        "jest-get-type": "21.2.0",
-        "leven": "2.1.0",
-        "pretty-format": "21.2.1"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "leven": {
           "version": "2.1.0",
-          "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
           "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
     "jpeg-js": {
       "version": "0.1.2",
-      "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4=",
       "dev": true
     },
     "jquery": {
-      "version": "1.11.3",
-      "integrity": "sha1-3Yt0J4snEC0p32Pq4oMIqM+htYM="
+      "version": "1.11.3"
     },
     "js-base64": {
-      "version": "2.4.0",
-      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA=="
+      "version": "2.4.0"
     },
     "js-stringify": {
-      "version": "1.0.2",
-      "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
+      "version": "1.0.2"
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "version": "3.0.2"
     },
     "js-yaml": {
       "version": "3.10.0",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
-      "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
-      },
       "dependencies": {
         "esprima": {
           "version": "4.0.0",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
           "dev": true
         }
       }
     },
     "jsbn": {
       "version": "0.1.1",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
     "jscodeshift": {
       "version": "0.3.30",
-      "integrity": "sha1-c/RZ2Pw7OoCEGZGut9JICc7238U=",
       "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "babel-core": "5.8.38",
-        "babel-plugin-transform-flow-strip-types": "6.22.0",
-        "babel-preset-es2015": "6.24.1",
-        "babel-preset-stage-1": "6.24.1",
-        "babel-register": "6.24.1",
-        "babylon": "6.18.0",
-        "colors": "1.1.2",
-        "es6-promise": "3.3.1",
-        "flow-parser": "0.61.0",
-        "lodash": "4.15.0",
-        "micromatch": "2.3.11",
-        "node-dir": "0.1.8",
-        "nomnom": "1.8.1",
-        "recast": "0.11.23",
-        "temp": "0.8.3",
-        "write-file-atomic": "1.3.4"
-      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "babel-core": {
           "version": "5.8.38",
-          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
           "dev": true,
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.0.0",
-            "convert-source-map": "1.5.1",
-            "core-js": "1.2.7",
-            "debug": "2.2.0",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.8",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "1.5.0",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "0.5.7",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          },
           "dependencies": {
             "babylon": {
               "version": "5.8.38",
-              "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
               "dev": true
             },
             "lodash": {
               "version": "3.10.1",
-              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
               "dev": true
             }
           }
         },
         "colors": {
           "version": "1.1.2",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
           "dev": true
         },
         "core-js": {
           "version": "1.2.7",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         },
         "detect-indent": {
           "version": "3.0.1",
-          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          }
+          "dev": true
         },
         "globals": {
           "version": "6.4.1",
-          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
           "dev": true
         },
         "home-or-tmp": {
           "version": "1.0.0",
-          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "1.0.2",
-            "user-home": "1.1.1"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "1.0.1",
-          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
           "dev": true
         },
         "json5": {
           "version": "0.4.0",
-          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
           "dev": true
         },
         "minimatch": {
           "version": "2.0.10",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "node-dir": {
           "version": "0.1.8",
-          "integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30=",
           "dev": true
         },
         "path-exists": {
           "version": "1.0.0",
-          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
           "dev": true
         },
         "repeating": {
           "version": "1.1.3",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },
         "source-map-support": {
           "version": "0.2.10",
-          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
           "dev": true,
-          "requires": {
-            "source-map": "0.1.32"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         }
@@ -8437,4897 +4178,2389 @@
     },
     "jsdom": {
       "version": "9.12.0",
-      "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
       "dev": true,
-      "requires": {
-        "abab": "1.0.4",
-        "acorn": "4.0.13",
-        "acorn-globals": "3.1.0",
-        "array-equal": "1.0.0",
-        "content-type-parser": "1.0.2",
-        "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
-        "escodegen": "1.9.0",
-        "html-encoding-sniffer": "1.0.2",
-        "nwmatcher": "1.4.3",
-        "parse5": "1.5.1",
-        "request": "2.83.0",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.3",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.3",
-        "whatwg-url": "4.8.0",
-        "xml-name-validator": "2.0.1"
-      },
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
           "dev": true
         },
         "parse5": {
           "version": "1.5.1",
-          "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
           "dev": true
         }
       }
     },
     "jsesc": {
-      "version": "1.3.0",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+      "version": "1.3.0"
     },
     "json-loader": {
-      "version": "0.5.4",
-      "integrity": "sha1-i6oTZaYy9Yo8RtIBdfxgAsluN94="
+      "version": "0.5.4"
     },
     "json-schema": {
-      "version": "0.2.3",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "version": "0.2.3"
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "version": "0.3.1"
     },
     "json-stable-stringify": {
-      "version": "1.0.1",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "0.0.0"
-      }
+      "version": "1.0.1"
     },
     "json-stringify-safe": {
-      "version": "5.0.1",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "version": "5.0.1"
     },
     "json3": {
-      "version": "3.3.2",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+      "version": "3.3.2"
     },
     "json5": {
-      "version": "0.5.1",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+      "version": "0.5.1"
     },
     "jsonfile": {
-      "version": "2.4.0",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
+      "version": "2.4.0"
     },
     "jsonfilter": {
       "version": "1.1.2",
-      "integrity": "sha1-Ie987cdRk4E8dZMulqmL4gW6WhE=",
       "dev": true,
-      "requires": {
-        "JSONStream": "0.8.4",
-        "minimist": "1.2.0",
-        "stream-combiner": "0.2.2",
-        "through2": "0.6.5"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "stream-combiner": {
           "version": "0.2.2",
-          "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-          "dev": true,
-          "requires": {
-            "duplexer": "0.1.1",
-            "through": "2.3.8"
-          }
+          "dev": true
         }
       }
     },
     "jsonify": {
-      "version": "0.0.0",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+      "version": "0.0.0"
     },
     "jsonparse": {
       "version": "0.0.5",
-      "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
       "dev": true
     },
     "jsonpointer": {
-      "version": "2.0.0",
-      "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk="
+      "version": "2.0.0"
+    },
+    "JSONStream": {
+      "version": "0.8.4",
+      "dev": true
     },
     "jsprim": {
-      "version": "1.4.1",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
+      "version": "1.4.1"
     },
     "jstimezonedetect": {
-      "version": "1.0.5",
-      "integrity": "sha1-k9A1zSDox9ZOsTdc9ap6EKAkRmo="
+      "version": "1.0.5"
     },
     "jstransform": {
       "version": "3.0.0",
-      "integrity": "sha1-olkats7o2XvzvoMNv6IxO4fNZAs=",
-      "requires": {
-        "base62": "0.1.1",
-        "esprima-fb": "3001.1.0-dev-harmony-fb",
-        "source-map": "0.1.31"
-      },
       "dependencies": {
         "esprima-fb": {
-          "version": "3001.1.0-dev-harmony-fb",
-          "integrity": "sha1-t303q8046gt3Qmu4vCkizmtCZBE="
+          "version": "3001.1.0-dev-harmony-fb"
         },
         "source-map": {
-          "version": "0.1.31",
-          "integrity": "sha1-n3BNDWnZ4TioG63267T94z0VHGE=",
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "version": "0.1.31"
         }
       }
     },
     "jstransformer": {
-      "version": "1.0.0",
-      "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
-      "requires": {
-        "is-promise": "2.1.0",
-        "promise": "7.3.1"
-      }
+      "version": "1.0.0"
     },
     "jsx-ast-utils": {
       "version": "1.4.1",
-      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
     "key-mirror": {
-      "version": "1.0.1",
-      "integrity": "sha1-ChMtXIqCo6T8199zL/lRDQSrNms="
+      "version": "1.0.1"
     },
     "keymaster": {
-      "version": "1.6.2",
-      "integrity": "sha1-4a5U0OqUiPn2C2a2aPAumhlGxus="
+      "version": "1.6.2"
     },
     "kind-of": {
-      "version": "3.2.2",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
+      "version": "3.2.2"
     },
     "klaw": {
-      "version": "1.3.1",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
+      "version": "1.3.1"
     },
     "latest-version": {
       "version": "1.0.1",
-      "integrity": "sha1-cs/Ebj6NG+ZR4eu1Tqn26pbzdLs=",
-      "dev": true,
-      "requires": {
-        "package-json": "1.2.0"
-      }
+      "dev": true
     },
     "lazy-cache": {
-      "version": "1.0.4",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+      "version": "1.0.4"
     },
     "lcid": {
-      "version": "1.0.0",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
+      "version": "1.0.0"
     },
     "ldjson-stream": {
       "version": "1.2.1",
-      "integrity": "sha1-kb7O2lrE7SsX5kn7d356v6AYnCs=",
-      "dev": true,
-      "requires": {
-        "split2": "0.2.1",
-        "through2": "0.6.5"
-      }
+      "dev": true
     },
     "level": {
-      "version": "1.7.0",
-      "integrity": "sha1-Q0ZKOounOy895WokKSgFFG2iE6E=",
-      "requires": {
-        "level-packager": "1.2.1",
-        "leveldown": "1.7.2"
-      }
+      "version": "1.7.0"
     },
     "level-codec": {
-      "version": "7.0.1",
-      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
+      "version": "7.0.1"
     },
     "level-errors": {
-      "version": "1.0.5",
-      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-      "requires": {
-        "errno": "0.1.6"
-      }
+      "version": "1.0.5"
     },
     "level-iterator-stream": {
-      "version": "1.3.1",
-      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-      "requires": {
-        "inherits": "2.0.1",
-        "level-errors": "1.0.5",
-        "readable-stream": "1.1.14",
-        "xtend": "4.0.1"
-      }
+      "version": "1.3.1"
     },
     "level-packager": {
-      "version": "1.2.1",
-      "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
-      "requires": {
-        "levelup": "1.3.9"
-      }
+      "version": "1.2.1"
     },
     "leveldown": {
       "version": "1.7.2",
-      "integrity": "sha1-XjRnuyfuJGpKe429j7KxYgam64s=",
-      "requires": {
-        "abstract-leveldown": "2.6.3",
-        "bindings": "1.2.1",
-        "fast-future": "1.0.2",
-        "nan": "2.6.2",
-        "prebuild-install": "2.4.1"
-      },
       "dependencies": {
         "nan": {
-          "version": "2.6.2",
-          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+          "version": "2.6.2"
         }
       }
     },
     "levelup": {
       "version": "1.3.9",
-      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-      "requires": {
-        "deferred-leveldown": "1.2.2",
-        "level-codec": "7.0.1",
-        "level-errors": "1.0.5",
-        "level-iterator-stream": "1.3.1",
-        "prr": "1.0.1",
-        "semver": "5.4.1",
-        "xtend": "4.0.1"
-      },
       "dependencies": {
         "semver": {
-          "version": "5.4.1",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+          "version": "5.4.1"
         }
       }
     },
     "leven": {
       "version": "1.0.2",
-      "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM=",
       "dev": true
     },
     "levn": {
       "version": "0.3.0",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
+      "dev": true
     },
     "libphonenumber-js": {
       "version": "0.4.27",
-      "integrity": "sha1-nOTQQv3Q6z+YBImKi/4SqEsU4fY=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "bluebird": "3.5.1",
-        "minimist": "1.2.0",
-        "xml2js": "0.4.19"
-      },
       "dependencies": {
         "bluebird": {
-          "version": "3.5.1",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+          "version": "3.5.1"
         },
         "minimist": {
-          "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.0"
         }
       }
     },
     "lie": {
-      "version": "3.0.2",
-      "integrity": "sha1-/9oh17uibzd8rYZdNkmy/Izjn+o=",
-      "requires": {
-        "es3ify": "0.1.4",
-        "immediate": "3.0.6",
-        "inline-process-browser": "1.0.0",
-        "unreachable-branch-transform": "0.3.0"
-      }
+      "version": "3.0.2"
     },
     "load-json-file": {
       "version": "1.1.0",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
-      },
       "dependencies": {
         "pify": {
-          "version": "2.3.0",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "version": "2.3.0"
         }
       }
     },
     "loader-runner": {
-      "version": "2.3.0",
-      "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
+      "version": "2.3.0"
     },
     "loader-utils": {
-      "version": "1.1.0",
-      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-      "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
-      }
+      "version": "1.1.0"
     },
     "localforage": {
-      "version": "1.4.3",
-      "integrity": "sha1-ohJUPDnHx2Qk7dEr9HTEiarKSUw=",
-      "requires": {
-        "lie": "3.0.2"
-      }
+      "version": "1.4.3"
     },
     "locate-path": {
-      "version": "2.0.0",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
-      }
+      "version": "2.0.0"
     },
     "lodash": {
-      "version": "4.15.0",
-      "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk="
+      "version": "4.15.0"
     },
     "lodash-es": {
-      "version": "4.17.4",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+      "version": "4.17.4"
     },
     "lodash._arraycopy": {
-      "version": "3.0.0",
-      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
+      "version": "3.0.0"
     },
     "lodash._arrayeach": {
-      "version": "3.0.0",
-      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
+      "version": "3.0.0"
     },
     "lodash._baseassign": {
-      "version": "3.2.0",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
+      "version": "3.2.0"
     },
     "lodash._baseclone": {
       "version": "3.3.0",
-      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
-      "dev": true,
-      "requires": {
-        "lodash._arraycopy": "3.0.0",
-        "lodash._arrayeach": "3.0.0",
-        "lodash._baseassign": "3.2.0",
-        "lodash._basefor": "3.0.3",
-        "lodash.isarray": "3.0.4",
-        "lodash.keys": "3.1.2"
-      }
+      "dev": true
     },
     "lodash._basecopy": {
-      "version": "3.0.1",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+      "version": "3.0.1"
     },
     "lodash._basefor": {
-      "version": "3.0.3",
-      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
+      "version": "3.0.3"
     },
     "lodash._basetostring": {
       "version": "3.0.1",
-      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
       "dev": true
     },
     "lodash._basevalues": {
       "version": "3.0.0",
-      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
       "dev": true
     },
     "lodash._bindcallback": {
-      "version": "3.0.1",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+      "version": "3.0.1"
     },
     "lodash._createassigner": {
-      "version": "3.1.1",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
-      }
+      "version": "3.1.1"
     },
     "lodash._getnative": {
-      "version": "3.9.1",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+      "version": "3.9.1"
     },
     "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+      "version": "3.0.9"
     },
     "lodash._reescape": {
       "version": "3.0.0",
-      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
       "dev": true
     },
     "lodash._reevaluate": {
       "version": "3.0.0",
-      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
       "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
     "lodash._root": {
       "version": "3.0.1",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "dev": true
     },
     "lodash.assign": {
-      "version": "3.2.0",
-      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._createassigner": "3.1.1",
-        "lodash.keys": "3.1.2"
-      }
+      "version": "3.2.0"
     },
     "lodash.camelcase": {
-      "version": "4.3.0",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+      "version": "4.3.0"
     },
     "lodash.clonedeep": {
-      "version": "4.5.0",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "version": "4.5.0"
     },
     "lodash.escape": {
       "version": "3.2.0",
-      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true,
-      "requires": {
-        "lodash._root": "3.0.1"
-      }
+      "dev": true
     },
     "lodash.flatten": {
-      "version": "4.4.0",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+      "version": "4.4.0"
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
     "lodash.isarguments": {
-      "version": "3.1.0",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+      "version": "3.1.0"
     },
     "lodash.isarray": {
-      "version": "3.0.4",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+      "version": "3.0.4"
     },
     "lodash.isplainobject": {
-      "version": "3.2.0",
-      "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
-      "requires": {
-        "lodash._basefor": "3.0.3",
-        "lodash.isarguments": "3.1.0",
-        "lodash.keysin": "3.0.8"
-      }
+      "version": "3.2.0"
     },
     "lodash.istypedarray": {
-      "version": "3.0.6",
-      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
+      "version": "3.0.6"
     },
     "lodash.kebabcase": {
-      "version": "4.1.1",
-      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY="
+      "version": "4.1.1"
     },
     "lodash.keys": {
-      "version": "3.1.2",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
+      "version": "3.1.2"
     },
     "lodash.keysin": {
-      "version": "3.0.8",
-      "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
-      "requires": {
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
+      "version": "3.0.8"
     },
     "lodash.merge": {
-      "version": "3.3.2",
-      "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
-      "requires": {
-        "lodash._arraycopy": "3.0.0",
-        "lodash._arrayeach": "3.0.0",
-        "lodash._createassigner": "3.1.1",
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4",
-        "lodash.isplainobject": "3.2.0",
-        "lodash.istypedarray": "3.0.6",
-        "lodash.keys": "3.1.2",
-        "lodash.keysin": "3.0.8",
-        "lodash.toplainobject": "3.0.0"
-      }
+      "version": "3.3.2"
     },
     "lodash.mergewith": {
-      "version": "4.6.0",
-      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
+      "version": "4.6.0"
     },
     "lodash.pickby": {
       "version": "4.6.0",
-      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
       "dev": true
     },
     "lodash.restparam": {
-      "version": "3.6.1",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+      "version": "3.6.1"
     },
     "lodash.snakecase": {
-      "version": "4.1.1",
-      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
+      "version": "4.1.1"
     },
     "lodash.template": {
       "version": "3.6.2",
-      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash._basetostring": "3.0.1",
-        "lodash._basevalues": "3.0.0",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0",
-        "lodash.keys": "3.1.2",
-        "lodash.restparam": "3.6.1",
-        "lodash.templatesettings": "3.1.1"
-      }
+      "dev": true
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
-      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-      "dev": true,
-      "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.escape": "3.2.0"
-      }
+      "dev": true
     },
     "lodash.toarray": {
       "version": "4.4.0",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
       "dev": true
     },
     "lodash.toplainobject": {
-      "version": "3.0.0",
-      "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keysin": "3.0.8"
-      }
+      "version": "3.0.0"
     },
     "lodash.unescape": {
       "version": "4.0.1",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
     },
     "log-symbols": {
       "version": "1.0.2",
-      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.0.0"
-      }
+      "dev": true
     },
     "log-update": {
       "version": "1.0.2",
-      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
-      }
+      "dev": true
     },
     "lolex": {
       "version": "1.3.2",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
     "longest": {
-      "version": "1.0.1",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+      "version": "1.0.1"
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "requires": {
-        "js-tokens": "3.0.2"
-      }
+      "version": "1.3.1"
     },
     "loud-rejection": {
-      "version": "1.6.0",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
-      }
+      "version": "1.6.0"
     },
     "lower-case": {
-      "version": "1.1.4",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+      "version": "1.1.4"
     },
     "lower-case-first": {
-      "version": "1.0.2",
-      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
-      "requires": {
-        "lower-case": "1.1.4"
-      }
+      "version": "1.0.2"
     },
     "lowercase-keys": {
       "version": "1.0.0",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
       "dev": true
     },
     "lru": {
-      "version": "3.1.0",
-      "integrity": "sha1-6n+4VG2DczOWoTCR12z+tMBoN9U=",
-      "requires": {
-        "inherits": "2.0.1"
-      }
+      "version": "3.1.0"
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
+      "version": "4.1.1"
     },
     "lunr": {
-      "version": "0.5.7",
-      "integrity": "sha1-4hp8eDIlqtKwTD4b+iG01IqFLm8="
+      "version": "0.5.7"
     },
     "make-dir": {
-      "version": "1.1.0",
-      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
-      "requires": {
-        "pify": "3.0.0"
-      }
+      "version": "1.1.0"
     },
     "makeerror": {
       "version": "1.0.11",
-      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-      "dev": true,
-      "requires": {
-        "tmpl": "1.0.4"
-      }
+      "dev": true
     },
     "map-obj": {
-      "version": "1.0.1",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+      "version": "1.0.1"
     },
     "map-stream": {
-      "version": "0.1.0",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+      "version": "0.1.0"
     },
     "map-values": {
-      "version": "1.0.1",
-      "integrity": "sha1-douOecAJvytk/ugG4ip7HEGQyZA="
+      "version": "1.0.1"
     },
     "marked": {
-      "version": "0.3.5",
-      "integrity": "sha1-QROhWsXXvKFYpargciRYe5+hW5Q="
+      "version": "0.3.5"
     },
     "marked-terminal": {
       "version": "1.7.0",
-      "integrity": "sha1-yMRgiBx3LHYEtkNnAH7l938SWQQ=",
       "dev": true,
-      "requires": {
-        "cardinal": "1.0.0",
-        "chalk": "1.1.3",
-        "cli-table": "0.3.1",
-        "lodash.assign": "4.2.0",
-        "node-emoji": "1.8.1"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "lodash.assign": {
           "version": "4.2.0",
-          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "md5-file": {
       "version": "3.1.0",
-      "integrity": "sha1-obCC/KOtQjHTaIAGIkJfs1x03VM=",
       "dev": true
     },
     "md5.js": {
       "version": "1.3.4",
-      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
-      "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.1"
-      },
       "dependencies": {
         "hash-base": {
-          "version": "3.0.4",
-          "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-          "requires": {
-            "inherits": "2.0.1",
-            "safe-buffer": "5.1.1"
-          }
+          "version": "3.0.4"
         }
       }
     },
     "media-typer": {
-      "version": "0.3.0",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+      "version": "0.3.0"
     },
     "mem": {
-      "version": "1.1.0",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "requires": {
-        "mimic-fn": "1.1.0"
-      }
+      "version": "1.1.0"
     },
     "memory-fs": {
       "version": "0.4.1",
-      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-      "requires": {
-        "errno": "0.1.6",
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3"
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "version": "2.3.3"
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "meow": {
       "version": "3.7.0",
-      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
-      },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.0"
         }
       }
     },
     "merge": {
       "version": "1.2.0",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
       "dev": true
     },
     "merge-descriptors": {
-      "version": "1.0.0",
-      "integrity": "sha1-IWnPdTjhsMyH+4jhUC2EdLv3mGQ="
+      "version": "1.0.0"
     },
     "methods": {
-      "version": "1.1.2",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+      "version": "1.1.2"
     },
     "micromatch": {
       "version": "2.3.11",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
-      },
       "dependencies": {
         "is-extglob": {
-          "version": "1.0.0",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "version": "1.0.0"
         },
         "is-glob": {
-          "version": "2.0.1",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
+          "version": "2.0.1"
         }
       }
     },
     "miller-rabin": {
-      "version": "4.0.1",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-      "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
-      }
+      "version": "4.0.1"
     },
     "mime": {
-      "version": "1.3.4",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+      "version": "1.3.4"
     },
     "mime-db": {
-      "version": "1.30.0",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "version": "1.30.0"
     },
     "mime-types": {
-      "version": "2.1.17",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "requires": {
-        "mime-db": "1.30.0"
-      }
+      "version": "2.1.17"
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+      "version": "1.1.0"
     },
     "minimalistic-assert": {
-      "version": "1.0.0",
-      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+      "version": "1.0.0"
     },
     "minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+      "version": "1.0.1"
     },
     "minimatch": {
-      "version": "3.0.4",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
+      "version": "3.0.4"
     },
     "minimist": {
-      "version": "0.0.8",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "0.0.8"
     },
     "mississippi": {
       "version": "1.3.0",
-      "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
-      "requires": {
-        "concat-stream": "1.5.2",
-        "duplexify": "3.5.1",
-        "end-of-stream": "1.4.0",
-        "flush-write-stream": "1.0.2",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "1.0.3",
-        "pumpify": "1.3.5",
-        "stream-each": "1.2.2",
-        "through2": "2.0.3"
-      },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3"
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "version": "2.3.3"
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         },
         "through2": {
-          "version": "2.0.3",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          }
+          "version": "2.0.3"
         }
       }
     },
     "mixedindentlint": {
       "version": "1.2.0",
-      "integrity": "sha1-/5P4dqoTCzfLN+920wfhvsoo89g=",
       "dev": true,
-      "requires": {
-        "globby": "6.1.0",
-        "minimist": "1.2.0"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "requires": {
-        "minimist": "0.0.8"
-      }
+      "version": "0.5.1"
     },
     "moment": {
-      "version": "2.19.2",
-      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA=="
+      "version": "2.19.2"
     },
     "moment-timezone": {
-      "version": "0.5.11",
-      "integrity": "sha1-m3bAPY71FMfkJJp7vOZJ7tOe8p8=",
-      "requires": {
-        "moment": "2.19.2"
-      }
+      "version": "0.5.11"
     },
     "morgan": {
       "version": "1.2.0",
-      "integrity": "sha1-jcF6V1mVmPgM16fh47VOcsaJkQ0=",
-      "requires": {
-        "basic-auth": "1.0.0",
-        "bytes": "1.0.0",
-        "depd": "0.4.2",
-        "finished": "1.2.2"
-      },
       "dependencies": {
         "bytes": {
-          "version": "1.0.0",
-          "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g="
+          "version": "1.0.0"
         },
         "depd": {
-          "version": "0.4.2",
-          "integrity": "sha1-pLyKDkgBdwpmNj2qbTUTjz47VN0="
+          "version": "0.4.2"
         }
       }
     },
     "mout": {
       "version": "1.1.0",
-      "integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw==",
       "dev": true
     },
     "move-concurrently": {
-      "version": "1.0.1",
-      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-      "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
-      }
+      "version": "1.0.1"
     },
     "ms": {
-      "version": "0.7.1",
-      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+      "version": "0.7.1"
     },
     "multimatch": {
       "version": "2.1.0",
-      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "dev": true,
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
-      }
+      "dev": true
     },
     "multipipe": {
       "version": "0.1.2",
-      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "dev": true,
-      "requires": {
-        "duplexer2": "0.0.2"
-      }
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.5",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
     "name-all-modules-plugin": {
-      "version": "1.0.1",
-      "integrity": "sha1-Cr+2rYNXGLn7Te8GdOBmV6lUN1w="
+      "version": "1.0.1"
     },
     "nan": {
-      "version": "2.8.0",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+      "version": "2.8.0"
     },
     "natives": {
       "version": "1.1.1",
-      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "ncname": {
-      "version": "1.0.0",
-      "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
-      "requires": {
-        "xml-char-classes": "1.0.0"
-      }
+      "version": "1.0.0"
     },
     "ndarray": {
       "version": "1.0.18",
-      "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
-      "dev": true,
-      "requires": {
-        "iota-array": "1.0.0",
-        "is-buffer": "1.1.6"
-      }
+      "dev": true
     },
     "ndarray-pack": {
       "version": "1.2.1",
-      "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
-      "dev": true,
-      "requires": {
-        "cwise-compiler": "1.1.3",
-        "ndarray": "1.0.18"
-      }
+      "dev": true
     },
     "nearley": {
       "version": "2.11.0",
-      "integrity": "sha512-clqqhEuP0ZCJQ85Xv2I/4o2Gs/fvSR6fCg5ZHVE2c8evWyNk2G++ih4JOO3lMb/k/09x6ihQ2nzKUlB/APCWjg==",
       "dev": true,
-      "requires": {
-        "nomnom": "1.6.2",
-        "railroad-diagrams": "1.0.0",
-        "randexp": "0.4.6"
-      },
       "dependencies": {
         "colors": {
           "version": "0.5.1",
-          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
           "dev": true
         },
         "nomnom": {
           "version": "1.6.2",
-          "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
-          "dev": true,
-          "requires": {
-            "colors": "0.5.1",
-            "underscore": "1.4.4"
-          }
+          "dev": true
         },
         "underscore": {
           "version": "1.4.4",
-          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
           "dev": true
         }
       }
     },
     "negotiator": {
-      "version": "0.5.3",
-      "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g="
+      "version": "0.5.3"
     },
     "neo-async": {
-      "version": "1.8.2",
-      "integrity": "sha1-MXlYiLed0ENXp8UhE6ZRg+k7ZzU="
+      "version": "1.8.2"
     },
     "nested-error-stacks": {
       "version": "1.0.2",
-      "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.1"
-      }
+      "dev": true
     },
     "nextgen-events": {
       "version": "0.10.2",
-      "integrity": "sha512-P6efDoVOOJjVLOhwINq+aqhC2B3a9IxojbWMn9fTv2coDiyRaaGLSgWsm84wQHlQeuqVgqiLEE+xiHXf3EVN6w==",
       "dev": true
     },
     "nock": {
       "version": "8.0.0",
-      "integrity": "sha1-+G1nZWjHOjuyFE68gHkdRHuzNNI=",
       "dev": true,
-      "requires": {
-        "chai": "3.5.0",
-        "debug": "2.2.0",
-        "deep-equal": "1.0.1",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.15.0",
-        "mkdirp": "0.5.1",
-        "propagate": "0.4.0",
-        "qs": "6.5.1"
-      },
       "dependencies": {
         "qs": {
           "version": "6.5.1",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
           "dev": true
         }
       }
     },
     "node-abi": {
       "version": "2.1.2",
-      "integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
-      "requires": {
-        "semver": "5.4.1"
-      },
       "dependencies": {
         "semver": {
-          "version": "5.4.1",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+          "version": "5.4.1"
         }
       }
     },
     "node-bitmap": {
       "version": "0.0.1",
-      "integrity": "sha1-GA6scAPgxwdhjvMTaPYvhLKmkJE=",
       "dev": true
     },
     "node-contains": {
-      "version": "1.0.0",
-      "integrity": "sha1-0sJzUkU22jtWGvBTnjM0T3yQLLg="
+      "version": "1.0.0"
     },
     "node-dir": {
-      "version": "0.1.17",
-      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
-      "requires": {
-        "minimatch": "3.0.4"
-      }
+      "version": "0.1.17"
     },
     "node-emoji": {
       "version": "1.8.1",
-      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
-      "dev": true,
-      "requires": {
-        "lodash.toarray": "4.4.0"
-      }
+      "dev": true
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
+      "version": "1.7.3"
     },
     "node-gyp": {
       "version": "3.6.2",
-      "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
-      "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.4",
-        "request": "2.83.0",
-        "rimraf": "2.6.2",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.3.0"
-      },
       "dependencies": {
         "glob": {
-          "version": "7.1.2",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "version": "7.1.2"
         },
         "semver": {
-          "version": "5.3.0",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+          "version": "5.3.0"
         }
       }
     },
     "node-int64": {
       "version": "0.4.0",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
     "node-libs-browser": {
       "version": "2.1.0",
-      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
-      "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.1.7",
-        "events": "1.0.2",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
-        "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.3",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.7.2",
-        "string_decoder": "1.0.3",
-        "timers-browserify": "2.0.4",
-        "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4"
-      },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3"
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "version": "2.3.3"
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "node-localstorage": {
       "version": "0.6.0",
-      "integrity": "sha1-RaBgHGky395mRKIzYfG+Fzx1068=",
       "dev": true
     },
     "node-notifier": {
       "version": "5.1.2",
-      "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
       "dev": true,
-      "requires": {
-        "growly": "1.3.0",
-        "semver": "5.4.1",
-        "shellwords": "0.1.1",
-        "which": "1.3.0"
-      },
       "dependencies": {
         "semver": {
           "version": "5.4.1",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         }
       }
     },
     "node-sass": {
       "version": "4.5.3",
-      "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
-      "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.2",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.0",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.8.0",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.2",
-        "request": "2.83.0",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0"
-      },
       "dependencies": {
         "chalk": {
-          "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "version": "1.1.3"
         },
         "cross-spawn": {
-          "version": "3.0.1",
-          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-          "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.3.0"
-          }
+          "version": "3.0.1"
         },
         "glob": {
-          "version": "7.1.2",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "version": "7.1.2"
         },
         "lodash.assign": {
-          "version": "4.2.0",
-          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+          "version": "4.2.0"
         },
         "supports-color": {
-          "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "version": "2.0.0"
         }
       }
     },
     "nodemon": {
       "version": "1.4.1",
-      "integrity": "sha1-7EDqKOgyYZtr+byTcO3MBilm3ss=",
       "dev": true,
-      "requires": {
-        "minimatch": "0.3.0",
-        "ps-tree": "0.0.3",
-        "touch": "1.0.0",
-        "update-notifier": "0.3.2"
-      },
       "dependencies": {
         "event-stream": {
           "version": "0.5.3",
-          "integrity": "sha1-t3uTCfcQet3+q2PwwOr9jbC9jBw=",
-          "dev": true,
-          "requires": {
-            "optimist": "0.2.8"
-          }
+          "dev": true
         },
         "lru-cache": {
           "version": "2.7.3",
-          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
           "dev": true
         },
         "minimatch": {
           "version": "0.3.0",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          }
+          "dev": true
         },
         "nopt": {
           "version": "1.0.10",
-          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1.1.1"
-          }
+          "dev": true
         },
         "optimist": {
           "version": "0.2.8",
-          "integrity": "sha1-6YGrfiaLRXlIWTtVZ0wJmoFcrDE=",
-          "dev": true,
-          "requires": {
-            "wordwrap": "0.0.2"
-          }
+          "dev": true
         },
         "ps-tree": {
           "version": "0.0.3",
-          "integrity": "sha1-2/jXUqf+Ivp9WGNWiUmWEOknbdw=",
-          "dev": true,
-          "requires": {
-            "event-stream": "0.5.3"
-          }
+          "dev": true
         },
         "touch": {
           "version": "1.0.0",
-          "integrity": "sha1-RJy+LbrlqMgDjjDXH6D/RklHxN4=",
-          "dev": true,
-          "requires": {
-            "nopt": "1.0.10"
-          }
+          "dev": true
         }
       }
     },
     "nomnom": {
       "version": "1.8.1",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "dev": true,
-      "requires": {
-        "chalk": "0.4.0",
-        "underscore": "1.6.0"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "1.0.0",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
           "dev": true
         },
         "chalk": {
           "version": "0.4.0",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
-          }
+          "dev": true
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         }
       }
     },
     "noop-logger": {
-      "version": "0.1.1",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+      "version": "0.1.1"
     },
     "nopt": {
-      "version": "3.0.6",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "requires": {
-        "abbrev": "1.1.1"
-      }
+      "version": "3.0.6"
     },
     "normalize-package-data": {
-      "version": "2.4.0",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.1.0",
-        "validate-npm-package-license": "3.0.1"
-      }
+      "version": "2.4.0"
     },
     "normalize-path": {
-      "version": "2.1.1",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "requires": {
-        "remove-trailing-separator": "1.1.0"
-      }
+      "version": "2.1.1"
     },
     "normalize-range": {
-      "version": "0.1.2",
-      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+      "version": "0.1.2"
     },
     "normalize-selector": {
       "version": "0.2.0",
-      "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
       "dev": true
     },
     "notifications-panel": {
-      "version": "2.1.2",
-      "integrity": "sha512-8qYXAA5+aP7OBzpRm99y60+ZZLGRHCa8V7J9Of5DRxBMtvo5ln2ICZor8S6vfm718K/DoG69f657PeYqMXBItw=="
+      "version": "2.1.2"
     },
     "npm-path": {
       "version": "1.1.0",
-      "integrity": "sha1-BHSuAEGcMn1UcBt88s0F3Ii+EUA=",
-      "dev": true,
-      "requires": {
-        "which": "1.3.0"
-      }
+      "dev": true
     },
     "npm-run": {
       "version": "1.1.1",
-      "integrity": "sha1-xDEkUfOCt67npIWOYCg6vz26yOw=",
       "dev": true,
-      "requires": {
-        "minimist": "1.2.0",
-        "npm-path": "1.1.0",
-        "serializerr": "1.0.3",
-        "sync-exec": "0.5.0"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
     },
     "npm-run-all": {
       "version": "4.0.2",
-      "integrity": "sha1-qEZpNI5ttsy+BSIAtM22v+A0pP4=",
-      "requires": {
-        "chalk": "1.1.3",
-        "cross-spawn": "5.1.0",
-        "minimatch": "3.0.4",
-        "ps-tree": "1.1.0",
-        "read-pkg": "2.0.0",
-        "shell-quote": "1.6.1",
-        "string.prototype.padend": "3.0.0"
-      },
       "dependencies": {
         "chalk": {
-          "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "version": "1.1.3"
         },
         "load-json-file": {
-          "version": "2.0.0",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
+          "version": "2.0.0"
         },
         "path-type": {
-          "version": "2.0.0",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "requires": {
-            "pify": "2.3.0"
-          }
+          "version": "2.0.0"
         },
         "pify": {
-          "version": "2.3.0",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "version": "2.3.0"
         },
         "read-pkg": {
-          "version": "2.0.0",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
+          "version": "2.0.0"
         },
         "strip-bom": {
-          "version": "3.0.0",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+          "version": "3.0.0"
         },
         "supports-color": {
-          "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "version": "2.0.0"
         }
       }
     },
     "npm-run-path": {
-      "version": "2.0.2",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "requires": {
-        "path-key": "2.0.1"
-      }
+      "version": "2.0.2"
     },
     "npmlog": {
-      "version": "4.1.2",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
-      }
+      "version": "4.1.2"
     },
     "nth-check": {
       "version": "1.0.1",
-      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-      "dev": true,
-      "requires": {
-        "boolbase": "1.0.0"
-      }
+      "dev": true
     },
     "num2fraction": {
-      "version": "1.2.2",
-      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+      "version": "1.2.2"
     },
     "number-is-nan": {
-      "version": "1.0.1",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "version": "1.0.1"
     },
     "numeral": {
-      "version": "2.0.4",
-      "integrity": "sha1-VFoMcJ4JCpz3m+vsgCuT9gBh8Dg="
+      "version": "2.0.4"
     },
     "nwmatcher": {
       "version": "1.4.3",
-      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
       "dev": true
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "version": "0.8.2"
     },
     "object-assign": {
-      "version": "4.1.1",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "version": "4.1.1"
     },
     "object-component": {
-      "version": "0.0.3",
-      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+      "version": "0.0.3"
     },
     "object-filter": {
-      "version": "1.0.2",
-      "integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g="
+      "version": "1.0.2"
     },
     "object-is": {
       "version": "1.0.1",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
       "dev": true
     },
     "object-keys": {
-      "version": "1.0.11",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+      "version": "1.0.11"
     },
     "object.assign": {
-      "version": "4.0.4",
-      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
-      "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "object-keys": "1.0.11"
-      }
+      "version": "4.0.4"
     },
     "object.entries": {
       "version": "1.0.4",
-      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.1"
-      }
+      "dev": true
     },
     "object.omit": {
-      "version": "2.0.1",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      }
+      "version": "2.0.1"
     },
     "object.values": {
       "version": "1.0.4",
-      "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.1"
-      }
+      "dev": true
     },
     "omggif": {
       "version": "1.0.8",
-      "integrity": "sha1-F483sqsLPXtG7ToORr0HkLWNNTA=",
       "dev": true
     },
     "on-finished": {
-      "version": "2.3.0",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "requires": {
-        "ee-first": "1.1.1"
-      }
+      "version": "2.3.0"
     },
     "once": {
-      "version": "1.4.0",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1.0.2"
-      }
+      "version": "1.4.0"
     },
     "onecolor": {
       "version": "3.0.5",
-      "integrity": "sha1-Nu/zIgE3nv3xGA+0ReUajiQl+fY=",
       "dev": true
     },
     "onetime": {
       "version": "1.1.0",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
     "opener": {
       "version": "1.4.3",
-      "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
       "dev": true
     },
     "optimist": {
       "version": "0.6.1",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.2"
-      }
+      "dev": true
     },
     "optionator": {
       "version": "0.8.1",
-      "integrity": "sha1-4xtJMs3V+4Yqiw0QvGPT7h7H14s=",
       "dev": true,
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "1.1.4",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      },
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
       }
     },
     "options": {
-      "version": "0.0.6",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+      "version": "0.0.6"
     },
     "os-browserify": {
-      "version": "0.3.0",
-      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+      "version": "0.3.0"
     },
     "os-homedir": {
-      "version": "1.0.2",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "version": "1.0.2"
     },
     "os-locale": {
-      "version": "1.4.0",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "requires": {
-        "lcid": "1.0.0"
-      }
+      "version": "1.4.0"
     },
     "os-tmpdir": {
-      "version": "1.0.2",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "version": "1.0.2"
     },
     "osenv": {
-      "version": "0.1.4",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "version": "0.1.4"
     },
     "output-file-sync": {
       "version": "1.1.2",
-      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "p-cancelable": {
       "version": "0.3.0",
-      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
       "dev": true
     },
     "p-finally": {
-      "version": "1.0.0",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "version": "1.0.0"
     },
     "p-limit": {
-      "version": "1.1.0",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+      "version": "1.1.0"
     },
     "p-locate": {
-      "version": "2.0.0",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "requires": {
-        "p-limit": "1.1.0"
-      }
+      "version": "2.0.0"
     },
     "package-json": {
       "version": "1.2.0",
-      "integrity": "sha1-yOysCUInzfdqMWh07QXifMk5oOA=",
-      "dev": true,
-      "requires": {
-        "got": "3.3.1",
-        "registry-url": "3.1.0"
-      }
+      "dev": true
     },
     "page": {
       "version": "1.6.4",
-      "integrity": "sha1-+3QTJXJH2eBPArFvE4H2two3v1o=",
-      "requires": {
-        "path-to-regexp": "1.2.1"
-      },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "version": "0.0.1"
         },
         "path-to-regexp": {
-          "version": "1.2.1",
-          "integrity": "sha1-szcFwUAjTYc8hyHHuf2LVB7Tr/k=",
-          "requires": {
-            "isarray": "0.0.1"
-          }
+          "version": "1.2.1"
         }
       }
     },
     "pako": {
-      "version": "1.0.6",
-      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+      "version": "1.0.6"
     },
     "parallel-transform": {
       "version": "1.1.0",
-      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-      "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3"
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "version": "2.3.3"
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "param-case": {
-      "version": "1.1.2",
-      "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
-      "requires": {
-        "sentence-case": "1.1.3"
-      }
+      "version": "1.1.2"
     },
     "parse-asn1": {
-      "version": "5.1.0",
-      "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
-      "requires": {
-        "asn1.js": "4.9.2",
-        "browserify-aes": "1.1.1",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
-      }
+      "version": "5.1.0"
     },
     "parse-data-uri": {
       "version": "0.2.0",
-      "integrity": "sha1-vwTYUd1ch7CrI45dAazklLYEtMk=",
-      "dev": true,
-      "requires": {
-        "data-uri-to-buffer": "0.0.3"
-      }
+      "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      },
       "dependencies": {
         "is-extglob": {
-          "version": "1.0.0",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+          "version": "1.0.0"
         },
         "is-glob": {
-          "version": "2.0.1",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
+          "version": "2.0.1"
         }
       }
     },
     "parse-int": {
-      "version": "1.0.2",
-      "integrity": "sha1-QzYNYNjuNaEll4DgUisLlqhOb8E=",
-      "requires": {
-        "is-integer": "1.0.7"
-      }
+      "version": "1.0.2"
     },
     "parse-json": {
-      "version": "2.2.0",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "requires": {
-        "error-ex": "1.3.1"
-      }
+      "version": "2.2.0"
     },
     "parse-year": {
-      "version": "1.0.0",
-      "integrity": "sha1-XB+Hh7Z8xY2uqHuKgDLu4uQtOIs=",
-      "requires": {
-        "expand-year": "1.0.0",
-        "parse-int": "1.0.2"
-      }
+      "version": "1.0.0"
     },
     "parse5": {
       "version": "3.0.3",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "8.0.58"
-      }
+      "dev": true
     },
     "parsejson": {
-      "version": "0.0.1",
-      "integrity": "sha1-mxDGwNglq1ieaFFTgm3go7oni8w=",
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "version": "0.0.1"
     },
     "parseqs": {
-      "version": "0.0.2",
-      "integrity": "sha1-nf5wss3aw4i95PNbHyQPpYrb5sc=",
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "version": "0.0.2"
     },
     "parseuri": {
-      "version": "0.0.4",
-      "integrity": "sha1-gGWCo5iH4eoY3V4v4OAZAiaOk1A=",
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "version": "0.0.4"
     },
     "parseurl": {
-      "version": "1.3.2",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+      "version": "1.3.2"
     },
     "pascal-case": {
-      "version": "1.1.2",
-      "integrity": "sha1-Pl1kogBDgwp8STRMLXS0G+DJyZs=",
-      "requires": {
-        "camel-case": "1.2.2",
-        "upper-case-first": "1.1.2"
-      }
+      "version": "1.1.2"
     },
     "path": {
       "version": "0.12.7",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-      "dev": true,
-      "requires": {
-        "process": "0.11.10",
-        "util": "0.10.3"
-      }
+      "dev": true
     },
     "path-browserify": {
-      "version": "0.0.0",
-      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+      "version": "0.0.0"
     },
     "path-case": {
-      "version": "1.1.2",
-      "integrity": "sha1-UM5roNO+090LXCqcRVNpdDRAlRQ=",
-      "requires": {
-        "sentence-case": "1.1.3"
-      }
+      "version": "1.1.2"
     },
     "path-exists": {
-      "version": "3.0.0",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "version": "3.0.0"
     },
     "path-is-absolute": {
-      "version": "1.0.1",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "version": "1.0.1"
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
-      "version": "2.0.1",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "version": "2.0.1"
     },
     "path-parse": {
-      "version": "1.0.5",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+      "version": "1.0.5"
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+      "version": "0.1.7"
     },
     "path-type": {
       "version": "1.1.0",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      },
       "dependencies": {
         "pify": {
-          "version": "2.3.0",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "version": "2.3.0"
         }
       }
     },
     "pause-stream": {
-      "version": "0.0.11",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "requires": {
-        "through": "2.3.8"
-      }
+      "version": "0.0.11"
     },
     "pbkdf2": {
-      "version": "3.0.14",
-      "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
-      "requires": {
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.9"
-      }
+      "version": "3.0.14"
     },
     "percentage-regex": {
-      "version": "3.0.0",
-      "integrity": "sha1-UAMhAKLwjdLpQoU/F7zu7mmjjZw="
+      "version": "3.0.0"
     },
     "performance-now": {
-      "version": "2.1.0",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "version": "2.1.0"
     },
     "phone": {
-      "version": "git+https://github.com/Automattic/node-phone.git#6be6549b03137f2cca01e202250bf2590750119e"
+      "version": "1.0.8",
+      "from": "git+https://github.com/Automattic/node-phone.git#1.0.8",
+      "resolved": "git+https://github.com/Automattic/node-phone.git#6be6549b03137f2cca01e202250bf2590750119e"
     },
     "photon": {
       "version": "2.0.1",
-      "integrity": "sha512-9/a0UvjyNL1xQI3v416Ym0GIm9HyzM4kHjOj06WFqGYGKnaFIEFJ1uJtjkobmur4KHIoXsxhHydrVsq2tJ1N5g==",
-      "requires": {
-        "crc32": "0.2.2",
-        "debug": "3.1.0",
-        "seed-random": "2.2.0"
-      },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "version": "3.1.0"
         },
         "ms": {
-          "version": "2.0.0",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "version": "2.0.0"
         }
       }
     },
     "pify": {
-      "version": "3.0.0",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+      "version": "3.0.0"
     },
     "pinkie": {
-      "version": "2.0.4",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "version": "2.0.4"
     },
     "pinkie-promise": {
-      "version": "2.0.1",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "2.0.4"
-      }
+      "version": "2.0.1"
     },
     "pipetteur": {
       "version": "2.0.3",
-      "integrity": "sha1-GVV2CVno0aEcsqUOyD7sRwYz5J8=",
-      "dev": true,
-      "requires": {
-        "onecolor": "3.0.5",
-        "synesthesia": "1.0.1"
-      }
+      "dev": true
     },
     "pkg-dir": {
-      "version": "2.0.0",
-      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-      "requires": {
-        "find-up": "2.1.0"
-      }
+      "version": "2.0.0"
     },
     "plur": {
       "version": "2.1.2",
-      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-      "dev": true,
-      "requires": {
-        "irregular-plurals": "1.4.0"
-      }
+      "dev": true
     },
     "pluralize": {
       "version": "1.2.1",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
     "pngjs": {
       "version": "2.3.1",
-      "integrity": "sha1-EdHhK5y2TWPjDBQ6Mw9MH1Z9qF8=",
       "dev": true
     },
     "postcss": {
       "version": "5.2.18",
-      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-      "requires": {
-        "chalk": "1.1.3",
-        "js-base64": "2.4.0",
-        "source-map": "0.5.7",
-        "supports-color": "3.2.3"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          },
           "dependencies": {
             "supports-color": {
-              "version": "2.0.0",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "version": "2.0.0"
             }
           }
         },
         "source-map": {
-          "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.5.7"
         }
       }
     },
     "postcss-cli": {
       "version": "2.5.1",
-      "integrity": "sha1-uwHFRSG6fg1lTtTRg8U7HK6bX30=",
-      "requires": {
-        "chokidar": "1.7.0",
-        "globby": "3.0.1",
-        "neo-async": "1.8.2",
-        "postcss": "5.2.18",
-        "read-file-stdin": "0.2.1",
-        "resolve": "1.5.0",
-        "yargs": "3.10.0"
-      },
       "dependencies": {
         "glob": {
-          "version": "5.0.15",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "version": "5.0.15"
         },
         "globby": {
-          "version": "3.0.1",
-          "integrity": "sha1-IJSvhCHhkVIVDViT62QWsxLZoi8=",
-          "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "5.0.15",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "1.0.0"
-          }
+          "version": "3.0.1"
         },
         "pify": {
-          "version": "2.3.0",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "version": "2.3.0"
         },
         "pinkie": {
-          "version": "1.0.0",
-          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
+          "version": "1.0.0"
         },
         "pinkie-promise": {
-          "version": "1.0.0",
-          "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
-          "requires": {
-            "pinkie": "1.0.0"
-          }
+          "version": "1.0.0"
         }
       }
     },
     "postcss-custom-properties": {
       "version": "6.2.0",
-      "integrity": "sha512-eNR2h9T9ciKMoQEORrPjH33XeN/nuvVuxArOKmHtsFbGbNss631tgTrKou3/pmjAZbA4QQkhLIkPQkIk3WW+8w==",
-      "requires": {
-        "balanced-match": "1.0.0",
-        "postcss": "6.0.14"
-      },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "version": "3.2.0"
         },
         "chalk": {
-          "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "version": "2.3.0"
         },
         "escape-string-regexp": {
-          "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+          "version": "1.0.5"
         },
         "has-flag": {
-          "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+          "version": "2.0.0"
         },
         "postcss": {
-          "version": "6.0.14",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
-          "requires": {
-            "chalk": "2.3.0",
-            "source-map": "0.6.1",
-            "supports-color": "4.5.0"
-          }
+          "version": "6.0.14"
         },
         "source-map": {
-          "version": "0.6.1",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "version": "0.6.1"
         },
         "supports-color": {
-          "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "version": "4.5.0"
         }
       }
     },
     "postcss-less": {
       "version": "1.1.1",
-      "integrity": "sha512-zl0EEqq8Urh37Ppdv9zzhpZpLHrgkxmt6e3O4ftRa7/b8Uq2LV+/KBVM8/KuzmHNu+mthhOArg1lxbfqQ3NUdg==",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.18"
-      }
+      "dev": true
     },
     "postcss-media-query-parser": {
       "version": "0.2.3",
-      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
       "dev": true
     },
     "postcss-reporter": {
       "version": "1.4.1",
-      "integrity": "sha1-wTbwpbFhkV83ndN2XGEHX357mvI=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.0.0",
-        "lodash": "4.15.0",
-        "log-symbols": "1.0.2",
-        "postcss": "5.2.18"
-      }
+      "dev": true
     },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
-      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
       "dev": true
     },
     "postcss-scss": {
       "version": "1.0.0",
-      "integrity": "sha1-SVcBMJeXPf1b2bGtim3BNFal0bo=",
       "dev": true,
-      "requires": {
-        "postcss": "6.0.14"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "postcss": {
           "version": "6.0.14",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.3.0",
-            "source-map": "0.6.1",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
     "postcss-selector-parser": {
       "version": "2.2.3",
-      "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-      "dev": true,
-      "requires": {
-        "flatten": "1.0.2",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
-      }
+      "dev": true
     },
     "postcss-value-parser": {
-      "version": "3.3.0",
-      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+      "version": "3.3.0"
     },
     "postcss-values-parser": {
       "version": "1.3.1",
-      "integrity": "sha512-chFn9CnFAAUpQ3cwrxvVjKB8c0y6BfONv6eapndJoTXJ3h8fr1uAiue8lGP3rUIpBI2KgJGdgCVk9KNvXh0n6A==",
-      "dev": true,
-      "requires": {
-        "flatten": "1.0.2",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
-      }
+      "dev": true
     },
     "prebuild-install": {
       "version": "2.4.1",
-      "integrity": "sha512-99TyEFYTTkBWANT+mwSptmLb9ZCLQ6qKIUE36fXSIOtShB0JNprL2hzBD8F1yIuT9btjFrFEwbRHXhqDi1HmRA==",
-      "requires": {
-        "expand-template": "1.1.0",
-        "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.1.2",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "1.0.3",
-        "rc": "1.2.2",
-        "simple-get": "1.4.3",
-        "tar-fs": "1.16.0",
-        "tunnel-agent": "0.6.0",
-        "xtend": "4.0.1"
-      },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.0"
         }
       }
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
     "preserve": {
-      "version": "0.2.0",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+      "version": "0.2.0"
     },
     "prettier": {
-      "version": "github:automattic/calypso-prettier#717e62ee3650aa6f8720c86474ce4dba78bd0c36",
+      "version": "1.7.4",
+      "from": "github:automattic/calypso-prettier#717e62ee",
+      "resolved": "github:automattic/calypso-prettier#717e62ee3650aa6f8720c86474ce4dba78bd0c36",
       "dev": true,
-      "requires": {
-        "babel-code-frame": "7.0.0-alpha.12",
-        "babylon": "7.0.0-beta.23",
-        "camelcase": "4.1.0",
-        "chalk": "2.1.0",
-        "cosmiconfig": "3.1.0",
-        "dashify": "0.2.2",
-        "diff": "3.2.0",
-        "esutils": "2.0.2",
-        "flow-parser": "0.51.0",
-        "get-stream": "3.0.0",
-        "globby": "6.1.0",
-        "graphql": "0.10.1",
-        "ignore": "3.3.5",
-        "jest-docblock": "21.3.0-beta.14",
-        "jest-validate": "21.1.0",
-        "leven": "2.1.0",
-        "mem": "1.1.0",
-        "minimatch": "3.0.4",
-        "minimist": "1.2.0",
-        "parse5": "3.0.2",
-        "postcss-less": "1.1.1",
-        "postcss-media-query-parser": "0.2.3",
-        "postcss-scss": "1.0.0",
-        "postcss-selector-parser": "2.2.3",
-        "postcss-values-parser": "1.3.1",
-        "strip-bom": "3.0.0",
-        "typescript": "2.5.3",
-        "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#9c71a627da36e97da52ed2731d58509c952b67ae"
-      },
       "dependencies": {
         "@types/node": {
           "version": "6.0.93",
-          "integrity": "sha512-RQor46kCg7bFlwwrXJhodwCTOKmDW6nCrF0RSYqMpPmg0zYoTW3ggkhlcxXFy1D/Y8gkuFwhEIFmm6dkZPw1Kw==",
           "dev": true
         },
         "babel-code-frame": {
           "version": "7.0.0-alpha.12",
-          "integrity": "sha512-5BmA2es52XNA9PN96HRfJg0co5CkmrKxWdvyW507LNqJmicnHM4we4HI16bIzgAuVeL7RKc4GJmTsyhkFco4Tw==",
           "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          },
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.3",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
+              "dev": true
             }
           }
         },
         "babylon": {
           "version": "7.0.0-beta.23",
-          "integrity": "sha512-Ik+5GkQUsL/IIzMP3lV9uyAQif+hoCy7y+8xz+j5RidL3FCexOvQojK8smt6NzTSJ1K9HgHKutXWdgMSUZtDsQ==",
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "chalk": {
           "version": "2.1.0",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          },
           "dependencies": {
             "ansi-styles": {
               "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-              "dev": true,
-              "requires": {
-                "color-convert": "1.9.1"
-              }
+              "dev": true
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
               "dev": true
             },
             "supports-color": {
               "version": "4.5.0",
-              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-              "dev": true,
-              "requires": {
-                "has-flag": "2.0.0"
-              }
+              "dev": true
             }
           }
         },
         "diff": {
           "version": "3.2.0",
-          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
           "dev": true
         },
         "flow-parser": {
           "version": "0.51.0",
-          "integrity": "sha1-4cDOtvgCuiHRbC/ajkLIJPQPRoQ=",
           "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "jest-docblock": {
           "version": "21.3.0-beta.14",
-          "integrity": "sha512-rKJrMcQEENAJSKUMlqdUzq4Hy5B0MkoV0GnogBlqBOrX6w+Hz8FAGNHCn4PYCyRIVXm4k2d1bscpD4Tw4c/Zww==",
-          "dev": true,
-          "requires": {
-            "detect-newline": "2.1.0"
-          }
+          "dev": true
         },
         "jest-validate": {
           "version": "21.1.0",
-          "integrity": "sha512-xS0cyErNWpsLFlGkn/b87pk/Mv7J+mCTs8hQ4KmtOIIoM1sHYobXII8AtkoN8FC7E3+Ptxjo+/3xWk6LK1dKcw==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.1.0",
-            "jest-get-type": "21.2.0",
-            "leven": "2.1.0",
-            "pretty-format": "21.2.1"
-          }
+          "dev": true
         },
         "leven": {
           "version": "2.1.0",
-          "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
           "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "parse5": {
           "version": "3.0.2",
-          "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
-          "dev": true,
-          "requires": {
-            "@types/node": "6.0.93"
-          }
+          "dev": true
         },
         "strip-bom": {
           "version": "3.0.0",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "pretty-bytes": {
       "version": "4.0.2",
-      "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
     },
     "pretty-format": {
       "version": "21.2.1",
-      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
       "dev": true,
-      "requires": {
-        "ansi-regex": "3.0.0",
-        "ansi-styles": "3.2.0"
-      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         }
       }
     },
     "prismjs": {
       "version": "1.6.0",
-      "integrity": "sha1-EY2V+3pm26InLjQ7NF9SNmWds2U=",
-      "requires": {
-        "clipboard": "1.7.1"
-      },
       "dependencies": {
         "clipboard": {
           "version": "1.7.1",
-          "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
-          "optional": true,
-          "requires": {
-            "good-listener": "1.2.2",
-            "select": "1.1.2",
-            "tiny-emitter": "2.0.2"
-          }
+          "optional": true
         },
         "tiny-emitter": {
           "version": "2.0.2",
-          "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
           "optional": true
         }
       }
     },
     "private": {
-      "version": "0.1.8",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+      "version": "0.1.8"
     },
     "process": {
-      "version": "0.11.10",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+      "version": "0.11.10"
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "1.0.7"
     },
     "progress": {
       "version": "1.1.8",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
     "progress-event": {
-      "version": "1.0.0",
-      "integrity": "sha1-EUbfS2GEndvpPugfk2WvkbiQHFE="
+      "version": "1.0.0"
     },
     "promise": {
-      "version": "7.3.1",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "2.0.6"
-      }
+      "version": "7.3.1"
     },
     "promise-inflight": {
-      "version": "1.0.1",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+      "version": "1.0.1"
     },
     "prop-types": {
-      "version": "15.5.10",
-      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1"
-      }
+      "version": "15.5.10"
     },
     "propagate": {
       "version": "0.4.0",
-      "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE=",
       "dev": true
     },
     "protochain": {
       "version": "1.0.5",
-      "integrity": "sha1-mRxAfpneJkqt+PgVBLXn+ve/omA=",
       "dev": true
     },
     "proxy-addr": {
-      "version": "1.0.10",
-      "integrity": "sha1-DUCoL4Afw1VWfS7LZe/j8HfxIcU=",
-      "requires": {
-        "forwarded": "0.1.2",
-        "ipaddr.js": "1.0.5"
-      }
+      "version": "1.0.10"
     },
     "prr": {
-      "version": "1.0.1",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+      "version": "1.0.1"
     },
     "ps-tree": {
-      "version": "1.1.0",
-      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-      "requires": {
-        "event-stream": "3.3.4"
-      }
+      "version": "1.1.0"
     },
     "pseudomap": {
-      "version": "1.0.2",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "version": "1.0.2"
     },
     "public-encrypt": {
-      "version": "4.0.0",
-      "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
-      "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
-      }
+      "version": "4.0.0"
     },
     "pug": {
-      "version": "2.0.0-rc.4",
-      "integrity": "sha512-SL7xovj6E2Loq9N0UgV6ynjMLW4urTFY/L/Fprhvz13Xc5vjzkjZjI1QHKq31200+6PSD8PyU6MqrtCTJj6/XA==",
-      "requires": {
-        "pug-code-gen": "2.0.0",
-        "pug-filters": "2.1.5",
-        "pug-lexer": "3.1.0",
-        "pug-linker": "3.0.3",
-        "pug-load": "2.0.9",
-        "pug-parser": "4.0.0",
-        "pug-runtime": "2.0.3",
-        "pug-strip-comments": "1.0.2"
-      }
+      "version": "2.0.0-rc.4"
     },
     "pug-attrs": {
-      "version": "2.0.2",
-      "integrity": "sha1-i+KyIlVo/6ddG4Zpgr/59BEa/8s=",
-      "requires": {
-        "constantinople": "3.1.0",
-        "js-stringify": "1.0.2",
-        "pug-runtime": "2.0.3"
-      }
+      "version": "2.0.2"
     },
     "pug-code-gen": {
-      "version": "2.0.0",
-      "integrity": "sha512-E4oiJT+Jn5tyEIloj8dIJQognbiNNp0i0cAJmYtQTFS0soJ917nlIuFtqVss3IXMEyQKUew3F4gIkBpn18KbVg==",
-      "requires": {
-        "constantinople": "3.1.0",
-        "doctypes": "1.1.0",
-        "js-stringify": "1.0.2",
-        "pug-attrs": "2.0.2",
-        "pug-error": "1.3.2",
-        "pug-runtime": "2.0.3",
-        "void-elements": "2.0.1",
-        "with": "5.1.1"
-      }
+      "version": "2.0.0"
     },
     "pug-error": {
-      "version": "1.3.2",
-      "integrity": "sha1-U659nSm7A89WRJOgJhCfVMR/XyY="
+      "version": "1.3.2"
     },
     "pug-filters": {
-      "version": "2.1.5",
-      "integrity": "sha512-xkw71KtrC4sxleKiq+cUlQzsiLn8pM5+vCgkChW2E6oNOzaqTSIBKIQ5cl4oheuDzvJYCTSYzRaVinMUrV4YLQ==",
-      "requires": {
-        "clean-css": "3.4.28",
-        "constantinople": "3.1.0",
-        "jstransformer": "1.0.0",
-        "pug-error": "1.3.2",
-        "pug-walk": "1.1.5",
-        "resolve": "1.5.0",
-        "uglify-js": "2.6.4"
-      }
+      "version": "2.1.5"
     },
     "pug-lexer": {
       "version": "3.1.0",
-      "integrity": "sha1-/QhzdtSmdbT1n4/vQiiDQ06VgaI=",
-      "requires": {
-        "character-parser": "2.2.0",
-        "is-expression": "3.0.0",
-        "pug-error": "1.3.2"
-      },
       "dependencies": {
         "acorn": {
-          "version": "4.0.13",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+          "version": "4.0.13"
         },
         "is-expression": {
-          "version": "3.0.0",
-          "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
-          "requires": {
-            "acorn": "4.0.13",
-            "object-assign": "4.1.1"
-          }
+          "version": "3.0.0"
         }
       }
     },
     "pug-linker": {
-      "version": "3.0.3",
-      "integrity": "sha512-DCKczglCXOzJ1lr4xUj/lVHYvS+lGmR2+KTCjZjtIpdwaN7lNOoX2SW6KFX5X4ElvW+6ThwB+acSUg08UJFN5A==",
-      "requires": {
-        "pug-error": "1.3.2",
-        "pug-walk": "1.1.5"
-      }
+      "version": "3.0.3"
     },
     "pug-load": {
-      "version": "2.0.9",
-      "integrity": "sha512-BDdZOCru4mg+1MiZwRQZh25+NTRo/R6/qArrdWIf308rHtWA5N9kpoUskRe4H6FslaQujC+DigH9LqlBA4gf6Q==",
-      "requires": {
-        "object-assign": "4.1.1",
-        "pug-walk": "1.1.5"
-      }
+      "version": "2.0.9"
     },
     "pug-parser": {
-      "version": "4.0.0",
-      "integrity": "sha512-ocEUFPdLG9awwFj0sqi1uiZLNvfoodCMULZzkRqILryIWc/UUlDlxqrKhKjAIIGPX/1SNsvxy63+ayEGocGhQg==",
-      "requires": {
-        "pug-error": "1.3.2",
-        "token-stream": "0.0.1"
-      }
+      "version": "4.0.0"
     },
     "pug-runtime": {
-      "version": "2.0.3",
-      "integrity": "sha1-mBYmB7D86eJU1CfzOYelrucWi9o="
+      "version": "2.0.3"
     },
     "pug-strip-comments": {
-      "version": "1.0.2",
-      "integrity": "sha1-0xOvoBvMN0mA4TmeI+vy65vchRM=",
-      "requires": {
-        "pug-error": "1.3.2"
-      }
+      "version": "1.0.2"
     },
     "pug-walk": {
-      "version": "1.1.5",
-      "integrity": "sha512-rJlH1lXerCIAtImXBze3dtKq/ykZMA4rpO9FnPcIgsWcxZLOvd8zltaoeOVFyBSSqCkhhJWbEbTMga8UxWUUSA=="
+      "version": "1.1.5"
     },
     "pump": {
-      "version": "1.0.3",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-      "requires": {
-        "end-of-stream": "1.4.0",
-        "once": "1.4.0"
-      }
+      "version": "1.0.3"
     },
     "pumpify": {
-      "version": "1.3.5",
-      "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
-      "requires": {
-        "duplexify": "3.5.1",
-        "inherits": "2.0.1",
-        "pump": "1.0.3"
-      }
+      "version": "1.3.5"
     },
     "punycode": {
-      "version": "1.4.1",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "version": "1.4.1"
     },
     "q": {
-      "version": "1.0.1",
-      "integrity": "sha1-EYcq7t7okmgRCxCnGESP+xARKhQ="
+      "version": "1.0.1"
     },
     "qr.js": {
-      "version": "0.0.0",
-      "integrity": "sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8="
+      "version": "0.0.0"
     },
     "qrcode.react": {
-      "version": "0.7.2",
-      "integrity": "sha512-s1x+E3bsp0ojI8cHQ+czr+aG3huLZegH+tqAuRsXh6oXvzNfC+9L2PeFRBBu8eRBiejMRrRzSH7iwi5LDyWfRg==",
-      "requires": {
-        "prop-types": "15.5.10",
-        "qr.js": "0.0.0"
-      }
+      "version": "0.7.2"
     },
     "qs": {
-      "version": "4.0.0",
-      "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc="
+      "version": "4.0.0"
     },
     "querystring": {
-      "version": "0.2.0",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "version": "0.2.0"
     },
     "querystring-es3": {
-      "version": "0.2.1",
-      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+      "version": "0.2.1"
     },
     "raf": {
       "version": "3.4.0",
-      "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
-      "dev": true,
-      "requires": {
-        "performance-now": "2.1.0"
-      }
+      "dev": true
     },
     "railroad-diagrams": {
       "version": "1.0.0",
-      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
       "dev": true
     },
     "randexp": {
       "version": "0.4.6",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dev": true,
-      "requires": {
-        "discontinuous-range": "1.0.0",
-        "ret": "0.1.15"
-      }
+      "dev": true
     },
     "randomatic": {
       "version": "1.1.7",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
-              "version": "3.2.2",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "version": "3.2.2"
             }
           }
         },
         "kind-of": {
-          "version": "4.0.0",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
+          "version": "4.0.0"
         }
       }
     },
     "randombytes": {
-      "version": "2.0.5",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+      "version": "2.0.5"
     },
     "randomfill": {
-      "version": "1.0.3",
-      "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
-      "requires": {
-        "randombytes": "2.0.5",
-        "safe-buffer": "5.1.1"
-      }
+      "version": "1.0.3"
     },
     "range-parser": {
-      "version": "1.0.3",
-      "integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU="
+      "version": "1.0.3"
     },
     "raw-body": {
-      "version": "2.2.0",
-      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
-      "requires": {
-        "bytes": "2.4.0",
-        "iconv-lite": "0.4.15",
-        "unpipe": "1.0.0"
-      }
+      "version": "2.2.0"
     },
     "rc": {
       "version": "1.2.2",
-      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
-      "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
-      },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.0"
         }
       }
     },
     "react": {
       "version": "16.2.0",
-      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
-      },
       "dependencies": {
         "prop-types": {
-          "version": "15.6.0",
-          "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
+          "version": "15.6.0"
         }
       }
     },
     "react-addons-create-fragment": {
-      "version": "15.6.2",
-      "integrity": "sha1-o5TefCx77Na1R1uhuXrEcs58dPg=",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
+      "version": "15.6.2"
     },
     "react-click-outside": {
-      "version": "2.3.1",
-      "integrity": "sha1-MYc3698IGko7zUaCVmNnTL6YNus=",
-      "requires": {
-        "hoist-non-react-statics": "1.2.0"
-      }
+      "version": "2.3.1"
     },
     "react-codemod": {
-      "version": "github:reactjs/react-codemod#f5a1282b80ab2280571a542e2ae98b91ca90a447",
+      "version": "4.0.0",
+      "from": "github:reactjs/react-codemod",
+      "resolved": "github:reactjs/react-codemod#f5a1282b80ab2280571a542e2ae98b91ca90a447",
       "dev": true,
-      "requires": {
-        "babel-eslint": "6.1.2",
-        "babel-jest": "15.0.0",
-        "babel-plugin-transform-object-rest-spread": "6.26.0",
-        "babel-preset-es2015": "6.24.1",
-        "eslint": "2.13.1",
-        "fbjs-scripts": "0.7.1",
-        "jest": "17.0.3",
-        "jscodeshift": "0.3.30",
-        "path": "0.12.7"
-      },
       "dependencies": {
         "babel-jest": {
           "version": "15.0.0",
-          "integrity": "sha1-ap4uOZnyQTg9uaseLvZwRAHXQkI=",
-          "dev": true,
-          "requires": {
-            "babel-core": "6.25.0",
-            "babel-plugin-istanbul": "2.0.3",
-            "babel-preset-jest": "15.0.0"
-          }
+          "dev": true
         },
         "babel-plugin-istanbul": {
           "version": "2.0.3",
-          "integrity": "sha1-JmswS5EJYH1gdIR0OUZ2mC9mDfQ=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "istanbul-lib-instrument": "1.9.1",
-            "object-assign": "4.1.1",
-            "test-exclude": "2.1.3"
-          }
+          "dev": true
         },
         "babel-plugin-jest-hoist": {
           "version": "15.0.0",
-          "integrity": "sha1-ey/b0M0S/DaoTT9f8AHsUEJiu1k=",
           "dev": true
         },
         "babel-preset-jest": {
           "version": "15.0.0",
-          "integrity": "sha1-8jmI8fkYZz/5tHD9/WD8wZvGGPU=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-jest-hoist": "15.0.0"
-          }
+          "dev": true
         },
         "bser": {
           "version": "1.0.2",
-          "integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
-          "dev": true,
-          "requires": {
-            "node-int64": "0.4.0"
-          }
+          "dev": true
         },
         "callsites": {
           "version": "2.0.0",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         },
         "camelcase": {
           "version": "3.0.0",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "cli-width": {
           "version": "2.2.0",
-          "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
           "dev": true
         },
         "cliui": {
           "version": "3.2.0",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
+          "dev": true
         },
         "doctrine": {
           "version": "1.5.0",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
-          }
+          "dev": true
         },
         "eslint": {
           "version": "2.13.1",
-          "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "concat-stream": "1.5.2",
-            "debug": "2.2.0",
-            "doctrine": "1.5.0",
-            "es6-map": "0.1.5",
-            "escope": "3.6.0",
-            "espree": "3.5.2",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "file-entry-cache": "1.3.1",
-            "glob": "7.0.3",
-            "globals": "9.18.0",
-            "ignore": "3.3.5",
-            "imurmurhash": "0.1.4",
-            "inquirer": "0.12.0",
-            "is-my-json-valid": "2.13.1",
-            "is-resolvable": "1.0.0",
-            "js-yaml": "3.10.0",
-            "json-stable-stringify": "1.0.1",
-            "levn": "0.3.0",
-            "lodash": "4.15.0",
-            "mkdirp": "0.5.1",
-            "optionator": "0.8.1",
-            "path-is-absolute": "1.0.1",
-            "path-is-inside": "1.0.2",
-            "pluralize": "1.2.1",
-            "progress": "1.1.8",
-            "require-uncached": "1.0.3",
-            "shelljs": "0.6.1",
-            "strip-json-comments": "1.0.4",
-            "table": "3.8.3",
-            "text-table": "0.2.0",
-            "user-home": "2.0.0"
-          }
+          "dev": true
         },
         "fb-watchman": {
           "version": "1.9.2",
-          "integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
-          "dev": true,
-          "requires": {
-            "bser": "1.0.2"
-          }
+          "dev": true
         },
         "file-entry-cache": {
           "version": "1.3.1",
-          "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
-          "dev": true,
-          "requires": {
-            "flat-cache": "1.3.0",
-            "object-assign": "4.1.1"
-          }
+          "dev": true
         },
         "find-up": {
           "version": "1.1.2",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "inquirer": {
           "version": "0.12.0",
-          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "1.4.0",
-            "ansi-regex": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "2.2.0",
-            "figures": "1.7.0",
-            "lodash": "4.15.0",
-            "readline2": "1.0.1",
-            "run-async": "0.1.0",
-            "rx-lite": "3.1.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
-          }
+          "dev": true
         },
         "jest": {
           "version": "17.0.3",
-          "integrity": "sha1-icQ7MLCqrUJGLp6nATUtrLrUo1Q=",
           "dev": true,
-          "requires": {
-            "jest-cli": "17.0.3"
-          },
           "dependencies": {
             "jest-cli": {
               "version": "17.0.3",
-              "integrity": "sha1-cAuMAqnqDsnqsM1an9QtioWM4UY=",
-              "dev": true,
-              "requires": {
-                "ansi-escapes": "1.4.0",
-                "callsites": "2.0.0",
-                "chalk": "1.1.3",
-                "graceful-fs": "4.1.11",
-                "is-ci": "1.0.10",
-                "istanbul-api": "1.2.1",
-                "istanbul-lib-coverage": "1.1.1",
-                "istanbul-lib-instrument": "1.9.1",
-                "jest-changed-files": "17.0.2",
-                "jest-config": "17.0.3",
-                "jest-environment-jsdom": "17.0.2",
-                "jest-file-exists": "17.0.0",
-                "jest-haste-map": "17.0.3",
-                "jest-jasmine2": "17.0.3",
-                "jest-mock": "17.0.2",
-                "jest-resolve": "17.0.3",
-                "jest-resolve-dependencies": "17.0.3",
-                "jest-runtime": "17.0.3",
-                "jest-snapshot": "17.0.3",
-                "jest-util": "17.0.2",
-                "json-stable-stringify": "1.0.1",
-                "node-notifier": "4.6.1",
-                "sane": "1.4.1",
-                "strip-ansi": "3.0.1",
-                "throat": "3.2.0",
-                "which": "1.3.0",
-                "worker-farm": "1.5.2",
-                "yargs": "6.6.0"
-              }
+              "dev": true
             }
           }
         },
         "jest-changed-files": {
           "version": "17.0.2",
-          "integrity": "sha1-9WV3WHNplvWQpRuH5ck2nZBLp7c=",
           "dev": true
         },
         "jest-config": {
           "version": "17.0.3",
-          "integrity": "sha1-tu112Q0JC3Mf2JQjGQTK231aXfI=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "istanbul": "0.4.5",
-            "jest-environment-jsdom": "17.0.2",
-            "jest-environment-node": "17.0.2",
-            "jest-jasmine2": "17.0.3",
-            "jest-mock": "17.0.2",
-            "jest-resolve": "17.0.3",
-            "jest-util": "17.0.2",
-            "json-stable-stringify": "1.0.1"
-          }
+          "dev": true
         },
         "jest-diff": {
           "version": "17.0.3",
-          "integrity": "sha1-j7Me+rOzFNe2G3tmsL3qYX7xwC8=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "diff": "3.4.0",
-            "jest-matcher-utils": "17.0.3",
-            "pretty-format": "4.2.3"
-          }
+          "dev": true
         },
         "jest-environment-jsdom": {
           "version": "17.0.2",
-          "integrity": "sha1-owmNwpgG1AgCxStiuEiraqAP26A=",
-          "dev": true,
-          "requires": {
-            "jest-mock": "17.0.2",
-            "jest-util": "17.0.2",
-            "jsdom": "9.12.0"
-          }
+          "dev": true
         },
         "jest-environment-node": {
           "version": "17.0.2",
-          "integrity": "sha1-r/YTP0yi+t3MWwzn0lzsg+FthGM=",
-          "dev": true,
-          "requires": {
-            "jest-mock": "17.0.2",
-            "jest-util": "17.0.2"
-          }
+          "dev": true
         },
         "jest-haste-map": {
           "version": "17.0.3",
-          "integrity": "sha1-UjJ4PnBXche2sX0qHBdmY3odL70=",
-          "dev": true,
-          "requires": {
-            "fb-watchman": "1.9.2",
-            "graceful-fs": "4.1.11",
-            "multimatch": "2.1.0",
-            "sane": "1.4.1",
-            "worker-farm": "1.5.2"
-          }
+          "dev": true
         },
         "jest-jasmine2": {
           "version": "17.0.3",
-          "integrity": "sha1-1DNrifOtKIJpocjiv8GA3PicatE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jest-matchers": "17.0.3",
-            "jest-snapshot": "17.0.3",
-            "jest-util": "17.0.2"
-          }
+          "dev": true
         },
         "jest-matcher-utils": {
           "version": "17.0.3",
-          "integrity": "sha1-8Qjkm5VuFSxmJtzAq6hk9Zq3sNM=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "pretty-format": "4.2.3"
-          }
+          "dev": true
         },
         "jest-mock": {
           "version": "17.0.2",
-          "integrity": "sha1-Pf6SIa/ZqmGz2ZkoQIE6NYuy9Ck=",
           "dev": true
         },
         "jest-resolve": {
           "version": "17.0.3",
-          "integrity": "sha1-dpKnneKDGHQ3Xp1mS8eCwp5NomI=",
-          "dev": true,
-          "requires": {
-            "browser-resolve": "1.11.2",
-            "jest-file-exists": "17.0.0",
-            "jest-haste-map": "17.0.3",
-            "resolve": "1.5.0"
-          }
+          "dev": true
         },
         "jest-resolve-dependencies": {
           "version": "17.0.3",
-          "integrity": "sha1-u9N/RkNwS5epgJJyEvOrErBuiJQ=",
-          "dev": true,
-          "requires": {
-            "jest-file-exists": "17.0.0",
-            "jest-resolve": "17.0.3"
-          }
+          "dev": true
         },
         "jest-runtime": {
           "version": "17.0.3",
-          "integrity": "sha1-7/QFX+jD4XyV7Rqq9fcZxCC4ax8=",
           "dev": true,
-          "requires": {
-            "babel-core": "6.25.0",
-            "babel-jest": "17.0.2",
-            "babel-plugin-istanbul": "2.0.3",
-            "chalk": "1.1.3",
-            "graceful-fs": "4.1.11",
-            "jest-config": "17.0.3",
-            "jest-file-exists": "17.0.0",
-            "jest-haste-map": "17.0.3",
-            "jest-mock": "17.0.2",
-            "jest-resolve": "17.0.3",
-            "jest-snapshot": "17.0.3",
-            "jest-util": "17.0.2",
-            "json-stable-stringify": "1.0.1",
-            "multimatch": "2.1.0",
-            "yargs": "6.6.0"
-          },
           "dependencies": {
             "babel-jest": {
               "version": "17.0.2",
-              "integrity": "sha1-jVHg0DdZcTwzHxCOsLLqpMbv/3Q=",
-              "dev": true,
-              "requires": {
-                "babel-core": "6.25.0",
-                "babel-plugin-istanbul": "2.0.3",
-                "babel-preset-jest": "17.0.2"
-              }
+              "dev": true
             },
             "babel-plugin-jest-hoist": {
               "version": "17.0.2",
-              "integrity": "sha1-ITSIzoJZkKzUww+IfcoJ//60UjU=",
               "dev": true
             },
             "babel-preset-jest": {
               "version": "17.0.2",
-              "integrity": "sha1-FB6TXevhZKqgNkwiDTHMshdkk7I=",
-              "dev": true,
-              "requires": {
-                "babel-plugin-jest-hoist": "17.0.2"
-              }
+              "dev": true
             }
           }
         },
         "jest-snapshot": {
           "version": "17.0.3",
-          "integrity": "sha1-yBmdtMy9VRXP7MjoAKsHa92nq8A=",
-          "dev": true,
-          "requires": {
-            "jest-diff": "17.0.3",
-            "jest-file-exists": "17.0.0",
-            "jest-matcher-utils": "17.0.3",
-            "jest-util": "17.0.2",
-            "natural-compare": "1.4.0",
-            "pretty-format": "4.2.3"
-          }
+          "dev": true
         },
         "jest-util": {
           "version": "17.0.2",
-          "integrity": "sha1-n9nagJHpkE+5dtp+TYkSyiaWhjg=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "diff": "3.4.0",
-            "graceful-fs": "4.1.11",
-            "jest-file-exists": "17.0.0",
-            "jest-mock": "17.0.2",
-            "mkdirp": "0.5.1"
-          }
+          "dev": true
         },
         "lodash.clonedeep": {
           "version": "3.0.2",
-          "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
-          "dev": true,
-          "requires": {
-            "lodash._baseclone": "3.3.0",
-            "lodash._bindcallback": "3.0.1"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "node-notifier": {
           "version": "4.6.1",
-          "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
-          "dev": true,
-          "requires": {
-            "cli-usage": "0.1.4",
-            "growly": "1.3.0",
-            "lodash.clonedeep": "3.0.2",
-            "minimist": "1.2.0",
-            "semver": "5.1.0",
-            "shellwords": "0.1.1",
-            "which": "1.3.0"
-          }
+          "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "pretty-format": {
           "version": "4.2.3",
-          "integrity": "sha1-iJTCrIFBnPgBYp2PZjIKJTgNiwU=",
           "dev": true
         },
         "sane": {
           "version": "1.4.1",
-          "integrity": "sha1-iPdj10BA9fDCVrYWPbOZvxEKxxU=",
-          "dev": true,
-          "requires": {
-            "exec-sh": "0.2.1",
-            "fb-watchman": "1.9.2",
-            "minimatch": "3.0.4",
-            "minimist": "1.2.0",
-            "walker": "1.0.7",
-            "watch": "0.10.0"
-          }
+          "dev": true
         },
         "strip-json-comments": {
           "version": "1.0.4",
-          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "test-exclude": {
           "version": "2.1.3",
-          "integrity": "sha1-qNiWjh2oMmb5hk8oUsVeIg8GQ0o=",
-          "dev": true,
-          "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "2.3.11",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
-          }
+          "dev": true
         },
         "throat": {
           "version": "3.2.0",
-          "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
           "dev": true
         },
         "user-home": {
           "version": "2.0.0",
-          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "1.0.2"
-          }
+          "dev": true
         },
         "watch": {
           "version": "0.10.0",
-          "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
           "dev": true
         },
         "yargs": {
           "version": "6.6.0",
-          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-          "dev": true,
-          "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
-          }
+          "dev": true
         },
         "yargs-parser": {
           "version": "4.2.1",
-          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-          "dev": true,
-          "requires": {
-            "camelcase": "3.0.0"
-          }
+          "dev": true
         }
       }
     },
     "react-day-picker": {
       "version": "6.2.1",
-      "integrity": "sha1-/CK4Cdt5I4bRRo0/RtclrZHgTbk=",
-      "requires": {
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
-      },
       "dependencies": {
         "prop-types": {
-          "version": "15.6.0",
-          "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
+          "version": "15.6.0"
         }
       }
     },
     "react-dom": {
       "version": "16.2.0",
-      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
-      "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
-      },
       "dependencies": {
         "prop-types": {
-          "version": "15.6.0",
-          "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
+          "version": "15.6.0"
         }
       }
     },
     "react-hot-api": {
-      "version": "0.4.7",
-      "integrity": "sha1-p+IqVtJS4Rq9k2a2EmTPRJLFgXE="
+      "version": "0.4.7"
     },
     "react-hot-loader": {
       "version": "1.3.1",
-      "integrity": "sha1-yVZHrni3Pfzv9uxx/8sEGC/22vk=",
-      "requires": {
-        "react-hot-api": "0.4.7",
-        "source-map": "0.4.4"
-      },
       "dependencies": {
         "source-map": {
-          "version": "0.4.4",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "version": "0.4.4"
         }
       }
     },
     "react-modal": {
-      "version": "3.1.0",
-      "integrity": "sha512-4sVW7Flm6sdaQeWr8OxXqMOuothdg+jnCA4MqloP65g2iWtOtho8VeI+z3SCsqunWefbuCHCnncxIBmDgPehQQ==",
-      "requires": {
-        "exenv": "1.2.2",
-        "prop-types": "15.5.10"
-      }
+      "version": "3.1.0"
     },
     "react-pure-render": {
-      "version": "1.0.2",
-      "integrity": "sha1-nYqSjH8sN1E8LQZOV7Pjw1bp+rs="
+      "version": "1.0.2"
     },
     "react-redux": {
       "version": "5.0.6",
-      "integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
-      "requires": {
-        "hoist-non-react-statics": "2.3.1",
-        "invariant": "2.2.2",
-        "lodash": "4.15.0",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.5.10"
-      },
       "dependencies": {
         "hoist-non-react-statics": {
-          "version": "2.3.1",
-          "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
+          "version": "2.3.1"
         }
       }
     },
     "react-test-renderer": {
       "version": "16.2.0",
-      "integrity": "sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==",
       "dev": true,
-      "requires": {
-        "fbjs": "0.8.16",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
-      },
       "dependencies": {
         "prop-types": {
           "version": "15.6.0",
-          "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
-          "dev": true,
-          "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
-          }
+          "dev": true
         }
       }
     },
     "react-transition-group": {
       "version": "1.2.1",
-      "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
-      "requires": {
-        "chain-function": "1.0.0",
-        "dom-helpers": "3.2.1",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.5.10",
-        "warning": "3.0.0"
-      },
       "dependencies": {
         "dom-helpers": {
-          "version": "3.2.1",
-          "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
+          "version": "3.2.1"
         }
       }
     },
     "react-virtualized": {
       "version": "9.9.0",
-      "integrity": "sha512-TDe2haZiFr5apN3myuumGyeJ7iqHcGcQ648tfNf9x+R6tkE1+o8yAmeh4nKC4ldcs9My1dOHN3x/lmEX9LyOLA==",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "classnames": "2.2.5",
-        "dom-helpers": "2.4.0",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.5.10"
-      },
       "dependencies": {
         "classnames": {
-          "version": "2.2.5",
-          "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+          "version": "2.2.5"
         }
       }
     },
     "read-all-stream": {
       "version": "3.1.0",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "dev": true,
-      "requires": {
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         }
       }
     },
     "read-file-stdin": {
-      "version": "0.2.1",
-      "integrity": "sha1-JezP86FTtoCa+ssj7hU4fbng7mE=",
-      "requires": {
-        "gather-stream": "1.0.0"
-      }
+      "version": "0.2.1"
     },
     "read-pkg": {
-      "version": "1.1.0",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
-      }
+      "version": "1.1.0"
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
-      },
       "dependencies": {
         "find-up": {
-          "version": "1.1.2",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
+          "version": "1.1.2"
         },
         "path-exists": {
-          "version": "2.1.0",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
+          "version": "2.1.0"
         }
       }
     },
     "readable-stream": {
       "version": "1.1.14",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
-      },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "version": "0.0.1"
         }
       }
     },
     "readdirp": {
       "version": "2.1.0",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
-      },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3"
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "version": "2.3.3"
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "readline-sync": {
       "version": "1.4.5",
-      "integrity": "sha1-xw0rFHPsq8Hk1TPLrz6CSft36ZI=",
       "dev": true
     },
     "readline2": {
       "version": "1.0.1",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "mute-stream": "0.0.5"
-      }
+      "dev": true
     },
     "recast": {
       "version": "0.11.23",
-      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-      "requires": {
-        "ast-types": "0.9.6",
-        "esprima": "3.1.3",
-        "private": "0.1.8",
-        "source-map": "0.5.7"
-      },
       "dependencies": {
         "source-map": {
-          "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.5.7"
         }
       }
     },
     "redent": {
-      "version": "1.0.0",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
-      }
+      "version": "1.0.0"
     },
     "redeyed": {
       "version": "1.0.1",
-      "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
       "dev": true,
-      "requires": {
-        "esprima": "3.0.0"
-      },
       "dependencies": {
         "esprima": {
           "version": "3.0.0",
-          "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k=",
           "dev": true
         }
       }
     },
     "reduce-component": {
-      "version": "1.0.1",
-      "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo="
+      "version": "1.0.1"
     },
     "redux": {
-      "version": "3.0.4",
-      "integrity": "sha1-cwGTdPejJHZeTjPzZ8JzCnhaMwU="
+      "version": "3.0.4"
     },
     "redux-form": {
       "version": "7.0.2",
-      "integrity": "sha512-R1H9APwnBiJE31FWS2vBlM6NplH7AQb+3FJ3Z2e5B1flbgAZbFr7S0R9yrL8P4yy1liIAJcLreI1Ji4KA6KMtA==",
-      "requires": {
-        "deep-equal": "1.0.1",
-        "es6-error": "4.0.2",
-        "hoist-non-react-statics": "2.3.1",
-        "invariant": "2.2.2",
-        "is-promise": "2.1.0",
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "prop-types": "15.5.10"
-      },
       "dependencies": {
         "hoist-non-react-statics": {
-          "version": "2.3.1",
-          "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
+          "version": "2.3.1"
         },
         "lodash": {
-          "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.4"
         }
       }
     },
     "redux-thunk": {
-      "version": "1.0.0",
-      "integrity": "sha1-41VEoQ/NnJ47qWCDrBbHAjlPQAk="
+      "version": "1.0.0"
     },
     "regenerate": {
-      "version": "1.3.3",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+      "version": "1.3.3"
     },
     "regenerator": {
       "version": "0.8.40",
-      "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
       "dev": true,
-      "requires": {
-        "commoner": "0.10.8",
-        "defs": "1.1.1",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "0.1.8",
-        "recast": "0.10.33",
-        "through": "2.3.8"
-      },
       "dependencies": {
         "ast-types": {
           "version": "0.8.12",
-          "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
           "dev": true
         },
         "esprima-fb": {
           "version": "15001.1001.0-dev-harmony-fb",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
           "dev": true
         },
         "recast": {
           "version": "0.10.33",
-          "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
-          "dev": true,
-          "requires": {
-            "ast-types": "0.8.12",
-            "esprima-fb": "15001.1001.0-dev-harmony-fb",
-            "private": "0.1.8",
-            "source-map": "0.5.7"
-          }
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "version": "0.11.1"
     },
     "regenerator-transform": {
-      "version": "0.10.1",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
-      }
+      "version": "0.10.1"
     },
     "regex-cache": {
-      "version": "0.4.4",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "requires": {
-        "is-equal-shallow": "0.1.3"
-      }
+      "version": "0.4.4"
     },
     "regexpu": {
       "version": "1.3.0",
-      "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
       "dev": true,
-      "requires": {
-        "esprima": "2.7.3",
-        "recast": "0.10.43",
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      },
       "dependencies": {
         "ast-types": {
           "version": "0.8.15",
-          "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI=",
           "dev": true
         },
         "esprima": {
           "version": "2.7.3",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
           "dev": true
         },
         "recast": {
           "version": "0.10.43",
-          "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
           "dev": true,
-          "requires": {
-            "ast-types": "0.8.15",
-            "esprima-fb": "15001.1001.0-dev-harmony-fb",
-            "private": "0.1.8",
-            "source-map": "0.5.7"
-          },
           "dependencies": {
             "esprima-fb": {
               "version": "15001.1001.0-dev-harmony-fb",
-              "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
               "dev": true
             }
           }
         },
         "source-map": {
           "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
     },
     "regexpu-core": {
-      "version": "2.0.0",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
+      "version": "2.0.0"
     },
     "registry-url": {
       "version": "3.1.0",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true,
-      "requires": {
-        "rc": "1.2.2"
-      }
+      "dev": true
     },
     "regjsgen": {
-      "version": "0.2.0",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+      "version": "0.2.0"
     },
     "regjsparser": {
       "version": "0.1.5",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "requires": {
-        "jsesc": "0.5.0"
-      },
       "dependencies": {
         "jsesc": {
-          "version": "0.5.0",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+          "version": "0.5.0"
         }
       }
     },
     "relateurl": {
-      "version": "0.2.7",
-      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+      "version": "0.2.7"
     },
     "remove-trailing-separator": {
-      "version": "1.1.0",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "version": "1.1.0"
     },
     "repeat-element": {
-      "version": "1.1.2",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+      "version": "1.1.2"
     },
     "repeat-string": {
-      "version": "1.6.1",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "version": "1.6.1"
     },
     "repeating": {
-      "version": "2.0.1",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "requires": {
-        "is-finite": "1.0.2"
-      }
+      "version": "2.0.1"
     },
     "replace-ext": {
       "version": "0.0.1",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
     "request": {
       "version": "2.83.0",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-      "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
-      },
       "dependencies": {
         "qs": {
-          "version": "6.5.1",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+          "version": "6.5.1"
         },
         "uuid": {
-          "version": "3.1.0",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+          "version": "3.1.0"
         }
       }
     },
     "require-directory": {
-      "version": "2.1.1",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "version": "2.1.1"
     },
     "require-from-string": {
       "version": "2.0.1",
-      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
       "dev": true
     },
     "require-main-filename": {
-      "version": "1.0.1",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "version": "1.0.1"
     },
     "require-uncached": {
       "version": "1.0.3",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
-      }
+      "dev": true
     },
     "requireindex": {
       "version": "1.1.0",
-      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
       "dev": true
     },
     "resolve": {
-      "version": "1.5.0",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-      "requires": {
-        "path-parse": "1.0.5"
-      }
+      "version": "1.5.0"
     },
     "resolve-from": {
       "version": "1.0.1",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
     "restore-cursor": {
       "version": "1.0.1",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true,
-      "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
-      }
+      "dev": true
     },
     "ret": {
       "version": "0.1.15",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
     "right-align": {
-      "version": "0.1.3",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "requires": {
-        "align-text": "0.1.4"
-      }
+      "version": "0.1.3"
     },
     "rimraf": {
       "version": "2.6.2",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "requires": {
-        "glob": "7.1.2"
-      },
       "dependencies": {
         "glob": {
-          "version": "7.1.2",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "version": "7.1.2"
         }
       }
     },
     "ripemd160": {
-      "version": "2.0.1",
-      "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-      "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.1"
-      }
+      "version": "2.0.1"
     },
     "rocambole": {
       "version": "0.7.0",
-      "integrity": "sha1-9seVBVF9xCtvuECEK4uVOw+WhYU=",
       "dev": true,
-      "requires": {
-        "esprima": "2.7.3"
-      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
           "dev": true
         }
       }
     },
     "rocambole-indent": {
       "version": "2.0.4",
-      "integrity": "sha1-oYokl3ygQAuGHapGMehh3LUtCFw=",
       "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "mout": "0.11.1",
-        "rocambole-token": "1.2.1"
-      },
       "dependencies": {
         "mout": {
           "version": "0.11.1",
-          "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k=",
           "dev": true
         }
       }
     },
     "rocambole-linebreak": {
       "version": "1.0.2",
-      "integrity": "sha1-A2IVFbQ7RyHJflocG8paA2Y2jy8=",
       "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "rocambole-token": "1.2.1",
-        "semver": "4.3.6"
-      },
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
           "dev": true
         }
       }
     },
     "rocambole-node": {
       "version": "1.0.0",
-      "integrity": "sha1-21tJ3nQHsAgN1RSHLyjjk9D3/z8=",
       "dev": true
     },
     "rocambole-token": {
       "version": "1.2.1",
-      "integrity": "sha1-x4XfdCjcPLJ614lwR71SOMwHDTU=",
       "dev": true
     },
     "rocambole-whitespace": {
       "version": "1.0.0",
-      "integrity": "sha1-YzMJSSVrKZQfWbGQRZ+ZnGsdO/k=",
-      "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "repeat-string": "1.6.1",
-        "rocambole-token": "1.2.1"
-      }
+      "dev": true
     },
     "rst-selector-parser": {
       "version": "2.2.3",
-      "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
-      "dev": true,
-      "requires": {
-        "lodash.flattendeep": "4.4.0",
-        "nearley": "2.11.0"
-      }
+      "dev": true
     },
     "rtlcss": {
-      "version": "2.0.5",
-      "integrity": "sha1-MFOkPgyMTM51C4LDwoUZCDC1GfM=",
-      "requires": {
-        "chalk": "1.0.0",
-        "findup": "0.1.5",
-        "mkdirp": "0.5.1",
-        "postcss": "5.2.18",
-        "strip-json-comments": "2.0.1"
-      }
+      "version": "2.0.5"
     },
     "run-async": {
       "version": "0.1.0",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0"
-      }
+      "dev": true
     },
     "run-parallel": {
-      "version": "1.1.6",
-      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk="
+      "version": "1.1.6"
     },
     "run-queue": {
-      "version": "1.0.3",
-      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-      "requires": {
-        "aproba": "1.2.0"
-      }
+      "version": "1.0.3"
     },
     "rx-lite": {
       "version": "3.1.2",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "version": "5.1.1"
     },
     "samsam": {
       "version": "1.1.2",
-      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
     },
     "sane": {
       "version": "2.2.0",
-      "integrity": "sha512-OSJxhHO0CgPUw3lUm3GhfREAfza45smvEI9ozuFrxKG10GHVo0ryW9FK5VYlLvxj0SV7HVKHW0voYJIRu27GWg==",
       "dev": true,
-      "requires": {
-        "anymatch": "1.3.2",
-        "exec-sh": "0.2.1",
-        "fb-watchman": "2.0.0",
-        "fsevents": "1.1.3",
-        "minimatch": "3.0.4",
-        "minimist": "1.2.0",
-        "walker": "1.0.7",
-        "watch": "0.18.0"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
     },
     "sass-graph": {
       "version": "2.2.4",
-      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
-      "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.15.0",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
-      },
       "dependencies": {
         "camelcase": {
-          "version": "3.0.0",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+          "version": "3.0.0"
         },
         "cliui": {
-          "version": "3.2.0",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
+          "version": "3.2.0"
         },
         "glob": {
-          "version": "7.1.2",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "version": "7.1.2"
         },
         "yargs": {
-          "version": "7.1.0",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-          "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
-          }
+          "version": "7.1.0"
         }
       }
     },
     "sax": {
-      "version": "1.2.4",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "version": "1.2.4"
     },
     "schema-utils": {
-      "version": "0.3.0",
-      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-      "requires": {
-        "ajv": "5.5.1"
-      }
+      "version": "0.3.0"
     },
     "scss-tokenizer": {
       "version": "0.2.3",
-      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-      "requires": {
-        "js-base64": "2.4.0",
-        "source-map": "0.4.4"
-      },
       "dependencies": {
         "source-map": {
-          "version": "0.4.4",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "version": "0.4.4"
         }
       }
     },
     "seed-random": {
-      "version": "2.2.0",
-      "integrity": "sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ="
+      "version": "2.2.0"
     },
     "select": {
-      "version": "1.1.2",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
+      "version": "1.1.2"
     },
     "semver": {
-      "version": "5.1.0",
-      "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU="
+      "version": "5.1.0"
     },
     "semver-diff": {
       "version": "2.1.0",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true,
-      "requires": {
-        "semver": "5.1.0"
-      }
+      "dev": true
     },
     "send": {
       "version": "0.13.0",
-      "integrity": "sha1-UY+SGusFYK7H3KspkLFM9vPM5d4=",
-      "requires": {
-        "debug": "2.2.0",
-        "depd": "1.0.1",
-        "destroy": "1.0.3",
-        "escape-html": "1.0.2",
-        "etag": "1.7.0",
-        "fresh": "0.3.0",
-        "http-errors": "1.3.1",
-        "mime": "1.3.4",
-        "ms": "0.7.1",
-        "on-finished": "2.3.0",
-        "range-parser": "1.0.3",
-        "statuses": "1.2.1"
-      },
       "dependencies": {
         "depd": {
-          "version": "1.0.1",
-          "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
+          "version": "1.0.1"
         },
         "http-errors": {
-          "version": "1.3.1",
-          "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "requires": {
-            "inherits": "2.0.1",
-            "statuses": "1.2.1"
-          }
+          "version": "1.3.1"
         },
         "statuses": {
-          "version": "1.2.1",
-          "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg="
+          "version": "1.2.1"
         }
       }
     },
     "sentence-case": {
-      "version": "1.1.3",
-      "integrity": "sha1-gDSq/CFFdy06vhUJqkLJ4QQtwTk=",
-      "requires": {
-        "lower-case": "1.1.4"
-      }
+      "version": "1.1.3"
     },
     "serialize-error": {
-      "version": "2.1.0",
-      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
+      "version": "2.1.0"
     },
     "serializerr": {
       "version": "1.0.3",
-      "integrity": "sha1-EtTFqhw/+49tHcXzlaqUVVacP5E=",
-      "dev": true,
-      "requires": {
-        "protochain": "1.0.5"
-      }
+      "dev": true
     },
     "serve-static": {
       "version": "1.10.3",
-      "integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
-      "requires": {
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
-        "send": "0.13.2"
-      },
       "dependencies": {
         "destroy": {
-          "version": "1.0.4",
-          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+          "version": "1.0.4"
         },
         "escape-html": {
-          "version": "1.0.3",
-          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+          "version": "1.0.3"
         },
         "http-errors": {
-          "version": "1.3.1",
-          "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "requires": {
-            "inherits": "2.0.1",
-            "statuses": "1.2.1"
-          }
+          "version": "1.3.1"
         },
         "send": {
-          "version": "0.13.2",
-          "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
-          "requires": {
-            "debug": "2.2.0",
-            "depd": "1.1.1",
-            "destroy": "1.0.4",
-            "escape-html": "1.0.3",
-            "etag": "1.7.0",
-            "fresh": "0.3.0",
-            "http-errors": "1.3.1",
-            "mime": "1.3.4",
-            "ms": "0.7.1",
-            "on-finished": "2.3.0",
-            "range-parser": "1.0.3",
-            "statuses": "1.2.1"
-          }
+          "version": "0.13.2"
         },
         "statuses": {
-          "version": "1.2.1",
-          "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg="
+          "version": "1.2.1"
         }
       }
     },
     "set-blocking": {
-      "version": "2.0.0",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "version": "2.0.0"
     },
     "set-immediate-shim": {
-      "version": "1.0.1",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+      "version": "1.0.1"
     },
     "setimmediate": {
-      "version": "1.0.5",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "version": "1.0.5"
     },
     "setprototypeof": {
-      "version": "1.0.3",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+      "version": "1.0.3"
     },
     "sha.js": {
-      "version": "2.4.9",
-      "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
-      "requires": {
-        "inherits": "2.0.1",
-        "safe-buffer": "5.1.1"
-      }
+      "version": "2.4.9"
     },
     "shebang-command": {
-      "version": "1.2.0",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
+      "version": "1.2.0"
     },
     "shebang-regex": {
-      "version": "1.0.0",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "version": "1.0.0"
     },
     "shell-quote": {
-      "version": "1.6.1",
-      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-      "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
-      }
+      "version": "1.6.1"
     },
     "shelljs": {
       "version": "0.6.1",
-      "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
       "dev": true
     },
     "shellwords": {
       "version": "0.1.1",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "version": "3.0.2"
     },
     "simple-fmt": {
       "version": "0.1.0",
-      "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms=",
       "dev": true
     },
     "simple-get": {
-      "version": "1.4.3",
-      "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
-      "requires": {
-        "once": "1.4.0",
-        "unzip-response": "1.0.2",
-        "xtend": "4.0.1"
-      }
+      "version": "1.4.3"
     },
     "simple-is": {
       "version": "0.2.0",
-      "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
       "dev": true
     },
     "sinon": {
       "version": "1.17.7",
-      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-      "dev": true,
-      "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": "0.10.3"
-      }
+      "dev": true
     },
     "sinon-chai": {
       "version": "2.8.0",
-      "integrity": "sha1-Qyqbv9Uab8AHmPTSUmqCnAYGh6w=",
       "dev": true
     },
     "slash": {
-      "version": "1.0.0",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+      "version": "1.0.0"
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
     "slide": {
       "version": "1.1.6",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
     },
     "snake-case": {
-      "version": "1.1.2",
-      "integrity": "sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=",
-      "requires": {
-        "sentence-case": "1.1.3"
-      }
+      "version": "1.1.2"
     },
     "sntp": {
-      "version": "2.1.0",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.2.0"
-      }
+      "version": "2.1.0"
     },
     "social-logos": {
-      "version": "2.0.0",
-      "integrity": "sha1-5x71006P0BSpRaI+VdBu+k4Ctr0="
+      "version": "2.0.0"
     },
     "socket.io": {
       "version": "1.4.5",
-      "integrity": "sha1-8gL0nuuc989sCXGtddjZbUUepPc=",
-      "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "engine.io": "1.6.8",
-        "has-binary": "0.1.7",
-        "socket.io-adapter": "0.4.0",
-        "socket.io-client": "1.4.5",
-        "socket.io-parser": "2.2.6"
-      }
+      "dev": true
     },
     "socket.io-adapter": {
       "version": "0.4.0",
-      "integrity": "sha1-+5+CqxqmUpC/csNleVW5MKmRok8=",
       "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "socket.io-parser": "2.2.2"
-      },
       "dependencies": {
         "component-emitter": {
           "version": "1.1.2",
-          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
           "dev": true
         },
         "isarray": {
           "version": "0.0.1",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "json3": {
           "version": "3.2.6",
-          "integrity": "sha1-9u/JPAagTemuxTBT3yVZuxniA4s=",
           "dev": true
         },
         "socket.io-parser": {
           "version": "2.2.2",
-          "integrity": "sha1-PXr2tkSX6Va32f53X5mXFgJ/lBc=",
           "dev": true,
-          "requires": {
-            "benchmark": "1.0.0",
-            "component-emitter": "1.1.2",
-            "debug": "0.7.4",
-            "isarray": "0.0.1",
-            "json3": "3.2.6"
-          },
           "dependencies": {
             "debug": {
               "version": "0.7.4",
-              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
               "dev": true
             }
           }
@@ -13335,1735 +6568,868 @@
       }
     },
     "socket.io-client": {
-      "version": "1.4.5",
-      "integrity": "sha1-QA1jDDHnyVeeRRc/l35PW9jcfS4=",
-      "requires": {
-        "backo2": "1.0.2",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.0",
-        "debug": "2.2.0",
-        "engine.io-client": "1.6.8",
-        "has-binary": "0.1.7",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseuri": "0.0.4",
-        "socket.io-parser": "2.2.6",
-        "to-array": "0.1.4"
-      }
+      "version": "1.4.5"
     },
     "socket.io-parser": {
       "version": "2.2.6",
-      "integrity": "sha1-ON/WHfUNz4qx2eIJEyK/kCuii5k=",
-      "requires": {
-        "benchmark": "1.0.0",
-        "component-emitter": "1.1.2",
-        "debug": "2.2.0",
-        "isarray": "0.0.1",
-        "json3": "3.3.2"
-      },
       "dependencies": {
         "component-emitter": {
-          "version": "1.1.2",
-          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+          "version": "1.1.2"
         },
         "isarray": {
-          "version": "0.0.1",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "version": "0.0.1"
         }
       }
     },
     "source-list-map": {
-      "version": "0.1.8",
-      "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY="
+      "version": "0.1.8"
     },
     "source-map": {
-      "version": "0.1.39",
-      "integrity": "sha1-ZK0ynEdhq5Vv99ARxrIFrrZqLUo=",
-      "requires": {
-        "amdefine": "1.0.1"
-      }
+      "version": "0.1.39"
     },
     "source-map-support": {
       "version": "0.3.2",
-      "integrity": "sha1-c31ckB4LeP21OspxPSTyPMuxC+E=",
-      "requires": {
-        "source-map": "0.1.32"
-      },
       "dependencies": {
         "source-map": {
-          "version": "0.1.32",
-          "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "version": "0.1.32"
         }
       }
     },
     "sparkles": {
       "version": "1.0.0",
-      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
       "dev": true
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "requires": {
-        "spdx-license-ids": "1.2.2"
-      }
+      "version": "1.0.2"
     },
     "spdx-expression-parse": {
-      "version": "1.0.4",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+      "version": "1.0.4"
     },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+      "version": "1.2.2"
     },
     "specificity": {
       "version": "0.2.1",
-      "integrity": "sha1-OnBHwqF581Ni45kHRc6lOfFRYbg=",
       "dev": true
     },
     "split": {
-      "version": "0.3.3",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "requires": {
-        "through": "2.3.8"
-      }
+      "version": "0.3.3"
     },
     "split2": {
       "version": "0.2.1",
-      "integrity": "sha1-At2smtwD7Au3jBKC7Aecpuha6QA=",
-      "dev": true,
-      "requires": {
-        "through2": "0.6.5"
-      }
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.1",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      }
+      "version": "1.13.1"
     },
     "ssri": {
-      "version": "5.0.0",
-      "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+      "version": "5.0.0"
     },
     "stable": {
       "version": "0.1.6",
-      "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA=",
       "dev": true
     },
     "statuses": {
-      "version": "1.4.0",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+      "version": "1.4.0"
     },
     "stdin": {
       "version": "0.0.1",
-      "integrity": "sha1-0wQZgarsPf28d6GzjWNy449ftx4=",
       "dev": true
     },
     "stdout-stream": {
       "version": "1.4.0",
-      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
-      "requires": {
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3"
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "version": "2.3.3"
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "store": {
-      "version": "1.3.16",
-      "integrity": "sha1-Tc/RiVRjfNrExqBF4DX1Y2E103Y="
+      "version": "1.3.16"
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-      "requires": {
-        "inherits": "2.0.1",
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "readable-stream": {
           "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          },
           "dependencies": {
             "inherits": {
-              "version": "2.0.3",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "version": "2.0.3"
             }
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "stream-combiner": {
-      "version": "0.0.4",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "requires": {
-        "duplexer": "0.1.1"
-      }
+      "version": "0.0.4"
     },
     "stream-each": {
-      "version": "1.2.2",
-      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
-      "requires": {
-        "end-of-stream": "1.4.0",
-        "stream-shift": "1.0.0"
-      }
+      "version": "1.2.2"
     },
     "stream-http": {
       "version": "2.7.2",
-      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
-      "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.1",
-        "readable-stream": "2.3.3",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
-      },
       "dependencies": {
         "readable-stream": {
           "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          },
           "dependencies": {
             "inherits": {
-              "version": "2.0.3",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "version": "2.0.3"
             }
           }
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+      "version": "1.0.0"
+    },
+    "string_decoder": {
+      "version": "0.10.31"
     },
     "string-kit": {
       "version": "0.6.4",
-      "integrity": "sha512-imrOojdsXlL6xzfERCxvc/iA9Zwpzbfs+qeP6VB0s0rQVnMc3Nwkyhge0e8Uoayph7PVAwPNmLpohox27G3fgA==",
-      "dev": true,
-      "requires": {
-        "xregexp": "3.2.0"
-      }
+      "dev": true
     },
     "string-length": {
       "version": "2.0.0",
-      "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
-      "requires": {
-        "astral-regex": "1.0.0",
-        "strip-ansi": "4.0.0"
-      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
+          "dev": true
         }
       }
     },
     "string-width": {
-      "version": "1.0.2",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
-      }
+      "version": "1.0.2"
     },
     "string.prototype.padend": {
-      "version": "3.0.0",
-      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
-      }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "version": "3.0.0"
     },
     "stringmap": {
       "version": "0.2.2",
-      "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE=",
       "dev": true
     },
     "stringset": {
       "version": "0.2.1",
-      "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
       "dev": true
     },
     "stringstream": {
-      "version": "0.0.5",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+      "version": "0.0.5"
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "version": "3.0.1"
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "requires": {
-        "is-utf8": "0.2.1"
-      }
+      "version": "2.0.0"
     },
     "strip-eof": {
-      "version": "1.0.0",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+      "version": "1.0.0"
     },
     "strip-indent": {
-      "version": "1.0.1",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "requires": {
-        "get-stdin": "4.0.1"
-      }
+      "version": "1.0.1"
     },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "version": "2.0.1"
     },
     "striptags": {
-      "version": "2.1.1",
-      "integrity": "sha1-53G4sxk7l7vtOS3KWaeCedPIpqY="
+      "version": "2.1.1"
     },
     "stylehacks": {
       "version": "2.3.2",
-      "integrity": "sha1-ZMg+BDimjJ7fRJ6MVSp9mrYAmws=",
       "dev": true,
-      "requires": {
-        "browserslist": "1.3.6",
-        "chalk": "1.1.3",
-        "log-symbols": "1.0.2",
-        "minimist": "1.2.0",
-        "plur": "2.1.2",
-        "postcss": "5.2.18",
-        "postcss-reporter": "1.4.1",
-        "postcss-selector-parser": "2.2.3",
-        "read-file-stdin": "0.2.1",
-        "text-table": "0.2.0",
-        "write-file-stdout": "0.0.2"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "stylelint": {
       "version": "6.9.0",
-      "integrity": "sha1-LSOHCXwetU5uMjuMSGdyXaXgIUg=",
       "dev": true,
-      "requires": {
-        "autoprefixer": "6.3.5",
-        "balanced-match": "0.4.2",
-        "chalk": "1.1.3",
-        "colorguard": "1.2.0",
-        "cosmiconfig": "1.1.0",
-        "doiuse": "2.6.0",
-        "execall": "1.0.0",
-        "get-stdin": "5.0.1",
-        "globby": "5.0.0",
-        "globjoin": "0.1.4",
-        "html-tags": "1.2.0",
-        "htmlparser2": "3.9.2",
-        "lodash": "4.15.0",
-        "log-symbols": "1.0.2",
-        "meow": "3.7.0",
-        "multimatch": "2.1.0",
-        "normalize-selector": "0.2.0",
-        "postcss": "5.2.18",
-        "postcss-less": "0.14.0",
-        "postcss-reporter": "1.4.1",
-        "postcss-resolve-nested-selector": "0.1.1",
-        "postcss-scss": "0.1.9",
-        "postcss-selector-parser": "2.2.3",
-        "postcss-value-parser": "3.3.0",
-        "resolve-from": "2.0.0",
-        "specificity": "0.2.1",
-        "string-width": "1.0.2",
-        "stylehacks": "2.3.2",
-        "sugarss": "0.1.6",
-        "svg-tags": "1.0.0",
-        "table": "3.8.3"
-      },
       "dependencies": {
         "balanced-match": {
           "version": "0.4.2",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "cosmiconfig": {
           "version": "1.1.0",
-          "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "js-yaml": "3.10.0",
-            "minimist": "1.2.0",
-            "object-assign": "4.1.1",
-            "os-homedir": "1.0.2",
-            "parse-json": "2.2.0",
-            "pinkie-promise": "2.0.1",
-            "require-from-string": "1.2.1"
-          }
+          "dev": true
         },
         "get-stdin": {
           "version": "5.0.1",
-          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
           "dev": true
         },
         "globby": {
           "version": "5.0.0",
-          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "dev": true,
-          "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.0.3",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "pify": {
           "version": "2.3.0",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "postcss-less": {
           "version": "0.14.0",
-          "integrity": "sha1-xjGwicbM5CK5oQ86lY0r7dOBkyQ=",
-          "dev": true,
-          "requires": {
-            "postcss": "5.2.18"
-          }
+          "dev": true
         },
         "postcss-scss": {
           "version": "0.1.9",
-          "integrity": "sha1-dgbK/2S7SzS3YFq3SVdM942Iawg=",
-          "dev": true,
-          "requires": {
-            "postcss": "5.2.18"
-          }
+          "dev": true
         },
         "require-from-string": {
           "version": "1.2.1",
-          "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "sugarss": {
       "version": "0.1.6",
-      "integrity": "sha1-/jrA4eBygq7x3oSoC3I4b/Tn6jc=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.18"
-      }
+      "dev": true
     },
     "superagent": {
       "version": "2.1.0",
-      "integrity": "sha1-cfOYNnx1jyFlysb9kI1JwrmpFxo=",
-      "requires": {
-        "component-emitter": "1.2.0",
-        "cookiejar": "2.1.1",
-        "debug": "2.2.0",
-        "extend": "3.0.1",
-        "form-data": "1.0.0-rc4",
-        "formidable": "1.1.1",
-        "methods": "1.1.2",
-        "mime": "1.3.4",
-        "qs": "6.5.1",
-        "readable-stream": "2.3.3"
-      },
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+          "version": "1.5.2"
         },
         "form-data": {
-          "version": "1.0.0-rc4",
-          "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
-          "requires": {
-            "async": "1.5.2",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
+          "version": "1.0.0-rc4"
         },
         "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3"
         },
         "qs": {
-          "version": "6.5.1",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+          "version": "6.5.1"
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "version": "2.3.3"
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "supertest": {
       "version": "2.0.0",
-      "integrity": "sha1-Bg4Y7a5W49YrlcbpxOKl5OUJef8=",
-      "dev": true,
-      "requires": {
-        "methods": "1.1.2",
-        "superagent": "2.1.0"
-      }
+      "dev": true
     },
     "supports-color": {
-      "version": "3.2.3",
-      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-      "requires": {
-        "has-flag": "1.0.0"
-      }
+      "version": "3.2.3"
     },
     "svg-tags": {
       "version": "1.0.0",
-      "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
     },
     "swap-case": {
-      "version": "1.1.2",
-      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
-      "requires": {
-        "lower-case": "1.1.4",
-        "upper-case": "1.1.3"
-      }
+      "version": "1.1.2"
     },
     "symbol-tree": {
       "version": "3.2.2",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
     "sync-exec": {
       "version": "0.5.0",
-      "integrity": "sha1-P3JY5KW6FyRTgZCfpqb2z1BuFmE=",
       "dev": true
     },
     "synesthesia": {
       "version": "1.0.1",
-      "integrity": "sha1-XvlepUjA1cbm+btLDQcx3/hkp3c=",
-      "dev": true,
-      "requires": {
-        "css-color-names": "0.0.3"
-      }
+      "dev": true
     },
     "table": {
       "version": "3.8.3",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
-      "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.15.0",
-        "slice-ansi": "0.0.4",
-        "string-width": "2.1.1"
-      },
       "dependencies": {
         "ajv": {
           "version": "4.11.8",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
+          "dev": true
         },
         "ajv-keywords": {
           "version": "1.5.1",
-          "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
           "dependencies": {
             "strip-ansi": {
               "version": "4.0.0",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
+              "dev": true
             }
           }
         },
         "supports-color": {
           "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "tapable": {
-      "version": "0.2.8",
-      "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
+      "version": "0.2.8"
     },
     "tar": {
-      "version": "2.2.1",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.1"
-      }
+      "version": "2.2.1"
     },
     "tar-fs": {
-      "version": "1.16.0",
-      "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
-      "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.5.5"
-      }
+      "version": "1.16.0"
     },
     "tar-stream": {
       "version": "1.5.5",
-      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
-      "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
-      },
       "dependencies": {
         "inherits": {
-          "version": "2.0.3",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "version": "2.0.3"
         },
         "readable-stream": {
-          "version": "2.3.3",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "version": "2.3.3"
         },
         "string_decoder": {
-          "version": "1.0.3",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "version": "1.0.3"
         }
       }
     },
     "temp": {
       "version": "0.8.3",
-      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
-      "requires": {
-        "os-tmpdir": "1.0.2",
-        "rimraf": "2.2.8"
-      },
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
       }
     },
     "terminal-kit": {
       "version": "1.13.13",
-      "integrity": "sha512-6A8b5OJd9oMLvbfPIaRr4F+FBnuH4/sQQPlVCnhbuQ+EwAyUbFB9Z+KTuivtmbWOUErXIYtlQ8t36+YBz5T2vA==",
-      "dev": true,
-      "requires": {
-        "async-kit": "2.2.3",
-        "get-pixels": "3.3.0",
-        "ndarray": "1.0.18",
-        "nextgen-events": "0.10.2",
-        "string-kit": "0.6.4",
-        "tree-kit": "0.5.26"
-      }
+      "dev": true
     },
     "test-exclude": {
       "version": "4.1.1",
-      "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
-      "dev": true,
-      "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "require-main-filename": "1.0.1"
-      }
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "throat": {
       "version": "4.1.0",
-      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
     "through": {
-      "version": "2.3.8",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "version": "2.3.8"
     },
     "through2": {
       "version": "0.6.5",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-      "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "4.0.1"
-      },
       "dependencies": {
         "isarray": {
-          "version": "0.0.1",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "version": "0.0.1"
         },
         "readable-stream": {
-          "version": "1.0.34",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "version": "1.0.34"
         }
       }
     },
     "time-stamp": {
       "version": "1.1.0",
-      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
       "dev": true
     },
     "timed-out": {
       "version": "2.0.0",
-      "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.4",
-      "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
-      "requires": {
-        "setimmediate": "1.0.5"
-      }
+      "version": "2.0.4"
     },
     "tiny-emitter": {
-      "version": "1.2.0",
-      "integrity": "sha1-bchFBSywjr78GHRyO1jySmSMO28="
+      "version": "1.2.0"
     },
     "tinymce": {
-      "version": "4.6.3",
-      "integrity": "sha1-lK0k6tTxOTjAkDr9L/RpwLZVYj4="
+      "version": "4.6.3"
     },
     "title-case": {
-      "version": "1.1.2",
-      "integrity": "sha1-+uSmrlRr+iLQg6DuqRCkDRLtT1o=",
-      "requires": {
-        "sentence-case": "1.1.3",
-        "upper-case": "1.1.3"
-      }
+      "version": "1.1.2"
     },
     "title-case-minors": {
-      "version": "0.0.2",
-      "integrity": "sha1-VaGhz0bM9S7kgjqaBx1rs7j5D4k="
+      "version": "0.0.2"
     },
     "tmpl": {
       "version": "1.0.4",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
     "to-array": {
-      "version": "0.1.4",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+      "version": "0.1.4"
     },
     "to-arraybuffer": {
-      "version": "1.0.1",
-      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+      "version": "1.0.1"
     },
     "to-camel-case": {
-      "version": "1.0.0",
-      "integrity": "sha1-GlYFSy+daWKYzmamCJcyK29CPkY=",
-      "requires": {
-        "to-space-case": "1.0.0"
-      }
+      "version": "1.0.0"
     },
     "to-capital-case": {
       "version": "0.1.1",
-      "integrity": "sha1-fgS22Bo8Cr/jCoxKhqF1vd9CjA0=",
-      "requires": {
-        "to-no-case": "0.1.1"
-      },
       "dependencies": {
         "to-no-case": {
-          "version": "0.1.1",
-          "integrity": "sha1-zzPHDg8oFo2V5BWavxUOjFQu+f4="
+          "version": "0.1.1"
         }
       }
     },
     "to-fast-properties": {
-      "version": "1.0.3",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "version": "1.0.3"
     },
     "to-no-case": {
-      "version": "1.0.2",
-      "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
+      "version": "1.0.2"
     },
     "to-space-case": {
-      "version": "1.0.0",
-      "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
-      "requires": {
-        "to-no-case": "1.0.2"
-      }
+      "version": "1.0.0"
     },
     "to-title-case": {
-      "version": "0.1.5",
-      "integrity": "sha1-AIHfk7KrJ0+fauljredxp8MjRTw=",
-      "requires": {
-        "escape-regexp-component": "1.0.2",
-        "title-case-minors": "0.0.2",
-        "to-capital-case": "0.1.1"
-      }
+      "version": "0.1.5"
     },
     "token-stream": {
-      "version": "0.0.1",
-      "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
+      "version": "0.0.1"
     },
     "tough-cookie": {
-      "version": "2.3.3",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "requires": {
-        "punycode": "1.4.1"
-      }
+      "version": "2.3.3"
     },
     "tr46": {
       "version": "0.0.3",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
       "dev": true
     },
     "tracekit": {
-      "version": "0.4.3",
-      "integrity": "sha1-moxDxIonW9stVaRa1B0KJI8xit8="
+      "version": "0.4.3"
     },
     "tree-kit": {
       "version": "0.5.26",
-      "integrity": "sha1-hXHIb6JNHbdU5bDLOn4J9B50qN8=",
       "dev": true
     },
     "trim-newlines": {
-      "version": "1.0.0",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+      "version": "1.0.0"
     },
     "trim-right": {
-      "version": "1.0.1",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+      "version": "1.0.1"
     },
     "try-resolve": {
       "version": "1.0.1",
-      "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI=",
-      "dev": true
-    },
-    "tryit": {
-      "version": "1.0.3",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
     "tryor": {
       "version": "0.1.2",
-      "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys=",
       "dev": true
     },
     "tty-browserify": {
-      "version": "0.0.0",
-      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+      "version": "0.0.0"
     },
     "tunnel-agent": {
-      "version": "0.6.0",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+      "version": "0.6.0"
     },
     "tween.js": {
-      "version": "16.3.1",
-      "integrity": "sha1-5VUw3c+d6RObi1glTRyeUMdy30U="
+      "version": "16.3.1"
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
     "twemoji": {
-      "version": "2.3.0",
-      "integrity": "sha1-RbSvQpLULy/fLY7FuG1aiplrwBg="
+      "version": "2.3.0"
     },
     "type-check": {
       "version": "0.3.2",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
+      "dev": true
     },
     "type-detect": {
       "version": "1.0.0",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
     },
     "type-is": {
-      "version": "1.6.15",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
-      }
+      "version": "1.6.15"
     },
     "typedarray": {
-      "version": "0.0.6",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "version": "0.0.6"
     },
     "typescript": {
       "version": "2.5.3",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
       "dev": true
     },
     "typescript-eslint-parser": {
-      "version": "git://github.com/eslint/typescript-eslint-parser.git#9c71a627da36e97da52ed2731d58509c952b67ae",
+      "version": "8.0.0",
+      "from": "git://github.com/eslint/typescript-eslint-parser.git#9c71a627da36e97da52ed2731d58509c952b67ae",
+      "resolved": "git://github.com/eslint/typescript-eslint-parser.git#9c71a627da36e97da52ed2731d58509c952b67ae",
       "dev": true,
-      "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.4.1"
-      },
       "dependencies": {
         "semver": {
           "version": "5.4.1",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         }
       }
     },
     "ua-parser-js": {
-      "version": "0.7.17",
-      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+      "version": "0.7.17"
     },
     "uglify-js": {
       "version": "2.6.4",
-      "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
-      "requires": {
-        "async": "0.2.10",
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
-      },
       "dependencies": {
         "async": {
-          "version": "0.2.10",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+          "version": "0.2.10"
         },
         "source-map": {
-          "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.5.7"
         }
       }
     },
     "uglify-to-browserify": {
-      "version": "1.0.2",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
+      "version": "1.0.2"
     },
     "uglifyjs-webpack-plugin": {
       "version": "1.0.1",
-      "integrity": "sha512-3IJhab8Xq7s6XqoPiVFuDpijefJsIrzACT4ggDErSxJAsB9GLDyuWpN7vuX4Lslu/nzIRz2NyXNX/fRMOgqRFw==",
-      "requires": {
-        "cacache": "10.0.1",
-        "find-cache-dir": "1.0.0",
-        "schema-utils": "0.3.0",
-        "source-map": "0.5.7",
-        "uglify-es": "3.2.2",
-        "webpack-sources": "1.1.0",
-        "worker-farm": "1.5.2"
-      },
       "dependencies": {
         "commander": {
-          "version": "2.12.2",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+          "version": "2.12.2"
         },
         "source-list-map": {
-          "version": "2.0.0",
-          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+          "version": "2.0.0"
         },
         "source-map": {
-          "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.5.7"
         },
         "uglify-es": {
           "version": "3.2.2",
-          "integrity": "sha512-l+s5VLzFwGJfS+fbqaGf/Dfwo1MF13jLOF2ekL0PytzqEqQ6cVppvHf4jquqFok+35USMpKjqkYxy6pQyUcuug==",
-          "requires": {
-            "commander": "2.12.2",
-            "source-map": "0.6.1"
-          },
           "dependencies": {
             "source-map": {
-              "version": "0.6.1",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+              "version": "0.6.1"
             }
           }
         },
         "webpack-sources": {
           "version": "1.1.0",
-          "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
-          "requires": {
-            "source-list-map": "2.0.0",
-            "source-map": "0.6.1"
-          },
           "dependencies": {
             "source-map": {
-              "version": "0.6.1",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+              "version": "0.6.1"
             }
           }
         }
       }
     },
     "uid": {
-      "version": "0.0.2",
-      "integrity": "sha1-XkpdS3gTi09w+J/Tx2/FmqnS8QM="
+      "version": "0.0.2"
     },
     "ultron": {
-      "version": "1.0.2",
-      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+      "version": "1.0.2"
     },
     "underscore": {
       "version": "1.6.0",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
       "dev": true
     },
     "uniq": {
       "version": "1.0.1",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
     "unique-filename": {
-      "version": "1.1.0",
-      "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
-      "requires": {
-        "unique-slug": "2.0.0"
-      }
+      "version": "1.1.0"
     },
     "unique-slug": {
-      "version": "2.0.0",
-      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-      "requires": {
-        "imurmurhash": "0.1.4"
-      }
+      "version": "2.0.0"
     },
     "unpipe": {
-      "version": "1.0.0",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "version": "1.0.0"
     },
     "unquoted-property-validator": {
       "version": "1.0.2",
-      "integrity": "sha512-LokWcfN2q9UnQTTIpRkTZNsLVVO2KaXeO3oUMQ7JShGhMdO8P+zN1MfrPMf1IwR/Cyh283lGaxbRcNGyq2IXYQ==",
       "dev": true
     },
     "unreachable-branch-transform": {
       "version": "0.3.0",
-      "integrity": "sha1-2ZzExudG0mSSiEW2EdtUsPNHTKo=",
-      "requires": {
-        "esmangle-evaluator": "1.0.1",
-        "recast": "0.10.43",
-        "through2": "0.6.5"
-      },
       "dependencies": {
         "ast-types": {
-          "version": "0.8.15",
-          "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI="
+          "version": "0.8.15"
         },
         "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+          "version": "15001.1001.0-dev-harmony-fb"
         },
         "recast": {
-          "version": "0.10.43",
-          "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
-          "requires": {
-            "ast-types": "0.8.15",
-            "esprima-fb": "15001.1001.0-dev-harmony-fb",
-            "private": "0.1.8",
-            "source-map": "0.5.7"
-          }
+          "version": "0.10.43"
         },
         "source-map": {
-          "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.5.7"
         }
       }
     },
     "unzip-response": {
-      "version": "1.0.2",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+      "version": "1.0.2"
     },
     "update-notifier": {
       "version": "0.3.2",
-      "integrity": "sha1-IqhzW6re8zIOLbko9pPaiY3Id3c=",
       "dev": true,
-      "requires": {
-        "chalk": "1.0.0",
-        "configstore": "0.3.2",
-        "is-npm": "1.0.0",
-        "latest-version": "1.0.1",
-        "semver-diff": "2.1.0",
-        "string-length": "1.0.1"
-      },
       "dependencies": {
         "string-length": {
           "version": "1.0.1",
-          "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
-          "dev": true,
-          "requires": {
-            "strip-ansi": "3.0.1"
-          }
+          "dev": true
         }
       }
     },
     "upper-case": {
-      "version": "1.1.3",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+      "version": "1.1.3"
     },
     "upper-case-first": {
-      "version": "1.1.2",
-      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
-      "requires": {
-        "upper-case": "1.1.3"
-      }
+      "version": "1.1.2"
     },
     "uppercamelcase": {
-      "version": "1.1.0",
-      "integrity": "sha1-Mk2YprOvx+iolT4QZBUJsOTiP5c=",
-      "requires": {
-        "camelcase": "1.2.1"
-      }
+      "version": "1.1.0"
     },
     "url": {
       "version": "0.11.0",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
       "dependencies": {
         "punycode": {
-          "version": "1.3.2",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+          "version": "1.3.2"
         }
       }
     },
     "user-home": {
       "version": "1.1.1",
-      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
       "dev": true
     },
     "utf8": {
-      "version": "2.1.0",
-      "integrity": "sha1-DP7FyAUtRKI+OqqQgQToB1+V39U="
+      "version": "2.1.0"
     },
     "util": {
-      "version": "0.10.3",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "requires": {
-        "inherits": "2.0.1"
-      }
+      "version": "0.10.3"
     },
     "util-deprecate": {
-      "version": "1.0.2",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "version": "1.0.2"
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+      "version": "1.0.0"
     },
     "uuid": {
-      "version": "2.0.1",
-      "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+      "version": "2.0.1"
     },
     "valid-url": {
-      "version": "1.0.9",
-      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
+      "version": "1.0.9"
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
-      }
+      "version": "3.0.1"
     },
     "vary": {
-      "version": "1.0.1",
-      "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA="
+      "version": "1.0.1"
     },
     "verror": {
-      "version": "1.10.0",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      }
+      "version": "1.10.0"
     },
     "vinyl": {
       "version": "0.5.3",
-      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-      "dev": true,
-      "requires": {
-        "clone": "1.0.3",
-        "clone-stats": "0.0.1",
-        "replace-ext": "0.0.1"
-      }
+      "dev": true
     },
     "vm-browserify": {
-      "version": "0.0.4",
-      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "requires": {
-        "indexof": "0.0.1"
-      }
+      "version": "0.0.4"
     },
     "void-elements": {
-      "version": "2.0.1",
-      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
+      "version": "2.0.1"
     },
     "vorpal": {
       "version": "1.12.0",
-      "integrity": "sha1-S+eypOSPj8/JzzZIxBnTEcUiFZ0=",
       "dev": true,
-      "requires": {
-        "babel-polyfill": "6.26.0",
-        "chalk": "1.1.3",
-        "in-publish": "2.0.0",
-        "inquirer": "0.11.0",
-        "lodash": "4.15.0",
-        "log-update": "1.0.2",
-        "minimist": "1.2.0",
-        "node-localstorage": "0.6.0",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "vorpal-autocomplete-fs": {
       "version": "0.0.3",
-      "integrity": "sha1-15b3sr1A2LbdxkE69M/QFv9QnQE=",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "strip-ansi": "3.0.1"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "walk": {
-      "version": "2.3.4",
-      "integrity": "sha1-Bs4VQVNTE+iswo6S60Jem2T0xQA=",
-      "requires": {
-        "foreachasync": "3.0.0"
-      }
+      "version": "2.3.4"
     },
     "walker": {
       "version": "1.0.7",
-      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-      "dev": true,
-      "requires": {
-        "makeerror": "1.0.11"
-      }
+      "dev": true
     },
     "warning": {
-      "version": "3.0.0",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
+      "version": "3.0.0"
     },
     "watch": {
       "version": "0.18.0",
-      "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
       "dev": true,
-      "requires": {
-        "exec-sh": "0.2.1",
-        "minimist": "1.2.0"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
     },
     "watchpack": {
       "version": "1.4.0",
-      "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
-      "requires": {
-        "async": "2.6.0",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
-      },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-          "requires": {
-            "lodash": "4.15.0"
-          }
+          "version": "2.6.0"
         }
       }
     },
     "webidl-conversions": {
       "version": "4.0.2",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
     },
     "webpack": {
       "version": "3.8.1",
-      "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
-      "requires": {
-        "acorn": "5.2.1",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.5.1",
-        "ajv-keywords": "2.1.1",
-        "async": "2.6.0",
-        "enhanced-resolve": "3.4.1",
-        "escope": "3.6.0",
-        "interpret": "1.1.0",
-        "json-loader": "0.5.4",
-        "json5": "0.5.1",
-        "loader-runner": "2.3.0",
-        "loader-utils": "1.1.0",
-        "memory-fs": "0.4.1",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "4.5.0",
-        "tapable": "0.2.8",
-        "uglifyjs-webpack-plugin": "0.4.6",
-        "watchpack": "1.4.0",
-        "webpack-sources": "1.1.0",
-        "yargs": "8.0.2"
-      },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+          "version": "5.2.1"
         },
         "ansi-regex": {
-          "version": "3.0.0",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "version": "3.0.0"
         },
         "async": {
-          "version": "2.6.0",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-          "requires": {
-            "lodash": "4.15.0"
-          }
+          "version": "2.6.0"
         },
         "has-flag": {
-          "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+          "version": "2.0.0"
         },
         "load-json-file": {
-          "version": "2.0.0",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
+          "version": "2.0.0"
         },
         "os-locale": {
-          "version": "2.1.0",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
+          "version": "2.1.0"
         },
         "path-type": {
-          "version": "2.0.0",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "requires": {
-            "pify": "2.3.0"
-          }
+          "version": "2.0.0"
         },
         "pify": {
-          "version": "2.3.0",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "version": "2.3.0"
         },
         "read-pkg": {
-          "version": "2.0.0",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
+          "version": "2.0.0"
         },
         "read-pkg-up": {
-          "version": "2.0.0",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
+          "version": "2.0.0"
         },
         "source-list-map": {
-          "version": "2.0.0",
-          "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+          "version": "2.0.0"
         },
         "source-map": {
-          "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.5.7"
         },
         "string-width": {
           "version": "2.1.1",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
           "dependencies": {
             "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+              "version": "2.0.0"
             },
             "strip-ansi": {
-              "version": "4.0.0",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
+              "version": "4.0.0"
             }
           }
         },
         "strip-bom": {
-          "version": "3.0.0",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+          "version": "3.0.0"
         },
         "supports-color": {
-          "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "version": "4.5.0"
         },
         "uglify-js": {
           "version": "2.8.29",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
           "dependencies": {
             "yargs": {
-              "version": "3.10.0",
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-              "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
-                "window-size": "0.1.0"
-              }
+              "version": "3.10.0"
             }
           }
         },
         "uglifyjs-webpack-plugin": {
-          "version": "0.4.6",
-          "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-js": "2.8.29",
-            "webpack-sources": "1.1.0"
-          }
+          "version": "0.4.6"
         },
         "webpack-sources": {
           "version": "1.1.0",
-          "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
-          "requires": {
-            "source-list-map": "2.0.0",
-            "source-map": "0.6.1"
-          },
           "dependencies": {
             "source-map": {
-              "version": "0.6.1",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+              "version": "0.6.1"
             }
           }
         },
         "which-module": {
-          "version": "2.0.0",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+          "version": "2.0.0"
         },
         "yargs": {
           "version": "8.0.2",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-          "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
-          },
           "dependencies": {
             "camelcase": {
-              "version": "4.1.0",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+              "version": "4.1.0"
             },
             "cliui": {
               "version": "3.2.0",
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-              "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
-              },
               "dependencies": {
                 "string-width": {
-                  "version": "1.0.2",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  }
+                  "version": "1.0.2"
                 }
               }
             }
@@ -15071,14 +7437,9 @@
         },
         "yargs-parser": {
           "version": "7.0.0",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "requires": {
-            "camelcase": "4.1.0"
-          },
           "dependencies": {
             "camelcase": {
-              "version": "4.1.0",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+              "version": "4.1.0"
             }
           }
         }
@@ -15086,312 +7447,158 @@
     },
     "webpack-bundle-analyzer": {
       "version": "2.8.2",
-      "integrity": "sha1-i2JAwpqdY7xy8J2SD7BQrbzOn+g=",
       "dev": true,
-      "requires": {
-        "acorn": "5.2.1",
-        "chalk": "1.1.3",
-        "commander": "2.12.2",
-        "ejs": "2.5.7",
-        "express": "4.16.2",
-        "filesize": "3.5.11",
-        "gzip-size": "3.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "opener": "1.4.3",
-        "ws": "2.3.1"
-      },
       "dependencies": {
         "accepts": {
           "version": "1.3.4",
-          "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
-          "dev": true,
-          "requires": {
-            "mime-types": "2.1.17",
-            "negotiator": "0.6.1"
-          }
+          "dev": true
         },
         "acorn": {
           "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
           "dev": true
         },
         "body-parser": {
           "version": "1.18.2",
-          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-          "dev": true,
-          "requires": {
-            "bytes": "3.0.0",
-            "content-type": "1.0.4",
-            "debug": "2.6.9",
-            "depd": "1.1.1",
-            "http-errors": "1.6.2",
-            "iconv-lite": "0.4.19",
-            "on-finished": "2.3.0",
-            "qs": "6.5.1",
-            "raw-body": "2.3.2",
-            "type-is": "1.6.15"
-          }
+          "dev": true
         },
         "bytes": {
           "version": "3.0.0",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.3",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "commander": {
           "version": "2.12.2",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
           "dev": true
         },
         "content-disposition": {
           "version": "0.5.2",
-          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
           "dev": true
         },
         "cookie": {
           "version": "0.3.1",
-          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
           "dev": true
         },
         "cookie-signature": {
           "version": "1.0.6",
-          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
           "dev": true
         },
         "debug": {
           "version": "2.6.9",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "dev": true
         },
         "destroy": {
           "version": "1.0.4",
-          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
           "dev": true
         },
         "escape-html": {
           "version": "1.0.3",
-          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
           "dev": true
         },
         "etag": {
           "version": "1.8.1",
-          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
           "dev": true
         },
         "express": {
           "version": "4.16.2",
-          "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
-          "dev": true,
-          "requires": {
-            "accepts": "1.3.4",
-            "array-flatten": "1.1.1",
-            "body-parser": "1.18.2",
-            "content-disposition": "0.5.2",
-            "content-type": "1.0.4",
-            "cookie": "0.3.1",
-            "cookie-signature": "1.0.6",
-            "debug": "2.6.9",
-            "depd": "1.1.1",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
-            "finalhandler": "1.1.0",
-            "fresh": "0.5.2",
-            "merge-descriptors": "1.0.1",
-            "methods": "1.1.2",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "path-to-regexp": "0.1.7",
-            "proxy-addr": "2.0.2",
-            "qs": "6.5.1",
-            "range-parser": "1.2.0",
-            "safe-buffer": "5.1.1",
-            "send": "0.16.1",
-            "serve-static": "1.13.1",
-            "setprototypeof": "1.1.0",
-            "statuses": "1.3.1",
-            "type-is": "1.6.15",
-            "utils-merge": "1.0.1",
-            "vary": "1.1.2"
-          }
+          "dev": true
         },
         "filesize": {
           "version": "3.5.11",
-          "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
           "dev": true
         },
         "finalhandler": {
           "version": "1.1.0",
-          "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
-          }
+          "dev": true
         },
         "fresh": {
           "version": "0.5.2",
-          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
           "dev": true
         },
         "iconv-lite": {
           "version": "0.4.19",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
           "dev": true
         },
         "ipaddr.js": {
           "version": "1.5.2",
-          "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
           "dev": true
         },
         "lodash": {
           "version": "4.17.4",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "merge-descriptors": {
           "version": "1.0.1",
-          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
           "dev": true
         },
         "mime": {
           "version": "1.4.1",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "negotiator": {
           "version": "0.6.1",
-          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
           "dev": true
         },
         "proxy-addr": {
           "version": "2.0.2",
-          "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
-          "dev": true,
-          "requires": {
-            "forwarded": "0.1.2",
-            "ipaddr.js": "1.5.2"
-          }
+          "dev": true
         },
         "qs": {
           "version": "6.5.1",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
           "dev": true
         },
         "range-parser": {
           "version": "1.2.0",
-          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
           "dev": true
         },
         "raw-body": {
           "version": "2.3.2",
-          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-          "dev": true,
-          "requires": {
-            "bytes": "3.0.0",
-            "http-errors": "1.6.2",
-            "iconv-lite": "0.4.19",
-            "unpipe": "1.0.0"
-          }
+          "dev": true
         },
         "send": {
           "version": "0.16.1",
-          "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "depd": "1.1.1",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
-            "fresh": "0.5.2",
-            "http-errors": "1.6.2",
-            "mime": "1.4.1",
-            "ms": "2.0.0",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.3.1"
-          }
+          "dev": true
         },
         "serve-static": {
           "version": "1.13.1",
-          "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
-          "dev": true,
-          "requires": {
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "parseurl": "1.3.2",
-            "send": "0.16.1"
-          }
+          "dev": true
         },
         "setprototypeof": {
           "version": "1.1.0",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
         },
         "statuses": {
           "version": "1.3.1",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "ultron": {
           "version": "1.1.1",
-          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
           "dev": true
         },
         "utils-merge": {
           "version": "1.0.1",
-          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
           "dev": true
         },
         "vary": {
           "version": "1.1.2",
-          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
           "dev": true
         },
         "ws": {
           "version": "2.3.1",
-          "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
           "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1",
-            "ultron": "1.1.1"
-          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
-              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
               "dev": true
             }
           }
@@ -15400,398 +7607,213 @@
     },
     "webpack-core": {
       "version": "0.6.9",
-      "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
-      "requires": {
-        "source-list-map": "0.1.8",
-        "source-map": "0.4.4"
-      },
       "dependencies": {
         "source-map": {
-          "version": "0.4.4",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "version": "0.4.4"
         }
       }
     },
     "webpack-dev-middleware": {
-      "version": "1.11.0",
-      "integrity": "sha1-CWkdCXOjCtH4Ksc6EuIIfwpHVPk=",
-      "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "1.3.4",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.0.3"
-      }
+      "version": "1.11.0"
     },
     "webpack-hot-middleware": {
-      "version": "2.15.0",
-      "integrity": "sha1-cZla98ACXxCd9IL4bx4QN5Um0CY=",
-      "requires": {
-        "ansi-html": "0.0.6",
-        "html-entities": "1.2.1",
-        "querystring": "0.2.0",
-        "strip-ansi": "3.0.1"
-      }
+      "version": "2.15.0"
     },
     "webpack-sources": {
       "version": "0.1.5",
-      "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
-      "requires": {
-        "source-list-map": "0.1.8",
-        "source-map": "0.5.7"
-      },
       "dependencies": {
         "source-map": {
-          "version": "0.5.7",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+          "version": "0.5.7"
         }
       }
     },
     "wemoji": {
-      "version": "0.1.9",
-      "integrity": "sha1-QHSo2p6CdWVNwfKwVe3x3A2wM0I="
+      "version": "0.1.9"
     },
     "whatwg-encoding": {
       "version": "1.0.3",
-      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
       "dev": true,
-      "requires": {
-        "iconv-lite": "0.4.19"
-      },
       "dependencies": {
         "iconv-lite": {
           "version": "0.4.19",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
           "dev": true
         }
       }
     },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "version": "2.0.3"
     },
     "whatwg-url": {
       "version": "4.8.0",
-      "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
       "dev": true,
-      "requires": {
-        "tr46": "0.0.3",
-        "webidl-conversions": "3.0.1"
-      },
       "dependencies": {
         "webidl-conversions": {
           "version": "3.0.1",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
           "dev": true
         }
       }
     },
     "which": {
-      "version": "1.3.0",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "requires": {
-        "isexe": "2.0.0"
-      }
+      "version": "1.3.0"
     },
     "which-module": {
-      "version": "1.0.0",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+      "version": "1.0.0"
     },
     "wide-align": {
-      "version": "1.1.2",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-      "requires": {
-        "string-width": "1.0.2"
-      }
+      "version": "1.1.2"
     },
     "window-size": {
-      "version": "0.1.0",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+      "version": "0.1.0"
     },
     "with": {
       "version": "5.1.1",
-      "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
-      "requires": {
-        "acorn": "3.3.0",
-        "acorn-globals": "3.1.0"
-      },
       "dependencies": {
         "acorn": {
-          "version": "3.3.0",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+          "version": "3.3.0"
         }
       }
     },
     "wordwrap": {
-      "version": "0.0.2",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+      "version": "0.0.2"
     },
     "worker-farm": {
-      "version": "1.5.2",
-      "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
-      "requires": {
-        "errno": "0.1.6",
-        "xtend": "4.0.1"
-      }
+      "version": "1.5.2"
     },
     "wp-error": {
       "version": "1.3.0",
-      "integrity": "sha1-cgJHqjJkJJkcWHdcsv7cm/2IVCA=",
-      "requires": {
-        "builtin-status-codes": "2.0.0",
-        "uppercamelcase": "1.1.0"
-      },
       "dependencies": {
         "builtin-status-codes": {
-          "version": "2.0.0",
-          "integrity": "sha1-byIAO6rPADzNKHr+aHIVH93FhXk="
+          "version": "2.0.0"
         }
       }
     },
     "wpcom": {
       "version": "5.4.0",
-      "integrity": "sha1-aRDXaX6ApLYTl6J/D0CREj7/vGU=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "debug": "2.2.0",
-        "qs": "4.0.0",
-        "wpcom-xhr-request": "1.0.0"
-      },
       "dependencies": {
         "wpcom-xhr-request": {
-          "version": "1.0.0",
-          "integrity": "sha1-YpaJ4G+RaxDxe+ZpMnKsmUsNiyw=",
-          "requires": {
-            "debug": "2.2.0",
-            "superagent": "2.1.0",
-            "wp-error": "1.3.0"
-          }
+          "version": "1.0.0"
         }
       }
     },
     "wpcom-oauth": {
       "version": "0.3.3",
-      "integrity": "sha1-rQt+uARxF6z/Bc7a1suID8CckjY=",
-      "requires": {
-        "debug": "2.2.0",
-        "superagent": "0.17.0"
-      },
       "dependencies": {
         "cookiejar": {
-          "version": "1.3.0",
-          "integrity": "sha1-3QCzVnkCHpnL1OhVua0EGRNHR2U="
+          "version": "1.3.0"
         },
         "extend": {
-          "version": "1.2.1",
-          "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w="
+          "version": "1.2.1"
         },
         "formidable": {
-          "version": "1.0.14",
-          "integrity": "sha1-Kz9MQRy7X91pXESEPiojUUpDIxo="
+          "version": "1.0.14"
         },
         "methods": {
-          "version": "0.0.1",
-          "integrity": "sha1-J3yQ+L7zlwlkWoNxxRw7bGSOBow="
+          "version": "0.0.1"
         },
         "mime": {
-          "version": "1.2.5",
-          "integrity": "sha1-nu0HMCKov14WyFZsaGe4gyv7+hM="
+          "version": "1.2.5"
         },
         "qs": {
-          "version": "0.6.5",
-          "integrity": "sha1-KUsmjksNQlD23eGbO4s0k13/FO8="
+          "version": "0.6.5"
         },
         "superagent": {
           "version": "0.17.0",
-          "integrity": "sha1-qtzVD75ak+cZkRGNeb8HFNYlu6g=",
-          "requires": {
-            "cookiejar": "1.3.0",
-            "debug": "0.7.4",
-            "emitter-component": "1.0.0",
-            "extend": "1.2.1",
-            "formidable": "1.0.14",
-            "methods": "0.0.1",
-            "mime": "1.2.5",
-            "qs": "0.6.5",
-            "reduce-component": "1.0.1"
-          },
           "dependencies": {
             "debug": {
-              "version": "0.7.4",
-              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+              "version": "0.7.4"
             }
           }
         }
       }
     },
     "wpcom-proxy-request": {
-      "version": "4.0.5",
-      "integrity": "sha512-eTt+n4qDvNNybYOMNXCPSehcQUCFENWLANp6th3ST+cwuKjzF6wKuMGQko1sHVPz0VKOCksOf/Ye8+rGPa6eAQ==",
-      "requires": {
-        "component-event": "0.1.4",
-        "debug": "2.2.0",
-        "progress-event": "1.0.0",
-        "uid": "0.0.2",
-        "wp-error": "1.3.0"
-      }
+      "version": "4.0.5"
     },
     "wpcom-xhr-request": {
-      "version": "1.1.1",
-      "integrity": "sha1-GIbjEn1/WAYe+GoYfyqjX2NlKNA=",
-      "requires": {
-        "debug": "2.2.0",
-        "superagent": "2.1.0",
-        "wp-error": "1.3.0"
-      }
+      "version": "1.1.1"
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
-      }
+      "version": "2.1.0"
     },
     "wrappy": {
-      "version": "1.0.2",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "version": "1.0.2"
     },
     "write": {
       "version": "0.2.1",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
+      "dev": true
     },
     "write-file-atomic": {
       "version": "1.3.4",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
-      }
+      "dev": true
     },
     "write-file-stdout": {
       "version": "0.0.2",
-      "integrity": "sha1-wlLXx8WxtAKJdjDjRTx7/mkNnKE=",
       "dev": true
     },
     "ws": {
-      "version": "1.0.1",
-      "integrity": "sha1-fQsqLljN3YGQOcKcneZQReGzEOk=",
-      "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
-      }
+      "version": "1.0.1"
     },
     "xdg-basedir": {
       "version": "1.0.1",
-      "integrity": "sha1-FP+PY6T9vLBdW27qIrNvMDO58E4=",
-      "dev": true,
-      "requires": {
-        "user-home": "1.1.1"
-      }
+      "dev": true
     },
     "xgettext-js": {
       "version": "1.0.0",
-      "integrity": "sha1-zZwElVeUaLH0ODReVEhcOJTqMFc=",
-      "requires": {
-        "babylon": "6.8.4",
-        "estree-walker": "0.2.1",
-        "lodash": "4.15.0"
-      },
       "dependencies": {
         "babylon": {
-          "version": "6.8.4",
-          "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
+          "version": "6.8.4"
         }
       }
     },
     "xml": {
       "version": "1.0.1",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
       "dev": true
     },
     "xml-char-classes": {
-      "version": "1.0.0",
-      "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0="
+      "version": "1.0.0"
     },
     "xml-name-validator": {
       "version": "2.0.1",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.19",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.4"
-      }
+      "version": "0.4.19"
     },
     "xmlbuilder": {
-      "version": "9.0.4",
-      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+      "version": "9.0.4"
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.1",
-      "integrity": "sha1-O3dB/qSoZnWXbpCNKW1ERZYfqmc="
+      "version": "1.5.1"
     },
     "xregexp": {
       "version": "3.2.0",
-      "integrity": "sha1-yzYBmHv+JpW1hAAMGPHEqMMih44=",
       "dev": true
     },
     "xtend": {
-      "version": "4.0.1",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.1"
     },
     "y18n": {
-      "version": "3.2.1",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+      "version": "3.2.1"
     },
     "yallist": {
-      "version": "2.1.2",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "version": "2.1.2"
     },
     "yargs": {
-      "version": "3.10.0",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
-        "window-size": "0.1.0"
-      }
+      "version": "3.10.0"
     },
     "yargs-parser": {
       "version": "5.0.0",
-      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-      "requires": {
-        "camelcase": "3.0.0"
-      },
       "dependencies": {
         "camelcase": {
-          "version": "3.0.0",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+          "version": "3.0.0"
         }
       }
     },
     "yeast": {
-      "version": "0.1.2",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+      "version": "0.1.2"
     },
     "zero-fill": {
-      "version": "2.2.3",
-      "integrity": "sha1-o97wa6XjmuZEhQu0yirUEStIVek="
+      "version": "2.2.3"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "fuse.js": "2.6.1",
     "get-video-id": "2.1.4",
     "globby": "6.1.0",
-    "gridicons": "2.1.0",
+    "gridicons": "2.1.1",
     "happypack": "4.0.0",
     "hard-source-webpack-plugin": "0.3.12",
     "hash.js": "1.1.3",


### PR DESCRIPTION
Following the recent addition of Zoom in/out icons in https://github.com/Automattic/gridicons/pull/268, this PR updates Gridicons to `v2.1.1`.

Tested locally and the icons show up on Devdocs:

![screenshot 2017-12-13 10 47 16](https://user-images.githubusercontent.com/4924246/33956312-0458f5fa-dff3-11e7-86fa-ddd9feb54e3b.png)

Related: https://github.com/Automattic/gridicons/pull/269
