### PR TITLE
Import only the action types used in client/state/preview

### DIFF
--- a/client/state/preview/actions.js
+++ b/client/state/preview/actions.js
@@ -10,7 +10,13 @@ import wpcom from 'lib/wp';
 /**
  * Internal dependencies
  */
-import * as ActionTypes from 'state/action-types';
+import {
+	PREVIEW_MARKUP_RECEIVE,
+	PREVIEW_CUSTOMIZATIONS_CLEAR,
+	PREVIEW_CUSTOMIZATIONS_UPDATE,
+	PREVIEW_CUSTOMIZATIONS_UNDO,
+	PREVIEW_CUSTOMIZATIONS_SAVED,
+} from 'state/action-types';
 import * as customizationSaveFunctions from './save-functions';
 
 const debug = debugFactory( 'calypso:preview-actions' );
@@ -39,23 +45,23 @@ export function fetchPreviewMarkup( site, slug, customizations ) {
 }
 
 export function gotMarkup( siteId, markup ) {
-	return { type: ActionTypes.PREVIEW_MARKUP_RECEIVE, markup, siteId };
+	return { type: PREVIEW_MARKUP_RECEIVE, markup, siteId };
 }
 
 export function clearCustomizations( siteId ) {
-	return { type: ActionTypes.PREVIEW_CUSTOMIZATIONS_CLEAR, siteId };
+	return { type: PREVIEW_CUSTOMIZATIONS_CLEAR, siteId };
 }
 
 export function updateCustomizations( siteId, customizations ) {
-	return { type: ActionTypes.PREVIEW_CUSTOMIZATIONS_UPDATE, customizations, siteId };
+	return { type: PREVIEW_CUSTOMIZATIONS_UPDATE, customizations, siteId };
 }
 
 export function undoCustomization( siteId ) {
-	return { type: ActionTypes.PREVIEW_CUSTOMIZATIONS_UNDO, siteId };
+	return { type: PREVIEW_CUSTOMIZATIONS_UNDO, siteId };
 }
 
 export function customizationsSaved( siteId ) {
-	return { type: ActionTypes.PREVIEW_CUSTOMIZATIONS_SAVED, siteId };
+	return { type: PREVIEW_CUSTOMIZATIONS_SAVED, siteId };
 }
 
 export function saveCustomizations() {

--- a/client/state/preview/reducer.js
+++ b/client/state/preview/reducer.js
@@ -4,7 +4,13 @@
  * Internal dependencies
  */
 
-import * as ActionTypes from 'state/action-types';
+import {
+	PREVIEW_MARKUP_RECEIVE,
+	PREVIEW_CUSTOMIZATIONS_CLEAR,
+	PREVIEW_CUSTOMIZATIONS_UPDATE,
+	PREVIEW_CUSTOMIZATIONS_UNDO,
+	PREVIEW_CUSTOMIZATIONS_SAVED,
+} from 'state/action-types';
 import { previewSchema } from './schema';
 
 const siteInitialState = {
@@ -17,24 +23,24 @@ const siteInitialState = {
 function siteReducer( newState = siteInitialState, action ) {
 	const state = Object.assign( {}, siteInitialState, newState );
 	switch ( action.type ) {
-		case ActionTypes.PREVIEW_MARKUP_RECEIVE:
+		case PREVIEW_MARKUP_RECEIVE:
 			if ( action.markup === state.previewMarkup ) {
 				return state;
 			}
 			return Object.assign( {}, state, { previewMarkup: action.markup } );
-		case ActionTypes.PREVIEW_CUSTOMIZATIONS_CLEAR:
+		case PREVIEW_CUSTOMIZATIONS_CLEAR:
 			return Object.assign( {}, state, {
 				isUnsaved: false,
 				customizations: {},
 				previousCustomizations: [],
 			} );
-		case ActionTypes.PREVIEW_CUSTOMIZATIONS_UPDATE:
+		case PREVIEW_CUSTOMIZATIONS_UPDATE:
 			return Object.assign( {}, state, {
 				isUnsaved: true,
 				previousCustomizations: state.previousCustomizations.concat( state.customizations ),
 				customizations: Object.assign( {}, state.customizations, action.customizations ),
 			} );
-		case ActionTypes.PREVIEW_CUSTOMIZATIONS_UNDO:
+		case PREVIEW_CUSTOMIZATIONS_UNDO:
 			const undoneCustomizations =
 				state.previousCustomizations.length > 0
 					? state.previousCustomizations.slice( -1 )[ 0 ]
@@ -44,7 +50,7 @@ function siteReducer( newState = siteInitialState, action ) {
 				previousCustomizations: state.previousCustomizations.slice( 0, -1 ),
 				customizations: undoneCustomizations,
 			} );
-		case ActionTypes.PREVIEW_CUSTOMIZATIONS_SAVED:
+		case PREVIEW_CUSTOMIZATIONS_SAVED:
 			return Object.assign( {}, state, { isUnsaved: false } );
 	}
 	return state;
@@ -52,11 +58,11 @@ function siteReducer( newState = siteInitialState, action ) {
 
 const preview = function( state = {}, action ) {
 	switch ( action.type ) {
-		case ActionTypes.PREVIEW_MARKUP_RECEIVE:
-		case ActionTypes.PREVIEW_CUSTOMIZATIONS_CLEAR:
-		case ActionTypes.PREVIEW_CUSTOMIZATIONS_UPDATE:
-		case ActionTypes.PREVIEW_CUSTOMIZATIONS_UNDO:
-		case ActionTypes.PREVIEW_CUSTOMIZATIONS_SAVED:
+		case PREVIEW_MARKUP_RECEIVE:
+		case PREVIEW_CUSTOMIZATIONS_CLEAR:
+		case PREVIEW_CUSTOMIZATIONS_UPDATE:
+		case PREVIEW_CUSTOMIZATIONS_UNDO:
+		case PREVIEW_CUSTOMIZATIONS_SAVED:
 			return Object.assign( {}, state, {
 				[ action.siteId ]: siteReducer( state[ action.siteId ], action ),
 			} );


### PR DESCRIPTION
I am trying to create a codemod script to move the imports of data-layer files (see #20667). The way these files imports `state/action-types` creates an exception for my script. I would like to get them fixed so I can parse the files consistently.

@sirbrillig Could you review this pull request? Thank you!