### PR TITLE
Turn off G Suite up sell test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -85,8 +85,8 @@ export default {
 	gsuiteUpsell: {
 		datestamp: '20171025',
 		variations: {
-			show: 50,
-			hide: 50,
+			show: 0,
+			hide: 100,
 		},
 		defaultVariation: 'hide',
 		allowExistingUsers: true,


### PR DESCRIPTION
While digging into the results of this test, we noticed some anomalies in addition to some errors that were being reported. Digging in further, we noticed there were issues with where this test was being assigned. This PR essentially disables the test by showing the control version to 100% of visitors. More details here: p5XAZ9-1Eo-p2#comment-2132

@taggon can you take a look?

cc @klimeryk 