### PR TITLE
esmodules: Update lib/oauth-store/constants

### DIFF
--- a/client/lib/oauth-store/actions.js
+++ b/client/lib/oauth-store/actions.js
@@ -10,8 +10,7 @@ import request from 'superagent';
  * Internal dependencies
  */
 import Dispatcher from 'dispatcher';
-import { actions } from './constants';
-import { errors as errorTypes } from './constants';
+import { actions, errors as errorTypes } from './constants';
 import analytics from 'lib/analytics';
 
 export function login( username, password, auth_code ) {

--- a/client/lib/oauth-store/constants.js
+++ b/client/lib/oauth-store/constants.js
@@ -1,19 +1,12 @@
 /** @format */
 
-/**
- * External dependencies
- */
+export const actions = {
+	AUTH_LOGIN: 'AUTH_LOGIN',
+	RECEIVE_AUTH_LOGIN: 'RECEIVE_AUTH_LOGIN',
+	AUTH_RESET: 'AUTH_RESET',
+};
 
-import keyMirror from 'key-mirror';
-
-export default {
-	actions: keyMirror( {
-		AUTH_LOGIN: null,
-		RECEIVE_AUTH_LOGIN: null,
-		AUTH_RESET: null,
-	} ),
-	errors: {
-		ERROR_REQUIRES_2FA: 'needs_2fa', // From WP.com API
-		ERROR_INVALID_OTP: 'invalid_otp', // From WP.com API
-	},
+export const errors = {
+	ERROR_REQUIRES_2FA: 'needs_2fa', // From WP.com API
+	ERROR_INVALID_OTP: 'invalid_otp', // From WP.com API
 };


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.