### PR TITLE
Plugins: fix incorrect import

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -21,7 +21,7 @@ import { hasTouch } from 'lib/touch-detect';
 import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
 import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
 import { installPerfmonPageHandlers } from 'lib/perfmon';
-import * as sectionsMiddleware from 'sections-middleware';
+import { getSections, setupRoutes } from 'sections-middleware';
 
 const debug = debugFactory( 'calypso' );
 
@@ -75,7 +75,7 @@ const setupContextMiddleware = reduxStore => {
 };
 
 // We need to require sections to load React with i18n mixin
-const loadSectionsMiddleware = () => sectionsMiddleware.setupRoutes();
+const loadSectionsMiddleware = () => setupRoutes();
 
 const loggedOutMiddleware = currentUser => {
 	if ( currentUser.get() ) {
@@ -96,7 +96,7 @@ const loggedOutMiddleware = currentUser => {
 		} );
 	}
 
-	const validSections = sectionsMiddleware.getSections().reduce( ( acc, section ) => {
+	const validSections = getSections().reduce( ( acc, section ) => {
 		return section.enableLoggedOut ? acc.concat( section.paths ) : acc;
 	}, [] );
 	const isValidSection = sectionPath =>

--- a/client/extensions/wp-job-manager/components/navigation/index.jsx
+++ b/client/extensions/wp-job-manager/components/navigation/index.jsx
@@ -16,7 +16,7 @@ import SectionNav from 'components/section-nav';
 import SectionNavTabs from 'components/section-nav/tabs';
 import SectionNavTabItem from 'components/section-nav/item';
 import { addSiteFragment } from 'lib/route';
-import sectionsModule from 'sections-middleware';
+import { getSections } from 'sections-middleware';
 import { Tabs } from '../../constants';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -32,7 +32,7 @@ class Navigation extends Component {
 	};
 
 	getSettingsPath() {
-		const sections = sectionsModule.getSections();
+		const sections = getSections();
 		const section = find( sections, value => value.name === 'wp-job-manager' );
 
 		return get( section, 'settings_path' );

--- a/client/extensions/zoninator/app/util.js
+++ b/client/extensions/zoninator/app/util.js
@@ -9,10 +9,10 @@ import { find, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import sectionsModule from 'sections-middleware';
+import { getSections } from 'sections-middleware';
 
 const getSettingsPath = () => {
-	const sections = sectionsModule.getSections();
+	const sections = getSections();
 	const section = find( sections, value => value.name === 'zoninator' );
 
 	return get( section, 'settings_path' );

--- a/client/my-sites/plugins/utils.js
+++ b/client/my-sites/plugins/utils.js
@@ -10,11 +10,11 @@ import { find, get, includes } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
-import sectionsModule from 'sections-middleware';
+import { getSections } from 'sections-middleware';
 
 export function getExtensionSettingsPath( plugin ) {
 	const pluginSlug = get( plugin, 'slug', '' );
-	const sections = sectionsModule.getSections();
+	const sections = getSections();
 	const section = find( sections, value => value.name === pluginSlug );
 	const env = get( section, 'envId', [] );
 


### PR DESCRIPTION
This PR fixes an undefined import, so the plugins management page can render.

### Testing Instructions
- Install Yoast SEO on a connected Jetpack page
- Navigating to http://calypso.localhost:3000//plugins/wordpress-seo/{my-site} loads
- In Production https://wordpress.com/plugins/wordpress-seo/{my-site} does not load