### PR TITLE
Comments: Remove comment from page state after change status and delete actions

### DIFF
--- a/client/state/selectors/get-comments-page.js
+++ b/client/state/selectors/get-comments-page.js
@@ -6,6 +6,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import { getFiltersKey } from 'state/ui/comments/utils';
+
+/**
  * Returns a list of comment IDs for the requested page and filters.
  *
  * @param {Object} state Redux state.
@@ -17,9 +22,10 @@ import { get } from 'lodash';
  * @param {String} [query.status] Comments status.
  * @returns {Array} List of comment IDs for the requested page and filters.
  */
-export const getCommentsPage = ( state, siteId, { page = 1, postId, search, status = 'all' } ) => {
+export const getCommentsPage = ( state, siteId, query ) => {
+	const { page = 1, postId } = query;
 	const parent = postId || 'site';
-	const filter = !! search ? `${ status }?s=${ search }` : status;
+	const filter = getFiltersKey( query );
 	return get( state, [ 'ui', 'comments', 'queries', siteId, parent, filter, page ] );
 };
 

--- a/client/state/ui/comments/reducer.js
+++ b/client/state/ui/comments/reducer.js
@@ -33,6 +33,9 @@ export const queries = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case COMMENTS_CHANGE_STATUS:
 		case COMMENTS_DELETE:
+			if ( ! action.refreshCommentListQuery ) {
+				return state;
+			}
 			const { page, postId, search, status } = action.refreshCommentListQuery;
 			if (
 				COMMENTS_DELETE !== action.type &&

--- a/client/state/ui/comments/reducer.js
+++ b/client/state/ui/comments/reducer.js
@@ -38,10 +38,11 @@ export const queries = ( state = {}, action ) => {
 			}
 			const { page, postId, search, status } = action.refreshCommentListQuery;
 			if (
-				COMMENTS_DELETE !== action.type &&
+				COMMENTS_CHANGE_STATUS === action.type &&
 				'all' === status &&
 				includes( [ 'approved', 'unapproved' ], action.status )
 			) {
+				// No-op when status changes from `approved` or `unapproved` in the All tab
 				return state;
 			}
 

--- a/client/state/ui/comments/reducer.js
+++ b/client/state/ui/comments/reducer.js
@@ -9,10 +9,12 @@ import { get, includes, isUndefined, map, without } from 'lodash';
  */
 import { COMMENTS_CHANGE_STATUS, COMMENTS_DELETE, COMMENTS_QUERY_UPDATE } from 'state/action-types';
 import { combineReducers, keyedReducer } from 'state/utils';
+import { getFiltersKey } from 'state/ui/comments/utils';
 
-const deepUpdateComments = ( state, comments, { page = 1, postId, search, status = 'all' } ) => {
+const deepUpdateComments = ( state, comments, query ) => {
+	const { page = 1, postId } = query;
 	const parent = postId || 'site';
-	const filter = !! search ? `${ status }?s=${ search }` : status;
+	const filter = getFiltersKey( query );
 
 	const parentObject = get( state, parent, {} );
 	const filterObject = get( parentObject, filter, {} );
@@ -36,7 +38,7 @@ export const queries = ( state = {}, action ) => {
 			if ( ! action.refreshCommentListQuery ) {
 				return state;
 			}
-			const { page, postId, search, status } = action.refreshCommentListQuery;
+			const { page, postId, status } = action.refreshCommentListQuery;
 			if (
 				COMMENTS_CHANGE_STATUS === action.type &&
 				'all' === status &&
@@ -47,7 +49,7 @@ export const queries = ( state = {}, action ) => {
 			}
 
 			const parent = postId || 'site';
-			const filter = !! search ? `${ status }?s=${ search }` : status;
+			const filter = getFiltersKey( action.refreshCommentListQuery );
 
 			const comments = get( state, [ parent, filter, page ] );
 

--- a/client/state/ui/comments/test/reducer.js
+++ b/client/state/ui/comments/test/reducer.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { COMMENTS_QUERY_UPDATE } from 'state/action-types';
+import { COMMENTS_CHANGE_STATUS, COMMENTS_DELETE, COMMENTS_QUERY_UPDATE } from 'state/action-types';
 import { queries } from 'state/ui/comments/reducer';
 
 const siteId = 12345678;
@@ -96,6 +96,47 @@ describe( 'reducer', () => {
 					'spam?s=foo': { 2: [ 11, 12, 13, 14, 15 ] },
 				},
 			} );
+		} );
+
+		test( 'should remove a comment from a page when the comment is deleted', () => {
+			const state = deepFreeze( {
+				site: { all: { 1: [ 1, 2, 3, 4, 5 ] } },
+			} );
+			const query = queries( state, {
+				type: COMMENTS_DELETE,
+				siteId,
+				commentId: 5,
+				refreshCommentListQuery: { page: 1, status: 'all' },
+			} );
+			expect( query ).to.eql( { site: { all: { 1: [ 1, 2, 3, 4 ] } } } );
+		} );
+
+		test( 'should remove a comment from a page when the comment status is changed', () => {
+			const state = deepFreeze( {
+				site: { spam: { 1: [ 1, 2, 3, 4, 5 ] } },
+			} );
+			const query = queries( state, {
+				type: COMMENTS_CHANGE_STATUS,
+				siteId,
+				commentId: 5,
+				status: 'approved',
+				refreshCommentListQuery: { page: 1, status: 'spam' },
+			} );
+			expect( query ).to.eql( { site: { spam: { 1: [ 1, 2, 3, 4 ] } } } );
+		} );
+
+		test( "should not remove a comment from a page when the comment status is changed but it doesn't change filter list", () => {
+			const state = deepFreeze( {
+				site: { all: { 1: [ 1, 2, 3, 4, 5 ] } },
+			} );
+			const query = queries( state, {
+				type: COMMENTS_CHANGE_STATUS,
+				siteId,
+				commentId: 5,
+				status: 'approved',
+				refreshCommentListQuery: { page: 1, status: 'all' },
+			} );
+			expect( query ).to.eql( { site: { all: { 1: [ 1, 2, 3, 4, 5 ] } } } );
 		} );
 	} );
 } );

--- a/client/state/ui/comments/utils.js
+++ b/client/state/ui/comments/utils.js
@@ -1,0 +1,13 @@
+/** @format */
+
+/**
+ * Creates a filters key to be used in the `ui.comments.queries` state.
+ * E.g. `ui.comments.queries.${ siteId }.${ postId }.${ 'approved?s=foo' }.${ page }`
+ *
+ * @param {Object} query Filter parameters.
+ * @param {String} [query.search] Search query.
+ * @param {String} query.status Comments status.
+ * @returns {String} Filter key.
+ */
+export const getFiltersKey = ( { search, status = 'all' } ) =>
+	!! search ? `${ status }?s=${ search }` : status;


### PR DESCRIPTION
Contributes to #21155

#21004 and #21035 introduced a new `ui.comments.queries` state that helps handling the Comments Management pagination.

Wiring it up with the `CommentList` component I noticed that, when changing a comment status or deleting it, the comment doesn't immediately disappear (as it is expected), but sticks around until the action is successful and the comment page is fetched again.

This PR adds `COMMENTS_CHANGE_STATUS` and `COMMENTS_DELETE` cases to the `queries` reducer, removing the comment from the page immediately for all the cases where the comment "leaves" the current list:
- Delete (every time).
- Change status, except when toggling between `approved` and `unapproved` in the All list.