### PR TITLE
Async Loader Babel Transform: Import directly in test

### DIFF
--- a/server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js
+++ b/server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js
@@ -7,7 +7,7 @@ const babel = require( 'babel-core' );
 describe( 'babel-plugin-transform-wpcalypso-async', () => {
 	function transform( code, async = true ) {
 		return babel.transform( code, {
-			plugins: [ 'syntax-jsx', [ __dirname + '/../', { async } ] ],
+			plugins: [ 'syntax-jsx', [ require( '..' ), { async } ] ],
 		} ).code;
 	}
 


### PR DESCRIPTION
We have been having failing tests for no understandable reason.

In this commit I'm replacing the string-concatenation-based path
joining in the babel options with a node `require( .. )` which should
eliminate any platform-specific or sporadic behaviors.

Hopefully this will resolve the spurious test failures.

This is a copy of the failing tests which seem unrelated to the
changes in several of my PRs…

```
ReferenceError: Unknown plugin "server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/../" specified in "base" at 1, attempted to resolve relative to "/home/ubuntu/wp-calypso"
  at /home/ubuntu/wp-calypso/node_modules/babel-core/lib/transformation/file/options/option-manager.js:180:17
  at Array.map (<anonymous>)
  at Function.normalisePlugins (/home/ubuntu/wp-calypso/node_modules/babel-core/lib/transformation/file/options/option-manager.js:158:20)
  at OptionManager.mergeOptions (/home/ubuntu/wp-calypso/node_modules/babel-core/lib/transformation/file/options/option-manager.js:234:36)
  at OptionManager.init (/home/ubuntu/wp-calypso/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
  at File.initOptions (/home/ubuntu/wp-calypso/node_modules/babel-core/lib/transformation/file/index.js:212:65)
  at new File (/home/ubuntu/wp-calypso/node_modules/babel-core/lib/transformation/file/index.js:135:24)
  at Pipeline.transform (/home/ubuntu/wp-calypso/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
  at transform (server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js:9:16)
  at Object.<anonymous> (server/bundler/babel/babel-plugin-transform-wpcalypso-async/test/index.js:72:16)
```

**Testing**

Examine the code and reason if any of this seems problematic.

To determine if this fixes the stated problem:
Find a PR which is failing in CircleCI because of these errors, merge this branch
into the PR, then see if the tests pass.