### PR TITLE
Comments: Add selectors for `getSiteCommentCounts` with tests.

### DIFF
--- a/client/state/selectors/get-site-comment-counts.js
+++ b/client/state/selectors/get-site-comment-counts.js
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+
+/**
+ * Return comment counts for the given site and post ID, if applicable.
+ *
+ * @param {Object} state Redux state
+ * @param {Number} siteId Site identifier
+ * @param {Number} [postId] Post identifier
+ * @returns {Object} The requested comment counts
+ */
+export const getSiteCommentCounts = ( state, siteId, postId ) => {
+	if ( postId ) {
+		return get( state, [ 'comments', 'counts', siteId, postId ], null );
+	}
+	return get( state, [ 'comments', 'counts', siteId, 'site' ], null );
+};
+
+export default getSiteCommentCounts;

--- a/client/state/selectors/test/get-site-comment-counts.js
+++ b/client/state/selectors/test/get-site-comment-counts.js
@@ -1,0 +1,64 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getSiteCommentCounts } from 'state/selectors';
+
+describe( 'getSiteCommentCounts()', () => {
+	const siteId = 2916284;
+
+	test( 'should return site counts given a site ID', () => {
+		const state = {
+			comments: {
+				counts: {
+					[ siteId ]: {
+						site: {
+							all: 5,
+							approved: 2,
+							pending: 3,
+						},
+					},
+				},
+			},
+		};
+		const output = getSiteCommentCounts( state, siteId );
+		expect( output ).toEqual( {
+			all: 5,
+			approved: 2,
+			pending: 3,
+		} );
+	} );
+
+	test( 'should return site counts given a site ID and a post ID', () => {
+		const state = {
+			comments: {
+				counts: {
+					[ siteId ]: {
+						12345: {
+							all: 5,
+							approved: 2,
+							pending: 3,
+						},
+					},
+				},
+			},
+		};
+		const output = getSiteCommentCounts( state, siteId, 12345 );
+		expect( output ).toEqual( {
+			all: 5,
+			approved: 2,
+			pending: 3,
+		} );
+	} );
+
+	test( 'should return null when counts are not available', () => {
+		const state = {};
+		const output = getSiteCommentCounts( state, siteId, 12345 );
+		expect( output ).toEqual( null );
+	} );
+} );


### PR DESCRIPTION
Add a selector for `getSiteCommentCounts` (using the `comment-counts` endpoint).