### PR TITLE
Extensions: Zoninator - Update Edit Zone page for zone locks

### DIFF
--- a/client/extensions/zoninator/components/forms/zone-content-form/index.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/index.jsx
@@ -22,6 +22,7 @@ const form = 'extensions.zoninator.zoneContent';
 
 class ZoneContentForm extends PureComponent {
 	static propTypes = {
+		disabled: PropTypes.bool,
 		handleSubmit: PropTypes.func.isRequired,
 		label: PropTypes.string.isRequired,
 		onSubmit: PropTypes.func.isRequired,
@@ -33,8 +34,8 @@ class ZoneContentForm extends PureComponent {
 	save = data => this.props.onSubmit( form, data );
 
 	render() {
-		const { handleSubmit, label, requesting, submitting, translate } = this.props;
-		const isDisabled = requesting || submitting;
+		const { disabled, handleSubmit, label, requesting, submitting, translate } = this.props;
+		const isDisabled = disabled || requesting || submitting;
 
 		return (
 			<form onSubmit={ handleSubmit( this.save ) }>

--- a/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
+++ b/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
@@ -24,6 +24,7 @@ const form = 'extensions.zoninator.zoneDetails';
 
 class ZoneDetailsForm extends PureComponent {
 	static propTypes = {
+		disabled: PropTypes.bool,
 		handleSubmit: PropTypes.func.isRequired,
 		label: PropTypes.string.isRequired,
 		onSubmit: PropTypes.func.isRequired,
@@ -35,8 +36,8 @@ class ZoneDetailsForm extends PureComponent {
 	save = data => this.props.onSubmit( form, mapValues( data, trim ) );
 
 	render() {
-		const { handleSubmit, label, requesting, submitting, translate } = this.props;
-		const isDisabled = requesting || submitting;
+		const { disabled, handleSubmit, label, requesting, submitting, translate } = this.props;
+		const isDisabled = disabled || requesting || submitting;
 
 		return (
 			<form onSubmit={ handleSubmit( this.save ) }>

--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -77,9 +77,9 @@ class Zone extends Component {
 	saveZoneFeed = ( form, data ) =>
 		this.props.saveFeed( this.props.siteId, this.props.zoneId, form, data.posts );
 
-	locked = () =>
-		! this.props.lockBlocked &&
-		( this.props.lockExpires === 0 || this.props.lockExpires > new Date().getTime() );
+	disabled = () =>
+		this.props.lockBlocked ||
+		( this.props.lockExpires !== 0 && this.props.lockExpires < new Date().getTime() );
 
 	renderContent = () => {
 		const { feed, requestingFeed, requestingZones, siteSlug, translate, zone } = this.props;
@@ -100,7 +100,7 @@ class Zone extends Component {
 				) }
 
 				<ZoneDetailsForm
-					disabled={ ! this.locked() }
+					disabled={ this.disabled() }
 					label={ translate( 'Zone label' ) }
 					requesting={ requestingZones }
 					onSubmit={ this.saveZoneDetails }
@@ -108,7 +108,7 @@ class Zone extends Component {
 				/>
 
 				<ZoneContentForm
-					disabled={ ! this.locked() }
+					disabled={ this.disabled() }
 					label={ translate( 'Zone content' ) }
 					requesting={ requestingFeed }
 					onSubmit={ this.saveZoneFeed }
@@ -122,7 +122,7 @@ class Zone extends Component {
 		const { requestingZones, siteId, siteSlug, translate, zone, zoneId } = this.props;
 
 		const deleteButton = (
-			<Button compact primary scary onClick={ this.showDeleteDialog } disabled={ ! this.locked() }>
+			<Button compact primary scary onClick={ this.showDeleteDialog } disabled={ this.disabled() }>
 				{ translate( 'Delete' ) }
 			</Button>
 		);
@@ -139,7 +139,7 @@ class Zone extends Component {
 					{ translate( 'Edit zone' ) }
 				</HeaderCake>
 
-				{ zone && ! this.locked() && <ZoneLockWarningNotice siteId={ siteId } zoneId={ zoneId } /> }
+				{ zone && this.disabled() && <ZoneLockWarningNotice siteId={ siteId } zoneId={ zoneId } /> }
 				{ zone && ! requestingZones && this.renderContent() }
 			</div>
 		);

--- a/client/extensions/zoninator/components/settings/zone/index.jsx
+++ b/client/extensions/zoninator/components/settings/zone/index.jsx
@@ -21,10 +21,12 @@ import QueryFeed from '../../data/query-feed';
 import ZoneContentForm from '../../forms/zone-content-form';
 import ZoneDetailsForm from '../../forms/zone-details-form';
 import ZoneLock from '../../data/zone-lock';
+import ZoneLockWarningNotice from './zone-lock-warning-notice';
 import ZoneNotFound from './zone-not-found';
 import { saveFeed } from '../../../state/feeds/actions';
 import { deleteZone, saveZone } from '../../../state/zones/actions';
 import { getFeed, isRequestingFeed } from '../../../state/feeds/selectors';
+import { blocked, expires } from '../../../state/locks/selectors';
 import { getZone, isRequestingZones } from '../../../state/zones/selectors';
 import { settingsPath } from '../../../app/util';
 
@@ -32,6 +34,8 @@ class Zone extends Component {
 	static propTypes = {
 		deleteZone: PropTypes.func.isRequired,
 		feed: PropTypes.array,
+		lockBlocked: PropTypes.bool,
+		lockExpires: PropTypes.number,
 		requestingFeed: PropTypes.bool,
 		requestingZones: PropTypes.bool,
 		saveFeed: PropTypes.func.isRequired,
@@ -47,6 +51,19 @@ class Zone extends Component {
 		showDeleteDialog: false,
 	};
 
+	componentWillReceiveProps( nextProps ) {
+		if ( ! nextProps.lockExpires || nextProps.lockExpires === this.props.lockExpires ) {
+			return;
+		}
+
+		// Add 2 seconds to the refresh clock to prevent race conditions
+		this._refresh && clearTimeout( this._refresh );
+		this._refresh = setTimeout(
+			() => this.forceUpdate(),
+			nextProps.lockExpires - new Date().getTime() + 2000
+		);
+	}
+
 	showDeleteDialog = () => this.setState( { showDeleteDialog: true } );
 
 	hideDeleteDialog = () => this.setState( { showDeleteDialog: false } );
@@ -60,7 +77,11 @@ class Zone extends Component {
 	saveZoneFeed = ( form, data ) =>
 		this.props.saveFeed( this.props.siteId, this.props.zoneId, form, data.posts );
 
-	renderContent() {
+	locked = () =>
+		! this.props.lockBlocked &&
+		( this.props.lockExpires === 0 || this.props.lockExpires > new Date().getTime() );
+
+	renderContent = () => {
 		const { feed, requestingFeed, requestingZones, siteSlug, translate, zone } = this.props;
 		const { showDeleteDialog } = this.state;
 
@@ -79,6 +100,7 @@ class Zone extends Component {
 				) }
 
 				<ZoneDetailsForm
+					disabled={ ! this.locked() }
 					label={ translate( 'Zone label' ) }
 					requesting={ requestingZones }
 					onSubmit={ this.saveZoneDetails }
@@ -86,6 +108,7 @@ class Zone extends Component {
 				/>
 
 				<ZoneContentForm
+					disabled={ ! this.locked() }
 					label={ translate( 'Zone content' ) }
 					requesting={ requestingFeed }
 					onSubmit={ this.saveZoneFeed }
@@ -93,13 +116,13 @@ class Zone extends Component {
 				/>
 			</div>
 		);
-	}
+	};
 
 	render() {
 		const { requestingZones, siteId, siteSlug, translate, zone, zoneId } = this.props;
 
 		const deleteButton = (
-			<Button compact primary scary onClick={ this.showDeleteDialog }>
+			<Button compact primary scary onClick={ this.showDeleteDialog } disabled={ ! this.locked() }>
 				{ translate( 'Delete' ) }
 			</Button>
 		);
@@ -116,7 +139,8 @@ class Zone extends Component {
 					{ translate( 'Edit zone' ) }
 				</HeaderCake>
 
-				{ ! requestingZones && this.renderContent() }
+				{ zone && ! this.locked() && <ZoneLockWarningNotice siteId={ siteId } zoneId={ zoneId } /> }
+				{ zone && ! requestingZones && this.renderContent() }
 			</div>
 		);
 	}
@@ -127,6 +151,8 @@ const connectComponent = connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
+			lockBlocked: blocked( state, siteId, zoneId ),
+			lockExpires: expires( state, siteId, zoneId ),
 			requestingFeed: isRequestingFeed( state, siteId, zoneId ),
 			requestingZones: isRequestingZones( state, siteId ),
 			siteId,

--- a/client/extensions/zoninator/components/settings/zone/zone-lock-warning-notice.jsx
+++ b/client/extensions/zoninator/components/settings/zone/zone-lock-warning-notice.jsx
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { flowRight } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+import { requestFeed } from '../../../state/feeds/actions';
+import { requestLock, resetLock } from '../../../state/locks/actions';
+import { requestZones } from '../../../state/zones/actions';
+import { blocked } from '../../../state/locks/selectors';
+
+class ZoneLockWarningNotice extends PureComponent {
+
+	static propTypes = {
+		isBlocked: PropTypes.bool,
+		requestFeed: PropTypes.func.isRequired,
+		requestLock: PropTypes.func.isRequired,
+		requestZones: PropTypes.func.isRequired,
+		resetLock: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
+		translate: PropTypes.func.isRequired,
+		zoneId: PropTypes.number.isRequired,
+	};
+
+	refreshLock = () => {
+		// Refresh the forms as well if the zone was blocked by another user
+		if ( this.props.isBlocked ) {
+			this.props.requestFeed( this.props.siteId, this.props.zoneId );
+			this.props.requestZones( this.props.siteId );
+		}
+
+		this.props.resetLock( this.props.siteId, this.props.zoneId );
+		this.props.requestLock( this.props.siteId, this.props.zoneId );
+	}
+
+	noticeText = isBlocked => isBlocked
+		? this.props.translate( 'This zone is currently being edited by another user. Try again in a moment.' )
+		: this.props.translate( 'You have reached the maximum idle limit. Refresh to continue.' );
+
+	render() {
+		const { isBlocked, translate } = this.props;
+
+		return (
+			<div>
+				<Notice
+					showDismiss={ false }
+					status="is-warning"
+					text={ this.noticeText( isBlocked ) }
+				>
+					<NoticeAction onClick={ this.refreshLock }>{ translate( 'Refresh' ) }</NoticeAction>
+				</Notice>
+			</div>
+		);
+	}
+}
+
+const connectComponent = connect(
+	( state, { siteId, zoneId } ) => ( { isBlocked: blocked( state, siteId, zoneId ) } ),
+	{ requestFeed, requestLock, requestZones, resetLock }
+);
+
+export default flowRight( connectComponent, localize )( ZoneLockWarningNotice );

--- a/client/extensions/zoninator/state/data-layer/feeds/index.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/index.js
@@ -15,6 +15,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
 import { fromApi, toApi } from './util';
 import { updateFeed } from '../../feeds/actions';
+import { resetLock } from '../../locks/actions';
 import { getZone } from '../../zones/selectors';
 import { ZONINATOR_REQUEST_FEED, ZONINATOR_SAVE_FEED } from 'zoninator/state/action-types';
 
@@ -60,6 +61,7 @@ export const saveZoneFeed = ( { dispatch }, action ) => {
 
 	dispatch( startSubmit( form ) );
 	dispatch( removeNotice( saveFeedNotice ) );
+	dispatch( resetLock( siteId, zoneId ) );
 	dispatch(
 		http(
 			{

--- a/client/extensions/zoninator/state/data-layer/feeds/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/test/index.js
@@ -6,6 +6,7 @@
 import { expect } from 'chai';
 import { translate } from 'i18n-calypso';
 import { initialize, startSubmit, stopSubmit } from 'redux-form';
+import { omit } from 'lodash';
 import sinon from 'sinon';
 
 /**
@@ -23,6 +24,7 @@ import { fromApi, toApi } from '../util';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
 import { updateFeed } from 'zoninator/state/feeds/actions';
+import { resetLock } from 'zoninator/state/locks/actions';
 
 const dummyAction = {
 	type: 'DUMMY_ACTION',
@@ -149,6 +151,14 @@ describe( '#saveZoneFeed()', () => {
 		saveZoneFeed( { dispatch }, dummyAction );
 
 		expect( dispatch ).to.have.been.calledWith( startSubmit( dummyAction.form ) );
+	} );
+
+	test( 'should dispatch `resetLock`', () => {
+		const dispatch = sinon.spy();
+
+		saveZoneFeed( { dispatch }, dummyAction );
+
+		expect( dispatch ).to.have.been.calledWithMatch( omit( resetLock( 123, 456 ), [ 'time' ] ) );
 	} );
 } );
 

--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -15,6 +15,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
 import { navigate } from 'state/ui/actions';
+import { resetLock } from '../../locks/actions';
 import { requestZones, requestError, updateZone, updateZones } from '../../zones/actions';
 import { fromApi } from './utils';
 import {
@@ -90,6 +91,7 @@ export const saveZone = ( { dispatch }, action ) => {
 
 	dispatch( startSubmit( form ) );
 	dispatch( removeNotice( saveZoneNotice ) );
+	dispatch( resetLock( siteId, zoneId ) );
 	dispatch(
 		http(
 			{

--- a/client/extensions/zoninator/state/data-layer/zones/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/test/index.js
@@ -6,6 +6,7 @@
 import { expect } from 'chai';
 import { translate } from 'i18n-calypso';
 import { initialize, startSubmit, stopSubmit } from 'redux-form';
+import { omit } from 'lodash';
 import sinon from 'sinon';
 
 /**
@@ -28,6 +29,7 @@ import { fromApi } from '../utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice, removeNotice, successNotice } from 'state/notices/actions';
 import { navigate } from 'state/ui/actions';
+import { resetLock } from 'zoninator/state/locks/actions';
 import { requestError, requestZones, updateZone, updateZones } from 'zoninator/state/zones/actions';
 
 const apiResponse = {
@@ -192,6 +194,21 @@ describe( '#saveZone()', () => {
 		saveZone( { dispatch }, action );
 
 		expect( dispatch ).to.have.been.calledWith( removeNotice( 'zoninator-zone-create' ) );
+	} );
+
+	test( 'should dispatch `resetLock`', () => {
+		const dispatch = sinon.spy();
+		const action = {
+			type: 'DUMMY_ACTION',
+			siteId: 123,
+			zoneId: 456,
+			form: 'form',
+			data: zone,
+		};
+
+		saveZone( { dispatch }, action );
+
+		expect( dispatch ).to.have.been.calledWithMatch( omit( resetLock( 123, 456 ), [ 'time' ] ) );
 	} );
 
 	test( 'should dispatch a HTTP request to save the zone properties', () => {


### PR DESCRIPTION
This PR updates Edit Zone page for zone locks functionality:

- A warning is displayed if a zone is blocked or the page idles for too long.
- *Save* and *delete* buttons are disabled when a zone is blocked or the lock has expired.
- Saving changes resets the maximum lock period timeout.

![screen shot 2018-01-17 at 14 18 02](https://user-images.githubusercontent.com/8056203/35044582-486db618-fb91-11e7-9266-1d0564d421a1.png)

# Testing

Requires checking out `update/restore-lock-zone-endpoin`t branch of `Automattic/zoninator` on the server.

- Log into WP Admin as a different user than your WP.com account and go to `Zones` and select a zone.
- On WP.com, go to `/extensions/zoninator` and select that same zone.
- A warning should appear about how that zone is being edited by another user.
- Click `refresh` - the warning should persist.
- Close the WP Admin tab, wait for 30 seconds and click `refresh` again.
- The forms should reload and the warning should disappear.
- Leave the tab open for 10 minutes or more - an idle timeout warning should appear.
- Click `refresh` and the warning should disappear without reloading the forms.
- Leave the tab open until the idle warning appears again.
- Open the same zone in WP Admin using a different user.
- Click `refresh` in Calypso, the warning message should change.

**Note:** The last steps can take a while. The timeout values can be adjusted on the server as described [here](https://wordpress.org/plugins/zoninator/#how-do-i-change-the-the-locking-feature-settings).