### PR TITLE
Jetpack: change some title words

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-return-to-dashboard.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-return-to-dashboard.jsx
@@ -24,7 +24,7 @@ export default localize( ( { selectedSite, translate } ) => {
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon="house"
-				title={ translate( 'Return to your dashboard' ) }
+				title={ translate( 'Return to your Jetpack dashboard' ) }
 				buttonText={ translate( 'Go back to %(site)s', { args: { site: selectedSite.name } } ) }
 				href={ adminURL }
 			/>


### PR DESCRIPTION
Uh, dumbest PR ever. Adds a word in the "return to your dashboard" card title

and fixes https://github.com/Automattic/wp-calypso/issues/21055

how to test
=========
1. Do we really want to test this?
2. Seriously?
3. Ok, ok, choose one of your connected jetpack sites and go to /plans/my-plan. The card what shows the button to return to your site should have a title that uses "jetpack dashboard" instead of "dashboard"