### PR TITLE
Webpack: stop silently bundling the crypto-browserify library

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -161,6 +161,7 @@ const webpackConfig = {
 		__filename: 'mock',
 		__dirname: 'mock',
 		fs: 'empty',
+		crypto: false,
 	},
 	plugins: _.compact( [
 		new webpack.DefinePlugin( {


### PR DESCRIPTION
Sometimes folks need to perform some crypto operation, i.e., compute a MD5 or SHA-1 hash, and they `require( 'crypto' )` to implement that.

When asked to import the `crypto` module, Webpack silently bundles the huge and bloated `crypto-browserify` library without raising a single eyebrow.

There are much better options: there is the tiny `hash.js` module, and all supported browsers (including IE11) support many crypto functions natively with the `window.crypto.subtle` (or `msCrypto` for IE11) object.

This patch disables the `crypto` library in Webpack config and makes the build fail when trying to import it.