### PR TITLE
Activity Log: add spacing after credentials notice

### DIFF
--- a/client/my-sites/stats/activity-log-credentials-notice/style.scss
+++ b/client/my-sites/stats/activity-log-credentials-notice/style.scss
@@ -1,6 +1,7 @@
-.activity-log-credentials-notice {
+.activity-log-credentials-notice.card {
 	display: flex;
 	align-items: center;
+	margin-bottom: 16px;
 }
 
 .activity-log-credentials-notice .card__link-indicator,


### PR DESCRIPTION
This PR adds spacing after the credentials notice in the Activity Log

#### Before

<img width="682" alt="captura de pantalla 2018-01-10 a la s 16 32 58" src="https://user-images.githubusercontent.com/1041600/34791745-aa88ea42-f624-11e7-9f43-6d0180e5332a.png">

#### After

<img width="689" alt="captura de pantalla 2018-01-10 a la s 16 36 05" src="https://user-images.githubusercontent.com/1041600/34791769-b7f4ffc2-f624-11e7-9986-80f5facd947f.png">
