### PR TITLE
Purchases: add helper function to check if a CC processor supports updates

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -66,6 +66,7 @@ function createPurchaseObject( purchase ) {
 			creditCard: {
 				id: Number( purchase.payment_card_id ),
 				type: purchase.payment_card_type,
+				processor: purchase.payment_card_processor,
 				number: Number( purchase.payment_details ),
 				expiryDate: purchase.payment_expiry,
 				expiryMoment: purchase.payment_expiry

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -165,6 +165,13 @@ function isRedeemable( purchase ) {
 	return purchase.isRedeemable;
 }
 
+function cardProcessorSupportsUpdates( purchase ) {
+	return (
+		isPaidWithCreditCard( purchase ) &&
+		purchase.payment.creditCard.processor !== 'WPCOM_Billing_Ebanx'
+	);
+}
+
 /**
  * Checks if a purchase can be canceled and refunded.
  * Purchases usually can be refunded up to 30 days after purchase.
@@ -356,5 +363,6 @@ export {
 	isSubscription,
 	paymentLogoType,
 	purchaseType,
+	cardProcessorSupportsUpdates,
 	showCreditCardExpiringWarning,
 };

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -165,6 +165,14 @@ function isRedeemable( purchase ) {
 	return purchase.isRedeemable;
 }
 
+/**
+ * Checks if a purchase credit card number can be updated
+ * Payments done via CC & Paygate can have their CC updated, but this
+ * is not currently true for other providers such as EBANX.
+ *
+ * @param {Object} purchase - the purchase with which we are concerned
+ * @return {boolean} if the purchase card can be updated
+ */
 function cardProcessorSupportsUpdates( purchase ) {
 	return (
 		isPaidWithCreditCard( purchase ) &&

--- a/client/lib/purchases/test/assembler.js
+++ b/client/lib/purchases/test/assembler.js
@@ -32,6 +32,7 @@ describe( 'assembler', () => {
 				payment_details: 7890,
 				payment_expiry: '11/16',
 				payment_type: 'credit_card',
+				payment_card_processor: 'WPCOM_Billing_MoneyPress_Paygate',
 				payment_name: 'My VISA',
 				payment_country_code: 'US',
 				payment_country_name: 'United States',
@@ -44,6 +45,7 @@ describe( 'assembler', () => {
 		expect( creditCard.id ).to.equal( 1234 );
 		expect( creditCard.number ).to.equal( 7890 );
 		expect( creditCard.type ).to.equal( 'visa' );
+		expect( creditCard.processor ).to.equal( 'WPCOM_Billing_MoneyPress_Paygate' );
 		expect( payment.type ).to.equal( 'credit_card' );
 		expect( payment.countryCode ).to.equal( 'US' );
 		expect( payment.countryName ).to.equal( 'United States' );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -36,6 +36,7 @@ import {
 	isRenewing,
 	isSubscription,
 	purchaseType,
+	cardProcessorSupportsUpdates,
 } from 'lib/purchases';
 import {
 	canEditPaymentDetails,
@@ -206,10 +207,13 @@ class ManagePurchase extends Component {
 
 		if ( canEditPaymentDetails( purchase ) ) {
 			const path = getEditCardDetailsPath( this.props.selectedSite, purchase );
+			const renewing = isRenewing( purchase );
 
-			const text = isRenewing( purchase )
-				? translate( 'Edit Payment Method' )
-				: translate( 'Add Credit Card' );
+			if ( renewing && ! cardProcessorSupportsUpdates( purchase ) ) {
+				return null;
+			}
+
+			const text = renewing ? translate( 'Edit Payment Method' ) : translate( 'Add Credit Card' );
 
 			return <CompactCard href={ path }>{ text }</CompactCard>;
 		}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -21,6 +21,7 @@ import {
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isPaidWithCreditCard,
+	cardProcessorSupportsUpdates,
 	isPaidWithPayPalDirect,
 	isRenewing,
 	isSubscription,
@@ -230,6 +231,7 @@ class PurchaseMeta extends Component {
 		if (
 			! canEditPaymentDetails( purchase ) ||
 			! isPaidWithCreditCard( purchase ) ||
+			! cardProcessorSupportsUpdates( purchase ) ||
 			! getSelectedSite( this.props )
 		) {
 			return <li>{ paymentDetails }</li>;


### PR DESCRIPTION
Extracted from #18286 - for the time being, it's not going to be possible to update CC purchases done with Ebanx. This new helper method makes it possible to disable payment editing on these payments from the purchase payment meta section in the purchase info.

Requires D8867-code for the necessary info to be added to the `/purchases` endpoint.
