### PR TITLE
Remove text-decoration from abbr to avoid double underline in Chrome

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -202,6 +202,7 @@ code, kbd, tt, var {
 abbr, acronym {
 	border-bottom: 1px dotted darken( $gray, 20% );
 	cursor: help;
+	// Prevent double underline in Chrome
 	text-decoration: none;
 }
 mark, ins {

--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -202,6 +202,7 @@ code, kbd, tt, var {
 abbr, acronym {
 	border-bottom: 1px dotted darken( $gray, 20% );
 	cursor: help;
+	text-decoration: none;
 }
 mark, ins {
 	background: lighten( $alert-yellow, 23% );


### PR DESCRIPTION
In recent versions of Chrome, a default `text-decoration` style has been added to the `abbr` element (see https://github.com/twbs/bootstrap/issues/22562). This currently results in a double dotted underline in Calypso:

<img width="374" alt="screen shot 2017-12-15 at 17 26 39" src="https://user-images.githubusercontent.com/17325/34054069-390b804a-e1c1-11e7-9f78-dd8615d930a5.png">

This PR removes `text-decoration` from abbr and acronym, but preserves the underline via the existing bottom border. 

After:

<img width="327" alt="screen shot 2017-12-15 at 17 52 44" src="https://user-images.githubusercontent.com/17325/34054090-4cd3413a-e1c1-11e7-88d0-126cfaa22e38.png">

Tested in Chrome 63 Mac.

### To test

Compare:

http://calypso.localhost:3000/read/blogs/76295396/posts/10

with:

http://wordpress.com/read/blogs/76295396/posts/10