### PR TITLE
Reader: store subscription status for new post notifications when subscribing/unsubscribing

### DIFF
--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -81,22 +81,15 @@ function updateNotificationSubscription( state, { payload, type } ) {
 		return state;
 	}
 
-	const currentFollowState = get( follow, [ 'delivery_methods', 'notification' ], {} );
+	const currentFollowState = get(
+		follow,
+		[ 'delivery_methods', 'notification', 'send_posts' ],
+		false
+	);
 
-	const newProps = {};
-	switch ( type ) {
-		case READER_SUBSCRIBE_TO_NEW_POST_NOTIFICATIONS:
-		case READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS:
-			newProps.send_posts = ! ( type === READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS );
-			break;
-	}
+	const newFollowState = ! ( type === READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS );
 
-	const newFollowState = {
-		...currentFollowState,
-		...newProps,
-	};
-
-	if ( isEqual( currentFollowState, newFollowState ) ) {
+	if ( currentFollowState === newFollowState ) {
 		return state;
 	}
 
@@ -106,7 +99,9 @@ function updateNotificationSubscription( state, { payload, type } ) {
 			...follow,
 			delivery_methods: {
 				email: get( follow, [ 'delivery_methods', 'email' ], {} ),
-				notification: newFollowState,
+				notification: {
+					send_posts: newFollowState,
+				},
 			},
 		},
 	};
@@ -218,20 +213,13 @@ export const items = createReducer(
 				[ urlKey ]: merge( {}, currentFollow, newFollow ),
 			};
 		},
