### PR TITLE
Store Orders: Record tracks events for creating a new order, manually sending invoice

### DIFF
--- a/client/extensions/woocommerce/app/order/create.js
+++ b/client/extensions/woocommerce/app/order/create.js
@@ -30,6 +30,7 @@ import Main from 'components/main';
 import OrderCustomerCreate from './order-customer/create';
 import OrderDetails from './order-details';
 import { ProtectFormGuard } from 'lib/protect-form';
+import { recordTrack } from 'woocommerce/lib/analytics';
 import { sendOrderInvoice } from 'woocommerce/state/sites/orders/send-invoice/actions';
 
 class Order extends Component {
@@ -85,6 +86,7 @@ class Order extends Component {
 			dispatch( errorNotice( translate( 'Unable to create order.' ), { duration: 8000 } ) );
 		};
 
+		recordTrack( 'calypso_woocommerce_order_create' );
 		this.props.saveOrder( siteId, order, onSuccess, onFailure );
 	};
 

--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -115,6 +115,8 @@ class Order extends Component {
 			const onFailure = errorNotice( translate( 'Unable to send order invoice.' ), {
 				duration: 8000,
 			} );
+
+			recordTrack( 'calypso_woocommerce_order_manual_invoice' );
 			this.props.sendOrderInvoice( siteId, orderId, onSuccess, onFailure );
 		}
 	};


### PR DESCRIPTION
This PR adds some tracks events for saving a new order & manually sending an invoice.

To test, enable tracks debugging: `localStorage.setItem('debug', '*analytics*');`

- Open a new order `/store/order/:site`
- Make some changes, save the order
- See `calypso_woocommerce_order_create` in your console
- Open a pending-payment order
- Click "Resend Invoice"
- See `calypso_woocommerce_order_manual_invoice` in your console

The new order button is a link to a new page, not a button, so if it's OK we can track it by looking at the calypso page view event? Or I can switch it to a button + redirection, it's just a little more code.