### PR TITLE
Stop using SCSS function 'random()' and make builds repeatable and stable

### DIFF
--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -182,61 +182,61 @@
 	.gridicon:nth-child(1) {
 		top: 18px;
 		left: 14.8%;
-		animation-delay: random(10) + s;
+		animation-delay: 6s;
 	}
 	.gridicon:nth-child(2) {
 		top: 118px;
 		left: 67.4%;
-		animation-delay: random(10) + s;
+		animation-delay: 4s;
 	}
 	.gridicon:nth-child(3) {
 		top: 108px;
 		left: 86.2%;
-		animation-delay: random(10) + s;
+		animation-delay: 7s;
 	}
 	.gridicon:nth-child(4) {
 		top: 190px;
 		left: 8.4%;
-		animation-delay: random(10) + s;
+		animation-delay: 1s;
 	}
 	.gridicon:nth-child(5) {
 		top: 233px;
 		left: 70.6%;
-		animation-delay: random(10) + s;
+		animation-delay: 7s;
 	}
 	.gridicon:nth-child(6) {
 		top: 83px;
 		left: 4.2%;
-		animation-delay: random(10) + s;
+		animation-delay: 6s;
 	}
 	.gridicon:nth-child(7) {
 		top: 213px;
 		left: 23.8%;
-		animation-delay: random(10) + s;
+		animation-delay: 3s;
 	}
 	.gridicon:nth-child(8) {
 		top: 30px;
 		left: 37.8%;
-		animation-delay: random(10) + s;
+		animation-delay: 5s;
 	}
 	.gridicon:nth-child(9) {
 		top: 26px;
 		left: 78.4%;
-		animation-delay: random(10) + s;
+		animation-delay: 7s;
 	}
 	.gridicon:nth-child(10) {
 		top: 101px;
 		left: 21%;
-		animation-delay: random(10) + s;
+		animation-delay: 5s;
 	}
 	.gridicon:nth-child(11) {
 		top: 21px;
 		left: 62%;
-		animation-delay: random(10) + s;
+		animation-delay: 9s;
 	}
 	.gridicon:nth-child(12) {
 		top: 161px;
 		left: 77.6%;
-		animation-delay: random(10) + s;
+		animation-delay: 4s;
 	}
 }

--- a/client/signup/processing-screen/style.scss
+++ b/client/signup/processing-screen/style.scss
@@ -73,14 +73,14 @@
 		left: calc( 50% + 310px);
 		height: 70px;
 		width: 70px;
