### PR TITLE
Domains: Update message on incoming transfer pre-check if privacy protection is detected

### DIFF
--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -268,7 +268,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 
 	getPrivacyMessage() {
 		const { translate } = this.props;
-		const { currentStep, email, loading } = this.state;
+		const { currentStep, email, loading, privacy } = this.state;
 		const step = 2;
 		const isStepFinished = currentStep > step;
 
@@ -315,6 +315,34 @@ class TransferDomainPrecheck extends React.PureComponent {
 								highlight="warning"
 							/>
 						),
+						strong: <strong className="transfer-domain-step__admin-email" />,
+						a: (
+							<a
+								href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY }
+								rel="noopener noreferrer"
+								target="_blank"
+							/>
+						),
+					},
+				}
+			);
+
+			buttonText = translate( 'I can access the email address listed' );
+		}
+
+		if ( privacy ) {
+			message = translate(
+				'{{notice}}You have privacy protection enabled. It must be turned off to transfer your domain.{{/notice}}' +
+					"{{card}}You must be able to access the email address listed for this domain's owner below. " +
+					"We'll send a link to start the process to the following email address: {{strong}}%(email)s{{/strong}}{{/card}}" +
+					'It looks like you have privacy protection enabled, which may prevent you from successfully ' +
+					'transferring your domain. Please contact your current domain provider or log into your ' +
+					"account to disable privacy protection. {{a}}Here's how to do that{{/a}}.",
+				{
+					args: { email },
+					components: {
+						notice: <Notice showDismiss={ false } status="is-error" />,
+						card: <Card className="transfer-domain-step__section-callout" compact={ true } />,
 						strong: <strong className="transfer-domain-step__admin-email" />,
 						a: (
 							<a

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -328,11 +328,10 @@ class TransferDomainPrecheck extends React.PureComponent {
 			);
 
 			buttonText = translate( 'I can access the email address listed' );
-		}
-
-		if ( privacy ) {
+		} else if ( privacy ) {
 			message = translate(
-				'{{notice}}You have privacy protection enabled. It must be turned off to transfer your domain.{{/notice}}' +
+				'{{notice}}It looks like you may have privacy protection enabled. It must be turned off to ' +
+					'transfer your domain.{{/notice}}' +
 					"{{card}}You must be able to access the email address listed for this domain's owner below. " +
 					"We'll send a link to start the process to the following email address: {{strong}}%(email)s{{/strong}}{{/card}}" +
 					'It looks like you have privacy protection enabled, which may prevent you from successfully ' +


### PR DESCRIPTION
This updates the messaging on the incoming transfer pre-check screen if privacy protection is detected. We need to make sure the user has privacy turned off before they try to start the transfer.

Before | After
------------ | -------------
![image](https://user-images.githubusercontent.com/448298/34795486-821b74fc-f620-11e7-957a-b021165e2c6f.png) | ![image](https://user-images.githubusercontent.com/448298/34795461-6b7155be-f620-11e7-93b7-c04846896ce7.png)

#### Testing

1. Start at `[/domains/add/transfer/](http://calypso.localhost:3000/domains/add/transfer/)`
2. Select a site to transfer a domain
3. Enter a domain that has a known privacy contact address (any addresses with `private`, `privacy`, `domainsbyproxy`, `whoisproxy`, or `whoisguard`)
4. Confirm it looks like the **After** screenshot above
5. Go back and enter a domain that doesn't have privacy on it
6. Confirm it looks like the **Before** screenshot above