### PR TITLE
Store: Update PriceInput component so that users can reset the value to an `initialValue`

### DIFF
--- a/client/components/forms/form-currency-input/index.jsx
+++ b/client/components/forms/form-currency-input/index.jsx
@@ -84,8 +84,8 @@ const CurrencyShape = PropTypes.shape( {
 } );
 
 FormCurrencyInput.propTypes = {
-	currencySymbolPrefix: PropTypes.string,
-	currencySymbolSuffix: PropTypes.string,
+	currencySymbolPrefix: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
+	currencySymbolSuffix: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
 	onCurrencyChange: PropTypes.func,
 	currencyList: PropTypes.arrayOf( CurrencyShape ),
 };

--- a/client/components/forms/form-currency-input/style.scss
+++ b/client/components/forms/form-currency-input/style.scss
@@ -18,15 +18,6 @@
 	&:hover .form-currency-input__select-icon {
 		color: darken( $gray, 20% );
 	}
-
-	.button {
-		margin: -8px -14px;
-		padding: 8px 14px;
-
-		.gridicon {
-			margin: 0;
-		}
-	}
 }
 
 .form-currency-input__select {

--- a/client/components/forms/form-currency-input/style.scss
+++ b/client/components/forms/form-currency-input/style.scss
@@ -24,7 +24,7 @@
 		padding: 8px 14px;
 
 		.gridicon {
-			margin-top: 0;
+			margin: 0;
 		}
 	}
 }

--- a/client/components/forms/form-currency-input/style.scss
+++ b/client/components/forms/form-currency-input/style.scss
@@ -18,6 +18,15 @@
 	&:hover .form-currency-input__select-icon {
 		color: darken( $gray, 20% );
 	}
