### PR TITLE
Jetpack Onboarding: Update wording of JPC link

### DIFF
--- a/client/jetpack-onboarding/constants.js
+++ b/client/jetpack-onboarding/constants.js
@@ -28,7 +28,7 @@ export const JETPACK_ONBOARDING_STEPS = {
 };
 
 export const JETPACK_ONBOARDING_SUMMARY_STEPS = {
-	JETPACK_CONNECTION: translate( 'Jetpack Connection' ),
+	JETPACK_CONNECTION: translate( 'Connect to WordPress.com' ),
 	THEME: translate( 'Choose a Theme' ),
 	SITE_ADDRESS: translate( 'Add a Site Address' ),
 	STORE: translate( 'Add a Store' ),


### PR DESCRIPTION
This PR updates the Jetpack Connect link in the Summary step of the Jetpack Onboarding flow to state **Connect to WordPress.com** vs what we currently have (**Jetpack Connection**).

To test:

1. Checkout this branch on your local Calypso.
1. Make sure your JP sandbox is running the latest Jetpack master.
1. Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
1. After you land the JPO flow, skip to the Summary step.
