### PR TITLE
Editor: fix the position of the pinned toolbar when scrolling in HTML mode

### DIFF
--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -35,7 +35,7 @@
 		border-top-width: 0;
 		max-width: none;
 		position: fixed;
-		top: 94px;
+		top: 46px;
 		width: 100%;
 		z-index: 2;
 
@@ -72,6 +72,10 @@
 		overflow-x: auto;
 		white-space: nowrap;
 		width: 100%;
+
+		button {
+			border-radius: 0;
+		}
 	}
 
 	&.is-scrollable .editor-html-toolbar__buttons::after {


### PR DESCRIPTION
When editing a blog post in HTML mode and then scrolling down, there is currently an unintended gap between the pinned toolbar and the "ground control" toolbar:

![editor-scroll-before](https://user-images.githubusercontent.com/23619/34775834-dc7cf54e-f614-11e7-9091-54b5ec680187.gif)

This PR fixes the positioning. In addition, it correct the `border-radius` for the buttons in the toolbar. After:

![editor-scroll-after](https://user-images.githubusercontent.com/23619/34775884-053098d8-f615-11e7-9347-544080a31e4b.gif)

To test:
- make sure you can reproduce #21307 on `master`
- check out this branch locally or use the calypso.live link
- make sure you cannot reproduce #21307

Fixes #21307.