### PR TITLE
esmodules: Update wporg plugins selectors

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
@@ -25,7 +23,7 @@ import URLSearch from 'lib/mixins/url-search';
 import EmptyContent from 'components/empty-content';
 import PluginsStore from 'lib/plugins/store';
 import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
-import WporgPluginsSelectors from 'state/plugins/wporg/selectors';
+import { getPlugin } from 'state/plugins/wporg/selectors';
 import PluginsList from './plugins-list';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
@@ -87,7 +85,7 @@ const PluginsMain = createReactClass( {
 	// plugins for Jetpack sites require additional data from the wporg-data store
 	addWporgDataToPlugins( plugins ) {
 		return plugins.map( plugin => {
-			const pluginData = WporgPluginsSelectors.getPlugin( this.props.wporgPlugins, plugin.slug );
+			const pluginData = getPlugin( this.props.wporgPlugins, plugin.slug );
 			if ( ! pluginData ) {
 				this.props.wporgFetchPluginData( plugin.slug );
 			}

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -18,7 +18,7 @@ import HeaderCake from 'components/header-cake';
 import PluginMeta from 'my-sites/plugins/plugin-meta';
 import PluginsStore from 'lib/plugins/store';
 import PluginsLog from 'lib/plugins/log-store';
-import WporgPluginsSelectors from 'state/plugins/wporg/selectors';
+import { getPlugin, isFetched, isFetching } from 'state/plugins/wporg/selectors';
 import PluginsActions from 'lib/plugins/actions';
 import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
 import PluginNotices from 'lib/plugins/notices';
@@ -175,7 +175,7 @@ const SinglePlugin = createReactClass( {
 	},
 
 	isFetched() {
-		return WporgPluginsSelectors.isFetched( this.props.wporgPlugins, this.props.pluginSlug );
+		return isFetched( this.props.wporgPlugins, this.props.pluginSlug );
 	},
 
 	isFetchingSites() {
@@ -185,10 +185,7 @@ const SinglePlugin = createReactClass( {
 	getPlugin() {
 		let plugin = Object.assign( {}, this.state.plugin );
 		// assign it .org details
-		plugin = Object.assign(
-			plugin,
-			WporgPluginsSelectors.getPlugin( this.props.wporgPlugins, this.props.pluginSlug )
-		);
+		plugin = Object.assign( plugin, getPlugin( this.props.wporgPlugins, this.props.pluginSlug ) );
 
 		return plugin;
 	},
@@ -342,11 +339,7 @@ const SinglePlugin = createReactClass( {
 			return this.getPluginDoesNotExistView( selectedSite );
 		}
 
-		if (
-			selectedSite &&
-			this.props.isJetpackSite( selectedSite.ID ) &&
-			! this.props.canJetpackSiteManage( selectedSite.ID )
-		) {
+		if ( selectedSite && this.props.isJetpackSite && ! this.props.canJetpackSiteManage ) {
 			return (
 				<MainComponent>
 					{ this.renderDocumentHead() }
@@ -366,7 +359,7 @@ const SinglePlugin = createReactClass( {
 			selectedSite &&
 			PluginsLog.isInProgressAction( selectedSite.ID, this.state.plugin.slug, 'INSTALL_PLUGIN' );
 
-		const isWpcom = selectedSite && ! this.props.isJetpackSite( selectedSite.ID );
+		const isWpcom = selectedSite && ! this.props.isJetpackSite;
 
 		return (
 			<MainComponent>
@@ -407,13 +400,10 @@ export default connect(
 
 		return {
 			wporgPlugins: state.plugins.wporg.items,
-			wporgFetching: WporgPluginsSelectors.isFetching(
-				state.plugins.wporg.fetchingItems,
-				props.pluginSlug
-			),
+			wporgFetching: isFetching( state.plugins.wporg.fetchingItems, props.pluginSlug ),
 			selectedSite: getSelectedSite( state ),
-			isJetpackSite: siteId => isJetpackSite( state, siteId ),
-			canJetpackSiteManage: siteId => canJetpackSiteManage( state, siteId ),
+			isJetpackSite: selectedSiteId && isJetpackSite( state, selectedSiteId ),
+			canJetpackSiteManage: selectedSiteId && canJetpackSiteManage( state, selectedSiteId ),
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, selectedSiteId ),
 			isRequestingSites: isRequestingSites( state ),
 			userCanManagePlugins: selectedSiteId

--- a/client/state/plugins/wporg/selectors.js
+++ b/client/state/plugins/wporg/selectors.js
@@ -1,12 +1,13 @@
 /** @format */
-const getPlugin = function( state, pluginSlug ) {
+
+export const getPlugin = function( state, pluginSlug ) {
 	if ( ! state || ! state[ pluginSlug ] ) {
 		return null;
 	}
 	return Object.assign( {}, state[ pluginSlug ] );
 };
 
-const isFetching = function( state, pluginSlug ) {
+export const isFetching = function( state, pluginSlug ) {
 	// if the `isFetching` attribute doesn't exist yet,
 	// we assume we are still launching the fetch action, so it's true
 	if ( typeof state[ pluginSlug ] === 'undefined' ) {
@@ -15,7 +16,7 @@ const isFetching = function( state, pluginSlug ) {
 	return state[ pluginSlug ];
 };
 
-const isFetched = function( state, pluginSlug ) {
+export const isFetched = function( state, pluginSlug ) {
 	const plugin = getPlugin( state, pluginSlug );
 	// if the plugin or the `isFetching` attribute doesn't exist yet,
 	// we assume we are still launching the fetch action, so it's true
@@ -24,5 +25,3 @@ const isFetched = function( state, pluginSlug ) {
 	}
 	return !! plugin.fetched;
 };
-
-export default { getPlugin, isFetching, isFetched };

--- a/client/state/plugins/wporg/test/selectors.js
+++ b/client/state/plugins/wporg/test/selectors.js
@@ -9,7 +9,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import selectors from '../selectors';
+import { getPlugin, isFetching, isFetched } from '../selectors';
 
 const items = deepFreeze( {
 	test: { slug: 'test' },
@@ -26,58 +26,58 @@ const fetchingItems = deepFreeze( {
 
 describe( 'WPorg Selectors', () => {
 	test( 'Should contain getPlugin method', () => {
-		assert.equal( typeof selectors.getPlugin, 'function' );
+		assert.equal( typeof getPlugin, 'function' );
 	} );
 
 	test( 'Should contain isFetching method', () => {
-		assert.equal( typeof selectors.isFetching, 'function' );
+		assert.equal( typeof isFetching, 'function' );
 	} );
 
 	describe( 'getPlugin', () => {
 		test( 'Should get null if the requested plugin is not in the current state', () => {
-			assert.equal( selectors.getPlugin( items, 'no-test' ), null );
+			assert.equal( getPlugin( items, 'no-test' ), null );
 		} );
 
 		test( 'Should get the plugin if the requested plugin is in the current state', () => {
-			assert.equal( selectors.getPlugin( items, 'test' ).slug, 'test' );
+			assert.equal( getPlugin( items, 'test' ).slug, 'test' );
 		} );
 
 		test( 'Should return a new object with no pointers to the one stored in state', () => {
-			let plugin = selectors.getPlugin( items, 'fetchedTest' );
+			const plugin = getPlugin( items, 'fetchedTest' );
 			plugin.fetched = false;
-			assert.equal( selectors.getPlugin( items, 'fetchedTest' ).fetched, true );
+			assert.equal( getPlugin( items, 'fetchedTest' ).fetched, true );
 		} );
 	} );
 
 	describe( 'isFetching', () => {
 		test( 'Should get `true` if the requested plugin is not in the current state', () => {
-			assert.equal( selectors.isFetching( fetchingItems, 'no.test' ), true );
+			assert.equal( isFetching( fetchingItems, 'no.test' ), true );
 		} );
 
 		test( 'Should get `false` if the requested plugin is not being fetched', () => {
-			assert.equal( selectors.isFetching( fetchingItems, 'test' ), false );
+			assert.equal( isFetching( fetchingItems, 'test' ), false );
 		} );
 
 		test( 'Should get `true` if the requested plugin is being fetched', () => {
-			assert.equal( selectors.isFetching( fetchingItems, 'fetchingTest' ), true );
+			assert.equal( isFetching( fetchingItems, 'fetchingTest' ), true );
 		} );
 	} );
 
 	describe( 'isFetched', () => {
 		test( 'Should get `false` if the requested plugin is not in the current state', () => {
-			assert.equal( selectors.isFetched( items, 'no.test' ), false );
+			assert.equal( isFetched( items, 'no.test' ), false );
 		} );
 
 		test( 'Should get `false` if the requested plugin has not being fetched', () => {
-			assert.equal( selectors.isFetched( items, 'test' ), false );
+			assert.equal( isFetched( items, 'test' ), false );
 		} );
 
 		test( 'Should get `true` if the requested plugin has being fetched', () => {
-			assert.equal( selectors.isFetched( items, 'fetchedTest' ), true );
+			assert.equal( isFetched( items, 'fetchedTest' ), true );
 		} );
 
 		test( "Should get `true` if the requested plugin has being fetched even if it's being fetche again", () => {
-			assert.equal( selectors.isFetched( items, 'fetchedTest2' ), true );
+			assert.equal( isFetched( items, 'fetchedTest2' ), true );
 		} );
 	} );
 } );


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.

**Testing**

We need to smoke-test the files which depend on these selectors.
They are testing against selected sites vs. unselected sites, so it's
important to test in both cases.