### PR TITLE
Remove restriction on free to paid nudge according to user registration.

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import url from 'url';
 import { connect } from 'react-redux';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import paths from 'my-sites/domains/paths';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
-import { canCurrentUser, isEligibleForFreeToPaidUpsell } from 'state/selectors';
+import { canCurrentUser, isDomainOnlySite, isEligibleForFreeToPaidUpsell } from 'state/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
 import {
@@ -27,7 +27,6 @@ import {
 } from 'state/plugins/premium/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import DomainToPaidPlanNotice from './domain-to-paid-plan-notice';
-import { isDomainOnlySite } from 'state/selectors';
 
 class SiteNotice extends React.Component {
 	static propTypes = {
@@ -163,7 +162,7 @@ export default connect(
 		const siteId = ownProps.site && ownProps.site.ID ? ownProps.site.ID : null;
 		return {
 			isDomainOnly: isDomainOnlySite( state, siteId ),
-			isEligibleForFreeToPaidUpsell: isEligibleForFreeToPaidUpsell( state, siteId, moment() ),
+			isEligibleForFreeToPaidUpsell: isEligibleForFreeToPaidUpsell( state, siteId ),
 			hasDomainCredit: hasDomainCredit( state, siteId ),
 			canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
 			pausedJetpackPluginsSetup:

--- a/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
@@ -4,36 +4,22 @@
  * Internal dependencies
  */
 
-import {
-	canCurrentUser,
-	isMappedDomainSite,
-	isSiteOnFreePlan,
-	isUserRegistrationDaysWithinRange,
-	isVipSite,
-} from 'state/selectors';
+import { canCurrentUser, isMappedDomainSite, isSiteOnFreePlan, isVipSite } from 'state/selectors';
 
 /**
  * Returns true if the current user is eligible to participate in the free to paid plan upsell for the site
  *
  * @param {Object} state Global state tree
  * @param {Number} siteId Site ID
- * @param {Object} moment Current moment for determination of elapsed days since registration
  * @return {?Boolean} True if the user can participate in the free to paid upsell
  */
-const isEligibleForFreeToPaidUpsell = ( state, siteId, moment ) => {
+const isEligibleForFreeToPaidUpsell = ( state, siteId ) => {
 	const userCanManageOptions = canCurrentUser( state, siteId, 'manage_options' );
 	const siteHasMappedDomain = isMappedDomainSite( state, siteId );
 	const siteIsOnFreePlan = isSiteOnFreePlan( state, siteId );
-	const registrationDaysIsWithinRange = isUserRegistrationDaysWithinRange( state, moment, 0, 180 );
 	const siteIsVipSite = isVipSite( state, siteId );
 
-	return (
-		userCanManageOptions &&
-		! siteHasMappedDomain &&
-		siteIsOnFreePlan &&
-		! siteIsVipSite &&
-		registrationDaysIsWithinRange
-	);
+	return userCanManageOptions && ! siteHasMappedDomain && siteIsOnFreePlan && ! siteIsVipSite;
 };
 
 export default isEligibleForFreeToPaidUpsell;

--- a/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-domain-to-paid-plan-upsell.js
@@ -12,6 +12,7 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import isMappedDomainSite from 'state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import isVipSite from 'state/selectors/is-vip-site';
+
 jest.mock( 'state/selectors/can-current-user', () => require( 'sinon' ).stub() );
 jest.mock( 'state/selectors/is-mapped-domain-site', () => require( 'sinon' ).stub() );
 jest.mock( 'state/selectors/is-site-on-free-plan', () => require( 'sinon' ).stub() );

--- a/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/test/is-eligible-for-free-to-paid-upsell.js
@@ -11,62 +11,50 @@ import isEligibleForFreeToPaidUpsell from '../is-eligible-for-free-to-paid-upsel
 import canCurrentUser from 'state/selectors/can-current-user';
 import isMappedDomainSite from 'state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
-import isUserRegistrationDaysWithinRange from 'state/selectors/is-user-registration-days-within-range';
 import isVipSite from 'state/selectors/is-vip-site';
 
 jest.mock( 'state/selectors/can-current-user', () => require( 'sinon' ).stub() );
 jest.mock( 'state/selectors/is-mapped-domain-site', () => require( 'sinon' ).stub() );
 jest.mock( 'state/selectors/is-site-on-free-plan', () => require( 'sinon' ).stub() );
-jest.mock( 'state/selectors/is-user-registration-days-within-range', () =>
-	require( 'sinon' ).stub()
-);
 jest.mock( 'state/selectors/is-vip-site', () => require( 'sinon' ).stub() );
 
 describe( 'isEligibleForFreeToPaidUpsell', () => {
 	const state = 'state';
-	const moment = 'moment';
 	const siteId = 'siteId';
 
 	const meetAllConditions = () => {
 		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( true );
 		isMappedDomainSite.withArgs( state, siteId ).returns( false );
 		isSiteOnFreePlan.withArgs( state, siteId ).returns( true );
-		isUserRegistrationDaysWithinRange.withArgs( state, moment, 0, 180 ).returns( true );
 		isVipSite.withArgs( state, siteId ).returns( false );
 	};
 
 	test( 'should return false when user can not manage options', () => {
 		meetAllConditions();
 		canCurrentUser.withArgs( state, siteId, 'manage_options' ).returns( false );
-		expect( isEligibleForFreeToPaidUpsell( state, siteId, moment ) ).to.be.false;
+		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
 	} );
 
 	test( 'should return false when site has mapped domain', () => {
 		meetAllConditions();
 		isMappedDomainSite.withArgs( state, siteId ).returns( true );
-		expect( isEligibleForFreeToPaidUpsell( state, siteId, moment ) ).to.be.false;
+		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
 	} );
 
 	test( 'should return false when site is not on a free plan', () => {
 		meetAllConditions();
 		isSiteOnFreePlan.withArgs( state, siteId ).returns( false );
-		expect( isEligibleForFreeToPaidUpsell( state, siteId, moment ) ).to.be.false;
-	} );
-
-	test( 'should return false when user registration days is not within range', () => {
-		meetAllConditions();
-		isUserRegistrationDaysWithinRange.withArgs( state, moment, 0, 180 ).returns( false );
-		expect( isEligibleForFreeToPaidUpsell( state, siteId, moment ) ).to.be.false;
+		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
 	} );
 
 	test( 'should return false when site is a vip site', () => {
 		meetAllConditions();
 		isVipSite.withArgs( state, siteId ).returns( true );
-		expect( isEligibleForFreeToPaidUpsell( state, siteId, moment ) ).to.be.false;
+		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.false;
 	} );
 
 	test( 'should return true when all conditions are met', () => {
 		meetAllConditions();
-		expect( isEligibleForFreeToPaidUpsell( state, siteId, moment ) ).to.be.true;
+		expect( isEligibleForFreeToPaidUpsell( state, siteId ) ).to.be.true;
 	} );
 } );


### PR DESCRIPTION
The free to paid nudge currently disappears once a user has been registered for > 180 days.

This change removes that restriction.

# Testing

With a user that had been registered for more than 180 days ago, create a new free site.

You should see the free to paid nudge in the sidebar.
