### PR TITLE
Rewind: disable menu item for backup creation based on Rewind availability

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -525,7 +525,9 @@ class ActivityLog extends Component {
 		const disableRestore =
 			includes( [ 'queued', 'running' ], get( this.props, [ 'restoreProgress', 'status' ] ) ) ||
 			'active' !== rewindState.state;
-		const disableBackup = 0 <= get( this.props, [ 'backupProgress', 'progress' ], -Infinity );
+		const disableBackup =
+			0 <= get( this.props, [ 'backupProgress', 'progress' ], -Infinity ) ||
+			'active' !== rewindState.state;
 
 		const restoreConfirmDialog = requestedRestore && (
 			<ActivityLogConfirmDialog


### PR DESCRIPTION
A new condition was added in https://github.com/Automattic/wp-calypso/commit/cc06dbd66d807895c9f82fb82ffabf10fedcf4f5 to hide the restore menu item but it wasn't added to backups. This PR adds that condition to backups too, so when a site doesn't have Rewind available for some reason, the menu item will be disabled.

#### Before

<img width="240" alt="captura de pantalla 2017-12-26 a la s 12 52 07" src="https://user-images.githubusercontent.com/1041600/34360123-76034a7c-ea3c-11e7-9722-820feb900aa5.png">

#### After

<img width="259" alt="captura de pantalla 2017-12-26 a la s 12 51 49" src="https://user-images.githubusercontent.com/1041600/34360129-7aff6efc-ea3c-11e7-8d18-a13e8c773cae.png">
