### PR TITLE
Decode email settings From Field entities.

### DIFF
--- a/client/extensions/woocommerce/state/sites/settings/email/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/reducer.js
@@ -11,6 +11,7 @@ import { filter, omit, isEmpty, setWith } from 'lodash';
  */
 import { createReducer } from 'state/utils';
 import { LOADING } from 'woocommerce/state/constants';
+import decodeEntitiesNode from 'lib/formatting/decode-entities/node';
 import {
 	WOOCOMMERCE_EMAIL_SETTINGS_REQUEST,
 	WOOCOMMERCE_EMAIL_SETTINGS_REQUEST_SUCCESS,
@@ -45,6 +46,10 @@ export default createReducer( null, {
 				Object
 			);
 		} );
+
+		options.email.woocommerce_email_from_name.value = decodeEntitiesNode(
+			options.email.woocommerce_email_from_name.value
+		);
 		return options;
 	},
 

--- a/client/extensions/woocommerce/state/sites/settings/email/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/reducer.js
@@ -11,7 +11,7 @@ import { filter, omit, isEmpty, setWith } from 'lodash';
  */
 import { createReducer } from 'state/utils';
 import { LOADING } from 'woocommerce/state/constants';
-import decodeEntitiesNode from 'lib/formatting/decode-entities/node';
+import { decodeEntities } from 'lib/formatting';
 import {
 	WOOCOMMERCE_EMAIL_SETTINGS_REQUEST,
 	WOOCOMMERCE_EMAIL_SETTINGS_REQUEST_SUCCESS,
@@ -47,7 +47,7 @@ export default createReducer( null, {
 			);
 		} );
 
-		options.email.woocommerce_email_from_name.value = decodeEntitiesNode(
+		options.email.woocommerce_email_from_name.value = decodeEntities(
 			options.email.woocommerce_email_from_name.value
 		);
 		return options;

--- a/client/extensions/woocommerce/state/sites/settings/email/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/reducer.js
@@ -4,7 +4,7 @@
  * @format
  */
 
-import { filter, omit, isEmpty, setWith } from 'lodash';
+import { filter, omit, isEmpty, setWith, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -47,9 +47,12 @@ export default createReducer( null, {
 			);
 		} );
 
-		options.email.woocommerce_email_from_name.value = decodeEntities(
-			options.email.woocommerce_email_from_name.value
-		);
+		// Decode: &, <, > entities.
+		const from_name = get( options, [ 'email', 'woocommerce_email_from_name', 'value' ], false );
+		if ( from_name ) {
+			options.email.woocommerce_email_from_name.value = decodeEntities( from_name );
+		}
+
 		return options;
 	},
 

--- a/client/extensions/woocommerce/state/sites/settings/email/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/test/reducer.js
@@ -136,6 +136,38 @@ describe( 'reducer', () => {
 		expect( newState[ siteId ].settings.email ).to.deep.equal( expectedResult );
 	} );
 
+	test( 'should decode entities in woocommerce_email_from_name', () => {
+		const siteId = 123;
+		const settings = [
+			{
+				id: 'woocommerce_email_from_name',
+				value: 'Tom&ampJerry',
+				group_id: 'email',
+				default: '',
+			},
+		];
+
+		const expectedResult = {
+			email: {
+				woocommerce_email_from_name: {
+					value: 'Tom&Jerry',
+					default: '',
+				},
+			},
+		};
+
+		const action = {
+			type: WOOCOMMERCE_EMAIL_SETTINGS_REQUEST_SUCCESS,
+			siteId,
+			data: settings,
+		};
+
+		const newState = reducer( {}, action );
+		expect( newState[ siteId ] ).to.exist;
+		expect( newState[ siteId ].settings ).to.exist;
+		expect( newState[ siteId ].settings.email ).to.deep.equal( expectedResult );
+	} );
+
 	test( 'should use default value from setting for settings with default and no value.', () => {
 		// test check if default is not overwritten by default from woocommerce_email_from_address if it exists.
 		const siteId = 123;


### PR DESCRIPTION
### Information
Decode &amp, &gt, &lt into `&`,  `>`, `<` in `From name` field in Email Settings.

### Testing
Go to Email Settings and in `From name` field use & > < elements. Save settings. Refresh.
The entities should be decoded correctly.