### PR TITLE
Jetpack onboarding: make input fields mandatory in the Site Title step

### DIFF
--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -37,7 +37,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 		this.setState( { title: event.target.value } );
 	};
 
-	submit = () => {
+	handleSubmit = () => {
 		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
 			siteTitle: this.state.title,
 			siteDescription: this.state.description,
@@ -62,7 +62,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<Card className="steps__form">
-					<form>
+					<form onSubmit={ this.handleSubmit }>
 						<FormFieldset>
 							<FormLabel htmlFor="title">{ translate( 'Site Title' ) }</FormLabel>
 							<FormTextInput
@@ -70,6 +70,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 								id="title"
 								onChange={ this.setTitle }
 								value={ this.state.title }
+								required
 							/>
 						</FormFieldset>
 
@@ -79,10 +80,11 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 								id="description"
 								onChange={ this.setDescription }
 								value={ this.state.description }
+								required
 							/>
 						</FormFieldset>
 
-						<Button href={ this.props.getForwardUrl() } onClick={ this.submit } primary>
+						<Button primary type="submit" href={ this.props.getForwardUrl() }>
 							{ translate( 'Next Step' ) }
 						</Button>
 					</form>

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -43,7 +43,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 			siteTitle: this.state.title,
 			siteDescription: this.state.description,
 		} );
-		page( this.props.getForwardUrl() );
+		page.redirect( this.props.getForwardUrl() );
 	};
 
 	render() {
@@ -71,8 +71,8 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 								autoFocus
 								id="title"
 								onChange={ this.setTitle }
-								value={ this.state.title }
 								required
+								value={ this.state.title }
 							/>
 						</FormFieldset>
 
@@ -81,8 +81,8 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 							<FormTextarea
 								id="description"
 								onChange={ this.setDescription }
-								value={ this.state.description }
 								required
+								value={ this.state.description }
 							/>
 						</FormFieldset>
 

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -4,8 +4,9 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import page from 'page';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -42,6 +43,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 			siteTitle: this.state.title,
 			siteDescription: this.state.description,
 		} );
+		page( this.props.getForwardUrl() );
 	};
 
 	render() {
@@ -84,7 +86,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 							/>
 						</FormFieldset>
 
-						<Button primary type="submit" href={ this.props.getForwardUrl() }>
+						<Button primary type="submit">
 							{ translate( 'Next Step' ) }
 						</Button>
 					</form>


### PR DESCRIPTION
This patch sets up the`Next Step` button to perform a simple input validation in the Site Title step.

It is based on the premise that the form input fields should be filled in as much as possible because: 1) JPO steps turn out to be not so useful otherwise
2) there is a `Skip` option should users opt to leave all fields empty.

**To test:**
* Checkout this branch
* Go to `https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`, where `YourJetpackSandbox.com` is the domain of your JP sandbox
* In the first step of the flow verify that Title and Description are required fields to move forward using `Next Step` (prompted to be filled when left empty)
  
*Idea/Q:* the default styling of the mandatory fields: 
![screen shot 2018-01-08 at 23 15 39](https://user-images.githubusercontent.com/13561163/34697167-d165ac06-f4c9-11e7-9d87-8010f27d0c81.png)
Should we adapt it or leave as-is? /cc @MichaelArestad 

*Note:*  this is an MVP version and we may want to switch to `redux-form` for next iterations.
  
  
  
  