### PR TITLE
Checkout: Add/isEbanx allowed payment method

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -17,7 +17,9 @@ import CreditCardNumberInput from 'components/upgrades/credit-card-number-input'
 import { CountrySelect, StateSelect, Input, HiddenInput } from 'my-sites/domains/components/form';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import { maskField, unmaskField } from 'lib/credit-card-details';
-import { isEbanx } from 'lib/credit-card-details/ebanx';
+import { isEbanxCountry } from 'lib/credit-card-details/ebanx';
+import { isEbanxEnabled } from 'lib/cart-values';
+import CartStore from 'lib/cart/store';
 
 export class CreditCardFormFields extends React.Component {
 	static propTypes = {
@@ -110,8 +112,7 @@ export class CreditCardFormFields extends React.Component {
 	};
 
 	shouldRenderEbanx() {
-		const { countryCode } = this.state;
-		return isEbanx( countryCode );
+		return isEbanxCountry( this.state.countryCode ) && isEbanxEnabled( CartStore.get() );
 	}
 
 	renderEbanxFields() {

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -17,9 +17,7 @@ import CreditCardNumberInput from 'components/upgrades/credit-card-number-input'
 import { CountrySelect, StateSelect, Input, HiddenInput } from 'my-sites/domains/components/form';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import { maskField, unmaskField } from 'lib/credit-card-details';
-import { isEbanxCountry } from 'lib/credit-card-details/ebanx';
-import { isEbanxEnabled } from 'lib/cart-values';
-import CartStore from 'lib/cart/store';
+import { isEbanxEnabledForCountry } from 'lib/credit-card-details/ebanx';
 
 export class CreditCardFormFields extends React.Component {
 	static propTypes = {
@@ -112,7 +110,7 @@ export class CreditCardFormFields extends React.Component {
 	};
 
 	shouldRenderEbanx() {
-		return isEbanxCountry( this.state.countryCode ) && isEbanxEnabled( CartStore.get() );
+		return isEbanxEnabledForCountry( this.state.countryCode );
 	}
 
 	renderEbanxFields() {

--- a/client/components/credit-card-form-fields/test/index.js
+++ b/client/components/credit-card-form-fields/test/index.js
@@ -14,7 +14,7 @@ import identity from 'lodash/identity';
  * Internal dependencies
  */
 import { CreditCardFormFields } from '../';
-import { isEbanx } from 'lib/credit-card-details/ebanx';
+import { isEbanxEnabledForCountry } from 'lib/credit-card-details/ebanx';
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
@@ -22,7 +22,7 @@ jest.mock( 'i18n-calypso', () => ( {
 
 jest.mock( 'lib/credit-card-details/ebanx', () => {
 	return {
-		isEbanx: jest.fn( false ),
+		isEbanxEnabledForCountry: jest.fn( false ),
 	};
 } );
 
@@ -43,10 +43,10 @@ describe( 'CreditCardFormFields', () => {
 
 	describe( 'with ebanx activated', () => {
 		beforeAll( () => {
-			isEbanx.mockReturnValue( true );
+			isEbanxEnabledForCountry.mockReturnValue( true );
 		} );
 		afterAll( () => {
-			isEbanx.mockReturnValue( false );
+			isEbanxEnabledForCountry.mockReturnValue( false );
 		} );
 
 		test( 'should display Ebanx fields when an Ebanx payment country is selected', () => {

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -190,6 +190,13 @@ function isBelgiumBancontactEnabled( cart ) {
 	);
 }
 
+function isEbanxEnabled( cart ) {
+	return (
+		config.isEnabled( 'upgrades/ebanx' ) &&
+		cart.allowed_payment_methods.indexOf( 'WPCOM_Billing_Ebanx' ) >= 0
+	);
+}
+
 export {
 	applyCoupon,
 	canRemoveFromCart,
@@ -205,6 +212,7 @@ export {
 	isPayPalExpressEnabled,
 	isNetherlandsIdealEnabled,
 	isCreditCardPaymentsEnabled,
+	isEbanxEnabled,
 };
 
 export default {
@@ -222,4 +230,5 @@ export default {
 	isPayPalExpressEnabled,
 	isNetherlandsIdealEnabled,
 	isCreditCardPaymentsEnabled,
+	isEbanxEnabled,
 };

--- a/client/lib/credit-card-details/ebanx.js
+++ b/client/lib/credit-card-details/ebanx.js
@@ -17,7 +17,7 @@ import { PAYMENT_PROCESSOR_EBANX_COUNTRIES } from './constants';
  * @param {string} countryCode - a two-letter country code, e.g., 'DE', 'BR'
  * @returns {bool} Whether the country code requires ebanx payment processing
  */
-export function isEbanx( countryCode = '' ) {
+export function isEbanxCountry( countryCode = '' ) {
 	return (
 		! isUndefined( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ countryCode ] ) &&
 		config.isEnabled( 'upgrades/ebanx' )

--- a/client/lib/credit-card-details/ebanx.js
+++ b/client/lib/credit-card-details/ebanx.js
@@ -14,8 +14,8 @@ import { PAYMENT_PROCESSOR_EBANX_COUNTRIES } from './constants';
 
 /**
  *
- * @param {string} countryCode - a two-letter country code, e.g., 'DE', 'BR'
- * @returns {bool} Whether the country code requires ebanx payment processing
+ * @param {String} countryCode - a two-letter country code, e.g., 'DE', 'BR'
+ * @returns {Boolean} Whether the country code requires ebanx payment processing
  */
 export function isEbanxCountry( countryCode = '' ) {
 	return (
@@ -30,8 +30,8 @@ export function isEbanxCountry( countryCode = '' ) {
  * The following test is a weak test only. Full algorithm here: http://www.geradorcpf.com/algoritmo_do_cpf.htm
  *
  * See: http://www.geradorcpf.com/algoritmo_do_cpf.htm
- * @param {string} cpf - a Brazilian tax identification number
- * @returns {bool} Whether the cpf is valid or not
+ * @param {String} cpf - a Brazilian tax identification number
+ * @returns {Boolean} Whether the cpf is valid or not
  */
 
 export function isValidCPF( cpf = '' ) {

--- a/client/lib/credit-card-details/ebanx.js
+++ b/client/lib/credit-card-details/ebanx.js
@@ -9,18 +9,19 @@ import isString from 'lodash/isString';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import { PAYMENT_PROCESSOR_EBANX_COUNTRIES } from './constants';
+import { isEbanxEnabled } from 'lib/cart-values';
+import CartStore from 'lib/cart/store';
 
 /**
  *
  * @param {String} countryCode - a two-letter country code, e.g., 'DE', 'BR'
  * @returns {Boolean} Whether the country code requires ebanx payment processing
  */
-export function isEbanxCountry( countryCode = '' ) {
+export function isEbanxEnabledForCountry( countryCode = '' ) {
 	return (
 		! isUndefined( PAYMENT_PROCESSOR_EBANX_COUNTRIES[ countryCode ] ) &&
-		config.isEnabled( 'upgrades/ebanx' )
+		isEbanxEnabled( CartStore.get() )
 	);
 }
 

--- a/client/lib/credit-card-details/test/ebanx.js
+++ b/client/lib/credit-card-details/test/ebanx.js
@@ -1,5 +1,6 @@
 /**
  * @format
+ * @jest-environment jsdom
  */
 
 /**
@@ -9,31 +10,31 @@
 /**
  * Internal dependencies
  */
-import { isEbanxCountry, isValidCPF } from '../ebanx';
-import { isEnabled } from 'config';
+import { isEbanxEnabledForCountry, isValidCPF } from '../ebanx';
+import { isEbanxEnabled } from 'lib/cart-values';
 
-jest.mock( 'config', () => {
-	const config = () => 'development';
+jest.mock( 'lib/cart-values', () => {
+	const cartValues = {};
 
-	config.isEnabled = jest.fn( false );
+	cartValues.isEbanxEnabled = jest.fn( false );
 
-	return config;
+	return cartValues;
 } );
 
 describe( 'Ebanx payment processing methods', () => {
-	describe( 'isEbanxCountry', () => {
+	describe( 'isEbanxEnabledForCountry', () => {
 		beforeAll( () => {
-			isEnabled.mockReturnValue( true );
+			isEbanxEnabled.mockReturnValue( true );
 		} );
 		afterAll( () => {
-			isEnabled.mockReturnValue( false );
+			isEbanxEnabled.mockReturnValue( false );
 		} );
 
 		test( 'should return false for non-ebanx country', () => {
-			expect( isEbanxCountry( 'AU' ) ).toEqual( false );
+			expect( isEbanxEnabledForCountry( 'AU' ) ).toEqual( false );
 		} );
 		test( 'should return true for ebanx country', () => {
-			expect( isEbanxCountry( 'BR' ) ).toEqual( true );
+			expect( isEbanxEnabledForCountry( 'BR' ) ).toEqual( true );
 		} );
 	} );
 

--- a/client/lib/credit-card-details/test/ebanx.js
+++ b/client/lib/credit-card-details/test/ebanx.js
@@ -9,12 +9,9 @@
 /**
  * Internal dependencies
  */
-import { isEbanx, isValidCPF } from '../ebanx';
+import { isEbanxCountry, isValidCPF } from '../ebanx';
 import { isEnabled } from 'config';
 
-jest.mock( 'lib/abtest', () => ( {
-	abtest: () => 'ebanx',
-} ) );
 jest.mock( 'config', () => {
 	const config = () => 'development';
 
@@ -24,7 +21,7 @@ jest.mock( 'config', () => {
 } );
 
 describe( 'Ebanx payment processing methods', () => {
-	describe( 'isEbanx', () => {
+	describe( 'isEbanxCountry', () => {
 		beforeAll( () => {
 			isEnabled.mockReturnValue( true );
 		} );
@@ -33,10 +30,10 @@ describe( 'Ebanx payment processing methods', () => {
 		} );
 
 		test( 'should return false for non-ebanx country', () => {
-			expect( isEbanx( 'AU' ) ).toEqual( false );
+			expect( isEbanxCountry( 'AU' ) ).toEqual( false );
 		} );
 		test( 'should return true for ebanx country', () => {
-			expect( isEbanx( 'BR' ) ).toEqual( true );
+			expect( isEbanxCountry( 'BR' ) ).toEqual( true );
 		} );
 	} );
 

--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment jsdom
+ */
 
 /**
  * External dependencies

--- a/client/lib/credit-card-details/test/validation.js
+++ b/client/lib/credit-card-details/test/validation.js
@@ -10,11 +10,11 @@ import moment from 'moment';
  * Internal dependencies
  */
 import { validateCardDetails } from '../validation';
-import { isEbanxCountry, isValidCPF } from 'lib/credit-card-details/ebanx';
+import { isEbanxEnabledForCountry, isValidCPF } from 'lib/credit-card-details/ebanx';
 
 jest.mock( 'lib/credit-card-details/ebanx', () => {
 	return {
-		isEbanxCountry: jest.fn( false ),
+		isEbanxEnabledForCountry: jest.fn( false ),
 		isValidCPF: jest.fn( false ),
 	};
 } );
@@ -119,7 +119,7 @@ describe( 'validation', () => {
 
 		describe( 'validate ebanx non-credit card details', () => {
 			beforeAll( () => {
-				isEbanxCountry.mockReturnValue( true );
+				isEbanxEnabledForCountry.mockReturnValue( true );
 				isValidCPF.mockReturnValue( true );
 			} );
 

--- a/client/lib/credit-card-details/test/validation.js
+++ b/client/lib/credit-card-details/test/validation.js
@@ -10,11 +10,11 @@ import moment from 'moment';
  * Internal dependencies
  */
 import { validateCardDetails } from '../validation';
-import { isEbanx, isValidCPF } from 'lib/credit-card-details/ebanx';
+import { isEbanxCountry, isValidCPF } from 'lib/credit-card-details/ebanx';
 
 jest.mock( 'lib/credit-card-details/ebanx', () => {
 	return {
-		isEbanx: jest.fn( false ),
+		isEbanxCountry: jest.fn( false ),
 		isValidCPF: jest.fn( false ),
 	};
 } );
@@ -119,7 +119,7 @@ describe( 'validation', () => {
 
 		describe( 'validate ebanx non-credit card details', () => {
 			beforeAll( () => {
-				isEbanx.mockReturnValue( true );
+				isEbanxCountry.mockReturnValue( true );
 				isValidCPF.mockReturnValue( true );
 			} );
 

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -16,7 +16,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isEbanx, isValidCPF } from 'lib/credit-card-details/ebanx';
+import { isEbanxCountry, isValidCPF } from 'lib/credit-card-details/ebanx';
 import { PAYMENT_PROCESSOR_EBANX_COUNTRIES } from './constants';
 
 function ebanxFieldRules( country ) {
@@ -249,7 +249,7 @@ function getErrors( field, value, cardDetails ) {
  * otherwise `null`
  */
 function getAdditionalFieldRules( { country } ) {
-	if ( isEbanx( country ) ) {
+	if ( isEbanxCountry( country ) ) {
 		return ebanxFieldRules( country );
 	}
 	return null;

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -16,7 +16,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isEbanxCountry, isValidCPF } from 'lib/credit-card-details/ebanx';
+import { isEbanxEnabledForCountry, isValidCPF } from 'lib/credit-card-details/ebanx';
 import { PAYMENT_PROCESSOR_EBANX_COUNTRIES } from './constants';
 
 function ebanxFieldRules( country ) {
@@ -249,7 +249,7 @@ function getErrors( field, value, cardDetails ) {
  * otherwise `null`
  */
 function getAdditionalFieldRules( { country } ) {
-	if ( isEbanxCountry( country ) ) {
+	if ( isEbanxEnabledForCountry( country ) ) {
 		return ebanxFieldRules( country );
 	}
 	return null;

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -23,7 +23,7 @@ import {
 	SUBMITTING_WPCOM_REQUEST,
 } from './step-types';
 import wp from 'lib/wp';
-import { isEbanx } from 'lib/credit-card-details/ebanx';
+import { isEbanxCountry } from 'lib/credit-card-details/ebanx';
 
 const wpcom = wp.undocumented();
 
@@ -139,7 +139,7 @@ TransactionFlow.prototype._paymentHandlers = {
 					country,
 				};
 
-				if ( isEbanx( country ) ) {
+				if ( isEbanxCountry( country ) ) {
 					const ebanxPaymentData = {
 						state,
 						city,
@@ -303,7 +303,7 @@ function createEbanxToken( requestType, cardDetails, callback ) {
 }
 
 function createCardToken( requestType, cardDetails, callback ) {
-	if ( isEbanx( cardDetails.country ) ) {
+	if ( isEbanxCountry( cardDetails.country ) ) {
 		return createEbanxToken( requestType, cardDetails, callback );
 	}
 

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -23,7 +23,7 @@ import {
 	SUBMITTING_WPCOM_REQUEST,
 } from './step-types';
 import wp from 'lib/wp';
-import { isEbanxCountry } from 'lib/credit-card-details/ebanx';
+import { isEbanxEnabledForCountry } from 'lib/credit-card-details/ebanx';
 
 const wpcom = wp.undocumented();
 
@@ -129,7 +129,7 @@ TransactionFlow.prototype._paymentHandlers = {
 
 		this._createCardToken(
 			function( gatewayData ) {
-				const { name, country, 'postal-code': zip, document, city, state } = newCardDetails;
+				const { name, country, 'postal-code': zip } = newCardDetails;
 
 				let paymentData = {
 					payment_method: gatewayData.paymentMethod,
@@ -139,15 +139,15 @@ TransactionFlow.prototype._paymentHandlers = {
 					country,
 				};
 
-				if ( isEbanxCountry( country ) ) {
+				if ( isEbanxEnabledForCountry( country ) ) {
 					const ebanxPaymentData = {
-						state,
-						city,
+						state: newCardDetails.state,
+						city: newCardDetails.city,
 						address_1: newCardDetails[ 'address-1' ],
 						address_2: newCardDetails[ 'address-2' ],
 						street_number: newCardDetails[ 'street-number' ],
 						phone_number: newCardDetails[ 'phone-number' ],
-						document,
+						document: newCardDetails.document,
 					};
 
 					paymentData = { ...paymentData, ...ebanxPaymentData };
@@ -303,7 +303,7 @@ function createEbanxToken( requestType, cardDetails, callback ) {
 }
 
 function createCardToken( requestType, cardDetails, callback ) {
-	if ( isEbanxCountry( cardDetails.country ) ) {
+	if ( isEbanxEnabledForCountry( cardDetails.country ) ) {
 		return createEbanxToken( requestType, cardDetails, callback );
 	}
 

--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -125,7 +125,6 @@ export class PaymentBox extends PureComponent {
 		if ( ! this.props.paymentMethods ) {
 			return null;
 		}
-
 		return this.props.paymentMethods.map( method => {
 			return this.paymentMethod( method );
 		} );


### PR DESCRIPTION
We need to determine if Ebanx payment processing is enabled by checking the `cart.allowed_payment_methods` array for `WPCOM_Billing_Ebanx`.

Cart details are available via `CartStore.get()`. 

The UI also needs a to check which fields to show when a user changes his or her country to an Ebanx-enabled one, so I have consolidated this check in `isEbanxEnabledForCountry()` in __client/lib/credit-card-details/ebanx.js__.

## Questions
1. The store admin doesn't show BRL as a currency option. Which other variables are we using to determine that a payment should be processed through Ebanx?

^^@yoavf 
