### PR TITLE
Support: Update Contact Form closure notice to reflect Christmas hours

### DIFF
--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -7,31 +7,30 @@
 import React from 'react';
 import i18n, { localize } from 'i18n-calypso';
 
+const christmas2017ClosureStartsAt = i18n.moment( 'Sun, 24 Dec 2017 00:00:00 +0000' );
+
 /**
  * Internal dependencies
  */
 import FormSectionHeading from 'components/forms/form-section-heading';
 
-// In the translated dates 7am UTC is 12am/midnight PT
-const closedStartDate = i18n.moment( 'Thu, 23 Nov 2017 00:00:00 +0000' );
-const closedEndDate = i18n.moment( 'Fri, 24 Nov 2017 00:00:00 +0000' );
-
 const HelpContactClosed = ( { translate } ) => {
 	return (
 		<div className="help-contact-closed">
-			<FormSectionHeading>{ translate( 'Limited Support on Thanksgiving' ) }</FormSectionHeading>
+			<FormSectionHeading>{ translate( 'Limited Support over Christmas' ) }</FormSectionHeading>
 			<div>
 				<p>
-					{ translate(
-						'Live chat support will be closed for the Thanksgiving holiday on %(closed_start_date)s. ' +
-							'Email support will be open during that time, and we will reopen live chat on %(closed_end_date)s.',
-						{
-							args: {
-								closed_start_date: closedStartDate.format( 'dddd, MMMM D' ),
-								closed_end_date: closedEndDate.format( 'dddd, MMMM D' ),
-							},
-						}
-					) }
+					{ i18n.moment() < christmas2017ClosureStartsAt
+						? translate(
+								'Live chat will be closed on Sunday, December 24th and Monday, December 25th for the Christmas holiday. ' +
+									'If you need to get in touch with us, you’ll be able to submit a support request from this page and ' +
+									'we will get to it as fast as we can. Live chat will reopen on December 26th. Thank you!'
+							)
+						: translate(
+								'Live chat is closed today for for the Christmas holiday. If you need to get in touch with us, ' +
+									'you can submit a support request below and we will get to it as fast as we can. Live chat will ' +
+									'reopen at 00:00 UTC on December 26. Thank you!'
+							) }
 				</p>
 			</div>
 			<hr />

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -76,10 +76,8 @@ const SUPPORT_LIVECHAT = 'SUPPORT_LIVECHAT';
 const SUPPORT_TICKET = 'SUPPORT_TICKET';
 const SUPPORT_FORUM = 'SUPPORT_FORUM';
 
-const startShowingThanksgiving2017ClosureNoticeAt = i18n.moment(
-	'Thu, 23 Nov 2017 00:00:00 +0000'
-);
-const stopShowingThanksgiving2017ClosureNoticeAt = i18n.moment( 'Fri, 24 Nov 2017 00:00:00 +0000' );
+const startShowingChristmas2017ClosureNoticeAt = i18n.moment( 'Sun, 17 Dec 2017 00:00:00 +0000' );
+const stopShowingChristmas2017ClosureNoticeAt = i18n.moment( 'Tue, 26 Dec 2017 00:00:00 +0000' );
 
 class HelpContact extends React.Component {
 	state = {
@@ -685,14 +683,14 @@ class HelpContact extends React.Component {
 
 		const currentDate = Date.now();
 
-		// Customers sent to Directly and Forum are not affected by the Thanksgiving closures
-		const isUserAffectedByThanksgiving2017Closure =
+		// Customers sent to Directly and Forum are not affected by the Christmas closures
+		const isUserAffectedByChristmas2017Closure =
 			supportVariation !== SUPPORT_DIRECTLY && supportVariation !== SUPPORT_FORUM;
 
 		const shouldShowClosureNotice =
-			isUserAffectedByThanksgiving2017Closure &&
-			currentDate > startShowingThanksgiving2017ClosureNoticeAt &&
-			currentDate < stopShowingThanksgiving2017ClosureNoticeAt;
+			isUserAffectedByChristmas2017Closure &&
+			currentDate > startShowingChristmas2017ClosureNoticeAt &&
+			currentDate < stopShowingChristmas2017ClosureNoticeAt;
 
 		return (
 			<div>

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -28,7 +28,6 @@ import wpcomLib from 'lib/wp';
 import notices from 'notices';
 import analytics from 'lib/analytics';
 import { isOlarkTimedOut } from 'state/ui/olark/selectors';
-import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import getHappychatUserInfo from 'state/happychat/selectors/get-happychat-userinfo';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import {
@@ -49,6 +48,7 @@ import {
 	getCurrentUser,
 	getCurrentUserLocale,
 	getCurrentUserSiteCount,
+	isCurrentUserEmailVerified,
 } from 'state/current-user/selectors';
 import {
 	askQuestion as askDirectlyQuestion,


### PR DESCRIPTION
Adds a banner to the top of the Contact Us form if you're eligible for live chat, noting that live chat will be closed on Dec 24 & 25.

Ref 477-gh-hg

### To test

Fake the dates to ensure things will show up correctly:

- As-is, you shouldn't see any closure messages.

- Change `startShowingChristmas2017ClosureNoticeAt` to `'Sun, 10 Dec 2017 00:00:00 +0000'`. You should see the first closure message appear.

- Now also change `christmas2017ClosureStartsAt` to `'Sun, 10 Dec 2017 00:00:00 +0000'`. You should see the second closure message appear.

- Now also change `stopShowingChristmas2017ClosureNoticeAt` to `'Tue, 12 Dec 2017 00:00:00 +0000'`. The closure message should go away again.