### PR TITLE
Introduce some navigation steps to about page tour

### DIFF
--- a/client/layout/guided-tours/tours/checklist-about-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour.js
@@ -26,11 +26,23 @@ export const ChecklistAboutPageTour = makeTour(
 	<Tour name="checklistAboutPage" version="20171205" path="/non-existent-route" when={ noop }>
 		<Step
 			name="init"
-			placement="right"
+			placement="beside"
+			arrow="left-top"
+			target="side-menu-page"
 			style={ {
 				animationDelay: '0.7s',
 			} }
 		>
+			<p>First we need to navigate to the pages section.</p>
+			<Continue target="side-menu-page" step="choose-page" click hidden />
+		</Step>
+
+		<Step name="choose-page" placement="right">
+			<p>Now we click the title of the About Page (the page we want to edit).</p>
+			<Next step="about-page">Got it!</Next>
+		</Step>
+
+		<Step name="about-page" placement="right">
 			<p>
 				{ translate(
 					'The About Page is often the most visited page on a site. ' +

--- a/client/layout/guided-tours/tours/checklist-about-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour.js
@@ -13,7 +13,6 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import {
-	ButtonRow,
 	Continue,
 	makeTour,
 	Next,
@@ -30,39 +29,42 @@ export const ChecklistAboutPageTour = makeTour(
 			arrow="left-top"
 			target="side-menu-page"
 			style={ {
-				animationDelay: '0.7s',
+				animationDelay: '0s',
 			} }
 		>
-			<p>First we need to navigate to the pages section.</p>
+			<p>
+				{ translate( 'Click on {{b}}Site Pages{{/b}} to see all the pages on our site.', {
+					components: { b: <strong /> },
+				} ) }
+			</p>
 			<Continue target="side-menu-page" step="choose-page" click hidden />
 		</Step>
 
-		<Step name="choose-page" placement="right">
-			<p>Now we click the title of the About Page (the page we want to edit).</p>
-			<Next step="about-page">Got it!</Next>
+		<Step name="choose-page" target="page-about" arrow="top-left" placement="below">
+			<p>
+				{ translate( 'Click {{b}}About{{/b}} to edit this page.', {
+					components: { b: <strong /> },
+				} ) }
+			</p>
+			<Continue target="page-about" step="about-page" click hidden />
 		</Step>
 
 		<Step name="about-page" placement="right">
 			<p>
 				{ translate(
-					'The About Page is often the most visited page on a site. ' +
-						'You might find that it never feels quite done - that’s OK. ' +
-						'This is the internet and we can update it as many times as we want. ' +
-						'The key is to just get it started.'
+					'The About Page is often the most visited page on a site. You might find ' +
+						'that it never feels quite done - that’s OK. This is the internet and ' +
+						'we can update it as many times as we want. The key is to just get it started.'
 				) }
 			</p>
 			<p>
 				{ translate(
-					'Let’s start by changing the default text with an introduction. ' +
-						'Here are some questions to help you out: Who are you and where are you based? ' +
-						'Why did you start this site? ' +
+					'Let’s change the default text with a new introduction. Here are some questions ' +
+						'to help you out: Who are you and where are you based? Why did you start this site? ' +
 						'What can visitors expect to get out of it?'
 				) }
 			</p>
-			<ButtonRow>
-				<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
-			</ButtonRow>
+			<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
 		</Step>
 
 		<Step

--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -27,7 +27,7 @@ const HelpContactClosed = ( { translate } ) => {
 									'we will get to it as fast as we can. Live chat will reopen on December 26th. Thank you!'
 							)
 						: translate(
-								'Live chat is closed today for for the Christmas holiday. If you need to get in touch with us, ' +
+								'Live chat is closed today for the Christmas holiday. If you need to get in touch with us, ' +
 									'you can submit a support request below and we will get to it as fast as we can. Live chat will ' +
 									'reopen on December 26. Thank you!'
 							) }

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -18,7 +18,6 @@ const tasks = {
 		duration: '10 mins',
 		completedTitle: 'You updated your About page',
 		completedButtonText: 'Change',
-		url: '/page/$siteSlug/2',
 		image: '/calypso/images/stats/tasks/about.svg',
 		tour: 'checklistAboutPage',
 	},

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -410,6 +410,7 @@ class Page extends Component {
 								: translate( 'View %(title)s', { textOnly: true, args: { title: page.title } } )
 						}
 						onClick={ this.props.recordPageTitle }
+						data-tip-target={ 'page-' + page.slug }
 					>
 						{ depthIndicator }
 						{ title }

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -199,6 +199,7 @@ class ManageMenu extends PureComponent {
 				icon={ icon }
 				preloadSectionName={ preload }
 				postType={ menuItem.name }
+				tipTarget={ `side-menu-${ menuItem.name }` }
 			>
 				{ menuItem.name === 'media' && (
 					<MediaLibraryUploadButton


### PR DESCRIPTION
This PR introduces some steps to the About Page tour so that the tour can start on the checklist page.

This makes the tour more resilient in case the about page has a different id and also avoids the issue where the tour would not launch on initial click (due to the sequence of events).

The copy for the steps is a placeholder at this stage.

