### PR TITLE
Jetpack Onboarding: save input from the Business Address step

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -25,7 +25,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 	state = {
 		city: '',
 		name: '',
-		stateName: '',
+		state: '',
 		street: '',
 		zip: '',
 	};
@@ -43,23 +43,14 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 			name: translate( 'Business Name' ),
 			street: translate( 'Street Address' ),
 			city: translate( 'City' ),
-			stateName: translate( 'State' ),
+			state: translate( 'State' ),
 			zip: translate( 'ZIP Code' ),
 		};
 	}
 
 	handleAddBusinessAddress = () => {
 		const { siteId } = this.props;
-
-		this.props.saveJetpackOnboardingSettings( siteId, {
-			businessAddress: {
-				city: this.state.city,
-				state: this.state.stateName,
-				street: this.state.street,
-				zip: this.state.zip,
-				name: this.state.name,
-			},
-		} );
+		this.props.saveJetpackOnboardingSettings( siteId, { businessAddress: this.state } );
 	};
 
 	render() {

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 /**
@@ -18,6 +19,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
+import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 	state = {
@@ -46,15 +48,29 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		};
 	}
 
+	handleAddBusinessAddress = () => {
+		const { siteId } = this.props;
+
+		this.props.saveJetpackOnboardingSettings( siteId, {
+			businessAddress: {
+				city: this.state.city,
+				state: this.state.stateName,
+				street: this.state.street,
+				zip: this.state.zip,
+				name: this.state.name,
+			},
+		} );
+	};
+
 	render() {
-		const { translate } = this.props;
+		const { getForwardUrl, translate } = this.props;
 		const headerText = translate( 'Add a business address.' );
 		const subHeaderText = translate(
 			'Enter your business address to have a map added to your website.'
 		);
 
 		return (
-			<div className="steps__main">
+			<Fragment>
 				<DocumentHead title={ translate( 'Business Address ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
 					path={ '/jetpack/onboarding/' + STEPS.BUSINESS_ADDRESS + '/:site' }
@@ -76,14 +92,16 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 								/>
 							</FormFieldset>
 						) ) }
-						<Button href={ this.props.getForwardUrl() } primary>
+						<Button href={ getForwardUrl() } onClick={ this.handleAddBusinessAddress } primary>
 							{ translate( 'Next Step' ) }
 						</Button>
 					</form>
 				</Card>
-			</div>
+			</Fragment>
 		);
 	}
 }
 
-export default localize( JetpackOnboardingBusinessAddressStep );
+export default connect( null, { saveJetpackOnboardingSettings } )(
+	localize( JetpackOnboardingBusinessAddressStep )
+);


### PR DESCRIPTION
Connect the `Business Address` flow step and save the input data in the Redux store. 

The actual data saving on the Jetpack end will happen in the companion PR https://github.com/Automattic/jetpack/pull/8426.

**To test:**
* Checkout this branch in local Calypso
* Run the latest JP master on the sandbox
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your JP sandbox
* Land in http://calypso.localhost:3000/jetpack/onboarding/yourjetpacksandbox.com (possibly after connecting, depending on whether we land the skip-connection for fresh sites by the time it is tested :) )
* Click through till hitting the `onboarding/business-address/`
* Add input to the fields in the `Add a business address` step
* Click `Next Step` button
* Verify that the `businessAddress` object is saved with correctly set/updated properties in `JETPACK_ONBOARDING_SETTINGS_SAVE` 

  
  
  
  