### PR TITLE
esmodules: Update wp/sync-handler/constants

### DIFF
--- a/client/lib/wp/sync-handler/constants.js
+++ b/client/lib/wp/sync-handler/constants.js
@@ -1,6 +1,5 @@
 /** @format */
-export default {
-	RECORDS_LIST_KEY: 'records-list',
-	SYNC_RECORD_NAMESPACE: 'sync-record-',
-	LIFETIME: '2 days',
-};
+
+export const RECORDS_LIST_KEY = 'records-list';
+export const SYNC_RECORD_NAMESPACE = 'sync-record-';
+export const LIFETIME = '2 days';


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.