### PR TITLE
Fix: Allow to switch to default locale

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -32,11 +32,8 @@ function setLocaleInDOM( localeSlug, isRTL ) {
 	switchCSS( 'main-css', cssUrl );
 }
 
+const switchLocaleRequestStack = [];
 export default function switchLocale( localeSlug ) {
-	if ( localeSlug === i18n.getLocaleSlug() ) {
-		return;
-	}
-
 	const language = getLanguage( localeSlug );
 
 	if ( ! language ) {
@@ -49,6 +46,8 @@ export default function switchLocale( localeSlug ) {
 		return;
 	}
 
+	switchLocaleRequestStack.push( localeSlug );
+
 	if ( isDefaultLocale( localeSlug ) ) {
 		i18n.configure( { defaultLocaleSlug: localeSlug } );
 		setLocaleInDOM( localeSlug, !! language.rtl );
@@ -60,6 +59,12 @@ export default function switchLocale( localeSlug ) {
 						localeSlug +
 						'. Falling back to English.'
 				);
+				return;
+			}
+
+			// Handle race condition when we're requested to switch to a different
+			// locale while we're in the middle of request, we should abondon result
+			if ( localeSlug !== switchLocaleRequestStack[ switchLocaleRequestStack.length - 1 ] ) {
 				return;
 			}
 


### PR DESCRIPTION
When user is set to non English locale, he can't get an English log-in page, although we say they can.

![switch-to-en](https://user-images.githubusercontent.com/326402/34413552-e1931518-ebec-11e7-8400-e6473c897beb.gif)
