### PR TITLE
Store: Add a CustomerSearch component

### DIFF
--- a/client/extensions/woocommerce/app/order/order-customer/create.js
+++ b/client/extensions/woocommerce/app/order/order-customer/create.js
@@ -16,6 +16,7 @@ import AddressView from 'woocommerce/components/address-view';
 import Button from 'components/button';
 import Card from 'components/card';
 import CustomerAddressDialog from './dialog';
+import CustomerSearch from 'woocommerce/components/customer-search';
 import { editOrder } from 'woocommerce/state/ui/orders/actions';
 import getAddressViewFormat from 'woocommerce/lib/get-address-view-format';
 import { getOrderWithEdits } from 'woocommerce/state/ui/orders/selectors';
@@ -53,6 +54,10 @@ class OrderCustomerInfo extends Component {
 		return () => {
 			this.setState( { showDialog: type } );
 		};
+	};
+
+	populateCustomer = () => {
+		// Set billing, shipping, and customer_id on the order
 	};
 
 	renderDialogs = () => {
@@ -147,6 +152,8 @@ class OrderCustomerInfo extends Component {
 				<SectionHeader label={ translate( 'Customer Information' ) } />
 				<Card>
 					<div className="order-customer__container">
+						<CustomerSearch onSelect={ this.populateCustomer } />
+
 						<div className="order-customer__billing">
 							<h3 className="order-customer__billing-details">
 								{ translate( 'Billing Details' ) }

--- a/client/extensions/woocommerce/components/customer-search/index.js
+++ b/client/extensions/woocommerce/components/customer-search/index.js
@@ -1,0 +1,50 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CustomerList from './list';
+import FormLabel from 'components/forms/form-label';
+import Search from 'components/search';
+
+class CustomerSearch extends Component {
+	static propTypes = {
+		onSelect: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+		value: PropTypes.string,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			term: props.value || '',
+		};
+	}
+
+	doSearch = term => {
+		this.setState( { term } );
+	};
+
+	render() {
+		const { onSelect, translate } = this.props;
+		const { term } = this.state;
+
+		return (
+			<div className="customer-search">
+				<FormLabel>{ translate( 'Look up an existing customer by email' ) }</FormLabel>
+				<Search onSearch={ this.doSearch } value={ term } />
+				<CustomerList term={ term } onSelect={ onSelect } />
+			</div>
+		);
+	}
+}
+
+export default localize( CustomerSearch );

--- a/client/extensions/woocommerce/components/customer-search/list.js
+++ b/client/extensions/woocommerce/components/customer-search/list.js
@@ -1,0 +1,101 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import {
+	getCustomerSearchResults,
+	isCustomerSearchLoaded,
+} from 'woocommerce/state/sites/customers/selectors';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import { searchCustomers } from 'woocommerce/state/sites/customers/actions';
+
+class CustomerList extends PureComponent {
+	static propTypes = {
+		isLoaded: PropTypes.bool.isRequired,
+		customers: PropTypes.arrayOf(
+			PropTypes.shape( {
+				email: PropTypes.string.isRequired,
+				billing: PropTypes.object.isRequired,
+				shipping: PropTypes.object.isRequired,
+			} )
+		),
+		onSelect: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
+		term: PropTypes.string,
+	};
+
+	componentWillMount() {
+		this.fetchData( this.props );
+	}
+
+	componentWillReceiveProps( newProps ) {
+		if ( newProps.siteId !== this.props.siteId || newProps.term !== this.props.term ) {
+			this.fetchData( newProps );
+		}
+	}
+
+	fetchData = ( { siteId, isLoaded, term } ) => {
+		if ( ! siteId ) {
+			return;
+		}
+		if ( ! isLoaded && term.length > 2 ) {
+			this.props.searchCustomers( siteId, term );
+		}
+	};
+
+	onSelect = term => event => {
+		event.preventDefault();
+		this.props.onSelect( term );
+	};
+
+	renderCustomer = customer => {
+		const { translate } = this.props;
+		return (
+			<div className="customer-search__customer" key={ customer.id }>
+				<Button compact onClick={ this.onSelect( customer ) }>
+					{ translate( 'Select' ) }
+				</Button>
+				<div className="customer-search__customer-name">
+					{ customer.first_name } { customer.last_name }
+				</div>
+				<div className="customer-search__customer-email">{ customer.email }</div>
+				<div className="customer-search__customer-city">
+					{ get( customer, 'billing.city', '' ) }, { get( customer, 'billing.state', '' ) }
+				</div>
+			</div>
+		);
+	};
+
+	render() {
+		const { customers } = this.props;
+
+		return <div className="customer-search__list">{ customers.map( this.renderCustomer ) }</div>;
+	}
+}
+
+export default connect(
+	( state, { term } ) => {
+		const site = getSelectedSiteWithFallback( state );
+		const siteId = site ? site.ID : false;
+		const customers = getCustomerSearchResults( state, term, siteId );
+		const isLoaded = isCustomerSearchLoaded( state, term, siteId );
+
+		return {
+			customers,
+			isLoaded,
+			siteId,
+		};
+	},
+	dispatch => bindActionCreators( { searchCustomers }, dispatch )
+)( localize( CustomerList ) );


### PR DESCRIPTION
This PR starts a customer search component, so that store owners can quickly pre-fill customer data when creating orders. Currently there is no design for this, so I've just thrown the elements into the Customer Details card:

<img src="https://user-images.githubusercontent.com/541093/34056498-39f2954a-e1a1-11e7-9526-2d28c1b80455.png" width="50%" /><img src="https://user-images.githubusercontent.com/541093/34056497-39a5861a-e1a1-11e7-8ad9-41c6daf9af6a.png"  width="50%"/>

Once selected, the customer details will be populated below in the shipping/billing details (not working yet). @kellychoffman @jameskoster I've pulled this idea from the original mockup for orders creation, but there was no flow or design for actually choosing a user. Can one of you work up a design? either a sketch mockup or directly editing this PR works 🙂   Thanks!