### PR TITLE
esmodules: Update components/post-schedule/utils

### DIFF
--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { moment } from 'i18n-calypso';
@@ -23,7 +21,7 @@ import EventsTooltip from 'components/date-picker/events-tooltip';
  */
 import Clock from './clock';
 import Header from './header';
-import utils from './utils';
+import { convertDateToUserLocation, convertDateToGivenOffset } from './utils';
 
 const user = new User();
 const noop = () => {};
@@ -112,7 +110,7 @@ class PostSchedule extends Component {
 	}
 
 	getDateToUserLocation( date ) {
-		return utils.convertDateToUserLocation(
+		return convertDateToUserLocation(
 			date || new Date(),
 			this.props.timezone,
 			this.props.gmtOffset
@@ -134,7 +132,7 @@ class PostSchedule extends Component {
 	}
 
 	updateDate = date => {
-		const convertedDate = utils.convertDateToGivenOffset(
+		const convertedDate = convertDateToGivenOffset(
 			date,
 			this.props.timezone,
 			this.props.gmtOffset

--- a/client/components/post-schedule/utils.js
+++ b/client/components/post-schedule/utils.js
@@ -19,7 +19,7 @@ import { moment } from 'i18n-calypso';
  * @param  {String}  timeFormat Time format.
  * @return {Boolean}            Whether it's a 12-hour time format.
  */
-const is12hr = timeFormat => timeFormat && /[gh]|[aA]$/.test( timeFormat );
+export const is12hr = timeFormat => timeFormat && /[gh]|[aA]$/.test( timeFormat );
 
 /**
  * Check whether is a valid gmtOffset value.
@@ -28,7 +28,7 @@ const is12hr = timeFormat => timeFormat && /[gh]|[aA]$/.test( timeFormat );
  * @param  {*}  gmtOffset - gmt offset
  * @return {Boolean} is it a valid gtm offset?
  */
-const isValidGMTOffset = gmtOffset => 'number' === typeof gmtOffset;
+export const isValidGMTOffset = gmtOffset => 'number' === typeof gmtOffset;
 
 /**
  * Return localized date depending of given timezone or gmtOffset
@@ -39,7 +39,7 @@ const isValidGMTOffset = gmtOffset => 'number' === typeof gmtOffset;
  * @param {Number} gmt - gmt offset in minutes
  * @return {Moment} localized date
  */
-const getLocalizedDate = ( date, tz, gmt ) => {
+export const getLocalizedDate = ( date, tz, gmt ) => {
 	date = moment( date );
 
 	if ( tz ) {
@@ -51,16 +51,16 @@ const getLocalizedDate = ( date, tz, gmt ) => {
 	return date;
 };
 
-const getDateInLocalUTC = date => moment( date.format ? date.format() : date );
+export const getDateInLocalUTC = date => moment( date.format ? date.format() : date );
 
-const getTimeOffset = ( date, tz, gmt ) => {
+export const getTimeOffset = ( date, tz, gmt ) => {
 	const userLocalDate = getDateInLocalUTC( date );
 	const localizedDate = getLocalizedDate( date, tz, gmt );
 
 	return userLocalDate.utcOffset() - localizedDate.utcOffset();
 };
 
-const convertDateToUserLocation = ( date, tz, gmt ) => {
+export const convertDateToUserLocation = ( date, tz, gmt ) => {
 	if ( ! ( tz || isValidGMTOffset( gmt ) ) ) {
 		return moment( date );
 	}
@@ -68,7 +68,7 @@ const convertDateToUserLocation = ( date, tz, gmt ) => {
 	return getDateInLocalUTC( date ).subtract( getTimeOffset( date, tz, gmt ), 'minute' );
 };
 
-const convertDateToGivenOffset = ( date, tz, gmt ) => {
+export const convertDateToGivenOffset = ( date, tz, gmt ) => {
 	date = getLocalizedDate( date, tz, gmt ).add( getTimeOffset( date, tz, gmt ), 'minute' );
 
 	if ( ! tz && isValidGMTOffset( gmt ) ) {
@@ -86,7 +86,7 @@ const convertDateToGivenOffset = ( date, tz, gmt ) => {
  * @param  {Number} minutes - a number of minutes
  * @return {String} `hh:mm` format
  */
-const convertMinutesToHHMM = minutes => {
+export const convertMinutesToHHMM = minutes => {
 	const hours = Math.trunc( minutes / 60 );
 	const sign = minutes > 0 ? '+' : '';
 
@@ -100,7 +100,7 @@ const convertMinutesToHHMM = minutes => {
 	return `${ sign }${ hours }:${ mm }`;
 };
 
-const convertHoursToHHMM = hours => convertMinutesToHHMM( hours * 60 );
+export const convertHoursToHHMM = hours => convertMinutesToHHMM( hours * 60 );
 
 /**
  * Check if the given value is useful to be assigned like hours or minutes.
@@ -110,7 +110,7 @@ const convertHoursToHHMM = hours => convertMinutesToHHMM( hours * 60 );
  * @param {String} value - time value to check
  * @return {Number|Boolean} valid number or `false`
  */
-const parseAndValidateNumber = value => {
+export const parseAndValidateNumber = value => {
 	value = String( value );
 	if ( value !== '0' && value !== '00' && ( value[ 0 ] === '0' || Number( value ) > 99 ) ) {
 		value = Number( value.substr( 1 ) );
@@ -121,17 +121,4 @@ const parseAndValidateNumber = value => {
 	}
 
 	return false;
-};
-
-export default {
-	convertDateToGivenOffset,
-	convertDateToUserLocation,
-	convertHoursToHHMM,
-	convertMinutesToHHMM,
-	getDateInLocalUTC,
-	getLocalizedDate,
-	getTimeOffset,
-	is12hr,
-	isValidGMTOffset,
-	parseAndValidateNumber,
 };


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.