### PR TITLE
Me: Refresh profile links using Redux after reauth

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -14,9 +14,10 @@ import emitter from 'lib/mixins/emitter';
 import userSettings from 'lib/user-settings';
 import applicationPasswords from 'lib/application-passwords-data';
 import connectedApplications from 'lib/connected-applications-data';
-import profileLinks from 'lib/user-profile-links';
 import analytics from 'lib/analytics';
 import wp from 'lib/wp';
+import { reduxDispatch } from 'lib/redux-bridge';
+import { requestUserProfileLinks } from 'state/profile-links/actions';
 
 const wpcom = wp.undocumented();
 
@@ -81,8 +82,7 @@ TwoStepAuthorization.prototype.validateCode = function( args, callback ) {
 					userSettings.fetchSettings();
 					applicationPasswords.fetch();
 					connectedApplications.fetch();
-					profileLinks.reAuthRequired = false;
-					profileLinks.fetchProfileLinks();
+					reduxDispatch( requestUserProfileLinks() );
 				}
 
 				this.data.two_step_reauthorization_required = false;


### PR DESCRIPTION
As part of #20241, we migrated profile links to use Redux, but forgot to migrate the last usage of the old library - refetching profile links after 2fa reauthorization.

To test:
* Checkout this branch
* Make sure you have 2fa enabled on the account.
* Go to http://calypso.localhost:3000/me
* Delete **only** your 2fa cookie (the cookie `twostep_auth` from `public-api.wordpress.com`).
* Refresh the page.
* You should be presented with the reauthorization dialog, and the user profile links behind should be showing a placeholder
* Input the authorization code, dialog should disappear.
* Verify the profile links load shortly after dialog has disappeared.

cc @ebinnion as he worked on this initially in 5345-gh-calypso-pre-oss