### PR TITLE
Reader: connect up new post notification toggle

### DIFF
--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -181,9 +181,9 @@ const mapStateToProps = ( state, ownProps ) => {
 	const deliveryMethodsEmail = get( follow, [ 'delivery_methods', 'email' ], {} );
 
 	return {
-		sendNewCommentsByEmail: !! deliveryMethodsEmail.send_comments,
-		sendNewPostsByEmail: !! deliveryMethodsEmail.send_posts,
-		emailDeliveryFrequency: deliveryMethodsEmail.post_delivery_frequency,
+		sendNewCommentsByEmail: deliveryMethodsEmail && !! deliveryMethodsEmail.send_comments,
+		sendNewPostsByEmail: deliveryMethodsEmail && !! deliveryMethodsEmail.send_posts,
+		emailDeliveryFrequency: deliveryMethodsEmail && deliveryMethodsEmail.post_delivery_frequency,
 		sendNewPostsByNotification: get(
 			follow,
 			[ 'delivery_methods', 'notification', 'send_posts' ],

--- a/client/state/data-layer/wpcom/read/sites/index.js
+++ b/client/state/data-layer/wpcom/read/sites/index.js
@@ -4,6 +4,7 @@
  */
 import { mergeHandlers } from 'state/action-watchers/utils';
 
+import notificationSubscriptions from './notification-subscriptions';
 import posts from './posts';
 
-export default mergeHandlers( posts );
+export default mergeHandlers( notificationSubscriptions, posts );

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js
@@ -16,8 +16,8 @@ import { bypassDataLayer } from 'state/data-layer/utils';
 import { subscribeToNewPostNotifications } from 'state/reader/follows/actions';
 
 export function fromApi( response ) {
-	const isAdded = !! ( response && response.success );
-	if ( ! isAdded ) {
+	const isUnsubscribed = !! ( response && response.subscribed === false );
+	if ( ! isUnsubscribed ) {
 		throw new Error(
 			`Unsubscription from new post notifications failed with response: ${ JSON.stringify(
 				response

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/index.js
@@ -31,9 +31,10 @@ export function fromApi( response ) {
 export function requestNotificationUnsubscription( action ) {
 	return http(
 		{
-			path: `/read/sites/${ action.payload.blogId }/notification-subscriptions/delete`,
 			method: 'POST',
 			apiNamespace: 'wpcom/v2',
+			path: `/read/sites/${ action.payload.blogId }/notification-subscriptions/delete`,
+			body: {}, // have to have an empty body to make wpcom-http happy
 		},
 		action
 	);

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/test/index.js
@@ -28,6 +28,7 @@ describe( 'notification-subscriptions-delete', () => {
 						apiNamespace: 'wpcom/v2',
 						method: 'POST',
 						path: `/read/sites/${ blogId }/notification-subscriptions/delete`,
+						body: {},
 					},
 					action
 				)

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/delete/test/index.js
@@ -37,8 +37,9 @@ describe( 'notification-subscriptions-delete', () => {
 	} );
 
 	describe( 'fromApi', () => {
-		test( 'should throw an error when success is false', () => {
+		test( 'should throw an error when the unsubscription fails', () => {
 			const response = {
+				subscribed: true,
 				success: false,
 			};
 
@@ -50,6 +51,7 @@ describe( 'notification-subscriptions-delete', () => {
 		test( 'should return response unchanged if response indicates a success', () => {
 			const response = Object.freeze( {
 				success: true,
+				subscribed: false,
 			} );
 
 			expect( fromApi( response ) ).toEqual( response );

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js
@@ -16,8 +16,8 @@ import { bypassDataLayer } from 'state/data-layer/utils';
 import { unsubscribeToNewPostNotifications } from 'state/reader/follows/actions';
 
 export function fromApi( response ) {
-	const isAdded = !! ( response && response.success );
-	if ( ! isAdded ) {
+	const isSubscribed = !! ( response && response.subscribed );
+	if ( ! isSubscribed ) {
 		throw new Error(
 			`Subscription to new post notifications failed with response: ${ JSON.stringify( response ) }`
 		);

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/index.js
@@ -29,9 +29,10 @@ export function fromApi( response ) {
 export function requestNotificationSubscription( action ) {
 	return http(
 		{
-			path: `/read/sites/${ action.payload.blogId }/notification-subscriptions/new`,
 			method: 'POST',
 			apiNamespace: 'wpcom/v2',
+			path: `/read/sites/${ action.payload.blogId }/notification-subscriptions/new`,
+			body: {}, // have to have an empty body to make wpcom-http happy
 		},
 		action
 	);

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/test/index.js
@@ -37,8 +37,9 @@ describe( 'notification-subscriptions-new', () => {
 	} );
 
 	describe( 'fromApi', () => {
-		test( 'should throw an error when success is false', () => {
+		test( 'should throw an error when subscription fails', () => {
 			const response = {
+				subscribed: false,
 				success: false,
 			};
 
@@ -49,6 +50,7 @@ describe( 'notification-subscriptions-new', () => {
 
 		test( 'should return response unchanged if response indicates a success', () => {
 			const response = Object.freeze( {
+				subscribed: true,
 				success: true,
 			} );
 

--- a/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/notification-subscriptions/new/test/index.js
@@ -28,6 +28,7 @@ describe( 'notification-subscriptions-new', () => {
 						apiNamespace: 'wpcom/v2',
 						method: 'POST',
 						path: `/read/sites/${ blogId }/notification-subscriptions/new`,
+						body: {},
 					},
 					action
 				)


### PR DESCRIPTION
Connects up the actions and data to power the UI toggle for new post notifications in the `ReaderSiteNotificationSettings` block (added in https://github.com/Automattic/wp-calypso/pull/20824).

<img width="286" alt="33993970-aa3dba40-e0d0-11e7-85d0-ce073095b506" src="https://user-images.githubusercontent.com/17325/34773711-97264fbe-f604-11e7-860c-2f1a619d2913.png">

Visible in development only.

### To test

Try toggling on new post notifications for a blog. Make sure the setting persists between reloads and is consistent between Manage Following and the site stream.