### PR TITLE
Store: Disable save button while images are uploading

### DIFF
--- a/client/extensions/woocommerce/app/product-categories/create.js
+++ b/client/extensions/woocommerce/app/product-categories/create.js
@@ -49,6 +49,7 @@ class ProductCategoryCreate extends React.Component {
 
 	state = {
 		busy: false,
+		isUploading: false,
 	};
 
 	componentDidMount() {
@@ -78,6 +79,14 @@ class ProductCategoryCreate extends React.Component {
 		}
 	}
 
+	onUploadStart = () => {
+		this.setState( { isUploading: true } );
+	};
+
+	onUploadFinish = () => {
+		this.setState( { isUploading: false } );
+	};
+
 	onSave = () => {
 		const { site, category, translate } = this.props;
 		this.setState( { busy: true } );
@@ -106,13 +115,14 @@ class ProductCategoryCreate extends React.Component {
 
 	render() {
 		const { site, category, hasEdits, className } = this.props;
-		const { busy } = this.state;
+		const { busy, isUploading } = this.state;
 
 		const saveEnabled =
 			hasEdits &&
 			category &&
 			( category.name && category.name.length ) &&
-			! isNull( category.parent );
+			! isNull( category.parent ) &&
+			! isUploading;
 
 		return (
 			<Main className={ className } wideLayout>
@@ -127,6 +137,8 @@ class ProductCategoryCreate extends React.Component {
 					siteId={ site && site.ID }
 					category={ category || { parent: 0 } }
 					editProductCategory={ this.props.editProductCategory }
+					onUploadStart={ this.onUploadStart }
+					onUploadFinish={ this.onUploadFinish }
 				/>
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -34,6 +34,8 @@ class ProductCategoryForm extends Component {
 			id: PropTypes.isRequired,
 		} ),
 		editProductCategory: PropTypes.func.isRequired,
+		onUploadStart: PropTypes.func,
+		onUploadFinish: PropTypes.func,
 	};
 
 	constructor( props ) {
@@ -131,6 +133,7 @@ class ProductCategoryForm extends Component {
 			transientId: file.ID,
 			isUploading: true,
 		} );
+		this.props.onUploadStart();
 	};
 
 	onUpload = file => {
@@ -208,6 +211,7 @@ class ProductCategoryForm extends Component {
 					onSelect={ this.onSelect }
 					onUpload={ this.onUpload }
 					onError={ this.onError }
+					onFinish={ this.props.onUploadFinish }
 				>
 					{ image }
 				</ProductImageUploader>

--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -34,8 +34,8 @@ class ProductCategoryForm extends Component {
 			id: PropTypes.isRequired,
 		} ),
 		editProductCategory: PropTypes.func.isRequired,
-		onUploadStart: PropTypes.func,
-		onUploadFinish: PropTypes.func,
+		onUploadStart: PropTypes.func.isRequired,
+		onUploadFinish: PropTypes.func.isRequired,
 	};
 
 	constructor( props ) {

--- a/client/extensions/woocommerce/app/product-categories/update.js
+++ b/client/extensions/woocommerce/app/product-categories/update.js
@@ -56,6 +56,7 @@ class ProductCategoryUpdate extends React.Component {
 
 	state = {
 		busy: false,
+		isUploading: false,
 	};
 
 	componentDidMount() {
@@ -88,6 +89,14 @@ class ProductCategoryUpdate extends React.Component {
 			this.props.clearProductCategoryEdits( site.ID );
 		}
 	}
+
+	onUploadStart = () => {
+		this.setState( { isUploading: true } );
+	};
+
+	onUploadFinish = () => {
+		this.setState( { isUploading: false } );
+	};
 
 	onDelete = () => {
 		const { translate, site, category, deleteProductCategory: dispatchDelete } = this.props;
@@ -147,13 +156,14 @@ class ProductCategoryUpdate extends React.Component {
 
 	render() {
 		const { site, category, hasEdits, className } = this.props;
-		const { busy } = this.state;
+		const { busy, isUploading } = this.state;
 
 		const saveEnabled =
 			hasEdits &&
 			category &&
 			( category.name && category.name.length ) &&
-			! isNull( category.parent );
+			! isNull( category.parent ) &&
+			! isUploading;
 
 		return (
 			<Main className={ className } wideLayout>
@@ -169,6 +179,8 @@ class ProductCategoryUpdate extends React.Component {
 					siteId={ site && site.ID }
 					category={ category || {} }
 					editProductCategory={ this.props.editProductCategory }
+					onUploadStart={ this.onUploadStart }
+					onUploadFinish={ this.onUploadFinish }
 				/>
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -65,6 +65,10 @@ class ProductCreate extends React.Component {
 		editProductVariation: PropTypes.func.isRequired,
 	};
 
+	state = {
+		isUploading: [],
+	};
+
 	componentDidMount() {
 		const { product, site } = this.props;
 
@@ -95,6 +99,18 @@ class ProductCreate extends React.Component {
 			this.props.clearProductVariationEdits( site.ID );
 		}
 	}
+
+	onUploadStart = () => {
+		this.setState( prevState => ( {
+			isUploading: [ ...prevState.isUploading, [ true ] ],
+		} ) );
+	};
+
+	onUploadFinish = () => {
+		this.setState( prevState => ( {
+			isUploading: prevState.isUploading.slice( 1 ),
+		} ) );
+	};
 
 	onSave = () => {
 		const { site, product, finishedInitialSetup, translate } = this.props;
@@ -172,7 +188,7 @@ class ProductCreate extends React.Component {
 
 		const isValid = 'undefined' !== site && this.isProductValid();
 		const isBusy = Boolean( actionList ); // If there's an action list present, we're trying to save.
-		const saveEnabled = isValid && ! isBusy;
+		const saveEnabled = isValid && ! isBusy && 0 === this.state.isUploading.length;
 
 		return (
 			<Main className={ className } wideLayout>
@@ -192,6 +208,8 @@ class ProductCreate extends React.Component {
 					editProductCategory={ this.props.editProductCategory }
 					editProductAttribute={ this.props.editProductAttribute }
 					editProductVariation={ this.props.editProductVariation }
+					onUploadStart={ this.onUploadStart }
+					onUploadFinish={ this.onUploadFinish }
 				/>
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -31,6 +31,8 @@ export default class ProductFormDetailsCard extends Component {
 			name: PropTypes.string,
 		} ),
 		editProduct: PropTypes.func.isRequired,
+		onUploadStart: PropTypes.func,
+		onUploadFinish: PropTypes.func,
 	};
 
 	constructor( props ) {
@@ -130,6 +132,8 @@ export default class ProductFormDetailsCard extends Component {
 						images={ images }
 						onUpload={ this.onImageUpload }
 						onRemove={ this.onImageRemove }
+						onUploadStart={ this.props.onUploadStart }
+						onUploadFinish={ this.props.onUploadFinish }
 					/>
 					<div className="products__product-form-details-basic">
 						<FormFieldSet className="products__product-form-details-basic-name">

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -30,6 +30,8 @@ class ProductFormImages extends Component {
 		),
 		onUpload: PropTypes.func.isRequired,
 		onRemove: PropTypes.func.isRequired,
+		onUploadStart: PropTypes.func,
+		onUploadFinish: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -84,6 +86,7 @@ class ProductFormImages extends Component {
 				id: null,
 			};
 		} );
+		this.props.onUploadStart();
 		this.setState( {
 			images: [ ...images, ...newImages ],
 		} );
@@ -183,6 +186,7 @@ class ProductFormImages extends Component {
 							onUpload={ this.onUpload }
 							onError={ this.onError }
 							compact={ this.state.images.length > 0 }
+							onFinish={ this.props.onUploadFinish }
 						/>
 					</div>
 				</div>

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -30,8 +30,8 @@ class ProductFormImages extends Component {
 		),
 		onUpload: PropTypes.func.isRequired,
 		onRemove: PropTypes.func.isRequired,
-		onUploadStart: PropTypes.func,
-		onUploadFinish: PropTypes.func,
+		onUploadStart: PropTypes.func.isRequired,
+		onUploadFinish: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {

--- a/client/extensions/woocommerce/app/products/product-form-variations-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-card.js
@@ -33,6 +33,8 @@ class ProductFormVariationsCard extends Component {
 		editProduct: PropTypes.func.isRequired,
 		editProductAttribute: PropTypes.func.isRequired,
 		editProductVariation: PropTypes.func.isRequired,
+		onUploadStart: PropTypes.func,
+		onUploadFinish: PropTypes.func,
 	};
 
 	simpleFields = [
@@ -144,6 +146,8 @@ class ProductFormVariationsCard extends Component {
 							product={ product }
 							variations={ variations }
 							editProductVariation={ editProductVariation }
+							onUploadStart={ this.props.onUploadStart }
+							onUploadFinish={ this.props.onUploadFinish }
 						/>
 					</div>
 				) }

--- a/client/extensions/woocommerce/app/products/product-form-variations-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-card.js
@@ -33,8 +33,8 @@ class ProductFormVariationsCard extends Component {
 		editProduct: PropTypes.func.isRequired,
 		editProductAttribute: PropTypes.func.isRequired,
 		editProductVariation: PropTypes.func.isRequired,
-		onUploadStart: PropTypes.func,
-		onUploadFinish: PropTypes.func,
+		onUploadStart: PropTypes.func.isRequired,
+		onUploadFinish: PropTypes.func.isRequired,
 	};
 
 	simpleFields = [

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -32,6 +32,8 @@ class ProductFormVariationsRow extends Component {
 		manageStock: PropTypes.bool,
 		onShowDialog: PropTypes.func,
 		editProductVariation: PropTypes.func.isRequired,
+		onUploadStart: PropTypes.func,
+		onUploadFinish: PropTypes.func,
 	};
 
 	constructor( props ) {
@@ -84,6 +86,7 @@ class ProductFormVariationsRow extends Component {
 			transientId: file.ID,
 			isUploading: true,
 		} );
+		this.props.onUploadStart();
 	};
 
 	onUpload = file => {
@@ -169,6 +172,7 @@ class ProductFormVariationsRow extends Component {
 					onSelect={ this.onSelect }
 					onUpload={ this.onUpload }
 					onError={ this.onError }
+					onFinish={ this.props.onUploadFinish }
 				>
 					{ image }
 				</ProductImageUploader>

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -32,8 +32,8 @@ class ProductFormVariationsRow extends Component {
 		manageStock: PropTypes.bool,
 		onShowDialog: PropTypes.func,
 		editProductVariation: PropTypes.func.isRequired,
-		onUploadStart: PropTypes.func,
-		onUploadFinish: PropTypes.func,
+		onUploadStart: PropTypes.func.isRequired,
+		onUploadFinish: PropTypes.func.isRequired,
 	};
 
 	constructor( props ) {

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -26,6 +26,8 @@ class ProductFormVariationsTable extends React.Component {
 		variations: PropTypes.array,
 		product: PropTypes.object,
 		editProductVariation: PropTypes.func.isRequired,
+		onUploadStart: PropTypes.func,
+		onUploadFinish: PropTypes.func,
 	};
 
 	constructor( props ) {
@@ -125,6 +127,8 @@ class ProductFormVariationsTable extends React.Component {
 				manageStock={ manageStock }
 				editProductVariation={ editProductVariation }
 				onShowDialog={ this.onShowDialog }
+				onUploadStart={ this.props.onUploadStart }
+				onUploadFinish={ this.props.onUploadFinish }
 			/>
 		);
 	};

--- a/client/extensions/woocommerce/app/products/product-form-variations-table.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-table.js
@@ -26,8 +26,8 @@ class ProductFormVariationsTable extends React.Component {
 		variations: PropTypes.array,
 		product: PropTypes.object,
 		editProductVariation: PropTypes.func.isRequired,
-		onUploadStart: PropTypes.func,
-		onUploadFinish: PropTypes.func,
+		onUploadStart: PropTypes.func.isRequired,
+		onUploadFinish: PropTypes.func.isRequired,
 	};
 
 	constructor( props ) {

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -32,6 +32,8 @@ export default class ProductForm extends Component {
 		editProductCategory: PropTypes.func.isRequired,
 		editProductAttribute: PropTypes.func.isRequired,
 		editProductVariation: PropTypes.func.isRequired,
+		onUploadStart: PropTypes.func,
+		onUploadFinish: PropTypes.func,
 	};
 
 	renderPlaceholder() {
@@ -61,7 +63,13 @@ export default class ProductForm extends Component {
 
 		return (
 			<div className={ classNames( 'products__form', this.props.className ) }>
-				<ProductFormDetailsCard siteId={ siteId } product={ product } editProduct={ editProduct } />
+				<ProductFormDetailsCard
+					siteId={ siteId }
+					product={ product }
+					editProduct={ editProduct }
+					onUploadStart={ this.props.onUploadStart }
+					onUploadFinish={ this.props.onUploadFinish }
+				/>
 				<ProductFormAdditionalDetailsCard
 					siteId={ siteId }
 					product={ product }
@@ -83,6 +91,8 @@ export default class ProductForm extends Component {
 					editProductCategory={ editProductCategory }
 					editProductAttribute={ editProductAttribute }
 					editProductVariation={ editProductVariation }
+					onUploadStart={ this.props.onUploadStart }
+					onUploadFinish={ this.props.onUploadFinish }
 				/>
 
 				{ 'simple' === type && (

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -32,8 +32,8 @@ export default class ProductForm extends Component {
 		editProductCategory: PropTypes.func.isRequired,
 		editProductAttribute: PropTypes.func.isRequired,
 		editProductVariation: PropTypes.func.isRequired,
-		onUploadStart: PropTypes.func,
-		onUploadFinish: PropTypes.func,
+		onUploadStart: PropTypes.func.isRequired,
+		onUploadFinish: PropTypes.func.isRequired,
 	};
 
 	renderPlaceholder() {

--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -69,6 +69,10 @@ class ProductUpdate extends React.Component {
 		editProductVariation: PropTypes.func.isRequired,
 	};
 
+	state = {
+		isUploading: [],
+	};
+
 	componentDidMount() {
 		const { params, product, site, variations } = this.props;
 		const productId = Number( params.product );
@@ -107,6 +111,18 @@ class ProductUpdate extends React.Component {
 			this.props.clearProductVariationEdits( site.ID );
 		}
 	}
+
+	onUploadStart = () => {
+		this.setState( prevState => ( {
+			isUploading: [ ...prevState.isUploading, [ true ] ],
+		} ) );
+	};
+
+	onUploadFinish = () => {
+		this.setState( prevState => ( {
+			isUploading: prevState.isUploading.slice( 1 ),
+		} ) );
+	};
 
 	// TODO: In v1, this deletes a product, as we don't have trash management.
 	// Once we have trashing management, we can introduce 'trash' instead.
@@ -184,7 +200,7 @@ class ProductUpdate extends React.Component {
 
 		const isValid = 'undefined' !== site && this.isProductValid();
 		const isBusy = Boolean( actionList ); // If there's an action list present, we're trying to save.
-		const saveEnabled = isValid && ! isBusy && hasEdits;
+		const saveEnabled = isValid && ! isBusy && hasEdits && 0 === this.state.isUploading.length;
 
 		return (
 			<Main className={ className } wideLayout>
@@ -207,6 +223,8 @@ class ProductUpdate extends React.Component {
 					editProductCategory={ this.props.editProductCategory }
 					editProductAttribute={ this.props.editProductAttribute }
 					editProductVariation={ this.props.editProductVariation }
+					onUploadStart={ this.onUploadStart }
+					onUploadFinish={ this.onUploadFinish }
 				/>
 			</Main>
 		);

--- a/client/extensions/woocommerce/components/product-image-uploader/index.js
+++ b/client/extensions/woocommerce/components/product-image-uploader/index.js
@@ -51,6 +51,13 @@ class ProductImageUploader extends Component {
 		errors: [],
 	};
 
+	componentWillMount() {
+		this._isMounted = true;
+	}
+	componentWillUnmount() {
+		this._isMounted = false;
+	}
+
 	showError = ( media, transientId ) => {
 		const { onError, errorNotice, translate } = this.props;
 		const { errors } = this.state;
@@ -159,6 +166,12 @@ class ProductImageUploader extends Component {
 
 			// File has finished uploading or failed.
 			if ( ! isUploadInProgress ) {
+				// Stop uploading and don't push events if they navigated away
+				if ( ! this._isMounted ) {
+					MediaStore.off( 'change', handleUpload );
+					return;
+				}
+
 				if ( media ) {
 					const file = find( filesToUpload, f => f.ID === transientId );
 					if ( media.URL ) {


### PR DESCRIPTION
Fixes #21474.

This PR disables the save button on both the product categories form and the product form. It also fixes the warning that can occur if you navigate away when an upload is in process.

For products, since there can be any number of image upload components (one per variation, and the parent) -- I track an array of uploads in progress and when all of them are removed, this save button is re-enabled. For product categories, this logic is a bit simpler since you can only have one image.

I'm hoping some of this is temporary and we can work on integrating the Calypso media modal experience instead in the future (#21302), but this helps fix a few buglets.

To Test:
* Go to the product category add new form and type in a title. Make sure that the save button becomes active. Upload an image and watch the button deactivate while the upload is in process, and reactivate again once it's done.
* Start another upload and then navigate away to the category listing page. Wait a few moments and verify that the warning mentioned in #21474 doesn't occur.
* Repeat step 1 in the edit context.
* Go to products add screen, add a title, and upload an image or two and verify the button updates correctly.
* Create two variations and upload an image for each and verify the button state.
* Repeat the above product steps in the edit context.