### PR TITLE
SitePicker: don't render on initial Calypso load

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -34,6 +34,7 @@ const debug = debugFactory( 'calypso:site-selector' );
 
 class SiteSelector extends Component {
 	static propTypes = {
+		isPlaceholder: PropTypes.bool,
 		sites: PropTypes.array,
 		siteBasePath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 		showAddNewSite: PropTypes.bool,
@@ -368,6 +369,12 @@ class SiteSelector extends Component {
 	}
 
 	render() {
+		// Render an empty div.site-selector element as a placeholder. It's useful for lazy
+		// rendering of the selector in sidebar while keeping the on-appear animation work.
+		if ( this.props.isPlaceholder ) {
+			return <div className="site-selector" />;
+		}
+
 		const hiddenSitesCount = this.props.siteCount - this.props.visibleSiteCount;
 
 		const selectorClass = classNames( 'site-selector', 'sites-list', this.props.className, {

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -36,6 +36,7 @@ class SitePicker extends React.Component {
 	state = {
 		isAutoFocused: false,
 		isOpened: false,
+		isRendered: false,
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -46,6 +47,10 @@ class SitePicker extends React.Component {
 		const isAutoFocused = nextProps.currentLayoutFocus === 'sites';
 		if ( isAutoFocused !== this.state.isAutoFocused ) {
 			this.setState( { isAutoFocused } );
+		}
+
+		if ( nextProps.currentLayoutFocus === 'sites' && ! this.state.isRendered ) {
+			this.setState( { isRendered: true } );
 		}
 	}
 
@@ -82,6 +87,10 @@ class SitePicker extends React.Component {
 	};
 
 	render() {
+		if ( ! this.state.isRendered && this.props.currentLayoutFocus !== 'sites' ) {
+			return null;
+		}
+
 		return (
 			<div>
 				<CloseOnEscape onEscape={ this.closePicker } />

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -35,11 +35,14 @@ class SitePicker extends React.Component {
 
 	state = {
 		isAutoFocused: false,
-		isOpened: false,
-		isRendered: false,
+		isRendered: this.props.currentLayoutFocus === 'sites',
 	};
 
 	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.currentLayoutFocus === 'sites' && ! this.state.isRendered ) {
+			this.setState( { isRendered: true } );
+		}
+
 		if ( ! nextProps.currentLayoutFocus || hasTouch() ) {
 			return;
 		}
@@ -47,10 +50,6 @@ class SitePicker extends React.Component {
 		const isAutoFocused = nextProps.currentLayoutFocus === 'sites';
 		if ( isAutoFocused !== this.state.isAutoFocused ) {
 			this.setState( { isAutoFocused } );
-		}
-
-		if ( nextProps.currentLayoutFocus === 'sites' && ! this.state.isRendered ) {
-			this.setState( { isRendered: true } );
 		}
 	}
 
@@ -87,15 +86,11 @@ class SitePicker extends React.Component {
 	};
 
 	render() {
-		if ( ! this.state.isRendered && this.props.currentLayoutFocus !== 'sites' ) {
-			return null;
-		}
-
 		return (
 			<div>
 				<CloseOnEscape onEscape={ this.closePicker } />
 				<SiteSelector
-					ref="siteSelector"
+					isPlaceholder={ ! this.state.isRendered }
 					indicator={ true }
 					showAddNewSite={ true }
 					showAllSites={ true }


### PR DESCRIPTION
To make Calypso initial page load faster, we are experimenting with not rendering `SitePicker` (which renders `SiteSelector`) on the initial page load. After a customer clicks on "Switch Site", it will be rendered. When it's hidden (ie clicking outside of it), it will not be unmounted from DOM but just hidden as it's done now. We've found out that removing it from DOM and re-adding is slower than just hiding and showing once rendered.

The main issue is animations. Currently, when you click on "Switch Site", it's nicely animated:
![image](https://user-images.githubusercontent.com/4988512/34178411-5b548900-e507-11e7-8198-3cf9f78ba5a5.png)

That's possible because the `SitePicker` is already rendered in the DOM but just hidden with `opacity: 0`. Opacity is then set to `1` when "Switch Site" is clicked. If we don't pre-render `SitePicker` on initial Calypso load (as we do in this PR), I'm not sure we can animate the initial opening of it. Any ideas?

/cc @jsnajdr 