### PR TITLE
JPO: add Tracks Analytics to the Homepage step.

### DIFF
--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -21,7 +21,10 @@ import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions'
 class JetpackOnboardingHomepageStep extends React.PureComponent {
 	handleHomepageSelection = homepageFormat => {
 		const { siteId } = this.props;
-		this.props.recordJpoEvent( 'calypso_jpo_' + homepageFormat + '_clicked' );
+
+		this.props.recordJpoEvent( 'calypso_jpo_homepage_format_clicked', {
+			homepageFormat,
+		} );
 
 		return () => {
 			this.props.saveJetpackOnboardingSettings( siteId, {

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -21,6 +21,7 @@ import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions'
 class JetpackOnboardingHomepageStep extends React.PureComponent {
 	handleHomepageSelection = homepageFormat => {
 		const { siteId } = this.props;
+		this.props.recordJpoEvent( 'calypso_jpo_' + homepageFormat + '_clicked' );
 
 		return () => {
 			this.props.saveJetpackOnboardingSettings( siteId, {


### PR DESCRIPTION
Introduce on click event tracking in the Homepage step.

**To test:**
* Checkout this branch in local Calypso.
* Run the latest JP master on the sandbox.
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your JP sandbox.
* Land in http://calypso.localhost:3000/jetpack/onboarding/yourjetpacksandbox.com.
* Click through till hitting the `onboarding/homepage/yourjetpacksandbox.com ` step.
* Click `Recent news or updates` and `A static welcome page` tiles and use `localStorage.debug = 'calypso:analytics:tracks'` to confirm that `calypso_jpo_homepage_format_clicked` event fires and 
 `homepageFormat: "page"` or `homepageFormat: "posts"`  is present in the event object properties (depending on the selected tile). 
