### PR TITLE
Add store flow to new site segment step

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -268,6 +268,14 @@ if ( config.isEnabled( 'signup/atomic-store-flow' ) ) {
 		description: 'Signup flow for creating an online store with an Atomic site',
 		lastModified: '2017-09-27',
 	};
+
+	flows[ 'segmented-store-nux' ] = {
+		steps: [ 'about', 'themes', 'domains', 'plans-store-nux', 'user' ],
+		destination: getSiteDestination,
+		description:
+			'Signup flow for creating an online store with an Atomic site from the new site segementing step',
+		lastModified: '2017-12-15',
+	};
 }
 
 if ( config.isEnabled( 'signup/wpcc' ) ) {

--- a/client/signup/steps/about/style.scss
+++ b/client/signup/steps/about/style.scss
@@ -1,6 +1,25 @@
 .about__wrapper {
+	position: relative;
+}
+
+.about__pressable-wrapper {
+	position: absolute;
+	width: 100%;
+	opacity: 1;
+	filter: blur( 0 );
+	transform: translateZ( 0 ) translateX( 0 );
+	transition: 0.5s ease-in-out opacity, 0.5s ease-in-out filter, 0.5s ease-in-out transform;
+}
+
+.about__form-wrapper {
 	max-width: 500px;
 	margin: 0 auto;
+}
+
+.about__wrapper-is-hidden {
+	pointer-events: none;
+	transform: translateZ( 0 ) translateX( 25% );
+	opacity: 0;
 }
 
 .about__checkboxes {

--- a/client/signup/steps/about/style.scss
+++ b/client/signup/steps/about/style.scss
@@ -14,6 +14,9 @@
 .about__form-wrapper {
 	max-width: 500px;
 	margin: 0 auto;
+	filter: blur( 0 );
+	transform: translateZ( 0 ) translateX( 0 );
+	transition: 0.5s ease-in-out opacity, 0.5s ease-in-out filter, 0.5s ease-in-out transform;
 }
 
 .about__wrapper-is-hidden {

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -170,8 +170,12 @@ function getThemeForSiteGoals( siteGoals ) {
 function getSiteTypeForSiteGoals( siteGoals ) {
 	const siteGoalsValue = siteGoals.split( ',' );
 
-	if ( siteGoalsValue.indexOf( 'sell' ) !== -1 ) {
+	if ( siteGoals === 'sell' ) {
 		return 'store';
+	}
+
+	if ( siteGoalsValue.indexOf( 'sell' ) !== -1 ) {
+		return 'page';
 	}
 
 	if ( siteGoalsValue.indexOf( 'promote' ) !== -1 ) {

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -170,6 +170,7 @@ function getThemeForSiteGoals( siteGoals ) {
 function getSiteTypeForSiteGoals( siteGoals ) {
 	const siteGoalsValue = siteGoals.split( ',' );
 
+	//Identify stores for the store signup flow
 	if ( siteGoals === 'sell' ) {
 		return 'store';
 	}


### PR DESCRIPTION
We recently tested a new site segmenting step that returned really positive results. We've implemented the new screen to 100% of english visitors while we get all the strings translated. With this new step, we no longer have the design-type step and as a result, we don't have any people going through our new store signup flow. 

This PR adds the ability for people to go through the new store signup flow if they pick "Sell products or collect payments", and only "Sell products or collect payments", from under "What’s the primary goal you have for your site?". 

## Screencap
![store-flow](https://user-images.githubusercontent.com/6981253/34059250-326983a0-e1ac-11e7-9cfa-66943892e607.gif)

## Testing store
* Visit `/start`
* **Only** select "Sell products or collect payments" from under "What’s the primary goal you have for your site?". 
* Next you should see a couple themes, pick one and complete signup
* Your should now have a store

## Testing non-store
* Visit `/start`
* Pick "Sell products or collect payments" plus another option from under "What’s the primary goal you have for your site?".
* Next step should be domain, pick a domain and complete signup
* You should now have a regular site

@lamosty @jsnajdr @apeatling @kellychoffman 