### PR TITLE
Site Settings: Support Infinite Scroll for WPCOM Simple

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -142,29 +142,27 @@ class SiteSettingsFormWriting extends Component {
 					fields={ fields }
 				/>
 
-				<div>
-					{ jetpackSettingsUI && <QueryJetpackModules siteId={ siteId } /> }
+				{ jetpackSettingsUI && <QueryJetpackModules siteId={ siteId } /> }
 
-					<ThemeEnhancements
-						onSubmitForm={ handleSubmitForm }
-						handleAutosavingToggle={ handleAutosavingToggle }
-						handleAutosavingRadio={ handleAutosavingRadio }
-						isSavingSettings={ isSavingSettings }
-						isRequestingSettings={ isRequestingSettings }
-						jetpackSettingsUI={ jetpackSettingsUI }
-						fields={ fields }
-					/>
+				<ThemeEnhancements
+					onSubmitForm={ handleSubmitForm }
+					handleAutosavingToggle={ handleAutosavingToggle }
+					handleAutosavingRadio={ handleAutosavingRadio }
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					jetpackSettingsUI={ jetpackSettingsUI }
+					fields={ fields }
+				/>
 
-					{ jetpackSettingsUI &&
-						config.isEnabled( 'press-this' ) && (
-							<PublishingTools
-								onSubmitForm={ handleSubmitForm }
-								isSavingSettings={ isSavingSettings }
-								isRequestingSettings={ isRequestingSettings }
-								fields={ fields }
-							/>
-						) }
-				</div>
+				{ jetpackSettingsUI &&
+					config.isEnabled( 'press-this' ) && (
+						<PublishingTools
+							onSubmitForm={ handleSubmitForm }
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+						/>
+					) }
 
 				{ config.isEnabled( 'press-this' ) &&
 					! this.isMobile() &&

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -35,14 +35,14 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 
 class SiteSettingsFormWriting extends Component {
 	renderSectionHeader( title, showButton = true ) {
-		const { isRequestingSettings, isSavingSettings, translate } = this.props;
+		const { handleSubmitForm, isRequestingSettings, isSavingSettings, translate } = this.props;
 		return (
 			<SectionHeader label={ title }>
 				{ showButton && (
 					<Button
 						compact
 						primary
-						onClick={ this.props.handleSubmitForm }
+						onClick={ handleSubmitForm }
 						disabled={ isRequestingSettings || isSavingSettings }
 					>
 						{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
@@ -62,11 +62,15 @@ class SiteSettingsFormWriting extends Component {
 			uniqueEventTracker,
 			fields,
 			handleSelect,
+			handleSubmitForm,
 			handleToggle,
 			handleAutosavingToggle,
 			handleAutosavingRadio,
+			isJetpackSite: _isJetpackSite,
 			isRequestingSettings,
 			isSavingSettings,
+			jetpackMasterbarSupported,
+			jetpackSettingsUISupported,
 			onChangeField,
 			setFieldValue,
 			siteId,
@@ -74,14 +78,16 @@ class SiteSettingsFormWriting extends Component {
 			updateFields,
 		} = this.props;
 
+		const jetpackSettingsUI = _isJetpackSite && jetpackSettingsUISupported;
+
 		return (
 			<form
 				id="site-settings"
-				onSubmit={ this.props.handleSubmitForm }
+				onSubmit={ handleSubmitForm }
 				className="site-settings__general-settings"
 			>
-				{ this.props.isJetpackSite &&
-					this.props.jetpackMasterbarSupported && (
+				{ _isJetpackSite &&
+					jetpackMasterbarSupported && (
 						<div>
 							{ this.renderSectionHeader( translate( 'WordPress.com toolbar' ), false ) }
 							<Masterbar
@@ -112,20 +118,19 @@ class SiteSettingsFormWriting extends Component {
 					fields={ fields }
 					updateFields={ updateFields }
 				/>
-				{ this.props.isJetpackSite &&
-					this.props.jetpackSettingsUISupported && (
-						<div>
-							{ this.renderSectionHeader( translate( 'Media' ) ) }
-							<MediaSettings
-								siteId={ this.props.siteId }
-								handleAutosavingToggle={ handleAutosavingToggle }
-								onChangeField={ onChangeField }
-								isSavingSettings={ isSavingSettings }
-								isRequestingSettings={ isRequestingSettings }
-								fields={ fields }
-							/>
-						</div>
-					) }
+				{ jetpackSettingsUI && (
+					<div>
+						{ this.renderSectionHeader( translate( 'Media' ) ) }
+						<MediaSettings
+							siteId={ siteId }
+							handleAutosavingToggle={ handleAutosavingToggle }
+							onChangeField={ onChangeField }
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+						/>
+					</div>
+				) }
 
 				{ this.renderSectionHeader( translate( 'Content types' ) ) }
 
@@ -137,34 +142,33 @@ class SiteSettingsFormWriting extends Component {
 					fields={ fields }
 				/>
 
-				{ this.props.isJetpackSite &&
-					this.props.jetpackSettingsUISupported && (
-						<div>
-							<QueryJetpackModules siteId={ this.props.siteId } />
+				<div>
+					{ jetpackSettingsUI && <QueryJetpackModules siteId={ siteId } /> }
 
-							<ThemeEnhancements
-								onSubmitForm={ this.props.handleSubmitForm }
-								handleAutosavingToggle={ handleAutosavingToggle }
-								handleAutosavingRadio={ handleAutosavingRadio }
+					<ThemeEnhancements
+						onSubmitForm={ handleSubmitForm }
+						handleAutosavingToggle={ handleAutosavingToggle }
+						handleAutosavingRadio={ handleAutosavingRadio }
+						isSavingSettings={ isSavingSettings }
+						isRequestingSettings={ isRequestingSettings }
+						jetpackSettingsUI={ jetpackSettingsUI }
+						fields={ fields }
+					/>
+
+					{ jetpackSettingsUI &&
+						config.isEnabled( 'press-this' ) && (
+							<PublishingTools
+								onSubmitForm={ handleSubmitForm }
 								isSavingSettings={ isSavingSettings }
 								isRequestingSettings={ isRequestingSettings }
 								fields={ fields }
 							/>
-
-							{ config.isEnabled( 'press-this' ) && (
-								<PublishingTools
-									onSubmitForm={ this.props.handleSubmitForm }
-									isSavingSettings={ isSavingSettings }
-									isRequestingSettings={ isRequestingSettings }
-									fields={ fields }
-								/>
-							) }
-						</div>
-					) }
+						) }
+				</div>
 
 				{ config.isEnabled( 'press-this' ) &&
 					! this.isMobile() &&
-					! ( this.props.isJetpackSite || this.props.jetpackSettingsUISupported ) && (
+					! ( _isJetpackSite || jetpackSettingsUISupported ) && (
 						<div>
 							{ this.renderSectionHeader(
 								translate( 'Press This', {

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -66,7 +66,6 @@ class SiteSettingsFormWriting extends Component {
 			handleToggle,
 			handleAutosavingToggle,
 			handleAutosavingRadio,
-			isJetpackSite: _isJetpackSite,
 			isRequestingSettings,
 			isSavingSettings,
 			jetpackMasterbarSupported,
@@ -74,11 +73,12 @@ class SiteSettingsFormWriting extends Component {
 			onChangeField,
 			setFieldValue,
 			siteId,
+			siteIsJetpack,
 			translate,
 			updateFields,
 		} = this.props;
 
-		const jetpackSettingsUI = _isJetpackSite && jetpackSettingsUISupported;
+		const jetpackSettingsUI = siteIsJetpack && jetpackSettingsUISupported;
 
 		return (
 			<form
@@ -86,7 +86,7 @@ class SiteSettingsFormWriting extends Component {
 				onSubmit={ handleSubmitForm }
 				className="site-settings__general-settings"
 			>
-				{ _isJetpackSite &&
+				{ siteIsJetpack &&
 					jetpackMasterbarSupported && (
 						<div>
 							{ this.renderSectionHeader( translate( 'WordPress.com toolbar' ), false ) }
@@ -168,7 +168,7 @@ class SiteSettingsFormWriting extends Component {
 
 				{ config.isEnabled( 'press-this' ) &&
 					! this.isMobile() &&
-					! ( _isJetpackSite || jetpackSettingsUISupported ) && (
+					! ( siteIsJetpack || jetpackSettingsUISupported ) && (
 						<div>
 							{ this.renderSectionHeader(
 								translate( 'Press This', {
@@ -192,7 +192,7 @@ const connectComponent = connect(
 		return {
 			jetpackSettingsUISupported: siteSupportsJetpackSettingsUi( state, siteId ),
 			jetpackMasterbarSupported: isJetpackMinimumVersion( state, siteId, '4.8' ),
-			isJetpackSite: isJetpackSite( state, siteId ),
+			siteIsJetpack: isJetpackSite( state, siteId ),
 			siteId,
 		};
 	},

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -210,6 +210,7 @@ const getFormSettings = settings => {
 		'jetpack_portfolio_posts_per_page',
 		'infinite-scroll',
 		'infinite_scroll',
+		'infinite_scroll_blocked',
 		'minileven',
 		'wp_mobile_excerpt',
 		'wp_mobile_featured_images',

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -38,6 +38,7 @@ class ThemeEnhancements extends Component {
 		handleAutosavingRadio: PropTypes.func.isRequired,
 		isSavingSettings: PropTypes.bool,
 		isRequestingSettings: PropTypes.bool,
+		jetpackSettingsUI: PropTypes.bool,
 		fields: PropTypes.object,
 	};
 
@@ -77,6 +78,40 @@ class ThemeEnhancements extends Component {
 	}
 
 	renderInfiniteScrollSettings() {
+		if ( this.props.jetpackSettingsUI ) {
+			return this.renderJetpackInfiniteScrollSettings();
+		}
+		return this.renderSimpleSiteInfiniteScrollSettings();
+	}
+
+	renderSimpleSiteInfiniteScrollSettings() {
+		const { translate } = this.props;
+		return (
+			<FormFieldset>
+				<FormLegend>{ translate( 'Infinite Scroll' ) }</FormLegend>
+
+				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
+					<InfoPopover position="left">
+						<ExternalLink
+							href="https://support.wordpress.com/infinite-scroll/"
+							icon
+							target="_blank"
+						>
+							{ translate( 'Learn more about Infinite Scroll.' ) }
+						</ExternalLink>
+					</InfoPopover>
+				</div>
+
+				{ this.renderToggle(
+					'infinite_scroll',
+					false,
+					translate( 'Load posts as you scroll. Disable to show a clickable button to load posts' )
+				) }
+			</FormFieldset>
+		);
+	}
+
+	renderJetpackInfiniteScrollSettings() {
 		const { translate } = this.props;
 
 		return (
@@ -160,17 +195,14 @@ class ThemeEnhancements extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { jetpackSettingsUI, translate } = this.props;
 		return (
 			<div>
 				<SectionHeader label={ translate( 'Theme Enhancements' ) } />
 
 				<Card className="theme-enhancements__card site-settings">
 					{ this.renderInfiniteScrollSettings() }
-
-					<hr />
-
-					{ this.renderMinilevenSettings() }
+					{ jetpackSettingsUI && <hr /> && this.renderMinilevenSettings() }
 				</Card>
 			</div>
 		);

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -19,7 +19,9 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
+import { getCustomizerUrl } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackModuleActive } from 'state/selectors';
 import InfoPopover from 'components/info-popover';
@@ -78,19 +80,21 @@ class ThemeEnhancements extends Component {
 	}
 
 	renderSimpleSiteInfiniteScrollSettings() {
-		const { translate } = this.props;
+		const { customizeUrl, translate } = this.props;
 		return (
 			<FormFieldset>
 				<FormLegend>{ translate( 'Infinite Scroll' ) }</FormLegend>
 
 				<div className="theme-enhancements__info-link-container site-settings__info-link-container">
 					<InfoPopover position="left">
+						{ translate( 'Control how additional posts are loaded.' ) }
+						<br />
 						<ExternalLink
 							href="https://support.wordpress.com/infinite-scroll/"
 							icon
 							target="_blank"
 						>
-							{ translate( 'Learn more about Infinite Scroll.' ) }
+							{ translate( 'Learn more' ) }
 						</ExternalLink>
 					</InfoPopover>
 				</div>
@@ -98,8 +102,18 @@ class ThemeEnhancements extends Component {
 				{ this.renderToggle(
 					'infinite_scroll',
 					false,
-					translate( 'Load posts as you scroll. Disable to show a clickable button to load posts' )
+					translate( 'Load posts as you scroll. Disable to show a clickable button to load posts.' )
 				) }
+				<FormSettingExplanation isIndented>
+					{ translate(
+						'If your site has a "footer" widget enabled, buttons will always be used. {{link}}Customize your site{{/link}}',
+						{
+							components: {
+								link: <a href={ customizeUrl } />,
+							},
+						}
+					) }
+				</FormSettingExplanation>
 			</FormFieldset>
 		);
 	}
@@ -213,6 +227,7 @@ export default connect( state => {
 	const selectedSiteId = getSelectedSiteId( state );
 
 	return {
+		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		selectedSiteId,
 		infiniteScrollModuleActive: !! isJetpackModuleActive(
 			state,

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -80,7 +81,9 @@ class ThemeEnhancements extends Component {
 	}
 
 	renderSimpleSiteInfiniteScrollSettings() {
-		const { customizeUrl, translate } = this.props;
+		const { customizeUrl, fields, translate } = this.props;
+		const blockedByFooter = 'footer' === get( fields, 'infinite_scroll_blocked' );
+
 		return (
 			<FormFieldset>
 				<FormLegend>{ translate( 'Infinite Scroll' ) }</FormLegend>
@@ -101,19 +104,21 @@ class ThemeEnhancements extends Component {
 
 				{ this.renderToggle(
 					'infinite_scroll',
-					false,
+					blockedByFooter,
 					translate( 'Load posts as you scroll. Disable to show a clickable button to load posts.' )
 				) }
-				<FormSettingExplanation isIndented>
-					{ translate(
-						'If your site has a "footer" widget enabled, buttons will always be used. {{link}}Customize your site{{/link}}',
-						{
-							components: {
-								link: <a href={ customizeUrl } />,
-							},
-						}
-					) }
-				</FormSettingExplanation>
+				{ blockedByFooter && (
+					<FormSettingExplanation isIndented>
+						{ translate(
+							'Your site has a "footer" widget enabled so buttons will always be used. {{link}}Customize your site{{/link}}',
+							{
+								components: {
+									link: <a href={ customizeUrl } />,
+								},
+							}
+						) }
+					</FormSettingExplanation>
+				) }
 			</FormFieldset>
 		);
 	}

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -77,13 +77,6 @@ class ThemeEnhancements extends Component {
 		);
 	}
 
-	renderInfiniteScrollSettings() {
-		if ( this.props.jetpackSettingsUI ) {
-			return this.renderJetpackInfiniteScrollSettings();
-		}
-		return this.renderSimpleSiteInfiniteScrollSettings();
-	}
-
 	renderSimpleSiteInfiniteScrollSettings() {
 		const { translate } = this.props;
 		return (
@@ -201,8 +194,15 @@ class ThemeEnhancements extends Component {
 				<SectionHeader label={ translate( 'Theme Enhancements' ) } />
 
 				<Card className="theme-enhancements__card site-settings">
-					{ this.renderInfiniteScrollSettings() }
-					{ jetpackSettingsUI && <hr /> && this.renderMinilevenSettings() }
+					{ jetpackSettingsUI ? (
+						<div>
+							{ this.renderJetpackInfiniteScrollSettings() }
+							<hr />
+							{ this.renderMinilevenSettings() }
+						</div>
+					) : (
+						this.renderSimpleSiteInfiniteScrollSettings()
+					) }
 				</Card>
 			</div>
 		);


### PR DESCRIPTION
Jetpack sites have the ability to control infinite scroll settings via Calypso Site Settings. See:
* #12174
* #13341
* https://github.com/Automattic/jetpack/issues/6218

This ports the simpler toggle UI from wp-admin into Calypso for WordPress.com Simple sites.

### Current wp-admin setting

<img width="1058" alt="screen shot 2017-12-27 at 3 12 22 pm" src="https://user-images.githubusercontent.com/1587282/34392153-6589bb2c-eb18-11e7-907f-4bd378a3d95a.png">
 
### Calypso setting (for Simple sites)

<img width="734" alt="screen shot 2018-01-09 at 2 18 15 pm" src="https://user-images.githubusercontent.com/1587282/34738731-f9138114-f547-11e7-99a8-60a99ceb0f13.png">

### Calypso setting (for Simple sites) Blocked by a Footer Widget

<img width="744" alt="screen shot 2018-01-09 at 2 17 43 pm" src="https://user-images.githubusercontent.com/1587282/34738749-09716ae4-f548-11e7-9d21-f558ec104b8e.png">

fixes #13237

## To Test

Apply D9203 & follow testing instructions in the Diff
  