### PR TITLE
Activity Log: Shuffle dialogs into `ActivityLogItem`

### DIFF
--- a/client/my-sites/stats/activity-log-day/index.jsx
+++ b/client/my-sites/stats/activity-log-day/index.jsx
@@ -1,15 +1,12 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { compact, flatMap, get, isEmpty, zip } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +14,7 @@ import { compact, flatMap, get, isEmpty, zip } from 'lodash';
 import ActivityLogItem from '../activity-log-item';
 import FoldableCard from 'components/foldable-card';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getActivityLog, getRewindEvents } from 'state/selectors';
+import { getActivityLog, getRequestedRewind, getRewindEvents } from 'state/selectors';
 import { ms, makeIsDiscarded } from 'state/activity-log/log/is-discarded';
 
 /**
@@ -25,46 +22,7 @@ import { ms, makeIsDiscarded } from 'state/activity-log/log/is-discarded';
  */
 const DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
 
-/**
- * Classifies events in a sorted list into pairs of a
- * classifier and the event itself (for rendering)
- *
- * @param {Array} logs sorted activity log items
- * @param {?Number} backupId selected backup operation
- * @param {?Number} restoreId selected rewind operation
- * @returns {Array<String, ?Object>} pairs of [ classifier, event ]
- */
-const classifyEvents = ( logs, { backupId = null, rewindId = null } ) =>
-	// the zip pairs up each log item with the following log item in the stream or undefined if at end
-	flatMap( zip( logs, logs.slice( 1 ) ), ( [ log, nextLog = {} ] ) =>
-		compact( [
-			log.activityId === rewindId && [ 'rewind-confirm-dialog', {} ],
-			log.activityId === backupId && [ 'backup-confirm-dialog', {} ],
-			[ nextLog.activityId === rewindId ? 'timeline-break-event' : 'event', log ],
-		] )
-	);
-
 class ActivityLogDay extends Component {
-	static propTypes = {
-		applySiteOffset: PropTypes.func.isRequired,
-		disableRestore: PropTypes.bool.isRequired,
-		disableBackup: PropTypes.bool.isRequired,
-		isRewindActive: PropTypes.bool,
-		logs: PropTypes.array.isRequired,
-		requestedRestoreId: PropTypes.string,
-		requestedBackupId: PropTypes.string,
-		requestDialog: PropTypes.func.isRequired,
-		closeDialog: PropTypes.func.isRequired,
-		restoreConfirmDialog: PropTypes.element,
-		backupConfirmDialog: PropTypes.element,
-		siteId: PropTypes.number,
-		tsEndOfSiteDay: PropTypes.number.isRequired,
-
-		// Connected props
-		isToday: PropTypes.bool.isRequired,
-		trackOpenDay: PropTypes.func.isRequired,
-	};
-
 	static defaultProps = {
 		disableRestore: false,
 		disableBackup: false,
@@ -84,19 +42,6 @@ class ActivityLogDay extends Component {
 			} );
 		}
 	}
