### PR TITLE
Jetpack Free Sites: Fix link to plugin management on My Plans page

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-wordpress-com.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-wordpress-com.jsx
@@ -28,7 +28,7 @@ export default localize( ( { selectedSite, translate } ) => {
 					}
 				) }
 				buttonText={ translate( 'Configure auto updates' ) }
-				href={ `/plugins/${ selectedSite.slug }` }
+				href={ `/plugins/manage/${ selectedSite.slug }` }
 			/>
 		</div>
 	);


### PR DESCRIPTION
On a Jetpack site with a Free plan, we show a card to encourage users to turn on auto updates. With recent changes to Plugin management, the link is now wrong. This fixes it.
![screen shot 2017-12-20 at 6 31 18 pm](https://user-images.githubusercontent.com/108942/34236278-fcf89934-e5b3-11e7-9686-8b83f9b28923.png)
