### PR TITLE
Schema: Fix invalid keyring schema

### DIFF
--- a/client/state/sharing/keyring/schema.js
+++ b/client/state/sharing/keyring/schema.js
@@ -5,7 +5,7 @@ export const itemSchema = {
 	patternProperties: {
 		'^\\d+$': {
 			type: 'object',
-			required: 'ID',
+			required: [ 'ID' ],
 			properties: {
 				ID: { type: 'integer' },
 				additional_external_users: { type: 'array' },


### PR DESCRIPTION
This PR fixes an invalid schema currently in use.

The invalid schema was exposed by #21125

Previously, invalid schemas were silently permitted with undefined behavior.

I have corrected the schema, but have no knowledge about its usage or correctness. Review is requested based on history to verify that the valid schema works as expected.

Related: #21044 and #21020