### PR TITLE
Domains: Better error messages from Email resent page

### DIFF
--- a/client/my-sites/domains/domain-management/components/email-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/email-verification/index.jsx
@@ -21,6 +21,7 @@ class EmailVerificationCard extends React.Component {
 	static propTypes = {
 		changeEmailHref: PropTypes.string,
 		contactEmail: PropTypes.string.isRequired,
+		errorMessage: PropTypes.string.isRequired,
 		headerText: PropTypes.string,
 		verificationExplanation: PropTypes.array.isRequired,
 		resendVerification: PropTypes.func.isRequired,
@@ -46,7 +47,7 @@ class EmailVerificationCard extends React.Component {
 	};
 
 	handleSubmit = event => {
-		const { resendVerification, selectedDomainName } = this.props;
+		const { errorMessage, resendVerification, selectedDomainName } = this.props;
 
 		event.preventDefault();
 
@@ -54,7 +55,7 @@ class EmailVerificationCard extends React.Component {
 
 		resendVerification( selectedDomainName, error => {
 			if ( error ) {
-				this.props.errorNotice( error.message );
+				this.props.errorNotice( errorMessage );
 			} else {
 				this.timer = setTimeout( this.revertToWaitingState, 5000 );
 				this.setState( { emailSent: true } );

--- a/client/my-sites/domains/domain-management/components/icann-verification/icann-verification-card.jsx
+++ b/client/my-sites/domains/domain-management/components/icann-verification/icann-verification-card.jsx
@@ -68,6 +68,7 @@ class IcannVerificationCard extends React.Component {
 			<EmailVerificationCard
 				changeEmailHref={ changeEmailHref }
 				contactEmail={ contactDetails.email }
+				errorMessage={ translate( 'Unable to resend ICANN verification email.' ) }
 				headerText={ translate( 'Important: Verify Your Email Address' ) }
 				verificationExplanation={ verificationExplanation }
 				resendVerification={ upgradesActions.resendIcannVerification }

--- a/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
@@ -61,6 +61,7 @@ class InboundTransferEmailVerificationCard extends React.Component {
 		return (
 			<EmailVerificationCard
 				contactEmail={ contactEmail }
+				errorMessage={ translate( 'Unable to resend domain transfer email.' ) }
 				headerText={
 					translate(
 						'Important: Confirm the transfer to proceed.'


### PR DESCRIPTION
Use localized messages in Calypso instead of the errors passed from the endpoints, which aren't localized, and are sometimes ineligible messages from the APIs.

Test:
- Hack back end to return an error for `/domains/test.com/resend-icann` and `/domains/test.com/resend-inbound-transfer-email`
- Go to an unverified domain
- Click resend
- Make sure proper message is shown
- Go to a transfer in `pending_owner` status
- Try to resend email