### PR TITLE
Fix subdomain flow

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -336,7 +336,11 @@ function filterDesignTypeInFlow( flowName, flow ) {
 		return;
 	}
 
-	if ( includes( flow.steps, 'design-type' ) && abtest( 'signupSiteSegmentStep' ) === 'variant' ) {
+	if (
+		includes( flow.steps, 'design-type' ) &&
+		abtest( 'signupSiteSegmentStep' ) === 'variant' &&
+		flowName !== 'subdomain'
+	) {
 		return replaceStepInFlow( flow, 'design-type', 'about' );
 	}
 


### PR DESCRIPTION
We recently launched a new signup screen that isn't compatible with an old flow. This PR excludes the new screen from the flow. 

## Before
![image](https://user-images.githubusercontent.com/6981253/34066136-68cb78e6-e1d8-11e7-9523-06bfb5c59879.png)


## After
![image](https://user-images.githubusercontent.com/6981253/34066128-51361f92-e1d8-11e7-9243-a136d773233f.png)


## Test
- visit `/start/subdomain?vertical=a8c.10`
- Pick a site/blog/portfolio
- Pick a theme
- Enter a domain name
- The search results should show a `.home.blog` sub domain as the first result

cc @travisw 