### PR TITLE
Domains: Copy and style updates for incoming domain pre-check step 2

### DIFF
--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -134,6 +134,11 @@
 		justify-content: space-between;
 	}
 
+	.transfer-domain-step__section-callout {
+		background: $gray-light;
+		margin: 14px 0;
+	}
+
 	&.is-expanded {
 		align-items: flex-start;
 
@@ -191,6 +196,8 @@
 }
 
 .transfer-domain-step__admin-email {
+	display: block;
+	margin-top: 20px;
 	hyphens: auto;
 	overflow-wrap: break-word;
 	word-break: break-word;

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -226,7 +226,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 		);
 		let buttonText = translate( 'I can access the email address' );
 
-		if ( ! email ) {
+		if ( email ) {
 			message = translate(
 				"{{card}}Make sure you can access the email address listed for this domain's owner. " +
 					"We'll send a link to start the process to the following email address: {{strong}}%(email)s{{/strong}}{{/card}}" +

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -16,6 +16,7 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import Notice from 'components/notice';
 import { recordTracksEvent } from 'state/analytics/actions';
 import FormattedHeader from 'components/formatted-header';
 import { checkInboundTransferStatus } from 'lib/domains';
@@ -201,14 +202,17 @@ class TransferDomainPrecheck extends React.PureComponent {
 
 		const heading = translate( 'Verify we can get in touch.' );
 		let message = translate(
-			"Make sure you have access to the email address on your domain's contact information with privacy " +
-				"protection turned off. We couldn't get the email address on file and we need to send an important " +
-				'email to start the transfer process.' +
+			"{{notice}}We couldn't get the email address listed for this domain's owner and we " +
+				'need to send an important email to start the process.{{/notice}}' +
+				'{{strong}}Make sure you can access the email address listed for your domain and ' +
+				'privacy protection is disabled.{{/strong}}' +
 				'{{br/}}{{br/}}' +
-				'Log in to your current domain provider to check your contact information and make sure privacy ' +
-				"is disabled. {{a}}Here's how to do that{{/a}}. Don't worry, you can turn it on once the transfer is done.",
+				'Log in to your current domain provider to double check the domain contact email address and ' +
+				"make sure to disable privacy protection. {{a}}Here's how to do that{{/a}}.",
 			{
 				components: {
+					notice: <Notice showDismiss={ false } status="is-warning" />,
+					strong: <strong />,
 					br: <br />,
 					a: (
 						<a
@@ -222,19 +226,24 @@ class TransferDomainPrecheck extends React.PureComponent {
 		);
 		let buttonText = translate( 'I can access the email address' );
 
-		if ( email ) {
+		if ( ! email ) {
 			message = translate(
-				"Make sure you have access to the email address on your domain's contact information with privacy " +
-					"protection turned off. We'll send an email to {{strong}}%(email)s{{/strong}} to start the " +
-					"transfer process. Don't recognize that address? Then you might have privacy protection enabled." +
-					'{{br/}}{{br/}}' +
-					'Log in to your current domain provider to check your contact information and make sure privacy ' +
-					"is disabled. {{a}}Here's how to do that{{/a}}. Don't worry, you can turn it on once the transfer is done.",
+				"{{card}}Make sure you can access the email address listed for this domain's owner. " +
+					"We'll send a link to start the process to the following email address: {{strong}}%(email)s{{/strong}}{{/card}}" +
+					"Don't recognize that address? You may have privacy protection enabled. It has to be " +
+					'disabled temporarily for the transfer to work. Log in to your current domain provider to ' +
+					"disable privacy protection. {{a}}Here's how to do that{{/a}}.",
 				{
 					args: { email },
 					components: {
+						card: (
+							<Card
+								className="transfer-domain-step__section-callout"
+								compact={ true }
+								highlight="warning"
+							/>
+						),
 						strong: <strong className="transfer-domain-step__admin-email" />,
-						br: <br />,
 						a: (
 							<a
 								href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY }
@@ -246,7 +255,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 				}
 			);
 
-			buttonText = translate( 'I can access this email address' );
+			buttonText = translate( 'I can access the email address listed' );
 		}
 
 		const statusClasses = loading


### PR DESCRIPTION
We've seen a trend with users not fully understanding this step when transferring a domain. This PR attempts to call out the required action and make the email address more noticeable. Hopefully this breaks up the wall of text enough to help users better understand what they have to do before clicking the button to continue.

**If we can get the email address:**

Before | After
------------ | -------------
<img width="744" alt="screen shot 2017-12-19 at 17 26 50" src="https://user-images.githubusercontent.com/448298/34181886-ff1a285e-e4e1-11e7-8eb7-94796a5d295c.png"> | <img width="737" alt="screen shot 2017-12-19 at 16 56 30" src="https://user-images.githubusercontent.com/448298/34181763-86ba208a-e4e1-11e7-8fa7-dafca2ba9017.png">

**If we can't get the email address:**

Before | After
------------ | -------------
<img width="745" alt="screen shot 2017-12-19 at 17 27 17" src="https://user-images.githubusercontent.com/448298/34181893-02d6210a-e4e2-11e7-9f70-a15f549c7f12.png"> | <img width="738" alt="screen shot 2017-12-19 at 17 16 55" src="https://user-images.githubusercontent.com/448298/34181790-a2755114-e4e1-11e7-8e78-e440666992d2.png">
