### PR TITLE
esmodules: Update lib/media-serialization

### DIFF
--- a/client/components/tinymce/plugins/media/advanced/index.jsx
+++ b/client/components/tinymce/plugins/media/advanced/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import ReactDom from 'react-dom';
 import ReactDomServer from 'react-dom/server';
@@ -13,7 +11,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import * as MediaSerialization from 'lib/media-serialization';
+import { deserialize } from 'lib/media-serialization';
 import config from 'config';
 import EditorMediaAdvanced from 'post-editor/editor-media-advanced';
 import { renderWithReduxStore } from 'lib/react-helpers';
@@ -81,7 +79,7 @@ export default function( editor ) {
 
 		onClick() {
 			const node = editor.selection.getStart();
-			const item = MediaSerialization.deserialize( node );
+			const item = deserialize( node );
 			showModal( item );
 		},
 	} );

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -15,7 +13,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import * as MediaSerialization from 'lib/media-serialization';
+import { deserialize } from 'lib/media-serialization';
 import MediaStore from 'lib/media/store';
 import MediaUtils from 'lib/media/utils';
 import Dialog from 'components/dialog';
@@ -167,7 +165,7 @@ class LinkDialog extends React.Component {
 
 		selectedNode = this.props.editor.selection.getNode();
 		if ( selectedNode && 'IMG' === selectedNode.nodeName ) {
-			parsedImage = MediaSerialization.deserialize( selectedNode );
+			parsedImage = deserialize( selectedNode );
 			if ( this.props.site && parsedImage.media.ID ) {
 				knownImage =
 					MediaStore.get( this.props.site.ID, parsedImage.media.ID ) || parsedImage.media;

--- a/client/lib/media-serialization/index.js
+++ b/client/lib/media-serialization/index.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * Internal dependencies
  */
-
 import detectFormat from './detect-format';
 import Strategies from './strategies';
 

--- a/client/post-editor/media-modal/markup.js
+++ b/client/post-editor/media-modal/markup.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import { assign } from 'lodash';
 import ReactDomServer from 'react-dom/server';
 import React from 'react';
@@ -14,7 +12,7 @@ import classNames from 'classnames';
  */
 import Shortcode from 'lib/shortcode';
 import MediaUtils from 'lib/media/utils';
-import MediaSerialization from 'lib/media-serialization';
+import { deserialize } from 'lib/media-serialization';
 
 /**
  * Module variables
@@ -103,7 +101,7 @@ Markup = {
 
 		width = parsed.attrs.named.width;
 		if ( ! width ) {
-			width = MediaSerialization.deserialize( img ).width;
+			width = deserialize( img ).width;
 		}
 
 		/*eslint-disable react/no-danger*/


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.