### PR TITLE
Store Orders: Remove PriceInput for refund value

### DIFF
--- a/client/extensions/woocommerce/app/order/order-payment/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-payment/dialog.js
@@ -20,7 +20,6 @@ import Button from 'components/button';
 import Dialog from 'components/dialog';
 import { fetchPaymentMethods } from 'woocommerce/state/sites/payment-methods/actions';
 import formatCurrency from 'lib/format-currency';
-import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
@@ -33,7 +32,6 @@ import { getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Notice from 'components/notice';
 import OrderRefundTable from './table';
-import PriceInput from 'woocommerce/components/price-input';
 import { sendRefund } from 'woocommerce/state/sites/orders/refunds/actions';
 
 class RefundDialog extends Component {
@@ -205,11 +203,10 @@ class RefundDialog extends Component {
 		const { refundNote } = this.state;
 		const dialogClass = 'woocommerce'; // eslint/css specificity hack
 
-		let refundTotal = formatCurrency( 0, order.currency );
+		let refundTotal = getCurrencyFormatDecimal( 0, order.currency );
 		if ( this.state.refundTotal ) {
-			refundTotal = formatCurrency( this.state.refundTotal, order.currency );
+			refundTotal = getCurrencyFormatDecimal( this.state.refundTotal, order.currency );
 		}
-		refundTotal = refundTotal.replace( /[^0-9.,]/g, '' );
 
 		const errorMessage = this.isRefundInvalid( refundTotal );
 		const refundDisabled = isPaymentLoading || !! errorMessage;
@@ -245,23 +242,18 @@ class RefundDialog extends Component {
 						<FormTextarea onChange={ this.updateNote } name="refund_note" value={ refundNote } />
 					</FormLabel>
 
-					<FormFieldset className="order-payment__details">
-						<FormLabel className="order-payment__amount">
+					<div className="order-payment__details">
+						<div className="order-payment__amount">
 							<span className="order-payment__amount-label">
 								{ translate( 'Total refund amount' ) }
 							</span>
-							<div className="order-payment__amount-value">
-								<PriceInput
-									name="refund_total"
-									readOnly
-									currency={ order.currency }
-									value={ refundTotal }
-								/>
-							</div>
-						</FormLabel>
+							<span className="order-payment__amount-value">
+								{ formatCurrency( refundTotal, order.currency ) }
+							</span>
+						</div>
 
 						{ this.renderCreditCard() }
-					</FormFieldset>
+					</div>
 				</form>
 			</Dialog>
 		);

--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -29,10 +29,6 @@
 		width: 155px;
 	}
 
-	.order-payment__amount-label {
-		margin-right: 16px;
-	}
-
 	.order-payment__item-total {
 		text-align: right;
 	}
@@ -77,10 +73,16 @@
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
-		padding-bottom: 16px;
+		justify-content: space-between;
+		padding: 14px;
 		margin-bottom: 16px;
-		border-bottom: 1px solid lighten( $gray, 30% );
-		justify-content: flex-end;
+		background: lighten( $gray, 30% );
+		border: 1px solid lighten( $gray, 15% );
+	}
+
+	.order-payment__amount-value {
+		text-align: right;
+		font-weight: bold;
 	}
 
 	.order-payment__method h3 {

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { clone, get, setWith } from 'lodash';
@@ -220,6 +220,35 @@ class OrderRefundTable extends Component {
 		);
 	};
 
+	renderRefundTotals = () => {
+		const { isEditing, order, translate } = this.props;
+		const refundValue = getOrderRefundTotal( order );
+		if ( isEditing || ! refundValue ) {
+			return null;
+		}
+		const showTax = this.shouldShowTax();
+		const totalValue = getCurrencyFormatDecimal( order.total, order.currency ) + refundValue;
+
+		return (
+			<Fragment>
+				<OrderTotalRow
+					className="order-payment__total-refund order-details__total-refund"
+					currency={ order.currency }
+					label={ translate( 'Refunded' ) }
+					value={ refundValue }
+					showTax={ showTax }
+				/>
+				<OrderTotalRow
+					className="order-payment__total-remaining order-details__total-remaining"
+					currency={ order.currency }
+					label={ translate( 'Remaining total' ) }
+					value={ totalValue }
+					showTax={ showTax }
+				/>
+			</Fragment>
+		);
+	};
+
 	render() {
 		const { order, translate } = this.props;
 		if ( ! order ) {
@@ -227,13 +256,14 @@ class OrderRefundTable extends Component {
 		}
 
 		const showTax = this.shouldShowTax();
+		const refundValue = getOrderRefundTotal( order );
 		const totalsClasses = classnames( {
 			'order-payment__totals': true,
 			'order-details__totals': true,
 			'has-taxes': showTax,
+			'has-refund': !! refundValue,
 			'is-refund-modal': true,
 		} );
-		const refundValue = getOrderRefundTotal( order );
 
 		return (
 			<div>
@@ -270,15 +300,7 @@ class OrderRefundTable extends Component {
 						taxValue={ getOrderTotalTax( order ) }
 						showTax={ showTax }
 					/>
-					{ !! refundValue && (
-						<OrderTotalRow
-							className="order-payment__total-refund order-details__total-refund"
-							currency={ order.currency }
-							label={ translate( 'Refunded' ) }
-							value={ refundValue }
-							showTax={ showTax }
-						/>
-					) }
+					{ this.renderRefundTotals() }
 				</Table>
 			</div>
 		);

--- a/client/extensions/woocommerce/components/order-status/index.js
+++ b/client/extensions/woocommerce/components/order-status/index.js
@@ -33,6 +33,9 @@ export class OrderStatus extends Component {
 				}
 				return translate( 'Paid in full' );
 			case 'completed':
+				if ( refunds.length > 0 ) {
+					return translate( 'Partially refunded' );
+				}
 				return translate( 'Paid in full' );
 			case 'cancelled':
 				return translate( 'Cancelled' );


### PR DESCRIPTION
Fixes #18672. Currently the refund total is shown in a PriceInput field, which makes it look editable, but it isn't - it's a computed value from the form data above it. This PR uses the design in https://github.com/Automattic/wp-calypso/issues/18672#issuecomment-352125028 to make it clear that this isn't an editable field, while still highlighting the refund amount.

![refund](https://user-images.githubusercontent.com/541093/34066040-171dbc6c-e1d7-11e7-86fe-cf97655e8ac7.png)

**To test**

- View a paid order, click "Submit refund"
- Make changes to the fields, see that the "refund total amount" updates correctly
- "Refund" the order (partially or fully) and see that it updates correctly