### PR TITLE
Memoize the results of the getSiteUserConnections selector

### DIFF
--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -9,6 +9,7 @@ import { filter, get } from 'lodash';
 /**
  * Internal dependencies
  */
+import createSelector from 'lib/create-selector';
 import { canCurrentUser } from 'state/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -33,12 +34,16 @@ export function getConnectionsBySiteId( state, siteId ) {
  * @param  {Number} userId User ID to filter
  * @return {Array}         User connections
  */
-export function getSiteUserConnections( state, siteId, userId ) {
-	return filter( state.sharing.publicize.connections, connection => {
-		const { site_ID, shared, keyring_connection_user_ID } = connection;
-		return site_ID === siteId && ( shared || keyring_connection_user_ID === userId );
-	} );
-}
+export const getSiteUserConnections = createSelector(
+	( state, siteId, userId ) =>
+		filter(
+			state.sharing.publicize.connections,
+			connection =>
+				connection.site_ID === siteId &&
+				( connection.shared || connection.keyring_connection_user_ID === userId )
+		),
+	state => [ state.sharing.publicize.connections ]
+);
 
 /**
  * Returns an array of known connections for the given site ID


### PR DESCRIPTION
The `getSiteUserConnections` selector now returns a new array every time it's called, even with identical `state`. This has performance implications, namely for the `EditorSharingAccordion` component that gets rerendered each and every time any Redux action is dispatched, even when completely unrelated.

**How to test:**
Open the "Sharing" accordion in post editor. Does it display your Facebook/Google/Twitter connections correctly?

How to spot the performance difference: repeat the Redux Form exercise from #20966:
1. Go to an Atomic site that has Simple Payments enabled and start editing a post.
2. Select "Payment Button" in the "Add" menu.
3. Start typing something into the form in the modal and profile the typing with Chrome profiler

Because the form uses Redux Form, every keystroke dispatches an action to the global store and its performance suffers when Redux does things it shouldn't, like rerendering components that didn't change at all. In this particular case, watch out for `EditorSharingAccordion`. Does it disappear from the profile after applying this patch?