### PR TITLE
Signup: Allow transfer-ins for signup

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -140,7 +140,6 @@ class DomainSearchResults extends React.Component {
 				if (
 					this.props.siteDesignType !== DESIGN_TYPE_STORE &&
 					this.props.transferInAllowed &&
-					! this.props.isSignupStep &&
 					lastDomainIsTransferrable
 				) {
 					availabilityElement = (
@@ -192,10 +191,6 @@ class DomainSearchResults extends React.Component {
 		this.props.onAddMapping( this.props.lastDomainSearched );
 	};
 
-	handleAddTransfer = () => {
-		this.props.onAddTransfer( this.props.lastDomainSearched );
-	};
-
 	renderPlaceholders() {
 		return times( this.props.placeholderQuantity, function( n ) {
 			return <DomainSuggestion.Placeholder key={ 'suggestion-' + n } />;
@@ -243,7 +238,7 @@ class DomainSearchResults extends React.Component {
 					/>
 				);
 
-				if ( this.props.transferInAllowed && ! this.props.isSignupStep ) {
+				if ( this.props.transferInAllowed ) {
 					unavailableOffer = (
 						<DomainTransferSuggestion
 							onButtonClick={ this.props.onClickTransfer }

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -26,7 +26,7 @@ import Card from 'components/card';
 import { getTld } from 'lib/domains';
 import { domainAvailability } from 'lib/domains/constants';
 import { currentUserHasFlag } from 'state/current-user/selectors';
-import { TRANSFER_IN } from 'state/current-user/constants';
+import { TRANSFER_IN_NUX } from 'state/current-user/constants';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 
@@ -139,7 +139,7 @@ class DomainSearchResults extends React.Component {
 			if ( this.props.offerUnavailableOption ) {
 				if (
 					this.props.siteDesignType !== DESIGN_TYPE_STORE &&
-					this.props.transferInAllowed &&
+					( ! this.props.isSignupStep || this.props.transferInNuxAllowed ) &&
 					lastDomainIsTransferrable
 				) {
 					availabilityElement = (
@@ -238,7 +238,7 @@ class DomainSearchResults extends React.Component {
 					/>
 				);
 
-				if ( this.props.transferInAllowed ) {
+				if ( ! this.props.isSignupStep || this.props.transferInNuxAllowed ) {
 					unavailableOffer = (
 						<DomainTransferSuggestion
 							onButtonClick={ this.props.onClickTransfer }
@@ -273,7 +273,7 @@ const mapStateToProps = state => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
 		isSiteOnPaidPlan: isSiteOnPaidPlan( state, selectedSiteId ),
-		transferInAllowed: currentUserHasFlag( state, TRANSFER_IN ),
+		transferInNuxAllowed: currentUserHasFlag( state, TRANSFER_IN_NUX ),
 		siteDesignType: getDesignType( state ),
 	};
 };

--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -56,9 +56,11 @@
 
 .domain-search-results__transfer-card-link {
 	flex-shrink: 0;
+	flex-grow: 1;
 	width: 100%;
 
 	a {
+		text-align: right;
 		display: block;
 		padding: 15px 0 0;
 	}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -648,7 +648,7 @@ class RegisterDomainStep extends React.Component {
 				/>
 			);
 
-			if ( this.props.transferInAllowed && ! this.props.isSignupStep ) {
+			if ( this.props.transferInAllowed ) {
 				domainUnavailableSuggestion = (
 					<DomainTransferSuggestion
 						onButtonClick={ this.goToTransferDomainStep }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -48,7 +48,7 @@ import {
 	getDomainsSuggestionsError,
 } from 'state/domains/suggestions/selectors';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
-import { TRANSFER_IN } from 'state/current-user/constants';
+import { TRANSFER_IN_NUX } from 'state/current-user/constants';
 
 const domains = wpcom.domains();
 
@@ -648,7 +648,7 @@ class RegisterDomainStep extends React.Component {
 				/>
 			);
 
-			if ( this.props.transferInAllowed ) {
+			if ( ! this.props.isSignupStep || this.props.transferInNuxAllowed ) {
 				domainUnavailableSuggestion = (
 					<DomainTransferSuggestion
 						onButtonClick={ this.goToTransferDomainStep }
@@ -882,7 +882,7 @@ export default connect(
 			currentUser: getCurrentUser( state ),
 			defaultSuggestions: getDomainsSuggestions( state, queryObject ),
 			defaultSuggestionsError: getDomainsSuggestionsError( state, queryObject ),
-			transferInAllowed: currentUserHasFlag( state, TRANSFER_IN ),
+			transferInNuxAllowed: currentUserHasFlag( state, TRANSFER_IN_NUX ),
 		};
 	},
 	{

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -40,6 +40,7 @@ import TransferRestrictionMessage from 'components/domains/transfer-domain-step/
 class TransferDomainStep extends React.Component {
 	static propTypes = {
 		analyticsSection: PropTypes.string.isRequired,
+		basePath: PropTypes.string,
 		cart: PropTypes.object,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
 		goBack: PropTypes.func,
@@ -244,8 +245,11 @@ class TransferDomainStep extends React.Component {
 
 		return (
 			<TransferRestrictionMessage
+				basePath={ this.props.basePath }
 				creationDate={ creationDate }
 				domain={ domain }
+				goBack={ this.goBack }
+				mapDomainUrl={ this.getMapDomainUrl() }
 				selectedSiteSlug={ get( this.props, 'selectedSite.slug', null ) }
 				termMaximumInYears={ termMaximumInYears }
 				transferEligibleDate={ transferEligibleDate }

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -44,6 +44,7 @@ class TransferDomainStep extends React.Component {
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
 		goBack: PropTypes.func,
 		initialQuery: PropTypes.string,
+		isSignupStep: PropTypes.bool,
 		onRegisterDomain: PropTypes.func.isRequired,
 		onTransferDomain: PropTypes.func.isRequired,
 		onSave: PropTypes.func,
@@ -275,11 +276,15 @@ class TransferDomainStep extends React.Component {
 			content = this.addTransfer();
 		}
 
+		const header = ! this.props.isSignupStep && (
+			<HeaderCake onClick={ this.goBack }>
+				{ this.props.translate( 'Use My Own Domain' ) }
+			</HeaderCake>
+		);
+
 		return (
 			<div className="transfer-domain-step">
-				<HeaderCake onClick={ this.goBack }>
-					{ this.props.translate( 'Use My Own Domain' ) }
-				</HeaderCake>
+				{ header }
 				<div>{ content }</div>
 			</div>
 		);
@@ -370,11 +375,15 @@ class TransferDomainStep extends React.Component {
 						break;
 					case domainAvailability.TRANSFERRABLE:
 					case domainAvailability.MAPPED_SAME_SITE_TRANSFERRABLE:
-						this.setState( {
-							domain,
-							supportsPrivacy: get( result, 'supports_privacy', false ),
-						} );
-						break;
+						if ( this.props.isSignupStep ) {
+							this.props.onTransferDomain( domain );
+						} else {
+							this.setState( {
+								domain,
+								supportsPrivacy: get( result, 'supports_privacy', false ),
+							} );
+							break;
+						}
 					case domainAvailability.MAPPABLE:
 					case domainAvailability.TLD_NOT_SUPPORTED:
 						const tld = getTld( domain );

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -335,6 +335,7 @@ class TransferDomainStep extends React.Component {
 	handleFormSubmit = event => {
 		event.preventDefault();
 
+		const domain = getFixedDomainSearch( this.state.searchQuery );
 		this.props.recordFormSubmitInTransferDomain( this.state.searchQuery );
 		this.setState( { notice: null, suggestion: null, submittingAvailability: true } );
 
@@ -358,6 +359,10 @@ class TransferDomainStep extends React.Component {
 
 					return { precheck: prevState.domain && ! submittingAvailability && ! submittingWhois };
 				} );
+
+				if ( this.props.isSignupStep && ! this.transferIsRestricted() ) {
+					this.props.onTransferDomain( domain );
+				}
 			}
 		);
 	};
@@ -375,15 +380,11 @@ class TransferDomainStep extends React.Component {
 						break;
 					case domainAvailability.TRANSFERRABLE:
 					case domainAvailability.MAPPED_SAME_SITE_TRANSFERRABLE:
-						if ( this.props.isSignupStep ) {
-							this.props.onTransferDomain( domain );
-						} else {
-							this.setState( {
-								domain,
-								supportsPrivacy: get( result, 'supports_privacy', false ),
-							} );
-							break;
-						}
+						this.setState( {
+							domain,
+							supportsPrivacy: get( result, 'supports_privacy', false ),
+						} );
+						break;
 					case domainAvailability.MAPPABLE:
 					case domainAvailability.TLD_NOT_SUPPORTED:
 						const tld = getTld( domain );

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -165,6 +165,10 @@
 	align-items: center;
 	display: flex;
 	margin-top: 20px;
+
+	.transfer-domain-step__section-action-button {
+		margin-right: 15px;
+	}
 }
 
 .transfer-domain-step__lock-status {

--- a/client/components/domains/transfer-domain-step/transfer-restriction-message.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-restriction-message.jsx
@@ -15,12 +15,13 @@ import Button from 'components/button';
 import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
 import { MAP_EXISTING_DOMAIN } from 'lib/url/support';
-import { domainMapping } from 'my-sites/domains/paths';
 
 class TransferRestrictionMessage extends React.PureComponent {
 	static propTypes = {
 		creationDate: PropTypes.string,
 		domain: PropTypes.string,
+		goBack: PropTypes.func,
+		mapDomainUrl: PropTypes.string,
 		selectedSiteSlug: PropTypes.string,
 		termMaximumInYears: PropTypes.number,
 		transferEligibleDate: PropTypes.string,
@@ -29,13 +30,14 @@ class TransferRestrictionMessage extends React.PureComponent {
 
 	goToMapDomainStep = event => {
 		event.preventDefault();
-		page( domainMapping( this.props.selectedSiteSlug, this.props.domain ) );
+		page( this.props.mapDomainUrl );
 	};
 
 	render() {
 		const {
 			creationDate,
 			domain,
+			goBack,
 			termMaximumInYears,
 			transferEligibleDate,
 			transferRestrictionStatus,
@@ -112,8 +114,19 @@ class TransferRestrictionMessage extends React.PureComponent {
 								{ reason }
 							</div>
 							<div className="transfer-domain-step__section-action">
-								<Button compact onClick={ this.goToMapDomainStep }>
+								<Button
+									className="transfer-domain-step__section-action-button"
+									compact
+									onClick={ this.goToMapDomainStep }
+								>
 									{ translate( 'Connect domain without transferring' ) }
+								</Button>
+								<Button
+									className="transfer-domain-step__section-action-button"
+									compact
+									onClick={ goBack }
+								>
+									{ translate( 'Transfer different domain' ) }
 								</Button>
 							</div>
 						</div>

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 import { assign, defer, get, isEmpty, isNull, omitBy, pick, startsWith } from 'lodash';
 import async from 'async';
@@ -22,6 +21,7 @@ import SignupCart from 'lib/signup/cart';
 import analytics from 'lib/analytics';
 import { SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET } from 'state/action-types';
 import { cartItems } from 'lib/cart-values';
+import { isDomainTransfer } from 'lib/products-values';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
@@ -147,10 +147,17 @@ export function createSiteWithCart(
 			const addToCartAndProceed = () => {
 				let privacyItem = null;
 				if ( domainItem ) {
-					privacyItem = cartItems.domainPrivacyProtection( {
-						domain: domainItem.meta,
-						source: 'signup',
-					} );
+					if ( isDomainTransfer( domainItem ) ) {
+						privacyItem = cartItems.domainTransferPrivacy( {
+							domain: domainItem.meta,
+							source: 'signup',
+						} );
+					} else {
+						privacyItem = cartItems.domainPrivacyProtection( {
+							domain: domainItem.meta,
+							source: 'signup',
+						} );
+					}
 				}
 
 				const newCartItems = [

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import TransferDomainStep from 'components/domains/transfer-domain-step';
-import { DOMAINS_WITH_PLANS_ONLY, TRANSFER_IN } from 'state/current-user/constants';
+import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import { cartItems } from 'lib/cart-values';
 import { addItem, addItems } from 'lib/upgrades/actions';
 import Notice from 'components/notice';
@@ -90,9 +90,6 @@ export class TransferDomain extends Component {
 	};
 
 	componentWillMount() {
-		if ( ! this.props.transferInAllowed ) {
-			page.redirect( '/domains/add/mapping/' + this.props.selectedSiteSlug );
-		}
 		this.checkSiteIsUpgradeable( this.props );
 	}
 
@@ -107,20 +104,9 @@ export class TransferDomain extends Component {
 	}
 
 	render() {
-		const {
-			cart,
-			domainsWithPlansOnly,
-			initialQuery,
-			productsList,
-			selectedSite,
-			transferInAllowed,
-		} = this.props;
+		const { cart, domainsWithPlansOnly, initialQuery, productsList, selectedSite } = this.props;
 
 		const { errorMessage } = this.state;
-
-		if ( ! transferInAllowed ) {
-			return null;
-		}
 
 		return (
 			<span>
@@ -151,5 +137,4 @@ export default connect( state => ( {
 	domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 	isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
 	productsList: getProductsList( state ),
-	transferInAllowed: currentUserHasFlag( state, TRANSFER_IN ),
 } ) )( TransferDomain );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -282,15 +282,15 @@ class DomainsStep extends React.Component {
 		return (
 			<div className="domains__step-section-wrapper">
 				<TransferDomainStep
-					path={ this.props.path }
+					analyticsSection="signup"
+					basePath={ this.props.path }
+					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					initialQuery={ initialQuery }
+					isSignupStep
 					onRegisterDomain={ this.handleAddDomain }
 					onTransferDomain={ this.handleAddTransfer }
 					onSave={ this.onTransferSave }
 					products={ productsList.get() }
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-					initialQuery={ initialQuery }
-					analyticsSection="signup"
-					isSignupStep
 				/>
 			</div>
 		);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -13,6 +13,7 @@ import { localize, getLocaleSlug } from 'i18n-calypso';
  * Internal dependencies
  */
 import MapDomainStep from 'components/domains/map-domain-step';
+import TransferDomainStep from 'components/domains/transfer-domain-step';
 import productsListFactory from 'lib/products-list';
 import RegisterDomainStep from 'components/domains/register-domain-step';
 import SignupActions from 'lib/signup/actions';
@@ -25,6 +26,7 @@ import { getUsernameSuggestion } from 'lib/signup/step-actions';
 import {
 	recordAddDomainButtonClick,
 	recordAddDomainButtonClickInMapDomain,
+	recordAddDomainButtonClickInTransferDomain,
 } from 'state/domains/actions';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
@@ -61,6 +63,10 @@ class DomainsStep extends React.Component {
 
 	getMapDomainUrl = () => {
 		return getStepUrl( this.props.flowName, this.props.stepName, 'mapping', this.props.locale );
+	};
+
+	getTransferDomainUrl = () => {
+		return getStepUrl( this.props.flowName, this.props.stepName, 'transfer', this.props.locale );
 	};
 
 	componentDidMount() {
@@ -178,6 +184,30 @@ class DomainsStep extends React.Component {
 		this.props.goToNextStep();
 	};
 
+	handleAddTransfer = domain => {
+		const domainItem = cartItems.domainTransfer( { domain, extra: { signup: true } } );
+		const isPurchasingItem = true;
+
+		this.props.recordAddDomainButtonClickInTransferDomain( domain, 'signup' );
+
+		SignupActions.submitSignupStep(
+			Object.assign(
+				{
+					processingMessage: this.props.translate( 'Adding your domain transfer' ),
+					stepName: this.props.stepName,
+					[ 'transfer' ]: {},
+					domainItem,
+					isPurchasingItem,
+					siteUrl: domain,
+					stepSectionName: this.props.stepSectionName,
+				},
+				this.getThemeArgs()
+			)
+		);
+
+		this.props.goToNextStep();
+	};
+
 	handleSave = ( sectionName, state ) => {
 		SignupActions.saveSignupStep( {
 			stepName: this.props.stepName,
@@ -202,6 +232,7 @@ class DomainsStep extends React.Component {
 				products={ this.state.products }
 				basePath={ this.props.path }
 				mapDomainUrl={ this.getMapDomainUrl() }
+				transferDomainUrl={ this.getTransferDomainUrl() }
 				onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
 				onSave={ this.handleSave.bind( this, 'domainForm' ) }
 				offerUnavailableOption={ ! this.props.isDomainOnly }
@@ -224,7 +255,7 @@ class DomainsStep extends React.Component {
 				this.props.step && this.props.step.domainForm && this.props.step.domainForm.lastQuery;
 
 		return (
-			<div className="domains-step__section-wrapper">
+			<div className="domains__step-section-wrapper">
 				<MapDomainStep
 					initialState={ initialState }
 					path={ this.props.path }
@@ -235,6 +266,31 @@ class DomainsStep extends React.Component {
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					initialQuery={ initialQuery }
 					analyticsSection="signup"
+				/>
+			</div>
+		);
+	};
+
+	onTransferSave = state => {
+		this.handleSave( 'transferForm', state );
+	};
+
+	transferForm = () => {
+		const initialQuery =
+			this.props.step && this.props.step.domainForm && this.props.step.domainForm.lastQuery;
+
+		return (
+			<div className="domains__step-section-wrapper">
+				<TransferDomainStep
+					path={ this.props.path }
+					onRegisterDomain={ this.handleAddDomain }
+					onTransferDomain={ this.handleAddTransfer }
+					onSave={ this.onTransferSave }
+					products={ productsList.get() }
+					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					initialQuery={ initialQuery }
+					analyticsSection="signup"
+					isSignupStep
 				/>
 			</div>
 		);
@@ -251,13 +307,17 @@ class DomainsStep extends React.Component {
 			content = this.mappingForm();
 		}
 
+		if ( 'transfer' === this.props.stepSectionName ) {
+			content = this.transferForm();
+		}
+
 		if ( ! this.props.stepSectionName ) {
 			content = this.domainForm();
 		}
 
 		if ( this.props.step && 'invalid' === this.props.step.status ) {
 			content = (
-				<div className="domains-step__section-wrapper">
+				<div className="domains__step-section-wrapper">
 					<Notice status="is-error" showDismiss={ false }>
 						{ this.props.step.errors.message }
 					</Notice>
@@ -329,6 +389,7 @@ export default connect(
 	{
 		recordAddDomainButtonClick,
 		recordAddDomainButtonClickInMapDomain,
+		recordAddDomainButtonClickInTransferDomain,
 		submitDomainStepSelection,
 	}
 )( localize( DomainsStep ) );

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -1,4 +1,4 @@
-.domains-step__section-wrapper {
+.domains__step-section-wrapper {
 	margin: 0 auto;
 	max-width: 650px;
 }

--- a/client/state/current-user/constants.js
+++ b/client/state/current-user/constants.js
@@ -1,4 +1,4 @@
 /** @format */
 
 export const DOMAINS_WITH_PLANS_ONLY = 'calypso_domains_with_plans_only';
-export const TRANSFER_IN = 'calypso_transfer_in';
+export const TRANSFER_IN_NUX = 'calypso_transfer_in_nux';

--- a/client/state/domains/actions.js
+++ b/client/state/domains/actions.js
@@ -34,6 +34,20 @@ export const recordAddDomainButtonClickInMapDomain = ( domainName, section ) =>
 		} )
 	);
 
+export const recordAddDomainButtonClickInTransferDomain = ( domainName, section ) =>
+	composeAnalytics(
+		recordGoogleEvent(
+			'Domain Search',
+			'Clicked "Transfer" Button on a Domain Registration in Transfer Domain Step',
+			'Domain Name',
+			domainName
+		),
+		recordTracksEvent( 'calypso_transfer_domain_step_add_domain_click', {
+			domain_name: domainName,
+			section,
+		} )
+	);
+
 export const recordRemoveDomainButtonClick = domainName =>
 	composeAnalytics(
 		recordGoogleEvent(


### PR DESCRIPTION
We want to allow users to purchase a transfer-in when signing up for a new wp.com site.

The flow is different, and we do the transfer precheck after the purchase.

- Make sure the `Add -> Domains` flow works
- Make sure if feature flag is set to false you can't see transfers in signup
- Test the signup with a transfer
- Test the restricted domains, try both buttons to map/transfer another domain
- Try go back along the flows
- Check if privacy properly added by default for transfers in signup

Dependency: D9378-code