### PR TITLE
Jetpack Connect: Use constants

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -38,6 +38,7 @@ import { authQueryPropTypes, getRoleFromScope } from './utils';
 import { decodeEntities } from 'lib/formatting';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { isRequestingSite, isRequestingSites } from 'state/sites/selectors';
+import { JPC_PATH_PLANS } from './constants';
 import { login } from 'lib/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
@@ -62,9 +63,8 @@ import {
 /**
  * Constants
  */
-const MAX_AUTH_ATTEMPTS = 3;
-const PLANS_PAGE = '/jetpack/connect/plans/';
 const debug = debugModule( 'calypso:jetpack-connect:authorize-form' );
+const MAX_AUTH_ATTEMPTS = 3;
 const PRESSABLE_PARTNER_ID = 49640;
 
 export class JetpackAuthorize extends Component {
@@ -528,7 +528,7 @@ export class JetpackAuthorize extends Component {
 			return `/start/pressable-nux?blogid=${ clientId }`;
 		}
 
-		return addQueryArgs( { redirect: redirectAfterAuth }, PLANS_PAGE + siteSlug );
+		return addQueryArgs( { redirect: redirectAfterAuth }, `${ JPC_PATH_PLANS }/${ siteSlug }` );
 	}
 
 	renderFooterLinks() {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -38,7 +38,7 @@ import { authQueryPropTypes, getRoleFromScope } from './utils';
 import { decodeEntities } from 'lib/formatting';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { isRequestingSite, isRequestingSites } from 'state/sites/selectors';
-import { JPC_PATH_PLANS } from './constants';
+import { JPC_PATH_PLANS, REMOTE_PATH_AUTH } from './constants';
 import { login } from 'lib/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
@@ -268,13 +268,12 @@ export class JetpackAuthorize extends Component {
 
 	handleResolve = () => {
 		const { site, recordTracksEvent } = this.props;
-		const authUrl = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true';
 		this.retryingAuth = false;
 		if ( this.props.hasExpiredSecretError ) {
 			// In this case, we need to re-issue the secret.
 			// We do this by redirecting to Jetpack client, which will automatically redirect back here.
 			recordTracksEvent( 'calypso_jpc_resolve_expired_secret_error_click' );
-			this.externalRedirectOnce( site + authUrl );
+			this.externalRedirectOnce( site + REMOTE_PATH_AUTH );
 			return;
 		}
 		// Otherwise, we assume the site is having trouble receive XMLRPC requests.

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -29,7 +29,7 @@ import userFactory from 'lib/user';
 import { authorizeQueryDataSchema } from './schema';
 import { authQueryTransformer } from './utils';
 import { JETPACK_CONNECT_QUERY_SET } from 'state/action-types';
-import { MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
+import { JPC_PATH_PLANS, MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
 import { receiveJetpackOnboardingCredentials } from 'state/jetpack-onboarding/actions';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
@@ -309,7 +309,7 @@ export function plansSelection( context, next ) {
 	context.primary = (
 		<CheckoutData>
 			<Plans
-				basePlansPath={ '/jetpack/connect/plans' }
+				basePlansPath={ JPC_PATH_PLANS }
 				context={ context }
 				destinationType={ context.params.destinationType }
 				interval={ context.params.interval }

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -28,6 +28,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
+import { JPC_PATH_PLANS } from './constants';
 import { mc } from 'lib/analytics';
 import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -80,7 +81,7 @@ class Plans extends Component {
 		}
 		if ( ! this.props.selectedSite && this.props.isSitesInitialized ) {
 			// Invalid site
-			this.redirect( '/jetpack/connect/plans' );
+			this.redirect( JPC_PATH_PLANS );
 		}
 		if ( ! this.props.canPurchasePlans ) {
 			if ( this.props.calypsoStartedConnection ) {

--- a/client/jetpack-connect/test/lib/plans.js
+++ b/client/jetpack-connect/test/lib/plans.js
@@ -64,14 +64,14 @@ export const SITE_PLAN_PRO = deepFreeze( {
 } );
 
 export const CONTEXT = deepFreeze( {
-	canonicalPath: `/jetpack/connect/plans/${ SITE_SLUG }`,
-	path: `/jetpack/connect/plans/${ SITE_SLUG }`,
+	canonicalPath: `${ BASE_PLANS_PATH }/${ SITE_SLUG }`,
+	path: `${ BASE_PLANS_PATH }/${ SITE_SLUG }`,
 	title: 'WordPress.com',
-	state: { path: `/jetpack/connect/plans/${ SITE_SLUG }` },
+	state: { path: `${ BASE_PLANS_PATH }/${ SITE_SLUG }` },
 	querystring: '',
-	pathname: `/jetpack/connect/plans/${ SITE_SLUG }`,
+	pathname: `${ BASE_PLANS_PATH }/${ SITE_SLUG }`,
 	params: {
-		0: `/jetpack/connect/plans/${ SITE_SLUG }`,
+		0: `${ BASE_PLANS_PATH }/${ SITE_SLUG }`,
 		site: SITE_SLUG,
 	},
 	hash: {},


### PR DESCRIPTION
This PR updates some string and other constants to use shared constant values for Jetpack Connect.

There should be no functional changes.

## Testing
1. Verify flow continue to work ask before
1. In particular, auth flows started in Calypso should land at the correct plans page in Calypso.