### PR TITLE
Themes: Update schema patternProperties to include dash

### DIFF
--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -109,7 +109,7 @@ export const themeFiltersSchema = {
 	type: 'object',
 	patternProperties: {
 		// Taxonomy ID
-		'^\\w+$': {
+		'^[\\w-]+$': {
 			title: 'Taxonomy',
 			type: 'object',
 			patternProperties: {


### PR DESCRIPTION
`skill-level` was invalidating persistence schema:

![skill-level](https://user-images.githubusercontent.com/841763/34938966-72df6a16-f9ea-11e7-9dbd-c03d5099ee90.png)

The PR updates the regex to allow `-`.

## Testing
1. Visit /themes in development environment
1. Refresh
1. Verify no state invalidation warning is displayed