### PR TITLE
Me: Update AddProfileLinksButtons to use React.Component

### DIFF
--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -5,50 +5,47 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import createReactClass from 'create-react-class';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
-// Internal dependencies
+/**
+ * Internal dependencies
+ */
 import Button from 'components/button';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-const AddProfileLinksButtons = createReactClass( {
-	displayName: 'AddProfileLinksButtons',
-
-	propTypes: {
+class AddProfileLinksButtons extends React.Component {
+	static propTypes = {
 		showingForm: PropTypes.bool,
 		showPopoverMenu: PropTypes.bool,
-	},
+	};
 
-	getDefaultProps() {
-		return {
-			showingForm: false,
-		};
-	},
+	static defaultProps = {
+		showingForm: false,
+	};
 
-	getInitialState() {
-		return {
-			popoverPosition: 'top',
-		};
-	},
+	state = {
+		popoverPosition: 'top',
+	};
 
-	recordClickEvent( action ) {
+	recordClickEvent = action => {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
-	},
+	};
 
-	handleAddWordPressSiteButtonClick() {
+	handleAddWordPressSiteButtonClick = () => {
 		this.recordClickEvent( 'Add a WordPress Site Button' );
 		this.props.onShowAddWordPress();
-	},
+	};
 
-	handleOtherSiteButtonClick() {
+	handleOtherSiteButtonClick = () => {
 		this.recordClickEvent( 'Add Other Site Button' );
 		this.props.onShowAddOther();
-	},
+	};
+
+	setPopoverContext = button => ( this.popoverMenuButton = button );
 
 	render() {
 		return (
@@ -57,7 +54,7 @@ const AddProfileLinksButtons = createReactClass( {
 					isVisible={ this.props.showPopoverMenu }
 					onClose={ this.props.onClosePopoverMenu }
 					position={ this.state.popoverPosition }
-					context={ this.refs && this.refs.popoverMenuButton }
+					context={ this.popoverMenuButton }
 				>
 					<PopoverMenuItem onClick={ this.handleAddWordPressSiteButtonClick }>
 						{ this.props.translate( 'Add WordPress Site' ) }
@@ -69,7 +66,7 @@ const AddProfileLinksButtons = createReactClass( {
 
 				<Button
 					compact
-					ref="popoverMenuButton"
+					ref={ this.setPopoverContext }
 					className="popover-icon"
 					onClick={ this.props.onShowPopoverMenu }
 				>
@@ -78,8 +75,8 @@ const AddProfileLinksButtons = createReactClass( {
 				</Button>
 			</div>
 		);
-	},
-} );
+	}
+}
 
 export default connect( null, {
 	recordGoogleEvent,


### PR DESCRIPTION
In #20994 we updated profile links to use Redux instead of the legacy user profile links store. This removed the last mixins that `AddProfileLinksButtons` was using, so this PR updates it to use `React.Component` instead of `createReactClass`. There should be no visual/behavioral changes.

Part of #20241.

To test:
* Checkout this branch
* Go to `/me` and verify the following works properly:
  * Clicking the "Add" button to reveal the popover menu.
  * Clicking somewhere outside of the popover menu closes the menu.
  * Clicking the "Add" button when the popover is open closes the menu.
  * Clicking the "Add WordPress Site" item from the popover menu reveals the list of WP sites.
  * Clicking the "Add URL" item from the popover menu reveals the custom URL form.
* Verify all of user profile links section works as expected.