### PR TITLE
Store: Prompt for store address but only push country defaults when no products yet created

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -40,7 +40,7 @@ import Main from 'components/main';
 import ManageNoOrdersView from './manage-no-orders-view';
 import ManageOrdersView from './manage-orders-view';
 import Placeholder from './placeholder';
-import PreSetupView from './pre-setup-view';
+import StoreLocationSetupView from './store-location-setup-view';
 import RequiredPagesSetupView from './required-pages-setup-view';
 import RequiredPluginsInstallView from './required-plugins-install-view';
 import SetupTasksView from './setup-tasks-view';
@@ -149,8 +149,13 @@ class Dashboard extends Component {
 			return <RequiredPagesSetupView site={ selectedSite } />;
 		}
 
-		if ( ! setStoreAddressDuringInitialSetup && ! hasProducts ) {
-			return <PreSetupView siteId={ selectedSite.ID } />;
+		if ( ! setStoreAddressDuringInitialSetup ) {
+			return (
+				<StoreLocationSetupView
+					siteId={ selectedSite.ID }
+					pushDefaultsForCountry={ ! hasProducts }
+				/>
+			);
 		}
 
 		if ( ! finishedInitialSetup ) {

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -113,7 +113,7 @@ class Dashboard extends Component {
 			return translate( 'Setting Up Store Pages' );
 		}
 
-		if ( ! setStoreAddressDuringInitialSetup && ! hasProducts ) {
+		if ( ! setStoreAddressDuringInitialSetup ) {
 			return translate( 'Store Location' );
 		}
 

--- a/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
@@ -30,7 +30,7 @@ import { doInitialSetup } from 'woocommerce/state/sites/settings/actions';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 
-class PreSetupView extends Component {
+class StoreLocationSetupView extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
@@ -50,6 +50,7 @@ class PreSetupView extends Component {
 			postalCode: PropTypes.string,
 			countryCode: PropTypes.string,
 		} ),
+		pushDefaultsForCountry: PropTypes.bool.isRequired,
 		settingsGeneralLoaded: PropTypes.bool,
 		storeLocation: PropTypes.shape( {
 			street: PropTypes.string,
@@ -167,6 +168,7 @@ class PreSetupView extends Component {
 			state,
 			this.state.address.postcode,
 			country,
+			this.props.pushDefaultsForCountry,
 			onSuccess,
 			onFailure
 		);
@@ -251,4 +253,4 @@ function mapDispatchToProps( dispatch ) {
 	);
 }
 
-export default connect( mapStateToProps, mapDispatchToProps )( localize( PreSetupView ) );
+export default connect( mapStateToProps, mapDispatchToProps )( localize( StoreLocationSetupView ) );

--- a/client/extensions/woocommerce/lib/countries/CA.js
+++ b/client/extensions/woocommerce/lib/countries/CA.js
@@ -16,6 +16,9 @@ export default () => {
 		code: 'CA',
 		name: translate( 'Canada' ),
 		defaultState: 'AB',
+		currency: 'CAD',
+		dimensionUnit: 'cm',
+		weightUnit: 'kg',
 		states: [
 			{
 				code: 'AB',

--- a/client/extensions/woocommerce/lib/countries/US.js
+++ b/client/extensions/woocommerce/lib/countries/US.js
@@ -16,6 +16,9 @@ export default () => {
 		code: 'US',
 		name: translate( 'USA' ),
 		defaultState: 'AL',
+		currency: 'USD',
+		dimensionUnit: 'in',
+		weightUnit: 'lbs',
 		states: [
 			{
 				code: 'AL',

--- a/client/extensions/woocommerce/lib/countries/index.js
+++ b/client/extensions/woocommerce/lib/countries/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { find, filter, sortBy } from 'lodash';
+import { find, filter, get, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,6 +43,51 @@ export const getStateData = ( country, state ) => {
 	}
 
 	return stateData;
+};
+
+/**
+ * Returns an appropriate default currency (code) for
+ * the given country (code).
+ * @param {string} country Country (code) to get currency code for
+ * @return {string} best default currency code for country
+ */
+export const getCurrencyCodeForCountry = country => {
+	const countryData = getCountryData( country );
+	if ( ! countryData ) {
+		return 'USD';
+	}
+
+	return get( countryData, 'currency', 'USD' );
+};
+
+/**
+ * Returns an appropriate default dimension unit for
+ * the given country (code).
+ * @param {string} country Country (code) to get currency code for
+ * @return {string} best default dimension unit for country
+ */
+export const getDimensionUnitForCountry = country => {
+	const countryData = getCountryData( country );
+	if ( ! countryData ) {
+		return 'USD';
+	}
+
+	return get( countryData, 'dimensionUnit', 'cm' );
+};
+
+/**
+ * Returns an appropriate default weight unit for
+ * the given country (code).
+ * @param {string} country Country (code) to get currency code for
+ * @return {string} best default weight unit for country
+ */
+export const getWeightUnitForCountry = country => {
+	const countryData = getCountryData( country );
+	if ( ! countryData ) {
+		return 'USD';
+	}
+
+	return get( countryData, 'weightUnit', 'kg' );
 };
 
 /**

--- a/client/extensions/woocommerce/lib/countries/index.js
+++ b/client/extensions/woocommerce/lib/countries/index.js
@@ -49,45 +49,33 @@ export const getStateData = ( country, state ) => {
  * Returns an appropriate default currency (code) for
  * the given country (code).
  * @param {string} country Country (code) to get currency code for
- * @return {string} best default currency code for country
+ * @return {string} default currency code for country
  */
 export const getCurrencyCodeForCountry = country => {
 	const countryData = getCountryData( country );
-	if ( ! countryData ) {
-		return 'USD';
-	}
-
 	return get( countryData, 'currency', 'USD' );
 };
 
 /**
  * Returns an appropriate default dimension unit for
  * the given country (code).
- * @param {string} country Country (code) to get currency code for
- * @return {string} best default dimension unit for country
+ * @param {string} country Country (code) to get dimension unit for
+ * @return {string} default dimension unit for country
  */
 export const getDimensionUnitForCountry = country => {
 	const countryData = getCountryData( country );
-	if ( ! countryData ) {
-		return 'USD';
-	}
-
-	return get( countryData, 'dimensionUnit', 'cm' );
+	return get( countryData, 'dimensionUnit', 'in' );
 };
 
 /**
  * Returns an appropriate default weight unit for
  * the given country (code).
- * @param {string} country Country (code) to get currency code for
- * @return {string} best default weight unit for country
+ * @param {string} country Country (code) to get weight unit for
+ * @return {string} default weight unit for country
  */
 export const getWeightUnitForCountry = country => {
 	const countryData = getCountryData( country );
-	if ( ! countryData ) {
-		return 'USD';
-	}
-
-	return get( countryData, 'weightUnit', 'kg' );
+	return get( countryData, 'weightUnit', 'lbs' );
 };
 
 /**


### PR DESCRIPTION
Fixes #20784 

Noteworthy:
* Builds on/refines @justinshreve 's logic in #16150
* Renamed PreSetupView to StoreLocationSetupView to make the name more clearly reflect the component's responsibilities
* Now use whether site has products to determine whether the doInitialSetup action should also push country-specific defaults (like currency, dimensions and weight) for the store
* Now hold country-specific defaults in the countries lib
* Can be extended in the future for more countries and more settings (e.g. number of digits, separators, etc)

To test:
* Trash all your products
* Use the developer console to set `set_store_address_during_initial_setup` to 0 (and all other settings as 1)
* Refresh wordpress.com/store/{DOMAIN}
* Ensure you are prompted for your address, enter a US or CA address, save the changes and observe the network request to ensure currency, dimension and weight defaults are pushed to the site
* Open wp-admin on the site and ensure WooCommerce shows country appropriate settings
* Repeat the steps above after restoring a product - ensure the network request does NOT include currency, dimension and weight defaults 
* Profit
