### PR TITLE
Editor: Fix flash of unstyled content when loading editor

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -35,6 +35,11 @@ import PostActionCounts from 'my-sites/post-type-list/post-action-counts';
 import PostActionsEllipsisMenu from 'my-sites/post-type-list/post-actions-ellipsis-menu';
 import PostTypeSiteInfo from 'my-sites/post-type-list/post-type-site-info';
 import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
+import { preload } from 'sections-preload';
+
+function preloadEditor() {
+	preload( 'post-editor' );
+}
 
 class PostItem extends React.Component {
 	hideCurrentSharePanel = () => {
@@ -138,7 +143,7 @@ class PostItem extends React.Component {
 							{ isAllSitesModeSelected && <PostTypeSiteInfo globalId={ globalId } /> }
 							{ isAuthorVisible && <PostTypePostAuthor globalId={ globalId } /> }
 						</div>
-						<h1 className="post-item__title" onClick={ this.clickHandler( 'title' ) }>
+						<h1 className="post-item__title" onClick={ this.clickHandler( 'title' ) } onMouseOver={ preloadEditor }>
 							{ ! externalPostLink && (
 								<a
 									href={ isPlaceholder || multiSelectEnabled ? null : postUrl }

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -33,7 +33,6 @@ import { isFrontPage, isPostsPage } from 'state/pages/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { setPreviewUrl } from 'state/ui/preview/actions';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
-import { getPreviewURL } from 'lib/posts/utils';
 
 const recordEvent = partial( recordGoogleEvent, 'Pages' );
 
@@ -473,7 +472,7 @@ const mapState = ( state, props ) => {
 		isFrontPage: isFrontPage( state, pageSiteId, props.page.ID ),
 		isPostsPage: isPostsPage( state, pageSiteId, props.page.ID ),
 		isPreviewable,
-		previewURL: getPreviewURL( site, props.page ),
+		previewURL: utils.getPreviewURL( site, props.page ),
 		site,
 		siteSlugOrId,
 	};

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -410,6 +410,7 @@ class Page extends Component {
 								: translate( 'View %(title)s', { textOnly: true, args: { title: page.title } } )
 						}
 						onClick={ this.props.recordPageTitle }
+						onMouseOver={ preloadEditor }
 						data-tip-target={ 'page-' + page.slug }
 					>
 						{ depthIndicator }

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -17,6 +17,11 @@ import { bumpStatGenerator } from './utils';
 import { getPost } from 'state/posts/selectors';
 import { canCurrentUserEditPost } from 'state/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
+import { preload } from 'sections-preload';
+
+function preloadEditor() {
+	preload( 'post-editor' );
+}
 
 function PostActionsEllipsisMenuEdit( { translate, canEdit, status, editUrl, bumpStat } ) {
 	if ( 'trash' === status || ! canEdit ) {
@@ -24,7 +29,7 @@ function PostActionsEllipsisMenuEdit( { translate, canEdit, status, editUrl, bum
 	}
 
 	return (
-		<PopoverMenuItem href={ editUrl } onClick={ bumpStat } icon="pencil">
+		<PopoverMenuItem href={ editUrl } onClick={ bumpStat } icon="pencil" onMouseOver={ preloadEditor }>
 			{ translate( 'Edit', { context: 'verb' } ) }
 		</PopoverMenuItem>
 	);


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/19396 that fixes https://github.com/Automattic/wp-calypso/issues/18703 in order to get rid of a [flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) that would otherwise happen the first time the editor is loaded, something quite noticeable with slow connections. It does so by pre-loading the `post-editor` section when hovering links leading to it.

#### Testing instructions

Depending on your Internet connection, you may want to set [throttling](https://developers.google.com/web/tools/chrome-devtools/network-performance/reference#throttling) to `Slow 3G` - or something even slower - in the `Network` panel in the Chrome devtools. 

1. Run `git checkout fix/editor-fouc` and start your server, or open a [live branch](https://calypso.live/?branch=fix/editor-fouc)

##### Scenario 1

2. Open the [`Site Pages` page](http://calypso.localhost:3000/pages) in a new tab
3. Click the name of any page
4. Assert that the editor loads with the correct styles applied right away

##### Scenario 2

2. Open the [`Blog Posts` page](http://calypso.localhost:3000/posts) in a new tab
3. Click the name of any post
4. Assert that the editor loads with the correct styles applied right away

##### Scenario 3

2. Open the [`Blog Posts` page](http://calypso.localhost:3000/posts) in a new tab
3. Click the `Edit` menu item that appears when you click the three dots in front of each page
4. Assert that the editor loads with the correct styles applied right away

#### Reviews

- [ ] Code
- [ ] Product