### PR TITLE
Jetpack Onboarding: Add PageViewTracker to all steps

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -16,6 +16,8 @@ import FormattedHeader from 'components/formatted-header';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 	state = {
@@ -54,6 +56,11 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		return (
 			<Fragment>
 				<DocumentHead title={ translate( 'Business Address ‹ Jetpack Onboarding' ) } />
+				<PageViewTracker
+					path={ '/jetpack/onboarding/' + STEPS.BUSINESS_ADDRESS + '/:site' }
+					title="Business Address ‹ Jetpack Onboarding"
+				/>
+
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<Card className="steps__form">

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -12,8 +12,10 @@ import { localize } from 'i18n-calypso';
  */
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
+import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class JetpackOnboardingContactFormStep extends React.PureComponent {
@@ -29,6 +31,10 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 		return (
 			<Fragment>
 				<DocumentHead title={ translate( 'Contact Form ‹ Jetpack Onboarding' ) } />
+				<PageViewTracker
+					path={ '/jetpack/onboarding/' + STEPS.CONTACT_FORM + '/:site' }
+					title="Contact Form ‹ Jetpack Onboarding"
+				/>
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -12,8 +12,10 @@ import { localize } from 'i18n-calypso';
  */
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
+import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingHomepageStep extends React.PureComponent {
@@ -36,6 +38,10 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 		return (
 			<Fragment>
 				<DocumentHead title={ translate( 'Homepage ‹ Jetpack Onboarding' ) } />
+				<PageViewTracker
+					path={ '/jetpack/onboarding/' + STEPS.HOMEPAGE + '/:site' }
+					title="Homepage ‹ Jetpack Onboarding"
+				/>
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -18,6 +18,8 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingSiteTitleStep extends React.PureComponent {
@@ -51,6 +53,11 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 		return (
 			<Fragment>
 				<DocumentHead title={ translate( 'Site Title ‹ Jetpack Onboarding' ) } />
+				<PageViewTracker
+					path={ '/jetpack/onboarding/' + STEPS.SITE_TITLE + '/:site' }
+					title="Site Title ‹ Jetpack Onboarding"
+				/>
+
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<Card className="steps__form">

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -11,8 +11,10 @@ import { localize } from 'i18n-calypso';
  */
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
+import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 	render() {
@@ -23,6 +25,10 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 		return (
 			<Fragment>
 				<DocumentHead title={ translate( 'Site Type ‹ Jetpack Onboarding' ) } />
+				<PageViewTracker
+					path={ '/jetpack/onboarding/' + STEPS.SITE_TYPE + '/:site' }
+					title="Site Type ‹ Jetpack Onboarding"
+				/>
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -14,6 +14,8 @@ import { map } from 'lodash';
 import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
 	renderCompleted = () => {
@@ -66,6 +68,10 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 		return (
 			<Fragment>
 				<DocumentHead title={ translate( 'Summary ‹ Jetpack Onboarding' ) } />
+				<PageViewTracker
+					path={ '/jetpack/onboarding/' + STEPS.SUMMARY + '/:site' }
+					title="Summary ‹ Jetpack Onboarding"
+				/>
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<div className="steps__summary-columns">

--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
+import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
@@ -24,6 +25,7 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 
 		return (
 			<Fragment>
+				<DocumentHead title={ translate( 'WooCommerce ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
 					path={ '/jetpack/onboarding/' + STEPS.WOOCOMMERCE + '/:site' }
 					title="WooCommerce ‹ Jetpack Onboarding"

--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -11,6 +11,8 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import FormattedHeader from 'components/formatted-header';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 	render() {
@@ -22,6 +24,11 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 
 		return (
 			<Fragment>
+				<PageViewTracker
+					path={ '/jetpack/onboarding/' + STEPS.WOOCOMMERCE + '/:site' }
+					title="WooCommerce ‹ Jetpack Onboarding"
+				/>
+
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<div className="steps__button-group">


### PR DESCRIPTION
This PR adds a `PageViewTracker` to all steps so we can adequately track page views of each step. In addition, it adds `DocumentHead` to 2 of the steps where it was missing.

To test:
* Checkout this branch
* Start the onboarding flow (as instructed in #20906).
* Call this in your browser console: `localStorage.setItem('debug', 'calypso:analytics:tracks' )`
* Go through each step and verify you can see the right page view event being recorded.
* Verify the document title is properly set on the WooCommerce and Summary steps.