### PR TITLE
Domains/ccTLDs: Add organization field to ca-form

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { camelCase, difference, isEmpty, keys, map, pick } from 'lodash';
+import { camelCase, difference, includes, isEmpty, keys, map, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,6 +21,11 @@ import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormInputValidation from 'components/forms/form-input-validation';
+import { Input } from 'my-sites/domains/components/form';
+
+// the organization field is optional for individuals
+const individualLegalTypes = [ 'CCT', 'MAJ', 'RES' ];
+const maybeIndividualLegalTypes = [ 'LGR', 'OMK', 'ABO' ];
 
 const ciraAgreementUrl = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
 const defaultValues = {
@@ -131,6 +136,31 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 		this.setState( { hasBeenClicked: true } );
 	};
 
+	currentlegalTypeIsAnIndividual() {
+		const { legalType } = this.props.contactDetailsExtra;
+
+		return includes( individualLegalTypes, legalType );
+	}
+
+	renderOrganizationField() {
+		const { translate } = this.props;
+		const { legalType } = this.props.contactDetailsExtra;
+
+		const className = includes( maybeIndividualLegalTypes, legalType )
+			? 'registrant-extra-info__optional'
+			: 'registrant-extra-info';
+
+		return (
+			<FormFieldset>
+				<Input
+					className={ className }
+					label={ translate( 'Organization' ) }
+					{ ...this.props.getFieldProps( 'organization' ) }
+				/>
+			</FormFieldset>
+		);
+	}
+
 	render() {
 		const { translate } = this.props;
 		const { legalTypeOptions, hasBeenClicked } = this.state;
@@ -185,7 +215,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 						) : null }
 					</FormLabel>
 				</FormFieldset>
-
+				{ this.currentlegalTypeIsAnIndividual() || this.renderOrganizationField() }
 				{ validatingSubmitButton }
 			</form>
 		);

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { camelCase, difference, includes, isEmpty, keys, map, pick } from 'lodash';
+import { camelCase, difference, isEmpty, keys, map, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,10 +22,6 @@ import FormSelect from 'components/forms/form-select';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormInputValidation from 'components/forms/form-input-validation';
 import { Input } from 'my-sites/domains/components/form';
-
-// the organization field is optional for individuals
-const individualLegalTypes = [ 'CCT', 'MAJ', 'RES' ];
-const maybeIndividualLegalTypes = [ 'LGR', 'OMK', 'ABO' ];
 
 const ciraAgreementUrl = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
 const defaultValues = {
@@ -136,19 +132,9 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 		this.setState( { hasBeenClicked: true } );
 	};
 
-	currentlegalTypeIsAnIndividual() {
-		const { legalType } = this.props.contactDetailsExtra;
-
-		return includes( individualLegalTypes, legalType );
-	}
-
 	renderOrganizationField() {
 		const { translate } = this.props;
-		const { legalType } = this.props.contactDetailsExtra;
-
-		const className = includes( maybeIndividualLegalTypes, legalType )
-			? 'registrant-extra-info__optional'
-			: 'registrant-extra-info';
+		const className = 'registrant-extra-info';
 
 		return (
 			<FormFieldset>
@@ -215,7 +201,12 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 						) : null }
 					</FormLabel>
 				</FormFieldset>
-				{ this.currentlegalTypeIsAnIndividual() || this.renderOrganizationField() }
+				{
+					// We have to validate the organization name for CCO legal
+					// types to avoid OpenSRS rejecting them and causing errors
+					// during payment
+					legalType !== 'CCO' || this.renderOrganizationField()
+				}
 				{ validatingSubmitButton }
 			</form>
 		);

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -141,7 +141,11 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 				<Input
 					className={ className }
 					label={ translate( 'Organization' ) }
-					{ ...this.props.getFieldProps( 'organization' ) }
+					{ ...// getFieldProps() includes all the callbacks we need
+					// to have this organization field behave the same as
+					// the field in the parent, particularly the state and
+					// back end validation
+					this.props.getFieldProps( 'organization' ) }
 				/>
 			</FormFieldset>
 		);
@@ -201,12 +205,10 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 						) : null }
 					</FormLabel>
 				</FormFieldset>
-				{
-					// We have to validate the organization name for CCO legal
-					// types to avoid OpenSRS rejecting them and causing errors
-					// during payment
-					legalType !== 'CCO' || this.renderOrganizationField()
-				}
+				{ // We have to validate the organization name for CCO legal
+				// types to avoid OpenSRS rejecting them and causing errors
+				// during payment
+				legalType !== 'CCO' || this.renderOrganizationField() }
 				{ validatingSubmitButton }
 			</form>
 		);

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -80,11 +80,8 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 			</option>
 		) );
 
