### PR TITLE
Schema: Fix invalid signup steps survey schema

### DIFF
--- a/client/state/signup/steps/survey/schema.js
+++ b/client/state/signup/steps/survey/schema.js
@@ -2,8 +2,8 @@
 export const surveyStepSchema = {
 	type: 'object',
 	properties: {
-		vertical: 'string',
-		otherText: 'string',
-		siteType: 'string',
+		vertical: { type: 'string' },
+		otherText: { type: 'string' },
+		siteType: { type: 'string' },
 	},
 };


### PR DESCRIPTION
This PR fixes an invalid schema currently in use.

The invalid schema was exposed by #21125

Previously, invalid schemas were silently permitted with undefined behavior.

I have corrected the schema, but have no knowledge about its usage or correctness. Review is requested based on history to verify that the valid schema works as expected.

Related: #21044 and #21020

## Validating the schema

1. Copy the [draft-04 meta-schema](https://raw.githubusercontent.com/json-schema-org/json-schema-spec/d4c5b3a2924370c51b710c8bfd81d3644a92766e/schema.json)
1. Paste the meta-schema in the left box of [this validator](https://www.jsonschemavalidator.net/)
1. Paste the JSON version of the schema modified by this PR:
   ```json
   {
     "type": "object",
     "properties": {
       "vertical": {
         "type": "string"
       },
       "otherText": {
         "type": "string"
       },
       "siteType": {
         "type": "string"
       }
     }
   }
   ```
1. Validation should pass
1. Optionally verify that the previous version was invalid:
   ```json
   {
     "type": "object",
     "properties": {
       "vertical": "string",
       "otherText":  "string",
       "siteType":  "string",
     }
   }
   ```