### PR TITLE
Domains: ccTLDs/ca-form: Always show organization field

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -151,6 +151,10 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		return get( this.props.contactDetails, 'extra.legalType' ) === 'CCO';
 	}
 
+	organizationFieldIsValid() {
+		return isEmpty( this.getOrganizationErrorMessage() );
+	}
+
 	getOrganizationErrorMessage() {
 		let message = ( this.state.errorMessages.organization || [] ).join( '\n' );
 		if ( this.needsOrganization() && isEmpty( this.props.contactDetails.organization ) ) {
@@ -159,10 +163,6 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 			);
 		}
 		return message;
-	}
-
-	organizationFieldIsValid() {
-		return isEmpty( this.getOrganizationErrorMessage() );
 	}
 
 	renderOrganizationField() {

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -147,12 +147,12 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		this.props.updateContactDetailsCache( { ...newContactDetails } );
 	};
 
-	shouldRenderOrganizationField() {
-		return this.props.ccTldDetails && this.props.ccTldDetails.legalType === 'CCO';
+	needsOrganization() {
+		return this.props..contactDetails.extra.legalType === 'CCO';
 	}
 
 	organizationFieldIsValid() {
-		if ( this.shouldRenderOrganizationField() ) {
+		if ( this.needsOrganization() ) {
 			return (
 				! isEmpty( this.props.contactDetails.organization ) &&
 				isEmpty( this.state.errorMessages.organization )
@@ -182,6 +182,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 					isError={ ! this.organizationFieldIsValid() }
 					errorMessage={ this.getOrganizationErrorMessage() }
 					label={ translate( 'Organization' ) }
+					labelProps: { optional: ! this.needsOrganization() },
 					onChange={ this.handleChangeEvent }
 				/>
 			</FormFieldset>
@@ -194,6 +195,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 			...defaultValues,
 			...this.props.ccTldDetails,
 		};
+
 		const formIsValid = ciraAgreementAccepted && this.organizationFieldIsValid();
 		const validatingSubmitButton = formIsValid ? children : disableSubmitButton( children );
 
@@ -237,7 +239,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 						) }
 					</FormLabel>
 				</FormFieldset>
-				{ this.shouldRenderOrganizationField() && this.renderOrganizationField() }
+				{ this.renderOrganizationField() }
 				{ validatingSubmitButton }
 			</form>
 		);

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -151,19 +151,9 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		return get( this.props.contactDetails, 'extra.legalType' ) === 'CCO';
 	}
 
