### PR TITLE
Themes: make live demo link work with modifier keys

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -199,18 +199,25 @@ class ThemeSheet extends React.Component {
 		return null;
 	};
 
-	previewAction = () => {
+	previewAction = event => {
+		if ( event.altKey || event.ctrlKey || event.metaKey || event.shiftKey ) {
+			return;
+		}
+		event.preventDefault();
+
 		const { preview } = this.props.options;
 		this.props.setThemePreviewOptions( this.props.defaultOption, this.props.secondaryOption );
 		return preview.action( this.props.id );
 	};
 
-	renderPreviewButton = () => {
+	renderPreviewButton = demo_uri => {
 		return (
 			<a
 				className="theme__sheet-preview-link"
 				onClick={ this.previewAction }
 				data-tip-target="theme-sheet-preview"
+				href={ demo_uri }
+				rel="noopener noreferrer"
 			>
 				<span className="theme__sheet-preview-link-text">
 					{ i18n.translate( 'Open Live Demo', {
@@ -231,7 +238,7 @@ class ThemeSheet extends React.Component {
 		if ( demo_uri && ! retired ) {
 			return (
 				<div className="theme__sheet-screenshot is-active" onClick={ this.previewAction }>
-					{ isActive ? null : this.renderPreviewButton() }
+					{ isActive ? null : this.renderPreviewButton( demo_uri ) }
 					{ img }
 				</div>
 			);


### PR DESCRIPTION
On the detail page for a theme, there is a link to "Open Live Demo" for the theme. This opens a Calypso preview modal. 

As suggested here, it would be nice to be able to Command-/Alt-/Meta-click that link and have the demo site open up in a new tab: https://github.com/Automattic/wp-calypso/issues/20664#issuecomment-352525412

This PR implements that behavior. Fixes #20664. Fixes #20889. 

To test: 
- visit the detail page for a theme
- click "Open Live Demo"
- make sure the Calypso-based preview for the theme opens
- close the preview
- click "Open Live Demo" but hold down a modifier key (alt, ctrl, shift, or meta (Command / Windows))
- make sure the theme's demo site opens in a new tab