### PR TITLE
Memoize the getSelectedOrAllSites selector

### DIFF
--- a/client/state/selectors/get-selected-or-all-sites.js
+++ b/client/state/selectors/get-selected-or-all-sites.js
@@ -4,10 +4,14 @@
  * Internal dependencies
  */
 
+import createSelector from 'lib/create-selector';
 import { getSites } from 'state/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 
-export default function getSelectedOrAllSites( state ) {
-	const selectedSite = getSelectedSite( state );
-	return selectedSite ? [ selectedSite ] : getSites( state );
-}
+export default createSelector(
+	state => {
+		const selectedSite = getSelectedSite( state );
+		return selectedSite ? [ selectedSite ] : getSites( state );
+	},
+	[ getSelectedSite, getSites ]
+);


### PR DESCRIPTION
Prevent returning a fresh array with a selected site on each invocation. That causes a rerender of the `CurrentSite` component on every action dispatch, relevant or not.

**How to test:**
Turn on the React devtool and check the "Highlight updates" checkbox. Then open and close notifications and watch what updates:

![updates-before](https://user-images.githubusercontent.com/664258/34798313-e06ff132-f65b-11e7-882d-26412bc4cb80.gif)

Notice the `CurrentSite` component updating, although no Redux state relevant to it changed.

After the patch, `CurrentSite` is no longer updated:

![updates-after](https://user-images.githubusercontent.com/664258/34798355-0082c288-f65c-11e7-8e98-bfdd53282647.gif)
