### PR TITLE
Domains: Add notice for unavailable inbound-transfer lock status

### DIFF
--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -181,6 +181,10 @@
 		color: $gray;
 	}
 
+	&.transfer-domain-step__unavailable {
+		color: $alert-yellow;
+	}
+
 	&.transfer-domain-step__unlocked {
 		color: $alert-green;
 	}

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -30,7 +30,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 	};
 
 	state = {
-		unlocked: null,
+		unlocked: false,
 		privacy: false,
 		email: '',
 		loading: true,
@@ -159,27 +159,8 @@ class TransferDomainPrecheck extends React.PureComponent {
 			heading = translate( 'Unlock the domain.' );
 		}
 
-		let message = translate(
-			"{{notice}}We couldn't get the lock status from your current registrar.{{/notice}} If you're sure it's unlocked then you " +
-				"can continue to the next step. If your domain isn't unlocked, then the transfer won't work. {{a}}Here are instructions " +
-				'to make sure your domain is unlocked.{{/a}}',
-			{
-				components: {
-					notice: <Notice showDismiss={ false } status="is-warning" />,
-					br: <br />,
-					a: (
-						<a
-							href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK }
-							rel="noopener noreferrer"
-							target="_blank"
-						/>
-					),
-				},
-			}
-		);
-		if ( true === unlocked ) {
-			message = translate( 'Your domain is unlocked at your current registrar.' );
-		} else if ( false === unlocked ) {
+		let message = translate( 'Your domain is unlocked at your current registrar.' );
+		if ( false === unlocked ) {
 			message = translate(
 				"Your domain is locked to prevent unauthorized transfers. You'll need to unlock " +
 					'it at your current domain provider before we can move it. {{a}}Here are instructions for unlocking it{{/a}}. ' +
@@ -196,28 +177,48 @@ class TransferDomainPrecheck extends React.PureComponent {
 					},
 				}
 			);
+		} else if ( null === unlocked ) {
+			message = translate(
+				"{{notice}}We couldn't get the lock status from your current registrar.{{/notice}} If you're sure it's unlocked then you " +
+					"can continue to the next step. If your domain isn't unlocked, then the transfer won't work. {{a}}Here are " +
+					'instructions to make sure your domain is unlocked.{{/a}}',
+				{
+					components: {
+						notice: <Notice showDismiss={ false } status="is-warning" />,
+						br: <br />,
+						a: (
+							<a
+								href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK }
+								rel="noopener noreferrer"
+								target="_blank"
+							/>
+						),
+					},
+				}
+			);
 		}
+
 		const buttonText = translate( "I've unlocked my domain" );
 
