### PR TITLE
Jetpack Connect: Move autoAuthorize to authorize component

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -98,14 +98,9 @@ export class LoggedInForm extends Component {
 
 	componentWillMount() {
 		const { recordTracksEvent } = this.props;
-		const { autoAuthorize } = this.props.authorizationData;
-		const { alreadyAuthorized, newUserStartedConnection } = this.props.authQuery;
 		recordTracksEvent( 'calypso_jpc_auth_view' );
 
-		const doAutoAuthorize =
-			! this.props.isAlreadyOnSitesList &&
-			! alreadyAuthorized &&
-			( this.props.calypsoStartedConnection || newUserStartedConnection || autoAuthorize );
+		const doAutoAuthorize = this.shouldAutoAuthorize();
 
 		// isSSO is a separate case from the rest since we have already validated
 		// it in authorize-form.jsx. Therefore, if it's set, just authorize and redirect.
@@ -185,6 +180,16 @@ export class LoggedInForm extends Component {
 		} else {
 			page.redirect( this.getRedirectionTarget() );
 		}
+	}
+
+	shouldAutoAuthorize() {
+		const { autoAuthorize } = this.props.authorizationData;
+		const { alreadyAuthorized, newUserStartedConnection } = this.props.authQuery;
+		return (
+			! this.props.isAlreadyOnSitesList &&
+			! alreadyAuthorized &&
+			( this.props.calypsoStartedConnection || newUserStartedConnection || autoAuthorize )
+		);
 	}
 
 	isFromJpo( props = this.props ) {

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -100,11 +100,7 @@ export class LoggedInForm extends Component {
 		const { recordTracksEvent } = this.props;
 		recordTracksEvent( 'calypso_jpc_auth_view' );
 
-		const doAutoAuthorize = this.shouldAutoAuthorize();
-
-		// isSSO is a separate case from the rest since we have already validated
-		// it in authorize-form.jsx. Therefore, if it's set, just authorize and redirect.
-		if ( this.isSso() || doAutoAuthorize ) {
+		if ( this.shouldAutoAuthorize() ) {
 			debug( 'Authorizing automatically on component mount' );
 			this.setState( { haveAuthorized: true } );
 			return this.authorize();
@@ -186,9 +182,10 @@ export class LoggedInForm extends Component {
 		const { autoAuthorize } = this.props.authorizationData;
 		const { alreadyAuthorized, newUserStartedConnection } = this.props.authQuery;
 		return (
-			! this.props.isAlreadyOnSitesList &&
-			! alreadyAuthorized &&
-			( this.props.calypsoStartedConnection || newUserStartedConnection || autoAuthorize )
+			this.isSso() ||
+			( ! this.props.isAlreadyOnSitesList &&
+				! alreadyAuthorized &&
+				( this.props.calypsoStartedConnection || newUserStartedConnection || autoAuthorize ) )
 		);
 	}
 

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -94,7 +94,6 @@ export class LoggedInForm extends Component {
 	};
 
 	retryingAuth = false;
-	state = { haveAuthorized: false };
 
 	componentWillMount() {
 		const { recordTracksEvent } = this.props;
@@ -102,7 +101,6 @@ export class LoggedInForm extends Component {
 
 		if ( this.shouldAutoAuthorize() ) {
 			debug( 'Authorizing automatically on component mount' );
-			this.setState( { haveAuthorized: true } );
 			return this.authorize();
 		}
 	}

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -183,6 +183,7 @@ export class LoggedInForm extends Component {
 		const { alreadyAuthorized, newUserStartedConnection } = this.props.authQuery;
 		return (
 			this.isSso() ||
+			this.isWoo() ||
 			( ! this.props.isAlreadyOnSitesList &&
 				! alreadyAuthorized &&
 				( this.props.calypsoStartedConnection || newUserStartedConnection || autoAuthorize ) )

--- a/client/jetpack-connect/test/auth-logged-in-form.js
+++ b/client/jetpack-connect/test/auth-logged-in-form.js
@@ -2,6 +2,14 @@
  * @format
  * @jest-environment jsdom
  */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { identity, noop } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -23,7 +31,7 @@ describe( 'LoggedInForm', () => {
 			expect( isSso( props ) ).toBe( true );
 		} );
 
-		test( 'returns false with bad from', () => {
+		test( 'returns false with non-sso from', () => {
 			document.cookie = `jetpack_sso_approved=${ queryDataSiteId };`;
 			const props = {
 				authQuery: {
@@ -54,6 +62,60 @@ describe( 'LoggedInForm', () => {
 				},
 			};
 			expect( isSso( props ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isWoo', () => {
+		const isWoo = new LoggedInForm().isWoo;
+
+		test( 'should return true for woo wizard', () => {
+			const props = { authQuery: { from: 'woocommerce-services-auto-authorize' } };
+			expect( isWoo( props ) ).toBe( true );
+		} );
+
+		test( 'should return true for woo services', () => {
+			const props = { authQuery: { from: 'woocommerce-setup-wizard' } };
+			expect( isWoo( props ) ).toBe( true );
+		} );
+
+		test( 'returns false with non-woo from', () => {
+			const props = { authQuery: { from: 'elsewhere' } };
+			expect( isWoo( props ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'shouldAutoAuthorize', () => {
+		const renderableComponent = (
+			<LoggedInForm
+				authQuery={ {} }
+				authAttempts={ 0 }
+				authorizationData={ { autoAuthorize: false } }
+				authorize={ noop }
+				goBackToWpAdmin={ noop }
+				goToXmlrpcErrorFallbackUrl={ noop }
+				recordTracksEvent={ noop }
+				retryAuth={ noop }
+				siteSlug={ '' }
+				translate={ identity }
+				user={ {} }
+				userAlreadyConnected={ false }
+			/>
+		);
+
+		test( 'should return true for sso', () => {
+			const component = shallow( renderableComponent );
+			component.instance().isSso = () => true;
+			const result = component.instance().shouldAutoAuthorize();
+
+			expect( result ).toBe( true );
+		} );
+
+		test( 'should return true for woo', () => {
+			const component = shallow( renderableComponent );
+			component.instance().isWoo = () => true;
+			const result = component.instance().shouldAutoAuthorize();
+
+			expect( result ).toBe( true );
 		} );
 	} );
 } );

--- a/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
@@ -2,7 +2,7 @@
 /**
  * External dependencis
  */
-import { get, includes, isEmpty, omit } from 'lodash';
+import { get, isEmpty, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -65,14 +65,10 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 			} );
 
 		case JETPACK_CONNECT_QUERY_SET:
-			const autoAuthorize = includes(
-				[ 'woocommerce-services-auto-authorize', 'woocommerce-setup-wizard' ],
-				action.from
-			);
 			return {
 				authorizeError: false,
 				authorizeSuccess: false,
-				autoAuthorize,
+				autoAuthorize: false,
 				isAuthorizing: false,
 				timestamp: Date.now(),
 				userAlreadyConnected: false,

--- a/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-connect-authorize.js
@@ -290,26 +290,4 @@ describe( '#jetpackConnectAuthorize()', () => {
 		} );
 		expect( state.autoAuthorize ).toEqual( false );
 	} );
-
-	test( 'should not auto-authorize non-Woo users', () => {
-		const state = jetpackConnectAuthorize( undefined, {
-			type: JETPACK_CONNECT_QUERY_SET,
-			from: 'somewhere-else',
-		} );
-		expect( state.autoAuthorize ).toEqual( false );
-	} );
-
-	test( 'should auto-authorize Woo users', () => {
-		const stateFromWooCommerceServicesPlugin = jetpackConnectAuthorize( undefined, {
-			type: JETPACK_CONNECT_QUERY_SET,
-			from: 'woocommerce-services-auto-authorize',
-		} );
-		expect( stateFromWooCommerceServicesPlugin.autoAuthorize ).toEqual( true );
-
-		const stateFromWooCommerceWizard = jetpackConnectAuthorize( undefined, {
-			type: JETPACK_CONNECT_QUERY_SET,
-			from: 'woocommerce-setup-wizard',
-		} );
-		expect( stateFromWooCommerceWizard.autoAuthorize ).toEqual( true );
-	} );
 } );


### PR DESCRIPTION
There is logic for auto authorization split between reducers and inline component conditionals.

This PR consolidates the logic into one method in the component and adds tests.

## Testing:
1. Standard connection flow should be unaffected
1. Test sso flow _autoauth_
1. Test woo flows _autoauth_
1. Test account creation flows _autoauth_

See #20406 for detailed instructions on testing the flows.