### PR TITLE
Jetpack Connect: Redirect back to mobile app on error

### DIFF
--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import debugModule from 'debug';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
@@ -10,6 +11,10 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Notice from 'components/notice';
+import { addQueryArgs } from 'lib/route';
+import { retrieveMobileRedirect } from './persistence-utils';
+
+const debug = debugModule( 'calypso:jetpack-connect:notices' );
 
 class JetpackConnectNotices extends Component {
 	static propTypes = {
@@ -106,6 +111,7 @@ class JetpackConnectNotices extends Component {
 				);
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'notice';
+				noticeValues.userCanRetry = true;
 				return noticeValues;
 
 			case 'retryAuth':
@@ -114,6 +120,7 @@ class JetpackConnectNotices extends Component {
 				);
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'notice';
+				noticeValues.userCanRetry = true;
 				return noticeValues;
 
 			case 'secretExpired':
@@ -157,6 +164,27 @@ class JetpackConnectNotices extends Component {
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'notice';
 				return noticeValues;
+		}
+	}
+
+	componenentDidUpdate() {
+		this.maybeRedirect();
+	}
+
+	componentDidMount() {
+		this.maybeRedirect();
+	}
+
+	maybeRedirect() {
+		const mobileRedirectUrl = retrieveMobileRedirect();
+		if ( ! mobileRedirectUrl ) {
+			return;
+		}
+		const notice = this.getNoticeValues();
+		if ( ! notice.userCanRetry ) {
+			const url = addQueryArgs( { reason: this.props.noticeType }, mobileRedirectUrl );
+			debug( 'Redirecting to', url );
+			return window.location.replace( url );
 		}
 	}
 


### PR DESCRIPTION
No visual differences.

In the mobile app flow, redirect back to the mobile app if we encounter a terminal error. Supply the error slug in the redirect url. This will allow the app to take appropriate action.

If the error is one that allows a retry, stay in the Calypso flow.

## Testing
* Turn on debug `localStorage.setItem( 'debug', 'calypso:jetpack-connect:*' );`
* Start the mobile app connection flow with the url http://calypso.localhost:3000/jetpack/connect?mobile_redirect=wordpress://jetpack-connection
* Cause an error condition by, for example, entering an invalid URL
* You should see a debug message specifying the redirect URL
