### PR TITLE
Add a helper function to compare objects in various ways: shallow, deep, partial

### DIFF
--- a/client/lib/compare-props/README.md
+++ b/client/lib/compare-props/README.md
@@ -1,0 +1,81 @@
+# Comparing object properties
+
+This module exports a helper that creates customized comparator functions to compare
+objects. The comparator can be configured to compare only selected properties and
+ignore all other ones, and compare some properties shallowly and other ones deeply.
+
+If no options are specified, the comparator will compare all properties shallowly:
+
+```js
+const comparator = compareProps();
+
+// returns true: the property values are strictly equal
+comparator( { a: 1 }, { a: 1 } );
+
+// returns false: the property values are not strictly equal
+comparator( { a: [] }, { a: [] } );
+```
+
+## `ignore` option
+
+Specify an `ignore` list of properties that should be ignored by the comparator:
+
+```js
+const comparator = compareProps( { ignore: [ 'irrelevant' ] } );
+
+// returns true: the `a` properties are strictly equal and other are irrelevant
+comparator(
+	{
+		a: 1,
+		irrelevant: 'whatever1'
+	},
+	{
+		a: 1,
+		irrelevant: 'whatever2'
+	}
+);
+```
+
+## `deep` option
+
+To compare selected properties deeply, specify a `deep` option:
+
+```js
+const comparator = compareProps( { deep: [ 'query' ] } );
+
+// returns true: the `page` properties are are strictly equal and
+// the `query` objects are deeply equal, although not identical
+comparator(
+	{
+		query: { text: 'plugin' },
+		page: 2
+	},
+	{
+		query: { text: 'plugin' },
+		page: 2
+	}
+);
+```
+
+## `shallow` option
+
+If you want to compare only some selected properties shallowly, it's more convenient
+to enumerate them in a `shallow` option instead of a long `ignore` list. This option
+also comes handy if the compared objects can have arbitrary extra properties that are
+not relevant for the comparison.
+
+```js
+const comparator = compareProps( { shallow: [ 'id' ] } );
+
+// returns true: the `id` properties are strictly equal and all others are ignored
+comparator(
+	{
+		id: 1,
+		is_jetpack: true
+	},
+	{
+		id: 1,
+	  is_domain_only: true
+	}
+);
+```

--- a/client/lib/compare-props/index.js
+++ b/client/lib/compare-props/index.js
@@ -1,0 +1,49 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { includes, isEqual } from 'lodash';
+
+export default ( options = {} ) => {
+	const { ignore, deep, shallow } = options;
+	return ( prevProps, nextProps ) => {
+		for ( const propName in prevProps ) {
+			// Skip ignored properties
+			if ( ignore && includes( ignore, propName ) ) {
+				continue;
+			}
+
+			// Some properties want to be compared deeply
+			if ( deep && includes( deep, propName ) ) {
+				if ( ! isEqual( prevProps[ propName ], nextProps[ propName ] ) ) {
+					return false;
+				}
+
+				continue;
+			}
+
+			// Compare all other props (or a selected subset) shallowly
+			if ( ! shallow || includes( shallow, propName ) ) {
+				if ( prevProps[ propName ] !== nextProps[ propName ] ) {
+					return false;
+				}
+			}
+		}
+
+		// Find properties that are only in `nextProps` and are not ignored.
+		// Presence of such properties means that the objects are not equal.
+		for ( const propName in nextProps ) {
+			if (
+				! ( propName in prevProps ) &&
+				! ( ignore && includes( ignore, propName ) ) &&
+				! ( shallow && ! includes( shallow, propName ) )
+			) {
+				return false;
+			}
+		}
+
+		return true;
+	};
+};

