### PR TITLE
esmodules: Update lib/credit-card-details

### DIFF
--- a/client/lib/credit-card-details/index.js
+++ b/client/lib/credit-card-details/index.js
@@ -1,15 +1,6 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
-import masking from './masking';
-import validation from './validation';
-
-export default {
-	getCreditCardType: validation.getCreditCardType,
-	maskField: masking.maskField,
-	unmaskField: masking.unmaskField,
-	validateCardDetails: validation.validateCardDetails,
-};
+export { maskField, unmaskField } from './masking';
+export { getCreditCardType, validateCardDetails } from './validation';

--- a/client/lib/credit-card-details/masking.js
+++ b/client/lib/credit-card-details/masking.js
@@ -1,12 +1,10 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { identity } from 'lodash';
 
-var fieldMasks = {};
+const fieldMasks = {};
 
 fieldMasks[ 'expiration-date' ] = {
 	mask: function( previousValue, nextValue ) {
@@ -30,9 +28,9 @@ fieldMasks[ 'expiration-date' ] = {
 
 		if ( nextValue.length <= 2 ) {
 			return nextValue;
-		} else {
-			return nextValue.substring( 0, 2 ) + '/' + nextValue.substring( 2, 4 );
 		}
+
+		return nextValue.substring( 0, 2 ) + '/' + nextValue.substring( 2, 4 );
 	},
 
 	unmask: identity,
@@ -40,7 +38,7 @@ fieldMasks[ 'expiration-date' ] = {
 
 fieldMasks.number = {
 	mask: function( previousValue, nextValue ) {
-		var digits = nextValue.replace( /[^0-9]/g, '' ),
+		const digits = nextValue.replace( /[^0-9]/g, '' ),
 			string =
 				digits.slice( 0, 4 ) +
 				' ' +
@@ -66,8 +64,8 @@ fieldMasks.cvv = {
 	unmask: identity,
 };
 
-function maskField( fieldName, previousValue, nextValue ) {
-	var fieldMask = fieldMasks[ fieldName ];
+export function maskField( fieldName, previousValue, nextValue ) {
+	const fieldMask = fieldMasks[ fieldName ];
 	if ( ! fieldMask ) {
 		return nextValue;
 	}
@@ -75,16 +73,11 @@ function maskField( fieldName, previousValue, nextValue ) {
 	return fieldMask.mask( previousValue, nextValue );
 }
 
-function unmaskField( fieldName, previousValue, nextValue ) {
-	var fieldMask = fieldMasks[ fieldName ];
+export function unmaskField( fieldName, previousValue, nextValue ) {
+	const fieldMask = fieldMasks[ fieldName ];
 	if ( ! fieldMask ) {
 		return nextValue;
 	}
 
 	return fieldMask.unmask( fieldMask.mask( previousValue, nextValue ) );
 }
-
-export default {
-	maskField: maskField,
-	unmaskField: unmaskField,
-};

--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -7,7 +7,7 @@ import assert from 'assert';
 /**
  * Internal dependencies
  */
-import { getCreditCardType } from '../index';
+import { getCreditCardType } from '../';
 
 function getRandomInt( min, max ) {
 	return Math.floor( Math.random() * ( max - min + 1 ) ) + min;

--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -1,15 +1,13 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import assert from 'assert';
 
 /**
  * Internal dependencies
  */
-import creditCardDetails from '../';
+import { getCreditCardType } from '../index';
 
 function getRandomInt( min, max ) {
 	return Math.floor( Math.random() * ( max - min + 1 ) ) + min;
@@ -21,11 +19,11 @@ describe( 'index', () => {
 			const randomNumberBetweenRange = getRandomInt( 622126, 622925 ).toString();
 
 			test( 'should return null for 622125', () => {
-				assert.equal( null, creditCardDetails.getCreditCardType( '622125' ) );
+				assert.equal( null, getCreditCardType( '622125' ) );
 			} );
 
 			test( 'should return `discover` for 622126', () => {
-				assert.equal( 'discover', creditCardDetails.getCreditCardType( '622126' ) );
+				assert.equal( 'discover', getCreditCardType( '622126' ) );
 			} );
 
 			test(
@@ -33,55 +31,52 @@ describe( 'index', () => {
 					randomNumberBetweenRange +
 					' (a random number between 622126 and 622925)',
 				() => {
-					assert.equal(
-						'discover',
-						creditCardDetails.getCreditCardType( randomNumberBetweenRange )
-					);
+					assert.equal( 'discover', getCreditCardType( randomNumberBetweenRange ) );
 				}
 			);
 
 			test( 'should return `discover` for 622925', () => {
-				assert.equal( 'discover', creditCardDetails.getCreditCardType( '622925' ) );
+				assert.equal( 'discover', getCreditCardType( '622925' ) );
 			} );
 
 			test( 'should return null for 622926', () => {
-				assert.equal( null, creditCardDetails.getCreditCardType( '622926' ) );
+				assert.equal( null, getCreditCardType( '622926' ) );
 			} );
 		} );
 
 		describe( 'Mastercard: range 2221-2720', () => {
 			test( 'should return null for 2220990000000000', () => {
-				assert.equal( null, creditCardDetails.getCreditCardType( '2220990000000000' ) );
+				assert.equal( null, getCreditCardType( '2220990000000000' ) );
 			} );
 
 			test( 'should return `mastercard` for 2221000000000000', () => {
-				assert.equal( 'mastercard', creditCardDetails.getCreditCardType( '2221000000000000' ) );
+				assert.equal( 'mastercard', getCreditCardType( '2221000000000000' ) );
 			} );
 
 			test( 'should return `mastercard` for 2720990000000000', () => {
-				assert.equal( 'mastercard', creditCardDetails.getCreditCardType( '2720990000000000' ) );
+				assert.equal( 'mastercard', getCreditCardType( '2720990000000000' ) );
 			} );
 
 			test( 'should return null for 2721000000000000', () => {
-				assert.equal( null, creditCardDetails.getCreditCardType( '2721000000000000' ) );
+				assert.equal( null, getCreditCardType( '2721000000000000' ) );
 			} );
 		} );
 
 		describe( 'Mastercard: range 51-55', () => {
 			test( 'should return null for 5099999999999999', () => {
-				assert.equal( null, creditCardDetails.getCreditCardType( '5099999999999999' ) );
+				assert.equal( null, getCreditCardType( '5099999999999999' ) );
 			} );
 
 			test( 'should return `mastercard` for 5100000000000000', () => {
-				assert.equal( 'mastercard', creditCardDetails.getCreditCardType( '5599000000000000' ) );
+				assert.equal( 'mastercard', getCreditCardType( '5599000000000000' ) );
 			} );
 
 			test( 'should return `mastercard` for 5599000000000000', () => {
-				assert.equal( 'mastercard', creditCardDetails.getCreditCardType( '5599000000000000' ) );
+				assert.equal( 'mastercard', getCreditCardType( '5599000000000000' ) );
 			} );
 
 			test( 'should return null for 5600000000000000', () => {
-				assert.equal( null, creditCardDetails.getCreditCardType( '5600000000000000' ) );
+				assert.equal( null, getCreditCardType( '5600000000000000' ) );
 			} );
 		} );
 	} );

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import creditcards from 'creditcards';
 import { capitalize, compact, inRange, isArray, isEmpty } from 'lodash';
 import i18n from 'i18n-calypso';
@@ -115,7 +113,7 @@ validators.validExpirationDate = {
 	error: validationError,
 };
 
-function validateCardDetails( cardDetails ) {
+export function validateCardDetails( cardDetails ) {
 	const rules = creditCardFieldRules(),
 		errors = Object.keys( rules ).reduce( function( allErrors, fieldName ) {
 			const field = rules[ fieldName ],
@@ -138,7 +136,7 @@ function validateCardDetails( cardDetails ) {
  * @returns {string} the type of the credit card
  * @see {@link http://en.wikipedia.org/wiki/Bank_card_number} for more information
  */
-function getCreditCardType( number ) {
+export function getCreditCardType( number ) {
 	if ( number ) {
 		number = number.replace( / /g, '' );
 
@@ -184,8 +182,3 @@ function getValidator( rule ) {
 
 	return validators[ rule ];
 }
-
-export default {
-	getCreditCardType: getCreditCardType,
-	validateCardDetails: validateCardDetails,
-};


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.