### PR TITLE
esmodules: Update lib/media/utils

### DIFF
--- a/client/blocks/image-editor/image-editor-canvas.jsx
+++ b/client/blocks/image-editor/image-editor-canvas.jsx
@@ -15,7 +15,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import ImageEditorCrop from './image-editor-crop';
-import MediaUtils from 'lib/media/utils';
+import { canvasToBlob } from 'lib/media/utils';
 import {
 	getImageEditorTransform,
 	getImageEditorFileInfo,
@@ -188,7 +188,7 @@ export class ImageEditorCanvas extends Component {
 		const newContext = newCanvas.getContext( '2d' );
 		newContext.putImageData( imageData, 0, 0 );
 
-		MediaUtils.canvasToBlob( newCanvas, callback, mimeType, 1 );
+		canvasToBlob( newCanvas, callback, mimeType, 1 );
 	}
 
 	drawImage() {

--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -21,7 +21,7 @@ import Notice from 'components/notice';
 import ImageEditorCanvas from './image-editor-canvas';
 import ImageEditorToolbar from './image-editor-toolbar';
 import ImageEditorButtons from './image-editor-buttons';
-import MediaUtils from 'lib/media/utils';
+import { getMimeType, url } from 'lib/media/utils';
 import {
 	resetImageEditorState,
 	resetAllImageEditorState,
@@ -112,13 +112,13 @@ class ImageEditor extends React.Component {
 		if ( media ) {
 			src =
 				media.src ||
-				MediaUtils.url( media, {
+				url( media, {
 					photon: site && ! site.is_private,
 				} );
 
 			fileName = media.file || path.basename( src );
 
-			mimeType = MediaUtils.getMimeType( media ) || mimeType;
+			mimeType = getMimeType( media ) || mimeType;
 
 			title = media.title || title;
 		}

--- a/client/blocks/upload-image/index.jsx
+++ b/client/blocks/upload-image/index.jsx
@@ -34,7 +34,7 @@ import ImageEditor from 'blocks/image-editor';
 import DropZone from 'components/drop-zone';
 import MediaActions from 'lib/media/actions';
 import MediaStore from 'lib/media/store';
-import MediaUtils from 'lib/media/utils';
+import { isItemBeingUploaded } from 'lib/media/utils';
 import MediaValidationStore from 'lib/media/validation-store';
 import { ValidationErrors } from 'lib/media/constants';
 import Button from 'components/button';
@@ -184,7 +184,7 @@ class UploadImage extends Component {
 		const { errors } = this.state;
 
 		const uploadedImage = MediaStore.get( siteId, this.uploadingImageTransientId );
-		const isUploadInProgress = uploadedImage && MediaUtils.isItemBeingUploaded( uploadedImage );
+		const isUploadInProgress = uploadedImage && isItemBeingUploaded( uploadedImage );
 
 		if ( isUploadInProgress ) {
 			return;

--- a/client/components/gallery-shortcode/index.jsx
+++ b/client/components/gallery-shortcode/index.jsx
@@ -15,7 +15,7 @@ import { assign, omit, pick } from 'lodash';
  */
 import Shortcode from 'components/shortcode';
 import { parse as parseShortcode } from 'lib/shortcode';
-import MediaUtils from 'lib/media/utils';
+import { generateGalleryShortcode } from 'lib/media/utils';
 import { GalleryDefaultAttrs } from 'lib/media/constants';
 
 /**
@@ -97,7 +97,7 @@ export default class GalleryShortcode extends React.Component {
 			return this.props.children;
 		}
 
-		return MediaUtils.generateGalleryShortcode( this.getAttributes() );
+		return generateGalleryShortcode( this.getAttributes() );
 	};
 
 	render() {

--- a/client/components/tinymce/plugins/media/drop-zone.jsx
+++ b/client/components/tinymce/plugins/media/drop-zone.jsx
@@ -16,7 +16,7 @@ import analytics from 'lib/analytics';
 import PostActions from 'lib/posts/actions';
 import MediaDropZone from 'my-sites/media-library/drop-zone';
 import MediaActions from 'lib/media/actions';
-import MediaUtils from 'lib/media/utils';
+import { getMimePrefix } from 'lib/media/utils';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import MediaValidationStore from 'lib/media/validation-store';
 import markup from 'post-editor/media-modal/markup';
@@ -102,7 +102,7 @@ class TinyMCEDropZone extends React.Component {
 		// inserted directly into the post contents.
 		const selectedItems = MediaLibrarySelectedStore.getAll( site.ID );
 		const isSingleImage =
-			1 === selectedItems.length && 'image' === MediaUtils.getMimePrefix( selectedItems[ 0 ] );
+			1 === selectedItems.length && 'image' === getMimePrefix( selectedItems[ 0 ] );
 
 		if ( isSingleImage && ! MediaValidationStore.hasErrors( site.ID ) ) {
 			// For single image upload, insert into post content, blocking save

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -19,7 +19,7 @@ import PostActions from 'lib/posts/actions';
 import PostEditStore from 'lib/posts/post-edit-store';
 import * as MediaConstants from 'lib/media/constants';
 import MediaActions from 'lib/media/actions';
-import MediaUtils from 'lib/media/utils';
+import { getThumbnailSizeDimensions } from 'lib/media/utils';
 import { deserialize } from 'lib/media-serialization';
 import MediaMarkup from 'post-editor/media-modal/markup';
 import MediaStore from 'lib/media/store';
@@ -607,7 +607,7 @@ function mediaButton( editor ) {
 		// If we are increasing the size, we select the default size that has the closest greater ratio
 		// While decreasing we take the closest lower ratio
 		const sizeRatios = SIZE_ORDER.map( size =>
-			computeRatio( MediaUtils.getThumbnailSizeDimensions( size, selectedSite ), media )
+			computeRatio( getThumbnailSizeDimensions( size, selectedSite ), media )
 		);
 		const sizeIndex = SIZE_ORDER.indexOf( parsed.appearance.size );
 		const displayedRatio =
@@ -665,7 +665,7 @@ function mediaButton( editor ) {
 			// Disable decrease button when it's ratio is smaller than the thumbnail's ratio
 			// Or when the current selected size is the thumbnail size
 			const thumbRatio = computeRatio(
-				MediaUtils.getThumbnailSizeDimensions( SIZE_ORDER[ 0 ], selectedSite ),
+				getThumbnailSizeDimensions( SIZE_ORDER[ 0 ], selectedSite ),
 				media
 			);
 			const isDisabled = currentRatio <= thumbRatio || SIZE_ORDER[ 0 ] === parsed.appearance.size;

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image.jsx
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import MediaUtils from 'lib/media/utils';
+import { url as mediaUrl } from 'lib/media/utils';
 import QueryMedia from 'components/data/query-media';
 import { getMediaItem } from 'state/selectors';
 
@@ -30,7 +30,7 @@ const ProductImage = ( { siteId, imageId, image } ) => {
 		);
 	}
 
-	const url = MediaUtils.url( image, { size: 'medium' } );
+	const url = mediaUrl( image, { size: 'medium' } );
 
 	return (
 		<figure className="editor-simple-payments-modal__figure">

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -15,7 +15,7 @@ import Gridicon from 'gridicons';
  */
 import { deserialize } from 'lib/media-serialization';
 import MediaStore from 'lib/media/store';
-import MediaUtils from 'lib/media/utils';
+import { url as mediaUrl } from 'lib/media/utils';
 import Dialog from 'components/dialog';
 import FormTextInput from 'components/forms/form-text-input';
 import FormCheckbox from 'components/forms/form-checkbox';
@@ -169,7 +169,7 @@ class LinkDialog extends React.Component {
 			if ( this.props.site && parsedImage.media.ID ) {
 				knownImage =
 					MediaStore.get( this.props.site.ID, parsedImage.media.ID ) || parsedImage.media;
-				return MediaUtils.url( knownImage, {
+				return mediaUrl( knownImage, {
 					size: 'full',
 				} );
 			} else if ( parsedImage.media.URL ) {

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -20,7 +20,7 @@ import { errorNotice as errorNoticeAction } from 'state/notices/actions';
 import DropZone from 'components/drop-zone';
 import FilePicker from 'components/file-picker';
 import MediaActions from 'lib/media/actions';
-import MediaUtils from 'lib/media/utils';
+import { filterItemsByMimePrefix, isItemBeingUploaded } from 'lib/media/utils';
 import MediaStore from 'lib/media/store';
 import MediaValidationStore from 'lib/media/validation-store';
 
@@ -136,9 +136,7 @@ class ProductImageUploader extends Component {
 		const { onSelect, onUpload, onFinish } = this.props;
 
 		// DropZone supplies an array, FilePicker supplies a FileList
-		let images = Array.isArray( files )
-			? MediaUtils.filterItemsByMimePrefix( files, 'image' )
-			: [ ...files ];
+		let images = Array.isArray( files ) ? filterItemsByMimePrefix( files, 'image' ) : [ ...files ];
 		if ( ! images ) {
 			return false;
 		}
@@ -162,7 +160,7 @@ class ProductImageUploader extends Component {
 		const handleUpload = () => {
 			const transientId = head( transientIds );
 			const media = MediaStore.get( site.ID, transientId );
-			const isUploadInProgress = media && MediaUtils.isItemBeingUploaded( media );
+			const isUploadInProgress = media && isItemBeingUploaded( media );
 
 			// File has finished uploading or failed.
 			if ( ! isUploadInProgress ) {

--- a/client/lib/media-serialization/detect-format.js
+++ b/client/lib/media-serialization/detect-format.js
@@ -10,7 +10,7 @@ import { includes } from 'lodash';
  * Internal dependencies
  */
 import { Formats, MediaTypes } from './constants';
-import MediaUtils from 'lib/media/utils';
+import { getMimePrefix } from 'lib/media/utils';
 
 /**
  * Module variables
@@ -34,7 +34,7 @@ export default function( node ) {
 		return Formats.OBJECT;
 	}
 
-	if ( MediaUtils.getMimePrefix( node ) ) {
+	if ( getMimePrefix( node ) ) {
 		return Formats.API;
 	}
 

--- a/client/lib/media-serialization/strategies/api.js
+++ b/client/lib/media-serialization/strategies/api.js
@@ -9,7 +9,7 @@ import { assign } from 'lodash';
 /**
  * Internal dependencies
  */
-import MediaUtils from 'lib/media/utils';
+import { getMimePrefix } from 'lib/media/utils';
 import { MediaTypes } from '../constants';
 
 /**
@@ -20,7 +20,7 @@ import { MediaTypes } from '../constants';
  * @return {Object}      Normalized object
  */
 export function deserialize( node ) {
-	let normalized = {
+	const normalized = {
 		media: assign(
 			{
 				transient: false,
@@ -31,7 +31,7 @@ export function deserialize( node ) {
 	};
 
 	// Infer media type
-	switch ( MediaUtils.getMimePrefix( node ) ) {
+	switch ( getMimePrefix( node ) ) {
 		case 'image':
 			normalized.type = MediaTypes.IMAGE;
 			break;

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -13,7 +13,7 @@ const debug = debugFactory( 'calypso:media' );
  */
 import Dispatcher from 'dispatcher';
 import wpcom from 'lib/wp';
-import MediaUtils from './utils';
+import { createTransientMedia } from './utils';
 import PostEditStore from 'lib/posts/post-edit-store';
 import MediaStore from './store';
 import MediaListStore from './list-store';
@@ -40,7 +40,7 @@ MediaActions.setQuery = function( siteId, query ) {
 };
 
 MediaActions.fetch = function( siteId, itemId ) {
-	var fetchKey = [ siteId, itemId ].join();
+	const fetchKey = [ siteId, itemId ].join();
 	if ( MediaActions._fetching[ fetchKey ] ) {
 		return;
 	}
@@ -153,7 +153,7 @@ function uploadFiles( uploader, files, site ) {
 
 		// Generate a fake transient item that can be used immediately, even
 		// before the media has persisted to the server
-		const transientMedia = { date, ...MediaUtils.createTransientMedia( file ) };
+		const transientMedia = { date, ...createTransientMedia( file ) };
 		if ( file.ID ) {
 			transientMedia.ID = file.ID;
 		}
@@ -212,7 +212,7 @@ MediaActions.add = function( site, files ) {
 };
 
 MediaActions.edit = function( siteId, item ) {
-	var newItem = assign( {}, MediaStore.get( siteId, item.ID ), item );
+	const newItem = assign( {}, MediaStore.get( siteId, item.ID ), item );
 
 	Dispatcher.handleViewAction( {
 		type: 'RECEIVE_MEDIA_ITEM',
@@ -243,13 +243,13 @@ MediaActions.update = function( siteId, item, editMediaFile = false ) {
 		// even before the media has persisted to the server
 		updateAction.data = {
 			...newItem,
-			...MediaUtils.createTransientMedia( item.media ),
+			...createTransientMedia( item.media ),
 			ID: mediaId,
 		};
 	} else if ( editMediaFile && item.media_url ) {
 		updateAction.data = {
 			...newItem,
-			...MediaUtils.createTransientMedia( item.media_url ),
+			...createTransientMedia( item.media_url ),
 			ID: mediaId,
 		};
 	}

--- a/client/lib/media/list-store.js
+++ b/client/lib/media/list-store.js
@@ -11,7 +11,7 @@ import { assign, isEqual, map, omit } from 'lodash';
  */
 import Dispatcher from 'dispatcher';
 import MediaStore from './store';
-import { sortItemsByDate } from './utils';
+import { sortItemsByDate as utilSortItemsByDate } from './utils';
 import emitter from 'lib/mixins/emitter';
 
 /**
@@ -26,13 +26,11 @@ const MediaListStore = {
 	SAME_QUERY_IGNORE_PARAMS = Object.freeze( [ 'number', 'page_handle' ] );
 
 function sortItemsByDate( siteId ) {
-	var sortedItems;
-
 	if ( ! ( siteId in MediaListStore._media ) ) {
 		return;
 	}
 
-	sortedItems = sortItemsByDate( MediaListStore.getAll( siteId ) );
+	const sortedItems = utilSortItemsByDate( MediaListStore.getAll( siteId ) );
 	MediaListStore._media[ siteId ] = map( sortedItems, 'ID' );
 }
 
@@ -43,7 +41,7 @@ function ensureMediaForSiteId( siteId ) {
 }
 
 function receiveSingle( siteId, item, itemId ) {
-	var existingIndex;
+	let existingIndex;
 
 	ensureMediaForSiteId( siteId );
 
@@ -63,7 +61,7 @@ function receiveSingle( siteId, item, itemId ) {
 }
 
 function removeSingle( siteId, item ) {
-	var index;
+	let index;
 
 	if ( ! ( siteId in MediaListStore._media ) ) {
 		return;

--- a/client/lib/media/list-store.js
+++ b/client/lib/media/list-store.js
@@ -11,7 +11,7 @@ import { assign, isEqual, map, omit } from 'lodash';
  */
 import Dispatcher from 'dispatcher';
 import MediaStore from './store';
-import MediaUtils from './utils';
+import { sortItemsByDate } from './utils';
 import emitter from 'lib/mixins/emitter';
 
 /**
@@ -32,7 +32,7 @@ function sortItemsByDate( siteId ) {
 		return;
 	}
 
-	sortedItems = MediaUtils.sortItemsByDate( MediaListStore.getAll( siteId ) );
+	sortedItems = sortItemsByDate( MediaListStore.getAll( siteId ) );
 	MediaListStore._media[ siteId ] = map( sortedItems, 'ID' );
 }
 

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -12,7 +12,7 @@ import { map } from 'lodash';
 /**
  * Internal dependencies
  */
-import MediaUtils from '../utils';
+import * as MediaUtils from '../utils';
 
 jest.mock( 'lib/impure-lodash', () => ( {
 	uniqueId: () => 'media-13',

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import url from 'url';
+import urlLib from 'url';
 import path from 'path';
 import photon from 'photon';
 import { includes, omitBy, startsWith, get } from 'lodash';
@@ -31,560 +31,549 @@ const { uniqueId } = impureLodash;
  */
 const REGEXP_VIDEOPRESS_GUID = /^[a-z\d]+$/i;
 
-const MediaUtils = {
-	/**
-	 * Given a media object, returns a URL string to that media. Accepts
-	 * optional options to specify photon usage or a maximum image width.
-	 *
-	 * @param  {Object} media   Media object
-	 * @param  {Object} options Optional options, accepting a `photon` boolean,
-	 *                          `maxWidth` pixel value, or `size`.
-	 * @return {string}         URL to the media
-	 */
-	url: function( media, options ) {
-		if ( ! media ) {
-			return;
-		}
+/**
+ * Given a media object, returns a URL string to that media. Accepts
+ * optional options to specify photon usage or a maximum image width.
+ *
+ * @param  {Object} media   Media object
+ * @param  {Object} options Optional options, accepting a `photon` boolean,
+ *                          `maxWidth` pixel value, or `size`.
+ * @return {string}         URL to the media
+ */
+export function url( media, options ) {
+	if ( ! media ) {
+		return;
+	}
 
-		if ( media.transient ) {
-			return media.URL;
-		}
-
-		// We've found that some media can be corrupt with an unusable URL.
-		// Return early so attempts to parse the URL don't result in an error.
-		if ( ! media.URL ) {
-			return;
-		}
-
-		options = options || {};
-
-		if ( options.photon ) {
-			if ( options.maxWidth ) {
-				return photon( media.URL, { width: options.maxWidth } );
-			}
-
-			return photon( media.URL );
-		}
-
-		if ( media.thumbnails && options.size in media.thumbnails ) {
-			return media.thumbnails[ options.size ];
-		}
-
-		if ( options.maxWidth ) {
-			return resize( media.URL, {
-				w: options.maxWidth,
-			} );
-		}
-
+	if ( media.transient ) {
 		return media.URL;
-	},
+	}
 
-	/**
-	 * Given a media string, File, or object, returns the file extension.
-	 *
-	 * @example
-	 * getFileExtension( 'example.gif' );
-	 * getFileExtension( { URL: 'https://wordpress.com/example.gif' } );
-	 * getFileExtension( new window.File( [''], 'example.gif' ) );
-	 * // All examples return 'gif'
-	 *
-	 * @param  {(string|File|Object)} media Media object or string
-	 * @return {string}                     File extension
-	 */
-	getFileExtension: function( media ) {
-		let extension;
+	// We've found that some media can be corrupt with an unusable URL.
+	// Return early so attempts to parse the URL don't result in an error.
+	if ( ! media.URL ) {
+		return;
+	}
 
-		if ( ! media ) {
-			return;
+	options = options || {};
+
+	if ( options.photon ) {
+		if ( options.maxWidth ) {
+			return photon( media.URL, { width: options.maxWidth } );
 		}
 
-		const isString = 'string' === typeof media;
-		const isFileObject = 'File' in window && media instanceof window.File;
+		return photon( media.URL );
+	}
 
-		if ( isString ) {
-			let filePath;
-			if ( isUri( media ) ) {
-				filePath = url.parse( media ).pathname;
-			} else {
-				filePath = media;
-			}
+	if ( media.thumbnails && options.size in media.thumbnails ) {
+		return media.thumbnails[ options.size ];
+	}
 
-			extension = path.extname( filePath ).slice( 1 );
-		} else if ( isFileObject ) {
-			extension = path.extname( media.name ).slice( 1 );
-		} else if ( media.extension ) {
-			extension = media.extension;
-		} else {
-			const pathname = url.parse( media.URL || media.file || media.guid || '' ).pathname || '';
-			extension = path.extname( pathname ).slice( 1 );
-		}
-
-		return extension;
-	},
-
-	/**
-	 * Given a media string or object, returns the MIME type prefix.
-	 *
-	 * @example
-	 * getMimeType( 'example.gif' );
-	 * getMimeType( { URL: 'https://wordpress.com/example.gif' } );
-	 * getMimeType( { mime_type: 'image/gif' } );
-	 * // All examples return 'image'
-	 *
-	 * @param  {string} media Media object or mime type string
-	 * @return {string}       The MIME type prefix
-	 */
-	getMimePrefix: function( media ) {
-		var mimeType = MediaUtils.getMimeType( media ),
-			mimePrefixMatch;
-
-		if ( ! mimeType ) {
-			return;
-		}
-
-		mimePrefixMatch = mimeType.match( /^([^\/]+)\// );
-
-		if ( mimePrefixMatch ) {
-			return mimePrefixMatch[ 1 ];
-		}
-	},
-
-	/**
-	 * Given a media string, File, or object, returns the MIME type if one can
-	 * be determined.
-	 *
-	 * @example
-	 * getMimeType( 'example.gif' );
-	 * getMimeType( { URL: 'https://wordpress.com/example.gif' } );
-	 * getMimeType( { mime_type: 'image/gif' } );
-	 * // All examples return 'image/gif'
-	 *
-	 * @param  {(string|File|Object)} media Media object or string
-	 * @return {string}                     Mime type of the media, if known
-	 */
-	getMimeType: function( media ) {
-		if ( ! media ) {
-			return;
-		}
-
-		if ( media.mime_type ) {
-			return media.mime_type;
-		} else if ( 'File' in window && media instanceof window.File ) {
-			return media.type;
-		}
-
-		let extension = MediaUtils.getFileExtension( media );
-
-		if ( ! extension ) {
-			return;
-		}
-
-		extension = extension.toLowerCase();
-		if ( MimeTypes.hasOwnProperty( extension ) ) {
-			return MimeTypes[ extension ];
-		}
-	},
-
-	/**
-	 * Given an array of media objects, returns a filtered array composed of
-	 * items from the original array matching the specified mime prefix.
-	 *
-	 * @param  {Array}  items      Array of media objects
-	 * @param  {string} mimePrefix A mime prefix, e.g. "image"
-	 * @return {Array}             Filtered array of matching media objects
-	 */
-	filterItemsByMimePrefix: function( items, mimePrefix ) {
-		return items.filter( function( item ) {
-			return MediaUtils.getMimePrefix( item ) === mimePrefix;
+	if ( options.maxWidth ) {
+		return resize( media.URL, {
+			w: options.maxWidth,
 		} );
-	},
+	}
 
-	/**
-	 * Given an array of media objects, returns a copy sorted by media date.
-	 *
-	 * @param  {Array} items Array of media objects
-	 * @return {Array}       Sorted array of media objects
-	 */
-	sortItemsByDate: function( items ) {
-		var copy = items.slice( 0 );
+	return media.URL;
+}
 
-		copy.sort( function( a, b ) {
-			var dateCompare;
+/**
+ * Given a media string, File, or object, returns the file extension.
+ *
+ * @example
+ * getFileExtension( 'example.gif' );
+ * getFileExtension( { URL: 'https://wordpress.com/example.gif' } );
+ * getFileExtension( new window.File( [''], 'example.gif' ) );
+ * // All examples return 'gif'
+ *
+ * @param  {(string|File|Object)} media Media object or string
+ * @return {string}                     File extension
+ */
+export function getFileExtension( media ) {
+	let extension;
 
-			if ( a.date && b.date ) {
-				dateCompare = Date.parse( b.date ) - Date.parse( a.date );
+	if ( ! media ) {
+		return;
+	}
 
-				// We only return the result of a date comaprison if item dates
-				// are set and the dates are not equal...
-				if ( 0 !== dateCompare ) {
-					return dateCompare;
+	const isString = 'string' === typeof media;
+	const isFileObject = 'File' in window && media instanceof window.File;
+
+	if ( isString ) {
+		let filePath;
+		if ( isUri( media ) ) {
+			filePath = urlLib.parse( media ).pathname;
+		} else {
+			filePath = media;
+		}
+
+		extension = path.extname( filePath ).slice( 1 );
+	} else if ( isFileObject ) {
+		extension = path.extname( media.name ).slice( 1 );
+	} else if ( media.extension ) {
+		extension = media.extension;
+	} else {
+		const pathname = urlLib.parse( media.URL || media.file || media.guid || '' ).pathname || '';
+		extension = path.extname( pathname ).slice( 1 );
+	}
+
+	return extension;
+}
+
+/**
+ * Given a media string or object, returns the MIME type prefix.
+ *
+ * @example
+ * getMimeType( 'example.gif' );
+ * getMimeType( { URL: 'https://wordpress.com/example.gif' } );
+ * getMimeType( { mime_type: 'image/gif' } );
+ * // All examples return 'image'
+ *
+ * @param  {string} media Media object or mime type string
+ * @return {string}       The MIME type prefix
+ */
+export function getMimePrefix( media ) {
+	const mimeType = getMimeType( media );
+
+	if ( ! mimeType ) {
+		return;
+	}
+
+	const mimePrefixMatch = mimeType.match( /^([^\/]+)\// );
+
+	if ( mimePrefixMatch ) {
+		return mimePrefixMatch[ 1 ];
+	}
+}
+
+/**
+ * Given a media string, File, or object, returns the MIME type if one can
+ * be determined.
+ *
+ * @example
+ * getMimeType( 'example.gif' );
+ * getMimeType( { URL: 'https://wordpress.com/example.gif' } );
+ * getMimeType( { mime_type: 'image/gif' } );
+ * // All examples return 'image/gif'
+ *
+ * @param  {(string|File|Object)} media Media object or string
+ * @return {string}                     Mime type of the media, if known
+ */
+export function getMimeType( media ) {
+	if ( ! media ) {
+		return;
+	}
+
+	if ( media.mime_type ) {
+		return media.mime_type;
+	} else if ( 'File' in window && media instanceof window.File ) {
+		return media.type;
+	}
+
+	let extension = getFileExtension( media );
+
+	if ( ! extension ) {
+		return;
+	}
+
+	extension = extension.toLowerCase();
+	if ( MimeTypes.hasOwnProperty( extension ) ) {
+		return MimeTypes[ extension ];
+	}
+}
+
+/**
+ * Given an array of media objects, returns a filtered array composed of
+ * items from the original array matching the specified mime prefix.
+ *
+ * @param  {Array}  items      Array of media objects
+ * @param  {string} mimePrefix A mime prefix, e.g. "image"
+ * @return {Array}             Filtered array of matching media objects
+ */
+export function filterItemsByMimePrefix( items, mimePrefix ) {
+	return items.filter( function( item ) {
+		return getMimePrefix( item ) === mimePrefix;
+	} );
+}
+
+/**
+ * Given an array of media objects, returns a copy sorted by media date.
+ *
+ * @param  {Array} items Array of media objects
+ * @return {Array}       Sorted array of media objects
+ */
+export function sortItemsByDate( items ) {
+	return items.slice( 0 ).sort( function( a, b ) {
+		if ( a.date && b.date ) {
+			const dateCompare = Date.parse( b.date ) - Date.parse( a.date );
+
+			// We only return the result of a date comaprison if item dates
+			// are set and the dates are not equal...
+			if ( 0 !== dateCompare ) {
+				return dateCompare;
+			}
+		}
+
+		// ...otherwise, we return the greater of the two item IDs
+		return b.ID - a.ID;
+	} );
+}
+
+/**
+ * Returns true if the site can be trusted to accurately report its allowed
+ * file types. Returns false otherwise.
+ *
+ * Jetpack currently does not sync the allowed file types
+ * option, so we must assume that all file types are supported.
+ *
+ * @param  {Object}  site Site object
+ * @return {Boolean}      Site allowed file types are accurate
+ */
+export function isSiteAllowedFileTypesToBeTrusted( site ) {
+	return ! site || ! site.jetpack;
+}
+
+/**
+ * Returns an array of supported file extensions for the specified site.
+ *
+ * @param  {Object} site Site object
+ * @return {Array}      Supported file extensions
+ */
+export function getAllowedFileTypesForSite( site ) {
+	if ( ! site ) {
+		return [];
+	}
+
+	return site.options.allowed_file_types;
+}
+
+/**
+ * Returns true if the specified item is a valid file in a Premium plan,
+ * or false otherwise.
+ *
+ * @param  {Object}  item Media object
+ * @param  {Object}  site Site object
+ * @return {Boolean}      Whether the Premium plan supports the item
+ */
+export function isSupportedFileTypeInPremium( item, site ) {
+	if ( ! site || ! item ) {
+		return false;
+	}
+
+	if ( ! isSiteAllowedFileTypesToBeTrusted( site ) ) {
+		return true;
+	}
+
+	return VideoPressFileTypes.some( function( allowed ) {
+		return allowed.toLowerCase() === item.extension.toLowerCase();
+	} );
+}
+
+/**
+ * Returns true if the specified item is a valid file for the given site,
+ * or false otherwise. A file is valid if the sites allowable file types
+ * contains the item's type.
+ *
+ * @param  {Object}  item Media object
+ * @param  {Object}  site Site object
+ * @return {Boolean}      Whether the site supports the item
+ */
+export function isSupportedFileTypeForSite( item, site ) {
+	if ( ! site || ! item ) {
+		return false;
+	}
+
+	if ( ! isSiteAllowedFileTypesToBeTrusted( site ) ) {
+		return true;
+	}
+
+	return getAllowedFileTypesForSite( site ).some( function( allowed ) {
+		return allowed.toLowerCase() === item.extension.toLowerCase();
+	} );
+}
+
+/**
+ * Returns true if the specified item exceeds the maximum upload size for
+ * the given site. Returns null if the bytes are invalid, the max upload
+ * size for the site is unknown or a video is being uploaded for a Jetpack
+ * site with VideoPress enabled. Otherwise, returns true.
+ *
+ * @param  {Object}   item  Media object
+ * @param  {Object}   site  Site object
+ * @return {?Boolean}       Whether the size exceeds the site maximum
+ */
+export function isExceedingSiteMaxUploadSize( item, site ) {
+	const bytes = item.size;
+
+	if ( ! site || ! site.options ) {
+		return null;
+	}
+
+	if ( ! isFinite( bytes ) || ! site.options.max_upload_size ) {
+		return null;
+	}
+
+	if (
+		site.jetpack &&
+		includes( get( site, 'options.active_modules' ), 'videopress' ) &&
+		versionCompare( get( site, 'options.jetpack_version' ), '4.5', '>=' ) &&
+		startsWith( getMimeType( item ), 'video/' )
+	) {
+		return null;
+	}
+
+	return bytes > site.options.max_upload_size;
+}
+
+/**
+ * Returns true if the provided media object is a VideoPress video item.
+ *
+ * @param  {Object}  item Media object
+ * @return {Boolean}      Whether the media is a VideoPress video item
+ */
+export function isVideoPressItem( item ) {
+	if ( ! item || ! item.videopress_guid ) {
+		return false;
+	}
+
+	return REGEXP_VIDEOPRESS_GUID.test( item.videopress_guid );
+}
+
+/**
+ * Returns a human-readable string representing the specified seconds
+ * duration.
+ *
+ * @example
+ * playtime( 7 ); // -> "0:07"
+ *
+ * @param  {number} duration Duration in seconds
+ * @return {string}          Human-readable duration
+ */
+export function playtime( duration ) {
+	if ( isNaN( duration ) ) {
+		return;
+	}
+
+	const hours = Math.floor( duration / 3600 ),
+		minutes = Math.floor( duration / 60 ) % 60,
+		seconds = Math.floor( duration ) % 60;
+
+	let runtime = [ minutes, seconds ]
+		.map( function( value ) {
+			return ( '0' + value ).slice( -2 );
+		} )
+		.join( ':' );
+
+	if ( hours ) {
+		runtime = [ hours, runtime ].join( ':' );
+	}
+
+	runtime = runtime.replace( /^(00:)+/g, '' );
+
+	if ( -1 === runtime.indexOf( ':' ) ) {
+		runtime = '0:' + runtime;
+	}
+
+	return runtime.replace( /^0(\d)(.*)/, '$1$2' );
+}
+
+/**
+ * Returns an object containing width and height dimenions in pixels for
+ * the thumbnail size, optionally for a given site. If the size cannot be
+ * determined or a site is not passed, a fallback default value is used.
+ *
+ * @param  {String} size Thumbnail size
+ * @param  {Object} site Site object
+ * @return {Object}      Width and height dimensions
+ */
+export function getThumbnailSizeDimensions( size, site ) {
+	let width, height;
+
+	if ( site && site.options ) {
+		width = site.options[ 'image_' + size + '_width' ];
+		height = site.options[ 'image_' + size + '_height' ];
+	}
+
+	if ( size in ThumbnailSizeDimensions ) {
+		width = width || ThumbnailSizeDimensions[ size ].width;
+		height = height || ThumbnailSizeDimensions[ size ].height;
+	}
+
+	return { width, height };
+}
+
+/**
+ * Given an array of media items, returns a gallery shortcode using an
+ * optional set of parameters.
+ *
+ * @param  {Object} settings Gallery settings
+ * @return {String}          Gallery shortcode
+ */
+export function generateGalleryShortcode( settings ) {
+	let attrs;
+
+	if ( ! settings.items.length ) {
+		return;
+	}
+
+	// gallery images are passed in as an array of objects
+	// in settings.items but we just need the IDs set to attrs.ids
+	attrs = Object.assign(
+		{
+			ids: settings.items.map( item => item.ID ).join(),
+		},
+		settings
+	);
+
+	delete attrs.items;
+
+	if ( ! includes( GalleryColumnedTypes, attrs.type ) ) {
+		delete attrs.columns;
+	}
+
+	if ( ! includes( GallerySizeableTypes, attrs.type ) ) {
+		delete attrs.size;
+	}
+
+	attrs = omitBy( attrs, function( value, key ) {
+		return GalleryDefaultAttrs[ key ] === value;
+	} );
+
+	// WordPress expects all lowercase
+	if ( attrs.orderBy ) {
+		attrs.orderby = attrs.orderBy;
+		delete attrs.orderBy;
+	}
+
+	return stringify( {
+		tag: 'gallery',
+		type: 'single',
+		attrs: attrs,
+	} );
+}
+
+/**
+ * Returns true if the specified user is capable of deleting the media
+ * item, or false otherwise.
+ *
+ * @param  {Object}  item Media item
+ * @param  {Object}  user User object
+ * @param  {Object}  site Site object
+ * @return {Boolean}      Whether user can delete item
+ */
+export function canUserDeleteItem( item, user, site ) {
+	if ( user.ID === item.author_ID ) {
+		return site.capabilities.delete_posts;
+	}
+
+	return site.capabilities.delete_others_posts;
+}
+
+/**
+ * Wrapper method for the HTML canvas toBlob() function. Polyfills if the
+ * function does not exist
+ *
+ * @param {Object} canvas the canvas element
+ * @param {Function} callback function to process the blob after it is extracted
+ * @param {String} type image type to be extracted
+ * @param {Number} quality extracted image quality
+ */
+export function canvasToBlob( canvas, callback, type, quality ) {
+	if ( ! HTMLCanvasElement.prototype.toBlob ) {
+		Object.defineProperty( HTMLCanvasElement.prototype, 'toBlob', {
+			value: function( polyfillCallback, polyfillType, polyfillQuality ) {
+				const binStr = atob( this.toDataURL( polyfillType, polyfillQuality ).split( ',' )[ 1 ] ),
+					len = binStr.length,
+					arr = new Uint8Array( len );
+
+				for ( let i = 0; i < len; i++ ) {
+					arr[ i ] = binStr.charCodeAt( i );
 				}
-			}
 
-			// ...otherwise, we return the greater of the two item IDs
-			return b.ID - a.ID;
-		} );
-
-		return copy;
-	},
-
-	/**
-	 * Returns true if the site can be trusted to accurately report its allowed
-	 * file types. Returns false otherwise.
-	 *
-	 * Jetpack currently does not sync the allowed file types
-	 * option, so we must assume that all file types are supported.
-	 *
-	 * @param  {Object}  site Site object
-	 * @return {Boolean}      Site allowed file types are accurate
-	 */
-	isSiteAllowedFileTypesToBeTrusted: function( site ) {
-		return ! site || ! site.jetpack;
-	},
-
-	/**
-	 * Returns an array of supported file extensions for the specified site.
-	 *
-	 * @param  {Object} site Site object
-	 * @return {Array}      Supported file extensions
-	 */
-	getAllowedFileTypesForSite: function( site ) {
-		if ( ! site ) {
-			return [];
-		}
-
-		return site.options.allowed_file_types;
-	},
-
-	/**
-	 * Returns true if the specified item is a valid file in a Premium plan,
-	 * or false otherwise.
-	 *
-	 * @param  {Object}  item Media object
-	 * @param  {Object}  site Site object
-	 * @return {Boolean}      Whether the Premium plan supports the item
-	 */
-	isSupportedFileTypeInPremium: function( item, site ) {
-		if ( ! site || ! item ) {
-			return false;
-		}
-
-		if ( ! MediaUtils.isSiteAllowedFileTypesToBeTrusted( site ) ) {
-			return true;
-		}
-
-		return VideoPressFileTypes.some( function( allowed ) {
-			return allowed.toLowerCase() === item.extension.toLowerCase();
-		} );
-	},
-
-	/**
-	 * Returns true if the specified item is a valid file for the given site,
-	 * or false otherwise. A file is valid if the sites allowable file types
-	 * contains the item's type.
-	 *
-	 * @param  {Object}  item Media object
-	 * @param  {Object}  site Site object
-	 * @return {Boolean}      Whether the site supports the item
-	 */
-	isSupportedFileTypeForSite: function( item, site ) {
-		if ( ! site || ! item ) {
-			return false;
-		}
-
-		if ( ! MediaUtils.isSiteAllowedFileTypesToBeTrusted( site ) ) {
-			return true;
-		}
-
-		return MediaUtils.getAllowedFileTypesForSite( site ).some( function( allowed ) {
-			return allowed.toLowerCase() === item.extension.toLowerCase();
-		} );
-	},
-
-	/**
-	 * Returns true if the specified item exceeds the maximum upload size for
-	 * the given site. Returns null if the bytes are invalid, the max upload
-	 * size for the site is unknown or a video is being uploaded for a Jetpack
-	 * site with VideoPress enabled. Otherwise, returns true.
-	 *
-	 * @param  {Object}   item  Media object
-	 * @param  {Object}   site  Site object
-	 * @return {?Boolean}       Whether the size exceeds the site maximum
-	 */
-	isExceedingSiteMaxUploadSize: function( item, site ) {
-		const bytes = item.size;
-
-		if ( ! site || ! site.options ) {
-			return null;
-		}
-
-		if ( ! isFinite( bytes ) || ! site.options.max_upload_size ) {
-			return null;
-		}
-
-		if (
-			site.jetpack &&
-			includes( get( site, 'options.active_modules' ), 'videopress' ) &&
-			versionCompare( get( site, 'options.jetpack_version' ), '4.5', '>=' ) &&
-			startsWith( MediaUtils.getMimeType( item ), 'video/' )
-		) {
-			return null;
-		}
-
-		return bytes > site.options.max_upload_size;
-	},
-
-	/**
-	 * Returns true if the provided media object is a VideoPress video item.
-	 *
-	 * @param  {Object}  item Media object
-	 * @return {Boolean}      Whether the media is a VideoPress video item
-	 */
-	isVideoPressItem: function( item ) {
-		if ( ! item || ! item.videopress_guid ) {
-			return false;
-		}
-
-		return REGEXP_VIDEOPRESS_GUID.test( item.videopress_guid );
-	},
-
-	/**
-	 * Returns a human-readable string representing the specified seconds
-	 * duration.
-	 *
-	 * @example
-	 * MediaUtils.playtime( 7 ); // -> "0:07"
-	 *
-	 * @param  {number} duration Duration in seconds
-	 * @return {string}          Human-readable duration
-	 */
-	playtime: function( duration ) {
-		if ( isNaN( duration ) ) {
-			return;
-		}
-
-		const hours = Math.floor( duration / 3600 ),
-			minutes = Math.floor( duration / 60 ) % 60,
-			seconds = Math.floor( duration ) % 60;
-
-		let playtime = [ minutes, seconds ]
-			.map( function( value ) {
-				return ( '0' + value ).slice( -2 );
-			} )
-			.join( ':' );
-
-		if ( hours ) {
-			playtime = [ hours, playtime ].join( ':' );
-		}
-
-		playtime = playtime.replace( /^(00:)+/g, '' );
-
-		if ( -1 === playtime.indexOf( ':' ) ) {
-			playtime = '0:' + playtime;
-		}
-
-		return playtime.replace( /^0(\d)(.*)/, '$1$2' );
-	},
-
-	/**
-	 * Returns an object containing width and height dimenions in pixels for
-	 * the thumbnail size, optionally for a given site. If the size cannot be
-	 * determined or a site is not passed, a fallback default value is used.
-	 *
-	 * @param  {String} size Thumbnail size
-	 * @param  {Object} site Site object
-	 * @return {Object}      Width and height dimensions
-	 */
-	getThumbnailSizeDimensions: function( size, site ) {
-		var width, height;
-
-		if ( site && site.options ) {
-			width = site.options[ 'image_' + size + '_width' ];
-			height = site.options[ 'image_' + size + '_height' ];
-		}
-
-		if ( size in ThumbnailSizeDimensions ) {
-			width = width || ThumbnailSizeDimensions[ size ].width;
-			height = height || ThumbnailSizeDimensions[ size ].height;
-		}
-
-		return { width, height };
-	},
-
-	/**
-	 * Given an array of media items, returns a gallery shortcode using an
-	 * optional set of parameters.
-	 *
-	 * @param  {Object} settings Gallery settings
-	 * @return {String}          Gallery shortcode
-	 */
-	generateGalleryShortcode: function( settings ) {
-		var attrs;
-
-		if ( ! settings.items.length ) {
-			return;
-		}
-
-		// gallery images are passed in as an array of objects
-		// in settings.items but we just need the IDs set to attrs.ids
-		attrs = Object.assign(
-			{
-				ids: settings.items.map( item => item.ID ).join(),
+				polyfillCallback(
+					new Blob( [ arr ], {
+						type: polyfillType || 'image/png',
+					} )
+				);
 			},
-			settings
-		);
-
-		delete attrs.items;
-
-		if ( ! includes( GalleryColumnedTypes, attrs.type ) ) {
-			delete attrs.columns;
-		}
-
-		if ( ! includes( GallerySizeableTypes, attrs.type ) ) {
-			delete attrs.size;
-		}
-
-		attrs = omitBy( attrs, function( value, key ) {
-			return GalleryDefaultAttrs[ key ] === value;
 		} );
+	}
 
-		// WordPress expects all lowercase
-		if ( attrs.orderBy ) {
-			attrs.orderby = attrs.orderBy;
-			delete attrs.orderBy;
-		}
+	canvas.toBlob( callback, type, quality );
+}
 
-		return stringify( {
-			tag: 'gallery',
-			type: 'single',
-			attrs: attrs,
+/**
+ * Returns true if specified item is currently being uploaded (i.e. is transient).
+ *
+ * @param  {Object}  item Media item
+ * @return {Boolean}      Whether item is being uploaded
+ */
+export function isItemBeingUploaded( item ) {
+	if ( ! item ) {
+		return null;
+	}
+
+	return !! item.transient;
+}
+
+export function isTransientPreviewable( item ) {
+	return !! ( item && item.URL );
+}
+
+/**
+ * Returns an object describing a transient media item which can be used in
+ * optimistic rendering prior to media persistence to server.
+ *
+ * @param  {(String|Object|Blob|File)} file URL or File object
+ * @return {Object}                         Transient media object
+ */
+export function createTransientMedia( file ) {
+	const transientMedia = {
+		transient: true,
+		ID: uniqueId( 'media-' ),
+	};
+
+	if ( 'string' === typeof file ) {
+		// Generate from string
+		Object.assign( transientMedia, {
+			file: file,
+			title: path.basename( file ),
+			extension: getFileExtension( file ),
+			mime_type: getMimeType( file ),
 		} );
-	},
+	} else if ( file.thumbnails ) {
+		// Generate from a file data object
+		Object.assign( transientMedia, {
+			file: file.URL,
+			title: file.name,
+			extension: file.extension,
+			mime_type: file.mime_type,
+			guid: file.URL,
+			URL: file.URL,
+			external: true,
+		} );
+	} else {
+		// Handle the case where a an object has been passed that wraps a
+		// Blob and contains a fileName
+		const fileContents = file.fileContents || file;
+		const fileName = file.fileName || file.name;
 
-	/**
-	 * Returns true if the specified user is capable of deleting the media
-	 * item, or false otherwise.
-	 *
-	 * @param  {Object}  item Media item
-	 * @param  {Object}  user User object
-	 * @param  {Object}  site Site object
-	 * @return {Boolean}      Whether user can delete item
-	 */
-	canUserDeleteItem( item, user, site ) {
-		if ( user.ID === item.author_ID ) {
-			return site.capabilities.delete_posts;
-		}
+		// Generate from window.File object
+		const fileUrl = window.URL.createObjectURL( fileContents );
 
-		return site.capabilities.delete_others_posts;
-	},
+		Object.assign( transientMedia, {
+			URL: fileUrl,
+			guid: fileUrl,
+			file: fileName,
+			title: file.title || path.basename( fileName ),
+			extension: getFileExtension( file.fileName || fileContents ),
+			mime_type: getMimeType( file.fileName || fileContents ),
+			// Size is not an API media property, though can be useful for
+			// validation purposes if known
+			size: fileContents.size,
+		} );
+	}
 
-	/**
-	 * Wrapper method for the HTML canvas toBlob() function. Polyfills if the
-	 * function does not exist
-	 *
-	 * @param {Object} canvas the canvas element
-	 * @param {Function} callback function to process the blob after it is extracted
-	 * @param {String} type image type to be extracted
-	 * @param {Number} quality extracted image quality
-	 */
-	canvasToBlob( canvas, callback, type, quality ) {
-		if ( ! HTMLCanvasElement.prototype.toBlob ) {
-			Object.defineProperty( HTMLCanvasElement.prototype, 'toBlob', {
-				value: function( polyfillCallback, polyfillType, polyfillQuality ) {
-					const binStr = atob( this.toDataURL( polyfillType, polyfillQuality ).split( ',' )[ 1 ] ),
-						len = binStr.length,
-						arr = new Uint8Array( len );
-
-					for ( let i = 0; i < len; i++ ) {
-						arr[ i ] = binStr.charCodeAt( i );
-					}
-
-					polyfillCallback(
-						new Blob( [ arr ], {
-							type: polyfillType || 'image/png',
-						} )
-					);
-				},
-			} );
-		}
-
-		canvas.toBlob( callback, type, quality );
-	},
-
-	/**
-	 * Returns true if specified item is currently being uploaded (i.e. is transient).
-	 *
-	 * @param  {Object}  item Media item
-	 * @return {Boolean}      Whether item is being uploaded
-	 */
-	isItemBeingUploaded( item ) {
-		if ( ! item ) {
-			return null;
-		}
-
-		return !! item.transient;
-	},
-
-	isTransientPreviewable( item ) {
-		return !! ( item && item.URL );
-	},
-
-	/**
-	 * Returns an object describing a transient media item which can be used in
-	 * optimistic rendering prior to media persistence to server.
-	 *
-	 * @param  {(String|Object|Blob|File)} file URL or File object
-	 * @return {Object}                         Transient media object
-	 */
-	createTransientMedia( file ) {
-		const transientMedia = {
-			transient: true,
-			ID: uniqueId( 'media-' ),
-		};
-
-		if ( 'string' === typeof file ) {
-			// Generate from string
-			Object.assign( transientMedia, {
-				file: file,
-				title: path.basename( file ),
-				extension: MediaUtils.getFileExtension( file ),
-				mime_type: MediaUtils.getMimeType( file ),
-			} );
-		} else if ( file.thumbnails ) {
-			// Generate from a file data object
-			Object.assign( transientMedia, {
-				file: file.URL,
-				title: file.name,
-				extension: file.extension,
-				mime_type: file.mime_type,
-				guid: file.URL,
-				URL: file.URL,
-				external: true,
-			} );
-		} else {
-			// Handle the case where a an object has been passed that wraps a
-			// Blob and contains a fileName
-			const fileContents = file.fileContents || file;
-			const fileName = file.fileName || file.name;
-
-			// Generate from window.File object
-			const fileUrl = window.URL.createObjectURL( fileContents );
-
-			Object.assign( transientMedia, {
-				URL: fileUrl,
-				guid: fileUrl,
-				file: fileName,
-				title: file.title || path.basename( fileName ),
-				extension: MediaUtils.getFileExtension( file.fileName || fileContents ),
-				mime_type: MediaUtils.getMimeType( file.fileName || fileContents ),
-				// Size is not an API media property, though can be useful for
-				// validation purposes if known
-				size: fileContents.size,
-			} );
-		}
-
-		return transientMedia;
-	},
-};
-
-export default MediaUtils;
+	return transientMedia;
+}

--- a/client/lib/media/validation-store.js
+++ b/client/lib/media/validation-store.js
@@ -11,7 +11,7 @@ import { isEmpty, mapValues, pickBy, without } from 'lodash';
  */
 import Dispatcher from 'dispatcher';
 import emitter from 'lib/mixins/emitter';
-import MediaUtils from './utils';
+import * as MediaUtils from './utils';
 import { ValidationErrors as MediaValidationErrors } from './constants';
 
 /**

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -17,7 +17,7 @@ import Content from './content';
 import MediaActions from 'lib/media/actions';
 import MediaLibraryDropZone from './drop-zone';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
-import MediaUtils from 'lib/media/utils';
+import { filterItemsByMimePrefix } from 'lib/media/utils';
 import filterToMimePrefix from './filter-to-mime-prefix';
 import FilterBar from './filter-bar';
 import MediaValidationData from 'components/data/media-validation-data';
@@ -103,7 +103,7 @@ class MediaLibrary extends Component {
 		if ( this.props.filter ) {
 			// Ensure that items selected as a consequence of this upload match
 			// the current filter
-			filteredItems = MediaUtils.filterItemsByMimePrefix(
+			filteredItems = filterItemsByMimePrefix(
 				filteredItems,
 				filterToMimePrefix( this.props.filter )
 			);

--- a/client/my-sites/media-library/list-item-image.jsx
+++ b/client/my-sites/media-library/list-item-image.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import MediaUtils from 'lib/media/utils';
+import { url as mediaUrl } from 'lib/media/utils';
 import MediaLibraryListItemFileDetails from './list-item-file-details';
 
 import { MEDIA_IMAGE_PHOTON, MEDIA_IMAGE_THUMBNAIL } from 'lib/media/constants';
@@ -77,7 +77,7 @@ export default class extends React.Component {
 	};
 
 	render() {
-		var url = MediaUtils.url( this.props.media, {
+		const url = mediaUrl( this.props.media, {
 			photon: this.props.thumbnailType === MEDIA_IMAGE_PHOTON,
 			maxWidth: this.props.maxImageWidth,
 			size: this.props.thumbnailType === MEDIA_IMAGE_THUMBNAIL ? 'medium' : false,

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -18,7 +18,7 @@ import ListItemImage from './list-item-image';
 import ListItemVideo from './list-item-video';
 import ListItemAudio from './list-item-audio';
 import ListItemDocument from './list-item-document';
-import MediaUtils from 'lib/media/utils';
+import { getMimePrefix } from 'lib/media/utils';
 import EditorMediaModalGalleryHelp from 'post-editor/media-modal/gallery-help';
 import { MEDIA_IMAGE_PHOTON } from 'lib/media/constants';
 
@@ -67,7 +67,7 @@ export default class extends React.Component {
 			return;
 		}
 
-		switch ( MediaUtils.getMimePrefix( this.props.media ) ) {
+		switch ( getMimePrefix( this.props.media ) ) {
 			case 'image':
 				component = ListItemImage;
 				break;

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -15,7 +15,7 @@ import React from 'react';
  * Internal dependencies
  */
 import MediaActions from 'lib/media/actions';
-import MediaUtils from 'lib/media/utils';
+import { getMimePrefix } from 'lib/media/utils';
 import ListItem from './list-item';
 import ListNoResults from './list-no-results';
 import ListNoContent from './list-no-content';
@@ -179,7 +179,7 @@ export class MediaLibraryList extends React.Component {
 			! this.props.single &&
 			selectedIndex !== -1 &&
 			selectedItems.length === 1 &&
-			'image' === MediaUtils.getMimePrefix( item );
+			'image' === getMimePrefix( item );
 
 		return (
 			<ListItem

--- a/client/my-sites/media-library/upload-button.jsx
+++ b/client/my-sites/media-library/upload-button.jsx
@@ -16,7 +16,7 @@ import page from 'page';
  */
 import analytics from 'lib/analytics';
 import MediaActions from 'lib/media/actions';
-import MediaUtils from 'lib/media/utils';
+import { getAllowedFileTypesForSite, isSiteAllowedFileTypesToBeTrusted } from 'lib/media/utils';
 import { VideoPressFileTypes } from 'lib/media/constants';
 
 export default class extends React.Component {
@@ -61,10 +61,10 @@ export default class extends React.Component {
 	 * @return {string} Supported file extensions, as comma-separated string
 	 */
 	getInputAccept = () => {
-		if ( ! MediaUtils.isSiteAllowedFileTypesToBeTrusted( this.props.site ) ) {
+		if ( ! isSiteAllowedFileTypesToBeTrusted( this.props.site ) ) {
 			return null;
 		}
-		const allowedFileTypesForSite = MediaUtils.getAllowedFileTypesForSite( this.props.site );
+		const allowedFileTypesForSite = getAllowedFileTypesForSite( this.props.site );
 
 		return uniq( allowedFileTypesForSite.concat( VideoPressFileTypes ) )
 			.map( type => `.${ type }` )

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -19,7 +19,7 @@ import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
 import ImageEditor from 'blocks/image-editor';
 import VideoEditor from 'blocks/video-editor';
 import MediaActions from 'lib/media/actions';
-import MediaUtils from 'lib/media/utils';
+import { getMimeType } from 'lib/media/utils';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import accept from 'lib/accept';
@@ -115,7 +115,7 @@ class Media extends Component {
 
 		const { fileName, site, ID, resetAllImageEditorState } = imageEditorProps;
 
-		const mimeType = MediaUtils.getMimeType( fileName );
+		const mimeType = getMimeType( fileName );
 
 		const item = {
 			ID: ID,

--- a/client/post-editor/editor-featured-image/dropzone.jsx
+++ b/client/post-editor/editor-featured-image/dropzone.jsx
@@ -15,7 +15,7 @@ import { localize } from 'i18n-calypso';
 import DropZone from 'components/drop-zone';
 import MediaActions from 'lib/media/actions';
 import MediaStore from 'lib/media/store';
-import MediaUtils from 'lib/media/utils';
+import { filterItemsByMimePrefix, isItemBeingUploaded } from 'lib/media/utils';
 import PostActions from 'lib/posts/actions';
 import FeaturedImageDropZoneIcon from './dropzone-icon';
 
@@ -32,7 +32,7 @@ class FeaturedImageDropZone extends Component {
 		 *
 		 * At the moment we ignore all the other images that were dragged onto the DropZone
 		 */
-		const droppedImage = head( MediaUtils.filterItemsByMimePrefix( files, 'image' ) );
+		const droppedImage = head( filterItemsByMimePrefix( files, 'image' ) );
 
 		if ( ! droppedImage ) {
 			return false;
@@ -43,7 +43,7 @@ class FeaturedImageDropZone extends Component {
 
 		const handleFeaturedImageUpload = () => {
 			const media = MediaStore.get( siteId, transientMediaId );
-			const isUploadInProgress = media && MediaUtils.isItemBeingUploaded( media );
+			const isUploadInProgress = media && isItemBeingUploaded( media );
 			const isFailedUpload = ! media;
 
 			if ( isFailedUpload ) {

--- a/client/post-editor/editor-featured-image/preview.jsx
+++ b/client/post-editor/editor-featured-image/preview.jsx
@@ -12,7 +12,7 @@ import { get, some } from 'lodash';
  * Internal dependencies
  */
 import MediaStore from 'lib/media/store';
-import MediaUtils from 'lib/media/utils';
+import { url } from 'lib/media/utils';
 import Spinner from 'components/spinner';
 import SpinnerLine from 'components/spinner-line';
 import ImagePreloader from 'components/image-preloader';
@@ -77,7 +77,7 @@ class EditorFeaturedImagePreview extends Component {
 			return;
 		}
 
-		return MediaUtils.url( props.image, {
+		return url( props.image, {
 			maxWidth: this.props.maxWidth,
 			size: 'post-thumbnail',
 		} );

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -20,7 +20,7 @@ import { serialize as serializeContactForm } from 'components/tinymce/plugins/co
 import { serialize as serializeSimplePayment } from 'components/tinymce/plugins/simple-payments/shortcode-utils';
 import MediaActions from 'lib/media/actions';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
-import MediaUtils from 'lib/media/utils';
+import { getMimePrefix } from 'lib/media/utils';
 import MediaValidationStore from 'lib/media/validation-store';
 import PostActions from 'lib/posts/actions';
 import { isWithinBreakpoint } from 'lib/viewport';
@@ -470,7 +470,7 @@ export class EditorHtmlToolbar extends Component {
 		// inserted directly into the post contents.
 		const selectedItems = MediaLibrarySelectedStore.getAll( site.ID );
 		const isSingleImage =
-			1 === selectedItems.length && 'image' === MediaUtils.getMimePrefix( selectedItems[ 0 ] );
+			1 === selectedItems.length && 'image' === getMimePrefix( selectedItems[ 0 ] );
 
 		if ( isSingleImage && ! MediaValidationStore.hasErrors( site.ID ) ) {
 			// For single image upload, insert into post content, blocking save

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import MediaUtils from 'lib/media/utils';
+import { getMimePrefix, url } from 'lib/media/utils';
 import MediaActions from 'lib/media/actions';
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import FormTextarea from 'components/forms/form-textarea';
@@ -61,7 +61,7 @@ class EditorMediaModalDetailFields extends Component {
 	};
 
 	isMimePrefix( prefix ) {
-		return MediaUtils.getMimePrefix( this.props.item ) === prefix;
+		return getMimePrefix( this.props.item ) === prefix;
 	}
 
 	persistChange() {
@@ -157,7 +157,7 @@ class EditorMediaModalDetailFields extends Component {
 				</EditorMediaModalFieldset>
 
 				<EditorMediaModalFieldset legend={ translate( 'URL' ) }>
-					<ClipboardButtonInput value={ MediaUtils.url( this.props.item ) } />
+					<ClipboardButtonInput value={ url( this.props.item ) } />
 				</EditorMediaModalFieldset>
 			</div>
 		);

--- a/client/post-editor/media-modal/detail/detail-file-info.jsx
+++ b/client/post-editor/media-modal/detail/detail-file-info.jsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import MediaUtils from 'lib/media/utils';
+import { playtime } from 'lib/media/utils';
 
 class EditorMediaModalDetailFileInfo extends React.Component {
 	static displayName = 'EditorMediaModalDetailFileInfo';
@@ -50,7 +50,7 @@ class EditorMediaModalDetailFileInfo extends React.Component {
 				break;
 
 			case 'length':
-				value = MediaUtils.playtime( this.props.item[ attribute ] );
+				value = playtime( this.props.item[ attribute ] );
 				break;
 
 			default:

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -25,7 +25,7 @@ import EditorMediaModalDetailPreviewDocument from './detail-preview-document';
 import Button from 'components/button';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import versionCompare from 'lib/version-compare';
-import MediaUtils, { isItemBeingUploaded } from 'lib/media/utils';
+import { getMimePrefix, isItemBeingUploaded, isVideoPressItem } from 'lib/media/utils';
 import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteOption, isJetpackModuleActive, isJetpackSite } from 'state/sites/selectors';
@@ -97,7 +97,7 @@ class EditorMediaModalDetailItem extends Component {
 		const { isJetpack, isVideoPressEnabled, isVideoPressModuleActive } = this.props;
 
 		// Not a VideoPress video
-		if ( ! MediaUtils.isVideoPressItem( item ) ) {
+		if ( ! isVideoPressItem( item ) ) {
 			return false;
 		}
 
@@ -125,7 +125,7 @@ class EditorMediaModalDetailItem extends Component {
 			return null;
 		}
 
-		const mimePrefix = MediaUtils.getMimePrefix( item );
+		const mimePrefix = getMimePrefix( item );
 
 		if ( ! includes( [ 'image', 'video' ], mimePrefix ) ) {
 			return null;
@@ -178,7 +178,7 @@ class EditorMediaModalDetailItem extends Component {
 			return null;
 		}
 
-		const mimePrefix = MediaUtils.getMimePrefix( item );
+		const mimePrefix = getMimePrefix( item );
 
 		return 'video' === mimePrefix
 			? this.renderVideoEditorButtons( item, classname )
@@ -259,7 +259,7 @@ class EditorMediaModalDetailItem extends Component {
 			return null;
 		}
 
-		const mimePrefix = MediaUtils.getMimePrefix( item );
+		const mimePrefix = getMimePrefix( item );
 
 		let Item;
 

--- a/client/post-editor/media-modal/detail/detail-preview-audio.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-audio.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import MediaUtils from 'lib/media/utils';
+import { url } from 'lib/media/utils';
 
 export default class extends React.Component {
 	static displayName = 'EditorMediaModalDetailPreviewAudio';
@@ -24,6 +24,6 @@ export default class extends React.Component {
 	render() {
 		const classes = classNames( this.props.className, 'is-audio' );
 
-		return <audio src={ MediaUtils.url( this.props.item ) } controls className={ classes } />;
+		return <audio src={ url( this.props.item ) } controls className={ classes } />;
 	}
 }

--- a/client/post-editor/media-modal/detail/detail-preview-video.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-video.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import MediaUtils from 'lib/media/utils';
+import { isVideoPressItem, url } from 'lib/media/utils';
 import EditorMediaModalDetailItemVideoPress from './detail-preview-videopress';
 
 export default class extends React.Component {
@@ -23,12 +23,12 @@ export default class extends React.Component {
 	};
 
 	render() {
-		if ( MediaUtils.isVideoPressItem( this.props.item ) ) {
+		if ( isVideoPressItem( this.props.item ) ) {
 			return <EditorMediaModalDetailItemVideoPress { ...this.props } />;
 		}
 
 		const classes = classNames( this.props.className, 'is-video' );
 
-		return <video src={ MediaUtils.url( this.props.item ) } controls className={ classes } />;
+		return <video src={ url( this.props.item ) } controls className={ classes } />;
 	}
 }

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -14,7 +14,7 @@ import { noop, partial } from 'lodash';
  * Internal dependencies
  */
 import DetailItem from './detail-item';
-import MediaUtils from 'lib/media/utils';
+import { getMimePrefix, filterItemsByMimePrefix, url } from 'lib/media/utils';
 import HeaderCake from 'components/header-cake';
 import preloadImage from '../preload-image';
 import { ModalViews } from 'state/ui/media-modal/constants';
@@ -45,8 +45,8 @@ class EditorMediaModalDetailBase extends React.Component {
 	}
 
 	preloadImages = () => {
-		MediaUtils.filterItemsByMimePrefix( this.props.items, 'image' ).forEach( function( image ) {
-			var src = MediaUtils.url( image, {
+		filterItemsByMimePrefix( this.props.items, 'image' ).forEach( function( image ) {
+			const src = url( image, {
 				photon: this.props.site && ! this.props.site.is_private,
 			} );
 
@@ -70,7 +70,7 @@ class EditorMediaModalDetailBase extends React.Component {
 		} = this.props;
 
 		const item = items[ selectedIndex ];
-		const mimePrefix = MediaUtils.getMimePrefix( item );
+		const mimePrefix = getMimePrefix( item );
 
 		return (
 			<div className="editor-media-modal-detail">

--- a/client/post-editor/media-modal/gallery/drop-zone.jsx
+++ b/client/post-editor/media-modal/gallery/drop-zone.jsx
@@ -14,7 +14,7 @@ import { isEqual } from 'lodash';
 import MediaLibraryDropZone from 'my-sites/media-library/drop-zone';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import MediaActions from 'lib/media/actions';
-import MediaUtils from 'lib/media/utils';
+import { filterItemsByMimePrefix } from 'lib/media/utils';
 
 export default class extends React.Component {
 	static displayName = 'EditorMediaModalGalleryDropZone';
@@ -35,7 +35,7 @@ export default class extends React.Component {
 		}
 
 		const selectedItems = MediaLibrarySelectedStore.getAll( site.ID );
-		const filteredItems = MediaUtils.filterItemsByMimePrefix( selectedItems, 'image' );
+		const filteredItems = filterItemsByMimePrefix( selectedItems, 'image' );
 
 		if ( ! isEqual( selectedItems, filteredItems ) ) {
 			MediaActions.setLibrarySelectedItems( site.ID, filteredItems );

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -32,7 +32,7 @@ import analytics from 'lib/analytics';
 import { recordEvent, recordStat } from 'lib/posts/stats';
 import MediaModalGallery from './gallery';
 import MediaActions from 'lib/media/actions';
-import MediaUtils from 'lib/media/utils';
+import * as MediaUtils from 'lib/media/utils';
 import Dialog from 'components/dialog';
 import CloseOnEscape from 'components/close-on-escape';
 import accept from 'lib/accept';

--- a/client/post-editor/media-modal/markup.js
+++ b/client/post-editor/media-modal/markup.js
@@ -11,7 +11,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { parse, stringify } from 'lib/shortcode';
-import MediaUtils from 'lib/media/utils';
+import * as MediaUtils from 'lib/media/utils';
 import { deserialize } from 'lib/media-serialization';
 
 /**


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.