### PR TITLE
Site Title Component: Add README file path to devdocs example

### DIFF
--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -191,7 +191,7 @@ class DesignAssets extends React.Component {
 					<SegmentedControl readmeFilePath="segmented-control" />
 					<SelectDropdown searchKeywords="menu" readmeFilePath="select-dropdown" />
 					<ShareButton />
-					<SiteTitleControl />
+					<SiteTitleControl readmeFilePath="site-title" />
 					<SocialLogos />
 					<Spinner searchKeywords="loading" readmeFilePath="spinner" />
 					<SpinnerButton searchKeywords="loading input submit" readmeFilePath="spinner-button" />


### PR DESCRIPTION
Oversight on my part :roll_eyes: 

To test: http://calypso.localhost:3000/devdocs/design/site-title-control

Before: 
![image](https://user-images.githubusercontent.com/96308/34830580-9f9c46ae-f6e4-11e7-9938-216c6d931bdf.png)

After:
![image](https://user-images.githubusercontent.com/96308/34830595-ac843f52-f6e4-11e7-8621-981872ce501c.png)

