### PR TITLE
State: Introduce a isJetpackOnboardingStepCompleted() selector

### DIFF
--- a/client/state/selectors/is-jetpack-onboarding-step-completed.js
+++ b/client/state/selectors/is-jetpack-onboarding-step-completed.js
@@ -1,0 +1,48 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getJetpackOnboardingSettings } from 'state/selectors';
+import { JETPACK_ONBOARDING_STEPS as STEPS } from 'jetpack-onboarding/constants';
+
+export const isJetpackOnboardingStepCompleted = createSelector(
+	( state, siteId, stepName ) => {
+		const settings = getJetpackOnboardingSettings( state, siteId );
+
+		if ( ! settings ) {
+			return null;
+		}
+
+		switch ( stepName ) {
+			case STEPS.SITE_TITLE:
+				const titleModified = get( settings, 'siteTitle', '' ) !== '';
+				const defaultDescription = translate( 'Just another WordPress site' );
+				const descriptionModified =
+					get( settings, 'siteDescription', defaultDescription ) !== defaultDescription;
+				return titleModified || descriptionModified;
+			case STEPS.SITE_TYPE:
+				return !! get( settings, 'siteType' );
+			case STEPS.HOMEPAGE:
+				return !! get( settings, 'homepageFormat' );
+			case STEPS.CONTACT_FORM:
+				return !! get( settings, 'contactForm' );
+			case STEPS.BUSINESS_ADDRESS:
+				return !! get( settings, 'businessAddress' );
+			case STEPS.WOOCOMMERCE:
+				return !! get( settings, 'woocommerce' );
+		}
+
+		return null;
+	},
+	state => [ state.jetpackOnboarding.settings ]
+);
+
+export default isJetpackOnboardingStepCompleted;

--- a/client/state/selectors/is-jetpack-onboarding-step-completed.js
+++ b/client/state/selectors/is-jetpack-onboarding-step-completed.js
@@ -18,7 +18,7 @@ export const isJetpackOnboardingStepCompleted = createSelector(
 		const settings = getJetpackOnboardingSettings( state, siteId );
 
 		if ( ! settings ) {
-			return null;
+			return false;
 		}
 
 		switch ( stepName ) {
@@ -38,9 +38,9 @@ export const isJetpackOnboardingStepCompleted = createSelector(
 				return !! get( settings, 'businessAddress' );
 			case STEPS.WOOCOMMERCE:
 				return !! get( settings, 'woocommerce' );
+			default:
+				return false;
 		}
-
-		return null;
 	},
 	state => [ state.jetpackOnboarding.settings ]
 );

--- a/client/state/selectors/is-jetpack-onboarding-step-completed.js
+++ b/client/state/selectors/is-jetpack-onboarding-step-completed.js
@@ -13,7 +13,7 @@ import createSelector from 'lib/create-selector';
 import { getJetpackOnboardingSettings } from 'state/selectors';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from 'jetpack-onboarding/constants';
 
