### PR TITLE
Add focus to search field clear

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -20,6 +20,12 @@
 		background-color: $white;
 		border-radius: inherit;
 		height: 100%;
+
+		&:focus {
+			box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
+			position: relative;
+			z-index: 9999;
+		}
 	}
 
 	.search__open-icon,


### PR DESCRIPTION
There is no focus state on the clear button of the search domain field in signup. This results in some unexpected behaviour if you're tabbing through the screen on a keyboard. This nice little PR adds a a new focus state to the clear button.

## Before
![master](https://user-images.githubusercontent.com/6981253/34792843-5bb61f96-f617-11e7-9db0-4387461b3dec.gif)

## After
![branch](https://user-images.githubusercontent.com/6981253/34792849-60096800-f617-11e7-9ea4-a55b70dddc69.gif)

## Testing
* Visit `/start`
* Proceed to the domain search
* Enter a term into the domain search
* Tab through the screen and see a visual highlight appear over the clear button when it's focused

cc @lucasartoni 
