### PR TITLE
State: Update isJetpackOnboardingStepCompleted names

### DIFF
--- a/client/state/selectors/is-jetpack-onboarding-step-completed.js
+++ b/client/state/selectors/is-jetpack-onboarding-step-completed.js
@@ -33,11 +33,11 @@ export default createSelector(
 			case STEPS.HOMEPAGE:
 				return !! get( settings, 'homepageFormat' );
 			case STEPS.CONTACT_FORM:
-				return !! get( settings, 'contactForm' );
+				return !! get( settings, 'addContactForm' );
 			case STEPS.BUSINESS_ADDRESS:
 				return !! get( settings, 'businessAddress' );
 			case STEPS.WOOCOMMERCE:
-				return !! get( settings, 'woocommerce' );
+				return !! get( settings, 'installWooCommerce' );
 			default:
 				return false;
 		}

--- a/client/state/selectors/test/is-jetpack-onboarding-step-completed.js
+++ b/client/state/selectors/test/is-jetpack-onboarding-step-completed.js
@@ -196,7 +196,7 @@ describe( 'isJetpackOnboardingStepCompleted()', () => {
 			jetpackOnboarding: {
 				settings: {
 					2916284: {
-						contactForm: true,
+						addContactForm: true,
 					},
 				},
 			},
@@ -226,7 +226,7 @@ describe( 'isJetpackOnboardingStepCompleted()', () => {
 			jetpackOnboarding: {
 				settings: {
 					2916284: {
-						contactForm: false,
+						addContactForm: false,
 					},
 				},
 			},
@@ -286,7 +286,7 @@ describe( 'isJetpackOnboardingStepCompleted()', () => {
 			jetpackOnboarding: {
 				settings: {
 					2916284: {
-						woocommerce: true,
+						installWooCommerce: true,
 					},
 				},
 			},
@@ -316,7 +316,7 @@ describe( 'isJetpackOnboardingStepCompleted()', () => {
 			jetpackOnboarding: {
 				settings: {
 					2916284: {
-						woocommerce: false,
+						installWooCommerce: false,
 					},
 				},
 			},


### PR DESCRIPTION
This PR updates the properties in the `isJetpackOnboardingStepCompleted` to use the right names, so they could be compliant with the ones we use to save data.

To test:
* Checkout this branch
* Verify all tests pass:

```
npm run test-client client/state/selectors/test/is-jetpack-onboarding-step-completed.js
```