### PR TITLE
Measure how much time it takes to load log-in

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -87,6 +87,8 @@ export class LoginForm extends Component {
 					elapsedMs: Date.now() - window.calypsoLoadStartTime[ 'log-in' ].startTimestamp,
 					path: '/log-in',
 				} );
+
+				delete window.calypsoLoadStartTime[ 'log-in' ];
 			}
 		}
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -81,10 +81,10 @@ export class LoginForm extends Component {
 
 	componentDidMount() {
 		if ( this.state.isFormDisabledWhileLoading ) {
-			if ( window && window.calypsoLoadStartTime[ 'log-in' ] ) {
+			if ( window && window.calypsoLoadStartTime && window.calypsoLoadStartTime[ 'log-in' ] ) {
 				this.props.recordTracksEvent( 'calypso_load_end', {
 					...window.calypsoLoadStartTime[ 'log-in' ],
-					elapsedMs: Date.now() - window.calypsoLoadStartTime[ 'log-in' ].timestamp,
+					elapsedMs: Date.now() - window.calypsoLoadStartTime[ 'log-in' ].startTimestamp,
 					path: '/log-in',
 				} );
 			}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -80,6 +80,16 @@ export class LoginForm extends Component {
 	};
 
 	componentDidMount() {
+		if ( this.state.isFormDisabledWhileLoading ) {
+			if ( window && window.calypsoLoadStartTime[ 'log-in' ] ) {
+				this.props.recordTracksEvent( 'calypso_load_end', {
+					...window.calypsoLoadStartTime[ 'log-in' ],
+					elapsedMs: Date.now() - window.calypsoLoadStartTime[ 'log-in' ].timestamp,
+					path: '/log-in',
+				} );
+			}
+		}
+
 		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { isFormDisabledWhileLoading: false }, () => {
 			this.usernameOrEmail && this.usernameOrEmail.focus();

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -84,7 +84,7 @@ export class LoginForm extends Component {
 			if ( window && window.calypsoLoadStartTime && window.calypsoLoadStartTime[ 'log-in' ] ) {
 				this.props.recordTracksEvent( 'calypso_load_end', {
 					...window.calypsoLoadStartTime[ 'log-in' ],
-					elapsedMs: Date.now() - window.calypsoLoadStartTime[ 'log-in' ].startTimestamp,
+					elapsedMs: window.performance.now() - window.calypsoLoadStartTime[ 'log-in' ].startTimestamp,
 					path: '/log-in',
 				} );
 

--- a/server/pages/index.pug
+++ b/server/pages/index.pug
@@ -227,6 +227,43 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			})();
 
 		script(type='text/javascript')!='COMMIT_SHA = ' + sanitize.jsonStringifyForHtml( commitSha )
+		script.
+			(function () {
+				function createUUID( timestamp ){
+					var dt = timestamp;
+					var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+						var r = ( dt + Math.random()*16)%16 | 0;
+						dt = Math.floor(dt/16);
+						return (c=='x' ? r :(r &0x3|0x8) ).toString( 16 );
+					} );
+					return uuid;
+				}
+
+				try {
+					var pathName = window.location.pathname.split( "/" ).slice( 1, 2 )[ 0 ];
+					if ( pathName === "log-in" ) {
+						if ( ! window.calypsoLoadStartTime ) {
+							window.calypsoLoadStartTime = {};
+						}
+						var timestamp = Date.now();
+						window.calypsoLoadStartTime[ pathName ] = {
+							timestamp: timestamp,
+							uuid: createUUID( timestamp ),
+						};
+						if ( ! window._tkq ) {
+							window._tkq = [];
+						}
+						window._tkq.push( [ 'recordEvent', 'calypso_load_start', {
+							timestamp: window.calypsoLoadStartTime[ pathName ].timestamp,
+							uuid: window.calypsoLoadStartTime[ pathName ].uuid,
+							path: "/" + pathName
+						} ] );
+					}
+				} catch ( ex ) {
+					console.error( 'Unable to report load time', ex );
+				}
+			})();
+
 		if user
 			script(type='text/javascript')!='var currentUser = ' + sanitize.jsonStringifyForHtml( user )
 		if app

--- a/server/pages/index.pug
+++ b/server/pages/index.pug
@@ -261,7 +261,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 
 				try {
 					var pathName = window.location.pathname.split( "/" ).slice( 1, 2 )[ 0 ];
-					if ( pathName === "log-in" && 'production' === window.configData.env ) {
+					if ( pathName === 'log-in' && 'production' === window.configData.env ) {
 
 						var stats = recordTracksEvent( 'calypso_load_start' );
 						if ( ! window.calypsoLoadStartTime ) {

--- a/server/pages/index.pug
+++ b/server/pages/index.pug
@@ -227,7 +227,16 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			})();
 
 		script(type='text/javascript')!='COMMIT_SHA = ' + sanitize.jsonStringifyForHtml( commitSha )
-		script.
+		if user
+			script(type='text/javascript')!='var currentUser = ' + sanitize.jsonStringifyForHtml( user )
+		if app
+			script(type='text/javascript')!='var app = ' + sanitize.jsonStringifyForHtml( app )
+		if initialReduxState
+			script(type='text/javascript')!='var initialReduxState = ' + sanitize.jsonStringifyForHtml( initialReduxState )
+		if config
+			script(type='text/javascript')!= config
+
+		script(type='text/javascript').
 			(function () {
 				// Mini tracks
 				function recordTracksEvent( eventName ) {
@@ -278,14 +287,6 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				}
 			})();
 
-		if user
-			script(type='text/javascript')!='var currentUser = ' + sanitize.jsonStringifyForHtml( user )
-		if app
-			script(type='text/javascript')!='var app = ' + sanitize.jsonStringifyForHtml( app )
-		if initialReduxState
-			script(type='text/javascript')!='var initialReduxState = ' + sanitize.jsonStringifyForHtml( initialReduxState )
-		if config
-			script(type='text/javascript')!= config
 		if i18nLocaleScript
 			script(src=i18nLocaleScript)
 		script(src=urls[ 'manifest' ])

--- a/server/pages/index.pug
+++ b/server/pages/index.pug
@@ -269,7 +269,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 							window.calypsoLoadStartTime = {};
 						}
 						window.calypsoLoadStartTime[ pathName ] = {
-							startTimestamp: stats['_ts'],
+							startTimestamp: window.performance.now(),
 						};
 
 					}

--- a/server/pages/index.pug
+++ b/server/pages/index.pug
@@ -229,35 +229,48 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		script(type='text/javascript')!='COMMIT_SHA = ' + sanitize.jsonStringifyForHtml( commitSha )
 		script.
 			(function () {
-				function createUUID( timestamp ){
-					var dt = timestamp;
-					var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-						var r = ( dt + Math.random()*16)%16 | 0;
-						dt = Math.floor(dt/16);
-						return (c=='x' ? r :(r &0x3|0x8) ).toString( 16 );
-					} );
-					return uuid;
+				// Mini tracks
+				function recordTracksEvent( eventName ) {
+					var statsPixel = 'http://pixel.wp.com/t.gif';
+					var stats = {
+						_pf: navigator.platform,
+						_lg: navigator.language,
+						_en: eventName,
+						_ht: window.screen.height,
+						_wd: window.screen.width,
+						_ut: 'anon',
+						_dl: document.location.origin + '/' + document.location.pathname,
+						_ts: Date.now(),
+						_tz: new Date().getTimezoneOffset() / 60
+					};
+
+					if ( window.currentUser ) {
+						stats[ '_ut' ] = 'wpcom:user_id';
+						stats[ '_ul' ] = currentUser.username;
+						stats[ '_ui' ] = currentUser.ID;
+					}
+
+					var pixel = document.createElement( 'img' );
+					pixel.src = statsPixel + '?' + Object.keys( stats ).map( key => key + '=' + encodeURIComponent( stats[ key ] ) ).join( '& ' );
+
+					var head = document.getElementsByTagName( 'head' )[ 0 ];
+					head.appendChild( pixel );
+
+					return stats;
 				}
 
 				try {
 					var pathName = window.location.pathname.split( "/" ).slice( 1, 2 )[ 0 ];
-					if ( pathName === "log-in" ) {
+					if ( pathName === "log-in" && 'production' === window.configData.env ) {
+
+						var stats = recordTracksEvent( 'calypso_load_start' );
 						if ( ! window.calypsoLoadStartTime ) {
 							window.calypsoLoadStartTime = {};
 						}
-						var timestamp = Date.now();
 						window.calypsoLoadStartTime[ pathName ] = {
-							timestamp: timestamp,
-							uuid: createUUID( timestamp ),
+							startTimestamp: stats['_ts'],
 						};
-						if ( ! window._tkq ) {
-							window._tkq = [];
-						}
-						window._tkq.push( [ 'recordEvent', 'calypso_load_start', {
-							timestamp: window.calypsoLoadStartTime[ pathName ].timestamp,
-							uuid: window.calypsoLoadStartTime[ pathName ].uuid,
-							path: "/" + pathName
-						} ] );
+
 					}
 				} catch ( ex ) {
 					console.error( 'Unable to report load time', ex );

--- a/server/pages/index.pug
+++ b/server/pages/index.pug
@@ -241,7 +241,8 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 						_ut: 'anon',
 						_dl: document.location.origin + '/' + document.location.pathname,
 						_ts: Date.now(),
-						_tz: new Date().getTimezoneOffset() / 60
+						_tz: new Date().getTimezoneOffset() / 60,
+						rand: Math.random()
 					};
 
 					if ( window.currentUser ) {
@@ -251,9 +252,9 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 					}
 
 					var pixel = document.createElement( 'img' );
-					pixel.src = statsPixel + '?' + Object.keys( stats ).map( key => key + '=' + encodeURIComponent( stats[ key ] ) ).join( '& ' );
+					pixel.src = statsPixel + '?' + Object.keys( stats ).map( key => encodeURIComponent( key ) + '=' + encodeURIComponent( stats[ key ] ) ).join( '& ' );
 
-					var head = document.getElementsByTagName( 'head' )[ 0 ];
+					var head = document.getElementsByTagName( 'body' )[ 0 ];
 					head.appendChild( pixel );
 
 					return stats;


### PR DESCRIPTION
I would like to answer the following questions:
1. How much time it takes to load calypso’s log-in page? ( Max. Min. Avg. Deviation, etc. )
2. How many users bail before calypso log-in page finish to load?

I plan this patch to be on production for ~1week to gather statistics and then to be reverted

@xyu mentioned on slack:
> ... at the end we care about how many “started to load” events there are vs how many “finished loading” events. It does not really matter if we can match any particular start event up with a finished load event unless we’re trying to figure out why some stopped loading.