### PR TITLE
Change sidebar nudge styling to ensure when visited, the text color does not change

### DIFF
--- a/client/my-sites/current-site/sidebar-banner/index.jsx
+++ b/client/my-sites/current-site/sidebar-banner/index.jsx
@@ -47,7 +47,7 @@ export class SidebarBanner extends Component {
 					eventName="calypso_upgrade_nudge_impression"
 					eventProperties={ { cta_name: ctaName } }
 				/>
-				<a onClick={ this.onClick } href={ href }>
+				<a className="sidebar-banner__link" onClick={ this.onClick } href={ href }>
 					<span className="sidebar-banner__icon-wrapper">
 						<Gridicon className="sidebar-banner__icon" icon={ icon } size={ 18 } />
 					</span>

--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -1,19 +1,10 @@
 .sidebar-banner {
 	font-size: 12px;
 
-	:hover {
-		transition: all 150ms ease-out;
-		background-color: lighten( $alert-green, 5% );
-	}
-
-	a {
+	.sidebar-banner__link {
 		background-color: $alert-green;
 		color: $white;
 		display: flex;
-
-		:visited {
-			color: $white;
-		}
 
 		@include breakpoint( "<660px" ) {
 			padding: 0 24px;


### PR DESCRIPTION
There is a current issue with the sidebar nudge.

When the url has been visited, 30 seconds or so after loading a page, some css is loaded that overrides the color resulting in the banner appearing like this:

<img width="275" alt="screen shot 2018-01-04 at 2 20 08 pm" src="https://user-images.githubusercontent.com/1926/34550179-6c9be078-f15a-11e7-8a2c-63caba86ebaf.png">

# Testing

Attempt to reproduce the current issue in production - compare with this branch and wait to see that the visited text does not turn blue.