### PR TITLE
Me: Update profile links to use Redux

### DIFF
--- a/client/me/profile-links-add-other/index.jsx
+++ b/client/me/profile-links-add-other/index.jsx
@@ -13,14 +13,13 @@ import { localize } from 'i18n-calypso';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormTextInput from 'components/forms/form-text-input';
-import Notice from 'components/notice';
+import { addUserProfileLinks } from 'state/profile-links/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class ProfileLinksAddOther extends React.Component {
 	state = {
 		title: '',
 		value: '',
-		lastError: false,
 	};
 
 	// As the user types, the component state changes thanks to the LinkedStateMixin.
@@ -86,57 +85,14 @@ class ProfileLinksAddOther extends React.Component {
 			return;
 		}
 
-		this.props.userProfileLinks.addProfileLinks(
-			[
-				{
-					title: this.state.title.trim(),
-					value: this.state.value.trim(),
-				},
-			],
-			this.onSubmitResponse
-		);
+		this.props.addUserProfileLinks( [
+			{
+				title: this.state.title.trim(),
+				value: this.state.value.trim(),
+			},
+		] );
+		this.props.onSuccess();
 	};
-
-	onSubmitResponse = ( error, data ) => {
-		if ( error ) {
-			this.setState( {
-				lastError: this.props.translate( 'Unable to add link right now. Please try again later.' ),
-			} );
-		} else if ( data.duplicate ) {
-			this.setState( {
-				lastError: this.props.translate(
-					'That link is already in your profile links. No changes were made.'
-				),
-			} );
-		} else if ( data.malformed ) {
-			this.setState( {
-				lastError: this.props.translate( 'An unexpected error occurred. Please try again later.' ),
-			} );
-		} else {
-			this.props.onSuccess();
-		}
-	};
-
-	clearLastError = () => {
-		this.setState( {
-			lastError: false,
-		} );
-	};
-
-	possiblyRenderError() {
-		if ( ! this.state.lastError ) {
-			return null;
-		}
-
-		return (
-			<Notice
-				className="profile-links-add-other__error"
-				status="is-error"
-				onDismissClick={ this.clearLastError }
-				text={ this.state.lastError }
-			/>
-		);
-	}
 
 	render() {
 		return (
@@ -146,7 +102,6 @@ class ProfileLinksAddOther extends React.Component {
 						'Please enter the URL and description of the site you want to add to your profile.'
 					) }
 				</p>
-				{ this.possiblyRenderError() }
 				<FormFieldset>
 					<FormTextInput
 						className="profile-links-add-other__value"
@@ -185,5 +140,6 @@ class ProfileLinksAddOther extends React.Component {
 }
 
 export default connect( null, {
+	addUserProfileLinks,
 	recordGoogleEvent,
 } )( localize( ProfileLinksAddOther ) );

--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -12,15 +12,12 @@ import { localize } from 'i18n-calypso';
 
 // Internal dependencies
 import Button from 'components/button';
-import observe from 'lib/mixins/data-observe';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 const AddProfileLinksButtons = createReactClass( {
 	displayName: 'AddProfileLinksButtons',
-
-	mixins: [ observe( 'userProfileLinks' ) ],
 
 	propTypes: {
 		showingForm: PropTypes.bool,

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import createReactClass from 'create-react-class';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
 
@@ -13,53 +14,22 @@ import { times } from 'lodash';
  * Internal dependencies
  */
 import ProfileLink from 'me/profile-link';
-import observe from 'lib/mixins/data-observe';
+import QueryProfileLinks from 'components/data/query-profile-links';
 import AddProfileLinksButtons from 'me/profile-links/add-buttons';
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
 import Notice from 'components/notice';
 import ProfileLinksAddWordPress from 'me/profile-links-add-wordpress';
 import ProfileLinksAddOther from 'me/profile-links-add-other';
+import { deleteUserProfileLink, resetUserProfileLinkErrors } from 'state/profile-links/actions';
+import { getProfileLinks, getProfileLinksErrorType } from 'state/selectors';
 
 const ProfileLinks = createReactClass( {
 	displayName: 'ProfileLinks',
 
-	mixins: [ observe( 'userProfileLinks' ) ],
-
-	componentDidMount() {
-		this.props.userProfileLinks.getProfileLinks();
-		if ( typeof document.hidden !== 'undefined' ) {
-			document.addEventListener( 'visibilitychange', this.handleVisibilityChange );
-		}
-	},
-
-	componentWillUnmount() {
-		if ( typeof document.hidden !== 'undefined' ) {
-			document.removeEventListener( 'visibilitychange', this.handleVisibilityChange );
-		}
-	},
-
-	handleVisibilityChange() {
-		// if we're visible now, fetch the links again in case they
-		// changed (added/removed) something while the component this tab
-		// is on was hidden
-		if ( ! document.hidden ) {
-			this.props.userProfileLinks.fetchProfileLinks();
-		}
-	},
-
-	getDefaultProps() {
-		return {
-			userProfileLinks: {
-				initialized: false,
-			},
-		};
-	},
-
 	getInitialState() {
 		return {
 			showingForm: false,
-			lastError: false,
 			showPopoverMenu: false,
 		};
 	},
@@ -96,33 +66,26 @@ const ProfileLinks = createReactClass( {
 		} );
 	},
 
-	onRemoveLinkResponse( error ) {
-		if ( error ) {
-			this.setState( {
-				lastError: error,
-			} );
-		} else {
-			this.setState( {
-				lastError: false,
-			} );
-		}
-	},
-
-	clearLastError() {
-		this.setState( {
-			lastError: false,
-		} );
-	},
-
 	onRemoveLink( profileLink ) {
-		this.props.userProfileLinks.deleteProfileLinkBySlug(
-			profileLink.link_slug,
-			this.onRemoveLinkResponse
-		);
+		return () => this.props.deleteUserProfileLink( profileLink.link_slug );
+	},
+
+	getErrorMessage() {
+		const { errorType, translate } = this.props;
+
+		if ( ! errorType ) {
+			return null;
+		}
+
+		if ( errorType === 'duplicate' ) {
+			return translate( 'That link is already in your profile links. No changes were made.' );
+		}
+		return translate( 'An unexpected error occurred. Please try again later.' );
 	},
 
 	possiblyRenderError() {
-		if ( ! this.state.lastError ) {
+		const errorMessage = this.getErrorMessage();
+		if ( ! errorMessage ) {
 			return null;
 		}
 
@@ -130,11 +93,9 @@ const ProfileLinks = createReactClass( {
 			<Notice
 				className="profile-links__error"
 				status="is-error"
-				onDismissClick={ this.clearLastError }
+				onDismissClick={ this.props.resetUserProfileLinkErrors }
 			>
-				{ this.props.translate(
-					'An error occurred while attempting to remove the link. Please try again later.'
-				) }
+				{ errorMessage }
 			</Notice>
 		);
 	},
@@ -142,17 +103,15 @@ const ProfileLinks = createReactClass( {
 	renderProfileLinksList() {
 		return (
 			<ul className="profile-links__list">
-				{ this.props.userProfileLinks
-					.getProfileLinks()
-					.map( profileLink => (
-						<ProfileLink
-							key={ profileLink.link_slug }
-							title={ profileLink.title }
-							url={ profileLink.value }
-							slug={ profileLink.link_slug }
-							onRemoveLink={ this.onRemoveLink.bind( this, profileLink ) }
-						/>
-					) ) }
+				{ this.props.profileLinks.map( profileLink => (
+					<ProfileLink
+						key={ profileLink.link_slug }
+						title={ profileLink.title }
+						url={ profileLink.value }
+						slug={ profileLink.link_slug }
+						onRemoveLink={ this.onRemoveLink( profileLink ) }
+					/>
+				) ) }
 			</ul>
 		);
 	},
@@ -184,8 +143,8 @@ const ProfileLinks = createReactClass( {
 	},
 
 	renderProfileLinks() {
-		const initialized = this.props.userProfileLinks.initialized,
-			countLinks = this.props.userProfileLinks.getProfileLinks().length;
+		const initialized = this.props.profileLinks !== null,
+			countLinks = initialized ? this.props.profileLinks.length : 0;
 		let links;
 
 		if ( ! initialized ) {
@@ -206,30 +165,18 @@ const ProfileLinks = createReactClass( {
 
 	renderForm() {
 		if ( 'wordpress' === this.state.showingForm ) {
-			return (
-				<ProfileLinksAddWordPress
-					userProfileLinks={ this.props.userProfileLinks }
-					onSuccess={ this.hideForms }
-					onCancel={ this.hideForms }
-				/>
-			);
+			return <ProfileLinksAddWordPress onSuccess={ this.hideForms } onCancel={ this.hideForms } />;
 		}
 
-		return (
-			<ProfileLinksAddOther
-				userProfileLinks={ this.props.userProfileLinks }
-				onSuccess={ this.hideForms }
-				onCancel={ this.hideForms }
-			/>
-		);
+		return <ProfileLinksAddOther onSuccess={ this.hideForms } onCancel={ this.hideForms } />;
 	},
 
 	render() {
 		return (
 			<div>
+				<QueryProfileLinks />
 				<SectionHeader label={ this.props.translate( 'Profile Links' ) }>
 					<AddProfileLinksButtons
-						userProfileLinks={ this.props.userProfileLinks }
 						showingForm={ !! this.state.showingForm }
 						onShowAddOther={ this.showAddOther }
 						showPopoverMenu={ this.state.showPopoverMenu }
@@ -244,4 +191,13 @@ const ProfileLinks = createReactClass( {
 	},
 } );
 
-export default localize( ProfileLinks );
+export default connect(
+	state => ( {
+		profileLinks: getProfileLinks( state ),
+		errorType: getProfileLinksErrorType( state ),
+	} ),
+	{
+		deleteUserProfileLink,
+		resetUserProfileLinkErrors,
+	}
+)( localize( ProfileLinks ) );

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -143,8 +143,8 @@ const ProfileLinks = createReactClass( {
 	},
 
 	renderProfileLinks() {
-		const initialized = this.props.profileLinks !== null,
-			countLinks = initialized ? this.props.profileLinks.length : 0;
+		const initialized = this.props.profileLinks !== null;
+		const countLinks = initialized ? this.props.profileLinks.length : 0;
 		let links;
 
 		if ( ! initialized ) {

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -28,7 +28,6 @@ import ProfileLinks from 'me/profile-links';
 import ReauthRequired from 'me/reauth-required';
 import SectionHeader from 'components/section-header';
 import twoStepAuthorization from 'lib/two-step-authorization';
-import userProfileLinks from 'lib/user-profile-links';
 import { protectForm } from 'lib/protect-form';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
@@ -159,7 +158,7 @@ const Profile = createReactClass( {
 					</p>
 				</Card>
 
-				<ProfileLinks userProfileLinks={ userProfileLinks } />
+				<ProfileLinks />
 			</Main>
 		);
 	},

--- a/client/state/selectors/get-profile-links-error-type.js
+++ b/client/state/selectors/get-profile-links-error-type.js
@@ -13,15 +13,15 @@ import { get } from 'lodash';
  * @return {?String}     Error type.
  */
 export default function getProfileLinksErrorType( state ) {
-	if ( get( state, [ 'profileLinks', 'errors', 'duplicate' ], false ) ) {
+	if ( get( state, [ 'userProfileLinks', 'errors', 'duplicate' ], false ) ) {
 		return 'duplicate';
 	}
 
-	if ( get( state, [ 'profileLinks', 'errors', 'malformed' ], false ) ) {
+	if ( get( state, [ 'userProfileLinks', 'errors', 'malformed' ], false ) ) {
 		return 'malformed';
 	}
 
-	if ( get( state, [ 'profileLinks', 'errors', 'error' ], false ) ) {
+	if ( get( state, [ 'userProfileLinks', 'errors', 'error' ], false ) ) {
 		return 'other';
 	}
 

--- a/client/state/selectors/get-profile-links.js
+++ b/client/state/selectors/get-profile-links.js
@@ -7,5 +7,5 @@
  * @return {?Array}        Profile links
  */
 export default function getProfileLinks( state ) {
-	return state.profileLinks.items;
+	return state.userProfileLinks.items;
 }

--- a/client/state/selectors/test/get-profile-links-error-type.js
+++ b/client/state/selectors/test/get-profile-links-error-type.js
@@ -15,7 +15,7 @@ describe( 'getProfileLinksErrorType()', () => {
 
 	test( 'should return null if there are no errors from the last profile links request', () => {
 		const state = {
-			profileLinks: {
+			userProfileLinks: {
 				errors: {},
 			},
 		};
@@ -25,7 +25,7 @@ describe( 'getProfileLinksErrorType()', () => {
 
 	test( 'should return "duplicate" if there are duplicates in the last profile links request', () => {
 		const state = {
-			profileLinks: {
+			userProfileLinks: {
 				errors: {
 					duplicate: profileLinks,
 				},
@@ -37,7 +37,7 @@ describe( 'getProfileLinksErrorType()', () => {
 
 	test( 'should return "malformed" if there are malformed links in the last profile links request', () => {
 		const state = {
-			profileLinks: {
+			userProfileLinks: {
 				errors: {
 					malformed: profileLinks,
 				},
@@ -49,7 +49,7 @@ describe( 'getProfileLinksErrorType()', () => {
 
 	test( 'should return "other" if there is another error in the last profile links request', () => {
 		const state = {
-			profileLinks: {
+			userProfileLinks: {
 				errors: {
 					error: {
 						status: 403,

--- a/client/state/selectors/test/get-profile-links.js
+++ b/client/state/selectors/test/get-profile-links.js
@@ -21,7 +21,7 @@ describe( 'getProfileLinks()', () => {
 
 	test( 'should return null if profile links have not been received yet', () => {
 		const state = {
-			profileLinks: {
+			userProfileLinks: {
 				items: null,
 			},
 		};
@@ -30,7 +30,7 @@ describe( 'getProfileLinks()', () => {
 
 	test( 'should return empty array if current user has no profile links', () => {
 		const state = {
-			profileLinks: {
+			userProfileLinks: {
 				items: [],
 			},
 		};
@@ -39,7 +39,7 @@ describe( 'getProfileLinks()', () => {
 
 	test( 'should return the profile links of the current user', () => {
 		const state = {
-			profileLinks: {
+			userProfileLinks: {
 				items: profileLinks,
 			},
 		};

--- a/client/state/selectors/test/is-site-in-profile-links.js
+++ b/client/state/selectors/test/is-site-in-profile-links.js
@@ -16,7 +16,7 @@ describe( 'isSiteInProfileLinks()', () => {
 
 	test( 'should return null if profile links have not been received yet', () => {
 		const state = {
-			profileLinks: {
+			userProfileLinks: {
 				items: null,
 			},
 		};
@@ -26,7 +26,7 @@ describe( 'isSiteInProfileLinks()', () => {
 
 	test( 'should return false if site is not in profile links', () => {
 		const state = {
-			profileLinks: {
+			userProfileLinks: {
 				items: profileLinks,
 			},
 		};
@@ -36,7 +36,7 @@ describe( 'isSiteInProfileLinks()', () => {
 
 	test( 'should return true if site is in profile links', () => {
 		const state = {
-			profileLinks: {
+			userProfileLinks: {
 				items: profileLinks,
 			},
 		};


### PR DESCRIPTION
This PR updates the user profile links to use Redux instead of the legacy `lib/user-profile-links` emitter object.

It also cleans up a lot of redundant logic, and introduces a couple of improvements:
* Errors are now displayed in the main view, which keeps it all more reactive.
* Similar error messages are now consolidated.

Part of #20241.

To test:
* Checkout this branch
* Go to `/me` and test all of profile links:
  * Loading existing profile links
  * Adding one or more WP site links.
  * Adding a custom URL link
  * Canceling the addition of a WP site link.
  * Canceling the addition of a custom URL link.
  * Removing links
  * Simulate failures (duplicate links, malformed links, error in deletion, other error in link creation)
* Verify all of user profile links section works as expected.

