### PR TITLE
esmodules: Update lib/feed-post-store/actions

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -20,7 +20,7 @@ import EmbedContainer from 'components/embed-container';
 import PostExcerpt from 'components/post-excerpt';
 import { setSection } from 'state/ui/actions';
 import smartSetState from 'lib/react-smart-set-state';
-import { fetchPost } from 'lib/feed-post-store/actions';
+import { fetchPost, markSeen } from 'lib/feed-post-store/actions';
 import ReaderFullPostHeader from './header';
 import AuthorCompactProfile from 'blocks/author-compact-profile';
 import LikeButton from 'reader/like-button';
@@ -44,7 +44,6 @@ import { getSiteName } from 'reader/get-helpers';
 import { keyForPost } from 'lib/feed-stream-store/post-key';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 import ReaderPostActions from 'blocks/reader-post-actions';
-import PostStoreActions from 'lib/feed-post-store/actions';
 import { RelatedPostsFromSameSite, RelatedPostsFromOtherSites } from 'components/related-posts-v2';
 import { getStreamUrlFromPost } from 'reader/route';
 import { likePost, unlikePost } from 'lib/like-store/actions';
@@ -237,7 +236,7 @@ export class FullPostView extends React.Component {
 		const { post, site } = this.props;
 
 		if ( post && post._state !== 'pending' && site && site.ID && ! this.hasSentPageView ) {
-			PostStoreActions.markSeen( post, site );
+			markSeen( post, site );
 			this.hasSentPageView = true;
 		}
 

--- a/client/lib/feed-post-store/actions.js
+++ b/client/lib/feed-post-store/actions.js
@@ -47,13 +47,13 @@ const blogPostFetcher = new PostFetcher( {
 		} );
 	},
 	onError: function( error, postKey ) {
-		FeedPostActions.receivePost( error, null, {
+		receivePost( error, null, {
 			blogId: postKey.blogId,
 			postId: postKey.postId,
 		} );
 	},
 	onPostReceived: function( blogId, postId, post ) {
-		FeedPostActions.receivePost( null, post, {
+		receivePost( null, post, {
 			blogId: blogId,
 			postId: postId,
 		} );

--- a/client/lib/feed-post-store/actions.js
+++ b/client/lib/feed-post-store/actions.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { assign, defer } from 'lodash';
 
 // Internal dependencies
@@ -12,9 +10,7 @@ import { action as ACTION } from './constants';
 import PostFetcher from './post-fetcher';
 import wpcom from 'lib/wp';
 
-let feedPostFetcher, blogPostFetcher, FeedPostActions;
-
-feedPostFetcher = new PostFetcher( {
+const feedPostFetcher = new PostFetcher( {
 	makeRequest: function( postKey ) {
 		return wpcom.undocumented().readFeedPost( postKey );
 	},
@@ -26,20 +22,20 @@ feedPostFetcher = new PostFetcher( {
 		} );
 	},
 	onError: function( error, postKey ) {
-		FeedPostActions.receivePost( error, null, {
+		receivePost( error, null, {
 			feedId: postKey.feedId,
 			postId: postKey.postId,
 		} );
 	},
 	onPostReceived: function( feedId, postId, post ) {
-		FeedPostActions.receivePost( null, post, {
+		receivePost( null, post, {
 			feedId: feedId,
 			postId: postId,
 		} );
 	},
 } );
 
-blogPostFetcher = new PostFetcher( {
+const blogPostFetcher = new PostFetcher( {
 	makeRequest: function( postKey ) {
 		return wpcom.undocumented().readSitePost( { site: postKey.blogId, postId: postKey.postId } );
 	},
@@ -64,42 +60,38 @@ blogPostFetcher = new PostFetcher( {
 	},
 } );
 
-FeedPostActions = {
-	fetchPost: function( postKey ) {
-		const fetcher = postKey.blogId ? blogPostFetcher : feedPostFetcher;
-		fetcher.add( postKey );
-	},
+export function fetchPost( postKey ) {
+	const fetcher = postKey.blogId ? blogPostFetcher : feedPostFetcher;
+	fetcher.add( postKey );
+}
 
-	receivePost: function( error, data, postKey ) {
-		const fetcher = postKey.blogId ? blogPostFetcher : feedPostFetcher;
-		if ( data ) {
-			fetcher.remove( postKey );
-		}
+export function receivePost( error, data, postKey ) {
+	const fetcher = postKey.blogId ? blogPostFetcher : feedPostFetcher;
+	if ( data ) {
+		fetcher.remove( postKey );
+	}
 
-		Dispatcher.handleServerAction(
-			assign(
-				{
-					type: ACTION.RECEIVE_FEED_POST,
-					data: data,
-					error: error,
-				},
-				postKey
-			)
-		);
-	},
+	Dispatcher.handleServerAction(
+		assign(
+			{
+				type: ACTION.RECEIVE_FEED_POST,
+				data: data,
+				error: error,
+			},
+			postKey
+		)
+	);
+}
 
-	markSeen: function( post, site, source ) {
-		defer( function() {
-			Dispatcher.handleViewAction( {
-				type: ACTION.MARK_FEED_POST_SEEN,
-				data: {
-					post,
-					site,
-					source,
-				},
-			} );
+export function markSeen( post, site, source ) {
+	defer( function() {
+		Dispatcher.handleViewAction( {
+			type: ACTION.MARK_FEED_POST_SEEN,
+			data: {
+				post,
+				site,
+				source,
+			},
 		} );
-	},
-};
-
-export default FeedPostActions;
+	} );
+}

--- a/client/lib/feed-post-store/constants.js
+++ b/client/lib/feed-post-store/constants.js
@@ -1,5 +1,4 @@
 /** @format */
-
 export const action = {
 	FETCH_FEED_POST: 'FETCH_FEED_POST',
 	RECEIVE_FEED_POST: 'RECEIVE_FEED_POST',

--- a/client/lib/feed-post-store/test/index.js
+++ b/client/lib/feed-post-store/test/index.js
@@ -12,13 +12,12 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { action as FeedStreamActionType } from 'lib/feed-stream-store/constants';
-import { action as FeedPostActionType } from '../constants';
+import { action as FeedPostActionType } from 'lib/feed-post-store/constants';
 
 jest.mock( 'lib/analytics', () => ( {} ) );
 jest.mock( 'lib/post-normalizer', () => require( './mocks/lib/post-normalizer' ) );
 jest.mock( 'lib/wp', () => require( './mocks/lib/wp' ) );
 
-import { action as FeedPostActionType } from 'lib/feed-post-store/constants';
 let Dispatcher, FeedPostStore;
 
 describe( 'feed-post-store', () => {

--- a/client/lib/feed-post-store/test/index.js
+++ b/client/lib/feed-post-store/test/index.js
@@ -18,6 +18,7 @@ jest.mock( 'lib/analytics', () => ( {} ) );
 jest.mock( 'lib/post-normalizer', () => require( './mocks/lib/post-normalizer' ) );
 jest.mock( 'lib/wp', () => require( './mocks/lib/wp' ) );
 
+import { action as FeedPostActionType } from 'lib/feed-post-store/constants';
 let Dispatcher, FeedPostStore;
 
 describe( 'feed-post-store', () => {

--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -1,9 +1,7 @@
+/** @format **/
 /**
  *  External Dependencies
- *
- * @format
  */
-
 import { forEach, get } from 'lodash';
 
 /**
@@ -11,7 +9,7 @@ import { forEach, get } from 'lodash';
  */
 import Dispatcher from 'dispatcher';
 import { action as ActionType } from './constants';
-import FeedPostStoreActions from 'lib/feed-post-store/actions';
+import { receivePost } from 'lib/feed-post-store/actions';
 import feedPostListCache from './feed-stream-cache';
 import wpcom from 'lib/wp';
 import { reduxDispatch } from 'lib/redux-bridge';
@@ -72,26 +70,26 @@ export function receivePage( id, error, data ) {
 		forEach( data.posts, function( post ) {
 			if ( post && get( post, 'meta.data.discover_original_post' ) ) {
 				// Looks like the original post for a Discover post (meta=discover_original_post)
-				FeedPostStoreActions.receivePost( null, post.meta.data.discover_original_post, {
+				receivePost( null, post.meta.data.discover_original_post, {
 					blogId: post.meta.data.discover_original_post.site_ID,
 					postId: post.meta.data.discover_original_post.ID,
 				} );
 			}
 
 			if ( post && get( post, 'meta.data.post' ) ) {
-				FeedPostStoreActions.receivePost( null, post.meta.data.post, {
+				receivePost( null, post.meta.data.post, {
 					feedId: post.feed_ID,
 					postId: post.ID,
 				} );
 			} else if ( post && post.feed_ID && post.feed_item_ID ) {
 				// 1.2 style
-				FeedPostStoreActions.receivePost( null, post, {
+				receivePost( null, post, {
 					feedId: post.feed_ID,
 					postId: post.feed_item_ID,
 				} );
 			} else if ( post && post.site_ID ) {
 				// this looks like a full post object
-				FeedPostStoreActions.receivePost( null, post, {
+				receivePost( null, post, {
 					blogId: post.site_ID,
 					postId: post.ID,
 				} );

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import page from 'page';
 import FeedPostStore from 'lib/feed-post-store';
-import FeedPostStoreActions from 'lib/feed-post-store/actions';
+import { fetchPost } from 'lib/feed-post-store/actions';
 import { getSourceData as getDiscoverSourceData } from 'reader/discover/helper';
 import { recordAction, recordGaEvent, recordTrackForPost } from 'reader/stats';
 import cssSafeUrl from 'lib/css-safe-url';
@@ -24,7 +24,7 @@ class FeedFeatured extends React.PureComponent {
 			const post = FeedPostStore.get( postKey );
 
 			if ( this.shouldFetch( post ) ) {
-				FeedPostStoreActions.fetchPost( postKey );
+				fetchPost( postKey );
 				return { post };
 			}
 
@@ -101,7 +101,7 @@ class FeedFeatured extends React.PureComponent {
 				case 'error':
 					break;
 				default:
-					let style = {
+					const style = {
 						backgroundImage:
 							post.canonical_image && post.canonical_image.uri
 								? 'url(' + cssSafeUrl( post.canonical_image.uri ) + ')'

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -10,7 +10,7 @@ import { defer, omit, includes } from 'lodash';
  * Internal Dependencies
  */
 import PostStore from 'lib/feed-post-store';
-import PostStoreActions from 'lib/feed-post-store/actions';
+import { fetchPost } from 'lib/feed-post-store/actions';
 import PostPlaceholder from './post-placeholder';
 import PostUnavailable from './post-unavailable';
 import ListGap from 'reader/list-gap';
@@ -50,7 +50,7 @@ export default class PostLifecycle extends React.Component {
 
 		const post = PostStore.get( props.postKey );
 		if ( ! post || post._state === 'minimal' ) {
-			defer( () => PostStoreActions.fetchPost( props.postKey ) );
+			defer( () => fetchPost( props.postKey ) );
 		}
 		return post;
 	}

--- a/client/state/ui/reader/card-expansions/actions.js
+++ b/client/state/ui/reader/card-expansions/actions.js
@@ -1,11 +1,9 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
 import { READER_EXPAND_CARD, READER_RESET_CARD_EXPANSIONS } from 'state/action-types';
-import PostStoreActions from 'lib/feed-post-store/actions';
+import { markSeen } from 'lib/feed-post-store/actions';
 import DISPLAY_TYPES from 'state/reader/posts/display-types';
 import * as stats from 'reader/stats';
 
@@ -18,7 +16,7 @@ export const expandCard = ( { postKey, post, site } ) => {
 	stats.recordTrackForPost( 'calypso_reader_article_opened', post );
 
 	// Record page view
-	PostStoreActions.markSeen( post, site );
+	markSeen( post, site );
 	return {
 		type: READER_EXPAND_CARD,
 		payload: { postKey },


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.