### PR TITLE
Jetpack connect: Remove debug placeholder

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -191,7 +191,7 @@ export class JetpackAuthorize extends Component {
 		const { state, redirectUri } = this.props.authQuery;
 		const code = this.props.authorizationData.authorizationCode;
 		const url = addQueryArgs( { code, state }, redirectUri );
-		debug( 'xmlrpc fallback to %s', url );
+		debug( 'xmlrpc fallback to', url );
 		this.externalRedirectOnce( url );
 	}
 


### PR DESCRIPTION
This debug statement added in #21104 produces the correct output in development, but not in production:

![debug-wat](https://user-images.githubusercontent.com/841763/34771569-41339016-f605-11e7-98f8-ba131998bd84.png)

The `%s` placeholder should be replaced with the url string `"https://…"`, but apparently debug's current console color is insterted 🤷‍♂️ 😕 

This PR drops the placeholder which produces the same result.

## Testing
Follow the xml-rpc steps in #21104 to see the debug output.