### PR TITLE
Activity Log: hide placeholder animation when logs are shown

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -594,6 +594,22 @@ class ActivityLog extends Component {
 			.utc()
 			.startOf( 'day' );
 
+		// Content shown when there are no logs.
+		// The network request either finished with no events or is still ongoing.
+		const noLogsContent = requestData.logs.hasLoaded ? (
+			<EmptyContent
+				title={ translate( 'No activity for %s', {
+					args: this.getStartMoment().format( 'MMMM YYYY' ),
+				} ) }
+			/>
+		) : (
+			<section className="activity-log__wrapper">
+				<ActivityLogDayPlaceholder />
+				<ActivityLogDayPlaceholder />
+				<ActivityLogDayPlaceholder />
+			</section>
+		);
+
 		return (
 			<Main wideLayout>
 				<QueryRewindStatus siteId={ siteId } />
@@ -609,22 +625,9 @@ class ActivityLog extends Component {
 				{ this.renderErrorMessage() }
 				{ hasFirstBackup && this.renderMonthNavigation() }
 				{ this.renderActionProgress() }
-				{ ! requestData.logs.hasLoaded && (
-					<section className="activity-log__wrapper">
-						<ActivityLogDayPlaceholder />
-						<ActivityLogDayPlaceholder />
-						<ActivityLogDayPlaceholder />
-					</section>
-				) }
-				{ requestData.logs.hasLoaded &&
-					isEmpty( logs ) && (
-						<EmptyContent
-							title={ translate( 'No activity for %s', {
-								args: this.getStartMoment().format( 'MMMM YYYY' ),
-							} ) }
-						/>
-					) }
-				{ ! isEmpty( logs ) && (
+				{ isEmpty( logs ) ? (
+					noLogsContent
+				) : (
 					<section className="activity-log__wrapper">
 						{ intoVisualGroups( moment, logs, this.getStartMoment(), this.applySiteOffset ).map(
 							( [ type, [ start, end ], events ] ) => {


### PR DESCRIPTION
Currently, the loading placeholder animation can be briefly seen even after the logs are shown. This is because the logs are cached but this placeholder is awaiting on a network request.

<img width="918" alt="captura de pantalla 2018-01-11 a la s 13 33 47" src="https://user-images.githubusercontent.com/1041600/34835630-1c457100-f6d4-11e7-8248-a16036506c5f.png">

This PR introduces a check to figure out if the logs are empty:
- if the logs are empty, it will check if the network request ended. If it ended it will show an empty content because indeed, we don't have logs.
    Otherwise if the request is still ongoing, it will display the placeholder.
- if there are logs already, neither the placeholder nor the empty content will be shown and instead the logs will be.

#### Test
1. in the browser, open the JS console and execute order sixtysi... err no, execute
`indexedDB.deleteDatabase( 'calypso' );`
2. reload the page. You should see the placeholder first, and then it will be hidden and the logs will be shown.
3. reload again. The logs are now cached, so you shouldn't see the placeholder.