### PR TITLE
Store Orders: Add UI for removing coupons when editing an order

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -173,6 +173,14 @@
 			color: $gray-text-min;
 			font-style: italic;
 		}
+
+		.order-details__coupon-list-tokens {
+			display: flex;
+
+			.token-field__token:first-child {
+				margin-left: 0;
+			}
+		}
 	}
 }
 

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -16,7 +16,7 @@ import Button from 'components/button';
 import formatCurrency from 'lib/format-currency';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
-import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
+import { getCurrencyFormatDecimal, getCurrencyFormatString } from 'woocommerce/lib/currency';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import {
 	getOrderDiscountTax,
@@ -144,6 +144,25 @@ class OrderDetailsTable extends Component {
 				newItem = { id, name: null, total: 0 };
 			}
 			this.props.onChange( { [ type ]: { [ index ]: newItem } } );
+		}
+	};
+
+	removeCoupon = item => () => {
+		const { coupon_lines, currency, discount_tax, discount_total } = this.props.order;
+		const index = findIndex( coupon_lines, { id: item.id } );
+		const getCurrencyDecimal = value => getCurrencyFormatDecimal( value, currency );
+		if ( index >= 0 ) {
+			const newItem = { id: item.id, code: null, discount: 0 };
+			const newDiscountTotal =
+				getCurrencyDecimal( discount_total ) - getCurrencyDecimal( item.discount );
+			const newDiscountTax =
+				getCurrencyDecimal( discount_tax ) - getCurrencyDecimal( item.discount_tax );
+			const orderChanges = {
+				coupon_lines: { [ index ]: newItem },
+				discount_total: getCurrencyFormatString( newDiscountTotal, currency ),
+				discount_tax: getCurrencyFormatString( newDiscountTax, currency ),
+			};
+			this.props.onChange( orderChanges );
 		}
 	};
 


### PR DESCRIPTION
This PR pulls out the coupon removal UI from #20929. This is on-hold until the coupon management API is ready, see woocommerce/wc-api-dev#78.

![screen shot 2018-01-04 at 3 46 51 pm](https://user-images.githubusercontent.com/541093/34583695-bc152bd0-f166-11e7-8170-cdfd053b234f.png)
