### PR TITLE
[WIP] Framework: Async load all Web Previews

### DIFF
--- a/client/blocks/site-preview/index.jsx
+++ b/client/blocks/site-preview/index.jsx
@@ -12,14 +12,10 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import WebPreview from 'components/web-preview';
-import designPreview from 'my-sites/design-preview';
-import urlPreview from 'blocks/url-preview';
+import DesignPreview from 'my-sites/design-preview';
+import UrlPreview from 'blocks/url-preview';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { getCurrentPreviewType } from 'state/ui/preview/selectors';
-
-const DesignPreview = designPreview( WebPreview );
-const UrlPreview = urlPreview( WebPreview );
 
 class SitePreview extends Component {
 	render() {

--- a/client/blocks/url-preview/index.jsx
+++ b/client/blocks/url-preview/index.jsx
@@ -17,10 +17,11 @@ import { getPreviewSite, getPreviewSiteId, getPreviewUrl } from 'state/ui/previe
 import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
 import addQueryArgs from 'lib/route/add-query-args';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
+import AsyncLoad from 'components/async-load';
 
 const debug = debugFactory( 'calypso:design-preview' );
 
-export default function urlPreview( WebPreview ) {
+export default function urlPreview() {
 	class UrlPreview extends React.Component {
 		constructor( props ) {
 			super( props );
@@ -76,7 +77,8 @@ export default function urlPreview( WebPreview ) {
 			}
 
 			return (
-				<WebPreview
+				<AsyncLoad
+					require="components/web-preview"
 					className={ this.props.className }
 					previewUrl={ this.getPreviewUrl() }
 					externalUrl={ this.getBasePreviewUrl() }

--- a/client/my-sites/design-preview/index.js
+++ b/client/my-sites/design-preview/index.js
@@ -32,10 +32,11 @@ import DesignMenu from 'blocks/design-menu';
 import { getSiteFragment } from 'lib/route/path';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import AsyncLoad from 'components/async-load';
 
 const debug = debugFactory( 'calypso:design-preview' );
 
-export default function designPreview( WebPreview ) {
+export default function designPreview() {
 	class DesignPreview extends React.Component {
 		constructor( props ) {
 			super( props );
@@ -167,7 +168,8 @@ export default function designPreview( WebPreview ) {
 			return (
 				<div>
 					<DesignMenu isVisible={ this.props.showPreview } />
-					<WebPreview
+					<AsyncLoad
+						require="components/web-preview"
 						className={ this.props.className }
 						showPreview={ this.props.showPreview }
 						showExternal={ false }
@@ -183,7 +185,7 @@ export default function designPreview( WebPreview ) {
 								{ this.props.translate( 'EDIT' ) }
 							</span>
 						</button>
-					</WebPreview>
+					</AsyncLoad>
 				</div>
 			);
 		}

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -23,7 +23,7 @@ import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
 import Gridicon from 'gridicons';
 import Main from 'components/main';
-import WebPreviewContent from 'components/web-preview/content';
+import AsyncLoad from 'components/async-load';
 
 const debug = debugFactory( 'calypso:my-sites:preview' );
 
@@ -138,7 +138,8 @@ class PreviewMain extends React.Component {
 		return (
 			<Main className="preview">
 				<DocumentHead title={ translate( 'Your Site' ) } />
-				<WebPreviewContent
+				<AsyncLoad
+					require="components/web-preview/content"
 					onLocationUpdate={ this.updateSiteLocation }
 					showUrl={ !! this.state.externalUrl }
 					showClose={ this.state.showingClose }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -48,7 +48,6 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackModuleActive, isHiddenSite, isPrivateSite } from 'state/selectors';
 import { toApi as seoTitleToApi } from 'components/seo/meta-title-editor/mappings';
 import { recordTracksEvent } from 'state/analytics/actions';
-import WebPreview from 'components/web-preview';
 import { requestSite } from 'state/sites/actions';
 import { activateModule } from 'state/jetpack/modules/actions';
 import { isBusiness, isEnterprise, isJetpackBusiness } from 'lib/products-values';
@@ -64,6 +63,7 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { requestSiteSettings, saveSiteSettings } from 'state/site-settings/actions';
+import AsyncLoad from 'components/async-load';
 
 // Basic matching for HTML tags
 // Not perfect but meets the needs of this component well
@@ -491,7 +491,8 @@ export class SeoForm extends React.Component {
 							</div>
 						) }
 				</form>
-				<WebPreview
+				<AsyncLoad
+					require="components/web-preview"
 					showPreview={ showPreview }
 					onClose={ this.hidePreview }
 					previewUrl={ siteUrl }

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -30,10 +30,10 @@ import EmptyContent from 'components/empty-content';
 import { getPostStat, isRequestingPostStats } from 'state/stats/posts/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Button from 'components/button';
-import WebPreview from 'components/web-preview';
 import { getSiteSlug, isJetpackSite, isSitePreviewable } from 'state/sites/selectors';
 import { getSitePost, isRequestingSitePost, getPostPreviewUrl } from 'state/posts/selectors';
 import { hasNavigated } from 'state/selectors';
+import AsyncLoad from 'components/async-load';
 
 class StatsPostDetail extends Component {
 	static propTypes = {
@@ -179,7 +179,8 @@ class StatsPostDetail extends Component {
 						</div>
 					) }
 
-				<WebPreview
+				<AsyncLoad
+					require="components/web-preview"
 					showPreview={ this.state.showPreview }
 					defaultViewportDevice="tablet"
 					previewUrl={ `${ previewUrl }?demo=true&iframe=true&theme_preview=true` }
@@ -187,7 +188,7 @@ class StatsPostDetail extends Component {
 					onClose={ this.closePreview }
 				>
 					<Button href={ `/post/${ siteSlug }/${ postId }` }>{ translate( 'Edit' ) }</Button>
-				</WebPreview>
+				</AsyncLoad>
 			</Main>
 		);
 	}

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -27,7 +27,7 @@ import {
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { hideThemePreview } from 'state/themes/actions';
-import WebPreview from 'components/web-preview';
+import AsyncLoad from 'components/async-load';
 
 class ThemePreview extends React.Component {
 	static displayName = 'ThemePreview';
@@ -113,7 +113,8 @@ class ThemePreview extends React.Component {
 			<div>
 				{ this.props.isJetpack && <QueryTheme themeId={ themeId } siteId="wporg" /> }
 				{ this.props.demoUrl && (
-					<WebPreview
+					<AsyncLoad
+						require="components/web-preview"
 						showPreview={ true }
 						showExternal={ false }
 						showSEO={ false }
@@ -124,7 +125,7 @@ class ThemePreview extends React.Component {
 						{ showActionIndicator && <PulsingDot active={ true } /> }
 						{ ! showActionIndicator && this.renderSecondaryButton() }
 						{ ! showActionIndicator && this.renderPrimaryButton() }
-					</WebPreview>
+					</AsyncLoad>
 				) }
 			</div>
 		);

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -14,9 +14,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { omitUrlParams } from 'lib/url';
-import WebPreview from 'components/web-preview';
-import WebPreviewContent from 'components/web-preview/content';
 import { isEnabled } from 'config';
+import AsyncLoad from 'components/async-load';
 
 class EditorPreview extends React.Component {
 	static propTypes = {
@@ -130,7 +129,8 @@ class EditorPreview extends React.Component {
 		return (
 			<div className={ className }>
 				{ isFullScreen ? (
-					<WebPreviewContent
+					<AsyncLoad
+						require="components/web-preview/content"
 						showPreview={ this.props.showPreview }
 						showEdit={ true }
 						showExternal={ true }
@@ -147,7 +147,8 @@ class EditorPreview extends React.Component {
 						) }
 					/>
 				) : (
-					<WebPreview
+					<AsyncLoad
+						require="components/web-preview"
 						showPreview={ this.props.showPreview }
 						defaultViewportDevice={ this.props.defaultViewportDevice }
 						onClose={ this.props.onClose }

--- a/client/post-editor/editor-seo-accordion/index.jsx
+++ b/client/post-editor/editor-seo-accordion/index.jsx
@@ -19,9 +19,9 @@ import AccordionSection from 'components/accordion/section';
 import CountedTextarea from 'components/forms/counted-textarea';
 import PostActions from 'lib/posts/actions';
 import EditorDrawerLabel from 'post-editor/editor-drawer/label';
-import WebPreview from 'components/web-preview';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import AsyncLoad from 'components/async-load';
 
 class EditorSeoAccordion extends Component {
 	static propTypes = {
@@ -83,7 +83,8 @@ class EditorSeoAccordion extends Component {
 							<Button className="editor-seo-accordion__preview-button" onClick={ this.showPreview }>
 								{ translate( 'Preview' ) }
 							</Button>
-							<WebPreview
+							<AsyncLoad
+								require="components/web-preview"
 								showPreview={ showPreview }
 								onClose={ this.hidePreview }
 								showDeviceSwitcher={ false }


### PR DESCRIPTION
Experimental, don't merge.

The `WebPreview` component is imported in `SitePreview` which is bundled in the main JS build file. @jsnajdr got an idea that we could async load it to reduce the size of the main build file. I'm doing that in this PR but it doesn't look the best. Wrote this in Slack:

"I'm playing with the async loading of SitePreview. My approach is to async load all occurrences of `WebPreview` actually, as that's the component which has like 250 KB.

I did that for like 10 files (various previews in editor, seo settings, etc). Lot of chunks went down in size by that 250 KB. However, some of them went up. Not by 250 KB but by 10 KB - 100 KB.

I think the problem is that `WebPreview` imports a lot of various modules and utils which are then shared across the whole codebase in `build`. When we async load `WebPreview`, we get rid of the 250 KB from some chunks but they gain the amount of KB needed for the various imports. I then calculated the difference between the sizes of all the packages and unfortunately, when we async load all the `WebPreview`s, we gain 1.7 MB of code.

What is more, when a customer is navigating through Calypso in one session, opening the site preview, then SEO preview, then writing a post and opening the post preview, etc – each time, they have to load the 250 KB `WebPreview` async loaded chunk. Or does it get reused? If not, it's like adding another 1 - 2 MB of data to download when using Calypso which is pretty bad.

In general, our only solution would be to manually (or codemod? – I have no exp with that) import all the shared modules/utils in `build` chunk so they get removed from the various smaller chunks and async load `WebPreview` as I did. But will that even save some data, in the end?"

`public` folder built on `master`:
![master](https://user-images.githubusercontent.com/4988512/34173512-f2cfb726-e4f5-11e7-891c-3fc280fc2017.png)

`public` folder built on this branch:

![async-loaded-web-preview](https://user-images.githubusercontent.com/4988512/34173521-f998dd8a-e4f5-11e7-900f-c8659ed91326.png)
