### PR TITLE
Store Orders: Display the original price along with the discounted value

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/line-item.js
+++ b/client/extensions/woocommerce/app/order/order-details/line-item.js
@@ -1,0 +1,118 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import formatCurrency from 'lib/format-currency';
+import { getLink } from 'woocommerce/lib/nav-utils';
+import { getOrderLineItemTax } from 'woocommerce/lib/order-values';
+import { getOrderItemCost } from 'woocommerce/lib/order-values/totals';
+import TableRow from 'woocommerce/components/table/table-row';
+import TableItem from 'woocommerce/components/table/table-item';
+
+// A shortcut for number or string proptypes, because prices and IDs can be either.
+const PropTypeNumberOrString = PropTypes.oneOfType( [
+	PropTypes.string.isRequired,
+	PropTypes.number.isRequired,
+] );
+
+class OrderLineItem extends Component {
+	static propTypes = {
+		deleteButton: PropTypes.element,
+		isEditing: PropTypes.bool,
+		item: PropTypes.shape( {
+			id: PropTypeNumberOrString,
+			name: PropTypes.string.isRequired,
+			price: PropTypeNumberOrString,
+			product_id: PropTypes.number.isRequired,
+			quantity: PropTypes.number.isRequired,
+			subtotal: PropTypeNumberOrString,
+			total: PropTypeNumberOrString,
+		} ),
+		order: PropTypes.shape( {
+			currency: PropTypes.string.isRequired,
+			discount_total: PropTypes.string.isRequired,
+			line_items: PropTypes.array.isRequired,
+			refunds: PropTypes.array.isRequired,
+			shipping_total: PropTypes.string.isRequired,
+			total: PropTypes.string.isRequired,
+		} ),
+		site: PropTypes.shape( {
+			ID: PropTypes.number.isRequired,
+			slug: PropTypes.string.isRequired,
+		} ),
+		translate: PropTypes.func,
+	};
+
+	renderName = item => {
+		const { isEditing, site } = this.props;
+		if ( isEditing ) {
+			return <span className="order-details__item-link">{ item.name }</span>;
+		}
+		return (
+			<a
+				href={ getLink( `/store/product/:site/${ item.product_id }`, site ) }
+				className="order-details__item-link"
+			>
+				{ item.name }
+			</a>
+		);
+	};
+
+	render() {
+		const { deleteButton, item, order, children: quantityField } = this.props;
+		const tax = getOrderLineItemTax( order, item.id );
+		if ( item.quantity <= 0 ) {
+			return null;
+		}
+		let itemPrice = formatCurrency( item.price, order.currency );
+		let itemTotal = formatCurrency( item.total, order.currency );
+		if ( parseFloat( item.total ) !== parseFloat( item.subtotal ) ) {
+			const preDiscountCost = getOrderItemCost( order, item.id );
+			itemPrice = (
+				<Fragment>
+					<del className="order-details__item-pre-discount">
+						{ formatCurrency( preDiscountCost, order.currency ) }
+					</del>
+					<ins className="order-details__item-with-discount">
+						{ formatCurrency( item.price, order.currency ) }
+					</ins>
+				</Fragment>
+			);
+
+			itemTotal = (
+				<Fragment>
+					<del className="order-details__item-pre-discount">
+						{ formatCurrency( item.subtotal, order.currency ) }
+					</del>
+					<ins className="order-details__item-with-discount">
+						{ formatCurrency( item.total, order.currency ) }
+					</ins>
+				</Fragment>
+			);
+		}
+		return (
+			<TableRow key={ item.id } className="order-details__items">
+				<TableItem isRowHeader className="order-details__item-product">
+					{ this.renderName( item ) }
+					<span className="order-details__item-sku">{ item.sku }</span>
+				</TableItem>
+				<TableItem className="order-details__item-cost">{ itemPrice }</TableItem>
+				<TableItem className="order-details__item-quantity">{ quantityField }</TableItem>
+				<TableItem className="order-details__item-tax">
+					{ formatCurrency( tax, order.currency ) }
+				</TableItem>
+				<TableItem className="order-details__item-total">{ itemTotal }</TableItem>
+				{ deleteButton || null }
+			</TableRow>
+		);
+	}
+}
+
+export default localize( OrderLineItem );

--- a/client/extensions/woocommerce/app/order/order-details/line-item.js
+++ b/client/extensions/woocommerce/app/order/order-details/line-item.js
@@ -50,6 +50,8 @@ class OrderLineItem extends Component {
 		translate: PropTypes.func,
 	};
 
