### PR TITLE
Jetpack Connect: Redirect back to mobile app (via notices callback) on error

### DIFF
--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -167,19 +167,19 @@ class JetpackConnectNotices extends Component {
 
 	componentDidUpdate() {
 		if ( this.errorIsTerminal() && this.props.onTerminalError ) {
-			this.props.onTerminalError();
+			this.props.onTerminalError( this.props.noticeType );
 		}
 	}
 
 	componentDidMount() {
 		if ( this.errorIsTerminal() && this.props.onTerminalError ) {
-			this.props.onTerminalError();
+			this.props.onTerminalError( this.props.noticeType );
 		}
 	}
 
 	errorIsTerminal() {
 		const notice = this.getNoticeValues();
-		return ! notice.userCanRetry;
+		return notice && ! notice.userCanRetry;
 	}
 
 	render() {

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -15,7 +15,7 @@ class JetpackConnectNotices extends Component {
 	static propTypes = {
 		// Supply a function that will be called for flow-ending error cases
 		// instead of showing a notice.
-		onTerminalError: PropTypes.oneOf( [ PropTypes.func, false ] ),
+		onTerminalError: PropTypes.func,
 		noticeType: PropTypes.oneOf( [
 			'alreadyConnected',
 			'alreadyConnectedByOtherUser',

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import Notice from 'components/notice';
 
-class JetpackConnectNotices extends Component {
+export class JetpackConnectNotices extends Component {
 	static propTypes = {
 		// Supply a function that will be called for flow-ending error cases
 		// instead of showing a notice.

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -15,7 +15,7 @@ class JetpackConnectNotices extends Component {
 	static propTypes = {
 		// Supply a function that will be called for flow-ending error cases
 		// instead of showing a notice.
-		onTerminalError: PropTypes.func,
+		onTerminalError: PropTypes.oneOf( [ PropTypes.func, false ] ),
 		noticeType: PropTypes.oneOf( [
 			'alreadyConnected',
 			'alreadyConnectedByOtherUser',

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -13,6 +13,8 @@ import Notice from 'components/notice';
 
 class JetpackConnectNotices extends Component {
 	static propTypes = {
+		// Supply a function that will be called for flow-ending error cases
+		// instead of showing a notice.
 		onTerminalError: PropTypes.func,
 		noticeType: PropTypes.oneOf( [
 			'alreadyConnected',

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -13,6 +13,7 @@ import Notice from 'components/notice';
 
 class JetpackConnectNotices extends Component {
 	static propTypes = {
+		onTerminalError: PropTypes.func,
 		noticeType: PropTypes.oneOf( [
 			'alreadyConnected',
 			'alreadyConnectedByOtherUser',
@@ -106,6 +107,7 @@ class JetpackConnectNotices extends Component {
 				);
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'notice';
+				noticeValues.userCanRetry = true;
 				return noticeValues;
 
 			case 'retryAuth':
@@ -114,6 +116,7 @@ class JetpackConnectNotices extends Component {
 				);
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'notice';
+				noticeValues.userCanRetry = true;
 				return noticeValues;
 
 			case 'secretExpired':
@@ -160,8 +163,28 @@ class JetpackConnectNotices extends Component {
 		}
 	}
 
+	componentDidUpdate() {
+		if ( this.errorIsTerminal() && this.props.onTerminalError ) {
+			this.props.onTerminalError();
+		}
+	}
+
+	componentDidMount() {
+		if ( this.errorIsTerminal() && this.props.onTerminalError ) {
+			this.props.onTerminalError();
+		}
+	}
+
+	errorIsTerminal() {
+		const notice = this.getNoticeValues();
+		return ! notice.userCanRetry;
+	}
+
 	render() {
 		const values = this.getNoticeValues();
+		if ( this.errorIsTerminal() && this.props.onTerminalError ) {
+			return null;
+		}
 		if ( values ) {
 			return (
 				<div className="jetpack-connect__notices-container">

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -418,7 +418,7 @@ export class JetpackConnectMain extends Component {
 						noticeType={ status }
 						onDismissClick={ this.dismissUrl }
 						url={ this.state.currentUrl }
-						onTerminalError={ this.props.isMobileAppFlow && this.redirectToMobileApp }
+						onTerminalError={ this.props.isMobileAppFlow ? this.redirectToMobileApp : null }
 					/>
 				) : null }
 

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -104,9 +104,7 @@ export class JetpackConnectMain extends Component {
 		}
 		if ( this.getStatus() === 'alreadyOwned' && ! this.redirecting ) {
 			if ( this.props.isMobileAppFlow ) {
-				const url = addQueryArgs( { reason: 'already-connected' }, this.props.mobileAppRedirect );
-				debug( 'redirect to', url );
-				return window.location.replace( url );
+				return this.redirectToMobileApp( 'already-connected' );
 			}
 			return this.goToPlans( this.state.currentUrl );
 		}
@@ -162,6 +160,12 @@ export class JetpackConnectMain extends Component {
 		} );
 
 		externalRedirect( addCalypsoEnvQueryArg( url + REMOTE_PATH_ACTIVATE ) );
+	} );
+
+	redirectToMobileApp = this.makeSafeRedirectionFunction( reason => {
+		const url = addQueryArgs( { reason }, this.props.mobileAppRedirect );
+		debug( `Redirecting to mobile app ${ url }` );
+		externalRedirect( url );
 	} );
 
 	isCurrentUrlFetched() {
@@ -414,6 +418,7 @@ export class JetpackConnectMain extends Component {
 						noticeType={ status }
 						onDismissClick={ this.dismissUrl }
 						url={ this.state.currentUrl }
+						onTerminalError={ this.props.isMobileAppFlow && this.redirectToMobileApp }
 					/>
 				) : null }
 

--- a/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`JetpackConnectNotices Should not render notice if callback supplied 1`] = `null`;
+
+exports[`JetpackConnectNotices Should render notice 1`] = `
+<div
+  className="jetpack-connect__notices-container"
+>
+  <div
+    className="notice is-error "
+  >
+    <span
+      className="notice__icon-wrapper"
+    >
+      <svg
+        className="gridicon gridicons-notice notice__icon"
+        height={24}
+        onClick={undefined}
+        viewBox="0 0 24 24"
+        width={24}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"
+          />
+        </g>
+      </svg>
+    </span>
+    <span
+      className="notice__content"
+    >
+      <span
+        className="notice__text"
+      >
+        That's not a valid url.
+      </span>
+    </span>
+  </div>
+</div>
+`;

--- a/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
@@ -1,42 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`JetpackConnectNotices Should not render notice if callback supplied 1`] = `null`;
+exports[`JetpackConnectNotices Should not render Notice on terminal error if callback supplied 1`] = `""`;
 
 exports[`JetpackConnectNotices Should render non-terminal notice if callback supplied 1`] = `
 <div
   className="jetpack-connect__notices-container"
 >
-  <div
-    className="notice is-warning "
-  >
-    <span
-      className="notice__icon-wrapper"
-    >
-      <svg
-        className="gridicon gridicons-notice notice__icon"
-        height={24}
-        onClick={undefined}
-        viewBox="0 0 24 24"
-        width={24}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <g>
-          <path
-            d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"
-          />
-        </g>
-      </svg>
-    </span>
-    <span
-      className="notice__content"
-    >
-      <span
-        className="notice__text"
-      >
-        In some cases, authorization can take a few attempts. Please try again.
-      </span>
-    </span>
-  </div>
+  <Localized(Notice)
+    icon="notice"
+    showDismiss={false}
+    status="is-warning"
+    text="In some cases, authorization can take a few attempts. Please try again."
+    userCanRetry={true}
+  />
 </div>
 `;
 
@@ -44,36 +20,11 @@ exports[`JetpackConnectNotices Should render notice 1`] = `
 <div
   className="jetpack-connect__notices-container"
 >
-  <div
-    className="notice is-error "
-  >
-    <span
-      className="notice__icon-wrapper"
-    >
-      <svg
-        className="gridicon gridicons-notice notice__icon"
-        height={24}
-        onClick={undefined}
-        viewBox="0 0 24 24"
-        width={24}
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <g>
-          <path
-            d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"
-          />
-        </g>
-      </svg>
-    </span>
-    <span
-      className="notice__content"
-    >
-      <span
-        className="notice__text"
-      >
-        That's not a valid url.
-      </span>
-    </span>
-  </div>
+  <Localized(Notice)
+    icon="notice"
+    showDismiss={false}
+    status="is-error"
+    text="That's not a valid url."
+  />
 </div>
 `;

--- a/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`JetpackConnectNotices Should not render Notice on terminal error if callback supplied 1`] = `""`;
+exports[`JetpackConnectNotices Should not render terminal notice if callback supplied 1`] = `""`;
 
 exports[`JetpackConnectNotices Should render non-terminal notice if callback supplied 1`] = `
 <div

--- a/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/jetpack-connect-notices.js.snap
@@ -2,6 +2,44 @@
 
 exports[`JetpackConnectNotices Should not render notice if callback supplied 1`] = `null`;
 
+exports[`JetpackConnectNotices Should render non-terminal notice if callback supplied 1`] = `
+<div
+  className="jetpack-connect__notices-container"
+>
+  <div
+    className="notice is-warning "
+  >
+    <span
+      className="notice__icon-wrapper"
+    >
+      <svg
+        className="gridicon gridicons-notice notice__icon"
+        height={24}
+        onClick={undefined}
+        viewBox="0 0 24 24"
+        width={24}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"
+          />
+        </g>
+      </svg>
+    </span>
+    <span
+      className="notice__content"
+    >
+      <span
+        className="notice__text"
+      >
+        In some cases, authorization can take a few attempts. Please try again.
+      </span>
+    </span>
+  </div>
+</div>
+`;
+
 exports[`JetpackConnectNotices Should render notice 1`] = `
 <div
   className="jetpack-connect__notices-container"

--- a/client/jetpack-connect/test/jetpack-connect-notices.js
+++ b/client/jetpack-connect/test/jetpack-connect-notices.js
@@ -27,4 +27,13 @@ describe( 'JetpackConnectNotices', () => {
 		expect( onTerminalError ).toHaveBeenCalledTimes( 1 );
 		expect( component ).toMatchSnapshot();
 	} );
+
+	test( 'Should render non-terminal notice if callback supplied', () => {
+		const onTerminalError = jest.fn();
+		const component = renderer.create(
+			<JetpackConnectNotices noticeType="retryAuth" onTerminalError={ onTerminalError } />
+		);
+		expect( onTerminalError ).toHaveNotBeenCalled;
+		expect( component ).toMatchSnapshot();
+	} );
 } );

--- a/client/jetpack-connect/test/jetpack-connect-notices.js
+++ b/client/jetpack-connect/test/jetpack-connect-notices.js
@@ -33,7 +33,7 @@ describe( 'JetpackConnectNotices', () => {
 		const component = renderer.create(
 			<JetpackConnectNotices noticeType="retryAuth" onTerminalError={ onTerminalError } />
 		);
-		expect( onTerminalError ).toHaveNotBeenCalled;
+		expect( onTerminalError ).not.toHaveBeenCalled();
 		expect( component ).toMatchSnapshot();
 	} );
 } );

--- a/client/jetpack-connect/test/jetpack-connect-notices.js
+++ b/client/jetpack-connect/test/jetpack-connect-notices.js
@@ -1,0 +1,30 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import JetpackConnectNotices from '../jetpack-connect-notices';
+
+describe( 'JetpackConnectNotices', () => {
+	test( 'Should render notice', () => {
+		const component = renderer.create( <JetpackConnectNotices noticeType="notExists" /> );
+		expect( component ).toMatchSnapshot();
+	} );
+
+	test( 'Should not render notice if callback supplied', () => {
+		const onTerminalError = jest.fn();
+		const component = renderer.create(
+			<JetpackConnectNotices noticeType="notExists" onTerminalError={ onTerminalError } />
+		);
+		expect( onTerminalError ).toHaveBeenCalledTimes( 1 );
+		expect( component ).toMatchSnapshot();
+	} );
+} );

--- a/client/jetpack-connect/test/jetpack-connect-notices.js
+++ b/client/jetpack-connect/test/jetpack-connect-notices.js
@@ -6,34 +6,64 @@
  * External dependencies
  */
 import React from 'react';
-import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
+import { identity } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import JetpackConnectNotices from '../jetpack-connect-notices';
+import { JetpackConnectNotices } from '../jetpack-connect-notices';
+import Notice from 'components/notice';
+
+const terminalErrorNoticeType = 'notExists';
+const nonTerminalErrorNoticeType = 'retryAuth';
+const requiredProps = { translate: identity };
 
 describe( 'JetpackConnectNotices', () => {
 	test( 'Should render notice', () => {
-		const component = renderer.create( <JetpackConnectNotices noticeType="notExists" /> );
-		expect( component ).toMatchSnapshot();
+		const wrapper = shallow(
+			<JetpackConnectNotices { ...requiredProps } noticeType={ terminalErrorNoticeType } />
+		);
+		expect( wrapper ).toMatchSnapshot();
+		expect( wrapper.find( Notice ) ).toHaveLength( 1 );
 	} );
 
-	test( 'Should not render notice if callback supplied', () => {
+	test( 'Should not render Notice on terminal error if callback supplied', () => {
 		const onTerminalError = jest.fn();
-		const component = renderer.create(
-			<JetpackConnectNotices noticeType="notExists" onTerminalError={ onTerminalError } />
+		const wrapper = shallow(
+			<JetpackConnectNotices
+				{ ...requiredProps }
+				noticeType={ terminalErrorNoticeType }
+				onTerminalError={ onTerminalError }
+			/>
+		);
+		expect( wrapper ).toMatchSnapshot();
+		expect( wrapper.find( Notice ) ).toHaveLength( 0 );
+	} );
+
+	test( 'Should call callback on terminal error', () => {
+		const onTerminalError = jest.fn();
+		shallow(
+			<JetpackConnectNotices
+				{ ...requiredProps }
+				noticeType={ terminalErrorNoticeType }
+				onTerminalError={ onTerminalError }
+			/>
 		);
 		expect( onTerminalError ).toHaveBeenCalledTimes( 1 );
-		expect( component ).toMatchSnapshot();
 	} );
 
 	test( 'Should render non-terminal notice if callback supplied', () => {
 		const onTerminalError = jest.fn();
-		const component = renderer.create(
-			<JetpackConnectNotices noticeType="retryAuth" onTerminalError={ onTerminalError } />
+		const wrapper = shallow(
+			<JetpackConnectNotices
+				{ ...requiredProps }
+				noticeType={ nonTerminalErrorNoticeType }
+				onTerminalError={ onTerminalError }
+			/>
 		);
 		expect( onTerminalError ).not.toHaveBeenCalled();
-		expect( component ).toMatchSnapshot();
+		expect( wrapper ).toMatchSnapshot();
+		expect( wrapper.find( Notice ) ).toHaveLength( 1 );
 	} );
 } );

--- a/client/jetpack-connect/test/jetpack-connect-notices.js
+++ b/client/jetpack-connect/test/jetpack-connect-notices.js
@@ -13,7 +13,6 @@ import { identity } from 'lodash';
  * Internal dependencies
  */
 import { JetpackConnectNotices } from '../jetpack-connect-notices';
-import Notice from 'components/notice';
 
 const terminalErrorNoticeType = 'notExists';
 const nonTerminalErrorNoticeType = 'retryAuth';
@@ -25,10 +24,10 @@ describe( 'JetpackConnectNotices', () => {
 			<JetpackConnectNotices { ...requiredProps } noticeType={ terminalErrorNoticeType } />
 		);
 		expect( wrapper ).toMatchSnapshot();
-		expect( wrapper.find( Notice ) ).toHaveLength( 1 );
+		expect( wrapper.isEmptyRender() ).toBe( false );
 	} );
 
-	test( 'Should not render Notice on terminal error if callback supplied', () => {
+	test( 'Should not render terminal notice if callback supplied', () => {
 		const onTerminalError = jest.fn();
 		const wrapper = shallow(
 			<JetpackConnectNotices
@@ -38,7 +37,7 @@ describe( 'JetpackConnectNotices', () => {
 			/>
 		);
 		expect( wrapper ).toMatchSnapshot();
-		expect( wrapper.find( Notice ) ).toHaveLength( 0 );
+		expect( wrapper.isEmptyRender() ).toBe( true );
 	} );
 
 	test( 'Should call callback on terminal error', () => {
@@ -64,6 +63,6 @@ describe( 'JetpackConnectNotices', () => {
 		);
 		expect( onTerminalError ).not.toHaveBeenCalled();
 		expect( wrapper ).toMatchSnapshot();
-		expect( wrapper.find( Notice ) ).toHaveLength( 1 );
+		expect( wrapper.isEmptyRender() ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
In the mobile app flow, redirect back to the mobile app if we encounter a terminal error. Supply the error slug in the redirect url. This will allow the app to take appropriate action.

If the error is one that allows a retry, stay in the Calypso flow.

Pass the callback function as a prop to the `<JetpackConnectNotices />` component to make the potential side-effect explicit. If the callback is executed, the error notice will not be rendered.

## Testing
* Turn on debug `localStorage.setItem( 'debug', 'calypso:jetpack-connect:*' );`
* Start the mobile app connection flow with the url http://calypso.localhost:3000/jetpack/connect?mobile_redirect=wordpress://jetpack-connection
* Cause an error condition by, for example, entering an invalid URL
* You should see a debug message specifying the redirect URL, and the notice should not be displayed
* Auth errors are harder to reproduce. Can be simulated by tweaking the logic in the code, for example [here](https://github.com/Automattic/wp-calypso/pull/21568/files#diff-ff76e1701bebf84cf3e5a847ffd165d0R442)
* When not in the mobile app flow (start from http://calypso.localhost:3000/jetpack/connect) notices should be displayed as usual.
