### PR TITLE
Reader: Pass before and after dates as ISO strings with a UTC offset

### DIFF
--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -26,7 +26,7 @@ function getNextPageParams( store ) {
 		lastDate = store.getLastItemWithDate();
 
 	if ( lastDate ) {
-		params.before = lastDate;
+		params.before = lastDate.toISOString();
 	} else {
 		// only fetch four items for the initial page
 		// speeds up the initial fetch a fair bit

--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -26,7 +26,7 @@ function getNextPageParams( store ) {
 		lastDate = store.getLastItemWithDate();
 
 	if ( lastDate ) {
-		params.before = lastDate.toISOString();
+		params.before = lastDate instanceof Date ? lastDate.toISOString() : lastDate;
 	} else {
 		// only fetch four items for the initial page
 		// speeds up the initial fetch a fair bit

--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -31,7 +31,7 @@ export function ensureStoreLoading( store, context ) {
 		if ( context && context.query && context.query.at ) {
 			const startDate = moment( context.query.at );
 			if ( startDate.isValid() ) {
-				store.startDate = startDate.format();
+				store.startDate = startDate.toISOString();
 			}
 		}
 		fetchNextPage( store.id );


### PR DESCRIPTION
Makes this more explicit and easier to reason about. No real functional changes.