### PR TITLE
JP Onboarding: Rename getJetpackOnboardingProgress() selector to getJetpackOnboardingCompletedSteps()

### DIFF
--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -20,7 +20,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Spinner from 'components/spinner';
 import {
 	getJetpackOnboardingPendingSteps,
-	getJetpackOnboardingProgress,
+	getJetpackOnboardingCompletedSteps,
 	getUnconnectedSiteUrl,
 } from 'state/selectors';
 import {
@@ -117,7 +117,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 
 export default connect( ( state, { siteId, steps } ) => {
 	const tasks = compact( [] );
-	const stepsCompleted = getJetpackOnboardingProgress( state, siteId, steps );
+	const stepsCompleted = getJetpackOnboardingCompletedSteps( state, siteId, steps );
 	const stepsPending = getJetpackOnboardingPendingSteps( state, siteId, steps );
 
 	return {

--- a/client/state/selectors/get-jetpack-onboarding-completed-steps.js
+++ b/client/state/selectors/get-jetpack-onboarding-completed-steps.js
@@ -18,7 +18,7 @@ import { isJetpackOnboardingStepCompleted } from 'state/selectors';
  * @param  {Array}    steps   Array of steps to retrieve onboarding progress for.
  * @return {Object}           An object containing all steps and whether each of them has been completed.
  */
-export default function getJetpackOnboardingProgress( state, siteId, steps ) {
+export default function getJetpackOnboardingCompletedSteps( state, siteId, steps ) {
 	return reduce(
 		steps,
 		( result, stepName ) => {

--- a/client/state/selectors/test/get-jetpack-onboarding-completed-steps.js
+++ b/client/state/selectors/test/get-jetpack-onboarding-completed-steps.js
@@ -4,9 +4,12 @@
  * Internal dependencies
  */
 import { JETPACK_ONBOARDING_STEPS as STEPS } from 'jetpack-onboarding/constants';
-import { getJetpackOnboardingProgress, isJetpackOnboardingStepCompleted } from 'state/selectors';
+import {
+	getJetpackOnboardingCompletedSteps,
+	isJetpackOnboardingStepCompleted,
+} from 'state/selectors';
 
-describe( 'getJetpackOnboardingProgress()', () => {
+describe( 'getJetpackOnboardingCompletedSteps()', () => {
 	test( 'should return onboading progress for the specified steps', () => {
 		const siteId = 2916284;
 		const state = {
@@ -21,7 +24,7 @@ describe( 'getJetpackOnboardingProgress()', () => {
 			[ STEPS.SITE_TITLE ]: isJetpackOnboardingStepCompleted( state, siteId, STEPS.SITE_TITLE ),
 			[ STEPS.SITE_TYPE ]: isJetpackOnboardingStepCompleted( state, siteId, STEPS.SITE_TYPE ),
 		};
-		const progress = getJetpackOnboardingProgress( state, siteId, steps );
+		const progress = getJetpackOnboardingCompletedSteps( state, siteId, steps );
 		expect( progress ).toEqual( expected );
 	} );
 } );


### PR DESCRIPTION
Per https://github.com/Automattic/wp-calypso/pull/21565#discussion_r162013654 -- for consistency with `getJetpackOnboardingPendingSteps()`

To test: See instructions at #21491