### PR TITLE
Store: Fix dashboard bug

### DIFF
--- a/client/extensions/woocommerce/state/sites/setup-choices/selectors.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/selectors.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { get, isObject } from 'lodash';
+import { get, isEmpty, isObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,7 +22,8 @@ const getSetupChoices = ( state, siteId ) => {
  * @return {boolean} Whether the setup choices list has been successfully loaded from the server
  */
 export const areSetupChoicesLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return isObject( getSetupChoices( state, siteId ) );
+	const setupChoices = getSetupChoices( state, siteId );
+	return isObject( setupChoices ) && ! isEmpty( setupChoices );
 };
 
 /**

--- a/client/extensions/woocommerce/state/sites/setup-choices/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/test/selectors.js
@@ -74,6 +74,17 @@ const loadedState = {
 		},
 	},
 };
+const loadedStateEmptySettings = {
+	extensions: {
+		woocommerce: {
+			sites: {
+				123: {
+					setupChoices: {},
+				},
+			},
+		},
+	},
+};
 
 const loadingStateWithUi = { ...loadingState, ui: { selectedSiteId: 123 } };
 const loadedStateWithUi = { ...loadedState, ui: { selectedSiteId: 123 } };
@@ -90,6 +101,10 @@ describe( 'selectors', () => {
 
 		test( 'should be true when setup choices are loaded.', () => {
 			expect( areSetupChoicesLoaded( loadedState, 123 ) ).to.be.true;
+		} );
+
+		test( 'should be false when setup choices object is empty.', () => {
+			expect( areSetupChoicesLoaded( loadedStateEmptySettings, 123 ) ).to.be.false;
 		} );
 
 		test( 'should be false when setup choices are loaded only for a different site.', () => {


### PR DESCRIPTION
This branch fixes #21008 - a bug which can be hit via multiple flows and results in the Store dashboard for a fully setup/configured site to display the "Have Something to Sell?" dashboard page:

![have-something](https://user-images.githubusercontent.com/22080/34447034-fc4d2378-ec94-11e7-98fb-5e95506f292c.png)

While investigating this using the order notif steps I posted on the original issue - I discovered that the `areSetupChoicesLoaded` selector was returning `true` when there was an empty `setupChoices` object in the state tree. I didn't dig into how the empty object was being ushered into the state tree in this PR, I opted to fix the selector itself and verify the value of `setupChoices` for a site was an object and was not empty instead.

__To Test__
- Test using the steps outlined in #21008, I had the best ability to reproduce by clicking on a link in an order notif - which I had changed the Order Detail page URL to `http://calypso.localhost:3000/` but the settings hard refresh should work as well
- Verify that when you click on the Dashboard, the setup screen is not shown, and your expected Store dashboard is rendered