### PR TITLE
Store: Support setup of stores in any country; redirect to Woo wizard when needed

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -45,6 +45,7 @@ import RequiredPagesSetupView from './required-pages-setup-view';
 import RequiredPluginsInstallView from './required-plugins-install-view';
 import SetupTasksView from './setup-tasks-view';
 import MailChimp from 'woocommerce/app/settings/email/mailchimp/index.js';
+import warn from 'lib/warn';
 
 class Dashboard extends Component {
 	static propTypes = {
@@ -157,6 +158,9 @@ class Dashboard extends Component {
 		} = this.props;
 
 		const adminURL = get( selectedSite, 'options.admin_url', '' );
+		if ( isEmpty( adminURL ) ) {
+			warn( 'options.admin_url unexpectedly empty in renderDashboardSetupContent' );
+		}
 
 		if ( setupChoicesLoading ) {
 			// Many of the clauses below depend on setup choices being in the state tree

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -65,6 +65,10 @@ class Dashboard extends Component {
 		setupChoicesLoading: PropTypes.bool,
 	};
 
+	state = {
+		redirectURL: false,
+	};
+
 	componentDidMount = () => {
 		const { siteId } = this.props;
 
@@ -80,6 +84,21 @@ class Dashboard extends Component {
 		if ( siteId && oldSiteId !== siteId ) {
 			this.fetchStoreData();
 		}
+	};
+
+	// If the user 1) has set the store address in StoreLocationSetupView
+	// and 2) we have a redirectURL, don't render but go ahead and
+	// redirect (i.e. to the WooCommerce Setup Wizard in wp-admin)
+	shouldComponentUpdate = ( nextProps, nextState ) => {
+		const { setStoreAddressDuringInitialSetup } = nextProps;
+		const { redirectURL } = nextState;
+
+		if ( setStoreAddressDuringInitialSetup && redirectURL ) {
+			window.location = redirectURL;
+			return false;
+		}
+
+		return true;
 	};
 
 	fetchStoreData = () => {
@@ -122,6 +141,10 @@ class Dashboard extends Component {
 		return translate( 'Dashboard' );
 	};
 
+	onRequestRedirect = redirectURL => {
+		this.setState( { redirectURL } );
+	};
+
 	renderDashboardSetupContent = () => {
 		const {
 			finishedInstallOfRequiredPlugins,
@@ -153,6 +176,7 @@ class Dashboard extends Component {
 			return (
 				<StoreLocationSetupView
 					adminURL={ adminURL }
+					onRequestRedirect={ this.onRequestRedirect }
 					siteId={ selectedSite.ID }
 					pushDefaultsForCountry={ ! hasProducts }
 				/>

--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -132,6 +133,8 @@ class Dashboard extends Component {
 			setupChoicesLoading,
 		} = this.props;
 
+		const adminURL = get( selectedSite, 'options.admin_url', '' );
+
 		if ( setupChoicesLoading ) {
 			// Many of the clauses below depend on setup choices being in the state tree
 			// Show a placeholder while they load
@@ -149,6 +152,7 @@ class Dashboard extends Component {
 		if ( ! setStoreAddressDuringInitialSetup ) {
 			return (
 				<StoreLocationSetupView
+					adminURL={ adminURL }
 					siteId={ selectedSite.ID }
 					pushDefaultsForCountry={ ! hasProducts }
 				/>

--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -393,12 +393,7 @@ class RequiredPluginsInstallView extends Component {
 						imageWidth={ 160 }
 						title={ translate( 'Have something to sell?' ) }
 						subtitle={ translate(
-							"If you're in the {{strong}}United States{{/strong}} " +
-								'or {{strong}}Canada{{/strong}}, you can sell your products right on ' +
-								'your site and ship them to customers in a snap!',
-							{
-								components: { strong: <strong /> },
-							}
+							'You can sell your products right on your site and ship them to customers in a snap!'
 						) }
 					>
 						<Button onClick={ this.startSetup } primary>

--- a/client/extensions/woocommerce/app/dashboard/setup-footer.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-footer.js
@@ -30,4 +30,10 @@ SetupFooter.propTypes = {
 	primary: PropTypes.bool,
 };
 
+SetupFooter.defaultProps = {
+	busy: false,
+	disabled: false,
+	primary: false,
+};
+
 export default SetupFooter;

--- a/client/extensions/woocommerce/app/dashboard/setup-footer.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-footer.js
@@ -12,10 +12,10 @@ import PropTypes from 'prop-types';
  */
 import Button from 'components/button';
 
-const SetupFooter = ( { disabled, label, onClick, primary } ) => {
+const SetupFooter = ( { busy, disabled, label, onClick, primary } ) => {
 	return (
 		<div className="dashboard__setup-footer">
-			<Button disabled={ disabled } onClick={ onClick } primary={ primary }>
+			<Button busy={ busy } disabled={ disabled } onClick={ onClick } primary={ primary }>
 				{ label }
 			</Button>
 		</div>
@@ -23,6 +23,7 @@ const SetupFooter = ( { disabled, label, onClick, primary } ) => {
 };
 
 SetupFooter.propTypes = {
+	busy: PropTypes.bool,
 	disabled: PropTypes.bool,
 	label: PropTypes.string.isRequired,
 	onClick: PropTypes.func.isRequired,

--- a/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
@@ -132,6 +132,11 @@ class StoreLocationSetupView extends Component {
 		const { adminURL, currentUserEmailVerified, onRequestRedirect, siteId, translate } = this.props;
 		event.preventDefault();
 
+		// Already saving? Bail.
+		if ( this.state.isSaving ) {
+			return;
+		}
+
 		if ( ! currentUserEmailVerified ) {
 			this.setState( { showEmailVerificationDialog: true } );
 			return;
@@ -226,6 +231,7 @@ class StoreLocationSetupView extends Component {
 					showAllLocations
 				/>
 				<SetupFooter
+					busy={ this.state.isSaving }
 					disabled={ submitDisabled }
 					onClick={ this.onNext }
 					label={ translate( "Let's Go!" ) }

--- a/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
@@ -127,7 +127,6 @@ class StoreLocationSetupView extends Component {
 
 	onNext = event => {
 		const { adminURL, currentUserEmailVerified, siteId, translate } = this.props;
-		const { adminURL, siteId, translate } = this.props;
 		event.preventDefault();
 
 		if ( ! currentUserEmailVerified ) {

--- a/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
@@ -15,6 +15,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import AddressView from 'woocommerce/components/address-view';
+import analytics from 'lib/analytics';
 import {
 	areSettingsGeneralLoaded,
 	getStoreLocation,
@@ -140,6 +141,9 @@ class StoreLocationSetupView extends Component {
 			// No need to set isSaving to false here - we're navigating away from here
 			// and setting isSaving to false will just light the button up again right
 			// before the next step's dialog displays
+
+			// mc stat 32 char max :P
+			analytics.mc.bumpStat( 'calypso_woo_store_setup_country', this.state.address.country );
 
 			// If we don't support a calypso experience yet for this country, let
 			// them complete setup with the wp-admin WooCommerce wizard

--- a/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
@@ -234,7 +234,7 @@ class StoreLocationSetupView extends Component {
 					busy={ this.state.isSaving }
 					disabled={ submitDisabled }
 					onClick={ this.onNext }
-					label={ translate( "Let's Go!" ) }
+					label={ translate( 'Next', { context: 'Label for button that submits a form' } ) }
 					primary
 				/>
 			</div>

--- a/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { every, includes, isEmpty, keys, pick, trim } from 'lodash';
+import { every, isEmpty, keys, pick, trim } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -59,6 +59,7 @@ class StoreLocationSetupView extends Component {
 			countryCode: PropTypes.string,
 		} ),
 		adminURL: PropTypes.string.isRequired,
+		onRequestRedirect: PropTypes.func.isRequired,
 		pushDefaultsForCountry: PropTypes.bool.isRequired,
 		settingsGeneralLoaded: PropTypes.bool,
 		storeLocation: PropTypes.shape( {
@@ -85,19 +86,15 @@ class StoreLocationSetupView extends Component {
 					postcode: '',
 					country: 'US',
 				};
-				// If the settings general country is US or CA and it has a street address, use it
-				// Otherwise, if the contact details country is US or CA and it has a street address, use it
-				if (
-					includes( [ 'US', 'CA' ], storeLocation.country ) &&
-					! isEmpty( storeLocation.street )
-				) {
+
+				// If settings general has an address, use it
+				// Otherwise, if the contact details has an address, use it
+				if ( ! isEmpty( storeLocation.street ) ) {
 					address = pick( storeLocation, keys( address ) );
-				} else if (
-					includes( [ 'US', 'CA' ], contactDetails.countryCode ) &&
-					! isEmpty( contactDetails.address1 )
-				) {
+				} else if ( ! isEmpty( contactDetails.address1 ) ) {
 					address = this.getAddressFromContactDetails( contactDetails );
 				}
+
 				this.setState( { address } );
 			}
 		}
@@ -126,7 +123,7 @@ class StoreLocationSetupView extends Component {
 	};
 
 	onNext = event => {
-		const { adminURL, currentUserEmailVerified, siteId, translate } = this.props;
+		const { adminURL, currentUserEmailVerified, onRequestRedirect, siteId, translate } = this.props;
 		event.preventDefault();
 
 		if ( ! currentUserEmailVerified ) {
@@ -149,7 +146,7 @@ class StoreLocationSetupView extends Component {
 			if ( ! isStoreManagementSupportedInCalypsoForCountry( this.state.address.country ) ) {
 				const storeSetupURL =
 					adminURL + 'admin.php?page=wc-setup&step=store_setup&activate_error=false&from=calypso';
-				window.location = storeSetupURL;
+				onRequestRedirect( storeSetupURL );
 			}
 
 			return setSetStoreAddressDuringInitialSetup( siteId, true );

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -66,6 +66,14 @@ class AddressView extends Component {
 		}
 	};
 
+	onChangeCountry = event => {
+		// First, always forward the country event through
+		this.props.onChange( event );
+
+		// Then, send a second onChange to clear state
+		this.props.onChange( { target: { name: 'state', value: '' } } );
+	};
+
 	getCountryData = () => {
 		const { country } = this.props.address;
 		let countryData = find( getCountries(), { code: country || 'US' } );
@@ -79,18 +87,18 @@ class AddressView extends Component {
 	};
 
 	renderCountry = () => {
-		const { address: { country }, onChange, showAllLocations, translate } = this.props;
+		const { address: { country }, showAllLocations, translate } = this.props;
 		if ( showAllLocations ) {
 			return (
 				<FormFieldSet className="address-view__country">
-					<FormCountrySelectFromApi value={ country } onChange={ onChange } />
+					<FormCountrySelectFromApi value={ country } onChange={ this.onChangeCountry } />
 				</FormFieldSet>
 			);
 		}
 		return (
 			<FormFieldSet className="address-view__country">
 				<FormLabel>{ translate( 'Country' ) }</FormLabel>
-				<FormSelect name="country" onChange={ onChange } value={ country || 'US' }>
+				<FormSelect name="country" onChange={ this.onChangeCountry } value={ country || 'US' }>
 					{ getCountries().map( option => {
 						return (
 							<option key={ option.code } value={ option.code }>

--- a/client/extensions/woocommerce/components/form-location-select/states.js
+++ b/client/extensions/woocommerce/components/form-location-select/states.js
@@ -39,7 +39,7 @@ class FormStateSelectFromApi extends Component {
 		onChange: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
 		translate: PropTypes.func.isRequired,
-		value: PropTypes.string.isRequired,
+		value: PropTypes.string,
 	};
 
 	componentWillMount() {

--- a/client/extensions/woocommerce/components/form-location-select/states.js
+++ b/client/extensions/woocommerce/components/form-location-select/states.js
@@ -7,6 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { bindActionCreators } from 'redux';
 
@@ -113,10 +114,17 @@ export default connect(
 	( state, props ) => {
 		const address = getStoreLocation( state );
 		const areSettingsLoaded = areSettingsGeneralLoaded( state );
+
 		let { country, value } = props;
-		// If value or country are empty, use the store's address
-		country = ! country ? address.country : country;
-		value = ! value ? address.state : value;
+		// If (state) value or country are empty, use the store's address
+		// Note: We only want to use te store's state if we are using
+		// the store's country, to avoid potential country-state mismatch
+		if ( isEmpty( country ) ) {
+			country = address.country; // use the store's country
+			if ( isEmpty( value ) ) {
+				value = address.state; // use the store's state
+			}
+		}
 
 		const site = getSelectedSiteWithFallback( state );
 		const siteId = site.ID || null;

--- a/client/extensions/woocommerce/components/query-locations/index.js
+++ b/client/extensions/woocommerce/components/query-locations/index.js
@@ -1,0 +1,65 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { fetchLocations } from 'woocommerce/state/sites/locations/actions';
+import { areLocationsLoaded } from 'woocommerce/state/sites/locations/selectors';
+
+class QueryLocations extends Component {
+	static propTypes = {
+		fetchLocations: PropTypes.func,
+		loaded: PropTypes.bool,
+		siteId: PropTypes.number.isRequired,
+	};
+
+	componentWillMount = () => {
+		const { siteId, loaded } = this.props;
+
+		if ( siteId && ! loaded ) {
+			this.props.fetchLocations( siteId );
+		}
+	};
+
+	componentWillReceiveProps = ( { siteId, loaded } ) => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		if ( siteId !== this.props.siteId && ! loaded ) {
+			this.props.fetchLocations( siteId );
+		}
+	};
+
+	render = () => {
+		return null;
+	};
+}
+
+const mapStateToProps = ( state, ownProps ) => {
+	const loaded = areLocationsLoaded( state, ownProps.siteId );
+
+	return {
+		loaded,
+	};
+};
+
+const mapDispatchToProps = dispatch => {
+	return bindActionCreators(
+		{
+			fetchLocations,
+		},
+		dispatch
+	);
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( QueryLocations );

--- a/client/extensions/woocommerce/components/query-locations/index.js
+++ b/client/extensions/woocommerce/components/query-locations/index.js
@@ -7,37 +7,24 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
  */
 import { fetchLocations } from 'woocommerce/state/sites/locations/actions';
-import { areLocationsLoaded } from 'woocommerce/state/sites/locations/selectors';
 
 class QueryLocations extends Component {
 	static propTypes = {
 		fetchLocations: PropTypes.func,
-		loaded: PropTypes.bool,
 		siteId: PropTypes.number.isRequired,
 	};
 
-	componentWillMount = () => {
-		const { siteId, loaded } = this.props;
-
-		if ( siteId && ! loaded ) {
-			this.props.fetchLocations( siteId );
-		}
+	componentDidMount = () => {
+		this.props.fetchLocations( this.props.siteId );
 	};
 
-	componentWillReceiveProps = ( { siteId, loaded } ) => {
-		if ( ! siteId ) {
-			return;
-		}
-
-		if ( siteId !== this.props.siteId && ! loaded ) {
-			this.props.fetchLocations( siteId );
-		}
+	componentDidUpdate = () => {
+		this.props.fetchLocations( this.props.siteId );
 	};
 
 	render = () => {
@@ -45,21 +32,4 @@ class QueryLocations extends Component {
 	};
 }
 
-const mapStateToProps = ( state, ownProps ) => {
-	const loaded = areLocationsLoaded( state, ownProps.siteId );
-
-	return {
-		loaded,
-	};
-};
-
-const mapDispatchToProps = dispatch => {
-	return bindActionCreators(
-		{
-			fetchLocations,
-		},
-		dispatch
-	);
-};
-
-export default connect( mapStateToProps, mapDispatchToProps )( QueryLocations );
+export default connect( null, { fetchLocations } )( QueryLocations );

--- a/client/extensions/woocommerce/lib/countries/index.js
+++ b/client/extensions/woocommerce/lib/countries/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { find, filter, get, sortBy } from 'lodash';
+import { find, filter, get, includes, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,6 +32,16 @@ export const getCountryData = country => {
 	return countryData;
 };
 
+/**
+ * Whether or not we support store management in calypso for
+ * the passed country
+ * @param {string} country Country (code) to check
+ * @return {bool} whether store management in calypso is supported
+ */
+export const isStoreManagementSupportedInCalypsoForCountry = country => {
+	return includes( [ 'US', 'CA' ], country );
+};
+
 export const getStateData = ( country, state ) => {
 	const countryData = getCountryData( country );
 	if ( ! countryData ) {
@@ -53,7 +63,7 @@ export const getStateData = ( country, state ) => {
  */
 export const getCurrencyCodeForCountry = country => {
 	const countryData = getCountryData( country );
-	return get( countryData, 'currency', 'USD' );
+	return get( countryData, 'currency', false );
 };
 
 /**
@@ -64,7 +74,7 @@ export const getCurrencyCodeForCountry = country => {
  */
 export const getDimensionUnitForCountry = country => {
 	const countryData = getCountryData( country );
-	return get( countryData, 'dimensionUnit', 'in' );
+	return get( countryData, 'dimensionUnit', false );
 };
 
 /**
@@ -75,7 +85,7 @@ export const getDimensionUnitForCountry = country => {
  */
 export const getWeightUnitForCountry = country => {
 	const countryData = getCountryData( country );
-	return get( countryData, 'weightUnit', 'lbs' );
+	return get( countryData, 'weightUnit', false );
 };
 
 /**

--- a/client/extensions/woocommerce/state/sites/locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/locations/selectors.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { find, flatMap, get, isArray, isEmpty, omit, sortBy } from 'lodash';
+import { find, filter, flatMap, get, isArray, isEmpty, omit, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -110,6 +110,24 @@ export const getCountryName = createSelector(
 		return [ loaded, loaded && getRawLocations( state, siteId ) ];
 	}
 );
+
+/**
+ * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Array} A list of countries (codes) that have states
+ */
+export const getCountriesWithStates = ( state, siteId = getSelectedSiteId( state ) ) => {
+	if ( ! areLocationsLoaded( state, siteId ) ) {
+		return [];
+	}
+
+	const allCountries = flatMap( getRawLocations( state, siteId ), 'countries' );
+	const countriesWithStates = filter( allCountries, country => {
+		return ! isEmpty( country.states );
+	} );
+
+	return countriesWithStates.map( country => country.code ).sort();
+};
 
 /**
  * @param {Object} state Whole Redux state tree

--- a/client/extensions/woocommerce/state/sites/locations/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/locations/test/selectors.js
@@ -14,6 +14,7 @@ import {
 	getContinents,
 	getCountries,
 	getCountryName,
+	getCountriesWithStates,
 	getStates,
 	hasStates,
 } from '../selectors';
@@ -257,6 +258,20 @@ describe( 'selectors', () => {
 
 		test( 'should return true if the country has states', () => {
 			expect( hasStates( loadedState, 'US' ) ).to.be.true;
+		} );
+	} );
+
+	describe( '#getCountriesWithStates', () => {
+		test( 'should return an empty list if the locations are not loaded', () => {
+			expect( getCountriesWithStates( emptyState ) ).to.deep.equal( [] );
+		} );
+
+		test( 'should return an empty list if the locations are being loaded', () => {
+			expect( getCountriesWithStates( loadingState ) ).to.deep.equal( [] );
+		} );
+
+		test( 'should return the countries with states, sorted', () => {
+			expect( getCountriesWithStates( loadedState ) ).to.deep.equal( [ 'CA', 'US' ] );
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/state/sites/settings/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/actions.js
@@ -51,7 +51,6 @@ export const doInitialSetup = (
 	// to create the appropriate value for woocommerce_default_country (e.g. US:CT)
 	const countryState = stateOrProvince ? country + ':' + stateOrProvince : country;
 
-	// TODO Support other currency positions, post-v1 etc. See https://github.com/Automattic/wp-calypso/issues/15498
 	let update = [
 		{
 			group_id: 'general',
@@ -80,53 +79,69 @@ export const doInitialSetup = (
 		},
 	];
 
-	if ( pushDefaultsForCountry ) {
-		const currency = getCurrencyCodeForCountry( country );
-		const dimensionUnit = getDimensionUnitForCountry( country );
-		const weightUnit = getWeightUnitForCountry( country );
+	// TODO Only enable taxes when applicable
+	update = update.concat( [
+		{
+			group_id: 'general',
+			id: 'woocommerce_calc_taxes',
+			value: 'yes',
+		},
+	] );
 
-		update = update.concat( [
-			{
-				group_id: 'general',
-				id: 'woocommerce_currency',
-				value: currency,
-			},
-			{
-				group_id: 'general',
-				id: 'woocommerce_currency_pos',
-				value: 'left',
-			},
-			{
-				group_id: 'general',
-				id: 'woocommerce_price_decimal_sep',
-				value: '.',
-			},
-			{
-				group_id: 'general',
-				id: 'woocommerce_price_num_decimals',
-				value: '2',
-			},
-			{
-				group_id: 'general',
-				id: 'woocommerce_price_thousand_sep',
-				value: ',',
-			},
-			{
-				group_id: 'products',
-				id: 'woocommerce_dimension_unit',
-				value: dimensionUnit,
-			},
-			{
-				group_id: 'products',
-				id: 'woocommerce_weight_unit',
-				value: weightUnit,
-			},
-			{
-				group_id: 'general',
-				id: 'woocommerce_calc_taxes',
-				value: 'yes',
-			},
-		] );
+	if ( pushDefaultsForCountry ) {
+		// TODO Support other currency positions, post-v1 etc. See https://github.com/Automattic/wp-calypso/issues/15498
+		const currency = getCurrencyCodeForCountry( country );
+		if ( currency ) {
+			update = update.concat( [
+				{
+					group_id: 'general',
+					id: 'woocommerce_currency',
+					value: currency,
+				},
+				{
+					group_id: 'general',
+					id: 'woocommerce_currency_pos',
+					value: 'left',
+				},
+				{
+					group_id: 'general',
+					id: 'woocommerce_price_decimal_sep',
+					value: '.',
+				},
+				{
+					group_id: 'general',
+					id: 'woocommerce_price_num_decimals',
+					value: '2',
+				},
+				{
+					group_id: 'general',
+					id: 'woocommerce_price_thousand_sep',
+					value: ',',
+				},
+			] );
+		}
+
+		const dimensionUnit = getDimensionUnitForCountry( country );
+		if ( dimensionUnit ) {
+			update = update.concat( [
+				{
+					group_id: 'products',
+					id: 'woocommerce_dimension_unit',
+					value: dimensionUnit,
+				},
+			] );
+		}
+
+		const weightUnit = getWeightUnitForCountry( country );
+		if ( weightUnit ) {
+			update = update.concat( [
+				{
+					group_id: 'products',
+					id: 'woocommerce_weight_unit',
+					value: weightUnit,
+				},
+			] );
+		}
 	}
 
 	return request( siteId )

--- a/client/extensions/woocommerce/state/sites/settings/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/actions.js
@@ -90,6 +90,9 @@ export const doInitialSetup = (
 
 	if ( pushDefaultsForCountry ) {
 		// TODO Support other currency positions, post-v1 etc. See https://github.com/Automattic/wp-calypso/issues/15498
+		// In the event this is a brand new site and ! isStoreManagementSupportedInCalypsoForCountry,
+		// WooCommerce defaults for that country will be automatically loaded by the WooCommerce Setup Wizard
+		// in the merchant's site's wp-admin (to which we redirect after setting up the store)
 		const currency = getCurrencyCodeForCountry( country );
 		if ( currency ) {
 			update = update.concat( [


### PR DESCRIPTION
Finishes #20877 

This code:
* changes the setup flow AddressView to use showAllLocations mode (thereby opening it up to all countries)
* tweaks `lib/countries` to NOT provide defaults for currency, dimensions, and weight for nonUS nonCA countries (thereby allowing the Woo wizard to do it itself)
* redirects the user to the Woo wizard if they provide a nonUS nonCA address in the "Howdy! Ready to start selling? First we need to know where you are in the world." view
* adds a `QueryLocations` component to kick off fetching locations
* adds a `getCountriesWithStates` selector so `StoreLocationSetupView` can appropriately require (or not) a state to be selected

Notes:
* I want to (later) refactor `AddressView` to a `connect`-ed component so it can manage things like whether or not a country has states

To test:
* `npm run test-client client/extensions/woocommerce/`
* Use https://developer.wordpress.com/docs/api/console/ to set set_store_address_during_initial_setup to 0 for the site using the POST /sites/{siteID}/calypso-preferences/woocommerce endpoint
* Navigate to http://calypso.localhost:3000/store/{domain}
* Test each of the following addresses. After hitting let's go, ensure 1) that you are dropped on your store's CALYPSO dashboard and 2) that the currency, dimensions and weight are set appropriately in settings-payments and product-add (repeat the developer console business above to regain access to the form each time needed)

```
15517 Main St
Mill Creek WA 98012
United States
(Make sure currency is set to USD, dimensions to in and weight to lbs)

811 Hornby St
Vancouver, BC V6Z2E6
Canada
(Make sure currency is set to CAD, dimensions to cm and weight to kg)
```

* Next, test each of the following addresses. After hitting let's go, ensure 1) that you are dropped on your store's WP-ADMIN WOOCOMMERCE SETUP WIZARD and 2) that the address has been copied over for you.
* Make sure for countries that have states, that you are required to choose one before you are allowed to submit the form.  For countries that do not, make sure you are not required to choose one :)
* NOTE: We do NOT push a default for nonUS nonCA stores at this time for currency, dimensions or weight. Your previous settings on the site will be retained, or, in the event this is a brand new site, WooCommerce defaults for that country will be automatically used in the wizard.

```
2 Elizabeth St
Melbourne VIC 3004
Australia

7 Allées du Président Franklin Roosevelt
31000 Toulouse
France
```
  
  