### PR TITLE
Jetpack connect: Add placeholder to store loading

### DIFF
--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -4,24 +4,24 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import page from 'page';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import addQueryArgs from 'lib/route/add-query-args';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
-import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import Placeholder from './plans-placeholder';
 import PlansGrid from './plans-grid';
 import PlansSkipButton from './plans-skip-button';
-import { recordTracksEvent } from 'state/analytics/actions';
+import QueryPlans from 'components/data/query-plans';
 import { getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
 import { getSite, isRequestingSites } from 'state/sites/selectors';
-import QueryPlans from 'components/data/query-plans';
-import addQueryArgs from 'lib/route/add-query-args';
+import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { storePlan } from './persistence-utils';
 
 const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -14,6 +14,7 @@ import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
+import Placeholder from './plans-placeholder';
 import PlansGrid from './plans-grid';
 import PlansSkipButton from './plans-skip-button';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -91,7 +92,7 @@ class PlansLanding extends Component {
 		// We're redirecting in componentDidMount if the site is already connected
 		// so don't bother rendering any markup if this is the case
 		if ( url && ( site || requestingSites ) ) {
-			return null;
+			return <Placeholder />;
 		}
 
 		return (


### PR DESCRIPTION
This PR adds the plans placeholder to the store loading page.

Follow-up from #20953 

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/34245418-0c3aa2ea-e62a-11e7-97fa-8a3bbe92538a.png)

### After

![after](https://user-images.githubusercontent.com/841763/34245424-16180fc8-e62a-11e7-9773-540505448d51.png)

## Testing
1. Most noticeable if you have a large list of sites. Try throttling network if you don't see the placeholder.
1. https://calypso.live/jetpack/connect/store?branch=update/jetpack-connect/store-placeholder&site=http://example.com&flags=+force-sympathy
1. Enjoy 😎 
1. You can see the before on staging at https://wordpress.com/jetpack/connect/store?branch=master&site=http://example.com&flags=+force-sympathy