### PR TITLE
Framework: bump webpack to 3.10

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -48,8 +48,8 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.0.0-beta.37",
-      "integrity": "sha512-LIpcKm+2otOOvOvhCbD6wkNYi8aUwHk73uWR+hxBdW2EFht5D0QX89n4me8nyeNGWr5zC3Pvmjq+9MvUof+jkg==",
+      "version": "7.0.0-beta.38",
+      "integrity": "sha512-JNHofQND7Iiuy3f6RXSillN1uBe87DAp+1ktsBfSxfL3xWeGFyJC9jH5zu2zs7eqVGp2qXWvJZFiJIwOYnaCQw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
@@ -482,7 +482,7 @@
       "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000790",
+        "caniuse-db": "1.0.30000793",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -755,12 +755,12 @@
       }
     },
     "babel-jest": {
-      "version": "22.0.6",
-      "integrity": "sha512-HkPxQ75YfYLjdaRTQn+a6fgHExPqsBLw9Gr6vDasylZBoiSEwhJUWE4Gh7mh4IC9zF/I+93mgTi5KsUjwOeeMA==",
+      "version": "22.1.0",
+      "integrity": "sha512-5pKRFTlDr+x1JESNRd5leqvxEJk3dRwVvIXikB6Lr4BWZbBppk1Wp+BLUzxWL8tM+EYGLCWgfqkD35Sft8r8Lw==",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.5",
-        "babel-preset-jest": "22.0.6"
+        "babel-preset-jest": "22.1.0"
       }
     },
     "babel-loader": {
@@ -821,8 +821,8 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "22.0.6",
-      "integrity": "sha512-KiAmvs8r+lJVzPfnWor4ftrDjvq3CRonbU5lYOqQLi1wXNRoGC21N1Yak6qGXjdpyz3H9plZJPcT7o14RyCs5g==",
+      "version": "22.1.0",
+      "integrity": "sha512-Og5sjbOZc4XUI3njqwYhS6WLTlHQUJ/y5+dOqmst8eHrozYZgT4OMzAaYaxhk75c2fBVYwn7+mNEN97XDO7cOw==",
       "dev": true
     },
     "babel-plugin-jscript": {
@@ -1343,22 +1343,22 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.11.1",
+        "browserslist": "2.11.3",
         "invariant": "2.2.2",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "2.11.1",
-          "integrity": "sha512-Gp4oJOQOby5TpOJJuUtCrGE0KSJOUYVa/I+/3eD/TRWEK8jqZuJPAK1t+VuG6jp0keudrqtxlH4MbYbmylun9g==",
+          "version": "2.11.3",
+          "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "requires": {
-            "caniuse-lite": "1.0.30000790",
-            "electron-to-chromium": "1.3.30"
+            "caniuse-lite": "1.0.30000792",
+            "electron-to-chromium": "1.3.31"
           }
         },
         "semver": {
-          "version": "5.4.1",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+          "version": "5.5.0",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         }
       }
     },
