### PR TITLE
Inline action types

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,6 +13,7 @@
 		"stage-2"
 	],
 	"plugins": [
+		"./inline-imports.js",
 		"add-module-exports",
 		"syntax-jsx",
 		"transform-export-extensions",

--- a/.babelrc
+++ b/.babelrc
@@ -13,7 +13,6 @@
 		"stage-2"
 	],
 	"plugins": [
-		"./inline-imports.js",
 		"add-module-exports",
 		"syntax-jsx",
 		"transform-export-extensions",
@@ -28,7 +27,8 @@
 					"kebabCase": true
 				}
 			}
-		]
+		],
+		"./inline-imports.js"
 	],
 	"env": {
 		"test": {

--- a/client/extensions/hello-dolly/state/reducer.js
+++ b/client/extensions/hello-dolly/state/reducer.js
@@ -6,7 +6,7 @@
 
 import lyrics from './lyrics';
 import { HELLO_DOLLY_NEXT_LYRIC } from './action-types';
-import { ROUTE_SET, SECTION_SET, SITE_SETTINGS_SAVE } from 'state/action-types.js';
+import { ROUTE_SET, SECTION_SET, SITE_SETTINGS_SAVE } from 'state/action-types';
 
 export default function lyricIndex( state = 0, action ) {
 	switch ( action.type ) {

--- a/client/extensions/hello-dolly/state/test/reducer.js
+++ b/client/extensions/hello-dolly/state/test/reducer.js
@@ -9,7 +9,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import reducer from '../reducer';
-import { ROUTE_SET, SECTION_SET, SITE_SETTINGS_SAVE } from 'state/action-types.js';
+import { ROUTE_SET, SECTION_SET, SITE_SETTINGS_SAVE } from 'state/action-types';
 
 describe( 'reducer', () => {
 	test( 'should initialize to the first index', () => {

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -20,7 +20,7 @@ import {
 	COMMENTS_UNLIKE,
 	COMMENTS_WRITE,
 	READER_EXPAND_COMMENTS,
-} from '../action-types';
+} from 'state/action-types';
 import { NUMBER_OF_COMMENTS_PER_FETCH } from './constants';
 
 /**

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -38,7 +38,7 @@ import {
 	COMMENTS_WRITE_ERROR,
 	READER_EXPAND_COMMENTS,
 	COMMENTS_SET_ACTIVE_REPLY,
-} from '../action-types';
+} from 'state/action-types';
 import { combineReducers, createReducer, keyedReducer } from 'state/utils';
 import {
 	PLACEHOLDER_STATE,

--- a/client/state/components-usage-stats/actions.js
+++ b/client/state/components-usage-stats/actions.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { COMPONENTS_USAGE_STATS_REQUEST, COMPONENTS_USAGE_STATS_RECEIVE } from '../action-types';
+import { COMPONENTS_USAGE_STATS_REQUEST, COMPONENTS_USAGE_STATS_RECEIVE } from 'state/action-types';
 import request from 'superagent';
 
 /**

--- a/client/state/components-usage-stats/reducer.js
+++ b/client/state/components-usage-stats/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 
-import { COMPONENTS_USAGE_STATS_REQUEST, COMPONENTS_USAGE_STATS_RECEIVE } from '../action-types';
+import { COMPONENTS_USAGE_STATS_REQUEST, COMPONENTS_USAGE_STATS_RECEIVE } from 'state/action-types';
 
 /**
  * Tracks usage stats fetching state

--- a/client/state/console-dispatch/index.js
+++ b/client/state/console-dispatch/index.js
@@ -15,15 +15,15 @@
 /**
  * Internal dependencies
  */
-import * as actionTypes from 'state/action-types';
+// import * as actionTypes from 'state/action-types';
 
 export const consoleDispatcher = next => ( ...args ) => {
 	const store = next( ...args );
 
 	if ( 'undefined' !== typeof window ) {
-		Object.assign( window, store, {
-			actionTypes,
-		} );
+		// Object.assign( window, store, {
+		// 	actionTypes,
+		// } );
 
 		Object.defineProperty( window, 'state', {
 			enumerable: true,

--- a/client/state/console-dispatch/index.js
+++ b/client/state/console-dispatch/index.js
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * Console dispatcher Redux store enhancer
  *
@@ -10,21 +9,14 @@
  * Will only attach if the `window` variable is available
  * globally. If not it will simply be an empty link in the
  * chain, passing straight through.
+ *
+ * @param {Function} next next store enhancer in chain
+ * @returns {Function} console dispatcher store enhancer
  */
-
-/**
- * Internal dependencies
- */
-// import * as actionTypes from 'state/action-types';
-
 export const consoleDispatcher = next => ( ...args ) => {
 	const store = next( ...args );
 
 	if ( 'undefined' !== typeof window ) {
-		// Object.assign( window, store, {
-		// 	actionTypes,
-		// } );
-
 		Object.defineProperty( window, 'state', {
 			enumerable: true,
 			get: store.getState,

--- a/client/state/help/reducer.js
+++ b/client/state/help/reducer.js
@@ -6,10 +6,9 @@
 
 import { HELP_CONTACT_FORM_SITE_SELECT } from 'state/action-types';
 import courses from './courses/reducer';
-import { combineReducers } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import directly from './directly/reducer';
 import ticket from './ticket/reducer';
-import { createReducer } from 'state/utils';
 
 /**
  * Tracks the site id for the selected site in the help/contact form

--- a/client/state/jitm/actions.js
+++ b/client/state/jitm/actions.js
@@ -2,7 +2,7 @@
 /**
  * Internal Dependencies
  */
-import { JITM_DISMISS, JITM_SET } from 'state/action-types.js';
+import { JITM_DISMISS, JITM_SET } from 'state/action-types';
 
 /**
  * Dismisses a jitm

--- a/client/state/plans/actions.js
+++ b/client/state/plans/actions.js
@@ -9,7 +9,7 @@ import {
 	PLANS_REQUEST,
 	PLANS_REQUEST_SUCCESS,
 	PLANS_REQUEST_FAILURE,
-} from '../action-types';
+} from 'state/action-types';
 
 /**
  * Action creator function: RECEIVE

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -24,7 +24,7 @@ import LRU from 'lru-cache';
 /**
  * Internal dependencies
  */
-import { DESERIALIZE, SERIALIZE } from './action-types';
+import { DESERIALIZE, SERIALIZE } from 'state/action-types';
 import warn from 'lib/warn';
 
 export function isValidStateWithSchema( state, schema, debugInfo ) {

--- a/inline-imports.js
+++ b/inline-imports.js
@@ -22,15 +22,11 @@ function transformIt( babel ) {
 		name: 'action-type-inliner',
 		visitor: {
 			ImportDeclaration( path, state ) {
-				const filename = state.file.opts.filename;
-
-				if ( ! /client\//.test( filename ) || /state\/selectors.js$/.test( filename ) ) {
-					return path.skip();
-				}
-
 				if ( path.node.source.value !== 'state/action-types' ) {
 					return path.skip();
 				}
+
+				const filename = state.file.opts.filename;
 
 				const myTypes = path.node.specifiers.filter( t.isImportSpecifier ).reduce( ( o, n ) => {
 					o[ n.local.name ] = n.imported.name;

--- a/inline-imports.js
+++ b/inline-imports.js
@@ -1,0 +1,48 @@
+/** @format */
+
+function transformIt( babel ) {
+	const { types: t } = babel;
+
+	const replacer = {
+		Identifier( path ) {
+			if ( t.isImportSpecifier( path.parentPath ) ) {
+				return path.skip();
+			}
+
+			const name = path.node.name;
+			if ( ! this.myTypes.hasOwnProperty( name ) ) {
+				return path.skip();
+			}
+
+			path.replaceWith( t.stringLiteral( this.myTypes[ name ] ) );
+		},
+	};
+
+	return {
+		name: 'action-type-inliner',
+		visitor: {
+			ImportDeclaration( path, state ) {
+				const filename = state.file.opts.filename;
+
+				if ( ! /client\//.test( filename ) || /state\/selectors.js$/.test( filename ) ) {
+					return path.skip();
+				}
+
+				if ( path.node.source.value !== 'state/action-types' ) {
+					return path.skip();
+				}
+
+				const myTypes = path.node.specifiers.filter( t.isImportSpecifier ).reduce( ( o, n ) => {
+					o[ n.local.name ] = n.imported.name;
+					return o;
+				}, {} );
+
+				path.parentPath.traverse( replacer, { myTypes } );
+
+				path.remove();
+			},
+		},
+	};
+}
+
+module.exports = transformIt;

--- a/inline-imports.js
+++ b/inline-imports.js
@@ -1,9 +1,60 @@
 /** @format */
+
+/**
+ * Inlines Redux action type constants with their string value
+ * Babel Transform
+ *
+ * We use named constants for our Redux action types for a number
+ * of reasons that aid our ability to manage and understand these
+ * actions. The constants help us find uses of a given action type
+ * and they limit the effect of action type typos because a type
+ * which is improperly written will result in an import error
+ * instead of a valid-but-useless string.
+ *
+ * However, none of this information is helpful or valuable to our
+ * customers after the bundle has been build. The values of the
+ * constants are meaningless in essence though they can be useful
+ * for debugging if they match something searchable in our code.
+ * Mostly the constants add bloat to the bundle without value.
+ *
+ * This transform replaces those constants with their string
+ * values directly, inlining those values, in order to eliminate
+ * our need to ship the "action type dictionary" mapping the
+ * constants with their values.
+ *
+ * @example
+ *   Input:
+ *     import { INCREMENT as INC, RESET } from 'state/action-types';
+ *
+ *     if ( INC === type ) { return state + 1 }
+ *     if ( RESET === type ) { return 0 }
+ *
+ *   Output:
+ *     // no more import statement
+ *
+ *     if ( 'INCREMENT' === type ) { return state + 1 }
+ *     if ( 'RESET' === type ) { return 0 }
+ *
+ * We can note a few important points:
+ *   - This inlines the actual constant name, not the imported-as name
+ *   - It ultimately doesn't matter what the values are as long as they
+ *     are unique. We have less risk of bugs occurring as a result of
+ *     action type clashes after this transform than we do before because
+ *     our imports are constrained to be unique while the string values
+ *     of our action types aren't.
+ *   - The end result of this transform is the elimination of the
+ *   ` `state/action-types` module from the final output bundle.
+ *
+ * @param {Object} babel exposed Babel API
+ * @returns {Object} the Babel transformer
+ */
 function transformIt( babel ) {
 	const { types: t } = babel;
 
 	const replacer = {
 		Identifier( path ) {
+			// we haven't deleted the `import` statement yet
+			// so if we don't skip it then we'll enter a cycle
 			if ( t.isImportSpecifier( path.parentPath ) ) {
 				return path.skip();
 			}
@@ -26,8 +77,11 @@ function transformIt( babel ) {
 		name: 'action-type-inliner',
 		visitor: {
 			ImportDeclaration( path ) {
+				// import … from '{ path.node.source.value }'
 				const name = path.node.source.value;
 
+				// this is a very-specific transform because
+				// we don't want to mess up other imports
 				if ( name !== 'state/action-types' ) {
 					return path.skip();
 				}
@@ -38,6 +92,8 @@ function transformIt( babel ) {
 
 				path.parentPath.traverse( replacer, { myTypes } );
 
+				// and remove the `import` statement after we have
+				// made our replacements in the module
 				path.remove();
 			},
 		},

--- a/inline-imports.js
+++ b/inline-imports.js
@@ -1,5 +1,4 @@
 /** @format */
-
 function transformIt( babel ) {
 	const { types: t } = babel;
 
@@ -18,20 +17,24 @@ function transformIt( babel ) {
 		},
 	};
 
+	const mergeImports = ( o, n ) => {
+		o[ n.local.name ] = n.imported.name;
+		return o;
+	};
+
 	return {
 		name: 'action-type-inliner',
 		visitor: {
-			ImportDeclaration( path, state ) {
-				if ( path.node.source.value !== 'state/action-types' ) {
+			ImportDeclaration( path ) {
+				const name = path.node.source.value;
+
+				if ( name !== 'state/action-types' ) {
 					return path.skip();
 				}
 
-				const filename = state.file.opts.filename;
-
-				const myTypes = path.node.specifiers.filter( t.isImportSpecifier ).reduce( ( o, n ) => {
-					o[ n.local.name ] = n.imported.name;
-					return o;
-				}, {} );
+				const myTypes = path.node.specifiers
+					.filter( t.isImportSpecifier )
+					.reduce( mergeImports, {} );
 
 				path.parentPath.traverse( replacer, { myTypes } );
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "async": "0.9.0",
     "autoprefixer": "6.3.5",
     "autosize": "3.0.15",
+    "babel-cli": "6.26.0",
     "babel-core": "6.25.0",
     "babel-loader": "7.1.1",
     "babel-plugin-add-module-exports": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "async": "0.9.0",
     "autoprefixer": "6.3.5",
     "autosize": "3.0.15",
-    "babel-cli": "6.26.0",
     "babel-core": "6.25.0",
     "babel-loader": "7.1.1",
     "babel-plugin-add-module-exports": "0.2.1",


### PR DESCRIPTION
Our action types are heavy strings and heavy constant names.

```js
export const REALLY_LONG_NAME = 'REALLY_LONG_NAME'
```

These get imported in every module which uses action types.

```js
const _actionTypes = require( 'state/action-types' );

{ type: _actionTypes.REALLY_LONG_NAME }
```

The action type file by itself is alomst 70KB in its raw form and I
suspect that it introduces bloat around the application with these
strings and imports.

In this PR we're replacing those constants with the string equivalents
and removing the import statements. Future optimization is possible by
shortening the strings.

This experiment will proceed step-by-step informed by reduction in
bundle sizes.

<img width="846" alt="screen shot 2017-12-26 at 12 01 16 am" src="https://user-images.githubusercontent.com/5431237/34349717-0513a6e8-e9d0-11e7-86b1-7427c842d0e1.png">

| kb | build | state | data-layer |
| - | --- | --- | --- |
| Master | 531.57 | 129.81 | 28.19 |
| Inlined | 521.92 | 119.93 | 27.85 |