### PR TITLE
Store: Add a new page callback to set the tracks store for all `store` routes

### DIFF
--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -214,11 +214,10 @@ function addStorePage( storePage, storeNavigation ) {
 
 			analytics.pageView.record( analyticsPath, analyticsPageTitle );
 
-			tracksStore.setReduxStore( context.store );
-
 			context.primary = React.createElement( App, appProps, component );
 			next();
 		},
+		addTracksContext,
 		makeLayout,
 		clientRender
 	);
@@ -243,6 +242,12 @@ function notFoundError( context, next ) {
 	next();
 }
 
+function addTracksContext( context, next ) {
+	tracksStore.setReduxStore( context.store );
+
+	next();
+}
+
 export default function() {
 	// Add pages that use the store navigation
 	getStorePages().forEach( function( storePage ) {
@@ -254,11 +259,19 @@ export default function() {
 	} );
 
 	// Add pages that use my-sites navigation instead
-	page( '/store/stats/:type/:unit', siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/store/stats/:type/:unit',
+		siteSelection,
+		sites,
+		addTracksContext,
+		makeLayout,
+		clientRender
+	);
 	page(
 		'/store/stats/:type/:unit/:site',
 		siteSelection,
 		navigation,
+		addTracksContext,
 		StatsController,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
Alternate fix for #21308, store stats not loading without loading a store page first. This adds a callback that's run for all store pages (except the 404 callback, but we don't seem to use our custom tracks there). It's currently called `addTracksContext` because naming is hard, but ideally this could be something more generic so that we can use this function for any future code we might need across all pages. Renaming can come after the fix, though 🙂 

**To test**

- View store stats for a site, ex: `/store/stats/orders/day/:site`
- Without branch, white-screens and there's an error in console
- After branch, store stats should load as expected