### PR TITLE
WIP: Revert "Framework: Update RTLCSS to 2.2.1"

### DIFF
--- a/client/components/remove-button/style.scss
+++ b/client/components/remove-button/style.scss
@@ -5,7 +5,8 @@
 		right: 0;
 	width: 28px;
 	height: 28px;
-	transform: translate( 25%, -25% ); /*rtl:ignore*/
+	/*rtl:ignore*/
+	transform: translate( 25%, -25% );
 	border: 1px solid lighten( $gray, 10% );
 	border-radius: 50%;
 	background-color: $gray-light;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -48,8 +48,8 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.0.0-beta.37",
-      "integrity": "sha512-LIpcKm+2otOOvOvhCbD6wkNYi8aUwHk73uWR+hxBdW2EFht5D0QX89n4me8nyeNGWr5zC3Pvmjq+9MvUof+jkg==",
+      "version": "7.0.0-beta.36",
+      "integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
@@ -96,8 +96,8 @@
       }
     },
     "@types/node": {
-      "version": "9.3.0",
-      "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==",
+      "version": "8.5.5",
+      "integrity": "sha512-JRnfoh0Ll4ElmIXKxbUfcOodkGvcNHljct6mO1X9hE/mlrMzAx0hYCLAD7sgT53YAY1HdlpzUcV0CkmDqUqTuA==",
       "dev": true
     },
     "JSONStream": {
@@ -411,8 +411,8 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
-      "version": "1.1.0",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "version": "1.0.2",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
     "assets-webpack-plugin": {
@@ -477,7 +477,7 @@
       "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000789",
+        "caniuse-db": "1.0.30000787",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1347,7 +1347,7 @@
           "version": "2.11.0",
           "integrity": "sha512-mNYp0RNeu1xueGuJFSXkU+K0nH+dBE/gcjtyhtNKfU8hwdrVIfoA7i5iFSjOmzkGdL2QaO7YX9ExiVPE7AY9JA==",
           "requires": {
-            "caniuse-lite": "1.0.30000789",
+            "caniuse-lite": "1.0.30000787",
             "electron-to-chromium": "1.3.30"
           }
         },
@@ -1843,7 +1843,7 @@
       "version": "1.3.6",
       "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
       "requires": {
-        "caniuse-db": "1.0.30000789"
+        "caniuse-db": "1.0.30000787"
       }
     },
     "bser": {
@@ -1880,8 +1880,8 @@
       "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
     },
     "cacache": {
-      "version": "10.0.2",
-      "integrity": "sha512-dljb7dk1jqO5ogE+dRpoR9tpHYv5xz9vPSNunh1+0wRuNdYxmzp9WmsyokgW/DUF1FDRVA/TMsmxt027R8djbQ==",
+      "version": "10.0.1",
+      "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
       "requires": {
         "bluebird": "3.5.1",
         "chownr": "1.0.1",
@@ -1960,12 +1960,12 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000789",
-      "integrity": "sha1-XPP+x1SABBqxYsoGQTFTFB4jQyU="
+      "version": "1.0.30000787",
+      "integrity": "sha1-ygeigb5Taoi9f6yWuolfPPU/gRs="
     },
     "caniuse-lite": {
-      "version": "1.0.30000789",
-      "integrity": "sha1-Lj2TeyZxM/Y2Ne9/RB+sZjYPyIk="
+      "version": "1.0.30000787",
+      "integrity": "sha1-p2xPodasAGQER+yDwefGsz3WFcU="
     },
     "cardinal": {
       "version": "1.0.0",
@@ -2017,7 +2017,7 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
+        "assertion-error": "1.0.2",
         "deep-eql": "0.1.3",
         "type-detect": "1.0.0"
       }
@@ -3253,7 +3253,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000789",
+        "caniuse-db": "1.0.30000787",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -4722,8 +4722,8 @@
       "dev": true
     },
     "flow-parser": {
-      "version": "0.63.1",
-      "integrity": "sha1-hP1ke1ijcML8BGKADiLtd8PN8kk=",
+      "version": "0.62.0",
+      "integrity": "sha1-5Y0wAigVcEActQ7lzzkqUiUCAB8=",
       "dev": true
     },
     "flush-write-stream": {
@@ -7209,13 +7209,38 @@
           }
         },
         "cliui": {
-          "version": "4.0.0",
-          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "version": "3.2.0",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
             "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            }
           }
         },
         "escape-string-regexp": {
@@ -7239,11 +7264,6 @@
         "has-flag": {
           "version": "2.0.0",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "jest-cli": {
@@ -7281,7 +7301,7 @@
             "string-length": "2.0.0",
             "strip-ansi": "4.0.0",
             "which": "1.3.0",
-            "yargs": "10.1.1"
+            "yargs": "10.0.3"
           }
         },
         "os-locale": {
@@ -7301,6 +7321,13 @@
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            }
           }
         },
         "strip-ansi": {
@@ -7325,11 +7352,11 @@
           "dev": true
         },
         "yargs": {
-          "version": "10.1.1",
-          "integrity": "sha512-7uRL1HZdCbc1QTP+X8mehOPuCYKC/XTaqAPj7gABLfTt6pgLyVRn3QVte4qhtilZouWCvqd1kipgMKl5tKsFiw==",
+          "version": "10.0.3",
+          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
           "dev": true,
           "requires": {
-            "cliui": "4.0.0",
+            "cliui": "3.2.0",
             "decamelize": "1.2.0",
             "find-up": "2.1.0",
             "get-caller-file": "1.0.2",
@@ -7743,7 +7770,7 @@
       "integrity": "sha512-AVBdCx7Oj5wBpMOH089lx7Zgwpdz9HbReA82HuVAlIT4kEQRvCy6Sl9yVWDGJwHTgB/OYQGkgmbv/P/K8TkWNw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.37",
+        "@babel/code-frame": "7.0.0-beta.36",
         "chalk": "2.3.0",
         "micromatch": "2.3.11",
         "slash": "1.0.0",
@@ -7892,7 +7919,7 @@
         "slash": "1.0.0",
         "strip-bom": "3.0.0",
         "write-file-atomic": "2.3.0",
-        "yargs": "10.1.1"
+        "yargs": "10.0.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7924,13 +7951,25 @@
           }
         },
         "cliui": {
-          "version": "4.0.0",
-          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "version": "3.2.0",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
             "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
           }
         },
         "escape-string-regexp": {
@@ -7941,11 +7980,6 @@
         "has-flag": {
           "version": "2.0.0",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "os-locale": {
@@ -7965,14 +7999,21 @@
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
           }
         },
         "strip-bom": {
@@ -8004,11 +8045,11 @@
           }
         },
         "yargs": {
-          "version": "10.1.1",
-          "integrity": "sha512-7uRL1HZdCbc1QTP+X8mehOPuCYKC/XTaqAPj7gABLfTt6pgLyVRn3QVte4qhtilZouWCvqd1kipgMKl5tKsFiw==",
+          "version": "10.0.3",
+          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
           "dev": true,
           "requires": {
-            "cliui": "4.0.0",
+            "cliui": "3.2.0",
             "decamelize": "1.2.0",
             "find-up": "2.1.0",
             "get-caller-file": "1.0.2",
@@ -8258,7 +8299,7 @@
         "babylon": "6.18.0",
         "colors": "1.1.2",
         "es6-promise": "3.3.1",
-        "flow-parser": "0.63.1",
+        "flow-parser": "0.62.0",
         "lodash": "4.15.0",
         "micromatch": "2.3.11",
         "node-dir": "0.1.8",
@@ -10545,7 +10586,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "9.3.0"
+        "@types/node": "8.5.5"
       }
     },
     "parsejson": {
@@ -10837,7 +10878,7 @@
       "integrity": "sha512-eNR2h9T9ciKMoQEORrPjH33XeN/nuvVuxArOKmHtsFbGbNss631tgTrKou3/pmjAZbA4QQkhLIkPQkIk3WW+8w==",
       "requires": {
         "balanced-match": "1.0.0",
-        "postcss": "6.0.16"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10874,8 +10915,8 @@
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
         },
         "postcss": {
-          "version": "6.0.16",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.15",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
@@ -10929,7 +10970,7 @@
       "integrity": "sha1-SVcBMJeXPf1b2bGtim3BNFal0bo=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.16"
+        "postcss": "6.0.15"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10971,8 +11012,8 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.16",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.15",
+          "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -11032,7 +11073,7 @@
         "npmlog": "4.1.2",
         "os-homedir": "1.0.2",
         "pump": "1.0.3",
-        "rc": "1.2.3",
+        "rc": "1.2.2",
         "simple-get": "1.4.3",
         "tar-fs": "1.16.0",
         "tunnel-agent": "0.6.0",
@@ -11094,8 +11135,8 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.96",
-          "integrity": "sha512-fsOOY6tMQ3jCB2wD51XFDmmpgm4wVKkJECdcVRqapbJEa7awJDcr+SaH8toz+4r4KW8YQ3M7ybXMoSDo1QGewA==",
+          "version": "6.0.95",
+          "integrity": "sha512-d1Twx1NM49dQ7jbNZfaHTQWuYL9cFVrGxYpbc3BvMf4626lOJOZnp2aJQNB9vP/WX3UOe1TrTUMABrGRu6FZhg==",
           "dev": true
         },
         "ansi-regex": {
@@ -11224,7 +11265,7 @@
           "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
           "dev": true,
           "requires": {
-            "@types/node": "6.0.96"
+            "@types/node": "6.0.95"
           }
         },
         "pretty-format": {
@@ -11648,8 +11689,8 @@
       }
     },
     "rc": {
-      "version": "1.2.3",
-      "integrity": "sha1-UVdakA+N1oOBxxC0cSwhVMPiA1s=",
+      "version": "1.2.2",
+      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.5",
@@ -12821,7 +12862,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.3"
+        "rc": "1.2.2"
       }
     },
     "regjsgen": {
@@ -13097,69 +13138,14 @@
       }
     },
     "rtlcss": {
-      "version": "2.2.1",
-      "integrity": "sha512-JjQ5DlrmwiItAjlmhoxrJq5ihgZcE0wMFxt7S17bIrt4Lw0WwKKFk+viRhvodB/0falyG/5fiO043ZDh6/aqTw==",
+      "version": "2.0.5",
+      "integrity": "sha1-MFOkPgyMTM51C4LDwoUZCDC1GfM=",
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "1.0.0",
         "findup": "0.1.5",
         "mkdirp": "0.5.1",
-        "postcss": "6.0.16",
+        "postcss": "5.2.18",
         "strip-json-comments": "2.0.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-        },
-        "postcss": {
-          "version": "6.0.16",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
-          "requires": {
-            "chalk": "2.3.0",
-            "source-map": "0.6.1",
-            "supports-color": "5.1.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.1.0",
-              "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
-              "requires": {
-                "has-flag": "2.0.0"
-              }
-            }
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
       }
     },
     "run-async": {
@@ -14750,11 +14736,11 @@
       "version": "1.0.1",
       "integrity": "sha512-3IJhab8Xq7s6XqoPiVFuDpijefJsIrzACT4ggDErSxJAsB9GLDyuWpN7vuX4Lslu/nzIRz2NyXNX/fRMOgqRFw==",
       "requires": {
-        "cacache": "10.0.2",
+        "cacache": "10.0.1",
         "find-cache-dir": "1.0.0",
         "schema-utils": "0.3.0",
         "source-map": "0.5.7",
-        "uglify-es": "3.3.5",
+        "uglify-es": "3.3.4",
         "webpack-sources": "1.1.0",
         "worker-farm": "1.5.2"
       },
@@ -14772,8 +14758,8 @@
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "uglify-es": {
-          "version": "3.3.5",
-          "integrity": "sha512-7IvaFuYtfbcXm0fGb13mmRYVQdzQDXETAtvYHbCDPt2V88Y8l2HaULOyW6ueoYA0JhGIcLK7dtHkDcBWySqnBw==",
+          "version": "3.3.4",
+          "integrity": "sha512-vDOyDaf7LcABZI5oJt8bin5FD8kYONux5jd8FY6SsV2SfD+MMXaPeGUotysbycSxdu170y5IQ8FvlKzU/TUryw==",
           "requires": {
             "commander": "2.12.2",
             "source-map": "0.6.1"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "redux": "3.0.4",
     "redux-form": "7.0.2",
     "redux-thunk": "1.0.0",
-    "rtlcss": "2.2.1",
+    "rtlcss": "2.0.5",
     "semver": "5.1.0",
     "social-logos": "2.0.0",
     "socket.io-client": "1.4.5",


### PR DESCRIPTION
Reverts Automattic/wp-calypso#21358
I missed the canary failure, testing to see if this makes it pass again.
