### PR TITLE
Store: Shipping Labels: Add checkout information to Rates step

### DIFF
--- a/client/extensions/woocommerce/lib/order-values/index.js
+++ b/client/extensions/woocommerce/lib/order-values/index.js
@@ -54,6 +54,16 @@ export function getOrderFeeTotalTax( order ) {
 }
 
 /**
+ * Get the method title for the shipping value
+ *
+ * @param {Object} order An order as returned from API
+ * @return {String} Shipping method title
+ */
+export function getOrderShippingMethod( order ) {
+	return get( order, 'shipping_lines[0].method_title', false );
+}
+
+/**
  * Get the total tax for the shipping value
  *
  * @param {Object} order An order as returned from API

--- a/client/extensions/woocommerce/lib/order-values/test/index.js
+++ b/client/extensions/woocommerce/lib/order-values/test/index.js
@@ -16,6 +16,7 @@ import {
 	getOrderShippingTax,
 	getOrderSubtotalTax,
 	getOrderTotalTax,
+	getOrderShippingMethod,
 } from '../index';
 import orderWithTax from './fixtures/order';
 import orderWithoutTax from './fixtures/order-no-tax';
@@ -156,5 +157,19 @@ describe( 'getOrderTotalTax', () => {
 
 	test( 'should get the correct tax amount with multiple coupons', () => {
 		expect( getOrderTotalTax( orderWithCoupons ) ).to.eql( 5.3618 );
+	} );
+} );
+
+describe( 'getOrderShippingMethod', () => {
+	test( 'should be a function', () => {
+		expect( getOrderShippingMethod ).to.be.a( 'function' );
+	} );
+
+	test( 'should get the correct shipping method name', () => {
+		expect( getOrderShippingMethod( orderWithTax ) ).to.eql( 'USPS' );
+	} );
+
+	test( 'should return false if there is no shipping method', () => {
+		expect( getOrderShippingMethod( orderWithoutTax ) ).to.eql( false );
 	} );
 } );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
@@ -28,6 +27,7 @@ import { getPaymentCurrencySettings } from 'woocommerce/state/sites/settings/gen
 import { getOrderShippingTotal } from 'woocommerce/lib/order-values/totals';
 import { getOrderShippingMethod } from 'woocommerce/lib/order-values';
 import { getOrder } from 'woocommerce/state/sites/orders/selectors';
+import Notice from 'components/notice';
 
 const ratesSummary = ( selectedRates, availableRates, total, packagesSaved, translate ) => {
 	if ( ! packagesSaved ) {
@@ -108,8 +108,7 @@ const showCheckoutShippingInfo = ( props ) => {
 
 		return (
 			<div className="rates-step__shipping-info">
-				<Gridicon icon="shipping" />
-				<span>{ shippingInfo }</span>
+				<Notice showDismiss={ false }>{ shippingInfo }</Notice>
 			</div>
 		);
 	}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/index.js
@@ -95,16 +95,29 @@ const showCheckoutShippingInfo = ( props ) => {
 		translate,
 	} = props;
 
-	if ( shippingMethod && shippingCost ) {
-		const shippingInfo = translate(
-			'Your customer selected {{shippingMethod/}} and paid {{shippingCost/}}',
-			{
-				components: {
-					shippingMethod: <span className="rates-step__shipping-info-method">{ shippingMethod }</span>,
-					shippingCost: <span className="rates-step__shipping-info-cost">{ formatCurrency( shippingCost, currency ) }</span>,
-				},
-			}
-		);
+	if ( shippingMethod ) {
+		let shippingInfo;
+
+		if ( 0 < shippingCost ) {
+			shippingInfo = translate(
+				'Your customer selected {{shippingMethod/}} and paid {{shippingCost/}}',
+				{
+					components: {
+						shippingMethod: <span className="rates-step__shipping-info-method">{ shippingMethod }</span>,
+						shippingCost: <span className="rates-step__shipping-info-cost">{ formatCurrency( shippingCost, currency ) }</span>,
+					},
+				}
+			);
+		} else {
+			shippingInfo = translate(
+				'Your customer selected {{shippingMethod/}}',
+				{
+					components: {
+						shippingMethod: <span className="rates-step__shipping-info-method">{ shippingMethod }</span>,
+					},
+				}
+			);
+		}
 
 		return (
 			<div className="rates-step__shipping-info">

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/rates-step/style.scss
@@ -23,3 +23,8 @@
 	margin: -24px -24px 24px;
 	width: inherit;
 }
+
+.rates-step__shipping-info-method,
+.rates-step__shipping-info-cost {
+	font-weight: 600;
+}


### PR DESCRIPTION
Implements https://github.com/Automattic/woocommerce-services/issues/1117. ~**Needs styling help.**~

This PR adds the customer chosen shipping method and cost to the Rates step in the labels modal:

![screen shot 2018-01-02 at 4 59 46 pm](https://user-images.githubusercontent.com/63922/34506353-316e8298-efe9-11e7-8916-30f845d74ce4.png)
