### PR TITLE
Reader: improve performance of conversations

### DIFF
--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -25,6 +25,9 @@ import treeSelect from 'lib/tree-select';
 import { fetchStatusInitialState } from './reducer';
 import { getStateKey, deconstructStateKey, getErrorKey } from './utils';
 
+const emptyObject = {};
+const emptyArray = [];
+
 /***
  * Gets comment items for post
  * @param {Object} state redux state
@@ -36,7 +39,7 @@ export const getPostCommentItems = ( state, siteId, postId ) =>
 	get( state.comments.items, `${ siteId }-${ postId }` );
 
 export const getDateSortedPostComments = treeSelect(
-	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) ],
+	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) || emptyArray ],
 	( [ comments ] ) => {
 		return sortBy( comments, comment => new Date( comment.date ) );
 	}
@@ -77,7 +80,7 @@ export const getPostTotalCommentsCount = ( state, siteId, postId ) =>
  * @return {Date} most recent comment date
  */
 export const getPostNewestCommentDate = treeSelect(
-	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) ],
+	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) || emptyArray ],
 	( [ comments ] ) => {
 		const firstContiguousComment = find( comments, 'contiguous' );
 		return firstContiguousComment ? new Date( get( firstContiguousComment, 'date' ) ) : undefined;
@@ -92,7 +95,7 @@ export const getPostNewestCommentDate = treeSelect(
  * @return {Date} earliest comment date
  */
 export const getPostOldestCommentDate = treeSelect(
-	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) ],
+	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) || emptyArray ],
 	( [ comments ] ) => {
 		const lastContiguousComment = findLast( comments, 'contiguous' );
 		return lastContiguousComment ? new Date( get( lastContiguousComment, 'date' ) ) : undefined;
@@ -109,7 +112,7 @@ export const getPostOldestCommentDate = treeSelect(
  * @return {Object} comments tree, and in addition a children array
  */
 export const getPostCommentsTree = treeSelect(
-	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) ],
+	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) || emptyArray ],
 	( [ allItems ], siteId, postId, status = 'approved', authorId ) => {
 		const items = filter( allItems, item => {
 			//only return pending comments that match the comment author
@@ -149,14 +152,13 @@ export const getPostCommentsTree = treeSelect(
 	}
 );
 
-const empty = {};
 export const getExpansionsForPost = ( state, siteId, postId ) =>
-	state.comments.expansions[ getStateKey( siteId, postId ) ] || empty;
+	state.comments.expansions[ getStateKey( siteId, postId ) ] || emptyObject;
 
 export const getHiddenCommentsForPost = treeSelect(
 	( state, siteId, postId ) => [
-		getPostCommentItems( state, siteId, postId ),
-		getExpansionsForPost( state, siteId, postId ),
+		getPostCommentItems( state, siteId, postId ) || emptyArray,
+		getExpansionsForPost( state, siteId, postId ) || emptyObject,
 	],
 	( [ comments, expanded ] ) => {
 		const commentsById = keyBy( comments, 'ID' );
@@ -190,7 +192,7 @@ export const commentsFetchingStatus = ( state, siteId, postId, commentTotal = 0 
  * @return {Object} that has i_like and like_count props
  */
 export const getCommentLike = treeSelect(
-	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) ],
+	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) || emptyArray ],
 	( [ comments ], siteId, postId, commentId ) => {
 		const comment = find( comments, { ID: commentId } );
 

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -25,9 +25,6 @@ import treeSelect from 'lib/tree-select';
 import { fetchStatusInitialState } from './reducer';
 import { getStateKey, deconstructStateKey, getErrorKey } from './utils';
 
-const emptyObject = {};
-const emptyArray = [];
-
 /***
  * Gets comment items for post
  * @param {Object} state redux state
@@ -39,7 +36,7 @@ export const getPostCommentItems = ( state, siteId, postId ) =>
 	get( state.comments.items, `${ siteId }-${ postId }` );
 
 export const getDateSortedPostComments = treeSelect(
-	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) || emptyArray ],
+	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) ],
 	( [ comments ] ) => {
 		return sortBy( comments, comment => new Date( comment.date ) );
 	}
@@ -80,7 +77,7 @@ export const getPostTotalCommentsCount = ( state, siteId, postId ) =>
  * @return {Date} most recent comment date
  */
 export const getPostNewestCommentDate = treeSelect(
-	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) || emptyArray ],
+	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) ],
 	( [ comments ] ) => {
 		const firstContiguousComment = find( comments, 'contiguous' );
 		return firstContiguousComment ? new Date( get( firstContiguousComment, 'date' ) ) : undefined;
@@ -95,7 +92,7 @@ export const getPostNewestCommentDate = treeSelect(
  * @return {Date} earliest comment date
  */
 export const getPostOldestCommentDate = treeSelect(
-	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) || emptyArray ],
+	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) ],
 	( [ comments ] ) => {
 		const lastContiguousComment = findLast( comments, 'contiguous' );
 		return lastContiguousComment ? new Date( get( lastContiguousComment, 'date' ) ) : undefined;
@@ -112,7 +109,7 @@ export const getPostOldestCommentDate = treeSelect(
  * @return {Object} comments tree, and in addition a children array
  */
 export const getPostCommentsTree = treeSelect(
-	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) || emptyArray ],
+	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) ],
 	( [ allItems ], siteId, postId, status = 'approved', authorId ) => {
 		const items = filter( allItems, item => {
 			//only return pending comments that match the comment author
@@ -153,12 +150,12 @@ export const getPostCommentsTree = treeSelect(
 );
 
 export const getExpansionsForPost = ( state, siteId, postId ) =>
-	state.comments.expansions[ getStateKey( siteId, postId ) ] || emptyObject;
+	state.comments.expansions[ getStateKey( siteId, postId ) ];
 
 export const getHiddenCommentsForPost = treeSelect(
 	( state, siteId, postId ) => [
-		getPostCommentItems( state, siteId, postId ) || emptyArray,
-		getExpansionsForPost( state, siteId, postId ) || emptyObject,
+		getPostCommentItems( state, siteId, postId ),
+		getExpansionsForPost( state, siteId, postId ),
 	],
 	( [ comments, expanded ] ) => {
 		const commentsById = keyBy( comments, 'ID' );
@@ -192,7 +189,7 @@ export const commentsFetchingStatus = ( state, siteId, postId, commentTotal = 0 
  * @return {Object} that has i_like and like_count props
  */
 export const getCommentLike = treeSelect(
-	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) || emptyArray ],
+	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) ],
 	( [ comments ], siteId, postId, commentId ) => {
 		const comment = find( comments, { ID: commentId } );
 
@@ -201,6 +198,5 @@ export const getCommentLike = treeSelect(
 		}
 		const { i_like, like_count } = comment;
 		return { i_like, like_count };
-	},
-	state => state.comments.items
+	}
 );

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -149,8 +149,9 @@ export const getPostCommentsTree = treeSelect(
 	}
 );
 
