### PR TITLE
State: Cleanup getJetpackOnboardingProgress tests

### DIFF
--- a/client/state/selectors/test/get-jetpack-onboarding-progress.js
+++ b/client/state/selectors/test/get-jetpack-onboarding-progress.js
@@ -16,7 +16,7 @@ describe( 'getJetpackOnboardingProgress()', () => {
 				},
 			},
 		};
-		const steps = [ [ STEPS.SITE_TITLE ], [ STEPS.SITE_TYPE ] ];
+		const steps = [ STEPS.SITE_TITLE, STEPS.SITE_TYPE ];
 		const expected = {
 			[ STEPS.SITE_TITLE ]: isJetpackOnboardingStepCompleted( state, siteId, STEPS.SITE_TITLE ),
 			[ STEPS.SITE_TYPE ]: isJetpackOnboardingStepCompleted( state, siteId, STEPS.SITE_TYPE ),


### PR DESCRIPTION
This PR cleans up unnecessary square brackets from the `getJetpackOnboardingProgress` tests. Kudos to @ockham for finding it in https://github.com/Automattic/wp-calypso/pull/21490#pullrequestreview-89176971.

To test:
* Checkout this branch
* Verify the `getJetpackOnboardingProgress` tests still pass:

```
npm run test-client client/state/selectors/test/get-jetpack-onboarding-progress.js
```