### PR TITLE
Jetpack connect: Handle invalid site slugs

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -27,7 +27,12 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-import { canCurrentUser, isRtl, isSiteAutomatedTransfer } from 'state/selectors';
+import {
+	canCurrentUser,
+	hasInitializedSites,
+	isRtl,
+	isSiteAutomatedTransfer,
+} from 'state/selectors';
 import { mc } from 'lib/analytics';
 import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
 
@@ -70,6 +75,10 @@ class Plans extends Component {
 		}
 		if ( this.props.hasPlan || this.props.notJetpack ) {
 			this.redirect( CALYPSO_PLANS_PAGE );
+		}
+		if ( ! this.props.selectedSite && this.props.isSitesInitialized ) {
+			// Invalid site
+			this.redirect( '/jetpack/connect/plans' );
 		}
 		if ( ! this.props.canPurchasePlans ) {
 			if ( this.props.isCalypsoStartedConnection ) {
@@ -223,6 +232,7 @@ export default connect(
 			isRtlLayout: isRtl( state ),
 			hasPlan: selectedSite ? isCurrentPlanPaid( state, selectedSite.ID ) : null,
 			notJetpack: selectedSite ? ! isJetpackSite( state, selectedSite.ID ) : null,
+			isSitesInitialized: hasInitializedSites( state ),
 		};
 	},
 	{


### PR DESCRIPTION
Part of #18266.

When an unknown site slug is passed on the /jetpack/connect/plans/:site route, redirect to the same route without the :site.

In practice, this will end up at /jetpack/connect/store, which is where /plans with no site redirects to.

## Testing
* The route /jetpack/connect/plans/{invalid_site} should redirect to /jetpack/connect/store
* /jetpack/connect/plans/:site with a valid site should behave as before