-		let lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__unavailable';
-		if ( true === unlocked ) {
-			lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__unlocked';
-		} else if ( false === unlocked ) {
+		let lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__unlocked';
+		if ( false === unlocked ) {
 			lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__locked';
+		} else if ( null === unlocked ) {
+			lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__unavailable';
 		}
 
-		let lockStatusIcon = 'info';
-		if ( true === unlocked ) {
-			lockStatusIcon = 'checkmark';
-		} else if ( false === unlocked ) {
+		let lockStatusIcon = 'checkmark';
+		if ( false === unlocked ) {
 			lockStatusIcon = 'cross';
+		} else if ( null === unlocked ) {
+			lockStatusIcon = 'info';
 		}
 
-		let lockStatusText = 'Unavailable';
-		if ( true === unlocked ) {
-			lockStatusText = translate( 'Unlocked' );
-		} else if ( false === lockStatusText ) {
+		let lockStatusText = 'Unlocked';
+		if ( false === unlocked ) {
 			lockStatusText = translate( 'Locked' );
+		} else if ( null === lockStatusText ) {
+			lockStatusText = translate( 'Unavailable' );
 		}
 
 		if ( loading && ! isStepFinished ) {

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -111,6 +111,8 @@ class TransferDomainPrecheck extends React.PureComponent {
 		} );
 
 		const sectionIcon = isStepFinished ? <Gridicon icon="checkmark-circle" size={ 36 } /> : step;
+		const onButtonClick =
+			true === unlocked || null === unlocked ? this.showNextStep : this.refreshStatus;
 
 		return (
 			<Card compact>
@@ -125,15 +127,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 							<div>
 								<div className="transfer-domain-step__section-message">{ message }</div>
 								<div className="transfer-domain-step__section-action">
-									<Button
-										compact
-										onClick={
-											true === unlocked || null === unlocked
-												? this.showNextStep
-												: this.refreshStatus
-										}
-										busy={ loading }
-									>
+									<Button compact onClick={ onButtonClick } busy={ loading }>
 										{ buttonText }
 									</Button>
 									{ stepStatus }
@@ -200,24 +194,24 @@ class TransferDomainPrecheck extends React.PureComponent {
 
 		const buttonText = translate( "I've unlocked my domain" );
 
-		let lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__unlocked';
-		if ( false === unlocked ) {
+		let lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__unavailable';
+		if ( true === unlocked ) {
+			lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__unlocked';
+		} else if ( false === unlocked ) {
 			lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__locked';
-		} else if ( null === unlocked ) {
-			lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__unavailable';
 		}
 
-		let lockStatusIcon = 'checkmark';
-		if ( false === unlocked ) {
+		let lockStatusIcon = 'info';
+		if ( true === unlocked ) {
+			lockStatusIcon = 'checkmark';
+		} else if ( false === unlocked ) {
 			lockStatusIcon = 'cross';
-		} else if ( null === unlocked ) {
-			lockStatusIcon = 'info';
 		}
 
 		let lockStatusText = 'Status unavailable';
 		if ( true === unlocked ) {
 			lockStatusText = translate( 'Unlocked' );
-		} else if ( false === lockStatusText ) {
+		} else if ( false === unlocked ) {
 			lockStatusText = translate( 'Locked' );
 		}
 

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -159,33 +159,33 @@ class TransferDomainPrecheck extends React.PureComponent {
 			heading = translate( 'Unlock the domain.' );
 		}
 
-		let message = translate( 'Your domain is unlocked at your current registrar.' );
-		if ( false === unlocked ) {
+		let message = translate(
+			"{{notice}}We couldn't get the lock status of your domain from your current registrar.{{/notice}} If you're sure your " +
+				"domain is unlocked then, you can continue to the next step. If it's not unlocked, then the transfer won't work. " +
+				'{{a}}Here are instructions to make sure your domain is unlocked.{{/a}}',
+			{
+				components: {
+					notice: <Notice showDismiss={ false } status="is-warning" />,
+					br: <br />,
+					a: (
+						<a
+							href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK }
+							rel="noopener noreferrer"
+							target="_blank"
+						/>
+					),
+				},
+			}
+		);
+		if ( true === unlocked ) {
+			message = translate( 'Your domain is unlocked at your current registrar.' );
+		} else if ( false === unlocked ) {
 			message = translate(
 				"Your domain is locked to prevent unauthorized transfers. You'll need to unlock " +
 					'it at your current domain provider before we can move it. {{a}}Here are instructions for unlocking it{{/a}}. ' +
 					'It might take a few minutes for any changes to take effect.',
 				{
 					components: {
-						a: (
-							<a
-								href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK }
-								rel="noopener noreferrer"
-								target="_blank"
-							/>
-						),
-					},
-				}
-			);
-		} else if ( null === unlocked ) {
-			message = translate(
-				"{{notice}}We couldn't get the lock status from your current registrar.{{/notice}} If you're sure it's unlocked then you " +
-					"can continue to the next step. If your domain isn't unlocked, then the transfer won't work. {{a}}Here are " +
-					'instructions to make sure your domain is unlocked.{{/a}}',
-				{
-					components: {
-						notice: <Notice showDismiss={ false } status="is-warning" />,
-						br: <br />,
 						a: (
 							<a
 								href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK }
@@ -214,11 +214,11 @@ class TransferDomainPrecheck extends React.PureComponent {
 			lockStatusIcon = 'info';
 		}
 
-		let lockStatusText = 'Unlocked';
-		if ( false === unlocked ) {
+		let lockStatusText = 'Status unavailable';
+		if ( true === unlocked ) {
+			lockStatusText = translate( 'Unlocked' );
+		} else if ( false === lockStatusText ) {
 			lockStatusText = translate( 'Locked' );
-		} else if ( null === lockStatusText ) {
-			lockStatusText = translate( 'Unavailable' );
 		}
 
 		if ( loading && ! isStepFinished ) {

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -30,7 +30,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 	};
 
 	state = {
-		unlocked: false,
+		unlocked: null,
 		privacy: false,
 		email: '',
 		loading: true,
@@ -71,7 +71,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 			}
 
 			// Reset steps if domain became locked again
-			if ( ! result.unlocked ) {
+			if ( false === result.unlocked ) {
 				this.resetSteps();
 			}
 
@@ -127,7 +127,11 @@ class TransferDomainPrecheck extends React.PureComponent {
 								<div className="transfer-domain-step__section-action">
 									<Button
 										compact
-										onClick={ unlocked ? this.showNextStep : this.refreshStatus }
+										onClick={
+											true === unlocked || null === unlocked
+												? this.showNextStep
+												: this.refreshStatus
+										}
 										busy={ loading }
 									>
 										{ buttonText }
@@ -148,35 +152,73 @@ class TransferDomainPrecheck extends React.PureComponent {
 		const step = 1;
 		const isStepFinished = currentStep > step;
 
-		const heading = unlocked
-			? translate( 'Domain is unlocked.' )
-			: translate( 'Unlock the domain.' );
-		const message = unlocked
-			? translate( 'Your domain is unlocked at your current registrar.' )
-			: translate(
-					"Your domain is locked to prevent unauthorized transfers. You'll need to unlock " +
-						'it at your current domain provider before we can move it. {{a}}Here are instructions for unlocking it{{/a}}. ' +
-						'It might take a few minutes for any changes to take effect.',
-					{
-						components: {
-							a: (
-								<a
-									href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK }
-									rel="noopener noreferrer"
-									target="_blank"
-								/>
-							),
-						},
-					}
-				);
+		let heading = translate( 'Lock status unavailable.' );
+		if ( true === unlocked ) {
+			heading = translate( 'Domain is unlocked.' );
+		} else if ( false === unlocked ) {
+			heading = translate( 'Unlock the domain.' );
+		}
+
+		let message = translate(
+			"{{notice}}We couldn't get the lock status from your current registrar.{{/notice}} If you're sure it's unlocked then you " +
+				"can continue to the next step. If your domain isn't unlocked, then the transfer won't work. {{a}}Here are instructions " +
+				'to make sure your domain is unlocked.{{/a}}',
+			{
+				components: {
+					notice: <Notice showDismiss={ false } status="is-warning" />,
+					br: <br />,
+					a: (
+						<a
+							href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK }
+							rel="noopener noreferrer"
+							target="_blank"
+						/>
+					),
+				},
+			}
+		);
+		if ( true === unlocked ) {
+			message = translate( 'Your domain is unlocked at your current registrar.' );
+		} else if ( false === unlocked ) {
+			message = translate(
+				"Your domain is locked to prevent unauthorized transfers. You'll need to unlock " +
+					'it at your current domain provider before we can move it. {{a}}Here are instructions for unlocking it{{/a}}. ' +
+					'It might take a few minutes for any changes to take effect.',
+				{
+					components: {
+						a: (
+							<a
+								href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK }
+								rel="noopener noreferrer"
+								target="_blank"
+							/>
+						),
+					},
+				}
+			);
+		}
 		const buttonText = translate( "I've unlocked my domain" );
 
-		let lockStatusClasses = unlocked
-			? 'transfer-domain-step__lock-status transfer-domain-step__unlocked'
-			: 'transfer-domain-step__lock-status transfer-domain-step__locked';
+		let lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__unavailable';
+		if ( true === unlocked ) {
+			lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__unlocked';
+		} else if ( false === unlocked ) {
+			lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__locked';
+		}
 
-		let lockStatusIcon = unlocked ? 'checkmark' : 'cross';
-		let lockStatusText = unlocked ? translate( 'Unlocked' ) : translate( 'Locked' );
+		let lockStatusIcon = 'info';
+		if ( true === unlocked ) {
+			lockStatusIcon = 'checkmark';
+		} else if ( false === unlocked ) {
+			lockStatusIcon = 'cross';
+		}
+
+		let lockStatusText = 'Unavailable';
+		if ( true === unlocked ) {
+			lockStatusText = translate( 'Unlocked' );
+		} else if ( false === lockStatusText ) {
+			lockStatusText = translate( 'Locked' );
+		}
 
 		if ( loading && ! isStepFinished ) {
 			lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__checking';


### PR DESCRIPTION
Some registrars don't return the EPP status codes for domains. If the unlock status of a domain is unavailable or can't otherwise be determined, we should warn the user but allow them to bypass the step.

<img width="741" alt="transfer_a_domain_ _a8c_test_site_ _wordpress_com" src="https://user-images.githubusercontent.com/1379730/34322521-156d140a-e7f7-11e7-99d8-94e13c56c415.png">

To test:

- Hack the inbound-transfer-status endpoint to return `null` for the unlocked status.
- Make sure this step shows the lock status unavailable message.
- Make sure that clicking the "I've unlocked my domain" button allows you to continue through to the rest of the steps.

Make sure that the pre-check page still works for both `false` and `true` unlocked statuses.
