### PR TITLE
Revert "esmodules: Update config"

### DIFF
--- a/client/config/index.js
+++ b/client/config/index.js
@@ -38,7 +38,4 @@ if ( process.env.NODE_ENV === 'development' || configData.env_id === 'stage' ) {
 	}
 }
 
-const configApi = createConfig( configData );
-
-export default configApi;
-export const isEnabled = configApi.isEnabled;
+export default createConfig( configData );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#21196

Something in the store broke and issued the following error:

```
TypeError: config is not a function
```

and in production

```
TypeError: s is not a function
```