### PR TITLE
Editor: Fix flash of unstyled content when loading editor

### DIFF
--- a/client/my-sites/post-type-list/empty-content.jsx
+++ b/client/my-sites/post-type-list/empty-content.jsx
@@ -17,6 +17,11 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import EmptyContent from 'components/empty-content';
+import { preload } from 'sections-preload';
+
+function preloadEditor() {
+	preload( 'post-editor' );
+}
 
 function PostTypeListEmptyContent( { siteId, translate, status, typeObject, editPath } ) {
 	let title, action;
@@ -38,6 +43,7 @@ function PostTypeListEmptyContent( { siteId, translate, status, typeObject, edit
 				title={ title }
 				action={ action }
 				actionURL={ editPath }
+				actionHoverCallback={ preloadEditor }
 				illustration="/calypso/images/pages/illustration-pages.svg"
 				illustrationWidth={ 150 }
 			/>


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/19396 and https://github.com/Automattic/wp-calypso/pull/21101 that gets rid of a [flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) that would otherwise happen the first time the editor is loaded when clicking the `Add New Post` button on the `Blog Posts` page.

#### Testing instructions

1. Run `git checkout fix/editor-fouc` and start your server, or open a [live branch](https://calypso.live/?branch=fix/editor-fouc)
2. Open the [`Blog Posts` page](http://calypso.localhost:3000/posts) in a new tab
3. Click any subsection (e.g. `Drafts`) that doesn't have any post
4. Click the `Add New Post` button that is displayed below `No posts found.`
5. Assert that the editor loads with the correct styles applied right away

#### Reviews

- [ ] Code
- [ ] Product