### PR TITLE
Concierge Chats: Enable in staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -24,6 +24,7 @@
 		"automated-transfer": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
+		"concierge-chats": true,
 		"desktop-promo": true,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
@@ -152,6 +153,7 @@
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",
+	"wpcom_concierge_schedule_id": 2048,
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": false,


### PR DESCRIPTION
Enables the `concierge-chats` feature flag in staging environments, so we can start internally testing this feature. This also sets the schedule to `2048` which is the test schedule for this feature, isolated from production data.