### PR TITLE
Card: Fix card link indicator gridicon in RTL mode

### DIFF
--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -50,14 +50,22 @@
 	}
 }
 
+
 // Clickable Card
 .card__link-indicator {
 	color: lighten( $gray, 20% );
 	display: block;
 	height: 100%;
 	position: absolute;
-		top: 0;
-		right: 16px;
+	top: 0;
+	right: 16px;
+
+	html[dir="rtl"] & {
+		&.gridicons-chevron-right {
+			transform: scaleX( -1 );
+		}
+	}
+
 }
 
 a.card:hover {


### PR DESCRIPTION
The card will output a `chevron-right` gridicon when it's an internal link.
In RTL mode, the icon needs to be flipped.

Normally, I'd prefer to change the icon name in the code depending on RTL mode (i.e #21093), but `Card` isn't connected to the state, and it's not worth connecting it. Instead, we're flipping the icon with CSS. 
 
**Before example:**
<img width="969" alt="screen shot 2017-12-25 at 16 43 47" src="https://user-images.githubusercontent.com/844866/34340790-433ad816-e993-11e7-92d3-3059bc9a8386.png">

**After example:**
<img width="963" alt="screen shot 2017-12-25 at 16 43 22" src="https://user-images.githubusercontent.com/844866/34340792-4815b658-e993-11e7-82b0-ec9001af7f14.png">

