### PR TITLE
Fix state validation error for locale switching

### DIFF
--- a/client/state/test/persistence.js
+++ b/client/state/test/persistence.js
@@ -6,12 +6,15 @@ import { DESERIALIZE, SERIALIZE } from 'state/action-types';
 import { createReduxStore, reducer } from 'state';
 
 describe( 'persistence', () => {
-	test( 'initial state should serialize and deserialize without errors', () => {
-		const consoleSpy = jest.spyOn( global.console, 'error' ).mockImplementation( () => () => {} );
+	test( 'initial state should serialize and deserialize without errors or warnings', () => {
+		const consoleErrorSpy = jest.spyOn( global.console, 'error' ).mockImplementation( () => () => {} );
+		const consoleWarnSpy = jest.spyOn( global.console, 'warn' ).mockImplementation( () => () => {} );
+
 		const initialState = createReduxStore().getState();
 
 		reducer( reducer( initialState, { type: SERIALIZE } ), { type: DESERIALIZE } );
 
-		expect( consoleSpy.mock.calls ).toHaveLength( 0 );
+		expect( consoleErrorSpy.mock.calls ).toHaveLength( 0 );
+		expect( consoleWarnSpy.mock.calls ).toHaveLength( 0 );
 	} );
 } );

--- a/client/state/test/persistence.js
+++ b/client/state/test/persistence.js
@@ -14,7 +14,7 @@ describe( 'persistence', () => {
 
 		reducer( reducer( initialState, { type: SERIALIZE } ), { type: DESERIALIZE } );
 
-		expect( consoleErrorSpy.mock.calls ).toHaveLength( 0 );
-		expect( consoleWarnSpy.mock.calls ).toHaveLength( 0 );
+		expect( consoleErrorSpy ).not.toHaveBeenCalled();
+		expect( consoleWarnSpy ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/state/ui/language/schema.js
+++ b/client/state/ui/language/schema.js
@@ -1,4 +1,4 @@
 /** @format */
 export const localeSlugSchema = {
-	type: 'string',
+	anyOf: [ { type: 'string' }, { enum: [ false ] } ],
 };


### PR DESCRIPTION
This PR fixes a state validation error introduced in #19319 ([#](https://github.com/Automattic/wp-calypso/pull/19319/files#diff-05f209b1240f072d67d9fc1b6cd41d2bL20)).  The default state was changed from `'en'` to `false` without updating the corresponding schema:

> <img src="https://user-images.githubusercontent.com/227022/34235960-19a0a220-e5c3-11e7-8c30-778c888efd26.png" width="579">

See also #21019 which seeks to improve the readability of these warning messages.