### PR TITLE
Documentation: Unit tests

### DIFF
--- a/docs/testing/testing-overview.md
+++ b/docs/testing/testing-overview.md
@@ -87,16 +87,6 @@ We use [Jest](https://facebook.github.io/jest/) testing tool to execute all test
 Historically we have been using [Mocha](https://mochajs.org/) with [Chai assertions](http://chaijs.com/) and [Sinon mocks](http://sinonjs.org/). We still support Chai and Sinon for backward compatibility reasons, but Jest equivalents should be used whenever new tests are added.
 
 End-to-end tests are still using Mocha to run tests.
- 
-##### How to add a new test file?
-
-We should use the same file names as the implementation files for the tests.
-Example: if we want to write unit tests covering the file `hello-world/index.jsx`, we should name a test file `hello-world/test/index.jsx`.
-
-If we ever need to add non-test files to a `test` folder, we should put them in a deeper level. Common choices are:
-
-* `test/mocks/name.js` for test mocks
-* `test/fixtures/name.js` for test data
 
 ##### How to run all tests?
 

--- a/docs/testing/testing-overview.md
+++ b/docs/testing/testing-overview.md
@@ -49,6 +49,9 @@ Tests can be run in 3 different modes:
 
 They are executed on every push on continuous integration (CircleCI). This is why all individual tests need to be blazing fast. Please note that network connection is disabled for this configuration.
 
+Often your changes will affect other parts of the application, so it's a good idea to run all the unit tests locally before checking in.
+
+
 _Check also how to write [unit tests](unit-tests.md) and [component tests](component-tests.md)._
 
 ### Integration tests
@@ -121,17 +124,17 @@ Example for client:
 The exclusivity feature allows you to run only the specified suite or test-case by appending `.only()` to the function.
 It works with `describe` and `it` functions. More details in [Jest documentation](https://facebook.github.io/jest/docs/api.html).
 
-Using `only` is a little bit dangerous, as you may end up committing the `only`, which would cause the test suite to only run your test on the build server. So be sure to look for stray only calls when reviewing a test. We have an `eslint` rule in the works that should catch them for you.
+Using `only` is a little bit dangerous, as you may end up committing the `only`, which would cause the test suite to only run your test on the build server. So be sure to look for stray only calls when reviewing a test. We have [eslint rules](https://github.com/jest-community/eslint-plugin-jest) that should catch them for you.
 
 Example:
 
 ```js
 describe.only( 'just run this suite', function() {
-	it( 'should run these tests', function() {
+	test( 'should run these tests', function() {
 		// your test
 	} );
 
-	it.only( 'should only run this one test', function() {
+	test.only( 'should only run this one test', function() {
 		// just run this test if the only is present
 	} );
 } );

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -9,7 +9,6 @@ This guide is intended as a quick reference of common tools and conventions we u
 * [Writing tests](writing-tests)
     * [Folder structure](#folder-structure)
     * [Describing tests](#describing-tests)
-    * [Mocking HTTP requests with nock](#mocking-http-requests-with nock)
     * [Snapshot testing](#snapshot-testing)
 * [Examples](#examples)
 

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -7,55 +7,21 @@ This guide is intended as a quick reference of common tools and conventions we u
 ## Table of contents
 * [Running tests](running-tests)
 * [Writing tests](writing-tests)
-    * [Describing tests](#describing-tests)
     * [Folder structure](#folder-structure)
+    * [Describing tests](#describing-tests)
     * [Mocking HTTP requests with nock](#mocking-http-requests-with nock)
-
-## What should I unit test?
-We assume you've Googled the 'why' of unit testing, but sometimes deciding __what__ to unit test is more difficult. 
-
-If your code were to break or receive unexpected input, what side-effects would the rest of the application experience?
+    * [Snapshot testing](#snapshot-testing)
+* [Examples](#examples)
 
 ## Running tests
 
-To execute all client side tests, run the following command in the root of the project folder:
-
-```bash
-npm run test-client
-```
-
-You can also run all tests in a specific directory or matching pattern, for example:
-
-```bash
-# run test suites for all files in a specific folder
-npm run test-client client/lib/domains
-
-# run test suites for all files matching pattern
-npm run test-client client/*/domains
-```
-
-To run a __specific suite or test__, append `.only() ` to the `describe` and `test` functions:
-
-```javascript
-describe.only( 'just run this suite', function() {
-	test( 'should run these tests', function() {
-		// your test
-	} );
-
-	test.only( 'should only run this one test', function() {
-		// just run this test if the only is present
-	} );
-} );
-```
-**Note:** Be careful not to check in tests when using the `only()` feature, otherwise the build server will __only__ run those suites or tests.
-
-[eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) runs over all tests files, and will catch common errors. Often your changes will affect other parts of the application, so it's a good idea to run all the unit tests locally before checking in.
+See [testing-overview.md](testing-overview.md).
 
 ## Writing tests
-We use [Jest](https://facebook.github.io/jest) for testing our client-side application, and [Enzyme](https://github.com/airbnb/enzyme) for testing React components.
+
+We use [Jest](https://facebook.github.io/jest) testing framework for unit tests, and [Enzyme](https://github.com/airbnb/enzyme) for testing React components. You can find more information on testing components at [component tests](component-tests.md)._
 
 Though you'll still see Chai assertions and Sinon spies/mocks throughout the code base, for all new tests we use the Jest API for [globals](https://facebook.github.io/jest/docs/en/mock-function-api.html#content) (`describe`, `test`, `beforeEach` and so on) [assertions](http://facebook.github.io/jest/docs/en/expect.html#content), [mocks](http://facebook.github.io/jest/docs/en/mock-functions.html#content) and [mock function/spies](https://facebook.github.io/jest/docs/en/mock-function-api.html#content).
-
 
 ## Folder structure
 Keep your tests in a `test` folder in your working directory. The test file should have the same name as the test subject file, and use the extension `.js`.
@@ -69,7 +35,7 @@ Keep your tests in a `test` folder in your working directory. The test file shou
 ### Describing tests
 Use 'describe' block to group test cases. Each test case should ideally describe one behaviour only.
 
-In test cases, try to describe in plain words the expected behaviour For UI components, this might entail describing expected behaviour from a user perspective rather than explaining code internals.
+In test cases, try to describe in plain words the expected behaviour. For UI components, this might entail describing expected behaviour from a user perspective rather than explaining code internals.
 
 **Good**
 
@@ -92,7 +58,7 @@ describe( 'CheckboxWithLabel', () => {
 ```
 
 ### Snapshot testing
-See[Snapshot testing](snapshot-testing.md)
+See [Snapshot testing](snapshot-testing.md)
 
 ### Examples
 
@@ -157,7 +123,7 @@ describe( 'requestSomeData', () => {
 
 #### Dependency injection
 
-Passing dependencies to a function as arguments can often make your code simpler to test. A a basic example, we have a utility function that checks whether a value exists in a list.
+Passing dependencies to a function as arguments can often make your code simpler to test. As a basic example, we have a utility function that checks whether a value exists in a list:
 
 One way to do it would be to reference a dependency in a higher scope:
 
@@ -280,5 +246,3 @@ When stubbing properties or methods in the global scope, make sure to cache the 
 	    // some test cases ...
 	} );	
 ```
-
-### Debugging tests (?)

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -256,6 +256,29 @@ Or event just stub out libraries whose effects we might not care about:
 
 `jest.mock( 'lib/analytics', () => ( {} ) );`
 
-### Mocking global objects
+#### Global objects
+
+When stubbing properties or methods in the global scope, make sure to cache the original value and reinstate it after the tests have completed. This way we avoid breaking other test suites that may rely on them.
+
+```javascript
+	describe( 'suggested languages', () => {
+		const browserLanguages = [ 'en-GB', 'en', 'en-US', 'en-AU', 'it' ];
+		let _navigator;
+
+		beforeEach( () => {
+			_navigator = global.navigator;
+			Object.defineProperty( global.navigator, 'languages', {
+				get: () => browserLanguages,
+				configurable: true,
+			} );
+		} );
+
+		afterEach( () => {
+			global.navigator = _navigator;
+		} );
+	    
+	    // some test cases ...
+	} );	
+```
 
 ### Debugging tests (?)

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -67,7 +67,7 @@ Keep your tests in a `test` folder in your working directory. The test file shou
 ```
 
 ### Describing tests
-User 'describe' block to group test cases. Each test case should ideally describe one behaviour only.
+Use 'describe' block to group test cases. Each test case should ideally describe one behaviour only.
 
 In test cases, try to describe in plain words the expected behaviour For UI components, this might entail describing expected behaviour from a user perspective rather than explaining code internals.
 
@@ -156,3 +156,5 @@ describe( 'requestSomeData', () => {
 ### Mocking dependencies
 
 ### Mocking global objects
+
+### Debugging tests (?)

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -1,3 +1,158 @@
 # Unit Tests
 
-TBD
+As well fostering code quality, well-written unit tests provide a fine way for developers to quickly understand how to run a piece of code, and what it does under various conditions. It's important therefore to maintain high standards not just in our source code, but in our tests as well. 
+
+This guide is intended as a quick reference of common tools and conventions we use for Calypso unit testing. You'll be able to glean a great deal from browsing through Calypso's existing tests, but we'll try to keep this page up to date with the most recent standards.
+
+## Table of contents
+* [Running tests](running-tests)
+* [Writing tests](writing-tests)
+    * [Describing tests](#describing-tests)
+    * [Folder structure](#folder-structure)
+    * [Mocking HTTP requests with nock](#mocking-http-requests-with nock)
+
+## What should I unit test?
+We assume you've Googled the 'why' of unit testing, but sometimes deciding __what__ to unit test is more difficult. 
+
+If your code were to break or receive unexpected input, what side-effects would the rest of the application experience?
+
+## Running tests
+
+To execute all client side tests, run the following command in the root of the project folder:
+
+```bash
+npm run test-client
+```
+
+You can also run all tests in a specific directory or matching pattern, for example:
+
+```bash
+# run test suites for all files in a specific folder
+npm run test-client client/lib/domains
+
+# run test suites for all files matching pattern
+npm run test-client client/*/domains
+```
+
+To run a __specific suite or test__, append `.only() ` to the `describe` and `test` functions:
+
+```javascript
+describe.only( 'just run this suite', function() {
+	test( 'should run these tests', function() {
+		// your test
+	} );
+
+	test.only( 'should only run this one test', function() {
+		// just run this test if the only is present
+	} );
+} );
+```
+**Note:** Be careful not to check in tests when using the `only()` feature, otherwise the build server will __only__ run those suites or tests.
+
+[eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) runs over all tests files, and will catch common errors. Often your changes will affect other parts of the application, so it's a good idea to run all the unit tests locally before checking in.
+
+## Writing tests
+We use [Jest](https://facebook.github.io/jest) for testing our client-side application, and [Enzyme](https://github.com/airbnb/enzyme) for testing React components.
+
+Though you'll still see Chai assertions and Sinon spies/mocks throughout the code base, for all new tests we use the Jest API for [assertions](http://facebook.github.io/jest/docs/en/expect.html#content), [mocks](http://facebook.github.io/jest/docs/en/mock-functions.html#content) and [mock function/spies](http://facebook.github.io/jest/docs/en/mock-function-api.html#content).
+
+
+## Folder structure
+Keep your tests in a `test` folder in your working directory. The test file should have the same name as the test subject file, and use the extension `.js`.
+
+```
++-- test
+|   +-- index.js
++-- index.jsx
+```
+
+### Describing tests
+User 'describe' block to group test cases. Each test case should ideally describe one behaviour only.
+
+In test cases, try to describe in plain words the expected behaviour For UI components, this might entail describing expected behaviour from a user perspective rather than explaining code internals.
+
+**Good**
+
+```javascript
+describe( 'CheckboxWithLabel', () => {
+    test('checking checkbox should disable the form submit button', () => {
+        ...
+    } );
+} );
+```
+
+**Not so good**
+
+```javascript
+describe( 'CheckboxWithLabel', () => {
+    test('checking checkbox should set this.state.disableButton to `true`', () => {
+        ...
+    } );
+} );
+```
+
+### Snapshot testing
+See[Snapshot testing](snapshot-testing.md)
+
+### Examples
+
+#### Mocking HTTP requests
+
+[Nock](https://github.com/node-nock/nock) allows us to override HTTP requests, and unit test code in isolation. For example, you might have an action  that returns a GET request in a thunk:
+
+```javascript
+// action.js
+export function requestSomeData() {
+	return dispatch => {
+		return wpcom
+            .getSomeData()
+            .then( data => {
+				dispatch( {
+					type: SOME_DATA_SUCCESS,
+					data,
+				} );
+			} )
+			.catch( error => {
+				dispatch( {
+					type: SOME_DATA_FAILURE,
+					error,
+				} );
+			} );
+	};
+}
+```
+
+To mock this response, we can specify the nock parameters in a describe block and use `persist()` to intercept all requests in that block.
+
+Here's a simple example:
+
+```javascript
+import { requestSomeData } from '../actions';
+import useNock from 'test/helpers/use-nock';
+
+describe( 'requestSomeData', () => {
+	describe( 'successful response', () => {
+		useNock( nock => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.get( '/rest/v1.1/some-endpoint' )
+				.reply( 200, { hoo: 'ray!' } );
+		} );
+
+		test( 'dispatches success action object when successful request is completed', () => {
+			const mockDispatchCallback = jest.fn();
+            // Trigger the action to return the thunk
+			requestSomeData()( mockDispatchCallback ).then( () => {
+                expect( mockDispatchCallback.mock.calls[ 0 ][ 0 ] ).toEqual( {
+                    type: SOME_DATA_SUCCESS,
+                    data: { hoo: 'ray!' }
+                } );
+            } );
+		} );
+     } );
+} );
+```
+
+### Mocking dependencies
+
+### Mocking global objects

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -13,16 +13,15 @@ This guide is intended as a quick reference of common tools and conventions we u
     * [Mocking dependencies](#mocking-dependencies)
     * [Testing globals](#testing-globals)
     * [Testing legacy code](#testing-legacy-code)
-    
+* [Further reading](#further-reading)
+
 ## Why unit test?
 
 Aside from the joy unit testing will bring to your life, unit tests are important not only because they help to ensure that our application behaves as it should, but also because they provide concise examples of how to use a piece of code. 
 
-
 Tests are also part of our code base, which means we apply to them the same standards we apply to all our application code. 
 
 As with all code, tests have to be maintained. Writing tests for the sake of having a test isn't the goal – rather we should try to strike the right balance between covering expected and unexpected behaviours, speedy execution and code maintenance.
-
 
 Unit tests test __units__ of behavior, and should contain relatively few abstractions. If our tests are failing in response to legitimate changes, it could be a sign that we have coupled our tests too closely to the internals of our code.
 
@@ -31,6 +30,7 @@ When writing unit tests consider the following:
 * What behaviour are we testing?
 * What errors are likely to occur when we run this code?
 * Does the test test what we think they are testing? Or are we introducing false positives and false negatives into our results?
+* Is it readable? Will other contributors be able to understand how our code behaves by looking at its corresponding test?
 
 ## Running tests
 
@@ -119,7 +119,10 @@ afterAll( () => {
 
 ```
 
-Though it is good practice to clean up after your tests suites, Jest tests are run in isolation so changes to things such as global values won't effect other Calypso tests.
+`afterEach` and `afterAll` provide a perfect (and preferred) way to 'clean up' after our tests, for example, by resetting state data.
+ 
+Avoid placing clean up code after assertions since, if any of those tests fail, the clean up won't take place and may cause failures in unrelated tests.
+
 
 ### Mocking dependencies
 
@@ -256,3 +259,9 @@ jest.mock( 'lib/wp', () => ( {
 	someWpComMethod: jest.fn(),
 } ) );
 ```
+
+## Further reading
+* [React testing with Jest](https://facebook.github.io/jest/docs/en/tutorial-react.html)
+* [Enyzme API](https://github.com/airbnb/enzyme/tree/master/docs/api)
+* [Test Contra-variance](http://blog.cleancoder.com/uncle-bob/2017/10/03/TestContravariance.html)
+* [The Failures of "Into to TDD"](http://blog.testdouble.com/posts/2014-01-25-the-failures-of-intro-to-tdd.html)

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -15,7 +15,7 @@ This guide is intended as a quick reference of common tools and conventions we u
 
 ## Running tests
 
-See [testing-overview.md](testing-overview.md).
+See [testing-overview.md](testing-overview.md) on how to run Calypso tests.
 
 ## Writing tests
 
@@ -80,6 +80,44 @@ describe( 'CheckboxWithLabel', () => {
 Snapshot testing is useful for verifying that any data produced during a test is not inadvertently changed. This is especially useful for large and complex data structures like component or state trees. See the [our full reference](snapshot-testing.md) for more information.
 
 ### Examples
+
+### Setup and Teardown methods
+
+The Jest API includes some nifty [setup and teardown methods](https://facebook.github.io/jest/docs/en/setup-teardown.html) that allow you to perform tasks *before* and *after* each or all of your tests, or tests within a specific `describe` block.
+
+These methods can handle asynchronous code to allow setup that you normally cannot do inline.
+
+For example, you 
+
+```javascript
+
+// one-time setup for *all* tests
+beforeAll( done => {
+    someAsyncAction()
+        .then( resp => {
+        	window.someGlobal = resp;
+        	done();
+        } );
+} );
+
+// one-time teardown for *all* tests
+afterAll( () => {
+    window.someGlobal = null;
+} );
+
+// one-time setup for *each* test
+beforeEach( () => {
+    
+} );
+
+// one-time teardown for *each* test
+afterEach( () => {
+    
+} );
+
+```
+
+Though it is good practice to clean up after your tests suites, Jest tests are run in isolation so changes to things such as global values won't effect other Calypso tests.
 
 ### Mocking dependencies
 

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -27,9 +27,9 @@ Unit tests test __units__ of behavior, and should contain relatively few abstrac
 
 When writing unit tests consider the following:
 
-* What behaviour are we testing?
+* What behaviour(s) are we testing?
 * What errors are likely to occur when we run this code?
-* Does the test test what we think they are testing? Or are we introducing false positives and false negatives into our results?
+* Does the test test what we think it is testing? Or are we introducing false positives/negatives?
 * Is it readable? Will other contributors be able to understand how our code behaves by looking at its corresponding test?
 
 ## Running tests
@@ -105,7 +105,6 @@ The Jest API includes some nifty [setup and teardown methods](https://facebook.g
 These methods can handle asynchronous code to allow setup that you normally cannot do inline. As with [individual test cases](https://facebook.github.io/jest/docs/en/asynchronous.html#promises), you can return a Promise and Jest will wait for it to resolve: 
 
 ```javascript
-
 // one-time setup for *all* tests
 beforeAll( () =>  someAsyncAction().then( resp => {
     window.someGlobal = resp;
@@ -115,8 +114,6 @@ beforeAll( () =>  someAsyncAction().then( resp => {
 afterAll( () => {
     window.someGlobal = null;
 } );
-
-
 ```
 
 `afterEach` and `afterAll` provide a perfect (and preferred) way to 'clean up' after our tests, for example, by resetting state data.
@@ -138,13 +135,11 @@ import VALID_VALUES_LIST from './constants'
 function isValueValid( value ) {
 	return VALID_VALUES_LIST.includes( value );
 }
-
 ```
 
 Here we'd have to import and use a value from `VALID_VALUES_LIST` in order to pass:
 
 `expect( isValueValid( VALID_VALUES_LIST[ 0 ] ) ).toBe( true );`
-
 
 The above assertion is testing two behaviours: 1) that the function can detect an item in a list, and 2) that it can detect an item in `VALID_VALUES_LIST`.
 
@@ -167,7 +162,6 @@ Because we're passing the list as an argument, we can pass mock  `validValuesLis
 `expect( isValueValid( 'hulk', [] ) ).toBe( false );`
 
 `expect( isValueValid( 'hulk', [ 'iron man', 'hulk' ] ) ).toBe( true );`
-
 
 #### Imported dependencies
 
@@ -203,14 +197,13 @@ describe( 'The bilbo module', () => {
 		expect( isBilboVisible() ).toBe( false );
 	} );
 } );
-
 ```
 
 ### Testing globals
 
 We can use [Jest spies](http://facebook.github.io/jest/docs/en/jest-object.html#jestspyonobject-methodname) to test code that calls global methods.
 
-When stubbing DOM properties or methods in the global scope, make sure to include `@jest-environment jsdom` the comment
+When stubbing DOM properties or methods in the global scope, make sure to include the `@jest-environment jsdom` comment to ensure there's a DOM to stub :)
 
 ```javascript
 

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -1,17 +1,36 @@
 # Unit Tests
-
-Unit tests are important because they help ensure correctness. A good unit test also provides a concise example of the usage and expected behavior of code in an isolated context. It's therefore important to maintain high standards to maximize the effectiveness of our tests.
-
 This guide is intended as a quick reference of common tools and conventions we use for Calypso unit testing. You'll be able to glean a great deal from browsing through Calypso's existing tests, but we'll try to keep this page up to date with the most recent standards.
 
 ## Table of contents
-* [Running tests](running-tests)
-* [Writing tests](writing-tests)
+* [Why unit test?](#why-unit-test)
+* [Running tests](#running-tests)
+* [Writing tests](#writing-tests)
     * [Folder structure](#folder-structure)
     * [Importing tests](#importing-tests)
     * [Describing tests](#describing-tests)
     * [Snapshot testing](#snapshot-testing)
-* [Examples](#examples)
+    * [Setup and Teardown methods](#setup-and-teardown-methods)
+    * [Mocking dependencies](#mocking-dependencies)
+    * [Testing globals](#testing-globals)
+    * [Testing legacy code](#testing-legacy-code)
+    
+## Why unit test?
+
+Aside from the joy unit testing will bring to your life, unit tests are important not only because they help to ensure that our application behaves as it should, but also because they provide concise examples of how to use a piece of code. 
+
+
+Tests are also part of our code base, which means we apply to them the same standards we apply to all our application code. 
+
+As with all code, tests have to be maintained. Writing tests for the sake of having a test isn't the goal – rather we should try to strike the right balance between covering expected and unexpected behaviours, speedy execution and code maintenance.
+
+
+Unit tests test __units__ of behavior, and should contain relatively few abstractions. If our tests are failing in response to legitimate changes, it could be a sign that we have coupled our tests too closely to the internals of our code.
+
+When writing unit tests consider the following:
+
+* What behaviour are we testing?
+* What errors are likely to occur when we run this code?
+* Does the test test what we think they are testing? Or are we introducing false positives and false negatives into our results?
 
 ## Running tests
 
@@ -24,7 +43,7 @@ We use [Jest](https://facebook.github.io/jest) testing framework for unit tests,
 Though you'll still see Chai assertions and Sinon spies/mocks throughout the code base, for all new tests we use the Jest API for [globals](https://facebook.github.io/jest/docs/en/api.html) (`describe`, `test`, `beforeEach` and so on) [assertions](http://facebook.github.io/jest/docs/en/expect.html), [mocks](http://facebook.github.io/jest/docs/en/mock-functions.html), [spies](http://facebook.github.io/jest/docs/en/jest-object.html#jestspyonobject-methodname) and [mock functions](https://facebook.github.io/jest/docs/en/mock-function-api.html).
 
 ## Folder structure
-Keep your tests in a `test` folder in your working directory. The test file should have the same name as the test subject file, and use the extension `.js`.
+Keep your tests in a `test` folder in your working directory. The test file should have the same name as the test subject file.
 
 ```
 +-- test
@@ -52,7 +71,7 @@ Given the previous folder structure, try to use relative paths when importing of
 It will make your life easier should you decide to relocate your code to another position in the application directory.
 
 ### Describing tests
-Use a 'describe' block to group test cases. Each test case should ideally describe one behaviour only.
+Use a `describe` block to group test cases. Each test case should ideally describe one behaviour only.
 
 In test cases, try to describe in plain words the expected behaviour. For UI components, this might entail describing expected behaviour from a user perspective rather than explaining code internals.
 
@@ -79,41 +98,24 @@ describe( 'CheckboxWithLabel', () => {
 ### Snapshot testing
 Snapshot testing is useful for verifying that any data produced during a test is not inadvertently changed. This is especially useful for large and complex data structures like component or state trees. See the [our full reference](snapshot-testing.md) for more information.
 
-### Examples
-
 ### Setup and Teardown methods
 
 The Jest API includes some nifty [setup and teardown methods](https://facebook.github.io/jest/docs/en/setup-teardown.html) that allow you to perform tasks *before* and *after* each or all of your tests, or tests within a specific `describe` block.
 
-These methods can handle asynchronous code to allow setup that you normally cannot do inline.
-
-For example, you 
+These methods can handle asynchronous code to allow setup that you normally cannot do inline. As with [individual test cases](https://facebook.github.io/jest/docs/en/asynchronous.html#promises), you can return a Promise and Jest will wait for it to resolve: 
 
 ```javascript
 
 // one-time setup for *all* tests
-beforeAll( done => {
-    someAsyncAction()
-        .then( resp => {
-        	window.someGlobal = resp;
-        	done();
-        } );
-} );
+beforeAll( () =>  someAsyncAction().then( resp => {
+    window.someGlobal = resp;
+} ) );
 
 // one-time teardown for *all* tests
 afterAll( () => {
     window.someGlobal = null;
 } );
 
-// one-time setup for *each* test
-beforeEach( () => {
-    
-} );
-
-// one-time teardown for *each* test
-afterEach( () => {
-    
-} );
 
 ```
 


### PR DESCRIPTION
As I began to summarize Calypso unit testing for our next team meetup, I thought it might be useful to add flesh to the yet-to-be penned Unit Testing doc.

So this is a work-in-progress-first-attempt-skeleton document to describe Calyspo client side unit testing best practices, examples, and whatever else we think might be useful for all contributors, new and experienced. Please forgive typos at this stage.

The doc so far is basically an info dump. It'd be helpful to get everyone's views on:

**1. What Calypso-specific information should this document contain?** 
The whys and whats of Unit Testing are just a search away, however which unit testing guidelines would _we_ like to promote and foster?

**2. How much information is too much?**
Creating numerous examples of how to tackle Calypso-specific unit testing scenarios might be nice, even helpful to some, yet does the risk of having yet another document to maintain outweigh the benefits?

**3. Preventing duplication**
We already have some good [general ](testing-overview.md) and [specific](snapshot-testing.md) docs in relation to testing. What should be the focus of a unit testing doc? Should we update and consolidate everything related to client side unit testing in one doc?

And lastly:

**4. Do we need this doc at all?**

All content suggestions and edits welcome. Thank you!
