### PR TITLE
Show site segment test variant to 100% of english visitors

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -104,8 +104,8 @@ export default {
 	signupSiteSegmentStep: {
 		datestamp: '20170329',
 		variations: {
-			control: 50,
-			variant: 50,
+			control: 0,
+			variant: 100,
 		},
 		defaultVariation: 'control',
 	},


### PR DESCRIPTION
Our site segmentation test has concluded and we have a winner! More details here: p5XAZ9-1EO-P2. 

This PR sets the test group `variant` to 100% so that all english speaking users see the new screen while we work on translating the copy. 

cc @markryall 