### PR TITLE
CurrentSite: get visible site count from user object

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -97,8 +97,6 @@ class CurrentSite extends Component {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
 				<Card className="current-site is-loading">
-					{ visibleSitesCount > 1 && <span className="current-site__switch-sites">&nbsp;</span> }
-
 					<div className="site">
 						<a className="site__content">
 							<div className="site-icon" />

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -23,16 +23,17 @@ import SiteNotice from './notice';
 import CartStore from 'lib/cart/store';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSite } from 'state/ui/selectors';
-import { getSelectedOrAllSites, getVisibleSites } from 'state/selectors';
+import { getSelectedOrAllSites } from 'state/selectors';
 import { infoNotice, removeNotice } from 'state/notices/actions';
 import { getNoticeLastTimeShown } from 'state/notices/selectors';
 import { getSectionName } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isRtl from 'state/selectors/is-rtl';
+import { getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
 
 class CurrentSite extends Component {
 	static propTypes = {
-		siteCount: PropTypes.number.isRequired,
+		visibleSitesCount: PropTypes.number.isRequired,
 		setLayoutFocus: PropTypes.func.isRequired,
 		selectedSite: PropTypes.object,
 		translate: PropTypes.func.isRequired,
@@ -90,13 +91,13 @@ class CurrentSite extends Component {
 	};
 
 	render() {
-		const { selectedSite, translate, anySiteSelected, rtlOn } = this.props;
+		const { selectedSite, translate, anySiteSelected, rtlOn, visibleSitesCount } = this.props;
 
 		if ( ! anySiteSelected.length ) {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
 				<Card className="current-site is-loading">
-					{ this.props.siteCount > 1 && <span className="current-site__switch-sites">&nbsp;</span> }
+					{ visibleSitesCount > 1 && <span className="current-site__switch-sites">&nbsp;</span> }
 
 					<div className="site">
 						<a className="site__content">
@@ -113,7 +114,7 @@ class CurrentSite extends Component {
 
 		return (
 			<Card className="current-site">
-				{ this.props.siteCount > 1 && (
+				{ visibleSitesCount > 1 && (
 					<span className="current-site__switch-sites">
 						<Button compact borderless onClick={ this.switchSites }>
 							<Gridicon icon={ rtlOn ? 'arrow-right' : 'arrow-left' } size={ 18 } />
@@ -143,7 +144,7 @@ export default connect(
 		rtlOn: isRtl( state ),
 		selectedSite: getSelectedSite( state ),
 		anySiteSelected: getSelectedOrAllSites( state ),
-		siteCount: getVisibleSites( state ).length,
+		visibleSitesCount: getCurrentUserVisibleSiteCount( state ),
 		staleCartItemNoticeLastTimeShown: getNoticeLastTimeShown( state, 'stale-cart-item-notice' ),
 		sectionName: getSectionName( state ),
 	} ),


### PR DESCRIPTION
Currently, we are getting the visible sites count from the site items themselves. However, for that to work, they need to be already fetched. I think the correct way is to get the option from the user object which is loaded very early. This might also help if we decide to prefetch some sites before all sites are loaded.

## Testing

Site selector in sidebar should work as before. Try clearing local state and reloading the page.

Note: in 4f201df, I also removed some unnecessary space which I think is not needed anymore. It was added in #1609, but I can't repro the original bug.