### PR TITLE
Update header and add link

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -14,6 +14,7 @@ export default {
 	COMMENTS: `${ root }/category/comments`,
 	COMMUNITY_TRANSLATOR: `${ root }/community-translator`,
 	COMPLETING_GOOGLE_APPS_SIGNUP: `${ root }/adding-g-suite-to-your-site/#completing-sign-up`,
+	CONCIERGE_SUPPORT: `${ root }/concierge-support`,
 	CONNECT: `${ root }/connect`,
 	CONTACT: `${ root }/contact`,
 	CALYPSO_CONTACT: '/help/contact',

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { isEmpty } from 'lodash';
 import { localize, moment } from 'i18n-calypso';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -25,18 +26,24 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import { getLanguage } from 'lib/i18n-utils';
+const defaultLanguage = getLanguage( config( 'i18n_default_locale_slug' ) ).name;
 
 class CalendarCard extends Component {
 	static propTypes = {
 		date: PropTypes.number.isRequired,
 		disabled: PropTypes.bool.isRequired,
+		isDefaultLocale: PropTypes.bool.isRequired,
 		onSubmit: PropTypes.func.isRequired,
 		times: PropTypes.arrayOf( PropTypes.number ).isRequired,
+		timezone: PropTypes.string.isRequired,
 	};
 
 	state = {
 		selectedTime: this.props.times[ 0 ],
 	};
+
+	withTimezone = dateTime => moment( dateTime ).tz( this.props.timezone );
 
 	/**
 	 * Returns a string representing the day of the week, with certain dates using natural
@@ -47,7 +54,7 @@ class CalendarCard extends Component {
 	 */
 	getDayOfWeekString = date => {
 		const { translate } = this.props;
-		const today = moment().startOf( 'day' );
+		const today = this.withTimezone().startOf( 'day' );
 		const dayOffset = today.diff( date.startOf( 'day' ), 'days' );
 
 		switch ( dayOffset ) {
@@ -61,7 +68,7 @@ class CalendarCard extends Component {
 
 	renderHeader = () => {
 		// The "Header" is that part of the foldable card that you click on to expand it.
-		const date = moment( this.props.date );
+		const date = this.withTimezone( this.props.date );
 
 		return (
 			<div className="concierge__calendar-card-header">
@@ -82,7 +89,12 @@ class CalendarCard extends Component {
 	};
 
 	render() {
-		const { disabled, times, translate } = this.props;
+		const { disabled, isDefaultLocale, signupForm, times, translate } = this.props;
+		const description = isDefaultLocale
+			? translate( 'Sessions are 30 minutes long.' )
+			: translate( 'Sessions are 30 minutes long and in %(defaultLanguage)s.', {
+				args: { defaultLanguage },
+			} );
 
 		return (
 			<FoldableCard
@@ -105,13 +117,11 @@ class CalendarCard extends Component {
 					>
 						{ times.map( time => (
 							<option value={ time } key={ time }>
-								{ moment( time ).format( 'h:mma z' ) }
+								{ this.withTimezone( time ).format( 'h:mma z' ) }
 							</option>
 						) ) }
 					</FormSelect>
-					<FormSettingExplanation>
-						{ translate( 'Sessions are 30 minutes long.' ) }
-					</FormSettingExplanation>
+					<FormSettingExplanation>{ description }</FormSettingExplanation>
 				</FormFieldset>
 
 				<FormFieldset>

--- a/client/me/concierge/calendar-step.js
+++ b/client/me/concierge/calendar-step.js
@@ -15,22 +15,24 @@ import CalendarCard from './calendar-card';
 import CompactCard from 'components/card/compact';
 import HeaderCake from 'components/header-cake';
 import { getConciergeSignupForm } from 'state/selectors';
-import { getCurrentUserId } from 'state/current-user/selectors';
+import { getCurrentUserId, getCurrentUserLocale } from 'state/current-user/selectors';
 import { bookConciergeAppointment } from 'state/concierge/actions';
 import {
 	CONCIERGE_STATUS_BOOKING,
 	CONCIERGE_STATUS_BOOKED,
 	WPCOM_CONCIERGE_SCHEDULE_ID,
 } from './constants';
+import { isDefaultLocale } from 'lib/i18n-utils';
 
 const NUMBER_OF_DAYS_TO_SHOW = 7;
 
-const groupAvailableTimesByDate = availableTimes => {
+const groupAvailableTimesByDate = ( availableTimes, timezone ) => {
 	const dates = {};
 
 	// Stub an object of { date: X, times: [] } for each day we care about
 	for ( let x = 0; x < NUMBER_OF_DAYS_TO_SHOW; x++ ) {
 		const startOfDay = moment()
+			.tz( timezone )
 			.startOf( 'day' )
 			.add( x, 'days' )
 			.valueOf();
@@ -40,6 +42,7 @@ const groupAvailableTimesByDate = availableTimes => {
 	// Go through all available times and bundle them into each date object
 	availableTimes.forEach( beginTimestamp => {
 		const startOfDay = moment( beginTimestamp )
+			.tz( timezone )
 			.startOf( 'day' )
 			.valueOf();
 		if ( dates.hasOwnProperty( startOfDay ) ) {
@@ -85,24 +88,24 @@ class CalendarStep extends Component {
 	}
 
 	render() {
-		const { availableTimes, translate } = this.props;
-		const availability = groupAvailableTimesByDate( availableTimes );
+		const { availableTimes, currentUserLocale, onBack, signupForm, translate } = this.props;
+		const availability = groupAvailableTimesByDate( availableTimes, signupForm.timezone );
 
 		return (
 			<div>
-				<HeaderCake onClick={ this.props.onBack }>
-					{ translate( 'Choose Concierge Session' ) }
-				</HeaderCake>
+				<HeaderCake onClick={ onBack }>{ translate( 'Choose Concierge Session' ) }</HeaderCake>
 				<CompactCard>
 					{ translate( 'Please select a day to have your Concierge session.' ) }
 				</CompactCard>
 				{ availability.map( ( { date, times } ) => (
 					<CalendarCard
 						date={ date }
-						disabled={ this.props.signupForm.status === CONCIERGE_STATUS_BOOKING }
+						disabled={ signupForm.status === CONCIERGE_STATUS_BOOKING }
+						isDefaultLocale={ isDefaultLocale( currentUserLocale ) }
 						key={ date }
 						onSubmit={ this.onSubmit }
 						times={ times }
+						timezone={ signupForm.timezone }
 					/>
 				) ) }
 			</div>
@@ -114,6 +117,7 @@ export default connect(
 	state => ( {
 		signupForm: getConciergeSignupForm( state ),
 		currentUserId: getCurrentUserId( state ),
+		currentUserLocale: getCurrentUserLocale( state ),
 	} ),
 	{ bookConciergeAppointment }
 )( localize( CalendarStep ) );

--- a/client/me/concierge/primary-header.js
+++ b/client/me/concierge/primary-header.js
@@ -17,18 +17,9 @@ import support from 'lib/url/support';
 class PrimaryHeader extends Component {
 	render() {
 		const { translate } = this.props;
-		return (
-			<Card>
-				<img
-					className="concierge__info-illustration"
-					src={ '/calypso/images/illustrations/illustration-start.svg' }
-				/>
-				<FormattedHeader
-					headerText={ translate( 'WordPress.com Business Concierge Session' ) }
-					subHeaderText={ translate(
-						"In this 30 minute session we'll help you get started with your site."
-					) }
-				/>
+		const subHeaderText = (
+			<div>
+				{ translate( "In this 30 minute session we'll help you get started with your site." ) }
 				<ExternalLink
 					className="concierge__info-link"
 					icon={ false }
@@ -37,6 +28,19 @@ class PrimaryHeader extends Component {
 				>
 					{ translate( 'Learn more' ) }
 				</ExternalLink>
+			</div>
+		);
+
+		return (
+			<Card>
+				<img
+					className="concierge__info-illustration"
+					src={ '/calypso/images/illustrations/illustration-start.svg' }
+				/>
+				<FormattedHeader
+					headerText={ translate( 'WordPress.com Business Concierge Session' ) }
+					subHeaderText={ subHeaderText }
+				/>
 			</Card>
 		);
 	}

--- a/client/me/concierge/primary-header.js
+++ b/client/me/concierge/primary-header.js
@@ -12,6 +12,7 @@ import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
 import ExternalLink from 'components/external-link';
 import { localize } from 'i18n-calypso';
+import support from 'lib/url/support';
 
 class PrimaryHeader extends Component {
 	render() {
@@ -31,8 +32,7 @@ class PrimaryHeader extends Component {
 				<ExternalLink
 					className="concierge__info-link"
 					icon={ false }
-					href={ 'https://en.support.wordpress.com/concierge-support' }
-					rel="noopener noreferrer"
+					href={ support.CONCIERGE_SUPPORT }
 					target="_blank"
 				>
 					{ translate( 'Learn more' ) }

--- a/client/me/concierge/primary-header.js
+++ b/client/me/concierge/primary-header.js
@@ -17,19 +17,6 @@ import support from 'lib/url/support';
 class PrimaryHeader extends Component {
 	render() {
 		const { translate } = this.props;
-		const subHeaderText = (
-			<div>
-				{ translate( "In this 30 minute session we'll help you get started with your site." ) }
-				<ExternalLink
-					className="concierge__info-link"
-					icon={ false }
-					href={ support.CONCIERGE_SUPPORT }
-					target="_blank"
-				>
-					{ translate( 'Learn more' ) }
-				</ExternalLink>
-			</div>
-		);
 
 		return (
 			<Card>
@@ -39,8 +26,18 @@ class PrimaryHeader extends Component {
 				/>
 				<FormattedHeader
 					headerText={ translate( 'WordPress.com Business Concierge Session' ) }
-					subHeaderText={ subHeaderText }
+					subHeaderText={ translate(
+						"In this 30 minute session we'll help you get started with your site."
+					) }
 				/>
+				<ExternalLink
+					className="concierge__info-link"
+					icon={ false }
+					href={ support.CONCIERGE_SUPPORT }
+					target="_blank"
+				>
+					{ translate( 'Learn more' ) }
+				</ExternalLink>
 			</Card>
 		);
 	}

--- a/client/me/concierge/primary-header.js
+++ b/client/me/concierge/primary-header.js
@@ -10,9 +10,12 @@ import React, { Component } from 'react';
  */
 import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
+import ExternalLink from 'components/external-link';
+import { localize } from 'i18n-calypso';
 
 class PrimaryHeader extends Component {
 	render() {
+		const { translate } = this.props;
 		return (
 			<Card>
 				<img
@@ -20,12 +23,23 @@ class PrimaryHeader extends Component {
 					src={ '/calypso/images/illustrations/illustration-start.svg' }
 				/>
 				<FormattedHeader
-					headerText="WordPress.com Business Site Setup"
-					subHeaderText="In this 30 minute session we'll help you get started with your site."
+					headerText={ translate( 'WordPress.com Business Concierge Session' ) }
+					subHeaderText={ translate(
+						"In this 30 minute session we'll help you get started with your site."
+					) }
 				/>
+				<ExternalLink
+					className="concierge__info-link"
+					icon={ false }
+					href={ 'https://en.support.wordpress.com/concierge-support' }
+					rel="noopener noreferrer"
+					target="_blank"
+				>
+					{ translate( 'Learn more' ) }
+				</ExternalLink>
 			</Card>
 		);
 	}
 }
 
-export default PrimaryHeader;
+export default localize( PrimaryHeader );

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -31,7 +31,7 @@
 .concierge__info-link {
 	display: block;
 	margin: 0 auto;
-	max-width: 100px;
+	width: auto;
 	text-align: center;
 }
 

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -28,6 +28,13 @@
 	max-width: 300px;
 }
 
+.concierge__info-link {
+	display: block;
+	margin: 0 auto;
+	max-width: 100px;
+	text-align: center;
+}
+
 .concierge__confirmation-illustration {
 	display: block;
 	margin: 50px auto 20px;


### PR DESCRIPTION
**Built on top https://github.com/Automattic/wp-calypso/pull/20979**

## Summary
- Change title to "WordPress.com Business Concierge Session" (instead of WordPress.com Business Site Setup")
- Add the "Learn more" link which points to https://en.support.wordpress.com/concierge-support/

Mobile view: https://cloudup.com/cwR2-x0WEKA
Desktop view: https://cloudup.com/cM4nyUEciqA