### PR TITLE
esmodules: Update lib/signup/utils

### DIFF
--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import {
 	assign,
 	compact,
@@ -36,7 +34,7 @@ import steps from 'signup/config/steps';
 import wpcom from 'lib/wp';
 import userFactory from 'lib/user';
 const user = userFactory();
-import utils from 'signup/utils';
+import { getStepUrl } from 'signup/utils';
 
 /**
  * Constants
@@ -130,7 +128,7 @@ assign( SignupFlowController.prototype, {
 				if ( ! isEmpty( dependenciesNotProvided ) ) {
 					if ( this._flowName !== flows.defaultFlowName ) {
 						// redirect to the default signup flow, hopefully it will be valid
-						page( utils.getStepUrl() );
+						page( getStepUrl() );
 					}
 
 					throw new Error(
@@ -153,12 +151,11 @@ assign( SignupFlowController.prototype, {
 		return every(
 			pick( steps, this._flow.steps ),
 			function( step ) {
-				var dependenciesNotProvided;
 				if ( ! step.providesDependencies ) {
 					return true;
 				}
 
-				dependenciesNotProvided = difference(
+				const dependenciesNotProvided = difference(
 					step.providesDependencies,
 					keys( SignupDependencyStore.get() )
 				);

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import page from 'page';
 import { isEmpty } from 'lodash';
@@ -15,7 +13,15 @@ import config from 'config';
 import { sectionify } from 'lib/route';
 import analytics from 'lib/analytics';
 import SignupComponent from './main';
-import utils from './utils';
+import {
+	getStepUrl,
+	canResumeFlow,
+	getFlowName,
+	getLocale,
+	getStepName,
+	getStepSectionName,
+	getValidPath,
+} from './utils';
 import userModule from 'lib/user';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import store from 'store';
@@ -35,11 +41,11 @@ let initialContext;
 
 export default {
 	redirectWithoutLocaleIfLoggedIn( context, next ) {
-		if ( user.get() && utils.getLocale( context.params ) ) {
-			const flowName = utils.getFlowName( context.params ),
-				stepName = utils.getStepName( context.params ),
-				stepSectionName = utils.getStepSectionName( context.params );
-			let urlWithoutLocale = utils.getStepUrl( flowName, stepName, stepSectionName );
+		if ( user.get() && getLocale( context.params ) ) {
+			const flowName = getFlowName( context.params ),
+				stepName = getStepName( context.params ),
+				stepSectionName = getStepSectionName( context.params );
+			let urlWithoutLocale = getStepUrl( flowName, stepName, stepSectionName );
 
 			if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
 				return page.redirect( urlWithoutLocale );
@@ -69,8 +75,8 @@ export default {
 	},
 
 	redirectToFlow( context, next ) {
-		const flowName = utils.getFlowName( context.params );
-		const localeFromParams = utils.getLocale( context.params );
+		const flowName = getFlowName( context.params );
+		const localeFromParams = getLocale( context.params );
 		const localeFromStore = store.get( 'signup-locale' );
 
 		// if flow can be resumed, use saved locale
@@ -78,13 +84,13 @@ export default {
 			! user.get() &&
 			! localeFromParams &&
 			localeFromStore &&
-			utils.canResumeFlow( flowName, SignupProgressStore.getFromCache() )
+			canResumeFlow( flowName, SignupProgressStore.getFromCache() )
 		) {
 			window.location =
-				utils.getStepUrl(
+				getStepUrl(
 					flowName,
-					utils.getStepName( context.params ),
-					utils.getStepSectionName( context.params ),
+					getStepName( context.params ),
+					getStepSectionName( context.params ),
 					localeFromStore
 				) +
 				( context.querystring ? '?' + context.querystring : '' ) +
@@ -92,10 +98,9 @@ export default {
 			return;
 		}
 
-		if ( context.pathname !== utils.getValidPath( context.params ) ) {
+		if ( context.pathname !== getValidPath( context.params ) ) {
 			return page.redirect(
-				utils.getValidPath( context.params ) +
-					( context.querystring ? '?' + context.querystring : '' )
+				getValidPath( context.params ) + ( context.querystring ? '?' + context.querystring : '' )
 			);
 		}
 
@@ -106,9 +111,9 @@ export default {
 
 	start( context, next ) {
 		const basePath = sectionify( context.path ),
-			flowName = utils.getFlowName( context.params ),
-			stepName = utils.getStepName( context.params ),
-			stepSectionName = utils.getStepSectionName( context.params );
+			flowName = getFlowName( context.params ),
+			stepName = getStepName( context.params ),
+			stepSectionName = getStepSectionName( context.params );
 
 		const { query } = initialContext;
 
@@ -122,7 +127,7 @@ export default {
 		context.primary = React.createElement( SignupComponent, {
 			path: context.path,
 			initialContext,
-			locale: utils.getLocale( context.params ),
+			locale: getLocale( context.params ),
 			flowName: flowName,
 			queryObject: query,
 			refParameter: query && query.ref,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import url from 'url';
 import debugModule from 'debug';
@@ -44,7 +42,7 @@ import WpcomLoginForm from './wpcom-login-form';
 import userModule from 'lib/user';
 import analytics from 'lib/analytics';
 import SignupProcessingScreen from 'signup/processing-screen';
-import utils from './utils';
+import { getDestination, canResumeFlow, getStepUrl } from './utils';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import * as oauthToken from 'lib/oauth-token';
@@ -161,7 +159,7 @@ class Signup extends React.Component {
 				const timeSinceLoading = this.state.loadingScreenStartTime
 					? Date.now() - this.state.loadingScreenStartTime
 					: undefined;
-				const filteredDestination = utils.getDestination(
+				const filteredDestination = getDestination(
 					destination,
 					dependencies,
 					this.props.flowName
@@ -179,7 +177,7 @@ class Signup extends React.Component {
 
 		this.loadProgressFromStore();
 
-		if ( utils.canResumeFlow( this.props.flowName, SignupProgressStore.get() ) ) {
+		if ( canResumeFlow( this.props.flowName, SignupProgressStore.get() ) ) {
 			// we loaded progress from local storage, attempt to resume progress
 			return this.resumeProgress();
 		}
@@ -188,7 +186,7 @@ class Signup extends React.Component {
 			// no progress was resumed and we're on a non-zero step
 			// redirect to the beginning of the flow
 			return page.redirect(
-				utils.getStepUrl(
+				getStepUrl(
 					this.props.flowName,
 					flows.getFlow( this.props.flowName ).steps[ 0 ],
 					this.props.locale
@@ -351,12 +349,7 @@ class Signup extends React.Component {
 		this.setState( { firstUnsubmittedStep } );
 
 		return page.redirect(
-			utils.getStepUrl(
-				this.props.flowName,
-				firstUnsubmittedStep,
-				stepSectionName,
-				this.props.locale
-			)
+			getStepUrl( this.props.flowName, firstUnsubmittedStep, stepSectionName, this.props.locale )
 		);
 	};
 
@@ -384,7 +377,7 @@ class Signup extends React.Component {
 		// redirect the user to the next step
 		scrollPromise.then( () => {
 			if ( ! this.isEveryStepSubmitted() ) {
-				page( utils.getStepUrl( flowName, stepName, stepSectionName, this.props.locale ) );
+				page( getStepUrl( flowName, stepName, stepSectionName, this.props.locale ) );
 			} else if ( this.isEveryStepSubmitted() ) {
 				this.goToFirstInvalidStep();
 			}
@@ -417,7 +410,7 @@ class Signup extends React.Component {
 				return;
 			}
 
-			page( utils.getStepUrl( this.props.flowName, firstInvalidStep.stepName, this.props.locale ) );
+			page( getStepUrl( this.props.flowName, firstInvalidStep.stepName, this.props.locale ) );
 		}
 	};
 

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize, getLocaleSlug } from 'i18n-calypso';
@@ -16,7 +14,7 @@ import Gridicon from 'gridicons';
 import analytics from 'lib/analytics';
 import Button from 'components/button';
 import { submitSignupStep } from 'lib/signup/actions';
-import signupUtils from 'signup/utils';
+import { getStepUrl } from 'signup/utils';
 
 export class NavigationLink extends Component {
 	static propTypes = {
@@ -70,12 +68,7 @@ export class NavigationLink extends Component {
 			''
 		);
 
-		return signupUtils.getStepUrl(
-			this.props.flowName,
-			previousStepName,
-			stepSectionName,
-			getLocaleSlug()
-		);
+		return getStepUrl( this.props.flowName, previousStepName, stepSectionName, getLocaleSlug() );
 	}
 
 	handleClick = () => {

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -12,7 +12,7 @@ import { stub } from 'sinon';
  */
 import { NavigationLink } from '../';
 import EMPTY_COMPONENT from 'components/empty-component';
-import signupUtils from 'signup/utils';
+import { getStepUrl } from 'signup/utils';
 
 jest.mock( 'lib/analytics', () => ( {
 	tracks: {
@@ -50,7 +50,7 @@ describe( 'NavigationLink', () => {
 	} );
 
 	afterEach( () => {
-		signupUtils.getStepUrl.reset();
+		getStepUrl.reset();
 	} );
 
 	test( 'should render Button element', () => {
@@ -87,24 +87,19 @@ describe( 'NavigationLink', () => {
 	} );
 
 	test( 'should set a proper url as href prop when the direction is "back".', () => {
-		expect( signupUtils.getStepUrl ).not.to.be.called;
+		expect( getStepUrl ).not.to.be.called;
 
 		const wrapper = shallow( <NavigationLink { ...props } direction="back" /> );
 
-		// It should call signupUtils.getStepUrl()
-		expect( signupUtils.getStepUrl ).to.has.been.called;
-		expect( signupUtils.getStepUrl ).to.has.been.calledWith(
-			'test:flow',
-			'test:step1',
-			'test:section1',
-			'en'
-		);
+		// It should call getStepUrl()
+		expect( getStepUrl ).to.has.been.called;
+		expect( getStepUrl ).to.has.been.calledWith( 'test:flow', 'test:step1', 'test:section1', 'en' );
 
 		// when it is the first step
-		signupUtils.getStepUrl = stub();
+		getStepUrl = stub();
 		wrapper.setProps( { stepName: 'test:step1' } ); // set the first step
-		expect( signupUtils.getStepUrl ).to.has.been.called;
-		expect( signupUtils.getStepUrl ).to.has.been.calledWith( 'test:flow', null, '', 'en' );
+		expect( getStepUrl ).to.has.been.called;
+		expect( getStepUrl ).to.has.been.calledWith( 'test:flow', null, '', 'en' );
 
 		// The href should be backUrl when exist.
 		wrapper.setProps( { backUrl: 'test:back-url' } );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -18,7 +16,7 @@ import MapDomainStep from 'components/domains/map-domain-step';
 import productsListFactory from 'lib/products-list';
 import RegisterDomainStep from 'components/domains/register-domain-step';
 import SignupActions from 'lib/signup/actions';
-import signupUtils from 'signup/utils';
+import { getStepUrl } from 'signup/utils';
 import StepWrapper from 'signup/step-wrapper';
 import { cartItems } from 'lib/cart-values';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
@@ -58,16 +56,11 @@ class DomainsStep extends React.Component {
 	state = { products: productsList.get() };
 
 	showDomainSearch = () => {
-		page( signupUtils.getStepUrl( this.props.flowName, this.props.stepName, this.props.locale ) );
+		page( getStepUrl( this.props.flowName, this.props.stepName, this.props.locale ) );
 	};
 
 	getMapDomainUrl = () => {
-		return signupUtils.getStepUrl(
-			this.props.flowName,
-			this.props.stepName,
-			'mapping',
-			this.props.locale
-		);
+		return getStepUrl( this.props.flowName, this.props.stepName, 'mapping', this.props.locale );
 	};
 
 	componentDidMount() {
@@ -251,12 +244,7 @@ class DomainsStep extends React.Component {
 		let content;
 		const { translate } = this.props;
 		const backUrl = this.props.stepSectionName
-			? signupUtils.getStepUrl(
-					this.props.flowName,
-					this.props.stepName,
-					undefined,
-					getLocaleSlug()
-				)
+			? getStepUrl( this.props.flowName, this.props.stepName, undefined, getLocaleSlug() )
 			: undefined;
 
 		if ( 'mapping' === this.props.stepSectionName ) {

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
@@ -20,7 +18,7 @@ import SignupActions from 'lib/signup/actions';
 import analytics from 'lib/analytics';
 import verticals from './verticals';
 import Button from 'components/button';
-import signupUtils from 'signup/utils';
+import { getStepUrl } from 'signup/utils';
 import FormTextInputWithAction from 'components/forms/form-text-input-with-action';
 import { setSurvey } from 'state/signup/steps/survey/actions';
 
@@ -112,12 +110,7 @@ class SurveyStep extends React.Component {
 		);
 
 		const backUrl = this.props.stepSectionName
-			? signupUtils.getStepUrl(
-					this.props.flowName,
-					this.props.stepName,
-					undefined,
-					this.props.locale
-				)
+			? getStepUrl( this.props.flowName, this.props.stepName, undefined, this.props.locale )
 			: undefined;
 
 		return (
@@ -145,9 +138,7 @@ class SurveyStep extends React.Component {
 	};
 
 	handleOther = () => {
-		page(
-			signupUtils.getStepUrl( this.props.flowName, this.props.stepName, 'other', this.props.locale )
-		);
+		page( getStepUrl( this.props.flowName, this.props.stepName, 'other', this.props.locale ) );
 	};
 
 	handleVerticalOther = otherTextValue => {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -16,7 +14,7 @@ import { identity, isEmpty, omit } from 'lodash';
 import { isWooOAuth2Client } from 'lib/oauth2-clients';
 import StepWrapper from 'signup/step-wrapper';
 import SignupForm from 'components/signup-form';
-import signupUtils from 'signup/utils';
+import { getFlowSteps, getNextStepName, getPreviousStepName, getStepUrl } from 'signup/utils';
 import SignupActions from 'lib/signup/actions';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import { getSuggestedUsername } from 'state/signup/optional-dependencies/selectors';
@@ -110,7 +108,7 @@ export class UserStep extends Component {
 					}
 				);
 			}
-		} else if ( 1 === signupUtils.getFlowSteps( flowName ).length ) {
+		} else if ( 1 === getFlowSteps( flowName ).length ) {
 			// Displays specific sub header if users only want to create an account, without a site
 			subHeaderText = translate( 'Welcome to the wonderful WordPress.com community' );
 		}
@@ -215,9 +213,9 @@ export class UserStep extends Component {
 		}
 
 		const stepAfterRedirect =
-			signupUtils.getNextStepName( this.props.flowName, this.props.stepName ) ||
-			signupUtils.getPreviousStepName( this.props.flowName, this.props.stepName );
-		return this.originUrl() + signupUtils.getStepUrl( this.props.flowName, stepAfterRedirect );
+			getNextStepName( this.props.flowName, this.props.stepName ) ||
+			getPreviousStepName( this.props.flowName, this.props.stepName );
+		return this.originUrl() + getStepUrl( this.props.flowName, stepAfterRedirect );
 	}
 
 	originUrl() {

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -2,7 +2,6 @@
  * @format
  * @jest-environment jsdom
  */
-
 /**
  * External dependencies
  */
@@ -13,7 +12,14 @@ import sinon from 'sinon';
 /**
  * Internal dependencies
  */
-import utils from '../utils';
+import {
+	getValueFromProgressStore,
+	getValidPath,
+	getStepName,
+	getLocale,
+	getFlowName,
+	mergeFormWithValue,
+} from '../utils';
 import mockedFlows from './fixtures/flows';
 import flows from 'signup/config/flows';
 
@@ -42,14 +48,14 @@ describe( 'utils', () => {
 
 	describe( 'getLocale', () => {
 		test( 'should find the locale anywhere in the params', () => {
-			assert.equal( utils.getLocale( { lang: 'fr' } ), 'fr' );
-			assert.equal( utils.getLocale( { stepName: 'fr' } ), 'fr' );
-			assert.equal( utils.getLocale( { flowName: 'fr' } ), 'fr' );
+			assert.equal( getLocale( { lang: 'fr' } ), 'fr' );
+			assert.equal( getLocale( { stepName: 'fr' } ), 'fr' );
+			assert.equal( getLocale( { flowName: 'fr' } ), 'fr' );
 		} );
 
 		test( 'should return undefined if no locale is present in the params', () => {
 			assert.equal(
-				utils.getLocale( {
+				getLocale( {
 					stepName: 'theme-selection',
 					flowName: 'flow-one',
 				} ),
@@ -60,12 +66,12 @@ describe( 'utils', () => {
 
 	describe( 'getStepName', () => {
 		test( 'should find the step name in either the stepName or flowName fragment', () => {
-			assert.equal( utils.getStepName( { stepName: 'user' } ), 'user' );
-			assert.equal( utils.getStepName( { flowName: 'user' } ), 'user' );
+			assert.equal( getStepName( { stepName: 'user' } ), 'user' );
+			assert.equal( getStepName( { flowName: 'user' } ), 'user' );
 		} );
 
 		test( 'should return undefined if no step name is found', () => {
-			assert.equal( utils.getStepName( { flowName: 'account' } ), undefined );
+			assert.equal( getStepName( { flowName: 'account' } ), undefined );
 		} );
 	} );
 
@@ -75,62 +81,62 @@ describe( 'utils', () => {
 		} );
 
 		test( 'should find the flow name in the flowName fragment if present', () => {
-			assert.equal( utils.getFlowName( { flowName: 'other' } ), 'other' );
+			assert.equal( getFlowName( { flowName: 'other' } ), 'other' );
 		} );
 
 		test( 'should return the default flow if the flow is missing', () => {
-			assert.equal( utils.getFlowName( {} ), 'main' );
+			assert.equal( getFlowName( {} ), 'main' );
 		} );
 
 		test( 'should return the result of filterFlowName if it is a function and the flow is missing', () => {
 			flows.filterFlowName = sinon.stub().returns( 'filtered' );
-			assert.equal( utils.getFlowName( {} ), 'filtered' );
+			assert.equal( getFlowName( {} ), 'filtered' );
 		} );
 
 		test( 'should return the result of filterFlowName if it is a function and the flow is not valid', () => {
 			flows.filterFlowName = sinon.stub().returns( 'filtered' );
-			assert.equal( utils.getFlowName( { flowName: 'invalid' } ), 'filtered' );
+			assert.equal( getFlowName( { flowName: 'invalid' } ), 'filtered' );
 		} );
 
 		test( 'should return the result of filterFlowName if it is a function and the requested flow is present', () => {
 			flows.filterFlowName = sinon.stub().returns( 'filtered' );
-			assert.equal( utils.getFlowName( { flowName: 'other' } ), 'filtered' );
+			assert.equal( getFlowName( { flowName: 'other' } ), 'filtered' );
 		} );
 
 		test( 'should return the passed flow if the result of filterFlowName is not valid', () => {
 			flows.filterFlowName = sinon.stub().returns( 'foobar' );
-			assert.equal( utils.getFlowName( { flowName: 'other' } ), 'other' );
+			assert.equal( getFlowName( { flowName: 'other' } ), 'other' );
 		} );
 
 		test( 'should call filterFlowName with the default flow if it is a function and the flow is not valid', () => {
 			flows.filterFlowName = sinon.stub().returns( 'filtered' );
-			utils.getFlowName( { flowName: 'invalid' } );
+			getFlowName( { flowName: 'invalid' } );
 			assert( flows.filterFlowName.calledWith( 'main' ) );
 		} );
 
 		test( 'should call filterFlowName with the requested flow if it is a function and the flow is valid', () => {
 			flows.filterFlowName = sinon.stub().returns( 'filtered' );
-			utils.getFlowName( { flowName: 'other' } );
+			getFlowName( { flowName: 'other' } );
 			assert( flows.filterFlowName.calledWith( 'other' ) );
 		} );
 	} );
 
 	describe( 'getValidPath', () => {
 		test( 'should redirect to the default if no flow is present', () => {
-			assert.equal( utils.getValidPath( {} ), '/start/user' );
+			assert.equal( getValidPath( {} ), '/start/user' );
 		} );
 
 		test( 'should redirect to the current flow default if no step is present', () => {
-			assert.equal( utils.getValidPath( { flowName: 'account' } ), '/start/account/user' );
+			assert.equal( getValidPath( { flowName: 'account' } ), '/start/account/user' );
 		} );
 
 		test( 'should redirect to the default flow if the flow is the default', () => {
-			assert.equal( utils.getValidPath( { flowName: 'main' } ), '/start/user' );
+			assert.equal( getValidPath( { flowName: 'main' } ), '/start/user' );
 		} );
 
 		test( 'should redirect invalid steps to the default flow if no flow is present', () => {
 			assert.equal(
-				utils.getValidPath( {
+				getValidPath( {
 					stepName: 'fr',
 					stepSectionName: 'fr',
 				} ),
@@ -140,7 +146,7 @@ describe( 'utils', () => {
 
 		test( 'should preserve a valid locale to the default flow if one is specified', () => {
 			assert.equal(
-				utils.getValidPath( {
+				getValidPath( {
 					stepName: 'fr',
 					stepSectionName: 'abc',
 				} ),
@@ -150,7 +156,7 @@ describe( 'utils', () => {
 
 		test( 'should redirect invalid steps to the current flow default', () => {
 			assert.equal(
-				utils.getValidPath( {
+				getValidPath( {
 					flowName: 'account',
 					stepName: 'fr',
 					stepSectionName: 'fr',
@@ -161,7 +167,7 @@ describe( 'utils', () => {
 
 		test( 'should preserve a valid locale if one is specified', () => {
 			assert.equal(
-				utils.getValidPath( {
+				getValidPath( {
 					flowName: 'account',
 					stepName: 'fr',
 					stepSectionName: 'abc',
@@ -174,7 +180,7 @@ describe( 'utils', () => {
 			const randomStepSectionName = 'random-step-section-' + Math.random();
 
 			assert.equal(
-				utils.getValidPath( {
+				getValidPath( {
 					flowName: 'account',
 					stepName: 'user',
 					stepSectionName: randomStepSectionName,
@@ -188,7 +194,7 @@ describe( 'utils', () => {
 			const randomStepSectionName = 'random-step-section-' + Math.random();
 
 			assert.equal(
-				utils.getValidPath( {
+				getValidPath( {
 					stepName: 'user',
 					stepSectionName: randomStepSectionName,
 					lang: 'fr',
@@ -207,12 +213,12 @@ describe( 'utils', () => {
 		};
 
 		test( 'should return the value of the field if it exists', () => {
-			assert.equal( utils.getValueFromProgressStore( config ), 'calypso' );
+			assert.equal( getValueFromProgressStore( config ), 'calypso' );
 		} );
 
 		test( 'should return null if the field is not present', () => {
 			delete signupProgress[ 1 ].site;
-			assert.equal( utils.getValueFromProgressStore( config ), null );
+			assert.equal( getValueFromProgressStore( config ), null );
 		} );
 	} );
 
@@ -225,7 +231,7 @@ describe( 'utils', () => {
 		test( "should return the form with the field added if the field doesn't have a value", () => {
 			const form = { username: {} };
 			config.form = form;
-			assert.deepEqual( utils.mergeFormWithValue( config ), {
+			assert.deepEqual( mergeFormWithValue( config ), {
 				username: { value: 'calypso' },
 			} );
 		} );
@@ -233,7 +239,7 @@ describe( 'utils', () => {
 		test( 'should return the form unchanged if there is already a value in the form', () => {
 			const form = { username: { value: 'wordpress' } };
 			config.form = form;
-			assert.equal( utils.mergeFormWithValue( config ), form );
+			assert.equal( mergeFormWithValue( config ), form );
 		} );
 	} );
 } );

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -14,7 +14,7 @@ import formState from 'lib/form-state';
 import userFactory from 'lib/user';
 const user = userFactory();
 
-function getFlowName( parameters ) {
+export function getFlowName( parameters ) {
 	const flow =
 		parameters.flowName && isFlowName( parameters.flowName )
 			? parameters.flowName
@@ -36,7 +36,7 @@ function isFlowName( pathFragment ) {
 	return ! isEmpty( flows.getFlow( pathFragment ) );
 }
 
-function getStepName( parameters ) {
+export function getStepName( parameters ) {
 	return find( pick( parameters, [ 'flowName', 'stepName' ] ), isStepName );
 }
 
@@ -44,7 +44,7 @@ function isStepName( pathFragment ) {
 	return ! isEmpty( steps[ pathFragment ] );
 }
 
-function getStepSectionName( parameters ) {
+export function getStepSectionName( parameters ) {
 	return find( pick( parameters, [ 'stepName', 'stepSectionName' ] ), isStepSectionName );
 }
 
@@ -52,7 +52,7 @@ function isStepSectionName( pathFragment ) {
 	return ! isStepName( pathFragment ) && ! isLocale( pathFragment );
 }
 
-function getLocale( parameters ) {
+export function getLocale( parameters ) {
 	return find(
 		pick( parameters, [ 'flowName', 'stepName', 'stepSectionName', 'lang' ] ),
 		isLocale
@@ -63,7 +63,7 @@ function isLocale( pathFragment ) {
 	return ! isEmpty( getLanguage( pathFragment ) );
 }
 
-function getStepUrl( flowName, stepName, stepSectionName, localeSlug ) {
+export function getStepUrl( flowName, stepName, stepSectionName, localeSlug ) {
 	const flow = flowName ? `/${ flowName }` : '',
 		step = stepName ? `/${ stepName }` : '',
 		section = stepSectionName ? `/${ stepSectionName }` : '',
@@ -80,7 +80,7 @@ function getStepUrl( flowName, stepName, stepSectionName, localeSlug ) {
 	return '/start' + flow + step + section + locale;
 }
 
-function getValidPath( parameters ) {
+export function getValidPath( parameters ) {
 	const locale = getLocale( parameters ),
 		flowName = getFlowName( parameters ),
 		currentFlowSteps = flows.getFlow( flowName ).steps,
@@ -94,27 +94,27 @@ function getValidPath( parameters ) {
 	return getStepUrl( flowName, stepName, stepSectionName, locale );
 }
 
-function getPreviousStepName( flowName, currentStepName ) {
+export function getPreviousStepName( flowName, currentStepName ) {
 	const flow = flows.getFlow( flowName );
 	return flow.steps[ indexOf( flow.steps, currentStepName ) - 1 ];
 }
 
-function getNextStepName( flowName, currentStepName ) {
+export function getNextStepName( flowName, currentStepName ) {
 	const flow = flows.getFlow( flowName );
 	return flow.steps[ indexOf( flow.steps, currentStepName ) + 1 ];
 }
 
-function getFlowSteps( flowName ) {
+export function getFlowSteps( flowName ) {
 	const flow = flows.getFlow( flowName );
 	return flow.steps;
 }
 
-function getValueFromProgressStore( { signupProgress, stepName, fieldName } ) {
+export function getValueFromProgressStore( { signupProgress, stepName, fieldName } ) {
 	const siteStepProgress = find( signupProgress, step => step.stepName === stepName );
 	return siteStepProgress ? siteStepProgress[ fieldName ] : null;
 }
 
-function mergeFormWithValue( { form, fieldName, fieldValue } ) {
+export function mergeFormWithValue( { form, fieldName, fieldValue } ) {
 	if ( ! formState.getFieldValue( form, fieldName ) ) {
 		return merge( form, {
 			[ fieldName ]: { value: fieldValue },
@@ -123,11 +123,11 @@ function mergeFormWithValue( { form, fieldName, fieldValue } ) {
 	return form;
 }
 
-function getDestination( destination, dependencies, flowName ) {
+export function getDestination( destination, dependencies, flowName ) {
 	return flows.filterDestination( destination, dependencies, flowName );
 }
 
-function getThemeForDesignType( designType ) {
+export function getThemeForDesignType( designType ) {
 	switch ( designType ) {
 		case 'blog':
 			return 'pub/independent-publisher-2';
@@ -142,7 +142,7 @@ function getThemeForDesignType( designType ) {
 	}
 }
 
-function getThemeForSiteGoals( siteGoals ) {
+export function getThemeForSiteGoals( siteGoals ) {
 	const siteGoalsValue = siteGoals.split( ',' );
 
 	if ( siteGoalsValue.indexOf( 'sell' ) !== -1 ) {
@@ -164,7 +164,7 @@ function getThemeForSiteGoals( siteGoals ) {
 	return 'pub/independent-publisher-2';
 }
 
-function getSiteTypeForSiteGoals( siteGoals ) {
+export function getSiteTypeForSiteGoals( siteGoals ) {
 	const siteGoalsValue = siteGoals.split( ',' );
 
 	//Identify stores for the store signup flow
@@ -187,7 +187,7 @@ function getSiteTypeForSiteGoals( siteGoals ) {
 	return 'blog';
 }
 
-function canResumeFlow( flowName, progress ) {
+export function canResumeFlow( flowName, progress ) {
 	const flow = flows.getFlow( flowName );
 	const flowStepsInProgressStore = filter(
 		progress,
@@ -196,22 +196,3 @@ function canResumeFlow( flowName, progress ) {
 
 	return flowStepsInProgressStore.length > 0 && ! flow.disallowResume;
 }
-
-export default {
-	canResumeFlow: canResumeFlow,
-	getFlowName: getFlowName,
-	getFlowSteps: getFlowSteps,
-	getStepName: getStepName,
-	getLocale: getLocale,
-	getStepSectionName: getStepSectionName,
-	getStepUrl: getStepUrl,
-	getValidPath: getValidPath,
-	getPreviousStepName: getPreviousStepName,
-	getNextStepName: getNextStepName,
-	getValueFromProgressStore: getValueFromProgressStore,
-	getDestination: getDestination,
-	mergeFormWithValue: mergeFormWithValue,
-	getThemeForDesignType: getThemeForDesignType,
-	getThemeForSiteGoals: getThemeForSiteGoals,
-	getSiteTypeForSiteGoals: getSiteTypeForSiteGoals,
-};


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.