### PR TITLE
Comments: Make comment author email a mailto link

### DIFF
--- a/client/my-sites/comments/comment/comment-author-more-info.jsx
+++ b/client/my-sites/comments/comment/comment-author-more-info.jsx
@@ -142,7 +142,12 @@ export class CommentAuthorMoreInfo extends Component {
 
 					<div className="comment__author-more-info-element">
 						<Gridicon icon="mail" />
-						<div>{ authorEmail || <em>{ translate( 'No email address' ) }</em> }</div>
+						<div>
+							{ !! authorEmail && (
+								<ExternalLink href={ `mailto:${ authorEmail }` }>{ authorEmail }</ExternalLink>
+							) }
+							{ ! authorEmail && <em>{ translate( 'No email address' ) }</em> }
+						</div>
 					</div>
 
 					<div className="comment__author-more-info-element">


### PR DESCRIPTION
Fix #20843 

Make the comment author email address in the User Info popover a `mailto` link.