### PR TITLE
Framework: Replace `config('env')` with `process.env.NODE_ENV

### DIFF
--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -11,7 +11,7 @@ export default {
 	getAll: function( selectedSite, siteCount ) {
 		let siteProps = {};
 		const defaultProps = {
-			environment: config( 'env' ),
+			environment: process.node.NODE_ENV,
 			site_count: siteCount || 0,
 			site_id_label: 'wpcom',
 			client: config( 'client_slug' ),

--- a/client/lib/analytics/super-props.js
+++ b/client/lib/analytics/super-props.js
@@ -11,7 +11,7 @@ export default {
 	getAll: function( selectedSite, siteCount ) {
 		let siteProps = {};
 		const defaultProps = {
-			environment: process.node.NODE_ENV,
+			environment: process.env.NODE_ENV,
 			site_count: siteCount || 0,
 			site_id_label: 'wpcom',
 			client: config( 'client_slug' ),

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -1,10 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
-import config from 'config';
 import { get, assign, forEach, isEqual, defer } from 'lodash';
 import debugModule from 'debug';
 
@@ -49,7 +46,7 @@ const FeedPostStore = {
 	},
 };
 
-if ( config( 'env' ) === 'development' ) {
+if ( process.env.NODE_ENV === 'development' ) {
 	assign( FeedPostStore, {
 		// These bedlumps are for testing.
 		// Ideally, we'd pull these out with envify for prod

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -46,7 +46,7 @@ const FeedPostStore = {
 	},
 };
 
-if ( process.env.NODE_ENV === 'development' ) {
+if ( process.env.NODE_ENV === 'test' ) {
 	assign( FeedPostStore, {
 		// These bedlumps are for testing.
 		// Ideally, we'd pull these out with envify for prod

--- a/client/lib/like-store/like-store.js
+++ b/client/lib/like-store/like-store.js
@@ -1,11 +1,8 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { assign, clone, isEqual } from 'lodash';
-import config from 'config';
 
 /**
  * Internal dependencies
@@ -172,7 +169,7 @@ LikeStore = {
 	},
 };
 
-if ( config( 'env' ) === 'development' ) {
+if ( process.env.NODE_ENV === 'development' ) {
 	assign( LikeStore, {
 		// These bedlumps are for testing.
 		// Ideally, we'd pull these out with envify for prod

--- a/client/lib/like-store/like-store.js
+++ b/client/lib/like-store/like-store.js
@@ -169,7 +169,7 @@ LikeStore = {
 	},
 };
 
-if ( process.env.NODE_ENV === 'development' ) {
+if ( process.env.NODE_ENV === 'test' ) {
 	assign( LikeStore, {
 		// These bedlumps are for testing.
 		// Ideally, we'd pull these out with envify for prod

--- a/client/lib/posts/stats.js
+++ b/client/lib/posts/stats.js
@@ -1,16 +1,13 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
 import debugModule from 'debug';
 import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import config from 'config';
 import analytics from 'lib/analytics';
 import PostEditStore from 'lib/posts/post-edit-store';
 import utils from 'lib/posts/utils';
@@ -114,7 +111,7 @@ export function recordSaveEvent( site, context ) {
 	} );
 }
 
-const shouldBumpStat = Math.random() <= 0.01 || config( 'env' ) === 'development';
+const shouldBumpStat = Math.random() <= 0.01 || process.env.NODE_ENV === 'development';
 const maybeBumpStat = shouldBumpStat ? analytics.mc.bumpStat : noop;
 
 export function recordTinyMCEButtonClick( buttonName ) {

--- a/client/lib/route/redirect.js
+++ b/client/lib/route/redirect.js
@@ -1,14 +1,11 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
 import page from 'page';
-import config from 'config';
 
 export default function redirect( path ) {
-	if ( config( 'env' ) === 'development' ) {
+	if ( process.env.NODE_ENV === 'development' ) {
 		throw 'route.redirect() is deprecated, use page.redirect()';
 	}
 

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -180,7 +180,7 @@ const communityTranslatorJumpstart = {
 		}
 
 		this.setInjectionURL( 'community-translator.min.js' );
-		if ( config( 'env' ) === 'production' ) {
+		if ( process.env.NODE_ENV === 'production' ) {
 			translationDataFromPage.glotPress.project = 'wpcom';
 		} else {
 			translationDataFromPage.glotPress.project = 'test';

--- a/client/lib/wp/sync-handler/index.js
+++ b/client/lib/wp/sync-handler/index.js
@@ -1,10 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
-import config from 'config';
 import debugFactory from 'debug';
 
 /**
@@ -57,7 +54,7 @@ export class SyncHandler {
 	 */
 	constructor( handler ) {
 		// expose `syncHandler` global var (dev mode)
-		if ( 'development' === config( 'env' ) && typeof window !== 'undefined' ) {
+		if ( 'development' === process.env.NODE_ENV && typeof window !== 'undefined' ) {
 			window.syncHandler = this;
 		}
 
@@ -318,6 +315,6 @@ export const clearAll = () => {
 };
 
 // expose `cacheIndex` global var (dev mode)
-if ( 'development' === config( 'env' ) && typeof window !== 'undefined' ) {
+if ( 'development' === process.env.NODE_ENV && typeof window !== 'undefined' ) {
 	window.cacheIndex = cacheIndex;
 }

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -478,7 +478,7 @@ class HelpContact extends React.Component {
 
 		switch ( variationSlug ) {
 			case SUPPORT_HAPPYCHAT:
-				const isDev = config( 'env' ) === 'development' || config( 'env_id' ) === 'stage';
+				const isDev = process.env.NODE_ENV === 'development' || config( 'env_id' ) === 'stage';
 				return {
 					onSubmit: this.startHappychat,
 					buttonLabel: isDev ? 'Happychat' : translate( 'Chat with us' ),

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -392,7 +392,7 @@ export class MySitesSidebar extends Component {
 
 		const countryCode = currentUser.user_ip_country_code;
 		const isCountryAllowed =
-			includes( allowedCountryCodes, countryCode ) || 'development' === config( 'env' );
+			includes( allowedCountryCodes, countryCode ) || 'development' === process.env.NODE_ENV;
 
 		return (
 			isCountryAllowed && (

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -182,7 +182,7 @@ const flows = {
 	},
 
 	'test-site': {
-		steps: config( 'env' ) === 'development' ? [ 'site', 'user' ] : [ 'user' ],
+		steps: process.env.NODE_ENV === 'development' ? [ 'site', 'user' ] : [ 'user' ],
 		destination: '/',
 		description: 'This flow is used to test the site step.',
 		lastModified: '2015-09-22',
@@ -309,7 +309,7 @@ if ( config.isEnabled( 'signup/domain-first-flow' ) ) {
 	};
 }
 
-if ( config( 'env' ) === 'development' ) {
+if ( process.env.NODE_ENV === 'development' ) {
 	flows[ 'test-plans' ] = {
 		steps: [ 'site', 'plans', 'user' ],
 		destination: getSiteDestination,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -1,10 +1,7 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
-import config from 'config';
 import AboutStepComponent from 'signup/steps/about';
 import CredsConfirmComponent from 'signup/steps/creds-confirm';
 import CredsCompleteComponent from 'signup/steps/creds-complete';
@@ -50,7 +47,7 @@ export default {
 	'site-title': SiteTitleComponent,
 	survey: SurveyStepComponent,
 	'survey-user': UserSignupComponent,
-	test: config( 'env' ) === 'development' ? require( 'signup/steps/test-step' ) : undefined,
+	test: process.env.NODE_ENV === 'development' ? require( 'signup/steps/test-step' ) : undefined,
 	themes: ThemeSelectionComponent,
 	'website-themes': ThemeSelectionComponent,
 	'blog-themes': ThemeSelectionComponent,

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -1,9 +1,7 @@
+/** @format */
 /**
  * External dependencies
- *
- * @format
  */
-
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -13,7 +11,6 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
 import formState from 'lib/form-state';
@@ -311,7 +308,7 @@ class AboutStep extends Component {
 
 		//Store
 		const isCountryAllowed =
-			includes( [ 'US', 'CA' ], this.props.countryCode ) || config( 'env' ) === 'development';
+			includes( [ 'US', 'CA' ], this.props.countryCode ) || process.env.NODE_ENV === 'development';
 		const nextFlowName =
 			designType === DESIGN_TYPE_STORE && isCountryAllowed
 				? 'segmented-store-nux'

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -10,7 +10,6 @@ import { includes, invoke } from 'lodash';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import StepWrapper from 'signup/step-wrapper';
 import Card from 'components/card';
 import { localize } from 'i18n-calypso';
@@ -110,7 +109,7 @@ class DesignTypeWithAtomicStoreStep extends Component {
 		this.props.recordTracksEvent( 'calypso_triforce_select_design', { category: designType } );
 
 		const isCountryAllowed =
-			includes( [ 'US', 'CA' ], this.props.countryCode ) || config( 'env' ) === 'development';
+			includes( [ 'US', 'CA' ], this.props.countryCode ) || process.env.NODE_ENV === 'development';
 
 		if (
 			designType === DESIGN_TYPE_STORE &&

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ server.listen( { port, host }, function() {
 } );
 
 // Enable hot reloader in development
-if ( config( 'env' ) === 'development' ) {
+if ( process.env.NODE_ENV === 'development' ) {
 	console.info( chalk.cyan( '\nGetting bundles ready, hold on...' ) );
 
 	hotReloader = require( 'bundler/hot-reloader' );

--- a/server/boot/index.js
+++ b/server/boot/index.js
@@ -30,7 +30,7 @@ function setup() {
 	app.use( cookieParser() );
 	app.use( userAgent.express() );
 
-	if ( 'development' === config( 'env' ) ) {
+	if ( 'development' === process.env.NODE_ENV ) {
 		// use legacy CSS rebuild system if css-hot-reload is disabled
 		if ( ! config.isEnabled( 'css-hot-reload' ) ) {
 			// only do `build` upon every request in "development"
@@ -93,7 +93,7 @@ function setup() {
 	} );
 
 	// serve files when not in production so that the source maps work correctly
-	if ( 'development' === config( 'env' ) ) {
+	if ( 'development' === process.env.NODE_ENV ) {
 		app.use( '/assets', express.static( path.resolve( __dirname, '..', '..', 'assets' ) ) );
 		app.use( '/client', express.static( path.resolve( __dirname, '..', '..', 'client' ) ) );
 	}

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -177,7 +177,7 @@ function getDefaultContext( request ) {
 		config.isEnabled( 'try/single-cdn' ) && !! request.query.enableSingleCDN;
 
 	const context = Object.assign( {}, request.context, {
-		compileDebug: config( 'env' ) === 'development' ? true : false,
+		compileDebug: process.env.NODE_ENV === 'development',
 		urls: generateStaticUrls(),
 		user: false,
 		env: calypsoEnv,
@@ -421,7 +421,7 @@ module.exports = function() {
 		res.redirect( redirectUrl );
 	} );
 
-	if ( config( 'env' ) !== 'development' ) {
+	if ( process.env.NODE_ENV !== 'development' ) {
 		app.get( '/discover', function( req, res, next ) {
 			if ( ! req.cookies.wordpress_logged_in ) {
 				res.redirect( config( 'discover_logged_out_redirect_url' ) );

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -37,7 +37,7 @@ const markupCache = new Lru( {
 function bumpStat( group, name ) {
 	const statUrl = `http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_${ group }=${ name }&t=${ Math.random() }`;
 
-	if ( config( 'env' ) === 'production' ) {
+	if ( process.env.NODE_ENV === 'production' ) {
 		superagent.get( statUrl ).end();
 	}
 }
@@ -72,7 +72,7 @@ export function render( element, key = JSON.stringify( element ) ) {
 
 		return renderedLayout;
 	} catch ( ex ) {
-		if ( config( 'env' ) === 'development' ) {
+		if ( process.env.NODE_ENV === 'development' ) {
 			throw ex;
 		}
 	}
@@ -145,7 +145,7 @@ export function serverRender( req, res ) {
 
 export function serverRenderError( err, req, res, next ) {
 	if ( err ) {
-		if ( config( 'env' ) !== 'production' ) {
+		if ( process.env.NODE_ENV !== 'production' ) {
 			console.error( err );
 		}
 		req.error = err;

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -19,6 +19,7 @@ const _ = require( 'lodash' );
  */
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( 'config' );
+const bundleEnv = config( 'env' );
 
 /**
  * This lists modules that must use commonJS `require()`s
@@ -133,6 +134,7 @@ const webpackConfig = {
 		} ),
 		new webpack.DefinePlugin( {
 			PROJECT_NAME: JSON.stringify( config( 'project' ) ),
+			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
 		} ),
 		new HappyPack( { loaders: [ babelLoader ] } ),
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]abtest$/, 'lodash/noop' ), // Depends on BOM


### PR DESCRIPTION
A webpack plugin defines `process.env.NODE_ENV` to equal the value of
`config('env')` when building Calypso. The value of `config('env')`
though in source code is only readable at runtime while the value of
`process.env.NODE_ENV` is knowable at build-time.

Because of this, if we use `process.env.NODE_ENV` we can rely on webpack
and uglify to prevent deploying code into production which is only
necessary in development.

By making this change we can update all those cases relying on runtime
information because they unnecessarily pull in additional code and
libraries we don't need.

**Testing**

Need to smoke-test this in `development` _and_ in `production` environments.
We should compare the size of the built bundles and confirm that this removes
code.
We should also check in the changed files in both environments to make sure
that nothing breaks with the change of the constant import.