### PR TITLE
Login: Fix locale propagation

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -16,6 +16,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import wpcom from 'lib/wp';
 import config from 'config';
 import analytics from 'lib/analytics';
@@ -369,6 +370,7 @@ class SignupForm extends Component {
 
 		let link = login( {
 			isNative: config.isEnabled( 'login/native-login-links' ),
+			locale: this.props.locale,
 			redirectTo: this.props.redirectToAfterLoginUrl,
 		} );
 
@@ -558,23 +560,14 @@ class SignupForm extends Component {
 		);
 	}
 
-	localizeUrlWithSubdomain( url ) {
-		const urlArray = url.split( '//' );
-		let returnUrl = urlArray[ 0 ] + '//';
-		if ( this.props.locale ) {
-			returnUrl += this.props.locale + '.';
-		}
-		return returnUrl + urlArray[ 1 ];
-	}
-
 	footerLink() {
 		if ( this.props.positionInFlow !== 0 ) {
 			return;
 		}
 
 		const logInUrl = config.isEnabled( 'login/native-login-links' )
-			? login( { isNative: true, redirectTo: this.props.redirectToAfterLoginUrl } )
-			: this.localizeUrlWithSubdomain( config( 'login_url' ) );
+			? login( { isNative: true, locale: this.props.locale, redirectTo: this.props.redirectToAfterLoginUrl } )
+			: addLocaleToWpcomUrl( config( 'login_url' ), this.props.locale );
 
 		return (
 			<LoggedOutFormLinks>

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Masterbar from './masterbar';
-import { localize } from 'i18n-calypso';
+import { getLocaleSlug, localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -19,7 +19,8 @@ import WordPressWordmark from 'components/wordpress-wordmark';
 import WordPressLogo from 'components/wordpress-logo';
 
 function getLoginUrl( redirectUri ) {
-	const params = {};
+	const params = { locale: getLocaleSlug() };
+
 	if ( redirectUri ) {
 		params.redirectTo = redirectUri;
 	} else if ( typeof window !== 'undefined' ) {

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -83,7 +83,9 @@ export default {
 	},
 
 	magicLogin( context, next ) {
-		context.primary = <MagicLogin />;
+		const { path } = context;
+
+		context.primary = <MagicLogin path={ path } />;
 
 		next();
 	},

--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -36,6 +36,10 @@ class EmailedLoginLinkExpired extends React.Component {
 		translate: PropTypes.func.isRequired,
 	};
 
+	componentDidMount() {
+		this.props.recordPageView( '/log-in/link/use', 'Login > Link > Expired' );
+	}
+
 	onClickTryAgainLink = event => {
 		event.preventDefault();
 
@@ -47,8 +51,6 @@ class EmailedLoginLinkExpired extends React.Component {
 	render() {
 		const { translate } = this.props;
 
-		this.props.recordPageView( '/log-in/link/use', 'Login > Link > Expired' );
-
 		return (
 			<div>
 				<RedirectWhenLoggedIn
@@ -56,6 +58,7 @@ class EmailedLoginLinkExpired extends React.Component {
 					redirectTo="/"
 					replaceCurrentLocation={ true }
 				/>
+
 				<EmptyContent
 					action={ translate( 'Try again' ) }
 					actionCallback={ this.onClickTryAgainLink }

--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -31,6 +31,7 @@ const lostPasswordURL = addQueryArgs(
 
 class EmailedLoginLinkExpired extends React.Component {
 	static propTypes = {
+		hideMagicLoginRequestForm: PropTypes.func.isRequired,
 		recordPageView: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -28,6 +28,10 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 		recordPageView: PropTypes.func.isRequired,
 	};
 
+	componentDidMount() {
+		this.props.recordPageView( '/log-in/link', 'Login > Link > Emailed' );
+	}
+
 	onClickBackLink = event => {
 		event.preventDefault();
 
@@ -49,8 +53,6 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 			' ',
 			translate( 'Please check your inbox and click the link to log in.' ),
 		];
-
-		this.props.recordPageView( '/log-in/link', 'Login > Link > Emailed' );
 
 		return (
 			<div>

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -27,7 +27,9 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 
 	onClickBackLink = event => {
 		event.preventDefault();
+
 		this.props.hideMagicLoginRequestForm();
+
 		page( login( { isNative: true } ) );
 	};
 
@@ -54,7 +56,9 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 					replaceCurrentLocation={ true }
 					waitForEmailAddress={ emailAddress }
 				/>
+
 				<h1 className="magic-login__form-header">{ translate( 'Check your email!' ) }</h1>
+
 				<Card className="magic-login__form">
 					<img
 						src="/calypso/images/login/check-email.svg"
@@ -62,9 +66,11 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 					/>
 					<p>{ line }</p>
 				</Card>
+
 				<div className="magic-login__footer">
-					<a href="#" onClick={ this.onClickBackLink }>
-						<Gridicon icon="arrow-left" size={ 18 } /> { translate( 'Back' ) }
+					<a href={ login( { isNative: true } ) } onClick={ this.onClickBackLink }>
+						<Gridicon icon="arrow-left" size={ 18 } />
+						{ translate( 'Back' ) }
 					</a>
 				</div>
 			</div>

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -23,6 +23,7 @@ import Gridicon from 'gridicons';
 
 class EmailedLoginLinkSuccessfully extends React.Component {
 	static propTypes = {
+		hideMagicLoginRequestForm: PropTypes.func.isRequired,
 		locale: PropTypes.string.isRequired,
 		recordPageView: PropTypes.func.isRequired,
 	};

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -17,11 +17,13 @@ import { login } from 'lib/paths';
 import Card from 'components/card';
 import RedirectWhenLoggedIn from 'components/redirect-when-logged-in';
 import { hideMagicLoginRequestForm } from 'state/login/magic-login/actions';
+import { getCurrentLocaleSlug } from 'state/selectors';
 import { recordPageViewWithClientId as recordPageView } from 'state/analytics/actions';
 import Gridicon from 'gridicons';
 
 class EmailedLoginLinkSuccessfully extends React.Component {
 	static propTypes = {
+		locale: PropTypes.string.isRequired,
 		recordPageView: PropTypes.func.isRequired,
 	};
 
@@ -30,7 +32,7 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 
 		this.props.hideMagicLoginRequestForm();
 
-		page( login( { isNative: true } ) );
+		page( login( { isNative: true, locale: this.props.locale } ) );
 	};
 
 	render() {
@@ -68,7 +70,10 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 				</Card>
 
 				<div className="magic-login__footer">
-					<a href={ login( { isNative: true } ) } onClick={ this.onClickBackLink }>
+					<a
+						href={ login( { isNative: true, locale: this.props.locale } ) }
+						onClick={ this.onClickBackLink }
+					>
 						<Gridicon icon="arrow-left" size={ 18 } />
 						{ translate( 'Back' ) }
 					</a>
@@ -78,9 +83,13 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 	}
 }
 
+const mapState = state => ( {
+	locale: getCurrentLocaleSlug( state ),
+} );
+
 const mapDispatch = {
 	hideMagicLoginRequestForm,
 	recordPageView,
 };
 
-export default connect( null, mapDispatch )( localize( EmailedLoginLinkSuccessfully ) );
+export default connect( mapState, mapDispatch )( localize( EmailedLoginLinkSuccessfully ) );

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -17,7 +17,7 @@ import page from 'page';
 import notices from 'notices';
 import { login } from 'lib/paths';
 import { CHECK_YOUR_EMAIL_PAGE } from 'state/login/magic-login/constants';
-import { getMagicLoginCurrentView } from 'state/selectors';
+import { getCurrentLocaleSlug, getMagicLoginCurrentView } from 'state/selectors';
 import { hideMagicLoginRequestForm } from 'state/login/magic-login/actions';
 import {
 	recordTracksEventWithClientId as recordTracksEvent,
@@ -36,6 +36,7 @@ class MagicLogin extends React.Component {
 		recordTracksEvent: PropTypes.func.isRequired,
 
 		// mapped to state
+		locale: PropTypes.string.isRequired,
 		showCheckYourEmail: PropTypes.bool.isRequired,
 
 		// From `localize`
@@ -47,7 +48,7 @@ class MagicLogin extends React.Component {
 
 		this.props.recordTracksEvent( 'calypso_login_email_link_page_click_back' );
 
-		page( login( { isNative: true } ) );
+		page( login( { isNative: true, locale: this.props.locale } ) );
 	};
 
 	render() {
@@ -57,7 +58,7 @@ class MagicLogin extends React.Component {
 
 		const footer = ! showCheckYourEmail && (
 			<div className="magic-login__footer">
-				<a href={ login( { isNative: true } ) } onClick={ this.onClickEnterPasswordInstead }>
+				<a href={ login( { isNative: true, locale: this.props.locale } ) } onClick={ this.onClickEnterPasswordInstead }>
 					<Gridicon icon="arrow-left" size={ 18 } />
 					{ translate( 'Enter a password instead' ) }
 				</a>
@@ -69,7 +70,9 @@ class MagicLogin extends React.Component {
 		return (
 			<Main className={ classes }>
 				<GlobalNotices id="notices" notices={ notices.list } />
+
 				<RequestLoginEmailForm />
+
 				{ footer }
 			</Main>
 		);
@@ -77,6 +80,7 @@ class MagicLogin extends React.Component {
 }
 
 const mapState = state => ( {
+	locale: getCurrentLocaleSlug( state ),
 	showCheckYourEmail: getMagicLoginCurrentView( state ) === CHECK_YOUR_EMAIL_PAGE,
 } );
 

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -45,6 +45,10 @@ class MagicLogin extends React.Component {
 		translate: PropTypes.func.isRequired,
 	};
 
+	componentDidMount() {
+		this.props.recordPageView( '/log-in/link', 'Login > Link' );
+	}
+
 	onClickEnterPasswordInstead = event => {
 		event.preventDefault();
 
@@ -84,8 +88,6 @@ class MagicLogin extends React.Component {
 	}
 
 	render() {
-		this.props.recordPageView( '/log-in/link', 'Login > Link' );
-
 		return (
 			<Main className="magic-login magic-login__request-link">
 				{ this.renderLocaleSuggestions() }

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
 import page from 'page';
 
 /**
@@ -54,6 +53,26 @@ class MagicLogin extends React.Component {
 		page( login( { isNative: true, locale: this.props.locale } ) );
 	};
 
+	renderLinks() {
+		const { locale, showCheckYourEmail, translate } = this.props;
+
+		if ( showCheckYourEmail ) {
+			return null;
+		}
+
+		return (
+			<div className="magic-login__footer">
+				<a
+					href={ login( { isNative: true, locale: locale } ) }
+					onClick={ this.onClickEnterPasswordInstead }
+				>
+					<Gridicon icon="arrow-left" size={ 18 } />
+					{ translate( 'Enter a password instead' ) }
+				</a>
+			</div>
+		);
+	}
+
 	renderLocaleSuggestions() {
 		const { locale, path, showCheckYourEmail } = this.props;
 
@@ -65,30 +84,17 @@ class MagicLogin extends React.Component {
 	}
 
 	render() {
-		const { showCheckYourEmail, translate } = this.props;
-
 		this.props.recordPageView( '/log-in/link', 'Login > Link' );
 
-		const footer = ! showCheckYourEmail && (
-			<div className="magic-login__footer">
-				<a href={ login( { isNative: true, locale: this.props.locale } ) } onClick={ this.onClickEnterPasswordInstead }>
-					<Gridicon icon="arrow-left" size={ 18 } />
-					{ translate( 'Enter a password instead' ) }
-				</a>
-			</div>
-		);
-
-		const classes = classNames( 'magic-login', 'magic-login__request-link' );
-
 		return (
-			<Main className={ classes }>
+			<Main className="magic-login magic-login__request-link">
 				{ this.renderLocaleSuggestions() }
 
 				<GlobalNotices id="notices" notices={ notices.list } />
 
 				<RequestLoginEmailForm />
 
-				{ footer }
+				{ this.renderLinks() }
 			</Main>
 		);
 	}

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -19,6 +19,7 @@ import { login } from 'lib/paths';
 import { CHECK_YOUR_EMAIL_PAGE } from 'state/login/magic-login/constants';
 import { getCurrentLocaleSlug, getMagicLoginCurrentView } from 'state/selectors';
 import { hideMagicLoginRequestForm } from 'state/login/magic-login/actions';
+import LocaleSuggestions from 'components/locale-suggestions';
 import {
 	recordTracksEventWithClientId as recordTracksEvent,
 	recordPageViewWithClientId as recordPageView,
@@ -30,6 +31,8 @@ import Gridicon from 'gridicons';
 
 class MagicLogin extends React.Component {
 	static propTypes = {
+		path: PropTypes.string.isRequired,
+
 		// mapped to dispatch
 		hideMagicLoginRequestForm: PropTypes.func.isRequired,
 		recordPageView: PropTypes.func.isRequired,
@@ -51,6 +54,16 @@ class MagicLogin extends React.Component {
 		page( login( { isNative: true, locale: this.props.locale } ) );
 	};
 
+	renderLocaleSuggestions() {
+		const { locale, path, showCheckYourEmail } = this.props;
+
+		if ( showCheckYourEmail ) {
+			return null;
+		}
+
+		return <LocaleSuggestions locale={ locale } path={ path } />;
+	}
+
 	render() {
 		const { showCheckYourEmail, translate } = this.props;
 
@@ -69,6 +82,8 @@ class MagicLogin extends React.Component {
 
 		return (
 			<Main className={ classes }>
+				{ this.renderLocaleSuggestions() }
+
 				<GlobalNotices id="notices" notices={ notices.list } />
 
 				<RequestLoginEmailForm />

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -44,6 +44,7 @@ class MagicLogin extends React.Component {
 
 	onClickEnterPasswordInstead = event => {
 		event.preventDefault();
+
 		this.props.recordTracksEvent( 'calypso_login_email_link_page_click_back' );
 
 		page( login( { isNative: true } ) );
@@ -56,8 +57,9 @@ class MagicLogin extends React.Component {
 
 		const footer = ! showCheckYourEmail && (
 			<div className="magic-login__footer">
-				<a href="#" onClick={ this.onClickEnterPasswordInstead }>
-					<Gridicon icon="arrow-left" size={ 18 } /> { translate( 'Enter a password instead' ) }
+				<a href={ login( { isNative: true } ) } onClick={ this.onClickEnterPasswordInstead }>
+					<Gridicon icon="arrow-left" size={ 18 } />
+					{ translate( 'Enter a password instead' ) }
 				</a>
 			</div>
 		);

--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -38,11 +38,11 @@ class RequestLoginEmailForm extends React.Component {
 	static propTypes = {
 		// mapped to state
 		currentUser: PropTypes.object,
+		emailRequested: PropTypes.bool,
 		isFetching: PropTypes.bool,
 		redirectTo: PropTypes.string,
 		requestError: PropTypes.string,
 		showCheckYourEmail: PropTypes.bool,
-		emailRequested: PropTypes.bool,
 
 		// mapped to dispatch
 		fetchMagicLoginRequestEmail: PropTypes.func.isRequired,

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -37,11 +37,11 @@ export class Login extends React.Component {
 		path: PropTypes.string.isRequired,
 		privateSite: PropTypes.bool,
 		recordPageView: PropTypes.func.isRequired,
-		translate: PropTypes.func.isRequired,
-		twoFactorAuthType: PropTypes.string,
 		socialConnect: PropTypes.bool,
 		socialService: PropTypes.string,
 		socialServiceResponse: PropTypes.object,
+		translate: PropTypes.func.isRequired,
+		twoFactorAuthType: PropTypes.string,
 	};
 
 	componentDidMount() {

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -22,7 +22,6 @@ import Gridicon from 'gridicons';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import {
 	recordTracksEventWithClientId as recordTracksEvent,
-	recordPageViewWithClientId as recordPageView,
 } from 'state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'state/login/magic-login/actions';
 import { login } from 'lib/paths';
@@ -32,13 +31,12 @@ export class LoginLinks extends React.Component {
 	static propTypes = {
 		isLoggedIn: PropTypes.bool.isRequired,
 		locale: PropTypes.string.isRequired,
+		oauth2Client: PropTypes.object,
 		privateSite: PropTypes.bool,
-		recordPageView: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 		resetMagicLoginRequestForm: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 		twoFactorAuthType: PropTypes.string,
-		oauth2Client: PropTypes.object,
 	};
 
 	recordBackToWpcomLinkClick = () => {
@@ -189,7 +187,6 @@ const mapState = state => ( {
 } );
 
 const mapDispatch = {
-	recordPageView,
 	recordTracksEvent,
 	resetMagicLoginRequestForm,
 };

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -88,6 +88,7 @@ export class LoginLinks extends React.Component {
 				},
 			} );
 		}
+
 		return (
 			<a
 				href={ url }
@@ -142,7 +143,7 @@ export class LoginLinks extends React.Component {
 
 		return (
 			<a
-				href="#"
+				href={ login( { isNative: true, twoFactorAuthType: 'link' } ) }
 				key="magic-login-link"
 				data-e2e-link="magic-login-link"
 				onClick={ this.handleMagicLoginLinkClick }

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -63,7 +63,7 @@ export class LoginLinks extends React.Component {
 		this.props.recordTracksEvent( 'calypso_login_magic_login_request_click' );
 		this.props.resetMagicLoginRequestForm();
 
-		page( login( { isNative: true, twoFactorAuthType: 'link' } ) );
+		page( login( { isNative: true, locale: this.props.locale, twoFactorAuthType: 'link' } ) );
 	};
 
 	recordResetPasswordLinkClick = () => {
@@ -143,7 +143,7 @@ export class LoginLinks extends React.Component {
 
 		return (
 			<a
-				href={ login( { isNative: true, twoFactorAuthType: 'link' } ) }
+				href={ login( { isNative: true, locale: this.props.locale, twoFactorAuthType: 'link' } ) }
 				key="magic-login-link"
 				data-e2e-link="magic-login-link"
 				onClick={ this.handleMagicLoginLinkClick }


### PR DESCRIPTION
This pull request fixes several scenarios where users would start in a specific language, then switch to a login page which would then be displayed in English. It also updates the `Magic Login` page to display locale suggestions to be consistent with the `Login` page, as well as fixes a React error.

#### Testing instructions

1. Run `git checkout fix/login-locale-propagation` and start your server, or open a [live branch](https://calypso.live/?branch=fix/login-locale-propagation)

##### Scenario 1

2. Open the [`Signup` page](http://calypso.localhost:3000/start/es) in Spanish in an incognito window
3. Click the `Acceder` link in the upper right corner
4. Assert that the `Login` page is displayed in Spanish

##### Scenario 2

2. Open the [`Login` page](http://calypso.localhost:3000/log-in/fr) in French in an incognito window
3. Click the `S’inscrire` link in the upper right corner
4. Assert that the `Signup` page is displayed in French

##### Scenario 3

2. Open the [`Login` page](http://calypso.localhost:3000/log-in/it) in Italian in an incognito window
3. Click the `Inviami una e-mail con il link dell'accesso` link in the footer
4. Assert that the `Magic Login` page is displayed in Italian
6. Enter an email address, and submit the form
7. Assert that the `Magic Login Confirmation` page is displayed in Italian

##### Scenario 4

2. Open the [`Magic Login` page](http://calypso.localhost:3000/log-in/link/fr) in French in an incognito window
3. Click the `Saisir un mot de passe à la place` link in the footer
4. Assert that the `Login` page is displayed in French

##### Scenario 5

2. Open the [`Signup` page](http://calypso.localhost:3000/start/fr) in French in an incognito window
3. Proceed to the [`User` step](http://calypso.localhost:3000/start/user)
4. Enter the email address of existing account, and hit <kbd>tab</kbd>kbd>
5. Click the link in the `Choisissez une autre adresse email. Celle-ci n'est pas disponible. Si c'est bien vous, connectez-vous maintenant.` error message
6. Assert that the `Login` page is displayed in French

##### Scenario 6

2. Open the [`Signup` page](http://calypso.localhost:3000/start/account/fr) for an account in French in an incognito window
3. Click the `Vous avez déjà un compte WordPress.com ? Connectez-vous maintenant.` link in the footer
4. Assert that the `Login` page is displayed in French

#### Reviews

- [ ] Code
- [x] Product