### PR TITLE
Site Utils – userCan: remove in post editor

### DIFF
--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -27,6 +27,7 @@ import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import { isEditedPostPrivate, isPrivateEditedPostPasswordValid } from 'state/posts/selectors';
+import { canCurrentUser } from 'state/selectors';
 
 class EditorConfirmationSidebar extends React.Component {
 	static propTypes = {
@@ -71,7 +72,8 @@ class EditorConfirmationSidebar extends React.Component {
 		const publishButtonStatus = getPublishButtonStatus(
 			this.props.site,
 			this.props.post,
-			this.props.savedPost
+			this.props.savedPost,
+			this.props.canUserPublishPosts
 		);
 		const buttonLabel = this.getPublishButtonLabel( publishButtonStatus );
 		const enabled = ! this.props.isPrivatePost || this.props.isPrivatePostPasswordValid;
@@ -134,7 +136,8 @@ class EditorConfirmationSidebar extends React.Component {
 		const publishButtonStatus = getPublishButtonStatus(
 			this.props.site,
 			this.props.post,
-			this.props.savedPost
+			this.props.savedPost,
+			this.props.canUserPublishPosts
 		);
 		const buttonLabel = this.getBusyButtonLabel( publishButtonStatus );
 
@@ -226,6 +229,7 @@ export default connect(
 		const post = getEditedPost( state, siteId, postId );
 		const isPrivatePost = isEditedPostPrivate( state, siteId, postId );
 		const isPrivatePostPasswordValid = isPrivateEditedPostPasswordValid( state, siteId, postId );
+		const canUserPublishPosts = canCurrentUser( state, siteId, 'publish_posts' );
 
 		return {
 			siteId,
@@ -233,6 +237,7 @@ export default connect(
 			post,
 			isPrivatePost,
 			isPrivatePostPasswordValid,
+			canUserPublishPosts,
 		};
 	},
 	{ editPost }

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -27,7 +27,7 @@ import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import { isEditedPostPrivate, isPrivateEditedPostPasswordValid } from 'state/posts/selectors';
-import { canCurrentUser } from 'state/selectors';
+import { canCurrentUser, isPrivateSite as isPrivateSiteSelector } from 'state/selectors';
 
 class EditorConfirmationSidebar extends React.Component {
 	static propTypes = {
@@ -40,7 +40,6 @@ class EditorConfirmationSidebar extends React.Component {
 		isPrivatePostPasswordValid: PropTypes.bool,
 		setPostDate: PropTypes.func,
 		setStatus: PropTypes.func,
-		site: PropTypes.object,
 		status: PropTypes.string,
 	};
 
@@ -65,7 +64,7 @@ class EditorConfirmationSidebar extends React.Component {
 	}
 
 	renderPublishButton() {
-		if ( ! this.props.site || ! this.props.post || ! this.props.savedPost ) {
+		if ( ! this.props.siteId || ! this.props.post || ! this.props.savedPost ) {
 			return;
 		}
 
@@ -104,9 +103,8 @@ class EditorConfirmationSidebar extends React.Component {
 			return;
 		}
 
-		const { password, type } = this.props.post || {};
+		const { password, type, isPrivateSite } = this.props.post || {};
 		const status = get( this.props.post, 'status', 'draft' );
-		const isPrivateSite = get( this.props, 'site.is_private' );
 		const savedStatus = get( this.props, 'savedPost.status' );
 		const savedPassword = get( this.props, 'savedPost.password' );
 		const props = {
@@ -227,6 +225,7 @@ export default connect(
 		const post = getEditedPost( state, siteId, postId );
 		const isPrivatePost = isEditedPostPrivate( state, siteId, postId );
 		const isPrivatePostPasswordValid = isPrivateEditedPostPasswordValid( state, siteId, postId );
+		const isPrivateSite = isPrivateSiteSelector( state, siteId );
 		const canUserPublishPosts = canCurrentUser( state, siteId, 'publish_posts' );
 
 		return {
@@ -234,6 +233,7 @@ export default connect(
 			postId,
 			post,
 			isPrivatePost,
+			isPrivateSite,
 			isPrivatePostPasswordValid,
 			canUserPublishPosts,
 		};

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -70,7 +70,6 @@ class EditorConfirmationSidebar extends React.Component {
 		}
 
 		const publishButtonStatus = getPublishButtonStatus(
-			this.props.site,
 			this.props.post,
 			this.props.savedPost,
 			this.props.canUserPublishPosts
@@ -134,7 +133,6 @@ class EditorConfirmationSidebar extends React.Component {
 		}
 
 		const publishButtonStatus = getPublishButtonStatus(
-			this.props.site,
 			this.props.post,
 			this.props.savedPost,
 			this.props.canUserPublishPosts

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -102,16 +102,18 @@ class EditorConfirmationSidebar extends Component {
 	}
 
 	renderPrivacyControl() {
-		if ( ! this.props.post ) {
+		const { isPrivateSite, post, onPrivatePublish } = this.props;
+
+		if ( ! post ) {
 			return;
 		}
 
-		const { password, type, isPrivateSite } = this.props.post || {};
-		const status = get( this.props.post, 'status', 'draft' );
+		const { password, type } = post || {};
+		const status = get( post, 'status', 'draft' );
 		const savedStatus = get( this.props, 'savedPost.status' );
 		const savedPassword = get( this.props, 'savedPost.password' );
 		const props = {
-			onPrivatePublish: this.props.onPrivatePublish,
+			onPrivatePublish,
 			isPrivateSite,
 			type,
 			password,

--- a/client/post-editor/editor-confirmation-sidebar/index.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -24,12 +24,15 @@ import EditorConfirmationSidebarHeader from './header';
 import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
-import { getEditedPost } from 'state/posts/selectors';
 import { getPublishButtonStatus } from 'post-editor/editor-publish-button';
-import { isEditedPostPrivate, isPrivateEditedPostPasswordValid } from 'state/posts/selectors';
+import {
+	isEditedPostPrivate,
+	isPrivateEditedPostPasswordValid,
+	getEditedPost,
+} from 'state/posts/selectors';
 import { canCurrentUser, isPrivateSite as isPrivateSiteSelector } from 'state/selectors';
 
-class EditorConfirmationSidebar extends React.Component {
+class EditorConfirmationSidebar extends Component {
 	static propTypes = {
 		handlePreferenceChange: PropTypes.func,
 		onPrivatePublish: PropTypes.func,
@@ -86,16 +89,16 @@ class EditorConfirmationSidebar extends React.Component {
 	getBusyButtonLabel( publishButtonStatus ) {
 		switch ( publishButtonStatus ) {
 			case 'update':
-				return this.props.translate( 'Updating...' );
+				return this.props.translate( 'Updating…' );
 			case 'schedule':
-				return this.props.translate( 'Scheduling...' );
+				return this.props.translate( 'Scheduling…' );
 			case 'publish':
-				return this.props.translate( 'Publishing...' );
+				return this.props.translate( 'Publishing…' );
 			case 'requestReview':
-				return this.props.translate( 'Submitting for Review...' );
+				return this.props.translate( 'Submitting for Review…' );
 		}
 
-		return this.props.translate( 'Publishing...' );
+		return this.props.translate( 'Publishing…' );
 	}
 
 	renderPrivacyControl() {

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -157,10 +157,6 @@ export class EditorGroundControl extends PureComponent {
 		);
 	}
 
-	canPublishPost() {
-		return this.props.canUserPublishPosts;
-	}
-
 	toggleAdvancedStatus = () => {
 		this.setState( { showAdvanceStatus: ! this.state.showAdvanceStatus } );
 	};

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -127,7 +127,6 @@ export class EditorGroundControl extends PureComponent {
 
 	getVerificationNoticeLabel() {
 		const primaryButtonState = getPublishButtonStatus(
-				this.props.site,
 				this.props.post,
 				this.props.savedPost,
 				this.props.canUserPublishPosts

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -4,7 +4,7 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { identity, noop } from 'lodash';
+import { identity, noop, get } from 'lodash';
 import moment from 'moment';
 import page from 'page';
 import i18n, { localize } from 'i18n-calypso';
@@ -17,11 +17,11 @@ import { connect } from 'react-redux';
 import Card from 'components/card';
 import Site from 'blocks/site';
 import postUtils from 'lib/posts/utils';
-import siteUtils from 'lib/site/utils';
 import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import Button from 'components/button';
 import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-buttons';
 import { composeAnalytics, recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
+import { canCurrentUser } from 'state/selectors';
 
 export class EditorGroundControl extends PureComponent {
 	static propTypes = {
@@ -129,7 +129,8 @@ export class EditorGroundControl extends PureComponent {
 		const primaryButtonState = getPublishButtonStatus(
 				this.props.site,
 				this.props.post,
-				this.props.savedPost
+				this.props.savedPost,
+				this.props.canUserPublishPosts
 			),
 			buttonLabels = {
 				update: i18n.translate( 'To update, check your email and confirm your address.' ),
@@ -158,7 +159,7 @@ export class EditorGroundControl extends PureComponent {
 	}
 
 	canPublishPost() {
-		return siteUtils.userCan( 'publish_posts', this.props.site );
+		return this.props.canUserPublishPosts;
 	}
 
 	toggleAdvancedStatus = () => {
@@ -192,7 +193,9 @@ export class EditorGroundControl extends PureComponent {
 					onClick={ this.onPreviewButtonClick }
 					tabIndex={ 4 }
 				>
-					<span className="editor-ground-control__button-label">{ this.getPreviewLabel() }</span>
+					<span className="editor-ground-control__button-label">
+						{ this.getPreviewLabel() }
+					</span>
 				</Button>
 				<div className="editor-ground-control__publish-button">
 					<EditorPublishButton
@@ -253,7 +256,7 @@ export class EditorGroundControl extends PureComponent {
 					homeLink={ true }
 					externalLink={ true }
 				/>
-				{ this.state.needsVerification && (
+				{ this.state.needsVerification &&
 					<div
 						className="editor-ground-control__email-verification-notice"
 						tabIndex={ 7 }
@@ -267,8 +270,7 @@ export class EditorGroundControl extends PureComponent {
 						<span className="editor-ground-control__email-verification-notice-more">
 							{ translate( 'Learn More' ) }
 						</span>
-					</div>
-				) }
+					</div> }
 				<QuickSaveButtons
 					isSaving={ isSaving }
 					isSaveBlocked={ isSaveBlocked }
@@ -283,6 +285,16 @@ export class EditorGroundControl extends PureComponent {
 		);
 	}
 }
+
+const mapStateToProps = ( state, ownProps ) => {
+	const siteId = get( ownProps, 'site.ID', null );
+
+	const canUserPublishPosts = canCurrentUser( state, siteId, 'publish_posts' );
+
+	return {
+		canUserPublishPosts,
+	};
+};
 
 const mapDispatchToProps = dispatch => ( {
 	recordPreviewButtonClick: () =>
@@ -303,4 +315,4 @@ const mapDispatchToProps = dispatch => ( {
 	recordBackButtonClick: () => dispatch( recordTracksEvent( 'calypso_editor_back_button_click' ) ),
 } );
 
-export default connect( null, mapDispatchToProps )( localize( EditorGroundControl ) );
+export default connect( mapStateToProps, mapDispatchToProps )( localize( EditorGroundControl ) );

--- a/client/post-editor/editor-publish-button/index.jsx
+++ b/client/post-editor/editor-publish-button/index.jsx
@@ -20,7 +20,7 @@ import { getEditorPostId } from 'state/ui/editor/selectors';
 import { isEditedPostPrivate, isPrivateEditedPostPasswordValid } from 'state/posts/selectors';
 import { canCurrentUser } from 'state/selectors';
 
-export const getPublishButtonStatus = ( site, post, savedPost, canUserPublishPosts ) => {
+export const getPublishButtonStatus = ( post, savedPost, canUserPublishPosts ) => {
 	if (
 		( postUtils.isPublished( savedPost ) &&
 			! postUtils.isBackDatedPublished( savedPost ) &&
@@ -47,7 +47,6 @@ export const getPublishButtonStatus = ( site, post, savedPost, canUserPublishPos
 
 export class EditorPublishButton extends Component {
 	static propTypes = {
-		site: PropTypes.object,
 		post: PropTypes.object,
 		savedPost: PropTypes.object,
 		onSave: PropTypes.func,
@@ -84,7 +83,6 @@ export class EditorPublishButton extends Component {
 			publish: 'Clicked Publish Page Button',
 		};
 		const buttonState = getPublishButtonStatus(
-			this.props.site,
 			this.props.post,
 			this.props.savedPost,
 			this.props.canUserPublishPosts
@@ -98,7 +96,6 @@ export class EditorPublishButton extends Component {
 
 	getButtonLabel() {
 		switch ( getPublishButtonStatus(
-			this.props.site,
 			this.props.post,
 			this.props.savedPost,
 			this.props.canUserPublishPosts

--- a/client/post-editor/editor-publish-button/test/index.jsx
+++ b/client/post-editor/editor-publish-button/test/index.jsx
@@ -130,6 +130,7 @@ describe( 'EditorPublishButton', () => {
 						savedPost={ { status: 'future', date: lastMonth } }
 						post={ { title: 'change', status: 'future', date: lastMonth } }
 						site={ MOCK_SITE }
+						canUserPublishPosts={ true }
 					/>
 				).instance();
 
@@ -142,6 +143,7 @@ describe( 'EditorPublishButton', () => {
 					translate={ identity }
 					savedPost={ { status: 'draft' } }
 					site={ MOCK_SITE }
+					canUserPublishPosts={ true }
 				/>
 			).instance();
 
@@ -260,6 +262,7 @@ describe( 'EditorPublishButton', () => {
 						post={ { status: 'draft' } }
 						site={ MOCK_SITE }
 						onPublish={ onPublish }
+						canUserPublishPosts={ true }
 					/>
 				).instance();
 
@@ -279,6 +282,7 @@ describe( 'EditorPublishButton', () => {
 						post={ { title: 'change', status: 'draft', date: nextMonth } }
 						onPublish={ onPublish }
 						site={ MOCK_SITE }
+						canUserPublishPosts={ true }
 					/>
 				).instance();
 
@@ -298,6 +302,7 @@ describe( 'EditorPublishButton', () => {
 						post={ { title: 'change', status: 'future', date: nextMonth } }
 						onPublish={ onPublish }
 						site={ MOCK_SITE }
+						canUserPublishPosts={ true }
 					/>
 				).instance();
 
@@ -317,6 +322,7 @@ describe( 'EditorPublishButton', () => {
 						post={ { title: 'change', status: 'future', date: lastMonth } }
 						onPublish={ onPublish }
 						site={ MOCK_SITE }
+						canUserPublishPosts={ true }
 					/>
 				).instance();
 

--- a/client/post-editor/editor-publish-button/test/index.jsx
+++ b/client/post-editor/editor-publish-button/test/index.jsx
@@ -41,7 +41,6 @@ describe( 'EditorPublishButton', () => {
 					translate={ identity }
 					savedPost={ { status: 'publish' } }
 					post={ { status: 'publish' } }
-					site={ MOCK_SITE }
 				/>
 			).instance();
 
@@ -54,7 +53,6 @@ describe( 'EditorPublishButton', () => {
 					translate={ identity }
 					savedPost={ { status: 'publish' } }
 					post={ { status: 'draft' } }
-					site={ MOCK_SITE }
 				/>
 			).instance();
 
@@ -69,7 +67,6 @@ describe( 'EditorPublishButton', () => {
 						translate={ identity }
 						savedPost={ { status: 'draft' } }
 						post={ { date: nextMonth } }
-						site={ MOCK_SITE }
 					/>
 				).instance();
 
@@ -99,7 +96,6 @@ describe( 'EditorPublishButton', () => {
 						translate={ identity }
 						savedPost={ { status: 'future', date: nextMonth } }
 						post={ { title: 'change', status: 'future', date: nextMonth } }
-						site={ MOCK_SITE }
 					/>
 				).instance();
 
@@ -114,7 +110,6 @@ describe( 'EditorPublishButton', () => {
 						translate={ identity }
 						savedPost={ { status: 'future', date: nextMonth } }
 						post={ { title: 'change', status: 'draft', date: nextMonth } }
-						site={ MOCK_SITE }
 					/>
 				).instance();
 
@@ -129,8 +124,7 @@ describe( 'EditorPublishButton', () => {
 						translate={ identity }
 						savedPost={ { status: 'future', date: lastMonth } }
 						post={ { title: 'change', status: 'future', date: lastMonth } }
-						site={ MOCK_SITE }
-						canUserPublishPosts={ true }
+						canUserPublishPosts
 					/>
 				).instance();
 
@@ -142,8 +136,7 @@ describe( 'EditorPublishButton', () => {
 				<EditorPublishButton
 					translate={ identity }
 					savedPost={ { status: 'draft' } }
-					site={ MOCK_SITE }
-					canUserPublishPosts={ true }
+					canUserPublishPosts
 				/>
 			).instance();
 
@@ -152,15 +145,7 @@ describe( 'EditorPublishButton', () => {
 
 		test( 'should return "Submit for Review" if the post is a draft and user can\'t publish', () => {
 			const tree = shallow(
-				<EditorPublishButton
-					translate={ identity }
-					savedPost={ { status: 'draft' } }
-					site={ {
-						capabilities: {
-							publish_posts: false,
-						},
-					} }
-				/>
+				<EditorPublishButton translate={ identity } savedPost={ { status: 'draft' } } />
 			).instance();
 
 			expect( tree.getButtonLabel() ).to.equal( 'Submit for Review' );
@@ -260,9 +245,8 @@ describe( 'EditorPublishButton', () => {
 					<EditorPublishButton
 						translate={ identity }
 						post={ { status: 'draft' } }
-						site={ MOCK_SITE }
 						onPublish={ onPublish }
-						canUserPublishPosts={ true }
+						canUserPublishPosts
 					/>
 				).instance();
 
@@ -282,7 +266,7 @@ describe( 'EditorPublishButton', () => {
 						post={ { title: 'change', status: 'draft', date: nextMonth } }
 						onPublish={ onPublish }
 						site={ MOCK_SITE }
-						canUserPublishPosts={ true }
+						canUserPublishPosts
 					/>
 				).instance();
 
@@ -301,8 +285,7 @@ describe( 'EditorPublishButton', () => {
 						savedPost={ { status: 'future', date: nextMonth } }
 						post={ { title: 'change', status: 'future', date: nextMonth } }
 						onPublish={ onPublish }
-						site={ MOCK_SITE }
-						canUserPublishPosts={ true }
+						canUserPublishPosts
 					/>
 				).instance();
 
@@ -321,8 +304,7 @@ describe( 'EditorPublishButton', () => {
 						savedPost={ { status: 'future', date: lastMonth } }
 						post={ { title: 'change', status: 'future', date: lastMonth } }
 						onPublish={ onPublish }
-						site={ MOCK_SITE }
-						canUserPublishPosts={ true }
+						canUserPublishPosts
 					/>
 				).instance();
 
@@ -355,11 +337,6 @@ describe( 'EditorPublishButton', () => {
 						translate={ identity }
 						savedPost={ { status: 'draft' } }
 						onSave={ onSave }
-						site={ {
-							capabilities: {
-								publish_posts: false,
-							},
-						} }
 					/>
 				).instance();
 

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -22,7 +22,6 @@ import * as paths from 'lib/paths';
 import PostMetadata from 'lib/post-metadata';
 import PopupMonitor from 'lib/popup-monitor';
 import Button from 'components/button';
-import siteUtils from 'lib/site/utils';
 import { recordStat, recordEvent } from 'lib/posts/stats';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
@@ -32,6 +31,7 @@ import { postTypeSupports } from 'state/post-types/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
 import { fetchConnections as requestConnections } from 'state/sharing/publicize/actions';
+import { canCurrentUser } from 'state/selectors';
 
 class EditorSharingPublicizeOptions extends React.Component {
 	static propTypes = {
@@ -154,7 +154,7 @@ class EditorSharingPublicizeOptions extends React.Component {
 
 	renderAddNewButton = () => {
 		// contributors cannot create publicize connections
-		if ( ! siteUtils.userCan( 'publish_posts', this.props.site ) ) {
+		if ( ! this.props.canUserPublishPosts ) {
 			return;
 		}
 
@@ -171,7 +171,7 @@ class EditorSharingPublicizeOptions extends React.Component {
 	renderInfoNotice = () => {
 		// don't show the message if the are no connections
 		// and the user is not allowed to add any
-		if ( ! this.hasConnections() && ! siteUtils.userCan( 'publish_posts', this.props.site ) ) {
+		if ( ! this.hasConnections() && ! this.props.canUserPublishPosts ) {
 			return;
 		}
 
@@ -225,7 +225,7 @@ class EditorSharingPublicizeOptions extends React.Component {
 
 		const classes = classNames( 'editor-sharing__publicize-options', {
 			'has-connections': this.hasConnections(),
-			'has-add-option': siteUtils.userCan( 'publish_posts', this.props.site ),
+			'has-add-option': this.props.canUserPublishPosts,
 		} );
 
 		return (
@@ -249,10 +249,12 @@ export default connect(
 		const isPublicizeEnabled =
 			false !== isJetpackModuleActive( state, siteId, 'publicize' ) &&
 			postTypeSupports( state, siteId, postType, 'publicize' );
+		const canUserPublishPosts = canCurrentUser( state, siteId, 'publish_posts' );
 
 		return {
 			siteId,
 			isPublicizeEnabled,
+			canUserPublishPosts,
 			connections: getSiteUserConnections( state, siteId, userId ),
 		};
 	},

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -24,13 +24,12 @@ import EditorMediaModalDetailPreviewAudio from './detail-preview-audio';
 import EditorMediaModalDetailPreviewDocument from './detail-preview-document';
 import Button from 'components/button';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
-import { userCan } from 'lib/site/utils';
 import versionCompare from 'lib/version-compare';
 import MediaUtils, { isItemBeingUploaded } from 'lib/media/utils';
 import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteOption, isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
-import { isPrivateSite } from 'state/selectors';
+import { isPrivateSite, canCurrentUser } from 'state/selectors';
 
 /**
  * This function return true if the image editor can be
@@ -116,9 +115,9 @@ class EditorMediaModalDetailItem extends Component {
 	}
 
 	renderEditButton() {
-		const { item, onEdit, site, translate } = this.props;
+		const { item, onEdit, translate, canUserUploadFiles } = this.props;
 
-		if ( ! userCan( 'upload_files', site ) ) {
+		if ( ! canUserUploadFiles ) {
 			return null;
 		}
 
@@ -214,9 +213,9 @@ class EditorMediaModalDetailItem extends Component {
 	}
 
 	renderFields() {
-		const { site, item } = this.props;
+		const { site, item, canUserUploadFiles } = this.props;
 
-		if ( ! userCan( 'upload_files', site ) ) {
+		if ( ! canUserUploadFiles ) {
 			return null;
 		}
 
@@ -319,6 +318,7 @@ class EditorMediaModalDetailItem extends Component {
 
 const connectComponent = connect( state => {
 	const siteId = getSelectedSiteId( state );
+	const canUserUploadFiles = canCurrentUser( state, siteId, 'upload_files' );
 
 	return {
 		isJetpack: isJetpackSite( state, siteId ),
@@ -326,6 +326,7 @@ const connectComponent = connect( state => {
 		isVideoPressModuleActive: isJetpackModuleActive( state, siteId, 'videopress' ),
 		isPrivateSite: isPrivateSite( state, siteId ),
 		siteId,
+		canUserUploadFiles,
 	};
 } );
 

--- a/client/post-editor/media-modal/gallery/edit-item.jsx
+++ b/client/post-editor/media-modal/gallery/edit-item.jsx
@@ -5,19 +5,18 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import { userCan } from 'lib/site/utils';
 import MediaLibraryListItem from 'my-sites/media-library/list-item';
 import EditorMediaModalGalleryCaption from './caption';
 import EditorMediaModalGalleryRemoveButton from './remove-button';
+import { canCurrentUser } from 'state/selectors';
 
-export default class extends React.Component {
-	static displayName = 'EditorMediaModalGalleryEditItem';
-
+class EditorMediaModalGalleryEditItem extends Component {
 	static propTypes = {
 		site: PropTypes.object,
 		item: PropTypes.object,
@@ -29,8 +28,8 @@ export default class extends React.Component {
 	};
 
 	renderCaption = () => {
-		const { site, item } = this.props;
-		if ( ! userCan( 'upload_files', site ) ) {
+		const { site, item, canUserUploadFiles } = this.props;
+		if ( ! canUserUploadFiles ) {
 			return;
 		}
 
@@ -51,3 +50,11 @@ export default class extends React.Component {
 		);
 	}
 }
+
+export default connect( ( state, { site = {} } ) => {
+	const canUserUploadFiles = canCurrentUser( state, site.ID, 'upload_files' );
+
+	return {
+		canUserUploadFiles,
+	};
+} )( EditorMediaModalGalleryEditItem );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -300,7 +300,6 @@ export const PostEditor = createReactClass( {
 					savedPost={ this.state.savedPost }
 					setPostDate={ this.setPostDate }
 					setStatus={ this.setConfirmationSidebar }
-					site={ site }
 					status={ this.state.confirmationSidebar }
 				/>
 				<EditorDocumentHead />

--- a/client/post-editor/restore-post-dialog.jsx
+++ b/client/post-editor/restore-post-dialog.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop, get } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,6 +18,7 @@ import FormButton from 'components/forms/form-button';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
+import { canCurrentUser } from 'state/selectors';
 
 class EditorRestorePostDialog extends Component {
 	static propTypes = {
@@ -26,7 +27,7 @@ class EditorRestorePostDialog extends Component {
 		onRestore: PropTypes.func,
 		isAutosave: PropTypes.bool,
 		postType: PropTypes.string,
-		userCanDeletePost: PropTypes.bool,
+		canUserDeletePost: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -36,10 +37,10 @@ class EditorRestorePostDialog extends Component {
 	};
 
 	restorePost = () => {
-		const { isAutosave, userCanDeletePost, onRestore } = this.props;
+		const { isAutosave, canUserDeletePost, onRestore } = this.props;
 		if ( isAutosave ) {
 			onRestore();
-		} else if ( userCanDeletePost ) {
+		} else if ( canUserDeletePost ) {
 			onRestore( 'draft' );
 		}
 	};
@@ -100,10 +101,10 @@ class EditorRestorePostDialog extends Component {
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );
-	const capabilities = getEditedPostValue( state, siteId, postId, 'capabilities' );
+	const canUserDeletePost = canCurrentUser( state, siteId, 'delete_post' );
 
 	return {
 		postType: getEditedPostValue( state, siteId, postId, 'type' ),
-		userCanDeletePost: get( capabilities, 'delete_post' ),
+		canUserDeletePost,
 	};
 } )( localize( EditorRestorePostDialog ) );

--- a/client/post-editor/restore-post-dialog.jsx
+++ b/client/post-editor/restore-post-dialog.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
+import { noop, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,7 +18,6 @@ import FormButton from 'components/forms/form-button';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
-import { canCurrentUser } from 'state/selectors';
 
 class EditorRestorePostDialog extends Component {
 	static propTypes = {
@@ -101,10 +100,10 @@ class EditorRestorePostDialog extends Component {
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );
-	const canUserDeletePost = canCurrentUser( state, siteId, 'delete_post' );
+	const capabilities = getEditedPostValue( state, siteId, postId, 'capabilities' );
 
 	return {
 		postType: getEditedPostValue( state, siteId, postId, 'type' ),
-		canUserDeletePost,
+		canUserDeletePost: get( capabilities, 'delete_post' ),
 	};
 } )( localize( EditorRestorePostDialog ) );


### PR DESCRIPTION
Part of cleaning after `sites-list` removal.

In this PR, we are removing all traces of `siteUtils.userCan` from `post-editor`.

## Testing

Start writing a new post. Can you publish it? Can you add media items to it (or edit current ones)? Can you change status of the post? Nothing unusual?