### PR TITLE
SimpleSiteRename: Add SimpleSiteRename component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -20,6 +20,7 @@
 @import 'account-recovery/reset-code-validation/style';
 @import 'account-recovery/style';
 @import 'auth/style';
+@import 'blocks/simple-site-rename-form/style';
 @import 'blocks/app-banner/style';
 @import 'blocks/app-promo/style';
 @import 'blocks/author-compact-profile/style';

--- a/client/blocks/simple-site-rename-form/dialog.jsx
+++ b/client/blocks/simple-site-rename-form/dialog.jsx
@@ -1,0 +1,99 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import { get, noop } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import Dialog from 'components/dialog';
+import FormTextInput from 'components/forms/form-text-input';
+
+class RenameSiteConfirmationDialog extends PureComponent {
+	static propTypes = {
+		isVisible: PropTypes.bool.isRequired,
+		onConfirm: PropTypes.func.isRequired,
+		onClose: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		onConfirm: noop,
+	};
+
+	state = {
+		confirmationTypedCorrectly: false,
+		confirmationValue: '',
+	};
+
+	onConfirmChange = event => {
+		const confirmationValue = get( event, 'target.value' );
+		const confirmationTypedCorrectly =
+			confirmationValue === `${ this.props.newDomainName }.wordpress.com`;
+
+		this.setState( {
+			confirmationValue,
+			confirmationTypedCorrectly,
+		} );
+	};
+
+	onConfirm = closeDialog => {
+		this.props.onConfirm( this.props.targetSite, closeDialog );
+	};
+
+	render() {
+		const {
+			disabledDialogButtons,
+			isVisible,
+			newDomainName,
+			currentDomainName,
+			translate,
+		} = this.props;
+		const buttons = [
+			{
+				action: 'cancel',
+				label: translate( 'Cancel' ),
+				disabled: disabledDialogButtons,
+			},
+			{
+				action: 'confirm',
+				label: translate( 'Change Site Address' ),
+				onClick: this.onConfirm,
+				disabled: disabledDialogButtons || ! this.state.confirmationTypedCorrectly,
+				isPrimary: true,
+			},
+		];
+
+		return (
+			<Dialog
+				className="simple-site-rename-form__dialog"
+				isVisible={ isVisible }
+				buttons={ buttons }
+				onClose={ this.props.onClose }
+			>
+				<h1>{ translate( 'Confirm Site Adress Change' ) }</h1>
+				<p>
+					{ translate(
+						'Please type your new address {{green}}%(newDomainName)s.wordpress.com{{/green}} ' +
+							'into the field below to confirm the change. ' +
+							'Your site will no longer be available at {{red}}%(currentDomainName)s.wordpress.com{{/red}}. ' +
+							'This change cannot be undone.',
+						{
+							args: { currentDomainName, newDomainName },
+							components: {
+								green: <strong className="simple-site-rename-form__copy-green" />,
+								red: <strong className="simple-site-rename-form__copy-red" />,
+							},
+						}
+					) }
+				</p>
+				<FormTextInput value={ this.state.confirmationValue } onChange={ this.onConfirmChange } />
+			</Dialog>
+		);
+	}
+}
+
+export default localize( RenameSiteConfirmationDialog );

