### PR TITLE
esmodules: Update lib/feature-detection

### DIFF
--- a/client/lib/feature-detection/index.js
+++ b/client/lib/feature-detection/index.js
@@ -5,7 +5,7 @@
  *
  * @return {boolean} true when feature is supported
  */
-export function supportsCssCustomPropertie() {
+export function supportsCssCustomProperties() {
 	return (
 		typeof window !== 'undefined' &&
 		window.CSS &&

--- a/client/lib/feature-detection/index.js
+++ b/client/lib/feature-detection/index.js
@@ -1,19 +1,15 @@
 /** @format */
 
-const featureDetection = {
-	/**
-	 * Detects if CSS custom properties are supported
-	 *
-	 * @return {boolean} true when feature is supported
-	 */
-	supportsCssCustomProperties: () => {
-		return (
-			typeof window !== 'undefined' &&
-			window.CSS &&
-			window.CSS.supports &&
-			( window.CSS.supports( '--a', 0 ) || window.CSS.supports( 'color', 'var(--a)' ) )
-		);
-	},
-};
-
-export default featureDetection;
+/**
+ * Detects if CSS custom properties are supported
+ *
+ * @return {boolean} true when feature is supported
+ */
+export function supportsCssCustomPropertie() {
+	return (
+		typeof window !== 'undefined' &&
+		window.CSS &&
+		window.CSS.supports &&
+		( window.CSS.supports( '--a', 0 ) || window.CSS.supports( 'color', 'var(--a)' ) )
+	);
+}


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.