### PR TITLE
Post Revisions: Track post revisions open once EditorRevisions mounted

### DIFF
--- a/client/post-editor/editor-revisions/dialog.jsx
+++ b/client/post-editor/editor-revisions/dialog.jsx
@@ -61,10 +61,6 @@ class PostRevisionsDialog extends PureComponent {
 		}
 	}
 
-	componentDidMount() {
-		this.props.recordTracksEvent( 'calypso_editor_post_revisions_open' );
-	}
-
 	onLoadClick = () => {
 		const { loadRevision, revision, closeDialog } = this.props;
 		loadRevision( revision );

--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -19,12 +19,17 @@ import {
 	getPostRevisionsSelectedRevisionId,
 } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 import EditorDiffViewer from 'post-editor/editor-diff-viewer';
 import EditorRevisionsList from 'post-editor/editor-revisions-list';
 import QueryPostRevisions from 'components/data/query-post-revisions';
 import QueryUsers from 'components/data/query-users';
 
 class EditorRevisions extends Component {
+	componentDidMount() {
+		this.props.recordTracksEvent( 'calypso_editor_post_revisions_open' );
+	}
+
 	render() {
 		const {
 			authorsIds,
@@ -63,7 +68,7 @@ class EditorRevisions extends Component {
 }
 
 EditorRevisions.propTypes = {
-	// connected
+	// connected to state
 	authorsIds: PropTypes.array.isRequired,
 	comparisons: PropTypes.object,
 	postId: PropTypes.number.isRequired,
@@ -72,29 +77,35 @@ EditorRevisions.propTypes = {
 	selectedRevisionId: PropTypes.number,
 	siteId: PropTypes.number.isRequired,
 
+	// connected to dispatch
+	recordTracksEvent: PropTypes.func.isRequired,
+
 	// localize
 	translate: PropTypes.func.isRequired,
 };
 
 export default flow(
 	localize,
-	connect( state => {
-		const postId = getEditorPostId( state );
-		const siteId = getSelectedSiteId( state );
+	connect(
+		state => {
+			const postId = getEditorPostId( state );
+			const siteId = getSelectedSiteId( state );
 
-		const revisions = getPostRevisions( state, siteId, postId );
-		const selectedRevisionId = getPostRevisionsSelectedRevisionId( state );
-		const comparisons = getPostRevisionsComparisons( state, siteId, postId );
-		const selectedDiff = get( comparisons, [ selectedRevisionId, 'diff' ], {} );
+			const revisions = getPostRevisions( state, siteId, postId );
+			const selectedRevisionId = getPostRevisionsSelectedRevisionId( state );
+			const comparisons = getPostRevisionsComparisons( state, siteId, postId );
+			const selectedDiff = get( comparisons, [ selectedRevisionId, 'diff' ], {} );
 
-		return {
-			authorsIds: getPostRevisionsAuthorsId( state, siteId, postId ),
-			comparisons,
-			postId,
-			revisions,
-			selectedDiff,
-			selectedRevisionId,
-			siteId,
-		};
-	} )
+			return {
+				authorsIds: getPostRevisionsAuthorsId( state, siteId, postId ),
+				comparisons,
+				postId,
+				revisions,
+				selectedDiff,
+				selectedRevisionId,
+				siteId,
+			};
+		},
+		{ recordTracksEvent }
+	)
 )( EditorRevisions );


### PR DESCRIPTION
## This PR
- ensures we only track `calypso_editor_post_revisions_open` when the modal actually opens
- adds a track event to EditorRevisions's componentDidMount fn
- removes the track event from PostRevisionsDialog's componentDidMount fn

## How to test
- navigate to a post that has revisions
- open the developer tools and go to the Network tab
- Reload
- filter for images and search for `t.gif`
- there should be no tracking pixel triggered for `calypso_editor_post_revisions_open`
- click on the `History` button
- now a tracking event should be triggered for `calypso_editor_post_revisions_open`
