### PR TITLE
Add data attribute for e2e testing

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -203,9 +203,10 @@ export class Theme extends Component {
 		const fit = '479,360';
 		const themeImgSrc = photon( screenshot, { fit } );
 		const themeImgSrcDoubleDpi = photon( screenshot, { fit, zoom: 2 } );
+		const e2eThemeName = name.toLowerCase().replace( /\s+/g, '-' );
 
 		return (
-			<Card className={ themeClass } data-e2e-theme={ this.props.theme.id }>
+			<Card className={ themeClass } data-e2e-theme={ e2eThemeName }>
 				{ this.isBeginnerTheme() && (
 					<Ribbon className="theme__ribbon" color="green">
 						{ translate( 'Beginner' ) }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -205,7 +205,7 @@ export class Theme extends Component {
 		const themeImgSrcDoubleDpi = photon( screenshot, { fit, zoom: 2 } );
 
 		return (
-			<Card className={ themeClass }>
+			<Card className={ themeClass } data-e2e-theme={ this.props.theme.id }>
 				{ this.isBeginnerTheme() && (
 					<Ribbon className="theme__ribbon" color="green">
 						{ translate( 'Beginner' ) }

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -3,6 +3,7 @@
 exports[`Theme rendering with default display buttonContents should match snapshot 1`] = `
 <Card
   className="theme is-actionable"
+  data-e2e-theme="twentyseventeen"
   highlight={false}
   tagName="div"
 >

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -3,7 +3,7 @@
 exports[`Theme rendering with default display buttonContents should match snapshot 1`] = `
 <Card
   className="theme is-actionable"
-  data-e2e-theme="twentyseventeen"
+  data-e2e-theme="twenty-seventeen"
   highlight={false}
   tagName="div"
 >


### PR DESCRIPTION
To test: Ensure that Theme cards in ThemeList(e.g. [here](https://wordpress.com/themes)) have `data-e2e-theme` attribute and its matching `theme.id` (lowercased theme name)