### PR TITLE
Move link and tracking logic into SidebarBanner component

### DIFF
--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -16,14 +16,8 @@ import { endsWith, noop } from 'lodash';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isEligibleForDomainToPaidPlanUpsell } from 'state/selectors';
 import SidebarBanner from 'my-sites/current-site/sidebar-banner';
-import TrackComponentView from 'lib/analytics/track-component-view';
-import { recordTracksEvent } from 'state/analytics/actions';
 import { isDomainOnlySite } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-
-const impressionEventName = 'calypso_upgrade_nudge_impression';
-const clickEventName = 'calypso_upgrade_nudge_cta_click';
-const eventProperties = { cta_name: 'domain-to-paid-sidebar' };
 
 export class DomainToPaidPlanNotice extends Component {
 	static propTypes = {
@@ -34,44 +28,31 @@ export class DomainToPaidPlanNotice extends Component {
 		translate: noop,
 	};
 
-	onClick = () => {
-		this.props.recordTracksEvent( clickEventName, eventProperties );
-	};
-
-	getBannerText = () => {
-		const { translate } = this.props;
-
-		if ( this.props.isJetpack ) {
-			return translate( 'Upgrade for full site backups.' );
-		}
-		return translate( 'Upgrade your site and save.' );
-	};
-
 	render() {
-		const { eligible, isConflicting, isDomainOnly, site, translate } = this.props;
+		const { eligible, isConflicting, isDomainOnly, isJetpack, site, translate } = this.props;
 
 		if ( ! site || ! eligible || isConflicting ) {
 			return null;
 		}
 
-		const actionLink = isDomainOnly
+		const href = isDomainOnly
 			? `/start/site-selected/?siteSlug=${ encodeURIComponent(
 					site.slug
 				) }&siteId=${ encodeURIComponent( site.ID ) }`
 			: `/plans/my-plan/${ site.slug }`;
 
+		const text = isJetpack
+			? translate( 'Upgrade for full site backups.' )
+			: translate( 'Upgrade your site and save.' );
+
 		return (
-			<SidebarBanner icon="info-outline" text={ this.getBannerText() }>
-				<a onClick={ this.onClick } href={ actionLink }>
-					<span>
-						{ translate( 'Go' ) }
-						<TrackComponentView
-							eventName={ impressionEventName }
-							eventProperties={ eventProperties }
-						/>
-					</span>
-				</a>
-			</SidebarBanner>
+			<SidebarBanner
+				ctaName="domain-to-paid-sidebar"
+				ctaText={ translate( 'Go' ) }
+				href={ href }
+				icon="info-outline"
+				text={ text }
+			/>
 		);
 	}
 }
@@ -89,6 +70,6 @@ const mapStateToProps = state => {
 		isJetpack,
 	};
 };
-const mapDispatchToProps = { recordTracksEvent };
+const mapDispatchToProps = null;
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( DomainToPaidPlanNotice ) );

--- a/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/domain-to-paid-plan-notice.jsx
@@ -39,7 +39,7 @@ export class DomainToPaidPlanNotice extends Component {
 			? `/start/site-selected/?siteSlug=${ encodeURIComponent(
 					site.slug
 				) }&siteId=${ encodeURIComponent( site.ID ) }`
-			: `/plans/my-plan/${ site.slug }`;
+			: `/plans/${ site.slug }`;
 
 		const text = isJetpack
 			? translate( 'Upgrade for full site backups.' )

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -95,22 +95,16 @@ class SiteNotice extends React.Component {
 			return null;
 		}
 
-		const eventName = 'calypso_upgrade_nudge_impression';
-		const eventProperties = { cta_name: 'free-to-paid-sidebar' };
 		const { translate } = this.props;
 
 		return (
-			<SidebarBanner icon="info-outline" text={ translate( 'Free domain with a plan' ) }>
-				<a
-					onClick={ this.props.clickFreeToPaidPlanNotice }
-					href={ `/plans/my-plan/${ this.props.site.slug }` }
-				>
-					<span>
-						{ translate( 'Upgrade' ) }
-						<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
-					</span>
-				</a>
-			</SidebarBanner>
+			<SidebarBanner
+				ctaName="free-to-paid-sidebar"
+				ctaText={ translate( 'Upgrade' ) }
+				href={ `/plans/my-plan/${ this.props.site.slug }` }
+				icon="info-outline"
+				text={ translate( 'Free domain with a plan' ) }
+			/>
 		);
 	}
 

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -95,13 +95,13 @@ class SiteNotice extends React.Component {
 			return null;
 		}
 
