### PR TITLE
Reader: fix follow list in RTL mode

### DIFF
--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -13,6 +13,11 @@
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes aliasing in Safari
 }
 
+/* Fix for https://github.com/bvaughn/react-virtualized/issues/454 */
+.following-manage__subscriptions-list .ReactVirtualized__List {
+	direction: ltr !important;
+}
+
 .following-manage__subscriptions-list .reader-subscription-list-item__options {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
Similarly to #21094, the list uses `react-virtualized/List` which defaults to setting the direction to `ltr` (see  https://github.com/bvaughn/react-virtualized/issues/454)

In this case, the result is that the blog list is faded on the wrong side, making the blog titles unreadable.

This fixes the design in RTL by explicitly setting the direction based on Calyso's direction (in RTL mode the direction:ltr is automatically replaced with direction:rtl).

**Before:**
<img width="855" alt="screen shot 2017-12-25 at 15 58 16" src="https://user-images.githubusercontent.com/844866/34340498-755b5290-e98d-11e7-9779-2cd7d3084c10.png">

**After:**
<img width="753" alt="screen shot 2017-12-25 at 16 02 08" src="https://user-images.githubusercontent.com/844866/34340499-76f9b0d8-e98d-11e7-8a8c-21d6aff77037.png">
