### PR TITLE
Lazy loading all sites data

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -15,12 +15,13 @@
 
 		.site-icon {
 			animation: pulse-light 0.8s ease-in-out infinite;
+			background-color: lighten( $gray, 70% );
 		}
 
 		.site__title,
 		.site__domain {
 			animation: pulse-light 0.8s ease-in-out infinite;
-			background-color: lighten( $gray, 30% );
+			background-color: lighten( $gray, 70% );
 			color: transparent;
 			width: 95%;
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -51,7 +51,8 @@ import NpsSurveyNotice from 'layout/nps-survey-notice';
 import AppBanner from 'blocks/app-banner';
 import { getPreference } from 'state/preferences/selectors';
 import JITM from 'blocks/jitm';
-import { getPrimarySiteId } from 'state/selectors';
+import { getPrimarySiteId, getSitesItems } from 'state/selectors';
+import { EMPTY_SITES } from 'state/selectors/get-sites-items';
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
@@ -156,19 +157,13 @@ const Layout = createReactClass( {
 				'is-active': this.props.isLoading,
 			} );
 
-		const { recentSitesPreference, primarySiteId } = this.props;
-
-		let siteIdToFetch = get( recentSitesPreference, '0', null );
-
-		if ( ! siteIdToFetch ) {
-			siteIdToFetch = primarySiteId;
-		}
+		const { siteIdToFetch, shouldFetchSite } = this.props;
 
 		return (
 			<div className={ sectionClass }>
 				<DocumentHead />
 				<SitesListNotices />
-				<QuerySites siteId={ siteIdToFetch } />
+				{ shouldFetchSite && <QuerySites siteId={ siteIdToFetch } /> }
 				<QueryPreferences />
 				{ <GuidedTours /> }
 				{ config.isEnabled( 'nps-survey/notice' ) && <NpsSurveyNotice /> }
@@ -213,16 +208,26 @@ const Layout = createReactClass( {
 
 export default connect( state => {
 	const { isLoading, section } = state.ui;
+
+	const recentSitesPreference = getPreference( state, 'recentSites' );
+	const primarySiteId = getPrimarySiteId( state );
+
+	let siteIdToFetch = get( recentSitesPreference, '0', null );
+
+	if ( ! siteIdToFetch ) {
+		siteIdToFetch = primarySiteId;
+	}
+
 	return {
 		isLoading,
-		isSupportUser: state.support.isSupportUser,
 		section,
+		siteIdToFetch,
+		shouldFetchSite: getSitesItems( state ) === EMPTY_SITES,
+		isSupportUser: state.support.isSupportUser,
 		hasSidebar: hasSidebar( state ),
 		isOffline: isOffline( state ),
 		currentLayoutFocus: getCurrentLayoutFocus( state ),
 		chatIsOpen: isHappychatOpen( state ),
 		colorSchemePreference: getPreference( state, 'colorScheme' ),
-		recentSitesPreference: getPreference( state, 'recentSites' ),
-		primarySiteId: getPrimarySiteId( state ),
 	};
 } )( Layout );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { property, sortBy } from 'lodash';
+import { property, sortBy, get } from 'lodash';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
@@ -51,6 +51,7 @@ import NpsSurveyNotice from 'layout/nps-survey-notice';
 import AppBanner from 'blocks/app-banner';
 import { getPreference } from 'state/preferences/selectors';
 import JITM from 'blocks/jitm';
+import { getPrimarySiteId } from 'state/selectors';
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
@@ -155,11 +156,19 @@ const Layout = createReactClass( {
 				'is-active': this.props.isLoading,
 			} );
 
+		const { recentSitesPreference, primarySiteId } = this.props;
+
+		let siteIdToFetch = get( recentSitesPreference, '0', null );
+
+		if ( ! siteIdToFetch ) {
+			siteIdToFetch = primarySiteId;
+		}
+
 		return (
 			<div className={ sectionClass }>
 				<DocumentHead />
 				<SitesListNotices />
-				<QuerySites allSites />
+				<QuerySites siteId={ siteIdToFetch } />
 				<QueryPreferences />
 				{ <GuidedTours /> }
 				{ config.isEnabled( 'nps-survey/notice' ) && <NpsSurveyNotice /> }
@@ -213,5 +222,7 @@ export default connect( state => {
 		currentLayoutFocus: getCurrentLayoutFocus( state ),
 		chatIsOpen: isHappychatOpen( state ),
 		colorSchemePreference: getPreference( state, 'colorScheme' ),
+		recentSitesPreference: getPreference( state, 'recentSites' ),
+		primarySiteId: getPrimarySiteId( state ),
 	};
 } )( Layout );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { property, sortBy, get } from 'lodash';
+import { property, sortBy } from 'lodash';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
@@ -82,18 +82,6 @@ const Layout = createReactClass( {
 		colorSchemePreference: PropTypes.string,
 	},
 
-	getInitialState() {
-		return {
-			initialSiteFetched: false,
-		};
-	},
-
-	componentWillReceiveProps() {
-		if ( ! this.state.initialSiteFetched ) {
-			this.setState( { initialSiteFetched: true } );
-		}
-	},
-
 	closeWelcome: function() {
 		this.props.nuxWelcome.closeWelcome();
 		analytics.ga.recordEvent( 'Welcome Box', 'Clicked Close Button' );
@@ -168,14 +156,13 @@ const Layout = createReactClass( {
 				'is-active': this.props.isLoading,
 			} );
 
-		const { siteIdToFetch } = this.props;
-		const { initialSiteFetched } = this.state;
+		const { primarySiteId } = this.props;
 
 		return (
 			<div className={ sectionClass }>
 				<DocumentHead />
 				<SitesListNotices />
-				{ ! initialSiteFetched && <QuerySites siteId={ siteIdToFetch } /> }
+				<QuerySites siteId={ primarySiteId } />
 				<QueryPreferences />
 				{ <GuidedTours /> }
 				{ config.isEnabled( 'nps-survey/notice' ) && <NpsSurveyNotice /> }
@@ -221,19 +208,10 @@ const Layout = createReactClass( {
 export default connect( state => {
 	const { isLoading, section } = state.ui;
 
-	const recentSitesPreference = getPreference( state, 'recentSites' );
-	const primarySiteId = getPrimarySiteId( state );
-
-	let siteIdToFetch = get( recentSitesPreference, '0', null );
-
-	if ( ! siteIdToFetch ) {
-		siteIdToFetch = primarySiteId;
-	}
-
 	return {
 		isLoading,
 		section,
-		siteIdToFetch,
+		primarySiteId: getPrimarySiteId( state ),
 		isSupportUser: state.support.isSupportUser,
 		hasSidebar: hasSidebar( state ),
 		isOffline: isOffline( state ),

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -51,8 +51,7 @@ import NpsSurveyNotice from 'layout/nps-survey-notice';
 import AppBanner from 'blocks/app-banner';
 import { getPreference } from 'state/preferences/selectors';
 import JITM from 'blocks/jitm';
-import { getPrimarySiteId, getSitesItems } from 'state/selectors';
-import { EMPTY_SITES } from 'state/selectors/get-sites-items';
+import { getPrimarySiteId } from 'state/selectors';
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
@@ -81,6 +80,18 @@ const Layout = createReactClass( {
 		section: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 		isOffline: PropTypes.bool,
 		colorSchemePreference: PropTypes.string,
+	},
+
+	getInitialState() {
+		return {
+			initialSiteFetched: false,
+		};
+	},
+
+	componentWillReceiveProps() {
+		if ( ! this.state.initialSiteFetched ) {
+			this.setState( { initialSiteFetched: true } );
+		}
 	},
 
 	closeWelcome: function() {
@@ -157,13 +168,14 @@ const Layout = createReactClass( {
 				'is-active': this.props.isLoading,
 			} );
 
-		const { siteIdToFetch, shouldFetchSite } = this.props;
+		const { siteIdToFetch } = this.props;
+		const { initialSiteFetched } = this.state;
 
 		return (
 			<div className={ sectionClass }>
 				<DocumentHead />
 				<SitesListNotices />
-				{ shouldFetchSite && <QuerySites siteId={ siteIdToFetch } /> }
+				{ ! initialSiteFetched && <QuerySites siteId={ siteIdToFetch } /> }
 				<QueryPreferences />
 				{ <GuidedTours /> }
 				{ config.isEnabled( 'nps-survey/notice' ) && <NpsSurveyNotice /> }
@@ -222,7 +234,6 @@ export default connect( state => {
 		isLoading,
 		section,
 		siteIdToFetch,
-		shouldFetchSite: getSitesItems( state ) === EMPTY_SITES,
 		isSupportUser: state.support.isSupportUser,
 		hasSidebar: hasSidebar( state ),
 		isOffline: isOffline( state ),

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -14,12 +14,13 @@ import { noop, some, startsWith, uniq } from 'lodash';
  */
 import { SITES_ONCE_CHANGED } from 'state/action-types';
 import userFactory from 'lib/user';
-import { receiveSite, requestSites } from 'state/sites/actions';
+import { receiveSite, requestSites, requestSite } from 'state/sites/actions';
 import {
 	getSite,
 	isJetpackModuleActive,
 	isJetpackSite,
 	isRequestingSites,
+	isRequestingSite,
 } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { setSelectedSiteId, setSection, setAllSitesSelected } from 'state/ui/actions';
@@ -376,9 +377,12 @@ export function siteSelection( context, next ) {
 			return;
 		}
 	} else {
+		// Fetch the site from siteFragment.
+		dispatch( requestSite( siteFragment ) );
+
 		// if sites has fresh data and siteId is invalid
 		// redirect to allSitesPath
-		if ( ! isRequestingSites( getState() ) ) {
+		if ( ! isRequestingSites( getState() ) && ! isRequestingSite( getState(), siteFragment ) ) {
 			return page.redirect( allSitesPath );
 		}
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -362,7 +362,12 @@ export function siteSelection( context, next ) {
 
 	// If the path fragment does not resemble a site, set all sites to visible
 	if ( ! siteFragment ) {
+		if ( ! isRequestingSites( getState() ) ) {
+			dispatch( requestSites() );
+		}
+
 		dispatch( setAllSitesSelected() );
+
 		return next();
 	}
 

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -29,6 +29,7 @@ import { getNoticeLastTimeShown } from 'state/notices/selectors';
 import { getSectionName } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
+import { isRequestingSites } from 'state/sites/selectors';
 
 class CurrentSite extends Component {
 	static propTypes = {
@@ -90,9 +91,15 @@ class CurrentSite extends Component {
 	};
 
 	render() {
-		const { selectedSite, translate, anySiteSelected, visibleSitesCount } = this.props;
+		const {
+			selectedSite,
+			translate,
+			anySiteSelected,
+			visibleSitesCount,
+			isRequestingAllSites,
+		} = this.props;
 
-		if ( ! anySiteSelected.length ) {
+		if ( ! anySiteSelected.length || ( ! selectedSite && isRequestingAllSites ) ) {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
 				<Card className="current-site is-loading">
@@ -145,6 +152,7 @@ export default connect(
 		visibleSitesCount: getCurrentUserVisibleSiteCount( state ),
 		staleCartItemNoticeLastTimeShown: getNoticeLastTimeShown( state, 'stale-cart-item-notice' ),
 		sectionName: getSectionName( state ),
+		isRequestingAllSites: isRequestingSites( state ),
 	} ),
 	{ setLayoutFocus, infoNotice, removeNotice, recordTracksEvent }
 )( localize( CurrentSite ) );

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -23,15 +23,16 @@ import SiteNotice from './notice';
 import CartStore from 'lib/cart/store';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSite } from 'state/ui/selectors';
-import { getSelectedOrAllSites, getVisibleSites } from 'state/selectors';
+import { getSelectedOrAllSites } from 'state/selectors';
 import { infoNotice, removeNotice } from 'state/notices/actions';
 import { getNoticeLastTimeShown } from 'state/notices/selectors';
 import { getSectionName } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
 
 class CurrentSite extends Component {
 	static propTypes = {
-		siteCount: PropTypes.number.isRequired,
+		visibleSitesCount: PropTypes.number.isRequired,
 		setLayoutFocus: PropTypes.func.isRequired,
 		selectedSite: PropTypes.object,
 		translate: PropTypes.func.isRequired,
@@ -89,13 +90,13 @@ class CurrentSite extends Component {
 	};
 
 	render() {
-		const { selectedSite, translate, anySiteSelected } = this.props;
+		const { selectedSite, translate, anySiteSelected, visibleSitesCount } = this.props;
 
 		if ( ! anySiteSelected.length ) {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
 				<Card className="current-site is-loading">
-					{ this.props.siteCount > 1 && <span className="current-site__switch-sites">&nbsp;</span> }
+					{ visibleSitesCount > 1 && <span className="current-site__switch-sites">&nbsp;</span> }
 
 					<div className="site">
 						<a className="site__content">
@@ -112,7 +113,7 @@ class CurrentSite extends Component {
 
 		return (
 			<Card className="current-site">
-				{ this.props.siteCount > 1 && (
+				{ visibleSitesCount > 1 && (
 					<span className="current-site__switch-sites">
 						<Button compact borderless onClick={ this.switchSites }>
 							<Gridicon icon="arrow-left" size={ 18 } />
@@ -141,7 +142,7 @@ export default connect(
 	state => ( {
 		selectedSite: getSelectedSite( state ),
 		anySiteSelected: getSelectedOrAllSites( state ),
-		siteCount: getVisibleSites( state ).length,
+		visibleSitesCount: getCurrentUserVisibleSiteCount( state ),
 		staleCartItemNoticeLastTimeShown: getNoticeLastTimeShown( state, 'stale-cart-item-notice' ),
 		sectionName: getSectionName( state ),
 	} ),

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -36,6 +36,7 @@ class SitePicker extends React.Component {
 	state = {
 		isAutoFocused: false,
 		isOpened: false,
+		isRendered: false,
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -46,6 +47,10 @@ class SitePicker extends React.Component {
 		const isAutoFocused = nextProps.currentLayoutFocus === 'sites';
 		if ( isAutoFocused !== this.state.isAutoFocused ) {
 			this.setState( { isAutoFocused } );
+		}
+
+		if ( nextProps.currentLayoutFocus === 'sites' && ! this.state.isRendered ) {
+			this.setState( { isRendered: true } );
 		}
 	}
 
@@ -82,6 +87,10 @@ class SitePicker extends React.Component {
 	};
 
 	render() {
+		if ( ! this.state.isRendered && this.props.currentLayoutFocus !== 'sites' ) {
+			return null;
+		}
+
 		return (
 			<div>
 				<CloseOnEscape onEscape={ this.closePicker } />

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -18,6 +18,7 @@ import SiteSelector from 'components/site-selector';
 import { hasTouch } from 'lib/touch-detect';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus, setLayoutFocus } from 'state/ui/layout-focus/actions';
+import QuerySites from 'components/data/query-sites';
 
 class SitePicker extends React.Component {
 	static displayName = 'SitePicker';
@@ -93,6 +94,7 @@ class SitePicker extends React.Component {
 
 		return (
 			<div>
+				<QuerySites allSites />
 				<CloseOnEscape onEscape={ this.closePicker } />
 				<SiteSelector
 					ref="siteSelector"

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -216,7 +216,7 @@ const handler = ( dispatch, action, getState ) => {
 		case SITES_RECEIVE:
 			// Wait a tick for the reducer to update the state tree
 			setTimeout( () => {
-				if ( action.type === SITES_RECEIVE ) {
+				if ( action.type === SITES_RECEIVE || action.type === SITE_RECEIVE ) {
 					fireChangeListeners();
 				}
 				if ( globalKeyBoardShortcutsEnabled ) {

--- a/client/state/selectors/get-sites-items.js
+++ b/client/state/selectors/get-sites-items.js
@@ -3,7 +3,7 @@
  *
  * @type {Object}
  */
-export const EMPTY_SITES = Object.freeze( {} );
+const EMPTY_SITES = Object.freeze( {} );
 
 /**
  * Returns site items object or empty object.

--- a/client/state/selectors/get-sites-items.js
+++ b/client/state/selectors/get-sites-items.js
@@ -3,11 +3,11 @@
  *
  * @type {Object}
  */
-const EMPTY_SITES = Object.freeze( {} );
+export const EMPTY_SITES = Object.freeze( {} );
 
 /**
  * Returns site items object or empty object.
- * 
+ *
  *
  * @format
  * @param {Object} state  Global state tree


### PR DESCRIPTION
Experimental, do not merge.

In this PR, we are lazy loading all sites data only when it's needed – after clicking on "Switch Site". Otherwise, either the recent site (or primary one if customer preferences are not loaded yet) or the site which it is navigated to is loaded.

There are still some things to polish, such as site placeholder colors or updating some code, but I think the general approach here might work for us while not reducing UX for our customers.

Video of how it's working: http://cld.wthms.co/lbmDpW
  