### PR TITLE
Build: remove `minify` package script

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,6 @@
     "lint:css": "stylelint \"client/**/*.scss\" --syntax scss",
     "lint:js": "npm run -s install-if-deps-outdated && eslint-eslines .",
     "lint:mixedindent": "mixedindentlint --ignore-comments \"client/**/*.scss\" \"assets/**/*.scss\" \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\" \"!client/config/index.js\"",
-    "minify": "node bin/minify.js",
     "precommit": "npm run -s install-if-no-packages && node bin/pre-commit-hook.js",
     "prepush": "npm run -s install-if-no-packages && node bin/pre-push-hook.js",
     "rm": "node bin/rm.js",


### PR DESCRIPTION
Clean out `minify` package script since `bin/minify.js` does not exist anymore (removed in Automattic/wp-calypso@ac29ee70fdb78b4f585ad0c79d5f00c32da63e64).