### PR TITLE
Components - Card: restore border lost when a card is highlighted

### DIFF
--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -36,6 +36,7 @@ class Card extends Component {
 				'is-card-link': !! href,
 				'is-clickable': !! onClick,
 				'is-compact': compact,
+				'is-highlight': highlightClass,
 			},
 			highlightClass
 		);

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -33,6 +33,10 @@
 		cursor: pointer;
 	}
 
+	&.is-highlight {
+		padding-left: 21px;
+	}
+
 	&.is-error {
 		border-left: 3px solid $alert-red;
 	}

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -34,19 +34,19 @@
 	}
 
 	&.is-error {
-		box-shadow: inset 3px 0 0 $alert-red;
+		border-left: 3px solid $alert-red;
 	}
 
 	&.is-info {
-		box-shadow: inset 3px 0 0 $blue-wordpress;
+		border-left: 3px solid $blue-wordpress;
 	}
 
 	&.is-success {
-		box-shadow: inset 3px 0 0 $alert-green;
+		border-left: 3px solid $alert-green;
 	}
 
 	&.is-warning {
-		box-shadow: inset 3px 0 0 $alert-yellow;
+		border-left: 3px solid $alert-yellow;
 	}
 }
 


### PR DESCRIPTION
Cards usually have a gray border added as a box shadow. This is lost when they're highlighted as a success, info, warning, or error, because the color accent is added as a box shadow, thus overwriting the border.
This PR restores that border adding it following the approach of `Banner` component, that adds it as a `border-left`.
Note that since `.card` uses `box-sizing: border-box;` this change doesn't affect layout and positioning anywhere.

#### Before

<img width="817" alt="captura de pantalla 2017-12-29 a la s 12 23 15" src="https://user-images.githubusercontent.com/1041600/34440713-bafdd2d6-ec95-11e7-98c6-04b764e13514.png">

#### After

<img width="818" alt="captura de pantalla 2017-12-29 a la s 12 22 22" src="https://user-images.githubusercontent.com/1041600/34440714-bf0b4c32-ec95-11e7-8737-ec97adcbe199.png">
