### PR TITLE
Component: Fix LoggedOutLinkFormItem props

### DIFF
--- a/client/components/logged-out-form/link-item.jsx
+++ b/client/components/logged-out-form/link-item.jsx
@@ -7,17 +7,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
-export default class LoggedOutFormLinkItem extends React.Component {
-	static propTypes = { className: PropTypes.string };
-
-	render() {
-		return (
-			<a
-				{ ...this.props }
-				className={ classnames( 'logged-out-form__link-item', this.props.className ) }
-			>
-				{ this.props.children }
-			</a>
-		);
-	}
+export default function LoggedOutFormLinkItem( props ) {
+	return (
+		<a { ...props } className={ classnames( 'logged-out-form__link-item', props.className ) }>
+			{ props.children }
+		</a>
+	);
 }
+LoggedOutFormLinkItem.propTypes = { className: PropTypes.string };

--- a/client/components/logged-out-form/link-item.jsx
+++ b/client/components/logged-out-form/link-item.jsx
@@ -9,12 +9,8 @@ import React from 'react';
 import classnames from 'classnames';
 import { omit } from 'lodash';
 
-export default class extends React.Component {
-	static displayName = 'LoggedOutFormLinkItem';
-
-	static propTypes = {
-		className: PropTypes.string,
-	};
+export default class LoggedOutFormLinkItem extends React.Component {
+	static propTypes = { className: PropTypes.string };
 
 	render() {
 		return (

--- a/client/components/logged-out-form/link-item.jsx
+++ b/client/components/logged-out-form/link-item.jsx
@@ -3,11 +3,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { omit } from 'lodash';
 
 export default class LoggedOutFormLinkItem extends React.Component {
 	static propTypes = { className: PropTypes.string };
@@ -15,7 +13,7 @@ export default class LoggedOutFormLinkItem extends React.Component {
 	render() {
 		return (
 			<a
-				{ ...omit( this.props, 'classNames' ) }
+				{ ...this.props }
 				className={ classnames( 'logged-out-form__link-item', this.props.className ) }
 			>
 				{ this.props.children }

--- a/client/components/logged-out-form/test/__snapshots__/link-item.js.snap
+++ b/client/components/logged-out-form/test/__snapshots__/link-item.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoggedOutFormLinkItem should render an <a> element 1`] = `
+<a
+  className="logged-out-form__link-item"
+  href="http://example.com"
+>
+  Example text here
+</a>
+`;

--- a/client/components/logged-out-form/test/link-item.js
+++ b/client/components/logged-out-form/test/link-item.js
@@ -1,0 +1,31 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import LoggedOutFormLinkItem from '../link-item';
+
+describe( 'LoggedOutFormLinkItem', () => {
+	test( 'should render an <a> element', () => {
+		const wrapper = shallow(
+			<LoggedOutFormLinkItem href="http://example.com">Example text here</LoggedOutFormLinkItem>
+		);
+
+		expect( wrapper ).toMatchSnapshot();
+		expect( wrapper.type() ).toBe( 'a' );
+	} );
+
+	test( 'should include own class and append passed class', () => {
+		const testClass = 'test-classname';
+		const wrapper = shallow( <LoggedOutFormLinkItem className={ testClass } /> );
+
+		expect( wrapper.hasClass( testClass ) ).toBe( true );
+		expect( wrapper.hasClass( 'logged-out-form__link-item' ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
This PR removes an `omit` on props that included a typo resulting in a no-op. Additionally, `omit` is not necessary here as the prop will be overwritten anyways.

Spotted while working on #20986 

## Testing
1. Tests pass?
1. [Snapshot](https://github.com/Automattic/wp-calypso/pull/20987/files#diff-58d7a881869509ee6212e9fe1da185f1) is as expected?