### PR TITLE
esmodules: Update lib/shortcode

### DIFF
--- a/client/components/tinymce/plugins/contact-form/shortcode-utils.js
+++ b/client/components/tinymce/plugins/contact-form/shortcode-utils.js
@@ -1,15 +1,13 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { pickBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import Shortcode from 'lib/shortcode';
+import { next, parse, stringify } from 'lib/shortcode';
 
 export function serialize( { to, subject, fields = [] } = {} ) {
 	const content = fields
@@ -18,7 +16,7 @@ export function serialize( { to, subject, fields = [] } = {} ) {
 				return;
 			}
 
-			let fieldShortcode = {
+			const fieldShortcode = {
 				tag: 'contact-field',
 				type: 'self-closing',
 				attrs: pickBy( { label, type, options } ),
@@ -28,11 +26,11 @@ export function serialize( { to, subject, fields = [] } = {} ) {
 				fieldShortcode.attrs.required = 1;
 			}
 
-			return Shortcode.stringify( fieldShortcode );
+			return stringify( fieldShortcode );
 		} )
 		.join( '' );
 
-	return Shortcode.stringify( {
+	return stringify( {
 		tag: 'contact-form',
 		type: 'closed',
 		content,
@@ -45,17 +43,17 @@ export function deserialize( shortcode ) {
 		return null;
 	}
 
-	const parsed = Shortcode.parse( shortcode );
+	const parsed = parse( shortcode );
 
 	if ( parsed ) {
 		return ( ( { attrs: { named: { to, subject } = {} } = {}, content } ) => {
-			let fields = [];
+			const fields = [];
 			let parsedField;
 
-			while ( content && ( parsedField = Shortcode.next( 'contact-field', content ) ) ) {
+			while ( content && ( parsedField = next( 'contact-field', content ) ) ) {
 				if ( 'attrs' in parsedField.shortcode ) {
 					const { label, type, options, required } = parsedField.shortcode.attrs.named;
-					let field = pickBy( { label, type, options, required } );
+					const field = pickBy( { label, type, options, required } );
 					if ( 'required' in field ) {
 						field.required = true;
 					}

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -1,16 +1,14 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import ReactDom from 'react-dom';
 import ReactDomServer from 'react-dom/server';
 import React from 'react';
 import tinymce from 'tinymce/tinymce';
 import { assign, debounce, find, findLast, pick, values } from 'lodash';
 import i18n from 'i18n-calypso';
-import Shortcode from 'lib/shortcode';
+import { parse, stringify } from 'lib/shortcode';
 import closest from 'component-closest';
 import Gridicon from 'gridicons';
 
@@ -560,7 +558,7 @@ function mediaButton( editor ) {
 				attrs.align = 'align' + parsed.appearance.align;
 			}
 
-			const shortcode = Shortcode.stringify( {
+			const shortcode = stringify( {
 				tag: 'caption',
 				attrs: attrs,
 				content: [ node.outerHTML, content ].join( ' ' ),
@@ -709,7 +707,7 @@ function mediaButton( editor ) {
 			return;
 		}
 
-		let gallery = Shortcode.parse( content );
+		let gallery = parse( content );
 		if ( gallery.tag !== 'gallery' ) {
 			return;
 		}

--- a/client/components/tinymce/plugins/simple-payments/shortcode-utils.js
+++ b/client/components/tinymce/plugins/simple-payments/shortcode-utils.js
@@ -1,22 +1,20 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import Shortcode from 'lib/shortcode';
+import { parse, stringify } from 'lib/shortcode';
 
 /**
  * Serializes shortcode data (object with id property) to a Simple Payments shortcode.
  * @returns {string} Serialized shortcode, e.g., `[simple-payment id="1"]`
  */
 export function serialize( { id } ) {
-	return Shortcode.stringify( {
+	return stringify( {
 		tag: 'simple-payment',
 		type: 'single',
 		attrs: { id },
@@ -34,7 +32,7 @@ export function deserialize( shortcode ) {
 		return null;
 	}
 
-	const parsed = Shortcode.parse( shortcode );
+	const parsed = parse( shortcode );
 
 	const shortcodeData = {};
 

--- a/client/components/tinymce/plugins/wpcom-view/gallery-view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/gallery-view.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -11,12 +9,12 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import shortcodeUtils from 'lib/shortcode';
+import { next } from 'lib/shortcode';
 import GalleryShortcode from 'components/gallery-shortcode';
 
 class GalleryView extends Component {
 	static match( content ) {
-		const nextMatch = shortcodeUtils.next( 'gallery', content );
+		const nextMatch = next( 'gallery', content );
 
 		if ( nextMatch ) {
 			return {

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { deserialize } from 'components/tinymce/plugins/contact-form/shortcode-utils';
@@ -11,7 +9,7 @@ import { deserialize } from 'components/tinymce/plugins/contact-form/shortcode-u
 /**
  * Internal dependencies
  */
-import shortcodeUtils from 'lib/shortcode';
+import { next } from 'lib/shortcode';
 import renderField from './preview-fields';
 
 const ContactForm = localize( ( { content, translate } ) => {
@@ -26,7 +24,7 @@ const ContactForm = localize( ( { content, translate } ) => {
 } );
 
 export function match( content ) {
-	const m = shortcodeUtils.next( 'contact-form', content );
+	const m = next( 'contact-form', content );
 
 	if ( m ) {
 		return {

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -1,9 +1,5 @@
-/**
- * /* eslint-disable wpcalypso/jsx-classname-namespace
- *
- * @format
- */
-
+/** @format **/
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies
  */
@@ -15,14 +11,13 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import shortcodeUtils from 'lib/shortcode';
+import { next } from 'lib/shortcode';
 import { deserialize } from 'components/tinymce/plugins/simple-payments/shortcode-utils';
-import { getSimplePayments } from 'state/selectors';
+import { getMediaItem, getSimplePayments } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import formatCurrency from 'lib/format-currency';
 import QuerySimplePayments from 'components/data/query-simple-payments';
 import QueryMedia from 'components/data/query-media';
-import { getMediaItem } from 'state/selectors';
 
 class SimplePaymentsView extends Component {
 	render() {
@@ -105,7 +100,7 @@ SimplePaymentsView = connect( ( state, props ) => {
 } )( localize( SimplePaymentsView ) );
 
 SimplePaymentsView.match = content => {
-	const match = shortcodeUtils.next( 'simple-payment', content );
+	const match = next( 'simple-payment', content );
 
 	if ( match ) {
 		return {

--- a/client/components/tinymce/plugins/wpcom-view/views/video/index.js
+++ b/client/components/tinymce/plugins/wpcom-view/views/video/index.js
@@ -1,14 +1,12 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
-import ShortcodeUtils from 'lib/shortcode';
+import { next } from 'lib/shortcode';
 import VideoView from './view';
 
 export function match( content ) {
-	const nextMatch = ShortcodeUtils.next( 'wpvideo', content );
+	const nextMatch = next( 'wpvideo', content );
 
 	if ( nextMatch ) {
 		return {

--- a/client/lib/media-serialization/strategies/string.js
+++ b/client/lib/media-serialization/strategies/string.js
@@ -1,10 +1,8 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
-import Shortcode from 'lib/shortcode';
+import { parse } from 'lib/shortcode';
 import { deserialize as _recurse } from '../';
 import createElementFromString from '../create-element-from-string';
 
@@ -19,7 +17,7 @@ import createElementFromString from '../create-element-from-string';
 function parseAsShortcode( node, _parsed ) {
 	// Attempt to convert string element into DOM node. If successful, recurse
 	// to trigger the shortcode strategy
-	const shortcode = Shortcode.parse( node );
+	const shortcode = parse( node );
 	if ( shortcode ) {
 		return _recurse( shortcode, _parsed );
 	}

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import url from 'url';
 import path from 'path';
 import photon from 'photon';
@@ -22,7 +20,7 @@ import {
 	GallerySizeableTypes,
 	GalleryDefaultAttrs,
 } from './constants';
-import Shortcode from 'lib/shortcode';
+import { stringify } from 'lib/shortcode';
 import { uniqueId } from 'lib/impure-lodash';
 import versionCompare from 'lib/version-compare';
 
@@ -454,7 +452,7 @@ const MediaUtils = {
 			delete attrs.orderBy;
 		}
 
-		return Shortcode.stringify( {
+		return stringify( {
 			tag: 'gallery',
 			type: 'single',
 			attrs: attrs,

--- a/client/lib/shortcode/README.md
+++ b/client/lib/shortcode/README.md
@@ -6,9 +6,9 @@ Utility functions for working with WordPress shortcodes. These functions largely
 ## Usage
 
 ```js
-import Shortcode from 'lib/shortcode';
+import { parse, stringify } from 'lib/shortcode';
 
-const value = Shortcode.stringify( {
+const value = stringify( {
 	tag: 'foo',
 	attrs: {
 		bar: 'baz'
@@ -17,7 +17,7 @@ const value = Shortcode.stringify( {
 
 // -> [foo bar="baz"][/foo]
 
-const parsed = Shortcode.parse( value );
+const parsed = parse( value );
 // -> { tag: 'foo', type: 'closed', attrs: { named: { bar: 'baz' }, numeric: [] } }
 ```
 

--- a/client/lib/shortcode/index.js
+++ b/client/lib/shortcode/index.js
@@ -1,17 +1,14 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { isEqual, memoize } from 'lodash';
 
 /**
  * Module variables
  */
-var Shortcode = {},
-	REGEXP_ATTR_STRING = /(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*\'([^\']*)\'(?:\s|$)|(\w+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/g,
-	REGEXP_SHORTCODE = /\[(\[?)([^\[\]\/\s\u00a0\u200b]+)(?![\w-])([^\]\/]*(?:\/(?!\])[^\]\/]*)*?)(?:(\/)\]|\](?:([^\[]*(?:\[(?!\/\2\])[^\[]*)*)(\[\/\2\]))?)(\]?)/;
+const REGEXP_ATTR_STRING = /(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*\'([^\']*)\'(?:\s|$)|(\w+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/g; // eslint-disable-line max-len
+const REGEXP_SHORTCODE = /\[(\[?)([^\[\]\/\s\u00a0\u200b]+)(?![\w-])([^\]\/]*(?:\/(?!\])[^\]\/]*)*?)(?:(\/)\]|\](?:([^\[]*(?:\[(?!\/\2\])[^\[]*)*)(\[\/\2\]))?)(\]?)/; // eslint-disable-line max-len
 
 /**
  * Given a string, parses shortcode attributes and returns an object containing
@@ -25,10 +22,10 @@ var Shortcode = {},
  * @param  {string} text A shortcode attribute string
  * @return {Object}      An object of attributes, split as named and numeric
  */
-Shortcode.parseAttributes = memoize( function( text ) {
-	var named = {},
-		numeric = [],
-		match;
+export const parseAttributes = memoize( function( text ) {
+	const named = {};
+	const numeric = [];
+	let match;
 
 	// Map zero-width spaces to actual spaces.
 	text = text.replace( /[\u00a0\u200b]/g, ' ' );
@@ -63,11 +60,12 @@ Shortcode.parseAttributes = memoize( function( text ) {
  * @param  {*}      attributes An object to normalize
  * @return {Object}            An object of attributes, split as named and numeric
  */
-Shortcode.normalizeAttributes = function( attributes ) {
-	var named, numeric;
+export const normalizeAttributes = function( attributes ) {
+	let named;
+	let numeric;
 
 	if ( 'string' === typeof attributes ) {
-		return Shortcode.parseAttributes( attributes );
+		return parseAttributes( attributes );
 	} else if ( Array.isArray( attributes ) ) {
 		numeric = attributes;
 	} else if (
@@ -91,12 +89,12 @@ Shortcode.normalizeAttributes = function( attributes ) {
  * @param  {Object} shortcode A shortcode object
  * @return {string}           The string value of the shortcode
  */
-Shortcode.stringify = function( shortcode ) {
-	var text = '[' + shortcode.tag,
-		attributes = Shortcode.normalizeAttributes( shortcode.attrs );
+export const stringify = function( shortcode ) {
+	let text = '[' + shortcode.tag;
+	const attributes = normalizeAttributes( shortcode.attrs );
 
 	Object.keys( attributes.named ).forEach( function( name ) {
-		var value = attributes.named[ name ];
+		const value = attributes.named[ name ];
 		text += ' ' + name + '="' + value + '"';
 	} );
 
@@ -133,10 +131,9 @@ Shortcode.stringify = function( shortcode ) {
  * @param  {string} shortcode A shortcode string
  * @return {Object}           The object value of the shortcode
  */
-Shortcode.parse = function( shortcode ) {
-	var match = shortcode.match( REGEXP_SHORTCODE ),
-		type,
-		parsed;
+export const parse = function( shortcode ) {
+	const match = shortcode.match( REGEXP_SHORTCODE );
+	let type;
 
 	if ( ! match ) {
 		return null;
@@ -150,13 +147,13 @@ Shortcode.parse = function( shortcode ) {
 		type = 'single';
 	}
 
-	parsed = {
+	const parsed = {
 		tag: match[ 2 ],
 		type: type,
 	};
 
 	if ( /\S/.test( match[ 3 ] ) ) {
-		parsed.attrs = Shortcode.parseAttributes( match[ 3 ] );
+		parsed.attrs = parseAttributes( match[ 3 ] );
 	}
 
 	if ( match[ 5 ] ) {
@@ -185,11 +182,11 @@ Shortcode.parse = function( shortcode ) {
  * @param {String} tag - shortcode name
  * @return {RegExp} regular expression
  */
-Shortcode.regexp = memoize( function( tag ) {
+export const regexp = memoize( function( tag ) {
 	return new RegExp(
 		'\\[(\\[?)(' +
 			tag +
-			')(?![\\w-])([^\\]\\/]*(?:\\/(?!\\])[^\\]\\/]*)*?)(?:(\\/)\\]|\\](?:([^\\[]*(?:\\[(?!\\/\\2\\])[^\\[]*)*)(\\[\\/\\2\\]))?)(\\]?)',
+			')(?![\\w-])([^\\]\\/]*(?:\\/(?!\\])[^\\]\\/]*)*?)(?:(\\/)\\]|\\](?:([^\\[]*(?:\\[(?!\\/\\2\\])[^\\[]*)*)(\\[\\/\\2\\]))?)(\\]?)', // eslint-disable-line max-len
 		'g'
 	);
 } );
@@ -209,13 +206,11 @@ Shortcode.regexp = memoize( function( tag ) {
  *
  * @return {Object|void} next match
  */
-Shortcode.next = function( tag, text, index ) {
-	var re = Shortcode.regexp( tag ),
-		match,
-		result;
+export const next = function( tag, text, index = 0 ) {
+	const re = regexp( tag );
 
 	re.lastIndex = index || 0;
-	match = re.exec( text );
+	const match = re.exec( text );
 
 	if ( ! match ) {
 		return;
@@ -223,13 +218,13 @@ Shortcode.next = function( tag, text, index ) {
 
 	// If we matched an escaped shortcode, try again.
 	if ( '[' === match[ 1 ] && ']' === match[ 7 ] ) {
-		return Shortcode.next( tag, text, re.lastIndex );
+		return next( tag, text, re.lastIndex );
 	}
 
-	result = {
+	const result = {
 		index: match.index,
 		content: match[ 0 ],
-		shortcode: Shortcode.parse( match[ 0 ] ),
+		shortcode: parse( match[ 0 ] ),
 	};
 
 	// If we matched a leading `[`, strip it from the match
@@ -246,5 +241,3 @@ Shortcode.next = function( tag, text, index ) {
 
 	return result;
 };
-
-export default Shortcode;

--- a/client/lib/shortcode/test/index.js
+++ b/client/lib/shortcode/test/index.js
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */
@@ -8,14 +7,12 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import Shortcode from '../';
+import { normalizeAttributes, parse, parseAttributes, stringify } from '../index';
 
 describe( 'index', () => {
 	describe( '#parseAttributes()', () => {
 		test( 'should parse a string of named attributes', () => {
-			var result = Shortcode.parseAttributes( 'bar="baz"' );
-
-			expect( result ).to.eql( {
+			expect( parseAttributes( 'bar="baz"' ) ).to.eql( {
 				named: {
 					bar: 'baz',
 				},
@@ -24,18 +21,14 @@ describe( 'index', () => {
 		} );
 
 		test( 'should parse a string of numeric attributes', () => {
-			var result = Shortcode.parseAttributes( 'bar baz' );
-
-			expect( result ).to.eql( {
+			expect( parseAttributes( 'bar baz' ) ).to.eql( {
 				named: {},
 				numeric: [ 'bar', 'baz' ],
 			} );
 		} );
 
 		test( 'should parse a string of mixed attributes', () => {
-			var result = Shortcode.parseAttributes( 'bar="baz" qux' );
-
-			expect( result ).to.eql( {
+			expect( parseAttributes( 'bar="baz" qux' ) ).to.eql( {
 				named: {
 					bar: 'baz',
 				},
@@ -46,9 +39,7 @@ describe( 'index', () => {
 
 	describe( '#normalizeAttributes()', () => {
 		test( 'should normalize a string of named attributes', () => {
-			var result = Shortcode.normalizeAttributes( 'bar="baz"' );
-
-			expect( result ).to.eql( {
+			expect( normalizeAttributes( 'bar="baz"' ) ).to.eql( {
 				named: {
 					bar: 'baz',
 				},
@@ -57,18 +48,14 @@ describe( 'index', () => {
 		} );
 
 		test( 'should normalize a string of numeric attributes', () => {
-			var result = Shortcode.normalizeAttributes( 'bar' );
-
-			expect( result ).to.eql( {
+			expect( normalizeAttributes( 'bar' ) ).to.eql( {
 				named: {},
 				numeric: [ 'bar' ],
 			} );
 		} );
 
 		test( 'should normalize a string of mixed attributes', () => {
-			var result = Shortcode.normalizeAttributes( 'bar="baz" qux' );
-
-			expect( result ).to.eql( {
+			expect( normalizeAttributes( 'bar="baz" qux' ) ).to.eql( {
 				named: {
 					bar: 'baz',
 				},
@@ -77,29 +64,25 @@ describe( 'index', () => {
 		} );
 
 		test( 'should normalize an array as numeric attributes', () => {
-			var result = Shortcode.normalizeAttributes( [ 'bar' ] );
-
-			expect( result ).to.eql( {
+			expect( normalizeAttributes( [ 'bar' ] ) ).to.eql( {
 				named: {},
 				numeric: [ 'bar' ],
 			} );
 		} );
 
 		test( 'should explicitly return an object of already split attributes', () => {
-			var attributes = {
-					named: { bar: 'baz' },
-					numeric: [ 'qux' ],
-				},
-				result = Shortcode.normalizeAttributes( attributes );
+			const attributes = {
+				named: { bar: 'baz' },
+				numeric: [ 'qux' ],
+			};
 
-			expect( result ).to.eql( attributes );
+			expect( normalizeAttributes( attributes ) ).to.eql( attributes );
 		} );
 
 		test( 'should normalize an object as the named attributes', () => {
-			var attributes = { bar: 'baz' },
-				result = Shortcode.normalizeAttributes( attributes );
+			const attributes = { bar: 'baz' };
 
-			expect( result ).to.eql( {
+			expect( normalizeAttributes( attributes ) ).to.eql( {
 				named: attributes,
 				numeric: [],
 			} );
@@ -108,87 +91,83 @@ describe( 'index', () => {
 
 	describe( '#stringify()', () => {
 		test( 'should generate a closed shortcode when only the tag is specified', () => {
-			var result = Shortcode.stringify( {
-				tag: 'foo',
-			} );
-
-			expect( result ).to.equal( '[foo][/foo]' );
+			expect(
+				stringify( {
+					tag: 'foo',
+				} )
+			).to.equal( '[foo][/foo]' );
 		} );
 
 		test( 'should accept an object of named attributes', () => {
-			var result = Shortcode.stringify( {
-				tag: 'foo',
-				attrs: {
-					bar: 'baz',
-				},
-			} );
-
-			expect( result ).to.equal( '[foo bar="baz"][/foo]' );
+			expect(
+				stringify( {
+					tag: 'foo',
+					attrs: {
+						bar: 'baz',
+					},
+				} )
+			).to.equal( '[foo bar="baz"][/foo]' );
 		} );
 
 		test( 'should accept an array of numeric attributes', () => {
-			var result = Shortcode.stringify( {
-				tag: 'foo',
-				attrs: [ 'bar' ],
-			} );
-
-			expect( result ).to.equal( '[foo bar][/foo]' );
+			expect(
+				stringify( {
+					tag: 'foo',
+					attrs: [ 'bar' ],
+				} )
+			).to.equal( '[foo bar][/foo]' );
 		} );
 
 		test( 'should accept an object of mixed attributes', () => {
-			var result = Shortcode.stringify( {
-				tag: 'foo',
-				attrs: {
-					named: { bar: 'baz' },
-					numeric: [ 'qux' ],
-				},
-			} );
-
-			expect( result ).to.equal( '[foo bar="baz" qux][/foo]' );
+			expect(
+				stringify( {
+					tag: 'foo',
+					attrs: {
+						named: { bar: 'baz' },
+						numeric: [ 'qux' ],
+					},
+				} )
+			).to.equal( '[foo bar="baz" qux][/foo]' );
 		} );
 
 		test( 'should omit the closing tag for single type', () => {
-			var result = Shortcode.stringify( {
-				tag: 'foo',
-				type: 'single',
-			} );
-
-			expect( result ).to.equal( '[foo]' );
+			expect(
+				stringify( {
+					tag: 'foo',
+					type: 'single',
+				} )
+			).to.equal( '[foo]' );
 		} );
 
 		test( 'should self-close for self-closing type', () => {
-			var result = Shortcode.stringify( {
-				tag: 'foo',
-				type: 'self-closing',
-			} );
-
-			expect( result ).to.equal( '[foo /]' );
+			expect(
+				stringify( {
+					tag: 'foo',
+					type: 'self-closing',
+				} )
+			).to.equal( '[foo /]' );
 		} );
 
 		test( 'should include content between the opening and closing tags', () => {
-			var result = Shortcode.stringify( {
-				tag: 'foo',
-				content: 'Bar',
-			} );
-
-			expect( result ).to.equal( '[foo]Bar[/foo]' );
+			expect(
+				stringify( {
+					tag: 'foo',
+					content: 'Bar',
+				} )
+			).to.equal( '[foo]Bar[/foo]' );
 		} );
 	} );
 
 	describe( '#parse()', () => {
 		test( 'should interpret a closed shortcode', () => {
-			var result = Shortcode.parse( '[foo][/foo]' );
-
-			expect( result ).to.eql( {
+			expect( parse( '[foo][/foo]' ) ).to.eql( {
 				tag: 'foo',
 				type: 'closed',
 			} );
 		} );
 
 		test( 'should interpret a shortcode with named attributes', () => {
-			var result = Shortcode.parse( '[foo bar="baz"][/foo]' );
-
-			expect( result ).to.eql( {
+			expect( parse( '[foo bar="baz"][/foo]' ) ).to.eql( {
 				tag: 'foo',
 				type: 'closed',
 				attrs: {
@@ -201,9 +180,7 @@ describe( 'index', () => {
 		} );
 
 		test( 'should interpret a shortcode with numeric attributes', () => {
-			var result = Shortcode.parse( '[foo bar][/foo]' );
-
-			expect( result ).to.eql( {
+			expect( parse( '[foo bar][/foo]' ) ).to.eql( {
 				tag: 'foo',
 				type: 'closed',
 				attrs: {
@@ -214,9 +191,7 @@ describe( 'index', () => {
 		} );
 
 		test( 'should interpret a shortcode with mixed attributes', () => {
-			var result = Shortcode.parse( '[foo bar="baz" qux][/foo]' );
-
-			expect( result ).to.eql( {
+			expect( parse( '[foo bar="baz" qux][/foo]' ) ).to.eql( {
 				tag: 'foo',
 				type: 'closed',
 				attrs: {
@@ -229,27 +204,21 @@ describe( 'index', () => {
 		} );
 
 		test( 'should interpret a single type shortcode', () => {
-			var result = Shortcode.parse( '[foo]' );
-
-			expect( result ).to.eql( {
+			expect( parse( '[foo]' ) ).to.eql( {
 				tag: 'foo',
 				type: 'single',
 			} );
 		} );
 
 		test( 'should interpret a self-closing shortcode', () => {
-			var result = Shortcode.parse( '[foo /]' );
-
-			expect( result ).to.eql( {
+			expect( parse( '[foo /]' ) ).to.eql( {
 				tag: 'foo',
 				type: 'self-closing',
 			} );
 		} );
 
 		test( 'should interpret a shortcode with content', () => {
-			var result = Shortcode.parse( '[foo]Bar[/foo]' );
-
-			expect( result ).to.eql( {
+			expect( parse( '[foo]Bar[/foo]' ) ).to.eql( {
 				tag: 'foo',
 				type: 'closed',
 				content: 'Bar',

--- a/client/lib/shortcodes/store.js
+++ b/client/lib/shortcodes/store.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { ReduceStore } from 'flux/utils';
 import { intersection, pickBy } from 'lodash';
 
@@ -11,7 +9,7 @@ import { intersection, pickBy } from 'lodash';
  * Internal dependencies
  */
 import Dispatcher from 'dispatcher';
-import Shortcode from 'lib/shortcode';
+import { parse } from 'lib/shortcode';
 import { ActionTypes, LoadStatus } from './constants';
 
 class ShortcodesStore extends ReduceStore {
@@ -83,7 +81,7 @@ class ShortcodesStore extends ReduceStore {
 
 				state = Object.assign( {}, state, {
 					[ action.siteId ]: pickBy( state[ action.siteId ], ( status, shortcode ) => {
-						const parsed = Shortcode.parse( shortcode );
+						const parsed = parse( shortcode );
 						if ( parsed.tag !== 'gallery' || ! parsed.attrs.named || ! parsed.attrs.named.ids ) {
 							return true;
 						}

--- a/client/post-editor/media-modal/markup.js
+++ b/client/post-editor/media-modal/markup.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { assign } from 'lodash';
 import ReactDomServer from 'react-dom/server';
 import React from 'react';
@@ -12,16 +10,14 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import Shortcode from 'lib/shortcode';
+import { parse, stringify } from 'lib/shortcode';
 import MediaUtils from 'lib/media/utils';
 import MediaSerialization from 'lib/media-serialization';
 
 /**
  * Module variables
  */
-var Markup;
-
-Markup = {
+const Markup = {
 	/**
 	 * Given a media object and a site, returns a markup string representing that object
 	 * as HTML.
@@ -32,13 +28,11 @@ Markup = {
 	 * @return {string}         A markup string
 	 */
 	get: function( site, media, options ) {
-		var mimePrefix;
-
 		if ( ! media || media.hasOwnProperty( 'status' ) ) {
 			return '';
 		}
 
-		mimePrefix = MediaUtils.getMimePrefix( media );
+		const mimePrefix = MediaUtils.getMimePrefix( media );
 
 		// Attempt to find a matching function in the mimeTypes object using
 		// the MIME type prefix
@@ -57,7 +51,7 @@ Markup = {
 	 * @return {string}       A link markup string
 	 */
 	link: function( media ) {
-		var element = React.createElement(
+		const element = React.createElement(
 			'a',
 			{
 				href: media.URL,
@@ -84,18 +78,18 @@ Markup = {
 	 *                                 a captioned item.
 	 */
 	caption: function( site, media ) {
-		var parsed, match, img, caption, width;
+		let img, caption, width;
 
 		if ( 'string' !== typeof media ) {
 			media = Markup.get( site, media );
 		}
 
-		parsed = Shortcode.parse( media );
+		const parsed = parse( media );
 		if ( ! parsed || ! parsed.content ) {
 			return null;
 		}
 
-		match = parsed.content.match( /((?:<a [^>]+>)?<img [^>]+>(?:<\/a>)?)([\s\S]*)/i );
+		const match = parsed.content.match( /((?:<a [^>]+>)?<img [^>]+>(?:<\/a>)?)([\s\S]*)/i );
 		if ( match ) {
 			img = match[ 1 ].trim();
 			caption = match[ 2 ].trim();
@@ -182,7 +176,7 @@ Markup = {
 
 			let markup = ReactDomServer.renderToStaticMarkup( img );
 			if ( media.caption && width ) {
-				markup = Shortcode.stringify( {
+				markup = stringify( {
 					tag: 'caption',
 					attrs: {
 						id: 'attachment_' + media.ID,
@@ -204,7 +198,7 @@ Markup = {
 		 * @return {string}       An audio markup string
 		 */
 		audio: function( site, media ) {
-			return Shortcode.stringify( {
+			return stringify( {
 				tag: 'audio',
 				attrs: {
 					src: media.URL,
@@ -222,14 +216,14 @@ Markup = {
 		 */
 		video: function( site, media ) {
 			if ( MediaUtils.isVideoPressItem( media ) ) {
-				return Shortcode.stringify( {
+				return stringify( {
 					tag: 'wpvideo',
 					attrs: [ media.videopress_guid ],
 					type: 'single',
 				} );
 			}
 
-			return Shortcode.stringify( {
+			return stringify( {
 				tag: 'video',
 				attrs: {
 					src: media.URL,


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.