### PR TITLE
Rewind: Use v2 `/rewind` endpoint

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -15,7 +15,7 @@ import downloads from './downloads';
 const fetchRewindState = action =>
 	http(
 		{
-			apiVersion: '1.1',
+			apiNamespace: 'wpcom/v2',
 			method: 'GET',
 			path: `/sites/${ action.siteId }/rewind`,
 			query: {


### PR DESCRIPTION
The v1.1 endpoint slipped in and we forgot to update it to v2 once we
rebuilt the API in the v2 system.

In this patch we update the URL so we hit the proper and newer version.

The data being returned should have been identical in all but
exceptional calls.

**Testing**

Smoke testing should be good - this should be a transparent update.