### PR TITLE
Remove the WEBPACK_OUTPUT_JSON env variable from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "npm": "5.5.1"
   },
   "scripts": {
-    "preanalyze-bundles": "cross-env-shell WEBPACK_OUTPUT_JSON=1 CALYPSO_ENV=production npm run -s env -- node --max_old_space_size=8192 ./node_modules/.bin/webpack --config webpack.config.js --profile --json > stats.json",
+    "preanalyze-bundles": "cross-env-shell CALYPSO_ENV=production npm run -s env -- node --max_old_space_size=8192 ./node_modules/.bin/webpack --config webpack.config.js --profile --json > stats.json",
     "analyze-bundles": "webpack-bundle-analyzer stats.json public -h 0.0.0.0 -p 9898 -s gzip",
     "analyze-css": "node bin/analyze-css.js",
     "autoprefixer": "postcss -r --use autoprefixer",

--- a/server/bundler/README.md
+++ b/server/bundler/README.md
@@ -86,11 +86,10 @@ In most of the environments that Calypso is deployed to, the static assets are s
 
 ### Webpack Stats
 
-Webpack stats can be serialized as JSON for the purposes of analyzing the results of a build. This can be used with tools like [Webpack Analyze](https://webpack.github.io/analyse/) or [Webpack Visualizer](https://chrisbateman.github.io/webpack-visualizer/) to visualize the modules and dependencies comprising a build. To generate a JSON file during a build, use the `WEBPACK_OUTPUT_JSON` environment variable flag:
+Webpack stats can be serialized as JSON for the purposes of analyzing the results of a build. This can be used with tools like [Webpack Analyze](https://webpack.github.io/analyse/) or [Webpack Visualizer](https://chrisbateman.github.io/webpack-visualizer/) to visualize the modules and dependencies comprising a build. To generate a JSON file during a build, use the `preanalyze-bundles` NPM script:
 
 ```bash
-WEBPACK_OUTPUT_JSON=1 NODE_ENV=production npm run build
+NODE_ENV=production npm run preanalyze-bundles
 ```
 
 This will cause a JSON file `stats.json` to be written to the root project directory once the build succeeds.
-


### PR DESCRIPTION
It was used before we integrated the `UglifyJsPlugin` directly into the Webpack config.
It has no purpose today and can be removed.