### PR TITLE
esmodules: Update lib/paths

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/video-audio-posts.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
@@ -11,7 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PurchaseDetail from 'components/purchase-detail';
-import paths from 'lib/paths';
+import { newPost } from 'lib/paths';
 
 export default localize( ( { selectedSite, translate } ) => {
 	return (
@@ -24,7 +22,7 @@ export default localize( ( { selectedSite, translate } ) => {
 						'No ads or limits. The Premium plan also adds 10GB of file storage.'
 				) }
 				buttonText={ translate( 'Start a new post' ) }
-				href={ paths.newPost( selectedSite ) }
+				href={ newPost( selectedSite ) }
 			/>
 		</div>
 	);

--- a/client/layout/masterbar/drafts.jsx
+++ b/client/layout/masterbar/drafts.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -13,13 +11,12 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import Popover from 'components/popover';
 import Count from 'components/count';
 import { getMyPostCounts } from 'state/posts/counts/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostsForQueryIgnoringPage, isRequestingPostsForQuery } from 'state/posts/selectors';
-import paths from 'lib/paths';
+import { newPost } from 'lib/paths';
 import Draft from 'my-sites/draft';
 import QueryPosts from 'components/data/query-posts';
 import QueryPostCounts from 'components/data/query-post-counts';
@@ -103,7 +100,7 @@ class MasterbarDrafts extends Component {
 						<Button
 							compact
 							className="masterbar__recent-drafts-add-new"
-							href={ paths.newPost( selectedSite ) }
+							href={ newPost( selectedSite ) }
 							onClick={ this.newDraftClicked }
 						>
 							{ translate( 'New Draft' ) }

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
@@ -15,7 +13,7 @@ import { connect } from 'react-redux';
 import { recordTracksEvent } from 'state/analytics/actions';
 import MasterbarItem from './item';
 import SitesPopover from 'components/sites-popover';
-import paths from 'lib/paths';
+import { newPost } from 'lib/paths';
 import { isMobile } from 'lib/viewport';
 import { preload } from 'sections-preload';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -71,7 +69,7 @@ class MasterbarItemNew extends React.Component {
 	render() {
 		const classes = classNames( this.props.className );
 		const currentSite = this.props.selectedSite || this.props.user.get().primarySiteSlug;
-		const newPostPath = paths.newPost( currentSite );
+		const newPostPath = newPost( currentSite );
 
 		return (
 			<div className="masterbar__publish">

--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -12,7 +12,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import paths from 'lib/paths';
+import { newPost } from 'lib/paths';
 import userFactory from 'lib/user';
 const user = userFactory();
 import { ipcRenderer as ipc } from 'electron'; // From Electron
@@ -157,7 +157,7 @@ var Desktop = {
 		debug( 'New post' );
 
 		this.clearNotificationBar();
-		page( paths.newPost( this.selectedSite ) );
+		page( newPost( this.selectedSite ) );
 	},
 
 	// now that our browser session has a valid wordpress.com cookie, let's force

--- a/client/lib/paths/index.js
+++ b/client/lib/paths/index.js
@@ -1,10 +1,8 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
-import { login } from './login';
+export { login } from './login';
 
 function editorPathFromSite( site ) {
 	let path = '',
@@ -26,7 +24,7 @@ function editorPathFromSite( site ) {
  * @param  {object|string} site Site object or site slug
  * @return {string}      URL to post editor
  */
-function newPost( site ) {
+export function newPost( site ) {
 	const sitePath = editorPathFromSite( site );
 	return '/post' + sitePath;
 }
@@ -37,7 +35,7 @@ function newPost( site ) {
  * @param  {object|string} site Site object or site slug
  * @return {string}      URL to page editor
  */
-function newPage( site ) {
+export function newPage( site ) {
 	const sitePath = editorPathFromSite( site );
 	return '/page' + sitePath;
 }
@@ -48,7 +46,7 @@ function newPage( site ) {
  * @param  {object} site Site object
  * @return {string}      URL to manage Publicize connections
  */
-function publicizeConnections( site ) {
+export function publicizeConnections( site ) {
 	let url = '/sharing';
 
 	if ( site ) {
@@ -57,10 +55,3 @@ function publicizeConnections( site ) {
 
 	return url;
 }
-
-export default {
-	login,
-	newPost,
-	newPage,
-	publicizeConnections,
-};

--- a/client/lib/paths/test/index.js
+++ b/client/lib/paths/test/index.js
@@ -1,20 +1,18 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
-import paths from '../';
+import { newPage, newPost, publicizeConnections } from '../index';
 
 /**
  * Module variables
  */
-var DUMMY_SITE = {
+const DUMMY_SITE = {
 	ID: 73693298,
 	slug: 'settingstestsite.wordpress.com',
 };
@@ -22,43 +20,31 @@ var DUMMY_SITE = {
 describe( 'index', () => {
 	describe( '#newPost()', () => {
 		test( 'should return the Calypso root post path no site', () => {
-			var url = paths.newPost();
-
-			expect( url ).to.equal( '/post' );
+			expect( newPost() ).to.equal( '/post' );
 		} );
 
 		test( 'should return a Calypso site-prefixed post path if site exists', () => {
-			var url = paths.newPost( DUMMY_SITE );
-
-			expect( url ).to.equal( '/post/' + DUMMY_SITE.slug );
+			expect( newPost( DUMMY_SITE ) ).to.equal( '/post/' + DUMMY_SITE.slug );
 		} );
 	} );
 
 	describe( '#newPage()', () => {
 		test( 'should return the Calypso root page path no site', () => {
-			var url = paths.newPage();
-
-			expect( url ).to.equal( '/page' );
+			expect( newPage() ).to.equal( '/page' );
 		} );
 
 		test( 'should return a Calypso site-prefixed page path if site exists', () => {
-			var url = paths.newPage( DUMMY_SITE );
-
-			expect( url ).to.equal( '/page/' + DUMMY_SITE.slug );
+			expect( newPage( DUMMY_SITE ) ).to.equal( '/page/' + DUMMY_SITE.slug );
 		} );
 	} );
 
 	describe( '#publicizeConnections()', () => {
 		test( 'should return the root sharing path if no site specified', () => {
-			var url = paths.publicizeConnections();
-
-			expect( url ).to.equal( '/sharing' );
+			expect( publicizeConnections() ).to.equal( '/sharing' );
 		} );
 
 		test( 'should return a Calypso site-suffixed sharing path if site specified', () => {
-			var url = paths.publicizeConnections( DUMMY_SITE );
-
-			expect( url ).to.equal( '/sharing/' + DUMMY_SITE.slug );
+			expect( publicizeConnections( DUMMY_SITE ) ).to.equal( '/sharing/' + DUMMY_SITE.slug );
 		} );
 	} );
 } );

--- a/client/me/next-steps/steps.js
+++ b/client/me/next-steps/steps.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import Gridicon from 'gridicons';
 import i18n from 'i18n-calypso';
@@ -11,7 +9,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import paths from 'lib/paths';
+import { newPage, newPost } from 'lib/paths';
 import config from 'config';
 
 function buildCustomizeButtonURL( site ) {
@@ -46,7 +44,7 @@ export default {
 					}
 				),
 				buttonText: i18n.translate( 'Start a Post' ),
-				buttonURL: paths.newPost( site ),
+				buttonURL: newPost( site ),
 			},
 
 			theme: {
@@ -109,7 +107,7 @@ export default {
 					}
 				),
 				buttonText: i18n.translate( 'Create a Page' ),
-				buttonURL: paths.newPage( site ),
+				buttonURL: newPage( site ),
 			},
 			site: {
 				title: i18n.translate( 'Create a Site' ),

--- a/client/my-sites/checkout/checkout-thank-you/chargeback-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/chargeback-details.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import i18n from 'i18n-calypso';
@@ -11,7 +9,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import paths from 'lib/paths';
+import { newPost } from 'lib/paths';
 import PurchaseDetail from 'components/purchase-detail';
 
 const ChargebackDetails = ( { selectedSite } ) => {
@@ -23,7 +21,7 @@ const ChargebackDetails = ( { selectedSite } ) => {
 				'You can now use the full features of your site, without limits.'
 			) }
 			buttonText={ i18n.translate( 'Write a Post' ) }
-			href={ paths.newPost( selectedSite ) }
+			href={ newPost( selectedSite ) }
 		/>
 	);
 };

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -18,7 +16,7 @@ import GoogleAppsDetails from './google-apps-details';
 import GoogleVoucherDetails from './google-voucher';
 import { isWordadsInstantActivationEligible } from 'lib/ads/utils';
 import { isPremium, isGoogleApps } from 'lib/products-values';
-import paths from 'lib/paths';
+import { newPost } from 'lib/paths';
 import PurchaseDetail from 'components/purchase-detail';
 import QuerySiteVouchers from 'components/data/query-site-vouchers';
 
@@ -84,7 +82,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 						'No ads or limits. The Premium plan also adds 10GB of file storage.'
 				) }
 				buttonText={ i18n.translate( 'Start a new post' ) }
-				href={ paths.newPost( selectedSite ) }
+				href={ newPost( selectedSite ) }
 			/>
 			{ isWordadsInstantActivationEligible( selectedSite ) && (
 				<PurchaseDetail

--- a/client/my-sites/site-settings/press-this/link.jsx
+++ b/client/my-sites/site-settings/press-this/link.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { omit } from 'lodash';
@@ -11,7 +9,7 @@ import { omit } from 'lodash';
 /**
  * Internal dependencies
  */
-import paths from 'lib/paths';
+import { newPost } from 'lib/paths';
 
 /**
  * Retrieves selection, title, and URL from current page and pops
@@ -80,7 +78,7 @@ class PressThisLink extends React.Component {
 		if ( window.location.port ) {
 			postDomain += `:${ window.location.port }`;
 		}
-		const postURL = postDomain + paths.newPost( this.props.site );
+		const postURL = postDomain + newPost( this.props.site );
 		return `javascript:( ${ functionText } )( '${ postURL }' )`;
 	}
 

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -18,7 +16,7 @@ import Gridicon from 'gridicons';
 import QueryPostTypes from 'components/data/query-post-types';
 import PublicizeMessage from './publicize-message';
 import PublicizeServices from './publicize-services';
-import * as paths from 'lib/paths';
+import { publicizeConnections } from 'lib/paths';
 import PostMetadata from 'lib/post-metadata';
 import PopupMonitor from 'lib/popup-monitor';
 import Button from 'components/button';
@@ -58,7 +56,7 @@ class EditorSharingPublicizeOptions extends React.Component {
 			return;
 		}
 
-		const href = paths.publicizeConnections( this.props.site );
+		const href = publicizeConnections( this.props.site );
 
 		if ( ! this.connectionPopupMonitor ) {
 			this.connectionPopupMonitor = new PopupMonitor();
@@ -91,9 +89,9 @@ class EditorSharingPublicizeOptions extends React.Component {
 	renderMessage = () => {
 		const skipped = this.hasConnections() ? PostMetadata.publicizeSkipped( this.props.post ) : [],
 			targeted = this.hasConnections()
-				? this.props.connections.filter( function( connection ) {
-						return skipped && -1 === skipped.indexOf( connection.keyring_connection_ID );
-					} )
+				? this.props.connections.filter(
+						connection => skipped && -1 === skipped.indexOf( connection.keyring_connection_ID )
+					)
 				: [],
 			requireCount = includes( map( targeted, 'service' ), 'twitter' ),
 			acceptableLength = requireCount ? 140 - 23 - 23 : null;


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.

**Testing**

Smoke-test links for new posts, pages, login, and publicize connections.