### PR TITLE
Take two on domain registration (Work in Progress

### DIFF
--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -47,6 +47,7 @@ class DomainSuggestion extends React.Component {
 				data-tracks-button-click-source={ this.props.tracksButtonClickSource }
 				role="button"
 				data-e2e-domain={ this.props.domain }
+				data-tip-target="domain-suggestion"
 			>
 				<div className="domain-suggestion__content">
 					{ children }

--- a/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/index.jsx
@@ -148,7 +148,12 @@ class GoogleAppsDialog extends React.Component {
 
 		if ( abtest( 'multiDomainRegistrationV1' ) === 'singlePurchaseFlow' ) {
 			return (
-				<a className="google-apps-dialog__cancel-link" href="#" onClick={ this.handleFormCheckout }>
+				<a
+					className="google-apps-dialog__cancel-link"
+					href="#"
+					onClick={ this.handleFormCheckout }
+					data-tip-target="gsuite-cancel"
+				>
 					{ translate( 'No thanks, I don’t need email or I’ll use another provider.' ) }
 				</a>
 			);
@@ -182,6 +187,7 @@ class GoogleAppsDialog extends React.Component {
 					className="google-apps-dialog__continue-button button is-primary"
 					type="submit"
 					onClick={ continueButtonHandler }
+					data-tip-target="gsuite-continue"
 				>
 					{ continueButtonText }
 				</button>

--- a/client/components/upgrades/google-apps/google-apps-dialog/users-form.jsx
+++ b/client/components/upgrades/google-apps/google-apps-dialog/users-form.jsx
@@ -60,6 +60,7 @@ class GoogleAppsUsersForm extends React.Component {
 						onChange={ this.updateInputField }
 						onBlur={ onBlur }
 						onClick={ this.recordInputFocusEmail }
+						data-tip-target="gsuite-email-input"
 					/>
 					{ emailError ? <FormInputValidation text={ emailError } isError={ true } /> : null }
 				</FormFieldset>

--- a/client/layout/guided-tours/tours/checklist-register-domain-tour.js
+++ b/client/layout/guided-tours/tours/checklist-register-domain-tour.js
@@ -12,127 +12,82 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import {
-	ButtonRow,
-	Continue,
-	makeTour,
-	Next,
-	Quit,
-	SiteLink,
-	Step,
-	Tour,
-} from 'layout/guided-tours/config-elements';
+import { Continue, makeTour, SiteLink, Step, Tour } from 'layout/guided-tours/config-elements';
 
 export const ChecklistRegisterDomainTour = makeTour(
 	<Tour name="checklistRegisterDomain" version="20171219" path="/domains/add" when={ noop }>
 		<Step
 			name="init"
-			arrow="right-top"
-			placement="beside"
+			placement="right"
 			style={ {
-				animationDelay: '0.7s',
+				animationDelay: '0.3s',
 			} }
-			target=".register-domain-step__search .search-card"
+			target="domain-suggestion"
 		>
 			<p>
 				{ translate(
-					'Search engines like Google and Bing prefer custom domain names and place them higher in search results.'
+					'Search engines like Google and Bing prefer custom domain names and place ' +
+						'them higher in search results.'
 				) }
 			</p>
-			<Continue target=".domain-suggestion" step="email-step" click hidden />
-			<Continue target=".domain-search-results" step="email-step" click hidden />
-			<ButtonRow>
-				<Next step="email-step">{ translate( 'Got it, thanks!' ) }</Next>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
-			</ButtonRow>
+
+			<p>
+				{ translate( 'Start by searching for a unique but memorable domain name for your site.' ) }
+			</p>
+
+			<Continue target="domain-suggestion" step="email-step" click hidden />
+			<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 		</Step>
 
-		<Step
-			name="email-step"
-			arrow="top-right"
-			placement="below"
-			target=".google-apps-dialog__continue-button"
-		>
-			<p>{ translate( 'Use G Suite by Google Cloud to manage your emails and more.' ) }</p>
+		<Step name="email-step" placement="right">
+			<p>
+				{ translate(
+					'If you need email, use G Suite by Google Cloud to manage your emails and more.'
+				) }
+			</p>
 
-			<Continue target=".google-apps-dialog__continue-button" step="email-step-2" click hidden />
-			<Continue target=".google-apps-dialog__cancel-link" step="contact-information" click hidden />
-
-			<ButtonRow>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
-			</ButtonRow>
+			<Continue target="gsuite-continue" step="email-step-2" click hidden />
+			<Continue target="gsuite-cancel" step="contact-information" click hidden />
 		</Step>
 
-		<Step
-			name="email-step-2"
-			arrow="bottom-left"
-			placement="above"
-			target=".google-apps-dialog__user-email"
-		>
-			<p>{ translate( 'Enter the email address to be created and move to the next step.' ) }</p>
-			<Continue
-				target=".google-apps-dialog__continue-button"
-				step="contact-information"
-				click
-				hidden
-			/>
-			<ButtonRow>
-				<Next step="contact-information">{ translate( 'Got it, thanks!' ) }</Next>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
-			</ButtonRow>
+		<Step name="email-step-2" placement="right">
+			<p>
+				{ translate(
+					'Great choice! Enter your email address(es) and then press {{b}}Continue{{/b}}.',
+					{
+						components: { b: <strong /> },
+					}
+				) }
+			</p>
+			<Continue target="gsuite-continue" step="contact-information" click hidden />
 		</Step>
 
-		<Step
-			name="contact-information"
-			arrow="bottom-left"
-			placement="above"
-			target=".checkout__payment-box-container .domain-details #first-name"
-		>
-			<p>{ translate( 'Enter your domain contact information for your domain records.' ) }</p>
+		<Step name="contact-information" placement="right">
+			<p>
+				{ translate(
+					'Enter your domain contact information for your domain ' +
+						'records then press {{b}}Continue to Checkout{{/b}}.',
+					{
+						components: { b: <strong /> },
+					}
+				) }
+			</p>
 
-			<Continue
-				target=".checkout__domain-details-form-submit-button"
-				step="contact-information-2"
-				click
-				hidden
-			/>
-
-			<ButtonRow>
-				<Next step="contact-information-2">{ translate( 'Got it, thanks!' ) }</Next>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
-			</ButtonRow>
+			<Continue target="domain-details-submit" step="checkout-step" click hidden />
 		</Step>
 
-		<Step
-			name="contact-information-2"
-			arrow="top-right"
-			placement="below"
-			target=".checkout__domain-details-form-submit-button"
-		>
-			<p>{ translate( 'One final step is remaining!' ) }</p>
+		<Step name="checkout-step" placement="right">
+			<p>
+				{ translate(
+					'Almost done! Enter your payment information and press {{b}}Pay{{/b}} ' +
+						'to complete your purchase.',
+					{
+						components: { b: <strong /> },
+					}
+				) }
+			</p>
 
-			<Continue
-				target=".checkout__domain-details-form-submit-button"
-				step="checkout-step"
-				click
-				hidden
-			/>
-		</Step>
-
-		<Step
-			name="checkout-step"
-			arrow="top-right"
-			placement="below"
-			target="g.checkout__secure-payment-content"
-		>
-			<p>{ translate( 'Enter your payment information to complete your purchase.' ) }</p>
-
-			<Continue target=".pay-button__button" step="finish" click hidden />
-
-			<ButtonRow>
-				<Quit>{ translate( 'Got it, thanks!' ) }</Quit>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
-			</ButtonRow>
+			<Continue target="pay-button" step="finish" click hidden />
 		</Step>
 
 		<Step name="finish" placement="right">

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -336,6 +336,7 @@ export class DomainDetailsForm extends PureComponent {
 				className="checkout__domain-details-form-submit-button"
 				onClick={ this.handleSubmitButtonClick }
 				disabled={ ! this.getCountryCode() }
+				data-tip-target="domain-details-submit"
 			>
 				{ continueText }
 			</FormButton>

--- a/client/my-sites/checkout/checkout/pay-button.jsx
+++ b/client/my-sites/checkout/checkout/pay-button.jsx
@@ -150,6 +150,7 @@ class PayButton extends React.Component {
 					type="submit"
 					className="button is-primary button-pay pay-button__button"
 					disabled={ buttonState.disabled }
+					data-tip-target="pay-button"
 				>
 					{ buttonState.text }
 				</button>


### PR DESCRIPTION
This is a second stab at this PR here: https://github.com/Automattic/wp-calypso/pull/20995/files. Some notable changes:
* Changed CSS classes to `data-tip-targets`
* Changed lots of copy and positioning of tours.

Some things to note:
* In cases where there are multiple `data-tip-targets` with the same name, it only works if you click the first (Domain suggestions is an example)
* We both can't get the last step to trigger
* My second last step triggers intermittently as you'll see below

## With G Suite
![gsuite-1](https://user-images.githubusercontent.com/6981253/34311133-bd6bebe6-e729-11e7-94a2-5513eac893db.gif)

## Without G Suite
![gsuite-2](https://user-images.githubusercontent.com/6981253/34311135-c03fd59e-e729-11e7-8897-285846c74dba.gif)

@taggon can you take a look?

cc @velesin 
