### PR TITLE
Jetpack: Free jetpack plan "my-plan" card

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -391,7 +391,10 @@ export const PLANS_LIST = {
 		getAudience: () => i18n.translate( 'Best for students' ),
 		getProductId: () => 2002,
 		getStoreSlug: () => PLAN_JETPACK_FREE,
-
+		getTagline: () =>
+			i18n.translate(
+				"Upgrade your site to access all of Jetpack's features, and give your site a boost."
+			),
 		getDescription: () =>
 			i18n.translate(
 				'The features most needed by WordPress sites' +

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -393,7 +393,7 @@ export const PLANS_LIST = {
 		getStoreSlug: () => PLAN_JETPACK_FREE,
 		getTagline: () =>
 			i18n.translate(
-				"Upgrade your site to access all of Jetpack's features, and give your site a boost."
+				'Upgrade your site to access additional features, including spam protection, backups, and priority support.'
 			),
 		getDescription: () =>
 			i18n.translate(

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -135,7 +135,10 @@ class CurrentPlanHeader extends Component {
 						</div>
 						{ this.renderPurchaseInfo() }
 						{ includePlansLink && (
-							<Button href={ '/plans/' + selectedSite.slug }>
+							<Button
+								className="current-plan__compare-plans"
+								href={ '/plans/' + selectedSite.slug }
+							>
 								{ translate( 'Compare Plans' ) }
 							</Button>
 						) }

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -100,10 +100,12 @@ class CurrentPlanHeader extends Component {
 	render() {
 		const {
 			currentPlanSlug,
+			includePlansLink,
 			isAutomatedTransfer,
 			isPlaceholder,
 			title,
 			tagLine,
+			translate,
 			selectedSite,
 		} = this.props;
 
@@ -132,6 +134,11 @@ class CurrentPlanHeader extends Component {
 							</h2>
 						</div>
 						{ this.renderPurchaseInfo() }
+						{ includePlansLink && (
+							<Button href={ '/plans/' + selectedSite.slug }>
+								{ translate( 'Compare Plans' ) }
+							</Button>
+						) }
 					</div>
 				</div>
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -18,6 +18,7 @@ import {
 	isCurrentPlanExpiring,
 	isRequestingSitePlans,
 } from 'state/sites/plans/selectors';
+import { isFreeJetpackPlan } from 'lib/products-values';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import DocumentHead from 'components/data/document-head';
@@ -98,7 +99,6 @@ class CurrentPlan extends Component {
 
 		const shouldQuerySiteDomains = selectedSiteId && shouldShowDomainWarnings;
 		const showDomainWarnings = hasDomainsLoaded && shouldShowDomainWarnings;
-
 		return (
 			<Main className="current-plan" wideLayout>
 				<SidebarNavigation />
@@ -135,6 +135,7 @@ class CurrentPlan extends Component {
 						currentPlan={ currentPlan }
 						isExpiring={ isExpiring }
 						isAutomatedTransfer={ isAutomatedTransfer }
+						includePlansLink={ currentPlan && isFreeJetpackPlan( currentPlan ) }
 					/>
 					<ProductPurchaseFeaturesList plan={ currentPlanSlug } isPlaceholder={ isLoading } />
 				</ProductPurchaseFeatures>

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -113,3 +113,7 @@
 .current-plan__header-expires-in {
 	color: $gray-text-min;
 }
+
+.current-plan__compare-plans {
+	margin: 16px 0 0;
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/21052
This PR changes the tagline used in "my plan" page when the site has a jetpack free plan. It also includes a "compare plans" button that takes you to the plans page

![image](https://user-images.githubusercontent.com/1554855/34355332-c7157c76-ea34-11e7-8335-cd4245eba944.png)

how to test
========
0. You need a connected jetpack site with a free plan
1. Go to https://calypso.live/plans/my-plan?branch=fix/update-jetpack-free-tagline (or http://calypso.localhost:3000/plans/my-plan/) and select said site (If you get redirected directly to the plans page, click on "my plan" )
2. You should see the new tagline and the button