### PR TITLE
Signup: Fix: ThemeSelection should accept predefined designType prop.

### DIFF
--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -121,9 +121,9 @@ class ThemeSelectionStep extends Component {
 	};
 }
 
-export default connect( state => ( {
+export default connect( ( state, props ) => ( {
 	chosenSurveyVertical: getSurveyVertical( state ),
 	currentUser: getCurrentUser( state ),
-	designType: getDesignType( state ),
+	designType: props.designType || getDesignType( state ),
 	dependencyStore: getSignupDependencyStore( state ),
 } ) )( localize( ThemeSelectionStep ) );


### PR DESCRIPTION
Some steps such as `portfolio-themes` and `blog-themes` have predefined props and `ThemeSelection` component should use the props if exist rather than ones from `state`.

## Test

1. Go to `/start/creative-mornings`.
2. There will be some themes to choose.
3. Inspect `<SignupThemeList />` component that wraps the themes, using React Dev tools.
4. The component's `designType` prop should have `grid` value.

cc @joanrho @fditrapani 