### PR TITLE
Post Item: scroll expanded PostShare into view.

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
@@ -73,6 +74,14 @@ class PostItem extends React.Component {
 
 	hasMultipleUsers() {
 		return this.inAllSitesModeWithMultipleUsers() || this.inSingleSiteModeWithMultipleUsers();
+	}
+
+	componentDidUpdate( prevProps ) {
+		const { hasExpandedContent } = this.props;
+
+		if ( ! prevProps.hasExpandedContent && hasExpandedContent ) {
+			ReactDom.findDOMNode( this ).scrollIntoView( false );
+		}
 	}
 
 	renderSelectionCheckbox() {

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -81,8 +81,8 @@ class PostItem extends React.Component {
 		const viewportBottom = document.documentElement.clientHeight + window.scrollY;
 		const distanceFromBottom = viewportBottom - element.offsetTop;
 
-		if ( distanceFromBottom < 200 ) {
-			const desiredOffset = window.scrollY + ( 200 - distanceFromBottom );
+		if ( distanceFromBottom < 250 ) {
+			const desiredOffset = window.scrollY + ( 250 - distanceFromBottom );
 
 			window.scrollTo( 0, desiredOffset );
 		}

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -99,9 +99,9 @@ class PostItem extends React.Component {
 	}
 
 	renderExpandedContent() {
-		const { post, isCurrentSharePanelOpen } = this.props;
+		const { post, hasExpandedContent } = this.props;
 
-		if ( ! post || ! isCurrentSharePanelOpen ) {
+		if ( ! post || ! hasExpandedContent ) {
 			return null;
 		}
 
@@ -125,6 +125,7 @@ class PostItem extends React.Component {
 			isAllSitesModeSelected,
 			translate,
 			multiSelectEnabled,
+			hasExpandedContent,
 		} = this.props;
 
 		const title = post ? post.title : null;
@@ -137,10 +138,8 @@ class PostItem extends React.Component {
 
 		const isAuthorVisible = this.hasMultipleUsers() && post && post.author;
 
-		const expandedContent = this.renderExpandedContent();
-
 		const rootClasses = classnames( 'post-item', {
-			'is-expanded': !! expandedContent,
+			'is-expanded': !! hasExpandedContent,
 		} );
 
 		return (
@@ -187,7 +186,7 @@ class PostItem extends React.Component {
 					/>
 					{ ! multiSelectEnabled && <PostActionsEllipsisMenu globalId={ globalId } /> }
 				</div>
-				{ expandedContent }
+				{ hasExpandedContent && this.renderExpandedContent() }
 			</div>
 		);
 	}
@@ -205,7 +204,6 @@ PostItem.propTypes = {
 	singleUserQuery: PropTypes.bool,
 	className: PropTypes.string,
 	compact: PropTypes.bool,
-	isCurrentSharePanelOpen: PropTypes.bool,
 	hideSharePanel: PropTypes.func,
 	hasExpandedContent: PropTypes.bool,
 };
@@ -223,8 +221,7 @@ export default connect(
 		const externalPostLink = false === canCurrentUserEditPost( state, globalId );
 		const postUrl = externalPostLink ? post.URL : getEditorPath( state, siteId, post.ID );
 
-		const isCurrentSharePanelOpen = isSharePanelOpen( state, globalId );
-		const hasExpandedContent = isCurrentSharePanelOpen || false;
+		const hasExpandedContent = isSharePanelOpen( state, globalId ) || false;
 
 		return {
 			post,
@@ -233,7 +230,6 @@ export default connect(
 			isAllSitesModeSelected: getSelectedSiteId( state ) === null,
 			allSitesSingleUser: areAllSitesSingleUser( state ),
 			singleUserSite: isSingleUserSite( state, siteId ),
-			isCurrentSharePanelOpen,
 			hasExpandedContent,
 			isCurrentPostSelected: isPostSelected( state, globalId ),
 			multiSelectEnabled: isMultiSelectEnabled( state ),

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -76,11 +76,23 @@ class PostItem extends React.Component {
 		return this.inAllSitesModeWithMultipleUsers() || this.inSingleSiteModeWithMultipleUsers();
 	}
 
+	maybeScrollIntoView() {
+		const element = ReactDom.findDOMNode( this );
+		const viewportBottom = document.documentElement.clientHeight + window.scrollY;
+		const distanceFromBottom = viewportBottom - element.offsetTop;
+
+		if ( distanceFromBottom < 200 ) {
+			const desiredOffset = window.scrollY + ( 200 - distanceFromBottom );
+
+			window.scrollTo( 0, desiredOffset );
+		}
+	}
+
 	componentDidUpdate( prevProps ) {
 		const { hasExpandedContent } = this.props;
 
 		if ( ! prevProps.hasExpandedContent && hasExpandedContent ) {
-			ReactDom.findDOMNode( this ).scrollIntoView( false );
+			this.maybeScrollIntoView();
 		}
 	}
 

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -198,6 +198,7 @@ PostItem.propTypes = {
 	compact: PropTypes.bool,
 	isCurrentSharePanelOpen: PropTypes.bool,
 	hideSharePanel: PropTypes.func,
+	hasExpandedContent: PropTypes.bool,
 };
 
 export default connect(
@@ -213,6 +214,9 @@ export default connect(
 		const externalPostLink = false === canCurrentUserEditPost( state, globalId );
 		const postUrl = externalPostLink ? post.URL : getEditorPath( state, siteId, post.ID );
 
+		const isCurrentSharePanelOpen = isSharePanelOpen( state, globalId );
+		const hasExpandedContent = isCurrentSharePanelOpen || false;
+
 		return {
 			post,
 			externalPostLink,
@@ -220,7 +224,8 @@ export default connect(
 			isAllSitesModeSelected: getSelectedSiteId( state ) === null,
 			allSitesSingleUser: areAllSitesSingleUser( state ),
 			singleUserSite: isSingleUserSite( state, siteId ),
-			isCurrentSharePanelOpen: isSharePanelOpen( state, globalId ),
+			isCurrentSharePanelOpen,
+			hasExpandedContent,
 			isCurrentPostSelected: isPostSelected( state, globalId ),
 			multiSelectEnabled: isMultiSelectEnabled( state ),
 		};


### PR DESCRIPTION
This PR makes sure that the expanded `PostShare` is visible when the `PostItem` is at the bottom of the `/posts/` window.

**Before:** | **After:**
----------- | ----------
![expanded-before](https://user-images.githubusercontent.com/942359/34129475-465f0ab6-e412-11e7-8c53-6d581f3da16c.gif) | ![expanded-after](https://user-images.githubusercontent.com/942359/34129487-4ea8a1f0-e412-11e7-9078-f36fd9cd8923.gif)

**To test:**
- Use the calypso.live link.
- Navigate to your `/posts/` list.
- Expand a post item at the bottom of the screen by clicking "share" inside the ellipsis menu.
- Verify that the post item scrolls into view.
