### PR TITLE
DONTMERGE: Add a dummy counter reducer and a masterbar button to invoke it

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -109,6 +109,7 @@ class MasterbarLoggedIn extends React.Component {
 				>
 					{ translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 				</Item>
+				<Item onClick={ () => window.perfCounter( 1000 ) }>Count!</Item>
 				{ config.isEnabled( 'resume-editing' ) && <ResumeEditing /> }
 				{ ! domainOnlySite && (
 					<Publish

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -91,6 +91,9 @@ import config from 'config';
 // Consolidate the extension reducers under 'extensions' for namespacing.
 const extensions = combineReducers( extensionsModule.reducers() );
 
+const perfCounter = ( state = 0, action ) =>
+	action.type === 'PERF_COUNTER_INC' ? state + 1 : state;
+
 const reducers = {
 	analyticsTracking,
 	accountRecovery,
@@ -159,6 +162,7 @@ const reducers = {
 	userProfileLinks,
 	userSettings,
 	wordads,
+	perfCounter,
 };
 
 export const reducer = combineReducers( reducers );
@@ -209,5 +213,15 @@ export function createReduxStore( initialState = {} ) {
 		isBrowser && window.devToolsExtension && window.devToolsExtension(),
 	].filter( Boolean );
 
-	return compose( ...enhancers )( createStore )( reducer, initialState );
+	const store = compose( ...enhancers )( createStore )( reducer, initialState );
+	if ( isBrowser ) {
+		window.perfCounter = ( repeats = 1 ) => {
+			console.time( 'perfcounter' );
+			for ( let i = 0; i < repeats; i++ ) {
+				store.dispatch( { type: 'PERF_COUNTER_INC' } );
+			}
+			console.timeEnd( 'perfcounter' );
+		};
+	}
+	return store;
 }


### PR DESCRIPTION
Useful for detecting performance problems with Redux. Updating a state slice
that nobody uses (the dummy counter) should be superfast, right? Turns out that
there are many inefficient selectors and needlessly updating React component
that make this process suprisingly slow.

This patch adds a utility that measures the speed of dispatching dummy actions.