### PR TITLE
esmodules: Update misc imports

### DIFF
--- a/client/components/domains/transfer-domain-step/transfer-restriction-message.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-restriction-message.jsx
@@ -15,7 +15,7 @@ import Button from 'components/button';
 import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
 import { MAP_EXISTING_DOMAIN } from 'lib/url/support';
-import paths from 'my-sites/domains/paths';
+import { domainMapping } from 'my-sites/domains/paths';
 
 class TransferRestrictionMessage extends React.PureComponent {
 	static propTypes = {
@@ -29,7 +29,7 @@ class TransferRestrictionMessage extends React.PureComponent {
 
 	goToMapDomainStep = event => {
 		event.preventDefault();
-		page( paths.domainMapping( this.props.selectedSiteSlug, this.props.domain ) );
+		page( domainMapping( this.props.selectedSiteSlug, this.props.domain ) );
 	};
 
 	render() {

--- a/client/lib/form-state/store/core.js
+++ b/client/lib/form-state/store/core.js
@@ -4,7 +4,9 @@
  * Internal dependencies
  */
 
-import { changeFieldValue } from '../';
+import formState from '../';
+
+const { changeFieldValue } = formState;
 
 function core() {
 	return {

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -18,7 +18,7 @@ import GoogleAppsDialog from 'components/upgrades/google-apps/google-apps-dialog
 import Main from 'components/main';
 import QuerySites from 'components/data/query-sites';
 import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
-import upgradesActions from 'lib/upgrades/actions';
+import { addItem, removeItem } from 'lib/upgrades/actions';
 import { cartItems } from 'lib/cart-values';
 import { isDotComPlan } from 'lib/products-values';
 
@@ -46,14 +46,14 @@ export class GsuiteNudge extends React.Component {
 
 		this.removePlanFromCart();
 
-		upgradesActions.addItem( googleAppsCartItem );
+		addItem( googleAppsCartItem );
 		page( `/checkout/${ siteSlug }` );
 	};
 
 	removePlanFromCart() {
 		const items = cartItems.getAll( this.props.cart );
 		items.filter( isDotComPlan ).forEach( function( item ) {
-			upgradesActions.removeItem( item, false );
+			removeItem( item, false );
 		} );
 	}
 

--- a/client/my-sites/preview/controller.js
+++ b/client/my-sites/preview/controller.js
@@ -11,9 +11,7 @@ import React from 'react';
  */
 import PreviewMain from './main';
 
-export default {
-	preview: function( context, next ) {
-		context.primary = <PreviewMain site={ context.params.site } />;
-		next();
-	},
-};
+export function preview( context, next ) {
+	context.primary = <PreviewMain site={ context.params.site } />;
+	next();
+}

--- a/client/reader/xpost-helper.js
+++ b/client/reader/xpost-helper.js
@@ -7,7 +7,9 @@ import url from 'url';
 /**
  * Internal dependencies
  */
-import { X_POST } from 'state/reader/posts/display-types';
+import displayTypes from 'state/reader/posts/display-types';
+
+const { X_POST } = displayTypes;
 
 const exported = {
 	/**

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -9,10 +9,12 @@ import { filter, find, indexOf, isEmpty, merge, pick } from 'lodash';
  */
 import { getLanguage } from 'lib/i18n-utils';
 import steps from 'signup/config/steps';
-import flows, { defaultFlowName } from 'signup/config/flows';
+import flows from 'signup/config/flows';
 import formState from 'lib/form-state';
 import userFactory from 'lib/user';
 const user = userFactory();
+
+const { defaultFlowName } = flows;
 
 export function getFlowName( parameters ) {
 	const flow =

--- a/client/state/ui/guided-tours/contexts.js
+++ b/client/state/ui/guided-tours/contexts.js
@@ -13,12 +13,14 @@ import { ANALYTICS_EVENT_RECORD, EDITOR_PASTE_EVENT } from 'state/action-types';
 import { SOURCE_GOOGLE_DOCS } from 'components/tinymce/plugins/wpcom-track-paste/sources';
 import config from 'config';
 import { abtest } from 'lib/abtest';
-import { getAll as getAllMedia } from 'lib/media/store';
+import MediaStore from 'lib/media/store';
 import { getSectionName, getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getLastAction } from 'state/ui/action-log/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { canCurrentUser } from 'state/selectors';
 import { hasDefaultSiteTitle, isCurrentPlanPaid } from 'state/sites/selectors';
+
+const { getAll: getAllMedia } = MediaStore;
 
 export const WEEK_IN_MILLISECONDS = 7 * 1000 * 3600 * 24;
 


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.