### PR TITLE
esmodules: Update my-sites/domains/paths

### DIFF
--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -12,7 +12,11 @@ import { translate } from 'i18n-calypso';
 import { getTld } from 'lib/domains';
 import support from 'lib/url/support';
 import { domainAvailability } from 'lib/domains/constants';
-import paths from 'my-sites/domains/paths';
+import {
+	domainManagementTransferToOtherSite,
+	domainManagementTransferIn,
+	domainTransferIn,
+} from 'my-sites/domains/paths';
 
 function getAvailabilityNotice( domain, error, site ) {
 	let message,
@@ -51,7 +55,7 @@ function getAvailabilityNotice( domain, error, site ) {
 						a: (
 							<a
 								rel="noopener noreferrer"
-								href={ paths.domainManagementTransferToOtherSite( site, domain ) }
+								href={ domainManagementTransferToOtherSite( site, domain ) }
 							/>
 						),
 					},
@@ -67,7 +71,7 @@ function getAvailabilityNotice( domain, error, site ) {
 					args: { domain },
 					components: {
 						strong: <strong />,
-						a: <a rel="noopener noreferrer" href={ paths.domainTransferIn( site, domain ) } />,
+						a: <a rel="noopener noreferrer" href={ domainTransferIn( site, domain ) } />,
 					},
 				}
 			);
@@ -100,12 +104,7 @@ function getAvailabilityNotice( domain, error, site ) {
 					args: { domain },
 					components: {
 						strong: <strong />,
-						a: (
-							<a
-								rel="noopener noreferrer"
-								href={ paths.domainManagementTransferIn( site, domain ) }
-							/>
-						),
+						a: <a rel="noopener noreferrer" href={ domainManagementTransferIn( site, domain ) } />,
 					},
 				}
 			);

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { find, get } from 'lodash';
@@ -23,12 +21,11 @@ import Card from 'components/card';
 import ChargebackDetails from './chargeback-details';
 import CheckoutThankYouFeaturesHeader from './features-header';
 import CheckoutThankYouHeader from './header';
-import { domainManagementList } from 'my-sites/domains/paths';
 import DomainMappingDetails from './domain-mapping-details';
 import DomainRegistrationDetails from './domain-registration-details';
 import { fetchReceipt } from 'state/receipts/actions';
 import { fetchSitePlans, refreshSitePlans } from 'state/sites/plans/actions';
-import { getPlansBySite } from 'state/sites/plans/selectors';
+import { getPlansBySite, getSitePlanSlug } from 'state/sites/plans/selectors';
 import { getReceiptById } from 'state/receipts/selectors';
 import { getCurrentUser, getCurrentUserDate } from 'state/current-user/selectors';
 import GoogleAppsDetails from './google-apps-details';
@@ -68,9 +65,8 @@ import RebrandCitiesThankYou from './rebrand-cities-thank-you';
 import SiteRedirectDetails from './site-redirect-details';
 import Notice from 'components/notice';
 import ThankYouCard from 'components/thank-you-card';
-import domainsPaths from 'my-sites/domains/paths';
+import { domainManagementEmail, domainManagementList } from 'my-sites/domains/paths';
 import config from 'config';
-import { getSitePlanSlug } from 'state/sites/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isRebrandCitiesSiteUrl } from 'lib/rebrand-cities';
 import {
@@ -240,13 +236,11 @@ class CheckoutThankYou extends React.Component {
 				purchases.some( isDomainRedemption ) ||
 				purchases.some( isSiteRedirect )
 			) {
-				return page( domainsPaths.domainManagementList( this.props.selectedSite.slug ) );
+				return page( domainManagementList( this.props.selectedSite.slug ) );
 			} else if ( purchases.some( isGoogleApps ) ) {
 				const purchase = find( purchases, isGoogleApps );
 
-				return page(
-					domainsPaths.domainManagementEmail( this.props.selectedSite.slug, purchase.meta )
-				);
+				return page( domainManagementEmail( this.props.selectedSite.slug, purchase.meta ) );
 			}
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/utils.js
+++ b/client/my-sites/checkout/checkout-thank-you/utils.js
@@ -4,12 +4,8 @@
  * Internal dependencies
  */
 
-import paths from 'my-sites/domains/paths';
+import { domainManagementEdit, domainManagementList } from 'my-sites/domains/paths';
 
-function getDomainManagementUrl( { slug }, domain ) {
-	return domain ? paths.domainManagementEdit( slug, domain ) : paths.domainManagementList( slug );
+export function getDomainManagementUrl( { slug }, domain ) {
+	return domain ? domainManagementEdit( slug, domain ) : domainManagementList( slug );
 }
-
-export default {
-	getDomainManagementUrl,
-};

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -20,7 +20,6 @@ import { canCurrentUser, isDomainOnlySite, isEligibleForFreeToPaidUpsell } from 
 import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
 import {
-	isDomainOnlySite,
 	isStarted as isJetpackPluginsStarted,
 	isFinished as isJetpackPluginsFinished,
 } from 'state/plugins/premium/selectors';

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import url from 'url';
@@ -16,12 +14,13 @@ import { localize } from 'i18n-calypso';
 import SidebarBanner from 'my-sites/current-site/sidebar-banner';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import paths from 'my-sites/domains/paths';
+import { domainManagementList } from 'my-sites/domains/paths';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { canCurrentUser, isDomainOnlySite, isEligibleForFreeToPaidUpsell } from 'state/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
 import {
+	isDomainOnlySite,
 	isStarted as isJetpackPluginsStarted,
 	isFinished as isJetpackPluginsFinished,
 } from 'state/plugins/premium/selectors';
@@ -55,7 +54,7 @@ class SiteNotice extends React.Component {
 					components: { a: <a href={ site.URL } /> },
 				} ) }
 			>
-				<NoticeAction href={ paths.domainManagementList( site.domain ) }>
+				<NoticeAction href={ domainManagementList( site.domain ) }>
 					{ translate( 'Edit' ) }
 				</NoticeAction>
 			</Notice>

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import _debug from 'debug';
@@ -22,16 +20,27 @@ import PendingGappsTosNotice from './pending-gapps-tos-notice';
 import purchasesPaths from 'me/purchases/paths';
 import { type as domainTypes, transferStatus } from 'lib/domains/constants';
 import { isSubdomain, hasPendingGoogleAppsUsers } from 'lib/domains';
-import support from 'lib/url/support';
-import paths from 'my-sites/domains/paths';
+import {
+	ALL_ABOUT_DOMAINS,
+	DOMAINS,
+	DOMAIN_HELPER_PREFIX,
+	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS,
+	MAP_EXISTING_DOMAIN_UPDATE_DNS,
+	MAP_SUBDOMAIN,
+} from 'lib/url/support';
+import {
+	domainManagementEdit,
+	domainManagementList,
+	domainManagementTransferIn,
+} from 'my-sites/domains/paths';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
 const debug = _debug( 'calypso:domain-warnings' );
 
 const allAboutDomainsLink = (
-	<a href={ support.ALL_ABOUT_DOMAINS } target="_blank" rel="noopener noreferrer" />
+	<a href={ ALL_ABOUT_DOMAINS } target="_blank" rel="noopener noreferrer" />
 );
