### PR TITLE
Jetpack Onboarding: Handle, set and persist currently onboarded site (Alternative Lyrics)

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -31,6 +31,7 @@ import { receiveJetpackOnboardingCredentials } from 'state/jetpack-onboarding/ac
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
 import { storePlan } from './persistence-utils';
+import { urlToSlug } from 'lib/url';
 import {
 	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_PERSONAL,
@@ -101,7 +102,8 @@ export function redirectWithoutLocaleifLoggedIn( context, next ) {
 
 export function maybeOnboard( { query, store }, next ) {
 	if ( ! isEmpty( query ) && query.onboarding ) {
-		const siteId = query.client_id;
+		const siteId = parseInt( query.client_id, 10 );
+		const siteSlug = urlToSlug( query.site_url );
 		const credentials = {
 			token: query.onboarding,
 			siteUrl: query.site_url,
@@ -110,7 +112,7 @@ export function maybeOnboard( { query, store }, next ) {
 
 		store.dispatch( receiveJetpackOnboardingCredentials( siteId, credentials ) );
 
-		return page.redirect( '/jetpack/onboarding' );
+		return page.redirect( '/jetpack/onboarding/' + siteSlug );
 	}
 
 	next();

--- a/client/jetpack-onboarding/controller.js
+++ b/client/jetpack-onboarding/controller.js
@@ -3,15 +3,12 @@
  * External Dependencies
  */
 import React from 'react';
-import { findKey } from 'lodash';
 
 /**
  * Internal Dependencies
  */
 import JetpackOnboardingMain from './main';
-import { setJetpackOnboardingSiteId } from 'state/ui/actions';
 import { setSection } from 'state/ui/actions';
-import { urlToSlug } from 'lib/url';
 
 const removeSidebar = context => {
 	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
@@ -20,22 +17,9 @@ const removeSidebar = context => {
 export const onboarding = ( context, next ) => {
 	removeSidebar( context );
 
-	context.primary = <JetpackOnboardingMain stepName={ context.params.stepName } />;
-	next();
-};
-
-export const siteSelection = ( context, next ) => {
-	const state = context.store.getState();
-
-	// TODO: move to a separate selector
-	const siteId = findKey( state.jetpackOnboarding.credentials, credentials => {
-		const siteSlug = urlToSlug( credentials.siteUrl );
-		return siteSlug === context.params.site;
-	} );
-
-	if ( siteId ) {
-		context.store.dispatch( setJetpackOnboardingSiteId( parseInt( siteId, 10 ) ) );
-	}
-
+	// We validate siteSlug inside the component
+	context.primary = (
+		<JetpackOnboardingMain siteSlug={ context.params.site } stepName={ context.params.stepName } />
+	);
 	next();
 };

--- a/client/jetpack-onboarding/controller.js
+++ b/client/jetpack-onboarding/controller.js
@@ -3,12 +3,15 @@
  * External Dependencies
  */
 import React from 'react';
+import { findKey } from 'lodash';
 
 /**
  * Internal Dependencies
  */
 import JetpackOnboardingMain from './main';
+import { setJetpackOnboardingSiteId } from 'state/ui/actions';
 import { setSection } from 'state/ui/actions';
+import { urlToSlug } from 'lib/url';
 
 const removeSidebar = context => {
 	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
@@ -18,5 +21,21 @@ export const onboarding = ( context, next ) => {
 	removeSidebar( context );
 
 	context.primary = <JetpackOnboardingMain stepName={ context.params.stepName } />;
+	next();
+};
+
+export const siteSelection = ( context, next ) => {
+	const state = context.store.getState();
+
+	// TODO: move to a separate selector
+	const siteId = findKey( state.jetpackOnboarding.credentials, credentials => {
+		const siteSlug = urlToSlug( credentials.siteUrl );
+		return siteSlug === context.params.site;
+	} );
+
+	if ( siteId ) {
+		context.store.dispatch( setJetpackOnboardingSiteId( parseInt( siteId, 10 ) ) );
+	}
+
 	next();
 };

--- a/client/jetpack-onboarding/index.js
+++ b/client/jetpack-onboarding/index.js
@@ -10,15 +10,14 @@ import { values } from 'lodash';
  * Internal dependencies
  */
 import { JETPACK_ONBOARDING_STEPS } from './constants';
-import { onboarding } from './controller';
+import { onboarding, siteSelection } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
-import { siteSelection } from '../my-sites/controller';
 
 export default function() {
 	if ( isEnabled( 'jetpack/onboarding' ) ) {
 		const validStepNames = values( JETPACK_ONBOARDING_STEPS );
 		page(
-			`/jetpack/onboarding/:stepName(${ validStepNames.join( '|' ) })?/:site?`,
+			`/jetpack/onboarding/:stepName(${ validStepNames.join( '|' ) })?/:site`,
 			siteSelection,
 			onboarding,
 			makeLayout,

--- a/client/jetpack-onboarding/index.js
+++ b/client/jetpack-onboarding/index.js
@@ -10,7 +10,7 @@ import { values } from 'lodash';
  * Internal dependencies
  */
 import { JETPACK_ONBOARDING_STEPS } from './constants';
-import { onboarding, siteSelection } from './controller';
+import { onboarding } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
@@ -18,7 +18,6 @@ export default function() {
 		const validStepNames = values( JETPACK_ONBOARDING_STEPS );
 		page(
 			`/jetpack/onboarding/:stepName(${ validStepNames.join( '|' ) })?/:site`,
-			siteSelection,
 			onboarding,
 			makeLayout,
 			clientRender

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { compact } from 'lodash';
+import { compact, findKey } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -16,6 +16,7 @@ import {
 	JETPACK_ONBOARDING_COMPONENTS as COMPONENTS,
 	JETPACK_ONBOARDING_STEPS as STEPS,
 } from './constants';
+import { urlToSlug } from 'lib/url';
 
 class JetpackOnboardingMain extends React.PureComponent {
 	static propTypes = {
@@ -26,13 +27,16 @@ class JetpackOnboardingMain extends React.PureComponent {
 		stepName: STEPS.SITE_TITLE,
 	};
 
+	// TODO: Add lifecycle methods to redirect if no siteId
+
 	render() {
-		const { stepName, steps } = this.props;
+		const { siteSlug, stepName, steps } = this.props;
 
 		return (
 			<Main className="jetpack-onboarding">
 				<Wizard
 					basePath="/jetpack/onboarding"
+					baseSuffix={ siteSlug }
 					components={ COMPONENTS }
 					steps={ steps }
 					stepName={ stepName }
@@ -43,7 +47,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 	}
 }
 
-export default connect( () => {
+export default connect( ( state, { siteSlug } ) => {
 	// Note: here we can select which steps to display, based on user's input
 	const steps = compact( [
 		STEPS.SITE_TITLE,
@@ -55,7 +59,14 @@ export default connect( () => {
 		STEPS.SUMMARY,
 	] );
 
+	// TODO: Make into selector
+	const siteId = findKey( state.jetpackOnboarding.credentials, ( { siteUrl } ) => {
+		return siteSlug === urlToSlug( siteUrl );
+	} );
+
 	return {
+		siteId,
+		siteSlug,
 		steps,
 	};
 } )( JetpackOnboardingMain );


### PR DESCRIPTION
[Don't cry](https://www.youtube.com/watch?v=QntHvkd46PE), @tyxla 😄 

Extract `site` fragment from the route, and validate it inside the component, using stored JPO credentials information. Necessary since we can't rely on the usual `siteSelection` / `getSelectedSiteId` mechanism for unconnected JP sites.

Alternative to #20862