### PR TITLE
Purchases: Re-introduce cancelling bundled domain with plans while still in domain refund period

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -47,6 +47,7 @@ function createPurchaseObject( purchase ) {
 		productId: Number( purchase.product_id ),
 		productName: purchase.product_name,
 		productSlug: purchase.product_slug,
+		refundAmount: Number( purchase.refund_amount ),
 		refundText: `${ purchase.refund_currency_symbol }${ purchase.refund_amount }`,
 		refundPeriodInDays: purchase.refund_period_in_days,
 		renewDate: purchase.renew_date,

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -299,7 +299,7 @@ class CancelPurchaseButton extends Component {
 		if ( refundable ) {
 			cancelAndRefundPurchase(
 				purchase.id,
-				{ product_id: purchase.productId, cancel_bundled_domain: cancel_bundled_domain },
+				{ product_id: purchase.productId, cancel_bundled_domain: cancel_bundled_domain ? 1 : 0 },
 				this.handleSubmit
 			);
 		} else {

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -308,12 +308,22 @@ class CancelPurchaseButton extends Component {
 	};
 
 	renderCancellationEffect = () => {
-		const { purchase, translate } = this.props;
+		const { purchase, translate, includedDomainPurchase, cancelBundledDomain } = this.props;
+		const overrides = {};
+
+		if (
+			cancelBundledDomain &&
+			includedDomainPurchase &&
+			isDomainRegistration( includedDomainPurchase )
+		) {
+			overrides.refundText =
+				purchase.currencySymbol + ( purchase.refundAmount + includedDomainPurchase.amount );
+		}
 
 		return (
 			<p>
 				{ cancellationEffectHeadline( purchase, translate ) }
-				{ cancellationEffectDetail( purchase, translate ) }
+				{ cancellationEffectDetail( purchase, translate, overrides ) }
 			</p>
 		);
 	};

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -45,6 +45,9 @@ class CancelPurchaseButton extends Component {
 	static propTypes = {
 		purchase: PropTypes.object.isRequired,
 		selectedSite: PropTypes.object.isRequired,
+		cancelBundledDomain: PropTypes.bool.isRequired,
+		includedDomainPurchase: PropTypes.object,
+		disabled: PropTypes.bool,
 	};
 
 	state = {
@@ -191,7 +194,7 @@ class CancelPurchaseButton extends Component {
 	cancelPurchase = () => {
 		const { purchase, translate } = this.props;
 
-		this.toggleDisabled();
+		this.setDisabled( true );
 
 		cancelPurchase( purchase.id, success => {
 			const purchaseName = getName( purchase ),
@@ -240,10 +243,8 @@ class CancelPurchaseButton extends Component {
 		} );
 	};
 
-	toggleDisabled = () => {
-		this.setState( {
-			disabled: ! this.state.disabled,
-		} );
+	setDisabled = disabled => {
+		this.setState( { disabled } );
 	};
 
 	handleSubmit = ( error, response ) => {
@@ -269,7 +270,7 @@ class CancelPurchaseButton extends Component {
 	submitCancelAndRefundPurchase = () => {
 		const { purchase, selectedSite } = this.props;
 		const refundable = isRefundable( purchase );
-
+		const cancel_bundled_domain = this.props.cancelBundledDomain;
 		this.setState( {
 			submitting: true,
 		} );
@@ -296,7 +297,11 @@ class CancelPurchaseButton extends Component {
 		}
 
 		if ( refundable ) {
-			cancelAndRefundPurchase( purchase.id, { product_id: purchase.productId }, this.handleSubmit );
+			cancelAndRefundPurchase(
+				purchase.id,
+				{ product_id: purchase.productId, cancel_bundled_domain: cancel_bundled_domain },
+				this.handleSubmit
+			);
 		} else {
 			this.cancelPurchase();
 		}
@@ -349,7 +354,7 @@ class CancelPurchaseButton extends Component {
 			<div>
 				<Button
 					className="cancel-purchase__button"
-					disabled={ this.state.disabled }
+					disabled={ this.state.disabled || this.props.disabled }
 					onClick={ onClick }
 					primary
 				>

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -270,7 +270,7 @@ class CancelPurchaseButton extends Component {
 	submitCancelAndRefundPurchase = () => {
 		const { purchase, selectedSite } = this.props;
 		const refundable = isRefundable( purchase );
-		const cancel_bundled_domain = this.props.cancelBundledDomain;
+		const cancelBundledDomain = this.props.cancelBundledDomain;
 		this.setState( {
 			submitting: true,
 		} );
@@ -299,7 +299,7 @@ class CancelPurchaseButton extends Component {
 		if ( refundable ) {
 			cancelAndRefundPurchase(
 				purchase.id,
-				{ product_id: purchase.productId, cancel_bundled_domain: cancel_bundled_domain ? 1 : 0 },
+				{ product_id: purchase.productId, cancel_bundled_domain: cancelBundledDomain ? 1 : 0 },
 				this.handleSubmit
 			);
 		} else {

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -331,7 +331,7 @@ class CancelPurchaseButton extends Component {
 			}
 
 			if ( isSubscription( purchase ) ) {
-				text = translate( 'Cancel Subscription and Refund' );
+				text = translate( 'Cancel Subscription' );
 			}
 
 			if ( isOneTimePurchase( purchase ) ) {

--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -45,8 +45,8 @@ export function cancellationEffectHeadline( purchase, translate ) {
 	);
 }
 
-function refundableCancellationEffectDetail( purchase, translate ) {
-	const { refundText } = purchase;
+function refundableCancellationEffectDetail( purchase, translate, overrides ) {
+	const refundText = overrides.refundText || purchase.refundText;
 
 	if ( isTheme( purchase ) ) {
 		return translate(
@@ -128,9 +128,9 @@ function nonrefundableCancellationEffectDetail( purchase, translate ) {
 	);
 }
 
-export function cancellationEffectDetail( purchase, translate ) {
+export function cancellationEffectDetail( purchase, translate, overrides = {} ) {
 	if ( isRefundable( purchase ) ) {
-		return refundableCancellationEffectDetail( purchase, translate );
+		return refundableCancellationEffectDetail( purchase, translate, overrides );
 	}
 	return nonrefundableCancellationEffectDetail( purchase, translate );
 }

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -226,7 +226,7 @@ export default connect( ( state, props ) => {
 	return {
 		hasLoadedSites: ! isRequestingSites( state ),
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-		selectedPurchase: getByPurchaseId( state, props.purchaseId ),
+		selectedPurchase: purchase,
 		includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
 		selectedSite: getSelectedSiteSelector( state ),
 	};

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -30,7 +30,11 @@ import {
 	isDataLoading,
 	recordPageView,
 } from 'me/purchases/utils';
-import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
+import {
+	getByPurchaseId,
+	hasLoadedUserPurchasesFromServer,
+	getIncludedDomainPurchase,
+} from 'state/purchases/selectors';
 import { getSelectedSite as getSelectedSiteSelector } from 'state/ui/selectors';
 import HeaderCake from 'components/header-cake';
 import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
@@ -49,7 +53,13 @@ class CancelPurchase extends React.Component {
 		hasLoadedSites: PropTypes.bool.isRequired,
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
 		selectedPurchase: PropTypes.object,
+		includedDomainPurchase: PropTypes.object,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
+	};
+
+	state = {
+		cancelBundledDomain: false,
+		confirmCancelBundledDomain: false,
 	};
 
 	componentWillMount() {
@@ -100,11 +110,21 @@ class CancelPurchase extends React.Component {
 		page.redirect( redirectPath );
 	};
 
+	onCancelConfirmationStateChange = newState => {
+		this.setState( newState );
+	};
+
 	renderFooterText = () => {
 		const purchase = getPurchase( this.props );
-		const { refundText, renewDate } = purchase;
+		const { refundText, renewDate, priceText } = purchase;
 
 		if ( isRefundable( purchase ) ) {
+			if ( this.state.cancelBundledDomain ) {
+				return this.props.translate( '%(refundText)s to be refunded', {
+					args: { refundText: priceText },
+					context: 'refundText is of the form "[currency-symbol][amount]" i.e. "$20"',
+				} );
+			}
 			return this.props.translate( '%(refundText)s to be refunded', {
 				args: { refundText },
 				context: 'refundText is of the form "[currency-symbol][amount]" i.e. "$20"',
@@ -168,7 +188,13 @@ class CancelPurchase extends React.Component {
 				<Card className="cancel-purchase__card">
 					<h2>{ heading }</h2>
 
-					<CancelPurchaseRefundInformation purchase={ purchase } />
+					<CancelPurchaseRefundInformation
+						purchase={ purchase }
+						includedDomainPurchase={ this.props.incudedDomainPurchase }
+						confirmBundledDomain={ this.state.confirmCancelBundledDomain }
+						cancelBundledDomain={ this.state.cancelBundledDomain }
+						onCancelConfirmationStateChange={ this.onCancelConfirmationStateChange }
+					/>
 				</Card>
 
 				<CompactCard className="cancel-purchase__product-information">
@@ -180,16 +206,26 @@ class CancelPurchase extends React.Component {
 					<div className="cancel-purchase__refund-amount">
 						{ this.renderFooterText( this.props ) }
 					</div>
-					<CancelPurchaseButton purchase={ purchase } selectedSite={ this.props.selectedSite } />
+					<CancelPurchaseButton
+						purchase={ purchase }
+						includedDomainPurchase={ this.props.incudedDomainPurchase }
+						disabled={ this.state.cancelBundledDomain && ! this.state.confirmCancelBundledDomain }
+						selectedSite={ this.props.selectedSite }
+						cancelBundledDomain={ this.state.cancelBundledDomain }
+					/>
 				</CompactCard>
 			</Main>
 		);
 	}
 }
 
-export default connect( ( state, props ) => ( {
-	hasLoadedSites: ! isRequestingSites( state ),
-	hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-	selectedPurchase: getByPurchaseId( state, props.purchaseId ),
-	selectedSite: getSelectedSiteSelector( state ),
-} ) )( localize( CancelPurchase ) );
+export default connect( ( state, props ) => {
+	const purchase = getByPurchaseId( state, props.purchaseId );
+	return {
+		hasLoadedSites: ! isRequestingSites( state ),
+		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+		selectedPurchase: getByPurchaseId( state, props.purchaseId ),
+		includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
+		selectedSite: getSelectedSiteSelector( state ),
+	};
+} )( localize( CancelPurchase ) );

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -192,7 +192,7 @@ class CancelPurchase extends React.Component {
 
 					<CancelPurchaseRefundInformation
 						purchase={ purchase }
-						includedDomainPurchase={ this.props.incudedDomainPurchase }
+						includedDomainPurchase={ this.props.includedDomainPurchase }
 						confirmBundledDomain={ this.state.confirmCancelBundledDomain }
 						cancelBundledDomain={ this.state.cancelBundledDomain }
 						onCancelConfirmationStateChange={ this.onCancelConfirmationStateChange }
@@ -210,7 +210,7 @@ class CancelPurchase extends React.Component {
 					</div>
 					<CancelPurchaseButton
 						purchase={ purchase }
-						includedDomainPurchase={ this.props.incudedDomainPurchase }
+						includedDomainPurchase={ this.props.includedDomainPurchase }
 						disabled={ this.state.cancelBundledDomain && ! this.state.confirmCancelBundledDomain }
 						selectedSite={ this.props.selectedSite }
 						cancelBundledDomain={ this.state.cancelBundledDomain }

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -116,12 +116,14 @@ class CancelPurchase extends React.Component {
 
 	renderFooterText = () => {
 		const purchase = getPurchase( this.props );
-		const { refundText, renewDate, priceText } = purchase;
+		const { refundText, renewDate, refundAmount, currencySymbol } = purchase;
 
 		if ( isRefundable( purchase ) ) {
-			if ( this.state.cancelBundledDomain ) {
+			if ( this.state.cancelBundledDomain && this.props.includedDomainPurchase ) {
+				const fullRefundText =
+					currencySymbol + ( refundAmount + this.props.includedDomainPurchase.amount );
 				return this.props.translate( '%(refundText)s to be refunded', {
-					args: { refundText: priceText },
+					args: { refundText: fullRefundText },
 					context: 'refundText is of the form "[currency-symbol][amount]" i.e. "$20"',
 				} );
 			}

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -100,6 +100,8 @@ const CancelPurchaseRefundInformation = ( {
 
 				showSupportLink = false;
 			} else if ( includedDomainPurchase && isDomainRegistration( includedDomainPurchase ) ) {
+				const planCostText =
+					purchase.currencySymbol + ( purchase.refundAmount + includedDomainPurchase.amount );
 				if ( isRefundable( includedDomainPurchase ) ) {
 					text.push(
 						i18n.translate(
@@ -163,7 +165,7 @@ const CancelPurchaseRefundInformation = ( {
 										"you'll lose it permanently.",
 									{
 										args: {
-											planCost: purchase.priceText,
+											planCost: planCostText,
 										},
 									}
 								) }
@@ -221,7 +223,7 @@ const CancelPurchaseRefundInformation = ( {
 							{
 								args: {
 									domainCost: includedDomainPurchase.priceText,
-									planCost: purchase.priceText,
+									planCost: planCostText,
 									refundAmount: purchase.refundText,
 								},
 							}

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -57,8 +57,18 @@ const CancelPurchaseRefundInformation = ( {
 		}
 
 		if ( isSubscription( purchase ) ) {
+			text = [
+				i18n.translate(
+					"We're sorry to hear the %(productName)s plan didn't fit your current needs, but thank you for giving it a try.",
+					{
+						args: {
+							productName: getName( purchase ),
+						},
+					}
+				),
+			];
 			if ( includedDomainPurchase && isDomainMapping( includedDomainPurchase ) ) {
-				text = [
+				text.push(
 					i18n.translate(
 						'This plan includes mapping for the domain %(mappedDomain)s. ' +
 							"Cancelling will remove all the plan's features from your site, including the domain.",
@@ -85,23 +95,24 @@ const CancelPurchaseRefundInformation = ( {
 								mappedDomain: includedDomainPurchase.meta,
 							},
 						}
-					),
-				];
+					)
+				);
 
 				showSupportLink = false;
 			} else if ( includedDomainPurchase && isDomainRegistration( includedDomainPurchase ) ) {
 				if ( isRefundable( includedDomainPurchase ) ) {
-					text = [
+					text.push(
 						i18n.translate(
-							'This plan includes the custom domain, %(domain)s, normally a %(domainCost)s purchase. ' +
-								'Cancelling the domain could cause interruptions for your visitors.',
+							'Your plan included the custom domain %(domain)s. You can cancel your domain as well as the plan, but keep ' +
+								'in mind that when you cancel a domain you risk losing it forever, and visitors to your site may ' +
+								'experience difficulties acessing it.',
 							{
 								args: {
 									domain: includedDomainPurchase.meta,
-									domainCost: includedDomainPurchase.priceText,
 								},
 							}
 						),
+						i18n.translate( "We'd like to offer you two options to choose from:" ),
 						<FormLabel key="keep_bundled_domain">
 							<FormRadio
 								name="keep_bundled_domain_false"
@@ -110,20 +121,20 @@ const CancelPurchaseRefundInformation = ( {
 								onChange={ onCancelBundledDomainChange }
 							/>
 							<span>
-								{ i18n.translate( 'Just cancel the plan and keep %(domain)s.', {
+								{ i18n.translate( 'Cancel the plan, but keep %(domain)s.', {
 									args: {
 										domain: includedDomainPurchase.meta,
 									},
 								} ) }
 								<br />
 								{ i18n.translate(
-									'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
-										'minus %(domainCost)s for the domain. The domain will remain registered to you and can be ' +
-										'used on WordPress.com or transferred.',
+									"You'll receive a partial refund of %(refundAmount)s -- the cost of the %(productName)s " +
+										'plan, minus %(domainCost)s for the domain. There will be no change to your domain ' +
+										"registration, and you're free to use it on WordPress.com or transfer it elsewhere.",
 									{
 										args: {
+											productName: getName( purchase ),
 											domainCost: includedDomainPurchase.priceText,
-											planCost: purchase.priceText,
 											refundAmount: purchase.refundText,
 										},
 									}
@@ -138,34 +149,35 @@ const CancelPurchaseRefundInformation = ( {
 								onChange={ onCancelBundledDomainChange }
 							/>
 							<span>
-								{ i18n.translate( 'Cancel the plan and the domain "%(domain)s."', {
+								{ i18n.translate( 'Cancel the plan {{em}}and{{/em}} the domain "%(domain)s."', {
 									args: {
 										domain: includedDomainPurchase.meta,
+									},
+									components: {
+										em: <em />,
 									},
 								} ) }
 								<br />
 								{ i18n.translate(
-									"You will be refunded %(planCost)s, but the domain will be canceled and can't be " +
-										'guaranteed to be available for registration again.',
+									"You'll receive a full refund of %(planCost)s. The domain will be cancelled, and it's possible " +
+										"you'll lose it permanently.",
 									{
 										args: {
-											domainCost: includedDomainPurchase.priceText,
 											planCost: purchase.priceText,
-											refundAmount: purchase.refundText,
 										},
 									}
 								) }
 							</span>
-						</FormLabel>,
-					];
+						</FormLabel>
+					);
 
 					if ( cancelBundledDomain ) {
-						text = text.concat( [
+						text.push(
 							i18n.translate(
-								'Canceling a domain name causes the domain to become unavailable for a brief period ' +
-									'before it can be purchased again, and someone may purchase it before you get a chance. ' +
-									'If you wish to use the domain with another service, ' +
-									'you’ll want to {{a}}update your name servers{{/a}} instead.',
+								"When you cancel a domain, it becomes unavailable for a while. Anyone may register it once it's " +
+									"available again, so it's possible you won't have another chance to register it in the future. " +
+									"If you'd like to use your domain on a site hosted elsewhere, consider {{a}}updating your name " +
+									'servers{{/a}} instead.',
 								{
 									components: {
 										a: <a href={ UPDATE_NAMESERVERS } target="_blank" rel="noopener noreferrer" />,
@@ -179,7 +191,8 @@ const CancelPurchaseRefundInformation = ( {
 								/>
 								<span>
 									{ i18n.translate(
-										'I understand that canceling means that I may {{strong}}lose this domain forever{{/strong}}.',
+										'I understand that canceling my domain means I might {{strong}}never be able to register it ' +
+											'again{{/strong}}.',
 										{
 											components: {
 												strong: <strong />,
@@ -187,11 +200,11 @@ const CancelPurchaseRefundInformation = ( {
 										}
 									) }
 								</span>
-							</FormLabel>,
-						] );
+							</FormLabel>
+						);
 					}
 				} else {
-					text = [
+					text.push(
 						i18n.translate(
 							'This plan includes the custom domain, %(domain)s, normally a %(domainCost)s purchase. ' +
 								'The domain will not be removed along with the plan, to avoid any interruptions for your visitors. ',
@@ -212,8 +225,8 @@ const CancelPurchaseRefundInformation = ( {
 									refundAmount: purchase.refundText,
 								},
 							}
-						),
-					];
+						)
+					);
 				}
 
 				showSupportLink = false;

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -109,6 +109,7 @@ describe( 'selectors', () => {
 				productSlug: undefined,
 				pendingTransfer: false,
 				refundPeriodInDays: undefined,
+				refundAmount: NaN,
 				refundText: 'undefinedundefined',
 				renewDate: undefined,
 				renewMoment: null,


### PR DESCRIPTION
Fixes: #21628

1. Purchase a plan and a bundle domain.
2. Go to http://calypso.localhost:3000/purchases and choose that plan
3. Click "Cancel WordPress.com [Plan Type].

* You should only receive the option to cancel the domain if the domain is still within the refund window.
* The cancel button should be disabled if you have chosen to cancel the domain, but not checked the confirmation checkbox.
* After clicking the button to "Cancel Subscription and Refund", the network request should include a parameter with `cancel_bundled_domain:true` if and only if the user chose to cancel the domain and the cancel confirmation was checked.

Note, that API side changes (D9415-code) still need to be made before this can be tested end to end.