### PR TITLE
Post Editor: remove { pure: false } from Redux connect calls

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -362,25 +362,20 @@ EditorDrawer.displayName = 'EditorDrawer';
 
 const enhance = flow(
 	localize,
-	connect(
-		state => {
-			const siteId = getSelectedSiteId( state );
-			const type = getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' );
+	connect( state => {
+		const siteId = getSelectedSiteId( state );
+		const type = getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' );
 
-			return {
-				isPermalinkEditable: areSitePermalinksEditable( state, siteId ),
-				canJetpackUseTaxonomies: isJetpackMinimumVersion( state, siteId, '4.1' ),
-				isJetpack: isJetpackSite( state, siteId ),
-				isSeoToolsModuleActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
-				jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4-beta1' ),
-				type,
-				typeObject: getPostType( state, siteId, type ),
-			};
-		},
-		null,
-		null,
-		{ pure: false }
-	)
+		return {
+			isPermalinkEditable: areSitePermalinksEditable( state, siteId ),
+			canJetpackUseTaxonomies: isJetpackMinimumVersion( state, siteId, '4.1' ),
+			isJetpack: isJetpackSite( state, siteId ),
+			isSeoToolsModuleActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
+			jetpackVersionSupportsSeo: isJetpackMinimumVersion( state, siteId, '4.4-beta1' ),
+			type,
+			typeObject: getPostType( state, siteId, type ),
+		};
+	} )
 );
 
 export default enhance( EditorDrawer );

--- a/client/post-editor/editor-seo-accordion/index.jsx
+++ b/client/post-editor/editor-seo-accordion/index.jsx
@@ -113,9 +113,4 @@ const mapStateToProps = state => {
 	};
 };
 
-export default connect(
-	mapStateToProps,
-	null,
-	null,
-	{ pure: false } // defaults to true, but this component has internal state
-)( localize( EditorSeoAccordion ) );
+export default connect( mapStateToProps )( localize( EditorSeoAccordion ) );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -1373,9 +1373,7 @@ const enhance = flow(
 			recordTracksEvent,
 			closeEditorSidebar,
 			openEditorSidebar,
-		},
-		null,
-		{ pure: false }
+		}
 	)
 );
 


### PR DESCRIPTION
Remove `{ pure: false}` from several `connect` calls in Post Editor components. It's no longer needed. This patch will avoid a lot of unneeded component rerenders in the editor sidebar.

The `{ pure: false}` option was originally added by @aduth in #3983 to fix a bug where the editor UI wouldn't get updated when switching between the "Visual" and "HTML" tabs. The bug was caused by code like this:
```jsx
const preferences = { 'editor-mode': 'html' };
const setEditorMode = mode => ( preferences['editor-mode'] = mode );
<PostEditor preferences={preferences} setEditorMode={setEditorMode} />
```
The `preferences` object reference is identical (`===`) to the previous one although a property was changed. The `shouldComponentUpdate` generated by `Connect(PostEditor)` therefore prevents a rerender.

The right fix would have been to add the `observe( preferences )` mixin that would force an update when the `preferences` Flux store fires a `change` event.

The preferences were converted to Redux a long time ago, so the problem doesn't happen any more.

All three changed components (`EditorDrawer`, `PostEditor` and `EditorSeoAccordion`) either rely on Redux for their props, or listen for changes in the Flux stores they use. The reviewer is kindly asked to verify that that's really the case.

**How to test:**
Click around the post editor and especially the sidebar and verify that nothing is broken.

There is also a performance win here. Try to do this:
1. Go to an Atomic site that has Simple Payments enabled and start editing a post.
2. Select "Payment Button" in the "Add" menu.
3. Start typing something into the form in the modal and profile the typing with Chrome profiler

Because the form uses Redux Form, every keystroke dispatches an action to the global store and its performance suffers when Redux does things it shouldn't, like rerendering components that didn't change at all. In your profile, you'll see the `EditorDrawer`, `PostEditor` and `EditorSeoAccordion` being updated and rerendered without reason. There are also several others, but these three do that because of the `{ pure: false }` option.

Verify that these updates disappear after applying this patch.