### PR TITLE
Checkout: Make checkout button 'busy' when processing

### DIFF
--- a/client/my-sites/checkout/checkout/pay-button.jsx
+++ b/client/my-sites/checkout/checkout/pay-button.jsx
@@ -3,16 +3,15 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { cartItems, isPaidForFullyInCredits } from 'lib/cart-values';
-import SubscriptionText from './subscription-text';
+import Button from 'components/button';
+import SubscriptionText from 'my-sites/checkout/checkout/subscription-text';
 import {
 	BEFORE_SUBMIT,
 	INPUT_VALIDATION,
@@ -153,13 +152,14 @@ class PayButton extends React.Component {
 
 		return (
 			<span className="pay-button">
-				<button
+				<Button
 					type="submit"
 					className="button is-primary button-pay pay-button__button"
+					busy={ buttonState.disabled }
 					disabled={ buttonState.disabled }
 				>
 					{ buttonState.text }
-				</button>
+				</Button>
 				<SubscriptionText cart={ this.props.cart } />
 			</span>
 		);

--- a/client/my-sites/checkout/checkout/pay-button.jsx
+++ b/client/my-sites/checkout/checkout/pay-button.jsx
@@ -23,7 +23,7 @@ import {
 
 class PayButton extends React.Component {
 	buttonState = () => {
-		var state;
+		let state;
 
 		switch ( this.props.transactionStep.name ) {
 			case BEFORE_SUBMIT:
@@ -70,7 +70,7 @@ class PayButton extends React.Component {
 	};
 
 	beforeSubmitText = () => {
-		var cart = this.props.cart;
+		const cart = this.props.cart;
 
 		if ( this.props.beforeSubmitText ) {
 			return this.props.beforeSubmitText;
@@ -131,7 +131,7 @@ class PayButton extends React.Component {
 	};
 
 	completing = () => {
-		var text;
+		let text;
 		if ( cartItems.hasFreeTrial( this.props.cart ) ) {
 			text = this.props.translate( 'Starting your free trial…', {
 				context: 'Loading state on /checkout',
@@ -148,7 +148,7 @@ class PayButton extends React.Component {
 	};
 
 	render() {
-		var buttonState = this.buttonState();
+		const buttonState = this.buttonState();
 
 		return (
 			<span className="pay-button">


### PR DESCRIPTION
Add feedback to checkout button. It would just go disabled and have no feedback that something is happening.

Before:
![checkout button old](https://user-images.githubusercontent.com/1103398/34545335-422836d2-f0e4-11e7-92fc-6546e70170b3.gif)


After:
![checkout button](https://user-images.githubusercontent.com/1103398/34545314-15be8ce0-f0e4-11e7-924d-2b4a66de6479.gif)


  