### PR TITLE
Reader Tags Data Layer: upgrade to dispatchRequestEx, and jest for tests

### DIFF
--- a/client/state/data-layer/wpcom/read/tags/index.js
+++ b/client/state/data-layer/wpcom/read/tags/index.js
@@ -13,56 +13,44 @@ import { receiveTags } from 'state/reader/tags/items/actions';
 import requestFollowHandler from 'state/data-layer/wpcom/read/tags/mine/new';
 import requestUnfollowHandler from 'state/data-layer/wpcom/read/tags/mine/delete';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest, getHeaders } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx, getHeaders } from 'state/data-layer/wpcom-http/utils';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { fromApi } from 'state/data-layer/wpcom/read/tags/utils';
 import { errorNotice } from 'state/notices/actions';
 
-export function requestTags( store, action ) {
+export function requestTags( action ) {
 	const path =
 		action.payload && action.payload.slug ? `/read/tags/${ action.payload.slug }` : '/read/tags';
 
-	store.dispatch(
-		http( {
-			path,
-			method: 'GET',
-			apiVersion: '1.2',
-			onSuccess: action,
-			onFailure: action,
-		} )
-	);
+	return http( {
+		path,
+		method: 'GET',
+		apiVersion: '1.2',
+		onSuccess: action,
+		onFailure: action,
+	} );
 }
 
-export function receiveTagsSuccess( store, action, apiResponse ) {
-	let tags = fromApi( apiResponse );
-	if ( ! apiResponse || ( ! apiResponse.tag && ! apiResponse.tags ) ) {
-		receiveTagsError( store, action, apiResponse );
-		return;
-	}
+const isFollowedTagsRequest = action => ! get( action, 'payload.slug' );
 
-	// if from the read following tags api, then we should add isFollowing=true to all of the tags
-	if ( apiResponse.tags ) {
+export function receiveTagsSuccess( action, tags ) {
+	const isFollowedTags = isFollowedTagsRequest( action );
+	const resetFollowingData = isFollowedTags;
+
+	if ( isFollowedTags ) {
 		tags = map( tags, tag => ( { ...tag, isFollowing: true } ) );
 	}
 
-	store.dispatch(
-		receiveTags( {
-			payload: tags,
-			resetFollowingData: !! apiResponse.tags,
-		} )
-	);
+	return receiveTags( { payload: tags, resetFollowingData } );
 }
 
-export function receiveTagsError( store, action, error ) {
+export function receiveTagsError( action, error ) {
 	// if tag does not exist, refreshing page wont help
 	if ( get( getHeaders( action ), 'status' ) === 404 ) {
 		const slug = action.payload.slug;
-		store.dispatch(
-			receiveTags( {
-				payload: [ { id: slug, slug, error: true } ],
-			} )
-		);
-		return;
+		return receiveTags( {
+			payload: [ { id: slug, slug, error: true } ],
+		} );
 	}
 
 	const errorText =
@@ -70,18 +58,22 @@ export function receiveTagsError( store, action, error ) {
 			? translate( 'Could not load tag, try refreshing the page' )
 			: translate( 'Could not load your followed tags, try refreshing the page' );
 
-	store.dispatch( errorNotice( errorText ) );
-	// imperfect solution of lying to Calypso and saying the tag doesn't exist so that the query component stops asking for it
 	// see: https://github.com/Automattic/wp-calypso/pull/11627/files#r104468481
-	store.dispatch( receiveTags( { payload: [] } ) );
 	if ( process.env.NODE_ENV === 'development' ) {
 		console.error( errorText, error ); // eslint-disable-line no-console
 	}
+
+	return [ errorNotice( errorText ), receiveTags( { payload: [] } ) ];
 }
 
 const readTagsHandler = {
 	[ READER_TAGS_REQUEST ]: [
-		dispatchRequest( requestTags, receiveTagsSuccess, receiveTagsSuccess ),
+		dispatchRequestEx( {
+			fetch: requestTags,
+			onSuccess: receiveTagsSuccess,
+			onError: receiveTagsError,
+			fromApi,
+		} ),
 	],
 };
 

--- a/client/state/data-layer/wpcom/read/tags/index.js
+++ b/client/state/data-layer/wpcom/read/tags/index.js
@@ -31,6 +31,13 @@ export function requestTags( action ) {
 	} );
 }
 
+/*
+ * Returns whether or a tags request action corresponds to a request
+ * for a user's follows. Its sadly derived instead of explicit.
+ * If the payload has an individual slug, then we know it was a request for a specific tag.
+ * If the payload does not have a slug, then we assume it was a request for the set of
+ *   user's followed tags
+ */
 const isFollowedTagsRequest = action => ! get( action, 'payload.slug' );
 
 export function receiveTagsSuccess( action, tags ) {

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
@@ -9,20 +9,18 @@
 import { READER_UNFOLLOW_TAG_REQUEST } from 'state/action-types';
 import { receiveUnfollowTag as receiveUnfollowTagAction } from 'state/reader/tags/items/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { translate } from 'i18n-calypso';
 
-export function requestUnfollow( store, action ) {
-	store.dispatch(
-		http( {
-			path: `/read/tags/${ action.payload.slug }/mine/delete`,
-			method: 'POST',
-			apiVersion: '1.1',
-			onSuccess: action,
-			onFailure: action,
-		} )
-	);
+export function requestUnfollow( action ) {
+	return http( {
+		path: `/read/tags/${ action.payload.slug }/mine/delete`,
+		method: 'POST',
+		apiVersion: '1.1',
+		onSuccess: action,
+		onFailure: action,
+	} );
 }
 
 /**
@@ -31,34 +29,40 @@ export function requestUnfollow( store, action ) {
  * @param  {RemovedTag} apiResponse api response from the unfollow
  * @return {Number} the ID of the tag that was removed
  */
-export const fromApi = apiResponse => apiResponse.removed_tag;
-
-export function receiveUnfollowTag( store, action, apiResponse ) {
+export const fromApi = apiResponse => {
 	if ( apiResponse.subscribed ) {
-		receiveError( store, action );
-		return;
+		throw new Error(
+			`failed to unsubscribe to tag with reponse: ${ JSON.stringify( apiResponse ) }`
+		);
 	}
 
-	store.dispatch(
-		receiveUnfollowTagAction( {
-			payload: fromApi( apiResponse ),
-		} )
-	);
+	return apiResponse.removed_tag;
+};
+
+export function receiveUnfollowTag( action, removedTagId ) {
+	return receiveUnfollowTagAction( {
+		payload: removedTagId,
+	} );
 }
 
-export function receiveError( store, action, error ) {
+export function receiveError( action, error ) {
 	const errorText = translate( 'Could not unfollow tag: %(tag)s', {
 		args: { tag: action.payload.slug },
 	} );
 
-	store.dispatch( errorNotice( errorText ) );
 	if ( process.env.NODE_ENV === 'development' ) {
 		console.error( errorText, error ); // eslint-disable-line no-console
 	}
+	return errorNotice( errorText );
 }
 
 export default {
 	[ READER_UNFOLLOW_TAG_REQUEST ]: [
-		dispatchRequest( requestUnfollow, receiveUnfollowTag, receiveError ),
+		dispatchRequestEx( {
+			fetch: requestUnfollow,
+			onSuccess: receiveUnfollowTag,
+			onError: receiveError,
+			fromApi,
+		} ),
 	],
 };

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/index.js
@@ -32,7 +32,7 @@ export function requestUnfollow( action ) {
 export const fromApi = apiResponse => {
 	if ( apiResponse.subscribed ) {
 		throw new Error(
-			`failed to unsubscribe to tag with reponse: ${ JSON.stringify( apiResponse ) }`
+			`failed to unsubscribe to tag with response: ${ JSON.stringify( apiResponse ) }`
 		);
 	}
 

--- a/client/state/data-layer/wpcom/read/tags/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/delete/test/index.js
@@ -1,11 +1,5 @@
 /** @format */
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-import sinon from 'sinon';
-
-/**
  * Internal dependencies
  */
 import { requestUnfollow, receiveUnfollowTag, receiveError, fromApi } from '../';
@@ -37,23 +31,14 @@ const successfulUnfollowResponse = {
 	],
 };
 
-const unsuccessfulResponse = {
-	...successfulUnfollowResponse,
-	subscribed: true,
-};
-
 const slug = 'chicken';
 
 describe( 'unfollow tag request', () => {
 	describe( '#requestUnfollow', () => {
-		test( 'should dispatch HTTP request to unfollow tag endpoint', () => {
+		test( 'should return an HTTP request to the unfollow tag endpoint', () => {
 			const action = requestUnfollowAction( slug );
-			const dispatch = sinon.spy();
 
-			requestUnfollow( { dispatch }, action );
-
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
+			expect( requestUnfollow( action ) ).toMatchObject(
 				http( {
 					apiVersion: '1.1',
 					method: 'POST',
@@ -66,43 +51,23 @@ describe( 'unfollow tag request', () => {
 	} );
 
 	describe( '#receiveUnfollowSuccess', () => {
-		test( 'should dispatch the id of the unfollowed tag', () => {
+		test( 'should return the id of the unfollowed tag', () => {
 			const action = requestUnfollowAction( slug );
-			const dispatch = sinon.spy();
 
-			receiveUnfollowTag( { dispatch }, action, successfulUnfollowResponse );
-
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
+			expect( receiveUnfollowTag( action, fromApi( successfulUnfollowResponse ) ) ).toMatchObject(
 				receiveUnfollowAction( {
 					payload: successfulUnfollowResponse.removed_tag,
 				} )
 			);
-		} );
-
-		test( 'if api reports error then should create an error notice', () => {
-			const action = requestUnfollowAction( slug );
-			const dispatch = sinon.spy();
-
-			receiveUnfollowTag( { dispatch }, action, unsuccessfulResponse );
-
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWithMatch( {
-				type: NOTICE_CREATE,
-			} );
 		} );
 	} );
 
 	describe( '#receiveError', () => {
 		test( 'should dispatch an error notice', () => {
 			const action = requestUnfollowAction( slug );
-			const dispatch = sinon.spy();
 			const error = 'could not find tag';
 
-			receiveError( { dispatch }, action, error );
-
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWithMatch( {
+			expect( receiveError( action, error ) ).toMatchObject( {
 				type: NOTICE_CREATE,
 			} );
 		} );
@@ -113,7 +78,7 @@ describe( 'unfollow tag request', () => {
 			const apiResponse = successfulUnfollowResponse;
 			const normalized = fromApi( apiResponse );
 
-			expect( normalized ).to.eql( apiResponse.removed_tag );
+			expect( normalized ).toEqual( apiResponse.removed_tag );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/tags/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/mine/new/test/index.js
@@ -2,10 +2,8 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import freeze from 'deep-freeze';
 import { find } from 'lodash';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -40,23 +38,14 @@ export const successfulFollowResponse = freeze( {
 	],
 } );
 
-const unsuccessfulResponse = freeze( {
-	...successfulFollowResponse,
-	subscribed: false,
-} );
-
 const slug = 'chicken';
 
 describe( 'follow tag request', () => {
 	describe( '#requestFollow', () => {
 		test( 'should dispatch HTTP request to tag endpoint', () => {
 			const action = requestFollowAction( slug );
-			const dispatch = sinon.spy();
 
-			requestFollowTag( { dispatch }, action );
-
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
+			expect( requestFollowTag( action ) ).toEqual(
 				http( {
 					apiVersion: '1.1',
 					method: 'POST',
@@ -69,11 +58,8 @@ describe( 'follow tag request', () => {
 	} );
 
 	describe( '#receiveFollowSuccess', () => {
-		test( 'should dispatch the followed tag with isFollowing=true', () => {
+		test( 'should return the followed tag with isFollowing=true', () => {
 			const action = requestFollowAction( slug );
-			const dispatch = sinon.spy();
-
-			receiveFollowTag( { dispatch }, action, successfulFollowResponse );
 
 			const followedTagId = successfulFollowResponse.added_tag;
 			const followedTag = find( successfulFollowResponse.tags, { ID: followedTagId } );
@@ -82,35 +68,20 @@ describe( 'follow tag request', () => {
 				isFollowing: true,
 			};
 
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWith(
+			expect( receiveFollowTag( action, [ normalizedFollowedTag ] ) ).toMatchObject(
 				receiveTagsAction( {
 					payload: [ normalizedFollowedTag ],
 				} )
 			);
-		} );
-
-		test( 'if api reports error then create an error notice', () => {
-			const action = requestFollowAction( slug );
-			const dispatch = sinon.spy();
-
-			receiveFollowTag( { dispatch }, action, unsuccessfulResponse );
-			expect( dispatch ).to.have.been.calledWithMatch( {
-				type: NOTICE_CREATE,
-			} );
 		} );
 	} );
 
 	describe( '#receiveError', () => {
 		test( 'should dispatch an error notice', () => {
 			const action = requestFollowAction( slug );
-			const dispatch = sinon.spy();
 			const error = 'could not find tag';
 
-			receiveError( { dispatch }, action, error );
-
-			expect( dispatch ).to.have.been.calledOnce;
-			expect( dispatch ).to.have.been.calledWithMatch( {
+			expect( receiveError( action, error ) ).toMatchObject( {
 				type: NOTICE_CREATE,
 			} );
 		} );

--- a/client/state/data-layer/wpcom/read/tags/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/test/index.js
@@ -2,10 +2,8 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import { map } from 'lodash';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -55,12 +53,8 @@ describe( 'wpcom-api', () => {
 		describe( '#requestTags', () => {
 			test( 'single tag: should dispatch HTTP request to tag endpoint', () => {
 				const action = requestTagsAction( slug );
-				const dispatch = sinon.spy();
 
-				requestTags( { dispatch }, action );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith(
+				expect( requestTags( action ) ).toMatchObject(
 					http( {
 						apiVersion: '1.2',
 						method: 'GET',
@@ -73,12 +67,8 @@ describe( 'wpcom-api', () => {
 
 			test( 'multiple tags: should dispatch HTTP request to tags endpoint', () => {
 				const action = requestTagsAction();
-				const dispatch = sinon.spy();
 
-				requestTags( { dispatch }, action );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith(
+				expect( requestTags( action ) ).toMatchObject(
 					http( {
 						apiVersion: '1.2',
 						method: 'GET',
@@ -93,12 +83,10 @@ describe( 'wpcom-api', () => {
 		describe( '#receiveTagsResponse', () => {
 			test( 'single tag: should normalize + dispatch', () => {
 				const action = requestTagsAction( slug );
-				const dispatch = sinon.spy();
 
-				receiveTagsSuccess( { dispatch }, action, successfulSingleTagResponse );
-
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith(
+				expect(
+					receiveTagsSuccess( action, fromApi( successfulSingleTagResponse ) )
+				).toMatchObject(
 					receiveTagsAction( {
 						payload: fromApi( successfulSingleTagResponse ),
 						resetFollowingData: false,
@@ -108,17 +96,15 @@ describe( 'wpcom-api', () => {
 
 			test( 'multiple tags: should dispatch the tags', () => {
 				const action = requestTagsAction();
-				const dispatch = sinon.spy();
-
-				receiveTagsSuccess( { dispatch }, action, successfulFollowedTagsResponse );
 
 				const transformedResponse = map( fromApi( successfulFollowedTagsResponse ), tag => ( {
 					...tag,
 					isFollowing: true,
 				} ) );
 
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWith(
+				expect(
+					receiveTagsSuccess( action, fromApi( successfulFollowedTagsResponse ) )
+				).toMatchObject(
 					receiveTagsAction( {
 						payload: transformedResponse,
 						resetFollowingData: true,
@@ -128,15 +114,11 @@ describe( 'wpcom-api', () => {
 		} );
 
 		describe( '#receiveTagsError', () => {
-			test( 'should dispatch an error notice', () => {
+			test( 'should return an error notice', () => {
 				const action = requestTagsAction( slug );
-				const dispatch = sinon.spy();
 				const error = 'could not find tag(s)';
 
-				receiveTagsError( { dispatch }, action, error );
-
-				expect( dispatch ).to.have.been.calledTwice;
-				expect( dispatch ).to.have.been.calledWithMatch( {
+				expect( receiveTagsError( action, error )[ 0 ] ).toMatchObject( {
 					type: NOTICE_CREATE,
 				} );
 			} );
@@ -150,12 +132,9 @@ describe( 'wpcom-api', () => {
 						},
 					},
 				};
-				const dispatch = sinon.spy();
 				const error = 'could not find tag(s)';
-				receiveTagsError( { dispatch }, action, error );
 
-				expect( dispatch ).to.have.been.calledOnce;
-				expect( dispatch ).to.have.been.calledWithMatch(
+				expect( receiveTagsError( action, error ) ).toMatchObject(
 					receiveTagsAction( {
 						payload: [ { id: slug, slug, error: true } ],
 					} )

--- a/client/state/data-layer/wpcom/read/tags/test/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/test/utils.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -70,22 +69,22 @@ describe( 'wpcom-api: read/tags utils', () => {
 	describe( '#fromApi', () => {
 		test( 'should properly normalize many tags', () => {
 			const transformedResponse = fromApi( successfulFollowedTagsResponse );
-			expect( transformedResponse ).to.eql( normalizedFollowedTagsResponse );
+			expect( transformedResponse ).toEqual( normalizedFollowedTagsResponse );
 		} );
 
 		test( 'should properly normalize a single tag', () => {
 			const transformedResponse = fromApi( successfulSingleTagResponse );
-			expect( transformedResponse ).to.eql( normalizedSuccessfulSingleTagResponse );
+			expect( transformedResponse ).toEqual( normalizedSuccessfulSingleTagResponse );
 		} );
 
-		test( 'should not blow up when given wrong keys', () => {
-			const transformedResponse = fromApi( { noCorrectKeys: 'evil test' } );
-			expect( transformedResponse ).to.eql( [] );
+		test( 'should blow up when given wrong keys', () => {
+			const badResponse = { noCorrectKeys: 'evil test' };
+			expect( () => fromApi( badResponse ) ).toThrow();
 		} );
 
-		test( 'should not blow up when given bad values', () => {
-			const transformedResponse = fromApi( { tag: 'evil test' } );
-			expect( transformedResponse ).to.eql( [] );
+		test( 'should blow up when given bad values', () => {
+			const badResponse = fromApi( { tag: 'evil test' } );
+			expect( () => fromApi( badResponse ) ).toThrow();
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/tags/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/utils.js
@@ -19,7 +19,7 @@ import { decodeEntities } from 'lib/formatting';
  */
 export function fromApi( apiResponse ) {
 	if ( ! apiResponse || ( ! apiResponse.tag && ! apiResponse.tags ) ) {
-		return [];
+		throw new Error( `invalid tags response: ${ JSON.stringify( apiResponse ) }` );
 	}
 
 	const tags = compact(


### PR DESCRIPTION
Changelist:
1. tests: nix sinon + chai in favor of jest
2. `dispatchRequest` --> `dispatchRequestEx`
3. move `fromApi` from the data-layer _onWhatever_ handlers to an arg of `dispatchRequestEx`.  Also modified fromApi so it throws an error when the api response is invalid (as needed by dispatchRequestEx).

To Test
----
1. unit tests pass
2. follow a new tag
3. unfollow a tag
4. load a tag page directly
5. load a non-existent tag page