### PR TITLE
Jetpack Onboarding: add event tracking to the `Contact Form` site

### DIFF
--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -18,7 +18,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 class JetpackOnboardingContactFormStep extends React.PureComponent {
 	clickAddContactForm = () => {
-		this.props.recordTracksEvent( 'calypso_jetpack_onboarding_contact_form_clicked' );
+		this.props.recordTracksEvent( 'calypso_jpo_contact_form_clicked' );
 	};
 
 	render() {

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -13,8 +14,15 @@ import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class JetpackOnboardingContactFormStep extends React.PureComponent {
+	clickAddContactForm = () => {
+		this.props.recordTracksEvent( 'calypso_onboarding_contact_form_clicked', {
+			site_id_type: 'wporg',
+		} );
+	};
+
 	render() {
 		const { translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
@@ -33,6 +41,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 							'Not sure? You can skip this step and add a contact form later.'
 						) }
 						image={ '/calypso/images/illustrations/contact-us.svg' }
+						onClick={ this.clickAddContactForm }
 					/>
 				</TileGrid>
 			</Fragment>
@@ -40,4 +49,6 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 	}
 }
 
-export default localize( JetpackOnboardingContactFormStep );
+export default connect( () => ( {} ), { recordTracksEvent } )(
+	localize( JetpackOnboardingContactFormStep )
+);

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -18,9 +18,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 class JetpackOnboardingContactFormStep extends React.PureComponent {
 	clickAddContactForm = () => {
-		this.props.recordTracksEvent( 'calypso_onboarding_contact_form_clicked', {
-			site_id_type: 'wporg',
-		} );
+		this.props.recordTracksEvent( 'calypso_jetpack_onboarding_contact_form_clicked' );
 	};
 
 	render() {
@@ -49,6 +47,6 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 	}
 }
 
-export default connect( () => ( {} ), { recordTracksEvent } )(
+export default connect( null, { recordTracksEvent } )(
 	localize( JetpackOnboardingContactFormStep )
 );


### PR DESCRIPTION
Add event tracking to the `Add Contact Form` button.

**To test:**
- use localStorage.debug = 'calypso:analytics:tracks' to confirm that the event fires