### PR TITLE
Framework: Make InfiniteList more reliably fire fetchNextPage

### DIFF
--- a/client/components/infinite-list/scroll-helper.js
+++ b/client/components/infinite-list/scroll-helper.js
@@ -458,7 +458,7 @@ class ScrollHelper {
 
 		// scroll check may be triggered while dispatching an action,
 		// we cannot create new action while dispatching old one
-		this.queuedFetchNextPage = setTimeout( () => {
+		this.queuedFetchNextPage = requestAnimationFrame( () => {
 			this.queuedFetchNextPage = null;
 			// checking these values again because we shifted the fetch to the next stack
 			if ( this.props.fetchingNextPage || this.props.lastPage ) {
@@ -467,7 +467,7 @@ class ScrollHelper {
 			this.props.fetchNextPage( {
 				triggeredByScroll: triggeredByScroll,
 			} );
-		}, 0 );
+		} );
 	}
 }
 

--- a/client/components/infinite-list/scroll-helper.js
+++ b/client/components/infinite-list/scroll-helper.js
@@ -443,6 +443,9 @@ class ScrollHelper {
 	}
 
 	loadNextPage() {
+		if ( this.queuedFetchNextPage ) {
+			return;
+		}
 		let triggeredByScroll = this.triggeredByScroll;
 
 		debug( 'fetching next page', this.containerBottom, this.bottomPlaceholderHeight );
@@ -455,7 +458,8 @@ class ScrollHelper {
 
 		// scroll check may be triggered while dispatching an action,
 		// we cannot create new action while dispatching old one
-		setTimeout( () => {
+		this.queuedFetchNextPage = setTimeout( () => {
+			this.queuedFetchNextPage = null;
 			// checking these values again because we shifted the fetch to the next stack
 			if ( this.props.fetchingNextPage || this.props.lastPage ) {
 				return false;

--- a/client/components/infinite-list/scroll-helper.js
+++ b/client/components/infinite-list/scroll-helper.js
@@ -458,7 +458,7 @@ class ScrollHelper {
 
 		// scroll check may be triggered while dispatching an action,
 		// we cannot create new action while dispatching old one
-		this.queuedFetchNextPage = requestAnimationFrame( () => {
+		this.queuedFetchNextPage = Promise.resolve().then( () => {
 			this.queuedFetchNextPage = null;
 			// checking these values again because we shifted the fetch to the next stack
 			if ( this.props.fetchingNextPage || this.props.lastPage ) {


### PR DESCRIPTION
Chrome appears to now be throttling setTimeout( fn, 0 ) style calls and we're seeing massive delays in the execution of the callback, sometimes 10 ~ 20s on a modern Mac. Switch to using requestAnimationFrame instead, which appears to be more reliable to call the callback within a second or so.

To test, pull up the Reader following stream on this branch and on production. Quickly scroll to the bottom of the stream repeatedly. On this branch you should see new posts flow in fairly quickly and the loading placeholders should appear even if the API is a little pokey. On prod, you hit the end of the stream and it just sits and hangs.