### PR TITLE
Plans: Update storage limit for Business plan

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -94,7 +94,11 @@ class ProductPurchaseFeaturesList extends Component {
 			<GoogleAnalyticsStats selectedSite={ selectedSite } key="googleAnalyticsStatsFeature" />,
 			<AdvertisingRemoved isBusinessPlan key="advertisingRemovedFeature" />,
 			<CustomizeTheme selectedSite={ selectedSite } key="customizeThemeFeature" />,
-			<VideoAudioPosts selectedSite={ selectedSite } key="videoAudioPostsFeature" />,
+			<VideoAudioPosts
+				selectedSite={ selectedSite }
+				key="videoAudioPostsFeature"
+				plan={ PLAN_BUSINESS }
+			/>,
 			<FindNewTheme selectedSite={ selectedSite } key="findNewThemeFeature" />,
 		];
 	}
@@ -111,7 +115,11 @@ class ProductPurchaseFeaturesList extends Component {
 			<AdvertisingRemoved isBusinessPlan={ false } key="advertisingRemovedFeature" />,
 			<GoogleVouchers selectedSite={ selectedSite } key="googleVouchersFeature" />,
 			<CustomizeTheme selectedSite={ selectedSite } key="customizeThemeFeature" />,
-			<VideoAudioPosts selectedSite={ selectedSite } key="videoAudioPostsFeature" />,
+			<VideoAudioPosts
+				selectedSite={ selectedSite }
+				key="videoAudioPostsFeature"
+				plan={ PLAN_PREMIUM }
+			/>,
 			isWordadsInstantActivationEligible( selectedSite ) ? (
 				<MonetizeSite selectedSite={ selectedSite } key="monetizeSiteFeature" />
 			) : null,

--- a/client/blocks/product-purchase-features/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/video-audio-posts.jsx
@@ -10,17 +10,34 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 import { newPost } from 'lib/paths';
+import { PLAN_BUSINESS, PLAN_PREMIUM } from 'lib/plans/constants';
 
-export default localize( ( { selectedSite, translate } ) => {
+export default localize( ( { selectedSite, plan, translate } ) => {
+	let featureDescription;
+
+	switch ( plan ) {
+		case PLAN_BUSINESS:
+			featureDescription = translate(
+				'Enrich your posts and pages with video or audio. Upload as much media as you want, ' +
+					'directly to your site — the Business Plan has unlimited storage.'
+			);
+			break;
+		case PLAN_PREMIUM:
+			featureDescription = translate(
+				'Enrich your posts and pages with video or audio. Upload up to 10GB of media directly to your site.'
+			);
+			break;
+		default:
+			featureDescription = '';
+			break;
+	}
+
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img src="/calypso/images/upgrades/media-post.svg" /> }
 				title={ translate( 'Video and audio posts' ) }
-				description={ translate(
-					'Enrich your posts with video and audio, uploaded directly on your site. ' +
-						'No ads or limits. The Premium plan also adds 10GB of file storage.'
-				) }
+				description={ featureDescription }
 				buttonText={ translate( 'Start a new post' ) }
 				href={ newPost( selectedSite ) }
 			/>


### PR DESCRIPTION
Currently, the storage features at `plans/my-plan/site` are a bit confusing for Business customers. If you have the Business plan, you actually have unlimited storage, but the plan features page reads the Premium description ('The Premium plan also adds 10GB of file storage.'). This updates the features page to reflect the unlimited storage and modify the wording depending on the plan.

### To test
1. Load up this branch on an account that has at least a Business plan and Premium plan.
2. For each site, visit http://calypso.localhost:3000/plans/my-plan/. You should notice the correct storage limit (unlimited for Business, 10GB for Premium, nonexistent for Personal) under the "Video and audio posts" header.

### Screenshots

**Business**

<img width="482" alt="screen shot 2017-12-15 at 1 59 34 pm" src="https://user-images.githubusercontent.com/7240478/34060452-12ffc854-e1a1-11e7-965f-c7ebd33c522a.png">

**Premium**

<img width="474" alt="screen shot 2017-12-15 at 1 59 19 pm" src="https://user-images.githubusercontent.com/7240478/34060460-1c6dd94e-e1a1-11e7-9716-e21407abde82.png">

The Video and audio feature block won't appear for Personal plan sites or Jetpack plans.

Fixes: #20759