### PR TITLE
esmodules: Update lib/plugins/utils

### DIFF
--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -13,7 +13,7 @@ import i18n from 'i18n-calypso';
 import notices from 'notices';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginsActions from 'lib/plugins/actions';
-import PluginsUtil from 'lib/plugins/utils';
+import { filterNotices } from 'lib/plugins/utils';
 import versionCompare from 'lib/version-compare';
 
 function getCombination( translateArg ) {
@@ -82,17 +82,9 @@ export default {
 	refreshPluginNotices() {
 		const site = this.props.selectedSite;
 		return {
-			errors: PluginsUtil.filterNotices( PluginsLog.getErrors(), site, this.props.pluginSlug ),
-			inProgress: PluginsUtil.filterNotices(
-				PluginsLog.getInProgress(),
-				site,
-				this.props.pluginSlug
-			),
-			completed: PluginsUtil.filterNotices(
-				PluginsLog.getCompleted(),
-				site,
-				this.props.pluginSlug
-			),
+			errors: filterNotices( PluginsLog.getErrors(), site, this.props.pluginSlug ),
+			inProgress: filterNotices( PluginsLog.getInProgress(), site, this.props.pluginSlug ),
+			completed: filterNotices( PluginsLog.getCompleted(), site, this.props.pluginSlug ),
 		};
 	},
 

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -14,7 +14,7 @@ import emitter from 'lib/mixins/emitter';
 /* eslint-enable no-restricted-imports */
 import PluginsActions from 'lib/plugins/actions';
 import versionCompare from 'lib/version-compare';
-import PluginUtils from 'lib/plugins/utils';
+import { normalizePluginData } from 'lib/plugins/utils';
 import { reduxDispatch, reduxGetState } from 'lib/redux-bridge';
 import { getNetworkSites } from 'state/selectors';
 import { getSite } from 'state/sites/selectors';
@@ -97,7 +97,7 @@ function update( site, slug, plugin ) {
 	if ( ! _pluginsBySite[ site.ID ][ slug ] ) {
 		_pluginsBySite[ site.ID ][ slug ] = { slug: slug };
 	}
-	plugin = PluginUtils.normalizePluginData( plugin );
+	plugin = normalizePluginData( plugin );
 	_pluginsBySite[ site.ID ][ slug ] = assign( {}, _pluginsBySite[ site.ID ][ slug ], plugin );
 
 	debug( 'update to ', _pluginsBySite[ site.ID ][ slug ] );

--- a/client/lib/plugins/test/utils.js
+++ b/client/lib/plugins/test/utils.js
@@ -11,7 +11,7 @@ import { assert } from 'chai';
 /**
  * Internal dependencies
  */
-import PluginUtils from '../utils';
+import * as PluginUtils from '../utils';
 
 describe( 'Plugins Utils', () => {
 	describe( 'normalizePluginData', () => {

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -9,8 +9,7 @@ import { assign, filter, map, pick, sortBy, transform } from 'lodash';
 /**
  * Internal dependencies
  */
-import { decodeEntities } from 'lib/formatting';
-import { parseHtml } from 'lib/formatting';
+import { decodeEntities, parseHtml } from 'lib/formatting';
 import { sanitizeSectionContent } from './sanitize-section-content';
 
 /**
@@ -53,175 +52,169 @@ function filterNoticesBy( site, pluginSlug, log ) {
 	return false;
 }
 
-const PluginUtils = {
-	whiteListPluginData: function( plugin ) {
-		return pick(
-			plugin,
-			'action_links',
-			'active',
-			'author',
-			'author_url',
-			'autoupdate',
-			'banners',
-			'compatibility',
-			'description',
-			'short_description',
-			'detailsFetched',
-			'downloaded',
-			'homepage',
-			'icons',
-			'id',
-			'last_updated',
-			'name',
-			'network',
-			'num_ratings',
-			'plugin_url',
-			'rating',
-			'ratings',
-			'sections',
-			'slug',
-			'support_URL',
-			'update',
-			'updating',
-			'version',
-			'wp_admin_settings_page_url'
-		);
-	},
+export function whiteListPluginData( plugin ) {
+	return pick(
+		plugin,
+		'action_links',
+		'active',
+		'author',
+		'author_url',
+		'autoupdate',
+		'banners',
+		'compatibility',
+		'description',
+		'short_description',
+		'detailsFetched',
+		'downloaded',
+		'homepage',
+		'icons',
+		'id',
+		'last_updated',
+		'name',
+		'network',
+		'num_ratings',
+		'plugin_url',
+		'rating',
+		'ratings',
+		'sections',
+		'slug',
+		'support_URL',
+		'update',
+		'updating',
+		'version',
+		'wp_admin_settings_page_url'
+	);
+}
 
-	extractAuthorName: function( authorElementSource ) {
-		if ( ! authorElementSource ) {
-			return '';
+export function extractAuthorName( authorElementSource ) {
+	if ( ! authorElementSource ) {
+		return '';
+	}
+	return decodeEntities( authorElementSource.replace( /(<([^>]+)>)/gi, '' ) );
+}
+
+export function extractAuthorUrl( authorElementSource ) {
+	const match = /<a\s+(?:[^>]*?\s+)?href="([^"]*)"/.exec( authorElementSource );
+	return match && match[ 1 ] ? match[ 1 ] : '';
+}
+
+export function extractScreenshots( screenshotsHtml ) {
+	const screenshotsDom = parseHtml( screenshotsHtml );
+
+	const list = screenshotsDom && screenshotsDom.querySelectorAll( 'li' );
+	if ( ! list ) {
+		return null;
+	}
+	let screenshots = map( list, function( li ) {
+		const img = li.querySelectorAll( 'img' );
+		const captionP = li.querySelectorAll( 'p' );
+
+		if ( img[ 0 ] && img[ 0 ].src ) {
+			return {
+				url: img[ 0 ].src,
+				caption: captionP[ 0 ] ? captionP[ 0 ].textContent : null,
+			};
 		}
-		return decodeEntities( authorElementSource.replace( /(<([^>]+)>)/gi, '' ) );
-	},
+	} );
 
-	extractAuthorUrl: function( authorElementSource ) {
-		const match = /<a\s+(?:[^>]*?\s+)?href="([^"]*)"/.exec( authorElementSource );
-		return match && match[ 1 ] ? match[ 1 ] : '';
-	},
+	screenshots = screenshots.filter( screenshot => screenshot );
 
-	extractScreenshots: function( screenshotsHtml ) {
-		const screenshotsDom = parseHtml( screenshotsHtml );
+	return screenshots.length ? screenshots : null;
+}
 
-		const list = screenshotsDom && screenshotsDom.querySelectorAll( 'li' );
-		if ( ! list ) {
-			return null;
-		}
-		let screenshots = map( list, function( li ) {
-			const img = li.querySelectorAll( 'img' );
-			const captionP = li.querySelectorAll( 'p' );
-
-			if ( img[ 0 ] && img[ 0 ].src ) {
-				return {
-					url: img[ 0 ].src,
-					caption: captionP[ 0 ] ? captionP[ 0 ].textContent : null,
-				};
-			}
+export function normalizeCompatibilityList( compatibilityList ) {
+	function splitInNumbers( version ) {
+		const splittedVersion = version.split( '.' ).map( function( versionComponent ) {
+			return Number.parseInt( versionComponent, 10 );
 		} );
-
-		screenshots = screenshots.filter( screenshot => screenshot );
-
-		return screenshots.length ? screenshots : null;
-	},
-
-	normalizeCompatibilityList: function( compatibilityList ) {
-		function splitInNumbers( version ) {
-			const splittedVersion = version.split( '.' ).map( function( versionComponent ) {
-				return Number.parseInt( versionComponent, 10 );
-			} );
-			while ( splittedVersion.length < 3 ) {
-				splittedVersion.push( 0 );
-			}
-			return splittedVersion;
+		while ( splittedVersion.length < 3 ) {
+			splittedVersion.push( 0 );
 		}
-		const sortedCompatibility = sortBy( Object.keys( compatibilityList ).map( splitInNumbers ), [
-			0,
-			1,
-			2,
-		] );
-		return sortedCompatibility.map( function( version ) {
-			if ( version.length && version[ version.length - 1 ] === 0 ) {
-				version.pop();
-			}
-			return version.join( '.' );
-		} );
-	},
-
-	sanitizeSectionContent,
-
-	normalizePluginData: function( plugin, pluginData ) {
-		plugin = this.whiteListPluginData( assign( plugin, pluginData ) );
-
-		return transform( plugin, function( returnData, item, key ) {
-			switch ( key ) {
-				case 'short_description':
-				case 'description':
-				case 'name':
-				case 'slug':
-					returnData[ key ] = decodeEntities( item );
-					break;
-				case 'author':
-					returnData.author = item;
-					returnData.author_name = PluginUtils.extractAuthorName( item );
-					returnData.author_url = plugin.author_url || PluginUtils.extractAuthorUrl( item );
-					break;
-				case 'sections':
-					const cleanItem = {};
-					for ( const sectionKey of Object.keys( item ) ) {
-						cleanItem[ sectionKey ] = PluginUtils.sanitizeSectionContent( item[ sectionKey ] );
-					}
-					returnData.sections = cleanItem;
-					returnData.screenshots = cleanItem.screenshots
-						? PluginUtils.extractScreenshots( cleanItem.screenshots )
-						: null;
-					break;
-				case 'num_ratings':
-				case 'rating':
-					returnData[ key ] = parseInt( item, 10 );
-					break;
-				case 'ratings':
-					for ( const prop in item ) {
-						item[ prop ] = parseInt( item[ prop ], 10 );
-					}
-					returnData[ key ] = item;
-					break;
-				case 'icons':
-					if ( item ) {
-						returnData.icon = item[ '2x' ] || item[ '1x' ] || item.svg || item.default;
-					}
-					break;
-				case 'homepage':
-				case 'plugin_url':
-					returnData.plugin_url = item;
-					break;
-				case 'compatibility':
-					returnData[ key ] = PluginUtils.normalizeCompatibilityList( item );
-					break;
-				default:
-					returnData[ key ] = item;
-			}
-		} );
-	},
-
-	normalizePluginsList: function( pluginsList ) {
-		if ( ! pluginsList ) {
-			return [];
+		return splittedVersion;
+	}
+	const sortedCompatibility = sortBy( Object.keys( compatibilityList ).map( splitInNumbers ), [
+		0,
+		1,
+		2,
+	] );
+	return sortedCompatibility.map( function( version ) {
+		if ( version.length && version[ version.length - 1 ] === 0 ) {
+			version.pop();
 		}
-		return map( pluginsList, pluginData => PluginUtils.normalizePluginData( pluginData ) );
-	},
+		return version.join( '.' );
+	} );
+}
 
-	/**
-	 * Return logs that match a certain critia.
-	 *
-	 * @param  {Array} logs        List of all notices
-	 * @param  {Object} site       Site Object
-	 * @param  {String} pluginSlug Plugin Slug
-	 *
-	 * @return {Array} Array of filtered logs that match the criteria
-	 */
-	filterNotices: function( logs, site, pluginSlug ) {
-		return filter( logs, filterNoticesBy.bind( this, site, pluginSlug ) );
-	},
-};
+export function normalizePluginData( plugin, pluginData ) {
+	plugin = this.whiteListPluginData( assign( plugin, pluginData ) );
 
-export default PluginUtils;
+	return transform( plugin, function( returnData, item, key ) {
+		switch ( key ) {
+			case 'short_description':
+			case 'description':
+			case 'name':
+			case 'slug':
+				returnData[ key ] = decodeEntities( item );
+				break;
+			case 'author':
+				returnData.author = item;
+				returnData.author_name = extractAuthorName( item );
+				returnData.author_url = plugin.author_url || extractAuthorUrl( item );
+				break;
+			case 'sections':
+				const cleanItem = {};
+				for ( const sectionKey of Object.keys( item ) ) {
+					cleanItem[ sectionKey ] = sanitizeSectionContent( item[ sectionKey ] );
+				}
+				returnData.sections = cleanItem;
+				returnData.screenshots = cleanItem.screenshots
+					? extractScreenshots( cleanItem.screenshots )
+					: null;
+				break;
+			case 'num_ratings':
+			case 'rating':
+				returnData[ key ] = parseInt( item, 10 );
+				break;
+			case 'ratings':
+				for ( const prop in item ) {
+					item[ prop ] = parseInt( item[ prop ], 10 );
+				}
+				returnData[ key ] = item;
+				break;
+			case 'icons':
+				if ( item ) {
+					returnData.icon = item[ '2x' ] || item[ '1x' ] || item.svg || item.default;
+				}
+				break;
+			case 'homepage':
+			case 'plugin_url':
+				returnData.plugin_url = item;
+				break;
+			case 'compatibility':
+				returnData[ key ] = normalizeCompatibilityList( item );
+				break;
+			default:
+				returnData[ key ] = item;
+		}
+	} );
+}
+
+export function normalizePluginsList( pluginsList ) {
+	if ( ! pluginsList ) {
+		return [];
+	}
+	return map( pluginsList, pluginData => normalizePluginData( pluginData ) );
+}
+
+/**
+ * Return logs that match a certain critia.
+ *
+ * @param  {Array} logs        List of all notices
+ * @param  {Object} site       Site Object
+ * @param  {String} pluginSlug Plugin Slug
+ *
+ * @return {Array} Array of filtered logs that match the criteria
+ */
+export function filterNotices( logs, site, pluginSlug ) {
+	return filter( logs, filterNoticesBy.bind( this, site, pluginSlug ) );
+}

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -146,7 +146,7 @@ export function normalizeCompatibilityList( compatibilityList ) {
 }
 
 export function normalizePluginData( plugin, pluginData ) {
-	plugin = this.whiteListPluginData( assign( plugin, pluginData ) );
+	plugin = whiteListPluginData( assign( plugin, pluginData ) );
 
 	return transform( plugin, function( returnData, item, key ) {
 		switch ( key ) {

--- a/client/lib/plugins/wporg-data/actions.js
+++ b/client/lib/plugins/wporg-data/actions.js
@@ -11,7 +11,7 @@ import debugFactory from 'debug';
  */
 import Dispatcher from 'dispatcher';
 import wporg from 'lib/wporg';
-import utils from 'lib/plugins/utils';
+import { normalizePluginsList } from 'lib/plugins/utils';
 import CuratedPlugins from 'lib/plugins/wporg-data/curated.json';
 import impureLodash from 'lib/impure-lodash';
 
@@ -85,7 +85,7 @@ const PluginsDataActions = {
 						action: 'FETCH_WPORG_PLUGINS_LIST',
 						page: page,
 						category: category,
-						data: data ? utils.normalizePluginsList( data.plugins ) : null,
+						data: data ? normalizePluginsList( data.plugins ) : null,
 						error: error,
 					} );
 				}
@@ -103,7 +103,7 @@ const PluginsDataActions = {
 			action: 'FETCH_WPORG_PLUGINS_LIST',
 			page: 1,
 			category: 'featured',
-			data: utils.normalizePluginsList( CuratedPlugins ),
+			data: normalizePluginsList( CuratedPlugins ),
 			error: null,
 		} );
 	},

--- a/client/my-sites/plugins/plugin-sections/custom.jsx
+++ b/client/my-sites/plugins/plugin-sections/custom.jsx
@@ -14,7 +14,7 @@ import Card from 'components/card';
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
 import SectionNav from 'components/section-nav';
-import { sanitizeSectionContent } from 'lib/plugins/utils';
+import { sanitizeSectionContent } from 'lib/plugins/sanitize-section-content';
 
 const PluginSectionsCustom = ( { plugin, translate } ) => {
 	const description = sanitizeSectionContent( plugin.description );

--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -9,7 +9,7 @@ const debug = debugFactory( 'calypso:wporg-data:actions' );
  * Internal dependencies
  */
 import wporg from 'lib/wporg';
-import utils from 'lib/plugins/utils';
+import { normalizePluginData } from 'lib/plugins/utils';
 import { WPORG_PLUGIN_DATA_RECEIVE, FETCH_WPORG_PLUGIN_DATA } from 'state/action-types';
 
 /**
@@ -38,7 +38,7 @@ export function fetchPluginData( pluginSlug ) {
 			dispatch( {
 				type: WPORG_PLUGIN_DATA_RECEIVE,
 				pluginSlug: pluginSlug,
-				data: data ? utils.normalizePluginData( { detailsFetched: Date.now() }, data ) : null,
+				data: data ? normalizePluginData( { detailsFetched: Date.now() }, data ) : null,
 				error: error,
 			} );
 		} );


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.

This one is helpful to view with the diff ignoring whitespace.
https://github.com/Automattic/wp-calypso/pull/21584/files?w=1
It becomes a 35 line PR.