### PR TITLE
Add timezone support

### DIFF
--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -35,6 +35,7 @@ class CalendarCard extends Component {
 		disabled: PropTypes.bool.isRequired,
 		isDefaultLocale: PropTypes.bool.isRequired,
 		onSubmit: PropTypes.func.isRequired,
+		signupForm: PropTypes.object.isRequired,
 		times: PropTypes.arrayOf( PropTypes.number ).isRequired,
 	};
 
@@ -51,7 +52,9 @@ class CalendarCard extends Component {
 	 */
 	getDayOfWeekString = date => {
 		const { translate } = this.props;
-		const today = moment().startOf( 'day' );
+		const today = moment()
+			.tz( this.props.signupForm.timezone )
+			.startOf( 'day' );
 		const dayOffset = today.diff( date.startOf( 'day' ), 'days' );
 
 		switch ( dayOffset ) {
@@ -65,7 +68,7 @@ class CalendarCard extends Component {
 
 	renderHeader = () => {
 		// The "Header" is that part of the foldable card that you click on to expand it.
-		const date = moment( this.props.date );
+		const date = moment( this.props.date ).tz( this.props.signupForm.timezone );
 
 		return (
 			<div className="concierge__calendar-card-header">
@@ -86,7 +89,7 @@ class CalendarCard extends Component {
 	};
 
 	render() {
-		const { isDefaultLocale, disabled, times, translate } = this.props;
+		const { isDefaultLocale, disabled, signupForm, times, translate } = this.props;
 		const description = isDefaultLocale
 			? translate( 'Sessions are 30 minutes long.' )
 			: translate( 'Sessions are 30 minutes long and in %(defaultLanguage)s.', {
@@ -114,7 +117,9 @@ class CalendarCard extends Component {
 					>
 						{ times.map( time => (
 							<option value={ time } key={ time }>
-								{ moment( time ).format( 'h:mma z' ) }
+								{ moment( time )
+									.tz( signupForm.timezone )
+									.format( 'h:mma z' ) }
 							</option>
 						) ) }
 					</FormSelect>

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -90,8 +90,8 @@ class CalendarCard extends Component {
 		const description = isDefaultLocale
 			? translate( 'Sessions are 30 minutes long.' )
 			: translate( 'Sessions are 30 minutes long and in %(defaultLanguage)s.', {
-					args: { defaultLanguage },
-				} );
+				args: { defaultLanguage },
+			} );
 
 		return (
 			<FoldableCard

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -35,13 +35,15 @@ class CalendarCard extends Component {
 		disabled: PropTypes.bool.isRequired,
 		isDefaultLocale: PropTypes.bool.isRequired,
 		onSubmit: PropTypes.func.isRequired,
-		signupForm: PropTypes.object.isRequired,
 		times: PropTypes.arrayOf( PropTypes.number ).isRequired,
+		timezone: PropTypes.string.isRequired,
 	};
 
 	state = {
 		selectedTime: this.props.times[ 0 ],
 	};
+
+	withTimezone = dateTime => moment( dateTime ).tz( this.props.timezone );
 
 	/**
 	 * Returns a string representing the day of the week, with certain dates using natural
@@ -52,9 +54,7 @@ class CalendarCard extends Component {
 	 */
 	getDayOfWeekString = date => {
 		const { translate } = this.props;
-		const today = moment()
-			.tz( this.props.signupForm.timezone )
-			.startOf( 'day' );
+		const today = this.withTimezone().startOf( 'day' );
 		const dayOffset = today.diff( date.startOf( 'day' ), 'days' );
 
 		switch ( dayOffset ) {
@@ -68,7 +68,7 @@ class CalendarCard extends Component {
 
 	renderHeader = () => {
 		// The "Header" is that part of the foldable card that you click on to expand it.
-		const date = moment( this.props.date ).tz( this.props.signupForm.timezone );
+		const date = this.withTimezone( this.props.date );
 
 		return (
 			<div className="concierge__calendar-card-header">
@@ -89,7 +89,7 @@ class CalendarCard extends Component {
 	};
 
 	render() {
-		const { isDefaultLocale, disabled, signupForm, times, translate } = this.props;
+		const { disabled, isDefaultLocale, signupForm, times, translate } = this.props;
 		const description = isDefaultLocale
 			? translate( 'Sessions are 30 minutes long.' )
 			: translate( 'Sessions are 30 minutes long and in %(defaultLanguage)s.', {
@@ -117,9 +117,7 @@ class CalendarCard extends Component {
 					>
 						{ times.map( time => (
 							<option value={ time } key={ time }>
-								{ moment( time )
-									.tz( signupForm.timezone )
-									.format( 'h:mma z' ) }
+								{ this.withTimezone( time ).format( 'h:mma z' ) }
 							</option>
 						) ) }
 					</FormSelect>

--- a/client/me/concierge/calendar-step.js
+++ b/client/me/concierge/calendar-step.js
@@ -88,26 +88,24 @@ class CalendarStep extends Component {
 	}
 
 	render() {
-		const { availableTimes, signupForm, translate } = this.props;
+		const { availableTimes, currentUserLocale, onBack, signupForm, translate } = this.props;
 		const availability = groupAvailableTimesByDate( availableTimes, signupForm.timezone );
 
 		return (
 			<div>
-				<HeaderCake onClick={ this.props.onBack }>
-					{ translate( 'Choose Concierge Session' ) }
-				</HeaderCake>
+				<HeaderCake onClick={ onBack }>{ translate( 'Choose Concierge Session' ) }</HeaderCake>
 				<CompactCard>
 					{ translate( 'Please select a day to have your Concierge session.' ) }
 				</CompactCard>
 				{ availability.map( ( { date, times } ) => (
 					<CalendarCard
 						date={ date }
-						disabled={ this.props.signupForm.status === CONCIERGE_STATUS_BOOKING }
-						isDefaultLocale={ isDefaultLocale( this.props.currentUserLocale ) }
+						disabled={ signupForm.status === CONCIERGE_STATUS_BOOKING }
+						isDefaultLocale={ isDefaultLocale( currentUserLocale ) }
 						key={ date }
 						onSubmit={ this.onSubmit }
-						signupForm={ this.props.signupForm }
 						times={ times }
+						timezone={ signupForm.timezone }
 					/>
 				) ) }
 			</div>

--- a/client/me/concierge/calendar-step.js
+++ b/client/me/concierge/calendar-step.js
@@ -26,12 +26,13 @@ import { isDefaultLocale } from 'lib/i18n-utils';
 
 const NUMBER_OF_DAYS_TO_SHOW = 7;
 
-const groupAvailableTimesByDate = availableTimes => {
+const groupAvailableTimesByDate = ( availableTimes, timezone ) => {
 	const dates = {};
 
 	// Stub an object of { date: X, times: [] } for each day we care about
 	for ( let x = 0; x < NUMBER_OF_DAYS_TO_SHOW; x++ ) {
 		const startOfDay = moment()
+			.tz( timezone )
 			.startOf( 'day' )
 			.add( x, 'days' )
 			.valueOf();
@@ -41,6 +42,7 @@ const groupAvailableTimesByDate = availableTimes => {
 	// Go through all available times and bundle them into each date object
 	availableTimes.forEach( beginTimestamp => {
 		const startOfDay = moment( beginTimestamp )
+			.tz( timezone )
 			.startOf( 'day' )
 			.valueOf();
 		if ( dates.hasOwnProperty( startOfDay ) ) {
@@ -86,8 +88,8 @@ class CalendarStep extends Component {
 	}
 
 	render() {
-		const { availableTimes, translate } = this.props;
-		const availability = groupAvailableTimesByDate( availableTimes );
+		const { availableTimes, signupForm, translate } = this.props;
+		const availability = groupAvailableTimesByDate( availableTimes, signupForm.timezone );
 
 		return (
 			<div>
@@ -104,6 +106,7 @@ class CalendarStep extends Component {
 						isDefaultLocale={ isDefaultLocale( this.props.currentUserLocale ) }
 						key={ date }
 						onSubmit={ this.onSubmit }
+						signupForm={ this.props.signupForm }
 						times={ times }
 					/>
 				) ) }

--- a/client/state/data-layer/wpcom/concierge/schedules/available-times/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/available-times/test/from-api.js
@@ -14,11 +14,7 @@ describe( 'fromApi()', () => {
 			1483268400, // unix timestamp of 2017-01-01 11:00:00 UTC
 		];
 
-		const expectedResult = [
-			new Date( '2017-01-01 10:00:00 UTC' ),
-			new Date( '2017-01-01 10:30:00 UTC' ),
-			new Date( '2017-01-01 11:00:00 UTC' ),
-		];
+		const expectedResult = [ 1483264800000, 1483266600000, 1483268400000 ];
 
 		expect( fromApi( validResponse ) ).toEqual( expectedResult );
 	} );

--- a/client/state/data-layer/wpcom/concierge/schedules/available-times/test/from-api.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/available-times/test/from-api.js
@@ -14,7 +14,11 @@ describe( 'fromApi()', () => {
 			1483268400, // unix timestamp of 2017-01-01 11:00:00 UTC
 		];
 
-		const expectedResult = [ 1483264800000, 1483266600000, 1483268400000 ];
+		const expectedResult = [
+			new Date( '2017-01-01 10:00:00 UTC' ),
+			new Date( '2017-01-01 10:30:00 UTC' ),
+			new Date( '2017-01-01 11:00:00 UTC' ),
+		];
 
 		expect( fromApi( validResponse ) ).toEqual( expectedResult );
 	} );


### PR DESCRIPTION
**https://github.com/Automattic/wp-calypso/pull/20996**

## Summary
In the first step we ask the customer to pick/confirm their Timezone. This should be used in the Calendar step to display available times & dates.

## Testing
1. Select a different timezone in the first step
2. Listed available slots should reflect the selected timezone