### PR TITLE
Activity Log: Use server-provided `isDiscarded` value when possible

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -187,7 +187,8 @@ class ActivityLogDay extends Component {
 			rewindId: requestedRestoreId,
 		} );
 
-		const isDiscarded = makeIsDiscarded( rewindEvents, isDiscardedPerspective );
+		const isDiscarded =
+			isDiscardedPerspective && makeIsDiscarded( rewindEvents, isDiscardedPerspective );
 
 		const LogItem = ( { log, hasBreak } ) => (
 			<ActivityLogItem
@@ -196,7 +197,7 @@ class ActivityLogDay extends Component {
 				disableRestore={ disableRestore }
 				disableBackup={ disableBackup }
 				hideRestore={ ! isRewindActive }
-				isDiscarded={ isDiscarded( log.activityTs ) }
+				isDiscarded={ isDiscarded ? isDiscarded( log.activityTs ) : log.activityIsDiscarded }
 				requestDialog={ requestDialog }
 				siteId={ siteId }
 			/>

--- a/client/state/activity-log/log/schema.js
+++ b/client/state/activity-log/log/schema.js
@@ -19,6 +19,7 @@ const activityItemSchema = {
 		activityGroup: { type: 'string' },
 		activityIcon: { type: 'string' },
 		activityId: { type: 'string' },
+		activityIsDiscarded: { type: 'boolean' },
 		activityIsRewindable: { type: 'boolean' },
 		activityName: { type: 'string' },
 		activityStatus: {

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -53,6 +53,7 @@ export function processItem( item ) {
 		activityGroup: ( item.name || '' ).split( '__', 1 )[ 0 ], // split always returns at least one item
 		activityIcon: get( item, 'gridicon', DEFAULT_GRIDICON ),
 		activityId: item.activity_id,
+		activityIsDiscarded: item.is_discarded,
 		activityIsRewindable: item.is_rewindable,
 		rewindId: item.rewind_id,
 		activityName: item.name,

--- a/client/state/data-layer/wpcom/sites/activity/schema.json
+++ b/client/state/data-layer/wpcom/sites/activity/schema.json
@@ -61,6 +61,7 @@
 				},
 				"generator": { "type": "object" },
 				"gridicon": { "type": "string" },
+				"is_discarded": { "type": "boolean" },
 				"is_rewindable": { "type": "boolean" },
 				"rewind_id": { "type": [ "null", "string" ] },
 				"items": {


### PR DESCRIPTION
The activity log entries change appearance if they are discarded from
a given perspective. On initial render the perspective is "now" and
the server has precomputed the values. When opening rewind dialogs
though the perspective changes and the values need to be dynamically
created.

In this patch we're defaulting to use the server-provided values to skip
processing time and only calculating the value dynamically when a
different perspective has been chosen.

**Testing**

Open a site with **Rewind** active in **My Sites** > **Stats** > **Activity**

Make sure you can find events that have been discarded by a restore operation.
Start the rewind process by clicking on the **Rewind** button in order to open
the confirmation dialog. Once open make sure that any previously-discarded
events which should not be restored are no longer discarded. Cancel the dialog
and verify that the events return to their previous state.
  
http://iscalypsofastyet.com/branch?branch=activity-log/use-server-is-discarded-when-possible
```
Delta:
chunk                                   stat_size           parsed_size           gzip_size
async-load-my-sites-stats-activity-log      +66 B  (+0.0%)        +27 B  (+0.0%)       +8 B  (+0.0%)
build                                      +138 B  (+0.0%)       +110 B  (+0.0%)      +18 B  (+0.0%)
manifest                                     +0 B                  +0 B                +0 B
```