### PR TITLE
Comments: Add order support to the new ui.comments.queries state

### DIFF
--- a/client/state/selectors/get-comments-page.js
+++ b/client/state/selectors/get-comments-page.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/state/selectors/get-comments-page.js
+++ b/client/state/selectors/get-comments-page.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 
-import { get } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +16,7 @@ import { getFiltersKey } from 'state/ui/comments/utils';
  * @param {Object} state Redux state.
  * @param {Number} siteId Site identifier.
  * @param {Object} query Filter parameters.
+ * @param {String} [query.order] Query order ('ASC' or 'DESC').
  * @param {Number} [query.page] Requested page.
  * @param {Number} [query.postId] Post identifier.
  * @param {String} [query.search] Search query.

--- a/client/state/selectors/test/get-comments-page.js
+++ b/client/state/selectors/test/get-comments-page.js
@@ -19,12 +19,12 @@ describe( 'getCommentsPage()', () => {
 				queries: {
 					[ SITE_ID ]: {
 						site: {
-							all: { 1: [ 1, 2, 3, 4, 5 ] },
-							trash: { 1: [] },
+							'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] },
+							'trash?order=DESC': { 1: [] },
 						},
 						[ POST_ID ]: {
-							all: { 1: [ 6, 7, 8, 9, 10 ] },
-							'spam?s=foo': { 2: [ 11, 12, 13, 14, 15 ] },
+							'all?order=DESC': { 1: [ 6, 7, 8, 9, 10 ] },
+							'spam?order=ASC&s=foo': { 2: [ 11, 12, 13, 14, 15 ] },
 						},
 					},
 				},
@@ -58,6 +58,7 @@ describe( 'getCommentsPage()', () => {
 
 	test( 'should return a comments page based on several filters', () => {
 		const commentsPage = getCommentsPage( state, SITE_ID, {
+			order: 'ASC',
 			page: 2,
 			postId: POST_ID,
 			search: 'foo',

--- a/client/state/ui/comments/actions.js
+++ b/client/state/ui/comments/actions.js
@@ -10,6 +10,7 @@ import { COMMENTS_QUERY_UPDATE } from 'state/action-types';
  * @param {Number} siteId Site identifier.
  * @param {Array<Object>} comments List of comments.
  * @param {Object} query Current filter parameters.
+ * @param {String} [query.order] Query order ('ASC' or 'DESC').
  * @param {Number} query.page Page to update.
  * @param {Number} [query.postId] Post identifier.
  * @param {String} [query.search] Search query.

--- a/client/state/ui/comments/test/actions.js
+++ b/client/state/ui/comments/test/actions.js
@@ -17,6 +17,7 @@ describe( 'actions', () => {
 			const postId = 1234;
 			const comments = [ { ID: 1 }, { ID: 2 }, { ID: 3 }, { ID: 4 }, { ID: 5 } ];
 			const query = {
+				order: 'DESC',
 				page: 1,
 				postId: postId,
 				search: 'foo',

--- a/client/state/ui/comments/test/reducer.js
+++ b/client/state/ui/comments/test/reducer.js
@@ -27,13 +27,13 @@ describe( 'reducer', () => {
 				query: { page: 1 },
 			} );
 			expect( query ).to.eql( {
-				site: { all: { 1: [ 1, 2, 3, 4, 5 ] } },
+				site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },
 			} );
 		} );
 
 		test( 'should add a comments page for the post view with no filters', () => {
 			const state = deepFreeze( {
-				site: { all: { 1: [ 1, 2, 3, 4, 5 ] } },
+				site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },
 			} );
 			const query = queries( state, {
 				type: COMMENTS_QUERY_UPDATE,
@@ -45,21 +45,22 @@ describe( 'reducer', () => {
 				},
 			} );
 			expect( query ).to.eql( {
-				site: { all: { 1: [ 1, 2, 3, 4, 5 ] } },
-				[ postId ]: { all: { 1: [ 6, 7, 8, 9, 10 ] } },
+				site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },
+				[ postId ]: { 'all?order=DESC': { 1: [ 6, 7, 8, 9, 10 ] } },
 			} );
 		} );
 
 		test( 'should add a comments page for the post view with several filters', () => {
 			const state = deepFreeze( {
-				site: { all: { 1: [ 1, 2, 3, 4, 5 ] } },
-				[ postId ]: { all: { 1: [ 6, 7, 8, 9, 10 ] } },
+				site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },
+				[ postId ]: { 'all?order=DESC': { 1: [ 6, 7, 8, 9, 10 ] } },
 			} );
 			const query = queries( state, {
 				type: COMMENTS_QUERY_UPDATE,
 				siteId,
 				comments: comments3,
 				query: {
+					order: 'ASC',
 					page: 2,
 					postId,
 					search: 'foo',
@@ -67,20 +68,20 @@ describe( 'reducer', () => {
 				},
 			} );
 			expect( query ).to.eql( {
-				site: { all: { 1: [ 1, 2, 3, 4, 5 ] } },
+				site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },
 				[ postId ]: {
-					all: { 1: [ 6, 7, 8, 9, 10 ] },
-					'spam?s=foo': { 2: [ 11, 12, 13, 14, 15 ] },
+					'all?order=DESC': { 1: [ 6, 7, 8, 9, 10 ] },
+					'spam?order=ASC&s=foo': { 2: [ 11, 12, 13, 14, 15 ] },
 				},
 			} );
 		} );
 
 		test( 'should replace a comments page after a new request', () => {
 			const state = deepFreeze( {
-				site: { all: { 1: [ 1, 2, 3, 4, 5 ] } },
+				site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },
 				[ postId ]: {
-					all: { 1: [ 6, 7, 8, 9, 10 ] },
-					'spam?s=foo': { 2: [ 11, 12, 13, 14, 15 ] },
+					'all?order=DESC': { 1: [ 6, 7, 8, 9, 10 ] },
+					'spam?order=ASC&s=foo': { 2: [ 11, 12, 13, 14, 15 ] },
 				},
 			} );
 			const query = queries( state, {
@@ -90,17 +91,17 @@ describe( 'reducer', () => {
 				query: { page: 1 },
 			} );
 			expect( query ).to.eql( {
-				site: { all: { 1: [ 11, 12, 13, 14, 15 ] } },
+				site: { 'all?order=DESC': { 1: [ 11, 12, 13, 14, 15 ] } },
 				[ postId ]: {
-					all: { 1: [ 6, 7, 8, 9, 10 ] },
-					'spam?s=foo': { 2: [ 11, 12, 13, 14, 15 ] },
+					'all?order=DESC': { 1: [ 6, 7, 8, 9, 10 ] },
+					'spam?order=ASC&s=foo': { 2: [ 11, 12, 13, 14, 15 ] },
 				},
 			} );
 		} );
 
 		test( 'should remove a comment from a page when the comment is deleted', () => {
 			const state = deepFreeze( {
-				site: { all: { 1: [ 1, 2, 3, 4, 5 ] } },
+				site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },
 			} );
 			const query = queries( state, {
 				type: COMMENTS_DELETE,
@@ -108,12 +109,12 @@ describe( 'reducer', () => {
 				commentId: 5,
 				refreshCommentListQuery: { page: 1, status: 'all' },
 			} );
-			expect( query ).to.eql( { site: { all: { 1: [ 1, 2, 3, 4 ] } } } );
+			expect( query ).to.eql( { site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4 ] } } } );
 		} );
 
 		test( 'should remove a comment from a page when the comment status is changed', () => {
 			const state = deepFreeze( {
-				site: { spam: { 1: [ 1, 2, 3, 4, 5 ] } },
+				site: { 'spam?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },
 			} );
 			const query = queries( state, {
 				type: COMMENTS_CHANGE_STATUS,
@@ -122,12 +123,12 @@ describe( 'reducer', () => {
 				status: 'approved',
 				refreshCommentListQuery: { page: 1, status: 'spam' },
 			} );
-			expect( query ).to.eql( { site: { spam: { 1: [ 1, 2, 3, 4 ] } } } );
+			expect( query ).to.eql( { site: { 'spam?order=DESC': { 1: [ 1, 2, 3, 4 ] } } } );
 		} );
 
 		test( "should not remove a comment from a page when the comment status is changed but it doesn't change filter list", () => {
 			const state = deepFreeze( {
-				site: { all: { 1: [ 1, 2, 3, 4, 5 ] } },
+				site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },
 			} );
 			const query = queries( state, {
 				type: COMMENTS_CHANGE_STATUS,
@@ -136,7 +137,7 @@ describe( 'reducer', () => {
 				status: 'approved',
 				refreshCommentListQuery: { page: 1, status: 'all' },
 			} );
-			expect( query ).to.eql( { site: { all: { 1: [ 1, 2, 3, 4, 5 ] } } } );
+			expect( query ).to.eql( { site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } } } );
 		} );
 	} );
 } );

--- a/client/state/ui/comments/utils.js
+++ b/client/state/ui/comments/utils.js
@@ -1,13 +1,21 @@
 /** @format */
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
 
 /**
  * Creates a filters key to be used in the `ui.comments.queries` state.
  * E.g. `ui.comments.queries.${ siteId }.${ postId }.${ 'approved?s=foo' }.${ page }`
  *
  * @param {Object} query Filter parameters.
+ * @param {String} [query.order] Query order ('ASC' or 'DESC').
  * @param {String} [query.search] Search query.
  * @param {String} query.status Comments status.
  * @returns {String} Filter key.
  */
-export const getFiltersKey = ( { search, status = 'all' } ) =>
-	!! search ? `${ status }?s=${ search }` : status;
+export const getFiltersKey = ( { order, search, status = 'all' } ) => {
+	const orderFilter = includes( [ 'ASC', 'DESC' ], order ) ? order : 'DESC';
+	const searchFilter = !! search ? `&s=${ search }` : '';
+	return `${ status }?order=${ orderFilter }${ searchFilter }`;
+};


### PR DESCRIPTION
#21004 and #21035 introduced a new `ui.comments.queries` state that helps handling the Comments Management pagination.

While working on the component (see #21155), I've realized that while changing page and filter works pretty much flawlessly, changing the sort order might end up (very briefly) showing the opposite sort order results before being replaced by the correct ones.
This is because the `state.ui.comments.queries` object currently doesn't make any distinctions between ascending and descending orders.

This PR adds a new parameter to the queries action/reducer/selector so that they always take into account the sort order of a comments page (defaulting to `DESC`).

### Note

I'm not actually sold on this whole "query param" approach.
Any suggestion on how to improve it is very welcome.