### PR TITLE
Customizer: try passing extra information to have the iframe nonce check succeed

### DIFF
--- a/client/lib/wp/support.js
+++ b/client/lib/wp/support.js
@@ -29,9 +29,23 @@ export default function wpcomSupport( wpcom ) {
 		} );
 	};
 
+	/**
+	 * Add the supportUser and supportToken to the query.
+	 * @param {Object}  params The original request params object
+	 * @return {Object}        The new query object with support data injected
+	 */
+	const addSupportParams = function( params ) {
+		return {
+			...params,
+			support_user: supportUser,
+			_support_token: supportToken,
+		};
+	};
+
 	const request = wpcom.request.bind( wpcom );
 
 	return Object.assign( wpcom, {
+		addSupportParams,
 		fetchSupportUserToken: function( username, password ) {
 			return wpcom.req.post(
 				{

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -27,6 +27,7 @@ import { getCustomizerFocus } from './panels';
 import { getMenusUrl } from 'state/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getCustomizerUrl, isJetpackSite } from 'state/sites/selectors';
+import wpcom from 'lib/wp';
 
 const debug = debugFactory( 'calypso:my-sites:customize' );
 
@@ -185,6 +186,10 @@ class Customize extends React.Component {
 			query.customize_amp = 1;
 		}
 
+		//needed to load the customizer correctly when su'd
+		if ( wpcom.addSupportParams ) {
+			return Qs.stringify( wpcom.addSupportParams( query ) );
+		}
 		return Qs.stringify( query );
 	};
 


### PR DESCRIPTION
While SU'd the customizer would fail to load due to X-FRAME-OPTIONS set to `sameorigin`. Apply D8965-code before testing the branch.