### PR TITLE
Fix: Fixes issue on resize handler in stats chart

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -70,7 +70,10 @@ class Chart extends React.Component {
 		const width = isTouch && clientWidth <= 0 ? 350 : clientWidth; // mobile safari bug with zero width
 		const maxBars = Math.floor( width / minWidth );
 
-		this.setState( { maxBars, width }, () => this.updateData( props ) );
+		this.setState( { maxBars, width }, () =>
+			// this may get called either directly or as a resize event callback
+			this.updateData( props instanceof Event ? this.props : props )
+		);
 	};
 
 	getYAxisMax = values => {


### PR DESCRIPTION
Introduced in #21272

On resize the `updateData()` method was being called with the actual
event instead of the props. In this fix we conditionally send the given
props or if it's an event handler, then the `this.props` at call time.