### PR TITLE
Contact form: Remove time for chat re-open after Christmas

### DIFF
--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -29,7 +29,7 @@ const HelpContactClosed = ( { translate } ) => {
 						: translate(
 								'Live chat is closed today for for the Christmas holiday. If you need to get in touch with us, ' +
 									'you can submit a support request below and we will get to it as fast as we can. Live chat will ' +
-									'reopen at 00:00 UTC on December 26. Thank you!'
+									'reopen on December 26. Thank you!'
 							) }
 				</p>
 			</div>


### PR DESCRIPTION
Very minor copy tweak to remove specific time that chat re-opens.