+
+	.button {
+		margin: -8px -14px;
+		padding: 8px 14px;
+
+		.gridicon {
+			margin-top: 0;
+		}
+	}
 }
 
 .form-currency-input__select {

--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -57,7 +57,7 @@ class OrderTotalRow extends Component {
 						currency={ currency }
 						onBlur={ onBlur }
 						onChange={ onChange }
-						max={ initialValue }
+						initialValue={ initialValue }
 						value={ total }
 					/>
 				</TableItem>

--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -38,7 +38,7 @@ class OrderTotalRow extends Component {
 	};
 
 	renderEditable = () => {
-		const { className, currency, label, onBlur, onChange, value } = this.props;
+		const { className, currency, initialValue, label, onBlur, onChange, value } = this.props;
 		let name = this.props.name;
 		if ( ! name ) {
 			name = snakeCase( label );
@@ -57,6 +57,7 @@ class OrderTotalRow extends Component {
 						currency={ currency }
 						onBlur={ onBlur }
 						onChange={ onChange }
+						max={ initialValue }
 						value={ total }
 					/>
 				</TableItem>

--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -43,7 +43,7 @@ class OrderTotalRow extends Component {
 		if ( ! name ) {
 			name = snakeCase( label );
 		}
-		const total = isNaN( parseFloat( value ) ) ? 0 : value;
+		const total = '' !== value && isNaN( parseFloat( value ) ) ? 0 : value;
 
 		const classes = classnames( className, 'order-details__total order-details__total-edit' );
 		return (

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -104,21 +104,6 @@
 	.order-details__totals-value.table-item {
 		padding-right: 24px;
 		width: 10em;
-
-		.price-input {
-			.form-text-input-with-affixes {
-				.form-text-input {
-					padding-right: 14px;
-					border-right-width: 0;
-					z-index: 9;
-
-					&:focus {
-						border-right-color: $blue-wordpress;
-						border-right-width: 1px;
-					}
-				}
-			}
-		}
 	}
 
 	&.has-taxes {

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -104,6 +104,21 @@
 	.order-details__totals-value.table-item {
 		padding-right: 24px;
 		width: 10em;
+
+		.price-input {
+			.form-text-input-with-affixes {
+				.form-text-input {
+					padding-right: 14px;
+					border-right-width: 0;
+					z-index: 9;
+
+					&:focus {
+						border-right-color: $blue-wordpress;
+						border-right-width: 1px;
+					}
+				}
+			}
+		}
 	}
 
 	&.has-taxes {

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -125,6 +125,15 @@
 	}
 
 	&.is-editing {
+		.order-details__totals-value {
+			// Increase width for PriceInput
+			width: 13em;
+		}
+
+		.form-text-input-with-affixes {
+			max-width: 13em;
+		}
+
 		.order-details__totals-tax {
 			color: $gray-text-min;
 			font-style: italic;

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -297,6 +297,7 @@ class OrderDetailsTable extends Component {
 		}
 
 		const showTax = this.shouldShowTax();
+		const initialShippingValue = getCurrencyFormatDecimal( order.shipping_total, order.currency );
 		const refundValue = getOrderRefundTotal( order );
 		const totalTaxValue = getOrderTotalTax( order );
 		const totalValue = isEditing ? getOrderTotal( order ) + totalTaxValue : order.total;
@@ -333,7 +334,7 @@ class OrderDetailsTable extends Component {
 					<OrderTotalRow
 						currency={ order.currency }
 						label={ translate( 'Shipping' ) }
-						initialValue={ order.shipping_total }
+						initialValue={ initialShippingValue }
 						value={ getOrderShippingTotal( order ) }
 						taxValue={ getOrderShippingTax( order ) }
 						showTax={ showTax }

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -333,6 +333,7 @@ class OrderDetailsTable extends Component {
 					<OrderTotalRow
 						currency={ order.currency }
 						label={ translate( 'Shipping' ) }
+						initialValue={ order.shipping_total }
 						value={ getOrderShippingTotal( order ) }
 						taxValue={ getOrderShippingTax( order ) }
 						showTax={ showTax }

--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -26,7 +26,7 @@
 
 	.form-text-input-with-affixes,
 	.form-text-input-with-suffixes {
-		width: 155px;
+		width: 13em;
 	}
 
 	.order-payment__item-total {

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -266,6 +266,10 @@ class OrderRefundTable extends Component {
 			'has-refund': !! refundValue,
 			'is-refund-modal': true,
 		} );
+		const initialShippingValue = getCurrencyFormatDecimal(
+			parseFloat( order.shipping_total ) + getOrderShippingTax( order ),
+			order.currency
+		);
 
 		return (
 			<div>
@@ -289,7 +293,7 @@ class OrderRefundTable extends Component {
 						isEditable
 						currency={ order.currency }
 						label={ translate( 'Shipping' ) }
-						initialValue={ order.shipping_total }
+						initialValue={ initialShippingValue }
 						value={ this.state.shippingTotal }
 						name="shipping_total"
 						onChange={ this.onChange( 'shipping_total' ) }

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -21,7 +21,7 @@ import {
 	getOrderShippingTax,
 	getOrderTotalTax,
 } from 'woocommerce/lib/order-values';
-import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
+import { getOrderFeeCost, getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
 import OrderTotalRow from '../order-details/row-total';
 import PriceInput from 'woocommerce/components/price-input';
 import ScreenReaderText from 'components/screen-reader-text';
@@ -190,6 +190,7 @@ class OrderRefundTable extends Component {
 		const { order, translate } = this.props;
 		const value = this.state.fees[ i ];
 		const inputId = `fee_line-${ item.id }`;
+		const initialValue = getOrderFeeCost( order, item.id ) + getOrderFeeTax( order, item.id );
 		return (
 			<TableRow key={ i } className="order-payment__items order-details__items">
 				<TableItem
@@ -211,7 +212,7 @@ class OrderRefundTable extends Component {
 					<PriceInput
 						id={ inputId }
 						currency={ order.currency }
-						max={ get( order, `fee_lines[${ i }].total` ) }
+						max={ getCurrencyFormatDecimal( initialValue, order.currency ) }
 						value={ value }
 						onChange={ this.onChange( 'fee', i ) }
 						onBlur={ this.formatInput( `fees[${ i }]` ) }

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -211,6 +211,7 @@ class OrderRefundTable extends Component {
 					<PriceInput
 						id={ inputId }
 						currency={ order.currency }
+						max={ get( order, `fee_lines[${ i }].total` ) }
 						value={ value }
 						onChange={ this.onChange( 'fee', i ) }
 						onBlur={ this.formatInput( `fees[${ i }]` ) }
@@ -287,6 +288,7 @@ class OrderRefundTable extends Component {
 						isEditable
 						currency={ order.currency }
 						label={ translate( 'Shipping' ) }
+						initialValue={ order.shipping_total }
 						value={ this.state.shippingTotal }
 						name="shipping_total"
 						onChange={ this.onChange( 'shipping_total' ) }

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -95,6 +95,9 @@ class OrderRefundTable extends Component {
 	};
 
 	validateValue = value => {
+		if ( '' === value ) {
+			return value;
+		}
 		value = value.replace( /[^0-9,.-]/g, '' );
 		if ( ! isNaN( parseFloat( value ) ) && parseFloat( value ) >= 0 ) {
 			return value;

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -212,7 +212,7 @@ class OrderRefundTable extends Component {
 					<PriceInput
 						id={ inputId }
 						currency={ order.currency }
-						max={ getCurrencyFormatDecimal( initialValue, order.currency ) }
+						initialValue={ getCurrencyFormatDecimal( initialValue, order.currency ) }
 						value={ value }
 						onChange={ this.onChange( 'fee', i ) }
 						onBlur={ this.formatInput( `fees[${ i }]` ) }

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 import { omit } from 'lodash';
 
 /**
@@ -58,36 +58,35 @@ class PriceInput extends Component {
 	};
 
 	render() {
-		const { currency, currencySetting, initialValue, siteId, value } = this.props;
-		const props = {
-			...omit( this.props, [
-				'currency',
-				'currencySetting',
-				'dispatch',
-				'initialValue',
-				'siteId',
-				'value',
-			] ),
-		};
+		const {
+			currency,
+			currencySetting,
+			initialValue,
+			siteId,
+			translate,
+			value,
+			...props
+		} = this.props;
+
 		const displayCurrency = ! currency && currencySetting ? currencySetting.value : currency;
 		const currencyObject = getCurrencyObject( value, displayCurrency );
 		let resetButton;
 		if ( initialValue ) {
 			resetButton = (
 				<Button onClick={ this.resetToInitial } compact borderless>
-					<Gridicon icon="undo" />
+					{ translate( 'Reset' ) }
 				</Button>
 			);
 		}
 		return (
-			<div>
+			<div className="price-input">
 				<QuerySettingsGeneral siteId={ siteId } />
 				{ currencyObject ? (
 					<FormCurrencyInput
 						currencySymbolPrefix={ currencyObject.symbol }
 						currencySymbolSuffix={ resetButton }
 						value={ this.state.value }
-						{ ...props }
+						{ ...omit( props, [ 'dispatch', 'moment', 'numberFormat' ] ) }
 					/>
 				) : (
 					<FormTextInput value={ this.state.value } { ...omit( props, [ 'noWrap', 'min' ] ) } />
@@ -106,4 +105,4 @@ function mapStateToProps( state ) {
 	};
 }
 
-export default connect( mapStateToProps )( PriceInput );
+export default connect( mapStateToProps )( localize( PriceInput ) );

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -6,6 +6,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
@@ -84,8 +85,10 @@ class PriceInput extends Component {
 				</Button>
 			);
 		}
+
+		const classes = classNames( 'price-input', { 'has-reset': !! initialValue } );
 		return (
-			<div className="price-input">
+			<div className={ classes }>
 				<QuerySettingsGeneral siteId={ siteId } />
 				{ currencyObject ? (
 					<FormCurrencyInput

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -6,12 +6,14 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { omit } from 'lodash';
 import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormTextInput from 'components/forms/form-text-input';
 import { getCurrencyObject } from 'lib/format-currency';
@@ -21,31 +23,74 @@ import QuerySettingsGeneral from 'woocommerce/components/query-settings-general'
 
 class PriceInput extends Component {
 	static propTypes = {
-		value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
 		currency: PropTypes.string,
 		currencySetting: PropTypes.shape( {
 			value: PropTypes.string,
 		} ),
+		max: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
+		name: PropTypes.string,
+		value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			value: props.value,
+		};
+	}
+
+	componentWillReceiveProps( { value } ) {
+		this.setState( { value } );
+	}
+
+	resetToMax = () => {
+		const { max, name = '' } = this.props;
+		this.setState( { value: this.props.max }, () => {
+			// All uses of onChange expect and event object of this shape
+			this.props.onChange( {
+				target: {
+					name,
+					value: max,
+				},
+			} );
+		} );
 	};
 
 	render() {
-		const { siteId, value, currency, currencySetting } = this.props;
+		const { currency, currencySetting, max, siteId, value } = this.props;
 		const props = {
-			...omit( this.props, [ 'value', 'currency', 'currencySetting', 'siteId', 'dispatch' ] ),
+			...omit( this.props, [
+				'currency',
+				'currencySetting',
+				'dispatch',
+				'max',
+				'siteId',
+				'value',
+			] ),
 		};
 		const displayCurrency = ! currency && currencySetting ? currencySetting.value : currency;
 		const currencyObject = getCurrencyObject( value, displayCurrency );
+		let maxButton;
+		if ( max ) {
+			maxButton = (
+				<Button onClick={ this.resetToMax } compact borderless>
+					<Gridicon icon="undo" />
+				</Button>
+			);
+		}
 		return (
 			<div>
 				<QuerySettingsGeneral siteId={ siteId } />
 				{ currencyObject ? (
 					<FormCurrencyInput
 						currencySymbolPrefix={ currencyObject.symbol }
-						value={ value }
+						currencySymbolSuffix={ maxButton }
+						value={ this.state.value }
 						{ ...props }
 					/>
 				) : (
-					<FormTextInput value={ value } { ...omit( props, [ 'noWrap', 'min' ] ) } />
+					<FormTextInput value={ this.state.value } { ...omit( props, [ 'noWrap', 'min' ] ) } />
 				) }
 			</div>
 		);

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -27,7 +27,7 @@ class PriceInput extends Component {
 		currencySetting: PropTypes.shape( {
 			value: PropTypes.string,
 		} ),
-		max: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
+		initialValue: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
 		name: PropTypes.string,
 		value: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
 	};
@@ -44,37 +44,37 @@ class PriceInput extends Component {
 		this.setState( { value } );
 	}
 
-	resetToMax = () => {
-		const { max, name = '' } = this.props;
-		this.setState( { value: this.props.max }, () => {
+	resetToInitial = () => {
+		const { initialValue, name = '' } = this.props;
+		this.setState( { value: initialValue }, () => {
 			// All uses of onChange expect and event object of this shape
 			this.props.onChange( {
 				target: {
 					name,
-					value: max,
+					value: initialValue,
 				},
 			} );
 		} );
 	};
 
 	render() {
-		const { currency, currencySetting, max, siteId, value } = this.props;
+		const { currency, currencySetting, initialValue, siteId, value } = this.props;
 		const props = {
 			...omit( this.props, [
 				'currency',
 				'currencySetting',
 				'dispatch',
-				'max',
+				'initialValue',
 				'siteId',
 				'value',
 			] ),
 		};
 		const displayCurrency = ! currency && currencySetting ? currencySetting.value : currency;
 		const currencyObject = getCurrencyObject( value, displayCurrency );
-		let maxButton;
-		if ( max ) {
-			maxButton = (
-				<Button onClick={ this.resetToMax } compact borderless>
+		let resetButton;
+		if ( initialValue ) {
+			resetButton = (
+				<Button onClick={ this.resetToInitial } compact borderless>
 					<Gridicon icon="undo" />
 				</Button>
 			);
@@ -85,7 +85,7 @@ class PriceInput extends Component {
 				{ currencyObject ? (
 					<FormCurrencyInput
 						currencySymbolPrefix={ currencyObject.symbol }
-						currencySymbolSuffix={ maxButton }
+						currencySymbolSuffix={ resetButton }
 						value={ this.state.value }
 						{ ...props }
 					/>

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -51,7 +51,7 @@ class PriceInput extends Component {
 			this.props.onChange( {
 				target: {
 					name,
-					value: initialValue,
+					value: initialValue.toString(),
 				},
 			} );
 		} );

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -7,6 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { omit } from 'lodash';
 
@@ -47,7 +48,7 @@ class PriceInput extends Component {
 	resetToInitial = () => {
 		const { initialValue, name = '' } = this.props;
 		this.setState( { value: initialValue }, () => {
-			// All uses of onChange expect and event object of this shape
+			// All uses of onChange expect an event object of this shape
 			this.props.onChange( {
 				target: {
 					name,
@@ -73,8 +74,13 @@ class PriceInput extends Component {
 		let resetButton;
 		if ( initialValue ) {
 			resetButton = (
-				<Button onClick={ this.resetToInitial } compact borderless>
-					{ translate( 'Reset' ) }
+				<Button
+					onClick={ this.resetToInitial }
+					compact
+					borderless
+					aria-label={ translate( 'Reset to %(value)s', { args: { value: initialValue } } ) }
+				>
+					<Gridicon icon="refresh" />
 				</Button>
 			);
 		}

--- a/client/extensions/woocommerce/components/price-input/index.js
+++ b/client/extensions/woocommerce/components/price-input/index.js
@@ -74,16 +74,20 @@ class PriceInput extends Component {
 		const currencyObject = getCurrencyObject( value, displayCurrency );
 		let resetButton;
 		if ( initialValue ) {
-			resetButton = (
-				<Button
-					onClick={ this.resetToInitial }
-					compact
-					borderless
-					aria-label={ translate( 'Reset to %(value)s', { args: { value: initialValue } } ) }
-				>
-					<Gridicon icon="refresh" />
-				</Button>
-			);
+			if ( initialValue === this.state.value ) {
+				resetButton = <span />;
+			} else {
+				resetButton = (
+					<Button
+						onClick={ this.resetToInitial }
+						compact
+						borderless
+						aria-label={ translate( 'Reset to %(value)s', { args: { value: initialValue } } ) }
+					>
+						<Gridicon icon="refresh" />
+					</Button>
+				);
+			}
 		}
 
 		const classes = classNames( 'price-input', { 'has-reset': !! initialValue } );

--- a/client/extensions/woocommerce/components/price-input/style.scss
+++ b/client/extensions/woocommerce/components/price-input/style.scss
@@ -1,5 +1,21 @@
 .price-input {
+	.form-text-input-with-affixes{
+		.form-text-input {
+			padding-right: 0;
+			border-right: none;
+		}
+	}
+
 	.form-text-input-with-affixes__suffix {
 		background: transparent;
+
+		.button {
+			margin: -8px -14px;
+			padding: 8px 14px;
+		}
+
+		.gridicon {
+			margin: 0;
+		}
 	}
 }

--- a/client/extensions/woocommerce/components/price-input/style.scss
+++ b/client/extensions/woocommerce/components/price-input/style.scss
@@ -8,10 +8,22 @@
 
 	.form-text-input-with-affixes__suffix {
 		background: transparent;
+		position: relative;
+		min-width: 12px;
 
 		.button {
-			margin: -8px -14px;
-			padding: 8px 14px;
+			position: absolute;
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			padding: 0;
+			width: 100%;
+
+			.gridicon {
+				top: 0;
+				margin: 0 auto;
+			}
 		}
 
 		.gridicon {

--- a/client/extensions/woocommerce/components/price-input/style.scss
+++ b/client/extensions/woocommerce/components/price-input/style.scss
@@ -1,0 +1,5 @@
+.price-input {
+	.form-text-input-with-affixes__suffix {
+		background: transparent;
+	}
+}

--- a/client/extensions/woocommerce/components/price-input/style.scss
+++ b/client/extensions/woocommerce/components/price-input/style.scss
@@ -1,4 +1,16 @@
 .price-input {
+
+	&.has-reset .form-text-input {
+		padding-right: 14px;
+		border-right-width: 0;
+		z-index: 9;
+
+		&:focus {
+			border-right-color: $blue-wordpress;
+			border-right-width: 1px;
+		}
+	}
+
 	.form-text-input-with-affixes__suffix {
 		background: transparent;
 		position: relative;

--- a/client/extensions/woocommerce/components/price-input/style.scss
+++ b/client/extensions/woocommerce/components/price-input/style.scss
@@ -1,11 +1,4 @@
 .price-input {
-	.form-text-input-with-affixes{
-		.form-text-input {
-			padding-right: 0;
-			border-right: none;
-		}
-	}
-
 	.form-text-input-with-affixes__suffix {
 		background: transparent;
 		position: relative;

--- a/client/extensions/woocommerce/lib/order-values/test/totals.js
+++ b/client/extensions/woocommerce/lib/order-values/test/totals.js
@@ -10,6 +10,7 @@ import { expect } from 'chai';
  */
 import {
 	getOrderDiscountTotal,
+	getOrderFeeCost,
 	getOrderFeeTotal,
 	getOrderItemCost,
 	getOrderRefundTotal,
@@ -40,21 +41,46 @@ describe( 'getOrderDiscountTotal', () => {
 	} );
 } );
 
+describe( 'getOrderFeeCost', () => {
+	test( 'should be a function', () => {
+		expect( getOrderFeeCost ).to.be.a( 'function' );
+	} );
+
+	test( 'should get the correct fee value', () => {
+		expect( getOrderFeeCost( orderWithTax, 48 ) ).to.eql( 1.53 );
+	} );
+
+	test( 'should get the correct tax amount with multiple fees', () => {
+		expect( getOrderFeeCost( orderWithCoupons, 41 ) ).to.eql( 10 );
+	} );
+
+	test( "should return 0 if this fee doesn't exist", () => {
+		// orderWithRefunds has no fees
+		expect( getOrderFeeCost( orderWithoutTax, 3 ) ).to.eql( 0 );
+	} );
+
+	test( 'should return 0 if there are no fees', () => {
+		// orderWithRefunds has no fees
+		expect( getOrderFeeCost( orderWithRefunds, 2 ) ).to.eql( 0 );
+	} );
+} );
+
 describe( 'getOrderFeeTotal', () => {
 	test( 'should be a function', () => {
 		expect( getOrderFeeTotal ).to.be.a( 'function' );
 	} );
 
-	test( 'should get the correct tax amount', () => {
+	test( 'should get the correct fee total', () => {
 		expect( getOrderFeeTotal( orderWithTax ) ).to.eql( 1.53 );
 	} );
 
-	test( 'should get the correct tax amount with multiple fees', () => {
+	test( 'should get the correct fee total with multiple fees', () => {
 		expect( getOrderFeeTotal( orderWithCoupons ) ).to.eql( 15 );
 	} );
 
-	test( 'should return 0 if there is no tax', () => {
-		expect( getOrderFeeTotal( orderWithoutTax ) ).to.eql( 20 );
+	test( 'should return 0 if there are no fees', () => {
+		// orderWithRefunds has no fees
+		expect( getOrderFeeTotal( orderWithRefunds ) ).to.eql( 0 );
 	} );
 } );
 

--- a/client/extensions/woocommerce/lib/order-values/totals.js
+++ b/client/extensions/woocommerce/lib/order-values/totals.js
@@ -17,6 +17,21 @@ export function getOrderDiscountTotal( order ) {
 }
 
 /**
+ * Get the value for a single fee on a given order
+ *
+ * @param {Object} order An order as returned from API
+ * @param {Number} id The ID of the fee_line
+ * @return {Float} The total fee amount as a decimal number
+ */
+export function getOrderFeeCost( order, id ) {
+	const item = find( get( order, 'fee_lines', [] ), { id } );
+	if ( item ) {
+		return parseFloat( item.total ) || 0;
+	}
+	return 0;
+}
+
+/**
  * Get the fee total on a given order
  *
  * @param {Object} order An order as returned from API

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -41,6 +41,7 @@
 	@import 'components/list/style';
 	@import 'components/location-flag/style';
 	@import 'components/order-status/style';
+	@import 'components/price-input/style';
 	@import 'components/process-orders-widget/style';
 	@import 'components/product-image-uploader/style';
 	@import 'components/product-reviews-widget/style';


### PR DESCRIPTION
Fixes #18961. This PR adds a button as a "suffix" to the `FormCurrencyInput` used in `PriceInput`, which when clicked resets the value of the `PriceInput` to a supplied prop `initialValue`. This also introduces a new function `getOrderFeeCost` (+ tests) to get the value for a single fee.

On the edit page, this is used on the shipping total field:
![edit](https://user-images.githubusercontent.com/541093/34065347-ff4bdcc0-e1ce-11e7-89a9-0dd061bf9f78.png)

On the refund screen, this is used on the shipping total, and each fee field:
![refund](https://user-images.githubusercontent.com/541093/34065348-ff6f8a80-e1ce-11e7-8702-ca3f12709c1d.png)

⚠️  _Note:_ This does mess with the alignment of the total refund value, but I'll be changing that to the new design in #18672.

**To Test: Edit**

- Edit an existing order, with or without taxes, with or without a shipping cost
- Change the shipping value
- Click the "undo" button to reset the shipping value
- It should reset to the shipping total (not including taxes, as taxes are handled on save)

**To Test: Refunds**

- Open an order, click Submit Refund
- If the order has fees, the fee total, value + taxes, should be pre-populated
- Change the fee value, then click the "undo" button
- Verify the value is fee total _with_ tax, and that the total refund value also updated to reflect the reset fee value
- Change the shipping total, then click the "undo" button
- Verify that the shipping total is reset to the value _with_ tax
