### PR TITLE
Site Settings: Display Net Neutrality Setting until EOY

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -321,8 +321,9 @@ class SiteSettingsFormGeneral extends Component {
 			isSavingSettings,
 		} = this.props;
 
-		const today = moment(),
-			lastDay = moment( { year: 2017, month: 11, day: 14 } );
+		const today = moment();
+		// Days and years are 1-indexed, and other things are 0-indexed; i.e. December is month 11.
+		const lastDay = moment( { year: 2017, month: 11, day: 31 } );
 
 		if ( today.isAfter( lastDay, 'day' ) ) {
 			return null;


### PR DESCRIPTION
As pointed out to me by @supernovia in Slack, https://www.battleforthenet.com/breaktheinternet/ continues campaigning for Congress to overrule the FCC on Net Neutrality.
There doesn't seem to be deadline this time, so I'm tentatively setting lastDay to EOY.

Users have actually asked to extend availability of the setting, see https://en.forums.wordpress.com/topic/net-neutrality

Requires D8868-code for the plugin to be enabled on the frontend side!

Originally re-enabled per #20748.