### PR TITLE
Store: Show Store in sidebar for all countries, provide means to get to wp-admin for unsupported countries

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -208,7 +208,8 @@ class Dashboard extends Component {
 
 		let manageView = null;
 		const storeCountry = get( storeLocation, 'country' );
-		if ( isStoreManagementSupportedInCalypsoForCountry( storeCountry ) ) {
+		const manageInCalypso = isStoreManagementSupportedInCalypsoForCountry( storeCountry );
+		if ( manageInCalypso ) {
 			if ( hasOrders ) {
 				manageView = <ManageOrdersView site={ selectedSite } />;
 			} else {
@@ -221,9 +222,8 @@ class Dashboard extends Component {
 		return (
 			<div>
 				{ manageView }
-				{ ! this.props.mailChimpConfigured && (
-					<MailChimp site={ selectedSite } redirectToSettings dashboardView />
-				) }
+				{ ! this.props.mailChimpConfigured &&
+					manageInCalypso && <MailChimp site={ selectedSite } redirectToSettings dashboardView /> }
 			</div>
 		);
 	};

--- a/client/extensions/woocommerce/app/dashboard/manage-external-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-external-view.js
@@ -1,0 +1,45 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import EmptyContent from 'components/empty-content';
+
+class ManageExternalView extends Component {
+	static propTypes = {
+		site: PropTypes.shape( {
+			URL: PropTypes.string.isRequired,
+		} ),
+	};
+
+	render = () => {
+		const { site, translate } = this.props;
+
+		const title = translate( 'Manage your store' );
+		const line = translate(
+			'Stores in your country are managed directly on your site. ' +
+				'We will let you know when you can manage your store here.'
+		);
+		const actionURL = site.URL + '/wp-admin/edit.php?post_type=shop_order';
+		return (
+			<div className="dashboard__manage-externally">
+				<EmptyContent
+					title={ title }
+					line={ line }
+					action={ translate( 'OK, take me to my site' ) }
+					actionURL={ actionURL }
+				/>
+			</div>
+		);
+	};
+}
+
+export default localize( ManageExternalView );

--- a/client/extensions/woocommerce/app/dashboard/manage-external-view.js
+++ b/client/extensions/woocommerce/app/dashboard/manage-external-view.js
@@ -12,12 +12,17 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import EmptyContent from 'components/empty-content';
+import { recordTrack } from 'woocommerce/lib/analytics';
 
 class ManageExternalView extends Component {
 	static propTypes = {
 		site: PropTypes.shape( {
 			URL: PropTypes.string.isRequired,
 		} ),
+	};
+
+	recordAction = () => {
+		recordTrack( 'calypso_woocommerce_manage_external_clicked' );
 	};
 
 	render = () => {
@@ -28,14 +33,26 @@ class ManageExternalView extends Component {
 			'Stores in your country are managed directly on your site. ' +
 				'We will let you know when you can manage your store here.'
 		);
+
 		const actionURL = site.URL + '/wp-admin/edit.php?post_type=shop_order';
+		const action = (
+				<a
+					className="dashboard__empty-action button is-primary"
+					onClick={ this.recordAction }
+					href={ actionURL }
+				>
+					{ translate( 'OK, take me to my site' ) }
+				</a>
+			),
+			secondaryAction = null;
+
 		return (
 			<div className="dashboard__manage-externally">
 				<EmptyContent
 					title={ title }
 					line={ line }
-					action={ translate( 'OK, take me to my site' ) }
-					actionURL={ actionURL }
+					action={ action }
+					secondaryAction={ secondaryAction }
 				/>
 			</div>
 		);

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
-import { includes } from 'lodash';
 import page from 'page';
 
 /**
@@ -359,11 +358,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	store() {
-		// IMPORTANT: If you add a country to this list, you must also add it
-		// to ../../extensions/woocommerce/lib/countries in the getCountries function
-		const allowedCountryCodes = [ 'US', 'CA' ];
 		const {
-			currentUser,
 			canUserManageOptions,
 			isJetpack,
 			site,
@@ -376,35 +371,28 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		const storeLink = '/store' + siteSuffix;
-
-		const isJetpackOrAtomicSite =
-			isJetpack && canUserManageOptions && this.props.isSiteAutomatedTransfer;
+		const isPermittedSite = isJetpack && canUserManageOptions && this.props.isSiteAutomatedTransfer;
 
 		if (
-			! isJetpackOrAtomicSite &&
+			! isPermittedSite &&
 			! ( config.isEnabled( 'signup/atomic-store-flow' ) && siteHasBackgroundTransfer )
 		) {
 			return null;
 		}
 
-		const countryCode = currentUser.user_ip_country_code;
-		const isCountryAllowed =
-			includes( allowedCountryCodes, countryCode ) || 'development' === process.env.NODE_ENV;
+		const storeLink = '/store' + siteSuffix;
 
 		return (
-			isCountryAllowed && (
-				<SidebarItem
-					label={ translate( 'Store' ) }
-					link={ storeLink }
-					onNavigate={ this.trackStoreClick }
-					icon="cart"
-				>
-					<div className="sidebar__chevron-right">
-						<Gridicon icon="chevron-right" />
-					</div>
-				</SidebarItem>
-			)
+			<SidebarItem
+				label={ translate( 'Store' ) }
+				link={ storeLink }
+				onNavigate={ this.trackStoreClick }
+				icon="cart"
+			>
+				<div className="sidebar__chevron-right">
+					<Gridicon icon="chevron-right" />
+				</div>
+			</SidebarItem>
 		);
 	}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -360,7 +360,6 @@ export class MySitesSidebar extends Component {
 	store() {
 		const {
 			canUserManageOptions,
-			isJetpack,
 			site,
 			siteSuffix,
 			translate,
@@ -371,7 +370,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		const isPermittedSite = isJetpack && canUserManageOptions && this.props.isSiteAutomatedTransfer;
+		const isPermittedSite = canUserManageOptions && this.props.isSiteAutomatedTransfer;
 
 		if (
 			! isPermittedSite &&


### PR DESCRIPTION
Fixes #20607 
Fixes #21478 

To test:
* Use https://developer.wordpress.com/docs/api/console/ to POST to /sites/{SITEID}/calypso-preferences/woocommerce set_store_address_during_initial_setup to 0
* Navigate to http://calypso.localhost:3000/store/{DOMAIN} and set your store's address to a US address
* Navigate to https://wordpress.com/stats/day{DOMAIN}
* Click on the Store link in the sidebar
* Ensure you are taken to the dashboard in calypso
* Repeat for a Canadian address, e.g.

```
811 Hornby St
Vancouver, BC V6Z2E6
Canada
```

* Ensure you are taken to the dashboard in calypso

* Repeat for a nonUS nonCA address, e.g.:

```
2 Elizabeth St
Melbourne VIC 3004
Australia

or

7 Allées du Président Franklin Roosevelt
31000 Toulouse
France
(Make sure currency is set to EUR, dimensions to cm and weight to kg)
```

* Make sure you see a prompt and a button and that the sidebar only has the dashboard itself, e.g.:

<img width="1061" alt="screen shot 2018-01-11 at 11 48 55 am" src="https://user-images.githubusercontent.com/1595739/34844168-71a516a0-f6c5-11e7-8f6f-02a8b7e04a49.png">

* Make sure that clicking on the button takes you to your orders view in wp-admin
