### PR TITLE
esmodules: Update login/controller

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -38,101 +38,99 @@ const enhanceContextWithLogin = context => {
 	);
 };
 
-export default {
-	// Defining this here so it can be used by both ./index.node.js and ./index.web.js
-	// We cannot export it from either of those (to import it from the other) because of
-	// the way that `server/bundler/loader` expects only a default export and nothing else.
-	lang: `:lang(${ map( config( 'languages' ), 'langSlug' ).join( '|' ) })?`,
+// Defining this here so it can be used by both ./index.node.js and ./index.web.js
+// We cannot export it from either of those (to import it from the other) because of
+// the way that `server/bundler/loader` expects only a default export and nothing else.
+export const lang = `:lang(${ map( config( 'languages' ), 'langSlug' ).join( '|' ) })?`;
 
-	login( context, next ) {
-		const { query: { client_id, redirect_to } } = context;
+export function login( context, next ) {
+	const { query: { client_id, redirect_to } } = context;
 
-		if ( client_id ) {
-			if ( ! redirect_to ) {
-				const error = new Error( 'The `redirect_to` query parameter is missing.' );
-				error.status = 401;
-				return next( error );
-			}
-
-			const parsedRedirectUrl = parseUrl( redirect_to );
-			const redirectQueryString = qs.parse( parsedRedirectUrl.query );
-
-			if ( client_id !== redirectQueryString.client_id ) {
-				recordTracksEvent( 'calypso_login_phishing_attempt', context.query );
-
-				const error = new Error(
-					'The `redirect_to` query parameter is invalid with the given `client_id`.'
-				);
-				error.status = 401;
-				return next( error );
-			}
-
-			context.store
-				.dispatch( fetchOAuth2ClientData( Number( client_id ) ) )
-				.then( () => {
-					enhanceContextWithLogin( context );
-
-					next();
-				} )
-				.catch( error => next( error ) );
-		} else {
-			enhanceContextWithLogin( context );
-
-			next();
+	if ( client_id ) {
+		if ( ! redirect_to ) {
+			const error = new Error( 'The `redirect_to` query parameter is missing.' );
+			error.status = 401;
+			return next( error );
 		}
-	},
 
-	magicLogin( context, next ) {
-		const { path } = context;
+		const parsedRedirectUrl = parseUrl( redirect_to );
+		const redirectQueryString = qs.parse( parsedRedirectUrl.query );
 
-		context.primary = <MagicLogin path={ path } />;
+		if ( client_id !== redirectQueryString.client_id ) {
+			recordTracksEvent( 'calypso_login_phishing_attempt', context.query );
+
+			const error = new Error(
+				'The `redirect_to` query parameter is invalid with the given `client_id`.'
+			);
+			error.status = 401;
+			return next( error );
+		}
+
+		context.store
+			.dispatch( fetchOAuth2ClientData( Number( client_id ) ) )
+			.then( () => {
+				enhanceContextWithLogin( context );
+
+				next();
+			} )
+			.catch( error => next( error ) );
+	} else {
+		enhanceContextWithLogin( context );
 
 		next();
-	},
+	}
+}
 
-	magicLoginUse( context, next ) {
-		/**
-		 * Pull the query arguments out of the URL & into the state.
-		 * It unclutters the address bar & will keep tokens out of tracking pixels.
-		 */
-		if ( context.querystring ) {
-			page.replace( context.pathname, context.query );
+export function magicLogin( context, next ) {
+	const { path } = context;
 
-			return;
-		}
+	context.primary = <MagicLogin path={ path } />;
 
-		const previousQuery = context.state || {};
+	next();
+}
 
-		const { client_id, email, token } = previousQuery;
+export function magicLoginUse( context, next ) {
+	/**
+	 * Pull the query arguments out of the URL & into the state.
+	 * It unclutters the address bar & will keep tokens out of tracking pixels.
+	 */
+	if ( context.querystring ) {
+		page.replace( context.pathname, context.query );
 
-		context.primary = (
-			<HandleEmailedLinkForm clientId={ client_id } emailAddress={ email } token={ token } />
-		);
+		return;
+	}
 
-		next();
-	},
+	const previousQuery = context.state || {};
 
-	redirectDefaultLocale( context, next ) {
-		// only redirect `/log-in/en` to `/log-in`
-		if ( context.pathname !== '/log-in/en' ) {
-			return next();
-		}
+	const { client_id, email, token } = previousQuery;
 
-		// Do not redirect if user bootrapping is disabled
-		if (
-			! getCurrentUser( context.store.getState() ) &&
-			! config.isEnabled( 'wpcom-user-bootstrap' )
-		) {
-			return next();
-		}
+	context.primary = (
+		<HandleEmailedLinkForm clientId={ client_id } emailAddress={ email } token={ token } />
+	);
 
-		// Do not redirect if user is logged in and the locale is different than english
-		// so we force the page to display in english
-		const currentUserLocale = getCurrentUserLocale( context.store.getState() );
-		if ( currentUserLocale && currentUserLocale !== 'en' ) {
-			return next();
-		}
+	next();
+}
 
-		context.redirect( '/log-in' );
-	},
-};
+export function redirectDefaultLocale( context, next ) {
+	// only redirect `/log-in/en` to `/log-in`
+	if ( context.pathname !== '/log-in/en' ) {
+		return next();
+	}
+
+	// Do not redirect if user bootrapping is disabled
+	if (
+		! getCurrentUser( context.store.getState() ) &&
+		! config.isEnabled( 'wpcom-user-bootstrap' )
+	) {
+		return next();
+	}
+
+	// Do not redirect if user is logged in and the locale is different than english
+	// so we force the page to display in english
+	const currentUserLocale = getCurrentUserLocale( context.store.getState() );
+	if ( currentUserLocale && currentUserLocale !== 'en' ) {
+		return next();
+	}
+
+	context.redirect( '/log-in' );
+}


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.