### PR TITLE
[WIP] Checkout: remove jQuery dependency for PaymentGatewayLoader

### DIFF
--- a/client/lib/payment-gateway-loader/index.js
+++ b/client/lib/payment-gateway-loader/index.js
@@ -11,7 +11,7 @@ const debug = debugFactory( 'calypso:payment-gateway' );
 /**
  * Internal dependencies
  */
-import { loadScript, loadjQueryDependentScript } from 'lib/load-script';
+import { loadScript } from 'lib/load-script';
 
 /**
  * PaymentGatewayLoader component
@@ -32,23 +32,16 @@ function PaymentGatewayLoader() {
  * @api public
  * @param {string} gatewayUrl - the URL to fetch the script
  * @param {string} gatewayNamespace - the global namespace of the script
- * @param {boolean} loadJquery - is jQuery required
  * @returns {Promise} promise
  */
-PaymentGatewayLoader.prototype.ready = function(
-	gatewayUrl,
-	gatewayNamespace,
-	loadJquery = false
-) {
+PaymentGatewayLoader.prototype.ready = function( gatewayUrl, gatewayNamespace ) {
 	return new Promise( ( resolve, reject ) => {
 		if ( window[ gatewayNamespace ] ) {
 			resolve( window[ gatewayNamespace ] );
 			return;
 		}
 
-		const loaderFunction = loadJquery ? loadjQueryDependentScript : loadScript;
-
-		loaderFunction( gatewayUrl, function( error ) {
+		loadScript( gatewayUrl, function( error ) {
 			if ( error ) {
 				reject( error );
 				return;

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -214,7 +214,7 @@ function createPaygateToken( requestType, cardDetails, callback ) {
 			}
 
 			paymentGatewayLoader
-				.ready( configuration.js_url, 'Paygate', true )
+				.ready( configuration.js_url, 'Paygate' )
 				.then( Paygate => {
 					Paygate.setProcessor( configuration.processor );
 					Paygate.setApiUrl( configuration.api_url );


### PR DESCRIPTION
When D9013-code (internal) lands, paygate will no longer require jQuery.
