### PR TITLE
Domains: Remove infinite loop when trying to remove redemption product

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -45,7 +45,11 @@ function canRemoveFromCart( cart, cartItem ) {
 		return false;
 	}
 
-	if ( cartItems.hasRenewalItem( cart ) && productsValues.isPrivacyProtection( cartItem ) ) {
+	if (
+		cartItems.hasRenewalItem( cart ) &&
+		( productsValues.isPrivacyProtection( cartItem ) ||
+			productsValues.isDomainRedemption( cartItem ) )
+	) {
 		return false;
 	}
 

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -38,9 +38,6 @@ const productDependencies = {
 		gapps_unlimited: true,
 		private_whois: true,
 	},
-	domain_redemption: {
-		domain: true,
-	},
 	[ domainProductSlugs.TRANSFER_IN ]: {
 		[ domainProductSlugs.TRANSFER_IN_PRIVACY ]: true,
 	},


### PR DESCRIPTION
There was a recursive dependency defined between the domain registration and domain redemption products which caused a stack overflow if someone tried to remove either of those products from the cart (when both were present).
Additionally, it should _not_ have been possible to remove the redemption product from cart in the first place.

### Testing
Try to renew a domain that has expired and has entered redemption period (between 40 and 70 days after expiration). The `Domain Late Renewal` fee should get automatically added to cart and:
 * it should not be possible to remove it from the cart,
 * it should get removed if the domain registration product that it's related to is removed from cart.

Before:
<img width="280" alt="screen shot 2018-01-17 at 23 25 54" src="https://user-images.githubusercontent.com/3392497/35070807-de3ebef6-fbde-11e7-941f-1198ff6f214f.png">

After:
<img width="289" alt="screen shot 2018-01-17 at 23 22 52" src="https://user-images.githubusercontent.com/3392497/35070814-e4bdba7a-fbde-11e7-8cc0-974d6a23fb38.png">



Fixes #13087