### PR TITLE
i18n: Add support for Calypso extension translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,7 +231,7 @@
     "test-server:ci": "cross-env-shell TEST_REPORT_FILENAME=./test-results-server.xml jest -c=test/server/jest.config.ci.js -w=2",
     "test-server:coverage": "npm run -s test-server -- --coverage",
     "test-server:watch": "npm run -s test-server -- --watch",
-    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\" \"!client/extensions/**\"",
+    "translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -e date \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\"",
     "update-deps": "npm run -s rm -- node_modules && npm run -s rm -- npm-shrinkwrap.json && npm install && npm shrinkwrap"
   },
   "devDependencies": {


### PR DESCRIPTION
This addresses #12935 by removing the exclusion of the directories. This is dependent on server-side changes so this is not yet ready to launch.