### PR TITLE
esmodules: Update form-state-store

### DIFF
--- a/client/lib/form-state/examples/async-initialize.jsx
+++ b/client/lib/form-state/examples/async-initialize.jsx
@@ -11,8 +11,10 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isFieldDisabled } from '../';
+import FormStateStore from '../';
 import createFormStore from '../store';
+
+const { isFieldDisabled } = FormStateStore;
 
 const debug = debugModule( 'calypso:lib:form-state:examples:async-initialize' );
 

--- a/client/lib/form-state/examples/sync-initialize.jsx
+++ b/client/lib/form-state/examples/sync-initialize.jsx
@@ -11,8 +11,10 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isFieldDisabled } from '../';
+import FormStateStore from '../';
 import createFormStore from '../store';
+
+const { isFieldDisabled } = FormStateStore;
 
 const debug = debugModule( 'calypso:lib:form-state:examples:sync-initialize' );
 

--- a/client/lib/form-state/store/async-initialize.js
+++ b/client/lib/form-state/store/async-initialize.js
@@ -4,7 +4,9 @@
  * Internal dependencies
  */
 
-import { createInitialFormState, createNullFieldValues, initializeFields } from '../';
+import FormStateStore from '../';
+
+const { createInitialFormState, createNullFieldValues, initializeFields } = FormStateStore;
 
 function asyncInitialize( { fieldNames, loadFunction } ) {
 	return {

--- a/client/lib/form-state/store/sync-initialize.js
+++ b/client/lib/form-state/store/sync-initialize.js
@@ -9,7 +9,9 @@ import { mapValues } from 'lodash';
 /**
  * Internal dependencies
  */
-import { initializeFields, createInitialFormState, createNullFieldValues } from '../';
+import FormStateStore from '../';
+
+const { createInitialFormState, createNullFieldValues, initializeFields } = FormStateStore;
 
 function syncInitialize( { fieldNames } ) {
 	return {

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -13,8 +13,10 @@ import Gridicon from 'gridicons';
  */
 import analytics from 'lib/analytics';
 import Button from 'components/button';
-import { submitSignupStep } from 'lib/signup/actions';
+import SignupActions from 'lib/signup/actions';
 import { getStepUrl } from 'signup/utils';
+
+const { submitSignupStep } = SignupActions;
 
 export class NavigationLink extends Component {
 	static propTypes = {


### PR DESCRIPTION
@see: https://github.com/Automattic/wp-calypso/milestone/224

Previously we were exporting a default object of multiple methods and
importing those through the non-spec-compliant Babel destructuring
import statements.

This patch makes those methods proper named exports in the work of
turning off CommonJS compilation.