### PR TITLE
Comments: fixes CommentListHeader failed prop type warning

### DIFF
--- a/client/my-sites/comments/comment-list/comment-list-header.jsx
+++ b/client/my-sites/comments/comment-list/comment-list-header.jsx
@@ -55,7 +55,7 @@ export const CommentListHeader = ( {
 				actionIcon="visible"
 				actionOnClick={ recordReaderArticleOpened }
 				actionText={ translate( 'View Post' ) }
-				onClick={ shouldUseHistoryBack && goBack }
+				onClick={ shouldUseHistoryBack ? goBack : undefined }
 				backHref={ backHref }
 				alwaysShowActionText
 			>


### PR DESCRIPTION
This PR removes React 16's [invalid event listener warning](https://github.com/facebook/react/blob/master/packages/react-dom/src/client/ReactDOMFiberComponent.js#L165) from the _Post Comments_ and _Comment_ views. 

It does as the warning suggests and replaces `{ condition && value }` for `{ condition ? value : undefined }`.

How to reproduce:

* Navigate to the _Post Comments_ view.
* Open your browser's developer console.
* Reload the page.

You should get these warnings:
> Warning: Failed prop type: Invalid prop `onClick` of type `boolean` supplied to `HeaderCake`, expected `function`.

>Warning: Failed prop type: Invalid prop `onClick` of type `boolean` supplied to `HeaderCakeBack`, expected `function`.

> Warning: Expected `onClick` listener to be a function, instead got `false`.
> If you used to conditionally omit it with onClick={condition && value}, pass onClick={condition ? value : undefined} instead.

When switching to this branch these warnings should disappear.