### PR TITLE
Build: Use node alpine base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM       node:8.9.3-alpine
 LABEL maintainer="Automattic"
 
+RUN apk add --no-cache git
+
 WORKDIR    /calypso
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM       node:8.9.3
+FROM       node:8.9.3-alpine
 LABEL maintainer="Automattic"
 
 WORKDIR    /calypso

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,26 +5,11 @@ RUN apk add --no-cache git
 
 WORKDIR    /calypso
 
-
 ENV        CONTAINER 'docker'
 ENV        NODE_PATH=/calypso/server:/calypso/client
 
-# Build a "base" layer
-#
-# This layer should never change unless env-config.sh
-# changes. For local development this should always
-# be an empty file and therefore this layer should
-# cache well.
-#
-# env-config.sh
-#   used by systems to overwrite some defaults
-#   such as the apt and npm mirrors
-
-#
-# ### TEMPORARILY DISABLED ###
-#
-# COPY       ./env-config.sh /tmp/env-config.sh
-# RUN        bash /tmp/env-config.sh
+ARG        npm_registry
+ENV        NPM_CONFIG_REGISTRY=$npm_registry
 
 # Build a "dependencies" layer
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,12 @@ ENV        NODE_PATH=/calypso/server:/calypso/client
 # env-config.sh
 #   used by systems to overwrite some defaults
 #   such as the apt and npm mirrors
-COPY       ./env-config.sh /tmp/env-config.sh
-RUN        bash /tmp/env-config.sh
+
+#
+# ### TEMPORARILY DISABLED ###
+#
+# COPY       ./env-config.sh /tmp/env-config.sh
+# RUN        bash /tmp/env-config.sh
 
 # Build a "dependencies" layer
 #


### PR DESCRIPTION
# DO NOT MERGE

Exploration in #19962 led to the conclusion that producing smaller builds by tweaking Calypso's Dockerfile yield little benefit.

However, simply changing the base image to alpine yields a drastic reduction in size.

**Before**

```
REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
wp-calypso          latest              548e4596803b        About a minute ago   1.56GB
```

**After**

```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
wp-calypso          latest              f07e67c0ff81        14 minutes ago      976MB
```

## Image information

> This image is based on the popular [Alpine Linux project](http://alpinelinux.org), available in [the `alpine` official image](https://hub.docker.com/_/alpine). Alpine Linux is much smaller than most distribution base images (~5MB), and thus leads to much slimmer images in general.
> 
> This variant is highly recommended when final image size being as small as possible is desired. The main caveat to note is that it does use [musl libc](http://www.musl-libc.org) instead of [glibc and friends](http://www.etalabs.net/compare_libcs.html), so certain software might run into issues depending on the depth of their libc requirements. However, most software doesn't have an issue with this, so this variant is usually a very safe choice. See [this Hacker News comment thread](https://news.ycombinator.com/item?id=10782897) for more discussion of the issues that might arise and some pro/con comparisons of using Alpine-based images. One common issue that may arise is a missing shared library required for use of `process.dlopen`. To add the missing shared libraries to your image, adding the [`libc6-compat`](https://pkgs.alpinelinux.org/package/edge/main/x86/libc6-compat) package in your Dockerfile is recommended: `apk add --no-cache libc6-compat`
> 
> To minimize image size, it's uncommon for additional related tools (such as `git` or `bash`) to be included in Alpine-based images. Using this image as a base, add the things you need in your own Dockerfile (see the [`alpine` image description](https://hub.docker.com/_/alpine/) for examples of how to install packages if you are unfamiliar).

[source](https://hub.docker.com/_/node/)

## Notable changes

`bash` is not included in the build. Running the `env-config` script has been temporarily disabled. A more "Docker" solution can likely be found. Pending conversation with systems (pMz3w-83J-p2).

What exactly does `env-config.sh` need to do? Changing npm registry can be handled by an environment variable. If we need to change alpine linux mirrors we'll need to find a solution. This build does rely on installing `git` via `apk`, which is not provided in the base image.

## Testing
1. Build and run this branch `npm run build-docker && npm run docker`.
1. Verify the build is correct and the produced image performs as expected.
1. Verify new build-arg works as expected:
   ```sh
   docker build --rm --build-arg npm_registry=somebadurl .
   ```
   Run and look for npm config registry warnings