### PR TITLE
Publicize: Remove dead code from publicize-options

### DIFF
--- a/client/lib/paths/index.js
+++ b/client/lib/paths/index.js
@@ -58,29 +58,7 @@ function publicizeConnections( site ) {
 	return url;
 }
 
-/**
- * Returns a URL to manage Jetpack modules for a given site.
- *
- * @param  {object} site 	Site object
- * @param  {string} module	Optional module name to link to
- * @return {string}      	URL to manage Jetpack modules
- */
-function jetpackModules( site, module ) {
-	let url = '';
-	if ( ! site.jetpack ) {
-		return url;
-	}
-
-	url = site.options.admin_url + 'admin.php?page=jetpack_modules';
-	if ( module ) {
-		url += '&info=' + module;
-	}
-
-	return url;
-}
-
 export default {
-	jetpackModules,
 	login,
 	newPost,
 	newPage,

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -54,13 +54,11 @@ class EditorSharingPublicizeOptions extends React.Component {
 	}
 
 	newConnectionPopup = () => {
-		let href;
-
 		if ( ! this.props.site ) {
 			return;
 		}
 
-		href = paths.publicizeConnections( this.props.site );
+		const href = paths.publicizeConnections( this.props.site );
 
 		if ( ! this.connectionPopupMonitor ) {
 			this.connectionPopupMonitor = new PopupMonitor();
@@ -143,10 +141,6 @@ class EditorSharingPublicizeOptions extends React.Component {
 				) }
 			</p>
 		);
-	};
-
-	dismissRepublicizeMessage = () => {
-		this.props.dismissShareConfirmation( this.props.siteId, this.props.post.ID );
 	};
 
 	render() {

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -44,7 +44,6 @@ class EditorSharingPublicizeOptions extends React.Component {
 	};
 
 	connectionPopupMonitor = false;
-	jetpackModulePopupMonitor = false;
 
 	hasConnections = () => {
 		return this.props.connections && this.props.connections.length;
@@ -53,10 +52,6 @@ class EditorSharingPublicizeOptions extends React.Component {
 	componentWillUnmount() {
 		if ( this.connectionPopupMonitor ) {
 			this.connectionPopupMonitor.off( 'close', this.onNewConnectionPopupClosed );
-		}
-
-		if ( this.jetpackModulePopupMonitor ) {
-			this.jetpackModulePopupMonitor.off( 'close', this.onModuleConnectionPopupClosed );
 		}
 	}
 
@@ -85,38 +80,6 @@ class EditorSharingPublicizeOptions extends React.Component {
 		this.newConnectionPopup();
 		recordStat( 'sharing_create_service' );
 		recordEvent( 'Opened Create New Sharing Service Dialog' );
-	};
-
-	jetpackModulePopup = () => {
-		let href;
-
-		if ( ! this.props.site || ! this.props.site.jetpack ) {
-			return;
-		}
-
-		href = paths.jetpackModules( this.props.site, 'publicize' );
-
-		if ( ! this.jetpackModulePopupMonitor ) {
-			this.jetpackModulePopupMonitor = new PopupMonitor();
-		}
-
-		this.jetpackModulePopupMonitor.open( href );
-		this.jetpackModulePopupMonitor.once( 'close', this.onModuleConnectionPopupClosed );
-	};
-
-	onModuleConnectionPopupClosed = () => {
-		if ( ! this.props.site || ! this.props.site.jetpack ) {
-			return;
-		}
-
-		// Refresh the list of connections so that the user is given the latest
-		// possible state.  Also prevents a possible infinite loading state due
-		// to connections previously returning a 400 error
-		this.props.site.once( 'change', () => {
-			if ( this.props.isPublicizeEnabled ) {
-				this.props.requestConnections( this.props.site.ID );
-			}
-		} );
 	};
 
 	renderServices = () => {
@@ -199,26 +162,6 @@ class EditorSharingPublicizeOptions extends React.Component {
 					<p>
 						<span>{ this.props.translate( 'Publicize is disabled on this site.' ) }</span>
 					</p>
-				</div>
-			);
-		}
-
-		if ( this.props.site && this.props.site.jetpack && ! this.props.isPublicizeEnabled ) {
-			return (
-				<div className="editor-sharing__publicize-disabled">
-					<p>
-						<span>
-							{ this.props.translate(
-								'Enable the Publicize module to automatically share new posts to social networks.'
-							) }
-						</span>
-					</p>
-					<button
-						className="editor-sharing__jetpack-modules-button button"
-						onClick={ this.jetpackModulePopup }
-					>
-						{ this.props.translate( 'View Module Settings' ) }
-					</button>
 				</div>
 			);
 		}

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -25,13 +25,11 @@ import Button from 'components/button';
 import { recordStat, recordEvent } from 'lib/posts/stats';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
-import { isJetpackModuleActive } from 'state/sites/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
-import { postTypeSupports } from 'state/post-types/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSiteUserConnections } from 'state/sharing/publicize/selectors';
 import { fetchConnections as requestConnections } from 'state/sharing/publicize/actions';
-import { canCurrentUser } from 'state/selectors';
+import { canCurrentUser, isPublicizeEnabled } from 'state/selectors';
 
 class EditorSharingPublicizeOptions extends React.Component {
 	static propTypes = {
@@ -179,14 +177,12 @@ export default connect(
 		const userId = getCurrentUserId( state );
 		const postId = getEditorPostId( state );
 		const postType = getEditedPostValue( state, siteId, postId, 'type' );
-		const isPublicizeEnabled =
-			false !== isJetpackModuleActive( state, siteId, 'publicize' ) &&
-			postTypeSupports( state, siteId, postType, 'publicize' );
+
 		const canUserPublishPosts = canCurrentUser( state, siteId, 'publish_posts' );
 
 		return {
 			siteId,
-			isPublicizeEnabled,
+			isPublicizeEnabled: isPublicizeEnabled( state, siteId, postType ),
 			canUserPublishPosts,
 			connections: getSiteUserConnections( state, siteId, userId ),
 		};

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -156,16 +156,6 @@ class EditorSharingPublicizeOptions extends React.Component {
 			return null;
 		}
 
-		if ( this.props.site && this.props.site.options.publicize_permanently_disabled ) {
-			return (
-				<div className="editor-sharing__publicize-disabled">
-					<p>
-						<span>{ this.props.translate( 'Publicize is disabled on this site.' ) }</span>
-					</p>
-				</div>
-			);
-		}
-
 		const classes = classNames( 'editor-sharing__publicize-options', {
 			'has-connections': this.hasConnections(),
 			'has-add-option': this.props.canUserPublishPosts,

--- a/client/post-editor/editor-sharing/publicize-options.scss
+++ b/client/post-editor/editor-sharing/publicize-options.scss
@@ -17,29 +17,3 @@
 		margin: 8px 0;
 	}
 }
-
-.editor-sharing__add-connection {
-	position: relative;
-	display: block;
-	padding-left: 20px;
-	margin-bottom: 16px;
-}
-
-.editor-sharing__add-connection-icon {
-	position: absolute;
-		top: 50%;
-		left: 0;
-	transform: translateY( -50% );
-}
-
-.editor-sharing__publicize-disabled {
-	color: $gray-text-min;
-	font-size: 13px;
-	span {
-		display: block;
-	}
-}
-
-.editor-sharing__jetpack-modules-button {
-	margin-top: 10px;
-}


### PR DESCRIPTION
In this PR, we are removing dead code from `post-editor/editor-sharing/publicize-options`.

Originally, @jsnajdr asked me to do something about the `this.props.site.once()` code – we removed `sites-list` and so the site object is from Redux and doesn't have any methods.

I tried to run the code which would execute that function but couldn't get to it. Opened editor, went to the sidebar, clicked on "Sharing" and still couldn't hit it.

When looking deeper, I found out that the `PublicizeOptions` component is rendered in `editor-sharing/index`. `editor-sharing/index` is rendered only in `editor-sharing/accordion` and only under the condition that the Publicize (Jetpack module) is enabled. "That's okay", you say. However, the code in `publicize-options` is called only if the Publicize (Jetpack module) is not enabled:

```
if ( this.props.site && this.props.site.jetpack && ! this.props.isPublicizeEnabled ) {
```

That makes it dead code to me. Is that correct?
