### PR TITLE
Update: jetpack upgrade prompt text

### DIFF
--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -19,6 +19,7 @@ import SidebarBanner from 'my-sites/current-site/sidebar-banner';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { isDomainOnlySite } from 'state/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 const impressionEventName = 'calypso_upgrade_nudge_impression';
 const clickEventName = 'calypso_upgrade_nudge_cta_click';
@@ -37,6 +38,15 @@ export class DomainToPaidPlanNotice extends Component {
 		this.props.recordTracksEvent( clickEventName, eventProperties );
 	};
 
+	getBannerText = () => {
+		const { translate } = this.props;
+
+		if ( this.props.isJetpack ) {
+			return translate( 'Upgrade for full site backups.' );
+		}
+		return translate( 'Upgrade your site and save.' );
+	};
+
 	render() {
 		const { eligible, isConflicting, isDomainOnly, site, translate } = this.props;
 
@@ -51,7 +61,7 @@ export class DomainToPaidPlanNotice extends Component {
 			: `/plans/my-plan/${ site.slug }`;
 
 		return (
-			<SidebarBanner icon="info-outline" text={ translate( 'Upgrade your site and save.' ) }>
+			<SidebarBanner icon="info-outline" text={ this.getBannerText() }>
 				<a onClick={ this.onClick } href={ actionLink }>
 					<span>
 						{ translate( 'Go' ) }
@@ -69,12 +79,14 @@ export class DomainToPaidPlanNotice extends Component {
 const mapStateToProps = state => {
 	const site = getSelectedSite( state );
 	const isDomainOnly = isDomainOnlySite( state, site.ID );
+	const isJetpack = isJetpackSite( state, site.ID );
 
 	return {
 		eligible: isEligibleForDomainToPaidPlanUpsell( state, site.ID ),
 		isConflicting: isDomainOnly && endsWith( site.domain, '.wordpress.com' ),
 		isDomainOnly,
 		site,
+		isJetpack,
 	};
 };
 const mapDispatchToProps = { recordTracksEvent };


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/21048

Quick & dumb PR to change the text used in the free sites upgrade prompt used in jetpack sites:

![image](https://user-images.githubusercontent.com/1554855/34304060-5ea9289e-e738-11e7-9f8d-bf721c2fe6da.png)

We are aware that this is not the place where we should be adding any jetpack content, but because some side effect (isJetpackSite not being checked in the selector) we are showing this banner to all jetpack plans, and we need to update as soon as possible, while we work in a more permanent solution (That would remove this hack)

How to test:

1. Select a jetpack site with a free plan 
2. you should see the new text for this banner in the sidebar