### PR TITLE
Preview: Fix theme preview buttons

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -16,7 +16,7 @@
 
 		.web-preview__content {
 			opacity: 1;
-			transform: translateY( 0 ) scale( 1 );
+			transform: translateY( 0 );
 		}
 	}
 
@@ -44,7 +44,7 @@
 	background: $gray-light;
 	border-radius: 4px 4px 0 0;
 	position: absolute;
-		top: 24px;
+		top: 0;
 		left: 0;
 		right: 0;
 		bottom: 0;
@@ -52,38 +52,13 @@
 	opacity: 0;
 	transform: translateY( 80vh );
 	transition: transform 0.2s ease-out,
-		opacity 0.1s ease-in-out,
-		max-width 0.2s ease-out;
+		opacity 0.1s ease-in-out;
 
-	.is-computer & {
-		max-width: 1200px;
-		@include breakpoint( ">960px" ) {
-			left: 24px;
-			right: 24px;
-			width: calc( 100% - 46px ); /* IE11 fix */
-		}
-	}
-
-	.is-tablet & {
-		max-width: 783px;
-	}
-
-	.is-phone & {
-		max-width: 460px;
-	}
-
-	.is-seo & {
-		max-width: 865px;
-	}
-}
-
-.web-preview.is-computer .web-preview__content,
-.web-preview.is-tablet .web-preview__content,
-.web-preview.is-phone .web-preview__content {
-	@include breakpoint( "<960px" ) {
-		top: 0;
-		width: 100%;
-		border-radius: 0;
+	@include breakpoint( ">960px" ) {
+		top: 24px;
+		left: 24px;
+		right: 24px;
+		width: calc( 100% - 46px ); /* IE11 fix */
 	}
 }
 
@@ -224,15 +199,29 @@ a.web-preview__external.button {
 .web-preview__frame {
 	display: block;
 	width: 100%;
+	max-width: 100%;
 	height: 100%;
 	opacity: 0;
-	transition: opacity 0.2s ease-in-out;
+	transition: opacity 0.2s ease-in-out,
+		max-width 0.2s ease-out;
 	margin: 0 auto;
 	pointer-events: none;
 
 	.is-loaded & {
 		opacity: 1;
 		pointer-events: all;
+	}
+
+	.is-tablet & {
+		max-width: 783px;
+	}
+
+	.is-phone & {
+		max-width: 460px;
+	}
+
+	.is-seo & {
+		max-width: 865px;
 	}
 }
 

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -84,7 +84,7 @@ class ThemePreview extends React.Component {
 
 		return (
 			<Button primary onClick={ this.onPrimaryButtonClick } href={ buttonHref }>
-				{ primaryOption.extendedLabel }
+				{ primaryOption.label }
 			</Button>
 		);
 	};
@@ -97,7 +97,7 @@ class ThemePreview extends React.Component {
 		const buttonHref = secondaryButton.getUrl ? secondaryButton.getUrl( this.props.themeId ) : null;
 		return (
 			<Button onClick={ this.onSecondaryButtonClick } href={ buttonHref }>
-				{ secondaryButton.extendedLabel }
+				{ secondaryButton.label }
 			</Button>
 		);
 	};
@@ -115,7 +115,7 @@ class ThemePreview extends React.Component {
 				{ this.props.demoUrl && (
 					<WebPreview
 						showPreview={ true }
-						showExternal={ true }
+						showExternal={ false }
 						showSEO={ false }
 						onClose={ this.props.hideThemePreview }
 						previewUrl={ this.props.demoUrl + '?demo=true&iframe=true&theme_preview=true' }


### PR DESCRIPTION
When previewing a theme currently, you'll see two additional buttons in the preview toolbar. These vary depending on the site's plan, but cause issues on smaller screens and when the device switcher is set to mobile.

This PR does a few things:

* Removes the "Visit Site" button from theme demo previews.
* Swaps out the theme demo button labels (like "Activate this design" or "Purchase this design") with their shorter counterparts ("Active" and "Purchase").
* Changes the the way the device picker works, shrinking just the preview and not the toolbar.

Here's a before and after:

![slice](https://user-images.githubusercontent.com/191598/34008216-8ed4ca6c-e0d2-11e7-8876-7a7aedf93c68.png)
