### PR TITLE
Update the remaining CONCIERGE_BOOK_APPOINTMENT as CONCIERGE_APPOINTMENT_CREATE.

### DIFF
--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/index.js
@@ -12,7 +12,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { updateConciergeBookingStatus } from 'state/concierge/actions';
 import { errorNotice } from 'state/notices/actions';
-import { CONCIERGE_BOOK_APPOINTMENT } from 'state/action-types';
+import { CONCIERGE_APPOINTMENT_CREATE } from 'state/action-types';
 import { CONCIERGE_STATUS_BOOKED, CONCIERGE_STATUS_BOOKING } from 'me/concierge/constants';
 import fromApi from './from-api';
 
@@ -50,7 +50,7 @@ export const handleBookingError = ( { dispatch } ) => {
 };
 
 export default {
-	[ CONCIERGE_BOOK_APPOINTMENT ]: [
+	[ CONCIERGE_APPOINTMENT_CREATE ]: [
 		dispatchRequest( bookConciergeAppointment, markSlotAsBooked, handleBookingError, { fromApi } ),
 	],
 };

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/test/index.js
@@ -6,7 +6,7 @@
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { bookConciergeAppointment, handleBookingError, markSlotAsBooked, toApi } from '../';
 import { updateConciergeBookingStatus } from 'state/concierge/actions';
-import { CONCIERGE_BOOK_APPOINTMENT } from 'state/action-types';
+import { CONCIERGE_APPOINTMENT_CREATE } from 'state/action-types';
 
 // we are mocking impure-lodash here, so that conciergeShiftsFetchError() will contain the expected id in the tests
 jest.mock( 'lib/impure-lodash', () => ( {
@@ -18,7 +18,7 @@ describe( 'wpcom-api', () => {
 		test( 'bookConciergeAppointment()', () => {
 			const dispatch = jest.fn();
 			const action = {
-				type: CONCIERGE_BOOK_APPOINTMENT,
+				type: CONCIERGE_APPOINTMENT_CREATE,
 				scheduleId: 123,
 				beginTimestamp: 1234567890,
 				customerId: 1,


### PR DESCRIPTION
## Summary
This looks like something we missed in 4e6fc102. This PR simply updates the rest to the new action type.

## Test Plan
`npm run test-client concierge`.