### PR TITLE
esmodules: Update state/sites/plans/assembler

### DIFF
--- a/client/state/sites/plans/assembler.js
+++ b/client/state/sites/plans/assembler.js
@@ -6,7 +6,7 @@
 
 import moment from 'moment';
 
-const createSitePlanObject = plan => {
+export const createSitePlanObject = plan => {
 	if ( ! plan ) {
 		return {};
 	}
@@ -42,8 +42,4 @@ const createSitePlanObject = plan => {
 			: null,
 		userIsOwner: Boolean( plan.user_is_owner ),
 	};
-};
-
-export default {
-	createSitePlanObject,
 };


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.