### PR TITLE
esmodules: Update lib/like-store/actions

### DIFF
--- a/client/blocks/like-button/index.jsx
+++ b/client/blocks/like-button/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { omit, noop } from 'lodash';
@@ -12,7 +10,7 @@ import { omit, noop } from 'lodash';
  * Internal dependencies
  */
 import smartSetState from 'lib/react-smart-set-state';
-import LikeActions from 'lib/like-store/actions';
+import { likePost, unlikePost } from 'lib/like-store/actions';
 import LikeButton from './button';
 import LikeStore from 'lib/like-store/like-store';
 
@@ -62,7 +60,9 @@ class LikeButtonContainer extends PureComponent {
 	}
 
 	handleLikeToggle( liked ) {
-		LikeActions[ liked ? 'likePost' : 'unlikePost' ]( this.props.siteId, this.props.postId );
+		const toggler = liked ? likePost : unlikePost;
+		toggler( this.props.siteId, this.props.postId );
+
 		this.props.onLikeToggle( liked );
 	}
 

--- a/client/lib/like-store/actions.js
+++ b/client/lib/like-store/actions.js
@@ -1,13 +1,4 @@
 /** @format */
-
-/**
- * External dependencies
- */
-
-import debugFactory from 'debug';
-
-const debug = debugFactory( 'calypso:like-store:actions' ); //eslint-disable-line no-unused-vars
-
 /**
  * Internal dependencies
  */
@@ -15,7 +6,7 @@ import Dispatcher from 'dispatcher';
 import { key } from './utils';
 import wpcom from 'lib/wp';
 
