### PR TITLE
External media: fix limits and allow different limits per service

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2748,6 +2748,17 @@ Undocumented.prototype.initiateTransfer = function( siteId, plugin, theme, onPro
 	} );
 };
 
+Undocumented.prototype.externalMediaQuery = function( query ) {
+	// the external-media endpoint takes `max` instead of `number`, and different
+	// sources require different max limits to account for stability or API usage limits
+	const limits = {
+		pexels: 40,
+		google_photos: 20,
+	};
+	const limit = limits[ query.source ] || query.number;
+	return { ...query, max: limit, number: limit };
+};
+
 /**
  * Returns a list of media from an external media service. Similar to Site.mediaList in use, but
  * with a more restricted set of query params.
@@ -2759,8 +2770,8 @@ Undocumented.prototype.initiateTransfer = function( siteId, plugin, theme, onPro
  */
 Undocumented.prototype.externalMediaList = function( query, fn ) {
 	debug( `/meta/external-media/${ query.source }` );
-
-	return this.wpcom.req.get( `/meta/external-media/${ query.source }`, query, fn );
+	const externalQuery = this.externalMediaQuery( query );
+	return this.wpcom.req.get( `/meta/external-media/${ externalQuery.source }`, externalQuery, fn );
 };
 
 /**

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2770,8 +2770,8 @@ Undocumented.prototype.externalMediaQuery = function( query ) {
  */
 Undocumented.prototype.externalMediaList = function( query, fn ) {
 	debug( `/meta/external-media/${ query.source }` );
-	//const externalQuery = this.externalMediaQuery( query );
-	return this.wpcom.req.get( `/meta/external-media/${ query.source }`, query, fn );
+	const externalQuery = this.externalMediaQuery( query );
+	return this.wpcom.req.get( `/meta/external-media/${ externalQuery.source }`, externalQuery, fn );
 };
 
 /**

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2770,8 +2770,8 @@ Undocumented.prototype.externalMediaQuery = function( query ) {
  */
 Undocumented.prototype.externalMediaList = function( query, fn ) {
 	debug( `/meta/external-media/${ query.source }` );
-	const externalQuery = this.externalMediaQuery( query );
-	return this.wpcom.req.get( `/meta/external-media/${ externalQuery.source }`, externalQuery, fn );
+	//const externalQuery = this.externalMediaQuery( query );
+	return this.wpcom.req.get( `/meta/external-media/${ query.source }`, query, fn );
 };
 
 /**


### PR DESCRIPTION
This fixes two issues.

1) The external-media API uses `max` instead of `number`. This patch prepares a query for use with the external-media endpoint just before the request is made. It's done at this point so that we don't alter any queries used by the Media List.

2) Allows us to specify a limit per service. This is because we have a limited number of API calls per month for the Pexels service, and when you perform a search, the Media Library can display up to 60 images by default. With our existing limit of 20, that's 3 API calls for every search. Bumping that up to 40 (Pexels maximum limit) reduces that to 2, reducing the number of API calls by 33%.