### PR TITLE
Site Selector: fix Site Placeholder styling

### DIFF
--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -9,7 +9,7 @@
 	border: none;
 	z-index: z-index( 'root', '.site-selector' );
 
-	&.is-large .search  {
+	&.is-large .search {
 		display: flex;
 		position: relative;
 		opacity: 1;
@@ -18,6 +18,15 @@
 
 	&.is-large .site-selector__sites {
 		border-top: 1px solid lighten( $gray, 20% );
+	}
+
+	.site.is-loading {
+		.site-icon,
+		.site__title,
+		.site__domain {
+			background-color: lighten( $gray, 35% );
+		}
+
 	}
 
 }


### PR DESCRIPTION
When sites are being loaded, normally, you can't click on Switch Sites in Site Selector. Therefore, the `SitePlaceholder` which is being used there is never seen. However, there's a styling bug: the background of Site Selector has the same color as the usual placeholder, making the Site Placeholder not visible.

As we want to add recent site pre-fetching, people will be able to access Site Selector even before all sites are loaded and we'll need this placeholder to work properly.

In this PR, I'm updating the background colors of it a bit just to make it visible. It probably needs some designer's eye, though. /cc @folletto 

## Testing

A bit harder because we need to be able to get into Site Selector before sites are loaded:

1. Open `my-sites/current-site/index` and comment out [the following code](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/current-site/index.jsx#L95-L112).
2. In the same file, remove [the following condition](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/current-site/index.jsx#L116).
3. Clear all local caches with Chrome dev tools -> Application -> Clear site data (make sure to uncheck "Cookies" first or you'll be logged out)
4. Now, if you reload local Calypso, immediately click on "Switch Sites". You should see the placeholder.
5. If you want to inspect it a bit more, open Chrome dev tools -> Elements, find `.site-selector`, right-click, "break on", "subtree modifications". You'll need to do this quickly until all sites are loaded. You can throttle your connection for more time in the Network tab of dev tools:

![image](https://user-images.githubusercontent.com/4988512/34822740-39823354-f6c8-11e7-86dd-6ee01885597a.png)

This is how it looks like:

![screenshot_2018-01-11 12 00 23_vxpx2v](https://user-images.githubusercontent.com/4988512/34822751-44cb25b8-f6c8-11e7-92bc-5037254760b6.png)
