### PR TITLE
Jetpack Onboarding: Bring back Business Address animations

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -64,7 +64,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		);
 
 		return (
-			<Fragment>
+			<div className="steps__main">
 				<DocumentHead title={ translate( 'Business Address ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
 					path={ '/jetpack/onboarding/' + STEPS.BUSINESS_ADDRESS + '/:site' }
@@ -92,7 +92,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 						</Button>
 					</form>
 				</Card>
-			</Fragment>
+			</div>
 		);
 	}
 }


### PR DESCRIPTION
It seems in #21083 (probably due to a bad rebase) we removed the animations from the Business Address step. This PR brings them back.

To test:
1. Checkout this branch on your local Calypso.
1. Make sure your JP sandbox is running the latest Jetpack master.
1. Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
1. After you land the JPO flow, skip to the Business Address step and verify it's presented with a quick appear+fade animation.