### PR TITLE
Jetpack: Change text and layout in my-plan's HE card for jetpack free…

### DIFF
--- a/client/components/happiness-support/README.md
+++ b/client/components/happiness-support/README.md
@@ -1,7 +1,7 @@
 Happiness Support
 ===============
 
-This component renders a card presenting our support resources, including links to the support form and documentation. It can also render a button to open a Live chat window if the prop `showLiveChatButton` is `true`. 
+This component renders a card presenting our support resources, including links to the support form and documentation. It can also render a button to open a Live chat window if the prop `showLiveChatButton` is `true`.
 
 ## Usage
 
@@ -23,5 +23,6 @@ export default () => {
 ## Props
 
 - *isJetpack* (boolean) – Indicates that the Happiness Support card is related to a Jetpack Plan.
+- *isJetpackFreePlan* (boolean) – Indicates that the Happiness Support card is related to a Jetpack Free Plan.
 - *liveChatButtonEventName* (string) – event name that will be recorded when the `HappychatButton` is clicked.
 - *showLiveChatButton* (boolean) – Whether to show a `HappychatButton` instead of the support link `Button`

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -62,12 +62,30 @@ export class HappinessSupport extends Component {
 				);
 	}
 
-	renderContactButton() {
-		const { isJetpackFreePlan } = this.props;
+	getSupportButtons() {
+		const { isJetpackFreePlan, liveChatAvailable, showLiveChatButton } = this.props;
+
 		if ( isJetpackFreePlan ) {
-			return;
+			return (
+				<div className="happiness-support__buttons">
+					{ this.renderSupportButton() }
+					{ this.renderContactButton() }
+				</div>
+			);
 		}
 
+		return (
+			<div className="happiness-support__buttons">
+				{ showLiveChatButton && <HappychatConnection /> }
+				{ showLiveChatButton && liveChatAvailable
+					? this.renderLiveChatButton()
+					: this.renderContactButton() }
+				{ this.renderSupportButton() }
+			</div>
+		);
+	}
+
+	renderContactButton() {
 		let url = support.CALYPSO_CONTACT,
 			target = '';
 
@@ -126,7 +144,6 @@ export class HappinessSupport extends Component {
 		const classes = {
 			'is-placeholder': this.props.isPlaceholder,
 		};
-		const { liveChatAvailable, showLiveChatButton } = this.props;
 
 		return (
 			<div className={ classNames( 'happiness-support', classes ) }>
@@ -136,13 +153,7 @@ export class HappinessSupport extends Component {
 
 				<p className="happiness-support__text">{ this.getSupportText() }</p>
 
-				<div className="happiness-support__buttons">
-					{ showLiveChatButton && <HappychatConnection /> }
-					{ showLiveChatButton && liveChatAvailable
-						? this.renderLiveChatButton()
-						: this.renderContactButton() }
-					{ this.renderSupportButton() }
-				</div>
+				{ this.getSupportButtons() }
 			</div>
 		);
 	}

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -23,6 +23,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 export class HappinessSupport extends Component {
 	static propTypes = {
 		isJetpack: PropTypes.bool,
+		isJetpackFreePlan: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
 		liveChatButtonEventName: PropTypes.string,
 		showLiveChatButton: PropTypes.bool,
@@ -38,7 +39,35 @@ export class HappinessSupport extends Component {
 		}
 	};
 
+	getHeadingText() {
+		const { isJetpackFreePlan, translate } = this.props;
+		return isJetpackFreePlan
+			? translate( 'Find answers in our documentation' )
+			: translate( 'Enjoy priority support from our Happiness Engineers' );
+	}
+
+	getSupportText() {
+		const { isJetpackFreePlan, translate } = this.props;
+		const components = {
+			strong: <strong />,
+		};
+		return isJetpackFreePlan
+			? translate(
+					'{{strong}}Need help?{{/strong}} Search our support site to find out more about how to make the most of your Jetpack site.', // eslint-disable-line max-len
+					{ components }
+				)
+			: translate(
+					'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site, your account, or how to do just about anything.', // eslint-disable-line max-len
+					{ components }
+				);
+	}
+
 	renderContactButton() {
+		const { isJetpackFreePlan } = this.props;
+		if ( isJetpackFreePlan ) {
+			return;
+		}
+
 		let url = support.CALYPSO_CONTACT,
 			target = '';
 
@@ -97,26 +126,15 @@ export class HappinessSupport extends Component {
 		const classes = {
 			'is-placeholder': this.props.isPlaceholder,
 		};
-		const { liveChatAvailable, showLiveChatButton, translate } = this.props;
+		const { liveChatAvailable, showLiveChatButton } = this.props;
 
 		return (
 			<div className={ classNames( 'happiness-support', classes ) }>
 				{ this.renderIllustration() }
 
-				<h3 className="happiness-support__heading">
-					{ translate( 'Enjoy priority support from our Happiness Engineers' ) }
-				</h3>
+				<h3 className="happiness-support__heading">{ this.getHeadingText() }</h3>
 
-				<p className="happiness-support__text">
-					{ translate(
-						'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site, your account, or how to do just about anything.', // eslint-disable-line max-len
-						{
-							components: {
-								strong: <strong />,
-							},
-						}
-					) }
-				</p>
+				<p className="happiness-support__text">{ this.getSupportText() }</p>
 
 				<div className="happiness-support__buttons">
 					{ showLiveChatButton && <HappychatConnection /> }

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -139,6 +139,7 @@ class CurrentPlanHeader extends Component {
 					<div className="current-plan__header-item-content">
 						<HappinessSupport
 							isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
+							isJetpackFreePlan={ currentPlanSlug === PLAN_JETPACK_FREE }
 							isPlaceholder={ isPlaceholder }
 							showLiveChatButton={ this.isEligibleForLiveChat() }
 							liveChatButtonEventName="calypso_plans_current_plan_chat_initiated"


### PR DESCRIPTION
fixes https://github.com/Automattic/wp-calypso/issues/21053

Right now, when a user on jetpack free plan sees their "my plan" page, we are telling them that they already have priority support, which is not true.

This PR changes the text and the layout of the support card in "my-plan":

![image](https://user-images.githubusercontent.com/1554855/34361449-771d69e6-ea6a-11e7-90a5-af225ace81c5.png)


how to test
========
0. You need a connected jetpack site with a free plan
1. Go to https://calypso.live/plans/my-plan?branch=fix/jetpack-free-documentation-card (or http://calypso.localhost:3000/plans/my-plan/) and select said site (If you get redirected directly to the plans page, click on "my plan" )
2. The support card should be shown like in the example image here
3. Test the same page with sites with paid plans (both jetpack and wp.com) and check it still shows the old card
