### PR TITLE
Editor: Revisions: Fix possible double modal window & simplify auto-selection

### DIFF
--- a/client/post-editor/editor-ground-control/history-button.jsx
+++ b/client/post-editor/editor-ground-control/history-button.jsx
@@ -13,20 +13,15 @@ import { flow } from 'lodash';
  */
 import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
 
-import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
-
-const HistoryButton = ( { loadRevision, postId, siteId, openDialog, translate } ) => (
+const HistoryButton = ( { openDialog, translate } ) => (
 	<div className="editor-ground-control__history">
 		<button className="editor-ground-control__history-button button is-link" onClick={ openDialog }>
 			{ translate( 'History' ) }
 		</button>
-		<EditorRevisionsDialog loadRevision={ loadRevision } postId={ postId } siteId={ siteId } />
 	</div>
 );
 
 HistoryButton.propTypes = {
-	loadRevision: PropTypes.func.isRequired,
-
 	// connected to dispatch
 	openDialog: PropTypes.func.isRequired,
 

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -16,7 +16,6 @@ import { get, head, isEmpty, map } from 'lodash';
 import EditorRevisionsListHeader from './header';
 import EditorRevisionsListItem from './item';
 import { selectPostRevision } from 'state/posts/revisions/actions';
-import { getPostRevision } from 'state/selectors';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 
 class EditorRevisionsList extends PureComponent {
@@ -28,10 +27,7 @@ class EditorRevisionsList extends PureComponent {
 		selectedRevisionId: PropTypes.number,
 	};
 
-	trySelectingInterval = null;
-
 	selectRevision = revisionId => {
-		clearInterval( this.trySelectingInterval );
 		this.props.selectPostRevision( revisionId );
 	};
 
@@ -55,20 +51,22 @@ class EditorRevisionsList extends PureComponent {
 		KeyboardShortcuts.on( 'move-selection-down', this.selectPreviousRevision );
 
 		if ( ! this.props.selectedRevisionId ) {
-			this.trySelectingInterval = setInterval( this.trySelectingFirstRevision, 500 );
+			this.trySelectingFirstRevision();
 		}
 	}
 
 	componentWillUnmount() {
 		KeyboardShortcuts.off( 'move-selection-up', this.selectNextRevision );
 		KeyboardShortcuts.off( 'move-selection-down', this.selectPreviousRevision );
-
-		clearInterval( this.trySelectingInterval );
 	}
 
-	componentDidUpdate() {
-		// @TODO -- maybe short-circuit this if selection doesn't change...?
-		this.scrollToSelectedItem();
+	componentDidUpdate( prevProps ) {
+		if ( ! this.props.selectedRevisionId ) {
+			this.trySelectingFirstRevision();
+		}
+		if ( this.props.selectedRevisionId !== prevProps.selectedRevisionId ) {
+			this.scrollToSelectedItem();
+		}
 	}
 
 	scrollToSelectedItem() {
@@ -147,7 +145,6 @@ export default connect(
 		return {
 			nextRevisionId,
 			prevRevisionId,
-			selectedRevision: getPostRevision( state, selectedRevisionId ),
 		};
 	},
 	{ selectPostRevision }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -261,7 +261,6 @@ export const PostEditor = createReactClass( {
 	},
 
 	loadRevision: function( revision ) {
-		this.setState( { selectedRevisionId: null } );
 		this.restoreRevision( {
 			content: revision.post_content,
 			excerpt: revision.post_excerpt,
@@ -331,7 +330,6 @@ export const PostEditor = createReactClass( {
 						toggleSidebar={ this.toggleSidebar }
 						onMoreInfoAboutEmailVerify={ this.onMoreInfoAboutEmailVerify }
 						allPostsUrl={ this.getAllPostsUrl() }
-						selectedRevisionId={ this.state.selectedRevisionId }
 						isSidebarOpened={ this.props.layoutFocus === 'sidebar' }
 					/>
 					<div className="post-editor__content">

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -68,6 +68,7 @@ import { isWithinBreakpoint } from 'lib/viewport';
 import { isSitePreviewable } from 'state/sites/selectors';
 import { removep } from 'lib/formatting';
 import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-buttons';
+import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
 
 export const PostEditor = createReactClass( {
 	displayName: 'PostEditor',
@@ -306,6 +307,7 @@ export const PostEditor = createReactClass( {
 				<EditorDocumentHead />
 				<EditorPostTypeUnsupported />
 				<EditorForbidden />
+				<EditorRevisionsDialog loadRevision={ this.loadRevision } />
 				<div className="post-editor__inner">
 					<EditorGroundControl
 						setPostDate={ this.setPostDate }

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -48,6 +48,7 @@ jest.mock( 'post-editor/invalid-url-dialog', () => require( 'components/empty-co
 jest.mock( 'post-editor/restore-post-dialog', () => require( 'components/empty-component' ) );
 jest.mock( 'post-editor/editor-sidebar', () => require( 'components/empty-component' ) );
 jest.mock( 'post-editor/editor-status-label', () => require( 'components/empty-component' ) );
+jest.mock( 'post-editor/editor-revisions/dialog', () => require( 'components/empty-component' ) );
 jest.mock( 'query', () => require( 'component-query' ), { virtual: true } );
 jest.mock( 'tinymce/tinymce', () => require( 'components/empty-component' ) );
 // TODO: REDUX - add proper tests when whole post-editor is reduxified


### PR DESCRIPTION
This decouples `HistoryButton` from `EditorRevisionsDialog`. Now we can have multiple History buttons on a single page and they all will open just a single modal window that is now managed by `PostEditor` directly. 

As part of this, I also removed interval hacks and replaced them by lifecycle methods. Namely for selecting the first revision when you first open the window. I also cleaned up some dead code after reduxification and guareded the scrolling to trigger only when selections change.

To test:

- just test the general functionality like: modal can open & close, first revision will get selected, j/k work…