### PR TITLE
Jetpack Onboarding: Use getJetpackOnboardingProgress selector in Summary

### DIFF
--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
-import { compact, get, map, reduce, without } from 'lodash';
+import { compact, get, map, without } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -17,7 +17,7 @@ import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { getUnconnectedSiteUrl, isJetpackOnboardingStepCompleted } from 'state/selectors';
+import { getJetpackOnboardingProgress, getUnconnectedSiteUrl } from 'state/selectors';
 import {
 	JETPACK_ONBOARDING_STEP_TITLES as STEP_TITLES,
 	JETPACK_ONBOARDING_STEPS as STEPS,
@@ -106,15 +106,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 
 export default connect( ( state, { siteId, steps } ) => {
 	const tasks = compact( [] );
-	const stepsCompleted = reduce(
-		steps,
-		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
-		( result, stepName ) => {
-			result[ stepName ] = isJetpackOnboardingStepCompleted( state, siteId, stepName );
-			return result;
-		},
-		{}
-	);
+	const stepsCompleted = getJetpackOnboardingProgress( state, siteId, steps );
 
 	return {
 		siteUrl: getUnconnectedSiteUrl( state, siteId ),


### PR DESCRIPTION
Updates the Summary step to use the new selector from #21490.

To test:
1. Checkout this branch on your local Calypso.
1. Make sure your JP sandbox is running the latest Jetpack master.
1. Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
1. After you land the JPO flow, skip to the Site Type step and select "Personal"
1. Fill some steps, skip some steps, and reach the Summary step.
1. Verify that the information about step completion is accurate.
1. Go back to the Site Type step and select "Business"
1. Fill some steps, skip some steps, and reach the Summary step.
1. Verify that the information about step completion is accurate.