### PR TITLE
esmodules: Update lib/formatting

### DIFF
--- a/client/components/tinymce/plugins/wpcom/plugin.js
+++ b/client/components/tinymce/plugins/wpcom/plugin.js
@@ -1,12 +1,10 @@
+/** @format **/
 /**
  * Adapted from the WordPress wp TinyMCE plugin.
- * 
  *
- * @format
  * @copyright 2015 by the WordPress contributors.
  * @license See CREDITS.md.
  */
-
 /**
  * External dependencies
  */
@@ -16,7 +14,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import formatting from 'lib/formatting';
+import { removep, wpautop } from 'lib/formatting';
 import { removeEmptySpacesInParagraphs } from './wpcom-utils';
 
 /* eslint-disable */
@@ -66,7 +64,7 @@ function wpcomPlugin( editor ) {
 			}
 
 			if ( event.load && event.format !== 'raw' ) {
-				event.content = formatting.wpautop( event.content );
+				event.content = wpautop( event.content );
 			}
 		}
 	} );
@@ -339,7 +337,7 @@ function wpcomPlugin( editor ) {
 		// Keep empty paragraphs :(
 		e.content = e.content.replace( /<p>(?:<br ?\/?>|\u00a0|\uFEFF| )*<\/p>/g, '<p>&nbsp;</p>' );
 
-		e.content = formatting.removep( e.content );
+		e.content = removep( e.content );
 	} );
 
 	// Remove spaces from empty paragraphs.

--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -10,7 +10,7 @@ import stripTags from 'striptags';
  */
 import decode from './decode-entities';
 
