### PR TITLE
Jetpack Onboarding: move the completed and todo steps to a constant.

### DIFF
--- a/client/jetpack-onboarding/constants.js
+++ b/client/jetpack-onboarding/constants.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -28,15 +28,15 @@ export const JETPACK_ONBOARDING_STEPS = {
 };
 
 export const JETPACK_ONBOARDING_SUMMARY_STEPS = {
-	SITE_TITLE_DESCRIPTION: i18n.translate( 'Site Title & Description' ),
-	SITE_TYPE: i18n.translate( 'Type of Site' ),
-	HOMEPAGE_TYPE: i18n.translate( 'Type of Homepage' ),
-	CONTACT_FORM: i18n.translate( 'Contact Us Form' ),
-	JETPACK_CONNECTION: i18n.translate( 'Jetpack Connection' ),
-	THEME: i18n.translate( 'Choose a Theme' ),
-	SITE_ADDRESS: i18n.translate( 'Add a Site Address' ),
-	STORE: i18n.translate( 'Add a Store' ),
-	BLOG: i18n.translate( 'Start a Blog' ),
+	SITE_TITLE_DESCRIPTION: translate( 'Site Title & Description' ),
+	SITE_TYPE: translate( 'Type of Site' ),
+	HOMEPAGE_TYPE: translate( 'Type of Homepage' ),
+	CONTACT_FORM: translate( 'Contact Us Form' ),
+	JETPACK_CONNECTION: translate( 'Jetpack Connection' ),
+	THEME: translate( 'Choose a Theme' ),
+	SITE_ADDRESS: translate( 'Add a Site Address' ),
+	STORE: translate( 'Add a Store' ),
+	BLOG: translate( 'Start a Blog' ),
 };
 
 export const JETPACK_ONBOARDING_COMPONENTS = {

--- a/client/jetpack-onboarding/constants.js
+++ b/client/jetpack-onboarding/constants.js
@@ -20,6 +20,18 @@ export const JETPACK_ONBOARDING_STEPS = {
 	SUMMARY: 'summary',
 };
 
+export const JETPACK_ONBOARDING_SUMMARY_STEPS = {
+	SITE_TITLE_DESCRIPTION: 'Site Title & Description',
+	SITE_TYPE: 'Type of Site',
+	HOMEPAGE_TYPE: 'Type of Homepage',
+	CONTACT_FORM: 'Contact Us Form',
+	JETPACK_CONNECTION: 'Jetpack Connection',
+	THEME: 'Choose a Theme',
+	SITE_ADDRESS: 'Add a Site Address',
+	STORE: 'Add a Store',
+	BLOG: 'Start a Blog',
+};
+
 export const JETPACK_ONBOARDING_COMPONENTS = {
 	[ JETPACK_ONBOARDING_STEPS.SITE_TITLE ]: <JetpackOnboardingSiteTitleStep />,
 	[ JETPACK_ONBOARDING_STEPS.SITE_TYPE ]: <JetpackOnboardingSiteTypeStep />,

--- a/client/jetpack-onboarding/constants.js
+++ b/client/jetpack-onboarding/constants.js
@@ -1,5 +1,12 @@
+/** @format */
+
 /**
- * Internal Dependencies
+ * External dependencies
+ */
+import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
  */
 import React from 'react';
 import JetpackOnboardingBusinessAddressStep from './steps/business-address';
@@ -21,15 +28,15 @@ export const JETPACK_ONBOARDING_STEPS = {
 };
 
 export const JETPACK_ONBOARDING_SUMMARY_STEPS = {
-	SITE_TITLE_DESCRIPTION: 'Site Title & Description',
-	SITE_TYPE: 'Type of Site',
-	HOMEPAGE_TYPE: 'Type of Homepage',
-	CONTACT_FORM: 'Contact Us Form',
-	JETPACK_CONNECTION: 'Jetpack Connection',
-	THEME: 'Choose a Theme',
-	SITE_ADDRESS: 'Add a Site Address',
-	STORE: 'Add a Store',
-	BLOG: 'Start a Blog',
+	SITE_TITLE_DESCRIPTION: i18n.translate( 'Site Title & Description' ),
+	SITE_TYPE: i18n.translate( 'Type of Site' ),
+	HOMEPAGE_TYPE: i18n.translate( 'Type of Homepage' ),
+	CONTACT_FORM: i18n.translate( 'Contact Us Form' ),
+	JETPACK_CONNECTION: i18n.translate( 'Jetpack Connection' ),
+	THEME: i18n.translate( 'Choose a Theme' ),
+	SITE_ADDRESS: i18n.translate( 'Add a Site Address' ),
+	STORE: i18n.translate( 'Add a Store' ),
+	BLOG: i18n.translate( 'Start a Blog' ),
 };
 
 export const JETPACK_ONBOARDING_COMPONENTS = {

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -5,8 +5,9 @@
  */
 import React from 'react';
 import Gridicon from 'gridicons';
+import { compact, map } from 'lodash';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,19 +16,20 @@ import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
+import {
+	JETPACK_ONBOARDING_STEPS as STEPS,
+	JETPACK_ONBOARDING_SUMMARY_STEPS as SUMMARY_STEPS,
+} from '../constants';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
 	renderCompleted = () => {
-		const { translate } = this.props;
 		const stepsCompleted = [
-			translate( 'Site Title & Description' ),
-			translate( 'Type of Site' ),
-			translate( 'Type of Homepage' ),
-			translate( 'Contact Us Form' ),
-			translate( 'Jetpack Connection' ),
+			SUMMARY_STEPS.SITE_TITLE_DESCRIPTION,
+			SUMMARY_STEPS.SITE_TYPE,
+			SUMMARY_STEPS.HOMEPAGE_TYPE,
+			SUMMARY_STEPS.CONTACT_FORM,
+			SUMMARY_STEPS.JETPACK_CONNECTION,
 		];
-
 		return map( stepsCompleted, ( fieldLabel, fieldIndex ) => (
 			<div key={ fieldIndex } className="steps__summary-entry completed">
 				<Gridicon icon="checkmark" size={ 18 } />
@@ -37,12 +39,11 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	};
 
 	renderTodo = () => {
-		const { translate } = this.props;
 		const stepsTodo = [
-			translate( 'Choose a Theme' ),
-			translate( 'Add a Site Address' ),
-			translate( 'Add a Store' ),
-			translate( 'Start a Blog' ),
+			SUMMARY_STEPS.THEME,
+			SUMMARY_STEPS.SITE_ADDRESS,
+			SUMMARY_STEPS.STORE,
+			SUMMARY_STEPS.BLOG,
 		];
 
 		// TODO: adapt when we have more info + it will differ for different steps
@@ -94,4 +95,9 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	}
 }
 
-export default localize( JetpackOnboardingSummaryStep );
+export default connect( () => {
+	const tasks = compact( [] );
+	return {
+		tasks,
+	};
+} )( localize( JetpackOnboardingSummaryStep ) );


### PR DESCRIPTION
Define flow tasks as translated constants. It will facilitate dynamic display of the Summary site content.

Tasks defined in https://github.com/Automattic/wp-calypso/pull/20740

**To test:**

- Checkout this branch and verify the JPO Summary step is displayed as previously in https://github.com/Automattic/wp-calypso/pull/20740
  