### PR TITLE
Add different message for non english speakers

### DIFF
--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { isEmpty } from 'lodash';
 import { localize, moment } from 'i18n-calypso';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -25,6 +26,8 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import { getLanguage } from 'lib/i18n-utils';
+const defaultLanguage = getLanguage( config( 'i18n_default_locale_slug' ) ).name;
 
 class CalendarCard extends Component {
 	static propTypes = {
@@ -86,7 +89,9 @@ class CalendarCard extends Component {
 		const { isDefaultLocale, disabled, times, translate } = this.props;
 		const description = isDefaultLocale
 			? translate( 'Sessions are 30 minutes long.' )
-			: translate( 'Sessions are 30 minutes long and in English.' );
+			: translate( 'Sessions are 30 minutes long and in %(defaultLanguage)s.', {
+					args: { defaultLanguage },
+				} );
 
 		return (
 			<FoldableCard

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -30,6 +30,7 @@ class CalendarCard extends Component {
 	static propTypes = {
 		date: PropTypes.number.isRequired,
 		disabled: PropTypes.bool.isRequired,
+		isDefaultLocale: PropTypes.bool.isRequired,
 		onSubmit: PropTypes.func.isRequired,
 		times: PropTypes.arrayOf( PropTypes.number ).isRequired,
 	};
@@ -82,7 +83,10 @@ class CalendarCard extends Component {
 	};
 
 	render() {
-		const { disabled, times, translate } = this.props;
+		const { isDefaultLocale, disabled, times, translate } = this.props;
+		const description = isDefaultLocale
+			? translate( 'Sessions are 30 minutes long.' )
+			: translate( 'Sessions are 30 minutes long and in English.' );
 
 		return (
 			<FoldableCard
@@ -109,9 +113,7 @@ class CalendarCard extends Component {
 							</option>
 						) ) }
 					</FormSelect>
-					<FormSettingExplanation>
-						{ translate( 'Sessions are 30 minutes long.' ) }
-					</FormSettingExplanation>
+					<FormSettingExplanation>{ description }</FormSettingExplanation>
 				</FormFieldset>
 
 				<FormFieldset>

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -36,11 +36,14 @@ class CalendarCard extends Component {
 		isDefaultLocale: PropTypes.bool.isRequired,
 		onSubmit: PropTypes.func.isRequired,
 		times: PropTypes.arrayOf( PropTypes.number ).isRequired,
+		timezone: PropTypes.string.isRequired,
 	};
 
 	state = {
 		selectedTime: this.props.times[ 0 ],
 	};
+
+	withTimezone = dateTime => moment( dateTime ).tz( this.props.timezone );
 
 	/**
 	 * Returns a string representing the day of the week, with certain dates using natural
@@ -51,7 +54,7 @@ class CalendarCard extends Component {
 	 */
 	getDayOfWeekString = date => {
 		const { translate } = this.props;
-		const today = moment().startOf( 'day' );
+		const today = this.withTimezone().startOf( 'day' );
 		const dayOffset = today.diff( date.startOf( 'day' ), 'days' );
 
 		switch ( dayOffset ) {
@@ -65,7 +68,7 @@ class CalendarCard extends Component {
 
 	renderHeader = () => {
 		// The "Header" is that part of the foldable card that you click on to expand it.
-		const date = moment( this.props.date );
+		const date = this.withTimezone( this.props.date );
 
 		return (
 			<div className="concierge__calendar-card-header">
@@ -86,12 +89,12 @@ class CalendarCard extends Component {
 	};
 
 	render() {
-		const { isDefaultLocale, disabled, times, translate } = this.props;
+		const { disabled, isDefaultLocale, signupForm, times, translate } = this.props;
 		const description = isDefaultLocale
 			? translate( 'Sessions are 30 minutes long.' )
 			: translate( 'Sessions are 30 minutes long and in %(defaultLanguage)s.', {
-					args: { defaultLanguage },
-				} );
+				args: { defaultLanguage },
+			} );
 
 		return (
 			<FoldableCard
@@ -114,7 +117,7 @@ class CalendarCard extends Component {
 					>
 						{ times.map( time => (
 							<option value={ time } key={ time }>
-								{ moment( time ).format( 'h:mma z' ) }
+								{ this.withTimezone( time ).format( 'h:mma z' ) }
 							</option>
 						) ) }
 					</FormSelect>

--- a/client/me/concierge/calendar-step.js
+++ b/client/me/concierge/calendar-step.js
@@ -26,12 +26,13 @@ import { isDefaultLocale } from 'lib/i18n-utils';
 
 const NUMBER_OF_DAYS_TO_SHOW = 7;
 
-const groupAvailableTimesByDate = availableTimes => {
+const groupAvailableTimesByDate = ( availableTimes, timezone ) => {
 	const dates = {};
 
 	// Stub an object of { date: X, times: [] } for each day we care about
 	for ( let x = 0; x < NUMBER_OF_DAYS_TO_SHOW; x++ ) {
 		const startOfDay = moment()
+			.tz( timezone )
 			.startOf( 'day' )
 			.add( x, 'days' )
 			.valueOf();
@@ -41,6 +42,7 @@ const groupAvailableTimesByDate = availableTimes => {
 	// Go through all available times and bundle them into each date object
 	availableTimes.forEach( beginTimestamp => {
 		const startOfDay = moment( beginTimestamp )
+			.tz( timezone )
 			.startOf( 'day' )
 			.valueOf();
 		if ( dates.hasOwnProperty( startOfDay ) ) {
@@ -86,25 +88,24 @@ class CalendarStep extends Component {
 	}
 
 	render() {
-		const { availableTimes, translate } = this.props;
-		const availability = groupAvailableTimesByDate( availableTimes );
+		const { availableTimes, currentUserLocale, onBack, signupForm, translate } = this.props;
+		const availability = groupAvailableTimesByDate( availableTimes, signupForm.timezone );
 
 		return (
 			<div>
-				<HeaderCake onClick={ this.props.onBack }>
-					{ translate( 'Choose Concierge Session' ) }
-				</HeaderCake>
+				<HeaderCake onClick={ onBack }>{ translate( 'Choose Concierge Session' ) }</HeaderCake>
 				<CompactCard>
 					{ translate( 'Please select a day to have your Concierge session.' ) }
 				</CompactCard>
 				{ availability.map( ( { date, times } ) => (
 					<CalendarCard
 						date={ date }
-						disabled={ this.props.signupForm.status === CONCIERGE_STATUS_BOOKING }
-						isDefaultLocale={ isDefaultLocale( this.props.currentUserLocale ) }
+						disabled={ signupForm.status === CONCIERGE_STATUS_BOOKING }
+						isDefaultLocale={ isDefaultLocale( currentUserLocale ) }
 						key={ date }
 						onSubmit={ this.onSubmit }
 						times={ times }
+						timezone={ signupForm.timezone }
 					/>
 				) ) }
 			</div>

--- a/client/me/concierge/calendar-step.js
+++ b/client/me/concierge/calendar-step.js
@@ -15,13 +15,14 @@ import CalendarCard from './calendar-card';
 import CompactCard from 'components/card/compact';
 import HeaderCake from 'components/header-cake';
 import { getConciergeSignupForm } from 'state/selectors';
-import { getCurrentUserId } from 'state/current-user/selectors';
+import { getCurrentUserId, getCurrentUserLocale } from 'state/current-user/selectors';
 import { bookConciergeAppointment } from 'state/concierge/actions';
 import {
 	CONCIERGE_STATUS_BOOKING,
 	CONCIERGE_STATUS_BOOKED,
 	WPCOM_CONCIERGE_SCHEDULE_ID,
 } from './constants';
+import { isDefaultLocale } from 'lib/i18n-utils';
 
 const NUMBER_OF_DAYS_TO_SHOW = 7;
 
@@ -100,6 +101,7 @@ class CalendarStep extends Component {
 					<CalendarCard
 						date={ date }
 						disabled={ this.props.signupForm.status === CONCIERGE_STATUS_BOOKING }
+						isDefaultLocale={ isDefaultLocale( this.props.currentUserLocale ) }
 						key={ date }
 						onSubmit={ this.onSubmit }
 						times={ times }
@@ -114,6 +116,7 @@ export default connect(
 	state => ( {
 		signupForm: getConciergeSignupForm( state ),
 		currentUserId: getCurrentUserId( state ),
+		currentUserLocale: getCurrentUserLocale( state ),
 	} ),
 	{ bookConciergeAppointment }
 )( localize( CalendarStep ) );

--- a/client/state/data-layer/wpcom/concierge/schedules/available-times/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/available-times/test/from-api.js
@@ -14,11 +14,7 @@ describe( 'fromApi()', () => {
 			1483268400, // unix timestamp of 2017-01-01 11:00:00 UTC
 		];
 
-		const expectedResult = [
-			new Date( '2017-01-01 10:00:00 UTC' ),
-			new Date( '2017-01-01 10:30:00 UTC' ),
-			new Date( '2017-01-01 11:00:00 UTC' ),
-		];
+		const expectedResult = [ 1483264800000, 1483266600000, 1483268400000 ];
 
 		expect( fromApi( validResponse ) ).toEqual( expectedResult );
 	} );

--- a/client/state/data-layer/wpcom/concierge/schedules/available-times/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/available-times/test/from-api.js
@@ -14,7 +14,11 @@ describe( 'fromApi()', () => {
 			1483268400, // unix timestamp of 2017-01-01 11:00:00 UTC
 		];
 
-		const expectedResult = [ 1483264800000, 1483266600000, 1483268400000 ];
+		const expectedResult = [
+			new Date( '2017-01-01 10:00:00 UTC' ),
+			new Date( '2017-01-01 10:30:00 UTC' ),
+			new Date( '2017-01-01 11:00:00 UTC' ),
+		];
 
 		expect( fromApi( validResponse ) ).toEqual( expectedResult );
 	} );


### PR DESCRIPTION
**Built on top https://github.com/Automattic/wp-calypso/pull/20993**

## Summary
On the Calendar Step (see screenshot below), where it says `Sessions are usually 30 minutes long.` we should instead say `Sessions are 30 minutes long and in English.` if the customer locale isn't English.

## Testing
1. Change your locale to es
2. On the calendar card the description message should specify that sessions are in english