### PR TITLE
Store Orders: Add invoice to notices when editing & creating orders

### DIFF
--- a/client/extensions/woocommerce/app/order/create.js
+++ b/client/extensions/woocommerce/app/order/create.js
@@ -4,7 +4,7 @@
  */
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { isEmpty } from 'lodash';
+import { get, isEmpty, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
 import page from 'page';
@@ -25,10 +25,12 @@ import {
 	getOrderWithEdits,
 } from 'woocommerce/state/ui/orders/selectors';
 import { isOrderUpdating } from 'woocommerce/state/sites/orders/selectors';
+import { isOrderWaitingPayment } from 'woocommerce/lib/order-status';
 import Main from 'components/main';
 import OrderCustomerCreate from './order-customer/create';
 import OrderDetails from './order-details';
 import { ProtectFormGuard } from 'lib/protect-form';
+import { sendOrderInvoice } from 'woocommerce/state/sites/orders/send-invoice/actions';
 
 class Order extends Component {
 	componentDidMount() {
@@ -50,13 +52,33 @@ class Order extends Component {
 		this.props.clearOrderEdits( this.props.siteId );
 	}
 
+	triggerInvoice = ( siteId, orderId ) => {
+		const { translate } = this.props;
+		const onSuccess = dispatch => {
+			dispatch(
+				successNotice( translate( 'An invoice has been sent to the customer.' ), {
+					duration: 5000,
+				} )
+			);
+		};
+
+		this.props.sendOrderInvoice( siteId, orderId, onSuccess, noop );
+	};
+
 	// Saves changes to the remote site via API
 	saveOrder = () => {
 		const { site, siteId, order, translate } = this.props;
 		const onSuccess = ( dispatch, orderId ) => {
 			dispatch(
-				successNotice( translate( 'Order created.' ), { duration: 5000, displayOnNextPage: true } )
+				successNotice( translate( 'Order successfully created.' ), {
+					duration: 5000,
+					displayOnNextPage: true,
+				} )
 			);
+			// Send invoice if the order is awaiting payment and there is an email
+			if ( isOrderWaitingPayment( order.status ) && get( order, 'billing.email', false ) ) {
+				this.triggerInvoice( siteId, orderId );
+			}
 			page.redirect( getLink( `/store/order/:site/${ orderId }`, site ) );
 		};
 		const onFailure = dispatch => {
@@ -119,5 +141,6 @@ export default connect(
 			siteId,
 		};
 	},
-	dispatch => bindActionCreators( { clearOrderEdits, editOrder, saveOrder }, dispatch )
+	dispatch =>
+		bindActionCreators( { clearOrderEdits, editOrder, saveOrder, sendOrderInvoice }, dispatch )
 )( localize( Order ) );

--- a/client/extensions/woocommerce/app/order/create.js
+++ b/client/extensions/woocommerce/app/order/create.js
@@ -57,7 +57,7 @@ class Order extends Component {
 		const onSuccess = dispatch => {
 			dispatch(
 				successNotice( translate( 'An invoice has been sent to the customer.' ), {
-					duration: 5000,
+					duration: 8000,
 				} )
 			);
 		};
@@ -71,7 +71,7 @@ class Order extends Component {
 		const onSuccess = ( dispatch, orderId ) => {
 			dispatch(
 				successNotice( translate( 'Order successfully created.' ), {
-					duration: 5000,
+					duration: 8000,
 					displayOnNextPage: true,
 				} )
 			);
@@ -82,7 +82,7 @@ class Order extends Component {
 			page.redirect( getLink( `/store/order/:site/${ orderId }`, site ) );
 		};
 		const onFailure = dispatch => {
-			dispatch( errorNotice( translate( 'Unable to create order.' ), { duration: 5000 } ) );
+			dispatch( errorNotice( translate( 'Unable to create order.' ), { duration: 8000 } ) );
 		};
 
 		this.props.saveOrder( siteId, order, onSuccess, onFailure );

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -92,7 +92,7 @@ class Order extends Component {
 	// Saves changes to the remote site via API
 	saveOrder = () => {
 		const { siteId, order, translate } = this.props;
-		const successOpts = { duration: 5000 };
+		const successOpts = { duration: 8000 };
 		if ( isOrderWaitingPayment( order.status ) ) {
 			successOpts.button = translate( 'Send new invoice to customer' );
 			successOpts.onClick = this.triggerInvoice;
@@ -101,7 +101,7 @@ class Order extends Component {
 			dispatch( successNotice( translate( 'Order successfully updated.' ), successOpts ) );
 		};
 		const onFailure = dispatch => {
-			dispatch( errorNotice( translate( 'Unable to save order.' ), { duration: 5000 } ) );
+			dispatch( errorNotice( translate( 'Unable to save order.' ), { duration: 8000 } ) );
 		};
 
 		recordTrack( 'calypso_woocommerce_order_edit_save' );
@@ -111,9 +111,9 @@ class Order extends Component {
 	triggerInvoice = () => {
 		const { siteId, orderId, translate } = this.props;
 		if ( siteId && orderId ) {
-			const onSuccess = successNotice( translate( 'Order invoice sent.' ), { duration: 5000 } );
+			const onSuccess = successNotice( translate( 'Order invoice sent.' ), { duration: 8000 } );
 			const onFailure = errorNotice( translate( 'Unable to send order invoice.' ), {
-				duration: 5000,
+				duration: 8000,
 			} );
 			this.props.sendOrderInvoice( siteId, orderId, onSuccess, onFailure );
 		}

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -92,8 +92,13 @@ class Order extends Component {
 	// Saves changes to the remote site via API
 	saveOrder = () => {
 		const { siteId, order, translate } = this.props;
+		const successOpts = { duration: 5000 };
+		if ( isOrderWaitingPayment( order.status ) ) {
+			successOpts.button = translate( 'Send new invoice to customer' );
+			successOpts.onClick = this.triggerInvoice;
+		}
 		const onSuccess = dispatch => {
-			dispatch( successNotice( translate( 'Order saved.' ), { duration: 5000 } ) );
+			dispatch( successNotice( translate( 'Order successfully updated.' ), successOpts ) );
 		};
 		const onFailure = dispatch => {
 			dispatch( errorNotice( translate( 'Unable to save order.' ), { duration: 5000 } ) );


### PR DESCRIPTION
Fixes #20794 – This updates the success process for both updated orders and new orders.

For updated orders, the success notice now shows a  "send invoice" action if the order is awaiting payment.

<img width="610" alt="screen shot 2018-01-09 at 5 58 52 pm" src="https://user-images.githubusercontent.com/541093/34781492-f8a630b2-f5f3-11e7-88ff-8c9d07c9f513.png">

For new orders, if the order is created as payment pending and has an email address set for the customer, it automatically sends the invoice to the customer. We do this with a manual call to the action which sends the invoice (like clicking the button above), so we see a second success message on the screen. This is to ensure we show the "order created" success message regardless of whether the invoice is successful.

<img width="487" alt="screen shot 2018-01-09 at 5 58 18 pm" src="https://user-images.githubusercontent.com/541093/34781491-f8658512-f5f3-11e7-9830-cbdc4558c247.png">

**To test**

This still needs master of `wc-calypso-bridge` on the remote site, but that should be pushed live before the call for testing goes out.

- Edit a payment-pending order, make sure the customer email is yours
- Save your changes, see the "send invoice" action in the notice
- Click the action
- See that your invoice is sent in the Activity Log, and that you get the invoice in your email
- Create a new order, set to payment-pending
- Make sure you've added a customer email (yours)
- Save the order
- See the two notices, check that you get the invoice email (might go to spam if you've been creating a lot of these 😆)


