### PR TITLE
Extensions: Zoninator - Implement the data layer for Zoninator's zone locks

### DIFF
--- a/client/extensions/zoninator/state/data-layer/index.js
+++ b/client/extensions/zoninator/state/data-layer/index.js
@@ -7,12 +7,13 @@
 import { mergeHandlers } from 'state/action-watchers/utils';
 import { addHandlers } from 'state/data-layer/extensions-middleware';
 import feeds from './feeds';
+import locks from './locks';
 import zones from './zones';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'zoninator:errors' );
 
-const handlers = mergeHandlers( feeds, zones );
+const handlers = mergeHandlers( feeds, locks, zones );
 
 export default function installActionHandlers() {
 	const added = addHandlers( 'zoninator', handlers );

--- a/client/extensions/zoninator/state/data-layer/locks/index.js
+++ b/client/extensions/zoninator/state/data-layer/locks/index.js
@@ -1,0 +1,60 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { errorNotice, removeNotice } from 'state/notices/actions';
+import { fromApi } from './utils';
+import { requestLockError, updateLock } from '../../locks/actions';
+import { ZONINATOR_REQUEST_LOCK } from 'zoninator/state/action-types';
+
+const updateLockNotice = 'zoninator-update-lock';
+
+export const requestZoneLock = ( { dispatch }, action ) => {
+	const { siteId, zoneId } = action;
+
+	dispatch( removeNotice( updateLockNotice ) );
+	dispatch(
+		http(
+			{
+				method: 'POST',
+				path: `/jetpack-blogs/${ siteId }/rest-api/`,
+				query: {
+					path: `/zoninator/v1/zones/${ zoneId }/lock&_method=PUT`,
+				},
+			},
+			action
+		)
+	);
+};
+
+export const handleLockSuccess = ( { dispatch }, { siteId, zoneId }, response ) => {
+	const lock = fromApi( response.data );
+	dispatch( updateLock( siteId, zoneId, lock.expires, lock.maxLockPeriod ) );
+};
+
+export const handleLockFailure = ( { dispatch }, { siteId, zoneId } ) => {
+	dispatch( requestLockError( siteId, zoneId ) );
+	dispatch(
+		errorNotice( translate( 'This zone is currently locked. Please try again later.' ), {
+			id: updateLockNotice,
+		} )
+	);
+};
+
+const dispatchCreateLockRequest = dispatchRequest(
+	requestZoneLock,
+	handleLockSuccess,
+	handleLockFailure
+);
+
+export default {
+	[ ZONINATOR_REQUEST_LOCK ]: [ dispatchCreateLockRequest ],
+};

--- a/client/extensions/zoninator/state/data-layer/locks/index.js
+++ b/client/extensions/zoninator/state/data-layer/locks/index.js
@@ -1,60 +1,31 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { translate } from 'i18n-calypso';
-
-/**
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { errorNotice, removeNotice } from 'state/notices/actions';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { fromApi } from './utils';
 import { requestLockError, updateLock } from '../../locks/actions';
 import { ZONINATOR_REQUEST_LOCK } from 'zoninator/state/action-types';
 
-const updateLockNotice = 'zoninator-update-lock';
-
-export const requestZoneLock = ( { dispatch }, action ) => {
-	const { siteId, zoneId } = action;
-
-	dispatch( removeNotice( updateLockNotice ) );
-	dispatch(
-		http(
-			{
-				method: 'POST',
-				path: `/jetpack-blogs/${ siteId }/rest-api/`,
-				query: {
-					path: `/zoninator/v1/zones/${ zoneId }/lock&_method=PUT`,
-				},
+export const fetch = action =>
+	http(
+		{
+			method: 'POST',
+			path: `/jetpack-blogs/${ action.siteId }/rest-api/`,
+			query: {
+				path: `/zoninator/v1/zones/${ action.zoneId }/lock&_method=PUT`,
 			},
-			action
-		)
+		},
+		action
 	);
-};
 
-export const handleLockSuccess = ( { dispatch }, { siteId, zoneId }, response ) => {
-	const lock = fromApi( response.data );
-	dispatch( updateLock( siteId, zoneId, lock.expires, lock.maxLockPeriod ) );
-};
+export const onSuccess = ( { siteId, zoneId }, lock ) =>
+	updateLock( siteId, zoneId, lock.expires, lock.maxLockPeriod );
 
-export const handleLockFailure = ( { dispatch }, { siteId, zoneId } ) => {
-	dispatch( requestLockError( siteId, zoneId ) );
-	dispatch(
-		errorNotice( translate( 'This zone is currently locked. Please try again later.' ), {
-			id: updateLockNotice,
-		} )
-	);
-};
-
-const dispatchCreateLockRequest = dispatchRequest(
-	requestZoneLock,
-	handleLockSuccess,
-	handleLockFailure
-);
+export const onError = ( { siteId, zoneId } ) => requestLockError( siteId, zoneId );
 
 export default {
-	[ ZONINATOR_REQUEST_LOCK ]: [ dispatchCreateLockRequest ],
+	[ ZONINATOR_REQUEST_LOCK ]: [ dispatchRequestEx( { fetch, fromApi, onSuccess, onError } ) ],
 };

--- a/client/extensions/zoninator/state/data-layer/locks/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/locks/test/index.js
@@ -1,0 +1,101 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { translate } from 'i18n-calypso';
+import { omit } from 'lodash';
+import sinon from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { requestZoneLock, handleLockSuccess, handleLockFailure } from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { errorNotice, removeNotice } from 'state/notices/actions';
+import { requestLock, requestLockError, updateLock } from 'zoninator/state/locks/actions';
+
+describe( '#requestZoneLock()', () => {
+	test( 'should dispatch a HTTP request to the lock endpoint', () => {
+		const dispatch = sinon.spy();
+		const action = {
+			type: 'DUMMY_ACTION',
+			siteId: 123,
+			zoneId: 456,
+		};
+
+		requestZoneLock( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledWith(
+			http(
+				{
+					method: 'POST',
+					path: '/jetpack-blogs/123/rest-api/',
+					query: {
+						path: '/zoninator/v1/zones/456/lock&_method=PUT',
+					},
+				},
+				action
+			)
+		);
+	} );
+
+	test( 'should dispatch `removeNotice`', () => {
+		const dispatch = sinon.spy();
+		const action = {
+			type: 'DUMMY_ACTION',
+			siteId: 123,
+			zoneId: 456,
+		};
+
+		requestZoneLock( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledWith( removeNotice( 'zoninator-update-lock' ) );
+	} );
+} );
+
+describe( '#handleLockSuccess()', () => {
+	const response = {
+		data: {
+			timeout: 30,
+			max_lock_period: 600,
+		},
+	};
+
+	test( 'should dispatch `updateLock`', () => {
+		const dispatch = sinon.spy();
+		const action = requestLock( 123, 456, true );
+
+		handleLockSuccess( { dispatch }, action, response );
+
+		expect( dispatch ).to.have.been.calledOnce;
+		expect( dispatch ).to.have.been.calledWithMatch(
+			omit( updateLock( 123, 456, 30000, 600000, true ), [ 'expires' ] )
+		);
+	} );
+} );
+
+describe( '#handleLockFailure()', () => {
+	test( 'should dispatch `requestLockError`', () => {
+		const dispatch = sinon.spy();
+		const action = requestLock( 123, 456 );
+
+		handleLockFailure( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledWith( requestLockError( 123, 456, true ) );
+	} );
+
+	test( 'should dispatch `errorNotice` if the locking process fails', () => {
+		const dispatch = sinon.spy();
+		const action = requestLock( 123, 456, false );
+
+		handleLockFailure( { dispatch }, action, {} );
+
+		expect( dispatch ).to.have.been.calledWith(
+			errorNotice( translate( 'This zone is currently locked. Please try again later.' ), {
+				id: 'zoninator-update-lock',
+			} )
+		);
+	} );
+} );

--- a/client/extensions/zoninator/state/data-layer/locks/test/utils.js
+++ b/client/extensions/zoninator/state/data-layer/locks/test/utils.js
@@ -21,8 +21,8 @@ describe( 'utils', () => {
 			const lock = fromApi( response );
 
 			expect( lock ).to.have.keys( [ 'expires', 'maxLockPeriod' ] );
-			expect( lock.maxLockPeriod ).to.deep.equal( 600000 ),
-				expect( lock.expires ).to.be.within( now + 30000, now + 31000 );
+			expect( lock.maxLockPeriod ).to.deep.equal( 600000 );
+			expect( lock.expires ).to.be.within( now + 30000, now + 31000 );
 		} );
 	} );
 } );

--- a/client/extensions/zoninator/state/data-layer/locks/test/utils.js
+++ b/client/extensions/zoninator/state/data-layer/locks/test/utils.js
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { fromApi } from '../utils';
+
+describe( 'utils', () => {
+	describe( '#fromApi()', () => {
+		test( 'should parse expiration time and maximum lock period into milliseconds', () => {
+			const response = {
+				timeout: 30,
+				max_lock_period: 600,
+			};
+			const now = new Date().getTime();
+			const lock = fromApi( response );
+
+			expect( lock ).to.have.keys( [ 'expires', 'maxLockPeriod' ] );
+			expect( lock.maxLockPeriod ).to.deep.equal( 600000 ),
+				expect( lock.expires ).to.be.within( now + 30000, now + 31000 );
+		} );
+	} );
+} );

--- a/client/extensions/zoninator/state/data-layer/locks/utils.js
+++ b/client/extensions/zoninator/state/data-layer/locks/utils.js
@@ -1,0 +1,4 @@
+export const fromApi = ( { timeout, max_lock_period } ) => ( {
+	expires: new Date().getTime() + timeout * 1000,
+	maxLockPeriod: max_lock_period * 1000,
+} );

--- a/client/extensions/zoninator/state/locks/actions.js
+++ b/client/extensions/zoninator/state/locks/actions.js
@@ -16,7 +16,7 @@ import {
  * @param  {Number}  siteId          Site ID
  * @param  {Number}  zoneId          Zone ID
  * @param  {Number}  expires         Expiration time in milliseconds
- * @param  {Number}  maxLockPeriod   Maximum number of seconds to extend the lock to
+ * @param  {Number}  maxLockPeriod   Maximum number of milliseconds to extend the lock to
  * @return {Object}                  Action object
  */
 export const updateLock = ( siteId, zoneId, expires, maxLockPeriod ) => ( {


### PR DESCRIPTION
This PR implements the data-layer needed to request zone locks in the Zoninator extension.

It's fairly straight forward - requesting a lock and dispatching an `updateLock` action when successful and `requestLockError` otherwise.  
No error notices are displayed on error. That'll be handled specifically in the Edit Zone UI as you won't be able to make any changes as long as the lock isn't successful.

The lock endpoint is implemented in Automattic/zoninator#64.

# Testing

`npm run test-client client/extensions/zoninator/state/data-layer/locks`