### PR TITLE
Jetpack Onboarding: Save site type selection

### DIFF
--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,12 +16,24 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
+import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingSiteTypeStep extends React.PureComponent {
+	handleSiteTypeSelection = siteType => {
+		const { siteId } = this.props;
+
+		return () => {
+			this.props.saveJetpackOnboardingSettings( siteId, {
+				siteType,
+			} );
+		};
+	};
+
 	render() {
-		const { translate } = this.props;
+		const { getForwardUrl, translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'What kind of site do you need? Choose an option below:' );
+		const forwardUrl = getForwardUrl();
 
 		return (
 			<div className="steps__main">
@@ -39,6 +52,8 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 							'To share your ideas, stories, photographs, or creative projects with your followers.'
 						) }
 						image={ '/calypso/images/illustrations/type-personal.svg' }
+						href={ forwardUrl }
+						onClick={ this.handleSiteTypeSelection( 'personal' ) }
 					/>
 					<Tile
 						buttonLabel={ translate( 'Business site' ) }
@@ -46,6 +61,8 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 							'To promote your business, organization, or brand, sell products or services, or connect with your audience.'
 						) }
 						image={ '/calypso/images/illustrations/type-business.svg' }
+						href={ forwardUrl }
+						onClick={ this.handleSiteTypeSelection( 'business' ) }
 					/>
 				</TileGrid>
 			</div>
@@ -53,4 +70,6 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 	}
 }
 
-export default localize( JetpackOnboardingSiteTypeStep );
+export default connect( null, { saveJetpackOnboardingSettings } )(
+	localize( JetpackOnboardingSiteTypeStep )
+);

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -19,14 +19,10 @@ import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingSiteTypeStep extends React.PureComponent {
-	handleSiteTypeSelection = siteType => {
-		const { siteId } = this.props;
-
-		return () => {
-			this.props.saveJetpackOnboardingSettings( siteId, {
-				siteType,
-			} );
-		};
+	handleSiteTypeSelection = siteType => () => {
+		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
+			siteType,
+		} );
 	};
 
 	render() {


### PR DESCRIPTION
This PR updates the site type step to be saved in the remote site when clicking the corresponding tile.

To test:
1. Checkout this branch on your local Calypso.
1. Make sure your JP sandbox is running https://github.com/Automattic/jetpack/pull/8431.
1. Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
1. After you land the JPO flow, skip to the Site Type step.
1. Click the "Personal" tile.
1. Verify the `jpo_site_type` option was saved to `personal` (to check this, go to https://YourJetpackSandbox.com/wp-admin/options.php and look for the `jpo_site_type` option)
1. Repeat steps 5-6 again, but this time with the Business tile, and `business` as an option value.
