### PR TITLE
esmodules: Update lib/domains/google-apps-users

### DIFF
--- a/client/lib/domains/google-apps-users/index.js
+++ b/client/lib/domains/google-apps-users/index.js
@@ -1,31 +1,25 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { compact, flatten, includes, isEmpty, mapValues, property, some, values } from 'lodash';
 import i18n from 'i18n-calypso';
 import emailValidator from 'email-validator';
 
-function filter( { users, fields } ) {
+export function filter( { users, fields } ) {
 	return users.filter( function( user, index ) {
-		var isFirst = index === 0,
-			hasInput = some( Object.keys( fields ), function( name ) {
-				return user[ name ].value;
-			} );
+		const isFirst = index === 0;
+		const hasInput = some( Object.keys( fields ), name => user[ name ].value );
 
 		return isFirst || hasInput;
 	} );
 }
 
-function validate( { users, fields } ) {
-	var errors;
-
+export function validate( { users, fields } ) {
 	users = filter( { users, fields } );
 	users = users.map( function( user ) {
 		return mapValues( user, function( field, key ) {
-			var error = null;
+			let error = null;
 
 			if ( isEmpty( field.value ) ) {
 				error = i18n.translate( 'This field is required.' );
@@ -43,16 +37,12 @@ function validate( { users, fields } ) {
 				}
 			}
 
-			return Object.assign( {}, field, { error: error } );
+			return Object.assign( {}, field, { error } );
 		} );
 	} );
 
-	errors = compact(
-		flatten(
-			users.map( function( user ) {
-				return values( user ).map( property( 'error' ) );
-			} )
-		)
+	const errors = compact(
+		flatten( users.map( user => values( user ).map( property( 'error' ) ) ) )
 	);
 
 	return {
@@ -60,8 +50,3 @@ function validate( { users, fields } ) {
 		users,
 	};
 }
-
-export default {
-	validate,
-	filter,
-};

--- a/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
+++ b/client/my-sites/domains/domain-management/add-google-apps/add-email-addresses-card.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { find, groupBy, isEmpty, map, mapValues } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -26,15 +24,12 @@ import paths from 'my-sites/domains/paths';
 import ValidationErrorList from 'notices/validation-error-list';
 import upgradesActions from 'lib/upgrades/actions';
 import { hasGoogleApps, getGoogleAppsSupportedDomains } from 'lib/domains';
-import googleAppsLibrary from 'lib/domains/google-apps-users';
+import { filter as filterUsers, validate as validateUsers } from 'lib/domains/google-apps-users';
 import DomainsSelect from './domains-select';
 
 /**
  * Internal dependencies
  */
-const validateUsers = googleAppsLibrary.validate,
-	filterUsers = googleAppsLibrary.filter;
-
 import Notice from 'components/notice';
 
 const AddEmailAddressesCard = createReactClass( {
@@ -181,7 +176,7 @@ const AddEmailAddressesCard = createReactClass( {
 
 	handleFieldChange( fieldName, index, event ) {
 		const newValue = event.target.value;
-		let command = { fieldsets: {} };
+		const command = { fieldsets: {} };
 
 		command.fieldsets[ index ] = {};
 		command.fieldsets[ index ][ fieldName ] = { value: { $set: newValue.trim() } };
@@ -273,9 +268,7 @@ const AddEmailAddressesCard = createReactClass( {
 	},
 
 	addProductsAndGoToCheckout() {
-		let googleAppsCartItems;
-
-		googleAppsCartItems = getGoogleAppsCartItems( {
+		const googleAppsCartItems = getGoogleAppsCartItems( {
 			domains: this.props.domains,
 			fieldsets: filterUsers( {
 				users: this.state.fieldsets,


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.