### PR TITLE
Activity log: Fix race condition on polling

### DIFF
--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -83,6 +83,9 @@ export const continuePolling = ( { dispatch }, action ) => {
 		}
 
 		const timer = setTimeout( () => {
+			// Since we update the list of sites with pollingSites.set()
+			// We need to check to make sure that the site was not removed.
+			// Otherwise this causes a bug where we poll the site forever.
 			if ( ! pollingSites.get( siteId ) ) {
 				return;
 			}

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -42,9 +42,17 @@ export const togglePolling = ( { dispatch, getState }, { isWatching, siteId } ) 
 			)
 		);
 	} else {
-		pollingSites.delete( siteId );
+		removePolling( siteId );
 	}
 };
+
+function removePolling( siteId ) {
+	const state = pollingSites.get( siteId );
+	if ( state.timer ) {
+		clearTimeout( state.timer );
+	}
+	pollingSites.delete( siteId );
+}
 
 export const continuePolling = ( { dispatch }, action ) => {
 	if ( ! get( action, 'meta.dataLayer.isWatching' ) ) {
@@ -55,7 +63,7 @@ export const continuePolling = ( { dispatch }, action ) => {
 
 	const error = getError( action );
 	if ( undefined !== error ) {
-		pollingSites.delete( siteId );
+		removePolling( siteId );
 
 		dispatch( recordTracksEvent( 'calypso_activity_log_polling_fail', { siteId } ) );
 		return;

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -42,17 +42,9 @@ export const togglePolling = ( { dispatch, getState }, { isWatching, siteId } ) 
 			)
 		);
 	} else {
-		removePolling( siteId );
+		pollingSites.delete( siteId );
 	}
 };
-
-function removePolling( siteId ) {
-	const state = pollingSites.get( siteId );
-	if ( state.timer ) {
-		clearTimeout( state.timer );
-	}
-	pollingSites.delete( siteId );
-}
 
 export const continuePolling = ( { dispatch }, action ) => {
 	if ( ! get( action, 'meta.dataLayer.isWatching' ) ) {
@@ -63,7 +55,7 @@ export const continuePolling = ( { dispatch }, action ) => {
 
 	const error = getError( action );
 	if ( undefined !== error ) {
-		removePolling( siteId );
+		pollingSites.delete( siteId );
 
 		dispatch( recordTracksEvent( 'calypso_activity_log_polling_fail', { siteId } ) );
 		return;
@@ -91,6 +83,9 @@ export const continuePolling = ( { dispatch }, action ) => {
 		}
 
 		const timer = setTimeout( () => {
+			if ( ! pollingSites.get( siteId ) ) {
+				return;
+			}
 			pollingSites.set( siteId, { ...pollingSites.get( siteId ), timer: null } );
 			dispatch(
 				merge(


### PR DESCRIPTION
When we remove the polling of a site we forgot to delete the timer which causes the sites to be polled forever. In some cases resulting in api being called where we never set the start_date.

To replicate the bug 
Go to activity log for a site then switch to a different site. 
Notice in the network tab that we still continue to query the activity log of both sites. 

This PR fixes is by removing the timer so that we stop doing that. 
Notice that the previous site's activity log doesn't get queried in the network tab. 



