### PR TITLE
Editor: Revisions: Add scroll hints

### DIFF
--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -10,13 +10,13 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { debounce, filter, first, flow, get, has, last, map, partial, throttle } from 'lodash';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
 import { getPostRevision } from 'state/selectors';
 import TextDiff from 'components/text-diff';
-// import EditorDiffChanges from './changes';
 import Button from 'components/button';
 import scrollTo from 'lib/scroll-to';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -185,29 +185,23 @@ class EditorDiffViewer extends PureComponent {
 				</div>
 				{ showHints &&
 					countAbove > 0 && (
-						<Button className="editor-diff-viewer__hint-above" onClick={ this.scrollAbove }>
-							{ this.props.translate(
-								'%(numberOfChanges)d change above',
-								'%(numberOfChanges)d changes above',
-								{
-									args: { numberOfChanges: countAbove },
-									count: countAbove,
-								}
-							) }
-						</Button>
+						<div className="editor-diff-viewer__hint-above" onClick={ this.scrollAbove }>
+							<Gridicon className="editor-diff-viewer__hint-icon" size={ 18 } icon="arrow-up" />
+							{ this.props.translate( '%(numberOfChanges)d change', '%(numberOfChanges)d changes', {
+								args: { numberOfChanges: countAbove },
+								count: countAbove,
+							} ) }
+						</div>
 					) }
 				{ showHints &&
 					countBelow > 0 && (
-						<Button className="editor-diff-viewer__hint-below" onClick={ this.scrollBelow }>
-							{ this.props.translate(
-								'%(numberOfChanges)d change below',
-								'%(numberOfChanges)d changes below',
-								{
-									args: { numberOfChanges: countBelow },
-									count: countBelow,
-								}
-							) }
-						</Button>
+						<div className="editor-diff-viewer__hint-below" onClick={ this.scrollBelow }>
+							<Gridicon className="editor-diff-viewer__hint-icon" size={ 18 } icon="arrow-down" />
+							{ this.props.translate( '%(numberOfChanges)d change', '%(numberOfChanges)d changes', {
+								args: { numberOfChanges: countBelow },
+								count: countBelow,
+							} ) }
+						</div>
 					) }
 			</div>
 		);

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -17,7 +17,6 @@ import Gridicon from 'gridicons';
  */
 import { getPostRevision } from 'state/selectors';
 import TextDiff from 'components/text-diff';
