### PR TITLE
Proper export / imports according to ES6 standard

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -30,7 +30,7 @@ import { isWooOAuth2Client } from 'lib/oauth2-clients';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import VerificationCodeForm from './two-factor-authentication/verification-code-form';
 import WaitingTwoFactorNotificationApproval from './two-factor-authentication/waiting-notification-approval';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import Notice from 'components/notice';
 import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
 import userFactory from 'lib/user';

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -32,7 +32,7 @@ import {
 	loginUser,
 	resetAuthAccountType,
 } from 'state/login/actions';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import { preventWidows } from 'lib/formatting';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import {

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -24,7 +24,7 @@ import {
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import WpcomLoginForm from 'signup/wpcom-login-form';
 import { InfoNotice } from 'blocks/global-notice';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 
 class SocialLoginForm extends Component {
 	static propTypes = {

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -17,7 +17,7 @@ import { localize } from 'i18n-calypso';
 import { isTwoFactorAuthTypeSupported } from 'state/login/selectors';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { sendSmsCode } from 'state/login/actions';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 
 class TwoFactorActions extends Component {
 	static propTypes = {

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -29,7 +29,7 @@ import FormButton from 'components/forms/form-button';
 import notices from 'notices';
 import Notice from 'components/notice';
 import LoggedOutForm from 'components/logged-out-form';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import formState from 'lib/form-state';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -15,7 +15,7 @@ import url from 'url';
  */
 import config from 'config';
 import DocsComponent from './main';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import SingleDocComponent from './doc';
 import DesignAssetsComponent from './design';
 import Blocks from './design/blocks';

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -38,7 +38,7 @@ import { authQueryPropTypes, getRoleFromScope } from './utils';
 import { decodeEntities } from 'lib/formatting';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { isRequestingSite, isRequestingSites } from 'state/sites/selectors';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
 import {

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -9,7 +9,7 @@ import page from 'page';
  */
 import userFactory from 'lib/user';
 import * as controller from './controller';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import { siteSelection } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
 

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -36,7 +36,7 @@ import WpcomLoginForm from 'signup/wpcom-login-form';
 import { authQueryPropTypes } from './utils';
 import { createAccount as createAccountAction } from 'state/jetpack-connect/actions';
 import { getAuthorizationData } from 'state/jetpack-connect/selectors';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
 const debug = debugFactory( 'calypso:jetpack-connect:authorize-form' );

--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -36,7 +36,7 @@ import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
 import { decodeEntities } from 'lib/formatting';
 import { getSSO } from 'state/jetpack-connect/selectors';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import { persistSsoApproved } from './persistence-utils';
 import { validateSSONonce, authorizeSSO } from 'state/jetpack-connect/actions';
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -14,7 +14,7 @@ import { getLocaleSlug, localize } from 'i18n-calypso';
  */
 import Item from './item';
 import config from 'config';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import WordPressWordmark from 'components/wordpress-wordmark';
 import WordPressLogo from 'components/wordpress-logo';
 

--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -6,8 +6,5 @@
 
 import i18n from 'i18n-calypso';
 
-module.exports = require( './utils.js' );
-
-module.exports.getLocaleSlug = function() {
-	return i18n.getLocaleSlug();
-};
+export * from './utils';
+export const getLocaleSlug = () => i18n.getLocaleSlug();

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -6,8 +6,5 @@
 
 import config from 'config';
 
-module.exports = require( './utils.js' );
-
-module.exports.getLocaleSlug = function() {
-	return config( 'i18n_default_locale_slug' );
-};
+export * from './utils';
+export const getLocaleSlug = () => config( 'i18n_default_locale_slug' );

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -6,5 +6,8 @@
 
 import config from 'config';
 
-export * from './utils';
-export const getLocaleSlug = () => config( 'i18n_default_locale_slug' );
+module.exports = require( './utils.js' );
+
+module.exports.getLocaleSlug = function() {
+	return config( 'i18n_default_locale_slug' );
+};

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -21,83 +21,79 @@ function getPathParts( path ) {
 	return path.replace( /\/$/, '' ).split( '/' );
 }
 
-const i18nUtils = {
-	/**
-	 * Checks if provided locale is a default one.
-	 *
-	 * @param {string} locale - locale slug (eg: 'fr')
-	 * @return {boolean} true when the default locale is provided
-	 */
-	isDefaultLocale: function( locale ) {
-		return locale === config( 'i18n_default_locale_slug' );
-	},
-
-	getLanguage: function( langSlug ) {
-		let language;
-
-		if ( localeRegex.test( langSlug ) || localeWithRegionRegex.test( langSlug ) ) {
-			language =
-				find( config( 'languages' ), { langSlug } ) ||
-				find( config( 'languages' ), { langSlug: langSlug.split( '-' )[ 0 ] } );
-		}
-
-		return language;
-	},
-
-	/**
-	 * Assuming that locale is adding at the end of path, retrieves the locale if present.
-	 * @param {string} path - original path
-	 * @return {string|undefined} The locale slug if present or undefined
-	 */
-	getLocaleFromPath: function( path ) {
-		const urlParts = parse( path );
-		const locale = getPathParts( urlParts.pathname ).pop();
-
-		return 'undefined' === typeof i18nUtils.getLanguage( locale ) ? undefined : locale;
-	},
-
-	/**
-	 * Adds a locale slug to the current path.
-	 *
-	 * Will replace existing locale slug, if present.
-	 *
-	 * @param {string} path - original path
-	 * @param {string} locale - locale slug (eg: 'fr')
-	 * @returns {string} original path with new locale slug
-	 */
-	addLocaleToPath: function( path, locale ) {
-		const urlParts = parse( path );
-		const queryString = urlParts.search || '';
-
-		return i18nUtils.removeLocaleFromPath( urlParts.pathname ) + `/${ locale }` + queryString;
-	},
-
-	addLocaleToWpcomUrl: function( url, locale ) {
-		if ( locale && locale !== 'en' ) {
-			return url.replace( 'https://wordpress.com', 'https://' + locale + '.wordpress.com' );
-		}
-
-		return url;
-	},
-
-	/**
-	 * Removes the trailing locale slug from the path, if it is present.
-	 * '/start/en' => '/start', '/start' => '/start', '/start/flow/fr' => '/start/flow', '/start/flow' => '/start/flow'
-	 * @param {string} path - original path
-	 * @returns {string} original path minus locale slug
-	 */
-	removeLocaleFromPath: function( path ) {
-		const urlParts = parse( path );
-		const queryString = urlParts.search || '';
-		const parts = getPathParts( urlParts.pathname );
-		const locale = parts.pop();
-
-		if ( 'undefined' === typeof i18nUtils.getLanguage( locale ) ) {
-			parts.push( locale );
-		}
-
-		return parts.join( '/' ) + queryString;
-	},
+/**
+ * Checks if provided locale is a default one.
+ *
+ * @param {string} locale - locale slug (eg: 'fr')
+ * @return {boolean} true when the default locale is provided
+ */
+export const isDefaultLocale = locale => {
+	return locale === config( 'i18n_default_locale_slug' );
 };
 
-export default i18nUtils;
+export const getLanguage = langSlug => {
+	let language;
+
+	if ( localeRegex.test( langSlug ) || localeWithRegionRegex.test( langSlug ) ) {
+		language =
+			find( config( 'languages' ), { langSlug } ) ||
+			find( config( 'languages' ), { langSlug: langSlug.split( '-' )[ 0 ] } );
+	}
+
+	return language;
+};
+
+/**
+ * Assuming that locale is adding at the end of path, retrieves the locale if present.
+ * @param {string} path - original path
+ * @return {string|undefined} The locale slug if present or undefined
+ */
+export const getLocaleFromPath = path => {
+	const urlParts = parse( path );
+	const locale = getPathParts( urlParts.pathname ).pop();
+
+	return 'undefined' === typeof getLanguage( locale ) ? undefined : locale;
+};
+
+/**
+ * Removes the trailing locale slug from the path, if it is present.
+ * '/start/en' => '/start', '/start' => '/start', '/start/flow/fr' => '/start/flow', '/start/flow' => '/start/flow'
+ * @param {string} path - original path
+ * @returns {string} original path minus locale slug
+ */
+export const removeLocaleFromPath = path => {
+	const urlParts = parse( path );
+	const queryString = urlParts.search || '';
+	const parts = getPathParts( urlParts.pathname );
+	const locale = parts.pop();
+
+	if ( 'undefined' === typeof getLanguage( locale ) ) {
+		parts.push( locale );
+	}
+
+	return parts.join( '/' ) + queryString;
+};
+
+/**
+ * Adds a locale slug to the current path.
+ *
+ * Will replace existing locale slug, if present.
+ *
+ * @param {string} path - original path
+ * @param {string} locale - locale slug (eg: 'fr')
+ * @returns {string} original path with new locale slug
+ */
+export const addLocaleToPath = ( path, locale ) => {
+	const urlParts = parse( path );
+	const queryString = urlParts.search || '';
+
+	return removeLocaleFromPath( urlParts.pathname ) + `/${ locale }` + queryString;
+};
+
+export const addLocaleToWpcomUrl = ( url, locale ) => {
+	if ( locale && locale !== 'en' ) {
+		return url.replace( 'https://wordpress.com', 'https://' + locale + '.wordpress.com' );
+	}
+
+	return url;
+};

--- a/client/lib/url/index.js
+++ b/client/lib/url/index.js
@@ -9,9 +9,8 @@ import { has, isString, omit, startsWith } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
-import { addQueryArgs } from 'lib/route';
 import { isLegacyRoute } from 'lib/route/legacy-routes';
-
+export { default as addQueryArgs } from 'lib/route/add-query-args';
 /**
  * Check if a URL is located outside of Calypso.
  * Note that the check this function implements is incomplete --
@@ -21,11 +20,11 @@ import { isLegacyRoute } from 'lib/route/legacy-routes';
  * @param {string} url - URL to check
  * @return {bool} true if the given URL is located outside of Calypso
  */
-function isOutsideCalypso( url ) {
+export function isOutsideCalypso( url ) {
 	return url && ( startsWith( url, '//' ) || ! startsWith( url, '/' ) );
 }
 
-function isExternal( url ) {
+export function isExternal( url ) {
 	// parseURL will return hostname = null if no protocol or double-slashes
 	// the url passed in might be of form `en.support.wordpress.com`
 	// so for this function we'll append double-slashes to fake it
@@ -59,7 +58,7 @@ function isExternal( url ) {
 	return hostname !== config( 'hostname' );
 }
 
-function isHttps( url ) {
+export function isHttps( url ) {
 	return url && startsWith( url, 'https://' );
 }
 
@@ -71,7 +70,7 @@ const urlWithoutHttpRegex = /^https?:\/\//;
  * @param  {String}  url The URL to remove http(s) from
  * @return {?String}     URL without the initial http(s)
  */
-function withoutHttp( url ) {
+export function withoutHttp( url ) {
 	if ( url === '' ) {
 		return '';
 	}
@@ -83,14 +82,14 @@ function withoutHttp( url ) {
 	return url.replace( urlWithoutHttpRegex, '' );
 }
 
-function addSchemeIfMissing( url, scheme ) {
+export function addSchemeIfMissing( url, scheme ) {
 	if ( false === schemeRegex.test( url ) ) {
 		return scheme + '://' + url;
 	}
 	return url;
 }
 
-function setUrlScheme( url, scheme ) {
+export function setUrlScheme( url, scheme ) {
 	const schemeWithSlashes = scheme + '://';
 	if ( startsWith( url, schemeWithSlashes ) ) {
 		return url;
@@ -104,7 +103,7 @@ function setUrlScheme( url, scheme ) {
 	return url.replace( schemeRegex, schemeWithSlashes );
 }
 
-function urlToSlug( url ) {
+export function urlToSlug( url ) {
 	if ( ! url ) {
 		return null;
 	}
@@ -120,7 +119,7 @@ function urlToSlug( url ) {
  * @param  {String} urlToConvert The URL to convert
  * @return {String} The URL's domain and path
  */
-function urlToDomainAndPath( urlToConvert ) {
+export function urlToDomainAndPath( urlToConvert ) {
 	return withoutHttp( urlToConvert ).replace( /\/$/, '' );
 }
 
@@ -133,7 +132,7 @@ function urlToDomainAndPath( urlToConvert ) {
  * @param  {String}  query The string to check
  * @return {Boolean} Does it appear to be a URL?
  */
-function resemblesUrl( query ) {
+export function resemblesUrl( query ) {
 	if ( ! query ) {
 		return false;
 	}
@@ -170,7 +169,7 @@ function resemblesUrl( query ) {
  * @param  {Array|String}  paramsToOmit The collection of params or single param to reject
  * @return {String} Url less the omitted params.
  */
-function omitUrlParams( url, paramsToOmit ) {
+export function omitUrlParams( url, paramsToOmit ) {
 	if ( ! url ) {
 		return null;
 	}
@@ -188,7 +187,7 @@ function omitUrlParams( url, paramsToOmit ) {
  * @param  {String} encodedURI URI to attempt to decode
  * @return {String}            Decoded URI (or passed in value on error)
  */
-function decodeURIIfValid( encodedURI ) {
+export function decodeURIIfValid( encodedURI ) {
 	if ( ! ( isString( encodedURI ) || has( encodedURI, 'toString' ) ) ) {
 		return '';
 	}
@@ -205,7 +204,7 @@ function decodeURIIfValid( encodedURI ) {
  * @param  {String} encodedURIComponent URI component to attempt to decode
  * @return {String}            Decoded URI component (or passed in value on error)
  */
-function decodeURIComponentIfValid( encodedURIComponent ) {
+export function decodeURIComponentIfValid( encodedURIComponent ) {
 	if ( ! ( isString( encodedURIComponent ) || has( encodedURIComponent, 'toString' ) ) ) {
 		return '';
 	}
@@ -215,20 +214,3 @@ function decodeURIComponentIfValid( encodedURIComponent ) {
 		return encodedURIComponent;
 	}
 }
-
-export default {
-	decodeURIIfValid,
-	decodeURIComponentIfValid,
-	isOutsideCalypso,
-	isExternal,
-	isHttps,
-	withoutHttp,
-	addSchemeIfMissing,
-	setUrlScheme,
-	urlToSlug,
-	urlToDomainAndPath,
-	// [TODO]: Move lib/route/add-query-args contents here
-	addQueryArgs,
-	resemblesUrl,
-	omitUrlParams,
-};

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -52,7 +52,7 @@ Undocumented.prototype.timezones = function( params, fn ) {
 		params = {};
 	}
 
-	let query = Object.assign( {}, params, { apiNamespace: 'wpcom/v2' } );
+	const query = Object.assign( {}, params, { apiNamespace: 'wpcom/v2' } );
 	return this.wpcom.req.get( '/timezones', query, fn );
 };
 
@@ -662,13 +662,11 @@ Undocumented.prototype.getDomainContactInformation = function( fn ) {
 			method: 'get',
 		},
 		function( error, data ) {
-			var newData;
-
 			if ( error ) {
 				return fn( error );
 			}
 
-			newData = mapKeysRecursively( data, function( key ) {
+			const newData = mapKeysRecursively( data, function( key ) {
 				return key === '_headers' ? key : camelCase( key );
 			} );
 
@@ -721,7 +719,7 @@ Undocumented.prototype.getSmsSupportedCountries = function( fn ) {
 
 function mapKeysRecursively( object, fn ) {
 	return Object.keys( object ).reduce( function( mapped, key ) {
-		var value = object[ key ];
+		let value = object[ key ];
 		if ( isPlainObject( value ) ) {
 			value = mapKeysRecursively( value, fn );
 		}
@@ -744,7 +742,7 @@ Undocumented.prototype.validateDomainContactInformation = function(
 	domainNames,
 	fn
 ) {
-	var data = {
+	let data = {
 		contactInformation: contactInformation,
 		domainNames: domainNames,
 	};
@@ -756,13 +754,11 @@ Undocumented.prototype.validateDomainContactInformation = function(
 		error,
 		successData
 	) {
-		var newData;
-
 		if ( error ) {
 			return fn( error );
 		}
 
-		newData = mapKeysRecursively( successData, function( key ) {
+		const newData = mapKeysRecursively( successData, function( key ) {
 			return key === '_headers' ? key : camelCase( key );
 		} );
 
@@ -1088,8 +1084,6 @@ Undocumented.prototype.createConnection = function(
 	options,
 	fn
 ) {
-	var body, path;
-
 	// Method overloading: Optional `options`
 	if ( 'undefined' === typeof fn && 'function' === typeof options ) {
 		fn = options;
@@ -1097,7 +1091,7 @@ Undocumented.prototype.createConnection = function(
 	}
 
 	// Build request body
-	body = { keyring_connection_ID: keyringConnectionId };
+	const body = { keyring_connection_ID: keyringConnectionId };
 	if ( 'boolean' === typeof options.shared ) {
 		body.shared = options.shared;
 	}
@@ -1106,7 +1100,7 @@ Undocumented.prototype.createConnection = function(
 		body.external_user_ID = externalUserId;
 	}
 
-	path = siteId
+	const path = siteId
 		? '/sites/' + siteId + '/publicize-connections/new'
 		: '/me/publicize-connections/new';
 
@@ -1148,7 +1142,7 @@ Undocumented.prototype.publicizePost = function( siteId, postId, message, skippe
  * @return {Promise} A Promise to resolve when complete.
  */
 Undocumented.prototype.updateConnection = function( siteId, connectionId, data, fn ) {
-	var path;
+	let path;
 
 	if ( siteId ) {
 		debug( '/sites/:site_id:/publicize-connections/:connection_id: query' );
@@ -1306,7 +1300,7 @@ Undocumented.prototype.setPrimaryDomain = function( siteId, domain, fn ) {
  */
 Undocumented.prototype.fetchPreviewMarkup = function( siteId, path, postData ) {
 	debug( '/sites/:site_id/previews/mine' );
-	return new Promise( ( resolve, reject ) => {
+	return new Promise( ( resolve, rejectPromise ) => {
 		const endpoint = `/sites/${ siteId }/previews/mine`;
 		const query = { path };
 		const isPreviewCustomized = postData && Object.keys( postData ).length > 0;
@@ -1316,11 +1310,11 @@ Undocumented.prototype.fetchPreviewMarkup = function( siteId, path, postData ) {
 		request
 			.then( response => {
 				if ( ! response.html ) {
-					return reject( new Error( 'No markup received from API' ) );
+					return rejectPromise( new Error( 'No markup received from API' ) );
 				}
 				resolve( response.html );
 			} )
-			.catch( reject );
+			.catch( rejectPromise );
 	} );
 };
 
@@ -1368,7 +1362,7 @@ Undocumented.prototype.readA8cConversations = function( query, fn ) {
 };
 
 Undocumented.prototype.readFeed = function( query, fn ) {
-	var params = omit( query, 'ID' );
+	const params = omit( query, 'ID' );
 	debug( '/read/feed' );
 	return this.wpcom.req.get( '/read/feed/' + encodeURIComponent( query.ID ), params, fn );
 };
@@ -1379,7 +1373,7 @@ Undocumented.prototype.discoverFeed = function( query, fn ) {
 };
 
 Undocumented.prototype.readFeedPosts = function( query, fn ) {
-	var params = omit( query, 'ID' );
+	const params = omit( query, 'ID' );
 	debug( '/read/feed/' + query.ID + '/posts' );
 	params.apiVersion = '1.3';
 	addReaderContentWidth( params );
@@ -1392,7 +1386,7 @@ Undocumented.prototype.readFeedPosts = function( query, fn ) {
 };
 
 Undocumented.prototype.readFeedPost = function( query, fn ) {
-	var params = omit( query, [ 'feedId', 'postId' ] );
+	const params = omit( query, [ 'feedId', 'postId' ] );
 	debug( '/read/feed/' + query.feedId + '/posts/' + query.postId );
 	params.apiVersion = '1.3';
 	addReaderContentWidth( params );
@@ -1415,7 +1409,7 @@ Undocumented.prototype.readSearch = function( query, fn ) {
 };
 
 Undocumented.prototype.readTagPosts = function( query, fn ) {
-	var params = omit( query, 'tag' );
+	const params = omit( query, 'tag' );
 	debug( '/read/tags/' + query.tag + '/posts' );
 	if ( config.isEnabled( 'reader/tags-with-elasticsearch' ) ) {
 		params.apiVersion = '1.3';
@@ -1460,7 +1454,7 @@ Undocumented.prototype.unfollowReaderTag = function( tag, fn ) {
 };
 
 Undocumented.prototype.readLiked = function( query, fn ) {
-	var params = clone( query );
+	const params = clone( query );
 	debug( '/read/liked' );
 	params.apiVersion = '1.2';
 	addReaderContentWidth( params );
@@ -1468,14 +1462,14 @@ Undocumented.prototype.readLiked = function( query, fn ) {
 };
 
 Undocumented.prototype.readList = function( query, fn ) {
-	var params = omit( query, [ 'owner', 'slug' ] );
+	const params = omit( query, [ 'owner', 'slug' ] );
 	debug( '/read/list' );
 	params.apiVersion = '1.2';
 	return this.wpcom.req.get( '/read/lists/' + query.owner + '/' + query.slug, params, fn );
 };
 
 Undocumented.prototype.readListPosts = function( query, fn ) {
-	var params = omit( query, [ 'owner', 'slug' ] );
+	const params = omit( query, [ 'owner', 'slug' ] );
 	debug( '/read/list/:list/posts' );
 	params.apiVersion = '1.2';
 	addReaderContentWidth( params );
@@ -1497,7 +1491,7 @@ Undocumented.prototype.readListsNew = function( title, fn ) {
 };
 
 Undocumented.prototype.readListsUpdate = function( query, fn ) {
-	var params = omit( query, [ 'owner', 'slug' ] );
+	const params = omit( query, [ 'owner', 'slug' ] );
 	debug( '/read/lists/:list/update' );
 	return this.wpcom.req.post(
 		'/read/lists/' +
@@ -1512,7 +1506,7 @@ Undocumented.prototype.readListsUpdate = function( query, fn ) {
 };
 
 Undocumented.prototype.followList = function( query, fn ) {
-	var params = omit( query, [ 'owner', 'slug' ] );
+	const params = omit( query, [ 'owner', 'slug' ] );
 	debug( '/read/lists/:owner/:slug/follow' );
 	return this.wpcom.req.post(
 		'/read/lists/' +
@@ -1527,7 +1521,7 @@ Undocumented.prototype.followList = function( query, fn ) {
 };
 
 Undocumented.prototype.unfollowList = function( query, fn ) {
-	var params = omit( query, [ 'owner', 'slug' ] );
+	const params = omit( query, [ 'owner', 'slug' ] );
 	debug( '/read/lists/:owner/:slug/unfollow' );
 	return this.wpcom.req.post(
 		'/read/lists/' +
@@ -1542,7 +1536,7 @@ Undocumented.prototype.unfollowList = function( query, fn ) {
 };
 
 Undocumented.prototype.readListTags = function( query, fn ) {
-	var params = omit( query, [ 'owner', 'slug' ] );
+	const params = omit( query, [ 'owner', 'slug' ] );
 	debug( '/read/lists/:owner/:list/tags' );
 	params.apiVersion = '1.2';
 	return this.wpcom.req.get(
@@ -1557,7 +1551,7 @@ Undocumented.prototype.readListTags = function( query, fn ) {
 };
 
 Undocumented.prototype.readListItems = function( query, fn ) {
-	var params = omit( query, [ 'owner', 'slug' ] );
+	const params = omit( query, [ 'owner', 'slug' ] );
 	debug( '/read/lists/:owner/:list/items' );
 	params.apiVersion = '1.2';
 	return this.wpcom.req.get(
@@ -1572,26 +1566,26 @@ Undocumented.prototype.readListItems = function( query, fn ) {
 };
 
 Undocumented.prototype.readSite = function( query, fn ) {
-	var params = omit( query, 'site' );
+	const params = omit( query, 'site' );
 	debug( '/read/sites/:site' );
 	return this.wpcom.req.get( '/read/sites/' + query.site, params, fn );
 };
 
 Undocumented.prototype.readSiteFeatured = function( siteId, query, fn ) {
-	var params = omit( query, [ 'before', 'after' ] );
+	const params = omit( query, [ 'before', 'after' ] );
 	debug( '/read/sites/:site/featured' );
 	return this.wpcom.req.get( '/read/sites/' + siteId + '/featured', params, fn );
 };
 
 Undocumented.prototype.readSitePosts = function( query, fn ) {
-	var params = omit( query, 'site' );
+	const params = omit( query, 'site' );
 	debug( '/read/sites/:site/posts' );
 	addReaderContentWidth( params );
 	return this.wpcom.req.get( '/read/sites/' + query.site + '/posts', params, fn );
 };
 
 Undocumented.prototype.readSitePost = function( query, fn ) {
-	var params = omit( query, [ 'site', 'postId' ] );
+	const params = omit( query, [ 'site', 'postId' ] );
 	debug( '/read/sites/:site/post/:post' );
 	addReaderContentWidth( params );
 	return this.wpcom.req.get( '/read/sites/' + query.site + '/posts/' + query.postId, params, fn );
@@ -1627,7 +1621,7 @@ Undocumented.prototype.graduateNewReader = function( fn ) {
  * @api public
  */
 Undocumented.prototype.saveABTestData = function( name, variation, fn ) {
-	var data = {
+	const data = {
 		name: name,
 		variation: variation,
 	};
@@ -1648,7 +1642,6 @@ Undocumented.prototype.saveABTestData = function( name, variation, fn ) {
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersNew = function( query, fn ) {
-	var args;
 	debug( '/users/new' );
 
 	// This API call is restricted to these OAuth keys
@@ -1656,7 +1649,7 @@ Undocumented.prototype.usersNew = function( query, fn ) {
 
 	// Set the language for the user
 	query.locale = getLocaleSlug();
-	args = {
+	const args = {
 		path: '/users/new',
 		body: query,
 	};
@@ -1692,13 +1685,12 @@ Undocumented.prototype.usersSocialNew = function( query, fn ) {
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersPhoneNew = function( query, fn ) {
-	var args;
 	debug( '/users/phone/new' );
 
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( query );
 
-	args = {
+	const args = {
 		path: '/users/phone/new',
 		body: mapKeysRecursively( query, snakeCase ),
 	};
@@ -1712,13 +1704,12 @@ Undocumented.prototype.usersPhoneNew = function( query, fn ) {
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersPhone = function( query, fn ) {
-	var args;
 	debug( '/users/phone' );
 
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( query );
 
-	args = {
+	const args = {
 		path: '/users/phone',
 		body: mapKeysRecursively( query, snakeCase ),
 	};
@@ -1733,13 +1724,12 @@ Undocumented.prototype.usersPhone = function( query, fn ) {
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersPhoneVerification = function( query, fn ) {
-	var args;
 	debug( '/users/phone/verification' );
 
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( query );
 
-	args = {
+	const args = {
 		path: '/users/phone/verification',
 		body: mapKeysRecursively( query, snakeCase ),
 	};
@@ -1753,13 +1743,12 @@ Undocumented.prototype.usersPhoneVerification = function( query, fn ) {
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersEmailNew = function( query, fn ) {
-	var args;
 	debug( '/users/email/new' );
 
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( query );
 
-	args = {
+	const args = {
 		path: '/users/email/new',
 		body: mapKeysRecursively( query, snakeCase ),
 	};
@@ -1773,13 +1762,12 @@ Undocumented.prototype.usersEmailNew = function( query, fn ) {
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersEmail = function( query, fn ) {
-	var args;
 	debug( '/users/email' );
 
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( query );
 
-	args = {
+	const args = {
 		path: '/users/email',
 		body: mapKeysRecursively( query, snakeCase ),
 	};
@@ -1794,13 +1782,12 @@ Undocumented.prototype.usersEmail = function( query, fn ) {
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersEmailVerification = function( query, fn ) {
-	var args;
 	debug( '/users/email/verification' );
 
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( query );
 
-	args = {
+	const args = {
 		path: '/users/email/verification',
 		body: mapKeysRecursively( query, snakeCase ),
 	};
@@ -1850,7 +1837,7 @@ Undocumented.prototype.requestMagicLoginEmail = function( data, fn ) {
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.sitesNew = function( query, fn ) {
-	var localeSlug = getLocaleSlug();
+	const localeSlug = getLocaleSlug();
 
 	debug( '/sites/new' );
 
@@ -1882,7 +1869,7 @@ Undocumented.prototype.getLocaleSuggestions = function( fn ) {
 };
 
 Undocumented.prototype.themes = function( siteId, query, fn ) {
-	var path = siteId ? '/sites/' + siteId + '/themes' : '/themes';
+	const path = siteId ? '/sites/' + siteId + '/themes' : '/themes';
 	debug( path );
 	return this.wpcom.req.get( path, query, fn );
 };
@@ -2094,7 +2081,7 @@ Undocumented.prototype.fetchDns = function( domainName, fn ) {
 };
 
 Undocumented.prototype.updateDns = function( domain, records, fn ) {
-	var filtered = reject( records, 'isBeingDeleted' ),
+	const filtered = reject( records, 'isBeingDeleted' ),
 		body = { dns: JSON.stringify( filtered ) };
 
 	return this.wpcom.req.post( '/domains/' + domain + '/dns', body, fn );
@@ -2184,7 +2171,7 @@ Undocumented.prototype.cancelTransferRequest = function(
 };
 
 Undocumented.prototype.enablePrivacyProtection = function( domainName, fn ) {
-	var data = {
+	const data = {
 		domainStatus: JSON.stringify( { command: 'enable-privacy' } ),
 	};
 
@@ -2192,7 +2179,7 @@ Undocumented.prototype.enablePrivacyProtection = function( domainName, fn ) {
 };
 
 Undocumented.prototype.acceptTransfer = function( domainName, fn ) {
-	var data = {
+	const data = {
 		domainStatus: JSON.stringify( { command: 'accept-transfer' } ),
 	};
 
@@ -2200,7 +2187,7 @@ Undocumented.prototype.acceptTransfer = function( domainName, fn ) {
 };
 
 Undocumented.prototype.declineTransfer = function( domainName, fn ) {
-	var data = {
+	const data = {
 		domainStatus: JSON.stringify( { command: 'deny-transfer' } ),
 	};
 
@@ -2350,9 +2337,9 @@ Undocumented.prototype.updateImporter = function( siteId, importerStatus ) {
 };
 
 Undocumented.prototype.uploadExportFile = function( siteId, params ) {
-	return new Promise( ( resolve, reject ) => {
+	return new Promise( ( resolve, rejectPromise ) => {
 		const resolver = ( error, data ) => {
-			error ? reject( error ) : resolve( data );
+			error ? rejectPromise( error ) : resolve( data );
 		};
 
 		const req = this.wpcom.req.post(
@@ -2576,7 +2563,7 @@ Undocumented.prototype.timezones = function( params, fn ) {
 		params = {};
 	}
 
-	let query = Object.assign( {}, params, { apiNamespace: 'wpcom/v2' } );
+	const query = Object.assign( {}, params, { apiNamespace: 'wpcom/v2' } );
 	return this.wpcom.req.get( '/timezones', query, fn );
 };
 
@@ -2590,7 +2577,7 @@ Undocumented.prototype.timezones = function( params, fn ) {
 Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters ) {
 	const parsedUrl = url.parse( targetUrl );
 	let endpointUrl = `/connect/site-info/${ parsedUrl.protocol.slice( 0, -1 ) }/${ parsedUrl.host }`;
-	let params = {
+	const params = {
 		filters: filters,
 		apiVersion: '1.1',
 	};

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -17,7 +17,7 @@ import Me from './me';
 import MailingList from './mailing-list';
 import AccountRecoveryReset from './account-recovery-reset';
 import config from 'config';
-import i18n from 'lib/i18n-utils';
+import { getLocaleSlug, getLanguage } from 'lib/i18n-utils';
 import readerContentWidth from 'reader/lib/content-width';
 
 /**
@@ -1655,7 +1655,7 @@ Undocumented.prototype.usersNew = function( query, fn ) {
 	restrictByOauthKeys( query );
 
 	// Set the language for the user
-	query.locale = i18n.getLocaleSlug();
+	query.locale = getLocaleSlug();
 	args = {
 		path: '/users/new',
 		body: query,
@@ -1672,7 +1672,7 @@ Undocumented.prototype.usersNew = function( query, fn ) {
  * @return {Promise} A promise for the request
  */
 Undocumented.prototype.usersSocialNew = function( query, fn ) {
-	query.locale = i18n.getLocaleSlug();
+	query.locale = getLocaleSlug();
 
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( query );
@@ -1816,7 +1816,7 @@ Undocumented.prototype.usersEmailVerification = function( query, fn ) {
 Undocumented.prototype.validateNewUser = function( data, fn ) {
 	debug( '/signups/validation/user' );
 
-	data.locale = i18n.getLocaleSlug();
+	data.locale = getLocaleSlug();
 
 	return this.wpcom.req.post( '/signups/validation/user/', null, data, fn );
 };
@@ -1830,8 +1830,8 @@ Undocumented.prototype.validateNewUser = function( data, fn ) {
 Undocumented.prototype.requestMagicLoginEmail = function( data, fn ) {
 	restrictByOauthKeys( data );
 
-	data.locale = i18n.getLocaleSlug();
-	data.lang_id = i18n.getLanguage( data.locale ).value;
+	data.locale = getLocaleSlug();
+	data.lang_id = getLanguage( data.locale ).value;
 
 	return this.wpcom.req.post(
 		'/auth/send-login-email',
@@ -1850,7 +1850,7 @@ Undocumented.prototype.requestMagicLoginEmail = function( data, fn ) {
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.sitesNew = function( query, fn ) {
-	var localeSlug = i18n.getLocaleSlug();
+	var localeSlug = getLocaleSlug();
 
 	debug( '/sites/new' );
 
@@ -1858,7 +1858,7 @@ Undocumented.prototype.sitesNew = function( query, fn ) {
 	restrictByOauthKeys( query );
 
 	// Set the language for the user
-	query.lang_id = i18n.getLanguage( localeSlug ).value;
+	query.lang_id = getLanguage( localeSlug ).value;
 	query.locale = localeSlug;
 
 	return this.wpcom.req.post(

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -38,101 +38,99 @@ const enhanceContextWithLogin = context => {
 	);
 };
 
-export default {
-	// Defining this here so it can be used by both ./index.node.js and ./index.web.js
-	// We cannot export it from either of those (to import it from the other) because of
-	// the way that `server/bundler/loader` expects only a default export and nothing else.
-	lang: `:lang(${ map( config( 'languages' ), 'langSlug' ).join( '|' ) })?`,
+// Defining this here so it can be used by both ./index.node.js and ./index.web.js
+// We cannot export it from either of those (to import it from the other) because of
+// the way that `server/bundler/loader` expects only a default export and nothing else.
+export const lang = `:lang(${ map( config( 'languages' ), 'langSlug' ).join( '|' ) })?`;
 
-	login( context, next ) {
-		const { query: { client_id, redirect_to } } = context;
+export const login = ( context, next ) => {
+	const { query: { client_id, redirect_to } } = context;
 
-		if ( client_id ) {
-			if ( ! redirect_to ) {
-				const error = new Error( 'The `redirect_to` query parameter is missing.' );
-				error.status = 401;
-				return next( error );
-			}
-
-			const parsedRedirectUrl = parseUrl( redirect_to );
-			const redirectQueryString = qs.parse( parsedRedirectUrl.query );
-
-			if ( client_id !== redirectQueryString.client_id ) {
-				recordTracksEvent( 'calypso_login_phishing_attempt', context.query );
-
-				const error = new Error(
-					'The `redirect_to` query parameter is invalid with the given `client_id`.'
-				);
-				error.status = 401;
-				return next( error );
-			}
-
-			context.store
-				.dispatch( fetchOAuth2ClientData( Number( client_id ) ) )
-				.then( () => {
-					enhanceContextWithLogin( context );
-
-					next();
-				} )
-				.catch( error => next( error ) );
-		} else {
-			enhanceContextWithLogin( context );
-
-			next();
+	if ( client_id ) {
+		if ( ! redirect_to ) {
+			const error = new Error( 'The `redirect_to` query parameter is missing.' );
+			error.status = 401;
+			return next( error );
 		}
-	},
 
-	magicLogin( context, next ) {
-		const { path } = context;
+		const parsedRedirectUrl = parseUrl( redirect_to );
+		const redirectQueryString = qs.parse( parsedRedirectUrl.query );
 
-		context.primary = <MagicLogin path={ path } />;
+		if ( client_id !== redirectQueryString.client_id ) {
+			recordTracksEvent( 'calypso_login_phishing_attempt', context.query );
+
+			const error = new Error(
+				'The `redirect_to` query parameter is invalid with the given `client_id`.'
+			);
+			error.status = 401;
+			return next( error );
+		}
+
+		context.store
+			.dispatch( fetchOAuth2ClientData( Number( client_id ) ) )
+			.then( () => {
+				enhanceContextWithLogin( context );
+
+				next();
+			} )
+			.catch( error => next( error ) );
+	} else {
+		enhanceContextWithLogin( context );
 
 		next();
-	},
+	}
+};
 
-	magicLoginUse( context, next ) {
-		/**
-		 * Pull the query arguments out of the URL & into the state.
-		 * It unclutters the address bar & will keep tokens out of tracking pixels.
-		 */
-		if ( context.querystring ) {
-			page.replace( context.pathname, context.query );
+export const magicLogin = ( context, next ) => {
+	const { path } = context;
 
-			return;
-		}
+	context.primary = <MagicLogin path={ path } />;
 
-		const previousQuery = context.state || {};
+	next();
+};
 
-		const { client_id, email, token } = previousQuery;
+export const magicLoginUse = ( context, next ) => {
+	/**
+	 * Pull the query arguments out of the URL & into the state.
+	 * It unclutters the address bar & will keep tokens out of tracking pixels.
+	 */
+	if ( context.querystring ) {
+		page.replace( context.pathname, context.query );
 
-		context.primary = (
-			<HandleEmailedLinkForm clientId={ client_id } emailAddress={ email } token={ token } />
-		);
+		return;
+	}
 
-		next();
-	},
+	const previousQuery = context.state || {};
 
-	redirectDefaultLocale( context, next ) {
-		// only redirect `/log-in/en` to `/log-in`
-		if ( context.pathname !== '/log-in/en' ) {
-			return next();
-		}
+	const { client_id, email, token } = previousQuery;
 
-		// Do not redirect if user bootrapping is disabled
-		if (
-			! getCurrentUser( context.store.getState() ) &&
-			! config.isEnabled( 'wpcom-user-bootstrap' )
-		) {
-			return next();
-		}
+	context.primary = (
+		<HandleEmailedLinkForm clientId={ client_id } emailAddress={ email } token={ token } />
+	);
 
-		// Do not redirect if user is logged in and the locale is different than english
-		// so we force the page to display in english
-		const currentUserLocale = getCurrentUserLocale( context.store.getState() );
-		if ( currentUserLocale && currentUserLocale !== 'en' ) {
-			return next();
-		}
+	next();
+};
 
-		context.redirect( '/log-in' );
-	},
+export const redirectDefaultLocale = ( context, next ) => {
+	// only redirect `/log-in/en` to `/log-in`
+	if ( context.pathname !== '/log-in/en' ) {
+		return next();
+	}
+
+	// Do not redirect if user bootrapping is disabled
+	if (
+		! getCurrentUser( context.store.getState() ) &&
+		! config.isEnabled( 'wpcom-user-bootstrap' )
+	) {
+		return next();
+	}
+
+	// Do not redirect if user is logged in and the locale is different than english
+	// so we force the page to display in english
+	const currentUserLocale = getCurrentUserLocale( context.store.getState() );
+	if ( currentUserLocale && currentUserLocale !== 'en' ) {
+		return next();
+	}
+
+	context.redirect( '/log-in' );
 };

--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -11,7 +11,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import { addQueryArgs } from 'lib/route';
 import EmptyContent from 'components/empty-content';
 import RedirectWhenLoggedIn from 'components/redirect-when-logged-in';

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -13,7 +13,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import Card from 'components/card';
 import RedirectWhenLoggedIn from 'components/redirect-when-logged-in';
 import { hideMagicLoginRequestForm } from 'state/login/magic-login/actions';

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -17,7 +17,7 @@ import EmptyContent from 'components/empty-content';
 import EmailedLoginLinkExpired from './emailed-login-link-expired';
 import config from 'config';
 import userFactory from 'lib/user';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import { localize } from 'i18n-calypso';
 import { LINK_EXPIRED_PAGE } from 'state/login/magic-login/constants';
 import {

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -14,7 +14,7 @@ import page from 'page';
  * Internal dependencies
  */
 import notices from 'notices';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import { CHECK_YOUR_EMAIL_PAGE } from 'state/login/magic-login/constants';
 import { getCurrentLocaleSlug, getMagicLoginCurrentView } from 'state/selectors';
 import { hideMagicLoginRequestForm } from 'state/login/magic-login/actions';

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -22,7 +22,7 @@ import Gridicon from 'gridicons';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'state/login/magic-login/actions';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 
 export class LoginLinks extends React.Component {

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -11,7 +11,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import { sectionify } from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import config from 'config';

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -16,7 +16,7 @@ import debugModule from 'debug';
  */
 import SignupForm from 'components/signup-form';
 import InviteFormHeader from 'my-sites/invites/invite-form-header';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import { createAccount, acceptInvite } from 'lib/invites/actions';
 import WpcomLoginForm from 'signup/wpcom-login-form';
 import LoggedOutFormLinks from 'components/logged-out-form/links';

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -18,7 +18,7 @@ import { bindActionCreators } from 'redux';
 import InviteHeader from 'my-sites/invites/invite-header';
 import LoggedIn from 'my-sites/invites/invite-accept-logged-in';
 import LoggedOut from 'my-sites/invites/invite-accept-logged-out';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import _user from 'lib/user';
 import { fetchInvite } from 'lib/invites/actions';
 import InvitesStore from 'lib/invites/stores/invites-accept-validation';

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -16,7 +16,7 @@ import config from 'config';
 import wpcom from 'lib/wp';
 import analytics from 'lib/analytics';
 import formState from 'lib/form-state';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import SignupActions from 'lib/signup/actions';
 import ValidationFieldset from 'signup/validation-fieldset';
 import FormLabel from 'components/forms/form-label';

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -9,7 +9,7 @@ import { filter, find, indexOf, isEmpty, merge, pick } from 'lodash';
 /**
  * Internal dependencies
  */
-import i18nUtils from 'lib/i18n-utils';
+import { getLanguage } from 'lib/i18n-utils';
 import steps from 'signup/config/steps';
 import flows from 'signup/config/flows';
 import { defaultFlowName } from 'signup/config/flows';
@@ -63,7 +63,7 @@ function getLocale( parameters ) {
 }
 
 function isLocale( pathFragment ) {
-	return ! isEmpty( i18nUtils.getLanguage( pathFragment ) );
+	return ! isEmpty( getLanguage( pathFragment ) );
 }
 
 function getStepUrl( flowName, stepName, stepSectionName, localeSlug ) {

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -48,7 +48,7 @@ import {
 	TWO_FACTOR_AUTHENTICATION_UPDATE_NONCE,
 	USER_RECEIVE,
 } from 'state/action-types';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 
 export const isRequesting = createReducer( false, {
 	[ LOGIN_AUTH_ACCOUNT_TYPE_REQUEST ]: () => true,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -23,7 +23,7 @@ import { serverRender, serverRenderError } from 'render';
 import stateCache from 'state-cache';
 import { createReduxStore, reducer } from 'state';
 import { DESERIALIZE, LOCALE_SET } from 'state/action-types';
-import { login } from 'lib/paths';
+import { login } from 'lib/paths/login';
 import { logSectionResponseTime } from './analytics';
 import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
 


### PR DESCRIPTION
What I've did here is took [webpack.login.js ](https://github.com/Automattic/wp-calypso/blob/57d58d55993653a5fc8e8b78f1c0fc8f257fe124/webpack.login.js) which is a webpack config that takes login as an entry point and changed `.babelrc`:

```diff
diff --git a/.babelrc b/.babelrc
index a74323b398..cb99d80eeb 100644
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,8 @@
                                        "iOS >= 10",
                                        "not ie <= 10"
                                ]
-                       }
+                       },
+                       "modules": false
                } ],
                "stage-2"
        ],
```
then fixed all errors regarding import / export.

The only case I didn't handle is `isEnabled` import from config, this deserves a separate PR.

![screen shot 2018-01-15 at 15 34 37](https://user-images.githubusercontent.com/326402/34944789-a3b0722e-fa09-11e7-8f09-d444d77474c9.png)
