### PR TITLE
Remove social links task from checklist

### DIFF
--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -122,7 +122,7 @@ const sequence = [
 	'site_icon_set',
 	'blogdescription_set',
 	'avatar_uploaded',
-	'social_links_set',
+	// 'social_links_set',
 	'about_page_updated',
 	'contact_page_updated',
 	'post_published',


### PR DESCRIPTION
The tour for social menus is incomplete so we would like to remove this task from the checklist and return to it later.

# Testing

- with a new or existing site, visit `/checklist`
- you should not see any mention of the social links task