### PR TITLE
esmodules: Update lib/i18n-utils

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -15,7 +15,7 @@ import { translate } from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import CheckoutData from 'components/data/checkout';
 import config from 'config';
-import i18nUtils from 'lib/i18n-utils';
+import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
 import JetpackAuthorize from './authorize';
 import JetpackConnect from './main';
 import JetpackNewSite from './jetpack-new-site/index';
@@ -94,8 +94,8 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 };
 
 export function redirectWithoutLocaleIfLoggedIn( context, next ) {
-	if ( userModule.get() && i18nUtils.getLocaleFromPath( context.path ) ) {
-		const urlWithoutLocale = i18nUtils.removeLocaleFromPath( context.path );
+	if ( userModule.get() && getLocaleFromPath( context.path ) ) {
+		const urlWithoutLocale = removeLocaleFromPath( context.path );
 		debug( 'redirectWithoutLocaleIfLoggedIn to %s', urlWithoutLocale );
 		return page.redirect( urlWithoutLocale );
 	}

--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -1,13 +1,16 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import i18n from 'i18n-calypso';
 
-module.exports = require( './utils.js' );
+export {
+	addLocaleToPath,
+	addLocaleToWpcomUrl,
+	getLanguage,
+	getLocaleFromPath,
+	isDefaultLocale,
+	removeLocaleFromPath,
+} from './utils';
 
-module.exports.getLocaleSlug = function() {
-	return i18n.getLocaleSlug();
-};
+export const getLocaleSlug = () => i18n.getLocaleSlug();

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -1,13 +1,16 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
 import config from 'config';
 
-module.exports = require( './utils.js' );
+export {
+	addLocaleToPath,
+	addLocaleToWpcomUrl,
+	getLanguage,
+	getLocaleFromPath,
+	isDefaultLocale,
+	removeLocaleFromPath,
+} from './utils';
 
-module.exports.getLocaleSlug = function() {
-	return config( 'i18n_default_locale_slug' );
-};
+export const getLocaleSlug = () => config( 'i18n_default_locale_slug' );

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -4,6 +4,12 @@
  */
 import config from 'config';
 
+// we cannot use the following export
+// until we have stopped compiling into
+// CommonJS modules through Babel due
+// to an issue with Babel faking a default export
+//
+// export * from './utils';
 export {
 	addLocaleToPath,
 	addLocaleToWpcomUrl,

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { find } from 'lodash';
 import { parse } from 'url';
 
@@ -21,83 +19,79 @@ function getPathParts( path ) {
 	return path.replace( /\/$/, '' ).split( '/' );
 }
 
-const i18nUtils = {
-	/**
-	 * Checks if provided locale is a default one.
-	 *
-	 * @param {string} locale - locale slug (eg: 'fr')
-	 * @return {boolean} true when the default locale is provided
-	 */
-	isDefaultLocale: function( locale ) {
-		return locale === config( 'i18n_default_locale_slug' );
-	},
+/**
+ * Checks if provided locale is a default one.
+ *
+ * @param {string} locale - locale slug (eg: 'fr')
+ * @return {boolean} true when the default locale is provided
+ */
+export function isDefaultLocale( locale ) {
+	return locale === config( 'i18n_default_locale_slug' );
+}
 
-	getLanguage: function( langSlug ) {
-		let language;
+export function getLanguage( langSlug ) {
+	let language;
 
-		if ( localeRegex.test( langSlug ) || localeWithRegionRegex.test( langSlug ) ) {
-			language =
-				find( config( 'languages' ), { langSlug } ) ||
-				find( config( 'languages' ), { langSlug: langSlug.split( '-' )[ 0 ] } );
-		}
+	if ( localeRegex.test( langSlug ) || localeWithRegionRegex.test( langSlug ) ) {
+		language =
+			find( config( 'languages' ), { langSlug } ) ||
+			find( config( 'languages' ), { langSlug: langSlug.split( '-' )[ 0 ] } );
+	}
 
-		return language;
-	},
+	return language;
+}
 
-	/**
-	 * Assuming that locale is adding at the end of path, retrieves the locale if present.
-	 * @param {string} path - original path
-	 * @return {string|undefined} The locale slug if present or undefined
-	 */
-	getLocaleFromPath: function( path ) {
-		const urlParts = parse( path );
-		const locale = getPathParts( urlParts.pathname ).pop();
+/**
+ * Assuming that locale is adding at the end of path, retrieves the locale if present.
+ * @param {string} path - original path
+ * @return {string|undefined} The locale slug if present or undefined
+ */
+export function getLocaleFromPath( path ) {
+	const urlParts = parse( path );
+	const locale = getPathParts( urlParts.pathname ).pop();
 
-		return 'undefined' === typeof i18nUtils.getLanguage( locale ) ? undefined : locale;
-	},
+	return 'undefined' === typeof getLanguage( locale ) ? undefined : locale;
+}
 
-	/**
-	 * Adds a locale slug to the current path.
-	 *
-	 * Will replace existing locale slug, if present.
-	 *
-	 * @param {string} path - original path
-	 * @param {string} locale - locale slug (eg: 'fr')
-	 * @returns {string} original path with new locale slug
-	 */
-	addLocaleToPath: function( path, locale ) {
-		const urlParts = parse( path );
-		const queryString = urlParts.search || '';
+/**
+ * Adds a locale slug to the current path.
+ *
+ * Will replace existing locale slug, if present.
+ *
+ * @param {string} path - original path
+ * @param {string} locale - locale slug (eg: 'fr')
+ * @returns {string} original path with new locale slug
+ */
+export function addLocaleToPath( path, locale ) {
+	const urlParts = parse( path );
+	const queryString = urlParts.search || '';
 
-		return i18nUtils.removeLocaleFromPath( urlParts.pathname ) + `/${ locale }` + queryString;
-	},
+	return removeLocaleFromPath( urlParts.pathname ) + `/${ locale }` + queryString;
+}
 
-	addLocaleToWpcomUrl: function( url, locale ) {
-		if ( locale && locale !== 'en' ) {
-			return url.replace( 'https://wordpress.com', 'https://' + locale + '.wordpress.com' );
-		}
+export function addLocaleToWpcomUrl( url, locale ) {
+	if ( locale && locale !== 'en' ) {
+		return url.replace( 'https://wordpress.com', 'https://' + locale + '.wordpress.com' );
+	}
 
-		return url;
-	},
+	return url;
+}
 
-	/**
-	 * Removes the trailing locale slug from the path, if it is present.
-	 * '/start/en' => '/start', '/start' => '/start', '/start/flow/fr' => '/start/flow', '/start/flow' => '/start/flow'
-	 * @param {string} path - original path
-	 * @returns {string} original path minus locale slug
-	 */
-	removeLocaleFromPath: function( path ) {
-		const urlParts = parse( path );
-		const queryString = urlParts.search || '';
-		const parts = getPathParts( urlParts.pathname );
-		const locale = parts.pop();
+/**
+ * Removes the trailing locale slug from the path, if it is present.
+ * '/start/en' => '/start', '/start' => '/start', '/start/flow/fr' => '/start/flow', '/start/flow' => '/start/flow'
+ * @param {string} path - original path
+ * @returns {string} original path minus locale slug
+ */
+export function removeLocaleFromPath( path ) {
+	const urlParts = parse( path );
+	const queryString = urlParts.search || '';
+	const parts = getPathParts( urlParts.pathname );
+	const locale = parts.pop();
 
-		if ( 'undefined' === typeof i18nUtils.getLanguage( locale ) ) {
-			parts.push( locale );
-		}
+	if ( 'undefined' === typeof getLanguage( locale ) ) {
+		parts.push( locale );
+	}
 
-		return parts.join( '/' ) + queryString;
-	},
-};
-
-export default i18nUtils;
+	return parts.join( '/' ) + queryString;
+}

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -17,7 +17,7 @@ import Me from './me';
 import MailingList from './mailing-list';
 import AccountRecoveryReset from './account-recovery-reset';
 import config from 'config';
-import i18n from 'lib/i18n-utils';
+import { getLanguage, getLocaleSlug } from 'lib/i18n-utils';
 import readerContentWidth from 'reader/lib/content-width';
 
 /**
@@ -1655,7 +1655,7 @@ Undocumented.prototype.usersNew = function( query, fn ) {
 	restrictByOauthKeys( query );
 
 	// Set the language for the user
-	query.locale = i18n.getLocaleSlug();
+	query.locale = getLocaleSlug();
 	args = {
 		path: '/users/new',
 		body: query,
@@ -1672,7 +1672,7 @@ Undocumented.prototype.usersNew = function( query, fn ) {
  * @return {Promise} A promise for the request
  */
 Undocumented.prototype.usersSocialNew = function( query, fn ) {
-	query.locale = i18n.getLocaleSlug();
+	query.locale = getLocaleSlug();
 
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( query );
@@ -1816,7 +1816,7 @@ Undocumented.prototype.usersEmailVerification = function( query, fn ) {
 Undocumented.prototype.validateNewUser = function( data, fn ) {
 	debug( '/signups/validation/user' );
 
-	data.locale = i18n.getLocaleSlug();
+	data.locale = getLocaleSlug();
 
 	return this.wpcom.req.post( '/signups/validation/user/', null, data, fn );
 };
@@ -1830,8 +1830,8 @@ Undocumented.prototype.validateNewUser = function( data, fn ) {
 Undocumented.prototype.requestMagicLoginEmail = function( data, fn ) {
 	restrictByOauthKeys( data );
 
-	data.locale = i18n.getLocaleSlug();
-	data.lang_id = i18n.getLanguage( data.locale ).value;
+	data.locale = getLocaleSlug();
+	data.lang_id = getLanguage( data.locale ).value;
 
 	return this.wpcom.req.post(
 		'/auth/send-login-email',
@@ -1850,7 +1850,7 @@ Undocumented.prototype.requestMagicLoginEmail = function( data, fn ) {
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.sitesNew = function( query, fn ) {
-	var localeSlug = i18n.getLocaleSlug();
+	var localeSlug = getLocaleSlug();
 
 	debug( '/sites/new' );
 
@@ -1858,7 +1858,7 @@ Undocumented.prototype.sitesNew = function( query, fn ) {
 	restrictByOauthKeys( query );
 
 	// Set the language for the user
-	query.lang_id = i18n.getLanguage( localeSlug ).value;
+	query.lang_id = getLanguage( localeSlug ).value;
 	query.locale = localeSlug;
 
 	return this.wpcom.req.post(

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1850,7 +1850,7 @@ Undocumented.prototype.requestMagicLoginEmail = function( data, fn ) {
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.sitesNew = function( query, fn ) {
-	var localeSlug = getLocaleSlug();
+	const localeSlug = getLocaleSlug();
 
 	debug( '/sites/new' );
 

--- a/client/my-sites/domains/domain-management/domain-connect/controller.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect/controller.jsx
@@ -1,22 +1,20 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 
 /**
  * Internal dependencies
  */
-import i18nUtils from 'lib/i18n-utils';
+import { getLanguage } from 'lib/i18n-utils';
 import DomainConnectAuthorize from './domain-connect-authorize';
 import DomainConnectNotFoundError from './domain-connect-not-found-error';
 
 export function domainConnectAuthorize( context, next ) {
 	context.primary = (
 		<DomainConnectAuthorize
-			locale={ i18nUtils.getLanguage( context.params.locale ) }
+			locale={ getLanguage( context.params.locale ) }
 			path={ context.path }
 			params={ context.query }
 			providerId={ context.params.providerId }

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import store from 'store';
 import page from 'page';
@@ -20,7 +18,7 @@ import { setSection } from 'state/ui/actions';
 import { getRedirectAfterAccept } from 'my-sites/invites/utils';
 import { acceptInvite as acceptInviteAction } from 'lib/invites/actions';
 import _user from 'lib/user';
-import i18nUtils from 'lib/i18n-utils';
+import { getLanguage, getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
 
 /**
  * Module variables
@@ -34,20 +32,20 @@ function getLocale( parameters ) {
 }
 
 function isLocale( pathFragment ) {
-	return ! isEmpty( i18nUtils.getLanguage( pathFragment ) );
+	return ! isEmpty( getLanguage( pathFragment ) );
 }
 
 export function redirectWithoutLocaleifLoggedIn( context, next ) {
-	if ( user.get() && i18nUtils.getLocaleFromPath( context.path ) ) {
-		let urlWithoutLocale = i18nUtils.removeLocaleFromPath( context.path );
-		return page.redirect( urlWithoutLocale );
+	if ( user.get() && getLocaleFromPath( context.path ) ) {
+		return page.redirect( removeLocaleFromPath( context.path ) );
 	}
 
 	next();
 }
 
 export function acceptInvite( context, next ) {
-	context.store.dispatch( setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) ) ); // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
+	context.store.dispatch( setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) ) );
 
 	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 

--- a/client/reader/search-stream/suggestion-provider.jsx
+++ b/client/reader/search-stream/suggestion-provider.jsx
@@ -9,7 +9,7 @@ import { map, sampleSize } from 'lodash';
 /**
  * Internal Dependencies
  */
-import i18nUtils from 'lib/i18n-utils';
+import { getLocaleSlug } from 'lib/i18n-utils';
 import { suggestions } from 'reader/search-stream/suggestions';
 import { getReaderFollowedTags } from 'state/selectors';
 import analytics from 'lib/analytics';
@@ -35,7 +35,7 @@ function suggestionsFromTags( count, tags ) {
 }
 
 function suggestionsFromPicks( count ) {
-	const lang = i18nUtils.getLocaleSlug().split( '-' )[ 0 ];
+	const lang = getLocaleSlug().split( '-' )[ 0 ];
 	if ( suggestions[ lang ] ) {
 		return map( sampleSize( suggestions[ lang ], count ), ( tag, i ) => {
 			const ui_algo = 'read:search-suggestions:picks/1';

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -1,18 +1,15 @@
+/** @format **/
 /**
  * Exernal dependencies
- *
- * @format
  */
-
 import { filter, find, indexOf, isEmpty, merge, pick } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import i18nUtils from 'lib/i18n-utils';
+import { getLanguage } from 'lib/i18n-utils';
 import steps from 'signup/config/steps';
-import flows from 'signup/config/flows';
-import { defaultFlowName } from 'signup/config/flows';
+import flows, { defaultFlowName } from 'signup/config/flows';
 import formState from 'lib/form-state';
 import userFactory from 'lib/user';
 const user = userFactory();
@@ -63,7 +60,7 @@ function getLocale( parameters ) {
 }
 
 function isLocale( pathFragment ) {
-	return ! isEmpty( i18nUtils.getLanguage( pathFragment ) );
+	return ! isEmpty( getLanguage( pathFragment ) );
 }
 
 function getStepUrl( flowName, stepName, stepSectionName, localeSlug ) {


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.