### PR TITLE
Site Tour: Improve translation consistency

### DIFF
--- a/client/layout/guided-tours/tours/checklist-about-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour.js
@@ -21,6 +21,9 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 
+const SetFeaturedImageButtonLabel = translate( 'Set Featured Image' );
+const UpdateButtonLabel = translate( 'Update' );
+
 export const ChecklistAboutPageTour = makeTour(
 	<Tour name="checklistAboutPage" version="20171205" path="/non-existent-route" when={ noop }>
 		<Step name="init" target="page-about" arrow="top-left" placement="below">
@@ -84,9 +87,11 @@ export const ChecklistAboutPageTour = makeTour(
 		>
 			<Continue target="dialog-base-action-confirm" step="click-update" click>
 				{ translate(
-					'We’re all set, press {{b}}Set Featured Image{{/b}} to add this image to your page.',
+					'We’re all set, press {{SetFeaturedImageButton/}} to add this image to your page.',
 					{
-						components: { b: <strong /> },
+						components: {
+							SetFeaturedImageButton: <strong>{ SetFeaturedImageButtonLabel }</strong>,
+						},
 					}
 				) }
 			</Continue>
@@ -94,8 +99,8 @@ export const ChecklistAboutPageTour = makeTour(
 
 		<Step name="click-update" target="editor-publish-button" arrow="right-top" placement="beside">
 			<Continue target="editor-publish-button" step="finish" click>
-				{ translate( 'Almost done, press the {{b}}Update{{/b}} button to save your changes.', {
-					components: { b: <strong /> },
+				{ translate( 'Almost done, press the {{UpdateButton/}} button to save your changes.', {
+					components: { UpdateButton: <strong>{ UpdateButtonLabel }</strong> },
 				} ) }
 			</Continue>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-about-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour.js
@@ -21,8 +21,8 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 
-const SetFeaturedImageButtonLabel = translate( 'Set Featured Image' );
-const UpdateButtonLabel = translate( 'Update' );
+const SET_FEATURED_IMAGE_BUTTON_LABEL = translate( 'Set Featured Image' );
+const UPDATE_BUTTON_LABEL = translate( 'Update' );
 
 export const ChecklistAboutPageTour = makeTour(
 	<Tour name="checklistAboutPage" version="20171205" path="/non-existent-route" when={ noop }>
@@ -87,10 +87,10 @@ export const ChecklistAboutPageTour = makeTour(
 		>
 			<Continue target="dialog-base-action-confirm" step="click-update" click>
 				{ translate(
-					'We’re all set, press {{SetFeaturedImageButton/}} to add this image to your page.',
+					'We’re all set, press {{setFeaturedImageButton/}} to add this image to your page.',
 					{
 						components: {
-							SetFeaturedImageButton: <strong>{ SetFeaturedImageButtonLabel }</strong>,
+							setFeaturedImageButton: <strong>{ SET_FEATURED_IMAGE_BUTTON_LABEL }</strong>,
 						},
 					}
 				) }
@@ -99,8 +99,8 @@ export const ChecklistAboutPageTour = makeTour(
 
 		<Step name="click-update" target="editor-publish-button" arrow="right-top" placement="beside">
 			<Continue target="editor-publish-button" step="finish" click>
-				{ translate( 'Almost done, press the {{UpdateButton/}} button to save your changes.', {
-					components: { UpdateButton: <strong>{ UpdateButtonLabel }</strong> },
+				{ translate( 'Almost done, press the {{updateButton/}} button to save your changes.', {
+					components: { updateButton: <strong>{ UPDATE_BUTTON_LABEL }</strong> },
 				} ) }
 			</Continue>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -27,6 +27,9 @@ function isPostEditorSection( state ) {
 	return getSectionName( state ) === 'post-editor';
 }
 
+const SetFeaturedImageButtonLabel = translate( 'Set Featured Image' );
+const UpdateButtonLabel = translate( 'Update' );
+
 export const ChecklistContactPageTour = makeTour(
 	<Tour name="checklistContactPage" version="20171205" path="/non-existent-route" when={ noop }>
 		<Step
@@ -47,7 +50,7 @@ export const ChecklistContactPageTour = makeTour(
 				) }
 			</p>
 			<ButtonRow>
-				<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
+			<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
 				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 				<Continue step="featured-images" hidden />
 			</ButtonRow>
@@ -92,9 +95,11 @@ export const ChecklistContactPageTour = makeTour(
 		>
 			<Continue target="dialog-base-action-confirm" step="click-update" click>
 				{ translate(
-					'We’re all set, press {{b}}Set Featured Image{{/b}} to add this image to your page.',
+					'We’re all set, press {{SetFeaturedImageButton/}} to add this image to your page.',
 					{
-						components: { b: <strong /> },
+						components: {
+							SetFeaturedImageButton: <strong>{ SetFeaturedImageButtonLabel }</strong>,
+						},
 					}
 				) }
 			</Continue>
@@ -108,8 +113,8 @@ export const ChecklistContactPageTour = makeTour(
 			style={ { marginTop: '-10px' } }
 		>
 			<Continue target="editor-publish-button" step="finish" click>
-				{ translate( 'Almost done, press the {{b}}Update{{/b}} button to save your changes.', {
-					components: { b: <strong /> },
+				{ translate( 'Almost done, press the {{UpdateButton/}} button to save your changes.', {
+					components: { UpdateButton: <strong>{ UpdateButtonLabel }</strong> },
 				} ) }
 			</Continue>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -27,8 +27,8 @@ function isPostEditorSection( state ) {
 	return getSectionName( state ) === 'post-editor';
 }
 
-const SetFeaturedImageButtonLabel = translate( 'Set Featured Image' );
-const UpdateButtonLabel = translate( 'Update' );
+const SET_FEATURED_IMAGE_BUTTON_LABEL = translate( 'Set Featured Image' );
+const UPDATE_BUTTON_LABEL = translate( 'Update' );
 
 export const ChecklistContactPageTour = makeTour(
 	<Tour name="checklistContactPage" version="20171205" path="/non-existent-route" when={ noop }>
@@ -50,7 +50,7 @@ export const ChecklistContactPageTour = makeTour(
 				) }
 			</p>
 			<ButtonRow>
-			<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
+				<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
 				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 				<Continue step="featured-images" hidden />
 			</ButtonRow>
@@ -95,10 +95,10 @@ export const ChecklistContactPageTour = makeTour(
 		>
 			<Continue target="dialog-base-action-confirm" step="click-update" click>
 				{ translate(
-					'We’re all set, press {{SetFeaturedImageButton/}} to add this image to your page.',
+					'We’re all set, press {{setFeaturedImageButton/}} to add this image to your page.',
 					{
 						components: {
-							SetFeaturedImageButton: <strong>{ SetFeaturedImageButtonLabel }</strong>,
+							setFeaturedImageButton: <strong>{ SET_FEATURED_IMAGE_BUTTON_LABEL }</strong>,
 						},
 					}
 				) }
@@ -113,8 +113,8 @@ export const ChecklistContactPageTour = makeTour(
 			style={ { marginTop: '-10px' } }
 		>
 			<Continue target="editor-publish-button" step="finish" click>
-				{ translate( 'Almost done, press the {{UpdateButton/}} button to save your changes.', {
-					components: { UpdateButton: <strong>{ UpdateButtonLabel }</strong> },
+				{ translate( 'Almost done, press the {{updateButton/}} button to save your changes.', {
+					components: { updateButton: <strong>{ UPDATE_BUTTON_LABEL }</strong> },
 				} ) }
 			</Continue>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-site-icon-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour.js
@@ -22,6 +22,10 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 
+const ChangeButtonLabel = translate( 'Change' );
+const ContinueButtonLabel = translate( 'Continue' );
+const DoneButtonLabel = translate( 'Done' );
+
 function handleTargetDisappear( { quit, next } ) {
 	const dialog = document.querySelector( '.editor-media-modal' );
 	if ( dialog ) {
@@ -45,7 +49,10 @@ export const ChecklistSiteIconTour = makeTour(
 		>
 			<p>
 				{ translate(
-					'Press this graphic to upload your own image or icon that can help people identify your site in the browser.'
+					'Press {{ChangeButton/}} to upload your own image or icon that can help people identify your site in the browser.',
+					{
+						components: { ChangeButton: <strong>{ ChangeButtonLabel }</strong> },
+					}
 				) }
 			</p>
 			<ButtonRow>
@@ -82,8 +89,8 @@ export const ChecklistSiteIconTour = makeTour(
 			onTargetDisappear={ handleTargetDisappear }
 		>
 			<Continue target="dialog-base-action-confirm" step="click-done" click>
-				{ translate( 'Good choice, press {{b}}Continue{{/b}} to use it as your Site Icon.', {
-					components: { b: <strong /> },
+				{ translate( 'Good choice, press {{ContinueButton/}} to use it as your Site Icon.', {
+					components: { ContinueButton: <strong>{ ContinueButtonLabel }</strong> },
 				} ) }
 			</Continue>
 		</Step>
@@ -97,8 +104,8 @@ export const ChecklistSiteIconTour = makeTour(
 		>
 			<Continue target="image-editor-button-done" step="finish" click>
 				{ translate(
-					'Let’s make sure it looks right before you press {{b}}Done{{/b}} to save your changes.',
-					{ components: { b: <strong /> } }
+					'Let’s make sure it looks right before you press {{DoneButton/}} to save your changes.',
+					{ components: { DoneButton: <strong>{ DoneButtonLabel }</strong> } }
 				) }
 			</Continue>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-site-icon-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour.js
@@ -22,9 +22,9 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 
-const ChangeButtonLabel = translate( 'Change' );
-const ContinueButtonLabel = translate( 'Continue' );
-const DoneButtonLabel = translate( 'Done' );
+const CHANGE_BUTTON_LABEL = translate( 'Change' );
+const CONTINUE_BUTTON_LABEL = translate( 'Continue' );
+const DONE_BUTTON_LABEL = translate( 'Done' );
 
 function handleTargetDisappear( { quit, next } ) {
 	const dialog = document.querySelector( '.editor-media-modal' );
@@ -49,9 +49,9 @@ export const ChecklistSiteIconTour = makeTour(
 		>
 			<p>
 				{ translate(
-					'Press {{ChangeButton/}} to upload your own image or icon that can help people identify your site in the browser.',
+					'Press {{changeButton/}} to upload your own image or icon that can help people identify your site in the browser.',
 					{
-						components: { ChangeButton: <strong>{ ChangeButtonLabel }</strong> },
+						components: { changeButton: <strong>{ CHANGE_BUTTON_LABEL }</strong> },
 					}
 				) }
 			</p>
@@ -89,8 +89,8 @@ export const ChecklistSiteIconTour = makeTour(
 			onTargetDisappear={ handleTargetDisappear }
 		>
 			<Continue target="dialog-base-action-confirm" step="click-done" click>
-				{ translate( 'Good choice, press {{ContinueButton/}} to use it as your Site Icon.', {
-					components: { ContinueButton: <strong>{ ContinueButtonLabel }</strong> },
+				{ translate( 'Good choice, press {{continueButton/}} to use it as your Site Icon.', {
+					components: { continueButton: <strong>{ CONTINUE_BUTTON_LABEL }</strong> },
 				} ) }
 			</Continue>
 		</Step>
@@ -104,8 +104,8 @@ export const ChecklistSiteIconTour = makeTour(
 		>
 			<Continue target="image-editor-button-done" step="finish" click>
 				{ translate(
-					'Let’s make sure it looks right before you press {{DoneButton/}} to save your changes.',
-					{ components: { DoneButton: <strong>{ DoneButtonLabel }</strong> } }
+					'Let’s make sure it looks right before you press {{doneButton/}} to save your changes.',
+					{ components: { doneButton: <strong>{ DONE_BUTTON_LABEL }</strong> } }
 				) }
 			</Continue>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
@@ -22,6 +22,9 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 
+const SiteTagLineButtonLabel = translate( 'Site Tagline' );
+const SaveSettingsButtonLabel = translate( 'Save Settings' );
+
 export const ChecklistSiteTaglineTour = makeTour(
 	<Tour name="checklistSiteTagline" version="20171205" path="/non-existent-route" when={ noop }>
 		<Step
@@ -37,8 +40,8 @@ export const ChecklistSiteTaglineTour = makeTour(
 				{ translate(
 					'First impressions last - a tagline tells visitors what your site is all about without ' +
 						'having to read all your content. Enter a short descriptive phrase about your site into ' +
-						'the {{b}}Site Tagline{{/b}} field.',
-					{ components: { b: <strong /> } }
+						'the {{SiteTaglineButton/}} field.',
+					{ components: { SiteTaglineButton: <strong>{ SiteTagLineButtonLabel }</strong> } }
 				) }
 			</p>
 			<ButtonRow>
@@ -51,8 +54,8 @@ export const ChecklistSiteTaglineTour = makeTour(
 		<Step name="click-save" target="settings-site-profile-save" arrow="top-left" placement="below">
 			<Continue target="settings-site-profile-save" step="finish" click>
 				{ translate(
-					'Almost done — press {{b}}Save Settings{{/b}} to save your changes and then see what’s next on our list.',
-					{ components: { b: <strong /> } }
+					'Almost done — press {{SaveSettingsButton/}} to save your changes and then see what’s next on our list.',
+					{ components: { SaveSettingsButton: <strong>{ SaveSettingsButtonLabel }</strong> } }
 				) }
 			</Continue>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
@@ -22,8 +22,8 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 
-const SiteTagLineButtonLabel = translate( 'Site Tagline' );
-const SaveSettingsButtonLabel = translate( 'Save Settings' );
+const SITE_TAG_LINE_BUTTON_LABEL = translate( 'Site Tagline' );
+const SAVE_SETTINGS_BUTTON_LABEL = translate( 'Save Settings' );
 
 export const ChecklistSiteTaglineTour = makeTour(
 	<Tour name="checklistSiteTagline" version="20171205" path="/non-existent-route" when={ noop }>
@@ -40,8 +40,8 @@ export const ChecklistSiteTaglineTour = makeTour(
 				{ translate(
 					'First impressions last - a tagline tells visitors what your site is all about without ' +
 						'having to read all your content. Enter a short descriptive phrase about your site into ' +
-						'the {{SiteTaglineButton/}} field.',
-					{ components: { SiteTaglineButton: <strong>{ SiteTagLineButtonLabel }</strong> } }
+						'the {{siteTaglineButton/}} field.',
+					{ components: { siteTaglineButton: <strong>{ SITE_TAG_LINE_BUTTON_LABEL }</strong> } }
 				) }
 			</p>
 			<ButtonRow>
@@ -54,8 +54,8 @@ export const ChecklistSiteTaglineTour = makeTour(
 		<Step name="click-save" target="settings-site-profile-save" arrow="top-left" placement="below">
 			<Continue target="settings-site-profile-save" step="finish" click>
 				{ translate(
-					'Almost done — press {{SaveSettingsButton/}} to save your changes and then see what’s next on our list.',
-					{ components: { SaveSettingsButton: <strong>{ SaveSettingsButtonLabel }</strong> } }
+					'Almost done — press {{saveSettingsButton/}} to save your changes and then see what’s next on our list.',
+					{ components: { saveSettingsButton: <strong>{ SAVE_SETTINGS_BUTTON_LABEL }</strong> } }
 				) }
 			</Continue>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-site-title-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour.js
@@ -22,6 +22,8 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 
+const SiteTitleButtonLabel = translate( 'Site Title' );
+
 export const ChecklistSiteTitleTour = makeTour(
 	<Tour name="checklistSiteTitle" version="20171205" path="/non-existent-route" when={ noop }>
 		<Step
@@ -35,9 +37,9 @@ export const ChecklistSiteTitleTour = makeTour(
 		>
 			<p>
 				{ translate(
-					'Update the {{b}}Site Title{{/b}} field with a descriptive name to let your visitors know which site they’re visiting.',
+					'Update the {{SiteTitleButton/}} field with a descriptive name to let your visitors know which site they’re visiting.',
 					{
-						components: { b: <strong /> },
+						components: { SiteTitleButton: <strong>{ SiteTitleButtonLabel }</strong> },
 					}
 				) }
 			</p>

--- a/client/layout/guided-tours/tours/checklist-site-title-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour.js
@@ -22,7 +22,7 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 
-const SiteTitleButtonLabel = translate( 'Site Title' );
+const SITE_TITLE_BUTTON_LABEL = translate( 'Site Title' );
 
 export const ChecklistSiteTitleTour = makeTour(
 	<Tour name="checklistSiteTitle" version="20171205" path="/non-existent-route" when={ noop }>
@@ -37,9 +37,9 @@ export const ChecklistSiteTitleTour = makeTour(
 		>
 			<p>
 				{ translate(
-					'Update the {{SiteTitleButton/}} field with a descriptive name to let your visitors know which site they’re visiting.',
+					'Update the {{siteTitleButton/}} field with a descriptive name to let your visitors know which site they’re visiting.',
 					{
-						components: { SiteTitleButton: <strong>{ SiteTitleButtonLabel }</strong> },
+						components: { siteTitleButton: <strong>{ SITE_TITLE_BUTTON_LABEL }</strong> },
 					}
 				) }
 			</p>

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -24,6 +24,8 @@ import {
 import { isNewUser } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
 
+const PublishButtonLabel = translate( 'Publish' );
+
 export const EditorBasicsTour = makeTour(
 	<Tour
 		name="editorBasicsTour"
@@ -116,10 +118,10 @@ export const EditorBasicsTour = makeTour(
 			<p>
 				{ translate(
 					'Your changes are saved automatically. ' +
-						'Click {{strong}}Publish{{/strong}} to share your work with the world!',
+						'Click {{PublishButton/}} to share your work with the world!',
 					{
 						components: {
-							strong: <strong />,
+							PublishButton: <strong>{ PublishButtonLabel }</strong>,
 						},
 					}
 				) }

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -24,7 +24,7 @@ import {
 import { isNewUser } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
 
-const PublishButtonLabel = translate( 'Publish' );
+const PUBLISH_BUTTON_LABEL = translate( 'Publish' );
 
 export const EditorBasicsTour = makeTour(
 	<Tour
@@ -118,10 +118,10 @@ export const EditorBasicsTour = makeTour(
 			<p>
 				{ translate(
 					'Your changes are saved automatically. ' +
-						'Click {{PublishButton/}} to share your work with the world!',
+						'Click {{publishButton/}} to share your work with the world!',
 					{
 						components: {
-							PublishButton: <strong>{ PublishButtonLabel }</strong>,
+							publishButton: <strong>{ PUBLISH_BUTTON_LABEL }</strong>,
 						},
 					}
 				) }

--- a/client/layout/guided-tours/tours/editor-insert-menu-tour.js
+++ b/client/layout/guided-tours/tours/editor-insert-menu-tour.js
@@ -30,6 +30,8 @@ class RepositioningStep extends Step {
 	}
 }
 
+const AddMediaButtonLabel = translate( 'Add Media' );
+
 export const EditorInsertMenuTour = makeTour(
 	<Tour
 		name="editorInsertMenu"
@@ -49,15 +51,13 @@ export const EditorInsertMenuTour = makeTour(
 			} }
 		>
 			<p>
-				{ translate( '{{strong}}Add Media{{/strong}} has moved to a new button.', {
-					components: { strong: <strong /> },
-					comment: 'Title of the Guided Tour for the Editor Insert Menu button.',
+				{ translate( '{{AddMediaButton/}} has moved to a new button.', {
+					components: { AddMediaButton: <strong>{ AddMediaButtonLabel }</strong> },
 				} ) }
 			</p>
 			<p>
 				{ translate( 'Click {{icon/}} to add media and other kinds of content.', {
 					components: { icon: <Gridicon icon="chevron-down" /> },
-					comment: 'Refers to the Insert Content button and dropdown in the post editor.',
 				} ) }
 			</p>
 			<ButtonRow>

--- a/client/layout/guided-tours/tours/editor-insert-menu-tour.js
+++ b/client/layout/guided-tours/tours/editor-insert-menu-tour.js
@@ -30,7 +30,7 @@ class RepositioningStep extends Step {
 	}
 }
 
-const AddMediaButtonLabel = translate( 'Add Media' );
+const ADD_MEDIA_BUTTON_LABEL = translate( 'Add Media' );
 
 export const EditorInsertMenuTour = makeTour(
 	<Tour
@@ -51,8 +51,8 @@ export const EditorInsertMenuTour = makeTour(
 			} }
 		>
 			<p>
-				{ translate( '{{AddMediaButton/}} has moved to a new button.', {
-					components: { AddMediaButton: <strong>{ AddMediaButtonLabel }</strong> },
+				{ translate( '{{addMediaButton/}} has moved to a new button.', {
+					components: { addMediaButton: <strong>{ ADD_MEDIA_BUTTON_LABEL }</strong> },
 				} ) }
 			</p>
 			<p>

--- a/client/layout/guided-tours/tours/main-tour.js
+++ b/client/layout/guided-tours/tours/main-tour.js
@@ -31,6 +31,7 @@ import { getScrollableSidebar } from 'layout/guided-tours/positioning';
 import scrollTo from 'lib/scroll-to';
 
 const scrollSidebarToTop = () => scrollTo( { y: 0, container: getScrollableSidebar() } );
+const ViewSiteButtonLabel = translate( 'View Site' );
 
 // note that this tour checks for a non-existent feature flag.
 // this is kept as an example, while making sure it never gets triggered
@@ -96,9 +97,9 @@ export const MainTour = makeTour(
 		>
 			<p>{ translate( 'Want to take a look at your site?' ) }</p>
 			<Continue click step="view-site" target="sitePreview">
-				{ translate( 'Click {{strong}}View Site{{/strong}} to continue.', {
+				{ translate( 'Click {{ViewSiteButton/}} to continue.', {
 					components: {
-						strong: <strong />,
+						ViewSiteButton: <strong>{ ViewSiteButtonLabel }</strong>,
 					},
 				} ) }
 			</Continue>

--- a/client/layout/guided-tours/tours/main-tour.js
+++ b/client/layout/guided-tours/tours/main-tour.js
@@ -31,7 +31,7 @@ import { getScrollableSidebar } from 'layout/guided-tours/positioning';
 import scrollTo from 'lib/scroll-to';
 
 const scrollSidebarToTop = () => scrollTo( { y: 0, container: getScrollableSidebar() } );
-const ViewSiteButtonLabel = translate( 'View Site' );
+const VIEW_SITE_BUTTON_LABEL = translate( 'View Site' );
 
 // note that this tour checks for a non-existent feature flag.
 // this is kept as an example, while making sure it never gets triggered
@@ -97,9 +97,9 @@ export const MainTour = makeTour(
 		>
 			<p>{ translate( 'Want to take a look at your site?' ) }</p>
 			<Continue click step="view-site" target="sitePreview">
-				{ translate( 'Click {{ViewSiteButton/}} to continue.', {
+				{ translate( 'Click {{viewSiteButton/}} to continue.', {
 					components: {
-						ViewSiteButton: <strong>{ ViewSiteButtonLabel }</strong>,
+						viewSiteButton: <strong>{ VIEW_SITE_BUTTON_LABEL }</strong>,
 					},
 				} ) }
 			</Continue>

--- a/client/layout/guided-tours/tours/media-basics-tour.js
+++ b/client/layout/guided-tours/tours/media-basics-tour.js
@@ -24,6 +24,11 @@ import {
 import { doesSelectedSiteHaveMediaFiles, isNewUser } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
 
+const AddNewButtonLabel = translate( 'Add New' );
+const EditButtonLabel = translate( 'Edit' );
+const EditImageButtonLabel = translate( 'Edit Image' );
+const DoneButtonLabel = translate( 'Done' );
+
 export const MediaBasicsTour = makeTour(
 	<Tour
 		name="mediaBasicsTour"
@@ -36,11 +41,11 @@ export const MediaBasicsTour = makeTour(
 			<p>
 				{ translate(
 					'Upload media — photos, documents, audio files, and more — ' +
-						'by clicking the {{icon/}} {{strong}}Add New{{/strong}} button.',
+						'by clicking the {{icon/}} {{AddNewButton/}} button.',
 					{
 						components: {
 							icon: <Gridicon icon="add-image" />,
-							strong: <strong />,
+							AddNewButton: <strong>{ AddNewButtonLabel }</strong>,
 						},
 					}
 				) }
@@ -99,9 +104,9 @@ export const MediaBasicsTour = makeTour(
 			style={ { marginLeft: '-8px' } }
 		>
 			<Continue click step="launch-modal" target=".editor-media-modal__secondary-action">
-				{ translate( 'Now click the {{strong}}Edit{{/strong}} button.', {
+				{ translate( 'Now click the {{EditButton/}} button.', {
 					components: {
-						strong: <strong />,
+						EditButton: <strong>{ EditButtonLabel }</strong>,
 					},
 				} ) }
 			</Continue>
@@ -122,24 +127,21 @@ export const MediaBasicsTour = makeTour(
 		<Step name="done" placement="center">
 			<p>
 				{ translate(
-					'Need to adjust your image? Click {{icon/}} {{strong}}Edit Image{{/strong}} to perform basic tweaks.',
+					'Need to adjust your image? Click {{icon/}} {{EditImageButton/}} to perform basic tweaks.',
 					{
 						components: {
 							icon: <Gridicon icon="pencil" />,
-							strong: <strong />,
+							EditImageButton: <strong>{ EditImageButtonLabel }</strong>,
 						},
 					}
 				) }
 			</p>
 			<p>
-				{ translate(
-					'Click {{strong}}Done{{/strong}} to go back to your full library. Happy uploading!',
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				) }
+				{ translate( 'Click {{DoneButton /}} to go back to your full library. Happy uploading!', {
+					components: {
+						DoneButton: <strong>{ DoneButtonLabel }</strong>,
+					},
+				} ) }
 			</p>
 			<ButtonRow>
 				<Quit primary>{ translate( "Got it, I'm ready to explore!" ) }</Quit>

--- a/client/layout/guided-tours/tours/media-basics-tour.js
+++ b/client/layout/guided-tours/tours/media-basics-tour.js
@@ -24,10 +24,10 @@ import {
 import { doesSelectedSiteHaveMediaFiles, isNewUser } from 'state/ui/guided-tours/contexts';
 import { isDesktop } from 'lib/viewport';
 
-const AddNewButtonLabel = translate( 'Add New' );
-const EditButtonLabel = translate( 'Edit' );
-const EditImageButtonLabel = translate( 'Edit Image' );
-const DoneButtonLabel = translate( 'Done' );
+const ADD_NEW_BUTTON_LABEL = translate( 'Add New' );
+const EDIT_BUTTON_LABEL = translate( 'Edit' );
+const EDIT_IMAGE_BUTTON_LABEL = translate( 'Edit Image' );
+const DONE_BUTTON_LABEL = translate( 'Done' );
 
 export const MediaBasicsTour = makeTour(
 	<Tour
@@ -41,11 +41,11 @@ export const MediaBasicsTour = makeTour(
 			<p>
 				{ translate(
 					'Upload media — photos, documents, audio files, and more — ' +
-						'by clicking the {{icon/}} {{AddNewButton/}} button.',
+						'by clicking the {{icon/}} {{addNewButton/}} button.',
 					{
 						components: {
 							icon: <Gridicon icon="add-image" />,
-							AddNewButton: <strong>{ AddNewButtonLabel }</strong>,
+							addNewButton: <strong>{ ADD_NEW_BUTTON_LABEL }</strong>,
 						},
 					}
 				) }
@@ -104,9 +104,9 @@ export const MediaBasicsTour = makeTour(
 			style={ { marginLeft: '-8px' } }
 		>
 			<Continue click step="launch-modal" target=".editor-media-modal__secondary-action">
-				{ translate( 'Now click the {{EditButton/}} button.', {
+				{ translate( 'Now click the {{editButton/}} button.', {
 					components: {
-						EditButton: <strong>{ EditButtonLabel }</strong>,
+						editButton: <strong>{ EDIT_BUTTON_LABEL }</strong>,
 					},
 				} ) }
 			</Continue>
@@ -127,19 +127,19 @@ export const MediaBasicsTour = makeTour(
 		<Step name="done" placement="center">
 			<p>
 				{ translate(
-					'Need to adjust your image? Click {{icon/}} {{EditImageButton/}} to perform basic tweaks.',
+					'Need to adjust your image? Click {{icon/}} {{editImageButton/}} to perform basic tweaks.',
 					{
 						components: {
 							icon: <Gridicon icon="pencil" />,
-							EditImageButton: <strong>{ EditImageButtonLabel }</strong>,
+							editImageButton: <strong>{ EDIT_IMAGE_BUTTON_LABEL }</strong>,
 						},
 					}
 				) }
 			</p>
 			<p>
-				{ translate( 'Click {{DoneButton /}} to go back to your full library. Happy uploading!', {
+				{ translate( 'Click {{doneButton /}} to go back to your full library. Happy uploading!', {
 					components: {
-						DoneButton: <strong>{ DoneButtonLabel }</strong>,
+						doneButton: <strong>{ DONE_BUTTON_LABEL }</strong>,
 					},
 				} ) }
 			</p>

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -33,6 +33,12 @@ import { isDesktop } from 'lib/viewport';
 
 const TWO_DAYS_IN_MILLISECONDS = 2 * 1000 * 3600 * 24;
 
+const SettingsButtonLabel = translate( '{{icon/}} Settings', {
+	components: {
+		icon: <Gridicon icon="cog" />,
+	},
+} );
+
 export const SiteTitleTour = makeTour(
 	<Tour
 		name="siteTitle"
@@ -73,10 +79,9 @@ export const SiteTitleTour = makeTour(
 			shouldScrollTo
 		>
 			<Continue target="settings" step="site-title-input" click>
-				{ translate( 'Click {{strong}}{{icon/}} Settings{{/strong}} to continue.', {
+				{ translate( 'Click {{SettingsButton/}} to continue.', {
 					components: {
-						icon: <Gridicon icon="cog" />,
-						strong: <strong />,
+						SettingsButton: <strong>{ SettingsButtonLabel }</strong>,
 					},
 				} ) }
 			</Continue>

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -33,7 +33,7 @@ import { isDesktop } from 'lib/viewport';
 
 const TWO_DAYS_IN_MILLISECONDS = 2 * 1000 * 3600 * 24;
 
-const SettingsButtonLabel = translate( '{{icon/}} Settings', {
+const SETTINGS_BUTTON_LABEL = translate( '{{icon/}} Settings', {
 	components: {
 		icon: <Gridicon icon="cog" />,
 	},
@@ -79,9 +79,9 @@ export const SiteTitleTour = makeTour(
 			shouldScrollTo
 		>
 			<Continue target="settings" step="site-title-input" click>
-				{ translate( 'Click {{SettingsButton/}} to continue.', {
+				{ translate( 'Click {{settingsButton/}} to continue.', {
 					components: {
-						SettingsButton: <strong>{ SettingsButtonLabel }</strong>,
+						settingsButton: <strong>{ SETTINGS_BUTTON_LABEL }</strong>,
 					},
 				} ) }
 			</Continue>

--- a/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
+++ b/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
@@ -25,6 +25,8 @@ import { isAbTestInVariant, isEnabled, isNewUser } from 'state/ui/guided-tours/c
 import { isPreviewShowing } from 'state/ui/selectors';
 import { isDesktop } from 'lib/viewport';
 
+const AllThemesButtonLabel = translate( 'All Themes' );
+
 export const ThemeSheetWelcomeTour = makeTour(
 	<Tour
 		name="themeSheetWelcomeTour"
@@ -128,9 +130,9 @@ export const ThemeSheetWelcomeTour = makeTour(
 			<p>
 				{ translate(
 					"That's it! " +
-						'You can click on {{strong}}All Themes{{/strong}} at any time to return to our design showcase.',
+						'You can click on {{AllThemesButton/}} at any time to return to our design showcase.',
 					{
-						components: { strong: <strong /> },
+						components: { AllThemesButton: <strong>{ AllThemesButtonLabel }</strong> },
 					}
 				) }
 			</p>

--- a/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
+++ b/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
@@ -25,7 +25,7 @@ import { isAbTestInVariant, isEnabled, isNewUser } from 'state/ui/guided-tours/c
 import { isPreviewShowing } from 'state/ui/selectors';
 import { isDesktop } from 'lib/viewport';
 
-const AllThemesButtonLabel = translate( 'All Themes' );
+const ALL_THEMES_BUTTON_LABEL = translate( 'All Themes' );
 
 export const ThemeSheetWelcomeTour = makeTour(
 	<Tour
@@ -130,9 +130,9 @@ export const ThemeSheetWelcomeTour = makeTour(
 			<p>
 				{ translate(
 					"That's it! " +
-						'You can click on {{AllThemesButton/}} at any time to return to our design showcase.',
+						'You can click on {{allThemesButton/}} at any time to return to our design showcase.',
 					{
-						components: { AllThemesButton: <strong>{ AllThemesButtonLabel }</strong> },
+						components: { allThemesButton: <strong>{ ALL_THEMES_BUTTON_LABEL }</strong> },
 					}
 				) }
 			</p>

--- a/client/layout/guided-tours/tours/tutorial-site-preview-tour.js
+++ b/client/layout/guided-tours/tours/tutorial-site-preview-tour.js
@@ -21,6 +21,8 @@ import {
 } from 'layout/guided-tours/config-elements';
 import { isNewUser, isEnabled, isSelectedSitePreviewable } from 'state/ui/guided-tours/contexts';
 
+const ViewSiteButtonLabel = translate( 'View Site' );
+
 export const TutorialSitePreviewTour = makeTour(
 	<Tour
 		name="tutorialSitePreview"
@@ -41,10 +43,10 @@ export const TutorialSitePreviewTour = makeTour(
 		>
 			<p>
 				{ translate(
-					'{{strong}}View Site{{/strong}} shows you what your site looks like to visitors. Click it to continue.',
+					'{{ViewSiteButton/}} shows you what your site looks like to visitors. Click it to continue.',
 					{
 						components: {
-							strong: <strong />,
+							ViewSiteButton: <strong>{ ViewSiteButtonLabel }</strong>,
 						},
 					}
 				) }

--- a/client/layout/guided-tours/tours/tutorial-site-preview-tour.js
+++ b/client/layout/guided-tours/tours/tutorial-site-preview-tour.js
@@ -21,7 +21,7 @@ import {
 } from 'layout/guided-tours/config-elements';
 import { isNewUser, isEnabled, isSelectedSitePreviewable } from 'state/ui/guided-tours/contexts';
 
-const ViewSiteButtonLabel = translate( 'View Site' );
+const VIEW_SITE_BUTTON_LABEL = translate( 'View Site' );
 
 export const TutorialSitePreviewTour = makeTour(
 	<Tour
@@ -43,10 +43,10 @@ export const TutorialSitePreviewTour = makeTour(
 		>
 			<p>
 				{ translate(
-					'{{ViewSiteButton/}} shows you what your site looks like to visitors. Click it to continue.',
+					'{{viewSiteButton/}} shows you what your site looks like to visitors. Click it to continue.',
 					{
 						components: {
-							ViewSiteButton: <strong>{ ViewSiteButtonLabel }</strong>,
+							viewSiteButton: <strong>{ VIEW_SITE_BUTTON_LABEL }</strong>,
 						},
 					}
 				) }


### PR DESCRIPTION
When referring to buttons or labels, we need to make sure that the labels are the same. When translating these, there is a chance different translators would translate the texts differently, thus creating an inconsistency ("Please click the _Save Settings_ button", but there is only a button _Save Configuration_).

By using the translation label as a component, this can be achieved quite easily. It also makes it possible to change the button label translation and the tour text will be altered accordingly.