-
-	handleClickRestore = event => {
-		event.stopPropagation();
-		this.setState( {
-			rewindHere: true,
-			dayExpanded: true,
-		} );
-		const { logs, requestDialog } = this.props;
-		const lastLogId = get( logs, [ 0, 'activityId' ], null );
-		if ( lastLogId ) {
-			requestDialog( lastLogId, 'day', 'restore' );
-		}
-	};
 
 	handleOpenDay = () =>
 		this.setState(
@@ -157,17 +102,14 @@ class ActivityLogDay extends Component {
 
 	render() {
 		const {
-			backupConfirmDialog,
 			disableBackup,
 			disableRestore,
 			isDiscardedPerspective,
 			isRewindActive,
 			isToday,
 			logs,
-			requestDialog,
 			requestedBackupId,
 			requestedRestoreId,
-			restoreConfirmDialog,
 			rewindEvents,
 			siteId,
 			tsEndOfSiteDay,
@@ -182,26 +124,8 @@ class ActivityLogDay extends Component {
 				( tsEndOfSiteDay <= activityTs && activityTs < tsEndOfSiteDay + DAY_IN_MILLISECONDS )
 		);
 
-		const events = classifyEvents( logs, {
-			backupId: requestedBackupId,
-			rewindId: requestedRestoreId,
-		} );
-
 		const isDiscarded =
 			isDiscardedPerspective && makeIsDiscarded( rewindEvents, isDiscardedPerspective );
-
-		const LogItem = ( { log, hasBreak } ) => (
-			<ActivityLogItem
-				className={ hasBreak ? 'is-before-dialog' : '' }
-				activityId={ log.activityId }
-				disableRestore={ disableRestore }
-				disableBackup={ disableBackup }
-				hideRestore={ ! isRewindActive }
-				isDiscarded={ isDiscarded ? isDiscarded( log.activityTs ) : log.activityIsDiscarded }
-				requestDialog={ requestDialog }
-				siteId={ siteId }
-			/>
-		);
 
 		return (
 			<FoldableCard
@@ -214,23 +138,17 @@ class ActivityLogDay extends Component {
 				onOpen={ this.handleOpenDay }
 				onClose={ this.handleCloseDay( hasConfirmDialog ) }
 			>
-				{ events.map( ( [ type, log ] ) => {
-					const key = log.activityId;
-
-					switch ( type ) {
-						case 'backup-confirm-dialog':
-							return backupConfirmDialog;
-
-						case 'event':
-							return <LogItem { ...{ key, log } } />;
-
-						case 'timeline-break-event':
-							return <LogItem { ...{ key, log, hasBreak: true } } />;
-
-						case 'rewind-confirm-dialog':
-							return restoreConfirmDialog;
-					}
-				} ) }
+				{ logs.map( log => (
+					<ActivityLogItem
+						key={ log.activityId }
+						activityId={ log.activityId }
+						disableRestore={ disableRestore }
+						disableBackup={ disableBackup }
+						hideRestore={ ! isRewindActive }
+						isDiscarded={ isDiscarded ? isDiscarded( log.activityTs ) : log.activityIsDiscarded }
+						siteId={ siteId }
+					/>
+				) ) }
 			</FoldableCard>
 		);
 	}
@@ -238,7 +156,8 @@ class ActivityLogDay extends Component {
 
 export default localize(
 	connect(
-		( state, { logs, siteId, requestedRestoreId } ) => {
+		( state, { logs, siteId } ) => {
+			const requestedRestoreId = getRequestedRewind( state, siteId );
 			const rewindEvents = getRewindEvents( state, siteId );
 			const isDiscardedPerspective = requestedRestoreId
 				? new Date( ms( getActivityLog( state, siteId, requestedRestoreId ).activityTs ) )

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -5,6 +5,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
+import scrollTo from 'lib/scroll-to';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,18 +13,34 @@ import { localize } from 'i18n-calypso';
  */
 import ActivityActor from './activity-actor';
 import ActivityIcon from './activity-icon';
+import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
 import SplitButton from 'components/split-button';
 import FoldableCard from 'components/foldable-card';
 import FormattedBlock from 'components/notes-formatted-block';
 import PopoverMenuItem from 'components/popover/menu-item';
-import { getActivityLog, getSiteGmtOffset, getSiteTimezoneValue } from 'state/selectors';
+import {
+	rewindBackup,
+	rewindBackupDismiss,
+	rewindRequestBackup,
+	rewindRequestDismiss,
+	rewindRequestRestore,
+	rewindRestore,
+} from 'state/activity-log/actions';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+import {
+	getActivityLog,
+	getRequestedBackup,
+	getRequestedRewind,
+	getSiteGmtOffset,
+	getSiteTimezoneValue,
+} from 'state/selectors';
 
 import { adjustMoment } from '../activity-log/utils';
 
 class ActivityLogItem extends Component {
-	handleClickRestore = () => this.props.requestDialog( this.props.activityId, 'item', 'restore' );
+	confirmBackup = () => this.props.confirmBackup( this.props.activity.rewindId );
 
-	handleClickBackup = () => this.props.requestDialog( this.props.activityId, 'item', 'backup' );
+	confirmRewind = () => this.props.confirmRewind( this.props.activity.rewindId );
 
 	renderHeader() {
 		const {
@@ -50,6 +67,8 @@ class ActivityLogItem extends Component {
 
 	renderItemAction() {
 		const {
+			createBackup,
+			createRewind,
 			disableRestore,
 			disableBackup,
 			hideRestore,
@@ -66,7 +85,7 @@ class ActivityLogItem extends Component {
 				<SplitButton
 					icon="history"
 					label={ translate( 'Rewind' ) }
-					onClick={ this.handleClickRestore }
+					onClick={ createRewind }
 					disableMain={ disableRestore }
 					disabled={ disableRestore && disableBackup }
 					compact
@@ -75,7 +94,7 @@ class ActivityLogItem extends Component {
 					<PopoverMenuItem
 						disabled={ disableBackup }
 						icon="cloud-download"
-						onClick={ this.handleClickBackup }
+						onClick={ createBackup }
 					>
 						{ translate( 'Download backup' ) }
 					</PopoverMenuItem>
@@ -85,46 +104,151 @@ class ActivityLogItem extends Component {
 	}
 
 	render() {
-		const { activity, className, gmtOffset, isDiscarded, moment, timezone } = this.props;
+		const {
+			activity,
+			className,
+			dismissBackup,
+			dismissRewind,
+			gmtOffset,
+			isDiscarded,
+			mightBackup,
+			mightRewind,
+			moment,
+			timezone,
+			translate,
+		} = this.props;
 		const { activityIcon, activityStatus, activityTs } = activity;
 
 		const classes = classNames( 'activity-log-item', className, {
 			'is-discarded': isDiscarded,
 		} );
 
+		const adjustedTime = adjustMoment( { gmtOffset, moment: moment.utc( activityTs ), timezone } );
+
 		return (
-			<div className={ classes }>
-				<div className="activity-log-item__type">
-					<div className="activity-log-item__time">
-						{ adjustMoment( {
-							gmtOffset,
-							moment: moment.utc( activityTs ),
-							timezone,
-						} ).format( 'LT' ) }
+			<React.Fragment>
+				{ mightRewind && (
+					<ActivityLogConfirmDialog
+						key="activity-rewind-dialog"
+						confirmTitle={ translate( 'Confirm Rewind' ) }
+						notice={
+							// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+							<span className="activity-log-confirm-dialog__notice-content">
+								{ translate(
+									'This will remove all content and options created or changed since then.'
+								) }
+							</span>
+						}
+						onClose={ dismissRewind }
+						onConfirm={ this.confirmRewind }
+						supportLink="https://jetpack.com/support/how-to-rewind"
+						title={ translate( 'Rewind Site' ) }
+					>
+						{ translate(
+							'This is the selected point for your site Rewind. ' +
+								'Are you sure you want to rewind your site back to {{time/}}?',
+							{
+								components: {
+									time: <b>{ adjustedTime.format( 'LLL' ) }</b>,
+								},
+							}
+						) }
+					</ActivityLogConfirmDialog>
+				) }
+				{ mightBackup && (
+					<ActivityLogConfirmDialog
+						key="activity-backup-dialog"
+						confirmTitle={ translate( 'Create download' ) }
+						onClose={ dismissBackup }
+						onConfirm={ this.confirmBackup }
+						supportLink="https://jetpack.com/support/backups"
+						title={ translate( 'Create downloadable backup' ) }
+						type={ 'backup' }
+						icon={ 'cloud-download' }
+					>
+						{ translate(
+							'We will build a downloadable backup of your site at {{time/}}. ' +
+								'You will get a notification when the backup is ready to download.',
+							{
+								components: {
+									time: <b>{ adjustedTime.format( 'LLL' ) }</b>,
+								},
+							}
+						) }
+					</ActivityLogConfirmDialog>
+				) }
+				<div className={ classes }>
+					<div className="activity-log-item__type">
+						<div className="activity-log-item__time">{ adjustedTime.format( 'LT' ) }</div>
+						<ActivityIcon activityIcon={ activityIcon } activityStatus={ activityStatus } />
 					</div>
-					<ActivityIcon activityIcon={ activityIcon } activityStatus={ activityStatus } />
+					<FoldableCard
+						className="activity-log-item__card"
+						expandedSummary={ this.renderItemAction() }
+						header={ this.renderHeader() }
+						summary={ this.renderItemAction() }
+					/>
 				</div>
-				<FoldableCard
-					className="activity-log-item__card"
-					expandedSummary={ this.renderItemAction() }
-					header={ this.renderHeader() }
-					summary={ this.renderItemAction() }
-				/>
-			</div>
+			</React.Fragment>
 		);
 	}
 }
 
-const mapStateToProps = ( state, { activityId, siteId } ) => {
-	const activity = getActivityLog( state, siteId, activityId );
-	const gmtOffset = getSiteGmtOffset( state, siteId );
-	const timezone = getSiteTimezoneValue( state, siteId );
+const mapStateToProps = ( state, { activityId, siteId } ) => ( {
+	activity: getActivityLog( state, siteId, activityId ),
+	gmtOffset: getSiteGmtOffset( state, siteId ),
+	mightBackup: activityId && activityId === getRequestedBackup( state, siteId ),
+	mightRewind: activityId && activityId === getRequestedRewind( state, siteId ),
+	timezone: getSiteTimezoneValue( state, siteId ),
+} );
 
-	return {
-		activity,
-		gmtOffset,
-		timezone,
-	};
-};
+const mapDispatchToProps = ( dispatch, { activityId, siteId } ) => ( {
+	createBackup: () =>
+		dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_activitylog_backup_request', { from: 'item' } ),
+				rewindRequestBackup( siteId, activityId )
+			)
+		),
+	createRewind: () =>
+		dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_activitylog_restore_request', { from: 'item' } ),
+				rewindRequestRestore( siteId, activityId )
+			)
+		),
+	dismissBackup: () =>
+		dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_activitylog_backup_cancel' ),
+				rewindBackupDismiss( siteId )
+			)
+		),
+	dismissRewind: () =>
+		dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_activitylog_restore_cancel' ),
+				rewindRequestDismiss( siteId )
+			)
+		),
+	confirmBackup: rewindId => (
+		scrollTo( { x: 0, y: 0, duration: 250 } ),
+		dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_activitylog_backup_confirm', { actionId: rewindId } ),
+				rewindBackup( siteId, rewindId )
+			)
+		)
+	),
+	confirmRewind: rewindId => (
+		scrollTo( { x: 0, y: 0, duration: 250 } ),
+		dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_activitylog_restore_confirm', { actionId: rewindId } ),
+				rewindRestore( siteId, rewindId )
+			)
+		)
+	),
+} );
 
-export default connect( mapStateToProps )( localize( ActivityLogItem ) );
+export default connect( mapStateToProps, mapDispatchToProps )( localize( ActivityLogItem ) );


### PR DESCRIPTION
This continues the work of #21320 to move logic into the Activity Log
itmes so they operate more as independent React components.

This patch brings us closer to the point where we won't have to recreate
all of the items on every render to the Activity Log view, thus
eliminating visual glitches and awkward state updates.

**Note**

<del>Currently this removes the timeline break in the activity stream view. We
can put it back in but it's gone in the process of figuring out why React
is recreating every item on every render.</del>

<ins>Apparently we weren't even styling the break so its removal is benign. I compared against **master** and it's demonstrating identical behavior, which is good, because it simplifies the render logic significantly not having it there.</ins>

**Testing**

This affects the opening, closing, and confirmation of the restore and
download file dialogs in Rewind. Make sure that we can perform those
actions properly.

**Before**
![rewinddestroyingeverything mov](https://user-images.githubusercontent.com/5431237/34859166-8cebe6f2-f722-11e7-8b42-fbcd43750883.gif)

**After**
![rewindnotdestroyingeverything mov](https://user-images.githubusercontent.com/5431237/34859141-73e94cb2-f722-11e7-970a-ad66aaa00b38.gif)

http://iscalypsofastyet.com/branch?branch=activity-log/shuffle-dialogs-to-item

```
Delta:
chunk                                   stat_size           parsed_size           gzip_size
async-load-my-sites-stats-activity-log    -3502 B  (-1.2%)      -1578 B  (-1.0%)     -398 B  (-1.4%)
build                                        +0 B                  -8 B  (-0.0%)       +0 B
manifest                                     +0 B                  +0 B                +0 B
```