### PR TITLE
Jetpack Connect: Use correct calypsoStartedConnection prop

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -72,7 +72,7 @@ class Plans extends Component {
 			this.redirect( CALYPSO_PLANS_PAGE );
 		}
 		if ( ! this.props.canPurchasePlans ) {
-			if ( this.props.isCalypsoStartedConnection ) {
+			if ( this.props.calypsoStartedConnection ) {
 				this.redirect( CALYPSO_REDIRECTION_PAGE );
 			} else {
 				this.redirectToWpAdmin();


### PR DESCRIPTION
This PR fixes an observed-in-code bad reference to an undefined prop `isCalypsoStartedConnection`, which should be the connected `calypsoStartedConnection`.

At the end of the connection flow, a user should stay in Calypso if they start in Calypso. This PR restores that functionality which appears to have been lost as a result of a bad rebase introduced in #9505.

## Testing
1. Create a site
1. Connect the site
1. Add a non-admin user (editor)
1. Log in to the site as that user
1. Connect to WordPress.com by entering the URL at `/jetpack/connect/`
1. Authorize
1. You should be redirected to `/posts/SITE_SLUG` rather than back to WP Admin.