### PR TITLE
EditLinkForPage: add safeguards against null page or site

### DIFF
--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -8,8 +8,16 @@ import { assign, forEach, groupBy, includes, map, reduce, sortBy } from 'lodash'
 const sortByMenuOrder = list => sortBy( list, 'menu_order' );
 const getParentId = page => page.parent && page.parent.ID;
 
-export const editLinkForPage = ( { ID: pageId } = {}, { ID: siteId, slug } = {} ) =>
-	pageId && siteId ? `/page/${ slug }/${ pageId }` : null;
+export const editLinkForPage = ( page, site ) => {
+	if ( ! page || ! site ) {
+		return null;
+	}
+
+	const { ID: pageId } = page;
+	const { ID: siteId, slug } = site;
+
+	return pageId && siteId ? `/page/${ slug }/${ pageId }` : null;
+};
 
 export const statsLinkForPage = ( { ID: pageId } = {}, { ID: siteId, slug } ) =>
 	pageId && siteId ? `/stats/post/${ pageId }/${ slug }` : null;


### PR DESCRIPTION
Fixes regression introduced in #20390.

When navigating to the All pages view `/pages` with cleared cache, it's throwing the following error:

![image](https://user-images.githubusercontent.com/4988512/34207989-e74ab382-e58c-11e7-9a5d-2228e72d8a44.png)

The problem is that we are trying to access the `ID` prop of a site or post which are `null` at that time. The function parameter object destructuring defaults help us if the parameter is not specified at all (`undefined`) but not against `null`.

## Testing

First, try to repro the original issue. Checkout `master` and go to `http://calypso.localhost:3000/pages` with opened dev console. Now, in the "Application" tab, hit "Clear site data" (uncheck Cookies so it doesn't log you out). Reload the page. You should see the same error which is on the above screenshot.

Now, checkout this branch and try to repro again. You should not.