-export const isJetpackOnboardingStepCompleted = createSelector(
+export default createSelector(
 	( state, siteId, stepName ) => {
 		const settings = getJetpackOnboardingSettings( state, siteId );
 
@@ -44,5 +44,3 @@ export const isJetpackOnboardingStepCompleted = createSelector(
 	},
 	state => [ state.jetpackOnboarding.settings ]
 );
-
-export default isJetpackOnboardingStepCompleted;

--- a/client/state/selectors/test/is-jetpack-onboarding-step-completed.js
+++ b/client/state/selectors/test/is-jetpack-onboarding-step-completed.js
@@ -5,7 +5,7 @@ import { JETPACK_ONBOARDING_STEPS as STEPS } from 'jetpack-onboarding/constants'
 import { isJetpackOnboardingStepCompleted } from 'state/selectors';
 
 describe( 'isJetpackOnboardingStepCompleted()', () => {
-	test( 'should return null for a null site ID', () => {
+	test( 'should return false for a null site ID', () => {
 		const state = {
 			jetpackOnboarding: {
 				settings: {
@@ -18,10 +18,10 @@ describe( 'isJetpackOnboardingStepCompleted()', () => {
 		};
 		const completed = isJetpackOnboardingStepCompleted( state, null, STEPS.SITE_TITLE );
 
-		expect( completed ).toBeNull();
+		expect( completed ).toBe( false );
 	} );
 
-	test( 'should return null if we have no settings for that site', () => {
+	test( 'should return false if we have no settings for that site', () => {
 		const state = {
 			jetpackOnboarding: {
 				settings: {
@@ -34,10 +34,10 @@ describe( 'isJetpackOnboardingStepCompleted()', () => {
 		};
 		const completed = isJetpackOnboardingStepCompleted( state, 12345678, STEPS.SITE_TITLE );
 
-		expect( completed ).toBeNull();
+		expect( completed ).toBe( false );
 	} );
 
-	test( 'should return null for an unexisting step', () => {
+	test( 'should return false for an unexisting step', () => {
 		const state = {
 			jetpackOnboarding: {
 				settings: {
@@ -50,7 +50,7 @@ describe( 'isJetpackOnboardingStepCompleted()', () => {
 		};
 		const completed = isJetpackOnboardingStepCompleted( state, 2916284, 'some-unexisting-step' );
 
-		expect( completed ).toBeNull();
+		expect( completed ).toBe( false );
 	} );
 
 	test( 'should return true for site title step if we have modified the site title', () => {

--- a/client/state/selectors/test/is-jetpack-onboarding-step-completed.js
+++ b/client/state/selectors/test/is-jetpack-onboarding-step-completed.js
@@ -1,0 +1,328 @@
+/**
+ * Internal dependencies
+ */
+import { JETPACK_ONBOARDING_STEPS as STEPS } from 'jetpack-onboarding/constants';
+import { isJetpackOnboardingStepCompleted } from 'state/selectors';
+
+describe( 'isJetpackOnboardingStepCompleted()', () => {
+	test( 'should return null for a null site ID', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteTitle: 'My awesome site',
+						siteDescription: 'Not just another amazing WordPress site',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, null, STEPS.SITE_TITLE );
+
+		expect( completed ).toBeNull();
+	} );
+
+	test( 'should return null if we have no settings for that site', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteTitle: 'My awesome site',
+						siteDescription: 'Not just another amazing WordPress site',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 12345678, STEPS.SITE_TITLE );
+
+		expect( completed ).toBeNull();
+	} );
+
+	test( 'should return null for an unexisting step', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteTitle: 'My awesome site',
+						siteDescription: 'Not just another amazing WordPress site',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, 'some-unexisting-step' );
+
+		expect( completed ).toBeNull();
+	} );
+
+	test( 'should return true for site title step if we have modified the site title', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteTitle: 'My awesome site',
+						siteDescription: 'Just another WordPress site',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.SITE_TITLE );
+
+		expect( completed ).toBe( true );
+	} );
+
+	test( 'should return true for site title step if we have modified the site description', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteTitle: '',
+						siteDescription: 'Not just another amazing WordPress site',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.SITE_TITLE );
+
+		expect( completed ).toBe( true );
+	} );
+
+	test( 'should return false if site title and description have not been modified yet', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteTitle: '',
+						siteDescription: 'Just another WordPress site',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.SITE_TITLE );
+
+		expect( completed ).toBe( false );
+	} );
+
+	test( 'should return true for site type step if we have selected the site type', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteType: 'personal',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.SITE_TYPE );
+
+		expect( completed ).toBe( true );
+	} );
+
+	test( 'should return false for site type step if we have not selected the site type yet', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteTitle: 'My awesome site',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.SITE_TYPE );
+
+		expect( completed ).toBe( false );
+	} );
+
+	test( 'should return false for site type step if site type is specified as not selected', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteType: false,
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.SITE_TYPE );
+
+		expect( completed ).toBe( false );
+	} );
+
+	test( 'should return true for homepage step if we have selected the homepage format', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						homepageFormat: 'page',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.HOMEPAGE );
+
+		expect( completed ).toBe( true );
+	} );
+
+	test( 'should return false for homepage step if we have not selected the homepage format yet', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteTitle: 'My awesome site',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.HOMEPAGE );
+
+		expect( completed ).toBe( false );
+	} );
+
+	test( 'should return false for homepage step if we it is specified as not selected', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						homepageFormat: false,
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.HOMEPAGE );
+
+		expect( completed ).toBe( false );
+	} );
+
+	test( 'should return true for contact form step if we have chosen to create a contact form', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						contactForm: true,
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.CONTACT_FORM );
+
+		expect( completed ).toBe( true );
+	} );
+
+	test( 'should return false for contact form step if we have not chosen to create a contact form', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteTitle: 'My awesome site',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.CONTACT_FORM );
+
+		expect( completed ).toBe( false );
+	} );
+
+	test( 'should return false for contact form step if it is specified as not selected', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						contactForm: false,
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.CONTACT_FORM );
+
+		expect( completed ).toBe( false );
+	} );
+
+	test( 'should return true for business address step if we have chosen to add a business address', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						businessAddress: [],
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.BUSINESS_ADDRESS );
+
+		expect( completed ).toBe( true );
+	} );
+
+	test( 'should return false for business address step if we have not added a business address', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteTitle: 'My awesome site',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.BUSINESS_ADDRESS );
+
+		expect( completed ).toBe( false );
+	} );
+
+	test( 'should return false for business address step if it is specified as not added yet', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						businessAddress: false,
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.BUSINESS_ADDRESS );
+
+		expect( completed ).toBe( false );
+	} );
+
+	test( 'should return true for woocommerce step if we have chosen to install woocommerce', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						woocommerce: true,
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.WOOCOMMERCE );
+
+		expect( completed ).toBe( true );
+	} );
+
+	test( 'should return false for woocommerce step if we have not installed/activated woocommerce', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteTitle: 'My awesome site',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.WOOCOMMERCE );
+
+		expect( completed ).toBe( false );
+	} );
+
+	test( 'should return false for woocommerce step if it is specified as not installed/activated yet', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						woocommerce: false,
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.WOOCOMMERCE );
+
+		expect( completed ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
This PR introduces a `isJetpackOnboardingStepCompleted` selector that we'll use on the Summary step in order to determine whether an onboarding step has been completed by the user or not.

To test:
* Checkout this branch.
* Verify all tests pass:

```
npm run test-client client/state/selectors/test/is-jetpack-onboarding-step-completed.js
```