### PR TITLE
State: Add documentation to all JPO selectors

### DIFF
--- a/client/state/selectors/get-jetpack-onboarding-progress.js
+++ b/client/state/selectors/get-jetpack-onboarding-progress.js
@@ -10,6 +10,14 @@ import { reduce } from 'lodash';
  */
 import { isJetpackOnboardingStepCompleted } from 'state/selectors';
 
+/**
+ * Returns the Jetpack onboarding progress of a site for the specified steps.
+ *
+ * @param  {Object}   state   Global state tree.
+ * @param  {Integer}  siteId  Unconnected site ID.
+ * @param  {Array}    steps   Array of steps to retrieve onboarding progress for.
+ * @return {Object}           An object containing all steps and whether each of them has been completed.
+ */
 export default function getJetpackOnboardingProgress( state, siteId, steps ) {
 	return reduce(
 		steps,

--- a/client/state/selectors/get-jetpack-onboarding-settings.js
+++ b/client/state/selectors/get-jetpack-onboarding-settings.js
@@ -6,8 +6,8 @@
 import { get } from 'lodash';
 
 /**
- * Returns the Jetpack onboarding settings of a particular site.
- * Returns null if site is not known.
+ * Returns the Jetpack onboarding settings of a given site.
+ * Returns null it the site is unknown.
  *
  * @param  {Object}   state   Global state tree.
  * @param  {Integer}  siteId  Unconnected site ID.

--- a/client/state/selectors/get-jetpack-onboarding-settings.js
+++ b/client/state/selectors/get-jetpack-onboarding-settings.js
@@ -5,6 +5,14 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Returns the Jetpack onboarding settings of a particular site.
+ * Returns null if site is not known.
+ *
+ * @param  {Object}   state   Global state tree.
+ * @param  {Integer}  siteId  Unconnected site ID.
+ * @return {?Object}          An object containing the currently known onboarding settings of the site.
+ */
 export default function getJetpackOnboardingSettings( state, siteId ) {
 	return get( state.jetpackOnboarding.settings, siteId, null );
 }

--- a/client/state/selectors/get-unconnected-site-id-by-slug.js
+++ b/client/state/selectors/get-unconnected-site-id-by-slug.js
@@ -9,6 +9,14 @@ import { findKey } from 'lodash';
  */
 import { urlToSlug } from 'lib/url';
 
+/**
+ * Returns the ID of particular Jetpack onboarding site by the site slug.
+ * Returns null if site is not known.
+ *
+ * @param  {Object}   state     Global state tree.
+ * @param  {String}   siteSlug  Slug of the unconnected site.
+ * @return {?Integer}           ID of the unconnected site.
+ */
 export default function getUnconnectedSiteIdBySlug( state, siteSlug ) {
 	const siteId = findKey(
 		state.jetpackOnboarding.credentials,

--- a/client/state/selectors/get-unconnected-site-url.js
+++ b/client/state/selectors/get-unconnected-site-url.js
@@ -10,6 +10,14 @@ import { get } from 'lodash';
  */
 import { getUnconnectedSite } from 'state/selectors';
 
+/**
+ * Returns the URL of a particular Jetpack onboarding site.
+ * Returns null if site is not known.
+ *
+ * @param  {Object}   state   Global state tree.
+ * @param  {Integer}  siteId  Unconnected site ID.
+ * @return {?String}          URL of the site.
+ */
 export default function getUnconnectedSiteUrl( state, siteId ) {
 	const site = getUnconnectedSite( state, siteId );
 	if ( ! site ) {

--- a/client/state/selectors/get-unconnected-site.js
+++ b/client/state/selectors/get-unconnected-site.js
@@ -5,6 +5,14 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Returns the Jetpack onboarding credentials of a particular site.
+ * Returns null if site is not known.
+ *
+ * @param  {Object}   state   Global state tree.
+ * @param  {Integer}  siteId  Unconnected site ID.
+ * @return {?Object}          An object containing the onboarding credentials of the site.
+ */
 export default function getUnconnectedSite( state, siteId ) {
 	return get( state.jetpackOnboarding.credentials, siteId, null );
 }

--- a/client/state/selectors/is-jetpack-onboarding-step-completed.js
+++ b/client/state/selectors/is-jetpack-onboarding-step-completed.js
@@ -13,6 +13,14 @@ import createSelector from 'lib/create-selector';
 import { getJetpackOnboardingSettings } from 'state/selectors';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from 'jetpack-onboarding/constants';
 
+/**
+ * Returns whether a Jetpack onboarding step is completed or not.
+ *
+ * @param  {Object}   state     Global state tree.
+ * @param  {Integer}  siteId    Unconnected site ID.
+ * @param  {String}   stepName  Name of the Jetpack onboarding step.
+ * @return {Boolean}            True if step has been completed, false otherwise.
+ */
 export default createSelector(
 	( state, siteId, stepName ) => {
 		const settings = getJetpackOnboardingSettings( state, siteId );


### PR DESCRIPTION
This PR adds some JSDoc to the all selectors that we recently introduced for JPO.

No testing is necessary, this just adds doc blocks.