### PR TITLE
Comments: Improve back navigation

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -45,17 +45,13 @@ export class CommentList extends Component {
 	};
 
 	componentWillReceiveProps( nextProps ) {
-		const { changePage, isPostView, siteId, status } = this.props;
+		const { siteId, status, changePage } = this.props;
 		const totalPages = this.getTotalPages();
 		if ( ! this.isRequestedPageValid() && totalPages > 1 ) {
 			return changePage( totalPages );
 		}
 
-		if (
-			isPostView !== nextProps.isPostView ||
-			siteId !== nextProps.siteId ||
-			status !== nextProps.status
-		) {
+		if ( siteId !== nextProps.siteId || status !== nextProps.status ) {
 			this.setState( {
 				isBulkMode: false,
 				selectedComments: [],
@@ -195,10 +191,10 @@ export class CommentList extends Component {
 						<Comment
 							commentId={ commentId }
 							commentsListQuery={ commentsListQuery }
+							key={ `comment-${ siteId }-${ commentId }` }
 							isBulkMode={ isBulkMode }
 							isPostView={ isPostView }
 							isSelected={ this.isCommentSelected( commentId ) }
-							key={ `comment-${ siteId }-${ commentId }` }
 							toggleSelected={ this.toggleCommentSelected }
 						/>
 					) ) }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -40,7 +40,6 @@ export class CommentList extends Component {
 	};
 
 	state = {
-		hasScrolledToComment: false,
 		isBulkMode: false,
 		selectedComments: [],
 	};
@@ -58,7 +57,6 @@ export class CommentList extends Component {
 			status !== nextProps.status
 		) {
 			this.setState( {
-				hasScrolledToComment: false,
 				isBulkMode: false,
 				selectedComments: [],
 			} );
@@ -73,7 +71,7 @@ export class CommentList extends Component {
 
 		recordChangePage( page, this.getTotalPages() );
 
-		this.setState( { hasScrolledToComment: false, selectedComments: [] } );
+		this.setState( { selectedComments: [] } );
 
 		changePage( page );
 	};
@@ -105,8 +103,6 @@ export class CommentList extends Component {
 	isSelectedAll = () =>
 		this.state.selectedComments.length &&
 		this.state.selectedComments.length === this.props.comments.length;
-
-	onScrollToComment = () => this.setState( { hasScrolledToComment: true } );
 
 	toggleBulkMode = () => {
 		this.setState( ( { isBulkMode } ) => ( { isBulkMode: ! isBulkMode, selectedComments: [] } ) );
@@ -145,7 +141,7 @@ export class CommentList extends Component {
 			siteFragment,
 			status,
 		} = this.props;
-		const { hasScrolledToComment, isBulkMode, selectedComments } = this.state;
+		const { isBulkMode, selectedComments } = this.state;
 
 		const validPage = this.isRequestedPageValid() ? page : 1;
 
@@ -199,12 +195,10 @@ export class CommentList extends Component {
 						<Comment
 							commentId={ commentId }
 							commentsListQuery={ commentsListQuery }
-							hasScrolledToComment={ hasScrolledToComment }
 							isBulkMode={ isBulkMode }
 							isPostView={ isPostView }
 							isSelected={ this.isCommentSelected( commentId ) }
 							key={ `comment-${ siteId }-${ commentId }` }
-							onScrollToComment={ this.onScrollToComment }
 							toggleSelected={ this.toggleCommentSelected }
 						/>
 					) ) }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -40,19 +40,25 @@ export class CommentList extends Component {
 	};
 
 	state = {
+		hasScrolledToComment: false,
 		isBulkMode: false,
 		selectedComments: [],
 	};
 
 	componentWillReceiveProps( nextProps ) {
-		const { siteId, status, changePage } = this.props;
+		const { changePage, isPostView, siteId, status } = this.props;
 		const totalPages = this.getTotalPages();
 		if ( ! this.isRequestedPageValid() && totalPages > 1 ) {
 			return changePage( totalPages );
 		}
 
-		if ( siteId !== nextProps.siteId || status !== nextProps.status ) {
+		if (
+			isPostView !== nextProps.isPostView ||
+			siteId !== nextProps.siteId ||
+			status !== nextProps.status
+		) {
 			this.setState( {
+				hasScrolledToComment: false,
 				isBulkMode: false,
 				selectedComments: [],
 			} );
@@ -67,7 +73,7 @@ export class CommentList extends Component {
 
 		recordChangePage( page, this.getTotalPages() );
 
-		this.setState( { selectedComments: [] } );
+		this.setState( { hasScrolledToComment: false, selectedComments: [] } );
 
 		changePage( page );
 	};
@@ -99,6 +105,8 @@ export class CommentList extends Component {
 	isSelectedAll = () =>
 		this.state.selectedComments.length &&
 		this.state.selectedComments.length === this.props.comments.length;
+
+	onScrollToComment = () => this.setState( { hasScrolledToComment: true } );
 
 	toggleBulkMode = () => {
 		this.setState( ( { isBulkMode } ) => ( { isBulkMode: ! isBulkMode, selectedComments: [] } ) );
@@ -137,7 +145,7 @@ export class CommentList extends Component {
 			siteFragment,
 			status,
 		} = this.props;
-		const { isBulkMode, selectedComments } = this.state;
+		const { hasScrolledToComment, isBulkMode, selectedComments } = this.state;
 
 		const validPage = this.isRequestedPageValid() ? page : 1;
 
@@ -191,10 +199,12 @@ export class CommentList extends Component {
 						<Comment
 							commentId={ commentId }
 							commentsListQuery={ commentsListQuery }
-							key={ `comment-${ siteId }-${ commentId }` }
+							hasScrolledToComment={ hasScrolledToComment }
 							isBulkMode={ isBulkMode }
 							isPostView={ isPostView }
 							isSelected={ this.isCommentSelected( commentId ) }
+							key={ `comment-${ siteId }-${ commentId }` }
+							onScrollToComment={ this.onScrollToComment }
 							toggleSelected={ this.toggleCommentSelected }
 						/>
 					) ) }

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -12,6 +12,7 @@ import { get, isEqual } from 'lodash';
 /**
  * Internal dependencies
  */
+import CommentLink from 'my-sites/comments/comment/comment-link';
 import CommentPostLink from 'my-sites/comments/comment/comment-post-link';
 import Emojify from 'components/emojify';
 import ExternalLink from 'components/external-link';
@@ -104,9 +105,14 @@ export class CommentAuthor extends Component {
 
 					<div className="comment__author-info-element">
 						<span className="comment__date">
-							<a href={ commentUrl } tabIndex={ isBulkMode ? -1 : 0 } title={ formattedDate }>
+							<CommentLink
+								commentId={ commentId }
+								href={ commentUrl }
+								tabIndex={ isBulkMode ? -1 : 0 }
+								title={ formattedDate }
+							>
 								{ relativeDate }
-							</a>
+							</CommentLink>
 						</span>
 						{ authorUrl && (
 							<span className="comment__author-url">

--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -13,6 +13,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import AutoDirection from 'components/auto-direction';
+import CommentLink from 'my-sites/comments/comment/comment-link';
 import CommentPostLink from 'my-sites/comments/comment/comment-post-link';
 import Emojify from 'components/emojify';
 import QueryComment from 'components/data/query-comment';
@@ -29,7 +30,7 @@ export class CommentContent extends Component {
 	};
 
 	renderInReplyTo = () => {
-		const { isBulkMode, parentCommentContent, parentCommentUrl, translate } = this.props;
+		const { commentId, isBulkMode, parentCommentContent, parentCommentUrl, translate } = this.props;
 
 		if ( ! parentCommentContent ) {
 			return null;
@@ -39,9 +40,13 @@ export class CommentContent extends Component {
 			<div className="comment__in-reply-to">
 				{ isBulkMode && <Gridicon icon="reply" size={ 18 } /> }
 				<span>{ translate( 'In reply to:' ) }</span>
-				<a href={ parentCommentUrl } tabIndex={ isBulkMode ? -1 : 0 }>
+				<CommentLink
+					commentId={ commentId }
+					href={ parentCommentUrl }
+					tabIndex={ isBulkMode ? -1 : 0 }
+				>
 					<Emojify>{ parentCommentContent }</Emojify>
-				</a>
+				</CommentLink>
 			</div>
 		);
 	};

--- a/client/my-sites/comments/comment/comment-link.jsx
+++ b/client/my-sites/comments/comment/comment-link.jsx
@@ -1,0 +1,58 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { get, includes, omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { navigate } from 'state/ui/actions';
+
+export class CommentLink extends PureComponent {
+	static propTypes = {
+		children: PropTypes.any,
+		commentId: PropTypes.number,
+		href: PropTypes.string,
+		navigate: PropTypes.func,
+	};
+
+	handleClick = event => {
+		if ( ! window ) {
+			return;
+		}
+		event.preventDefault();
+		window.scrollTo( 0, 0 );
+
+		const { commentId, href } = this.props;
+		const path = get( window, 'history.state.path' );
+
+		const newPath = includes( path, '#' )
+			? path.replace( /[#].*/, `#comment-${ commentId }` )
+			: `${ path }#comment-${ commentId }`;
+
+		window.history.replaceState( { ...window.history.state, path: newPath }, null );
+
+		this.props.navigate( href );
+	};
+
+	render() {
+		const { children, href } = this.props;
+		return (
+			<a
+				href={ href }
+				onClick={ this.handleClick }
+				{ ...omit( this.props, [ 'children', 'commentId', 'href', 'navigate' ] ) }
+			>
+				{ children }
+			</a>
+		);
+	}
+}
+
+const mapDispatchToProps = { navigate };
+
+export default connect( null, mapDispatchToProps )( CommentLink );

--- a/client/my-sites/comments/comment/comment-post-link.jsx
+++ b/client/my-sites/comments/comment/comment-post-link.jsx
@@ -11,6 +11,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import CommentLink from 'my-sites/comments/comment/comment-link';
 import QueryPosts from 'components/data/query-posts';
 import { decodeEntities, stripHTML } from 'lib/formatting';
 import { getSiteComment } from 'state/selectors';
@@ -18,6 +19,7 @@ import { getSitePost } from 'state/posts/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
 const CommentPostLink = ( {
+	commentId,
 	isBulkMode,
 	isPostTitleLoaded,
 	postId,
@@ -32,9 +34,13 @@ const CommentPostLink = ( {
 
 		<Gridicon icon={ isBulkMode ? 'chevron-right' : 'posts' } size={ 18 } />
 
-		<a href={ `/comments/${ status }/${ siteSlug }/${ postId }` } tabIndex={ isBulkMode ? -1 : 0 }>
+		<CommentLink
+			commentId={ commentId }
+			href={ `/comments/${ status }/${ siteSlug }/${ postId }` }
+			tabIndex={ isBulkMode ? -1 : 0 }
+		>
 			{ postTitle.trim() || translate( 'Untitled' ) }
-		</a>
+		</CommentLink>
 	</div>
 );
 

--- a/client/my-sites/comments/comment/comment-reply.jsx
+++ b/client/my-sites/comments/comment/comment-reply.jsx
@@ -114,6 +114,13 @@ export class CommentReply extends Component {
 		if ( alsoApprove ) {
 			approveComment( siteId, postId, { previousStatus: commentStatus } );
 		}
+
+		// Back navigation scrolling fix
+		if ( window ) {
+			const path = get( window, 'history.state.path' );
+			const newPath = path.replace( /[#].*/, '' );
+			window.history.replaceState( window.history.state, '', newPath );
+		}
 	};
 
 	updateTextarea = event => {

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -54,7 +54,7 @@ export class Comment extends Component {
 	}
 
 	componentWillMount() {
-		this.debounceScrollToOffset = debounce( this.scrollToOffset, 200 );
+		this.debounceScrollToOffset = debounce( this.scrollToOffset, 500 );
 	}
 
 	componentWillReceiveProps( nextProps ) {

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -94,7 +94,12 @@ export class Comment extends Component {
 	};
 
 	scrollToComment = ( { commentId, hasScrolledToComment, onScrollToComment } ) => {
-		if ( ! window || hasScrolledToComment || `#comment-${ commentId }` !== window.location.hash ) {
+		if (
+			! window ||
+			! onScrollToComment ||
+			hasScrolledToComment ||
+			`#comment-${ commentId }` !== window.location.hash
+		) {
 			return;
 		}
 

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -102,7 +102,8 @@ export class Comment extends Component {
 		const commentNode = ReactDom.findDOMNode( this.commentCard );
 		// Adjust the comment card `offsetTop` to avoid being covered by the masterbar.
 		// 56px = 48px (masterbar height) + 8px (comment card vertical margin)
-		return commentNode.offsetTop - 56;
+		// 66px = 58px (post view sticky header) + 8px (comment card vertical margin)
+		return commentNode.offsetTop - 56 - ( this.props.isPostView ? 66 : 0 );
 	};
 
 	scrollToOffset = () => {

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -124,6 +124,7 @@ export class Comment extends Component {
 		return (
 			<Card
 				className={ classes }
+				id={ `comment-${ commentId }` }
 				onClick={ isBulkMode ? this.toggleSelected : undefined }
 				onKeyDown={ this.keyDownHandler }
 				ref={ this.storeCardRef }

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -124,15 +124,7 @@ export class Comment extends Component {
 			return;
 		}
 		const { offsetTop } = this.state;
-		scrollTo( {
-			x: 0,
-			y: offsetTop,
-			onComplete: () => {
-				if ( offsetTop !== window.scrollY ) {
-					window.scrollTo( 0, offsetTop );
-				}
-			},
-		} );
+		scrollTo( { x: 0, y: offsetTop } );
 	};
 
 	toggleEditMode = () => {

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -110,7 +110,16 @@ export class Comment extends Component {
 		if ( ! window || `#comment-${ this.props.commentId }` !== window.location.hash ) {
 			return;
 		}
-		scrollTo( { x: 0, y: this.state.offsetTop } );
+		const { offsetTop } = this.state;
+		scrollTo( {
+			x: 0,
+			y: offsetTop,
+			onComplete: () => {
+				if ( offsetTop !== window.scrollY ) {
+					window.scrollTo( 0, offsetTop );
+				}
+			},
+		} );
 	};
 
 	toggleEditMode = () => {

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -54,7 +54,7 @@ export class Comment extends Component {
 	}
 
 	componentWillMount() {
-		this.debounceScrollToOffset = debounce( this.scrollToOffset, 500 );
+		this.debounceScrollToOffset = debounce( this.scrollToOffset, 100 );
 	}
 
 	componentWillReceiveProps( nextProps ) {


### PR DESCRIPTION
Fix #20300
Fix #19972
Replace #20567

In the Comments' site and post view, after clicking on a post or comment view link, going back, either via the header's Back or the browser's own button, scroll down to the clicked comment.

(_If you somehow managed to understand what I wrote, please update it with a better description!_ 🙇)

### Example

I'm in the site view, I scroll down halfway through the page, and I click on the comment X post link: the post view will open.
Then I hit Back: the site view will open, scrolled all the way down to comment X.

## Logic

In the previous attempt we had several problems, all of which caused by the fact that the comment position in the page changes several times during the first load.

By replacing the comment tree approach with the comment list one, we basically removed the biggest offender. Loading each comment separately, in fact, caused the comment to move around quite a lot, if we consider these steps: `null -> placeholder -> proper comment`, multiplied to the number of comments in the page (max 20).

Without the tree we remove the _times 20_, but we still have the three `null -> placeholder -> proper comment(s)` changes.

The original idea (from the previous attempt) was to track the loading status of the comments.
Once everything was in state, we were sure that the comment position wouldn't change anymore.
Wrong!

Comment _replies_ have yet another little thing to load: the parent comment excerpt.
In fact, we show an `In reply to: {parent comment excerpt}` line. This excerpt is not provided in the (child) comment object, but has to be fetched by its own (if it's not already in state).
Once the `In reply to` line is populated, it shifts all the following comments by ~20px.
If many comments in a page are replies, we might end up with a quite big shift.

In the aforementioned loading status tracker, we would have needed to check if a comment was a reply and track its parent comment status as well.

So this is a completely different approach.
Instead of tracking all kind of things that don't tell us anything about what we most eagerly need, we only track the comment position when it moves, and if it moves down, we scroll toward it.

It could go like this:
```es6
0 // starting offset
...
50 // layout loaded
[ scroll to 50 ]
...
400 // comments loaded
[ scroll to 400 ]
...
480 // some "in reply to" lines populated
[ scroll to 480 ]
```

Once the comment reaches its final position, we can be sure that it won't ever change because any action (except one) would never increase the offset beyond the final position.

```es6
...
200 // we changed to bulk mode and collapsed all comments
[ remain at 480 ]
...
480 // exit from bulk mode
[ remain at 480 ]
...
360 // trash a comment above
[ remain at 480 ]
...
480 // undo the trash
[ remain at 480 ]
```

There is one action though that would actually move down the comment: the reply.
It adds a whole new comment on top of the first page (if in descending order).

My solution is to remove the `#comment-{ id }` hash from the path, right after the reply happens.
This way we'd break out of the whole repositioning logic once and for all.

One last kink: I've noticed that in some cases (I couldn't determine the repro steps though) the page would jump back on top after everything loaded.
For this reason, I've added an additional `scrollTo` on `scrollTo` complete.
I'm not 100% sure it's needed, but apparently I haven't gotten any more jumps after I added this additional nudge.

## Testing instructions

- Open `/comments`, pick a comment "below the fold".
- Click on its post view link, on its date permalink (aka: comment view link), or on its "in reply to" link (aka: parent comment link).
- Then hit back, either on the header component or on the browser.
- The path should have a `#comment-{ id }` hash, and the page should be scrolled down to the comment.