### PR TITLE
Error Logging: Add commit sha to docker build

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,8 @@ module.exports = {
 	},
 	globals: {
 		asyncRequire: true,
-		PROJECT_NAME: true
+		PROJECT_NAME: true,
+		COMMIT_SHA: true,
 	},
 	plugins: [
 		'jest'

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,9 @@ RUN        touch node_modules
 #
 # This contains built environments of Calypso. It will
 # change any time any of the Calypso source-code changes.
+ARG        commit_sha=(unknown)
 RUN        true \
-           && CALYPSO_ENV=production npm run build \
+           && CALYPSO_ENV=production COMMIT_SHA=$commit_sha npm run build \
            && chown -R nobody /calypso \
            && true
 

--- a/bin/build-docker.js
+++ b/bin/build-docker.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+/**
+ * Script to run docker build.
+ *
+ * This script is needed to enable us to embed the git SHA as a build arg
+ * in both unix shells and windows.
+ *
+ * Essentially, it doees this:
+ * docker build --build-arg commit_sha=`git rev-parse HEAD` -t wp-calypso .
+ */
+
+const { promisify } = require( 'util' );
+const { spawn, exec } = require( 'child_process' );
+
+function readSha() {
+	return promisify( exec )( 'git rev-parse HEAD' ).then( ( { stdout } ) => {
+		return stdout.trim();
+	} );
+}
+
+readSha().then( ( sha ) => {
+	const args = [
+		'build',
+		'--build-arg', 'commit_sha=' + sha,
+		'-t', 'wp-calypso',
+		'.'
+	];
+
+	console.log( 'docker ' + args.join( ' ' ) );
+	spawn( 'docker', args, { stdio: 'inherit' } );
+} );
+

--- a/bin/build-docker.js
+++ b/bin/build-docker.js
@@ -10,24 +10,17 @@
  * docker build --build-arg commit_sha=`git rev-parse HEAD` -t wp-calypso .
  */
 
-const { promisify } = require( 'util' );
-const { spawn, exec } = require( 'child_process' );
+const { spawnSync, execSync } = require( 'child_process' );
 
-function readSha() {
-	return promisify( exec )( 'git rev-parse HEAD' ).then( ( { stdout } ) => {
-		return stdout.trim();
-	} );
-}
+const sha = String( execSync( 'git rev-parse HEAD' ) ).trim();
 
-readSha().then( ( sha ) => {
-	const args = [
-		'build',
-		'--build-arg', 'commit_sha=' + sha,
-		'-t', 'wp-calypso',
-		'.'
-	];
+const args = [
+	'build',
+	'--build-arg', 'commit_sha=' + sha,
+	'-t', 'wp-calypso',
+	'.'
+];
 
-	console.log( 'docker ' + args.join( ' ' ) );
-	spawn( 'docker', args, { stdio: 'inherit' } );
-} );
+console.log( 'docker ' + args.join( ' ' ) );
+spawnSync( 'docker', args, { stdio: 'inherit' } );
 

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -29,6 +29,7 @@ const log = debug( 'calypso:error-logger' );
 export default class ErrorLogger {
 	constructor() {
 		this.diagnosticData = {
+			commit: COMMIT_SHA,
 			extra: {
 				previous_paths: [],
 				throttled: 0,

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "build-devdocs:components-usage-stats:_env": "node server/devdocs/bin/generate-components-usage-stats.js \"client/**/*.js\" \"client/**/*.jsx\" \"!**/docs/**\" \"!**/test/**\" \"!**/docs-example/**\"",
     "build-devdocs:index": "npm run -s env -- npm run -s build-devdocs:index:_env",
     "build-devdocs:index:_env": "node server/devdocs/bin/generate-devdocs-index \"**/*.md\" \".github/**.md\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
-    "build-docker": "docker build --build-arg commit_sha=`git rev-parse HEAD` -t wp-calypso .",
+    "build-docker": "node bin/build-docker.js",
     "prebuild-server": "mkdirp build",
     "build-server": "npm run -s env -- webpack --display-error-details --config webpack.config.node.js",
     "build-client": "npm run -s env -- webpack --display-error-details --config webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "build-devdocs:components-usage-stats:_env": "node server/devdocs/bin/generate-components-usage-stats.js \"client/**/*.js\" \"client/**/*.jsx\" \"!**/docs/**\" \"!**/test/**\" \"!**/docs-example/**\"",
     "build-devdocs:index": "npm run -s env -- npm run -s build-devdocs:index:_env",
     "build-devdocs:index:_env": "node server/devdocs/bin/generate-devdocs-index \"**/*.md\" \".github/**.md\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
-    "build-docker": "docker build -t wp-calypso .",
+    "build-docker": "docker build --build-arg commit_sha=`git rev-parse HEAD` -t wp-calypso .",
     "prebuild-server": "mkdirp build",
     "build-server": "npm run -s env -- webpack --display-error-details --config webpack.config.node.js",
     "build-client": "npm run -s env -- webpack --display-error-details --config webpack.config.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,7 @@ const isDevelopment = bundleEnv === 'development';
 const shouldMinify = process.env.hasOwnProperty( 'MINIFY_JS' )
 	? process.env.MINIFY_JS === 'true'
 	: ! isDevelopment;
+const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
 
 /**
  * This function scans the /client/extensions directory in order to generate a map that looks like this:
@@ -165,6 +166,7 @@ const webpackConfig = {
 		new webpack.DefinePlugin( {
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
 			PROJECT_NAME: JSON.stringify( config( 'project' ) ),
+			COMMIT_SHA: JSON.stringify( commitSha ),
 		} ),
 		new webpack.IgnorePlugin( /^props$/ ),
 		new CopyWebpackPlugin( [

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -22,6 +22,11 @@ const config = require( 'config' );
 const bundleEnv = config( 'env' );
 
 /**
+ * Internal variables
+ */
+const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
+
+/**
  * This lists modules that must use commonJS `require()`s
  * All modules listed here need to be ES5.
  *
@@ -134,6 +139,7 @@ const webpackConfig = {
 		} ),
 		new webpack.DefinePlugin( {
 			PROJECT_NAME: JSON.stringify( config( 'project' ) ),
+			COMMIT_SHA: JSON.stringify( commitSha ),
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
 		} ),
 		new HappyPack( { loaders: [ babelLoader ] } ),


### PR DESCRIPTION
This adds a commit sha to the docker build environment variable
COMMIT_SHA which is picked up and logged to logstash on all unhandled JS
exceptions.

Note: This only works in a docker build, the sha will come up as "(unknown)" in dev builds.

I originally tried this in #21079 but it didn't work correctly within the docker build. Therefore, I added the SHA to the `build-docker` script as a docker build arg, which is then passed as an environment variable to webpack to be embedded as a JS global in the bundle to be used by the error logging. The end result is that this only works in a docker build, but then, it's only really useful in a docker build anyway.

The SHA takes the following path:

[ docker-build variable ] ➡️  [ environment variable ] ➡️  [ JavaScript global ] ➡️  [ logstash ]

1. `docker build`: git command embedded into a docker build variable (`commit_sha`).
2. `Dockerfile`: build variable (commit_sha) copied to environment variable (`COMMIT_SHA`) when running webpack build.
3. `webpack`: Copies environment variable (`COMMIT_SHA`) to a JavaScript global (`COMMIT_SHA`).
4. `catch-js-errors/index.js`: Adds JavaScript global (`COMMIT_SHA`) to logstash field (`commit`).

Note: `commit` is already a whitelisted field for logstash, we're just not using it until now.

To Test:

1. You need to add some temporary code that throws an exception. I modified `client/reader/reader-sidebar-tags/index.jsx` and added a line to `handleAddClick()` like this: `throw new Error( 'Test error for commit sha' );` So that way when I click in the reader sidebar to add a tag, it throws an error.
2. Follow the instructions on how to do a docker build.
3. Bring up the browser on your local docker build.
4. Open the dev console.
5. Click your modified button to generate the error.
6. Verify you see an "Uncaught Error" message in the console, and look in the Network log for a request to `js-error?http_envelope=1`.
7. Inspect the Form Data for an `error` field. Search the error field data for a `commit` field. It should match the SHA from your build.

