### PR TITLE
esmodules: Update lib/url/support

### DIFF
--- a/client/account-recovery/lost-password-form/index.jsx
+++ b/client/account-recovery/lost-password-form/index.jsx
@@ -12,7 +12,7 @@ import { identity, noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import support from 'lib/url/support';
+import { ACCOUNT_RECOVERY } from 'lib/url/support';
 import Card from 'components/card';
 import FormButton from 'components/button';
 import FormLabel from 'components/forms/form-label';
@@ -73,7 +73,7 @@ export class LostPasswordFormComponent extends Component {
 					<p>
 						{ translate(
 							'Want more help? We have a full {{link}}guide to resetting your password{{/link}}.',
-							{ components: { link: <a href={ support.ACCOUNT_RECOVERY } /> } }
+							{ components: { link: <a href={ ACCOUNT_RECOVERY } /> } }
 						) }
 					</p>
 				</Card>

--- a/client/account-recovery/reset-password/transaction-id-form/index.jsx
+++ b/client/account-recovery/reset-password/transaction-id-form/index.jsx
@@ -11,7 +11,7 @@ import { identity } from 'lodash';
 /**
  * Internal dependencies
  */
-import support from 'lib/url/support';
+import { ACCOUNT_RECOVERY } from 'lib/url/support';
 import Card from 'components/card';
 import Button from 'components/button';
 import FormLabel from 'components/forms/form-label';
@@ -52,7 +52,7 @@ export class TransactionIdFormComponent extends Component {
 						{
 							components: {
 								strong: <strong />,
-								helpLink: <a href={ support.ACCOUNT_RECOVERY } />,
+								helpLink: <a href={ ACCOUNT_RECOVERY } />,
 							},
 						}
 					) }
@@ -66,7 +66,7 @@ export class TransactionIdFormComponent extends Component {
 								'{{helpLink}}Need help to find your transaction id?{{/helpLink}}',
 							{
 								components: {
-									helpLink: <a href={ support.ACCOUNT_RECOVERY } />,
+									helpLink: <a href={ ACCOUNT_RECOVERY } />,
 								},
 							}
 						) }

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -22,7 +22,7 @@ import notices from 'notices';
 import { validateCardDetails } from 'lib/credit-card-details';
 import ValidationErrorList from 'notices/validation-error-list';
 import wpcomFactory from 'lib/wp';
-import support from 'lib/url/support';
+import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'lib/url/support';
 
 const wpcom = wpcomFactory.undocumented();
 
