### PR TITLE
Themes: highlight search field when active

### DIFF
--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -21,6 +21,8 @@
 	padding-top: 30px;
 	z-index: 20;
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
+	border: 5px solid blue;
+
 }
 
 .search-stream__fixed-area .section-nav-tabs.is-dropdown {


### PR DESCRIPTION
#21325
Before, as referenced in error, the search field lost the blue highlight, thus looking detached from the dropdown just below. However, the highlight still showed (correctly) on scroll:

Changed styling for the search bar so that it never disappears