+	isDiscountedProduct = item => parseFloat( item.total ) !== parseFloat( item.subtotal );
+
 	renderName = item => {
 		const { isEditing, site } = this.props;
 		if ( isEditing ) {
@@ -65,17 +67,11 @@ class OrderLineItem extends Component {
 		);
 	};
 
-	render() {
-		const { deleteButton, item, order, children: quantityField } = this.props;
-		const tax = getOrderLineItemTax( order, item.id );
-		if ( item.quantity <= 0 ) {
-			return null;
-		}
-		let itemPrice = formatCurrency( item.price, order.currency );
-		let itemTotal = formatCurrency( item.total, order.currency );
-		if ( parseFloat( item.total ) !== parseFloat( item.subtotal ) ) {
+	renderPrice = item => {
+		const { order } = this.props;
+		if ( this.isDiscountedProduct( item ) ) {
 			const preDiscountCost = getOrderItemCost( order, item.id );
-			itemPrice = (
+			return (
 				<Fragment>
 					<del className="order-details__item-pre-discount">
 						{ formatCurrency( preDiscountCost, order.currency ) }
@@ -85,8 +81,14 @@ class OrderLineItem extends Component {
 					</ins>
 				</Fragment>
 			);
+		}
+		return formatCurrency( item.price, order.currency );
+	};
 
-			itemTotal = (
+	renderTotal = item => {
+		const { order } = this.props;
+		if ( this.isDiscountedProduct( item ) ) {
+			return (
 				<Fragment>
 					<del className="order-details__item-pre-discount">
 						{ formatCurrency( item.subtotal, order.currency ) }
@@ -97,18 +99,28 @@ class OrderLineItem extends Component {
 				</Fragment>
 			);
 		}
+		return formatCurrency( item.total, order.currency );
+	};
+
+	render() {
+		const { deleteButton, item, order, children: quantityField } = this.props;
+		const tax = getOrderLineItemTax( order, item.id );
+		if ( item.quantity <= 0 ) {
+			return null;
+		}
+
 		return (
 			<TableRow key={ item.id } className="order-details__items">
 				<TableItem isRowHeader className="order-details__item-product">
 					{ this.renderName( item ) }
 					<span className="order-details__item-sku">{ item.sku }</span>
 				</TableItem>
-				<TableItem className="order-details__item-cost">{ itemPrice }</TableItem>
+				<TableItem className="order-details__item-cost">{ this.renderPrice( item ) }</TableItem>
 				<TableItem className="order-details__item-quantity">{ quantityField }</TableItem>
 				<TableItem className="order-details__item-tax">
 					{ formatCurrency( tax, order.currency ) }
 				</TableItem>
-				<TableItem className="order-details__item-total">{ itemTotal }</TableItem>
+				<TableItem className="order-details__item-total">{ this.renderTotal( item ) }</TableItem>
 				{ deleteButton || null }
 			</TableRow>
 		);

--- a/client/extensions/woocommerce/app/order/order-details/line-item.js
+++ b/client/extensions/woocommerce/app/order/order-details/line-item.js
@@ -73,12 +73,12 @@ class OrderLineItem extends Component {
 			const preDiscountCost = getOrderItemCost( order, item.id );
 			return (
 				<Fragment>
-					<del className="order-details__item-pre-discount">
-						{ formatCurrency( preDiscountCost, order.currency ) }
-					</del>
 					<ins className="order-details__item-with-discount">
 						{ formatCurrency( item.price, order.currency ) }
 					</ins>
+					<del className="order-details__item-pre-discount">
+						{ formatCurrency( preDiscountCost, order.currency ) }
+					</del>
 				</Fragment>
 			);
 		}
@@ -90,12 +90,12 @@ class OrderLineItem extends Component {
 		if ( this.isDiscountedProduct( item ) ) {
 			return (
 				<Fragment>
-					<del className="order-details__item-pre-discount">
-						{ formatCurrency( item.subtotal, order.currency ) }
-					</del>
 					<ins className="order-details__item-with-discount">
 						{ formatCurrency( item.total, order.currency ) }
 					</ins>
+					<del className="order-details__item-pre-discount">
+						{ formatCurrency( item.subtotal, order.currency ) }
+					</del>
 				</Fragment>
 			);
 		}

--- a/client/extensions/woocommerce/app/order/order-details/product-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/product-dialog.js
@@ -41,7 +41,7 @@ function getExistingLineItem( item, order ) {
 
 function createLineItem( item, allProducts ) {
 	const line = {
-		id: uniqueId( 'fee_' ),
+		id: uniqueId( 'product_' ),
 		name: item.name || '',
 		price: item.price,
 		subtotal: item.price,

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -31,6 +31,17 @@
 		}
 	}
 
+	.order-details__item-pre-discount,
+	.order-details__item-with-discount {
+		display: block;
+		background: transparent;
+	}
+
+	.order-details__item-pre-discount {
+		font-size: 0.9em;
+		text-decoration: line-through;
+	}
+
 	.order-details__item-quantity .form-text-input {
 		width: 5em;
 	}

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -55,6 +55,9 @@
 	}
 }
 
+.order-details__item-cost,
+.order-details__item-quantity,
+.order-details__item-tax,
 .order-details__item-delete,
 .order-details__item-total {
 	text-align: right;

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -31,6 +31,10 @@
 		}
 	}
 
+	.table-item {
+		vertical-align: top;
+	}
+
 	.order-details__item-pre-discount,
 	.order-details__item-with-discount {
 		display: block;

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -114,7 +114,7 @@ class OrderDetailsTable extends Component {
 		// A zero quantity does strange things with the price, so we'll force 1
 		const quantity = Math.abs( event.target.value ) || 1;
 		const subtotal = getOrderItemCost( order, id ) * quantity;
-		const total = subtotal;
+		const total = parseFloat( item.price ) * quantity;
 		const newItem = { ...item, quantity, subtotal, total };
 		this.props.onChange( { line_items: { [ index ]: newItem } } );
 	};

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -204,24 +204,46 @@ class OrderDetailsTable extends Component {
 		if ( item.quantity <= 0 ) {
 			return null;
 		}
+		let itemPrice = formatCurrency( item.price, order.currency );
+		let itemTotal = formatCurrency( item.total, order.currency );
+		if ( parseFloat( item.total ) !== parseFloat( item.subtotal ) ) {
+			const preDiscountCost = getOrderItemCost( order, item.id );
+			itemPrice = (
+				<Fragment>
+					<del className="order-details__item-pre-discount">
+						{ formatCurrency( preDiscountCost, order.currency ) }
+					</del>
+					<ins className="order-details__item-with-discount">
+						{ formatCurrency( item.price, order.currency ) }
+					</ins>
+				</Fragment>
+			);
+
+			itemTotal = (
+				<Fragment>
+					<del className="order-details__item-pre-discount">
+						{ formatCurrency( item.subtotal, order.currency ) }
+					</del>
+					<ins className="order-details__item-with-discount">
+						{ formatCurrency( item.total, order.currency ) }
+					</ins>
+				</Fragment>
+			);
+		}
 		return (
 			<TableRow key={ item.id } className="order-details__items">
 				<TableItem isRowHeader className="order-details__item-product">
 					{ this.renderName( item ) }
 					<span className="order-details__item-sku">{ item.sku }</span>
 				</TableItem>
-				<TableItem className="order-details__item-cost">
-					{ formatCurrency( item.price, order.currency ) }
-				</TableItem>
+				<TableItem className="order-details__item-cost">{ itemPrice }</TableItem>
 				<TableItem className="order-details__item-quantity">
 					{ this.renderQuantity( item, i ) }
 				</TableItem>
 				<TableItem className="order-details__item-tax">
 					{ formatCurrency( tax, order.currency ) }
 				</TableItem>
-				<TableItem className="order-details__item-total">
-					{ formatCurrency( item.total, order.currency ) }
-				</TableItem>
+				<TableItem className="order-details__item-total">{ itemTotal }</TableItem>
 				{ this.renderDeleteButton( item, 'line_items' ) }
 			</TableRow>
 		);

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -11,21 +11,16 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import formatCurrency from 'lib/format-currency';
 import FormTextInput from 'components/forms/form-text-input';
 import { getCurrencyFormatDecimal } from 'woocommerce/lib/currency';
 import {
 	getOrderDiscountTax,
 	getOrderFeeTax,
-	getOrderLineItemTax,
 	getOrderShippingTax,
 	getOrderTotalTax,
 } from 'woocommerce/lib/order-values';
-import {
-	getOrderFeeCost,
-	getOrderItemCost,
-	getOrderRefundTotal,
-} from 'woocommerce/lib/order-values/totals';
+import { getOrderFeeCost, getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
+import OrderLineItem from '../order-details/line-item';
 import OrderTotalRow from '../order-details/row-total';
 import PriceInput from 'woocommerce/components/price-input';
 import ScreenReaderText from 'components/screen-reader-text';
@@ -155,71 +150,29 @@ class OrderRefundTable extends Component {
 		);
 	};
 
-	renderOrderItems = item => {
-		const { order, translate } = this.props;
-		const tax = getOrderLineItemTax( order, item.id );
+	renderOrderItem = item => {
+		const { order, site, translate } = this.props;
 		const inputId = `quantity-${ item.id }`;
-		let itemPrice = formatCurrency( item.price, order.currency );
-		let itemTotal = formatCurrency( item.total, order.currency );
-		if ( parseFloat( item.total ) !== parseFloat( item.subtotal ) ) {
-			const preDiscountCost = getOrderItemCost( order, item.id );
-			itemPrice = (
-				<Fragment>
-					<del className="order-payment__item-pre-discount order-details__item-pre-discount">
-						{ formatCurrency( preDiscountCost, order.currency ) }
-					</del>
-					<ins className="order-payment__item-with-discount order-details__item-with-discount">
-						{ formatCurrency( item.price, order.currency ) }
-					</ins>
-				</Fragment>
-			);
-
-			itemTotal = (
-				<Fragment>
-					<del className="order-payment__item-pre-discount order-details__item-pre-discount">
-						{ formatCurrency( item.subtotal, order.currency ) }
-					</del>
-					<ins className="order-payment__item-with-discount order-details__item-with-discount">
-						{ formatCurrency( item.total, order.currency ) }
-					</ins>
-				</Fragment>
-			);
-		}
 		return (
-			<TableRow key={ item.id } className="order-payment__items order-details__items">
-				<TableItem isRowHeader className="order-payment__item-product order-details__item-product">
-					<span className="order-payment__item-link order-details__item-link">{ item.name }</span>
-					<span className="order-payment__item-sku order-details__item-sku">{ item.sku }</span>
-				</TableItem>
-				<TableItem className="order-payment__item-cost order-details__item-cost">
-					{ itemPrice }
-				</TableItem>
-				<TableItem className="order-payment__item-quantity order-details__item-quantity">
-					<ScreenReaderText>
-						<label htmlFor={ inputId }>
-							{ translate( 'Quantity of %(item)s', { args: { item: item.name } } ) }
-						</label>
-					</ScreenReaderText>
-					<FormTextInput
-						type="number"
-						id={ inputId }
-						onChange={ this.onChange( 'quantity', item.id ) }
-						min="0"
-						max={ item.quantity }
-						value={ this.state.quantities[ item.id ] || 0 }
-					/>
-				</TableItem>
-				<TableItem className="order-payment__item-tax order-details__item-tax">
-					{ formatCurrency( tax, order.currency ) }
-				</TableItem>
-				<TableItem className="order-payment__item-total order-details__item-total">
-					{ itemTotal }
-				</TableItem>
-			</TableRow>
+			<OrderLineItem key={ item.id } isEditing item={ item } order={ order } site={ site }>
+				<ScreenReaderText>
+					<label htmlFor={ inputId }>
+						{ translate( 'Quantity of %(item)s', { args: { item: item.name } } ) }
+					</label>
+				</ScreenReaderText>
+				<FormTextInput
+					type="number"
+					id={ inputId }
+					onChange={ this.onChange( 'quantity', item.id ) }
+					min="0"
+					max={ item.quantity }
+					value={ this.state.quantities[ item.id ] || 0 }
+				/>
+			</OrderLineItem>
 		);
 	};
 
-	renderOrderFees = ( item, i ) => {
+	renderOrderFee = ( item, i ) => {
 		const { order, translate } = this.props;
 		const value = this.state.fees[ i ];
 		const inputId = `fee_line-${ item.id }`;
@@ -310,8 +263,8 @@ class OrderRefundTable extends Component {
 					className="order-payment__table order-details__table"
 					header={ this.renderTableHeader() }
 				>
-					{ order.line_items.map( this.renderOrderItems ) }
-					{ order.fee_lines.map( this.renderOrderFees ) }
+					{ order.line_items.map( this.renderOrderItem ) }
+					{ order.fee_lines.map( this.renderOrderFee ) }
 				</Table>
 
 				<Table className={ totalsClasses } compact>

--- a/client/extensions/woocommerce/app/order/order-payment/table.js
+++ b/client/extensions/woocommerce/app/order/order-payment/table.js
@@ -21,7 +21,11 @@ import {
 	getOrderShippingTax,
 	getOrderTotalTax,
 } from 'woocommerce/lib/order-values';
-import { getOrderFeeCost, getOrderRefundTotal } from 'woocommerce/lib/order-values/totals';
+import {
+	getOrderFeeCost,
+	getOrderItemCost,
+	getOrderRefundTotal,
+} from 'woocommerce/lib/order-values/totals';
 import OrderTotalRow from '../order-details/row-total';
 import PriceInput from 'woocommerce/components/price-input';
 import ScreenReaderText from 'components/screen-reader-text';
@@ -155,6 +159,32 @@ class OrderRefundTable extends Component {
 		const { order, translate } = this.props;
 		const tax = getOrderLineItemTax( order, item.id );
 		const inputId = `quantity-${ item.id }`;
+		let itemPrice = formatCurrency( item.price, order.currency );
+		let itemTotal = formatCurrency( item.total, order.currency );
+		if ( parseFloat( item.total ) !== parseFloat( item.subtotal ) ) {
+			const preDiscountCost = getOrderItemCost( order, item.id );
+			itemPrice = (
+				<Fragment>
+					<del className="order-payment__item-pre-discount order-details__item-pre-discount">
+						{ formatCurrency( preDiscountCost, order.currency ) }
+					</del>
+					<ins className="order-payment__item-with-discount order-details__item-with-discount">
+						{ formatCurrency( item.price, order.currency ) }
+					</ins>
+				</Fragment>
+			);
+
+			itemTotal = (
+				<Fragment>
+					<del className="order-payment__item-pre-discount order-details__item-pre-discount">
+						{ formatCurrency( item.subtotal, order.currency ) }
+					</del>
+					<ins className="order-payment__item-with-discount order-details__item-with-discount">
+						{ formatCurrency( item.total, order.currency ) }
+					</ins>
+				</Fragment>
+			);
+		}
 		return (
 			<TableRow key={ item.id } className="order-payment__items order-details__items">
 				<TableItem isRowHeader className="order-payment__item-product order-details__item-product">
@@ -162,7 +192,7 @@ class OrderRefundTable extends Component {
 					<span className="order-payment__item-sku order-details__item-sku">{ item.sku }</span>
 				</TableItem>
 				<TableItem className="order-payment__item-cost order-details__item-cost">
-					{ formatCurrency( item.price, order.currency ) }
+					{ itemPrice }
 				</TableItem>
 				<TableItem className="order-payment__item-quantity order-details__item-quantity">
 					<ScreenReaderText>
@@ -183,7 +213,7 @@ class OrderRefundTable extends Component {
 					{ formatCurrency( tax, order.currency ) }
 				</TableItem>
 				<TableItem className="order-payment__item-total order-details__item-total">
-					{ formatCurrency( item.total, order.currency ) }
+					{ itemTotal }
 				</TableItem>
 			</TableRow>
 		);


### PR DESCRIPTION
Fixes #16662 – This adds the original price of the item to the item row, crossed-out with the discounted value below it. This makes it more clear that the discounted value has already been accounted for in the total.

<img width="590" alt="screen shot 2018-01-09 at 11 03 03 am" src="https://user-images.githubusercontent.com/541093/34730210-b6241bf4-f52c-11e7-87bd-25b2f569e4aa.png">

This also fixes a bug in edit mode where discounted products would jump back up to full price if the quantity is edited. For example, a $10 product which was sold for $5 would jump up to $20 when the quantity was increased to 2. The editing math now uses the discounted value to calculate product subtotals, so that example would be $10 for 2.

I've created a new component, `OrderLineItem`, which is used across the order single view, edit state, and refund modal. The functionality of the quantity field is slightly different for refund & edit, so that's still handled in the parent component and passed in as `children`. 

**To test**

- View an order with a coupon that affects product price applied
- See the original product cost crossed out over the discounted cost
- Edit the order
- Editing quantity works, and the price stays discounted as it changes
- Save the order, mark it as paid
- Open the refund dialog
- Edit the quantity of the refund - there should be no functionality change here
