### PR TITLE
Enable Perfmon for stage and wpcalypso for the /stats page

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -20,7 +20,7 @@ import { setRoute as setRouteAction } from 'state/ui/actions';
 import { hasTouch } from 'lib/touch-detect';
 import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
 import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
-import perfmon from 'lib/perfmon';
+import { installPerfmonPageHandlers } from 'lib/perfmon';
 
 const debug = debugFactory( 'calypso' );
 
@@ -194,7 +194,7 @@ export const configureReduxStore = ( currentUser, reduxStore ) => {
 export const setupMiddlewares = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso setup middlewares.' );
 
-	perfmon();
+	installPerfmonPageHandlers();
 	setupContextMiddleware( reduxStore );
 	oauthTokenMiddleware();
 	loadSectionsMiddleware();

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -20,6 +20,7 @@ import { setRoute as setRouteAction } from 'state/ui/actions';
 import { hasTouch } from 'lib/touch-detect';
 import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
 import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
+import perfmon from 'lib/perfmon';
 
 const debug = debugFactory( 'calypso' );
 
@@ -193,6 +194,7 @@ export const configureReduxStore = ( currentUser, reduxStore ) => {
 export const setupMiddlewares = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso setup middlewares.' );
 
+	perfmon();
 	setupContextMiddleware( reduxStore );
 	oauthTokenMiddleware();
 	loadSectionsMiddleware();

--- a/client/lib/perfmon/index.js
+++ b/client/lib/perfmon/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { debounce, each, remove, includes, get } from 'lodash';
+import { each, remove } from 'lodash';
 import page from 'page';
 
 /**
@@ -12,8 +12,8 @@ import page from 'page';
 
 import analytics from 'lib/analytics';
 import { isEnabled } from 'config';
-
 import debugFactory from 'debug';
+
 const debug = debugFactory( 'calypso:perfmon' );
 
 const PLACEHOLDER_CLASSES = [
@@ -25,137 +25,123 @@ const PLACEHOLDER_CLASSES = [
 
 const EXCLUDE_PLACEHOLDER_CLASSES = [
 	'editor-drawer-well__placeholder', // used in featured image in editor
+	'stats-page-placeholder__header',
+	'stats-page-placeholder__content',
 ];
 
 const PLACEHOLDER_MATCHER = PLACEHOLDER_CLASSES.map( clazz => `[class*='${ clazz }']` ).join(
 	', '
 );
+
 const OBSERVE_ROOT = document.getElementById( 'wpcom' );
 
+// specifies the mutations we are interested in: childList and class attr changes
+const OBSERVE_OPTIONS = {
+	subtree: true,
+	attributes: true,
+	childList: true,
+	attributeFilter: [ 'class' ],
+};
+
+let mutationObserver = null;
+let mutationObserverActive = false;
+
+let navigationCount = 0;
+let navigationStartTime = null;
 let activePlaceholders = [];
-let placeholdersVisibleStart = null;
-let initialized = false;
+let activePlaceholderEverDetected = false;
 
-const enabledRoutes = [];
+function processMutations( mutations ) {
+	// record all the nodes that match our placeholder classes in the "activePlaceholders" array
+	mutations.forEach( recordPlaceholders );
 
-// add listeners for various DOM events - scrolling, mutation and navigation
-// and use these to trigger checks for visible placeholders (and, in the case of mutations,
-// to record new placeholders and remove nodes that are no longer placeholders)
-function observeDomChanges( MutationObserver ) {
-	// if anything scrolls, check if any of our placeholder elements are in view,
-	// but not more than a few times a second
-	window.addEventListener(
-		'scroll',
-		debounce( checkForVisiblePlaceholders.bind( null, 'scroll' ), 200 ),
-		true
-	);
+	// remove any nodes from activePlaceholders that are no longer placeholders
+	// check each node for:
+	// a. whether it's still in the DOM at all, and if so:
+	// b. whether it still has a placeholder class
+	remove( activePlaceholders, node => ! OBSERVE_ROOT.contains( node ) || ! isPlaceholder( node ) );
 
-	// if the user navigates, stop the current event and proceed to the next one
-	page( function( context, next ) {
-		// send "placeholder-wait-navigated" event
-		checkForVisiblePlaceholders( 'navigate' );
-		next();
-	} );
-
-	// this is fired for matching mutations (childList and class attr changes)
-	var observer = new MutationObserver( function( mutations ) {
-		// record all the nodes that match our placeholder classes in the "activePlaceholders" array
-		mutations.forEach( recordPlaceholders );
-
-		// remove any nodes from activePlaceholders that are no longer placeholders
-		// check each node for:
-		// a. whether it's still in the DOM at all, and if so:
-		// b. whether it still has a placeholder class
-		remove( activePlaceholders, function( node ) {
-			return ! OBSERVE_ROOT.contains( node ) || ! isPlaceholder( node );
-		} );
-
-		checkForVisiblePlaceholders( 'mutation' );
-	} );
-
-	observer.observe( OBSERVE_ROOT, {
-		subtree: true,
-		attributes: true,
-		childList: true,
-		attributeFilter: [ 'class' ],
-	} );
+	checkActivePlaceholders();
 }
 
-// check if there are any placeholders on the screen,
-// and trigger a timing event when all the placeholders are gone or the user
-// has navigated
-function checkForVisiblePlaceholders( trigger ) {
-	const urlPathParts = window.location.pathname.split( '/' );
-	const currentRoute = get( urlPathParts, '1', false );
+function createMutationObserver() {
+	const MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
 
-	if ( ! includes( enabledRoutes, currentRoute ) ) {
-		return;
+	mutationObserver = new MutationObserver( processMutations );
+}
+
+// Start observing the DOM changes
+function startMutationObserver() {
+	if ( mutationObserver && ! mutationObserverActive ) {
+		mutationObserver.observe( OBSERVE_ROOT, OBSERVE_OPTIONS );
+		mutationObserverActive = true;
+	}
+}
+
+// Stop observing the DOM changes and clean up all data structures
+function stopMutationObserver() {
+	if ( mutationObserver && mutationObserverActive ) {
+		activePlaceholders = [];
+		activePlaceholderEverDetected = false;
+		mutationObserver.disconnect();
+		mutationObserverActive = false;
+	}
+}
+
+// Determine what kind of timing are we recording.
+// Initial app load or after-load navigation to another route?
+function determineTimingType() {
+	if ( navigationCount > 1 ) {
+		// This is navigation inside the single-page app after it was fully loaded.
+		// Measure the time since the `page` router started displaying this page.
+		return {
+			startTime: navigationStartTime,
+			trigger: 'navigation',
+		};
 	}
 
-	// determine how many placeholders are active in the viewport
-	const visibleCount = activePlaceholders.reduce( function( count, node ) {
-		return count + ( isElementVisibleInViewport( node ) ? 1 : 0 );
-	}, 0 );
+	// This is the initial load of the app. We measure the whole time the app needed to load.
+	// `performance.now()` measures the time since "time origin", i.e., the start time is zero.
+	// See https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp#The_time_origin
+	return {
+		startTime: 0,
+		trigger: 'initial',
+	};
+}
 
-	// record event and reset timer if all placeholders are loaded OR user has just navigated
-	if ( placeholdersVisibleStart && ( visibleCount === 0 || trigger === 'navigate' ) ) {
+// Check if there are any placeholders on the screen and trigger a timing event
+// when all the placeholders are gone
+function checkActivePlaceholders() {
+	const placeholdersCount = activePlaceholders.length;
+	debug( `Checking active placeholders. Count: ${ placeholdersCount }` );
+
+	if ( placeholdersCount > 0 ) {
+		activePlaceholderEverDetected = true;
+	}
+
+	// record event if there ever were any placeholders and if they all just disappeared
+	if ( activePlaceholderEverDetected && placeholdersCount === 0 ) {
 		// tell tracks to record duration
-		var duration = parseInt( performance.now() - placeholdersVisibleStart, 10 );
+		const { startTime, trigger } = determineTimingType();
+		const duration = Math.round( performance.now() - startTime );
 		debug( `Recording placeholder wait. Duration: ${ duration }, Trigger: ${ trigger }` );
-		analytics.timing.record( `placeholder-wait`, duration, trigger );
-		placeholdersVisibleStart = visibleCount === 0 ? null : performance.now();
-	}
-
-	// if we can see placeholders, placeholdersVisibleStart is falsy, start the clock
-	if ( visibleCount > 0 && ! placeholdersVisibleStart ) {
-		placeholdersVisibleStart = performance.now(); // TODO: performance.now()?
-	}
-
-	// if there are placeholders hanging around, print some useful stats
-	if ( activePlaceholders.length > 0 ) {
-		debug( 'Active placeholders: ' + activePlaceholders.length );
-		debug( 'Visible in viewport: ' + visibleCount );
+		analytics.timing.record( `placeholder-wait.${ trigger }`, duration );
+		stopMutationObserver();
 	}
 }
 
 function isPlaceholder( node ) {
-	var className = node.className;
+	const className = node.className;
 	return (
 		className &&
 		className.indexOf &&
-		PLACEHOLDER_CLASSES.some( function( clazz ) {
-			return className.indexOf( clazz ) >= 0;
-		} ) &&
-		! EXCLUDE_PLACEHOLDER_CLASSES.some( function( clazz ) {
-			return className.indexOf( clazz ) >= 0;
-		} )
-	);
-}
-
-// adapted from http://stackoverflow.com/questions/123999/how-to-tell-if-a-dom-element-is-visible-in-the-current-viewport/7557433#7557433
-function isElementVisibleInViewport( node ) {
-	var rect = node.getBoundingClientRect();
-
-	// discard if width or height are zero
-	if ( rect.top - rect.bottom === 0 || rect.right - rect.left === 0 ) {
-		return false;
-	}
-
-	var windowHeight = window.innerHeight || document.documentElement.clientHeight;
-	var windowWidth = window.innerWidth || document.documentElement.clientWidth;
-
-	// if top or bottom are inside window, AND left or right edge are inside window, then
-	// the element is at least partially visible
-	return (
-		( ( rect.top >= 0 && rect.top <= windowHeight ) ||
-			( rect.bottom >= 0 && rect.bottom <= windowHeight ) ) &&
-		( ( rect.left >= 0 && rect.left <= windowWidth ) ||
-			( rect.right >= 0 && rect.right <= windowWidth ) )
+		PLACEHOLDER_CLASSES.some( clazz => className.indexOf( clazz ) >= 0 ) &&
+		! EXCLUDE_PLACEHOLDER_CLASSES.some( clazz => className.indexOf( clazz ) >= 0 )
 	);
 }
 
 function recordPlaceholders( mutation ) {
-	var nodes = [];
+	let nodes = [];
 
 	if ( mutation.attributeName === 'class' ) {
 		// mutation.type === 'attributes' is redundant
@@ -188,33 +174,39 @@ function recordPlaceholderNode( node ) {
 	}
 }
 
-export const enablePerfmonForRoute = ( context, next ) => {
-	if ( ! initialized ) {
+function platformFeaturesAvailable() {
+	return (
+		typeof window !== 'undefined' &&
+		( window.MutationObserver || window.WebKitMutationObserver ) &&
+		window.performance
+	);
+}
+
+export function installPerfmonPageHandlers() {
+	if ( ! isEnabled( 'perfmon' ) ) {
 		return;
 	}
 
-	const urlPathParts = context.path.split( '/' );
-	const currentRoute = get( urlPathParts, '1', null );
-
-	if ( currentRoute && ! includes( enabledRoutes, currentRoute ) ) {
-		enabledRoutes.push( currentRoute );
-	}
-
-	next();
-};
-
-export default function() {
-	if ( typeof window === 'undefined' || ! isEnabled( 'perfmon' ) ) {
+	if ( ! platformFeaturesAvailable() ) {
 		return;
 	}
 
-	if ( ! initialized ) {
-		var MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+	page( function( context, next ) {
+		navigationCount++;
+		navigationStartTime = performance.now();
+		debug( 'entering page navigation', context.path );
+		next();
+	} );
 
-		if ( MutationObserver && window.performance ) {
-			observeDomChanges( MutationObserver );
-		}
+	page.exit( function( context, next ) {
+		debug( 'exiting page navigation', context.path );
+		stopMutationObserver();
+		next();
+	} );
 
-		initialized = true;
-	}
+	createMutationObserver();
+}
+
+export function recordPlaceholdersTiming() {
+	startMutationObserver();
 }

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -12,6 +12,7 @@ import { find, pick } from 'lodash';
  */
 import { getSiteFragment, getStatsDefaultSitePage, sectionify } from 'lib/route';
 import analytics from 'lib/analytics';
+import { recordPlaceholdersTiming } from 'lib/perfmon';
 import titlecase from 'to-title-case';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { savePreference } from 'state/preferences/actions';
@@ -261,6 +262,7 @@ export default {
 				baseAnalyticsPath,
 				analyticsPageTitle + ' > ' + titlecase( activeFilter.period )
 			);
+			recordPlaceholdersTiming();
 
 			period = rangeOfPeriod( activeFilter.period, date );
 			chartTab = queryOptions.tab || 'views';

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -11,11 +11,8 @@ import { navigation, siteSelection, sites } from 'my-sites/controller';
 import statsController from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
-import { enablePerfmonForRoute } from 'lib/perfmon';
 
 export default function() {
-	page( '/stats/*', enablePerfmonForRoute );
-
 	page(
 		'/stats/activity/:site_id',
 		siteSelection,

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -11,8 +11,11 @@ import { navigation, siteSelection, sites } from 'my-sites/controller';
 import statsController from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
+import { enablePerfmonForRoute } from 'lib/perfmon';
 
 export default function() {
+	page( '/stats/*', enablePerfmonForRoute );
+
 	page(
 		'/stats/activity/:site_id',
 		siteSelection,

--- a/config/production.json
+++ b/config/production.json
@@ -82,7 +82,7 @@
 		"nps-survey/notice": true,
 		"olark": true,
 		"onboarding-checklist": false,
-		"perfmon": true,
+		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,
 		"plans/jetpack-config-v2": true,


### PR DESCRIPTION
Enables [perfmon](#2102) for `stage` and `wpcalypso` for the `/stats` page.

## Testing

Enable Perfmon for `development` (`perfmon: true`). Navigate to `/stats`. Open dev console and type in `localStorage.setItem('debug', 'calypso:perfmon');`. That will enable Perfmon logging into console. Do a full page reload and see if you get the logs.

Try navigating to a different page in Calypso whether you still get the logs – you should not as Perfmon is enabled only for the `/stats` page.
  