@@ -1425,11 +1425,11 @@
       }
     },
     "babel-preset-jest": {
-      "version": "22.0.6",
-      "integrity": "sha512-NZEqqliZAlDO5mOta5SQPwt14S+KxLYbdTRMvSmpaGcvEnStOWEBOPNmdYrVxP7j7MgTQwP+bUstiaxMc1mrXQ==",
+      "version": "22.1.0",
+      "integrity": "sha512-ps2UYz7IQpP2IgZ41tJjUuUDTxJioprHXD8fi9DoycKDGNqB3nAX/ggy1S3plaQd43ktBvMS1FkkyGNoBujFpg==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "22.0.6",
+        "babel-plugin-jest-hoist": "22.1.0",
         "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
@@ -1696,7 +1696,7 @@
         "bytes": "2.4.0",
         "content-type": "1.0.4",
         "debug": "2.6.7",
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "http-errors": "1.6.2",
         "iconv-lite": "0.4.15",
         "on-finished": "2.3.0",
@@ -1853,7 +1853,7 @@
       "version": "1.3.6",
       "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
       "requires": {
-        "caniuse-db": "1.0.30000790"
+        "caniuse-db": "1.0.30000793"
       }
     },
     "bser": {
@@ -1970,12 +1970,12 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000790",
-      "integrity": "sha1-qAI+brn+nA7z1gtEJ84QTqh9OBw="
+      "version": "1.0.30000793",
+      "integrity": "sha1-PADGbkI6ehkHx92Wdpp4sq+opy4="
     },
     "caniuse-lite": {
-      "version": "1.0.30000790",
-      "integrity": "sha1-yVTMp4AEbzTEtDPTJO9Bnh21GlM="
+      "version": "1.0.30000792",
+      "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI="
     },
     "cardinal": {
       "version": "1.0.0",
@@ -2931,7 +2931,7 @@
       "version": "1.0.0",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "d3-array": {
@@ -3200,8 +3200,8 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
-      "version": "1.1.1",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+      "version": "1.1.2",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "des.js": {
       "version": "1.0.0",
@@ -3295,7 +3295,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000790",
+        "caniuse-db": "1.0.30000793",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -3488,16 +3488,9 @@
       "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
       "dev": true
     },
-    "electron-releases": {
-      "version": "2.1.0",
-      "integrity": "sha512-cyKFD1bTE/UgULXfaueIN1k5EPFzs+FRc/rvCY5tIynefAPqopQEgjr0EzY+U3Dqrk/G4m9tXSPuZ77v6dL/Rw=="
-    },
     "electron-to-chromium": {
-      "version": "1.3.30",
-      "integrity": "sha512-zx1Prv7kYLfc4OA60FhxGbSo4qrEjgSzpo1/37i7l9ltXPYOoQBtjQxY9KmsgfHnBxHlBGXwLlsbt/gub1w5lw==",
-      "requires": {
-        "electron-releases": "2.1.0"
-      }
+      "version": "1.3.31",
+      "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA=="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -3807,8 +3800,8 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.37",
-      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
+      "version": "0.10.38",
+      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
       "requires": {
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
@@ -3823,7 +3816,7 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-symbol": "3.1.1"
       }
     },
@@ -3832,7 +3825,7 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -3849,7 +3842,7 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -3860,7 +3853,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "es6-templates": {
@@ -3876,7 +3869,7 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -4317,7 +4310,7 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "event-stream": {
@@ -4378,6 +4371,11 @@
       "version": "1.2.2",
       "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
     },
+    "exit": {
+      "version": "0.1.2",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
     "exit-hook": {
       "version": "1.1.1",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
@@ -4410,16 +4408,16 @@
       }
     },
     "expect": {
-      "version": "22.0.6",
-      "integrity": "sha512-8n81n5hW60Wr934QpBz0JyFr084z30rEzMIxbCekWnCZ9kjUtClNBCQjKLA9YaVQepPxHHvc4b7m/B/H0CSpsA==",
+      "version": "22.1.0",
+      "integrity": "sha512-8K+8TjNnZq73KYtqNWKWTbYbN8z4loeL+Pn2bqpmtTdBtLNXJtpz9vkUcQlFsgKMDRA3VM8GXRA6qbV/oBF7Bw==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
-        "jest-diff": "22.0.6",
-        "jest-get-type": "22.0.6",
-        "jest-matcher-utils": "22.0.6",
-        "jest-message-util": "22.0.6",
-        "jest-regex-util": "22.0.6"
+        "jest-diff": "22.1.0",
+        "jest-get-type": "22.1.0",
+        "jest-matcher-utils": "22.1.0",
+        "jest-message-util": "22.1.0",
+        "jest-regex-util": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6541,6 +6539,10 @@
         "statuses": "1.4.0"
       },
       "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+        },
         "inherits": {
           "version": "2.0.3",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
@@ -6660,6 +6662,15 @@
     "immutable": {
       "version": "3.7.6",
       "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
+    },
+    "import-local": {
+      "version": "1.0.0",
+      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
+      }
     },
     "imports-loader": {
       "version": "0.6.5",
@@ -7243,12 +7254,12 @@
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "istanbul-lib-coverage": "1.1.1",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       },
       "dependencies": {
         "semver": {
-          "version": "5.4.1",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "version": "5.5.0",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         }
       }
@@ -7318,7 +7329,7 @@
       "integrity": "sha512-90H1wLqiNR3tLhQUgwhC6GWHfRCG+Da14m7vxD608Mt/QTKR0TA751D+QH09x5bvcrLfvxLtxArtA0VEC0ORow==",
       "dev": true,
       "requires": {
-        "jest-cli": "22.0.6"
+        "jest-cli": "22.1.2"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -7393,34 +7404,36 @@
           "dev": true
         },
         "jest-cli": {
-          "version": "22.0.6",
-          "integrity": "sha512-0hqadrUDDj4FDmrODXvLXCFwHGMegH+2fZ6x3Y0SyKw7ODJ91+2WeVCQwQRXaj6v9hmygjsbfdGo3tYIeOZVhw==",
+          "version": "22.1.2",
+          "integrity": "sha512-t0W04YJBK5pLjp9AroUVTWE46ERh2pNLTVqJzS6nOwq6pn1/wAjCBNeE+HmK1uKVjNPGmDMhoqxxV9FFBFEjyA==",
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
             "chalk": "2.3.0",
+            "exit": "0.1.2",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
+            "import-local": "1.0.0",
             "is-ci": "1.1.0",
             "istanbul-api": "1.2.1",
             "istanbul-lib-coverage": "1.1.1",
             "istanbul-lib-instrument": "1.9.1",
             "istanbul-lib-source-maps": "1.2.2",
-            "jest-changed-files": "22.0.6",
-            "jest-config": "22.0.6",
-            "jest-environment-jsdom": "22.0.6",
-            "jest-get-type": "22.0.6",
-            "jest-haste-map": "22.0.6",
-            "jest-message-util": "22.0.6",
-            "jest-regex-util": "22.0.6",
-            "jest-resolve-dependencies": "22.0.6",
-            "jest-runner": "22.0.6",
-            "jest-runtime": "22.0.6",
-            "jest-snapshot": "22.0.6",
-            "jest-util": "22.0.6",
-            "jest-worker": "22.0.6",
+            "jest-changed-files": "22.1.0",
+            "jest-config": "22.1.2",
+            "jest-environment-jsdom": "22.1.2",
+            "jest-get-type": "22.1.0",
+            "jest-haste-map": "22.1.0",
+            "jest-message-util": "22.1.0",
+            "jest-regex-util": "22.1.0",
+            "jest-resolve-dependencies": "22.1.0",
+            "jest-runner": "22.1.2",
+            "jest-runtime": "22.1.2",
+            "jest-snapshot": "22.1.2",
+            "jest-util": "22.1.2",
+            "jest-worker": "22.1.0",
             "micromatch": "2.3.11",
-            "node-notifier": "5.1.2",
+            "node-notifier": "5.2.1",
             "realpath-native": "1.0.0",
             "rimraf": "2.6.2",
             "slash": "1.0.0",
@@ -7500,29 +7513,29 @@
       }
     },
     "jest-changed-files": {
-      "version": "22.0.6",
-      "integrity": "sha512-eRnDzJm8gm0UsSV6H0LvIi5wANWDXmzKNglAl6zFRUv1K9FXTsqInE4zFWUzerGZv7LIvAYaVVAzyMrttbpcKQ==",
+      "version": "22.1.0",
+      "integrity": "sha512-NGc5HF3zXaMMph1L3HwPw7zVu0uAad2CZ+5QYQaP9QzB9jBioukulg2vcy7gdJRfWAr3D8EGlu4jfUHOtLNVmQ==",
       "dev": true,
       "requires": {
         "throat": "4.1.0"
       }
     },
     "jest-config": {
-      "version": "22.0.6",
-      "integrity": "sha512-wwt7ZqQTiy+xDddFU868+RfZ0lEJdxu6q1ErT/b1qknBZSIKjW5eXp6fyITk/xzwQZ4Q2YhlMEjz0NXPCBNLwg==",
+      "version": "22.1.2",
+      "integrity": "sha512-nhE4OZn+PvB4zyogvN5zK2+h+FIAgO7uEzH7eHwuJtBpRSBci6DLeMEIMC9ztJTOvg/wLySAm4WRqdyAehRCzw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "glob": "7.1.2",
-        "jest-environment-jsdom": "22.0.6",
-        "jest-environment-node": "22.0.6",
-        "jest-get-type": "22.0.6",
-        "jest-jasmine2": "22.0.6",
-        "jest-regex-util": "22.0.6",
-        "jest-resolve": "22.0.6",
-        "jest-util": "22.0.6",
-        "jest-validate": "22.0.6",
-        "pretty-format": "22.0.6"
+        "jest-environment-jsdom": "22.1.2",
+        "jest-environment-node": "22.1.2",
+        "jest-get-type": "22.1.0",
+        "jest-jasmine2": "22.1.2",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve": "22.1.0",
+        "jest-util": "22.1.2",
+        "jest-validate": "22.1.2",
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7577,14 +7590,14 @@
       }
     },
     "jest-diff": {
-      "version": "22.0.6",
-      "integrity": "sha512-wwyXqHgTNX17OaSVJFuHdpT0j+B/ygi4DzKqrZDpTt6oIJfv+jOYTjxBL3t1NlyQuaDWSdByfL05TDoGnJuO0Q==",
+      "version": "22.1.0",
+      "integrity": "sha512-lowdbU/dzXh+2/MR5QcvU5KPNkO4JdAEYw0PkQCbIQIuy5+g3QZBuVhWh8179Fmpg4CQrz1WgoK/yQHDCHbqqw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "diff": "3.4.0",
-        "jest-get-type": "22.0.6",
-        "pretty-format": "22.0.6"
+        "jest-get-type": "22.1.0",
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7634,22 +7647,22 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "22.0.6",
-      "integrity": "sha512-a0YrUxW49YDMoj+LOgPZMhyh/dGUv6th4TbDfX4O/DVjkUGLzc4c6a0bCxcUZSkDuocXbxBYW8TAPIt84/OF1w==",
+      "version": "22.1.2",
+      "integrity": "sha512-mGcuJPJ4+F+GJaWw+YZVMcTWFXxB+FR2E1CztnC85kTbVbLv2wWKCn91KgxstYf2E3/OQ26WICngnOBISZiEXQ==",
       "dev": true,
       "requires": {
-        "jest-mock": "22.0.6",
-        "jest-util": "22.0.6",
+        "jest-mock": "22.1.0",
+        "jest-util": "22.1.2",
         "jsdom": "11.5.1"
       }
     },
     "jest-environment-node": {
-      "version": "22.0.6",
-      "integrity": "sha512-taEm3EjDx6B1bQKwOwnctp6ddajJIwW2qfRLfEpYNcKxthO4Y2b79jTGJPGYkwpXgGZBN9cYmBuCU8saguEXQw==",
+      "version": "22.1.2",
+      "integrity": "sha512-khr801nOSK380J97T2T0kMABJbSMOl8Mn3xwP0PiaCoaAaYlQ4XB+x+aXsVNPUH4FOOZq9ojytu84EdWChR+Hg==",
       "dev": true,
       "requires": {
-        "jest-mock": "22.0.6",
-        "jest-util": "22.0.6"
+        "jest-mock": "22.1.0",
+        "jest-util": "22.1.2"
       }
     },
     "jest-file-exists": {
@@ -7658,26 +7671,26 @@
       "dev": true
     },
     "jest-get-type": {
-      "version": "22.0.6",
-      "integrity": "sha512-NGiuzfSXssBIN5PGAmKPWk29/eJlv5gVhD7un9Dcr9w+rJXAOGR/Ggx3HKJ7IArkIq0YCN4lFdbyHpB42NMUWw==",
+      "version": "22.1.0",
+      "integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "22.0.6",
-      "integrity": "sha512-Y/9MKcpI6AMobdHDIHOvz/0OiXiZNV5Uy997EyzRFWDb8EZTP8WD7nEqVCgG/4ned/DmxRnoCaHIZA2vS0/Vtg==",
+      "version": "22.1.0",
+      "integrity": "sha512-vETdC6GboGlZX6+9SMZkXtYRQSKBbQ47sFF7NGglbMN4eyIZBODply8rlcO01KwBiAeiNCKdjUyfonZzJ93JEg==",
       "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
-        "jest-docblock": "22.0.6",
-        "jest-worker": "22.0.6",
+        "jest-docblock": "22.1.0",
+        "jest-worker": "22.1.0",
         "micromatch": "2.3.11",
         "sane": "2.2.0"
       },
       "dependencies": {
         "jest-docblock": {
-          "version": "22.0.6",
-          "integrity": "sha512-evcMu0AdVy1jchCz9ngB+PHxQchvHckInpP0OSjwyIji6UEpRU1m9XULpeIWp2D3odnIbLM/egeLEmRbQNhvJA==",
+          "version": "22.1.0",
+          "integrity": "sha512-/+OGgBVRJb5wCbXrB1LQvibQBz2SdrvDdKRNzY1gL+OISQJZCR9MOewbygdT5rVzbbkfhC4AR2x+qWmNUdJfjw==",
           "dev": true,
           "requires": {
             "detect-newline": "2.1.0"
@@ -7686,21 +7699,21 @@
       }
     },
     "jest-jasmine2": {
-      "version": "22.0.6",
-      "integrity": "sha512-zc64Y0g27wlEjYbt0aNgGoER5lSp942uLvDAJXTBr4SKnyjjm4Lr4g+GfbJuR3WSlfO3T+MXcjQbvK0+sWaxeA==",
+      "version": "22.1.2",
+      "integrity": "sha512-z8X41QkqJovovpeO0e6+wutZnJmjUC0G0ZopKhPQ5JIobxbU9AqOc402vdKhEYnrjaw8WszR5+HU3EL08Arguw==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.3.0",
         "co": "4.6.0",
-        "expect": "22.0.6",
+        "expect": "22.1.0",
         "graceful-fs": "4.1.11",
         "is-generator-fn": "1.0.0",
-        "jest-diff": "22.0.6",
-        "jest-matcher-utils": "22.0.6",
-        "jest-message-util": "22.0.6",
-        "jest-snapshot": "22.0.6",
-        "source-map-support": "0.5.0"
+        "jest-diff": "22.1.0",
+        "jest-matcher-utils": "22.1.0",
+        "jest-message-util": "22.1.0",
+        "jest-snapshot": "22.1.2",
+        "source-map-support": "0.5.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7742,8 +7755,8 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.0",
-          "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+          "version": "0.5.1",
+          "integrity": "sha512-EZNecLNrsdRk9fcdOcjjy+Z/id7cr68sdmsYtR1gA45oQ81Ccea0UvM7DdSRblO0Ie5zWX31bvJTC7Y3QZVujg==",
           "dev": true,
           "requires": {
             "source-map": "0.6.1"
@@ -7768,21 +7781,21 @@
       }
     },
     "jest-leak-detector": {
-      "version": "22.0.6",
-      "integrity": "sha512-Ll8C0iH8Un+liiOnnp18WTVScvhSr6GUFrhFa4p46peFWg8rgh4MuJvG7A1Dwpa00ZHV5W5kzVViFaedDWxJMw==",
+      "version": "22.1.0",
+      "integrity": "sha512-8QsCWkncWAqdvrXN4yXQp9vgWF6CT3RkRey+d06SIHX913uXzAJhJdZyo6eE+uHVYMxUbxqW93npbUFhAR0YxA==",
       "dev": true,
       "requires": {
-        "pretty-format": "22.0.6"
+        "pretty-format": "22.1.0"
       }
     },
     "jest-matcher-utils": {
-      "version": "22.0.6",
-      "integrity": "sha512-AvuW0IpyB3lcUrDW3nj9lMP/pJw3t97BDPj3HcEncx8MAg+DS216w14H9AuCYrhYBgqRE9UqrKomy7ey3X6Y9A==",
+      "version": "22.1.0",
+      "integrity": "sha512-Zn1OD9wVjILOdvRxgAnqiCN36OX6KJx+P2FHN+3lzQ0omG2N2OAguxE1QXuJJneG2yndlkXjekXFP254c0cSpw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-get-type": "22.0.6",
-        "pretty-format": "22.0.6"
+        "jest-get-type": "22.1.0",
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7896,11 +7909,11 @@
       }
     },
     "jest-message-util": {
-      "version": "22.0.6",
-      "integrity": "sha512-JKGctxpAsEfK5Ywc6n8kGewSzGOhJYg2GZWqIKjaGKpEWgO1iex8qsGkxPDGKiv1EivLs7yuGRBhwnCd8eTUwA==",
+      "version": "22.1.0",
+      "integrity": "sha512-kftcoawOeOVUGuGWmMupJt7FGLK1pqOrh02FlJwtImmPGZ2yTWCTx2D+N/g95qD2jCbQ/ntH1goBixhAIIxL+g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.37",
+        "@babel/code-frame": "7.0.0-beta.38",
         "chalk": "2.3.0",
         "micromatch": "2.3.11",
         "slash": "1.0.0",
@@ -7946,18 +7959,18 @@
       }
     },
     "jest-mock": {
-      "version": "22.0.6",
-      "integrity": "sha512-RBnO1ZFuzPGss/hPdzPawoqGrcF1igL6yfd6OwKszuRv3SviEZaGye/T/Pev8tU9Ye7uR8bfLeNQbe1qi5w0YQ==",
+      "version": "22.1.0",
+      "integrity": "sha512-gL3/C8ds6e1PWiOTsV7sIejPP/ECYQgDbwMzbNCc+ZFPuPH3EpwsVLGmQqPK6okgnDagimbbQnss3kPJ8HCMtA==",
       "dev": true
     },
     "jest-regex-util": {
-      "version": "22.0.6",
-      "integrity": "sha512-VfgVLmPv1Mmu87P53vZK0XdQlioVcw7MjAxiIHS9/QruNqbDH3fPfeqL3YkJI283CmkkxmQNZOCAYinlwJTJfA==",
+      "version": "22.1.0",
+      "integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "22.0.6",
-      "integrity": "sha512-T7gjP8YijRTRxMtRN5j1QELa/casAUy6Y7geQKQE5impkVibCFt9UImaDtYYfiQ+zJlJ5uIrDyaI+L5YVc8jvA==",
+      "version": "22.1.0",
+      "integrity": "sha512-hp4Od9YNEv3A/xNN5pPlNjMuisdZyg3u+XAZOqnGxWPVqnbjvEZ25U2HmYM0eLhOzVTHAAsNnAA8HWDzY1Cwjw==",
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
@@ -8003,33 +8016,34 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "22.0.6",
-      "integrity": "sha512-JVbG4cE6N/1jTjut9XqveGqUddrHVlD7fJpIh5tH41ML+GjjDk8WwmcoA2RykXYSbt0vdUrAOV/FXVIgHTgHfw==",
+      "version": "22.1.0",
+      "integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
       "dev": true,
       "requires": {
-        "jest-regex-util": "22.0.6"
+        "jest-regex-util": "22.1.0"
       }
     },
     "jest-runner": {
-      "version": "22.0.6",
-      "integrity": "sha512-xFXmP6T6IDIZYyieBJNZeyQcowCcaFXmtUra+yJJYpWp/zijGRpf8BPExbUeUM6Es59yTFnyepZrWXwZ5l1fRQ==",
+      "version": "22.1.2",
+      "integrity": "sha512-ib7Rld/2wjNWs3voI8nxx1wSyB6/UFplEW6c3faWCqhPrC01UUIHLUgSOpUKdhj+LOlB1EOS9r4+r99xJHJS4g==",
       "dev": true,
       "requires": {
-        "jest-config": "22.0.6",
-        "jest-docblock": "22.0.6",
-        "jest-haste-map": "22.0.6",
-        "jest-jasmine2": "22.0.6",
-        "jest-leak-detector": "22.0.6",
-        "jest-message-util": "22.0.6",
-        "jest-runtime": "22.0.6",
-        "jest-util": "22.0.6",
-        "jest-worker": "22.0.6",
+        "exit": "0.1.2",
+        "jest-config": "22.1.2",
+        "jest-docblock": "22.1.0",
+        "jest-haste-map": "22.1.0",
+        "jest-jasmine2": "22.1.2",
+        "jest-leak-detector": "22.1.0",
+        "jest-message-util": "22.1.0",
+        "jest-runtime": "22.1.2",
+        "jest-util": "22.1.2",
+        "jest-worker": "22.1.0",
         "throat": "4.1.0"
       },
       "dependencies": {
         "jest-docblock": {
-          "version": "22.0.6",
-          "integrity": "sha512-evcMu0AdVy1jchCz9ngB+PHxQchvHckInpP0OSjwyIji6UEpRU1m9XULpeIWp2D3odnIbLM/egeLEmRbQNhvJA==",
+          "version": "22.1.0",
+          "integrity": "sha512-/+OGgBVRJb5wCbXrB1LQvibQBz2SdrvDdKRNzY1gL+OISQJZCR9MOewbygdT5rVzbbkfhC4AR2x+qWmNUdJfjw==",
           "dev": true,
           "requires": {
             "detect-newline": "2.1.0"
@@ -8038,21 +8052,22 @@
       }
     },
     "jest-runtime": {
-      "version": "22.0.6",
-      "integrity": "sha512-DM6fQb+ivYWkMCxTEOCV746i0ZoeNz+ksmar7pulJ4OT2wUG2P8f1GsXbfzM+AtoYMDfo/jPXSVmuudcAnppaw==",
+      "version": "22.1.2",
+      "integrity": "sha512-wlYWwpI0loqdrp+h0bBB1Rpn2UqLgKMgYZqQBVxg9Dx0OqPNtVkqSGkINlYv5Jkf1eNCXDbv5JEvdlhiy9fh7Q==",
       "dev": true,
       "requires": {
         "babel-core": "6.25.0",
-        "babel-jest": "22.0.6",
+        "babel-jest": "22.1.0",
         "babel-plugin-istanbul": "4.1.5",
         "chalk": "2.3.0",
         "convert-source-map": "1.5.1",
+        "exit": "0.1.2",
         "graceful-fs": "4.1.11",
-        "jest-config": "22.0.6",
-        "jest-haste-map": "22.0.6",
-        "jest-regex-util": "22.0.6",
-        "jest-resolve": "22.0.6",
-        "jest-util": "22.0.6",
+        "jest-config": "22.1.2",
+        "jest-haste-map": "22.1.0",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve": "22.1.0",
+        "jest-util": "22.1.2",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
         "realpath-native": "1.0.0",
@@ -8200,16 +8215,16 @@
       }
     },
     "jest-snapshot": {
-      "version": "22.0.6",
-      "integrity": "sha512-s9arPbLVe1SHJ2uw9F3cPYBQvWF0o9ppn7mIUWiVrAc7eNb9xhRBDk7DSO/erF61dAGnIrI4KXwhiQ97IjkSog==",
+      "version": "22.1.2",
+      "integrity": "sha512-45co/M0gTe6Y6yHaJLydEZKHOFpFHESLah40jW35DWd3pd7q188bsi0oUY4Kls7PDXUamvTWuTKTZXCtzwSvCw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-diff": "22.0.6",
-        "jest-matcher-utils": "22.0.6",
+        "jest-diff": "22.1.0",
+        "jest-matcher-utils": "22.1.0",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
-        "pretty-format": "22.0.6"
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8251,16 +8266,16 @@
       }
     },
     "jest-util": {
-      "version": "22.0.6",
-      "integrity": "sha512-Je0ZVGGsnbPc6VNPFeTBDz1TbylFXshsLJkkZWLEPU+G7rn/8Xb2H+tqLr22+iaxuEBDyw9zgbZ9pcDElAykXw==",
+      "version": "22.1.2",
+      "integrity": "sha512-z/7pZG4b+uXWRLWJnJ8iZKfiMBONB3KBWJQlximgRBBsFM7bX3sLd09Dzy6lgwyUUTa286XSJP59d8ux5V3D1g==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.3.0",
         "graceful-fs": "4.1.11",
         "is-ci": "1.1.0",
-        "jest-message-util": "22.0.6",
-        "jest-validate": "22.0.6",
+        "jest-message-util": "22.1.0",
+        "jest-validate": "22.1.2",
         "mkdirp": "0.5.1"
       },
       "dependencies": {
@@ -8308,14 +8323,14 @@
       }
     },
     "jest-validate": {
-      "version": "22.0.6",
-      "integrity": "sha512-vTNjS2ZwD+QK2k18p5KR/l2+QwkbCYmGPpbYBVC2pYnMUEaEupwe7fyJzGbeMD1BnoNd2E6ufCzjGWDU5SNI5Q==",
+      "version": "22.1.2",
+      "integrity": "sha512-IjvMsV7GW5ghg5PTQvU23zJqTBmnq10eY+4n47awUeXYEGH27N+JajFPOg6tsN+OYvEPsohPquKoqQ5XBVs/ow==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-get-type": "22.0.6",
+        "jest-get-type": "22.1.0",
         "leven": "2.1.0",
-        "pretty-format": "22.0.6"
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8362,8 +8377,8 @@
       }
     },
     "jest-worker": {
-      "version": "22.0.6",
-      "integrity": "sha512-4GlBXpqO/RrmaNF9unPkwNbqlQqR0VtYX4QpYfSUzxBEuuRT0w7PyKj99k15KUC2gRNlNK/eN/bY81LAeW1NEg==",
+      "version": "22.1.0",
+      "integrity": "sha512-ezLueYAQowk5N6g2J7bNZfq4NWZvMNB5Qd24EmOZLcM5SXTdiFvxykZIoNiMj9C98cCbPaojX8tfR7b1LJwNig==",
       "dev": true,
       "requires": {
         "merge-stream": "1.0.1"
@@ -8379,8 +8394,8 @@
       "integrity": "sha1-3Yt0J4snEC0p32Pq4oMIqM+htYM="
     },
     "js-base64": {
-      "version": "2.4.0",
-      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA=="
+      "version": "2.4.1",
+      "integrity": "sha512-2h586r2I/CqU7z1aa1kBgWaVAXWAZK+zHnceGi/jFgn7+7VSluxYer/i3xOZVearCxxXvyDkLtTBo+OeJCA3kA=="
     },
     "js-stringify": {
       "version": "1.0.2",
@@ -9617,7 +9632,7 @@
         "from2": "2.3.0",
         "parallel-transform": "1.1.0",
         "pump": "1.0.3",
-        "pumpify": "1.3.6",
+        "pumpify": "1.4.0",
         "stream-each": "1.2.2",
         "through2": "2.0.3"
       },
@@ -9876,12 +9891,12 @@
       "version": "2.1.2",
       "integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
       "requires": {
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       },
       "dependencies": {
         "semver": {
-          "version": "5.4.1",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+          "version": "5.5.0",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         }
       }
     },
