### PR TITLE
Domains: Update notices for transfer

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -795,16 +795,43 @@ export class DomainWarnings extends React.PureComponent {
 		switch ( domainInTransfer.transferStatus ) {
 			case transferStatus.PENDING_OWNER:
 				compactMessage = translate( 'Transfer confirmation required' );
-				message = translate(
-					'We sent an email to confirm the transfer of {{strong}}%(domain)s{{/strong}}. {{a}}More Info{{/a}}',
-					{
-						components: {
-							strong: <strong />,
-							a: <a href={ domainManagementLink } rel="noopener noreferrer" />,
-						},
-						args: { domain: domainInTransfer.name },
-					}
-				);
+
+				if ( domainInTransfer.manualWhois ) {
+					message = translate(
+						"We'll send an email to confirm the transfer of {{strong}}%(domain)s{{/strong}} " +
+							'as soon as we get the correct address. {{a}}More Info{{/a}}',
+						{
+							components: {
+								strong: <strong />,
+								a: <a href={ domainManagementLink } rel="noopener noreferrer" />,
+							},
+							args: { domain: domainInTransfer.name },
+						}
+					);
+				} else if ( domainInTransfer.adminEmail ) {
+					message = translate(
+						'We sent an email to {{strong}}%(email)s{{/strong}} to confirm the transfer of ' +
+							'{{strong}}%(domain)s{{/strong}}. {{a}}More Info{{/a}}',
+						{
+							components: {
+								strong: <strong />,
+								a: <a href={ domainManagementLink } rel="noopener noreferrer" />,
+							},
+							args: { domain: domainInTransfer.name, email: domainInTransfer.adminEmail },
+						}
+					);
+				} else {
+					message = translate(
+						"We'll send an email shortly to confirm the transfer of {{strong}}%(domain)s{{/strong}}. {{a}}More Info{{/a}}",
+						{
+							components: {
+								strong: <strong />,
+								a: <a href={ domainManagementLink } rel="noopener noreferrer" />,
+							},
+							args: { domain: domainInTransfer.name },
+						}
+					);
+				}
 				break;
 			case transferStatus.PENDING_REGISTRY:
 				message = translate(

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -796,40 +796,31 @@ export class DomainWarnings extends React.PureComponent {
 			case transferStatus.PENDING_OWNER:
 				compactMessage = translate( 'Transfer confirmation required' );
 
+				const translateParams = {
+					components: {
+						strong: <strong />,
+						a: <a href={ domainManagementLink } rel="noopener noreferrer" />,
+					},
+					args: { domain: domainInTransfer.name },
+				};
+
 				if ( domainInTransfer.manualWhois ) {
 					message = translate(
 						"We'll send an email to confirm the transfer of {{strong}}%(domain)s{{/strong}} " +
 							'as soon as we get the correct address. {{a}}More Info{{/a}}',
-						{
-							components: {
-								strong: <strong />,
-								a: <a href={ domainManagementLink } rel="noopener noreferrer" />,
-							},
-							args: { domain: domainInTransfer.name },
-						}
+						translateParams
 					);
 				} else if ( domainInTransfer.adminEmail ) {
+					translateParams.args.email = domainInTransfer.adminEmail;
 					message = translate(
 						'We sent an email to {{strong}}%(email)s{{/strong}} to confirm the transfer of ' +
 							'{{strong}}%(domain)s{{/strong}}. {{a}}More Info{{/a}}',
-						{
-							components: {
-								strong: <strong />,
-								a: <a href={ domainManagementLink } rel="noopener noreferrer" />,
-							},
-							args: { domain: domainInTransfer.name, email: domainInTransfer.adminEmail },
-						}
+						translateParams
 					);
 				} else {
 					message = translate(
 						"We'll send an email shortly to confirm the transfer of {{strong}}%(domain)s{{/strong}}. {{a}}More Info{{/a}}",
-						{
-							components: {
-								strong: <strong />,
-								a: <a href={ domainManagementLink } rel="noopener noreferrer" />,
-							},
-							args: { domain: domainInTransfer.name },
-						}
+						translateParams
 					);
 				}
 				break;

--- a/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
@@ -54,8 +54,8 @@ class InboundTransferEmailVerificationCard extends React.PureComponent {
 							) }
 						</h1>
 						{ translate(
-							"We'll let you know which mailbox to check as soon as the email is sent. " 
-							+ 'Check again in a few minutes.'
+							"We'll let you know which mailbox to check as soon as the email is sent. " +
+							'Check again in a few minutes.'
 						) }
 					</div>
 				</Card>

--- a/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
@@ -54,7 +54,8 @@ class InboundTransferEmailVerificationCard extends React.PureComponent {
 							) }
 						</h1>
 						{ translate(
-							'Check again in a few minutes to see which mailbox you can find the email in.'
+							"The domain contact address wasn't immediately available but we should have it soon. " +
+							'Check again in a few minutes to see where to look for the authorization email.'
 						) }
 					</div>
 				</Card>

--- a/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
@@ -54,8 +54,8 @@ class InboundTransferEmailVerificationCard extends React.PureComponent {
 							) }
 						</h1>
 						{ translate(
-							"The domain contact address wasn't immediately available but we should have it soon. " +
-							'Check again in a few minutes to see where to look for the authorization email.'
+							"We'll let you know which mailbox to check as soon as the email is sent. " 
+							+ 'Check again in a few minutes.'
 						) }
 					</div>
 				</Card>


### PR DESCRIPTION
Add 3 cases when we initiate transfer:
- When we couldn't get the e-mail right away
- When we got the email, and waiting for the FOA to be sent
- When we already have the email