### PR TITLE
Invalid state tree schemas treat any value as valid

### DIFF
--- a/client/state/ui/language/reducer.js
+++ b/client/state/ui/language/reducer.js
@@ -17,7 +17,7 @@ import { localeSlugSchema } from './schema';
  *
  */
 export const localeSlug = createReducer(
-	false,
+	{ broken: true },
 	{
 		[ LOCALE_SET ]: ( state, action ) => action.localeSlug,
 	},

--- a/client/state/ui/language/schema.js
+++ b/client/state/ui/language/schema.js
@@ -1,4 +1,4 @@
 /** @format */
 export const localeSlugSchema = {
-	anyOf: [ { type: 'string' }, { enum: [ false ] } ],
+	anyOf: [ { type: 'string' }, false ],
 };


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/21020#issuecomment-353431755

This change should fail the tests introduced in that PR, but it doesn't.  This seems to be because `false` as a JSON schema accepts any value as valid.  It seems like it would be a good idea to validate the schemas we're using for state persistence.