### PR TITLE
esmodules: Upgrade lib/store-transactions

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -36,7 +36,7 @@ const wpcom = wp.undocumented();
  * @param {object} domainDetails - Optional domain registration details if the shopping cart contains a domain registration product
  *   transaction.
  */
-function submit( params ) {
+export function submit( params ) {
 	return new TransactionFlow( params );
 }
 
@@ -65,15 +65,13 @@ inherits( TransactionFlow, Readable );
  * while the first one finises.
  */
 TransactionFlow.prototype._read = function() {
-	var paymentMethod, paymentHandler;
-
 	if ( this._hasStarted ) {
 		return false;
 	}
 	this._hasStarted = true;
 
-	paymentMethod = this._initialData.payment.paymentMethod;
-	paymentHandler = this._paymentHandlers[ paymentMethod ];
+	const paymentMethod = this._initialData.payment.paymentMethod;
+	const paymentHandler = this._paymentHandlers[ paymentMethod ];
 	if ( ! paymentHandler ) {
 		throw new Error( 'Invalid payment method: ' + paymentMethod );
 	}
@@ -82,7 +80,7 @@ TransactionFlow.prototype._read = function() {
 };
 
 TransactionFlow.prototype._pushStep = function( options ) {
-	var defaults = {
+	const defaults = {
 		first: false,
 		last: false,
 		timestamp: Date.now(),
@@ -169,12 +167,12 @@ TransactionFlow.prototype._createCardToken = function( callback ) {
 };
 
 TransactionFlow.prototype._submitWithPayment = function( payment ) {
-	var onComplete = this.push.bind( this, null ), // End the stream when the transaction has finished
-		transaction = {
-			cart: omit( this._initialData.cart, [ 'messages' ] ), // messages contain reference to DOMNode
-			domain_details: this._initialData.domainDetails,
-			payment: payment,
-		};
+	const onComplete = this.push.bind( this, null ); // End the stream when the transaction has finished
+	const transaction = {
+		cart: omit( this._initialData.cart, [ 'messages' ] ), // messages contain reference to DOMNode
+		domain_details: this._initialData.domainDetails,
+		payment: payment,
+	};
 
 	this._pushStep( { name: SUBMITTING_WPCOM_REQUEST } );
 
@@ -200,7 +198,7 @@ TransactionFlow.prototype._submitWithPayment = function( payment ) {
 	);
 };
 
-function createPaygateToken( requestType, cardDetails, callback ) {
+export function createCardToken( requestType, cardDetails, callback ) {
 	debug( 'creating token with Paygate' );
 	wpcom.paygateConfiguration(
 		{
@@ -245,10 +243,6 @@ function createPaygateToken( requestType, cardDetails, callback ) {
 	}
 }
 
-function createCardToken( requestType, cardDetails, callback ) {
-	return createPaygateToken( requestType, cardDetails, callback );
-}
-
 function getPaygateParameters( cardDetails ) {
 	return {
 		name: cardDetails.name,
@@ -261,33 +255,22 @@ function getPaygateParameters( cardDetails ) {
 	};
 }
 
-function hasDomainDetails( transaction ) {
+export function hasDomainDetails( transaction ) {
 	return ! isEmpty( transaction.domainDetails );
 }
 
-function newCardPayment( newCardDetails ) {
+export function newCardPayment( newCardDetails ) {
 	return {
 		paymentMethod: 'WPCOM_Billing_MoneyPress_Paygate',
 		newCardDetails: newCardDetails || {},
 	};
 }
 
-function storedCardPayment( storedCard ) {
+export function storedCardPayment( storedCard ) {
 	return {
 		paymentMethod: 'WPCOM_Billing_MoneyPress_Stored',
 		storedCard: storedCard,
 	};
 }
 
-function fullCreditsPayment() {
-	return { paymentMethod: 'WPCOM_Billing_WPCOM' };
-}
-
-export default {
-	createCardToken,
-	fullCreditsPayment,
-	hasDomainDetails,
-	newCardPayment,
-	storedCardPayment,
-	submit,
-};
+export const fullCreditsPayment = { paymentMethod: 'WPCOM_Billing_WPCOM' };

--- a/client/lib/upgrades/actions/checkout.js
+++ b/client/lib/upgrades/actions/checkout.js
@@ -1,12 +1,10 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
 import { action as ActionTypes } from '../constants';
 import Dispatcher from 'dispatcher';
-import storeTransactions from 'lib/store-transactions';
+import { submit } from 'lib/store-transactions';
 
 function setDomainDetails( domainDetails ) {
 	Dispatcher.handleViewAction( {
@@ -33,7 +31,7 @@ function setNewCreditCardDetails( options ) {
 }
 
 function submitTransaction( { cart, transaction }, onComplete ) {
-	const steps = storeTransactions.submit( {
+	const steps = submit( {
 		cart: cart,
 		payment: transaction.payment,
 		domainDetails: transaction.domainDetails,

--- a/client/lib/upgrades/actions/free-trials.js
+++ b/client/lib/upgrades/actions/free-trials.js
@@ -24,7 +24,7 @@ const productsList = productsListFactory();
 function submitFreeTransaction( partialCart, onComplete ) {
 	const cart = fillInAllCartItemAttributes( partialCart, productsList.get() ),
 		transaction = {
-			payment: fullCreditsPayment(),
+			payment: fullCreditsPayment,
 		};
 
 	submitTransaction( { cart, transaction }, onComplete );

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -14,7 +14,7 @@ import { find } from 'lodash';
 import analytics from 'lib/analytics';
 import StoredCard from './stored-card';
 import NewCardForm from './new-card-form';
-import storeTransactions from 'lib/store-transactions';
+import { newCardPayment, storedCardPayment } from 'lib/store-transactions';
 import upgradesActions from 'lib/upgrades/actions';
 
 class CreditCardSelector extends React.Component {
@@ -83,9 +83,9 @@ class CreditCardSelector extends React.Component {
 
 		if ( 'new-card' === section ) {
 			analytics.ga.recordEvent( 'Upgrades', 'Clicked Use a New Credit/Debit Card Link' );
-			newPayment = storeTransactions.newCardPayment( this.props.transaction.newCardFormFields );
+			newPayment = newCardPayment( this.props.transaction.newCardFormFields );
 		} else {
-			newPayment = storeTransactions.storedCardPayment( this.getStoredCardDetails( section ) );
+			newPayment = storedCardPayment( this.getStoredCardDetails( section ) );
 		}
 
 		upgradesActions.setPayment( newPayment );

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -18,7 +18,7 @@ import FreeCartPaymentBox from './free-cart-payment-box';
 import CreditCardPaymentBox from './credit-card-payment-box';
 import PayPalPaymentBox from './paypal-payment-box';
 import SourcePaymentBox from './source-payment-box';
-import storeTransactions from 'lib/store-transactions';
+import { fullCreditsPayment, newCardPayment, storedCardPayment } from 'lib/store-transactions';
 import analytics from 'lib/analytics';
 import TransactionStepsMixin from './transaction-steps-mixin';
 import upgradesActions from 'lib/upgrades/actions';
@@ -116,14 +116,14 @@ const SecurePaymentForm = createReactClass( {
 				// FIXME: The endpoint doesn't currently support transactions with no
 				//   payment info, so for now we rely on the credits payment method for
 				//   free carts.
-				newPayment = storeTransactions.fullCreditsPayment();
+				newPayment = fullCreditsPayment;
 				break;
 
 			case 'credit-card':
 				if ( this.getInitialCard() ) {
-					newPayment = storeTransactions.storedCardPayment( this.getInitialCard() );
+					newPayment = storedCardPayment( this.getInitialCard() );
 				} else {
-					newPayment = storeTransactions.newCardPayment();
+					newPayment = newCardPayment();
 				}
 				break;
 


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.