### PR TITLE
esmodules: Update lib/site/utils

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -24,7 +24,7 @@ import Gridicon from 'gridicons';
 import QueryPluginKeys from 'components/data/query-plugin-keys';
 import analytics from 'lib/analytics';
 import support from 'lib/url/support';
-import utils from 'lib/site/utils';
+import { getSiteFileModDisableReason } from 'lib/site/utils';
 import HappyChatButton from 'components/happychat/button';
 
 // Redux actions & selectors
@@ -347,7 +347,7 @@ class JetpackThankYouCard extends Component {
 			return null;
 		}
 
-		const reasons = utils.getSiteFileModDisableReason( selectedSite, 'modifyFiles' );
+		const reasons = getSiteFileModDisableReason( selectedSite, 'modifyFiles' );
 		let reason;
 		if ( reasons && reasons.length > 0 ) {
 			reason = translate( "We can't modify files on your site." );

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -27,7 +27,7 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
 import analytics from 'lib/analytics';
 import support from 'lib/url/support';
-import utils from 'lib/site/utils';
+import { getSiteFileModDisableReason } from 'lib/site/utils';
 
 // Redux actions & selectors
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
@@ -196,7 +196,7 @@ class PlansSetup extends React.Component {
 	renderCantInstallPlugins = () => {
 		const { translate } = this.props;
 		const site = this.props.selectedSite;
-		const reasons = utils.getSiteFileModDisableReason( site, 'modifyFiles' );
+		const reasons = getSiteFileModDisableReason( site, 'modifyFiles' );
 		let reason;
 
 		if ( reasons && reasons.length > 0 ) {


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.

**Testing**

Smoke-test capabilities in this file.

Make sure timezones work properly.