### PR TITLE
Store: Fix product category list z-index and improve form handling

### DIFF
--- a/client/extensions/woocommerce/app/product-categories/create.js
+++ b/client/extensions/woocommerce/app/product-categories/create.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isEmpty, omit, isNumber } from 'lodash';
+import { isEmpty, omit, isNumber, isNull } from 'lodash';
 import page from 'page';
 
 /**
@@ -32,6 +32,7 @@ import { getLink } from 'woocommerce/lib/nav-utils';
 import ProductCategoryForm from './form';
 import ProductCategoryHeader from './header';
 import { successNotice, errorNotice } from 'state/notices/actions';
+import { getSaveErrorMessage } from './utils';
 
 class ProductCategoryCreate extends React.Component {
 	static propTypes = {
@@ -89,14 +90,15 @@ class ProductCategoryCreate extends React.Component {
 			} );
 		};
 
-		const failureAction = () => {
+		const failureAction = ( dispatch, getState, passedProps ) => {
 			this.setState( { busy: false } );
-			return errorNotice(
-				translate( 'There was a problem saving your category. Please try again.' ),
-				{
-					duration: 8000,
-				}
-			);
+
+			const { error } = passedProps;
+			const errorSlug = ( error && error.error ) || undefined;
+
+			return errorNotice( getSaveErrorMessage( errorSlug, translate ), {
+				duration: 8000,
+			} );
 		};
 
 		this.props.createProductCategory( site.ID, category, successAction, failureAction );
@@ -106,12 +108,18 @@ class ProductCategoryCreate extends React.Component {
 		const { site, category, hasEdits, className } = this.props;
 		const { busy } = this.state;
 
+		const saveEnabled =
+			hasEdits &&
+			category &&
+			( category.name && category.name.length ) &&
+			! isNull( category.parent );
+
 		return (
 			<Main className={ className } wideLayout>
 				<ProductCategoryHeader
 					site={ site }
 					category={ category }
-					onSave={ hasEdits ? this.onSave : false }
+					onSave={ saveEnabled ? this.onSave : false }
 					isBusy={ busy }
 				/>
 				<ProtectFormGuard isChanged={ hasEdits } />

--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import { debounce, isNumber, head } from 'lodash';
+import { debounce, isNumber, head, isNull } from 'lodash';
 
 /**
  * Internal dependencies
@@ -68,6 +68,13 @@ class ProductCategoryForm extends Component {
 		}
 
 		if ( nextProps.category.parent !== this.props.category.parent ) {
+			if ( isNull( nextProps.category.parent ) ) {
+				this.setState( {
+					selectedParent: [],
+					isTopLevel: false,
+				} );
+				return;
+			}
 			const isTopLevel = nextProps.category && nextProps.category.parent ? false : true;
 			const selectedParent = ( ! isTopLevel && [ nextProps.category.parent ] ) || [];
 			this.setState( {
@@ -95,7 +102,13 @@ class ProductCategoryForm extends Component {
 
 	onTopLevelChange = () => {
 		const { siteId, category, editProductCategory } = this.props;
-		editProductCategory( siteId, category, { parent: 0 } );
+
+		if ( this.state.isTopLevel ) {
+			editProductCategory( siteId, category, { parent: null } );
+		} else {
+			editProductCategory( siteId, category, { parent: 0 } );
+		}
+
 		if ( ! category.parent ) {
 			this.setState( {
 				isTopLevel: ! this.state.isTopLevel,
@@ -273,7 +286,7 @@ class ProductCategoryForm extends Component {
 									</span>
 								</FormLabel>
 
-								{ ! isTopLevel && (
+								{ ( ! isTopLevel || isNull( category.parent ) ) && (
 									<div>
 										<FormLabel>{ translate( 'Select a parent category' ) }</FormLabel>
 										<TermTreeSelectorTerms

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -131,7 +131,11 @@
 	flex: 2
 }
 
-
+.product_categories__list-wrapper {
+	.search, .search__open-icon, .search__close-icon {
+		z-index: initial;
+	}
+}
 
 .product-categories__form-image-wrapper {
 	display: flex;

--- a/client/extensions/woocommerce/app/product-categories/utils.js
+++ b/client/extensions/woocommerce/app/product-categories/utils.js
@@ -1,0 +1,8 @@
+export function getSaveErrorMessage( slug, translate ) {
+	switch ( slug ) {
+		case 'term_exists':
+			return translate( 'A category with this name already exists. Please choose a new name or select a different parent category.' );
+		default:
+			return translate( 'There was a problem saving your category. Please try again.' );
+	}
+}


### PR DESCRIPTION
This PR fixes a few misc reported issues with product category management:

* The search icon z-index being off and showing above the "Add category" button. Fixes #21428.
* Returns a more helpful error message when a category name already exists at a certain parent level. See https://github.com/Automattic/wp-calypso/pull/21379#issuecomment-356775762.
* Disables the save button if name  is blank or a parent/top level input is not selected. See https://github.com/Automattic/wp-calypso/pull/21379#issuecomment-356760475.

To Test:
* Visit the `http://calypso.localhost:3000/store/products/categories/:site`, and make sure you have enough categories to make the page scroll. Scroll and make sure that the search icon does not overlap the "Add category button".
* Go to "Add category" and type in a description but no name. Verify that the save button is disabled.
* Type in a name and verify that the save button is enabled.
* Unselect "Top Level Category" and don't select a parent category yet, and verify the save button is disabled. Select the checkbox again, or select a parent and verify the save button becomes enabled.
* Now try naming your category to something that already exists at the top level. Hit save, and verify that you get an error message about the name existing. You should be able to create it as a sub-category under another category.