### PR TITLE
Components: fix header cake arrow in RTL

### DIFF
--- a/client/components/header-cake/style.scss
+++ b/client/components/header-cake/style.scss
@@ -41,6 +41,12 @@
 			margin-right: 4px;
 		}
 	}
+
+	html[dir="rtl"] & {
+		.gridicons-arrow-left {
+			transform: scaleX( -1 );
+		}
+	}
 }
 
 .header-cake__title {


### PR DESCRIPTION
Similar to #21097, the header-cake output an arrow-left gridicon for "back". This icon should point right in RTL mode. 

Normally, I'd prefer to change the icon name in the code depending on RTL mode (i.e #21093), but we're not connected to the state, and it's not worth connecting it. Instead, we're flipping the icon with CSS.
