### PR TITLE
PostTypeList: Refactor share panels state

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -24,7 +24,7 @@ import {
 	isMultiSelectEnabled,
 	isPostSelected,
 } from 'state/ui/post-type-list/selectors';
-import { hideSharePanel, togglePostSelection } from 'state/ui/post-type-list/actions';
+import { hideActiveSharePanel, togglePostSelection } from 'state/ui/post-type-list/actions';
 import { bumpStat } from 'state/analytics/actions';
 import ExternalLink from 'components/external-link';
 import FormInputCheckbox from 'components/forms/form-checkbox';
@@ -43,10 +43,6 @@ function preloadEditor() {
 }
 
 class PostItem extends React.Component {
-	hideCurrentSharePanel = () => {
-		this.props.hideSharePanel( this.props.globalId );
-	};
-
 	clickHandler = clickTarget => () => {
 		this.props.bumpStat( 'calypso_post_item_click', clickTarget );
 	};
@@ -122,7 +118,7 @@ class PostItem extends React.Component {
 				post={ post }
 				siteId={ post.site_ID }
 				showClose={ true }
-				onClose={ this.hideCurrentSharePanel }
+				onClose={ this.props.hideActiveSharePanel }
 			/>
 		);
 	}
@@ -216,7 +212,7 @@ PostItem.propTypes = {
 	singleUserQuery: PropTypes.bool,
 	className: PropTypes.string,
 	compact: PropTypes.bool,
-	hideSharePanel: PropTypes.func,
+	hideActiveSharePanel: PropTypes.func,
 	hasExpandedContent: PropTypes.bool,
 };
 
