### PR TITLE
i18n: localize momentjs dates properly

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -391,7 +391,7 @@ class PostShare extends Component {
 			return (
 				<Notice status="is-success" onDismissClick={ this.dismiss }>
 					{ translate( "We'll share your post on %s.", {
-						args: this.props.scheduledAt.format( 'ddd, MMMM Do YYYY, h:mm:ss a' ),
+						args: this.props.scheduledAt.format( 'LLLL' ),
 					} ) }
 				</Notice>
 			);

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -49,7 +49,7 @@ class ApplicationPasswordsItem extends React.Component {
 					<h2 className="application-password-item__name">{ password.name }</h2>
 					<p className="application-password-item__generated">
 						{ this.props.translate( 'Generated on %s', {
-							args: this.props.moment( password.generated ).format( 'MMM DD, YYYY @ h:mm a' ),
+							args: this.props.moment( password.generated ).format( 'LL @ LT' ),
 						} ) }
 					</p>
 				</div>

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -49,7 +49,7 @@ class ApplicationPasswordsItem extends React.Component {
 					<h2 className="application-password-item__name">{ password.name }</h2>
 					<p className="application-password-item__generated">
 						{ this.props.translate( 'Generated on %s', {
-							args: this.props.moment( password.generated ).format( 'LL @ LT' ),
+							args: this.props.moment( password.generated ).format( 'll @ LT' ),
 						} ) }
 					</p>
 				</div>

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -49,7 +49,7 @@ class ApplicationPasswordsItem extends React.Component {
 					<h2 className="application-password-item__name">{ password.name }</h2>
 					<p className="application-password-item__generated">
 						{ this.props.translate( 'Generated on %s', {
-							args: this.props.moment( password.generated ).format( 'll @ LT' ),
+							args: this.props.moment( password.generated ).format( 'lll' ),
 						} ) }
 					</p>
 				</div>

--- a/client/me/billing-history/table-rows.js
+++ b/client/me/billing-history/table-rows.js
@@ -8,7 +8,7 @@ import { moment } from 'i18n-calypso';
 import { flatten, isDate, omit, some, values, without } from 'lodash';
 
 function formatDate( date ) {
-	return moment( date ).format( 'MMM D, YYYY' );
+	return moment( date ).format( 'll' );
 }
 
 function getSearchableStrings( transaction ) {

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -149,7 +149,7 @@ class ConnectedApplicationItem extends React.Component {
 							),
 						},
 						args: {
-							date: this.props.moment( authorized ).format( 'MMM D, YYYY @ h:mm a' ),
+							date: this.props.moment( authorized ).format( 'LL @ LT' ),
 						},
 					}
 				) }

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -149,7 +149,7 @@ class ConnectedApplicationItem extends React.Component {
 							),
 						},
 						args: {
-							date: this.props.moment( authorized ).format( 'LL @ LT' ),
+							date: this.props.moment( authorized ).format( 'll @ LT' ),
 						},
 					}
 				) }

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -149,7 +149,7 @@ class ConnectedApplicationItem extends React.Component {
 							),
 						},
 						args: {
-							date: this.props.moment( authorized ).format( 'll @ LT' ),
+							date: this.props.moment( authorized ).format( 'lll' ),
 						},
 					}
 				) }

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -142,7 +142,7 @@ class Security2faBackupCodesList extends React.Component {
 	};
 
 	getBackupCodeHTML = codes => {
-		const datePrinted = this.props.moment().format( 'll @ LT' );
+		const datePrinted = this.props.moment().format( 'lll' );
 		let row;
 		let html = '<html><head><title>';
 

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -142,7 +142,7 @@ class Security2faBackupCodesList extends React.Component {
 	};
 
 	getBackupCodeHTML = codes => {
-		const datePrinted = this.props.moment().format( 'LL @ LT' );
+		const datePrinted = this.props.moment().format( 'll @ LT' );
 		let row;
 		let html = '<html><head><title>';
 

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -142,7 +142,7 @@ class Security2faBackupCodesList extends React.Component {
 	};
 
 	getBackupCodeHTML = codes => {
-		const datePrinted = this.props.moment().format( 'MMM DD, YYYY @ h:mm a' );
+		const datePrinted = this.props.moment().format( 'LL @ LT' );
 		let row;
 		let html = '<html><head><title>';
 


### PR DESCRIPTION
We have many places in the code where we use `moment.format( 'MMM D, YYYY')` or similar formats.

Unless we use the pre-localized https://momentjs.com/docs/#/i18n/ from momentjs (i.e `LT LTS L LL LLL LLLL` etc) those dates won't be localized (unless the custom format is passed through `translate()`). 

This PR fixes this in three places:

**1.The schedule post share**
Before (locale: es):
<img width="697" alt="screen shot 2017-12-25 at 18 00 03" src="https://user-images.githubusercontent.com/844866/34341327-2c5426d8-e99e-11e7-9859-3d6b64e47cbc.png">

After (locale: es):
<img width="692" alt="screen shot 2017-12-25 at 17 57 52" src="https://user-images.githubusercontent.com/844866/34341333-381bab08-e99e-11e7-800a-51b2a6366f20.png">

**2. Billing history (purchase list)**
Before (locale: es):
<img width="705" alt="screen shot 2017-12-25 at 17 45 34" src="https://user-images.githubusercontent.com/844866/34341335-4c14d30a-e99e-11e7-9a2a-73d32b7c6e09.png">
After (locale: es):
<img width="702" alt="screen shot 2017-12-25 at 17 53 36" src="https://user-images.githubusercontent.com/844866/34341339-57710d22-e99e-11e7-9dfb-c4aa80d7849f.png">

**3. 2fa tokens and connected applications list**
Before (locale: es):
<img width="666" alt="screen shot 2017-12-25 at 17 31 58" src="https://user-images.githubusercontent.com/844866/34341350-81f76c3a-e99e-11e7-9651-478ff1076ed6.png">

After (locale: es):
<img width="672" alt="screen shot 2017-12-25 at 17 55 57" src="https://user-images.githubusercontent.com/844866/34341354-8be19cac-e99e-11e7-85e1-87a6c09757ec.png">

  