### PR TITLE
Framework: update marked to 0.3.9

### DIFF
--- a/client/components/empty-content/README.md
+++ b/client/components/empty-content/README.md
@@ -34,21 +34,21 @@ render() {
 
 ## Properties
 
-* <strong>title</strong> — The title to be displayed.
-* <strong>line</strong> — (optional) A secondary line, usually leads to the call to action.
-* <strong>illustration</strong> — (optional) The url string of an image path. Displays drake illustration by default.
-* <strong>illustrationWidth</strong> — (optional) Will display the image at native width unless a specific width is provided.
-* <strong>action</strong> — (optional) Label or React element used for the primary action button.
-* <strong>actionURL</strong> — (optional) `href` value for the primary action button.
-* <strong>actionCallback</strong> — (optional) `onClick` value for the primary action button.
-* <strong>actionTarget</strong> - (optional) If ommitted, no target attribute is specified.
+* **title** — The title to be displayed.
+* **line** — (optional) A secondary line, usually leads to the call to action.
+* **illustration** — (optional) The url string of an image path. Displays drake illustration by default.
+* **illustrationWidth** — (optional) Will display the image at native width unless a specific width is provided.
+* **action** — (optional) Label or React element used for the primary action button.
+* **actionURL** — (optional) `href` value for the primary action button.
+* **actionCallback** — (optional) `onClick` value for the primary action button.
+* **actionTarget** - (optional) If ommitted, no target attribute is specified.
 
 The component also supports a secondary action. This should be used sparingly.
 
-* <strong>secondaryAction</strong> — (optional) Label or React element used for the secondary action button.
-* <strong>secondaryActionURL</strong> — (optional) `href` value for the secondary action button.
-* <strong>secondaryActionCallback</strong> — (optional) `onClick` value for the secondary action button.
-* <strong>secondaryActionTarget</strong> - (optional) If ommitted, no target attribute is specified.
+* **secondaryAction** — (optional) Label or React element used for the secondary action button.
+* **secondaryActionURL** — (optional) `href` value for the secondary action button.
+* **secondaryActionCallback** — (optional) `onClick` value for the secondary action button.
+* **secondaryActionTarget** - (optional) If ommitted, no target attribute is specified.
 
 ### Example: Sites
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -48,8 +48,8 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.0.0-beta.35",
-      "integrity": "sha512-l0SE8cl9DUIY4hYAFAKTLX3F2Yr14Qri7uTsuI7iegB5E4KyQy4XY72L3VOxmj6kwR/RDQURoKYr2NzyETGo7A==",
+      "version": "7.0.0-beta.36",
+      "integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
@@ -96,8 +96,8 @@
       }
     },
     "@types/node": {
-      "version": "8.5.2",
-      "integrity": "sha512-KA4GKOpgXnrqEH2eCVhiv2CsxgXGQJgV1X0vsGlh+WCnxbeAE1GT44ZsTU1IN5dEeV/gDupKa7gWo08V5IxWVQ==",
+      "version": "8.5.5",
+      "integrity": "sha512-JRnfoh0Ll4ElmIXKxbUfcOodkGvcNHljct6mO1X9hE/mlrMzAx0hYCLAD7sgT53YAY1HdlpzUcV0CkmDqUqTuA==",
       "dev": true
     },
     "JSONStream": {
@@ -477,7 +477,7 @@
       "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000784",
+        "caniuse-db": "1.0.30000787",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1338,16 +1338,16 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.10.0",
+        "browserslist": "2.11.0",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       },
       "dependencies": {
         "browserslist": {
-          "version": "2.10.0",
-          "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
+          "version": "2.11.0",
+          "integrity": "sha512-mNYp0RNeu1xueGuJFSXkU+K0nH+dBE/gcjtyhtNKfU8hwdrVIfoA7i5iFSjOmzkGdL2QaO7YX9ExiVPE7AY9JA==",
           "requires": {
-            "caniuse-lite": "1.0.30000784",
+            "caniuse-lite": "1.0.30000787",
             "electron-to-chromium": "1.3.30"
           }
         },
@@ -1843,7 +1843,7 @@
       "version": "1.3.6",
       "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
       "requires": {
-        "caniuse-db": "1.0.30000784"
+        "caniuse-db": "1.0.30000787"
       }
     },
     "bser": {
@@ -1960,12 +1960,12 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000784",
-      "integrity": "sha1-G+lQEtlInHcZB0+BruV9vf/mNhs="
+      "version": "1.0.30000787",
+      "integrity": "sha1-ygeigb5Taoi9f6yWuolfPPU/gRs="
     },
     "caniuse-lite": {
-      "version": "1.0.30000784",
-      "integrity": "sha1-EpztdOmhKApEGIC2zSvOMO9Z5sA="
+      "version": "1.0.30000787",
+      "integrity": "sha1-p2xPodasAGQER+yDwefGsz3WFcU="
     },
     "cardinal": {
       "version": "1.0.0",
@@ -2247,15 +2247,8 @@
       "integrity": "sha1-fAHg3HBsI0s5yTODjI4gshdXduI=",
       "dev": true,
       "requires": {
-        "marked": "0.3.7",
+        "marked": "0.3.9",
         "marked-terminal": "1.7.0"
-      },
-      "dependencies": {
-        "marked": {
-          "version": "0.3.7",
-          "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
-          "dev": true
-        }
       }
     },
     "cli-width": {
@@ -3197,13 +3190,13 @@
       "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "defined": "1.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "version": "5.3.0",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
           "dev": true
         }
       }