--- a/client/blocks/simple-site-rename-form/docs/example.js
+++ b/client/blocks/simple-site-rename-form/docs/example.js
@@ -1,0 +1,28 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { SimpleSiteRenameForm } from '../';
+
+const SimpleSiteRenameFormExample = ( { siteId, siteSlug, translate } ) => {
+	const currentDomainNameStub = {
+		name: 'something-awesome.wordpress.com',
+		type: 'WPCOM',
+	};
+
+	return (
+		<SimpleSiteRenameForm translate={ translate } currentDomainName={ currentDomainNameStub } />
+	);
+};
+
+const EnhancedComponent = localize( SimpleSiteRenameFormExample );
+
+EnhancedComponent.displayName = 'SimpleSiteRenameForm';
+
+export default EnhancedComponent;

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -1,0 +1,91 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { noop, get, flow } from 'lodash';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import CompactCard from 'components/card/compact';
+import FormButton from 'components/forms/form-button';
+import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+import ConfirmationDialog from './dialog';
+
+export class SimpleSiteRenameForm extends Component {
+	state = {
+		showDialog: false,
+		domainFieldValue: '',
+	};
+
+	onSubmit = event => {
+		event.preventDefault();
+
+		this.setState( {
+			showDialog: true,
+		} );
+	};
+
+	onDialogClose = () => {
+		this.setState( {
+			showDialog: false,
+		} );
+	};
+
+	onFieldChange = event => {
+		this.setState( { domainFieldValue: get( event, 'target.value' ) } );
+	};
+
+	render() {
+		const { currentDomainName, translate } = this.props;
+
+		// This may need more consideration given the new x.music.blog type domains
+		const isWPCOM = currentDomainName.type === 'WPCOM';
+		// This is naive - there's surely a better way.
+		const domainPrefix = currentDomainName.name.replace( '.wordpress.com', '' );
+
+		const isDisabled =
+			! isWPCOM || ! this.state.domainFieldValue || this.state.domainFieldValue === domainPrefix;
+
+		return (
+			<div className="simple-site-rename-form">
+				<ConfirmationDialog
+					isVisible={ this.state.showDialog }
+					onClose={ this.onDialogClose }
+					newDomainName={ this.state.domainFieldValue }
+					currentDomainName={ currentDomainName.name.replace( '.wordpress.com', '' ) }
+				/>
+				<form onSubmit={ this.onSubmit }>
+					<Card className="simple-site-rename-form__content">
+						<FormTextInputWithAffixes
+							type="text"
+							value={ this.state.domainFieldValue }
+							suffix={ '.wordpress.com' }
+							onBlur={ noop }
+							onChange={ this.onFieldChange }
+							onFocus={ noop }
+							placeholder={ domainPrefix }
+						/>
+						<div className="simple-site-rename-form__info">
+							<Gridicon icon="info-outline" size={ 18 } />
+							<p>
+								{ translate( 'This address was included with your site and is free for life!' ) }
+							</p>
+						</div>
+					</Card>
+					<CompactCard className="simple-site-rename-form__footer">
+						<FormButton disabled={ isDisabled } type="submit">
+							{ translate( 'Change Site Address' ) }
+						</FormButton>
+					</CompactCard>
+				</form>
+			</div>
+		);
+	}
+}
+
+export default flow( localize )( SimpleSiteRenameForm );

--- a/client/blocks/simple-site-rename-form/style.scss
+++ b/client/blocks/simple-site-rename-form/style.scss
@@ -1,0 +1,71 @@
+/** @format */
+
+.simple-site-rename-form__dialog {
+	text-align: center;
+	max-width: 400px;
+	color: darken($gray, 20%);
+}
+
+.simple-site-rename-form__copy-green {
+	color: $alert-green;
+}
+
+.simple-site-rename-form__copy-red {
+	color: $alert-red;
+}
+
+.card.simple-site-rename-form__content {
+	margin-bottom: 0;
+}
+
+.simple-site-rename-form__info {
+	color: $gray-text-min;
+	margin: 5px 0 0 0;
+	padding: 0;
+	text-align: center;
+
+	@include breakpoint( '>660px' ) {
+		padding: 0;
+		text-align: left;
+	}
+
+	p {
+		font-size: 12px;
+		margin: 0;
+
+		@include breakpoint( '>660px' ) {
+			margin-left: 24px;
+		}
+	}
+
+	.gridicon {
+		float: left;
+
+		@include breakpoint( '<660px' ) {
+			display: none;
+		}
+	}
+}
+
+.simple-site-rename-form__footer {
+	align-items: center;
+	border-top-color: $gray-light;
+	display: flex;
+	justify-content: space-between;
+
+	button {
+		margin-left: auto;
+	}
+
+	@include breakpoint( '<660px' ) {
+		flex-direction: column-reverse;
+
+		em {
+			margin-top: 10px;
+		}
+
+		button {
+			width: 100%;
+		}
+	}
+}

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -81,6 +81,7 @@ import SimplePaymentsDialog from 'components/tinymce/plugins/simple-payments/dia
 import ConversationCaterpillar from 'blocks/conversation-caterpillar/docs/example';
 import ConversationFollowButton from 'blocks/conversation-follow-button/docs/example';
 import ColorSchemePicker from 'blocks/color-scheme-picker/docs/example';
