### PR TITLE
Comments: pluralize header title only on post list

### DIFF
--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -61,7 +61,7 @@ export class CommentView extends Component {
 				{ 'delete' === action && (
 					<CommentDeleteWarning { ...{ siteId, postId, commentId, redirectToPostView } } />
 				) }
-				<CommentListHeader { ...{ postId } } />
+				<CommentListHeader { ...{ postId, commentId } } />
 				{ ! canModerateComments && (
 					<EmptyContent
 						title={ preventWidows(

--- a/client/my-sites/comments/comment-list/comment-list-header.jsx
+++ b/client/my-sites/comments/comment-list/comment-list-header.jsx
@@ -26,6 +26,7 @@ function goBack() {
 }
 
 export const CommentListHeader = ( {
+	commentId,
 	postDate,
 	postId,
 	postTitle,
@@ -60,10 +61,15 @@ export const CommentListHeader = ( {
 				alwaysShowActionText
 			>
 				<div className="comment-list__header-title">
-					{ translate( 'Comments on {{span}}%(postTitle)s{{/span}}', {
-						args: { postTitle: title },
-						components: { span: <span className="comment-list__header-post-title" /> },
-					} ) }
+					{ translate(
+						'Comment on {{span}}%(postTitle)s{{/span}}',
+						'Comments on {{span}}%(postTitle)s{{/span}}',
+						{
+							count: commentId ? 1 : 2,
+							args: { postTitle: title },
+							components: { span: <span className="comment-list__header-post-title" /> },
+						}
+					) }
 				</div>
 				<div className="comment-list__header-date">{ formattedDate }</div>
 			</HeaderCake>


### PR DESCRIPTION
This PR removes the pluralization of the header title on the _Comment_ view.

To test:

* navigate to a _Comment View_ by clicking on a comment timestamp
* the header title should show `Comment on` instead of `Comments on`.

| Before | After |
| -- | -- |
| ![screen shot 2017-12-15 at 15 15 34](https://user-images.githubusercontent.com/233601/34054724-fd2da3d4-e1aa-11e7-99eb-5af554af0c71.png) | ![screen shot 2017-12-15 at 15 16 26](https://user-images.githubusercontent.com/233601/34054729-01cd4cfa-e1ab-11e7-86d2-5177da2e393c.png) |

There should be no regressions on the _Post Comments_ view.