### PR TITLE
Reader: Fix usage of element.matches on IE11

### DIFF
--- a/client/lib/post-normalizer/rule-content-remove-styles.js
+++ b/client/lib/post-normalizer/rule-content-remove-styles.js
@@ -6,6 +6,17 @@
 
 import { forEach } from 'lodash';
 
+function matches( element, selector ) {
+	const ep = Element.prototype;
+	// modern browsers support `matches` but IE11 and older safari support it as `matchesSelector` with a prefix
+	const matcher =
+		ep.matches || ep.webkitMatchesSelector || ep.mozMatchesSelector || ep.msMatchesSelector;
+	if ( ! matcher ) {
+		return false;
+	}
+	return matcher.call( element, selector );
+}
+
 export default function removeContentStyles( post, dom ) {
 	if ( ! dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
@@ -20,14 +31,14 @@ export default function removeContentStyles( post, dom ) {
 	// remove most style attributes
 	const styled = dom.querySelectorAll( '[style]' );
 	forEach( styled, function( element ) {
-		if ( ! element.matches( whitelistSelector ) ) {
+		if ( ! matches( element, whitelistSelector ) ) {
 			element.removeAttribute( 'style' );
 		}
 	} );
 
 	// remove all style elements outside of galleries and embeds
 	forEach( dom.querySelectorAll( 'style' ), function( element ) {
-		if ( ! element.matches( whitelistSelector ) ) {
+		if ( ! matches( element, whitelistSelector ) ) {
 			element.parentNode && element.parentNode.removeChild( element );
 		}
 	} );


### PR DESCRIPTION
IE11 uses the old name, matchesSelector, instead of matches. Conditionnally call the correct method.

Fixes #21383