### PR TITLE
Wizard: Introduce new baseSuffix prop

### DIFF
--- a/client/components/wizard/README.md
+++ b/client/components/wizard/README.md
@@ -42,7 +42,17 @@ Link text for navigating to the previous step in the wizard.
 </table>
 
 Used when navigating between steps. The URL that the user is sent to will be constructed using
-`basePath` and `stepName` (see below).
+`basePath`, `stepName`, and `baseSuffix` (see below).
+
+### `baseSuffix`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+Used when navigating between steps. The URL that the user is sent to will be constructed using
+`basePath`, `stepName`, and `baseSuffix` (see below).
 
 ### `components`
 

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { get, indexOf } from 'lodash';
+import { compact, get, indexOf } from 'lodash';
 
 /**
  * Internal dependencies
@@ -46,7 +46,7 @@ class Wizard extends Component {
 			return;
 		}
 
-		return `${ basePath }/${ previousStepName }`;
+		return compact( [ basePath, previousStepName ] ).join( '/' );
 	};
 
 	getForwardUrl = () => {
@@ -63,7 +63,7 @@ class Wizard extends Component {
 			return;
 		}
 
-		return `${ basePath }/${ nextStepName }`;
+		return compact( [ basePath, nextStepName ] ).join( '/' );
 	};
 
 	render() {

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -18,6 +18,7 @@ class Wizard extends Component {
 	static propTypes = {
 		backText: PropTypes.string,
 		basePath: PropTypes.string,
+		baseSuffix: PropTypes.string,
 		components: PropTypes.objectOf( PropTypes.element ).isRequired,
 		forwardText: PropTypes.string,
 		hideNavigation: PropTypes.bool,
@@ -27,6 +28,7 @@ class Wizard extends Component {
 
 	static defaultProps = {
 		basePath: '',
+		baseSuffix: '',
 		hideNavigation: false,
 	};
 
@@ -39,18 +41,18 @@ class Wizard extends Component {
 			return;
 		}
 
-		const { basePath, steps } = this.props;
+		const { basePath, baseSuffix, steps } = this.props;
 		const previousStepName = steps[ stepIndex - 1 ];
 
 		if ( ! previousStepName ) {
 			return;
 		}
 
-		return compact( [ basePath, previousStepName ] ).join( '/' );
+		return compact( [ basePath, previousStepName, baseSuffix ] ).join( '/' );
 	};
 
 	getForwardUrl = () => {
-		const { basePath, steps } = this.props;
+		const { basePath, baseSuffix, steps } = this.props;
 		const stepIndex = this.getStepIndex();
 
 		if ( stepIndex === -1 || stepIndex === steps.length - 1 ) {
@@ -63,7 +65,7 @@ class Wizard extends Component {
 			return;
 		}
 
-		return compact( [ basePath, nextStepName ] ).join( '/' );
+		return compact( [ basePath, nextStepName, baseSuffix ] ).join( '/' );
 	};
 
 	render() {


### PR DESCRIPTION
This allows for routes like `basePath/stepName/baseSuffix` -- the most relevant use case will likely be a site slug in `baseSuffix`.

To test: Verify that existing instances of the `Wizard` component still work, e.g.
* `/extensions/wp-job-manager/setup/:site`