### PR TITLE
Store Orders: Improve handling for empty/default payment methods

### DIFF
--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -49,12 +49,20 @@ class OrderPaymentCard extends Component {
 				},
 			} );
 		} else if ( 'on-hold' === order.status || 'pending' === order.status ) {
-			paymentStatus = translate( 'Awaiting payment of %(total)s via %(method)s', {
-				args: {
-					total: formatCurrency( order.total, order.currency ),
-					method: order.payment_method_title,
-				},
-			} );
+			if ( order.payment_method_title ) {
+				paymentStatus = translate( 'Awaiting payment of %(total)s via %(method)s', {
+					args: {
+						total: formatCurrency( order.total, order.currency ),
+						method: order.payment_method_title,
+					},
+				} );
+			} else {
+				paymentStatus = translate( 'Awaiting payment of %(total)s', {
+					args: {
+						total: formatCurrency( order.total, order.currency ),
+					},
+				} );
+			}
 		} else if ( order.refunds.length ) {
 			const refund = getOrderRefundTotal( order );
 			paymentStatus = translate( 'Payment of %(total)s has been partially refunded %(refund)s', {
@@ -69,11 +77,17 @@ class OrderPaymentCard extends Component {
 					total: formatCurrency( order.total, order.currency ),
 				},
 			} );
-		} else {
+		} else if ( order.payment_method_title ) {
 			paymentStatus = translate( 'Payment of %(total)s received via %(method)s', {
 				args: {
 					total: formatCurrency( order.total, order.currency ),
 					method: order.payment_method_title,
+				},
+			} );
+		} else {
+			paymentStatus = translate( 'Payment of %(total)s received', {
+				args: {
+					total: formatCurrency( order.total, order.currency ),
 				},
 			} );
 		}

--- a/client/extensions/woocommerce/state/sites/payment-methods/selectors.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/selectors.js
@@ -5,6 +5,7 @@
  */
 
 import { find, get, isArray } from 'lodash';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -28,6 +29,18 @@ export const getPaymentMethods = ( state, siteId = getSelectedSiteId( state ) ) 
  * @return {Object} Object with payment method data, false if no method found
  */
 export const getPaymentMethod = ( state, methodId, siteId = getSelectedSiteId( state ) ) => {
+	if ( methodId === 'manual' ) {
+		return {
+			id: 'manual',
+			title: translate( 'Manual Payment' ),
+			description: '', // Not used for this method
+			enabled: true,
+			method_title: 'manual',
+			methodType: 'offline',
+			method_description: '', // Not used for this method
+			method_supports: [ 'products' ],
+		};
+	}
 	const methods = getPaymentMethods( state, siteId );
 	return find( methods, { id: methodId } ) || false;
 };

