### PR TITLE
Schema: Fix invalid wp-super-cache plugins schema

### DIFF
--- a/client/extensions/wp-super-cache/state/plugins/schema.js
+++ b/client/extensions/wp-super-cache/state/plugins/schema.js
@@ -10,11 +10,14 @@ export const itemsSchema = {
 			patternProperties: {
 				// Plugin ID
 				'^\\w+$': {
-					desc: { type: 'string' },
-					enabled: { type: 'boolean' },
-					key: { type: 'string' },
-					title: { type: 'string' },
-					url: { type: 'string' },
+					type: 'object',
+					properties: {
+						desc: { type: 'string' },
+						enabled: { type: 'boolean' },
+						key: { type: 'string' },
+						title: { type: 'string' },
+						url: { type: 'string' },
+					},
 				},
 			},
 		},


### PR DESCRIPTION
This PR fixes an invalid schema currently in use.

The invalid schema was exposed by #21125

Previously, invalid schemas were silently permitted with undefined behavior.

I have corrected the schema, but have no knowledge about its usage or correctness. Review is requested based on history to verify that the valid schema works as expected.

Related: #21044 and #21020