### PR TITLE
Privacy Policy Banner: avoid rerenders when no relevant state changes

### DIFF
--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -147,12 +147,12 @@ class PrivacyPolicyBanner extends Component {
 
 const mapStateToProps = state => {
 	const privacyPolicy = getPrivacyPolicyByEntity( state, AUTOMATTIC_ENTITY );
-	const privacyPolicyUserStatus = getPreference( state, PRIVACY_POLICY_PREFERENCE ) || {};
+	const privacyPolicyUserStatus = getPreference( state, PRIVACY_POLICY_PREFERENCE );
 	const privacyPolicyId = privacyPolicy.id;
 
 	return {
 		fetchingPreferences: isFetchingPreferences( state ),
-		isPolicyAlreadyAccepted: privacyPolicyUserStatus[ privacyPolicyId ] || false,
+		isPolicyAlreadyAccepted: get( privacyPolicyUserStatus, privacyPolicyId, false ),
 		privacyPolicyUserStatus,
 		privacyPolicy,
 		privacyPolicyId,
@@ -162,10 +162,10 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = {
 	acceptPrivacyPolicy: ( privacyPolicyId, privacyPolicyUserStatus ) =>
-		savePreference( PRIVACY_POLICY_PREFERENCE, {
-			...privacyPolicyUserStatus,
-			[ privacyPolicyId ]: true,
-		} ),
+		savePreference(
+			PRIVACY_POLICY_PREFERENCE,
+			Object.assign( {}, privacyPolicyUserStatus, { [ privacyPolicyId ]: true } )
+		),
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( PrivacyPolicyBanner ) );


### PR DESCRIPTION
If my `PRIVACY_POLICY_PREFERENCE` preference is `null`, the `mapStateToProps` selector defaults it to `{}`. That's a different object each time the selector is called and a shallow equality comparison of the prev and next result of `mapStateToProps` returns `false`. The component is needlessly rerendered.

My patch removes the default objects and teaches the rest of the code to work with a `null` value.

The rerender was showing up in performance profiles of the `/stats` page.

**How to test:**
1. Reset your settings so that the latest privacy policy is not yet accepted by you and the banner is displayed.
2. Go to the `/stats/day/:siteid` page.
3. Is the privacy banner visible?
4. Do something on the page that's irrelevant to the privacy banner, like switching time periods on the chart. At the same time, have a `console.log` in the component's `render` methods or capture a profile.
5. Does the `PrivacyPolicyBanner` component rerender? Before the patch, it did. After the patch, it shouldn't.