### PR TITLE
esmodules: Update lib/viewport

### DIFF
--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -23,7 +23,7 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
 import FormFieldset from 'components/forms/form-fieldset';
-import viewport from 'lib/viewport';
+import { isMobile } from 'lib/viewport';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
 import { getTerms } from 'state/terms/selectors';
@@ -329,7 +329,7 @@ class TermFormDialog extends Component {
 				<FormSectionHeading>{ isNew ? labels.add_new_item : labels.edit_item }</FormSectionHeading>
 				<FormFieldset>
 					<FormTextInput
-						autoFocus={ showDialog && ! viewport.isMobile() }
+						autoFocus={ showDialog && ! isMobile() }
 						placeholder={ labels.new_item_name }
 						ref="termName"
 						isError={ isError }

--- a/client/boot/project/wordpress-com.js
+++ b/client/boot/project/wordpress-com.js
@@ -28,7 +28,7 @@ import superProps from 'lib/analytics/super-props';
 import translatorJumpstart from 'lib/translator-jumpstart';
 import nuxWelcome from 'layout/nux-welcome';
 import emailVerification from 'components/email-verification';
-import viewport from 'lib/viewport';
+import { isDesktop } from 'lib/viewport';
 import { init as pushNotificationsInit } from 'state/push-notifications/actions';
 import { pruneStaleRecords } from 'lib/wp/sync-handler';
 import { setReduxStore as setSupportUserReduxStore } from 'lib/user/support-user-interop';
@@ -163,7 +163,7 @@ export function setupMiddlewares( currentUser, reduxStore ) {
 			context.pathname.indexOf( '/me/next' ) === -1
 		) {
 			// show welcome message, persistent for full sized screens
-			nuxWelcome.setWelcome( viewport.isDesktop() );
+			nuxWelcome.setWelcome( isDesktop() );
 		} else {
 			nuxWelcome.clearTempWelcome();
 		}

--- a/client/components/forms/form-password-input/index.jsx
+++ b/client/components/forms/form-password-input/index.jsx
@@ -13,7 +13,7 @@ import { omit } from 'lodash';
  * Internal dependencies
  */
 import FormTextInput from 'components/forms/form-text-input';
-import viewport from 'lib/viewport';
+import { isMobile } from 'lib/viewport';
 
 export default class extends React.Component {
 	static displayName = 'FormPasswordInput';
@@ -23,9 +23,7 @@ export default class extends React.Component {
 	};
 
 	componentDidMount() {
-		var isMobile = viewport.isMobile();
-
-		if ( isMobile ) {
+		if ( isMobile() ) {
 			this.state = { hidePassword: false };
 			return;
 		} else {

--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -16,7 +16,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import viewport from 'lib/viewport';
+import { isMobile } from 'lib/viewport';
 import { getHappychatAuth } from 'state/happychat/utils';
 import hasUnreadMessages from 'state/happychat/selectors/has-unread-messages';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
@@ -54,7 +54,7 @@ export class HappychatButton extends Component {
 	};
 
 	onClick = event => {
-		if ( this.props.allowMobileRedirect && viewport.isMobile() ) {
+		if ( this.props.allowMobileRedirect && isMobile() ) {
 			// For mobile clients, happychat will always use the
 			// page componet instead of the sidebar
 			page( '/me/chat' );

--- a/client/components/header-cake/back.jsx
+++ b/client/components/header-cake/back.jsx
@@ -15,7 +15,7 @@ import { throttle } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
-import viewport from 'lib/viewport';
+import { getWindowInnerWidth } from 'lib/viewport';
 
 /**
  * Module variables
@@ -41,7 +41,7 @@ class HeaderCakeBack extends Component {
 	};
 
 	state = {
-		windowWidth: viewport.getWindowInnerWidth(),
+		windowWidth: getWindowInnerWidth(),
 	};
 
 	componentDidMount() {
@@ -55,7 +55,7 @@ class HeaderCakeBack extends Component {
 
 	handleWindowResize = () => {
 		this.setState( {
-			windowWidth: viewport.getWindowInnerWidth(),
+			windowWidth: getWindowInnerWidth(),
 		} );
 	};
 

--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -17,7 +17,7 @@ import ControlItem from 'components/segmented-control/item';
 import InfoPopover from 'components/info-popover';
 import { getSiteSetting } from 'state/selectors';
 import SegmentedControl from 'components/segmented-control';
-import viewport from 'lib/viewport';
+import { isMobile } from 'lib/viewport';
 
 /**
  * Local dependencies
@@ -153,7 +153,7 @@ class PostScheduleClock extends Component {
 			return;
 		}
 
-		const popoverPosition = viewport.isMobile() ? 'top' : 'right';
+		const popoverPosition = isMobile() ? 'top' : 'right';
 		const timezoneText = timezone
 			? `${ timezone.replace( /\_/gi, ' ' ) } ${ tzDateOffset }`
 			: `UTC${ convertHoursToHHMM( gmtOffset ) }`;

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -15,7 +15,7 @@ import { debounce } from 'lodash';
  */
 import DropdownItem from 'components/select-dropdown/item';
 import SelectDropdown from 'components/select-dropdown';
-import viewport from 'lib/viewport';
+import { getWindowInnerWidth } from 'lib/viewport';
 import afterLayoutFlush from 'lib/after-layout-flush';
 
 /**
@@ -71,7 +71,7 @@ class NavTabs extends Component {
 			'has-siblings': this.props.hasSiblingControls,
 		} );
 
-		const innerWidth = viewport.getWindowInnerWidth();
+		const innerWidth = getWindowInnerWidth();
 
 		return (
 			<div className="section-nav-group" ref="navGroup">

--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -13,7 +13,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import viewport from 'lib/viewport';
+import { isMobile } from 'lib/viewport';
 
 export default class extends React.Component {
 	static displayName = 'StickyPanel';
@@ -65,7 +65,7 @@ export default class extends React.Component {
 
 		if (
 			( this.props.minLimit !== false && this.props.minLimit >= window.innerWidth ) ||
-			viewport.isMobile()
+			isMobile()
 		) {
 			return this.setState( { isSticky: false } );
 		}

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -87,7 +87,7 @@ import userFactory from 'lib/user';
 
 const user = userFactory();
 import i18n from './i18n';
-import viewport from 'lib/viewport';
+import { isMobile } from 'lib/viewport';
 import config from 'config';
 import { decodeEntities, wpautop, removep } from 'lib/formatting';
 
@@ -319,7 +319,7 @@ export default class extends React.Component {
 			// minus the surrounding editor chrome to avoid scrollbars. In the
 			// future, we should calculate from the rendered editor bounds.
 			autoresize_min_height: Math.max( document.documentElement.clientHeight - 300, 300 ),
-			autoresize_bottom_margin: viewport.isMobile() ? 10 : 50,
+			autoresize_bottom_margin: isMobile() ? 10 : 50,
 
 			toolbar1: `wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,${ ltrButton }wpcom_advanced`,
 			toolbar2:

--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -12,7 +12,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Popover from 'components/popover';
-import viewport from 'lib/viewport';
+import { isMobile } from 'lib/viewport';
 
 /**
  * Module variables
@@ -39,7 +39,7 @@ class Tooltip extends Component {
 	};
 
 	render() {
-		if ( ! this.props.showOnMobile && viewport.isMobile() ) {
+		if ( ! this.props.showOnMobile && isMobile() ) {
 			return null;
 		}
 

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -9,7 +9,7 @@ import { startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
-import viewport from 'lib/viewport';
+import { isMobile } from 'lib/viewport';
 import scrollTo from 'lib/scroll-to';
 
 const DIALOG_WIDTH = 410;
@@ -151,7 +151,7 @@ export function getStepPosition( {
 }
 
 export function getScrollableSidebar() {
-	if ( viewport.isMobile() ) {
+	if ( isMobile() ) {
 		return query( '#secondary .sidebar' )[ 0 ];
 	}
 	return query( '#secondary .sidebar .sidebar__region' )[ 0 ];
@@ -160,20 +160,18 @@ export function getScrollableSidebar() {
 function validatePlacement( placement, target ) {
 	const targetSlug = target && target.dataset && target.dataset.tipTarget;
 
-	if ( targetSlug === 'sidebar' && viewport.isMobile() ) {
+	if ( targetSlug === 'sidebar' && isMobile() ) {
 		return 'middle';
 	}
 
-	return target && placement !== 'center' && viewport.isMobile() ? 'below' : placement;
+	return target && placement !== 'center' && isMobile() ? 'below' : placement;
 }
 
 function scrollIntoView( target, scrollContainer ) {
 	// TODO(lsinger): consider replacing with http://yiminghe.me/dom-scroll-into-view/
 	const container = scrollContainer || getScrollableSidebar();
 	const { top, bottom } = target.getBoundingClientRect();
-	const clientHeight = viewport.isMobile()
-		? document.documentElement.clientHeight
-		: container.clientHeight;
+	const clientHeight = isMobile() ? document.documentElement.clientHeight : container.clientHeight;
 
 	if ( bottom + DIALOG_PADDING + DIALOG_HEIGHT <= clientHeight ) {
 		return 0;

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -16,7 +16,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import MasterbarItem from './item';
 import SitesPopover from 'components/sites-popover';
 import paths from 'lib/paths';
-import viewport from 'lib/viewport';
+import { isMobile } from 'lib/viewport';
 import { preload } from 'sections-preload';
 import { getSelectedSite } from 'state/ui/selectors';
 import AsyncLoad from 'components/async-load';
@@ -57,7 +57,7 @@ class MasterbarItemNew extends React.Component {
 	};
 
 	getPopoverPosition = () => {
-		if ( viewport.isMobile() ) {
+		if ( isMobile() ) {
 			return 'bottom';
 		}
 

--- a/client/lib/viewport/index.js
+++ b/client/lib/viewport/index.js
@@ -28,7 +28,7 @@
 //
 // [1] https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/css.md#media-queries
 //
-function isWithinBreakpoint( breakpoint ) {
+export function isWithinBreakpoint( breakpoint ) {
 	var screenWidth = getWindowInnerWidth(),
 		breakpoints = {
 			'<480px': () => screenWidth <= 480,
@@ -54,23 +54,16 @@ function isWithinBreakpoint( breakpoint ) {
 	return breakpoints[ breakpoint ]();
 }
 
-function isMobile() {
+export function isMobile() {
 	return isWithinBreakpoint( '<480px' );
 }
 
-function isDesktop() {
+export function isDesktop() {
 	return isWithinBreakpoint( '>960px' );
 }
 
 // FIXME: We can't detect window size on the server, so until we have more intelligent detection,
 // use 769, which is just above the general maximum mobile screen width.
-function getWindowInnerWidth() {
+export function getWindowInnerWidth() {
 	return global.window ? global.window.innerWidth : 769;
 }
-
-export default {
-	isMobile: isMobile,
-	isDesktop: isDesktop,
-	isWithinBreakpoint: isWithinBreakpoint,
-	getWindowInnerWidth: getWindowInnerWidth,
-};

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -12,7 +12,7 @@ import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
 import SiftScience from 'lib/siftscience';
 import config from 'config';
-import paths from './paths';
+import * as paths from './paths';
 import { makeLayout, render as clientRender } from 'controller';
 
 function registerMultiPage( { paths: givenPaths, handlers } ) {

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -12,7 +12,7 @@ import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
 import SiftScience from 'lib/siftscience';
 import config from 'config';
-import * as paths from './paths';
+import paths from './paths';
 import { makeLayout, render as clientRender } from 'controller';
 
 function registerMultiPage( { paths: givenPaths, handlers } ) {

--- a/client/my-sites/domains/navigation.jsx
+++ b/client/my-sites/domains/navigation.jsx
@@ -18,7 +18,7 @@ import { sectionify } from 'lib/route/path';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
-import viewport from 'lib/viewport';
+import { isMobile } from 'lib/viewport';
 import { action as upgradesActionTypes } from 'lib/upgrades/constants';
 import PopoverCart from 'my-sites/checkout/cart/popover-cart';
 import { isATEnabled } from 'lib/automated-transfer';
@@ -86,7 +86,7 @@ class PlansNavigation extends React.Component {
 
 		return (
 			<SectionNav
-				hasPinnedItems={ viewport.isMobile() }
+				hasPinnedItems={ isMobile() }
 				selectedText={ sectionTitle }
 				onMobileNavPanelOpen={ this.onMobileNavPanelOpen }
 			>
@@ -157,7 +157,7 @@ class PlansNavigation extends React.Component {
 				cart={ this.props.cart }
 				selectedSite={ this.props.selectedSite }
 				onToggle={ this.toggleCartVisibility }
-				pinned={ viewport.isMobile() }
+				pinned={ isMobile() }
 				visible={ this.state.cartVisible }
 				showKeepSearching={ this.state.cartShowKeepSearching }
 				onKeepSearchingClick={ this.onKeepSearchingClick }

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -11,7 +11,7 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import InfoPopover from 'components/info-popover';
-import viewport from 'lib/viewport';
+import { isMobile } from 'lib/viewport';
 
 export default function PlanFeaturesItem( { children, description, hideInfoPopover } ) {
 	return (
@@ -21,7 +21,7 @@ export default function PlanFeaturesItem( { children, description, hideInfoPopov
 			{ hideInfoPopover ? null : (
 				<InfoPopover
 					className="plan-features__item-tip-info"
-					position={ viewport.isMobile() ? 'top' : 'right' }
+					position={ isMobile() ? 'top' : 'right' }
 				>
 					{ description }
 				</InfoPopover>

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -33,7 +33,7 @@ import observe from 'lib/mixins/data-observe';
 import ReaderListsStore from 'lib/reader-lists/lists';
 import userSettings from 'lib/user-settings';
 import userUtils from 'lib/user/utils';
-import viewport from 'lib/viewport';
+import { isMobile } from 'lib/viewport';
 import { isDiscoverEnabled } from 'reader/discover/helper';
 import { isAutomatticTeamMember } from 'reader/lib/teams';
 import { getTagStreamUrl } from 'reader/route';
@@ -317,7 +317,7 @@ export const shouldRenderAppPromo = ( options = {} ) => {
 	const haveUserSettingsLoaded = userSettings.getSetting( ' is_desktop_app_user' ) === null;
 	const {
 		isDesktopPromoDisabled = store.get( 'desktop_promo_disabled' ),
-		isViewportMobile = viewport.isMobile(),
+		isViewportMobile = isMobile(),
 		isUserLocaleEnglish = 'en' === userUtils.getLocaleSlug(),
 		isDesktopPromoConfiguredToRun = config.isEnabled( 'desktop-promo' ),
 		isUserDesktopAppUser = haveUserSettingsLoaded ||


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.