-		[ READER_SUBSCRIBE_TO_NEW_POST_EMAIL ]: ( state, action ) =>
-			updateEmailSubscription( state, action ),
-		[ READER_UPDATE_NEW_POST_EMAIL_SUBSCRIPTION ]: ( state, action ) =>
-			updateEmailSubscription( state, action ),
-		[ READER_UNSUBSCRIBE_TO_NEW_POST_EMAIL ]: ( state, action ) =>
-			updateEmailSubscription( state, action ),
-		[ READER_SUBSCRIBE_TO_NEW_COMMENT_EMAIL ]: ( state, action ) =>
-			updateEmailSubscription( state, action ),
-		[ READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL ]: ( state, action ) =>
-			updateEmailSubscription( state, action ),
-		[ READER_SUBSCRIBE_TO_NEW_POST_NOTIFICATIONS ]: ( state, action ) =>
-			updateNotificationSubscription( state, action ),
-		[ READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS ]: ( state, action ) =>
-			updateNotificationSubscription( state, action ),
+		[ READER_SUBSCRIBE_TO_NEW_POST_EMAIL ]: updateEmailSubscription,
+		[ READER_UPDATE_NEW_POST_EMAIL_SUBSCRIPTION ]: updateEmailSubscription,
+		[ READER_UNSUBSCRIBE_TO_NEW_POST_EMAIL ]: updateEmailSubscription,
+		[ READER_SUBSCRIBE_TO_NEW_COMMENT_EMAIL ]: updateEmailSubscription,
+		[ READER_UNSUBSCRIBE_TO_NEW_COMMENT_EMAIL ]: updateEmailSubscription,
+		[ READER_SUBSCRIBE_TO_NEW_POST_NOTIFICATIONS ]: updateNotificationSubscription,
+		[ READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS ]: updateNotificationSubscription,
 		[ READER_FOLLOWS_SYNC_COMPLETE ]: ( state, action ) => {
 			const seenSubscriptions = new Set( action.payload );
 

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { expect as chaiExpect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -31,11 +30,24 @@ import {
 	READER_SITE_REQUEST_SUCCESS,
 } from 'state/action-types';
 
+const exampleFollow = {
+	is_following: true,
+	blog_ID: 123,
+	URL: 'http://example.com',
+	feed_URL: 'http://example.com',
+	delivery_methods: {
+		email: {
+			send_posts: false,
+		},
+		notification: {},
+	},
+};
+
 describe( 'reducer', () => {
 	describe( '#itemsCount()', () => {
 		test( 'should default to 0', () => {
 			const state = itemsCount( undefined, {} );
-			chaiExpect( state ).to.eql( 0 );
+			expect( state ).toBe( 0 );
 		} );
 
 		test( 'should get set to whatever is in the payload', () => {
@@ -43,14 +55,14 @@ describe( 'reducer', () => {
 				type: READER_FOLLOWS_RECEIVE,
 				payload: { totalCount: 20 },
 			} );
-			chaiExpect( state ).eql( 20 );
+			expect( state ).toBe( 20 );
 		} );
 	} );
 
 	describe( '#items()', () => {
 		test( 'should default to an empty object', () => {
 			const state = items( undefined, {} );
-			chaiExpect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should insert a new URL when followed', () => {
@@ -62,7 +74,7 @@ describe( 'reducer', () => {
 				type: READER_RECORD_FOLLOW,
 				payload: { url: 'http://data.blog' },
 			} );
-			chaiExpect( state[ 'data.blog' ] ).to.eql( { is_following: true } );
+			expect( state[ 'data.blog' ] ).toEqual( { is_following: true } );
 		} );
 
 		test( 'should remove a URL when unfollowed', () => {
@@ -74,7 +86,7 @@ describe( 'reducer', () => {
 				type: READER_RECORD_UNFOLLOW,
 				payload: { url: 'http://discover.wordpress.com' },
 			} );
-			chaiExpect( state[ 'discover.wordpress.com' ] ).to.eql( {
+			expect( state[ 'discover.wordpress.com' ] ).toEqual( {
 				blog_ID: 123,
 				is_following: false,
 			} );
@@ -95,14 +107,14 @@ describe( 'reducer', () => {
 			} );
 
 			// Updated follow
-			chaiExpect( state[ 'dailypost.wordpress.com' ] ).to.eql( {
+			expect( state[ 'dailypost.wordpress.com' ] ).toEqual( {
 				is_following: true,
 				blog_ID: 125,
 				URL: 'http://dailypost.wordpress.com',
 			} );
 
 			// Brand new follow
-			chaiExpect( state[ 'postcardsfromthereader.wordpress.com' ] ).to.eql( {
+			expect( state[ 'postcardsfromthereader.wordpress.com' ] ).toEqual( {
 				is_following: true,
 				blog_ID: 126,
 				URL: 'https://postcardsfromthereader.wordpress.com',
@@ -124,7 +136,7 @@ describe( 'reducer', () => {
 					blog_ID: 124,
 				},
 			} );
-			chaiExpect( items( original, { type: SERIALIZE } ) ).to.eql( {
+			expect( items( original, { type: SERIALIZE } ) ).toEqual( {
 				'dailypost.wordpress.com': {
 					feed_URL: 'http://dailypost.wordpress.com',
 					URL: 'http://dailypost.wordpress.com',
@@ -144,7 +156,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			chaiExpect( items( original, { type: DESERIALIZE } ) ).to.eql( original );
+			expect( items( original, { type: DESERIALIZE } ) ).toEqual( original );
 		} );
 
 		test( 'should return the blank state for bad serialized data', () => {
@@ -156,15 +168,13 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			chaiExpect( items( original, { type: DESERIALIZE } ) ).to.eql( {} );
+			expect( items( original, { type: DESERIALIZE } ) ).toEqual( {} );
 		} );
 
-		test( 'should update when passed new post subscription info', () => {
+		test( 'should update when passed new post email subscription info', () => {
 			const original = deepFreeze( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_posts: false,
@@ -176,9 +186,7 @@ describe( 'reducer', () => {
 			const state = items( original, subscribeToNewPostEmail( 123 ) );
 			expect( state ).toEqual( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_posts: true,
@@ -189,12 +197,10 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		test( 'should not update when passed identical new post subscription info', () => {
+		test( 'should not update when passed identical new post email subscription info', () => {
 			const original = deepFreeze( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_posts: true,
@@ -203,15 +209,13 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewPostEmail( 123 ) );
-			chaiExpect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
-		test( 'should not update when passed bad new post subscription info', () => {
+		test( 'should not update when passed bad new post email subscription info', () => {
 			const original = deepFreeze( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_posts: false,
@@ -220,15 +224,13 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewPostEmail( 456 ) );
-			chaiExpect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
-		test( 'should update when passed updated post subscription info', () => {
+		test( 'should update when passed updated post email subscription info', () => {
 			const original = deepFreeze( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_posts: true,
@@ -242,9 +244,7 @@ describe( 'reducer', () => {
 				const state = items( original, updateNewPostEmailSubscription( 123, frequency ) );
 				expect( state ).toEqual( {
 					'example.com': {
-						is_following: true,
-						blog_ID: 123,
-						URL: 'http://example.com',
+						...exampleFollow,
 						delivery_methods: {
 							email: {
 								send_posts: true,
@@ -257,13 +257,11 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		test( 'should not update when passed identical updated post subscription info', () => {
+		test( 'should not update when passed identical updated post email subscription info', () => {
 			[ 'instantly', 'daily', 'weekly' ].forEach( frequency => {
 				const original = deepFreeze( {
 					'example.com': {
-						is_following: true,
-						blog_ID: 123,
-						URL: 'http://example.com',
+						...exampleFollow,
 						delivery_methods: {
 							email: {
 								send_posts: true,
@@ -273,16 +271,14 @@ describe( 'reducer', () => {
 					},
 				} );
 				const state = items( original, updateNewPostEmailSubscription( 123, frequency ) );
-				chaiExpect( state ).to.equal( original );
+				expect( state ).toEqual( original );
 			} );
 		} );
 
-		test( 'should not update when passed bad updated post subscription info', () => {
+		test( 'should not update when passed bad updated post email subscription info', () => {
 			const original = deepFreeze( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_posts: true,
@@ -293,16 +289,14 @@ describe( 'reducer', () => {
 
 			[ 'instantly', 'daily', 'weekly' ].forEach( frequency => {
 				const state = items( original, updateNewPostEmailSubscription( 456, frequency ) );
-				chaiExpect( state ).to.equal( original );
+				expect( state ).toEqual( original );
 			} );
 		} );
 
-		test( 'should update when passed post unsubscription info', () => {
+		test( 'should update when passed post email unsubscription info', () => {
 			const original = deepFreeze( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_posts: true,
@@ -315,9 +309,7 @@ describe( 'reducer', () => {
 			const state = items( original, unsubscribeToNewPostEmail( 123 ) );
 			expect( state ).toEqual( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_posts: false,
@@ -329,12 +321,10 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		test( 'should not update when passed identical post unsubscription info', () => {
+		test( 'should not update when passed identical post email unsubscription info', () => {
 			const original = deepFreeze( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_posts: false,
@@ -344,15 +334,13 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewPostEmail( 123 ) );
-			chaiExpect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
-		test( 'should not update when passed bad post unsubscription info', () => {
+		test( 'should not update when passed bad post email unsubscription info', () => {
 			const original = deepFreeze( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_posts: true,
@@ -362,10 +350,10 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewPostEmail( 456 ) );
-			chaiExpect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
-		test( 'should update when passed comment subscription info', () => {
+		test( 'should update when passed comment email subscription info', () => {
 			const original = deepFreeze( {
 				'example.com': {
 					is_following: true,
@@ -395,12 +383,10 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		test( 'should not update when passed identical comment subscription info', () => {
+		test( 'should not update when passed identical comment email subscription info', () => {
 			const original = deepFreeze( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_comments: true,
@@ -412,12 +398,10 @@ describe( 'reducer', () => {
 			expect( state ).toEqual( original );
 		} );
 
-		test( 'should not update when passed comment sub info about a missing sub', () => {
+		test( 'should not update when passed comment email sub info about a missing sub', () => {
 			const original = deepFreeze( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_comments: true,
@@ -426,15 +410,13 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewCommentEmail( 456 ) );
-			chaiExpect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
-		test( 'should update when passed comment unsubscription info', () => {
+		test( 'should update when passed comment email unsubscription info', () => {
 			const original = deepFreeze( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_comments: true,
@@ -446,9 +428,7 @@ describe( 'reducer', () => {
 			const state = items( original, unsubscribeToNewCommentEmail( 123 ) );
 			expect( state ).toEqual( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_comments: false,
@@ -459,12 +439,10 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		test( 'should not update when passed identical comment unsubscription info', () => {
+		test( 'should not update when passed identical comment email unsubscription info', () => {
 			const original = deepFreeze( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					...exampleFollow,
 					delivery_methods: {
 						email: {
 							send_comments: false,
@@ -473,15 +451,13 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewCommentEmail( 123 ) );
-			chaiExpect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
-		test( 'should not update when passed bad comment unsubscription info', () => {
+		test( 'should not update when passed bad comment email unsubscription info', () => {
 			const original = deepFreeze( {
 				'example.com': {
-					is_following: true,
-					blog_ID: 123,
-					URL: 'http://example.com',
+					exampleFollow,
 					delivery_methods: {
 						email: {
 							send_comments: true,
@@ -490,7 +466,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewCommentEmail( 456 ) );
-			chaiExpect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should update when a new post notification subscription is received', () => {
@@ -654,7 +630,7 @@ describe( 'reducer', () => {
 				type: READER_FOLLOW_ERROR,
 				payload: { feedUrl: 'http://discoverinvalid.wordpress.com', error: 'invalid_feed' },
 			} );
-			chaiExpect( state[ 'discoverinvalid.wordpress.com' ] ).to.eql( {
+			expect( state[ 'discoverinvalid.wordpress.com' ] ).toEqual( {
 				is_following: true,
 				error: 'invalid_feed',
 			} );
@@ -772,24 +748,23 @@ describe( 'reducer', () => {
 		test( 'should mark an existing feed as followed, add in a feed_URL if missing, and leave the rest alone', () => {
 			const original = deepFreeze( {
 				'example.com': {
+					...exampleFollow,
 					is_following: false,
-					blog_ID: 123,
 				},
 			} );
 
 			const state = items( original, follow( 'http://example.com' ) );
-			chaiExpect( state ).to.eql( {
+			expect( state ).toEqual( {
 				'example.com': {
+					...exampleFollow,
 					is_following: true,
-					feed_URL: 'http://example.com',
-					blog_ID: 123,
 				},
 			} );
 		} );
 
 		test( 'should create a new entry for a new follow', () => {
 			const state = items( {}, follow( 'http://example.com' ) );
-			chaiExpect( state ).to.eql( {
+			expect( state ).toEqual( {
 				'example.com': {
 					feed_URL: 'http://example.com',
 					is_following: true,
@@ -818,7 +793,7 @@ describe( 'reducer', () => {
 			};
 
 			const state = items( original, follow( 'http://example.com', subscriptionInfo ) );
-			chaiExpect( state ).to.eql( {
+			expect( state ).toEqual( {
 				'example.com': {
 					...subscriptionInfo,
 					is_following: true,
@@ -847,7 +822,7 @@ describe( 'reducer', () => {
 			};
 
 			const state = items( original, follow( 'http://example.com', subscriptionInfo ) );
-			chaiExpect( state ).to.eql( {
+			expect( state ).toEqual( {
 				'example.com/feed': {
 					...subscriptionInfo,
 					is_following: true,
@@ -861,18 +836,16 @@ describe( 'reducer', () => {
 		test( 'should mark an existing follow as unfollowed', () => {
 			const original = deepFreeze( {
 				'example.com': {
+					...exampleFollow,
 					is_following: true,
-					feed_URL: 'http://example.com',
-					blog_ID: 123,
 				},
 			} );
 
 			const state = items( original, unfollow( 'http://example.com' ) );
-			chaiExpect( state ).to.eql( {
+			expect( state ).toEqual( {
 				'example.com': {
+					...exampleFollow,
 					is_following: false,
-					feed_URL: 'http://example.com',
-					blog_ID: 123,
 				},
 			} );
 		} );
@@ -880,20 +853,19 @@ describe( 'reducer', () => {
 		test( 'should return the original state when already unfollowed', () => {
 			const original = deepFreeze( {
 				'example.com': {
+					...exampleFollow,
 					is_following: false,
-					feed_URL: 'http://example.com',
-					blog_ID: 123,
 				},
 			} );
 
 			const state = items( original, unfollow( 'http://example.com' ) );
-			chaiExpect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should return the same state for an item that does not exist', () => {
 			const original = deepFreeze( {} );
 			const state = items( original, unfollow( 'http://example.com' ) );
-			chaiExpect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 	} );
 
@@ -912,7 +884,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, syncComplete( [ 'http://example2.com' ] ) );
-			chaiExpect( state ).to.eql( {
+			expect( state ).toEqual( {
 				'example2.com': {
 					feed_URL: 'http://example2.com',
 					ID: 2,

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -14,6 +14,8 @@ import {
 	unsubscribeToNewPostEmail,
 	subscribeToNewCommentEmail,
 	unsubscribeToNewCommentEmail,
+	subscribeToNewPostNotifications,
+	unsubscribeToNewPostNotifications,
 	follow,
 	unfollow,
 	syncComplete,
@@ -167,11 +169,12 @@ describe( 'reducer', () => {
 						email: {
 							send_posts: false,
 						},
+						notification: {},
 					},
 				},
 			} );
 			const state = items( original, subscribeToNewPostEmail( 123 ) );
-			chaiExpect( state ).to.eql( {
+			expect( state ).toEqual( {
 				'example.com': {
 					is_following: true,
 					blog_ID: 123,
@@ -180,6 +183,7 @@ describe( 'reducer', () => {
 						email: {
 							send_posts: true,
 						},
+						notification: {},
 					},
 				},
 			} );
@@ -229,13 +233,14 @@ describe( 'reducer', () => {
 						email: {
 							send_posts: true,
 						},
+						notification: {},
 					},
 				},
 			} );
 
 			[ 'instantly', 'daily', 'weekly' ].forEach( frequency => {
 				const state = items( original, updateNewPostEmailSubscription( 123, frequency ) );
-				chaiExpect( state ).to.eql( {
+				expect( state ).toEqual( {
 					'example.com': {
 						is_following: true,
 						blog_ID: 123,
@@ -245,6 +250,7 @@ describe( 'reducer', () => {
 								send_posts: true,
 								post_delivery_frequency: frequency,
 							},
+							notification: {},
 						},
 					},
 				} );
@@ -302,11 +308,12 @@ describe( 'reducer', () => {
 							send_posts: true,
 							post_delivery_frequency: 'instantly',
 						},
+						notification: {},
 					},
 				},
 			} );
 			const state = items( original, unsubscribeToNewPostEmail( 123 ) );
-			chaiExpect( state ).to.eql( {
+			expect( state ).toEqual( {
 				'example.com': {
 					is_following: true,
 					blog_ID: 123,
@@ -316,6 +323,7 @@ describe( 'reducer', () => {
 							send_posts: false,
 							post_delivery_frequency: 'instantly',
 						},
+						notification: {},
 					},
 				},
 			} );
@@ -367,11 +375,12 @@ describe( 'reducer', () => {
 						email: {
 							send_comments: false,
 						},
+						notification: {},
 					},
 				},
 			} );
 			const state = items( original, subscribeToNewCommentEmail( 123 ) );
-			chaiExpect( state ).to.eql( {
+			expect( state ).toEqual( {
 				'example.com': {
 					is_following: true,
 					blog_ID: 123,
@@ -380,6 +389,7 @@ describe( 'reducer', () => {
 						email: {
 							send_comments: true,
 						},
+						notification: {},
 					},
 				},
 			} );
@@ -399,7 +409,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewCommentEmail( 123 ) );
-			chaiExpect( state ).to.equal( original );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should not update when passed comment sub info about a missing sub', () => {
@@ -429,11 +439,12 @@ describe( 'reducer', () => {
 						email: {
 							send_comments: true,
 						},
+						notification: {},
 					},
 				},
 			} );
 			const state = items( original, unsubscribeToNewCommentEmail( 123 ) );
-			chaiExpect( state ).to.eql( {
+			expect( state ).toEqual( {
 				'example.com': {
 					is_following: true,
 					blog_ID: 123,
@@ -442,6 +453,7 @@ describe( 'reducer', () => {
 						email: {
 							send_comments: false,
 						},
+						notification: {},
 					},
 				},
 			} );
@@ -479,6 +491,158 @@ describe( 'reducer', () => {
 			} );
 			const state = items( original, unsubscribeToNewCommentEmail( 456 ) );
 			chaiExpect( state ).to.equal( original );
+		} );
+
+		test( 'should update when a new post notification subscription is received', () => {
+			const original = deepFreeze( {
+				'example.com': {
+					is_following: true,
+					blog_ID: 123,
+					URL: 'http://example.com',
+					delivery_methods: {
+						email: {
+							send_posts: false,
+						},
+						notification: {
+							send_posts: false,
+						},
+					},
+				},
+			} );
+			const state = items( original, subscribeToNewPostNotifications( 123 ) );
+			expect( state ).toEqual( {
+				'example.com': {
+					is_following: true,
+					blog_ID: 123,
+					URL: 'http://example.com',
+					delivery_methods: {
+						email: {
+							send_posts: false,
+						},
+						notification: {
+							send_posts: true,
+						},
+					},
+				},
+			} );
+		} );
+
+		test( 'should not update when a new post notification subscription is identical', () => {
+			const original = deepFreeze( {
+				'example.com': {
+					is_following: true,
+					blog_ID: 123,
+					URL: 'http://example.com',
+					delivery_methods: {
+						email: {
+							send_posts: true,
+						},
+						notification: {
+							send_posts: true,
+						},
+					},
+				},
+			} );
+			const state = items( original, subscribeToNewPostNotifications( 123 ) );
+			expect( state ).toEqual( original );
+		} );
+
+		test( 'should not update when a new post notification subscription for a non-existent follow is received', () => {
+			const original = deepFreeze( {
+				'example.com': {
+					is_following: true,
+					blog_ID: 123,
+					URL: 'http://example.com',
+					delivery_methods: {
+						email: {
+							send_posts: false,
+						},
+						notification: {
+							send_posts: false,
+						},
+					},
+				},
+			} );
+			const state = items( original, subscribeToNewPostNotifications( 456 ) );
+			expect( state ).toEqual( original );
+		} );
+
+		test( 'should update when a new post notification unsubscription is received', () => {
+			const original = deepFreeze( {
+				'example.com': {
+					is_following: true,
+					blog_ID: 123,
+					URL: 'http://example.com',
+					delivery_methods: {
+						email: {
+							send_posts: true,
+							post_delivery_frequency: 'instantly',
+						},
+						notification: {
+							send_posts: true,
+						},
+					},
+				},
+			} );
+			const state = items( original, unsubscribeToNewPostNotifications( 123 ) );
+			expect( state ).toEqual( {
+				'example.com': {
+					is_following: true,
+					blog_ID: 123,
+					URL: 'http://example.com',
+					delivery_methods: {
+						email: {
+							send_posts: true,
+							post_delivery_frequency: 'instantly',
+						},
+						notification: {
+							send_posts: false,
+						},
+					},
+				},
+			} );
+		} );
+
+		test( 'should not update when a new post notification unsubscription is identical', () => {
+			const original = deepFreeze( {
+				'example.com': {
+					is_following: true,
+					blog_ID: 123,
+					URL: 'http://example.com',
+					delivery_methods: {
+						email: {
+							send_posts: false,
+							post_delivery_frequency: 'instantly',
+						},
+						notification: {
+							send_posts: false,
+						},
+					},
+				},
+			} );
+			const state = items( original, unsubscribeToNewPostNotifications( 123 ) );
+			expect( state ).toEqual( original );
+		} );
+
+		test( 'should not update when a new post notification unsubscription for a non-existent follow is received', () => {
+			const original = deepFreeze( {
+				'example.com': {
+					is_following: true,
+					blog_ID: 123,
+					URL: 'http://example.com',
+					delivery_methods: {
+						email: {
+							send_posts: true,
+							post_delivery_frequency: 'instantly',
+						},
+						notification: {
+							send_posts: true,
+						},
+					},
+				},
+			} );
+			const state = items( original, unsubscribeToNewPostNotifications( 456 ) );
+			expect( state ).toEqual( original );
 		} );
 
 		test( 'should insert a follow error if one is received', () => {

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -156,7 +156,7 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			expect( items( original, { type: DESERIALIZE } ) ).toEqual( original );
+			expect( items( original, { type: DESERIALIZE } ) ).toBe( original );
 		} );
 
 		test( 'should return the blank state for bad serialized data', () => {
@@ -209,7 +209,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewPostEmail( 123 ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should not update when passed bad new post email subscription info', () => {
@@ -224,7 +224,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewPostEmail( 456 ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should update when passed updated post email subscription info', () => {
@@ -271,7 +271,7 @@ describe( 'reducer', () => {
 					},
 				} );
 				const state = items( original, updateNewPostEmailSubscription( 123, frequency ) );
-				expect( state ).toEqual( original );
+				expect( state ).toBe( original );
 			} );
 		} );
 
@@ -289,7 +289,7 @@ describe( 'reducer', () => {
 
 			[ 'instantly', 'daily', 'weekly' ].forEach( frequency => {
 				const state = items( original, updateNewPostEmailSubscription( 456, frequency ) );
-				expect( state ).toEqual( original );
+				expect( state ).toBe( original );
 			} );
 		} );
 
@@ -334,7 +334,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewPostEmail( 123 ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should not update when passed bad post email unsubscription info', () => {
@@ -350,7 +350,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewPostEmail( 456 ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should update when passed comment email subscription info', () => {
@@ -395,7 +395,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewCommentEmail( 123 ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should not update when passed comment email sub info about a missing sub', () => {
@@ -410,7 +410,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewCommentEmail( 456 ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should update when passed comment email unsubscription info', () => {
@@ -451,7 +451,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewCommentEmail( 123 ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should not update when passed bad comment email unsubscription info', () => {
@@ -466,7 +466,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewCommentEmail( 456 ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should update when a new post notification subscription is received', () => {
@@ -520,7 +520,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewPostNotifications( 123 ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should not update when a new post notification subscription for a non-existent follow is received', () => {
@@ -540,7 +540,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, subscribeToNewPostNotifications( 456 ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should update when a new post notification unsubscription is received', () => {
@@ -597,7 +597,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewPostNotifications( 123 ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should not update when a new post notification unsubscription for a non-existent follow is received', () => {
@@ -618,7 +618,7 @@ describe( 'reducer', () => {
 				},
 			} );
 			const state = items( original, unsubscribeToNewPostNotifications( 456 ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should insert a follow error if one is received', () => {
@@ -740,7 +740,7 @@ describe( 'reducer', () => {
 				payload: incomingSite,
 			} );
 
-			expect( state[ 'postcardsfromthereader.wordpress.com' ] ).toEqual( undefined );
+			expect( state[ 'postcardsfromthereader.wordpress.com' ] ).toBe( undefined );
 		} );
 	} );
 
@@ -859,13 +859,13 @@ describe( 'reducer', () => {
 			} );
 
 			const state = items( original, unfollow( 'http://example.com' ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 
 		test( 'should return the same state for an item that does not exist', () => {
 			const original = deepFreeze( {} );
 			const state = items( original, unfollow( 'http://example.com' ) );
-			expect( state ).toEqual( original );
+			expect( state ).toBe( original );
 		} );
 	} );
 


### PR DESCRIPTION
This PR updates the `state/reader/follows` reducer to store new post notification subscribes and unsubscribes.

### To test

```
npm run test-client client/state/reader/follows/test/reducer.js
```