### PR TITLE
Trigger social links guided tour from checklist

### DIFF
--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -111,7 +111,7 @@ const tasks = {
 		duration: '2 mins',
 		completedTitle: 'You added your social accounts.',
 		completedButtonText: 'Change',
-		url: '/customize/$siteSlug',
+		url: '/customize/$siteSlug?guide=social-media',
 		image: '/calypso/images/stats/tasks/social-links.svg',
 	},
 };


### PR DESCRIPTION
This PR adds a guided tour triggered from the onboarding checklist.

# Testing

* Visit `/checklist/<domain>` for your site
* Click 'Do It' for the social links task (whether completed or not - the tour should show)
* Verify that the customizer is launched and shows the tour.