### PR TITLE
Fix: Rewind Credentials form error on `event`

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -53,7 +53,7 @@ export class CredentialsForm extends Component {
 
 		this.setState( {
 			form,
-			formErrors: { ...this.state.formErrors, [ event.target.name ]: false },
+			formErrors: { ...this.state.formErrors, [ name ]: false },
 		} );
 	};
 


### PR DESCRIPTION
In some refactor the `event` identifier wasn't removed when we started
destructing its properties on the event handler.

This fixes that.

The bug appeared in Firefox on the Rewind credentials form when entering
text into the credential form fields. `event is not defined`