### PR TITLE
Fixed: remove the wrong reference 'router' in gsuiteNudge() of the checkout controller

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -131,7 +131,7 @@ export default {
 
 	gsuiteNudge( context, next ) {
 		const CartData = require( 'components/data/cart' );
-		const { routePath, routeParams } = route.sectionifyWithRoutes( context.path, checkoutRoutes );
+		const { routePath, routeParams } = sectionifyWithRoutes( context.path, checkoutRoutes );
 		const { domain, site, receiptId } = context.params;
 		context.store.dispatch( setSection( { name: 'gsuite-nudge' }, { hasSidebar: false } ) );
 


### PR DESCRIPTION
This can cause a fatal error when you try to move to the g suite upsell page.