### PR TITLE
Streamline share panel

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -545,7 +545,7 @@ class PostShare extends Component {
 
 				<div className={ classes }>
 					<div className="post-share__head">
-						<h4 className="post-share__title">
+						<div className="post-share__title">
 							<span>
 								{ translate(
 									'Share on your connected social media accounts using ' + '{{a}}Publicize{{/a}}.',
@@ -567,7 +567,7 @@ class PostShare extends Component {
 									<Gridicon icon="cross" />
 								</Button>
 							) }
-						</h4>
+						</div>
 					</div>
 					{ ! hasFetchedConnections && <div className="post-share__placeholder" /> }
 					{ this.renderRequestSharingNotice() }

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -225,6 +225,7 @@ class PostShare extends Component {
 				disabled={ this.isDisabled() }
 				message={ this.state.message }
 				requireCount={ requireCount }
+				displayMessageHeading={ false }
 				onChange={ this.setMessage }
 				acceptableLength={ acceptableLength }
 			/>

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -103,7 +103,6 @@ class PostShare extends Component {
 		message: PostMetadata.publicizeMessage( this.props.post ) || '',
 		skipped: PostMetadata.publicizeSkipped( this.props.post ) || [],
 		showSharingPreview: false,
-		showAccountTooltip: false,
 		scheduledDate: null,
 		showTooltip: false,
 		tooltipContext: null,
@@ -430,10 +429,6 @@ class PostShare extends Component {
 			);
 		}
 	}
-
-	showAddTooltip = () => this.setState( { showAccountTooltip: true } );
-
-	hideAddTooltip = () => this.setState( { showAccountTooltip: false } );
 
 	renderConnectionsSection() {
 		const { hasFetchedConnections, siteId, siteSlug, translate } = this.props;

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -568,17 +568,6 @@ class PostShare extends Component {
 								</Button>
 							) }
 						</h4>
-						<div className="post-share__subtitle">
-							{ translate(
-								'Share your post on all of your connected social media accounts using ' +
-									'{{a}}Publicize{{/a}}.',
-								{
-									components: {
-										a: <a href={ `/sharing/${ siteSlug }` } />,
-									},
-								}
-							) }
-						</div>
 					</div>
 					{ ! hasFetchedConnections && <div className="post-share__placeholder" /> }
 					{ this.renderRequestSharingNotice() }

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -65,8 +65,6 @@ import ConnectionsList, { NoConnectionsNotice } from './connections-list';
 import ActionsList from './publicize-actions-list';
 import CalendarButton from 'blocks/calendar-button';
 import EventsTooltip from 'components/date-picker/events-tooltip';
-import SectionHeader from 'components/section-header';
-import Tooltip from 'components/tooltip';
 import analytics from 'lib/analytics';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { sectionify } from 'lib/route/path';
@@ -447,31 +445,6 @@ class PostShare extends Component {
 
 		return (
 			<div className="post-share__services">
-				<SectionHeader
-					className="post-share__services-header"
-					label={ translate( 'Connected accounts' ) }
-				>
-					<Button
-						compact
-						href={ '/sharing/' + siteId }
-						className="post-share__add-button"
-						onMouseEnter={ this.showAddTooltip }
-						onMouseLeave={ this.hideAddTooltip }
-						ref="addAccountButton"
-						aria-label={ translate( 'Add account' ) }
-					>
-						<Gridicon icon="plus-small" size={ 18 } />
-						<Gridicon icon="user" size={ 18 } />
-						<Tooltip
-							isVisible={ this.state.showAccountTooltip }
-							context={ this.refs && this.refs.addAccountButton }
-							position="bottom"
-						>
-							{ translate( 'Add account' ) }
-						</Tooltip>
-					</Button>
-				</SectionHeader>
-
 				<ConnectionsList
 					{ ...{
 						connections,

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -546,7 +546,16 @@ class PostShare extends Component {
 				<div className={ classes }>
 					<div className="post-share__head">
 						<h4 className="post-share__title">
-							<span>{ translate( 'Share this post' ) }</span>
+							<span>
+								{ translate(
+									'Share on your connected social media accounts using ' + '{{a}}Publicize{{/a}}.',
+									{
+										components: {
+											a: <a href={ `/sharing/${ siteSlug }` } />,
+										},
+									}
+								) }
+							</span>
 							{ showClose && (
 								<Button
 									borderless

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -496,12 +496,12 @@ class PostShare extends Component {
 		return (
 			<div>
 				<div className="post-share__main">
+					{ this.renderConnectionsSection() }
+
 					<div className="post-share__form">
 						{ this.renderMessage() }
 						{ this.renderSharingButtons() }
 					</div>
-
-					{ this.renderConnectionsSection() }
 				</div>
 
 				<ActionsList { ...this.props } />

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -455,7 +455,7 @@ class PostShare extends Component {
 					onToggle={ this.toggleConnection }
 				/>
 
-				<div className="post-share__connections">
+				<div className="post-share__manage-connections-link">
 					{ translate( '{{a}}Manage connections{{/a}}', {
 						components: {
 							a: <a href={ `/sharing/${ siteId }` } />,

--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -454,6 +454,14 @@ class PostShare extends Component {
 					} }
 					onToggle={ this.toggleConnection }
 				/>
+
+				<div className="post-share__connections">
+					{ translate( '{{a}}Manage connections{{/a}}', {
+						components: {
+							a: <a href={ `/sharing/${ siteId }` } />,
+						},
+					} ) }
+				</div>
 			</div>
 		);
 	}

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -58,7 +58,6 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 }
 
 .post-share__head {
-	border-bottom: 1px solid transparentize( lighten( $gray, 20% ), .5 );
 	.post-share__wrapper.is-placeholder & {
 		border-bottom-width: 0;
 	}

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -13,7 +13,8 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	background-color: $white;
 
 	& .notice {
-		margin: 0;
+		margin: 0 0 16px 0;
+		border-radius: 0;
 	}
 }
 

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -32,6 +32,10 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	}
 }
 
+.post-share__connections {
+	margin: 16px 0 0;
+}
+
 .post-share__main {
 	display: flex;
 	flex-direction: column-reverse;

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -25,7 +25,7 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	}
 }
 
-.post-share__connections {
+.post-share__manage-connections-link {
 	margin: 16px 0 0;
 }
 

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -120,7 +120,7 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 
 		//TODO Clean-up after PostTypeList is used for /posts/
 		.post-type-list & {
-			margin: 0 16px 16px;
+			margin: 0 16px 16px 16px;
 		}
 	}
 	@include breakpoint( ">960px" ) {
@@ -128,7 +128,7 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 
 		//TODO Clean-up after PostTypeList is used for /posts/
 		.post-type-list & {
-			margin: 0 16px 16px 0;
+			margin: 0 16px 16px 16px;
 		}
 	}
 }

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -20,13 +20,6 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 .post-share__title {
 	display: flex;
 
-	font-size: 15px;
-	margin: 16px 0 4px;
-
-	@include breakpoint( ">660px" ) {
-		font-size: 18px;
-	}
-
 	span {
 		flex: 1;
 	}
@@ -62,13 +55,13 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 		border-bottom-width: 0;
 	}
 
-	padding: 0 16px 16px;
+	padding: 16px;
 	@include breakpoint( ">480px" ) {
-		padding: 0 24px 16px;
+		padding: 16px 24px 16px;
 
 		//TODO Clean-up after PostTypeList is used for /posts/
 		.post-type-list & {
-			padding: 0 16px 16px;
+			padding: 16px;
 		}
 	}
 }

--- a/client/post-editor/editor-sharing/publicize-message.jsx
+++ b/client/post-editor/editor-sharing/publicize-message.jsx
@@ -25,6 +25,7 @@ class PublicizeMessage extends Component {
 		preview: PropTypes.string,
 		acceptableLength: PropTypes.number,
 		requireCount: PropTypes.bool,
+		displayMessageHeading: PropTypes.bool,
 		onChange: PropTypes.func,
 	};
 
@@ -33,6 +34,7 @@ class PublicizeMessage extends Component {
 		message: '',
 		acceptableLength: 140,
 		requireCount: false,
+		displayMessageHeading: true,
 	};
 
 	onChange = event => {
@@ -100,11 +102,13 @@ class PublicizeMessage extends Component {
 	render() {
 		return (
 			<div className="editor-sharing__publicize-message">
-				<h5 className="editor-sharing__message-heading">
-					{ this.props.translate( 'Customize the message', {
-						context: 'Post editor sharing message heading',
-					} ) }
-				</h5>
+				{ this.props.displayMessageHeading && (
+					<h5 className="editor-sharing__message-heading">
+						{ this.props.translate( 'Customize the message', {
+							context: 'Post editor sharing message heading',
+						} ) }
+					</h5>
+				) }
 				<TrackInputChanges onNewValue={ this.recordStats }>
 					{ this.renderTextarea() }
 				</TrackInputChanges>


### PR DESCRIPTION
This PR seeks to streamline the share panel layout to make it easier to read and quicker to understand what its purpose is.

Before:

![before](https://user-images.githubusercontent.com/1017839/34110051-c578f97c-e405-11e7-93c1-a5a4c9da812e.png)

After:

![after](https://user-images.githubusercontent.com/1017839/34109977-8aa14c6e-e405-11e7-9f9a-0447fad2138f.png)

To test:

- Checkout branch
- `npm start`
- Visit the "Blog Posts" page and click Share from the action menu
- Make sure the layout is correct