### PR TITLE
Me: Update Auth to use Redux analytics and React.Component

### DIFF
--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -1,29 +1,30 @@
 /** @format */
+
 /**
  * External dependencies
  */
 import React from 'react';
+import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
+import AuthCodeButton from './auth-code-button';
+import AuthStore from 'lib/oauth-store';
 import config from 'config';
-import Main from 'components/main';
-import FormTextInput from 'components/forms/form-text-input';
-import FormPasswordInput from 'components/forms/form-password-input';
-import FormFieldset from 'components/forms/form-fieldset';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
-import Notice from 'components/notice';
-import AuthStore from 'lib/oauth-store';
-import { login } from 'lib/oauth-store/actions';
-import WordPressLogo from 'components/wordpress-logo';
-import AuthCodeButton from './auth-code-button';
-import SelfHostedInstructions from './self-hosted-instructions';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormPasswordInput from 'components/forms/form-password-input';
+import FormTextInput from 'components/forms/form-text-input';
 import LostPassword from './lost-password';
+import Main from 'components/main';
+import Notice from 'components/notice';
+import SelfHostedInstructions from './self-hosted-instructions';
+import WordPressLogo from 'components/wordpress-logo';
+import { login } from 'lib/oauth-store/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 class Auth extends React.Component {

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -28,14 +28,12 @@ import { login } from 'lib/oauth-store/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 export class Auth extends Component {
-	state = Object.assign(
-		{
-			login: '',
-			password: '',
-			auth_code: '',
-		},
-		AuthStore.get()
-	);
+	state = {
+		login: '',
+		password: '',
+		auth_code: '',
+		...AuthStore.get(),
+	};
 
 	componentDidMount() {
 		AuthStore.on( 'change', this.refreshData );

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -21,7 +21,6 @@ import FormButtonsBar from 'components/forms/form-buttons-bar';
 import Notice from 'components/notice';
 import AuthStore from 'lib/oauth-store';
 import * as AuthActions from 'lib/oauth-store/actions';
-import eventRecorder from 'me/event-recorder';
 import WordPressLogo from 'components/wordpress-logo';
 import AuthCodeButton from './auth-code-button';
 import SelfHostedInstructions from './self-hosted-instructions';
@@ -30,7 +29,6 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 
 export const Login = createReactClass( {
 	displayName: 'Auth',
-	mixins: [ eventRecorder ],
 
 	componentDidMount: function() {
 		AuthStore.on( 'change', this.refreshData );

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -27,7 +27,7 @@ import WordPressLogo from 'components/wordpress-logo';
 import { login } from 'lib/oauth-store/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-class Auth extends React.Component {
+export class Auth extends React.Component {
 	state = Object.assign(
 		{
 			login: '',

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
@@ -27,62 +26,64 @@ import SelfHostedInstructions from './self-hosted-instructions';
 import LostPassword from './lost-password';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-export const Login = createReactClass( {
-	displayName: 'Auth',
+class Auth extends React.Component {
+	state = Object.assign(
+		{
+			login: '',
+			password: '',
+			auth_code: '',
+		},
+		AuthStore.get()
+	);
 
-	componentDidMount: function() {
+	componentDidMount() {
 		AuthStore.on( 'change', this.refreshData );
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		AuthStore.off( 'change', this.refreshData );
-	},
+	}
 
-	getClickHandler( action ) {
-		return () => this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
-	},
+	getClickHandler = action => () => this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
 
-	getFocusHandler( action ) {
-		return () => this.props.recordGoogleEvent( 'Me', 'Focused on ' + action );
-	},
+	getFocusHandler = action => () => this.props.recordGoogleEvent( 'Me', 'Focused on ' + action );
 
-	refreshData: function() {
+	refreshData = () => {
 		this.setState( AuthStore.get() );
-	},
+	};
 
-	focusInput( input ) {
+	focusInput = input => {
 		if ( this.state.requires2fa && this.state.inProgress === false ) {
 			input.focus();
 		}
-	},
+	};
 
-	getInitialState: function() {
-		return Object.assign(
-			{
-				login: '',
-				password: '',
-				auth_code: '',
-			},
-			AuthStore.get()
-		);
-	},
-
-	submitForm: function( event ) {
+	submitForm = event => {
 		event.preventDefault();
 		event.stopPropagation();
 
 		AuthActions.login( this.state.login, this.state.password, this.state.auth_code );
-	},
+	};
 
-	hasLoginDetails: function() {
+	toggleSelfHostedInstructions = () => {
+		const isShowing = ! this.state.showInstructions;
+		this.setState( { showInstructions: isShowing } );
+	};
+
+	handleChange = e => {
+		const { name, value } = e.currentTarget;
+		this.setState( { [ name ]: value } );
+	};
+
+	hasLoginDetails() {
 		if ( this.state.login === '' || this.state.password === '' ) {
 			return false;
 		}
 
 		return true;
-	},
+	}
 
-	canSubmitForm: function() {
+	canSubmitForm() {
 		// No submission until the ajax has finished
 		if ( this.state.inProgress ) {
 			return false;
@@ -95,14 +96,9 @@ export const Login = createReactClass( {
 
 		// Don't allow submission until username+password is entered
 		return this.hasLoginDetails();
-	},
+	}
 
-	toggleSelfHostedInstructions: function() {
-		const isShowing = ! this.state.showInstructions;
-		this.setState( { showInstructions: isShowing } );
-	},
-
-	render: function() {
+	render() {
 		const { translate } = this.props;
 		const { requires2fa, inProgress, errorMessage, errorLevel, showInstructions } = this.state;
 
@@ -188,14 +184,9 @@ export const Login = createReactClass( {
 				</div>
 			</Main>
 		);
-	},
-
-	handleChange( e ) {
-		const { name, value } = e.currentTarget;
-		this.setState( { [ name ]: value } );
-	},
-} );
+	}
+}
 
 export default connect( null, {
 	recordGoogleEvent,
-} )( localize( Login ) );
+} )( localize( Auth ) );

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import createReactClass from 'create-react-class';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -25,6 +26,7 @@ import WordPressLogo from 'components/wordpress-logo';
 import AuthCodeButton from './auth-code-button';
 import SelfHostedInstructions from './self-hosted-instructions';
 import LostPassword from './lost-password';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 export const Login = createReactClass( {
 	displayName: 'Auth',
@@ -36,6 +38,14 @@ export const Login = createReactClass( {
 
 	componentWillUnmount: function() {
 		AuthStore.off( 'change', this.refreshData );
+	},
+
+	getClickHandler( action ) {
+		return () => this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
+	},
+
+	getFocusHandler( action ) {
+		return () => this.props.recordGoogleEvent( 'Me', 'Focused on ' + action );
 	},
 
 	refreshData: function() {
@@ -110,7 +120,7 @@ export const Login = createReactClass( {
 									name="login"
 									disabled={ requires2fa || inProgress }
 									placeholder={ translate( 'Email address or username' ) }
-									onFocus={ this.recordFocusEvent( 'Username or email address' ) }
+									onFocus={ this.getFocusHandler( 'Username or email address' ) }
 									value={ this.state.login }
 									onChange={ this.handleChange }
 								/>
@@ -121,7 +131,7 @@ export const Login = createReactClass( {
 									name="password"
 									disabled={ requires2fa || inProgress }
 									placeholder={ translate( 'Password' ) }
-									onFocus={ this.recordFocusEvent( 'Password' ) }
+									onFocus={ this.getFocusHandler( 'Password' ) }
 									hideToggle={ requires2fa }
 									submitting={ inProgress }
 									value={ this.state.password }
@@ -136,7 +146,7 @@ export const Login = createReactClass( {
 										ref={ this.focusInput }
 										disabled={ inProgress }
 										placeholder={ translate( 'Verification code' ) }
-										onFocus={ this.recordFocusEvent( 'Verification code' ) }
+										onFocus={ this.getFocusHandler( 'Verification code' ) }
 										value={ this.state.auth_code }
 										onChange={ this.handleChange }
 									/>
@@ -146,7 +156,7 @@ export const Login = createReactClass( {
 						<FormButtonsBar>
 							<FormButton
 								disabled={ ! this.canSubmitForm() }
-								onClick={ this.recordClickEvent( 'Sign in' ) }
+								onClick={ this.getClickHandler( 'Sign in' ) }
 							>
 								{ requires2fa ? translate( 'Verify' ) : translate( 'Sign in' ) }
 							</FormButton>
@@ -188,4 +198,6 @@ export const Login = createReactClass( {
 	},
 } );
 
-export default localize( Login );
+export default connect( null, {
+	recordGoogleEvent,
+} )( localize( Login ) );

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -27,7 +27,7 @@ import WordPressLogo from 'components/wordpress-logo';
 import { login } from 'lib/oauth-store/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-export class Auth extends React.Component {
+export class Auth extends Component {
 	state = Object.assign(
 		{
 			login: '',

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -19,7 +19,7 @@ import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import Notice from 'components/notice';
 import AuthStore from 'lib/oauth-store';
-import * as AuthActions from 'lib/oauth-store/actions';
+import { login } from 'lib/oauth-store/actions';
 import WordPressLogo from 'components/wordpress-logo';
 import AuthCodeButton from './auth-code-button';
 import SelfHostedInstructions from './self-hosted-instructions';
@@ -62,7 +62,7 @@ class Auth extends React.Component {
 		event.preventDefault();
 		event.stopPropagation();
 
-		AuthActions.login( this.state.login, this.state.password, this.state.auth_code );
+		login( this.state.login, this.state.password, this.state.auth_code );
 	};
 
 	toggleSelfHostedInstructions = () => {

--- a/client/auth/test/login.jsx
+++ b/client/auth/test/login.jsx
@@ -15,7 +15,7 @@ import { identity, noop } from 'lodash';
  * Internal dependencies
  */
 import { login as loginStub } from 'lib/oauth-store/actions';
-import { Login } from '../login.jsx';
+import { Auth } from '../login';
 import FormButton from 'components/forms/form-button';
 
 jest.mock( 'lib/oauth-store/actions', () => ( {
@@ -28,7 +28,7 @@ jest.mock( 'lib/analytics', () => ( {
 } ) );
 
 describe( 'LoginTest', () => {
-	const page = shallow( <Login translate={ identity } /> );
+	const page = shallow( <Auth translate={ identity } /> );
 
 	test( 'OTP is not present on first render', done => {
 		page.setState( { requires2fa: false }, function() {


### PR DESCRIPTION
This PR refactors `Auth` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove all mixins, specifically `eventRecorder`.
* Convert from `createReactClass` to a `React.Component`.
* Sort some imports 🔤 .
* Sort some methods.
* Use concrete imports instead of `import *`.

This PR should not introduce any visual or behavioral changes.

Part of #20053.

To test:
1. Checkout this branch
1. Run calypso with `oauth` enabled: `ENABLE_FEATURES=oauth npm start`
1. Log out (or open a new session in incognito mode)
1. Go to http://calypso.localhost:3000/oauth-login
1. Make sure your `ga` debug is enabled: `localStorage.debug = 'calypso:analytics:ga,calypso:analytics:utils'`
1. Verify focus events are recorded properly when:
6.1. Focusing the username field
6.2. Focusing the password field
1. Verify click event is recorded properly when inputting dummy credentials and clicking the submit button.
1. Verify clicking the `Add self-hosted site` link reveals the instructions.
1. Verify clicking the close button in the instructions box works as expected.
1. Test again steps 3-9 while logged in.

Note: you might want to disregard failing network requests, those are expected in the development environment.