### PR TITLE
Prevent query args _timestamp to be serialized

### DIFF
--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -19,7 +19,7 @@ import RootChild from 'components/root-child';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import { getLastAction } from 'state/ui/action-log/selectors';
 import { getSectionName, isSectionLoading } from 'state/ui/selectors';
-import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
+import { getInitialQueryArguments } from 'state/selectors';
 import {
 	nextGuidedTourStep,
 	quitGuidedTour,

--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -81,21 +81,18 @@ const getToursSeen = createSelector(
 	getToursHistory
 );
 
-const getTourFromQuery = state => {
-	const initial = getInitialQueryArguments( state );
-	const current = getCurrentQueryArguments( state );
-	const tourProps = [ 'tour', '_timestamp' ];
-
-	return current && current.tour ? pick( current, tourProps ) : pick( initial, tourProps );
-};
-
 /*
- * Returns the name of the tour requested via the URL's query arguments, if the
- * tour exists. Returns `undefined` otherwise.
+ * Returns the name and timestamp of the tour requested via the URL's query
+ * arguments, if the tour exists. Returns `undefined` otherwise.
  */
-const getTourNameFromQuery = createSelector(
+const getTourFromQuery = createSelector(
 	state => {
-		const { tour, _timestamp } = getTourFromQuery( state );
+		const initial = getInitialQueryArguments( state );
+		const current = getCurrentQueryArguments( state );
+		const tourProps = [ 'tour', '_timestamp' ];
+		const { tour, _timestamp } =
+			current && current.tour ? pick( current, tourProps ) : pick( initial, tourProps );
+
 		if ( tour && find( relevantFeatures, { tour } ) ) {
 			return { tour, _timestamp };
 		}
@@ -120,7 +117,7 @@ const hasJustSeenTour = createSelector(
  * "just" been seen (i.e., in the current Calypso session).
  */
 const findRequestedTour = state => {
-	const requestedTour = getTourNameFromQuery( state );
+	const requestedTour = getTourFromQuery( state );
 	if ( requestedTour && ! hasJustSeenTour( state, requestedTour ) ) {
 		return requestedTour.tour;
 	}

--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -86,7 +86,7 @@ const reallyGetTourFromQuery = state => {
 	const current = getCurrentQueryArguments( state );
 	const tourProps = [ 'tour', '_timestamp' ];
 
-	return current.tour ? pick( current, tourProps ) : pick( initial, tourProps );
+	return current && current.tour ? pick( current, tourProps ) : pick( initial, tourProps );
 };
 
 /*

--- a/client/state/ui/guided-tours/selectors/index.js
+++ b/client/state/ui/guided-tours/selectors/index.js
@@ -81,7 +81,7 @@ const getToursSeen = createSelector(
 	getToursHistory
 );
 
-const reallyGetTourFromQuery = state => {
+const getTourFromQuery = state => {
 	const initial = getInitialQueryArguments( state );
 	const current = getCurrentQueryArguments( state );
 	const tourProps = [ 'tour', '_timestamp' ];
@@ -93,9 +93,9 @@ const reallyGetTourFromQuery = state => {
  * Returns the name of the tour requested via the URL's query arguments, if the
  * tour exists. Returns `undefined` otherwise.
  */
-const getTourFromQuery = createSelector(
+const getTourNameFromQuery = createSelector(
 	state => {
-		const { tour, _timestamp } = reallyGetTourFromQuery( state );
+		const { tour, _timestamp } = getTourFromQuery( state );
 		if ( tour && find( relevantFeatures, { tour } ) ) {
 			return { tour, _timestamp };
 		}
@@ -120,7 +120,7 @@ const hasJustSeenTour = createSelector(
  * "just" been seen (i.e., in the current Calypso session).
  */
 const findRequestedTour = state => {
-	const requestedTour = getTourFromQuery( state );
+	const requestedTour = getTourNameFromQuery( state );
 	if ( requestedTour && ! hasJustSeenTour( state, requestedTour ) ) {
 		return requestedTour.tour;
 	}

--- a/client/state/ui/route/query/reducer.js
+++ b/client/state/ui/route/query/reducer.js
@@ -10,7 +10,7 @@ import { isEqual, omit } from 'lodash';
  * Internal dependencies
  */
 import { combineReducers, createReducer } from 'state/utils';
-import { ROUTE_SET } from 'state/action-types';
+import { ROUTE_SET, SERIALIZE, DESERIALIZE } from 'state/action-types';
 
 const timestamped = query => ( {
 	...query,
@@ -23,6 +23,8 @@ const initial = createReducer(
 	false,
 	{
 		[ ROUTE_SET ]: ( state, { query } ) => ( state === false ? timestamped( query ) : state ),
+		[ SERIALIZE ]: state => omit( state, '_timestamp' ),
+		[ DESERIALIZE ]: state => omit( state, '_timestamp' ),
 	},
 	{ type: [ 'boolean', 'object' ] }
 );
@@ -32,6 +34,8 @@ const current = createReducer(
 	{
 		[ ROUTE_SET ]: ( state, { query } ) =>
 			! isEqualQuery( state, query ) ? timestamped( query ) : state,
+		[ SERIALIZE ]: state => omit( state, '_timestamp' ),
+		[ DESERIALIZE ]: state => omit( state, '_timestamp' ),
 	},
 	{ type: 'object' }
 );

--- a/client/state/ui/route/query/reducer.js
+++ b/client/state/ui/route/query/reducer.js
@@ -10,7 +10,7 @@ import { isEqual, omit } from 'lodash';
  * Internal dependencies
  */
 import { combineReducers, createReducer } from 'state/utils';
-import { ROUTE_SET, SERIALIZE, DESERIALIZE } from 'state/action-types';
+import { ROUTE_SET } from 'state/action-types';
 
 const timestamped = query => ( {
 	...query,
@@ -23,8 +23,6 @@ const initial = createReducer(
 	false,
 	{
 		[ ROUTE_SET ]: ( state, { query } ) => ( state === false ? timestamped( query ) : state ),
-		[ SERIALIZE ]: state => omit( state, '_timestamp' ),
-		[ DESERIALIZE ]: state => omit( state, '_timestamp' ),
 	},
 	{ type: [ 'boolean', 'object' ] }
 );
@@ -34,8 +32,6 @@ const current = createReducer(
 	{
 		[ ROUTE_SET ]: ( state, { query } ) =>
 			! isEqualQuery( state, query ) ? timestamped( query ) : state,
-		[ SERIALIZE ]: state => omit( state, '_timestamp' ),
-		[ DESERIALIZE ]: state => omit( state, '_timestamp' ),
 	},
 	{ type: 'object' }
 );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/20553

This patch prevents the `_timestamp` property to be serialized in our query parameters. It seems to be necessary that timestamp is never persisted locally for guided tours to work properly.

### Testing Instructions
- Boot the branch locally or use [calypso.live](https://calypso.live/?branch=update/fix-guided-tours)
- Go to My Sites
- Add the `?tour=main` parameter on the url and reload
- Ensure that you are able to enter the main guided tour
- Ensure that it works and that you are able to go through the whole flow

### Reviews
- [x] Code
- [x] Product