### PR TITLE
JP Onboarding: Pass siteId down to individual steps (different approach)

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -30,7 +30,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 	// TODO: Add lifecycle methods to redirect if no siteId
 
 	render() {
-		const { siteSlug, stepName, steps } = this.props;
+		const { siteId, siteSlug, stepName, steps } = this.props;
 
 		return (
 			<Main className="jetpack-onboarding">
@@ -38,6 +38,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 					basePath="/jetpack/onboarding"
 					baseSuffix={ siteSlug }
 					components={ COMPONENTS }
+					siteId={ siteId /* Passed down to individual steps */ }
 					steps={ steps }
 					stepName={ stepName }
 					hideNavigation={ stepName === STEPS.SUMMARY }

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -18,25 +18,13 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
-import QuerySiteSettings from 'components/data/query-site-settings';
-import { saveSiteSettings } from 'state/site-settings/actions';
-import { getSiteSettings, isRequestingSiteSettings } from 'state/site-settings/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	state = {
 		description: '',
 		title: '',
 	};
-
-	componentWillReceiveProps( nextProps ) {
-		if ( this.props.isRequesting && ! nextProps.isRequesting ) {
-			this.setState( {
-				title: nextProps.siteSettings.blogname,
-				description: nextProps.siteSettings.blogdescription,
-			} );
-		}
-	}
 
 	setDescription = event => {
 		this.setState( { description: event.target.value } );
@@ -47,14 +35,14 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	};
 
 	submit = () => {
-		this.props.saveSiteSettings( this.props.siteId, {
-			blogname: this.state.title,
-			blogdescription: this.state.description,
+		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
+			siteTitle: this.state.title,
+			siteDescription: this.state.description,
 		} );
 	};
 
 	render() {
-		const { isRequesting, siteId, translate } = this.props;
+		const { translate } = this.props;
 		const headerText = translate( "Let's get started." );
 		const subHeaderText = translate(
 			'First up, what would you like to name your site and have as its public description?'
@@ -62,7 +50,6 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 
 		return (
 			<Fragment>
-				<QuerySiteSettings siteId={ siteId } />
 				<DocumentHead title={ translate( 'Site Title ‹ Jetpack Onboarding' ) } />
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
@@ -72,7 +59,6 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 							<FormLabel htmlFor="title">{ translate( 'Site Title' ) }</FormLabel>
 							<FormTextInput
 								autoFocus
-								disabled={ isRequesting }
 								id="title"
 								onChange={ this.setTitle }
 								value={ this.state.title }
@@ -82,7 +68,6 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 						<FormFieldset>
 							<FormLabel htmlFor="description">{ translate( 'Site Description' ) }</FormLabel>
 							<FormTextarea
-								disabled={ isRequesting }
 								id="description"
 								onChange={ this.setDescription }
 								value={ this.state.description }
@@ -99,15 +84,6 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	}
 }
 
-export default connect(
-	state => {
-		const siteId = getSelectedSiteId( state );
-
-		return {
-			isRequesting: isRequestingSiteSettings( state, siteId ),
-			siteId,
-			siteSettings: getSiteSettings( state, siteId ),
-		};
-	},
-	{ saveSiteSettings }
-)( localize( JetpackOnboardingSiteTitleStep ) );
+export default connect( null, { saveJetpackOnboardingSettings } )(
+	localize( JetpackOnboardingSiteTitleStep )
+);


### PR DESCRIPTION
Alternative to #20873.

Additionally, drop the old Redux bits that connected to  `sites` and `siteSettings` state, since as of #20906, we're aiming to use our dedicated `jetpackOnboarding` subtree.

To test (stealing instructions from @tyxla):

* Checkout this branch on your local Calypso.
* Make sure your JP sandbox is running JP >= 5.6.1.
* Apply D7342-code on your wp.com sandbox and make sure you're sandboxing the API and jetpack.wordpress.com.
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
* Verify that after a couple of redirects you land in http://calypso.localhost:3000/jetpack/onboarding/yourjetpacksandbox.com
* Enter a new title and description, click 'Next Step'
* Go to your Jetpack site and verify that title and desc have been updated properly.