### PR TITLE
Comments: Add commentsListQuery object to navigation and actions components

### DIFF
--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -32,7 +32,12 @@ import {
 	recordTracksEvent,
 	withAnalytics,
 } from 'state/analytics/actions';
-import { changeCommentStatus, deleteComment, unlikeComment } from 'state/comments/actions';
+import {
+	changeCommentStatus,
+	deleteComment,
+	requestCommentsList,
+	unlikeComment,
+} from 'state/comments/actions';
 import { removeNotice, successNotice } from 'state/notices/actions';
 import { getSiteComment } from 'state/selectors';
 import { NEWEST_FIRST, OLDEST_FIRST } from '../constants';
@@ -103,9 +108,11 @@ export class CommentNavigation extends Component {
 	setBulkStatus = newStatus => () => {
 		const {
 			changeStatus,
+			commentsListQuery,
 			deletePermanently,
 			postId: isPostView,
 			recordBulkAction,
+			refreshPage,
 			selectedComments,
 			status: queryStatus,
 			toggleBulkMode,
@@ -123,6 +130,11 @@ export class CommentNavigation extends Component {
 				unlike( postId, commentId );
 			}
 		} );
+
+		if ( commentsListQuery ) {
+			refreshPage( commentsListQuery );
+		}
+
 		recordBulkAction(
 			newStatus,
 			selectedComments.length,
@@ -379,6 +391,7 @@ const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
 			)
 		),
 	removeNotice: noticeId => dispatch( removeNotice( noticeId ) ),
