### PR TITLE
Site Selector: Use CSS selectors to scroll to a highlighted site

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -76,6 +76,7 @@ class Site extends React.Component {
 			return null;
 		}
 
+		// Note: Update CSS selectors in SiteSelector.scrollToHighlightedSite() if the class names change.
 		const siteClass = classnames( {
 			site: true,
 			'is-jetpack': site.jetpack,

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -98,15 +98,19 @@ class SiteSelector extends Component {
 	}
 
 	scrollToHighlightedSite() {
-		const selectorElement = ReactDom.findDOMNode( this.refs.selector );
+		if ( ! this.siteSelectorRef ) {
+			return;
+		}
+
+		const selectorElement = ReactDom.findDOMNode( this.siteSelectorRef );
 
 		if ( ! selectorElement ) {
 			return;
 		}
 
 		// Note: Update CSS selectors if the class names change.
-		const highlightedSiteElem = document.body.querySelector(
-			'.site-selector .site.is-highlighted, .site-selector .all-sites.is-highlighted'
+		const highlightedSiteElem = selectorElement.querySelector(
+			'.site.is-highlighted, .site-selector .all-sites.is-highlighted'
 		);
 
 		if ( ! highlightedSiteElem ) {
@@ -188,7 +192,11 @@ class SiteSelector extends Component {
 		const handledByHost = this.props.onSiteSelect( siteId );
 		this.props.onClose( event, siteId );
 
-		const node = ReactDom.findDOMNode( this.refs.selector );
+		if ( ! this.siteSelectorRef ) {
+			return;
+		}
+
+		const node = ReactDom.findDOMNode( this.siteSelectorRef );
 		if ( node ) {
 			node.scrollTop = 0;
 		}
@@ -258,6 +266,8 @@ class SiteSelector extends Component {
 	shouldShowGroups() {
 		return this.props.groups;
 	}
+
+	setSiteSelectorRef = component => ( this.siteSelectorRef = component );
 
 	renderSites() {
 		let sites;
@@ -366,7 +376,6 @@ class SiteSelector extends Component {
 	render() {
 		const hiddenSitesCount = this.props.siteCount - this.props.visibleSiteCount;
 
-		// Note: Update CSS selectors in scrollToHighlightedSite() if the class names change.
 		const selectorClass = classNames( 'site-selector', 'sites-list', this.props.className, {
 			'is-large': this.props.siteCount > 6 || hiddenSitesCount > 0 || this.state.showSearch,
 			'is-single': this.props.visibleSiteCount === 1,
@@ -391,7 +400,7 @@ class SiteSelector extends Component {
 					onSearchClose={ this.props.onClose }
 					onKeyDown={ this.onKeyDown }
 				/>
-				<div className="site-selector__sites" ref="selector">
+				<div className="site-selector__sites" ref={ this.setSiteSelectorRef }>
 					{ this.renderAllSites() }
 					{ this.renderRecentSites() }
 					{ this.renderSites() }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -104,6 +104,7 @@ class SiteSelector extends Component {
 			return;
 		}
 
+		// Note: Update CSS selectors if the class names change.
 		const highlightedSiteElem = document.body.querySelector(
 			'.site-selector .site.is-highlighted, .site-selector .all-sites.is-highlighted'
 		);
@@ -364,6 +365,8 @@ class SiteSelector extends Component {
 
 	render() {
 		const hiddenSitesCount = this.props.siteCount - this.props.visibleSiteCount;
+
+		// Note: Update CSS selectors in scrollToHighlightedSite() if the class names change.
 		const selectorClass = classNames( 'site-selector', 'sites-list', this.props.className, {
 			'is-large': this.props.siteCount > 6 || hiddenSitesCount > 0 || this.state.showSearch,
 			'is-single': this.props.visibleSiteCount === 1,

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -104,19 +104,17 @@ class SiteSelector extends Component {
 			return;
 		}
 
-		if ( ! this.highlightedSiteRef ) {
-			selectorElement.scrollTop = 0;
+		const highlightedSiteElem = document.body.querySelector(
+			'.site-selector .site.is-highlighted, .site-selector .all-sites.is-highlighted'
+		);
 
+		if ( ! highlightedSiteElem ) {
 			return;
 		}
 
-		const highlightedSiteElement = ReactDom.findDOMNode( this.highlightedSiteRef );
-
-		if ( highlightedSiteElement ) {
-			scrollIntoView( highlightedSiteElement, selectorElement, {
-				onlyScrollIfNeeded: true,
-			} );
-		}
+		scrollIntoView( highlightedSiteElem, selectorElement, {
+			onlyScrollIfNeeded: true,
+		} );
 	}
 
 	computeHighlightedSite() {
@@ -301,14 +299,6 @@ class SiteSelector extends Component {
 		return siteElements;
 	}
 
-	setHighlightedSiteRef = isHighlighted => component => {
-		if ( isHighlighted && component ) {
-			this.highlightedSiteRef = component;
-		} else if ( isHighlighted ) {
-			this.highlightedSiteRef = null;
-		}
-	};
-
 	renderAllSites() {
 		if ( this.props.showAllSites && ! this.props.sitesFound && this.props.allSitesPath ) {
 			this.visibleSites.push( ALL_SITES );
@@ -323,7 +313,6 @@ class SiteSelector extends Component {
 					onMouseEnter={ this.onAllSitesHover }
 					isHighlighted={ isHighlighted }
 					isSelected={ this.isSelected( ALL_SITES ) }
-					ref={ this.setHighlightedSiteRef( isHighlighted ) }
 				/>
 			);
 		}
@@ -347,7 +336,6 @@ class SiteSelector extends Component {
 				onMouseEnter={ this.onSiteHover }
 				isHighlighted={ isHighlighted }
 				isSelected={ this.isSelected( site ) }
-				ref={ this.setHighlightedSiteRef( isHighlighted ) }
 			/>
 		);
 	}

--- a/client/my-sites/all-sites/index.jsx
+++ b/client/my-sites/all-sites/index.jsx
@@ -61,6 +61,8 @@ class AllSites extends Component {
 			isSelected,
 			showCount,
 		} = this.props;
+
+		// Note: Update CSS selectors in SiteSelector.scrollToHighlightedSite() if the class names change.
 		const allSitesClass = classNames( {
 			'all-sites': true,
 			'is-selected': isSelected,


### PR DESCRIPTION
In this PR, we are simplifying getting the DOM node of highlighted site in `SiteSelector` by using `querySelector` instead of keeping React `ref`s for all the sites. I think it should make it a bit faster since we are not calling a function each time a site re-renders.

## Testing

Using keyboard arrows, try navigating through `SiteSelector`. When you move below the fold, does the list of sites move down?