### PR TITLE
Jetpack: Fix plans descriptions

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -526,7 +526,7 @@ export const PLANS_LIST = {
 		getPathSlug: () => 'jetpack-personal',
 		getDescription: () =>
 			i18n.translate(
-				'Security essentials for every WordPress site including ' +
+				'Security essentials for your WordPress site including ' +
 					'automated backups and priority support.'
 			),
 		getTagline: () =>
@@ -563,7 +563,7 @@ export const PLANS_LIST = {
 		availableFor: plan => includes( [ PLAN_JETPACK_FREE ], plan ),
 		getDescription: () =>
 			i18n.translate(
-				'Security essentials for every WordPress site including ' +
+				'Security essentials for your WordPress site including ' +
 					'automated backups and priority support.'
 			),
 		getTagline: () =>


### PR DESCRIPTION
Change a couple of descriptions for jetpack plans that were confusing for some users.
  
how to test:
=========
1. Go to https://calypso.live/plans?branch=fix/jetpack-plans-descriptions
2. Pick a jetpack plan
3. Click on the (i) button in the jetpack personal plan and see the text says "your WordPress" and not "every WordPress".
4. Repeat with the monthly plan