### PR TITLE
Comments: Make header in single post view sticky

### DIFF
--- a/client/my-sites/comments/comment-list/comment-list-header.jsx
+++ b/client/my-sites/comments/comment-list/comment-list-header.jsx
@@ -12,6 +12,7 @@ import { get } from 'lodash';
  */
 import HeaderCake from 'components/header-cake';
 import QueryPosts from 'components/data/query-posts';
+import StickyPanel from 'components/sticky-panel';
 import { convertDateToUserLocation } from 'components/post-schedule/utils';
 import { decodeEntities, stripHTML } from 'lib/formatting';
 import { gmtOffset, timezone } from 'lib/site/utils';
@@ -48,7 +49,7 @@ export const CommentListHeader = ( {
 	const backHref = ! shouldUseHistoryBack ? `/comments/all/${ siteSlug }` : null;
 
 	return (
-		<div className="comment-list__header">
+		<StickyPanel className="comment-list__header">
 			<QueryPosts siteId={ siteId } postId={ postId } />
 
 			<HeaderCake
@@ -73,7 +74,7 @@ export const CommentListHeader = ( {
 				</div>
 				<div className="comment-list__header-date">{ formattedDate }</div>
 			</HeaderCake>
-		</div>
+		</StickyPanel>
 	);
 };
 

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -80,7 +80,6 @@
 
 	&.is-sticky .header-cake {
 		box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1), 0 0 56px rgba(0, 0, 0, 0.075);
-		margin: 9px 0;
 	}
 }
 

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -75,6 +75,15 @@
 	}
 }
 
+.comment-list__header {
+	overflow: visible;
+
+	&.is-sticky .header-cake {
+		box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1), 0 0 56px rgba(0, 0, 0, 0.075);
+		margin: 9px 0;
+	}
+}
+
 .comment-list__header-title {
 	font-weight: 600;
 	overflow: hidden;


### PR DESCRIPTION
Fix #20844

Make header in single post view of Comments Management sticky.

![dec-18-2017 18-05-33](https://user-images.githubusercontent.com/2070010/34118131-2ba3d65a-e41e-11e7-897e-4ac9d3205ba1.gif)