-	organizationFieldIsValid() {
-		if ( this.needsOrganization() ) {
-			return (
-				! isEmpty( this.props.contactDetails.organization ) &&
-				isEmpty( this.state.errorMessages.organization )
-			);
-		}
-		return true;
-	}
-
 	getOrganizationErrorMessage() {
 		let message = ( this.state.errorMessages.organization || [] ).join( '\n' );
-		if ( isEmpty( this.props.contactDetails.organization ) ) {
+		if ( this.needsOrganization() && isEmpty( this.props.contactDetails.organization ) ) {
 			message = this.props.translate(
 				'An organization name is required for Canadian corporations'
 			);
@@ -171,8 +161,13 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		return message;
 	}
 
+	organizationFieldIsValid() {
+		return isEmpty( this.getOrganizationErrorMessage() );
+	}
+
 	renderOrganizationField() {
 		const { translate, contactDetails } = this.props;
+
 		return (
 			<FormFieldset>
 				<Input

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -182,7 +182,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 					isError={ ! this.organizationFieldIsValid() }
 					errorMessage={ this.getOrganizationErrorMessage() }
 					label={ translate( 'Organization' ) }
-					labelProps: { optional: ! this.needsOrganization() },
+					labelProps={ ! this.needsOrganization() ? { optional: true } : {} }
 					onChange={ this.handleChangeEvent }
 				/>
 			</FormFieldset>

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -167,6 +167,10 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 
 	renderOrganizationField() {
 		const { translate, contactDetails } = this.props;
+		const label = {
+			label: translate( 'Organization' ),
+			...( this.needsOrganization() ? {} : { labelProps: { optional: true } } ),
+		};
 
 		return (
 			<FormFieldset>
@@ -176,8 +180,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 					value={ contactDetails.organization || '' }
 					isError={ ! this.organizationFieldIsValid() }
 					errorMessage={ this.getOrganizationErrorMessage() }
-					label={ translate( 'Organization' ) }
-					labelProps={ ! this.needsOrganization() ? { optional: true } : {} }
+					{ ...label }
 					onChange={ this.handleChangeEvent }
 				/>
 			</FormFieldset>

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -148,7 +148,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 	};
 
 	needsOrganization() {
-		return this.props..contactDetails.extra.legalType === 'CCO';
+		return get( this.props.contactDetails, 'extra.legalType' ) === 'CCO';
 	}
 
 	organizationFieldIsValid() {

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -148,7 +148,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 	};
 
 	needsOrganization() {
-		return get( this.props.contactDetails, 'extra.legalType' ) === 'CCO';
+		return get( this.props.ccTldDetails, 'legalType' ) === 'CCO';
 	}
 
 	organizationFieldIsValid() {

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -218,9 +218,8 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel className="registrant-extra-info__optional" htmlFor="registrantVatId">
+					<FormLabel htmlFor="registrantVatId" optional>
 						{ translate( 'VAT Number' ) }
-						{ this.renderOptional() }
 					</FormLabel>
 					<FormTextInput
 						id="registrantVatId"
@@ -236,9 +235,8 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel className="registrant-extra-info__optional" htmlFor="sirenSiret">
+					<FormLabel htmlFor="sirenSiret" optional>
 						{ translate( 'SIREN or SIRET Number' ) }
-						{ this.renderOptional() }
 					</FormLabel>
 					<FormTextInput
 						id="sirenSiret"
@@ -259,9 +257,8 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel className="registrant-extra-info__optional" htmlFor="trademarkNumber">
+					<FormLabel htmlFor="trademarkNumber" optional>
 						{ translate( 'EU Trademark Number' ) }
-						{ this.renderOptional() }
 					</FormLabel>
 					<FormTextInput
 						id="trademarkNumber"
@@ -281,14 +278,6 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 					{ trademarkNumberValidationMessage }
 				</FormFieldset>
 			</div>
-		);
-	}
-
-	renderOptional() {
-		return (
-			<span className="registrant-extra-info__optional-label">
-				{ this.props.translate( 'Optional' ) }
-			</span>
 		);
 	}
 

--- a/client/components/domains/registrant-extra-info/style.scss
+++ b/client/components/domains/registrant-extra-info/style.scss
@@ -9,17 +9,6 @@
 	margin: 0 0 1.7em;
 }
 
-// We need .form-label for specificity
-.form-label.registrant-extra-info__optional {
-	display: flex;
-
-	.registrant-extra-info__optional-label {
-		color: $gray-darken-20;
-		font-weight: 200;
-		margin-left: 5px;
-	}
-}
-
 // Turn off number spinners
 .registrant-extra-info__form {
 	input[type=number] {
@@ -30,6 +19,12 @@
 			-webkit-appearance: none;
 			margin: 0;
 		}
+	}
+
+	.form-label .form-label__optional {
+		font-weight: 200;
+		font-size: 100%;
+		margin-left: 5px;
 	}
 }
 

--- a/client/components/domains/registrant-extra-info/style.scss
+++ b/client/components/domains/registrant-extra-info/style.scss
@@ -22,9 +22,12 @@
 	}
 
 	.form-label .form-label__optional {
-		font-weight: 200;
 		font-size: 100%;
 		margin-left: 5px;
+	}
+
+	.form-input-validation {
+		font-weight: normal;
 	}
 }
 

--- a/client/components/forms/form-label/index.jsx
+++ b/client/components/forms/form-label/index.jsx
@@ -14,13 +14,21 @@ const renderRequiredBadge = translate => (
 	<small className="form-label__required">{ translate( 'Required' ) }</small>
 );
 
+const renderOptionalBadge = translate => (
+	<small className="form-label__optional">{ translate( 'Optional' ) }</small>
+);
+
 const addKeys = elements =>
 	elements.map( ( elem, idx ) => ( isObject( elem ) ? { ...elem, key: idx } : elem ) );
 
