### PR TITLE
Store Stats: Fix exception

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/controller.js
+++ b/client/extensions/woocommerce/app/store-stats/controller.js
@@ -16,7 +16,7 @@ import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { getQueryDate } from './utils';
 import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
-import { recordTrack } from 'woocommerce/lib/analytics';
+import { recordTrack, tracksStore } from 'woocommerce/lib/analytics';
 
 function isValidParameters( context ) {
 	const validParameters = {
@@ -29,6 +29,8 @@ function isValidParameters( context ) {
 }
 
 export default function StatsController( context, next ) {
+	tracksStore.setReduxStore( context.store );
+
 	if ( ! context.params.site || context.params.site === 'null' ) {
 		page.redirect( '/stats/day/' );
 	}


### PR DESCRIPTION
When #21245 was merged in yesterday, it appears we introduced a bug where when the Store Stats page is visited before visiting any standard route in `/store/*` an error is thrown:

![error-stats](https://user-images.githubusercontent.com/22080/34632368-ddbd2760-f229-11e7-807c-ee0b9f9924cc.png)

__Steps to Reproduce__
- Open https://wordpress.com
- Click on My Sites, select a site that has Store enabled, hard refresh on the Site Stats page
- Click Store in the stats navigation menu ( above the chart )

This is one proposed fix for the issue, @ryelle is looking at a different approach using some `page.js` middleware.