### PR TITLE
Add Continue step to ensure tour shows on first click.

### DIFF
--- a/client/layout/guided-tours/tours/checklist-about-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour.js
@@ -48,6 +48,12 @@ export const ChecklistAboutPageTour = makeTour(
 				) }
 			</p>
 			<ButtonRow>
+				<Continue
+					target="editor-featured-image-current-image"
+					step="featured-images"
+					click
+					hidden
+				/>
 				<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
 				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 			</ButtonRow>

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -39,6 +39,12 @@ export const ChecklistContactPageTour = makeTour(
 				) }
 			</p>
 			<ButtonRow>
+				<Continue
+					target="editor-featured-image-current-image"
+					step="featured-images"
+					click
+					hidden
+				/>
 				<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
 				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 			</ButtonRow>


### PR DESCRIPTION
The about page and contact page checklist tours do not show on first click.

Adding a `Continue` step seems to alleviate this situation.

# Testing

- view `/checklist/<domain>` for a site
- perform a hard page refresh
- click the about page tour
- verify that the first tour step shows

- view `/checklist/<domain>` for a site
- perform a hard page refresh
- click the contact page tour
- verify that the first tour step shows

