### PR TITLE
Activity Log: Replace API source for credentials display in settings

### DIFF
--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -92,13 +92,9 @@ export default connect( state => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
 	const rewindState = getRewindState( state, siteId ).state;
-	const showRewindCredentials =
-		rewindState === 'active' ||
-		rewindState === 'provisioning' ||
-		rewindState === 'awaitingCredentials';
 
 	return {
-		showRewindCredentials,
+		showRewindCredentials: rewindState.state !== 'unavailable',
 		site,
 		siteId,
 		siteIsJetpack: isJetpackSite( state, siteId ),

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -19,15 +19,21 @@ import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import FormSecurity from 'my-sites/site-settings/form-security';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-import { isRewindActive } from 'state/selectors';
+import { getRewindState } from 'state/selectors';
 import JetpackDevModeNotice from 'my-sites/site-settings/jetpack-dev-mode-notice';
 import JetpackMonitor from 'my-sites/site-settings/form-jetpack-monitor';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import Placeholder from 'my-sites/site-settings/placeholder';
 import JetpackCredentials from 'my-sites/site-settings/jetpack-credentials';
-import QueryRewindStatus from 'components/data/query-rewind-status';
+import QueryRewindState from 'components/data/query-rewind-state';
 
-const SiteSettingsSecurity = ( { rewindActive, site, siteId, siteIsJetpack, translate } ) => {
+const SiteSettingsSecurity = ( {
+	showRewindCredentials,
+	site,
+	siteId,
+	siteIsJetpack,
+	translate,
+} ) => {
 	if ( ! site ) {
 		return <Placeholder />;
 	}
@@ -63,12 +69,12 @@ const SiteSettingsSecurity = ( { rewindActive, site, siteId, siteIsJetpack, tran
 
 	return (
 		<Main className="settings-security__main site-settings">
-			<QueryRewindStatus siteId={ siteId } />
+			<QueryRewindState siteId={ siteId } />
 			<DocumentHead title={ translate( 'Site Settings' ) } />
 			<JetpackDevModeNotice />
 			<SidebarNavigation />
 			<SiteSettingsNavigation site={ site } section="security" />
-			{ rewindActive && <JetpackCredentials /> }
+			{ showRewindCredentials && <JetpackCredentials /> }
 			<JetpackMonitor />
 			<FormSecurity />
 		</Main>
@@ -76,7 +82,7 @@ const SiteSettingsSecurity = ( { rewindActive, site, siteId, siteIsJetpack, tran
 };
 
 SiteSettingsSecurity.propTypes = {
-	rewindActive: PropTypes.bool,
+	showRewindCredentials: PropTypes.bool,
 	site: PropTypes.object,
 	siteId: PropTypes.number,
 	siteIsJetpack: PropTypes.bool,
@@ -85,9 +91,14 @@ SiteSettingsSecurity.propTypes = {
 export default connect( state => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
+	const rewindState = getRewindState( state, siteId ).state;
+	const showRewindCredentials =
+		rewindState === 'active' ||
+		rewindState === 'provisioning' ||
+		rewindState === 'awaitingCredentials';
 
 	return {
-		rewindActive: isRewindActive( state, siteId ),
+		showRewindCredentials,
 		site,
 		siteId,
 		siteIsJetpack: isJetpackSite( state, siteId ),


### PR DESCRIPTION
Previously we were hitting the deprecated endpoint at
`/activity-log/{ site }/rewind` to get information about whether or not
to show the Rewind credentials form in the **Security** settings.
This relied on client-side logic to determine if Rewind is `active`
or not but we have consolidated this logic in the server through
the `/sites/{ site }/rewind` API.

In this patch we're simply replacing the data source to use the
standardized API to ensure consistency in the display of the form.

**Testing**

Visit **My Sites** > **Settings** > **Security**. You will need to
be viewing a site with a Jetpack connection (else the **Security**
tab will be missing).

If your site is capable of activating **Rewind** then there should
be a credentials form at the top of the settings page. If not, then
it should be missing.

**There should be no functional or visual changes from the
existing behavior in master**.

**Site without Rewindability**
<img width="668" alt="screen shot 2018-01-13 at 2 33 18 pm" src="https://user-images.githubusercontent.com/5431237/34909430-d446ba98-f86e-11e7-9dd3-6ebc41895db6.png">

**Site with Rewindability**
<img width="677" alt="screen shot 2018-01-13 at 2 33 07 pm" src="https://user-images.githubusercontent.com/5431237/34909431-d6f55c7c-f86e-11e7-87a5-1bea1fa0fbaf.png">


---

In the future @rickybanister or @MichaelArestad or @samhotchkiss 
I think that in the absence of this credentials form it would be a good
place to include a nudge to upgrade the Jetpack plan. This would
both alleviate the gap/flash when it loads and also help point people
in the direction of **Rewind**

It's kind of awkward right now how it's sometimes there and other
times it's not there (there's no loading placeholder either because
until we get data from the API we don't know whether or not to show
anything here). Fixing this of course is out of scope of this PR.