### PR TITLE
Concierge Chats: Use a sensible default time in the CalendarCard time picker

### DIFF
--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -45,9 +45,9 @@ class CalendarCard extends Component {
 		// To find the best default time for the time picker, we're going to pick the time that's
 		// closest to the current time of day. To do this first we find out how many seconds it's
 		// been since midnight on the current real world day...
-		const timeSinceMidnight = moment().diff( moment().startOf( 'day' ) );
+		const timeSinceMidnight = moment().diff( this.withTimezone().startOf( 'day' ) );
 		// Then we'll use that to find the same time of day on the Card's given date...
-		const currentTimeOnGivenDate = moment( this.props.date )
+		const currentTimeOnGivenDate = this.withTimezone( this.props.date )
 			.startOf( 'day' )
 			.add( timeSinceMidnight );
 

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -42,29 +42,34 @@ class CalendarCard extends Component {
 	constructor( props ) {
 		super( props );
 
-		// To find the best default time for the time picker, we're going to pick the time that's
-		// closest to the current time of day. To do this first we find out how many seconds it's
-		// been since midnight on the current real world day...
-		const millisecondsSinceMidnight = moment().diff( this.withTimezone().startOf( 'day' ) );
+		let closestTimestamp;
 
-		// Then we'll use that to find the same time of day on the Card's given date. This will be the
-		// target timestamp we're trying to get as close to as possible.
-		const targetTimestamp = this.withTimezone( this.props.date )
-			.startOf( 'day' )
-			.add( millisecondsSinceMidnight );
+		// If there are times passed in, pick a sensible default.
+		if ( Array.isArray( this.props.times ) && ! isEmpty( this.props.times ) ) {
+			// To find the best default time for the time picker, we're going to pick the time that's
+			// closest to the current time of day. To do this first we find out how many seconds it's
+			// been since midnight on the current real world day...
+			const millisecondsSinceMidnight = moment().diff( this.withTimezone().startOf( 'day' ) );
 
-		// Default to the first timestamp and calculate how many seconds it's offset from the target
-		let closestTimestamp = this.props.times[ 0 ];
-		let closestTimeOffset = Math.abs( closestTimestamp - targetTimestamp );
+			// Then we'll use that to find the same time of day on the Card's given date. This will be the
+			// target timestamp we're trying to get as close to as possible.
+			const targetTimestamp = this.withTimezone( this.props.date )
+				.startOf( 'day' )
+				.add( millisecondsSinceMidnight );
 
-		// Then look through all timestamps to find which one is the closest to the target
-		this.props.times.forEach( time => {
-			const offset = Math.abs( time - targetTimestamp );
-			if ( offset < closestTimeOffset ) {
-				closestTimestamp = time;
-				closestTimeOffset = offset;
-			}
-		} );
+			// Default to the first timestamp and calculate how many seconds it's offset from the target
+			closestTimestamp = this.props.times[ 0 ];
+			let closestTimeOffset = Math.abs( closestTimestamp - targetTimestamp );
+
+			// Then look through all timestamps to find which one is the closest to the target
+			this.props.times.forEach( time => {
+				const offset = Math.abs( time - targetTimestamp );
+				if ( offset < closestTimeOffset ) {
+					closestTimestamp = time;
+					closestTimeOffset = offset;
+				}
+			} );
+		}
 
 		this.state = {
 			selectedTime: closestTimestamp,

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -39,9 +39,38 @@ class CalendarCard extends Component {
 		timezone: PropTypes.string.isRequired,
 	};
 
-	state = {
-		selectedTime: this.props.times[ 0 ],
-	};
+	constructor( props ) {
+		super( props );
+
+		// To find the best default time for the time picker, we're going to pick the time that's
+		// closest to the current time of day. To do this first we find out how many seconds it's
+		// been since midnight on the current real world day...
+		const timeSinceMidnight = moment().diff( moment().startOf( 'day' ) );
+		// Then we'll use that to find the same time of day on the Card's given date...
+		const currentTimeOnGivenDate = moment( this.props.date )
+			.startOf( 'day' )
+			.add( timeSinceMidnight );
+
+		// Then we'll use a reducer to find the timestamp that's closest (before or after) to the
+		// current time on the given date.
+		const closestTimestamp = this.props.times.reduce(
+			( closestTime, newTime ) => {
+				// On each iteration, return the time that's closer to the current time on the given date
+				const closestTimeOffset = Math.abs( closestTime - currentTimeOnGivenDate );
+				const newTimeOffset = Math.abs( newTime - currentTimeOnGivenDate );
+				if ( newTimeOffset < closestTimeOffset ) {
+					return newTime;
+				}
+				return closestTime;
+			},
+			// Seed the reducer with the first timestamp for a sensible default
+			this.props.times[ 0 ]
+		);
+
+		this.state = {
+			selectedTime: closestTimestamp,
+		};
+	}
 
 	withTimezone = dateTime => moment( dateTime ).tz( this.props.timezone );
 

--- a/client/me/concierge/calendar-card.js
+++ b/client/me/concierge/calendar-card.js
@@ -45,27 +45,26 @@ class CalendarCard extends Component {
 		// To find the best default time for the time picker, we're going to pick the time that's
 		// closest to the current time of day. To do this first we find out how many seconds it's
 		// been since midnight on the current real world day...
-		const timeSinceMidnight = moment().diff( this.withTimezone().startOf( 'day' ) );
-		// Then we'll use that to find the same time of day on the Card's given date...
-		const currentTimeOnGivenDate = this.withTimezone( this.props.date )
-			.startOf( 'day' )
-			.add( timeSinceMidnight );
+		const millisecondsSinceMidnight = moment().diff( this.withTimezone().startOf( 'day' ) );
 
-		// Then we'll use a reducer to find the timestamp that's closest (before or after) to the
-		// current time on the given date.
-		const closestTimestamp = this.props.times.reduce(
-			( closestTime, newTime ) => {
-				// On each iteration, return the time that's closer to the current time on the given date
-				const closestTimeOffset = Math.abs( closestTime - currentTimeOnGivenDate );
-				const newTimeOffset = Math.abs( newTime - currentTimeOnGivenDate );
-				if ( newTimeOffset < closestTimeOffset ) {
-					return newTime;
-				}
-				return closestTime;
-			},
-			// Seed the reducer with the first timestamp for a sensible default
-			this.props.times[ 0 ]
-		);
+		// Then we'll use that to find the same time of day on the Card's given date. This will be the
+		// target timestamp we're trying to get as close to as possible.
+		const targetTimestamp = this.withTimezone( this.props.date )
+			.startOf( 'day' )
+			.add( millisecondsSinceMidnight );
+
+		// Default to the first timestamp and calculate how many seconds it's offset from the target
+		let closestTimestamp = this.props.times[ 0 ];
+		let closestTimeOffset = Math.abs( closestTimestamp - targetTimestamp );
+
+		// Then look through all timestamps to find which one is the closest to the target
+		this.props.times.forEach( time => {
+			const offset = Math.abs( time - targetTimestamp );
+			if ( offset < closestTimeOffset ) {
+				closestTimestamp = time;
+				closestTimeOffset = offset;
+			}
+		} );
 
 		this.state = {
 			selectedTime: closestTimestamp,


### PR DESCRIPTION
Ref 502-gh-hg

Currently the `CalendarCard` defaults to the first available time, which is often in the very early hours of the morning for the user's given timezone.

<img width="743" alt="screen shot 2018-01-09 at 8 04 22 pm" src="https://user-images.githubusercontent.com/518059/34752586-d02186da-f578-11e7-8db0-df66814e994e.png">

We should default this to something more sensible, so this PR picks the time closest to the current clock time.

<img width="772" alt="screen shot 2018-01-09 at 8 10 20 pm" src="https://user-images.githubusercontent.com/518059/34752646-2b5368a2-f579-11e7-97d5-8debbbd44216.png">

### How to test

- Go to /me/concierge/<URLofYourBusinessSite.com>
- Enter info into the first step
- On the Calendar step, check each date — ensure that the default selected time is the closest option to the current time of day