### PR TITLE
Store: Add tracks events for product category management

### DIFF
--- a/client/extensions/woocommerce/app/product-categories/create.js
+++ b/client/extensions/woocommerce/app/product-categories/create.js
@@ -34,6 +34,7 @@ import ProductCategoryHeader from './header';
 import { recordTrack } from 'woocommerce/lib/analytics';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { getSaveErrorMessage } from './utils';
+import { withAnalytics } from 'state/analytics/actions';
 
 class ProductCategoryCreate extends React.Component {
 	static propTypes = {
@@ -103,8 +104,6 @@ class ProductCategoryCreate extends React.Component {
 		};
 
 		this.props.createProductCategory( site.ID, category, successAction, failureAction );
-
-		recordTrack( 'calypso_woocommerce_product_category_create' );
 	};
 
 	render() {
@@ -155,7 +154,11 @@ function mapDispatchToProps( dispatch ) {
 		{
 			editProductCategory,
 			clearProductCategoryEdits,
-			createProductCategory,
+			createProductCategory: ( ...args ) =>
+				withAnalytics(
+					recordTrack( 'calypso_woocommerce_product_category_create' ),
+					createProductCategory( ...args )
+				),
 		},
 		dispatch
 	);

--- a/client/extensions/woocommerce/app/product-categories/create.js
+++ b/client/extensions/woocommerce/app/product-categories/create.js
@@ -31,6 +31,7 @@ import {
 import { getLink } from 'woocommerce/lib/nav-utils';
 import ProductCategoryForm from './form';
 import ProductCategoryHeader from './header';
+import { recordTrack } from 'woocommerce/lib/analytics';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { getSaveErrorMessage } from './utils';
 
@@ -102,6 +103,8 @@ class ProductCategoryCreate extends React.Component {
 		};
 
 		this.props.createProductCategory( site.ID, category, successAction, failureAction );
+
+		recordTrack( 'calypso_woocommerce_product_category_create' );
 	};
 
 	render() {

--- a/client/extensions/woocommerce/app/product-categories/index.js
+++ b/client/extensions/woocommerce/app/product-categories/index.js
@@ -20,6 +20,7 @@ import Main from 'components/main';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import ProductCategoriesList from 'woocommerce/app/product-categories/list';
+import { recordTrack } from 'woocommerce/lib/analytics';
 import SectionNav from 'components/section-nav';
 import Search from 'components/search';
 
@@ -78,6 +79,10 @@ class ProductCategories extends Component {
 
 		this.setState( { searchQuery: query, requestedSearchPages: [ 1 ] } );
 		this.props.fetchProductCategories( site.ID, { search: query } );
+
+		recordTrack( 'calypso_woocommerce_product_category_search', {
+			query,
+		} );
 	};
 
 	render() {

--- a/client/extensions/woocommerce/app/product-categories/index.js
+++ b/client/extensions/woocommerce/app/product-categories/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -23,6 +22,7 @@ import ProductCategoriesList from 'woocommerce/app/product-categories/list';
 import { recordTrack } from 'woocommerce/lib/analytics';
 import SectionNav from 'components/section-nav';
 import Search from 'components/search';
+import { withAnalytics } from 'state/analytics/actions';
 
 class ProductCategories extends Component {
 
@@ -78,11 +78,7 @@ class ProductCategories extends Component {
 		}
 
 		this.setState( { searchQuery: query, requestedSearchPages: [ 1 ] } );
-		this.props.fetchProductCategories( site.ID, { search: query } );
-
-		recordTrack( 'calypso_woocommerce_product_category_search', {
-			query,
-		} );
+		this.props.searchProductCategories( site.ID, { search: query } );
 	};
 
 	render() {
@@ -137,13 +133,12 @@ function mapStateToProps( state ) {
 	};
 }
 
-function mapDispatchToProps( dispatch ) {
-	return bindActionCreators(
-		{
-			fetchProductCategories,
-		},
-		dispatch
-	);
-}
+const mapDispatchToProps = dispatch => ( {
+	searchProductCategories: ( siteId, query ) => withAnalytics(
+		recordTrack( 'calypso_woocommerce_product_category_search', query ),
+		fetchProductCategories( siteId, query )( dispatch ),
+	),
+	fetchProductCategories: ( ...args ) => fetchProductCategories( ...args )( dispatch ),
+} );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( ProductCategories ) );

--- a/client/extensions/woocommerce/app/product-categories/update.js
+++ b/client/extensions/woocommerce/app/product-categories/update.js
@@ -38,6 +38,7 @@ import ProductCategoryHeader from './header';
 import { recordTrack } from 'woocommerce/lib/analytics';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { getSaveErrorMessage } from './utils';
+import { withAnalytics } from 'state/analytics/actions';
 
 class ProductCategoryUpdate extends React.Component {
 	static propTypes = {
@@ -117,7 +118,6 @@ class ProductCategoryUpdate extends React.Component {
 				);
 			};
 			dispatchDelete( site.ID, category, successAction, failureAction );
-			recordTrack( 'calypso_woocommerce_product_category_delete', { id: category.id } );
 		} );
 	};
 
@@ -145,8 +145,6 @@ class ProductCategoryUpdate extends React.Component {
 		};
 
 		this.props.updateProductCategory( site.ID, category, successAction, failureAction );
-
-		recordTrack( 'calypso_woocommerce_product_category_update', { id: category.id } );
 	};
 
 	render() {
@@ -199,8 +197,16 @@ function mapDispatchToProps( dispatch ) {
 			editProductCategory,
 			fetchProductCategories,
 			clearProductCategoryEdits,
-			updateProductCategory,
-			deleteProductCategory,
+			updateProductCategory: ( siteId, category, ...args ) =>
+				withAnalytics(
+					recordTrack( 'calypso_woocommerce_product_category_update', { id: category.id } ),
+					updateProductCategory( siteId, category, ...args )
+				),
+			deleteProductCategory: ( siteId, category, ...args ) =>
+				withAnalytics(
+					recordTrack( 'calypso_woocommerce_product_category_delete', { id: category.id } ),
+					deleteProductCategory( siteId, category, ...args )
+				),
 		},
 		dispatch
 	);

--- a/client/extensions/woocommerce/app/product-categories/update.js
+++ b/client/extensions/woocommerce/app/product-categories/update.js
@@ -35,6 +35,7 @@ import {
 import { getLink } from 'woocommerce/lib/nav-utils';
 import ProductCategoryForm from './form';
 import ProductCategoryHeader from './header';
+import { recordTrack } from 'woocommerce/lib/analytics';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { getSaveErrorMessage } from './utils';
 
@@ -116,6 +117,7 @@ class ProductCategoryUpdate extends React.Component {
 				);
 			};
 			dispatchDelete( site.ID, category, successAction, failureAction );
+			recordTrack( 'calypso_woocommerce_product_category_delete', { id: category.id } );
 		} );
 	};
 
@@ -143,6 +145,8 @@ class ProductCategoryUpdate extends React.Component {
 		};
 
 		this.props.updateProductCategory( site.ID, category, successAction, failureAction );
+
+		recordTrack( 'calypso_woocommerce_product_category_update', { id: category.id } );
 	};
 
 	render() {


### PR DESCRIPTION
This PR adds tracks events to product category management. See #20295.

Open your console and paste `localStorage.setItem('debug', '*analytics*');`. You will be looking for `woocommerce:analytics track` events.

Please test the following events and make sure you see them in your console:

* Searching from the product category listing page.
* Save/create a new product category.
* Save/update a product category.
* Delete a product category.