### PR TITLE
JP Onboarding: Install WooCommerce

### DIFF
--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,14 +15,22 @@ import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
+import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingWoocommerceStep extends React.PureComponent {
+	handleWooCommerceInstallation = () => {
+		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
+			installWooCommerce: true,
+		} );
+	};
+
 	render() {
-		const { translate } = this.props;
+		const { getForwardUrl, translate } = this.props;
 		const headerText = translate( 'Are you looking to sell online?' );
 		const subHeaderText = translate(
 			"We'll set you up with WooCommerce for all of your online selling needs."
 		);
+		const forwardUrl = getForwardUrl();
 
 		return (
 			<div className="steps__main">
@@ -34,12 +43,16 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<div className="steps__button-group">
-					<Button primary>{ translate( 'Yes, I am' ) }</Button>
-					<Button>{ translate( 'Not right now' ) }</Button>
+					<Button href={ forwardUrl } onClick={ this.handleWooCommerceInstallation } primary>
+						{ translate( 'Yes, I am' ) }
+					</Button>
+					<Button href={ forwardUrl }>{ translate( 'Not right now' ) }</Button>
 				</div>
 			</div>
 		);
 	}
 }
 
-export default localize( JetpackOnboardingWoocommerceStep );
+export default connect( null, { saveJetpackOnboardingSettings } )(
+	localize( JetpackOnboardingWoocommerceStep )
+);


### PR DESCRIPTION
This PR updates the WooCommerce step to install the WC plugin on the remote site when clicking the corresponding button.

To test:
1. Checkout this branch on your local Calypso.
1. Apply Automattic/jetpack#8450 to your Jetpack sandbox.
1. Make sure you don't have WooCommerce installed on your Jetpack sandbox.
1. Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
1. After you land the JPO flow, skip to the WooCommerce step.
1. Click the "Yes, I am" button.
1. Verify that the WooCommerce plugin was installed and activated on your JP site.
1. Try the same procedure with WooCommerce already 
   * installed but inactive
   * installed and active

  
  