### PR TITLE
Domains: Add availability message for initial registration period.

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -34,6 +34,7 @@ const domainAvailability = {
 	EMPTY_QUERY: 'empty_query',
 	FORBIDDEN: 'forbidden_domain',
 	FORBIDDEN_SUBDOMAIN: 'forbidden_subdomain',
+	INITIAL_REGISTRATION_PERIOD_MAPPABLE: 'initial_registration_period_mappable',
 	INVALID: 'invalid_domain',
 	INVALID_QUERY: 'invalid_query',
 	INVALID_TLD: 'invalid_tld',

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -144,6 +144,23 @@ function getAvailabilityNotice( domain, error, site ) {
 				severity = 'info';
 			}
 			break;
+		case domainAvailability.INITIAL_REGISTRATION_PERIOD_MAPPABLE:
+			if ( tld ) {
+				message = translate(
+					'This domain is still in the 60-day initial registration period and cannot yet be transferred. ' +
+						'You can either wait until the domain has been registered for 60 days or you can {{a}}map it ' +
+						'to WordPress.com{{/a}} to use it with your site right now.',
+					{
+						args: { tld },
+						components: {
+							strong: <strong />,
+							a: <a rel="noopener noreferrer" href={ paths.domainMapping( site, domain ) } />,
+						},
+					}
+				);
+				severity = 'info';
+			}
+			break;
 		case domainAvailability.MAINTENANCE:
 			if ( tld ) {
 				message = translate(

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -109,6 +109,15 @@ function domainManagementTransferToOtherSite( siteName, domainName ) {
 	return domainManagementTransfer( siteName, domainName, 'other-site' );
 }
 
+function domainMapping( siteName, domain ) {
+	let path = `/domains/add/mapping/${ siteName }`;
+	if ( domain ) {
+		path += `?initialQuery=${ domain }`;
+	}
+
+	return path;
+}
+
 function domainTransferIn( siteName, domain ) {
 	let path = `/domains/add/transfer/${ siteName }`;
 	if ( domain ) {
@@ -144,6 +153,7 @@ export default {
 	domainManagementTransferOut,
 	domainManagementTransferToAnotherUser,
 	domainManagementTransferToOtherSite,
+	domainMapping,
 	domainTransferIn,
 	getSectionName,
 };


### PR DESCRIPTION
If a domain is in the initial 60-day registration period, it is not transferrable. We should let the user know and provide an option to map the domain in the case where the user does not want to wait for the transfer period to expire before using their domain with WordPress.com.

Depends on D8866-code

Testing:
- Apply the patch
- Hack the endpoint to return `initial_registration_period_mappable`
- Search for a domain that would otherwise be transferrable.
- Make sure that the new notice is shown and that the link to map the domain works.