### PR TITLE
Domains: Fix logic for showing privacy message on incoming transfer pre-check

### DIFF
--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -328,7 +328,9 @@ class TransferDomainPrecheck extends React.PureComponent {
 			);
 
 			buttonText = translate( 'I can access the email address listed' );
-		} else if ( privacy ) {
+		}
+
+		if ( privacy && email ) {
 			message = translate(
 				'{{notice}}It looks like you may have privacy protection enabled. It must be turned off to ' +
 					'transfer your domain.{{/notice}}' +


### PR DESCRIPTION
This PR fixes the logic that shows the privacy message on the incoming transfer pre-check screen.