### PR TITLE
Contact Form: Add New Years Day closure messages

### DIFF
--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -8,6 +8,8 @@ import React from 'react';
 import i18n, { localize } from 'i18n-calypso';
 
 const christmas2017ClosureStartsAt = i18n.moment( 'Sun, 24 Dec 2017 00:00:00 +0000' );
+const newYear2018NoticeStartsAt = i18n.moment( 'Fri, 29 Dec 2017 00:00:00 +0000' );
+const newYear2018ClosureStartsAt = i18n.moment( 'Sun, 31 Dec 2017 00:00:00 +0000' );
 
 /**
  * Internal dependencies
@@ -15,23 +17,45 @@ const christmas2017ClosureStartsAt = i18n.moment( 'Sun, 24 Dec 2017 00:00:00 +00
 import FormSectionHeading from 'components/forms/form-section-heading';
 
 const HelpContactClosed = ( { translate } ) => {
+	const currentDate = i18n.moment();
+	let closureHeading;
+	let closureMessage;
+
+	if ( currentDate >= newYear2018ClosureStartsAt ) {
+		closureHeading = translate( "Limited Support New Year's Day" );
+		closureMessage = translate(
+			"Live chat is closed today for the New Year's Day holiday. If you need to get in touch with us, " +
+				'you can submit a support request below and we will get to it as fast as we can. Live chat will ' +
+				'reopen on January 2nd. Thank you!'
+		);
+	} else if ( currentDate >= newYear2018NoticeStartsAt ) {
+		closureHeading = translate( "Limited Support New Year's Day" );
+		closureMessage = translate(
+			"Live chat will be closed on Monday, January 1, 2018 for the New Year's Day holiday. If you need " +
+				'to get in touch with us, you’ll be able to submit a support request from this page and we will ' +
+				'get to it as fast as we can. Live chat will reopen on January 2nd. Thank you!'
+		);
+	} else if ( currentDate >= christmas2017ClosureStartsAt ) {
+		closureHeading = translate( 'Limited Support over Christmas' );
+		closureMessage = translate(
+			'Live chat is closed today for the Christmas holiday. If you need to get in touch with us, ' +
+				'you can submit a support request below and we will get to it as fast as we can. Live chat will ' +
+				'reopen on December 26. Thank you!'
+		);
+	} else {
+		closureHeading = translate( 'Limited Support over Christmas' );
+		closureMessage = translate(
+			'Live chat will be closed on Sunday, December 24th and Monday, December 25th for the Christmas holiday. ' +
+				'If you need to get in touch with us, you’ll be able to submit a support request from this page and ' +
+				'we will get to it as fast as we can. Live chat will reopen on December 26th. Thank you!'
+		);
+	}
+
 	return (
 		<div className="help-contact-closed">
-			<FormSectionHeading>{ translate( 'Limited Support over Christmas' ) }</FormSectionHeading>
+			<FormSectionHeading>{ closureHeading }</FormSectionHeading>
 			<div>
-				<p>
-					{ i18n.moment() < christmas2017ClosureStartsAt
-						? translate(
-								'Live chat will be closed on Sunday, December 24th and Monday, December 25th for the Christmas holiday. ' +
-									'If you need to get in touch with us, you’ll be able to submit a support request from this page and ' +
-									'we will get to it as fast as we can. Live chat will reopen on December 26th. Thank you!'
-							)
-						: translate(
-								'Live chat is closed today for the Christmas holiday. If you need to get in touch with us, ' +
-									'you can submit a support request below and we will get to it as fast as we can. Live chat will ' +
-									'reopen on December 26. Thank you!'
-							) }
-				</p>
+				<p>{ closureMessage }</p>
 			</div>
 			<hr />
 		</div>

--- a/client/me/help/help-contact-closed/index.jsx
+++ b/client/me/help/help-contact-closed/index.jsx
@@ -24,30 +24,28 @@ const HelpContactClosed = ( { translate } ) => {
 	if ( currentDate >= newYear2018ClosureStartsAt ) {
 		closureHeading = translate( "Limited Support New Year's Day" );
 		closureMessage = translate(
-			"Live chat is closed today for the New Year's Day holiday. If you need to get in touch with us, " +
-				'you can submit a support request below and we will get to it as fast as we can. Live chat will ' +
-				'reopen on January 2nd. Thank you!'
+			"Live chat is closed today for the New Year's Day holiday. If you need to get in touch with us, submit " +
+				"a support request below and we'll respond by email. Live chat will reopen on January 2nd. Thank you!"
 		);
 	} else if ( currentDate >= newYear2018NoticeStartsAt ) {
 		closureHeading = translate( "Limited Support New Year's Day" );
 		closureMessage = translate(
 			"Live chat will be closed on Monday, January 1, 2018 for the New Year's Day holiday. If you need " +
-				'to get in touch with us, you’ll be able to submit a support request from this page and we will ' +
-				'get to it as fast as we can. Live chat will reopen on January 2nd. Thank you!'
+				"to get in touch with us, you’ll be able to submit a support request from this page and we'll " +
+				'respond by email. Live chat will reopen on January 2nd. Thank you!'
 		);
 	} else if ( currentDate >= christmas2017ClosureStartsAt ) {
 		closureHeading = translate( 'Limited Support over Christmas' );
 		closureMessage = translate(
-			'Live chat is closed today for the Christmas holiday. If you need to get in touch with us, ' +
-				'you can submit a support request below and we will get to it as fast as we can. Live chat will ' +
-				'reopen on December 26. Thank you!'
+			'Live chat is closed today for the Christmas holiday. If you need to get in touch with us, submit ' +
+				"a support request below and we'll respond by email. Live chat will reopen on December 26. Thank you!"
 		);
 	} else {
 		closureHeading = translate( 'Limited Support over Christmas' );
 		closureMessage = translate(
 			'Live chat will be closed on Sunday, December 24th and Monday, December 25th for the Christmas holiday. ' +
 				'If you need to get in touch with us, you’ll be able to submit a support request from this page and ' +
-				'we will get to it as fast as we can. Live chat will reopen on December 26th. Thank you!'
+				"we'll respond by email. Live chat will reopen on December 26th. Thank you!"
 		);
 	}
 

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -78,6 +78,8 @@ const SUPPORT_FORUM = 'SUPPORT_FORUM';
 
 const startShowingChristmas2017ClosureNoticeAt = i18n.moment( 'Sun, 17 Dec 2017 00:00:00 +0000' );
 const stopShowingChristmas2017ClosureNoticeAt = i18n.moment( 'Tue, 26 Dec 2017 00:00:00 +0000' );
+const startShowingNewYear2018ClosureNoticeAt = i18n.moment( 'Fri, 29 Dec 2017 00:00:00 +0000' );
+const stopShowingNewYear2018ClosureNoticeAt = i18n.moment( 'Tue, 2 Jan 2018 00:00:00 +0000' );
 
 class HelpContact extends React.Component {
 	state = {
@@ -681,16 +683,24 @@ class HelpContact extends React.Component {
 			this.getContactFormPropsVariation( supportVariation )
 		);
 
-		const currentDate = Date.now();
+		const currentDate = i18n.moment();
 
 		// Customers sent to Directly and Forum are not affected by the Christmas closures
 		const isUserAffectedByChristmas2017Closure =
 			supportVariation !== SUPPORT_DIRECTLY && supportVariation !== SUPPORT_FORUM;
 
+		const isClosureNoticeAvailable =
+			currentDate.isBetween(
+				startShowingChristmas2017ClosureNoticeAt,
+				stopShowingChristmas2017ClosureNoticeAt
+			) ||
+			currentDate.isBetween(
+				startShowingNewYear2018ClosureNoticeAt,
+				stopShowingNewYear2018ClosureNoticeAt
+			);
+
 		const shouldShowClosureNotice =
-			isUserAffectedByChristmas2017Closure &&
-			currentDate > startShowingChristmas2017ClosureNoticeAt &&
-			currentDate < stopShowingChristmas2017ClosureNoticeAt;
+			isUserAffectedByChristmas2017Closure && isClosureNoticeAvailable;
 
 		return (
 			<div>

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -689,7 +689,7 @@ class HelpContact extends React.Component {
 		const isUserAffectedByChristmas2017Closure =
 			supportVariation !== SUPPORT_DIRECTLY && supportVariation !== SUPPORT_FORUM;
 
-		const isClosureNoticeAvailable =
+		const isClosureNoticeInEffect =
 			currentDate.isBetween(
 				startShowingChristmas2017ClosureNoticeAt,
 				stopShowingChristmas2017ClosureNoticeAt
@@ -699,8 +699,7 @@ class HelpContact extends React.Component {
 				stopShowingNewYear2018ClosureNoticeAt
 			);
 
-		const shouldShowClosureNotice =
-			isUserAffectedByChristmas2017Closure && isClosureNoticeAvailable;
+		const shouldShowClosureNotice = isUserAffectedByChristmas2017Closure && isClosureNoticeInEffect;
 
 		return (
 			<div>


### PR DESCRIPTION
Adds a banner to the top of the Contact Us form if you're eligible for live chat, noting that live chat will be closed on January 1, 2018.

Ref 515-gh-hg

### To test

Fake the current date by modifying **both lines** that say `const currentDate = i18n.moment();`. Set to the following and you should get the described result:

- `const currentDate = i18n.moment();`  
  You should see the current pre-Christmas notice
- `const currentDate = i18n.moment( '2017-12-25 12:00:00' );`  
  You should see the Christmas Day notice
- `const currentDate = i18n.moment( '2017-12-26 12:00:00' );`  
  The notice should be gone
- `const currentDate = i18n.moment( '2017-12-30 12:00:00' );`  
  You should see the pre-New Year's notice
- `const currentDate = i18n.moment( '2018-01-01 12:00:00' );`  
  You should see the New Year's Day notice
- `const currentDate = i18n.moment( '2018-01-02 12:00:00' );`  
  The notice should be gone
