### PR TITLE
Update concierge chats confirmation step

### DIFF
--- a/client/me/concierge/confirmation-step.js
+++ b/client/me/concierge/confirmation-step.js
@@ -11,20 +11,32 @@ import React, { Component } from 'react';
 import Button from 'components/button';
 import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
+import { localize } from 'i18n-calypso';
 
 class ConfirmationStep extends Component {
 	render() {
-		// TODO: Send Button back to site's dashboard
+		const { translate } = this.props;
 		return (
 			<Card>
-				<FormattedHeader
-					headerText="Your Concierge session is booked!"
-					subHeaderText="We will send you an email with information on how to get prepared"
+				<img
+					className="concierge__confirmation-illustration"
+					src={ '/calypso/images/illustrations/support.svg' }
 				/>
-				<Button href="/">Back to your dashboard</Button>
+
+				<FormattedHeader
+					headerText={ translate( 'Your Concierge session is booked!' ) }
+					subHeaderText={ translate(
+						'We will send you an email with information on how to get prepared'
+					) }
+				/>
+
+				<Button className="concierge__confirmation-button" primary={ true } href="/stats">
+					{' '}
+					{ translate( 'Return to your dashboard' ) }
+				</Button>
 			</Card>
 		);
 	}
 }
 
-export default ConfirmationStep;
+export default localize( ConfirmationStep );

--- a/client/me/concierge/confirmation-step.js
+++ b/client/me/concierge/confirmation-step.js
@@ -26,7 +26,7 @@ class ConfirmationStep extends Component {
 				<FormattedHeader
 					headerText={ translate( 'Your Concierge session is booked!' ) }
 					subHeaderText={ translate(
-						'We will send you an email with information on how to get prepared'
+						'We will send you an email with information on how to get prepared.'
 					) }
 				/>
 

--- a/client/me/concierge/confirmation-step.js
+++ b/client/me/concierge/confirmation-step.js
@@ -15,7 +15,7 @@ import { localize } from 'i18n-calypso';
 
 class ConfirmationStep extends Component {
 	render() {
-		const { translate } = this.props;
+		const { site, translate } = this.props;
 		return (
 			<Card>
 				<img
@@ -30,8 +30,11 @@ class ConfirmationStep extends Component {
 					) }
 				/>
 
-				<Button className="concierge__confirmation-button" primary={ true } href="/stats">
-					{' '}
+				<Button
+					className="concierge__confirmation-button"
+					primary={ true }
+					href={ `/stats/day/${ site.slug }` }
+				>
 					{ translate( 'Return to your dashboard' ) }
 				</Button>
 			</Card>

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -27,3 +27,15 @@
 	margin: 0 auto 20px;
 	max-width: 300px;
 }
+
+.concierge__confirmation-illustration {
+	display: block;
+	margin: 0 auto 20px;
+	max-width: 182px;
+}
+
+.concierge__confirmation-button {
+	display: block;
+	margin: 0 auto 40px;
+	max-width: 204px;
+}

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -30,7 +30,7 @@
 
 .concierge__confirmation-illustration {
 	display: block;
-	margin: 0 auto 20px;
+	margin: 50px auto 20px;
 	max-width: 182px;
 }
 


### PR DESCRIPTION
**Built on top of https://github.com/Automattic/wp-calypso/pull/20787**

## Summary
This PR adds the illustration and updates the button styling for the confirmation step.
https://cloudup.com/cv6r7ver7G1

## Testing
**Until the api is fixed you can change this constant https://github.com/Automattic/wp-calypso/blob/master/client/me/concierge/constants.js to 9527 to use mock data.**

1. Pick one of you Business plan sites and pass the slug into the URL: http://calypso.localhost:3000/me/concierge/[biz site url]

2. Select a different timezone and a message

3. Continue to Calendar

4. Book the session

5. Check confirmation page looks as expected