### PR TITLE
Cap the number of selected images at 99 (#20956)

### DIFF
--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -98,18 +98,18 @@ export default class extends React.Component {
 	};
 
 	render() {
-		var classes, props, style, title;
+		let title, selectedNumber;
 
-		classes = classNames( 'media-library__list-item', {
+		const classes = classNames( 'media-library__list-item', {
 			'is-placeholder': ! this.props.media,
 			'is-selected': -1 !== this.props.selectedIndex,
 			'is-transient': this.props.media && this.props.media.transient,
 			'is-small': this.props.scale <= 0.125,
 		} );
 
-		props = omit( this.props, Object.keys( this.constructor.propTypes ) );
+		const props = omit( this.props, Object.keys( this.constructor.propTypes ) );
 
-		style = assign(
+		const style = assign(
 			{
 				width: this.props.scale * 100 + '%',
 			},
@@ -121,7 +121,8 @@ export default class extends React.Component {
 		}
 
 		if ( -1 !== this.props.selectedIndex ) {
-			props[ 'data-selected-number' ] = this.props.selectedIndex + 1;
+			selectedNumber = this.props.selectedIndex + 1;
+			props[ 'data-selected-number' ] = selectedNumber > 99 ? '99+' : selectedNumber;
 		}
 
 		return (

--- a/client/my-sites/media-library/test/list-item.jsx
+++ b/client/my-sites/media-library/test/list-item.jsx
@@ -1,0 +1,44 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import fixtures from './fixtures';
+import ListItem from 'my-sites/media-library/list-item';
+
+describe( 'MediaLibraryListItem', () => {
+	let wrapper;
+
+	beforeEach( () => {
+		if ( wrapper ) {
+			wrapper.unmount();
+		}
+	} );
+
+	describe( 'selectedIndex', () => {
+		test( 'when selectedIndex is over 99 it gets capped', () => {
+			wrapper = shallow(
+				<ListItem media={ fixtures.media[ 0 ] } scale={ 1 } selectedIndex={ 99 } />
+			);
+
+			expect( wrapper.props()[ 'data-selected-number' ] ).to.be.equal( '99+' );
+		} );
+		test( 'when selectedIndex is under 100 it is as shown', () => {
+			wrapper = shallow(
+				<ListItem media={ fixtures.media[ 0 ] } scale={ 1 } selectedIndex={ 98 } />
+			);
+
+			expect( wrapper.props()[ 'data-selected-number' ] ).to.be.equal( 99 );
+		} );
+	} );
+} );


### PR DESCRIPTION
When number of selected images is over 99 cap it
to 99+. This prevents us from trying to show a number
that does not fit into the counter.