### PR TITLE
Components: add a split button with a popover menu

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -209,6 +209,7 @@
 @import 'components/spinner/style';
 @import 'components/spinner-button/style';
 @import 'components/spinner-line/style';
+@import 'components/split-button/style';
 @import 'components/stat-update-indicator/style';
 @import 'components/sticky-panel/style';
 @import 'components/sub-masterbar-nav/style';

--- a/client/components/split-button/README.md
+++ b/client/components/split-button/README.md
@@ -1,0 +1,129 @@
+Split Button
+=============
+
+A React component for displaying a button with a labeled main action plus a secondary, identified by a chevron, that toggles the menu's visibility.
+
+## Usage
+
+Render `<SplitButton />` in a similar fashion as you would [the `<PopoverMenu />` component](../popover-menu), as it is effectively a convenience wrapper for this component with a few additional options. Specifically, you'll still need to render `<PopoverMenuItem />` as children of the `<SplitButton />`.
+
+```jsx
+import SplitButton from 'components/split-button';
+import PopoverMenuItem from 'components/popover/menu-item';
+
+export default function MyComponent( { onMenuItemClick } ) {
+	return (
+		<SplitButton
+			mainFace="Split Button"
+		>
+			<PopoverMenuItem onClick={ onMenuItemClick }>
+				Click Me!
+			</PopoverMenuItem>
+		</SplitButton>
+	);
+}
+```
+
+## Props
+
+### `mainFace`
+
+<table>
+	<tr><td>Type</td><td><code>PropTypes.node</code></td></tr>
+    <tr><td>Required</td><td>Yes</td></tr>
+	<tr><td>Default</td><td><code>noop</code></td></tr>
+</table>
+
+Text or icon for the main button.
+
+### `compact`
+
+<table>
+	<tr><td>Type</td><td><code>PropTypes.bool</code></td></tr>
+    <tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>false</code></td></tr>
+</table>
+
+Whether the button is compact or not.
+
+### `primary`
+
+<table>
+	<tr><td>Type</td><td><code>PropTypes.bool</code></td></tr>
+    <tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>false</code></td></tr>
+</table>
+
+Whether the button is styled as a primary button.
+
+### `scary`
+
+<table>
+	<tr><td>Type</td><td><code>PropTypes.bool</code></td></tr>
+    <tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>false</code></td></tr>
+</table>
+
+Whether the button has modified styling to warn users (delete, remove, etc).es
+
+### `onClick`
+
+<table>
+	<tr><td>Type</td><td>Function</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>noop</code></td></tr>
+</table>
+
+Callback that will be invoked when menu button is clicked.
+Will be passed the click event.
+
+### `onToggle`
+
+<table>
+	<tr><td>Type</td><td>Function</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>noop</code></td></tr>
+</table>
+
+Callback that will be invoked when menu is toggled.
+Will be passed the boolean visibility of the menu.
+
+### `toggleTitle`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>null</code></td></tr>
+</table>
+
+Override for the default "Toggle menu" `title` attribute on the toggle button.
+
+### `position`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>bottom left</code></td></tr>
+</table>
+
+The position at which the menu should be rendered. If omitted, uses the default `position` from [the `<PopoverMenu />` component](../popover-menu).
+
+### `children`
+
+<table>
+	<tr><td>Type</td><td><code>PropTypes.node</code></td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>null</code></td></tr>
+</table>
+
+Menu children to be rendered.
+
+### `disabled`
+
+<table>
+	<tr><td>Type</td><td><code>PropTypes.bool</code></td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>null</code></td></tr>
+</table>
+
+If `true`, then the menu icon will be displayed in light gray and will not be clickable.

