### PR TITLE
SiteTitleControl: Make Site Title required and autoFocus'd

### DIFF
--- a/client/components/site-title/index.jsx
+++ b/client/components/site-title/index.jsx
@@ -17,12 +17,14 @@ import FormTextInput from 'components/forms/form-text-input';
 
 class SiteTitleControl extends React.Component {
 	static propTypes = {
+		autoFocusBlogname: PropTypes.bool,
 		blogname: PropTypes.string,
 		blogdescription: PropTypes.string,
 		onChange: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
+		autoFocusBlogname: false,
 		blogname: '',
 		blogdescription: '',
 	};
@@ -45,7 +47,7 @@ class SiteTitleControl extends React.Component {
 				<FormFieldset>
 					<FormLabel htmlFor="blogname">{ this.props.translate( 'Site Title' ) }</FormLabel>
 					<FormTextInput
-						autoFocus
+						autoFocus={ this.props.autoFocusBlogname }
 						name="blogname"
 						onChange={ this.onChangeSiteTitle }
 						required

--- a/client/components/site-title/index.jsx
+++ b/client/components/site-title/index.jsx
@@ -48,7 +48,7 @@ class SiteTitleControl extends React.Component {
 					<FormLabel htmlFor="blogname">{ this.props.translate( 'Site Title' ) }</FormLabel>
 					<FormTextInput
 						autoFocus={ this.props.autoFocusBlogname }
-						name="blogname"
+						id="blogname"
 						onChange={ this.onChangeSiteTitle }
 						required
 						value={ this.props.blogname }
@@ -57,7 +57,7 @@ class SiteTitleControl extends React.Component {
 				<FormFieldset>
 					<FormLabel htmlFor="blogdescription">{ this.props.translate( 'Tagline' ) }</FormLabel>
 					<FormTextInput
-						name="blogdescription"
+						id="blogdescription"
 						onChange={ this.onChangeDescription }
 						value={ this.props.blogdescription }
 					/>

--- a/client/components/site-title/index.jsx
+++ b/client/components/site-title/index.jsx
@@ -45,8 +45,10 @@ class SiteTitleControl extends React.Component {
 				<FormFieldset>
 					<FormLabel htmlFor="blogname">{ this.props.translate( 'Site Title' ) }</FormLabel>
 					<FormTextInput
+						autoFocus
 						name="blogname"
 						onChange={ this.onChangeSiteTitle }
+						required
 						value={ this.props.blogname }
 					/>
 				</FormFieldset>

--- a/client/components/site-title/index.jsx
+++ b/client/components/site-title/index.jsx
@@ -46,16 +46,16 @@ class SiteTitleControl extends React.Component {
 					<FormLabel htmlFor="blogname">{ this.props.translate( 'Site Title' ) }</FormLabel>
 					<FormTextInput
 						name="blogname"
-						value={ this.props.blogname }
 						onChange={ this.onChangeSiteTitle }
+						value={ this.props.blogname }
 					/>
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="blogdescription">{ this.props.translate( 'Tagline' ) }</FormLabel>
 					<FormTextInput
 						name="blogdescription"
-						value={ this.props.blogdescription }
 						onChange={ this.onChangeDescription }
+						value={ this.props.blogdescription }
 					/>
 				</FormFieldset>
 			</div>


### PR DESCRIPTION
For feature parity with our own https://github.com/Automattic/wp-calypso/blob/master/client/jetpack-onboarding/steps/site-title.jsx (so we can drop it in favor of the generic component).

I opted not to make the tagline required -- I think it's permissible to not set that.

To test: Check that http://calypso.localhost:3000/devdocs/design/site-title-control still works, and that there are no console errors.