### PR TITLE
Jetpack Onboarding: Allow additional properties for recordJpoEvent

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -74,10 +74,11 @@ export default connect(
 	( { siteId, ...stateProps }, { recordTracksEvent: recordTracksEventAction }, ownProps ) => ( {
 		siteId,
 		...stateProps,
-		recordJpoEvent: event =>
+		recordJpoEvent: ( event, additionalProperties ) =>
 			recordTracksEventAction( event, {
 				blog_id: siteId,
 				site_id_type: 'jpo',
+				...additionalProperties,
 			} ),
 		...ownProps,
 	} )


### PR DESCRIPTION
This PR introduces the option to add additional properties to tracks events that we record with `recordJpoEvent`.

Inspired by #21578.

To test:
* Checkout this branch
* Go through the onboarding flow, add a contact form, verify it records the event like before.
* Try adding some additional props to the contact form event, verify it saves them too. To do this, replace:

```
this.props.recordJpoEvent( 'calypso_jpo_contact_form_clicked' );
```

with

```
this.props.recordJpoEvent( 'calypso_jpo_contact_form_clicked', { exampleData: 'something' } );
```