### PR TITLE
Update MailChimp notices to better reflect context.

### DIFF
--- a/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/mailchimp_dashboard.js
@@ -121,9 +121,9 @@ class MailChimpDashboard extends React.Component {
 		const { translate } = nextProps;
 		if ( ( false === nextProps.isSaving ) && this.props.isSaving ) {
 			if ( nextProps.newsletterSettingsSubmitError ) {
-				nextProps.errorNotice( translate( 'There was a problem saving the email settings. Please try again.' ) );
+				nextProps.errorNotice( translate( 'There was a problem saving MailChimp settings. Please try again.' ) );
 			} else {
-				nextProps.successNotice( translate( 'Email settings saved.' ), { duration: 4000 } );
+				nextProps.successNotice( translate( 'MailChimp settings saved.' ), { duration: 4000 } );
 			}
 		}
 		if ( ( false === this.props.saveSettingsRequest ) && nextProps.saveSettingsRequest ) {


### PR DESCRIPTION
### Information

With new Email Settings section added the old MailChimp information notices should be more precise in what part of the settings they address.

### Testing
Open Store/settings/email  on a site that has MailChimp configured ( configure one if not ). Change some settings on MailChimp dashboard and click Save. Notice should appear that should now include "MailChimp" and not just "Email" wording.