### PR TITLE
Stats: Insights: Add annual site stats

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -411,6 +411,7 @@
 @import 'my-sites/stats/activity-log-day/style';
 @import 'my-sites/stats/activity-log-item/style';
 @import 'my-sites/stats/all-time/style';
+@import 'my-sites/stats/annual-site-stats/style';
 @import 'my-sites/stats/checklist-banner/style';
 @import 'my-sites/stats/geochart/style';
 @import 'my-sites/stats/most-popular/style';

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -96,7 +96,7 @@ class AnnualSiteStats extends Component {
 				<SectionHeader label={ translate( 'Annual Site Stats', { args: [ currentYear ] } ) } />
 				<Card className="stats-module">
 					<StatsModulePlaceholder isLoading={ isLoading } />
-					{ isError && <ErrorPanel message={ translate( 'Oops, something went wrong' ) } /> }
+					{ isError && <ErrorPanel message={ translate( 'Oops! Something went wrong.' ) } /> }
 					{ noData && (
 						<ErrorPanel message={ translate( 'No annual stats recorded for this year' ) } />
 					) }

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -1,0 +1,92 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import QuerySiteStats from 'components/data/query-site-stats';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	isRequestingSiteStatsForQuery,
+	getSiteStatsNormalizedData,
+} from 'state/stats/lists/selectors';
+
+class AnnualSiteStats extends Component {
+	static propTypes = {
+		requesting: PropTypes.bool,
+		siteId: PropTypes.number,
+		years: PropTypes.object,
+		translate: PropTypes.func,
+	};
+
+	render() {
+		const { years, requesting, siteId, translate, statType } = this.props;
+		const year = years && years[ '2011' ];
+		if ( ! year ) {
+			return null; // for now
+		}
+		const classes = classNames( 'stats-module', {
+			'is-loading': requesting && ! years,
+			'is-empty': ! years,
+		} );
+
+		return (
+			<div>
+				{ siteId && <QuerySiteStats siteId={ siteId } statType={ statType } /> }
+				<SectionHeader label={ translate( 'Annual Site Stats' ) } />
+				<Card className={ classes }>
+					<div className="annual-site-stats__content">
+						<div className="annual-site-stats__stat">
+							<div className="annual-site-stats__stat-title">year</div>
+							<div className="annual-site-stats__stat-figure is-large">2011</div>
+						</div>
+						<div className="annual-site-stats__stat">
+							<div className="annual-site-stats__stat-title">total posts</div>
+							<div className="annual-site-stats__stat-figure is-large">{ year.total_posts }</div>
+						</div>
+						<div className="annual-site-stats__stat">
+							<div className="annual-site-stats__stat-title">total comments</div>
+							<div className="annual-site-stats__stat-figure">{ year.total_comments }</div>
+						</div>
+						<div className="annual-site-stats__stat">
+							<div className="annual-site-stats__stat-title">total words</div>
+							<div className="annual-site-stats__stat-figure">{ year.total_words }</div>
+						</div>
+						<div className="annual-site-stats__stat">
+							<div className="annual-site-stats__stat-title">avg comments per post</div>
+							<div className="annual-site-stats__stat-figure">{ year.avg_comments }</div>
+						</div>
+						<div className="annual-site-stats__stat">
+							<div className="annual-site-stats__stat-title">avg words per post</div>
+							<div className="annual-site-stats__stat-figure">{ year.avg_words }</div>
+						</div>
+					</div>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default connect( state => {
+	const statType = 'statsInsights';
+	const siteId = getSelectedSiteId( state );
+	const insights = getSiteStatsNormalizedData( state, siteId, statType, {} );
+
+	return {
+		requesting: isRequestingSiteStatsForQuery( state, siteId, statType, {} ),
+		siteId,
+		statType,
+		years: insights.years,
+	};
+} )( localize( AnnualSiteStats ) );

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -79,22 +79,29 @@ class AnnualSiteStats extends Component {
 
 	render() {
 		const { years, translate, moment } = this.props;
-		const currentYear = moment().format( 'YYYY' );
-		const year = years && find( years, y => y.year === currentYear );
+		const now = moment();
+		const currentYear = now.format( 'YYYY' );
+		let previousYear = null;
+		if ( now.month() === 0 ) {
+			previousYear = now.subtract( 1, 'months' ).format( 'YYYY' );
+		}
+		const currentYearData = years && find( years, y => y.year === currentYear );
+		const previousYearData = previousYear && years && find( years, y => y.year === previousYear );
 		const isLoading = ! years;
 		const isError = ! isLoading && years.errors;
-		const noData = ! isLoading && ! isError && ! year;
+		const noData = ! isLoading && ! isError && ! ( currentYearData || previousYearData );
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Annual Site Stats' ) } />
+				<SectionHeader label={ translate( 'Annual Site Stats', { args: [ currentYear ] } ) } />
 				<Card className="stats-module">
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					{ isError && <ErrorPanel message={ translate( 'Oops, something went wrong' ) } /> }
 					{ noData && (
 						<ErrorPanel message={ translate( 'No annual stats recorded for this year' ) } />
 					) }
-					{ year && this.renderContent( year ) }
+					{ previousYearData && this.renderContent( previousYearData ) }
+					{ currentYearData && this.renderContent( currentYearData ) }
 				</Card>
 			</div>
 		);

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,22 +22,23 @@ import {
 	getSiteStatsNormalizedData,
 } from 'state/stats/lists/selectors';
 import StatsModulePlaceholder from 'my-sites/stats/stats-module/placeholder';
+import ErrorPanel from 'my-sites/stats/stats-error';
 
 class AnnualSiteStats extends Component {
 	static propTypes = {
 		requesting: PropTypes.bool,
 		siteId: PropTypes.number,
-		years: PropTypes.object,
+		years: PropTypes.array,
 		translate: PropTypes.func,
 		moment: PropTypes.func,
 	};
 
-	renderContent( currentYear, data ) {
+	renderContent( data ) {
 		return (
 			<div className="annual-site-stats__content">
 				<div className="annual-site-stats__stat">
 					<div className="annual-site-stats__stat-title">year</div>
-					<div className="annual-site-stats__stat-figure is-large">{ currentYear }</div>
+					<div className="annual-site-stats__stat-figure is-large">{ data.year }</div>
 				</div>
 				<div className="annual-site-stats__stat">
 					<div className="annual-site-stats__stat-title">total posts</div>
@@ -47,12 +49,20 @@ class AnnualSiteStats extends Component {
 					<div className="annual-site-stats__stat-figure">{ data.total_comments }</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">total words</div>
-					<div className="annual-site-stats__stat-figure">{ data.total_words }</div>
-				</div>
-				<div className="annual-site-stats__stat">
 					<div className="annual-site-stats__stat-title">avg comments per post</div>
 					<div className="annual-site-stats__stat-figure">{ data.avg_comments }</div>
+				</div>
+				<div className="annual-site-stats__stat">
+					<div className="annual-site-stats__stat-title">total likes</div>
+					<div className="annual-site-stats__stat-figure">{ data.total_likes }</div>
+				</div>
+				<div className="annual-site-stats__stat">
+					<div className="annual-site-stats__stat-title">avg likes per post</div>
+					<div className="annual-site-stats__stat-figure">{ data.avg_likes }</div>
+				</div>
+				<div className="annual-site-stats__stat">
+					<div className="annual-site-stats__stat-title">total words</div>
+					<div className="annual-site-stats__stat-figure">{ data.total_words }</div>
 				</div>
 				<div className="annual-site-stats__stat">
 					<div className="annual-site-stats__stat-title">avg words per post</div>
@@ -65,13 +75,7 @@ class AnnualSiteStats extends Component {
 	render() {
 		const { years, requesting, siteId, translate, moment, statType } = this.props;
 		const currentYear = moment().format( 'YYYY' );
-		const defaultYear = {
-			avg_comments: 0,
-			avg_words: 0,
-			total_comments: 0,
-			total_posts: 0,
-			total_words: 0,
-		};
+		const year = years && find( years, y => y.year === currentYear );
 		const isLoading = requesting && ! years;
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
@@ -80,7 +84,9 @@ class AnnualSiteStats extends Component {
 				<SectionHeader label={ translate( 'Annual Site Stats' ) } />
 				<Card className="stats-module">
 					<StatsModulePlaceholder isLoading={ isLoading } />
-					{ years && this.renderContent( currentYear, years[ currentYear ] || defaultYear ) }
+					{ ! year &&
+						! isLoading && <ErrorPanel message={ 'No annual stats recorded for this year.' } /> }
+					{ year && this.renderContent( year ) }
 				</Card>
 			</div>
 		);

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -6,7 +6,6 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -21,6 +20,7 @@ import {
 	isRequestingSiteStatsForQuery,
 	getSiteStatsNormalizedData,
 } from 'state/stats/lists/selectors';
+import StatsModulePlaceholder from 'my-sites/stats/stats-module/placeholder';
 
 class AnnualSiteStats extends Component {
 	static propTypes = {
@@ -28,53 +28,63 @@ class AnnualSiteStats extends Component {
 		siteId: PropTypes.number,
 		years: PropTypes.object,
 		translate: PropTypes.func,
+		moment: PropTypes.func,
 	};
 
-	render() {
-		const { years, requesting, siteId, translate, statType } = this.props;
-		const year = years && years[ '2011' ];
-		if ( ! year ) {
-			return null; // for now
-		}
-		const classes = classNames( 'stats-module', {
-			'is-loading': requesting && ! years,
-			'is-empty': ! years,
-		} );
+	renderContent( currentYear, data ) {
+		return (
+			<div className="annual-site-stats__content">
+				<div className="annual-site-stats__stat">
+					<div className="annual-site-stats__stat-title">year</div>
+					<div className="annual-site-stats__stat-figure is-large">{ currentYear }</div>
+				</div>
+				<div className="annual-site-stats__stat">
+					<div className="annual-site-stats__stat-title">total posts</div>
+					<div className="annual-site-stats__stat-figure is-large">{ data.total_posts }</div>
+				</div>
+				<div className="annual-site-stats__stat">
+					<div className="annual-site-stats__stat-title">total comments</div>
+					<div className="annual-site-stats__stat-figure">{ data.total_comments }</div>
+				</div>
+				<div className="annual-site-stats__stat">
+					<div className="annual-site-stats__stat-title">total words</div>
+					<div className="annual-site-stats__stat-figure">{ data.total_words }</div>
+				</div>
+				<div className="annual-site-stats__stat">
+					<div className="annual-site-stats__stat-title">avg comments per post</div>
+					<div className="annual-site-stats__stat-figure">{ data.avg_comments }</div>
+				</div>
+				<div className="annual-site-stats__stat">
+					<div className="annual-site-stats__stat-title">avg words per post</div>
+					<div className="annual-site-stats__stat-figure">{ data.avg_words }</div>
+				</div>
+			</div>
+		);
+	}
 
+	render() {
+		const { years, requesting, siteId, translate, moment, statType } = this.props;
+		const currentYear = moment().format( 'YYYY' );
+		const defaultYear = {
+			avg_comments: 0,
+			avg_words: 0,
+			total_comments: 0,
+			total_posts: 0,
+			total_words: 0,
+		};
+		const isLoading = requesting && ! years;
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div>
 				{ siteId && <QuerySiteStats siteId={ siteId } statType={ statType } /> }
 				<SectionHeader label={ translate( 'Annual Site Stats' ) } />
-				<Card className={ classes }>
-					<div className="annual-site-stats__content">
-						<div className="annual-site-stats__stat">
-							<div className="annual-site-stats__stat-title">year</div>
-							<div className="annual-site-stats__stat-figure is-large">2011</div>
-						</div>
-						<div className="annual-site-stats__stat">
-							<div className="annual-site-stats__stat-title">total posts</div>
-							<div className="annual-site-stats__stat-figure is-large">{ year.total_posts }</div>
-						</div>
-						<div className="annual-site-stats__stat">
-							<div className="annual-site-stats__stat-title">total comments</div>
-							<div className="annual-site-stats__stat-figure">{ year.total_comments }</div>
-						</div>
-						<div className="annual-site-stats__stat">
-							<div className="annual-site-stats__stat-title">total words</div>
-							<div className="annual-site-stats__stat-figure">{ year.total_words }</div>
-						</div>
-						<div className="annual-site-stats__stat">
-							<div className="annual-site-stats__stat-title">avg comments per post</div>
-							<div className="annual-site-stats__stat-figure">{ year.avg_comments }</div>
-						</div>
-						<div className="annual-site-stats__stat">
-							<div className="annual-site-stats__stat-title">avg words per post</div>
-							<div className="annual-site-stats__stat-figure">{ year.avg_words }</div>
-						</div>
-					</div>
+				<Card className="stats-module">
+					<StatsModulePlaceholder isLoading={ isLoading } />
+					{ years && this.renderContent( currentYear, years[ currentYear ] || defaultYear ) }
 				</Card>
 			</div>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -16,10 +16,7 @@ import { find } from 'lodash';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import {
-	isRequestingSiteStatsForQuery,
-	getSiteStatsNormalizedData,
-} from 'state/stats/lists/selectors';
+import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
 import StatsModulePlaceholder from 'my-sites/stats/stats-module/placeholder';
 import ErrorPanel from 'my-sites/stats/stats-error';
 
@@ -81,20 +78,22 @@ class AnnualSiteStats extends Component {
 	}
 
 	render() {
-		const { years, requesting, translate, moment } = this.props;
+		const { years, translate, moment } = this.props;
 		const currentYear = moment().format( 'YYYY' );
 		const year = years && find( years, y => y.year === currentYear );
-		const isLoading = requesting && ! years;
+		const isLoading = ! years;
+		const isError = ! isLoading && years.errors;
+		const noData = ! isLoading && ! isError && ! year;
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div>
 				<SectionHeader label={ translate( 'Annual Site Stats' ) } />
 				<Card className="stats-module">
 					<StatsModulePlaceholder isLoading={ isLoading } />
-					{ ! year &&
-						! isLoading && (
-							<ErrorPanel message={ translate( 'No annual stats recorded for this year' ) } />
-						) }
+					{ isError && <ErrorPanel message={ translate( 'Oops, something went wrong' ) } /> }
+					{ noData && (
+						<ErrorPanel message={ translate( 'No annual stats recorded for this year' ) } />
+					) }
 					{ year && this.renderContent( year ) }
 				</Card>
 			</div>
@@ -109,7 +108,6 @@ export default connect( state => {
 	const insights = getSiteStatsNormalizedData( state, siteId, statType, {} );
 
 	return {
-		requesting: isRequestingSiteStatsForQuery( state, siteId, statType, {} ),
 		years: insights.years,
 	};
 } )( localize( AnnualSiteStats ) );

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -33,7 +33,7 @@ class AnnualSiteStats extends Component {
 		const { translate, numberFormat } = this.props;
 		return (
 			<div className="annual-site-stats__content">
-				<div className="annual-site-stats__stat">
+				<div className="annual-site-stats__stat is-year">
 					<div className="annual-site-stats__stat-title">{ translate( 'year' ) }</div>
 					<div className="annual-site-stats__stat-figure is-large">{ data.year }</div>
 				</div>

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -28,6 +28,7 @@ class AnnualSiteStats extends Component {
 		requesting: PropTypes.bool,
 		years: PropTypes.array,
 		translate: PropTypes.func,
+		numberFormat: PropTypes.func,
 		moment: PropTypes.func,
 	};
 

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -15,7 +15,6 @@ import { find } from 'lodash';
  */
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
-import QuerySiteStats from 'components/data/query-site-stats';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	isRequestingSiteStatsForQuery,
@@ -27,14 +26,13 @@ import ErrorPanel from 'my-sites/stats/stats-error';
 class AnnualSiteStats extends Component {
 	static propTypes = {
 		requesting: PropTypes.bool,
-		siteId: PropTypes.number,
 		years: PropTypes.array,
 		translate: PropTypes.func,
 		moment: PropTypes.func,
 	};
 
 	renderContent( data ) {
-		const { translate } = this.props;
+		const { translate, numberFormat } = this.props;
 		return (
 			<div className="annual-site-stats__content">
 				<div className="annual-site-stats__stat">
@@ -43,47 +41,52 @@ class AnnualSiteStats extends Component {
 				</div>
 				<div className="annual-site-stats__stat">
 					<div className="annual-site-stats__stat-title">{ translate( 'total posts' ) }</div>
-					<div className="annual-site-stats__stat-figure is-large">{ data.total_posts }</div>
+					<div className="annual-site-stats__stat-figure is-large">
+						{ numberFormat( data.total_posts ) }
+					</div>
 				</div>
 				<div className="annual-site-stats__stat">
 					<div className="annual-site-stats__stat-title">{ translate( 'total comments' ) }</div>
-					<div className="annual-site-stats__stat-figure">{ data.total_comments }</div>
+					<div className="annual-site-stats__stat-figure">
+						{ numberFormat( data.total_comments ) }
+					</div>
 				</div>
 				<div className="annual-site-stats__stat">
 					<div className="annual-site-stats__stat-title">
 						{ translate( 'avg comments per post' ) }
 					</div>
-					<div className="annual-site-stats__stat-figure">{ data.avg_comments }</div>
+					<div className="annual-site-stats__stat-figure">
+						{ numberFormat( data.avg_comments ) }
+					</div>
 				</div>
 				<div className="annual-site-stats__stat">
 					<div className="annual-site-stats__stat-title">{ translate( 'total likes' ) }</div>
-					<div className="annual-site-stats__stat-figure">{ data.total_likes }</div>
+					<div className="annual-site-stats__stat-figure">{ numberFormat( data.total_likes ) }</div>
 				</div>
 				<div className="annual-site-stats__stat">
 					<div className="annual-site-stats__stat-title">{ translate( 'avg likes per post' ) }</div>
-					<div className="annual-site-stats__stat-figure">{ data.avg_likes }</div>
+					<div className="annual-site-stats__stat-figure">{ numberFormat( data.avg_likes ) }</div>
 				</div>
 				<div className="annual-site-stats__stat">
 					<div className="annual-site-stats__stat-title">{ translate( 'total words' ) }</div>
-					<div className="annual-site-stats__stat-figure">{ data.total_words }</div>
+					<div className="annual-site-stats__stat-figure">{ numberFormat( data.total_words ) }</div>
 				</div>
 				<div className="annual-site-stats__stat">
 					<div className="annual-site-stats__stat-title">{ translate( 'avg words per post' ) }</div>
-					<div className="annual-site-stats__stat-figure">{ data.avg_words }</div>
+					<div className="annual-site-stats__stat-figure">{ numberFormat( data.avg_words ) }</div>
 				</div>
 			</div>
 		);
 	}
 
 	render() {
-		const { years, requesting, siteId, translate, moment, statType } = this.props;
+		const { years, requesting, translate, moment } = this.props;
 		const currentYear = moment().format( 'YYYY' );
 		const year = years && find( years, y => y.year === currentYear );
 		const isLoading = requesting && ! years;
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div>
-				{ siteId && <QuerySiteStats siteId={ siteId } statType={ statType } /> }
 				<SectionHeader label={ translate( 'Annual Site Stats' ) } />
 				<Card className="stats-module">
 					<StatsModulePlaceholder isLoading={ isLoading } />
@@ -106,8 +109,6 @@ export default connect( state => {
 
 	return {
 		requesting: isRequestingSiteStatsForQuery( state, siteId, statType, {} ),
-		siteId,
-		statType,
 		years: insights.years,
 	};
 } )( localize( AnnualSiteStats ) );

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -34,38 +34,41 @@ class AnnualSiteStats extends Component {
 	};
 
 	renderContent( data ) {
+		const { translate } = this.props;
 		return (
 			<div className="annual-site-stats__content">
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">year</div>
+					<div className="annual-site-stats__stat-title">{ translate( 'year' ) }</div>
 					<div className="annual-site-stats__stat-figure is-large">{ data.year }</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">total posts</div>
+					<div className="annual-site-stats__stat-title">{ translate( 'total posts' ) }</div>
 					<div className="annual-site-stats__stat-figure is-large">{ data.total_posts }</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">total comments</div>
+					<div className="annual-site-stats__stat-title">{ translate( 'total comments' ) }</div>
 					<div className="annual-site-stats__stat-figure">{ data.total_comments }</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">avg comments per post</div>
+					<div className="annual-site-stats__stat-title">
+						{ translate( 'avg comments per post' ) }
+					</div>
 					<div className="annual-site-stats__stat-figure">{ data.avg_comments }</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">total likes</div>
+					<div className="annual-site-stats__stat-title">{ translate( 'total likes' ) }</div>
 					<div className="annual-site-stats__stat-figure">{ data.total_likes }</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">avg likes per post</div>
+					<div className="annual-site-stats__stat-title">{ translate( 'avg likes per post' ) }</div>
 					<div className="annual-site-stats__stat-figure">{ data.avg_likes }</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">total words</div>
+					<div className="annual-site-stats__stat-title">{ translate( 'total words' ) }</div>
 					<div className="annual-site-stats__stat-figure">{ data.total_words }</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">avg words per post</div>
+					<div className="annual-site-stats__stat-title">{ translate( 'avg words per post' ) }</div>
 					<div className="annual-site-stats__stat-figure">{ data.avg_words }</div>
 				</div>
 			</div>
@@ -85,7 +88,9 @@ class AnnualSiteStats extends Component {
 				<Card className="stats-module">
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					{ ! year &&
-						! isLoading && <ErrorPanel message={ 'No annual stats recorded for this year.' } /> }
+						! isLoading && (
+							<ErrorPanel message={ translate( 'No annual stats recorded for this year' ) } />
+						) }
 					{ year && this.renderContent( year ) }
 				</Card>
 			</div>

--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -100,8 +100,8 @@ class AnnualSiteStats extends Component {
 					{ noData && (
 						<ErrorPanel message={ translate( 'No annual stats recorded for this year' ) } />
 					) }
-					{ previousYearData && this.renderContent( previousYearData ) }
 					{ currentYearData && this.renderContent( currentYearData ) }
+					{ previousYearData && this.renderContent( previousYearData ) }
 				</Card>
 			</div>
 		);

--- a/client/my-sites/stats/annual-site-stats/style.scss
+++ b/client/my-sites/stats/annual-site-stats/style.scss
@@ -1,0 +1,28 @@
+.annual-site-stats_content {
+	padding: 16px;
+	display: flex;
+	flex-wrap: wrap;
+
+	@include breakpoint( ">480px" ) {
+		padding: 16px 24px;
+	}
+}
+
+.annual-site-stats_stat {
+	width: 50%;
+	padding-bottom: 12px;
+}
+
+.annual-site-stats_stat-title {
+	font-size: 12px;
+	text-transform: uppercase;
+	color: $gray;
+}
+
+.annual-site-stats_stat-figure {
+	font-size: 18px;
+
+	&.is-large {
+		font-size: 24px;
+	}
+}

--- a/client/my-sites/stats/annual-site-stats/style.scss
+++ b/client/my-sites/stats/annual-site-stats/style.scss
@@ -1,7 +1,7 @@
 .annual-site-stats__content {
-	padding: 16px 16px 0;
 	display: flex;
 	flex-wrap: wrap;
+	padding: 0;
 
 	@include breakpoint( ">480px" ) {
 		padding: 16px 24px 0;
@@ -9,27 +9,61 @@
 }
 
 .annual-site-stats__stat {
+	display: flex;
+	flex-direction: column;
 	padding-bottom: 16px;
 
-	&:nth-child(2n+1) {
-		width: 55%;
+	@include breakpoint( "<480px" ) {
+		border-bottom: 1px solid $gray-light;
+		flex-direction: row;
+		flex-basis: 100%;
+		padding: 13px 16px;
 	}
 
-	&:nth-child(2n+0) {
-		width: 45%;
+	&:nth-child( 2n + 1 ) {
+		width: 50%;
+
+		@include breakpoint( ">960px" ) {
+			width: 45%;
+		}
+	}
+
+	&:nth-child( 2n + 0 ) {
+		width: 50%;
+
+		@include breakpoint( ">960px" ) {
+			width: 55%;
+		}
 	}
 }
 
 .annual-site-stats__stat-title {
-	font-size: 12px;
-	text-transform: uppercase;
 	color: $gray;
+	font-size: 11px;
+	text-transform: uppercase;
+
+	@include breakpoint( "<480px" ) {
+		color: $gray-dark;
+		font-size: 14px;
+		text-transform: capitalize;
+		width: 50%;
+	}
 }
 
 .annual-site-stats__stat-figure {
 	font-size: 18px;
 
+	@include breakpoint( "<480px" ) {
+		font-size: 14px;
+		text-align: right;
+		width: 50%;
+	}
+
 	&.is-large {
-		font-size: 30px;
+		font-size: 14px;
+
+		@include breakpoint( ">480px" ) {
+			font-size: 30px;
+		}
 	}
 }

--- a/client/my-sites/stats/annual-site-stats/style.scss
+++ b/client/my-sites/stats/annual-site-stats/style.scss
@@ -1,9 +1,10 @@
+/** @format */
 .annual-site-stats__content {
 	display: flex;
 	flex-wrap: wrap;
 	padding: 0;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		padding: 16px 24px 0;
 	}
 }
@@ -13,25 +14,29 @@
 	flex-direction: column;
 	padding-bottom: 16px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		border-bottom: 1px solid $gray-light;
 		flex-direction: row;
 		flex-basis: 100%;
 		padding: 13px 16px;
+
+		&.is-year {
+			font-weight: bold;
+		}
 	}
 
-	&:nth-child( 2n + 1 ) {
+	&:nth-child(2n + 1) {
 		width: 50%;
 
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			width: 45%;
 		}
 	}
 
-	&:nth-child( 2n + 0 ) {
+	&:nth-child(2n + 0) {
 		width: 50%;
 
-		@include breakpoint( ">960px" ) {
+		@include breakpoint( '>960px' ) {
 			width: 55%;
 		}
 	}
@@ -42,7 +47,7 @@
 	font-size: 11px;
 	text-transform: uppercase;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		color: $gray-dark;
 		font-size: 14px;
 		text-transform: capitalize;
@@ -53,16 +58,20 @@
 .annual-site-stats__stat-figure {
 	font-size: 18px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( '<480px' ) {
 		font-size: 14px;
 		text-align: right;
 		width: 50%;
+
+		.is-year {
+			font-weight: bold;
+		}
 	}
 
 	&.is-large {
 		font-size: 14px;
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoint( '>480px' ) {
 			font-size: 30px;
 		}
 	}

--- a/client/my-sites/stats/annual-site-stats/style.scss
+++ b/client/my-sites/stats/annual-site-stats/style.scss
@@ -1,28 +1,35 @@
-.annual-site-stats_content {
-	padding: 16px;
+.annual-site-stats__content {
+	padding: 16px 16px 0;
 	display: flex;
 	flex-wrap: wrap;
 
 	@include breakpoint( ">480px" ) {
-		padding: 16px 24px;
+		padding: 16px 24px 0;
 	}
 }
 
-.annual-site-stats_stat {
-	width: 50%;
-	padding-bottom: 12px;
+.annual-site-stats__stat {
+	padding-bottom: 16px;
+
+	&:nth-child(2n+1) {
+		width: 55%;
+	}
+
+	&:nth-child(2n+0) {
+		width: 45%;
+	}
 }
 
-.annual-site-stats_stat-title {
+.annual-site-stats__stat-title {
 	font-size: 12px;
 	text-transform: uppercase;
 	color: $gray;
 }
 
-.annual-site-stats_stat-figure {
+.annual-site-stats__stat-figure {
 	font-size: 18px;
 
 	&.is-large {
-		font-size: 24px;
+		font-size: 30px;
 	}
 }

--- a/client/my-sites/stats/most-popular/index.jsx
+++ b/client/my-sites/stats/most-popular/index.jsx
@@ -41,7 +41,6 @@ class StatsMostPopular extends Component {
 			'is-loading': requesting && ! percent,
 			'is-empty': ! percent,
 		} );
-
 		return (
 			<div>
 				{ siteId && <QuerySiteStats siteId={ siteId } statType={ statType } /> }

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -32,6 +32,7 @@ import Followers from '../stats-followers';
 import JetpackColophon from 'components/jetpack-colophon';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import AnnualSiteStats from 'my-sites/stats/annual-site-stats';
 
 const StatsInsights = props => {
 	const { followList, isJetpack, siteId, siteSlug, translate } = props;
@@ -66,6 +67,7 @@ const StatsInsights = props => {
 							<LatestPostSummary />
 							<MostPopular />
 							{ tagsList }
+							<AnnualSiteStats />
 						</div>
 						<div className="stats__module-column">
 							<Reach />

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1009,6 +1009,7 @@ describe( 'utils', () => {
 					highest_day_of_week: 6,
 					highest_hour_percent: 5,
 					hourly_views: [],
+					years: [],
 				} );
 
 				expect( stats ).to.eql( {
@@ -1017,6 +1018,7 @@ describe( 'utils', () => {
 					hourPercent: 5,
 					percent: 10,
 					hourlyViews: [],
+					years: [],
 				} );
 			} );
 		} );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -332,6 +332,7 @@ export const normalizers = {
 			highest_day_of_week,
 			highest_hour_percent,
 			hourly_views,
+			years,
 		} = data;
 
 		// Adjust Day of Week from 0 = Monday to 0 = Sunday (for Moment)
@@ -351,6 +352,7 @@ export const normalizers = {
 				.format( 'LT' ),
 			hourPercent: Math.round( highest_hour_percent ),
 			hourlyViews: hourly_views,
+			years,
 		};
 	},
 


### PR DESCRIPTION
Add yearly stats as a stats module to Insights page

<img width="458" alt="screen shot 2017-12-28 at 10 21 51 pm" src="https://user-images.githubusercontent.com/1922453/34406616-f3194668-ec1e-11e7-8ad9-1ccfdb29c1fe.png">

cc @jancavan 

### Notes
* Average Comments is taken to one decimal place. Maybe this should only be for values < 10 or something?
* "View All" link at the bottom of the module can be included in the next PR that creates that page

### ToDo
- [x] Finalize design and update CSS and markup
- [x] i18n strings
- [x] Fix failing tests around the `utils` modification