-const FormLabel = ( { children, required, translate, className, ...extraProps } ) => {
+const FormLabel = ( { children, required, optional, translate, className, ...extraProps } ) => {
 	children = React.Children.toArray( children ) || [];
 	if ( required ) {
 		children.push( renderRequiredBadge( translate ) );
+	}
+
+	if ( optional ) {
+		children.push( renderOptionalBadge( translate ) );
 	}
 
 	return (

--- a/client/components/forms/form-label/style.scss
+++ b/client/components/forms/form-label/style.scss
@@ -9,6 +9,12 @@
 		font-weight: normal;
 		margin-left: 6px;
 	}
+
+	.form-label__optional {
+		color: darken( $gray, 20% );
+		font-weight: normal;
+		margin-left: 6px;
+	}
 }
 
 .form-label input[type="checkbox"] + span,

--- a/client/my-sites/domains/components/form/input.jsx
+++ b/client/my-sites/domains/components/form/input.jsx
@@ -20,7 +20,7 @@ import scrollIntoViewport from 'lib/scroll-into-viewport';
 
 export default class extends React.Component {
 	static displayName = 'Input';
-	static defaultProps = { autoFocus: false, autoComplete: 'on' };
+	static defaultProps = { autoFocus: false, autoComplete: 'on', labelProps: {} };
 
 	componentDidMount() {
 		this.setupInputModeHandlers();
@@ -85,7 +85,9 @@ export default class extends React.Component {
 
 		return (
 			<div className={ classes }>
-				<FormLabel htmlFor={ this.props.name }>{ this.props.label }</FormLabel>
+				<FormLabel htmlFor={ this.props.name } { ...this.props.labelProps }>
+					{ this.props.label }
+				</FormLabel>
 				<FormTextInput
 					placeholder={ this.props.placeholder ? this.props.placeholder : this.props.label }
 					id={ this.props.name }

--- a/client/my-sites/domains/components/form/input.jsx
+++ b/client/my-sites/domains/components/form/input.jsx
@@ -20,7 +20,7 @@ import scrollIntoViewport from 'lib/scroll-into-viewport';
 
 export default class extends React.Component {
 	static displayName = 'Input';
-	static defaultProps = { autoFocus: false, autoComplete: 'on', labelProps: {} };
+	static defaultProps = { autoFocus: false, autoComplete: 'on' };
 
 	componentDidMount() {
 		this.setupInputModeHandlers();


### PR DESCRIPTION
This PR fixes a hole in #20984 where organization validation errors can be present while the organization field is hidden, leading to misleading error notifications and failed domain purchases.

Originally these improvements where in that PR, but I'm splitting them out here in order to deploy the approved improvements sooner.

To test:
1) Add a .ca domain to your cart
2) fill out the main form and continue to the .ca details form
3) Make sure that validation errors on the organization field are handled correctly
 - Can't submit invalid organizations
 - Correct validation errors are shown for both .CA specific validation (whitelist, required for CCO) and general org name validation (limited special characters, length)

I also added an `optional` option to the form-label component that mirrors the `required` option. I refactored the fr-form to use it, so that's worth checking that. It's not used by anything else, but it wouldn't hurt to have a bit of a general check of form labels.

Original comment from #20984:
Ah, I see. Good catch!

Ironically, the "required" check is the one that I do handle, and it's the other checks  that trigger that error, despite what that error notification claims (invalid characters, too long or the .ca specific naming).

Those are real validation errors that we don't want to ignore. OpenSRS doesn't care, but we don't want them in the database.

I first tried showing the field if there's an error for it and that works fine, but it feels bad. You fix the problem, and the field inexplicably disappears, even if you haven't finished changing the value there. Clearing the field would also work, but that's a weird exception to add.

So I think the only way that hangs together is to always have the field visible, and use the secondary cues to guide the user - enabling/disabling the checkout button, the error messages, and the "optional" decoration:

![ca-form- always show organization field](https://user-images.githubusercontent.com/5952255/36770501-43843782-1c96-11e8-938f-94bf5ab34f1d.gif)
#
One minor imperfection is that we do run the org name validation for non-corporation entities, even though OpenSRS doesn't care. This is Consistent with the main domain details form, and a pretty minor inconvenience.

One new thing to check: While I was de-duping the "optional" styling I found the `required` prop in the FormLabel component, so I've added optional there alongside it, as it seems like something with pretty broad applicability. I `grep`ed the codebase to make sure that `optional` is not being used as a prop anywhere, so the only thing that this will effect is the fr-form, which should look exactly the same. For your convenience, here's a before pic to compare:

![fr-form-before](https://user-images.githubusercontent.com/5952255/34429935-a1d5338e-ecaa-11e7-8014-4e9e74f0a109.jpg)

Another thing worth noting is that the organization field in both the `domain-details-form` and the `ca-form` are validating against all tlds. If you add a `(.*)?.uk` domain to the cart, you can get the .uk specific error about corporation names being at least 4 characters:

![banners_and_alerts_and_checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/36770641-27326774-1c97-11e8-9192-fd66f098cb1a.jpg)
( "Numele organizației trebuie să aibă cel puțin 4 caractere." )