### PR TITLE
Domains: Assume domain is unlocked if status is null.

### DIFF
--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -65,12 +65,12 @@ class TransferDomainPrecheck extends React.PureComponent {
 				return;
 			}
 
-			if ( proceedToNextStep && result.unlocked ) {
+			if ( proceedToNextStep && ( true === result.unlocked || null === result.unlocked ) ) {
 				this.showNextStep();
 			}
 
 			// Reset steps if domain became locked again
-			if ( ! result.unlocked ) {
+			if ( false === result.unlocked ) {
 				this.resetSteps();
 			}
 


### PR DESCRIPTION
If no status information is returned from whois, then the `inbound-transfer-status` endpoint sets the unlocked parameter to `null`. Since some registrars don't return status information, we should probably just assume that a domain with no status is unlocked.

To test:

Hack the endpoint to return `null` for the `unlocked` parameter.
Attempt to start a transfer
The precheck page should successfully pass the unlocked step.
