### PR TITLE
Site-Settings: Add feed settings to "Writing" section.

### DIFF
--- a/assets/stylesheets/sections/site-settings.scss
+++ b/assets/stylesheets/sections/site-settings.scss
@@ -15,7 +15,7 @@
 @import 'my-sites/site-settings/date-time-format/style';
 @import 'my-sites/site-settings/delete-site/style';
 @import 'my-sites/site-settings/disconnect-site/style';
-@import 'my-sites/site-settings/feed/style';
+@import 'my-sites/site-settings/feed-settings/style';
 @import 'my-sites/site-settings/site-tools/style';
 @import 'my-sites/site-settings/delete-site-warning-dialog/style';
 @import 'my-sites/site-settings/jetpack-sync-panel/style';

--- a/assets/stylesheets/sections/site-settings.scss
+++ b/assets/stylesheets/sections/site-settings.scss
@@ -15,6 +15,7 @@
 @import 'my-sites/site-settings/date-time-format/style';
 @import 'my-sites/site-settings/delete-site/style';
 @import 'my-sites/site-settings/disconnect-site/style';
+@import 'my-sites/site-settings/feed/style';
 @import 'my-sites/site-settings/site-tools/style';
 @import 'my-sites/site-settings/delete-site-warning-dialog/style';
 @import 'my-sites/site-settings/jetpack-sync-panel/style';

