### PR TITLE
esmodules: Update lib/impure-lodash

### DIFF
--- a/client/lib/impure-lodash/README.md
+++ b/client/lib/impure-lodash/README.md
@@ -17,7 +17,8 @@ In this new module we export a single object instead of separate named exports.
 When importing this works the same way…
 
 ```js
-import { uniqueId } from 'lib/impure-lodash';
+import impureLodash from 'lib/impure-lodash';
+const { uniqueId } = impureLodash;
 ```
 
 However, the big difference from importing from `lodash` directly is that since this export is itself an object with member methods, that object is changeable.

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -21,8 +21,10 @@ import {
 	GalleryDefaultAttrs,
 } from './constants';
 import { stringify } from 'lib/shortcode';
-import { uniqueId } from 'lib/impure-lodash';
+import impureLodash from 'lib/impure-lodash';
 import versionCompare from 'lib/version-compare';
+
+const { uniqueId } = impureLodash;
 
 /**
  * Module variables

--- a/client/lib/plugins/wporg-data/actions.js
+++ b/client/lib/plugins/wporg-data/actions.js
@@ -13,7 +13,9 @@ import Dispatcher from 'dispatcher';
 import wporg from 'lib/wporg';
 import utils from 'lib/plugins/utils';
 import CuratedPlugins from 'lib/plugins/wporg-data/curated.json';
-import { debounce } from 'lib/impure-lodash';
+import impureLodash from 'lib/impure-lodash';
+
+const { debounce } = impureLodash;
 
 /**
  * Constants

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -4,7 +4,8 @@
  * External dependencies
  */
 
-import { uniqueId } from 'lib/impure-lodash';
+import impureLodash from 'lib/impure-lodash';
+const { uniqueId } = impureLodash;
 
 /**
  * Internal dependencies


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.