### PR TITLE
Stats: fix "No popular day and time recorded" message box

### DIFF
--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -80,7 +80,8 @@
 		padding: 13px 48px;
 		font-size: inherit;
 		display: inline-flex;
-		top: 18px;
+		top: 10px;
+		margin: 0 5px;
 
 		&::before {
 			@include noticon-style;

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -79,6 +79,8 @@
 	@include breakpoint( ">660px" ) {
 		padding: 13px 48px;
 		font-size: inherit;
+		display:inline-flex;
+		top: 18px;
 
 		&::before {
 			@include noticon-style;

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -79,7 +79,7 @@
 	@include breakpoint( ">660px" ) {
 		padding: 13px 48px;
 		font-size: inherit;
-		display:inline-flex;
+		display: inline-flex;
 		top: 18px;
 
 		&::before {


### PR DESCRIPTION
This is my attempt to fix #20658 

The problem, as originally described:

"No popular day and time recorded" message is visually off.

**Steps to reproduce**

1. Starting at URL: https://wordpress.com/stats/insights/:site

2. For empty / new blog you will see "No popular day and time recorded" message in "Most popular day and hour" box:
![33779973-b48df3fc-dc57-11e7-82ca-7ed21973a5e6](https://user-images.githubusercontent.com/2965712/34240638-99de08fa-e5c4-11e7-8b7e-ad1a99f059f8.png)
 
3. Message will break into two lines If you make your browser window just under ~1000px wide or around ~1300px wide:
![33779990-c45e97e6-dc57-11e7-8d37-f27ccc7442c5](https://user-images.githubusercontent.com/2965712/34240648-a8a16c74-e5c4-11e7-9bf5-5f456744ca75.png)

**What I expected**
Message box to change its height when text inside it breaks into multiple lines.

**What happened instead**
The box broke. 😢

**Browser / OS version**
Firefox / MacOS

-----------

My attempt to fix this was to modify the style.scss file found in:
client/my-sites/stats/most-popular/

Adding the following CSS to the _.most-popular__notice_ class at the breakpoint on screens larger than 660px:
_display:inline-flex;_
line to handle wrapping text to the next line 
and
_top:18px;_
to move it up a little higher to where it was originally.

I've tested this fix in Chrome, Firefox, IE, Edge and Opera, according to the browser compatibility specifications, as well as Android and iOS tablets and phones. 

Please let me know if you have any questions or any feedback. Thank you!

cc @simison @juliaamosova @timmyc 






