### PR TITLE
Components: add validation to the required text input fields in SiteTitle.

### DIFF
--- a/client/components/site-title/README.md
+++ b/client/components/site-title/README.md
@@ -17,4 +17,5 @@ For an example of how to use, have a look at [docs/example.jsx](docs/example.jsx
 - `blogname` - *optional* (string) Site title to be displayed in corresponding input field.
 - `blogdescription` - *optional* (string) Site tagline to be displayed in corresponding input field.
 - `disabled` - *optional* (bool) Whether input fields should be disabled (defaults to `false`).
+- `isTitleRequired` - *optional* (bool) Whether set the blogname field as required 
 - `onChange` - *optional* (function) Called whenever user changes either the site title or tagline field. Invoked with an object with `blogname` and `blogdescription` attributes.

--- a/client/components/site-title/README.md
+++ b/client/components/site-title/README.md
@@ -17,5 +17,5 @@ For an example of how to use, have a look at [docs/example.jsx](docs/example.jsx
 - `blogname` - *optional* (string) Site title to be displayed in corresponding input field.
 - `blogdescription` - *optional* (string) Site tagline to be displayed in corresponding input field.
 - `disabled` - *optional* (bool) Whether input fields should be disabled (defaults to `false`).
-- `isTitleRequired` - *optional* (bool) Whether set the blogname field as required 
+- `isBlognameRequired` - *optional* (bool) Whether set the blogname field as required 
 - `onChange` - *optional* (function) Called whenever user changes either the site title or tagline field. Invoked with an object with `blogname` and `blogdescription` attributes.

--- a/client/components/site-title/index.jsx
+++ b/client/components/site-title/index.jsx
@@ -22,7 +22,7 @@ class SiteTitleControl extends React.Component {
 		blogname: PropTypes.string,
 		blogdescription: PropTypes.string,
 		disabled: PropTypes.bool,
-		isTitleRequired: PropTypes.bool,
+		isBlognameRequired: PropTypes.bool,
 		onChange: PropTypes.func.isRequired,
 	};
 
@@ -30,7 +30,7 @@ class SiteTitleControl extends React.Component {
 		autoFocusBlogname: false,
 		blogname: '',
 		blogdescription: '',
-		isTitleRequired: false,
+		isBlognameRequired: false,
 		disabled: false,
 	};
 
@@ -46,19 +46,13 @@ class SiteTitleControl extends React.Component {
 		this.props.onChange( { blogname, blogdescription } );
 	};
 
-	renderValidation = blogname => {
-		const isError = blogname ? false : true;
-
-		return <FormInputValidation isError={ isError } text="Required field." />;
-	};
-
 	render() {
 		const {
 			autoFocusBlogname,
 			blogname,
 			blogdescription,
 			disabled,
-			isTitleRequired,
+			isBlognameRequired,
 			translate,
 		} = this.props;
 		return (
@@ -72,7 +66,9 @@ class SiteTitleControl extends React.Component {
 						onChange={ this.onChangeSiteTitle }
 						value={ blogname }
 					/>
-					{ isTitleRequired ? this.renderValidation( blogname ) : null }
+					{ isBlognameRequired && (
+						<FormInputValidation isError={ ! blogname } text={ translate( 'Required field.' ) } />
+					) }
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="blogdescription">{ translate( 'Tagline' ) }</FormLabel>

--- a/client/components/site-title/index.jsx
+++ b/client/components/site-title/index.jsx
@@ -46,6 +46,12 @@ class SiteTitleControl extends React.Component {
 		this.props.onChange( { blogname, blogdescription } );
 	};
 
+	renderValidation = blogname => {
+		const isError = blogname ? false : true;
+
+		return <FormInputValidation isError={ isError } text="Required field." />;
+	};
+
 	render() {
 		const {
 			autoFocusBlogname,
@@ -66,11 +72,7 @@ class SiteTitleControl extends React.Component {
 						onChange={ this.onChangeSiteTitle }
 						value={ blogname }
 					/>
-					{ blogname && isTitleRequired ? (
-						<FormInputValidation isError={ false } text="Required field." />
-					) : (
-						<FormInputValidation isError={ true } text="Required field." />
-					) }
+					{ isTitleRequired ? this.renderValidation( blogname ) : null }
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="blogdescription">{ translate( 'Tagline' ) }</FormLabel>

--- a/client/components/site-title/index.jsx
+++ b/client/components/site-title/index.jsx
@@ -12,6 +12,7 @@ import React from 'react';
  * Internal dependencies
  */
 import FormFieldset from 'components/forms/form-fieldset';
+import FormInputValidation from 'components/forms/form-input-validation';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 
@@ -21,6 +22,7 @@ class SiteTitleControl extends React.Component {
 		blogname: PropTypes.string,
 		blogdescription: PropTypes.string,
 		disabled: PropTypes.bool,
+		isTitleRequired: PropTypes.bool,
 		onChange: PropTypes.func.isRequired,
 	};
 
@@ -28,6 +30,7 @@ class SiteTitleControl extends React.Component {
 		autoFocusBlogname: false,
 		blogname: '',
 		blogdescription: '',
+		isTitleRequired: false,
 		disabled: false,
 	};
 
@@ -44,7 +47,14 @@ class SiteTitleControl extends React.Component {
 	};
 
 	render() {
-		const { autoFocusBlogname, blogname, blogdescription, disabled, translate } = this.props;
+		const {
+			autoFocusBlogname,
+			blogname,
+			blogdescription,
+			disabled,
+			isTitleRequired,
+			translate,
+		} = this.props;
 		return (
 			<div className="site-title">
 				<FormFieldset>
@@ -54,9 +64,13 @@ class SiteTitleControl extends React.Component {
 						disabled={ disabled }
 						id="blogname"
 						onChange={ this.onChangeSiteTitle }
-						required
 						value={ blogname }
 					/>
+					{ blogname && isTitleRequired ? (
+						<FormInputValidation isError={ false } text="Required field." />
+					) : (
+						<FormInputValidation isError={ true } text="Required field." />
+					) }
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="blogdescription">{ translate( 'Tagline' ) }</FormLabel>

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -81,7 +81,11 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 							onChange={ this.handleChange }
 						/>
 
-						<Button disabled={ isRequestingSettings } primary type="submit">
+						<Button
+							disabled={ isRequestingSettings || ! this.state.blogname }
+							primary
+							type="submit"
+						>
 							{ translate( 'Next Step' ) }
 						</Button>
 					</form>

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -78,6 +78,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 							blogname={ this.state.blogname }
 							blogdescription={ this.state.blogdescription }
 							disabled={ isRequestingSettings }
+							isTitleRequired={ true }
 							onChange={ this.handleChange }
 						/>
 

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -78,7 +78,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 							blogname={ this.state.blogname }
 							blogdescription={ this.state.blogdescription }
 							disabled={ isRequestingSettings }
-							isTitleRequired={ true }
+							isBlognameRequired
 							onChange={ this.handleChange }
 						/>
 


### PR DESCRIPTION
This patch contains 2 changes:
- adds a prop that can set the blogname field in the the SiteTitle component as required. By default it is false and does not change current functionality. When passed to the component set to `true`, it uses the Calypso style validation to require input for the blogname,
- modifies the site-title step of the JPO to use the above prop and disables the wizard button when no content has been provided.

Context: the Site Title ( blogname) is required in JPO, thus this change.
Addresses part of #21685.

**To test:**
- checkout this branch on your local Calypso
- use the redirect from your JP sandbox `https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` to land in the first screen of the JPO flow
- verify that empty/filled in site title disables/enables the button and relevant validations are shown

![screen shot 2018-01-24 at 00 12 27](https://user-images.githubusercontent.com/13561163/35307549-104dfb80-009b-11e8-9e65-2277c94437af.png)
![screen shot 2018-01-24 at 00 12 12](https://user-images.githubusercontent.com/13561163/35307551-11bcd626-009b-11e8-9ac4-4a73bd958e7d.png)

