### PR TITLE
Store: Refactor formatted-variation-name

### DIFF
--- a/client/extensions/woocommerce/lib/formatted-variation-name/index.js
+++ b/client/extensions/woocommerce/lib/formatted-variation-name/index.js
@@ -1,20 +1,19 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { map } from 'lodash';
+
 /**
  * Returns a formatted variation name for display based on attributes.
  * 
  *
- * @format
+ * @param {Object} variant the product variant option which includes the attributes key.
  * @param {String} fallbackName Fallback name to use if no attributes are passed.
  * @return {String} Formatted variation name.
  */
 
 export default function formattedVariationName( { attributes }, fallbackName = '' ) {
-	return (
-		( Array.isArray( attributes ) &&
-			attributes
-				.map( function( attribute ) {
-					return attribute.option;
-				} )
-				.join( ' - ' ) ) ||
-		fallbackName
-	);
+	return map( attributes, 'option' ).join( ' - ' ) || fallbackName;
 }

--- a/client/extensions/woocommerce/lib/formatted-variation-name/test/index.js
+++ b/client/extensions/woocommerce/lib/formatted-variation-name/test/index.js
@@ -11,6 +11,26 @@ import { expect } from 'chai';
 import formattedVariationName from '../index';
 
 describe( 'formattedVariationName', () => {
+	test( 'returns correctly when passed corrupt attributes data array', () => {
+		const malformedVariant = {
+			id: 100,
+			visible: true,
+			attributes: [ 'foo', null ],
+		};
+
+		const name = formattedVariationName( malformedVariant, 'All Variations' );
+		expect( name ).to.eql( ' - ' );
+	} );
+	test( 'returns default when passed single null variation', () => {
+		const malformedVariant = {
+			id: 100,
+			visible: true,
+			attributes: [ null ],
+		};
+
+		const name = formattedVariationName( malformedVariant, '' );
+		expect( name ).to.eql( '' );
+	} );
 	test( 'returns fallback when passed a variation with no attributes', () => {
 		const variation = {
 			id: 1,


### PR DESCRIPTION
While looking of the kibana logs for store, there are numerous instances of the following errors on product pages:

`undefined is not an object (evaluating 'r.option')`
`Cannot read property 'join' of undefined`

I have SSP'ed into a few of the reporting sites, but have been unable to reproduce - it seems the issues have magically fixed themselves! Since these all happened on product pages, and products all had variant data - `formattedVariationName` seemed like a likely culprit since it calls `.option` on variant attributes, and also does a `.join()`.

I was able to reproduce the first bug with a failing test which is included and fixed in this PR.

__To Test__
- Verify the test suite passes `npm run test-client client/extensions/woocommerce/lib/formatted-variation-name`
- And manually test a product page that has variants, verify the variant table and modal look unchanged from production:

<img width="601" alt="variant-name" src="https://user-images.githubusercontent.com/22080/34314921-26927be0-e72e-11e7-97a2-12c76df68e8c.png">

<img width="1010" alt="variant-name2" src="https://user-images.githubusercontent.com/22080/34314923-2c56e836-e72e-11e7-885b-1e44079488d8.png">