@@ -289,14 +289,10 @@ const CreditCardForm = createReactClass( {
 											<a href="//wordpress.com/tos/" target="_blank" rel="noopener noreferrer" />
 										),
 										autoRenewalSupportPage: (
-											<a href={ support.AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
+											<a href={ AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
 										),
 										managePurchasesSupportPage: (
-											<a
-												href={ support.MANAGE_PURCHASES }
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
+											<a href={ MANAGE_PURCHASES } target="_blank" rel="noopener noreferrer" />
 										),
 									},
 								}

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -26,7 +26,7 @@ import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/an
 import { getSelectedSite } from 'state/ui/selectors';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import TransferDomainPrecheck from './transfer-domain-precheck';
-import support from 'lib/url/support';
+import { INCOMING_DOMAIN_TRANSFER, MAP_EXISTING_DOMAIN } from 'lib/url/support';
 import HeaderCake from 'components/header-cake';
 import Button from 'components/button';
 
@@ -132,7 +132,7 @@ class TransferDomainStep extends React.Component {
 									components: {
 										a: (
 											<a
-												href={ support.INCOMING_DOMAIN_TRANSFER }
+												href={ INCOMING_DOMAIN_TRANSFER }
 												rel="noopener noreferrer"
 												target="_blank"
 											/>
@@ -179,7 +179,7 @@ class TransferDomainStep extends React.Component {
 						) }
 						<a
 							className="transfer-domain-step__map-help"
-							href={ support.MAP_EXISTING_DOMAIN }
+							href={ MAP_EXISTING_DOMAIN }
 							rel="noopener noreferrer"
 							target="_blank"
 						>

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -20,7 +20,12 @@ import Notice from 'components/notice';
 import { recordTracksEvent } from 'state/analytics/actions';
 import FormattedHeader from 'components/formatted-header';
 import { checkInboundTransferStatus } from 'lib/domains';
-import support from 'lib/url/support';
+import {
+	CALYPSO_CONTACT,
+	INCOMING_DOMAIN_TRANSFER_PREPARE_AUTH_CODE,
+	INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY,
+	INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK,
+} from 'lib/url/support';
 import TransferRestrictionMessage from 'components/domains/transfer-domain-step/transfer-restriction-message';
 
 class TransferDomainPrecheck extends React.PureComponent {
@@ -197,7 +202,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 					br: <br />,
 					a: (
 						<a
-							href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK }
+							href={ INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK }
 							rel="noopener noreferrer"
 							target="_blank"
 						/>
@@ -217,7 +222,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 					components: {
 						a: (
 							<a
-								href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK }
+								href={ INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK }
 								rel="noopener noreferrer"
 								target="_blank"
 							/>
@@ -288,7 +293,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 					br: <br />,
 					a: (
 						<a
-							href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY }
+							href={ INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY }
 							rel="noopener noreferrer"
 							target="_blank"
 						/>
@@ -318,7 +323,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 						strong: <strong className="transfer-domain-step__admin-email" />,
 						a: (
 							<a
-								href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY }
+								href={ INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY }
 								rel="noopener noreferrer"
 								target="_blank"
 							/>
@@ -347,7 +352,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 						strong: <strong className="transfer-domain-step__admin-email" />,
 						a: (
 							<a
-								href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY }
+								href={ INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY }
 								rel="noopener noreferrer"
 								target="_blank"
 							/>
@@ -388,7 +393,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 				components: {
 					a: (
 						<a
-							href={ support.INCOMING_DOMAIN_TRANSFER_PREPARE_AUTH_CODE }
+							href={ INCOMING_DOMAIN_TRANSFER_PREPARE_AUTH_CODE }
 							rel="noopener noreferrer"
 							target="_blank"
 						/>
@@ -445,13 +450,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 									'Need help? {{a}}Get in touch with one of our Happiness Engineers{{/a}}.',
 								{
 									components: {
-										a: (
-											<a
-												href={ support.CALYPSO_CONTACT }
-												rel="noopener noreferrer"
-												target="_blank"
-											/>
-										),
+										a: <a href={ CALYPSO_CONTACT } rel="noopener noreferrer" target="_blank" />,
 									},
 								}
 							) }

--- a/client/components/domains/transfer-domain-step/transfer-restriction-message.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-restriction-message.jsx
@@ -14,7 +14,7 @@ import page from 'page';
 import Button from 'components/button';
 import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
-import support from 'lib/url/support';
+import { MAP_EXISTING_DOMAIN } from 'lib/url/support';
 import paths from 'my-sites/domains/paths';
 
 class TransferRestrictionMessage extends React.PureComponent {
@@ -62,7 +62,7 @@ class TransferRestrictionMessage extends React.PureComponent {
 				'{{a}}Learn how{{/a}}.',
 			{
 				components: {
-					a: <a href={ support.MAP_EXISTING_DOMAIN } rel="noopener noreferrer" target="_blank" />,
+					a: <a href={ MAP_EXISTING_DOMAIN } rel="noopener noreferrer" target="_blank" />,
 				},
 			}
 		);

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -15,7 +15,12 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
-import support from 'lib/url/support';
+import {
+	CALYPSO_CONTACT,
+	JETPACK_CONTACT_SUPPORT,
+	JETPACK_SUPPORT,
+	SUPPORT_ROOT,
+} from 'lib/url/support';
 import HappychatButton from 'components/happychat/button';
 import HappychatConnection from 'components/happychat/connection-connected';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -86,11 +91,11 @@ export class HappinessSupport extends Component {
 	}
 
 	renderContactButton() {
-		let url = support.CALYPSO_CONTACT,
+		let url = CALYPSO_CONTACT,
 			target = '';
 
 		if ( this.props.isJetpack ) {
-			url = support.JETPACK_CONTACT_SUPPORT;
+			url = JETPACK_CONTACT_SUPPORT;
 			target = '_blank';
 		}
 
@@ -122,10 +127,10 @@ export class HappinessSupport extends Component {
 	}
 
 	renderSupportButton() {
-		let url = support.SUPPORT_ROOT;
+		let url = SUPPORT_ROOT;
 
 		if ( this.props.isJetpack ) {
-			url = support.JETPACK_SUPPORT;
+			url = JETPACK_SUPPORT;
 		}
 
 		return (

--- a/client/components/happiness-support/test/index.jsx
+++ b/client/components/happiness-support/test/index.jsx
@@ -14,7 +14,12 @@ import { spy } from 'sinon';
 import { HappinessSupport } from '..';
 import HappychatButton from 'components/happychat/button';
 import HappychatConnection from 'components/happychat/connection-connected';
-import support from 'lib/url/support';
+import {
+	CALYPSO_CONTACT,
+	JETPACK_CONTACT_SUPPORT,
+	JETPACK_SUPPORT,
+	SUPPORT_ROOT,
+} from 'lib/url/support';
 
 describe( 'HappinessSupport', () => {
 	let wrapper;
@@ -51,7 +56,7 @@ describe( 'HappinessSupport', () => {
 			<HappinessSupport translate={ translate } recordTracksEvent={ noop } isJetpack={ false } />
 		);
 		expect( wrapper.find( 'Button.happiness-support__support-button' ).props().href ).to.equal(
-			support.SUPPORT_ROOT
+			SUPPORT_ROOT
 		);
 	} );
 
@@ -64,7 +69,7 @@ describe( 'HappinessSupport', () => {
 				.find( 'Button' )
 				.last()
 				.prop( 'href' )
-		).to.equal( support.JETPACK_SUPPORT );
+		).to.equal( JETPACK_SUPPORT );
 	} );
 
 	test( 'should have is-placeholder className only if it is a placeholder', () => {
@@ -213,12 +218,12 @@ describe( 'HappinessSupport', () => {
 
 		test( 'should be rendered with link to CALYPSO_CONTACT if it is not for JetPack', () => {
 			wrapper = shallow( <HappinessSupport { ...props } /> );
-			expect( wrapper.find( selector ).prop( 'href' ) ).to.equal( support.CALYPSO_CONTACT );
+			expect( wrapper.find( selector ).prop( 'href' ) ).to.equal( CALYPSO_CONTACT );
 		} );
 
 		test( 'should be rendered with link to JETPACK_CONTACT_SUPPORT if it is for JetPack', () => {
 			wrapper = shallow( <HappinessSupport { ...props } isJetpack={ true } /> );
-			expect( wrapper.find( selector ).prop( 'href' ) ).to.equal( support.JETPACK_CONTACT_SUPPORT );
+			expect( wrapper.find( selector ).prop( 'href' ) ).to.equal( JETPACK_CONTACT_SUPPORT );
 		} );
 
 		test( 'should render translated content', () => {

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -10,7 +10,11 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { getTld } from 'lib/domains';
-import support from 'lib/url/support';
+import {
+	CALYPSO_CONTACT,
+	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS,
+	MAP_EXISTING_DOMAIN,
+} from 'lib/url/support';
 import { domainAvailability } from 'lib/domains/constants';
 import {
 	domainManagementTransferToOtherSite,
@@ -92,7 +96,7 @@ function getAvailabilityNotice( domain, error, site ) {
 					args: { domain, site },
 					components: {
 						strong: <strong />,
-						a: <a rel="noopener noreferrer" href={ support.CALYPSO_CONTACT } />,
+						a: <a rel="noopener noreferrer" href={ CALYPSO_CONTACT } />,
 					},
 				}
 			);
@@ -118,10 +122,7 @@ function getAvailabilityNotice( domain, error, site ) {
 					components: {
 						strong: <strong />,
 						a: (
-							<a
-								rel="noopener noreferrer"
-								href={ support.INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
-							/>
+							<a rel="noopener noreferrer" href={ INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS } />
 						),
 					},
 				}
@@ -136,7 +137,7 @@ function getAvailabilityNotice( domain, error, site ) {
 						args: { tld },
 						components: {
 							strong: <strong />,
-							a: <a rel="noopener noreferrer" href={ support.MAP_EXISTING_DOMAIN } />,
+							a: <a rel="noopener noreferrer" href={ MAP_EXISTING_DOMAIN } />,
 						},
 					}
 				);
@@ -183,7 +184,7 @@ function getAvailabilityNotice( domain, error, site ) {
 									href="http://wordpressfoundation.org/trademark-policy/"
 								/>
 							),
-							a2: <a href={ support.CALYPSO_CONTACT } />,
+							a2: <a href={ CALYPSO_CONTACT } />,
 						},
 					}
 				);

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -1,90 +1,88 @@
 /** @format */
 const root = 'https://support.wordpress.com';
 
-export default {
-	ACCOUNT_RECOVERY: `${ root }/account-recovery`,
-	ADDING_GOOGLE_APPS_TO_YOUR_SITE: `${ root }/adding-g-suite-to-your-site`,
-	ADDING_USERS: `${ root }/adding-users`,
-	ALL_ABOUT_DOMAINS: `${ root }/all-about-domains`,
-	AUTO_RENEWAL: `${ root }/auto-renewal`,
-	BANDPAGE_WIDGET: `${ root }/widgets/bandpage-widget`,
-	CATEGORIES_VS_TAGS: `${ root }/posts/categories-vs-tags`,
-	CHANGE_NAME_SERVERS: `${ root }/domains/change-name-servers`,
-	CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS: `${ root }/domains/change-name-servers/#finding-out-your-new-name-server`,
-	COMMENTS: `${ root }/category/comments`,
-	COMMUNITY_TRANSLATOR: `${ root }/community-translator`,
-	COMPLETING_GOOGLE_APPS_SIGNUP: `${ root }/adding-g-suite-to-your-site/#completing-sign-up`,
-	CONCIERGE_SUPPORT: `${ root }/concierge-support`,
-	CONNECT: `${ root }/connect`,
-	CONTACT: `${ root }/contact`,
-	CALYPSO_CONTACT: '/help/contact',
-	CALYPSO_COURSES: '/help/courses',
-	CREATE: `${ root }/create`,
-	CUSTOM_DNS: `${ root }/domains/custom-dns`,
-	DESIGNATED_AGENT: `${ root }/designated-agent/`,
-	DOMAIN_HELPER_PREFIX: `${ root }/domain-helper/?host=`,
-	DOMAIN_REGISTRATION_AGREEMENTS: `${ root }/domain-registration-agreements/`,
-	DOMAINS: `${ root }/domains`,
-	INCOMING_DOMAIN_TRANSFER_STATUSES_PENDING_CONFIRMATION: `${ root }/incoming-domain-transfer/status-and-failed-transfers/#confirmation`,
-	INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS: `${ root }/incoming-domain-transfer/status-and-failed-transfers/#pending`,
-	INCOMING_DOMAIN_TRANSFER_STATUSES_FAILED: `${ root }/incoming-domain-transfer/status-and-failed-transfers/#failed`,
-	INCOMING_DOMAIN_TRANSFER_STATUSES_CANCEL: `${ root }/incoming-domain-transfer/status-and-failed-transfers/#cancel`,
-	INCOMING_DOMAIN_TRANSFER: `${ root }/incoming-domain-transfer/`,
-	INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK: `${ root }/incoming-domain-transfer/prepare-domain-for-transfer/#unlock`,
-	INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY: `${ root }/incoming-domain-transfer/prepare-domain-for-transfer/#privacy`,
-	INCOMING_DOMAIN_TRANSFER_PREPARE_AUTH_CODE: `${ root }/incoming-domain-transfer/prepare-domain-for-transfer/#auth-code`,
-	EMAIL_FORWARDING: `${ root }/email-forwarding`,
-	EMAIL_VALIDATION_AND_VERIFICATION: `${ root }/domains/register-domain/#email-validation-and-verification`,
-	EMPTY_SITE: `${ root }/empty-site/`,
-	ENABLE_DISABLE_COMMENTS: `${ root }/enable-disable-comments`,
-	EVENTBRITE: `${ root }/eventbrite`,
-	EVENTBRITE_EVENT_CALENDARLISTING_WIDGET: `${ root }/widgets/eventbrite-event-calendarlisting-widget`,
-	EXPORT: `${ root }/export`,
-	FACEBOOK_EMBEDS: `${ root }/facebook-integration/facebook-embeds`,
-	FACEBOOK_LIKE_BOX: `${ root }/facebook-integration/#facebook-like-box`,
-	FOLLOWERS: `${ root }/followers`,
-	GETTING_MORE_VIEWS_AND_TRAFFIC: `${ root }/getting-more-views-and-traffic`,
-	GOOGLE_ANALYTICS: `${ root }/google-analytics`,
-	GOOGLE_APPS_LEARNING_CENTER: 'https://gsuite.google.com/learning-center/',
-	GOOGLE_PLUS_EMBEDS: `${ root }/google-plus-embeds`,
-	GRAVATAR_HOVERCARDS: `${ root }/gravatar-hovercards`,
-	GUIDED_TRANSFER: `${ root }/guided-transfer`,
-	IMPORT: `${ root }/import`,
-	INSTAGRAM_WIDGET: `${ root }/instagram/instagram-widget`,
-	JETPACK_SUPPORT: 'https://jetpack.com/support/',
-	JETPACK_CONTACT_SUPPORT: 'https://jetpack.com/contact-support/?rel=support',
-	JETPACK_SERVICE_VAULTPRESS: 'https://help.vaultpress.com/',
-	JETPACK_SERVICE_AKISMET: 'https://akismet.com/support/',
-	JETPACK_SERVICE_POLLDADDY: 'https://support.polldaddy.com/',
-	LIVE_CHAT: `${ root }/live-chat`,
-	MANAGE_PURCHASES: `${ root }/manage-purchases`,
-	MAP_EXISTING_DOMAIN: `${ root }/domains/map-existing-domain`,
-	MAP_EXISTING_DOMAIN_UPDATE_DNS: `${ root }/domains/map-existing-domain#2-ask-your-domain-provider-to-update-your-dns-settings`,
-	MAP_SUBDOMAIN: `${ root }/domains/map-subdomain`,
-	MEDIA: `${ root }/media`,
-	PUBLICIZE: `${ root }/publicize`,
-	PUBLIC_VS_PRIVATE: `${ root }/domains/register-domain/#public-versus-private`,
-	REFUNDS: `${ root }/refunds`,
-	REGISTER_DOMAIN: `${ root }/domains/register-domain/`,
-	SEO_TAGS: `${ root }/getting-more-views-and-traffic/#use-appropriate-tags`,
-	SETTING_PRIMARY_DOMAIN: `${ root }/domains/#setting-the-primary-domain`,
-	SETTING_UP_PREMIUM_SERVICES: `${ root }/setting-up-premium-services`,
-	STRONG_PASSWORD: `${ root }/selecting-a-strong-password/`,
-	SHARING: `${ root }/sharing`,
-	START: `${ root }/start`,
-	STATS_CLICKS: `${ root }/stats/#clicks`,
-	STATS_REFERRERS: `${ root }/stats/#referrers`,
-	STATS_SEO_TERMS: `${ root }/stats/#search-engine-terms`,
-	STATS_SPAM_REFERRER: `${ root }/stats/#marking-spam-referrers`,
-	STATS_TOP_POSTS_PAGES: `${ root }/stats/#top-posts-pages`,
-	STATS_VIEWS_BY_COUNTRY: `${ root }/stats/#views-by-country`,
-	SUPPORT_ROOT: `${ root }/`,
-	TRANSFER_DOMAIN_REGISTRATION: `${ root }/transfer-domain-registration`,
-	TWITTER_TIMELINE_WIDGET: `${ root }/widgets/twitter-timeline-widget`,
-	UPDATE_CONTACT_INFORMATION: `${ root }/update-contact-information/`,
-	UPDATE_NAMESERVERS: `${ root }/domains/domain-management/#update-nameservers`,
-	USERS: `${ root }/category/users`,
-	USER_ROLES: `${ root }/user-roles`,
-	VIDEOS: `${ root }/videos`,
-	WPCC: `${ root }/wpcc-faq`,
-};
+export const ACCOUNT_RECOVERY = `${ root }/account-recovery`;
+export const ADDING_GOOGLE_APPS_TO_YOUR_SITE = `${ root }/adding-g-suite-to-your-site`;
+export const ADDING_USERS = `${ root }/adding-users`;
+export const ALL_ABOUT_DOMAINS = `${ root }/all-about-domains`;
+export const AUTO_RENEWAL = `${ root }/auto-renewal`;
+export const BANDPAGE_WIDGET = `${ root }/widgets/bandpage-widget`;
+export const CATEGORIES_VS_TAGS = `${ root }/posts/categories-vs-tags`;
+export const CHANGE_NAME_SERVERS = `${ root }/domains/change-name-servers`;
+export const CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS = `${ root }/domains/change-name-servers/#finding-out-your-new-name-server`;
+export const COMMENTS = `${ root }/category/comments`;
+export const COMMUNITY_TRANSLATOR = `${ root }/community-translator`;
+export const COMPLETING_GOOGLE_APPS_SIGNUP = `${ root }/adding-g-suite-to-your-site/#completing-sign-up`;
+export const CONCIERGE_SUPPORT = `${ root }/concierge-support`;
+export const CONNECT = `${ root }/connect`;
+export const CONTACT = `${ root }/contact`;
+export const CALYPSO_CONTACT = '/help/contact';
+export const CALYPSO_COURSES = '/help/courses';
+export const CREATE = `${ root }/create`;
+export const CUSTOM_DNS = `${ root }/domains/custom-dns`;
+export const DESIGNATED_AGENT = `${ root }/designated-agent/`;
+export const DOMAIN_HELPER_PREFIX = `${ root }/domain-helper/?host=`;
+export const DOMAIN_REGISTRATION_AGREEMENTS = `${ root }/domain-registration-agreements/`;
+export const DOMAINS = `${ root }/domains`;
+export const INCOMING_DOMAIN_TRANSFER_STATUSES_PENDING_CONFIRMATION = `${ root }/incoming-domain-transfer/status-and-failed-transfers/#confirmation`; // eslint-disable-line max-len
+export const INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS = `${ root }/incoming-domain-transfer/status-and-failed-transfers/#pending`;
+export const INCOMING_DOMAIN_TRANSFER_STATUSES_FAILED = `${ root }/incoming-domain-transfer/status-and-failed-transfers/#failed`;
+export const INCOMING_DOMAIN_TRANSFER_STATUSES_CANCEL = `${ root }/incoming-domain-transfer/status-and-failed-transfers/#cancel`;
+export const INCOMING_DOMAIN_TRANSFER = `${ root }/incoming-domain-transfer/`;
+export const INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK = `${ root }/incoming-domain-transfer/prepare-domain-for-transfer/#unlock`;
+export const INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY = `${ root }/incoming-domain-transfer/prepare-domain-for-transfer/#privacy`;
+export const INCOMING_DOMAIN_TRANSFER_PREPARE_AUTH_CODE = `${ root }/incoming-domain-transfer/prepare-domain-for-transfer/#auth-code`;
+export const EMAIL_FORWARDING = `${ root }/email-forwarding`;
+export const EMAIL_VALIDATION_AND_VERIFICATION = `${ root }/domains/register-domain/#email-validation-and-verification`;
+export const EMPTY_SITE = `${ root }/empty-site/`;
+export const ENABLE_DISABLE_COMMENTS = `${ root }/enable-disable-comments`;
+export const EVENTBRITE = `${ root }/eventbrite`;
+export const EVENTBRITE_EVENT_CALENDARLISTING_WIDGET = `${ root }/widgets/eventbrite-event-calendarlisting-widget`;
+export const EXPORT = `${ root }/export`;
+export const FACEBOOK_EMBEDS = `${ root }/facebook-integration/facebook-embeds`;
+export const FACEBOOK_LIKE_BOX = `${ root }/facebook-integration/#facebook-like-box`;
+export const FOLLOWERS = `${ root }/followers`;
+export const GETTING_MORE_VIEWS_AND_TRAFFIC = `${ root }/getting-more-views-and-traffic`;
+export const GOOGLE_ANALYTICS = `${ root }/google-analytics`;
+export const GOOGLE_APPS_LEARNING_CENTER = 'https://gsuite.google.com/learning-center/';
+export const GOOGLE_PLUS_EMBEDS = `${ root }/google-plus-embeds`;
+export const GRAVATAR_HOVERCARDS = `${ root }/gravatar-hovercards`;
+export const GUIDED_TRANSFER = `${ root }/guided-transfer`;
+export const IMPORT = `${ root }/import`;
+export const INSTAGRAM_WIDGET = `${ root }/instagram/instagram-widget`;
+export const JETPACK_SUPPORT = 'https://jetpack.com/support/';
+export const JETPACK_CONTACT_SUPPORT = 'https://jetpack.com/contact-support/?rel=support';
+export const JETPACK_SERVICE_VAULTPRESS = 'https://help.vaultpress.com/';
+export const JETPACK_SERVICE_AKISMET = 'https://akismet.com/support/';
+export const JETPACK_SERVICE_POLLDADDY = 'https://support.polldaddy.com/';
+export const LIVE_CHAT = `${ root }/live-chat`;
+export const MANAGE_PURCHASES = `${ root }/manage-purchases`;
+export const MAP_EXISTING_DOMAIN = `${ root }/domains/map-existing-domain`;
+export const MAP_EXISTING_DOMAIN_UPDATE_DNS = `${ root }/domains/map-existing-domain#2-ask-your-domain-provider-to-update-your-dns-settings`; // eslint-disable-line max-len
+export const MAP_SUBDOMAIN = `${ root }/domains/map-subdomain`;
+export const MEDIA = `${ root }/media`;
+export const PUBLICIZE = `${ root }/publicize`;
+export const PUBLIC_VS_PRIVATE = `${ root }/domains/register-domain/#public-versus-private`;
+export const REFUNDS = `${ root }/refunds`;
+export const REGISTER_DOMAIN = `${ root }/domains/register-domain/`;
+export const SEO_TAGS = `${ root }/getting-more-views-and-traffic/#use-appropriate-tags`;
+export const SETTING_PRIMARY_DOMAIN = `${ root }/domains/#setting-the-primary-domain`;
+export const SETTING_UP_PREMIUM_SERVICES = `${ root }/setting-up-premium-services`;
+export const STRONG_PASSWORD = `${ root }/selecting-a-strong-password/`;
+export const SHARING = `${ root }/sharing`;
+export const START = `${ root }/start`;
+export const STATS_CLICKS = `${ root }/stats/#clicks`;
+export const STATS_REFERRERS = `${ root }/stats/#referrers`;
+export const STATS_SEO_TERMS = `${ root }/stats/#search-engine-terms`;
+export const STATS_SPAM_REFERRER = `${ root }/stats/#marking-spam-referrers`;
+export const STATS_TOP_POSTS_PAGES = `${ root }/stats/#top-posts-pages`;
+export const STATS_VIEWS_BY_COUNTRY = `${ root }/stats/#views-by-country`;
+export const SUPPORT_ROOT = `${ root }/`;
+export const TRANSFER_DOMAIN_REGISTRATION = `${ root }/transfer-domain-registration`;
+export const TWITTER_TIMELINE_WIDGET = `${ root }/widgets/twitter-timeline-widget`;
+export const UPDATE_CONTACT_INFORMATION = `${ root }/update-contact-information/`;
+export const UPDATE_NAMESERVERS = `${ root }/domains/domain-management/#update-nameservers`;
+export const USERS = `${ root }/category/users`;
+export const USER_ROLES = `${ root }/user-roles`;
+export const VIDEOS = `${ root }/videos`;
+export const WPCC = `${ root }/wpcc-faq`;

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -12,7 +12,7 @@ import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
 import ExternalLink from 'components/external-link';
 import { localize } from 'i18n-calypso';
-import support from 'lib/url/support';
+import { CONCIERGE_SUPPORT } from 'lib/url/support';
 
 class PrimaryHeader extends Component {
 	render() {
@@ -33,7 +33,7 @@ class PrimaryHeader extends Component {
 				<ExternalLink
 					className="shared__info-link"
 					icon={ false }
-					href={ support.CONCIERGE_SUPPORT }
+					href={ CONCIERGE_SUPPORT }
 					target="_blank"
 				>
 					{ translate( 'Learn more' ) }

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -18,7 +18,7 @@ import config from 'config';
 import HelpComponent from './main';
 import CoursesComponent from './help-courses';
 import ContactComponent from './help-contact';
-import support from 'lib/url/support';
+import { CONTACT, SUPPORT_ROOT } from 'lib/url/support';
 import userUtils from 'lib/user/utils';
 
 export default {
@@ -30,10 +30,10 @@ export default {
 		let url;
 		switch ( context.path ) {
 			case '/help':
-				url = support.SUPPORT_ROOT;
+				url = SUPPORT_ROOT;
 				break;
 			case '/help/contact':
-				url = support.CONTACT;
+				url = CONTACT;
 				break;
 			default:
 				url = login( { redirectTo: window.location.href } );

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -15,7 +15,7 @@ import i18n from 'i18n-calypso';
 import { getName, isRefundable, isSubscription, isOneTimePurchase } from 'lib/purchases';
 import { isDomainRegistration, isDomainMapping } from 'lib/products-values';
 import { getIncludedDomainPurchase } from 'state/purchases/selectors';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 
 const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } ) => {
 	const { refundPeriodInDays } = purchase;
@@ -98,7 +98,7 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 								'please {{contactLink}}contact support{{/contactLink}}.',
 							{
 								components: {
-									contactLink: <a href={ support.CALYPSO_CONTACT } />,
+									contactLink: <a href={ CALYPSO_CONTACT } />,
 								},
 							}
 						)
@@ -194,7 +194,7 @@ const CancelPurchaseRefundInformation = ( { purchase, includedDomainPurchase } )
 						'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}',
 						{
 							components: {
-								contactLink: <a href={ support.CALYPSO_CONTACT } />,
+								contactLink: <a href={ CALYPSO_CONTACT } />,
 							},
 						}
 					) }

--- a/client/me/purchases/confirm-cancel-domain/cancellation-reasons.js
+++ b/client/me/purchases/confirm-cancel-domain/cancellation-reasons.js
@@ -10,7 +10,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import support from 'lib/url/support';
+import { TRANSFER_DOMAIN_REGISTRATION, UPDATE_NAMESERVERS } from 'lib/url/support';
 
 export default [
 	{
@@ -30,7 +30,7 @@ export default [
 				'you’ll want to {{a}}update your name servers{{/a}} instead.',
 			{
 				components: {
-					a: <a href={ support.UPDATE_NAMESERVERS } target="_blank" rel="noopener noreferrer" />,
+					a: <a href={ UPDATE_NAMESERVERS } target="_blank" rel="noopener noreferrer" />,
 				},
 			}
 		),
@@ -44,13 +44,7 @@ export default [
 				'please {{a}}use our transfer out feature{{/a}} if you want to use this domain again in the future.',
 			{
 				components: {
-					a: (
-						<a
-							href={ support.TRANSFER_DOMAIN_REGISTRATION }
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
+					a: <a href={ TRANSFER_DOMAIN_REGISTRATION } target="_blank" rel="noopener noreferrer" />,
 				},
 			}
 		),

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -77,7 +77,7 @@ import QueryUserPurchases from 'components/data/query-user-purchases';
 import RemovePurchase from '../remove-purchase';
 import VerticalNavItem from 'components/vertical-nav/item';
 import paths from '../paths';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 import titles from 'me/purchases/titles';
 import userFactory from 'lib/user';
 import * as upgradesActions from 'lib/upgrades/actions';
@@ -237,7 +237,7 @@ class ManagePurchase extends Component {
 			if ( isDomainRegistration( purchase ) ) {
 				if ( isRenewal( purchase ) ) {
 					text = translate( 'Contact Support to Cancel Domain and Refund' );
-					link = support.CALYPSO_CONTACT;
+					link = CALYPSO_CONTACT;
 				} else {
 					text = translate( 'Cancel Domain and Refund' );
 				}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -36,7 +36,7 @@ import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import { getUser } from 'state/users/selectors';
 import paths from '../paths';
 import PaymentLogo from 'components/payment-logo';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 import UserItem from 'components/user';
 import {
 	canEditPaymentDetails,
@@ -266,7 +266,7 @@ class PurchaseMeta extends Component {
 							siteSlug: this.props.selectedPurchase.domain,
 						},
 						components: {
-							contactSupportLink: <a href={ support.CALYPSO_CONTACT } />,
+							contactSupportLink: <a href={ CALYPSO_CONTACT } />,
 						},
 					}
 				) }

--- a/client/me/purchases/purchases-site/reconnect-notice.jsx
+++ b/client/me/purchases/purchases-site/reconnect-notice.jsx
@@ -13,7 +13,7 @@ import React, { Component } from 'react';
  */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT, JETPACK_CONTACT_SUPPORT } from 'lib/url/support';
 
 class PurchaseReconnectNotice extends Component {
 	static propTypes = {
@@ -38,9 +38,7 @@ class PurchaseReconnectNotice extends Component {
 
 		return (
 			<Notice showDismiss={ false } status="is-error" text={ text }>
-				<NoticeAction
-					href={ isJetpack ? support.JETPACK_CONTACT_SUPPORT : support.CALYPSO_CONTACT }
-				>
+				<NoticeAction href={ isJetpack ? JETPACK_CONTACT_SUPPORT : CALYPSO_CONTACT }>
 					{ translate( 'Contact Support' ) }
 				</NoticeAction>
 			</Notice>

--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
 import Notice from 'components/notice';
 import Security2faBackupCodesList from 'me/security-2fa-backup-codes-list';
 import Security2faProgress from 'me/security-2fa-progress';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
@@ -66,7 +66,7 @@ class Security2faSetupBackupCodes extends React.Component {
 				components: {
 					supportLink: (
 						<a
-							href={ support.CALYPSO_CONTACT }
+							href={ CALYPSO_CONTACT }
 							onClick={ this.getClickHandler( 'No Backup Codes Contact Support Link' ) }
 						/>
 					),

--- a/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-mapping-details.jsx
@@ -11,7 +11,7 @@ import React from 'react';
  */
 import { localize } from 'i18n-calypso';
 import PurchaseDetail from 'components/purchase-detail';
-import supportUrls from 'lib/url/support';
+import { MAP_EXISTING_DOMAIN } from 'lib/url/support';
 
 const DomainMappingDetails = ( { domain, registrarSupportUrl, translate } ) => {
 	const registrarSupportLink = registrarSupportUrl ? (
@@ -65,7 +65,7 @@ const DomainMappingDetails = ( { domain, registrarSupportUrl, translate } ) => {
 				icon="cog"
 				description={ description }
 				buttonText={ translate( 'Learn more' ) }
-				href={ supportUrls.MAP_EXISTING_DOMAIN }
+				href={ MAP_EXISTING_DOMAIN }
 				target="_blank"
 				rel="noopener noreferrer"
 				isRequired

--- a/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
@@ -15,7 +15,7 @@ import { getDomainManagementUrl } from './utils';
 import GoogleAppsDetails from './google-apps-details';
 import { isGoogleApps } from 'lib/products-values';
 import PurchaseDetail from 'components/purchase-detail';
-import supportUrls from 'lib/url/support';
+import { EMAIL_VALIDATION_AND_VERIFICATION, REGISTER_DOMAIN } from 'lib/url/support';
 
 const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 	const googleAppsWasPurchased = purchases.some( isGoogleApps ),
@@ -36,7 +36,7 @@ const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 							'We sent you an email with a request to verify your new domain. Unverified domains may be suspended.'
 						) }
 						buttonText={ i18n.translate( 'Learn more about verifying your domain' ) }
-						href={ supportUrls.EMAIL_VALIDATION_AND_VERIFICATION }
+						href={ EMAIL_VALIDATION_AND_VERIFICATION }
 						target="_blank"
 						rel="noopener noreferrer"
 						requiredText={ i18n.translate( 'Important! Your action is required.' ) }
@@ -54,7 +54,7 @@ const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 					'Your domain should start working immediately, but may be unreliable during the first 72 hours.'
 				) }
 				buttonText={ i18n.translate( 'Learn more about your domain' ) }
-				href={ supportUrls.REGISTER_DOMAIN }
+				href={ REGISTER_DOMAIN }
 				target="_blank"
 				rel="noopener noreferrer"
 			/>

--- a/client/my-sites/checkout/checkout-thank-you/failed-purchase-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/failed-purchase-details.jsx
@@ -11,7 +11,7 @@ import React from 'react';
  */
 import { localize } from 'i18n-calypso';
 import PurchaseDetail from 'components/purchase-detail';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 
 const FailedPurchaseDetails = ( { failedPurchases, purchases, translate } ) => {
 	const successfulPurchases = purchases.length > 0 && (
@@ -50,7 +50,7 @@ const FailedPurchaseDetails = ( { failedPurchases, purchases, translate } ) => {
 							"If the problem persists, please don't hesitate to {{a}}contact support{{/a}}.",
 						{
 							components: {
-								a: <a href={ support.CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />,
+								a: <a href={ CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />,
 							},
 						}
 					) }

--- a/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
@@ -10,7 +10,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import supportUrls from 'lib/url/support';
+import { GOOGLE_APPS_LEARNING_CENTER } from 'lib/url/support';
 import PurchaseDetail from 'components/purchase-detail';
 import userFactory from 'lib/user';
 
@@ -31,7 +31,7 @@ const GoogleAppsDetails = () => {
 						link: (
 							<a
 								className="checkout-thank-you__gsuite-support-link"
-								href={ supportUrls.GOOGLE_APPS_LEARNING_CENTER }
+								href={ GOOGLE_APPS_LEARNING_CENTER }
 								rel="noopener noreferrer"
 								target="_blank"
 							/>

--- a/client/my-sites/checkout/checkout-thank-you/guided-transfer-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/guided-transfer-details.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import supportUrls from 'lib/url/support';
+import { GUIDED_TRANSFER } from 'lib/url/support';
 import PurchaseDetail from 'components/purchase-detail';
 
 const GuidedTransferDetails = ( { translate } ) => (
@@ -23,7 +23,7 @@ const GuidedTransferDetails = ( { translate } ) => (
 				'the transfer.'
 		) }
 		buttonText={ translate( 'Learn more about Guided Transfers' ) }
-		href={ supportUrls.GUIDED_TRANSFER }
+		href={ GUIDED_TRANSFER }
 		target="_blank"
 		rel="noopener noreferrer"
 	/>

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -23,7 +23,7 @@ import Spinner from 'components/spinner';
 import Gridicon from 'gridicons';
 import QueryPluginKeys from 'components/data/query-plugin-keys';
 import analytics from 'lib/analytics';
-import support from 'lib/url/support';
+import { SETTING_UP_PREMIUM_SERVICES } from 'lib/url/support';
 import { getSiteFileModDisableReason } from 'lib/site/utils';
 import HappyChatButton from 'components/happychat/button';
 
@@ -549,7 +549,7 @@ class JetpackThankYouCard extends Component {
 					<p>
 						{ translate( 'You will have to {{link}}set up your plan manually{{/link}}.', {
 							components: {
-								link: <a href={ support.SETTING_UP_PREMIUM_SERVICES } />,
+								link: <a href={ SETTING_UP_PREMIUM_SERVICES } />,
 							},
 						} ) }
 					</p>

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -22,7 +22,11 @@ import { cartItems } from 'lib/cart-values';
 import { clearSitePlans } from 'state/sites/plans/actions';
 import { clearPurchases } from 'state/purchases/actions';
 import DomainDetailsForm from './domain-details-form';
-import { domainMapping } from 'lib/cart-values/cart-items';
+import {
+	domainMapping,
+	planItem as getCartItemForPlan,
+	themeItem,
+} from 'lib/cart-values/cart-items';
 import { fetchReceiptCompleted } from 'state/receipts/actions';
 import { getExitCheckoutUrl } from 'lib/checkout';
 import { hasDomainDetails } from 'lib/store-transactions';
@@ -36,22 +40,24 @@ import QueryStoredCards from 'components/data/query-stored-cards';
 import QueryGeo from 'components/data/query-geo';
 import SecurePaymentForm from './secure-payment-form';
 import SecurePaymentFormPlaceholder from './secure-payment-form-placeholder';
-import supportPaths from 'lib/url/support';
-import { themeItem } from 'lib/cart-values/cart-items';
+import { AUTO_RENEWAL } from 'lib/url/support';
 import {
 	RECEIVED_WPCOM_RESPONSE,
 	SUBMITTING_WPCOM_REQUEST,
 } from 'lib/store-transactions/step-types';
 import upgradesActions from 'lib/upgrades/actions';
-import { getContactDetailsCache, isEligibleForCheckoutToChecklist } from 'state/selectors';
+import {
+	getContactDetailsCache,
+	getCurrentUserPaymentMethods,
+	isDomainOnlySite,
+	isEligibleForCheckoutToChecklist,
+} from 'state/selectors';
 import { getStoredCards } from 'state/stored-cards/selectors';
 import { isValidFeatureKey, getUpgradePlanSlugFromPath } from 'lib/plans';
-import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import { recordViewCheckout } from 'lib/analytics/ad-tracking';
 import { recordApplePayStatus } from 'lib/apple-pay';
 import { requestSite } from 'state/sites/actions';
 import { isNewSite } from 'state/sites/selectors';
-import { isDomainOnlySite, getCurrentUserPaymentMethods } from 'state/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { canAddGoogleApps } from 'lib/domains';
@@ -380,9 +386,7 @@ const Checkout = createReactClass( {
 								productName: renewalItem.product_name,
 							},
 							components: {
-								a: (
-									<a href={ supportPaths.AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
-								),
+								a: <a href={ AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />,
 							},
 						}
 					),

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -59,7 +59,7 @@ import GAppsFieldset from 'my-sites/domains/components/domain-form-fieldsets/g-a
 import RegionAddressFieldsets from 'my-sites/domains/components/domain-form-fieldsets/region-address-fieldsets';
 import NoticeErrorMessage from 'my-sites/checkout/checkout/notice-error-message';
 import notices from 'notices';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 
 const debug = debugFactory( 'calypso:my-sites:upgrades:checkout:domain-details' );
 const wpcom = wp.undocumented();
@@ -482,7 +482,7 @@ export class DomainDetailsForm extends PureComponent {
 					'Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
 				{
 					components: {
-						contactSupportLink: <a href={ support.CALYPSO_CONTACT } />,
+						contactSupportLink: <a href={ CALYPSO_CONTACT } />,
 						firstErrorName: <NoticeErrorMessage message={ firstErrorName } />,
 					},
 					comment: 'Validation error when filling out domain checkout contact details form',

--- a/client/my-sites/checkout/checkout/terms-of-service.jsx
+++ b/client/my-sites/checkout/checkout/terms-of-service.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import support from 'lib/url/support';
+import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'lib/url/support';
 import Gridicon from 'gridicons';
 
 class TermsOfService extends React.Component {
@@ -40,10 +40,10 @@ class TermsOfService extends React.Component {
 					components: {
 						tosLink: <a href="//wordpress.com/tos/" target="_blank" rel="noopener noreferrer" />,
 						autoRenewalSupportPage: (
-							<a href={ support.AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
+							<a href={ AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
 						),
 						managePurchasesSupportPage: (
-							<a href={ support.MANAGE_PURCHASES } target="_blank" rel="noopener noreferrer" />
+							<a href={ MANAGE_PURCHASES } target="_blank" rel="noopener noreferrer" />
 						),
 					},
 				}

--- a/client/my-sites/domains/components/domain-warnings/pending-gapps-tos-notice.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gapps-tos-notice.jsx
@@ -14,13 +14,13 @@ import { localize } from 'i18n-calypso';
  */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import support from 'lib/url/support';
+import { COMPLETING_GOOGLE_APPS_SIGNUP } from 'lib/url/support';
 import { domainManagementEmail } from 'my-sites/domains/paths';
 import PendingGappsTosNoticeMultipleDomainListItem from './pending-gapps-tos-notice-multiple-domain-list-item';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
 const learnMoreLink = (
-	<a href={ support.COMPLETING_GOOGLE_APPS_SIGNUP } target="_blank" rel="noopener noreferrer" />
+	<a href={ COMPLETING_GOOGLE_APPS_SIGNUP } target="_blank" rel="noopener noreferrer" />
 );
 const strong = <strong />;
 

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -19,7 +19,7 @@ import ReactDom from 'react-dom';
  */
 import { DomainWarnings } from '../';
 import { type as domainTypes } from 'lib/domains/constants';
-import support from 'lib/url/support';
+import { MAP_EXISTING_DOMAIN_UPDATE_DNS, MAP_SUBDOMAIN } from 'lib/url/support';
 
 jest.mock( 'lib/analytics', () => ( {} ) );
 
@@ -161,7 +161,7 @@ describe( 'index', () => {
 			const domNode = ReactDom.findDOMNode( component ),
 				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
 
-			assert( links.some( link => link.href === support.MAP_EXISTING_DOMAIN_UPDATE_DNS ) );
+			assert( links.some( link => link.href === MAP_EXISTING_DOMAIN_UPDATE_DNS ) );
 		} );
 
 		test( 'should show a subdomain mapping related message for one misconfigured subdomain', () => {
@@ -184,7 +184,7 @@ describe( 'index', () => {
 				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
 
 			expect( textContent ).to.contain( 'CNAME records should be configured' );
-			assert( links.some( link => link.href === support.MAP_SUBDOMAIN ) );
+			assert( links.some( link => link.href === MAP_SUBDOMAIN ) );
 		} );
 
 		test( 'should show a subdomain mapping related message for multiple misconfigured subdomains', () => {
@@ -215,7 +215,7 @@ describe( 'index', () => {
 			expect( textContent ).to.contain(
 				"Some of your domains' CNAME records should be configured"
 			);
-			assert( links.some( link => link.href === support.MAP_SUBDOMAIN ) );
+			assert( links.some( link => link.href === MAP_SUBDOMAIN ) );
 		} );
 
 		test( 'should show a subdomain mapping related message for multiple misconfigured subdomains and domains mixed', () => {
@@ -246,7 +246,7 @@ describe( 'index', () => {
 			expect( textContent ).to.contain(
 				"Some of your domains' name server records should be configured"
 			);
-			assert( links.some( link => link.href === support.MAP_EXISTING_DOMAIN_UPDATE_DNS ) );
+			assert( links.some( link => link.href === MAP_EXISTING_DOMAIN_UPDATE_DNS ) );
 		} );
 	} );
 

--- a/client/my-sites/domains/domain-management/components/designated-agent-notice/index.jsx
+++ b/client/my-sites/domains/domain-management/components/designated-agent-notice/index.jsx
@@ -11,7 +11,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal Dependencies
  */
-import support from 'lib/url/support';
+import { DESIGNATED_AGENT, DOMAIN_REGISTRATION_AGREEMENTS } from 'lib/url/support';
 
 const DesignatedAgentNotice = props => (
 	<div className="designated-agent-notice__container">
@@ -30,14 +30,12 @@ const DesignatedAgentNotice = props => (
 						strong: <strong />,
 						draLink: (
 							<a
-								href={ support.DOMAIN_REGISTRATION_AGREEMENTS }
+								href={ DOMAIN_REGISTRATION_AGREEMENTS }
 								target="_blank"
 								rel="noopener noreferrer"
 							/>
 						),
-						supportLink: (
-							<a href={ support.DESIGNATED_AGENT } target="_blank" rel="noopener noreferrer" />
-						),
+						supportLink: <a href={ DESIGNATED_AGENT } target="_blank" rel="noopener noreferrer" />,
 					},
 				}
 			) }

--- a/client/my-sites/domains/domain-management/components/icann-verification/icann-verification-card.jsx
+++ b/client/my-sites/domains/domain-management/components/icann-verification/icann-verification-card.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import support from 'lib/url/support';
+import { EMAIL_VALIDATION_AND_VERIFICATION } from 'lib/url/support';
 import upgradesActions from 'lib/upgrades/actions';
 import { errorNotice } from 'state/notices/actions';
 import { domainManagementEditContactInfo } from 'my-sites/domains/paths';
@@ -45,7 +45,7 @@ class IcannVerificationCard extends React.Component {
 				components: {
 					learnMoreLink: (
 						<a
-							href={ support.EMAIL_VALIDATION_AND_VERIFICATION }
+							href={ EMAIL_VALIDATION_AND_VERIFICATION }
 							target="_blank"
 							rel="noopener noreferrer"
 						/>

--- a/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/inbound-transfer-verification/index.jsx
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  *
+ * @format
  */
+
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
@@ -11,7 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import EmailVerificationCard from 'my-sites/domains/domain-management/components/email-verification';
 import { resendInboundTransferEmail } from 'lib/domains';
-import support from 'lib/url/support';
+import { INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS } from 'lib/url/support';
 import Card from 'components/card';
 
 class InboundTransferEmailVerificationCard extends React.PureComponent {
@@ -30,14 +32,12 @@ class InboundTransferEmailVerificationCard extends React.PureComponent {
 				<Card highlight="warning">
 					<div>
 						<h1 className="inbound-transfer-verification__heading">
-							{ translate(
-								'The authorization email is still waiting to be sent.'
-							) }
+							{ translate( 'The authorization email is still waiting to be sent.' ) }
 						</h1>
 						{ translate(
-							'The contact address for this domain wasn\'t immediately available. ' +
-							'We will keep checking and send the email to initiate the transfer once we have the ' +
-							'correct address. This could take up to 24 hours. We appreciate your patience.'
+							"The contact address for this domain wasn't immediately available. " +
+								'We will keep checking and send the email to initiate the transfer once we have the ' +
+								'correct address. This could take up to 24 hours. We appreciate your patience.'
 						) }
 					</div>
 				</Card>
@@ -49,13 +49,11 @@ class InboundTransferEmailVerificationCard extends React.PureComponent {
 				<Card highlight="info">
 					<div>
 						<h1 className="inbound-transfer-verification__heading">
-							{ translate(
-								'The authorization email will be sent shortly.'
-							) }
+							{ translate( 'The authorization email will be sent shortly.' ) }
 						</h1>
 						{ translate(
 							"We'll let you know which mailbox to check as soon as the email is sent. " +
-							'Check again in a few minutes.'
+								'Check again in a few minutes.'
 						) }
 					</div>
 				</Card>
@@ -66,15 +64,11 @@ class InboundTransferEmailVerificationCard extends React.PureComponent {
 			<EmailVerificationCard
 				contactEmail={ adminEmail }
 				errorMessage={ translate( 'Unable to resend domain transfer email.' ) }
-				headerText={
-					translate(
-						'Important: Confirm the transfer to proceed.'
-					)
-				}
+				headerText={ translate( 'Important: Confirm the transfer to proceed.' ) }
 				verificationExplanation={ translate(
 					'We sent an email to confirm the transfer of {{strong}}%(domain)s{{/strong}}. ' +
-					'Open the email, click the link, and enter your domain authorization code to start the process. ' +
-					'Please confirm in 5 days or the transfer will be canceled. ' +
+						'Open the email, click the link, and enter your domain authorization code to start the process. ' +
+						'Please confirm in 5 days or the transfer will be canceled. ' +
 						'{{learnMoreLink}}Learn more.{{/learnMoreLink}}',
 					{
 						args: {
@@ -83,7 +77,7 @@ class InboundTransferEmailVerificationCard extends React.PureComponent {
 						components: {
 							learnMoreLink: (
 								<a
-									href={ support.INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
+									href={ INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
 									rel="noopener noreferrer"
 									target="_blank"
 								/>

--- a/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
@@ -19,7 +19,7 @@ import {
 	domainManagementTransferOut,
 } from 'my-sites/domains/paths';
 import SectionHeader from 'components/section-header';
-import support from 'lib/url/support';
+import { PUBLIC_VS_PRIVATE } from 'lib/url/support';
 
 class ContactsPrivacyCard extends React.PureComponent {
 	static propTypes = {
@@ -45,13 +45,7 @@ class ContactsPrivacyCard extends React.PureComponent {
 								'{{a}}Learn more.{{/a}}',
 							{
 								components: {
-									a: (
-										<a
-											href={ support.PUBLIC_VS_PRIVATE }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
+									a: <a href={ PUBLIC_VS_PRIVATE } target="_blank" rel="noopener noreferrer" />,
 								},
 							}
 						) }

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -29,7 +29,7 @@ import { domainManagementContactsPrivacy } from 'my-sites/domains/paths';
 import upgradesActions from 'lib/upgrades/actions';
 import wp from 'lib/wp';
 import { successNotice } from 'state/notices/actions';
-import support from 'lib/url/support';
+import { UPDATE_CONTACT_INFORMATION } from 'lib/url/support';
 import { registrar as registrarNames } from 'lib/domains/constants';
 import DesignatedAgentNotice from 'my-sites/domains/domain-management/components/designated-agent-notice';
 import Dialog from 'components/dialog';
@@ -196,7 +196,7 @@ class EditContactInfoFormCard extends React.Component {
 							components: {
 								link: (
 									<a
-										href={ support.UPDATE_CONTACT_INFORMATION }
+										href={ UPDATE_CONTACT_INFORMATION }
 										target="_blank"
 										rel="noopener noreferrer"
 									/>

--- a/client/my-sites/domains/domain-management/edit-contact-info/pending-whois-update-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/pending-whois-update-card.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import Notice from 'components/notice';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 
 function PendingWhoisUpdateCard( { translate } ) {
 	return (
@@ -28,7 +28,7 @@ function PendingWhoisUpdateCard( { translate } ) {
 						'{{supporta}}support page{{/supporta}} or {{a}}contact support{{/a}}.',
 					{
 						components: {
-							a: <a href={ support.CALYPSO_CONTACT } rel="noopener noreferrer" />,
+							a: <a href={ CALYPSO_CONTACT } rel="noopener noreferrer" />,
 							supporta: (
 								<a
 									href="https://en.support.wordpress.com/update-contact-information/#email-or-name-changes"

--- a/client/my-sites/domains/domain-management/edit-contact-info/privacy-enabled-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/privacy-enabled-card.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 
 class EditContactInfoPrivacyEnabledCard extends React.Component {
 	render() {
@@ -24,7 +24,7 @@ class EditContactInfoPrivacyEnabledCard extends React.Component {
 							"If you need to make a change to your domain's contact info, please {{a}}contact support{{/a}}.",
 						{
 							components: {
-								a: <a href={ support.CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />,
+								a: <a href={ CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />,
 							},
 						}
 					) }

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -18,7 +18,7 @@ import Property from './card/property';
 import SubscriptionSettings from './card/subscription-settings';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { transferStatus } from 'lib/domains/constants';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT, INCOMING_DOMAIN_TRANSFER_STATUSES_FAILED } from 'lib/url/support';
 import { restartInboundTransfer } from 'lib/domains';
 import { fetchDomains } from 'lib/upgrades/actions';
 import { errorNotice, successNotice } from 'state/notices/actions';
@@ -139,7 +139,7 @@ class Transfer extends React.PureComponent {
 									strong: <strong />,
 									a: (
 										<a
-											href={ support.INCOMING_DOMAIN_TRANSFER_STATUSES_FAILED }
+											href={ INCOMING_DOMAIN_TRANSFER_STATUSES_FAILED }
 											rel="noopener noreferrer"
 											target="_blank"
 										/>
@@ -163,7 +163,7 @@ class Transfer extends React.PureComponent {
 					</Button>
 					<Button
 						className="edit__transfer-button-fail edit__transfer-button-fail-margin"
-						href={ support.CALYPSO_CONTACT }
+						href={ CALYPSO_CONTACT }
 					>
 						{ this.props.translate( 'Contact Support' ) }
 					</Button>

--- a/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-add-new.jsx
+++ b/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-add-new.jsx
@@ -14,7 +14,7 @@ import createReactClass from 'create-react-class';
  * Internal dependencies
  */
 import EmailForwardingLimit from './email-forwarding-limit';
-import { emailForwardingPlanLimit } from 'lib/domains/email-forwarding';
+import { emailForwardingPlanLimit, validateAllFields } from 'lib/domains/email-forwarding';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormFooter from 'my-sites/domains/domain-management/components/form-footer';
@@ -26,8 +26,7 @@ import formState from 'lib/form-state';
 import analyticsMixin from 'lib/mixins/analytics';
 import notices from 'notices';
 import * as upgradesActions from 'lib/upgrades/actions';
-import { validateAllFields } from 'lib/domains/email-forwarding';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 
 const EmailForwardingAddNew = createReactClass( {
 	displayName: 'EmailForwardingAddNew',
@@ -106,7 +105,7 @@ const EmailForwardingAddNew = createReactClass( {
 									'Failed to add email forwarding record. Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
 									{
 										components: {
-											contactSupportLink: <a href={ support.CALYPSO_CONTACT } />,
+											contactSupportLink: <a href={ CALYPSO_CONTACT } />,
 										},
 									}
 								)

--- a/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-details.jsx
+++ b/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-details.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import support from 'lib/url/support';
+import { EMAIL_FORWARDING } from 'lib/url/support';
 import analyticsMixin from 'lib/mixins/analytics';
 
 const EmailForwardingDetails = createReactClass( {
@@ -27,7 +27,7 @@ const EmailForwardingDetails = createReactClass( {
 					'Email Forwarding lets you use your custom domain in your email address, so your email address can be just as memorable as your blog.'
 				) }{' '}
 				<a
-					href={ support.EMAIL_FORWARDING }
+					href={ EMAIL_FORWARDING }
 					target="_blank"
 					rel="noopener noreferrer"
 					onClick={ this.handleLearnMoreClick }

--- a/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-item.jsx
+++ b/client/my-sites/domains/domain-management/email-forwarding/email-forwarding-item.jsx
@@ -18,7 +18,7 @@ import analyticsMixin from 'lib/mixins/analytics';
 import Button from 'components/button';
 import notices from 'notices';
 import { successNotice } from 'state/notices/actions';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 import * as upgradesActions from 'lib/upgrades/actions';
 
 const EmailForwardingItem = createReactClass( {
@@ -42,7 +42,7 @@ const EmailForwardingItem = createReactClass( {
 							'Failed to delete email forwarding record. Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
 							{
 								components: {
-									contactSupportLink: <a href={ support.CALYPSO_CONTACT } />,
+									contactSupportLink: <a href={ CALYPSO_CONTACT } />,
 								},
 							}
 						)
@@ -81,7 +81,7 @@ const EmailForwardingItem = createReactClass( {
 						'Failed to resend verification email for email forwarding record. Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
 						{
 							components: {
-								contactSupportLink: <a href={ support.CALYPSO_CONTACT } />,
+								contactSupportLink: <a href={ CALYPSO_CONTACT } />,
 							},
 						}
 					)

--- a/client/my-sites/domains/domain-management/email/google-apps-users-card.jsx
+++ b/client/my-sites/domains/domain-management/email/google-apps-users-card.jsx
@@ -22,7 +22,7 @@ import analyticsMixin from 'lib/mixins/analytics';
 import SectionHeader from 'components/section-header';
 import GoogleAppsUserItem from './google-apps-user-item';
 import { getSelectedDomain, hasPendingGoogleAppsUsers } from 'lib/domains';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 
 const GoogleAppsUsers = createReactClass( {
 	displayName: 'GoogleAppsUsers',
@@ -96,7 +96,7 @@ const GoogleAppsUsers = createReactClass( {
 			let status = 'is-warning',
 				text = user.error,
 				supportLink = (
-					<a href={ support.CALYPSO_CONTACT }>
+					<a href={ CALYPSO_CONTACT }>
 						<strong>{ this.props.translate( 'Please contact support' ) }</strong>
 					</a>
 				);

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -19,7 +19,7 @@ import FormFooter from 'my-sites/domains/domain-management/components/form-foote
 import CustomNameserversRow from './custom-nameservers-row';
 import { change, remove } from 'lib/domains/nameservers';
 import Notice from 'components/notice';
-import support from 'lib/url/support';
+import { CHANGE_NAME_SERVERS, CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS } from 'lib/url/support';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
 const MIN_NAMESERVER_LENGTH = 2;
@@ -44,7 +44,7 @@ class CustomNameserversForm extends React.PureComponent {
 						'WordPress.com site to load & other features to be available.'
 				) }{' '}
 				<a
-					href={ support.CHANGE_NAME_SERVERS }
+					href={ CHANGE_NAME_SERVERS }
 					target="_blank"
 					rel="noopener noreferrer"
 					onClick={ this.handleLearnMoreClick }
@@ -66,7 +66,7 @@ class CustomNameserversForm extends React.PureComponent {
 			<div className="custom-nameservers-form__explanation">
 				{ translate( 'Not sure what name servers to use?' ) }{' '}
 				<a
-					href={ support.CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS }
+					href={ CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS }
 					target="_blank"
 					rel="noopener noreferrer"
 					onClick={ this.handleLookUpClick }

--- a/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Toggle from 'components/forms/form-toggle';
-import support from 'lib/url/support';
+import { CHANGE_NAME_SERVERS } from 'lib/url/support';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
 class NameserversToggle extends React.PureComponent {
@@ -66,7 +66,7 @@ class NameserversToggle extends React.PureComponent {
 						components: {
 							a: (
 								<a
-									href={ support.CHANGE_NAME_SERVERS }
+									href={ CHANGE_NAME_SERVERS }
 									target="_blank"
 									rel="noopener noreferrer"
 									onClick={ this.handleLearnMoreClick }

--- a/client/my-sites/domains/domain-management/primary-domain/index.jsx
+++ b/client/my-sites/domains/domain-management/primary-domain/index.jsx
@@ -22,7 +22,7 @@ import { domainManagementEdit } from 'my-sites/domains/paths';
 import * as upgradesActions from 'lib/upgrades/actions';
 import { getSelectedDomain } from 'lib/domains';
 import SectionHeader from 'components/section-header';
-import support from 'lib/url/support';
+import { SETTING_PRIMARY_DOMAIN } from 'lib/url/support';
 import { getDomainsBySite } from 'state/sites/domains/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
@@ -96,7 +96,7 @@ class PrimaryDomain extends React.Component {
 
 	render() {
 		const { selectedDomainName, selectedSite, translate } = this.props;
-		const primaryDomainSupportUrl = support.SETTING_PRIMARY_DOMAIN;
+		const primaryDomainSupportUrl = SETTING_PRIMARY_DOMAIN;
 
 		return (
 			<Main className="domain-management-primary-domain">

--- a/client/my-sites/domains/domain-management/privacy-protection/card/content.jsx
+++ b/client/my-sites/domains/domain-management/privacy-protection/card/content.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import AddButton from './add-button';
-import support from 'lib/url/support';
+import { PUBLIC_VS_PRIVATE } from 'lib/url/support';
 
 class Content extends React.PureComponent {
 	static propTypes = {
@@ -32,7 +32,7 @@ class Content extends React.PureComponent {
 						{ translate(
 							"With Privacy Protection, we show our partner's contact information instead of your own."
 						) }
-						<a href={ support.PUBLIC_VS_PRIVATE } target="_blank" rel="noopener noreferrer">
+						<a href={ PUBLIC_VS_PRIVATE } target="_blank" rel="noopener noreferrer">
 							{ translate( 'Learn more.' ) }
 						</a>
 					</p>

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/icann-verification.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/icann-verification.jsx
@@ -15,7 +15,7 @@ import SectionHeader from 'components/section-header';
 import { resendIcannVerification } from 'lib/upgrades/actions/domain-management';
 import Button from 'components/button';
 import notices from 'notices';
-import support from 'lib/url/support';
+import { TRANSFER_DOMAIN_REGISTRATION } from 'lib/url/support';
 
 class IcannVerification extends React.Component {
 	state = {
@@ -61,7 +61,7 @@ class IcannVerification extends React.Component {
 								components: {
 									learnMoreLink: (
 										<a
-											href={ support.TRANSFER_DOMAIN_REGISTRATION }
+											href={ TRANSFER_DOMAIN_REGISTRATION }
 											target="_blank"
 											rel="noopener noreferrer"
 										/>

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
@@ -16,7 +16,7 @@ import { getSelectedDomain } from 'lib/domains';
 import Button from 'components/button';
 import { requestTransferCode } from 'lib/upgrades/actions';
 import { displayRequestTransferCodeResponseNotice } from './shared';
-import support from 'lib/url/support';
+import { TRANSFER_DOMAIN_REGISTRATION } from 'lib/url/support';
 
 class Locked extends React.Component {
 	state = {
@@ -74,11 +74,7 @@ class Locked extends React.Component {
 											'Your contact information will be publicly available during the transfer period.'
 									)
 								: translate( 'To transfer your domain, we must unlock it.' ) }{' '}
-							<a
-								href={ support.TRANSFER_DOMAIN_REGISTRATION }
-								target="_blank"
-								rel="noopener noreferrer"
-							>
+							<a href={ TRANSFER_DOMAIN_REGISTRATION } target="_blank" rel="noopener noreferrer">
 								{ translate( 'Learn More.' ) }
 							</a>
 						</p>

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/shared.js
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/shared.js
@@ -11,7 +11,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import notices from 'notices';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 
 export const displayResponseError = responseError => {
 	const errorMessages = {
@@ -38,7 +38,7 @@ export const displayResponseError = responseError => {
 					args: errorMessages[ responseError.error ],
 					components: {
 						strong: <strong />,
-						a: <a href={ support.CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />,
+						a: <a href={ CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />,
 					},
 				}
 			)
@@ -51,7 +51,7 @@ export const displayResponseError = responseError => {
 					'to have trouble.',
 				{
 					components: {
-						a: <a href={ support.CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />,
+						a: <a href={ CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />,
 					},
 				}
 			)

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-prohibited.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/transfer-prohibited.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
-import support from 'lib/url/support';
+import { TRANSFER_DOMAIN_REGISTRATION } from 'lib/url/support';
 
 const TransferProhibited = ( { translate } ) => (
 	<div>
@@ -27,7 +27,7 @@ const TransferProhibited = ( { translate } ) => (
 						components: {
 							learnMoreLink: (
 								<a
-									href={ support.TRANSFER_DOMAIN_REGISTRATION }
+									href={ TRANSFER_DOMAIN_REGISTRATION }
 									target="_blank"
 									rel="noopener noreferrer"
 								/>

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/unlocked.jsx
@@ -18,7 +18,7 @@ import Button from 'components/button';
 import { requestTransferCode, cancelTransferRequest } from 'lib/upgrades/actions';
 import notices from 'notices';
 import { displayRequestTransferCodeResponseNotice } from './shared';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT, TRANSFER_DOMAIN_REGISTRATION } from 'lib/url/support';
 
 class Unlocked extends React.Component {
 	state = {
@@ -71,7 +71,7 @@ class Unlocked extends React.Component {
 
 				if ( error ) {
 					const contactLink = (
-						<a href={ support.CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />
+						<a href={ CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />
 					);
 					let errorMessage;
 
@@ -294,11 +294,7 @@ class Unlocked extends React.Component {
 						{ submitting && <p>{ translate( 'Sending request…' ) }</p> }
 						{ domainStateMessage && <p>{ domainStateMessage }</p> }
 						{ this.renderBody( domain ) }
-						<a
-							href={ support.TRANSFER_DOMAIN_REGISTRATION }
-							target="_blank"
-							rel="noopener noreferrer"
-						>
+						<a href={ TRANSFER_DOMAIN_REGISTRATION } target="_blank" rel="noopener noreferrer">
 							{ translate( 'Learn More.' ) }
 						</a>
 					</div>

--- a/client/my-sites/exporter/guided-transfer-card/in-progress.jsx
+++ b/client/my-sites/exporter/guided-transfer-card/in-progress.jsx
@@ -13,7 +13,7 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import supportUrls from 'lib/url/support';
+import { GUIDED_TRANSFER } from 'lib/url/support';
 
 const GuidedTransferInProgress = ( { translate } ) => (
 	<Card className="guided-transfer-card__in-progress">
@@ -29,9 +29,7 @@ const GuidedTransferInProgress = ( { translate } ) => (
 					'will work with you to set up a day to perform the transfer.'
 			) }
 		</p>
-		<Button href={ supportUrls.GUIDED_TRANSFER }>
-			{ translate( 'Learn more about Guided Transfers' ) }
-		</Button>
+		<Button href={ GUIDED_TRANSFER }>{ translate( 'Learn more about Guided Transfers' ) }</Button>
 	</Card>
 );
 

--- a/client/my-sites/exporter/guided-transfer-card/index.jsx
+++ b/client/my-sites/exporter/guided-transfer-card/index.jsx
@@ -23,7 +23,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getProductDisplayCost } from 'state/products-list/selectors';
 import InfoPopover from 'components/info-popover';
-import SUPPORT_URLS from 'lib/url/support';
+import { GUIDED_TRANSFER } from 'lib/url/support';
 
 const Feature = ( { children } ) => (
 	<li className="guided-transfer-card__feature-list-item">
@@ -97,7 +97,7 @@ class GuidedTransferCard extends Component {
 								{ components: { strong: <strong /> } }
 							) }
 							<br />
-							<a href={ SUPPORT_URLS.GUIDED_TRANSFER }>{ translate( 'Learn more.' ) }</a>
+							<a href={ GUIDED_TRANSFER }>{ translate( 'Learn more.' ) }</a>
 						</div>
 						<ul className="guided-transfer-card__feature-list">
 							<Feature>{ translate( 'Seamless content transfer' ) }</Feature>
@@ -107,7 +107,7 @@ class GuidedTransferCard extends Component {
 							<Feature>
 								{ translate( 'Switch your domain over {{link}}and more!{{/link}}', {
 									components: {
-										link: <a href={ SUPPORT_URLS.GUIDED_TRANSFER } />,
+										link: <a href={ GUIDED_TRANSFER } />,
 									},
 								} ) }
 							</Feature>

--- a/client/my-sites/exporter/notices.jsx
+++ b/client/my-sites/exporter/notices.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
 import CompletePurchaseNotice from './guided-transfer-card/complete-purchase-notice';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import support from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 import { getExportingState } from 'state/site-settings/exporter/selectors';
 import { isGuidedTransferAwaitingPurchase } from 'state/sites/guided-transfer/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -51,7 +51,7 @@ class Notices extends Component {
 							'again, or contact support.'
 					) }
 				>
-					<NoticeAction href={ support.CALYPSO_CONTACT }>{ translate( 'Get Help' ) }</NoticeAction>
+					<NoticeAction href={ CALYPSO_CONTACT }>{ translate( 'Get Help' ) }</NoticeAction>
 				</Notice>
 			);
 		}

--- a/client/my-sites/guided-transfer/host-credentials-page/error-notice.jsx
+++ b/client/my-sites/guided-transfer/host-credentials-page/error-notice.jsx
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
  */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import supportUrl from 'lib/url/support';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getGuidedTransferError } from 'state/sites/guided-transfer/selectors';
 
@@ -47,7 +47,7 @@ const ErrorNotice = localize( ( { translate, errorCode } ) => {
 			status="is-error"
 			text={ getErrorText( { translate, errorCode } ) }
 		>
-			<NoticeAction href={ supportUrl.CALYPSO_CONTACT }>{ translate( 'Get Help' ) }</NoticeAction>
+			<NoticeAction href={ CALYPSO_CONTACT }>{ translate( 'Get Help' ) }</NoticeAction>
 		</Notice>
 	);
 } );

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -26,7 +26,12 @@ import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
 import analytics from 'lib/analytics';
-import support from 'lib/url/support';
+import {
+	JETPACK_CONTACT_SUPPORT,
+	JETPACK_SERVICE_AKISMET,
+	JETPACK_SERVICE_VAULTPRESS,
+	JETPACK_SUPPORT,
+} from 'lib/url/support';
 import { getSiteFileModDisableReason } from 'lib/site/utils';
 
 // Redux actions & selectors
@@ -50,8 +55,8 @@ import {
 import PluginsStore from 'lib/plugins/store';
 
 const helpLinks = {
-	vaultpress: support.JETPACK_SERVICE_VAULTPRESS,
-	akismet: support.JETPACK_SERVICE_AKISMET,
+	vaultpress: JETPACK_SERVICE_VAULTPRESS,
+	akismet: JETPACK_SERVICE_AKISMET,
 };
 
 class PlansSetup extends React.Component {
@@ -219,7 +224,7 @@ class PlansSetup extends React.Component {
 			<JetpackManageErrorPage
 				siteId={ this.props.siteId }
 				action={ translate( 'Contact Support' ) }
-				actionURL={ support.JETPACK_CONTACT_SUPPORT }
+				actionURL={ JETPACK_CONTACT_SUPPORT }
 				title={ translate( "Oh no! We can't install plugins on this site." ) }
 				line={ reason }
 				illustration={ '/calypso/images/jetpack/jetpack-manage.svg' }
@@ -422,7 +427,7 @@ class PlansSetup extends React.Component {
 						plugin: pluginsWithErrors[ 0 ].name,
 					},
 					components: {
-						a: <a href={ support.JETPACK_SUPPORT } onClick={ this.trackManualInstall } />,
+						a: <a href={ JETPACK_SUPPORT } onClick={ this.trackManualInstall } />,
 					},
 				}
 			);
@@ -432,14 +437,14 @@ class PlansSetup extends React.Component {
 					'It may be possible to fix this by {{a}}manually installing{{/a}} the plugins.',
 				{
 					components: {
-						a: <a href={ support.JETPACK_SUPPORT } onClick={ this.trackManualInstall } />,
+						a: <a href={ JETPACK_SUPPORT } onClick={ this.trackManualInstall } />,
 					},
 				}
 			);
 		}
 		return (
 			<Notice status="is-error" text={ noticeText } showDismiss={ false }>
-				<NoticeAction href={ support.JETPACK_CONTACT_SUPPORT } onClick={ this.trackContactSupport }>
+				<NoticeAction href={ JETPACK_CONTACT_SUPPORT } onClick={ this.trackContactSupport }>
 					{ translate( 'Contact Support' ) }
 				</NoticeAction>
 			</Notice>
@@ -536,7 +541,7 @@ class PlansSetup extends React.Component {
 					<Button primary href={ manageUrl }>
 						{ translate( 'Enable Manage' ) }
 					</Button>
-					<Button href={ support.JETPACK_SUPPORT }>{ translate( 'Manual Installation' ) }</Button>
+					<Button href={ JETPACK_SUPPORT }>{ translate( 'Manual Installation' ) }</Button>
 				</Card>
 			);
 		}

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -19,7 +19,7 @@ import ActionPanelBody from 'my-sites/site-settings/action-panel/body';
 import ActionPanelFigure from 'my-sites/site-settings/action-panel/figure';
 import ActionPanelFooter from 'my-sites/site-settings/action-panel/footer';
 import Button from 'components/button';
-import support from 'lib/url/support';
+import { EMPTY_SITE } from 'lib/url/support';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 const StartOver = ( { translate, selectedSiteSlug } ) => {
@@ -53,10 +53,7 @@ const StartOver = ( { translate, selectedSiteSlug } ) => {
 					</p>
 				</ActionPanelBody>
 				<ActionPanelFooter>
-					<Button
-						className="settings-action-panel__support-button is-external"
-						href={ support.EMPTY_SITE }
-					>
+					<Button className="settings-action-panel__support-button is-external" href={ EMPTY_SITE }>
 						{ translate( 'Follow the Steps' ) }
 						<Gridicon icon="external" size={ 48 } />
 					</Button>

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -24,7 +24,10 @@ import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 const StartOver = ( { translate, selectedSiteSlug } ) => {
 	return (
-		<div className="main main-column" role="main">
+		<div
+			className="main main-column" // eslint-disable-line wpcalypso/jsx-classname-namespace
+			role="main"
+		>
 			<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug }>
 				<h1>{ translate( 'Start Over' ) }</h1>
 			</HeaderCake>
@@ -53,11 +56,17 @@ const StartOver = ( { translate, selectedSiteSlug } ) => {
 					</p>
 				</ActionPanelBody>
 				<ActionPanelFooter>
-					<Button className="settings-action-panel__support-button is-external" href={ EMPTY_SITE }>
+					<Button
+						className="settings-action-panel__support-button is-external" // eslint-disable-line wpcalypso/jsx-classname-namespace,max-len
+						href={ EMPTY_SITE }
+					>
 						{ translate( 'Follow the Steps' ) }
 						<Gridicon icon="external" size={ 48 } />
 					</Button>
-					<Button className="settings-action-panel__support-button" href="/help/contact">
+					<Button
+						className="settings-action-panel__support-button" // eslint-disable-line wpcalypso/jsx-classname-namespace
+						href="/help/contact"
+					>
 						{ translate( 'Contact Support' ) }
 					</Button>
 				</ActionPanelFooter>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -21,7 +21,7 @@ import SignupActions from 'lib/signup/actions';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import { getSuggestedUsername } from 'state/signup/optional-dependencies/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
-import support from 'lib/url/support';
+import { WPCC } from 'lib/url/support';
 import config from 'config';
 
 function getSocialServiceFromClientId( clientId ) {
@@ -103,7 +103,7 @@ export class UserStep extends Component {
 					'Not sure what this is all about? {{a}}We can help clear that up for you.{{/a}}',
 					{
 						components: {
-							a: <a href={ support.WPCC } target="_blank" />,
+							a: <a href={ WPCC } target="_blank" />,
 						},
 						comment:
 							'Text displayed on the Signup page to users willing to sign up for an app via WordPress.com',


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.

**This is take-2 of the work to update support URLs due to rebase conflicts**

Not that these are only named export constants. Should be pretty safe.