### PR TITLE
Jetpack Connect: Hide masterbar in mobile app flow

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -32,8 +32,8 @@ import { JETPACK_CONNECT_QUERY_SET } from 'state/action-types';
 import { MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
 import { receiveJetpackOnboardingCredentials } from 'state/jetpack-onboarding/actions';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { setSection } from 'state/ui/actions';
-import { persistMobileRedirect, storePlan } from './persistence-utils';
+import { hideMasterbar, setSection, showMasterbar } from 'state/ui/actions';
+import { persistMobileRedirect, retrieveMobileRedirect, storePlan } from './persistence-utils';
 import { urlToSlug } from 'lib/url';
 import {
 	PLAN_JETPACK_PREMIUM,
@@ -127,16 +127,8 @@ export function newSite( context, next ) {
 	next();
 }
 
-export function connect( context, next ) {
-	const { path, pathname, params, query } = context;
-	const { type = false, interval } = params;
-	const analyticsPageTitle = get( type, analyticsPageTitleByType, 'Jetpack Connect' );
-
-	debug( 'entered connect flow with params %o', params );
-
-	const planSlug = getPlanSlugFromFlowType( type, interval );
-	planSlug && storePlan( planSlug );
-
+export function persistMobileAppFlow( context, next ) {
+	const { query } = context;
 	if ( config.isEnabled( 'jetpack/connect/mobile-app-flow' ) ) {
 		if (
 			some( MOBILE_APP_REDIRECT_URL_WHITELIST, pattern => pattern.test( query.mobile_redirect ) )
@@ -147,6 +139,26 @@ export function connect( context, next ) {
 			persistMobileRedirect( '' );
 		}
 	}
+	next();
+}
+
+export function setMasterbar( context, next ) {
+	if ( config.isEnabled( 'jetpack/connect/mobile-app-flow' ) ) {
+		const masterbarToggle = retrieveMobileRedirect() ? hideMasterbar() : showMasterbar();
+		context.store.dispatch( masterbarToggle );
+	}
+	next();
+}
+
+export function connect( context, next ) {
+	const { path, pathname, params, query } = context;
+	const { type = false, interval } = params;
+	const analyticsPageTitle = get( type, analyticsPageTitleByType, 'Jetpack Connect' );
+
+	debug( 'entered connect flow with params %o', params );
+
+	const planSlug = getPlanSlugFromFlowType( type, interval );
+	planSlug && storePlan( planSlug );
 
 	analytics.pageView.record( pathname, analyticsPageTitle );
 

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -57,7 +57,6 @@ export default function() {
 
 		page(
 			'/jetpack/connect/authorize/:interval/:locale',
-
 			controller.maybeOnboard,
 			controller.setMasterbar,
 			controller.signupForm,

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -19,6 +19,8 @@ export default function() {
 
 	page(
 		'/jetpack/connect/:type(personal|premium|pro)/:interval(yearly|monthly)?',
+		controller.persistMobileAppFlow,
+		controller.setMasterbar,
 		controller.connect,
 		makeLayout,
 		clientRender
@@ -27,17 +29,27 @@ export default function() {
 	page(
 		'/jetpack/connect/:type(install)/:locale?',
 		controller.redirectWithoutLocaleIfLoggedIn,
+		controller.persistMobileAppFlow,
+		controller.setMasterbar,
 		controller.connect,
 		makeLayout,
 		clientRender
 	);
 
-	page( '/jetpack/connect', controller.connect, makeLayout, clientRender );
+	page(
+		'/jetpack/connect',
+		controller.persistMobileAppFlow,
+		controller.setMasterbar,
+		controller.connect,
+		makeLayout,
+		clientRender
+	);
 
 	if ( isLoggedOut ) {
 		page(
 			'/jetpack/connect/authorize/:localeOrInterval?',
 			controller.maybeOnboard,
+			controller.setMasterbar,
 			controller.signupForm,
 			makeLayout,
 			clientRender
@@ -45,7 +57,9 @@ export default function() {
 
 		page(
 			'/jetpack/connect/authorize/:interval/:locale',
+
 			controller.maybeOnboard,
+			controller.setMasterbar,
 			controller.signupForm,
 			makeLayout,
 			clientRender
@@ -55,6 +69,7 @@ export default function() {
 			'/jetpack/connect/authorize/:localeOrInterval?',
 			controller.maybeOnboard,
 			controller.redirectWithoutLocaleIfLoggedIn,
+			controller.setMasterbar,
 			controller.authorizeForm,
 			makeLayout,
 			clientRender
@@ -64,6 +79,7 @@ export default function() {
 			'/jetpack/connect/authorize/:interval/:locale',
 			controller.maybeOnboard,
 			controller.redirectWithoutLocaleIfLoggedIn,
+			controller.setMasterbar,
 			controller.authorizeForm,
 			makeLayout,
 			clientRender
@@ -100,6 +116,8 @@ export default function() {
 	page(
 		'/jetpack/connect/:locale?',
 		controller.redirectWithoutLocaleIfLoggedIn,
+		controller.persistMobileAppFlow,
+		controller.setMasterbar,
 		controller.connect,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
Depends on #21401.

**Before/After**
<img width="250" alt="screen shot 2018-01-11 at 14 05 32" src="https://user-images.githubusercontent.com/7767559/34829738-97c4475c-f6d9-11e7-9a7f-4fa393a36cff.png"> <img width="250" alt="screen shot 2018-01-11 at 14 12 57" src="https://user-images.githubusercontent.com/7767559/34829750-a031aa10-f6d9-11e7-8cf5-7543b9814007.png">


Set the `ui.masterbarVisibility` state (added in #21401) when we are in the mobile app jetpack connection flow, so that users cannot click on any masterbar links.

For further details of the jetpack connect mobile app flow see p7rd6c-1aP-p2 and #20955.

## Testing
Start the jetpack connection flow, passing the arg mobile_redirect:
http://calypso.localhost:3000/jetpack/connect?mobile_redirect=wordpress://jetpack-connection

The masterbar should not be visible.

