### PR TITLE
Store: Add UI for product category listing

### DIFF
--- a/client/extensions/woocommerce/app/product-categories/index.js
+++ b/client/extensions/woocommerce/app/product-categories/index.js
@@ -1,29 +1,113 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { union, includes, trim, debounce } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import ActionHeader from 'woocommerce/components/action-header';
+import { DEFAULT_PRODUCT_CATEGORIES_PER_PAGE } from 'woocommerce/state/sites/product-categories/utils';
+import { fetchProductCategories } from 'woocommerce/state/sites/product-categories/actions';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import Main from 'components/main';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
+import ProductCategoriesList from 'woocommerce/app/product-categories/list';
 import SectionNav from 'components/section-nav';
 import Search from 'components/search';
 
 class ProductCategories extends Component {
 
+	state = {
+		requestedPages: [ 1 ],
+		requestedSearchPages: [],
+	};
+
+	constructor( props ) {
+		super( props );
+		this.debouncedOnSearch = debounce( this.onSearch, 500 );
+	}
+
+	componentWillMount() {
+		const { site } = this.props;
+		this.props.fetchProductCategories( site.ID, {
+			page: 1,
+			per_page: DEFAULT_PRODUCT_CATEGORIES_PER_PAGE,
+		} );
+	}
+
+	componentWillReceiveProps( newProps ) {
+		const { site } = this.props;
+		const newSiteId = ( newProps.site && newProps.site.ID ) || null;
+		const oldSiteId = ( site && site.ID ) || null;
+		if ( oldSiteId !== newSiteId ) {
+			this.props.fetchProductCategories( newSiteId, {
+				page: 1,
+				per_page: DEFAULT_PRODUCT_CATEGORIES_PER_PAGE,
+			} );
+		}
+	}
+
+	requestPages = pages => {
+		const { site } = this.props;
+		const { searchQuery } = this.state;
+
+		if ( searchQuery && searchQuery.length ) {
+			pages.forEach( page => {
+				if ( ! includes( this.state.requestedSearchPages, page ) ) {
+					this.props.fetchProductCategories( site.ID, {
+						per_page: DEFAULT_PRODUCT_CATEGORIES_PER_PAGE,
+						search: searchQuery,
+						page,
+					} );
+				}
+			} );
+
+			this.setState( {
+				requestedSearchPages: union( this.state.requestedSearchPages, pages ),
+			} );
+		} else {
+			pages.forEach( page => {
+				if ( ! includes( this.state.requestedPages, page ) ) {
+					this.props.fetchProductCategories( site.ID, {
+						per_page: DEFAULT_PRODUCT_CATEGORIES_PER_PAGE,
+						page,
+					} );
+				}
+			} );
+
+			this.setState( {
+				requestedPages: union( this.state.requestedPages, pages ),
+			} );
+		}
+	};
+
+	onSearch = query => {
+		const { site } = this.props;
+
+		if ( trim( query ) === '' ) {
+			this.setState( { searchQuery: '', requestedSearchPages: [] } );
+			return;
+		}
+
+		this.setState( { searchQuery: query, requestedSearchPages: [ 1 ] } );
+		this.props.fetchProductCategories( site.ID, {
+			search: query,
+			per_page: DEFAULT_PRODUCT_CATEGORIES_PER_PAGE,
+		} );
+	};
+
 	render() {
-		const { className, translate, site } = this.props;
-		const classes = classNames( 'product_categories__list', className );
+		const { site, className, translate } = this.props;
+		const { searchQuery } = this.state;
+		const classes = classNames( 'product_categories__list-wrapper', className );
 
 		const productsLabel = translate( 'Products' );
 		const categoriesLabel = translate( 'Categories' );
@@ -46,9 +130,14 @@ class ProductCategories extends Component {
 					<Search
 						pinned
 						fitsContainer
+						onSearch={ this.debouncedOnSearch }
 						placeholder={ translate( 'Search categories…' ) }
 					/>
 				</SectionNav>
+				<ProductCategoriesList
+					searchQuery={ searchQuery }
+					requestPages={ this.requestPages }
+				/>
 			</Main>
 		);
 	}
@@ -62,4 +151,13 @@ function mapStateToProps( state ) {
 	};
 }
 
