### PR TITLE
esmodules: Update lib/domains/assembler

### DIFF
--- a/client/lib/domains/assembler.js
+++ b/client/lib/domains/assembler.js
@@ -12,7 +12,7 @@ import i18n from 'i18n-calypso';
  */
 import { getDomainType, getTransferStatus } from './utils';
 
-function createDomainObjects( dataTransferObject ) {
+export function createDomainObjects( dataTransferObject ) {
 	let domains = [];
 
 	if ( ! Array.isArray( dataTransferObject ) ) {
@@ -55,7 +55,7 @@ function createDomainObjects( dataTransferObject ) {
 	return ensurePrimaryDomainIsFirst( domains );
 }
 
-function assembleGoogleAppsSubscription( googleAppsSubscription ) {
+export function assembleGoogleAppsSubscription( googleAppsSubscription ) {
 	if ( ! googleAppsSubscription ) {
 		return;
 	}
@@ -72,8 +72,3 @@ function ensurePrimaryDomainIsFirst( domains ) {
 
 	return [ primaryDomain ].concat( without( domains, primaryDomain ) );
 }
-
-export default {
-	assembleGoogleAppsSubscription,
-	createDomainObjects,
-};

--- a/client/lib/domains/test/assembler.js
+++ b/client/lib/domains/test/assembler.js
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */
@@ -9,7 +8,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import domainsAssembler from './../assembler';
+import { createDomainObjects } from './../assembler';
 import { type as domainTypes } from './../constants';
 
 describe( 'assembler', () => {
@@ -75,18 +74,18 @@ describe( 'assembler', () => {
 		} );
 
 	test( 'should produce empty array when null data transfer object passed', () => {
-		expect( domainsAssembler.createDomainObjects( null ) ).to.be.eql( [] );
+		expect( createDomainObjects( null ) ).to.be.eql( [] );
 	} );
 
 	test( 'should produce array with domains even when there is no primary domain', () => {
-		expect( domainsAssembler.createDomainObjects( [ redirectDataTransferObject ] ) ).to.be.eql( [
+		expect( createDomainObjects( [ redirectDataTransferObject ] ) ).to.be.eql( [
 			redirectDomainObject,
 		] );
 	} );
 
 	test( 'should produce array with registered domain first when registered domain is set as primary domain', () => {
 		expect(
-			domainsAssembler.createDomainObjects( [
+			createDomainObjects( [
 				mappedDataTransferObject,
 				primaryRegisteredDataTransferObject,
 				redirectDataTransferObject,

--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -1,9 +1,7 @@
+/** @format **/
 /**
  * Externel dependencies
- *
- * @format
  */
-
 import { noop } from 'lodash';
 import i18n from 'i18n-calypso';
 
@@ -14,7 +12,7 @@ import { action as ActionTypes } from '../constants';
 import { isInitialized as isDomainInitialized } from 'lib/domains';
 import Dispatcher from 'dispatcher';
 import DnsStore from 'lib/domains/dns/store';
-import domainsAssembler from 'lib/domains/assembler';
+import { createDomainObjects } from 'lib/domains/assembler';
 import DomainsStore from 'lib/domains/store';
 import EmailForwardingStore from 'lib/domains/email-forwarding/store';
 import NameserversStore from 'lib/domains/nameservers/store';
@@ -155,7 +153,7 @@ function fetchDomains( siteId ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.DOMAINS_FETCH_COMPLETED,
 				siteId,
-				domains: domainsAssembler.createDomainObjects( data.domains ),
+				domains: createDomainObjects( data.domains ),
 			} );
 		} )
 		.catch( error => {


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.