### PR TITLE
Add geocode query for unauthenticated users

### DIFF
--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -30,6 +30,7 @@ import userFactory from 'lib/user';
 const user = userFactory();
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { getGeoCountryShort } from 'state/geo/selectors';
+import QueryGeo from 'components/data/query-geo';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import PressableStoreStep from '../design-type-with-store/pressable-store';
 import { abtest } from 'lib/abtest';
@@ -506,6 +507,7 @@ class AboutStep extends Component {
 
 		return (
 			<div className="about__wrapper">
+				<QueryGeo />
 				<div className={ pressableWrapperClassName }>
 					<PressableStoreStep
 						{ ...this.props }


### PR DESCRIPTION
I found a bug with our site segmenting step in signup that would always show the Pressable store option for unauthenticated users in Canada and the US. This PR introduces a fix that helps us detect the users geocode if they are unauthenticated. 

## Before
![logged-out](https://user-images.githubusercontent.com/6981253/34498809-3f55994a-efd1-11e7-91cb-f76b4d9574d3.gif)

## After
![fix](https://user-images.githubusercontent.com/6981253/34498830-5d141d58-efd1-11e7-954a-eb39bec1f32e.gif)

## Test
* Remove `|| process.env.NODE_ENV === 'development'` from https://github.com/Automattic/wp-calypso/blob/2843602b5e01ce23df5f6c37b7c061eab44810ce/client/signup/steps/about/index.jsx#L312
* Visit `/start` as an unauthenticated user
* Select `Sell products or collect payments` and only that under "What’s the primary goal you have for your site?"
* Click continue and see the theme step if you're in Canada or the US.