### PR TITLE
Jetpack Connect: Add more detailed placeholder for plans

### DIFF
--- a/client/jetpack-connect/plans-placeholder.js
+++ b/client/jetpack-connect/plans-placeholder.js
@@ -4,16 +4,16 @@
  * External dependencies
  */
 import React from 'react';
+import { times, random } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import Main from 'components/main';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const placeholderContent = (
-	<Main wideLayout>
+	<Main className="jetpack-connect__hide-plan-icons" wideLayout>
 		<div className="jetpack-connect__plans placeholder">
 			<header className="formatted-header">
 				<h1 className="formatted-header__title">
@@ -23,9 +23,47 @@ const placeholderContent = (
 					<span className="placeholder-text">Now pick a plan that's right for you.</span>
 				</p>
 			</header>
-			<Card>
-				<div className="jetpack-connect-plans-placeholder__plans-content" />
-			</Card>
+
+			<div className="plans-wrapper">
+				<div className="plan-features plan-features--signup">
+					<table className="plan-features__table">
+						<tr className="plan-features__row">
+							{ times( 3, cellKey => (
+								<td className="plan-features__table-item has-border-top" key={ cellKey }>
+									<div className="plan-features__header-wrapper">
+										<header className="plan-features__header">
+											<div className="plan-features__header-text">
+												<h4 className="plan-features__header-title">
+													<span className="placeholder-text">Premium</span>
+												</h4>
+												<span className="placeholder-text">Best for small businesses</span>
+											</div>
+										</header>
+										<div className="plan-features__pricing">
+											<span className="plan-price is-original placeholder-text">$108,00</span>
+											<span className="plan-price placeholder-text">$99,00</span>
+										</div>
+									</div>
+									<div className="plan-features__actions">
+										<div className="plan-features__actions-buttons">
+											<div className="placeholder-text">
+												Upgrade<br />Your Plan
+											</div>
+										</div>
+									</div>
+									{ times( 5, featureKey => (
+										<div className="plan-features__item" key={ featureKey }>
+											<span className="placeholder-text">
+												Test feature { random( 1, Number.MAX_SAFE_INTEGER ) }
+											</span>
+										</div>
+									) ) }
+								</td>
+							) ) }
+						</tr>
+					</table>
+				</div>
+			</div>
 		</div>
 	</Main>
 );

--- a/client/jetpack-connect/plans-placeholder.js
+++ b/client/jetpack-connect/plans-placeholder.js
@@ -27,40 +27,42 @@ const placeholderContent = (
 			<div className="plans-wrapper">
 				<div className="plan-features plan-features--signup">
 					<table className="plan-features__table">
-						<tr className="plan-features__row">
-							{ times( 3, cellKey => (
-								<td className="plan-features__table-item has-border-top" key={ cellKey }>
-									<div className="plan-features__header-wrapper">
-										<header className="plan-features__header">
-											<div className="plan-features__header-text">
-												<h4 className="plan-features__header-title">
-													<span className="placeholder-text">Premium</span>
-												</h4>
-												<span className="placeholder-text">Best for small businesses</span>
-											</div>
-										</header>
-										<div className="plan-features__pricing">
-											<span className="plan-price is-original placeholder-text">$108,00</span>
-											<span className="plan-price placeholder-text">$99,00</span>
-										</div>
-									</div>
-									<div className="plan-features__actions">
-										<div className="plan-features__actions-buttons">
-											<div className="placeholder-text">
-												Upgrade<br />Your Plan
+						<tbody>
+							<tr className="plan-features__row">
+								{ times( 3, cellKey => (
+									<td className="plan-features__table-item has-border-top" key={ cellKey }>
+										<div className="plan-features__header-wrapper">
+											<header className="plan-features__header">
+												<div className="plan-features__header-text">
+													<h4 className="plan-features__header-title">
+														<span className="placeholder-text">Premium</span>
+													</h4>
+													<span className="placeholder-text">Best for small businesses</span>
+												</div>
+											</header>
+											<div className="plan-features__pricing">
+												<span className="plan-price is-original placeholder-text">$108,00</span>
+												<span className="plan-price placeholder-text">$99,00</span>
 											</div>
 										</div>
-									</div>
-									{ times( 5, featureKey => (
-										<div className="plan-features__item" key={ featureKey }>
-											<span className="placeholder-text">
-												Test feature { random( 1, Number.MAX_SAFE_INTEGER ) }
-											</span>
+										<div className="plan-features__actions">
+											<div className="plan-features__actions-buttons">
+												<div className="placeholder-text">
+													Upgrade<br />Your Plan
+												</div>
+											</div>
 										</div>
-									) ) }
-								</td>
-							) ) }
-						</tr>
+										{ times( 5, featureKey => (
+											<div className="plan-features__item" key={ featureKey }>
+												<span className="placeholder-text">
+													Test feature { random( 1, Number.MAX_SAFE_INTEGER ) }
+												</span>
+											</div>
+										) ) }
+									</td>
+								) ) }
+							</tr>
+						</tbody>
 					</table>
 				</div>
 			</div>

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -534,6 +534,16 @@
 	.jetpack-connect-plans-placeholder__plans-content {
 		min-height: 400px;
 	}
+
+	.plan-features--signup .plan-price.is-original:before {
+		border-top: 0;
+	}
+
+	.plan-features__item {
+		.placeholder-text {
+			margin: 0 auto;
+		}
+	}
 }
 
 .jetpack-connect__auth-form-header-image {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -539,6 +539,10 @@
 		border-top: 0;
 	}
 
+	.plan-features__actions-buttons {
+		margin-top: 16px;
+	}
+
 	.plan-features__item {
 		.placeholder-text {
 			margin: 0 auto;


### PR DESCRIPTION
This PR is a follow up to #20953 and adds a more detailed placeholder to Jetpack Connect plans:

![](https://cldup.com/sAAzXdgGcx.png)

Testing:

1. Most noticeable if you have a large list of sites. Try throttling network if you don't see the placeholder.
1. https://calypso.live/jetpack/connect/store?branch=update/jpc-plans-more-detailed-placeholder&site=http://example.com&flags=+force-sympathy
1. Enjoy 😎 
1. You can see the before on staging at https://wordpress.com/jetpack/connect/store?site=http://example.com&flags=+force-sympathy