### PR TITLE
Wizard: Pass Additional Props to Steps

### DIFF
--- a/client/components/wizard/README.md
+++ b/client/components/wizard/README.md
@@ -99,3 +99,7 @@ An array of strings denoting each of the steps in the wizard.
 </table>
 
 The name of the current step (one of the values in `steps`).
+
+### Additional props
+
+Any additional props will be passed to each individual step component.

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { compact, get, indexOf } from 'lodash';
+import { compact, get, indexOf, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -69,7 +69,15 @@ class Wizard extends Component {
 	};
 
 	render() {
-		const { backText, components, forwardText, hideNavigation, steps, stepName } = this.props;
+		const {
+			backText,
+			components,
+			forwardText,
+			hideNavigation,
+			steps,
+			stepName,
+			...otherProps
+		} = this.props;
 		const component = get( components, stepName );
 		const stepIndex = this.getStepIndex();
 		const totalSteps = steps.length;
@@ -85,6 +93,7 @@ class Wizard extends Component {
 				{ React.cloneElement( component, {
 					getBackUrl: this.getBackUrl,
 					getForwardUrl: this.getForwardUrl,
+					...omit( otherProps, [ 'basePath', 'baseSuffix' ] ),
 				} ) }
 
 				{ ! hideNavigation &&


### PR DESCRIPTION
This allows us e.g. to pass a `siteSlug` or `siteId` to each step.

To test: Verify that existing instances of the `Wizard` component still work, e.g.
* `/extensions/wp-job-manager/setup/:site`