### PR TITLE
Add filter flag to timezones

### DIFF
--- a/client/components/timezone/README.md
+++ b/client/components/timezone/README.md
@@ -33,6 +33,9 @@ module.exports = React.createClass( {
 
 `selectedZone` - **optional** String value to define the selected timezone.
 
+`includeManualOffsets` - **optional** Boolean value to include/exclude the manual offsets from the 
+list of timezones, the default value is `true`
+
 `onSelect` - **optional** Called when user selects a timezone from the
 select. An object parameter is passed to the function which has two
 properties: `label` usually used to show the selected timezone to the user and

--- a/client/components/timezone/index.jsx
+++ b/client/components/timezone/index.jsx
@@ -68,7 +68,7 @@ class Timezone extends Component {
 				<optgroup label="UTC">
 					<option value="UTC">UTC</option>
 				</optgroup>
-				{ this.renderManualUtcOffsets() }
+				{ this.props.includeManualOffsets && this.renderManualUtcOffsets() }
 			</select>
 		);
 	}
@@ -76,11 +76,13 @@ class Timezone extends Component {
 
 Timezone.defaultProps = {
 	onSelect: noop,
+	includeManualOffsets: true,
 };
 
 Timezone.propTypes = {
 	selectedZone: PropTypes.string,
 	onSelect: PropTypes.func,
+	includeManualOffsets: PropTypes.bool,
 };
 
 export default connect( state => ( {

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -62,7 +62,12 @@ class InfoStep extends Component {
 				<CompactCard>
 					<FormFieldset>
 						<FormLabel>{ translate( "What's your timezone?" ) }</FormLabel>
-						<Timezone name="timezone" onSelect={ this.setTimezone } selectedZone={ timezone } />
+						<Timezone
+							includeManualOffsets={ false }
+							name="timezone"
+							onSelect={ this.setTimezone }
+							selectedZone={ timezone }
+						/>
 						<FormSettingExplanation>
 							{ translate( 'Choose a city in your timezone.' ) }
 						</FormSettingExplanation>


### PR DESCRIPTION
## Summary
This PR filters out the manual offsets from the timezone picker in the concierge section. This was added because moment cannot parse them.

## Testing
1. Access `http://calypso.localhost:3000/me/concierge/<business-site-slug>/book`
2. Timezone picker should not contain manual offsets (eg. UTC+1, UTC-10)