### PR TITLE
Post revisions: fix revision list navigation in IE

### DIFF
--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -91,8 +91,9 @@ class EditorRevisionsList extends PureComponent {
 		const targetWhenAbove = selectedTop - listTop;
 		const targetWhenBelow = Math.abs( scrollerHeight - ( selectedBottom - listTop ) );
 
-		isAboveBounds && scrollerNode.scrollTo( 0, targetWhenAbove );
-		isBelowBounds && scrollerNode.scrollTo( 0, targetWhenBelow );
+		if ( isAboveBounds || isBelowBounds ) {
+			scrollerNode.scrollTop = isAboveBounds ? targetWhenAbove : targetWhenBelow;
+		}
 	}
 
 	selectNextRevision = () => {


### PR DESCRIPTION
## This PR
- fixes an issue where clicking revision list items broke the site in IE
- fixes an issue with the keyboard navigation in IE

The Issue was caused by using [`window.scrollTo`](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo) on an element. Webkit based browsers and Firefox auto-correct the behavior and allow the use of `window.scrollTo` on an element as well. IE/Edge, on the other hand, is less forgiving. So in Edge, this caused an error that stopped further execution and thus prevented the revision content from being displayed. The straightforward solution to the problem is to use [`Element.scrollTop`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop) instead.

## How to test

- Open IE11 on Windows
(Tip: If you don't have a local version you can use our browserstack.com account.)
- Navigate to or create a post with a lot of revisions
- Click on the `History` button to trigger the Post Revisions modal
- Click on a revision in the revision list that is not fully visible
- Navigate through all items using j/k keyboard navigation
- The error shown in the before state below shouldn't occur anymore

**Before**

<img width="1156" alt="screen shot 2017-12-18 at 19 37 46" src="https://user-images.githubusercontent.com/1562646/34135612-cae52d20-e42f-11e7-8013-0d288c65d41f.png">
