### PR TITLE
Store Services - fixes/tweaks to the print label button

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -513,26 +513,41 @@ const handlePrintFinished = ( orderId, siteId, dispatch, getState, hasError, lab
 	if ( shouldEmailDetails( getState(), orderId, siteId ) ) {
 		const trackingNumbers = labels.map( ( label ) => label.tracking );
 		const carrierId = first( labels ).carrier_id;
-		const carrierName = 'usps' === carrierId ? translate( 'USPS' ) : translate( 'an unknown carrier' );
-
-		const note = {
-			note: translate(
-				'Your order consisting of %(packageNum)d package has been shipped with %(carrierName)s. ' +
+		let note = '';
+		if ( 'usps' === carrierId ) {
+			note = translate(
+				'Your order consisting of %(packageNum)d package has been shipped with USPS. ' +
 					'The tracking number is %(trackingNumbers)s.',
-				'Your order consisting of %(packageNum)d packages has been shipped with %(carrierName)s. ' +
+				'Your order consisting of %(packageNum)d packages has been shipped with USPS. ' +
 					'The tracking numbers are %(trackingNumbers)s.',
 				{
 					args: {
 						packageNum: trackingNumbers.length,
-						carrierName,
 						trackingNumbers: trackingNumbers.join( ', ' ),
 					},
 					count: trackingNumbers.length,
-				}
-			),
+				},
+			);
+		} else {
+			note = translate(
+				'Your order consisting of %(packageNum)d package has been shipped. ' +
+					'The tracking number is %(trackingNumbers)s.',
+				'Your order consisting of %(packageNum)d packages has been shipped. ' +
+					'The tracking numbers are %(trackingNumbers)s.',
+				{
+					args: {
+						packageNum: trackingNumbers.length,
+						trackingNumbers: trackingNumbers.join( ', ' ),
+					},
+					count: trackingNumbers.length,
+				},
+			);
+		}
+
+		dispatch( createNote( siteId, orderId, {
+			note,
 			customer_note: true,
-		};
-		dispatch( createNote( siteId, orderId, note ) );
+		} ) );
 	}
 
 	if ( shouldFulfillOrder( getState(), orderId, siteId ) ) {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+/* eslint-disable wpcalypso/i18n-mismatched-placeholders */
 /**
  * External dependencies
  */
@@ -516,8 +517,7 @@ const handlePrintFinished = ( orderId, siteId, dispatch, getState, hasError, lab
 		let note = '';
 		if ( 'usps' === carrierId ) {
 			note = translate(
-				'Your order consisting of %(packageNum)d package has been shipped with USPS. ' +
-					'The tracking number is %(trackingNumbers)s.',
+				'Your order has been shipped with USPS. The tracking number is %(trackingNumbers)s.',
 				'Your order consisting of %(packageNum)d packages has been shipped with USPS. ' +
 					'The tracking numbers are %(trackingNumbers)s.',
 				{
@@ -530,8 +530,7 @@ const handlePrintFinished = ( orderId, siteId, dispatch, getState, hasError, lab
 			);
 		} else {
 			note = translate(
-				'Your order consisting of %(packageNum)d package has been shipped. ' +
-					'The tracking number is %(trackingNumbers)s.',
+				'Your order has been shipped. The tracking number is %(trackingNumbers)s.',
 				'Your order consisting of %(packageNum)d packages has been shipped. ' +
 					'The tracking numbers are %(trackingNumbers)s.',
 				{
@@ -591,7 +590,7 @@ const pollForLabelsPurchase = ( orderId, siteId, dispatch, getState, labels ) =>
 	const printUrl = getPrintURL( state.paperSize, labelsToPrint );
 	const showSuccessNotice = () => {
 		dispatch( NoticeActions.successNotice( translate(
-			'Your %(count)d shipping label was purchased successfully',
+			'Your shipping label was purchased successfully',
 			'Your %(count)d shipping labels were purchased successfully',
 			{
 				count: labels.length,

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -502,6 +502,47 @@ const labelStatusTask = ( orderId, siteId, labelId, retryCount ) => {
 		} );
 };
 
+const handlePrintFinished = ( orderId, siteId, dispatch, getState, hasError, labels ) => {
+	dispatch( exitPrintingFlow( orderId, siteId, true ) );
+	dispatch( clearAvailableRates( orderId, siteId ) );
+
+	if ( hasError ) {
+		return;
+	}
+
+	if ( shouldEmailDetails( getState(), orderId, siteId ) ) {
+		const trackingNumbers = labels.map( ( label ) => label.tracking );
+		const carrierId = first( labels ).carrier_id;
+		const carrierName = 'usps' === carrierId ? translate( 'USPS' ) : translate( 'an unknown carrier' );
+
+		const note = {
+			note: translate(
+				'Your order consisting of %(packageNum)d package has been shipped with %(carrierName)s. ' +
+					'The tracking number is %(trackingNumbers)s.',
+				'Your order consisting of %(packageNum)d packages has been shipped with %(carrierName)s. ' +
+					'The tracking numbers are %(trackingNumbers)s.',
+				{
+					args: {
+						packageNum: trackingNumbers.length,
+						carrierName,
+						trackingNumbers: trackingNumbers.join( ', ' ),
+					},
+					count: trackingNumbers.length,
+				}
+			),
+			customer_note: true,
+		};
+		dispatch( createNote( siteId, orderId, note ) );
+	}
+
+	if ( shouldFulfillOrder( getState(), orderId, siteId ) ) {
+		dispatch( saveOrder( siteId, {
+			id: orderId,
+			status: 'completed',
+		} ) );
+	}
+};
+
 const pollForLabelsPurchase = ( orderId, siteId, dispatch, getState, labels ) => {
 	const errorLabel = find( labels, { status: 'PURCHASE_ERROR' } );
 	if ( errorLabel ) {
@@ -533,24 +574,28 @@ const pollForLabelsPurchase = ( orderId, siteId, dispatch, getState, labels ) =>
 	} ) );
 	const state = getShippingLabel( getState(), orderId, siteId );
 	const printUrl = getPrintURL( state.paperSize, labelsToPrint );
+	const showSuccessNotice = () => {
+		dispatch( NoticeActions.successNotice( translate(
+			'Your %(count)d shipping label was purchased successfully',
+			'Your %(count)d shipping labels were purchased successfully',
+			{
+				count: labels.length,
+				args: { count: labels.length },
+			}
+		) ) );
+	};
 	let hasError = false;
 
 	api.get( siteId, printUrl )
 		.then( ( fileData ) => {
 			if ( 'addon' === getPDFSupport() ) {
+				showSuccessNotice();
 				// If the browser has a PDF "addon", we need another user click to trigger opening it in a new tab
-				dispatch( { type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SHOW_PRINT_CONFIRMATION, orderId, siteId, fileData } );
+				dispatch( { type: WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SHOW_PRINT_CONFIRMATION, orderId, siteId, fileData, labels } );
 			} else {
 				printDocument( fileData, getPDFFileName( orderId ) )
 					.then( () => {
-						dispatch( NoticeActions.successNotice( translate(
-							'Your %(count)d shipping label was purchased successfully',
-							'Your %(count)d shipping labels were purchased successfully',
-							{
-								count: labels.length,
-								args: { count: labels.length },
-							}
-						) ) );
+						showSuccessNotice();
 					} )
 					.catch( ( err ) => {
 						console.error( err );
@@ -558,44 +603,7 @@ const pollForLabelsPurchase = ( orderId, siteId, dispatch, getState, labels ) =>
 						hasError = true;
 					} )
 					.then( () => {
-						dispatch( exitPrintingFlow( orderId, siteId, true ) );
-						dispatch( clearAvailableRates( orderId, siteId ) );
-
-						if ( hasError ) {
-							return;
-						}
-
-						if ( shouldEmailDetails( getState(), orderId, siteId ) ) {
-							const trackingNumbers = labels.map( ( label ) => label.tracking );
-							const carrierId = first( labels ).carrier_id;
-							const carrierName = 'usps' === carrierId ? translate( 'USPS' ) : translate( 'an unknown carrier' );
-
-							const note = {
-								note: translate(
-									'Your order consisting of %(packageNum)d package has been shipped with %(carrierName)s. ' +
-										'The tracking number is %(trackingNumbers)s.',
-									'Your order consisting of %(packageNum)d packages has been shipped with %(carrierName)s. ' +
-										'The tracking numbers are %(trackingNumbers)s.',
-									{
-										args: {
-											packageNum: trackingNumbers.length,
-											carrierName,
-											trackingNumbers: trackingNumbers.join( ', ' ),
-										},
-										count: trackingNumbers.length,
-									}
-								),
-								customer_note: true,
-							};
-							dispatch( createNote( siteId, orderId, note ) );
-						}
-
-						if ( shouldFulfillOrder( getState(), orderId, siteId ) ) {
-							dispatch( saveOrder( siteId, {
-								id: orderId,
-								status: 'completed',
-							} ) );
-						}
+						handlePrintFinished( orderId, siteId, dispatch, getState, hasError, labels );
 					} );
 			}
 		} );
@@ -671,6 +679,7 @@ export const confirmPrintLabel = ( orderId, siteId ) => ( dispatch, getState ) =
 		.then( () => {
 			dispatch( exitPrintingFlow( orderId, siteId, true ) );
 			dispatch( clearAvailableRates( orderId, siteId ) );
+			handlePrintFinished( orderId, siteId, dispatch, getState, false, shippingLabel.form.labelsToPrint );
 		} )
 		.catch( ( error ) => dispatch( NoticeActions.errorNotice( error.toString() ) ) );
 };

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -594,11 +594,12 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_PURCHASE_RESPONSE ] = ( state, { r
 	};
 };
 
-reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SHOW_PRINT_CONFIRMATION ] = ( state, { fileData } ) => {
+reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SHOW_PRINT_CONFIRMATION ] = ( state, { fileData, labels } ) => {
 	return { ...state,
 		form: { ...state.form,
 			needsPrintConfirmation: true,
 			fileData,
+			labelsToPrint: labels,
 		},
 	};
 };

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -76,7 +76,7 @@ const PurchaseDialog = ( props ) => {
 			disabled={ ! props.form.needsPrintConfirmation && ( ! props.canPurchase || props.form.isSubmitting ) }
 			onClick={ getPurchaseButtonAction() }
 			primary
-			busy={ props.form.isSubmitting }>
+			busy={ props.form.isSubmitting && ! props.form.needsPrintConfirmation }>
 			{ getPurchaseButtonLabel() }
 		</Button> ),
 	];


### PR DESCRIPTION
An issue was raised in Slack that on Firefox, the `Print` button doesn't lose the `isBusy` state after the purchase has been made.

I fixed it in this PR, and also fixed the following issues:
* no success notification is shown after the complete purchase on FF
* the "send email" and "mark order as fulfilled" checkboxes are ignored on FF

To test:
* On Firefox:
  * Purchase a label
  * The dialog button label should change from `Buy` to `Print` and should not show the busy animation
  * A success notification should be shown
  * Clicking on `Print` should open a new tab with the PDF. In Calypso, the order should be fulfilled and a note should be added to it if the relevant checkboxes are checked
* On Chrome and other browsers:
  * Everything should work as before