### PR TITLE
i18n: Fix language loading race condition in local dev environment

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -21,7 +21,6 @@ import { setCurrentUserId, setCurrentUserFlags } from 'state/current-user/action
 import { setRoute as setRouteAction } from 'state/ui/actions';
 import touchDetect from 'lib/touch-detect';
 import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
-import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 
 const debug = debugFactory( 'calypso' );
 
@@ -143,9 +142,9 @@ export const locales = ( currentUser, reduxStore ) => {
 		reduxStore.dispatch( setLocaleRawData( i18nLocaleStringsObject ) );
 	}
 
-	// Use current user's locale if it was not bootstrapped
+	// Use current user's locale if it was not bootstrapped (non-ssr pages)
 	if (
-		( ! getCurrentLocaleSlug( reduxStore.getState() ) || ! window.i18nLocaleStrings ) &&
+		! window.i18nLocaleStrings &&
 		! config.isEnabled( 'wpcom-user-bootstrap' ) &&
 		currentUser.get()
 	) {

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -145,7 +145,7 @@ export const locales = ( currentUser, reduxStore ) => {
 
 	// Use current user's locale if it was not bootstrapped
 	if (
-		! getCurrentLocaleSlug( reduxStore.getState() ) &&
+		( ! getCurrentLocaleSlug( reduxStore.getState() ) || ! window.i18nLocaleStrings ) &&
 		! config.isEnabled( 'wpcom-user-bootstrap' ) &&
 		currentUser.get()
 	) {


### PR DESCRIPTION
When loading a local install of Calypso with a logged in user that has set a language different than English, the UI only loads up in that language in one out of 10 reloads. This seems to be the case because `state.ui.language` is persisted on the client.

I am no expert the Calypso bootup code but with some experimenting and consulting with @Tug the suggested fix works for me. I'd appreciate any further insights on this to get this merged.