### PR TITLE
JPO: pass user creds to individual steps

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -31,7 +31,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 	// TODO: Add lifecycle methods to redirect if no siteId
 
 	render() {
-		const { recordTracksEventForJpoSite, siteId, siteSlug, stepName, steps } = this.props;
+		const { recordJpoEvent, siteId, siteSlug, stepName, steps } = this.props;
 		return (
 			<Main className="jetpack-onboarding">
 				<Wizard
@@ -39,7 +39,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 					baseSuffix={ siteSlug }
 					components={ COMPONENTS }
 					hideNavigation={ stepName === STEPS.SUMMARY }
-					recordTracksEventForJpoSite={ recordTracksEventForJpoSite }
+					recordJpoEvent={ recordJpoEvent }
 					siteId={ siteId }
 					stepName={ stepName }
 					steps={ steps }
@@ -65,16 +65,16 @@ export default connect(
 			STEPS.SUMMARY,
 		] );
 		return {
-			steps,
 			siteId,
 			siteSlug,
+			steps,
 		};
 	},
 	{ recordTracksEvent },
 	( { siteId, ...stateProps }, { recordTracksEvent: recordTracksEventAction }, ownProps ) => ( {
 		siteId,
 		...stateProps,
-		recordTracksEventForJpoSite: event =>
+		recordJpoEvent: event =>
 			recordTracksEventAction( event, {
 				blog_id: siteId,
 				site_id_type: 'jpo',

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -30,7 +30,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 	// TODO: Add lifecycle methods to redirect if no siteId
 
 	render() {
-		const { siteId, siteSlug, stepName, steps } = this.props;
+		const { jpUser, siteId, siteSlug, stepName, steps, token } = this.props;
 
 		return (
 			<Main className="jetpack-onboarding">
@@ -38,10 +38,12 @@ class JetpackOnboardingMain extends React.PureComponent {
 					basePath="/jetpack/onboarding"
 					baseSuffix={ siteSlug }
 					components={ COMPONENTS }
-					siteId={ siteId /* Passed down to individual steps */ }
+					hideNavigation={ stepName === STEPS.SUMMARY }
+					jpUser={ jpUser }
+					siteId={ siteId }
 					steps={ steps }
 					stepName={ stepName }
-					hideNavigation={ stepName === STEPS.SUMMARY }
+					token={ token }
 				/>
 			</Main>
 		);
@@ -65,8 +67,10 @@ export default connect( ( state, { siteSlug } ) => {
 	] );
 
 	return {
+		jpUser: get( state.jetpackOnboarding.credentials, [ siteId, 'userEmail' ], null ),
 		siteId,
 		siteSlug,
 		steps,
+		token: get( state.jetpackOnboarding.credentials, [ siteId, 'token' ], null ),
 	};
 } )( JetpackOnboardingMain );

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -21,9 +21,13 @@ import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions'
 
 class JetpackOnboardingContactFormStep extends React.PureComponent {
 	handleAddContactForm = () => {
-		const { siteId } = this.props;
+		const { jpUser, siteId, token } = this.props;
 
-		this.props.recordTracksEvent( 'calypso_jpo_contact_form_clicked' );
+		this.props.recordTracksEvent( 'calypso_jpo_contact_form_clicked', {
+			blog_id: token,
+			site_id_type: 'jpo',
+			user_id_type: jpUser,
+		} );
 
 		this.props.saveJetpackOnboardingSettings( siteId, {
 			addContactForm: true,

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -21,7 +21,7 @@ import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions'
 class JetpackOnboardingContactFormStep extends React.PureComponent {
 	handleAddContactForm = () => {
 		const { siteId } = this.props;
-		this.props.recordTracksEventForJpoSite( 'calypso_jpo_contact_form_clicked' );
+		this.props.recordJpoEvent( 'calypso_jpo_contact_form_clicked' );
 
 		this.props.saveJetpackOnboardingSettings( siteId, {
 			addContactForm: true,

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -16,18 +16,12 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
-import { recordTracksEvent } from 'state/analytics/actions';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingContactFormStep extends React.PureComponent {
 	handleAddContactForm = () => {
-		const { jpUser, siteId, token } = this.props;
-
-		this.props.recordTracksEvent( 'calypso_jpo_contact_form_clicked', {
-			blog_id: token,
-			site_id_type: 'jpo',
-			user_id_type: jpUser,
-		} );
+		const { siteId } = this.props;
+		this.props.recordTracksEventForJpoSite( 'calypso_jpo_contact_form_clicked' );
 
 		this.props.saveJetpackOnboardingSettings( siteId, {
 			addContactForm: true,
@@ -65,6 +59,6 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 	}
 }
 
-export default connect( null, { recordTracksEvent, saveJetpackOnboardingSettings } )(
+export default connect( null, { saveJetpackOnboardingSettings } )(
 	localize( JetpackOnboardingContactFormStep )
 );


### PR DESCRIPTION
Pass site and user creds to the individual steps in JPO in order to include this information in tracking object events without reading it from the store in each step.

This patch includes 
- the actual changes to the main component file: binding the tracking functions to be passed as props
- use of these props when firing on click tracking event upon creating the Contact Form ( for testing and proof of concept)

**To test:**
* Checkout this branch in local Calypso
* Run the latest JP master on the sandbox
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your JP sandbox
* Land in http://calypso.localhost:3000/jetpack/onboarding/yourjetpacksandbox.com (possibly after connecting, depending on whether we land the skip-connection for fresh sites by the time it is tested :) )
* Click through till hitting the `onboarding/contact-form/yourjetpacksandbox.com ` step
* Click `Add a contact form` button
* Use `localStorage.debug = 'calypso:analytics:tracks'` to confirm that the event fires and 
verify seeing `blog_id: .. , site_id_type: "jpo", user_id_type: ...` filled in with relevant data in the tracking object 

  
  