### PR TITLE
SEO Tools: hide meta description when conflicting plugin is active

### DIFF
--- a/client/lib/seo/index.js
+++ b/client/lib/seo/index.js
@@ -4,15 +4,14 @@
  */
 import { includes } from 'lodash';
 
-export const getConflictingSeoPlugins = activePlugins => {
-	const conflictingSeoPlugins = [
-		'Yoast SEO',
-		'Yoast SEO Premium',
-		'All In One SEO Pack',
-		'All in One SEO Pack Pro',
-	];
+const conflictingSeoPlugins = [
+	'Yoast SEO',
+	'Yoast SEO Premium',
+	'All In One SEO Pack',
+	'All in One SEO Pack Pro',
+];
 
-	return activePlugins
+export const getConflictingSeoPlugins = activePlugins =>
+	activePlugins
 		.filter( ( { name } ) => includes( conflictingSeoPlugins, name ) )
 		.map( ( { name, slug } ) => ( { name, slug } ) );
-};

--- a/client/lib/seo/index.js
+++ b/client/lib/seo/index.js
@@ -1,0 +1,18 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+export const getConflictingSeoPlugins = activePlugins => {
+	const conflictingSeoPlugins = [
+		'Yoast SEO',
+		'Yoast SEO Premium',
+		'All In One SEO Pack',
+		'All in One SEO Pack Pro',
+	];
+
+	return activePlugins
+		.filter( ( { name } ) => includes( conflictingSeoPlugins, name ) )
+		.map( ( { name, slug } ) => ( { name, slug } ) );
+};

--- a/client/lib/seo/index.js
+++ b/client/lib/seo/index.js
@@ -15,3 +15,6 @@ export const getConflictingSeoPlugins = activePlugins =>
 	activePlugins
 		.filter( ( { name } ) => includes( conflictingSeoPlugins, name ) )
 		.map( ( { name, slug } ) => ( { name, slug } ) );
+
+export const getFirstConflictingPlugin = activePlugins =>
+	getConflictingSeoPlugins( activePlugins )[ 0 ];

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -4,17 +4,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import {
-	get,
-	includes,
-	isArray,
-	isEqual,
-	mapValues,
-	omit,
-	overSome,
-	pickBy,
-	partial,
-} from 'lodash';
+import { get, isArray, isEqual, mapValues, omit, overSome, pickBy, partial } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -64,6 +54,7 @@ import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { requestSiteSettings, saveSiteSettings } from 'state/site-settings/actions';
 import WebPreview from 'components/web-preview';
+import { getConflictingSeoPlugins } from 'lib/seo';
 
 // Basic matching for HTML tags
 // Not perfect but meets the needs of this component well
@@ -268,19 +259,6 @@ export class SeoForm extends React.Component {
 		this.setState( { showPreview: false } );
 	};
 
