### PR TITLE
Activity Log: Updated styles to prep for new event formatting

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -76,9 +76,12 @@ class ActivityLogItem extends Component {
 				/>
 				{ activityDescription && (
 					<div className="activity-log-item__description">
-						{ activityDescription.map( ( part, key ) => (
-							<FormattedBlock key={ key } content={ part } />
-						) ) }
+						<div className="activity-log-item__description-summary">
+							{ activityDescription.map( ( part, key ) => (
+								<FormattedBlock key={ key } content={ part } />
+							) ) }
+						</div>
+						<div className="activity-log-item__description-format">Plugin updated</div>
 					</div>
 				) }
 				{ activityTitle && <div className="activity-log-item__title">{ activityTitle }</div> }

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -76,15 +76,14 @@ class ActivityLogItem extends Component {
 				/>
 				{ activityDescription && (
 					<div className="activity-log-item__description">
-						<div className="activity-log-item__description-summary">
+						<div className="activity-log-item__description-content">
 							{ activityDescription.map( ( part, key ) => (
 								<FormattedBlock key={ key } content={ part } />
 							) ) }
 						</div>
-						<div className="activity-log-item__description-format">Plugin updated</div>
+						{ activityTitle && <div className="activity-log-item__description-summary">{ activityTitle }</div> }
 					</div>
 				) }
-				{ activityTitle && <div className="activity-log-item__title">{ activityTitle }</div> }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -227,7 +227,6 @@
 	color: $gray-text-min;
 }
 
-.activity-log-item__title,
 .activity-log-item__description {
 	flex: 1 1 50%;
 	font-size: 14px;

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -219,26 +219,20 @@
 	}
 }
 
-.activity-log-item__actor-role {
+.activity-log-item__actor-role,
+.activity-log-item__description-format {
 	text-transform: capitalize;
 	font-size: 12px;
 	color: $gray-text-min;
 }
 
-.activity-log-item__title {
+.activity-log-item__title,
+.activity-log-item__description {
 	flex: 1 1 50%;
 	font-size: 14px;
 	word-break: break-word;
 
 	@include breakpoint( '<960px' ) {
 		margin-top: 8px;
-	}
-}
-
-.activity-log-item__description {
-	font-size: 14px;
-
-	@include breakpoint( '<960px' ) {
-		margin-top: 4px;
 	}
 }

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -237,8 +237,3 @@
 		margin-top: 8px;
 	}
 }
-
-.activity-log-item__description-summary {
-}
-.activity-log-item__description-content {
-}

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -155,6 +155,7 @@
 	padding-left: 56px;
 	align-items: center;
 	min-width: 0;
+	width: 100%;
 
 	@include breakpoint( '<960px' ) {
 		flex-direction: column;
@@ -220,7 +221,7 @@
 }
 
 .activity-log-item__actor-role,
-.activity-log-item__description-format {
+.activity-log-item__description-summary {
 	text-transform: capitalize;
 	font-size: 12px;
 	color: $gray-text-min;
@@ -235,4 +236,9 @@
 	@include breakpoint( '<960px' ) {
 		margin-top: 8px;
 	}
+}
+
+.activity-log-item__description-summary {
+}
+.activity-log-item__description-content {
 }


### PR DESCRIPTION
This is currently using fake data for the format so it will need to be replaced. I'm relying on y'all to hook it up. @enejb, this contains all you should need for layout and styles. Feel free to use this branch or copy the changes elsewhere. Thanks for your help!

Currently looks like this:

![image](https://user-images.githubusercontent.com/1123119/33997032-533ef554-e0a0-11e7-8e19-5a892ba54455.png)
