### PR TITLE
esmodules: Update state/plugins/premium

### DIFF
--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -291,52 +291,50 @@ function configure( site, plugin, dispatch ) {
 		} );
 }
 
-export default {
-	fetchInstallInstructions: function( siteId ) {
-		return dispatch => {
-			if ( _fetching[ siteId ] ) {
-				return;
-			}
-			_fetching[ siteId ] = true;
+export function fetchInstallInstructions( siteId ) {
+	return dispatch => {
+		if ( _fetching[ siteId ] ) {
+			return;
+		}
+		_fetching[ siteId ] = true;
 
-			setTimeout( () => {
-				dispatch( {
-					type: PLUGIN_SETUP_INSTRUCTIONS_FETCH,
-					siteId,
-				} );
-			}, 1 );
+		setTimeout( () => {
+			dispatch( {
+				type: PLUGIN_SETUP_INSTRUCTIONS_FETCH,
+				siteId,
+			} );
+		}, 1 );
 
-			wpcom.undocumented().fetchJetpackKeys( siteId, ( error, data ) => {
-				if ( error ) {
-					dispatch( {
-						type: PLUGIN_SETUP_INSTRUCTIONS_RECEIVE,
-						siteId,
-						data: [],
-					} );
-					return;
-				}
-
-				data = normalizePluginInstructions( data );
-
+		wpcom.undocumented().fetchJetpackKeys( siteId, ( error, data ) => {
+			if ( error ) {
 				dispatch( {
 					type: PLUGIN_SETUP_INSTRUCTIONS_RECEIVE,
 					siteId,
-					data,
+					data: [],
 				} );
-			} );
-		};
-	},
+				return;
+			}
 
-	installPlugin: function( plugin, site ) {
-		return dispatch => {
-			// Starting Install
+			data = normalizePluginInstructions( data );
+
 			dispatch( {
-				type: PLUGIN_SETUP_INSTALL,
-				siteId: site.ID,
-				slug: plugin.slug,
+				type: PLUGIN_SETUP_INSTRUCTIONS_RECEIVE,
+				siteId,
+				data,
 			} );
+		} );
+	};
+}
 
-			install( site, plugin, dispatch );
-		};
-	},
-};
+export function installPlugin( plugin, site ) {
+	return dispatch => {
+		// Starting Install
+		dispatch( {
+			type: PLUGIN_SETUP_INSTALL,
+			siteId: site.ID,
+			slug: plugin.slug,
+		} );
+
+		install( site, plugin, dispatch );
+	};
+}

--- a/client/state/plugins/premium/selectors.js
+++ b/client/state/plugins/premium/selectors.js
@@ -6,7 +6,7 @@
 
 import { find, filter, some, every } from 'lodash';
 
-const isRequesting = function( state, siteId ) {
+export const isRequesting = function( state, siteId ) {
 	// if the `isRequesting` attribute doesn't exist yet,
 	// we assume we are still launching the fetch action, so it's true
 	if ( typeof state.plugins.premium.isRequesting[ siteId ] === 'undefined' ) {
@@ -15,14 +15,14 @@ const isRequesting = function( state, siteId ) {
 	return state.plugins.premium.isRequesting[ siteId ];
 };
 
-const hasRequested = function( state, siteId ) {
+export const hasRequested = function( state, siteId ) {
 	if ( typeof state.plugins.premium.hasRequested[ siteId ] === 'undefined' ) {
 		return false;
 	}
 	return state.plugins.premium.hasRequested[ siteId ];
 };
 
-const getPluginsForSite = function( state, siteId, whitelist = false ) {
+export const getPluginsForSite = function( state, siteId, whitelist = false ) {
 	const pluginList = state.plugins.premium.plugins[ siteId ];
 	if ( typeof pluginList === 'undefined' ) {
 		return [];
@@ -41,14 +41,14 @@ const getPluginsForSite = function( state, siteId, whitelist = false ) {
 	} );
 };
 
-const isStarted = function( state, siteId, whitelist = false ) {
+export const isStarted = function( state, siteId, whitelist = false ) {
 	const pluginList = getPluginsForSite( state, siteId, whitelist );
 	return ! every( pluginList, item => {
 		return 'wait' === item.status;
 	} );
 };
 
-const isFinished = function( state, siteId, whitelist = false ) {
+export const isFinished = function( state, siteId, whitelist = false ) {
 	const pluginList = getPluginsForSite( state, siteId, whitelist );
 	if ( pluginList.length === 0 ) {
 		return true;
@@ -59,7 +59,7 @@ const isFinished = function( state, siteId, whitelist = false ) {
 	} );
 };
 
-const isInstalling = function( state, siteId, whitelist = false ) {
+export const isInstalling = function( state, siteId, whitelist = false ) {
 	const pluginList = getPluginsForSite( state, siteId, whitelist );
 	if ( pluginList.length === 0 ) {
 		return false;
@@ -71,7 +71,7 @@ const isInstalling = function( state, siteId, whitelist = false ) {
 	} );
 };
 
-const getActivePlugin = function( state, siteId, whitelist = false ) {
+export const getActivePlugin = function( state, siteId, whitelist = false ) {
 	const pluginList = getPluginsForSite( state, siteId, whitelist );
 	const plugin = find( pluginList, item => {
 		return -1 === [ 'done', 'wait' ].indexOf( item.status ) && item.error === null;
@@ -82,7 +82,7 @@ const getActivePlugin = function( state, siteId, whitelist = false ) {
 	return plugin;
 };
 
-const getNextPlugin = function( state, siteId, whitelist = false ) {
+export const getNextPlugin = function( state, siteId, whitelist = false ) {
 	const pluginList = getPluginsForSite( state, siteId, whitelist );
 	const plugin = find( pluginList, item => {
 		return 'wait' === item.status && item.error === null;
@@ -91,15 +91,4 @@ const getNextPlugin = function( state, siteId, whitelist = false ) {
 		return false;
 	}
 	return plugin;
-};
-
-export default {
-	isRequesting,
-	hasRequested,
-	isStarted,
-	isFinished,
-	isInstalling,
-	getPluginsForSite,
-	getActivePlugin,
-	getNextPlugin,
 };

--- a/client/state/plugins/premium/test/selectors.js
+++ b/client/state/plugins/premium/test/selectors.js
@@ -9,7 +9,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import selectors from '../selectors';
+import * as selectors from '../selectors';
 import { initSite, installingSite, finishedSite, configuringSite } from './examples';
 
 const state = deepFreeze( {


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.