### PR TITLE
Billing: fix wrong payment method displayed

### DIFF
--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -74,7 +74,7 @@ class BillingReceipt extends React.Component {
 
 		if ( transaction.pay_part === 'paypal_express' ) {
 			text = translate( 'PayPal' );
-		} else if ( 'XXXX' !== transaction.cc_num.toUpperCase() ) {
+		} else if ( 'XXXX' !== transaction.cc_num ) {
 			text = translate( '%(cardType)s ending in %(cardNum)s', {
 				args: {
 					cardType: transaction.cc_type.toUpperCase(),

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -75,7 +75,12 @@ class BillingReceipt extends React.Component {
 		if ( transaction.pay_part === 'paypal_express' ) {
 			text = translate( 'PayPal' );
 		} else if ( 'XXXX' !== transaction.cc_num.toUpperCase() ) {
-			text = transaction.cc_type.toUpperCase() + translate( ' ending in ' ) + transaction.cc_num;
+			text = translate( '%(cardType)s ending in %(cardNum)s', {
+				args: {
+					cardType: transaction.cc_type.toUpperCase(),
+					cardNum: transaction.cc_num,
+				},
+			} );
 		} else {
 			return null;
 		}

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -74,10 +74,10 @@ class BillingReceipt extends React.Component {
 
 		if ( transaction.pay_part === 'paypal_express' ) {
 			text = translate( 'PayPal' );
-		} else if ( 'NOT STORED' === transaction.cc_type.toUpperCase() ) {
-			text = translate( 'Credit Card' );
-		} else {
+		} else if ( 'XXXX' !== transaction.cc_num.toUpperCase() ) {
 			text = transaction.cc_type.toUpperCase() + translate( ' ending in ' ) + transaction.cc_num;
+		} else {
+			return null;
 		}
 
 		return (


### PR DESCRIPTION
There are three issues with the current code:

1. It compares `cc_type` with "NOT STORED", while this string is coming from the server translated.
This means that user in French will see something like this
<img width="247" alt="screen shot 2018-01-10 at 13 26 47" src="https://user-images.githubusercontent.com/844866/34770497-0c837aa2-f60a-11e7-81f5-83905088ce87.png">

Which says "Payment method: NOT STORED expiring on XXXX" :(

2. The string fro "card type ending in XXXX" is concatenated, meaning that translating it is difficult. For evidence, the French version above says "expiring in" instead of "ending in". 

3. We assume all non-stored payment methods are credit card which is wrong (i.e we also have iDEAL, Giropay etc. )

While the backend data isn't detailed enough yet to let us know about these payment methods, we should for now just not display the method instead.

