### PR TITLE
JPO: add tracking to the Site Type step.

### DIFF
--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -20,6 +20,8 @@ import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions'
 
 class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 	handleSiteTypeSelection = siteType => () => {
+		this.props.recordJpoEvent( 'calypso_jpo_' + siteType + '_clicked' );
+
 		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
 			siteType,
 		} );

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -20,8 +20,9 @@ import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions'
 
 class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 	handleSiteTypeSelection = siteType => () => {
-		this.props.recordJpoEvent( 'calypso_jpo_' + siteType + '_clicked' );
-
+		this.props.recordJpoEvent( 'calypso_jpo_site_type_clicked', {
+			siteType,
+		} );
 		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
 			siteType,
 		} );


### PR DESCRIPTION
Introduce on click event tracking in the Site Type step.

**To test:**
* Follow the instructions on https://github.com/Automattic/wp-calypso/pull/21578 to arrive at `onboarding/site-type/yourjetpacksandbox.com`
* Use `localStorage.debug = 'calypso:analytics:tracks'` to confirm that `calypso_jpo_personal_clicked` event fires on clicking `Personal site` tile and  `calypso_jpo_business_clicked` for `Business site`.
* Verify seeing `blog_id: your_site_id, site_id_type: "jpo"` in the tracking object in both cases.