### PR TITLE
Store: Fix for image/parent selector width issues while resizing

### DIFF
--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -59,6 +59,7 @@ class TermTreeSelectorList extends Component {
 		onChange: PropTypes.func,
 		isError: PropTypes.bool,
 		height: PropTypes.number,
+		width: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -402,7 +403,7 @@ class TermTreeSelectorList extends Component {
 		const showSearch =
 			( searchLength > 0 || ! isSmall ) &&
 			( this.props.terms || ( ! this.props.terms && searchLength > 0 ) );
-		const { className, isError, loading, siteId, taxonomy, query, height } = this.props;
+		const { className, isError, loading, siteId, taxonomy, query, height, width } = this.props;
 		const classes = classNames( 'term-tree-selector', className, {
 			'is-loading': loading,
 			'is-small': isSmall,
@@ -423,7 +424,7 @@ class TermTreeSelectorList extends Component {
 				{ showSearch && <Search searchTerm={ this.state.searchTerm } onSearch={ this.onSearch } /> }
 				<List
 					ref={ this.setListRef }
-					width={ this.getResultsWidth() }
+					width={ width || this.getResultsWidth() }
 					height={ isSmall ? this.getCompactContainerHeight() : height }
 					onRowsRendered={ this.setRequestedPages }
 					rowCount={ rowCount }

--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -283,6 +283,7 @@ class ProductCategoryForm extends Component {
 											onChange={ this.setParent }
 											multiple={ false }
 											height={ 300 }
+											width={ 400 }
 											hideTermAndChildren={ ( isNumber( category.id ) && category.id ) || null }
 											query={ query }
 											onSearch={ this.onSearch }


### PR DESCRIPTION
As reported at https://github.com/Automattic/wp-calypso/pull/21351#issuecomment-356746604, the term selector component has some weird behavior with the form when resizing the window.

It looks like a width is calculated based on the initial client width of the window and passed to `react-virtualized`'s `List` component. If you resize, that width never changes, so the component and form start to look weird as you resize.

My attempt to fix this is to introduce a new (optional) width prop, that we can use to pass a smaller initial value that works with the rest of our form. 

To Test:

* Go `http://calypso.localhost:3000/store/products/category/:site` and open the parent selector.
* Resize your window and verify the fields look OK as you resize them.
* Go to `http://calypso.localhost:3000/settings/taxonomies/category/:site` and open the modal (edit or new) and spot check the component.