### PR TITLE
Comments: display counts and reflect count changes when status updates

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -23,6 +23,7 @@ import Pagination from 'components/pagination';
 import QuerySiteCommentsList from 'components/data/query-site-comments-list';
 import QuerySiteCommentsTree from 'components/data/query-site-comments-tree';
 import QuerySiteSettings from 'components/data/query-site-settings';
+import QuerySiteCommentCounts from 'components/data/query-site-comment-counts';
 import { getSiteCommentsTree, isCommentsTreeInitialized } from 'state/selectors';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
@@ -170,7 +171,7 @@ export class CommentList extends Component {
 		return (
 			<div className="comment-list">
 				<QuerySiteSettings siteId={ siteId } />
-
+				<QuerySiteCommentCounts siteId={ siteId } postId={ postId } />
 				{ ! isCommentsTreeSupported && (
 					<QuerySiteCommentsList
 						number={ 100 }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -24,7 +24,11 @@ import QuerySiteCommentsList from 'components/data/query-site-comments-list';
 import QuerySiteCommentsTree from 'components/data/query-site-comments-tree';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import QuerySiteCommentCounts from 'components/data/query-site-comment-counts';
-import { getSiteCommentsTree, isCommentsTreeInitialized } from 'state/selectors';
+import {
+	getSiteCommentCounts,
+	getSiteCommentsTree,
+	isCommentsTreeInitialized,
+} from 'state/selectors';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { COMMENTS_PER_PAGE, NEWEST_FIRST } from '../constants';
@@ -146,6 +150,7 @@ export class CommentList extends Component {
 
 	render() {
 		const {
+			counts,
 			isCommentsTreeSupported,
 			isLoading,
 			isPostView,
@@ -186,6 +191,7 @@ export class CommentList extends Component {
 
 				<CommentNavigation
 					commentsPage={ commentsPage }
+					counts={ counts }
 					isBulkMode={ isBulkMode }
 					isSelectedAll={ this.isSelectedAll() }
 					postId={ postId }
@@ -260,6 +266,7 @@ const mapStateToProps = ( state, { postId, siteId, status } ) => {
 		: map( siteCommentsTree, 'commentId' );
 
 	const isLoading = ! isCommentsTreeInitialized( state, siteId, status );
+	const counts = getSiteCommentCounts( state, siteId, postId );
 	return {
 		comments,
 		isCommentsTreeSupported:
@@ -267,6 +274,7 @@ const mapStateToProps = ( state, { postId, siteId, status } ) => {
 		isLoading,
 		isPostView,
 		siteId,
+		counts,
 	};
 };
 

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -68,22 +68,27 @@ export class CommentNavigation extends Component {
 	changeFilter = status => () => this.props.recordChangeFilter( status );
 
 	getNavItems = () => {
-		const { translate } = this.props;
+		const { translate, counts } = this.props;
 		const navItems = {
 			all: {
 				label: translate( 'All' ),
+				count: get( counts, 'all' ),
 			},
 			unapproved: {
 				label: translate( 'Pending' ),
+				count: get( counts, 'pending' ),
 			},
 			approved: {
 				label: translate( 'Approved' ),
+				count: get( counts, 'approved' ),
 			},
 			spam: {
 				label: translate( 'Spam' ),
+				count: get( counts, 'spam' ),
 			},
 			trash: {
 				label: translate( 'Trash' ),
+				count: get( counts, 'trash' ),
 			},
 		};
 
@@ -262,9 +267,10 @@ export class CommentNavigation extends Component {
 		return (
 			<SectionNav className="comment-navigation" selectedText={ navItems[ queryStatus ].label }>
 				<NavTabs selectedText={ navItems[ queryStatus ].label }>
-					{ map( navItems, ( { label }, status ) => (
+					{ map( navItems, ( { label, count }, status ) => (
 						<NavItem
 							key={ status }
+							count={ count }
 							onClick={ this.changeFilter( status ) }
 							path={ this.getStatusPath( status ) }
 							selected={ queryStatus === status }

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -5,6 +5,7 @@
 import { isEnabled } from 'config';
 import {
 	COMMENT_COUNTS_REQUEST,
+	COMMENT_COUNTS_UPDATE,
 	COMMENT_REQUEST,
 	COMMENTS_CHANGE_STATUS,
 	COMMENTS_DELETE,
@@ -298,3 +299,41 @@ export const setActiveReply = ( { siteId, postId, commentId } ) => ( {
 		commentId,
 	},
 } );
+
+/***
+ * Creates an action that updates comment counts in the comments management section.
+ * @param {Number} siteId Site identifier
+ * @param {Number} postId Post identifier
+ * @param {Number} all filter counts
+ * @param {Number} approved filter counts
+ * @param {Number} pending filter counts
+ * @param {Number} postTrashed filter counts
+ * @param {Number} spam filter counts
+ * @param {Number} totalComments filter counts
+ * @param {Number} trash filter counts
+ * @returns {Object} Action to update comment counts
+ */
+export const updateCommentCounts = ( {
+	siteId,
+	postId,
+	all,
+	approved,
+	pending,
+	postTrashed,
+	spam,
+	totalComments,
+	trash,
+} ) => {
+	return {
+		type: COMMENT_COUNTS_UPDATE,
+		siteId,
+		postId,
+		all,
+		approved,
+		pending,
+		postTrashed,
+		spam,
+		totalComments,
+		trash,
+	};
+};

--- a/client/state/data-layer/wpcom/sites/comment-counts/index.js
+++ b/client/state/data-layer/wpcom/sites/comment-counts/index.js
@@ -8,7 +8,7 @@ import { mapValues } from 'lodash';
 /**
  * Internal dependencies
  */
-import { COMMENT_COUNTS_REQUEST, COMMENT_COUNTS_UPDATE } from 'state/action-types';
+import { COMMENT_COUNTS_REQUEST } from 'state/action-types';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { updateCommentCounts as updateCounts } from 'state/comments/actions';

--- a/client/state/data-layer/wpcom/sites/comment-counts/index.js
+++ b/client/state/data-layer/wpcom/sites/comment-counts/index.js
@@ -11,6 +11,7 @@ import { mapValues } from 'lodash';
 import { COMMENT_COUNTS_REQUEST, COMMENT_COUNTS_UPDATE } from 'state/action-types';
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { updateCommentCounts as updateCounts } from 'state/comments/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 
 export const fetchCommentCounts = action => {
@@ -41,8 +42,7 @@ export const updateCommentCounts = ( action, response ) => {
 		trash,
 	} = intResponse;
 	const { siteId, postId } = action;
-	return {
-		type: COMMENT_COUNTS_UPDATE,
+	return updateCounts( {
 		siteId,
 		postId,
 		all,
@@ -52,7 +52,7 @@ export const updateCommentCounts = ( action, response ) => {
 		spam,
 		totalComments,
 		trash,
-	};
+	} );
 };
 
 const countHandlers = {

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -28,15 +28,15 @@ import {
 	receiveComments,
 	receiveCommentsError as receiveCommentErrorAction,
 	requestComment as requestCommentAction,
+	updateCommentCounts,
 } from 'state/comments/actions';
 import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 
 const changeCommentStatus = ( { dispatch, getState }, action ) => {
 	const { siteId, commentId, status } = action;
-	const previousStatus = get(
-		getSiteComment( getState(), action.siteId, action.commentId ),
-		'status'
-	);
+	const state = getState();
+	const previousStatus = get( getSiteComment( state, action.siteId, action.commentId ), 'status' );
+	// const counts = getSiteCommentCounts( siteId, )
 
 	dispatch(
 		http(
@@ -53,6 +53,12 @@ const changeCommentStatus = ( { dispatch, getState }, action ) => {
 				previousStatus,
 			}
 		)
+	);
+
+	dispatch(
+		updateCommentCounts( {
+			siteId,
+		} )
 	);
 };
 

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -23,7 +23,7 @@ import replies from './replies';
 import likes from './likes';
 import { errorNotice, removeNotice } from 'state/notices/actions';
 import { getRawSite } from 'state/sites/selectors';
-import { getSiteComment } from 'state/selectors';
+import { getCurrentRoute, getSiteComment, getSiteCommentCounts } from 'state/selectors';
 import {
 	receiveComments,
 	receiveCommentsError as receiveCommentErrorAction,
@@ -32,11 +32,31 @@ import {
 } from 'state/comments/actions';
 import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 
+function createCommentCounts( counts, previousStatus, status, modifier = 1 ) {
+	const countStatus = status === 'unapproved' ? 'pending' : status;
+	const prevCountStatus = previousStatus === 'unapproved' ? 'pending' : previousStatus;
+
+	const newCounts = {
+		...counts,
+		[ prevCountStatus ]: counts[ prevCountStatus ] - modifier,
+		[ countStatus ]: counts[ countStatus ] + modifier,
+	};
+	return { ...newCounts, all: newCounts.pending + newCounts.approved };
+}
+
+const postIdRegex = /^\/comments\/[a-z]+\/.+\/(\d+$)/;
+
+function getPostIdForCommentCounts( state ) {
+	const [ route, postString ] = postIdRegex.exec( getCurrentRoute( state ) ) || [];
+	return route ? parseInt( postString, 10 ) : null;
+}
+
 const changeCommentStatus = ( { dispatch, getState }, action ) => {
 	const { siteId, commentId, status } = action;
 	const state = getState();
 	const previousStatus = get( getSiteComment( state, action.siteId, action.commentId ), 'status' );
-	// const counts = getSiteCommentCounts( siteId, )
+	const postId = getPostIdForCommentCounts( state );
+	const counts = getSiteCommentCounts( state, siteId, postId );
 
 	dispatch(
 		http(
@@ -56,17 +76,26 @@ const changeCommentStatus = ( { dispatch, getState }, action ) => {
 	);
 
 	dispatch(
-		updateCommentCounts( {
-			siteId,
-		} )
+		updateCommentCounts(
+			Object.assign(
+				{
+					siteId,
+					postId,
+				},
+				createCommentCounts( counts, previousStatus, status, 1 )
+			)
+		)
 	);
 };
 
 export const removeCommentStatusErrorNotice = ( { dispatch }, { commentId } ) =>
 	dispatch( removeNotice( `comment-notice-error-${ commentId }` ) );
 
-const announceStatusChangeFailure = ( { dispatch }, action ) => {
-	const { commentId, status, previousStatus } = action;
+const announceStatusChangeFailure = ( { dispatch, getState }, action ) => {
+	const { siteId, commentId, status, previousStatus } = action;
+	const state = getState();
+	const counts = getSiteCommentCounts( state, siteId );
+	const postId = getPostIdForCommentCounts( state );
 
 	dispatch( removeNotice( `comment-notice-${ commentId }` ) );
 
@@ -75,6 +104,18 @@ const announceStatusChangeFailure = ( { dispatch }, action ) => {
 			...omit( action, [ 'meta' ] ),
 			status: previousStatus,
 		} )
+	);
+
+	dispatch(
+		updateCommentCounts(
+			Object.assign(
+				{
+					siteId,
+					postId,
+				},
+				createCommentCounts( counts, previousStatus, status, -1 )
+			)
+		)
 	);
 
 	const errorMessage = {


### PR DESCRIPTION
WIP. This will PR will display comment counts in the /comments section. This also adds handling so counts should update appropriately if we change comment statuses, add comments or delete comments.

<img width="886" alt="screen shot 2017-12-13 at 4 59 24 pm" src="https://user-images.githubusercontent.com/1270189/33970294-25b2424a-e027-11e7-9a2c-0f4b323d5dd1.png">


<img width="884" alt="screen shot 2017-12-13 at 4 59 38 pm" src="https://user-images.githubusercontent.com/1270189/33970292-2170542e-e027-11e7-896e-fdb3570f9bcc.png">


<img width="458" alt="screen shot 2017-12-13 at 5 01 05 pm" src="https://user-images.githubusercontent.com/1270189/33970308-3e2ebf1a-e027-11e7-90b0-b7bf34b31bd6.png">

### TODO
Counts update when:

Site View:
- [x] comment status changes
- [ ] reply

Post Specific View
- [x] comment status changes
- [ ] reply

