### PR TITLE
Fix: Format entire Activity Log description

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -57,7 +57,9 @@ class ActivityLogItem extends Component {
 				<ActivityActor { ...{ actorActivityUrl, actorName, actorRole, actorType } } />
 				<div className="activity-log-item__description">
 					<div className="activity-log-item__description-content">
-						<FormattedBlock content={ activityDescription[ 0 ] } />
+						{ activityDescription.map( ( part, i ) => (
+							<FormattedBlock key={ i } content={ part } />
+						) ) }
 					</div>
 					<div className="activity-log-item__description-summary">{ activityTitle }</div>
 				</div>

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -57,6 +57,10 @@ class ActivityLogItem extends Component {
 				<ActivityActor { ...{ actorActivityUrl, actorName, actorRole, actorType } } />
 				<div className="activity-log-item__description">
 					<div className="activity-log-item__description-content">
+						{ /* There is no great way to generate a more valid React key here
+						  * but the index is probably sufficient because these sub-items
+						  * shouldn't be changing.
+						  */ }
 						{ activityDescription.map( ( part, i ) => (
 							<FormattedBlock key={ i } content={ part } />
 						) ) }


### PR DESCRIPTION
Previously due to some confusion about the shape of the data in the
`content` property of the API response providing Activity Log data I was
only rendering the first part of a formatted message in activity log
event descriptions.

When we started passing in descriptions with multiple parts it was
cutting off everything past the first part.

`This <em>is hidden</em>`

^^^ that string would turn into this structure

```js
[
  'This ',
  {
    type: 'i',
    children: [ 'is hidden' ]
  }
]
```

So we can see how this cut off the formatting. In this patch we're
instead mapping over every part in the description which should resolve
the issue and others coming after it.

**Before**
![screen shot 2018-01-15 at 7 52 55 pm](https://user-images.githubusercontent.com/5431237/34966993-bb67e720-fa2d-11e7-92ff-e3479e83a62b.png)

**After**
![screen shot 2018-01-15 at 7 51 06 pm](https://user-images.githubusercontent.com/5431237/34966995-bd83c1e6-fa2d-11e7-8105-4e82c9c6ae72.png)

**Testing**

Open a site with the Activity Log enabled and navigate to
**My Sites** > **Stats** > **Activity Log** (make sure you are in a local
development environment).

Open the dev tools and inject an activity log entry with a multi-part
description. You can modify this one for testing…

```js
dispatch( {
	type: 'ACTIVITY_LOG_UPDATE',
	data: [
		{
			actorAvatarUrl: 'https://www.gravatar.com/avatar/0',
			actorName: 'Jetpack',
			actorRemoteId: 0,
			actorRole: '',
			actorType: 'Application',
			actorWpcomId: 0,
			activityDate: '2018-01-15T23:36:20+00:00',
			activityGroup: 'formatting',
			activityIcon: 'notice-outline',
			activityId: 'DOOPDOOP',
			activityIsDiscarded: false,
			activityIsRewindable: false,
			rewindId: '1234',
			activityName: 'test__message',
			activityStatus: 'warning',
			activityTitle: 'Formatting test',
			activityTs: 1516059291000, // <-- may need to bump this up to see the change
			activityDescription: [ 'first ', { type: 'i', children: [ 'second ' ] }, 'third' ],
		},
	],
	query: {
		dateEnd: 1517443199999,
		dateStart: 1514764800000,
		number: 1000,
	},
	siteId: YOUR_SITE_ID,
	meta: {
		dataLayer: {
			requestKey:
				'{"params":{"dateEnd":1517443199999,"dateStart":1514764800000,"number":1000},"siteId":YOUR_SITE_ID,"type":"ACTIVITY_LOG_REQUEST"}',
			status: 'success',
			lastUpdated: 1516063076352,
		},
		timestamp: 1516063076355,
	},
} )
```

In **master** you should only see the first part of the message but in this branch you
should see all of them.