### PR TITLE
Plans: update primary button in Site Security so it references Activity Log

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -143,7 +143,7 @@ class ProductPurchaseFeaturesList extends Component {
 
 		return [
 			<MonetizeSite selectedSite={ selectedSite } key="monetizeSiteFeature" />,
-			<JetpackBackupSecurity key="jetpackBackupSecurity" />,
+			<JetpackBackupSecurity selectedSite={ selectedSite } key="jetpackBackupSecurity" />,
 			<JetpackAntiSpam key="jetpackAntiSpam" />,
 			<JetpackPublicize key="jetpackPublicize" />,
 			<JetpackVideo key="jetpackVideo" />,
@@ -156,7 +156,7 @@ class ProductPurchaseFeaturesList extends Component {
 		const { selectedSite } = this.props;
 
 		return [
-			<JetpackBackupSecurity key="jetpackBackupSecurity" />,
+			<JetpackBackupSecurity selectedSite={ selectedSite } key="jetpackBackupSecurity" />,
 			<JetpackAntiSpam key="jetpackAntiSpam" />,
 			<JetpackWordPressCom selectedSite={ selectedSite } key="jetpackWordPressCom" />,
 			<JetpackReturnToDashboard selectedSite={ selectedSite } key="jetpackReturnToDashboard" />,
@@ -173,7 +173,7 @@ class ProductPurchaseFeaturesList extends Component {
 				link="https://calendly.com/jetpack/concierge"
 			/>,
 			<FindNewTheme selectedSite={ selectedSite } key="findNewThemeFeature" />,
-			<JetpackBackupSecurity key="jetpackBackupSecurity" />,
+			<JetpackBackupSecurity selectedSite={ selectedSite } key="jetpackBackupSecurity" />,
 			<MonetizeSite selectedSite={ selectedSite } key="monetizeSiteFeature" />,
 			<GoogleAnalyticsStats selectedSite={ selectedSite } key="googleAnalyticsStatsFeature" />,
 			<JetpackAntiSpam key="jetpackAntiSpam" />,

--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-backup-security.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-backup-security.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { translate } ) => {
+export default localize( ( { selectedSite, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -21,8 +21,8 @@ export default localize( ( { translate } ) => {
 				description={ translate(
 					'Your site is being securely backed up and scanned with real-time sync.'
 				) }
-				buttonText={ translate( 'Visit security dashboard' ) }
-				href="https://dashboard.vaultpress.com/"
+				buttonText={ translate( 'Visit Activity Log' ) }
+				href={ `/stats/activity/${ selectedSite.slug }` }
 			/>
 		</div>
 	);


### PR DESCRIPTION
Fixes #21017

This PR updates the button in Site Security block in Plans view to reference and link to Activity Log

<img width="399" alt="captura de pantalla 2017-12-20 a la s 23 14 14" src="https://user-images.githubusercontent.com/1041600/34237449-82e10b36-e5db-11e7-980d-98d51f173a79.png">
