### PR TITLE
Extensions: Zoninator - Add a ZoneLock data component

### DIFF
--- a/client/extensions/zoninator/components/data/zone-lock/index.jsx
+++ b/client/extensions/zoninator/components/data/zone-lock/index.jsx
@@ -1,0 +1,92 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getRequest } from 'state/selectors';
+import { requestLock, resetLock } from '../../../state/locks/actions';
+import { created, expires, maxLockPeriod } from '../../../state/locks/selectors';
+
+class ZoneLock extends PureComponent {
+	static propTypes = {
+		created: PropTypes.number,
+		expires: PropTypes.number,
+		maxLockPeriod: PropTypes.number,
+		request: PropTypes.shape( {
+			isLoading: PropTypes.bool,
+		} ),
+		requestLock: PropTypes.func.isRequired,
+		resetLock: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
+		zoneId: PropTypes.number.isRequired,
+	};
+
+	componentWillMount() {
+		this.resetLock( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.siteId === nextProps.siteId && this.props.zoneId === nextProps.zoneId ) {
+			this.scheduleRefresh( nextProps );
+			return;
+		}
+
+		this.resetLock( nextProps );
+	}
+
+	componentWillUnmount() {
+		this._refresh && clearTimeout( this._refresh );
+		this._refresh = null;
+	}
+
+	resetLock( props ) {
+		this.requestLock( props );
+		this.props.resetLock( props.siteId, props.zoneId );
+	}
+
+	requestLock( props ) {
+		const { request, siteId, zoneId } = props;
+		! request.isLoading && siteId && zoneId && props.requestLock( siteId, zoneId );
+	}
+
+	scheduleRefresh( props ) {
+		if ( ! this.shouldRefresh( props ) ) {
+			return;
+		}
+
+		// Request a refresh one second before the current lock expires
+		this._refresh = setTimeout( () => {
+			this._refresh = null;
+			this.requestLock( props );
+		}, props.expires - new Date().getTime() - 1000 );
+	}
+
+	shouldRefresh = ( props ) =>
+		! this._refresh &&
+		props.expires &&
+		new Date().getTime() < props.expires &&
+		props.expires < props.created + props.maxLockPeriod;
+
+	render() {
+		return null;
+	}
+}
+
+const connectComponent = connect(
+	( state, { siteId, zoneId } ) => ( {
+		created: created( state, siteId, zoneId ),
+		expires: expires( state, siteId, zoneId ),
+		maxLockPeriod: maxLockPeriod( state, siteId, zoneId ),
+		request: getRequest( state, requestLock( siteId, zoneId ) ),
+	} ),
+	{ requestLock, resetLock }
+);
+
+export default connectComponent( ZoneLock );

--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -20,6 +20,7 @@ import DeleteZoneDialog from './delete-zone-dialog';
 import QueryFeed from '../../data/query-feed';
 import ZoneContentForm from '../../forms/zone-content-form';
 import ZoneDetailsForm from '../../forms/zone-details-form';
+import ZoneLock from '../../data/zone-lock';
 import ZoneNotFound from './zone-not-found';
 import { saveFeed } from '../../../state/feeds/actions';
 import { deleteZone, saveZone } from '../../../state/zones/actions';
@@ -106,6 +107,7 @@ class Zone extends Component {
 		return (
 			<div>
 				{ siteId && zoneId && <QueryFeed siteId={ siteId } zoneId={ zoneId } /> }
+				{ siteId && zoneId && <ZoneLock siteId={ siteId } zoneId={ zoneId } /> }
 
 				<HeaderCake
 					backHref={ `${ settingsPath }/${ siteSlug }` }

--- a/client/extensions/zoninator/state/data-layer/locks/test/utils.js
+++ b/client/extensions/zoninator/state/data-layer/locks/test/utils.js
@@ -14,8 +14,10 @@ describe( 'utils', () => {
 	describe( '#fromApi()', () => {
 		test( 'should parse expiration time and maximum lock period into milliseconds', () => {
 			const response = {
-				timeout: 30,
-				max_lock_period: 600,
+				data: {
+					timeout: 30,
+					max_lock_period: 600,
+				},
 			};
 			const now = new Date().getTime();
 			const lock = fromApi( response );

--- a/client/extensions/zoninator/state/data-layer/locks/utils.js
+++ b/client/extensions/zoninator/state/data-layer/locks/utils.js
@@ -1,4 +1,4 @@
-export const fromApi = ( { timeout, max_lock_period } ) => ( {
+export const fromApi = ( { data: { max_lock_period, timeout } } ) => ( {
 	expires: new Date().getTime() + timeout * 1000,
 	maxLockPeriod: max_lock_period * 1000,
 } );


### PR DESCRIPTION
This PR adds a `ZoneLock` data component that is used on *Edit Zone* page. It's purpose is to initially request a lock for the zone when a user enters the page as well as ping the server every `n` seconds until `maxLockPeriod` is reached according to the parameters in the response.  
A notice of when a zone lock has expired will be implemented in a separate PR.

# Testing

Requires checking out `update/restore-lock-zone-endpoint` branch of `Automattic/zoninator` on the server.

- Open devtools and go to `/extensions/zoninator` and select a zone.
- You should see an outgoing request to `/zoninator/v1/zones/{id}/lock&_method=PUT`.
- If the response is successful, the request should repeat after around 30 seconds ( the default for the plugin ).