### PR TITLE
Fix invalid prop type

### DIFF
--- a/client/layout/guided-tours/tours/checklist-about-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour.js
@@ -130,7 +130,7 @@ export const ChecklistAboutPageTour = makeTour(
 						'return to our checklist and see what’s next.'
 				) }
 			</p>
-			<SiteLink isButton="true" href={ '/checklist/:site' }>
+			<SiteLink isButton href={ '/checklist/:site' }>
 				{ translate( 'Return to the checklist' ) }
 			</SiteLink>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -123,7 +123,7 @@ export const ChecklistContactPageTour = makeTour(
 						'to our checklist and see what’s next.'
 				) }
 			</p>
-			<SiteLink isButton="true" href={ '/checklist/:site' }>
+			<SiteLink isButton href={ '/checklist/:site' }>
 				{ translate( 'Return to the checklist' ) }
 			</SiteLink>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour.js
@@ -138,7 +138,7 @@ export const ChecklistPublishPostTour = makeTour(
 						'Let’s move on and see what’s next on our checklist.'
 				) }
 			</p>
-			<SiteLink isButton="true" href={ '/checklist/:site' }>
+			<SiteLink isButton href={ '/checklist/:site' }>
 				{ translate( 'Return to the checklist' ) }
 			</SiteLink>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
@@ -68,7 +68,7 @@ export const ChecklistSiteTaglineTour = makeTour(
 					'Your tagline has been saved! Let’s move on and see what’s next on our checklist.'
 				) }
 			</p>
-			<SiteLink isButton="true" href={ '/checklist/:site' }>
+			<SiteLink isButton href={ '/checklist/:site' }>
 				{ translate( 'Return to the checklist' ) }
 			</SiteLink>
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-site-title-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour.js
@@ -68,7 +68,7 @@ export const ChecklistSiteTitleTour = makeTour(
 					'Your changes have been saved. Let’s move on and see what’s next on our checklist.'
 				) }
 			</p>
-			<SiteLink isButton="true" href={ '/checklist/:site' }>
+			<SiteLink isButton href={ '/checklist/:site' }>
 				{ translate( 'Return to the checklist' ) }
 			</SiteLink>
 		</Step>


### PR DESCRIPTION
I noticed some errors being thrown when you reached the last step of some of the tours. Digging in a little further, I noticed we were passing the wrong value to our SiteLink component. This PR removes the invalid prop type and prevents the error from happening. 

![image](https://user-images.githubusercontent.com/6981253/34576241-418ce97c-f14b-11e7-8499-14305b37faa7.png)

@markryall can you take a look? 
  