### PR TITLE
esmodules: Update lib/signup/step-actions

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -30,7 +30,7 @@ import { requestSites } from 'state/sites/actions';
 
 const debug = debugFactory( 'calypso:signup:step-actions' );
 
-function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
+export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 	const { siteId, siteSlug } = data;
 	const { cartItem, designType, domainItem, siteUrl, themeSlugWithRepo } = dependencies;
 
@@ -93,7 +93,7 @@ function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 	}
 }
 
-function createSiteWithCart(
+export function createSiteWithCart(
 	callback,
 	dependencies,
 	{
@@ -200,7 +200,7 @@ function fetchSitesUntilSiteAppears( siteSlug, reduxStore, callback ) {
 		.then( () => fetchSitesUntilSiteAppears( siteSlug, reduxStore, callback ) );
 }
 
-function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {
+export function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {
 	async.parallel(
 		[
 			callback => fetchSitesUntilSiteAppears( siteSlug, reduxStore, callback ),
@@ -213,7 +213,7 @@ function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {
 	);
 }
 
-function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
+export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
 	if ( isEmpty( themeSlugWithRepo ) ) {
 		defer( callback );
 
@@ -238,7 +238,7 @@ function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
  * @param {string} username The username to get suggestions for.
  * @param {object} reduxState The Redux state object
  */
-function getUsernameSuggestion( username, reduxState ) {
+export function getUsernameSuggestion( username, reduxState ) {
 	const fields = {
 		givesuggestions: 1,
 		username: username,
@@ -289,135 +289,119 @@ function getUsernameSuggestion( username, reduxState ) {
 	} );
 }
 
-export default {
-	createSiteOrDomain,
+export function addPlanToCart( callback, { siteId }, { cartItem, privacyItem } ) {
+	if ( isEmpty( cartItem ) ) {
+		// the user selected the free plan
+		defer( callback );
 
-	createSiteWithCart,
+		return;
+	}
 
-	addPlanToCart( callback, { siteId }, { cartItem, privacyItem } ) {
-		if ( isEmpty( cartItem ) ) {
-			// the user selected the free plan
-			defer( callback );
+	const newCartItems = [ cartItem, privacyItem ].filter( item => item );
 
-			return;
-		}
+	SignupCart.addToCart( siteId, newCartItems, error =>
+		callback( error, { cartItem, privacyItem } )
+	);
+}
 
-		const newCartItems = [ cartItem, privacyItem ].filter( item => item );
+export function createAccount(
+	callback,
+	dependencies,
+	{ userData, flowName, queryArgs, service, access_token, id_token, oauth2Signup },
+	reduxStore
+) {
+	const surveyVertical = getSurveyVertical( reduxStore.getState() ).trim();
+	const surveySiteType = getSurveySiteType( reduxStore.getState() ).trim();
 
-		SignupCart.addToCart( siteId, newCartItems, error =>
-			callback( error, { cartItem, privacyItem } )
-		);
-	},
+	if ( service ) {
+		// We're creating a new social account
+		wpcom.undocumented().usersSocialNew( {
+			service,
+			access_token,
+			id_token,
+			signup_flow_name: flowName,
+		},
+		( error, response ) => {
+			const errors =
+				error && error.error
+					? [ { error: error.error, message: error.message, email: get( error, 'data.email' ) } ]
+					: undefined;
 
-	createAccount(
-		callback,
-		dependencies,
-		{ userData, flowName, queryArgs, service, access_token, id_token, oauth2Signup },
-		reduxStore
-	) {
-		const surveyVertical = getSurveyVertical( reduxStore.getState() ).trim();
-		const surveySiteType = getSurveySiteType( reduxStore.getState() ).trim();
-
-		if ( service ) {
-			// We're creating a new social account
-			wpcom.undocumented().usersSocialNew( {
-				service,
-				access_token,
-				id_token,
-				signup_flow_name: flowName,
-			},
-			( error, response ) => {
-				const errors =
-					error && error.error
-						? [ { error: error.error, message: error.message, email: get( error, 'data.email' ) } ]
-						: undefined;
-
-				if ( errors ) {
-					callback( errors );
-				} else {
-					callback( undefined, response );
-				}
-			} );
-		} else {
-			wpcom.undocumented().usersNew( assign(
-				{},
-				userData,
-				{
-					ab_test_variations: getSavedVariations(),
-					validate: false,
-					signup_flow_name: flowName,
-					nux_q_site_type: surveySiteType,
-					nux_q_question_primary: surveyVertical,
-					// url sent in the confirmation email
-					jetpack_redirect: queryArgs.jetpack_redirect,
-				},
-				oauth2Signup
-					? {
-							oauth2_client_id: queryArgs.oauth2_client_id,
-							// url of the WordPress.com authorize page for this OAuth2 client
-							// convert to legacy oauth2_redirect format: %s@https://public-api.wordpress.com/oauth2/authorize/...
-							oauth2_redirect: queryArgs.oauth2_redirect && '0@' + queryArgs.oauth2_redirect,
-						}
-					: null
-			),
-			( error, response ) => {
-				const errors =
-						error && error.error ? [ { error: error.error, message: error.message } ] : undefined,
-					bearerToken = error && error.error ? {} : { bearer_token: response.bearer_token };
-
-				if ( ! errors ) {
-					// Fire after a new user registers.
-					analytics.tracks.recordEvent( 'calypso_user_registration_complete' );
-					analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
-				}
-
-				const providedDependencies = assign( {}, { username: userData.username }, bearerToken );
-
-				if ( oauth2Signup ) {
-					assign( providedDependencies, {
-						oauth2_client_id: queryArgs.oauth2_client_id,
-						oauth2_redirect: queryArgs.oauth2_redirect,
-					} );
-				}
-
-				callback( errors, providedDependencies );
-			} );
-		}
-	},
-
-	createSite( callback, { themeSlugWithRepo }, { site }, reduxStore ) {
-		var data = {
-			blog_name: site,
-			blog_title: '',
-			options: { theme: themeSlugWithRepo },
-			validate: false,
-		};
-
-		wpcom.undocumented().sitesNew( data, function( errors, response ) {
-			let providedDependencies, siteSlug;
-
-			if ( response && response.blog_details ) {
-				const parsedBlogURL = parseURL( response.blog_details.url );
-				siteSlug = parsedBlogURL.hostname;
-
-				providedDependencies = { siteSlug };
-			}
-
-			if ( user.get() && isEmpty( errors ) ) {
-				fetchSitesAndUser(
-					siteSlug,
-					() => callback( undefined, providedDependencies ),
-					reduxStore
-				);
+			if ( errors ) {
+				callback( errors );
 			} else {
-				callback( isEmpty( errors ) ? undefined : [ errors ], providedDependencies );
+				callback( undefined, response );
 			}
 		} );
-	},
+	} else {
+		wpcom.undocumented().usersNew( assign(
+			{},
+			userData,
+			{
+				ab_test_variations: getSavedVariations(),
+				validate: false,
+				signup_flow_name: flowName,
+				nux_q_site_type: surveySiteType,
+				nux_q_question_primary: surveyVertical,
+				// url sent in the confirmation email
+				jetpack_redirect: queryArgs.jetpack_redirect,
+			},
+			oauth2Signup
+				? {
+						oauth2_client_id: queryArgs.oauth2_client_id,
+						// url of the WordPress.com authorize page for this OAuth2 client
+						// convert to legacy oauth2_redirect format: %s@https://public-api.wordpress.com/oauth2/authorize/...
+						oauth2_redirect: queryArgs.oauth2_redirect && '0@' + queryArgs.oauth2_redirect,
+					}
+				: null
+		),
+		( error, response ) => {
+			const errors =
+					error && error.error ? [ { error: error.error, message: error.message } ] : undefined,
+				bearerToken = error && error.error ? {} : { bearer_token: response.bearer_token };
 
-	fetchSitesAndUser: fetchSitesAndUser,
+			if ( ! errors ) {
+				// Fire after a new user registers.
+				analytics.tracks.recordEvent( 'calypso_user_registration_complete' );
+				analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
+			}
 
-	setThemeOnSite: setThemeOnSite,
+			const providedDependencies = assign( {}, { username: userData.username }, bearerToken );
 
-	getUsernameSuggestion: getUsernameSuggestion,
-};
+			if ( oauth2Signup ) {
+				assign( providedDependencies, {
+					oauth2_client_id: queryArgs.oauth2_client_id,
+					oauth2_redirect: queryArgs.oauth2_redirect,
+				} );
+			}
+
+			callback( errors, providedDependencies );
+		} );
+	}
+}
+
+export function createSite( callback, { themeSlugWithRepo }, { site }, reduxStore ) {
+	const data = {
+		blog_name: site,
+		blog_title: '',
+		options: { theme: themeSlugWithRepo },
+		validate: false,
+	};
+
+	wpcom.undocumented().sitesNew( data, function( errors, response ) {
+		let providedDependencies, siteSlug;
+
+		if ( response && response.blog_details ) {
+			const parsedBlogURL = parseURL( response.blog_details.url );
+			siteSlug = parsedBlogURL.hostname;
+
+			providedDependencies = { siteSlug };
+		}
+
+		if ( user.get() && isEmpty( errors ) ) {
+			fetchSitesAndUser( siteSlug, () => callback( undefined, providedDependencies ), reduxStore );
+		} else {
+			callback( isEmpty( errors ) ? undefined : [ errors ], providedDependencies );
+		}
+	} );
+}

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -11,7 +11,14 @@ import i18n from 'i18n-calypso';
 * Internal dependencies
 */
 import config from 'config';
-import stepActions from 'lib/signup/step-actions';
+import {
+	addPlanToCart,
+	createAccount,
+	createSite,
+	createSiteOrDomain,
+	createSiteWithCart,
+	setThemeOnSite,
+} from 'lib/signup/step-actions';
 
 export default {
 	survey: {
@@ -63,7 +70,7 @@ export default {
 		stepName: 'themes-site-selected',
 		dependencies: [ 'siteSlug', 'themeSlugWithRepo' ],
 		providesDependencies: [ 'themeSlugWithRepo' ],
-		apiRequestFunction: stepActions.setThemeOnSite,
+		apiRequestFunction: setThemeOnSite,
 		props: {
 			headerText: i18n.translate( 'Choose a theme for your new site.' ),
 		},
@@ -71,7 +78,7 @@ export default {
 
 	'plans-site-selected': {
 		stepName: 'plans-site-selected',
-		apiRequestFunction: stepActions.addPlanToCart,
+		apiRequestFunction: addPlanToCart,
 		dependencies: [ 'siteSlug', 'siteId' ],
 		providesDependencies: [ 'cartItem', 'privacyItem' ],
 	},
@@ -93,13 +100,13 @@ export default {
 
 	site: {
 		stepName: 'site',
-		apiRequestFunction: stepActions.createSite,
+		apiRequestFunction: createSite,
 		providesDependencies: [ 'siteSlug' ],
 	},
 
 	'rebrand-cities-welcome': {
 		stepName: 'rebrand-cities-welcome',
-		apiRequestFunction: stepActions.createSiteWithCart,
+		apiRequestFunction: createSiteWithCart,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
 		props: {
 			isDomainOnly: false,
@@ -114,7 +121,7 @@ export default {
 
 	user: {
 		stepName: 'user',
-		apiRequestFunction: stepActions.createAccount,
+		apiRequestFunction: createAccount,
 		providesToken: true,
 		providesDependencies: [ 'bearer_token', 'username' ],
 		unstorableDependencies: [ 'bearer_token' ],
@@ -134,21 +141,21 @@ export default {
 
 	plans: {
 		stepName: 'plans',
-		apiRequestFunction: stepActions.addPlanToCart,
+		apiRequestFunction: addPlanToCart,
 		dependencies: [ 'siteSlug', 'siteId', 'domainItem' ],
 		providesDependencies: [ 'cartItem', 'privacyItem' ],
 	},
 
 	'plans-store-nux': {
 		stepName: 'plans-store-nux',
-		apiRequestFunction: stepActions.addPlanToCart,
+		apiRequestFunction: addPlanToCart,
 		dependencies: [ 'siteSlug', 'siteId', 'domainItem' ],
 		providesDependencies: [ 'cartItem', 'privacyItem' ],
 	},
 
 	domains: {
 		stepName: 'domains',
-		apiRequestFunction: stepActions.createSiteWithCart,
+		apiRequestFunction: createSiteWithCart,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
 		props: {
 			isDomainOnly: false,
@@ -159,7 +166,7 @@ export default {
 
 	'domains-theme-preselected': {
 		stepName: 'domains-theme-preselected',
-		apiRequestFunction: stepActions.createSiteWithCart,
+		apiRequestFunction: createSiteWithCart,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
 		props: {
 			isDomainOnly: false,
@@ -169,7 +176,7 @@ export default {
 
 	'jetpack-user': {
 		stepName: 'jetpack-user',
-		apiRequestFunction: stepActions.createAccount,
+		apiRequestFunction: createAccount,
 		providesToken: true,
 		props: {
 			headerText: i18n.translate( 'Create an account for Jetpack' ),
@@ -180,7 +187,7 @@ export default {
 
 	'oauth2-user': {
 		stepName: 'oauth2-user',
-		apiRequestFunction: stepActions.createAccount,
+		apiRequestFunction: createAccount,
 		props: {
 			oauth2Signup: true,
 		},
@@ -189,7 +196,7 @@ export default {
 	},
 
 	'get-dot-blog-plans': {
-		apiRequestFunction: stepActions.createSiteWithCart,
+		apiRequestFunction: createSiteWithCart,
 		stepName: 'get-dot-blog-plans',
 		dependencies: [ 'cartItem' ],
 		providesDependencies: [
@@ -232,7 +239,7 @@ export default {
 	},
 	'site-picker': {
 		stepName: 'site-picker',
-		apiRequestFunction: stepActions.createSiteOrDomain,
+		apiRequestFunction: createSiteOrDomain,
 		props: {
 			headerText: i18n.translate( 'Choose your site?' ),
 		},


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.