### PR TITLE
Jetpack Connect: Whitelist mobile app redirect URLs

### DIFF
--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -6,3 +6,4 @@ export const REMOTE_PATH_ACTIVATE = '/wp-admin/plugins.php';
 export const REMOTE_PATH_AUTH = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true';
 export const REMOTE_PATH_INSTALL =
 	'/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
+export const MOBILE_APP_REDIRECT_URL_WHITELIST = [ /^wordpress:\/\// ];

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -6,7 +6,7 @@ import React from 'react';
 import Debug from 'debug';
 import page from 'page';
 import validator from 'is-my-json-valid';
-import { get, isEmpty } from 'lodash';
+import { get, isEmpty, some } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -28,6 +28,7 @@ import userFactory from 'lib/user';
 import { authorizeQueryDataSchema } from './schema';
 import { authQueryTransformer } from './utils';
 import { JETPACK_CONNECT_QUERY_SET } from 'state/action-types';
+import { MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
 import { receiveJetpackOnboardingCredentials } from 'state/jetpack-onboarding/actions';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
@@ -136,7 +137,13 @@ export function connect( context, next ) {
 	planSlug && storePlan( planSlug );
 
 	if ( config.isEnabled( 'jetpack/connect/mobile-app-flow' ) ) {
-		persistMobileRedirect( query.mobile_redirect || '' );
+		if (
+			some( MOBILE_APP_REDIRECT_URL_WHITELIST, pattern => pattern.test( query.mobile_redirect ) )
+		) {
+			persistMobileRedirect( query.mobile_redirect );
+		} else {
+			persistMobileRedirect( '' );
+		}
 	}
 
 	analytics.pageView.record( pathname, analyticsPageTitle );

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -140,6 +140,7 @@ export function connect( context, next ) {
 		if (
 			some( MOBILE_APP_REDIRECT_URL_WHITELIST, pattern => pattern.test( query.mobile_redirect ) )
 		) {
+			debug( `In mobile app flow with redirect url: ${ query.mobile_redirect }` );
 			persistMobileRedirect( query.mobile_redirect );
 		} else {
 			persistMobileRedirect( '' );


### PR DESCRIPTION
Avoid leaving an open redirect by checking supplied mobile app redirect URL against a whitelist.

Currently the list is simply `wordpress://`. The mobile apps may want to use different schemes as part of dev process, such as `wpdebug`, `wpinternal`, so these can be added to the list as needed.

### Testing
* Check the value of the `jetpack_connect_mobile_redirect` cookie in the browser on the following routes. It should be set for valid values of `?mobile_redirect`, and empty for invalid values (or not supplied).

Valid:
`http://calypso.localhost:3000/jetpack/connect?mobile_redirect=wordpress://jetpack-connection`
Invalid:
`http://calypso.localhost:3000/jetpack/connect?mobile_redirect=blah`
