### PR TITLE
JP onboarding: make add Business Name form fields mandatory

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -82,7 +82,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 									autoFocus={ fieldName === 'name' }
 									id={ fieldName }
 									onChange={ this.getChangeHandler( fieldName ) }
-									required={ fieldName === 'name' }
+									required
 									value={ this.state[ fieldName ] }
 								/>
 							</FormFieldset>

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -49,7 +49,8 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		};
 	}
 
-	handleSubmit = () => {
+	handleSubmit = event => {
+		event.preventDefault();
 		const { siteId } = this.props;
 		this.props.saveJetpackOnboardingSettings( siteId, { businessAddress: this.state } );
 		page( this.props.getForwardUrl() );

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -82,7 +82,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 									autoFocus={ fieldName === 'name' }
 									id={ fieldName }
 									onChange={ this.getChangeHandler( fieldName ) }
-									required
+									required={ fieldName !== 'state' }
 									value={ this.state[ fieldName ] }
 								/>
 							</FormFieldset>

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -6,6 +6,7 @@
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 import { map } from 'lodash';
 /**
  * Internal dependencies
@@ -48,13 +49,14 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		};
 	}
 
-	handleAddBusinessAddress = () => {
+	handleSubmit = () => {
 		const { siteId } = this.props;
 		this.props.saveJetpackOnboardingSettings( siteId, { businessAddress: this.state } );
+		page( this.props.getForwardUrl() );
 	};
 
 	render() {
-		const { getForwardUrl, translate } = this.props;
+		const { translate } = this.props;
 		const headerText = translate( 'Add a business address.' );
 		const subHeaderText = translate(
 			'Enter your business address to have a map added to your website.'
@@ -76,14 +78,15 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 							<FormFieldset key={ fieldName }>
 								<FormLabel htmlFor={ fieldName }>{ fieldLabel }</FormLabel>
 								<FormTextInput
+									autoFocus={ fieldName === 'name' }
 									id={ fieldName }
 									onChange={ this.getChangeHandler( fieldName ) }
+									required={ fieldName === 'name' }
 									value={ this.state[ fieldName ] }
-									autoFocus={ fieldName === 'name' }
 								/>
 							</FormFieldset>
 						) ) }
-						<Button href={ getForwardUrl() } onClick={ this.handleAddBusinessAddress } primary>
+						<Button primary type="submit">
 							{ translate( 'Next Step' ) }
 						</Button>
 					</form>

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -73,7 +73,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<Card className="steps__form">
-					<form>
+					<form onSubmit={ this.handleSubmit }>
 						{ map( this.fields, ( fieldLabel, fieldName ) => (
 							<FormFieldset key={ fieldName }>
 								<FormLabel htmlFor={ fieldName }>{ fieldLabel }</FormLabel>


### PR DESCRIPTION
Analogue to https://github.com/Automattic/wp-calypso/pull/21346.

This patch sets up only Business Name as a mandatory field. Should we use any other fields?

**To test:**
Please use the test instruction in https://github.com/Automattic/wp-calypso/pull/21346
replacing `Site Title` step with the `add Business Address` one.
  