### PR TITLE
DevDocs: complete relative path for devdocs examples

### DIFF
--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -40,7 +40,7 @@ const Collection = ( { children, filter, section = 'design', component } ) => {
 		}
 
 		const exampleName = getComponentName( example );
-		const exampleLink = `./${ section }/${ camelCaseToSlug( exampleName ) }`;
+		const exampleLink = `/devdocs/${ section }/${ camelCaseToSlug( exampleName ) }`;
 
 		showCounter++;
 


### PR DESCRIPTION
While working on https://github.com/Automattic/wp-calypso/pull/20898, I discovered a frustrating bug currently affecting devdocs.
In a regular flow, its possible for none of the buttons that go to individual components would work.

Repro Steps:
1. go to wpcalypso.wordpress.com
2. click on the devdocs link on the bottom right
3. click "ui components" once.  it will bring you to the url /devdocs/design and then quickly switch you back to just /devdocs (but keeping the contents of /devdocs/design)
4. clicking any component wont work and repeated presses being you to a broken themes page.  e.g. clicking the accordion will bring you to `/design/accordion` on first click instead of `/devdocs/design/accordion` like it should.


To test
----
1. verify the issue as described
2. verify it is fixed in this branch

cc @folletto 