### PR TITLE
PostRevisions: Add 'load new revisions' functionality

### DIFF
--- a/client/post-editor/editor-revisions-list/header.jsx
+++ b/client/post-editor/editor-revisions-list/header.jsx
@@ -3,19 +3,30 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
+/**
+ * Internal dependencies
+ */
+import RevisionsCounter from './revisions-counter';
+
+// TODO: don't pass numRevisions, connect it in revisions counter.
 const EditorRevisionsListHeader = ( { numRevisions, translate } ) => {
 	return (
 		<div className="editor-revisions-list__header">
-			{ !! numRevisions &&
-				translate( '%(revisions)d revision', '%(revisions)d revisions', {
-					count: numRevisions,
-					args: { revisions: numRevisions },
-				} ) }
+			{ !! numRevisions && (
+				<span
+					style={ {
+						flex: '1 0 0',
+						marginLeft: '16px',
+					} }
+				>
+					{ translate( 'History' ) }
+				</span>
+			) }
+			{ !! numRevisions && <RevisionsCounter count={ numRevisions } /> }
 		</div>
 	);
 };

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -64,7 +64,10 @@ class EditorRevisionsList extends PureComponent {
 		if ( ! this.props.selectedRevisionId ) {
 			this.trySelectingFirstRevision();
 		}
-		if ( this.props.selectedRevisionId !== prevProps.selectedRevisionId ) {
+		if (
+			this.props.selectedRevisionId !== prevProps.selectedRevisionId ||
+			this.props.revisions.length !== prevProps.revisions.length
+		) {
 			this.scrollToSelectedItem();
 		}
 	}

--- a/client/post-editor/editor-revisions-list/revisions-counter/index.jsx
+++ b/client/post-editor/editor-revisions-list/revisions-counter/index.jsx
@@ -1,0 +1,83 @@
+/** @format */
+/**
+ * External Dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { noop, flow } from 'lodash';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Count from 'components/count';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import getPendingPostRevisionCount from 'state/selectors/get-pending-revisions-count';
+import { loadPendingPostRevisions, selectPostRevision } from 'state/posts/revisions/actions';
+
+class RevisionsCounter extends PureComponent {
+	static propTypes = {
+		pendingPostRevisionsCount: PropTypes.number,
+		onClick: PropTypes.func,
+	};
+
+	static defaultProps = {
+		onClick: noop,
+		pendingPostRevisionsCount: 0,
+	};
+
+	loadPendingRevisions = () => {
+		const { postId, siteId, pendingPostRevisionsCount } = this.props;
+
+		if ( ! pendingPostRevisionsCount ) {
+			return;
+		}
+
+		this.props.loadPendingPostRevisions( {
+			siteId,
+			postId,
+		} );
+
+		// selectPostRevision here?
+	};
+
+	render() {
+		const { pendingPostRevisionsCount, count, translate } = this.props;
+		const classes = classnames( 'revisions-counter', {
+			'revisions-counter__show-notification': !! pendingPostRevisionsCount,
+		} );
+
+		return (
+			<div className={ classes }>
+				{ count && <Count count={ count } /> }
+				<div className="revisions-counter__notification" onClick={ this.loadPendingRevisions }>
+					{ pendingPostRevisionsCount &&
+						translate( '%s new', {
+							args: pendingPostRevisionsCount,
+						} ) }
+				</div>
+			</div>
+		);
+	}
+}
+
+export default flow(
+	connect(
+		state => {
+			const postId = getEditorPostId( state );
+			const siteId = getSelectedSiteId( state );
+			const pendingPostRevisionsCount = getPendingPostRevisionCount( state, siteId, postId ) || 0;
+
+			return {
+				pendingPostRevisionsCount,
+				siteId,
+				postId,
+			};
+		},
+		{ selectPostRevision, loadPendingPostRevisions }
+	),
+	localize
+)( RevisionsCounter );

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -222,8 +222,6 @@
 	display: flex;
 	flex: 1;
 	opacity: 0;
-	transition: all 0.1s;
-	transition-delay: 0.1s;
 	transform: translateY(20%);
 }
 
@@ -233,6 +231,8 @@
 	}
 
 	.revisions-counter__notification {
+		transition: all 0.1s;
+		transition-delay: 0.1s;
 		opacity: 1;
 		transform: translateY(0);
 	}

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -38,12 +38,13 @@
 .editor-revisions-list__header {
 	$editor-revisions-list-header-height: 46px;
 	$editor-revisions-list-header-font-size: 16px;
-	padding: 0 16px;
 	height: $editor-revisions-list-header-height;
 	line-height: $editor-revisions-list-header-height;
 	color: $gray-text-min;
 	background: $white;
 	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
+	display: flex;
+	flex-direction: row;
 
 	.editor-revisions-list.is-loading & {
 		position: relative;
@@ -193,4 +194,46 @@
 .editor-revisions-list__minor-changes {
 	top: 8px;
 	color: $gray-text-min;
+}
+
+// Revision Counter & New Revisions Notification
+
+.revisions-counter {
+	position: relative;
+}
+
+.revisions-counter .count {
+	margin: 8px 6px;
+	border-radius: 24px;
+	line-height: 26px;
+	position: absolute;
+	right: 0;
+	transition: all 0.2s;
+	opacity: 1;
+}
+
+.revisions-counter__notification {
+	background: rgba(240, 130, 30, 0.96);
+	border-radius: 24px;
+	color: white;
+	line-height: 26px;
+	padding: 4px 12px;
+	margin: 6px;
+	display: flex;
+	flex: 1;
+	opacity: 0;
+	transition: all 0.1s;
+	transition-delay: 0.1s;
+	transform: translateY(20%);
+}
+
+.revisions-counter__show-notification {
+	.count {
+		opacity: 0;
+	}
+
+	.revisions-counter__notification {
+		opacity: 1;
+		transform: translateY(0);
+	}
 }

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -203,37 +203,35 @@
 }
 
 .revisions-counter .count {
-	margin: 8px 6px;
-	border-radius: 24px;
-	line-height: 26px;
 	position: absolute;
-	right: 0;
-	transition: all 0.2s;
+	top: 14px;
+	right: 12px;
+	transition: all 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 	opacity: 1;
 }
 
 .revisions-counter__notification {
-	background: rgba(240, 130, 30, 0.96);
+	position: absolute;
+	top: 10px;
+	right: 12px;
+	background: $orange-jazzy;
+	line-height: 1;
 	border-radius: 24px;
 	color: white;
-	line-height: 26px;
-	padding: 4px 12px;
-	margin: 6px;
-	display: flex;
-	flex: 1;
+	padding: 6px 12px;
 	opacity: 0;
-	transform: translateY(20%);
+	transform: translateX(10px) scale(0.6);
+	transition: all 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
 
 .revisions-counter__show-notification {
 	.count {
 		opacity: 0;
+		transform: scale(1.4);
 	}
 
 	.revisions-counter__notification {
-		transition: all 0.1s;
-		transition-delay: 0.1s;
 		opacity: 1;
-		transform: translateY(0);
+		transform: translateX(0) scale(1);
 	}
 }

--- a/client/state/posts/revisions/actions.js
+++ b/client/state/posts/revisions/actions.js
@@ -77,6 +77,12 @@ export const receivePostRevisions = ( { diffs, postId, revisions, siteId } ) => 
 	siteId,
 } );
 
+export const loadPendingPostRevisions = ( { postId, siteId } ) => ( {
+	type: 'POST_REVISIONS_LOAD_PENDING',
+	postId,
+	siteId,
+} );
+
 export const selectPostRevision = revisionId => ( {
 	type: POST_REVISIONS_SELECT,
 	revisionId,

--- a/client/state/posts/revisions/reducer.js
+++ b/client/state/posts/revisions/reducer.js
@@ -23,58 +23,101 @@ import {
 import { combineReducers } from 'state/utils';
 
 export function diffs( state = {}, { diffs: diffsFromServer, postId, revisions, siteId, type } ) {
-	if ( type !== POST_REVISIONS_RECEIVE ) {
-		return state;
-	}
 	if ( ! isInteger( siteId ) || siteId <= 0 ) {
 		return state;
 	}
 
-	const sitePostState = get( state, [ siteId, postId ], {} );
-	const mergedRevisions = {
-		...get( sitePostState, 'revisions', {} ),
-		...revisions,
-	};
-
-	const filteredDiffs = filter( diffsFromServer, ( { diff, from, to } ) => {
-		if ( ! isInteger( from ) || from < 0 ) {
-			// `from` can be zero
-			return false;
-		}
-		if ( ! isInteger( to ) || to < 1 ) {
-			// `to` cannot be zero
-			return false;
-		}
-
-		// Ensure fresh revisions were provided for `from` and `to` in the payload
-		if ( from !== 0 && isEmpty( mergedRevisions[ from ] ) ) {
-			// if `from` is `0`, there won't be a revision to validate
-			return false;
-		}
-		if ( isEmpty( mergedRevisions[ to ] ) ) {
-			return false;
-		}
-
-		return ! isEmpty( diff );
-	} );
-
-	if ( isEmpty( filteredDiffs ) ) {
+	if ( type !== 'POST_REVISIONS_LOAD_PENDING' && type !== POST_REVISIONS_RECEIVE ) {
 		return state;
 	}
 
-	return {
-		...state,
-		[ siteId ]: {
-			...state[ siteId ],
-			[ postId ]: {
-				...{
-					...omit( sitePostState, 'revisions' ),
-					...keyBy( filteredDiffs, d => `${ d.from }:${ d.to }` ),
+	// general for both
+	const sitePostState = get( state, [ siteId, postId ], {} );
+	const previousRevisions = get( sitePostState, 'revisions', {} );
+
+	if ( type === 'POST_REVISIONS_LOAD_PENDING' ) {
+		return {
+			...state,
+			[ siteId ]: {
+				...state[ siteId ],
+				[ postId ]: {
+					...get( sitePostState, 'pending.diffs', {} ),
+					revisions: get( sitePostState, 'pending.revisions', {} ),
+					pending: {},
 				},
-				revisions: mergedRevisions,
 			},
-		},
-	};
+		};
+	}
+
+	if ( type === POST_REVISIONS_RECEIVE ) {
+		const mergedRevisions = {
+			...get( sitePostState, 'revisions', {} ),
+			...revisions,
+		};
+
+		const filteredDiffs = filter( diffsFromServer, ( { diff, from, to } ) => {
+			if ( ! isInteger( from ) || from < 0 ) {
+				// `from` can be zero
+				return false;
+			}
+			if ( ! isInteger( to ) || to < 1 ) {
+				// `to` cannot be zero
+				return false;
+			}
+
+			// Ensure fresh revisions were provided for `from` and `to` in the payload
+			if ( from !== 0 && isEmpty( mergedRevisions[ from ] ) ) {
+				// if `from` is `0`, there won't be a revision to validate
+				return false;
+			}
+			if ( isEmpty( mergedRevisions[ to ] ) ) {
+				return false;
+			}
+
+			return ! isEmpty( diff );
+		} );
+
+		if ( isEmpty( filteredDiffs ) ) {
+			return state;
+		}
+
+		const keyedDiffs = keyBy( filteredDiffs, d => `${ d.from }:${ d.to }` );
+
+		if ( ! isEmpty( previousRevisions ) ) {
+			return {
+				...state,
+				[ siteId ]: {
+					...state[ siteId ],
+					[ postId ]: {
+						// return previous sitePostState as-is, updating only the pending values
+						...sitePostState,
+						pending: {
+							count: length,
+							diffs: keyedDiffs,
+							revisions: mergedRevisions,
+						},
+					},
+				},
+			};
+		}
+
+		return {
+			...state,
+			[ siteId ]: {
+				...state[ siteId ],
+				[ postId ]: {
+					...{
+						...omit( sitePostState, [ 'revisions', 'pending' ] ),
+						...keyedDiffs,
+					},
+					revisions: mergedRevisions,
+					pending: {},
+				},
+			},
+		};
+	}
+
+	return state;
 }
 
 export function requesting( state = {}, action ) {

--- a/client/state/selectors/get-pending-revisions-count.js
+++ b/client/state/selectors/get-pending-revisions-count.js
@@ -1,0 +1,18 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+
+const getPendingRevisionsCount = createSelector(
+	( state, siteId, postId ) =>
+		get( state.posts.revisions.diffs, [ siteId, postId, 'pending', 'count' ], 0 ),
+	state => [ state.posts.revisions.diffs ]
+);
+
+export default getPendingRevisionsCount;


### PR DESCRIPTION
**As a Calypso post author, when I open the revisions modal and there are new revisions, I want them to appear in a predictable way I can easily understand.**

* This PR addresses how new revisions are added to the list after the revisions modal has opened.
* When you reopen the revisions modal after new revisions have been created, the new revisions load at the top of the list soon afterwards. If you're trying to select a particular revision at the time, this can create a moving target.
* The latest revision isn't auto-selected at the moment: the selection stays where you last left it. Restoring this could potentially create an extra issue. After you've selected a revision, the selection would change unprompted.
* When multiple authors are working on a draft, we need a way of updating the list without disrupting the UI.

Currently, this PR changes the behaviour to load incoming revisions only when the user interacts with a notification. But there are several different possible approaches, and it would help to get views on which is preferred.

## Options
*With sub-options*

* Load new revisions at the top of the list as we do currently, and automatically select the latest when they load.

	* Show the loading state somehow.
	* Highlight the arrival of new revisions with a pip count or a momentary fade of background colour on the new items.
	* Grey out the list while new revisions are loading.
	* Show a placeholder to indicate that new revisions may appear.

* Load new revisions as they arrive, but don't switch the selection if the user has chosen a revision since opening the modal.

	* Scroll the list so the selected item keeps its position.

* Don't load new revisions automatically: alert the user but don't render them till they interact with the notification.

* Reverse the list, so new revisions are added at the bottom and the list doesn't move. Signal the change but don't switch the selection if the user's already selected an item. (This could work like Slack, where the timeline doesn't move but notifies you there's new content.)

![loading-revisions-480-2](https://user-images.githubusercontent.com/1647564/36107733-ed652f8a-1012-11e8-98d2-8e78c274e46d.gif)

![revision counter](https://user-images.githubusercontent.com/191598/34223275-ba45cf2a-e58c-11e7-91d4-4966769d8790.gif)

cc @jblz @spen @shaunandrews 
