### PR TITLE
Comments: only select comments we can moderate in bulk mode

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -127,6 +127,10 @@ export class CommentList extends Component {
 	};
 
 	toggleCommentSelected = comment => {
+		if ( ! comment.can_moderate ) {
+			return;
+		}
+
 		if ( this.isCommentSelected( comment.commentId ) ) {
 			return this.setState( ( { selectedComments } ) => ( {
 				selectedComments: selectedComments.filter(

--- a/client/my-sites/comments/comment/comment-header.jsx
+++ b/client/my-sites/comments/comment/comment-header.jsx
@@ -17,13 +17,20 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 
 export class CommentHeader extends PureComponent {
 	render() {
-		const { commentId, isBulkMode, isPostView, isSelected, showAuthorMoreInfo } = this.props;
+		const {
+			commentId,
+			isBulkMode,
+			isPostView,
+			isSelected,
+			showAuthorMoreInfo,
+			isDisabled,
+		} = this.props;
 
 		return (
 			<div className="comment__header">
 				{ isBulkMode && (
 					<span className="comment__bulk-select">
-						<FormCheckbox checked={ isSelected } tabIndex="0" />
+						<FormCheckbox checked={ isSelected } tabIndex="0" disabled={ isDisabled } />
 					</span>
 				) }
 
@@ -39,9 +46,11 @@ const mapStateToProps = ( state, { commentId, isBulkMode } ) => {
 	const siteId = getSelectedSiteId( state );
 	const comment = getSiteComment( state, siteId, commentId );
 	const commentType = get( comment, 'type', 'comment' );
+	const canModerateComment = get( comment, 'can_moderate', false );
 
 	return {
 		showAuthorMoreInfo: ! isBulkMode && 'comment' === commentType,
+		isDisabled: ! canModerateComment,
 	};
 };
 

--- a/client/my-sites/comments/comment/utils.js
+++ b/client/my-sites/comments/comment/utils.js
@@ -15,4 +15,5 @@ export const getMinimumComment = comment => ( {
 	isLiked: get( comment, 'i_like' ),
 	postId: get( comment, 'post.ID' ),
 	status: get( comment, 'status' ),
+	can_moderate: get( comment, 'can_moderate' ),
 } );


### PR DESCRIPTION
This PR updates logic so we can only select comments in bulk mode that we can moderate. Fixes #21301 

I did consider disabling Comments for the Contibutor role, since they are unable to moderate any comments. At the moment the sidebar uses a single capability check which makes this difficult. We can revisit this later if it causes confusion. (wp-admin also shows contributors comments but doesn't give them any ability to moderate).

### Testing Instructions
- Create a site with a contributor (with a published post + comments )
- On that same site create an Author user ( with a publish post + comments )
As An Author
- Navigate to /comments
- Select that site
- Click on "Bulk Edit"
- Comments that can be moderated by you are selectable (comments on your posts), but other comments are not.
- Actions should succeed without errors
As A Contributor
- You can enter bulk mode, but no items are selectable.
Editors/Admins can moderate all comments in bulk mode as normal