### PR TITLE
Store: Prompt user to confirm email before letting them save store address

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -24,6 +24,7 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import ProgressBar from 'components/progress-bar';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import SetupHeader from './setup-header';
+import SetupNotices from './setup-notices';
 import { setFinishedInstallOfRequiredPlugins } from 'woocommerce/state/sites/setup-choices/actions';
 import { hasSitePendingAutomatedTransfer } from 'state/selectors';
 import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
@@ -384,24 +385,27 @@ class RequiredPluginsInstallView extends Component {
 	renderConfirmScreen = () => {
 		const { translate } = this.props;
 		return (
-			<div className="card dashboard__setup-wrapper dashboard__setup-confirm">
-				<SetupHeader
-					imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-setup.svg' }
-					imageWidth={ 160 }
-					title={ translate( 'Have something to sell?' ) }
-					subtitle={ translate(
-						"If you're in the {{strong}}United States{{/strong}} " +
-							'or {{strong}}Canada{{/strong}}, you can sell your products right on ' +
-							'your site and ship them to customers in a snap!',
-						{
-							components: { strong: <strong /> },
-						}
-					) }
-				>
-					<Button onClick={ this.startSetup } primary>
-						{ translate( 'Set up my store!' ) }
-					</Button>
-				</SetupHeader>
+			<div className="dashboard__setup-wrapper">
+				<SetupNotices />
+				<div className="card dashboard__setup-confirm">
+					<SetupHeader
+						imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-setup.svg' }
+						imageWidth={ 160 }
+						title={ translate( 'Have something to sell?' ) }
+						subtitle={ translate(
+							"If you're in the {{strong}}United States{{/strong}} " +
+								'or {{strong}}Canada{{/strong}}, you can sell your products right on ' +
+								'your site and ship them to customers in a snap!',
+							{
+								components: { strong: <strong /> },
+							}
+						) }
+					>
+						<Button onClick={ this.startSetup } primary>
+							{ translate( 'Set up my store!' ) }
+						</Button>
+					</SetupHeader>
+				</div>
 			</div>
 		);
 	};
@@ -425,16 +429,19 @@ class RequiredPluginsInstallView extends Component {
 		}
 
 		return (
-			<div className="card dashboard__setup-wrapper">
-				{ site && <QueryJetpackPlugins siteIds={ [ site.ID ] } /> }
-				<SetupHeader
-					imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-store-creation.svg' }
-					imageWidth={ 160 }
-					title={ translate( 'Building your store' ) }
-					subtitle={ translate( "Give us a minute and we'll move right along." ) }
-				>
-					<ProgressBar value={ progress } total={ totalSeconds } isPulsing />
-				</SetupHeader>
+			<div className="dashboard__setup-wrapper">
+				<SetupNotices />
+				<div className="card dashboard__plugins-install-view">
+					{ site && <QueryJetpackPlugins siteIds={ [ site.ID ] } /> }
+					<SetupHeader
+						imageSource={ '/calypso/images/extensions/woocommerce/woocommerce-store-creation.svg' }
+						imageWidth={ 160 }
+						title={ translate( 'Building your store' ) }
+						subtitle={ translate( "Give us a minute and we'll move right along." ) }
+					>
+						<ProgressBar value={ progress } total={ totalSeconds } isPulsing />
+					</SetupHeader>
+				</div>
 			</div>
 		);
 	};

--- a/client/extensions/woocommerce/app/dashboard/setup-notices.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-notices.js
@@ -1,0 +1,69 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/selectors';
+import Notice from 'components/notice';
+
+class SetupNotices extends Component {
+	static propTypes = {
+		currentUserEmail: PropTypes.string,
+		currentUserEmailVerified: PropTypes.bool,
+		translate: PropTypes.func,
+	};
+
+	possiblyRenderEmailWarning = () => {
+		const { currentUserEmail, currentUserEmailVerified, translate } = this.props;
+
+		if ( ! currentUserEmail || currentUserEmailVerified ) {
+			return null;
+		}
+
+		return (
+			<Notice
+				status="is-warning"
+				showDismiss={ false }
+				text={ translate(
+					"You need to confirm your email address to activate your account. We've sent " +
+						'an email to {{strong}}%(email)s{{/strong}} with instructions for you to follow.',
+					{
+						components: {
+							strong: <strong />,
+						},
+						args: {
+							email: currentUserEmail,
+						},
+					}
+				) }
+			/>
+		);
+	};
+
+	render = () => {
+		return <div>{ this.possiblyRenderEmailWarning() }</div>;
+	};
+}
+
+function mapStateToProps( state ) {
+	const currentUser = getCurrentUser( state );
+	const currentUserEmail = get( currentUser, 'email', '' );
+	const currentUserEmailVerified = isCurrentUserEmailVerified( state );
+
+	return {
+		currentUserEmail,
+		currentUserEmailVerified,
+	};
+}
+
+export default connect( mapStateToProps )( localize( SetupNotices ) );

