### PR TITLE
Jetpack Connect: Show placeholder while plans page is loading

### DIFF
--- a/client/jetpack-connect/plans-placeholder.js
+++ b/client/jetpack-connect/plans-placeholder.js
@@ -1,0 +1,36 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Main from 'components/main';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+const placeholderContent = (
+	<Main wideLayout>
+		<div className="jetpack-connect__plans placeholder">
+			<header className="formatted-header">
+				<h1 className="formatted-header__title">
+					<span className="placeholder-text">Your site is now connected!</span>
+				</h1>
+				<p className="formatted-header__subtitle">
+					<span className="placeholder-text">Now pick a plan that's right for you.</span>
+				</p>
+			</header>
+			<Card>
+				<div className="jetpack-connect-plans-placeholder__plans-content" />
+			</Card>
+		</div>
+	</Main>
+);
+/* eslint-enable wpcalypso/jsx-classname-namespace */
+
+export default function PlansPlaceholder() {
+	return placeholderContent;
+}

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import page from 'page';
 import { connect } from 'react-redux';
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
+import Placeholder from './plans-placeholder';
 import { clearPlan, isCalypsoStartedConnection, retrievePlan } from './persistence-utils';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
@@ -168,11 +168,10 @@ class Plans extends Component {
 
 		if ( this.shouldShowPlaceholder() ) {
 			return (
-				<div>
+				<Fragment>
 					<QueryPlans />
-					<h1 className="jetpack-connect__plans-placeholder-title">Loading...</h1>
-					<Card className="jetpack-connect__plans-placeholder-card" />
-				</div>
+					<Placeholder />
+				</Fragment>
 			);
 		}
 

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -155,13 +155,16 @@ class Plans extends Component {
 		this.redirect( '/checkout/' );
 	};
 
-	shouldShowPlaceholder = () =>
-		this.redirecting ||
-		this.props.selectedPlanSlug ||
-		false !== this.props.notJetpack ||
-		! this.props.canPurchasePlans ||
-		false !== this.props.hasPlan ||
-		false !== this.props.isAutomatedTransfer;
+	shouldShowPlaceholder() {
+		return (
+			this.redirecting ||
+			this.props.selectedPlanSlug ||
+			false !== this.props.notJetpack ||
+			! this.props.canPurchasePlans ||
+			false !== this.props.hasPlan ||
+			false !== this.props.isAutomatedTransfer
+		);
+	}
 
 	render() {
 		const { interval, isRtlLayout, selectedSite, translate } = this.props;

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -155,27 +155,18 @@ class Plans extends Component {
 		this.redirect( '/checkout/' );
 	};
 
-	render() {
-		const {
-			canPurchasePlans,
-			hasPlan,
-			interval,
-			isAutomatedTransfer,
-			isRtlLayout,
-			notJetpack,
-			selectedPlanSlug,
-			selectedSite,
-			translate,
-		} = this.props;
+	shouldShowPlaceholder = () =>
+		this.redirecting ||
+		this.props.selectedPlanSlug ||
+		false !== this.props.notJetpack ||
+		! this.props.canPurchasePlans ||
+		false !== this.props.hasPlan ||
+		false !== this.props.isAutomatedTransfer;
 
-		if (
-			this.redirecting ||
-			selectedPlanSlug ||
-			false !== notJetpack ||
-			! canPurchasePlans ||
-			false !== hasPlan ||
-			false !== isAutomatedTransfer
-		) {
+	render() {
+		const { interval, isRtlLayout, selectedSite, translate } = this.props;
+
+		if ( this.shouldShowPlaceholder() ) {
 			return (
 				<div>
 					<QueryPlans />

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import { clearPlan, isCalypsoStartedConnection, retrievePlan } from './persistence-utils';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
@@ -175,7 +176,13 @@ class Plans extends Component {
 			false !== hasPlan ||
 			false !== isAutomatedTransfer
 		) {
-			return <QueryPlans />;
+			return (
+				<div>
+					<QueryPlans />
+					<h1 className="jetpack-connect__plans-placeholder-title">Loading...</h1>
+					<Card className="jetpack-connect__plans-placeholder-card" />
+				</div>
+			);
 		}
 
 		const helpButtonLabel = translate( 'Need help?' );

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -178,7 +178,7 @@ class Plans extends Component {
 		const helpButtonLabel = translate( 'Need help?' );
 
 		return (
-			<div>
+			<Fragment>
 				<QueryPlans />
 				{ selectedSite && <QuerySitePlans siteId={ selectedSite.ID } /> }
 				<PlansGrid
@@ -199,7 +199,7 @@ class Plans extends Component {
 						</JetpackConnectHappychatButton>
 					</LoggedOutFormLinks>
 				</PlansGrid>
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -526,19 +526,14 @@
 	}
 }
 
-.jetpack-connect__plans-placeholder-title {
-	margin: 30px auto 20px;
-	width: 280px;
-	height: 100px;
-	margin-bottom: 40px;
-	@include placeholder();
-}
-
-.jetpack-connect__plans-placeholder-card {
-	width: 960px;
-	height: 400px;
-	box-shadow: none;
-	@include placeholder();
+.jetpack-connect__plans.placeholder {
+	.placeholder-text,
+	.jetpack-connect-plans-placeholder__plans-content {
+		@include placeholder();
+	}
+	.jetpack-connect-plans-placeholder__plans-content {
+		min-height: 400px;
+	}
 }
 
 .jetpack-connect__auth-form-header-image {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -528,6 +528,21 @@
 	}
 }
 
+.jetpack-connect__plans-placeholder-title {
+	margin: 30px auto 20px;
+	width: 280px;
+	height: 100px;
+	margin-bottom: 40px;
+	@include placeholder();
+}
+
+.jetpack-connect__plans-placeholder-card {
+	width: 960px;
+	height: 400px;
+	box-shadow: none;
+	@include placeholder();
+}
+
 .jetpack-connect__auth-form-header-image {
 	text-align: center;
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1,3 +1,4 @@
+/** @format */
 .jetpack-connect__main {
 	max-width: 400px;
 
@@ -5,7 +6,7 @@
 		max-width: 100%;
 	}
 
-	.formatted-header{
+	.formatted-header {
 		margin-bottom: 16px;
 	}
 }
@@ -50,7 +51,6 @@
 
 .jetpack-connect__site-url-input-container,
 .example-components__site-url-input-container {
-
 	.jetpack-connect__site-address-container,
 	.example-components__site-address-container {
 		position: relative;
@@ -59,7 +59,7 @@
 			position: absolute;
 			top: 8px;
 			left: 8px;
-			color: lighten( $gray, 20% );
+			color: lighten($gray, 20%);
 		}
 
 		.form-text-input {
@@ -111,23 +111,23 @@
 	flex-direction: column;
 	flex-wrap: wrap;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		flex-direction: row;
 	}
 }
 
 .jetpack-connect__install-step {
 	display: flex;
-		flex-direction: column;
-		justify-content: space-between;
+	flex-direction: column;
+	justify-content: space-between;
 	min-width: 320px;
 	text-align: left;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		max-width: 360px;
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoint( '>660px' ) {
 		margin: 0 8px 16px 8px;
 	}
 }
@@ -149,14 +149,13 @@
 	width: 100%;
 
 	&:hover > div {
-		box-shadow: 0 0 0 1px $gray,
-					0 2px 4px lighten( $gray, 20% );
+		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten($gray, 20%);
 	}
 }
 
 .example-components__browser-chrome {
 	padding: 8px;
-	background-color: lighten( $gray, 30% );
+	background-color: lighten($gray, 30%);
 	border-radius: 8px 8px 0 0;
 }
 
@@ -168,7 +167,7 @@
 .example-components__browser-chrome-dot {
 	display: inline-block;
 	margin-right: 8px;
-	background-color: lighten( $gray, 10% );
+	background-color: lighten($gray, 10%);
 	width: 8px;
 	height: 8px;
 	border-radius: 50%;
@@ -178,14 +177,13 @@
 	position: relative;
 	margin: 0;
 	line-height: 0;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize(lighten($gray, 20%), 0.5), 0 1px 2px lighten($gray, 30%);
 }
 
 .example-components__install-plugin-header {
 	width: 100%;
 	padding-bottom: 12%;
-	background-color: #8CC258; //Jetpack Green
+	background-color: #8cc258; //Jetpack Green
 }
 
 .example-components__install-plugin-body {
@@ -195,12 +193,12 @@
 
 .example-components__install-plugin-footer {
 	position: absolute;
-		right: 0;
-		bottom: 0;
-		left: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
 	padding: 9px 16px;
 	text-align: right;
-	background-color: #F3F3F3;
+	background-color: #f3f3f3;
 }
 
 .example-components__install-plugin-footer-button {
@@ -209,23 +207,23 @@
 	padding: 7px 14px;
 	line-height: 1;
 	color: $white;
-	background-color: #008EC2; // wp-admin button blue
+	background-color: #008ec2; // wp-admin button blue
 	border: 1px solid #006799;
 	border-radius: 3px;
 }
 
 .example-components__activate-jetpack {
-	background-color: #F1F1F1;
+	background-color: #f1f1f1;
 }
 
 .example-components__connect-jetpack {
-	background-color: #F1F1F1;
+	background-color: #f1f1f1;
 }
 
 .example-components__content-wp-admin-masterbar {
 	width: 100%;
 	padding-bottom: 6%;
-	background-color: #23282D;
+	background-color: #23282d;
 }
 
 .example-components__content-wp-admin-sidebar {
@@ -233,7 +231,7 @@
 	width: 15%;
 	padding-bottom: 44%;
 	line-height: 0;
-	background-color: #23282D;
+	background-color: #23282d;
 }
 
 .example-components__content-wp-admin-main {
@@ -244,7 +242,6 @@
 }
 
 .example-components__connect-jetpack {
-
 	.example-components__content-wp-admin-plugin-name {
 		font-size: 14px;
 		margin-bottom: 8px;
@@ -263,19 +260,18 @@
 		padding: 7px 14px;
 		line-height: 1;
 		color: $white;
-		background-color: #008EC2; // wp-admin button blue
+		background-color: #008ec2; // wp-admin button blue
 		border: 1px solid #006799;
 		border-radius: 3px;
 	}
 }
 
 .example-components__connect-jetpack.is-legacy {
-
 	.example-components__content-wp-admin-connect-banner {
 		margin: 10px;
 		padding: 12px 10px 16px 10px;
 		text-align: right;
-		background-color: #81A844;
+		background-color: #81a844;
 		border-left: 0;
 	}
 
@@ -285,10 +281,10 @@
 		line-height: 1;
 		padding: 11px 10px;
 		color: $white;
-		background-color: #518D2A;
-		border-color: #518D2A;
+		background-color: #518d2a;
+		border-color: #518d2a;
 		border-radius: 4px;
-		box-shadow: 0 2px 3px 0 rgba( 0, 0, 0, .2 ), 0 4px 0 0 #3E6C20;
+		box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.2), 0 4px 0 0 #3e6c20;
 	}
 }
 
@@ -304,7 +300,7 @@
 
 .example-components__content-wp-admin-plugin-activate-link {
 	font-size: 12px;
-	color: #0073AA;
+	color: #0073aa;
 }
 
 .example-components__content-wp-admin-activate-view {
@@ -313,11 +309,13 @@
 
 .example-components__content-wp-admin-activate-link {
 	font-size: 12px;
-	color: #0073AA;
+	color: #0073aa;
 	text-decoration: underline;
 }
 
-.example-components__site-url-input-container .example-components__site-address-container .example-components__browser-chrome-url {
+.example-components__site-url-input-container
+	.example-components__site-address-container
+	.example-components__browser-chrome-url {
 	height: 40px;
 	font-size: 12px;
 	color: $gray;
@@ -332,7 +330,7 @@
 	margin: 0 auto 16px;
 }
 
-.jetpack-connect__sso-log-in-as{
+.jetpack-connect__sso-log-in-as {
 	font-family: $sans;
 	font-size: 21px;
 	font-weight: 300;
@@ -344,7 +342,7 @@
 }
 
 .jetpack-connect__sso-user-email {
-	color: lighten( $gray, 10% );
+	color: lighten($gray, 10%);
 	font-weight: 400;
 	text-align: center;
 }
@@ -380,13 +378,13 @@
 }
 
 .jetpack-connect__connect-button-card {
-	background: lighten( $gray, 34% );
-	border-top: 1px solid lighten( $gray, 30% );
+	background: lighten($gray, 34%);
+	border-top: 1px solid lighten($gray, 30%);
 	box-shadow: none;
 	margin: 16px -16px -16px -16px;
 	padding: 16px;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		margin: 24px -24px -24px -24px;
 		padding: 24px;
 	}
@@ -430,7 +428,7 @@
 	padding-bottom: 8px;
 }
 
-@include breakpoint( "<480px" ) {
+@include breakpoint( '<480px' ) {
 	.jetpack-connect__sso-shared-detail-label,
 	.jetpack-connect__sso-shared-detail-value {
 		display: block;
@@ -480,7 +478,7 @@
 .jetpack-connect__happychat-button {
 	background: none;
 	border: none;
-	color: darken( $gray, 20% );
+	color: darken($gray, 20%);
 	font-weight: normal;
 	padding: 16px 24px;
 	text-align: left;

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -1,57 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Plans should render placeholder with a paid plan 1`] = `
-<div>
-  <components--data--query-plans />
-  <h1
-    className="jetpack-connect__plans-placeholder-title"
-  >
-    Loading...
-  </h1>
-  <Card
-    className="jetpack-connect__plans-placeholder-card"
-    highlight={false}
-    tagName="div"
-  />
-</div>
+exports[`Plans should render placeholder when shouldShowPlaceholder is true 1`] = `
+<React.Fragment>
+  <Connect(QueryPlans) />
+  <PlansPlaceholder />
+</React.Fragment>
 `;
 
-exports[`Plans should render placeholder with unknown Atomic 1`] = `
-<div>
-  <components--data--query-plans />
-  <h1
-    className="jetpack-connect__plans-placeholder-title"
-  >
-    Loading...
-  </h1>
-  <Card
-    className="jetpack-connect__plans-placeholder-card"
-    highlight={false}
-    tagName="div"
-  />
-</div>
-`;
-
-exports[`Plans should render placeholder with unknown plan 1`] = `
-<div>
-  <components--data--query-plans />
-  <h1
-    className="jetpack-connect__plans-placeholder-title"
-  >
-    Loading...
-  </h1>
-  <Card
-    className="jetpack-connect__plans-placeholder-card"
-    highlight={false}
-    tagName="div"
-  />
-</div>
-`;
-
-exports[`Plans should render with no plan (free) 1`] = `
-<div>
-  <components--data--query-plans />
-  <components--data--query-site-plans
+exports[`Plans should render plans 1`] = `
+<React.Fragment>
+  <Connect(QueryPlans) />
+  <Connect(QuerySitePlans)
     siteId={1234567}
   />
   <Localized(JetpackPlansGrid)
@@ -193,7 +152,7 @@ exports[`Plans should render with no plan (free) 1`] = `
       onClick={[Function]}
     />
     <LoggedOutFormLinks>
-      <jetpack-connect--happychat-button
+      <Connect(Localized(JetpackConnectHappychatButton))
         eventName="calypso_jpc_plans_chat_initiated"
         label="Need help?"
       >
@@ -201,8 +160,8 @@ exports[`Plans should render with no plan (free) 1`] = `
           label="Need help?"
           onClick={[Function]}
         />
-      </jetpack-connect--happychat-button>
+      </Connect(Localized(JetpackConnectHappychatButton))>
     </LoggedOutFormLinks>
   </Localized(JetpackPlansGrid)>
-</div>
+</React.Fragment>
 `;

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -1,6 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Plans should render empty with a paid plan 1`] = `<components--data--query-plans />`;
+exports[`Plans should render placeholder with a paid plan 1`] = `
+<div>
+  <components--data--query-plans />
+  <h1
+    className="jetpack-connect__plans-placeholder-title"
+  >
+    Loading...
+  </h1>
+  <Card
+    className="jetpack-connect__plans-placeholder-card"
+    highlight={false}
+    tagName="div"
+  />
+</div>
+`;
+
+exports[`Plans should render placeholder with unknown Atomic 1`] = `
+<div>
+  <components--data--query-plans />
+  <h1
+    className="jetpack-connect__plans-placeholder-title"
+  >
+    Loading...
+  </h1>
+  <Card
+    className="jetpack-connect__plans-placeholder-card"
+    highlight={false}
+    tagName="div"
+  />
+</div>
+`;
+
+exports[`Plans should render placeholder with unknown plan 1`] = `
+<div>
+  <components--data--query-plans />
+  <h1
+    className="jetpack-connect__plans-placeholder-title"
+  >
+    Loading...
+  </h1>
+  <Card
+    className="jetpack-connect__plans-placeholder-card"
+    highlight={false}
+    tagName="div"
+  />
+</div>
+`;
 
 exports[`Plans should render with no plan (free) 1`] = `
 <div>

--- a/client/jetpack-connect/test/plans.js
+++ b/client/jetpack-connect/test/plans.js
@@ -17,7 +17,7 @@ import { DEFAULT_PROPS, SELECTED_SITE, SITE_PLAN_PRO } from './lib/plans';
 import { PlansTestComponent as Plans } from '../plans';
 
 describe( 'Plans', () => {
-	test( 'should render with no plan (free)', () => {
+	test( 'should render plans', () => {
 		const wrapper = shallow( <Plans { ...DEFAULT_PROPS } /> );
 
 		expect( wrapper ).toMatchSnapshot();
@@ -25,34 +25,42 @@ describe( 'Plans', () => {
 		expect( wrapper.find( QueryPlans ) ).toHaveLength( 1 );
 	} );
 
-	test( 'should render placeholder with unknown plan', () => {
-		const wrapper = shallow( <Plans { ...DEFAULT_PROPS } hasPlan={ null } /> );
+	test( 'should render placeholder when shouldShowPlaceholder is true', () => {
+		const wrapper = shallow( <Plans { ...DEFAULT_PROPS } /> );
+		wrapper.instance().shouldShowPlaceholder = jest.fn( () => true );
+
+		// Force rerender with our mocked method
+		wrapper.setProps( DEFAULT_PROPS );
 
 		expect( wrapper ).toMatchSnapshot();
 		expect( wrapper.find( PlansGrid ) ).toHaveLength( 0 );
 		expect( wrapper.find( QueryPlans ) ).toHaveLength( 1 );
 	} );
 
-	test( 'should render placeholder with unknown Atomic', () => {
-		const wrapper = shallow( <Plans { ...DEFAULT_PROPS } isAutomatedTransfer={ null } /> );
+	describe( 'shouldRenderPlaceholder', () => {
+		test( 'should return true with unknown plan', () => {
+			const wrapper = shallow( <Plans { ...DEFAULT_PROPS } hasPlan={ null } /> );
 
-		expect( wrapper ).toMatchSnapshot();
-		expect( wrapper.find( PlansGrid ) ).toHaveLength( 0 );
-		expect( wrapper.find( QueryPlans ) ).toHaveLength( 1 );
-	} );
+			expect( wrapper.instance().shouldShowPlaceholder() ).toBe( true );
+		} );
 
-	test( 'should render placeholder with a paid plan', () => {
-		const wrapper = shallow(
-			<Plans
-				{ ...DEFAULT_PROPS }
-				hasPlan={ true }
-				selectedSite={ { ...SELECTED_SITE, plan: SITE_PLAN_PRO } }
-			/>
-		);
+		test( 'should return true if isAutomatedTransfer is null', () => {
+			const wrapper = shallow( <Plans { ...DEFAULT_PROPS } isAutomatedTransfer={ null } /> );
 
-		expect( wrapper ).toMatchSnapshot();
-		expect( wrapper.find( PlansGrid ) ).toHaveLength( 0 );
-		expect( wrapper.find( QueryPlans ) ).toHaveLength( 1 );
+			expect( wrapper.instance().shouldShowPlaceholder() ).toBe( true );
+		} );
+
+		test( 'should return true with a paid plan', () => {
+			const wrapper = shallow(
+				<Plans
+					{ ...DEFAULT_PROPS }
+					hasPlan={ true }
+					selectedSite={ { ...SELECTED_SITE, plan: SITE_PLAN_PRO } }
+				/>
+			);
+
+			expect( wrapper.instance().shouldShowPlaceholder() ).toBe( true );
+		} );
 	} );
 
 	test( 'should redirect when hasPlan is loaded', () => {

--- a/client/jetpack-connect/test/plans.js
+++ b/client/jetpack-connect/test/plans.js
@@ -30,21 +30,23 @@ describe( 'Plans', () => {
 		expect( wrapper.find( QueryPlans ) ).toHaveLength( 1 );
 	} );
 
-	test( 'should render empty with unknown plan', () => {
+	test( 'should render placeholder with unknown plan', () => {
 		const wrapper = shallow( <Plans { ...DEFAULT_PROPS } hasPlan={ null } /> );
 
+		expect( wrapper ).toMatchSnapshot();
 		expect( wrapper.find( PlansGrid ) ).toHaveLength( 0 );
 		expect( wrapper.find( QueryPlans ) ).toHaveLength( 1 );
 	} );
 
-	test( 'should render empty with unknown Atomic', () => {
+	test( 'should render placeholder with unknown Atomic', () => {
 		const wrapper = shallow( <Plans { ...DEFAULT_PROPS } isAutomatedTransfer={ null } /> );
 
+		expect( wrapper ).toMatchSnapshot();
 		expect( wrapper.find( PlansGrid ) ).toHaveLength( 0 );
 		expect( wrapper.find( QueryPlans ) ).toHaveLength( 1 );
 	} );
 
-	test( 'should render empty with a paid plan', () => {
+	test( 'should render placeholder with a paid plan', () => {
 		const wrapper = shallow(
 			<Plans
 				{ ...DEFAULT_PROPS }

--- a/client/jetpack-connect/test/plans.js
+++ b/client/jetpack-connect/test/plans.js
@@ -5,7 +5,7 @@
 /**
  * External dependencies
  */
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 
 /**
@@ -15,11 +15,6 @@ import PlansGrid from '../plans-grid';
 import QueryPlans from 'components/data/query-plans';
 import { DEFAULT_PROPS, SELECTED_SITE, SITE_PLAN_PRO } from './lib/plans';
 import { PlansTestComponent as Plans } from '../plans';
-
-jest.mock( 'components/data/query-plans', () => 'components--data--query-plans' );
-jest.mock( 'components/data/query-site-plans', () => 'components--data--query-site-plans' );
-jest.mock( 'jetpack-connect/happychat-button', () => 'jetpack-connect--happychat-button' );
-jest.mock( 'my-sites/plan-features', () => 'my-sites--plan-features' );
 
 describe( 'Plans', () => {
 	test( 'should render with no plan (free)', () => {
@@ -61,7 +56,9 @@ describe( 'Plans', () => {
 	} );
 
 	test( 'should redirect when hasPlan is loaded', () => {
-		const wrapper = mount( <Plans { ...DEFAULT_PROPS } hasPlan={ null } selectedSite={ null } /> );
+		const wrapper = shallow(
+			<Plans { ...DEFAULT_PROPS } hasPlan={ null } selectedSite={ null } />
+		);
 
 		const redirect = ( wrapper.instance().redirect = jest.fn() );
 
@@ -71,12 +68,10 @@ describe( 'Plans', () => {
 		} );
 
 		expect( redirect.mock.calls ).toHaveLength( 1 );
-
-		wrapper.unmount();
 	} );
 
 	test( 'should redirect if notJetpack', () => {
-		const wrapper = mount(
+		const wrapper = shallow(
 			<Plans { ...DEFAULT_PROPS } hasPlan={ null } selectedSite={ null } notJetpack={ null } />
 		);
 
@@ -88,14 +83,12 @@ describe( 'Plans', () => {
 		} );
 
 		expect( redirect.mock.calls ).toHaveLength( 1 );
-
-		wrapper.unmount();
 	} );
 
 	test( 'should redirect if Atomic', () => {
 		const goBackToWpAdmin = jest.fn();
 
-		const wrapper = mount(
+		shallow(
 			<Plans
 				{ ...DEFAULT_PROPS }
 				goBackToWpAdmin={ goBackToWpAdmin }
@@ -110,7 +103,5 @@ describe( 'Plans', () => {
 		);
 
 		expect( goBackToWpAdmin.mock.calls ).toHaveLength( 1 );
-
-		wrapper.unmount();
 	} );
 } );


### PR DESCRIPTION
![plans_placeholder](https://user-images.githubusercontent.com/7767559/34166415-bcc0a5b0-e4d6-11e7-9270-14c81610b184.gif)

Show a loading placeholder where previously we rendered a blank page. Loading the sites data in the plans page can take a long time coming from cold for a user with many sites.

**NOTE:** Later we may want to move this down to the [`<PlansGrid/>`](https://github.com/Automattic/wp-calypso/blob/master/client/jetpack-connect/plans-grid.jsx) component so that we can use it elsewhere.

## Testing
* Clear local application state (delete `indexedDB` in Chrome's _Application_ tab)
* Go to /jetpack/connect/plans/{connected-jetpack-site}

Expected: The placeholder should show whilst the data for the page loads.

* Try and connect a new jetpack site, starting at /jetpack/connect

Expected: The plans page should show as usual after connecting.

