### PR TITLE
Comments: Use the comment counts endpoint for pagination.

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -36,8 +36,8 @@ import { COMMENTS_PER_PAGE, NEWEST_FIRST } from '../constants';
 export class CommentList extends Component {
 	static propTypes = {
 		changePage: PropTypes.func,
-		commentCounts: PropTypes.number,
 		comments: PropTypes.array,
+		commentsCount: PropTypes.number,
 		recordChangePage: PropTypes.func,
 		replyComment: PropTypes.func,
 		siteId: PropTypes.number,
@@ -149,14 +149,9 @@ export class CommentList extends Component {
 
 	updateLastUndo = commentId => this.setState( { lastUndo: commentId } );
 
-	getCommentsCount = ( commentCounts, status ) => {
-		const validatedStatus = 'unapproved' === status ? 'pending' : status;
-		return commentCounts ? commentCounts[ validatedStatus ] : null;
-	};
-
 	render() {
 		const {
-			commentCounts,
+			commentsCount,
 			isCommentsTreeSupported,
 			isLoading,
 			isPostView,
@@ -171,7 +166,6 @@ export class CommentList extends Component {
 		const validPage = this.isRequestedPageValid() ? page : 1;
 
 		const comments = this.getComments();
-		const commentsCount = this.getCommentsCount( commentCounts, status );
 		const commentsPage = this.getCommentsPage( comments, validPage );
 
 		const showPlaceholder = ( ! siteId || isLoading ) && ! commentsCount;
@@ -270,10 +264,12 @@ const mapStateToProps = ( state, { postId, siteId, status } ) => {
 		? map( filter( siteCommentsTree, { postId } ), 'commentId' )
 		: map( siteCommentsTree, 'commentId' );
 	const commentCounts = getSiteCommentCounts( state, siteId, postId );
+	const validatedStatus = 'unapproved' === status ? 'pending' : status;
+	const commentsCount = commentCounts ? commentCounts[ validatedStatus ] : null;
 
 	const isLoading = ! isCommentsTreeInitialized( state, siteId, status );
 	return {
-		commentCounts,
+		commentsCount,
 		comments,
 		isCommentsTreeSupported:
 			! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.5' ),


### PR DESCRIPTION
This PR uses the new `comment-counts` endpoint as the count source for pagination, rather than the `length` we've been using up to now.

This can be tested on its own as it includes some of #20812 and #20809 .  A rebase will be needed after those land.

**Testing**
* Load `/comments` and check the Networking tab to be sure a request to `comment-counts` was fired.
* Ensure that pagination numbers make sense and match up with the comments being viewed.

Fixes #20674 .