### PR TITLE
Only change route for incomplete checklist tasks

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -36,19 +36,22 @@ class ChecklistShow extends PureComponent {
 		const url = urlForTask( id, siteSlug );
 
 		if ( siteChecklist && siteChecklist.tasks && ( url || tour ) ) {
-			const status = siteChecklist.tasks[ id ] ? 'complete' : 'incomplete';
+			if ( siteChecklist.tasks[ id ] ) {
+				if ( url ) {
+					page( url );
+				}
+			} else {
+				track( 'calypso_checklist_task_start', {
+					checklist_name: 'new_blog',
+					step_name: id,
+				} );
 
-			track( 'calypso_checklist_task_start', {
-				checklist_name: 'new_blog',
-				step_name: id,
-				status,
-			} );
-
-			if ( url ) {
-				page( url );
-			}
-			if ( tour ) {
-				requestTour( tour );
+				if ( url ) {
+					page( url );
+				}
+				if ( tour ) {
+					requestTour( tour );
+				}
 			}
 		}
 	};


### PR DESCRIPTION
We do not want to show guided tours for completed checklist tasks.

This change ensures that the route change occurs but guided tours are not launched for already completed tasks.

# Testing

- enable tracks debugging with `localStorage.setItem('debug', 'calypso:analytics:tracks');`
- for a new or existing site visit `/checklist/<site>`
- click 'Do It' for an incomplete task
- verify that a tracks event is fired, the route is changed and a guided tour starts
- mark the same task as completed
- verify that no tracks event is fired, the route is changed and a guided tour is not started



  