### PR TITLE
Signup: Detect language based on browser settings

### DIFF
--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -10,7 +10,7 @@ import { getLocaleSlug } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { addLocaleToPath } from 'lib/i18n-utils';
+import { addLocaleToPath, getLanguage } from 'lib/i18n-utils';
 import LocaleSuggestionsListItem from './list-item';
 import LocaleSuggestionStore from 'lib/locale-suggestions';
 import Notice from 'components/notice';
@@ -28,9 +28,19 @@ class LocaleSuggestions extends Component {
 	};
 
 	componentWillMount() {
-		if ( this.props.locale ) {
-			switchLocale( this.props.locale );
+		let { locale } = this.props;
+
+		if ( ! locale && typeof navigator === 'object' && 'languages' in navigator ) {
+			for ( const langSlug of navigator.languages ) {
+				const language = getLanguage( langSlug.toLowerCase() );
+				if ( language ) {
+					locale = language.langSlug;
+					break;
+				}
+			}
 		}
+
+		switchLocale( locale );
 	}
 
 	componentDidMount() {

--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -5,6 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { getLocaleSlug } from 'i18n-calypso';
 
 /**
@@ -14,12 +15,13 @@ import { addLocaleToPath, getLanguage } from 'lib/i18n-utils';
 import LocaleSuggestionsListItem from './list-item';
 import LocaleSuggestionStore from 'lib/locale-suggestions';
 import Notice from 'components/notice';
-import switchLocale from 'lib/i18n-utils/switch-locale';
+import { setLocale } from 'state/ui/language/actions';
 
 class LocaleSuggestions extends Component {
 	static propTypes = {
 		locale: PropTypes.string,
 		path: PropTypes.string.isRequired,
+		setLocale: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -40,7 +42,7 @@ class LocaleSuggestions extends Component {
 			}
 		}
 
-		switchLocale( locale );
+		this.props.setLocale( locale );
 	}
 
 	componentDidMount() {
@@ -55,7 +57,7 @@ class LocaleSuggestions extends Component {
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.locale !== nextProps.locale ) {
-			switchLocale( nextProps.locale );
+			this.props.setLocale( nextProps.locale );
 		}
 	}
 
@@ -105,4 +107,6 @@ class LocaleSuggestions extends Component {
 	}
 }
 
-export default LocaleSuggestions;
+export default connect( null, {
+	setLocale,
+} )( LocaleSuggestions );

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -61,7 +61,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
   <div
     className="jetpack-connect__authorize-form"
   >
-    <LocaleSuggestions
+    <Connect(LocaleSuggestions)
       locale="es"
       path="/jetpack/connect/authorize/es"
     />


### PR DESCRIPTION
This PR address #14508

## What this PR does

When arriving at https://wordpress.com/start without a locale in any of the context parameters, the language defaults to English.

As a fallback we check the values in the `navigator.languages` array, using the first WordPress-compatible langSlug. If we don't find any, the page defaults to English as per the current behavior.

<img width="804" alt="ja" src="https://user-images.githubusercontent.com/6458278/34429315-c89084b0-ecaa-11e7-9494-83d2db22f312.png">

## What this PR doesn't do
It does not suggest languages based on the items of `navigator.languages`. 

Sometimes the suggestions return a language even though its variant is activated. We've reported this in Issue #21250
  