### PR TITLE
esmodules: Update lib/touch-detect

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -19,7 +19,7 @@ import config from 'config';
 import { receiveUser } from 'state/users/actions';
 import { setCurrentUserId, setCurrentUserFlags } from 'state/current-user/actions';
 import { setRoute as setRouteAction } from 'state/ui/actions';
-import touchDetect from 'lib/touch-detect';
+import { hasTouch } from 'lib/touch-detect';
 import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
 
 const debug = debugFactory( 'calypso' );
@@ -161,7 +161,7 @@ export const utils = () => {
 
 	// Infer touch screen by checking if device supports touch events
 	// See touch-detect/README.md
-	if ( touchDetect.hasTouch() ) {
+	if ( hasTouch() ) {
 		document.documentElement.classList.add( 'touch' );
 	} else {
 		document.documentElement.classList.add( 'notouch' );

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -13,7 +13,7 @@ import { some, noop, throttle } from 'lodash';
  * Internal dependencies
  */
 import BarContainer from './bar-container';
-import touchDetect from 'lib/touch-detect';
+import { hasTouch } from 'lib/touch-detect';
 
 class ModuleChartExport extends React.Component {
 	state = {
@@ -60,7 +60,7 @@ class ModuleChartExport extends React.Component {
 		let width = node.clientWidth - 82,
 			maxBars;
 
-		if ( touchDetect.hasTouch() ) {
+		if ( hasTouch() ) {
 			width = width <= 0 ? 350 : width; // mobile safari bug with zero width
 			maxBars = Math.floor( width / this.props.minTouchBarWidth );
 		} else {
@@ -148,7 +148,7 @@ class ModuleChartExport extends React.Component {
 					data={ data }
 					yAxisMax={ yAxisMax }
 					chartWidth={ this.state.width }
-					isTouch={ touchDetect.hasTouch() }
+					isTouch={ hasTouch() }
 				/>
 				{ emptyChart }
 			</div>

--- a/client/components/forms/sortable-list/index.jsx
+++ b/client/components/forms/sortable-list/index.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
@@ -15,7 +13,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import touchDetect from 'lib/touch-detect';
+import { hasTouch } from 'lib/touch-detect';
 
 const debug = debugFactory( 'calypso:forms:sortable-list' );
 
@@ -197,7 +195,7 @@ class SortableList extends React.Component {
 
 	onMouseMove = event => {
 		var activeOrder, newIndex;
-		if ( null === this.state.activeIndex || ! this.props.allowDrag || touchDetect.hasTouch() ) {
+		if ( null === this.state.activeIndex || ! this.props.allowDrag || hasTouch() ) {
 			return;
 		}
 
@@ -265,7 +263,7 @@ class SortableList extends React.Component {
 			this.props.children,
 			function( child, index ) {
 				var isActive = this.state.activeIndex === index,
-					isDraggable = this.props.allowDrag && ! touchDetect.hasTouch(),
+					isDraggable = this.props.allowDrag && ! hasTouch(),
 					events = isDraggable ? [ 'onMouseDown', 'onMouseUp' ] : [ 'onClick' ],
 					style = { order: this.getAdjustedElementIndex( index ) },
 					classes = classNames( {
@@ -318,7 +316,7 @@ class SortableList extends React.Component {
 	};
 
 	getNavigationElement = () => {
-		if ( this.props.allowDrag && ! touchDetect.hasTouch() ) {
+		if ( this.props.allowDrag && ! hasTouch() ) {
 			return;
 		}
 

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -18,7 +18,7 @@ import addQueryArgs from 'lib/route/add-query-args';
  * Internal dependencies
  */
 import Toolbar from './toolbar';
-import touchDetect from 'lib/touch-detect';
+import { hasTouch } from 'lib/touch-detect';
 import { isWithinBreakpoint } from 'lib/viewport';
 import { localize } from 'i18n-calypso';
 import SpinnerLine from 'components/spinner-line';
@@ -44,7 +44,7 @@ export class WebPreviewContent extends PureComponent {
 
 	componentWillMount() {
 		// Cache touch and mobile detection for the entire lifecycle of the component
-		this._hasTouch = touchDetect.hasTouch();
+		this._hasTouch = hasTouch();
 	}
 
 	componentDidMount() {

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -13,7 +13,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import touchDetect from 'lib/touch-detect';
+import { hasTouch } from 'lib/touch-detect';
 import { isMobile } from 'lib/viewport';
 import { localize } from 'i18n-calypso';
 import RootChild from 'components/root-child';
@@ -38,7 +38,7 @@ export class WebPreview extends PureComponent {
 
 	componentWillMount() {
 		// Cache touch and mobile detection for the entire lifecycle of the component
-		this._hasTouch = touchDetect.hasTouch();
+		this._hasTouch = hasTouch();
 		this._isMobile = isMobile();
 	}
 

--- a/client/lib/touch-detect/index.js
+++ b/client/lib/touch-detect/index.js
@@ -1,25 +1,19 @@
-/**
- * Module exports.
- *
- * @format
- */
+/** @format **/
 
-export default {
-	/**
-	 * This test is for touch events.
-	 * It may not accurately detect a touch screen, but may be close enough depending on the use case.
-	 *
-	 * @copyright Modernizr © 2009-2015.
-	 * @license See CREDITS.md.
-	 * @see https://github.com/Modernizr/Modernizr/blob/master/feature-detects/touchevents.js
-	 *
-	 * @returns {Boolean} whether touch screen is available
-	 */
-	hasTouch: function() {
-		/* global DocumentTouch:true */
-		return (
-			window &&
-			( 'ontouchstart' in window || ( window.DocumentTouch && document instanceof DocumentTouch ) )
-		);
-	},
-};
+/**
+ * This test is for touch events.
+ * It may not accurately detect a touch screen, but may be close enough depending on the use case.
+ *
+ * @copyright Modernizr © 2009-2015.
+ * @license See CREDITS.md.
+ * @see https://github.com/Modernizr/Modernizr/blob/master/feature-detects/touchevents.js
+ *
+ * @returns {Boolean} whether touch screen is available
+ */
+export function hasTouch() {
+	/* global DocumentTouch:true */
+	return (
+		window &&
+		( 'ontouchstart' in window || ( window.DocumentTouch && document instanceof DocumentTouch ) )
+	);
+}

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -24,7 +24,7 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
 import actions from 'lib/posts/actions';
 import photon from 'photon';
-import touchDetect from 'lib/touch-detect';
+import { hasTouch } from 'lib/touch-detect';
 import updatePostStatus from 'components/update-post-status';
 import utils from 'lib/posts/utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -161,7 +161,7 @@ class Draft extends Component {
 		const classes = classnames( 'draft', `is-${ post.format }`, {
 			'has-image': !! image,
 			'is-placeholder': this.props.isPlaceholder,
-			'is-touch': touchDetect.hasTouch(),
+			'is-touch': hasTouch(),
 			'is-selected': this.props.selected,
 		} );
 

--- a/client/my-sites/sharing/buttons/preview-buttons.jsx
+++ b/client/my-sites/sharing/buttons/preview-buttons.jsx
@@ -17,7 +17,7 @@ import classNames from 'classnames';
 import ButtonsPreviewButton from 'my-sites/sharing/buttons/preview-button';
 import ResizableIframe from 'components/resizable-iframe';
 import previewWidget from './preview-widget';
-import touchDetect from 'lib/touch-detect';
+import { hasTouch } from 'lib/touch-detect';
 
 class SharingButtonsPreviewButtons extends React.Component {
 	static displayName = 'SharingButtonsPreviewButtons';
@@ -123,10 +123,7 @@ class SharingButtonsPreviewButtons extends React.Component {
 	showMorePreview = event => {
 		var moreButton, offset;
 
-		if (
-			event &&
-			( event.currentTarget.contains( event.relatedTarget ) || touchDetect.hasTouch() )
-		) {
+		if ( event && ( event.currentTarget.contains( event.relatedTarget ) || hasTouch() ) ) {
 			// Only allow the preview to be shown if cursor has moved from outside
 			// the element to inside. This restriction should only apply to non-
 			// touch devices

--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -16,7 +16,7 @@ import Gravatar from 'components/gravatar';
 import userFactory from 'lib/user';
 import AuthorSelector from 'blocks/author-selector';
 import PostActions from 'lib/posts/actions';
-import touchDetect from 'lib/touch-detect';
+import { hasTouch } from 'lib/touch-detect';
 import * as stats from 'lib/posts/stats';
 import { getSelectedSite } from 'state/ui/selectors';
 
@@ -44,7 +44,7 @@ export class EditorAuthor extends Component {
 		const author = post && postAuthor ? postAuthor : user.get();
 		const name = author.display_name || author.name;
 		const Wrapper = this.userCanAssignAuthor() ? AuthorSelector : 'div';
-		const popoverPosition = touchDetect.hasTouch() ? 'bottom right' : 'bottom left';
+		const popoverPosition = hasTouch() ? 'bottom right' : 'bottom left';
 		const wrapperProps = this.userCanAssignAuthor()
 			? {
 					siteId: site.ID,

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -21,7 +21,7 @@ import FormInputValidation from 'components/forms/form-input-validation';
 import FormTextInput from 'components/forms/form-text-input';
 import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
-import touchDetect from 'lib/touch-detect';
+import { hasTouch } from 'lib/touch-detect';
 import postActions from 'lib/posts/actions';
 import { recordEvent, recordStat } from 'lib/posts/stats';
 import { tracks } from 'lib/analytics';
@@ -308,7 +308,7 @@ class EditorVisibility extends React.Component {
 	render() {
 		const visibility = this.getVisibility();
 		const classes = classNames( 'editor-visibility', {
-			'is-touch': touchDetect.hasTouch(),
+			'is-touch': hasTouch(),
 		} );
 
 		return <div className={ classes }>{ this.renderPrivacyDropdown( visibility ) }</div>;


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.