### PR TITLE
Post Revisions: Add top fade to revisions content

### DIFF
--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -14,6 +14,25 @@
 		z-index: 1; // Put the list above the action-buttons:before overlay gradient. -shaun
 		flex-basis: 230px;
 	}
+
+	@include breakpoint( '<660px' ) {
+		&:after {
+			$editor-revisions-list-fade-height: 20px;
+			content: '';
+			position: absolute;
+			bottom: -$editor-revisions-list-fade-height;
+			right: 0;
+			left: 0;
+			height: $editor-revisions-list-fade-height;
+			background: linear-gradient(
+				to bottom,
+				rgba(255, 255, 255, 1) 0%,
+				rgba(255, 255, 255, 1) 25%,
+				rgba(255, 255, 255, 0.85) 50%,
+				rgba(255, 255, 255, 0) 100%
+			);
+		}
+	}
 }
 
 .editor-revisions-list__header {

--- a/client/post-editor/editor-revisions/style.scss
+++ b/client/post-editor/editor-revisions/style.scss
@@ -16,6 +16,24 @@
 		width: 100vw;
 		height: calc(100vh - 73px);
 	}
+
+	@include breakpoint( '>660px' ) {
+		&:before {
+			content: '';
+			position: absolute;
+			top: 0;
+			right: 0;
+			left: 0;
+			height: 25px;
+			background: linear-gradient(
+				to bottom,
+				rgba(255, 255, 255, 1) 0%,
+				rgba(255, 255, 255, 1) 25%,
+				rgba(255, 255, 255, 0.85) 50%,
+				rgba(255, 255, 255, 0) 100%
+			);
+		}
+	}
 }
 
 .editor-revisions__wpadmin-link {


### PR DESCRIPTION
## This PR
- adds a fade to the top of the revision content
- ensures that the revision content does not look cut off on both desktop & mobile

## How to test

- Visit calypso.live link below
- Navigate to post with revisions
- Click on History button to open revisions modal
- Check if state observed looks like the `after` state below

**Before** 
<img width="1088" alt="screen shot 2017-12-14 at 14 56 55" src="https://user-images.githubusercontent.com/1562646/34013196-82aa4e6c-e0e4-11e7-890f-bfcdafd4b3d6.png">

<img width="343" alt="screen shot 2017-12-14 at 15 26 17" src="https://user-images.githubusercontent.com/1562646/34013200-877f964a-e0e4-11e7-818c-a0e5336c425d.png">

**After**

<img width="1068" alt="screen shot 2017-12-14 at 15 10 20" src="https://user-images.githubusercontent.com/1562646/34013209-91adbf98-e0e4-11e7-9794-0500229a87cb.png">

<img width="356" alt="screen shot 2017-12-14 at 15 24 08" src="https://user-images.githubusercontent.com/1562646/34013215-9594a5c2-e0e4-11e7-8109-a96f3367396f.png">

