### PR TITLE
Checkout: Format and validate the CPF field in ebanx card details

### DIFF
--- a/client/lib/credit-card-details/ebanx.js
+++ b/client/lib/credit-card-details/ebanx.js
@@ -4,7 +4,7 @@
  * @format
  */
 import isUndefined from 'lodash/isUndefined';
-import isString from 'lodash/isString';
+import { isValid } from 'cpf';
 
 /**
  * Internal dependencies
@@ -28,13 +28,11 @@ export function isEbanxEnabledForCountry( countryCode = '' ) {
 /**
  * CPF number (Cadastrado de Pessoas Físicas) is the Brazilian tax identification number.
  * Total of 11 digits: 9 numbers followed by 2 verification numbers . E.g., 188.247.019-22
- * The following test is a weak test only. Full algorithm here: http://www.geradorcpf.com/algoritmo_do_cpf.htm
  *
- * See: http://www.geradorcpf.com/algoritmo_do_cpf.htm
  * @param {String} cpf - a Brazilian tax identification number
  * @returns {Boolean} Whether the cpf is valid or not
  */
 
 export function isValidCPF( cpf = '' ) {
-	return isString( cpf ) && /^[0-9]{3}\.[0-9]{3}\.[0-9]{3}-[0-9]{2}$/.test( cpf );
+	return isValid( cpf );
 }

--- a/client/lib/credit-card-details/masking.js
+++ b/client/lib/credit-card-details/masking.js
@@ -64,6 +64,8 @@ fieldMasks.cvv = {
 	unmask: identity,
 };
 
+// `document` is an EBANX field. Currently used for Brazilian CPF numbers
+// See isValidCPF() / ebanx.js
 fieldMasks.document = {
 	mask: function( previousValue, nextValue ) {
 		const digits = nextValue.replace( /[^0-9]/g, '' ),

--- a/client/lib/credit-card-details/masking.js
+++ b/client/lib/credit-card-details/masking.js
@@ -64,6 +64,24 @@ fieldMasks.cvv = {
 	unmask: identity,
 };
 
+fieldMasks.document = {
+	mask: function( previousValue, nextValue ) {
+		const digits = nextValue.replace( /[^0-9]/g, '' ),
+			string =
+				digits.slice( 0, 3 ) +
+				'.' +
+				digits.slice( 3, 6 ) +
+				'.' +
+				digits.slice( 6, 9 ) +
+				'-' +
+				digits.slice( 9, 11 );
+
+		return string.replace( /^[\s\.\-]+|[\s\.\-]+$/g, '' );
+	},
+
+	unmask: identity,
+};
+
 export function maskField( fieldName, previousValue, nextValue ) {
 	const fieldMask = fieldMasks[ fieldName ];
 	if ( ! fieldMask ) {

--- a/client/lib/credit-card-details/test/ebanx.js
+++ b/client/lib/credit-card-details/test/ebanx.js
@@ -40,11 +40,12 @@ describe( 'Ebanx payment processing methods', () => {
 
 	describe( 'isValidCPF', () => {
 		test( 'should return true for valid CPF (Brazilian tax identification number)', () => {
+			expect( isValidCPF( '85384484632' ) ).toEqual( true );
 			expect( isValidCPF( '853.513.468-93' ) ).toEqual( true );
 		} );
 		test( 'should return false for invalid CPF', () => {
-			expect( isValidCPF( '85384484632' ) ).toEqual( false );
-			expect( isValidCPF( '853.844.846.32' ) ).toEqual( false );
+			expect( isValidCPF( '85384484612' ) ).toEqual( false );
+			expect( isValidCPF( '853.844.846.12' ) ).toEqual( false );
 		} );
 	} );
 } );

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cookie": "0.1.2",
     "cookie-parser": "1.3.2",
     "copy-webpack-plugin": "4.0.1",
+    "cpf": "1.0.0",
     "create-react-class": "15.6.2",
     "creditcards": "2.1.2",
     "cross-env": "5.1.1",


### PR DESCRIPTION
This improves the input and validation of the document/cpf field in ebanx card details:
 - The validation is now a strong validation based on the CPF algorithm (using https://github.com/theuves/cpf with no additional dependencies) 
 - The dots and dash are added automatically to facilitate typing (in a similar way to how spaces are added in the credit card number field).

*Testing:*
- Enabling ebanx can be done either through a WPCOM sandbox, or by locally modifying the `isEbanxEnabled()` function (easier)
- The additional form should show up when you select Bresil as the card country.

Fixes #21368
