### PR TITLE
Jetpack Connect: updated wording to remove ambiguity. 

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -332,7 +332,7 @@ export class JetpackConnectMain extends Component {
 			return {
 				headerTitle: translate( 'Get Jetpack Personal' ),
 				headerSubtitle: translate(
-					'Security essentials for every WordPress site ' +
+					'Security essentials for your WordPress site ' +
 						'including automated backups and priority support.'
 				),
 			};


### PR DESCRIPTION
You must purchase a new plan for each site, so the copy now reflects that.

Before:

![image](https://user-images.githubusercontent.com/437258/34536862-848e1df2-f094-11e7-8e0b-bcc720554f34.png)

After:

![image](https://user-images.githubusercontent.com/437258/34536834-6b6cbd56-f094-11e7-8d66-15fa1eed0ca7.png)

If this looks good to the reviewer, feel free to merge!

context: p7kMJG-4da

cc @danjjohnson @johnHackworth 