### PR TITLE
Activity Log: add upgrade notice when site doesn't have a paid plan

### DIFF
--- a/client/my-sites/stats/activity-log-upgrade-notice/index.jsx
+++ b/client/my-sites/stats/activity-log-upgrade-notice/index.jsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import QuerySitePlans from 'components/data/query-site-plans';
+import Banner from 'components/banner';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { isCurrentPlanPaid } from 'state/sites/selectors';
+
+class ActivityLogUpgradeNotice extends Component {
+	static propTypes = {
+		siteId: PropTypes.number.isRequired,
+
+		// Connected props
+		siteSlug: PropTypes.string.isRequired,
+		hasPlan: PropTypes.bool.isRequired,
+
+		// localize
+		translate: PropTypes.func.isRequired,
+	};
+
+	render() {
+		if ( null === this.props.hasPlan || this.props.hasPlan ) {
+			return false;
+		}
+
+		const {
+			siteId,
+			siteSlug,
+			translate,
+		} = this.props;
+
+		return [
+			<QuerySitePlans siteId={ siteId } />,
+			<Banner
+				plan="personal-bundle"
+				href={ `/plans/${ siteSlug }` }
+				callToAction={ translate( 'Upgrade' ) }
+				title={ translate( 'Upgrade your Jetpack plan to restore your site to events in the past.' ) }
+			/>,
+		];
+	}
+}
+
+export default connect(
+	( state, { siteId } ) => {
+		return {
+			siteSlug: getSelectedSiteSlug( state, siteId ),
+			hasPlan: isCurrentPlanPaid( state, siteId ),
+		};
+	}
+)( localize( ActivityLogUpgradeNotice ) );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -13,6 +13,7 @@ import { first, get, groupBy, includes, isEmpty, isNull, last, range, sortBy } f
 /**
  * Internal dependencies
  */
+import ActivityLogUpgradeNotice from '../activity-log-upgrade-notice';
 import ActivityLogDay from '../activity-log-day';
 import ActivityLogDayPlaceholder from '../activity-log-day/placeholder';
 import Banner from 'components/banner';
@@ -510,6 +511,7 @@ class ActivityLog extends Component {
 				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />
+				{ siteId && <ActivityLogUpgradeNotice siteId={ siteId } /> }
 				{ 'awaitingCredentials' === rewindState.state && (
 					<Banner
 						icon="history"


### PR DESCRIPTION
Fixes #19613 

<img width="885" alt="captura de pantalla 2018-01-11 a la s 15 14 54" src="https://user-images.githubusercontent.com/1041600/34839976-3ed993b4-f6e2-11e7-80bc-07c373c9b468.png">

This PR introduces the `ActivityLogUpgradeNotice` component that will show a notice to upgrade to a paid plan when the site is in a free plan and doesn't have Rewind.

#### Test

Test this with a plan without and with a paid plan. In the first case, the notice should show. In the latter, the notice should not be shown.

To test this, you can find the component using React, typing its name and unchecking the checkbox for `hasPlan`

<img width="1085" alt="captura de pantalla 2018-01-11 a la s 15 15 44" src="https://user-images.githubusercontent.com/1041600/34840018-6e830a6e-f6e2-11e7-9ae3-6a29d6709b41.png">

<img width="188" alt="captura de pantalla 2018-01-11 a la s 15 15 57" src="https://user-images.githubusercontent.com/1041600/34840021-714ff202-f6e2-11e7-8439-b432d88fd0c1.png">
