### PR TITLE
Editor: prepare Close button behavior for Drafts popover

### DIFF
--- a/client/state/ui/action-log/selectors.js
+++ b/client/state/ui/action-log/selectors.js
@@ -10,6 +10,7 @@ import { last } from 'lodash';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
+import { ROUTE_SET } from 'state/action-types';
 
 /**
  * Returns a log of actions from certain types that have previously been
@@ -24,6 +25,18 @@ import createSelector from 'lib/create-selector';
  */
 export function getActionLog( state ) {
 	return state.ui.actionLog;
+}
+
+/**
+ * Returns a log of ROUTE_SET actions that have previously been
+ * dispatched for the current user.
+ *
+ * @param  {Object}   state      Global state tree
+ * @return {Array}               Array of Redux actions of with a type of
+ *                               ROUTE_SET, each with timestamp
+ */
+export function getRouteHistory( state ) {
+	return getActionLog( state ).filter( action => action.type === ROUTE_SET );
 }
 
 /**


### PR DESCRIPTION
Together with @shaunandrews I've been working on a Drafts popover for the Editor's "ground control" toolbar. This would allow you to switch between different drafts without leaving the Editor. However, this would break the "Close" button's behavior, as it is currently implemented as a back button. Clicking "Close" wouldn't close the editor, but, if the previous page was a draft as well, would just go back to that other draft. 

This PR tweaks the "Close" button's behavior to always go back to last non-editor URL. 

This also fixes #20582. 

To test:
- For now, make sure that the "Close" button still works as before (since you can't yet switch Drafts as described above). Try different "origin" URLs, different depths of navigation, and different content types. 