### PR TITLE
Editor: Adding drafts popover to editor

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -366,9 +366,7 @@ $autobar-height: 20px;
 }
 
 .masterbar__toggle-drafts.button.is-borderless {
-	background: lighten( $gray, 26% );
-	border-left: 1px solid lighten( $gray, 10% );
-	color: $gray-text-min;
+	background: $white;
 	height: 36px;
 	margin: 5px 8px 5px -10px;
 	padding: 0 8px;
@@ -376,22 +374,15 @@ $autobar-height: 20px;
 	position: relative;
 	transition: all 0.2s ease-out;
 
-	.count {
-		border: none;
-		margin: 0;
-		font-size: 13px;
-		font-weight: 400;
-		color: $gray-dark;
-		padding: 0 4px;
-		line-height: 30px;
-	}
-
 	&:hover {
-		background: $white;
-
 		.count {
+			border-color: $blue-wordpress;
 			color: $blue-wordpress;
 		}
+	}
+
+	.masterbar__publish & {
+		margin-left: -20px;
 	}
 }
 

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -23,6 +23,7 @@ import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-butto
 import { composeAnalytics, recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
 import { canCurrentUser } from 'state/selectors';
 import { getRouteHistory } from 'state/ui/action-log/selectors';
+import Drafts from 'layout/masterbar/drafts';
 
 export class EditorGroundControl extends PureComponent {
 	static propTypes = {
@@ -258,6 +259,7 @@ export class EditorGroundControl extends PureComponent {
 					onSelect={ this.props.recordSiteButtonClick }
 					indicator={ true }
 				/>
+				<Drafts />
 				{ this.state.needsVerification && (
 					<div
 						className="editor-ground-control__email-verification-notice"

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -20,10 +20,10 @@ import postUtils from 'lib/posts/utils';
 import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import Button from 'components/button';
 import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-buttons';
+import Drafts from 'layout/masterbar/drafts';
 import { composeAnalytics, recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
 import { canCurrentUser } from 'state/selectors';
 import { getRouteHistory } from 'state/ui/action-log/selectors';
-import Drafts from 'layout/masterbar/drafts';
 
 export class EditorGroundControl extends PureComponent {
 	static propTypes = {


### PR DESCRIPTION
Simplifying the drafts count in the masterbar, and adding the count and popover to the editor.

Changing the design of the draft count so it fits in the masterbar and the editor:
<img width="412" alt="screen shot 2018-01-11 at 4 30 25 pm" src="https://user-images.githubusercontent.com/191598/34848462-db59063e-f6ec-11e7-9cd5-e35a4fc79570.png">

<img width="507" alt="screen shot 2018-01-11 at 4 30 47 pm" src="https://user-images.githubusercontent.com/191598/34848478-ed9df12e-f6ec-11e7-8a20-03668ca22d1c.png">
