### PR TITLE
esmodules: Update me/purchases

### DIFF
--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */
@@ -10,7 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import purchasesPaths from 'me/purchases/paths';
+import { billingHistoryReceipt } from 'me/purchases/paths';
 import TransactionsTable from './transactions-table';
 import { isSendingBillingReceiptEmail } from 'state/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
@@ -56,7 +55,7 @@ class BillingHistoryTable extends React.Component {
 			<div className="billing-history__transaction-links">
 				<a
 					className="billing-history__view-receipt"
-					href={ purchasesPaths.billingHistoryReceipt( transaction.id ) }
+					href={ billingHistoryReceipt( transaction.id ) }
 					onClick={ this.handleReceiptLinkClick }
 				>
 					{ translate( 'View Receipt' ) }

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -23,7 +21,7 @@ import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
-import purchasesPaths from 'me/purchases/paths';
+import { purchasesRoot } from 'me/purchases/paths';
 import { getPastBillingTransactions, getUpcomingBillingTransactions } from 'state/selectors';
 
 const BillingHistory = ( { pastTransactions, upcomingTransactions, translate } ) => (
@@ -36,7 +34,7 @@ const BillingHistory = ( { pastTransactions, upcomingTransactions, translate } )
 		<Card className="billing-history__receipts">
 			<BillingHistoryTable transactions={ pastTransactions } />
 		</Card>
-		<Card href={ purchasesPaths.purchasesRoot() }>
+		<Card href={ purchasesRoot }>
 			{ translate( 'Go to "Purchases" to add or cancel a plan.' ) }
 		</Card>
 		{ pastTransactions && (

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */
@@ -17,7 +16,7 @@ import DocumentHead from 'components/data/document-head';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import purchasesPaths from 'me/purchases/paths';
+import { billingHistory } from 'me/purchases/paths';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
 import tableRows from './table-rows';
 import { getPastBillingTransaction, getPastBillingTransactions } from 'state/selectors';
@@ -49,7 +48,7 @@ class BillingReceipt extends React.Component {
 		const { totalTransactions, transaction } = this.props;
 
 		if ( ! transaction && totalTransactions !== null ) {
-			page.redirect( purchasesPaths.billingHistory() );
+			page.redirect( billingHistory );
 		}
 	}
 
@@ -96,11 +95,7 @@ class BillingReceipt extends React.Component {
 	renderTitle() {
 		const { translate } = this.props;
 
-		return (
-			<HeaderCake backHref={ purchasesPaths.billingHistory() }>
-				{ translate( 'Billing History' ) }
-			</HeaderCake>
-		);
+		return <HeaderCake backHref={ billingHistory }>{ translate( 'Billing History' ) }</HeaderCake>;
 	}
 
 	renderPlaceholder() {

--- a/client/me/billing-history/upcoming-charges-table.jsx
+++ b/client/me/billing-history/upcoming-charges-table.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -12,7 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import purchasesPaths from 'me/purchases/paths';
+import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import TransactionsTable from './transactions-table';
 import { getSiteSlugsForUpcomingTransactions } from 'state/selectors';
 
@@ -32,7 +30,7 @@ class UpcomingChargesTable extends Component {
 
 		return (
 			<div className="billing-history__transaction-links">
-				<a href={ purchasesPaths.managePurchase( siteSlug, transaction.id ) }>
+				<a href={ managePurchase( siteSlug, transaction.id ) }>
 					{ translate( 'Manage Purchase' ) }
 				</a>
 			</div>
@@ -45,7 +43,7 @@ class UpcomingChargesTable extends Component {
 			'The upgrades on your account will not renew automatically. ' +
 				'To manage your upgrades or enable Auto Renew visit {{link}}My Upgrades{{/link}}.',
 			{
-				components: { link: <a href={ purchasesPaths.purchasesRoot() } /> },
+				components: { link: <a href={ purchasesRoot } /> },
 			}
 		);
 		const noFilterResultsText = translate( 'No upcoming charges found.' );

--- a/client/me/purchases/add-credit-card/index.jsx
+++ b/client/me/purchases/add-credit-card/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { connect } from 'react-redux';
 import { curry } from 'lodash';
 import page from 'page';
@@ -22,7 +20,7 @@ import DocumentHead from 'components/data/document-head';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import titles from 'me/purchases/titles';
-import purchasesPaths from 'me/purchases/paths';
+import { billingHistory } from 'me/purchases/paths';
 
 class AddCreditCard extends Component {
 	static propTypes = {
@@ -35,7 +33,7 @@ class AddCreditCard extends Component {
 	}
 
 	goToBillingHistory() {
-		page( purchasesPaths.billingHistory() );
+		page( billingHistory );
 	}
 
 	recordFormSubmitEvent() {

--- a/client/me/purchases/cancel-privacy-protection/index.jsx
+++ b/client/me/purchases/cancel-privacy-protection/index.jsx
@@ -28,7 +28,7 @@ import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
 import notices from 'notices';
 import Notice from 'components/notice';
-import paths from '../paths';
+import { managePurchase, purchasesRoot } from '../paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
@@ -65,7 +65,7 @@ class CancelPrivacyProtection extends Component {
 
 	redirectIfDataIsInvalid = ( props = this.props ) => {
 		if ( ! this.isDataValid( props ) ) {
-			page.redirect( paths.purchasesRoot() );
+			page.redirect( purchasesRoot );
 		}
 	};
 
@@ -106,7 +106,7 @@ class CancelPrivacyProtection extends Component {
 					{ persistent: true }
 				);
 
-				page( paths.managePurchase( this.props.selectedSite.slug, id ) );
+				page( managePurchase( this.props.selectedSite.slug, id ) );
 			} )
 			.catch( () => {
 				this.resetState();

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -1,15 +1,12 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { moment } from 'i18n-calypso';
+import { localize, moment } from 'i18n-calypso';
 import { get } from 'lodash';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -39,7 +36,7 @@ import {
 } from 'lib/purchases';
 import { isDomainRegistration, isJetpackPlan } from 'lib/products-values';
 import notices from 'notices';
-import paths from 'me/purchases/paths';
+import { confirmCancelDomain, purchasesRoot } from 'me/purchases/paths';
 import { refreshSitePlans } from 'state/sites/plans/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { cancellationEffectDetail, cancellationEffectHeadline } from './cancellation-effect';
@@ -188,7 +185,7 @@ class CancelPurchaseButton extends Component {
 		const { id } = this.props.purchase,
 			{ slug } = this.props.selectedSite;
 
-		page( paths.confirmCancelDomain( slug, id ) );
+		page( confirmCancelDomain( slug, id ) );
 	};
 
 	cancelPurchase = () => {
@@ -219,7 +216,7 @@ class CancelPurchaseButton extends Component {
 					{ persistent: true }
 				);
 
-				page( paths.purchasesRoot() );
+				page( purchasesRoot );
 			} else {
 				notices.error(
 					translate(
@@ -266,7 +263,7 @@ class CancelPurchaseButton extends Component {
 
 		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 
-		page.redirect( paths.purchasesRoot() );
+		page.redirect( purchasesRoot );
 	};
 
 	submitCancelAndRefundPurchase = () => {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -29,16 +27,16 @@ import {
 	getPurchase,
 	getSelectedSite,
 	goToManagePurchase,
+	isDataLoading,
 	recordPageView,
 } from 'me/purchases/utils';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import HeaderCake from 'components/header-cake';
-import { isDataLoading } from 'me/purchases/utils';
 import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
-import paths from '../paths';
+import { managePurchase, purchasesRoot } from '../paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import ProductLink from 'me/purchases/product-link';
 import titles from 'me/purchases/titles';
@@ -89,14 +87,14 @@ class CancelPurchase extends React.Component {
 	redirect = props => {
 		const purchase = getPurchase( props );
 		const selectedSite = getSelectedSite( props );
-		let redirectPath = paths.purchasesRoot();
+		let redirectPath = purchasesRoot;
 
 		if (
 			selectedSite &&
 			purchase &&
 			( ! isCancelable( purchase ) || isDomainTransfer( purchase ) )
 		) {
-			redirectPath = paths.managePurchase( selectedSite.slug, purchase.id );
+			redirectPath = managePurchase( selectedSite.slug, purchase.id );
 		}
 
 		page.redirect( redirectPath );

--- a/client/me/purchases/components/purchase-card-details/index.jsx
+++ b/client/me/purchases/components/purchase-card-details/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 import { Component } from 'react';
 import { curry } from 'lodash';
@@ -14,7 +12,7 @@ import { curry } from 'lodash';
 import analytics from 'lib/analytics';
 import { createCardToken } from 'lib/store-transactions';
 import { getPurchase, goToManagePurchase, isDataLoading } from 'me/purchases/utils';
-import paths from 'me/purchases/paths';
+import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 
 class PurchaseCardDetails extends Component {
 	constructor( props ) {
@@ -31,7 +29,7 @@ class PurchaseCardDetails extends Component {
 		}
 
 		if ( ! this.isDataValid( props ) ) {
-			page( paths.purchasesRoot() );
+			page( purchasesRoot );
 		}
 	}
 
@@ -63,7 +61,7 @@ class PurchaseCardDetails extends Component {
 
 		this.props.clearPurchases();
 
-		page( paths.managePurchase( this.props.selectedSite.slug, id ) );
+		page( managePurchase( this.props.selectedSite.slug, id ) );
 	}
 }
 

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -34,7 +32,7 @@ import { isDomainRegistration } from 'lib/products-values';
 import { isRequestingSites } from 'state/sites/selectors';
 import Main from 'components/main';
 import notices from 'notices';
-import paths from 'me/purchases/paths';
+import { purchasesRoot } from 'me/purchases/paths';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import { receiveDeletedSite } from 'state/sites/actions';
 import { refreshSitePlans } from 'state/sites/plans/actions';
@@ -83,7 +81,7 @@ class ConfirmCancelDomain extends React.Component {
 		const purchase = getPurchase( props );
 
 		if ( ! purchase || ! isDomainRegistration( purchase ) || ! props.selectedSite ) {
-			page.redirect( paths.purchasesRoot() );
+			page.redirect( purchasesRoot );
 		}
 	};
 
@@ -154,7 +152,7 @@ class ConfirmCancelDomain extends React.Component {
 				product_slug: purchase.productSlug,
 			} );
 
-			page.redirect( paths.purchasesRoot() );
+			page.redirect( purchasesRoot );
 		} );
 	};
 

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -19,7 +19,7 @@ import EditCardDetails from './payment/edit-card-details';
 import Main from 'components/main';
 import ManagePurchase from './manage-purchase';
 import NoSitesMessage from 'components/empty-content/no-sites-message';
-import paths from './paths';
+import * as paths from './paths';
 import PurchasesHeader from './purchases-list/header';
 import PurchasesList from './purchases-list';
 import { concatTitle, recordPageView } from 'lib/react-helpers';
@@ -47,7 +47,7 @@ export default {
 	},
 
 	addCreditCard( context, next ) {
-		recordPurchasesPageView( paths.addCreditCard(), 'Add Credit Card' );
+		recordPurchasesPageView( paths.addCreditCard, 'Add Credit Card' );
 
 		context.primary = <AddCreditCard />;
 		next();
@@ -101,7 +101,7 @@ export default {
 	list( context, next ) {
 		setTitle( context );
 
-		recordPurchasesPageView( paths.purchasesRoot() );
+		recordPurchasesPageView( paths.purchasesRoot );
 
 		context.primary = <PurchasesList noticeType={ context.params.noticeType } />;
 		next();

--- a/client/me/purchases/credit-cards/index.jsx
+++ b/client/me/purchases/credit-cards/index.jsx
@@ -49,7 +49,7 @@ class CreditCards extends Component {
 	}
 
 	goToAddCreditCard() {
-		page( addCreditCard() );
+		page( addCreditCard );
 	}
 
 	renderAddCreditCardButton() {

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -116,7 +116,7 @@ export default function() {
 	);
 
 	// redirect legacy urls
-	page( '/purchases', () => page.redirect( paths.purchasesRoot() ) );
+	page( '/purchases', () => page.redirect( paths.purchasesRoot ) );
 	page( '/purchases/:siteName/:purchaseId', ( { params: { siteName, purchaseId } } ) =>
 		page.redirect( paths.managePurchase( siteName, purchaseId ) )
 	);

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -13,13 +13,13 @@ import billingController from 'me/billing-history/controller';
 import meController from 'me/controller';
 import { siteSelection } from 'my-sites/controller';
 import controller from './controller';
-import paths from './paths';
+import * as paths from './paths';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	if ( config.isEnabled( 'manage/payment-methods' ) ) {
 		page(
-			paths.addCreditCard(),
+			paths.addCreditCard,
 			meController.sidebar,
 			controller.addCreditCard,
 			makeLayout,
@@ -27,11 +27,11 @@ export default function() {
 		);
 
 		// redirect legacy urls
-		page( '/payment-methods/add-credit-card', () => page.redirect( paths.addCreditCard() ) );
+		page( '/payment-methods/add-credit-card', () => page.redirect( paths.addCreditCard ) );
 	}
 
 	page(
-		paths.billingHistory(),
+		paths.billingHistory,
 		meController.sidebar,
 		billingController.billingHistory,
 		makeLayout,
@@ -47,7 +47,7 @@ export default function() {
 	);
 
 	page(
-		paths.purchasesRoot(),
+		paths.purchasesRoot,
 		meController.sidebar,
 		controller.noSitesMessage,
 		controller.list,
@@ -141,7 +141,7 @@ export default function() {
 		( { params: { siteName, purchaseId, cardId } } ) =>
 			page.redirect( paths.editCardDetails( siteName, purchaseId, cardId ) )
 	);
-	page( '/me/billing', () => page.redirect( paths.billingHistory() ) );
+	page( '/me/billing', () => page.redirect( paths.billingHistory ) );
 	page( '/me/billing/:receiptId', ( { params: { receiptId } } ) =>
 		page.redirect( paths.billingHistoryReceipt( receiptId ) )
 	);

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -76,7 +76,7 @@ import QueryCanonicalTheme from 'components/data/query-canonical-theme';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import RemovePurchase from '../remove-purchase';
 import VerticalNavItem from 'components/vertical-nav/item';
-import paths from '../paths';
+import { cancelPurchase, cancelPrivacyProtection, purchasesRoot } from '../paths';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
@@ -95,7 +95,7 @@ class ManagePurchase extends Component {
 
 	componentWillMount() {
 		if ( ! this.isDataValid() ) {
-			page.redirect( paths.purchasesRoot() );
+			page.redirect( purchasesRoot );
 			return;
 		}
 
@@ -104,7 +104,7 @@ class ManagePurchase extends Component {
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.isDataValid() && ! this.isDataValid( nextProps ) ) {
-			page.redirect( paths.purchasesRoot() );
+			page.redirect( purchasesRoot );
 			return;
 		}
 
@@ -231,7 +231,7 @@ class ManagePurchase extends Component {
 		}
 
 		let text,
-			link = paths.cancelPurchase( this.props.selectedSite.slug, id );
+			link = cancelPurchase( this.props.selectedSite.slug, id );
 
 		if ( isRefundable( purchase ) ) {
 			if ( isDomainRegistration( purchase ) ) {
@@ -281,7 +281,7 @@ class ManagePurchase extends Component {
 		}
 
 		return (
-			<CompactCard href={ paths.cancelPrivacyProtection( this.props.selectedSite.slug, id ) }>
+			<CompactCard href={ cancelPrivacyProtection( this.props.selectedSite.slug, id ) }>
 				{ translate( 'Cancel Privacy Protection' ) }
 			</CompactCard>
 		);

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -34,7 +34,7 @@ import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchas
 import { isRequestingSites } from 'state/sites/selectors';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import { getUser } from 'state/users/selectors';
-import paths from '../paths';
+import { managePurchase } from '../paths';
 import PaymentLogo from 'components/payment-logo';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import UserItem from 'components/user';
@@ -152,7 +152,7 @@ class PurchaseMeta extends Component {
 		const { translate, moment } = this.props;
 
 		if ( isIncludedWithPlan( purchase ) ) {
-			const attachedPlanUrl = paths.managePurchase(
+			const attachedPlanUrl = managePurchase(
 				this.props.selectedSite.slug,
 				purchase.attachedToPurchaseId
 			);

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -1,53 +1,35 @@
 /** @format */
-function purchasesRoot() {
-	return '/me/purchases';
+
+export const purchasesRoot = '/me/purchases';
+
+export const addCreditCard = purchasesRoot + '/add-credit-card';
+
+export const billingHistory = purchasesRoot + '/billing';
+
+export function billingHistoryReceipt( receiptId = ':receiptId' ) {
+	return billingHistory + `/${ receiptId }`;
 }
 
-function addCreditCard() {
-	return purchasesRoot() + '/add-credit-card';
+export function managePurchase( siteName = ':site', purchaseId = ':purchaseId' ) {
+	return purchasesRoot + `/${ siteName }/${ purchaseId }`;
 }
 
-function billingHistory() {
-	return purchasesRoot() + '/billing';
-}
-
-function billingHistoryReceipt( receiptId = ':receiptId' ) {
-	return billingHistory() + `/${ receiptId }`;
-}
-
-function managePurchase( siteName = ':site', purchaseId = ':purchaseId' ) {
-	return purchasesRoot() + `/${ siteName }/${ purchaseId }`;
-}
-
-function cancelPurchase( siteName, purchaseId ) {
+export function cancelPurchase( siteName, purchaseId ) {
 	return managePurchase( siteName, purchaseId ) + '/cancel';
 }
 
-function confirmCancelDomain( siteName, purchaseId ) {
+export function confirmCancelDomain( siteName, purchaseId ) {
 	return managePurchase( siteName, purchaseId ) + '/confirm-cancel-domain';
 }
 
-function cancelPrivacyProtection( siteName, purchaseId ) {
+export function cancelPrivacyProtection( siteName, purchaseId ) {
 	return managePurchase( siteName, purchaseId ) + '/cancel-privacy-protection';
 }
 
-function addCardDetails( siteName, purchaseId ) {
+export function addCardDetails( siteName, purchaseId ) {
 	return managePurchase( siteName, purchaseId ) + '/payment/add';
 }
 
-function editCardDetails( siteName, purchaseId, cardId = ':cardId' ) {
+export function editCardDetails( siteName, purchaseId, cardId = ':cardId' ) {
 	return managePurchase( siteName, purchaseId ) + `/payment/edit/${ cardId }`;
 }
-
-export default {
-	addCardDetails,
-	addCreditCard,
-	billingHistory,
-	billingHistoryReceipt,
-	cancelPrivacyProtection,
-	cancelPurchase,
-	confirmCancelDomain,
-	editCardDetails,
-	managePurchase,
-	purchasesRoot,
-};

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -33,7 +31,7 @@ import {
 import Notice from 'components/notice';
 import PlanIcon from 'components/plans/plan-icon';
 import Gridicon from 'gridicons';
-import paths from '../paths';
+import { managePurchase } from '../paths';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
 const eventProperties = warning => ( { warning, position: 'purchase-list' } );
@@ -202,7 +200,7 @@ class PurchaseItem extends Component {
 			};
 
 			if ( ! isDisconnectedSite ) {
-				props.href = paths.managePurchase( this.props.slug, this.props.purchase.id );
+				props.href = managePurchase( this.props.slug, this.props.purchase.id );
 			}
 		}
 

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -13,7 +13,7 @@ import i18n from 'i18n-calypso';
  */
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
-import paths from '../../paths.js';
+import { billingHistory, purchasesRoot } from '../../paths.js';
 import SectionNav from 'components/section-nav';
 
 const PurchasesHeader = ( { section } ) => {
@@ -26,11 +26,11 @@ const PurchasesHeader = ( { section } ) => {
 	return (
 		<SectionNav selectedText={ text }>
 			<NavTabs>
-				<NavItem path={ paths.purchasesRoot() } selected={ section === 'purchases' }>
+				<NavItem path={ purchasesRoot } selected={ section === 'purchases' }>
 					{ i18n.translate( 'Purchases' ) }
 				</NavItem>
 
-				<NavItem path={ paths.billingHistory() } selected={ section === 'billing' }>
+				<NavItem path={ billingHistory } selected={ section === 'billing' }>
 					{ i18n.translate( 'Billing History' ) }
 				</NavItem>
 			</NavTabs>

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { connect } from 'react-redux';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -31,7 +29,7 @@ import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/
 import { getPurchase, isDataLoading } from '../utils';
 import { isDomainRegistration, isPlan, isGoogleApps, isJetpackPlan } from 'lib/products-values';
 import notices from 'notices';
-import purchasePaths from '../paths';
+import { purchasesRoot } from '../paths';
 import { getPurchasesError } from 'state/purchases/selectors';
 import { removePurchase } from 'state/purchases/actions';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
@@ -223,7 +221,7 @@ class RemovePurchase extends Component {
 					);
 				}
 
-				page( purchasePaths.purchasesRoot() );
+				page( purchasesRoot );
 			}
 		} );
 	};

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -10,7 +10,13 @@ import page from 'page';
  */
 import analytics from 'lib/analytics';
 import config from 'config';
-import paths from './paths';
+import {
+	addCardDetails,
+	editCardDetails,
+	cancelPurchase,
+	managePurchase,
+	purchasesRoot,
+} from './paths';
 import {
 	isExpired,
 	isIncludedWithPlan,
@@ -32,18 +38,18 @@ function goToCancelPurchase( props ) {
 	const { id } = getPurchase( props ),
 		{ slug } = getSelectedSite( props );
 
-	page( paths.cancelPurchase( slug, id ) );
+	page( cancelPurchase( slug, id ) );
 }
 
 function goToList() {
-	page( paths.purchasesRoot() );
+	page( purchasesRoot );
 }
 
 function goToManagePurchase( props ) {
 	const { id } = getPurchase( props ),
 		{ slug } = getSelectedSite( props );
 
-	page( paths.managePurchase( slug, id ) );
+	page( managePurchase( slug, id ) );
 }
 
 function isDataLoading( props ) {
@@ -92,9 +98,9 @@ function getEditCardDetailsPath( site, purchase ) {
 	if ( isPaidWithCreditCard( purchase ) ) {
 		const { payment: { creditCard } } = purchase;
 
-		return paths.editCardDetails( site.slug, purchase.id, creditCard.id );
+		return editCardDetails( site.slug, purchase.id, creditCard.id );
 	}
-	return paths.addCardDetails( site.slug, purchase.id );
+	return addCardDetails( site.slug, purchase.id );
 }
 
 export {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */
@@ -14,7 +13,7 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import config from 'config';
 import ProfileGravatar from 'me/profile-gravatar';
-import purchasesPaths from 'me/purchases/paths';
+import { addCreditCard, billingHistory, purchasesRoot } from 'me/purchases/paths';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarHeading from 'layout/sidebar/heading';
@@ -92,9 +91,9 @@ class MeSidebar extends React.Component {
 			'/me/notifications/updates': 'notifications',
 			'/me/notifications/subscriptions': 'notifications',
 			'/help/contact': 'help',
-			[ purchasesPaths.purchasesRoot() ]: 'purchases',
-			[ purchasesPaths.billingHistory() ]: 'purchases',
-			[ purchasesPaths.addCreditCard() ]: 'purchases',
+			[ purchasesRoot ]: 'purchases',
+			[ billingHistory ]: 'purchases',
+			[ addCreditCard ]: 'purchases',
 			'/me/chat': 'happychat',
 		};
 		const filteredPath = context.path.replace( /\/\d+$/, '' ); // Remove ID from end of path
@@ -151,7 +150,7 @@ class MeSidebar extends React.Component {
 
 						<SidebarItem
 							selected={ selected === 'purchases' }
-							link={ purchasesPaths.purchasesRoot() }
+							link={ purchasesRoot }
 							label={ translate( 'Manage Purchases' ) }
 							icon="credit-card"
 							onNavigate={ this.onNavigate }

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -34,7 +34,7 @@ import notices from 'notices';
 /* eslint-disable no-restricted-imports */
 import observe from 'lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
-import purchasePaths from 'me/purchases/paths';
+import { managePurchase } from 'me/purchases/paths';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryStoredCards from 'components/data/query-stored-cards';
 import QueryGeo from 'components/data/query-geo';
@@ -289,10 +289,7 @@ const Checkout = createReactClass( {
 		if ( cartItems.hasRenewalItem( cart ) ) {
 			renewalItem = cartItems.getRenewalItems( cart )[ 0 ];
 
-			return purchasePaths.managePurchase(
-				renewalItem.extra.purchaseDomain,
-				renewalItem.extra.purchaseId
-			);
+			return managePurchase( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId );
 		}
 
 		if ( cartItems.hasFreeTrial( cart ) ) {

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -17,7 +17,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import PendingGappsTosNotice from './pending-gapps-tos-notice';
-import purchasesPaths from 'me/purchases/paths';
+import { purchasesRoot } from 'me/purchases/paths';
 import { type as domainTypes, transferStatus } from 'lib/domains/constants';
 import { isSubdomain, hasPendingGoogleAppsUsers } from 'lib/domains';
 import {
@@ -88,7 +88,7 @@ export class DomainWarnings extends React.PureComponent {
 		const link =
 			count === 1
 				? `/checkout/domain_map:${ domain }/renew/${ subscriptionId }/${ selectedSite.slug }`
-				: purchasesPaths.purchasesRoot();
+				: purchasesRoot;
 
 		return (
 			<NoticeAction href={ link } onClick={ onClick }>

--- a/client/my-sites/domains/domain-management/edit/card/subscription-settings/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/subscription-settings/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
@@ -12,7 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
-import purchasesPaths from 'me/purchases/paths';
+import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import { type as domainTypes } from 'lib/domains/constants';
 
 class SubscriptionSettings extends React.Component {
@@ -29,10 +27,10 @@ class SubscriptionSettings extends React.Component {
 			case domainTypes.REGISTERED:
 			case domainTypes.SITE_REDIRECT:
 			case domainTypes.TRANSFER:
-				return purchasesPaths.managePurchase( this.props.siteSlug, this.props.subscriptionId );
+				return managePurchase( this.props.siteSlug, this.props.subscriptionId );
 
 			default:
-				return purchasesPaths.purchasesRoot();
+				return purchasesRoot;
 		}
 	}
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
@@ -33,7 +31,7 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import FAQ from 'components/faq';
 import FAQItem from 'components/faq/faq-item';
 import { isEnabled } from 'config';
-import purchasesPaths from 'me/purchases/paths';
+import { purchasesRoot } from 'me/purchases/paths';
 import { plansLink } from 'lib/plans';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
@@ -323,7 +321,7 @@ class PlansFeaturesMain extends Component {
 						'Yes. We want you to love everything you do at WordPress.com, so we provide a 30-day' +
 							' refund on all of our plans. {{a}}Manage purchases{{/a}}.',
 						{
-							components: { a: <a href={ purchasesPaths.purchasesRoot() } /> },
+							components: { a: <a href={ purchasesRoot } /> },
 						}
 					) }
 				/>

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -29,7 +27,7 @@ import {
 	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_PERSONAL,
 } from 'lib/plans/constants';
-import purchasesPaths from 'me/purchases/paths';
+import { managePurchase } from 'me/purchases/paths';
 
 class CurrentPlanHeader extends Component {
 	static propTypes = {
@@ -85,10 +83,7 @@ class CurrentPlanHeader extends Component {
 								} ) }
 					</span>
 					{ currentPlan.userIsOwner && (
-						<Button
-							compact
-							href={ purchasesPaths.managePurchase( selectedSite.slug, currentPlan.id ) }
-						>
+						<Button compact href={ managePurchase( selectedSite.slug, currentPlan.id ) }>
 							{ hasAutoRenew ? translate( 'Manage Payment' ) : translate( 'Renew Now' ) }
 						</Button>
 					) }

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 import React from 'react';
 
@@ -15,7 +13,7 @@ import config from 'config';
 import DeleteSite from './delete-site';
 import ConfirmDisconnection from './disconnect-site/confirm';
 import DisconnectSite from './disconnect-site';
-import purchasesPaths from 'me/purchases/paths';
+import { billingHistory } from 'me/purchases/paths';
 import SiteSettingsMain from 'my-sites/site-settings/main';
 import StartOver from './start-over';
 import ThemeSetup from './theme-setup';
@@ -152,8 +150,8 @@ const controller = {
 				notifications: '/me/notifications',
 				disbursements: '/me/public-profile',
 				earnings: '/me/public-profile',
-				'billing-history': purchasesPaths.billingHistory(),
-				'billing-history-v2': purchasesPaths.billingHistory(),
+				'billing-history': billingHistory,
+				'billing-history-v2': billingHistory,
 				'connected-apps': '/me/security/connected-applications',
 			};
 		if ( ! context ) {

--- a/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
+++ b/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import i18n from 'i18n-calypso';
@@ -12,14 +10,14 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import Dialog from 'components/dialog';
-import purchasesPaths from 'me/purchases/paths';
+import { purchasesRoot } from 'me/purchases/paths';
 
 const DeleteSiteWarningDialog = ( { isVisible, onClose } ) => (
 	<Dialog
 		isVisible={ isVisible }
 		buttons={ [
 			{ action: 'dismiss', label: i18n.translate( 'Dismiss' ) },
-			<a className="button is-primary" href={ purchasesPaths.purchasesRoot() }>
+			<a className="button is-primary" href={ purchasesRoot }>
 				{ i18n.translate( 'Manage Purchases', { context: 'button label' } ) }
 			</a>,
 		] }

--- a/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
+++ b/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
@@ -17,7 +17,10 @@ const DeleteSiteWarningDialog = ( { isVisible, onClose } ) => (
 		isVisible={ isVisible }
 		buttons={ [
 			{ action: 'dismiss', label: i18n.translate( 'Dismiss' ) },
-			<a className="button is-primary" href={ purchasesRoot }>
+			<a
+				className="button is-primary" // eslint-disable-line wpcalypso/jsx-classname-namespace
+				href={ purchasesRoot }
+			>
 				{ i18n.translate( 'Manage Purchases', { context: 'button label' } ) }
 			</a>,
 		] }

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { translate } from 'i18n-calypso';
 import { truncate, includes } from 'lodash';
 
@@ -55,7 +53,7 @@ import {
 	THEME_DELETE_SUCCESS,
 	THEME_ACTIVATE_FAILURE,
 } from 'state/action-types';
-import purchasesPaths from 'me/purchases/paths';
+import { purchasesRoot } from 'me/purchases/paths';
 import { dispatchSuccess, dispatchError } from './utils';
 
 import {
@@ -258,7 +256,7 @@ const onSiteDeleteFailure = ( dispatch, { error } ) => {
 					id: 'site-delete',
 					showDismiss: false,
 					button: translate( 'Manage Purchases' ),
-					href: purchasesPaths.purchasesRoot(),
+					href: purchasesRoot,
 				}
 			)
 		);


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.