### PR TITLE
Allow checklist tasks to be launched from checklist banner

### DIFF
--- a/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
@@ -42,6 +42,7 @@ export const ChecklistSiteTaglineTour = makeTour(
 				) }
 			</p>
 			<ButtonRow>
+				<Continue target="settings-site-profile-save" step="finish" click hidden />
 				<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
 				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 			</ButtonRow>

--- a/client/layout/guided-tours/tours/checklist-site-title-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour.js
@@ -42,6 +42,7 @@ export const ChecklistSiteTitleTour = makeTour(
 				) }
 			</p>
 			<ButtonRow>
+				<Continue target="settings-site-profile-save" step="finish" click hidden />
 				<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
 				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 			</ButtonRow>

--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -7,7 +7,6 @@
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { find } from 'lodash';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -23,7 +22,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteChecklist } from 'state/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
-import { onboardingTasks, tourForTask, urlForTask } from '../onboardingChecklist';
+import { launchTask, launchCompletedTask, onboardingTasks } from '../onboardingChecklist';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { createNotice } from 'state/notices/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
@@ -32,26 +31,20 @@ class ChecklistShow extends PureComponent {
 	onAction = id => {
 		const { requestTour, siteSlug, siteChecklist, track } = this.props;
 
-		const tour = tourForTask( id );
-		const url = urlForTask( id, siteSlug );
-
-		if ( siteChecklist && siteChecklist.tasks && ( url || tour ) ) {
+		if ( siteChecklist && siteChecklist.tasks ) {
 			if ( siteChecklist.tasks[ id ] ) {
-				if ( url ) {
-					page( url );
-				}
-			} else {
-				track( 'calypso_checklist_task_start', {
-					checklist_name: 'new_blog',
-					step_name: id,
+				launchCompletedTask( {
+					id,
+					siteSlug,
 				} );
-
-				if ( url ) {
-					page( url );
-				}
-				if ( tour ) {
-					requestTour( tour );
-				}
+			} else {
+				launchTask( {
+					id,
+					location: 'checklist_show',
+					requestTour,
+					siteSlug,
+					track,
+				} );
 			}
 		}
 	};

--- a/client/my-sites/checklist/checklist-thank-you/index.jsx
+++ b/client/my-sites/checklist/checklist-thank-you/index.jsx
@@ -108,7 +108,7 @@ const mapStateToProps = state => {
 	const siteChecklist = getSiteChecklist( state, siteId );
 	const tasks = siteChecklist ? onboardingTasks( siteChecklist.tasks ) : [];
 
-	return { siteId, siteSlug, tasks };
+	return { siteChecklist, siteId, siteSlug, tasks };
 };
 
 const mapDispatchToProps = {

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -5,6 +5,7 @@
  */
 
 import { assign, map } from 'lodash';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -149,3 +150,33 @@ export const onboardingTasks = currentState =>
 		const task = tasks[ id ];
 		return assign( { id, completed }, task );
 	} );
+
+export const launchTask = ( { id, location, requestTour, siteSlug, track } ) => {
+	const checklist_name = 'new_blog';
+	const tour = tourForTask( id );
+	const url = urlForTask( id, siteSlug );
+
+	if ( ! tour && ! url ) {
+		return;
+	}
+
+	track( 'calypso_checklist_task_start', {
+		checklist_name,
+		step_name: id,
+		location,
+	} );
+
+	if ( url ) {
+		page( url );
+	}
+	if ( tour ) {
+		requestTour( tour );
+	}
+};
+
+export const launchCompletedTask = ( { id, siteSlug } ) => {
+	const url = urlForTask( id, siteSlug );
+	if ( url ) {
+		page( url );
+	}
+};

--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { countBy, find, noop } from 'lodash';
 import Gridicon from 'gridicons';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -24,8 +23,9 @@ import ShareButton from 'components/share-button';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import { getSiteChecklist } from 'state/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
-import { onboardingTasks, urlForTask } from 'my-sites/checklist/onboardingChecklist';
+import { launchTask, onboardingTasks } from 'my-sites/checklist/onboardingChecklist';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 
 const storageKey = 'onboarding-checklist-banner-closed';
 
@@ -55,12 +55,15 @@ export class ChecklistBanner extends Component {
 	};
 
 	handleClick = () => {
-		const { task, siteSlug } = this.props;
-		const url = urlForTask( task.id, siteSlug );
+		const { requestTour, task, track, siteSlug } = this.props;
 
-		if ( url ) {
-			page( url );
-		}
+		launchTask( {
+			id: task.id,
+			location: 'checklist_banner',
+			requestTour,
+			siteSlug,
+			track,
+		} );
 	};
 
 	handleClose = () => {
@@ -202,6 +205,9 @@ const mapStateToProps = ( state, { siteId } ) => {
 	};
 };
 
-const mapDispatchToProps = { track: recordTracksEvent };
+const mapDispatchToProps = {
+	track: recordTracksEvent,
+	requestTour: requestGuidedTour,
+};
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( ChecklistBanner ) );


### PR DESCRIPTION
Some of the ChecklistShow logic had been duplicated in both the ChecklistBanner and ChecklistThankYou components but did not include launching guided tours or notifications.

This PR moves the logic to functions that can be shared between these two components.

# Testing

- enable tracks debugging (`localStorage.setItem('debug', 'calypso:analytics:tracks');`)
- sign up a new site
- click on a few tasks on the thank you page, verify that the tours appear and tracks events are fired
- click on the next task on the checklist banner displayed on the site stats page and check that the tours appear and tracks events are fired
- click on a few incomplete tasks in the `/checklist/<site>` checklist component and verify the same

note that each of the three above tracks events should include a different 'location' attribute to distinguish where the event has been triggered.
  