### PR TITLE
Update analyze-bundles to use the gzip size for the treemap by default

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -468,6 +468,11 @@
         }
       }
     },
+    "async-limiter": {
+      "version": "1.0.0",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
@@ -477,7 +482,7 @@
       "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000789",
+        "caniuse-db": "1.0.30000790",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -750,12 +755,12 @@
       }
     },
     "babel-jest": {
-      "version": "22.0.4",
-      "integrity": "sha512-/Yt61fUpdFjetYlnpj280BPKEsPnK4mqzxDdo8DybPvrPNrLurbAF/WBjn2nnoi1Hc2Ippsf12/aOp8ys/Vl1A==",
+      "version": "22.0.6",
+      "integrity": "sha512-HkPxQ75YfYLjdaRTQn+a6fgHExPqsBLw9Gr6vDasylZBoiSEwhJUWE4Gh7mh4IC9zF/I+93mgTi5KsUjwOeeMA==",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.5",
-        "babel-preset-jest": "22.0.3"
+        "babel-preset-jest": "22.0.6"
       }
     },
     "babel-loader": {
@@ -816,8 +821,8 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "22.0.3",
-      "integrity": "sha512-Z0pOZFs0xDctwF0bPEKrnAzvbbgDi2vDFbQ0EdofnLI2bOa3P1H66gNLb2vMJJaa00VDjfiGhIocsHvBkqtyEQ==",
+      "version": "22.0.6",
+      "integrity": "sha512-KiAmvs8r+lJVzPfnWor4ftrDjvq3CRonbU5lYOqQLi1wXNRoGC21N1Yak6qGXjdpyz3H9plZJPcT7o14RyCs5g==",
       "dev": true
     },
     "babel-plugin-jscript": {
@@ -1338,16 +1343,16 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.11.0",
+        "browserslist": "2.11.1",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       },
       "dependencies": {
         "browserslist": {
-          "version": "2.11.0",
-          "integrity": "sha512-mNYp0RNeu1xueGuJFSXkU+K0nH+dBE/gcjtyhtNKfU8hwdrVIfoA7i5iFSjOmzkGdL2QaO7YX9ExiVPE7AY9JA==",
+          "version": "2.11.1",
+          "integrity": "sha512-Gp4oJOQOby5TpOJJuUtCrGE0KSJOUYVa/I+/3eD/TRWEK8jqZuJPAK1t+VuG6jp0keudrqtxlH4MbYbmylun9g==",
           "requires": {
-            "caniuse-lite": "1.0.30000789",
+            "caniuse-lite": "1.0.30000790",
             "electron-to-chromium": "1.3.30"
           }
         },
@@ -1420,11 +1425,11 @@
       }
     },
     "babel-preset-jest": {
-      "version": "22.0.3",
-      "integrity": "sha512-FbMMniSMXFvkKldCf+e4Tuol/v3XMaIpIp8xiT1WFlEW3ZapTKDW9YgVt3hqcpZXsIGFf6eUF3Owxom7yFlI8w==",
+      "version": "22.0.6",
+      "integrity": "sha512-NZEqqliZAlDO5mOta5SQPwt14S+KxLYbdTRMvSmpaGcvEnStOWEBOPNmdYrVxP7j7MgTQwP+bUstiaxMc1mrXQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "22.0.3",
+        "babel-plugin-jest-hoist": "22.0.6",
         "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
@@ -1821,7 +1826,7 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "4.11.8",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -1848,7 +1853,7 @@
       "version": "1.3.6",
       "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
       "requires": {
-        "caniuse-db": "1.0.30000789"
+        "caniuse-db": "1.0.30000790"
       }
     },
     "bser": {
@@ -1965,12 +1970,12 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000789",
-      "integrity": "sha1-XPP+x1SABBqxYsoGQTFTFB4jQyU="
+      "version": "1.0.30000790",
+      "integrity": "sha1-qAI+brn+nA7z1gtEJ84QTqh9OBw="
     },
     "caniuse-lite": {
-      "version": "1.0.30000789",
-      "integrity": "sha1-Lj2TeyZxM/Y2Ne9/RB+sZjYPyIk="
+      "version": "1.0.30000790",
+      "integrity": "sha1-yVTMp4AEbzTEtDPTJO9Bnh21GlM="
     },
     "cardinal": {
       "version": "1.0.0",
@@ -2268,12 +2273,19 @@
       }
     },
     "cli-usage": {
-      "version": "0.1.4",
-      "integrity": "sha1-fAHg3HBsI0s5yTODjI4gshdXduI=",
+      "version": "0.1.7",
+      "integrity": "sha512-x/Q52iLSZsRrRb2ePmTsVYXrGcrPQ8G4yRAY7QpMlumxAfPVrnDOH2X6Z5s8qsAX7AA7YuIi8AXFrvH0wWEesA==",
       "dev": true,
       "requires": {
-        "marked": "0.3.9",
-        "marked-terminal": "1.7.0"
+        "marked": "0.3.12",
+        "marked-terminal": "2.0.0"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "0.3.12",
+          "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
+          "dev": true
+        }
       }
     },
     "cli-width": {
@@ -2426,7 +2438,7 @@
       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
       "dev": true,
       "requires": {
-        "commander": "2.12.2",
+        "commander": "2.13.0",
         "detective": "4.7.1",
         "glob": "5.0.15",
         "graceful-fs": "4.1.11",
@@ -2438,8 +2450,8 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.12.2",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "version": "2.13.0",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
           "dev": true
         },
         "glob": {
@@ -2827,7 +2839,7 @@
         "inherits": "2.0.1",
         "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5",
+        "randombytes": "2.0.6",
         "randomfill": "1.0.3"
       }
     },
