### PR TITLE
Fetch the user's site count for AllSites component from Redux

### DIFF
--- a/client/my-sites/all-sites/index.jsx
+++ b/client/my-sites/all-sites/index.jsx
@@ -17,9 +17,7 @@ import classNames from 'classnames';
 import AllSitesIcon from 'my-sites/all-sites-icon';
 import Count from 'components/count';
 import { getSites } from 'state/selectors';
-import userLib from 'lib/user';
-
-const user = userLib();
+import { getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
 
 class AllSites extends Component {
 	static defaultProps = {
@@ -49,8 +47,7 @@ class AllSites extends Component {
 	};
 
 	renderSiteCount() {
-		const count = this.props.count || user.get().visible_site_count;
-		return <Count count={ count } />;
+		return <Count count={ this.props.count } />;
 	}
 
 	render() {
@@ -92,6 +89,7 @@ class AllSites extends Component {
 }
 
 export default connect( ( state, props ) => {
-	const { sites = getSites( state ) } = props;
-	return { sites };
+	// If sites or count are not specified as props, fetch the default values from Redux
+	const { sites = getSites( state ), count = getCurrentUserVisibleSiteCount( state ) } = props;
+	return { sites, count };
 } )( localize( AllSites ) );

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -79,6 +79,21 @@ export function getCurrentUserSiteCount( state ) {
 }
 
 /**
+ * Returns the number of visible sites for the current user.
+ *
+ * @param  {Object}  state  Global state tree
+ * @return {?Number}        Current user visible site count
+ */
+export function getCurrentUserVisibleSiteCount( state ) {
+	const user = getCurrentUser( state );
+	if ( ! user ) {
+		return null;
+	}
+
+	return user.visible_site_count || 0;
+}
+
+/**
  * Returns the currency code for the current user.
  *
  * @param  {Object}  state  Global state tree


### PR DESCRIPTION
When the count is fetched from the `lib/user` module, the component is not rerendered when the count gets updated. This patch is fixing this by adding a `getCurrentUserVisibleSiteCount` selector and getting the count from Redux.

The site count displayed in `AllSites` is sometimes not correct after adding and removing a site. This PR is one of several steps that attempt to fix that.