### PR TITLE
Activity Log Item: replace ellipsis menu with split button

### DIFF
--- a/client/components/split-button/index.jsx
+++ b/client/components/split-button/index.jsx
@@ -63,13 +63,10 @@ class SplitButton extends Component {
 		this.setPopoverContext = this.setPopoverContext.bind( this );
 	}
 
-	handleClick = event => {
-		const { onClick } = this.props;
-		const { isMenuVisible } = this.state;
+	handleMainClick = event => this.props.onClick( event );
 
-		onClick( event );
-
-		if ( isMenuVisible ) {
+	handleMenuClick = () => {
+		if ( this.state.isMenuVisible ) {
 			this.hideMenu();
 		} else {
 			this.showMenu();
@@ -120,6 +117,7 @@ class SplitButton extends Component {
 					compact={ compact }
 					primary={ primary }
 					scary={ scary }
+					onClick={ this.handleMainClick }
 					disabled={ disabled || disableMain }
 					className="split-button__main"
 				>
@@ -131,7 +129,7 @@ class SplitButton extends Component {
 					primary={ primary }
 					scary={ scary }
 					ref={ this.setPopoverContext }
-					onClick={ this.handleClick }
+					onClick={ this.handleMenuClick }
 					title={ toggleTitle || translate( 'Toggle menu' ) }
 					disabled={ disabled || disableMenu }
 					className="split-button__toggle"

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -14,12 +14,10 @@ import { localize } from 'i18n-calypso';
  */
 import ActivityActor from './activity-actor';
 import ActivityIcon from './activity-icon';
-import EllipsisMenu from 'components/ellipsis-menu';
+import SplitButton from 'components/split-button';
 import FoldableCard from 'components/foldable-card';
 import FormattedBlock from 'components/notes-formatted-block';
 import PopoverMenuItem from 'components/popover/menu-item';
-
-const stopPropagation = event => event.stopPropagation();
 
 class ActivityLogItem extends Component {
 	static propTypes = {
@@ -81,7 +79,9 @@ class ActivityLogItem extends Component {
 								<FormattedBlock key={ key } content={ part } />
 							) ) }
 						</div>
-						{ activityTitle && <div className="activity-log-item__description-summary">{ activityTitle }</div> }
+						{ activityTitle && (
+							<div className="activity-log-item__description-summary">{ activityTitle }</div>
+						) }
 					</div>
 				) }
 			</div>
@@ -103,14 +103,14 @@ class ActivityLogItem extends Component {
 
 		return (
 			<div className="activity-log-item__action">
-				<EllipsisMenu onClick={ stopPropagation } position="bottom right">
-					<PopoverMenuItem
-						disabled={ disableRestore }
-						icon="history"
-						onClick={ this.handleClickRestore }
-					>
-						{ translate( 'Rewind to this point' ) }
-					</PopoverMenuItem>
+				<SplitButton
+					icon="history"
+					label={ translate( 'Rewind' ) }
+					onClick={ this.handleClickRestore }
+					disableMain={ disableRestore }
+					compact
+					primary
+				>
 					<PopoverMenuItem
 						disabled={ disableBackup }
 						icon="cloud-download"
@@ -118,7 +118,7 @@ class ActivityLogItem extends Component {
 					>
 						{ translate( 'Download backup' ) }
 					</PopoverMenuItem>
-				</EllipsisMenu>
+				</SplitButton>
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -108,8 +108,9 @@ class ActivityLogItem extends Component {
 					label={ translate( 'Rewind' ) }
 					onClick={ this.handleClickRestore }
 					disableMain={ disableRestore }
+					disabled={ disableRestore && disableBackup }
 					compact
-					primary
+					primary={ ! disableRestore }
 				>
 					<PopoverMenuItem
 						disabled={ disableBackup }

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -40,6 +40,10 @@
 
 	.foldable-card__secondary {
 		flex-grow: 0;
+
+		.foldable-card__summary-expanded {
+			margin-right: 0;
+		}
 	}
 
 	&.is-discarded {
@@ -234,5 +238,12 @@
 
 	@include breakpoint( '<960px' ) {
 		margin-top: 8px;
+	}
+}
+
+.activity-log-item__action {
+	.split-button {
+		/* 8 x 15 so split button doesn't break */
+		min-width: 128px;
 	}
 }


### PR DESCRIPTION
Fixes #20453

This PR replaces the ellipsis menu with a split button that emphasizes the Rewind action, leaving the backup download relegated to the popover menu.

<img width="244" alt="captura de pantalla 2017-12-22 a la s 15 56 57" src="https://user-images.githubusercontent.com/1041600/34309458-c4d30994-e730-11e7-933f-8bbcb2ff6620.png">

<img width="246" alt="captura de pantalla 2017-12-22 a la s 15 57 01" src="https://user-images.githubusercontent.com/1041600/34309459-c5078b9c-e730-11e7-8f12-7e93285c775d.png">

#### Restore in progress
<img width="229" alt="captura de pantalla 2017-12-22 a la s 16 18 17" src="https://user-images.githubusercontent.com/1041600/34310052-09cca872-e734-11e7-979d-b82cf845c45e.png">

#### Backup in progress
<img width="273" alt="captura de pantalla 2017-12-22 a la s 16 18 23" src="https://user-images.githubusercontent.com/1041600/34310053-09f96696-e734-11e7-8d6e-9d2ba765ff7b.png">

#### Restore and Backup in progress
<img width="209" alt="captura de pantalla 2017-12-22 a la s 18 41 28" src="https://user-images.githubusercontent.com/1041600/34313117-c9113050-e747-11e7-832e-8bc22fa3b801.png">