-		this.state = {
-			legalTypes,
-			legalTypeOptions,
-			uncheckedCiraAgreementFlag: false,
-		};
+		this.legalTypes = legalTypes;
+		this.legalTypeOptions = legalTypeOptions;
 	}
 
 	componentWillMount() {
@@ -143,7 +140,6 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 
 	render() {
 		const { getFieldProps, translate } = this.props;
-		const { legalTypeOptions } = this.state;
 		const { legalType, ciraAgreementAccepted } = {
 			...defaultValues,
 			...this.props.contactDetailsExtra,
@@ -182,7 +178,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 						className="registrant-extra-info__form-legal-type"
 						onChange={ this.handleChangeEvent }
 					>
-						{ legalTypeOptions }
+						{ this.legalTypeOptions }
 					</FormSelect>
 				</FormFieldset>
 				<FormFieldset>
@@ -200,9 +196,9 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 								},
 							} ) }
 						</span>
-						{ ciraAgreementAccepted ? (
+						{ ciraAgreementAccepted || (
 							<FormInputValidation text={ translate( 'Required' ) } isError={ true } />
-						) : null }
+						) }
 					</FormLabel>
 				</FormFieldset>
 				{ doesntNeedOrganizationValidation || this.renderOrganizationField() }

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -120,6 +120,11 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 	};
 
 	renderOrganizationField( organizationFieldProps ) {
+		// These props include all the values and callbacks we need to
+		// have this organization field behave the same as the field in the
+		// parent (domain-details-form), particularly around the
+		// formState and back end validation
+
 		const { translate } = this.props;
 		const className = 'registrant-extra-info';
 
@@ -128,11 +133,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 				<Input
 					className={ className }
 					label={ translate( 'Organization' ) }
-					{ ...// These props includes all the callbacks we need to
-					// have this organization field behave the same as
-					// the field in the parent, particularly around the
-					// formState and back end validation
-					organizationFieldProps }
+					{ ...organizationFieldProps }
 				/>
 			</FormFieldset>
 		);

--- a/client/components/domains/registrant-extra-info/test/index.js
+++ b/client/components/domains/registrant-extra-info/test/index.js
@@ -13,6 +13,9 @@ import RegistrantExtraInfoCaForm from '../ca-form';
 import RegistrantExtraInfoFrForm from '../fr-form';
 import RegistrantExtraInfoForm from '../index';
 
+jest.mock( 'store', () => ( { get: () => {}, set: () => {} } ) );
+jest.mock( 'lib/analytics', () => {} );
+
 describe( 'Switcher Form', () => {
 	test( 'should render correct form for fr', () => {
 		const wrapper = shallow( <RegistrantExtraInfoForm tld="fr" /> );

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -459,7 +459,11 @@ export class DomainDetailsForm extends PureComponent {
 	}
 
 	renderExtraDetailsForm( tld ) {
-		return <ExtraInfoForm tld={ tld }>{ this.renderSubmitButton() }</ExtraInfoForm>;
+		return (
+			<ExtraInfoForm tld={ tld } getFieldProps={ this.getFieldProps }>
+				{ this.renderSubmitButton() }
+			</ExtraInfoForm>
+		);
 	}
 
 	handleRadioChange = enable => {


### PR DESCRIPTION
This PR adds the organization field to the ca-form so we can validate against the tld-specific requirements for this field.

OpenSRS will not provision domains that don't meet these criteria, leading to cryptic error messages and a very poor user experience, and we've been getting a steady trickle of reports from our Happiness Engineers about it.

To test, add a .ca domain to your cart and make sure that the the ca form is properly validated:
- The organization field is required for legal type "Canadian Organization"
- Optional otherwise (I checked this by throwing every option at OpenSRS)
- If present, the organization name needs to include one of the strings on OpenSRS's white-list (e.g. Inc, corp, llc, sarl, bank, banque etc. It's quite a long list)
- The cira agreement must be accepted

It's also worth confirming that in-flight validation works ok. You should not be able to submit until we get the validation results back from the server. We've also had issues in the past with components are not visible when the validation comes back from the server, so it's worth confirming that that works too.

![ca-form-organization](https://user-images.githubusercontent.com/5952255/34296315-d355f986-e75d-11e7-84a8-14c330a6ec55.gif)

We already have some non-trivial validation running on the back end, so in this the case it doesn't make as much sense to add the client-side validation the way we did in https://github.com/Automattic/wp-calypso/pull/20043, and the Organization is only compulsory for a specific value of the tld-specific `legalType` , so we can't just run the validation in the `domains-details-form` either, unfortunately.

Instead, we're going to leverage the existing `formState` logic from `domain-details-form` by passing in the `getFieldProps()` which has closed around the formState. I don't love how tightly coupled this leaves the `ca-form` and the `domain-details-form`, but it seems like a reasonable compromise because:
- it's exactly what we need in this case, and we get really clean re-use.
- There's a clear seam for testing (getFieldProps).
- The life cycle is being directly managed by the `domain-details-form` so there's no way the `ca-form` can exist before or after the state it depends on is mounted.

I've also changed the way the submit behaved. We used to hide the "Required" validation note and enable the submit button until the user clicks submit (I'm pretty sure "we" here is "me". Maybe I was aiming for "Haha! Gotcha!"? ;) ). The new behaviour has the submit button disabled while the form is invalid, and shows the validation warnings for fields the user needs to update to change. Now that this form has back-end validation, we also wait for any in-flight validation to return when the user hits submit.