### PR TITLE
esmodules: Update lib/users/actions

### DIFF
--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -17,7 +17,7 @@ import Popover from 'components/popover';
 import PopoverMenuItem from 'components/popover/menu-item';
 import UserItem from 'components/user';
 import InfiniteList from 'components/infinite-list';
-import UsersActions from 'lib/users/actions';
+import { fetchUsers } from 'lib/users/actions';
 import Search from 'components/search';
 import { hasTouch } from 'lib/touch-detect';
 
@@ -222,7 +222,7 @@ const SwitcherShell = createReactClass( {
 			offset: this.props.users.length,
 		} );
 		debug( 'fetching next batch of authors' );
-		UsersActions.fetchUsers( fetchOptions );
+		fetchUsers( fetchOptions );
 	},
 
 	_getAuthorItemGUID: function( author ) {

--- a/client/components/site-users-fetcher/index.jsx
+++ b/client/components/site-users-fetcher/index.jsx
@@ -14,13 +14,13 @@ const debug = debugFactory( 'calypso:site-users-fetcher' );
  * Internal dependencies
  */
 import UsersStore from 'lib/users/store';
-import UsersActions from 'lib/users/actions';
+import { fetchUpdated, fetchUsers } from 'lib/users/actions';
 import pollers from 'lib/data-poller';
 
 /**
  * Module variables
  */
-var defaultOptions = {
+const defaultOptions = {
 	number: 100,
 	offset: 0,
 };
@@ -37,11 +37,9 @@ export default class extends React.Component {
 		debug( 'Mounting SiteUsersFetcher' );
 		UsersStore.on( 'change', this._updateSiteUsers );
 		this._fetchIfEmpty();
-		this._poller = pollers.add(
-			UsersStore,
-			UsersActions.fetchUpdated.bind( UsersActions, this.props.fetchOptions, true ),
-			{ leading: false }
-		);
+		this._poller = pollers.add( UsersStore, () => fetchUpdated( this.props.fetchOptions ), {
+			leading: false,
+		} );
 	}
 
 	componentWillUnmount() {
@@ -57,11 +55,9 @@ export default class extends React.Component {
 			this._updateSiteUsers( nextProps.fetchOptions );
 			this._fetchIfEmpty( nextProps.fetchOptions );
 			pollers.remove( this._poller );
-			this._poller = pollers.add(
-				UsersStore,
-				UsersActions.fetchUpdated.bind( UsersActions, nextProps.fetchOptions, true ),
-				{ leading: false }
-			);
+			this._poller = pollers.add( UsersStore, () => fetchUpdated( nextProps.fetchOptions ), {
+				leading: false,
+			} );
 		}
 	}
 
@@ -122,7 +118,7 @@ export default class extends React.Component {
 			if ( paginationData.fetchingUsers ) {
 				return;
 			}
-			UsersActions.fetchUsers( fetchOptions );
+			fetchUsers( fetchOptions );
 		}, 0 );
 	};
 

--- a/client/lib/users/actions.js
+++ b/client/lib/users/actions.js
@@ -15,163 +15,159 @@ import Dispatcher from 'dispatcher';
 import wpcom from 'lib/wp';
 import UsersStore from 'lib/users/store';
 
