### PR TITLE
Jetpack Onboading: Link Summary to Jetpack Connect

### DIFF
--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -16,6 +16,7 @@ import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { getUnconnectedSiteUrl } from 'state/selectors';
 import {
 	JETPACK_ONBOARDING_STEPS as STEPS,
 	JETPACK_ONBOARDING_SUMMARY_STEPS as SUMMARY_STEPS,
@@ -28,7 +29,6 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 			SUMMARY_STEPS.SITE_TYPE,
 			SUMMARY_STEPS.HOMEPAGE_TYPE,
 			SUMMARY_STEPS.CONTACT_FORM,
-			SUMMARY_STEPS.JETPACK_CONNECTION,
 		];
 		return map( stepsCompleted, ( fieldLabel, fieldIndex ) => (
 			<div key={ fieldIndex } className="steps__summary-entry completed">
@@ -40,18 +40,24 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 
 	renderTodo = () => {
 		const stepsTodo = [
+			SUMMARY_STEPS.JETPACK_CONNECTION,
 			SUMMARY_STEPS.THEME,
 			SUMMARY_STEPS.SITE_ADDRESS,
 			SUMMARY_STEPS.STORE,
 			SUMMARY_STEPS.BLOG,
 		];
-
-		// TODO: adapt when we have more info + it will differ for different steps
-		const siteRedirectHref = '#';
+		const stepLinks = [
+			'/jetpack/connect?url=' + this.props.siteUrl,
+			// TODO: update the following with relevant links
+			'#',
+			'#',
+			'#',
+			'#',
+		];
 
 		return map( stepsTodo, ( fieldLabel, fieldIndex ) => (
 			<div key={ fieldIndex } className="steps__summary-entry todo">
-				<a href={ siteRedirectHref }>{ fieldLabel }</a>
+				<a href={ stepLinks[ fieldIndex ] }>{ fieldLabel }</a>
 			</div>
 		) );
 	};
@@ -95,9 +101,10 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	}
 }
 
-export default connect( () => {
+export default connect( ( state, { siteId } ) => {
 	const tasks = compact( [] );
 	return {
+		siteUrl: getUnconnectedSiteUrl( state, siteId ),
 		tasks,
 	};
 } )( localize( JetpackOnboardingSummaryStep ) );


### PR DESCRIPTION
This PR updates the Jetpack Connection item in the Summary step to actually link to Jetpack Connect. This basically **provides a connection between the Jetpack Onboarding flow and the Jetpack Connect flow**.

To test:
1. Checkout this branch on your local Calypso.
1. Make sure your JP sandbox is running the latest Jetpack master.
1. Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
1. After you land the JPO flow, skip to the Summary step.
1. Click on the **Jetpack Connection** item.
1. Verify you're redirected to the Jetpack Connect step and connection process has been initiated.
  