### PR TITLE
Jetpack Onboarding: Introduce generic enter animations on all steps

### DIFF
--- a/assets/stylesheets/shared/_animation.scss
+++ b/assets/stylesheets/shared/_animation.scss
@@ -238,6 +238,17 @@ html {
 	}
 }
 
+@keyframes appearWithScaling {
+	0% {
+		transform: scale( 0.5, 0.5 );
+		opacity: 0;
+	}
+	100% {
+		transform: scale( 1, 1 );
+		opacity: 1;
+	}
+}
+
 @keyframes pulse-light {
 	50% { background-color: lighten( $gray, 30% ); }
 }

--- a/assets/stylesheets/shared/_animation.scss
+++ b/assets/stylesheets/shared/_animation.scss
@@ -240,7 +240,7 @@ html {
 
 @keyframes appearWithScaling {
 	0% {
-		transform: scale( 0.5, 0.5 );
+		transform: scale( 0.9, 0.9 );
 		opacity: 0;
 	}
 	100% {

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 /**
@@ -54,7 +54,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		);
 
 		return (
-			<Fragment>
+			<div className="steps__main">
 				<DocumentHead title={ translate( 'Business Address ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
 					path={ '/jetpack/onboarding/' + STEPS.BUSINESS_ADDRESS + '/:site' }
@@ -81,7 +81,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 						</Button>
 					</form>
 				</Card>
-			</Fragment>
+			</div>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -29,7 +29,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 		const subHeaderText = translate( 'Would you like to get started with a Contact Us page?' );
 
 		return (
-			<Fragment>
+			<div className="steps__main">
 				<DocumentHead title={ translate( 'Contact Form ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
 					path={ '/jetpack/onboarding/' + STEPS.CONTACT_FORM + '/:site' }
@@ -48,7 +48,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 						onClick={ this.clickAddContactForm }
 					/>
 				</TileGrid>
-			</Fragment>
+			</div>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -36,7 +36,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 		const forwardUrl = getForwardUrl();
 
 		return (
-			<Fragment>
+			<div className="steps__main">
 				<DocumentHead title={ translate( 'Homepage ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
 					path={ '/jetpack/onboarding/' + STEPS.HOMEPAGE + '/:site' }
@@ -63,7 +63,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 						onClick={ this.handleHomepageSelection( 'page' ) }
 					/>
 				</TileGrid>
-			</Fragment>
+			</div>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -51,7 +51,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 		);
 
 		return (
-			<Fragment>
+			<div className="steps__main">
 				<DocumentHead title={ translate( 'Site Title ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
 					path={ '/jetpack/onboarding/' + STEPS.SITE_TITLE + '/:site' }
@@ -86,7 +86,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 						</Button>
 					</form>
 				</Card>
-			</Fragment>
+			</div>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -23,7 +23,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 		const subHeaderText = translate( 'What kind of site do you need? Choose an option below:' );
 
 		return (
-			<Fragment>
+			<div className="steps__main">
 				<DocumentHead title={ translate( 'Site Type ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
 					path={ '/jetpack/onboarding/' + STEPS.SITE_TYPE + '/:site' }
@@ -48,7 +48,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 						image={ '/calypso/images/illustrations/type-business.svg' }
 					/>
 				</TileGrid>
-			</Fragment>
+			</div>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
@@ -66,7 +66,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 		const buttonRedirectHref = '#';
 
 		return (
-			<Fragment>
+			<div className="steps__main">
 				<DocumentHead title={ translate( 'Summary ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
 					path={ '/jetpack/onboarding/' + STEPS.SUMMARY + '/:site' }
@@ -89,7 +89,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 						{ translate( 'Visit your site' ) }
 					</Button>
 				</div>
-			</Fragment>
+			</div>
 		);
 	}
 }

--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -24,7 +24,7 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 		);
 
 		return (
-			<Fragment>
+			<div className="steps__main">
 				<DocumentHead title={ translate( 'WooCommerce ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
 					path={ '/jetpack/onboarding/' + STEPS.WOOCOMMERCE + '/:site' }
@@ -37,7 +37,7 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 					<Button primary>{ translate( 'Yes, I am' ) }</Button>
 					<Button>{ translate( 'Not right now' ) }</Button>
 				</div>
-			</Fragment>
+			</div>
 		);
 	}
 }

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -1,4 +1,8 @@
 .jetpack-onboarding {
+	.steps__main {
+		animation: appearWithScaling .3s ease-in-out;
+	}
+
 	.steps__form {
 		max-width: 320px;
 


### PR DESCRIPTION
This PR introduces a very generic enter animation on all Jetpack Onboarding step - fading in with scaling from 50% to 100%. It's pretty basic, but should do the job as a first iteration.

To test:
* Checkout this branch.
* Go to http://calypso.localhost:3000/jetpack/onboarding/homepage/site-title
* Skip consistently to reach the last Summary step, and in the meantime verify that you can see the entry animation when each of the steps is displayed.