### PR TITLE
Jetpack Connect: Record mobile app flow to tracks

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -101,6 +101,8 @@ export class JetpackAuthorize extends Component {
 		const { recordTracksEvent } = this.props;
 
 		const tracksProperties = pick( this.props.authQuery, 'from' );
+		tracksProperties[ 'is-mobile-app-flow' ] = this.props.isMobileAppFlow;
+
 		recordTracksEvent( 'calypso_jpc_authorize_form_view', tracksProperties );
 		recordTracksEvent( 'calypso_jpc_auth_view', tracksProperties );
 

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -101,7 +101,7 @@ export class JetpackAuthorize extends Component {
 		const { recordTracksEvent } = this.props;
 
 		const tracksProperties = pick( this.props.authQuery, 'from' );
-		tracksProperties[ 'is-mobile-app-flow' ] = this.props.isMobileAppFlow;
+		tracksProperties.is_mobile_app_flow = this.props.isMobileAppFlow;
 
 		recordTracksEvent( 'calypso_jpc_authorize_form_view', tracksProperties );
 		recordTracksEvent( 'calypso_jpc_auth_view', tracksProperties );


### PR DESCRIPTION
Record whether or not a connection is being made from the mobile apps by adding an `is_mobile_app_flow` property to the major connection auth events.

This will allow segmententing jetpack connection funnels by connections made via mobile app.

## Testing
1. Run in the browser console:
   ```js
   localStorage.debug = 'calypso:analytics:tracks'
   ```
1. Connect a new site via `/jetpack/connect`
1. See the modified analytics calls including `is_mobile_app_flow`, for example `calypso_jpc_auth_form`
