### PR TITLE
Changed <p> to <div>

### DIFF
--- a/client/layout/guided-tours/config-elements/continue.js
+++ b/client/layout/guided-tours/config-elements/continue.js
@@ -90,10 +90,12 @@ export default class Continue extends Component {
 			return null;
 		}
 
+		const instructionClassName = 'guided-tours__actionstep-instructions';
+
 		return (
-			<p className="guided-tours__actionstep-instructions">
+			<div className={ instructionClassName }>
 				<em>{ this.props.children || this.defaultMessage() }</em>
-			</p>
+			</div>
 		);
 	}
 }


### PR DESCRIPTION
I noticed an error popping up on some of the tours we've been creating for the checklist. It appears we have a `<p>` wrapper element that doesn't like `<p>` children in it. This PR changes the wrapper element from a `<p>` to a `<div>`. 

<img width="1840" alt="screen shot 2018-01-04 at 12 41 28 pm" src="https://user-images.githubusercontent.com/6981253/34576838-3e691f98-f14d-11e7-88f4-bf4cc5a58461.png">


@lsinger can you take a look?