### PR TITLE
Store Orders: List coupons in the totals section

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -65,9 +65,20 @@
 	}
 }
 
+.order-details__coupon-list {
+	.order-details__coupon-list-label {
+		text-align: left !important;
+	}
+
+	.order-details__coupon-list-title {
+		font-weight: bold;
+		margin-bottom: -6px;
+	}
+}
+
 // Duplicating `.table` for increased specificity
 .order-details__totals.table.table {
-	margin: 16px -24px;
+	margin: 8px -24px;
 	box-shadow: none;
 	border: none;
 	text-align: right;
@@ -92,7 +103,7 @@
 
 		td,
 		th {
-			border-top: 1px solid lighten($gray, 30%);
+			border-bottom: 1px solid lighten($gray, 30%);
 		}
 	}
 

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -173,14 +173,6 @@
 			color: $gray-text-min;
 			font-style: italic;
 		}
-
-		.order-details__coupon-list-tokens {
-			display: flex;
-
-			.token-field__token:first-child {
-				margin-left: 0;
-			}
-		}
 	}
 }
 

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -121,6 +121,13 @@
 
 		.table-item {
 			border-bottom: 1px solid lighten($gray, 30%);
+			padding-bottom: 16px;
+		}
+
+		& + .order-details__total-remaining {
+			.table-item {
+				padding-top: 16px;
+			}
 		}
 	}
 

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -65,38 +65,6 @@
 	}
 }
 
-.table.is-compact-table {
-	.order-details__coupon-list {
-		.order-details__coupon-list-label {
-			text-align: left !important;
-		}
-
-		.order-details__coupon-list-title {
-			font-weight: 600;
-			margin-bottom: -6px;
-		}
-
-		+ .order-details__total {
-			.table-item:first-child,
-			td {
-				padding-top: 16px;
-			}
-		}
-	}
-}
-
-.table.is-compact-table .table-item:first-child.order-details__coupon-list-label {
-	padding-left: 24px;
-	border-bottom: 1px solid lighten($gray, 30%);
-	padding-bottom: 16px;
-
-	& + .order-details__totals-value {
-		border-bottom: 1px solid lighten($gray, 30%);
-		padding-top: 0;
-		vertical-align: top;
-	}
-}
-
 // Duplicating `.table` for increased specificity
 .order-details__totals.table.table {
 	margin: 8px -24px;
@@ -119,11 +87,39 @@
 		font-size: 14px;
 	}
 
+	.order-details__coupon-list {
+		.table-item {
+			padding-left: 24px;
+			border-bottom: 1px solid lighten($gray, 30%);
+			padding-bottom: 16px;
+		}
+
+		.table-item:not(.is-row-heading) {
+			border-bottom: 1px solid lighten($gray, 30%);
+			padding-top: 0;
+			vertical-align: top;
+		}
+
+		.order-details__coupon-list-label {
+			text-align: left;
+		}
+
+		.order-details__coupon-list-title {
+			font-weight: 600;
+			margin-bottom: -6px;
+		}
+	}
+
+	.order-details__coupon-list + .order-details__total {
+		.table-item {
+			padding-top: 16px;
+		}
+	}
+
 	.order-details__total-refund {
 		color: $alert-red;
 
-		td,
-		th {
+		.table-item {
 			border-bottom: 1px solid lighten($gray, 30%);
 		}
 	}

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -65,14 +65,35 @@
 	}
 }
 
