### PR TITLE
Comments: use snake case for http query

### DIFF
--- a/client/state/data-layer/wpcom/sites/comment-counts/index.js
+++ b/client/state/data-layer/wpcom/sites/comment-counts/index.js
@@ -25,7 +25,7 @@ export const fetchCommentCounts = action => {
 			path: `/sites/${ siteId }/comment-counts`,
 			apiVersion: '1.0',
 			query: {
-				postId,
+				post_id: postId,
 			},
 		},
 		action

--- a/client/state/data-layer/wpcom/sites/comment-counts/index.js
+++ b/client/state/data-layer/wpcom/sites/comment-counts/index.js
@@ -3,9 +3,7 @@
 /**
  * External dependencies
  */
-
-// import { translate } from 'i18n-calypso';
-// import { flatMap, flatten, isArray, map } from 'lodash';
+import { mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,7 +12,6 @@ import { COMMENT_COUNTS_REQUEST, COMMENT_COUNTS_UPDATE } from 'state/action-type
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
-import { mapValues } from 'lodash';
 
 export const fetchCommentCounts = action => {
 	const { siteId, postId } = action;


### PR DESCRIPTION
While wiring the comment counts endpoint `/sites/{siteSlug}/comment-counts?post_id=1`. We missed that the query parameter should be in snake_case versus camelCase.

### Testing Instructions

Start the branch in a dev environment. Open the console:
```
dispatch( { type: 'COMMENT_COUNTS_REQUEST', siteId: yoursiteid, postId: postId } ) ;
dispatch( { type: 'COMMENT_COUNTS_REQUEST', siteId: yoursiteid } );
state.comments.counts; 
```

The counts tree should be populated with 2 values for the site vs post values:

<img width="511" alt="screen shot 2017-12-13 at 4 49 08 pm" src="https://user-images.githubusercontent.com/1270189/33970091-ec773e28-e025-11e7-9d7a-5134fd237901.png">