@@ -9979,7 +9994,7 @@
         "querystring-es3": "0.2.1",
         "readable-stream": "2.3.3",
         "stream-browserify": "2.0.1",
-        "stream-http": "2.7.2",
+        "stream-http": "2.8.0",
         "string_decoder": "1.0.3",
         "timers-browserify": "2.0.4",
         "tty-browserify": "0.0.0",
@@ -10020,19 +10035,19 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "5.1.2",
-      "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+      "version": "5.2.1",
+      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "dev": true,
       "requires": {
         "growly": "1.3.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "shellwords": "0.1.1",
         "which": "1.3.0"
       },
       "dependencies": {
         "semver": {
-          "version": "5.4.1",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "version": "5.5.0",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
         }
       }
@@ -10949,7 +10964,7 @@
       "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.4.0",
+        "js-base64": "2.4.1",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
@@ -11230,7 +11245,7 @@
         "npmlog": "4.1.2",
         "os-homedir": "1.0.2",
         "pump": "1.0.3",
-        "rc": "1.2.3",
+        "rc": "1.2.4",
         "simple-get": "1.4.3",
         "tar-fs": "1.16.0",
         "tunnel-agent": "0.6.0",
@@ -11456,8 +11471,8 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "22.0.6",
-      "integrity": "sha512-U7vmPaahWJapEjMbqvHK4D0k7Cux2S1qHsXI5UHwdRK4gidtT0fFwFU3nutg3Ho8b7s5ikN0HVYNaHOjpRiY4g==",
+      "version": "22.1.0",
+      "integrity": "sha512-0HHR5hCmjDGU4sez3w5zRDAAwn7V0vT4SgPiYPZ1XDm5sT3Icb+Bh+fsOP3+Y3UwPjMr7TbRj+L7eQyMkPAxAw==",
       "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
