### PR TITLE
Guided Tours: separate example tours and selectors

### DIFF
--- a/client/layout/guided-tours/docs/examples/selectors/has-selected-site-premium-or-business-plan.js
+++ b/client/layout/guided-tours/docs/examples/selectors/has-selected-site-premium-or-business-plan.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { PLAN_PREMIUM, PLAN_BUSINESS } from 'lib/plans/constants';
+import { getSitePlan } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+import { isDesktop } from 'lib/viewport';
+
+// NOTE: selector moved here because tour is no longer active and serves as example only
+// to use in a tour, move back to 'state/ui/guided-tours/contexts' (see commented out import above)
+/**
+ * Returns true if the selected site is on the Premium or Business plan
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True if selected site is on the Premium or Business plan, false otherwise.
+ */
+
+export const hasSelectedSitePremiumOrBusinessPlan = state => {
+	const siteId = getSelectedSiteId( state );
+	const sitePlan = getSitePlan( state, siteId );
+	if ( ! sitePlan ) {
+		return false;
+	}
+	return includes( [ PLAN_PREMIUM, PLAN_BUSINESS ], sitePlan.product_slug );
+};

--- a/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
+++ b/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -22,30 +20,8 @@ import {
 	Quit,
 	Link,
 } from 'layout/guided-tours/config-elements';
-// import { hasSelectedSitePremiumOrBusinessPlan } from 'state/ui/guided-tours/contexts';
-
+import { hasSelectedSitePremiumOrBusinessPlan } from '../selectors/has-selected-site-premium-or-business-plan';
 import { isDesktop } from 'lib/viewport';
-
-// NOTE: selector moved here because tour is no longer active and serves as example only
-// to use in a tour, move back to 'state/ui/guided-tours/contexts' (see commented out import above)
-/**
- * Returns true if the selected site is on the Premium or Business plan
- *
- * @param {Object} state Global state tree
- * @return {Boolean} True if selected site is on the Premium or Business plan, false otherwise.
- */
-import { includes } from 'lodash';
-import { PLAN_PREMIUM, PLAN_BUSINESS } from 'lib/plans/constants';
-import { getSitePlan } from 'state/sites/selectors';
-
-export const hasSelectedSitePremiumOrBusinessPlan = state => {
-	const siteId = getSelectedSiteId( state );
-	const sitePlan = getSitePlan( state, siteId );
-	if ( ! sitePlan ) {
-		return false;
-	}
-	return includes( [ PLAN_PREMIUM, PLAN_BUSINESS ], sitePlan.product_slug );
-};
 
 export const SimplePaymentsEndOfYearGuide = makeTour(
 	<Tour


### PR DESCRIPTION
As suggested in #20857, separate example tours and example selectors in the Guided Tours documentation. 