### PR TITLE
esmodules: Update lib/url

### DIFF
--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -9,8 +9,9 @@ import { has, isString, omit, startsWith } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
-import { addQueryArgs } from 'lib/route';
 import { isLegacyRoute } from 'lib/route/legacy-routes';
+
+export { addQueryArgs } from 'lib/route';
 
 /**
  * Check if a URL is located outside of Calypso.
@@ -21,11 +22,11 @@ import { isLegacyRoute } from 'lib/route/legacy-routes';
  * @param {string} url - URL to check
  * @return {bool} true if the given URL is located outside of Calypso
  */
-function isOutsideCalypso( url ) {
+export function isOutsideCalypso( url ) {
 	return url && ( startsWith( url, '//' ) || ! startsWith( url, '/' ) );
 }
 
-function isExternal( url ) {
+export function isExternal( url ) {
 	// parseURL will return hostname = null if no protocol or double-slashes
 	// the url passed in might be of form `en.support.wordpress.com`
 	// so for this function we'll append double-slashes to fake it
@@ -59,7 +60,7 @@ function isExternal( url ) {
 	return hostname !== config( 'hostname' );
 }
 
-function isHttps( url ) {
+export function isHttps( url ) {
 	return url && startsWith( url, 'https://' );
 }
 
@@ -71,7 +72,7 @@ const urlWithoutHttpRegex = /^https?:\/\//;
  * @param  {String}  url The URL to remove http(s) from
  * @return {?String}     URL without the initial http(s)
  */
-function withoutHttp( url ) {
+export function withoutHttp( url ) {
 	if ( url === '' ) {
 		return '';
 	}
@@ -83,14 +84,14 @@ function withoutHttp( url ) {
 	return url.replace( urlWithoutHttpRegex, '' );
 }
 
-function addSchemeIfMissing( url, scheme ) {
+export function addSchemeIfMissing( url, scheme ) {
 	if ( false === schemeRegex.test( url ) ) {
 		return scheme + '://' + url;
 	}
 	return url;
 }
 
-function setUrlScheme( url, scheme ) {
+export function setUrlScheme( url, scheme ) {
 	const schemeWithSlashes = scheme + '://';
 	if ( startsWith( url, schemeWithSlashes ) ) {
 		return url;
@@ -104,7 +105,7 @@ function setUrlScheme( url, scheme ) {
 	return url.replace( schemeRegex, schemeWithSlashes );
 }
 
-function urlToSlug( url ) {
+export function urlToSlug( url ) {
 	if ( ! url ) {
 		return null;
 	}
@@ -120,7 +121,7 @@ function urlToSlug( url ) {
  * @param  {String} urlToConvert The URL to convert
  * @return {String} The URL's domain and path
  */
-function urlToDomainAndPath( urlToConvert ) {
+export function urlToDomainAndPath( urlToConvert ) {
 	return withoutHttp( urlToConvert ).replace( /\/$/, '' );
 }
 
@@ -133,7 +134,7 @@ function urlToDomainAndPath( urlToConvert ) {
  * @param  {String}  query The string to check
  * @return {Boolean} Does it appear to be a URL?
  */
-function resemblesUrl( query ) {
+export function resemblesUrl( query ) {
 	if ( ! query ) {
 		return false;
 	}
@@ -170,7 +171,7 @@ function resemblesUrl( query ) {
  * @param  {Array|String}  paramsToOmit The collection of params or single param to reject
  * @return {String} Url less the omitted params.
  */
-function omitUrlParams( url, paramsToOmit ) {
+export function omitUrlParams( url, paramsToOmit ) {
 	if ( ! url ) {
 		return null;
 	}
@@ -188,7 +189,7 @@ function omitUrlParams( url, paramsToOmit ) {
  * @param  {String} encodedURI URI to attempt to decode
  * @return {String}            Decoded URI (or passed in value on error)
  */
-function decodeURIIfValid( encodedURI ) {
+export function decodeURIIfValid( encodedURI ) {
 	if ( ! ( isString( encodedURI ) || has( encodedURI, 'toString' ) ) ) {
 		return '';
 	}
@@ -205,7 +206,7 @@ function decodeURIIfValid( encodedURI ) {
  * @param  {String} encodedURIComponent URI component to attempt to decode
  * @return {String}            Decoded URI component (or passed in value on error)
  */
-function decodeURIComponentIfValid( encodedURIComponent ) {
+export function decodeURIComponentIfValid( encodedURIComponent ) {
 	if ( ! ( isString( encodedURIComponent ) || has( encodedURIComponent, 'toString' ) ) ) {
 		return '';
 	}
@@ -215,20 +216,3 @@ function decodeURIComponentIfValid( encodedURIComponent ) {
 		return encodedURIComponent;
 	}
 }
-
-export default {
-	decodeURIIfValid,
-	decodeURIComponentIfValid,
-	isOutsideCalypso,
-	isExternal,
-	isHttps,
-	withoutHttp,
-	addSchemeIfMissing,
-	setUrlScheme,
-	urlToSlug,
-	urlToDomainAndPath,
-	// [TODO]: Move lib/route/add-query-args contents here
-	addQueryArgs,
-	resemblesUrl,
-	omitUrlParams,
-};


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.

**Testing**

Smoke test changed files.
There are lots of constants changed in the support links.