-const domainsLink = <a href={ support.DOMAINS } target="_blank" rel="noopener noreferrer" />;
+const domainsLink = <a href={ DOMAINS } target="_blank" rel="noopener noreferrer" />;
 const pNode = <p />;
 
 const expiredDomainsCanManageWarning = 'expired-domains-can-manage';
@@ -162,7 +171,7 @@ export class DomainWarnings extends React.PureComponent {
 						context: 'Notice for mapped subdomain that has CNAME records need to set up',
 					}
 				);
-				learnMoreUrl = support.MAP_SUBDOMAIN;
+				learnMoreUrl = MAP_SUBDOMAIN;
 			} else {
 				text = translate(
 					"{{strong}}%(domainName)s's{{/strong}} name server records should be configured.",
@@ -172,7 +181,7 @@ export class DomainWarnings extends React.PureComponent {
 						context: 'Notice for mapped domain notice with NS records pointing to somewhere else',
 					}
 				);
-				learnMoreUrl = support.DOMAIN_HELPER_PREFIX + domain.name;
+				learnMoreUrl = DOMAIN_HELPER_PREFIX + domain.name;
 			}
 		} else {
 			offendingList = (
@@ -184,12 +193,12 @@ export class DomainWarnings extends React.PureComponent {
 				text = translate( "Some of your domains' CNAME records should be configured.", {
 					context: 'Notice for mapped subdomain that has CNAME records need to set up',
 				} );
-				learnMoreUrl = support.MAP_SUBDOMAIN;
+				learnMoreUrl = MAP_SUBDOMAIN;
 			} else {
 				text = translate( "Some of your domains' name server records should be configured.", {
 					context: 'Mapped domain notice with NS records pointing to somewhere else',
 				} );
-				learnMoreUrl = support.MAP_EXISTING_DOMAIN_UPDATE_DNS;
+				learnMoreUrl = MAP_EXISTING_DOMAIN_UPDATE_DNS;
 			}
 		}
 		const noticeProps = {
@@ -203,7 +212,7 @@ export class DomainWarnings extends React.PureComponent {
 		if ( this.props.isCompact ) {
 			noticeProps.text = translate( 'DNS configuration required' );
 			children = (
-				<NoticeAction href={ paths.domainManagementList( this.props.selectedSite.slug ) }>
+				<NoticeAction href={ domainManagementList( this.props.selectedSite.slug ) }>
 					{ translate( 'Fix' ) }
 				</NoticeAction>
 			);
@@ -569,7 +578,7 @@ export class DomainWarnings extends React.PureComponent {
 					key="unverified-domains-can-manage"
 					text={ this.props.isCompact ? compactMessage : fullMessage }
 				>
-					<NoticeAction href={ paths.domainManagementEdit( this.props.selectedSite.slug, domain ) }>
+					<NoticeAction href={ domainManagementEdit( this.props.selectedSite.slug, domain ) }>
 						{ action }
 					</NoticeAction>
 				</Notice>
@@ -578,7 +587,7 @@ export class DomainWarnings extends React.PureComponent {
 
 		let fullContent, compactContent, compactNoticeText;
 
-		const editLink = name => paths.domainManagementEdit( this.props.selectedSite.slug, name );
+		const editLink = name => domainManagementEdit( this.props.selectedSite.slug, name );
 		if ( severity === 'is-error' ) {
 			fullContent = (
 				<span>
@@ -596,7 +605,7 @@ export class DomainWarnings extends React.PureComponent {
 			);
 			compactNoticeText = translate( 'Issues with your domains.' );
 			compactContent = (
-				<NoticeAction href={ paths.domainManagementList( this.props.selectedSite.slug ) }>
+				<NoticeAction href={ domainManagementList( this.props.selectedSite.slug ) }>
 					{ action }
 				</NoticeAction>
 			);
@@ -615,7 +624,7 @@ export class DomainWarnings extends React.PureComponent {
 			);
 			compactNoticeText = translate( 'Verification required for domains.' );
 			compactContent = (
-				<NoticeAction href={ paths.domainManagementList( this.props.selectedSite.slug ) }>
+				<NoticeAction href={ domainManagementList( this.props.selectedSite.slug ) }>
 					{ action }
 				</NoticeAction>
 			);
@@ -646,7 +655,7 @@ export class DomainWarnings extends React.PureComponent {
 
 		const { translate } = this.props;
 		const compactContent = (
-			<NoticeAction href={ paths.domainManagementList( this.props.selectedSite.slug ) }>
+			<NoticeAction href={ domainManagementList( this.props.selectedSite.slug ) }>
 				{ translate( 'More' ) }
 			</NoticeAction>
 		);
@@ -774,7 +783,7 @@ export class DomainWarnings extends React.PureComponent {
 		let compactMessage = null;
 		let message;
 
-		const domainManagementLink = paths.domainManagementTransferIn(
+		const domainManagementLink = domainManagementTransferIn(
 			this.props.selectedSite.slug,
 			domainInTransfer.name
 		);
@@ -806,7 +815,7 @@ export class DomainWarnings extends React.PureComponent {
 							strong: <strong />,
 							a: (
 								<a
-									href={ support.INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
+									href={ INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
 									rel="noopener noreferrer"
 									target="_blank"
 								/>

--- a/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
+++ b/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
@@ -20,7 +20,7 @@ import FormFooter from 'my-sites/domains/domain-management/components/form-foote
 import FormLabel from 'components/forms/form-label';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import { cartItems } from 'lib/cart-values';
-import paths from 'my-sites/domains/paths';
+import { domainManagementEmail } from 'my-sites/domains/paths';
 import ValidationErrorList from 'notices/validation-error-list';
 import upgradesActions from 'lib/upgrades/actions';
 import { hasGoogleApps, getGoogleAppsSupportedDomains } from 'lib/domains';
@@ -285,9 +285,7 @@ const AddEmailAddressesCard = createReactClass( {
 
 		this.recordEvent( 'cancelClick', this.props.selectedDomainName );
 
-		page(
-			paths.domainManagementEmail( this.props.selectedSite.slug, this.props.selectedDomainName )
-		);
+		page( domainManagementEmail( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	},
 } );
 

--- a/client/my-sites/domains/domain-management/add-google-apps/index.jsx
+++ b/client/my-sites/domains/domain-management/add-google-apps/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import page from 'page';
 import { localize } from 'i18n-calypso';
@@ -14,7 +12,7 @@ import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import Header from 'my-sites/domains/domain-management/components/header';
 import AddEmailAddressesCard from './add-email-addresses-card';
-import paths from 'my-sites/domains/paths';
+import { domainManagementEmail } from 'my-sites/domains/paths';
 import { hasGoogleAppsSupportedDomain } from 'lib/domains';
 import SectionHeader from 'components/section-header';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
@@ -34,7 +32,7 @@ class AddGoogleApps extends React.Component {
 			! hasGoogleAppsSupportedDomain( this.props.domains.list );
 
 		if ( needsRedirect ) {
-			const path = paths.domainManagementEmail(
+			const path = domainManagementEmail(
 				this.props.selectedSite.slug,
 				this.props.selectedDomainName
 			);
@@ -68,7 +66,7 @@ class AddGoogleApps extends React.Component {
 	}
 
 	goToEmail = () => {
-		const path = paths.domainManagementEmail(
+		const path = domainManagementEmail(
 			this.props.selectedSite.slug,
 			this.props.selectedDomainName
 		);

--- a/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
@@ -14,7 +14,10 @@ import { localize } from 'i18n-calypso';
 import CompactCard from 'components/card/compact';
 import ContactDisplay from './contact-display';
 import Notice from 'components/notice';
-import paths from 'my-sites/domains/paths';
+import {
+	domainManagementPrivacyProtection,
+	domainManagementTransferOut,
+} from 'my-sites/domains/paths';
 import SectionHeader from 'components/section-header';
 import support from 'lib/url/support';
 
@@ -103,10 +106,7 @@ class ContactsPrivacyCard extends React.PureComponent {
 								strong: <strong />,
 								a: (
 									<a
-										href={ paths.domainManagementTransferOut(
-											selectedSite.slug,
-											selectedDomainName
-										) }
+										href={ domainManagementTransferOut( selectedSite.slug, selectedDomainName ) }
 									/>
 								),
 							},
@@ -127,7 +127,7 @@ class ContactsPrivacyCard extends React.PureComponent {
 							strong: <strong />,
 							a: (
 								<a
-									href={ paths.domainManagementPrivacyProtection(
+									href={ domainManagementPrivacyProtection(
 										selectedSite.slug,
 										selectedDomainName
 									) }

--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import page from 'page';
@@ -18,7 +16,11 @@ import Header from 'my-sites/domains/domain-management/components/header';
 import Main from 'components/main';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
-import paths from 'my-sites/domains/paths';
+import {
+	domainManagementEdit,
+	domainManagementEditContactInfo,
+	domainManagementPrivacyProtection,
+} from 'my-sites/domains/paths';
 import { getSelectedDomain } from 'lib/domains';
 import { findRegistrantWhois, findPrivacyServiceWhois } from 'lib/domains/whois/utils';
 
@@ -60,7 +62,7 @@ class ContactsPrivacy extends React.PureComponent {
 					/>
 
 					<VerticalNavItem
-						path={ paths.domainManagementEditContactInfo(
+						path={ domainManagementEditContactInfo(
 							this.props.selectedSite.slug,
 							this.props.selectedDomainName
 						) }
@@ -71,7 +73,7 @@ class ContactsPrivacy extends React.PureComponent {
 					{ ! hasPrivacyProtection &&
 						privacyAvailable && (
 							<VerticalNavItem
-								path={ paths.domainManagementPrivacyProtection(
+								path={ domainManagementPrivacyProtection(
 									this.props.selectedSite.slug,
 									this.props.selectedDomainName
 								) }
@@ -89,9 +91,7 @@ class ContactsPrivacy extends React.PureComponent {
 	}
 
 	goToEdit = () => {
-		page(
-			paths.domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName )
-		);
+		page( domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	};
 }
 

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { includes } from 'lodash';
 import page from 'page';
 import React from 'react';
@@ -18,7 +16,20 @@ import DomainManagementData from 'components/data/domain-management';
 import EmailData from 'components/data/domain-management/email';
 import EmailForwardingData from 'components/data/domain-management/email-forwarding';
 import NameserversData from 'components/data/domain-management/nameservers';
-import paths from 'my-sites/domains/paths';
+import {
+	domainManagementAddGoogleApps,
+	domainManagementContactsPrivacy,
+	domainManagementDns,
+	domainManagementEdit,
+	domainManagementEditContactInfo,
+	domainManagementEmail,
+	domainManagementEmailForwarding,
+	domainManagementList,
+	domainManagementNameServers,
+	domainManagementPrimaryDomain,
+	domainManagementPrivacyProtection,
+	domainManagementRedirectSettings,
+} from 'my-sites/domains/paths';
 import ProductsList from 'lib/products-list';
 import SiteRedirectData from 'components/data/domain-management/site-redirect';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -31,7 +42,7 @@ const productsList = new ProductsList();
 
 export default {
 	domainManagementList( pageContext, next ) {
-		analytics.pageView.record( paths.domainManagementList( ':site' ), 'Domain Management' );
+		analytics.pageView.record( domainManagementList( ':site' ), 'Domain Management' );
 
 		pageContext.primary = (
 			<DomainManagementData
@@ -45,7 +56,7 @@ export default {
 
 	domainManagementEdit( pageContext, next ) {
 		analytics.pageView.record(
-			paths.domainManagementEdit( ':site', ':domain' ),
+			domainManagementEdit( ':site', ':domain' ),
 			'Domain Management › Edit'
 		);
 
@@ -65,7 +76,7 @@ export default {
 
 	domainManagementPrimaryDomain: function( pageContext, next ) {
 		analytics.pageView.record(
-			paths.domainManagementPrimaryDomain( ':site', ':domain' ),
+			domainManagementPrimaryDomain( ':site', ':domain' ),
 			'Domain Management › Set Primary Domain'
 		);
 
@@ -77,7 +88,7 @@ export default {
 
 	domainManagementContactsPrivacy( pageContext, next ) {
 		analytics.pageView.record(
-			paths.domainManagementContactsPrivacy( ':site', ':domain' ),
+			domainManagementContactsPrivacy( ':site', ':domain' ),
 			'Domain Management › Contacts and Privacy'
 		);
 
@@ -93,7 +104,7 @@ export default {
 
 	domainManagementEditContactInfo( pageContext, next ) {
 		analytics.pageView.record(
-			paths.domainManagementEditContactInfo( ':site', ':domain' ),
+			domainManagementEditContactInfo( ':site', ':domain' ),
 			'Domain Management › Contacts and Privacy › Edit Contact Info'
 		);
 
@@ -109,7 +120,7 @@ export default {
 
 	domainManagementEmail( pageContext, next ) {
 		analytics.pageView.record(
-			paths.domainManagementEmail( ':site', pageContext.params.domain ? ':domain' : undefined ),
+			domainManagementEmail( ':site', pageContext.params.domain ? ':domain' : undefined ),
 			'Domain Management › Email'
 		);
 
@@ -126,7 +137,7 @@ export default {
 
 	domainManagementEmailForwarding( pageContext, next ) {
 		analytics.pageView.record(
-			paths.domainManagementEmailForwarding( ':site', ':domain' ),
+			domainManagementEmailForwarding( ':site', ':domain' ),
 			'Domain Management › Email › Email Forwarding'
 		);
 
@@ -141,7 +152,7 @@ export default {
 
 	domainManagementDns( pageContext, next ) {
 		analytics.pageView.record(
-			paths.domainManagementDns( ':site', ':domain' ),
+			domainManagementDns( ':site', ':domain' ),
 			'Domain Management › Name Servers and DNS › DNS Records'
 		);
 
@@ -155,7 +166,7 @@ export default {
 	},
 	domainManagementNameServers( pageContext, next ) {
 		analytics.pageView.record(
-			paths.domainManagementNameServers( ':site', ':domain' ),
+			domainManagementNameServers( ':site', ':domain' ),
 			'Domain Management › Name Servers and DNS'
 		);
 
@@ -170,7 +181,7 @@ export default {
 
 	domainManagementPrivacyProtection( pageContext, next ) {
 		analytics.pageView.record(
-			paths.domainManagementPrivacyProtection( ':site', ':domain' ),
+			domainManagementPrivacyProtection( ':site', ':domain' ),
 			'Domain Management › Contacts and Privacy › Privacy Protection'
 		);
 
@@ -186,10 +197,7 @@ export default {
 
 	domainManagementAddGoogleApps( pageContext, next ) {
 		analytics.pageView.record(
-			paths.domainManagementAddGoogleApps(
-				':site',
-				pageContext.params.domain ? ':domain' : undefined
-			),
+			domainManagementAddGoogleApps( ':site', pageContext.params.domain ? ':domain' : undefined ),
 			'Domain Management › Add Google Apps'
 		);
 
@@ -206,7 +214,7 @@ export default {
 
 	domainManagementRedirectSettings( pageContext, next ) {
 		analytics.pageView.record(
-			paths.domainManagementRedirectSettings( ':site', ':domain' ),
+			domainManagementRedirectSettings( ':site', ':domain' ),
 			'Domain Management › Redirect Settings'
 		);
 

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -18,7 +18,7 @@ import DnsList from './dns-list';
 import DomainMainPlaceholder from 'my-sites/domains/domain-management/components/domain/main-placeholder';
 import Header from 'my-sites/domains/domain-management/components/header';
 import Main from 'components/main';
-import paths from 'my-sites/domains/paths';
+import { domainManagementEdit, domainManagementNameServers } from 'my-sites/domains/paths';
 import { getSelectedDomain, isMappedDomain, isRegisteredDomain } from 'lib/domains';
 import Card from 'components/card/compact';
 import SectionHeader from 'components/section-header';
@@ -88,9 +88,9 @@ class Dns extends React.Component {
 		let path;
 
 		if ( isRegisteredDomain( getSelectedDomain( this.props ) ) ) {
-			path = paths.domainManagementNameServers;
+			path = domainManagementNameServers;
 		} else {
-			path = paths.domainManagementEdit;
+			path = domainManagementEdit;
 		}
 
 		page( path( this.props.selectedSite.slug, this.props.selectedDomainName ) );

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -25,7 +25,7 @@ import ValidationErrorList from 'notices/validation-error-list';
 import { forDomainRegistrations as countriesList } from 'lib/countries-list';
 import formState from 'lib/form-state';
 import notices from 'notices';
-import paths from 'my-sites/domains/paths';
+import { domainManagementContactsPrivacy } from 'my-sites/domains/paths';
 import upgradesActions from 'lib/upgrades/actions';
 import wp from 'lib/wp';
 import { successNotice } from 'state/notices/actions';
@@ -476,7 +476,7 @@ class EditContactInfoFormCard extends React.Component {
 
 	goToContactsPrivacy = () => {
 		page(
-			paths.domainManagementContactsPrivacy(
+			domainManagementContactsPrivacy(
 				this.props.selectedSite.slug,
 				this.props.selectedDomain.name
 			)

--- a/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
@@ -20,7 +20,7 @@ import PendingWhoisUpdateCard from './pending-whois-update-card';
 import NonOwnerCard from 'my-sites/domains/domain-management/components/domain/non-owner-card';
 import Header from 'my-sites/domains/domain-management/components/header';
 import Main from 'components/main';
-import paths from 'my-sites/domains/paths';
+import { domainManagementContactsPrivacy } from 'my-sites/domains/paths';
 import { getSelectedDomain } from 'lib/domains';
 import { findRegistrantWhois } from 'lib/domains/whois/utils';
 import SectionHeader from 'components/section-header';
@@ -86,10 +86,7 @@ class EditContactInfo extends React.Component {
 
 	goToContactsPrivacy = () => {
 		page(
-			paths.domainManagementContactsPrivacy(
-				this.props.selectedSite.slug,
-				this.props.selectedDomainName
-			)
+			domainManagementContactsPrivacy( this.props.selectedSite.slug, this.props.selectedDomainName )
 		);
 	};
 }

--- a/client/my-sites/domains/domain-management/edit/card/header/primary-domain-button.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/header/primary-domain-button.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -14,7 +12,7 @@ import page from 'page';
  * Internal dependencies
  */
 import analyticsMixin from 'lib/mixins/analytics';
-import paths from 'my-sites/domains/paths';
+import { domainManagementPrimaryDomain } from 'my-sites/domains/paths';
 import Button from 'components/button';
 
 const PrimaryDomainButton = createReactClass( {
@@ -30,14 +28,12 @@ const PrimaryDomainButton = createReactClass( {
 	handleClick() {
 		this.recordEvent( 'makePrimaryClick', this.props.domain );
 
-		page(
-			paths.domainManagementPrimaryDomain( this.props.selectedSite.slug, this.props.domain.name )
-		);
+		page( domainManagementPrimaryDomain( this.props.selectedSite.slug, this.props.domain.name ) );
 	},
 
 	render() {
 		const domain = this.props.domain;
-		var label;
+		let label;
 
 		if ( domain && ! domain.isPrimary ) {
 			if ( this.props.settingPrimaryDomain ) {

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -17,7 +17,7 @@ import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import MaintenanceCard from 'my-sites/domains/domain-management/components/domain/maintenance-card';
 import MappedDomain from './mapped-domain';
-import paths from 'my-sites/domains/paths';
+import { domainManagementList } from 'my-sites/domains/paths';
 import RegisteredDomain from './registered-domain';
 import { registrar as registrarNames, type as domainTypes } from 'lib/domains/constants';
 import SiteRedirect from './site-redirect';
@@ -86,7 +86,7 @@ class Edit extends React.Component {
 	};
 
 	goToDomainManagement = () => {
-		page( paths.domainManagementList( this.props.selectedSite.slug ) );
+		page( domainManagementList( this.props.selectedSite.slug ) );
 	};
 }
 

--- a/client/my-sites/domains/domain-management/edit/mapped-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/mapped-domain.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
@@ -19,7 +17,7 @@ import SubscriptionSettings from './card/subscription-settings';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
 import DomainWarnings from 'my-sites/domains/components/domain-warnings';
-import paths from 'my-sites/domains/paths';
+import { domainManagementDns, domainManagementEmail } from 'my-sites/domains/paths';
 
 const MappedDomain = createReactClass( {
 	displayName: 'MappedDomain',
@@ -120,16 +118,13 @@ const MappedDomain = createReactClass( {
 	},
 
 	emailNavItem() {
-		const path = paths.domainManagementEmail(
-			this.props.selectedSite.slug,
-			this.props.domain.name
-		);
+		const path = domainManagementEmail( this.props.selectedSite.slug, this.props.domain.name );
 
 		return <VerticalNavItem path={ path }>{ this.props.translate( 'Email' ) }</VerticalNavItem>;
 	},
 
 	dnsRecordsNavItem() {
-		const path = paths.domainManagementDns( this.props.selectedSite.slug, this.props.domain.name );
+		const path = domainManagementDns( this.props.selectedSite.slug, this.props.domain.name );
 
 		return (
 			<VerticalNavItem path={ path }>{ this.props.translate( 'DNS Records' ) }</VerticalNavItem>

--- a/client/my-sites/domains/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/registered-domain.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
@@ -16,7 +14,13 @@ import Card from 'components/card/compact';
 import Notice from 'components/notice';
 import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import Header from './card/header';
-import paths from 'my-sites/domains/paths';
+import {
+	domainManagementContactsPrivacy,
+	domainManagementEmail,
+	domainManagementNameServers,
+	domainManagementTransfer,
+	domainManagementTransferOut,
+} from 'my-sites/domains/paths';
 import Property from './card/property';
 import SubscriptionSettings from './card/subscription-settings';
 import VerticalNav from 'components/vertical-nav';
@@ -77,8 +81,8 @@ const RegisteredDomain = createReactClass( {
 			} = this.props.domain,
 			{ slug } = this.props.selectedSite,
 			{ translate } = this.props,
-			privacyPath = paths.domainManagementContactsPrivacy( slug, name ),
-			transferPath = paths.domainManagementTransferOut( slug, name );
+			privacyPath = domainManagementContactsPrivacy( slug, name ),
+			transferPath = domainManagementTransferOut( slug, name );
 		let label;
 
 		if ( ! privacyAvailable ) {
@@ -167,16 +171,13 @@ const RegisteredDomain = createReactClass( {
 	},
 
 	emailNavItem() {
-		const path = paths.domainManagementEmail(
-			this.props.selectedSite.slug,
-			this.props.domain.name
-		);
+		const path = domainManagementEmail( this.props.selectedSite.slug, this.props.domain.name );
 
 		return <VerticalNavItem path={ path }>{ this.props.translate( 'Email' ) }</VerticalNavItem>;
 	},
 
 	nameServersNavItem() {
-		const path = paths.domainManagementNameServers(
+		const path = domainManagementNameServers(
 			this.props.selectedSite.slug,
 			this.props.domain.name
 		);
@@ -191,7 +192,7 @@ const RegisteredDomain = createReactClass( {
 	contactsPrivacyNavItem() {
 		const { privacyAvailable } = this.props.domain;
 		const { translate } = this.props;
-		const path = paths.domainManagementContactsPrivacy(
+		const path = domainManagementContactsPrivacy(
 			this.props.selectedSite.slug,
 			this.props.domain.name
 		);
@@ -204,10 +205,7 @@ const RegisteredDomain = createReactClass( {
 	},
 
 	transferNavItem() {
-		const path = paths.domainManagementTransfer(
-			this.props.selectedSite.slug,
-			this.props.domain.name
-		);
+		const path = domainManagementTransfer( this.props.selectedSite.slug, this.props.domain.name );
 
 		return (
 			<VerticalNavItem path={ path }>{ this.props.translate( 'Transfer Domain' ) }</VerticalNavItem>

--- a/client/my-sites/domains/domain-management/edit/site-redirect.jsx
+++ b/client/my-sites/domains/domain-management/edit/site-redirect.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
@@ -18,7 +16,7 @@ import Property from './card/property';
 import SubscriptionSettings from './card/subscription-settings';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
-import paths from 'my-sites/domains/paths';
+import { domainManagementRedirectSettings } from 'my-sites/domains/paths';
 
 const SiteRedirect = createReactClass( {
 	displayName: 'SiteRedirect',
@@ -78,7 +76,7 @@ const SiteRedirect = createReactClass( {
 	siteRedirectNavItem() {
 		return (
 			<VerticalNavItem
-				path={ paths.domainManagementRedirectSettings(
+				path={ domainManagementRedirectSettings(
 					this.props.selectedSite.slug,
 					this.props.domain.name
 				) }

--- a/client/my-sites/domains/domain-management/email-forwarding/index.jsx
+++ b/client/my-sites/domains/domain-management/email-forwarding/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -18,7 +16,7 @@ import Header from 'my-sites/domains/domain-management/components/header';
 import EmailForwardingList from './email-forwarding-list';
 import EmailForwardingAddNew from './email-forwarding-add-new';
 import EmailForwardingDetails from './email-forwarding-details';
-import paths from 'my-sites/domains/paths';
+import { domainManagementEmail } from 'my-sites/domains/paths';
 import Card from 'components/card/compact';
 import SectionHeader from 'components/section-header';
 
@@ -63,9 +61,7 @@ class EmailForwarding extends React.Component {
 	};
 
 	goToEditEmail = () => {
-		page(
-			paths.domainManagementEmail( this.props.selectedSite.slug, this.props.selectedDomainName )
-		);
+		page( domainManagementEmail( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	};
 }
 

--- a/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
+++ b/client/my-sites/domains/domain-management/email/add-google-apps-card.jsx
@@ -18,8 +18,8 @@ import { get } from 'lodash';
 import Button from 'components/forms/form-button';
 import CompactCard from 'components/card/compact';
 import config from 'config';
-import paths from 'my-sites/domains/paths';
-import support from 'lib/url/support';
+import { domainManagementAddGoogleApps } from 'my-sites/domains/paths';
+import { ADDING_GOOGLE_APPS_TO_YOUR_SITE } from 'lib/url/support';
 import analyticsMixin from 'lib/mixins/analytics';
 import { getAnnualPrice, getMonthlyPrice } from 'lib/google-apps';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
@@ -38,7 +38,7 @@ const AddGoogleAppsCard = createReactClass( {
 	render() {
 		const { currencyCode, translate } = this.props,
 			price = get( this.props, [ 'products', 'gapps', 'prices', currencyCode ], 0 ),
-			googleAppsSupportUrl = support.ADDING_GOOGLE_APPS_TO_YOUR_SITE,
+			googleAppsSupportUrl = ADDING_GOOGLE_APPS_TO_YOUR_SITE,
 			selectedDomainName = this.props.selectedSite.domain;
 
 		const annualPrice = getAnnualPrice( price, currencyCode );
@@ -216,10 +216,7 @@ const AddGoogleAppsCard = createReactClass( {
 
 	goToAddGoogleApps() {
 		page(
-			paths.domainManagementAddGoogleApps(
-				this.props.selectedSite.slug,
-				this.props.selectedDomainName
-			)
+			domainManagementAddGoogleApps( this.props.selectedSite.slug, this.props.selectedDomainName )
 		);
 	},
 } );

--- a/client/my-sites/domains/domain-management/email/google-apps-users-card.jsx
+++ b/client/my-sites/domains/domain-management/email/google-apps-users-card.jsx
@@ -17,7 +17,7 @@ import CompactCard from 'components/card/compact';
 import Notice from 'components/notice';
 import Button from 'components/button';
 import PendingGappsTosNotice from 'my-sites/domains/components/domain-warnings/pending-gapps-tos-notice';
-import paths from 'my-sites/domains/paths';
+import { domainManagementAddGoogleApps } from 'my-sites/domains/paths';
 import analyticsMixin from 'lib/mixins/analytics';
 import SectionHeader from 'components/section-header';
 import GoogleAppsUserItem from './google-apps-user-item';
@@ -75,7 +75,7 @@ const GoogleAppsUsers = createReactClass( {
 						<Button
 							primary
 							compact
-							href={ paths.domainManagementAddGoogleApps( this.props.selectedSite.slug, domain ) }
+							href={ domainManagementAddGoogleApps( this.props.selectedSite.slug, domain ) }
 							onClick={ this.goToAddGoogleApps }
 						>
 							{ this.props.translate( 'Add G Suite User' ) }

--- a/client/my-sites/domains/domain-management/email/index.jsx
+++ b/client/my-sites/domains/domain-management/email/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import page from 'page';
@@ -22,7 +20,11 @@ import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
 import UpgradesNavigation from 'my-sites/domains/navigation';
 import EmptyContent from 'components/empty-content';
-import paths from 'my-sites/domains/paths';
+import {
+	domainManagementEdit,
+	domainManagementList,
+	domainManagementEmailForwarding,
+} from 'my-sites/domains/paths';
 import { hasGoogleApps, hasGoogleAppsSupportedDomain, getSelectedDomain } from 'lib/domains';
 import { isPlanFeaturesEnabled } from 'lib/plans';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
@@ -100,7 +102,7 @@ class Email extends React.Component {
 				title: translate( 'G Suite is not supported on this domain' ),
 				line: translate( 'Only domains registered with WordPress.com are eligible for G Suite.' ),
 				secondaryAction: translate( 'Add Email Forwarding' ),
-				secondaryActionURL: paths.domainManagementEmailForwarding(
+				secondaryActionURL: domainManagementEmailForwarding(
 					selectedSite.slug,
 					selectedDomainName
 				),
@@ -140,7 +142,7 @@ class Email extends React.Component {
 				{ this.props.selectedDomainName && (
 					<VerticalNav>
 						<VerticalNavItem
-							path={ paths.domainManagementEmailForwarding(
+							path={ domainManagementEmailForwarding(
 								this.props.selectedSite.slug,
 								this.props.selectedDomainName
 							) }
@@ -155,11 +157,9 @@ class Email extends React.Component {
 
 	goToEditOrList = () => {
 		if ( this.props.selectedDomainName ) {
-			page(
-				paths.domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName )
-			);
+			page( domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 		} else {
-			page( paths.domainManagementList( this.props.selectedSite.slug ) );
+			page( domainManagementList( this.props.selectedSite.slug ) );
 		}
 	};
 }

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { connect } from 'react-redux';
 import { find, findIndex, identity, noop, times } from 'lodash';
 import Gridicon from 'gridicons';
@@ -20,7 +18,11 @@ import DomainOnly from './domain-only';
 import ListItem from './item';
 import ListItemPlaceholder from './item-placeholder';
 import Main from 'components/main';
-import paths from 'my-sites/domains/paths';
+import {
+	domainManagementEdit,
+	domainManagementList,
+	domainManagementTransferIn,
+} from 'my-sites/domains/paths';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
 import UpgradesNavigation from 'my-sites/domains/navigation';
@@ -316,7 +318,7 @@ export class List extends React.Component {
 		return new Promise( ( resolve, reject ) => {
 			this.props.setPrimaryDomain( this.props.selectedSite.ID, domainName, ( error, data ) => {
 				if ( ! error && data && data.success ) {
-					page.redirect( paths.domainManagementList( this.props.selectedSite.slug ) );
+					page.redirect( domainManagementList( this.props.selectedSite.slug ) );
 					resolve();
 				} else {
 					reject( error );
@@ -403,9 +405,9 @@ export class List extends React.Component {
 
 	goToEditDomainRoot = domain => {
 		if ( domain.type !== type.TRANSFER ) {
-			page( paths.domainManagementEdit( this.props.selectedSite.slug, domain.name ) );
+			page( domainManagementEdit( this.props.selectedSite.slug, domain.name ) );
 		} else {
-			page( paths.domainManagementTransferIn( this.props.selectedSite.slug, domain.name ) );
+			page( domainManagementTransferIn( this.props.selectedSite.slug, domain.name ) );
 		}
 	};
 }

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import page from 'page';
@@ -20,7 +18,7 @@ import CustomNameserversForm from './custom-nameservers-form';
 import WpcomNameserversToggle from './wpcom-nameservers-toggle';
 import IcannVerificationCard from 'my-sites/domains/domain-management/components/icann-verification/icann-verification-card';
 import DnsTemplates from './dns-templates';
-import paths from 'my-sites/domains/paths';
+import { domainManagementEdit, domainManagementDns } from 'my-sites/domains/paths';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
 import * as upgradesActions from 'lib/upgrades/actions';
@@ -154,9 +152,7 @@ class NameServers extends React.Component {
 	}
 
 	back = () => {
-		page(
-			paths.domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName )
-		);
+		page( domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	};
 
 	customNameservers() {
@@ -215,10 +211,7 @@ class NameServers extends React.Component {
 		return (
 			<VerticalNavItem
 				isPlaceholder={ this.isLoading() }
-				path={ paths.domainManagementDns(
-					this.props.selectedSite.slug,
-					this.props.selectedDomainName
-				) }
+				path={ domainManagementDns( this.props.selectedSite.slug, this.props.selectedDomainName ) }
 			>
 				{ this.props.translate( 'DNS Records' ) }
 			</VerticalNavItem>

--- a/client/my-sites/domains/domain-management/primary-domain/index.jsx
+++ b/client/my-sites/domains/domain-management/primary-domain/index.jsx
@@ -18,7 +18,7 @@ import Card from 'components/card/compact';
 import Header from 'my-sites/domains/domain-management/components/header';
 import Notice from 'components/notice';
 import QuerySiteDomains from 'components/data/query-site-domains';
-import paths from 'my-sites/domains/paths';
+import { domainManagementEdit } from 'my-sites/domains/paths';
 import * as upgradesActions from 'lib/upgrades/actions';
 import { getSelectedDomain } from 'lib/domains';
 import SectionHeader from 'components/section-header';
@@ -40,10 +40,7 @@ class PrimaryDomain extends React.Component {
 	};
 
 	getEditPath() {
-		return paths.domainManagementEdit(
-			this.props.selectedSite.slug,
-			this.props.selectedDomainName
-		);
+		return domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName );
 	}
 
 	goToEditDomainRoot = () => {

--- a/client/my-sites/domains/domain-management/privacy-protection/index.jsx
+++ b/client/my-sites/domains/domain-management/privacy-protection/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -21,7 +19,11 @@ import Header from 'my-sites/domains/domain-management/components/header';
 import { getProductDisplayCost } from 'state/products-list/selectors';
 import { getSelectedDomain } from 'lib/domains';
 import Main from 'components/main';
-import paths from 'my-sites/domains/paths';
+import {
+	domainManagementEdit,
+	domainManagementContactsPrivacy,
+	getSectionName,
+} from 'my-sites/domains/paths';
 import QueryProductsList from 'components/data/query-products-list';
 import { type as domainTypes } from 'lib/domains/constants';
 
@@ -50,7 +52,7 @@ class PrivacyProtection extends Component {
 
 		if ( ! this.canAddPrivacyProtection() ) {
 			page(
-				paths.domainManagementContactsPrivacy(
+				domainManagementContactsPrivacy(
 					this.props.selectedSite.slug,
 					this.props.selectedDomainName
 				)
@@ -96,13 +98,13 @@ class PrivacyProtection extends Component {
 
 	goToPreviousSection = () => {
 		const { prevPath } = this.props.context;
-		const previousSection = paths.getSectionName( prevPath );
+		const previousSection = getSectionName( prevPath );
 		let path;
 
 		if ( previousSection === 'contacts-privacy' ) {
-			path = paths.domainManagementContactsPrivacy;
+			path = domainManagementContactsPrivacy;
 		} else {
-			path = paths.domainManagementEdit;
+			path = domainManagementEdit;
 		}
 
 		page( path( this.props.selectedSite.slug, this.props.selectedDomainName ) );

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
@@ -11,6 +9,7 @@ import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';
 import { trim, trimEnd } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -23,7 +22,7 @@ import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affi
 import Main from 'components/main';
 import Notice from 'components/notice';
 import notices from 'notices';
-import paths from 'my-sites/domains/paths';
+import { domainManagementEdit, domainManagementRedirectSettings } from 'my-sites/domains/paths';
 import * as upgradesActions from 'lib/upgrades/actions';
 import Card from 'components/card/compact';
 import SectionHeader from 'components/section-header';
@@ -82,7 +81,7 @@ class SiteRedirect extends React.Component {
 
 				if ( success ) {
 					page(
-						paths.domainManagementRedirectSettings(
+						domainManagementRedirectSettings(
 							this.props.selectedSite.slug,
 							trim( trimEnd( this.state.redirectUrl, '/' ) )
 						)
@@ -166,7 +165,7 @@ class SiteRedirect extends React.Component {
 		const { selectedDomainName, selectedSite } = this.props;
 
 		this.props.cancelClick( selectedDomainName );
-		page( paths.domainManagementEdit( selectedSite.slug, selectedDomainName ) );
+		page( domainManagementEdit( selectedSite.slug, selectedDomainName ) );
 	};
 }
 

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { connect } from 'react-redux';
 import React from 'react';
 
@@ -16,7 +14,12 @@ import Header from 'my-sites/domains/domain-management/components/header';
 import { isDomainOnlySite, isSiteAutomatedTransfer } from 'state/selectors';
 import { localize } from 'i18n-calypso';
 import Main from 'components/main';
-import paths from 'my-sites/domains/paths';
+import {
+	domainManagementEdit,
+	domainManagementTransferOut,
+	domainManagementTransferToAnotherUser,
+	domainManagementTransferToOtherSite,
+} from 'my-sites/domains/paths';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
 
@@ -28,26 +31,24 @@ function Transfer( props ) {
 		<Main className="domain-management-transfer">
 			<Header
 				selectedDomainName={ selectedDomainName }
-				backHref={ paths.domainManagementEdit( slug, selectedDomainName ) }
+				backHref={ domainManagementEdit( slug, selectedDomainName ) }
 			>
 				{ translate( 'Transfer Domain' ) }
 			</Header>
 			<VerticalNav>
-				<VerticalNavItem path={ paths.domainManagementTransferOut( slug, selectedDomainName ) }>
+				<VerticalNavItem path={ domainManagementTransferOut( slug, selectedDomainName ) }>
 					{ translate( 'Transfer to another registrar' ) }
 				</VerticalNavItem>
 				{ ! isAutomatedTransfer &&
 					! isDomainOnly && (
 						<VerticalNavItem
-							path={ paths.domainManagementTransferToAnotherUser( slug, selectedDomainName ) }
+							path={ domainManagementTransferToAnotherUser( slug, selectedDomainName ) }
 						>
 							{ translate( 'Transfer to another user' ) }
 						</VerticalNavItem>
 					) }
 				{ ! isAutomatedTransfer && (
-					<VerticalNavItem
-						path={ paths.domainManagementTransferToOtherSite( slug, selectedDomainName ) }
-					>
+					<VerticalNavItem path={ domainManagementTransferToOtherSite( slug, selectedDomainName ) }>
 						{ translate( 'Transfer to another WordPress.com site' ) }
 					</VerticalNavItem>
 				) }

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -17,7 +15,7 @@ import DomainMainPlaceholder from 'my-sites/domains/domain-management/components
 import Header from 'my-sites/domains/domain-management/components/header';
 import Main from 'components/main';
 import NonOwnerCard from 'my-sites/domains/domain-management/components/domain/non-owner-card';
-import paths from 'my-sites/domains/paths';
+import { domainManagementTransfer } from 'my-sites/domains/paths';
 import { getSelectedDomain } from 'lib/domains';
 import IcannVerification from './icann-verification.jsx';
 import Locked from './locked.jsx';
@@ -68,9 +66,7 @@ class Transfer extends React.Component {
 	}
 
 	goToEdit = () => {
-		page(
-			paths.domainManagementTransfer( this.props.selectedSite.slug, this.props.selectedDomainName )
-		);
+		page( domainManagementTransfer( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	};
 
 	isDataLoading() {

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -18,12 +16,11 @@ import Card from 'components/card';
 import SiteSelector from 'components/site-selector';
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
-import { getSites } from 'state/selectors';
+import { getSites, isDomainOnlySite } from 'state/selectors';
 import Header from 'my-sites/domains/domain-management/components/header';
 import Main from 'components/main';
-import paths from 'my-sites/domains/paths';
+import { domainManagementList, domainManagementTransfer } from 'my-sites/domains/paths';
 import { getSelectedDomain } from 'lib/domains';
-import { isDomainOnlySite } from 'state/selectors';
 import NonOwnerCard from 'my-sites/domains/domain-management/components/domain/non-owner-card';
 import DomainMainPlaceholder from 'my-sites/domains/domain-management/components/domain/main-placeholder';
 import SectionHeader from 'components/section-header';
@@ -93,9 +90,9 @@ class TransferToOtherSite extends React.Component {
 					if ( this.props.isDomainOnly ) {
 						this.props.requestSites();
 						const transferedTo = find( this.props.sites, { ID: targetSite.ID } );
-						page( paths.domainManagementList( transferedTo.slug ) );
+						page( domainManagementList( transferedTo.slug ) );
 					} else {
-						page( paths.domainManagementList( this.props.selectedSite.slug ) );
+						page( domainManagementList( this.props.selectedSite.slug ) );
 					}
 				},
 				error => {
@@ -124,7 +121,7 @@ class TransferToOtherSite extends React.Component {
 			<Main className="transfer-to-other-site">
 				<Header
 					selectedDomainName={ selectedDomainName }
-					backHref={ paths.domainManagementTransfer( slug, selectedDomainName ) }
+					backHref={ domainManagementTransfer( slug, selectedDomainName ) }
 				>
 					{ this.props.translate( 'Transfer Domain To Another Site' ) }
 				</Header>

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -18,7 +16,7 @@ import Card from 'components/card';
 import { getCurrentUser } from 'state/current-user/selectors';
 import Header from 'my-sites/domains/domain-management/components/header';
 import Main from 'components/main';
-import paths from 'my-sites/domains/paths';
+import { domainManagementEdit, domainManagementTransfer } from 'my-sites/domains/paths';
 import FormSelect from 'components/forms/form-select';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -105,10 +103,7 @@ class TransferOtherUser extends React.Component {
 					this.props.successNotice( successMessage, { duration: 4000, isPersistent: true } );
 					closeDialog();
 					page(
-						paths.domainManagementEdit(
-							this.props.selectedSite.slug,
-							this.props.selectedDomainName
-						)
+						domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName )
 					);
 				},
 				err => {
@@ -152,7 +147,7 @@ class TransferOtherUser extends React.Component {
 			<Main className="transfer-to-other-user">
 				<Header
 					selectedDomainName={ selectedDomainName }
-					backHref={ paths.domainManagementTransfer( slug, selectedDomainName ) }
+					backHref={ domainManagementTransfer( slug, selectedDomainName ) }
 				>
 					{ this.props.translate( 'Transfer Domain To Another User' ) }
 				</Header>

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -12,7 +12,7 @@ import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
 import SiftScience from 'lib/siftscience';
 import config from 'config';
-import paths from './paths';
+import * as paths from './paths';
 import { makeLayout, render as clientRender } from 'controller';
 
 function registerMultiPage( { paths: givenPaths, handlers } ) {

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -19,7 +17,7 @@ import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import { cartItems } from 'lib/cart-values';
 import upgradesActions from 'lib/upgrades/actions';
 import wp from 'lib/wp';
-import paths from 'my-sites/domains/paths';
+import { domainManagementList } from 'my-sites/domains/paths';
 import Notice from 'components/notice';
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import { isSiteUpgradeable } from 'state/selectors';
@@ -56,7 +54,7 @@ export class MapDomain extends Component {
 		}
 
 		if ( selectedSite.is_vip ) {
-			page( paths.domainManagementList( selectedSiteSlug ) );
+			page( domainManagementList( selectedSiteSlug ) );
 			return;
 		}
 
@@ -88,7 +86,7 @@ export class MapDomain extends Component {
 			wpcom
 				.addVipDomainMapping( selectedSite.ID, domain )
 				.then(
-					() => page( paths.domainManagementList( selectedSiteSlug ) ),
+					() => page( domainManagementList( selectedSiteSlug ) ),
 					error => this.setState( { errorMessage: error.message } )
 				);
 			return;

--- a/client/my-sites/domains/map-domain/test/map-domain.js
+++ b/client/my-sites/domains/map-domain/test/map-domain.js
@@ -2,7 +2,6 @@
  * @format
  * @jest-environment jsdom
  */
-
 /**
  * External dependencies
  */
@@ -17,7 +16,7 @@ import React from 'react';
 import { MapDomain } from '..';
 import MapDomainStep from 'components/domains/map-domain-step';
 import HeaderCake from 'components/header-cake';
-import paths from 'my-sites/domains/paths';
+import { domainManagementList } from 'my-sites/domains/paths';
 
 jest.mock( 'lib/user', () => () => {} );
 jest.mock( 'page', () => {
@@ -90,7 +89,7 @@ describe( 'MapDomain component', () => {
 			/>
 		);
 		wrapper.instance().goBack();
-		expect( pageSpy ).to.have.been.calledWith( paths.domainManagementList( 'baba' ) );
+		expect( pageSpy ).to.have.been.calledWith( domainManagementList( 'baba' ) );
 	} );
 
 	test( 'goes back to domain add page if non-VIP site', () => {

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -3,18 +3,17 @@
 /**
  * External dependencies
  */
-
 import { filter, startsWith } from 'lodash';
 
-function domainManagementRoot() {
+export function domainManagementRoot() {
 	return '/domains/manage';
 }
 
-function domainManagementList( siteName ) {
+export function domainManagementList( siteName ) {
 	return domainManagementRoot() + '/' + siteName;
 }
 
-function domainManagementEdit( siteName, domainName, slug ) {
+export function domainManagementEdit( siteName, domainName, slug ) {
 	slug = slug || 'edit';
 
 	// Encodes only real domain names and not parameter placeholders
@@ -27,7 +26,7 @@ function domainManagementEdit( siteName, domainName, slug ) {
 	return domainManagementRoot() + '/' + domainName + '/' + slug + '/' + siteName;
 }
 
-function domainManagementAddGoogleApps( siteName, domainName ) {
+export function domainManagementAddGoogleApps( siteName, domainName ) {
 	let path;
 
 	if ( domainName ) {
@@ -39,15 +38,15 @@ function domainManagementAddGoogleApps( siteName, domainName ) {
 	return path;
 }
 
-function domainManagementContactsPrivacy( siteName, domainName ) {
+export function domainManagementContactsPrivacy( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'contacts-privacy' );
 }
 
-function domainManagementEditContactInfo( siteName, domainName ) {
+export function domainManagementEditContactInfo( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'edit-contact-info' );
 }
 
-function domainManagementEmail( siteName, domainName ) {
+export function domainManagementEmail( siteName, domainName ) {
 	let path;
 
 	if ( domainName ) {
@@ -61,31 +60,31 @@ function domainManagementEmail( siteName, domainName ) {
 	return path;
 }
 
-function domainManagementEmailForwarding( siteName, domainName ) {
+export function domainManagementEmailForwarding( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'email-forwarding' );
 }
 
-function domainManagementNameServers( siteName, domainName ) {
+export function domainManagementNameServers( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'name-servers' );
 }
 
-function domainManagementDns( siteName, domainName ) {
+export function domainManagementDns( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'dns' );
 }
 
-function domainManagementPrivacyProtection( siteName, domainName ) {
+export function domainManagementPrivacyProtection( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'privacy-protection' );
 }
 
-function domainManagementRedirectSettings( siteName, domainName ) {
+export function domainManagementRedirectSettings( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'redirect-settings' );
 }
 
-function domainManagementPrimaryDomain( siteName, domainName ) {
+export function domainManagementPrimaryDomain( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'primary-domain' );
 }
 
-function domainManagementTransfer( siteName, domainName, transferType = '' ) {
+export function domainManagementTransfer( siteName, domainName, transferType = '' ) {
 	return domainManagementEdit(
 		siteName,
 		domainName,
@@ -93,23 +92,23 @@ function domainManagementTransfer( siteName, domainName, transferType = '' ) {
 	);
 }
 
-function domainManagementTransferIn( siteName, domainName ) {
+export function domainManagementTransferIn( siteName, domainName ) {
 	return domainManagementTransfer( siteName, domainName, 'in' );
 }
 
-function domainManagementTransferOut( siteName, domainName ) {
+export function domainManagementTransferOut( siteName, domainName ) {
 	return domainManagementTransfer( siteName, domainName, 'out' );
 }
 
-function domainManagementTransferToAnotherUser( siteName, domainName ) {
+export function domainManagementTransferToAnotherUser( siteName, domainName ) {
 	return domainManagementTransfer( siteName, domainName, 'other-user' );
 }
 
-function domainManagementTransferToOtherSite( siteName, domainName ) {
+export function domainManagementTransferToOtherSite( siteName, domainName ) {
 	return domainManagementTransfer( siteName, domainName, 'other-site' );
 }
 
-function domainTransferIn( siteName, domain ) {
+export function domainTransferIn( siteName, domain ) {
 	let path = `/domains/add/transfer/${ siteName }`;
 	if ( domain ) {
 		path += `?initialQuery=${ domain }`;
@@ -118,32 +117,9 @@ function domainTransferIn( siteName, domain ) {
 	return path;
 }
 
-function getSectionName( pathname ) {
+export function getSectionName( pathname ) {
 	const regExp = new RegExp( '^' + domainManagementRoot() + '/[^/]+/([^/]+)', 'g' );
 	const matches = regExp.exec( pathname );
 
 	return matches ? matches[ 1 ] : null;
 }
-
-export default {
-	domainManagementAddGoogleApps,
-	domainManagementContactsPrivacy,
-	domainManagementDns,
-	domainManagementEdit,
-	domainManagementEditContactInfo,
-	domainManagementEmail,
-	domainManagementEmailForwarding,
-	domainManagementList,
-	domainManagementNameServers,
-	domainManagementPrimaryDomain,
-	domainManagementPrivacyProtection,
-	domainManagementRedirectSettings,
-	domainManagementRoot,
-	domainManagementTransfer,
-	domainManagementTransferIn,
-	domainManagementTransferOut,
-	domainManagementTransferToAnotherUser,
-	domainManagementTransferToOtherSite,
-	domainTransferIn,
-	getSectionName,
-};


### PR DESCRIPTION
@depends on #21137
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.