### PR TITLE
Comments: Page selector returns undefined if the page is not initialized yet

### DIFF
--- a/client/state/selectors/get-comments-page.js
+++ b/client/state/selectors/get-comments-page.js
@@ -20,7 +20,7 @@ import { get } from 'lodash';
 export const getCommentsPage = ( state, siteId, { page = 1, postId, search, status = 'all' } ) => {
 	const parent = postId || 'site';
 	const filter = !! search ? `${ status }?s=${ search }` : status;
-	return get( state, [ 'ui', 'comments', 'queries', siteId, parent, filter, page ], [] );
+	return get( state, [ 'ui', 'comments', 'queries', siteId, parent, filter, page ] );
 };
 
 export default getCommentsPage;

--- a/client/state/selectors/test/get-comments-page.js
+++ b/client/state/selectors/test/get-comments-page.js
@@ -18,7 +18,10 @@ describe( 'getCommentsPage()', () => {
 			comments: {
 				queries: {
 					[ SITE_ID ]: {
-						site: { all: { 1: [ 1, 2, 3, 4, 5 ] } },
+						site: {
+							all: { 1: [ 1, 2, 3, 4, 5 ] },
+							trash: { 1: [] },
+						},
 						[ POST_ID ]: {
 							all: { 1: [ 6, 7, 8, 9, 10 ] },
 							'spam?s=foo': { 2: [ 11, 12, 13, 14, 15 ] },
@@ -29,7 +32,12 @@ describe( 'getCommentsPage()', () => {
 		},
 	};
 
-	test( 'should return an empty array if there is state is empty for the requested filters', () => {
+	test( 'should return undefined if the state is not initialized for the requested filter', () => {
+		const commentsPage = getCommentsPage( state, SITE_ID, { page: 10, status: 'all' } );
+		expect( commentsPage ).to.be.undefined;
+	} );
+
+	test( 'should return an empty array if the state is empty for the requested filters', () => {
 		const commentsPage = getCommentsPage( state, SITE_ID, { page: 1, status: 'trash' } );
 		expect( commentsPage ).to.eql( [] );
 	} );


### PR DESCRIPTION
Contributes to #21155

#21004 and #21035 introduced a new `ui.comments.queries` state that helps handling the Comments Management pagination.

Currently, we return `[]` if a comments page is either empty or undefined.
For this reason, we don't have any way to tell empty and undefined (uninitialized) apart.

This PR defaults the `getCommentsPage` selector to `undefined`.
Once applied to `CommentList`, we'll be able to use the `undefined` value to know that the page is not initialized yet and we have to show the placeholder.