### PR TITLE
Extract the loader for code splitting

### DIFF
--- a/client/lib/sections-utils/index.js
+++ b/client/lib/sections-utils/index.js
@@ -1,0 +1,25 @@
+/**
+ * External Dependencies
+ */
+import escapeRegExp from 'lodash/escapeRegExp';
+
+export function pathToRegExp( path ) {
+	// Prevents root level double dash urls from being validated.
+	return path === '/' ? path : new RegExp( '^' + escapeRegExp( path ) + '(/.*)?$' );
+}
+
+export function loadSectionsFactory( sections, createPageDefinition ) {
+	return function loadSections() {
+		sections.forEach( sectionDefinition =>
+			sectionDefinition.paths.forEach( path =>
+				createPageDefinition( path, sectionDefinition )
+			)
+		);
+	};
+}
+
+export function getSectionsFactory( sections ) {
+	return function getSections() {
+		return sections;
+	};
+}

--- a/client/lib/sections-utils/index.js
+++ b/client/lib/sections-utils/index.js
@@ -17,9 +17,3 @@ export function loadSectionsFactory( sections, createPageDefinition ) {
 		);
 	};
 }
-
-export function getSectionsFactory( sections ) {
-	return function getSections() {
-		return sections;
-	};
-}

--- a/client/lib/sections-utils/index.js
+++ b/client/lib/sections-utils/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import escapeRegExp from 'lodash/escapeRegExp';
+import { escapeRegExp } from 'lodash';
 
 export function pathToRegExp( path ) {
 	// Prevents root level double dash urls from being validated.

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -98,7 +98,7 @@ const sections = [
 		group: 'sites',
 	},
 	{
-		name: 'posts-pages',
+		name: 'posts',
 		paths: [ '/posts' ],
 		module: 'my-sites/posts',
 		secondary: true,

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -98,7 +98,7 @@ const sections = [
 		group: 'sites',
 	},
 	{
-		name: 'posts',
+		name: 'posts-pages',
 		paths: [ '/posts' ],
 		module: 'my-sites/posts',
 		secondary: true,

--- a/server/bundler/loader-template-code-split.js
+++ b/server/bundler/loader-template-code-split.js
@@ -3,6 +3,7 @@ var config = require( 'config' ),
 	page = require( 'page' ),
 	React = require( 'react' ), //eslint-disable-line no-unused-vars
 	find = require( 'lodash/find' ),
+	sectionsUtils = require( 'lib/sections-utils' ),
 	activateNextLayoutFocus = require( 'state/ui/layout-focus/actions' ).activateNextLayoutFocus,
 	LoadingError = require( 'layout/error' ),
 	controller = require( 'controller' ),
@@ -39,18 +40,8 @@ function preload( sectionName ) {
 }
 preloadHub.on( 'preload', preload );
 
-function pathToRegExp( path ) {
-	// Prevents root level double dash urls from being validated.
-	if ( path === '/' ) {
-		return path;
-	}
-
-	//TODO: Escape path
-	return new RegExp( '^' + path + '(/.*)?$' );
-}
-
 function createPageDefinition( path, sectionDefinition ) {
-	var pathRegex = pathToRegExp( path );
+	var pathRegex = sectionsUtils.pathToRegExp( path );
 
 	page( pathRegex, function( context, next ) {
 		var envId = sectionDefinition.envId;
@@ -90,12 +81,6 @@ function createPageDefinition( path, sectionDefinition ) {
 }
 
 module.exports = {
-	get: function() {
-		return sections;
-	},
-	load: function() {
-		sections.forEach( sectionDefinition => {
-			sectionDefinition.paths.forEach( path => createPageDefinition( path, sectionDefinition ) );
-		} );
-	},
+	get: sectionsUtils.getSectionsFactory( sections ),
+	load: sectionsUtils.loadSectionsFactory( sections, createPageDefinition ),
 };

--- a/server/bundler/loader-template-code-split.js
+++ b/server/bundler/loader-template-code-split.js
@@ -34,9 +34,16 @@ function loadCSS( sectionName ) { //eslint-disable-line no-unused-vars
 }
 
 function preload( sectionName ) {
+	var loadedModules = [];
 	switch ( sectionName ) { //eslint-disable-line no-empty
 		/*___LOADERS___*/
 	}
+
+	if ( loadedModules.length === 1 ) {
+		return loadedModules[ 0 ];
+	}
+
+	return Promise.all( loadedModules );
 }
 preloadHub.on( 'preload', preload );
 
@@ -58,10 +65,11 @@ function createPageDefinition( path, sectionDefinition ) {
 		}
 		context.store.dispatch( { type: 'SECTION_SET', isLoading: true } );
 		preload( sectionDefinition.name ).then( function( requiredModule ) {
+			var loadedModules = Array.isArray( requiredModule ) ? requiredModule : [ requiredModule ];
 			context.store.dispatch( { type: 'SECTION_SET', isLoading: false } );
 			controller.setSection( sectionDefinition )( context );
 			if ( ! _loadedSections[ sectionDefinition.module ] ) {
-				requiredModule( controller.clientRouter );
+				loadedModules.forEach( mod => mod( controller.clientRouter ) );
 				_loadedSections[ sectionDefinition.module ] = true;
 			}
 			context.store.dispatch( activateNextLayoutFocus() );

--- a/server/bundler/loader-template-code-split.js
+++ b/server/bundler/loader-template-code-split.js
@@ -1,0 +1,101 @@
+/*eslint-disable no-var */
+var config = require( 'config' ),
+	page = require( 'page' ),
+	React = require( 'react' ),
+	find = require( 'lodash/find' ),
+	activateNextLayoutFocus = require( 'state/ui/layout-focus/actions' ).activateNextLayoutFocus,
+	LoadingError = require( 'layout/error' ),
+	controller = require( 'controller' ),
+	restoreLastSession = require( 'lib/restore-last-path' ).restoreLastSession,
+	preloadHub = require( 'sections-preload' ).hub,
+	switchCSS = require( 'lib/i18n-utils/switch-locale' ).switchCSS;
+
+var sections = ___SECTIONS_DEFINITION___;
+
+var _loadedSections = {};
+
+function loadCSS( sectionName ) {
+	var section = find( sections, function ( section ) {
+		return section.name === sectionName;
+	} );
+
+	if ( ! ( section && section.css ) ) {
+		return;
+	}
+
+	var url = section.css.urls.ltr;
+
+	if ( typeof document !== 'undefined' && document.documentElement.dir === 'rtl' ) {
+		url = section.css.urls.rtl;
+	}
+
+	switchCSS( 'section-css-' + section.css.id, url );
+};
+
+function preload( sectionName ) {
+	switch ( sectionName ) {
+		___LOADERS___
+	}
+}
+preloadHub.on( 'preload', preload );
+
+function pathToRegExp( path ) {
+	// Prevents root level double dash urls from being validated.
+	if ( path === '/' ) {
+		return path;
+	}
+
+	//TODO: Escape path
+	return new RegExp( '^' + path + '(/.*)?$' );
+}
+
+function createPageDefinition( path, sectionDefinition ) {
+	var pathRegex = pathToRegExp( path );
+
+	page( pathRegex, function( context, next ) {
+		var envId = sectionDefinition.envId;
+		if ( envId && envId.indexOf( config( "env_id" ) ) === -1 ) {
+			return next();
+		}
+		if ( _loadedSections[ sectionDefinition.module ] ) {
+			controller.setSection( sectionDefinition )( context );
+			context.store.dispatch( activateNextLayoutFocus() );
+			return next();
+		}
+		if ( config.isEnabled( "restore-last-location" ) && restoreLastSession( context.path ) ) {
+			return;
+		}
+		context.store.dispatch( { type: "SECTION_SET", isLoading: true } );
+		preload( sectionDefinition.name ).then( function( requiredModule ) {
+			context.store.dispatch( { type: "SECTION_SET", isLoading: false } );
+			controller.setSection( sectionDefinition )( context );
+			if ( ! _loadedSections[ sectionDefinition.module ] ) {
+				requiredModule( controller.clientRouter );
+				_loadedSections[ sectionDefinition.module ] = true;
+			}
+			context.store.dispatch( activateNextLayoutFocus() );
+			next();
+		},
+		function onError( error ) {
+			if ( ! LoadingError.isRetry() ) {
+				console.warn( error );
+				LoadingError.retry( sectionDefinition.name );
+			} else {
+				console.error( error );
+				context.store.dispatch( { type: "SECTION_SET", isLoading: false } );
+				LoadingError.show( sectionDefinition.name );
+			}
+		} );
+	} );
+}
+
+module.exports = {
+	get: function() {
+		return sections;
+	},
+	load: function() {
+		sections.forEach( sectionDefinition => {
+			sectionDefinition.paths.forEach( path => createPageDefinition( path, sectionDefinition ) );
+		} );
+	}
+};

--- a/server/bundler/loader-template-code-split.js
+++ b/server/bundler/loader-template-code-split.js
@@ -65,10 +65,11 @@ function createPageDefinition( path, sectionDefinition ) {
 			return;
 		}
 		dispatch( { type: 'SECTION_SET', isLoading: true } );
-		preload( sectionDefinition.name ).then( function( requiredModule ) {
-			var loadedModules = Array.isArray( requiredModule ) ? requiredModule : [ requiredModule ];
+		preload( sectionDefinition.name ).then( function( requiredModules ) {
 			if ( ! _loadedSections[ sectionDefinition.module ] ) {
-				loadedModules.forEach( mod => mod( controller.clientRouter ) );
+				requiredModules.forEach( function moduleIterator( mod ) {
+					mod( controller.clientRouter );
+				} );
 				_loadedSections[ sectionDefinition.module ] = true;
 			}
 			return activateSection( sectionDefinition, context, next );

--- a/server/bundler/loader-template-code-split.js
+++ b/server/bundler/loader-template-code-split.js
@@ -1,7 +1,7 @@
 /*eslint-disable no-var */
 var config = require( 'config' ),
 	page = require( 'page' ),
-	React = require( 'react' ),
+	React = require( 'react' ), //eslint-disable-line no-unused-vars
 	find = require( 'lodash/find' ),
 	activateNextLayoutFocus = require( 'state/ui/layout-focus/actions' ).activateNextLayoutFocus,
 	LoadingError = require( 'layout/error' ),
@@ -10,13 +10,13 @@ var config = require( 'config' ),
 	preloadHub = require( 'sections-preload' ).hub,
 	switchCSS = require( 'lib/i18n-utils/switch-locale' ).switchCSS;
 
-var sections = ___SECTIONS_DEFINITION___;
+var sections = /*___SECTIONS_DEFINITION___*/[];
 
 var _loadedSections = {};
 
-function loadCSS( sectionName ) {
-	var section = find( sections, function ( section ) {
-		return section.name === sectionName;
+function loadCSS( sectionName ) { //eslint-disable-line no-unused-vars
+	var section = find( sections, function finder( currentSection ) {
+		return currentSection.name === sectionName;
 	} );
 
 	if ( ! ( section && section.css ) ) {
@@ -30,11 +30,11 @@ function loadCSS( sectionName ) {
 	}
 
 	switchCSS( 'section-css-' + section.css.id, url );
-};
+}
 
 function preload( sectionName ) {
-	switch ( sectionName ) {
-		___LOADERS___
+	switch ( sectionName ) { //eslint-disable-line no-empty
+		/*___LOADERS___*/
 	}
 }
 preloadHub.on( 'preload', preload );
@@ -54,7 +54,7 @@ function createPageDefinition( path, sectionDefinition ) {
 
 	page( pathRegex, function( context, next ) {
 		var envId = sectionDefinition.envId;
-		if ( envId && envId.indexOf( config( "env_id" ) ) === -1 ) {
+		if ( envId && envId.indexOf( config( 'env_id' ) ) === -1 ) {
 			return next();
 		}
 		if ( _loadedSections[ sectionDefinition.module ] ) {
@@ -62,12 +62,12 @@ function createPageDefinition( path, sectionDefinition ) {
 			context.store.dispatch( activateNextLayoutFocus() );
 			return next();
 		}
-		if ( config.isEnabled( "restore-last-location" ) && restoreLastSession( context.path ) ) {
+		if ( config.isEnabled( 'restore-last-location' ) && restoreLastSession( context.path ) ) {
 			return;
 		}
-		context.store.dispatch( { type: "SECTION_SET", isLoading: true } );
+		context.store.dispatch( { type: 'SECTION_SET', isLoading: true } );
 		preload( sectionDefinition.name ).then( function( requiredModule ) {
-			context.store.dispatch( { type: "SECTION_SET", isLoading: false } );
+			context.store.dispatch( { type: 'SECTION_SET', isLoading: false } );
 			controller.setSection( sectionDefinition )( context );
 			if ( ! _loadedSections[ sectionDefinition.module ] ) {
 				requiredModule( controller.clientRouter );
@@ -82,7 +82,7 @@ function createPageDefinition( path, sectionDefinition ) {
 				LoadingError.retry( sectionDefinition.name );
 			} else {
 				console.error( error );
-				context.store.dispatch( { type: "SECTION_SET", isLoading: false } );
+				context.store.dispatch( { type: 'SECTION_SET', isLoading: false } );
 				LoadingError.show( sectionDefinition.name );
 			}
 		} );
@@ -97,5 +97,5 @@ module.exports = {
 		sections.forEach( sectionDefinition => {
 			sectionDefinition.paths.forEach( path => createPageDefinition( path, sectionDefinition ) );
 		} );
-	}
+	},
 };

--- a/server/bundler/loader-template-code-split.js
+++ b/server/bundler/loader-template-code-split.js
@@ -88,6 +88,6 @@ function createPageDefinition( path, sectionDefinition ) {
 }
 
 module.exports = {
-	get: sectionsUtils.getSectionsFactory( sections ),
+	get: () => sections,
 	load: sectionsUtils.loadSectionsFactory( sections, createPageDefinition ),
 };

--- a/server/bundler/loader-template.js
+++ b/server/bundler/loader-template.js
@@ -1,0 +1,47 @@
+/*eslint-disable no-var */
+var config = require( 'config' ),
+	page = require( 'page' ),
+	controller = require( 'controller' );
+
+var sections = /*___SECTIONS_DEFINITION___*/[];
+
+function pathToRegExp( path ) {
+	// Prevents root level double dash urls from being validated.
+	if ( path === '/' ) {
+		return path;
+	}
+
+	//TODO: Escape path
+	return new RegExp( '^' + path + '(/.*)?$' );
+}
+
+function load( sectionName ) {
+	switch ( sectionName ) { //eslint-disable-line no-empty
+		/*___LOADERS___*/
+	}
+}
+
+function createPageDefinition( path, sectionDefinition ) {
+	var pathRegex = pathToRegExp( path );
+
+	page( pathRegex, function( context, next ) {
+		var envId = sectionDefinition.envId;
+		if ( envId && envId.indexOf( config( 'env_id' ) ) === -1 ) {
+			return next();
+		}
+		controller.setSection( sectionDefinition )( context );
+		load( sectionDefinition.name )( controller.clientRouter );
+		next();
+	} );
+}
+
+module.exports = {
+	get: function() {
+		return sections;
+	},
+	load: function() {
+		sections.forEach( sectionDefinition => {
+			sectionDefinition.paths.forEach( path => createPageDefinition( path, sectionDefinition ) );
+		} );
+	},
+};

--- a/server/bundler/loader-template.js
+++ b/server/bundler/loader-template.js
@@ -1,19 +1,10 @@
 /*eslint-disable no-var */
 var config = require( 'config' ),
 	page = require( 'page' ),
+	sectionsUtils = require( 'lib/sections-utils' ),
 	controller = require( 'controller' );
 
 var sections = /*___SECTIONS_DEFINITION___*/[];
-
-function pathToRegExp( path ) {
-	// Prevents root level double dash urls from being validated.
-	if ( path === '/' ) {
-		return path;
-	}
-
-	//TODO: Escape path
-	return new RegExp( '^' + path + '(/.*)?$' );
-}
 
 function load( sectionName ) {
 	switch ( sectionName ) { //eslint-disable-line no-empty
@@ -22,7 +13,7 @@ function load( sectionName ) {
 }
 
 function createPageDefinition( path, sectionDefinition ) {
-	var pathRegex = pathToRegExp( path );
+	var pathRegex = sectionsUtils.pathToRegExp( path );
 
 	page( pathRegex, function( context, next ) {
 		var envId = sectionDefinition.envId;
@@ -36,12 +27,6 @@ function createPageDefinition( path, sectionDefinition ) {
 }
 
 module.exports = {
-	get: function() {
-		return sections;
-	},
-	load: function() {
-		sections.forEach( sectionDefinition => {
-			sectionDefinition.paths.forEach( path => createPageDefinition( path, sectionDefinition ) );
-		} );
-	},
+	get: sectionsUtils.getSectionsFactory( sections ),
+	load: sectionsUtils.loadSectionsFactory( sections, createPageDefinition ),
 };

--- a/server/bundler/loader-template.js
+++ b/server/bundler/loader-template.js
@@ -21,7 +21,9 @@ function createPageDefinition( path, sectionDefinition ) {
 			return next();
 		}
 		controller.setSection( sectionDefinition )( context );
-		load( sectionDefinition.name )( controller.clientRouter );
+		load( sectionDefinition.name ).forEach( function moduleIterator( mod ) {
+			mod( controller.clientRouter );
+		} );
 		next();
 	} );
 }

--- a/server/bundler/loader-template.js
+++ b/server/bundler/loader-template.js
@@ -29,6 +29,6 @@ function createPageDefinition( path, sectionDefinition ) {
 }
 
 module.exports = {
-	get: sectionsUtils.getSectionsFactory( sections ),
+	get: () => sections,
 	load: sectionsUtils.loadSectionsFactory( sections, createPageDefinition ),
 };

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -1,20 +1,21 @@
 /** @format */
 const config = require( 'config' ),
 	fs = require( 'fs' ),
+	path = require( 'path' ),
 	utils = require( './utils' );
 
 function getSectionsModule( sections ) {
-	if ( config.isEnabled( 'code-splitting' ) ) {
-		return fs
-			.readFileSync( __dirname + '/loader-template-code-split.js', 'utf8' )
-			.replace( '/*___SECTIONS_DEFINITION___*/', JSON.stringify( sections ) + ' || ' )
-			.replace( '/*___LOADERS___*/', sections.map( getSectionPreLoaderTemplate ).join( '\n' ) );
-	}
+	const templateFile = config.isEnabled( 'code-splitting' )
+		? 'loader-template-code-split.js'
+		: 'loader-template.js';
+	const loaderFactory = config.isEnabled( 'code-splitting' )
+		? getSectionPreLoaderTemplate
+		: getSectionRequire;
 
 	return fs
-		.readFileSync( __dirname + '/loader-template.js', 'utf8' )
+		.readFileSync( path.join( __dirname, templateFile ), 'utf8' )
 		.replace( '/*___SECTIONS_DEFINITION___*/', JSON.stringify( sections ) + ' || ' )
-		.replace( '/*___LOADERS___*/', sections.map( getSectionRequire ).join( '\n' ) );
+		.replace( '/*___LOADERS___*/', sections.map( loaderFactory ).join( '\n' ) );
 }
 
 function getSectionRequire( section ) {

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -34,26 +34,20 @@ function getSectionRequire( section ) {
 function getSectionPreLoaderTemplate( sectionsByName ) {
 	const [ sectionName, sections ] = sectionsByName;
 	const sectionNameString = JSON.stringify( sectionName );
-	let cssLoader = '';
-
-	if ( sections.some( section => section.css ) ) {
-		cssLoader = `loadCSS( ${ sectionNameString } );`;
-	}
 
 	const getModuleLoader = ( importSectionName, importModuleName ) =>
 		`import( /* webpackChunkName: '${ importSectionName }' */ '${ importModuleName }' )`;
 
 	const loader =
 		sections.length === 1
-			? `return ${ getModuleLoader( sectionName, sections[ 0 ].module ) };`
-			: `return Promise.all( [ ${ sections
+			? `${ getModuleLoader( sectionName, sections[ 0 ].module ) }`
+			: `Promise.all( [ ${ sections
 					.map( sec => getModuleLoader( sectionName, sec.module ) )
-					.join( ',' ) } ] );`;
+					.join( ',' ) } ] )`;
 
 	return `
 		case ${ sectionNameString }:
-			${ cssLoader }
-			${ loader }
+			return ${ loader };
 	`;
 }
 

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -9,8 +9,8 @@ function getSectionsModule( sections ) {
 	if ( config.isEnabled( 'code-splitting' ) ) {
 		return fs
 			.readFileSync( __dirname + '/loader-template-code-split.js', 'utf8' )
-			.replace( '___SECTIONS_DEFINITION___', JSON.stringify( sections ) )
-			.replace( '___LOADERS___', sections.map( getSectionPreLoaderTemplate ).join( '\n' ) );
+			.replace( '/*___SECTIONS_DEFINITION___*/', JSON.stringify( sections ) + ' || ' )
+			.replace( '/*___LOADERS___*/', sections.map( getSectionPreLoaderTemplate ).join( '\n' ) );
 	}
 
 	const dependencies = [

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -4,8 +4,6 @@ const config = require( 'config' ),
 	utils = require( './utils' );
 
 function getSectionsModule( sections ) {
-	let sectionLoaders = '';
-
 	if ( config.isEnabled( 'code-splitting' ) ) {
 		return fs
 			.readFileSync( __dirname + '/loader-template-code-split.js', 'utf8' )
@@ -13,63 +11,16 @@ function getSectionsModule( sections ) {
 			.replace( '/*___LOADERS___*/', sections.map( getSectionPreLoaderTemplate ).join( '\n' ) );
 	}
 
-	const dependencies = [
-		"var config = require( 'config' ),",
-		"\tpage = require( 'page' ),",
-		"\tcontroller = require( 'controller' );\n",
-	].join( '\n' );
-
-	sectionLoaders = getRequires( sections );
-
-	return [
-		dependencies,
-		'module.exports = {',
-		'	get: function() {',
-		'		return ' + JSON.stringify( sections ) + ';',
-		'	},',
-		'	load: function() {',
-		'		' + sectionLoaders,
-		'	}',
-		'};',
-	].join( '\n' );
+	return fs
+		.readFileSync( __dirname + '/loader-template.js', 'utf8' )
+		.replace( '/*___SECTIONS_DEFINITION___*/', JSON.stringify( sections ) + ' || ' )
+		.replace( '/*___LOADERS___*/', sections.map( getSectionRequire ).join( '\n' ) );
 }
 
-function getRequires( sections ) {
-	let content = '';
-
-	sections.forEach( function( section ) {
-		content += requireTemplate( section );
-	} );
-
-	return content;
-}
-
-function getPathRegex( pathString ) {
-	if ( pathString === '/' ) {
-		return JSON.stringify( pathString );
-	}
-	const regex = utils.pathToRegExp( pathString );
-	return '/' + regex.toString().slice( 1, -1 ) + '/';
-}
-
-function requireTemplate( section ) {
-	const result = section.paths.reduce( function( acc, path ) {
-		const pathRegex = getPathRegex( path );
-
-		return acc.concat( [
-			'page( ' + pathRegex + ', function( context, next ) {',
-			'	var envId = ' + JSON.stringify( section.envId ) + ';',
-			'	if ( envId && envId.indexOf( config( "env_id" ) ) === -1 ) {',
-			'		return next();',
-			'	}',
-			'	controller.setSection( ' + JSON.stringify( section ) + ' )( context );',
-			'	require( ' + JSON.stringify( section.module ) + ' )( controller.clientRouter );',
-			'	next();',
-			'} );\n',
-		] );
-	}, [] );
-
-	return result.join( '\n' );
+function getSectionRequire( section ) {
+	return `
+		case ${ JSON.stringify( section.name ) }: return require( ${ JSON.stringify( section.module ) } );
+	`;
 }
 
 function getSectionPreLoaderTemplate( section ) {
@@ -84,7 +35,7 @@ function getSectionPreLoaderTemplate( section ) {
 		case ${ sectionNameString }:
 			${ cssLoader }
 			return import( /* webpackChunkName: ${ sectionNameString } */ '${ section.module }' );
-`;
+	`;
 }
 
 function sectionsWithCSSUrls( sections ) {

--- a/server/bundler/utils.js
+++ b/server/bundler/utils.js
@@ -9,14 +9,6 @@ const SERVER_BASE_PATH = '/public';
 
 // Adapts route paths to also include wildcard
 // subroutes under the root level section.
-function pathToRegExp( path ) {
-	// Prevents root level double dash urls from being validated.
-	if ( path === '/' ) {
-		return path;
-	}
-	return new RegExp( '^' + path + '(/.*)?$' );
-}
-
 function hashFile( path ) {
 	const md5 = crypto.createHash( 'md5' );
 	let data, hash;
@@ -57,7 +49,6 @@ function getCssUrls( css ) {
 }
 
 module.exports = {
-	pathToRegExp: pathToRegExp,
 	hashFile: hashFile,
 	getUrl: getUrl,
 	getCssUrls: getCssUrls,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -26,6 +26,7 @@ import { DESERIALIZE, LOCALE_SET } from 'state/action-types';
 import { login } from 'lib/paths';
 import { logSectionResponseTime } from './analytics';
 import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
+import { pathToRegExp } from 'lib/sections-utils';
 
 const debug = debugFactory( 'calypso:pages' );
 
@@ -476,7 +477,7 @@ module.exports = function() {
 		.filter( section => ! section.envId || section.envId.indexOf( config( 'env_id' ) ) > -1 )
 		.forEach( section => {
 			section.paths.forEach( sectionPath => {
-				const pathRegex = utils.pathToRegExp( sectionPath );
+				const pathRegex = pathToRegExp( sectionPath );
 
 				app.get( pathRegex, function( req, res, next ) {
 					req.context = Object.assign( {}, req.context, { sectionName: section.name } );


### PR DESCRIPTION
This PR tries to:
* Decrease sections size
* Increase sections loader readability

It is based on previous work done in #18424 and #18383

master - sections.js 135K (`"code-splitting": true`):
![screen shot 2018-01-04 at 16 08 46](https://user-images.githubusercontent.com/326402/34567102-94ded86a-f169-11e7-8e2c-0f34fd579dca.png)


this branch - sections.js 19K (`"code-splitting": true`):
![screen shot 2018-01-04 at 16 00 29](https://user-images.githubusercontent.com/326402/34566760-7268fe1a-f168-11e7-897f-8608dcaf2b1f.png)

[ICFY](http://iscalypsofastyet.com/branch?branch=try/sections-refactor):
```
Delta:
chunk     stat_size           parsed_size           gzip_size
build      -35486 B  (-0.6%)     -46611 B  (-1.7%)     +985 B  (+0.2%)
devdocs       +99 B  (+0.0%)        +50 B  (+0.0%)      +19 B  (+0.0%)
manifest       +0 B                  +0 B                +0 B
```

#### Testing instructions
  
1. Run `git checkout try/sections-refactor` and start your server, or open a [live branch](https://calypso.live/?branch=try/sections-refactor)
2. Open the [`Home` page](http://calypso.localhost:3000/)
3. Use the calypso app while browsing different sections: login, reader, post, etc.
4. Assert app is working as expected and sections are indeed loaded
 
Need to test for both values of `"code-splitting": true|false`

#### Reviews
  
- [ ] Code
- [ ] Product
  
  
  
  