### PR TITLE
esmodules: Update state/plugins/wporg/actions

### DIFF
--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -1,11 +1,8 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
-
 const debug = debugFactory( 'calypso:wporg-data:actions' );
 
 /**
@@ -18,34 +15,32 @@ import { WPORG_PLUGIN_DATA_RECEIVE, FETCH_WPORG_PLUGIN_DATA } from 'state/action
 /**
  *  Local variables;
  */
-let _fetching = {};
+const _fetching = {};
 
-export default {
-	fetchPluginData: function( pluginSlug ) {
-		return dispatch => {
-			if ( _fetching[ pluginSlug ] ) {
-				return;
-			}
-			_fetching[ pluginSlug ] = true;
+export function fetchPluginData( pluginSlug ) {
+	return dispatch => {
+		if ( _fetching[ pluginSlug ] ) {
+			return;
+		}
+		_fetching[ pluginSlug ] = true;
 
-			setTimeout( () => {
-				dispatch( {
-					type: FETCH_WPORG_PLUGIN_DATA,
-					pluginSlug: pluginSlug,
-				} );
-			}, 1 );
-
-			wporg.fetchPluginInformation( pluginSlug, function( error, data ) {
-				_fetching[ pluginSlug ] = null;
-				debug( 'plugin details fetched from .org', pluginSlug, error, data );
-
-				dispatch( {
-					type: WPORG_PLUGIN_DATA_RECEIVE,
-					pluginSlug: pluginSlug,
-					data: data ? utils.normalizePluginData( { detailsFetched: Date.now() }, data ) : null,
-					error: error,
-				} );
+		setTimeout( () => {
+			dispatch( {
+				type: FETCH_WPORG_PLUGIN_DATA,
+				pluginSlug: pluginSlug,
 			} );
-		};
-	},
-};
+		}, 1 );
+
+		wporg.fetchPluginInformation( pluginSlug, function( error, data ) {
+			_fetching[ pluginSlug ] = null;
+			debug( 'plugin details fetched from .org', pluginSlug, error, data );
+
+			dispatch( {
+				type: WPORG_PLUGIN_DATA_RECEIVE,
+				pluginSlug: pluginSlug,
+				data: data ? utils.normalizePluginData( { detailsFetched: Date.now() }, data ) : null,
+				error: error,
+			} );
+		} );
+	};
+}

--- a/client/state/plugins/wporg/test/actions.js
+++ b/client/state/plugins/wporg/test/actions.js
@@ -7,7 +7,7 @@ import { assert } from 'chai';
 /**
  * Internal dependencies
  */
-import WPorgActions from '../actions';
+import { fetchPluginData } from '../actions';
 import wporg from 'lib/wporg';
 jest.mock( 'lib/wporg', () => require( './mocks/lib/wporg' ) );
 jest.mock( 'lib/impure-lodash', () => ( {
@@ -29,16 +29,12 @@ describe( 'WPorg Data Actions', () => {
 		wporg.reset();
 	} );
 
-	test( 'Actions should be an object', () => {
-		assert.isObject( WPorgActions );
-	} );
-
 	test( 'Actions should have method fetchPluginData', () => {
-		assert.isFunction( WPorgActions.fetchPluginData );
+		assert.isFunction( fetchPluginData );
 	} );
 
 	test( 'FetchPluginData action should make a request', done => {
-		WPorgActions.fetchPluginData( 'test' )(
+		fetchPluginData( 'test' )(
 			testDispatch( function() {
 				assert.equal( wporg.getActivity().fetchPluginInformation, 1 );
 				done();
@@ -47,7 +43,7 @@ describe( 'WPorg Data Actions', () => {
 	} );
 
 	test( "FetchPluginData action shouldn't return an error", done => {
-		WPorgActions.fetchPluginData( 'test' )(
+		fetchPluginData( 'test' )(
 			testDispatch( function( action ) {
 				done( action.error );
 			}, 2 )
@@ -55,7 +51,7 @@ describe( 'WPorg Data Actions', () => {
 	} );
 
 	test( 'FetchPluginData action should return a plugin ', done => {
-		WPorgActions.fetchPluginData( 'test' )(
+		fetchPluginData( 'test' )(
 			testDispatch( function( action ) {
 				assert.equal( action.data.slug, 'test' );
 				done();
@@ -65,8 +61,8 @@ describe( 'WPorg Data Actions', () => {
 
 	test( "FetchPluginData action should not make another request if there's already one in progress", () => {
 		wporg.deactivatedCallbacks = true;
-		WPorgActions.fetchPluginData( 'test' )( function() {} );
-		WPorgActions.fetchPluginData( 'test' )( function() {} );
+		fetchPluginData( 'test' )( function() {} );
+		fetchPluginData( 'test' )( function() {} );
 		assert.equal( wporg.getActivity().fetchPluginInformation, 1 );
 	} );
 } );


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.