### PR TITLE
Purchases: Error when no purchases on ConfirmCancelDomain

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -190,6 +190,23 @@ function isBelgiumBancontactEnabled( cart ) {
 	);
 }
 
+export {
+	applyCoupon,
+	canRemoveFromCart,
+	cartItems,
+	emptyCart,
+	fillInAllCartItemAttributes,
+	fillInSingleCartItemAttributes,
+	getNewMessages,
+	getRefundPolicy,
+	isFree,
+	isPaidForFullyInCredits,
+	isPaymentMethodEnabled,
+	isPayPalExpressEnabled,
+	isNetherlandsIdealEnabled,
+	isCreditCardPaymentsEnabled,
+};
+
 export default {
 	applyCoupon,
 	canRemoveFromCart,

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -190,23 +190,6 @@ function isBelgiumBancontactEnabled( cart ) {
 	);
 }
 
-export {
-	applyCoupon,
-	canRemoveFromCart,
-	cartItems,
-	emptyCart,
-	fillInAllCartItemAttributes,
-	fillInSingleCartItemAttributes,
-	getNewMessages,
-	getRefundPolicy,
-	isFree,
-	isPaidForFullyInCredits,
-	isPaymentMethodEnabled,
-	isPayPalExpressEnabled,
-	isNetherlandsIdealEnabled,
-	isCreditCardPaymentsEnabled,
-};
-
 export default {
 	applyCoupon,
 	canRemoveFromCart,

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -267,9 +267,12 @@ class ConfirmCancelDomain extends React.Component {
 			);
 		}
 
-		const purchase = getPurchase( this.props ),
-			domain = getDomainName( purchase ),
-			selectedReason = this.state.selectedReason;
+		const purchase = getPurchase( this.props );
+		if ( ! purchase ) {
+			return null;
+		}
+		const domain = getDomainName( purchase );
+		const selectedReason = this.state.selectedReason;
 
 		return (
 			<Main className="confirm-cancel-domain">

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -268,9 +268,6 @@ class ConfirmCancelDomain extends React.Component {
 		}
 
 		const purchase = getPurchase( this.props );
-		if ( ! purchase ) {
-			return null;
-		}
 		const domain = getDomainName( purchase );
 		const selectedReason = this.state.selectedReason;
 

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { partial } from 'lodash';
+import { noop, partial } from 'lodash';
 import React from 'react';
 
 /**
@@ -26,6 +26,7 @@ import { concatTitle, recordPageView } from 'lib/react-helpers';
 import { setDocumentHeadTitle } from 'state/document-head/actions';
 import titles from './titles';
 import userFactory from 'lib/user';
+import { makeLayout, render as clientRender } from 'controller';
 
 const recordPurchasesPageView = partial( recordPageView, partial.placeholder, 'Purchases' );
 const user = userFactory();
@@ -135,5 +136,8 @@ export default {
 				<NoSitesMessage />
 			</Main>
 		);
+
+		makeLayout( context, noop );
+		clientRender( context );
 	},
 };


### PR DESCRIPTION
If purchases are empty, redirect doesn't fire before render and since there is no purchase an error is thrown before page() picks it up.

Fixes: https://github.com/Automattic/wp-calypso/issues/20798