### PR TITLE
Store: Add a base form page for managing product categories

### DIFF
--- a/client/extensions/woocommerce/app/product-categories/create.js
+++ b/client/extensions/woocommerce/app/product-categories/create.js
@@ -1,0 +1,118 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { isEmpty, omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import { ProtectFormGuard } from 'lib/protect-form';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import {
+	clearProductCategoryEdits,
+	editProductCategory,
+} from 'woocommerce/state/ui/product-categories/actions';
+import {
+	getProductCategoryWithLocalEdits,
+	getCurrentlyEditingId,
+	getProductCategoryEdits,
+} from 'woocommerce/state/ui/product-categories/selectors';
+import ProductCategoryForm from './form';
+import ProductCategoryHeader from './header';
+
+class ProductCategoryCreate extends React.Component {
+	static propTypes = {
+		className: PropTypes.string,
+		site: PropTypes.shape( {
+			ID: PropTypes.number,
+			slug: PropTypes.string,
+		} ),
+		hasEdits: PropTypes.bool,
+		category: PropTypes.object,
+		editProductCategory: PropTypes.func.isRequired,
+		clearProductCategoryEdits: PropTypes.func.isRequired,
+	};
+
+	componentDidMount() {
+		const { category, site } = this.props;
+
+		if ( site && site.ID ) {
+			if ( ! category ) {
+				this.props.editProductCategory( site.ID, null, {} );
+			}
+		}
+	}
+
+	componentWillReceiveProps( newProps ) {
+		const { site } = this.props;
+		const newSiteId = ( newProps.site && newProps.site.ID ) || null;
+		const oldSiteId = ( site && site.ID ) || null;
+		if ( oldSiteId !== newSiteId ) {
+			this.props.editProductCategory( newSiteId, null, {} );
+		}
+	}
+
+	componentWillUnmount() {
+		const { site } = this.props;
+
+		if ( site ) {
+			this.props.clearProductCategoryEdits( site.ID );
+		}
+	}
+
+	onSave = () => {};
+
+	render() {
+		const { site, category, hasEdits, className } = this.props;
+
+		return (
+			<Main className={ className } wideLayout>
+				<ProductCategoryHeader
+					site={ site }
+					category={ category }
+					onSave={ hasEdits ? this.onSave : false }
+				/>
+				<ProtectFormGuard isChanged={ hasEdits } />
+				<ProductCategoryForm
+					siteId={ site && site.ID }
+					category={ category || {} }
+					editProductCategory={ this.props.editProductCategory }
+				/>
+			</Main>
+		);
+	}
+}
+
+function mapStateToProps( state ) {
+	const site = getSelectedSiteWithFallback( state );
+	const categoryId = getCurrentlyEditingId( state );
+	const category = getProductCategoryWithLocalEdits( state, categoryId );
+	const hasEdits = ! isEmpty( omit( getProductCategoryEdits( state, categoryId ), 'id' ) );
+
+	return {
+		site,
+		category,
+		hasEdits,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			editProductCategory,
+			clearProductCategoryEdits,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( ProductCategoryCreate ) );

--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -1,0 +1,67 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
+import { isNumber } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import FormFieldSet from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+
+class ProductCategoryForm extends Component {
+	static propTypes = {
+		className: PropTypes.string,
+		siteId: PropTypes.number,
+		category: PropTypes.shape( {
+			id: PropTypes.isRequired,
+		} ),
+		editProductCategory: PropTypes.func.isRequired,
+	};
+
+	setName = e => {
+		const { siteId, category, editProductCategory } = this.props;
+		const name = e.target.value;
+		editProductCategory( siteId, category, { name } );
+	};
+
+	renderPlaceholder() {
+		const { className } = this.props;
+		return (
+			<div className={ classNames( 'product-categories__form', 'is-placeholder', className ) }>
+				<div />
+			</div>
+		);
+	}
+
+	render() {
+		const { siteId, category, translate } = this.props;
+
+		const isCategoryLoaded = category && isNumber( category.id ) ? Boolean( category.slug ) : true;
+
+		if ( ! siteId || ! category || ! isCategoryLoaded ) {
+			return this.renderPlaceholder();
+		}
+		return (
+			<div className={ classNames( 'product-categories__form', this.props.className ) }>
+				<Card>
+					<FormFieldSet>
+						<FormLabel htmlFor="name">{ translate( 'Category name' ) }</FormLabel>
+						<FormTextInput id="name" value={ category.name || '' } onChange={ this.setName } />
+					</FormFieldSet>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default localize( ProductCategoryForm );

--- a/client/extensions/woocommerce/app/product-categories/header.js
+++ b/client/extensions/woocommerce/app/product-categories/header.js
@@ -1,0 +1,88 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+import { isObject } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import ActionHeader from 'woocommerce/components/action-header';
+import Button from 'components/button';
+import { getLink } from 'woocommerce/lib/nav-utils';
+
+function renderTrashButton( onTrash, category, translate ) {
+	return (
+		onTrash && (
+			<Button borderless scary onClick={ onTrash ? onTrash : undefined }>
+				<Gridicon icon="trash" />
+				<span>{ translate( 'Delete' ) } </span>
+			</Button>
+		)
+	);
+}
+
+function renderSaveButton( onSave, category, translate ) {
+	const saveExists = 'undefined' !== typeof onSave;
+	const saveDisabled = false === onSave;
+
+	const saveLabel =
+		category && ! isObject( category.id ) ? translate( 'Update' ) : translate( 'Save' );
+
+	return (
+		saveExists && (
+			<Button primary onClick={ onSave ? onSave : undefined } disabled={ saveDisabled }>
+				{ saveLabel }
+			</Button>
+		)
+	);
+}
+
+const ProductCategoryHeader = ( { onTrash, onSave, translate, site, category } ) => {
+	const existing = category && ! isObject( category.id );
+
+	const trashButton = renderTrashButton( onTrash, category, translate );
+	const saveButton = renderSaveButton( onSave, category, translate );
+
+	const currentCrumb =
+		category && existing ? (
+			<span>{ translate( 'Edit Product Category' ) }</span>
+		) : (
+			<span>{ translate( 'Add New' ) }</span>
+		);
+
+	const breadcrumbs = [
+		<a href={ getLink( '/store/products/:site/', site ) }> { translate( 'Products' ) } </a>,
+		<a href={ getLink( '/store/products/categories/:site/', site ) }>
+			{' '}
+			{ translate( 'Categories' ) }{' '}
+		</a>,
+		currentCrumb,
+	];
+
+	return (
+		<ActionHeader breadcrumbs={ breadcrumbs }>
+			{ trashButton }
+			{ saveButton }
+		</ActionHeader>
+	);
+};
+
+ProductCategoryHeader.propTypes = {
+	site: PropTypes.shape( {
+		slug: PropTypes.string,
+	} ),
+	category: PropTypes.shape( {
+		id: PropTypes.oneOfType( [ PropTypes.number, PropTypes.object ] ),
+	} ),
+	onTrash: PropTypes.func,
+	onSave: PropTypes.oneOfType( [ PropTypes.func, PropTypes.bool ] ),
+};
+
+export default localize( ProductCategoryHeader );

--- a/client/extensions/woocommerce/app/product-categories/index.js
+++ b/client/extensions/woocommerce/app/product-categories/index.js
@@ -12,6 +12,7 @@ import { union, includes, trim, debounce } from 'lodash';
  * Internal dependencies
  */
 import ActionHeader from 'woocommerce/components/action-header';
+import Button from 'components/button';
 import { fetchProductCategories } from 'woocommerce/state/sites/product-categories/actions';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
@@ -93,6 +94,9 @@ class ProductCategories extends Component {
 					<a href={ getLink( '/store/products/:site/', site ) }>{ productsLabel }</a>,
 					<span>{ categoriesLabel }</span>,
 				] }>
+				<Button primary href={ getLink( '/store/products/category/:site/', site ) }>
+					{ translate( 'Add category' ) }
+				</Button>
 				</ActionHeader>
 				<SectionNav selectedText={ categoriesLabel }>
 					<NavTabs label={ translate( 'Products' ) } selectedText={ categoriesLabel }>

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -1,3 +1,4 @@
+
 .product-categories__list-placeholder {
 	@include placeholder();
 	background: $white;
@@ -89,4 +90,20 @@
 
 .product-categories__list-nested {
 	margin-left: 2em;
+}
+
+.product-categories__form {
+	@include breakpoint( ">660px" ) {
+		margin-top: 58px;
+	}
+
+	&.is-placeholder div {
+		@include placeholder();
+		background: $white;
+		margin-bottom: 8px;
+
+		&:first-child {
+			height: 575px;
+		}
+	}
 }

--- a/client/extensions/woocommerce/app/product-categories/update.js
+++ b/client/extensions/woocommerce/app/product-categories/update.js
@@ -1,0 +1,126 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { localize } from 'i18n-calypso';
+import { isEmpty, omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import { ProtectFormGuard } from 'lib/protect-form';
+import { fetchProductCategories } from 'woocommerce/state/sites/product-categories/actions';
+import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import {
+	editProductCategory,
+	clearProductCategoryEdits,
+} from 'woocommerce/state/ui/product-categories/actions';
+import {
+	getProductCategoryWithLocalEdits,
+	getProductCategoryEdits,
+} from 'woocommerce/state/ui/product-categories/selectors';
+import ProductCategoryForm from './form';
+import ProductCategoryHeader from './header';
+
+class ProductCategoryUpdate extends React.Component {
+	static propTypes = {
+		params: PropTypes.object,
+		className: PropTypes.string,
+		category: PropTypes.shape( {
+			id: PropTypes.isRequired,
+		} ),
+		fetchProductCategories: PropTypes.func.isRequired,
+		editProductCategory: PropTypes.func.isRequired,
+		clearProductCategoryEdits: PropTypes.func.isRequired,
+	};
+
+	componentDidMount() {
+		const { params, site, category } = this.props;
+		const categoryId = Number( params.category );
+
+		if ( site && site.ID ) {
+			if ( ! category ) {
+				this.props.fetchProductCategories( site.ID, { include: [ categoryId ] } );
+				this.props.editProductCategory( site.ID, { id: categoryId }, {} );
+			}
+		}
+	}
+
+	componentWillReceiveProps( newProps ) {
+		const { params, site } = this.props;
+		const categoryId = Number( params.category );
+		const newSiteId = ( newProps.site && newProps.site.ID ) || null;
+		const oldSiteId = ( site && site.ID ) || null;
+		if ( oldSiteId !== newSiteId ) {
+			this.props.fetchProductCategories( newSiteId, { include: [ categoryId ] } );
+			this.props.editProductCategory( newSiteId, { id: categoryId }, {} );
+		}
+	}
+
+	componentWillUnmount() {
+		const { site } = this.props;
+
+		if ( site ) {
+			this.props.clearProductCategoryEdits( site.ID );
+		}
+	}
+
+	onTrash = () => {};
+
+	onSave = () => {};
+
+	render() {
+		const { site, category, hasEdits, className } = this.props;
+
+		return (
+			<Main className={ className } wideLayout>
+				<ProductCategoryHeader
+					site={ site }
+					category={ category }
+					onTrash={ this.onTrash }
+					onSave={ hasEdits ? this.onSave : false }
+				/>
+				<ProtectFormGuard isChanged={ hasEdits } />
+				<ProductCategoryForm
+					siteId={ site && site.ID }
+					category={ category || {} }
+					editProductCategory={ this.props.editProductCategory }
+				/>
+			</Main>
+		);
+	}
+}
+
+function mapStateToProps( state, ownProps ) {
+	const categoryId = Number( ownProps.params.category );
+
+	const site = getSelectedSiteWithFallback( state );
+	const category = getProductCategoryWithLocalEdits( state, categoryId );
+	const hasEdits = ! isEmpty( omit( getProductCategoryEdits( state, categoryId ), 'id' ) );
+
+	return {
+		site,
+		category,
+		hasEdits,
+	};
+}
+
+function mapDispatchToProps( dispatch ) {
+	return bindActionCreators(
+		{
+			editProductCategory,
+			fetchProductCategories,
+			clearProductCategoryEdits,
+		},
+		dispatch
+	);
+}
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( ProductCategoryUpdate ) );

--- a/client/extensions/woocommerce/app/product-categories/update.js
+++ b/client/extensions/woocommerce/app/product-categories/update.js
@@ -33,6 +33,10 @@ class ProductCategoryUpdate extends React.Component {
 	static propTypes = {
 		params: PropTypes.object,
 		className: PropTypes.string,
+		site: PropTypes.shape( {
+			ID: PropTypes.number,
+			slug: PropTypes.string,
+		} ),
 		category: PropTypes.shape( {
 			id: PropTypes.isRequired,
 		} ),

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -22,6 +22,8 @@ import Order from './app/order';
 import OrderCreate from './app/order/create';
 import Orders from './app/orders';
 import ProductCategories from './app/product-categories';
+import ProductCategoryCreate from './app/product-categories/create';
+import ProductCategoryUpdate from './app/product-categories/update';
 import Products from './app/products';
 import ProductCreate from './app/products/product-create';
 import ProductUpdate from './app/products/product-update';
@@ -73,6 +75,18 @@ const getStorePages = () => {
 			configKey: 'woocommerce/extension-product-categories',
 			documentTitle: translate( 'Product Categories' ),
 			path: '/store/products/categories/:site',
+		},
+		{
+			container: ProductCategoryUpdate,
+			configKey: 'woocommerce/extension-product-categories',
+			documentTitle: translate( 'Edit Product Category' ),
+			path: '/store/products/category/:site/:category',
+		},
+		{
+			container: ProductCategoryCreate,
+			configKey: 'woocommerce/extension-product-categories',
+			documentTitle: translate( 'New Product Category' ),
+			path: '/store/products/category/:site',
 		},
 		{
 			container: Orders,

--- a/client/extensions/woocommerce/state/ui/product-categories/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/edits-reducer.js
@@ -77,7 +77,7 @@ function editProductCategory( array, category, data ) {
 	// Look for this object in the appropriate create or edit array first.
 	const newArray = compact(
 		prevArray.map( c => {
-			if ( category.id === c.id ) {
+			if ( isEqual( category.id, c.id ) ) {
 				found = true;
 
 				// If data is null, remove this edit, otherwise update the edit data.

--- a/client/extensions/woocommerce/state/ui/product-categories/selectors.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/selectors.js
@@ -95,3 +95,17 @@ export function getCurrentlyEditingProductCategory( rootState, siteId ) {
 
 	return getProductCategoryWithLocalEdits( rootState, currentlyEditingId, siteId );
 }
+
+/**
+ * Gets the id of the currently editing product category.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Number|Object} Id of the currently editing product category.
+ */
+export function getCurrentlyEditingId( state, siteId = getSelectedSiteId( state ) ) {
+	const edits = getAllProductCategoryEdits( state, siteId ) || {};
+	const { currentlyEditingId } = edits;
+
+	return currentlyEditingId;
+}

--- a/client/extensions/woocommerce/state/ui/product-categories/test/edits-reducer.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/test/edits-reducer.js
@@ -104,6 +104,29 @@ describe( 'edits-reducer', () => {
 		expect( edits.creates[ 0 ].slug ).to.eql( 'new-category' );
 	} );
 
+	test( 'should modify "creates" on second edit', () => {
+		const edits1 = reducer(
+			undefined,
+			editProductCategory( siteId, null, {
+				name: 'After first edit',
+			} )
+		);
+
+		expect( edits1.creates[ 0 ].name ).to.eql( 'After first edit' );
+		expect( edits1.creates[ 0 ].description ).to.not.exist;
+
+		const edits2 = reducer(
+			edits1,
+			editProductCategory( siteId, edits1.creates[ 0 ], {
+				name: 'After second edit',
+				description: 'Description',
+			} )
+		);
+
+		expect( edits2.creates[ 0 ].name ).to.eql( 'After second edit' );
+		expect( edits2.creates[ 0 ].description ).to.eql( 'Description' );
+	} );
+
 	test( 'should create more than one category', () => {
 		const id1 = { placeholder: 'productCategory_1' };
 		const edits1 = reducer(

--- a/client/extensions/woocommerce/state/ui/product-categories/test/selectors.js
+++ b/client/extensions/woocommerce/state/ui/product-categories/test/selectors.js
@@ -14,6 +14,7 @@ import {
 	getProductCategoryWithLocalEdits,
 	getProductCategoriesWithLocalEdits,
 	getCurrentlyEditingProductCategory,
+	getCurrentlyEditingId,
 } from '../selectors';
 import {
 	getProductCategory,
@@ -156,6 +157,21 @@ describe( 'selectors', () => {
 			set( uiProductCategories, [ siteId, 'edits', 'currentlyEditingId' ], newCategory.id );
 
 			expect( getCurrentlyEditingProductCategory( state ) ).to.eql( newCategory );
+		} );
+	} );
+
+	describe( '#getCurrentlyEditingId', () => {
+		test( 'should return undefined if there are no edits', () => {
+			expect( getCurrentlyEditingId( state ) ).to.not.exist;
+		} );
+
+		test( 'should get the last edited category id', () => {
+			const newCategory = { id: { index: 0 }, name: 'New Category' };
+			const uiProductCategories = state.extensions.woocommerce.ui.productCategories;
+			set( uiProductCategories, [ siteId, 'edits', 'creates' ], [ newCategory ] );
+			set( uiProductCategories, [ siteId, 'edits', 'currentlyEditingId' ], newCategory.id );
+
+			expect( getCurrentlyEditingId( state ) ).to.eql( newCategory.id );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds a base for me to build out the rest of the management form. It only implements the name field at the moment. The form works in both the create and edit contexts.

I'll be implementing the actual form fields, saving, and trash behavior in future PRs.

See #20295.

To Test:
* Run `npm run test-client client/extensions/woocommerce` and make sure all tests pass.
* Boot up this branch and go to `http://calypso.localhost:3000/store/products/categories/:site`
* Click the "Add category" button. Verify you see a "category name" field and can type in the field. You can use Redux devtools to verify that `edits` state is being updated.
* Go back to the category listing (you should be prompted for unsaved changes), and select an existing category
* Make sure that the name field contains the correct category name, and that the `edits` state is being updated when you type.

<img width="1416" alt="screen shot 2018-01-04 at 3 17 08 pm" src="https://user-images.githubusercontent.com/689165/34588771-9cd1586e-f163-11e7-94ce-0d5361eb6a11.png">