### PR TITLE
Checkout: Credit card payment validation is too verbose for empty fieldsInitial commit

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -93,24 +93,8 @@ class CreditCardForm extends Component {
 	validate = ( formValues, onComplete ) =>
 		this.formElem && onComplete( null, this.getValidationErrors() );
 
-	setFormState = form => {
-		if ( ! this.formElem ) {
-			return;
-		}
-
-		const messages = formState.getErrorMessages( form );
-		const notice =
-			messages.length > 0 ? notices.error( <ValidationErrorList messages={ messages } /> ) : null;
-
-		if ( ! notice && this.state.notice ) {
-			notices.removeNotice( this.state.notice );
-		}
-
-		this.setState( {
-			form,
-			notice,
-		} );
-	};
+	setFormState = form =>
+		this.formElem && this.setState( { form } );
 
 	endFormSubmitting = () => this.formElem && this.setState( { formSubmitting: false } );
 
@@ -122,6 +106,10 @@ class CreditCardForm extends Component {
 				value,
 			} );
 		} );
+	};
+
+	getErrorMessage = fieldName => {
+		return formState.getFieldErrorMessages( this.state.form, fieldName );
 	};
 
 	onSubmit = event => {
@@ -254,8 +242,8 @@ class CreditCardForm extends Component {
 						card={ this.getCardDetails() }
 						countriesList={ countriesList }
 						eventFormName="Edit Card Details Form"
-						isFieldInvalid={ this.isFieldInvalid }
 						onFieldChange={ this.onFieldChange }
+						getErrorMessage={ this.getErrorMessage }
 					/>
 					<div className="credit-card-form__card-terms">
 						<Gridicon icon="info-outline" size={ 18 } />

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -93,8 +93,7 @@ class CreditCardForm extends Component {
 	validate = ( formValues, onComplete ) =>
 		this.formElem && onComplete( null, this.getValidationErrors() );
 
-	setFormState = form =>
-		this.formElem && this.setState( { form } );
+	setFormState = form => this.formElem && this.setState( { form } );
 
 	endFormSubmitting = () => this.formElem && this.setState( { formSubmitting: false } );
 
@@ -108,9 +107,7 @@ class CreditCardForm extends Component {
 		} );
 	};
 
-	getErrorMessage = fieldName => {
-		return formState.getFieldErrorMessages( this.state.form, fieldName );
-	};
+	getErrorMessage = fieldName => formState.getFieldErrorMessages( this.state.form, fieldName );
 
 	onSubmit = event => {
 		event.preventDefault();
@@ -214,8 +211,6 @@ class CreditCardForm extends Component {
 			cardToken,
 		};
 	}
-
-	isFieldInvalid = name => formState.isFieldInvalid( this.state.form, name );
 
 	getValidationErrors() {
 		const validationResult = validateCardDetails( this.getCardDetails() );

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { assign, isEmpty, isEqual } from 'lodash';
+import { isEmpty, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,10 +23,15 @@ export class CreditCardFormFields extends React.Component {
 	static propTypes = {
 		card: PropTypes.object.isRequired,
 		countriesList: PropTypes.object.isRequired,
-		eventFormName: PropTypes.string.isRequired,
-		isFieldInvalid: PropTypes.func.isRequired,
-		onFieldChange: PropTypes.func.isRequired
-		getErrorMessage: PropTypes.func.isRequired,
+		eventFormName: PropTypes.string,
+		onFieldChange: PropTypes.func,
+		getErrorMessage: PropTypes.func,
+	};
+
+	static defaultProps = {
+		eventFormName: 'Credit card input',
+		onFieldChange: noop,
+		getErrorMessage: noop,
 	};
 
 	constructor( props ) {
@@ -37,15 +42,8 @@ export class CreditCardFormFields extends React.Component {
 		};
 	}
 
-	shouldComponentUpdate( nextProps ) {
-		if ( ! isEqual( nextProps.card, this.props.card ) ) {
-			return true;
-		}
-		return false;
-	}
-
 	createField = ( fieldName, componentClass, props ) => {
-		const errorMessage = ( this.props.getErrorMessage( fieldName ) || [] );
+		const errorMessage = this.props.getErrorMessage( fieldName ) || [];
 		return React.createElement(
 			componentClass,
 			Object.assign(

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import isEqual from 'lodash/isEqual';
+import { assign, isEmpty, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,7 +25,8 @@ export class CreditCardFormFields extends React.Component {
 		countriesList: PropTypes.object.isRequired,
 		eventFormName: PropTypes.string.isRequired,
 		isFieldInvalid: PropTypes.func.isRequired,
-		onFieldChange: PropTypes.func.isRequired,
+		onFieldChange: PropTypes.func.isRequired
+		getErrorMessage: PropTypes.func.isRequired,
 	};
 
 	constructor( props ) {
@@ -44,6 +45,7 @@ export class CreditCardFormFields extends React.Component {
 	}
 
 	createField = ( fieldName, componentClass, props ) => {
+		const errorMessage = ( this.props.getErrorMessage( fieldName ) || [] );
 		return React.createElement(
 			componentClass,
 			Object.assign(
@@ -51,10 +53,12 @@ export class CreditCardFormFields extends React.Component {
 				{
 					additionalClasses: 'credit-card-form-fields__field',
 					eventFormName: this.props.eventFormName,
-					isError: this.props.isFieldInvalid( fieldName ),
+					isError: ! isEmpty( errorMessage ),
+					errorMessage: errorMessage[ 0 ],
 					name: fieldName,
+					onBlur: this.handleFieldChange,
 					onChange: this.handleFieldChange,
-					value: this.getFieldValue( fieldName ) || '',
+					value: this.getFieldValue( fieldName ),
 					autoComplete: 'off',
 				},
 				props

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -64,9 +64,7 @@ export class CreditCardFormFields extends React.Component {
 		);
 	};
 
-	getFieldValue = fieldName => {
-		return this.props.card[ fieldName ] || '';
-	};
+	getFieldValue = fieldName => this.props.card[ fieldName ] || '';
 
 	updateFieldValues( fieldName, nextValue ) {
 		const { onFieldChange } = this.props;

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -121,7 +121,7 @@ validators.required = {
 	},
 
 	error: function( description ) {
-		return i18n.translate( '%(description)s is a required field', {
+		return i18n.translate( 'Missing required %(description)s field', {
 			args: { description: description },
 		} );
 	},

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -121,7 +121,7 @@ validators.required = {
 	},
 
 	error: function( description ) {
-		return i18n.translate( 'Missing required %(description)s field', {
+		return i18n.translate( '%(description)s is a required field', {
 			args: { description: description },
 		} );
 	},

--- a/client/my-sites/checkout/checkout/new-card-form.jsx
+++ b/client/my-sites/checkout/checkout/new-card-form.jsx
@@ -14,6 +14,7 @@ import classNames from 'classnames';
  */
 import CreditCardFormFields from 'components/credit-card-form-fields';
 import { setNewCreditCardDetails } from 'lib/upgrades/actions';
+import { INPUT_VALIDATION } from 'lib/store-transactions/step-types';
 
 class NewCardForm extends Component {
 	static displayName = 'NewCardForm';
@@ -24,8 +25,9 @@ class NewCardForm extends Component {
 		transaction: PropTypes.object.isRequired,
 	};
 
-	isFieldInvalid = fieldName => {
-		return ! isEmpty( this.props.transaction.errors[ fieldName ] );
+	getErrorMessage = fieldName => {
+		const { transaction } = this.props;
+		return transaction.step.name === INPUT_VALIDATION && transaction.errors[ fieldName ];
 	};
 
 	render() {
@@ -52,8 +54,8 @@ class NewCardForm extends Component {
 						card={ this.props.transaction.newCardFormFields }
 						countriesList={ this.props.countriesList }
 						eventFormName="Checkout Form"
-						isFieldInvalid={ this.isFieldInvalid }
 						onFieldChange={ this.handleFieldChange }
+						getErrorMessage={ this.getErrorMessage }
 					/>
 				</div>
 			</div>

--- a/client/my-sites/checkout/checkout/new-card-form.jsx
+++ b/client/my-sites/checkout/checkout/new-card-form.jsx
@@ -1,5 +1,4 @@
 /** @format */
-import { isEmpty } from 'lodash';
 
 /**
  * External dependencies
@@ -31,28 +30,29 @@ class NewCardForm extends Component {
 	};
 
 	render() {
+		const { countriesList, hasStoredCards, translate, transaction } = this.props;
 		const classes = classNames( 'all-fields-required', {
 			'has-saved-cards': this.props.hasStoredCards,
 		} );
 
 		return (
-			<div className="new-card">
-				<button type="button" className="new-card-toggle">
-					{ this.props.translate( '+ Use a New Credit/Debit Card' ) }
+			<div className="checkout__new-card">
+				<button type="button" className="checkout__new-card-toggle">
+					{ translate( '+ Use a New Credit/Debit Card' ) }
 				</button>
 
-				<div className="new-card-fields">
-					{ this.props.hasStoredCards ? (
+				<div className="checkout__new-card-fields">
+					{ hasStoredCards ? (
 						<h6 className="checkout__new-card-header">
-							{ this.props.translate( 'Use New Credit/Debit Card' ) }:
+							{ translate( 'Use New Credit/Debit Card' ) }:
 						</h6>
 					) : null }
 
-					<span className={ classes }>{ this.props.translate( 'All fields required' ) }</span>
+					<span className={ classes }>{ translate( 'All fields required' ) }</span>
 
 					<CreditCardFormFields
-						card={ this.props.transaction.newCardFormFields }
-						countriesList={ this.props.countriesList }
+						card={ transaction.newCardFormFields }
+						countriesList={ countriesList }
 						eventFormName="Checkout Form"
 						onFieldChange={ this.handleFieldChange }
 						getErrorMessage={ this.getErrorMessage }

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -324,23 +324,23 @@
 			.payment-box-section-inner {
 				border-left: 3px solid $alert-green;
 			}
-			.new-card-fields {
+			.checkout__new-card-fields {
 				background-color: #fafdf6;
 			}
 		}
 
-		.no-stored-cards .new-card-fields > .checkout-field:first-child {
+		.no-stored-cards .checkout__new-card-fields > .checkout-field:first-child {
 			margin-top: 0;
 		}
 
-		.payment-box-section .new-card-toggle {
+		.payment-box-section .checkout__new-card-toggle {
 			box-shadow: none;
 			cursor: pointer;
 			font-size: 13px;
 			position: absolute;
 		}
 
-		.payment-box-section .new-card-fields {
+		.payment-box-section .checkout__new-card-fields {
 			background-color: $white;
 			max-height: 0;
 			overflow: hidden;
@@ -349,13 +349,13 @@
 			transition: all 500ms ease-in-out;
 		}
 
-		.payment-box-section.selected .new-card-fields {
+		.payment-box-section.selected .checkout__new-card-fields {
 			max-height: 100%;
 			margin-bottom: 0;
 			padding-top: 15px;
 		}
 
-		.new-card-toggle {
+		.checkout__new-card-toggle {
 			color: $blue-wordpress;
 			padding: 15px 15px 15px 12px;
 			border: 0;

--- a/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
@@ -49,8 +49,6 @@ const TransactionStepsMixin = {
 
 	_displayNotices: function( cart, step ) {
 		if ( step.error ) {
-			// eslint-disable-next-line
-			console.log( 'step.error', step, typeof step.error, typeof step.error.message  );
 			step.name !== INPUT_VALIDATION && displayError( step.error );
 			return;
 		}

--- a/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
@@ -18,6 +18,7 @@ import { cartItems } from 'lib/cart-values';
 import { displayError, clear } from 'lib/upgrades/notices';
 import { submitTransaction } from 'lib/upgrades/actions';
 import { removeNestedProperties } from 'lib/cart/store/cart-analytics';
+import { INPUT_VALIDATION } from 'lib/store-transactions/step-types';
 
 const TransactionStepsMixin = {
 	submitTransaction: function( event ) {
@@ -48,7 +49,9 @@ const TransactionStepsMixin = {
 
 	_displayNotices: function( cart, step ) {
 		if ( step.error ) {
-			displayError( step.error );
+			// eslint-disable-next-line
+			console.log( 'step.error', step, typeof step.error, typeof step.error.message  );
+			step.name !== INPUT_VALIDATION && displayError( step.error );
 			return;
 		}
 


### PR DESCRIPTION
## What is PR does

This PR addresses #19747, by moving form validation errors inline from the `notice` overlay.

<img width="770" alt="screen shot 2017-12-27 at 4 02 33 pm" src="https://user-images.githubusercontent.com/6458278/34371220-67e885b8-eb1f-11e7-88f2-11263a216868.png">

Any errors from the server will still display in the `notice` overlay.

<img width="834" alt="screen shot 2017-12-27 at 4 05 18 pm" src="https://user-images.githubusercontent.com/6458278/34371256-c8346b8a-eb1f-11e7-9604-7e0c5776fc3c.png">

## What is PR doesn't do
React complains when we attempt to change an "uncontrolled input of type text to be controlled".

<img width="1564" alt="screen shot 2017-12-27 at 3 16 12 pm" src="https://user-images.githubusercontent.com/6458278/34370565-2b3ee6b2-eb19-11e7-810a-485ed7509c1f.png">

This PR doesn't address this existing warning, but, as noted in __Possible areas for further improvement__, there's the possibility of adding a `formState` controller.

## Testing

1. Add a plan to your and visit checkout: http://calypso.localhost:3000/checkout/{domain.com}
2. Submit the credit card form with invalid values
3. Submit with an invalid credit card
4. Submit with valid (or sandbox-friendly) credit card details

Visit http://calypso.localhost:3000/me/purchases/add-credit-card at repeat steps 2-4.

### Expectations
1. *At 2*: individual field errors should appear inline
2. *At 3*: individual field errors should disappear after submit, and a notice error will appear
3. *At 4*: purchase/add card should be successful

## Possible areas for further improvement
- [ ] use `formState` to control the fields in `client/my-sites/checkout/checkout/new-card-form.jsx`, allowing us to remove input field errors onChange and onBlur instead of onSubmit 
- [ ] highlighting of fields after server validation message, for example, if a cc is declined and the overlay notice appears, we mark the cc fields as invalid
- [ ] update i18n error labels, e.g., __Missing required Credit Card Expiration Date field__. Could `'Missing required %(description)s field'` be improved?
