### PR TITLE
Framework: Fix the schema for ui/language to allow the boolean default

### DIFF
--- a/client/state/ui/language/schema.js
+++ b/client/state/ui/language/schema.js
@@ -1,4 +1,4 @@
 /** @format */
 export const localeSlugSchema = {
-	type: 'string',
+	anyOf: [ { type: 'string' }, { type: 'boolean' } ],
 };

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -207,7 +207,12 @@ export function createReducer( initialState = null, customHandlers = {}, schema 
 					return state;
 				}
 
-				warn( 'state validation failed - check schema used for:', customHandlers );
+				warn(
+					'state validation failed - check schema used for: %o. state: %o. schema: %o',
+					customHandlers,
+					state,
+					schema
+				);
 
 				return initialState;
 			},


### PR DESCRIPTION
 Also make the json schema error reporter more useful.

To test, turn off user sympathy and load up calypso as a english user. Then reload. Prior to this patch, you would see an error in the console that state failed to validate. After this patch, there is no error. 