### PR TITLE
Change the term avatar to profile picture

### DIFF
--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -24,9 +24,9 @@ const tasks = {
 	avatar_uploaded: {
 		title: 'Upload your profile picture',
 		description:
-			'Who’s the person behind the site? Personalize your posts and comments with a custom avatar.',
+			'Who’s the person behind the site? Personalize your posts and comments with a custom profile picture.',
 		duration: '2 mins',
-		completedTitle: 'You uploaded an avatar',
+		completedTitle: 'You uploaded a profile picture',
 		completedButtonText: 'Change',
 		url: '/me',
 		image: '/calypso/images/stats/tasks/upload-profile-picture.svg',


### PR DESCRIPTION
During some user testing, I discovered that people didn't know what the term `avatar` meant. This PR updates all public occurrences of `avatar` to `profile picture`

## Before
![image](https://user-images.githubusercontent.com/6981253/34008077-2777efb6-e0d2-11e7-9044-762e138b95b4.png)

![image](https://user-images.githubusercontent.com/6981253/34008091-32c21cd4-e0d2-11e7-8308-e379252efe40.png)


## After
![image](https://user-images.githubusercontent.com/6981253/34008046-0dc10dbe-e0d2-11e7-8b4a-b9f14d3bbb58.png)

![image](https://user-images.githubusercontent.com/6981253/34008054-14ed74c4-e0d2-11e7-8fb1-646b4a6bc93c.png)

cc @markryall @taggon @sararosso 