### PR TITLE
Fix invalid uris in fr-schema and uk-schema

### DIFF
--- a/client/components/domains/registrant-extra-info/fr-schema.json
+++ b/client/components/domains/registrant-extra-info/fr-schema.json
@@ -1,5 +1,5 @@
 {
-	"id": "/contact-validation/fr",
+	"id": "https://public-api.wordpress.com/rest/v1/domains/validation-schema/fr",
 	"$schema": "http://json-schema.org/draft-04/schema",
 	"definitions": {
 		"empty": {

--- a/client/components/domains/registrant-extra-info/uk-schema.json
+++ b/client/components/domains/registrant-extra-info/uk-schema.json
@@ -1,5 +1,5 @@
 {
-	"id": "\/contact-validation\/contact-validation\/uk",
+	"id": "https://public-api.wordpress.com/rest/v1/domains/validation-schema/uk",
 	"errorCode": "dotukValidation",
 	"$comment": "See http:\/\/domains.opensrs.guide\/docs\/tld#section-uk",
 	"type": "object",


### PR DESCRIPTION
#21509 highlighted that the `id`s being used in the schemas are invalid. We do need some `id` in order to resolve refs on the backend, so the urls we'll (hopefully) serve them at in the near future seems the obvious choice (D9157-code).