### PR TITLE
Allow ChecklistShow component to be used after signup

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -58,10 +58,32 @@ class ChecklistShow extends PureComponent {
 		}
 	};
 
-	renderHeader( completed ) {
+	renderHeader( completed, displayMode ) {
 		const shareTo = [ 'facebook', 'twitter', 'linkedin', 'google-plus', 'pinterest' ];
 
 		if ( ! completed ) {
+			if ( displayMode ) {
+				const title =
+					displayMode === 'free' ? 'Your site has been created!' : 'Thank you for your purchase!';
+
+				return (
+					<Fragment>
+						<img
+							src="/calypso/images/signup/confetti.svg"
+							aria-hidden="true"
+							className="checklist-show__confetti"
+						/>
+						<FormattedHeader
+							headerText={ title }
+							subHeaderText={
+								"Now that your site has been created, it's time to get it ready for you to share. " +
+								"We've prepared a list of things that will help you get there quickly."
+							}
+						/>
+					</Fragment>
+				);
+			}
+
 			return (
 				<FormattedHeader
 					headerText="Welcome back!"
@@ -97,7 +119,7 @@ class ChecklistShow extends PureComponent {
 	}
 
 	render() {
-		const { siteId, siteChecklist } = this.props;
+		const { displayMode, siteId, siteChecklist } = this.props;
 		let tasks = null;
 
 		if ( siteChecklist && siteChecklist.tasks ) {
@@ -106,11 +128,16 @@ class ChecklistShow extends PureComponent {
 
 		const completed = tasks && ! find( tasks, { completed: false } );
 
+		let title = 'Site Checklist';
+		if ( displayMode ) {
+			title = 'Thank You';
+		}
+
 		return (
 			<Main className="checklist-show">
-				<DocumentHead title="Site Checklist" />
+				<DocumentHead title={ title } />
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
-				{ this.renderHeader( completed ) }
+				{ this.renderHeader( completed, displayMode ) }
 				<Checklist
 					isLoading={ ! tasks }
 					tasks={ tasks }

--- a/client/my-sites/checklist/controller/index.jsx
+++ b/client/my-sites/checklist/controller/index.jsx
@@ -5,30 +5,15 @@
  */
 
 import React from 'react';
-import ReactDom from 'react-dom';
 
 /**
  * Internal Dependencies
  */
 
-import { renderWithReduxStore } from 'lib/react-helpers';
-import { setSection } from 'state/ui/actions';
 import ChecklistShow from '../checklist-show';
-import ChecklistThankYou from '../checklist-thank-you';
 
 export function show( context, next ) {
 	const { params } = context;
 	context.primary = <ChecklistShow displayMode={ params.displayMode } />;
 	next();
-}
-
-export function thankYou( context ) {
-	const { params, store } = context;
-	store.dispatch( setSection( { name: 'checklist-thank-you' }, { hasSidebar: false } ) );
-	renderWithReduxStore(
-		<ChecklistThankYou receiptId={ params.receiptId ? Number( params.receiptId ) : 0 } />,
-		'primary',
-		store
-	);
-	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 }

--- a/client/my-sites/checklist/controller/index.jsx
+++ b/client/my-sites/checklist/controller/index.jsx
@@ -17,7 +17,8 @@ import ChecklistShow from '../checklist-show';
 import ChecklistThankYou from '../checklist-thank-you';
 
 export function show( context, next ) {
-	context.primary = <ChecklistShow />;
+	const { params } = context;
+	context.primary = <ChecklistShow displayMode={ params.displayMode } />;
 	next();
 }
 

--- a/client/my-sites/checklist/index.js
+++ b/client/my-sites/checklist/index.js
@@ -17,7 +17,14 @@ import { makeLayout, render as clientRender } from 'controller';
 export default function() {
 	if ( config.isEnabled( 'onboarding-checklist' ) ) {
 		page( '/checklist', siteSelection, sites, makeLayout, clientRender );
-		page( '/checklist/:site_id', siteSelection, navigation, show, makeLayout, clientRender );
+		page(
+			'/checklist/:site_id/:displayMode?',
+			siteSelection,
+			navigation,
+			show,
+			makeLayout,
+			clientRender
+		);
 		page( '/checklist/thank-you/:site/:receiptId?', siteSelection, thankYou );
 	}
 }

--- a/client/my-sites/checklist/index.js
+++ b/client/my-sites/checklist/index.js
@@ -10,7 +10,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
-import { show, thankYou } from './controller';
+import { show } from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -25,6 +25,5 @@ export default function() {
 			makeLayout,
 			clientRender
 		);
-		page( '/checklist/thank-you/:site/:receiptId?', siteSelection, thankYou );
 	}
 }

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -307,7 +307,7 @@ const Checkout = createReactClass( {
 			this.props.isEligibleForCheckoutToChecklist &&
 			'show' === abtest( 'checklistThankYouForPaidUser' )
 		) {
-			return `/checklist/thank-you/${ selectedSiteSlug }/${ receiptId }`;
+			return `/checklist/${ selectedSiteSlug }/paid`;
 		}
 
 		if ( domainReceiptId && receiptId && abtest( 'gsuiteUpsellV2' ) === 'modified' ) {

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -285,7 +285,7 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	showChecklistAfterLogin = () => {
-		this.props.loginHandler( { redirectTo: `/checklist/thank-you/${ this.state.siteSlug }` } );
+		this.props.loginHandler( { redirectTo: `/checklist/${ this.state.siteSlug }/free` } );
 	};
 
 	shouldShowChecklist() {


### PR DESCRIPTION
The signup flow where users have been allocated to the checklist a/b test seems smoother if the thank you message is incorporated into the same component that is subsequently used for the checklist.

# Testing

## free plan signup

- allocate yourself to the checklist free plan a/b test
- sign up for a new site on a free plan
- verify that the thank you page appears as expected

## paid plan signup

- allocate yourself to the checklist paid plan a/b test
- sign up for a new site on a paid plan
- verify that the paid thank you page appears as expected
