### PR TITLE
Store: Add wc-api readme

### DIFF
--- a/client/extensions/woocommerce/state/wc-api/README.md
+++ b/client/extensions/woocommerce/state/wc-api/README.md
@@ -1,0 +1,90 @@
+wc-api
+======
+
+**The WooCommerce API access module for Calypso.**
+
+This module connects the application to a WooCommerce Site via its API and manages local state.
+
+## Features
+
+* Provides a Higher Order Component that allows a component to define its data needs instead of performing fetches each time.
+* Providing selectors to access data in various formats.
+* Fetching data from each of the API endpoints. (products, orders, etc.)
+* Holding cached data from previous fetches.
+* Retrying API options when they fail, with an automatic back-off to prevent hammering the API (via data layer).
+* Determining overall error states:
+	- WooCommerce API Operational (determined by last successful API call).
+	- WooCommerce API Not Available (plugin deactivated, uninstalled, detected via 404 errors).
+	- WooCommerce API Not Responsive (multiple API calls timing out).
+
+## Future features
+
+This centralized design allows for some more sophisticated data handling down the line as well:
+
+* Managing cached data
+	- Allows a freshness requirement to be defined from components.
+	- Automatically re-fetching data according to connected component freshness needs.
+	- Avoiding fetching data that has already recently been fetched.
+	- Releasing cached data when no longer needed for a period of time.
+* Provides a single abstraction point to implement on other platforms (such as wp-admin)
+
+## How to use
+
+### Higher Order Component: `withWooCommerceSite`
+
+The higher order component eliminates the need to track the site id of a connected WooCommerce site.
+It also allows the WooCommerce API data requirements of a component to be defined declaratively instead
+of trying a fetch each time the component is mounted.
+
+```javascript
+import { withWooCommerceSite } from 'woocommerce/state/wc-api';
+
+class MyProductPage extends Component {
+
+	render() {
+		const { product, variations, productCategories } = this.props;
+
+		return ...;
+	}
+}
+
+function mapSiteDataToProps( siteData, ownProps, state ) {
+	const { productId } = ownProps;
+	const variationsExpanded = isVariationsExpanded( state );
+
+	const product = siteData.products(
+		{ productId },
+		{ freshness: 1.5 * MINUTES },
+	);
+
+	const variations = siteData.productVariations(
+		{ productId },
+		{ freshness: ( variationsExpanded ? 1.5 : 10 ) * MINUTES },
+	);
+
+	const productCategories = siteData.productCategories(
+		{ freshness: 1.5 * HOURS },
+	);
+
+	return {
+		product,
+		variations,
+		productCategories,
+	};
+}
+
+function mapSiteActionsToProps( siteActions, dispatch ) {
+	return {
+		updateProduct: dispatch( siteActions.products.update ),
+		updateVariation: dispatch( siteActions.productVariations.update ),
+	};
+}
+
+export default withWooCommerceSite( mapSiteDataToProps, mapSiteActionsToProps, MyProductPage );
+```
+
+And the wrapped component can be rendered as such:
+
+```jsx
+<MyProductPage wcApiSite={ { siteId } } productId={ 125 } />
+```

