### PR TITLE
WordAds Earnings Report: update translation to use component for infobox string

### DIFF
--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -219,9 +219,9 @@ class AdsFormEarnings extends Component {
 		return (
 			<div className="ads__module-content-text module-content-text module-content-text-info">
 				<p>
-					<strong>{ translate( 'Ads Served' ) } </strong>
 					{ translate(
-						'is the number of ads we attempted to display on your site (page impressions x available ad slots).'
+						'{{strong}}Ads Served{{/strong}} is the number of ads we attempted to display on your site (page impressions x available ad slots).',
+						{ components: { strong: <strong /> } }
 					) }
 				</p>
 

--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -220,7 +220,8 @@ class AdsFormEarnings extends Component {
 			<div className="ads__module-content-text module-content-text module-content-text-info">
 				<p>
 					{ translate(
-						'{{strong}}Ads Served{{/strong}} is the number of ads we attempted to display on your site (page impressions x available ad slots).',
+						'{{strong}}Ads Served{{/strong}} is the number of ads we attempted to display on your site ' +
+							'(page impressions x available ad slots).',
 						{ components: { strong: <strong /> } }
 					) }
 				</p>


### PR DESCRIPTION
This is a follow-up to https://github.com/Automattic/wp-calypso/pull/21378

Updating the 'Ads Served' translated sentence to use a component structure so it's more clear for translators.

There should be no visual change, however you can confirm the display is working by visiting http://calypso.localhost:3000/ads/earnings/yoursite.com, where you should see the following infobox:

<img width="736" alt="screen shot 2018-01-17 at 3 38 40 pm" src="https://user-images.githubusercontent.com/2522431/35066406-764d604e-fb9e-11e7-8da9-94d151a8740e.png">


thanks to @akirk for info & help with this