### PR TITLE
People: clarify the invite copy

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -328,7 +328,8 @@ class InvitePeople extends React.Component {
 							<FormSettingExplanation>
 								{ translate(
 									'Want to invite new users to your site? The more the merrier! ' +
-										'Invite as many as you want, up to 10 at a time, by adding their email addresses or WordPress.com usernames.'
+										'Invite as many as you want, up to 10 at a time, by adding ' +
+										'their email addresses or WordPress.com usernames.'
 								) }
 							</FormSettingExplanation>
 						</div>

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -327,8 +327,8 @@ class InvitePeople extends React.Component {
 							/>
 							<FormSettingExplanation>
 								{ translate(
-									'Invite up to 10 email addresses and/or WordPress.com usernames. ' +
-										'Those needing a username will be sent instructions on how to create one.'
+									'Want to invite new users to your site? The more the merrier! ' +
+										'Invite as many as you want, up to 10 at a time, by adding their email addresses or WordPress.com usernames.'
 								) }
 							</FormSettingExplanation>
 						</div>


### PR DESCRIPTION
Make it clear that you can invite 10 users at a time, not just 10 users total. Also, make the message a little more friendly based on feedback from the editorial team.

Fixes #21586.