--- a/client/extensions/woocommerce/state/wc-api/README.md
+++ b/client/extensions/woocommerce/state/wc-api/README.md
@@ -57,19 +57,25 @@ class MyProductPage extends Component {
 }
 
 function mapSiteDataToProps( siteData, ownProps, state ) {
+	const {
+		getProduct,
+		getVariationsForProduct,
+		getProductCategories,
+	} = siteData;
 	const { productId } = ownProps;
 	const variationsExpanded = isVariationsExpanded( state );
 	const productEdits = getProductEdits( state, productId );
 
-	const product = siteData.products.single( productId, { freshness: 1.5 * MINUTES } );
+	const product = getProduct( productId, { freshness: 1.5 * MINUTES } );
 	const productWithEdits = { ...product, ...productEdits };
 
-	const variations = siteData.productVariations.forProduct(
+	const variations = getVariationsForProduct(
 		productId,
 		{ freshness: ( variationsExpanded ? 1.5 : 10 ) * MINUTES },
 	);
 
-	const productCategories = siteData.productCategories.all(
+	const productCategories = getProductCategories(
+		{ all: true },
 		{ freshness: 1.5 * HOURS },
 	);
 
@@ -91,7 +97,7 @@ export default withWooCommerceSite( mapSiteDataToProps, mappedSiteActions )( MyP
 And the wrapped component can be rendered as such:
 
 ```jsx
-<MyProductPage wcApiSite={ { siteId } } productId={ 125 } />
+<MyProductPage wcApiSite={ site && site.ID } productId={ productId } />
 ```
 
 #### Higher Order Component - Definitions
@@ -101,10 +107,13 @@ And the wrapped component can be rendered as such:
 - `mappedSiteActions` - Maps site actions to props (defined in more detail below).
 
 `mapSiteDataToProps()` - A function to be defined, which returns props to be rendered. Has the following parameters available when called by the HOC. This is similar to redux connect's `mapStateToProps()`.
-- `siteData` - A collection of functions that define the data needed from the WooCommerce API and return the current state of that data.
+- `siteData` - A collection of pre-curried selectors, which also track usage of API data when used.
 - `ownProps` - Props that are assigned to the implementation of this component and passed through here.
 - `state` - The redux state, made available for normal selectors.
 
 `mappedSiteActions` - An object that maps site actions to props. When passed into `withWooCommerceSite`, it maps pre-curried dispatch functions to the specified props. This is similar to redux connect's `mapDispatchToProps()`.
 
-`wcApiSite` - The site identifier that pertains to the environment in which `wc-api` is running. For Calypso on WordPress.com, this is `{ siteId: <number> }`.
+`wcApiSite` - The site identifier that pertains to the environment in which `wc-api` is running.
+- For Calypso on WordPress.com, this is just the numeric site.ID
+- For wp-admin, this could be the base URL of the site's REST API (for compatibility with multi-site)
+

--- a/client/extensions/woocommerce/state/wc-api/README.md
+++ b/client/extensions/woocommerce/state/wc-api/README.md
@@ -40,7 +40,7 @@ The sample code below is simplistic in a few ways (editing variations, for examp
 After the sample code is a list of detailed explanations of the pieces involved.
 
 ```javascript
-import { withWooCommerceSite, siteActions } from 'woocommerce/state/wc-api';
+import { withWooCommerceSite } from 'woocommerce/state/wc-api';
 
 class MyProductPage extends Component {
 
@@ -86,12 +86,16 @@ function mapSiteDataToProps( siteData, ownProps, state ) {
 	};
 }
 
-const mappedSiteActions = {
-	updateProduct: siteActions.products.update,
-	updateVariation: siteActions.productVariations.update,
-};
+function mapSiteActionsToProps( siteActions ) {
+	const { updateProduct, updateVariation } = siteActions;
 
-export default withWooCommerceSite( mapSiteDataToProps, mappedSiteActions )( MyProductPage );
+	return {
+		updateProduct,
+		updateVariation,
+	};
+}
+
+export default withWooCommerceSite( mapSiteDataToProps, mapSiteActionsToProps )( MyProductPage );
 ```
 
 And the wrapped component can be rendered as such:


### PR DESCRIPTION
Note: Putting on hold in favor of #22961

Note: This is a README-only PR for discussion purposes and to provide context for the next PRs that will incrementally work towards this approach as a goal.

This describes plans for a unified WooCommerce API module that will provide certain benefits and hopefully allow us to reduce the amount of overlapping code for our API calls to WooCommerce
while providing better data flow and functionality. That's the overall goal.

Feel free to review the document and comment below.

Here's a [convenient link](https://github.com/Automattic/wp-calypso/blob/714519942f2b6357ce321b7f4e2ff72dbfce641d/client/extensions/woocommerce/state/wc-api/README.md) to the rendered markdown.

Also, the initial PR for the HOC is #21506 
  