### PR TITLE
Store - style trash pickup

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -130,7 +130,7 @@ class Order extends Component {
 				busy={ isSaving }
 				disabled={ ! hasOrderEdits || isSaving }
 			>
-				{ translate( 'Save Order' ) }
+				{ translate( 'Update' ) }
 			</Button>,
 		];
 		if ( ! isEditing ) {

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -51,7 +51,7 @@
 
 .order-details__actions {
 	margin: 0 -24px;
-	padding: 16px 24px;
+	padding: 16px 76px 16px 24px;
 	border-bottom: 1px solid lighten($gray, 30%);
 	text-align: right;
 
@@ -71,6 +71,11 @@
 	box-shadow: none;
 	border: none;
 	text-align: right;
+	padding-right: 55px;
+
+	& + .form-setting-explanation {
+		padding-right: 55px;
+	}
 
 	.table-row {
 		&:hover {

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -51,7 +51,7 @@
 
 .order-details__actions {
 	margin: 0 -24px;
-	padding: 8px 78px 8px 24px;
+	padding: 16px 24px;
 	border-bottom: 1px solid lighten($gray, 30%);
 	text-align: right;
 
@@ -104,11 +104,6 @@
 	}
 
 	&.is-editing {
-		.order-details__totals-value {
-			// Indent enough to account for delete button
-			padding-right: 78px !important;
-		}
-
 		.order-details__totals-tax {
 			color: $gray-text-min;
 			font-style: italic;

--- a/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
@@ -16,6 +16,10 @@
 .order-fulfillment__print-container {
 	display: flex;
 	align-items: center;
+	margin-top: 16px;
+	@include breakpoint( ">960px" ) {
+		margin-top: 0;
+	}
 }
 
 .order-fulfillment__tracking,

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -101,7 +101,6 @@
 
 		.button {
 			float: left;
-			margin-right: 8px;
 			white-space: nowrap;
 			margin-left: 12px;
 

--- a/client/extensions/woocommerce/app/promotions/fields/style.scss
+++ b/client/extensions/woocommerce/app/promotions/fields/style.scss
@@ -136,4 +136,8 @@
 
 		}
 	}
+
+	.form-select {
+		margin-bottom: 16px;
+	}
 }

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -3,6 +3,12 @@
 		width: 660px;
 	}
 
+	.dialog__content {
+		.form-fieldset:last-child {
+			margin-bottom: 0;
+		}
+	}
+
 	.dialog__action-buttons {
 		overflow: visible;
 

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -1,9 +1,6 @@
 &.payments__dialog {
-	max-width: 660px;
-
-	.dialog__content {
-		height: 100%;
-		overflow-y: scroll;
+	@include breakpoint( ">660px" ) {
+		width: 660px;
 	}
 
 	.dialog__action-buttons {

--- a/client/extensions/woocommerce/app/settings/shipping/save-button.js
+++ b/client/extensions/woocommerce/app/settings/shipping/save-button.js
@@ -94,7 +94,7 @@ class ShippingSettingsSaveButton extends Component {
 				</Button>
 			) : null;
 		}
-		const label = wcsEnabled ? translate( 'Save and finish' ) : translate( "I'm Finished" );
+		const label = wcsEnabled ? translate( 'Save & finish' ) : translate( "I'm Finished" );
 		return (
 			<Button onClick={ this.redirect } primary busy={ isSaving } disabled={ isSaving }>
 				{ label }

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
@@ -49,8 +49,9 @@ const ShippingZoneHeader = ( {
 	return (
 		<ActionHeader breadcrumbs={ breadcrumbs }>
 			{ showDelete && (
-				<Button borderless onClick={ onDelete } disabled={ isSaving }>
+				<Button borderless scary onClick={ onDelete } disabled={ isSaving }>
 					<Gridicon icon="trash" />
+					{ translate( 'Delete' ) }
 				</Button>
 			) }
 			<Button primary onClick={ onSave } busy={ isSaving } disabled={ isSaving }>

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -206,17 +206,8 @@
 }
 
 &.shipping-zone__method-dialog {
-	max-height: 80%;
-	display: flex;
-	flex-direction: column;
-
-	.dialog__content {
-		height: 100%;
-		overflow-y: scroll;
-	}
-
-	.dialog__action-buttons {
-		overflow: visible;
+	@include breakpoint( ">660px" ) {
+		width: 660px;
 	}
 }
 
@@ -296,13 +287,8 @@
 }
 
 &.shipping-zone__location-dialog {
-	max-height: 85%;
-	display: flex;
-	flex-direction: column;
-
-	.dialog__content {
-		height: 100%;
-		overflow-y: scroll;
+	@include breakpoint( ">660px" ) {
+		width: 660px;
 	}
 
 	.dialog__action-buttons {

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -44,22 +44,19 @@
 	.button {
 		white-space: nowrap;
 		padding: 5px 14px 7px;
-		
+		margin-left: 12px;
+
 		&.is-borderless {
 			padding: 0;
 			margin-top: -6px;
 		}
-		
-		&.is-borderless .gridicon{
+
+		&.is-borderless .gridicon {
 			margin-right: 2px;
 		}
 
-		&:not( :first-child ) {
+		&.is-borderless + .button {
 			margin-left: 24px;
-
-			@include breakpoint( "<660px" ) {
-				margin-left: 18px;
-			}
 		}
 	}
 }

--- a/client/extensions/woocommerce/components/address-view/style.scss
+++ b/client/extensions/woocommerce/components/address-view/style.scss
@@ -44,9 +44,7 @@
 	}
 
 	.form-select {
-		@include breakpoint( ">960px" ) {
-			max-width: 200px;
-		}
+		width: 100%;
 	}
 }
 

--- a/client/extensions/woocommerce/components/filtered-list/style.scss
+++ b/client/extensions/woocommerce/components/filtered-list/style.scss
@@ -1,7 +1,3 @@
-.filtered-list {
-	max-width: 440px;
-}
-
 .filtered-list__container {
 	border: 1px solid lighten( $gray, 20% );
 	border-top: none;

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -36,7 +36,7 @@
 
 	&.is-on-hold {
 		background: lighten( $alert-yellow, 20% );
-		color: darken( $alert-yellow, 30% );
+		color: darken( $alert-yellow, 40% );
 
 		span + span {
 			border-color: $alert-yellow;

--- a/client/extensions/woocommerce/components/store-address/index.js
+++ b/client/extensions/woocommerce/components/store-address/index.js
@@ -127,7 +127,7 @@ class StoreAddress extends Component {
 				<div>
 					{ showLabel && <FormLabel>{ translate( 'Store location' ) }</FormLabel> }
 					<AddressView address={ this.state.address } />
-					<Button borderless onClick={ this.onShowDialog }>
+					<Button compact onClick={ this.onShowDialog }>
 						{ translate( 'Edit address' ) }
 					</Button>
 				</div>

--- a/client/extensions/woocommerce/components/store-address/style.scss
+++ b/client/extensions/woocommerce/components/store-address/style.scss
@@ -1,3 +1,9 @@
+&.store-location__edit-dialog {
+	@include breakpoint( ">660px" ) {
+		width: 660px;
+	}
+}
+
 .store-address {
 	&.is-placeholder {
 		@include placeholder();

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -19,7 +19,7 @@
 	}
 
 	.form-text-input-with-affixes {
-		width: 90%;
+		width: 70%;
 	}
 }
 


### PR DESCRIPTION
Just a few odds and ends that need tidying up;

- [x] Trash action icon styling for shipping zones doesn't match products / promos etc
- [x] Order status accessibility - I'm not convinced the colors meet WCAG AA guidelines for contrast
- [x] Print and fulfil button alignment https://cloudup.com/cqB9YXxtKdJ
- [x] Edit order - ragged right alignment https://cloudup.com/c2iRPRzd_hO
- [x] "Applies" dropdown margin in promos https://cloudup.com/c_lWsqqKSaY
- [x] Orders save button label = save. Promos + products = update. Should be consistent.
- [x] Margin beneath "Payment authorisation" radios in PayPal settings (same applies for all payment methods) https://cloudup.com/cEVXKFyupx7
- [x] Cash on delivery dialog is unnecessarily narrow https://cloudup.com/cCOAxTq6B91 let's make all methods the same
- [x] Edit address link color in shipping & tax settings https://cloudup.com/clIv4LElp-q
- [x] Selecting a location in Zones changes the dialog width https://cloudup.com/cWpq75Ph-WP
- [x] Order actions on smaller screens https://cloudup.com/cOEeKYa3G5R
- [x] Instances of "Save and Finish" vs "Save & Finish"