### PR TITLE
Add site selector step

### DIFF
--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -17,6 +17,7 @@ import BookSkeleton from './book/skeleton';
 import RescheduleCalendarStep from './reschedule/calendar-step';
 import RescheduleConfirmationStep from './reschedule/confirmation-step';
 import RescheduleSkeleton from './reschedule/skeleton';
+import i18n from 'i18n-calypso';
 
 const book = ( context, next ) => {
 	context.primary = (
@@ -53,7 +54,10 @@ const reschedule = ( context, next ) => {
 
 const siteSelector = ( context, next ) => {
 	context.getSiteSelectionHeaderText = () =>
-		'Please select a business site to book a Concierge session';
+		i18n.translate(
+			'Please select a site for your {{strong}}Business Concierge Session{{/strong}}',
+			{ components: { strong: <strong /> } }
+		);
 	next();
 };
 

--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -51,8 +51,15 @@ const reschedule = ( context, next ) => {
 	next();
 };
 
+const siteSelector = ( context, next ) => {
+	context.getSiteSelectionHeaderText = () =>
+		'Please select a business site to book a Concierge session';
+	next();
+};
+
 export default {
 	book,
 	cancel,
 	reschedule,
+	siteSelector,
 };

--- a/client/me/concierge/index.js
+++ b/client/me/concierge/index.js
@@ -12,9 +12,26 @@ import page from 'page';
 import config from 'config';
 import controller from './controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { siteSelection, sites } from 'my-sites/controller';
+
+const redirectToBooking = context => {
+	page.redirect( `/me/concierge/${ context.params.siteSlug }/book` );
+};
 
 export default () => {
 	if ( config.isEnabled( 'concierge-chats' ) ) {
+		page(
+			'/me/concierge',
+			controller.siteSelector,
+			siteSelection,
+			sites,
+			makeLayout,
+			clientRender
+		);
+
+		// redirect to booking page after site selection
+		page( '/me/concierge/:siteSlug', redirectToBooking );
+
 		page( '/me/concierge/:siteSlug/book', controller.book, makeLayout, clientRender );
 
 		page(


### PR DESCRIPTION
## Summary 
Add a site selection step to the concierge flow. More context 532-hg-gh.

## Testing
1. Access `http://calypso.localhost:3000/me/concierge`
2. It should look like this https://cloudup.com/cko-2utJjCY
3. Selecting a site should redirect the customer to the first step of the booking process