@@ -3260,7 +3253,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000784",
+        "caniuse-db": "1.0.30000787",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -3588,7 +3581,7 @@
       "dev": true,
       "requires": {
         "cheerio": "1.0.0-rc.2",
-        "function.prototype.name": "1.0.3",
+        "function.prototype.name": "1.1.0",
         "has": "1.0.1",
         "is-subset": "0.1.1",
         "lodash": "4.17.4",
@@ -3738,8 +3731,8 @@
       }
     },
     "es6-error": {
-      "version": "4.0.2",
-      "integrity": "sha1-7sXHJurO9Rt/a3PCDbbhsTsGnJg="
+      "version": "4.1.1",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "es6-iterator": {
       "version": "2.0.3",
@@ -4196,13 +4189,13 @@
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "acorn-jsx": "3.0.1"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "version": "5.3.0",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
           "dev": true
         }
       }
@@ -4729,8 +4722,8 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.61.0",
-      "integrity": "sha1-V9HTO7yPsbk0GYRGSsAy4FTuEIQ=",
+      "version": "0.62.0",
+      "integrity": "sha1-5Y0wAigVcEActQ7lzzkqUiUCAB8=",
       "dev": true
     },
     "flush-write-stream": {
@@ -5722,8 +5715,8 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "function.prototype.name": {
-      "version": "1.0.3",
-      "integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
+      "version": "1.1.0",
+      "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
@@ -6472,7 +6465,7 @@
       "requires": {
         "chalk": "1.1.3",
         "find-parent-dir": "0.3.0",
-        "is-ci": "1.0.10",
+        "is-ci": "1.1.0",
         "normalize-path": "1.0.0"
       },
       "dependencies": {
@@ -6730,8 +6723,8 @@
       "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
     },
     "is-ci": {
-      "version": "1.0.10",
-      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "version": "1.1.0",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
         "ci-info": "1.1.2"
@@ -7282,7 +7275,7 @@
             "chalk": "2.3.0",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
-            "is-ci": "1.0.10",
+            "is-ci": "1.1.0",
             "istanbul-api": "1.2.1",
             "istanbul-lib-coverage": "1.1.1",
             "istanbul-lib-instrument": "1.9.1",
@@ -7777,7 +7770,7 @@
       "integrity": "sha512-AVBdCx7Oj5wBpMOH089lx7Zgwpdz9HbReA82HuVAlIT4kEQRvCy6Sl9yVWDGJwHTgB/OYQGkgmbv/P/K8TkWNw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.35",
+        "@babel/code-frame": "7.0.0-beta.36",
         "chalk": "2.3.0",
         "micromatch": "2.3.11",
         "slash": "1.0.0",
@@ -8139,7 +8132,7 @@
         "callsites": "2.0.0",
         "chalk": "2.3.0",
         "graceful-fs": "4.1.11",
-        "is-ci": "1.0.10",
+        "is-ci": "1.1.0",
         "jest-message-util": "22.0.3",
         "jest-validate": "22.0.3",
         "mkdirp": "0.5.1"
@@ -8306,7 +8299,7 @@
         "babylon": "6.18.0",
         "colors": "1.1.2",
         "es6-promise": "3.3.1",
-        "flow-parser": "0.61.0",
+        "flow-parser": "0.62.0",
         "lodash": "4.15.0",
         "micromatch": "2.3.11",
         "node-dir": "0.1.8",
@@ -8492,7 +8485,7 @@
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "browser-process-hrtime": "0.1.2",
@@ -8505,7 +8498,7 @@
         "left-pad": "1.2.0",
         "nwmatcher": "1.4.3",
         "parse5": "3.0.3",
-        "pn": "1.0.0",
+        "pn": "1.1.0",
         "request": "2.83.0",
         "request-promise-native": "1.0.5",
         "sax": "1.2.4",
@@ -8518,8 +8511,8 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "version": "5.3.0",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
           "dev": true
         },
         "acorn-globals": {
@@ -8527,7 +8520,7 @@
           "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
           "dev": true,
           "requires": {
-            "acorn": "5.2.1"
+            "acorn": "5.3.0"
           }
         }
       }
@@ -9221,18 +9214,12 @@
       "integrity": "sha1-7ti+rYKXi6zxe3ahHFWToBPi2XY=",
       "requires": {
         "loader-utils": "1.1.0",
-        "marked": "0.3.7"
-      },
-      "dependencies": {
-        "marked": {
-          "version": "0.3.7",
-          "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ=="
-        }
+        "marked": "0.3.9"
       }
     },
     "marked": {
-      "version": "0.3.5",
-      "integrity": "sha1-QROhWsXXvKFYpargciRYe5+hW5Q="
+      "version": "0.3.9",
+      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw=="
     },
     "marked-terminal": {
       "version": "1.7.0",
@@ -10438,15 +10425,22 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "1.1.0",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+      "version": "1.2.0",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.2.0"
       }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "package-json": {
       "version": "1.2.0",
@@ -10592,7 +10586,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.2"
+        "@types/node": "8.5.5"
       }
     },
     "parsejson": {
@@ -10784,8 +10778,8 @@
       "dev": true
     },
     "pn": {
-      "version": "1.0.0",
-      "integrity": "sha1-HPWjCw2AbNGPiPxBprXUrWFbO6k=",
+      "version": "1.1.0",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
     "pngjs": {
@@ -10884,7 +10878,7 @@
       "integrity": "sha512-eNR2h9T9ciKMoQEORrPjH33XeN/nuvVuxArOKmHtsFbGbNss631tgTrKou3/pmjAZbA4QQkhLIkPQkIk3WW+8w==",
       "requires": {
         "balanced-match": "1.0.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10901,6 +10895,15 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "escape-string-regexp": {
@@ -10912,12 +10915,12 @@
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
         },
         "postcss": {
-          "version": "6.0.14",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -10925,8 +10928,8 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
-          "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -10967,7 +10970,7 @@
       "integrity": "sha1-SVcBMJeXPf1b2bGtim3BNFal0bo=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10986,6 +10989,16 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "escape-string-regexp": {
@@ -10999,13 +11012,13 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.15",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -11014,8 +11027,8 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -11939,7 +11952,7 @@
                 "callsites": "2.0.0",
                 "chalk": "1.1.3",
                 "graceful-fs": "4.1.11",
-                "is-ci": "1.0.10",
+                "is-ci": "1.1.0",
                 "istanbul-api": "1.2.1",
                 "istanbul-lib-coverage": "1.1.1",
                 "istanbul-lib-instrument": "1.9.1",
@@ -12700,7 +12713,7 @@
       "integrity": "sha512-R1H9APwnBiJE31FWS2vBlM6NplH7AQb+3FJ3Z2e5B1flbgAZbFr7S0R9yrL8P4yy1liIAJcLreI1Ji4KA6KMtA==",
       "requires": {
         "deep-equal": "1.0.1",
-        "es6-error": "4.0.2",
+        "es6-error": "4.1.1",
         "hoist-non-react-statics": "2.3.1",
         "invariant": "2.2.2",
         "is-promise": "2.1.0",
@@ -14727,7 +14740,7 @@
         "find-cache-dir": "1.0.0",
         "schema-utils": "0.3.0",
         "source-map": "0.5.7",
-        "uglify-es": "3.2.2",
+        "uglify-es": "3.3.4",
         "webpack-sources": "1.1.0",
         "worker-farm": "1.5.2"
       },
@@ -14745,8 +14758,8 @@
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "uglify-es": {
-          "version": "3.2.2",
-          "integrity": "sha512-l+s5VLzFwGJfS+fbqaGf/Dfwo1MF13jLOF2ekL0PytzqEqQ6cVppvHf4jquqFok+35USMpKjqkYxy6pQyUcuug==",
+          "version": "3.3.4",
+          "integrity": "sha512-vDOyDaf7LcABZI5oJt8bin5FD8kYONux5jd8FY6SsV2SfD+MMXaPeGUotysbycSxdu170y5IQ8FvlKzU/TUryw==",
           "requires": {
             "commander": "2.12.2",
             "source-map": "0.6.1"
@@ -15148,7 +15161,7 @@
       "version": "3.8.1",
       "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "acorn-dynamic-import": "2.0.2",
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
@@ -15173,8 +15186,8 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+          "version": "5.3.0",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug=="
         },
         "ansi-regex": {
           "version": "3.0.0",
@@ -15391,7 +15404,7 @@
       "integrity": "sha1-i2JAwpqdY7xy8J2SD7BQrbzOn+g=",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "chalk": "1.1.3",
         "commander": "2.12.2",
         "ejs": "2.5.7",
@@ -15414,8 +15427,8 @@
           }
         },
         "acorn": {
-          "version": "5.2.1",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "version": "5.3.0",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
           "dev": true
         },
         "body-parser": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "lru": "3.1.0",
     "lunr": "0.5.7",
     "markdown-loader": "2.0.1",
-    "marked": "0.3.5",
+    "marked": "0.3.9",
     "mkdirp": "0.5.1",
     "moment": "2.19.2",
     "morgan": "1.2.0",


### PR DESCRIPTION
Marked is currently used in devdocs to help format related readmes. Code blocks should be highlighted as expected in https://github.com/Automattic/wp-calypso/pull/10359

Testing Instructions
===
### Testing

Test various syntax types, checking that A) they are highlighted and B) they are highlighted correctly (allowing for caveats mentioned in https://github.com/Automattic/wp-calypso/pull/10359 ):
- js: [ButtonGroup](http://calypso.localhost:3000/devdocs/client/components/button-group/README.md) (ignoring jsx here)
- javascript: [UrlPreview](http://calypso.localhost:3000/devdocs/client/blocks/url-preview/README.md) (ignoring jsx here)
- jsx: [EmptyContent](http://calypso.localhost:3000/devdocs/client/components/empty-content/README.md)  