### PR TITLE
Store: Add image and description fields to product category management

### DIFF
--- a/client/extensions/woocommerce/app/product-categories/create.js
+++ b/client/extensions/woocommerce/app/product-categories/create.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isEmpty, omit } from 'lodash';
+import { isEmpty, omit, isNumber } from 'lodash';
 
 /**
  * Internal dependencies
@@ -43,12 +43,11 @@ class ProductCategoryCreate extends React.Component {
 	};
 
 	componentDidMount() {
-		const { category, site } = this.props;
+		const { site } = this.props;
 
 		if ( site && site.ID ) {
-			if ( ! category ) {
-				this.props.editProductCategory( site.ID, null, {} );
-			}
+			this.props.clearProductCategoryEdits( site.ID );
+			this.props.editProductCategory( site.ID, null, {} );
 		}
 	}
 
@@ -57,6 +56,7 @@ class ProductCategoryCreate extends React.Component {
 		const newSiteId = ( newProps.site && newProps.site.ID ) || null;
 		const oldSiteId = ( site && site.ID ) || null;
 		if ( oldSiteId !== newSiteId ) {
+			this.props.clearProductCategoryEdits( newSiteId );
 			this.props.editProductCategory( newSiteId, null, {} );
 		}
 	}
@@ -95,7 +95,8 @@ class ProductCategoryCreate extends React.Component {
 function mapStateToProps( state ) {
 	const site = getSelectedSiteWithFallback( state );
 	const categoryId = getCurrentlyEditingId( state );
-	const category = getProductCategoryWithLocalEdits( state, categoryId );
+	const category =
+		! isNumber( categoryId ) && getProductCategoryWithLocalEdits( state, categoryId );
 	const hasEdits = ! isEmpty( omit( getProductCategoryEdits( state, categoryId ), 'id' ) );
 
 	return {

--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -131,7 +131,7 @@ class ProductCategoryForm extends Component {
 		} else if ( isUploading ) {
 			image = (
 				<figure>
-					<img src={ placeholder || <span /> } />
+					<img src={ placeholder || null } />
 					<Spinner />
 				</figure>
 			);

--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -8,12 +8,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { isNumber } from 'lodash';
+import { debounce, isNumber } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
+import CompactTinyMCE from 'woocommerce/components/compact-tinymce';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
@@ -28,10 +29,21 @@ class ProductCategoryForm extends Component {
 		editProductCategory: PropTypes.func.isRequired,
 	};
 
+	constructor( props ) {
+		super( props );
+
+		this.debouncedSetDescription = debounce( this.setDescription, 200 );
+	}
+
 	setName = e => {
 		const { siteId, category, editProductCategory } = this.props;
 		const name = e.target.value;
 		editProductCategory( siteId, category, { name } );
+	};
+
+	setDescription = description => {
+		const { siteId, category, editProductCategory } = this.props;
+		editProductCategory( siteId, category, { description } );
 	};
 
 	renderPlaceholder() {
@@ -40,6 +52,24 @@ class ProductCategoryForm extends Component {
 			<div className={ classNames( 'product-categories__form', 'is-placeholder', className ) }>
 				<div />
 			</div>
+		);
+	}
+
+	renderTinyMCE() {
+		const { category } = this.props;
+
+		if (
+			( isNumber( category.id ) && 'undefined' === typeof category.description ) ||
+			'undefined' === typeof category.id
+		) {
+			return <div className="product-categories__form-tinymce-placeholder" />;
+		}
+
+		return (
+			<CompactTinyMCE
+				initialValue={ category.description || '' }
+				onContentsChange={ this.debouncedSetDescription }
+			/>
 		);
 	}
 
@@ -57,6 +87,10 @@ class ProductCategoryForm extends Component {
 					<FormFieldSet>
 						<FormLabel htmlFor="name">{ translate( 'Category name' ) }</FormLabel>
 						<FormTextInput id="name" value={ category.name || '' } onChange={ this.setName } />
+					</FormFieldSet>
+					<FormFieldSet>
+						<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
+						{ this.renderTinyMCE() }
 					</FormFieldSet>
 				</Card>
 			</div>

--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -7,17 +7,22 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import { debounce, isNumber } from 'lodash';
+import { debounce, isNumber, head } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Card from 'components/card';
 import CompactTinyMCE from 'woocommerce/components/compact-tinymce';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
+import ImagePreloader from 'components/image-preloader';
+import ProductImageUploader from 'woocommerce/components/product-image-uploader';
+import Spinner from 'components/spinner';
 
 class ProductCategoryForm extends Component {
 	static propTypes = {
@@ -32,7 +37,28 @@ class ProductCategoryForm extends Component {
 	constructor( props ) {
 		super( props );
 
+		const { category } = props;
+		const image = ( category && category.image ) || {};
+
+		this.state = {
+			id: image.id || null,
+			src: image.src || null,
+			placeholder: null,
+			transientId: null,
+			isUploading: false,
+		};
+
 		this.debouncedSetDescription = debounce( this.setDescription, 200 );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.category !== this.props.category ) {
+			const image = ( nextProps.category && nextProps.category.image ) || {};
+			this.setState( {
+				id: image.id || null,
+				src: image.src || null,
+			} );
+		}
 	}
 
 	setName = e => {
@@ -44,6 +70,101 @@ class ProductCategoryForm extends Component {
 	setDescription = description => {
 		const { siteId, category, editProductCategory } = this.props;
 		editProductCategory( siteId, category, { description } );
+	};
+
+	onSelect = files => {
+		const file = head( files );
+		this.setState( {
+			placeholder: file.preview,
+			transientId: file.ID,
+			isUploading: true,
+		} );
+	};
+
+	onUpload = file => {
+		const { siteId, editProductCategory, category } = this.props;
+		const image = {
+			src: file.URL,
+			id: file.ID,
+		};
+		this.setState( {
+			...image,
+			transientId: null,
+			isUploading: false,
+		} );
+		editProductCategory( siteId, category, { image } );
+	};
+
+	onError = () => {
+		this.setState( {
+			placeholder: null,
+			transientId: null,
+			isUploading: false,
+		} );
+	};
+
+	removeImage = () => {
+		const { siteId, editProductCategory, category } = this.props;
+		this.setState( {
+			placeholder: null,
+			transientId: null,
+			isUploading: false,
+			src: null,
+			id: null,
+		} );
+		editProductCategory( siteId, category, { image: {} } );
+	};
+
+	renderImage = () => {
+		const { src, placeholder, isUploading } = this.state;
+
+		let image = null;
+		if ( src && ! isUploading ) {
+			image = (
+				<figure>
+					<ImagePreloader
+						src={ src }
+						placeholder={ ( placeholder && <img src={ placeholder } /> ) || <span /> }
+					/>
+				</figure>
+			);
+		} else if ( isUploading ) {
+			image = (
+				<figure>
+					<img src={ placeholder || <span /> } />
+					<Spinner />
+				</figure>
+			);
+		}
+
+		const classes = classNames( 'product-categories__form-image', {
+			preview: null === src,
+			uploader: ! image,
+		} );
+
+		const removeButton = image && (
+			<Button
+				compact
+				onClick={ this.removeImage }
+				className="product-categories__form-image-remove"
+			>
+				<Gridicon icon="cross" size={ 24 } className="product-categories__form-image-remove-icon" />
+			</Button>
+		);
+
+		return (
+			<div className={ classes }>
+				<ProductImageUploader
+					multiple={ false }
+					onSelect={ this.onSelect }
+					onUpload={ this.onUpload }
+					onError={ this.onError }
+				>
+					{ image }
+				</ProductImageUploader>
+				{ removeButton }
+			</div>
+		);
 	};
 
 	renderPlaceholder() {
@@ -84,14 +205,19 @@ class ProductCategoryForm extends Component {
 		return (
 			<div className={ classNames( 'product-categories__form', this.props.className ) }>
 				<Card>
-					<FormFieldSet>
-						<FormLabel htmlFor="name">{ translate( 'Category name' ) }</FormLabel>
-						<FormTextInput id="name" value={ category.name || '' } onChange={ this.setName } />
-					</FormFieldSet>
-					<FormFieldSet>
-						<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
-						{ this.renderTinyMCE() }
-					</FormFieldSet>
+					<div className="product-categories__form-info-fields">
+						<div className="product-categories__form-image-wrapper">{ this.renderImage() }</div>
+						<div className="product-categories__form-name-description">
+							<FormFieldSet>
+								<FormLabel htmlFor="name">{ translate( 'Category name' ) }</FormLabel>
+								<FormTextInput id="name" value={ category.name || '' } onChange={ this.setName } />
+							</FormFieldSet>
+							<FormFieldSet>
+								<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
+								{ this.renderTinyMCE() }
+							</FormFieldSet>
+						</div>
+					</div>
 				</Card>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -118,3 +118,112 @@
 .product-categories__form .compact-tinymce  .mce-container.mce-tinymce {
 	max-width: initial;
 }
+
+.product-categories__form-info-fields {
+	display: flex;
+	flex-direction: column;
+	@include breakpoint( ">960px" ) {
+		flex-direction: row;
+	}
+}
+
+.product-categories__form-name-description {
+	flex: 2
+}
+
+.product-categories__form-image-wrapper {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+
+	width: 100%;
+	margin-bottom: 16px;
+
+	@include breakpoint( ">960px" ) {
+		margin-bottom: 0;
+		width: 250px;
+		margin-right: 24px;
+	}
+
+	@include breakpoint( ">1040px" ) {
+		width: 339px;
+	}
+
+	.product-categories__form-image {
+		position: relative;
+		display: inline-block;
+		margin-bottom: 16px;
+		margin-right: 0;
+		margin-left: 0;
+		clear: both;
+		width: 100%;
+		cursor: pointer;
+
+		figure {
+			border: 1px solid lighten( $gray, 30% );
+		}
+
+		img {
+			display: block;
+			width: 100%;
+			height: auto;
+		}
+	}
+
+	figure {
+		position: relative;
+		overflow: hidden;
+	}
+
+	.product-categories__form-image.preview figure::after {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+	}
+
+	.product-categories__form-image.preview img {
+		opacity: 0.7;
+	}
+
+	.spinner {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% );
+	}
+
+	.product-categories__form-image-remove {
+		position: absolute;
+		top: 0;
+		right: 0;
+		width: 28px;
+		height: 28px;
+		transform: translate( 25%, -25% );
+		border: 1px solid lighten( $gray, 10% );
+		border-radius: 50%;
+		background-color: $gray-light;
+		cursor: pointer;
+
+		&:hover {
+			background: lighten( $gray, 30% );
+		}
+	}
+
+	.product-categories__form-image-remove-icon.gridicon {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% );
+		width: 24px;
+		height: 24px;
+		margin: 0;
+		color: lighten( $gray, 10% );
+
+		&:hover {
+			color: $gray;
+		}
+	}
+}
+

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -107,3 +107,14 @@
 		}
 	}
 }
+
+.product-categories__form-tinymce-placeholder {
+	@include placeholder();
+	background: lighten( $gray, 35% );
+	height: 225px;
+	border: 1px solid lighten( $gray, 20% );
+}
+
+.product-categories__form .compact-tinymce  .mce-container.mce-tinymce {
+	max-width: initial;
+}

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -202,13 +202,16 @@ class ProductImageUploader extends Component {
 
 	renderUploader() {
 		const { translate, multiple } = this.props;
+
+		const addString = multiple ? translate( 'Add images' ) : translate( 'Add image' );
+
 		return (
 			<div className="product-image-uploader__wrapper">
 				<div className="product-image-uploader__picker">
 					<FilePicker multiple={ multiple } accept="image/*" onPick={ this.onPick }>
 						<div>
 							<Gridicon icon="add-image" size={ 36 } />
-							<p>{ translate( 'Add images' ) }</p>
+							<p>{ addString }</p>
 						</div>
 					</FilePicker>
 				</div>


### PR DESCRIPTION
This PR continues building out the product category management form (see #20295) by adding a description field, and image management.

To Test:
* Boot up this branch and visit `http://calypso.localhost:3000/store/products/categories/:store`.
* Select a category with an image and description (create one via wp-admin if you need to)
* Make sure that the image loads, and the description ends up in the TinyMCE instance.
* Verify you can type in the description field.
* Remove the image using the "x".
* Add a new image and verify successful upload.
* Test again by going back to the category listing and selecting the "Add category" button and testing in the create context.
* You can also monitor these updates via the Redux dev tools, to make sure edits state is being properly updated.

Note: Saving has not been hooked up yet.

<img width="1088" alt="screen shot 2018-01-08 at 2 36 33 pm" src="https://user-images.githubusercontent.com/689165/34696242-d97ce3ba-f482-11e7-8f68-dbc2a7c05216.png">

<img width="1135" alt="screen shot 2018-01-08 at 2 38 00 pm" src="https://user-images.githubusercontent.com/689165/34696285-00d4db66-f483-11e7-9b48-0dfb568cf72f.png">
