### PR TITLE
If we have an exact match from a subdomain search, only use the domain.

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
 import classNames from 'classnames';
-import { endsWith, includes, times } from 'lodash';
+import { endsWith, get, includes, times } from 'lodash';
 
 /**
  * Internal dependencies
@@ -61,7 +61,7 @@ class DomainSearchResults extends React.Component {
 			availableDomain,
 			lastDomainIsTransferrable,
 			lastDomainStatus,
-			lastDomainSearched: domain,
+			lastDomainSearched,
 			translate,
 		} = this.props;
 		const availabilityElementClasses = classNames( {
@@ -70,6 +70,8 @@ class DomainSearchResults extends React.Component {
 		} );
 		const suggestions = this.props.suggestions || [];
 		const { MAPPABLE, MAPPED, TLD_NOT_SUPPORTED, TRANSFERRABLE, UNKNOWN } = domainAvailability;
+
+		const domain = get( availableDomain, 'domain_name', lastDomainSearched );
 
 		let availabilityElement, domainSuggestionElement, offer;
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -506,7 +506,7 @@ class RegisterDomainStep extends React.Component {
 					suggestion.is_free === true || suggestion.status === domainAvailability.UNKNOWN;
 				const strippedDomainBase = this.getStrippedDomainBase( domain );
 				const exactMatchBeforeTld = suggestion =>
-					suggestion === this.state.exactMatchDomain ||
+					suggestion.domain_name === this.state.exactMatchDomain ||
 					startsWith( suggestion.domain_name, `${ strippedDomainBase }.` );
 				const bestAlternative = suggestion =>
 					! exactMatchBeforeTld( suggestion ) && suggestion.isRecommended !== true;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -335,6 +335,7 @@ class RegisterDomainStep extends React.Component {
 		const loadingResults = Boolean( getFixedDomainSearch( searchQuery ) );
 
 		this.setState( {
+			exactMatchDomain: null,
 			lastQuery: searchQuery,
 			lastDomainSearched: null,
 			loadingResults: loadingResults,
@@ -395,12 +396,14 @@ class RegisterDomainStep extends React.Component {
 						( error, result ) => {
 							const timeDiff = Date.now() - timestamp;
 							const status = get( result, 'status', error );
+							const domainChecked = get( result, 'domain_name', domain );
 
 							const { AVAILABLE, TRANSFERRABLE, UNKNOWN } = domainAvailability;
 							const isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
 							const isDomainTransferrable = TRANSFERRABLE === status;
 
 							this.setState( {
+								exactMatchDomain: domainChecked,
 								lastDomainStatus: status,
 								lastDomainIsTransferrable: isDomainTransferrable,
 							} );
@@ -503,6 +506,7 @@ class RegisterDomainStep extends React.Component {
 					suggestion.is_free === true || suggestion.status === domainAvailability.UNKNOWN;
 				const strippedDomainBase = this.getStrippedDomainBase( domain );
 				const exactMatchBeforeTld = suggestion =>
+					suggestion === this.state.exactMatchDomain ||
 					startsWith( suggestion.domain_name, `${ strippedDomainBase }.` );
 				const bestAlternative = suggestion =>
 					! exactMatchBeforeTld( suggestion ) && suggestion.isRecommended !== true;
@@ -666,8 +670,13 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	allSearchResults() {
-		const { lastDomainIsTransferrable, lastDomainSearched, lastDomainStatus } = this.state;
-		const matchesSearchedDomain = suggestion => suggestion.domain_name === lastDomainSearched;
+		const {
+			exactMatchDomain,
+			lastDomainIsTransferrable,
+			lastDomainSearched,
+			lastDomainStatus,
+		} = this.state;
+		const matchesSearchedDomain = suggestion => suggestion.domain_name === exactMatchDomain;
 		const availableDomain =
 			lastDomainStatus === domainAvailability.AVAILABLE &&
 			find( this.state.searchResults, matchesSearchedDomain );


### PR DESCRIPTION
Depends on D9250-code

See D9250-code for testing instructions.