### PR TITLE
esmodules: Update lib/analytics/ad-tracking

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -403,7 +403,7 @@ function isAdTrackingAllowed() {
  *
  * @returns {void}
  */
-function retarget() {
+function only_retarget() {
 	if ( ! isAdTrackingAllowed() ) {
 		return;
 	}
@@ -487,7 +487,7 @@ function retarget() {
  * @param {Object} properties - The custom event attributes.
  * @returns {void}
  */
-function trackCustomFacebookConversionEvent( name, properties ) {
+export function trackCustomFacebookConversionEvent( name, properties ) {
 	window.fbw && window.fbq( 'trackCustom', name, properties );
 }
 
@@ -497,7 +497,7 @@ function trackCustomFacebookConversionEvent( name, properties ) {
  * @param {Object} properties - The custom event attributes.
  * @returns {void}
  */
-function trackCustomAdWordsRemarketingEvent( properties ) {
+export function trackCustomAdWordsRemarketingEvent( properties ) {
 	window.google_trackConversion &&
 		window.google_trackConversion( {
 			google_conversion_id: ADWORDS_CONVERSION_ID,
@@ -509,7 +509,7 @@ function trackCustomAdWordsRemarketingEvent( properties ) {
 /**
  * A generic function that we can export and call to track plans page views with our ad partners
  */
-function retargetViewPlans() {
+export function retargetViewPlans() {
 	if ( ! isAdTrackingAllowed() ) {
 		return;
 	}
@@ -525,7 +525,7 @@ function retargetViewPlans() {
  * @param {Object} cartItem - The item added to the cart
  * @returns {void}
  */
-function recordAddToCart( cartItem ) {
+export function recordAddToCart( cartItem ) {
 	if ( ! isAdTrackingAllowed() ) {
 		return;
 	}
@@ -555,7 +555,7 @@ function recordAddToCart( cartItem ) {
  *
  * @param {Object} cart - cart as `CartValue` object
  */
-function recordViewCheckout( cart ) {
+export function recordViewCheckout( cart ) {
 	if ( isCriteoEnabled ) {
 		recordViewCheckoutInCriteo( cart );
 	}
@@ -568,7 +568,7 @@ function recordViewCheckout( cart ) {
  * @param {Number} orderId - the order id
  * @returns {void}
  */
-function recordOrder( cart, orderId ) {
+export function recordOrder( cart, orderId ) {
 	if ( ! isAdTrackingAllowed() ) {
 		return;
 	}
@@ -838,7 +838,7 @@ function recordOrderInFloodlight( cart, orderId ) {
  *
  * @returns {void}
  */
-function recordAliasInFloodlight() {
+export function recordAliasInFloodlight() {
 	if ( ! isAdTrackingAllowed() || ! isFloodlightEnabled ) {
 		return;
 	}
@@ -899,7 +899,7 @@ function recordSignupCompletionInFloodlight() {
  * @param {String} urlPath - The URL path
  * @returns {void}
  */
-function recordPageViewInFloodlight( urlPath ) {
+export function recordPageViewInFloodlight( urlPath ) {
 	if ( ! isAdTrackingAllowed() || ! isFloodlightEnabled ) {
 		return;
 	}
@@ -1236,7 +1236,7 @@ function isSupportedCurrency( currency ) {
  *
  * @returns {void}
  */
-function recordSignupStart() {
+export function recordSignupStart() {
 	recordSignupStartInFloodlight();
 }
 
@@ -1245,29 +1245,14 @@ function recordSignupStart() {
  *
  * @returns {void}
  */
-function recordSignupCompletion() {
+export function recordSignupCompletion() {
 	recordSignupCompletionInFloodlight();
 }
 
-export default {
-	retarget: function( context, next ) {
-		const nextFunction = typeof next === 'function' ? next : noop;
+export function retarget( context, next ) {
+	const nextFunction = typeof next === 'function' ? next : noop;
 
-		retarget();
+	only_retarget();
 
-		nextFunction();
-	},
-
-	retargetViewPlans,
-
-	recordAliasInFloodlight,
-	recordPageViewInFloodlight,
-
-	recordAddToCart,
-	recordViewCheckout,
-	recordOrder,
-	recordSignupStart,
-	recordSignupCompletion,
-	trackCustomFacebookConversionEvent,
-	trackCustomAdWordsRemarketingEvent,
-};
+	nextFunction();
+}

--- a/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react'; // eslint-disable-line no-unused-vars
 import debugFactory from 'debug';
 import { defer, isEqual, pick } from 'lodash';
@@ -14,7 +12,7 @@ const debug = debugFactory( 'calypso:my-sites:upgrades:checkout:transaction-step
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import adTracking from 'lib/analytics/ad-tracking';
+import { recordOrder } from 'lib/analytics/ad-tracking';
 import { getTld } from 'lib/domains';
 import { cartItems } from 'lib/cart-values';
 import { displayError, clear } from 'lib/upgrades/notices';
@@ -92,7 +90,7 @@ const TransactionStepsMixin = {
 					// Makes sure free trials are not recorded as purchases in ad trackers since they are products with
 					// zero-value cost and would thus lead to a wrong computation of conversions
 					if ( ! cartItems.hasFreeTrial( cartValue ) ) {
-						adTracking.recordOrder( cartValue, step.data.receipt_id );
+						recordOrder( cartValue, step.data.receipt_id );
 					}
 
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_success', {


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.