-.order-details__coupon-list {
-	.order-details__coupon-list-label {
-		text-align: left !important;
-	}
+.table.is-compact-table {
+	.order-details__coupon-list {
+		.order-details__coupon-list-label {
+			text-align: left !important;
+		}
 
-	.order-details__coupon-list-title {
-		font-weight: bold;
-		margin-bottom: -6px;
+		.order-details__coupon-list-title {
+			font-weight: 600;
+			margin-bottom: -6px;
+		}
+
+		+ .order-details__total {
+			.table-item:first-child,
+			td {
+				padding-top: 16px;
+			}
+		}
+	}
+}
+
+.table.is-compact-table .table-item:first-child.order-details__coupon-list-label {
+	padding-left: 24px;
+	border-bottom: 1px solid lighten($gray, 30%);
+	padding-bottom: 16px;
+
+	& + .order-details__totals-value {
+		border-bottom: 1px solid lighten($gray, 30%);
+		padding-top: 0;
+		vertical-align: top;
 	}
 }
 

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -166,6 +166,10 @@
 			color: $gray-text-min;
 			font-style: italic;
 		}
+
+		.order-details__coupon-list-tokens {
+			display: flex;
+		}
 	}
 }
 

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -51,7 +51,7 @@
 
 .order-details__actions {
 	margin: 0 -24px;
-	padding: 16px 76px 16px 24px;
+	padding: 16px 80px 16px 24px;
 	border-bottom: 1px solid lighten($gray, 30%);
 	text-align: right;
 
@@ -71,7 +71,6 @@
 	box-shadow: none;
 	border: none;
 	text-align: right;
-	padding-right: 55px;
 
 	& + .form-setting-explanation {
 		padding-right: 55px;
@@ -163,6 +162,7 @@
 		.order-details__totals-value {
 			// Increase width for PriceInput
 			width: 13em;
+			padding-right: 79px;
 		}
 
 		.form-text-input-with-affixes {

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -169,6 +169,10 @@
 
 		.order-details__coupon-list-tokens {
 			display: flex;
+
+			.token-field__token:first-child {
+				margin-left: 0;
+			}
 		}
 	}
 }

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -288,8 +288,9 @@ class OrderDetailsTable extends Component {
 			return null;
 		}
 
+		let couponMarkup;
 		if ( isEditing ) {
-			const couponMarkup = coupons.map( item => {
+			couponMarkup = coupons.map( item => {
 				if ( ! item.code ) {
 					return null;
 				}
@@ -316,7 +317,7 @@ class OrderDetailsTable extends Component {
 			);
 		}
 
-		const couponMarkup = coupons.map( ( item, i ) => {
+		couponMarkup = coupons.map( ( item, i ) => {
 			if ( ! item.code ) {
 				return null;
 			}

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -265,6 +265,9 @@ class OrderDetailsTable extends Component {
 		const { order, site, translate } = this.props;
 		const showTax = this.shouldShowTax();
 		const coupons = order.coupon_lines || [];
+		if ( parseFloat( order.discount_total ) <= 0 && ! order.coupon_lines.length ) {
+			return null;
+		}
 
 		const couponMarkup = coupons.map( ( item, i ) => {
 			const meta = find( get( item, 'meta_data', [] ), { key: 'coupon_data' } );

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -311,7 +311,7 @@ class OrderDetailsTable extends Component {
 						<div className="order-details__coupon-list-tokens">{ couponMarkup }</div>
 					</TableItem>
 					<TableItem className="order-details__totals-value">
-						{ formatCurrency( order.discount_total, order.currency ) }
+						{ formatCurrency( parseFloat( order.discount_total ) * -1, order.currency ) }
 					</TableItem>
 				</TableRow>
 			);
@@ -349,11 +349,11 @@ class OrderDetailsTable extends Component {
 				</TableItem>
 				{ showTax && (
 					<TableItem className="order-details__totals-tax">
-						{ formatCurrency( getOrderDiscountTax( order ), order.currency ) }
+						{ formatCurrency( getOrderDiscountTax( order ) * -1, order.currency ) }
 					</TableItem>
 				) }
 				<TableItem className="order-details__totals-value">
-					{ formatCurrency( order.discount_total, order.currency ) }
+					{ formatCurrency( parseFloat( order.discount_total ) * -1, order.currency ) }
 				</TableItem>
 			</TableRow>
 		);

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -16,7 +16,7 @@ import Button from 'components/button';
 import formatCurrency from 'lib/format-currency';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
-import { getCurrencyFormatDecimal, getCurrencyFormatString } from 'woocommerce/lib/currency';
+import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import {
 	getOrderDiscountTax,
@@ -143,25 +143,6 @@ class OrderDetailsTable extends Component {
 				newItem = { id, name: null, total: 0 };
 			}
 			this.props.onChange( { [ type ]: { [ index ]: newItem } } );
-		}
-	};
-
-	removeCoupon = item => () => {
-		const { coupon_lines, currency, discount_tax, discount_total } = this.props.order;
-		const index = findIndex( coupon_lines, { id: item.id } );
-		const getCurrencyDecimal = value => getCurrencyFormatDecimal( value, currency );
-		if ( index >= 0 ) {
-			const newItem = { id: item.id, code: null, discount: 0 };
-			const newDiscountTotal =
-				getCurrencyDecimal( discount_total ) - getCurrencyDecimal( item.discount );
-			const newDiscountTax =
-				getCurrencyDecimal( discount_tax ) - getCurrencyDecimal( item.discount_tax );
-			const orderChanges = {
-				coupon_lines: { [ index ]: newItem },
-				discount_total: getCurrencyFormatString( newDiscountTotal, currency ),
-				discount_tax: getCurrencyFormatString( newDiscountTax, currency ),
-			};
-			this.props.onChange( orderChanges );
 		}
 	};
 

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import { find, findIndex, get, identity, noop } from 'lodash';
+import { find, findIndex, get, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,7 +37,6 @@ import ScreenReaderText from 'components/screen-reader-text';
 import Table from 'woocommerce/components/table';
 import TableRow from 'woocommerce/components/table/table-row';
 import TableItem from 'woocommerce/components/table/table-item';
-import Token from 'components/token-field/token';
 
 class OrderDetailsTable extends Component {
 	static propTypes = {
@@ -280,44 +279,15 @@ class OrderDetailsTable extends Component {
 	};
 
 	renderCoupons = () => {
-		const { isEditing, order, site, translate } = this.props;
+		const { order, site, translate } = this.props;
 		const showTax = this.shouldShowTax();
 		const coupons = order.coupon_lines || [];
 		const hasCoupons = parseFloat( order.discount_total ) > 0 || order.coupon_lines.length > 0;
-		if ( ! isEditing && ! hasCoupons ) {
+		if ( ! hasCoupons ) {
 			return null;
 		}
 
-		let couponMarkup;
-		if ( isEditing ) {
-			couponMarkup = coupons.map( item => {
-				if ( ! item.code ) {
-					return null;
-				}
-				return (
-					<Token
-						key={ item.id }
-						value={ item.code }
-						displayTransform={ identity }
-						onClickRemove={ this.removeCoupon( item ) }
-					/>
-				);
-			} );
-
-			return (
-				<TableRow className="order-details__coupon-list">
-					<TableItem className="order-details__coupon-list-label" colSpan={ showTax ? 2 : 1 }>
-						<h3 className="order-details__coupon-list-title">{ translate( 'Coupons' ) }</h3>
-						<div className="order-details__coupon-list-tokens">{ couponMarkup }</div>
-					</TableItem>
-					<TableItem className="order-details__totals-value">
-						{ formatCurrency( parseFloat( order.discount_total ) * -1, order.currency ) }
-					</TableItem>
-				</TableRow>
-			);
-		}
-
-		couponMarkup = coupons.map( ( item, i ) => {
+		const couponMarkup = coupons.map( ( item, i ) => {
 			if ( ! item.code ) {
 				return null;
 			}

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -310,7 +310,7 @@ class OrderDetailsTable extends Component {
 						<div className="order-details__coupon-list-tokens">{ couponMarkup }</div>
 					</TableItem>
 					<TableItem className="order-details__totals-value">
-						({ formatCurrency( order.discount_total, order.currency ) })
+						{ formatCurrency( order.discount_total, order.currency ) }
 					</TableItem>
 				</TableRow>
 			);
@@ -348,11 +348,11 @@ class OrderDetailsTable extends Component {
 				</TableItem>
 				{ showTax && (
 					<TableItem className="order-details__totals-tax">
-						({ formatCurrency( getOrderDiscountTax( order ), order.currency ) })
+						{ formatCurrency( getOrderDiscountTax( order ), order.currency ) }
 					</TableItem>
 				) }
 				<TableItem className="order-details__totals-value">
-					({ formatCurrency( order.discount_total, order.currency ) })
+					{ formatCurrency( order.discount_total, order.currency ) }
 				</TableItem>
 			</TableRow>
 		);


### PR DESCRIPTION
This PR adds the applied coupons to the single order view, in place of the "Discounts" total label, to imply "these coupons discounted this amount". Also it fits better this way 😁 

<img width="608" alt="screen shot 2017-12-18 at 5 47 22 pm" src="https://user-images.githubusercontent.com/541093/34132029-0f512ff4-e41c-11e7-9c0e-bb4188bc78f6.png">

I've also added parenthesis around the discount total, because technically this amount has already been subtracted from the order subtotal (each product shows the post-coupon price). The discount total here is more of a reference number than a subtotal to be tallied. 

This does not touch the edit-state yet. I'm marking this as **In Progress** so that I can keep working there, but I'd like some designer input on whether this positioning is OK, @kellychoffman @jameskoster 

**To test**

1. Create an order with at least one coupon applied
2. View the order in calypso: `/store/order/:site/:orderId`
3. You should see the coupon applied, and the total discount granted
4. If we can tell which coupon this is, we'll link the code to the promotions edit screen - coupons applied via editing in wp-admin don't include the coupon ID in meta-data, so we can't create the link for those. given most orders are not created via wp-admin, this seems okay.