### PR TITLE
Security Settings: empty header for spam filtering card when there's no Akismet key

### DIFF
--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { includes } from 'lodash';
+import { includes, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,11 +42,14 @@ const SpamFilteringSettings = ( {
 	const { akismet: akismetActive, wordpress_api_key } = fields;
 	const isStoredKey = wordpress_api_key === currentAkismetKey;
 	const isDirty = includes( dirtyFields, 'wordpress_api_key' );
+	const isCurrentKeyEmpty = isEmpty( currentAkismetKey );
+	const isKeyFieldEmpty = isEmpty( wordpress_api_key );
+	const isEmptyKey = isCurrentKeyEmpty || isKeyFieldEmpty;
 	const inTransition = isRequestingSettings || isSavingSettings;
 	const isValidKey =
 		( wordpress_api_key && isStoredKey ) ||
 		( wordpress_api_key && isDirty && isStoredKey && ! hasAkismetKeyError );
-	const isInvalidKey = isDirty && hasAkismetKeyError && ! isStoredKey;
+	const isInvalidKey = ( isDirty && hasAkismetKeyError && ! isStoredKey ) || isEmptyKey;
 	let validationText,
 		className,
 		header = null;
@@ -73,8 +76,9 @@ const SpamFilteringSettings = ( {
 			</div>
 		);
 	}
+
 	if ( ! inTransition && isInvalidKey ) {
-		validationText = translate( "There's a problem with your Antispam API key." );
+		validationText = translate( 'Please enter a valid Antispam API key.' );
 		className = 'is-error';
 		header = (
 			<div>
@@ -83,6 +87,7 @@ const SpamFilteringSettings = ( {
 			</div>
 		);
 	}
+
 	return (
 		<FoldableCard
 			header={ header }


### PR DESCRIPTION
I noticed that this card was showing an empty text and when I unfolded it, I saw the key was missing which is why this doesn't have a header.

<img width="749" alt="captura de pantalla 2017-12-28 a la s 13 10 59" src="https://user-images.githubusercontent.com/1041600/34420381-f70430f8-ebe7-11e7-8f26-5a58ef9f7855.png">

<img width="740" alt="captura de pantalla 2017-12-28 a la s 13 10 53" src="https://user-images.githubusercontent.com/1041600/34420380-f6d7ee9e-ebe7-11e7-8de6-7676e0f31ee6.png">

I added a checking to see if the stored key or the key field are empty. If so, then that will count as an invalid key. This results in a proper behavior and doesn't affect existing behavior when the key is valid:

<img width="741" alt="captura de pantalla 2017-12-28 a la s 13 28 48" src="https://user-images.githubusercontent.com/1041600/34420418-3c20c7a0-ebe8-11e7-9744-62e05081feda.png">

<img width="735" alt="captura de pantalla 2017-12-28 a la s 15 52 52" src="https://user-images.githubusercontent.com/1041600/34420426-4436cec6-ebe8-11e7-8550-384bc2106240.png">
