### PR TITLE
Remove custom domain registered task.

### DIFF
--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -127,7 +127,7 @@ const sequence = [
 	'about_page_updated',
 	'contact_page_updated',
 	'post_published',
-	'custom_domain_registered',
+	// 'custom_domain_registered',
 ];
 
 export const urlForTask = ( id, siteSlug ) => {


### PR DESCRIPTION
The domain registration task will be removed for the moment due to issues with the guided tour.

We may reinstate this as part of a future a/b test.

# Testing

- create a new site
- verify that the custom domain task does not appear on `/checklist/<domain>`