### PR TITLE
Jetpack Onboarding: Add disclaimer to first step

### DIFF
--- a/client/jetpack-onboarding/disclaimer.jsx
+++ b/client/jetpack-onboarding/disclaimer.jsx
@@ -6,8 +6,14 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'gridicons';
+
 const JetpackOnboardingDisclaimer = ( { translate } ) => (
 	<p className="jetpack-onboarding__disclaimer">
+		<Gridicon icon="info-outline" size={ 18 } />
 		{ translate(
 			'By continuing, you agree to our {{link}}fascinating terms and conditions{{/link}}.',
 			{

--- a/client/jetpack-onboarding/disclaimer.jsx
+++ b/client/jetpack-onboarding/disclaimer.jsx
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+const JetpackOnboardingDisclaimer = ( { translate } ) => (
+	<p className="jetpack-onboarding__disclaimer">
+		{ translate(
+			'By continuing, you agree to our {{link}}fascinating terms and conditions{{/link}}.',
+			{
+				components: {
+					link: <a href="//wordpress.com/tos/" target="_blank" rel="noopener noreferrer" />,
+				},
+			}
+		) }
+	</p>
+);
+
+export default localize( JetpackOnboardingDisclaimer );

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -18,6 +18,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
+import JetpackOnboardingDisclaimer from '../disclaimer';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
@@ -86,6 +87,8 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 						</Button>
 					</form>
 				</Card>
+
+				<JetpackOnboardingDisclaimer />
 			</div>
 		);
 	}

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -69,3 +69,8 @@
 		}
 	}
 }
+
+.jetpack-onboarding__disclaimer {
+	text-align: center;
+	font-size: 12px;
+}

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -73,4 +73,10 @@
 .jetpack-onboarding__disclaimer {
 	text-align: center;
 	font-size: 12px;
+
+	.gridicon {
+		position: relative;
+		top: 4px;
+		margin-right: 12px;
+	}
 }

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -18,14 +18,14 @@
 	}
 
 	.steps__summary-columns {
-	display: flex;
-	justify-content: center;
-	font-size: 14px;
-	margin-top: 30px;
+		display: flex;
+		justify-content: center;
+		font-size: 14px;
+		margin-top: 30px;
 
-	@include breakpoint( '<480px' ) {
-		display: block;
-		text-align: center;
+		@include breakpoint( '<480px' ) {
+			display: block;
+			text-align: center;
 		}
 	}
 


### PR DESCRIPTION
This PR adds a disclaimer to the first step of the flow (site title), letting the users know that with using JPO they agree to our terms and conditions:

![](https://cldup.com/A8eOvcD2FM.png)

Fixes #20985.

To test:
* Checkout this branch.
* Go to http://calypso.localhost:3000/jetpack/onboarding/site-title/test
* Verify the copy looks as on the screenshot and link leads to the ToS page of WP.com (in a new window).

cc @Automattic/editorial for copy review and @MichaelArestad for design review