### PR TITLE
Build: Move COMMIT_SHA to index template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,9 +54,11 @@ RUN        touch node_modules
 #
 # This contains built environments of Calypso. It will
 # change any time any of the Calypso source-code changes.
-ARG        commit_sha=(unknown)
+ARG        commit_sha="(unknown)"
+ENV        COMMIT_SHA $commit_sha
+
 RUN        true \
-           && CALYPSO_ENV=production COMMIT_SHA=$commit_sha npm run build \
+           && CALYPSO_ENV=production npm run build \
            && find . -not -path './node_modules/*' -print0 | xargs -0 chown nobody \
            && true
 

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -173,7 +173,9 @@ function getDefaultContext( request ) {
 		config.isEnabled( 'try/single-cdn' ) && !! request.query.enableSingleCDN;
 
 	const context = Object.assign( {}, request.context, {
-		commitSha: process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)',
+		commitSha: process.env.hasOwnProperty( 'COMMIT_SHA' )
+			? process.env.COMMIT_SHA
+			: JSON.stringify( '(unknown)' ),
 		compileDebug: process.env.NODE_ENV === 'development',
 		urls: generateStaticUrls(),
 		user: false,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -173,6 +173,7 @@ function getDefaultContext( request ) {
 		config.isEnabled( 'try/single-cdn' ) && !! request.query.enableSingleCDN;
 
 	const context = Object.assign( {}, request.context, {
+		commitSha: process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)',
 		compileDebug: process.env.NODE_ENV === 'development',
 		urls: generateStaticUrls(),
 		user: false,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -173,9 +173,7 @@ function getDefaultContext( request ) {
 		config.isEnabled( 'try/single-cdn' ) && !! request.query.enableSingleCDN;
 
 	const context = Object.assign( {}, request.context, {
-		commitSha: JSON.stringify(
-			process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)'
-		),
+		commitSha: process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)',
 		compileDebug: process.env.NODE_ENV === 'development',
 		urls: generateStaticUrls(),
 		user: false,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -173,9 +173,9 @@ function getDefaultContext( request ) {
 		config.isEnabled( 'try/single-cdn' ) && !! request.query.enableSingleCDN;
 
 	const context = Object.assign( {}, request.context, {
-		commitSha: process.env.hasOwnProperty( 'COMMIT_SHA' )
-			? process.env.COMMIT_SHA
-			: JSON.stringify( '(unknown)' ),
+		commitSha: JSON.stringify(
+			process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)'
+		),
 		compileDebug: process.env.NODE_ENV === 'development',
 		urls: generateStaticUrls(),
 		user: false,

--- a/server/pages/index.pug
+++ b/server/pages/index.pug
@@ -226,6 +226,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				}
 			})();
 
+		script(type='text/javascript')!='COMMIT_SHA = ' + commitSha
 		if user
 			script(type='text/javascript')!='var currentUser = ' + sanitize.jsonStringifyForHtml( user )
 		if app

--- a/server/pages/index.pug
+++ b/server/pages/index.pug
@@ -226,7 +226,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				}
 			})();
 
-		script(type='text/javascript')!='COMMIT_SHA = ' + commitSha
+		script(type='text/javascript')!='COMMIT_SHA = ' + sanitize.jsonStringifyForHtml( commitSha )
 		if user
 			script(type='text/javascript')!='var currentUser = ' + sanitize.jsonStringifyForHtml( user )
 		if app

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,6 @@ const isDevelopment = bundleEnv === 'development';
 const shouldMinify = process.env.hasOwnProperty( 'MINIFY_JS' )
 	? process.env.MINIFY_JS === 'true'
 	: ! isDevelopment;
-const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
 
 // load in the babel config from babelrc and disable commonjs transform
 // this enables static analysis from webpack including treeshaking
@@ -176,7 +175,6 @@ const webpackConfig = {
 		new webpack.DefinePlugin( {
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
 			PROJECT_NAME: JSON.stringify( config( 'project' ) ),
-			COMMIT_SHA: JSON.stringify( commitSha ),
 		} ),
 		new webpack.IgnorePlugin( /^props$/ ),
 		new CopyWebpackPlugin( [


### PR DESCRIPTION
The previous implementation, while working, caused the bundle hashes to
be updated every time even when there were no changes. This was due to
the webpack define plugin setting the global COMMIT_SHA in the bundles.

This approach instead defines COMMIT_SHA in an inline script tag in the
index.pug template. This will not affect the builds and their hashes,
but will still make the global available for error logging purposes.

To Test (copied from a previous PR):

Since this code is only designed to run in non-development environments and only when an uncaught exception is thrown, you'll have to simulate these to test in a development environment. Just make sure to not commit these changes and undo them when you're done.

Pre-step 1. Add a place in the code that throws an error. I added an "onClick" handler to a button in the devdocs `client/components/button/docs`, and this what I changed on line 94: `<Button primary scary onClick={ () => { throw new Error( 'Test Error for sha' ) } }>`

Now you can test:

1. Start calypso, enabling errors in development: `ENABLE_FEATURES=catch-js-errors COMMIT_SHA=12345 npm start`
2. Go to `http://calypso.localhost:3000/devdocs`
3. Open your browser dev console, and show both the console and the network tabs.
4. Go to "UI Components", find your modified button and click it. (or whatever you did for testing)
5. You should see your error trace in the console as normal.
6. In the network requests, you should see one that is `js-error?http_envelope=1`, click on it.
7. In the Form Data of the request, you should see the `error:` field. It should contain something like `"commit":"12345"`.
8. Undo your Pre-step changes you did above so you don't accidentally commit them somewhere! 
  