### PR TITLE
Store: Respond to click on chevron in 'Store' sidebar item

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -475,5 +475,11 @@ form.sidebar__button input {
 	}
 }
 .sidebar__chevron-right {
-	padding-top: 10px;
+	position: absolute;
+	right: 0;
+	pointer-events: none;
+
+	.gridicon {
+		padding-top: 10px;
+	}
 }

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -482,4 +482,8 @@ form.sidebar__button input {
 	.gridicon {
 		padding-top: 10px;
 	}
+
+	:hover + & .gridicon {
+		fill: $blue-medium;
+	}
 }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -402,7 +402,9 @@ export class MySitesSidebar extends Component {
 					onNavigate={ this.trackStoreClick }
 					icon="cart"
 				>
-					<Gridicon className="sidebar__chevron-right" icon="chevron-right" />
+					<div className="sidebar__chevron-right">
+						<Gridicon icon="chevron-right" />
+					</div>
 				</SidebarItem>
 			)
 		);


### PR DESCRIPTION
The chevron wasn't clickable despite looking like an action element and triggering the list item's hover state (as previously brought up in https://github.com/Automattic/wp-calypso/issues/17311#issuecomment-331919262). This change gets the icon out of the way of the click event. cc: @kellychoffman

Before | After
-- | --
![store-sidebar-item-before](https://user-images.githubusercontent.com/1867547/34496980-a13a0dd8-efc9-11e7-8cf7-155c144825f1.gif) | ![store-sidebar-item-after](https://user-images.githubusercontent.com/1867547/34496988-a4baa102-efc9-11e7-97d2-1036391cc61e.gif)

Tested in Chrome 63, Firefox 57, and Safari 10.1.1.