### PR TITLE
Purchases: compare to payment.type, no toLowerCase()

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -147,19 +147,19 @@ function isPaidWithPaypal( purchase ) {
 }
 
 function isPaidWithIdeal( purchase ) {
-	return 'ideal' === purchase.payment.type.toLowerCase();
+	return 'ideal' === purchase.payment.type;
 }
 
 function isPaidWithGiropay( purchase ) {
-	return 'giropay' === purchase.payment.type.toLowerCase();
+	return 'giropay' === purchase.payment.type;
 }
 
 function isPaidWithBancontact( purchase ) {
-	return 'bancontact' === purchase.payment.type.toLowerCase();
+	return 'bancontact' === purchase.payment.type;
 }
 
 function isPaidWithP24( purchase ) {
-	return 'p24' === purchase.payment.type.toLowerCase();
+	return 'p24' === purchase.payment.type;
 }
 
 function isPendingTransfer( purchase ) {


### PR DESCRIPTION
Prevent `TypeError: Cannot read property 'toLowerCase' of undefined` 
Since #21323 we were lowering case the payment.type (which is unfortunately not always defined). In any case (;-) ) the backend is now lowering the case, so no longer necessary