### PR TITLE
JP Onboarding: Add QueryJetpackOnboardingSettings component

### DIFF
--- a/client/components/data/query-jetpack-onboarding-settings/README.md
+++ b/client/components/data/query-jetpack-onboarding-settings/README.md
@@ -1,0 +1,44 @@
+Query Jetpack Onboarding Settings
+=================================
+
+`<QueryJetpackOnboardingSettings />` is a React component used in managing network requests for Jetpack Onboarding Settings.
+
+## Usage
+
+Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import { connect } from 'react-redux';
+import { map } from 'lodash';
+import QueryJetpackOnboardingSettings from 'components/data/query-jetpack-onboarding-settings';
+import { getJetpackOnboardingSettings } from 'state/selectors';
+
+function MyJetpackOnboardingSettings( { settings, siteId } ) {
+	return (
+		<div>
+			<QueryJetpackOnboardingSettings siteId={ siteId } />
+			{ map( settings, ( value, name ) => (
+				<div>{ name }: { value }</div>
+			) }
+		</div>
+	);
+}
+
+export default connect(
+	( state, { siteId } ) => ( {
+		settings: getJetpackOnboardingSettings( state, siteId )
+	} )
+)( MyJetpackOnboardingSettings );
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The site ID for which Jetpack Onboarding Settings should be requested.

--- a/client/components/data/query-jetpack-onboarding-settings/README.md
+++ b/client/components/data/query-jetpack-onboarding-settings/README.md
@@ -20,7 +20,7 @@ function MyJetpackOnboardingSettings( { settings, siteId } ) {
 		<div>
 			<QueryJetpackOnboardingSettings siteId={ siteId } />
 			{ map( settings, ( value, name ) => (
-				<div>{ name }: { value }</div>
+				<div>{ name }: { value.toString() }</div>
 			) }
 		</div>
 	);

--- a/client/components/data/query-jetpack-onboarding-settings/README.md
+++ b/client/components/data/query-jetpack-onboarding-settings/README.md
@@ -11,8 +11,9 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 import React from 'react';
 import { connect } from 'react-redux';
 import { map } from 'lodash';
-import QueryJetpackOnboardingSettings from 'components/data/query-jetpack-onboarding-settings';
+
 import { getJetpackOnboardingSettings } from 'state/selectors';
+import QueryJetpackOnboardingSettings from 'components/data/query-jetpack-onboarding-settings';
 
 function MyJetpackOnboardingSettings( { settings, siteId } ) {
 	return (

--- a/client/components/data/query-jetpack-onboarding-settings/index.jsx
+++ b/client/components/data/query-jetpack-onboarding-settings/index.jsx
@@ -1,0 +1,51 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
+import { getRequest } from 'state/selectors';
+
+class QueryJetpackOnboardingSettings extends Component {
+	static propTypes = {
+		siteId: PropTypes.number.isRequired,
+		requestingSettings: PropTypes.bool,
+		requestJetpackOnboardingSettings: PropTypes.func,
+	};
+
+	componentWillMount() {
+		this.request( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.siteId !== nextProps.siteId ) {
+			this.request( nextProps );
+		}
+	}
+
+	request( props ) {
+		if ( props.requestingSettings ) {
+			return;
+		}
+
+		props.requestJetpackOnboardingSettings( props.siteId );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	( state, { siteId } ) => ( {
+		requestingSettings: getRequest( state, requestJetpackOnboardingSettings( siteId ) ).isLoading,
+	} ),
+	{ requestJetpackOnboardingSettings }
+)( QueryJetpackOnboardingSettings );

--- a/client/components/data/query-jetpack-onboarding-settings/index.jsx
+++ b/client/components/data/query-jetpack-onboarding-settings/index.jsx
@@ -10,8 +10,8 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 import { getRequest } from 'state/selectors';
+import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class QueryJetpackOnboardingSettings extends Component {
 	static propTypes = {

--- a/client/state/jetpack-onboarding/actions.js
+++ b/client/state/jetpack-onboarding/actions.js
@@ -19,6 +19,11 @@ export const receiveJetpackOnboardingCredentials = ( siteId, credentials ) => ( 
 export const requestJetpackOnboardingSettings = siteId => ( {
 	type: JETPACK_ONBOARDING_SETTINGS_REQUEST,
 	siteId,
+	meta: {
+		dataLayer: {
+			trackRequest: true,
+		},
+	},
 } );
 
 export const saveJetpackOnboardingSettings = ( siteId, settings ) => ( {

--- a/client/state/jetpack-onboarding/actions.js
+++ b/client/state/jetpack-onboarding/actions.js
@@ -5,6 +5,7 @@
  */
 import {
 	JETPACK_ONBOARDING_CREDENTIALS_RECEIVE,
+	JETPACK_ONBOARDING_SETTINGS_REQUEST,
 	JETPACK_ONBOARDING_SETTINGS_SAVE,
 	JETPACK_ONBOARDING_SETTINGS_UPDATE,
 } from 'state/action-types';
@@ -13,6 +14,11 @@ export const receiveJetpackOnboardingCredentials = ( siteId, credentials ) => ( 
 	type: JETPACK_ONBOARDING_CREDENTIALS_RECEIVE,
 	siteId,
 	credentials,
+} );
+
+export const requestJetpackOnboardingSettings = siteId => ( {
+	type: JETPACK_ONBOARDING_SETTINGS_REQUEST,
+	siteId,
 } );
 
 export const saveJetpackOnboardingSettings = ( siteId, settings ) => ( {

--- a/client/state/jetpack-onboarding/test/actions.js
+++ b/client/state/jetpack-onboarding/test/actions.js
@@ -5,11 +5,13 @@
  */
 import {
 	receiveJetpackOnboardingCredentials,
+	requestJetpackOnboardingSettings,
 	saveJetpackOnboardingSettings,
 	updateJetpackOnboardingSettings,
 } from '../actions';
 import {
 	JETPACK_ONBOARDING_CREDENTIALS_RECEIVE,
+	JETPACK_ONBOARDING_SETTINGS_REQUEST,
 	JETPACK_ONBOARDING_SETTINGS_SAVE,
 	JETPACK_ONBOARDING_SETTINGS_UPDATE,
 } from 'state/action-types';
@@ -29,6 +31,18 @@ describe( 'actions', () => {
 				type: JETPACK_ONBOARDING_CREDENTIALS_RECEIVE,
 				siteId,
 				credentials,
+			} );
+		} );
+	} );
+
+	describe( 'requestJetpackOnboardingSettings()', () => {
+		test( 'should return a jetpack onboarding settings request action object', () => {
+			const siteId = 12345678;
+			const action = requestJetpackOnboardingSettings( siteId );
+
+			expect( action ).toEqual( {
+				type: JETPACK_ONBOARDING_SETTINGS_REQUEST,
+				siteId,
 			} );
 		} );
 	} );

--- a/client/state/jetpack-onboarding/test/actions.js
+++ b/client/state/jetpack-onboarding/test/actions.js
@@ -43,6 +43,11 @@ describe( 'actions', () => {
 			expect( action ).toEqual( {
 				type: JETPACK_ONBOARDING_SETTINGS_REQUEST,
 				siteId,
+				meta: {
+					dataLayer: {
+						trackRequest: true,
+					},
+				},
 			} );
 		} );
 	} );


### PR DESCRIPTION
Add a `requestJetpackOnboardingSettings()` action and `QueryJetpackOnboardingSettings `. Required for #21598.

To test: Make sure that tests pass.