### PR TITLE
Add more steps to avatar tour

### DIFF
--- a/client/layout/guided-tours/tours/checklist-user-avatar-tour.js
+++ b/client/layout/guided-tours/tours/checklist-user-avatar-tour.js
@@ -16,6 +16,7 @@ import {
 	ButtonRow,
 	Continue,
 	makeTour,
+	Next,
 	SiteLink,
 	Step,
 	Tour,
@@ -39,11 +40,25 @@ export const ChecklistUserAvatarTour = makeTour(
 				) }
 			</p>
 			<ButtonRow>
-				<Continue target="edit-gravatar" step="finish" click hidden />
+				<Continue target="edit-gravatar" step="image-notice" click hidden />
 				<SiteLink isButton={ false } href="/checklist/:site">
 					{ translate( 'Return to the checklist' ) }
 				</SiteLink>
 			</ButtonRow>
+		</Step>
+
+		<Step name="image-notice" placement="right">
+			<p>{ translate( "Let's make sure it looks right before we proceed." ) }</p>
+			<Next step="crop-image">{ translate( 'Looks good, continue' ) }</Next>
+		</Step>
+
+		<Step name="crop-image" placement="right">
+			<p>
+				{ translate( 'Alright! Press {{b}}Change My Photo{{/b}} to save your changes.', {
+					components: { b: <strong /> },
+				} ) }
+			</p>
+			<Continue target="image-editor-button-done" step="finish" click hidden />
 		</Step>
 
 		<Step name="finish" placement="right">


### PR DESCRIPTION
There are some issue with the Guided Tours picking up the `image-editor-button-done` target before it loads on the screen. This PR introduces a work around that adds a couple steps to walk people through the avatar updating process. 

## Before
![avatar-master](https://user-images.githubusercontent.com/6981253/34285375-5ef04396-e6a7-11e7-8716-d34fd01d7af2.gif)

## After
![avatar](https://user-images.githubusercontent.com/6981253/34285341-14f9a2e6-e6a7-11e7-8437-74b83fdd777c.gif)

## Testing
* Start a new site and visit `/checklist/url`
* Complete the profile picture task

@markryall can you take a look?

cc @lsinger if you have any ideas on how to capture the event on `image-editor-button-done`