### PR TITLE
esmodules: Update lib/domains/email-formarding

### DIFF
--- a/client/lib/domains/email-forwarding/index.js
+++ b/client/lib/domains/email-forwarding/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { mapValues } from 'lodash';
 import emailValidator from 'email-validator';
 
@@ -12,11 +10,11 @@ import emailValidator from 'email-validator';
  */
 import { isBusiness } from 'lib/products-values';
 
-function emailForwardingPlanLimit( plan ) {
+export function emailForwardingPlanLimit( plan ) {
 	return isBusiness( plan ) ? 100 : 5;
 }
 
-function validateAllFields( fieldValues ) {
+export function validateAllFields( fieldValues ) {
 	return mapValues( fieldValues, ( value, fieldName ) => {
 		const isValid = validateField( {
 			value,
@@ -37,8 +35,3 @@ function validateField( { name, value } ) {
 			return true;
 	}
 }
-
-export default {
-	emailForwardingPlanLimit,
-	validateAllFields,
-};

--- a/client/lib/domains/email-forwarding/reducer.js
+++ b/client/lib/domains/email-forwarding/reducer.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { findIndex, sortBy } from 'lodash';
 import update from 'immutability-helper';
 

--- a/client/lib/domains/email-forwarding/store.js
+++ b/client/lib/domains/email-forwarding/store.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
 import { createReducerStore } from 'lib/store';
 import { initialDomainState, reducer } from './reducer';
 

--- a/client/lib/domains/email-forwarding/test/store.js
+++ b/client/lib/domains/email-forwarding/test/store.js
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.