@@ -3241,7 +3253,7 @@
       "requires": {
         "bn.js": "4.11.8",
         "miller-rabin": "4.0.1",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "discontinuous-range": {
@@ -3283,7 +3295,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000789",
+        "caniuse-db": "1.0.30000790",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -3385,10 +3397,10 @@
       }
     },
     "duplexify": {
-      "version": "3.5.1",
-      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+      "version": "3.5.3",
+      "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "inherits": "2.0.1",
         "readable-stream": "2.3.3",
         "stream-shift": "1.0.0"
@@ -3436,7 +3448,7 @@
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
-        "commander": "2.12.2",
+        "commander": "2.13.0",
         "lru-cache": "3.2.0",
         "semver": "5.1.0",
         "sigmund": "1.0.1"
@@ -3448,8 +3460,8 @@
           "dev": true
         },
         "commander": {
-          "version": "2.12.2",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "version": "2.13.0",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
           "dev": true
         },
         "lru-cache": {
@@ -3537,8 +3549,8 @@
       }
     },
     "end-of-stream": {
-      "version": "1.4.0",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "version": "1.4.1",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "1.4.0"
       }
@@ -4398,16 +4410,16 @@
       }
     },
     "expect": {
-      "version": "22.0.5",
-      "integrity": "sha512-LC68K+29U8BymcH8kK7r06hgHYmWOOCxZMiUS4y13Iw0UrEK2sZ9FOgCMM1iY66WuSkBRIsiF5QbjoGmrhFzYw==",
+      "version": "22.0.6",
+      "integrity": "sha512-8n81n5hW60Wr934QpBz0JyFr084z30rEzMIxbCekWnCZ9kjUtClNBCQjKLA9YaVQepPxHHvc4b7m/B/H0CSpsA==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
-        "jest-diff": "22.0.5",
-        "jest-get-type": "22.0.3",
-        "jest-matcher-utils": "22.0.5",
-        "jest-message-util": "22.0.3",
-        "jest-regex-util": "22.0.5"
+        "jest-diff": "22.0.6",
+        "jest-get-type": "22.0.6",
+        "jest-matcher-utils": "22.0.6",
+        "jest-message-util": "22.0.6",
+        "jest-regex-util": "22.0.6"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6043,7 +6055,7 @@
       "integrity": "sha1-5dDtSvVfw+701WAHdp2YGSvLLso=",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.1",
+        "duplexify": "3.5.3",
         "infinity-agent": "2.0.3",
         "is-redirect": "1.0.0",
         "is-stream": "1.1.0",
@@ -6588,7 +6600,7 @@
       "integrity": "sha512-vAEAmvbuytZEs/2d0M4WJYCKtzuCt4L2R7jMg57yO50kCmm5uPIj/9EJadum+MBPU7JgyWzDHH5J8PDr7deW4A==",
       "requires": {
         "async": "1.5.2",
-        "commander": "2.12.2",
+        "commander": "2.13.0",
         "create-react-class": "15.6.2",
         "debug": "2.2.0",
         "globby": "6.1.0",
@@ -6608,8 +6620,8 @@
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "commander": {
-          "version": "2.12.2",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+          "version": "2.13.0",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
         },
         "lodash.assign": {
           "version": "4.2.0",
@@ -7306,7 +7318,7 @@
       "integrity": "sha512-90H1wLqiNR3tLhQUgwhC6GWHfRCG+Da14m7vxD608Mt/QTKR0TA751D+QH09x5bvcrLfvxLtxArtA0VEC0ORow==",
       "dev": true,
       "requires": {
-        "jest-cli": "22.0.5"
+        "jest-cli": "22.0.6"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -7381,8 +7393,8 @@
           "dev": true
         },
         "jest-cli": {
-          "version": "22.0.5",
-          "integrity": "sha512-ivVAg7Q6kRixiquGDVLYguolmvbkZOTno3Q6AgkHv8I6KldUqG78DsXhVf/giGgwkPi1C/e1nxc1EWJtZyZSVQ==",
+          "version": "22.0.6",
+          "integrity": "sha512-0hqadrUDDj4FDmrODXvLXCFwHGMegH+2fZ6x3Y0SyKw7ODJ91+2WeVCQwQRXaj6v9hmygjsbfdGo3tYIeOZVhw==",
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
@@ -7394,19 +7406,19 @@
             "istanbul-lib-coverage": "1.1.1",
             "istanbul-lib-instrument": "1.9.1",
             "istanbul-lib-source-maps": "1.2.2",
-            "jest-changed-files": "22.0.5",
-            "jest-config": "22.0.5",
-            "jest-environment-jsdom": "22.0.5",
-            "jest-get-type": "22.0.3",
-            "jest-haste-map": "22.0.3",
-            "jest-message-util": "22.0.3",
-            "jest-regex-util": "22.0.5",
-            "jest-resolve-dependencies": "22.0.5",
-            "jest-runner": "22.0.5",
-            "jest-runtime": "22.0.5",
-            "jest-snapshot": "22.0.5",
-            "jest-util": "22.0.5",
-            "jest-worker": "22.0.3",
+            "jest-changed-files": "22.0.6",
+            "jest-config": "22.0.6",
+            "jest-environment-jsdom": "22.0.6",
+            "jest-get-type": "22.0.6",
+            "jest-haste-map": "22.0.6",
+            "jest-message-util": "22.0.6",
+            "jest-regex-util": "22.0.6",
+            "jest-resolve-dependencies": "22.0.6",
+            "jest-runner": "22.0.6",
+            "jest-runtime": "22.0.6",
+            "jest-snapshot": "22.0.6",
+            "jest-util": "22.0.6",
+            "jest-worker": "22.0.6",
             "micromatch": "2.3.11",
             "node-notifier": "5.1.2",
             "realpath-native": "1.0.0",
@@ -7488,29 +7500,29 @@
       }
     },
     "jest-changed-files": {
-      "version": "22.0.5",
-      "integrity": "sha512-WL8DktSnt/U+D7y6ddF42kgJKeyRlPDqy8OL04czLumWfnQDolbuowh5oapKTHBIjtAA+MY1OkGv6yFXDQHeEg==",
+      "version": "22.0.6",
+      "integrity": "sha512-eRnDzJm8gm0UsSV6H0LvIi5wANWDXmzKNglAl6zFRUv1K9FXTsqInE4zFWUzerGZv7LIvAYaVVAzyMrttbpcKQ==",
       "dev": true,
       "requires": {
         "throat": "4.1.0"
       }
     },
     "jest-config": {
-      "version": "22.0.5",
-      "integrity": "sha512-8cSVTCTnHPz1Ztv/xg2ULNkkBHjS60Btdr2Q39jmO9G62mcfCmMcUlEW+YZR36p2o1b7BlFaHYoxMjAwe4mPZw==",
+      "version": "22.0.6",
+      "integrity": "sha512-wwt7ZqQTiy+xDddFU868+RfZ0lEJdxu6q1ErT/b1qknBZSIKjW5eXp6fyITk/xzwQZ4Q2YhlMEjz0NXPCBNLwg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "glob": "7.1.2",
-        "jest-environment-jsdom": "22.0.5",
-        "jest-environment-node": "22.0.5",
-        "jest-get-type": "22.0.3",
-        "jest-jasmine2": "22.0.5",
-        "jest-regex-util": "22.0.5",
-        "jest-resolve": "22.0.4",
-        "jest-util": "22.0.5",
-        "jest-validate": "22.0.5",
-        "pretty-format": "22.0.5"
+        "jest-environment-jsdom": "22.0.6",
+        "jest-environment-node": "22.0.6",
+        "jest-get-type": "22.0.6",
+        "jest-jasmine2": "22.0.6",
+        "jest-regex-util": "22.0.6",
+        "jest-resolve": "22.0.6",
+        "jest-util": "22.0.6",
+        "jest-validate": "22.0.6",
+        "pretty-format": "22.0.6"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7565,14 +7577,14 @@
       }
     },
     "jest-diff": {
-      "version": "22.0.5",
-      "integrity": "sha512-waIjlxSyHwzfKWd2hDXcCj0dmv0JBhpp0b6mIfjefoc2KN+OzTMPQicdXRO50mEk2q+70+ynjKLBX7IzENeNjg==",
+      "version": "22.0.6",
+      "integrity": "sha512-wwyXqHgTNX17OaSVJFuHdpT0j+B/ygi4DzKqrZDpTt6oIJfv+jOYTjxBL3t1NlyQuaDWSdByfL05TDoGnJuO0Q==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "diff": "3.4.0",
-        "jest-get-type": "22.0.3",
-        "pretty-format": "22.0.5"
+        "jest-get-type": "22.0.6",
+        "pretty-format": "22.0.6"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7622,22 +7634,22 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "22.0.5",
-      "integrity": "sha512-uZiAYhFtpActX4NbofR+WvgjHceWxmrVjhpbX1qttGGIbT2un8cRA+zcTwyaRfVeKANaWGSdHmoLKtWbt1uCwg==",
+      "version": "22.0.6",
+      "integrity": "sha512-a0YrUxW49YDMoj+LOgPZMhyh/dGUv6th4TbDfX4O/DVjkUGLzc4c6a0bCxcUZSkDuocXbxBYW8TAPIt84/OF1w==",
       "dev": true,
       "requires": {
-        "jest-mock": "22.0.5",
-        "jest-util": "22.0.5",
+        "jest-mock": "22.0.6",
+        "jest-util": "22.0.6",
         "jsdom": "11.5.1"
       }
     },
     "jest-environment-node": {
-      "version": "22.0.5",
-      "integrity": "sha512-dguShAKdSZ+jDOX4bVDq8JINnzcg9uUoiLcHKi0SOP6u5y7y0KR/6UFZneWSGRxB+0I/AN2DK00l0SJpxcYBBQ==",
+      "version": "22.0.6",
+      "integrity": "sha512-taEm3EjDx6B1bQKwOwnctp6ddajJIwW2qfRLfEpYNcKxthO4Y2b79jTGJPGYkwpXgGZBN9cYmBuCU8saguEXQw==",
       "dev": true,
       "requires": {
-        "jest-mock": "22.0.5",
-        "jest-util": "22.0.5"
+        "jest-mock": "22.0.6",
+        "jest-util": "22.0.6"
       }
     },
     "jest-file-exists": {
@@ -7646,38 +7658,48 @@
       "dev": true
     },
     "jest-get-type": {
-      "version": "22.0.3",
-      "integrity": "sha512-TaJnc/lnJQ3jwry+NUWkqaJmKrM/Ut3XdK89HfiqdI3DMRLd6Zb4wyKjwuNP37MEQqlNg0YWH4sbBR8D4exjCA==",
+      "version": "22.0.6",
+      "integrity": "sha512-NGiuzfSXssBIN5PGAmKPWk29/eJlv5gVhD7un9Dcr9w+rJXAOGR/Ggx3HKJ7IArkIq0YCN4lFdbyHpB42NMUWw==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "22.0.3",
-      "integrity": "sha512-VosIMOFQFu1rTF+MvOWVuv2KVmZ9eTkRgfwW2yUAs6/AhwmIfXRl/tih+fIOYcHzU4Auu1G8Fvl2kkF5g0k6/A==",
+      "version": "22.0.6",
+      "integrity": "sha512-Y/9MKcpI6AMobdHDIHOvz/0OiXiZNV5Uy997EyzRFWDb8EZTP8WD7nEqVCgG/4ned/DmxRnoCaHIZA2vS0/Vtg==",
       "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
-        "jest-docblock": "22.0.3",
-        "jest-worker": "22.0.3",
+        "jest-docblock": "22.0.6",
+        "jest-worker": "22.0.6",
         "micromatch": "2.3.11",
         "sane": "2.2.0"
+      },
+      "dependencies": {
+        "jest-docblock": {
+          "version": "22.0.6",
+          "integrity": "sha512-evcMu0AdVy1jchCz9ngB+PHxQchvHckInpP0OSjwyIji6UEpRU1m9XULpeIWp2D3odnIbLM/egeLEmRbQNhvJA==",
+          "dev": true,
+          "requires": {
+            "detect-newline": "2.1.0"
+          }
+        }
       }
     },
     "jest-jasmine2": {
-      "version": "22.0.5",
-      "integrity": "sha512-FTY56tlGvCK9JMWvwRsAjshuwqx2HZghhMIcvLhkZoPNow2WQdjTV265jiMg/aG9/8kwEJ1Tuh8RBozS2xg3Fw==",
+      "version": "22.0.6",
+      "integrity": "sha512-zc64Y0g27wlEjYbt0aNgGoER5lSp942uLvDAJXTBr4SKnyjjm4Lr4g+GfbJuR3WSlfO3T+MXcjQbvK0+sWaxeA==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.3.0",
         "co": "4.6.0",
-        "expect": "22.0.5",
+        "expect": "22.0.6",
         "graceful-fs": "4.1.11",
         "is-generator-fn": "1.0.0",
-        "jest-diff": "22.0.5",
-        "jest-matcher-utils": "22.0.5",
-        "jest-message-util": "22.0.3",
-        "jest-snapshot": "22.0.5",
+        "jest-diff": "22.0.6",
+        "jest-matcher-utils": "22.0.6",
+        "jest-message-util": "22.0.6",
+        "jest-snapshot": "22.0.6",
         "source-map-support": "0.5.0"
       },
       "dependencies": {
@@ -7746,21 +7768,21 @@
       }
     },
     "jest-leak-detector": {
-      "version": "22.0.5",
-      "integrity": "sha512-vxqiSBwoqLglZqw/IFWSdYOw1V4oMNXJpLySsQ+yKatM4I80uXJalDNoezqZvrQVX9zKuVpxIUqYGXDTF2mCYA==",
+      "version": "22.0.6",
+      "integrity": "sha512-Ll8C0iH8Un+liiOnnp18WTVScvhSr6GUFrhFa4p46peFWg8rgh4MuJvG7A1Dwpa00ZHV5W5kzVViFaedDWxJMw==",
       "dev": true,
       "requires": {
-        "pretty-format": "22.0.5"
+        "pretty-format": "22.0.6"
       }
     },
     "jest-matcher-utils": {
-      "version": "22.0.5",
-      "integrity": "sha512-W0m1Y8DICVNbCQRD5q0au9XOEL+t2VoHGYM4vcT3R1rPIkLFy32a7JlpE3fnJvcSMi5HjxoqvPRoouT2WH5kpw==",
+      "version": "22.0.6",
+      "integrity": "sha512-AvuW0IpyB3lcUrDW3nj9lMP/pJw3t97BDPj3HcEncx8MAg+DS216w14H9AuCYrhYBgqRE9UqrKomy7ey3X6Y9A==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-get-type": "22.0.3",
-        "pretty-format": "22.0.5"
+        "jest-get-type": "22.0.6",
+        "pretty-format": "22.0.6"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7874,8 +7896,8 @@
       }
     },
     "jest-message-util": {
-      "version": "22.0.3",
-      "integrity": "sha512-AVBdCx7Oj5wBpMOH089lx7Zgwpdz9HbReA82HuVAlIT4kEQRvCy6Sl9yVWDGJwHTgB/OYQGkgmbv/P/K8TkWNw==",
+      "version": "22.0.6",
+      "integrity": "sha512-JKGctxpAsEfK5Ywc6n8kGewSzGOhJYg2GZWqIKjaGKpEWgO1iex8qsGkxPDGKiv1EivLs7yuGRBhwnCd8eTUwA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0-beta.37",
@@ -7924,18 +7946,18 @@
       }
     },
     "jest-mock": {
-      "version": "22.0.5",
-      "integrity": "sha512-jy468NENjFOCHVqENhrsu6qadWSKH6BYDcJodYgPpsCrKrhY0cfRb/d8Zpd70gbwWST4zs6rUSAR8A0UI7Nh6A==",
+      "version": "22.0.6",
+      "integrity": "sha512-RBnO1ZFuzPGss/hPdzPawoqGrcF1igL6yfd6OwKszuRv3SviEZaGye/T/Pev8tU9Ye7uR8bfLeNQbe1qi5w0YQ==",
       "dev": true
     },
     "jest-regex-util": {
-      "version": "22.0.5",
-      "integrity": "sha512-4Jo9jYhH1OyKm6cYUKdXGgsPnw7EtAhlmnbN0Ik6OoQkIDgkO+rizFNfXSayZQKq2w+QIPD0jroyE13aKd7KxA==",
+      "version": "22.0.6",
+      "integrity": "sha512-VfgVLmPv1Mmu87P53vZK0XdQlioVcw7MjAxiIHS9/QruNqbDH3fPfeqL3YkJI283CmkkxmQNZOCAYinlwJTJfA==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "22.0.4",
-      "integrity": "sha512-yoxHsX4MTT2Ra/dFia9VCunzsA/4jMBENMmLjREIUkCIP1edk/PZUOGVVf680Gw04CtmT5stETylcbmbL7hJBw==",
+      "version": "22.0.6",
+      "integrity": "sha512-T7gjP8YijRTRxMtRN5j1QELa/casAUy6Y7geQKQE5impkVibCFt9UImaDtYYfiQ+zJlJ5uIrDyaI+L5YVc8jvA==",
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
@@ -7981,46 +8003,56 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "22.0.5",
-      "integrity": "sha512-IB++WyVBKauRjK3/DpI681YDJJcha7+AlGIrM2+BF7yZPFmYK43UOz60qjOoDdmHGOrRUJFtHn0NdY7shFDahg==",
+      "version": "22.0.6",
+      "integrity": "sha512-JVbG4cE6N/1jTjut9XqveGqUddrHVlD7fJpIh5tH41ML+GjjDk8WwmcoA2RykXYSbt0vdUrAOV/FXVIgHTgHfw==",
       "dev": true,
       "requires": {
-        "jest-regex-util": "22.0.5"
+        "jest-regex-util": "22.0.6"
       }
     },
     "jest-runner": {
-      "version": "22.0.5",
-      "integrity": "sha512-ttNSPOHPJRXpNMO+cAMLfTHUgCE64h9YX8tjh17aJmoMzhEjBhAyYN/O2qf81TPzMj3ri5e24D+NPP9RQwtBUw==",
+      "version": "22.0.6",
+      "integrity": "sha512-xFXmP6T6IDIZYyieBJNZeyQcowCcaFXmtUra+yJJYpWp/zijGRpf8BPExbUeUM6Es59yTFnyepZrWXwZ5l1fRQ==",
       "dev": true,
       "requires": {
-        "jest-config": "22.0.5",
-        "jest-docblock": "22.0.3",
-        "jest-haste-map": "22.0.3",
-        "jest-jasmine2": "22.0.5",
-        "jest-leak-detector": "22.0.5",
-        "jest-message-util": "22.0.3",
-        "jest-runtime": "22.0.5",
-        "jest-util": "22.0.5",
-        "jest-worker": "22.0.3",
+        "jest-config": "22.0.6",
+        "jest-docblock": "22.0.6",
+        "jest-haste-map": "22.0.6",
+        "jest-jasmine2": "22.0.6",
+        "jest-leak-detector": "22.0.6",
+        "jest-message-util": "22.0.6",
+        "jest-runtime": "22.0.6",
+        "jest-util": "22.0.6",
+        "jest-worker": "22.0.6",
         "throat": "4.1.0"
+      },
+      "dependencies": {
+        "jest-docblock": {
+          "version": "22.0.6",
+          "integrity": "sha512-evcMu0AdVy1jchCz9ngB+PHxQchvHckInpP0OSjwyIji6UEpRU1m9XULpeIWp2D3odnIbLM/egeLEmRbQNhvJA==",
+          "dev": true,
+          "requires": {
+            "detect-newline": "2.1.0"
+          }
+        }
       }
     },
     "jest-runtime": {
-      "version": "22.0.5",
-      "integrity": "sha512-8uMCbh1ho1CZYLZ/X8hEtaIP7X5o3JwmZ8yy7jrMpq8KQ26pcQHHnk1IhQNShWXsr7YpovNNcetSVpTKH7/2ag==",
+      "version": "22.0.6",
+      "integrity": "sha512-DM6fQb+ivYWkMCxTEOCV746i0ZoeNz+ksmar7pulJ4OT2wUG2P8f1GsXbfzM+AtoYMDfo/jPXSVmuudcAnppaw==",
       "dev": true,
       "requires": {
         "babel-core": "6.25.0",
-        "babel-jest": "22.0.4",
+        "babel-jest": "22.0.6",
         "babel-plugin-istanbul": "4.1.5",
         "chalk": "2.3.0",
         "convert-source-map": "1.5.1",
         "graceful-fs": "4.1.11",
-        "jest-config": "22.0.5",
-        "jest-haste-map": "22.0.3",
-        "jest-regex-util": "22.0.5",
-        "jest-resolve": "22.0.4",
-        "jest-util": "22.0.5",
+        "jest-config": "22.0.6",
+        "jest-haste-map": "22.0.6",
+        "jest-regex-util": "22.0.6",
+        "jest-resolve": "22.0.6",
+        "jest-util": "22.0.6",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
         "realpath-native": "1.0.0",
@@ -8168,16 +8200,16 @@
       }
     },
     "jest-snapshot": {
-      "version": "22.0.5",
-      "integrity": "sha512-C+BHwGrZ76abH+EyX0KLQvQjGM4Isik2Dow55RAZWUep2ZJ94uJ/Pyh++yEINJ4WBpUb7gbLK1oHhTlz6HfH1A==",
+      "version": "22.0.6",
+      "integrity": "sha512-s9arPbLVe1SHJ2uw9F3cPYBQvWF0o9ppn7mIUWiVrAc7eNb9xhRBDk7DSO/erF61dAGnIrI4KXwhiQ97IjkSog==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-diff": "22.0.5",
-        "jest-matcher-utils": "22.0.5",
+        "jest-diff": "22.0.6",
+        "jest-matcher-utils": "22.0.6",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
-        "pretty-format": "22.0.5"
+        "pretty-format": "22.0.6"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8219,16 +8251,16 @@
       }
     },
     "jest-util": {
-      "version": "22.0.5",
-      "integrity": "sha512-gQa3FSScRPrbdjqlxBubs3vI5YtCqmB1uYI5XtlA+1Ui5zajrz5dNug4Lj9ADX9Lhte9UuwoM6kawbtmWy3h3Q==",
+      "version": "22.0.6",
+      "integrity": "sha512-Je0ZVGGsnbPc6VNPFeTBDz1TbylFXshsLJkkZWLEPU+G7rn/8Xb2H+tqLr22+iaxuEBDyw9zgbZ9pcDElAykXw==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.3.0",
         "graceful-fs": "4.1.11",
         "is-ci": "1.1.0",
-        "jest-message-util": "22.0.3",
-        "jest-validate": "22.0.5",
+        "jest-message-util": "22.0.6",
+        "jest-validate": "22.0.6",
         "mkdirp": "0.5.1"
       },
       "dependencies": {
@@ -8276,14 +8308,14 @@
       }
     },
     "jest-validate": {
-      "version": "22.0.5",
-      "integrity": "sha512-4boEocPuJwUv0n8Y2Y1PNLiX5Yxm+Ab3Ticw3wVQNyrWL6Z7Ie7u/FJKa9ZLpNS+FqLnQG7LhLxT1PcN/+Ar9A==",
+      "version": "22.0.6",
+      "integrity": "sha512-vTNjS2ZwD+QK2k18p5KR/l2+QwkbCYmGPpbYBVC2pYnMUEaEupwe7fyJzGbeMD1BnoNd2E6ufCzjGWDU5SNI5Q==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-get-type": "22.0.3",
+        "jest-get-type": "22.0.6",
         "leven": "2.1.0",
-        "pretty-format": "22.0.5"
+        "pretty-format": "22.0.6"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8330,8 +8362,8 @@
       }
     },
     "jest-worker": {
-      "version": "22.0.3",
-      "integrity": "sha512-fPdCTnogFQiR0CP6whEsIly2RfcHxvalqyLjhui6qa1SnOmHiX7L8k4Umo8CBIp5ndWY0+ej1o7OTE5MlzPabg==",
+      "version": "22.0.6",
+      "integrity": "sha512-4GlBXpqO/RrmaNF9unPkwNbqlQqR0VtYX4QpYfSUzxBEuuRT0w7PyKj99k15KUC2gRNlNK/eN/bY81LAeW1NEg==",
       "dev": true,
       "requires": {
         "merge-stream": "1.0.1"
@@ -9321,8 +9353,8 @@
       "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw=="
     },
     "marked-terminal": {
-      "version": "1.7.0",
-      "integrity": "sha1-yMRgiBx3LHYEtkNnAH7l938SWQQ=",
+      "version": "2.0.0",
+      "integrity": "sha1-Xq9Wi+ZvaGVBr6UqVYKAMQox3i0=",
       "dev": true,
       "requires": {
         "cardinal": "1.0.0",
@@ -9579,13 +9611,13 @@
       "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
       "requires": {
         "concat-stream": "1.5.2",
-        "duplexify": "3.5.1",
-        "end-of-stream": "1.4.0",
+        "duplexify": "3.5.3",
+        "end-of-stream": "1.4.1",
         "flush-write-stream": "1.0.2",
         "from2": "2.3.0",
         "parallel-transform": "1.1.0",
         "pump": "1.0.3",
-        "pumpify": "1.3.5",
+        "pumpify": "1.3.6",
         "stream-each": "1.2.2",
         "through2": "2.0.3"
       },
@@ -11424,8 +11456,8 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "22.0.5",
-      "integrity": "sha512-kWls6NjFrwueDmrTq0qtXxDn/fiAica59J+C4lpE6mfeUYeg6gMR/4TH6ahz/Ceqh8O09au8Qe7TYRyDqT8NvQ==",
+      "version": "22.0.6",
+      "integrity": "sha512-U7vmPaahWJapEjMbqvHK4D0k7Cux2S1qHsXI5UHwdRK4gidtT0fFwFU3nutg3Ho8b7s5ikN0HVYNaHOjpRiY4g==",
       "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
@@ -11552,7 +11584,7 @@
         "browserify-rsa": "4.0.1",
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "pug": {
@@ -11675,17 +11707,31 @@
       "version": "1.0.3",
       "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "once": "1.4.0"
       }
     },
     "pumpify": {
-      "version": "1.3.5",
-      "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
+      "version": "1.3.6",
+      "integrity": "sha512-BurGAcvezsINL5US9T9wGHHcLNrG6MCp//ECtxron3vcR+Rfx5Anqq7HbZXNJvFQli8FGVsWCAvywEJFV5Hx/Q==",
       "requires": {
-        "duplexify": "3.5.1",
-        "inherits": "2.0.1",
-        "pump": "1.0.3"
+        "duplexify": "3.5.3",
+        "inherits": "2.0.3",
+        "pump": "2.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "pump": {
+          "version": "2.0.0",
+          "integrity": "sha512-6MYypjOvtiXhBSTOD0Zs5eNjCGfnqi5mPsCsW+dgKTxrZzQMZQNpBo3XRkLx7id753f3EeyHLBqzqqUymIolgw==",
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        }
       }
     },
     "punycode": {
@@ -11780,8 +11826,8 @@
       }
     },
     "randombytes": {
-      "version": "2.0.5",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "version": "2.0.6",
+      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -11790,7 +11836,7 @@
       "version": "1.0.3",
       "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
       "requires": {
-        "randombytes": "2.0.5",
+        "randombytes": "2.0.6",
         "safe-buffer": "5.1.1"
       }
     },
