### PR TITLE
Upgrade Prettier fork to version 1.9.2

### DIFF
--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -22,7 +22,11 @@ import Card from 'components/card';
 import { localize } from 'i18n-calypso';
 import { getTwoFactorAuthRequestError } from 'state/login/selectors';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
-import { formUpdate, loginUserWithTwoFactorVerificationCode, sendSmsCode } from 'state/login/actions';
+import {
+	formUpdate,
+	loginUserWithTwoFactorVerificationCode,
+	sendSmsCode,
+} from 'state/login/actions';
 import TwoFactorActions from './two-factor-actions';
 
 class VerificationCodeForm extends Component {

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -143,7 +143,11 @@ class PostItem extends React.Component {
 							{ isAllSitesModeSelected && <PostTypeSiteInfo globalId={ globalId } /> }
 							{ isAuthorVisible && <PostTypePostAuthor globalId={ globalId } /> }
 						</div>
-						<h1 className="post-item__title" onClick={ this.clickHandler( 'title' ) } onMouseOver={ preloadEditor }>
+						<h1
+							className="post-item__title"
+							onClick={ this.clickHandler( 'title' ) }
+							onMouseOver={ preloadEditor }
+						>
 							{ ! externalPostLink && (
 								<a
 									href={ isPlaceholder || multiSelectEnabled ? null : postUrl }

--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -77,9 +77,9 @@ class VideoEditor extends Component {
 	};
 
 	/**
-   * Updates the poster by selecting a particular frame of the video.
-   * @param {number} currentTime - Time at which to capture the frame
-   */
+	 * Updates the poster by selecting a particular frame of the video.
+	 * @param {number} currentTime - Time at which to capture the frame
+	 */
 	updatePoster = currentTime => {
 		if ( ! this.state.isSelectingFrame ) {
 			return;
@@ -110,9 +110,9 @@ class VideoEditor extends Component {
 	};
 
 	/**
-   * Uploads an image to use as the poster for the video.
-   * @param {object} file - Uploaded image
-   */
+	 * Uploads an image to use as the poster for the video.
+	 * @param {object} file - Uploaded image
+	 */
 	uploadImage = file => {
 		if ( ! file ) {
 			return;

--- a/client/components/data/query-posts/index.jsx
+++ b/client/components/data/query-posts/index.jsx
@@ -12,15 +12,8 @@ import debug from 'debug';
 /**
  * Internal dependencies
  */
-import {
-	isRequestingPostsForQuery,
-	isRequestingSitePost,
-} from 'state/posts/selectors';
-import {
-	requestSitePosts,
-	requestSitePost,
-	requestAllSitesPosts,
-} from 'state/posts/actions';
+import { isRequestingPostsForQuery, isRequestingSitePost } from 'state/posts/selectors';
+import { requestSitePosts, requestSitePost, requestAllSitesPosts } from 'state/posts/actions';
 
 /**
  * Module variables

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -154,14 +154,11 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 
 				{ formIsValid
 					? this.props.children
-					: map(
-							castArray( this.props.children ),
-							( child, index ) =>
-									React.cloneElement( child, {
-										disabled: child.props.className.match( /submit-button/ ) ||
-											child.props.disabled,
-										key: index,
-									} )
+					: map( castArray( this.props.children ), ( child, index ) =>
+							React.cloneElement( child, {
+								disabled: child.props.className.match( /submit-button/ ) || child.props.disabled,
+								key: index,
+							} )
 						) }
 			</form>
 		);

--- a/client/components/happychat/autoscroll.js
+++ b/client/components/happychat/autoscroll.js
@@ -2,10 +2,10 @@
  * Mixin that will scroll to the bottom of a scrollable container whenever it's rendered.
  * When the scrollable element is scrolled manually by the user autoscroll is disabled until the
  * user scrolls back to the bottom of the content.
- * 
+ *
  * To use declare the mixin and then call the `setupAutoscroll( node )` method on your component
  * where `node` is an html element with scrolling enabled.
- * 
+ *
  * After every update the content will be scrolled to the bottom of the content.
  *
  * @format

--- a/client/components/happychat/scrollbleed.js
+++ b/client/components/happychat/scrollbleed.js
@@ -2,7 +2,7 @@
  * /*
  * A mixin that prevents scrolling events triggered by the mousewheel from moving scrollable containers
  * not directly under the mouse.
- * 
+ *
  * By default when scrolling a scrollable HTML element, once the boundary is reached the scrolling events
  * will continue up the DOM tree and ultimately end up scrolling the page.
  *

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -234,7 +234,9 @@ export function formatNumber( inputNumber, country ) {
 
 	if ( pattern ) {
 		debug(
-			`Will replace "${ nationalNumber }" with "${ pattern.match }" and "${ pattern.replace }" with prefix "${ prefix }"`
+			`Will replace "${ nationalNumber }" with "${ pattern.match }" and "${
+				pattern.replace
+			}" with prefix "${ prefix }"`
 		);
 		return prefix + nationalNumber.replace( new RegExp( pattern.match ), pattern.replace );
 	}

--- a/client/components/tinymce/plugins/after-the-deadline/plugin.js
+++ b/client/components/tinymce/plugins/after-the-deadline/plugin.js
@@ -2,17 +2,17 @@
  * /*
  * TinyMCE Writing Improvement Tool Plugin
  * Author: Raphael Mudge (raffi@automattic.com), Andrew Duthie (andrew.duthie@automattic.com)
- * 
+ *
  * http:
- * 
+ *
  * Distributed under the LGPL
- * 
+ *
  * Derived from:
  * 	$Id: editor_plugin_src.js 425 2007-11-21 15:17:39Z spocke $
- * 
+ *
  * 	@author Moxiecode
  * 	@copyright Copyright (C) 2004-2008, Moxiecode Systems AB, All rights reserved.
- * 
+ *
  * 	Moxiecode Spell Checker plugin released under the LGPL with TinyMCE
  *
  * @format

--- a/client/components/tinymce/plugins/embed/plugin.js
+++ b/client/components/tinymce/plugins/embed/plugin.js
@@ -40,7 +40,11 @@ const embed = editor => {
 			},
 		};
 
-		renderWithReduxStore( React.createElement( EmbedDialog, embedDialogProps ), embedDialogContainer, store );
+		renderWithReduxStore(
+			React.createElement( EmbedDialog, embedDialogProps ),
+			embedDialogContainer,
+			store
+		);
 
 		// Focus on the editor when closing the dialog, so that the user can start typing right away
 		// instead of having to tab back to the editor.

--- a/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-autoresize/plugin.js
@@ -1,8 +1,8 @@
 /**
  * WordPress TinyMCE Auto Resize plugin
- * 
+ *
  * Adapted from WordPress.
- * 
+ *
  *
  * @format
  * @copyright 2015 by the WordPress contributors.

--- a/client/components/tinymce/plugins/wpcom-charmap/charmap.jsx
+++ b/client/components/tinymce/plugins/wpcom-charmap/charmap.jsx
@@ -1,8 +1,8 @@
 /**
  * Reactified port of the TinyMCE charmap plugin.
- * 
+ *
  * Adapted from WordPress.
- * 
+ *
  *
  * @format
  * @copyright 2015 by the WordPress contributors.

--- a/client/components/tinymce/plugins/wpcom-track-paste/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-track-paste/plugin.js
@@ -29,14 +29,14 @@ function trackPaste( editor ) {
 		types.some( isGoogleDocsType ) ? SOURCE_GOOGLE_DOCS : SOURCE_UNKNOWN;
 
 	/**
-	* Although types should be an array, some browsers -as Firefox- will pass a DOMStringList instead.
-	*
-	* @see [types]{@link https://html.spec.whatwg.org/multipage/interaction.html#datatransfer}
-	* @see [DOMStringList]{@link https://developer.mozilla.org/en-US/docs/Web/API/DOMStringList}
-	*
-	* @param {String} mode 'html-editor' or 'visual-editor', indicates which editor was in use on paste.
-	* @param {(Array|DOMStringList)} types The types the content is available to paste.
-	*/
+	 * Although types should be an array, some browsers -as Firefox- will pass a DOMStringList instead.
+	 *
+	 * @see [types]{@link https://html.spec.whatwg.org/multipage/interaction.html#datatransfer}
+	 * @see [DOMStringList]{@link https://developer.mozilla.org/en-US/docs/Web/API/DOMStringList}
+	 *
+	 * @param {String} mode 'html-editor' or 'visual-editor', indicates which editor was in use on paste.
+	 * @param {(Array|DOMStringList)} types The types the content is available to paste.
+	 */
 	const recordPasteEvent = ( mode, types ) => {
 		debug( 'track paste event' );
 		const typesAsArray = Array.from( types );

--- a/client/components/tinymce/plugins/wpcom-view/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-view/plugin.js
@@ -1,6 +1,6 @@
 /**
  * Adapted from the WordPress wp-view TinyMCE plugin.
- * 
+ *
  *
  * @format
  * @copyright 2015 by the WordPress contributors.
@@ -355,7 +355,9 @@ function wpview( editor ) {
 			if ( imageMatch ) {
 				// If the link looks like an image, replace the pasted content with an <img> tag.
 				// As a side effect, this won't request an embed code to the REST API anymore.
-				event.content = `<img src="${ imageMatch[ 1 ] }${ imageMatch[ 2 ] }" style="max-width:100%;" />`;
+				event.content = `<img src="${ imageMatch[ 1 ] }${
+					imageMatch[ 2 ]
+				}" style="max-width:100%;" />`;
 			} else if ( /^https?:\/\/\S+$/i.test( pastedStr ) ) {
 				// Otherwise replace the content with the cleaned URL.
 				event.content = pastedStr;

--- a/client/components/tinymce/plugins/wpcom/plugin.js
+++ b/client/components/tinymce/plugins/wpcom/plugin.js
@@ -1,6 +1,6 @@
 /**
  * Adapted from the WordPress wp TinyMCE plugin.
- * 
+ *
  *
  * @format
  * @copyright 2015 by the WordPress contributors.

--- a/client/components/tinymce/plugins/wpcom/wpcom-utils.js
+++ b/client/components/tinymce/plugins/wpcom/wpcom-utils.js
@@ -1,8 +1,8 @@
 /**
  * Removes empty spaces from empty paragraphs
  * This logic is borrowed from core's TinyMCE Plugin
- * 
- * 
+ *
+ *
  *
  * @format
  * @see https:

--- a/client/components/tinymce/plugins/wpeditimage/plugin.js
+++ b/client/components/tinymce/plugins/wpeditimage/plugin.js
@@ -1,6 +1,6 @@
 /**
  * Adapted from the WordPress wp-editimage TinyMCE plugin.
- * 
+ *
  *
  * @format
  * @copyright 2015 by the WordPress contributors.

--- a/client/components/tinymce/plugins/wplink/plugin.js
+++ b/client/components/tinymce/plugins/wplink/plugin.js
@@ -1,6 +1,6 @@
 /**
  * Adapted from the WordPress wplink TinyMCE plugin.
- * 
+ *
  *
  * @format
  * @copyright 2015 by the WordPress contributors.

--- a/client/components/tinymce/plugins/wptextpattern/plugin.js
+++ b/client/components/tinymce/plugins/wptextpattern/plugin.js
@@ -1,14 +1,14 @@
 /**
  * Adapted from the WordPress wptextpattern TinyMCE plugin.
- * 
- * 
+ *
+ *
  * Text pattern plugin for TinyMCE
- * 
- * 
+ *
+ *
  * This plugin can automatically format text patterns as you type. It includes two patterns:
  *  - Unordered list (`* ` and `- `).
  *  - Ordered list (`1. ` and `1) `).
- * 
+ *
  * If the transformation in unwanted, the user can undo the change by pressing backspace,
  * using the undo shortcut, or the undo button in the toolbar.
  *

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -142,7 +142,11 @@ class PreviewToolbar extends Component {
 				) }
 				<div className="web-preview__toolbar-actions">
 					{ showEdit && (
-						<Button className="web-preview__edit" href={ editUrl } onClick={ this.handleEditorWebPreviewEdit }>
+						<Button
+							className="web-preview__edit"
+							href={ editUrl }
+							onClick={ this.handleEditorWebPreviewEdit }
+						>
 							{ translate( 'Edit' ) }
 						</Button>
 					) }

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -30,7 +30,7 @@ const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary, redirectUri }
  *
  * Produce a `LayoutLoggedOut` element in `context.layout`, using
  * `context.primary` and `context.secondary` to populate it.
-*/
+ */
 export const makeLayout = makeLayoutMiddleware( ReduxWrappedLoggedOutLayout );
 
 export function redirectLoggedIn( { isLoggedIn, res }, next ) {

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -133,7 +133,10 @@ class DesignAssets extends React.Component {
 				) }
 
 				<Collection component={ component } filter={ filter }>
-					<Accordions componentUsageStats={ componentsUsageStats.accordion } readmeFilePath="accordion" />
+					<Accordions
+						componentUsageStats={ componentsUsageStats.accordion }
+						readmeFilePath="accordion"
+					/>
 					<Banner readmeFilePath="banner" />
 					<BulkSelect readmeFilePath="bulk-select" />
 					<ButtonGroups readmeFilePath="button-group" />

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -7,8 +7,8 @@
 import React from 'react';
 
 /**
-* Internal dependencies
-*/
+ * Internal dependencies
+ */
 import DocsExampleWrapper from 'devdocs/docs-example/wrapper';
 import { camelCaseToSlug, getComponentName } from 'devdocs/docs-example/util';
 import ReadmeViewer from 'devdocs/docs-example/readme-viewer';

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -10,10 +10,7 @@ import React from 'react';
 * Internal dependencies
 */
 import DocsExampleWrapper from 'devdocs/docs-example/wrapper';
-import {
-	camelCaseToSlug,
-	getComponentName,
-} from 'devdocs/docs-example/util';
+import { camelCaseToSlug, getComponentName } from 'devdocs/docs-example/util';
 import ReadmeViewer from 'devdocs/docs-example/readme-viewer';
 
 const shouldShowInstance = ( example, filter, component ) => {

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -112,10 +112,8 @@ export default class extends React.Component {
 				<div
 					className="devdocs__doc-content"
 					ref="body"
-					dangerouslySetInnerHTML={
-						//eslint-disable-line react/no-danger
-						{ __html: highlight( this.props.term, this.state.body ) }
-					}
+					//eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={ { __html: highlight( this.props.term, this.state.body ) } }
 				/>
 			</div>
 		);

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -112,8 +112,10 @@ export default class extends React.Component {
 				<div
 					className="devdocs__doc-content"
 					ref="body"
-					dangerouslySetInnerHTML={ //eslint-disable-line react/no-danger
-					{ __html: highlight( this.props.term, this.state.body ) } }
+					dangerouslySetInnerHTML={
+						//eslint-disable-line react/no-danger
+						{ __html: highlight( this.props.term, this.state.body ) }
+					}
 				/>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/products/products-list-table.js
+++ b/client/extensions/woocommerce/app/products/products-list-table.js
@@ -23,15 +23,13 @@ const ProductsListTable = ( { translate, products, site, isRequesting } ) => {
 			isHeader
 			className={ classNames( { 'products__list-placeholder': ! products.length } ) }
 		>
-			{ [
-				translate( 'Product' ),
-				translate( 'Inventory' ),
-				translate( 'Category' ),
-			].map( ( item, i ) => (
-				<TableItem isHeader key={ i } isTitle={ 0 === i }>
-					{ item }
-				</TableItem>
-			) ) }
+			{ [ translate( 'Product' ), translate( 'Inventory' ), translate( 'Category' ) ].map(
+				( item, i ) => (
+					<TableItem isHeader key={ i } isTitle={ 0 === i }>
+						{ item }
+					</TableItem>
+				)
+			) }
 		</TableRow>
 	);
 

--- a/client/extensions/woocommerce/app/store-stats/listview.js
+++ b/client/extensions/woocommerce/app/store-stats/listview.js
@@ -46,9 +46,9 @@ class StoreStatsListView extends Component {
 	goBack = () => {
 		const pathParts = this.props.path.split( '/' );
 		const queryString = this.props.querystring ? '?' + this.props.querystring : '';
-		const pathExtra = `${ pathParts[ pathParts.length - 2 ] }/${ pathParts[
-			pathParts.length - 1
-		] }${ queryString }`;
+		const pathExtra = `${ pathParts[ pathParts.length - 2 ] }/${
+			pathParts[ pathParts.length - 1 ]
+		}${ queryString }`;
 		const defaultBack = `/store/stats/orders/${ pathExtra }`;
 
 		setTimeout( () => {

--- a/client/extensions/woocommerce/app/store-stats/utils.js
+++ b/client/extensions/woocommerce/app/store-stats/utils.js
@@ -120,7 +120,7 @@ export function getEndPeriod( date, unit ) {
  * @param {string} format - string of 'text', 'number' or 'currency'
  * @param {string} [code] - optional currency code
  * @return {string|number} - formatted number or string value
-*/
+ */
 export function formatValue( value, format, code ) {
 	switch ( format ) {
 		case 'currency':
@@ -140,7 +140,7 @@ export function formatValue( value, format, code ) {
  * @param {string} selectedDate - string of date in 'YYYY-MM-DD'
  * @param {string} stat - string of stat to be referenced
  * @return {array} - array of delta objects matching selectedDate
-*/
+ */
 export function getDelta( deltas, selectedDate, stat ) {
 	const selectedDeltas = find( deltas, item => item.period === selectedDate );
 	return selectedDeltas[ stat ];

--- a/client/extensions/woocommerce/lib/formatted-variation-name/index.js
+++ b/client/extensions/woocommerce/lib/formatted-variation-name/index.js
@@ -1,6 +1,6 @@
 /**
  * Returns a formatted variation name for display based on attributes.
- * 
+ *
  *
  * @format
  * @param {String} fallbackName Fallback name to use if no attributes are passed.

--- a/client/extensions/woocommerce/lib/get-keyboard-handler/index.js
+++ b/client/extensions/woocommerce/lib/get-keyboard-handler/index.js
@@ -3,7 +3,7 @@
  * This triggers a callback on a keydown event, only if the key pressed is space or enter
  * to mirror button functionality. It will also focus the next/previous sibling (if one
  * exists) if the down/up arrows are pressed.
- * 
+ *
  *
  * @format
  * @param {Function} callback A callback function

--- a/client/extensions/woocommerce/state/sites/request.js
+++ b/client/extensions/woocommerce/state/sites/request.js
@@ -27,18 +27,16 @@ const _request = ( method, path, siteId, body, namespace = 'wc/v3' ) => {
 	// WPCOM API breaks if query parameters are passed after "?" instead of "&". Hide this hack from the calling code
 	path = path.replace( '?', '&' );
 
-	return wp.req
-		[ 'get' === method ? 'get' : 'post' ](
-			{
-				path: `/jetpack-blogs/${ siteId }/rest-api/`,
-			},
-			{
-				path: `/${ namespace }/${ path }&_method=${ method }`,
-				body: body && JSON.stringify( body ),
-				json: true,
-			}
-		)
-		.then( ( { data } ) => omitDeep( data, '_links' ) );
+	return wp.req[ 'get' === method ? 'get' : 'post' ](
+		{
+			path: `/jetpack-blogs/${ siteId }/rest-api/`,
+		},
+		{
+			path: `/${ namespace }/${ path }&_method=${ method }`,
+			body: body && JSON.stringify( body ),
+			json: true,
+		}
+	).then( ( { data } ) => omitDeep( data, '_links' ) );
 };
 
 const _requestWithHeaders = ( method, path, siteId, sendBody, namespace = 'wc/v3' ) => {

--- a/client/extensions/zoninator/components/forms/zone-content-form/post-card.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/post-card.jsx
@@ -39,7 +39,7 @@ class PostCard extends Component {
 		event.preventDefault();
 	};
 
-	viewPost = ( event ) => {
+	viewPost = event => {
 		const { dispatch, isPreviewable, previewUrl } = this.props;
 
 		event.preventDefault();
@@ -51,16 +51,10 @@ class PostCard extends Component {
 		dispatch( setPreviewType( 'site-preview' ) );
 		dispatch( setPreviewUrl( setUrlScheme( previewUrl, 'https' ) ) );
 		dispatch( setLayoutFocus( 'preview' ) );
-	}
+	};
 
 	render() {
-		const {
-			editorPath,
-			postTitle,
-			previewUrl,
-			remove,
-			translate,
-		} = this.props;
+		const { editorPath, postTitle, previewUrl, remove, translate } = this.props;
 
 		const postCardClass = 'zoninator__zone-list-item';
 
@@ -72,7 +66,8 @@ class PostCard extends Component {
 					onClick={ this.viewPost }
 					href={ previewUrl }
 					draggable="false"
-					target="_blank">
+					target="_blank"
+				>
 					{ translate( 'View' ) }
 				</Button>
 				<Button compact onMouseDown={ this.handleMouseDown } href={ editorPath } draggable="false">

--- a/client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/posts-list.jsx
@@ -79,26 +79,27 @@ class PostsList extends Component {
 					</SearchAutocomplete>
 				</FormFieldset>
 
-				{ !! posts.length && ! requesting && (
-					<FormFieldset>
-						<p className={ explanationTextClass }>
-							{ translate(
-								"You can reorder the zone's content by dragging it to a different location on the list."
-							) }
-						</p>
-						<SortableList direction="vertical" onChange={ this.changePostOrder( fields ) }>
-							{ posts.map( ( post, index ) => (
-								<PostCard
-									key={ post.id }
-									postId={ post.id }
-									postTitle={ post.title }
-									siteId={ post.siteId }
-									remove={ this.removePost( fields, index ) }
-								/>
-							) ) }
-						</SortableList>
-					</FormFieldset>
-				) }
+				{ !! posts.length &&
+					! requesting && (
+						<FormFieldset>
+							<p className={ explanationTextClass }>
+								{ translate(
+									"You can reorder the zone's content by dragging it to a different location on the list."
+								) }
+							</p>
+							<SortableList direction="vertical" onChange={ this.changePostOrder( fields ) }>
+								{ posts.map( ( post, index ) => (
+									<PostCard
+										key={ post.id }
+										postId={ post.id }
+										postTitle={ post.title }
+										siteId={ post.siteId }
+										remove={ this.removePost( fields, index ) }
+									/>
+								) ) }
+							</SortableList>
+						</FormFieldset>
+					) }
 
 				{ requesting && times( 3, index => <PostPlaceholder key={ index } /> ) }
 			</div>

--- a/client/layout/sidebar/index.jsx
+++ b/client/layout/sidebar/index.jsx
@@ -18,9 +18,9 @@ export default class extends React.Component {
 	};
 
 	render() {
-		const hasRegions = React.Children
-			.toArray( this.props.children )
-			.some( el => el.type === SidebarRegion );
+		const hasRegions = React.Children.toArray( this.props.children ).some(
+			el => el.type === SidebarRegion
+		);
 
 		return (
 			<ul

--- a/client/lib/apple-pay/index.js
+++ b/client/lib/apple-pay/index.js
@@ -24,8 +24,7 @@ export const recordApplePayStatus = () => dispatch => {
 		return;
 	}
 
-	window.ApplePaySession
-		.canMakePaymentsWithActiveCard( MERCHANT_IDENTIFIER )
+	window.ApplePaySession.canMakePaymentsWithActiveCard( MERCHANT_IDENTIFIER )
 		.then( canMakePaymentsWithActiveCard =>
 			dispatch( recordApplePayStatusEvent( canMakePaymentsWithActiveCard ) )
 		)

--- a/client/lib/directly/index.js
+++ b/client/lib/directly/index.js
@@ -1,6 +1,6 @@
 /**
- * 
- * 
+ *
+ *
  *
  * @format
  * @file Interface to the third-party Real Time Messaging (RTM) widget from Directly.

--- a/client/lib/follow-list/site.js
+++ b/client/lib/follow-list/site.js
@@ -35,8 +35,8 @@ function FollowListSite( args ) {
 Emitter( FollowListSite.prototype );
 
 /**
-*	if is_following is false, calls the follow endpoint
-*/
+ *	if is_following is false, calls the follow endpoint
+ */
 
 FollowListSite.prototype.follow = function() {
 	if ( ! this.is_following ) {
@@ -53,8 +53,8 @@ FollowListSite.prototype.follow = function() {
 };
 
 /**
-*	if is_following is true, calls the delete action on follow
-*/
+ *	if is_following is true, calls the delete action on follow
+ */
 
 FollowListSite.prototype.unfollow = function() {
 	if ( this.is_following ) {

--- a/client/lib/like-store/actions.js
+++ b/client/lib/like-store/actions.js
@@ -36,15 +36,15 @@ function getQuery() {
 
 var LikeActions = {
 	/**
-	* Fetch a post's list of likes
-	*
-	*
-	* Note: the endpoint will currently return a maximum of 90 likes, and there's no pagination
-	*
-	*
-	* @param {int} Site ID
-	* @param {int} Post ID
-	*/
+	 * Fetch a post's list of likes
+	 *
+	 *
+	 * Note: the endpoint will currently return a maximum of 90 likes, and there's no pagination
+	 *
+	 *
+	 * @param {int} Site ID
+	 * @param {int} Post ID
+	 */
 	fetchLikes: function( siteId, postId ) {
 		if ( requestInflight( key( siteId, postId ) ) ) {
 			return;
@@ -62,11 +62,11 @@ var LikeActions = {
 	},
 
 	/**
-	* Like a post as the current user
-	*
-	* @param {int} siteId The Site ID
-	* @param {int} postId The Post ID
-	*/
+	 * Like a post as the current user
+	 *
+	 * @param {int} siteId The Site ID
+	 * @param {int} postId The Post ID
+	 */
 	likePost: function( siteId, postId ) {
 		Dispatcher.handleViewAction( {
 			type: 'LIKE_POST',

--- a/client/lib/load-script/test/callback-handler.js
+++ b/client/lib/load-script/test/callback-handler.js
@@ -1,6 +1,6 @@
 /**
  * @format
-*/
+ */
 
 /**
  * Internal dependencies

--- a/client/lib/load-script/test/index.js
+++ b/client/lib/load-script/test/index.js
@@ -1,7 +1,7 @@
 /**
  * @format
  * @jest-environment jsdom
-*/
+ */
 
 /**
  * Internal dependencies

--- a/client/lib/media-serialization/create-element-from-string.js
+++ b/client/lib/media-serialization/create-element-from-string.js
@@ -1,6 +1,6 @@
 /**
  * Given a string, attempts to generate the equivalent HTMLElement
- * 
+ *
  *
  * @format
  * @param {string}      string HTML string

--- a/client/lib/media-serialization/strategies/object.js
+++ b/client/lib/media-serialization/strategies/object.js
@@ -1,6 +1,6 @@
 /**
  * Given a deserialized media object, returns itself.
- * 
+ *
  *
  * @format
  * @param {Object} node Deserialized media object

--- a/client/lib/mixins/searchable/index.js
+++ b/client/lib/mixins/searchable/index.js
@@ -56,7 +56,7 @@ function Searchable( prototype, searchNodes ) {
 
 	/**
 	 * Public method added to a collection to return a filtered set of matching items
-	 * 
+	 *
 	 * @param {string} keyword The string we are searching for on the collection
 	 * @return {array} The filtered set of items in the collection that match the search term
 	 */

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -8,17 +8,15 @@ import { addQueryArgs } from 'lib/url';
 import { addLocaleToPath, addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import config, { isEnabled } from 'config';
 
-export function login(
-	{
-		isNative,
-		locale,
-		redirectTo,
-		twoFactorAuthType,
-		socialConnect,
-		emailAddress,
-		socialService,
-	} = {}
-) {
+export function login( {
+	isNative,
+	locale,
+	redirectTo,
+	twoFactorAuthType,
+	socialConnect,
+	emailAddress,
+	socialService,
+} = {} ) {
 	let url = config( 'login_url' );
 
 	if ( isNative && isEnabled( 'login/wp-login' ) ) {

--- a/client/lib/post-normalizer/rule-content-detect-media.js
+++ b/client/lib/post-normalizer/rule-content-detect-media.js
@@ -14,9 +14,9 @@ import { iframeIsWhitelisted, maxWidthPhotonishURL, deduceImageWidthAndHeight } 
 import { READER_CONTENT_WIDTH } from 'state/reader/posts/normalization-rules';
 
 /** Checks whether or not an image is a tracking pixel
-* @param {Node} image - DOM node for an img
-* @returns {boolean} isTrackingPixel - returns true if image is probably a tracking pixel
-*/
+ * @param {Node} image - DOM node for an img
+ * @returns {boolean} isTrackingPixel - returns true if image is probably a tracking pixel
+ */
 function isTrackingPixel( image ) {
 	if ( ! image || ! image.src ) {
 		return false;
@@ -47,9 +47,9 @@ function isCandidateForContentImage( image ) {
 }
 
 /** Detects and returns metadata if it should be considered as a content image
-* @param {image} image - the image
-* @returns {object} metadata - regarding the image or null
-*/
+ * @param {image} image - the image
+ * @returns {object} metadata - regarding the image or null
+ */
 const detectImage = image => {
 	if ( isCandidateForContentImage( image ) ) {
 		const { width, height } = deduceImageWidthAndHeight( image ) || { width: 0, height: 0 };

--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -17,8 +17,8 @@ const TRANSPARENT_GIF =
 	'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
 /**
-* @param {Node} node - Takes in a DOM Node and mutates it so that it no longer has an 'on*' event handlers e.g. onClick
-*/
+ * @param {Node} node - Takes in a DOM Node and mutates it so that it no longer has an 'on*' event handlers e.g. onClick
+ */
 const removeUnwantedAttributes = node => {
 	if ( ! node || ! node.hasAttributes() ) {
 		return;

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -451,10 +451,10 @@ PostActions = {
 	},
 
 	/**
-	* Fetch next page of posts from the user's sites via the WordPress.com REST API.
-	*
-	* @api public
-	*/
+	 * Fetch next page of posts from the user's sites via the WordPress.com REST API.
+	 *
+	 * @api public
+	 */
 	fetchNextPage: function( postListStoreId = 'default' ) {
 		const postListStore = postListStoreFactory( postListStoreId );
 

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -15,7 +15,6 @@ import { includes } from 'lodash';
 import postNormalizer from 'lib/post-normalizer';
 
 var utils = {
-
 	getEditURL: function( post, site ) {
 		let basePath = '';
 

--- a/client/lib/reader-lists/actions.js
+++ b/client/lib/reader-lists/actions.js
@@ -106,20 +106,22 @@ const ReaderListActions = {
 		fetchingLists[ key ] = true;
 		ReaderListsStore.setIsFetching( true );
 
-		wpcom.undocumented().readList( {
-			owner: owner,
-			slug: slug,
-		},
-		function( error, data ) {
-			delete fetchingLists[ key ];
-			ReaderListsStore.setIsFetching( false );
+		wpcom.undocumented().readList(
+			{
+				owner: owner,
+				slug: slug,
+			},
+			function( error, data ) {
+				delete fetchingLists[ key ];
+				ReaderListsStore.setIsFetching( false );
 
-			Dispatcher.handleServerAction( {
-				type: actionTypes.RECEIVE_READER_LIST,
-				data: data,
-				error: error,
-			} );
-		} );
+				Dispatcher.handleServerAction( {
+					type: actionTypes.RECEIVE_READER_LIST,
+					data: data,
+					error: error,
+				} );
+			}
+		);
 	},
 
 	create: function( title ) {

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -459,12 +459,12 @@ describe( 'route', function() {
 	describe( 'sectionifyWithRoutes', function() {
 		describe( 'for checkout paths', function() {
 			test( 'should parameterize checkout thank you paths', function() {
-				expect(
-					route.sectionifyWithRoutes( '/checkout/thank-you', checkoutRoutes )
-				).to.deep.equal( {
-					routePath: '/checkout/thank-you',
-					routeParams: {},
-				} );
+				expect( route.sectionifyWithRoutes( '/checkout/thank-you', checkoutRoutes ) ).to.deep.equal(
+					{
+						routePath: '/checkout/thank-you',
+						routeParams: {},
+					}
+				);
 				expect(
 					route.sectionifyWithRoutes( '/checkout/thank-you/25222194', checkoutRoutes )
 				).to.deep.equal( {
@@ -543,12 +543,12 @@ describe( 'route', function() {
 				} );
 			} );
 			test( 'should parameterize comment paths', function() {
-				expect(
-					route.sectionifyWithRoutes( '/comments/approved', commentsRoutes )
-				).to.deep.equal( {
-					routePath: '/comments/approved',
-					routeParams: {},
-				} );
+				expect( route.sectionifyWithRoutes( '/comments/approved', commentsRoutes ) ).to.deep.equal(
+					{
+						routePath: '/comments/approved',
+						routeParams: {},
+					}
+				);
 				expect( route.sectionifyWithRoutes( '/comments/pending', commentsRoutes ) ).to.deep.equal( {
 					routePath: '/comments/pending',
 					routeParams: {},

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -20,13 +20,11 @@ describe( 'safeImageUrl()', () => {
 		} );
 
 		test( 'should make a non-whitelisted protocol safe', () => {
-			[
-				'javascript:alert("foo")',
-				'data:application/json;base64,',
-				'about:config',
-			].forEach( url => {
-				expect( safeImageUrl( url ) ).to.match( /^https:\/\/i[0-2]\.wp.com\// );
-			} );
+			[ 'javascript:alert("foo")', 'data:application/json;base64,', 'about:config' ].forEach(
+				url => {
+					expect( safeImageUrl( url ) ).to.match( /^https:\/\/i[0-2]\.wp.com\// );
+				}
+			);
 		} );
 
 		test( 'should make a non-wpcom http url safe', () => {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -111,78 +111,80 @@ function createSiteWithCart(
 	const siteTitle = getSiteTitle( reduxStore.getState() ).trim();
 	const surveyVertical = getSurveyVertical( reduxStore.getState() ).trim();
 
-	wpcom.undocumented().sitesNew( {
-		blog_name: siteUrl,
-		blog_title: siteTitle,
-		options: {
-			designType: designType || undefined,
-			// the theme can be provided in this step's dependencies or the
-			// step object itself depending on if the theme is provided in a
-			// query. See `getThemeSlug` in `DomainsStep`.
-			theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
-			vertical: surveyVertical || undefined,
+	wpcom.undocumented().sitesNew(
+		{
+			blog_name: siteUrl,
+			blog_title: siteTitle,
+			options: {
+				designType: designType || undefined,
+				// the theme can be provided in this step's dependencies or the
+				// step object itself depending on if the theme is provided in a
+				// query. See `getThemeSlug` in `DomainsStep`.
+				theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
+				vertical: surveyVertical || undefined,
+			},
+			validate: false,
+			find_available_url: isPurchasingItem,
 		},
-		validate: false,
-		find_available_url: isPurchasingItem,
-	},
-	function( error, response ) {
-		if ( error ) {
-			callback( error );
+		function( error, response ) {
+			if ( error ) {
+				callback( error );
 
-			return;
-		}
-
-		const parsedBlogURL = parseURL( response.blog_details.url );
-
-		const siteSlug = parsedBlogURL.hostname;
-		const siteId = response.blog_details.blogid;
-		const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' ) && ! themeItem;
-		const providedDependencies = {
-			siteId,
-			siteSlug,
-			domainItem,
-			themeItem,
-		};
-		const addToCartAndProceed = () => {
-			let privacyItem = null;
-			if ( domainItem ) {
-				privacyItem = cartItems.domainPrivacyProtection( {
-					domain: domainItem.meta,
-					source: 'signup',
-				} );
+				return;
 			}
 
-			const newCartItems = [
-				cartItem,
-				domainItem,
-				googleAppsCartItem,
-				themeItem,
-				privacyItem,
-			].filter( item => item );
+			const parsedBlogURL = parseURL( response.blog_details.url );
 
-			if ( newCartItems.length ) {
-				SignupCart.addToCart( siteId, newCartItems, function( cartError ) {
-					callback( cartError, providedDependencies );
-				} );
-			} else {
-				callback( undefined, providedDependencies );
-			}
-		};
-
-		if ( ! user.get() && isFreeThemePreselected ) {
-			setThemeOnSite( addToCartAndProceed, { siteSlug, themeSlugWithRepo } );
-		} else if ( user.get() && isFreeThemePreselected ) {
-			fetchSitesAndUser(
+			const siteSlug = parsedBlogURL.hostname;
+			const siteId = response.blog_details.blogid;
+			const isFreeThemePreselected = startsWith( themeSlugWithRepo, 'pub' ) && ! themeItem;
+			const providedDependencies = {
+				siteId,
 				siteSlug,
-				setThemeOnSite.bind( null, addToCartAndProceed, { siteSlug, themeSlugWithRepo } ),
-				reduxStore
-			);
-		} else if ( user.get() ) {
-			fetchSitesAndUser( siteSlug, addToCartAndProceed, reduxStore );
-		} else {
-			addToCartAndProceed();
+				domainItem,
+				themeItem,
+			};
+			const addToCartAndProceed = () => {
+				let privacyItem = null;
+				if ( domainItem ) {
+					privacyItem = cartItems.domainPrivacyProtection( {
+						domain: domainItem.meta,
+						source: 'signup',
+					} );
+				}
+
+				const newCartItems = [
+					cartItem,
+					domainItem,
+					googleAppsCartItem,
+					themeItem,
+					privacyItem,
+				].filter( item => item );
+
+				if ( newCartItems.length ) {
+					SignupCart.addToCart( siteId, newCartItems, function( cartError ) {
+						callback( cartError, providedDependencies );
+					} );
+				} else {
+					callback( undefined, providedDependencies );
+				}
+			};
+
+			if ( ! user.get() && isFreeThemePreselected ) {
+				setThemeOnSite( addToCartAndProceed, { siteSlug, themeSlugWithRepo } );
+			} else if ( user.get() && isFreeThemePreselected ) {
+				fetchSitesAndUser(
+					siteSlug,
+					setThemeOnSite.bind( null, addToCartAndProceed, { siteSlug, themeSlugWithRepo } ),
+					reduxStore
+				);
+			} else if ( user.get() ) {
+				fetchSitesAndUser( siteSlug, addToCartAndProceed, reduxStore );
+			} else {
+				addToCartAndProceed();
+			}
 		}
-	} );
+	);
 }
 
 function fetchSitesUntilSiteAppears( siteSlug, reduxStore, callback ) {
@@ -320,68 +322,74 @@ export default {
 
 		if ( service ) {
 			// We're creating a new social account
-			wpcom.undocumented().usersSocialNew( {
-				service,
-				access_token,
-				id_token,
-				signup_flow_name: flowName,
-			},
-			( error, response ) => {
-				const errors =
-					error && error.error
-						? [ { error: error.error, message: error.message, email: get( error, 'data.email' ) } ]
-						: undefined;
-
-				if ( errors ) {
-					callback( errors );
-				} else {
-					callback( undefined, response );
-				}
-			} );
-		} else {
-			wpcom.undocumented().usersNew( assign(
-				{},
-				userData,
+			wpcom.undocumented().usersSocialNew(
 				{
-					ab_test_variations: getSavedVariations(),
-					validate: false,
+					service,
+					access_token,
+					id_token,
 					signup_flow_name: flowName,
-					nux_q_site_type: surveySiteType,
-					nux_q_question_primary: surveyVertical,
-					// url sent in the confirmation email
-					jetpack_redirect: queryArgs.jetpack_redirect,
 				},
-				oauth2Signup
-					? {
+				( error, response ) => {
+					const errors =
+						error && error.error
+							? [
+									{ error: error.error, message: error.message, email: get( error, 'data.email' ) },
+								]
+							: undefined;
+
+					if ( errors ) {
+						callback( errors );
+					} else {
+						callback( undefined, response );
+					}
+				}
+			);
+		} else {
+			wpcom.undocumented().usersNew(
+				assign(
+					{},
+					userData,
+					{
+						ab_test_variations: getSavedVariations(),
+						validate: false,
+						signup_flow_name: flowName,
+						nux_q_site_type: surveySiteType,
+						nux_q_question_primary: surveyVertical,
+						// url sent in the confirmation email
+						jetpack_redirect: queryArgs.jetpack_redirect,
+					},
+					oauth2Signup
+						? {
+								oauth2_client_id: queryArgs.oauth2_client_id,
+								// url of the WordPress.com authorize page for this OAuth2 client
+								// convert to legacy oauth2_redirect format: %s@https://public-api.wordpress.com/oauth2/authorize/...
+								oauth2_redirect: queryArgs.oauth2_redirect && '0@' + queryArgs.oauth2_redirect,
+							}
+						: null
+				),
+				( error, response ) => {
+					const errors =
+							error && error.error ? [ { error: error.error, message: error.message } ] : undefined,
+						bearerToken = error && error.error ? {} : { bearer_token: response.bearer_token };
+
+					if ( ! errors ) {
+						// Fire after a new user registers.
+						analytics.tracks.recordEvent( 'calypso_user_registration_complete' );
+						analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
+					}
+
+					const providedDependencies = assign( {}, { username: userData.username }, bearerToken );
+
+					if ( oauth2Signup ) {
+						assign( providedDependencies, {
 							oauth2_client_id: queryArgs.oauth2_client_id,
-							// url of the WordPress.com authorize page for this OAuth2 client
-							// convert to legacy oauth2_redirect format: %s@https://public-api.wordpress.com/oauth2/authorize/...
-							oauth2_redirect: queryArgs.oauth2_redirect && '0@' + queryArgs.oauth2_redirect,
-						}
-					: null
-			),
-			( error, response ) => {
-				const errors =
-						error && error.error ? [ { error: error.error, message: error.message } ] : undefined,
-					bearerToken = error && error.error ? {} : { bearer_token: response.bearer_token };
+							oauth2_redirect: queryArgs.oauth2_redirect,
+						} );
+					}
 
-				if ( ! errors ) {
-					// Fire after a new user registers.
-					analytics.tracks.recordEvent( 'calypso_user_registration_complete' );
-					analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
+					callback( errors, providedDependencies );
 				}
-
-				const providedDependencies = assign( {}, { username: userData.username }, bearerToken );
-
-				if ( oauth2Signup ) {
-					assign( providedDependencies, {
-						oauth2_client_id: queryArgs.oauth2_client_id,
-						oauth2_redirect: queryArgs.oauth2_redirect,
-					} );
-				}
-
-				callback( errors, providedDependencies );
-			} );
+			);
 		}
 	},
 

--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -103,10 +103,10 @@ export const rebootNormally = () => {
 };
 
 /**
-  * Reboot Calypso as the support user
-  * @param  {string} user  The support user's username
-  * @param  {string} token The support token
-  */
+ * Reboot Calypso as the support user
+ * @param  {string} user  The support user's username
+ * @param  {string} token The support token
+ */
 export const rebootWithToken = ( user, token ) => {
 	if ( ! isEnabled() ) {
 		return;

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -135,9 +135,9 @@ User.prototype.fetch = function() {
 					error.error === 'authorization_required'
 				) {
 					/**
-				 * if the user bootstrap is disabled (in development), we need to rely on a request to
-				 * /me to determine if the user is logged in.
-				 */
+					 * if the user bootstrap is disabled (in development), we need to rely on a request to
+					 * /me to determine if the user is logged in.
+					 */
 					debug( 'The user is not logged in.' );
 
 					this.initialized = true;

--- a/client/lib/wp/handlers/http-envelope-normalizer.js
+++ b/client/lib/wp/handlers/http-envelope-normalizer.js
@@ -1,6 +1,6 @@
 /**
  * Detect error looking in the reponse data object.
- * 
+ *
  *
  * @format
  * @param {Function} handler - wpcom handler

--- a/client/lib/wpcom-undocumented/lib/account-recovery-reset.js
+++ b/client/lib/wpcom-undocumented/lib/account-recovery-reset.js
@@ -1,6 +1,6 @@
 /**
  * `AccountRecoveryReset` constructor.
- * 
+ *
  *
  * @format
  * @constructor

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -36,10 +36,10 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 		const line = [
 			emailAddress
 				? translate( 'We just emailed a link to %(emailAddress)s.', {
-					args: {
-						emailAddress,
-					},
-				} )
+						args: {
+							emailAddress,
+						},
+					} )
 				: translate( 'We just emailed you a link.' ),
 			' ',
 			translate( 'Please check your inbox and click the link to log in.' ),

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -101,10 +101,7 @@ class HandleEmailedLinkForm extends React.Component {
 				login( {
 					isNative: true,
 					// If no notification is sent, the user is using the authenticator for 2FA by default
-					twoFactorAuthType: twoFactorNotificationSent.replace(
-						'none',
-						'authenticator'
-					),
+					twoFactorAuthType: twoFactorNotificationSent.replace( 'none', 'authenticator' ),
 					redirectTo: redirectToSanitized,
 				} )
 			);

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -314,15 +314,17 @@ const Checkout = createReactClass( {
 				);
 
 				if ( domainsForGsuite.length ) {
-					return `/checkout/${ selectedSiteSlug }/with-gsuite/${ domainsForGsuite[ 0 ]
-						.meta }/${ receiptId }`;
+					return `/checkout/${ selectedSiteSlug }/with-gsuite/${
+						domainsForGsuite[ 0 ].meta
+					}/${ receiptId }`;
 				}
 			}
 		}
 
 		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )
-			? `/checkout/thank-you/features/${ this.props
-					.selectedFeature }/${ selectedSiteSlug }/${ receiptId }`
+			? `/checkout/thank-you/features/${
+					this.props.selectedFeature
+				}/${ selectedSiteSlug }/${ receiptId }`
 			: `/checkout/thank-you/${ selectedSiteSlug }/${ receiptId }`;
 	},
 

--- a/client/my-sites/customize/panels.js
+++ b/client/my-sites/customize/panels.js
@@ -1,6 +1,6 @@
 /**
  * Mapping from Calypso panel slug to tuple of focus key and value.
- * 
+ *
  *
  * @format
  * @type {Object}

--- a/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
@@ -39,8 +39,9 @@ const WpcomDomain = createReactClass( {
 		return (
 			<VerticalNav>
 				<VerticalNavItem
-					path={ `https://${ this.props.domain
-						.name }/wp-admin/index.php?page=my-blogs#blog_row_${ this.props.selectedSite.ID }` }
+					path={ `https://${ this.props.domain.name }/wp-admin/index.php?page=my-blogs#blog_row_${
+						this.props.selectedSite.ID
+					}` }
 					external={ true }
 					onClick={ this.handleEditSiteAddressClick }
 				>

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
@@ -215,9 +215,7 @@ class Unlocked extends React.Component {
 
 		return (
 			<p>
-				{ translate(
-					'The registry for your domain requires a special process for transfers. '
-				) }{' '}
+				{ translate( 'The registry for your domain requires a special process for transfers. ' ) }{' '}
 				{ sent
 					? translate(
 							'Our Happiness Engineers have been notified about ' +

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -19,9 +19,10 @@ function registerMultiPage( { paths: givenPaths, handlers } ) {
 	givenPaths.forEach( path => page( path, ...handlers ) );
 }
 
-function getCommonHandlers(
-	{ noSitePath = paths.domainManagementRoot(), warnIfJetpack = true } = {}
-) {
+function getCommonHandlers( {
+	noSitePath = paths.domainManagementRoot(),
+	warnIfJetpack = true,
+} = {} ) {
 	const handlers = [ siteSelection, navigation ];
 
 	if ( noSitePath ) {

--- a/client/my-sites/media-library/filter-to-mime-prefix.js
+++ b/client/my-sites/media-library/filter-to-mime-prefix.js
@@ -1,12 +1,12 @@
 /**
  * Given a media filter, returns the associated mime type prefix, or undefined
  * if media filter isn't supported.
- * 
+ *
  * This nearly duplicates existing behavior in <MediaListData /> utility
  * library, but does not include the `/` suffix required for REST API
  * filtering, but not utilized in MediaLibrary mime prefix detection.
- * 
- * 
+ *
+ *
  *
  * @format
  * @see /client/components/data/media-list-data/utils.js

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/edit.jsx
@@ -29,7 +29,12 @@ function PostActionsEllipsisMenuEdit( { translate, canEdit, status, editUrl, bum
 	}
 
 	return (
-		<PopoverMenuItem href={ editUrl } onClick={ bumpStat } icon="pencil" onMouseOver={ preloadEditor }>
+		<PopoverMenuItem
+			href={ editUrl }
+			onClick={ bumpStat }
+			icon="pencil"
+			onMouseOver={ preloadEditor }
+		>
 			{ translate( 'Edit', { context: 'verb' } ) }
 		</PopoverMenuItem>
 	);

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -81,7 +81,9 @@ class ActivityLogItem extends Component {
 								<FormattedBlock key={ key } content={ part } />
 							) ) }
 						</div>
-						{ activityTitle && <div className="activity-log-item__description-summary">{ activityTitle }</div> }
+						{ activityTitle && (
+							<div className="activity-log-item__description-summary">{ activityTitle }</div>
+						) }
 					</div>
 				) }
 			</div>

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -626,68 +626,65 @@ class ActivityLog extends Component {
 					) }
 				{ ! isEmpty( logs ) && (
 					<section className="activity-log__wrapper">
-						{ intoVisualGroups(
-							moment,
-							logs,
-							this.getStartMoment(),
-							this.applySiteOffset
-						).map( ( [ type, [ start, end ], events ] ) => {
-							const isToday = today.isSame(
-								end
-									.clone()
-									.utc()
-									.startOf( 'day' )
-							);
+						{ intoVisualGroups( moment, logs, this.getStartMoment(), this.applySiteOffset ).map(
+							( [ type, [ start, end ], events ] ) => {
+								const isToday = today.isSame(
+									end
+										.clone()
+										.utc()
+										.startOf( 'day' )
+								);
 
-							switch ( type ) {
-								case 'empty-day':
-									return (
-										<div key={ start.format() } className="activity-log__empty-day">
-											<div className="activity-log__empty-day-title">
-												{ start.format( 'LL' ) }
-												{ isToday && ` \u2014 ${ translate( 'Today' ) }` }
+								switch ( type ) {
+									case 'empty-day':
+										return (
+											<div key={ start.format() } className="activity-log__empty-day">
+												<div className="activity-log__empty-day-title">
+													{ start.format( 'LL' ) }
+													{ isToday && ` \u2014 ${ translate( 'Today' ) }` }
+												</div>
+												<div className="activity-log__empty-day-events">
+													{ translate( 'No activity' ) }
+												</div>
 											</div>
-											<div className="activity-log__empty-day-events">
-												{ translate( 'No activity' ) }
-											</div>
-										</div>
-									);
+										);
 
-								case 'empty-range':
-									return (
-										<div key={ start.format( 'LL' ) } className="activity-log__empty-day">
-											<div className="activity-log__empty-day-title">
-												{ `${ start.format( 'LL' ) } - ${ end.format( 'LL' ) }` }
-												{ isToday && ` \u2014 ${ translate( 'Today' ) }` }
+									case 'empty-range':
+										return (
+											<div key={ start.format( 'LL' ) } className="activity-log__empty-day">
+												<div className="activity-log__empty-day-title">
+													{ `${ start.format( 'LL' ) } - ${ end.format( 'LL' ) }` }
+													{ isToday && ` \u2014 ${ translate( 'Today' ) }` }
+												</div>
+												<div className="activity-log__empty-day-events">
+													{ translate( 'No activity' ) }
+												</div>
 											</div>
-											<div className="activity-log__empty-day-events">
-												{ translate( 'No activity' ) }
-											</div>
-										</div>
-									);
+										);
 
-								case 'non-empty-day':
-									return (
-										<ActivityLogDay
-											key={ start.format() }
-											applySiteOffset={ this.applySiteOffset }
-											requestedRestoreId={ requestedRestoreId }
-											requestedBackupId={ requestedBackupId }
-											restoreConfirmDialog={ restoreConfirmDialog }
-											backupConfirmDialog={ backupConfirmDialog }
-											disableRestore={ disableRestore }
-											disableBackup={ disableBackup }
-											isRewindActive={ isRewindActive }
-											logs={ events }
-											requestDialog={ this.handleRequestDialog }
-											closeDialog={ this.handleCloseDialog }
-											siteId={ siteId }
-											tsEndOfSiteDay={ start.valueOf() }
-											isToday={ isToday }
-										/>
-									);
+									case 'non-empty-day':
+										return (
+											<ActivityLogDay
+												key={ start.format() }
+												applySiteOffset={ this.applySiteOffset }
+												requestedRestoreId={ requestedRestoreId }
+												requestedBackupId={ requestedBackupId }
+												restoreConfirmDialog={ restoreConfirmDialog }
+												backupConfirmDialog={ backupConfirmDialog }
+												disableRestore={ disableRestore }
+												disableBackup={ disableBackup }
+												isRewindActive={ isRewindActive }
+												logs={ events }
+												requestDialog={ this.handleRequestDialog }
+												closeDialog={ this.handleCloseDialog }
+												siteId={ siteId }
+												tsEndOfSiteDay={ start.valueOf() }
+												isToday={ isToday }
+											/>
+										);
+								}
 							}
-						} ) }
+						) }
 					</section>
 				) }
 				{ hasFirstBackup && this.renderMonthNavigation( 'bottom' ) }

--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -43,9 +43,9 @@ export const StatsModuleSummaryLinks = props => {
 	const summaryPath = `/stats/day/${ path }/${ siteSlug }?startDate=${ moment().format(
 		'YYYY-MM-DD'
 	) }&summarize=1&num=`;
-	const summaryPeriodPath = `/stats/${ period.period }/${ path }/${ siteSlug }?startDate=${ period.endOf.format(
-		'YYYY-MM-DD'
-	) }`;
+	const summaryPeriodPath = `/stats/${
+		period.period
+	}/${ path }/${ siteSlug }?startDate=${ period.endOf.format( 'YYYY-MM-DD' ) }`;
 	const options = [
 		{ value: '0', label: getSummaryPeriodLabel(), path: summaryPeriodPath, stat: 'Period Summary' },
 		{ value: '7', label: translate( '7 days' ), path: `${ summaryPath }7`, stat: '7 Days' },

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -542,12 +542,12 @@ class ThemeSheet extends React.Component {
 		const section = this.validateSection( this.props.section );
 		const { siteId, retired } = this.props;
 
-		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${ siteId
-			? '/:site_id'
-			: '' }`;
-		const analyticsPageTitle = `Themes > Details Sheet${ section
-			? ' > ' + titlecase( section )
-			: '' }${ siteId ? ' > Site' : '' }`;
+		const analyticsPath = `/theme/:slug${ section ? '/' + section : '' }${
+			siteId ? '/:site_id' : ''
+		}`;
+		const analyticsPageTitle = `Themes > Details Sheet${
+			section ? ' > ' + titlecase( section ) : ''
+		}${ siteId ? ' > Site' : '' }`;
 
 		const { canonicalUrl, currentUserId, description, name: themeName } = this.props;
 		const title =

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -1,12 +1,12 @@
 /**
  * Loads the notifications client into Calypso and
  * connects the messaging and interactive elements
- * 
+ *
  *  - messages through iframe
  *  - keyboard hotkeys
  *  - window/pane scrolling
  *  - service worker
- * 
+ *
  *
  * @format
  * @module notifications

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -143,14 +143,14 @@ function startEditingPostCopy( site, postToCopyId, context ) {
 			postAttributes.featured_image = getFeaturedImageId( postToCopy );
 
 			/**
-		 * A post attributes whitelist for Redux's `editPost()` action.
-		 *
-		 * This is needed because blindly passing all post attributes to `editPost()`
-		 * caused some of them (notably the featured image) to revert to their original value
-		 * when modified right after the copy.
-		 *
-		 * @see https://github.com/Automattic/wp-calypso/pull/13933
-		 */
+			 * A post attributes whitelist for Redux's `editPost()` action.
+			 *
+			 * This is needed because blindly passing all post attributes to `editPost()`
+			 * caused some of them (notably the featured image) to revert to their original value
+			 * when modified right after the copy.
+			 *
+			 * @see https://github.com/Automattic/wp-calypso/pull/13933
+			 */
 			const reduxPostAttributes = {
 				terms: postAttributes.terms,
 				title: postAttributes.title,
@@ -165,13 +165,13 @@ function startEditingPostCopy( site, postToCopyId, context ) {
 			actions.edit( postAttributes );
 
 			/**
-		 * A post metadata whitelist for Flux's `updateMetadata()` action.
-		 *
-		 * This is needed because blindly passing all post metadata to `updateMetadata()`
-		 * causes unforeseeable issues, such as Publicize not triggering on the copied post.
-		 *
-		 * @see https://github.com/Automattic/wp-calypso/issues/14840
-		 */
+			 * A post metadata whitelist for Flux's `updateMetadata()` action.
+			 *
+			 * This is needed because blindly passing all post metadata to `updateMetadata()`
+			 * causes unforeseeable issues, such as Publicize not triggering on the copied post.
+			 *
+			 * @see https://github.com/Automattic/wp-calypso/issues/14840
+			 */
 			const metadataWhitelist = [ 'geo_latitude', 'geo_longitude' ];
 
 			// Convert the metadata array into a metadata object, needed because `updateMetadata()` expects an object.

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -188,9 +188,7 @@ export class EditorGroundControl extends PureComponent {
 					onClick={ this.onPreviewButtonClick }
 					tabIndex={ 4 }
 				>
-					<span className="editor-ground-control__button-label">
-						{ this.getPreviewLabel() }
-					</span>
+					<span className="editor-ground-control__button-label">{ this.getPreviewLabel() }</span>
 				</Button>
 				<div className="editor-ground-control__publish-button">
 					<EditorPublishButton
@@ -249,7 +247,7 @@ export class EditorGroundControl extends PureComponent {
 					onSelect={ this.props.recordSiteButtonClick }
 					indicator={ true }
 				/>
-				{ this.state.needsVerification &&
+				{ this.state.needsVerification && (
 					<div
 						className="editor-ground-control__email-verification-notice"
 						tabIndex={ 7 }
@@ -263,7 +261,8 @@ export class EditorGroundControl extends PureComponent {
 						<span className="editor-ground-control__email-verification-notice-more">
 							{ translate( 'Learn More' ) }
 						</span>
-					</div> }
+					</div>
+				) }
 				<QuickSaveButtons
 					isSaving={ isSaving }
 					isSaveBlocked={ isSaveBlocked }

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -627,9 +627,9 @@ export class EditorHtmlToolbar extends Component {
 							{ map( buttons, ( { disabled, label, onClick }, tag ) => (
 								<Button
 									borderless
-									className={ `editor-html-toolbar__button-${ tag } ${ this.isTagOpen( tag )
-										? 'is-tag-open'
-										: '' }` }
+									className={ `editor-html-toolbar__button-${ tag } ${
+										this.isTagOpen( tag ) ? 'is-tag-open' : ''
+									}` }
 									compact
 									disabled={ disabled }
 									key={ tag }

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -111,7 +111,8 @@ export class EditorMediaModalGalleryFields extends React.Component {
 								key={ 'value-' + value }
 								selected={ value === settings[ settingName ] }
 								onClick={ () =>
-									onUpdateSetting( settingName, isFinite( parseInt( value ) ) ? +value : value ) }
+									onUpdateSetting( settingName, isFinite( parseInt( value ) ) ? +value : value )
+								}
 							>
 								{ label }
 							</SelectDropdownItem>

--- a/client/post-editor/media-modal/markup.js
+++ b/client/post-editor/media-modal/markup.js
@@ -130,7 +130,7 @@ Markup = {
 		 *
 		 * @param  {Object} site    A site object
 		 * @param  {Object} media   An image media object
-	 	 * @param  {Object} options Appearance options
+		 * @param  {Object} options Appearance options
 		 * @return {string}         An image markup string
 		 */
 		image: function( site, media, options ) {

--- a/client/reader/discover/stats.js
+++ b/client/reader/discover/stats.js
@@ -1,7 +1,7 @@
 /** @format */
 /**
-* Internal dependencies
-*/
+ * Internal dependencies
+ */
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 export function recordAuthorClick( author ) {

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -8,8 +8,8 @@ import { current } from 'page';
 import i18n from 'i18n-calypso';
 
 /**
-* Internal dependencies
-*/
+ * Internal dependencies
+ */
 import config from 'config';
 import stepActions from 'lib/signup/step-actions';
 

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -104,8 +104,7 @@ class Site extends React.Component {
 				validate: true,
 			},
 			function( error, response ) {
-				let messages = {},
-					errorObject = {};
+				let messages = {};
 
 				debug( error, response );
 
@@ -121,8 +120,11 @@ class Site extends React.Component {
 
 					timesValidationFailed++;
 
-					errorObject[ error.error ] = error.message;
-					messages = { site: errorObject };
+					messages = {
+						site: {
+							[ error.error ]: error.message,
+						},
+					};
 				}
 				onComplete( null, messages );
 			}

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -97,34 +97,36 @@ class Site extends React.Component {
 	};
 
 	validate = ( fields, onComplete ) => {
-		wpcom.undocumented().sitesNew( {
-			blog_name: fields.site,
-			blog_title: fields.site,
-			validate: true,
-		},
-		function( error, response ) {
-			let messages = {},
-				errorObject = {};
+		wpcom.undocumented().sitesNew(
+			{
+				blog_name: fields.site,
+				blog_title: fields.site,
+				validate: true,
+			},
+			function( error, response ) {
+				let messages = {},
+					errorObject = {};
 
-			debug( error, response );
+				debug( error, response );
 
-			if ( error && error.message ) {
-				if ( fields.site && ! includes( siteUrlsSearched, fields.site ) ) {
-					siteUrlsSearched.push( fields.site );
+				if ( error && error.message ) {
+					if ( fields.site && ! includes( siteUrlsSearched, fields.site ) ) {
+						siteUrlsSearched.push( fields.site );
 
-					analytics.tracks.recordEvent( 'calypso_signup_site_url_validation_failed', {
-						error: error.error,
-						site_url: fields.site,
-					} );
+						analytics.tracks.recordEvent( 'calypso_signup_site_url_validation_failed', {
+							error: error.error,
+							site_url: fields.site,
+						} );
+					}
+
+					timesValidationFailed++;
+
+					errorObject[ error.error ] = error.message;
+					messages = { site: errorObject };
 				}
-
-				timesValidationFailed++;
-
-				errorObject[ error.error ] = error.message;
-				messages = { site: errorObject };
+				onComplete( null, messages );
 			}
-			onComplete( null, messages );
-		} );
+		);
 	};
 
 	setFormState = state => {

--- a/client/signup/steps/theme-selection/signup-themes-list.jsx
+++ b/client/signup/steps/theme-selection/signup-themes-list.jsx
@@ -42,7 +42,9 @@ class SignupThemesList extends Component {
 	}
 
 	getScreenshotUrl( theme ) {
-		return `https://i1.wp.com/s0.wp.com/wp-content/themes/${ theme.repo }/${ theme.slug }/screenshot.png?w=660`;
+		return `https://i1.wp.com/s0.wp.com/wp-content/themes/${ theme.repo }/${
+			theme.slug
+		}/screenshot.png?w=660`;
 	}
 
 	render() {

--- a/client/state/analytics/actions.js
+++ b/client/state/analytics/actions.js
@@ -28,9 +28,9 @@ const mergedMetaData = ( a, b ) => [
 const joinAnalytics = ( analytics, action ) =>
 	isFunction( action )
 		? dispatch => {
-			dispatch( analytics );
-			dispatch( action );
-		}
+				dispatch( analytics );
+				dispatch( action );
+			}
 		: merge( {}, action, { meta: { analytics: mergedMetaData( analytics, action ) } } );
 
 export const composeAnalytics = ( ...analytics ) => ( {

--- a/client/state/analytics/test/actions.js
+++ b/client/state/analytics/test/actions.js
@@ -115,7 +115,7 @@ describe( 'middleware', () => {
 			const thunk = recordTracksEventWithClientId( ...props );
 
 			let dispatchedEvent;
-			const dispatch = ( createdAction ) => dispatchedEvent = createdAction;
+			const dispatch = createdAction => ( dispatchedEvent = createdAction );
 
 			const clientId = 123;
 			const getState = () => ( {
@@ -141,7 +141,7 @@ describe( 'middleware', () => {
 			const thunk = recordPageViewWithClientId( ...props );
 
 			let dispatchedEvent;
-			const dispatch = ( createdAction ) => dispatchedEvent = createdAction;
+			const dispatch = createdAction => ( dispatchedEvent = createdAction );
 
 			const clientId = 123;
 			const getState = () => ( {

--- a/client/state/country-states/selectors.js
+++ b/client/state/country-states/selectors.js
@@ -1,7 +1,7 @@
 /**
  * Returns an array of states objects for the specified country code, or null
  * if there are not states for the country.
- * 
+ *
  *
  * @format
  * @param {String} countryCode Country code to check.

--- a/client/state/data-layer/third-party/directly/test/index.js
+++ b/client/state/data-layer/third-party/directly/test/index.js
@@ -120,11 +120,12 @@ describe( 'Directly data layer', () => {
 		test( 'should dispatch an analytics event if initialization fails', done => {
 			initialize( store )
 				.then( () =>
-					expect(
-						analytics.recordTracksEvent
-					).to.have.been.calledWith( 'calypso_directly_initialization_error', {
-						error: 'Error: Something went wrong',
-					} )
+					expect( analytics.recordTracksEvent ).to.have.been.calledWith(
+						'calypso_directly_initialization_error',
+						{
+							error: 'Error: Something went wrong',
+						}
+					)
 				)
 				.then( () => done() );
 

--- a/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/delays.js
+++ b/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/delays.js
@@ -2,13 +2,13 @@
  * PRNG-based functions providing enhanced versions of simple delay
  * formulas in order to spread out an array of failing operations
  * over more uniform time distributions.
- * 
+ *
  * Jitter is introduced so that if, for example, twenty requests all
  * fail at the same time, that they won't all retry at the same time.
  * This should mitigate load on the server after failed requests and
  * lead towards more retry attempts succeeding faster than with the
  * naïve delay formulas.
- * 
+ *
  *
  * @format
  * @module state/data-layer/wpcom-http/pipeline/retry-on-failure/delays

--- a/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
+++ b/client/state/data-layer/wpcom/sites/blog-stickers/remove/index.js
@@ -21,8 +21,9 @@ export function requestBlogStickerRemove( { dispatch }, action ) {
 	dispatch(
 		http( {
 			method: 'POST',
-			path: `/sites/${ action.payload.blogId }/blog-stickers/remove/${ action.payload
-				.stickerName }`,
+			path: `/sites/${ action.payload.blogId }/blog-stickers/remove/${
+				action.payload.stickerName
+			}`,
 			body: {}, // have to have an empty body to make wpcom-http happy
 			apiVersion: '1.1',
 			onSuccess: action,

--- a/client/state/domains/suggestions/utils.js
+++ b/client/state/domains/suggestions/utils.js
@@ -1,7 +1,7 @@
 /**
  * Returns a serialized domains suggestions query, used as the key in the
  * `state.domains.suggestions` state object.
- * 
+ *
  *
  * @format
  * @param {Object} queryObject   DomainsSuggestions query

--- a/client/state/happiness-engineers/selectors.js
+++ b/client/state/happiness-engineers/selectors.js
@@ -1,6 +1,6 @@
 /**
  * Returns happiness engineers
- * 
+ *
  *
  * @format
  * @param {{}} state currents state

--- a/client/state/help/courses/selectors.js
+++ b/client/state/help/courses/selectors.js
@@ -1,6 +1,6 @@
 /**
  * Returns an array of course objects.
- * 
+ *
  *
  * @format
  * @param {Object} state  Global state tree

--- a/client/state/jetpack-sync/utils.js
+++ b/client/state/jetpack-sync/utils.js
@@ -1,7 +1,7 @@
 /**
  * Returns an array of keys that are expected to be returned
  * from the API when checking sync status for a site.
- * 
+ *
  *
  * @format
  * @return {Array} Array of strings that are expected keys in API response.

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -84,7 +84,8 @@ export const redirectTo = combineReducers( {
 		[ SOCIAL_LOGIN_REQUEST_SUCCESS ]: ( state, { data } ) => get( data, 'redirect_to', null ),
 		[ SOCIAL_CONNECT_ACCOUNT_REQUEST ]: () => null,
 		[ SOCIAL_CONNECT_ACCOUNT_REQUEST_FAILURE ]: () => null,
-		[ SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS ]: ( state, action ) => get( action, 'redirect_to', null ),
+		[ SOCIAL_CONNECT_ACCOUNT_REQUEST_SUCCESS ]: ( state, action ) =>
+			get( action, 'redirect_to', null ),
 		[ LOGOUT_REQUEST ]: () => null,
 		[ LOGOUT_REQUEST_FAILURE ]: () => null,
 		[ LOGOUT_REQUEST_SUCCESS ]: () => ( state, { data } ) => get( data, 'redirect_to', null ),

--- a/client/state/page-templates/selectors.js
+++ b/client/state/page-templates/selectors.js
@@ -1,7 +1,7 @@
 /**
  * Returns true if a request is in progress to retrieve the page templates for
  * the specified site, or false otherwise.
- * 
+ *
  *
  * @format
  * @param {Number}  siteId Site ID

--- a/client/state/post-formats/selectors.js
+++ b/client/state/post-formats/selectors.js
@@ -1,7 +1,7 @@
 /**
  * Returns true if currently requesting post formats for the specified site ID, or
  * false otherwise.
- * 
+ *
  *
  * @format
  * @param {Number}  siteId Site ID

--- a/client/state/post-types/selectors.js
+++ b/client/state/post-types/selectors.js
@@ -1,7 +1,7 @@
 /**
  * Returns true if current requesting post types for the specified site ID, or
  * false otherwise.
- * 
+ *
  *
  * @format
  * @param {Number}  siteId Site ID

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -165,10 +165,7 @@ export function queryRequests( state = {}, action ) {
 export const queries = ( () => {
 	function applyToManager( state, siteId, method, createDefault, ...args ) {
 		if ( ! siteId ) {
-			debug(
-				'state.posts.queries#applyToManager called without siteId',
-				{ siteId, method, args }
-			);
+			debug( 'state.posts.queries#applyToManager called without siteId', { siteId, method, args } );
 			mc && mc.bumpStat( 'calypso_missing_site_id', 'state.posts.queries' );
 			return state;
 		}
@@ -199,7 +196,8 @@ export const queries = ( () => {
 		{},
 		{
 			[ POSTS_REQUEST_SUCCESS ]: ( state, { siteId, query, posts, found } ) => {
-				if ( ! siteId ) { // Handle site-specific queries only
+				if ( ! siteId ) {
+					// Handle site-specific queries only
 					return state;
 				}
 				const normalizedPosts = posts.map( normalizePostForState );
@@ -323,94 +321,91 @@ export const queries = ( () => {
  */
 export const allSitesQueries = ( () => {
 	function findItemKey( state, siteId, postId ) {
-		return findKey( state.data.items, post => {
-			return post.site_ID === siteId && post.ID === postId;
-		} ) || null;
+		return (
+			findKey( state.data.items, post => {
+				return post.site_ID === siteId && post.ID === postId;
+			} ) || null
+		);
 	}
 
-	return createReducer(
-		new PostQueryManager( {}, { itemKey: 'global_ID' } ),
-		{
-			[ POSTS_REQUEST_SUCCESS ]: ( state, { siteId, query, posts, found } ) => {
-				if ( siteId ) { // Handle all-sites queries only.
-					return state;
-				}
-				return state.receive(
-					posts.map( normalizePostForState ),
-					{ query, found }
-				);
-			},
-			[ POSTS_RECEIVE ]: ( state, { posts } ) => {
-				return state.receive( posts );
-			},
-			[ POST_RESTORE ]: ( state, { siteId, postId } ) => {
-				const globalId = findItemKey( state, siteId, postId );
-				return state.receive(
-					{
-						global_ID: globalId,
-						status: '__RESTORE_PENDING',
-					},
-					{ patch: true }
-				);
-			},
-			[ POST_RESTORE_FAILURE ]: ( state, { siteId, postId } ) => {
-				const globalId = findItemKey( state, siteId, postId );
-				return state.receive(
-					{
-						global_ID: globalId,
-						status: 'trash',
-					},
-					{ patch: true }
-				);
-			},
-			[ POST_SAVE ]: ( state, { siteId, postId, post } ) => {
-				const globalId = findItemKey( state, siteId, postId );
-				return state.receive(
-					{
-						global_ID: globalId,
-						...post,
-					},
-					{ patch: true }
-				);
-			},
-			[ POST_DELETE ]: ( state, { siteId, postId } ) => {
-				const globalId = findItemKey( state, siteId, postId );
-				return state.receive(
-					{
-						global_ID: globalId,
-						status: '__DELETE_PENDING',
-					},
-					{ patch: true }
-				);
-			},
-			[ POST_DELETE_FAILURE ]: ( state, { siteId, postId } ) => {
-				const globalId = findItemKey( state, siteId, postId );
-				return state.receive(
-					{
-						global_ID: globalId,
-						status: 'trash',
-					},
-					{ patch: true }
-				);
-			},
-			[ POST_DELETE_SUCCESS ]: ( state, { siteId, postId } ) => {
-				const globalId = findItemKey( state, siteId, postId );
-				return state.removeItem( globalId );
-			},
-			[ SERIALIZE ]: state => {
-				return {
-					data: state.data,
-					options: state.options,
-				};
-			},
-			[ DESERIALIZE ]: state => {
-				if ( ! isValidStateWithSchema( state, allSitesQueriesSchema ) ) {
-					return new PostQueryManager( {}, { itemKey: 'global_ID' } );
-				}
-				return new PostQueryManager( state.data, state.options );
-			},
-		}
-	);
+	return createReducer( new PostQueryManager( {}, { itemKey: 'global_ID' } ), {
+		[ POSTS_REQUEST_SUCCESS ]: ( state, { siteId, query, posts, found } ) => {
+			if ( siteId ) {
+				// Handle all-sites queries only.
+				return state;
+			}
+			return state.receive( posts.map( normalizePostForState ), { query, found } );
+		},
+		[ POSTS_RECEIVE ]: ( state, { posts } ) => {
+			return state.receive( posts );
+		},
+		[ POST_RESTORE ]: ( state, { siteId, postId } ) => {
+			const globalId = findItemKey( state, siteId, postId );
+			return state.receive(
+				{
+					global_ID: globalId,
+					status: '__RESTORE_PENDING',
+				},
+				{ patch: true }
+			);
+		},
+		[ POST_RESTORE_FAILURE ]: ( state, { siteId, postId } ) => {
+			const globalId = findItemKey( state, siteId, postId );
+			return state.receive(
+				{
+					global_ID: globalId,
+					status: 'trash',
+				},
+				{ patch: true }
+			);
+		},
+		[ POST_SAVE ]: ( state, { siteId, postId, post } ) => {
+			const globalId = findItemKey( state, siteId, postId );
+			return state.receive(
+				{
+					global_ID: globalId,
+					...post,
+				},
+				{ patch: true }
+			);
+		},
+		[ POST_DELETE ]: ( state, { siteId, postId } ) => {
+			const globalId = findItemKey( state, siteId, postId );
+			return state.receive(
+				{
+					global_ID: globalId,
+					status: '__DELETE_PENDING',
+				},
+				{ patch: true }
+			);
+		},
+		[ POST_DELETE_FAILURE ]: ( state, { siteId, postId } ) => {
+			const globalId = findItemKey( state, siteId, postId );
+			return state.receive(
+				{
+					global_ID: globalId,
+					status: 'trash',
+				},
+				{ patch: true }
+			);
+		},
+		[ POST_DELETE_SUCCESS ]: ( state, { siteId, postId } ) => {
+			const globalId = findItemKey( state, siteId, postId );
+			return state.removeItem( globalId );
+		},
+		[ SERIALIZE ]: state => {
+			return {
+				data: state.data,
+				options: state.options,
+			};
+		},
+		[ DESERIALIZE ]: state => {
+			if ( ! isValidStateWithSchema( state, allSitesQueriesSchema ) ) {
+				return new PostQueryManager( {}, { itemKey: 'global_ID' } );
+			}
+			return new PostQueryManager( state.data, state.options );
+		},
+	} );
 } )();
 
 /**

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -1435,9 +1435,9 @@ describe( 'reducer', () => {
 				postId: 841,
 			} );
 
-			expect(
-				state.getItem( '48b6010b559efe6a77a429773e0cbf12' ).status
-			).to.equal( '__RESTORE_PENDING' );
+			expect( state.getItem( '48b6010b559efe6a77a429773e0cbf12' ).status ).to.equal(
+				'__RESTORE_PENDING'
+			);
 			expect( state.getItems( { status: 'trash' } ) ).to.have.length( 0 );
 		} );
 
@@ -1471,9 +1471,7 @@ describe( 'reducer', () => {
 				postId: 841,
 			} );
 
-			expect(
-				state.getItem( '48b6010b559efe6a77a429773e0cbf12' ).status
-			).to.equal( 'trash' );
+			expect( state.getItem( '48b6010b559efe6a77a429773e0cbf12' ).status ).to.equal( 'trash' );
 			expect( state.getItems( { status: 'trash' } ) ).to.have.length( 1 );
 		} );
 
@@ -1540,9 +1538,9 @@ describe( 'reducer', () => {
 				postId: 841,
 			} );
 
-			expect(
-				state.getItem( '48b6010b559efe6a77a429773e0cbf12' ).status
-			).to.equal( '__DELETE_PENDING' );
+			expect( state.getItem( '48b6010b559efe6a77a429773e0cbf12' ).status ).to.equal(
+				'__DELETE_PENDING'
+			);
 			expect( state.getItems( { status: 'trash' } ) ).to.have.length( 0 );
 		} );
 
@@ -1577,9 +1575,7 @@ describe( 'reducer', () => {
 				postId: 841,
 			} );
 
-			expect(
-				state.getItem( '48b6010b559efe6a77a429773e0cbf12' ).status
-			).to.equal( 'trash' );
+			expect( state.getItem( '48b6010b559efe6a77a429773e0cbf12' ).status ).to.equal( 'trash' );
 			expect( state.getItems( { status: 'trash' } ) ).to.have.length( 1 );
 		} );
 
@@ -1680,22 +1676,27 @@ describe( 'reducer', () => {
 
 			const state = allSitesQueries( original, { type: DESERIALIZE } );
 
-			expect( state ).to.eql( new PostQueryManager( {
-				items: {
-					'3d097cb7c5473c169bba0eb8e3c6cb64': {
-						ID: 841,
-						global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
-						site_ID: 2916284,
-						title: 'Hello World',
+			expect( state ).to.eql(
+				new PostQueryManager(
+					{
+						items: {
+							'3d097cb7c5473c169bba0eb8e3c6cb64': {
+								ID: 841,
+								global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+								site_ID: 2916284,
+								title: 'Hello World',
+							},
+						},
+						queries: {
+							'[["search","Hello"]]': {
+								found: 1,
+								itemKeys: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
+							},
+						},
 					},
-				},
-				queries: {
-					'[["search","Hello"]]': {
-						found: 1,
-						itemKeys: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
-					},
-				},
-			}, { itemKey: 'global_ID' } ) );
+					{ itemKey: 'global_ID' }
+				)
+			);
 		} );
 
 		test( 'should not load invalid persisted state', () => {

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -63,8 +63,9 @@ export function fetchPost( postKey ) {
 							site_ID: postKey.blogId,
 							is_external: ! postKey.blogId,
 							is_error: true,
-							global_ID: `${ postKey.feedId || 'na' }-${ postKey.blogId ||
-								'na' }-${ postKey.postId }`,
+							global_ID: `${ postKey.feedId || 'na' }-${ postKey.blogId || 'na' }-${
+								postKey.postId
+							}`,
 							error: err,
 						},
 					],

--- a/client/state/reader/posts/test/actions.js
+++ b/client/state/reader/posts/test/actions.js
@@ -86,12 +86,14 @@ describe( 'actions', () => {
 	describe( '#receivePosts()', () => {
 		test( 'should return an action object and dispatch posts receive', () => {
 			const posts = [];
-			return actions.receivePosts( posts )( dispatchSpy ).then( () => {
-				expect( dispatchSpy ).to.have.been.calledWith( {
-					type: READER_POSTS_RECEIVE,
-					posts,
+			return actions
+				.receivePosts( posts )( dispatchSpy )
+				.then( () => {
+					expect( dispatchSpy ).to.have.been.calledWith( {
+						type: READER_POSTS_RECEIVE,
+						posts,
+					} );
 				} );
-			} );
 		} );
 
 		test( 'should fire tracks events for posts with railcars', () => {

--- a/client/state/selectors/are-all-sites-single-user.js
+++ b/client/state/selectors/are-all-sites-single-user.js
@@ -13,10 +13,7 @@ import { isSingleUserSite } from 'state/sites/selectors';
  * @param  {Object}  state Global state tree
  * @return {Boolean}       True if all sites are single user sites
  */
-export default createSelector(
-	state => {
-		const siteIds = Object.keys( getSitesItems( state ) );
-		return !! siteIds.length && siteIds.every( siteId => isSingleUserSite( state, siteId ) );
-	},
-	getSitesItems
-);
+export default createSelector( state => {
+	const siteIds = Object.keys( getSitesItems( state ) );
+	return !! siteIds.length && siteIds.every( siteId => isSingleUserSite( state, siteId ) );
+}, getSitesItems );

--- a/client/state/selectors/edited-post-has-content.js
+++ b/client/state/selectors/edited-post-has-content.js
@@ -27,13 +27,13 @@ export function isEmptyContent( content ) {
 }
 
 /**
-  * Returns true if the edited post has content
-  * (title, excerpt or content not empty)
-  *
-  * @param  {Object}  state  Global state tree
-  * @param  {Number}  siteId Site ID
-  * @param  {Number}  postId Post ID
-  * @return {Boolean}        Whether the edited post has content or not
+ * Returns true if the edited post has content
+ * (title, excerpt or content not empty)
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {Number}  postId Post ID
+ * @return {Boolean}        Whether the edited post has content or not
  */
 export default function editedPostHasContent( state, siteId, postId ) {
 	const editedPost = getEditedPost( state, siteId, postId );

--- a/client/state/selectors/get-account-recovery-reset-options.js
+++ b/client/state/selectors/get-account-recovery-reset-options.js
@@ -1,6 +1,6 @@
 /**
  * Returns a list of pairs of email and sms number that can be used for resetting a user's password.
- * 
+ *
  *
  * @format
  * @param {Object} state Global state tree

--- a/client/state/selectors/get-media-item.js
+++ b/client/state/selectors/get-media-item.js
@@ -1,6 +1,6 @@
 /**
  * Returns a media object by site ID, media ID, or null if not known
- * 
+ *
  *
  * @format
  * @param {Number}  mediaId Media ID

--- a/client/state/selectors/get-media.js
+++ b/client/state/selectors/get-media.js
@@ -1,6 +1,6 @@
 /**
  * Returns media for a specified site ID and query.
- * 
+ *
  *
  * @format
  * @param {Object}  query  Query object

--- a/client/state/selectors/get-poster-upload-progress.js
+++ b/client/state/selectors/get-poster-upload-progress.js
@@ -1,6 +1,6 @@
 /**
  * Returns the poster upload progress.
- * 
+ *
  *
  * @format
  * @param {Object}  state  Global state tree

--- a/client/state/selectors/get-poster-url.js
+++ b/client/state/selectors/get-poster-url.js
@@ -1,6 +1,6 @@
 /**
  * Returns the poster URL of the video.
- * 
+ *
  *
  * @format
  * @param {Object}  state Global state tree

--- a/client/state/selectors/get-reader-recommended-sites-paging-offset.js
+++ b/client/state/selectors/get-reader-recommended-sites-paging-offset.js
@@ -1,6 +1,6 @@
 /**
  * Returns the recommended sites paging offset
- * 
+ *
  *
  * @format
  * @param {Number} seed the elasticsearch seed for which to grab recs

--- a/client/state/selectors/get-reader-recommended-sites.js
+++ b/client/state/selectors/get-reader-recommended-sites.js
@@ -1,6 +1,6 @@
 /**
  * Returns the recommended sites for a given seed.
- * 
+ *
  *
  * @format
  * @param {Number} seed the elasticsearch seed for which to grab recs

--- a/client/state/selectors/get-reader-tags.js
+++ b/client/state/selectors/get-reader-tags.js
@@ -1,6 +1,6 @@
 /**
  * Returns all of the reader tags cached in calypso
- * 
+ *
  *
  * @format
  * @param {Object}  state  Global state tree

--- a/client/state/selectors/get-reader-teams.js
+++ b/client/state/selectors/get-reader-teams.js
@@ -1,6 +1,6 @@
 /**
  * Returns all of the reader teams for a user
- * 
+ *
  *
  * @format
  * @param {Object}  state  Global state tree

--- a/client/state/selectors/get-theme-filters.js
+++ b/client/state/selectors/get-theme-filters.js
@@ -1,6 +1,6 @@
 /**
  * Returns the list of available theme filters
- * 
+ *
  *
  * @format
  * @param {Object}  state Global state tree

--- a/client/state/selectors/get-unsaved-user-settings.js
+++ b/client/state/selectors/get-unsaved-user-settings.js
@@ -1,6 +1,6 @@
 /**
  * Returns all unsaved user settings as one object
- * 
+ *
  *
  * @format
  * @param {Object} state Global state tree

--- a/client/state/selectors/get-user-settings.js
+++ b/client/state/selectors/get-user-settings.js
@@ -1,6 +1,6 @@
 /**
  * Returns all user settings as one object
- * 
+ *
  *
  * @format
  * @param {Object} state Global state tree

--- a/client/state/selectors/has-user-asked-a-directly-question.js
+++ b/client/state/selectors/has-user-asked-a-directly-question.js
@@ -1,7 +1,7 @@
 /**
  * Tells whether the user has asked a question through the Directly RTM widget.
- * 
- * 
+ *
+ *
  *
  * @format
  * @see lib/directly for more about Directly

--- a/client/state/selectors/has-user-settings.js
+++ b/client/state/selectors/has-user-settings.js
@@ -1,6 +1,6 @@
 /**
  * Returns a boolean signifying whether there are settings or not
- * 
+ *
  *
  * @format
  * @param {Object} state Global state tree

--- a/client/state/selectors/is-account-recovery-reset-options-ready.js
+++ b/client/state/selectors/is-account-recovery-reset-options-ready.js
@@ -1,6 +1,6 @@
 /**
  * Return a boolean value indicating whether the account recovery reset options are fetched and ready to be used.
- * 
+ *
  *
  * @format
  * @param {Object} state Global state tree

--- a/client/state/selectors/is-deleting-site.js
+++ b/client/state/selectors/is-deleting-site.js
@@ -1,7 +1,7 @@
 /**
  * Returns true if a network request is in progress to delete the specified site, or
  * false otherwise.
- * 
+ *
  *
  * @format
  * @param {Number}  siteId Site ID

--- a/client/state/selectors/is-directly-failed.js
+++ b/client/state/selectors/is-directly-failed.js
@@ -1,7 +1,7 @@
 /**
  * Tells whether the Directly RTM widget has failed to initialize
- * 
- * 
+ *
+ *
  *
  * @format
  * @see lib/directly for more about Directly

--- a/client/state/selectors/is-directly-ready.js
+++ b/client/state/selectors/is-directly-ready.js
@@ -1,7 +1,7 @@
 /**
  * Tells whether the Directly RTM widget is ready to be used
- * 
- * 
+ *
+ *
  *
  * @format
  * @see lib/directly for more about Directly

--- a/client/state/selectors/is-directly-uninitialized.js
+++ b/client/state/selectors/is-directly-uninitialized.js
@@ -1,7 +1,7 @@
 /**
  * Tells whether the Directly RTM widget has started initialization
- * 
- * 
+ *
+ *
  *
  * @format
  * @see lib/directly for more about Directly

--- a/client/state/selectors/is-site-blocked.js
+++ b/client/state/selectors/is-site-blocked.js
@@ -1,6 +1,6 @@
 /**
  * Returns true if a site is known to be blocked
- * 
+ *
  *
  * @format
  * @param {Number}  siteId Site ID

--- a/client/state/selectors/is-tracking.js
+++ b/client/state/selectors/is-tracking.js
@@ -1,6 +1,6 @@
 /**
  * Returns true if tracking is enabled for a given tracking tool
- * 
+ *
  *
  * @format
  * @param {String}  trackingTool The name of the tracking tool

--- a/client/state/selectors/should-show-video-editor-error.js
+++ b/client/state/selectors/should-show-video-editor-error.js
@@ -1,6 +1,6 @@
 /**
  * Returns true if an error should be shown in the video editor.
- * 
+ *
  *
  * @format
  * @param {Object}  state Global state tree

--- a/client/state/stored-cards/selectors.js
+++ b/client/state/stored-cards/selectors.js
@@ -1,6 +1,6 @@
 /**
  * Return user's stored cards from state object
- * 
+ *
  *
  * @format
  * @param {Object} state - current state object

--- a/client/state/terms/test/actions.js
+++ b/client/state/terms/test/actions.js
@@ -392,18 +392,17 @@ describe( 'actions', () => {
 			};
 			const getState = () => state;
 
-			return updateTerm( siteId, taxonomyName, 10, 'rib', { name: 'ribs' } )(
-				spy,
-				getState
-			).then( () => {
-				expect( spy ).to.not.have.been.calledWith( {
-					type: SITE_SETTINGS_UPDATE,
-					siteId: siteId,
-					settings: {
-						default_category: 123,
-					},
-				} );
-			} );
+			return updateTerm( siteId, taxonomyName, 10, 'rib', { name: 'ribs' } )( spy, getState ).then(
+				() => {
+					expect( spy ).to.not.have.been.calledWith( {
+						type: SITE_SETTINGS_UPDATE,
+						siteId: siteId,
+						settings: {
+							default_category: 123,
+						},
+					} );
+				}
+			);
 		} );
 	} );
 

--- a/client/state/test/persistence.js
+++ b/client/state/test/persistence.js
@@ -7,8 +7,12 @@ import { createReduxStore, reducer } from 'state';
 
 describe( 'persistence', () => {
 	test( 'initial state should serialize and deserialize without errors or warnings', () => {
-		const consoleErrorSpy = jest.spyOn( global.console, 'error' ).mockImplementation( () => () => {} );
-		const consoleWarnSpy = jest.spyOn( global.console, 'warn' ).mockImplementation( () => () => {} );
+		const consoleErrorSpy = jest
+			.spyOn( global.console, 'error' )
+			.mockImplementation( () => () => {} );
+		const consoleWarnSpy = jest
+			.spyOn( global.console, 'warn' )
+			.mockImplementation( () => () => {} );
 
 		const initialState = createReduxStore().getState();
 

--- a/client/state/ui/editor/image-editor/selectors.js
+++ b/client/state/ui/editor/image-editor/selectors.js
@@ -1,6 +1,6 @@
 /**
  * Returns an object representing the image editor transform
- * 
+ *
  *
  * @format
  * @param {Object}  state Global state tree

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -150,7 +150,7 @@ export const isSelectedSiteCustomizable = state =>
  *
  * @param {Object} state Global state tree
  * @return {Boolean} True if site has any media files, false otherwise.
-*/
+ */
 export const doesSelectedSiteHaveMediaFiles = state => {
 	const siteId = getSelectedSiteId( state );
 	if ( ! siteId ) {

--- a/client/state/ui/layout-focus/selectors.js
+++ b/client/state/ui/layout-focus/selectors.js
@@ -1,6 +1,6 @@
 /**
  * Returns the current layout focus area
- * 
+ *
  *
  * @format
  * @param {Object}  state Global state tree

--- a/client/state/ui/media-modal/constants.js
+++ b/client/state/ui/media-modal/constants.js
@@ -1,6 +1,6 @@
 /**
  * Media modal views
- * 
+ *
  *
  * @format
  * @enum {String}

--- a/client/state/ui/media-modal/selectors.js
+++ b/client/state/ui/media-modal/selectors.js
@@ -1,7 +1,7 @@
 /**
  * Returns the current media modal view.
- * 
- * 
+ *
+ *
  *
  * @format
  * @see ./constants.js (MediaView)

--- a/client/state/users/selectors.js
+++ b/client/state/users/selectors.js
@@ -1,6 +1,6 @@
 /**
  * Returns a user object by user ID.
- * 
+ *
  *
  * @format
  * @param {Number} userId User ID

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -48,8 +48,8 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.0.0-beta.35",
-      "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
+      "version": "7.0.0-beta.36",
+      "integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
@@ -750,8 +750,8 @@
       }
     },
     "babel-jest": {
-      "version": "22.0.3",
-      "integrity": "sha512-vIJAdq0YuLwg5TF6DDvcSFYx+Cqb9f2pTzC3ZcpGUBeysUUzPxZ6J3WVvuFMzpxgHa23tDKlNivDN9C4jIAKUQ==",
+      "version": "22.0.4",
+      "integrity": "sha512-/Yt61fUpdFjetYlnpj280BPKEsPnK4mqzxDdo8DybPvrPNrLurbAF/WBjn2nnoi1Hc2Ippsf12/aOp8ys/Vl1A==",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.5",
@@ -1566,6 +1566,11 @@
       "version": "1.0.2",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
+    "bail": {
+      "version": "1.0.2",
+      "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q=",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
@@ -2092,12 +2097,27 @@
         "upper-case-first": "1.1.2"
       }
     },
+    "character-entities": {
+      "version": "1.2.1",
+      "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco=",
+      "dev": true
+    },
+    "character-entities-legacy": {
+      "version": "1.1.1",
+      "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8=",
+      "dev": true
+    },
     "character-parser": {
       "version": "2.2.0",
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
       "requires": {
         "is-regex": "1.0.4"
       }
+    },
+    "character-reference-invalid": {
+      "version": "1.1.1",
+      "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw=",
+      "dev": true
     },
     "check-node-version": {
       "version": "2.1.0",
@@ -2106,7 +2126,7 @@
         "map-values": "1.0.1",
         "minimist": "1.2.0",
         "object-filter": "1.0.2",
-        "object.assign": "4.0.4",
+        "object.assign": "4.1.0",
         "run-parallel": "1.1.6",
         "semver": "5.1.0"
       },
@@ -2191,6 +2211,11 @@
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
+    "cjk-regex": {
+      "version": "1.0.2",
+      "integrity": "sha512-NwSMtwULPLk8Ka9DEUcoFXhMRnV/bpyKDnoyDiVw/Qy5przhvHTvXLcsKaOmx13o8J4XEsPVT1baoCUj5zQs3w==",
+      "dev": true
+    },
     "classnames": {
       "version": "1.1.1",
       "integrity": "sha1-Lluagh1sn8K5enM8VNnwV43v/8k="
@@ -2247,13 +2272,13 @@
       "integrity": "sha1-fAHg3HBsI0s5yTODjI4gshdXduI=",
       "dev": true,
       "requires": {
-        "marked": "0.3.7",
+        "marked": "0.3.9",
         "marked-terminal": "1.7.0"
       },
       "dependencies": {
         "marked": {
-          "version": "0.3.7",
-          "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
+          "version": "0.3.9",
+          "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw==",
           "dev": true
         }
       }
@@ -2316,6 +2341,11 @@
     "code-point-at": {
       "version": "1.1.0",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "collapse-white-space": {
+      "version": "1.0.3",
+      "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw=",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.1",
@@ -2404,7 +2434,7 @@
       "dev": true,
       "requires": {
         "commander": "2.12.2",
-        "detective": "4.7.0",
+        "detective": "4.7.1",
         "glob": "5.0.15",
         "graceful-fs": "4.1.11",
         "iconv-lite": "0.4.15",
@@ -3193,17 +3223,17 @@
       "dev": true
     },
     "detective": {
-      "version": "4.7.0",
-      "integrity": "sha512-4mBqSEdMfBpRAo/DQZnTcAXenpiSIJmVKbCMSotS+SFWWcrP/CKM6iBRPdTiEO+wZhlfEsoZlGqpG6ycl5vTqw==",
+      "version": "4.7.1",
+      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "defined": "1.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "version": "5.3.0",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
           "dev": true
         }
       }
@@ -3407,6 +3437,43 @@
         "jsbn": "0.1.1"
       }
     },
+    "editorconfig": {
+      "version": "0.14.2",
+      "integrity": "sha512-tghjvKwo1gakrhFiZWlbo5ILWAfnuOu1JFztW0li+vzbnInN0CMZuF4F0T/Pnn9UWpT7Mr1aFTWdHVuxiR9K9A==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "commander": "2.12.2",
+        "lru-cache": "3.2.0",
+        "semver": "5.1.0",
+        "sigmund": "1.0.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.12.2",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "3.2.0",
+          "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2"
+          }
+        }
+      }
+    },
+    "editorconfig-to-prettier": {
+      "version": "0.0.6",
+      "integrity": "sha512-Ysw+hBdwhPFruYmLapKRm7Or5XgMzhasbqu4AN07V2l/AkqpgooWm2xtTQPzTD6S0tq54A+WbSxNt6qmsO3hoA==",
+      "dev": true
+    },
     "ee-first": {
       "version": "1.1.1",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
@@ -3447,6 +3514,11 @@
     "emitter-component": {
       "version": "1.0.0",
       "integrity": "sha1-8E3Rj8PcPpp0y8DzELCIZm5MAW8="
+    },
+    "emoji-regex": {
+      "version": "6.5.1",
+      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+      "dev": true
     },
     "emoji-text": {
       "version": "0.2.6",
@@ -3593,7 +3665,7 @@
         "is-subset": "0.1.1",
         "lodash": "4.17.4",
         "object-is": "1.0.1",
-        "object.assign": "4.0.4",
+        "object.assign": "4.1.0",
         "object.entries": "1.0.4",
         "object.values": "1.0.4",
         "raf": "3.4.0",
@@ -3614,7 +3686,7 @@
       "requires": {
         "enzyme-adapter-utils": "1.3.0",
         "lodash": "4.17.4",
-        "object.assign": "4.0.4",
+        "object.assign": "4.1.0",
         "object.values": "1.0.4",
         "prop-types": "15.6.0",
         "react-reconciler": "0.7.0",
@@ -3644,7 +3716,7 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.4",
-        "object.assign": "4.0.4",
+        "object.assign": "4.1.0",
         "prop-types": "15.6.0"
       },
       "dependencies": {
@@ -4196,13 +4268,13 @@
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "version": "5.3.0",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
           "dev": true
         }
       }
@@ -4496,6 +4568,14 @@
       "version": "1.1.1",
       "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
     },
+    "fault": {
+      "version": "1.0.1",
+      "integrity": "sha1-3o01Df1IviS13BsChn4IcbkTUJI=",
+      "dev": true,
+      "requires": {
+        "format": "0.2.2"
+      }
+    },
     "fb-watchman": {
       "version": "2.0.0",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
@@ -4729,8 +4809,8 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.61.0",
-      "integrity": "sha1-V9HTO7yPsbk0GYRGSsAy4FTuEIQ=",
+      "version": "0.62.0",
+      "integrity": "sha1-5Y0wAigVcEActQ7lzzkqUiUCAB8=",
       "dev": true
     },
     "flush-write-stream": {
@@ -4828,6 +4908,11 @@
         "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
       }
+    },
+    "format": {
+      "version": "0.2.2",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
+      "dev": true
     },
     "formatio": {
       "version": "1.1.1",
@@ -5790,7 +5875,7 @@
         "ndarray": "1.0.18",
         "ndarray-pack": "1.2.1",
         "node-bitmap": "0.0.1",
-        "omggif": "1.0.8",
+        "omggif": "1.0.9",
         "parse-data-uri": "0.2.0",
         "pngjs": "2.3.1",
         "request": "2.83.0",
@@ -5993,8 +6078,8 @@
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "graphql": {
-      "version": "0.10.1",
-      "integrity": "sha1-dck8LOc661uuLu+1Vajp45w2An0=",
+      "version": "0.10.5",
+      "integrity": "sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==",
       "dev": true,
       "requires": {
         "iterall": "1.1.3"
@@ -6065,6 +6150,11 @@
             "string_decoder": "1.0.3",
             "util-deprecate": "1.0.2"
           }
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
@@ -6226,6 +6316,10 @@
       "requires": {
         "sparkles": "1.0.0"
       }
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -6699,6 +6793,20 @@
       "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
       "dev": true
     },
+    "is-alphabetical": {
+      "version": "1.0.1",
+      "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg=",
+      "dev": true
+    },
+    "is-alphanumerical": {
+      "version": "1.0.1",
+      "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
+      "dev": true,
+      "requires": {
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
@@ -6736,6 +6844,11 @@
     "is-date-object": {
       "version": "1.0.1",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-decimal": {
+      "version": "1.0.1",
+      "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI=",
+      "dev": true
     },
     "is-directory": {
       "version": "0.3.1",
@@ -6796,6 +6909,11 @@
         "is-extglob": "2.1.1"
       }
     },
+    "is-hexadecimal": {
+      "version": "1.0.1",
+      "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk=",
+      "dev": true
+    },
     "is-integer": {
       "version": "1.0.7",
       "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
@@ -6852,6 +6970,11 @@
       "requires": {
         "path-is-inside": "1.0.2"
       }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -6931,9 +7054,19 @@
         "is-integer": "1.0.7"
       }
     },
+    "is-whitespace-character": {
+      "version": "1.0.1",
+      "integrity": "sha1-muAXbzKCtlRXoZks2whPil+DPjs=",
+      "dev": true
+    },
     "is-windows": {
       "version": "1.0.1",
       "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk="
+    },
+    "is-word-character": {
+      "version": "1.0.1",
+      "integrity": "sha1-WgP6HqkazopusMfNdw64bWXIvvs=",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -7175,7 +7308,7 @@
       "integrity": "sha512-90H1wLqiNR3tLhQUgwhC6GWHfRCG+Da14m7vxD608Mt/QTKR0TA751D+QH09x5bvcrLfvxLtxArtA0VEC0ORow==",
       "dev": true,
       "requires": {
-        "jest-cli": "22.0.3"
+        "jest-cli": "22.0.4"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -7270,8 +7403,8 @@
           "dev": true
         },
         "jest-cli": {
-          "version": "22.0.3",
-          "integrity": "sha512-aX71DL4q9aLxbSmYI8uuPVlXVRyREU4VbApOdiuD79oqqqSGYu9E5S1SLXRm/PB5lJPh5xd8bVRrdsrMVs2hyw==",
+          "version": "22.0.4",
+          "integrity": "sha512-f1lZRM13IwIINzjE3RebXQKtQLiKncpSrbJZ/aTZJXmzEWGdgSayW4ESyhU+xK3uGiJEUSzbHjwPY6nGJ8VbUA==",
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
@@ -7284,17 +7417,17 @@
             "istanbul-lib-instrument": "1.9.1",
             "istanbul-lib-source-maps": "1.2.2",
             "jest-changed-files": "22.0.3",
-            "jest-config": "22.0.3",
-            "jest-environment-jsdom": "22.0.3",
+            "jest-config": "22.0.4",
+            "jest-environment-jsdom": "22.0.4",
             "jest-get-type": "22.0.3",
             "jest-haste-map": "22.0.3",
             "jest-message-util": "22.0.3",
             "jest-regex-util": "22.0.3",
             "jest-resolve-dependencies": "22.0.3",
-            "jest-runner": "22.0.3",
-            "jest-runtime": "22.0.3",
+            "jest-runner": "22.0.4",
+            "jest-runtime": "22.0.4",
             "jest-snapshot": "22.0.3",
-            "jest-util": "22.0.3",
+            "jest-util": "22.0.4",
             "jest-worker": "22.0.3",
             "micromatch": "2.3.11",
             "node-notifier": "5.1.2",
@@ -7392,19 +7525,19 @@
       }
     },
     "jest-config": {
-      "version": "22.0.3",
-      "integrity": "sha512-omqyzFPhRm+YaHku+jPuqpSFJ0QD61G/hqR+m09r2IajJbaRjV9XDezCIOD+rJiQlAyfFfo+DAc+u1mLy2IEaA==",
+      "version": "22.0.4",
+      "integrity": "sha512-NcBeixqHjHDZO9+pUj+365LQV2s65d2f0/IrwlUyv0xaJovRNc6eDvoJ/r2UUlHnqjP3Go+R0ECUsXPXjk4SHw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "glob": "7.1.2",
-        "jest-environment-jsdom": "22.0.3",
-        "jest-environment-node": "22.0.3",
+        "jest-environment-jsdom": "22.0.4",
+        "jest-environment-node": "22.0.4",
         "jest-get-type": "22.0.3",
-        "jest-jasmine2": "22.0.3",
+        "jest-jasmine2": "22.0.4",
         "jest-regex-util": "22.0.3",
-        "jest-resolve": "22.0.3",
-        "jest-util": "22.0.3",
+        "jest-resolve": "22.0.4",
+        "jest-util": "22.0.4",
         "jest-validate": "22.0.3",
         "pretty-format": "22.0.3"
       },
@@ -7518,22 +7651,22 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "22.0.3",
-      "integrity": "sha512-LrR9flT6I4IZKIA/dmoAiTmTzGi7W8sP5mCXbgsTjFop1Jh3rNluza/xnf6VfK/aOZvBglJIVYbKqGxtcm0KsQ==",
+      "version": "22.0.4",
+      "integrity": "sha512-vnjefLZlsNsmnjKcaXkx2IxTBNG40vfRVOdMfcfkPkq85JxFB7wzNtjLx+RIfiNpIZd04C1PXbF0aJIenY85Ng==",
       "dev": true,
       "requires": {
         "jest-mock": "22.0.3",
-        "jest-util": "22.0.3",
+        "jest-util": "22.0.4",
         "jsdom": "11.5.1"
       }
     },
     "jest-environment-node": {
-      "version": "22.0.3",
-      "integrity": "sha512-Kk7FYtCQZ+CFwwCL1t3DJ/Lxvjoda4qRt/NJh/6jsAEWM7VcSBAzmmayA5JcMRpQQ4FRiUcLrvrKEfO01/Fgsw==",
+      "version": "22.0.4",
+      "integrity": "sha512-9vjNKb86UivvKCZCudMNixQgdMnOG7ql6iVYnaiK0CmvZ0WQD+mlM10NvgiWpRv4HstcnRL1pY/GSIHXAD6qXw==",
       "dev": true,
       "requires": {
         "jest-mock": "22.0.3",
-        "jest-util": "22.0.3"
+        "jest-util": "22.0.4"
       }
     },
     "jest-file-exists": {
@@ -7560,8 +7693,8 @@
       }
     },
     "jest-jasmine2": {
-      "version": "22.0.3",
-      "integrity": "sha512-0Gz3pFZytCjbCKssBJWzx5NolNLg179gkT0Zfe+fWrJS9Ap9EH7eTB9UHoiT2O3lRNBfaYTzrXhOMgf4l/jCMg==",
+      "version": "22.0.4",
+      "integrity": "sha512-pn1XPHUkffHK6oNY1Dfl/+Rg0UuTdlg3aGDnjyK6dZzGEBeiH1uKuSgZEjy3Lj461l3atpzsQyw7ilXPyjFnUw==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
@@ -7773,7 +7906,7 @@
       "integrity": "sha512-AVBdCx7Oj5wBpMOH089lx7Zgwpdz9HbReA82HuVAlIT4kEQRvCy6Sl9yVWDGJwHTgB/OYQGkgmbv/P/K8TkWNw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.35",
+        "@babel/code-frame": "7.0.0-beta.36",
         "chalk": "2.3.0",
         "micromatch": "2.3.11",
         "slash": "1.0.0",
@@ -7829,8 +7962,8 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "22.0.3",
-      "integrity": "sha512-UHpim1kXTXH5hlftIpVOUkh0n+wd36/QNuYgpZnzwX8PsB8DizBuaPJbl5VvorHBpRouz21Ty0K0QM1pPny9cw==",
+      "version": "22.0.4",
+      "integrity": "sha512-yoxHsX4MTT2Ra/dFia9VCunzsA/4jMBENMmLjREIUkCIP1edk/PZUOGVVf680Gw04CtmT5stETylcbmbL7hJBw==",
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
@@ -7884,38 +8017,38 @@
       }
     },
     "jest-runner": {
-      "version": "22.0.3",
-      "integrity": "sha512-b/Eh+bPFLU09R0AULy4/IcUQ4Cgiao7YcmCehI7eailVj2xGQAfhmzSlhDpVIYmvoRZFyReOseihZXXRsdFafA==",
+      "version": "22.0.4",
+      "integrity": "sha512-srBkbqmiSB+jzSaG652fmi3kS6rV6wS/4fOG8dxxBg3dCqNQcM2/L3TI3ZK0SwIAcdGJh5Gybs8aDboT8K9Cdw==",
       "dev": true,
       "requires": {
-        "jest-config": "22.0.3",
+        "jest-config": "22.0.4",
         "jest-docblock": "22.0.3",
         "jest-haste-map": "22.0.3",
-        "jest-jasmine2": "22.0.3",
+        "jest-jasmine2": "22.0.4",
         "jest-leak-detector": "22.0.3",
         "jest-message-util": "22.0.3",
-        "jest-runtime": "22.0.3",
-        "jest-util": "22.0.3",
+        "jest-runtime": "22.0.4",
+        "jest-util": "22.0.4",
         "jest-worker": "22.0.3",
         "throat": "4.1.0"
       }
     },
     "jest-runtime": {
-      "version": "22.0.3",
-      "integrity": "sha512-SSOiAde16JhEtVtNaWV2OmimmyxP8lmUdHxYde5rwv7iibkRy/o4QtalmmmH48oUxwy/epZVDaEyBKBA/iDFBg==",
+      "version": "22.0.4",
+      "integrity": "sha512-+7uEwf/4f8k1E/eViyGK6/M5yA4O3f6TdWViuqF9MV7vXwG2OVJu8YEZa5239nEnHJiwinXp4eZXX+HB4pQRPg==",
       "dev": true,
       "requires": {
         "babel-core": "6.25.0",
-        "babel-jest": "22.0.3",
+        "babel-jest": "22.0.4",
         "babel-plugin-istanbul": "4.1.5",
         "chalk": "2.3.0",
         "convert-source-map": "1.5.1",
         "graceful-fs": "4.1.11",
-        "jest-config": "22.0.3",
+        "jest-config": "22.0.4",
         "jest-haste-map": "22.0.3",
         "jest-regex-util": "22.0.3",
-        "jest-resolve": "22.0.3",
-        "jest-util": "22.0.3",
+        "jest-resolve": "22.0.4",
+        "jest-util": "22.0.4",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
         "realpath-native": "1.0.0",
@@ -8128,8 +8261,8 @@
       }
     },
     "jest-util": {
-      "version": "22.0.3",
-      "integrity": "sha512-iDnKIw4P+9433L7II90UGYZ4rQOatbbcjZO/+1+Fga+rNUF1wEijDfTDjGQil98smAquvB02RBrDgfbquUHLmg==",
+      "version": "22.0.4",
+      "integrity": "sha512-gNNPtcCFkVh7daKIl3/06eoQ90QXGXCyDOfyZ3IEyTWmHBdX3GvklcOtyGcdOvrYEubaZTfMcMKmEeo/6sRTog==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
@@ -8302,7 +8435,7 @@
         "babylon": "6.18.0",
         "colors": "1.1.2",
         "es6-promise": "3.3.1",
-        "flow-parser": "0.61.0",
+        "flow-parser": "0.62.0",
         "lodash": "4.15.0",
         "micromatch": "2.3.11",
         "node-dir": "0.1.8",
@@ -8488,7 +8621,7 @@
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "browser-process-hrtime": "0.1.2",
@@ -8514,8 +8647,8 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "version": "5.3.0",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
           "dev": true
         },
         "acorn-globals": {
@@ -8523,7 +8656,7 @@
           "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
           "dev": true,
           "requires": {
-            "acorn": "5.2.1"
+            "acorn": "5.3.0"
           }
         }
       }
@@ -9232,17 +9365,22 @@
       "version": "1.0.1",
       "integrity": "sha1-douOecAJvytk/ugG4ip7HEGQyZA="
     },
+    "markdown-escapes": {
+      "version": "1.0.1",
+      "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg=",
+      "dev": true
+    },
     "markdown-loader": {
       "version": "2.0.1",
       "integrity": "sha1-7ti+rYKXi6zxe3ahHFWToBPi2XY=",
       "requires": {
         "loader-utils": "1.1.0",
-        "marked": "0.3.7"
+        "marked": "0.3.9"
       },
       "dependencies": {
         "marked": {
-          "version": "0.3.7",
-          "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ=="
+          "version": "0.3.9",
+          "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw=="
         }
       }
     },
@@ -10297,11 +10435,12 @@
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
     },
     "object.assign": {
-      "version": "4.0.4",
-      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+      "version": "4.1.0",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "requires": {
         "define-properties": "1.1.2",
         "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
         "object-keys": "1.0.11"
       }
     },
@@ -10345,8 +10484,8 @@
       }
     },
     "omggif": {
-      "version": "1.0.8",
-      "integrity": "sha1-F483sqsLPXtG7ToORr0HkLWNNTA=",
+      "version": "1.0.9",
+      "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8=",
       "dev": true
     },
     "on-finished": {
@@ -10557,6 +10696,19 @@
         "data-uri-to-buffer": "0.0.3"
       }
     },
+    "parse-entities": {
+      "version": "1.1.1",
+      "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
+      "dev": true,
+      "requires": {
+        "character-entities": "1.2.1",
+        "character-entities-legacy": "1.1.1",
+        "character-reference-invalid": "1.1.1",
+        "is-alphanumerical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-hexadecimal": "1.0.1"
+      }
+    },
     "parse-glob": {
       "version": "3.0.4",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
@@ -10683,6 +10835,19 @@
     "path-parse": {
       "version": "1.0.5",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dev": true,
+      "requires": {
+        "path-root-regex": "0.1.2"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -10949,8 +11114,8 @@
       }
     },
     "postcss-less": {
-      "version": "1.1.1",
-      "integrity": "sha512-zl0EEqq8Urh37Ppdv9zzhpZpLHrgkxmt6e3O4ftRa7/b8Uq2LV+/KBVM8/KuzmHNu+mthhOArg1lxbfqQ3NUdg==",
+      "version": "1.1.3",
+      "integrity": "sha512-WS0wsQxRm+kmN8wEYAGZ3t4lnoNfoyx9EJZrhiPR1K0lMHR0UNWnz52Ya5QRXChHtY75Ef+kDc05FpnBujebgw==",
       "dev": true,
       "requires": {
         "postcss": "5.2.18"
@@ -10978,8 +11143,8 @@
       "dev": true
     },
     "postcss-scss": {
-      "version": "1.0.0",
-      "integrity": "sha1-SVcBMJeXPf1b2bGtim3BNFal0bo=",
+      "version": "1.0.2",
+      "integrity": "sha1-/0XPM1S4ee6JpOtoaA9GrJuxT5Q=",
       "dev": true,
       "requires": {
         "postcss": "6.0.14"
@@ -11103,76 +11268,76 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "github:automattic/calypso-prettier#717e62ee3650aa6f8720c86474ce4dba78bd0c36",
+      "version": "github:automattic/calypso-prettier#503d7779e8e95f0ea0d6dc55056db41c16835cb1",
       "dev": true,
       "requires": {
-        "babel-code-frame": "7.0.0-alpha.12",
-        "babylon": "7.0.0-beta.23",
+        "babel-code-frame": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.34",
         "camelcase": "4.1.0",
         "chalk": "2.1.0",
+        "cjk-regex": "1.0.2",
         "cosmiconfig": "3.1.0",
         "dashify": "0.2.2",
         "diff": "3.2.0",
+        "editorconfig": "0.14.2",
+        "editorconfig-to-prettier": "0.0.6",
+        "emoji-regex": "6.5.1",
+        "escape-string-regexp": "1.0.5",
         "esutils": "2.0.2",
-        "flow-parser": "0.51.0",
+        "flow-parser": "0.59.0",
         "get-stream": "3.0.0",
         "globby": "6.1.0",
-        "graphql": "0.10.1",
-        "ignore": "3.3.5",
-        "jest-docblock": "21.3.0-beta.15",
+        "graphql": "0.10.5",
+        "ignore": "3.3.7",
+        "jest-docblock": "21.3.0-beta.11",
         "jest-validate": "21.1.0",
         "leven": "2.1.0",
         "mem": "1.1.0",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
-        "parse5": "3.0.2",
-        "postcss-less": "1.1.1",
+        "parse5": "3.0.3",
+        "path-root": "0.1.1",
+        "postcss-less": "1.1.3",
         "postcss-media-query-parser": "0.2.3",
-        "postcss-scss": "1.0.0",
+        "postcss-scss": "1.0.2",
         "postcss-selector-parser": "2.2.3",
         "postcss-values-parser": "1.3.1",
-        "strip-bom": "3.0.0",
-        "typescript": "2.5.3",
-        "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#9c71a627da36e97da52ed2731d58509c952b67ae"
+        "remark-frontmatter": "1.1.0",
+        "remark-parse": "4.0.0",
+        "semver": "5.4.1",
+        "string-width": "2.1.1",
+        "typescript": "2.6.2",
+        "typescript-eslint-parser": "9.0.1",
+        "unicode-regex": "1.0.1",
+        "unified": "6.1.6"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "6.0.95",
-          "integrity": "sha512-d1Twx1NM49dQ7jbNZfaHTQWuYL9cFVrGxYpbc3BvMf4626lOJOZnp2aJQNB9vP/WX3UOe1TrTUMABrGRu6FZhg==",
-          "dev": true
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "babel-code-frame": {
-          "version": "7.0.0-alpha.12",
-          "integrity": "sha512-5BmA2es52XNA9PN96HRfJg0co5CkmrKxWdvyW507LNqJmicnHM4we4HI16bIzgAuVeL7RKc4GJmTsyhkFco4Tw==",
+        "ansi-styles": {
+          "version": "3.2.0",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
+            "color-convert": "1.9.1"
+          }
+        },
+        "babel-code-frame": {
+          "version": "7.0.0-beta.3",
+          "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.1.0",
             "esutils": "2.0.2",
             "js-tokens": "3.0.2"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.3",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            }
           }
         },
         "babylon": {
-          "version": "7.0.0-beta.23",
-          "integrity": "sha512-Ik+5GkQUsL/IIzMP3lV9uyAQif+hoCy7y+8xz+j5RidL3FCexOvQojK8smt6NzTSJ1K9HgHKutXWdgMSUZtDsQ==",
+          "version": "7.0.0-beta.34",
+          "integrity": "sha512-ribEzWEhWKKjY+1FdKCryo+HiN/1idPjUB8vyR5Yf221MtGzCd5+7OwPvWvYHerHHC2eJLr6MhvumbTocXGY7Q==",
           "dev": true
         },
         "camelcase": {
@@ -11188,29 +11353,6 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-              "dev": true,
-              "requires": {
-                "color-convert": "1.9.1"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "4.5.0",
-              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-              "dev": true,
-              "requires": {
-                "has-flag": "2.0.0"
-              }
-            }
           }
         },
         "diff": {
@@ -11218,9 +11360,14 @@
           "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
           "dev": true
         },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
         "flow-parser": {
-          "version": "0.51.0",
-          "integrity": "sha1-4cDOtvgCuiHRbC/ajkLIJPQPRoQ=",
+          "version": "0.59.0",
+          "integrity": "sha1-9uvK5h/6GH5CCZnUDOCoAfObJjU=",
           "dev": true
         },
         "has-flag": {
@@ -11228,9 +11375,19 @@
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
+        "ignore": {
+          "version": "3.3.7",
+          "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
         "jest-docblock": {
-          "version": "21.3.0-beta.15",
-          "integrity": "sha512-RlXssbcqMUrkTI5tNiupIyEhLkGfFSj8+8bvx/IG9ISQSmkaK0EPsEpCjUIvwIeBCHDPoiY73qIa/2csUcZo/Q==",
+          "version": "21.3.0-beta.11",
+          "integrity": "sha512-sxSwZUm7JyCO8dverup5g/OKJhjYRrBdgEdezIO1qAmMGWuza7ewovpfDmxp+JLvlm0i2WRFKUQNNIMGmPGTVg==",
           "dev": true,
           "requires": {
             "detect-newline": "2.1.0"
@@ -11262,14 +11419,6 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
-        "parse5": {
-          "version": "3.0.2",
-          "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
-          "dev": true,
-          "requires": {
-            "@types/node": "6.0.95"
-          }
-        },
         "pretty-format": {
           "version": "21.2.1",
           "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
@@ -11277,27 +11426,37 @@
           "requires": {
             "ansi-regex": "3.0.0",
             "ansi-styles": "3.2.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "3.2.0",
-              "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-              "dev": true,
-              "requires": {
-                "color-convert": "1.9.1"
-              }
-            }
           }
         },
-        "strip-bom": {
-          "version": "3.0.0",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+        "semver": {
+          "version": "5.4.1",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         },
+        "string-width": {
+          "version": "2.1.1",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
         "supports-color": {
-          "version": "2.0.0",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "version": "4.5.0",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
@@ -12888,6 +13047,37 @@
       "version": "0.2.7",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
+    "remark-frontmatter": {
+      "version": "1.1.0",
+      "integrity": "sha512-mLbYtwP9w1L9TA8dX+I/HyDF5lCpa0dmYvvW9Io+zUPpqEZ49QMKWb0hSpunpLVA+Squy0SowzSzjHVPbxWq1g==",
+      "dev": true,
+      "requires": {
+        "fault": "1.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "remark-parse": {
+      "version": "4.0.0",
+      "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
+      "dev": true,
+      "requires": {
+        "collapse-white-space": "1.0.3",
+        "is-alphabetical": "1.0.1",
+        "is-decimal": "1.0.1",
+        "is-whitespace-character": "1.0.1",
+        "is-word-character": "1.0.1",
+        "markdown-escapes": "1.0.1",
+        "parse-entities": "1.1.1",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "1.1.0",
+        "unherit": "1.1.0",
+        "unist-util-remove-position": "1.1.1",
+        "vfile-location": "2.0.2",
+        "xtend": "4.0.1"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
@@ -12908,8 +13098,8 @@
       }
     },
     "replace-ext": {
-      "version": "0.0.1",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+      "version": "1.0.0",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
       "dev": true
     },
     "request": {
@@ -13741,6 +13931,11 @@
     "stack-utils": {
       "version": "1.0.1",
       "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+      "dev": true
+    },
+    "state-toggle": {
+      "version": "1.0.0",
+      "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU=",
       "dev": true
     },
     "statuses": {
@@ -14618,6 +14813,11 @@
       "integrity": "sha1-hXHIb6JNHbdU5bDLOn4J9B50qN8=",
       "dev": true
     },
+    "trim": {
+      "version": "0.0.1",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
@@ -14625,6 +14825,16 @@
     "trim-right": {
       "version": "1.0.1",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.0",
+      "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ=",
+      "dev": true
+    },
+    "trough": {
+      "version": "1.0.1",
+      "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y=",
+      "dev": true
     },
     "try-resolve": {
       "version": "1.0.1",
@@ -14686,12 +14896,13 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.5.3",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+      "version": "2.6.2",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
       "dev": true
     },
     "typescript-eslint-parser": {
-      "version": "git://github.com/eslint/typescript-eslint-parser.git#9c71a627da36e97da52ed2731d58509c952b67ae",
+      "version": "9.0.1",
+      "integrity": "sha512-w1jqotvnhLtLukD9H3gQPAlbD0kLf7ZkoQGwiwSIshKIlzRL7i0OY9Y7VIdE1xtytZXThg678eomxMZ1rZXGVQ==",
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.1",
@@ -14741,7 +14952,7 @@
         "find-cache-dir": "1.0.0",
         "schema-utils": "0.3.0",
         "source-map": "0.5.7",
-        "uglify-es": "3.2.2",
+        "uglify-es": "3.3.2",
         "webpack-sources": "1.1.0",
         "worker-farm": "1.5.2"
       },
@@ -14759,8 +14970,8 @@
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "uglify-es": {
-          "version": "3.2.2",
-          "integrity": "sha512-l+s5VLzFwGJfS+fbqaGf/Dfwo1MF13jLOF2ekL0PytzqEqQ6cVppvHf4jquqFok+35USMpKjqkYxy6pQyUcuug==",
+          "version": "3.3.2",
+          "integrity": "sha512-g7rGvx7YiFROLXKUtFMTw+YpTVV/XXPNvDUQfzwDTcB3vINwLUr3qXnkcPCu8VCIVjxI2EqaZ+sHoAxcYE/98w==",
           "requires": {
             "commander": "2.12.2",
             "source-map": "0.6.1"
@@ -14815,6 +15026,34 @@
         "underscore.string": "3.0.3"
       }
     },
+    "unherit": {
+      "version": "1.1.0",
+      "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "unicode-regex": {
+      "version": "1.0.1",
+      "integrity": "sha1-+BngUBkdW5VhozmljdO5CV7ZSzU=",
+      "dev": true
+    },
+    "unified": {
+      "version": "6.1.6",
+      "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
+      "dev": true,
+      "requires": {
+        "bail": "1.0.2",
+        "extend": "3.0.1",
+        "is-plain-obj": "1.1.0",
+        "trough": "1.0.1",
+        "vfile": "2.3.0",
+        "x-is-function": "1.0.4",
+        "x-is-string": "0.1.0"
+      }
+    },
     "uniq": {
       "version": "1.0.1",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
@@ -14832,6 +15071,32 @@
       "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
       "requires": {
         "imurmurhash": "0.1.4"
+      }
+    },
+    "unist-util-is": {
+      "version": "2.1.1",
+      "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs=",
+      "dev": true
+    },
+    "unist-util-remove-position": {
+      "version": "1.1.1",
+      "integrity": "sha1-WoXBVV/BugwQG4ZwfRXlD6TIcbs=",
+      "dev": true,
+      "requires": {
+        "unist-util-visit": "1.3.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "1.1.1",
+      "integrity": "sha1-PMvcU2ee7W7PN3fdf14yKcG2qjw=",
+      "dev": true
+    },
+    "unist-util-visit": {
+      "version": "1.3.0",
+      "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "2.1.1"
       }
     },
     "unpipe": {
@@ -14997,6 +15262,30 @@
         "extsprintf": "1.3.0"
       }
     },
+    "vfile": {
+      "version": "2.3.0",
+      "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.6",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "1.1.1",
+        "vfile-message": "1.0.0"
+      }
+    },
+    "vfile-location": {
+      "version": "2.0.2",
+      "integrity": "sha1-02dcWch3SY5JK0dW/2Xkrxp1IlU=",
+      "dev": true
+    },
+    "vfile-message": {
+      "version": "1.0.0",
+      "integrity": "sha512-HPREhzTOB/sNDc9/Mxf8w0FmHnThg5CRSJdR9VRFkD2riqYWs+fuXlj5z8mIpv2LrD7uU41+oPWFOL4Mjlf+dw==",
+      "dev": true,
+      "requires": {
+        "unist-util-stringify-position": "1.1.1"
+      }
+    },
     "vinyl": {
       "version": "0.5.3",
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
@@ -15005,6 +15294,13 @@
         "clone": "1.0.3",
         "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
+      },
+      "dependencies": {
+        "replace-ext": {
+          "version": "0.0.1",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+          "dev": true
+        }
       }
     },
     "vm-browserify": {
@@ -15162,7 +15458,7 @@
       "version": "3.8.1",
       "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "acorn-dynamic-import": "2.0.2",
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
@@ -15187,8 +15483,8 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+          "version": "5.3.0",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -15405,7 +15701,7 @@
       "integrity": "sha1-i2JAwpqdY7xy8J2SD7BQrbzOn+g=",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "chalk": "1.1.3",
         "commander": "2.12.2",
         "ejs": "2.5.7",
@@ -15428,8 +15724,8 @@
           }
         },
         "acorn": {
-          "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "version": "5.3.0",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
           "dev": true
         },
         "body-parser": {
@@ -15998,6 +16294,16 @@
         "options": "0.0.6",
         "ultron": "1.0.2"
       }
+    },
+    "x-is-function": {
+      "version": "1.0.4",
+      "integrity": "sha1-XSlNw9Joy90GJYDgxd93o5HR+h4=",
+      "dev": true
+    },
+    "x-is-string": {
+      "version": "0.1.0",
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+      "dev": true
     },
     "xdg-basedir": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
     "mixedindentlint": "1.2.0",
     "nock": "8.0.0",
     "nodemon": "1.4.1",
-    "prettier": "github:automattic/calypso-prettier#717e62ee",
+    "prettier": "github:automattic/calypso-prettier#503d7779",
     "pretty-bytes": "4.0.2",
     "react-codemod": "reactjs/react-codemod",
     "react-test-renderer": "16.2.0",

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -43,13 +43,13 @@ function bumpStat( group, name ) {
 }
 
 /**
-* Render and cache supplied React element to a markup string.
-* Cache is keyed by stringified element by default.
-*
-* @param {object} element - React element to be rendered to html
-* @param {string} key - (optional) custom key
-* @return {string} The rendered Layout
-*/
+ * Render and cache supplied React element to a markup string.
+ * Cache is keyed by stringified element by default.
+ *
+ * @param {object} element - React element to be rendered to html
+ * @param {string} key - (optional) custom key
+ * @return {string} The rendered Layout
+ */
 export function render( element, key = JSON.stringify( element ) ) {
 	try {
 		const startTime = Date.now();

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -8,8 +8,8 @@ var config = require( 'config' ),
 	userUtils = require( './shared-utils' ),
 	AUTH_COOKIE_NAME = 'wordpress_logged_in',
 	/**
-	* WordPress.com REST API /me endpoint.
-	*/
+	 * WordPress.com REST API /me endpoint.
+	 */
 	url = 'https://public-api.wordpress.com/rest/v1/me?meta=flags';
 
 module.exports = function( authCookieValue, callback ) {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -25,7 +25,7 @@ const config = require( 'config' );
  * All modules listed here need to be ES5.
  *
  * @returns { object } list of externals
-*/
+ */
 function getExternals() {
 	const externals = {};
 


### PR DESCRIPTION
This PR upgrades Prettier fork from version 1.7.4 to 1.9.2.

The first commit runs `npm run reformat-files` with the old Prettier version. There were some files that were not properly formatted after modified. This commit reformats them so that the formatting changes introduced by the upgrade are clearly visible.

The second commit changes the Prettier version in `package.json` and `npm-shrinkwrap.json`.

The third commit reformats the codebase with the new version. Notable changes:
- JSdoc comments are now formatted. This means a lot of whitespace changes: proper indentation, replacing indentation with spaces with tabs, removing trailing whitespace in comments
- template literals can break inside JS expressions if they are not simple identifiers:
```js
const msg = `hello ${ person }, welcome to ${
  location.name
}!`;
```
My personal opinion is that this formatting isn't especially beautiful, but I expect some further development in future Prettier versions -- formatting template literals seems to be an area of active interest.

Another news is support for JSX fragments, a recent addition to React 16. To use these in Calypso, we'll need to upgrade several other components (React, Babel, maybe others), but Prettier is at least not an obstacle at this moment.

Here's a full changelong of the upstream version 1.9.2: https://github.com/prettier/prettier/blob/master/CHANGELOG.md#192