### PR TITLE
getVisibleSites: add memoization

### DIFF
--- a/client/state/selectors/get-visible-sites.js
+++ b/client/state/selectors/get-visible-sites.js
@@ -6,6 +6,7 @@
 
 import { getSite } from 'state/sites/selectors';
 import { getSitesItems } from 'state/selectors';
+import createSelector from 'lib/create-selector';
 
 /**
  * Get all visible sites
@@ -13,7 +14,10 @@ import { getSitesItems } from 'state/selectors';
  * @param {Object} state  Global state tree
  * @return {Array}        Sites objects
  */
-export default state =>
-	Object.values( getSitesItems( state ) )
-		.filter( site => site.visible === true )
-		.map( site => getSite( state, site.ID ) );
+export default createSelector(
+	state =>
+		Object.values( getSitesItems( state ) )
+			.filter( site => site.visible === true )
+			.map( site => getSite( state, site.ID ) ),
+	state => [ getSitesItems( state ) ]
+);


### PR DESCRIPTION
In this PR, we add `createSelector` to the `getVisibleSites` selector. Should help with reducing re-renders of at least `SiteSelector`.

## Testing

Checkout `master` and add the following code (by @samouri) to the `SiteSelector` component:

```
    componentWillReceiveProps( nextProps ) {
        const keys = Object.keys( nextProps );

        keys.forEach( key => {
            const deep = isEqual( this.props[ key ], nextProps[ key ] );
            const shallow = this.props[ key ] === nextProps[ key ];

            if ( deep !== shallow ) {
                console.error( key );
            }
        } );
    }
```

Open Calypso and navigate through it. You should see sea of reds in your Dev Console caused by constant re-renders of `SiteSelector` even though nothing changed regarding sites.

Now, checkout the branch of this PR and do the same. You should see very occasional re-renders, just a few of them.