### PR TITLE
Sidebar: swapping Notice for SidebarBanner for ads

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -327,6 +327,7 @@
 @import 'my-sites/all-sites/style';
 @import 'my-sites/all-sites-icon/style';
 @import 'my-sites/current-site/style';
+@import 'my-sites/current-site/sidebar-banner/style';
 @import 'my-sites/customize/style';
 @import 'my-sites/domain-tip/style';
 @import 'my-sites/draft/style';

--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -15,7 +15,7 @@ import { endsWith, noop } from 'lodash';
  */
 import { getSelectedSite } from 'state/ui/selectors';
 import { isEligibleForDomainToPaidPlanUpsell } from 'state/selectors';
-import SidebarBanner from './sidebar-banner';
+import SidebarBanner from 'my-sites/current-site/sidebar-banner';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { isDomainOnlySite } from 'state/selectors';
@@ -51,16 +51,14 @@ export class DomainToPaidPlanNotice extends Component {
 			: `/plans/my-plan/${ site.slug }`;
 
 		return (
-			<SidebarBanner
-				icon="info-outline"
-				text={ translate( 'Upgrade your site and save.' ) }
-				>
-				<a
-					onClick={ this.onClick }
-					href={ actionLink }>
+			<SidebarBanner icon="info-outline" text={ translate( 'Upgrade your site and save.' ) }>
+				<a onClick={ this.onClick } href={ actionLink }>
 					<span>
 						{ translate( 'Go' ) }
-						<TrackComponentView eventName={ impressionEventName } eventProperties={ eventProperties } />
+						<TrackComponentView
+							eventName={ impressionEventName }
+							eventProperties={ eventProperties }
+						/>
 					</span>
 				</a>
 			</SidebarBanner>

--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -15,8 +15,7 @@ import { endsWith, noop } from 'lodash';
  */
 import { getSelectedSite } from 'state/ui/selectors';
 import { isEligibleForDomainToPaidPlanUpsell } from 'state/selectors';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
+import SidebarBanner from './sidebar-banner';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { isDomainOnlySite } from 'state/selectors';
@@ -52,22 +51,18 @@ export class DomainToPaidPlanNotice extends Component {
 			: `/plans/my-plan/${ site.slug }`;
 
 		return (
-			<Notice
+			<SidebarBanner
 				icon="info-outline"
-				isCompact
-				status="is-success"
-				showDismiss={ false }
 				text={ translate( 'Upgrade your site and save.' ) }
-				className="current-site__notice-upsell"
-			>
-				<NoticeAction onClick={ this.onClick } href={ actionLink }>
-					{ translate( 'Go' ) }
-					<TrackComponentView
-						eventName={ impressionEventName }
-						eventProperties={ eventProperties }
 					/>
-				</NoticeAction>
-			</Notice>
+				>
+				<a
+					onClick={ this.onClick }
+					href={ actionLink }>
+					<span>
+					</span>
+				</a>
+			</SidebarBanner>
 		);
 	}
 }

--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -54,12 +54,13 @@ export class DomainToPaidPlanNotice extends Component {
 			<SidebarBanner
 				icon="info-outline"
 				text={ translate( 'Upgrade your site and save.' ) }
-					/>
 				>
 				<a
 					onClick={ this.onClick }
 					href={ actionLink }>
 					<span>
+						{ translate( 'Go' ) }
+						<TrackComponentView eventName={ impressionEventName } eventProperties={ eventProperties } />
 					</span>
 				</a>
 			</SidebarBanner>

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -13,7 +13,7 @@ import { localize, moment } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import SidebarBanner from './sidebar-banner';
+import SidebarBanner from 'my-sites/current-site/sidebar-banner';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import paths from 'my-sites/domains/paths';
@@ -100,13 +100,11 @@ class SiteNotice extends React.Component {
 		const { translate } = this.props;
 
 		return (
-			<SidebarBanner
-				icon="info-outline"
-				text={ translate( 'Free domain with a plan' ) }
-				>
+			<SidebarBanner icon="info-outline" text={ translate( 'Free domain with a plan' ) }>
 				<a
 					onClick={ this.props.clickFreeToPaidPlanNotice }
-					href={ `/plans/my-plan/${ this.props.site.slug }` }>
+					href={ `/plans/my-plan/${ this.props.site.slug }` }
+				>
 					<span>
 						{ translate( 'Upgrade' ) }
 						<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -13,6 +13,7 @@ import { localize, moment } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import SidebarBanner from './sidebar-banner';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import paths from 'my-sites/domains/paths';
@@ -99,21 +100,19 @@ class SiteNotice extends React.Component {
 		const { translate } = this.props;
 
 		return (
-			<Notice
-				isCompact
-				status="is-success"
+			<SidebarBanner
 				icon="info-outline"
 				text={ translate( 'Free domain with a plan' ) }
-				className="current-site__notice-upsell"
-			>
-				<NoticeAction
-					onClick={ this.props.clickFreeToPaidPlanNotice }
-					href={ `/plans/my-plan/${ this.props.site.slug }` }
 				>
-					{ translate( 'Upgrade' ) }
-					<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
-				</NoticeAction>
-			</Notice>
+				<a
+					onClick={ this.props.clickFreeToPaidPlanNotice }
+					href={ `/plans/my-plan/${ this.props.site.slug }` }>
+					<span>
+						{ translate( 'Upgrade' ) }
+						<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
+					</span>
+				</a>
+			</SidebarBanner>
 		);
 	}
 

--- a/client/my-sites/current-site/sidebar-banner/index.jsx
+++ b/client/my-sites/current-site/sidebar-banner/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
@@ -35,7 +34,7 @@ export class SidebarBanner extends Component {
 		return (
 			<div className={ classes }>
 				<span className="sidebar-banner__icon-wrapper">
-					<Gridicon className="sidebar-banner__icon" icon={ icon } size={ 18 } />
+					<Gridicon className="sidebar-banner__icon" icon={ icon } size={ 24 } />
 				</span>
 				<span className="sidebar-banner__content">
 					<span className="sidebar-banner__text">{ text ? text : children }</span>

--- a/client/my-sites/current-site/sidebar-banner/index.jsx
+++ b/client/my-sites/current-site/sidebar-banner/index.jsx
@@ -34,7 +34,7 @@ export class SidebarBanner extends Component {
 		return (
 			<div className={ classes }>
 				<span className="sidebar-banner__icon-wrapper">
-					<Gridicon className="sidebar-banner__icon" icon={ icon } size={ 24 } />
+					<Gridicon className="sidebar-banner__icon" icon={ icon } size={ 18 } />
 				</span>
 				<span className="sidebar-banner__content">
 					<span className="sidebar-banner__text">{ text ? text : children }</span>

--- a/client/my-sites/current-site/sidebar-banner/index.jsx
+++ b/client/my-sites/current-site/sidebar-banner/index.jsx
@@ -1,0 +1,49 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+export class SidebarBanner extends Component {
+	static defaultProps = {
+		className: '',
+		icon: null,
+		text: null,
+	};
+
+	static propTypes = {
+		className: PropTypes.string,
+		icon: PropTypes.string,
+		onDismissClick: PropTypes.func,
+		text: PropTypes.oneOfType( [
+			PropTypes.arrayOf( PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ) ),
+			PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
+		] ),
+		translate: PropTypes.func.isRequired,
+	};
+
+	render() {
+		const { children, className, icon, text } = this.props;
+		const classes = classnames( 'sidebar-banner', className );
+
+		return (
+			<div className={ classes }>
+				<span className="sidebar-banner__icon-wrapper">
+					<Gridicon className="sidebar-banner__icon" icon={ icon } size={ 18 } />
+				</span>
+				<span className="sidebar-banner__content">
+					<span className="sidebar-banner__text">{ text ? text : children }</span>
+				</span>
+				{ text ? children : null }
+			</div>
+		);
+	}
+}
+
+export default localize( SidebarBanner );

--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -11,11 +11,16 @@
 	.sidebar-banner__icon-wrapper {
 		flex: 0 0 auto;
 		padding: 5px 5px 2px;
+
+		svg {
+			width: 18px;
+			height: 18px;
+		}
 	}
 
 	.sidebar-banner__content {
 		width: 100%;
-		padding: 6px 5px 2px;
+		padding: 6px 5px 5px;
 	}
 
 	a {

--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -20,12 +20,12 @@
 
 	a {
 		transition: all 200ms ease-out;
-		padding: 6px 5px 2px;
+		padding: 6px 8px 2px 5px;
 		color: $white;
 		text-transform: uppercase;
 	}
 
 	a:hover {
-		background: transparentize( $white, 0.9 );
+		text-decoration: underline;
 	}
 }

--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -1,0 +1,31 @@
+.sidebar-banner {
+	display: flex;
+	background-color: $alert-green;
+	color: $white;
+	font-size: 12px;
+
+	@include breakpoint( "<660px" ) {
+		padding: 0 24px;
+	}
+
+	.sidebar-banner__icon-wrapper {
+		flex: 0 0 auto;
+		padding: 5px 5px 2px;
+	}
+
+	.sidebar-banner__content {
+		width: 100%;
+		padding: 6px 5px 2px;
+	}
+
+	a {
+		transition: all 200ms ease-out;
+		padding: 6px 5px 2px;
+		color: $white;
+		text-transform: uppercase;
+	}
+
+	a:hover {
+		background: transparentize( $white, 0.9 );
+	}
+}

--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -11,11 +11,6 @@
 	.sidebar-banner__icon-wrapper {
 		flex: 0 0 auto;
 		padding: 5px 5px 2px;
-
-		svg {
-			width: 18px;
-			height: 18px;
-		}
 	}
 
 	.sidebar-banner__content {

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -149,16 +149,3 @@
 		border-radius: 0;
 	}
 }
-
-.site__notices .current-site__notice-upsell {
-	background-color: $alert-green;
-
-	.notice__content {
-		padding-left: 0;
-	}
-
-	.notice__action {
-		color: $white;
-		text-transform: uppercase;
-	}
-}

--- a/client/my-sites/current-site/test/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/test/domain-to-paid-plan-notice.jsx
@@ -35,6 +35,6 @@ describe( 'DomainToPaidPlanNotice', () => {
 
 	test( 'should render component when site information is available and the site is eligible', () => {
 		const wrapper = shallow( <DomainToPaidPlanNotice site={ site } eligible /> );
-		expect( wrapper.type().displayName ).to.equal( 'Localized(Notice)' );
+		expect( wrapper.type().displayName ).to.equal( 'Localized(SidebarBanner)' );
 	} );
 } );


### PR DESCRIPTION
<img width="259" alt="screen shot 2017-12-14 at 23 03 04" src="https://user-images.githubusercontent.com/4389/34016732-468471da-e123-11e7-94d6-2460ea83d3f9.png">

Follow up from #20833.

This PR simply extracts and simplifies the banner nudges as being separate from the notice component to be more future-proof and allow better, more specific style iterations and tests.

Note:

1. This is meant to reproduce the design as-is. It just changes the component so it's safe to iterate changes and A/B test future design tweaks.
2. There might be more places where this might be swapped, but it's currently limited to iterate fixing the issue in #20833.
3. It just adds an hover state.

In the future we might use a style like the one in the [Banner component](https://wpcalypso.wordpress.com/devdocs/design/banner).

### How to test

1. Open My Sites
2. Find a site with a Free Plan and created between 2 and 180 days or change in code the eligibility conditions in the two files.
3. Check the banner shows up with the right colors.
4. Check also that other banners preserve the normal styling.
5. Check it works on mobile
6. Check the links and the tracking works
