### PR TITLE
Framework: Create a separate build entry for logged out users

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,8 @@
 					"iOS >= 10",
 					"not ie <= 10"
 				]
-			}
+			},
+			"modules": false
 		} ],
 		"stage-2"
 	],

--- a/.babelrc
+++ b/.babelrc
@@ -8,8 +8,7 @@
 					"iOS >= 10",
 					"not ie <= 10"
 				]
-			},
-			"modules": false
+			}
 		} ],
 		"stage-2"
 	],

--- a/client/boot/loggedout-app.js
+++ b/client/boot/loggedout-app.js
@@ -23,7 +23,7 @@ import { default as loginRouteSetter } from 'login';
 import { createStore, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import { combineReducers } from 'state/utils';
-import { setupContextMiddleware } from './page-context-middleware';
+import { default as setupContextMiddleware } from './page-context-middleware';
 
 // Middlewares:
 import { default as wpcomApiMiddleware } from 'state/data-layer/wpcom-api-middleware';

--- a/client/boot/loggedout-app.js
+++ b/client/boot/loggedout-app.js
@@ -1,0 +1,53 @@
+/** @format */
+// Initialize polyfills before any dependencies are loaded
+import './polyfills';
+
+if ( process.env.NODE_ENV === 'development' ) {
+	require( 'lib/wrap-es6-functions' ).default();
+}
+
+/**
+ * External dependencies
+ */
+// import debugFactory from 'debug';
+// import { invoke } from 'lodash';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+// import { configureReduxStore, locales, setupMiddlewares, utils } from './common';
+// import createReduxStoreFromPersistedInitialState from 'state/initial-state';
+// import detectHistoryNavigation from 'lib/detect-history-navigation';
+// import userFactory from 'lib/user';
+import login from 'login';
+
+const debug = debugFactory( 'calypso' );
+
+const boot = currentUser => {
+	debug( "Starting Calypso. Let's do this." );
+
+	// const project = require( `./project/${ PROJECT_NAME }` );
+	// utils();
+	// invoke( project, 'utils' );
+	//createReduxStoreFromPersistedInitialState( reduxStore => {
+		// locales( currentUser, reduxStore );
+		// invoke( project, 'locales', currentUser, reduxStore );
+		// configureReduxStore( currentUser, reduxStore );
+		// invoke( project, 'configureReduxStore', currentUser, reduxStore );
+		// setupMiddlewares( currentUser, reduxStore );
+		// invoke( project, 'setupMiddlewares', currentUser, reduxStore );
+		// detectHistoryNavigation.start();
+		page.start( { decodeURLComponents: false } );
+	//} );
+};
+
+window.AppBoot = () => {
+	boot();
+	// const user = userFactory();
+	// if ( user.initialized ) {
+	// 	boot( user );
+	// } else {
+	// 	user.once( 'change', () => boot( user ) );
+	// }
+};

--- a/client/boot/page-context-middleware.js
+++ b/client/boot/page-context-middleware.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import page from 'page';
+import qs from 'querystring';
+import url from 'url';
+
+const debug = debugFactory( 'calypso' );
+
+const setupContextMiddleware = reduxStore => {
+	page( '*', ( context, next ) => {
+		// page.js url parsing is broken so we had to disable it with `decodeURLComponents: false`
+		const parsed = url.parse( context.canonicalPath, true );
+		context.prevPath = parsed.path === context.path ? false : parsed.path;
+		context.query = parsed.query;
+
+		context.hashstring = ( parsed.hash && parsed.hash.substring( 1 ) ) || '';
+		// set `context.hash` (we have to parse manually)
+		if ( context.hashstring ) {
+			try {
+				context.hash = qs.parse( context.hashstring );
+			} catch ( e ) {
+				debug( 'failed to query-string parse `location.hash`', e );
+				context.hash = {};
+			}
+		} else {
+			context.hash = {};
+		}
+
+		context.store = reduxStore;
+
+		// client version of the isomorphic method for redirecting to another page
+		context.redirect = ( httpCode, newUrl = null ) => {
+			if ( isNaN( httpCode ) && ! newUrl ) {
+				newUrl = httpCode;
+			}
+
+			return page.replace( newUrl, context.state, false, false );
+		};
+
+		// Break routing and do full load for logout link in /me
+		if ( context.pathname === '/wp-login.php' ) {
+			window.location.href = context.path;
+			return;
+		}
+
+		next();
+	} );
+};
+
+export default setupContextMiddleware;

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -12,33 +12,22 @@ import page from 'page';
 /**
  * Internal Dependencies
  */
-import Layout from 'layout';
-import LayoutLoggedOut from 'layout/logged-out';
-import nuxWelcome from 'layout/nux-welcome';
-import translatorInvitation from 'layout/community-translator/invitation-utils';
 import { makeLayoutMiddleware } from './shared.js';
 import { getCurrentUser } from 'state/current-user/selectors';
-import userFactory from 'lib/user';
+import LoggedInLayout from 'layout-wrapper/logged-in';
+import LoggedOutLayout from 'layout-wrapper/logged-out';
 
 /**
  * Re-export
  */
 export { setSection, setUpLocale } from './shared.js';
 
-const user = userFactory();
-
-export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } ) => (
-	<ReduxProvider store={ store }>
-		{ getCurrentUser( store.getState() ) ? (
-			<Layout
-				primary={ primary }
-				secondary={ secondary }
-				user={ user }
-				nuxWelcome={ nuxWelcome }
-				translatorInvitation={ translatorInvitation }
-			/>
+export const ReduxWrappedLayout = props => (
+	<ReduxProvider store={ props.store }>
+		{ getCurrentUser( props.store.getState() ) ? (
+			<LoggedInLayout { ...props } />
 		) : (
-			<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
+			<LoggedOutLayout { ...props } />
 		) }
 	</ReduxProvider>
 );

--- a/client/layout-wrapper/logged-in.jsx
+++ b/client/layout-wrapper/logged-in.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import Layout from 'layout';
+import nuxWelcome from 'layout/nux-welcome';
+import translatorInvitation from 'layout/community-translator/invitation-utils';
+import userFactory from 'lib/user';
+
+const user = userFactory();
+
+const LoggedInLayout = ( { primary, secondary } ) => <Layout
+		primary={ primary }
+		secondary={ secondary }
+		user={ user }
+		nuxWelcome={ nuxWelcome }
+		translatorInvitation={ translatorInvitation }
+	/>;
+
+export default LoggedInLayout;

--- a/client/layout-wrapper/logged-out.jsx
+++ b/client/layout-wrapper/logged-out.jsx
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import LayoutLoggedOut from 'layout/logged-out';
+
+const LoggedOutLayout = ( { primary, secondary, redirectUri } ) =>
+	<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />;
+
+export default LoggedOutLayout;

--- a/create-loggedout.sh
+++ b/create-loggedout.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-mkdir ./login-build
+mkdir -p ./login-build
 rm -rf ./login-build/*
 #rm -rf ./public/build.*.js
 #rm -rf ./public/vendor.*.js

--- a/create-loggedout.sh
+++ b/create-loggedout.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+mkdir ./login-build
+rm -rf ./login-build/*
+#rm -rf ./public/build.*
+#rm -rf ./public/vendor.*
+#rm -rf ./public/manifest.*
+
+echo Creating:
+./node_modules/.bin/webpack --config webpack.login.js --json | jq -r '.assets[] | .name'
+
+ls ./public/build.*
+ls ./public/vendor.*
+ls ./public/manifest.*
+
+
+cp ./login-build/build.* `ls ./public/build.*`
+cp ./login-build/vendor.* `ls ./public/vendor.*`
+cp ./login-build/manifest.* `ls ./public/manifest.*`

--- a/create-loggedout.sh
+++ b/create-loggedout.sh
@@ -13,6 +13,6 @@ ls ./public/vendor.*
 ls ./public/manifest.*
 
 
-cp ./login-build/build.* `ls ./public/build.*`
-cp ./login-build/vendor.* `ls ./public/vendor.*`
-cp ./login-build/manifest.* `ls ./public/manifest.*`
+cp ./login-build/build.* `ls ./public/build.*.js`
+cp ./login-build/vendor.* `ls ./public/vendor.*.js`
+cp ./login-build/manifest.* `ls ./public/manifest.*.js`

--- a/create-loggedout.sh
+++ b/create-loggedout.sh
@@ -1,17 +1,16 @@
 #!/bin/sh
 mkdir ./login-build
 rm -rf ./login-build/*
-#rm -rf ./public/build.*
-#rm -rf ./public/vendor.*
-#rm -rf ./public/manifest.*
+#rm -rf ./public/build.*.js
+#rm -rf ./public/vendor.*.js
+#rm -rf ./public/manifest.*.js
 
-echo Creating:
+echo Creating loggedout build
 ./node_modules/.bin/webpack --config webpack.login.js --json | jq -r '.assets[] | .name'
 
-ls ./public/build.*
-ls ./public/vendor.*
-ls ./public/manifest.*
-
+ls ./public/build.*.js
+ls ./public/vendor.*.js
+ls ./public/manifest.*.js
 
 cp ./login-build/build.* `ls ./public/build.*.js`
 cp ./login-build/vendor.* `ls ./public/vendor.*.js`

--- a/webpack.login.js
+++ b/webpack.login.js
@@ -1,0 +1,100 @@
+const path = require( 'path' );
+const UglifyJSPlugin = require( 'uglifyjs-webpack-plugin' );
+const webpack = require( 'webpack' );
+
+// const babelLoader = {
+// 	loader: 'babel-loader',
+// 	options: {
+// 		cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
+// 		cacheIdentifier: cacheIdentifier,
+// 		plugins: [
+// 			[
+// 				path.join(
+// 					__dirname,
+// 					'server',
+// 					'bundler',
+// 					'babel',
+// 					'babel-plugin-transform-wpcalypso-async'
+// 				),
+// 				{ async: true },
+// 			],
+// 		],
+// 	},
+// };
+
+const config = {
+	entry: {
+		build: path.join( path.resolve( __dirname ), 'client', 'login' ),
+		vendor: [
+			'classnames',
+			'create-react-class',
+			'gridicons',
+			'i18n-calypso',
+			'immutable',
+			'lodash',
+			'moment',
+			'page',
+			'prop-types',
+			'react',
+			'react-dom',
+			'react-redux',
+			'redux',
+			'redux-thunk',
+			'social-logos',
+			'store',
+			'wpcom',
+		],
+	},
+	output: {
+		filename: '[name].[chunkhash].min.js', // prefer the chunkhash, which depends on the chunk, not the entire build
+		chunkFilename: '[name].[chunkhash].min.js', // ditto
+		path: path.resolve( 'login-build' ),
+	},
+	module: {
+		loaders: [
+				{ test: /\.js$/, loader: 'babel-loader', exclude: /node_modules[\/\\](?!notifications-panel)/ },
+				{ test: /\.jsx$/, loader: 'babel-loader', exclude: /node_modules[\/\\](?!notifications-panel)/ },
+		],
+	},
+	resolve: {
+		extensions: [ '.json', '.js', '.jsx' ],
+		modules: [ path.join( path.resolve( __dirname ), 'client' ), 'node_modules' ],
+		alias: Object.assign(
+			{
+				'react-virtualized': 'react-virtualized/dist/commonjs',
+				'social-logos/example': 'social-logos/build/example',
+			}, {}
+		),
+	},
+	node: {
+		console: false,
+		process: true,
+		global: true,
+		Buffer: true,
+		__filename: 'mock',
+		__dirname: 'mock',
+		fs: 'empty',
+	},
+	plugins: [
+		new webpack.DefinePlugin( {
+			'process.env.NODE_ENV': JSON.stringify( 'production' ),
+			PROJECT_NAME: JSON.stringify( 'wordpress-com' ),
+			COMMIT_SHA: JSON.stringify( '123fffeee' ),
+		} ),
+		new UglifyJSPlugin(),
+		new webpack.optimize.CommonsChunkPlugin( { name: 'vendor', minChunks: Infinity } ),
+		new webpack.NormalModuleReplacementPlugin(
+			/layout-wrapper\/logged-in/,
+			'lodash/noop'
+		),
+		new webpack.NormalModuleReplacementPlugin(
+			/^lib[\/\\]desktop$/,
+			'lodash/noop'
+		),
+	],
+	externals: [
+		'jquery',
+	],
+};
+
+module.exports = config;

--- a/webpack.login.js
+++ b/webpack.login.js
@@ -22,7 +22,7 @@ const babelLoader = {
 		cacheIdentifier: cacheIdentifier,
 		plugins: [
 			...babelConfig.plugins,
-			'/Users/yury/Automattic/wp-calypso/inline-imports.js',
+			path.resolve( 'inline-imports.js' ),
 		],
 	} ),
 };

--- a/webpack.login.js
+++ b/webpack.login.js
@@ -2,29 +2,9 @@ const path = require( 'path' );
 const UglifyJSPlugin = require( 'uglifyjs-webpack-plugin' );
 const webpack = require( 'webpack' );
 
-// const babelLoader = {
-// 	loader: 'babel-loader',
-// 	options: {
-// 		cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
-// 		cacheIdentifier: cacheIdentifier,
-// 		plugins: [
-// 			[
-// 				path.join(
-// 					__dirname,
-// 					'server',
-// 					'bundler',
-// 					'babel',
-// 					'babel-plugin-transform-wpcalypso-async'
-// 				),
-// 				{ async: true },
-// 			],
-// 		],
-// 	},
-// };
-
 const config = {
 	entry: {
-		build: path.join( path.resolve( __dirname ), 'client', 'login' ),
+		build: path.join( path.resolve( __dirname ), 'client', 'boot', 'loggedout-app' ),
 		vendor: [
 			'classnames',
 			'create-react-class',

--- a/webpack.login.js
+++ b/webpack.login.js
@@ -23,6 +23,7 @@ const config = {
 			'social-logos',
 			'store',
 			'wpcom',
+			'debug',
 		],
 	},
 	output: {
@@ -63,6 +64,7 @@ const config = {
 		} ),
 		new UglifyJSPlugin(),
 		new webpack.optimize.CommonsChunkPlugin( { name: 'vendor', minChunks: Infinity } ),
+		new webpack.optimize.CommonsChunkPlugin( { name: 'manifest' } ),
 		new webpack.NormalModuleReplacementPlugin(
 			/layout-wrapper\/logged-in/,
 			'lodash/noop'


### PR DESCRIPTION
### Background
Calypso build is a bit large, even with code splitting, the main entry point is ~407kb gzipped
![screen shot 2018-01-31 at 15 54 42](https://user-images.githubusercontent.com/326402/35626683-2299b14e-069f-11e8-909a-a18768690952.png)

The login screen, and some additional logged out screens require only a small subset of calypso to work, but the user still needs to download whole calypso main bundle even if she needs to use initially only the login screen.

### Proposal
Create a new entry point which is a subset of calypso for logged-out users, and serve this bundle when we detect on server side the user is logged out.


### This PR
This PR is a proof of concept exploration of creating a logged out build entry point for calypso that'll have a working login screen.
~159Kb gzipped build

![screen shot 2018-02-01 at 12 40 08](https://user-images.githubusercontent.com/326402/35674495-834a52f6-074d-11e8-8f61-269b55252f06.png)


### Testing
0. run `rm public/build.*.js && rm public/vendor.*.js && rm public/manifest.*.js`
1. run `NODE_ENV=production CALYPSO_ENV=production npm start` ( wait until calypso is up and running )
2. run `./create-loggedout.sh `
3. open http://calypso.localhost:3000/log-in/ and follow the log-in flow

### Viewing bundle stats
```
./node_modules/.bin/webpack --config webpack.login.js --profile --json > ./login-build/stats.json && ./node_modules/.bin/webpack-bundle-analyzer ./login-build/stats.json 
```

### Next steps
- [ ] Figure out how to share `vendor` and `manifest` from the "regular" build
- [ ] Figure out how to create a development build that will play nicely with our development flow
- [ ] Make the server serve the correct build depending on user's log in state
