### PR TITLE
Post revisions: fix spacing issue of revisions list items in Safari

### DIFF
--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -109,6 +109,7 @@
 	cursor: pointer;
 	text-align: left;
 	padding: 8px 16px;
+	margin: 0;
 	min-height: 73px;
 	width: 60vw;
 


### PR DESCRIPTION
## This PR
- fixes an issue where the spacing of the revisions list items was off in Safari

## How to test

- Use the calypso.live link or check out branch locally
- In Safari navigate to or create a post with revisions
- Click on the History button to trigger the Post Revisions modal
- The Post revisions list should look like the after state below

**Before:**
<img width="232" alt="screen shot 2017-12-18 at 21 15 19" src="https://user-images.githubusercontent.com/1562646/34138165-35f6d77e-e43c-11e7-8881-29a41c29729d.png">

**After:**
<img width="232" alt="screen shot 2017-12-18 at 21 13 55" src="https://user-images.githubusercontent.com/1562646/34138174-3d77bcde-e43c-11e7-8d85-b6d99e958d4a.png">
