### PR TITLE
Sidebar: fix to restore upsell ads old styling (Free Domain, Upgrade)

### DIFF
--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -58,6 +58,7 @@ export class DomainToPaidPlanNotice extends Component {
 				status="is-success"
 				showDismiss={ false }
 				text={ translate( 'Upgrade your site and save.' ) }
+				className="current-site__notice-upsell"
 			>
 				<NoticeAction onClick={ this.onClick } href={ actionLink }>
 					{ translate( 'Go' ) }

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -104,6 +104,7 @@ class SiteNotice extends React.Component {
 				status="is-success"
 				icon="info-outline"
 				text={ translate( 'Free domain with a plan' ) }
+				className="current-site__notice-upsell"
 			>
 				<NoticeAction
 					onClick={ this.props.clickFreeToPaidPlanNotice }

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -149,3 +149,16 @@
 		border-radius: 0;
 	}
 }
+
+.site__notices .current-site__notice-upsell {
+	background-color: $alert-green;
+
+	.notice__content {
+		padding-left: 0;
+	}
+
+	.notice__action {
+		color: $white;
+		text-transform: uppercase;
+	}
+}


### PR DESCRIPTION
This PR restores the styling of the upgrade banners in the sidebar that were changed as a side effect of #17796.

Before:

<img width="292" alt="screen shot 2017-12-14 at 18 11 04" src="https://user-images.githubusercontent.com/4389/34005117-2b8f9694-e0fa-11e7-9b96-37fbb89e36ee.png">


After:

<img width="283" alt="screen shot 2017-12-14 at 18 06 33" src="https://user-images.githubusercontent.com/4389/34005107-25696592-e0fa-11e7-996f-28e783d9400c.png">

_Note: in the screenshot I forced both the banners to be visible, they aren't normally._

The fix isn't amazing, it's just adding a class and overriding the styling. This needs later to me moved to an ad-hoc component for marketing purposes.

### To review

1. Open My Sites
2. Find a site with a Free Plan and created less than 180 days or change in code the eligibility conditions in the two files.
3. Check the banner shows up with the right colors.
4. Check also that other banners preserve the normal styling. 