### PR TITLE
JP Onboarding: Show Spinner while installing WooCommerce

### DIFF
--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -38,7 +38,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 			return (
 				<div key={ stepName } className={ className }>
 					{ isPending ? (
-						<Spinner />
+						<Spinner size={ 18 } />
 					) : (
 						<Gridicon icon={ isCompleted ? 'checkmark' : 'cross' } size={ 18 } />
 					) }

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -5,9 +5,9 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
-import { compact, get, map, without } from 'lodash';
 import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
+import { compact, get, map, mapValues, without } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -17,24 +17,31 @@ import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { getJetpackOnboardingProgress, getUnconnectedSiteUrl } from 'state/selectors';
+import Spinner from 'components/spinner';
+import { getJetpackOnboardingProgress, getRequest, getUnconnectedSiteUrl } from 'state/selectors';
 import {
 	JETPACK_ONBOARDING_STEP_TITLES as STEP_TITLES,
 	JETPACK_ONBOARDING_STEPS as STEPS,
 	JETPACK_ONBOARDING_SUMMARY_STEPS as SUMMARY_STEPS,
 } from '../constants';
+import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
 	renderCompleted = () => {
-		const { steps, stepsCompleted } = this.props;
+		const { steps, stepsCompleted, stepsPending } = this.props;
 
 		return map( without( steps, STEPS.SUMMARY ), stepName => {
 			const isCompleted = get( stepsCompleted, stepName ) === true;
+			const isPending = get( stepsPending, stepName );
 			const className = classNames( 'steps__summary-entry', isCompleted ? 'completed' : 'todo' );
 
 			return (
 				<div key={ stepName } className={ className }>
-					<Gridicon icon={ isCompleted ? 'checkmark' : 'cross' } size={ 18 } />
+					{ isPending ? (
+						<Spinner />
+					) : (
+						<Gridicon icon={ isCompleted ? 'checkmark' : 'cross' } size={ 18 } />
+					) }
 					{ STEP_TITLES[ stepName ] }
 				</div>
 			);
@@ -67,6 +74,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 
 	render() {
 		const { translate } = this.props;
+
 		const headerText = translate( 'Congratulations! Your site is on its way.' );
 		const subHeaderText = translate(
 			'You enabled Jetpack and unlocked dozens of website-bolstering features. Continue preparing your site below.'
@@ -108,9 +116,22 @@ export default connect( ( state, { siteId, steps } ) => {
 	const tasks = compact( [] );
 	const stepsCompleted = getJetpackOnboardingProgress( state, siteId, steps );
 
+	const stepActionsMap = {
+		[ STEPS.WOOCOMMERCE ]: {
+			installWooCommerce: true,
+		},
+	};
+
+	const stepsPending = mapValues(
+		stepActionsMap,
+		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+		action => getRequest( state, saveJetpackOnboardingSettings( siteId, action ) ).isLoading
+	);
+
 	return {
 		siteUrl: getUnconnectedSiteUrl( state, siteId ),
 		stepsCompleted,
+		stepsPending,
 		tasks,
 	};
 } )( localize( JetpackOnboardingSummaryStep ) );

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -1,6 +1,8 @@
+/** @format */
+
 .jetpack-onboarding {
 	.steps__main {
-		animation: appearWithScaling .3s ease-in-out;
+		animation: appearWithScaling 0.3s ease-in-out;
 	}
 
 	.steps__form {
@@ -49,6 +51,11 @@
 		.gridicon {
 			position: relative;
 			top: 3px;
+			margin-right: 12px;
+		}
+
+		.spinner {
+			float: left;
 			margin-right: 12px;
 		}
 

--- a/client/state/jetpack-onboarding/actions.js
+++ b/client/state/jetpack-onboarding/actions.js
@@ -19,6 +19,11 @@ export const saveJetpackOnboardingSettings = ( siteId, settings ) => ( {
 	type: JETPACK_ONBOARDING_SETTINGS_SAVE,
 	siteId,
 	settings,
+	meta: {
+		dataLayer: {
+			trackRequest: true,
+		},
+	},
 } );
 
 export const updateJetpackOnboardingSettings = ( siteId, settings ) => ( {

--- a/client/state/jetpack-onboarding/test/actions.js
+++ b/client/state/jetpack-onboarding/test/actions.js
@@ -46,6 +46,11 @@ describe( 'actions', () => {
 				type: JETPACK_ONBOARDING_SETTINGS_SAVE,
 				siteId,
 				settings,
+				meta: {
+					dataLayer: {
+						trackRequest: true,
+					},
+				},
 			} );
 		} );
 	} );


### PR DESCRIPTION
Modeled after #20038. Rebased on `master` after merging #21533, so no workarounds are needed anymore to ensure that the network success action is dispatched.

![image](https://user-images.githubusercontent.com/96308/34950790-724f788c-fa14-11e7-84fc-155f94e2c00d.png)

To test:
1. Checkout this branch on your local Calypso.
1. Make sure your JP sandbox is running the latest Jetpack master.
1. Make sure WooCommerce isn't installed on your JP sandbox.
1. Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
1. Skip to Step 2, select Business Site; skip thru to Step 6 ('...sell online...?')
1. Click the 'Yes, I do' button.
1. You're being directed to the Summary page. Note that there's a spinner next to the 'Adding store' item (bottom left) that then changes to an 'X' (we'll change that to a checkmark in a subsequent PR).
1. Verify that WooCommerce was indeed installed and activated on your JP site.