### PR TITLE
Enable store email settings in production.

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -138,7 +138,7 @@
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,
-		"woocommerce/extension-settings-email-generic": false,
+		"woocommerce/extension-settings-email-generic": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-stripe-connect-flows": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -142,7 +142,7 @@
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,
-		"woocommerce/extension-settings-email-generic": false,
+		"woocommerce/extension-settings-email-generic": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-stripe-connect-flows": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -156,7 +156,7 @@
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,
-		"woocommerce/extension-settings-email-generic": false,
+		"woocommerce/extension-settings-email-generic": true,
 		"woocommerce/extension-settings-payments": true,
 		"woocommerce/extension-settings-shipping": true,
 		"woocommerce/extension-settings-stripe-connect-flows": true,


### PR DESCRIPTION
### Information
Go Live with Emails Settings section in Store.

### Perquisites
- [x] https://github.com/Automattic/wp-calypso/pull/21360
- [x] https://github.com/Automattic/wp-calypso/pull/21327
- [x] https://github.com/Automattic/wp-calypso/pull/21292

### End
Last comments and suggestions are more than welcome. 