### PR TITLE
JPO: Update the tracking object to include hashed userID and siteID_userID properties.

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -111,6 +111,7 @@ export default connect(
 				blog_id: siteId,
 				site_id_type: 'jpo',
 				user_id: 'jpo_user_' + userIdHashed,
+				id: siteId + '_' + userIdHashed,
 				...additionalProperties,
 			} ),
 		...ownProps,

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -21,6 +21,7 @@ import {
 import {
 	getJetpackOnboardingSettings,
 	getRequest,
+	getUnconnectedSite,
 	getUnconnectedSiteIdBySlug,
 } from 'state/selectors';
 import { requestJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
@@ -35,7 +36,6 @@ class JetpackOnboardingMain extends React.PureComponent {
 	};
 
 	// TODO: Add lifecycle methods to redirect if no siteId
-
 	render() {
 		const {
 			isRequestingSettings,
@@ -73,6 +73,9 @@ export default connect(
 		const isRequestingSettings = getRequest( state, requestJetpackOnboardingSettings( siteId ) )
 			.isLoading;
 
+		const site = getUnconnectedSite( state, siteId );
+		const userId = site ? get( site, 'userEmail', null ) : '';
+
 		// Note: here we can select which steps to display, based on user's input
 		const steps = compact( [
 			STEPS.SITE_TITLE,
@@ -89,16 +92,22 @@ export default connect(
 			siteSlug,
 			settings,
 			steps,
+			userId,
 		};
 	},
 	{ recordTracksEvent },
-	( { siteId, ...stateProps }, { recordTracksEvent: recordTracksEventAction }, ownProps ) => ( {
+	(
+		{ siteId, userId, ...stateProps },
+		{ recordTracksEvent: recordTracksEventAction },
+		ownProps
+	) => ( {
 		siteId,
 		...stateProps,
 		recordJpoEvent: ( event, additionalProperties ) =>
 			recordTracksEventAction( event, {
 				blog_id: siteId,
 				site_id_type: 'jpo',
+				user_id: userId,
 				...additionalProperties,
 			} ),
 		...ownProps,

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import sha1 from 'hash.js/lib/hash/sha/1';
 import { compact, get } from 'lodash';
 import { connect } from 'react-redux';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -75,7 +76,9 @@ export default connect(
 
 		const site = getUnconnectedSite( state, siteId );
 		const userId = site ? get( site, 'userEmail', null ) : '';
-
+		const hash = sha1();
+		hash.update( userId );
+		const userIdHashed = hash.digest( 'hex' );
 		// Note: here we can select which steps to display, based on user's input
 		const steps = compact( [
 			STEPS.SITE_TITLE,
@@ -92,12 +95,12 @@ export default connect(
 			siteSlug,
 			settings,
 			steps,
-			userId,
+			userIdHashed,
 		};
 	},
 	{ recordTracksEvent },
 	(
-		{ siteId, userId, ...stateProps },
+		{ siteId, userIdHashed, ...stateProps },
 		{ recordTracksEvent: recordTracksEventAction },
 		ownProps
 	) => ( {
@@ -107,7 +110,7 @@ export default connect(
 			recordTracksEventAction( event, {
 				blog_id: siteId,
 				site_id_type: 'jpo',
-				user_id: userId,
+				user_id: 'jpo_user_' + userIdHashed,
 				...additionalProperties,
 			} ),
 		...ownProps,


### PR DESCRIPTION
We wish to persist non-logged `userId`s across sessions ( triggers of the JPO flow). Default anon IDs provided by Tracks is stored in cookies, which is not a reliable way ( cookies can be cleaned and do store this info across devices). This PR uses hashed user emails as `userID`.

`siteID_userID ` will come in handy to track user actions on a specific site and being able to distinguish between actions on different sites. This event cannot be constructed with `siteID` and `userID` alone and needs to be created explicitly.

**To test:**
* follow instructions on https://github.com/Automattic/wp-calypso/pull/21370
* verify that the tracking objects contains additional fields: `user_id: 'jpo_user_userIdHashed` and 
`id: siteId_userIdHashed`, where `siteId` is a site id as passed from .org site and `userIdHashed` a hash generated from the email associated with your sandbox.