### PR TITLE
PostDiffViewer: Move component to /blocks/

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -213,6 +213,7 @@
 @import 'components/sub-masterbar-nav/style';
 @import 'components/suggestions/style';
 @import 'components/textarea-autosize/style';
+@import 'components/text-diff/style';
 @import 'components/thank-you-card/style';
 @import 'components/theme/style';
 @import 'components/themes-list/style';

--- a/assets/stylesheets/sections/post-editor.scss
+++ b/assets/stylesheets/sections/post-editor.scss
@@ -23,7 +23,6 @@
 @import 'post-editor/editor-categories-tags/style';
 @import 'post-editor/editor-confirmation-sidebar/style';
 @import 'post-editor/editor-delete-post/style';
-@import 'post-editor/editor-diff-viewer/style';
 @import 'post-editor/editor-discussion/style';
 @import 'post-editor/editor-drawer/style';
 @import 'post-editor/editor-drawer-well/style';

--- a/client/blocks/post-diff-viewer/README.md
+++ b/client/blocks/post-diff-viewer/README.md
@@ -1,0 +1,55 @@
+# PostDiffViewer
+
+PostDiffViewer is a block that can be used for visualizing changes (diffs) to a post, page or other body of content that comprises of a title and content.
+
+## Usage
+
+PostDiffViewer should be passed a 'diff' object containing an array of 'changes' to the title and an array of changes to the content. These changes might be additions, deletions or copies.
+In the following example the changes represent an amended title and update to the post content:
+
+```jsx
+import PostDiffViewer from 'blocks/post-diff-viewer';
+ 
+export default function PostDiffViewerExample() {
+	const diff = {
+		title: [
+			{ op: 'copy', value: 'Bitcoin ' },
+			{ op: 'del', value: 'climbs' },
+			{ op: 'add', value: 'rockets' },
+			{ op: 'copy', value: ' above previous high' },
+			{ op: 'del', value: '.' },
+			{ op: 'add', value: '!' },
+		],
+		content: [
+			{ op: 'copy', value: 'Today the price of Bitcoin ' },
+			{ op: 'del', value: 'climbed' },
+			{ op: 'add', value: 'rocketed' },
+			{ op: 'copy', value: ' to over ' },
+			{ op: 'del', value: '$15000' },
+			{ op: 'add', value: '$16000' },
+			{
+				op: 'copy',
+				value:
+					'.\n Experts believe this is a result of the influx of retail investors scrambling to get in on the action.',
+			},
+			{ op: 'copy', value: '\n But along with this ' },
+			{ op: 'add', value: 'huge ' },
+			{
+				op: 'copy',
+				value:
+					'growth comes more criticism as more and more financial professionals warn that Bitcoin may be a bubble waiting to burst.',
+			},
+		],
+	};
+
+	return <PostDiffViewer diff={ diff } />;
+}
+```
+
+## Props
+
+PostDiffViewer only accepts a single 'diff' prop:
+
+- `diff`: Two arrays of objects, one for the title and one for the body, representing a content change, of shape:
+  - `op`: The type of operation, addition ('add'), deletion ('del') or copy ('copy')
+  - `value`: The content that was either added, deleted or copied.

--- a/client/blocks/post-diff-viewer/docs/example.jsx
+++ b/client/blocks/post-diff-viewer/docs/example.jsx
@@ -1,0 +1,48 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PostDiffViewer from 'blocks/post-diff-viewer';
+
+export default function PostDiffViewerExample() {
+	const diff = {
+		title: [
+			{ op: 'copy', value: 'Bitcoin ' },
+			{ op: 'del', value: 'climbs' },
+			{ op: 'add', value: 'rockets' },
+			{ op: 'copy', value: ' above previous high' },
+			{ op: 'del', value: '.' },
+			{ op: 'add', value: '!' },
+		],
+		content: [
+			{ op: 'copy', value: 'Today the price of Bitcoin ' },
+			{ op: 'del', value: 'climbed' },
+			{ op: 'add', value: 'rocketed' },
+			{ op: 'copy', value: ' to over ' },
+			{ op: 'del', value: '$15000' },
+			{ op: 'add', value: '$16000' },
+			{
+				op: 'copy',
+				value:
+					'.\n Experts believe this is a result of the influx of retail investors scrambling to get in on the action.',
+			},
+			{ op: 'copy', value: '\n But along with this ' },
+			{ op: 'add', value: 'huge ' },
+			{
+				op: 'copy',
+				value:
+					'growth comes more criticism as more and more financial professionals warn that Bitcoin may be a bubble waiting to burst.',
+			},
+		],
+	};
+
+	return <PostDiffViewer diff={ diff } />;
+}
+
+PostDiffViewerExample.displayName = 'PostDiffViewerExample';

