### PR TITLE
Reader: add post notifications toggle to settings popover in development

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -69,6 +69,7 @@
 @import 'blocks/reader-post-options-menu/style';
 @import 'blocks/reader-recommended-sites/style';
 @import 'blocks/reader-related-card-v2/style';
+@import 'blocks/reader-site-notification-settings/style';
 @import 'blocks/reader-share/style';
 @import 'blocks/reader-subscription-list-item/style';
 @import 'blocks/reader-visit-link/style';

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -20,6 +20,8 @@ import SiteIcon from 'blocks/site-icon';
 import BlogStickers from 'blocks/blog-stickers';
 import ReaderFeedHeaderSiteBadge from './badge';
 import ReaderEmailSettings from 'blocks/reader-email-settings';
+import ReaderSiteNotificationSettings from 'blocks/reader-site-notification-settings';
+import config from 'config';
 import userSettings from 'lib/user-settings';
 import { isFollowing } from 'state/selectors';
 
@@ -50,11 +52,18 @@ class FeedHeader extends Component {
 		const siteTitle = getSiteName( { feed, site } );
 		const siteUrl = getSiteUrl( { feed, site } );
 		const isEmailBlocked = userSettings.getSetting( 'subscription_delivery_email_blocked' );
+		const siteId = site && site.ID;
 
 		const classes = classnames( 'reader-feed-header', {
 			'is-placeholder': ! site && ! feed,
 			'has-back-button': showBack,
 		} );
+
+		const notificationSettings = config.isEnabled( 'reader/new-post-notifications' ) ? (
+			<ReaderSiteNotificationSettings siteId={ siteId } />
+		) : (
+			<ReaderEmailSettings siteId={ siteId } />
+		);
 
 		return (
 			<div className={ classes }>
@@ -79,9 +88,7 @@ class FeedHeader extends Component {
 						{ site &&
 							following &&
 							! isEmailBlocked && (
-								<div className="reader-feed-header__email-settings">
-									<ReaderEmailSettings siteId={ site.ID } />
-								</div>
+								<div className="reader-feed-header__email-settings">{ notificationSettings }</div>
 							) }
 					</div>
 				</div>

--- a/client/blocks/reader-site-notification-settings/README.md
+++ b/client/blocks/reader-site-notification-settings/README.md
@@ -1,0 +1,9 @@
+# Reader Site Notifications Settings
+
+Provides a Settings link with a popover containing notification settings for the specified site.
+
+## Props
+
+| Prop | Type | Required | Description |
+|-----|:----:|:--------:|-------------|
+| `siteId`| Number | Yes | The site ID to manage notifications for |

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -156,6 +156,10 @@ class ReaderSiteNotificationSettings extends Component {
 }
 
 const mapStateToProps = ( state, ownProps ) => {
+	if ( ! ownProps.siteId ) {
+		return {};
+	}
+
 	const follow = find( getReaderFollows( state ), { blog_ID: ownProps.siteId } );
 	const deliveryMethods = get( follow, [ 'delivery_methods', 'email' ], {} );
 	const { send_posts, post_delivery_frequency, send_comments } = deliveryMethods;

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -1,0 +1,172 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { find, get, noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import ReaderPopover from 'components/reader-popover';
+import SegmentedControl from 'components/segmented-control';
+import ControlItem from 'components/segmented-control/item';
+import FormToggle from 'components/forms/form-toggle';
+import { getReaderFollows } from 'state/selectors';
+import {
+	subscribeToNewPostEmail,
+	updateNewPostEmailSubscription,
+	unsubscribeToNewPostEmail,
+	subscribeToNewCommentEmail,
+	unsubscribeToNewCommentEmail,
+} from 'state/reader/follows/actions';
+
+class ReaderSiteNotificationSettings extends Component {
+	static displayName = 'ReaderSiteNotificationSettings';
+	static propTypes = {
+		siteId: PropTypes.number,
+		deliveryFrequency: PropTypes.string,
+	};
+
+	state = {
+		showPopover: false,
+		selected: this.props.deliveryFrequency,
+	};
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.deliveryFrequency !== this.props.deliveryFrequency ) {
+			this.setState( { selected: nextProps.deliveryFrequency } );
+		}
+	}
+
+	togglePopoverVisibility = () => {
+		this.setState( { showPopover: ! this.state.showPopover } );
+	};
+
+	closePopover = () => {
+		this.setState( { showPopover: false } );
+	};
+
+	saveIconRef = ref => ( this.iconRef = ref );
+	saveSpanRef = ref => ( this.spanRef = ref );
+
+	setSelected = text => () => {
+		const { siteId } = this.props;
+		this.setState( { selected: text } );
+		this.props.updateNewPostEmailSubscription( siteId, text );
+	};
+
+	toggleNewPostEmail = () => {
+		const toggleSubscription = this.props.notifyOnNewPosts
+			? this.props.unsubscribeToNewPostEmail
+			: this.props.subscribeToNewPostEmail;
+
+		toggleSubscription( this.props.siteId );
+	};
+
+	toggleNewCommentEmail = () => {
+		const toggleSubscription = this.props.notifyOnNewComments
+			? this.props.unsubscribeToNewCommentEmail
+			: this.props.subscribeToNewCommentEmail;
+
+		toggleSubscription( this.props.siteId );
+	};
+
+	render() {
+		const { translate, notifyOnNewComments, notifyOnNewPosts } = this.props;
+
+		if ( ! this.props.siteId ) {
+			return null;
+		}
+
+		return (
+			<div className="reader-site-notification-settings">
+				<span
+					className="reader-site-notification-settings__button"
+					onClick={ this.togglePopoverVisibility }
+					ref={ this.saveSpanRef }
+				>
+					<Gridicon icon="cog" size={ 24 } ref={ this.saveIconRef } />
+					<span
+						className="reader-site-notification-settings__button-label"
+						title={ translate( 'Email settings' ) }
+					>
+						{ translate( 'Settings' ) }
+					</span>
+				</span>
+
+				<ReaderPopover
+					onClose={ this.closePopover }
+					isVisible={ this.state.showPopover }
+					context={ this.iconRef }
+					ignoreContext={ this.spanRef }
+					position={ 'bottom left' }
+					className="reader-site-notification-settings__popout"
+				>
+					<div className="reader-site-notification-settings__popout-toggle">
+						{ translate( 'New post notifications' ) }
+						<FormToggle onChange={ noop } checked={ false } />
+						<p className="reader-site-notification-settings__popout-hint">
+							{ translate( 'Receive web and mobile notifications for new posts from this site' ) }
+						</p>
+					</div>
+
+					<div className="reader-site-notification-settings__popout-toggle">
+						{ translate( 'New post emails' ) }
+						<FormToggle onChange={ this.toggleNewPostEmail } checked={ notifyOnNewPosts } />
+					</div>
+					{ notifyOnNewPosts && (
+						<SegmentedControl>
+							<ControlItem
+								selected={ this.state.selected === 'instantly' }
+								onClick={ this.setSelected( 'instantly' ) }
+							>
+								{ translate( 'Instantly' ) }
+							</ControlItem>
+							<ControlItem
+								selected={ this.state.selected === 'daily' }
+								onClick={ this.setSelected( 'daily' ) }
+							>
+								{ translate( 'Daily' ) }
+							</ControlItem>
+							<ControlItem
+								selected={ this.state.selected === 'weekly' }
+								onClick={ this.setSelected( 'weekly' ) }
+							>
+								{ translate( 'Weekly' ) }
+							</ControlItem>
+						</SegmentedControl>
+					) }
+					<div className="reader-site-notification-settings__popout-toggle">
+						{ translate( 'New comment emails' ) }
+						<FormToggle onChange={ this.toggleNewCommentEmail } checked={ notifyOnNewComments } />
+					</div>
+				</ReaderPopover>
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = ( state, ownProps ) => {
+	const follow = find( getReaderFollows( state ), { blog_ID: ownProps.siteId } );
+	const deliveryMethods = get( follow, [ 'delivery_methods', 'email' ], {} );
+	const { send_posts, post_delivery_frequency, send_comments } = deliveryMethods;
+
+	return {
+		notifyOnNewComments: !! send_comments,
+		notifyOnNewPosts: !! send_posts,
+		deliveryFrequency: post_delivery_frequency,
+	};
+};
+
+export default connect( mapStateToProps, {
+	subscribeToNewPostEmail,
+	unsubscribeToNewPostEmail,
+	updateNewPostEmailSubscription,
+	subscribeToNewCommentEmail,
+	unsubscribeToNewCommentEmail,
+} )( localize( ReaderSiteNotificationSettings ) );

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -109,7 +109,11 @@ class ReaderSiteNotificationSettings extends Component {
 				>
 					<div className="reader-site-notification-settings__popout-toggle">
 						{ translate( 'New post notifications' ) }
-						<FormToggle onChange={ noop } checked={ false } />
+						<FormToggle
+							onChange={ noop }
+							checked={ false }
+							wrapperClassName="reader-site-notification-settings__popout-form-toggle"
+						/>
 						<p className="reader-site-notification-settings__popout-hint">
 							{ translate( 'Receive web and mobile notifications for new posts from this site' ) }
 						</p>

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -47,6 +47,10 @@
 	}
 }
 
+.reader-site-notification-settings__popout-form-toggle {
+	margin-left: 10px;
+}
+
 .reader-site-notification-settings__popout-hint {
 	color: $gray;
 	font-size: 12px;

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -1,0 +1,54 @@
+.reader-site-notification-settings__button {
+	color: $gray;
+
+	&:hover {
+		cursor: pointer;
+	}
+}
+
+.reader-site-notification-settings__button-label {
+	font-size: 14px;
+	margin-left: -2px;
+
+	@include breakpoint( "<660px" ) {
+		display: none;
+	}
+}
+
+.reader-popover__wrapper {
+	.segmented-control {
+		background: inherit;
+		padding: 0 12px 0 16px;
+	}
+
+	.segmented-control__link {
+		background: $white;
+	}
+}
+
+.reader-site-notification-settings__popout-toggle {
+	color: $gray-dark;
+	display: flex;
+	justify-content: space-between;
+	font-size: 14px;
+	margin: 10px 0 10px 15px;
+}
+
+.reader-site-notification-settings .gridicons-cog {
+	fill: lighten( $gray, 10% );
+	height: 18px;
+	position: relative;
+		left: 0;
+		top: 8px;
+
+	@include breakpoint( ">660px" ) {
+		left: -4px;
+		top: 4px;
+	}
+}
+
+.reader-site-notification-settings__popout-hint {
+	color: $gray;
+	font-size: 12px;
+	display: none;
+}

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -14,7 +14,9 @@ import moment from 'moment';
 import ReaderAvatar from 'blocks/reader-avatar';
 import FollowButton from 'reader/follow-button';
 import { getStreamUrl } from 'reader/route';
-import EmailSettings from 'blocks/reader-email-settings';
+import ReaderEmailSettings from 'blocks/reader-email-settings';
+import ReaderSiteNotificationSettings from 'blocks/reader-site-notification-settings';
+import config from 'config';
 import {
 	getSiteName,
 	getSiteDescription,
@@ -43,7 +45,7 @@ function ReaderSubscriptionListItem( {
 	className = '',
 	translate,
 	followSource,
-	showEmailSettings,
+	showEmailSettings, // @todo rename to showNotificationSettings
 	showLastUpdatedDate,
 	isFollowing,
 	railcar,
@@ -82,6 +84,12 @@ function ReaderSubscriptionListItem( {
 	const recordAuthorClick = () => recordEvent( 'calypso_reader_author_link_clicked' );
 	const recordSiteUrlClick = () => recordEvent( 'calypso_reader_site_url_clicked' );
 	const recordAvatarClick = () => recordEvent( 'calypso_reader_avatar_clicked' );
+
+	const notificationSettings = config.isEnabled( 'reader/new-post-notifications' ) ? (
+		<ReaderSiteNotificationSettings siteId={ siteId } />
+	) : (
+		<ReaderEmailSettings siteId={ siteId } />
+	);
 
 	return (
 		<div
@@ -159,7 +167,7 @@ function ReaderSubscriptionListItem( {
 					siteId={ siteId }
 					railcar={ railcar }
 				/>
-				{ isFollowing && showEmailSettings && <EmailSettings siteId={ siteId } /> }
+				{ isFollowing && showEmailSettings && notificationSettings }
 			</div>
 		</div>
 	);

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -17,6 +17,7 @@ export default class FormToggle extends PureComponent {
 		disabled: PropTypes.bool,
 		id: PropTypes.string,
 		className: PropTypes.string,
+		wrapperClassName: PropTypes.string,
 		toggling: PropTypes.bool,
 		'aria-label': PropTypes.string,
 	};
@@ -71,7 +72,7 @@ export default class FormToggle extends PureComponent {
 
 	render() {
 		const id = this.props.id || 'toggle-' + this.id;
-		const wrapperClasses = classNames( 'form-toggle__wrapper', {
+		const wrapperClasses = classNames( 'form-toggle__wrapper', this.props.wrapperClassName, {
 			'is-disabled': this.props.disabled,
 		} );
 		const toggleClasses = classNames( 'form-toggle', this.props.className, {

--- a/config/development.json
+++ b/config/development.json
@@ -142,6 +142,7 @@
 		"reader/full-errors": true,
 		"reader/list-management": false,
 		"reader/nesting-arrow": true,
+		"reader/new-post-notifications": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/search": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -89,6 +89,7 @@
 		"reader/conversations": false,
 		"reader/following-intro": true,
 		"reader/nesting-arrow": true,
+		"reader/new-post-notifications": false,
 		"reader/related-posts": true,
 		"reader/search": true,
 		"resume-editing": true,

--- a/config/production.json
+++ b/config/production.json
@@ -97,6 +97,7 @@
 		"reader/following-intro": true,
 		"reader/full-errors": false,
 		"reader/nesting-arrow": true,
+		"reader/new-post-notifications": false,
 		"reader/tags-with-elasticsearch": false,
 		"reader/related-posts": true,
 		"reader/search": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -100,6 +100,7 @@
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/nesting-arrow": true,
+		"reader/new-post-notifications": false,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/tags-with-elasticsearch": false,

--- a/config/test.json
+++ b/config/test.json
@@ -90,6 +90,7 @@
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,
+		"reader/new-post-notifications": false,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/test.json
+++ b/config/test.json
@@ -90,7 +90,7 @@
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,
-		"reader/new-post-notifications": false,
+		"reader/new-post-notifications": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -107,6 +107,7 @@
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/nesting-arrow": true,
+		"reader/new-post-notifications": false,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/search": true,


### PR DESCRIPTION
Adds a feature flag `reader/new-post-notifications` and, where enabled, uses the new `ReaderSiteNotificationSettings` block rather than `ReaderEmailSettings`.

The UI is not final and the toggle for new posts notifications is not yet functional. It'll be connected up in subsequent PRs.

See https://github.com/Automattic/wp-calypso/issues/19440.

<img width="286" alt="screen shot 2017-12-14 at 13 11 11" src="https://user-images.githubusercontent.com/17325/33993970-aa3dba40-e0d0-11e7-85d0-ce073095b506.png">

### Why a new block?

I started adding conditionals to `ReaderEmailSettings` based on the feature flag, but decided that the layout and functionality of the new popover is sufficiently different to merit a new block.

It'd need a rename at some point anyway, because the new block contains both email and push notification settings.

### To test

In development mode, ensure that you are shown the new post notification toggle in the popover from the Reader feed header and from Manage Following.

In other environments, ensure that you are shown the existing email settings popover.