### PR TITLE
Reader: fix j/k comment loading for full-post

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -98,13 +98,6 @@ class PostCommentList extends React.Component {
 	 * @returns {boolean} - whether or not we should scroll to a comment
 	 */
 	shouldScrollToComment = ( props = this.props ) => {
-		console.error(
-			props.startingCommentId,
-			props.commentsTree[ this.props.startingCommentId ],
-			props.commentsFetchingStatus.hasReceivedBefore,
-			props.commentsFetchingStatus.hasReceivedAfter,
-			! this.hasScrolledToComment
-		);
 		return !! (
 			props.startingCommentId &&
 			props.commentsTree[ this.props.startingCommentId ] &&

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -87,27 +87,6 @@ class PostCommentList extends React.Component {
 		activeEditCommentId: null,
 	};
 
-	/**
-	 * Should we scroll down to a comment? Only if we have satisfied these conditions:
-	 * 1. there is a startingCommentId
-	 * 2. the comment has loaded and is on the DOM
-	 * 3. we haven't already scrolled to it yet
-	 * 4. we have loaded some comments above + below it already (or there is only 1 comment)
-	 *
-	 * @param {object} props - the propes to use when evaluating if window should be scrolled down to a comment.
-	 * @returns {boolean} - whether or not we should scroll to a comment
-	 */
-	shouldScrollToComment = ( props = this.props ) => {
-		return !! (
-			props.startingCommentId &&
-			props.commentsTree[ this.props.startingCommentId ] &&
-			props.commentsFetchingStatus.hasReceivedBefore &&
-			props.commentsFetchingStatus.hasReceivedAfter &&
-			! this.hasScrolledToComment &&
-			window.document.getElementById( `comment-${ props.startingCommentId }` )
-		);
-	};
-
 	shouldFetchInitialComment = ( { startingCommentId, initialComment } ) => {
 		return !! ( startingCommentId && ! initialComment );
 	};
@@ -191,9 +170,11 @@ class PostCommentList extends React.Component {
 		}
 	}
 
+	commentIsOnDOM = commentId => !! window.document.getElementById( `comment-${ commentId }` );
+
 	scrollWhenDOMReady = () => {
 		if ( this.props.startingCommentId && ! this.hasScrolledToComment ) {
-			if ( this.shouldScrollToComment() ) {
+			if ( this.commentIsOnDOM( this.props.startingCommentId ) ) {
 				delay( () => this.scrollToComment(), 50 );
 			}
 			delay( this.scrollWhenDOMReady, 100 );


### PR DESCRIPTION
fixes https://github.com/Automattic/wp-calypso/issues/21543.

> When paging through posts in Full Post using the keyboard shortcuts "j" and "k", the comments do not auto-show.

To Test:
load up https://dserve.a8c.com/?branch=fix/reader/fp-comments and verify comments always load even when using keyboard shortcuts in fullpost mode