### PR TITLE
Concierge Chats: make the concierge schedule id configurable through config files.

### DIFF
--- a/client/me/concierge/constants.js
+++ b/client/me/concierge/constants.js
@@ -1,4 +1,9 @@
-export const WPCOM_CONCIERGE_SCHEDULE_ID = 1;
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+export const WPCOM_CONCIERGE_SCHEDULE_ID = config( 'wpcom_concierge_schedule_id' ) || 1;
 
 // booking status
 export const CONCIERGE_STATUS_BOOKED = 'booked';

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -184,6 +184,7 @@
 	"signup/social-management": false,
 	"twemoji_cdn_url": "https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/",
 	"woocommerce_blog_id": 113771570,
+	"wpcom_concierge_schedule_id": 1,
 	"wpcom_signup_id": false,
 	"wpcom_signup_key": false,
 	"statsd_analytics_response_time_max_logs_per_second": 50

--- a/config/client.json
+++ b/config/client.json
@@ -38,6 +38,7 @@
   "support-user",
   "sync-handler-defaults",
   "twemoji_cdn_url",
+  "wpcom_concierge_schedule_id",
   "wpcom_signup_id",
   "wpcom_signup_key"
 ]


### PR DESCRIPTION
## Summary
This PR makes `WPCOM_CONCIERGE_SCHEDULE_ID` be configurable through config files, so that we won't need to touch git-tracked source code just for testing anymore.