-import Button from 'components/button';
 import scrollTo from 'lib/scroll-to';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -89,9 +88,7 @@ class EditorDiffViewer extends PureComponent {
 	};
 
 	recomputeChanges = callback => {
-		const diffNodes = this.node.querySelectorAll(
-			'.editor-diff-viewer__additions, .editor-diff-viewer__deletions'
-		);
+		const diffNodes = this.node.querySelectorAll( '.text-diff__additions, .text-diff__deletions' );
 		this.setState(
 			{
 				changeOffsets: map( diffNodes, getCenterOffset ),

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -5,17 +5,21 @@
  */
 
 import React, { PureComponent } from 'react';
-import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get, has } from 'lodash';
+import { get, has, map, filter, first, last, debounce, partial } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { getPostRevision } from 'state/selectors';
 import TextDiff from 'components/text-diff';
+// import EditorDiffChanges from './changes';
+import Button from 'components/button';
+import scrollTo from 'lib/scroll-to';
+
+const getCenterOffset = node => get( node, 'offsetTop', 0 ) + get( node, 'offsetHeight', 0 ) / 2;
 
 class EditorDiffViewer extends PureComponent {
 	static propTypes = {
@@ -29,23 +33,98 @@ class EditorDiffViewer extends PureComponent {
 		} ).isRequired,
 	};
 
-	scrollToFirstChangeOrTop = () => {
-		const thisNode = ReactDom.findDOMNode( this );
-		const diffNode = thisNode.querySelector(
+	state = {
+		changeOffsets: [],
+		scrollTop: 0,
+		viewportHeight: 0,
+	};
+
+	lastScolledRevisionId = null;
+
+	tryScrollingToFirstChangeOrTop = () => {
+		if (
+			! this.props.selectedRevisionId ||
+			this.props.selectedRevisionId === this.lastScolledRevisionId
+		) {
+			return;
+		}
+
+		// save revisionId so we don't scroll again, unless it changes
+		this.lastScolledRevisionId = this.props.selectedRevisionId;
+
+		this.recomputeChanges( () => {
+			this.centerScrollingOnOffset( this.state.changeOffsets[ 0 ] || 0, false );
+		} );
+	};
+
+	recomputeChanges = callback => {
+		const diffNodes = this.node.querySelectorAll(
 			'.editor-diff-viewer__additions, .editor-diff-viewer__deletions'
 		);
-		const thisNodeHeight = get( thisNode, 'offsetHeight', 0 );
-		const offset = Math.max( 0, get( diffNode, 'offsetTop', 0 ) - thisNodeHeight / 2 );
-		thisNode.scrollTop = offset;
+		this.setState(
+			{
+				changeOffsets: map( diffNodes, getCenterOffset ),
+				viewportHeight: get( this.node, 'offsetHeight', 0 ),
+				scrollTop: get( this.node, 'scrollTop', 0 ),
+			},
+			callback
+		);
+	};
+
+	debouncedRecomputeChanges = debounce( partial( this.recomputeChanges, null ), 1000 );
+
+	centerScrollingOnOffset = ( offset, animated = true ) => {
+		const nextScrollTop = Math.max( 0, offset - this.state.viewportHeight / 2 );
+
+		if ( ! animated ) {
+			this.node.scrollTop = nextScrollTop;
+			return;
+		}
+
+		scrollTo( {
+			container: this.node,
+			x: 0,
+			y: nextScrollTop,
+		} );
+	};
+
+	handleScroll = e => {
+		this.setState( {
+			scrollTop: get( e.target, 'scrollTop', 0 ),
+		} );
 	};
 
 	componentDidMount() {
-		this.scrollToFirstChangeOrTop();
+		this.tryScrollingToFirstChangeOrTop();
+		if ( typeof window !== undefined ) {
+			window.addEventListener( 'resize', this.debouncedRecomputeChanges );
+		}
 	}
 
-	componentDidUpdate() {
-		this.scrollToFirstChangeOrTop();
+	componentWillUnmount() {
+		window.removeEventListener( 'resize', this.debouncedRecomputeChanges );
 	}
+
+	handleScrollableNode = node => {
+		this.node = node;
+		if ( this.node ) {
+			this.node.addEventListener( 'scroll', this.handleScroll );
+		} else {
+			this.node.removeEventListener( 'scroll', this.handleScroll );
+		}
+	};
+
+	componentDidUpdate() {
+		this.tryScrollingToFirstChangeOrTop();
+	}
+
+	scrollAbove = () => {
+		this.centerScrollingOnOffset( last( this.changesAboveViewport ) );
+	};
+
+	scrollBelow = () => {
+		this.centerScrollingOnOffset( first( this.changesBelowViewport ) );
+	};
 
 	render() {
 		const { diff } = this.props;
@@ -53,14 +132,38 @@ class EditorDiffViewer extends PureComponent {
 			'is-loading': ! has( diff, 'post_content' ) && ! has( diff, 'post_title' ),
 		} );
 
+		const bottomBoundary = this.state.scrollTop + this.state.viewportHeight;
+
+		// saving to this to we can access if from `scrollAbove` and `scrollBelow`
+		this.changesAboveViewport = filter(
+			this.state.changeOffsets,
+			offset => offset < this.state.scrollTop
+		);
+		this.changesBelowViewport = filter(
+			this.state.changeOffsets,
+			offset => offset > bottomBoundary
+		);
+
 		return (
 			<div className={ classes }>
-				<h1 className="editor-diff-viewer__title">
-					<TextDiff operations={ diff.post_title } />
-				</h1>
-				<pre className="editor-diff-viewer__content">
-					<TextDiff operations={ diff.post_content } splitLines />
-				</pre>
+				<div className="editor-diff-viewer__scrollable" ref={ this.handleScrollableNode }>
+					<h1 className="editor-diff-viewer__title">
+						<TextDiff operations={ diff.post_title } />
+					</h1>
+					<pre className="editor-diff-viewer__content">
+						<TextDiff operations={ diff.post_content } splitLines />
+					</pre>
+				</div>
+				{ this.changesAboveViewport.length > 0 && (
+					<Button className="editor-diff-viewer__hint-above" onClick={ this.scrollAbove }>
+						{ this.changesAboveViewport.length } changes above
+					</Button>
+				) }
+				{ this.changesBelowViewport.length > 0 && (
+					<Button className="editor-diff-viewer__hint-below" onClick={ this.scrollBelow }>
+						{ this.changesBelowViewport.length } changes below
+					</Button>
+				) }
 			</div>
 		);
 	}

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -39,6 +39,23 @@ class EditorDiffViewer extends PureComponent {
 		viewportHeight: 0,
 	};
 
+	componentDidMount() {
+		this.tryScrollingToFirstChangeOrTop();
+		if ( typeof window !== 'undefined' ) {
+			window.addEventListener( 'resize', this.debouncedRecomputeChanges );
+		}
+	}
+
+	componentWillUnmount() {
+		if ( typeof window !== 'undefined' ) {
+			window.removeEventListener( 'resize', this.debouncedRecomputeChanges );
+		}
+	}
+
+	componentDidUpdate() {
+		this.tryScrollingToFirstChangeOrTop();
+	}
+
 	lastScolledRevisionId = null;
 
 	tryScrollingToFirstChangeOrTop = () => {
@@ -94,17 +111,6 @@ class EditorDiffViewer extends PureComponent {
 		} );
 	};
 
-	componentDidMount() {
-		this.tryScrollingToFirstChangeOrTop();
-		if ( typeof window !== undefined ) {
-			window.addEventListener( 'resize', this.debouncedRecomputeChanges );
-		}
-	}
-
-	componentWillUnmount() {
-		window.removeEventListener( 'resize', this.debouncedRecomputeChanges );
-	}
-
 	handleScrollableNode = node => {
 		this.node = node;
 		if ( this.node ) {
@@ -113,10 +119,6 @@ class EditorDiffViewer extends PureComponent {
 			this.node.removeEventListener( 'scroll', this.handleScroll );
 		}
 	};
-
-	componentDidUpdate() {
-		this.tryScrollingToFirstChangeOrTop();
-	}
 
 	scrollAbove = () => {
 		this.centerScrollingOnOffset( last( this.changesAboveViewport ) );
@@ -134,7 +136,7 @@ class EditorDiffViewer extends PureComponent {
 
 		const bottomBoundary = this.state.scrollTop + this.state.viewportHeight;
 
-		// saving to this to we can access if from `scrollAbove` and `scrollBelow`
+		// saving to `this` so we can access if from `scrollAbove` and `scrollBelow`
 		this.changesAboveViewport = filter(
 			this.state.changeOffsets,
 			offset => offset < this.state.scrollTop

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -169,6 +169,7 @@ class EditorDiffViewer extends PureComponent {
 			offset => offset > bottomBoundary
 		);
 
+		const showHints = this.state.viewportHeight > 600;
 		const countAbove = this.changesAboveViewport.length;
 		const countBelow = this.changesBelowViewport.length;
 
@@ -182,30 +183,32 @@ class EditorDiffViewer extends PureComponent {
 						<TextDiff operations={ diff.post_content } splitLines />
 					</pre>
 				</div>
-				{ countAbove > 0 && (
-					<Button className="editor-diff-viewer__hint-above" onClick={ this.scrollAbove }>
-						{ this.props.translate(
-							'%(numberOfChanges)d change above',
-							'%(numberOfChanges)d changes above',
-							{
-								args: { numberOfChanges: countAbove },
-								count: countAbove,
-							}
-						) }
-					</Button>
-				) }
-				{ countBelow > 0 && (
-					<Button className="editor-diff-viewer__hint-below" onClick={ this.scrollBelow }>
-						{ this.props.translate(
-							'%(numberOfChanges)d change below',
-							'%(numberOfChanges)d changes below',
-							{
-								args: { numberOfChanges: countBelow },
-								count: countBelow,
-							}
-						) }
-					</Button>
-				) }
+				{ showHints &&
+					countAbove > 0 && (
+						<Button className="editor-diff-viewer__hint-above" onClick={ this.scrollAbove }>
+							{ this.props.translate(
+								'%(numberOfChanges)d change above',
+								'%(numberOfChanges)d changes above',
+								{
+									args: { numberOfChanges: countAbove },
+									count: countAbove,
+								}
+							) }
+						</Button>
+					) }
+				{ showHints &&
+					countBelow > 0 && (
+						<Button className="editor-diff-viewer__hint-below" onClick={ this.scrollBelow }>
+							{ this.props.translate(
+								'%(numberOfChanges)d change below',
+								'%(numberOfChanges)d changes below',
+								{
+									args: { numberOfChanges: countBelow },
+									count: countBelow,
+								}
+							) }
+						</Button>
+					) }
 			</div>
 		);
 	}

--- a/client/post-editor/editor-diff-viewer/index.jsx
+++ b/client/post-editor/editor-diff-viewer/index.jsx
@@ -169,7 +169,7 @@ class EditorDiffViewer extends PureComponent {
 			offset => offset > bottomBoundary
 		);
 
-		const showHints = this.state.viewportHeight > 600;
+		const showHints = this.state.viewportHeight > 470;
 		const countAbove = this.changesAboveViewport.length;
 		const countBelow = this.changesBelowViewport.length;
 

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -1,10 +1,17 @@
 /** @format */
 .editor-diff-viewer {
+	box-sizing: border-box;
+	overflow-y: hidden;
 	flex: 1;
 	margin: 0;
-	padding: 24px 32px 32px 32px;
-	box-sizing: border-box;
-	overflow-y: auto;
+	position: relative;
+
+	.editor-diff-viewer__scrollable {
+		padding: 24px 32px 32px 32px;
+		height: 100%;
+		overflow-y: auto;
+		box-sizing: border-box;
+	}
 
 	.editor-diff-viewer__title {
 		font-family: $serif;
@@ -15,6 +22,20 @@
 		height: auto;
 		line-height: 1.425;
 	}
+}
+
+.editor-diff-viewer__hint-above,
+.editor-diff-viewer__hint-below {
+	position: absolute;
+	right: 20px;
+}
+
+.editor-diff-viewer__hint-above {
+	top: 20px;
+}
+
+.editor-diff-viewer__hint-below {
+	bottom: 20px;
 }
 
 .editor-diff-viewer.is-loading .editor-diff-viewer__title {

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -11,6 +11,7 @@
 		height: 100%;
 		overflow-y: auto;
 		box-sizing: border-box;
+		-webkit-overflow-scrolling: touch;
 	}
 
 	.editor-diff-viewer__title {

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -27,15 +27,15 @@
 .editor-diff-viewer__hint-above,
 .editor-diff-viewer__hint-below {
 	position: absolute;
-	right: 20px;
+	right: 24px;
 }
 
 .editor-diff-viewer__hint-above {
-	top: 20px;
+	top: 24px;
 }
 
 .editor-diff-viewer__hint-below {
-	bottom: 20px;
+	bottom: 24px;
 }
 
 .editor-diff-viewer.is-loading .editor-diff-viewer__title {

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -38,6 +38,10 @@
 	padding: 0 16px 0 8px;
 	color: #fff;
 	font-size: 13px;
+
+	@include breakpoint( '<660px' ) {
+		display: none;
+	}
 }
 
 .editor-diff-viewer__hint-above {

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -5,6 +5,7 @@
 	flex: 1;
 	margin: 0;
 	position: relative;
+	z-index: 1; // Put the viewer above the action-buttons:before overlay gradient. -shaun
 
 	.editor-diff-viewer__scrollable {
 		padding: 24px 32px 32px 32px;
@@ -29,14 +30,30 @@
 .editor-diff-viewer__hint-below {
 	position: absolute;
 	right: 24px;
+	border-radius: 4px;
+	height: 28px;
+	line-height: 27px;
+	background-color: $gray-text-min;
+	cursor: pointer;
+	padding: 0 16px 0 8px;
+	color: #fff;
+	font-size: 13px;
 }
 
 .editor-diff-viewer__hint-above {
-	top: 24px;
+	top: 0;
+	border-radius: 0 0 4px 4px;
 }
 
 .editor-diff-viewer__hint-below {
-	bottom: 24px;
+	bottom: 0;
+	border-radius: 4px 4px 0 0;
+}
+
+.editor-diff-viewer__hint-icon {
+	margin-right: 6px;
+	position: relative;
+	top: 4px;
 }
 
 .editor-diff-viewer.is-loading .editor-diff-viewer__title {

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -68,6 +68,7 @@
 	bottom: 0;
 	left: 0;
 	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
 
 	@include breakpoint( '<660px' ) {
 		overflow-y: hidden;


### PR DESCRIPTION
When browsing revisions, there is currently no way to tell there are more changes apart from those initially visible on a screen. You can only scroll through the whole content and look for changes.

This PR adds hints to the top and bottom of the scrollable area that indicate whether there are more changes above/below the viewport. Clicking them will scroll to the next invisible change in the selected direction.

To test:
- open revisions for some long post
- try selecting different revisions and make sure their first addition/deletion is always centered on the screen
- scroll in the diff window and see if hints show up at appropriate times
- click hints and confirm they scroll to content & trigger tracks events
- on mobile, scroll hints should not show for now
    - we'd like the functionality but haven't figured out the best way yet

Demo:
![scroll-hints-3](https://user-images.githubusercontent.com/156676/34061933-71639c1a-e1ea-11e7-9131-320011d18a0d.gif)
