### PR TITLE
Chat: Correct typo warning for ChatClosureNotice.

### DIFF
--- a/client/me/help/chat-closure-notice/index.jsx
+++ b/client/me/help/chat-closure-notice/index.jsx
@@ -67,7 +67,7 @@ export default class ChatClosureNotice extends Component {
 	}
 }
 
-ChatClosureNotice.PropTypes = {
+ChatClosureNotice.propTypes = {
 	from: PropTypes.string.isRequired,
 	to: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
This PR corrects a typo identified by React at runtime:

![screen shot 2018-01-10 at 12 15 01 pm](https://user-images.githubusercontent.com/349751/34793522-7bbbd720-f600-11e7-82f9-cb2bf2b55493.png)

**Testing**
* Open `http://calypso.localhost:3000/help/contact` and notice the above warning.
* Switch to this branch, load the same URL, and the warning should have gone away.