### PR TITLE
JPO: replace page.redirect() with page() when redirecting

### DIFF
--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -43,7 +43,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 			siteTitle: this.state.title,
 			siteDescription: this.state.description,
 		} );
-		page.redirect( this.props.getForwardUrl() );
+		page( this.props.getForwardUrl() );
 	};
 
 	render() {

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -38,7 +38,8 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 		this.setState( { title: event.target.value } );
 	};
 
-	handleSubmit = () => {
+	handleSubmit = event => {
+		event.preventDefault();
 		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
 			siteTitle: this.state.title,
 			siteDescription: this.state.description,


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/21346 introduced a missed redirection using `page.redirect(string)`,  which (apparently) wipes the state clean (as would redirecting away from Calypso).

This PR replaces it with `page(string)` when redirecting to the following step of the flow.

**To test:**
* checkout this branch
* follow the instructions in https://github.com/Automattic/wp-calypso/pull/21346  to arrive at the 1st step of the flow
* verify that after filling in the fields the redirection to the 2nd step is completed.
  