### PR TITLE
Editor: Fix visual issues in taxonomy selector in RTL

### DIFF
--- a/client/blocks/term-tree-selector/style.scss
+++ b/client/blocks/term-tree-selector/style.scss
@@ -103,3 +103,8 @@ input[type=checkbox].term-tree-selector__input {
 		display: block;
 	}
 }
+
+/* Fix for https://github.com/bvaughn/react-virtualized/issues/454 */
+.term-tree-selector__results {
+	direction: ltr !important;
+}


### PR DESCRIPTION
`term-tree-selector` uses `react-virtualized/List` which defaults to setting the direction to `ltr` (see  https://github.com/bvaughn/react-virtualized/issues/454)

This fixes it by explicitly setting the direction based on Calyso's direction (in RTL mode the `direction:ltr` is automatically replaced with `direction:rtl`.)

Fixes #11954

**Before:**
<img width="255" alt="screen shot 2017-12-25 at 13 37 15" src="https://user-images.githubusercontent.com/844866/34339204-3dfc1f28-e979-11e7-8803-6ce2b160d20c.png">

**After:** 
<img width="263" alt="screen shot 2017-12-25 at 13 37 23" src="https://user-images.githubusercontent.com/844866/34339205-43c0bee6-e979-11e7-85c9-7dbf3d1f256a.png">
