### PR TITLE
Me: Update ProfileLinks to use React.Component

### DIFF
--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -3,9 +3,7 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
@@ -24,51 +22,47 @@ import ProfileLinksAddOther from 'me/profile-links-add-other';
 import { deleteUserProfileLink, resetUserProfileLinkErrors } from 'state/profile-links/actions';
 import { getProfileLinks, getProfileLinksErrorType } from 'state/selectors';
 
-const ProfileLinks = createReactClass( {
-	displayName: 'ProfileLinks',
+class ProfileLinks extends React.Component {
+	state = {
+		showingForm: false,
+		showPopoverMenu: false,
+	};
 
-	getInitialState() {
-		return {
-			showingForm: false,
-			showPopoverMenu: false,
-		};
-	},
-
-	showAddWordPress() {
+	showAddWordPress = () => {
 		this.setState( {
 			showingForm: 'wordpress',
 			showPopoverMenu: false,
 		} );
-	},
+	};
 
-	showAddOther() {
+	showAddOther = () => {
 		this.setState( {
 			showingForm: 'other',
 			showPopoverMenu: false,
 		} );
-	},
+	};
 
-	showPopoverMenu() {
+	showPopoverMenu = () => {
 		this.setState( {
 			showPopoverMenu: ! this.state.showPopoverMenu,
 		} );
-	},
+	};
 
-	closePopoverMenu() {
+	closePopoverMenu = () => {
 		this.setState( {
 			showPopoverMenu: false,
 		} );
-	},
+	};
 
-	hideForms() {
+	hideForms = () => {
 		this.setState( {
 			showingForm: false,
 		} );
-	},
+	};
 
-	onRemoveLink( profileLink ) {
+	onRemoveLink = profileLink => {
 		return () => this.props.deleteUserProfileLink( profileLink.link_slug );
-	},
+	};
 
 	getErrorMessage() {
 		const { errorType, translate } = this.props;
@@ -81,7 +75,7 @@ const ProfileLinks = createReactClass( {
 			return translate( 'That link is already in your profile links. No changes were made.' );
 		}
 		return translate( 'An unexpected error occurred. Please try again later.' );
-	},
+	}
 
 	possiblyRenderError() {
 		const errorMessage = this.getErrorMessage();
@@ -98,7 +92,7 @@ const ProfileLinks = createReactClass( {
 				{ errorMessage }
 			</Notice>
 		);
-	},
+	}
 
 	renderProfileLinksList() {
 		return (
@@ -114,7 +108,7 @@ const ProfileLinks = createReactClass( {
 				) ) }
 			</ul>
 		);
-	},
+	}
 
 	renderNoProfileLinks() {
 		return (
@@ -124,7 +118,7 @@ const ProfileLinks = createReactClass( {
 				) }
 			</p>
 		);
-	},
+	}
 
 	renderPlaceholders() {
 		return (
@@ -140,7 +134,7 @@ const ProfileLinks = createReactClass( {
 				) ) }
 			</ul>
 		);
-	},
+	}
 
 	renderProfileLinks() {
 		const initialized = this.props.profileLinks !== null;
@@ -161,7 +155,7 @@ const ProfileLinks = createReactClass( {
 				{ links }
 			</div>
 		);
-	},
+	}
 
 	renderForm() {
 		if ( 'wordpress' === this.state.showingForm ) {
@@ -169,7 +163,7 @@ const ProfileLinks = createReactClass( {
 		}
 
 		return <ProfileLinksAddOther onSuccess={ this.hideForms } onCancel={ this.hideForms } />;
-	},
+	}
 
 	render() {
 		return (
@@ -188,8 +182,8 @@ const ProfileLinks = createReactClass( {
 				<Card>{ !! this.state.showingForm ? this.renderForm() : this.renderProfileLinks() }</Card>
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default connect(
 	state => ( {


### PR DESCRIPTION
In #20994 we updated profile links to use Redux instead of the legacy user profile links store. This removed the last mixins that `ProfileLinks` was using, so this PR updates it to use `React.Component` instead of `createReactClass`. There should be no visual/behavioral changes.

Part of #20241.

To test:
* Checkout this branch
* Go to `/me` and verify the following works properly:
  * Clicking the "Add" button to reveal the popover menu.
  * Clicking the "Add WordPress Site" item from the popover menu.
  * Clicking the "Add URL" item from the popover menu.
  * Clicking the "Cancel" button to go back from the site addition form. 
  * Clicking somewhere outside of the popover menu to close it.
  * Removing a link.
  * Rendering the section with no links.
  * Rendering the section with one or more links.
* Verify all of user profile links section works as expected.