### PR TITLE
Improve keyboard accessibility

### DIFF
--- a/client/components/tile-grid/tile.jsx
+++ b/client/components/tile-grid/tile.jsx
@@ -37,7 +37,7 @@ export default class extends React.PureComponent {
 		const tileClassName = classNames( 'tile-grid__item', className );
 
 		return (
-			<Card className={ tileClassName } href={ href } onClick={ onClick }>
+			<Card className={ tileClassName } href={ href } onClick={ onClick } tabIndex="-1">
 				{ image && (
 					<div className="tile-grid__image">
 						<img src={ image } />

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -513,6 +513,7 @@ class AboutStep extends Component {
 						{ ...this.props }
 						onBackClick={ this.handleStoreBackClick }
 						setRef={ this.setPressableStore }
+						isVisible={ this.state.showStore }
 					/>
 				</div>
 

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -172,6 +172,7 @@ class DesignTypeWithAtomicStoreStep extends Component {
 						{ ...this.props }
 						onBackClick={ this.handleStoreBackClick }
 						setRef={ this.setPressableStore }
+						isVisible={ this.state.showStore }
 					/>
 				</div>
 				<div className={ designTypeListClassName }>

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -154,6 +154,7 @@ class DesignTypeWithStoreStep extends Component {
 						{ ...this.props }
 						onBackClick={ this.handleStoreBackClick }
 						setRef={ this.setPressableStore }
+						isVisible={ this.state.showStore }
 					/>
 				</div>
 				<div className={ designTypeListClassName }>

--- a/client/signup/steps/design-type-with-store/pressable-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/pressable-store/index.jsx
@@ -40,6 +40,14 @@ class PressableStoreStep extends Component {
 		};
 	}
 
+	static propTypes = {
+		isVisible: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		isVisible: false,
+	};
+
 	componentDidMount() {
 		this.props.setRef( this );
 	}
@@ -81,6 +89,16 @@ class PressableStoreStep extends Component {
 		this.input = input;
 	};
 
+	getTabIndex() {
+		const { isVisible } = this.props;
+
+		if ( isVisible ) {
+			return 1;
+		}
+
+		return -1;
+	}
+
 	renderStoreForm() {
 		const { translate } = this.props;
 
@@ -116,8 +134,9 @@ class PressableStoreStep extends Component {
 								type="email"
 								placeholder="Email Address"
 								name="email"
+								tabIndex={ this.getTabIndex() }
 							/>
-							<FormButton className="pressable-store__form-submit">
+							<FormButton className="pressable-store__form-submit" tabIndex={ this.getTabIndex() }>
 								{ translate( 'Get started on Pressable' ) }
 								<Gridicon icon="external" size={ 12 } />
 							</FormButton>
@@ -132,6 +151,7 @@ class PressableStoreStep extends Component {
 						className="pressable-store__privacy-policy"
 						target="__blank"
 						href="https://pressable.com/legal/privacy-policy/"
+						tabIndex={ this.getTabIndex() }
 					>
 						{ translate( 'Pressable Privacy Policy', {
 							comment: '“Pressable” is the name of a WordPress.org hosting provider',
@@ -150,7 +170,12 @@ class PressableStoreStep extends Component {
 			<div className="pressable-store">
 				{ this.renderStoreForm() }
 				<div className="pressable-store__back-button-wrapper">
-					<Button compact={ true } borderless={ true } onClick={ this.props.onBackClick }>
+					<Button
+						compact={ true }
+						borderless={ true }
+						onClick={ this.props.onBackClick }
+						tabIndex={ this.getTabIndex() }
+					>
 						<Gridicon icon="arrow-left" size={ 18 } />
 						{ translate( 'Back', { context: 'Return to previous step' } ) }
 					</Button>


### PR DESCRIPTION
When you visit our [new signup screen](https://wordpress.com/start) and try tab through the page, you'll notice your keyboard gets stuck right after your focus leaves the login button — that's because it's cycling through the hidden inputs on the pressable store flow. This PR, removes the tab index for those elements while they are hidden. 

## Screenshot
![tabbing](https://user-images.githubusercontent.com/6981253/34627237-dc56a8de-f22d-11e7-99ca-f31de077b144.gif)

## Testing regular flow
* Visit `/start`
* Tab right away, you should see the focus go from login to the site title field

## Testing store flow
* Visit `/start/store-nux/design-type-with-store-nux` in an incognito window
* Tab right away, you should see the focus go from login to buttons in the card

## Testing the Pressable fields
* Set [this if statement](https://github.com/Automattic/wp-calypso/blob/fix/about-screen-keyboard-accessibility/client/signup/steps/about/index.jsx#L320) to `true`
* Visit `/start`
* Select `Sell products or collect payments` from the options under primary goal
* Press continue
* Ensure you can still tab