### PR TITLE
Store Orders: Update order total display after refunds

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -84,6 +84,11 @@
 
 	.order-details__total-refund {
 		color: $alert-red;
+
+		td,
+		th {
+			border-top: 1px solid lighten($gray, 30%);
+		}
 	}
 
 	.order-details__total-full .order-details__totals-label,
@@ -100,6 +105,17 @@
 		.order-details__totals-tax,
 		.order-details__totals-value {
 			width: 8em;
+		}
+	}
+
+	&.has-refund {
+		.order-details__total-full .order-details__totals-label,
+		.order-details__total-full .order-details__totals-value {
+			font-weight: 400;
+		}
+		.order-details__total-remaining .order-details__totals-label,
+		.order-details__total-remaining .order-details__totals-value {
+			font-weight: 600;
 		}
 	}
 

--- a/client/extensions/woocommerce/app/orders/orders-list.js
+++ b/client/extensions/woocommerce/app/orders/orders-list.js
@@ -26,6 +26,8 @@ import {
 	getOrdersCurrentPage,
 	getOrdersCurrentSearch,
 } from 'woocommerce/state/ui/orders/selectors';
+import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
+import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import humanDate from 'lib/human-date';
 import { ORDER_UNPAID, ORDER_UNFULFILLED, ORDER_COMPLETED } from 'woocommerce/lib/order-status';
@@ -130,6 +132,10 @@ class Orders extends Component {
 
 	renderOrderItem = ( order, i ) => {
 		const { site } = this.props;
+		const total = formatCurrency( order.total, order.currency );
+		const refundValue = getOrderRefundTotal( order );
+		const remainingTotal = getCurrencyFormatDecimal( order.total, order.currency ) + refundValue;
+
 		return (
 			<TableRow
 				className={ 'orders__status-' + order.status }
@@ -149,7 +155,14 @@ class Orders extends Component {
 					<OrderStatus order={ order } />
 				</TableItem>
 				<TableItem className="orders__table-total">
-					{ formatCurrency( order.total, order.currency ) || order.total }
+					{ refundValue ? (
+						<span>
+							<span className="orders__table-old-total">{ total }</span>{' '}
+							{ formatCurrency( remainingTotal, order.currency ) }
+						</span>
+					) : (
+						total
+					) }
 				</TableItem>
 			</TableRow>
 		);

--- a/client/extensions/woocommerce/app/orders/style.scss
+++ b/client/extensions/woocommerce/app/orders/style.scss
@@ -51,3 +51,8 @@
 .orders__table-total {
 	text-align: right;
 }
+
+.orders__table-old-total {
+	text-decoration: line-through;
+	color: $gray-text-min;
+}

--- a/client/extensions/woocommerce/components/order-status/index.js
+++ b/client/extensions/woocommerce/components/order-status/index.js
@@ -19,7 +19,7 @@ export class OrderStatus extends Component {
 
 	getPaymentLabel = () => {
 		const { order, translate } = this.props;
-		const { status, payment_method } = order;
+		const { status, payment_method, refunds = [] } = order;
 		switch ( status ) {
 			case 'pending':
 			case 'on-hold':
@@ -27,6 +27,9 @@ export class OrderStatus extends Component {
 			case 'processing':
 				if ( 'cod' === payment_method ) {
 					return translate( 'Paid on delivery' );
+				}
+				if ( refunds.length > 0 ) {
+					return translate( 'Partially refunded' );
 				}
 				return translate( 'Paid in full' );
 			case 'completed':


### PR DESCRIPTION
Fixes #19053 — The order total was still displaying as full value even when the order has been partially or fully refunded. This PR updates the view with a "remaining total" field on orders with refunds, displaying the "real" current total (post-refund):

<img width="585" alt="refunded" src="https://user-images.githubusercontent.com/541093/34051453-af11bd98-e18c-11e7-957e-950331d897b3.png">

This also updates the list view with the full total crossed out, with the remaining total visible:

<img width="893" alt="list-view" src="https://user-images.githubusercontent.com/541093/34051454-af6060f6-e18c-11e7-922b-28c321262588.png">

To test:

- View your orders list, see that any refunded orders have a crossed-out total + remaining total
- View an order with a refund (grant yourself a partial refund if needed)
- You should see the refund + remaining total on the single order view
- The refund view goes away when editing, because it's not an editable field
- Check orders without refunds, there should be no refund totals listed