### PR TITLE
esmodules: config (take 2)

### DIFF
--- a/client/config/index.js
+++ b/client/config/index.js
@@ -38,4 +38,7 @@ if ( process.env.NODE_ENV === 'development' || configData.env_id === 'stage' ) {
 	}
 }
 
-export default createConfig( configData );
+const configApi = createConfig( configData );
+
+export default configApi;
+export const isEnabled = configApi.isEnabled;

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -9,7 +9,7 @@ function getSectionsModule( sections ) {
 		let sectionPreLoaders = '';
 
 		const dependencies = [
-			"var config = require( 'config' ),",
+			"var config = require( 'config' ).default,",
 			"\tpage = require( 'page' ),",
 			"\tReact = require( 'react' ),",
 			"\tactivateNextLayoutFocus = require( 'state/ui/layout-focus/actions' ).activateNextLayoutFocus,",


### PR DESCRIPTION
reverts the revert: https://github.com/Automattic/wp-calypso/pull/21343

I believe this broke because `server/bundler/loader` isn't being put through babel the same way everything else is. I'm still confused as to why only store broke.  It could have to do with its interactions with extensions-loader.


To Test
- smoke test calyspo
- on an AT site try navigating to the store