### PR TITLE
Store Orders: UI updates

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/add-items.js
+++ b/client/extensions/woocommerce/app/order/order-details/add-items.js
@@ -3,8 +3,9 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+import { isObject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +15,11 @@ import OrderFeeDialog from './fee-dialog';
 import OrderProductDialog from './product-dialog';
 
 class OrderAddItems extends Component {
+	static propTypes = {
+		orderId: PropTypes.oneOfType( [ PropTypes.number, PropTypes.object ] ).isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
 	state = {
 		showDialog: false,
 	};
@@ -23,15 +29,18 @@ class OrderAddItems extends Component {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { orderId, translate } = this.props;
+		const isNewOrder = isObject( orderId );
 		return (
 			<div className="order-details__actions">
 				<Button borderless onClick={ this.toggleDialog( 'fee' ) }>
-					<Gridicon icon="plus-small" />
 					{ translate( 'Add Fee' ) }
 				</Button>
-				<Button primary onClick={ this.toggleDialog( 'product' ) }>
-					<Gridicon icon="plus-small" />
+				<Button
+					borderless={ ! isNewOrder }
+					primary={ isNewOrder }
+					onClick={ this.toggleDialog( 'product' ) }
+				>
 					{ translate( 'Add Product' ) }
 				</Button>
 				<OrderFeeDialog

--- a/client/extensions/woocommerce/app/order/order-details/add-items.js
+++ b/client/extensions/woocommerce/app/order/order-details/add-items.js
@@ -33,15 +33,15 @@ class OrderAddItems extends Component {
 		const isNewOrder = isObject( orderId );
 		return (
 			<div className="order-details__actions">
-				<Button borderless onClick={ this.toggleDialog( 'fee' ) }>
-					{ translate( 'Add Fee' ) }
-				</Button>
 				<Button
 					borderless={ ! isNewOrder }
 					primary={ isNewOrder }
 					onClick={ this.toggleDialog( 'product' ) }
 				>
 					{ translate( 'Add Product' ) }
+				</Button>
+				<Button borderless onClick={ this.toggleDialog( 'fee' ) }>
+					{ translate( 'Add Fee' ) }
 				</Button>
 				<OrderFeeDialog
 					isVisible={ 'fee' === this.state.showDialog }

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -57,6 +57,16 @@
 	.button + .button {
 		margin-left: 24px;
 	}
+
+	.button {
+		&.is-borderless {
+			color: $blue-wordpress;
+
+			&:hover {
+				color: $link-highlight;
+			}
+		}
+	}
 }
 
 // Duplicating `.table` for increased specificity

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -53,15 +53,9 @@
 	margin: 0 -24px;
 	padding: 16px 80px 16px 24px;
 	border-bottom: 1px solid lighten($gray, 30%);
-	text-align: right;
 
 	.button + .button {
 		margin-left: 24px;
-	}
-
-	// Fix alignment with neighboring primary button
-	.button.is-borderless {
-		padding-top: 3px;
 	}
 }
 

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -364,10 +364,18 @@ class OrderDetailsTable extends Component {
 			'is-editing': isEditing,
 		} );
 
+		const emptyLines = (
+			<TableRow>
+				<TableItem colSpan={ isEditing ? 6 : 5 }>
+					{ translate( 'There are no products on this order.' ) }
+				</TableItem>
+			</TableRow>
+		);
+
 		return (
 			<div>
 				<Table className={ tableClasses } header={ this.renderTableHeader() }>
-					{ order.line_items.map( this.renderOrderItem ) }
+					{ order.line_items.length ? order.line_items.map( this.renderOrderItem ) : emptyLines }
 					{ order.fee_lines.map( this.renderOrderFee ) }
 				</Table>
 				{ isEditing && <OrderAddItems orderId={ order.id } /> }

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import { find, findIndex, get, noop } from 'lodash';
+import { every, find, findIndex, get, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -372,10 +372,13 @@ class OrderDetailsTable extends Component {
 			</TableRow>
 		);
 
+		// There are line_items, and they're not all quantity: 0
+		const hasLineItems = order.line_items.length && ! every( order.line_items, { quantity: 0 } );
+
 		return (
 			<div>
 				<Table className={ tableClasses } header={ this.renderTableHeader() }>
-					{ order.line_items.length ? order.line_items.map( this.renderOrderItem ) : emptyLines }
+					{ hasLineItems ? order.line_items.map( this.renderOrderItem ) : emptyLines }
 					{ order.fee_lines.map( this.renderOrderFee ) }
 				</Table>
 				{ isEditing && <OrderAddItems orderId={ order.id } /> }

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -370,7 +370,7 @@ class OrderDetailsTable extends Component {
 					{ order.line_items.map( this.renderOrderItem ) }
 					{ order.fee_lines.map( this.renderOrderFee ) }
 				</Table>
-				{ isEditing && <OrderAddItems /> }
+				{ isEditing && <OrderAddItems orderId={ order.id } /> }
 
 				<Table className={ totalsClasses } compact>
 					{ this.renderCoupons() }


### PR DESCRIPTION
This PR updates the orders screen with some UI tweaks:

- the button fix from https://github.com/Automattic/wp-calypso/pull/20856#issuecomment-355032726 (which removes the primary button style from "Add Products" in the edit state, and left-aligns the buttons)
- a string for "empty" orders – either all items have been deleted, or the order was just created (happy to change this copy, of course)

<img width="946" alt="screen shot 2018-01-09 at 12 54 12 pm" src="https://user-images.githubusercontent.com/541093/34735117-41daa0c8-f53c-11e7-9839-4dd3287d7723.png">

@kellychoffman @jameskoster If you have any other small tweaks for the new orders screen, let me know here & I'll address it before writing up an internal call for testing.

**To test**

- Create a new order: `/store/order/:site`
- The products section should read "There are no products on this order."
- The buttons should be left aligned
- Edit an existing order (pending-payment) - by saving the above order 😁
- The buttons should be left aligned, and Add Products is not a primary button