### PR TITLE
Site Settings: Add language and timezone pickers to Jetpack

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -179,14 +179,15 @@ class SiteSettingsFormGeneral extends Component {
 			siteIsJetpack,
 			translate,
 		} = this.props;
-		if ( siteIsJetpack ) {
-			return null;
-		}
+
 		return (
-			<FormFieldset>
+			<FormFieldset
+				className={ siteIsJetpack && classNames( 'site-settings__has-divider', 'is-top-only' ) }
+			>
 				<FormLabel htmlFor="lang_id">{ translate( 'Language' ) }</FormLabel>
 				<LanguagePicker
 					languages={ config( 'languages' ) }
+					valueKey={ siteIsJetpack ? 'wpLocale' : 'value' }
 					value={ fields.lang_id }
 					onChange={ onChangeField( 'lang_id' ) }
 					disabled={ isRequestingSettings }
@@ -379,10 +380,7 @@ class SiteSettingsFormGeneral extends Component {
 	}
 
 	Timezone() {
-		const { fields, isRequestingSettings, siteIsJetpack, translate } = this.props;
-		if ( siteIsJetpack ) {
-			return;
-		}
+		const { fields, isRequestingSettings, translate } = this.props;
 
 		return (
 			<FormFieldset>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -207,9 +207,7 @@ class SiteSettingsFormGeneral extends Component {
 		}
 
 		return (
-			<FormFieldset
-				className={ siteIsJetpack && classNames( 'site-settings__has-divider', 'is-top-only' ) }
-			>
+			<FormFieldset className={ siteIsJetpack && 'site-settings__has-divider is-top-only' }>
 				<FormLabel htmlFor="lang_id">{ translate( 'Language' ) }</FormLabel>
 				{ this.renderLanguagePickerNotice() || (
 					<LanguagePicker
@@ -412,9 +410,7 @@ class SiteSettingsFormGeneral extends Component {
 
 		return (
 			<FormFieldset
-				className={
-					! supportsLanguageSelection && classNames( 'site-settings__has-divider', 'is-top-only' )
-				}
+				className={ ! supportsLanguageSelection && 'site-settings__has-divider is-top-only' }
 			>
 				<FormLabel htmlFor="blogtimezone">{ translate( 'Site Timezone' ) }</FormLabel>
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -566,7 +566,7 @@ const connectComponent = connect(
 			siteSlug: getSelectedSiteSlug( state ),
 			supportsLanguageSelection:
 				! siteIsJetpack ||
-				( isJetpackMinimumVersion( state, siteId, '5.8-beta' ) &&
+				( isJetpackMinimumVersion( state, siteId, '5.8-alpha' ) &&
 					config.isEnabled( 'jetpack/site-settings-language-selection' ) ),
 			supportsHolidaySnowOption: ! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '4.0' ),
 		};

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -183,7 +183,11 @@ class SiteSettingsFormGeneral extends Component {
 			),
 		};
 
-		return errors[ langId ] && <Notice text={ errors[ langId ] } isCompact />;
+		return (
+			errors[ langId ] && (
+				<Notice text={ errors[ langId ] } className="language-picker-notice" isCompact />
+			)
+		);
 	};
 
 	languageOptions() {
@@ -196,6 +200,8 @@ class SiteSettingsFormGeneral extends Component {
 			supportsLanguageSelection,
 			translate,
 		} = this.props;
+		const errorNotice = this.renderLanguagePickerNotice();
+
 		if ( ! supportsLanguageSelection ) {
 			return null;
 		}
@@ -203,16 +209,15 @@ class SiteSettingsFormGeneral extends Component {
 		return (
 			<FormFieldset className={ siteIsJetpack && 'site-settings__has-divider is-top-only' }>
 				<FormLabel htmlFor="lang_id">{ translate( 'Language' ) }</FormLabel>
-				{ this.renderLanguagePickerNotice() || (
-					<LanguagePicker
-						languages={ config( 'languages' ) }
-						valueKey={ siteIsJetpack ? 'wpLocale' : 'value' }
-						value={ fields.lang_id }
-						onChange={ onChangeField( 'lang_id' ) }
-						disabled={ isRequestingSettings }
-						onClick={ eventTracker( 'Clicked Language Field' ) }
-					/>
-				) }
+				{ errorNotice }
+				<LanguagePicker
+					languages={ config( 'languages' ) }
+					valueKey={ siteIsJetpack ? 'wpLocale' : 'value' }
+					value={ errorNotice ? 'en_US' : fields.lang_id }
+					onChange={ onChangeField( 'lang_id' ) }
+					disabled={ isRequestingSettings || ( siteIsJetpack && errorNotice ) }
+					onClick={ eventTracker( 'Clicked Language Field' ) }
+				/>
 				<FormSettingExplanation>
 					{ translate( 'Language this blog is primarily written in.' ) }&nbsp;
 					<a href={ config.isEnabled( 'me/account' ) ? '/me/account' : '/settings/account/' }>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import { flowRight } from 'lodash';
+import { flowRight, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -170,6 +170,33 @@ class SiteSettingsFormGeneral extends Component {
 		} );
 	};
 
+	renderLanguagePickerNotice = () => {
+		const { fields, translate } = this.props;
+
+		const langId = get( fields, 'lang_id', '' );
+		const matches = /^error_(\w+)$/.exec( langId );
+
+		let notice;
+		switch ( matches && matches[ 1 ] ) {
+			case 'cap':
+				notice = translate(
+					'The Site Language setting is disabled due to insufficient permissions.'
+				);
+			case 'const':
+				notice = translate(
+					'The Site Language setting is disabled because your site has the WPLANG constant set.'
+				);
+		}
+
+		return (
+			notice && (
+				<FormSettingExplanation className="site-settings__language-picker-blocked">
+					{ notice }
+				</FormSettingExplanation>
+			)
+		);
+	};
+
 	languageOptions() {
 		const {
 			eventTracker,
@@ -189,14 +216,16 @@ class SiteSettingsFormGeneral extends Component {
 				className={ siteIsJetpack && classNames( 'site-settings__has-divider', 'is-top-only' ) }
 			>
 				<FormLabel htmlFor="lang_id">{ translate( 'Language' ) }</FormLabel>
-				<LanguagePicker
-					languages={ config( 'languages' ) }
-					valueKey={ siteIsJetpack ? 'wpLocale' : 'value' }
-					value={ fields.lang_id }
-					onChange={ onChangeField( 'lang_id' ) }
-					disabled={ isRequestingSettings }
-					onClick={ eventTracker( 'Clicked Language Field' ) }
-				/>
+				{ this.renderLanguagePickerNotice() || (
+					<LanguagePicker
+						languages={ config( 'languages' ) }
+						valueKey={ siteIsJetpack ? 'wpLocale' : 'value' }
+						value={ fields.lang_id }
+						onChange={ onChangeField( 'lang_id' ) }
+						disabled={ isRequestingSettings }
+						onClick={ eventTracker( 'Clicked Language Field' ) }
+					/>
+				) }
 				<FormSettingExplanation>
 					{ translate( 'Language this blog is primarily written in.' ) }&nbsp;
 					<a href={ config.isEnabled( 'me/account' ) ? '/me/account' : '/settings/account/' }>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -173,23 +173,17 @@ class SiteSettingsFormGeneral extends Component {
 
 	renderLanguagePickerNotice = () => {
 		const { fields, translate } = this.props;
-
 		const langId = get( fields, 'lang_id', '' );
-		const matches = /^error_(\w+)$/.exec( langId );
+		const errors = {
+			error_cap: translate(
+				'The Site Language setting is disabled due to insufficient permissions.'
+			),
+			error_const: translate(
+				'The Site Language setting is disabled because your site has the WPLANG constant set.'
+			),
+		};
 
-		let noticeText;
-		switch ( matches && matches[ 1 ] ) {
-			case 'cap':
-				noticeText = translate(
-					'The Site Language setting is disabled due to insufficient permissions.'
-				);
-			case 'const':
-				noticeText = translate(
-					'The Site Language setting is disabled because your site has the WPLANG constant set.'
-				);
-		}
-
-		return noticeText && <Notice text={ noticeText } isCompact />;
+		return errors[ langId ] && <Notice text={ errors[ langId ] } isCompact />;
 	};
 
 	languageOptions() {

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -17,6 +17,7 @@ import wrapSettingsForm from './wrap-settings-form';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Button from 'components/button';
+import Notice from 'components/notice';
 import LanguagePicker from 'components/language-picker';
 import SectionHeader from 'components/section-header';
 import config from 'config';
@@ -188,13 +189,7 @@ class SiteSettingsFormGeneral extends Component {
 				);
 		}
 
-		return (
-			notice && (
-				<FormSettingExplanation className="site-settings__language-picker-blocked">
-					{ notice }
-				</FormSettingExplanation>
-			)
-		);
+		return notice && <Notice text={ notice } isCompact />;
 	};
 
 	languageOptions() {

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import { flowRight, get } from 'lodash';
+import { flowRight, get, has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,6 +18,7 @@ import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Button from 'components/button';
 import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 import LanguagePicker from 'components/language-picker';
 import SectionHeader from 'components/section-header';
 import config from 'config';
@@ -175,21 +176,35 @@ class SiteSettingsFormGeneral extends Component {
 		const { fields, translate } = this.props;
 		const langId = get( fields, 'lang_id', '' );
 		const errors = {
-			error_cap: translate(
-				'The Site Language setting is disabled due to insufficient permissions.'
-			),
-			error_const: translate(
-				'The Site Language setting is disabled because your site has the WPLANG constant set.'
-			),
+			error_cap: {
+				text: translate( 'The Site Language setting is disabled due to insufficient permissions.' ),
+				link: 'https://codex.wordpress.org/Roles_and_Capabilities',
+				linkText: translate( 'More info' ),
+			},
+			error_const: {
+				text: translate(
+					'The Site Language setting is disabled because your site has the WPLANG constant set.'
+				),
+				link:
+					'https://codex.wordpress.org/Installing_WordPress_in_Your_Language#Setting_the_language_for_your_site',
+				linkText: translate( 'More info' ),
+			},
 		};
+		const noticeContent = errors[ langId ];
 
 		return (
-			errors[ langId ] && (
+			has( noticeContent, 'text' ) && (
 				<Notice
-					text={ errors[ langId ] }
+					text={ noticeContent.text }
 					className="site-settings__language-picker-notice"
 					isCompact
-				/>
+				>
+					{ has( noticeContent, 'link' ) && (
+						<NoticeAction href={ noticeContent.link } external>
+							{ noticeContent.linkText }
+						</NoticeAction>
+					) }
+				</Notice>
 			)
 		);
 	};

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -185,7 +185,11 @@ class SiteSettingsFormGeneral extends Component {
 
 		return (
 			errors[ langId ] && (
-				<Notice text={ errors[ langId ] } className="language-picker-notice" isCompact />
+				<Notice
+					text={ errors[ langId ] }
+					className="site-settings__language-picker-notice"
+					isCompact
+				/>
 			)
 		);
 	};

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -177,8 +177,12 @@ class SiteSettingsFormGeneral extends Component {
 			isRequestingSettings,
 			onChangeField,
 			siteIsJetpack,
+			supportsLanguageSelection,
 			translate,
 		} = this.props;
+		if ( ! supportsLanguageSelection ) {
+			return null;
+		}
 
 		return (
 			<FormFieldset
@@ -380,10 +384,14 @@ class SiteSettingsFormGeneral extends Component {
 	}
 
 	Timezone() {
-		const { fields, isRequestingSettings, translate } = this.props;
+		const { fields, isRequestingSettings, translate, supportsLanguageSelection } = this.props;
 
 		return (
-			<FormFieldset>
+			<FormFieldset
+				className={
+					! supportsLanguageSelection && classNames( 'site-settings__has-divider', 'is-top-only' )
+				}
+			>
 				<FormLabel htmlFor="blogtimezone">{ translate( 'Site Timezone' ) }</FormLabel>
 
 				<Timezone
@@ -527,6 +535,10 @@ const connectComponent = connect(
 		return {
 			siteIsJetpack,
 			siteSlug: getSelectedSiteSlug( state ),
+			supportsLanguageSelection:
+				! siteIsJetpack ||
+				( isJetpackMinimumVersion( state, siteId, '5.8-beta' ) &&
+					config.isEnabled( 'jetpack/site-settings-language-selection' ) ),
 			supportsHolidaySnowOption: ! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '4.0' ),
 		};
 	},

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -177,19 +177,19 @@ class SiteSettingsFormGeneral extends Component {
 		const langId = get( fields, 'lang_id', '' );
 		const matches = /^error_(\w+)$/.exec( langId );
 
-		let notice;
+		let noticeText;
 		switch ( matches && matches[ 1 ] ) {
 			case 'cap':
-				notice = translate(
+				noticeText = translate(
 					'The Site Language setting is disabled due to insufficient permissions.'
 				);
 			case 'const':
-				notice = translate(
+				noticeText = translate(
 					'The Site Language setting is disabled because your site has the WPLANG constant set.'
 				);
 		}
 
-		return notice && <Notice text={ notice } isCompact />;
+		return noticeText && <Notice text={ noticeText } isCompact />;
 	};
 
 	languageOptions() {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -248,6 +248,12 @@
 	}
 }
 
+.site-settings__general-settings {
+	.language-picker-notice {
+		margin-bottom: 10px;
+	}
+}
+
 .site-settings__discussion-settings {
 	.form-toggle__label {
 		display: flex;

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -248,10 +248,8 @@
 	}
 }
 
-.site-settings__general-settings {
-	.language-picker-notice {
-		margin-bottom: 10px;
-	}
+.site-settings__language-picker-notice {
+	margin-bottom: 10px;
 }
 
 .site-settings__discussion-settings {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -247,8 +247,7 @@
 		margin: 0 -24px 1.5em;
 	}
 }
-
-.site-settings__language-picker-notice {
+.site-settings__general-settings .site-settings__language-picker-notice {
 	margin-bottom: 10px;
 }
 

--- a/config/development.json
+++ b/config/development.json
@@ -65,6 +65,7 @@
 		"jetpack/google-analytics-for-stores": true,
 		"jetpack/google-analytics-for-stores-enhanced": true,
 		"jetpack/onboarding": true,
+		"jetpack/site-settings-language-selection": true,
 		"jetpack_core_inline_update": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,


### PR DESCRIPTION
## This PR
- adds the Calypso portion that's needed to solve Issue #11316 
- aims to add support for the language and timezone pickers in Jetpack

## How to test

- Apply the corresponding Jetpack PR (https://github.com/Automattic/jetpack/pull/8568) to your connected Jetpack site.
- Navigate to `/settings/general/your-jetpack-site`
- Change timezone & language and save settings
- Check in your Jetpack site's wp-admin if the settings were changes as expected

- What it should look like if Jetpack version is <5.8-beta or the feature flag "jetpack/site-settings-language-selection" is disabled:

<img width="746" alt="screen shot 2018-01-18 at 16 17 05" src="https://user-images.githubusercontent.com/1562646/35128164-635b1d4e-fc72-11e7-9651-5384a44354e6.png">

- What it should look like if it's not Jetpack or the Jetpack version is >=5.8-beta and the feature flag "jetpack/site-settings-language-selection" is enabled:

<img width="739" alt="screen shot 2018-01-18 at 16 19 35" src="https://user-images.githubusercontent.com/1562646/35128268-e3ee7af0-fc72-11e7-88bc-d9eb094830cb.png">

- What it should look like if it's Jetpack version is >=5.8-beta and the feature flag "jetpack/site-settings-language-selection" is enabled, but there's a permissions issue or WPLANG constant is set:

<img width="743" alt="screen shot 2018-01-19 at 13 39 24" src="https://user-images.githubusercontent.com/1562646/35170742-7bd8e1a6-fd1e-11e7-9e06-8004076c1e63.png">


