### PR TITLE
Rewind: update path to fetch restore status

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/restore-status/index.js
@@ -47,7 +47,7 @@ const fetchProgress = ( { dispatch }, action ) => {
 			{
 				apiVersion: '1',
 				method: 'GET',
-				path: `/activity-log/${ siteId }/rewind/${ restoreId }/restore-status`,
+				path: `/activity-log/${ siteId }/rewind/restore-status/${ restoreId }`,
 			},
 			action
 		)


### PR DESCRIPTION
Rewind: update path for endpoint that returns the status of a specific restore.
Companion to D9128.
Required for https://github.com/Automattic/wp-calypso/pull/20656

#### Test
Apply D9128.
Perform a restore.
You should be able to see the progress.