### PR TITLE
Rewind Credentials: Shuffle props around

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 
@@ -14,11 +15,12 @@ import FoldableCard from 'components/foldable-card';
 import CompactCard from 'components/card/compact';
 import CredentialsForm from '../credentials-form/index';
 import Button from 'components/button';
+import { deleteCredentials, updateCredentials } from 'state/jetpack/credentials/actions';
 
 class CredentialsConfigured extends Component {
-	componentWillMount() {
-		this.setState( { isRevoking: false } );
-	}
+	state = {
+		isRevoking: false,
+	};
 
 	getProtocolDescription = protocol => {
 		const { translate } = this.props;
@@ -43,13 +45,11 @@ class CredentialsConfigured extends Component {
 
 	render() {
 		const {
-			isPressable,
+			canAutoconfigure,
 			credentialsUpdating,
 			mainCredentials,
 			formIsSubmitting,
 			siteId,
-			updateCredentials,
-			deleteCredentials,
 			translate,
 		} = this.props;
 
@@ -89,7 +89,7 @@ class CredentialsConfigured extends Component {
 			);
 		}
 
-		if ( isPressable ) {
+		if ( canAutoconfigure ) {
 			return (
 				<CompactCard className="credentials-configured" onClick={ this.toggleRevoking } href="#">
 					<Gridicon
@@ -133,10 +133,10 @@ class CredentialsConfigured extends Component {
 						role: 'main',
 						formIsSubmitting,
 						siteId,
-						updateCredentials,
+						updateCredentials: this.props.updateCredentials,
 						showCancelButton: false,
 						showDeleteButton: true,
-						deleteCredentials,
+						deleteCredentials: this.props.deleteCredentials,
 					} }
 				/>
 			</FoldableCard>
@@ -144,4 +144,9 @@ class CredentialsConfigured extends Component {
 	}
 }
 
-export default localize( CredentialsConfigured );
+const mapDispatchToProps = {
+	deleteCredentials,
+	updateCredentials,
+};
+
+export default connect( null, mapDispatchToProps )( localize( CredentialsConfigured ) );

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -4,6 +4,7 @@
  * External dependendies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { get, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -19,6 +20,7 @@ import FormTextArea from 'components/forms/form-textarea';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormPasswordInput from 'components/forms/form-password-input';
 import Gridicon from 'gridicons';
+import { updateCredentials } from 'state/jetpack/credentials/actions';
 
 export class CredentialsForm extends Component {
 	state = {
@@ -237,4 +239,4 @@ export class CredentialsForm extends Component {
 	}
 }
 
-export default localize( CredentialsForm );
+export default connect( null, { updateCredentials } )( localize( CredentialsForm ) );

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/index.jsx
@@ -1,8 +1,10 @@
+/** @format */
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 
@@ -13,57 +15,50 @@ import SetupStart from './setup-start';
 import SetupTos from './setup-tos';
 import SetupForm from './setup-form';
 import SetupFooter from './setup-footer';
+import { getCredentialsAutoConfigStatus } from 'state/selectors';
 
 class CredentialsSetupFlow extends Component {
 	static propTypes = {
-		isPressable: PropTypes.bool,
+		canAutoconfigure: PropTypes.bool,
 		formIsSubmitting: PropTypes.bool,
 		siteId: PropTypes.number,
-		updateCredentials: PropTypes.func,
-		autoConfigCredentials: PropTypes.func,
-		autoConfigStatus: PropTypes.string
+		autoConfigStatus: PropTypes.string,
 	};
 
-	componentWillMount() {
-		this.setState( { currentStep: 'start', showPopover: false } );
-	}
-
-	togglePopover = () => this.setState( { showPopover: ! this.state.showPopover } );
+	state = {
+		currentStep: 'start',
+		showPopover: false,
+	};
 
 	reset = () => this.setState( { currentStep: 'start' } );
 
-	getNextStep = step => get( {
-		start: 'tos',
-		tos: 'form',
-	}, step, step );
+	getNextStep = step =>
+		get(
+			{
+				start: 'tos',
+				tos: 'form',
+			},
+			step,
+			step
+		);
 
-	goToNextStep = () => this.setState( {
-		currentStep: this.getNextStep( this.state.currentStep )
-	} );
-
-	autoConfigure = () => this.props.autoConfigCredentials( this.props.siteId );
+	goToNextStep = () =>
+		this.setState( {
+			currentStep: this.getNextStep( this.state.currentStep ),
+		} );
 
 	render() {
-		const {
-			isPressable,
-			formIsSubmitting,
-			updateCredentials,
-			siteId
-		} = this.props;
+		const { canAutoconfigure, formIsSubmitting, siteId } = this.props;
 
 		return (
 			<div className="credentials-setup-flow">
-				{ 'start' === this.state.currentStep && (
-					<SetupStart
-						goToNextStep={ this.goToNextStep }
-					/>
-				) }
+				{ 'start' === this.state.currentStep && <SetupStart goToNextStep={ this.goToNextStep } /> }
 				{ 'tos' === this.state.currentStep && (
 					<SetupTos
-						autoConfigure={ this.autoConfigure }
-						isPressable={ isPressable }
-						reset={ this.reset }
+						canAutoconfigure={ canAutoconfigure }
 						goToNextStep={ this.goToNextStep }
+						reset={ this.reset }
+						siteId={ siteId }
 					/>
 				) }
 				{ 'form' === this.state.currentStep && [
@@ -72,7 +67,6 @@ class CredentialsSetupFlow extends Component {
 						formIsSubmitting={ formIsSubmitting }
 						reset={ this.reset }
 						siteId={ siteId }
-						updateCredentials={ updateCredentials }
 					/>,
 					<SetupFooter key="credentials-flow-setup-form-footer" />,
 				] }
@@ -81,4 +75,8 @@ class CredentialsSetupFlow extends Component {
 	}
 }
 
-export default localize( CredentialsSetupFlow );
+const mapStateToProps = ( state, { siteId } ) => ( {
+	autoConfigStatus: getCredentialsAutoConfigStatus( state, siteId ),
+} );
+
+export default connect( mapStateToProps )( localize( CredentialsSetupFlow ) );

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-form.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-form.jsx
@@ -3,14 +3,12 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
 import CredentialsForm from '../credentials-form/index';
-import { updateCredentials } from 'state/jetpack/credentials/actions';
 
 const SetupForm = ( { formIsSubmitting, reset, siteId } ) => (
 	<CompactCard>
@@ -26,11 +24,10 @@ const SetupForm = ( { formIsSubmitting, reset, siteId } ) => (
 				kpri: '',
 				onCancel: reset,
 				siteId,
-				updateCredentials: this.props.updateCredentials,
 				showCancelButton: true,
 			} }
 		/>
 	</CompactCard>
 );
 
-export default connect( null, { updateCredentials } )( SetupForm );
+export default SetupForm;

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-form.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-form.jsx
@@ -1,31 +1,36 @@
+/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
 import CredentialsForm from '../credentials-form/index';
+import { updateCredentials } from 'state/jetpack/credentials/actions';
 
-const SetupForm = ( { formIsSubmitting, reset, siteId, updateCredentials } ) => (
+const SetupForm = ( { formIsSubmitting, reset, siteId } ) => (
 	<CompactCard>
-		<CredentialsForm { ...{
-			formIsSubmitting,
-			protocol: 'ssh',
-			host: '',
-			port: '22',
-			user: '',
-			pass: '',
-			abspath: '',
-			kpri: '',
-			onCancel: reset,
-			siteId,
-			updateCredentials,
-			showCancelButton: true
-		} } />
+		<CredentialsForm
+			{ ...{
+				formIsSubmitting,
+				protocol: 'ssh',
+				host: '',
+				port: '22',
+				user: '',
+				pass: '',
+				abspath: '',
+				kpri: '',
+				onCancel: reset,
+				siteId,
+				updateCredentials: this.props.updateCredentials,
+				showCancelButton: true,
+			} }
+		/>
 	</CompactCard>
 );
 
-export default SetupForm;
+export default connect( null, { updateCredentials } )( SetupForm );

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-tos.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-tos.jsx
@@ -1,7 +1,9 @@
+/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -10,35 +12,45 @@ import { localize } from 'i18n-calypso';
 import CompactCard from 'components/card/compact';
 import Gridicon from 'gridicons';
 import Button from 'components/button';
+import { autoConfigCredentials } from 'state/jetpack/credentials/actions';
 
-const SetupTos = ( { autoConfigure, isPressable, reset, translate, goToNextStep } ) => (
-	<CompactCard
-		className="credentials-setup-flow__tos"
-		highlight="info"
-	>
+const SetupTos = ( { autoConfigure, canAutoconfigure, reset, translate, goToNextStep } ) => (
+	<CompactCard className="credentials-setup-flow__tos" highlight="info">
 		<Gridicon icon="info" size={ 48 } className="credentials-setup-flow__tos-gridicon" />
 		<div className="credentials-setup-flow__tos-text">
-			{
-				isPressable
-					? translate( 'WordPress.com can obtain the credentials from your ' +
-					'current host which are necessary to perform site backups and ' +
-					'restores. Do you want to give WordPress.com access to your ' +
-					'host\'s server?' )
-					: translate( 'By adding your site credentials, you are giving ' +
-					'WordPress.com access to perform automatic actions on your ' +
-					'server including backing up your site, restoring your site, ' +
-					'as well as manually accessing your site in case of an emergency.' )
-			}
+			{ canAutoconfigure
+				? translate(
+						'WordPress.com can obtain the credentials from your ' +
+							'current host which are necessary to perform site backups and ' +
+							'restores. Do you want to give WordPress.com access to your ' +
+							"host's server?"
+					)
+				: translate(
+						'By adding your site credentials, you are giving ' +
+							'WordPress.com access to perform automatic actions on your ' +
+							'server including backing up your site, restoring your site, ' +
+							'as well as manually accessing your site in case of an emergency.'
+					) }
 		</div>
 		<div className="credentials-setup-flow__tos-buttons">
-			<Button borderless={ true } onClick={ reset }>{ translate( 'Cancel' ) }</Button>
-			{
-				isPressable
-					? <Button primary onClick={ autoConfigure }>{ translate( 'Auto Configure' ) }</Button>
-					: <Button primary onClick={ goToNextStep }>{ translate( 'Ok, I understand' ) }</Button>
-			}
+			<Button borderless={ true } onClick={ reset }>
+				{ translate( 'Cancel' ) }
+			</Button>
+			{ canAutoconfigure ? (
+				<Button primary onClick={ autoConfigure }>
+					{ translate( 'Auto Configure' ) }
+				</Button>
+			) : (
+				<Button primary onClick={ goToNextStep }>
+					{ translate( 'Ok, I understand' ) }
+				</Button>
+			) }
 		</div>
 	</CompactCard>
 );
 
-export default localize( SetupTos );
+const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
+	autoConfigure: () => dispatch( autoConfigCredentials( siteId ) ),
+} );
+
+export default connect( null, mapDispatchToProps )( localize( SetupTos ) );

--- a/client/my-sites/site-settings/jetpack-credentials/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/index.jsx
@@ -1,6 +1,9 @@
 /**
  * External dependencies
+ *
+ * @format
  */
+
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
@@ -13,99 +16,101 @@ import CompactCard from 'components/card/compact';
 import CredentialsSetupFlow from './credentials-setup-flow/index';
 import CredentialsConfigured from './credentials-configured/index';
 import Gridicon from 'gridicons';
+import QueryRewindState from 'components/data/query-rewind-state';
 import QueryRewindStatus from 'components/data/query-rewind-status';
 import QueryJetpackCredentials from 'components/data/query-jetpack-credentials';
-import { isRewindActive } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
 	getJetpackCredentials,
-	isUpdatingJetpackCredentials,
+	getRewindState,
 	hasMainCredentials,
-	isSitePressable,
-	getCredentialsAutoConfigStatus
+	isRewindActive,
+	isUpdatingJetpackCredentials,
 } from 'state/selectors';
-import {
-	updateCredentials,
-	autoConfigCredentials,
-	deleteCredentials,
-} from 'state/jetpack/credentials/actions';
 
 class Backups extends Component {
 	static propTypes = {
-		autoConfigStatus: PropTypes.string,
 		formIsSubmitting: PropTypes.bool,
 		hasMainCredentials: PropTypes.bool,
 		mainCredentials: PropTypes.object,
 		isPressable: PropTypes.bool,
 		isRewindActive: PropTypes.bool,
-		siteId: PropTypes.number.isRequired
+		siteId: PropTypes.number.isRequired,
 	};
 
 	render() {
 		const {
-			autoConfigStatus,
-			hasMainCredentials, // eslint-disable-line no-shadow
-			isPressable,
-			isRewindActive, // eslint-disable-line no-shadow
-			translate,
 			formIsSubmitting,
-			updateCredentials,
+			hasMainCredentials, // eslint-disable-line no-shadow
+			isRewindActive, // eslint-disable-line no-shadow
+			mainCredentials,
+			rewindState,
 			siteId,
-			autoConfigCredentials
+			translate,
 		} = this.props;
+
+		const canAutoconfigure =
+			!! rewindState.canAutoconfigure ||
+			( rewindState.credentials || [] ).some( cred => cred.type === 'auto' );
 
 		return (
 			<div className="jetpack-credentials">
+				<QueryRewindState siteId={ this.props.siteId } />
 				<QueryRewindStatus siteId={ this.props.siteId } />
 				<QueryJetpackCredentials siteId={ this.props.siteId } />
 				{ isRewindActive && (
 					<CompactCard className="jetpack-credentials__header">
 						<span>{ translate( 'Backups and security scans' ) }</span>
-							{ hasMainCredentials && (
-								<span className="jetpack-credentials__connected">
-									<Gridicon icon="checkmark" size={ 18 } className="jetpack-credentials__connected-checkmark" />
-									{ translate( 'Connected' ) }
-								</span>
-							) }
+						{ hasMainCredentials && (
+							<span className="jetpack-credentials__connected">
+								<Gridicon
+									icon="checkmark"
+									size={ 18 }
+									className="jetpack-credentials__connected-checkmark"
+								/>
+								{ translate( 'Connected' ) }
+							</span>
+						) }
 					</CompactCard>
 				) }
 
-				{ isRewindActive && ! hasMainCredentials && (
-					<CredentialsSetupFlow { ...{
-						isPressable,
-						formIsSubmitting,
-						siteId,
-						updateCredentials,
-						autoConfigCredentials,
-						autoConfigStatus
-					} } />
-				) }
+				{ isRewindActive &&
+					! hasMainCredentials && (
+						<CredentialsSetupFlow
+							{ ...{
+								canAutoconfigure,
+								formIsSubmitting,
+								siteId,
+							} }
+						/>
+					) }
 
-				{ isRewindActive && hasMainCredentials && (
-					<CredentialsConfigured { ...this.props } />
-				) }
+				{ isRewindActive &&
+					hasMainCredentials && (
+						<CredentialsConfigured
+							{ ...{
+								canAutoconfigure,
+								mainCredentials,
+								formIsSubmitting,
+								siteId,
+							} }
+						/>
+					) }
 			</div>
 		);
 	}
 }
 
-export default connect(
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
-		const credentials = getJetpackCredentials( state, siteId, 'main' );
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+	const credentials = getJetpackCredentials( state, siteId, 'main' );
 
-		return {
-			autoConfigStatus: getCredentialsAutoConfigStatus( state, siteId ),
-			formIsSubmitting: isUpdatingJetpackCredentials( state, siteId ),
-			hasMainCredentials: hasMainCredentials( state, siteId ),
-			mainCredentials: credentials,
-			isPressable: isSitePressable( state, siteId ),
-			isRewindActive: isRewindActive( state, siteId ),
-			siteId,
-		};
-	}, {
-		autoConfigCredentials,
-		updateCredentials,
-		deleteCredentials,
-	}
-)( localize( Backups ) );
+	return {
+		formIsSubmitting: isUpdatingJetpackCredentials( state, siteId ),
+		hasMainCredentials: hasMainCredentials( state, siteId ),
+		mainCredentials: credentials,
+		isRewindActive: isRewindActive( state, siteId ),
+		rewindState: getRewindState( state, siteId ),
+		siteId,
+	};
+} )( localize( Backups ) );

--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -34,6 +34,7 @@ export const transformApi = data =>
 			state: camelCase( data.state ),
 			lastUpdated: new Date( data.last_updated * 1000 ),
 		},
+		data.hasOwnProperty( 'can_autoconfigure' ) && { canAutoconfigure: data.can_autoconfigure },
 		data.credentials && { credentials: data.credentials.map( transformCredential ) },
 		data.downloads && { downloads: data.downloads.map( transformDownload ) },
 		data.reason && { failureReason: data.reason },

--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -3,10 +3,22 @@
  * Internal dependencies
  */
 import { mergeHandlers } from 'state/action-watchers/utils';
-import { REWIND_STATE_REQUEST, REWIND_STATE_UPDATE } from 'state/action-types';
+import {
+	JETPACK_CREDENTIALS_AUTOCONFIGURE,
+	JETPACK_CREDENTIALS_DELETE,
+	JETPACK_CREDENTIALS_UPDATE,
+	REWIND_STATE_REQUEST,
+	REWIND_STATE_UPDATE,
+} from 'state/action-types';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+import { requestRewindState } from 'state/rewind/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { dispatchRequestEx, makeParser } from 'state/data-layer/wpcom-http/utils';
+import {
+	dispatchRequestEx,
+	getData,
+	getError,
+	makeParser,
+} from 'state/data-layer/wpcom-http/utils';
 import { transformApi } from './api-transformer';
 import { rewind } from './schema';
 
@@ -46,7 +58,19 @@ const setUnknownState = ( { siteId }, error ) =>
 		}
 	);
 
+/*
+ * In response to network activity for the watched types
+ * Also update the Rewind state to see changes
+ */
+const alsoUpdateRewindState = ( { dispatch }, action ) =>
+	getData( action ) || getError( action )
+		? dispatch( requestRewindState( action.siteId ) )
+		: undefined;
+
 export default mergeHandlers( downloads, {
+	[ JETPACK_CREDENTIALS_AUTOCONFIGURE ]: [ alsoUpdateRewindState ],
+	[ JETPACK_CREDENTIALS_DELETE ]: [ alsoUpdateRewindState ],
+	[ JETPACK_CREDENTIALS_UPDATE ]: [ alsoUpdateRewindState ],
 	[ REWIND_STATE_REQUEST ]: [
 		dispatchRequestEx( {
 			fetch: fetchRewindState,


### PR DESCRIPTION
This is part of a mini-project to untangle data flows within the
Activity Log and Rewind system so that each component operates more
independently of its parents and can be worked on in isolation.

Many of the props and callbacks relevant to Jetpack Rewind credentials
get passed down through multiple chains of React component props. In
this patch we're disconnecting some of those parent-child relationships.

This is preparatory work further to deprecate and eventually remove code
dependent on the older and also-deprecated Rewind APIs, preferring
instead to move to the specified and centralized "state machine" API

**There should be no visual changes in this PR from master**

**Testing**

Since this patch impacts Jetpack Rewind credentials, navigate to
**My Sites** > **Settings** > **Security** for a site with a Jetpack
connection and also one which can activate **Rewind**. Try activating
auto-credentials and revoke credentials, try adding custom credentials.
Make sure everything works as expected.