### PR TITLE
docker run: don't specify env

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "clean:public": "npm run -s rm -- public .css .css.map .js .js.map && npm run -s rm -- public/sections .css .css.map && npm run -s rm -- public/sections-rtl .css .css.map",
     "codemod": "node bin/codemods/run",
     "distclean": "npm run -s clean && npm run -s rm -- node_modules",
-    "docker": "docker run -it --name wp-calypso --rm -p 80:3000 -e NODE_ENV=wpcalypso -e CALYPSO_ENV=wpcalypso wp-calypso",
+    "docker": "docker run -it --name wp-calypso --rm -p 80:3000 -e NODE_ENV=production -e CALYPSO_ENV=wpcalypso wp-calypso",
     "env": "cross-env-shell NODE_PATH=$NODE_PATH:server:client:.",
     "eslint-branch": "node bin/eslint-branch.js",
     "install-if-deps-outdated": "node bin/install-if-deps-outdated.js",

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "clean:public": "npm run -s rm -- public .css .css.map .js .js.map && npm run -s rm -- public/sections .css .css.map && npm run -s rm -- public/sections-rtl .css .css.map",
     "codemod": "node bin/codemods/run",
     "distclean": "npm run -s clean && npm run -s rm -- node_modules",
-    "docker": "docker run -it --name wp-calypso --rm -p 80:3000 -e NODE_ENV=production -e CALYPSO_ENV=wpcalypso wp-calypso",
+    "docker": "docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso",
     "env": "cross-env-shell NODE_PATH=$NODE_PATH:server:client:.",
     "eslint-branch": "node bin/eslint-branch.js",
     "install-if-deps-outdated": "node bin/install-if-deps-outdated.js",


### PR DESCRIPTION
`NODE_ENV` should only be one of 3 or 4 values depending on who you ask:
1. undefined
2. `development` (controversial)
3. `production` (pattern created by express)
4. `test` (as assigned by jest)

They value is most essential during the webpack build and doest not matter a lick during the docker run.  No reason to set anything when running the container.