### PR TITLE
Activity Log: don't refresh the day component unless it's necessary

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -76,6 +76,18 @@ class ActivityLogDay extends Component {
 		dayExpanded: false,
 	};
 
+	shouldComponentUpdate( nextProps ) {
+		return (
+			nextProps.logs.length !== this.props.logs.length ||
+			nextProps.disableRestore !== this.props.disableRestore ||
+			nextProps.disableBackup !== this.props.disableBackup ||
+			nextProps.requestedRestoreId !== this.props.requestedRestoreId ||
+			nextProps.requestedBackupId !== this.props.requestedBackupId ||
+			nextProps.isToday !== this.props.isToday ||
+			nextProps.isRewindActive !== this.props.isRewindActive
+		);
+	}
+
 	componentWillReceiveProps( nextProps ) {
 		// if Rewind dialog is being displayed and it's then canceled or a different Rewind button is clicked
 		if ( this.state.rewindHere && this.props.requestedRestoreId !== nextProps.requestedRestoreId ) {


### PR DESCRIPTION
Fixes #20230

The introduction to continuous polling brought a nice improvement: a day is refreshed every time the state is updated and if there are new events, they're inserted.
However, the day is also refreshed even when there aren't new events. This PR solves that by refreshing the day only if certain props that modify the event list or the inserted dialogs have changed. For example, the number of logged items in the day, a requested backup id, whether today is the current day, if Rewind is enabled, and so on.

To test:
- make sure new logged events are added to the timeline
- the timeline should not refresh if there are not new logged events