### PR TITLE
Store: Fix Apple Pay Option

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-stripe.js
@@ -44,7 +44,7 @@ class PaymentMethodStripe extends Component {
 		} ),
 		method: PropTypes.shape( {
 			settings: PropTypes.shape( {
-				apple_pay: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
+				payment_request: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
 				capture: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
 				secret_key: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
 				publishable_key: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,

--- a/client/extensions/woocommerce/app/settings/payments/stripe/payment-method-stripe-connected-dialog.js
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/payment-method-stripe-connected-dialog.js
@@ -34,7 +34,7 @@ class PaymentMethodStripeConnectedDialog extends Component {
 		domain: PropTypes.string.isRequired,
 		method: PropTypes.shape( {
 			settings: PropTypes.shape( {
-				apple_pay: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
+				payment_request: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
 				capture: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
 				secret_key: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
 				publishable_key: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
@@ -107,10 +107,14 @@ class PaymentMethodStripeConnectedDialog extends Component {
 					</FormSettingExplanation>
 				</FormFieldset>
 				<FormFieldset className="stripe__method-edit-field-container">
-					<FormLabel>{ translate( 'Use Apple Pay' ) }</FormLabel>
+					<FormLabel>{ translate( 'Use Apple Pay & Chrome Payment Request API' ) }</FormLabel>
 					<PaymentMethodEditFormToggle
-						checked={ method.settings.apple_pay.value === 'yes' ? true : false }
-						name="apple_pay"
+						checked={
+							method.settings.payment_request && method.settings.payment_request.value === 'yes'
+								? true
+								: false
+						}
+						name="payment_request"
 						onChange={ onEditField }
 					/>
 					<span>
@@ -118,6 +122,9 @@ class PaymentMethodStripeConnectedDialog extends Component {
 							'By using Apple Pay you agree to Stripe and ' + "Apple's terms of service"
 						) }
 					</span>
+					<FormSettingExplanation>
+						{ translate( 'Enables Apple Pay and Chrome Payment Request buttons.' ) }
+					</FormSettingExplanation>
 				</FormFieldset>
 			</div>
 		);

--- a/client/extensions/woocommerce/app/settings/payments/stripe/payment-method-stripe-key-based-dialog.js
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/payment-method-stripe-key-based-dialog.js
@@ -30,7 +30,7 @@ class PaymentMethodStripeKeyBasedDialog extends Component {
 		domain: PropTypes.string.isRequired,
 		method: PropTypes.shape( {
 			settings: PropTypes.shape( {
-				apple_pay: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
+				payment_request: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
 				capture: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
 				secret_key: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
 				publishable_key: PropTypes.shape( { value: PropTypes.string.isRequired } ).isRequired,
@@ -169,12 +169,14 @@ class PaymentMethodStripeKeyBasedDialog extends Component {
 					</FormSettingExplanation>
 				</FormFieldset>
 				<FormFieldset className="stripe__method-edit-field-container">
-					<FormLabel>{ translate( 'Use Apple Pay' ) }</FormLabel>
+					<FormLabel>{ translate( 'Use Apple Pay & Chrome Payment Request API' ) }</FormLabel>
 					<PaymentMethodEditFormToggle
 						checked={
-							method.settings.apple_pay && method.settings.apple_pay.value === 'yes' ? true : false
+							method.settings.payment_request && method.settings.payment_request.value === 'yes'
+								? true
+								: false
 						}
-						name="apple_pay"
+						name="payment_request"
 						onChange={ this.props.onEditField }
 					/>
 					<span>
@@ -182,6 +184,9 @@ class PaymentMethodStripeKeyBasedDialog extends Component {
 							'By using Apple Pay you agree to Stripe and ' + "Apple's terms of service"
 						) }
 					</span>
+					<FormSettingExplanation>
+						{ translate( 'Enables Apple Pay and Chrome Payment Request buttons.' ) }
+					</FormSettingExplanation>
 				</FormFieldset>
 			</div>
 		);

--- a/client/extensions/woocommerce/state/data-layer/payment-methods/index.js
+++ b/client/extensions/woocommerce/state/data-layer/payment-methods/index.js
@@ -26,11 +26,22 @@ export default {
 				settings[ settingKey ] = method.settings[ settingKey ].value;
 			} );
 
-			// Temporary Fix. See https://github.com/woocommerce/woocommerce-gateway-stripe/issues/459
-			// The API default when no choice has been chosen previously is a string 'default'
-			// If that gets passed back to the API, the entire request fails.
+			// Temporary Fix.
+			// If blank values get passed back to the API (see https://github.com/Automattic/wp-calypso/pull/21618#issuecomment-358844061)
+			// the API call will fail. We can remove this hack when we stop the payment method saving code from passing up all fields, and
+			// only pass edited fields. See https://github.com/Automattic/wp-calypso/issues/21670
 			if ( 'stripe' === method.id ) {
-				settings.payment_request_button_theme = 'dark';
+				if ( ! settings.payment_request_button_theme ) {
+					settings.payment_request_button_theme = 'dark';
+				}
+
+				if ( ! settings.payment_request_button_type ) {
+					settings.payment_request_button_type = 'buy';
+				}
+
+				if ( ! settings.payment_request_button_height ) {
+					settings.payment_request_button_height = '44';
+				}
 			}
 
 			const payload = {

--- a/client/extensions/woocommerce/state/data-layer/payment-methods/index.js
+++ b/client/extensions/woocommerce/state/data-layer/payment-methods/index.js
@@ -26,6 +26,13 @@ export default {
 				settings[ settingKey ] = method.settings[ settingKey ].value;
 			} );
 
+			// Temporary Fix. See https://github.com/woocommerce/woocommerce-gateway-stripe/issues/459
+			// The API default when no choice has been chosen previously is a string 'default'
+			// If that gets passed back to the API, the entire request fails.
+			if ( 'stripe' === method.id ) {
+				settings.payment_request_button_theme = 'dark';
+			}
+
 			const payload = {
 				settings,
 				description: method.description,


### PR DESCRIPTION
Apple Pay support still exists in the latest Stripe Gateway plugin, but has been renamed to "Payment Request Buttons" which also includes Chrome Pay support.

This updates the option we are saving, as well as the text to reflect that both will be enabled (which matches what wp-admin does).

It also introduces a temporary API fix that is causing Stripe saves to fail for new stores (which was also reported on our P2 this morning). The value 'default' gets pushed back for one of the settings that is a dropdown and only has three valid options. This one forces a default. I opened an issue at https://github.com/woocommerce/woocommerce-gateway-stripe/issues/459. I'm not sure if we want to offer a drop down option for this either or just stick with the default the gateway sets. I've left it out for now but we can add it in a follow-up.

To Test:
* Make sure you can open up the stripe dialog both in 'key' mode and 'connect' mode.
* Make sure you can toggle the value of the button.
* Make sure your values save.