### PR TITLE
State: Enhance JPO save error notice

### DIFF
--- a/client/state/data-layer/wpcom/jetpack-onboarding/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/index.js
@@ -109,8 +109,13 @@ export const storeJetpackOnboardingSettings = ( { dispatch }, { settings, siteId
 	dispatch( updateJetpackOnboardingSettings( siteId, settings ) );
 };
 
-export const announceSaveFailure = ( { dispatch } ) =>
-	dispatch( errorNotice( translate( 'An unexpected error occurred. Please try again later.' ) ) );
+export const announceSaveFailure = ( { dispatch }, { siteId } ) =>
+	dispatch(
+		errorNotice( translate( 'An unexpected error occurred. Please try again later.' ), {
+			id: `jpo-notice-error-${ siteId }`,
+			duration: 5000,
+		} )
+	);
 
 export default {
 	[ JETPACK_ONBOARDING_SETTINGS_REQUEST ]: [

--- a/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
@@ -198,15 +198,18 @@ describe( 'storeJetpackOnboardingSettings()', () => {
 
 describe( 'announceSaveFailure()', () => {
 	const dispatch = jest.fn();
+	const siteId = 12345678;
 
 	test( 'should trigger an error notice upon unsuccessful save request', () => {
-		announceSaveFailure( { dispatch } );
+		announceSaveFailure( { dispatch }, { siteId } );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				notice: expect.objectContaining( {
 					status: 'is-error',
 					text: 'An unexpected error occurred. Please try again later.',
+					noticeId: `jpo-notice-error-${ siteId }`,
+					duration: 5000,
 				} ),
 			} )
 		);


### PR DESCRIPTION
While working on JPO I noticed a couple of things with the error notice that we display when save is unsuccessful:

* Notice will never disappear.
* Similar notices inadvertently stack up.

This PR fixes both issues by:

* Introducing an ID for the error notice.
* Introducing a duration for the error notice.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/onboarding/test
* In the console, type `dispatch( { type: 'JETPACK_ONBOARDING_SETTINGS_SAVE' } )`
* Verify the notice disappears after 5 secs.
* In the console, type `dispatch( { type: 'JETPACK_ONBOARDING_SETTINGS_SAVE' } )` 2-3 times.
* Verify the same notice doesn't appear more than once.
