### PR TITLE
PostItem: record mc stats for title and image clicks

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -25,6 +25,7 @@ import {
 	isPostSelected,
 } from 'state/ui/post-type-list/selectors';
 import { hideSharePanel, togglePostSelection } from 'state/ui/post-type-list/actions';
+import { bumpStat } from 'state/analytics/actions';
 import ExternalLink from 'components/external-link';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import PostTime from 'blocks/post-time';
@@ -39,6 +40,10 @@ import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
 class PostItem extends React.Component {
 	hideCurrentSharePanel = () => {
 		this.props.hideSharePanel( this.props.globalId );
+	};
+
+	clickHandler = clickTarget => () => {
+		this.props.bumpStat( 'calypso_post_item_click', clickTarget );
 	};
 
 	toggleCurrentPostSelection = event => {
@@ -136,7 +141,7 @@ class PostItem extends React.Component {
 							{ isSiteInfoVisible && <PostTypeSiteInfo globalId={ globalId } /> }
 							{ isAuthorVisible && <PostTypePostAuthor globalId={ globalId } /> }
 						</div>
-						<h1 className="post-item__title">
+						<h1 className="post-item__title" onClick={ this.clickHandler( 'title' ) }>
 							{ ! externalPostLink && (
 								<a
 									href={ isPlaceholder || multiSelectEnabled ? null : postUrl }
@@ -165,7 +170,10 @@ class PostItem extends React.Component {
 							<PostActionCounts globalId={ globalId } />
 						</div>
 					</div>
-					<PostTypeListPostThumbnail globalId={ globalId } />
+					<PostTypeListPostThumbnail
+						globalId={ globalId }
+						onClick={ this.clickHandler( 'image' ) }
+					/>
 					{ ! multiSelectEnabled && <PostActionsEllipsisMenu globalId={ globalId } /> }
 				</div>
 				{ expandedContent }
@@ -216,6 +224,7 @@ export default connect(
 		};
 	},
 	{
+		bumpStat,
 		hideSharePanel,
 		togglePostSelection,
 	}

--- a/client/my-sites/post-type-list/post-thumbnail.jsx
+++ b/client/my-sites/post-type-list/post-thumbnail.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { get, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ import resizeImageUrl from 'lib/resize-image-url';
 import safeImageUrl from 'lib/safe-image-url';
 import { getNormalizedPost } from 'state/posts/selectors';
 
-function PostTypeListPostThumbnail( { thumbnail } ) {
+function PostTypeListPostThumbnail( { onClick, thumbnail } ) {
 	const classes = classnames( 'post-type-list__post-thumbnail-wrapper', {
 		'has-image': !! thumbnail,
 	} );
@@ -28,6 +28,7 @@ function PostTypeListPostThumbnail( { thumbnail } ) {
 				<img
 					src={ resizeImageUrl( safeImageUrl( thumbnail ), { h: 80 } ) }
 					className="post-type-list__post-thumbnail"
+					onClick={ onClick }
 				/>
 			) }
 		</div>
@@ -36,7 +37,12 @@ function PostTypeListPostThumbnail( { thumbnail } ) {
 
 PostTypeListPostThumbnail.propTypes = {
 	globalId: PropTypes.string,
+	onClick: PropTypes.func,
 	thumbnail: PropTypes.string,
+};
+
+PostTypeListPostThumbnail.defaultProps = {
+	onClick: noop,
 };
 
 export default connect( ( state, ownProps ) => {


### PR DESCRIPTION
This PR adds mc stats to record click on the title and the image within PostItem to allow us to get a better sense of how many users are attempting to click on the image.

![image](https://user-images.githubusercontent.com/363749/34002917-8ae7acda-e0b9-11e7-9311-afcb6227cd0a.png)


To test:
* Run the PR locally or use the calypso.live link below
* In your browser's console, debug mc stats: `localStorage.setItem('debug','calypso:analytics:mc')`
* Reload the page
* Visit the "Blog Posts" page and click on a post image. Ensure that the console shows the stat `calypso_post_item_click` being bumped with a value of `image`.
* Click on a post title. Ensure that the console shows the stat `calypso_post_item_click` being bumped with a value of `title`.