### PR TITLE
Reader: Fix Follow and Settings button alignment

### DIFF
--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -79,17 +79,19 @@ class FeedHeader extends Component {
 								} ) }
 							</span>
 						) }
-						{ feed &&
-							! feed.is_error && (
-								<div className="reader-feed-header__follow-button">
-									<ReaderFollowButton siteUrl={ feed.feed_URL } iconSize={ 24 } />
-								</div>
-							) }
-						{ site &&
-							following &&
-							! isEmailBlocked && (
-								<div className="reader-feed-header__email-settings">{ notificationSettings }</div>
-							) }
+						<div className="reader-feed-header__follow-and-settings">
+							{ feed &&
+								! feed.is_error && (
+									<div className="reader-feed-header__follow-button">
+										<ReaderFollowButton siteUrl={ feed.feed_URL } iconSize={ 24 } />
+									</div>
+								) }
+							{ site &&
+								following &&
+								! isEmailBlocked && (
+									<div className="reader-feed-header__email-settings">{ notificationSettings }</div>
+								) }
+						</div>
 					</div>
 				</div>
 				<Card className="reader-feed-header__site">

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -88,17 +88,20 @@
 	.reader-feed-header__follow-count {
 		color: $gray;
 		font-size: 14px;
+		margin-right: 15px;
 
 		@include breakpoint( "<960px" ) {
 			display: none;
 		}
 	}
 
-	.reader-feed-header__follow-button .follow-button {
+	.reader-feed-header__follow-and-settings {
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-start;
+	}
 
-		@include breakpoint( ">960px" ) {
-			margin-left: 20px;
-		}
+	.reader-feed-header__follow-button .follow-button {
 
 		.follow-button__label {
 
@@ -109,21 +112,6 @@
 			@include breakpoint( "<480px" ) {
 				display: none;
 			}
-		}
-	}
-
-	.reader-feed-header__email-settings {
-		display: flex;
-		justify-content: flex-end;
-		padding-right: 10px;
-		width: 100%;
-
-		@include breakpoint( ">660px" ) {
-			padding-right: 10px;
-		}
-
-		@include breakpoint( "<480px" ) {
-			padding-right: 3px;
 		}
 	}
 

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -59,10 +59,6 @@
 	position: relative;
 		left: -4px;
 		top: 4px;
-
-	@include breakpoint( "<480px" ) {
-		left: 0;
-	}
 }
 
 .reader-site-notification-settings__popout-form-toggle {


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/21551#issuecomment-358285465, @bluefuton noticed that the alignment for the Follow and Settings button is off in some languages.

**Before:**
<img width="354" alt="screen shot 2018-01-17 at 13 04 22" src="https://user-images.githubusercontent.com/17325/35042097-78111806-fb87-11e7-8cae-2b5e21a19014.png">

**After:**
![screenshot 2018-01-17 13 26 31](https://user-images.githubusercontent.com/4924246/35068730-d105cbd2-fb8c-11e7-83ee-7d4c28f15963.png)