+	refreshPage: query => dispatch( requestCommentsList( query ) ),
 	successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
 	unlike: ( postId, commentId ) =>
 		dispatch(

--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -39,14 +39,15 @@ const commentActions = {
 
 export class CommentActions extends Component {
 	static propTypes = {
-		canModerateComment: PropTypes.bool,
 		siteId: PropTypes.number,
 		postId: PropTypes.number,
 		commentId: PropTypes.number,
+		canModerateComment: PropTypes.bool,
+		commentsListQuery: PropTypes.object,
+		redirect: PropTypes.func,
 		toggleEditMode: PropTypes.func,
 		toggleReply: PropTypes.func,
 		updateLastUndo: PropTypes.func,
-		redirect: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -279,7 +280,7 @@ const mapStateToProps = ( state, { siteId, commentId } ) => {
 	};
 };
 
-const mapDispatchToProps = ( dispatch, { siteId, postId, commentId } ) => ( {
+const mapDispatchToProps = ( dispatch, { siteId, postId, commentId, commentsListQuery } ) => ( {
 	changeStatus: ( status, analytics = { alsoUnlike: false, isUndo: false } ) =>
 		dispatch(
 			withAnalytics(
@@ -292,7 +293,7 @@ const mapDispatchToProps = ( dispatch, { siteId, postId, commentId } ) => ( {
 					} ),
 					bumpStat( 'calypso_comment_management', 'comment_status_changed_to_' + status )
 				),
-				changeCommentStatus( siteId, postId, commentId, status )
+				changeCommentStatus( siteId, postId, commentId, status, commentsListQuery )
 			)
 		),
 	deletePermanently: () =>
@@ -302,7 +303,7 @@ const mapDispatchToProps = ( dispatch, { siteId, postId, commentId } ) => ( {
 					recordTracksEvent( 'calypso_comment_management_delete' ),
 					bumpStat( 'calypso_comment_management', 'comment_deleted' )
 				),
-				deleteComment( siteId, postId, commentId, { showSuccessNotice: true } )
+				deleteComment( siteId, postId, commentId, { showSuccessNotice: true }, commentsListQuery )
 			)
 		),
 	like: ( analytics = { alsoApprove: false } ) =>

--- a/client/my-sites/comments/comment/comment-reply.jsx
+++ b/client/my-sites/comments/comment/comment-reply.jsx
@@ -34,6 +34,7 @@ const TEXTAREA_VERTICAL_BORDER = 2;
 export class CommentReply extends Component {
 	static propTypes = {
 		commentId: PropTypes.number,
+		commentsListQuery: PropTypes.object,
 		isReplyVisible: PropTypes.bool,
 	};
 
@@ -188,7 +189,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 	};
 };
 
-const mapDispatchToProps = ( dispatch, { commentId } ) => ( {
+const mapDispatchToProps = ( dispatch, { commentId, commentsListQuery } ) => ( {
 	approveComment: ( siteId, postId, analytics = {} ) =>
 		dispatch(
 			withAnalytics(
@@ -214,7 +215,7 @@ const mapDispatchToProps = ( dispatch, { commentId } ) => ( {
 					} ),
 					bumpStat( 'calypso_comment_management', 'comment_reply' )
 				),
-				replyComment( replyContent, siteId, postId, commentId )
+				replyComment( replyContent, siteId, postId, commentId, commentsListQuery )
 			)
 		),
 	successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -30,6 +30,7 @@ export class Comment extends Component {
 		siteId: PropTypes.number,
 		postId: PropTypes.number,
 		commentId: PropTypes.number,
+		commentsListQuery: PropTypes.object,
 		isEditMode: PropTypes.bool,
 		isBulkMode: PropTypes.bool,
 		isPostView: PropTypes.bool,
@@ -101,6 +102,7 @@ export class Comment extends Component {
 			postId,
 			commentId,
 			commentIsPending,
+			commentsListQuery,
 			isBulkMode,
 			isLoading,
 			isPostView,
@@ -138,13 +140,15 @@ export class Comment extends Component {
 
 						{ ! isBulkMode && (
 							<CommentActions
-								{ ...{ siteId, postId, commentId, redirect, updateLastUndo } }
+								{ ...{ siteId, postId, commentId, commentsListQuery, redirect, updateLastUndo } }
 								toggleEditMode={ this.toggleEditMode }
 								toggleReply={ this.toggleReply }
 							/>
 						) }
 
-						{ ! isBulkMode && <CommentReply { ...{ commentId, isReplyVisible } } /> }
+						{ ! isBulkMode && (
+							<CommentReply { ...{ commentId, commentsListQuery, isReplyVisible } } />
+						) }
 					</div>
 				) }
 

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -161,17 +161,14 @@ export const fetchCommentsList = ( { dispatch }, action ) => {
 	);
 };
 
-export const addComments = (
-	{ dispatch },
-	{ query: { page, postId, search, siteId, status } },
-	{ comments }
-) => {
+export const addComments = ( { dispatch }, { query }, { comments } ) => {
+	const { siteId, status } = query;
 	// Initialize the comments tree to let CommentList know if a tree is actually loaded and empty.
 	// This is needed as a workaround for Jetpack sites populating their comments trees
 	// via `fetchCommentsList` instead of `fetchCommentsTreeForSite`.
 	// @see https://github.com/Automattic/wp-calypso/pull/16997#discussion_r132161699
 	if ( 0 === comments.length ) {
-		dispatch( updateCommentsQuery( siteId, [], { page, postId, search, status } ) );
+		dispatch( updateCommentsQuery( siteId, [], query ) );
 		dispatch( {
 			type: COMMENTS_TREE_SITE_ADD,
 			siteId,
@@ -181,7 +178,7 @@ export const addComments = (
 		return;
 	}
 
-	dispatch( updateCommentsQuery( siteId, comments, { page, postId, search, status } ) );
+	dispatch( updateCommentsQuery( siteId, comments, query ) );
 
 	const byPost = groupBy( comments, ( { post: { ID } } ) => ID );
 


### PR DESCRIPTION
Contributes to #21155

#21004 and #21035 introduced a new `ui.comments.queries` state that helps handling the Comments Management pagination.

To reduce #21077 size and to allow for more experimentation, I've decided to move the non-`CommentList` changes in this PR.

Every action that potentially removes a comment from a list, with the effect of changing that list's pagination, have to fetch the page of comments again.
`commentsListQuery` is an optional parameter that contains all the page information and that, when passed to those actions, triggers a new fetch of the page.

This PR does not build the `commentsListQuery` object (thus the annoying testing instructions), but is limited to adapt `CommentList`'s children components to wait for it.

## Testing instructions

Open `CommentList` (`my-sites/comments/comment-list/index.jsx`) and add this object to the `render` method:
```es6
const commentsListQuery = {
	listType: 'site',
	number: 20,
	order: 'DESC',
	page: 1,
	siteId,
	status,
	type: 'any',
};
```

Then add it as a prop to both `CommentNavigation` and `Comment` instances:
```es6
commentsListQuery={ commentsListQuery }
```

Open `/comments`, perform the following actions and make sure `COMMENTS_QUERY_UPDATE` is dispatched immediately (or soon-ish) after:
- Change status
- Delete permanently
- Reply
- Bulk action (any)