### PR TITLE
Concierge Chats: Use availability data from the API

### DIFF
--- a/client/me/concierge/calendar-step.js
+++ b/client/me/concierge/calendar-step.js
@@ -13,49 +13,48 @@ import CalendarCard from './calendar-card';
 import CompactCard from 'components/card/compact';
 import HeaderCake from 'components/header-cake';
 
-const generateMockData = () => {
-	// This is a temporary function to simulate the data that will be gathered from Redux.
-	// It's hard-coded to show some of the UI, e.g. what it looks like on a day with no
-	// available times.
-	const today = moment().startOf( 'day' );
-	const tomorrow = moment( today ).add( 1, 'day' );
-	const nextDay = moment( today ).add( 2, 'days' );
+const NUMBER_OF_DAYS_TO_SHOW = 7;
 
-	return [
-		{
-			date: today.valueOf(),
-			times: [
-				today.set( { hour: 9, minute: 30 } ).valueOf(),
-				today.set( { hour: 10, minute: 15 } ).valueOf(),
-				today.set( { hour: 21, minute: 0 } ).valueOf(),
-			],
-		},
-		{
-			date: tomorrow.valueOf(),
-			times: [],
-		},
-		{
-			date: nextDay.valueOf(),
-			times: [
-				nextDay.set( { hour: 7, minute: 0 } ).valueOf(),
-				nextDay.set( { hour: 7, minute: 45 } ).valueOf(),
-				nextDay.set( { hour: 8, minute: 0 } ).valueOf(),
-				nextDay.set( { hour: 13, minute: 15 } ).valueOf(),
-			],
-		},
-	];
+const groupAvailableTimesByDate = availableTimes => {
+	const dates = {};
+
+	// Stub an object of { date: X, times: [] } for each day we care about
+	for ( let x = 0; x < NUMBER_OF_DAYS_TO_SHOW; x++ ) {
+		const startOfDay = moment()
+			.startOf( 'day' )
+			.add( x, 'days' )
+			.valueOf();
+		dates[ startOfDay ] = { date: startOfDay, times: [] };
+	}
+
+	// Go through all available times and bundle them into each date object
+	availableTimes.forEach( ( { beginTimestamp } ) => {
+		const startOfDay = moment( beginTimestamp )
+			.startOf( 'day' )
+			.valueOf();
+		if ( dates.hasOwnProperty( startOfDay ) ) {
+			dates[ startOfDay ].times.push( beginTimestamp );
+		}
+	} );
+
+	// Convert the dates object into an array sorted by date and return it
+	return Object.keys( dates )
+		.sort()
+		.map( date => dates[ date ] );
 };
 
 class CalendarStep extends Component {
 	static propTypes = {
+		availableTimes: PropTypes.arrayOf(
+			PropTypes.shape( { beginTimestamp: PropTypes.number.isRequired } )
+		).isRequired,
 		onBack: PropTypes.func.isRequired,
 		onComplete: PropTypes.func.isRequired,
 	};
 
 	render() {
-		const { translate } = this.props;
-		// TODO: Replace mock data with data from Redux
-		const availability = generateMockData();
+		const { availableTimes, translate } = this.props;
+		const availability = groupAvailableTimesByDate( availableTimes );
 
 		return (
 			<div>

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -54,10 +54,10 @@ class ConciergeMain extends Component {
 	};
 
 	getDisplayComponent = () => {
-		const { shifts, site } = this.props;
+		const { availableTimes, site } = this.props;
 		const CurrentStep = STEP_COMPONENTS[ this.state.currentStep ];
 
-		if ( ! shifts || ! site || ! site.plan ) {
+		if ( ! availableTimes || ! site || ! site.plan ) {
 			return <Skeleton />;
 		}
 
@@ -68,7 +68,7 @@ class ConciergeMain extends Component {
 		// We have shift data and this is a business site — show the signup steps
 		return (
 			<CurrentStep
-				shifts={ shifts }
+				availableTimes={ availableTimes }
 				site={ site }
 				onComplete={ this.goToNextStep }
 				onBack={ this.goToPreviousStep }
@@ -94,7 +94,7 @@ class ConciergeMain extends Component {
 
 export default connect(
 	( state, props ) => ( {
-		shifts: getConciergeShifts( state ),
+		availableTimes: getConciergeShifts( state ),
 		site: getSite( state, props.siteSlug ),
 	} ),
 	{ getConciergeShifts }

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/from-api.js
@@ -7,8 +7,9 @@ import { makeParser } from 'state/data-layer/wpcom-http/utils';
 import responseSchema from './schema';
 
 export const transformShift = shift => ( {
-	beginTimestamp: shift.begin_timestamp,
-	endTimestamp: shift.end_timestamp,
+	// Convert Unix seconds-based timestamps to JS milliseconds-based timestamps
+	beginTimestamp: shift.begin_timestamp * 1000,
+	endTimestamp: shift.end_timestamp * 1000,
 } );
 
 export const transform = response => response.map( transformShift );

--- a/client/state/data-layer/wpcom/concierge/schedules/shifts/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/shifts/test/from-api.js
@@ -14,9 +14,10 @@ describe( 'transformShift()', () => {
 			not_going_to_take_this: 'should ignore this one',
 		};
 
+		// Note: We're ensuring that the timestamps are converted from Unix seconds to JS milliseconds
 		expect( transformShift( mockShift ) ).toEqual( {
-			beginTimestamp: mockShift.begin_timestamp,
-			endTimestamp: mockShift.end_timestamp,
+			beginTimestamp: mockShift.begin_timestamp * 1000,
+			endTimestamp: mockShift.end_timestamp * 1000,
 		} );
 	} );
 } );
@@ -38,12 +39,12 @@ describe( 'fromApi()', () => {
 
 		const expectedResult = [
 			{
-				beginTimestamp: validResponse[ 0 ].begin_timestamp,
-				endTimestamp: validResponse[ 0 ].end_timestamp,
+				beginTimestamp: validResponse[ 0 ].begin_timestamp * 1000,
+				endTimestamp: validResponse[ 0 ].end_timestamp * 1000,
 			},
 			{
-				beginTimestamp: validResponse[ 1 ].begin_timestamp,
-				endTimestamp: validResponse[ 1 ].end_timestamp,
+				beginTimestamp: validResponse[ 1 ].begin_timestamp * 1000,
+				endTimestamp: validResponse[ 1 ].end_timestamp * 1000,
 			},
 		];
 		expect( fromApi( validResponse ) ).toEqual( expectedResult );


### PR DESCRIPTION
Use the data being pulled from the Concierge API to power the Calendar Step.

Ref: 484-gh-hg

### To test
- Ensure that the times showing up in the Calendar step match what's being sent in the `/concierge/schedules/X/shifts` API request.