-const UsersActions = {
-	fetchUsers: fetchOptions => {
-		const paginationData = UsersStore.getPaginationData( fetchOptions );
-		if ( paginationData.fetchingUsers ) {
-			return;
-		}
-		debug( 'fetchUsers', fetchOptions );
-		Dispatcher.handleViewAction( {
-			type: 'FETCHING_USERS',
+export function fetchUsers( fetchOptions ) {
+	const paginationData = UsersStore.getPaginationData( fetchOptions );
+	if ( paginationData.fetchingUsers ) {
+		return;
+	}
+	debug( 'fetchUsers', fetchOptions );
+	Dispatcher.handleViewAction( {
+		type: 'FETCHING_USERS',
+		fetchOptions: fetchOptions,
+	} );
+
+	wpcom.site( fetchOptions.siteId ).usersList( fetchOptions, ( error, data ) => {
+		Dispatcher.handleServerAction( {
+			type: 'RECEIVE_USERS',
 			fetchOptions: fetchOptions,
+			data: data,
+			error: error,
 		} );
+	} );
+}
 
-		wpcom.site( fetchOptions.siteId ).usersList( fetchOptions, ( error, data ) => {
-			Dispatcher.handleServerAction( {
-				type: 'RECEIVE_USERS',
-				fetchOptions: fetchOptions,
-				data: data,
-				error: error,
-			} );
-		} );
-	},
+export function fetchUpdated( fetchOptions ) {
+	const paginationData = UsersStore.getPaginationData( fetchOptions );
+	if ( paginationData.fetchingUsers ) {
+		return;
+	}
 
-	fetchUpdated: fetchOptions => {
-		const paginationData = UsersStore.getPaginationData( fetchOptions );
-		if ( paginationData.fetchingUsers ) {
-			return;
-		}
+	Dispatcher.handleViewAction( {
+		type: 'FETCHING_UPDATED_USERS',
+		fetchOptions: fetchOptions,
+	} );
 
-		Dispatcher.handleViewAction( {
-			type: 'FETCHING_UPDATED_USERS',
+	const updatedFetchOptions = UsersStore.getUpdatedParams( fetchOptions );
+	debug( 'Updated fetchOptions: ' + JSON.stringify( updatedFetchOptions ) );
+
+	wpcom.site( fetchOptions.siteId ).usersList( updatedFetchOptions, ( error, data ) => {
+		Dispatcher.handleServerAction( {
+			type: 'RECEIVE_UPDATED_USERS',
 			fetchOptions: fetchOptions,
+			data: data,
+			error: error,
 		} );
+	} );
+}
 
-		const updatedFetchOptions = UsersStore.getUpdatedParams( fetchOptions );
-		debug( 'Updated fetchOptions: ' + JSON.stringify( updatedFetchOptions ) );
+export function deleteUser( siteId, userId, reassignUserId ) {
+	debug( 'deleteUser', userId );
+	const user = UsersStore.getUser( siteId, userId );
+	if ( ! user ) {
+		return;
+	}
+	Dispatcher.handleViewAction( {
+		type: 'DELETE_SITE_USER',
+		siteId: siteId,
+		user: user,
+	} );
 
-		wpcom.site( fetchOptions.siteId ).usersList( updatedFetchOptions, ( error, data ) => {
-			Dispatcher.handleServerAction( {
-				type: 'RECEIVE_UPDATED_USERS',
-				fetchOptions: fetchOptions,
-				data: data,
-				error: error,
-			} );
+	let attributes;
+	if ( 'undefined' !== typeof reassignUserId ) {
+		attributes = {
+			reassign: reassignUserId,
+		};
+	}
+
+	wpcom
+		.undocumented()
+		.site( siteId )
+		.deleteUser( userId, attributes, ( error, data ) => {
+			if ( error || ! data.success ) {
+				Dispatcher.handleServerAction( {
+					type: 'RECEIVE_DELETE_SITE_USER_FAILURE',
+					action: 'DELETE_SITE_USER',
+					siteId: siteId,
+					user: user,
+					error: error,
+				} );
+			} else {
+				Dispatcher.handleServerAction( {
+					type: 'RECEIVE_DELETE_SITE_USER_SUCCESS',
+					action: 'DELETE_SITE_USER',
+					siteId: siteId,
+					user: user,
+					data: data,
+				} );
+			}
 		} );
-	},
+}
 
-	deleteUser: ( siteId, userId, reassignUserId ) => {
-		debug( 'deleteUser', userId );
-		const user = UsersStore.getUser( siteId, userId );
-		if ( ! user ) {
-			return;
-		}
-		Dispatcher.handleViewAction( {
-			type: 'DELETE_SITE_USER',
-			siteId: siteId,
-			user: user,
+export function updateUser( siteId, userId, attributes ) {
+	debug( 'updateUser', userId );
+	const user = UsersStore.getUser( siteId, userId ),
+		updatedUser = Object.assign( user, attributes );
+
+	if ( ! user ) {
+		return;
+	}
+
+	Dispatcher.handleViewAction( {
+		type: 'UPDATE_SITE_USER',
+		siteId: siteId,
+		user: updatedUser,
+	} );
+	wpcom
+		.undocumented()
+		.site( siteId )
+		.updateUser( userId, attributes, ( error, data ) => {
+			if ( error ) {
+				debug( 'Update user error', error );
+				Dispatcher.handleServerAction( {
+					type: 'RECEIVE_UPDATE_SITE_USER_FAILURE',
+					action: 'UPDATE_SITE_USER',
+					siteId: siteId,
+					user: user,
+					error: error,
+				} );
+			} else {
+				Dispatcher.handleServerAction( {
+					type: 'RECEIVE_UPDATE_SITE_USER_SUCCESS',
+					action: 'UPDATE_SITE_USER',
+					siteId: siteId,
+					user: user,
+					data: data,
+				} );
+			}
 		} );
+}
 
-		let attributes;
-		if ( 'undefined' !== typeof reassignUserId ) {
-			attributes = {
-				reassign: reassignUserId,
-			};
-		}
+export function fetchUser( fetchOptions, login ) {
+	debug( 'fetchUser', fetchOptions );
 
-		wpcom
-			.undocumented()
-			.site( siteId )
-			.deleteUser( userId, attributes, ( error, data ) => {
-				if ( error || ! data.success ) {
-					Dispatcher.handleServerAction( {
-						type: 'RECEIVE_DELETE_SITE_USER_FAILURE',
-						action: 'DELETE_SITE_USER',
-						siteId: siteId,
-						user: user,
-						error: error,
-					} );
-				} else {
-					Dispatcher.handleServerAction( {
-						type: 'RECEIVE_DELETE_SITE_USER_SUCCESS',
-						action: 'DELETE_SITE_USER',
-						siteId: siteId,
-						user: user,
-						data: data,
-					} );
-				}
-			} );
-	},
+	Dispatcher.handleViewAction( {
+		type: 'FETCHING_USERS',
+		fetchOptions: fetchOptions,
+	} );
 
-	updateUser: ( siteId, userId, attributes ) => {
-		debug( 'updateUser', userId );
-		const user = UsersStore.getUser( siteId, userId ),
-			updatedUser = Object.assign( user, attributes );
-
-		if ( ! user ) {
-			return;
-		}
-
-		Dispatcher.handleViewAction( {
-			type: 'UPDATE_SITE_USER',
-			siteId: siteId,
-			user: updatedUser,
+	wpcom
+		.undocumented()
+		.site( fetchOptions.siteId )
+		.getUser( login, ( error, data ) => {
+			if ( error ) {
+				Dispatcher.handleServerAction( {
+					type: 'RECEIVE_USER_FAILED',
+					fetchOptions: fetchOptions,
+					siteId: fetchOptions.siteId,
+					login: login,
+					error: error,
+				} );
+			} else {
+				Dispatcher.handleServerAction( {
+					type: 'RECEIVE_SINGLE_USER',
+					fetchOptions: fetchOptions,
+					user: data,
+				} );
+			}
 		} );
-		wpcom
-			.undocumented()
-			.site( siteId )
-			.updateUser( userId, attributes, ( error, data ) => {
-				if ( error ) {
-					debug( 'Update user error', error );
-					Dispatcher.handleServerAction( {
-						type: 'RECEIVE_UPDATE_SITE_USER_FAILURE',
-						action: 'UPDATE_SITE_USER',
-						siteId: siteId,
-						user: user,
-						error: error,
-					} );
-				} else {
-					Dispatcher.handleServerAction( {
-						type: 'RECEIVE_UPDATE_SITE_USER_SUCCESS',
-						action: 'UPDATE_SITE_USER',
-						siteId: siteId,
-						user: user,
-						data: data,
-					} );
-				}
-			} );
-	},
-
-	fetchUser: ( fetchOptions, login ) => {
-		debug( 'fetchUser', fetchOptions );
-
-		Dispatcher.handleViewAction( {
-			type: 'FETCHING_USERS',
-			fetchOptions: fetchOptions,
-		} );
-
-		wpcom
-			.undocumented()
-			.site( fetchOptions.siteId )
-			.getUser( login, ( error, data ) => {
-				if ( error ) {
-					Dispatcher.handleServerAction( {
-						type: 'RECEIVE_USER_FAILED',
-						fetchOptions: fetchOptions,
-						siteId: fetchOptions.siteId,
-						login: login,
-						error: error,
-					} );
-				} else {
-					Dispatcher.handleServerAction( {
-						type: 'RECEIVE_SINGLE_USER',
-						fetchOptions: fetchOptions,
-						user: data,
-					} );
-				}
-			} );
-	},
-};
-
-export default UsersActions;
+}

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -20,7 +20,7 @@ import FormRadio from 'components/forms/form-radio';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import AuthorSelector from 'blocks/author-selector';
-import UsersActions from 'lib/users/actions';
+import { deleteUser } from 'lib/users/actions';
 import accept from 'lib/accept';
 import analytics from 'lib/analytics';
 import Gravatar from 'components/gravatar';
@@ -118,7 +118,7 @@ class DeleteUser extends React.PureComponent {
 						'People',
 						'Clicked Confirm Remove User on Edit User Network Site'
 					);
-					UsersActions.deleteUser( this.props.siteId, this.props.user.ID );
+					deleteUser( this.props.siteId, this.props.user.ID );
 				} else {
 					analytics.ga.recordEvent(
 						'People',
@@ -142,7 +142,7 @@ class DeleteUser extends React.PureComponent {
 			reassignUserId = this.state.reassignUser.ID;
 		}
 
-		UsersActions.deleteUser( this.props.siteId, this.props.user.ID, reassignUserId );
+		deleteUser( this.props.siteId, this.props.user.ID, reassignUserId );
 		analytics.ga.recordEvent( 'People', 'Clicked Remove User on Edit User Single Site' );
 	};
 

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -18,7 +18,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import analytics from 'lib/analytics';
-import UsersActions from 'lib/users/actions';
+import { updateUser } from 'lib/users/actions';
 import userModule from 'lib/user';
 import RoleSelect from 'my-sites/people/role-select';
 
@@ -103,7 +103,7 @@ const EditUserForm = createReactClass( {
 		// Since we store 'roles' in state as a string, but user objects expect
 		// roles to be an array, if we've updated the user's role, we need to
 		// place the role in an array before updating the user.
-		UsersActions.updateUser(
+		updateUser(
 			this.props.siteId,
 			this.state.ID,
 			changedSettings.roles

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -17,12 +17,11 @@ import HeaderCake from 'components/header-cake';
 import Card from 'components/card';
 import PeopleProfile from 'my-sites/people/people-profile';
 import UsersStore from 'lib/users/store';
-import UsersActions from 'lib/users/actions';
+import { fetchUser } from 'lib/users/actions';
 import userModule from 'lib/user';
 import { protectForm } from 'lib/protect-form';
 import DeleteUser from 'my-sites/people/delete-user';
 import PeopleNotices from 'my-sites/people/people-notices';
-import PeopleLog from 'lib/people/log-store';
 import analytics from 'lib/analytics';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -46,15 +45,15 @@ export class EditTeamMemberForm extends Component {
 
 	componentDidMount() {
 		UsersStore.on( 'change', this.refreshUser );
-		PeopleLog.on( 'change', this.checkRemoveUser );
-		PeopleLog.on( 'change', this.redirectIfError );
+		PeopleLogStore.on( 'change', this.checkRemoveUser );
+		PeopleLogStore.on( 'change', this.redirectIfError );
 		this.requestUser();
 	}
 
 	componentWillUnmount() {
 		UsersStore.removeListener( 'change', this.refreshUser );
-		PeopleLog.removeListener( 'change', this.checkRemoveUser );
-		PeopleLog.removeListener( 'change', this.redirectIfError );
+		PeopleLogStore.removeListener( 'change', this.checkRemoveUser );
+		PeopleLogStore.removeListener( 'change', this.redirectIfError );
 	}
 
 	componentDidUpdate( lastProps ) {
@@ -71,7 +70,7 @@ export class EditTeamMemberForm extends Component {
 
 	requestUser = () => {
 		if ( this.props.siteId ) {
-			UsersActions.fetchUser( { siteId: this.props.siteId }, this.props.userLogin );
+			fetchUser( { siteId: this.props.siteId }, this.props.userLogin );
 		}
 	};
 
@@ -102,7 +101,7 @@ export class EditTeamMemberForm extends Component {
 			return;
 		}
 
-		const removeUserSuccessful = PeopleLog.getCompleted( log => {
+		const removeUserSuccessful = PeopleLogStore.getCompleted( log => {
 			return (
 				'RECEIVE_DELETE_SITE_USER_SUCCESS' === log.action &&
 				this.props.siteId === log.siteId &&
@@ -116,7 +115,7 @@ export class EditTeamMemberForm extends Component {
 			page.redirect( redirect );
 		}
 
-		const removeUserInProgress = PeopleLog.getInProgress(
+		const removeUserInProgress = PeopleLogStore.getInProgress(
 			function( log ) {
 				return (
 					'DELETE_SITE_USER' === log.action &&

--- a/client/my-sites/people/team-list/team.jsx
+++ b/client/my-sites/people/team-list/team.jsx
@@ -13,7 +13,7 @@ import debugFactory from 'debug';
  */
 import Card from 'components/card';
 import PeopleListItem from 'my-sites/people/people-list-item';
-import UsersActions from 'lib/users/actions';
+import { fetchUsers } from 'lib/users/actions';
 import InfiniteList from 'components/infinite-list';
 import NoResults from 'my-sites/no-results';
 import analytics from 'lib/analytics';
@@ -127,7 +127,7 @@ class Team extends React.Component {
 		const fetchOptions = Object.assign( {}, this.props.fetchOptions, { offset: offset } );
 		analytics.ga.recordEvent( 'People', 'Fetched more users with infinite list', 'offset', offset );
 		debug( 'fetching next batch of users' );
-		UsersActions.fetchUsers( fetchOptions );
+		fetchUsers( fetchOptions );
 	};
 
 	_getPersonRef = user => {


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.