### PR TITLE
esmodules: Update lib/domains/whois

### DIFF
--- a/client/lib/domains/whois/constants.js
+++ b/client/lib/domains/whois/constants.js
@@ -1,9 +1,6 @@
 /** @format */
-const whoisType = {
+
+export const whoisType = {
 	REGISTRANT: 'registrant',
 	PRIVACY_SERVICE: 'privacy_service',
-};
-
-export default {
-	whoisType,
 };

--- a/client/lib/domains/whois/utils.js
+++ b/client/lib/domains/whois/utils.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { find } from 'lodash';
 
 /**
@@ -11,15 +9,10 @@ import { find } from 'lodash';
  */
 import { whoisType } from './constants';
 
-function findRegistrantWhois( whoisContacts ) {
+export function findRegistrantWhois( whoisContacts ) {
 	return find( whoisContacts, { type: whoisType.REGISTRANT } );
 }
 
-function findPrivacyServiceWhois( whoisContacts ) {
+export function findPrivacyServiceWhois( whoisContacts ) {
 	return find( whoisContacts, { type: whoisType.PRIVACY_SERVICE } );
 }
-
-export default {
-	findRegistrantWhois,
-	findPrivacyServiceWhois,
-};


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.