--- a/client/my-sites/site-settings/feed-settings/index.jsx
+++ b/client/my-sites/site-settings/feed-settings/index.jsx
@@ -34,14 +34,14 @@ class FeedSettings extends Component {
 
 		return (
 			<div className="feed-settings">
-				<SectionHeader label={ translate( 'Syndication Feeds (RSS)' ) }>
+				<SectionHeader label={ translate( 'Feed Settings' ) }>
 					<Button compact primary disabled={ false } onClick={ handleSubmitForm }>
 						{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
 					</Button>
 				</SectionHeader>
 				<CompactCard>
 					<FormFieldset>
-						{ translate( 'Show the {{field /}} most recent items', {
+						{ translate( 'Display {{field /}} most recent blog posts', {
 							components: {
 								field: (
 									<FormTextInput
@@ -60,7 +60,14 @@ class FeedSettings extends Component {
 							},
 						} ) }
 						<FormSettingExplanation>
-							{ translate( 'In syndication feeds, the number of items to show.' ) }
+							{ translate(
+								"The number of posts to include in your site's feed. {{link}}Learn more about feeds{{/link}}",
+								{
+									components: {
+										link: <a href="https://en.support.wordpress.com/feeds/" />,
+									},
+								}
+							) }
 						</FormSettingExplanation>
 					</FormFieldset>
 					<CompactFormToggle
@@ -68,10 +75,13 @@ class FeedSettings extends Component {
 						disabled={ false }
 						onChange={ handleToggle( 'rss_use_excerpt' ) }
 					>
-						{ translate( 'Use excerpts in the feed' ) }
+						{ translate( 'Limit feed to excerpt only' ) }
 					</CompactFormToggle>
-					<FormSettingExplanation isIndented>
-						When an excerpt is available for your content, it will be used instead of the full text.
+					<FormSettingExplanation isIndented className="feed-settings__excerpt-explanation">
+						{ translate(
+							'Enable this to include only an excerpt of your content. ' +
+								'Users will need to visit your site to view the full content.'
+						) }
 					</FormSettingExplanation>
 				</CompactCard>
 			</div>

--- a/client/my-sites/site-settings/feed-settings/index.jsx
+++ b/client/my-sites/site-settings/feed-settings/index.jsx
@@ -58,9 +58,7 @@ class FeedSettings extends Component {
 										step="1"
 										min="0"
 										id="posts_per_rss"
-										value={
-											'undefined' === typeof fields.posts_per_rss ? 10 : fields.posts_per_rss
-										}
+										value={ fields.posts_per_rss }
 										onChange={ onChangeField( 'posts_per_rss' ) }
 										disabled={ isDisabled }
 									/>

--- a/client/my-sites/site-settings/feed-settings/index.jsx
+++ b/client/my-sites/site-settings/feed-settings/index.jsx
@@ -1,0 +1,88 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+
+import Button from 'components/button';
+import CompactCard from 'components/card/compact';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormTextInput from 'components/forms/form-text-input';
+import SectionHeader from 'components/section-header';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+class FeedSettings extends Component {
+	render() {
+		const {
+			fields,
+			handleSubmitForm,
+			handleToggle,
+			isSavingSettings,
+			onChangeField,
+			translate,
+		} = this.props;
+
+		return (
+			<div className="feed-settings">
+				<SectionHeader label={ translate( 'Syndication Feeds (RSS)' ) }>
+					<Button compact primary disabled={ false } onClick={ handleSubmitForm }>
+						{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+					</Button>
+				</SectionHeader>
+				<CompactCard>
+					<FormFieldset>
+						{ translate( 'Show the {{field /}} most recent items', {
+							components: {
+								field: (
+									<FormTextInput
+										name="posts_per_rss"
+										type="number"
+										step="1"
+										min="0"
+										id="posts_per_rss"
+										value={
+											'undefined' === typeof fields.posts_per_rss ? 10 : fields.posts_per_rss
+										}
+										onChange={ onChangeField( 'posts_per_rss' ) }
+										disabled={ false }
+									/>
+								),
+							},
+						} ) }
+						<FormSettingExplanation>
+							{ translate( 'In syndication feeds, the number of items to show.' ) }
+						</FormSettingExplanation>
+					</FormFieldset>
+					<CompactFormToggle
+						checked={ !! fields.rss_use_excerpt }
+						disabled={ false }
+						onChange={ handleToggle( 'rss_use_excerpt' ) }
+					>
+						{ translate( 'Use excerpts in the feed' ) }
+					</CompactFormToggle>
+					<FormSettingExplanation isIndented>
+						When an excerpt is available for your content, it will be used instead of the full text.
+					</FormSettingExplanation>
+				</CompactCard>
+			</div>
+		);
+	}
+}
+
+export default connect( state => {
+	const selectedSiteId = getSelectedSiteId( state );
+
+	return {
+		selectedSiteId,
+	};
+} )( localize( FeedSettings ) );

--- a/client/my-sites/site-settings/feed-settings/index.jsx
+++ b/client/my-sites/site-settings/feed-settings/index.jsx
@@ -27,10 +27,13 @@ class FeedSettings extends Component {
 			fields,
 			handleSubmitForm,
 			handleToggle,
+			isRequestingSettings,
 			isSavingSettings,
 			onChangeField,
 			translate,
 		} = this.props;
+
+		const isDisabled = isRequestingSettings || isSavingSettings;
 
 		if ( 'undefined' === typeof fields.posts_per_rss ) {
 			// Do not allow these settings to be updated if they cannot be read from the API.
@@ -40,7 +43,7 @@ class FeedSettings extends Component {
 		return (
 			<div className="feed-settings">
 				<SectionHeader label={ translate( 'Feed Settings' ) }>
-					<Button compact primary disabled={ false } onClick={ handleSubmitForm }>
+					<Button compact primary disabled={ isDisabled } onClick={ handleSubmitForm }>
 						{ isSavingSettings ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
 					</Button>
 				</SectionHeader>
@@ -59,7 +62,7 @@ class FeedSettings extends Component {
 											'undefined' === typeof fields.posts_per_rss ? 10 : fields.posts_per_rss
 										}
 										onChange={ onChangeField( 'posts_per_rss' ) }
-										disabled={ false }
+										disabled={ isDisabled }
 									/>
 								),
 							},
@@ -77,7 +80,7 @@ class FeedSettings extends Component {
 					</FormFieldset>
 					<CompactFormToggle
 						checked={ !! fields.rss_use_excerpt }
-						disabled={ false }
+						disabled={ isDisabled }
 						onChange={ handleToggle( 'rss_use_excerpt' ) }
 					>
 						{ translate( 'Limit feed to excerpt only' ) }

--- a/client/my-sites/site-settings/feed-settings/index.jsx
+++ b/client/my-sites/site-settings/feed-settings/index.jsx
@@ -32,6 +32,11 @@ class FeedSettings extends Component {
 			translate,
 		} = this.props;
 
+		if ( 'undefined' === typeof fields.posts_per_rss ) {
+			// Do not allow these settings to be updated if they cannot be read from the API.
+			return null;
+		}
+
 		return (
 			<div className="feed-settings">
 				<SectionHeader label={ translate( 'Feed Settings' ) }>

--- a/client/my-sites/site-settings/feed-settings/style.scss
+++ b/client/my-sites/site-settings/feed-settings/style.scss
@@ -1,0 +1,3 @@
+.feed-settings {
+	margin-bottom: 16px;	
+}

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -63,7 +63,6 @@ class SiteSettingsFormWriting extends Component {
 			uniqueEventTracker,
 			fields,
 			handleSelect,
-			handleSubmitForm,
 			handleToggle,
 			handleAutosavingToggle,
 			handleAutosavingRadio,

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -213,6 +213,8 @@ const connectComponent = connect(
 const getFormSettings = settings => {
 	const formSettings = pick( settings, [
 		'posts_per_page',
+		'posts_per_rss',
+		'rss_use_excerpt',
 		'default_post_format',
 		'custom-content-types',
 		'jetpack_testimonial',

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -144,6 +144,15 @@ class SiteSettingsFormWriting extends Component {
 					fields={ fields }
 				/>
 
+				<FeedSettings
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+					handleSubmitForm={ handleSubmitForm }
+					handleToggle={ handleToggle }
+					onChangeField={ onChangeField }
+				/>
+
 				{ jetpackSettingsUI && <QueryJetpackModules siteId={ siteId } /> }
 
 				<ThemeEnhancements
@@ -165,15 +174,6 @@ class SiteSettingsFormWriting extends Component {
 							fields={ fields }
 						/>
 					) }
-
-				<FeedSettings
-					isSavingSettings={ isSavingSettings }
-					isRequestingSettings={ isRequestingSettings }
-					fields={ fields }
-					handleSubmitForm={ handleSubmitForm }
-					handleToggle={ handleToggle }
-					onChangeField={ onChangeField }
-				/>
 
 				{ config.isEnabled( 'press-this' ) &&
 					! this.isMobile() &&

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -27,6 +27,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestPostTypes } from 'state/post-types/actions';
 import Composing from './composing';
 import CustomContentTypes from './custom-content-types';
+import FeedSettings from 'my-sites/site-settings/feed-settings';
 import Masterbar from './masterbar';
 import MediaSettings from './media-settings';
 import ThemeEnhancements from './theme-enhancements';
@@ -66,6 +67,7 @@ class SiteSettingsFormWriting extends Component {
 			handleToggle,
 			handleAutosavingToggle,
 			handleAutosavingRadio,
+			handleSubmitForm,
 			isRequestingSettings,
 			isSavingSettings,
 			jetpackMasterbarSupported,
@@ -163,6 +165,15 @@ class SiteSettingsFormWriting extends Component {
 							fields={ fields }
 						/>
 					) }
+
+				<FeedSettings
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+					handleSubmitForm={ handleSubmitForm }
+					handleToggle={ handleToggle }
+					onChangeField={ onChangeField }
+				/>
 
 				{ config.isEnabled( 'press-this' ) &&
 					! this.isMobile() &&

--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -140,8 +140,6 @@ const getFormSettings = partialRight( pick, [
 	'amp_is_supported',
 	'amp_is_enabled',
 	'blog_public',
-	'posts_per_rss',
-	'rss_use_excerpt',
 ] );
 
 export default flowRight( connectComponent, localize, wrapSettingsForm( getFormSettings ) )(

--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -26,7 +26,6 @@ import JetpackAds from 'my-sites/site-settings/jetpack-ads';
 import RelatedPosts from 'my-sites/site-settings/related-posts';
 import AmpJetpack from 'my-sites/site-settings/amp/jetpack';
 import AmpWpcom from 'my-sites/site-settings/amp/wpcom';
-import FeedSettings from 'my-sites/site-settings/feed-settings';
 import Sitemaps from 'my-sites/site-settings/sitemaps';
 import Search from 'my-sites/site-settings/search';
 import Placeholder from 'my-sites/site-settings/placeholder';
@@ -38,13 +37,10 @@ const SiteSettingsTraffic = ( {
 	fields,
 	jetpackSettingsUiSupported,
 	handleAutosavingToggle,
-	handleRadio,
 	handleSubmitForm,
-	handleToggle,
 	isJetpack,
 	isRequestingSettings,
 	isSavingSettings,
-	onChangeField,
 	setFieldValue,
 	site,
 	submitForm,
@@ -102,15 +98,6 @@ const SiteSettingsTraffic = ( {
 			<SeoSettingsHelpCard />
 			<SeoSettingsMain />
 			<AnalyticsSettings />
-			<FeedSettings
-				isSavingSettings={ isSavingSettings }
-				isRequestingSettings={ isRequestingSettings }
-				fields={ fields }
-				handleRadio={ handleRadio }
-				handleSubmitForm={ handleSubmitForm }
-				handleToggle={ handleToggle }
-				onChangeField={ onChangeField }
-			/>
 			<Sitemaps
 				isSavingSettings={ isSavingSettings }
 				isRequestingSettings={ isRequestingSettings }

--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -26,7 +26,7 @@ import JetpackAds from 'my-sites/site-settings/jetpack-ads';
 import RelatedPosts from 'my-sites/site-settings/related-posts';
 import AmpJetpack from 'my-sites/site-settings/amp/jetpack';
 import AmpWpcom from 'my-sites/site-settings/amp/wpcom';
-import FeedSettings from 'my-sites/site-settings/feed';
+import FeedSettings from 'my-sites/site-settings/feed-settings';
 import Sitemaps from 'my-sites/site-settings/sitemaps';
 import Search from 'my-sites/site-settings/search';
 import Placeholder from 'my-sites/site-settings/placeholder';

--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -26,6 +26,7 @@ import JetpackAds from 'my-sites/site-settings/jetpack-ads';
 import RelatedPosts from 'my-sites/site-settings/related-posts';
 import AmpJetpack from 'my-sites/site-settings/amp/jetpack';
 import AmpWpcom from 'my-sites/site-settings/amp/wpcom';
+import FeedSettings from 'my-sites/site-settings/feed';
 import Sitemaps from 'my-sites/site-settings/sitemaps';
 import Search from 'my-sites/site-settings/search';
 import Placeholder from 'my-sites/site-settings/placeholder';
@@ -37,10 +38,13 @@ const SiteSettingsTraffic = ( {
 	fields,
 	jetpackSettingsUiSupported,
 	handleAutosavingToggle,
+	handleRadio,
 	handleSubmitForm,
+	handleToggle,
 	isJetpack,
 	isRequestingSettings,
 	isSavingSettings,
+	onChangeField,
 	setFieldValue,
 	site,
 	submitForm,
@@ -98,6 +102,15 @@ const SiteSettingsTraffic = ( {
 			<SeoSettingsHelpCard />
 			<SeoSettingsMain />
 			<AnalyticsSettings />
+			<FeedSettings
+				isSavingSettings={ isSavingSettings }
+				isRequestingSettings={ isRequestingSettings }
+				fields={ fields }
+				handleRadio={ handleRadio }
+				handleSubmitForm={ handleSubmitForm }
+				handleToggle={ handleToggle }
+				onChangeField={ onChangeField }
+			/>
 			<Sitemaps
 				isSavingSettings={ isSavingSettings }
 				isRequestingSettings={ isRequestingSettings }
@@ -140,6 +153,8 @@ const getFormSettings = partialRight( pick, [
 	'amp_is_supported',
 	'amp_is_enabled',
 	'blog_public',
+	'posts_per_rss',
+	'rss_use_excerpt',
 ] );
 
 export default flowRight( connectComponent, localize, wrapSettingsForm( getFormSettings ) )(


### PR DESCRIPTION
This PR adds feed settings to the "Writing" section of site settings beneath content types.

See p3Ex-32f-p2

![image](https://user-images.githubusercontent.com/363749/34836953-ee95b78e-f6be-11e7-9673-0dc3c462ec51.png)

Testing instructions:
* Sandbox the API and patch with D9173-code
* Visit the "Writing" tab of site settings for a WPCOM simple site, or a Jetpack site with a similar patch applied.
* Verify that the feed settings that appear are correct.
* Update the settings. Verify that they persist after a reload of the page and are also reflected correctly in wp-admin.
* Revert the D9173-code patch or test with a non-patched Jetpack site. Verify that when the API doesn't return the settings, that the interface to update them isn't present.