--- a/client/extensions/woocommerce/state/sites/payment-methods/selectors.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/selectors.js
@@ -29,13 +29,13 @@ export const getPaymentMethods = ( state, siteId = getSelectedSiteId( state ) ) 
  * @return {Object} Object with payment method data, false if no method found
  */
 export const getPaymentMethod = ( state, methodId, siteId = getSelectedSiteId( state ) ) => {
-	if ( methodId === 'manual' ) {
+	if ( methodId === 'calypso_manual' ) {
 		return {
-			id: 'manual',
+			id: 'calypso_manual',
 			title: translate( 'Manual Payment' ),
 			description: '', // Not used for this method
 			enabled: true,
-			method_title: 'manual',
+			method_title: 'calypso_manual',
 			methodType: 'offline',
 			method_description: '', // Not used for this method
 			method_supports: [ 'products' ],

--- a/client/extensions/woocommerce/state/sites/payment-methods/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/test/selectors.js
@@ -132,13 +132,13 @@ describe( 'selectors', () => {
 			} );
 		} );
 
-		test( 'should return the "fake" paymentMethod "manual" when requested.', () => {
-			expect( getPaymentMethod( loadedState, 'manual', 123 ) ).to.eql( {
-				id: 'manual',
+		test( 'should return the "fake" paymentMethod "calypso_manual" when requested.', () => {
+			expect( getPaymentMethod( loadedState, 'calypso_manual', 123 ) ).to.eql( {
+				id: 'calypso_manual',
 				title: 'Manual Payment',
 				description: '',
 				enabled: true,
-				method_title: 'manual',
+				method_title: 'calypso_manual',
 				methodType: 'offline',
 				method_description: '',
 				method_supports: [ 'products' ],

--- a/client/extensions/woocommerce/state/sites/payment-methods/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/test/selectors.js
@@ -132,6 +132,19 @@ describe( 'selectors', () => {
 			} );
 		} );
 
+		test( 'should return the "fake" paymentMethod "manual" when requested.', () => {
+			expect( getPaymentMethod( loadedState, 'manual', 123 ) ).to.eql( {
+				id: 'manual',
+				title: 'Manual Payment',
+				description: '',
+				enabled: true,
+				method_title: 'manual',
+				methodType: 'offline',
+				method_description: '',
+				method_supports: [ 'products' ],
+			} );
+		} );
+
 		test( 'should be false when given a loading state tree.', () => {
 			expect( getPaymentMethod( loadingState, 'bacs', 123 ) ).to.be.false;
 		} );

--- a/client/extensions/woocommerce/state/ui/orders/selectors.js
+++ b/client/extensions/woocommerce/state/ui/orders/selectors.js
@@ -74,7 +74,7 @@ export const getDefaultEmptyOrder = () => {
 		prices_include_tax: false,
 		billing: {},
 		shipping: {},
-		payment_method: 'manual',
+		payment_method: 'calypso_manual',
 		payment_method_title: translate( 'Manual Payment' ),
 		line_items: [],
 		tax_lines: [],

--- a/client/extensions/woocommerce/state/ui/orders/selectors.js
+++ b/client/extensions/woocommerce/state/ui/orders/selectors.js
@@ -5,6 +5,7 @@
  */
 
 import { get, isObject, merge } from 'lodash';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -73,6 +74,8 @@ export const getDefaultEmptyOrder = () => {
 		prices_include_tax: false,
 		billing: {},
 		shipping: {},
+		payment_method: 'manual',
+		payment_method_title: translate( 'Manual Payment' ),
 		line_items: [],
 		tax_lines: [],
 		shipping_lines: [],


### PR DESCRIPTION
This PR does a few things to address the payment method of orders. First, to fix the bug where we display an empty method on `Awaiting payment of $10.00 via`, this now checks to see if `payment_method_title` isn't empty before displaying the "via __" text. Now if empty, it just says `Awaiting payment of $10.00`.

This also adds a default payment method of `calypso_manual`, which all owner-created orders are set to. This is purely for display on the single-order view, which will look like this:

<img width="607" alt="screen shot 2017-12-18 at 1 17 46 pm" src="https://user-images.githubusercontent.com/541093/34121804-4e3bc46e-e3f8-11e7-9560-aee3a6f424e2.png">

Assuming the next step after creating an order is to go through the customer payment page, the customer (or store owner, if filling out on their behalf) can select which real payment method to use (check payments, stripe, paypal, etc), and the order updates to reflect that method.

**To test**

1. View an order that previously had an empty payment method (by creating an order on master, for example)
2. Check that it no longer cuts off after `… via`.
3. Go back to the orders list, and click "New Order"
4. Create a new order, save it
5. Verify that the payment method is set to Manual in the payment card
6. Go to the customer payment page (can be found in wp-admin, for now)
7. Finish the payment process
8. Verify that the payment method updated to the real method used
9. Create a new order again
10. Mark this one as paid via the button ("Mark as Paid") in the payment card
11. Go to refund the order with "Submit a Refund"
12. Verify that the refund is possible, and is considered a manual refund
