### PR TITLE
Jetpack Onboarding: Save selection in Homepage step

### DIFF
--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -31,6 +31,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 		const { getForwardUrl, translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'What should visitors see on your homepage?' );
+		const forwardUrl = getForwardUrl();
 
 		return (
 			<Fragment>
@@ -45,14 +46,14 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 							'We can pull the latest information into your homepage for you.'
 						) }
 						image={ '/calypso/images/illustrations/homepage-news.svg' }
-						href={ getForwardUrl() }
+						href={ forwardUrl }
 						onClick={ this.handleHomepageSelection( 'posts' ) }
 					/>
 					<Tile
 						buttonLabel={ translate( 'A static welcome page' ) }
 						description={ translate( 'Have your homepage stay the same as time goes on.' ) }
 						image={ '/calypso/images/illustrations/homepage-static.svg' }
-						href={ getForwardUrl() }
+						href={ forwardUrl }
 						onClick={ this.handleHomepageSelection( 'page' ) }
 					/>
 				</TileGrid>

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -13,10 +14,21 @@ import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
+import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingHomepageStep extends React.PureComponent {
+	handleHomepageSelection = homepageFormat => {
+		const { siteId } = this.props;
+
+		return () => {
+			this.props.saveJetpackOnboardingSettings( siteId, {
+				homepageFormat,
+			} );
+		};
+	};
+
 	render() {
-		const { translate } = this.props;
+		const { getForwardUrl, translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'What should visitors see on your homepage?' );
 
@@ -33,11 +45,15 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 							'We can pull the latest information into your homepage for you.'
 						) }
 						image={ '/calypso/images/illustrations/homepage-news.svg' }
+						href={ getForwardUrl() }
+						onClick={ this.handleHomepageSelection( 'posts' ) }
 					/>
 					<Tile
 						buttonLabel={ translate( 'A static welcome page' ) }
 						description={ translate( 'Have your homepage stay the same as time goes on.' ) }
 						image={ '/calypso/images/illustrations/homepage-static.svg' }
+						href={ getForwardUrl() }
+						onClick={ this.handleHomepageSelection( 'page' ) }
 					/>
 				</TileGrid>
 			</Fragment>
@@ -45,4 +61,6 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 	}
 }
 
-export default localize( JetpackOnboardingHomepageStep );
+export default connect( null, { saveJetpackOnboardingSettings } )(
+	localize( JetpackOnboardingHomepageStep )
+);


### PR DESCRIPTION
This PR updates the Homepage step to actually save the selection on this step. This means that:

* When selecting "Recent news or updates", nothing will be changed, since that's the default setting after installing WordPress.
* When selecting "A static welcome page", 2 new pages will be created: "Home Page" and "Blog" and will assigned to respectively the "Home Page" (`page_on_front`) and "Posts Page" (`page_for_posts`) of the site.

To test:

* Checkout this branch on your local Calypso.
* Make sure your JP sandbox is running the latest Jetpack master (or Jetpack 5.6.1)
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
* Verify that after a couple of redirects you land in http://calypso.localhost:3000/jetpack/onboarding/yourjetpacksandbox.com
* Skip 2 steps until you reach the "Homepage" step.
* Select "A static welcome page".
* Go to `/wp-admin/options-reading.php` on your Jetpack site and verify the "Homepage" setting is set to a page, called "Home Page", and "Posts Page" setting is set to a page, called "Blog".