--- a/client/blocks/post-diff-viewer/index.jsx
+++ b/client/blocks/post-diff-viewer/index.jsx
@@ -3,28 +3,22 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { connect } from 'react-redux';
 import { get, has } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { getPostRevision } from 'state/selectors';
 import TextDiff from 'components/text-diff';
 
-class EditorDiffViewer extends PureComponent {
+class PostDiffViewer extends PureComponent {
 	static propTypes = {
-		postId: PropTypes.number.isRequired,
-		selectedRevisionId: PropTypes.number,
-		siteId: PropTypes.number.isRequired,
 		diff: PropTypes.shape( {
-			post_content: PropTypes.array,
-			post_title: PropTypes.array,
+			content: PropTypes.array,
+			title: PropTypes.array,
 			totals: PropTypes.object,
 		} ).isRequired,
 	};
@@ -32,7 +26,7 @@ class EditorDiffViewer extends PureComponent {
 	scrollToFirstChangeOrTop = () => {
 		const thisNode = ReactDom.findDOMNode( this );
 		const diffNode = thisNode.querySelector(
-			'.editor-diff-viewer__additions, .editor-diff-viewer__deletions'
+			'.post-diff-viewer__additions, .post-diff-viewer__deletions'
 		);
 		const thisNodeHeight = get( thisNode, 'offsetHeight', 0 );
 		const offset = Math.max( 0, get( diffNode, 'offsetTop', 0 ) - thisNodeHeight / 2 );
@@ -49,23 +43,21 @@ class EditorDiffViewer extends PureComponent {
 
 	render() {
 		const { diff } = this.props;
-		const classes = classNames( 'editor-diff-viewer', {
-			'is-loading': ! has( diff, 'post_content' ) && ! has( diff, 'post_title' ),
+		const classes = classNames( 'post-diff-viewer', {
+			'is-loading': ! has( diff, 'content' ) && ! has( diff, 'title' ),
 		} );
 
 		return (
 			<div className={ classes }>
-				<h1 className="editor-diff-viewer__title">
-					<TextDiff changes={ diff.post_title } />
+				<h1 className="post-diff-viewer__title">
+					<TextDiff changes={ diff.title } />
 				</h1>
-				<pre className="editor-diff-viewer__content">
-					<TextDiff changes={ diff.post_content } splitLines />
+				<pre className="post-diff-viewer__content">
+					<TextDiff changes={ diff.content } splitLines />
 				</pre>
 			</div>
 		);
 	}
 }
 
-export default connect( ( state, { siteId, postId, selectedRevisionId } ) => ( {
-	revision: getPostRevision( state, siteId, postId, selectedRevisionId, 'display' ),
-} ) )( EditorDiffViewer );
+export default PostDiffViewer;

--- a/client/blocks/post-diff-viewer/index.jsx
+++ b/client/blocks/post-diff-viewer/index.jsx
@@ -19,7 +19,6 @@ class PostDiffViewer extends PureComponent {
 		diff: PropTypes.shape( {
 			content: PropTypes.array,
 			title: PropTypes.array,
-			totals: PropTypes.object,
 		} ).isRequired,
 	};
 

--- a/client/blocks/post-diff-viewer/style.scss
+++ b/client/blocks/post-diff-viewer/style.scss
@@ -1,12 +1,12 @@
 /** @format */
-.editor-diff-viewer {
+.post-diff-viewer {
 	flex: 1;
 	margin: 0;
 	padding: 24px 32px 32px 32px;
 	box-sizing: border-box;
 	overflow-y: auto;
 
-	.editor-diff-viewer__title {
+	.post-diff-viewer__title {
 		font-family: $serif;
 		font-size: 32px;
 		color: $gray-dark;
@@ -17,14 +17,14 @@
 	}
 }
 
-.editor-diff-viewer.is-loading .editor-diff-viewer__title {
+.post-diff-viewer.is-loading .post-diff-viewer__title {
 	display: inline-block;
 	width: 50%;
 	height: 38px;
 	@include placeholder(23%);
 }
 
-.editor-diff-viewer__content {
+.post-diff-viewer__content {
 	font-family: $serif;
 	font-size: 15px;
 	white-space: pre-wrap;
@@ -34,7 +34,7 @@
 	overflow-y: hidden;
 }
 
-.editor-diff-viewer.is-loading .editor-diff-viewer__content {
+.post-diff-viewer.is-loading .post-diff-viewer__content {
 	&:before,
 	&:after {
 		content: '';

--- a/client/components/text-diff/README.md
+++ b/client/components/text-diff/README.md
@@ -1,0 +1,37 @@
+# TextDiff
+
+TextDiff is a component useful for visualizing changes (diffs) to bodies of text.
+
+## Usage
+
+TextDiff should be passed an array of 'changes'. These changes might be additions, deletions or copies.
+In the following example the changes array represents a title rename by including the deletion of the old title and addition of a new title:
+
+```jsx
+import TextDiff from 'components/text-diff';
+
+export default function RenamedTitle() {
+	const changes = [ {
+		op: 'del',
+		value: 'Old Title.',
+	}, {
+		op: 'add',
+		value: 'New Title!',
+	} ];
+
+	return (
+		<h2>
+			<TextDiff changes={ changes } />
+		</h2>
+	);
+}
+```
+
+## Props
+
+The following props are available to customize the accordion:
+
+- `changes`: An array of objects representing a content change, of shape:
+  - `op`: The type of operation, addition ('add'), deletion ('del') or copy ('copy')
+  - `value`: The content that was either added, deleted or copied.
+- `splitLines`: Boolean indicating whether the changes should be broken out on to new lines or not.

--- a/client/components/text-diff/docs/example.jsx
+++ b/client/components/text-diff/docs/example.jsx
@@ -1,0 +1,31 @@
+/** @format */
+/**
+* External dependencies
+*/
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import TextDiff from 'components/text-diff';
+
+export default function TextDiffExample() {
+	const changes = [
+		{
+			op: 'del',
+			value: 'Old Title.',
+		},
+		{
+			op: 'add',
+			value: 'New Title!',
+		},
+	];
+
+	return (
+		<h2>
+			<TextDiff changes={ changes } />
+		</h2>
+	);
+}
+
+TextDiffExample.displayName = 'TextDiffExample';

--- a/client/components/text-diff/index.jsx
+++ b/client/components/text-diff/index.jsx
@@ -20,9 +20,9 @@ const renderChange = ( change, changeIndex, splitLines ) => {
 	const content = orig || final || value;
 
 	const classnames = classNames( {
-		'editor-diff-viewer__additions': op === 'add',
-		'editor-diff-viewer__context': op === 'copy',
-		'editor-diff-viewer__deletions': op === 'del',
+		'text-diff__additions': op === 'add',
+		'text-diff__context': op === 'copy',
+		'text-diff__deletions': op === 'del',
 	} );
 
 	return (

--- a/client/components/text-diff/style.scss
+++ b/client/components/text-diff/style.scss
@@ -1,0 +1,15 @@
+.text-diff__additions {
+	background: lighten($blue-wordpress, 58%);
+	border-bottom: 2px solid $blue-wordpress;
+}
+
+
+.text-diff__context {
+	// TODO: Should there be specific styles for this class? Should we just remove it altogther?
+}
+
+.text-diff__deletions {
+	background: lighten($alert-red, 38%);
+	border-bottom: 2px solid $alert-red;
+	text-decoration: line-through;
+}

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -52,6 +52,7 @@ import ReaderFullPostHeader from 'blocks/reader-full-post/docs/header-example';
 import AuthorCompactProfile from 'blocks/author-compact-profile/docs/example';
 import RelatedPostCardv2 from 'blocks/reader-related-card-v2/docs/example';
 import PlanPrice from 'my-sites/plan-price/docs/example';
+import PostDiffViewer from 'blocks/post-diff-viewer/docs/example';
 import PostShare from 'blocks/post-share/docs/example';
 import PlanThankYouCard from 'blocks/plan-thank-you-card/docs/example';
 import DismissibleCard from 'blocks/dismissible-card/docs/example';
@@ -143,6 +144,7 @@ export default class AppComponents extends React.Component {
 					<FeatureComparison />
 					<DomainTip />
 					<RelatedPostCardv2 />
+					<PostDiffViewer />
 					<PostItem />
 					<PostStatus />
 					<PostTime />

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -81,6 +81,7 @@ import Spinner from 'components/spinner/docs/example';
 import SpinnerButton from 'components/spinner-button/docs/example';
 import SpinnerLine from 'components/spinner-line/docs/example';
 import Suggestions from 'components/suggestions/docs/example';
+import TextDiff from 'components/text-diff/docs/example';
 import TileGrid from 'components/tile-grid/docs/example';
 import TimeSince from 'components/time-since/docs/example';
 import Timezone from 'components/timezone/docs/example';
@@ -188,6 +189,7 @@ class DesignAssets extends React.Component {
 					<SpinnerButton searchKeywords="loading input submit" />
 					<SpinnerLine searchKeywords="loading" />
 					<Suggestions />
+					<TextDiff />
 					<TileGrid />
 					<TimeSince />
 					<Timezone />

--- a/client/post-editor/editor-diff-viewer/changes.jsx
+++ b/client/post-editor/editor-diff-viewer/changes.jsx
@@ -3,10 +3,10 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isArray, isEmpty, map } from 'lodash';
+import classNames from 'classnames';
+import { isArray, isEmpty, map, partialRight } from 'lodash';
 
 const addLinesToChanges = changes => {
 	if ( ! isArray( changes ) || isEmpty( changes ) ) {
@@ -16,40 +16,35 @@ const addLinesToChanges = changes => {
 };
 
 const renderChange = ( change, changeIndex, splitLines ) => {
-	switch ( change.op ) {
-		case 'add': {
-			const content = change.final || change.value;
-			return (
-				<span className="editor-diff-viewer__additions" key={ changeIndex }>
-					{ splitLines ? addLinesToChanges( content ) : content }
-				</span>
-			);
-		}
-		case 'copy': {
-			const content = change.final || change.value;
-			return (
-				<span className="editor-diff-viewer__context" key={ changeIndex }>
-					{ splitLines ? addLinesToChanges( content ) : content }
-				</span>
-			);
-		}
-		case 'del': {
-			const content = change.orig || change.value;
-			return (
-				<span className="editor-diff-viewer__deletions" key={ changeIndex }>
-					{ splitLines ? addLinesToChanges( content ) : content }
-				</span>
-			);
-		}
-	}
+	const { orig, final, value, op } = change;
+	const content = orig || final || value;
+
+	const classnames = classNames( {
+		'editor-diff-viewer__additions': op === 'add',
+		'editor-diff-viewer__context': op === 'copy',
+		'editor-diff-viewer__deletions': op === 'del',
+	} );
+
+	return (
+		<span className={ classnames } key={ changeIndex }>
+			{ splitLines ? addLinesToChanges( content ) : content }
+		</span>
+	);
 };
 
-const EditorDiffChanges = ( { changes, splitLines } ) =>
-	map( changes, ( change, changeIndex ) => renderChange( change, changeIndex, splitLines ) );
+const renderSplitLineChange = partialRight( renderChange, true );
 
-EditorDiffChanges.propTypes = {
-	changes: PropTypes.array,
+const DiffChanges = ( { changes, splitLines } ) =>
+	map( changes, splitLines ? renderSplitLineChange : renderChange );
+
+DiffChanges.propTypes = {
+	changes: PropTypes.arrayOf(
+		PropTypes.shape( {
+			op: PropTypes.oneOf( [ 'add', 'copy', 'del' ] ),
+			value: PropTypes.string.isRequired,
+		} )
+	),
 	splitLines: PropTypes.bool,
 };
 
-export default EditorDiffChanges;
+export default DiffChanges;

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -15,7 +15,7 @@ import { get, has } from 'lodash';
  * Internal dependencies
  */
 import { getPostRevision } from 'state/selectors';
-import EditorDiffChanges from './changes';
+import TextDiff from 'components/text-diff';
 
 class EditorDiffViewer extends PureComponent {
 	static propTypes = {
@@ -56,10 +56,10 @@ class EditorDiffViewer extends PureComponent {
 		return (
 			<div className={ classes }>
 				<h1 className="editor-diff-viewer__title">
-					<EditorDiffChanges changes={ diff.post_title } />
+					<TextDiff changes={ diff.post_title } />
 				</h1>
 				<pre className="editor-diff-viewer__content">
-					<EditorDiffChanges changes={ diff.post_content } splitLines />
+					<TextDiff changes={ diff.post_content } splitLines />
 				</pre>
 			</div>
 		);

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -54,14 +54,3 @@
 		box-shadow: 0px 26px 0px 0px lighten($gray, 23%);
 	}
 }
-
-.editor-diff-viewer__additions {
-	background: lighten($blue-wordpress, 58%);
-	border-bottom: 2px solid $blue-wordpress;
-}
-
-.editor-diff-viewer__deletions {
-	background: lighten($alert-red, 38%);
-	border-bottom: 2px solid $alert-red;
-	text-decoration: line-through;
-}

--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow, get } from 'lodash';
+import { flow, get, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ import {
 	getPostRevisionsSelectedRevisionId,
 } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import EditorDiffViewer from 'post-editor/editor-diff-viewer';
+import PostDiffViewer from 'blocks/post-diff-viewer';
 import EditorRevisionsList from 'post-editor/editor-revisions-list';
 import QueryPostRevisions from 'components/data/query-post-revisions';
 import QueryUsers from 'components/data/query-users';
@@ -44,7 +44,7 @@ class EditorRevisions extends Component {
 					selectedRevisionId={ selectedRevisionId }
 				/>
 				<QueryUsers siteId={ siteId } userIds={ authorsIds } />
-				<EditorDiffViewer
+				<PostDiffViewer
 					diff={ selectedDiff }
 					postId={ postId }
 					selectedRevisionId={ selectedRevisionId }
@@ -92,7 +92,11 @@ export default flow(
 			comparisons,
 			postId,
 			revisions,
-			selectedDiff,
+			selectedDiff: {
+				...omit( selectedDiff, [ 'post_content', 'post_title' ] ),
+				content: selectedDiff.post_content,
+				title: selectedDiff.post_title,
+			},
 			selectedRevisionId,
 			siteId,
 		};


### PR DESCRIPTION
*Note*: This PR is currently point to #20822 as it's base - that should be landed prior to this PR.

### Summary
This PR is the second in an effort towards decoupling some components that have been built during the development of the post revisions work, making them reusable in other areas of the project, easier to unit test and easier to document.

Specifically - here we're moving `EditorDiffViewer` in to a more general-use `PostDiffViewer` block.

<img width="942" alt="screen shot 2017-12-14 at 20 46 33" src="https://user-images.githubusercontent.com/4335450/34013578-e9e6508c-e10f-11e7-94df-aeb43d82a888.png">

### Testing
There should be no deviations from the original functionality in post revisions.
To test this:
- Go to a the post editor
- Make some revisions if the post doesn't already have a few
- Click on the 'history' button in the editors header
- You should see removals highlighted in a faint red, additions in a faint blue exactly as before
- Also pay attention to the line splitting, the title shouldn't break changes on to new lines but the changes in the content should.

Also, take a look at the DevDocs entry - does this look reasonable?
Go to https://calypso.live/devdocs and search PostDiffViewer under 'blocks'.

Note: I'm open to renaming this block, it's a tough one to name given it applies to pages and CPT's as well as standard posts.