### PR TITLE
Add: ca-form smoke test

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -33,7 +33,9 @@ const defaultValues = {
 export class RegistrantExtraInfoCaForm extends React.PureComponent {
 	static propTypes = {
 		contactDetailsExtra: PropTypes.object.isRequired,
+		userWpcomLang: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+		getFieldProps: PropTypes.func.isRequired,
 	};
 
 	constructor( props ) {

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -22,6 +22,7 @@ import FormSelect from 'components/forms/form-select';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormInputValidation from 'components/forms/form-input-validation';
 import { Input } from 'my-sites/domains/components/form';
+import { disableSubmitButton } from './with-contact-details-validation';
 
 const ciraAgreementUrl = 'https://services.cira.ca/agree/agreement/agreementVersion2.0.jsp';
 const defaultValues = {
@@ -180,10 +181,9 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 			doesntNeedOrganizationField || ! organizationFieldProps.isError;
 
 		const formIsValid = ciraAgreementAccepted && organizationFieldIsValid;
-
 		const validatingSubmitButton = formIsValid
 			? this.props.children
-			: React.cloneElement( this.props.children, { disabled: true } );
+			: disableSubmitButton( this.props.children );
 
 		return (
 			<form className="registrant-extra-info__form">

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -30,7 +30,7 @@ const defaultValues = {
 	ciraAgreementAccepted: false,
 };
 
-class RegistrantExtraInfoCaForm extends React.PureComponent {
+export class RegistrantExtraInfoCaForm extends React.PureComponent {
 	static propTypes = {
 		contactDetailsExtra: PropTypes.object.isRequired,
 		translate: PropTypes.func.isRequired,

--- a/client/components/domains/registrant-extra-info/test/ca-form.js
+++ b/client/components/domains/registrant-extra-info/test/ca-form.js
@@ -1,0 +1,33 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { RegistrantExtraInfoCaForm } from '../ca-form';
+
+jest.mock( 'store', () => ( { get: () => {}, set: () => {} } ) );
+jest.mock( 'lib/analytics', () => {} );
+
+const mockProps = {
+	translate: identity,
+	updateContactDetailsCache: identity,
+	userWpcomLang: 'EN',
+	getFieldProps: () => ( {} ),
+};
+
+describe( 'ca-form', () => {
+	test( 'should render without errors when extra is empty', () => {
+		const testProps = {
+			...mockProps,
+			contactDetailsExtra: {},
+		};
+
+		shallow( <RegistrantExtraInfoCaForm { ...testProps } /> );
+	} );
+} );


### PR DESCRIPTION
Following up on #21511, this PR adds a very basic ca-form test that's still enough to catch basic problems like that one.

Adding the test turned up a couple of missing required properties, so I've added those too.

I also tweaked the behaviour of the submit button (in known-good ways) to make testing easier (by making children optional), so we should double-checking that that works:

![ca-form](https://user-images.githubusercontent.com/5952255/34922833-c3bc9760-f9e0-11e7-945e-4c30a490a6ff.gif)
