### PR TITLE
Store: Discard track events for flagged test sites

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -14,7 +14,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import ActionHeader from 'woocommerce/components/action-header';
-import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import {
 	areSetupChoicesLoading,
 	getFinishedInitialSetup,
@@ -61,7 +60,6 @@ class Dashboard extends Component {
 		siteId: PropTypes.number,
 		mailChimpConfigured: PropTypes.bool,
 		fetchOrders: PropTypes.func,
-		fetchSetupChoices: PropTypes.func,
 		requestSyncStatus: PropTypes.func,
 		setupChoicesLoading: PropTypes.bool,
 	};
@@ -85,7 +83,6 @@ class Dashboard extends Component {
 
 	fetchStoreData = () => {
 		const { siteId, productsLoaded } = this.props;
-		this.props.fetchSetupChoices( siteId );
 		this.props.fetchOrders( siteId );
 		this.props.requestSettings( siteId );
 
@@ -229,7 +226,6 @@ function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
 			fetchOrders,
-			fetchSetupChoices,
 			fetchProducts,
 			requestSettings,
 		},

--- a/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-no-orders-view.js
@@ -12,11 +12,11 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import BasicWidget from 'woocommerce/components/basic-widget';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import ShareWidget from 'woocommerce/components/share-widget';
 import WidgetGroup from 'woocommerce/components/widget-group';
+import { recordTrack } from 'woocommerce/lib/analytics';
 
 class ManageNoOrdersView extends Component {
 	static propTypes = {
@@ -43,7 +43,7 @@ class ManageNoOrdersView extends Component {
 	renderStatsWidget = () => {
 		const { site, translate } = this.props;
 		const trackClick = () => {
-			analytics.tracks.recordEvent( 'calypso_woocommerce_dashboard_action_click', {
+			recordTrack( 'calypso_woocommerce_dashboard_action_click', {
 				action: 'view-stats',
 			} );
 			page.redirect( getLink( '/store/stats/orders/day/:site', site ) );
@@ -68,7 +68,7 @@ class ManageNoOrdersView extends Component {
 	renderViewAndTestWidget = () => {
 		const { site, translate } = this.props;
 		const trackClick = () => {
-			analytics.tracks.recordEvent( 'calypso_woocommerce_dashboard_action_click', {
+			recordTrack( 'calypso_woocommerce_dashboard_action_click', {
 				action: 'view-and-test',
 			} );
 		};

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -16,7 +16,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { activatePlugin, installPlugin, fetchPlugins } from 'state/plugins/installed/actions';
-import analytics from 'lib/analytics';
 import Button from 'components/button';
 import { fetchPluginData } from 'state/plugins/wporg/actions';
 import { getPlugin } from 'state/plugins/wporg/selectors';
@@ -29,6 +28,7 @@ import { setFinishedInstallOfRequiredPlugins } from 'woocommerce/state/sites/set
 import { hasSitePendingAutomatedTransfer } from 'state/selectors';
 import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
 import { transferStates } from 'state/automated-transfer/constants';
+import { recordTrack } from 'woocommerce/lib/analytics';
 
 // Time in seconds to complete various steps.
 const TIME_TO_TRANSFER_ACTIVE = 5;
@@ -370,7 +370,7 @@ class RequiredPluginsInstallView extends Component {
 	startSetup = () => {
 		const { hasPendingAT } = this.props;
 
-		analytics.tracks.recordEvent( 'calypso_woocommerce_dashboard_action_click', {
+		recordTrack( 'calypso_woocommerce_dashboard_action_click', {
 			action: 'initial-setup',
 		} );
 

--- a/client/extensions/woocommerce/app/dashboard/setup-task.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-task.js
@@ -13,8 +13,8 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import Button from 'components/button';
+import { recordTrack } from 'woocommerce/lib/analytics';
 
 class SetupTask extends Component {
 	static propTypes = {
@@ -37,7 +37,7 @@ class SetupTask extends Component {
 	};
 
 	track( analyticsProp ) {
-		analytics.tracks.recordEvent( 'calypso_woocommerce_dashboard_action_click', {
+		recordTrack( 'calypso_woocommerce_dashboard_action_click', {
 			action: analyticsProp,
 		} );
 	}

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks-view.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks-view.js
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import {
 	getOptedOutOfShippingSetup,
 	getOptedOutofTaxesSetup,
@@ -26,6 +25,7 @@ import SetupTasks from './setup-tasks';
 import QueryShippingZones from 'woocommerce/components/query-shipping-zones';
 import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 import { areAnyShippingMethodsEnabled } from 'woocommerce/state/ui/shipping/zones/selectors';
+import { recordTrack } from 'woocommerce/lib/analytics';
 
 class SetupTasksView extends Component {
 	static propTypes = {
@@ -37,7 +37,7 @@ class SetupTasksView extends Component {
 
 	onFinished = event => {
 		event.preventDefault();
-		analytics.tracks.recordEvent( 'calypso_woocommerce_dashboard_action_click', {
+		recordTrack( 'calypso_woocommerce_dashboard_action_click', {
 			action: 'finished',
 		} );
 		this.props.setFinishedInitialSetup( this.props.site.ID, true );

--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -23,7 +23,6 @@ import { getTotalProducts, areProductsLoaded } from 'woocommerce/state/sites/pro
 import { fetchProducts } from 'woocommerce/state/sites/products/actions';
 import { fetchPaymentMethods } from 'woocommerce/state/sites/payment-methods/actions';
 import {
-	fetchSetupChoices,
 	setOptedOutOfShippingSetup,
 	setTriedCustomizerDuringInitialSetup,
 	setCheckedTaxSetup,
@@ -54,7 +53,6 @@ class SetupTasks extends Component {
 
 		if ( site && site.ID ) {
 			this.props.fetchPaymentMethods( site.ID );
-			this.props.fetchSetupChoices( site.ID );
 
 			if ( ! areProductsLoaded ) {
 				this.props.fetchProducts( site.ID, { page: 1 } );
@@ -69,7 +67,6 @@ class SetupTasks extends Component {
 		const oldSiteId = ( site && site.ID ) || null;
 
 		if ( newSiteId && oldSiteId !== newSiteId ) {
-			this.props.fetchSetupChoices( newSiteId );
 			if ( ! areProductsLoaded ) {
 				this.props.fetchProducts( newSiteId, { page: 1 } );
 			}
@@ -236,7 +233,6 @@ function mapDispatchToProps( dispatch ) {
 		{
 			fetchPaymentMethods,
 			fetchProducts,
-			fetchSetupChoices,
 			setOptedOutOfShippingSetup,
 			setCheckedTaxSetup,
 			setTriedCustomizerDuringInitialSetup,

--- a/client/extensions/woocommerce/app/index.js
+++ b/client/extensions/woocommerce/app/index.js
@@ -5,10 +5,11 @@
  */
 
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import page from 'page';
 import { localize } from 'i18n-calypso';
+import page from 'page';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -20,8 +21,9 @@ import {
 } from 'state/selectors';
 import config from 'config';
 import DocumentHead from 'components/data/document-head';
-import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
+import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import route from 'lib/route';
 
 class App extends Component {
@@ -35,9 +37,26 @@ class App extends Component {
 		children: PropTypes.element.isRequired,
 	};
 
+	componentDidMount = () => {
+		const { siteId } = this.props;
+
+		if ( siteId ) {
+			this.props.fetchSetupChoices( siteId );
+		}
+	};
+
 	componentWillReceiveProps( newProps ) {
 		if ( this.props.children !== newProps.children ) {
 			window.scrollTo( 0, 0 );
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		const { siteId } = this.props;
+		const oldSiteId = prevProps.siteId ? prevProps.siteId : null;
+
+		if ( siteId && oldSiteId !== siteId ) {
+			this.props.fetchSetupChoices( siteId );
 		}
 	}
 
@@ -112,4 +131,13 @@ function mapStateToProps( state ) {
 	};
 }
 
-export default connect( mapStateToProps )( localize( App ) );
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			fetchSetupChoices,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( App ) );

--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -29,7 +29,6 @@ import {
 	clearProductCategoryEdits,
 	editProductCategory,
 } from 'woocommerce/state/ui/product-categories/actions';
-import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import { getActionList } from 'woocommerce/state/action-list/selectors';
 import {
 	getCurrentlyEditingId,
@@ -74,7 +73,6 @@ class ProductCreate extends React.Component {
 				this.props.editProduct( site.ID, null, {} );
 			}
 			this.props.fetchProductCategories( site.ID );
-			this.props.fetchSetupChoices( site.ID );
 		}
 	}
 
@@ -85,7 +83,6 @@ class ProductCreate extends React.Component {
 		if ( oldSiteId !== newSiteId ) {
 			this.props.editProduct( newSiteId, null, {} );
 			this.props.fetchProductCategories( newSiteId );
-			this.props.fetchSetupChoices( newSiteId );
 		}
 	}
 
@@ -233,7 +230,6 @@ function mapDispatchToProps( dispatch ) {
 			editProductAttribute,
 			editProductVariation,
 			fetchProductCategories,
-			fetchSetupChoices,
 			clearProductEdits,
 			clearProductCategoryEdits,
 			clearProductVariationEdits,

--- a/client/extensions/woocommerce/app/settings/payments/index.js
+++ b/client/extensions/woocommerce/app/settings/payments/index.js
@@ -20,7 +20,6 @@ import Button from 'components/button';
 import { createPaymentSettingsActionList } from 'woocommerce/state/ui/payments/actions';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import ExtendedHeader from 'woocommerce/components/extended-header';
-import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import { getActionList } from 'woocommerce/state/action-list/selectors';
 import { getFinishedInitialSetup } from 'woocommerce/state/sites/setup-choices/selectors';
 import { getLink } from 'woocommerce/lib/nav-utils';
@@ -53,26 +52,11 @@ class SettingsPayments extends Component {
 	componentDidMount = () => {
 		const { site } = this.props;
 
-		if ( site && site.ID ) {
-			this.props.fetchSetupChoices( site.ID );
-		}
-
 		// If we are in the middle of the Stripe Connect OAuth flow
 		// go ahead and option the Stripe dialog right away so
 		// we can complete the flow
 		if ( hasOAuthParamsInLocation() || hasOAuthCompleteInLocation() ) {
 			this.props.openPaymentMethodForEdit( site.ID, 'stripe' );
-		}
-	};
-
-	componentWillReceiveProps = newProps => {
-		const { site } = this.props;
-
-		const newSiteId = newProps.site ? newProps.site.ID : null;
-		const oldSiteId = site ? site.ID : null;
-
-		if ( oldSiteId !== newSiteId ) {
-			this.props.fetchSetupChoices( newSiteId );
 		}
 	};
 
@@ -178,7 +162,6 @@ function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
 			createPaymentSettingsActionList,
-			fetchSetupChoices,
 			openPaymentMethodForEdit,
 		},
 		dispatch

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import Button from 'components/button';
 import {
 	cancelEditingPaymentMethod,
@@ -35,6 +34,7 @@ import PaymentMethodEditFormToggle from './payment-method-edit-form-toggle';
 import PaymentMethodPaypal from './payment-method-paypal';
 import PaymentMethodStripe from './payment-method-stripe';
 import PaymentMethodCheque from './payment-method-cheque';
+import { recordTrack } from 'woocommerce/lib/analytics';
 
 class PaymentMethodItem extends Component {
 	static propTypes = {
@@ -90,11 +90,11 @@ class PaymentMethodItem extends Component {
 		this.props.changePaymentMethodEnabled( site.ID, method.id, enabled );
 
 		if ( enabled ) {
-			analytics.tracks.recordEvent( 'calypso_woocommerce_payment_method_enabled', {
+			recordTrack( 'calypso_woocommerce_payment_method_enabled', {
 				payment_method: method.id,
 			} );
 		} else {
-			analytics.tracks.recordEvent( 'calypso_woocommerce_payment_method_disabled', {
+			recordTrack( 'calypso_woocommerce_payment_method_disabled', {
 				payment_method: method.id,
 			} );
 		}
@@ -111,7 +111,7 @@ class PaymentMethodItem extends Component {
 		if ( ! method.enabled ) {
 			this.props.onChange();
 			this.props.changePaymentMethodEnabled( site.ID, method.id, true );
-			analytics.tracks.recordEvent( 'calypso_woocommerce_payment_method_enabled', {
+			recordTrack( 'calypso_woocommerce_payment_method_enabled', {
 				payment_method: method.id,
 			} );
 		}

--- a/client/extensions/woocommerce/app/settings/shipping/save-button.js
+++ b/client/extensions/woocommerce/app/settings/shipping/save-button.js
@@ -15,7 +15,6 @@ import page from 'page';
  * Internal dependencies
  */
 import Button from 'components/button';
-import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import {
 	areSetupChoicesLoading,
 	getFinishedInitialSetup,
@@ -30,25 +29,6 @@ import { isWcsEnabled } from 'woocommerce/state/selectors/plugins';
 class ShippingSettingsSaveButton extends Component {
 	static propTypes = {
 		onSaveSuccess: PropTypes.func.isRequired,
-	};
-
-	componentDidMount = () => {
-		const { site } = this.props;
-
-		if ( site && site.ID ) {
-			this.props.fetchSetupChoices( site.ID );
-		}
-	};
-
-	componentWillReceiveProps = newProps => {
-		const { site } = this.props;
-
-		const newSiteId = newProps.site ? newProps.site.ID : null;
-		const oldSiteId = site ? site.ID : null;
-
-		if ( oldSiteId !== newSiteId ) {
-			this.props.fetchSetupChoices( newSiteId );
-		}
 	};
 
 	onSaveSuccess = dispatch => {
@@ -133,7 +113,6 @@ function mapStateToProps( state ) {
 function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
-			fetchSetupChoices,
 			createWcsShippingSaveActionList,
 		},
 		dispatch

--- a/client/extensions/woocommerce/app/settings/taxes/save-button.js
+++ b/client/extensions/woocommerce/app/settings/taxes/save-button.js
@@ -6,7 +6,6 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -15,7 +14,6 @@ import page from 'page';
  * Internal dependencies
  */
 import Button from 'components/button';
-import { fetchSetupChoices } from 'woocommerce/state/sites/setup-choices/actions';
 import {
 	areSetupChoicesLoading,
 	getFinishedInitialSetup,
@@ -26,25 +24,6 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 class TaxSettingsSaveButton extends Component {
 	static propTypes = {
 		onSave: PropTypes.func.isRequired,
-	};
-
-	componentDidMount = () => {
-		const { site } = this.props;
-
-		if ( site && site.ID ) {
-			this.props.fetchSetupChoices( site.ID );
-		}
-	};
-
-	componentWillReceiveProps = newProps => {
-		const { site } = this.props;
-
-		const newSiteId = newProps.site ? newProps.site.ID : null;
-		const oldSiteId = site ? site.ID : null;
-
-		if ( oldSiteId !== newSiteId ) {
-			this.props.fetchSetupChoices( newSiteId );
-		}
 	};
 
 	onSave = e => {
@@ -88,13 +67,4 @@ function mapStateToProps( state ) {
 	};
 }
 
-function mapDispatchToProps( dispatch ) {
-	return bindActionCreators(
-		{
-			fetchSetupChoices,
-		},
-		dispatch
-	);
-}
-
-export default connect( mapStateToProps, mapDispatchToProps )( localize( TaxSettingsSaveButton ) );
+export default connect( mapStateToProps )( localize( TaxSettingsSaveButton ) );

--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -16,6 +16,7 @@ import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getQueryDate } from './utils';
 import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
+import { recordTrack } from 'woocommerce/lib/analytics';
 
 function isValidParameters( context ) {
 	const validParameters = {
@@ -67,7 +68,7 @@ export default function StatsController( context, next ) {
 			break;
 	}
 	if ( tracksEvent ) {
-		analytics.tracks.recordEvent( tracksEvent, {
+		recordTrack( tracksEvent, {
 			unit: props.unit,
 			query_date: props.queryDate,
 			selected_date: props.selectedDate,

--- a/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-chart/index.js
@@ -28,9 +28,8 @@ import {
 import Legend from 'components/chart/legend';
 import Tabs from 'my-sites/stats/stats-tabs';
 import Tab from 'my-sites/stats/stats-tabs/tab';
-import { UNITS } from 'woocommerce/app/store-stats/constants';
-import analytics from 'lib/analytics';
-import { chartTabs as tabs } from 'woocommerce/app/store-stats/constants';
+import { UNITS, chartTabs as tabs } from 'woocommerce/app/store-stats/constants';
+import { recordTrack } from 'woocommerce/lib/analytics';
 
 class StoreStatsChart extends Component {
 	static propTypes = {
@@ -57,7 +56,7 @@ class StoreStatsChart extends Component {
 			selectedTabIndex: tab.index,
 		} );
 
-		analytics.tracks.recordEvent( 'calypso_woocommerce_stats_chart_tab_click', {
+		recordTrack( 'calypso_woocommerce_stats_chart_tab_click', {
 			tab: tabs[ tab.index ].attr,
 		} );
 	};

--- a/client/extensions/woocommerce/components/reading-widget/index.js
+++ b/client/extensions/woocommerce/components/reading-widget/index.js
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import Button from 'components/button';
 import config from 'config';
 import ExternalLink from 'components/external-link';
@@ -22,6 +21,7 @@ import { getPostsForQueryIgnoringPage } from 'state/posts/selectors';
 import humanDate from 'lib/human-date';
 import MultiCheckbox from 'components/forms/multi-checkbox';
 import QueryPosts from 'components/data/query-posts';
+import { recordTrack } from 'woocommerce/lib/analytics';
 
 class ReadingWidget extends Component {
 	state = {
@@ -144,8 +144,8 @@ class ReadingWidget extends Component {
 	};
 
 	onSubmit = () => {
-		// TODO
-		analytics.tracks.recordEvent( 'calypso_woocommerce_dashboard_action_click', {
+		// TODO Logic for this. Not currently in use.
+		recordTrack( 'calypso_woocommerce_dashboard_action_click', {
 			action: 'subscribe',
 		} );
 	};

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -36,6 +36,7 @@ import Shipping from './app/settings/shipping';
 import ShippingZone from './app/settings/shipping/shipping-zone';
 import StatsController from './app/store-stats/controller';
 import StoreSidebar from './store-sidebar';
+import { tracksStore } from './lib/analytics';
 import { makeLayout, render as clientRender } from 'controller';
 
 function initExtension() {
@@ -198,6 +199,8 @@ function addStorePage( storePage, storeNavigation ) {
 			}
 
 			analytics.pageView.record( analyticsPath, analyticsPageTitle );
+
+			tracksStore.setReduxStore( context.store );
 
 			context.primary = React.createElement( App, appProps, component );
 			next();

--- a/client/extensions/woocommerce/lib/analytics/index.js
+++ b/client/extensions/woocommerce/lib/analytics/index.js
@@ -10,7 +10,19 @@ import debugFactory from 'debug';
  */
 import analytics from 'lib/analytics';
 import * as tracksUtils from './tracks-utils';
-
+import { isTestSite } from 'woocommerce/state/sites/setup-choices/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 const debug = debugFactory( 'woocommerce:analytics' );
 
-export const recordTrack = tracksUtils.recordTrack( analytics.tracks, debug );
+export const tracksStore = {
+	isTestSite: function() {
+		const state = tracksStore.reduxStore.getState();
+		const siteId = getSelectedSiteId( state );
+		return isTestSite( state, siteId ) || false;
+	},
+	setReduxStore( reduxStore ) {
+		this.reduxStore = reduxStore;
+	},
+};
+
+export const recordTrack = tracksUtils.recordTrack( analytics.tracks, debug, tracksStore );

--- a/client/extensions/woocommerce/lib/analytics/test/tracks-utils.js
+++ b/client/extensions/woocommerce/lib/analytics/test/tracks-utils.js
@@ -36,7 +36,16 @@ describe( 'recordTrack', () => {
 			c: '3',
 		};
 
-		recordTrack( tracksSpy, noop )( 'calypso_woocommerce_tracks_utils_test', eventProps );
+		const tracksStore = {
+			isTestSite: function() {
+				return false;
+			},
+		};
+
+		recordTrack( tracksSpy, noop, tracksStore )(
+			'calypso_woocommerce_tracks_utils_test',
+			eventProps
+		);
 
 		expect( tracksSpy.recordEvent ).to.have.been.calledWith(
 			'calypso_woocommerce_tracks_utils_test',
@@ -49,7 +58,13 @@ describe( 'recordTrack', () => {
 
 		const eventProps = { a: 1 };
 
-		recordTrack( { recordEvent: noop }, debugSpy )(
+		const tracksStore = {
+			isTestSite: function() {
+				return false;
+			},
+		};
+
+		recordTrack( { recordEvent: noop }, debugSpy, tracksStore )(
 			'calypso_woocommerce_tracks_utils_test',
 			eventProps
 		);
@@ -71,6 +86,28 @@ describe( 'recordTrack', () => {
 		expect( tracksSpy.recordEvent ).to.not.have.been.called;
 		expect( debugSpy ).to.have.been.calledWith(
 			"invalid store track name: 'calypso_somethingelse_invalid_name', must start with 'calypso_woocommerce_'"
+		);
+	} );
+
+	it( 'should ignore and debug log tracks for test sites', () => {
+		const tracksSpy = {
+			recordEvent: spy(),
+		};
+		const debugSpy = spy();
+
+		const tracksStore = {
+			isTestSite: function() {
+				return true;
+			},
+		};
+
+		recordTrack( tracksSpy, debugSpy, tracksStore )( 'calypso_woocommerce_tracks_utils_test', {
+			a: 1,
+		} );
+
+		expect( tracksSpy.recordEvent ).to.not.have.been.called;
+		expect( debugSpy ).to.have.been.calledWith(
+			'track request discarded. this site is flagged with `dotcom-store-test-site`'
 		);
 	} );
 } );

--- a/client/extensions/woocommerce/lib/analytics/tracks-utils.js
+++ b/client/extensions/woocommerce/lib/analytics/tracks-utils.js
@@ -5,13 +5,18 @@
  */
 import { startsWith } from 'lodash';
 
-export const recordTrack = ( tracks, debug ) => ( eventName, eventProperties ) => {
+export const recordTrack = ( tracks, debug, tracksStore ) => ( eventName, eventProperties ) => {
 	if ( ! startsWith( eventName, 'calypso_woocommerce_' ) ) {
 		debug( `invalid store track name: '${ eventName }', must start with 'calypso_woocommerce_'` );
 		return;
 	}
 
-	debug( `track '${ eventName }': `, eventProperties );
+	debug( `track '${ eventName }': `, eventProperties || {} );
+
+	if ( tracksStore.isTestSite() ) {
+		debug( 'track request discarded. this site is flagged with `dotcom-store-test-site`' );
+		return;
+	}
 
 	tracks.recordEvent( eventName, eventProperties );
 };

--- a/client/extensions/woocommerce/state/data-layer/ui/shipping-zones/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/shipping-zones/index.js
@@ -11,7 +11,6 @@ import { find, flatten, isEmpty, isNil, map, omit, some, xor } from 'lodash';
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getShippingZonesEdits } from 'woocommerce/state/ui/shipping/zones/selectors';
 import {
 	createShippingZone,
 	updateShippingZone,
@@ -38,22 +37,23 @@ import {
 	getShippingZoneLocationsWithEdits,
 	areCurrentlyEditingShippingZoneLocationsValid,
 } from 'woocommerce/state/ui/shipping/zones/locations/selectors';
-import { getCurrentlyEditingShippingZone } from 'woocommerce/state/ui/shipping/zones/selectors';
+import {
+	getShippingZonesEdits,
+	getCurrentlyEditingShippingZone,
+	generateZoneName,
+	generateCurrentlyEditingZoneName,
+} from 'woocommerce/state/ui/shipping/zones/selectors';
 import { getCurrentlyEditingShippingZoneMethods } from 'woocommerce/state/ui/shipping/zones/methods/selectors';
 import { getRawShippingZoneLocations } from 'woocommerce/state/sites/shipping-zone-locations/selectors';
 import { getShippingZoneMethod } from 'woocommerce/state/sites/shipping-zone-methods/selectors';
 import { getZoneLocationsPriority } from 'woocommerce/state/sites/shipping-zone-locations/helpers';
 import { getAPIShippingZones } from 'woocommerce/state/sites/shipping-zones/selectors';
-import analytics from 'lib/analytics';
 import { getStoreLocation } from 'woocommerce/state/sites/settings/general/selectors';
 import { getActionList } from 'woocommerce/state/action-list/selectors';
 import { getCountryName } from 'woocommerce/state/sites/locations/selectors';
 import { isDefaultShippingZoneCreated } from 'woocommerce/state/sites/setup-choices/selectors';
 import { setCreatedDefaultShippingZone } from 'woocommerce/state/sites/setup-choices/actions';
-import {
-	generateZoneName,
-	generateCurrentlyEditingZoneName,
-} from 'woocommerce/state/ui/shipping/zones/selectors';
+import { recordTrack } from 'woocommerce/lib/analytics';
 
 const createShippingZoneSuccess = actionList => (
 	dispatch,
@@ -199,7 +199,7 @@ const getZoneMethodDeleteSteps = ( siteId, zoneId, method, state ) => {
 		{
 			description: translate( 'Deleting Shipping Method' ),
 			onStep: ( dispatch, actionList ) => {
-				analytics.tracks.recordEvent( 'calypso_woocommerce_shipping_method_deleted', {
+				recordTrack( 'calypso_woocommerce_shipping_method_deleted', {
 					shipping_method: methodType,
 				} );
 				dispatch(
@@ -238,7 +238,7 @@ const getZoneMethodUpdateSteps = ( siteId, zoneId, method, state ) => {
 						false !== methodProps.enabled
 							? 'calypso_woocommerce_shipping_method_enabled'
 							: 'calypso_woocommerce_shipping_method_disabled';
-					analytics.tracks.recordEvent( event, { shipping_method: methodType } );
+					recordTrack( event, { shipping_method: methodType } );
 				}
 
 				dispatch(
@@ -279,7 +279,7 @@ const getZoneMethodCreateSteps = ( siteId, zoneId, method, defaultOrder, state )
 		{
 			description: translate( 'Creating Shipping Method' ),
 			onStep: ( dispatch, actionList ) => {
-				analytics.tracks.recordEvent( 'calypso_woocommerce_shipping_method_created', {
+				recordTrack( 'calypso_woocommerce_shipping_method_created', {
 					shipping_method: methodType,
 				} );
 				dispatch(
@@ -307,7 +307,7 @@ const getZoneMethodCreateSteps = ( siteId, zoneId, method, defaultOrder, state )
 		steps.push.apply( steps, {
 			description: translate( 'Updating Shipping Method' ), // Better not tell the user we're just tracking at this point
 			onStep: ( dispatch, actionList ) => {
-				analytics.tracks.recordEvent( 'calypso_woocommerce_shipping_method_enabled', {
+				recordTrack( 'calypso_woocommerce_shipping_method_enabled', {
 					shipping_method: methodType,
 				} );
 				dispatch( actionListStepSuccess( actionList ) );

--- a/client/extensions/woocommerce/state/sites/setup-choices/reducer.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/reducer.js
@@ -12,6 +12,8 @@ import {
 	WOOCOMMERCE_SETUP_CHOICES_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
 
+// TODO: Rename setup choices to something like calypso preferences, to match the endpoint
+
 // TODO: Handle error
 
 export default createReducer(
@@ -26,7 +28,7 @@ export default createReducer(
 		},
 
 		[ WOOCOMMERCE_SETUP_CHOICE_UPDATE_REQUEST_SUCCESS ]: ( state, { data } ) => {
-			return data;
+			return { ...state, ...data };
 		},
 	}
 );

--- a/client/extensions/woocommerce/state/sites/setup-choices/selectors.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/selectors.js
@@ -169,3 +169,12 @@ export function isStoreSetupComplete( state, siteId = getSelectedSiteId( state )
 		getFinishedInitialSetup( state, siteId )
 	);
 }
+
+/**
+ * @param {Object} state Global state tree
+ * @param {Number} siteId wpcom site id. If not provided, the Site ID selected in the UI will be used
+ * @return {boolean} Whether or not this site is a test site.
+ */
+export function isTestSite( state, siteId = getSelectedSiteId( state ) ) {
+	return isChoiceTrue( state, siteId, 'is_test_site' );
+}

--- a/client/extensions/woocommerce/state/sites/setup-choices/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/setup-choices/test/selectors.js
@@ -20,6 +20,7 @@ import {
 	getTriedCustomizerDuringInitialSetup,
 	isDefaultShippingZoneCreated,
 	isStoreSetupComplete,
+	isTestSite,
 	getCheckedTaxSetup,
 } from '../selectors';
 import { LOADING } from 'woocommerce/state/constants';
@@ -46,6 +47,7 @@ const loadedState = {
 			sites: {
 				123: {
 					setupChoices: {
+						is_test_site: true,
 						finished_initial_setup: true,
 						finished_page_setup: true,
 						opted_out_of_shipping_setup: true,
@@ -59,6 +61,7 @@ const loadedState = {
 				},
 				124: {
 					setupChoices: {
+						is_test_site: false,
 						finished_initial_setup: false,
 						finished_page_setup: false,
 						opted_out_of_shipping_setup: false,
@@ -275,6 +278,20 @@ describe( 'selectors', () => {
 
 		test( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( getSetStoreAddressDuringInitialSetup( loadedStateWithUi ) ).to.eql( true );
+		} );
+	} );
+
+	describe( '#isTestSite', () => {
+		test( 'should get whether initial setup was completed from the state (123-true).', () => {
+			expect( isTestSite( loadedState, 123 ) ).to.eql( true );
+		} );
+
+		test( 'should get whether initial setup was completed from the state (124-false).', () => {
+			expect( isTestSite( loadedState, 124 ) ).to.eql( false );
+		} );
+
+		test( 'should get the siteId from the UI tree if not provided.', () => {
+			expect( isTestSite( loadedStateWithUi ) ).to.eql( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
This branch uses the recently added `is_test_site` flag to determine if we should disregard tracks calls. It adds this logic to the `recordTrack` method already in use by orders and promotions. It also updates our other track events to use this method.

Closes #20962.

To Test:
* `npm run test-client client/extensions/woocommerce/` and make sure all tests pass
* Open your developer console and enter `localStorage.setItem('debug', '*analytics*');`.
* Make sure your site is flagged as a test site using the blog sticker. See `/flagging-store-test-sites-with-blog-stickers-and-wpsh/` on the field guide for more information.
* Check the following to verify tracks are discarded for the test site (you should see something like `track request discarded. this site is flagged with 'dotcom-store-test-site'`)
    * Dashboard actions (initial setup button on plugin view, buttons on the "no orders view", buttons on the setup task list, etc).
        * Since this PR also updates some of the fetching for the dashboard view, verify things look correct here as well (i.e. if you have `finished_initial_setup` set to false, make sure that view displays, and that you can update the state by clicking "I'm finished")
    * Order editing
    * Settings (payment method enabled/disabled, shipping zones, etc)
    * Store stats (switching tabs)
    * Promotions
* Remove the blog sticker (verify via the developer console) and retest the above actions. You should see actual tracks being logged. Example: `calypso:analytics:tracks  Recording event "calypso_woocommerce_dashboard_action_click" with actual props`
 * Lastly, put the blog sticker back when you are done 