--- a/client/components/split-button/docs/example.jsx
+++ b/client/components/split-button/docs/example.jsx
@@ -1,0 +1,104 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import SplitButton from '../';
+import PopoverMenuItem from 'components/popover/menu-item';
+import PopoverMenuSeparator from 'components/popover/menu-separator';
+import Card from 'components/card';
+
+const popoverItems = [
+	<PopoverMenuItem key="sbe-oa" icon="add">
+		Option A
+	</PopoverMenuItem>,
+	<PopoverMenuItem key="sbe-ob" icon="pencil">
+		Option B
+	</PopoverMenuItem>,
+	<PopoverMenuSeparator key="sbe-sep" />,
+	<PopoverMenuItem key="sbe-oc" icon="help">
+		Option C
+	</PopoverMenuItem>,
+	<PopoverMenuItem key="sbe-od" disabled icon="cross-circle">
+		Disabled option
+	</PopoverMenuItem>,
+];
+
+class SplitButtonExample extends React.PureComponent {
+	state = {
+		compactButtons: false,
+	};
+
+	toggleButtons = () => this.setState( { compactButtons: ! this.state.compactButtons } );
+
+	render() {
+		const compact = { compact: this.state.compactButtons };
+		return (
+			<div>
+				<a className="docs__design-toggle button" onClick={ this.toggleButtons }>
+					{ this.state.compactButtons ? 'Normal Buttons' : 'Compact Buttons' }
+				</a>
+				<Card>
+					{ map(
+						[
+							[
+								{ label: 'Split Button', icon: 'history' },
+								{ label: 'Split Button', primary: true },
+								{ icon: 'globe' },
+							],
+							[
+								{ label: 'Split Button', primary: true, disableMain: true },
+								{ label: 'Split Button', icon: 'history', primary: true, disableMenu: true },
+							],
+							[
+								{ label: 'Split Button', primary: true, disabled: true },
+								{ icon: 'globe', primary: true, disabled: true },
+							],
+							[
+								{ label: 'Split Button', icon: 'history', scary: true },
+								{ label: 'Split Button', primary: true, scary: true },
+								{ icon: 'globe', scary: true },
+							],
+							[
+								{ label: 'Split Button', primary: true, disableMain: true, scary: true },
+								{
+									label: 'Split Button',
+									icon: 'history',
+									primary: true,
+									disableMenu: true,
+									scary: true,
+								},
+							],
+							[
+								{ label: 'Split Button', primary: true, disabled: true, scary: true },
+								{ icon: 'globe', primary: true, disabled: true, scary: true },
+							],
+						],
+						( row, rowIndex ) => (
+							<div className="docs__design-button-row" key={ `split-button-row-${ rowIndex }` }>
+								{ map( row, ( item, itemIndex ) => (
+									<SplitButton
+										key={ `split-button-item-${ rowIndex }-${ itemIndex }` }
+										{ ...item }
+										{ ...compact }
+									>
+										{ popoverItems }
+									</SplitButton>
+								) ) }
+							</div>
+						)
+					) }
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default SplitButtonExample;

--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -1,0 +1,155 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import PopoverMenu from 'components/popover/menu';
+
+class SplitButton extends Component {
+	static propTypes = {
+		translate: PropTypes.func,
+		label: PropTypes.string,
+		icon: PropTypes.string,
+		toggleTitle: PropTypes.string,
+		position: PropTypes.string,
+		disabled: PropTypes.bool,
+		disableMain: PropTypes.bool,
+		disableMenu: PropTypes.bool,
+		compact: PropTypes.bool,
+		primary: PropTypes.bool,
+		scary: PropTypes.bool,
+		onClick: PropTypes.func,
+		onToggle: PropTypes.func,
+		popoverClassName: PropTypes.string,
+	};
+
+	static defaultProps = {
+		onClick: noop,
+		onToggle: noop,
+		label: '',
+		icon: '',
+		position: 'bottom left',
+		disabled: false,
+		disableMain: false,
+		disableMenu: false,
+		compact: false,
+		primary: false,
+		scary: false,
+	};
+
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			isMenuVisible: false,
+			popoverContext: null,
+		};
+
+		this.showMenu = this.toggleMenu.bind( this, true );
+		this.hideMenu = this.toggleMenu.bind( this, false );
+
+		this.setPopoverContext = this.setPopoverContext.bind( this );
+	}
+
+	handleClick = event => {
+		const { onClick } = this.props;
+		const { isMenuVisible } = this.state;
+
+		onClick( event );
+
+		if ( isMenuVisible ) {
+			this.hideMenu();
+		} else {
+			this.showMenu();
+		}
+	};
+
+	setPopoverContext( popoverContext ) {
+		if ( popoverContext ) {
+			this.setState( { popoverContext } );
+		}
+	}
+
+	toggleMenu( isMenuVisible ) {
+		if ( ! this.props.disabled ) {
+			this.setState( { isMenuVisible } );
+			this.props.onToggle( isMenuVisible );
+		}
+	}
+
+	render() {
+		const {
+			label,
+			icon,
+			compact,
+			primary,
+			scary,
+			toggleTitle,
+			translate,
+			position,
+			children,
+			disabled,
+			disableMain,
+			disableMenu,
+			className,
+			popoverClassName,
+		} = this.props;
+		const { isMenuVisible, popoverContext } = this.state;
+		const popoverClasses = classnames( 'split-button__menu', 'popover', popoverClassName );
+		const classes = classnames( 'split-button', className, {
+			'is-menu-visible': isMenuVisible,
+			'is-disabled': disabled,
+			'has-icon-text': label && icon,
+		} );
+
+		return (
+			<span className={ classes }>
+				<Button
+					compact={ compact }
+					primary={ primary }
+					scary={ scary }
+					disabled={ disabled || disableMain }
+					className="split-button__main"
+				>
+					{ icon && <Gridicon icon={ icon } /> }
+					{ label }
+				</Button>
+				<Button
+					compact={ compact }
+					primary={ primary }
+					scary={ scary }
+					ref={ this.setPopoverContext }
+					onClick={ this.handleClick }
+					title={ toggleTitle || translate( 'Toggle menu' ) }
+					disabled={ disabled || disableMenu }
+					className="split-button__toggle"
+				>
+					<Gridicon icon="chevron-down" className="split-button__toggle-icon" />
+				</Button>
+				<PopoverMenu
+					isVisible={ isMenuVisible }
+					onClose={ this.hideMenu }
+					position={ position }
+					context={ popoverContext }
+					className={ popoverClasses }
+				>
+					{ children }
+				</PopoverMenu>
+			</span>
+		);
+	}
+}
+
+export default localize( SplitButton );

--- a/client/components/split-button/style.scss
+++ b/client/components/split-button/style.scss
@@ -1,0 +1,24 @@
+.split-button {
+	// So both buttons drop together
+	display: inline-block;
+}
+.split-button__main {
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
+	border-right: 0;
+
+	.has-icon-text & .gridicon {
+		margin-right: 4px;
+	}
+}
+.split-button__toggle {
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
+}
+.gridicon.split-button__toggle-icon {
+	transition: transform 0.2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
+
+	.split-button.is-menu-visible & {
+		transform: rotate( 180deg );
+	}
+}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -80,6 +80,7 @@ import SocialLogos from 'social-logos/example';
 import Spinner from 'components/spinner/docs/example';
 import SpinnerButton from 'components/spinner-button/docs/example';
 import SpinnerLine from 'components/spinner-line/docs/example';
+import SplitButton from 'components/split-button/docs/example';
 import Suggestions from 'components/suggestions/docs/example';
 import TextDiff from 'components/text-diff/docs/example';
 import TileGrid from 'components/tile-grid/docs/example';
@@ -137,6 +138,7 @@ class DesignAssets extends React.Component {
 					<BulkSelect readmeFilePath="bulk-select" />
 					<ButtonGroups readmeFilePath="button-group" />
 					<Buttons componentUsageStats={ componentsUsageStats.button } readmeFilePath="button" />
+					<SplitButton readmeFilePath="split-button" />
 					<Cards readmeFilePath="card" />
 					<Checklist />
 					<ClipboardButtonInput readmeFilePath="clipboard-button-input" />

--- a/client/devdocs/design/style.scss
+++ b/client/devdocs/design/style.scss
@@ -68,7 +68,8 @@
 	}
 }
 
-.docs__design-button-row .button-group .button {
+.docs__design-button-row .button-group .button,
+.docs__design-button-row .split-button__main {
 	margin-right: 0 !important;
 }
 


### PR DESCRIPTION
This PR introduces a new component SplitButton. It displays a button with a labeled main action plus a secondary, identified by a chevron, that toggles the menu's visibility

<img width="708" alt="captura de pantalla 2017-12-21 a la s 13 27 00" src="https://user-images.githubusercontent.com/1041600/34264759-a816db98-e652-11e7-9bed-59eaee2bcc29.png">

To test, build this branch and check 
http://calypso.localhost:3000/devdocs/design/split-button

This will be used to implement #20453