### PR TITLE
Switch default reducer state to null

### DIFF
--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -18,7 +18,7 @@ import switchLocale from 'lib/i18n-utils/switch-locale';
 
 class LocaleSuggestions extends Component {
 	static propTypes = {
-		locale: PropTypes.string.isRequired,
+		locale: PropTypes.string,
 		path: PropTypes.string.isRequired,
 	};
 

--- a/client/state/ui/language/reducer.js
+++ b/client/state/ui/language/reducer.js
@@ -17,7 +17,7 @@ import { localeSlugSchema } from './schema';
  *
  */
 export const localeSlug = createReducer(
-	false,
+	null,
 	{
 		[ LOCALE_SET ]: ( state, action ) => action.localeSlug,
 	},

--- a/client/state/ui/language/schema.js
+++ b/client/state/ui/language/schema.js
@@ -1,4 +1,2 @@
 /** @format */
-export const localeSlugSchema = {
-	anyOf: [ { type: 'string' }, { enum: [ false ] } ],
-};
+export const localeSlugSchema = { type: [ 'string', 'null' ] };

--- a/client/state/ui/language/test/reducer.js
+++ b/client/state/ui/language/test/reducer.js
@@ -13,9 +13,26 @@ import { LOCALE_SET } from 'state/action-types';
 
 describe( 'reducer', () => {
 	describe( 'localeSlug', () => {
-		test( 'returns an appropriate localeSlug', () => {
+		test( 'returns default state with undefined state and empty action', () => {
+			expect( localeSlug( undefined, {} ) ).to.be.null;
+		} );
+
+		test( 'returns previous state with empty action', () => {
+			expect( localeSlug( 'fr', {} ) ).to.eql( 'fr' );
+		} );
+
+		test( 'returns default state with undefined state and invalid action type', () => {
+			expect( localeSlug( undefined, { type: 'foobar' } ) ).to.be.null;
+		} );
+
+		test( 'returns undefined with undefined state and missing slug', () => {
+			expect( localeSlug( undefined, { type: LOCALE_SET } ) ).to.be.undefined;
+		} );
+
+		test( 'returns new state with valid slug', () => {
 			const state = 'en';
 			const action = { type: LOCALE_SET, localeSlug: 'he' };
+
 			expect( localeSlug( state, action ) ).to.eql( 'he' );
 		} );
 	} );


### PR DESCRIPTION
Followup #21020
Switch default reducer state to null to better reflect the value is missing
and easier schema definition.


### Testing Instructions ( from #19319 which originally set the default state to `false` )
- Boot the app locally
- Go to http://calypso.localhost:3000/me/account
- Switch the language of your account and save multiple times, check that it works correctly
- While logged in navigate to http://calypso.localhost:3000/log-in/fr http://calypso.localhost:3000/log-in/es and http://calypso.localhost:3000/log-in/he and check that the page locale is respected
 - While logged out try going to http://calypso.localhost:3000/log-in/fr http://calypso.localhost:3000/log-in/es and http://calypso.localhost:3000/log-in/he and check that the locale is respected
- Edit `config/development.json` and set `"wpcom-user-bootstrap": true`. Also edit `config/secrets.json` and add the entry `"wordpress_logged_in_cookie": "<current value of your wordpress_logged_in cookie>"`.
- Reboot the app, go back to http://calypso.localhost:3000/me/account and try switching languages, also try to load the log in page in multiple languages while logged in and logged out.

You can also run unit tests with:

```
npm run test-client client/state/ui/language
```