### PR TITLE
Add several missing features to treeSelect

### DIFF
--- a/client/lib/tree-select/index.js
+++ b/client/lib/tree-select/index.js
@@ -5,15 +5,20 @@
  */
 import { isObject, some, isFunction } from 'lodash';
 
+const defaultGetCacheKey = ( ...args ) => args.join();
+
 /**
  * Returns a selector that caches values.
  *
  * @param  {Function} getDependents A Function describing the dependent(s) of the selector.
  *                                    Must return an array which gets passed as the first arg to the selector
  * @param  {Function} selector      A standard selector for calculating cached result
+ * @param  {Object}   options       Options bag with additional arguments
+ * @param  {Function} options.getCacheKey
+ *                                  Custom way to compute the cache key from the `args` list
  * @return {Function}               Cached selector
  */
-export default function treeSelect( getDependents, selector ) {
+export default function treeSelect( getDependents, selector, options = {} ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( ! isFunction( getDependents ) || ! isFunction( selector ) ) {
 			throw new TypeError(
@@ -22,13 +27,15 @@ export default function treeSelect( getDependents, selector ) {
 		}
 	}
 
-	const cache = new WeakMap();
+	let cache = new WeakMap();
 
-	return function( state, ...args ) {
+	const { getCacheKey = defaultGetCacheKey } = options;
+
+	const cachedSelector = function( state, ...args ) {
 		const dependents = getDependents( state, ...args );
 
 		if ( process.env.NODE_ENV !== 'production' ) {
-			if ( some( args, isObject ) ) {
+			if ( getCacheKey === defaultGetCacheKey && some( args, isObject ) ) {
 				throw new Error( 'Do not pass objects as arguments to a treeSelector' );
 			}
 		}
@@ -38,7 +45,7 @@ export default function treeSelect( getDependents, selector ) {
 		// garbage collect any values that are based on outdated dependents
 		const leafCache = dependents.reduce( insertDependentKey, cache );
 
-		const key = args.join();
+		const key = getCacheKey( ...args );
 		if ( leafCache.has( key ) ) {
 			return leafCache.get( key );
 		}
@@ -47,7 +54,18 @@ export default function treeSelect( getDependents, selector ) {
 		leafCache.set( key, value );
 		return value;
 	};
+
+	cachedSelector.clearCache = () => {
+		cache = new WeakMap();
+	};
+
+	return cachedSelector;
 }
+
+/*
+ * This object will be used as a WeakMap key if a dependency is a falsy value (null, undefined, ...)
+ */
+const STATIC_FALSY_KEY = {};
 
 /*
  * First tries to get the value for the key.
@@ -57,6 +75,8 @@ export default function treeSelect( getDependents, selector ) {
  * The last map is a regular one because the the key for the last map is the string results of args.join().
  */
 function insertDependentKey( map, key, currentIndex, arr ) {
+	key = key || STATIC_FALSY_KEY;
+
 	if ( map.has( key ) ) {
 		return map.get( key );
 	}

--- a/client/lib/tree-select/index.js
+++ b/client/lib/tree-select/index.js
@@ -56,6 +56,7 @@ export default function treeSelect( getDependents, selector, options = {} ) {
 	};
 
 	cachedSelector.clearCache = () => {
+		// WeakMap doesn't have `clear` method, so we need to recreate it
 		cache = new WeakMap();
 	};
 
@@ -75,13 +76,14 @@ const STATIC_FALSY_KEY = {};
  * The last map is a regular one because the the key for the last map is the string results of args.join().
  */
 function insertDependentKey( map, key, currentIndex, arr ) {
-	key = key || STATIC_FALSY_KEY;
+	const weakMapKey = key || STATIC_FALSY_KEY;
 
-	if ( map.has( key ) ) {
-		return map.get( key );
+	const existingMap = map.get( weakMapKey );
+	if ( existingMap ) {
+		return existingMap;
 	}
 
 	const newMap = currentIndex === arr.length - 1 ? new Map() : new WeakMap();
-	map.set( key, newMap );
+	map.set( weakMapKey, newMap );
 	return newMap;
 }


### PR DESCRIPTION
While trying to use `treeSelect` to optimize `stats/lists/selectors`, I found several missing features that make it impossible to use there.

1. Allow custom `getCacheKey` function. Stats selectors get a `query` object that is both used as a key in serialized form and the selector needs to access its properties. We need to allow object arguments and serialize them properly in `getCacheKey`.

2. Allow clearing the cache by calling `selector.clearCache()`. Used by tests.

3. Don't crash on an invalid `WeakMap` key when `getDependents` returns `null` or other falsy value as one of the dependencies. That happens all the time when the required dependency is being requested from network and its value in Redux state is `null` in the meantime. I consider all falsy values (`null`, `undefined`, `false`, ...) as identical and map them to one `WeakMap` key. Discussion whether that's a good idea or whether we should distinguish between them has a great
bikeshedding potential, but I don't expect any trouble in practice.