@@ -249,7 +245,7 @@ export default connect(
 	},
 	{
 		bumpStat,
-		hideSharePanel,
+		hideActiveSharePanel,
 		togglePostSelection,
 	}
 )( localize( PostItem ) );

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -159,7 +159,11 @@ class PostItem extends React.Component {
 							{ isAllSitesModeSelected && <PostTypeSiteInfo globalId={ globalId } /> }
 							{ isAuthorVisible && <PostTypePostAuthor globalId={ globalId } /> }
 						</div>
-						<h1 className="post-item__title" onClick={ this.clickHandler( 'title' ) } onMouseOver={ preloadEditor }>
+						<h1
+							className="post-item__title"
+							onClick={ this.clickHandler( 'title' ) }
+							onMouseOver={ preloadEditor }
+						>
 							{ ! externalPostLink && (
 								<a
 									href={ isPlaceholder || multiSelectEnabled ? null : postUrl }

--- a/client/state/ui/post-type-list/actions.js
+++ b/client/state/ui/post-type-list/actions.js
@@ -26,10 +26,9 @@ export function toggleLikesPopover( postGlobalId ) {
 	};
 }
 
-export function hideSharePanel( postGlobalId ) {
+export function hideActiveSharePanel() {
 	return {
 		type: POST_TYPE_LIST_SHARE_PANEL_HIDE,
-		postGlobalId,
 	};
 }
 

--- a/client/state/ui/post-type-list/reducer.js
+++ b/client/state/ui/post-type-list/reducer.js
@@ -20,7 +20,7 @@ import {
 } from 'state/action-types';
 
 const initialState = {
-	activeSharePanels: [],
+	postIdWithActiveSharePanel: null,
 	postIdWithActiveLikesPopover: null,
 	isMultiSelectEnabled: false,
 	selectedPosts: [],
@@ -75,19 +75,19 @@ export const postTypeList = ( state = initialState, action ) => {
 		case POST_TYPE_LIST_SHARE_PANEL_HIDE:
 			return {
 				...state,
-				activeSharePanels: without( state.activeSharePanels, action.postGlobalId ),
+				postIdWithActiveSharePanel: null,
 			};
 
 		case POST_TYPE_LIST_SHARE_PANEL_TOGGLE:
-			if ( state.activeSharePanels.indexOf( action.postGlobalId ) > -1 ) {
+			if ( state.postIdWithActiveSharePanel === action.postGlobalId ) {
 				return {
 					...state,
-					activeSharePanels: without( state.activeSharePanels, action.postGlobalId ),
+					postIdWithActiveSharePanel: null,
 				};
 			}
 			return {
 				...state,
-				activeSharePanels: [ action.postGlobalId ],
+				postIdWithActiveSharePanel: action.postGlobalId,
 			};
 	}
 

--- a/client/state/ui/post-type-list/selectors.js
+++ b/client/state/ui/post-type-list/selectors.js
@@ -8,7 +8,11 @@ export function isLikesPopoverOpen( state, postGlobalId ) {
 }
 
 export function isSharePanelOpen( state, postGlobalId ) {
-	return state.ui.postTypeList.activeSharePanels.indexOf( postGlobalId ) > -1;
+	if ( ! postGlobalId ) {
+		// Avoid returning `true` if an invalid post ID is passed.
+		return false;
+	}
+	return state.ui.postTypeList.postIdWithActiveSharePanel === postGlobalId;
 }
 
 export function isPostSelected( state, postGlobalId ) {

--- a/client/state/ui/post-type-list/test/reducer.js
+++ b/client/state/ui/post-type-list/test/reducer.js
@@ -22,7 +22,7 @@ import {
 describe( 'reducer', () => {
 	test( 'should export expected reducer keys', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
-			'activeSharePanels',
+			'postIdWithActiveSharePanel',
 			'postIdWithActiveLikesPopover',
 			'isMultiSelectEnabled',
 			'selectedPosts',
@@ -33,14 +33,14 @@ describe( 'reducer', () => {
 		test( 'should remove postGlobalId from the state when hiding Share panel', () => {
 			const postGlobalId = 4;
 			const state = postTypeList(
-				{ activeSharePanels: [ postGlobalId ] },
+				{ postIdWithActiveSharePanel: postGlobalId },
 				{
 					type: POST_TYPE_LIST_SHARE_PANEL_HIDE,
 					postGlobalId: postGlobalId,
 				}
 			);
 
-			expect( state.activeSharePanels ).to.be.empty;
+			expect( state.postIdWithActiveSharePanel ).to.be.null;
 		} );
 
 		test( 'should not fail when hiding an already hidden Share panel', () => {
@@ -49,47 +49,47 @@ describe( 'reducer', () => {
 				postGlobalId: 4,
 			} );
 
-			expect( state.activeSharePanels ).to.be.empty;
+			expect( state.postIdWithActiveSharePanel ).to.be.null;
 		} );
 
 		test( 'should hide an already-visible Share panel when toggling', () => {
 			const postGlobalId = 4;
 			const state = postTypeList(
-				{ activeSharePanels: [ postGlobalId ] },
+				{ postIdWithActiveSharePanel: postGlobalId },
 				{
 					type: POST_TYPE_LIST_SHARE_PANEL_TOGGLE,
 					postGlobalId: postGlobalId,
 				}
 			);
 
-			expect( state.activeSharePanels ).to.be.empty;
+			expect( state.postIdWithActiveSharePanel ).to.be.null;
 		} );
 
 		test( 'should show a hidden Share panel when toggling', () => {
 			const postGlobalId = 4;
 			const state = postTypeList(
-				{ activeSharePanels: [] },
+				{ postIdWithActiveLikesPopover: null },
 				{
 					type: POST_TYPE_LIST_SHARE_PANEL_TOGGLE,
 					postGlobalId: postGlobalId,
 				}
 			);
 
-			expect( state.activeSharePanels ).to.eql( [ postGlobalId ] );
+			expect( state.postIdWithActiveSharePanel ).to.eql( postGlobalId );
 		} );
 
 		test( 'should only allow one active Share panel at a time', () => {
 			const existingPostGlobalId = 5;
 			const postGlobalId = 4;
 			const state = postTypeList(
-				{ activeSharePanels: [ existingPostGlobalId ] },
+				{ postIdWithActiveSharePanel: existingPostGlobalId },
 				{
 					type: POST_TYPE_LIST_SHARE_PANEL_TOGGLE,
 					postGlobalId: postGlobalId,
 				}
 			);
 
-			expect( state.activeSharePanels ).to.eql( [ postGlobalId ] );
+			expect( state.postIdWithActiveSharePanel ).to.eql( postGlobalId );
 		} );
 
 		test( 'should remove postGlobalId from the state when hiding likes popover', () => {

--- a/client/state/ui/post-type-list/test/selectors.js
+++ b/client/state/ui/post-type-list/test/selectors.js
@@ -68,13 +68,13 @@ describe( 'isLikesPopoverOpen', () => {
 } );
 
 describe( 'isSharePanelOpen', () => {
-	test( 'should return true if the Share panel is open', () => {
+	test( 'should return true if the Share panel for the given post is open', () => {
 		const postGlobalId = 4;
 		const isOpen = isSharePanelOpen(
 			{
 				ui: {
 					postTypeList: {
-						activeSharePanels: [ postGlobalId ],
+						postIdWithActiveSharePanel: postGlobalId,
 					},
 				},
 			},
@@ -84,13 +84,30 @@ describe( 'isSharePanelOpen', () => {
 		expect( isOpen ).to.be.true;
 	} );
 
-	test( 'should return false if the Share panel is not open', () => {
+	test( 'should return false if no Share panel is open', () => {
 		const postGlobalId = 4;
 		const isOpen = isSharePanelOpen(
 			{
 				ui: {
 					postTypeList: {
-						activeSharePanels: [],
+						postIdWithActiveLikesPopover: null,
+					},
+				},
+			},
+			postGlobalId
+		);
+
+		expect( isOpen ).to.be.false;
+	} );
+
+	test( 'should return false if the Share panel for a different post is open', () => {
+		const postGlobalId = 4;
+		const otherPostGlobalId = 5;
+		const isOpen = isSharePanelOpen(
+			{
+				ui: {
+					postTypeList: {
+						postIdWithActiveSharePanel: otherPostGlobalId,
 					},
 				},
 			},


### PR DESCRIPTION
This PR updates the Redux state responsible for hiding/showing share panels in the posts list.  We only support a single share panel being visible at a time, so the structure of the Redux state should reflect this.

## To test

Verify that the Redux state and related code (action creators, reducer, selectors, tests) for share panels have the same structure as the corresponding code for the likes popover, which works the same way.

Verify that share panels in the posts list still work as expected:

- Can be shown using the ellipsis menu
- Can be hidden using the ellipsis menu
- Can be hidden using the X button
- Only one share panel can be active at a time

Verify that unit tests pass.