### PR TITLE
Purchases: return an object from createToken rather than just a token

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -156,7 +156,7 @@ const CreditCardForm = createReactClass( {
 
 			if ( this.props.saveStoredCard ) {
 				this.props
-					.saveStoredCard( gatewayData.token )
+					.saveStoredCard( gatewayData )
 					.then( () => {
 						notices.success( this.props.translate( 'Card added successfully' ), {
 							persistent: true,

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -143,7 +143,7 @@ const CreditCardForm = createReactClass( {
 	saveCreditCard() {
 		const cardDetails = this.getCardDetails();
 
-		this.props.createCardToken( cardDetails, ( gatewayError, cardToken ) => {
+		this.props.createCardToken( cardDetails, ( gatewayError, gatewayData ) => {
 			if ( ! this._mounted ) {
 				return;
 			}
@@ -156,7 +156,7 @@ const CreditCardForm = createReactClass( {
 
 			if ( this.props.saveStoredCard ) {
 				this.props
-					.saveStoredCard( cardToken )
+					.saveStoredCard( gatewayData.token )
 					.then( () => {
 						notices.success( this.props.translate( 'Card added successfully' ), {
 							persistent: true,
@@ -176,7 +176,11 @@ const CreditCardForm = createReactClass( {
 						}
 					} );
 			} else {
-				const apiParams = this.getParamsForApi( cardDetails, cardToken, this.props.apiParams );
+				const apiParams = this.getParamsForApi(
+					cardDetails,
+					gatewayData.token,
+					this.props.apiParams
+				);
 
 				wpcom.updateCreditCard( apiParams, ( apiError, response ) => {
 					if ( apiError ) {

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -127,12 +127,12 @@ TransactionFlow.prototype._paymentHandlers = {
 		debug( 'submitting transaction with new card' );
 
 		this._createCardToken(
-			function( cardToken ) {
+			function( gatewayData ) {
 				const { name, country, 'postal-code': zip } = newCardDetails;
 
 				this._submitWithPayment( {
-					payment_method: 'WPCOM_Billing_MoneyPress_Paygate',
-					payment_key: cardToken,
+					payment_method: gatewayData.paymentMethod,
+					payment_key: gatewayData.token,
 					name,
 					zip,
 					country,
@@ -235,7 +235,9 @@ function createPaygateToken( requestType, cardDetails, callback ) {
 			return callback( new Error( 'Paygate Response Error: ' + data.error_msg ) );
 		}
 
-		callback( null, data.token );
+		data.paymentMethod = 'WPCOM_Billing_MoneyPress_Paygate';
+
+		callback( null, data );
 	}
 
 	function onFailure() {

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -201,14 +201,15 @@ TransactionFlow.prototype._submitWithPayment = function( payment ) {
 };
 
 function createPaygateToken( requestType, cardDetails, callback ) {
+	debug( 'creating token with Paygate' );
 	wpcom.paygateConfiguration(
 		{
 			request_type: requestType,
 			country: cardDetails.country,
 		},
-		function( error, configuration ) {
-			if ( error ) {
-				callback( error );
+		function( configError, configuration ) {
+			if ( configError ) {
+				callback( configError );
 				return;
 			}
 

--- a/client/state/stored-cards/actions.js
+++ b/client/state/stored-cards/actions.js
@@ -14,12 +14,12 @@ import {
 } from 'state/action-types';
 import wp from 'lib/wp';
 
-export const addStoredCard = cardToken => dispatch => {
+export const addStoredCard = cardData => dispatch => {
 	return new Promise( ( resolve, reject ) => {
 		wp
 			.undocumented()
 			.me()
-			.storedCardAdd( cardToken, ( error, data ) => {
+			.storedCardAdd( cardData.token, ( error, data ) => {
 				error ? reject( error ) : resolve( data );
 			} );
 	} ).then( item => {

--- a/client/state/stored-cards/test/actions.js
+++ b/client/state/stored-cards/test/actions.js
@@ -36,7 +36,9 @@ describe( 'actions', () => {
 	};
 
 	describe( '#addStoredCard', () => {
-		const cardToken = 'pg_1234',
+		const cardData = {
+				token: 'pg_1234',
+			},
 			item = { stored_details_id: 123 };
 		let sandbox;
 
@@ -49,7 +51,7 @@ describe( 'actions', () => {
 				} ),
 			} ) );
 
-			const result = addStoredCard( cardToken )( spy );
+			const result = addStoredCard( cardData )( spy );
 
 			return result.then( () => {
 				expect( spy ).to.have.been.calledWith( {


### PR DESCRIPTION
In preparation for adding additional CC gateways (rather than always using Paygate).
These changes make sure we always return an object containing a `paymentMethod` and the token from `createToken`  

Extracted from #18286 

*Manual testing instructions*
- Under `/me/purchases/add-credit-card` save a new credit card (using details from [here](https://stripe.com/docs/testing#cards))