### PR TITLE
Comments: Split the Tree and List components

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { find, get, isEqual, isUndefined, map, orderBy, slice } from 'lodash';
+import { find, get, isEqual, isUndefined, map } from 'lodash';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 /**
@@ -71,13 +71,6 @@ export class CommentList extends Component {
 		changePage( page );
 	};
 
-	getComments = () => orderBy( this.props.comments, null, this.state.sortOrder );
-
-	getCommentsPage = ( comments, page ) => {
-		const startingIndex = ( page - 1 ) * COMMENTS_PER_PAGE;
-		return slice( comments, startingIndex, startingIndex + COMMENTS_PER_PAGE );
-	};
-
 	getEmptyMessage = () => {
 		const { status, translate } = this.props;
 
@@ -96,18 +89,15 @@ export class CommentList extends Component {
 		);
 	};
 
-	getTotalPages = () => Math.ceil( this.props.comments.length / COMMENTS_PER_PAGE );
+	getTotalPages = () => Math.ceil( this.props.commentsCount / COMMENTS_PER_PAGE );
 
 	isCommentSelected = commentId => !! find( this.state.selectedComments, { commentId } );
 
 	isRequestedPageValid = () => this.getTotalPages() >= this.props.page;
 
-	isSelectedAll = () => {
-		const { page } = this.props;
-		const { selectedComments } = this.state;
-		const visibleComments = this.getCommentsPage( this.getComments(), page );
-		return selectedComments.length && selectedComments.length === visibleComments.length;
-	};
+	isSelectedAll = () =>
+		this.state.selectedComments.length &&
+		this.state.selectedComments.length === this.props.comments.length;
 
 	setSortOrder = order => () => {
 		this.setState( {

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -173,7 +173,7 @@ export class CommentList extends Component {
 					postId={ postId }
 					selectedComments={ selectedComments }
 					setSortOrder={ this.setSortOrder }
-					sortOrder={ this.state.sortOrder }
+					sortOrder={ sortOrder }
 					siteId={ siteId }
 					siteFragment={ siteFragment }
 					status={ status }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -153,7 +153,7 @@ export class CommentList extends Component {
 		};
 
 		const showPlaceholder = ( ! siteId || isLoading ) && ! comments.length;
-		const showEmptyContent = ! commentsCount && ! showPlaceholder;
+		const showEmptyContent = ! isLoading && ! commentsCount && ! showPlaceholder;
 
 		const [ emptyMessageTitle, emptyMessageLine ] = this.getEmptyMessage();
 
@@ -212,7 +212,8 @@ export class CommentList extends Component {
 					) }
 				</ReactCSSTransitionGroup>
 
-				{ ! showPlaceholder &&
+				{ ! isLoading &&
+					! showPlaceholder &&
 					! showEmptyContent && (
 						<Pagination
 							key="comment-list-pagination"
@@ -228,7 +229,7 @@ export class CommentList extends Component {
 }
 
 const mapStateToProps = ( state, { page, postId, siteId, status } ) => {
-	const comments = getCommentsPage( state, siteId, { page, postId, status } ) || [];
+	const comments = getCommentsPage( state, siteId, { page, postId, status } );
 	const commentsCount = get(
 		getSiteCommentCounts( state, siteId, postId ),
 		'unapproved' === status ? 'pending' : status
@@ -237,7 +238,7 @@ const mapStateToProps = ( state, { page, postId, siteId, status } ) => {
 	const isPostView = !! postId;
 
 	return {
-		comments,
+		comments: comments || [],
 		commentsCount,
 		isLoading,
 		isPostView,

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -39,7 +39,6 @@ export class CommentList extends Component {
 
 	state = {
 		isBulkMode: false,
-		lastUndo: null,
 		selectedComments: [],
 		sortOrder: NEWEST_FIRST,
 	};
@@ -54,7 +53,6 @@ export class CommentList extends Component {
 		if ( siteId !== nextProps.siteId || status !== nextProps.status ) {
 			this.setState( {
 				isBulkMode: false,
-				lastUndo: null,
 				selectedComments: [],
 			} );
 		}
@@ -100,8 +98,6 @@ export class CommentList extends Component {
 
 	getTotalPages = () => Math.ceil( this.props.comments.length / COMMENTS_PER_PAGE );
 
-	hasCommentJustMovedBackToCurrentStatus = commentId => this.state.lastUndo === commentId;
-
 	isCommentSelected = commentId => !! find( this.state.selectedComments, { commentId } );
 
 	isRequestedPageValid = () => this.getTotalPages() >= this.props.page;
@@ -138,8 +134,6 @@ export class CommentList extends Component {
 	};
 
 	toggleSelectAll = selectedComments => this.setState( { selectedComments } );
-
-	updateLastUndo = commentId => this.setState( { lastUndo: commentId } );
 
 	render() {
 		const {
@@ -209,12 +203,7 @@ export class CommentList extends Component {
 							isBulkMode={ isBulkMode }
 							isPostView={ isPostView }
 							isSelected={ this.isCommentSelected( commentId ) }
-							refreshCommentData={
-								isCommentsTreeSupported &&
-								! this.hasCommentJustMovedBackToCurrentStatus( commentId )
-							}
 							toggleSelected={ this.toggleCommentSelected }
-							updateLastUndo={ this.updateLastUndo }
 						/>
 					) ) }
 

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -100,11 +100,6 @@ export class CommentList extends Component {
 		this.state.selectedComments.length &&
 		this.state.selectedComments.length === this.props.comments.length;
 
-	setOrder = order => () => {
-		this.props.setOrder( order );
-		this.setState( { page: 1 } );
-	};
-
 	toggleBulkMode = () => {
 		this.setState( ( { isBulkMode } ) => ( { isBulkMode: ! isBulkMode, selectedComments: [] } ) );
 	};
@@ -133,6 +128,7 @@ export class CommentList extends Component {
 			order,
 			page,
 			postId,
+			setOrder,
 			siteId,
 			siteFragment,
 			status,
@@ -173,7 +169,7 @@ export class CommentList extends Component {
 					order={ order }
 					postId={ postId }
 					selectedComments={ selectedComments }
-					setOrder={ this.setOrder }
+					setOrder={ setOrder }
 					siteId={ siteId }
 					siteFragment={ siteFragment }
 					status={ status }

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -55,7 +55,7 @@ export class CommentNavigation extends Component {
 		isSelectedAll: false,
 		selectedComments: [],
 		status: 'unapproved',
-		sortOrder: NEWEST_FIRST,
+		order: NEWEST_FIRST,
 	};
 
 	shouldComponentUpdate = nextProps => ! isEqual( this.props, nextProps );
@@ -192,8 +192,8 @@ export class CommentNavigation extends Component {
 			isSelectedAll,
 			query,
 			selectedComments,
-			setSortOrder,
-			sortOrder,
+			setOrder,
+			order,
 			status: queryStatus,
 			toggleBulkMode,
 			translate,
@@ -292,16 +292,16 @@ export class CommentNavigation extends Component {
 						hasComments && (
 							<SegmentedControl compact className="comment-navigation__sort-buttons">
 								<ControlItem
-									onClick={ setSortOrder( NEWEST_FIRST ) }
-									selected={ sortOrder === NEWEST_FIRST }
+									onClick={ setOrder( NEWEST_FIRST ) }
+									selected={ order === NEWEST_FIRST }
 								>
 									{ translate( 'Newest', {
 										comment: 'Chronological order for sorting the comments list.',
 									} ) }
 								</ControlItem>
 								<ControlItem
-									onClick={ setSortOrder( OLDEST_FIRST ) }
-									selected={ sortOrder === OLDEST_FIRST }
+									onClick={ setOrder( OLDEST_FIRST ) }
+									selected={ order === OLDEST_FIRST }
 								>
 									{ translate( 'Oldest', {
 										comment: 'Chronological order for sorting the comments list.',

--- a/client/my-sites/comments/comment-tree/index.jsx
+++ b/client/my-sites/comments/comment-tree/index.jsx
@@ -1,0 +1,282 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { filter, find, get, isEqual, map, orderBy, slice } from 'lodash';
+import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+
+/**
+ * Internal dependencies
+ */
+import { isEnabled } from 'config';
+import Comment from 'my-sites/comments/comment';
+import CommentListHeader from 'my-sites/comments/comment-list/comment-list-header';
+import CommentNavigation from 'my-sites/comments/comment-navigation';
+import EmptyContent from 'components/empty-content';
+import Pagination from 'components/pagination';
+import QuerySiteCommentsList from 'components/data/query-site-comments-list';
+import QuerySiteCommentsTree from 'components/data/query-site-comments-tree';
+import QuerySiteSettings from 'components/data/query-site-settings';
+import { getSiteCommentsTree, isCommentsTreeInitialized } from 'state/selectors';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
+import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { COMMENTS_PER_PAGE, NEWEST_FIRST } from '../constants';
+
+export class CommentTree extends Component {
+	static propTypes = {
+		changePage: PropTypes.func,
+		comments: PropTypes.array,
+		recordChangePage: PropTypes.func,
+		replyComment: PropTypes.func,
+		siteId: PropTypes.number,
+		status: PropTypes.string,
+		translate: PropTypes.func,
+	};
+
+	state = {
+		isBulkMode: false,
+		lastUndo: null,
+		selectedComments: [],
+		sortOrder: NEWEST_FIRST,
+	};
+
+	componentWillReceiveProps( nextProps ) {
+		const { siteId, status, changePage } = this.props;
+		const totalPages = this.getTotalPages();
+		if ( ! this.isRequestedPageValid() && totalPages > 1 ) {
+			return changePage( totalPages );
+		}
+
+		if ( siteId !== nextProps.siteId || status !== nextProps.status ) {
+			this.setState( {
+				isBulkMode: false,
+				lastUndo: null,
+				selectedComments: [],
+			} );
+		}
+	}
+
+	shouldComponentUpdate = ( nextProps, nextState ) =>
+		! isEqual( this.props, nextProps ) || ! isEqual( this.state, nextState );
+
+	changePage = page => {
+		const { recordChangePage, changePage } = this.props;
+
+		recordChangePage( page, this.getTotalPages() );
+
+		this.setState( { selectedComments: [] } );
+
+		changePage( page );
+	};
+
+	getComments = () => orderBy( this.props.comments, null, this.state.sortOrder );
+
+	getCommentsPage = ( comments, page ) => {
+		const startingIndex = ( page - 1 ) * COMMENTS_PER_PAGE;
+		return slice( comments, startingIndex, startingIndex + COMMENTS_PER_PAGE );
+	};
+
+	getEmptyMessage = () => {
+		const { status, translate } = this.props;
+
+		const defaultLine = translate( 'Your queue is clear.' );
+
+		return get(
+			{
+				unapproved: [ translate( 'No pending comments.' ), defaultLine ],
+				approved: [ translate( 'No approved comments.' ), defaultLine ],
+				spam: [ translate( 'No spam comments.' ), defaultLine ],
+				trash: [ translate( 'No deleted comments.' ), defaultLine ],
+				all: [ translate( 'No comments yet.' ), defaultLine ],
+			},
+			status,
+			[ '', '' ]
+		);
+	};
+
+	getTotalPages = () => Math.ceil( this.props.comments.length / COMMENTS_PER_PAGE );
+
+	hasCommentJustMovedBackToCurrentStatus = commentId => this.state.lastUndo === commentId;
+
+	isCommentSelected = commentId => !! find( this.state.selectedComments, { commentId } );
+
+	isRequestedPageValid = () => this.getTotalPages() >= this.props.page;
+
+	isSelectedAll = () => {
+		const { page } = this.props;
+		const { selectedComments } = this.state;
+		const visibleComments = this.getCommentsPage( this.getComments(), page );
+		return selectedComments.length && selectedComments.length === visibleComments.length;
+	};
+
+	setSortOrder = order => () => {
+		this.setState( {
+			sortOrder: order,
+			page: 1,
+		} );
+	};
+
+	toggleBulkMode = () => {
+		this.setState( ( { isBulkMode } ) => ( { isBulkMode: ! isBulkMode, selectedComments: [] } ) );
+	};
+
+	toggleCommentSelected = comment => {
+		if ( this.isCommentSelected( comment.commentId ) ) {
+			return this.setState( ( { selectedComments } ) => ( {
+				selectedComments: selectedComments.filter(
+					( { commentId } ) => comment.commentId !== commentId
+				),
+			} ) );
+		}
+		this.setState( ( { selectedComments } ) => ( {
+			selectedComments: selectedComments.concat( comment ),
+		} ) );
+	};
+
+	toggleSelectAll = selectedComments => this.setState( { selectedComments } );
+
+	updateLastUndo = commentId => this.setState( { lastUndo: commentId } );
+
+	render() {
+		const {
+			isCommentsTreeSupported,
+			isLoading,
+			isPostView,
+			page,
+			postId,
+			siteId,
+			siteFragment,
+			status,
+		} = this.props;
+		const { isBulkMode, selectedComments } = this.state;
+
+		const validPage = this.isRequestedPageValid() ? page : 1;
+
+		const comments = this.getComments();
+		const commentsCount = comments.length;
+		const commentsPage = this.getCommentsPage( comments, validPage );
+
+		const showPlaceholder = ( ! siteId || isLoading ) && ! commentsCount;
+		const showEmptyContent = ! commentsCount && ! showPlaceholder;
+
+		const [ emptyMessageTitle, emptyMessageLine ] = this.getEmptyMessage();
+
+		return (
+			<div className="comment-tree comment-list">
+				<QuerySiteSettings siteId={ siteId } />
+
+				{ ! isCommentsTreeSupported && (
+					<QuerySiteCommentsList
+						number={ 100 }
+						offset={ ( validPage - 1 ) * COMMENTS_PER_PAGE }
+						siteId={ siteId }
+						status={ status }
+					/>
+				) }
+				{ isCommentsTreeSupported && <QuerySiteCommentsTree siteId={ siteId } status={ status } /> }
+
+				{ isPostView && <CommentListHeader postId={ postId } /> }
+
+				<CommentNavigation
+					commentsPage={ commentsPage }
+					isBulkMode={ isBulkMode }
+					isSelectedAll={ this.isSelectedAll() }
+					postId={ postId }
+					selectedComments={ selectedComments }
+					setSortOrder={ this.setSortOrder }
+					sortOrder={ this.state.sortOrder }
+					siteId={ siteId }
+					siteFragment={ siteFragment }
+					status={ status }
+					toggleBulkMode={ this.toggleBulkMode }
+					toggleSelectAll={ this.toggleSelectAll }
+				/>
+
+				<ReactCSSTransitionGroup
+					className="comment-tree__transition-wrapper comment-list__transition-wrapper"
+					transitionEnterTimeout={ 150 }
+					transitionLeaveTimeout={ 150 }
+					transitionName="comment-list__transition"
+				>
+					{ map( commentsPage, commentId => (
+						<Comment
+							commentId={ commentId }
+							key={ `comment-${ siteId }-${ commentId }` }
+							isBulkMode={ isBulkMode }
+							isPostView={ isPostView }
+							isSelected={ this.isCommentSelected( commentId ) }
+							refreshCommentData={
+								isCommentsTreeSupported &&
+								! this.hasCommentJustMovedBackToCurrentStatus( commentId )
+							}
+							toggleSelected={ this.toggleCommentSelected }
+							updateLastUndo={ this.updateLastUndo }
+						/>
+					) ) }
+
+					{ showPlaceholder && <Comment commentId={ 0 } key="comment-detail-placeholder" /> }
+
+					{ showEmptyContent && (
+						<EmptyContent
+							illustration="/calypso/images/comments/illustration_comments_gray.svg"
+							illustrationWidth={ 150 }
+							key="comment-list-empty"
+							line={ emptyMessageLine }
+							title={ emptyMessageTitle }
+						/>
+					) }
+				</ReactCSSTransitionGroup>
+
+				{ ! showPlaceholder &&
+					! showEmptyContent && (
+						<Pagination
+							key="comment-list-pagination"
+							page={ validPage }
+							pageClick={ this.changePage }
+							perPage={ COMMENTS_PER_PAGE }
+							total={ commentsCount }
+						/>
+					) }
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = ( state, { postId, siteId, status } ) => {
+	const isPostView = !! postId;
+	const siteCommentsTree =
+		isPostView && isEnabled( 'comments/management/threaded-view' )
+			? filter( getSiteCommentsTree( state, siteId, status ), { commentParentId: 0 } )
+			: getSiteCommentsTree( state, siteId, status );
+	const comments = isPostView
+		? map( filter( siteCommentsTree, { postId } ), 'commentId' )
+		: map( siteCommentsTree, 'commentId' );
+
+	const isLoading = ! isCommentsTreeInitialized( state, siteId, status );
+	return {
+		comments,
+		isCommentsTreeSupported:
+			! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.5' ),
+		isLoading,
+		isPostView,
+		siteId,
+	};
+};
+
+const mapDispatchToProps = dispatch => ( {
+	recordChangePage: ( page, total ) =>
+		dispatch(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_comment_management_change_page', { page, total } ),
+				bumpStat( 'calypso_comment_management', 'change_page' )
+			)
+		),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( CommentTree ) );

--- a/client/my-sites/comments/comment-tree/index.jsx
+++ b/client/my-sites/comments/comment-tree/index.jsx
@@ -26,14 +26,16 @@ import QuerySiteSettings from 'components/data/query-site-settings';
 import { getSiteCommentsTree, isCommentsTreeInitialized } from 'state/selectors';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
-import { COMMENTS_PER_PAGE, NEWEST_FIRST } from '../constants';
+import { COMMENTS_PER_PAGE } from '../constants';
 
 export class CommentTree extends Component {
 	static propTypes = {
 		changePage: PropTypes.func,
 		comments: PropTypes.array,
+		order: PropTypes.string,
 		recordChangePage: PropTypes.func,
 		replyComment: PropTypes.func,
+		setOrder: PropTypes.func,
 		siteId: PropTypes.number,
 		status: PropTypes.string,
 		translate: PropTypes.func,
@@ -43,7 +45,6 @@ export class CommentTree extends Component {
 		isBulkMode: false,
 		lastUndo: null,
 		selectedComments: [],
-		sortOrder: NEWEST_FIRST,
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -75,7 +76,7 @@ export class CommentTree extends Component {
 		changePage( page );
 	};
 
-	getComments = () => orderBy( this.props.comments, null, this.state.sortOrder );
+	getComments = () => orderBy( this.props.comments, null, this.props.order );
 
 	getCommentsPage = ( comments, page ) => {
 		const startingIndex = ( page - 1 ) * COMMENTS_PER_PAGE;
@@ -115,11 +116,9 @@ export class CommentTree extends Component {
 		return selectedComments.length && selectedComments.length === visibleComments.length;
 	};
 
-	setSortOrder = order => () => {
-		this.setState( {
-			sortOrder: order,
-			page: 1,
-		} );
+	setOrder = order => () => {
+		this.props.setOrder( order );
+		this.setState( { page: 1 } );
 	};
 
 	toggleBulkMode = () => {
@@ -148,6 +147,7 @@ export class CommentTree extends Component {
 			isCommentsTreeSupported,
 			isLoading,
 			isPostView,
+			order,
 			page,
 			postId,
 			siteId,
@@ -187,10 +187,10 @@ export class CommentTree extends Component {
 					commentsPage={ commentsPage }
 					isBulkMode={ isBulkMode }
 					isSelectedAll={ this.isSelectedAll() }
+					order={ order }
 					postId={ postId }
 					selectedComments={ selectedComments }
-					setSortOrder={ this.setSortOrder }
-					sortOrder={ this.state.sortOrder }
+					setOrder={ this.setOrder }
 					siteId={ siteId }
 					siteFragment={ siteFragment }
 					status={ status }

--- a/client/my-sites/comments/comment-tree/index.jsx
+++ b/client/my-sites/comments/comment-tree/index.jsx
@@ -116,11 +116,6 @@ export class CommentTree extends Component {
 		return selectedComments.length && selectedComments.length === visibleComments.length;
 	};
 
-	setOrder = order => () => {
-		this.props.setOrder( order );
-		this.setState( { page: 1 } );
-	};
-
 	toggleBulkMode = () => {
 		this.setState( ( { isBulkMode } ) => ( { isBulkMode: ! isBulkMode, selectedComments: [] } ) );
 	};
@@ -150,6 +145,7 @@ export class CommentTree extends Component {
 			order,
 			page,
 			postId,
+			setOrder,
 			siteId,
 			siteFragment,
 			status,
@@ -190,7 +186,7 @@ export class CommentTree extends Component {
 					order={ order }
 					postId={ postId }
 					selectedComments={ selectedComments }
-					setOrder={ this.setOrder }
+					setOrder={ setOrder }
 					siteId={ siteId }
 					siteFragment={ siteFragment }
 					status={ status }

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -18,6 +18,7 @@ import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import CommentList from './comment-list';
+import CommentTree from './comment-tree';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { canCurrentUser } from 'state/selectors';
 import { preventWidows } from 'lib/formatting';
@@ -25,6 +26,7 @@ import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import { updatePlugin } from 'state/plugins/installed/actions';
 import { getPlugins } from 'state/plugins/installed/selectors';
 import { infoNotice } from 'state/notices/actions';
+import { isEnabled } from 'config';
 
 export class CommentsManagement extends Component {
 	static propTypes = {
@@ -53,9 +55,11 @@ export class CommentsManagement extends Component {
 	render() {
 		const {
 			changePage,
-			showJetpackUpdateScreen,
 			page,
 			postId,
+			showCommentList,
+			showCommentTree,
+			showJetpackUpdateScreen,
 			showPermissionError,
 			siteId,
 			siteFragment,
@@ -92,37 +96,59 @@ export class CommentsManagement extends Component {
 							illustration="/calypso/images/illustrations/illustration-500.svg"
 						/>
 					) }
-				{ ! showJetpackUpdateScreen &&
-					! showPermissionError && (
-						<CommentList
-							changePage={ changePage }
-							order={ 'desc' }
-							page={ page }
-							postId={ postId }
-							siteId={ siteId }
-							siteFragment={ siteFragment }
-							status={ status }
-						/>
-					) }
+				{ showCommentList && (
+					<CommentList
+						changePage={ changePage }
+						order={ 'desc' }
+						page={ page }
+						postId={ postId }
+						siteId={ siteId }
+						siteFragment={ siteFragment }
+						status={ status }
+					/>
+				) }
+				{ showCommentTree && (
+					<CommentTree
+						changePage={ changePage }
+						order={ 'desc' }
+						page={ page }
+						postId={ postId }
+						siteId={ siteId }
+						siteFragment={ siteFragment }
+						status={ status }
+					/>
+				) }
 			</Main>
 		);
 	}
 }
 
-const mapStateToProps = ( state, { siteFragment } ) => {
+const mapStateToProps = ( state, { postId, siteFragment } ) => {
 	const siteId = getSiteId( state, siteFragment );
 	const isJetpack = isJetpackSite( state, siteId );
+	const isPostView = !! postId;
 	const canModerateComments = canCurrentUser( state, siteId, 'edit_posts' );
-	const showJetpackUpdateScreen = isJetpack && ! isJetpackMinimumVersion( state, siteId, '5.5' );
+	const showPermissionError = false === canModerateComments;
+	const showJetpackUpdateScreen = isJetpack && ! isJetpackMinimumVersion( state, siteId, '5.6' );
 
 	const sitePlugins = getPlugins( state, [ siteId ] );
 	const jetpackPlugin = find( sitePlugins, { slug: 'jetpack' } );
 
+	const showCommentTree =
+		! showJetpackUpdateScreen &&
+		! showPermissionError &&
+		isPostView &&
+		isEnabled( 'comments/management/threaded-view' );
+
+	const showCommentList = ! showCommentTree && ! showJetpackUpdateScreen && ! showPermissionError;
+
 	return {
 		siteId,
 		jetpackPlugin,
+		showCommentList,
+		showCommentTree,
 		showJetpackUpdateScreen,
-		showPermissionError: canModerateComments === false,
+		showPermissionError,
 	};
 };
 

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -27,6 +27,7 @@ import { updatePlugin } from 'state/plugins/installed/actions';
 import { getPlugins } from 'state/plugins/installed/selectors';
 import { infoNotice } from 'state/notices/actions';
 import { isEnabled } from 'config';
+import { NEWEST_FIRST } from './constants';
 
 export class CommentsManagement extends Component {
 	static propTypes = {
@@ -44,6 +45,12 @@ export class CommentsManagement extends Component {
 		page: 1,
 		status: 'all',
 	};
+
+	state = {
+		order: NEWEST_FIRST,
+	};
+
+	setOrder = order => this.setState( { order } );
 
 	updateJetpackHandler = () => {
 		const { siteId, translate, jetpackPlugin } = this.props;
@@ -66,6 +73,7 @@ export class CommentsManagement extends Component {
 			status,
 			translate,
 		} = this.props;
+		const { order } = this.state;
 
 		return (
 			<Main className="comments" wideLayout>
@@ -99,9 +107,10 @@ export class CommentsManagement extends Component {
 				{ showCommentList && (
 					<CommentList
 						changePage={ changePage }
-						order={ 'desc' }
+						order={ order }
 						page={ page }
 						postId={ postId }
+						setOrder={ this.setOrder }
 						siteId={ siteId }
 						siteFragment={ siteFragment }
 						status={ status }
@@ -110,9 +119,10 @@ export class CommentsManagement extends Component {
 				{ showCommentTree && (
 					<CommentTree
 						changePage={ changePage }
-						order={ 'desc' }
+						order={ order }
 						page={ page }
 						postId={ postId }
+						setOrder={ this.setOrder }
 						siteId={ siteId }
 						siteFragment={ siteFragment }
 						status={ status }

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -50,7 +50,7 @@ export class CommentsManagement extends Component {
 		order: NEWEST_FIRST,
 	};
 
-	setOrder = order => this.setState( { order } );
+	setOrder = order => () => this.setState( { order } );
 
 	updateJetpackHandler = () => {
 		const { siteId, translate, jetpackPlugin } = this.props;

--- a/client/state/comments/middleware.js
+++ b/client/state/comments/middleware.js
@@ -1,6 +1,11 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { COMMENTS_DELETE, COMMENTS_CHANGE_STATUS } from 'state/action-types';
@@ -14,7 +19,9 @@ const handler = ( dispatch, action, getState ) => {
 			const previousStatus = siteComment && siteComment.status;
 			return {
 				...action,
-				meta: Object.assign( {}, action.meta, { comment: { previousStatus } } ),
+				meta: Object.assign( {}, action.meta, {
+					comment: Object.assign( {}, get( action, 'meta.comment' ), { previousStatus } ),
+				} ),
 			};
 		default:
 			return action;

--- a/client/state/ui/comments/reducer.js
+++ b/client/state/ui/comments/reducer.js
@@ -42,10 +42,13 @@ export const queries = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case COMMENTS_CHANGE_STATUS:
 		case COMMENTS_DELETE:
-			if ( ! action.refreshCommentListQuery ) {
+			const query = action.refreshCommentListQuery
+				? action.refreshCommentListQuery
+				: get( action, 'meta.comment.commentsListQuery' );
+			if ( ! query ) {
 				return state;
 			}
-			const { page, postId, status } = action.refreshCommentListQuery;
+			const { page, postId, status } = query;
 			if (
 				COMMENTS_CHANGE_STATUS === action.type &&
 				'all' === status &&
@@ -56,15 +59,11 @@ export const queries = ( state = {}, action ) => {
 			}
 
 			const parent = postId || 'site';
-			const filter = getFiltersKey( action.refreshCommentListQuery );
+			const filter = getFiltersKey( query );
 
 			const comments = get( state, [ parent, filter, page ] );
 
-			return deepUpdateComments(
-				state,
-				without( comments, action.commentId ),
-				action.refreshCommentListQuery
-			);
+			return deepUpdateComments( state, without( comments, action.commentId ), query );
 		case COMMENTS_QUERY_UPDATE:
 			return isUndefined( get( action, 'query.page' ) )
 				? state

--- a/client/state/ui/comments/test/reducer.js
+++ b/client/state/ui/comments/test/reducer.js
@@ -131,7 +131,7 @@ describe( 'reducer', () => {
 			expect( query ).toEqual( { site: { 'spam?order=DESC': { 1: [ 1, 2, 3, 4 ] } } } );
 		} );
 
-		test( "should not remove a comment from a page when the comment status is changed but it doesn't change filter list", () => {
+		test( 'should not remove a comment from a page when the comment status is changed but it does not change filter list', () => {
 			const state = deepFreeze( {
 				site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },
 			} );
@@ -143,6 +143,62 @@ describe( 'reducer', () => {
 				refreshCommentListQuery: { page: 1, status: 'all' },
 			} );
 			expect( query ).toEqual( { site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } } } );
+		} );
+
+		test( 'should add back a comment on undo in DESC order', () => {
+			const state = deepFreeze( {
+				site: { 'all?order=DESC': { 1: [ 5, 4, 2, 1 ] } },
+			} );
+			const query = queries( state, {
+				type: COMMENTS_CHANGE_STATUS,
+				siteId,
+				commentId: 3,
+				status: 'approved',
+				refreshCommentListQuery: { page: 1, status: 'all', order: 'DESC' },
+			} );
+			expect( query ).toEqual( { site: { 'all?order=DESC': { 1: [ 5, 4, 3, 2, 1 ] } } } );
+		} );
+
+		test( 'should add back a comment on undo in ASC order', () => {
+			const state = deepFreeze( {
+				site: { 'all?order=ASC': { 1: [ 1, 3, 4, 5 ] } },
+			} );
+			const query = queries( state, {
+				type: COMMENTS_CHANGE_STATUS,
+				siteId,
+				commentId: 2,
+				status: 'approved',
+				refreshCommentListQuery: { page: 1, status: 'all', order: 'ASC' },
+			} );
+			expect( query ).toEqual( { site: { 'all?order=ASC': { 1: [ 1, 2, 3, 4, 5 ] } } } );
+		} );
+
+		test( 'should update on undo in a tab other than all', () => {
+			const state = deepFreeze( {
+				site: { 'approved?order=ASC': { 1: [ 1, 3, 4, 5 ] } },
+			} );
+			const query = queries( state, {
+				type: COMMENTS_CHANGE_STATUS,
+				siteId,
+				commentId: 2,
+				status: 'approved',
+				refreshCommentListQuery: { page: 1, status: 'approved', order: 'ASC' },
+			} );
+			expect( query ).toEqual( { site: { 'approved?order=ASC': { 1: [ 1, 2, 3, 4, 5 ] } } } );
+		} );
+
+		test( 'should update the view when a bulk action occurs', () => {
+			const state = deepFreeze( {
+				site: { 'approved?order=ASC': { 1: [ 1, 3, 4, 5 ] } },
+			} );
+			const query = queries( state, {
+				type: COMMENTS_CHANGE_STATUS,
+				siteId,
+				commentId: 4,
+				status: 'unapproved',
+				meta: { comment: { commentsListQuery: { page: 1, status: 'approved', order: 'ASC' } } },
+			} );
+			expect( query ).toEqual( { site: { 'approved?order=ASC': { 1: [ 1, 3, 5 ] } } } );
 		} );
 	} );
 	describe( '#pendingActions', () => {

--- a/client/state/ui/comments/utils.js
+++ b/client/state/ui/comments/utils.js
@@ -14,8 +14,11 @@ import { includes } from 'lodash';
  * @param {String} query.status Comments status.
  * @returns {String} Filter key.
  */
-export const getFiltersKey = ( { order, search, status = 'all' } ) => {
-	const orderFilter = includes( [ 'ASC', 'DESC' ], order ) ? order : 'DESC';
+export const getFiltersKey = ( { order = 'DESC', search, status = 'all' } ) => {
+	const caseInsensitiveOrder = order.toUpperCase();
+	const orderFilter = includes( [ 'ASC', 'DESC' ], caseInsensitiveOrder )
+		? caseInsensitiveOrder
+		: 'DESC';
 	const searchFilter = !! search ? `&s=${ search }` : '';
 	return `${ status }?order=${ orderFilter }${ searchFilter }`;
 };


### PR DESCRIPTION
Depends on #21112, #21115, #21121
Replaces #21077

#21004 and #21035 introduced a new `ui.comments.queries` state that helps handling the Comments Management pagination.

To improve this section performance, we decided to use a combination of the comment list and the new comment count endpoints, instead of the comment tree one.
To keep supporting all our cases (e.g. we have a threaded view behind feature flag that requires the tree approach), I've moved the tree approach into a new `CommentTree` component, and modified the old `CommentList` to only use the list+count approach.

The `CommentsManagement` Main component will decide which one to render, or *not to* if Jetpack is not up to date or the user has not enough permissions.

The `CommentTree` component is in fact a carbon copy of the old `CommentList`, with just the `sortOrder` and `setSortOrder` props renamed as `order` and `sortOrder`.
There should be no need to review `my-sites/comments/comment-tree/index.jsx`.

## Testing instructions

- Does it use `CommentList`?
  - Open `/comments` on this branch and navigate around.
  - Make sure the component used to render the list is `CommentList` (visually: it loads all the comments at once, instead of trickling in one by one).
- Does it ask to update Jetpack if the site uses a version < 5.6?
  - Open `/comments` on a totally outdated Jetpack site.
  - You should see an illustration prompting to update Jetpack, and of course no comments should be displayed.
- On `CommentList`, make sure all these actions work as intended:
  - Change tab
  - Change sort order
  - Change page
  - Bulk change status and permanent delete
  - (Single) change status and permanent delete
  - Approve and reply

The following test case is only to check that things still work with the old comments tree approach, in the one single case we still need to use it (and which is not enabled in any environment)
We know it's not good performance-wise, hence the whole rework.
Also, its design is still WIP.

- Does it use `CommentTree` when in threaded view?
  - Load Calypso with the `?flags=comments/management/threaded-view` query parameter to enable the threaded view.
  - Open `/comments` and navigate to a post view.
  - Make sure the component used to render the list is `CommentTree` (visually: it trickles in the comments one by one, instead of loading all of them at once).
  - Make sure all these actions still work as intended:
    - Change tab
    - Change sort order
    - Change page
    - Bulk change status and permanent delete
    - (Single) change status and permanent delete
    - Approve and reply
  