### PR TITLE
Reader: move read/site/:site to data layer

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1408,12 +1408,6 @@ Undocumented.prototype.unfollowList = function( query, fn ) {
 	);
 };
 
-Undocumented.prototype.readSite = function( query, fn ) {
-	var params = omit( query, 'site' );
-	debug( '/read/sites/:site' );
-	return this.wpcom.req.get( '/read/sites/' + query.site, params, fn );
-};
-
 Undocumented.prototype.readSiteFeatured = function( siteId, query, fn ) {
 	var params = omit( query, [ 'before', 'after' ] );
 	debug( '/read/sites/:site/featured' );

--- a/client/state/data-layer/wpcom/read/sites/index.js
+++ b/client/state/data-layer/wpcom/read/sites/index.js
@@ -35,8 +35,8 @@ export function receiveReadSiteSuccess( action, response ) {
 	return bypassDataLayer( receiveReaderSiteRequestSuccess( response ) );
 }
 
-export function receiveReadSiteError( action ) {
-	return bypassDataLayer( receiveReaderSiteRequestFailure( action.payload.blogId ) );
+export function receiveReadSiteError( action, response ) {
+	return bypassDataLayer( receiveReaderSiteRequestFailure( action, response ) );
 }
 
 const index = {

--- a/client/state/data-layer/wpcom/read/sites/index.js
+++ b/client/state/data-layer/wpcom/read/sites/index.js
@@ -15,6 +15,7 @@ import {
 	receiveReaderSiteRequestFailure,
 } from 'state/reader/sites/actions';
 import { fields } from 'state/reader/sites/fields';
+import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 
 export function requestReadSite( action ) {
 	return http(
@@ -26,6 +27,7 @@ export function requestReadSite( action ) {
 				fields: fields.join( ',' ),
 				options: [ 'is_mapped_domain', 'unmapped_url', 'is_redirect' ].join( ',' ),
 			},
+			retryPolicy: noRetry(),
 		},
 		action
 	);

--- a/client/state/data-layer/wpcom/read/sites/index.js
+++ b/client/state/data-layer/wpcom/read/sites/index.js
@@ -1,10 +1,52 @@
 /** @format */
+
 /**
  * Internal Dependencies
  */
+import { READER_SITE_REQUEST } from 'state/action-types';
 import { mergeHandlers } from 'state/action-watchers/utils';
-
 import notificationSubscriptions from './notification-subscriptions';
 import posts from './posts';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { bypassDataLayer } from 'state/data-layer/utils';
+import {
+	receiveReaderSiteRequestSuccess,
+	receiveReaderSiteRequestFailure,
+} from 'state/reader/sites/actions';
+import { fields } from 'state/reader/sites/fields';
 
-export default mergeHandlers( notificationSubscriptions, posts );
+export function requestReadSite( action ) {
+	return http(
+		{
+			apiVersion: '1.1',
+			method: 'GET',
+			path: `/read/sites/${ action.payload.ID }`,
+			query: {
+				fields: fields.join( ',' ),
+				options: [ 'is_mapped_domain', 'unmapped_url', 'is_redirect' ].join( ',' ),
+			},
+		},
+		action
+	);
+}
+
+export function receiveReadSiteSuccess( action, response ) {
+	return bypassDataLayer( receiveReaderSiteRequestSuccess( response ) );
+}
+
+export function receiveReadSiteError( action ) {
+	return bypassDataLayer( receiveReaderSiteRequestFailure( action.payload.blogId ) );
+}
+
+const index = {
+	[ READER_SITE_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch: requestReadSite,
+			onSuccess: receiveReadSiteSuccess,
+			onError: receiveReadSiteError,
+		} ),
+	],
+};
+
+export default mergeHandlers( index, notificationSubscriptions, posts );

--- a/client/state/data-layer/wpcom/read/sites/test/index.js
+++ b/client/state/data-layer/wpcom/read/sites/test/index.js
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { requestReadSite } from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { requestSite } from 'state/reader/sites/actions';
+
+describe( 'read-sites-site', () => {
+	describe( 'requestReadSite', () => {
+		test( 'should dispatch an http request', () => {
+			const blogId = 123;
+			const action = requestSite( blogId );
+
+			expect( requestReadSite( action ) ).toMatchObject(
+				http(
+					{
+						apiVersion: '1.1',
+						method: 'GET',
+						path: `/read/sites/${ blogId }`,
+					},
+					action
+				)
+			);
+		} );
+	} );
+} );

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -45,7 +45,7 @@ function handleDeserialize( state ) {
 }
 
 function handleRequestFailure( state, action ) {
-	// new object proceeds current state to prevent new errors from overwriting existing values
+	// new object precedes current state to prevent new errors from overwriting existing values
 	return assign(
 		{
 			[ action.payload.feed_ID ]: {

--- a/client/state/reader/sites/actions.js
+++ b/client/state/reader/sites/actions.js
@@ -30,12 +30,11 @@ export function receiveReaderSiteRequestSuccess( data ) {
 	};
 }
 
-export function receiveReaderSiteRequestFailure( blogId ) {
+export function receiveReaderSiteRequestFailure( action, error ) {
 	return {
 		type: READER_SITE_REQUEST_FAILURE,
-		payload: {
-			ID: blogId,
-		},
+		payload: action.payload,
+		error,
 	};
 }
 

--- a/client/state/reader/sites/actions.js
+++ b/client/state/reader/sites/actions.js
@@ -7,49 +7,35 @@ import { isArray } from 'lodash';
 /**
  * Internal Dependencies
  */
-import wpcom from 'lib/wp';
 import {
 	READER_SITE_REQUEST,
 	READER_SITE_REQUEST_SUCCESS,
 	READER_SITE_REQUEST_FAILURE,
 	READER_SITE_UPDATE,
 } from 'state/action-types';
-import { fields } from './fields';
 
-export function requestSite( siteId ) {
-	return function( dispatch ) {
-		dispatch( {
-			type: READER_SITE_REQUEST,
-			payload: {
-				ID: siteId,
-			},
-		} );
-		return wpcom
-			.undocumented()
-			.readSite( {
-				site: siteId,
-				fields: fields.join( ',' ),
-				options: [ 'is_mapped_domain', 'unmapped_url', 'is_redirect' ].join( ',' ),
-			} )
-			.then(
-				function success( data ) {
-					dispatch( {
-						type: READER_SITE_REQUEST_SUCCESS,
-						payload: data,
-					} );
-					return data;
-				},
-				function failure( error ) {
-					dispatch( {
-						type: READER_SITE_REQUEST_FAILURE,
-						payload: {
-							ID: siteId,
-						},
-						error,
-					} );
-					throw error;
-				}
-			);
+export function requestSite( blogId ) {
+	return {
+		type: READER_SITE_REQUEST,
+		payload: {
+			ID: blogId,
+		},
+	};
+}
+
+export function receiveReaderSiteRequestSuccess( data ) {
+	return {
+		type: READER_SITE_REQUEST_SUCCESS,
+		payload: data,
+	};
+}
+
+export function receiveReaderSiteRequestFailure( blogId ) {
+	return {
+		type: READER_SITE_REQUEST_FAILURE,
+		payload: {
+			ID: blogId,
+		},
 	};
 }
 

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -50,7 +50,6 @@ function handleRequestFailure( state, action ) {
 		return state;
 	}
 
-	// new object proceeds current state to prevent new errors from overwriting existing values
 	return assign( {}, state, {
 		[ action.payload.ID ]: {
 			ID: action.payload.ID,

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -2,7 +2,7 @@
 /**
  * External Dependencies
  */
-import { assign, keyBy, map, omit, omitBy, reduce, trim } from 'lodash';
+import { assign, includes, keyBy, map, omit, omitBy, reduce, trim } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -45,8 +45,10 @@ function handleDeserialize( state ) {
 }
 
 function handleRequestFailure( state, action ) {
-	// 410 means site moved. site used to be wpcom but is no longer
-	if ( action.error && action.error.statusCode !== 410 ) {
+	// 410 means site moved - site used to be on wpcom but is no longer
+	const handledStatusCodes = [ 403, 410 ];
+
+	if ( action.error && ! includes( handledStatusCodes, action.error.statusCode ) ) {
 		return state;
 	}
 

--- a/client/state/reader/sites/test/actions.js
+++ b/client/state/reader/sites/test/actions.js
@@ -1,105 +1,46 @@
 /** @format */
 /**
- * External dependencies
- */
-import { assert, expect } from 'chai';
-import sinon from 'sinon';
-
-/**
  * Internal dependencies
  */
-import { requestSite } from '../actions';
+import {
+	requestSite,
+	receiveReaderSiteRequestSuccess,
+	receiveReaderSiteRequestFailure,
+} from '../actions';
 import {
 	READER_SITE_REQUEST,
 	READER_SITE_REQUEST_SUCCESS,
 	READER_SITE_REQUEST_FAILURE,
 } from 'state/action-types';
-import useNock from 'test/helpers/use-nock';
-import { fields } from '../fields';
 
 describe( 'actions', () => {
-	describe( 'a valid fetch', () => {
-		const spy = sinon.spy();
-		let request;
-
-		useNock( nock => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.1/read/sites/1' )
-				.query( {
-					fields: fields.join( ',' ),
-					options: [ 'is_mapped_domain', 'unmapped_url', 'is_redirect' ].join( ',' ),
-				} )
-				.reply( 200, {
-					ID: 1,
-					name: 'My test site',
-				} );
-			request = requestSite( 1 )( spy );
-		} );
-
-		test( 'should dispatch request sync', () => {
-			expect( spy ).to.have.been.calledWith( {
+	describe( '#requestSite', () => {
+		test( 'should return an action when a site is requested', () => {
+			const action = requestSite( 123 );
+			expect( action ).toEqual( {
 				type: READER_SITE_REQUEST,
-				payload: {
-					ID: 1,
-				},
+				payload: { ID: 123 },
 			} );
-		} );
-
-		test( 'should dispatch success, eventually', () => {
-			return request.then(
-				() => {
-					expect( spy ).to.have.been.calledWith( {
-						type: READER_SITE_REQUEST_SUCCESS,
-						payload: {
-							ID: 1,
-							name: 'My test site',
-						},
-					} );
-				},
-				err => {
-					assert.fail( 'Errback should not be invoked!', err );
-					return err;
-				}
-			);
 		} );
 	} );
 
-	describe( 'a request for a site that does not exist', () => {
-		const spy = sinon.spy();
-		let request;
-
-		useNock( nock => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.get( '/rest/v1.1/read/sites/1' )
-				.reply( 404 );
-			request = requestSite( 1 )( spy );
-		} );
-
-		test( 'should dispatch request sync', () => {
-			expect( spy ).to.have.been.calledWith( {
-				type: READER_SITE_REQUEST,
-				payload: {
-					ID: 1,
-				},
+	describe( '#receiveReaderSiteRequestSuccess', () => {
+		test( 'should return an action when a site request succeeds', () => {
+			const action = receiveReaderSiteRequestSuccess( { ID: 123 } );
+			expect( action ).toEqual( {
+				type: READER_SITE_REQUEST_SUCCESS,
+				payload: { ID: 123 },
 			} );
 		} );
+	} );
 
-		test( 'should dispatch error, eventually', () => {
-			return request.then(
-				() => {
-					assert.fail( 'callback should not be invoked!', arguments );
-					throw new Error( 'errback should have been invoked' );
-				},
-				() => {
-					expect( spy ).to.have.been.calledWithMatch( {
-						type: READER_SITE_REQUEST_FAILURE,
-						payload: {
-							ID: 1,
-						},
-						error: sinon.match.instanceOf( Error ),
-					} );
-				}
-			);
+	describe( '#receiveReaderSiteRequestFailure', () => {
+		test( 'should return an action when a site request fails', () => {
+			const action = receiveReaderSiteRequestFailure( 123 );
+			expect( action ).toEqual( {
+				type: READER_SITE_REQUEST_FAILURE,
+				payload: { ID: 123 },
+			} );
 		} );
 	} );
 } );

--- a/client/state/reader/sites/test/actions.js
+++ b/client/state/reader/sites/test/actions.js
@@ -36,10 +36,14 @@ describe( 'actions', () => {
 
 	describe( '#receiveReaderSiteRequestFailure', () => {
 		test( 'should return an action when a site request fails', () => {
-			const action = receiveReaderSiteRequestFailure( 123 );
+			const action = receiveReaderSiteRequestFailure(
+				{ payload: { ID: 123 } },
+				{ statusCode: 410 }
+			);
 			expect( action ).toEqual( {
 				type: READER_SITE_REQUEST_FAILURE,
 				payload: { ID: 123 },
+				error: { statusCode: 410 },
 			} );
 		} );
 	} );


### PR DESCRIPTION
This PR moves the request for site information (`/read/site/:site`) from a Redux action to the data layer.

I've tried to keep the shape and type of actions we were previously using so that no reducer changes are required at this stage. 

Fixes #21213.

### To test

Try out a site that's been moved (410 Gone), like:

http://calypso.localhost:3000/read/blogs/234567

...and a site you're forbidden to view (403 Forbidden) as a non-superuser, like:

http://calypso.localhost:3000/read/blogs/179922

... and make sure you get the 'we couldn't find that site' error page in each case.

<img width="483" alt="screen shot 2018-01-15 at 19 53 55" src="https://user-images.githubusercontent.com/17325/34959311-dab6aed6-fa2d-11e7-90f2-6227586a96cc.png">

Also ensure site information is received correctly for other site streams.