### PR TITLE
Store: Make FilePicker click target larger on Product Page

### DIFF
--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -206,8 +206,10 @@ class ProductImageUploader extends Component {
 			<div className="product-image-uploader__wrapper">
 				<div className="product-image-uploader__picker">
 					<FilePicker multiple={ multiple } accept="image/*" onPick={ this.onPick }>
-						<Gridicon icon="add-image" size={ 36 } />
-						<p>{ translate( 'Add images' ) }</p>
+						<div>
+							<Gridicon icon="add-image" size={ 36 } />
+							<p>{ translate( 'Add images' ) }</p>
+						</div>
 					</FilePicker>
 				</div>
 				<DropZone onFilesDrop={ this.onPick } />

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -36,6 +36,14 @@
 			}
 		}
 
+		.file-picker {
+			width: 100%;
+			height: 100%;
+			display: flex;
+			justify-content: center;
+			flex-direction: column;
+		}
+
 		.gridicon {
 			color: darken( $gray, 10% );
 		}


### PR DESCRIPTION
Fixes #19443

This quick PR makes the `<FilePicker />` instance on the product page expand to fill 100% of its' parent container. This allows clicking anywhere in the container to upload an image - a bug that has been reported a few times.

![add-images](https://user-images.githubusercontent.com/22080/34235755-9dd11932-e5a8-11e7-8367-a95861be66f7.png)

__To Test__
- Open up a new product
- Click anywhere inside the grey "Add Image" box
- Verify the file browser is opened