### PR TITLE
Sidebar Upgrade Prompt: Update Link

### DIFF
--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -58,7 +58,7 @@ export class DomainToPaidPlanNotice extends Component {
 			? `/start/site-selected/?siteSlug=${ encodeURIComponent(
 					site.slug
 				) }&siteId=${ encodeURIComponent( site.ID ) }`
-			: `/plans/my-plan/${ site.slug }`;
+			: `/plans/${ site.slug }`;
 
 		return (
 			<SidebarBanner icon="info-outline" text={ this.getBannerText() }>


### PR DESCRIPTION
Update the link in the sidebar upgrade prompt to point directly to the Plans page, which is where you can actually make a purchase/upgrade.

Closes #21049 