### PR TITLE
Enable checklist on wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -92,7 +92,7 @@
 		"nps-survey/dev-trigger": true,
 		"nps-survey/notice": true,
 		"olark": true,
-		"onboarding-checklist": false,
+		"onboarding-checklist": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
The onboarding checklist is currently disabled in all environments except development.

This config change allows us to get feedback on the checklist prior to launch