### PR TITLE
State: Introduce getJetpackOnboardingSettings selector

### DIFF
--- a/client/state/selectors/get-jetpack-onboarding-settings.js
+++ b/client/state/selectors/get-jetpack-onboarding-settings.js
@@ -1,0 +1,10 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export default function getJetpackOnboardingSettings( state, siteId ) {
+	return get( state.jetpackOnboarding.settings, siteId, null );
+}

--- a/client/state/selectors/test/get-jetpack-onboarding-settings.js
+++ b/client/state/selectors/test/get-jetpack-onboarding-settings.js
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import { getJetpackOnboardingSettings } from 'state/selectors';
+
+describe( '#getJetpackOnboardingSettings()', () => {
+	const onboardingSettings = {
+		siteTitle: 'My awesome site',
+		siteDescription: 'Not just another amazing WordPress site',
+	};
+	const settings = {
+		2916284: onboardingSettings,
+	};
+
+	test( 'should return null if we have no settings at all', () => {
+		const selected = getJetpackOnboardingSettings( {
+			jetpackOnboarding: {
+				settings: {},
+			},
+		}, 12345678 );
+
+		expect( selected ).toBeNull();
+	} );
+
+	test( 'should return null if we have no settings for the current site ID', () => {
+		const selected = getJetpackOnboardingSettings( {
+			jetpackOnboarding: {
+				settings,
+			},
+		}, 12345678 );
+
+		expect( selected ).toBeNull();
+	} );
+
+	test( 'should return the site settings of a known unconnected site', () => {
+		const selected = getJetpackOnboardingSettings( {
+			jetpackOnboarding: {
+				settings,
+			},
+		}, 2916284 );
+
+		expect( selected ).toBe( onboardingSettings );
+	} );
+} );


### PR DESCRIPTION
This PR introduces a `getJetpackOnboardingSettings` selector that we'll use throughout the Jetpack Onboarding steps in order to retrieve current settings of an onboarding site.

To test:
* Checkout this branch
* Verify all tests pass:

```
npm run test-client get-jetpack-onboarding-settings
```