### PR TITLE
State: Introduce getUnconnectedSite and getUnconnectedSiteUrl selectors.

### DIFF
--- a/client/state/selectors/get-unconnected-site-url.js
+++ b/client/state/selectors/get-unconnected-site-url.js
@@ -1,0 +1,20 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getUnconnectedSite } from 'state/selectors';
+
+export default function getUnconnectedSiteUrl( state, siteId ) {
+	const site = getUnconnectedSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+
+	return get( site, 'siteUrl', null );
+}

--- a/client/state/selectors/get-unconnected-site.js
+++ b/client/state/selectors/get-unconnected-site.js
@@ -1,0 +1,10 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export default function getUnconnectedSite( state, siteId ) {
+	return get( state.jetpackOnboarding.credentials, siteId, null );
+}

--- a/client/state/selectors/test/get-unconnected-site-url.js
+++ b/client/state/selectors/test/get-unconnected-site-url.js
@@ -1,0 +1,59 @@
+/**
+ * Internal dependencies
+ */
+import { getUnconnectedSiteUrl } from 'state/selectors';
+
+describe( '#getUnconnectedSiteUrl()', () => {
+	const credentials = {
+		2916284: {
+			token: 'abcd1234',
+			siteUrl: 'http://yourgroovydomain.com',
+			userEmail: 'contact@yourgroovydomain.com',
+		},
+	};
+
+	test( 'should return null if we have no credentials at all', () => {
+		const selected = getUnconnectedSiteUrl( {
+			jetpackOnboarding: {
+				credentials: {},
+			},
+		}, 12345678 );
+
+		expect( selected ).toBeNull();
+	} );
+
+	test( 'should return null if we have no credentials for the current site ID', () => {
+		const selected = getUnconnectedSiteUrl( {
+			jetpackOnboarding: {
+				credentials,
+			},
+		}, 12345678 );
+
+		expect( selected ).toBeNull();
+	} );
+
+	test( 'should return null if we have no siteUrl in the credentials of the current site ID', () => {
+		const selected = getUnconnectedSiteUrl( {
+			jetpackOnboarding: {
+				credentials: {
+					2916284: {
+						token: 'abcd1234',
+						userEmail: 'contact@yourgroovydomain.com',
+					},
+				},
+			},
+		}, 2916284 );
+
+		expect( selected ).toBeNull();
+	} );
+
+	test( 'should return the site URL of a known unconnected site', () => {
+		const selected = getUnconnectedSiteUrl( {
+			jetpackOnboarding: {
+				credentials,
+			},
+		}, 2916284 );
+
+		expect( selected ).toBe( 'http://yourgroovydomain.com' );
+	} );
+} );

--- a/client/state/selectors/test/get-unconnected-site.js
+++ b/client/state/selectors/test/get-unconnected-site.js
@@ -1,0 +1,45 @@
+/**
+ * Internal dependencies
+ */
+import { getUnconnectedSite } from 'state/selectors';
+
+describe( '#getUnconnectedSite()', () => {
+	const site = {
+		token: 'abcd1234',
+		siteUrl: 'http://yourgroovydomain.com',
+		userEmail: 'contact@yourgroovydomain.com',
+	};
+	const credentials = {
+		2916284: site,
+	};
+
+	test( 'should return null if we have no credentials at all', () => {
+		const selected = getUnconnectedSite( {
+			jetpackOnboarding: {
+				credentials: {},
+			},
+		}, 12345678 );
+
+		expect( selected ).toBeNull();
+	} );
+
+	test( 'should return null if we have no credentials for the current site ID', () => {
+		const selected = getUnconnectedSite( {
+			jetpackOnboarding: {
+				credentials,
+			},
+		}, 12345678 );
+
+		expect( selected ).toBeNull();
+	} );
+
+	test( 'should return the site credentials of a known unconnected site', () => {
+		const selected = getUnconnectedSite( {
+			jetpackOnboarding: {
+				credentials,
+			},
+		}, 2916284 );
+
+		expect( selected ).toBe( site );
+	} );
+} );


### PR DESCRIPTION
This PR introduces 2 selectors that we'll use throughout the Jetpack Onboarding steps:

* `getUnconnectedSite()` - retrieves the credentials of an onboarding site by its ID.
* `getUnconnectedSiteUrl()` - retrieves the URL of an onboarding site by its ID.

To test:
* Checkout this branch
* Verify all tests pass:

```
npm run test-client client/state/selectors/test/get-unconnected-site*
```