### PR TITLE
Build: Add sourcemap generation option

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,9 +35,6 @@ const shouldMinify = process.env.hasOwnProperty( 'MINIFY_JS' )
 	? process.env.MINIFY_JS === 'true'
 	: ! isDevelopment;
 const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
-const shouldBuildSourceMaps = process.env.hasOwnProperty( 'SOURCEMAPS' )
-	? process.env.SOURCEMAPS === 'true'
-	: false;
 
 /**
  * This function scans the /client/extensions directory in order to generate a map that looks like this:
@@ -255,7 +252,7 @@ if ( isDevelopment ) {
 	webpackConfig.devtool = '#eval';
 } else {
 	webpackConfig.entry.build = path.join( __dirname, 'client', 'boot', 'app' );
-	webpackConfig.devtool = false;
+	webpackConfig.devtool = process.env.SOURCEMAP || false;
 }
 
 if ( ! config.isEnabled( 'desktop' ) ) {
@@ -273,17 +270,13 @@ if ( config.isEnabled( 'webpack/persistent-caching' ) ) {
 	);
 }
 
-if ( shouldBuildSourceMaps ) {
-	webpackConfig.devtool = 'source-map';
-}
-
 if ( shouldMinify ) {
 	webpackConfig.plugins.push(
 		new UglifyJsPlugin( {
 			cache: true,
 			parallel: true,
 			uglifyOptions: { ecma: 5 },
-			sourceMap: shouldBuildSourceMaps,
+			sourceMap: Boolean( process.env.SOURCEMAP ),
 		} )
 	);
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,9 @@ const shouldMinify = process.env.hasOwnProperty( 'MINIFY_JS' )
 	? process.env.MINIFY_JS === 'true'
 	: ! isDevelopment;
 const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
+const shouldBuildSourceMaps = process.env.hasOwnProperty( 'SOURCEMAPS' )
+	? process.env.SOURCEMAPS === 'true'
+	: false;
 
 /**
  * This function scans the /client/extensions directory in order to generate a map that looks like this:
@@ -270,13 +273,17 @@ if ( config.isEnabled( 'webpack/persistent-caching' ) ) {
 	);
 }
 
+if ( shouldBuildSourceMaps ) {
+	webpackConfig.devtool = 'source-map';
+}
+
 if ( shouldMinify ) {
 	webpackConfig.plugins.push(
 		new UglifyJsPlugin( {
 			cache: true,
 			parallel: true,
 			uglifyOptions: { ecma: 5 },
-			sourceMap: false,
+			sourceMap: shouldBuildSourceMaps,
 		} )
 	);
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,7 +84,7 @@ const babelLoader = {
 const webpackConfig = {
 	bail: ! isDevelopment,
 	entry: {},
-	devtool: 'false',
+	devtool: isDevelopment ? '#eval' : process.env.SOURCEMAP || false, // in production builds you can specify a source-map via env var
 	output: {
 		path: path.join( __dirname, 'public' ),
 		publicPath: '/calypso/',
@@ -249,10 +249,8 @@ if ( isDevelopment ) {
 		path.join( __dirname, 'client', 'boot', 'app' ),
 	];
 	webpackConfig.devServer = { hot: true, inline: true };
-	webpackConfig.devtool = '#eval';
 } else {
 	webpackConfig.entry.build = path.join( __dirname, 'client', 'boot', 'app' );
-	webpackConfig.devtool = process.env.SOURCEMAP || false;
 }
 
 if ( ! config.isEnabled( 'desktop' ) ) {


### PR DESCRIPTION
This adds a sourcemap option to builds, which allows sourcemaps to be
generated optionally. This is done with the goal of better debugging of
production errors from minified bundles.

To test:

1. `CALYPSO_ENV=production npm run build`
2. `ls public` and verify you see `*.min.js` files, and no `*.min.js.map` files.
3. `CALYPSO_ENV=production SOURCEMAP=source-map npm run build`
4. `ls public` and you should see a `*.min.js.map` file for each `*.min.js` file.
  