### PR TITLE
Jetpack connect: Remove unused schema

### DIFF
--- a/client/state/jetpack-connect/reducer/schema.js
+++ b/client/state/jetpack-connect/reducer/schema.js
@@ -1,20 +1,4 @@
 /** @format */
-export const jetpackConnectSessionsSchema = {
-	type: 'object',
-	additionalProperties: false,
-	patternProperties: {
-		'^.+$': {
-			type: 'object',
-			required: [ 'timestamp' ],
-			properties: {
-				timestamp: { type: 'number' },
-				flowType: { type: 'string' },
-			},
-			additionalProperties: false,
-		},
-	},
-};
-
 export const jetpackConnectAuthorizeSchema = {
 	type: 'object',
 	additionalProperties: false,


### PR DESCRIPTION
This PR removes a schema that [is unused since](https://github.com/Automattic/wp-calypso/pull/19654/files#diff-d8f80fa3e63b056cf3e28a148ea8aad2L12) #19654 

~It also updates some `number` types in a schema to be `integer`.~

Noticed while working on #20863

## Testing
1. Tests should ensure the schemas are valid. Tests passing?
1. Test connect flow.