-	getConflictingSeoPlugins = activePlugins => {
-		const conflictingSeoPlugins = [
-			'Yoast SEO',
-			'Yoast SEO Premium',
-			'All In One SEO Pack',
-			'All in One SEO Pack Pro',
-		];
-
-		return activePlugins
-			.filter( ( { name } ) => includes( conflictingSeoPlugins, name ) )
-			.map( ( { name, slug } ) => ( { name, slug } ) );
-	};
-
 	render() {
 		const {
 			siteId,
@@ -335,8 +313,7 @@ export class SeoForm extends React.Component {
 		);
 
 		const conflictedSeoPlugin = siteIsJetpack
-			? // Let's just pick the first one to keep the notice short.
-				this.getConflictingSeoPlugins( activePlugins )[ 0 ]
+			? getConflictingSeoPlugins( activePlugins )[ 0 ] // Pick first one to keep the notice short.
 			: null;
 
 		/* eslint-disable react/jsx-no-target-blank */

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -54,7 +54,7 @@ import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { requestSiteSettings, saveSiteSettings } from 'state/site-settings/actions';
 import WebPreview from 'components/web-preview';
-import { getConflictingSeoPlugins } from 'lib/seo';
+import { getFirstConflictingPlugin } from 'lib/seo';
 
 // Basic matching for HTML tags
 // Not perfect but meets the needs of this component well
@@ -261,6 +261,7 @@ export class SeoForm extends React.Component {
 
 	render() {
 		const {
+			conflictedSeoPlugin,
 			siteId,
 			siteIsJetpack,
 			jetpackVersionSupportsSeo,
@@ -271,7 +272,6 @@ export class SeoForm extends React.Component {
 			isSeoToolsActive,
 			isSitePrivate,
 			isSiteHidden,
-			activePlugins,
 			translate,
 		} = this.props;
 		const { slug = '', URL: siteUrl = '' } = site;
@@ -311,10 +311,6 @@ export class SeoForm extends React.Component {
 				{ isSubmittingForm ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
 			</Button>
 		);
-
-		const conflictedSeoPlugin = siteIsJetpack
-			? getConflictingSeoPlugins( activePlugins )[ 0 ] // Pick first one to keep the notice short.
-			: null;
 
 		/* eslint-disable react/jsx-no-target-blank */
 		return (
@@ -493,7 +489,13 @@ const mapStateToProps = ( state, ownProps ) => {
 	const isAdvancedSeoSupported =
 		site && ( ! siteIsJetpack || ( siteIsJetpack && jetpackVersionSupportsSeo ) );
 
+	const activePlugins = getPlugins( state, [ siteId ], 'active' );
+	const conflictedSeoPlugin = siteIsJetpack
+		? getFirstConflictingPlugin( activePlugins ) // Pick first one to keep the notice short.
+		: null;
+
 	return {
+		conflictedSeoPlugin,
 		siteId,
 		siteIsJetpack,
 		selectedSite: getSelectedSite( state ),
@@ -505,7 +507,6 @@ const mapStateToProps = ( state, ownProps ) => {
 		isSeoToolsActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
 		isSiteHidden: isHiddenSite( state, siteId ),
 		isSitePrivate: isPrivateSite( state, siteId ),
-		activePlugins: getPlugins( state, [ siteId ], 'active' ),
 		hasAdvancedSEOFeature: hasFeature( state, siteId, FEATURE_ADVANCED_SEO ),
 		hasSeoPreviewFeature: hasFeature( state, siteId, FEATURE_SEO_PREVIEW_TOOLS ),
 		isSaveSuccess: isSiteSettingsSaveSuccessful( state, siteId ),

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -29,6 +29,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
+import { getPlugins } from 'state/plugins/installed/selectors';
 import {
 	isJetpackMinimumVersion,
 	isJetpackModuleActive,
@@ -41,6 +42,7 @@ import EditorDrawerPageOptions from './page-options';
 import EditorDrawerLabel from './label';
 import EditorMoreOptionsCopyPost from 'post-editor/editor-more-options/copy-post';
 import EditPostStatus from 'post-editor/edit-post-status';
+import { getConflictingSeoPlugins } from 'lib/seo';
 
 /**
  * Constants
@@ -241,7 +243,7 @@ class EditorDrawer extends Component {
 	}
 
 	renderSeo() {
-		const { jetpackVersionSupportsSeo } = this.props;
+		const { jetpackVersionSupportsSeo, activePlugins } = this.props;
 
 		if ( ! this.props.site ) {
 			return;
@@ -249,6 +251,11 @@ class EditorDrawer extends Component {
 
 		if ( this.props.isJetpack ) {
 			if ( ! this.props.isSeoToolsModuleActive || ! jetpackVersionSupportsSeo ) {
+				return;
+			}
+
+			// Don't show SEO accordion if this setting is managed by other SEO plugin.
+			if ( !! getConflictingSeoPlugins( activePlugins ).length ) {
 				return;
 			}
 		}
@@ -367,6 +374,7 @@ const enhance = flow(
 		const type = getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' );
 
 		return {
+			activePlugins: getPlugins( state, [ siteId ], 'active' ),
 			isPermalinkEditable: areSitePermalinksEditable( state, siteId ),
 			canJetpackUseTaxonomies: isJetpackMinimumVersion( state, siteId, '4.1' ),
 			isJetpack: isJetpackSite( state, siteId ),


### PR DESCRIPTION
Closes: https://github.com/Automattic/wp-calypso/issues/21211

Trying to save meta description for posts will fail if conflicting SEO plugins are active on Jetpack site (e.g. Yoast). We should hide the SEO accordion in that case in order to prevent errors while saving.

### Testing instructions

1. Use a test Jetpack site with Professional plan enabled.
2. Install Yoast SEO plugin.
3. Navigate to `settings/traffic/{siteSlug}` and verify that the following notice is displayed: 
  - `Your SEO settings are managed by the following plugin: Yoast SEO`
4. Navigate to post editor `post/{siteSlug}` and verify that SEO accordion is not visible.