### PR TITLE
Post Type List: fix height of PostImage

### DIFF
--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -56,7 +56,8 @@
 		top: 50%;
 		left: 50%;
 	transform: translate( -50%, -50% );
-	max-height: 100%;
+	height: 100%;
+	max-height: 80px;
 	max-width: none;
 }
 


### PR DESCRIPTION
In the condensed post list and custom post type list, when featured images were narrow or the post item was tall (due to long post titles on smaller viewports), the image could stretch and pixelate. This adds an absolute `max-height` (equal to the Photon request) and relative `height` to the image. Other featured images should be relatively unchanged.

**Before:** | **After:**
----------- | ----------
<img width="728" alt="desktop-before" src="https://user-images.githubusercontent.com/942359/33996086-150f3c18-e0ae-11e7-81db-d7f8114b92b8.png"> | <img width="730" alt="desktop-after" src="https://user-images.githubusercontent.com/942359/33996096-1c312ef2-e0ae-11e7-9717-e4d238db0612.png">
----------- | ----------
<img width="322" alt="mobile-before" src="https://user-images.githubusercontent.com/942359/33996106-2ab2f834-e0ae-11e7-9376-0dcc00430b93.png"> | <img width="322" alt="mobile-after" src="https://user-images.githubusercontent.com/942359/33996112-303aca02-e0ae-11e7-9c96-f847f19d257b.png">
