### PR TITLE
Domains: Ca-form: Fix props reference

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -88,7 +88,7 @@ class RegistrantExtraInfoCaForm extends React.PureComponent {
 		// Add defaults to redux state to make accepting default values work.
 		const neededRequiredDetails = difference(
 			[ 'lang', 'legalType', 'ciraAgreementAccepted' ],
-			keys( this.props.contactDetails.extra )
+			keys( this.props.contactDetailsExtra )
 		);
 
 		// Bail early as we already have the details from a previous purchase.


### PR DESCRIPTION
The ca-form should use 'this.props.contactDetailsExtra' (no dot).

I had to change the uk-form from using this pattern to `this.props.contactDetails.extra` (with the dot) to fix an issue there, so I'm guessing I changed it here too by mistake.

This would have been covered by even a very simple unit test, so I'll add that on Monday.

Introduced here https://github.com/Automattic/wp-calypso/pull/20750/files#diff-c86d961a1d872f5b82823f3a05aa9f03L91