### PR TITLE
JP Onboarding: Prepopulate Site Title/Description Fields with Current Settings

### DIFF
--- a/client/components/data/query-jetpack-onboarding-settings/index.jsx
+++ b/client/components/data/query-jetpack-onboarding-settings/index.jsx
@@ -15,7 +15,8 @@ import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actio
 
 class QueryJetpackOnboardingSettings extends Component {
 	static propTypes = {
-		siteId: PropTypes.number.isRequired,
+		siteId: PropTypes.number,
+		// Connected props
 		requestingSettings: PropTypes.bool,
 		requestJetpackOnboardingSettings: PropTypes.func,
 	};
@@ -31,7 +32,7 @@ class QueryJetpackOnboardingSettings extends Component {
 	}
 
 	request( props ) {
-		if ( props.requestingSettings ) {
+		if ( props.requestingSettings || ! props.siteId ) {
 			return;
 		}
 

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -12,12 +12,18 @@ import { recordTracksEvent } from 'state/analytics/actions';
  * Internal dependencies
  */
 import Main from 'components/main';
+import QueryJetpackOnboardingSettings from 'components/data/query-jetpack-onboarding-settings';
 import Wizard from 'components/wizard';
 import {
 	JETPACK_ONBOARDING_COMPONENTS as COMPONENTS,
 	JETPACK_ONBOARDING_STEPS as STEPS,
 } from './constants';
-import { getJetpackOnboardingSettings, getUnconnectedSiteIdBySlug } from 'state/selectors';
+import {
+	getJetpackOnboardingSettings,
+	getRequest,
+	getUnconnectedSiteIdBySlug,
+} from 'state/selectors';
+import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingMain extends React.PureComponent {
 	static propTypes = {
@@ -31,16 +37,27 @@ class JetpackOnboardingMain extends React.PureComponent {
 	// TODO: Add lifecycle methods to redirect if no siteId
 
 	render() {
-		const { recordJpoEvent, siteId, siteSlug, stepName, steps } = this.props;
+		const {
+			isRequestingSettings,
+			recordJpoEvent,
+			settings,
+			siteId,
+			siteSlug,
+			stepName,
+			steps,
+		} = this.props;
 		return (
 			<Main className="jetpack-onboarding">
+				<QueryJetpackOnboardingSettings siteId={ siteId } />
 				<Wizard
 					basePath="/jetpack/onboarding"
 					baseSuffix={ siteSlug }
 					components={ COMPONENTS }
 					hideNavigation={ stepName === STEPS.SUMMARY }
+					isRequestingSettings={ isRequestingSettings }
 					recordJpoEvent={ recordJpoEvent }
 					siteId={ siteId }
+					settings={ settings }
 					stepName={ stepName }
 					steps={ steps }
 				/>
@@ -53,6 +70,8 @@ export default connect(
 		const siteId = getUnconnectedSiteIdBySlug( state, siteSlug );
 		const settings = getJetpackOnboardingSettings( state, siteId );
 		const isBusiness = get( settings, 'siteType' ) === 'business';
+		const isRequestingSettings = getRequest( state, requestJetpackOnboardingSettings( siteId ) )
+			.isLoading;
 
 		// Note: here we can select which steps to display, based on user's input
 		const steps = compact( [
@@ -65,8 +84,10 @@ export default connect(
 			STEPS.SUMMARY,
 		] );
 		return {
+			isRequestingSettings,
 			siteId,
 			siteSlug,
+			settings,
 			steps,
 		};
 	},

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -23,8 +24,8 @@ import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions'
 
 class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	state = {
-		blogname: '',
-		blogdescription: '',
+		blogname: get( this.props.settings, 'siteTitle' ),
+		blogdescription: get( this.props.settings, 'siteDescription' ),
 	};
 
 	componentWillReceiveProps( nextProps ) {

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -43,6 +43,10 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 
 	handleSubmit = event => {
 		event.preventDefault();
+		if ( this.props.isRequestingSettings ) {
+			return;
+		}
+
 		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
 			siteTitle: this.state.blogname,
 			siteDescription: this.state.blogdescription,

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -27,6 +27,15 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 		blogdescription: '',
 	};
 
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.isRequestingSettings && ! nextProps.isRequestingSettings ) {
+			this.setState( {
+				blogname: nextProps.settings.siteTitle,
+				blogdescription: nextProps.settings.siteDescription,
+			} );
+		}
+	}
+
 	handleChange = ( { blogname, blogdescription } ) => {
 		this.setState( { blogname, blogdescription } );
 	};

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -77,7 +77,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 							onChange={ this.handleChange }
 						/>
 
-						<Button primary type="submit">
+						<Button disabled={ isRequestingSettings } primary type="submit">
 							{ translate( 'Next Step' ) }
 						</Button>
 					</form>

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -50,7 +50,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { isRequestingSettings, translate } = this.props;
 		const headerText = translate( "Let's get started." );
 		const subHeaderText = translate(
 			'First up, what would you like to name your site and have as its public description?'
@@ -72,6 +72,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 							autoFocusBlogname
 							blogname={ this.state.blogname }
 							blogdescription={ this.state.blogdescription }
+							disabled={ isRequestingSettings }
 							onChange={ this.handleChange }
 						/>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/96308/35048566-c056a494-fb9d-11e7-89a8-6894121705c3.png)

To test:
* Checkout this branch on your local Calypso.
* Apply https://github.com/Automattic/jetpack/pull/8497 to your JP sandbox.
* Make sure you're sandboxing the API and jetpack.wordpress.com.
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
* Wait until being redirected to the JPO flow in Calypso.
* Verify that site title and step input fields are being pre-populated with your site's current settings.
* Change site title and/or description, click 'Next Step'
* Click 'Back' -- verify that input fields show your updated settings.