-export default connect( mapStateToProps )( localize( ProductCategories ) );
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			fetchProductCategories,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( ProductCategories ) );

--- a/client/extensions/woocommerce/app/product-categories/list.js
+++ b/client/extensions/woocommerce/app/product-categories/list.js
@@ -22,7 +22,7 @@ import {
 } from 'woocommerce/state/sites/product-categories/selectors';
 import Count from 'components/count';
 import CompactCard from 'components/card/compact';
-import { DEFAULT_PRODUCT_CATEGORIES_PER_PAGE } from 'woocommerce/state/sites/product-categories/utils';
+import { DEFAULT_QUERY } from 'woocommerce/state/sites/product-categories/utils';
 import EmptyContent from 'components/empty-content';
 import { fetchProductCategories } from 'woocommerce/state/sites/product-categories/actions';
 import { getLink } from 'woocommerce/lib/nav-utils';
@@ -100,7 +100,13 @@ class ProductCategories extends Component {
 			<div key={ 'product-category-' + itemId } className="product-categories__list-item">
 				<CompactCard key={ itemId } className="product-categories__list-item-card" onClick={ goToLink }>
 					<div className="product-categories__list-item-wrapper">
-						<div className={ imageClasses }>{ item.image && <img src={ item.image.src } /> }</div>
+						<div className="product-categories__list-thumb">
+							<div className={ imageClasses }>
+								<figure>
+									{ item.image && <img src={ item.image.src } /> }
+								</figure>
+							</div>
+						</div>
 						<span className="product-categories__list-item-info">
 							<a href={ link }>{ item.name }</a>
 							<Count count={ item.count } />
@@ -138,7 +144,7 @@ class ProductCategories extends Component {
 						getRowHeight={ this.getRowHeight }
 						renderRow={ this.renderRow }
 						onRequestPages={ this.props.requestPages }
-						perPage={ DEFAULT_PRODUCT_CATEGORIES_PER_PAGE }
+						perPage={ DEFAULT_QUERY.per_page }
 						loadOffset={ 10 }
 						searching={ searchQuery && searchQuery.length }
 						defaultRowHeight={ ITEM_HEIGHT }
@@ -168,11 +174,13 @@ class ProductCategories extends Component {
 		const classes = classNames( 'product-categories__list', className );
 
 		return (
-			<div className={ classes }>
-				{
-					this.props.isInitialRequestLoaded && this.renderCategoryList() ||
-					<div className="product-categories__list-placeholder" />
-				}
+			<div className="product-categories__list-container">
+				<div className={ classes }>
+					{
+						this.props.isInitialRequestLoaded && this.renderCategoryList() ||
+						<div className="product-categories__list-placeholder" />
+					}
+				</div>
 			</div>
 		);
 	}
@@ -181,7 +189,7 @@ class ProductCategories extends Component {
 
 function mapStateToProps( state, ownProps ) {
 	const { searchQuery } = ownProps;
-	let query = { per_page: DEFAULT_PRODUCT_CATEGORIES_PER_PAGE };
+	let query = {};
 	if ( searchQuery && searchQuery.length ) {
 		query = { search: searchQuery, ...query };
 	}

--- a/client/extensions/woocommerce/app/product-categories/list.js
+++ b/client/extensions/woocommerce/app/product-categories/list.js
@@ -1,0 +1,214 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { map, filter, reduce, includes } from 'lodash';
+import page from 'page';
+import WindowScroller from 'react-virtualized/WindowScroller';
+
+/**
+ * Internal dependencies
+ */
+import {
+	areProductCategoriesLoadingIgnoringPage,
+	getProductCategoriesLastPage,
+	getProductCategoriesIgnoringPage,
+	areProductCategoriesLoaded,
+	getTotalProductCategories,
+} from 'woocommerce/state/sites/product-categories/selectors';
+import Count from 'components/count';
+import CompactCard from 'components/card/compact';
+import { DEFAULT_PRODUCT_CATEGORIES_PER_PAGE } from 'woocommerce/state/sites/product-categories/utils';
+import EmptyContent from 'components/empty-content';
+import { fetchProductCategories } from 'woocommerce/state/sites/product-categories/actions';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import VirtualList from 'components/virtual-list';
+
+const ITEM_HEIGHT = 70;
+
+class ProductCategories extends Component {
+
+	componentWillMount() {
+		this.catIds = map( this.props.categories, 'id' );
+	}
+
+	componentWillReceiveProps( newProps ) {
+		if ( newProps.categories !== this.props.categories ) {
+			this.catIds = map( newProps.categories, 'id' );
+		}
+	}
+
+	getChildren( id ) {
+		const { categories } = this.props;
+		return filter( categories, { parent: id } );
+	}
+
+	getItemHeight = ( item, _recurse = false ) => {
+		if ( ! item ) {
+			return ITEM_HEIGHT;
+		}
+
+		// if item has a parent, and parent is in payload, height is already part of parent
+		if ( item.parent && ! _recurse && includes( this.catIds, item.parent ) ) {
+			return 0;
+		}
+
+		return reduce(
+			this.getChildren( item.id ),
+			( height, childItem ) => {
+				return height + this.getItemHeight( childItem, true );
+			},
+			ITEM_HEIGHT
+		);
+	};
+
+	getRowHeight = ( { index } ) => {
+		return this.getItemHeight( this.getItem( index ) );
+	};
+
+	getItem( index ) {
+		if ( this.props.categories ) {
+			return this.props.categories[ index ];
+		}
+	}
+
+	renderItem( item, _recurse = false ) {
+		const { site } = this.props;
+
+		// if item has a parent and it is in current props.categories, do not render
+		if ( item.parent && ! _recurse && includes( this.catIds, item.parent ) ) {
+			return;
+		}
+		const children = this.getChildren( item.id );
+		const itemId = item.id;
+		const image = item.image && item.image.src;
+		const imageClasses = classNames( 'product-categories__list-item-icon', {
+			'is-thumb-placeholder': ! image,
+		} );
+		const link = getLink( '/store/products/category/:site/' + itemId, site );
+
+		const goToLink = () => {
+			page( link );
+		};
+
+		return (
+			<div key={ 'product-category-' + itemId } className="product-categories__list-item">
+				<CompactCard key={ itemId } className="product-categories__list-item-card" onClick={ goToLink }>
+					<div className="product-categories__list-item-wrapper">
+						<div className={ imageClasses }>{ item.image && <img src={ item.image.src } /> }</div>
+						<span className="product-categories__list-item-info">
+							<a href={ link }>{ item.name }</a>
+							<Count count={ item.count } />
+							<span className="product-categories__list-item-description">{ item.description }</span>
+						</span>
+					</div>
+				</CompactCard>
+					{ children.length > 0 && (
+						<div className="product-categories__list-nested">
+							{ children.map( child => this.renderItem( child, true ) ) }
+						</div>
+					) }
+			</div>
+		);
+	}
+
+	renderRow = ( { index } ) => {
+		const item = this.getItem( index );
+		if ( item ) {
+			return this.renderItem( item );
+		}
+
+		return null;
+	};
+
+	renderCategoryList() {
+		const { loading, categories, lastPage, searchQuery } = this.props;
+		return (
+			<WindowScroller>
+				{( { height, scrollTop } ) => (
+					<VirtualList
+						items={ categories }
+						lastPage={ lastPage }
+						loading={ loading }
+						getRowHeight={ this.getRowHeight }
+						renderRow={ this.renderRow }
+						onRequestPages={ this.props.requestPages }
+						perPage={ DEFAULT_PRODUCT_CATEGORIES_PER_PAGE }
+						loadOffset={ 10 }
+						searching={ searchQuery && searchQuery.length }
+						defaultRowHeight={ ITEM_HEIGHT }
+						height={ height }
+						scrollTop={ scrollTop }
+					/>
+				)}
+			</WindowScroller>
+		);
+	}
+
+	render() {
+		const { className, translate, totalCategories, searchQuery } = this.props;
+
+		if ( this.props.isInitialRequestLoaded && 0 === totalCategories ) {
+			let message = null;
+			if ( searchQuery ) {
+				message = translate( 'No product categories found for {{query /}}.', {
+					components: {
+						query: <em>{ searchQuery }</em>,
+					},
+				} );
+			}
+			return <EmptyContent title={ translate( 'No product categories found.' ) } line={ message } />;
+		}
+
+		const classes = classNames( 'product-categories__list', className );
+
+		return (
+			<div className={ classes }>
+				{
+					this.props.isInitialRequestLoaded && this.renderCategoryList() ||
+					<div className="product-categories__list-placeholder" />
+				}
+			</div>
+		);
+	}
+
+}
+
+function mapStateToProps( state, ownProps ) {
+	const { searchQuery } = ownProps;
+	let query = { per_page: DEFAULT_PRODUCT_CATEGORIES_PER_PAGE };
+	if ( searchQuery && searchQuery.length ) {
+		query = { search: searchQuery, ...query };
+	}
+
+	const site = getSelectedSiteWithFallback( state );
+	const loading = areProductCategoriesLoadingIgnoringPage( state, query );
+	const isInitialRequestLoaded = areProductCategoriesLoaded( state, query ); // first page request
+	const categories = getProductCategoriesIgnoringPage( state, query );
+	const totalCategories = getTotalProductCategories( state, query );
+	const lastPage = getProductCategoriesLastPage( state, query );
+	return {
+		site,
+		loading,
+		categories,
+		lastPage,
+		isInitialRequestLoaded,
+		totalCategories,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			fetchProductCategories,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( ProductCategories ) );

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -1,0 +1,75 @@
+.product-categories__list-placeholder {
+	@include placeholder();
+	background: $white;
+	height: 525px;
+}
+
+.product-categories__list {
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+		0 1px 2px lighten( $gray, 30% );
+}
+
+.product-categories__list-item {
+	background-color: $gray-light;
+}
+
+.product-categories__list-item-card {
+	cursor: pointer;
+}
+
+.product-categories__list-item-card.card.is-compact {
+	padding: 0;
+}
+
+.product-categories__list-item-wrapper {
+	display: flex;
+	flex-direction: row;
+
+	.product-categories__list-item-icon {
+		height: 40px;
+		min-width: 40px;
+		overflow: hidden;
+		position: relative;
+		margin: 16px 16px 0px 16px;
+
+		&.is-thumb-placeholder {
+			background: $gray-light;
+		}
+
+		img {
+			position: absolute;
+			left: 50%;
+			top: 50%;
+			height: 100%;
+			width: auto;
+			-webkit-transform: translate( -50%, -50% );
+			transform: translate( -50%, -50% );
+		}
+	}
+
+	.product-categories__list-item-info {
+		line-height: 69px;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		flex-grow: 1;
+		position: relative;
+	}
+
+	.product-categories__list-item-description {
+		margin-left: 24px;
+	}
+
+	.count {
+		margin: 18px 0px 0px 16px;
+	}
+
+
+	&:hover {
+		background: lighten( $gray, 35% );
+	}
+}
+
+.product-categories__list-nested {
+	margin-left: 2em;
+}

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -70,6 +70,7 @@
 		text-overflow: ellipsis;
 		flex-grow: 1;
 		position: relative;
+		padding-right: 16px;
 	}
 
 	.product-categories__list-item-description {

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -4,9 +4,9 @@
 	height: 525px;
 }
 
-.product-categories__list {
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+.product-categories__list-container {
+	border: 1px solid lighten( $gray, 30% );
+	border-bottom: 0;
 }
 
 .product-categories__list-item {
@@ -21,20 +21,24 @@
 	padding: 0;
 }
 
-.product-categories__list-item-wrapper {
-	display: flex;
+.product-categories__list-thumb {
+	display: inline-flex;
 	flex-direction: row;
+	align-items: center;
+	transform: translateY( 2px );
+	margin: 0px 16px 0px 16px;
+}
 
-	.product-categories__list-item-icon {
+.product-categories__list-item-icon {
+	margin-bottom: 0;
+	margin-right: 0px;
+	flex-shrink: 0;
+	position: relative;
+
+	figure {
+		width: 40px;
 		height: 40px;
-		min-width: 40px;
 		overflow: hidden;
-		position: relative;
-		margin: 16px 16px 0px 16px;
-
-		&.is-thumb-placeholder {
-			background: $gray-light;
-		}
 
 		img {
 			position: absolute;
@@ -42,10 +46,22 @@
 			top: 50%;
 			height: 100%;
 			width: auto;
-			-webkit-transform: translate( -50%, -50% );
-			transform: translate( -50%, -50% );
+			transform: translate( -50%,-50% );
 		}
 	}
+
+	&.is-thumb-placeholder {
+		height: 40px;
+		min-width: 40px;
+		overflow: hidden;
+		position: relative;
+		background: $gray-light;
+	}
+}
+
+.product-categories__list-item-wrapper {
+	display: flex;
+	flex-direction: row;
 
 	.product-categories__list-item-info {
 		line-height: 69px;

--- a/client/extensions/woocommerce/app/products/index.js
+++ b/client/extensions/woocommerce/app/products/index.js
@@ -94,7 +94,7 @@ class Products extends Component {
 			const productsLabel = translate( 'Products' );
 
 			return (
-				<SectionNav>
+				<SectionNav selectedText={ productsLabel }>
 					<NavTabs label={ productsLabel } selectedText={ productsLabel }>
 						<NavItem path={ getLink( '/store/products/:site/', site ) } selected>
 							{ productsLabel }

--- a/client/extensions/woocommerce/state/data-layer/product-categories/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/product-categories/test/index.js
@@ -41,7 +41,7 @@ describe( 'handlers', () => {
 					method: 'GET',
 					path: `/jetpack-blogs/${ siteId }/rest-api/`,
 					query: {
-						path: '/wc/v3/products/categories&page=1&per_page=10&_envelope&_method=GET',
+						path: '/wc/v3/products/categories&page=1&per_page=100&_envelope&_method=GET',
 						json: true,
 						apiVersion: '1.1',
 					},

--- a/client/extensions/woocommerce/state/sites/product-categories/utils.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/utils.js
@@ -6,12 +6,10 @@
 
 import { omitBy } from 'lodash';
 
-export const DEFAULT_PRODUCT_CATEGORIES_PER_PAGE = 100;
-
 // Defaults from https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-product-categories
 export const DEFAULT_QUERY = {
 	page: 1,
-	per_page: 10,
+	per_page: 100,
 	search: '',
 };
 

--- a/client/extensions/woocommerce/state/sites/product-categories/utils.js
+++ b/client/extensions/woocommerce/state/sites/product-categories/utils.js
@@ -6,6 +6,8 @@
 
 import { omitBy } from 'lodash';
 
+export const DEFAULT_PRODUCT_CATEGORIES_PER_PAGE = 100;
+
 // Defaults from https://woocommerce.github.io/woocommerce-rest-api-docs/#list-all-product-categories
 export const DEFAULT_QUERY = {
 	page: 1,

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -17,6 +17,7 @@
 	@import 'app/settings/email/email-settings/style';
 	@import 'app/products/product-form';
 	@import 'app/products/products-list';
+	@import 'app/product-categories/style';
 	@import 'app/promotions/style';
 	@import 'app/reviews/style';
 	@import 'app/settings/shipping/style';


### PR DESCRIPTION
This PR adds a new product category listing page. It is behind a feature flag.

It is based off of the current taxonomy manager UI and p90Yrv-9S-p2. Also see #20295.

To Test:

* Create a bunch of product categories via wp-admin. Make sure to give some product images and descriptions. Apply a product to a few so that some of the categories have a product count greater than 0. Create sub-categories to test nesting.
* Apply this branch, and go to `http://calypso.localhost:3000/store/products/categories/:site`
* Make sure that your categories load in correctly, and display accurate information, and are nested correctly.

Note: Clicking a category will display a 404 since editing hasn't been implemented yet.

Preview:

<img width="1109" alt="screen shot 2018-01-02 at 2 18 10 pm" src="https://user-images.githubusercontent.com/689165/34502335-eb1aab30-efc7-11e7-903b-70b7df81c6c5.png">
