### PR TITLE
Stats Summary: Fix `connect()` call

### DIFF
--- a/client/components/data/query-site-checklist/index.js
+++ b/client/components/data/query-site-checklist/index.js
@@ -42,4 +42,4 @@ class QuerySiteChecklist extends Component {
 	}
 }
 
-export default connect( () => ( {} ), { requestSiteChecklist } )( QuerySiteChecklist );
+export default connect( null, { requestSiteChecklist } )( QuerySiteChecklist );

--- a/client/my-sites/stats/stats-summary/index.jsx
+++ b/client/my-sites/stats/stats-summary/index.jsx
@@ -108,6 +108,6 @@ class StatsSummaryChart extends Component {
 	}
 }
 
-const connectComponent = connect( () => ( {} ), { recordGoogleEvent } );
+const connectComponent = connect( null, { recordGoogleEvent } );
 
 export default flowRight( connectComponent, localize )( StatsSummaryChart );


### PR DESCRIPTION
For some reason in `StatsSummaryChart` we were creating a new empty
object on every call to `mapStateToProps` inside of `connect()` instead
of bypassing the function altogether.

In this patch we're passing `null` into `connect()` to properly indicate
that we have no state values to select inside of `connect()`. This
should result in a negligable decline in memory pressure and CPU usage.

http://iscalypsofastyet.com/branch?branch=fix/connect-no-map-state-to-props
```
Delta:
chunk                                        stat_size           parsed_size           gzip_size
async-load-my-sites-stats-site                   -23 B  (-0.0%)        -16 B  (-0.0%)       -5 B  (-0.0%)
async-load-my-sites-stats-stats-post-detail      -23 B  (-0.0%)        -16 B  (-0.0%)       -2 B  (-0.0%)
async-load-my-sites-stats-summary                -23 B  (-0.0%)        -30 B  (-0.0%)       -2 B  (-0.0%)
build                                             +0 B                  +8 B  (+0.0%)      -22 B  (-0.0%)
checklist                                        -23 B  (-0.0%)        -16 B  (-0.1%)       -6 B  (-0.1%)
manifest                                          +0 B                  +0 B                +0 B
```
  