### PR TITLE
Activity Log: Handle changes to description in API formats

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -38,7 +38,7 @@ class ActivityLogItem extends Component {
 			activityId: PropTypes.string.isRequired,
 			activityName: PropTypes.string.isRequired,
 			activityStatus: PropTypes.string,
-			activityTitle: PropTypes.string.isRequired,
+			activityTitle: PropTypes.string,
 			activityTs: PropTypes.number.isRequired,
 
 			// Actor

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -74,9 +74,6 @@ class ActivityLogItem extends Component {
 				<ActivityActor
 					{ ...pick( log, [ 'actorAvatarUrl', 'actorName', 'actorRole', 'actorType' ] ) }
 				/>
-				{ ! activityDescription && (
-					<div className="activity-log-item__title">{ activityTitle }</div>
-				) }
 				{ activityDescription && (
 					<div className="activity-log-item__description">
 						{ activityDescription.map( ( part, key ) => (
@@ -84,6 +81,7 @@ class ActivityLogItem extends Component {
 						) ) }
 					</div>
 				) }
+				{ activityTitle && <div className="activity-log-item__title">{ activityTitle }</div> }
 			</div>
 		);
 	}

--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -1,7 +1,6 @@
 /** @format */
 const activityItemSchema = {
 	type: 'object',
-	additionalProperties: false,
 	required: [
 		'activityDate',
 		'activityGroup',
@@ -9,7 +8,6 @@ const activityItemSchema = {
 		'activityId',
 		'activityIsRewindable',
 		'activityName',
-		'activityTitle',
 		'activityTs',
 		'actorAvatarUrl',
 		'actorName',

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -36,7 +36,7 @@ export function transformer( apiResponse ) {
  * contain links to resources referenced in the explanation
  *
  * @param {Object} item from API response
- * @returns {?Object} parsed notifications-formatted block
+ * @returns {Object|undefined} parsed notifications-formatted block
  */
 const getDescription = item => {
 	// first generation had all of description in summary as string
@@ -68,7 +68,7 @@ const getDescription = item => {
  * e.g. "Post published" "Theme updated" "Plugin installed" etc…
  *
  * @param {Object} item from API response
- * @returns {?String} activity title
+ * @returns {String|undefined} activity title
  */
 const getTitle = item => {
 	// third generation provided title

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -30,6 +30,61 @@ export function transformer( apiResponse ) {
 }
 
 /**
+ * Description is an explanation of specific knowledge about an activity
+ *
+ * The description is a formatted explanation of an activity and may
+ * contain links to resources referenced in the explanation
+ *
+ * @param {Object} item from API response
+ * @returns {?Object} parsed notifications-formatted block
+ */
+const getDescription = item => {
+	// first generation had all of description in summary as string
+	if ( ! item.content && ! item.formatted_content && 'string' === typeof item.summary ) {
+		return parseBlock( { text: item.summary } );
+	}
+
+	// second generation had notes-formatted block as summary
+	if ( 'string' !== typeof item.summary ) {
+		return parseBlock( item.summary );
+	}
+
+	// third generation had either title as plaintext summary or in formatted content
+	if ( item.formatted_content ) {
+		return parseBlock( item.formatted_content.content );
+	}
+
+	if ( item.content ) {
+		return parseBlock( item.content );
+	}
+
+	return undefined;
+};
+
+/**
+ * Title is a terse and generic summary of the kind of activity
+ *
+ * Usually this includes a noun and a verb acting on that noun
+ * e.g. "Post published" "Theme updated" "Plugin installed" etc…
+ *
+ * @param {Object} item from API response
+ * @returns {?String} activity title
+ */
+const getTitle = item => {
+	// third generation provided title
+	if ( item.formatted_content ) {
+		return item.formatted_content.name;
+	}
+
+	if ( item.content && 'string' === typeof item.summary ) {
+		return item.summary;
+	}
+
+	// first and second generations provided no title
+	return undefined;
+};
+
+/**
  * Takes an Activity item in the API format and returns a processed Activity item for use in UI
  *
  * @param  {object}  item Validated Activity item
@@ -38,7 +93,6 @@ export function transformer( apiResponse ) {
 export function processItem( item ) {
 	const published = item.published;
 	const actor = item.actor;
-	const isFormatted = 'string' !== typeof item.summary;
 
 	return {
 		/* activity actor */
@@ -59,9 +113,9 @@ export function processItem( item ) {
 		activityName: item.name,
 		activityStatus: item.status,
 		activityTargetTs: get( item, 'object.target_ts', undefined ),
-		activityTitle: isFormatted ? get( item, 'summary.text', '' ) : item.summary,
+		activityTitle: getTitle( item ),
 		activityTs: Date.parse( published ),
-		activityDescription: isFormatted ? parseBlock( item.summary ) : undefined,
+		activityDescription: getDescription( item ),
 	};
 }
 

--- a/client/state/data-layer/wpcom/sites/activity/schema.json
+++ b/client/state/data-layer/wpcom/sites/activity/schema.json
@@ -54,6 +54,11 @@
 						"wpcom_user_id": { "type": "integer" }
 					}
 				},
+				"content": { "type": "object" },
+				"formatted_content": {
+					"name": { "type": "string" },
+					"content": { "type": "object" }
+				},
 				"generator": { "type": "object" },
 				"gridicon": { "type": "string" },
 				"is_rewindable": { "type": "boolean" },


### PR DESCRIPTION
As we develop a specification for how to describe activity log events we
need to handle any expected transitions in Calypso.

In this PR I have tried to handle all previous and expected future
changes so that Calypso won't be a blocker in the development and
rollout of activity descriptions and titles.

**Testing**

Since the API changes aren't available yet, this isn't too testable other than
to smoke-test in the current **Activity** section under **Stats**. It should
continue to display as **master** displays. As new APIs are testing in your
sandbox this should continue to display properly and add in the activity
titles as the API provides.