### PR TITLE
Stats: Make segmented control in header compact

### DIFF
--- a/client/blocks/stats-navigation/intervals.js
+++ b/client/blocks/stats-navigation/intervals.js
@@ -19,7 +19,7 @@ const Intervals = props => {
 		'is-standalone': standalone,
 	} );
 	return (
-		<SegmentedControl primary className={ classes }>
+		<SegmentedControl compact primary className={ classes }>
 			{ intervals.map( i => {
 				const path = pathTemplate.replace( /{{ interval }}/g, i.value );
 				return (


### PR DESCRIPTION
Fix #19682

The segmented control in the Stats header should be compact!

Before
<img width="694" alt="screen shot 2018-01-02 at 12 06 44" src="https://user-images.githubusercontent.com/2070010/34483309-96f9d876-efb5-11e7-8c15-5d27c0974500.png">

After
<img width="692" alt="screen shot 2018-01-02 at 12 06 16" src="https://user-images.githubusercontent.com/2070010/34483310-99195a82-efb5-11e7-8157-31114b888339.png">