### PR TITLE
Handle specific booking errors

### DIFF
--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -14,11 +14,12 @@ import { connect } from 'react-redux';
 import HeaderCake from 'components/header-cake';
 import { getConciergeSignupForm } from 'state/selectors';
 import { getCurrentUserId, getCurrentUserLocale } from 'state/current-user/selectors';
-import { bookConciergeAppointment } from 'state/concierge/actions';
+import { bookConciergeAppointment, requestConciergeAvailableTimes } from 'state/concierge/actions';
 import AvailableTimePicker from '../shared/available-time-picker';
 import {
-	CONCIERGE_STATUS_BOOKING,
 	CONCIERGE_STATUS_BOOKED,
+	CONCIERGE_STATUS_BOOKING,
+	CONCIERGE_STATUS_BOOKING_ERROR,
 	WPCOM_CONCIERGE_SCHEDULE_ID,
 } from '../constants';
 
@@ -53,6 +54,9 @@ class CalendarStep extends Component {
 		if ( nextProps.signupForm.status === CONCIERGE_STATUS_BOOKED ) {
 			// go to confirmation page if booking was successfull
 			this.props.onComplete();
+		} else if ( nextProps.signupForm.status === CONCIERGE_STATUS_BOOKING_ERROR ) {
+			// request new available times
+			this.props.requestConciergeAvailableTimes( WPCOM_CONCIERGE_SCHEDULE_ID );
 		}
 	}
 
@@ -83,5 +87,5 @@ export default connect(
 		currentUserId: getCurrentUserId( state ),
 		currentUserLocale: getCurrentUserLocale( state ),
 	} ),
-	{ bookConciergeAppointment }
+	{ bookConciergeAppointment, requestConciergeAvailableTimes }
 )( localize( CalendarStep ) );

--- a/client/me/concierge/constants.js
+++ b/client/me/concierge/constants.js
@@ -8,8 +8,12 @@ export const WPCOM_CONCIERGE_SCHEDULE_ID = config( 'wpcom_concierge_schedule_id'
 // booking status
 export const CONCIERGE_STATUS_BOOKED = 'booked';
 export const CONCIERGE_STATUS_BOOKING = 'booking';
+export const CONCIERGE_STATUS_BOOKING_ERROR = 'booking_error';
 
 // cancelling status
 export const CONCIERGE_STATUS_CANCELLED = 'cancelled';
 export const CONCIERGE_STATUS_CANCELLING = 'cancelling';
 export const CONCIERGE_STATUS_CANCELLING_ERROR = 'cancelling_error';
+
+// error codes
+export const CONCIERGE_ERROR_NO_AVAILABLE_STAFF = 'rest_concierge_no_available_staff';

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/index.js
@@ -105,7 +105,7 @@ export const handleBookingError = ( { dispatch }, action, error ) => {
 	switch ( error.code ) {
 		case CONCIERGE_ERROR_NO_AVAILABLE_STAFF:
 			errorMessage = translate(
-				'The selected time slot is not available anymore. Please select a different slot.'
+				'This session is no longer available. Please select a different time.'
 			);
 			break;
 

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/index.js
@@ -20,9 +20,11 @@ import {
 import {
 	CONCIERGE_STATUS_BOOKED,
 	CONCIERGE_STATUS_BOOKING,
+	CONCIERGE_STATUS_BOOKING_ERROR,
 	CONCIERGE_STATUS_CANCELLED,
 	CONCIERGE_STATUS_CANCELLING,
 	CONCIERGE_STATUS_CANCELLING_ERROR,
+	CONCIERGE_ERROR_NO_AVAILABLE_STAFF,
 } from 'me/concierge/constants';
 import fromApi from './from-api';
 
@@ -96,11 +98,23 @@ export const rescheduleConciergeAppointment = ( { dispatch }, action ) => {
 export const markSlotAsBooked = ( { dispatch } ) =>
 	dispatch( updateConciergeBookingStatus( CONCIERGE_STATUS_BOOKED ) );
 
-export const handleBookingError = ( { dispatch } ) => {
-	dispatch( updateConciergeBookingStatus( null ) );
-	dispatch(
-		errorNotice( translate( 'We could not book your appointment. Please try again later.' ) )
-	);
+export const handleBookingError = ( { dispatch }, action, error ) => {
+	dispatch( updateConciergeBookingStatus( CONCIERGE_STATUS_BOOKING_ERROR ) );
+
+	let errorMessage;
+	switch ( error.code ) {
+		case CONCIERGE_ERROR_NO_AVAILABLE_STAFF:
+			errorMessage = translate(
+				'The selected time slot is not available anymore. Please select a different slot.'
+			);
+			break;
+
+		default:
+			errorMessage = translate( 'We could not book your appointment. Please try again later.' );
+			break;
+	}
+
+	dispatch( errorNotice( errorMessage ) );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/test/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/test/index.js
@@ -18,6 +18,7 @@ import {
 	CONCIERGE_APPOINTMENT_CREATE,
 	CONCIERGE_APPOINTMENT_RESCHEDULE,
 } from 'state/action-types';
+import { CONCIERGE_STATUS_BOOKING_ERROR } from 'me/concierge/constants';
 
 // we are mocking impure-lodash here, so that conciergeShiftsFetchError() will contain the expected id in the tests
 jest.mock( 'lib/impure-lodash', () => ( {
@@ -40,7 +41,9 @@ describe( 'wpcom-api', () => {
 				http(
 					{
 						method: 'POST',
-						path: `/concierge/schedules/${ action.scheduleId }/appointments/${ action.appointmentId }/cancel`,
+						path: `/concierge/schedules/${ action.scheduleId }/appointments/${
+							action.appointmentId
+						}/cancel`,
 						apiNamespace: 'wpcom/v2',
 						body: {},
 					},
@@ -90,7 +93,9 @@ describe( 'wpcom-api', () => {
 				http(
 					{
 						method: 'POST',
-						path: `/concierge/schedules/${ action.scheduleId }/appointments/${ action.appointmentId }/reschedule`,
+						path: `/concierge/schedules/${ action.scheduleId }/appointments/${
+							action.appointmentId
+						}/reschedule`,
 						apiNamespace: 'wpcom/v2',
 						body: {
 							begin_timestamp: action.beginTimestamp / 1000,
@@ -112,9 +117,11 @@ describe( 'wpcom-api', () => {
 		test( 'handleBookingError()', () => {
 			const dispatch = jest.fn();
 
-			handleBookingError( { dispatch } );
+			handleBookingError( { dispatch }, {}, { code: 'error' } );
 
-			expect( dispatch ).toHaveBeenCalledWith( updateConciergeBookingStatus( null ) );
+			expect( dispatch ).toHaveBeenCalledWith(
+				updateConciergeBookingStatus( CONCIERGE_STATUS_BOOKING_ERROR )
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
## Summary
This PR adds more complex error handling for booking a concierge appointment. If the selected time slot was already booked by someone else error in the notification will be `The selected time slot is not available anymore. Please select a different slot.` and it will automatically trigger a refresh of the available times dropdowns.

More info in 514-hg-gh.

## Testing
1. Apply the diff D9369-code
2. Comment out the line https://github.com/Automattic/wp-calypso/pull/21576/files#diff-da7910002dde6a4a40bb4a6f6a0b659bR56 so it will not redirect to the confirmation page
3. Update `"wpcom_concierge_schedule_id": 1938,` in calypso `development.json` config
4. Select a time slot and book it until all available staff is booked
5. The error should state that we have no more staff available for that time slot
6. The calendar page should re-render with the latest available times https://cloudup.com/c8XxVilaTST
