### PR TITLE
Jetpack connect: Dedicated action creator for starting auth step

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -28,12 +28,12 @@ import { authorizeQueryDataSchema } from './schema';
 import { authQueryTransformer } from './utils';
 import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
 import { hideMasterbar, setSection, showMasterbar } from 'state/ui/actions';
-import { JETPACK_CONNECT_QUERY_SET } from 'state/action-types';
 import { JPC_PATH_PLANS, MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
 import { persistMobileRedirect, retrieveMobileRedirect, storePlan } from './persistence-utils';
 import { receiveJetpackOnboardingCredentials } from 'state/jetpack-onboarding/actions';
 import { sectionify } from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+import { startAuthorizeStep } from 'state/jetpack-connect/actions';
 import { urlToSlug } from 'lib/url';
 import {
 	PLAN_JETPACK_BUSINESS,
@@ -187,23 +187,7 @@ export function signupForm( context, next ) {
 
 	if ( validQueryObject ) {
 		const transformedQuery = authQueryTransformer( query );
-
-		// No longer setting/persisting query
-		//
-		// FIXME
-		//
-		// However, clientId is required for some reducer logic :(
-		//
-		// Set timestamp here so reducer can remain pure
-		//
-		// Hopefully when actions move to data-layer, this will become clearer and
-		// we won't need to store clientId in state
-		//
-		context.store.dispatch( {
-			type: JETPACK_CONNECT_QUERY_SET,
-			clientId: transformedQuery.clientId,
-			timestamp: Date.now(),
-		} );
+		context.store.dispatch( startAuthorizeStep( transformedQuery.clientId ) );
 
 		let interval = context.params.interval;
 		let locale = context.params.locale;
@@ -238,22 +222,7 @@ export function authorizeForm( context, next ) {
 
 	if ( validQueryObject ) {
 		const transformedQuery = authQueryTransformer( query );
-
-		// No longer setting/persisting query
-		//
-		// FIXME
-		//
-		// However, from and clientId are required for some reducer logic :(
-		//
-		// Hopefully when actions move to data-layer, this will become clearer and
-		// we won't need to store clientId in state
-		//
-		context.store.dispatch( {
-			type: JETPACK_CONNECT_QUERY_SET,
-			clientId: transformedQuery.clientId,
-			timestamp: Date.now(),
-		} );
-
+		context.store.dispatch( startAuthorizeStep( transformedQuery.clientId ) );
 		context.primary = <JetpackAuthorize authQuery={ transformedQuery } />;
 	} else {
 		context.primary = <NoDirectAccessError />;

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -15,7 +15,6 @@ import { translate } from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import CheckoutData from 'components/data/checkout';
 import config from 'config';
-import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
 import JetpackAuthorize from './authorize';
 import JetpackConnect from './main';
 import JetpackNewSite from './jetpack-new-site/index';
@@ -24,24 +23,25 @@ import JetpackSsoForm from './sso';
 import NoDirectAccessError from './no-direct-access-error';
 import Plans from './plans';
 import PlansLanding from './plans-landing';
-import { sectionify } from 'lib/route';
 import userFactory from 'lib/user';
 import { authorizeQueryDataSchema } from './schema';
 import { authQueryTransformer } from './utils';
+import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
+import { hideMasterbar, setSection, showMasterbar } from 'state/ui/actions';
 import { JETPACK_CONNECT_QUERY_SET } from 'state/action-types';
 import { JPC_PATH_PLANS, MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
-import { receiveJetpackOnboardingCredentials } from 'state/jetpack-onboarding/actions';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { hideMasterbar, setSection, showMasterbar } from 'state/ui/actions';
 import { persistMobileRedirect, retrieveMobileRedirect, storePlan } from './persistence-utils';
+import { receiveJetpackOnboardingCredentials } from 'state/jetpack-onboarding/actions';
+import { sectionify } from 'lib/route';
+import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { urlToSlug } from 'lib/url';
 import {
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
 } from 'lib/plans/constants';
 
 /**

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -27,6 +27,7 @@ import {
 	JETPACK_CONNECT_CREATE_ACCOUNT,
 	JETPACK_CONNECT_CREATE_ACCOUNT_RECEIVE,
 	JETPACK_CONNECT_DISMISS_URL_STATUS,
+	JETPACK_CONNECT_QUERY_SET,
 	JETPACK_CONNECT_RETRY_AUTH,
 	JETPACK_CONNECT_SSO_AUTHORIZE_ERROR,
 	JETPACK_CONNECT_SSO_AUTHORIZE_REQUEST,
@@ -64,6 +65,14 @@ export function dismissUrl( url ) {
 	return {
 		type: JETPACK_CONNECT_DISMISS_URL_STATUS,
 		url: url,
+	};
+}
+
+export function startAuthorizeStep( clientId ) {
+	return {
+		type: JETPACK_CONNECT_QUERY_SET,
+		clientId,
+		timestamp: Date.now(),
 	};
 }
 


### PR DESCRIPTION
A raw action was being created in the controller. This is a bit ugly, especially since it must add `timestamp: Date.now()` to the action.

This PR adds and uses a dedicated action creator.

## Testing
1. Verify the auth flow continues to work as before.
1. Test pass