+const empty = {};
 export const getExpansionsForPost = ( state, siteId, postId ) =>
-	state.comments.expansions[ getStateKey( siteId, postId ) ];
+	state.comments.expansions[ getStateKey( siteId, postId ) ] || empty;
 
 export const getHiddenCommentsForPost = treeSelect(
 	( state, siteId, postId ) => [


### PR DESCRIPTION
**summary**
Conversations are dependent upon a single posts's comments and not the entire collection of comments. Therefore the current `createSelector` approach is less effective than it could be. This PR improves the performance by utilizing  [treeSelector](https://github.com/Automattic/wp-calypso/pull/20547).

I tested for fewer re-renders by using this unmerged  [performance](https://github.com/Automattic/wp-calypso/pull/21081) tool.


below is the result of loading conversations and clicking "more comments" a couple times.

**before**
<img width="1031" alt="screen shot 2018-01-11 at 4 00 02 pm" src="https://user-images.githubusercontent.com/4656974/34847199-8b60e97a-f6e8-11e7-9cd9-4a71a801462b.png">

**after**
<img width="523" alt="screen shot 2018-01-11 at 4 43 25 pm" src="https://user-images.githubusercontent.com/4656974/34848913-94f15b72-f6ee-11e7-829d-610dc0a5b30a.png">

---
**summary of results**
By using `treeSelect` instead of `createSelector` I was able to get the wasted render count down from ~351 to 8.   These numbers were just after a few second after loading -- I'm sure it would get wayy more drastic if i used conversations for much longer.
