### PR TITLE
Fix a typo on the onboarding checklist.

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -82,7 +82,7 @@ class ChecklistShow extends PureComponent {
 					className="checklist-show__confetti"
 				/>
 				<FormattedHeader
-					headerText="Conguratulations!"
+					headerText="Congratulations!"
 					subHeaderText="You have completed all your tasks. Now let's tell people about it. Share your site."
 				/>
 				<div className="checklist-show__share">


### PR DESCRIPTION
The header text should be `Congratulations`.

# How to test
1. Follow the steps described in #20861.
2. You should be able to see the fixed heading.

cc @fditrapani @markryall 