### PR TITLE
Jetpack connect: Remove bad and unused icon prop

### DIFF
--- a/client/jetpack-connect/auth-logged-in-form.jsx
+++ b/client/jetpack-connect/auth-logged-in-form.jsx
@@ -522,7 +522,7 @@ export class LoggedInForm extends Component {
 		} = this.props.authorizationData;
 		const { blogname, redirectAfterAuth } = this.props.authQuery;
 		const backToWpAdminLink = (
-			<LoggedOutFormLinkItem icon={ true } href={ redirectAfterAuth }>
+			<LoggedOutFormLinkItem href={ redirectAfterAuth }>
 				<Gridicon size={ 18 } icon="arrow-left" />{' '}
 				{ translate( 'Return to %(sitename)s', {
 					args: { sitename: decodeEntities( blogname ) },


### PR DESCRIPTION
This PR removes a prop that was causing warnings and appears to be unintentional:

![warning](https://user-images.githubusercontent.com/841763/34204180-1086a99a-e57e-11e7-83d7-6017f92c572e.png)

## Testing
1. The warning shows at /jetpack/connect/authorize when logged in to WordPress.com
1. Verify the warning is not displayed during connection and that the items display as before.

