### PR TITLE
Docs: update performance page

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -3,3 +3,4 @@ Performance
 
 - React Docs: [Optimizing Performance](https://reactjs.org/docs/optimizing-performance.html)
 - [Debugging React performance with React 16 and Chrome Devtools](https://building.calibreapp.com/debugging-react-performance-with-react-16-and-chrome-devtools-c90698a522ad)
+- Chrome DevTools Docs: [Analyze Runtime Performance](https://developers.google.com/web/tools/chrome-devtools/rendering-tools/)

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,7 +1,5 @@
 Performance
 ===========
 
-Performance Tools
------------------
-
-React offers [Performance Tools](http://facebook.github.io/react/docs/perf.html) that help you get an overview of your app's overall performance. The documentation is fairly complete and should help you get quickly started.
+- React Docs: [Optimizing Performance](https://reactjs.org/docs/optimizing-performance.html)
+- [Debugging React performance with React 16 and Chrome Devtools](https://building.calibreapp.com/debugging-react-performance-with-react-16-and-chrome-devtools-c90698a522ad)


### PR DESCRIPTION
As of [React 16 upgrade](https://github.com/Automattic/wp-calypso/projects/49), `react-addons-perf` [is not supported](http://facebook.github.io/react/docs/perf.html).