### PR TITLE
Reader: rename showEmailSettings to showNotificationSettings

### DIFF
--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -80,7 +80,7 @@ export class RecommendedSites extends React.PureComponent {
 								<ConnectedSubscriptionListItem
 									siteId={ siteId }
 									railcar={ site.railcar }
-									showEmailSettings={ false }
+									showNotificationSettings={ false }
 									showLastUpdatedDate={ false }
 									followSource={ followSource }
 									onComponentMountWithNewRailcar={ recordRecommendationRender( index ) }

--- a/client/blocks/reader-subscription-list-item/connected.jsx
+++ b/client/blocks/reader-subscription-list-item/connected.jsx
@@ -25,7 +25,7 @@ class ConnectedSubscriptionListItem extends React.Component {
 		siteId: PropTypes.number,
 		onShouldMeasure: PropTypes.func,
 		onComponentMountWithNewRailcar: PropTypes.func,
-		showEmailSettings: PropTypes.bool,
+		showNotificationSettings: PropTypes.bool,
 		showLastUpdatedDate: PropTypes.bool,
 		isFollowing: PropTypes.bool,
 		followSource: PropTypes.string,
@@ -35,7 +35,7 @@ class ConnectedSubscriptionListItem extends React.Component {
 	static defaultProps = {
 		onShouldMeasure: noop,
 		onComponentMountWithNewRailcar: noop,
-		showEmailSettings: true,
+		showNotificationSettings: true,
 		showLastUpdatedDate: true,
 	};
 
@@ -63,7 +63,7 @@ class ConnectedSubscriptionListItem extends React.Component {
 			url,
 			feedId,
 			siteId,
-			showEmailSettings,
+			showNotificationSettings,
 			showLastUpdatedDate,
 			isFollowing,
 			followSource,
@@ -79,7 +79,7 @@ class ConnectedSubscriptionListItem extends React.Component {
 				site={ site }
 				feed={ feed }
 				url={ url }
-				showEmailSettings={ showEmailSettings && ! isEmailBlocked }
+				showNotificationSettings={ showNotificationSettings && ! isEmailBlocked }
 				showLastUpdatedDate={ showLastUpdatedDate }
 				isFollowing={ isFollowing }
 				followSource={ followSource }

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -45,7 +45,7 @@ function ReaderSubscriptionListItem( {
 	className = '',
 	translate,
 	followSource,
-	showEmailSettings, // @todo rename to showNotificationSettings
+	showNotificationSettings,
 	showLastUpdatedDate,
 	isFollowing,
 	railcar,
@@ -92,11 +92,7 @@ function ReaderSubscriptionListItem( {
 	);
 
 	return (
-		<div
-			className={ classnames( 'reader-subscription-list-item', className, {
-				'has-email-settings': showEmailSettings && isFollowing,
-			} ) }
-		>
+		<div className={ classnames( 'reader-subscription-list-item', className ) }>
 			<div className="reader-subscription-list-item__avatar">
 				<ReaderAvatar
 					siteIcon={ siteIcon }
@@ -167,7 +163,7 @@ function ReaderSubscriptionListItem( {
 					siteId={ siteId }
 					railcar={ railcar }
 				/>
-				{ isFollowing && showEmailSettings && notificationSettings }
+				{ isFollowing && showNotificationSettings && notificationSettings }
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Renames the prop `showEmailSettings` to `showNotificationSettings` to reflect the fact that the popover now deals with new post notifications _and_ email notification settings (see https://github.com/Automattic/wp-calypso/pull/20824).

<img width="286" alt="33993970-aa3dba40-e0d0-11e7-85d0-ce073095b506" src="https://user-images.githubusercontent.com/17325/34728766-ae1c4992-f552-11e7-9f13-13a2314655d2.png">

### To test

In http://calypso.localhost:3000/following/manage, ensure that the recommended sites under the search box do not have a 'Settings' link, even if you're following one of them:

![screen shot 2018-01-09 at 15 27 36](https://user-images.githubusercontent.com/17325/34728795-c63610b2-f552-11e7-9bf0-5fa45c7c8ae7.png)
