### PR TITLE
Purchases: Fix the weird button when transfer bundled with plan

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -247,6 +247,10 @@ class ManagePurchase extends Component {
 				text = translate( 'Cancel and Refund' );
 			}
 		} else {
+			if ( isDomainTransfer( purchase ) ) {
+				return null;
+			}
+
 			if ( isDomainRegistration( purchase ) ) {
 				text = translate( 'Cancel Domain' );
 			}


### PR DESCRIPTION
There was an action item which shouldn't be there on the
manage purchase screen.

Test:
- Create a new site
- Buy a plan
- Buy a transfer
- Go to transfer screen
- Shouldn't be able to see button