### PR TITLE
JP Onboarding: Pass siteId down to individual steps

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -30,7 +30,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 	// TODO: Add lifecycle methods to redirect if no siteId
 
 	render() {
-		const { siteSlug, stepName, steps } = this.props;
+		const { siteId, siteSlug, stepName, steps } = this.props;
 
 		return (
 			<Main className="jetpack-onboarding">
@@ -38,6 +38,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 					basePath="/jetpack/onboarding"
 					baseSuffix={ siteSlug }
 					components={ COMPONENTS }
+					siteId={ siteId /* Passed down to individual steps */ }
 					steps={ steps }
 					stepName={ stepName }
 					hideNavigation={ stepName === STEPS.SUMMARY }

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -21,7 +21,6 @@ import FormTextInput from 'components/forms/form-text-input';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { saveSiteSettings } from 'state/site-settings/actions';
 import { getSiteSettings, isRequestingSiteSettings } from 'state/site-settings/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
 
 class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	state = {
@@ -100,14 +99,9 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 }
 
 export default connect(
-	state => {
-		const siteId = getSelectedSiteId( state );
-
-		return {
-			isRequesting: isRequestingSiteSettings( state, siteId ),
-			siteId,
-			siteSettings: getSiteSettings( state, siteId ),
-		};
-	},
+	( state, { siteId } ) => ( {
+		isRequesting: isRequestingSiteSettings( state, siteId ),
+		siteSettings: getSiteSettings( state, siteId ),
+	} ),
 	{ saveSiteSettings }
 )( localize( JetpackOnboardingSiteTitleStep ) );


### PR DESCRIPTION
To test (stealing instructions from @tyxla's #20862):

* Checkout this branch on your local Calypso.
* Checkout the latest master on your Jetpack sandbox.
* Apply D7342-code on your wp.com sandbox and make sure you're sandboxing the API and jetpack.wordpress.com.
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
* Verify that after a couple of redirects you land in http://calypso.localhost:3000/jetpack/onboarding/yourjetpacksandbox.com

And, new in this PR:

* Site Title and Description will be filled in _if your Jetpack Sandbox is connected to WP.com_. You'll get a console error about a missing `blogdescription` field otherwise. (The reason is simply that the required actions for fetching and setting of site settings only work with connected JP sites as of yet since we haven't implemented the necessary logic for unconnected sites yet.)
