### PR TITLE
Avoid creating too many objects in combineReducers

### DIFF
--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -17,7 +17,6 @@ import {
 	omit,
 	omitBy,
 	partialRight,
-	reduce,
 } from 'lodash';
 import { combineReducers as combine } from 'redux'; // eslint-disable-line wpcalypso/import-no-redux-combine-reducers
 import LRU from 'lru-cache';
@@ -429,16 +428,9 @@ export const withSchemaValidation = ( schema, reducer ) => {
  * @returns {function} - Returns the combined reducer function
  */
 export function combineReducers( reducers ) {
-	const validatedReducers = reduce(
+	const validatedReducers = mapValues(
 		reducers,
-		( validated, next, key ) => {
-			const { schema, hasCustomPersistence } = next;
-			return {
-				...validated,
-				[ key ]: hasCustomPersistence ? next : withSchemaValidation( schema, next ),
-			};
-		},
-		{}
+		next => ( next.hasCustomPersistence ? next : withSchemaValidation( next.schema, next ) )
 	);
 	const combined = combine( validatedReducers );
 	combined.hasCustomPersistence = true;


### PR DESCRIPTION
When the `combineReducers` function creates the `validatedReducers` object, it creates a new
object on each iteration of `reduce`. Avoid this by using the `mapValues` function from lodash.
That function creates only one object and assigns properties to it.

`combineReducers` is called more that 600 times on Calypso boot, when creating the store. This
patch should make the boot slightly faster. I was unable to prove it with measurements, because the
improvement is rather small and is hidden in the noise of executing many other things.