### PR TITLE
Post likes popover: link to Reader

### DIFF
--- a/client/blocks/post-likes/README.md
+++ b/client/blocks/post-likes/README.md
@@ -1,15 +1,18 @@
 Post Likes
 ==========
 
-`<PostLikes />` is a connected React component for rendering the post likes.
+`<PostLikes />` is a connected React component for rendering a list of users
+who liked a given post.  If the user has a primary site set on WP.com, the
+user's avatar (and display name, if shown) will link to that site in the
+Calypso Reader.
 
 ## Usage
 
-Render the component passing a siteId and a postId.
+Render the component passing a `siteId` and a `postId`.
 
 ```jsx
 function MyAwesomeComponent() {
-	return <PostLikes siteId="10" postId="1143" />;
+	return <PostLikes siteId={ 10 } postId={ 1143 } />;
 }
 ```
 

--- a/client/blocks/post-likes/docs/example.jsx
+++ b/client/blocks/post-likes/docs/example.jsx
@@ -70,7 +70,7 @@ class PostLikesExample extends React.PureComponent {
 				{ this.state.showPopover && (
 					<PostLikesPopover
 						siteId={ 3584907 }
-						postId={ 39717 }
+						postId={ 39687 }
 						showDisplayNames={ this.state.showDisplayNames }
 						context={ this.state.popoverContext }
 						position="bottom"

--- a/client/blocks/post-likes/docs/example.jsx
+++ b/client/blocks/post-likes/docs/example.jsx
@@ -70,7 +70,7 @@ class PostLikesExample extends React.PureComponent {
 				{ this.state.showPopover && (
 					<PostLikesPopover
 						siteId={ 3584907 }
-						postId={ 39687 }
+						postId={ 39717 }
 						showDisplayNames={ this.state.showDisplayNames }
 						context={ this.state.popoverContext }
 						position="bottom"

--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Gravatar from 'components/gravatar';
-import Gridicon from 'gridicons';
 import QueryPostLikes from 'components/data/query-post-likes';
 import { isRequestingPostLikes, getPostLikes, countPostLikes } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
@@ -23,10 +22,6 @@ class PostLikes extends React.PureComponent {
 		showDisplayNames: false,
 	};
 
-	getLikeUrl = like => {
-		return like.URL ? like.URL : `https://gravatar.com/${ like.login }`;
-	};
-
 	trackLikeClick = () => {
 		this.props.recordGoogleEvent( 'Post Likes', 'Clicked on Gravatar' );
 	};
@@ -34,23 +29,19 @@ class PostLikes extends React.PureComponent {
 	renderLike = like => {
 		const { showDisplayNames } = this.props;
 
+		const likeUrl = like.site_ID ? '/read/blogs/' + like.site_ID : null;
+		const LikeWrapper = likeUrl ? 'a' : 'span';
+
 		return (
-			<a
+			<LikeWrapper
 				key={ like.ID }
-				href={ this.getLikeUrl( like ) }
-				rel="noopener noreferrer"
-				target="_blank"
+				href={ likeUrl }
 				className="post-likes__item"
-				onClick={ this.trackLikeClick }
+				onClick={ likeUrl ? this.trackLikeClick : null }
 			>
 				<Gravatar user={ like } alt={ like.login } title={ like.login } size={ 24 } />
-				{ showDisplayNames && (
-					<span className="post-likes__display-name">
-						{ like.name }
-						<Gridicon className="post-likes__external-link-icon" icon="external" size={ 12 } />
-					</span>
-				) }
-			</a>
+				{ showDisplayNames && <span className="post-likes__display-name">{ like.name }</span> }
+			</LikeWrapper>
 		);
 	};
 

--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -29,7 +29,7 @@ class PostLikes extends React.PureComponent {
 	renderLike = like => {
 		const { showDisplayNames } = this.props;
 
-		const likeUrl = like.site_ID && ! like.site_is_private ? '/read/blogs/' + like.site_ID : null;
+		const likeUrl = like.site_ID && like.site_visible ? '/read/blogs/' + like.site_ID : null;
 		const LikeWrapper = likeUrl ? 'a' : 'span';
 
 		return (

--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -29,7 +29,7 @@ class PostLikes extends React.PureComponent {
 	renderLike = like => {
 		const { showDisplayNames } = this.props;
 
-		const likeUrl = like.site_ID ? '/read/blogs/' + like.site_ID : null;
+		const likeUrl = like.site_ID && ! like.site_is_private ? '/read/blogs/' + like.site_ID : null;
 		const LikeWrapper = likeUrl ? 'a' : 'span';
 
 		return (

--- a/client/blocks/post-likes/style.scss
+++ b/client/blocks/post-likes/style.scss
@@ -23,7 +23,7 @@ $post-likes-per-popover-row: 12;
 		.post-likes__item {
 			display: block;
 			position: relative;
-			padding: 4px 16px 4px 8px;
+			padding: 4px 8px;
 			border-bottom: 1px solid $gray-light;
 
 			&:last-child {
@@ -42,14 +42,6 @@ $post-likes-per-popover-row: 12;
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
-		}
-
-		.post-likes__external-link-icon {
-			vertical-align: middle;
-			position: relative;
-			top: -1px;
-			color: lighten( $gray, 10% );
-			padding-left: 4px;
 		}
 
 		.post-likes__count:not( .is-loading ) {

--- a/client/state/posts/likes/reducer.js
+++ b/client/state/posts/likes/reducer.js
@@ -66,7 +66,9 @@ export const items = createReducer(
 				[ siteId ]: {
 					...state[ siteId ],
 					[ postId ]: {
-						likes: likes.map( like => pick( like, 'ID', 'avatar_URL', 'URL', 'login', 'name' ) ),
+						likes: likes.map( like =>
+							pick( like, 'ID', 'avatar_URL', 'URL', 'login', 'name', 'site_ID' )
+						),
 						iLike,
 						found,
 					},

--- a/client/state/posts/likes/reducer.js
+++ b/client/state/posts/likes/reducer.js
@@ -67,7 +67,7 @@ export const items = createReducer(
 					...state[ siteId ],
 					[ postId ]: {
 						likes: likes.map( like =>
-							pick( like, 'ID', 'avatar_URL', 'URL', 'login', 'name', 'site_ID' )
+							pick( like, 'ID', 'avatar_URL', 'login', 'name', 'site_ID' )
 						),
 						iLike,
 						found,

--- a/client/state/posts/likes/reducer.js
+++ b/client/state/posts/likes/reducer.js
@@ -67,7 +67,7 @@ export const items = createReducer(
 					...state[ siteId ],
 					[ postId ]: {
 						likes: likes.map( like =>
-							pick( like, 'ID', 'avatar_URL', 'login', 'name', 'site_ID', 'site_is_private' )
+							pick( like, 'ID', 'avatar_URL', 'login', 'name', 'site_ID', 'site_visible' )
 						),
 						iLike,
 						found,

--- a/client/state/posts/likes/reducer.js
+++ b/client/state/posts/likes/reducer.js
@@ -67,7 +67,7 @@ export const items = createReducer(
 					...state[ siteId ],
 					[ postId ]: {
 						likes: likes.map( like =>
-							pick( like, 'ID', 'avatar_URL', 'login', 'name', 'site_ID' )
+							pick( like, 'ID', 'avatar_URL', 'login', 'name', 'site_ID', 'site_is_private' )
 						),
 						iLike,
 						found,

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -320,7 +320,6 @@ describe( 'reducer', () => {
 				{
 					ID: 1,
 					avatar_URL: 'https://gravatar.com/whatever',
-					URL: 'https://example.com/',
 					login: 'chicken',
 					name: 'A Former Egg',
 					site_ID: 2,
@@ -346,7 +345,6 @@ describe( 'reducer', () => {
 							{
 								ID: 1,
 								avatar_URL: 'https://gravatar.com/whatever',
-								URL: 'https://example.com/',
 								login: 'chicken',
 								name: 'A Former Egg',
 								site_ID: 2,

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -323,6 +323,7 @@ describe( 'reducer', () => {
 					URL: 'https://example.com/',
 					login: 'chicken',
 					name: 'A Former Egg',
+					site_ID: 2,
 					some_other_property: 'aaaaa',
 				},
 			];
@@ -348,6 +349,7 @@ describe( 'reducer', () => {
 								URL: 'https://example.com/',
 								login: 'chicken',
 								name: 'A Former Egg',
+								site_ID: 2,
 							},
 						],
 						found: 2,

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -323,6 +323,7 @@ describe( 'reducer', () => {
 					login: 'chicken',
 					name: 'A Former Egg',
 					site_ID: 2,
+					site_is_private: false,
 					some_other_property: 'aaaaa',
 				},
 			];
@@ -348,6 +349,7 @@ describe( 'reducer', () => {
 								login: 'chicken',
 								name: 'A Former Egg',
 								site_ID: 2,
+								site_is_private: false,
 							},
 						],
 						found: 2,

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -323,7 +323,7 @@ describe( 'reducer', () => {
 					login: 'chicken',
 					name: 'A Former Egg',
 					site_ID: 2,
-					site_is_private: false,
+					site_visible: true,
 					some_other_property: 'aaaaa',
 				},
 			];
@@ -349,7 +349,7 @@ describe( 'reducer', () => {
 								login: 'chicken',
 								name: 'A Former Egg',
 								site_ID: 2,
-								site_is_private: false,
+								site_visible: true,
 							},
 						],
 						found: 2,


### PR DESCRIPTION
Follow-up to #20882.  Changes the links for each user who liked a post in the `PostLikesPopover` displayed in the posts list.

## Previously

Open the URL specified in each user's profile (usually their primary site) in a new tab, or open their Gravatar profile page if no URL is present.

> <img src="https://user-images.githubusercontent.com/227022/34225274-cc64b9f8-e593-11e7-9678-dd303e122cad.png" width="250">

## In this PR

Open the user's primary site in the same tab in the Reader, or do not display a link if the user has no primary site set.

> <img src="https://user-images.githubusercontent.com/227022/34312111-b3746ce8-e72f-11e7-8c44-084a71b873e2.png" width="550">