### PR TITLE
Fix invalid jitm schema

### DIFF
--- a/client/state/data-layer/wpcom/sites/jitm/schema.json
+++ b/client/state/data-layer/wpcom/sites/jitm/schema.json
@@ -1,79 +1,59 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "definitions": {},
-  "id": "http://example.com/example.json",
   "properties": {
     "data": {
-      "id": "/properties/data",
       "items": {
-        "id": "/properties/data/items",
         "properties": {
           "CTA": {
-            "id": "/properties/data/items/properties/CTA",
             "properties": {
               "hook": {
-                "id": "/properties/data/items/properties/CTA/properties/hook",
                 "type": "string"
               },
               "message": {
-                "id": "/properties/data/items/properties/CTA/properties/message",
                 "type": "string"
               },
               "primary": {
-                "id": "/properties/data/items/properties/CTA/properties/primary",
                 "type": "boolean"
               }
             },
             "type": "object"
           },
           "content": {
-            "id": "/properties/data/items/properties/content",
             "properties": {
               "classes": {
-                "id": "/properties/data/items/properties/content/properties/classes",
                 "type": "string"
               },
               "description": {
-                "id": "/properties/data/items/properties/content/properties/description",
                 "type": "string"
               },
               "emblem": {
-                "id": "/properties/data/items/properties/content/properties/emblem",
                 "type": "null"
               },
               "icon": {
-                "id": "/properties/data/items/properties/content/properties/icon",
                 "type": "string"
               },
               "message": {
-                "id": "/properties/data/items/properties/content/properties/message",
                 "type": "string"
               }
             },
             "type": "object"
           },
           "feature_class": {
-            "id": "/properties/data/items/properties/feature_class",
             "type": "string"
           },
           "id": {
-            "id": "/properties/data/items/properties/id",
             "type": "string"
           },
           "jitm_stats_url": {
-            "id": "/properties/data/items/properties/jitm_stats_url",
             "type": "string"
           },
           "template": {
-            "id": "/properties/data/items/properties/template",
             "type": "string"
           },
           "ttl": {
-            "id": "/properties/data/items/properties/ttl",
             "type": "integer"
           },
           "url": {
-            "id": "/properties/data/items/properties/url",
             "type": "string"
           }
         },


### PR DESCRIPTION
This PR fixes an invalid schema detected by a method proposed #21509.

## Testing
1. Visit https://www.jsonschemavalidator.net/
1. Copy the draft-04 schema and paste it into the left (the validation schema): https://raw.githubusercontent.com/json-schema-org/json-schema-spec/d4c5b3a2924370c51b710c8bfd81d3644a92766e/schema.json
1. Paste the [modified schema](https://raw.githubusercontent.com/Automattic/wp-calypso/7547c4d5c17c40042af23b309cb97fab9a95dbab/client/state/data-layer/wpcom/sites/jitm/schema.json) from this PR into the right (data to be validated).
1. Validation should pass
1. Optional: Paste the [original schema](https://raw.githubusercontent.com/Automattic/wp-calypso/6fe50e5646b6c7c6d983db17a812497809990449/client/state/data-layer/wpcom/sites/jitm/schema.json) before modification and verify that it was invalid.
1. Verify that the schema behaves as expected. Behavior with invalid schemas in undefined.