### PR TITLE
Sites List: fetch primary and recent sites first

### DIFF
--- a/client/components/data/query-sites/README.md
+++ b/client/components/data/query-sites/README.md
@@ -1,11 +1,19 @@
 Query Sites
 ===========================
 
-`<QuerySites />` is a React component used in managing network requests for sites. If passed a site ID, it will request the site when the component is mounted. If no site ID is passed, it will request all sites for the current user.
+`<QuerySites />` is a React component used in managing network requests for sites.
 
 ## Usage
 
-Render the component, optionally passing a site ID. The component does not accept any children, nor does it render any of its own.
+The component does not accept any children, nor does it render any of its own.
+
+If you want to request a single site, provide its ID with `siteId`. If you want to request all sites,
+provide the `allSites` prop. If you want to request the primary and the recent sites, provide the
+`primaryAndRecent` prop. You can also combine these props.
+
+If the `siteId`, primary site or recent sites change (ie Redux is updated with new data), `QuerySites` will
+re-fetch them if it's not fetching them already. If `allSites` is provided, it will request all sites just once,
+even if state has been updated.
 
 ```jsx
 function AllSites() {
@@ -14,6 +22,10 @@ function AllSites() {
 
 function SingleSite() {
 	return <QuerySites siteId={ 2916284 } />
+}
+
+function PrimaryAndRecentSites() {
+	return <QuerySites primaryAndRecent />
 }
 ```
 
