### PR TITLE
Store: update email settigns origin card UI.

### DIFF
--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
@@ -12,8 +12,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import ListItem from 'woocommerce/components/list/list-item';
-import ListItemField from 'woocommerce/components/list/list-item-field';
 import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
@@ -41,32 +39,30 @@ const NotificationsOrigin = ( {
 	const placeholderComponent = <p className="components__is-placeholder" />;
 
 	return (
-		<ListItem>
-			<ListItemField className="components__notification-origin">
-				{ ! isPlaceholder ? <FormLabel>{ item.title }</FormLabel> : placeholderComponent }
-				<FormTextInput
-					className={ isPlaceholder ? 'components__is-placeholder' : null }
-					isError={ emailValidationError }
-					name={ item.field }
-					onChange={ change }
-					value={ recipient }
-					placeholder={ placeholder }
+		<div className="components__notification-origin">
+			{ ! isPlaceholder ? <FormLabel>{ item.title }</FormLabel> : placeholderComponent }
+			<FormTextInput
+				className={ isPlaceholder ? 'components__is-placeholder' : null }
+				isError={ emailValidationError }
+				name={ item.field }
+				onChange={ change }
+				value={ recipient }
+				placeholder={ placeholder }
+			/>
+			{ emailValidationError && (
+				<FormTextValidation
+					isError={ true }
+					text={ translate( '%(recipient)s is not a valid email address.', {
+						args: { recipient },
+					} ) }
 				/>
-				{ emailValidationError && (
-					<FormTextValidation
-						isError={ true }
-						text={ translate( '%(recipient)s is not a valid email address.', {
-							args: { recipient },
-						} ) }
-					/>
-				) }
-				{ ! isPlaceholder ? (
-					<FormSettingExplanation>{ item.subtitle }</FormSettingExplanation>
-				) : (
-					placeholderComponent
-				) }
-			</ListItemField>
-		</ListItem>
+			) }
+			{ ! isPlaceholder ? (
+				<FormSettingExplanation>{ item.subtitle }</FormSettingExplanation>
+			) : (
+				placeholderComponent
+			) }
+		</div>
 	);
 };
 

--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -30,6 +30,7 @@ import {
 } from 'woocommerce/state/sites/settings/email/selectors';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import CustomerNotification from './components/customer-notification';
+import Card from 'components/card';
 import ExtendedHeader from 'woocommerce/components/extended-header';
 import InternalNotification from './components/internal-notification';
 import NotificationsOrigin from './components/notifications-origin';
@@ -208,7 +209,7 @@ class Settings extends React.Component {
 		return (
 			<div className="email-settings__container">
 				<ExtendedHeader label={ translate( 'Origin' ) } />
-				<List>{ originNotifications.map( this.renderOriginNotification ) }</List>
+				<Card>{ originNotifications.map( this.renderOriginNotification ) }</Card>
 				<div>
 					<ExtendedHeader
 						label={ translate( 'Internal notifications' ) }

--- a/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
@@ -56,6 +56,11 @@
 
 	.components__notification-origin {
 		width: 100%;
+		margin-bottom: 20px;
+	}
+
+	.components__notification-origin:last-child {
+		margin-bottom: 0;
 	}
 
 	.components__is-placeholder {


### PR DESCRIPTION
### Information
In following comment  https://github.com/Automattic/wp-calypso/pull/20060#issuecomment-351108390 it was pointed out that the styling of Origin card should be updated to match other parts of store UI.

### Testing
Go to email settings in store and observer the settings Origin card:
![image](https://user-images.githubusercontent.com/17271089/34719614-bbf00b60-f53b-11e7-9c41-5f0930027fed.png)
