### PR TITLE
Jetpack Connect: Accept a `mobile_redirect` query arg

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -188,6 +188,11 @@ export class LoggedInForm extends Component {
 
 	shouldAutoAuthorize() {
 		const { alreadyAuthorized, authApproved } = this.props.authQuery;
+
+		if ( this.props.isMobileAppFlow ) {
+			return false;
+		}
+
 		return (
 			this.isSso() ||
 			this.isWoo() ||

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -36,7 +36,11 @@ import userUtilities from 'lib/user/utils';
 import { decodeEntities } from 'lib/formatting';
 import { externalRedirect } from 'lib/route/path';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { isCalypsoStartedConnection, isSsoApproved } from './persistence-utils';
+import {
+	isCalypsoStartedConnection,
+	isSsoApproved,
+	retrieveMobileRedirect,
+} from './persistence-utils';
 import { isRequestingSite, isRequestingSites } from 'state/sites/selectors';
 import { login } from 'lib/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
@@ -159,8 +163,14 @@ export class LoggedInForm extends Component {
 	}
 
 	redirect() {
-		const { goBackToWpAdmin } = this.props;
+		const { isMobileAppFlow, mobileAppRedirect, goBackToWpAdmin } = this.props;
 		const { from, redirectAfterAuth } = this.props.authQuery;
+
+		if ( isMobileAppFlow ) {
+			debug( `Redirecting to mobile app ${ mobileAppRedirect }` );
+			window.location.replace( mobileAppRedirect );
+			return;
+		}
 
 		if ( this.isSso() || this.isWoo() || this.isFromJpo() || this.shouldRedirectJetpackStart() ) {
 			debug(
@@ -622,6 +632,8 @@ export default connect(
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state, authQuery.site ),
 			isFetchingAuthorizationSite: isRequestingSite( state, authQuery.clientId ),
 			isFetchingSites: isRequestingSites( state ),
+			isMobileAppFlow: !! retrieveMobileRedirect(),
+			mobileAppRedirect: retrieveMobileRedirect(),
 			siteSlug,
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),

--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -187,11 +187,11 @@ export class LoggedInForm extends Component {
 	}
 
 	shouldAutoAuthorize() {
-		const { alreadyAuthorized, authApproved } = this.props.authQuery;
-
 		if ( this.props.isMobileAppFlow ) {
 			return false;
 		}
+
+		const { alreadyAuthorized, authApproved } = this.props.authQuery;
 
 		return (
 			this.isSso() ||
@@ -628,6 +628,11 @@ export default connect(
 	( state, { authQuery } ) => {
 		const siteSlug = urlToSlug( authQuery.site );
 
+		// Note: reading from a cookie here rather than redux state,
+		// so any change in value will not execute connect().
+		const mobileAppRedirect = retrieveMobileRedirect();
+		const isMobileAppFlow = !! mobileAppRedirect;
+
 		return {
 			authAttempts: getAuthAttempts( state, siteSlug ),
 			authorizationData: getAuthorizationData( state ),
@@ -637,8 +642,8 @@ export default connect(
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state, authQuery.site ),
 			isFetchingAuthorizationSite: isRequestingSite( state, authQuery.clientId ),
 			isFetchingSites: isRequestingSites( state ),
-			isMobileAppFlow: !! retrieveMobileRedirect(),
-			mobileAppRedirect: retrieveMobileRedirect(),
+			isMobileAppFlow,
+			mobileAppRedirect,
 			siteSlug,
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -14,6 +14,7 @@ import { translate } from 'i18n-calypso';
  */
 import analytics from 'lib/analytics';
 import CheckoutData from 'components/data/checkout';
+import config from 'config';
 import i18nUtils from 'lib/i18n-utils';
 import JetpackConnect from './main';
 import JetpackConnectAuthorizeForm from './authorize-form';
@@ -134,7 +135,9 @@ export function connect( context, next ) {
 	const planSlug = getPlanSlugFromFlowType( type, interval );
 	planSlug && storePlan( planSlug );
 
-	persistMobileRedirect( query.mobile_redirect || '' );
+	if ( config.isEnabled( 'jetpack/connect/mobile-app-flow' ) ) {
+		persistMobileRedirect( query.mobile_redirect || '' );
+	}
 
 	analytics.pageView.record( pathname, analyticsPageTitle );
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -30,7 +30,7 @@ import { JETPACK_CONNECT_QUERY_SET } from 'state/action-types';
 import { receiveJetpackOnboardingCredentials } from 'state/jetpack-onboarding/actions';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
-import { storePlan } from './persistence-utils';
+import { persistMobileRedirect, storePlan } from './persistence-utils';
 import { urlToSlug } from 'lib/url';
 import {
 	PLAN_JETPACK_PREMIUM,
@@ -125,7 +125,7 @@ export function newSite( context, next ) {
 }
 
 export function connect( context, next ) {
-	const { path, pathname, params } = context;
+	const { path, pathname, params, query } = context;
 	const { type = false, interval } = params;
 	const analyticsPageTitle = get( type, analyticsPageTitleByType, 'Jetpack Connect' );
 
@@ -133,6 +133,8 @@ export function connect( context, next ) {
 
 	const planSlug = getPlanSlugFromFlowType( type, interval );
 	planSlug && storePlan( planSlug );
+
+	persistMobileRedirect( query.mobile_redirect || '' );
 
 	analytics.pageView.record( pathname, analyticsPageTitle );
 
@@ -145,7 +147,7 @@ export function connect( context, next ) {
 		locale: params.locale,
 		path,
 		type,
-		url: context.query.url,
+		url: query.url,
 		userModule,
 	} );
 	next();

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -10,10 +10,12 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Main from 'components/main';
+import { retrieveMobileRedirect } from './persistence-utils';
 
 const JetpackConnectMainWrapper = ( { isWide, className, children } ) => {
 	const wrapperClassName = classNames( 'jetpack-connect__main', {
 		'is-wide': isWide,
+		'is-mobile-app-flow': !! retrieveMobileRedirect(),
 	} );
 	return <Main className={ classNames( className, wrapperClassName ) }>{ children }</Main>;
 };

--- a/client/jetpack-connect/persistence-utils.js
+++ b/client/jetpack-connect/persistence-utils.js
@@ -56,3 +56,13 @@ export const isSsoApproved = siteId => {
 	const cookies = cookie.parse( document.cookie );
 	return siteId === parseInt( cookies.jetpack_sso_approved, 10 );
 };
+
+export const persistMobileRedirect = url => {
+	const options = { path: '/' };
+	document.cookie = cookie.serialize( 'jetpack_connect_mobile_redirect', url, options );
+};
+
+export const retrieveMobileRedirect = () => {
+	const cookies = cookie.parse( document.cookie );
+	return cookies.jetpack_connect_mobile_redirect;
+};

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -9,6 +9,12 @@
 	.formatted-header {
 		margin-bottom: 16px;
 	}
+
+	&.is-mobile-app-flow {
+		.logged-out-form__links {
+			display: none;
+		}
+	}
 }
 
 .jetpack-connect__main.is-wide {

--- a/client/jetpack-connect/test/main-wrapper.jsx
+++ b/client/jetpack-connect/test/main-wrapper.jsx
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment jsdom
+ */
 /**
  * External dependencies
  */

--- a/client/jetpack-connect/test/main-wrapper.jsx
+++ b/client/jetpack-connect/test/main-wrapper.jsx
@@ -56,4 +56,17 @@ describe( 'JetpackConnectMainWrapper', () => {
 
 		expect( wrapper.hasClass( 'is-wide' ) ).to.be.true;
 	} );
+
+	test( 'should not contain the is-mobile-app-flow modifier class by default', () => {
+		const wrapper = shallow( <JetpackConnectMainWrapper /> );
+
+		expect( wrapper.hasClass( 'is-mobile-app-flow' ) ).to.be.false;
+	} );
+
+	test( 'should contain the is-mobile-app-flow modifier if cookie is set', () => {
+		document.cookie = 'jetpack_connect_mobile_redirect=some url';
+		const wrapper = shallow( <JetpackConnectMainWrapper isWide /> );
+
+		expect( wrapper.hasClass( 'is-mobile-app-flow' ) ).to.be.true;
+	} );
 } );

--- a/config/development.json
+++ b/config/development.json
@@ -63,7 +63,7 @@
 		"help/courses": true,
 		"jetpack/api-cache": true,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
-		"jetpack/connect/mobile-app-flow": false,
+		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/happychat": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,

--- a/config/development.json
+++ b/config/development.json
@@ -63,6 +63,7 @@
 		"help/courses": true,
 		"jetpack/api-cache": true,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
+		"jetpack/connect/mobile-app-flow": false,
 		"jetpack/happychat": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -37,6 +37,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/api-cache": true,
+		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/happychat": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,


### PR DESCRIPTION
Create a special jetpack connection flow for the mobile apps by accepting a `mobile_redirect` query arg on the `/jetpack/connect` route.

* The flow will redirect to the supplied URL immediately after auth is complete (no plan purchases can be made from the apps
* The flow will always ask user for confirmation before authorizing the connection, because the app does not show the TOS beforehand
* The flow will hide links to elsewhere in Calypso as much as possible

More details: p7rd6c-1az-p2.

**Todo**
- [x] Don't automatically authorize the connection
- [ ] Hide masterbar (will address in subsequent PR)
- [x] Hide links
- [ ] Add error string to redirect url in error cases (will address in subsequent PR)

## Testing
* Set debug in browser console: `localStorage.setItem( 'debug', 'calypso:jetpack-connect:authorize-form' )`
* Start the jetpack connection flow, passing the arg `mobile_redirect` for example:

`http://calypso.localhost:3000/jetpack/connect?mobile_redirect=wordpress://jetpack-connection`

or with a .org site url as well:

`http://calypso.localhost:3000/jetpack/connect?mobile_redirect=wordpress://jetpack-connection&url=http://elated-eater-275.jurassic.ninja/`

* When connection is completed, you should see a line of debug in the console:

`calypso:jetpack-connect:authorize-form Redirecting to mobile app wordpress://jetpack-connection`

/cc @koke 

