### PR TITLE
Store - Replaced relative imports of the request module with absolute paths

### DIFF
--- a/client/extensions/woocommerce/state/sites/currencies/actions.js
+++ b/client/extensions/woocommerce/state/sites/currencies/actions.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import request from '../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../status/wc-api/actions';
 import {
 	WOOCOMMERCE_CURRENCIES_REQUEST,

--- a/client/extensions/woocommerce/state/sites/locations/actions.js
+++ b/client/extensions/woocommerce/state/sites/locations/actions.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import request from '../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../status/wc-api/actions';
 import {
 	WOOCOMMERCE_LOCATIONS_REQUEST,

--- a/client/extensions/woocommerce/state/sites/orders/notes/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/notes/actions.js
@@ -6,7 +6,7 @@
 
 import { areOrderNotesLoaded, areOrderNotesLoading } from './selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import request from '../../request';
+import request from 'woocommerce/state/sites/request';
 import {
 	WOOCOMMERCE_ORDER_NOTE_CREATE,
 	WOOCOMMERCE_ORDER_NOTE_CREATE_SUCCESS,

--- a/client/extensions/woocommerce/state/sites/payment-methods/actions.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/actions.js
@@ -6,7 +6,7 @@
 
 import getPaymentMethodDetails from '../../../lib/get-payment-method-details';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import request from '../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../status/wc-api/actions';
 import {
 	WOOCOMMERCE_PAYMENT_METHOD_UPDATE,

--- a/client/extensions/woocommerce/state/sites/products/actions.js
+++ b/client/extensions/woocommerce/state/sites/products/actions.js
@@ -9,7 +9,7 @@ import { isArray } from 'lodash';
  */
 import { DEFAULT_QUERY, getNormalizedProductsQuery } from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import request from '../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../status/wc-api/actions';
 import {
 	WOOCOMMERCE_PRODUCTS_REQUEST,

--- a/client/extensions/woocommerce/state/sites/settings/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/actions.js
@@ -5,7 +5,7 @@
  */
 
 import { getSelectedSiteId } from 'state/ui/selectors';
-import request from '../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../status/wc-api/actions';
 import {
 	WOOCOMMERCE_SETTINGS_BATCH_REQUEST,

--- a/client/extensions/woocommerce/state/sites/settings/email/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/actions.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import request from '../../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../../status/wc-api/actions';
 import {
 	WOOCOMMERCE_EMAIL_SETTINGS_REQUEST,

--- a/client/extensions/woocommerce/state/sites/settings/general/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/actions.js
@@ -5,7 +5,7 @@
  */
 
 import { getSelectedSiteId } from 'state/ui/selectors';
-import request from '../../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../../status/wc-api/actions';
 import {
 	WOOCOMMERCE_TAXES_ENABLED_UPDATE,

--- a/client/extensions/woocommerce/state/sites/settings/mailchimp/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/mailchimp/actions.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import request from '../../request';
+import request from 'woocommerce/state/sites/request';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	WOOCOMMERCE_MAILCHIMP_API_KEY_SUBMIT_FAILURE,

--- a/client/extensions/woocommerce/state/sites/settings/products/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/products/actions.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import request from '../../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../../status/wc-api/actions';
 import {
 	WOOCOMMERCE_SETTINGS_PRODUCTS_UPDATE_REQUEST,

--- a/client/extensions/woocommerce/state/sites/settings/stripe-connect-account/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/stripe-connect-account/actions.js
@@ -21,7 +21,7 @@ import {
 	WOOCOMMERCE_SETTINGS_STRIPE_CONNECT_ACCOUNT_OAUTH_CONNECT_COMPLETE,
 } from 'woocommerce/state/action-types';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import request from '../../request';
+import request from 'woocommerce/state/sites/request';
 
 /**
  * Action Creator: Clear any error from a previous action.

--- a/client/extensions/woocommerce/state/sites/settings/tax/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/tax/actions.js
@@ -6,7 +6,7 @@
 
 import { areTaxSettingsLoaded, areTaxSettingsLoading } from './selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import request from '../../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../../status/wc-api/actions';
 import {
 	WOOCOMMERCE_SETTINGS_TAX_BATCH_REQUEST,

--- a/client/extensions/woocommerce/state/sites/setup-choices/actions.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/actions.js
@@ -6,7 +6,7 @@
 
 import { areSetupChoicesLoaded, areSetupChoicesLoading } from './selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import request from '../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../status/wc-api/actions';
 import {
 	WOOCOMMERCE_SETUP_CHOICE_UPDATE_REQUEST,

--- a/client/extensions/woocommerce/state/sites/shipping-methods/actions.js
+++ b/client/extensions/woocommerce/state/sites/shipping-methods/actions.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import request from '../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../status/wc-api/actions';
 import {
 	WOOCOMMERCE_SHIPPING_METHODS_REQUEST,

--- a/client/extensions/woocommerce/state/sites/shipping-zone-locations/actions.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-locations/actions.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import request from '../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../status/wc-api/actions';
 import {
 	WOOCOMMERCE_SHIPPING_ZONE_LOCATIONS_REQUEST,

--- a/client/extensions/woocommerce/state/sites/shipping-zone-methods/actions.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zone-methods/actions.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import request from '../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../status/wc-api/actions';
 import {
 	WOOCOMMERCE_SHIPPING_ZONE_METHOD_CREATE,

--- a/client/extensions/woocommerce/state/sites/shipping-zones/actions.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zones/actions.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import request from '../request';
+import request from 'woocommerce/state/sites/request';
 import { setError } from '../status/wc-api/actions';
 import {
 	WOOCOMMERCE_SHIPPING_ZONE_CREATE,

--- a/client/extensions/woocommerce/state/sites/test/request.js
+++ b/client/extensions/woocommerce/state/sites/test/request.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import request from '../request';
+import request from 'woocommerce/state/sites/request';
 import useNock from 'test/helpers/use-nock';
 
 describe( 'request', () => {


### PR DESCRIPTION
The WooCommerce Services plugin imports components and state library from Calypso. However, some of the Calypso-specific files need to be stubbed. One of these is `request.js` which gets replaced with a simpler file that makes requests directly to the REST endpoints of the site. This is achieved through Webpack config.

But if the file is imported via relative paths, the config doesn't replace it with the stub.

This PR replaces the `request` imports using the relative paths with absolute paths.

Related PR: https://github.com/Automattic/woocommerce-services/pull/1268

To test:
* everything should work as before
* unit tests should pass