### PR TITLE
Activity Log: Shuffle data gathering into <ActivityLogItem />

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -157,7 +157,6 @@ class ActivityLogDay extends Component {
 
 	render() {
 		const {
-			applySiteOffset,
 			disableRestore,
 			disableBackup,
 			isRewindActive,
@@ -189,11 +188,10 @@ class ActivityLogDay extends Component {
 		const LogItem = ( { log, hasBreak } ) => (
 			<ActivityLogItem
 				className={ hasBreak ? 'is-before-dialog' : '' }
-				applySiteOffset={ applySiteOffset }
+				activityId={ log.activityId }
 				disableRestore={ disableRestore }
 				disableBackup={ disableBackup }
 				hideRestore={ ! isRewindActive }
-				log={ log }
 				requestDialog={ requestDialog }
 				siteId={ siteId }
 			/>

--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -18,7 +18,7 @@ import ActivityLogItem from '../activity-log-item';
 import FoldableCard from 'components/foldable-card';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getActivityLog, getRewindEvents } from 'state/selectors';
-import { ms, rewriteStream } from 'state/activity-log/log/is-discarded';
+import { ms, makeIsDiscarded } from 'state/activity-log/log/is-discarded';
 
 /**
  * Module constants
@@ -157,16 +157,18 @@ class ActivityLogDay extends Component {
 
 	render() {
 		const {
-			disableRestore,
+			backupConfirmDialog,
 			disableBackup,
+			disableRestore,
+			isDiscardedPerspective,
 			isRewindActive,
 			isToday,
 			logs,
-			requestedRestoreId,
-			requestedBackupId,
 			requestDialog,
+			requestedBackupId,
+			requestedRestoreId,
 			restoreConfirmDialog,
-			backupConfirmDialog,
+			rewindEvents,
 			siteId,
 			tsEndOfSiteDay,
 		} = this.props;
@@ -185,6 +187,8 @@ class ActivityLogDay extends Component {
 			rewindId: requestedRestoreId,
 		} );
 
+		const isDiscarded = makeIsDiscarded( rewindEvents, isDiscardedPerspective );
+
 		const LogItem = ( { log, hasBreak } ) => (
 			<ActivityLogItem
 				className={ hasBreak ? 'is-before-dialog' : '' }
@@ -192,6 +196,7 @@ class ActivityLogDay extends Component {
 				disableRestore={ disableRestore }
 				disableBackup={ disableBackup }
 				hideRestore={ ! isRewindActive }
+				isDiscarded={ isDiscarded( log.activityTs ) }
 				requestDialog={ requestDialog }
 				siteId={ siteId }
 			/>
@@ -239,7 +244,9 @@ export default localize(
 				: undefined;
 
 			return {
-				logs: rewriteStream( logs, rewindEvents, isDiscardedPerspective ),
+				logs,
+				rewindEvents,
+				isDiscardedPerspective,
 				requestedRestoreId,
 			};
 		},

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -85,11 +85,11 @@ class ActivityLogItem extends Component {
 	}
 
 	render() {
-		const { activity, className, gmtOffset, moment, timezone } = this.props;
-		const { activityIcon, activityIsDiscarded, activityStatus, activityTs } = activity;
+		const { activity, className, gmtOffset, isDiscarded, moment, timezone } = this.props;
+		const { activityIcon, activityStatus, activityTs } = activity;
 
 		const classes = classNames( 'activity-log-item', className, {
-			'is-discarded': activityIsDiscarded,
+			'is-discarded': isDiscarded,
 		} );
 
 		return (

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -26,7 +26,6 @@ class ActivityLogItem extends Component {
 	handleClickBackup = () => this.props.requestDialog( this.props.activityId, 'item', 'backup' );
 
 	renderHeader() {
-		const { activity } = this.props;
 		const {
 			activityDescription,
 			activityTitle,
@@ -34,30 +33,17 @@ class ActivityLogItem extends Component {
 			actorName,
 			actorRole,
 			actorType,
-		} = activity;
+		} = this.props.activity;
 
 		return (
 			<div className="activity-log-item__card-header">
-				<ActivityActor
-					{ ...{
-						actorActivityUrl,
-						actorName,
-						actorRole,
-						actorType,
-					} }
-				/>
-				{ activityDescription && (
-					<div className="activity-log-item__description">
-						<div className="activity-log-item__description-content">
-							{ activityDescription.map( ( part, key ) => (
-								<FormattedBlock key={ key } content={ part } />
-							) ) }
-						</div>
-						{ activityTitle && (
-							<div className="activity-log-item__description-summary">{ activityTitle }</div>
-						) }
+				<ActivityActor { ...{ actorActivityUrl, actorName, actorRole, actorType } } />
+				<div className="activity-log-item__description">
+					<div className="activity-log-item__description-content">
+						<FormattedBlock content={ activityDescription[ 0 ] } />
 					</div>
-				) }
+					<div className="activity-log-item__description-summary">{ activityTitle }</div>
+				</div>
 			</div>
 		);
 	}

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -3,9 +3,8 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { pick } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -17,59 +16,35 @@ import SplitButton from 'components/split-button';
 import FoldableCard from 'components/foldable-card';
 import FormattedBlock from 'components/notes-formatted-block';
 import PopoverMenuItem from 'components/popover/menu-item';
+import { getActivityLog, getSiteGmtOffset, getSiteTimezoneValue } from 'state/selectors';
+
+import { adjustMoment } from '../activity-log/utils';
 
 class ActivityLogItem extends Component {
-	static propTypes = {
-		applySiteOffset: PropTypes.func.isRequired,
-		disableRestore: PropTypes.bool.isRequired,
-		disableBackup: PropTypes.bool.isRequired,
-		hideRestore: PropTypes.bool,
-		requestDialog: PropTypes.func.isRequired,
-		siteId: PropTypes.number.isRequired,
+	handleClickRestore = () => this.props.requestDialog( this.props.activityId, 'item', 'restore' );
 
-		log: PropTypes.shape( {
-			// Base
-			activityDate: PropTypes.string.isRequired,
-			activityGroup: PropTypes.string.isRequired,
-			activityIcon: PropTypes.string.isRequired,
-			activityId: PropTypes.string.isRequired,
-			activityName: PropTypes.string.isRequired,
-			activityStatus: PropTypes.string,
-			activityTitle: PropTypes.string,
-			activityTs: PropTypes.number.isRequired,
-
-			// Actor
-			actorAvatarUrl: PropTypes.string.isRequired,
-			actorName: PropTypes.string.isRequired,
-			actorRemoteId: PropTypes.number.isRequired,
-			actorRole: PropTypes.string.isRequired,
-			actorType: PropTypes.string.isRequired,
-			actorWpcomId: PropTypes.number.isRequired,
-		} ).isRequired,
-
-		// localize
-		moment: PropTypes.func.isRequired,
-		translate: PropTypes.func.isRequired,
-	};
-
-	static defaultProps = {
-		disableRestore: false,
-		disableBackup: false,
-	};
-
-	handleClickRestore = () =>
-		this.props.requestDialog( this.props.log.activityId, 'item', 'restore' );
-
-	handleClickBackup = () => this.props.requestDialog( this.props.log.activityId, 'item', 'backup' );
+	handleClickBackup = () => this.props.requestDialog( this.props.activityId, 'item', 'backup' );
 
 	renderHeader() {
-		const { log } = this.props;
-		const { activityDescription, activityTitle } = log;
+		const { activity } = this.props;
+		const {
+			activityDescription,
+			activityTitle,
+			actorActivityUrl,
+			actorName,
+			actorRole,
+			actorType,
+		} = activity;
 
 		return (
 			<div className="activity-log-item__card-header">
 				<ActivityActor
-					{ ...pick( log, [ 'actorAvatarUrl', 'actorName', 'actorRole', 'actorType' ] ) }
+					{ ...{
+						actorActivityUrl,
+						actorName,
+						actorRole,
+						actorType,
+					} }
 				/>
 				{ activityDescription && (
 					<div className="activity-log-item__description">
@@ -93,7 +68,7 @@ class ActivityLogItem extends Component {
 			disableBackup,
 			hideRestore,
 			translate,
-			log: { activityIsRewindable },
+			activity: { activityIsRewindable },
 		} = this.props;
 
 		if ( hideRestore || ! activityIsRewindable ) {
@@ -124,8 +99,8 @@ class ActivityLogItem extends Component {
 	}
 
 	render() {
-		const { applySiteOffset, className, log, moment } = this.props;
-		const { activityIcon, activityIsDiscarded, activityStatus } = log;
+		const { activity, className, gmtOffset, moment, timezone } = this.props;
+		const { activityIcon, activityIsDiscarded, activityStatus, activityTs } = activity;
 
 		const classes = classNames( 'activity-log-item', className, {
 			'is-discarded': activityIsDiscarded,
@@ -135,7 +110,11 @@ class ActivityLogItem extends Component {
 			<div className={ classes }>
 				<div className="activity-log-item__type">
 					<div className="activity-log-item__time">
-						{ applySiteOffset( moment.utc( log.activityTs ) ).format( 'LT' ) }
+						{ adjustMoment( {
+							gmtOffset,
+							moment: moment.utc( activityTs ),
+							timezone,
+						} ).format( 'LT' ) }
 					</div>
 					<ActivityIcon activityIcon={ activityIcon } activityStatus={ activityStatus } />
 				</div>
@@ -150,4 +129,16 @@ class ActivityLogItem extends Component {
 	}
 }
 
-export default localize( ActivityLogItem );
+const mapStateToProps = ( state, { activityId, siteId } ) => {
+	const activity = getActivityLog( state, siteId, activityId );
+	const gmtOffset = getSiteGmtOffset( state, siteId );
+	const timezone = getSiteTimezoneValue( state, siteId );
+
+	return {
+		activity,
+		gmtOffset,
+		timezone,
+	};
+};
+
+export default connect( mapStateToProps )( localize( ActivityLogItem ) );

--- a/client/state/selectors/get-rewind-events.js
+++ b/client/state/selectors/get-rewind-events.js
@@ -9,6 +9,8 @@ import { get, values } from 'lodash';
  */
 import { getRewinds } from 'state/activity-log/log/is-discarded';
 
+const cache = new WeakMap();
+
 /**
  * Returns all events which represent rewind operations
  * from the activity log for a given site
@@ -24,7 +26,15 @@ export const getRewindEvents = ( state, siteId ) => {
 		return null;
 	}
 
-	return getRewinds( values( siteEvents ) );
+	if ( cache.has( siteEvents ) ) {
+		return cache.get( siteEvents );
+	}
+
+	const rewinds = getRewinds( values( siteEvents ) );
+
+	cache.set( siteEvents, rewinds );
+
+	return rewinds;
 };
 
 export default getRewindEvents;


### PR DESCRIPTION
Previously we have been passing around complex data objects via React
props and also recreating individual day elements from the top-down.
This causes render issues and needless re-renders.

In this patch we're starting to move data-gathering from React parents
into the `<ActivityLogItem />` so we can break these chains and end up
with a more efficient and error-free render.
 
This is a part of a bigger project to prevent recreating all of the activity
log items on every render, which is causing visual glitches and needless
React re-renders.

```
Delta:
chunk                                   stat_size           parsed_size           gzip_size
async-load-my-sites-stats-activity-log     +390 B  (+0.1%)       -253 B  (-0.2%)      +34 B  (+0.1%)
build                                        +0 B                  +0 B                +5 B  (+0.0%)
manifest                                     +0 B                  +0 B                +2 B  (+0.1%)
```