### PR TITLE
Credentials: update help links in setup form footer

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/index.jsx
@@ -66,15 +66,16 @@ class CredentialsSetupFlow extends Component {
 						goToNextStep={ this.goToNextStep }
 					/>
 				) }
-				{ 'form' === this.state.currentStep && (
+				{ 'form' === this.state.currentStep && [
 					<SetupForm
+						key="credentials-flow-setup-form"
 						formIsSubmitting={ formIsSubmitting }
 						reset={ this.reset }
 						siteId={ siteId }
 						updateCredentials={ updateCredentials }
-					/>
-				) }
-				<SetupFooter />
+					/>,
+					<SetupFooter key="credentials-flow-setup-form-footer" />,
+				] }
 			</div>
 		);
 	}

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
@@ -13,20 +13,56 @@ import Gridicon from 'gridicons';
 import HappychatButton from 'components/happychat/button';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
+import Button from 'components/button';
+import Popover from 'components/popover';
 
 class SetupFooter extends Component {
-	componentWillMount() {
-		this.setState( { showPopover: false } );
-	}
+	state = {
+		isPopoverVisible: false,
+		popoverContext: null,
+	};
+
+	setPopoverContext = popoverContext => {
+		if ( popoverContext ) {
+			this.setState( { popoverContext } );
+		}
+	};
+	togglePopover = () => this.setState( { isPopoverVisible: ! this.state.isPopoverVisible } );
+	hidePopover = () => this.setState( { isPopoverVisible: false } );
 
 	render() {
 		const { happychatAvailable, translate } = this.props;
+		const { isPopoverVisible, popoverContext } = this.state;
 
 		return (
 			<CompactCard className="credentials-setup-flow__footer">
-				{ happychatAvailable
-					? <HappychatButton
-						className="credentials-setup-flow__happychat-button"
+				<Button
+					ref={ this.setPopoverContext }
+					onClick={ this.togglePopover }
+					borderless
+				>
+					<Gridicon icon="help" />
+					<span className="credentials-setup-flow__help-button-text">
+						{
+							translate( "Need help finding your site's server credentials?" )
+						}
+					</span>
+				</Button>
+				<Popover
+					context={ popoverContext }
+					isVisible={ isPopoverVisible }
+					onClose={ this.hidePopover }
+					className="credentials-setup-flow__popover"
+					position="top"
+				>
+					{
+						translate( 'You can normally get your credentials from your hosting provider. ' +
+							'Their website should explain how to get or create the credentials you need.' )
+					}
+				</Popover>
+
+				{ happychatAvailable && (
+					<HappychatButton
 						onClick={ this.props.happychatEvent }
 					>
 						<Gridicon icon="chat" />
@@ -34,14 +70,7 @@ class SetupFooter extends Component {
 							{ translate( 'Get help' ) }
 						</span>
 					</HappychatButton>
-					: <a href="/help/contact" className="credentials-setup-flow__help-button">
-						<Gridicon icon="help" />
-						<span className="credentials-setup-flow__help-button-text">
-							{ translate( 'Get help' ) }
-						</span>
-					</a>
-				}
-
+				) }
 			</CompactCard>
 		);
 	}

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
@@ -46,33 +46,23 @@
 	margin-right: 15px;
 }
 
-.credentials-setup-flow__footer-popover-link {
-	cursor: pointer;
-}
-
-.credentials-setup-flow__footer-popover-icon {
-	position: relative;
-	top: 3px;
-	left: -6px;
-}
-
-.credentials-setup-flow__happychat-button.is-borderless {
-	padding: 0;
-	margin-left: 2rem;
-	margin-top: -4px;
+.credentials-setup-flow__footer .button.is-borderless {
+	margin-right: 24px;
 	color: $blue-wordpress;
+	padding: 0 0 5px;
+
+	&:hover {
+		color: $link-highlight;
+	}
+
+	span {
+		margin-left: 6px;
+	}
 }
 
-.credentials-setup-flow__happychat-button.is-borderless:hover {
-	color: $link-highlight;
-}
-
-.credentials-setup-flow__happychat-button-text {
-	margin-left: 6px;
-}
-
-.credentials-setup-flow__help-button-text {
-	position: relative;
-	top: -6px;
-	left: 6px;
+.credentials-setup-flow__popover .popover__inner {
+	color: darken( $gray, 20% );
+	font-size: 13px;
+	max-width: 220px;
+	padding: 16px;
 }


### PR DESCRIPTION
Fixes #20116

This PR removes the **Get help** link that was always visible in the footer of the credentials card. Now help links are only shown when user is entering their credentials:
- a new link opens a popover with additional information
- when chat support is available, a button to start a chat shows up