### PR TITLE
Post List: increase click-ability of post item

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -163,7 +163,7 @@ class PostItem extends React.Component {
 								</a>
 							) }
 							{ isAuthorVisible && (
-								<a href={ enabledPostLink } className="post-item__site-info-link">
+								<a href={ enabledPostLink } className="post-item__post-author-link">
 									<PostTypePostAuthor globalId={ globalId } />
 								</a>
 							) }

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -138,6 +138,7 @@ class PostItem extends React.Component {
 
 		const title = post ? post.title : null;
 		const isPlaceholder = ! globalId;
+		const enabledPostLink = isPlaceholder || multiSelectEnabled ? null : postUrl;
 
 		const panelClasses = classnames( 'post-item__panel', className, {
 			'is-untitled': ! title,
@@ -156,8 +157,16 @@ class PostItem extends React.Component {
 					{ this.renderSelectionCheckbox() }
 					<div className="post-item__detail">
 						<div className="post-item__info">
-							{ isAllSitesModeSelected && <PostTypeSiteInfo globalId={ globalId } /> }
-							{ isAuthorVisible && <PostTypePostAuthor globalId={ globalId } /> }
+							{ isAllSitesModeSelected && (
+								<a href={ enabledPostLink } className="post-item__site-info-link">
+									<PostTypeSiteInfo globalId={ globalId } />
+								</a>
+							) }
+							{ isAuthorVisible && (
+								<a href={ enabledPostLink } className="post-item__site-info-link">
+									<PostTypePostAuthor globalId={ globalId } />
+								</a>
+							) }
 						</div>
 						<h1
 							className="post-item__title"
@@ -165,10 +174,7 @@ class PostItem extends React.Component {
 							onMouseOver={ preloadEditor }
 						>
 							{ ! externalPostLink && (
-								<a
-									href={ isPlaceholder || multiSelectEnabled ? null : postUrl }
-									className="post-item__title-link"
-								>
+								<a href={ enabledPostLink } className="post-item__title-link">
 									{ title || translate( 'Untitled' ) }
 								</a>
 							) }
@@ -186,8 +192,10 @@ class PostItem extends React.Component {
 						</h1>
 						<div className="post-item__meta">
 							<span className="post-item__meta-time-status">
-								<PostTime globalId={ globalId } />
-								<PostStatus globalId={ globalId } />
+								<a href={ enabledPostLink } className="post-item__time-status-link">
+									<PostTime globalId={ globalId } />
+									<PostStatus globalId={ globalId } />
+								</a>
 							</span>
 							<PostActionCounts globalId={ globalId } />
 						</div>

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -72,7 +72,8 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 
 .post-item__title {
 	@extend %content-font;
-	margin-bottom: 2px;
+	padding-bottom: 2px;
+	padding-right: 8px;
 	font-weight: 700;
 	font-size: 18px;
 	line-height: 1.2;
@@ -120,5 +121,50 @@ a.post-item__title-link:visited {
 }
 
 .post-item__meta-time-status {
+	display: inline-block;
 	margin-right: 16px;
+}
+
+.post-item__time-status-link,
+.post-item__time-status-link:active,
+.post-item__time-status-link:visited {
+	color: $gray-text-min;
+	display: block;
+}
+
+.post-type-list__post-thumbnail-wrapper {
+	display: none;
+	position: relative;
+	width: 80px;
+	align-self: stretch;
+	overflow: hidden;
+
+	margin: 8px 0;
+	.post-item__card.is-mini & {
+		margin: 0;
+	}
+
+	&.has-image,
+	.post-item__card.is-placeholder & {
+		display: block;
+	}
+
+	.post-item__card.is-placeholder & {
+		@include placeholder;
+	}
+}
+
+.post-type-list__post-thumbnail-link {
+	display: block;
+	height: 100%;
+}
+
+.post-type-list__post-thumbnail {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate( -50%, -50% );
+	height: 100%;
+	max-height: 80px;
+	max-width: none;
 }

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -57,6 +57,11 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	}
 }
 
+.post-item__site-info-link,
+.post-item__post-author-link {
+	display: block;
+}
+
 .post-item__detail {
 	position: relative;
 	width: calc( 100% - 50px );
@@ -72,8 +77,8 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 
 .post-item__title {
 	@extend %content-font;
-	padding-bottom: 2px;
-	padding-right: 8px;
+	margin: 0;
+	padding: 0;
 	font-weight: 700;
 	font-size: 18px;
 	line-height: 1.2;
@@ -83,6 +88,8 @@ a.post-item__title-link,
 a.post-item__title-link:visited {
 	color: $gray-dark;
 	display: block;
+	padding-bottom: 2px;
+	padding-right: 8px;
 
 	&:hover {
 		color: darken( $gray, 20% );

--- a/client/my-sites/post-type-list/post-thumbnail.jsx
+++ b/client/my-sites/post-type-list/post-thumbnail.jsx
@@ -16,8 +16,11 @@ import { get, noop } from 'lodash';
 import resizeImageUrl from 'lib/resize-image-url';
 import safeImageUrl from 'lib/safe-image-url';
 import { getNormalizedPost } from 'state/posts/selectors';
+import { getEditorPath } from 'state/ui/editor/selectors';
+import { canCurrentUserEditPost } from 'state/selectors';
+import { isMultiSelectEnabled } from 'state/ui/post-type-list/selectors';
 
-function PostTypeListPostThumbnail( { onClick, thumbnail, postUrl } ) {
+function PostTypeListPostThumbnail( { onClick, thumbnail, postLink } ) {
 	const classes = classnames( 'post-type-list__post-thumbnail-wrapper', {
 		'has-image': !! thumbnail,
 	} );
@@ -25,7 +28,7 @@ function PostTypeListPostThumbnail( { onClick, thumbnail, postUrl } ) {
 	return (
 		<div className={ classes }>
 			{ thumbnail && (
-				<a href={ postUrl } className="post-type-list__post-thumbnail-link">
+				<a href={ postLink } className="post-type-list__post-thumbnail-link">
 					<img
 						src={ resizeImageUrl( safeImageUrl( thumbnail ), { h: 80 } ) }
 						className="post-type-list__post-thumbnail"
@@ -50,8 +53,16 @@ PostTypeListPostThumbnail.defaultProps = {
 
 export default connect( ( state, ownProps ) => {
 	const post = getNormalizedPost( state, ownProps.globalId );
-	const postUrl = get( post, 'URL' );
 	const thumbnail = get( post, 'canonical_image.uri' );
 
-	return { thumbnail, postUrl };
+	const siteId = get( post, 'site_ID' );
+	const postId = get( post, 'ID' );
+	const postUrl = canCurrentUserEditPost( state, ownProps.globalId )
+		? getEditorPath( state, siteId, postId )
+		: get( post, 'URL' );
+
+	// Null if the item is a placeholder or bulk edit mode is active.
+	const postLink = ! ownProps.globalId || isMultiSelectEnabled( state ) ? null : postUrl;
+
+	return { thumbnail, postLink };
 } )( PostTypeListPostThumbnail );

--- a/client/my-sites/post-type-list/post-thumbnail.jsx
+++ b/client/my-sites/post-type-list/post-thumbnail.jsx
@@ -17,7 +17,7 @@ import resizeImageUrl from 'lib/resize-image-url';
 import safeImageUrl from 'lib/safe-image-url';
 import { getNormalizedPost } from 'state/posts/selectors';
 
-function PostTypeListPostThumbnail( { onClick, thumbnail } ) {
+function PostTypeListPostThumbnail( { onClick, thumbnail, postUrl } ) {
 	const classes = classnames( 'post-type-list__post-thumbnail-wrapper', {
 		'has-image': !! thumbnail,
 	} );
@@ -25,11 +25,13 @@ function PostTypeListPostThumbnail( { onClick, thumbnail } ) {
 	return (
 		<div className={ classes }>
 			{ thumbnail && (
-				<img
-					src={ resizeImageUrl( safeImageUrl( thumbnail ), { h: 80 } ) }
-					className="post-type-list__post-thumbnail"
-					onClick={ onClick }
-				/>
+				<a href={ postUrl } className="post-type-list__post-thumbnail-link">
+					<img
+						src={ resizeImageUrl( safeImageUrl( thumbnail ), { h: 80 } ) }
+						className="post-type-list__post-thumbnail"
+						onClick={ onClick }
+					/>
+				</a>
 			) }
 		</div>
 	);
@@ -39,6 +41,7 @@ PostTypeListPostThumbnail.propTypes = {
 	globalId: PropTypes.string,
 	onClick: PropTypes.func,
 	thumbnail: PropTypes.string,
+	postUrl: PropTypes.string,
 };
 
 PostTypeListPostThumbnail.defaultProps = {
@@ -47,7 +50,8 @@ PostTypeListPostThumbnail.defaultProps = {
 
 export default connect( ( state, ownProps ) => {
 	const post = getNormalizedPost( state, ownProps.globalId );
+	const postUrl = get( post, 'URL' );
 	const thumbnail = get( post, 'canonical_image.uri' );
 
-	return { thumbnail };
+	return { thumbnail, postUrl };
 } )( PostTypeListPostThumbnail );

--- a/client/my-sites/post-type-list/post-type-post-author/style.scss
+++ b/client/my-sites/post-type-list/post-type-post-author/style.scss
@@ -4,6 +4,7 @@
 
 .post-type-post-author__name {
 	margin: 0;
+	padding-bottom: 2px;
 	line-height: 16px;
 	vertical-align: middle;
 	font-size: 13px;

--- a/client/my-sites/post-type-list/post-type-site-info/style.scss
+++ b/client/my-sites/post-type-list/post-type-site-info/style.scss
@@ -10,6 +10,7 @@
 .post-type-site-info__title {
 	display: inline;
 	margin-right: 15px;
+	padding-bottom: 2px;
 	line-height: 16px;
 	vertical-align: middle;
 	font-size: 13px;

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -29,6 +29,12 @@
 	}
 }
 
+.post-item__time-status-link,
+.post-item__time-status-link:active,
+.post-item__time-status-link:visited {
+	color: $gray-text-min;
+}
+
 .post-type-list__post-thumbnail-wrapper {
 	display: none;
 	position: relative;

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -29,45 +29,6 @@
 	}
 }
 
-.post-item__time-status-link,
-.post-item__time-status-link:active,
-.post-item__time-status-link:visited {
-	color: $gray-text-min;
-}
-
-.post-type-list__post-thumbnail-wrapper {
-	display: none;
-	position: relative;
-	width: 80px;
-	align-self: stretch;
-	overflow: hidden;
-
-	margin: 8px 0 8px 8px;
-	.post-item__card.is-mini & {
-		margin: 0;
-	}
-
-	&.has-image,
-	.post-item__card.is-placeholder & {
-		display: block;
-	}
-
-	.post-item__card.is-placeholder & {
-		@include placeholder;
-	}
-}
-
-.post-type-list__post-thumbnail {
-	position: absolute;
-		top: 50%;
-		left: 50%;
-	transform: translate( -50%, -50% );
-	height: 100%;
-	max-height: 80px;
-	max-width: none;
-}
-
-
 .post-type-list__max-pages-notice {
 	text-align: center;
 	margin: 16px 0;


### PR DESCRIPTION
The goal of this PR is to increase the clickable area of a post item, by adding links to the editor to all action-less components inside the post item (site name, author, date, post status, and featured image).

**Before:** | **After:**
----------- | ----------
<img width="695" alt="screen shot 2018-01-05 at 12 11 54 pm" src="https://user-images.githubusercontent.com/942359/34620234-c05ca57c-f212-11e7-94fd-69b0df344234.png"> | <img width="694" alt="screen shot 2018-01-05 at 12 11 12 pm" src="https://user-images.githubusercontent.com/942359/34620242-c76d6d56-f212-11e7-9f6c-2f1d6c088eb4.png">

_Yellow area is clickable to post editor._
