### PR TITLE
Build: Run Docker commands as Calypso user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,4 +66,5 @@ RUN        true \
 USER       calypso
 ARG        commit_sha=(unknown)
 RUN        CALYPSO_ENV=production COMMIT_SHA=$commit_sha npm run build
+RUN        find . -not -user calypso -or -not -group calypso | wc -l
 CMD        NODE_ENV=production node build/bundle.js


### PR DESCRIPTION
# DO NOT MERGE

The most expensive operation in the existing Docker build is to chown
all of the files produced during the entire Calypso build process. This
is because of the way the overlay file system works, where any file
modifications imply a copy operation from a lower layer to the current
layer.

~By running operations as a non-root user from the beginning, we can
avoid the need to chown all of these files, saving significant time and
space.~

`COPY` operations will require `chown` to be run for now. Some work can be saved by being smarter about when `chown` is run. This PR builds on the changes in #20589.

See the following link for more information:

https://docs.docker.com/engine/userguide/storagedriver/overlayfs-driver/#overlayfs-and-docker-performance

Related: #20589 