### PR TITLE
Store: Fix react warning for quantity field

### DIFF
--- a/client/extensions/woocommerce/app/products/product-form-simple-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-simple-card.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { isNull } from 'lodash';
+import { isNull, isUndefined } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -97,7 +97,7 @@ const ProductFormSimpleCard = ( { siteId, product, editProduct, translate } ) =>
 	} );
 
 	const { stock_quantity } = product;
-	const quantity = ! isNull( stock_quantity ) ? stock_quantity : '';
+	const quantity = isNull( stock_quantity ) || isUndefined( stock_quantity ) ? '' : stock_quantity;
 
 	const renderStock = () => (
 		<Card className={ stockClasses }>


### PR DESCRIPTION
This fixes a warning from React about changing a component from managed
to unmanaged as `undefined` was being passed as a value to the field.

To test:

1. Edit a product and update it.
2. Click the "Add" button for a new product in the sidebar.
3. Verify no React warnings for managed/unmanaged components in the console.

Note: I found this issue while looking at #20490 and this PR doesn't solve that issue, only the extra warning I found here.

Fixes #19438