### PR TITLE
Reader Tags: allow hashtags

### DIFF
--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -4,7 +4,7 @@
  */
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
-import { identity } from 'lodash';
+import { identity, startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -35,6 +35,10 @@ export class ReaderSidebarTags extends Component {
 	};
 
 	followTag = tag => {
+		if ( startsWith( tag, '#' ) ) {
+			tag = tag.substring( 1 );
+		}
+
 		this.props.followTag( decodeURIComponent( tag ) );
 		recordAction( 'followed_topic' );
 		recordGaEvent( 'Clicked Follow Topic', tag );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -40,10 +40,9 @@ import PostLifecycle from './post-lifecycle';
 import { showSelectedPost } from 'reader/utils';
 import getBlockedSites from 'state/selectors/get-blocked-sites';
 import { getReaderFollows } from 'state/selectors';
-import { keysAreEqual } from 'lib/feed-stream-store/post-key';
+import { keysAreEqual, keyToString, keyForPost } from 'lib/feed-stream-store/post-key';
 import { resetCardExpansions } from 'state/ui/reader/card-expansions/actions';
 import { combineCards, injectRecommendations, RECS_PER_BLOCK } from './utils';
-import { keyToString, keyForPost } from 'lib/feed-stream-store/post-key';
 
 const GUESSED_POST_HEIGHT = 600;
 const HEADER_OFFSET_TOP = 46;

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import page from 'page';
+import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,7 +12,14 @@ import { tagListing } from './controller';
 import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
 import { makeLayout, render as clientRender } from 'controller';
 
+const redirectHashtaggedTags = ( context, next ) => {
+	if ( context.hashstring && startsWith( context.pathname, '/tag/#' ) ) {
+		page.redirect( `/tag/${ context.hashstring }` );
+	}
+	next();
+};
+
 export default function() {
-	page( '/tag/*', preloadReaderBundle, initAbTests );
+	page( '/tag/*', preloadReaderBundle, redirectHashtaggedTags, initAbTests );
 	page( '/tag/:tag', updateLastRoute, sidebar, tagListing, makeLayout, clientRender );
 }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -109,6 +109,25 @@ class TagStream extends React.Component {
 			} );
 		}
 
+		if ( ! tag ) {
+			return (
+				<React.Fragment>
+					<QueryReaderFollowedTags />
+					<QueryReaderTag tag={ this.props.decodedTagSlug } />
+					{ this.props.showBack && <HeaderBack /> }
+					<TagStreamHeader
+						title={ title }
+						imageSearchString={ imageSearchString }
+						showFollow={ !! ( tag && tag.id ) }
+						following={ this.isSubscribed() }
+						onFollowToggle={ this.toggleFollowing }
+						showBack={ this.props.showBack }
+					/>
+					<EmptyContent />
+				</React.Fragment>
+			);
+		}
+
 		return (
 			<Stream
 				{ ...this.props }

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -109,7 +109,7 @@ class TagStream extends React.Component {
 			} );
 		}
 
-		if ( ! tag ) {
+		if ( ! tag || tag.error ) {
 			return (
 				<React.Fragment>
 					<QueryReaderFollowedTags />
@@ -118,9 +118,7 @@ class TagStream extends React.Component {
 					<TagStreamHeader
 						title={ title }
 						imageSearchString={ imageSearchString }
-						showFollow={ !! ( tag && tag.id ) }
-						following={ this.isSubscribed() }
-						onFollowToggle={ this.toggleFollowing }
+						showFollow={ false }
 						showBack={ this.props.showBack }
 					/>
 					<EmptyContent />

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -109,7 +109,7 @@ class TagStream extends React.Component {
 			} );
 		}
 
-		if ( ! tag || tag.error ) {
+		if ( tag && tag.error ) {
 			return (
 				<React.Fragment>
 					<QueryReaderFollowedTags />

--- a/client/state/data-layer/wpcom/read/tags/index.js
+++ b/client/state/data-layer/wpcom/read/tags/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { map } from 'lodash';
+import { map, get } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -55,7 +55,7 @@ export function receiveTagsSuccess( store, action, apiResponse ) {
 
 export function receiveTagsError( store, action, error ) {
 	// if tag does not exist, refreshing page wont help
-	if ( getHeaders( action ).status === 404 ) {
+	if ( get( getHeaders( action ), 'status' ) === 404 ) {
 		store.dispatch(
 			receiveTags( {
 				payload: [ { id: action.payload.slug, error: true } ],

--- a/client/state/data-layer/wpcom/read/tags/index.js
+++ b/client/state/data-layer/wpcom/read/tags/index.js
@@ -56,9 +56,10 @@ export function receiveTagsSuccess( store, action, apiResponse ) {
 export function receiveTagsError( store, action, error ) {
 	// if tag does not exist, refreshing page wont help
 	if ( get( getHeaders( action ), 'status' ) === 404 ) {
+		const slug = action.payload.slug;
 		store.dispatch(
 			receiveTags( {
-				payload: [ { id: action.payload.slug, error: true } ],
+				payload: [ { id: slug, slug, error: true } ],
 			} )
 		);
 		return;

--- a/client/state/data-layer/wpcom/read/tags/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/test/index.js
@@ -157,7 +157,7 @@ describe( 'wpcom-api', () => {
 				expect( dispatch ).to.have.been.calledOnce;
 				expect( dispatch ).to.have.been.calledWithMatch(
 					receiveTagsAction( {
-						payload: [ { id: slug, error: true } ],
+						payload: [ { id: slug, slug, error: true } ],
 					} )
 				);
 			} );

--- a/client/state/data-layer/wpcom/read/tags/test/index.js
+++ b/client/state/data-layer/wpcom/read/tags/test/index.js
@@ -140,6 +140,27 @@ describe( 'wpcom-api', () => {
 					type: NOTICE_CREATE,
 				} );
 			} );
+
+			test( 'should not dispatch error notice if the error is a 404', () => {
+				const action = {
+					...requestTagsAction( slug ),
+					meta: {
+						dataLayer: {
+							headers: { status: 404 },
+						},
+					},
+				};
+				const dispatch = sinon.spy();
+				const error = 'could not find tag(s)';
+				receiveTagsError( { dispatch }, action, error );
+
+				expect( dispatch ).to.have.been.calledOnce;
+				expect( dispatch ).to.have.been.calledWithMatch(
+					receiveTagsAction( {
+						payload: [ { id: slug, error: true } ],
+					} )
+				);
+			} );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/read/tags/utils.js
+++ b/client/state/data-layer/wpcom/read/tags/utils.js
@@ -19,7 +19,6 @@ import { decodeEntities } from 'lib/formatting';
  */
 export function fromApi( apiResponse ) {
 	if ( ! apiResponse || ( ! apiResponse.tag && ! apiResponse.tags ) ) {
-		console.error( 'bad api response for /read/tags' ); // eslint-disable-line no-console
 		return [];
 	}
 


### PR DESCRIPTION
This PR brings about two changes:
1. Going to a url: `/tag/#tagname` should redirect to `/tag/tagname`
2. Adding a tag: `#tagname` should actually add the tag `tagname`

To Test
----
test both cases above^^

related to: https://github.com/Automattic/wp-calypso/issues/20705