### PR TITLE
Reader Manage: recs should be placeholders as early as possible

### DIFF
--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -41,11 +41,8 @@ export class RecommendedSites extends React.PureComponent {
 	};
 
 	render() {
-		const { sites, followSource } = this.props;
-
-		if ( isEmpty( sites ) ) {
-			return null;
-		}
+		const { followSource } = this.props;
+		const sites = ! isEmpty( this.props.sites ) ? this.props.sites : [ {}, {} ];
 
 		function recordRecommendationRender( index ) {
 			return function( railcar ) {
@@ -68,7 +65,7 @@ export class RecommendedSites extends React.PureComponent {
 						return (
 							<li
 								className="reader-recommended-sites__site-list-item"
-								key={ `site-rec-${ siteId }` }
+								key={ `site-rec-${ index }` }
 							>
 								<div className="reader-recommended-sites__recommended-site-dismiss">
 									<Button

--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -42,7 +42,8 @@ export class RecommendedSites extends React.PureComponent {
 
 	render() {
 		const { followSource } = this.props;
-		const sites = ! isEmpty( this.props.sites ) ? this.props.sites : [ {}, {} ];
+		const placeholders = [ {}, {} ];
+		const sites = isEmpty( this.props.sites ) ? placeholders : this.props.sites;
 
 		function recordRecommendationRender( index ) {
 			return function( railcar ) {

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -24,6 +24,7 @@ import {
 	getReaderRecommendedSitesPagingOffset,
 	getBlockedSites,
 	getReaderAliasedFollowFeedUrl,
+	getReaderFollowsCount,
 } from 'state/selectors';
 import QueryReaderFeedsSearch from 'components/data/query-reader-feeds-search';
 import QueryReaderRecommendedSites from 'components/data/query-reader-recommended-sites';
@@ -32,14 +33,12 @@ import FollowingManageSubscriptions from './subscriptions';
 import FollowingManageSearchFeedsResults from './feed-search-results';
 import FollowingManageEmptyContent from './empty';
 import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
-import { addQueryArgs } from 'lib/url';
 import FollowButton from 'reader/follow-button';
 import {
 	READER_FOLLOWING_MANAGE_URL_INPUT,
 	READER_FOLLOWING_MANAGE_RECOMMENDATION,
 } from 'reader/follow-sources';
-import { resemblesUrl, withoutHttp, addSchemeIfMissing } from 'lib/url';
-import { getReaderFollowsCount } from 'state/selectors';
+import { resemblesUrl, withoutHttp, addSchemeIfMissing, addQueryArgs } from 'lib/url';
 import { recordTrack, recordAction } from 'reader/stats';
 import { SORT_BY_RELEVANCE } from 'state/reader/feed-searches/actions';
 
@@ -238,13 +237,12 @@ class FollowingManage extends Component {
 						</div>
 					) }
 				</div>
-				{ hasFollows &&
-					! sitesQuery && (
-						<RecommendedSites
-							sites={ take( filteredRecommendedSites, 2 ) }
-							followSource={ READER_FOLLOWING_MANAGE_RECOMMENDATION }
-						/>
-					) }
+				{ ! sitesQuery && (
+					<RecommendedSites
+						sites={ take( filteredRecommendedSites, 2 ) }
+						followSource={ READER_FOLLOWING_MANAGE_RECOMMENDATION }
+					/>
+				) }
 				{ !! sitesQuery &&
 					! isFollowByUrlWithNoSearchResults && (
 						<FollowingManageSearchFeedsResults

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -24,6 +24,10 @@ export const getSiteUrl = ( { feed, site, post } = {} ) => {
 	const feedUrl = !! feed && ( feed.URL || feed.feed_URL );
 	const postUrl = !! post && post.site_URL;
 
+	if ( ! siteUrl && ! feedUrl && ! postUrl ) {
+		return undefined;
+	}
+
 	return siteUrl || feedUrl || postUrl;
 };
 

--- a/client/reader/test/get-helpers.js
+++ b/client/reader/test/get-helpers.js
@@ -38,7 +38,7 @@ describe( '#getSiteUrl', () => {
 		expect( siteUrl ).eql( postWithSiteUrl.site_URL );
 	} );
 
-	test( 'should return false if cannot find a reasonable url', () => {
+	test( 'should return undefined if cannot find a reasonable url', () => {
 		const noArg = getSiteUrl();
 		expect( noArg ).not.ok;
 


### PR DESCRIPTION
fixes: https://github.com/Automattic/wp-calypso/issues/20706

To Test
------
load following/manage page and verify that:
1. you see placeholders much earlier on (no jumping occurs)
2. no errors in the console