### PR TITLE
Reader: accept email subscriptions from /read/sites/:site endpoint

### DIFF
--- a/client/blocks/reader-email-settings/index.jsx
+++ b/client/blocks/reader-email-settings/index.jsx
@@ -147,12 +147,11 @@ class ReaderEmailSettings extends Component {
 const mapStateToProps = ( state, ownProps ) => {
 	const follow = find( getReaderFollows( state ), { blog_ID: ownProps.siteId } );
 	const deliveryMethods = get( follow, [ 'delivery_methods', 'email' ], {} );
-	const { send_posts, post_delivery_frequency, send_comments } = deliveryMethods;
 
 	return {
-		notifyOnNewComments: !! send_comments,
-		notifyOnNewPosts: !! send_posts,
-		deliveryFrequency: post_delivery_frequency,
+		notifyOnNewComments: deliveryMethods && !! deliveryMethods.send_comments,
+		notifyOnNewPosts: deliveryMethods && !! deliveryMethods.send_posts,
+		deliveryFrequency: deliveryMethods && deliveryMethods.post_delivery_frequency,
 	};
 };
 

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -162,12 +162,11 @@ const mapStateToProps = ( state, ownProps ) => {
 
 	const follow = find( getReaderFollows( state ), { blog_ID: ownProps.siteId } );
 	const deliveryMethods = get( follow, [ 'delivery_methods', 'email' ], {} );
-	const { send_posts, post_delivery_frequency, send_comments } = deliveryMethods;
 
 	return {
-		notifyOnNewComments: !! send_comments,
-		notifyOnNewPosts: !! send_posts,
-		deliveryFrequency: post_delivery_frequency,
+		notifyOnNewComments: deliveryMethods && !! deliveryMethods.send_comments,
+		notifyOnNewPosts: deliveryMethods && !! deliveryMethods.send_posts,
+		deliveryFrequency: deliveryMethods && deliveryMethods.post_delivery_frequency,
 	};
 };
 

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -16,6 +16,7 @@ import {
 	READER_FOLLOWS_SYNC_START,
 	READER_FOLLOWS_SYNC_COMPLETE,
 	READER_FOLLOWS_RECEIVE,
+	READER_SITE_REQUEST_SUCCESS,
 	READER_SUBSCRIBE_TO_NEW_POST_EMAIL,
 	READER_SUBSCRIBE_TO_NEW_COMMENT_EMAIL,
 	READER_UPDATE_NEW_POST_EMAIL_SUBSCRIPTION,
@@ -157,6 +158,25 @@ export const items = createReducer(
 				{}
 			);
 			return merge( {}, state, keyedNewFollows );
+		},
+		[ READER_SITE_REQUEST_SUCCESS ]: ( state, action ) => {
+			const incomingSite = action.payload;
+			if ( ! incomingSite || ! incomingSite.is_following ) {
+				return state;
+			}
+			const urlKey = prepareComparableUrl( incomingSite.URL );
+			const currentFollow = state[ urlKey ];
+			const newFollow = {
+				delivery_methods: get( incomingSite, 'subscription.delivery_methods' ),
+				is_following: true,
+				URL: incomingSite.URL,
+				feed_URL: incomingSite.feed_URL,
+				blog_ID: incomingSite.ID,
+			};
+			return {
+				...state,
+				[ urlKey ]: merge( {}, currentFollow, newFollow ),
+			};
 		},
 		[ READER_SUBSCRIBE_TO_NEW_POST_EMAIL ]: ( state, action ) =>
 			updatePostSubscription( state, action ),

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -161,14 +161,14 @@ export const items = createReducer(
 		},
 		[ READER_SITE_REQUEST_SUCCESS ]: ( state, action ) => {
 			const incomingSite = action.payload;
-			if ( ! incomingSite || ! incomingSite.feed_URL ) {
+			if ( ! incomingSite || ! incomingSite.feed_URL || ! incomingSite.is_following ) {
 				return state;
 			}
 			const urlKey = prepareComparableUrl( incomingSite.feed_URL );
 			const currentFollow = state[ urlKey ];
 			const newFollow = {
 				delivery_methods: get( incomingSite, 'subscription.delivery_methods' ),
-				is_following: incomingSite.is_following,
+				is_following: true,
 				URL: incomingSite.URL,
 				feed_URL: incomingSite.feed_URL,
 				blog_ID: incomingSite.ID,

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -168,7 +168,7 @@ export const items = createReducer(
 			const currentFollow = state[ urlKey ];
 			const newFollow = {
 				delivery_methods: get( incomingSite, 'subscription.delivery_methods' ),
-				is_following: true,
+				is_following: incomingSite.is_following,
 				URL: incomingSite.URL,
 				feed_URL: incomingSite.feed_URL,
 				blog_ID: incomingSite.ID,

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -164,7 +164,7 @@ export const items = createReducer(
 			if ( ! incomingSite || ! incomingSite.is_following ) {
 				return state;
 			}
-			const urlKey = prepareComparableUrl( incomingSite.URL );
+			const urlKey = prepareComparableUrl( incomingSite.feed_URL );
 			const currentFollow = state[ urlKey ];
 			const newFollow = {
 				delivery_methods: get( incomingSite, 'subscription.delivery_methods' ),

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -161,7 +161,7 @@ export const items = createReducer(
 		},
 		[ READER_SITE_REQUEST_SUCCESS ]: ( state, action ) => {
 			const incomingSite = action.payload;
-			if ( ! incomingSite || ! incomingSite.is_following || ! incomingSite.feed_URL ) {
+			if ( ! incomingSite || ! incomingSite.feed_URL ) {
 				return state;
 			}
 			const urlKey = prepareComparableUrl( incomingSite.feed_URL );

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -161,7 +161,7 @@ export const items = createReducer(
 		},
 		[ READER_SITE_REQUEST_SUCCESS ]: ( state, action ) => {
 			const incomingSite = action.payload;
-			if ( ! incomingSite || ! incomingSite.is_following ) {
+			if ( ! incomingSite || ! incomingSite.is_following || ! incomingSite.feed_URL ) {
 				return state;
 			}
 			const urlKey = prepareComparableUrl( incomingSite.feed_URL );

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -585,24 +585,6 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		test( 'should disregard an unfollowed site from a site request', () => {
-			const original = deepFreeze( {} );
-			const incomingSite = {
-				ID: 125,
-				name: 'Postcards from the Reader',
-				URL: 'https://postcardsfromthereader.wordpress.com',
-				feed_URL: 'https://postcardsfromthereader.wordpress.com',
-				is_following: false,
-			};
-
-			const state = items( original, {
-				type: READER_SITE_REQUEST_SUCCESS,
-				payload: incomingSite,
-			} );
-
-			expect( state[ 'postcardsfromthereader.wordpress.com' ] ).toEqual( undefined );
-		} );
-
 		test( 'should disregard a site with no feed URL from a site request', () => {
 			const original = deepFreeze( {} );
 			const incomingSite = {

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
+import { expect as chaiExpect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -26,13 +26,14 @@ import {
 	SERIALIZE,
 	DESERIALIZE,
 	READER_FOLLOW_ERROR,
+	READER_SITE_REQUEST_SUCCESS,
 } from 'state/action-types';
 
 describe( 'reducer', () => {
 	describe( '#itemsCount()', () => {
 		test( 'should default to 0', () => {
 			const state = itemsCount( undefined, {} );
-			expect( state ).to.eql( 0 );
+			chaiExpect( state ).to.eql( 0 );
 		} );
 
 		test( 'should get set to whatever is in the payload', () => {
@@ -40,14 +41,14 @@ describe( 'reducer', () => {
 				type: READER_FOLLOWS_RECEIVE,
 				payload: { totalCount: 20 },
 			} );
-			expect( state ).eql( 20 );
+			chaiExpect( state ).eql( 20 );
 		} );
 	} );
 
 	describe( '#items()', () => {
 		test( 'should default to an empty object', () => {
 			const state = items( undefined, {} );
-			expect( state ).to.eql( {} );
+			chaiExpect( state ).to.eql( {} );
 		} );
 
 		test( 'should insert a new URL when followed', () => {
@@ -59,7 +60,7 @@ describe( 'reducer', () => {
 				type: READER_RECORD_FOLLOW,
 				payload: { url: 'http://data.blog' },
 			} );
-			expect( state[ 'data.blog' ] ).to.eql( { is_following: true } );
+			chaiExpect( state[ 'data.blog' ] ).to.eql( { is_following: true } );
 		} );
 
 		test( 'should remove a URL when unfollowed', () => {
@@ -71,7 +72,10 @@ describe( 'reducer', () => {
 				type: READER_RECORD_UNFOLLOW,
 				payload: { url: 'http://discover.wordpress.com' },
 			} );
-			expect( state[ 'discover.wordpress.com' ] ).to.eql( { blog_ID: 123, is_following: false } );
+			chaiExpect( state[ 'discover.wordpress.com' ] ).to.eql( {
+				blog_ID: 123,
+				is_following: false,
+			} );
 		} );
 
 		test( 'should accept a new set of follows', () => {
@@ -89,14 +93,14 @@ describe( 'reducer', () => {
 			} );
 
 			// Updated follow
-			expect( state[ 'dailypost.wordpress.com' ] ).to.eql( {
+			chaiExpect( state[ 'dailypost.wordpress.com' ] ).to.eql( {
 				is_following: true,
 				blog_ID: 125,
 				URL: 'http://dailypost.wordpress.com',
 			} );
 
 			// Brand new follow
-			expect( state[ 'postcardsfromthereader.wordpress.com' ] ).to.eql( {
+			chaiExpect( state[ 'postcardsfromthereader.wordpress.com' ] ).to.eql( {
 				is_following: true,
 				blog_ID: 126,
 				URL: 'https://postcardsfromthereader.wordpress.com',
@@ -118,7 +122,7 @@ describe( 'reducer', () => {
 					blog_ID: 124,
 				},
 			} );
-			expect( items( original, { type: SERIALIZE } ) ).to.eql( {
+			chaiExpect( items( original, { type: SERIALIZE } ) ).to.eql( {
 				'dailypost.wordpress.com': {
 					feed_URL: 'http://dailypost.wordpress.com',
 					URL: 'http://dailypost.wordpress.com',
@@ -138,7 +142,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( items( original, { type: DESERIALIZE } ) ).to.eql( original );
+			chaiExpect( items( original, { type: DESERIALIZE } ) ).to.eql( original );
 		} );
 
 		test( 'should return the blank state for bad serialized data', () => {
@@ -150,7 +154,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( items( original, { type: DESERIALIZE } ) ).to.eql( {} );
+			chaiExpect( items( original, { type: DESERIALIZE } ) ).to.eql( {} );
 		} );
 
 		test( 'should update when passed new post subscription info', () => {
@@ -167,7 +171,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewPostEmail( 123 ) );
-			expect( state ).to.eql( {
+			chaiExpect( state ).to.eql( {
 				'example.com': {
 					is_following: true,
 					blog_ID: 123,
@@ -195,7 +199,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewPostEmail( 123 ) );
-			expect( state ).to.equal( original );
+			chaiExpect( state ).to.equal( original );
 		} );
 
 		test( 'should not update when passed bad new post subscription info', () => {
@@ -212,7 +216,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewPostEmail( 456 ) );
-			expect( state ).to.equal( original );
+			chaiExpect( state ).to.equal( original );
 		} );
 
 		test( 'should update when passed updated post subscription info', () => {
@@ -231,7 +235,7 @@ describe( 'reducer', () => {
 
 			[ 'instantly', 'daily', 'weekly' ].forEach( frequency => {
 				const state = items( original, updateNewPostEmailSubscription( 123, frequency ) );
-				expect( state ).to.eql( {
+				chaiExpect( state ).to.eql( {
 					'example.com': {
 						is_following: true,
 						blog_ID: 123,
@@ -263,7 +267,7 @@ describe( 'reducer', () => {
 					},
 				} );
 				const state = items( original, updateNewPostEmailSubscription( 123, frequency ) );
-				expect( state ).to.equal( original );
+				chaiExpect( state ).to.equal( original );
 			} );
 		} );
 
@@ -283,7 +287,7 @@ describe( 'reducer', () => {
 
 			[ 'instantly', 'daily', 'weekly' ].forEach( frequency => {
 				const state = items( original, updateNewPostEmailSubscription( 456, frequency ) );
-				expect( state ).to.equal( original );
+				chaiExpect( state ).to.equal( original );
 			} );
 		} );
 
@@ -302,7 +306,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewPostEmail( 123 ) );
-			expect( state ).to.eql( {
+			chaiExpect( state ).to.eql( {
 				'example.com': {
 					is_following: true,
 					blog_ID: 123,
@@ -332,7 +336,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewPostEmail( 123 ) );
-			expect( state ).to.equal( original );
+			chaiExpect( state ).to.equal( original );
 		} );
 
 		test( 'should not update when passed bad post unsubscription info', () => {
@@ -350,7 +354,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewPostEmail( 456 ) );
-			expect( state ).to.equal( original );
+			chaiExpect( state ).to.equal( original );
 		} );
 
 		test( 'should update when passed comment subscription info', () => {
@@ -367,7 +371,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewCommentEmail( 123 ) );
-			expect( state ).to.eql( {
+			chaiExpect( state ).to.eql( {
 				'example.com': {
 					is_following: true,
 					blog_ID: 123,
@@ -395,7 +399,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewCommentEmail( 123 ) );
-			expect( state ).to.equal( original );
+			chaiExpect( state ).to.equal( original );
 		} );
 
 		test( 'should not update when passed comment sub info about a missing sub', () => {
@@ -412,7 +416,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewCommentEmail( 456 ) );
-			expect( state ).to.equal( original );
+			chaiExpect( state ).to.equal( original );
 		} );
 
 		test( 'should update when passed comment unsubscription info', () => {
@@ -429,7 +433,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewCommentEmail( 123 ) );
-			expect( state ).to.eql( {
+			chaiExpect( state ).to.eql( {
 				'example.com': {
 					is_following: true,
 					blog_ID: 123,
@@ -457,7 +461,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewCommentEmail( 123 ) );
-			expect( state ).to.equal( original );
+			chaiExpect( state ).to.equal( original );
 		} );
 
 		test( 'should not update when passed bad comment unsubscription info', () => {
@@ -474,7 +478,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewCommentEmail( 456 ) );
-			expect( state ).to.equal( original );
+			chaiExpect( state ).to.equal( original );
 		} );
 
 		test( 'should insert a follow error if one is received', () => {
@@ -486,9 +490,46 @@ describe( 'reducer', () => {
 				type: READER_FOLLOW_ERROR,
 				payload: { feedUrl: 'http://discoverinvalid.wordpress.com', error: 'invalid_feed' },
 			} );
-			expect( state[ 'discoverinvalid.wordpress.com' ] ).to.eql( {
+			chaiExpect( state[ 'discoverinvalid.wordpress.com' ] ).to.eql( {
 				is_following: true,
 				error: 'invalid_feed',
+			} );
+		} );
+
+		test( 'should accept subscription delivery details from a site request', () => {
+			const original = deepFreeze( {} );
+			const incomingSite = {
+				ID: 125,
+				name: 'Postcards from the Reader',
+				URL: 'https://postcardsfromthereader.wordpress.com',
+				is_following: true,
+				subscription: {
+					delivery_methods: {
+						email: {
+							send_posts: true,
+							send_comments: false,
+							post_delivery_frequency: 'weekly',
+						},
+					},
+				},
+			};
+
+			const state = items( original, {
+				type: READER_SITE_REQUEST_SUCCESS,
+				payload: incomingSite,
+			} );
+
+			expect( state[ 'postcardsfromthereader.wordpress.com' ] ).toEqual( {
+				is_following: true,
+				blog_ID: 125,
+				URL: 'https://postcardsfromthereader.wordpress.com',
+				delivery_methods: {
+					email: {
+						send_posts: true,
+						send_comments: false,
+						post_delivery_frequency: 'weekly',
+					},
+				},
 			} );
 		} );
 	} );
@@ -503,7 +544,7 @@ describe( 'reducer', () => {
 			} );
 
 			const state = items( original, follow( 'http://example.com' ) );
-			expect( state ).to.eql( {
+			chaiExpect( state ).to.eql( {
 				'example.com': {
 					is_following: true,
 					feed_URL: 'http://example.com',
@@ -514,7 +555,7 @@ describe( 'reducer', () => {
 
 		test( 'should create a new entry for a new follow', () => {
 			const state = items( {}, follow( 'http://example.com' ) );
-			expect( state ).to.eql( {
+			chaiExpect( state ).to.eql( {
 				'example.com': {
 					feed_URL: 'http://example.com',
 					is_following: true,
@@ -543,7 +584,7 @@ describe( 'reducer', () => {
 			};
 
 			const state = items( original, follow( 'http://example.com', subscriptionInfo ) );
-			expect( state ).to.eql( {
+			chaiExpect( state ).to.eql( {
 				'example.com': {
 					...subscriptionInfo,
 					is_following: true,
@@ -572,7 +613,7 @@ describe( 'reducer', () => {
 			};
 
 			const state = items( original, follow( 'http://example.com', subscriptionInfo ) );
-			expect( state ).to.eql( {
+			chaiExpect( state ).to.eql( {
 				'example.com/feed': {
 					...subscriptionInfo,
 					is_following: true,
@@ -593,7 +634,7 @@ describe( 'reducer', () => {
 			} );
 
 			const state = items( original, unfollow( 'http://example.com' ) );
-			expect( state ).to.eql( {
+			chaiExpect( state ).to.eql( {
 				'example.com': {
 					is_following: false,
 					feed_URL: 'http://example.com',
@@ -612,13 +653,13 @@ describe( 'reducer', () => {
 			} );
 
 			const state = items( original, unfollow( 'http://example.com' ) );
-			expect( state ).to.equal( original );
+			chaiExpect( state ).to.equal( original );
 		} );
 
 		test( 'should return the same state for an item that does not exist', () => {
 			const original = deepFreeze( {} );
 			const state = items( original, unfollow( 'http://example.com' ) );
-			expect( state ).to.equal( original );
+			chaiExpect( state ).to.equal( original );
 		} );
 	} );
 
@@ -637,7 +678,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, syncComplete( [ 'http://example2.com' ] ) );
-			expect( state ).to.eql( {
+			chaiExpect( state ).to.eql( {
 				'example2.com': {
 					feed_URL: 'http://example2.com',
 					ID: 2,

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -602,6 +602,24 @@ describe( 'reducer', () => {
 
 			expect( state[ 'postcardsfromthereader.wordpress.com' ] ).toEqual( undefined );
 		} );
+
+		test( 'should disregard a site with no feed URL from a site request', () => {
+			const original = deepFreeze( {} );
+			const incomingSite = {
+				ID: 125,
+				name: 'Postcards from the Reader',
+				URL: 'https://postcardsfromthereader.wordpress.com',
+				feed_URL: null,
+				is_following: false,
+			};
+
+			const state = items( original, {
+				type: READER_SITE_REQUEST_SUCCESS,
+				payload: incomingSite,
+			} );
+
+			expect( state[ 'postcardsfromthereader.wordpress.com' ] ).toEqual( undefined );
+		} );
 	} );
 
 	describe( 'follow', () => {

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -496,7 +496,7 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		test( 'should accept subscription delivery details from a site request', () => {
+		test( 'should add a new follow from a site request', () => {
 			const original = deepFreeze( {} );
 			const incomingSite = {
 				ID: 125,
@@ -533,6 +533,74 @@ describe( 'reducer', () => {
 					},
 				},
 			} );
+		} );
+
+		test( 'should update an existing follow from a site request', () => {
+			const original = deepFreeze( {
+				is_following: true,
+				blog_ID: 125,
+				URL: 'https://postcardsfromthereader.wordpress.com',
+				feed_URL: 'https://postcardsfromthereader.wordpress.com',
+				delivery_methods: {
+					email: {
+						send_posts: false,
+						send_comments: true,
+					},
+				},
+			} );
+			const incomingSite = {
+				ID: 125,
+				name: 'Postcards from the Reader',
+				URL: 'https://postcardsfromthereader.wordpress.com',
+				feed_URL: 'https://postcardsfromthereader.wordpress.com',
+				is_following: true,
+				subscription: {
+					delivery_methods: {
+						email: {
+							send_posts: true,
+							send_comments: false,
+							post_delivery_frequency: 'weekly',
+						},
+					},
+				},
+			};
+
+			const state = items( original, {
+				type: READER_SITE_REQUEST_SUCCESS,
+				payload: incomingSite,
+			} );
+
+			expect( state[ 'postcardsfromthereader.wordpress.com' ] ).toEqual( {
+				is_following: true,
+				blog_ID: 125,
+				URL: 'https://postcardsfromthereader.wordpress.com',
+				feed_URL: 'https://postcardsfromthereader.wordpress.com',
+				delivery_methods: {
+					email: {
+						send_posts: true,
+						send_comments: false,
+						post_delivery_frequency: 'weekly',
+					},
+				},
+			} );
+		} );
+
+		test( 'should disregard an unfollowed site from a site request', () => {
+			const original = deepFreeze( {} );
+			const incomingSite = {
+				ID: 125,
+				name: 'Postcards from the Reader',
+				URL: 'https://postcardsfromthereader.wordpress.com',
+				feed_URL: 'https://postcardsfromthereader.wordpress.com',
+				is_following: false,
+			};
+
+			const state = items( original, {
+				type: READER_SITE_REQUEST_SUCCESS,
+				payload: incomingSite,
+			} );
+
+			expect( state[ 'postcardsfromthereader.wordpress.com' ] ).toEqual( undefined );
 		} );
 	} );
 

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -502,6 +502,7 @@ describe( 'reducer', () => {
 				ID: 125,
 				name: 'Postcards from the Reader',
 				URL: 'https://postcardsfromthereader.wordpress.com',
+				feed_URL: 'https://postcardsfromthereader.wordpress.com',
 				is_following: true,
 				subscription: {
 					delivery_methods: {
@@ -523,6 +524,7 @@ describe( 'reducer', () => {
 				is_following: true,
 				blog_ID: 125,
 				URL: 'https://postcardsfromthereader.wordpress.com',
+				feed_URL: 'https://postcardsfromthereader.wordpress.com',
 				delivery_methods: {
 					email: {
 						send_posts: true,

--- a/client/state/reader/sites/fields.js
+++ b/client/state/reader/sites/fields.js
@@ -5,6 +5,7 @@ export const fields = [
 	'title',
 	'URL',
 	'icon',
+	'is_following',
 	'is_jetpack',
 	'description',
 	'is_private',

--- a/client/state/reader/sites/fields.js
+++ b/client/state/reader/sites/fields.js
@@ -1,3 +1,4 @@
+/** @format */
 export const fields = [
 	'ID',
 	'name',
@@ -13,4 +14,5 @@ export const fields = [
 	'prefer_feed',
 	'subscribers_count',
 	'options', // have to include this to get options at all
+	'subscription',
 ];

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -62,7 +62,7 @@ function handleRequestFailure( state, action ) {
 
 function adaptSite( attributes ) {
 	// this also ends up cloning attributes, which is important since we mutate it
-	attributes = omit( attributes, [ 'meta' ] );
+	attributes = omit( attributes, [ 'meta', 'subscription' ] );
 
 	if ( attributes.URL ) {
 		attributes.domain = withoutHttp( attributes.URL );

--- a/client/state/reader/sites/schema.js
+++ b/client/state/reader/sites/schema.js
@@ -11,6 +11,7 @@ export const readerSitesSchema = {
 			properties: {
 				...sitesSchema.patternProperties[ '^\\d+$' ].properties,
 				feed_ID: { type: 'number' },
+				subscription: { type: 'object' },
 			},
 		},
 	},


### PR DESCRIPTION
In D8882-code, we start returning email subscription status with responses from the /read/sites/:site endpoint.

This PR starts accepting this data and adding it to the state tree in `reader.follows`.

### To test

Load up a site stream like:

https://wpcalypso.wordpress.com/read/blogs/72017470

Subscribe by email using the Settings popover, then do a hard refresh and re-check the Settings popover.

You can also run the unit tests with:

`npm run test-client client/state/reader/follows`
