### PR TITLE
Rename 'Personalize your site' task

### DIFF
--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -34,7 +34,7 @@ const tasks = {
 		tour: 'checklistUserAvatar',
 	},
 	blogname_set: {
-		title: 'Personalize your site',
+		title: 'Give your site a name',
 		description: 'Give your site a descriptive name to entice visitors.',
 		duration: '1 min',
 		completedTitle: 'You updated your site title',


### PR DESCRIPTION
This PR updates the "Personalize your site" task title to "Give your site a name"

## Before
![image](https://user-images.githubusercontent.com/6981253/34176144-df72c0a2-e4cc-11e7-934c-51c16c8ae2d3.png)

## After
![image](https://user-images.githubusercontent.com/6981253/34176115-c85c5f18-e4cc-11e7-907c-a0a369acd3a3.png)

@markryall @taggon can you please review?

Thanks to the suggestion from @lsinger 