### PR TITLE
Comments: track bulk actions via state.dataRequests

### DIFF
--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -63,10 +63,8 @@ export class CommentNavigation extends Component {
 
 	componentDidUpdate = prevProps => {
 		const { commentsListQuery, hasPendingBulkAction, refreshPage } = this.props;
-		if ( ! hasPendingBulkAction && prevProps.hasPendingBulkAction ) {
-			if ( commentsListQuery ) {
-				refreshPage( commentsListQuery );
-			}
+		if ( commentsListQuery && ! hasPendingBulkAction && prevProps.hasPendingBulkAction ) {
+			refreshPage( commentsListQuery );
 		}
 	};
 

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import { each, get, includes, isEqual, isUndefined, map, some } from 'lodash';
+import { each, get, includes, isEqual, isUndefined, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -39,7 +39,7 @@ import {
 	unlikeComment,
 } from 'state/comments/actions';
 import { removeNotice, successNotice } from 'state/notices/actions';
-import { getSiteComment } from 'state/selectors';
+import { getSiteComment, hasPendingCommentRequests } from 'state/selectors';
 import { NEWEST_FIRST, OLDEST_FIRST } from '../constants';
 
 const bulkActions = {
@@ -325,13 +325,6 @@ export class CommentNavigation extends Component {
 	}
 }
 
-const hasPendingRequests = state => {
-	const pendingActions = get( state, 'ui.comments.pendingActions' );
-	return some( pendingActions, requestKey => {
-		return get( state, [ 'dataRequests', requestKey, 'status' ] ) === 'pending';
-	} );
-};
-
 const mapStateToProps = ( state, { commentsPage, siteId } ) => {
 	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 	const visibleComments = map( commentsPage, commentId => {
@@ -349,7 +342,7 @@ const mapStateToProps = ( state, { commentsPage, siteId } ) => {
 	return {
 		visibleComments,
 		hasComments: visibleComments.length > 0,
-		hasPendingBulkAction: hasPendingRequests( state ),
+		hasPendingBulkAction: hasPendingCommentRequests( state ),
 		isCommentsTreeSupported:
 			! isJetpackSite( state, siteId ) || isJetpackMinimumVersion( state, siteId, '5.3' ),
 	};

--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -159,6 +159,11 @@ export const deleteComment = (
 	commentId,
 	options,
 	refreshCommentListQuery,
+	meta: {
+		dataLayer: {
+			trackRequest: true,
+		},
+	},
 } );
 
 /***
@@ -249,6 +254,11 @@ export const changeCommentStatus = (
 	commentId,
 	status,
 	refreshCommentListQuery,
+	meta: {
+		dataLayer: {
+			trackRequest: true,
+		},
+	},
 } );
 
 /**

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -52,7 +52,7 @@ const changeCommentStatus = ( { dispatch, getState }, action ) => {
 			},
 			{
 				...action,
-				previousStatus,
+				meta: Object.assign( {}, action.meta, { comment: { previousStatus } } ),
 			}
 		)
 	);
@@ -69,7 +69,8 @@ export const handleChangeCommentStatusSuccess = (
 };
 
 const announceStatusChangeFailure = ( { dispatch }, action ) => {
-	const { commentId, status, previousStatus } = action;
+	const { commentId, status } = action;
+	const previousStatus = get( action, 'meta.comment.previousStatus' );
 
 	dispatch( removeNotice( `comment-notice-${ commentId }` ) );
 

--- a/client/state/selectors/has-pending-comment-requests.js
+++ b/client/state/selectors/has-pending-comment-requests.js
@@ -1,0 +1,19 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get, some } from 'lodash';
+
+/**
+ * Returns true if we have any pending comment actions that we are tracking.
+ *
+ * @param {object} state - global application state
+ * @returns {boolean} - true if we have pending actions
+ */
+export default state => {
+	const pendingActions = get( state, 'ui.comments.pendingActions' );
+	return some( pendingActions, requestKey => {
+		return get( state, [ 'dataRequests', requestKey, 'status' ] ) === 'pending';
+	} );
+};

--- a/client/state/selectors/test/has-pending-comment-requests.js
+++ b/client/state/selectors/test/has-pending-comment-requests.js
@@ -1,0 +1,67 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { hasPendingCommentRequests } from 'state/selectors';
+import { COMMENTS_CHANGE_STATUS } from 'state/action-types';
+import { getRequestKey } from 'state/data-layer/wpcom-http/utils';
+
+const actionKey = getRequestKey( {
+	type: COMMENTS_CHANGE_STATUS,
+	commentId: 1,
+	status: 'approved',
+	meta: {
+		dataLayer: {
+			trackRequest: true,
+		},
+	},
+} );
+const actionKey2 = getRequestKey( {
+	type: COMMENTS_CHANGE_STATUS,
+	commentId: 2,
+	status: 'approved',
+	meta: {
+		dataLayer: {
+			trackRequest: true,
+		},
+	},
+} );
+
+describe( 'hasPendingCommentRequests()', () => {
+	test( 'should return true if we have pending actions', () => {
+		const state = deepFreeze( {
+			ui: { comments: { pendingActions: [ actionKey, actionKey2 ] } },
+			dataRequests: {
+				[ actionKey ]: { status: 'success' },
+				[ actionKey2 ]: { status: 'pending' },
+			},
+		} );
+		expect( hasPendingCommentRequests( state ) ).toEqual( true );
+	} );
+	test( 'should return false if do not have pending actions', () => {
+		const state = deepFreeze( {
+			ui: { comments: { pendingActions: [ actionKey, actionKey2 ] } },
+			dataRequests: {
+				[ actionKey ]: { status: 'success' },
+				[ actionKey2 ]: { status: 'success' },
+			},
+		} );
+		expect( hasPendingCommentRequests( state ) ).toEqual( false );
+	} );
+	test( 'only checks against actions we track in ui state', () => {
+		const state = deepFreeze( {
+			ui: { comments: { pendingActions: [ actionKey ] } },
+			dataRequests: {
+				[ actionKey ]: { status: 'success' },
+				[ actionKey2 ]: { status: 'pending' },
+			},
+		} );
+		expect( hasPendingCommentRequests( state ) ).toEqual( false );
+	} );
+} );

--- a/client/state/ui/comments/test/reducer.js
+++ b/client/state/ui/comments/test/reducer.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import deepFreeze from 'deep-freeze';
-import { expect } from 'chai';
 
 /**
  * Internal dependencies
@@ -26,7 +25,7 @@ describe( 'reducer', () => {
 				comments,
 				query: { page: 1 },
 			} );
-			expect( query ).to.eql( {
+			expect( query ).toEqual( {
 				site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },
 			} );
 		} );
@@ -44,7 +43,7 @@ describe( 'reducer', () => {
 					postId,
 				},
 			} );
-			expect( query ).to.eql( {
+			expect( query ).toEqual( {
 				site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },
 				[ postId ]: { 'all?order=DESC': { 1: [ 6, 7, 8, 9, 10 ] } },
 			} );
@@ -67,7 +66,7 @@ describe( 'reducer', () => {
 					status: 'spam',
 				},
 			} );
-			expect( query ).to.eql( {
+			expect( query ).toEqual( {
 				site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } },
 				[ postId ]: {
 					'all?order=DESC': { 1: [ 6, 7, 8, 9, 10 ] },
@@ -90,7 +89,7 @@ describe( 'reducer', () => {
 				comments: comments3,
 				query: { page: 1 },
 			} );
-			expect( query ).to.eql( {
+			expect( query ).toEqual( {
 				site: { 'all?order=DESC': { 1: [ 11, 12, 13, 14, 15 ] } },
 				[ postId ]: {
 					'all?order=DESC': { 1: [ 6, 7, 8, 9, 10 ] },
@@ -109,7 +108,7 @@ describe( 'reducer', () => {
 				commentId: 5,
 				refreshCommentListQuery: { page: 1, status: 'all' },
 			} );
-			expect( query ).to.eql( { site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4 ] } } } );
+			expect( query ).toEqual( { site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4 ] } } } );
 		} );
 
 		test( 'should remove a comment from a page when the comment status is changed', () => {
@@ -123,7 +122,7 @@ describe( 'reducer', () => {
 				status: 'approved',
 				refreshCommentListQuery: { page: 1, status: 'spam' },
 			} );
-			expect( query ).to.eql( { site: { 'spam?order=DESC': { 1: [ 1, 2, 3, 4 ] } } } );
+			expect( query ).toEqual( { site: { 'spam?order=DESC': { 1: [ 1, 2, 3, 4 ] } } } );
 		} );
 
 		test( "should not remove a comment from a page when the comment status is changed but it doesn't change filter list", () => {
@@ -137,7 +136,7 @@ describe( 'reducer', () => {
 				status: 'approved',
 				refreshCommentListQuery: { page: 1, status: 'all' },
 			} );
-			expect( query ).to.eql( { site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } } } );
+			expect( query ).toEqual( { site: { 'all?order=DESC': { 1: [ 1, 2, 3, 4, 5 ] } } } );
 		} );
 	} );
 } );


### PR DESCRIPTION
A Proof of Concept Alternative to #21275. I've updated code to store the exact request keys we're interested in, in UI state. We clear this list whenever we detect a list request or tree request. (A fresh page view/switch site).

Note that I needed to modify how the data-layer was passing previousStatus (now moved to meta). Modifying the action caused  multiple entries to be recorded with one always in `pending` state.

Regardless of what we choose, in the long run I would recommend we bump priority on completing the bulk endpoints, and remove the related comment tracking client code.

Testing Instructions
====
- Select some comments, and perform a bulk action like "unapprove"
- `state.ui.comments.pendingActions` should now have the keys of the actions we'd like to change
- Adding a console.log for `hasPendingBulkAction` in mapStateToProps should change from false, to true, to false again when performing the action.
  