### PR TITLE
State: Add getJetpackOnboardingProgress selector

### DIFF
--- a/client/state/selectors/get-jetpack-onboarding-progress.js
+++ b/client/state/selectors/get-jetpack-onboarding-progress.js
@@ -3,19 +3,14 @@
 /**
  * External dependencies
  */
-import { reduce, values } from 'lodash';
+import { reduce } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { isJetpackOnboardingStepCompleted } from 'state/selectors';
-import { JETPACK_ONBOARDING_STEPS as STEPS } from 'jetpack-onboarding/constants';
 
 export default function getJetpackOnboardingProgress( state, siteId, steps ) {
-	if ( ! steps ) {
-		steps = values( STEPS );
-	}
-
 	return reduce(
 		steps,
 		( result, stepName ) => {

--- a/client/state/selectors/get-jetpack-onboarding-progress.js
+++ b/client/state/selectors/get-jetpack-onboarding-progress.js
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { reduce, values } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { isJetpackOnboardingStepCompleted } from 'state/selectors';
+import { JETPACK_ONBOARDING_STEPS as STEPS } from 'jetpack-onboarding/constants';
+
+export default function getJetpackOnboardingProgress( state, siteId, steps ) {
+	if ( ! steps ) {
+		steps = values( STEPS );
+	}
+
+	return reduce(
+		steps,
+		( result, stepName ) => {
+			result[ stepName ] = isJetpackOnboardingStepCompleted( state, siteId, stepName );
+			return result;
+		},
+		{}
+	);
+}

--- a/client/state/selectors/test/get-jetpack-onboarding-progress.js
+++ b/client/state/selectors/test/get-jetpack-onboarding-progress.js
@@ -7,7 +7,7 @@ import { JETPACK_ONBOARDING_STEPS as STEPS } from 'jetpack-onboarding/constants'
 import { getJetpackOnboardingProgress, isJetpackOnboardingStepCompleted } from 'state/selectors';
 
 describe( 'getJetpackOnboardingProgress()', () => {
-	test( 'should return progress of concrete steps if such are specified', () => {
+	test( 'should return onboading progress for the specified steps', () => {
 		const siteId = 2916284;
 		const state = {
 			jetpackOnboarding: {

--- a/client/state/selectors/test/get-jetpack-onboarding-progress.js
+++ b/client/state/selectors/test/get-jetpack-onboarding-progress.js
@@ -1,42 +1,27 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { invert, mapValues } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { JETPACK_ONBOARDING_STEPS as STEPS } from 'jetpack-onboarding/constants';
 import { getJetpackOnboardingProgress, isJetpackOnboardingStepCompleted } from 'state/selectors';
 
 describe( 'getJetpackOnboardingProgress()', () => {
-	const siteId = 2916284;
-	const state = {
-		jetpackOnboarding: {
-			settings: {
-				[ siteId ]: {},
-			},
-		},
-	};
-
-	test( 'should return progress of all steps if no steps are specified', () => {
-		const steps = invert( STEPS );
-		const expected = mapValues( steps, stepName =>
-			isJetpackOnboardingStepCompleted( state, siteId, stepName )
-		);
-		const progress = getJetpackOnboardingProgress( state, 2916284 );
-		expect( progress ).toEqual( expected );
-	} );
-
 	test( 'should return progress of concrete steps if such are specified', () => {
+		const siteId = 2916284;
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					[ siteId ]: {},
+				},
+			},
+		};
 		const steps = [ [ STEPS.SITE_TITLE ], [ STEPS.SITE_TYPE ] ];
 		const expected = {
 			[ STEPS.SITE_TITLE ]: isJetpackOnboardingStepCompleted( state, siteId, STEPS.SITE_TITLE ),
 			[ STEPS.SITE_TYPE ]: isJetpackOnboardingStepCompleted( state, siteId, STEPS.SITE_TYPE ),
 		};
-		const progress = getJetpackOnboardingProgress( state, 2916284, steps );
+		const progress = getJetpackOnboardingProgress( state, siteId, steps );
 		expect( progress ).toEqual( expected );
 	} );
 } );

--- a/client/state/selectors/test/get-jetpack-onboarding-progress.js
+++ b/client/state/selectors/test/get-jetpack-onboarding-progress.js
@@ -1,0 +1,42 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { invert, mapValues } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { JETPACK_ONBOARDING_STEPS as STEPS } from 'jetpack-onboarding/constants';
+import { getJetpackOnboardingProgress, isJetpackOnboardingStepCompleted } from 'state/selectors';
+
+describe( 'getJetpackOnboardingProgress()', () => {
+	const siteId = 2916284;
+	const state = {
+		jetpackOnboarding: {
+			settings: {
+				[ siteId ]: {},
+			},
+		},
+	};
+
+	test( 'should return progress of all steps if no steps are specified', () => {
+		const steps = invert( STEPS );
+		const expected = mapValues( steps, stepName =>
+			isJetpackOnboardingStepCompleted( state, siteId, stepName )
+		);
+		const progress = getJetpackOnboardingProgress( state, 2916284 );
+		expect( progress ).toEqual( expected );
+	} );
+
+	test( 'should return progress of concrete steps if such are specified', () => {
+		const steps = [ [ STEPS.SITE_TITLE ], [ STEPS.SITE_TYPE ] ];
+		const expected = {
+			[ STEPS.SITE_TITLE ]: isJetpackOnboardingStepCompleted( state, siteId, STEPS.SITE_TITLE ),
+			[ STEPS.SITE_TYPE ]: isJetpackOnboardingStepCompleted( state, siteId, STEPS.SITE_TYPE ),
+		};
+		const progress = getJetpackOnboardingProgress( state, 2916284, steps );
+		expect( progress ).toEqual( expected );
+	} );
+} );


### PR DESCRIPTION
This PR introduces a `getJetpackOnboardingProgress` selector, which is essentially a port of https://github.com/Automattic/wp-calypso/blob/master/client/jetpack-onboarding/steps/summary.jsx#L109

To test:

* Checkout this branch
* Verify all tests pass:

```
npm run test-client client/state/selectors/test/get-jetpack-onboarding-progress.js
```