### PR TITLE
Handle empty values for better analytics

### DIFF
--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -254,6 +254,7 @@ class AboutStep extends Component {
 		const siteTitleInput = formState.getFieldValue( this.state.form, 'siteTitle' );
 		const siteGoalsInput = formState.getFieldValue( this.state.form, 'siteGoals' );
 		const siteGoalsArray = siteGoalsInput.split( ',' );
+		const siteGoalsGroup = siteGoalsArray.sort().join();
 		const userExperienceInput = this.state.userExperience;
 		const siteTopicInput = formState.getFieldValue( this.state.form, 'siteTopic' );
 
@@ -261,16 +262,17 @@ class AboutStep extends Component {
 		if ( siteTitleInput !== '' ) {
 			siteTitleValue = siteTitleInput;
 			this.props.setSiteTitle( siteTitleValue );
-			this.props.recordTracksEvent( 'calypso_signup_actions_user_input', {
-				field: 'Site title',
-				value: siteTitleInput,
-			} );
 		}
+
+		this.props.recordTracksEvent( 'calypso_signup_actions_user_input', {
+			field: 'Site title',
+			value: siteTitleInput !== '' ? siteTitleInput : 'N/A',
+		} );
 
 		//Site Topic
 		this.props.recordTracksEvent( 'calypso_signup_actions_user_input', {
 			field: 'Site topic',
-			value: siteTopicInput,
+			value: siteTopicInput !== '' ? siteTopicInput : 'N/A',
 		} );
 
 		this.props.setSurvey( {
@@ -290,6 +292,11 @@ class AboutStep extends Component {
 				value: siteGoalsArray[ i ],
 			} );
 		}
+
+		this.props.recordTracksEvent( 'calypso_signup_actions_user_input', {
+			field: 'Site goal selections',
+			value: siteGoalsGroup,
+		} );
 
 		//SET SITETYPE
 		this.props.setDesignType( designType );

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -266,13 +266,13 @@ class AboutStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_signup_actions_user_input', {
 			field: 'Site title',
-			value: siteTitleInput !== '' ? siteTitleInput : 'N/A',
+			value: siteTitleInput || 'N/A',
 		} );
 
 		//Site Topic
 		this.props.recordTracksEvent( 'calypso_signup_actions_user_input', {
 			field: 'Site topic',
-			value: siteTopicInput !== '' ? siteTopicInput : 'N/A',
+			value: siteTopicInput || 'N/A',
 		} );
 
 		this.props.setSurvey( {


### PR DESCRIPTION
Shortly after launching our new Site segmenting screen, I noticed it was hard to create Tracks funnels for the following cases:
- If someone didn't enter a site title,
- If someone didn't enter a site topic,
- Seeing the combination of goals people picked.

This PR makes some updates that will allow us to build better funnels for those use cases. 

## Testing
* Turn on debugging by adding `localStorage.setItem( 'debug', 'calypso:analytics*' );` to the console.
* Refresh your screen.
* Visit `/start/.
* Don't enter any values in `What would you like to name your site?` or `What will your site be about?`.
* Select `Showcase your portfolio`, and `Sell products or collect payments` from primary goals in that order.
* Click next and check the console. 
* `field: "Site title"` and `field: "Site topic"` should have a value of N/A. and `field: "Site goal selections"` should equal `"sell,showcase"`.

cc @taggon 
