### PR TITLE
Jetpack Connect: Enable mobile app flow in staging/production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -35,6 +35,7 @@
 		"help/courses": true,
 		"jetpack/api-cache": false,
 		"jetpack/connect-redirect-pressable-credential-approval": false,
+		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,
 		"jetpack/google-analytics-for-stores-enhanced": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -37,6 +37,7 @@
 		"help/courses": true,
 		"jetpack/api-cache": true,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
+		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/happychat": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,


### PR DESCRIPTION
Initial testing of Jetpack Connect mobile app flow introduced in #20955 show that the mobile app can work with the flow and detect the redirect at the end.

After whitelisting the redirect param in #21071, we can enable this flow in production so that the mobile apps can test the plugin install/activate flows which always come back to wordpress.com.

### Testing
n/a
