### PR TITLE
Jetpack Onboarding: Make contact form step create a form

### DIFF
--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -17,14 +17,21 @@ import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingContactFormStep extends React.PureComponent {
-	clickAddContactForm = () => {
+	handleAddContactForm = () => {
+		const { siteId } = this.props;
+
 		this.props.recordTracksEvent( 'calypso_jpo_contact_form_clicked' );
+
+		this.props.saveJetpackOnboardingSettings( siteId, {
+			addContactForm: true,
+		} );
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { getForwardUrl, translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'Would you like to get started with a Contact Us page?' );
 
@@ -45,7 +52,8 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 							'Not sure? You can skip this step and add a contact form later.'
 						) }
 						image={ '/calypso/images/illustrations/contact-us.svg' }
-						onClick={ this.clickAddContactForm }
+						onClick={ this.handleAddContactForm }
+						href={ getForwardUrl() }
 					/>
 				</TileGrid>
 			</div>
@@ -53,6 +61,6 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 	}
 }
 
-export default connect( null, { recordTracksEvent } )(
+export default connect( null, { recordTracksEvent, saveJetpackOnboardingSettings } )(
 	localize( JetpackOnboardingContactFormStep )
 );


### PR DESCRIPTION
This PR updates the contact form to actually insert a contact form when clicking the corresponding tile.

To test:
1. Checkout this branch on your local Calypso.
1. Make sure your JP sandbox is running ~~https://github.com/Automattic/jetpack/pull/8409~~ the latest master.
1. Make sure your JP sandbox has Jetpack development mode on - `define('JETPACK_DEV_DEBUG', true);` in `wp-config.php`.
1. Deactivate your Contact Form module (`wp jetpack module deactivate contact-form` if you use WP CLI).
1. Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
1. After you land the JPO flow, skip to the Contact Form step.
1. Click the "Add a contact form" tile.
1. Verify a "Contact us" page is created with a contact form in it.
1. Delete the contact form page that we just created.
1. Make sure the contact form module is enabled (`wp jetpack module list` in WP CLI to check)
1. Repeat steps 4-7 again.

  
  