### PR TITLE
esmodules: Update lib/posts/utils

### DIFF
--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -16,7 +16,7 @@ import { localize } from 'i18n-calypso';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { blockSite } from 'state/reader/site-blocks/actions';
-import PostUtils from 'lib/posts/utils';
+import { getEditURL, userCan } from 'lib/posts/utils';
 import FollowButton from 'reader/follow-button';
 import * as DiscoverHelper from 'reader/discover/helper';
 import * as stats from 'reader/stats';
@@ -90,7 +90,7 @@ class ReaderPostOptionsMenu extends React.Component {
 		let editUrl = '//wordpress.com/post/' + post.site_ID + '/' + post.ID + '/';
 
 		if ( site && site.slug ) {
-			editUrl = PostUtils.getEditURL( post, site );
+			editUrl = getEditURL( post, site );
 		}
 
 		stats.recordAction( 'edit_post' );
@@ -124,7 +124,7 @@ class ReaderPostOptionsMenu extends React.Component {
 	render() {
 		const { post, site, feed, teams, translate, position } = this.props;
 		const { ID: postId, site_ID: siteId } = post;
-		const isEditPossible = PostUtils.userCan( 'edit_post', post );
+		const isEditPossible = userCan( 'edit_post', post );
 		const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
 		const followUrl = this.getFollowUrl();
 		const isTeamMember = isAutomatticTeamMember( teams );

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -16,7 +16,7 @@ import { localize } from 'i18n-calypso';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { blockSite } from 'state/reader/site-blocks/actions';
-import { getEditURL, userCan } from 'lib/posts/utils';
+import * as PostUtils from 'lib/posts/utils';
 import FollowButton from 'reader/follow-button';
 import * as DiscoverHelper from 'reader/discover/helper';
 import * as stats from 'reader/stats';
@@ -90,7 +90,7 @@ class ReaderPostOptionsMenu extends React.Component {
 		let editUrl = '//wordpress.com/post/' + post.site_ID + '/' + post.ID + '/';
 
 		if ( site && site.slug ) {
-			editUrl = getEditURL( post, site );
+			editUrl = PostUtils.getEditURL( post, site );
 		}
 
 		stats.recordAction( 'edit_post' );
@@ -124,7 +124,7 @@ class ReaderPostOptionsMenu extends React.Component {
 	render() {
 		const { post, site, feed, teams, translate, position } = this.props;
 		const { ID: postId, site_ID: siteId } = post;
-		const isEditPossible = userCan( 'edit_post', post );
+		const isEditPossible = PostUtils.userCan( 'edit_post', post );
 		const isDiscoverPost = DiscoverHelper.isDiscoverPost( post );
 		const followUrl = this.getFollowUrl();
 		const isTeamMember = isAutomatticTeamMember( teams );

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -16,7 +16,7 @@ import PostsStore from './posts-store';
 import PostEditStore from './post-edit-store';
 import postListStoreFactory from './post-list-store-factory';
 import PreferencesStore from 'lib/preferences/store';
-import utils from './utils';
+import * as utils from './utils';
 import versionCompare from 'lib/version-compare';
 import Dispatcher from 'dispatcher';
 import { recordSaveEvent } from './stats';

--- a/client/lib/posts/post-edit-store.js
+++ b/client/lib/posts/post-edit-store.js
@@ -13,7 +13,7 @@ import emitter from 'lib/mixins/emitter';
  */
 import Dispatcher from 'dispatcher';
 import { decodeEntities } from 'lib/formatting';
-import utils from './utils';
+import * as utils from './utils';
 
 /**
  * Module variables

--- a/client/lib/posts/posts-store.js
+++ b/client/lib/posts/posts-store.js
@@ -11,7 +11,7 @@ const debug = debugFactory( 'calypso:posts' );
 /**
  * Internal dependencies
  */
-import utils from './utils';
+import * as utils from './utils';
 import Dispatcher from 'dispatcher';
 
 var _posts = {},

--- a/client/lib/posts/stats.js
+++ b/client/lib/posts/stats.js
@@ -10,7 +10,7 @@ import { noop } from 'lodash';
  */
 import analytics from 'lib/analytics';
 import PostEditStore from 'lib/posts/post-edit-store';
-import utils from 'lib/posts/utils';
+import { getVisibility, isPublished } from 'lib/posts/utils';
 
 /**
  * Module variables
@@ -56,7 +56,7 @@ export function recordSaveEvent( site, context ) {
 	let usageAction = false;
 	let eventContext = null;
 
-	if ( ! post.ID && ! utils.isPublished( post ) ) {
+	if ( ! post.ID && ! isPublished( post ) ) {
 		tracksEventName += 'savedraft';
 	} else if ( 'draft' === nextStatus ) {
 		tracksEventName += 'savedraft';
@@ -104,7 +104,7 @@ export function recordSaveEvent( site, context ) {
 	analytics.tracks.recordEvent( tracksEventName, {
 		post_id: post.ID,
 		post_type: post.type,
-		visibility: utils.getVisibility( post ),
+		visibility: getVisibility( post ),
 		current_status: currentStatus,
 		next_status: nextStatus,
 		context: eventContext,

--- a/client/lib/posts/stats.js
+++ b/client/lib/posts/stats.js
@@ -10,7 +10,7 @@ import { noop } from 'lodash';
  */
 import analytics from 'lib/analytics';
 import PostEditStore from 'lib/posts/post-edit-store';
-import { getVisibility, isPublished } from 'lib/posts/utils';
+import * as utils from 'lib/posts/utils';
 
 /**
  * Module variables
@@ -56,7 +56,7 @@ export function recordSaveEvent( site, context ) {
 	let usageAction = false;
 	let eventContext = null;
 
-	if ( ! post.ID && ! isPublished( post ) ) {
+	if ( ! post.ID && ! utils.isPublished( post ) ) {
 		tracksEventName += 'savedraft';
 	} else if ( 'draft' === nextStatus ) {
 		tracksEventName += 'savedraft';
@@ -104,7 +104,7 @@ export function recordSaveEvent( site, context ) {
 	analytics.tracks.recordEvent( tracksEventName, {
 		post_id: post.ID,
 		post_type: post.type,
-		visibility: getVisibility( post ),
+		visibility: utils.getVisibility( post ),
 		current_status: currentStatus,
 		next_status: nextStatus,
 		context: eventContext,

--- a/client/lib/posts/test/utils.js
+++ b/client/lib/posts/test/utils.js
@@ -11,7 +11,7 @@ import assert from 'assert';
 /**
  * Internal dependencies
  */
-import postUtils from '../utils';
+import * as postUtils from '../utils';
 
 jest.mock( 'lib/wp', () => require( './mocks/lib/wp' ) );
 

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import url from 'url';
 import i18n from 'i18n-calypso';
 import moment from 'moment-timezone';
@@ -14,246 +12,214 @@ import { includes } from 'lodash';
  */
 import postNormalizer from 'lib/post-normalizer';
 
-var utils = {
-	getEditURL: function( post, site ) {
-		let basePath = '';
+const MINUTE_IN_MS = 60 * 1000;
 
-		if ( ! includes( [ 'post', 'page' ], post.type ) ) {
-			basePath = '/edit';
+export function getEditURL( post, site ) {
+	let basePath = '';
+
+	if ( ! includes( [ 'post', 'page' ], post.type ) ) {
+		basePath = '/edit';
+	}
+
+	return `${ basePath }/${ post.type }/${ site.slug }/${ post.ID }`;
+}
+
+export function getPreviewURL( site, post ) {
+	let parsed, previewUrl;
+
+	if ( ! post || ! post.URL || post.status === 'trash' ) {
+		return '';
+	}
+
+	if ( post.preview_URL ) {
+		previewUrl = post.preview_URL;
+	} else if ( post.status === 'publish' ) {
+		previewUrl = post.URL;
+	} else {
+		parsed = url.parse( post.URL, true );
+		parsed.query.preview = 'true';
+		delete parsed.search;
+		previewUrl = url.format( parsed );
+	}
+
+	if ( post.site_ID ) {
+		if ( ! ( site && site.options ) ) {
+			// site info is still loading, just use what we already have until it does
+			return previewUrl;
 		}
-
-		return `${ basePath }/${ post.type }/${ site.slug }/${ post.ID }`;
-	},
-
-	getPreviewURL: function( site, post ) {
-		let parsed, previewUrl;
-
-		if ( ! post || ! post.URL || post.status === 'trash' ) {
-			return '';
+		if ( site.options.is_mapped_domain ) {
+			previewUrl = previewUrl.replace( site.URL, site.options.unmapped_url );
 		}
-
-		if ( post.preview_URL ) {
-			previewUrl = post.preview_URL;
-		} else if ( post.status === 'publish' ) {
-			previewUrl = post.URL;
-		} else {
-			parsed = url.parse( post.URL, true );
-			parsed.query.preview = 'true';
+		if ( site.options.frame_nonce ) {
+			parsed = url.parse( previewUrl, true );
+			parsed.query[ 'frame-nonce' ] = site.options.frame_nonce;
 			delete parsed.search;
 			previewUrl = url.format( parsed );
 		}
+	}
 
-		if ( post.site_ID ) {
-			if ( ! ( site && site.options ) ) {
-				// site info is still loading, just use what we already have until it does
-				return previewUrl;
-			}
-			if ( site.options.is_mapped_domain ) {
-				previewUrl = previewUrl.replace( site.URL, site.options.unmapped_url );
-			}
-			if ( site.options.frame_nonce ) {
-				parsed = url.parse( previewUrl, true );
-				parsed.query[ 'frame-nonce' ] = site.options.frame_nonce;
-				delete parsed.search;
-				previewUrl = url.format( parsed );
-			}
-		}
+	return previewUrl;
+}
 
-		return previewUrl;
-	},
+export function userCan( capability, post ) {
+	const hasCap = post.capabilities && post.capabilities[ capability ];
 
-	userCan: function( capability, post ) {
-		var hasCap = post.capabilities && post.capabilities[ capability ];
+	return capability === 'edit_post' ? hasCap && post.status !== 'trash' : hasCap;
+}
 
-		if ( capability === 'edit_post' ) {
-			return hasCap && post.status !== 'trash';
-		}
+export function isPublished( post ) {
+	return (
+		post &&
+		( post.status === 'publish' || post.status === 'private' || this.isBackDatedPublished( post ) )
+	);
+}
 
-		return hasCap;
-	},
+export function isPrivate( post ) {
+	return post && 'private' === post.status;
+}
 
-	isPublished: function( post ) {
-		return (
-			post &&
-			( post.status === 'publish' ||
-				post.status === 'private' ||
-				this.isBackDatedPublished( post ) )
-		);
-	},
+export function isPending( post ) {
+	return post && 'pending' === post.status;
+}
 
-	isPrivate: function( post ) {
-		return post && 'private' === post.status;
-	},
+export function getEditedTime( post ) {
+	if ( ! post ) {
+		return;
+	}
 
-	isPending: function( post ) {
-		return post && 'pending' === post.status;
-	},
+	return post.status === 'publish' || post.status === 'future' ? post.date : post.modified;
+}
 
-	getEditedTime: function( post ) {
-		if ( ! post ) {
-			return;
-		}
+export function isBackDatedPublished( post ) {
+	return ! post || post.status !== 'future' ? false : moment( post.date ).isBefore( moment() );
+}
 
-		if ( post.status === 'publish' || post.status === 'future' ) {
-			return post.date;
-		}
+export function isFutureDated( post ) {
+	return ! post ? false : post && +new Date() + MINUTE_IN_MS < +new Date( post.date );
+}
 
-		return post.modified;
-	},
+export function isBackDated( post ) {
+	return ! post || ! post.date || ! post.modified
+		? false
+		: moment( post.date ).isBefore( moment( post.modified ) );
+}
 
-	isBackDatedPublished: function( post ) {
-		if ( ! post || post.status !== 'future' ) {
-			return false;
-		}
+export function isPage( post ) {
+	return ! post ? false : post && 'page' === post.type;
+}
 
-		return moment( post.date ).isBefore( moment() );
-	},
+export function normalizeSync( post, callback ) {
+	const imageWidth = 653;
+	postNormalizer(
+		post,
+		[
+			postNormalizer.decodeEntities,
+			postNormalizer.stripHTML,
+			postNormalizer.safeImageProperties( imageWidth ),
+			postNormalizer.withContentDOM( [
+				postNormalizer.content.removeStyles,
+				postNormalizer.content.makeImagesSafe( imageWidth ),
+				postNormalizer.content.detectMedia,
+			] ),
+			postNormalizer.pickCanonicalImage,
+		],
+		callback
+	);
+}
 
-	isFutureDated: function( post ) {
-		if ( ! post ) {
-			return false;
-		}
+export function getVisibility( post ) {
+	if ( ! post ) {
+		return;
+	}
 
-		const oneMinute = 1000 * 60;
+	if ( post.password ) {
+		return 'password';
+	}
 
-		return post && +new Date() + oneMinute < +new Date( post.date );
-	},
+	if ( 'private' === post.status ) {
+		return 'private';
+	}
 
-	isBackDated: function( post ) {
-		if ( ! post || ! post.date || ! post.modified ) {
-			return false;
-		}
+	return 'public';
+}
 
-		return moment( post.date ).isBefore( moment( post.modified ) );
-	},
+export function normalizeAsync( post, callback ) {
+	postNormalizer( post, [ postNormalizer.keepValidImages( 72, 72 ) ], callback );
+}
 
-	isPage: function( post ) {
-		if ( ! post ) {
-			return false;
-		}
+export function getPermalinkBasePath( post ) {
+	if ( ! post ) {
+		return;
+	}
 
-		return post && 'page' === post.type;
-	},
+	let path = post.URL;
 
-	normalizeSync: function( post, callback ) {
-		var imageWidth = 653;
-		postNormalizer(
-			post,
-			[
-				postNormalizer.decodeEntities,
-				postNormalizer.stripHTML,
-				postNormalizer.safeImageProperties( imageWidth ),
-				postNormalizer.withContentDOM( [
-					postNormalizer.content.removeStyles,
-					postNormalizer.content.makeImagesSafe( imageWidth ),
-					postNormalizer.content.detectMedia,
-				] ),
-				postNormalizer.pickCanonicalImage,
-			],
-			callback
-		);
-	},
+	// if we have a permalink_URL, utlize that
+	if ( ! this.isPublished( post ) && post.other_URLs && post.other_URLs.permalink_URL ) {
+		path = post.other_URLs.permalink_URL;
+	}
 
-	getVisibility: function( post ) {
-		if ( ! post ) {
-			return;
-		}
+	return this.removeSlug( path );
+}
 
-		if ( post.password ) {
-			return 'password';
-		}
+export function getPagePath( post ) {
+	if ( ! post ) {
+		return;
+	}
+	if ( ! this.isPublished( post ) ) {
+		return this.getPermalinkBasePath( post );
+	}
 
-		if ( 'private' === post.status ) {
-			return 'private';
-		}
+	return this.removeSlug( post.URL );
+}
 
-		return 'public';
-	},
+export function removeSlug( path ) {
+	if ( ! path ) {
+		return;
+	}
 
-	normalizeAsync: function( post, callback ) {
-		postNormalizer( post, [ postNormalizer.keepValidImages( 72, 72 ) ], callback );
-	},
+	const pathParts = path.slice( 0, -1 ).split( '/' );
+	pathParts[ pathParts.length - 1 ] = '';
 
-	getPermalinkBasePath: function( post ) {
-		if ( ! post ) {
-			return;
-		}
+	return pathParts.join( '/' );
+}
 
-		let path = post.URL;
+/**
+ * Returns the ID of the featured image assigned to the specified post, or
+ * `undefined` otherwise. A utility function is useful because the format
+ * of a post varies between the retrieve and update endpoints. When
+ * retrieving a post, the thumbnail ID is assigned in `post_thumbnail`, but
+ * in creating a post, the thumbnail ID is assigned to `featured_image`.
+ *
+ * @param  {Object} post Post object
+ * @return {Number}      The featured image ID
+ */
+export function getFeaturedImageId( post ) {
+	if ( ! post ) {
+		return;
+	}
 
-		// if we have a permalink_URL, utlize that
-		if ( ! this.isPublished( post ) && post.other_URLs && post.other_URLs.permalink_URL ) {
-			path = post.other_URLs.permalink_URL;
-		}
+	if ( 'featured_image' in post && ! /^https?:\/\//.test( post.featured_image ) ) {
+		// Return the `featured_image` property if it does not appear to be
+		// formatted as a URL
+		return post.featured_image;
+	}
 
-		return this.removeSlug( path );
-	},
+	if ( post.post_thumbnail ) {
+		// After the initial load from the REST API, pull the numeric ID
+		// from the thumbnail object if one exists
+		return post.post_thumbnail.ID;
+	}
+}
 
-	getPagePath: function( post ) {
-		if ( ! post ) {
-			return;
-		}
-		if ( ! this.isPublished( post ) ) {
-			return this.getPermalinkBasePath( post );
-		}
-
-		return this.removeSlug( post.URL );
-	},
-
-	removeSlug: function( path ) {
-		if ( ! path ) {
-			return;
-		}
-
-		let pathParts = path.slice( 0, -1 ).split( '/' );
-		pathParts[ pathParts.length - 1 ] = '';
-
-		return pathParts.join( '/' );
-	},
-
-	/**
-	 * Returns the ID of the featured image assigned to the specified post, or
-	 * `undefined` otherwise. A utility function is useful because the format
-	 * of a post varies between the retrieve and update endpoints. When
-	 * retrieving a post, the thumbnail ID is assigned in `post_thumbnail`, but
-	 * in creating a post, the thumbnail ID is assigned to `featured_image`.
-	 *
-	 * @param  {Object} post Post object
-	 * @return {Number}      The featured image ID
-	 */
-	getFeaturedImageId: function( post ) {
-		if ( ! post ) {
-			return;
-		}
-
-		if ( 'featured_image' in post && ! /^https?:\/\//.test( post.featured_image ) ) {
-			// Return the `featured_image` property if it does not appear to be
-			// formatted as a URL
-			return post.featured_image;
-		}
-
-		if ( post.post_thumbnail ) {
-			// After the initial load from the REST API, pull the numeric ID
-			// from the thumbnail object if one exists
-			return post.post_thumbnail.ID;
-		}
-	},
-
-	/**
-	 * Return date with timezone offset.
-	 * If `date` is not defined it returns `now`.
-	 *
-	 * @param {String|Date} date - date
-	 * @param {String} tz - timezone
-	 * @return {Moment} moment instance
-	 */
-	getOffsetDate: function( date, tz ) {
-		if ( ! tz ) {
-			return i18n.moment( date );
-		}
-
-		return i18n.moment( moment.tz( date, tz ) );
-	},
-};
-
-export default utils;
+/**
+ * Return date with timezone offset.
+ * If `date` is not defined it returns `now`.
+ *
+ * @param {String|Date} date - date
+ * @param {String} tz - timezone
+ * @return {Moment} moment instance
+ */
+export function getOffsetDate( date, tz ) {
+	return ! tz ? i18n.moment( date ) : i18n.moment( moment.tz( date, tz ) );
+}

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -216,7 +216,7 @@ export const removeSlug = function( path ) {
  * in creating a post, the thumbnail ID is assigned to `featured_image`.
  *
  * @param  {Object} post Post object
- * @ret
+ * @returns {*} featured image id or undefined
  */
 export const getFeaturedImageId = function( post ) {
 	if ( ! post ) {

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -1,7 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
+
 import url from 'url';
 import i18n from 'i18n-calypso';
 import moment from 'moment-timezone';
@@ -12,9 +14,7 @@ import { includes } from 'lodash';
  */
 import postNormalizer from 'lib/post-normalizer';
 
-const MINUTE_IN_MS = 60 * 1000;
-
-export function getEditURL( post, site ) {
+export const getEditURL = function( post, site ) {
 	let basePath = '';
 
 	if ( ! includes( [ 'post', 'page' ], post.type ) ) {
@@ -22,9 +22,9 @@ export function getEditURL( post, site ) {
 	}
 
 	return `${ basePath }/${ post.type }/${ site.slug }/${ post.ID }`;
-}
+};
 
-export function getPreviewURL( site, post ) {
+export const getPreviewURL = function( site, post ) {
 	let parsed, previewUrl;
 
 	if ( ! post || ! post.URL || post.status === 'trash' ) {
@@ -59,56 +59,80 @@ export function getPreviewURL( site, post ) {
 	}
 
 	return previewUrl;
-}
+};
 
-export function userCan( capability, post ) {
+export const userCan = function( capability, post ) {
 	const hasCap = post.capabilities && post.capabilities[ capability ];
 
-	return capability === 'edit_post' ? hasCap && post.status !== 'trash' : hasCap;
-}
+	if ( capability === 'edit_post' ) {
+		return hasCap && post.status !== 'trash';
+	}
 
-export function isPublished( post ) {
+	return hasCap;
+};
+
+export const isPublished = function( post ) {
 	return (
 		post &&
 		( post.status === 'publish' || post.status === 'private' || this.isBackDatedPublished( post ) )
 	);
-}
+};
 
-export function isPrivate( post ) {
+export const isPrivate = function( post ) {
 	return post && 'private' === post.status;
-}
+};
 
-export function isPending( post ) {
+export const isPending = function( post ) {
 	return post && 'pending' === post.status;
-}
+};
 
-export function getEditedTime( post ) {
+export const getEditedTime = function( post ) {
 	if ( ! post ) {
 		return;
 	}
 
-	return post.status === 'publish' || post.status === 'future' ? post.date : post.modified;
-}
+	if ( post.status === 'publish' || post.status === 'future' ) {
+		return post.date;
+	}
 
-export function isBackDatedPublished( post ) {
-	return ! post || post.status !== 'future' ? false : moment( post.date ).isBefore( moment() );
-}
+	return post.modified;
+};
 
-export function isFutureDated( post ) {
-	return ! post ? false : post && +new Date() + MINUTE_IN_MS < +new Date( post.date );
-}
+export const isBackDatedPublished = function( post ) {
+	if ( ! post || post.status !== 'future' ) {
+		return false;
+	}
 
-export function isBackDated( post ) {
-	return ! post || ! post.date || ! post.modified
-		? false
-		: moment( post.date ).isBefore( moment( post.modified ) );
-}
+	return moment( post.date ).isBefore( moment() );
+};
 
-export function isPage( post ) {
-	return ! post ? false : post && 'page' === post.type;
-}
+export const isFutureDated = function( post ) {
+	if ( ! post ) {
+		return false;
+	}
 
-export function normalizeSync( post, callback ) {
+	const oneMinute = 1000 * 60;
+
+	return post && +new Date() + oneMinute < +new Date( post.date );
+};
+
+export const isBackDated = function( post ) {
+	if ( ! post || ! post.date || ! post.modified ) {
+		return false;
+	}
+
+	return moment( post.date ).isBefore( moment( post.modified ) );
+};
+
+export const isPage = function( post ) {
+	if ( ! post ) {
+		return false;
+	}
+
+	return post && 'page' === post.type;
+};
+
+export const normalizeSync = function( post, callback ) {
 	const imageWidth = 653;
 	postNormalizer(
 		post,
@@ -125,9 +149,9 @@ export function normalizeSync( post, callback ) {
 		],
 		callback
 	);
-}
+};
 
-export function getVisibility( post ) {
+export const getVisibility = function( post ) {
 	if ( ! post ) {
 		return;
 	}
@@ -141,13 +165,13 @@ export function getVisibility( post ) {
 	}
 
 	return 'public';
-}
+};
 
-export function normalizeAsync( post, callback ) {
+export const normalizeAsync = function( post, callback ) {
 	postNormalizer( post, [ postNormalizer.keepValidImages( 72, 72 ) ], callback );
-}
+};
 
-export function getPermalinkBasePath( post ) {
+export const getPermalinkBasePath = function( post ) {
 	if ( ! post ) {
 		return;
 	}
@@ -160,9 +184,9 @@ export function getPermalinkBasePath( post ) {
 	}
 
 	return this.removeSlug( path );
-}
+};
 
-export function getPagePath( post ) {
+export const getPagePath = function( post ) {
 	if ( ! post ) {
 		return;
 	}
@@ -171,9 +195,9 @@ export function getPagePath( post ) {
 	}
 
 	return this.removeSlug( post.URL );
-}
+};
 
-export function removeSlug( path ) {
+export const removeSlug = function( path ) {
 	if ( ! path ) {
 		return;
 	}
@@ -182,7 +206,7 @@ export function removeSlug( path ) {
 	pathParts[ pathParts.length - 1 ] = '';
 
 	return pathParts.join( '/' );
-}
+};
 
 /**
  * Returns the ID of the featured image assigned to the specified post, or
@@ -192,9 +216,9 @@ export function removeSlug( path ) {
  * in creating a post, the thumbnail ID is assigned to `featured_image`.
  *
  * @param  {Object} post Post object
- * @return {Number}      The featured image ID
+ * @ret
  */
-export function getFeaturedImageId( post ) {
+export const getFeaturedImageId = function( post ) {
 	if ( ! post ) {
 		return;
 	}
@@ -210,7 +234,7 @@ export function getFeaturedImageId( post ) {
 		// from the thumbnail object if one exists
 		return post.post_thumbnail.ID;
 	}
-}
+};
 
 /**
  * Return date with timezone offset.
@@ -220,6 +244,10 @@ export function getFeaturedImageId( post ) {
  * @param {String} tz - timezone
  * @return {Moment} moment instance
  */
-export function getOffsetDate( date, tz ) {
-	return ! tz ? i18n.moment( date ) : i18n.moment( moment.tz( date, tz ) );
-}
+export const getOffsetDate = function( date, tz ) {
+	if ( ! tz ) {
+		return i18n.moment( date );
+	}
+
+	return i18n.moment( moment.tz( date, tz ) );
+};

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
@@ -26,7 +24,7 @@ import actions from 'lib/posts/actions';
 import photon from 'photon';
 import { hasTouch } from 'lib/touch-detect';
 import updatePostStatus from 'components/update-post-status';
-import utils from 'lib/posts/utils';
+import { getEditURL, getPreviewURL, userCan } from 'lib/posts/utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite } from 'state/sites/selectors';
 import TimeSince from 'components/time-since';
@@ -80,7 +78,7 @@ class Draft extends Component {
 			return this.setState( { isTrashing: false } );
 		}.bind( this );
 
-		if ( utils.userCan( 'delete_post', this.props.post ) ) {
+		if ( userCan( 'delete_post', this.props.post ) ) {
 			actions.trash( this.props.site, this.props.post, updateStatus );
 		}
 	};
@@ -106,18 +104,18 @@ class Draft extends Component {
 			return this.setState( { isRestoring: false } );
 		}.bind( this );
 
-		if ( utils.userCan( 'delete_post', this.props.post ) ) {
+		if ( userCan( 'delete_post', this.props.post ) ) {
 			actions.restore( this.props.site, this.props.post, updateStatus );
 		}
 	};
 
 	previewPost = () => {
-		window.open( utils.getPreviewURL( this.props.site, this.props.post ) );
+		window.open( getPreviewURL( this.props.site, this.props.post ) );
 	};
 
 	publishPost = () => {
 		this.setState( { showPopoverMenu: false } );
-		if ( utils.userCan( 'publish_post', this.props.post ) ) {
+		if ( userCan( 'publish_post', this.props.post ) ) {
 			this.props.updatePostStatus( 'publish' );
 		}
 	};
@@ -139,8 +137,8 @@ class Draft extends Component {
 
 		const site = this.props.site;
 
-		if ( utils.userCan( 'edit_post', post ) ) {
-			editPostURL = utils.getEditURL( post, site );
+		if ( userCan( 'edit_post', post ) ) {
+			editPostURL = getEditURL( post, site );
 		}
 
 		if ( this.props.postImages && this.props.postImages.canonical_image ) {
@@ -244,7 +242,7 @@ class Draft extends Component {
 	}
 
 	renderTrashAction() {
-		if ( ! utils.userCan( 'delete_post', this.props.post ) ) {
+		if ( ! userCan( 'delete_post', this.props.post ) ) {
 			return null;
 		}
 

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -1,7 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
+
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
@@ -24,7 +26,7 @@ import actions from 'lib/posts/actions';
 import photon from 'photon';
 import { hasTouch } from 'lib/touch-detect';
 import updatePostStatus from 'components/update-post-status';
-import { getEditURL, getPreviewURL, userCan } from 'lib/posts/utils';
+import * as utils from 'lib/posts/utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite } from 'state/sites/selectors';
 import TimeSince from 'components/time-since';
@@ -78,7 +80,7 @@ class Draft extends Component {
 			return this.setState( { isTrashing: false } );
 		}.bind( this );
 
-		if ( userCan( 'delete_post', this.props.post ) ) {
+		if ( utils.userCan( 'delete_post', this.props.post ) ) {
 			actions.trash( this.props.site, this.props.post, updateStatus );
 		}
 	};
@@ -104,18 +106,18 @@ class Draft extends Component {
 			return this.setState( { isRestoring: false } );
 		}.bind( this );
 
-		if ( userCan( 'delete_post', this.props.post ) ) {
+		if ( utils.userCan( 'delete_post', this.props.post ) ) {
 			actions.restore( this.props.site, this.props.post, updateStatus );
 		}
 	};
 
 	previewPost = () => {
-		window.open( getPreviewURL( this.props.site, this.props.post ) );
+		window.open( utils.getPreviewURL( this.props.site, this.props.post ) );
 	};
 
 	publishPost = () => {
 		this.setState( { showPopoverMenu: false } );
-		if ( userCan( 'publish_post', this.props.post ) ) {
+		if ( utils.userCan( 'publish_post', this.props.post ) ) {
 			this.props.updatePostStatus( 'publish' );
 		}
 	};
@@ -137,8 +139,8 @@ class Draft extends Component {
 
 		const site = this.props.site;
 
-		if ( userCan( 'edit_post', post ) ) {
-			editPostURL = getEditURL( post, site );
+		if ( utils.userCan( 'edit_post', post ) ) {
+			editPostURL = utils.getEditURL( post, site );
 		}
 
 		if ( this.props.postImages && this.props.postImages.canonical_image ) {
@@ -242,7 +244,7 @@ class Draft extends Component {
 	}
 
 	renderTrashAction() {
-		if ( ! userCan( 'delete_post', this.props.post ) ) {
+		if ( ! utils.userCan( 'delete_post', this.props.post ) ) {
 			return null;
 		}
 

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
@@ -22,7 +20,7 @@ import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import SiteIcon from 'blocks/site-icon';
 import { editLinkForPage, statsLinkForPage } from '../helpers';
-import utils from 'lib/posts/utils';
+import { getPreviewURL, userCan } from 'lib/posts/utils';
 import classNames from 'classnames';
 import MenuSeparator from 'components/popover/menu-separator';
 import PageCardInfo from '../page-card-info';
@@ -131,7 +129,7 @@ class Page extends Component {
 
 		// This is technically if you can edit the current page, not the parent.
 		// Capabilities are not exposed on the parent page.
-		const parentHref = utils.userCan( 'edit_post', this.props.page )
+		const parentHref = userCan( 'edit_post', this.props.page )
 			? editLinkForPage( page.parent, site )
 			: page.parent.URL;
 		const parentLink = <a href={ parentHref }>{ parentTitle }</a>;
@@ -162,7 +160,7 @@ class Page extends Component {
 	getPublishItem() {
 		if (
 			this.props.page.status === 'publish' ||
-			! utils.userCan( 'publish_post', this.props.page ) ||
+			! userCan( 'publish_post', this.props.page ) ||
 			this.props.page.status === 'trash'
 		) {
 			return null;
@@ -181,7 +179,7 @@ class Page extends Component {
 			return null;
 		}
 
-		if ( ! utils.userCan( 'edit_post', this.props.page ) ) {
+		if ( ! userCan( 'edit_post', this.props.page ) ) {
 			return null;
 		}
 
@@ -198,7 +196,7 @@ class Page extends Component {
 			return null;
 		}
 
-		if ( ! utils.userCan( 'delete_post', this.props.page ) ) {
+		if ( ! userCan( 'delete_post', this.props.page ) ) {
 			return null;
 		}
 
@@ -225,7 +223,7 @@ class Page extends Component {
 		const { page: post, siteSlugOrId } = this.props;
 		if (
 			! includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) ||
-			! utils.userCan( 'edit_post', post )
+			! userCan( 'edit_post', post )
 		) {
 			return null;
 		}
@@ -241,7 +239,7 @@ class Page extends Component {
 	}
 
 	getRestoreItem() {
-		if ( this.props.page.status !== 'trash' || ! utils.userCan( 'delete_post', this.props.page ) ) {
+		if ( this.props.page.status !== 'trash' || ! userCan( 'delete_post', this.props.page ) ) {
 			return null;
 		}
 
@@ -326,7 +324,7 @@ class Page extends Component {
 	render() {
 		const { page, site = {}, translate } = this.props;
 		const title = page.title || translate( '(no title)' );
-		const canEdit = utils.userCan( 'edit_post', page );
+		const canEdit = userCan( 'edit_post', page );
 		const depthIndicator = ! this.props.hierarchical && page.parent && '— ';
 
 		const viewItem = this.getViewItem();
@@ -472,7 +470,7 @@ const mapState = ( state, props ) => {
 		isFrontPage: isFrontPage( state, pageSiteId, props.page.ID ),
 		isPostsPage: isPostsPage( state, pageSiteId, props.page.ID ),
 		isPreviewable,
-		previewURL: utils.getPreviewURL( site, props.page ),
+		previewURL: getPreviewURL( site, props.page ),
 		site,
 		siteSlugOrId,
 	};

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -1,7 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
+
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
@@ -20,7 +22,7 @@ import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import SiteIcon from 'blocks/site-icon';
 import { editLinkForPage, statsLinkForPage } from '../helpers';
-import { getPreviewURL, userCan } from 'lib/posts/utils';
+import * as utils from 'lib/posts/utils';
 import classNames from 'classnames';
 import MenuSeparator from 'components/popover/menu-separator';
 import PageCardInfo from '../page-card-info';
@@ -129,7 +131,7 @@ class Page extends Component {
 
 		// This is technically if you can edit the current page, not the parent.
 		// Capabilities are not exposed on the parent page.
-		const parentHref = userCan( 'edit_post', this.props.page )
+		const parentHref = utils.userCan( 'edit_post', this.props.page )
 			? editLinkForPage( page.parent, site )
 			: page.parent.URL;
 		const parentLink = <a href={ parentHref }>{ parentTitle }</a>;
@@ -160,7 +162,7 @@ class Page extends Component {
 	getPublishItem() {
 		if (
 			this.props.page.status === 'publish' ||
-			! userCan( 'publish_post', this.props.page ) ||
+			! utils.userCan( 'publish_post', this.props.page ) ||
 			this.props.page.status === 'trash'
 		) {
 			return null;
@@ -179,7 +181,7 @@ class Page extends Component {
 			return null;
 		}
 
-		if ( ! userCan( 'edit_post', this.props.page ) ) {
+		if ( ! utils.userCan( 'edit_post', this.props.page ) ) {
 			return null;
 		}
 
@@ -196,7 +198,7 @@ class Page extends Component {
 			return null;
 		}
 
-		if ( ! userCan( 'delete_post', this.props.page ) ) {
+		if ( ! utils.userCan( 'delete_post', this.props.page ) ) {
 			return null;
 		}
 
@@ -223,7 +225,7 @@ class Page extends Component {
 		const { page: post, siteSlugOrId } = this.props;
 		if (
 			! includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) ||
-			! userCan( 'edit_post', post )
+			! utils.userCan( 'edit_post', post )
 		) {
 			return null;
 		}
@@ -239,7 +241,7 @@ class Page extends Component {
 	}
 
 	getRestoreItem() {
-		if ( this.props.page.status !== 'trash' || ! userCan( 'delete_post', this.props.page ) ) {
+		if ( this.props.page.status !== 'trash' || ! utils.userCan( 'delete_post', this.props.page ) ) {
 			return null;
 		}
 
@@ -324,7 +326,7 @@ class Page extends Component {
 	render() {
 		const { page, site = {}, translate } = this.props;
 		const title = page.title || translate( '(no title)' );
-		const canEdit = userCan( 'edit_post', page );
+		const canEdit = utils.userCan( 'edit_post', page );
 		const depthIndicator = ! this.props.hierarchical && page.parent && '— ';
 
 		const viewItem = this.getViewItem();
@@ -470,7 +472,7 @@ const mapState = ( state, props ) => {
 		isFrontPage: isFrontPage( state, pageSiteId, props.page.ID ),
 		isPostsPage: isPostsPage( state, pageSiteId, props.page.ID ),
 		isPreviewable,
-		previewURL: getPreviewURL( site, props.page ),
+		previewURL: utils.getPreviewURL( site, props.page ),
 		site,
 		siteSlugOrId,
 	};

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
@@ -18,7 +16,7 @@ import { isEnabled } from 'config';
 import Button from 'components/button';
 import FormToggle from 'components/forms/form-toggle/compact';
 import EditorRevisionsLegacyLink from 'post-editor/editor-revisions/legacy-link';
-import postUtils from 'lib/posts/utils';
+import { getVisibility, isPending, isPublished } from 'lib/posts/utils';
 import InfoPopover from 'components/info-popover';
 import { recordStat, recordEvent } from 'lib/posts/stats';
 import { editPost } from 'state/posts/actions';
@@ -85,14 +83,14 @@ export class EditPostStatus extends Component {
 	};
 
 	render() {
-		let isSticky, isPublished, isPending, isScheduled, isPasswordProtected;
+		let isSticky, isPostPublished, isPostPending, isScheduled, isPasswordProtected;
 		const { translate, isPostPrivate, canUserPublishPosts } = this.props;
 
 		if ( this.props.post ) {
-			isPasswordProtected = postUtils.getVisibility( this.props.post ) === 'password';
+			isPasswordProtected = getVisibility( this.props.post ) === 'password';
 			isSticky = this.props.post.sticky;
-			isPending = postUtils.isPending( this.props.post );
-			isPublished = postUtils.isPublished( this.props.savedPost );
+			isPostPending = isPending( this.props.post );
+			isPostPublished = isPublished( this.props.savedPost );
 			isScheduled = this.props.savedPost && this.props.savedPost.status === 'future';
 		}
 
@@ -124,7 +122,7 @@ export class EditPostStatus extends Component {
 							/>
 						</label>
 					) }
-				{ ! isPublished &&
+				{ ! isPostPublished &&
 					! isScheduled &&
 					canUserPublishPosts && (
 						<label className="edit-post-status__pending-review">
@@ -135,13 +133,13 @@ export class EditPostStatus extends Component {
 								</InfoPopover>
 							</span>
 							<FormToggle
-								checked={ isPending }
+								checked={ isPostPending }
 								onChange={ this.togglePendingStatus }
 								aria-label={ translate( 'Request review for post' ) }
 							/>
 						</label>
 					) }
-				{ ( isPublished || isScheduled || ( isPending && ! canUserPublishPosts ) ) && (
+				{ ( isPostPublished || isScheduled || ( isPostPending && ! canUserPublishPosts ) ) && (
 					<Button
 						className="edit-post-status__revert-to-draft"
 						onClick={ this.revertToDraft }

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -1,7 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
+
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
@@ -16,7 +18,7 @@ import { isEnabled } from 'config';
 import Button from 'components/button';
 import FormToggle from 'components/forms/form-toggle/compact';
 import EditorRevisionsLegacyLink from 'post-editor/editor-revisions/legacy-link';
-import { getVisibility, isPending, isPublished } from 'lib/posts/utils';
+import * as postUtils from 'lib/posts/utils';
 import InfoPopover from 'components/info-popover';
 import { recordStat, recordEvent } from 'lib/posts/stats';
 import { editPost } from 'state/posts/actions';
@@ -83,14 +85,14 @@ export class EditPostStatus extends Component {
 	};
 
 	render() {
-		let isSticky, isPostPublished, isPostPending, isScheduled, isPasswordProtected;
+		let isSticky, isPublished, isPending, isScheduled, isPasswordProtected;
 		const { translate, isPostPrivate, canUserPublishPosts } = this.props;
 
 		if ( this.props.post ) {
-			isPasswordProtected = getVisibility( this.props.post ) === 'password';
+			isPasswordProtected = postUtils.getVisibility( this.props.post ) === 'password';
 			isSticky = this.props.post.sticky;
-			isPostPending = isPending( this.props.post );
-			isPostPublished = isPublished( this.props.savedPost );
+			isPending = postUtils.isPending( this.props.post );
+			isPublished = postUtils.isPublished( this.props.savedPost );
 			isScheduled = this.props.savedPost && this.props.savedPost.status === 'future';
 		}
 
@@ -122,7 +124,7 @@ export class EditPostStatus extends Component {
 							/>
 						</label>
 					) }
-				{ ! isPostPublished &&
+				{ ! isPublished &&
 					! isScheduled &&
 					canUserPublishPosts && (
 						<label className="edit-post-status__pending-review">
@@ -133,13 +135,13 @@ export class EditPostStatus extends Component {
 								</InfoPopover>
 							</span>
 							<FormToggle
-								checked={ isPostPending }
+								checked={ isPending }
 								onChange={ this.togglePendingStatus }
 								aria-label={ translate( 'Request review for post' ) }
 							/>
 						</label>
 					) }
-				{ ( isPostPublished || isScheduled || ( isPostPending && ! canUserPublishPosts ) ) && (
+				{ ( isPublished || isScheduled || ( isPending && ! canUserPublishPosts ) ) && (
 					<Button
 						className="edit-post-status__revert-to-draft"
 						onClick={ this.revertToDraft }

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
@@ -14,7 +12,7 @@ import { connect } from 'react-redux';
  */
 import AsyncLoad from 'components/async-load';
 import EditorSticky from 'post-editor/editor-sticky';
-import utils from 'lib/posts/utils';
+import { getVisibility, isPublished } from 'lib/posts/utils';
 import Tooltip from 'components/tooltip';
 import Button from 'components/button';
 import EditorActionBarViewLabel from './view-label';
@@ -44,7 +42,7 @@ class EditorActionBar extends Component {
 		// This results in checking Flux for some items and Redux for others to correctly
 		// update based on post changes. Flux changes are passed down from parent components.
 		const multiUserSite = this.props.site && ! this.props.site.single_user_site;
-		const isPasswordProtected = utils.getVisibility( this.props.post ) === 'password';
+		const isPasswordProtected = getVisibility( this.props.post ) === 'password';
 		const { isPostPrivate, postAuthor } = this.props;
 
 		return (
@@ -67,7 +65,7 @@ class EditorActionBar extends Component {
 						this.props.type === 'post' &&
 						! isPasswordProtected &&
 						! isPostPrivate && <EditorSticky /> }
-					{ utils.isPublished( this.props.savedPost ) && (
+					{ isPublished( this.props.savedPost ) && (
 						<Button
 							href={ this.props.savedPost.URL }
 							target="_blank"

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -1,7 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
+
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
@@ -12,7 +14,7 @@ import { connect } from 'react-redux';
  */
 import AsyncLoad from 'components/async-load';
 import EditorSticky from 'post-editor/editor-sticky';
-import { getVisibility, isPublished } from 'lib/posts/utils';
+import * as utils from 'lib/posts/utils';
 import Tooltip from 'components/tooltip';
 import Button from 'components/button';
 import EditorActionBarViewLabel from './view-label';
@@ -42,7 +44,7 @@ class EditorActionBar extends Component {
 		// This results in checking Flux for some items and Redux for others to correctly
 		// update based on post changes. Flux changes are passed down from parent components.
 		const multiUserSite = this.props.site && ! this.props.site.single_user_site;
-		const isPasswordProtected = getVisibility( this.props.post ) === 'password';
+		const isPasswordProtected = utils.getVisibility( this.props.post ) === 'password';
 		const { isPostPrivate, postAuthor } = this.props;
 
 		return (
@@ -65,7 +67,7 @@ class EditorActionBar extends Component {
 						this.props.type === 'post' &&
 						! isPasswordProtected &&
 						! isPostPrivate && <EditorSticky /> }
-					{ isPublished( this.props.savedPost ) && (
+					{ utils.isPublished( this.props.savedPost ) && (
 						<Button
 							href={ this.props.savedPost.URL }
 							target="_blank"

--- a/client/post-editor/editor-confirmation-sidebar/header.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/header.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -15,7 +13,7 @@ import { get } from 'lodash';
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostTypes } from 'state/post-types/selectors';
-import utils from 'lib/posts/utils';
+import { isFutureDated } from 'lib/posts/utils';
 
 class EditorConfirmationSidebarHeader extends PureComponent {
 	static propTypes = {
@@ -155,7 +153,7 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 	}
 
 	render() {
-		const isScheduled = utils.isFutureDated( this.props.post );
+		const isScheduled = isFutureDated( this.props.post );
 
 		if ( isScheduled ) {
 			return this.renderScheduleHeader();

--- a/client/post-editor/editor-confirmation-sidebar/header.jsx
+++ b/client/post-editor/editor-confirmation-sidebar/header.jsx
@@ -1,7 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
+
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -13,7 +15,7 @@ import { get } from 'lodash';
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getPostTypes } from 'state/post-types/selectors';
-import { isFutureDated } from 'lib/posts/utils';
+import * as utils from 'lib/posts/utils';
 
 class EditorConfirmationSidebarHeader extends PureComponent {
 	static propTypes = {
@@ -153,7 +155,7 @@ class EditorConfirmationSidebarHeader extends PureComponent {
 	}
 
 	render() {
-		const isScheduled = isFutureDated( this.props.post );
+		const isScheduled = utils.isFutureDated( this.props.post );
 
 		if ( isScheduled ) {
 			return this.renderScheduleHeader();

--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -16,7 +14,7 @@ import Gridicon from 'gridicons';
  */
 import actions from 'lib/posts/actions';
 import accept from 'lib/accept';
-import utils from 'lib/posts/utils';
+import { userCan } from 'lib/posts/utils';
 import Button from 'components/button';
 import { getSelectedSite } from 'state/ui/selectors';
 
@@ -34,7 +32,7 @@ class EditorDeletePost extends React.Component {
 	};
 
 	sendToTrash = () => {
-		if ( ! utils.userCan( 'delete_post', this.props.post ) ) {
+		if ( ! userCan( 'delete_post', this.props.post ) ) {
 			return;
 		}
 

--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -1,7 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
+
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -14,7 +16,7 @@ import Gridicon from 'gridicons';
  */
 import actions from 'lib/posts/actions';
 import accept from 'lib/accept';
-import { userCan } from 'lib/posts/utils';
+import * as utils from 'lib/posts/utils';
 import Button from 'components/button';
 import { getSelectedSite } from 'state/ui/selectors';
 
@@ -32,7 +34,7 @@ class EditorDeletePost extends React.Component {
 	};
 
 	sendToTrash = () => {
-		if ( ! userCan( 'delete_post', this.props.post ) ) {
+		if ( ! utils.userCan( 'delete_post', this.props.post ) ) {
 			return;
 		}
 

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -18,7 +16,7 @@ import MediaLibrarySelectedData from 'components/data/media-library-selected-dat
 import MediaModal from 'post-editor/media-modal';
 import MediaActions from 'lib/media/actions';
 import PostActions from 'lib/posts/actions';
-import PostUtils from 'lib/posts/utils';
+import { getFeaturedImageId } from 'lib/posts/utils';
 import * as stats from 'lib/posts/stats';
 import EditorFeaturedImagePreviewContainer from './preview-container';
 import FeaturedImageDropZone from 'post-editor/editor-featured-image/dropzone';
@@ -26,7 +24,6 @@ import isDropZoneVisible from 'state/selectors/is-drop-zone-visible';
 import Button from 'components/button';
 import RemoveButton from 'components/remove-button';
 import { getMediaItem } from 'state/selectors';
-import { getFeaturedImageId } from 'lib/posts/utils';
 import QueryMedia from 'components/data/query-media';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -128,7 +125,7 @@ class EditorFeaturedImage extends Component {
 			return;
 		}
 
-		const itemId = PostUtils.getFeaturedImageId( this.props.post );
+		const itemId = getFeaturedImageId( this.props.post );
 		if ( ! itemId ) {
 			return;
 		}
@@ -146,7 +143,7 @@ class EditorFeaturedImage extends Component {
 		const { site, post } = this.props;
 		const featuredImageId = getFeaturedImageId( post );
 		const classes = classnames( 'editor-featured-image', {
-			'is-assigned': PostUtils.getFeaturedImageId( this.props.post ),
+			'is-assigned': getFeaturedImageId( this.props.post ),
 			'has-active-drop-zone': this.props.hasDropZone && this.props.isDropZoneVisible,
 		} );
 

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -1,7 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
+
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -16,7 +18,6 @@ import MediaLibrarySelectedData from 'components/data/media-library-selected-dat
 import MediaModal from 'post-editor/media-modal';
 import MediaActions from 'lib/media/actions';
 import PostActions from 'lib/posts/actions';
-import { getFeaturedImageId } from 'lib/posts/utils';
 import * as stats from 'lib/posts/stats';
 import EditorFeaturedImagePreviewContainer from './preview-container';
 import FeaturedImageDropZone from 'post-editor/editor-featured-image/dropzone';
@@ -24,6 +25,7 @@ import isDropZoneVisible from 'state/selectors/is-drop-zone-visible';
 import Button from 'components/button';
 import RemoveButton from 'components/remove-button';
 import { getMediaItem } from 'state/selectors';
+import { getFeaturedImageId } from 'lib/posts/utils';
 import QueryMedia from 'components/data/query-media';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -16,7 +16,7 @@ import { connect } from 'react-redux';
  */
 import Card from 'components/card';
 import Site from 'blocks/site';
-import { isPage, isPublished } from 'lib/posts/utils';
+import * as postUtils from 'lib/posts/utils';
 import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import Button from 'components/button';
 import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-buttons';
@@ -148,7 +148,7 @@ export class EditorGroundControl extends PureComponent {
 	shouldShowStatusLabel() {
 		const { isSaving, post } = this.props;
 
-		return isSaving || ( post && post.ID && ! isPublished( post ) );
+		return isSaving || ( post && post.ID && ! postUtils.isPublished( post ) );
 	}
 
 	isPreviewEnabled() {
@@ -207,7 +207,7 @@ export class EditorGroundControl extends PureComponent {
 						needsVerification={ this.state.needsVerification }
 						busy={
 							this.props.isPublishing ||
-							( isPublished( this.props.savedPost ) && this.props.isSaving )
+							( postUtils.isPublished( this.props.savedPost ) && this.props.isSaving )
 						}
 					/>
 				</div>
@@ -307,13 +307,13 @@ const mapDispatchToProps = dispatch => ( {
 		dispatch(
 			composeAnalytics(
 				recordTracksEvent(
-					`calypso_editor_${ isPage( page ) ? 'page' : 'post' }_preview_button_click`
+					`calypso_editor_${ postUtils.isPage( page ) ? 'page' : 'post' }_preview_button_click`
 				),
 				recordGoogleEvent(
 					'Editor',
-					`Clicked Preview ${ isPage( page ) ? 'Page' : 'Post' } Button`,
-					`Editor Preview ${ isPage( page ) ? 'Page' : 'Post' } Button Clicked`,
-					`editor${ isPage( page ) ? 'Page' : 'Post' }ButtonClicked`
+					`Clicked Preview ${ postUtils.isPage( page ) ? 'Page' : 'Post' } Button`,
+					`Editor Preview ${ postUtils.isPage( page ) ? 'Page' : 'Post' } Button Clicked`,
+					`editor${ postUtils.isPage( page ) ? 'Page' : 'Post' }ButtonClicked`
 				)
 			)
 		),

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -16,7 +16,7 @@ import { connect } from 'react-redux';
  */
 import Card from 'components/card';
 import Site from 'blocks/site';
-import postUtils from 'lib/posts/utils';
+import { isPage, isPublished } from 'lib/posts/utils';
 import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import Button from 'components/button';
 import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-buttons';
@@ -148,7 +148,7 @@ export class EditorGroundControl extends PureComponent {
 	shouldShowStatusLabel() {
 		const { isSaving, post } = this.props;
 
-		return isSaving || ( post && post.ID && ! postUtils.isPublished( post ) );
+		return isSaving || ( post && post.ID && ! isPublished( post ) );
 	}
 
 	isPreviewEnabled() {
@@ -207,7 +207,7 @@ export class EditorGroundControl extends PureComponent {
 						needsVerification={ this.state.needsVerification }
 						busy={
 							this.props.isPublishing ||
-							( postUtils.isPublished( this.props.savedPost ) && this.props.isSaving )
+							( isPublished( this.props.savedPost ) && this.props.isSaving )
 						}
 					/>
 				</div>
@@ -307,13 +307,13 @@ const mapDispatchToProps = dispatch => ( {
 		dispatch(
 			composeAnalytics(
 				recordTracksEvent(
-					`calypso_editor_${ postUtils.isPage( page ) ? 'page' : 'post' }_preview_button_click`
+					`calypso_editor_${ isPage( page ) ? 'page' : 'post' }_preview_button_click`
 				),
 				recordGoogleEvent(
 					'Editor',
-					`Clicked Preview ${ postUtils.isPage( page ) ? 'Page' : 'Post' } Button`,
-					`Editor Preview ${ postUtils.isPage( page ) ? 'Page' : 'Post' } Button Clicked`,
-					`editor${ postUtils.isPage( page ) ? 'Page' : 'Post' }ButtonClicked`
+					`Clicked Preview ${ isPage( page ) ? 'Page' : 'Post' } Button`,
+					`Editor Preview ${ isPage( page ) ? 'Page' : 'Post' } Button Clicked`,
+					`editor${ isPage( page ) ? 'Page' : 'Post' }ButtonClicked`
 				)
 			)
 		),

--- a/client/post-editor/editor-ground-control/quick-save-buttons.jsx
+++ b/client/post-editor/editor-ground-control/quick-save-buttons.jsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import postUtils from 'lib/posts/utils';
+import { isPage, isPublished } from 'lib/posts/utils';
 import { isEnabled } from 'config';
 import HistoryButton from 'post-editor/editor-ground-control/history-button';
 import { recordEvent, recordStat } from 'lib/posts/stats';
@@ -21,13 +21,7 @@ export const isSaveAvailableFn = ( {
 	isDirty = false,
 	hasContent = false,
 	post = null,
-} ) =>
-	! isSaving &&
-	! isSaveBlocked &&
-	isDirty &&
-	hasContent &&
-	!! post &&
-	! postUtils.isPublished( post );
+} ) => ! isSaving && ! isSaveBlocked && isDirty && hasContent && !! post && ! isPublished( post );
 
 const QuickSaveButtons = ( {
 	isSaving,
@@ -42,9 +36,7 @@ const QuickSaveButtons = ( {
 } ) => {
 	const onSaveButtonClick = () => {
 		onSave();
-		const eventLabel = postUtils.isPage( post )
-			? 'Clicked Save Page Button'
-			: 'Clicked Save Post Button';
+		const eventLabel = isPage( post ) ? 'Clicked Save Page Button' : 'Clicked Save Post Button';
 		recordEvent( eventLabel );
 		recordStat( 'save_draft_clicked' );
 	};
@@ -57,7 +49,7 @@ const QuickSaveButtons = ( {
 		post,
 	} );
 
-	const showingStatusLabel = isSaving || ( post && post.ID && ! postUtils.isPublished( post ) );
+	const showingStatusLabel = isSaving || ( post && post.ID && ! isPublished( post ) );
 	const showingSaveStatus = isSaveAvailable || showingStatusLabel;
 	const hasRevisions =
 		showRevisions && isEnabled( 'post-editor/revisions' ) && get( post, 'revisions.length' );

--- a/client/post-editor/editor-ground-control/quick-save-buttons.jsx
+++ b/client/post-editor/editor-ground-control/quick-save-buttons.jsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { isPage, isPublished } from 'lib/posts/utils';
+import * as postUtils from 'lib/posts/utils';
 import { isEnabled } from 'config';
 import HistoryButton from 'post-editor/editor-ground-control/history-button';
 import { recordEvent, recordStat } from 'lib/posts/stats';
@@ -21,7 +21,13 @@ export const isSaveAvailableFn = ( {
 	isDirty = false,
 	hasContent = false,
 	post = null,
-} ) => ! isSaving && ! isSaveBlocked && isDirty && hasContent && !! post && ! isPublished( post );
+} ) =>
+	! isSaving &&
+	! isSaveBlocked &&
+	isDirty &&
+	hasContent &&
+	!! post &&
+	! postUtils.isPublished( post );
 
 const QuickSaveButtons = ( {
 	isSaving,
@@ -36,7 +42,9 @@ const QuickSaveButtons = ( {
 } ) => {
 	const onSaveButtonClick = () => {
 		onSave();
-		const eventLabel = isPage( post ) ? 'Clicked Save Page Button' : 'Clicked Save Post Button';
+		const eventLabel = postUtils.isPage( post )
+			? 'Clicked Save Page Button'
+			: 'Clicked Save Post Button';
 		recordEvent( eventLabel );
 		recordStat( 'save_draft_clicked' );
 	};
@@ -49,7 +57,7 @@ const QuickSaveButtons = ( {
 		post,
 	} );
 
-	const showingStatusLabel = isSaving || ( post && post.ID && ! isPublished( post ) );
+	const showingStatusLabel = isSaving || ( post && post.ID && ! postUtils.isPublished( post ) );
 	const showingSaveStatus = isSaveAvailable || showingStatusLabel;
 	const hasRevisions =
 		showRevisions && isEnabled( 'post-editor/revisions' ) && get( post, 'revisions.length' );

--- a/client/post-editor/editor-publish-button/index.jsx
+++ b/client/post-editor/editor-publish-button/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -12,7 +10,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { recordEvent } from 'lib/posts/stats';
-import postUtils from 'lib/posts/utils';
+import { isBackDatedPublished, isFutureDated, isPage, isPublished } from 'lib/posts/utils';
 import Button from 'components/button';
 import { localize } from 'i18n-calypso';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -22,15 +20,15 @@ import { canCurrentUser } from 'state/selectors';
 
 export const getPublishButtonStatus = ( post, savedPost, canUserPublishPosts ) => {
 	if (
-		( postUtils.isPublished( savedPost ) &&
-			! postUtils.isBackDatedPublished( savedPost ) &&
-			! postUtils.isFutureDated( post ) ) ||
-		( savedPost && savedPost.status === 'future' && postUtils.isFutureDated( post ) )
+		( isPublished( savedPost ) &&
+			! isBackDatedPublished( savedPost ) &&
+			! isFutureDated( post ) ) ||
+		( savedPost && savedPost.status === 'future' && isFutureDated( post ) )
 	) {
 		return 'update';
 	}
 
-	if ( postUtils.isFutureDated( post ) ) {
+	if ( isFutureDated( post ) ) {
 		return 'schedule';
 	}
 
@@ -87,7 +85,7 @@ export class EditorPublishButton extends Component {
 			this.props.savedPost,
 			this.props.canUserPublishPosts
 		);
-		const eventString = postUtils.isPage( this.props.post )
+		const eventString = isPage( this.props.post )
 			? pageEvents[ buttonState ]
 			: postEvents[ buttonState ];
 		recordEvent( eventString );
@@ -132,10 +130,7 @@ export class EditorPublishButton extends Component {
 	onClick() {
 		this.trackClick();
 
-		if (
-			postUtils.isPublished( this.props.savedPost ) &&
-			! postUtils.isBackDatedPublished( this.props.savedPost )
-		) {
+		if ( isPublished( this.props.savedPost ) && ! isBackDatedPublished( this.props.savedPost ) ) {
 			return this.props.onSave();
 		}
 

--- a/client/post-editor/editor-publish-button/index.jsx
+++ b/client/post-editor/editor-publish-button/index.jsx
@@ -1,7 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
+
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -10,7 +12,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { recordEvent } from 'lib/posts/stats';
-import { isBackDatedPublished, isFutureDated, isPage, isPublished } from 'lib/posts/utils';
+import * as postUtils from 'lib/posts/utils';
 import Button from 'components/button';
 import { localize } from 'i18n-calypso';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -20,15 +22,15 @@ import { canCurrentUser } from 'state/selectors';
 
 export const getPublishButtonStatus = ( post, savedPost, canUserPublishPosts ) => {
 	if (
-		( isPublished( savedPost ) &&
-			! isBackDatedPublished( savedPost ) &&
-			! isFutureDated( post ) ) ||
-		( savedPost && savedPost.status === 'future' && isFutureDated( post ) )
+		( postUtils.isPublished( savedPost ) &&
+			! postUtils.isBackDatedPublished( savedPost ) &&
+			! postUtils.isFutureDated( post ) ) ||
+		( savedPost && savedPost.status === 'future' && postUtils.isFutureDated( post ) )
 	) {
 		return 'update';
 	}
 
-	if ( isFutureDated( post ) ) {
+	if ( postUtils.isFutureDated( post ) ) {
 		return 'schedule';
 	}
 
@@ -85,7 +87,7 @@ export class EditorPublishButton extends Component {
 			this.props.savedPost,
 			this.props.canUserPublishPosts
 		);
-		const eventString = isPage( this.props.post )
+		const eventString = postUtils.isPage( this.props.post )
 			? pageEvents[ buttonState ]
 			: postEvents[ buttonState ];
 		recordEvent( eventString );
@@ -130,7 +132,10 @@ export class EditorPublishButton extends Component {
 	onClick() {
 		this.trackClick();
 
-		if ( isPublished( this.props.savedPost ) && ! isBackDatedPublished( this.props.savedPost ) ) {
+		if (
+			postUtils.isPublished( this.props.savedPost ) &&
+			! postUtils.isBackDatedPublished( this.props.savedPost )
+		) {
 			return this.props.onSave();
 		}
 

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDom from 'react-dom';
@@ -18,7 +16,7 @@ import { intersection } from 'lodash';
  */
 import Button from 'components/button';
 import PostScheduler from './post-scheduler';
-import utils from 'lib/posts/utils';
+import { isBackDated, isFutureDated, isPublished } from 'lib/posts/utils';
 import { getSelectedSite } from 'state/ui/selectors';
 
 export class EditorPublishDate extends React.Component {
@@ -78,23 +76,23 @@ export class EditorPublishDate extends React.Component {
 	};
 
 	getHeaderDescription() {
-		const isScheduled = utils.isFutureDated( this.props.post );
-		const isBackDated = utils.isBackDated( this.props.post );
-		const isPublished = utils.isPublished( this.props.post );
+		const isPostSchduled = isFutureDated( this.props.post );
+		const isPostBackDated = isBackDated( this.props.post );
+		const isPostPublished = isPublished( this.props.post );
 
-		if ( isPublished && isScheduled ) {
+		if ( isPostPublished && isPostSchduled ) {
 			return this.props.translate( 'Scheduled' );
 		}
 
-		if ( isScheduled ) {
+		if ( isPostSchduled ) {
 			return this.props.translate( 'Schedule' );
 		}
 
-		if ( isPublished ) {
+		if ( isPostPublished ) {
 			return this.props.translate( 'Published' );
 		}
 
-		if ( isBackDated ) {
+		if ( isPostBackDated ) {
 			return this.props.translate( 'Backdate' );
 		}
 
@@ -102,15 +100,15 @@ export class EditorPublishDate extends React.Component {
 	}
 
 	renderCalendarHeader() {
-		const isScheduled = utils.isFutureDated( this.props.post );
-		const isBackDated = utils.isBackDated( this.props.post );
-		const isPublished = utils.isPublished( this.props.post );
+		const isScheduled = isFutureDated( this.props.post );
+		const isPostBackDated = isBackDated( this.props.post );
+		const isPostPublished = isPublished( this.props.post );
 
-		if ( isPublished ) {
+		if ( isPostPublished ) {
 			return;
 		}
 
-		if ( ! isScheduled && ! isBackDated ) {
+		if ( ! isScheduled && ! isPostBackDated ) {
 			return (
 				<div className="editor-publish-date__choose-header">
 					{ this.props.translate( 'Choose a date to schedule' ) }
@@ -130,13 +128,13 @@ export class EditorPublishDate extends React.Component {
 	}
 
 	renderHeader() {
-		const isScheduled = utils.isFutureDated( this.props.post );
-		const isBackDated = utils.isBackDated( this.props.post );
-		const isPublished = utils.isPublished( this.props.post );
+		const isScheduled = isFutureDated( this.props.post );
+		const isPostBackDated = isBackDated( this.props.post );
+		const isPostPublishd = isPublished( this.props.post );
 		const className = classNames( 'editor-publish-date__header', {
 			'is-scheduled': isScheduled,
-			'is-back-dated': isBackDated,
-			'is-published': isPublished,
+			'is-back-dated': isPostBackDated,
+			'is-published': isPostPublishd,
 		} );
 		const selectedDay = this.props.post && this.props.post.date ? this.props.post.date : null;
 
@@ -147,7 +145,7 @@ export class EditorPublishDate extends React.Component {
 					<div className="editor-publish-date__header-description">
 						{ this.getHeaderDescription() }
 					</div>
-					{ ( isScheduled || isBackDated || isPublished ) && (
+					{ ( isScheduled || isPostBackDated || isPostPublishd ) && (
 						<div className="editor-publish-date__header-chrono">
 							{ this.props.moment( selectedDay ).calendar() }
 						</div>
@@ -160,7 +158,7 @@ export class EditorPublishDate extends React.Component {
 	renderSchedule() {
 		const selectedDay = this.props.post && this.props.post.date ? this.props.post.date : null;
 
-		const isScheduled = utils.isFutureDated( this.props.post );
+		const isScheduled = isFutureDated( this.props.post );
 		const className = classNames( 'editor-publish-date__schedule', {
 			'is-scheduled': isScheduled,
 		} );

--- a/client/post-editor/editor-publish-date/index.jsx
+++ b/client/post-editor/editor-publish-date/index.jsx
@@ -1,7 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDom from 'react-dom';
@@ -16,7 +18,7 @@ import { intersection } from 'lodash';
  */
 import Button from 'components/button';
 import PostScheduler from './post-scheduler';
-import { isBackDated, isFutureDated, isPublished } from 'lib/posts/utils';
+import * as utils from 'lib/posts/utils';
 import { getSelectedSite } from 'state/ui/selectors';
 
 export class EditorPublishDate extends React.Component {
@@ -76,23 +78,23 @@ export class EditorPublishDate extends React.Component {
 	};
 
 	getHeaderDescription() {
-		const isPostSchduled = isFutureDated( this.props.post );
-		const isPostBackDated = isBackDated( this.props.post );
-		const isPostPublished = isPublished( this.props.post );
+		const isScheduled = utils.isFutureDated( this.props.post );
+		const isBackDated = utils.isBackDated( this.props.post );
+		const isPublished = utils.isPublished( this.props.post );
 
-		if ( isPostPublished && isPostSchduled ) {
+		if ( isPublished && isScheduled ) {
 			return this.props.translate( 'Scheduled' );
 		}
 
-		if ( isPostSchduled ) {
+		if ( isScheduled ) {
 			return this.props.translate( 'Schedule' );
 		}
 
-		if ( isPostPublished ) {
+		if ( isPublished ) {
 			return this.props.translate( 'Published' );
 		}
 
-		if ( isPostBackDated ) {
+		if ( isBackDated ) {
 			return this.props.translate( 'Backdate' );
 		}
 
@@ -100,15 +102,15 @@ export class EditorPublishDate extends React.Component {
 	}
 
 	renderCalendarHeader() {
-		const isScheduled = isFutureDated( this.props.post );
-		const isPostBackDated = isBackDated( this.props.post );
-		const isPostPublished = isPublished( this.props.post );
+		const isScheduled = utils.isFutureDated( this.props.post );
+		const isBackDated = utils.isBackDated( this.props.post );
+		const isPublished = utils.isPublished( this.props.post );
 
-		if ( isPostPublished ) {
+		if ( isPublished ) {
 			return;
 		}
 
-		if ( ! isScheduled && ! isPostBackDated ) {
+		if ( ! isScheduled && ! isBackDated ) {
 			return (
 				<div className="editor-publish-date__choose-header">
 					{ this.props.translate( 'Choose a date to schedule' ) }
@@ -128,13 +130,13 @@ export class EditorPublishDate extends React.Component {
 	}
 
 	renderHeader() {
-		const isScheduled = isFutureDated( this.props.post );
-		const isPostBackDated = isBackDated( this.props.post );
-		const isPostPublishd = isPublished( this.props.post );
+		const isScheduled = utils.isFutureDated( this.props.post );
+		const isBackDated = utils.isBackDated( this.props.post );
+		const isPublished = utils.isPublished( this.props.post );
 		const className = classNames( 'editor-publish-date__header', {
 			'is-scheduled': isScheduled,
-			'is-back-dated': isPostBackDated,
-			'is-published': isPostPublishd,
+			'is-back-dated': isBackDated,
+			'is-published': isPublished,
 		} );
 		const selectedDay = this.props.post && this.props.post.date ? this.props.post.date : null;
 
@@ -145,7 +147,7 @@ export class EditorPublishDate extends React.Component {
 					<div className="editor-publish-date__header-description">
 						{ this.getHeaderDescription() }
 					</div>
-					{ ( isScheduled || isPostBackDated || isPostPublishd ) && (
+					{ ( isScheduled || isBackDated || isPublished ) && (
 						<div className="editor-publish-date__header-chrono">
 							{ this.props.moment( selectedDay ).calendar() }
 						</div>
@@ -158,7 +160,7 @@ export class EditorPublishDate extends React.Component {
 	renderSchedule() {
 		const selectedDay = this.props.post && this.props.post.date ? this.props.post.date : null;
 
-		const isScheduled = isFutureDated( this.props.post );
+		const isScheduled = utils.isFutureDated( this.props.post );
 		const className = classNames( 'editor-publish-date__schedule', {
 			'is-scheduled': isScheduled,
 		} );

--- a/client/post-editor/editor-publish-date/post-scheduler.jsx
+++ b/client/post-editor/editor-publish-date/post-scheduler.jsx
@@ -12,8 +12,8 @@ import { get } from 'lodash';
  */
 import PostSchedule from 'components/post-schedule';
 import QueryPosts from 'components/data/query-posts';
+import * as postUtils from 'lib/posts/utils';
 import { timezone } from 'lib/site/utils';
-import { getOffsetDate, isPage } from 'lib/posts/utils';
 import { getPostsForQueryIgnoringPage } from 'state/posts/selectors';
 
 const PostScheduleWithOtherPostsIndicated = connect( ( state, { site, query } ) => ( {
@@ -47,7 +47,7 @@ export default class PostScheduler extends PureComponent {
 	getFirstDayOfTheMonth( date ) {
 		const tz = timezone( this.props.site );
 
-		return getOffsetDate( date, tz ).set( {
+		return postUtils.getOffsetDate( date, tz ).set( {
 			year: date.year(),
 			month: date.month(),
 			date: 1,
@@ -82,7 +82,9 @@ export default class PostScheduler extends PureComponent {
 
 		return (
 			<div>
-				{ ! isPage( post ) && <QueryPosts siteId={ get( site, 'ID' ) } query={ query } /> }
+				{ ! postUtils.isPage( post ) && (
+					<QueryPosts siteId={ get( site, 'ID' ) } query={ query } />
+				) }
 				<PostScheduleWithOtherPostsIndicated
 					onDateChange={ setPostDate }
 					onMonthChange={ this.setCurrentMonth }

--- a/client/post-editor/editor-publish-date/post-scheduler.jsx
+++ b/client/post-editor/editor-publish-date/post-scheduler.jsx
@@ -12,8 +12,8 @@ import { get } from 'lodash';
  */
 import PostSchedule from 'components/post-schedule';
 import QueryPosts from 'components/data/query-posts';
-import postUtils from 'lib/posts/utils';
 import { timezone } from 'lib/site/utils';
+import { getOffsetDate, isPage } from 'lib/posts/utils';
 import { getPostsForQueryIgnoringPage } from 'state/posts/selectors';
 
 const PostScheduleWithOtherPostsIndicated = connect( ( state, { site, query } ) => ( {
@@ -47,7 +47,7 @@ export default class PostScheduler extends PureComponent {
 	getFirstDayOfTheMonth( date ) {
 		const tz = timezone( this.props.site );
 
-		return postUtils.getOffsetDate( date, tz ).set( {
+		return getOffsetDate( date, tz ).set( {
 			year: date.year(),
 			month: date.month(),
 			date: 1,
@@ -82,9 +82,7 @@ export default class PostScheduler extends PureComponent {
 
 		return (
 			<div>
-				{ ! postUtils.isPage( post ) && (
-					<QueryPosts siteId={ get( site, 'ID' ) } query={ query } />
-				) }
+				{ ! isPage( post ) && <QueryPosts siteId={ get( site, 'ID' ) } query={ query } /> }
 				<PostScheduleWithOtherPostsIndicated
 					onDateChange={ setPostDate }
 					onMonthChange={ this.setCurrentMonth }

--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -19,7 +17,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import PostMetadata from 'lib/post-metadata';
 import Sharing from './';
 import AccordionSection from 'components/accordion/section';
-import postUtils from 'lib/posts/utils';
+import { isPublished } from 'lib/posts/utils';
 import { isMobile } from 'lib/viewport';
 import QueryPublicizeConnections from 'components/data/query-publicize-connections';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -70,7 +68,7 @@ class EditorSharingAccordion extends React.Component {
 			'is-standalone': this.hideSharing(),
 		} );
 
-		if ( ! postUtils.isPublished( this.props.post ) ) {
+		if ( ! isPublished( this.props.post ) ) {
 			return null;
 		}
 
@@ -104,7 +102,7 @@ class EditorSharingAccordion extends React.Component {
 
 		// if sharing is hidden, and post is not published (no short URL yet),
 		// then do not render this accordion
-		if ( hideSharing && ! postUtils.isPublished( this.props.post ) ) {
+		if ( hideSharing && ! isPublished( this.props.post ) ) {
 			return null;
 		}
 

--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -1,7 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
+
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -17,7 +19,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import PostMetadata from 'lib/post-metadata';
 import Sharing from './';
 import AccordionSection from 'components/accordion/section';
-import { isPublished } from 'lib/posts/utils';
+import * as postUtils from 'lib/posts/utils';
 import { isMobile } from 'lib/viewport';
 import QueryPublicizeConnections from 'components/data/query-publicize-connections';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -68,7 +70,7 @@ class EditorSharingAccordion extends React.Component {
 			'is-standalone': this.hideSharing(),
 		} );
 
-		if ( ! isPublished( this.props.post ) ) {
+		if ( ! postUtils.isPublished( this.props.post ) ) {
 			return null;
 		}
 
@@ -102,7 +104,7 @@ class EditorSharingAccordion extends React.Component {
 
 		// if sharing is hidden, and post is not published (no short URL yet),
 		// then do not render this accordion
-		if ( hideSharing && ! isPublished( this.props.post ) ) {
+		if ( hideSharing && ! postUtils.isPublished( this.props.post ) ) {
 			return null;
 		}
 

--- a/client/post-editor/editor-status-label/index.jsx
+++ b/client/post-editor/editor-status-label/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -13,7 +11,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import postUtils from 'lib/posts/utils';
+import { getEditedTime } from 'lib/posts/utils';
 import EditorStatusLabelPlaceholder from './placeholder';
 
 class StatusLabel extends React.PureComponent {
@@ -84,9 +82,9 @@ class StatusLabel extends React.PureComponent {
 	}
 
 	renderLabel = () => {
-		var post = this.props.post,
-			editedTime = this.props.moment( postUtils.getEditedTime( post ) ),
-			label;
+		const post = this.props.post;
+		let editedTime = this.props.moment( getEditedTime( post ) );
+		let label;
 
 		if ( ! post.modified ) {
 			return this.props.translate( 'New Draft' );

--- a/client/post-editor/editor-status-label/index.jsx
+++ b/client/post-editor/editor-status-label/index.jsx
@@ -1,7 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
+
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -11,7 +13,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import { getEditedTime } from 'lib/posts/utils';
+import * as postUtils from 'lib/posts/utils';
 import EditorStatusLabelPlaceholder from './placeholder';
 
 class StatusLabel extends React.PureComponent {
@@ -82,9 +84,9 @@ class StatusLabel extends React.PureComponent {
 	}
 
 	renderLabel = () => {
-		const post = this.props.post;
-		let editedTime = this.props.moment( getEditedTime( post ) );
-		let label;
+		var post = this.props.post,
+			editedTime = this.props.moment( postUtils.getEditedTime( post ) ),
+			label;
 
 		if ( ! post.modified ) {
 			return this.props.translate( 'New Draft' );

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -14,7 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import PostUtils from 'lib/posts/utils';
+import { getPermalinkBasePath, isPage } from 'lib/posts/utils';
 import EditorPermalink from 'post-editor/editor-permalink';
 import TrackInputChanges from 'components/track-input-changes';
 import TextareaAutosize from 'components/textarea-autosize';
@@ -79,9 +77,9 @@ class EditorTitle extends Component {
 	};
 
 	recordChangeStats = () => {
-		const isPage = PostUtils.isPage( this.props.post );
-		stats.recordStat( isPage ? 'page_title_changed' : 'post_title_changed' );
-		stats.recordEvent( isPage ? 'Changed Page Title' : 'Changed Post Title' );
+		const isAPage = isPage( this.props.post );
+		stats.recordStat( isAPage ? 'page_title_changed' : 'post_title_changed' );
+		stats.recordEvent( isAPage ? 'Changed Page Title' : 'Changed Post Title' );
 	};
 
 	render() {
@@ -95,9 +93,9 @@ class EditorTitle extends Component {
 			<div className={ classes }>
 				{ post &&
 					post.ID &&
-					! PostUtils.isPage( post ) && (
+					! isPage( post ) && (
 						<EditorPermalink
-							path={ isPermalinkEditable ? PostUtils.getPermalinkBasePath( post ) : post.URL }
+							path={ isPermalinkEditable ? getPermalinkBasePath( post ) : post.URL }
 							isEditable={ isPermalinkEditable }
 						/>
 					) }

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -1,7 +1,9 @@
 /** @format */
+
 /**
  * External dependencies
  */
+
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -12,7 +14,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getPermalinkBasePath, isPage } from 'lib/posts/utils';
+import * as PostUtils from 'lib/posts/utils';
 import EditorPermalink from 'post-editor/editor-permalink';
 import TrackInputChanges from 'components/track-input-changes';
 import TextareaAutosize from 'components/textarea-autosize';
@@ -77,9 +79,9 @@ class EditorTitle extends Component {
 	};
 
 	recordChangeStats = () => {
-		const isAPage = isPage( this.props.post );
-		stats.recordStat( isAPage ? 'page_title_changed' : 'post_title_changed' );
-		stats.recordEvent( isAPage ? 'Changed Page Title' : 'Changed Post Title' );
+		const isPage = PostUtils.isPage( this.props.post );
+		stats.recordStat( isPage ? 'page_title_changed' : 'post_title_changed' );
+		stats.recordEvent( isPage ? 'Changed Page Title' : 'Changed Post Title' );
 	};
 
 	render() {
@@ -93,9 +95,9 @@ class EditorTitle extends Component {
 			<div className={ classes }>
 				{ post &&
 					post.ID &&
-					! isPage( post ) && (
+					! PostUtils.isPage( post ) && (
 						<EditorPermalink
-							path={ isPermalinkEditable ? getPermalinkBasePath( post ) : post.URL }
+							path={ isPermalinkEditable ? PostUtils.getPermalinkBasePath( post ) : post.URL }
 							isEditable={ isPermalinkEditable }
 						/>
 					) }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -30,7 +30,7 @@ import SegmentedControlItem from 'components/segmented-control/item';
 import InvalidURLDialog from 'post-editor/invalid-url-dialog';
 import RestorePostDialog from 'post-editor/restore-post-dialog';
 import VerifyEmailDialog from 'components/email-verification/email-verification-dialog';
-import utils from 'lib/posts/utils';
+import * as utils from 'lib/posts/utils';
 import EditorPreview from './editor-preview';
 import { recordStat, recordEvent } from 'lib/posts/stats';
 import analytics from 'lib/analytics';


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.