### PR TITLE
Jetpack Plans: Enable Happychat in all cancellation cases

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/stepsForProductAndSurvey.js
@@ -44,10 +44,8 @@ export default function stepsForProductAndSurvey( survey, product, canChat ) {
 		}
 	}
 
-	if ( survey && survey.questionOneRadio === 'couldNotActivate' ) {
-		if ( canChat && includesProduct( JETPACK_PAID_PLANS, product ) ) {
-			return [ steps.INITIAL_STEP, steps.HAPPYCHAT_STEP, steps.FINAL_STEP ];
-		}
+	if ( canChat && includesProduct( JETPACK_PAID_PLANS, product ) ) {
+		return [ steps.INITIAL_STEP, steps.HAPPYCHAT_STEP, steps.FINAL_STEP ];
 	}
 
 	return [ steps.INITIAL_STEP, steps.FINAL_STEP ];


### PR DESCRIPTION
This PR is an extension to #19441, and updates the Happychat step in the Jetpack plan cancellation flow to be shown in all cases when it's available (regardless of what the user selects in the cancellation flow survey. Previously, it was displayed only when the users select `I was unable to activate or use the product` as the answer of the first question.

Motivation for this change and further discussion: p7kMJG-4cV-p2

To test:
* Checkout this branch, or get it going on calypso.live.
* Make yourself available as an operator in the Happychat staging interface.
* Go to `/me/purchases`
* Select a Jetpack paid plan purchase.
* Click the "Remove Jetpack %plan%" button at the bottom.
* You'll see the first step of the cancellation flow.
* Select any answer to both questions. 
* Click "Next Step".
* Verify you can see the Happychat step, and it opens a live chat properly.
* Try the above with various Jetpack plans and various answers to the cancellation survey questions, verify Happychat step is shown in all cases.

cc @annezazu 