### PR TITLE
Update Comment Counts

### DIFF
--- a/client/state/comments/middleware.js
+++ b/client/state/comments/middleware.js
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { COMMENTS_CHANGE_STATUS } from 'state/action-types';
+import { getSiteComment } from 'state/selectors';
+
+const handler = ( dispatch, action, getState ) => {
+	switch ( action.type ) {
+		case COMMENTS_CHANGE_STATUS:
+			const siteComment = getSiteComment( getState(), action.siteId, action.commentId );
+			const previousStatus = siteComment && siteComment.status;
+			return {
+				...action,
+				meta: Object.assign( {}, action.meta, { comment: { previousStatus } } ),
+			};
+		default:
+			return action;
+	}
+};
+
+export const commentsMiddleware = ( { dispatch, getState } ) => next => action => {
+	return next( handler( dispatch, action, getState ) );
+};
+
+export default commentsMiddleware;

--- a/client/state/comments/middleware.js
+++ b/client/state/comments/middleware.js
@@ -3,12 +3,13 @@
 /**
  * Internal dependencies
  */
-import { COMMENTS_CHANGE_STATUS } from 'state/action-types';
+import { COMMENTS_DELETE, COMMENTS_CHANGE_STATUS } from 'state/action-types';
 import { getSiteComment } from 'state/selectors';
 
 const handler = ( dispatch, action, getState ) => {
 	switch ( action.type ) {
 		case COMMENTS_CHANGE_STATUS:
+		case COMMENTS_DELETE:
 			const siteComment = getSiteComment( getState(), action.siteId, action.commentId );
 			const previousStatus = siteComment && siteComment.status;
 			return {

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -399,9 +399,9 @@ export const counts = createReducer(
 			return Object.assign( {}, state, siteCounts );
 		},
 		[ COMMENTS_CHANGE_STATUS ]: ( state, action ) => {
-			const { siteId, postId, status } = action;
+			const { siteId, postId = -1, status } = action;
 			const previousStatus = get( action, 'meta.comment.previousStatus' );
-			if ( ! siteId || ! postId || ! status || ! state[ siteId ] || ! previousStatus ) {
+			if ( ! siteId || ! status || ! state[ siteId ] || ! previousStatus ) {
 				return state;
 			}
 
@@ -420,13 +420,13 @@ export const counts = createReducer(
 			return Object.assign( {}, state, { [ siteId ]: newTotalSiteCounts } );
 		},
 		[ COMMENTS_DELETE ]: ( state, action ) => {
-			const { siteId, postId, commentId } = action;
+			const { siteId, postId = -1, commentId } = action;
 			if ( commentId && startsWith( commentId, 'placeholder' ) ) {
 				return state;
 			}
 			const previousStatus = get( action, 'meta.comment.previousStatus' );
 
-			if ( ! siteId || ! postId || ! state[ siteId ] || ! previousStatus ) {
+			if ( ! siteId || ! state[ siteId ] || ! previousStatus ) {
 				return state;
 			}
 			const { site: siteCounts, [ postId ]: postCounts } = state[ siteId ];
@@ -446,8 +446,8 @@ export const counts = createReducer(
 			if ( get( action, 'meta.comment.context' ) !== 'add' ) {
 				return state;
 			}
-			const { siteId, postId } = action;
-			if ( ! siteId || ! postId || ! state[ siteId ] ) {
+			const { siteId, postId = -1 } = action;
+			if ( ! siteId || ! state[ siteId ] ) {
 				return state;
 			}
 			const { site: siteCounts, [ postId ]: postCounts } = state[ siteId ];

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -408,8 +408,28 @@ export const counts = createReducer(
 
 			//increase new status counts by one and decrement previous status counts by 1
 			const newSiteCounts = updateCount( updateCount( siteCounts, status, 1 ), previousStatus, -1 );
-
 			const newPostCounts = updateCount( updateCount( postCounts, status, 1 ), previousStatus, -1 );
+
+			const newTotalSiteCounts = Object.assign(
+				{},
+				state[ siteId ],
+				newSiteCounts && { site: newSiteCounts },
+				newPostCounts && { [ postId ]: newPostCounts }
+			);
+			return Object.assign( {}, state, { [ siteId ]: newTotalSiteCounts } );
+		},
+		[ COMMENTS_DELETE ]: ( state, { siteId, postId, commentId } ) => {
+			if ( commentId && commentId.indexOf( 'placeholder' ) === 0 ) {
+				return state;
+			}
+
+			if ( ! siteId || ! postId || ! state[ siteId ] ) {
+				return state;
+			}
+			const { site: siteCounts, [ postId ]: postCounts } = state[ siteId ];
+
+			const newSiteCounts = updateCount( siteCounts, 'trash', -1 );
+			const newPostCounts = updateCount( postCounts, 'trash', -1 );
 
 			const newTotalSiteCounts = Object.assign(
 				{},

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -17,6 +17,7 @@ import {
 	values,
 	omit,
 	startsWith,
+	isInteger,
 } from 'lodash';
 
 /**
@@ -367,7 +368,7 @@ export const activeReplies = createReducer(
 
 function updateCount( counts, rawStatus, value = 1 ) {
 	const status = rawStatus === 'unapproved' ? 'pending' : rawStatus;
-	if ( ! counts || ! counts[ status ] ) {
+	if ( ! counts || ! isInteger( counts[ status ] ) ) {
 		return undefined;
 	}
 	const newCounts = {

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -419,18 +419,20 @@ export const counts = createReducer(
 			);
 			return Object.assign( {}, state, { [ siteId ]: newTotalSiteCounts } );
 		},
-		[ COMMENTS_DELETE ]: ( state, { siteId, postId, commentId } ) => {
+		[ COMMENTS_DELETE ]: ( state, action ) => {
+			const { siteId, postId, commentId } = action;
 			if ( commentId && startsWith( commentId, 'placeholder' ) ) {
 				return state;
 			}
+			const previousStatus = get( action, 'meta.comment.previousStatus' );
 
-			if ( ! siteId || ! postId || ! state[ siteId ] ) {
+			if ( ! siteId || ! postId || ! state[ siteId ] || ! previousStatus ) {
 				return state;
 			}
 			const { site: siteCounts, [ postId ]: postCounts } = state[ siteId ];
 
-			const newSiteCounts = updateCount( siteCounts, 'trash', -1 );
-			const newPostCounts = updateCount( postCounts, 'trash', -1 );
+			const newSiteCounts = updateCount( siteCounts, previousStatus, -1 );
+			const newPostCounts = updateCount( postCounts, previousStatus, -1 );
 
 			const newTotalSiteCounts = Object.assign(
 				{},

--- a/client/state/comments/test/reducer.js
+++ b/client/state/comments/test/reducer.js
@@ -19,6 +19,7 @@ import {
 	COMMENTS_DELETE,
 	COMMENTS_TREE_SITE_ADD,
 	COMMENTS_EDIT,
+	COMMENTS_CHANGE_STATUS,
 } from '../../action-types';
 import { expandComments, setActiveReply } from '../actions';
 import { PLACEHOLDER_STATE } from '../constants';
@@ -626,6 +627,228 @@ describe( 'reducer', () => {
 						spam: 5,
 						totalComments: 6,
 						trash: 7,
+					},
+				},
+			} );
+		} );
+
+		test( 'updates counts when a comment status changes', () => {
+			const action = {
+				type: COMMENTS_CHANGE_STATUS,
+				siteId: 2916284,
+				postId: 234,
+				status: 'unapproved',
+				meta: { comment: { previousStatus: 'approved' } },
+			};
+			const state = deepFreeze( {
+				2916284: {
+					site: {
+						all: 11,
+						approved: 5,
+						pending: 6,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 12,
+						trash: 0,
+					},
+					234: {
+						all: 5,
+						approved: 2,
+						pending: 3,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 6,
+						trash: 0,
+					},
+				},
+			} );
+			const nextState = counts( state, action );
+			expect( nextState ).toEqual( {
+				2916284: {
+					site: {
+						all: 11,
+						approved: 4,
+						pending: 7,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 12,
+						trash: 0,
+					},
+					234: {
+						all: 5,
+						approved: 1,
+						pending: 4,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 6,
+						trash: 0,
+					},
+				},
+			} );
+		} );
+		test( 'can update counts when only site counts are loaded', () => {
+			const action = {
+				type: COMMENTS_CHANGE_STATUS,
+				siteId: 2916284,
+				postId: 234,
+				status: 'unapproved',
+				meta: { comment: { previousStatus: 'approved' } },
+			};
+			const state = deepFreeze( {
+				2916284: {
+					site: {
+						all: 11,
+						approved: 5,
+						pending: 6,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 12,
+						trash: 0,
+					},
+				},
+				77203074: {
+					site: {
+						all: 11,
+						approved: 5,
+						pending: 6,
+						postTrashed: 0,
+						spam: 0,
+						totalComments: 11,
+						trash: 0,
+					},
+				},
+			} );
+			const nextState = counts( state, action );
+			expect( nextState ).toEqual( {
+				2916284: {
+					site: {
+						all: 11,
+						approved: 4,
+						pending: 7,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 12,
+						trash: 0,
+					},
+				},
+				77203074: {
+					site: {
+						all: 11,
+						approved: 5,
+						pending: 6,
+						postTrashed: 0,
+						spam: 0,
+						totalComments: 11,
+						trash: 0,
+					},
+				},
+			} );
+		} );
+
+		test( 'updates counts when a comment is deleted', () => {
+			const action = {
+				type: COMMENTS_DELETE,
+				siteId: 2916284,
+				postId: 234,
+				commentId: 2,
+			};
+			const state = deepFreeze( {
+				2916284: {
+					site: {
+						all: 11,
+						approved: 5,
+						pending: 6,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 12,
+						trash: 10,
+					},
+					234: {
+						all: 5,
+						approved: 2,
+						pending: 3,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 6,
+						trash: 4,
+					},
+				},
+			} );
+			const nextState = counts( state, action );
+			expect( nextState ).toEqual( {
+				2916284: {
+					site: {
+						all: 11,
+						approved: 5,
+						pending: 6,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 12,
+						trash: 9,
+					},
+					234: {
+						all: 5,
+						approved: 2,
+						pending: 3,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 6,
+						trash: 3,
+					},
+				},
+			} );
+		} );
+
+		test( 'updates counts when a new comment is added', () => {
+			const action = {
+				type: COMMENTS_RECEIVE,
+				siteId: 2916284,
+				postId: 234,
+				comments: [ { status: 'approved' } ],
+				meta: { comment: { context: 'add' } },
+			};
+			const state = deepFreeze( {
+				2916284: {
+					site: {
+						all: 11,
+						approved: 5,
+						pending: 6,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 12,
+						trash: 10,
+					},
+					234: {
+						all: 5,
+						approved: 2,
+						pending: 3,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 6,
+						trash: 4,
+					},
+				},
+			} );
+			const nextState = counts( state, action );
+			expect( nextState ).toEqual( {
+				2916284: {
+					site: {
+						all: 12,
+						approved: 6,
+						pending: 6,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 13,
+						trash: 10,
+					},
+					234: {
+						all: 6,
+						approved: 3,
+						pending: 3,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 7,
+						trash: 4,
 					},
 				},
 			} );

--- a/client/state/comments/test/reducer.js
+++ b/client/state/comments/test/reducer.js
@@ -690,7 +690,6 @@ describe( 'reducer', () => {
 			const action = {
 				type: COMMENTS_CHANGE_STATUS,
 				siteId: 2916284,
-				postId: 234,
 				status: 'unapproved',
 				meta: { comment: { previousStatus: 'approved' } },
 			};

--- a/client/state/comments/test/reducer.js
+++ b/client/state/comments/test/reducer.js
@@ -751,6 +751,7 @@ describe( 'reducer', () => {
 				siteId: 2916284,
 				postId: 234,
 				commentId: 2,
+				meta: { comment: { previousStatus: 'trash' } },
 			};
 			const state = deepFreeze( {
 				2916284: {
@@ -794,6 +795,61 @@ describe( 'reducer', () => {
 						spam: 1,
 						totalComments: 6,
 						trash: 3,
+					},
+				},
+			} );
+		} );
+
+		test( 'updates counts when a comment is deleted from spam', () => {
+			const action = {
+				type: COMMENTS_DELETE,
+				siteId: 2916284,
+				postId: 234,
+				commentId: 2,
+				meta: { comment: { previousStatus: 'spam' } },
+			};
+			const state = deepFreeze( {
+				2916284: {
+					site: {
+						all: 11,
+						approved: 5,
+						pending: 6,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 12,
+						trash: 10,
+					},
+					234: {
+						all: 5,
+						approved: 2,
+						pending: 3,
+						postTrashed: 0,
+						spam: 1,
+						totalComments: 6,
+						trash: 4,
+					},
+				},
+			} );
+			const nextState = counts( state, action );
+			expect( nextState ).toEqual( {
+				2916284: {
+					site: {
+						all: 11,
+						approved: 5,
+						pending: 6,
+						postTrashed: 0,
+						spam: 0,
+						totalComments: 11,
+						trash: 10,
+					},
+					234: {
+						all: 5,
+						approved: 2,
+						pending: 3,
+						postTrashed: 0,
+						spam: 0,
+						totalComments: 5,
+						trash: 4,
 					},
 				},
 			} );

--- a/client/state/comments/test/reducer.js
+++ b/client/state/comments/test/reducer.js
@@ -637,8 +637,8 @@ describe( 'reducer', () => {
 				type: COMMENTS_CHANGE_STATUS,
 				siteId: 2916284,
 				postId: 234,
-				status: 'unapproved',
-				meta: { comment: { previousStatus: 'approved' } },
+				status: 'trash',
+				meta: { comment: { previousStatus: 'unapproved' } },
 			};
 			const state = deepFreeze( {
 				2916284: {
@@ -666,22 +666,22 @@ describe( 'reducer', () => {
 			expect( nextState ).toEqual( {
 				2916284: {
 					site: {
-						all: 11,
-						approved: 4,
-						pending: 7,
+						all: 10,
+						approved: 5,
+						pending: 5,
 						postTrashed: 0,
 						spam: 1,
-						totalComments: 12,
-						trash: 0,
+						totalComments: 11,
+						trash: 1,
 					},
 					234: {
-						all: 5,
-						approved: 1,
-						pending: 4,
+						all: 4,
+						approved: 2,
+						pending: 2,
 						postTrashed: 0,
 						spam: 1,
-						totalComments: 6,
-						trash: 0,
+						totalComments: 5,
+						trash: 1,
 					},
 				},
 			} );

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -248,6 +248,11 @@ export const announceDeleteFailure = ( { dispatch }, action ) => {
 			postId,
 			comments: [ comment ],
 			skipSort: !! get( comment, 'parent.ID' ),
+			meta: {
+				comment: {
+					context: 'add', //adds a hint for the counts reducer.
+				},
+			},
 		} );
 	}
 };

--- a/client/state/data-layer/wpcom/sites/test/utils.js
+++ b/client/state/data-layer/wpcom/sites/test/utils.js
@@ -130,6 +130,7 @@ describe( 'utility functions', () => {
 				postId: 1010,
 				comments: [ { ID: 1, content: 'this is the content' } ],
 				skipSort: false,
+				meta: { comment: { context: 'add' } },
 			} );
 		} );
 

--- a/client/state/data-layer/wpcom/sites/utils.js
+++ b/client/state/data-layer/wpcom/sites/utils.js
@@ -103,6 +103,11 @@ export const updatePlaceholderComment = (
 		postId,
 		comments: [ comment ],
 		skipSort: !! parentCommentId,
+		meta: {
+			comment: {
+				context: 'add', //adds a hint for the counts reducer.
+			},
+		},
 	} );
 	// increment comments count
 	dispatch( { type: COMMENTS_COUNT_INCREMENT, siteId, postId } );

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -199,6 +199,7 @@ export function createReduxStore( initialState = {} ) {
 			require( './routing/middleware.js' ).default,
 		isAudioSupported && require( './audio/middleware.js' ).default,
 		navigationMiddleware,
+		isBrowser && require( './comments/middleware.js' ).default,
 	].filter( Boolean );
 
 	const enhancers = [


### PR DESCRIPTION
This PR updates comments counts when we change a comment status, delete a comment, or add new comments. Display of the comment counts are used for testing purposes and will be dropped before this merges.

![screen shot 2017-12-15 at 4 35 56 pm](https://user-images.githubusercontent.com/1270189/34065376-0c7187ce-e1b6-11e7-97e2-095bb3a9fafd.png)

### Testing Instructions
- Checkout this branch
- Navigate to /comments
- Select a site
- Counts update correctly when adding a new reply
- Counts update correctly when updating comment status. (eg spam trash etc)
- Counts update correctly when emptying trash
- Going into a post specific view, counts update normally too
  
  
  