### PR TITLE
JP Onboarding: Use existing SiteTitle component

### DIFF
--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -15,34 +15,27 @@ import Button from 'components/button';
 import Card from 'components/card';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormTextarea from 'components/forms/form-textarea';
-import FormTextInput from 'components/forms/form-text-input';
 import JetpackOnboardingDisclaimer from '../disclaimer';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import SiteTitle from 'components/site-title';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	state = {
-		description: '',
-		title: '',
+		blogname: '',
+		blogdescription: '',
 	};
 
-	setDescription = event => {
-		this.setState( { description: event.target.value } );
-	};
-
-	setTitle = event => {
-		this.setState( { title: event.target.value } );
+	handleChange = ( { blogname, blogdescription } ) => {
+		this.setState( { blogname, blogdescription } );
 	};
 
 	handleSubmit = event => {
 		event.preventDefault();
 		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
-			siteTitle: this.state.title,
-			siteDescription: this.state.description,
+			siteTitle: this.state.blogname,
+			siteDescription: this.state.blogdescription,
 		} );
 		page( this.props.getForwardUrl() );
 	};
@@ -66,26 +59,11 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 
 				<Card className="steps__form">
 					<form onSubmit={ this.handleSubmit }>
-						<FormFieldset>
-							<FormLabel htmlFor="title">{ translate( 'Site Title' ) }</FormLabel>
-							<FormTextInput
-								autoFocus
-								id="title"
-								onChange={ this.setTitle }
-								required
-								value={ this.state.title }
-							/>
-						</FormFieldset>
-
-						<FormFieldset>
-							<FormLabel htmlFor="description">{ translate( 'Site Description' ) }</FormLabel>
-							<FormTextarea
-								id="description"
-								onChange={ this.setDescription }
-								required
-								value={ this.state.description }
-							/>
-						</FormFieldset>
+						<SiteTitle
+							blogname={ this.state.blogname }
+							blogdescription={ this.state.blogdescription }
+							onChange={ this.handleChange }
+						/>
 
 						<Button primary type="submit">
 							{ translate( 'Next Step' ) }

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -60,6 +60,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 				<Card className="steps__form">
 					<form onSubmit={ this.handleSubmit }>
 						<SiteTitle
+							autoFocusBlogname
 							blogname={ this.state.blogname }
 							blogdescription={ this.state.blogdescription }
 							onChange={ this.handleChange }


### PR DESCRIPTION
De-dupe all the things! Companion PR #21439 for feature parity.

To test:
1. Checkout this branch on your local Calypso.
1. Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
1. Enter site title and tagline
1. Submit
1. Verify that they are applied to your site.