### PR TITLE
Preview: fix site selector not appearing for `/view` route

### DIFF
--- a/client/my-sites/preview/index.js
+++ b/client/my-sites/preview/index.js
@@ -9,6 +9,6 @@ import { siteSelection, sites, navigation } from 'my-sites/controller';
 import { preview } from './controller';
 
 export default function( router ) {
-	router( '/view', siteSelection, sites );
+	router( '/view', siteSelection, sites, makeLayout );
 	router( '/view/:site', siteSelection, navigation, preview, makeLayout );
 }


### PR DESCRIPTION
Add missing `makeLayout` middleware so that the view can be rendered.

https://wordpress.com/view

## Testing
Open `/view`
Before: blank page
After: site selector

Kudos @planarvoid and @siobhyb for pointing this out.