### PR TITLE
Activity Log: Support upcoming `provisioning` state for Rewind

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -522,14 +522,13 @@ class ActivityLog extends Component {
 				) }
 				{ 'provisioning' === rewindState.state && (
 					<Banner
-						description={ translate(
-							"We're configuring your site. " +
-								"There's nothing more you need to do right now. " +
-								'Check back soon to see your updated Activity Log ' +
-								'or restore backups.'
-						) }
 						icon="history"
 						disableHref
+						title={ translate( 'Site configuration underway' ) }
+						description={ translate(
+							"There's nothing more you need to do right now. " +
+								"You'll be able to restore backups soon."
+						) }
 					/>
 				) }
 				{ this.renderErrorMessage() }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -520,6 +520,18 @@ class ActivityLog extends Component {
 						) }
 					/>
 				) }
+				{ 'provisioning' === rewindState.state && (
+					<Banner
+						description={ translate(
+							"We're configuring your site. " +
+								"There's nothing more you need to do right now. " +
+								'Check back soon to see your updated Activity Log ' +
+								'or restore backups.'
+						) }
+						icon="history"
+						disableHref
+					/>
+				) }
 				{ this.renderErrorMessage() }
 				{ hasFirstBackup && this.renderMonthNavigation() }
 				{ this.renderActionProgress() }

--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -31,23 +31,20 @@ const updateRewindState = ( { siteId }, data ) => ( {
 	data,
 } );
 
-const setUnknownState = ( { siteId }, { schemaErrors } ) => {
-	if ( schemaErrors ) {
-		return withAnalytics(
-			recordTracksEvent( 'rewind_state_parse_error', {
-				schemaErrors: JSON.stringify( schemaErrors, null, 2 ),
-			} ),
-			{
-				type: REWIND_STATE_UPDATE,
-				siteId,
-				data: {
-					state: 'unknown',
-					lastUpdated: new Date(),
-				},
-			}
-		);
-	}
-};
+const setUnknownState = ( { siteId }, error ) =>
+	withAnalytics(
+		recordTracksEvent( 'rewind_state_parse_error', {
+			error: JSON.stringify( error, null, 2 ),
+		} ),
+		{
+			type: REWIND_STATE_UPDATE,
+			siteId,
+			data: {
+				state: 'unknown',
+				lastUpdated: new Date(),
+			},
+		}
+	);
 
 export default mergeHandlers( downloads, {
 	[ REWIND_STATE_REQUEST ]: [

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -76,6 +76,22 @@ export const awaitingCredentials = {
 	required: [ 'state', 'last_updated' ],
 };
 
+export const provisioning = {
+	type: 'object',
+	properties: {
+		state: {
+			type: 'string',
+			pattern: '^provisioning$',
+		},
+		credentials: {
+			type: [ 'array', null ],
+			items: credential,
+		},
+		last_updated: { type: 'integer' },
+	},
+	required: [ 'state', 'last_updated' ],
+};
+
 export const active = {
 	type: 'object',
 	properties: {
@@ -98,5 +114,5 @@ export const active = {
 };
 
 export const rewind = {
-	oneOf: [ unavailable, inactive, awaitingCredentials, active ],
+	oneOf: [ unavailable, inactive, awaitingCredentials, provisioning, active ],
 };


### PR DESCRIPTION
Sometimes it takes a while between submitting everything a customer
needs in order to activate Rewind and the time we are actively
protecting the site.

In this time the server may report `provisioning` as the state.

In this patch we support that by means of augmenting the API fetching
logic and also by showing a banner indicating that Rewind is coming
soon.

![screen shot 2018-01-12 at 4 56 21 pm](https://user-images.githubusercontent.com/5431237/34896900-8d218748-f7b9-11e7-8f05-79187bea4847.png)


**Testing**

Apply D9172 and sandbox `public-api.wordpress.com`.
Open a site in the provisioning state and check for the banner.
Nothing else should change from before, except that in **master**
we're erroneously showing the `needs credentials` banner.

http://iscalypsofastyet.com/branch?branch=activity-log/support-provisioning-state

```
Delta:
chunk                                   stat_size           parsed_size           gzip_size
async-load-my-sites-stats-activity-log    +1585 B  (+0.5%)      +1044 B  (+0.7%)     +140 B  (+0.5%)
build                                      +215 B  (+0.0%)       +180 B  (+0.0%)       -1 B  (-0.0%)
manifest                                     +0 B                  +0 B                +0 B
```
  
  