### PR TITLE
Stats: hide sidebar on site selection

### DIFF
--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -189,7 +189,6 @@ export default function() {
 		page(
 			'/stats/(.*)',
 			siteSelection,
-			navigation,
 			statsController.redirectToDefaultSitePage,
 			sites,
 			makeLayout,


### PR DESCRIPTION
Don't show the sidebar when selecting a site for stats/insights.

Fixes regression caused by Automattic/wp-calypso@126f3cff8f0763edec9beab8e32ec6f722d81cef

## Test

Open http://calypso.localhost:3000/stats/insights

Without the fix: you can see site selector + sidebar
With the fix: you see only the site selector

Confirm rest of the `/stats` routes continue working with the sidebar visible.