-		const { translate } = this.props;
+		const { site, translate } = this.props;
 
 		return (
 			<SidebarBanner
 				ctaName="free-to-paid-sidebar"
 				ctaText={ translate( 'Upgrade' ) }
-				href={ `/plans/my-plan/${ this.props.site.slug }` }
+				href={ `/plans/${ site.slug }` }
 				icon="info-outline"
 				text={ translate( 'Free domain with a plan' ) }
 			/>

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -91,7 +91,7 @@ class SiteNotice extends React.Component {
 	}
 
 	freeToPaidPlanNotice() {
-		if ( ! this.props.isEligibleForFreeToPaidUpsell || '/plans' === this.props.allSitesPath ) {
+		if ( ! this.props.isEligibleForFreeToPaidUpsell ) {
 			return null;
 		}
 

--- a/client/my-sites/current-site/sidebar-banner/index.jsx
+++ b/client/my-sites/current-site/sidebar-banner/index.jsx
@@ -5,44 +5,61 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
+/**
+ * Internal dependencies
+ */
+import TrackComponentView from 'lib/analytics/track-component-view';
+import { recordTracksEvent } from 'state/analytics/actions';
+
 export class SidebarBanner extends Component {
 	static defaultProps = {
 		className: '',
-		icon: null,
-		text: null,
 	};
 
 	static propTypes = {
 		className: PropTypes.string,
+		ctaName: PropTypes.string,
+		ctaText: PropTypes.string,
 		icon: PropTypes.string,
-		onDismissClick: PropTypes.func,
-		text: PropTypes.oneOfType( [
-			PropTypes.arrayOf( PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ) ),
-			PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
-		] ),
+		href: PropTypes.string,
+		text: PropTypes.string,
+		track: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
+	onClick = () => {
+		const { ctaName, track } = this.props;
+		track( 'calypso_upgrade_nudge_cta_click', { cta_name: ctaName } );
+	};
+
 	render() {
-		const { children, className, icon, text } = this.props;
+		const { className, ctaName, ctaText, href, icon, text } = this.props;
 		const classes = classnames( 'sidebar-banner', className );
 
 		return (
-			<div className={ classes }>
+			<a className={ classes } onClick={ this.onClick } href={ href }>
+				<TrackComponentView
+					eventName="calypso_upgrade_nudge_impression"
+					eventProperties={ { cta_name: ctaName } }
+				/>
 				<span className="sidebar-banner__icon-wrapper">
 					<Gridicon className="sidebar-banner__icon" icon={ icon } size={ 18 } />
 				</span>
 				<span className="sidebar-banner__content">
-					<span className="sidebar-banner__text">{ text ? text : children }</span>
+					<span className="sidebar-banner__text">{ text }</span>
 				</span>
-				{ text ? children : null }
-			</div>
+				<span className="sidebar-banner__cta">{ ctaText }</span>
+			</a>
 		);
 	}
 }
 
-export default localize( SidebarBanner );
+const mapStateToProps = null;
+const mapDispatchToProps = { track: recordTracksEvent };
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( SidebarBanner ) );

--- a/client/my-sites/current-site/sidebar-banner/index.jsx
+++ b/client/my-sites/current-site/sidebar-banner/index.jsx
@@ -42,19 +42,21 @@ export class SidebarBanner extends Component {
 		const classes = classnames( 'sidebar-banner', className );
 
 		return (
-			<a className={ classes } onClick={ this.onClick } href={ href }>
+			<div className={ classes }>
 				<TrackComponentView
 					eventName="calypso_upgrade_nudge_impression"
 					eventProperties={ { cta_name: ctaName } }
 				/>
-				<span className="sidebar-banner__icon-wrapper">
-					<Gridicon className="sidebar-banner__icon" icon={ icon } size={ 18 } />
-				</span>
-				<span className="sidebar-banner__content">
-					<span className="sidebar-banner__text">{ text }</span>
-				</span>
-				<span className="sidebar-banner__cta">{ ctaText }</span>
-			</a>
+				<a onClick={ this.onClick } href={ href }>
+					<span className="sidebar-banner__icon-wrapper">
+						<Gridicon className="sidebar-banner__icon" icon={ icon } size={ 18 } />
+					</span>
+					<span className="sidebar-banner__content">
+						<span className="sidebar-banner__text">{ text }</span>
+					</span>
+					<span className="sidebar-banner__cta">{ ctaText }</span>
+				</a>
+			</div>
 		);
 	}
 }

--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -1,30 +1,38 @@
-a.sidebar-banner {
-	display: flex;
-	background-color: $alert-green;
-	color: $white;
+.sidebar-banner {
 	font-size: 12px;
+	transition: all 150ms ease-out;
 
-	:visited {
+	:hover {
+		background-color: lighten( $alert-green, 5% );
+	}
+
+	a {
+		background-color: $alert-green;
 		color: $white;
-	}
+		display: flex;
 
-	@include breakpoint( "<660px" ) {
-		padding: 0 24px;
-	}
+		:visited {
+			color: $white;
+		}
 
-	.sidebar-banner__icon-wrapper {
-		flex: 0 0 auto;
-		padding: 5px 5px 2px;
-	}
+		@include breakpoint( "<660px" ) {
+			padding: 0 24px;
+		}
 
-	.sidebar-banner__content {
-		width: 100%;
-		padding: 6px 5px 5px;
-	}
+		.sidebar-banner__icon-wrapper {
+			flex: 0 0 auto;
+			padding: 5px 5px 2px;
+		}
 
-	.sidebar-banner__cta {
-		transition: all 200ms ease-out;
-		padding: 6px 8px 2px 5px;
-		text-transform: uppercase;
+		.sidebar-banner__content {
+			width: 100%;
+			padding: 6px 5px 5px;
+		}
+
+		.sidebar-banner__cta {
+			transition: all 200ms ease-out;
+			padding: 6px 8px 2px 5px;
+			text-transform: uppercase;
+		}
 	}
 }

--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -1,8 +1,8 @@
 .sidebar-banner {
 	font-size: 12px;
-	transition: all 150ms ease-out;
 
 	:hover {
+		transition: all 150ms ease-out;
 		background-color: lighten( $alert-green, 5% );
 	}
 
@@ -30,7 +30,6 @@
 		}
 
 		.sidebar-banner__cta {
-			transition: all 200ms ease-out;
 			padding: 6px 8px 2px 5px;
 			text-transform: uppercase;
 		}

--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -4,6 +4,10 @@ a.sidebar-banner {
 	color: $white;
 	font-size: 12px;
 
+	:visited {
+		color: $white;
+	}
+
 	@include breakpoint( "<660px" ) {
 		padding: 0 24px;
 	}

--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -1,4 +1,4 @@
-.sidebar-banner {
+a.sidebar-banner {
 	display: flex;
 	background-color: $alert-green;
 	color: $white;
@@ -18,14 +18,9 @@
 		padding: 6px 5px 5px;
 	}
 
-	a {
+	.sidebar-banner__cta {
 		transition: all 200ms ease-out;
 		padding: 6px 8px 2px 5px;
-		color: $white;
 		text-transform: uppercase;
-	}
-
-	a:hover {
-		text-decoration: underline;
 	}
 }

--- a/client/my-sites/current-site/test/domain-to-paid-plan-notice.jsx
+++ b/client/my-sites/current-site/test/domain-to-paid-plan-notice.jsx
@@ -35,6 +35,6 @@ describe( 'DomainToPaidPlanNotice', () => {
 
 	test( 'should render component when site information is available and the site is eligible', () => {
 		const wrapper = shallow( <DomainToPaidPlanNotice site={ site } eligible /> );
-		expect( wrapper.type().displayName ).to.equal( 'Localized(SidebarBanner)' );
+		expect( wrapper.type().displayName ).to.equal( 'Connect(Localized(SidebarBanner))' );
 	} );
 } );


### PR DESCRIPTION
The primary goal of this change is to make the entire Sidebar banner component clickable rather than just the small link on the right hand side to address issue #21047.

In order to accomplish this, the change also moves the link and associated tracking logic into the component.

The url is also changed to `/plans/<site>` rather than `/plans/my-plan/<site>` as plans are actually purchased on the former page.  This will address issue #21049.

The component is only used in two scenarios: a free site that has a custom domain and a site on the free plan.  Both appear for both wpcom and jetpack sites (but not VIP sites).

# Testing

There are multiple cases for testing here: all free plans should see one of these nudges but the specific nudge will depend on whether jetpack or wpcom and whether there is a custom domain (a legacy product now usually only available as part of a plan).

If you create a free wpcom site with a custom domain, you should see the following nudge in the sidebar:

<img width="271" alt="screen shot 2018-01-03 at 3 12 45 pm" src="https://user-images.githubusercontent.com/1926/34509674-988b4876-f098-11e7-8e15-dd14c5341c13.png">

You should be able to click anywhere to visit the `/plans` page for the current site.

  