### PR TITLE
esmodules: Update state/jetpack-connect/selectors

### DIFF
--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -12,7 +12,7 @@ import { AUTH_ATTEMPS_TTL } from './constants';
 import { getSiteByUrl } from 'state/sites/selectors';
 import { isStale } from './utils';
 
-const getJetpackSiteByUrl = ( state, url ) => {
+export const getJetpackSiteByUrl = ( state, url ) => {
 	const site = getSiteByUrl( state, url );
 	if ( site && ! site.jetpack ) {
 		return null;
@@ -20,15 +20,15 @@ const getJetpackSiteByUrl = ( state, url ) => {
 	return site;
 };
 
-const getConnectingSite = state => {
+export const getConnectingSite = state => {
 	return get( state, [ 'jetpackConnect', 'jetpackConnectSite' ] );
 };
 
-const getAuthorizationData = state => {
+export const getAuthorizationData = state => {
 	return get( state, [ 'jetpackConnect', 'jetpackConnectAuthorize' ] );
 };
 
-const isRemoteSiteOnSitesList = ( state, remoteUrl ) => {
+export const isRemoteSiteOnSitesList = ( state, remoteUrl ) => {
 	const authorizationData = getAuthorizationData( state );
 
 	if ( ! remoteUrl ) {
@@ -42,16 +42,16 @@ const isRemoteSiteOnSitesList = ( state, remoteUrl ) => {
 	return !! getJetpackSiteByUrl( state, remoteUrl );
 };
 
-const getSSO = state => {
+export const getSSO = state => {
 	return get( state, [ 'jetpackConnect', 'jetpackSSO' ] );
 };
 
-const isRedirectingToWpAdmin = function( state ) {
+export const isRedirectingToWpAdmin = function( state ) {
 	const authorizationData = getAuthorizationData( state );
 	return !! authorizationData.isRedirectingToWpAdmin;
 };
 
-const getAuthAttempts = ( state, slug ) => {
+export const getAuthAttempts = ( state, slug ) => {
 	const attemptsData = get( state, [ 'jetpackConnect', 'jetpackAuthAttempts', slug ] );
 	if ( attemptsData && isStale( attemptsData.timestamp, AUTH_ATTEMPS_TTL ) ) {
 		return 0;
@@ -65,7 +65,7 @@ const getAuthAttempts = ( state, slug ) => {
  * @param  {Object}  state Global state tree
  * @return {boolean}       True if the user is connected otherwise false
  */
-const getUserAlreadyConnected = state => {
+export const getUserAlreadyConnected = state => {
 	return get( getAuthorizationData( state ), 'userAlreadyConnected', false );
 };
 
@@ -78,7 +78,7 @@ const getUserAlreadyConnected = state => {
  * @param  {object}  state Global state tree
  * @return {Boolean}       True if there's an xmlrpc error otherwise false
  */
-const hasXmlrpcError = function( state ) {
+export const hasXmlrpcError = function( state ) {
 	const authorizeData = getAuthorizationData( state );
 
 	return (
@@ -93,24 +93,11 @@ const hasXmlrpcError = function( state ) {
  * @param  {object}  state Global state tree
  * @return {Boolean}       True if there's an xmlrpc error otherwise false
  */
-const hasExpiredSecretError = function( state ) {
+export const hasExpiredSecretError = function( state ) {
 	const authorizeData = getAuthorizationData( state );
 
 	return (
 		!! get( authorizeData, 'authorizationCode', false ) &&
 		includes( get( authorizeData, [ 'authorizeError', 'message' ] ), 'verify_secrets_expired' )
 	);
-};
-
-export default {
-	getConnectingSite,
-	getAuthorizationData,
-	getSSO,
-	isRedirectingToWpAdmin,
-	isRemoteSiteOnSitesList,
-	getJetpackSiteByUrl,
-	hasXmlrpcError,
-	hasExpiredSecretError,
-	getAuthAttempts,
-	getUserAlreadyConnected,
 };


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.