### PR TITLE
Editor: Fix impossible to click tinymce inline toolbar buttons in RTL mode

### DIFF
--- a/client/components/tinymce/plugins/wpcom/plugin.js
+++ b/client/components/tinymce/plugins/wpcom/plugin.js
@@ -397,7 +397,9 @@ function wpcomPlugin( editor ) {
 				mceIframe = document.getElementById( editor.id + '_ifr' ),
 				mceToolbar,
 				mceStatusbar,
-				wpStatusbar;
+				wpStatusbar,
+				isChromeRtl =
+					editor.getParam( 'directionality' ) === 'rtl' && /Chrome/.test( navigator.userAgent );
 
 			if ( container ) {
 				mceToolbar = tinymce.$( '.mce-toolbar-grp', container )[ 0 ];
@@ -650,6 +652,9 @@ function wpcomPlugin( editor ) {
 
 				toolbar.on( 'show', function() {
 					this.reposition();
+					if ( isChromeRtl ) {
+						editor.$( '.mce-widget.mce-tooltip', document.body ).addClass( 'wp-hide-mce-tooltip' );
+					}
 				} );
 
 				toolbar.on( 'keydown', function( event ) {

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -193,6 +193,11 @@
 	opacity: 1 !important;
 }
 
+/* Don't show the tooltip. Used in Chrome RTL, see https://github.com/Automattic/wp-calypso/issues/19189 */
+.mce-tooltip.wp-hide-mce-tooltip {
+	display: none !important;
+}
+
 .mce-tooltip-inner {
 	box-shadow: none !important;
 	background: $gray-dark !important;


### PR DESCRIPTION
This is a port of core's https://core.trac.wordpress.org/changeset/41643 (props @azaozz)
It fixes #19189 which occurs in recent versions of chrome in RTL mode.
