### PR TITLE
Jetpack Onboarding: Make step list dynamic in Summary step

### DIFF
--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -93,6 +93,7 @@ class Wizard extends Component {
 				{ React.cloneElement( component, {
 					getBackUrl: this.getBackUrl,
 					getForwardUrl: this.getForwardUrl,
+					steps,
 					...omit( otherProps, [ 'basePath', 'baseSuffix' ] ),
 				} ) }
 

--- a/client/jetpack-onboarding/constants.js
+++ b/client/jetpack-onboarding/constants.js
@@ -28,15 +28,21 @@ export const JETPACK_ONBOARDING_STEPS = {
 };
 
 export const JETPACK_ONBOARDING_SUMMARY_STEPS = {
-	SITE_TITLE_DESCRIPTION: translate( 'Site Title & Description' ),
-	SITE_TYPE: translate( 'Type of Site' ),
-	HOMEPAGE_TYPE: translate( 'Type of Homepage' ),
-	CONTACT_FORM: translate( 'Contact Us Form' ),
 	JETPACK_CONNECTION: translate( 'Jetpack Connection' ),
 	THEME: translate( 'Choose a Theme' ),
 	SITE_ADDRESS: translate( 'Add a Site Address' ),
 	STORE: translate( 'Add a Store' ),
 	BLOG: translate( 'Start a Blog' ),
+};
+
+export const JETPACK_ONBOARDING_STEP_TITLES = {
+	[ JETPACK_ONBOARDING_STEPS.SITE_TITLE ]: translate( 'Site Title & Description' ),
+	[ JETPACK_ONBOARDING_STEPS.SITE_TYPE ]: translate( 'Type of Site' ),
+	[ JETPACK_ONBOARDING_STEPS.HOMEPAGE ]: translate( 'Type of Homepage' ),
+	[ JETPACK_ONBOARDING_STEPS.CONTACT_FORM ]: translate( 'Contact Us Form' ),
+	[ JETPACK_ONBOARDING_STEPS.BUSINESS_ADDRESS ]: translate( 'Business Address' ),
+	[ JETPACK_ONBOARDING_STEPS.WOOCOMMERCE ]: translate( 'Add a Store' ),
+	[ JETPACK_ONBOARDING_STEPS.SUMMARY ]: translate( 'Summary' ),
 };
 
 export const JETPACK_ONBOARDING_COMPONENTS = {

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import Gridicon from 'gridicons';
-import { compact, map } from 'lodash';
+import { compact, map, without } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -18,22 +18,18 @@ import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getUnconnectedSiteUrl } from 'state/selectors';
 import {
+	JETPACK_ONBOARDING_STEP_TITLES as STEP_TITLES,
 	JETPACK_ONBOARDING_STEPS as STEPS,
 	JETPACK_ONBOARDING_SUMMARY_STEPS as SUMMARY_STEPS,
 } from '../constants';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
 	renderCompleted = () => {
-		const stepsCompleted = [
-			SUMMARY_STEPS.SITE_TITLE_DESCRIPTION,
-			SUMMARY_STEPS.SITE_TYPE,
-			SUMMARY_STEPS.HOMEPAGE_TYPE,
-			SUMMARY_STEPS.CONTACT_FORM,
-		];
-		return map( stepsCompleted, ( fieldLabel, fieldIndex ) => (
-			<div key={ fieldIndex } className="steps__summary-entry completed">
+		return map( without( this.props.steps, STEPS.SUMMARY ), stepName => (
+			// TODO: Make step completed state dynamic
+			<div key={ stepName } className="steps__summary-entry completed">
 				<Gridicon icon="checkmark" size={ 18 } />
-				{ fieldLabel }
+				{ STEP_TITLES[ stepName ] }
 			</div>
 		) );
 	};


### PR DESCRIPTION
This PR updates the Jetpack Onboarding summary step to display a dynamic list of steps. Note that we're still not displaying whether each of the steps has been completed yet. (this will be done in another PR as noted by the inline comment that this PR introduces - we need to land https://github.com/Automattic/jetpack/pull/8497 first).

To achieve this, the PR updates the `Wizard` component to pass the current steps prop down to the step components, and moves the step title constants in a another constant, separate from the "next tasks" titles.

To test:
1. Checkout this branch on your local Calypso.
1. Make sure your JP sandbox is running the latest Jetpack master.
1. Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
1. After you land the JPO flow, skip to the Site Type step and select "Personal".
1. Verify you can see only 4 steps in the left list (Site Title & Description, Type of Site, Type of Homepage, Contact Us Form).
1. Go back to the Site Type step and select "Business"
1. Verify you can see all 6 steps in the left list (Site Title & Description, Type of Site, Type of Homepage, Contact Us Form, Business Address, Add a Store).