@@ -11712,8 +11727,8 @@
       }
     },
     "pumpify": {
-      "version": "1.3.6",
-      "integrity": "sha512-BurGAcvezsINL5US9T9wGHHcLNrG6MCp//ECtxron3vcR+Rfx5Anqq7HbZXNJvFQli8FGVsWCAvywEJFV5Hx/Q==",
+      "version": "1.4.0",
+      "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
       "requires": {
         "duplexify": "3.5.3",
         "inherits": "2.0.3",
@@ -11854,8 +11869,8 @@
       }
     },
     "rc": {
-      "version": "1.2.3",
-      "integrity": "sha1-UVdakA+N1oOBxxC0cSwhVMPiA1s=",
+      "version": "1.2.4",
+      "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.5",
@@ -13027,7 +13042,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.3"
+        "rc": "1.2.4"
       }
     },
     "regjsgen": {
@@ -13131,7 +13146,7 @@
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "qs": {
@@ -13139,8 +13154,8 @@
           "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
         },
         "uuid": {
-          "version": "3.1.0",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+          "version": "3.2.1",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         }
       }
     },
@@ -13194,6 +13209,21 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
         "path-parse": "1.0.5"
+      }
+    },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
       }
     },
     "resolve-from": {
@@ -13526,7 +13556,7 @@
       "version": "0.2.3",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "requires": {
-        "js-base64": "2.4.0",
+        "js-base64": "2.4.1",
         "source-map": "0.4.4"
       },
       "dependencies": {
@@ -13644,7 +13674,7 @@
           "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
           "requires": {
             "debug": "2.2.0",
-            "depd": "1.1.1",
+            "depd": "1.1.2",
             "destroy": "1.0.4",
             "escape-html": "1.0.3",
             "etag": "1.7.0",
@@ -14101,8 +14131,8 @@
       }
     },
     "stream-http": {
-      "version": "2.7.2",
-      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+      "version": "2.8.0",
+      "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
       "requires": {
         "builtin-status-codes": "3.0.0",
         "inherits": "2.0.1",
@@ -15012,14 +15042,14 @@
         "find-cache-dir": "1.0.0",
         "schema-utils": "0.3.0",
         "source-map": "0.5.7",
-        "uglify-es": "3.3.5",
+        "uglify-es": "3.3.7",
         "webpack-sources": "1.1.0",
         "worker-farm": "1.5.2"
       },
       "dependencies": {
         "commander": {
-          "version": "2.12.2",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+          "version": "2.13.0",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
         },
         "source-list-map": {
           "version": "2.0.0",
@@ -15030,10 +15060,10 @@
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "uglify-es": {
-          "version": "3.3.5",
-          "integrity": "sha512-7IvaFuYtfbcXm0fGb13mmRYVQdzQDXETAtvYHbCDPt2V88Y8l2HaULOyW6ueoYA0JhGIcLK7dtHkDcBWySqnBw==",
+          "version": "3.3.7",
+          "integrity": "sha512-fGMnE6SsDRsCjxm78C+lv7MuXsse/dtF7QuTUT43BYf4jlxPjd+XTnGB8YjaCQJ3sv2LT4zk0mwpp9+QJocU6g==",
           "requires": {
-            "commander": "2.12.2",
+            "commander": "2.13.0",
             "source-map": "0.6.1"
           },
           "dependencies": {
@@ -15505,8 +15535,8 @@
       "dev": true
     },
     "webpack": {
-      "version": "3.8.1",
-      "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
+      "version": "3.10.0",
+      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
       "requires": {
         "acorn": "5.3.0",
         "acorn-dynamic-import": "2.0.2",
@@ -15786,7 +15816,7 @@
             "bytes": "3.0.0",
             "content-type": "1.0.4",
             "debug": "2.6.9",
-            "depd": "1.1.1",
+            "depd": "1.1.2",
             "http-errors": "1.6.2",
             "iconv-lite": "0.4.19",
             "on-finished": "2.3.0",
@@ -15868,7 +15898,7 @@
             "cookie": "0.3.1",
             "cookie-signature": "1.0.6",
             "debug": "2.6.9",
-            "depd": "1.1.1",
+            "depd": "1.1.2",
             "encodeurl": "1.0.1",
             "escape-html": "1.0.3",
             "etag": "1.8.1",
@@ -15987,7 +16017,7 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "1.1.1",
+            "depd": "1.1.2",
             "destroy": "1.0.4",
             "encodeurl": "1.0.1",
             "escape-html": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "uuid": "2.0.1",
     "valid-url": "1.0.9",
     "walk": "2.3.4",
-    "webpack": "3.8.1",
+    "webpack": "3.10.0",
     "webpack-dev-middleware": "1.11.0",
     "webpack-hot-middleware": "2.15.0",
     "wpcom": "5.4.0",


### PR DESCRIPTION
Consult https://github.com/webpack/webpack/releases for a changelog.
Mostly bugfixes, treeshaking support to `require.include`, and some other minor changes.

I in particular am interested in this release because it includes a memory leak fix for the Scope Hoisting plugin.

**to test**
no extensive testing necessary.  Just make sure you can still start up and click around in Calypso.