--- a/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
@@ -31,13 +31,17 @@ import SetupNotices from './setup-notices';
 import { doInitialSetup } from 'woocommerce/state/sites/settings/actions';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
+import userFactory from 'lib/user';
 import VerifyEmailDialog from 'components/email-verification/email-verification-dialog';
+
+const user = userFactory();
 
 class StoreLocationSetupView extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
 			address: {},
+			isFetchingUser: false,
 			isSaving: false,
 			showEmailVerificationDialog: false,
 			userBeganEditing: false,
@@ -193,7 +197,8 @@ class StoreLocationSetupView extends Component {
 		const everyRequiredFieldHasAValue = every( requiredAddressFields, field => {
 			return ! isEmpty( trim( field ) );
 		} );
-		const submitDisabled = this.state.isSaving || ! everyRequiredFieldHasAValue;
+		const submitDisabled =
+			this.state.isSaving || this.state.isFetchingUser || ! everyRequiredFieldHasAValue;
 
 		if ( ! showForm ) {
 			return (
@@ -223,6 +228,10 @@ class StoreLocationSetupView extends Component {
 
 	closeVerifyEmailDialog = () => {
 		this.setState( { showEmailVerificationDialog: false } );
+		// Re-fetch the user to see if they actually took care of things
+		user.fetch();
+		this.setState( { isFetchingUser: true } );
+		user.once( 'change', () => this.setState( { isFetchingUser: false } ) );
 	};
 
 	render = () => {


### PR DESCRIPTION
Partially addresses #20877 

This PR:
* adds a notice to the Building Your Store (plugins install) view if the user has not activated their WordPress.com account yet
* adds a notice to the Howdy! Ready to Start Selling (set store location) view if the user has not activated their WordPress.com account yet
* intercepts clicks on the "Let's Go" button on the Howdy! Ready to Start Selling (set store location) view if the user has not activated their WordPress.com account yet and pops a dialog for them to do so
* re-fetches the user (including the activation status) when they dismiss that dialog in case they completed activation in another tab so we don't continue to block "Let's Go" if they are now activated

To test:
* Open an incognito window
* Navigate to wordpress.com/start
* In step 1 of 4, give your site a name (e.g. “allendav201701041351” ) and tick the “Sell products or collect payments” checkbox
* Hit Continue.
* In step 2 of 4, select any theme by clicking on it
* In step 3 of 4, enter your site name again (e.g. “allendav201701041351” ) and then, after it has loaded, select the .blog domain name (e.g. allendav201701041351.blog)
* In step 4 of 5, select the business plan
* In step 4 of 5, leave your username as is (e.g. allendav201701041351), give a unique email address (e.g. allendavidsnook+1351@gmail.com) and choose a password
* Wait for the “give is a minute to finish”
* Wait for the privacy protection and domain contact information view to load
* Open another window as an automattician and give your new user 300 free credits
* Return to the privacy protection and domain contact information view and then Continue to Checkout
* In the Secure Payment window, click on “Pay with Credits”
* Wait for it to complete your purchase
* On the “Thank you for your purchase screen, verify you have the “We’ve sent a message…confirm your address” notice at the top
* Click on “Create Your Store”
* Wait while the “Building Your Store” view loads and completes
* You’ll be dropped on the “Howdy! Ready to start selling? First we need to know where you are in the world.” view.
* Stop.
* In the same incognito window, switch from wordpress.com to this branch - e.g. navigate to http://calypso.localhost:3000/store/allendav201701041351.blog
* Make sure you get the “You need to confirm…” notice at the top (above the address form)
* Enter your address (it should be pre-filled in from your domain contact information) and hit “Let’s Go”
* Make sure that you immediately get the “Please verify your email address” dialog
* Hit OK to close the dialog
* Try “Let’s Go!” again
* Make sure that you immediately get the “Please verify your email address” dialog again
* Go open your email, find the “Activate allendav201701041351” email, and “Copy Link Address” from Confirm Now button therein. Paste it into a new tab in the incognito window.
* Close that tab after it is done processing
* Return to the tab with the “Howdy! Ready to start selling? First we need to know where you are in the world.” view
* Hit OK to close the Please verify your email address dialog
* Try “Let’s Go!” again
* Verify you are delivered to the “Let's set up your store. Here are the things you’ll need to do” task list view
  