### PR TITLE
Set up an A/B test for G Suite upsell (V2)

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -82,15 +82,6 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	gsuiteUpsell: {
-		datestamp: '20171025',
-		variations: {
-			show: 0,
-			hide: 100,
-		},
-		defaultVariation: 'hide',
-		allowExistingUsers: true,
-	},
 	signupSiteSegmentStep: {
 		datestamp: '20170329',
 		variations: {
@@ -115,6 +106,15 @@ export default {
 			hide: 50,
 		},
 		defaultVariation: 'hide',
+		allowExistingUsers: true,
+	},
+	gsuiteUpsellV2: {
+		datestamp: '20171225',
+		variations: {
+			original: 50,
+			modified: 50,
+		},
+		defaultVariation: 'original',
 		allowExistingUsers: true,
 	},
 };

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -16,7 +16,11 @@ import { get } from 'lodash';
 import DocumentHead from 'components/data/document-head';
 import GoogleAppsDialog from 'components/upgrades/google-apps/google-apps-dialog';
 import Main from 'components/main';
-import { getSite } from 'state/sites/selectors';
+import QuerySites from 'components/data/query-sites';
+import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
+import upgradesActions from 'lib/upgrades/actions';
+import { cartItems } from 'lib/cart-values';
+import { isDotComPlan } from 'lib/products-values';
 
 export class GsuiteNudge extends React.Component {
 	static propTypes = {
@@ -27,15 +31,34 @@ export class GsuiteNudge extends React.Component {
 	};
 
 	handleClickSkip = () => {
-		this.props.onClickSkip( this.props.siteSlug );
+		const { siteSlug, receiptId } = this.props;
+
+		page( `/checkout/thank-you/${ siteSlug }/${ receiptId }` );
 	};
 
 	handleAddGoogleApps = googleAppsCartItem => {
-		this.props.onAddGoogleApps( googleAppsCartItem, this.props.siteSlug );
+		const { siteSlug, receiptId } = this.props;
+
+		googleAppsCartItem.extra = {
+			...googleAppsCartItem.extra,
+			receipt_for_domain: receiptId,
+		};
+
+		this.removePlanFromCart();
+
+		upgradesActions.addItem( googleAppsCartItem );
+		page( `/checkout/${ siteSlug }` );
 	};
 
+	removePlanFromCart() {
+		const items = cartItems.getAll( this.props.cart );
+		items.filter( isDotComPlan ).forEach( function( item ) {
+			upgradesActions.removeItem( item, false );
+		} );
+	}
+
 	render() {
-		const { siteTitle, translate } = this.props;
+		const { selectedSiteId, siteTitle, translate } = this.props;
 
 		return (
 			<Main className="gsuite-nudge">
@@ -44,6 +67,7 @@ export class GsuiteNudge extends React.Component {
 						args: { siteTitle },
 					} ) }
 				/>
+				<QuerySites siteId={ selectedSiteId } />
 				<GoogleAppsDialog
 					domain={ this.props.domain }
 					productsList={ this.props.productsList }
@@ -56,9 +80,8 @@ export class GsuiteNudge extends React.Component {
 }
 
 export default connect( ( state, props ) => {
-	const selectedSite = getSite( state, props.selectedSiteId );
 	return {
-		siteSlug: get( selectedSite, 'slug', '' ),
-		siteTitle: get( selectedSite, 'name', '' ),
+		siteSlug: getSiteSlug( state, props.selectedSiteId ),
+		siteTitle: getSiteTitle( state, props.selectedSiteId ),
 	};
 } )( localize( GsuiteNudge ) );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -20,6 +20,7 @@ import {
 	startsWith,
 } from 'lodash';
 import i18n from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -1084,3 +1085,22 @@ export const siteSupportsGoogleAnalyticsBasicEcommerceTracking = ( state, siteId
 export const siteSupportsGoogleAnalyticsEnhancedEcommerceTracking = ( state, siteId ) => {
 	return isJetpackMinimumVersion( state, siteId, '5.6-beta2' );
 };
+
+/**
+ * Returns true if the site is created less than 30 mins ago.
+ * False otherwise.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {Boolean}        Whether site is newly created.
+ */
+export function isNewSite( state, siteId ) {
+	const createdAt = getSiteOption( state, siteId, 'created_at' );
+
+	if ( ! createdAt ) {
+		return false;
+	}
+
+	// less than 30 minutes
+	return moment().diff( createdAt, 'minutes' ) < 30;
+}


### PR DESCRIPTION
Since the first G Suite upsell includes inappropriate test assignments, we paused the first one for a while. This PR will launch the G Suite upsell again but with some fixes this time.

For more details, see p8Eqe3-mp-p2

The test plan is the same as [the previous one](https://github.com/Automattic/wp-calypso/pull/19134) except the test name has changed to `gsuiteUpsellV2`.

cc @fditrapani @anneforbush 