### PR TITLE
Use 'chat' icon for the Comments action menu item in post list.

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/comments.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/comments.jsx
@@ -32,7 +32,7 @@ class PostActionsEllipsisMenuComments extends PureComponent {
 		return (
 			<PopoverMenuItem
 				href={ `/comments/all/${ siteSlug }/${ postId }` }
-				icon="comment"
+				icon="chat"
 				onClick={ bumpStat }
 			>
 				{ translate( 'Comments', { context: 'noun' } ) }


### PR DESCRIPTION
This pull request updates the icon for the Comments action menu item in post list.

Before:

![screen shot 2017-12-14 at 4 48 22 pm](https://user-images.githubusercontent.com/1017839/34004616-a98d9d68-e0f8-11e7-99ec-5f9320e4465a.png)

After:

![screen shot 2017-12-14 at 4 47 48 pm](https://user-images.githubusercontent.com/1017839/34004608-a4e04126-e0f8-11e7-8827-5206d560d818.png)

To test:

- Checkout branch
- `npm start`
- Select a Site and navigate to Blog Posts
- Open the action menu
- Verify that the icon shown is the 'chat' icon (two speech bubbles)