-		animation-delay: random(10) + s;
+		animation-delay: 6s;
 	}
 	.gridicons-attachment {
 		height: 60px;
 		width: 60px;
 		top: 70px;
 		left: calc(50% + 220px);
-		animation-delay: random(10) + s;
+		animation-delay: 7s;
 	}
 	.gridicons-audio {
 		height: 80px;
@@ -88,21 +88,21 @@
 		top: 170px;
 		left: calc(50% - 220px );
 		transform: rotate( -30deg );
-		animation-delay: random(10) + s;
+		animation-delay: 6s;
 	}
 	.gridicons-bell {
 		height: 120px;
 		width: 120px;
 		top: 10px;
 		left: calc( 50% + 290px);
-		animation-delay: random(10) + s;
+		animation-delay: 10s;
 	}
 	.gridicons-book {
 		top: 340px;
 		left: calc(50% - 300px);
 		height: 100px;
 		width: 100px;
-		animation-delay: random(10) + s;
+		animation-delay: 1s;
 	}
 	.gridicons-camera {
 		top: 300px;
@@ -110,7 +110,7 @@
 		height: 160px;
 		width: 160px;
 		transform: rotate( -10deg );
-		animation-delay: random(10) + s;
+		animation-delay: 3s;
 	}
 	.gridicons-comment {
 		left: calc( 50% + 130px );
@@ -124,21 +124,21 @@
 		width: 100px;
 		top: 220px;
 		left: calc(50% - 330px );
-		animation-delay: random(10) + s;
+		animation-delay: 3s;
 	}
 	.gridicons-pencil {
 		height: 220px;
 		width: 220px;
 		top: -110px;
 		left: calc(50% + 110px );
-		animation-delay: random(10) + s;
+		animation-delay: 1s;
 	}
 	.gridicons-phone {
 		height: 80px;
 		width: 80px;
 		top: 130px;
 		left: calc(50% - 390px);
-		animation-delay: random(10) + s;
+		animation-delay: 6s;
 	}
 	.gridicons-reader {
 		height: 130px;
@@ -146,7 +146,7 @@
 		top: 360px;
 		left: calc(50% - 170px );
 		transform: rotate( 12deg );
-		animation-delay: random(10) + s;
+		animation-delay: 8s;
 	}
 	.gridicons-star {
 		height: 90px;
@@ -157,67 +157,67 @@
 	.gridicons-video {
 		top: 245px;
 		left: calc(50% - 160px);
-		animation-delay: random(10) + s;
+		animation-delay: 3s;
 	}
 	.gridicons-align-image-right {
 		top: 280px;
 		left: calc(50% + 90px);
-		animation-delay: random(10) + s;
+		animation-delay: 7s;
 	}
 	.gridicons-bookmark {
 		top: 460px;
 		height: 110px;
 		width: 110px;
 		left: calc(50% - 440px);
-		animation-delay: random(10) + s;
+		animation-delay: 5s;
 	}
 	.gridicons-briefcase {
 		top: 320px;
 		height: 80px;
 		width: 80px;
 		left: calc(50% - 450px);
-		animation-delay: random(10) + s;
+		animation-delay: 1s;
 	}
 	.gridicons-calendar {
 		top: 460px;
 		left: calc(50% + 300px);
 		height: 80px;
 		width: 80px;
-		animation-delay: random(10) + s;
+		animation-delay: 2s;
 	}
 	.gridicons-clipboard {
 		top: 240px;
 		left: calc(50% + 290px);
 		height: 50px;
-		animation-delay: random(10) + s;
+		animation-delay: 6s;
 	}
 	.gridicons-cloud-upload {
 		top: 180px;
 		left: calc(50% - 280px);
 		height: 40px;
 		width: 40px;
-		animation-delay: random(10) + s;
+		animation-delay: 5s;
 	}
 	.gridicons-cog {
 		top: 110px;
 		left: calc(50% + 160px);
 		height: 40px;
 		width: 40px;
-		animation-delay: random(10) + s;
+		animation-delay: 1s;
 	}
 	.gridicons-customize {
 		top: 240px;
 		height: 40px;
 		width: 40px;
 		left: calc(50% - 400px);
-		animation-delay: random(10) + s;
+		animation-delay: 1s;
 	}
 	.gridicons-help {
 		top: 460px;
 		left: calc(50% + 160px );
 		height: 90px;
 		width: 90px;
-		animation-delay: random(10) + s;
+		animation-delay: 1s;
 	}
 	.gridicons-link {
 		top: 60px;
@@ -225,33 +225,33 @@
 		height: 50px;
 		width: 50px;
 		transform: rotate(-45deg);
-		animation-delay: random(10) + s;
+		animation-delay: 5s;
 	}
 	.gridicons-lock {
 		top: 60px;
 		left: calc(50% - 400px);
 		height: 50px;
 		width: 50px;
-		animation-delay: random(10) + s;
+		animation-delay: 6s;
 	}
 	.gridicons-pages {
 		top: 70px;
 		left: calc(50% + 70px);
 		height: 50px;
 		width: 50px;
-		animation-delay: random(10) + s;
+		animation-delay: 8s;
 	}
 	.gridicons-share {
 		top: 280px;
 		left: calc(50% + 360px);
-		animation-delay: random(10) + s;
+		animation-delay: 2s;
 	}
 	.gridicons-stats {
 		top: 470px;
 		left: calc(50% - 270px);
 		height: 80px;
 		width: 80px;
-		animation-delay: random(10) + s;
+		animation-delay: 9s;
 	}
 }
 


### PR DESCRIPTION
Two components (`ThankYouCard` and `SignupProcessingScreen`) use SCSS function `random()` to render animated floating gridicons. The generated CSS is different on every build, making its hash different, too. The `build` chunk contains URLs to CSS files including the hashes, and is therefore different on every build, too.

This patch replaces the `random` calls with one-time generated random numbers and makes the build stable. It should result in much better caching of JS and CSS files.

**How to test:**
Run production build twice:
```bash
CALYPSO_ENV=production npm run build
```
Look at the produced build chunks:
```bash
ls -l public/build.*
```
Before the patch, the two builds produced two version of the `build` chunk with different hashes.
After the patch, there is only one file.
