### PR TITLE
Comments: Update existing actions to support pagination logic

### DIFF
--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -143,19 +143,22 @@ export const requestCommentCounts = ( siteId, postId ) => ( {
  * @param {Number|String} commentId comment or comment placeholder identifier
  * @param {Object} options Action options
  * @param {Boolean} options.showSuccessNotice Announce the delete success with a notice (default: true)
+ * @param {Object} refreshCommentListQuery Forces requesting a fresh copy of a comments page with these query parameters.
  * @returns {Object} action that deletes a comment
  */
 export const deleteComment = (
 	siteId,
 	postId,
 	commentId,
-	options = { showSuccessNotice: true }
+	options = { showSuccessNotice: true },
+	refreshCommentListQuery = {}
 ) => ( {
 	type: COMMENTS_DELETE,
 	siteId,
 	postId,
 	commentId,
 	options,
+	refreshCommentListQuery,
 } );
 
 /***
@@ -178,14 +181,22 @@ export const writeComment = ( commentText, siteId, postId ) => ( {
  * @param {Number} siteId site identifier
  * @param {Number} postId post identifier
  * @param {Number} parentCommentId parent comment identifier
+ * @param {Object} refreshCommentListQuery Forces requesting a fresh copy of a comments page with these query parameters.
  * @returns {Function} a thunk that creates a comment for a given post
  */
-export const replyComment = ( commentText, siteId, postId, parentCommentId ) => ( {
+export const replyComment = (
+	commentText,
+	siteId,
+	postId,
+	parentCommentId,
+	refreshCommentListQuery = {}
+) => ( {
 	type: COMMENTS_REPLY_WRITE,
 	siteId,
 	postId,
 	parentCommentId,
 	commentText,
+	refreshCommentListQuery,
 } );
 
 /***
@@ -222,14 +233,22 @@ export const unlikeComment = ( siteId, postId, commentId ) => ( {
  * @param {Number} postId Post identifier
  * @param {Number} commentId Comment identifier
  * @param {String} status New status
+ * @param {Object} refreshCommentListQuery Forces requesting a fresh copy of a comments page with these query parameters.
  * @returns {Object} Action that changes a comment status
  */
-export const changeCommentStatus = ( siteId, postId, commentId, status ) => ( {
+export const changeCommentStatus = (
+	siteId,
+	postId,
+	commentId,
+	status,
+	refreshCommentListQuery = {}
+) => ( {
 	type: COMMENTS_CHANGE_STATUS,
 	siteId,
 	postId,
 	commentId,
 	status,
+	refreshCommentListQuery,
 } );
 
 /**

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -151,7 +151,7 @@ export const deleteComment = (
 	postId,
 	commentId,
 	options = { showSuccessNotice: true },
-	refreshCommentListQuery = {}
+	refreshCommentListQuery = null
 ) => ( {
 	type: COMMENTS_DELETE,
 	siteId,
@@ -189,7 +189,7 @@ export const replyComment = (
 	siteId,
 	postId,
 	parentCommentId,
-	refreshCommentListQuery = {}
+	refreshCommentListQuery = null
 ) => ( {
 	type: COMMENTS_REPLY_WRITE,
 	siteId,
@@ -241,7 +241,7 @@ export const changeCommentStatus = (
 	postId,
 	commentId,
 	status,
-	refreshCommentListQuery = {}
+	refreshCommentListQuery = null
 ) => ( {
 	type: COMMENTS_CHANGE_STATUS,
 	siteId,

--- a/client/state/comments/test/actions.js
+++ b/client/state/comments/test/actions.js
@@ -97,7 +97,7 @@ describe( 'actions', () => {
 				postId: POST_ID,
 				parentCommentId: 1,
 				commentText: 'comment text',
-				refreshCommentListQuery: {},
+				refreshCommentListQuery: null,
 			} );
 		} );
 	} );

--- a/client/state/comments/test/actions.js
+++ b/client/state/comments/test/actions.js
@@ -97,6 +97,7 @@ describe( 'actions', () => {
 				postId: POST_ID,
 				parentCommentId: 1,
 				commentText: 'comment text',
+				refreshCommentListQuery: {},
 			} );
 		} );
 	} );

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { get, isDate, isEmpty, startsWith, pickBy, map } from 'lodash';
+import { get, isDate, startsWith, pickBy, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -226,7 +226,7 @@ export const handleDeleteSuccess = ( { dispatch }, { options, refreshCommentList
 		);
 	}
 
-	if ( ! isEmpty( refreshCommentListQuery ) ) {
+	if ( !! refreshCommentListQuery ) {
 		dispatch( requestCommentsList( refreshCommentListQuery ) );
 	}
 };

--- a/client/state/data-layer/wpcom/comments/index.js
+++ b/client/state/data-layer/wpcom/comments/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { get, isDate, startsWith, pickBy, map } from 'lodash';
+import { get, isDate, isEmpty, startsWith, pickBy, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,6 +19,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { getSitePost } from 'state/posts/selectors';
+import { requestCommentsList } from 'state/comments/actions';
 import { getPostOldestCommentDate, getPostNewestCommentDate } from 'state/comments/selectors';
 import getSiteComment from 'state/selectors/get-site-comment';
 import { decodeEntities } from 'lib/formatting';
@@ -213,19 +214,21 @@ export const deleteComment = ( { dispatch, getState }, action ) => {
 	);
 };
 
-export const announceDeleteSuccess = ( { dispatch }, { options } ) => {
+export const handleDeleteSuccess = ( { dispatch }, { options, refreshCommentListQuery } ) => {
 	const showSuccessNotice = get( options, 'showSuccessNotice', false );
-	if ( ! showSuccessNotice ) {
-		return;
+	if ( showSuccessNotice ) {
+		dispatch(
+			successNotice( translate( 'Comment deleted permanently.' ), {
+				duration: 5000,
+				id: 'comment-notice',
+				isPersistent: true,
+			} )
+		);
 	}
 
-	dispatch(
-		successNotice( translate( 'Comment deleted permanently.' ), {
-			duration: 5000,
-			id: 'comment-notice',
-			isPersistent: true,
-		} )
-	);
+	if ( ! isEmpty( refreshCommentListQuery ) ) {
+		dispatch( requestCommentsList( refreshCommentListQuery ) );
+	}
 };
 
 export const announceDeleteFailure = ( { dispatch }, action ) => {
@@ -252,6 +255,6 @@ export const announceDeleteFailure = ( { dispatch }, action ) => {
 export default {
 	[ COMMENTS_REQUEST ]: [ dispatchRequest( fetchPostComments, addComments, announceFailure ) ],
 	[ COMMENTS_DELETE ]: [
-		dispatchRequest( deleteComment, announceDeleteSuccess, announceDeleteFailure ),
+		dispatchRequest( deleteComment, handleDeleteSuccess, announceDeleteFailure ),
 	],
 };

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { forEach, get, groupBy, isEmpty, omit } from 'lodash';
+import { forEach, get, groupBy, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -63,7 +63,7 @@ export const handleChangeCommentStatusSuccess = (
 	{ commentId, refreshCommentListQuery }
 ) => {
 	dispatch( removeNotice( `comment-notice-error-${ commentId }` ) );
-	if ( ! isEmpty( refreshCommentListQuery ) ) {
+	if ( !! refreshCommentListQuery ) {
 		dispatch( requestCommentsList( refreshCommentListQuery ) );
 	}
 };

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { forEach, get, groupBy, omit } from 'lodash';
+import { forEach, get, groupBy, isEmpty, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,6 +28,7 @@ import {
 	receiveComments,
 	receiveCommentsError as receiveCommentErrorAction,
 	requestComment as requestCommentAction,
+	requestCommentsList,
 } from 'state/comments/actions';
 import { updateCommentsQuery } from 'state/ui/comments/actions';
 import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
@@ -57,8 +58,15 @@ const changeCommentStatus = ( { dispatch, getState }, action ) => {
 	);
 };
 
-export const removeCommentStatusErrorNotice = ( { dispatch }, { commentId } ) =>
+export const handleChangeCommentStatusSuccess = (
+	{ dispatch },
+	{ commentId, refreshCommentListQuery }
+) => {
 	dispatch( removeNotice( `comment-notice-error-${ commentId }` ) );
+	if ( ! isEmpty( refreshCommentListQuery ) ) {
+		dispatch( requestCommentsList( refreshCommentListQuery ) );
+	}
+};
 
 const announceStatusChangeFailure = ( { dispatch }, action ) => {
 	const { commentId, status, previousStatus } = action;
@@ -262,7 +270,7 @@ export const fetchHandler = {
 	[ COMMENTS_CHANGE_STATUS ]: [
 		dispatchRequest(
 			changeCommentStatus,
-			removeCommentStatusErrorNotice,
+			handleChangeCommentStatusSuccess,
 			announceStatusChangeFailure
 		),
 	],

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -171,13 +171,13 @@ export const addComments = (
 	// via `fetchCommentsList` instead of `fetchCommentsTreeForSite`.
 	// @see https://github.com/Automattic/wp-calypso/pull/16997#discussion_r132161699
 	if ( 0 === comments.length ) {
+		dispatch( updateCommentsQuery( siteId, [], { page, postId, search, status } ) );
 		dispatch( {
 			type: COMMENTS_TREE_SITE_ADD,
 			siteId,
 			status,
 			tree: [],
 		} );
-		dispatch( updateCommentsQuery( siteId, [], { page, postId, search, status } ) );
 		return;
 	}
 
@@ -242,7 +242,7 @@ export const editComment = ( { dispatch, getState }, action ) => {
 };
 
 export const updateComment = ( store, action, data ) => {
-	removeCommentStatusErrorNotice( store, action );
+	store.dispatch( removeNotice( `comment-notice-error-${ action.commentId }` ) );
 	store.dispatch(
 		bypassDataLayer( {
 			...omit( action, [ 'originalComment' ] ),

--- a/client/state/data-layer/wpcom/sites/comments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/test/index.js
@@ -14,11 +14,12 @@ import {
 	announceEditFailure,
 	editComment,
 	fetchCommentsList,
+	handleChangeCommentStatusSuccess,
 	requestComment,
 	receiveCommentError,
 	receiveCommentSuccess,
 } from '../';
-import { COMMENTS_EDIT } from 'state/action-types';
+import { COMMENTS_EDIT, NOTICE_REMOVE } from 'state/action-types';
 import {
 	requestComment as requestCommentAction,
 	editComment as editCommentAction,
@@ -289,5 +290,47 @@ describe( '#announceEditFailure', () => {
 				id: `comment-notice-error-${ action.commentId }`,
 			} )
 		);
+	} );
+} );
+
+describe( '#handleChangeCommentStatusSuccess', () => {
+	test( 'should remove the error notice', () => {
+		const dispatch = spy();
+		handleChangeCommentStatusSuccess( { dispatch }, { commentId: 1234 } );
+		expect( dispatch ).to.have.been.calledOnce;
+		expect( dispatch ).to.have.been.calledWithMatch( {
+			type: NOTICE_REMOVE,
+			noticeId: 'comment-notice-error-1234',
+		} );
+	} );
+
+	test( 'should request a fresh copy of a comments page when the query object is filled', () => {
+		const dispatch = spy();
+		handleChangeCommentStatusSuccess(
+			{ dispatch },
+			{
+				commentId: 1234,
+				refreshCommentListQuery: {
+					listType: 'site',
+					number: 20,
+					page: 1,
+					siteId: 12345678,
+					status: 'all',
+					type: 'any',
+				},
+			}
+		);
+		expect( dispatch ).to.have.been.calledTwice;
+		expect( dispatch.lastCall ).to.have.been.calledWithExactly( {
+			type: 'COMMENTS_LIST_REQUEST',
+			query: {
+				listType: 'site',
+				number: 20,
+				page: 1,
+				siteId: 12345678,
+				status: 'all',
+				type: 'any',
+			},
+		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/comments/test/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/test/index.js
@@ -17,7 +17,6 @@ import {
 	requestComment,
 	receiveCommentError,
 	receiveCommentSuccess,
-	removeCommentStatusErrorNotice,
 } from '../';
 import { COMMENTS_EDIT } from 'state/action-types';
 import {
@@ -45,7 +44,7 @@ describe( '#addComments', () => {
 	test( 'should dispatch a tree initialization action for no comments', () => {
 		addComments( { dispatch }, { query }, { comments: [] } );
 
-		expect( dispatch ).to.have.been.calledOnce;
+		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch.lastCall ).to.have.been.calledWith( {
 			type: 'COMMENTS_TREE_SITE_ADD',
 			siteId: query.siteId,
@@ -59,7 +58,7 @@ describe( '#addComments', () => {
 
 		addComments( { dispatch }, { query }, { comments } );
 
-		expect( dispatch ).to.have.been.calledOnce;
+		expect( dispatch ).to.have.been.calledTwice;
 		expect( dispatch.lastCall ).to.have.been.calledWith(
 			receiveCommentsAction( {
 				siteId: query.siteId,
@@ -78,7 +77,7 @@ describe( '#addComments', () => {
 
 		addComments( { dispatch }, { query }, { comments } );
 
-		expect( dispatch ).to.have.been.calledTwice;
+		expect( dispatch ).to.have.been.calledThrice;
 
 		expect( dispatch ).to.have.been.calledWithMatch( {
 			postId: 1,
@@ -251,18 +250,6 @@ describe( '#editComment', () => {
 				}
 			)
 		);
-	} );
-} );
-
-describe( '#removeCommentStatusErrorNotice', () => {
-	let dispatch;
-
-	beforeEach( () => ( dispatch = spy() ) );
-
-	test( 'should dispatch a remove notice action', () => {
-		removeCommentStatusErrorNotice( { dispatch }, { commentId: 123 } );
-
-		expect( dispatch ).to.have.been.calledWith( removeNotice( 'comment-notice-error-123' ) );
 	} );
 } );
 

--- a/client/state/data-layer/wpcom/sites/test/utils.js
+++ b/client/state/data-layer/wpcom/sites/test/utils.js
@@ -152,6 +152,40 @@ describe( 'utility functions', () => {
 				postId: 1010,
 			} );
 		} );
+
+		test( 'should request a fresh copy of a comments page when the query object is filled', () => {
+			const dispatch = spy();
+			updatePlaceholderComment(
+				{ dispatch },
+				{
+					siteId: 12345678,
+					postId: 1234,
+					parentCommentId: null,
+					placeholderId: 'placeholder-id',
+					refreshCommentListQuery: {
+						listType: 'site',
+						number: 20,
+						page: 1,
+						siteId: 12345678,
+						status: 'all',
+						type: 'any',
+					},
+				},
+				{ ID: 1, content: 'this is the content' }
+			);
+			expect( dispatch ).to.have.callCount( 4 );
+			expect( dispatch.lastCall ).to.have.been.calledWithExactly( {
+				type: 'COMMENTS_LIST_REQUEST',
+				query: {
+					listType: 'site',
+					number: 20,
+					page: 1,
+					siteId: 12345678,
+					status: 'all',
+					type: 'any',
+				},
+			} );
+		} );
 	} );
 
 	describe( '#handleWriteCommentFailure()', () => {

--- a/client/state/data-layer/wpcom/sites/utils.js
+++ b/client/state/data-layer/wpcom/sites/utils.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -108,7 +107,7 @@ export const updatePlaceholderComment = (
 	// increment comments count
 	dispatch( { type: COMMENTS_COUNT_INCREMENT, siteId, postId } );
 
-	if ( ! isEmpty( refreshCommentListQuery ) ) {
+	if ( !! refreshCommentListQuery ) {
 		dispatch( requestCommentsList( refreshCommentListQuery ) );
 	}
 };

--- a/client/state/data-layer/wpcom/sites/utils.js
+++ b/client/state/data-layer/wpcom/sites/utils.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import {
 	COMMENTS_COUNT_INCREMENT,
 	COMMENTS_WRITE_ERROR,
 } from 'state/action-types';
+import { requestCommentsList } from 'state/comments/actions';
 import { bypassDataLayer } from 'state/data-layer/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { getSitePost } from 'state/posts/selectors';
@@ -88,7 +90,7 @@ export const dispatchNewCommentRequest = ( dispatch, action, path ) => {
  */
 export const updatePlaceholderComment = (
 	{ dispatch },
-	{ siteId, postId, parentCommentId, placeholderId },
+	{ siteId, postId, parentCommentId, placeholderId, refreshCommentListQuery },
 	comment
 ) => {
 	// remove placeholder from state
@@ -105,6 +107,10 @@ export const updatePlaceholderComment = (
 	} );
 	// increment comments count
 	dispatch( { type: COMMENTS_COUNT_INCREMENT, siteId, postId } );
+
+	if ( ! isEmpty( refreshCommentListQuery ) ) {
+		dispatch( requestCommentsList( refreshCommentListQuery ) );
+	}
 };
 
 /**


### PR DESCRIPTION
Part of #20957 refactor
Contribute to #20737
Follow #21004

Add the new `updateCommentsQuery` action to the success handler of `requestCommentsList` in order to populate `state.ui.comments.queries` that helps building the Comments Management pagination.

Furthermore, this PR adds `requestCommentsList` as a side effect in the success handler of the change status, delete, and reply actions.
To avoid getting in the way of the existing and established behaviours, this side effect is only triggered when the action contains the optional `refreshCommentListQuery` parameter.

### Follow up

The third and last part of this refactor will wire up this new logic into `CommentList` and the other Comments Management components.

## Testing instructions

Try dispatching this in the browser console (shown here the bare minimum params that is supposed to trigger when opening `/comments/all/${ siteSlug }`):
```es6
dispatch( { type: 'COMMENTS_LIST_REQUEST', query: {
	listType: 'site',
	number: 20,
	page: 1,
	siteId: state.ui.selectedSiteId,
	status: 'all',
	type: 'any'
} } )
```

and then check if the state updated accordingly:
```es6
state.ui.comments.queries
```

Query object parameters that can be changed or added to modify the state update:
- **`page`**: changes the requested page.
E.g. `state.ui.comments.queries[12345678].site.all[2]` contains the list for `/comments/all/example.org?page=2`

- **`postId`**: when added, creates a post id keyed object instead of using the site-wide `site` one.
E.g. `state.ui.comments.queries[12345678].1234.all[1]` contains the list for `/comments/all/example.org/1234`

- **`search`**: search query (search logic is not implemented yet though) that changes one of the keys of the state.
E.g. `state.ui.comments.queries[12345678].site.[all?s=test][1]` contains the list for `/comments/all/example.org?s=test`

- **`status`**: changes the status filter.
E.g. `state.ui.comments.queries[12345678].site.unapproved[1]` contains the list for `/comments/unapproved/example.org`

### Additional tests

Try dispatching a change status, a delete, and a reply actions with the new `refreshCommentListQuery` parameter and check that `state.ui.comments.queries` is updated accordingly.

Note that this state does not persist, so a reload is enough to try from scratch.

```es6
dispatch( {
	type: 'COMMENTS_CHANGE_STATUS',
	siteId: state.ui.selectedSiteId,
	postId: 1234,
	commentId: 1,
	status: 'approved',
	refreshCommentListQuery: {
		listType: 'site',
		number: 20,
		page: 1,
		siteId: state.ui.selectedSiteId,
		status: 'all',
		type: 'any'
	}
} )
```

```es6
dispatch( {
	type: 'COMMENTS_DELETE',
	siteId: state.ui.selectedSiteId,
	postId: 1234,
	commentId: 1,
	options: {},
	refreshCommentListQuery: {
		listType: 'site',
		number: 20,
		page: 1,
		siteId: state.ui.selectedSiteId,
		status: 'all',
		type: 'any'
	}
} )
```

```es6
dispatch( {
	type: 'COMMENTS_REPLY_WRITE',
	siteId: state.ui.selectedSiteId,
	postId: 1234,
	parentCommentId: 1,
	commentText: 'Lorem ipsum dolor sit amet',
	refreshCommentListQuery: {
		listType: 'site',
		number: 20,
		page: 1,
		siteId: state.ui.selectedSiteId,
		status: 'all',
		type: 'any'
	}
} )
```