### PR TITLE
Jetpack Onboarding: Show Business Address and Woo steps only for Business sites

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { compact } from 'lodash';
+import { compact, get } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -16,7 +16,7 @@ import {
 	JETPACK_ONBOARDING_COMPONENTS as COMPONENTS,
 	JETPACK_ONBOARDING_STEPS as STEPS,
 } from './constants';
-import { getUnconnectedSiteIdBySlug } from 'state/selectors';
+import { getJetpackOnboardingSettings, getUnconnectedSiteIdBySlug } from 'state/selectors';
 
 class JetpackOnboardingMain extends React.PureComponent {
 	static propTypes = {
@@ -50,18 +50,22 @@ class JetpackOnboardingMain extends React.PureComponent {
 
 export default connect( ( state, { siteSlug } ) => {
 	// Note: here we can select which steps to display, based on user's input
+	const siteId = getUnconnectedSiteIdBySlug( state, siteSlug );
+	const settings = getJetpackOnboardingSettings( state, siteId );
+	const isBusiness = get( settings, 'siteType' ) === 'business';
+
 	const steps = compact( [
 		STEPS.SITE_TITLE,
 		STEPS.SITE_TYPE,
 		STEPS.HOMEPAGE,
 		STEPS.CONTACT_FORM,
-		STEPS.BUSINESS_ADDRESS,
-		STEPS.WOOCOMMERCE,
+		isBusiness && STEPS.BUSINESS_ADDRESS,
+		isBusiness && STEPS.WOOCOMMERCE,
 		STEPS.SUMMARY,
 	] );
 
 	return {
-		siteId: getUnconnectedSiteIdBySlug( state, siteSlug ),
+		siteId,
 		siteSlug,
 		steps,
 	};


### PR DESCRIPTION
This PR updates the Jetpack Onboarding step display logic, so the Business Address and WooCommerce steps will only be shown if the "Business" site type is selected.

Relies on #21395.

To test:
1. Checkout this branch on your local Calypso.
1. Make sure your JP sandbox is running the latest Jetpack master.
1. Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
1. After you land the JPO flow, verify you can see "Step 1 of 5" at the top.
1. Skip to the Site Type step and select "Personal"
1. Skip steps towards the end of the flow and verify you can still see "Step N of 5" till the end of the flow, and Business Address and WooCommerce steps are skipped in the process.
1. Go back to the Site Type step and select "Business"
1. Skip steps towards the end of the flow and verify you can still see "Step N of 7" till the end of the flow, and Business Address and WooCommerce steps are being displayed in the process.