### PR TITLE
Domains: Use domainAvailability.MAPPABLE to show message in transfer step.

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -297,6 +297,7 @@ class TransferDomainStep extends React.Component {
 							supportsPrivacy: get( result, 'supports_privacy', false ),
 						} );
 						return;
+					case domainAvailability.MAPPABLE:
 					case domainAvailability.TLD_NOT_SUPPORTED:
 						const tld = getTld( domain );
 


### PR DESCRIPTION
Depends on D8809-code

Should show a notice offering to transfer the domain if a domain that doesn't allow inbound transfers is selected on the transfer page (/domains/add/transfer/).