### PR TITLE
Tests: Add valid schema expect matcher

### DIFF
--- a/client/state/signup/steps/survey/test/schema.js
+++ b/client/state/signup/steps/survey/test/schema.js
@@ -1,0 +1,10 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { surveyStepSchema } from '../schema';
+
+test( 'schema should be valid', () => {
+	expect( surveyStepSchema ).toBeValidSchema();
+} );

--- a/test/client/jsonschema-draft-04.json
+++ b/test/client/jsonschema-draft-04.json
@@ -1,0 +1,150 @@
+{
+    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "positiveInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "positiveIntegerDefault0": {
+            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+        },
+        "simpleTypes": {
+            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxLength": { "$ref": "#/definitions/positiveInteger" },
+        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/positiveInteger" },
+        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "dependencies": {
+        "exclusiveMaximum": [ "maximum" ],
+        "exclusiveMinimum": [ "minimum" ]
+    },
+    "default": {}
+}

--- a/test/client/setup-test-framework.js
+++ b/test/client/setup-test-framework.js
@@ -1,11 +1,12 @@
-/**
- * @format
- */
+/** @format */
 
 /**
  * External dependencies
  */
+import jsonSchema from './jsonschema-draft-04';
+import validator from 'is-my-json-valid';
 import { disableNetConnect } from 'nock';
+import { forEach, get, isEmpty } from 'lodash';
 
 // It disables all network requests for all tests.
 disableNetConnect();
@@ -53,4 +54,48 @@ jest.mock( 'sinon', () => {
 		actualSinon.assert.expose( chai.assert, { prefix: '' } );
 	}
 	return actualSinon;
+} );
+
+const validateSchema = validator( jsonSchema, { verbose: true, greedy: true } );
+
+expect.extend( {
+	toBeValidSchema( received, expected ) {
+		this.utils.ensureNoExpected( expected, '.toBeValidSchema' );
+		const pass = validateSchema( received );
+
+		const testMessage = pass
+			? /* Error message for valid schema that should not be. */ () =>
+					[
+						this.utils.matcherHint( '.not.toBeValidSchema', 'schema', '' ),
+						'',
+						`Expected ${ this.utils.printReceived( received ) } not to be a valid schema.`,
+					].join( '\n' )
+			: /* Error message for invalid schema that should be valid */ () => {
+					const msg = [
+						this.utils.matcherHint( '.toBeValidSchema', 'schema', '' ),
+						'',
+						`expected ${ this.utils.printReceived( received ) } to be a valid schema`,
+						'',
+					];
+					forEach( validateSchema.errors, ( { field, message, schemaPath, value } ) => {
+						// data.myField is required
+						msg.push( `${ field } ${ message }` );
+
+						// Found: { my: 'state' }
+						msg.push( `Found: ${ JSON.stringify( value ) }` );
+
+						// Violates rule: { type: 'boolean' }
+						if ( ! isEmpty( schemaPath ) ) {
+							msg.push( `Violates rule: ${ JSON.stringify( get( jsonSchema, schemaPath ) ) }` );
+						}
+						msg.push( '' );
+					} );
+					return msg.join( '\n' );
+				};
+		return {
+			actual: received,
+			message: testMessage,
+			pass,
+		};
+	},
 } );


### PR DESCRIPTION
Invalid schemas are easy to produce, tricky to find, and behave in undefined ways.

Related to #21125 #21044

This PR adds a Jest `expect` matcher: `.toBeValidSchema()`. It validates agains the draft-04 schema, which is what `is-my-json-valid` supports.

See p4TIVU-8O2-p2

## Testing
1. See examples below
1. Should also work well with `.not.toBeValidSchema()`;
1. You can see the test in action thanks to 7ac336c

## Examples

```js
expect( { type: 'null' } ).toBeValidSchema();
```

👍  passes

---

```js
expect( { type: null } ).toBeValidSchema();
```

Fails:
```
    expect(schema).toBeValidSchema()

    expected {"type": null} to be a valid schema

    data.type no schemas match
    Found: null
    Violates rule: {"anyOf":[{"$ref":"#/definitions/simpleTypes"},{"type":"array","items":{"$ref":"#/definitions/simpleTypes"},"minItems":1,"uniqueItems":true}]}
```

---

```js
expect( false ).toBeValidSchema();
```

Fails:
```
    expect(schema).toBeValidSchema()

    expected false to be a valid schema

    data is the wrong type
    Found: false
```