@@ -27,6 +39,15 @@ function SingleSite() {
 </table>
 
 An optional prop specifying a single site to be requested.
+
+### `primaryAndRecent`
+
+<table>
+	<tr><th>Type</th><td>Boolean</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+An optional prop specifying primary and recent sites to be requested.
 
 ### `allSites`
 

--- a/client/components/data/query-sites/index.jsx
+++ b/client/components/data/query-sites/index.jsx
@@ -17,10 +17,6 @@ import { requestSites, requestSite } from 'state/sites/actions';
 import { getPreference } from 'state/preferences/selectors';
 import { getPrimarySiteId } from 'state/selectors';
 
-const isRequestingSiteFactory = state => {
-	return siteId => isRequestingSite( state, siteId );
-};
-
 class QuerySites extends Component {
 	componentWillMount() {
 		this.requestAll( this.props );
@@ -116,9 +112,9 @@ export default connect(
 			requestingSites: isRequestingSites( state ),
 			requestingSite: isRequestingSite( state, siteId ),
 			isRequestingPrimarySite: isRequestingSite( state, primarySiteId ),
-			isRequestingRecentSites: some(
-				recentSiteIdsWithoutPrimary,
-				isRequestingSiteFactory( state )
+			// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+			isRequestingRecentSites: some( recentSiteIdsWithoutPrimary, id =>
+				isRequestingSite( state, id )
 			),
 		};
 	},

--- a/client/components/data/query-sites/index.jsx
+++ b/client/components/data/query-sites/index.jsx
@@ -7,29 +7,72 @@
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { some, forEach, isEqual, without } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { isRequestingSites, isRequestingSite } from 'state/sites/selectors';
 import { requestSites, requestSite } from 'state/sites/actions';
+import { getPreference } from 'state/preferences/selectors';
+import { getPrimarySiteId } from 'state/selectors';
+
+const isRequestingSiteFactory = state => {
+	return siteId => isRequestingSite( state, siteId );
+};
 
 class QuerySites extends Component {
 	componentWillMount() {
-		this.request( this.props );
+		this.requestAll( this.props );
+		this.requestPrimary( this.props );
+		this.requestRecent( this.props );
+		this.requestSingle( this.props );
 	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.siteId !== this.props.siteId ) {
-			this.request( nextProps );
+			this.requestSingle( nextProps );
+		}
+
+		if ( nextProps.primaryAndRecent && nextProps.primarySiteId !== this.props.primarySiteId ) {
+			this.requestPrimary( nextProps );
+		}
+
+		if (
+			nextProps.primaryAndRecent &&
+			! isEqual( nextProps.recentSiteIds, this.props.recentSiteIds )
+		) {
+			this.requestRecent( nextProps );
 		}
 	}
 
-	request( props ) {
+	requestAll( props ) {
 		if ( props.allSites && ! props.requestingSites ) {
 			props.requestSites();
 		}
+	}
 
+	requestPrimary( props ) {
+		if ( props.primaryAndRecent ) {
+			const { primarySiteId, isRequestingPrimarySite } = props;
+
+			if ( primarySiteId && ! isRequestingPrimarySite ) {
+				props.requestSite( primarySiteId );
+			}
+		}
+	}
+
+	requestRecent( props ) {
+		if ( props.primaryAndRecent ) {
+			const { recentSiteIds, isRequestingRecentSites, primarySiteId } = props;
+
+			if ( recentSiteIds && recentSiteIds.length && ! isRequestingRecentSites ) {
+				forEach( without( recentSiteIds, primarySiteId ), props.requestSite );
+			}
+		}
+	}
+
+	requestSingle( props ) {
 		if ( props.siteId && ! props.requestingSite ) {
 			props.requestSite( props.siteId );
 		}
@@ -42,6 +85,7 @@ class QuerySites extends Component {
 
 QuerySites.propTypes = {
 	allSites: PropTypes.bool,
+	primaryAndRecent: PropTypes.bool,
 	siteId: PropTypes.number,
 	requestingSites: PropTypes.bool,
 	requestingSite: PropTypes.bool,
@@ -51,15 +95,30 @@ QuerySites.propTypes = {
 
 QuerySites.defaultProps = {
 	allSites: false,
+	primaryAndRecent: false,
 	requestSites: () => {},
 	requestSite: () => {},
 };
 
 export default connect(
 	( state, { siteId } ) => {
+		const primarySiteId = getPrimarySiteId( state );
+		const recentSiteIds = getPreference( state, 'recentSites' );
+		const recentSiteIdsWithoutPrimary = without(
+			getPreference( state, 'recentSites' ),
+			primarySiteId
+		);
+
 		return {
+			primarySiteId,
+			recentSiteIds,
 			requestingSites: isRequestingSites( state ),
 			requestingSite: isRequestingSite( state, siteId ),
+			isRequestingPrimarySite: isRequestingSite( state, primarySiteId ),
+			isRequestingRecentSites: some(
+				recentSiteIdsWithoutPrimary,
+				isRequestingSiteFactory( state )
+			),
 		};
 	},
 	{ requestSites, requestSite }

--- a/client/components/data/query-sites/index.jsx
+++ b/client/components/data/query-sites/index.jsx
@@ -12,7 +12,7 @@ import { some, forEach, isEqual, without } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isRequestingSites, isRequestingSite } from 'state/sites/selectors';
+import { isRequestingSites, isRequestingSite, hasAllSitesList } from 'state/sites/selectors';
 import { requestSites, requestSite } from 'state/sites/actions';
 import { getPreference } from 'state/preferences/selectors';
 import { getPrimarySiteId } from 'state/selectors';
@@ -53,7 +53,7 @@ class QuerySites extends Component {
 	}
 
 	requestPrimary( props ) {
-		if ( props.primaryAndRecent ) {
+		if ( props.primaryAndRecent && ! props.hasAllSitesList ) {
 			const { primarySiteId, isRequestingPrimarySite } = props;
 
 			if ( primarySiteId && ! isRequestingPrimarySite ) {
@@ -63,7 +63,7 @@ class QuerySites extends Component {
 	}
 
 	requestRecent( props ) {
-		if ( props.primaryAndRecent ) {
+		if ( props.primaryAndRecent && ! props.hasAllSitesList ) {
 			const { recentSiteIds, isRequestingRecentSites, primarySiteId } = props;
 
 			if ( recentSiteIds && recentSiteIds.length && ! isRequestingRecentSites ) {
@@ -112,6 +112,7 @@ export default connect(
 		return {
 			primarySiteId,
 			recentSiteIds,
+			hasAllSitesList: hasAllSitesList( state ),
 			requestingSites: isRequestingSites( state ),
 			requestingSite: isRequestingSite( state, siteId ),
 			isRequestingPrimarySite: isRequestingSite( state, primarySiteId ),

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -19,7 +19,7 @@ import debugFactory from 'debug';
 import { getPreference } from 'state/preferences/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-import { getSite, isRequestingSites } from 'state/sites/selectors';
+import { getSite, hasAllSitesList } from 'state/sites/selectors';
 import { areAllSitesSingleUser, getSites, getVisibleSites, hasLoadedSites } from 'state/selectors';
 import AllSites from 'my-sites/all-sites';
 import Site from 'blocks/site';
@@ -267,7 +267,7 @@ class SiteSelector extends Component {
 	renderSites() {
 		let sites;
 
-		if ( this.props.isRequestingSites ) {
+		if ( ! this.props.hasAllSitesList ) {
 			return <SitePlaceholder key="site-placeholder" />;
 		}
 
@@ -497,7 +497,7 @@ const mapState = state => {
 		selectedSite: getSelectedSite( state ),
 		visibleSites: getVisibleSites( state ),
 		allSitesSingleUser: areAllSitesSingleUser( state ),
-		isRequestingSites: isRequestingSites( state ),
+		hasAllSitesList: hasAllSitesList( state ),
 	};
 };
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -19,7 +19,7 @@ import debugFactory from 'debug';
 import { getPreference } from 'state/preferences/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-import { getSite } from 'state/sites/selectors';
+import { getSite, isRequestingSites } from 'state/sites/selectors';
 import { areAllSitesSingleUser, getSites, getVisibleSites, hasLoadedSites } from 'state/selectors';
 import AllSites from 'my-sites/all-sites';
 import Site from 'blocks/site';
@@ -267,7 +267,7 @@ class SiteSelector extends Component {
 	renderSites() {
 		let sites;
 
-		if ( ! this.props.hasLoadedSites ) {
+		if ( this.props.isRequestingSites ) {
 			return <SitePlaceholder key="site-placeholder" />;
 		}
 
@@ -497,6 +497,7 @@ const mapState = state => {
 		selectedSite: getSelectedSite( state ),
 		visibleSites: getVisibleSites( state ),
 		allSitesSingleUser: areAllSitesSingleUser( state ),
+		isRequestingSites: isRequestingSites( state ),
 	};
 };
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { property, sortBy, map } from 'lodash';
+import { property, sortBy } from 'lodash';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
@@ -51,7 +51,6 @@ import NpsSurveyNotice from 'layout/nps-survey-notice';
 import AppBanner from 'blocks/app-banner';
 import { getPreference } from 'state/preferences/selectors';
 import JITM from 'blocks/jitm';
-import { getPrimarySiteId } from 'state/selectors';
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
@@ -156,16 +155,11 @@ const Layout = createReactClass( {
 				'is-active': this.props.isLoading,
 			} );
 
-		const { primarySiteId, recentSiteIds } = this.props;
-
 		return (
 			<div className={ sectionClass }>
 				<DocumentHead />
 				<SitesListNotices />
-				{ primarySiteId && <QuerySites siteId={ primarySiteId } /> }
-				{ map( recentSiteIds, recentSiteId => (
-					<QuerySites key={ recentSiteId } siteId={ recentSiteId } />
-				) ) }
+				<QuerySites primaryAndRecent />
 				<QuerySites allSites />
 				<QueryPreferences />
 				{ <GuidedTours /> }
@@ -220,7 +214,5 @@ export default connect( state => {
 		currentLayoutFocus: getCurrentLayoutFocus( state ),
 		chatIsOpen: isHappychatOpen( state ),
 		colorSchemePreference: getPreference( state, 'colorScheme' ),
-		primarySiteId: getPrimarySiteId( state ),
-		recentSiteIds: getPreference( state, 'recentSites' ),
 	};
 } )( Layout );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { property, sortBy } from 'lodash';
+import { property, sortBy, map } from 'lodash';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
@@ -51,6 +51,7 @@ import NpsSurveyNotice from 'layout/nps-survey-notice';
 import AppBanner from 'blocks/app-banner';
 import { getPreference } from 'state/preferences/selectors';
 import JITM from 'blocks/jitm';
+import { getPrimarySiteId } from 'state/selectors';
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
@@ -155,10 +156,16 @@ const Layout = createReactClass( {
 				'is-active': this.props.isLoading,
 			} );
 
+		const { primarySiteId, recentSiteIds } = this.props;
+
 		return (
 			<div className={ sectionClass }>
 				<DocumentHead />
 				<SitesListNotices />
+				{ primarySiteId && <QuerySites siteId={ primarySiteId } /> }
+				{ map( recentSiteIds, recentSiteId => (
+					<QuerySites key={ recentSiteId } siteId={ recentSiteId } />
+				) ) }
 				<QuerySites allSites />
 				<QueryPreferences />
 				{ <GuidedTours /> }
@@ -213,5 +220,7 @@ export default connect( state => {
 		currentLayoutFocus: getCurrentLayoutFocus( state ),
 		chatIsOpen: isHappychatOpen( state ),
 		colorSchemePreference: getPreference( state, 'colorScheme' ),
+		primarySiteId: getPrimarySiteId( state ),
+		recentSiteIds: getPreference( state, 'recentSites' ),
 	};
 } )( Layout );

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -29,6 +29,7 @@ import { getNoticeLastTimeShown } from 'state/notices/selectors';
 import { getSectionName } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isRtl from 'state/selectors/is-rtl';
+import { isRequestingSites } from 'state/sites/selectors';
 
 class CurrentSite extends Component {
 	static propTypes = {
@@ -90,9 +91,9 @@ class CurrentSite extends Component {
 	};
 
 	render() {
-		const { selectedSite, translate, anySiteSelected, rtlOn } = this.props;
+		const { selectedSite, translate, anySiteSelected, rtlOn, isRequestingAllSites } = this.props;
 
-		if ( ! anySiteSelected.length ) {
+		if ( ! anySiteSelected.length || ( ! selectedSite && isRequestingAllSites ) ) {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
 				<Card className="current-site is-loading">
@@ -102,7 +103,9 @@ class CurrentSite extends Component {
 						<a className="site__content">
 							<div className="site-icon" />
 							<div className="site__info">
-								<span className="site__title">{ translate( 'Loading My Sites…' ) }</span>
+								<span className="site__title">
+									{ translate( 'Loading My Sites…' ) }
+								</span>
 							</div>
 						</a>
 					</div>
@@ -113,22 +116,19 @@ class CurrentSite extends Component {
 
 		return (
 			<Card className="current-site">
-				{ this.props.siteCount > 1 && (
+				{ this.props.siteCount > 1 &&
 					<span className="current-site__switch-sites">
 						<Button compact borderless onClick={ this.switchSites }>
 							<Gridicon icon={ rtlOn ? 'arrow-right' : 'arrow-left' } size={ 18 } />
 							{ translate( 'Switch Site' ) }
 						</Button>
-					</span>
-				) }
+					</span> }
 
-				{ selectedSite ? (
-					<div>
-						<Site site={ selectedSite } />
-					</div>
-				) : (
-					<AllSites />
-				) }
+				{ selectedSite
+					? <div>
+							<Site site={ selectedSite } />
+						</div>
+					: <AllSites /> }
 
 				<AsyncLoad require="my-sites/current-site/domain-warnings" placeholder={ null } />
 
@@ -146,6 +146,7 @@ export default connect(
 		siteCount: getVisibleSites( state ).length,
 		staleCartItemNoticeLastTimeShown: getNoticeLastTimeShown( state, 'stale-cart-item-notice' ),
 		sectionName: getSectionName( state ),
+		isRequestingAllSites: isRequestingSites( state ),
 	} ),
 	{ setLayoutFocus, infoNotice, removeNotice, recordTracksEvent }
 )( localize( CurrentSite ) );

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -29,7 +29,7 @@ import { getNoticeLastTimeShown } from 'state/notices/selectors';
 import { getSectionName } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isRtl from 'state/selectors/is-rtl';
-import { isRequestingSites } from 'state/sites/selectors';
+import { hasAllSitesList } from 'state/sites/selectors';
 
 class CurrentSite extends Component {
 	static propTypes = {
@@ -91,9 +91,9 @@ class CurrentSite extends Component {
 	};
 
 	render() {
-		const { selectedSite, translate, anySiteSelected, rtlOn, isRequestingAllSites } = this.props;
+		const { selectedSite, translate, anySiteSelected, rtlOn } = this.props;
 
-		if ( ! anySiteSelected.length || ( ! selectedSite && isRequestingAllSites ) ) {
+		if ( ! anySiteSelected.length || ( ! selectedSite && ! this.props.hasAllSitesList ) ) {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
 				<Card className="current-site is-loading">
@@ -145,7 +145,7 @@ export default connect(
 		siteCount: getVisibleSites( state ).length,
 		staleCartItemNoticeLastTimeShown: getNoticeLastTimeShown( state, 'stale-cart-item-notice' ),
 		sectionName: getSectionName( state ),
-		isRequestingAllSites: isRequestingSites( state ),
+		hasAllSitesList: hasAllSitesList( state ),
 	} ),
 	{ setLayoutFocus, infoNotice, removeNotice, recordTracksEvent }
 )( localize( CurrentSite ) );

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -97,15 +97,11 @@ class CurrentSite extends Component {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
 				<Card className="current-site is-loading">
-					{ this.props.siteCount > 1 && <span className="current-site__switch-sites">&nbsp;</span> }
-
 					<div className="site">
 						<a className="site__content">
 							<div className="site-icon" />
 							<div className="site__info">
-								<span className="site__title">
-									{ translate( 'Loading My Sites…' ) }
-								</span>
+								<span className="site__title">{ translate( 'Loading My Sites…' ) }</span>
 							</div>
 						</a>
 					</div>
@@ -116,19 +112,22 @@ class CurrentSite extends Component {
 
 		return (
 			<Card className="current-site">
-				{ this.props.siteCount > 1 &&
+				{ this.props.siteCount > 1 && (
 					<span className="current-site__switch-sites">
 						<Button compact borderless onClick={ this.switchSites }>
 							<Gridicon icon={ rtlOn ? 'arrow-right' : 'arrow-left' } size={ 18 } />
 							{ translate( 'Switch Site' ) }
 						</Button>
-					</span> }
+					</span>
+				) }
 
-				{ selectedSite
-					? <div>
-							<Site site={ selectedSite } />
-						</div>
-					: <AllSites /> }
+				{ selectedSite ? (
+					<div>
+						<Site site={ selectedSite } />
+					</div>
+				) : (
+					<AllSites />
+				) }
 
 				<AsyncLoad require="my-sites/current-site/domain-warnings" placeholder={ null } />
 

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -39,7 +39,7 @@ import {
 	THEME_ACTIVATE_SUCCESS,
 	WORDADS_SITE_APPROVE_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { sitesSchema } from './schema';
+import { sitesSchema, hasAllSitesListSchema } from './schema';
 import { combineReducers, createReducer, keyedReducer } from 'state/utils';
 
 /**
@@ -275,9 +275,13 @@ export const deleting = keyedReducer(
  * @param  {Object} action Action object
  * @return {Object}        Updated state
  */
-export const hasAllSitesList = createReducer( false, {
-	[ SITES_RECEIVE ]: () => true,
-} );
+export const hasAllSitesList = createReducer(
+	false,
+	{
+		[ SITES_RECEIVE ]: () => true,
+	},
+	hasAllSitesListSchema
+);
 
 export default combineReducers( {
 	connection,

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -268,6 +268,17 @@ export const deleting = keyedReducer(
 	)
 );
 
+/**
+ * Tracks whether all sites have been fetched.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action object
+ * @return {Object}        Updated state
+ */
+export const hasAllSitesList = createReducer( false, {
+	[ SITES_RECEIVE ]: () => true,
+} );
+
 export default combineReducers( {
 	connection,
 	deleting,
@@ -283,4 +294,5 @@ export default combineReducers( {
 	requesting,
 	sharingButtons,
 	blogStickers,
+	hasAllSitesList,
 } );

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -50,3 +50,7 @@ export const sitesSchema = {
 	},
 	additionalProperties: false,
 };
+
+export const hasAllSitesListSchema = {
+	type: [ 'boolean', 'null' ],
+};

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -1104,3 +1104,12 @@ export function isNewSite( state, siteId ) {
 	// less than 30 minutes
 	return moment().diff( createdAt, 'minutes' ) < 30;
 }
+
+/**
+ * Returns whether all sites have been fetched.
+ * @param {Object}    state  Global state tree
+ * @return {Boolean}        Request State
+ */
+export function hasAllSitesList( state ) {
+	return !! state.sites.hasAllSitesList;
+}

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -9,7 +9,13 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import reducer, { items as unwrappedItems, requestingAll, requesting, deleting } from '../reducer';
+import reducer, {
+	items as unwrappedItems,
+	requestingAll,
+	requesting,
+	deleting,
+	hasAllSitesList,
+} from '../reducer';
 import {
 	MEDIA_DELETE,
 	SITE_DELETE,
@@ -58,6 +64,7 @@ describe( 'reducer', () => {
 			'requesting',
 			'sharingButtons',
 			'blogStickers',
+			'hasAllSitesList',
 		] );
 	} );
 
@@ -740,6 +747,30 @@ describe( 'reducer', () => {
 				2916284: false,
 				77203074: false,
 			} );
+		} );
+	} );
+
+	describe( 'hasAllSitesList()', () => {
+		test( 'should default false', () => {
+			const state = hasAllSitesList( undefined, {} );
+
+			expect( state ).to.be.false;
+		} );
+
+		test( 'should update on receiving all sites', () => {
+			const state = hasAllSitesList( undefined, {
+				type: SITES_RECEIVE,
+			} );
+
+			expect( state ).to.be.true;
+		} );
+
+		test( 'should not update on receiving a single site', () => {
+			const state = hasAllSitesList( false, {
+				type: SITE_RECEIVE,
+			} );
+
+			expect( state ).to.be.false;
 		} );
 	} );
 } );


### PR DESCRIPTION
Part of optimizing initial Calypso load performance.

In this PR, we are adding fetching the primary and recent sites in Layout in addition to fetching all sites. It helps with the initial Calypso load when:
- you go to wp.com
- click on My Sites

Currently, you have to wait till all the sites load to be able to work with your primary or recent sites. With this change, you can work with the primary or recent sites immediately while the rest of the sites load.

The logic when navigating to a site directly (ie wp.com/stats/day/site.com) is unchanged. We could also pre-fetch this site so we wouldn't have to wait for all sites to load first, but there is a problem with [correct routing](https://github.com/Automattic/wp-calypso/blob/master/client/state/sites/selectors.js#L132). We could improve that in future iterations but I don't consider it as a high priority since usually, the sites are cached at that point.

## Testing

Clear the local cache and navigate to local Calypso. Click My Sites and verify that you can see your primary and recent sites in Switch Site. Verify that site placeholder is shown when you open site selector and all sites are not loaded yet. If you go to a specific site with cleared cache, verify sidebar is showing "Loading my sites..." until all sites are not loaded. Also if you go to all sites view (such as `/plugins/woocommerce`). Verify other places using site selector are working as before ("Write" in Masterbar or `/sites` page with clean cache).