-function decodeEntities( text ) {
+export function decodeEntities( text ) {
 	// Bypass decode if text doesn't include entities
 	if ( 'string' !== typeof text || -1 === text.indexOf( '&' ) ) {
 		return text;
@@ -26,7 +26,7 @@ function decodeEntities( text ) {
  * @param {*[]} list - list
  * @returns {*[]} the list with separators
  */
-function interpose( separator, list ) {
+export function interpose( separator, list ) {
 	return list.reduce( function( previousValue, currentValue, index ) {
 		let value;
 		if ( index > 0 ) {
@@ -43,7 +43,7 @@ function interpose( separator, list ) {
  * @param  {string} string The string to strip tags from
  * @return {string}        The stripped string
  */
-function stripHTML( string ) {
+export function stripHTML( string ) {
 	return stripTags( string );
 }
 
@@ -53,7 +53,7 @@ function stripHTML( string ) {
  * @param  {number} wordsToKeep the number of words to keep together
  * @return {string}             the widow-prevented string
  */
-function preventWidows( text, wordsToKeep = 2 ) {
+export function preventWidows( text, wordsToKeep = 2 ) {
 	let words, endWords;
 
 	if ( typeof text !== 'string' ) {
@@ -91,7 +91,7 @@ function preventWidows( text, wordsToKeep = 2 ) {
  * @param {string} pee     html string
  * @return {string}        html string with HTML paragraphs instead of double line-breaks
  */
-function wpautop( pee ) {
+export function wpautop( pee ) {
 	const blocklist =
 		'table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre' +
 		'|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section' +
@@ -181,7 +181,7 @@ function wpautop( pee ) {
 	return pee;
 }
 
-function removep( html ) {
+export function removep( html ) {
 	const blocklist = 'blockquote|ul|ol|li|table|thead|tbody|tfoot|tr|th|td|h[1-6]|fieldset';
 	const blocklist1 = blocklist + '|div|p';
 	const blocklist2 = blocklist + '|pre';
@@ -276,7 +276,7 @@ function removep( html ) {
 	return html;
 }
 
-function capitalPDangit( input ) {
+export function capitalPDangit( input ) {
 	if ( 'string' !== typeof input ) {
 		throw new Error( 'capitalPDangit expects a string as input' );
 	}
@@ -289,7 +289,7 @@ function capitalPDangit( input ) {
  * @param  {String} html HTML String to be converted into DOM fragment
  * @return {Dom} DOM fragment that can be queried using built in browser functions.
  */
-function parseHtml( html ) {
+export function parseHtml( html ) {
 	if ( html && html.querySelector ) {
 		return html;
 	}
@@ -331,18 +331,6 @@ const nbsp = String.fromCharCode( 160 );
  * @param	{String} str String to unescape in preparation for React rendering
  * @return	{String} Transformed string
  */
-function unescapeAndFormatSpaces( str ) {
+export function unescapeAndFormatSpaces( str ) {
 	return decodeEntities( str ).replace( / /g, nbsp );
 }
-
-export default {
-	decodeEntities: decodeEntities,
-	interpose: interpose,
-	stripHTML: stripHTML,
-	preventWidows: preventWidows,
-	wpautop: wpautop,
-	removep: removep,
-	capitalPDangit: capitalPDangit,
-	parseHtml: parseHtml,
-	unescapeAndFormatSpaces: unescapeAndFormatSpaces,
-};

--- a/client/lib/formatting/test/index.js
+++ b/client/lib/formatting/test/index.js
@@ -12,16 +12,13 @@ import chai from 'chai';
  * Internal dependencies
  */
 import decodeEntitiesNode from '../decode-entities/node';
+import { capitalPDangit, parseHtml, preventWidows } from '../index';
 
 describe( 'formatting', () => {
-	let formatting, capitalPDangit, parseHtml, decodeEntitiesBrowser, preventWidows;
+	let decodeEntitiesBrowser;
 
 	beforeAll( () => {
-		formatting = require( '../' );
-		capitalPDangit = formatting.capitalPDangit;
-		parseHtml = formatting.parseHtml;
 		decodeEntitiesBrowser = require( '../decode-entities/browser' );
-		preventWidows = formatting.preventWidows;
 	} );
 
 	describe( '#capitalPDangtest()', function() {

--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 import { defer } from 'lodash';
 
@@ -12,7 +10,7 @@ import { defer } from 'lodash';
  */
 import analytics from 'lib/analytics';
 import Dispatcher from 'dispatcher';
-import utils from 'lib/site/utils';
+import { userCan } from 'lib/site/utils';
 import wpcom from 'lib/wp';
 
 /**
@@ -23,13 +21,11 @@ let _actionsQueueBySite = {};
 
 const queueSitePluginAction = ( action, siteId, pluginId, callback ) => {
 	const next = ( nextCallback, error, data ) => {
-		let nextAction;
-
 		if ( nextCallback ) {
 			nextCallback( error, data );
 		}
 
-		nextAction = _actionsQueueBySite[ siteId ].shift();
+		const nextAction = _actionsQueueBySite[ siteId ].shift();
 
 		if ( nextAction ) {
 			nextAction.action( next.bind( this, nextAction.callback ) );
@@ -139,7 +135,7 @@ const PluginsActions = {
 	},
 
 	fetchSitePlugins: site => {
-		if ( ! utils.userCan( 'manage_options', site ) || ! site.jetpack ) {
+		if ( ! userCan( 'manage_options', site ) || ! site.jetpack ) {
 			defer( () => {
 				Dispatcher.handleViewAction( {
 					type: 'NOT_ALLOWED_TO_RECEIVE_PLUGINS',
@@ -207,7 +203,7 @@ const PluginsActions = {
 			return getRejectedPromise( "Error: Can't update files on the site" );
 		}
 
-		if ( ! utils.userCan( 'manage_options', site ) ) {
+		if ( ! userCan( 'manage_options', site ) ) {
 			return getRejectedPromise( "Error: User can't manage the site" );
 		}
 
@@ -309,7 +305,7 @@ const PluginsActions = {
 	},
 
 	removePlugin: ( site, plugin ) => {
-		if ( ! site.canUpdateFiles || ! utils.userCan( 'manage_options', site ) ) {
+		if ( ! site.canUpdateFiles || ! userCan( 'manage_options', site ) ) {
 			return;
 		}
 
@@ -457,7 +453,7 @@ const PluginsActions = {
 	},
 
 	togglePluginActivation: ( site, plugin ) => {
-		if ( ! utils.userCan( 'manage_options', site ) ) {
+		if ( ! userCan( 'manage_options', site ) ) {
 			return;
 		}
 
@@ -470,7 +466,7 @@ const PluginsActions = {
 	},
 
 	enableAutoUpdatesPlugin: ( site, plugin ) => {
-		if ( ! utils.userCan( 'manage_options', site ) || ! site.canAutoupdateFiles ) {
+		if ( ! userCan( 'manage_options', site ) || ! site.canAutoupdateFiles ) {
 			return;
 		}
 		Dispatcher.handleViewAction( {
@@ -499,7 +495,7 @@ const PluginsActions = {
 	},
 
 	disableAutoUpdatesPlugin: ( site, plugin ) => {
-		if ( ! utils.userCan( 'manage_options', site ) || ! site.canAutoupdateFiles ) {
+		if ( ! userCan( 'manage_options', site ) || ! site.canAutoupdateFiles ) {
 			return;
 		}
 
@@ -526,7 +522,7 @@ const PluginsActions = {
 	},
 
 	togglePluginAutoUpdate: ( site, plugin ) => {
-		if ( ! utils.userCan( 'manage_options', site ) || ! site.canAutoupdateFiles ) {
+		if ( ! userCan( 'manage_options', site ) || ! site.canAutoupdateFiles ) {
 			return;
 		}
 

--- a/client/lib/post-normalizer/rule-prevent-widows.js
+++ b/client/lib/post-normalizer/rule-prevent-widows.js
@@ -1,20 +1,18 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { forEach } from 'lodash';
 
 /**
  * Internal Dependencies
  */
-import formatting from 'lib/formatting';
+import { preventWidows as preventWidowFormatting } from 'lib/formatting';
 
 export default function preventWidows( post ) {
 	forEach( [ 'excerpt' ], function( prop ) {
 		if ( post[ prop ] ) {
-			post[ prop ] = formatting.preventWidows( post[ prop ], 2 );
+			post[ prop ] = preventWidowFormatting( post[ prop ], 2 );
 		}
 	} );
 	return post;

--- a/client/lib/post-normalizer/rule-strip-html.js
+++ b/client/lib/post-normalizer/rule-strip-html.js
@@ -1,25 +1,23 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { forEach } from 'lodash';
 
 /**
  * Internal Dependencies
  */
-import formatting from 'lib/formatting';
+import { stripHTML } from 'lib/formatting';
 
 export default function stripHtml( post ) {
 	forEach( [ 'excerpt', 'title', 'site_name' ], function( prop ) {
 		if ( post[ prop ] ) {
-			post[ prop ] = formatting.stripHTML( post[ prop ] );
+			post[ prop ] = stripHTML( post[ prop ] );
 		}
 	} );
 
 	if ( post.author && post.author.name ) {
-		post.author.name = formatting.stripHTML( post.author.name );
+		post.author.name = stripHTML( post.author.name );
 	}
 	return post;
 }

--- a/client/lib/site/test/utils.js
+++ b/client/lib/site/test/utils.js
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */
@@ -8,26 +7,26 @@ import chai from 'chai';
 /**
  * Internal dependencies
  */
-import SiteUtils from 'lib/site/utils';
+import { canUpdateFiles, isMainNetworkSite } from 'lib/site/utils';
 
 const assert = chai.assert;
 
 describe( 'Site Utils', () => {
 	describe( 'canUpdateFiles', () => {
 		test( 'Should have a method canUpdateFiles.', () => {
-			assert.isFunction( SiteUtils.canUpdateFiles );
+			assert.isFunction( canUpdateFiles );
 		} );
 
 		test( 'Should return false when no site object is passed in.', () => {
-			assert.isFalse( SiteUtils.canUpdateFiles() );
+			assert.isFalse( canUpdateFiles() );
 		} );
 
 		test( 'Should return false when passed an empty object.', () => {
-			assert.isFalse( SiteUtils.canUpdateFiles( {} ) );
+			assert.isFalse( canUpdateFiles( {} ) );
 		} );
 
 		test( 'Should return false when passed an object without options.', () => {
-			assert.isFalse( SiteUtils.canUpdateFiles( { hello: 'not important' } ) );
+			assert.isFalse( canUpdateFiles( { hello: 'not important' } ) );
 		} );
 
 		test( 'Should return false when passed an site object that has something value in the file_mod_option.', () => {
@@ -40,7 +39,7 @@ describe( 'Site Utils', () => {
 					file_mod_disabled: [ 'something else' ],
 				},
 			};
-			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
+			assert.isFalse( canUpdateFiles( site ) );
 		} );
 
 		test( 'Should return false when passed a multi site when unmapped_url and main_network_site are not equal.', () => {
@@ -54,7 +53,7 @@ describe( 'Site Utils', () => {
 					file_mod_disabled: false,
 				},
 			};
-			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
+			assert.isFalse( canUpdateFiles( site ) );
 		} );
 
 		test( 'Should return true when passed a site a single site even though the unmapped_url is not the same as main_network_site.', () => {
@@ -68,7 +67,7 @@ describe( 'Site Utils', () => {
 					file_mod_disabled: false,
 				},
 			};
-			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
+			assert.isTrue( canUpdateFiles( site ) );
 		} );
 
 		test( 'Should return true when passed a site that has different protocolls for unmapped_url and main_network_site.', () => {
@@ -82,7 +81,7 @@ describe( 'Site Utils', () => {
 					file_mod_disabled: false,
 				},
 			};
-			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
+			assert.isTrue( canUpdateFiles( site ) );
 		} );
 
 		test( 'Should return false when passed a site  that has compares ftp to http protocolls for unmapped_url and main_network_site.', () => {
@@ -96,7 +95,7 @@ describe( 'Site Utils', () => {
 					file_mod_disabled: false,
 				},
 			};
-			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
+			assert.isFalse( canUpdateFiles( site ) );
 		} );
 
 		test( 'Should return true when passed a site that has all the right settings permissions to be able to update files.', () => {
@@ -110,25 +109,25 @@ describe( 'Site Utils', () => {
 					file_mod_disabled: false,
 				},
 			};
-			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
+			assert.isTrue( canUpdateFiles( site ) );
 		} );
 	} );
 
 	describe( 'isMainNetworkSite', () => {
 		test( 'Should have a method isMainNetworkSite.', () => {
-			assert.isFunction( SiteUtils.isMainNetworkSite );
+			assert.isFunction( isMainNetworkSite );
 		} );
 
 		test( 'Should return false when no site object is passed in.', () => {
-			assert.isFalse( SiteUtils.isMainNetworkSite() );
+			assert.isFalse( isMainNetworkSite() );
 		} );
 
 		test( 'Should return false when passed an empty object.', () => {
-			assert.isFalse( SiteUtils.isMainNetworkSite( {} ) );
+			assert.isFalse( isMainNetworkSite( {} ) );
 		} );
 
 		test( 'Should return false when passed an object without options.', () => {
-			assert.isFalse( SiteUtils.isMainNetworkSite( { hello: 'not important' } ) );
+			assert.isFalse( isMainNetworkSite( { hello: 'not important' } ) );
 		} );
 
 		test( 'Should return false when passed a multi site when unmapped_url and main_network_site are not equal.', () => {
@@ -139,7 +138,7 @@ describe( 'Site Utils', () => {
 					main_network_site: 'someurl-different',
 				},
 			};
-			assert.isFalse( SiteUtils.isMainNetworkSite( site ) );
+			assert.isFalse( isMainNetworkSite( site ) );
 		} );
 
 		test( 'Should return true when passed a site a single site even though the unmapped_url is not the same as main_network_site.', () => {
@@ -150,7 +149,7 @@ describe( 'Site Utils', () => {
 					main_network_site: 'someurl-different',
 				},
 			};
-			assert.isTrue( SiteUtils.isMainNetworkSite( site ) );
+			assert.isTrue( isMainNetworkSite( site ) );
 		} );
 
 		test( 'Should return false when passed a site that a part of a multi network.', () => {
@@ -159,7 +158,7 @@ describe( 'Site Utils', () => {
 					is_multi_network: true,
 				},
 			};
-			assert.isFalse( SiteUtils.isMainNetworkSite( site ) );
+			assert.isFalse( isMainNetworkSite( site ) );
 		} );
 
 		test( 'Should return true when passed a site that has different protocolls for unmapped_url and main_network_site.', () => {
@@ -170,7 +169,7 @@ describe( 'Site Utils', () => {
 					main_network_site: 'https://someurl',
 				},
 			};
-			assert.isTrue( SiteUtils.isMainNetworkSite( site ) );
+			assert.isTrue( isMainNetworkSite( site ) );
 		} );
 
 		test( 'Should return false when passed a site that has compares ftp to http protocolls for unmapped_url and main_network_site.', () => {
@@ -181,7 +180,7 @@ describe( 'Site Utils', () => {
 					main_network_site: 'ftp://someurl',
 				},
 			};
-			assert.isFalse( SiteUtils.isMainNetworkSite( site ) );
+			assert.isFalse( isMainNetworkSite( site ) );
 		} );
 
 		test( 'Does not explode when unmapped_url is not defined', () => {
@@ -189,7 +188,7 @@ describe( 'Site Utils', () => {
 				is_multisite: true,
 				options: {},
 			};
-			assert.isFalse( SiteUtils.isMainNetworkSite( site ) );
+			assert.isFalse( isMainNetworkSite( site ) );
 		} );
 	} );
 } );

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -1,162 +1,149 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import i18n from 'i18n-calypso';
 import { get } from 'lodash';
 import { withoutHttp } from 'lib/url';
 
-export default {
-	userCan( capability, site ) {
-		return site && site.capabilities && site.capabilities[ capability ];
-	},
+export function userCan( capability, site ) {
+	return site && site.capabilities && site.capabilities[ capability ];
+}
 
-	/**
-	 * site's timezone getter
-	 *
-	 * @param {Object} site - site object
-	 * @return {String} timezone
-	 */
-	timezone( site ) {
-		return site && site.options ? site.options.timezone : null;
-	},
+/**
+ * site's timezone getter
+ *
+ * @param {Object} site - site object
+ * @return {String} timezone
+ */
+export function timezone( site ) {
+	return site && site.options ? site.options.timezone : null;
+}
 
-	/**
-	 * site's gmt_offset getter
-	 *
-	 * @param {Object} site - site object
-	 * @return {String} gmt_offset
-	 */
-	gmtOffset( site ) {
-		return site && site.options ? site.options.gmt_offset : null;
-	},
+/**
+ * site's gmt_offset getter
+ *
+ * @param {Object} site - site object
+ * @return {String} gmt_offset
+ */
+export function gmtOffset( site ) {
+	return site && site.options ? site.options.gmt_offset : null;
+}
 
-	getSiteFileModDisableReason( site, action = 'modifyFiles' ) {
-		if ( ! site || ! site.options || ! site.options.file_mod_disabled ) {
-			return;
-		}
+export function getSiteFileModDisableReason( site, action = 'modifyFiles' ) {
+	if ( ! site || ! site.options || ! site.options.file_mod_disabled ) {
+		return;
+	}
 
-		return site.options.file_mod_disabled
-			.map( clue => {
-				if (
-					action === 'modifyFiles' ||
-					action === 'autoupdateFiles' ||
-					action === 'autoupdateCore'
-				) {
-					if ( clue === 'has_no_file_system_write_access' ) {
-						return i18n.translate( 'The file permissions on this host prevent editing files.' );
-					}
-					if ( clue === 'disallow_file_mods' ) {
-						return i18n.translate(
-							'File modifications are explicitly disabled by a site administrator.'
-						);
-					}
+	return site.options.file_mod_disabled
+		.map( clue => {
+			if (
+				action === 'modifyFiles' ||
+				action === 'autoupdateFiles' ||
+				action === 'autoupdateCore'
+			) {
+				if ( clue === 'has_no_file_system_write_access' ) {
+					return i18n.translate( 'The file permissions on this host prevent editing files.' );
 				}
-
-				if (
-					( action === 'autoupdateFiles' || action === 'autoupdateCore' ) &&
-					clue === 'automatic_updater_disabled'
-				) {
+				if ( clue === 'disallow_file_mods' ) {
 					return i18n.translate(
-						'Any autoupdates are explicitly disabled by a site administrator.'
+						'File modifications are explicitly disabled by a site administrator.'
 					);
 				}
-
-				if ( action === 'autoupdateCore' && clue === 'wp_auto_update_core_disabled' ) {
-					return i18n.translate(
-						'Core autoupdates are explicitly disabled by a site administrator.'
-					);
-				}
-				return null;
-			} )
-			.filter( reason => reason );
-	},
-
-	canUpdateFiles( site ) {
-		if ( ! site ) {
-			return false;
-		}
-		if ( ! site.hasMinimumJetpackVersion ) {
-			return false;
-		}
-
-		if ( ! this.isMainNetworkSite( site ) ) {
-			return false;
-		}
-
-		const options = site.options;
-
-		if ( options.is_multi_network ) {
-			return false;
-		}
-
-		if (
-			options.file_mod_disabled &&
-			( -1 < options.file_mod_disabled.indexOf( 'disallow_file_mods' ) ||
-				-1 < options.file_mod_disabled.indexOf( 'has_no_file_system_write_access' ) )
-		) {
-			return false;
-		}
-
-		return true;
-	},
-
-	canAutoupdateFiles( site ) {
-		if ( ! this.canUpdateFiles( site ) ) {
-			return false;
-		}
-
-		if (
-			site.options.file_mod_disabled &&
-			-1 < site.options.file_mod_disabled.indexOf( 'automatic_updater_disabled' )
-		) {
-			return false;
-		}
-		return true;
-	},
-
-	isMainNetworkSite( site ) {
-		if ( ! site ) {
-			return false;
-		}
-
-		if ( site.options && site.options.is_multi_network ) {
-			return false;
-		}
-
-		if ( site.is_multisite === false ) {
-			return true;
-		}
-
-		if ( site.is_multisite ) {
-			const unmappedUrl = get( site.options, 'unmapped_url', null );
-			const mainNetworkSite = get( site.options, 'main_network_site', null );
-			if ( ! unmappedUrl || ! mainNetworkSite ) {
-				return false;
 			}
-			// Compare unmapped_url with the main_network_site to see if is the main network site.
-			return ! ( withoutHttp( unmappedUrl ) !== withoutHttp( mainNetworkSite ) );
-		}
 
-		return false;
-	},
+			if (
+				( action === 'autoupdateFiles' || action === 'autoupdateCore' ) &&
+				clue === 'automatic_updater_disabled'
+			) {
+				return i18n.translate( 'Any autoupdates are explicitly disabled by a site administrator.' );
+			}
 
-	/**
-	 * Checks whether a site has a custom mapped URL.
-	 * @param  {Object}   site Site object
-	 * @return {?Boolean}      Whether site has custom domain
-	 */
-	hasCustomDomain( site ) {
-		if ( ! site || ! site.domain || ! site.wpcom_url ) {
+			if ( action === 'autoupdateCore' && clue === 'wp_auto_update_core_disabled' ) {
+				return i18n.translate(
+					'Core autoupdates are explicitly disabled by a site administrator.'
+				);
+			}
 			return null;
+		} )
+		.filter( reason => reason );
+}
+
+export function canUpdateFiles( site ) {
+	if ( ! site ) {
+		return false;
+	}
+	if ( ! site.hasMinimumJetpackVersion ) {
+		return false;
+	}
+
+	if ( ! isMainNetworkSite( site ) ) {
+		return false;
+	}
+
+	const options = site.options;
+
+	if ( options.is_multi_network ) {
+		return false;
+	}
+
+	return ! (
+		options.file_mod_disabled &&
+		( -1 < options.file_mod_disabled.indexOf( 'disallow_file_mods' ) ||
+			-1 < options.file_mod_disabled.indexOf( 'has_no_file_system_write_access' ) )
+	);
+}
+
+export function canAutoupdateFiles( site ) {
+	if ( ! this.canUpdateFiles( site ) ) {
+		return false;
+	}
+
+	return ! (
+		site.options.file_mod_disabled &&
+		-1 < site.options.file_mod_disabled.indexOf( 'automatic_updater_disabled' )
+	);
+}
+
+export function isMainNetworkSite( site ) {
+	if ( ! site ) {
+		return false;
+	}
+
+	if ( site.options && site.options.is_multi_network ) {
+		return false;
+	}
+
+	if ( site.is_multisite === false ) {
+		return true;
+	}
+
+	if ( site.is_multisite ) {
+		const unmappedUrl = get( site.options, 'unmapped_url', null );
+		const mainNetworkSite = get( site.options, 'main_network_site', null );
+		if ( ! unmappedUrl || ! mainNetworkSite ) {
+			return false;
 		}
+		// Compare unmapped_url with the main_network_site to see if is the main network site.
+		return ! ( withoutHttp( unmappedUrl ) !== withoutHttp( mainNetworkSite ) );
+	}
 
-		return site.domain !== site.wpcom_url;
-	},
+	return false;
+}
 
-	isModuleActive( site, moduleId ) {
-		return site.options.active_modules && site.options.active_modules.indexOf( moduleId ) > -1;
-	},
-};
+/**
+ * Checks whether a site has a custom mapped URL.
+ * @param  {Object}   site Site object
+ * @return {?Boolean}      Whether site has custom domain
+ */
+export function hasCustomDomain( site ) {
+	if ( ! site || ! site.domain || ! site.wpcom_url ) {
+		return null;
+	}
+
+	return site.domain !== site.wpcom_url;
+}
+
+export function isModuleActive( site, moduleId ) {
+	return site.options.active_modules && site.options.active_modules.indexOf( moduleId ) > -1;
+}

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -13,7 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 import userFactory from 'lib/user';
-import utils from 'lib/site/utils';
+import { getSiteFileModDisableReason } from 'lib/site/utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import config from 'config';
 const user = userFactory();
@@ -84,7 +82,7 @@ class EnhancedDetails extends Component {
 }
 
 const getTracksDataForAutoconfigHalt = selectedSite => {
-	const reasons = utils.getSiteFileModDisableReason( selectedSite, 'modifyFiles' );
+	const reasons = getSiteFileModDisableReason( selectedSite, 'modifyFiles' );
 
 	if ( reasons && reasons.length > 0 ) {
 		return {

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -17,7 +15,7 @@ import PluginsLog from 'lib/plugins/log-store';
 import PluginAction from 'my-sites/plugins/plugin-action/plugin-action';
 import ExternalLink from 'components/external-link';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
-import utils from 'lib/site/utils';
+import { getSiteFileModDisableReason, isMainNetworkSite } from 'lib/site/utils';
 
 export class PluginAutoUpdateToggle extends Component {
 	toggleAutoUpdates = () => {
@@ -91,7 +89,7 @@ export class PluginAutoUpdateToggle extends Component {
 			);
 		}
 
-		if ( ! utils.isMainNetworkSite( site ) ) {
+		if ( ! isMainNetworkSite( site ) ) {
 			return translate(
 				'Only the main site on a multi-site installation can enable autoupdates for plugins.',
 				{
@@ -101,7 +99,7 @@ export class PluginAutoUpdateToggle extends Component {
 		}
 
 		if ( ! site.canAutoupdateFiles && site.options.file_mod_disabled ) {
-			const reasons = utils.getSiteFileModDisableReason( site, 'autoupdateFiles' );
+			const reasons = getSiteFileModDisableReason( site, 'autoupdateFiles' );
 			const html = [];
 
 			if ( reasons.length > 1 ) {

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
@@ -18,7 +16,7 @@ import PluginsActions from 'lib/plugins/actions';
 import Button from 'components/button';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
-import utils from 'lib/site/utils';
+import { getSiteFileModDisableReason, isMainNetworkSite } from 'lib/site/utils';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import QuerySiteConnectionStatus from 'components/data/query-site-connection-status';
 import { getSiteConnectionStatus } from 'state/selectors';
@@ -104,14 +102,14 @@ export class PluginInstallButton extends Component {
 			);
 		}
 
-		if ( ! utils.isMainNetworkSite( selectedSite ) ) {
+		if ( ! isMainNetworkSite( selectedSite ) ) {
 			return translate( 'Only the main site on a multi-site installation can install plugins.', {
 				args: { site: selectedSite.title },
 			} );
 		}
 
 		if ( ! selectedSite.canUpdateFiles && selectedSite.options.file_mod_disabled ) {
-			const reasons = utils.getSiteFileModDisableReason( selectedSite, 'modifyFiles' );
+			const reasons = getSiteFileModDisableReason( selectedSite, 'modifyFiles' );
 			const html = [];
 
 			if ( reasons.length > 1 ) {

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
@@ -17,7 +15,7 @@ import PluginsLog from 'lib/plugins/log-store';
 import PluginAction from 'my-sites/plugins/plugin-action/plugin-action';
 import PluginsActions from 'lib/plugins/actions';
 import ExternalLink from 'components/external-link';
-import utils from 'lib/site/utils';
+import { getSiteFileModDisableReason, isMainNetworkSite } from 'lib/site/utils';
 
 class PluginRemoveButton extends React.Component {
 	static displayName = 'PluginRemoveButton';
@@ -99,7 +97,7 @@ class PluginRemoveButton extends React.Component {
 			);
 		}
 
-		if ( ! utils.isMainNetworkSite( this.props.site ) ) {
+		if ( ! isMainNetworkSite( this.props.site ) ) {
 			return this.props.translate(
 				'%(pluginName)s cannot be removed because %(site)s is not the main site of the multi-site installation.',
 				{
@@ -112,7 +110,7 @@ class PluginRemoveButton extends React.Component {
 		}
 
 		if ( ! this.props.site.canUpdateFiles && this.props.site.options.file_mod_disabled ) {
-			const reasons = utils.getSiteFileModDisableReason( this.props.site, 'modifyFiles' );
+			const reasons = getSiteFileModDisableReason( this.props.site, 'modifyFiles' );
 			const html = [];
 
 			if ( reasons.length > 1 ) {

--- a/client/post-editor/editor-publish-date/post-scheduler.jsx
+++ b/client/post-editor/editor-publish-date/post-scheduler.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -15,7 +13,7 @@ import { get } from 'lodash';
 import PostSchedule from 'components/post-schedule';
 import QueryPosts from 'components/data/query-posts';
 import postUtils from 'lib/posts/utils';
-import siteUtils from 'lib/site/utils';
+import { timezone } from 'lib/site/utils';
 import { getPostsForQueryIgnoringPage } from 'state/posts/selectors';
 
 const PostScheduleWithOtherPostsIndicated = connect( ( state, { site, query } ) => ( {
@@ -47,7 +45,7 @@ export default class PostScheduler extends PureComponent {
 	};
 
 	getFirstDayOfTheMonth( date ) {
-		const tz = siteUtils.timezone( this.props.site );
+		const tz = timezone( this.props.site );
 
 		return postUtils.getOffsetDate( date, tz ).set( {
 			year: date.year(),


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.