### PR TITLE
Optimize the getSiteOptions selector

### DIFF
--- a/client/state/selectors/get-site-options.js
+++ b/client/state/selectors/get-site-options.js
@@ -6,6 +6,8 @@
 
 import { getRawSite } from 'state/sites/selectors';
 
+const EMTPY_OPTIONS = Object.freeze( {} );
+
 /**
  * Returns the site options
  *
@@ -18,11 +20,5 @@ export default ( state, siteId ) => {
 	if ( ! site ) {
 		return null;
 	}
-	let options = site.options || {};
-	const defaultPostFormat = options.default_post_format;
-	// The 'standard' post format is saved as an option of '0'
-	if ( ! defaultPostFormat || defaultPostFormat === '0' ) {
-		options = { ...options, default_post_format: 'standard' };
-	}
-	return options;
+	return site.options || EMTPY_OPTIONS;
 };

--- a/client/state/selectors/test/get-public-sites.js
+++ b/client/state/selectors/test/get-public-sites.js
@@ -66,7 +66,6 @@ describe( 'getPublicSites()', () => {
 				is_customizable: false,
 				is_previewable: false,
 				options: {
-					default_post_format: 'standard',
 					unmapped_url: 'http://example.com',
 				},
 			},

--- a/client/state/selectors/test/get-site-options.js
+++ b/client/state/selectors/test/get-site-options.js
@@ -34,56 +34,7 @@ describe( 'getSiteOptions()', () => {
 		};
 
 		const siteOptions = getSiteOptions( state, 2916288 );
-		expect( siteOptions ).to.eql( {
-			default_post_format: 'standard',
-		} );
-	} );
-
-	test( 'should return the options of the site if they exist with default_post_format added if it was not set', () => {
-		const state = {
-			...userState,
-			sites: {
-				items: {
-					2916288: {
-						ID: 2916288,
-						name: 'WordPress.com Example Blog',
-						options: {
-							option1: 'ok',
-						},
-					},
-				},
-			},
-		};
-
-		const siteOptions = getSiteOptions( state, 2916288 );
-		expect( siteOptions ).to.eql( {
-			default_post_format: 'standard',
-			option1: 'ok',
-		} );
-	} );
-
-	test( 'should return the options of the site with correct default_post_format added if it was set to 0', () => {
-		const state = {
-			...userState,
-			sites: {
-				items: {
-					2916288: {
-						ID: 2916288,
-						name: 'WordPress.com Example Blog',
-						options: {
-							option1: 'ok',
-							default_post_format: '0',
-						},
-					},
-				},
-			},
-		};
-
-		const siteOptions = getSiteOptions( state, 2916288 );
-		expect( siteOptions ).to.eql( {
-			default_post_format: 'standard',
-			option1: 'ok',
-		} );
+		expect( siteOptions ).to.eql( {} );
 	} );
 
 	test( 'should return the options of the site if they exist', () => {

--- a/client/state/selectors/test/get-visible-sites.js
+++ b/client/state/selectors/test/get-visible-sites.js
@@ -65,7 +65,6 @@ describe( 'getVisibleSites()', () => {
 				is_customizable: false,
 				is_previewable: false,
 				options: {
-					default_post_format: 'standard',
 					unmapped_url: 'http://example.com',
 				},
 			},

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -176,7 +176,6 @@ describe( 'selectors', () => {
 				isSiteUpgradeable: null,
 				options: {
 					jetpack_version: jetpackMinVersion,
-					default_post_format: 'standard',
 					unmapped_url: 'https://example.wordpress.com',
 				},
 			};
@@ -240,7 +239,6 @@ describe( 'selectors', () => {
 				is_customizable: false,
 				is_previewable: true,
 				options: {
-					default_post_format: 'standard',
 					unmapped_url: 'https://example.wordpress.com',
 				},
 			} );

--- a/client/state/sites/test/utils.js
+++ b/client/state/sites/test/utils.js
@@ -46,9 +46,7 @@ describe( 'utils', () => {
 				hasConflict: false,
 				domain: 'example.wordpress.com',
 				slug: 'example.wordpress.com',
-				options: {
-					default_post_format: 'standard',
-				},
+				options: {},
 			} );
 		} );
 

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -61,9 +61,7 @@ describe( 'selectors', () => {
 				hasConflict: false,
 				is_customizable: false,
 				is_previewable: false,
-				options: {
-					default_post_format: 'standard',
-				},
+				options: {},
 				slug: 'example.com',
 				title: 'WordPress.com Example Blog',
 			} );


### PR DESCRIPTION
The `getSiteOptions` selector creates a new object on each invocation just to normalize the `default_post_format` option. The selector is called 3000+ times on initial load of Calypso and shows up in profiles like this one from [Gecko Profiler](https://perf-html.io/) -- I was profiling the "dummy Redux counter" in this case:

<img width="744" alt="get-site-options-in-profile" src="https://user-images.githubusercontent.com/664258/34831687-ed5208fe-f6e7-11e7-80f2-6d4c0a8be18c.png">

This patch simplifies the selector to just return the raw `options` value. The default post format is taken care of in specialized `getSiteDefaultPostFormat` selector. No need to slow everything down for every other caller interested in other options.

Also updates the tests that expected the `default_post_format` option to be present.