-var inflight = {};
+const inflight = {};
 
 function requestInflight( requestKey ) {
 	return requestKey in inflight;
@@ -34,106 +25,94 @@ function getQuery() {
 	return { source: 'reader' };
 }
 
-var LikeActions = {
-	/**
-	 * Fetch a post's list of likes
-	 *
-	 *
-	 * Note: the endpoint will currently return a maximum of 90 likes, and there's no pagination
-	 *
-	 *
-	 * @param {int} Site ID
-	 * @param {int} Post ID
-	 */
-	fetchLikes: function( siteId, postId ) {
-		if ( requestInflight( key( siteId, postId ) ) ) {
-			return;
-		}
+/**
+ * Fetch a post's list of likes
+ *
+ *
+ * Note: the endpoint will currently return a maximum of 90 likes, and there's no pagination
+ *
+ *
+ * @param {int} Site ID
+ * @param {int} Post ID
+ */
+export function fetchLikes( siteId, postId ) {
+	if ( requestInflight( key( siteId, postId ) ) ) {
+		return;
+	}
 
-		var requestKey = key( siteId, postId ),
-			callback = requestTracker( requestKey, function( error, data ) {
-				LikeActions.receivePostLikes( error, siteId, postId, data );
-			} );
-
-		wpcom
-			.site( siteId )
-			.post( postId )
-			.likesList( callback );
-	},
-
-	/**
-	 * Like a post as the current user
-	 *
-	 * @param {int} siteId The Site ID
-	 * @param {int} postId The Post ID
-	 */
-	likePost: function( siteId, postId ) {
-		Dispatcher.handleViewAction( {
-			type: 'LIKE_POST',
-			siteId: siteId,
-			postId: postId,
+	var requestKey = key( siteId, postId ),
+		callback = requestTracker( requestKey, function( error, data ) {
+			receivePostLikes( error, siteId, postId, data );
 		} );
 
-		wpcom
-			.site( siteId )
-			.post( postId )
-			.like()
-			.add( getQuery(), function( error, data ) {
-				LikeActions.receiveLikeResponse( error, siteId, postId, data );
-			} );
-	},
+	wpcom
+		.site( siteId )
+		.post( postId )
+		.likesList( callback );
+}
 
-	/**
-	 * Unlike a post as the current user
-	 * @param {int} siteId The Site ID
-	 * @param {int} postId The Post ID
-	 */
-	unlikePost: function( siteId, postId ) {
-		Dispatcher.handleViewAction( {
-			type: 'UNLIKE_POST',
-			siteId: siteId,
-			postId: postId,
+/**
+ * Like a post as the current user
+ *
+ * @param {int} siteId The Site ID
+ * @param {int} postId The Post ID
+ */
+export function likePost( siteId, postId ) {
+	Dispatcher.handleViewAction( {
+		type: 'LIKE_POST',
+		siteId: siteId,
+		postId: postId,
+	} );
+
+	wpcom
+		.site( siteId )
+		.post( postId )
+		.like()
+		.add( getQuery(), function( error, data ) {
+			receiveLikeResponse( error, siteId, postId, data );
 		} );
+}
 
-		wpcom
-			.site( siteId )
-			.post( postId )
-			.like()
-			.del( getQuery(), function( error, data ) {
-				LikeActions.receiveUnlikeResponse( error, siteId, postId, data );
-			} );
-	},
+/**
+ * Unlike a post as the current user
+ * @param {int} siteId The Site ID
+ * @param {int} postId The Post ID
+ */
+export function unlikePost( siteId, postId ) {
+	Dispatcher.handleViewAction( {
+		type: 'UNLIKE_POST',
+		siteId: siteId,
+		postId: postId,
+	} );
+}
 
-	receivePostLikes: function( error, siteId, postId, data ) {
-		Dispatcher.handleServerAction( {
-			type: 'RECEIVE_POST_LIKES',
-			error: error,
-			siteId: siteId,
-			postId: postId,
-			data: data,
-		} );
-	},
+export function receivePostLikes( error, siteId, postId, data ) {
+	Dispatcher.handleServerAction( {
+		type: 'RECEIVE_POST_LIKES',
+		error: error,
+		siteId: siteId,
+		postId: postId,
+		data: data,
+	} );
+}
 
-	receiveLikeResponse: function( error, siteId, postId, data ) {
-		Dispatcher.handleServerAction( {
-			type: 'RECEIVE_LIKE_RESPONSE',
-			error: error,
-			siteId: siteId,
-			postId: postId,
-			data: data,
-		} );
-	},
+export function receiveLikeResponse( error, siteId, postId, data ) {
+	Dispatcher.handleServerAction( {
+		type: 'RECEIVE_LIKE_RESPONSE',
+		error: error,
+		siteId: siteId,
+		postId: postId,
+		data: data,
+	} );
+}
 
-	// @todo Some weirdness with the data received here...seems to be attached to siteId not data.
-	receiveUnlikeResponse: function( error, siteId, postId, data ) {
-		Dispatcher.handleServerAction( {
-			type: 'RECEIVE_UNLIKE_RESPONSE',
-			error: error,
-			siteId: siteId,
-			postId: postId,
-			data: data,
-		} );
-	},
-};
-
-export default LikeActions;
+// @todo Some weirdness with the data received here...seems to be attached to siteId not data.
+export function receiveUnlikeResponse( error, siteId, postId, data ) {
+	Dispatcher.handleServerAction( {
+		type: 'RECEIVE_UNLIKE_RESPONSE',
+		error: error,
+		siteId: siteId,
+		postId: postId,
+		data: data,
+	} );
+}

--- a/client/lib/like-store/actions.js
+++ b/client/lib/like-store/actions.js
@@ -28,22 +28,20 @@ function getQuery() {
 /**
  * Fetch a post's list of likes
  *
- *
  * Note: the endpoint will currently return a maximum of 90 likes, and there's no pagination
  *
- *
- * @param {int} Site ID
- * @param {int} Post ID
+ * @param {int} siteId Site ID
+ * @param {int} postId Post ID
  */
 export function fetchLikes( siteId, postId ) {
 	if ( requestInflight( key( siteId, postId ) ) ) {
 		return;
 	}
 
-	var requestKey = key( siteId, postId ),
-		callback = requestTracker( requestKey, function( error, data ) {
-			receivePostLikes( error, siteId, postId, data );
-		} );
+	const requestKey = key( siteId, postId );
+	const callback = requestTracker( requestKey, function( error, data ) {
+		receivePostLikes( error, siteId, postId, data );
+	} );
 
 	wpcom
 		.site( siteId )
@@ -54,8 +52,8 @@ export function fetchLikes( siteId, postId ) {
 /**
  * Like a post as the current user
  *
- * @param {int} siteId The Site ID
- * @param {int} postId The Post ID
+ * @param {int} siteId Site ID
+ * @param {int} postId Post ID
  */
 export function likePost( siteId, postId ) {
 	Dispatcher.handleViewAction( {

--- a/client/lib/like-store/like-store.js
+++ b/client/lib/like-store/like-store.js
@@ -10,7 +10,7 @@ import { assign, clone, isEqual } from 'lodash';
 import Dispatcher from 'dispatcher';
 import Emitter from 'lib/mixins/emitter';
 import { action as FeedPostStoreActionType } from 'lib/feed-post-store/constants';
-import LikeActions from './actions';
+import { fetchLikes } from 'lib/like-store/actions';
 import { key } from './utils';
 
 var _likesForPost = {},
@@ -42,7 +42,7 @@ LikeStore = {
 			return likes.likes;
 		}
 
-		LikeActions.fetchLikes( siteId, postId );
+		fetchLikes( siteId, postId );
 
 		return null;
 	},
@@ -63,7 +63,7 @@ LikeStore = {
 			return likes.count;
 		}
 
-		LikeActions.fetchLikes( siteId, postId );
+		fetchLikes( siteId, postId );
 
 		return null;
 	},
@@ -84,7 +84,7 @@ LikeStore = {
 			return likes.i_like;
 		}
 
-		LikeActions.fetchLikes( siteId, postId );
+		fetchLikes( siteId, postId );
 
 		return null;
 	},

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -25,7 +25,7 @@ import {
 	shufflePosts,
 } from 'lib/feed-stream-store/actions';
 import LikeStore from 'lib/like-store/like-store';
-import LikeStoreActions from 'lib/like-store/actions';
+import { likePost, unlikePost } from 'lib/like-store/actions';
 import LikeHelper from 'reader/like-helper';
 import ListEnd from 'components/list-end';
 import InfiniteList from 'components/infinite-list';
@@ -283,7 +283,9 @@ class ReaderStream extends React.Component {
 			// unknown... ignore for now
 			return;
 		}
-		LikeStoreActions[ liked ? 'unlikePost' : 'likePost' ]( siteId, postId );
+
+		const toggler = liked ? unlikePost : likePost;
+		toggler( siteId, postId );
 	}
 
 	isPostFullScreen() {


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.