### PR TITLE
Media: add container div around item spinner

### DIFF
--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -90,7 +90,11 @@ export default class extends React.Component {
 			return;
 		}
 
-		return <Spinner className="media-library__list-item-spinner" />;
+		return (
+			<div className="media-library__list-item-spinner">
+				<Spinner />
+			</div>
+		);
 	};
 
 	render() {


### PR DESCRIPTION
closes #20945 

The problem occurred because there's a `is-fallback` class which overwrites the CSS we give into the Spinner component for the actual positioning on the media library item.

I think there are probably a few solutions which lead to the same result. The one to create a wrapper div around the <Spinner /> component is imo the most safe method without possibly breaking any other integrations of this component. The positioning of the Spinner is now a bit more decoupled from the component itself.

Let me know what you think!

/cc @alisterscott 