### PR TITLE
Community Translator: Make compatible with React 16

### DIFF
--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -43,6 +43,8 @@ class NavTabs extends Component {
 	};
 
 	componentDidMount() {
+		// eslint-disable-next-line
+		console.log( this.props.selectedText );
 		this.setDropdownAfterLayoutFlush();
 		window.addEventListener( 'resize', this.setDropdownDebounced );
 	}

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -43,8 +43,6 @@ class NavTabs extends Component {
 	};
 
 	componentDidMount() {
-		// eslint-disable-next-line
-		console.log( this.props.selectedText );
 		this.setDropdownAfterLayoutFlush();
 		window.addEventListener( 'resize', this.setDropdownDebounced );
 	}

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -6,7 +6,6 @@
 
 import debugModule from 'debug';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import i18n from 'i18n-calypso';
 import { find } from 'lodash';
 
@@ -107,19 +106,17 @@ const communityTranslatorJumpstart = {
 			props[ 'data-plural' ] = optionsFromPage.plural;
 		}
 
-		// React.DOM.data returns a frozen object, therefore we make a copy so that we can modify it below
-		// const dataElement = Object.assign( {}, React.DOM.data( props, displayedTranslationFromPage ) );
+		// <data> returns a frozen object, therefore we make a copy so that we can modify it below
+		const dataElement = Object.assign(
+			{},
+			<data { ...props }>{ displayedTranslationFromPage }</data>
+		);
 
-		const dataElement = <data { ...props }> { displayedTranslationFromPage } </data>;
-
-		// eslint-disable-next-line
-		// console.log( dataElement );
-
-/*		// now we can override the toString function which would otherwise return [object Object]
+		// now we can override the toString function which would otherwise return [object Object]
 		dataElement.toString = () => displayedTranslationFromPage;
 
 		// freeze the object again to certify the same behavior as the original ReactElement object
-		Object.freeze( dataElement );*/
+		Object.freeze( dataElement );
 
 		return dataElement;
 	},

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -6,6 +6,7 @@
 
 import debugModule from 'debug';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import i18n from 'i18n-calypso';
 import { find } from 'lodash';
 
@@ -51,10 +52,6 @@ var injectUrl,
  */
 const communityTranslatorJumpstart = {
 	isEnabled() {
-		if ( ! config.isEnabled( 'community-translator' ) ) {
-			return false;
-		}
-
 		const currentUser = user.get();
 
 		if ( ! currentUser || 'en' === currentUser.localeSlug || ! currentUser.localeSlug ) {
@@ -76,6 +73,7 @@ const communityTranslatorJumpstart = {
 
 		return true;
 	},
+
 	isActivated() {
 		return _shouldWrapTranslations;
 	},
@@ -110,13 +108,18 @@ const communityTranslatorJumpstart = {
 		}
 
 		// React.DOM.data returns a frozen object, therefore we make a copy so that we can modify it below
-		const dataElement = Object.assign( {}, React.DOM.data( props, displayedTranslationFromPage ) );
+		// const dataElement = Object.assign( {}, React.DOM.data( props, displayedTranslationFromPage ) );
 
-		// now we can override the toString function which would otherwise return [object Object]
+		const dataElement = <data { ...props }> { displayedTranslationFromPage } </data>;
+
+		// eslint-disable-next-line
+		// console.log( dataElement );
+
+/*		// now we can override the toString function which would otherwise return [object Object]
 		dataElement.toString = () => displayedTranslationFromPage;
 
 		// freeze the object again to certify the same behavior as the original ReactElement object
-		Object.freeze( dataElement );
+		Object.freeze( dataElement );*/
 
 		return dataElement;
 	},

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -152,7 +152,7 @@ const Account = createReactClass( {
 		const { translate } = this.props;
 		const userLocale = this.getUserSetting( 'language' );
 		const showTranslator = userLocale && userLocale !== 'en';
-		if ( config.isEnabled( 'community-translator' ) && showTranslator ) {
+		if ( showTranslator ) {
 			return (
 				<FormFieldset>
 					<FormLegend>{ translate( 'Community Translator' ) }</FormLegend>


### PR DESCRIPTION
The Community Translator was broken with React 16 (see #20534) and therefore disabled in #20555. One reason is that `React.DOM` was deprecated.

**Testing**
- Enable the Community Translator on /me/account
- Save
- Click the globe icon on the bottom right to activate it
- Make sure nothing breaks