### PR TITLE
Add target to icon

### DIFF
--- a/client/layout/guided-tours/tours/checklist-site-icon-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour.js
@@ -35,7 +35,7 @@ export const ChecklistSiteIconTour = makeTour(
 		>
 			<p>
 				{ translate(
-					'Press this image to upload a file that can help people identify your site in the browser.'
+					'Press this graphic to upload your own image or icon that can help people identify your site in the browser.'
 				) }
 			</p>
 			<ButtonRow>

--- a/client/layout/guided-tours/tours/checklist-site-icon-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour.js
@@ -35,10 +35,7 @@ export const ChecklistSiteIconTour = makeTour(
 		>
 			<p>
 				{ translate(
-					'Press {{b}}Change{{/b}} to upload an image or icon that helps people identify your site in the browser.',
-					{
-						components: { b: <strong /> },
-					}
+					'Press this image to upload a file that can help people identify your site in the browser.'
 				) }
 			</p>
 			<ButtonRow>

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -293,7 +293,6 @@ class SiteIconSetting extends Component {
 				<Button
 					{ ...buttonProps }
 					className="site-icon-setting__button"
-					data-tip-target="settings-site-icon-change"
 					disabled={ isSaving }
 					compact
 				>

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -245,6 +245,7 @@ class SiteIconSetting extends Component {
 			buttonProps = {
 				type: 'button',
 				onClick: this.showModal,
+				'data-tip-target': 'settings-site-icon-change',
 				onMouseEnter: this.preloadModal,
 			};
 		} else {


### PR DESCRIPTION
When you're viewing the checklist on mobile and do the site icon task, the prompt points to the image rather than the change button. This PR changes the target and the prompt's copy to work better with the UI.

## Before
![avatar-master](https://user-images.githubusercontent.com/6981253/34573525-7a7bc00e-f142-11e7-990b-2b6042034beb.gif)

## After
<img width="1152" alt="screen shot 2018-01-04 at 11 46 06 pm" src="https://user-images.githubusercontent.com/6981253/34595889-79977e00-f1a9-11e7-9799-37f836fea4ee.png">

![image](https://user-images.githubusercontent.com/6981253/34595894-860129d4-f1a9-11e7-9bdb-1c0cc66fe9ce.png)


## Testing
* Create a new site or visit a site with a checklist.
* Start the site icon tour on a small screen.
* Click on the image to launch the next step of the tour.

@markryall can you take a look at this?

cc @taggon 
  
  