+import SimpleSiteRenameForm from 'blocks/simple-site-rename-form/docs/example';
 
 export default class AppComponents extends React.Component {
 	static displayName = 'AppComponents';
@@ -115,6 +116,8 @@ export default class AppComponents extends React.Component {
 					filter={ this.state.filter }
 					section="blocks"
 				>
+					{ /* To Be reordered */
+					isEnabled( 'simple-site-rename/devdocs' ) && <SimpleSiteRenameForm /> }
 					<AuthorSelector />
 					<CalendarButton />
 					<CalendarPopover />

--- a/config/development.json
+++ b/config/development.json
@@ -163,6 +163,7 @@
 		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
 		"simple-payments": true,
+		"simple-site-rename/devdocs": true,
 		"support-user": true,
 		"sync-handler": true,
 		"try/preconnect": true,


### PR DESCRIPTION
### Summary

This PR aims to add a new component/block that will ultimately allow users to change their `.wordpress.com` domain (And, in the future, `.x.blog` domains). For now, this PR will only aim to add the base component as a dev-docs example, adding the component to Calypso and interacting with the API will come in later PRs.

### Design
I've based the design of this component on the prototype shown in https://github.com/Automattic/wp-calypso/issues/2473 though I'm very keen to take feedback and suggestions for improvement as this prototype was made (almost exactly) 2 years ago.

#### Component

<img width="548" alt="screen shot 2018-01-03 at 13 46 44" src="https://user-images.githubusercontent.com/4335450/34522971-540e72dc-f08d-11e7-83fa-5e7f7e8185e6.png">

#### Modal

<img width="480" alt="screen shot 2018-01-03 at 13 46 50" src="https://user-images.githubusercontent.com/4335450/34522970-53ee9660-f08d-11e7-9e18-84afb23849f5.png">

### Testing
> Note: I've been seeing a state issue where the users primary domain isn't available right away. As a temporary workaround I've found that visiting Calypso first (click `my sites`) then hitting the back button causes that state to be added. I'll be fixing that before this PR is ready for a final review but for now you'll need to do this to see the example in devdocs.

- Visit: http://calypso.localhost:3000/devdocs/blocks and find `SimpleSiteRenameForm`.
  - You should see your primary domain as the form field placeholder and the action button should be disabled.
- Edit the form field with a new site name.
  - The action button should now be enabled.
- Edit the form field to match the current name of your site
  - The button should now be disabled
- Edit again to some new site name.
- Click the action button
  - A modal should appear (appearing as in the modal screenshot above).
  - Note that the confirmation button is diabled
- Edit the modals form field as the instructions describe, matching the new url (`x.wordpress.com`)
  - Note that the confirmation button is now enabled
- Clicking the confirm button doesn't do anything as of yet.

### Future Work
- [ ] Functional API interactions (ability to actually change the name and persist that change)
- [ ] Include other freely available domains
- [ ] Offer domain suggestions if a domain is already taken (implementing existing components)
- [ ] Replace the existing flow entirely
  - [ ] Update https://en.support.wordpto reflect the change.
- [ ] Form validation
  - [ ] Handle cases where a customer types a full address rather than just the suffix<img width="527" alt="screen shot 2018-01-05 at 14 31 55" src="https://user-images.githubusercontent.com/4335450/34613317-3c6efedc-f225-11e7-8e06-965bb3b29675.png">


  
  
  