### PR TITLE
WordAds Earnings Report: Update "Attempted Impressions" to "Ads Served"

### DIFF
--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -150,14 +150,38 @@ class AdsFormEarnings extends Component {
 	getStatus( status ) {
 		const { translate } = this.props;
 		const statuses = {
-			0: translate( 'Unpaid' ),
-			1: translate( 'Paid' ),
-			2: translate( 'a8c-only' ),
-			3: translate( 'Pending (Missing Tax Info)' ),
-			4: translate( 'Pending (Invalid PayPal)' ),
+			0: {
+				name: translate( 'Unpaid' ),
+				tooltip: translate( 'Payment is on hold until the end of the current month.' ),
+			},
+			1: {
+				name: translate( 'Paid' ),
+				tooltip: translate( 'Payment has been processed through PayPal.' ),
+			},
+			2: {
+				name: translate( 'a8c-only' ),
+			},
+			3: {
+				name: translate( 'Pending (Missing Tax Info)' ),
+				tooltip: translate(
+					'Payment is pending due to missing information. ' +
+						'You can provide tax information in the settings screen.'
+				),
+			},
+			4: {
+				name: translate( 'Pending (Invalid PayPal)' ),
+				tooltip: translate(
+					'Payment processing has failed due to invalid PayPal address. ' +
+						'You can correct the PayPal address in the settings screen.'
+				),
+			},
 		};
 
-		return statuses[ status ] ? statuses[ status ] : '?';
+		return (
+			<span title={ statuses[ status ].tooltip ? statuses[ status ].tooltip : '' }>
+				{ statuses[ status ] ? statuses[ status ].name : '?' }
+			</span>
+		);
 	}
 
 	payoutNotice() {
@@ -194,31 +218,42 @@ class AdsFormEarnings extends Component {
 
 		return (
 			<div className="ads__module-content-text module-content-text module-content-text-info">
-				<p>{ translate( 'Payments can have the following statuses:' ) }</p>
-				<ul className="ads__earnings-history-statuses-list">
-					<li className="ads__earnings-history-status">
-						<strong>{ translate( 'Unpaid:' ) } </strong>
-						{ translate( 'Payment is on hold until the end of the current month.' ) }
+				<p>
+					<strong>{ translate( 'Ads Served' ) } </strong>
+					{ translate(
+						'is the number of ads we attempted to display on your site (page impressions x available ad slots).'
+					) }
+				</p>
+
+				<p>
+					{ translate(
+						'Not every ad served will result in a paid impression. This can happen when:'
+					) }
+				</p>
+
+				<ul className="ads__earnings-history-info-list">
+					<li className="ads__earnings-history-info">
+						{ translate( 'A visitor is using an ad blocker, preventing ads from showing.' ) }
 					</li>
-					<li className="ads__earnings-history-status">
-						<strong>{ translate( 'Paid:' ) } </strong>
-						{ translate( 'Payment has been processed through PayPal.' ) }
-					</li>
-					<li className="ads__earnings-history-status">
-						<strong>{ translate( 'Pending (Missing Tax Info):' ) } </strong>
+					<li className="ads__earnings-history-info">
 						{ translate(
-							'Payment is pending due to missing information. ' +
-								'You can provide tax information in the settings screen.'
+							'A visitor leaves your site before ads can fully load in their browser.'
 						) }
 					</li>
-					<li className="ads__earnings-history-status">
-						<strong>{ translate( 'Pending (Invalid PayPal):' ) } </strong>
+					<li className="ads__earnings-history-info">
 						{ translate(
-							'Payment processing has failed due to invalid PayPal address. ' +
-								'You can correct the PayPal address in the settings screen.'
+							'There were no advertisers who bid higher than the minimum price required to display their ad.'
 						) }
 					</li>
 				</ul>
+
+				<hr />
+
+				<p>
+					<em>
+						{ translate( 'Earnings fluctuate based on real-time bidding from advertisers.' ) }
+					</em>
+				</p>
 			</div>
 		);
 	}
@@ -314,9 +349,7 @@ class AdsFormEarnings extends Component {
 							<tr>
 								<th className="ads__earnings-history-header">{ translate( 'Period' ) }</th>
 								<th className="ads__earnings-history-header">{ translate( 'Earnings' ) }</th>
-								<th className="ads__earnings-history-header">
-									{ translate( 'Attempted Impressions' ) }
-								</th>
+								<th className="ads__earnings-history-header">{ translate( 'Ads Served' ) }</th>
 								<th className="ads__earnings-history-header">{ translate( 'Status' ) }</th>
 							</tr>
 						</thead>

--- a/client/my-sites/ads/style.scss
+++ b/client/my-sites/ads/style.scss
@@ -84,13 +84,21 @@
 			display: inline-block;
 		}
 	}
+
+	tbody tr:hover {
+		background-color: #f3f6f8;
+	}
 }
 
-.module-content-text ul.ads__earnings-history-statuses-list {
+.ads__module-content-text p {
+	text-align: left;
+}
+
+.module-content-text ul.ads__earnings-history-info-list {
 	margin: 1em 24px 1em 40px;
 }
 
-.ads__earnings-history-status {
+.ads__earnings-history-info {
 	padding-bottom: 10px;
 	text-align: left;
 }


### PR DESCRIPTION
### Updates

1. Remove the status column explanation from the infobox in the earnings & adjustment history tables. This info has been moved into tooltips on each individual status value.

2. Update "Attempted Impressions" column label to "Ads Served", and add a corresponding explanation for this term to the table infobox.

3. Also adds the following notice to the infobox: "Earnings fluctuate based on real-time bidding from advertisers."

4. Add bg color hover effect on each table row. This is seen elsewhere in calypso (for example in Stats).