### PR TITLE
Fix incorrect redirect of /sharing/jetpack.site to /stats

### DIFF
--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -18,8 +18,13 @@ import Sharing from './main';
 import SharingButtons from './buttons/buttons';
 import SharingConnections from './connections/connections';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { canCurrentUser, isJetpackModuleActive } from 'state/selectors';
-import { isJetpackSite, getSiteSlug, getSiteOption } from 'state/sites/selectors';
+import { canCurrentUser } from 'state/selectors';
+import {
+	isJetpackSite,
+	isJetpackModuleActive,
+	getSiteSlug,
+	getSiteOption,
+} from 'state/sites/selectors';
 import versionCompare from 'lib/version-compare';
 
 const analyticsPageTitle = 'Sharing';


### PR DESCRIPTION
Fixes #20710 which is a regression introduced by #20192. The original `sites-list`
code used method `JetpackSite.prototype.isModuleActive`. This methods looks at the
`options.active_modules` property of the site object.

In Redux, the situation with the analogous selector `isJetpackModuleActive`. There
are actually two selectors with this name! One is in `state/sites/selectors`, which
is the right one we want to use, because it corresponds to the `JetpackSite` method.

The other one, which we used in #20192, lives in `state/selectors` and it looks at
data in `state.jetpack.modules`. These data are not loaded at the time when the
`page.js` handlers are executed. They need to be queried by `QueryJetpackModules`
first. On the other hand, the `siteSelection` handler makes sure that `state.sites.items`
data are loaded before it sets the selected site ID.

This patch changes the `isJetpackModuleActive` import to the right module.

Thanks @lamosty for helping debug the issue! :+1: