### PR TITLE
Reader: Turn on new post notifications on wpcalypso and horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -92,7 +92,7 @@
 		"reader/conversations": false,
 		"reader/following-intro": true,
 		"reader/nesting-arrow": true,
-		"reader/new-post-notifications": false,
+		"reader/new-post-notifications": true,
 		"reader/related-posts": true,
 		"reader/search": true,
 		"resume-editing": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -109,7 +109,7 @@
 		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/nesting-arrow": true,
-		"reader/new-post-notifications": false,
+		"reader/new-post-notifications": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
 		"reader/search": true,


### PR DESCRIPTION
Turns on the new post notifications popover on wpcalypso and horizon
