### PR TITLE
Jetpack Onboarding: Restart flow when credentials are missing

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -11,9 +11,11 @@ import { recordTracksEvent } from 'state/analytics/actions';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import Main from 'components/main';
 import QueryJetpackOnboardingSettings from 'components/data/query-jetpack-onboarding-settings';
 import Wizard from 'components/wizard';
+import { addQueryArgs, externalRedirect } from 'lib/route';
 import {
 	JETPACK_ONBOARDING_COMPONENTS as COMPONENTS,
 	JETPACK_ONBOARDING_STEPS as STEPS,
@@ -35,7 +37,25 @@ class JetpackOnboardingMain extends React.PureComponent {
 		stepName: STEPS.SITE_TITLE,
 	};
 
-	// TODO: Add lifecycle methods to redirect if no siteId
+	componentDidMount() {
+		const { siteId, siteSlug } = this.props;
+
+		// If we are missing the Jetpack onboarding credentials,
+		// redirect back to wp-admin so we can obtain them again.
+		if ( ! siteId && siteSlug ) {
+			const siteDomain = siteSlug.replace( '::', '/' );
+			const url = addQueryArgs(
+				{
+					page: 'jetpack',
+					action: 'onboard',
+					calypso_env: config( 'env_id' ),
+				},
+				`//${ siteDomain }/wp-admin/admin.php`
+			);
+			externalRedirect( url );
+		}
+	}
+
 	render() {
 		const {
 			isRequestingSettings,
@@ -49,19 +69,23 @@ class JetpackOnboardingMain extends React.PureComponent {
 		return (
 			<Main className="jetpack-onboarding">
 				<QueryJetpackOnboardingSettings siteId={ siteId } />
-				<Wizard
-					basePath="/jetpack/onboarding"
-					baseSuffix={ siteSlug }
-					components={ COMPONENTS }
-					hideNavigation={ stepName === STEPS.SUMMARY }
-					isRequestingSettings={ isRequestingSettings }
-					recordJpoEvent={ recordJpoEvent }
-					siteId={ siteId }
-					siteSlug={ siteSlug }
-					settings={ settings }
-					stepName={ stepName }
-					steps={ steps }
-				/>
+				{ siteId ? (
+					<Wizard
+						basePath="/jetpack/onboarding"
+						baseSuffix={ siteSlug }
+						components={ COMPONENTS }
+						hideNavigation={ stepName === STEPS.SUMMARY }
+						isRequestingSettings={ isRequestingSettings }
+						recordJpoEvent={ recordJpoEvent }
+						siteId={ siteId }
+						siteSlug={ siteSlug }
+						settings={ settings }
+						stepName={ stepName }
+						steps={ steps }
+					/>
+				) : (
+					<div className="jetpack-onboarding__loading wpcom-site__logo noticon noticon-wordpress" />
+				) }
 			</Main>
 		);
 	}


### PR DESCRIPTION
This PR implements a mechanism to restart the Jetpack Onboarding flow if we visit the flow and we don't have credentials yet.

Fixes #21688.

To test:

* Checkout this branch
* Go to http://calypso.localhost:3000/jetpack/onboarding/:site, where `:site` is the slug of one of your non-connected Jetpack sites.
* Verify you're presented with a WP loading logo and after a short redirect loop you're redirected back to the JPO flow with JPO credentials loaded in Calypso.
* Start the onboarding flow from wp-admin (`?page=jetpack&action=onboard&calypso_env=development`)
* Verify the JPO flow works like it did before.