### PR TITLE
esmodules: Update state/jetpack-sync/actions

### DIFF
--- a/client/state/jetpack-sync/actions.js
+++ b/client/state/jetpack-sync/actions.js
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import debugModule from 'debug';
 import { pick } from 'lodash';
 
@@ -25,60 +23,58 @@ import {
  */
 const debug = debugModule( 'calypso:state:jetpack-sync:actions' );
 
-export default {
-	getSyncStatus( siteId ) {
-		return dispatch => {
-			debug( 'Getting sync status for: ' + siteId );
-			dispatch( {
-				type: JETPACK_SYNC_STATUS_REQUEST,
-				siteId,
-			} );
+export function getSyncStatus( siteId ) {
+	return dispatch => {
+		debug( 'Getting sync status for: ' + siteId );
+		dispatch( {
+			type: JETPACK_SYNC_STATUS_REQUEST,
+			siteId,
+		} );
 
-			return wpcom
-				.undocumented()
-				.getJetpackSyncStatus( siteId )
-				.then( data => {
-					dispatch( {
-						type: JETPACK_SYNC_STATUS_SUCCESS,
-						siteId,
-						data,
-					} );
-				} )
-				.catch( error => {
-					dispatch( {
-						type: JETPACK_SYNC_STATUS_ERROR,
-						siteId,
-						error: pick( error, [ 'error', 'status', 'message' ] ),
-					} );
+		return wpcom
+			.undocumented()
+			.getJetpackSyncStatus( siteId )
+			.then( data => {
+				dispatch( {
+					type: JETPACK_SYNC_STATUS_SUCCESS,
+					siteId,
+					data,
 				} );
-		};
-	},
-
-	scheduleJetpackFullysync( siteId ) {
-		return dispatch => {
-			debug( 'Requesting full sync for: ' + siteId );
-			dispatch( {
-				type: JETPACK_SYNC_START_REQUEST,
-				siteId,
-			} );
-
-			return wpcom
-				.undocumented()
-				.scheduleJetpackFullysync( siteId )
-				.then( data => {
-					dispatch( {
-						type: JETPACK_SYNC_START_SUCCESS,
-						siteId,
-						data,
-					} );
-				} )
-				.catch( error => {
-					dispatch( {
-						type: JETPACK_SYNC_START_ERROR,
-						siteId,
-						error: pick( error, [ 'error', 'status', 'message' ] ),
-					} );
+			} )
+			.catch( error => {
+				dispatch( {
+					type: JETPACK_SYNC_STATUS_ERROR,
+					siteId,
+					error: pick( error, [ 'error', 'status', 'message' ] ),
 				} );
-		};
-	},
-};
+			} );
+	};
+}
+
+export function scheduleJetpackFullysync( siteId ) {
+	return dispatch => {
+		debug( 'Requesting full sync for: ' + siteId );
+		dispatch( {
+			type: JETPACK_SYNC_START_REQUEST,
+			siteId,
+		} );
+
+		return wpcom
+			.undocumented()
+			.scheduleJetpackFullysync( siteId )
+			.then( data => {
+				dispatch( {
+					type: JETPACK_SYNC_START_SUCCESS,
+					siteId,
+					data,
+				} );
+			} )
+			.catch( error => {
+				dispatch( {
+					type: JETPACK_SYNC_START_ERROR,
+					siteId,
+					error: pick( error, [ 'error', 'status', 'message' ] ),
+				} );
+			} );
+	};
+}

--- a/client/state/jetpack-sync/test/actions.js
+++ b/client/state/jetpack-sync/test/actions.js
@@ -16,19 +16,16 @@ import {
 	JETPACK_SYNC_STATUS_SUCCESS,
 	JETPACK_SYNC_STATUS_ERROR,
 } from 'state/action-types';
+import { getSyncStatus, scheduleJetpackFullysync } from '../actions';
 import useNock from 'test/helpers/use-nock';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'actions', () => {
-	let actions, sandbox, spy;
+	let sandbox, spy;
 
 	useSandbox( newSandbox => {
 		sandbox = newSandbox;
 		spy = sandbox.spy();
-	} );
-
-	beforeEach( () => {
-		actions = require( '../actions' );
 	} );
 
 	describe( '#getSyncStatus()', () => {
@@ -72,8 +69,6 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch request action when thunk triggered', () => {
-				const { getSyncStatus } = actions;
-
 				getSyncStatus( siteId )( spy );
 				expect( spy ).to.have.been.calledWith( {
 					siteId: siteId,
@@ -82,8 +77,6 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch success action when request completes', () => {
-				const { getSyncStatus } = actions;
-
 				return getSyncStatus( siteId )( spy ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						siteId: siteId,
@@ -112,8 +105,6 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch receive action when request completes', () => {
-				const { getSyncStatus } = actions;
-
 				return getSyncStatus( siteId )( spy ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						error: {
@@ -145,8 +136,6 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch request action when thunk triggered', () => {
-				const { scheduleJetpackFullysync } = actions;
-
 				scheduleJetpackFullysync( siteId )( spy );
 				expect( spy ).to.have.been.calledWith( {
 					siteId: siteId,
@@ -155,8 +144,6 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch success action when request completes', () => {
-				const { scheduleJetpackFullysync } = actions;
-
 				return scheduleJetpackFullysync( siteId )( spy ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						siteId: siteId,
@@ -185,8 +172,6 @@ describe( 'actions', () => {
 			} );
 
 			test( 'should dispatch receive action when request completes', () => {
-				const { scheduleJetpackFullysync } = actions;
-
 				return scheduleJetpackFullysync( siteId )( spy ).then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						error: {


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.