### PR TITLE
WIP: Allow `createSelector` to store a cache

### DIFF
--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 
+import deterministicStringify from 'json-stable-stringify';
 import {
 	sortBy,
 	toPairs,
@@ -139,7 +140,7 @@ export function buildExportArray( data, parent = null ) {
  * @return {String}          Serialized stats query
  */
 export function getSerializedStatsQuery( query = {} ) {
-	return JSON.stringify( sortBy( toPairs( query ), pair => pair[ 0 ] ) );
+	return deterministicStringify( query );
 }
 
 /**


### PR DESCRIPTION
@see #20330 which is basically the same except this PR makes the behavior global and default
@see #20547 which provides an explicit and robust way of caching

> This is **exploratory** and may be **fundamentally flawed** but I'm opening it for the discussion because maybe, just maybe it's a good decision.

`createSelector` has a big problem: it invalidates its cache way too
frequently. It does this whenever dependants change, but it's not
comparing those dependants against the called parameters - it's applying
them "globally" within the selector such that even when the underlying
data in `state` is the same, because the selector was invoked with
different parameters it generates different dependants and thinks things
are different.

This change caches the dependants per cache key so we don't need to
clear so often. This introduces memory bloat because we're storing those
cached values throughout the session.