### PR TITLE
Fix completed task coloor

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -218,9 +218,11 @@
 			}
 		}
 
-		.checklist__task-title {
+		.checklist__task-title,
+		.checklist__task-title-link {
 			color: $gray;
 			font-size: 14px;
+			cursor: default;
 		}
 
 		.gridicons-checkmark {


### PR DESCRIPTION
I suspect this PR https://github.com/Automattic/wp-calypso/pull/20764 unintentionally changed the colour of the completed task and made it look like it was clickable. This PR fixes it.

## Before
![image](https://user-images.githubusercontent.com/6981253/34286072-55c61962-e6ac-11e7-8d3d-ccafabb105f0.png)

## After
![image](https://user-images.githubusercontent.com/6981253/34286040-32e305ea-e6ac-11e7-915d-7f382a156d9f.png)

cc @markryall @taggon 