@@ -12325,7 +12371,7 @@
           "integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
           "dev": true,
           "requires": {
-            "cli-usage": "0.1.4",
+            "cli-usage": "0.1.7",
             "growly": "1.3.0",
             "lodash.clonedeep": "3.0.2",
             "minimist": "1.2.0",
@@ -14050,7 +14096,7 @@
       "version": "1.2.2",
       "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
       "requires": {
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "stream-shift": "1.0.0"
       }
     },
@@ -14588,7 +14634,7 @@
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
         "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
       },
@@ -15701,13 +15747,13 @@
       }
     },
     "webpack-bundle-analyzer": {
-      "version": "2.8.2",
-      "integrity": "sha1-i2JAwpqdY7xy8J2SD7BQrbzOn+g=",
+      "version": "2.9.2",
+      "integrity": "sha1-Y+2G63HMTNqG9o5oWoRTC6ASZEk=",
       "dev": true,
       "requires": {
         "acorn": "5.3.0",
         "chalk": "1.1.3",
-        "commander": "2.12.2",
+        "commander": "2.13.0",
         "ejs": "2.5.7",
         "express": "4.16.2",
         "filesize": "3.5.11",
@@ -15715,7 +15761,7 @@
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
         "opener": "1.4.3",
-        "ws": "2.3.1"
+        "ws": "4.0.0"
       },
       "dependencies": {
         "accepts": {
@@ -15767,8 +15813,8 @@
           }
         },
         "commander": {
-          "version": "2.12.2",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "version": "2.13.0",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
           "dev": true
         },
         "content-disposition": {
@@ -15997,19 +16043,13 @@
           "dev": true
         },
         "ws": {
-          "version": "2.3.1",
-          "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
+          "version": "4.0.0",
+          "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.0.1",
+            "async-limiter": "1.0.0",
+            "safe-buffer": "5.1.1",
             "ultron": "1.1.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.0.1",
-              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-              "dev": true
-            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
   },
   "scripts": {
     "preanalyze-bundles": "cross-env-shell WEBPACK_OUTPUT_JSON=1 CALYPSO_ENV=production npm run -s env -- node --max_old_space_size=8192 ./node_modules/.bin/webpack --config webpack.config.js --profile --json > stats.json",
-    "analyze-bundles": "webpack-bundle-analyzer stats.json public -h 0.0.0.0 -p 9898",
+    "analyze-bundles": "webpack-bundle-analyzer stats.json public -h 0.0.0.0 -p 9898 -s gzip",
     "analyze-css": "node bin/analyze-css.js",
     "autoprefixer": "postcss -r --use autoprefixer",
     "postcss": "postcss -r -u postcss-custom-properties -u autoprefixer -c postcss.config.json",
@@ -281,7 +281,7 @@
     "stylelint": "6.9.0",
     "supertest": "2.0.0",
     "terminal-kit": "1.13.13",
-    "webpack-bundle-analyzer": "2.8.2"
+    "webpack-bundle-analyzer": "2.9.2"
   },
   "optionalDependencies": {
     "fsevents": "1.1.3"


### PR DESCRIPTION
Makes the default treemap a better indicator of where we're spending bytes for wire transfer.
Functionality was already present in the UI, this just changes the default.