### PR TITLE
Jetpack connect: Redirect subscribers to WP Admin

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -34,7 +34,7 @@ import NoticeAction from 'components/notice/notice-action';
 import QueryUserConnection from 'components/data/query-user-connection';
 import Spinner from 'components/spinner';
 import userUtilities from 'lib/user/utils';
-import { authQueryPropTypes } from './utils';
+import { authQueryPropTypes, getRoleFromScope } from './utils';
 import { decodeEntities } from 'lib/formatting';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { isRequestingSite, isRequestingSites } from 'state/sites/selectors';
@@ -165,7 +165,7 @@ export class JetpackAuthorize extends Component {
 
 	redirect() {
 		const { isMobileAppFlow, mobileAppRedirect } = this.props;
-		const { from, redirectAfterAuth } = this.props.authQuery;
+		const { from, redirectAfterAuth, scope } = this.props.authQuery;
 
 		if ( isMobileAppFlow ) {
 			debug( `Redirecting to mobile app ${ mobileAppRedirect }` );
@@ -173,7 +173,13 @@ export class JetpackAuthorize extends Component {
 			return;
 		}
 
-		if ( this.isSso() || this.isWoo() || this.isFromJpo() || this.shouldRedirectJetpackStart() ) {
+		if (
+			this.isSso() ||
+			this.isWoo() ||
+			this.isFromJpo() ||
+			this.shouldRedirectJetpackStart() ||
+			getRoleFromScope( scope ) === 'subscriber'
+		) {
 			debug(
 				'Going back to WP Admin.',
 				'Connection initiated via: ',

--- a/client/jetpack-connect/test/utils.js
+++ b/client/jetpack-connect/test/utils.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { addCalypsoEnvQueryArg } from '../utils';
+import { addCalypsoEnvQueryArg, getRoleFromScope } from '../utils';
 
 jest.mock( 'config', () => input => {
 	const lookupTable = {
@@ -20,5 +20,27 @@ describe( 'addCalypsoEnvQueryArg', () => {
 		expect( addCalypsoEnvQueryArg( 'http://example.com' ) ).toBe(
 			'http://example.com/?calypso_env=mocked-test-env-id'
 		);
+	} );
+} );
+
+describe( 'getRoleFromScope', () => {
+	test( 'should return role from scope', () => {
+		const result = getRoleFromScope( 'role:e8ae7346d1a0f800b64e' );
+		expect( result ).toBe( 'role' );
+	} );
+
+	test( 'should return null if no role is found', () => {
+		const result = getRoleFromScope( ':e8ae7346d1a0f800b64e' );
+		expect( result ).toBe( null );
+	} );
+
+	test( 'should return null if no hash is found', () => {
+		const result = getRoleFromScope( 'role' );
+		expect( result ).toBe( null );
+	} );
+
+	test( 'should return null if scope is malformed', () => {
+		const result = getRoleFromScope( 'rolee8ae7346d1a0f800b64e' );
+		expect( result ).toBe( null );
 	} );
 } );

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -60,9 +60,10 @@ export function addCalypsoEnvQueryArg( url ) {
 }
 
 /**
- * Convert a auth query scope to a role
+ * Convert an auth query scope to a role
  *
- * Auth queries include a scope with is `role:hash`
+ * Auth queries include a scope like `role:hash`. This function will attempt to extract the role
+ * when provided with a scope.
  *
  * @param  {string}  scope From authorization query
  * @return {?string}       Role parsed from scope if found

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -2,9 +2,10 @@
 /**
  * External dependencies
  */
-import { addQueryArgs } from 'lib/route';
 import config from 'config';
 import PropTypes from 'prop-types';
+import { addQueryArgs } from 'lib/route';
+import { head, includes, isEmpty, split } from 'lodash';
 
 export function authQueryTransformer( queryObject ) {
 	return {
@@ -56,4 +57,23 @@ export const authQueryPropTypes = PropTypes.shape( {
 
 export function addCalypsoEnvQueryArg( url ) {
 	return addQueryArgs( { calypso_env: config( 'env_id' ) }, url );
+}
+
+/**
+ * Convert a auth query scope to a role
+ *
+ * Auth queries include a scope with is `role:hash`
+ *
+ * @param  {string}  scope From authorization query
+ * @return {?string}       Role parsed from scope if found
+ */
+export function getRoleFromScope( scope ) {
+	if ( ! includes( scope, ':' ) ) {
+		return null;
+	}
+	const role = head( split( scope, ':', 1 ) );
+	if ( ! isEmpty( role ) ) {
+		return role;
+	}
+	return null;
 }


### PR DESCRIPTION
Subscriber sites are not included in a users sites. They cannot operate on sites in Calypso.

After connecting a site as a subscriber, redirect to WP Admin.

Fixes #19469

This works by looking for `subscriber` in the `scope` passed by Jetpack as part of the authorize flow. It includes the role 😀 

https://github.com/Automattic/jetpack/blob/47aac995469c807f65c3b24e152a606925bba206/class.jetpack.php#L4495
https://github.com/Automattic/jetpack/blob/47aac995469c807f65c3b24e152a606925bba206/class.jetpack.php#L4391

## Testing
1. Create a Jetpack site
1. Connect it
1. Add a new subscriber user
1. Connect an unconnected WordPress.com account to the new subscriber account
1. Verify you are redirected to WP Admin after connection.