--- a/client/lib/compare-props/test/index.js
+++ b/client/lib/compare-props/test/index.js
@@ -1,0 +1,104 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import compareProps from '..';
+
+describe( 'compare-props', () => {
+	test( 'should do a shallow comparison when no options are supplied', () => {
+		const comparator = compareProps();
+
+		expect( comparator( { a: 1 }, { a: 1 } ) ).to.be.true;
+		expect( comparator( { a: 1, extra: 2 }, { a: 1 } ) ).to.be.false;
+		expect( comparator( { a: 1 }, { a: 1, extra: 2 } ) ).to.be.false;
+		expect( comparator( { a: [] }, { a: [] } ) ).to.be.false;
+		const a = { b: 1 };
+		expect( comparator( { a }, { a } ) ).to.be.true;
+	} );
+
+	test( 'should ignore properties marked as `ignore`', () => {
+		const comparator = compareProps( { ignore: [ 'irrelevant' ] } );
+
+		expect( comparator( { a: 1, irrelevant: 'whatever1' }, { a: 1, irrelevant: 'whatever2' } ) ).to
+			.be.true;
+
+		expect( comparator( { a: 1, irrelevant: 'whatever1' }, { a: 1 } ) ).to.be.true;
+
+		expect( comparator( { a: 1 }, { a: 1, irrelevant: 'whatever2' } ) ).to.be.true;
+	} );
+
+	test( 'should compare selected properties deeply and the remaining ones shallowly', () => {
+		const comparator = compareProps( { deep: [ 'query' ] } );
+
+		expect(
+			comparator(
+				{
+					query: { text: 'plugin' },
+					page: 2,
+				},
+				{
+					query: { text: 'plugin' },
+					page: 2,
+				}
+			)
+		).to.be.true;
+
+		expect(
+			comparator(
+				{
+					query: { text: 'plugin' },
+					options: [ 'quick' ],
+				},
+				{
+					query: { text: 'plugin' },
+					options: [ 'quick' ],
+				}
+			)
+		).to.be.false;
+	} );
+
+	test( 'should ignore properties that are not part of `shallow` list', () => {
+		const comparator = compareProps( { shallow: [ 'id' ] } );
+
+		expect( comparator( { id: 1, is_jetpack: true }, { id: 1, is_domain_only: true } ) ).to.be.true;
+
+		expect( comparator( { is_jetpack: true }, { id: 1, is_domain_only: true } ) ).to.be.false;
+
+		expect( comparator( { id: 1, is_jetpack: true }, { is_domain_only: true } ) ).to.be.false;
+	} );
+
+	test( 'should prefer `ignore` list over `deep` and both over `shallow`', () => {
+		const comparator = compareProps( {
+			ignore: [ 'ignored', 'deep_ignored', 'shallow_ignored' ],
+			deep: [ 'deep', 'deep_ignored', 'deep_shallow' ],
+			shallow: [ 'shallow', 'shallow_ignored', 'deep_shallow' ],
+		} );
+
+		expect(
+			comparator(
+				{
+					ignored: 'whatever1', // ignored
+					deep: { a: 'relevant' }, // compared deeply
+					deep_ignored: { a: 'whatever1' }, // ignored, deeply inequal
+					deep_shallow: { a: 'deep' }, // compared deeply
+					shallow: 1, // compared shallowly
+					shallow_ignored: { a: 'whatever' }, // ignored
+				},
+				{
+					ignored: 'whatever2',
+					deep: { a: 'relevant' },
+					deep_ignored: { a: 'whatever2' },
+					deep_shallow: { a: 'deep' },
+					shallow: 1,
+					shallow_ignored: { a: 'whatever' },
+				}
+			)
+		).to.be.true;
+	} );
+} );


### PR DESCRIPTION
Module that exports a `compareProps( options )` function that returns an object comparator with the desired properties.

The default is to compare everything shallowly and there are options to compare selected properties deeply or ignore them completely.

Very useful when optimizing React components and Redux `connect` calls by adding `shouldComponentUpdate` or `areStatePropsEqual`. I extracted this module from my WIP work that optimizes 10+ components that benefit from it.

See the README.md file supplied for documentation and the tests for examples.

The implementation is strongly inspired by the [is-equal-shallow](https://github.com/jonschlinkert/is-equal-shallow) package used internally by React to implement `PureComponent`. Very simple and
fast code that doesn't do any array allocations (no `Object.keys`, `map` or `filter`) or other fancy stuff.