### PR TITLE
Framework: Error Logging - Add commit sha to error logs.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,8 @@ module.exports = {
 	},
 	globals: {
 		asyncRequire: true,
-		PROJECT_NAME: true
+		PROJECT_NAME: true,
+		COMMIT_SHA: true,
 	},
 	plugins: [
 		'jest'

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -29,6 +29,7 @@ const log = debug( 'calypso:error-logger' );
 export default class ErrorLogger {
 	constructor() {
 		this.diagnosticData = {
+			commit: COMMIT_SHA, // eslint-disable-line no-undef
 			extra: {
 				previous_paths: [],
 				throttled: 0,

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -29,7 +29,7 @@ const log = debug( 'calypso:error-logger' );
 export default class ErrorLogger {
 	constructor() {
 		this.diagnosticData = {
-			commit: COMMIT_SHA, // eslint-disable-line no-undef
+			commit: COMMIT_SHA,
 			extra: {
 				previous_paths: [],
 				throttled: 0,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ const NameAllModulesPlugin = require( 'name-all-modules-plugin' );
 const AssetsPlugin = require( 'assets-webpack-plugin' );
 const UglifyJsPlugin = require( 'uglifyjs-webpack-plugin' );
 const prism = require( 'prismjs' );
+const childProcess = require( 'child_process' );
 
 /**
  * Internal dependencies
@@ -34,6 +35,10 @@ const isDevelopment = bundleEnv === 'development';
 const shouldMinify = process.env.hasOwnProperty( 'MINIFY_JS' )
 	? process.env.MINIFY_JS === 'true'
 	: ! isDevelopment;
+const gitCommitSha = childProcess
+	.execSync( 'git rev-parse HEAD' )
+	.toString()
+	.trim();
 
 /**
  * This function scans the /client/extensions directory in order to generate a map that looks like this:
@@ -165,6 +170,7 @@ const webpackConfig = {
 		new webpack.DefinePlugin( {
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
 			PROJECT_NAME: JSON.stringify( config( 'project' ) ),
+			COMMIT_SHA: JSON.stringify( gitCommitSha ),
 		} ),
 		new webpack.IgnorePlugin( /^props$/ ),
 		new CopyWebpackPlugin( [

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -13,6 +13,7 @@ const HardSourceWebpackPlugin = require( 'hard-source-webpack-plugin' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 const _ = require( 'lodash' );
+const childProcess = require( 'child_process' );
 
 /**
  * Internal dependencies
@@ -20,6 +21,14 @@ const _ = require( 'lodash' );
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( 'config' );
 const bundleEnv = config( 'env' );
+
+/**
+ * Internal variables
+ */
+const gitCommitSha = childProcess
+	.execSync( 'git rev-parse HEAD' )
+	.toString()
+	.trim();
 
 /**
  * This lists modules that must use commonJS `require()`s
@@ -134,6 +143,7 @@ const webpackConfig = {
 		} ),
 		new webpack.DefinePlugin( {
 			PROJECT_NAME: JSON.stringify( config( 'project' ) ),
+			COMMIT_SHA: JSON.stringify( gitCommitSha ),
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
 		} ),
 		new HappyPack( { loaders: [ babelLoader ] } ),


### PR DESCRIPTION
This adds a "commit" field to all error logs with the SHA of the
commit for the build. This will allow for better debugging of
production error logs.

Note: `commit` is already in the whitelist of parameters allowed, we're just not using it until now.

To Test:

Since this code is only designed to run in non-development environments and only when an uncaught exception is thrown, you'll have to simulate these to test in a development environment. Just make sure to not commit these changes and undo them when you're done.

Pre-step 1. Add a place in the code that throws an error. I added an "onClick" handler to a button in the devdocs `client/components/button/docs`, and this what I changed on line 94: `<Button primary scary onClick={ () => { throw new Error( 'Test Error for sha' ) } }>`

Now you can test:

1. Start calypso, enabling errors in development: `ENABLE_FEATURES=catch-js-errors npm start`
2. Go to `http://calypso.localhost:3000/devdocs`
3. Open your browser dev console, and show both the console and the network tabs.
4. Go to "UI Components", find your modified button and click it. (or whatever you did for testing)
5. You should see your error trace in the console as normal.
6. In the network requests, you should see one that is `js-error?http_envelope=1`, click on it.
7. In the Form Data of the request, you should see the `error:` field. It should contain something like `"commit":"#####################"`.
8. Undo your Pre-step changes you did above so you don't accidentally commit them somewhere! 