### PR TITLE
Jetpack connect: Add notice type constants

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -43,6 +43,15 @@ import { login } from 'lib/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
 import {
+	ALREADY_CONNECTED,
+	ALREADY_CONNECTED_BY_OTHER_USER,
+	DEFAULT_AUTHORIZE_ERROR,
+	RETRY_AUTH,
+	RETRYING_AUTH,
+	SECRET_EXPIRED,
+	USER_IS_ALREADY_CONNECTED_TO_SITE,
+} from './connection-notice-types';
+import {
 	isCalypsoStartedConnection,
 	isSsoApproved,
 	retrieveMobileRedirect,
@@ -395,7 +404,7 @@ export class JetpackAuthorize extends Component {
 			// flows will be reserved for brand new connections.
 			return (
 				<JetpackConnectNotices
-					noticeType="alreadyConnectedByOtherUser"
+					noticeType={ ALREADY_CONNECTED_BY_OTHER_USER }
 					onTerminalError={ redirectToMobileApp }
 				/>
 			);
@@ -407,7 +416,7 @@ export class JetpackAuthorize extends Component {
 			// connected, we need to show an error.
 			return (
 				<JetpackConnectNotices
-					noticeType="userIsAlreadyConnectedToSite"
+					noticeType={ USER_IS_ALREADY_CONNECTED_TO_SITE }
 					onTerminalError={ redirectToMobileApp }
 				/>
 			);
@@ -415,7 +424,10 @@ export class JetpackAuthorize extends Component {
 
 		if ( this.retryingAuth ) {
 			return (
-				<JetpackConnectNotices noticeType="retryingAuth" onTerminalError={ redirectToMobileApp } />
+				<JetpackConnectNotices
+					noticeType={ RETRYING_AUTH }
+					onTerminalError={ redirectToMobileApp }
+				/>
 			);
 		}
 
@@ -426,7 +438,7 @@ export class JetpackAuthorize extends Component {
 			! authorizeSuccess
 		) {
 			return (
-				<JetpackConnectNotices noticeType="retryAuth" onTerminalError={ redirectToMobileApp } />
+				<JetpackConnectNotices noticeType={ RETRY_AUTH } onTerminalError={ redirectToMobileApp } />
 			);
 		}
 
@@ -437,7 +449,7 @@ export class JetpackAuthorize extends Component {
 		if ( includes( get( authorizeError, 'message' ), 'already_connected' ) ) {
 			return (
 				<JetpackConnectNotices
-					noticeType="alreadyConnected"
+					noticeType={ ALREADY_CONNECTED }
 					onTerminalError={ redirectToMobileApp }
 				/>
 			);
@@ -445,7 +457,7 @@ export class JetpackAuthorize extends Component {
 		if ( this.props.hasExpiredSecretError ) {
 			return (
 				<JetpackConnectNotices
-					noticeType="secretExpired"
+					noticeType={ SECRET_EXPIRED }
 					siteUrl={ site }
 					onTerminalError={ redirectToMobileApp }
 				/>
@@ -457,7 +469,7 @@ export class JetpackAuthorize extends Component {
 		return (
 			<div>
 				<JetpackConnectNotices
-					noticeType="defaultAuthorizeError"
+					noticeType={ DEFAULT_AUTHORIZE_ERROR }
 					onTerminalError={ redirectToMobileApp }
 				/>
 				{ this.renderErrorDetails() }

--- a/client/jetpack-connect/connection-notice-types.js
+++ b/client/jetpack-connect/connection-notice-types.js
@@ -1,0 +1,26 @@
+/** @format */
+
+/**
+ * Shared notice types
+ *
+ * These notice types are indicators of Jetpack Connection status.
+ */
+
+export const ALREADY_CONNECTED = 'alreadyConnected';
+export const ALREADY_CONNECTED_BY_OTHER_USER = 'alreadyConnectedByOtherUser';
+export const ALREADY_OWNED = 'alreadyOwned';
+export const DEFAULT_AUTHORIZE_ERROR = 'defaultAuthorizeError';
+export const IS_DOT_COM = 'isDotCom';
+export const JETPACK_IS_DISCONNECTED = 'jetpackIsDisconnected';
+export const JETPACK_IS_VALID = 'jetpackIsValid';
+export const NOT_ACTIVE_JETPACK = 'notActiveJetpack';
+export const NOT_CONNECTED_JETPACK = 'notConnectedJetpack';
+export const NOT_EXISTS = 'notExists';
+export const NOT_JETPACK = 'notJetpack';
+export const NOT_WORDPRESS = 'notWordPress';
+export const OUTDATED_JETPACK = 'outdatedJetpack';
+export const RETRY_AUTH = 'retryAuth';
+export const RETRYING_AUTH = 'retryingAuth';
+export const SECRET_EXPIRED = 'secretExpired';
+export const USER_IS_ALREADY_CONNECTED_TO_SITE = 'userIsAlreadyConnectedToSite';
+export const WORDPRESS_DOT_COM = 'wordpress.com';

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -9,6 +9,26 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import {
+	ALREADY_CONNECTED,
+	ALREADY_CONNECTED_BY_OTHER_USER,
+	ALREADY_OWNED,
+	DEFAULT_AUTHORIZE_ERROR,
+	IS_DOT_COM,
+	JETPACK_IS_DISCONNECTED,
+	JETPACK_IS_VALID,
+	NOT_ACTIVE_JETPACK,
+	NOT_CONNECTED_JETPACK,
+	NOT_EXISTS,
+	NOT_JETPACK,
+	NOT_WORDPRESS,
+	OUTDATED_JETPACK,
+	RETRY_AUTH,
+	RETRYING_AUTH,
+	SECRET_EXPIRED,
+	USER_IS_ALREADY_CONNECTED_TO_SITE,
+	WORDPRESS_DOT_COM,
+} from './connection-notice-types';
 import Notice from 'components/notice';
 
 export class JetpackConnectNotices extends Component {
@@ -17,23 +37,24 @@ export class JetpackConnectNotices extends Component {
 		// instead of showing a notice.
 		onTerminalError: PropTypes.func,
 		noticeType: PropTypes.oneOf( [
-			'alreadyConnected',
-			'alreadyConnectedByOtherUser',
-			'alreadyOwned',
-			'defaultAuthorizeError',
-			'isDotCom',
-			'jetpackIsValid',
-			'notActiveJetpack',
-			'notConnectedJetpack', // notConnectedJetpack is expected, but no notice is shown.
-			'notExists',
-			'notJetpack',
-			'notWordPress',
-			'outdatedJetpack',
-			'retryAuth',
-			'retryingAuth',
-			'secretExpired',
-			'userIsAlreadyConnectedToSite',
-			'wordpress.com',
+			ALREADY_CONNECTED,
+			ALREADY_CONNECTED_BY_OTHER_USER,
+			ALREADY_OWNED,
+			DEFAULT_AUTHORIZE_ERROR,
+			IS_DOT_COM,
+			JETPACK_IS_DISCONNECTED,
+			JETPACK_IS_VALID,
+			NOT_ACTIVE_JETPACK,
+			NOT_CONNECTED_JETPACK,
+			NOT_EXISTS,
+			NOT_JETPACK,
+			NOT_WORDPRESS,
+			OUTDATED_JETPACK,
+			RETRY_AUTH,
+			RETRYING_AUTH,
+			SECRET_EXPIRED,
+			USER_IS_ALREADY_CONNECTED_TO_SITE,
+			WORDPRESS_DOT_COM,
 		] ).isRequired,
 		translate: PropTypes.func.isRequired,
 		url: PropTypes.string,
@@ -55,55 +76,55 @@ export class JetpackConnectNotices extends Component {
 		}
 
 		switch ( noticeType ) {
-			case 'notExists':
+			case NOT_EXISTS:
 				return noticeValues;
 
-			case 'isDotCom':
+			case IS_DOT_COM:
 				noticeValues.icon = 'block';
 				noticeValues.text = translate(
 					"That's a WordPress.com site, so you don't need to connect it."
 				);
 				return noticeValues;
 
-			case 'notWordPress':
+			case NOT_WORDPRESS:
 				noticeValues.icon = 'block';
 				noticeValues.text = translate( "That's not a WordPress site." );
 				return noticeValues;
 
-			case 'notActiveJetpack':
+			case NOT_ACTIVE_JETPACK:
 				noticeValues.icon = 'block';
 				noticeValues.text = translate( 'Jetpack is deactivated.' );
 				return noticeValues;
 
-			case 'outdatedJetpack':
+			case OUTDATED_JETPACK:
 				noticeValues.icon = 'block';
 				noticeValues.text = translate( 'You must update Jetpack before connecting.' );
 				return noticeValues;
 
-			case 'jetpackIsDisconnected':
+			case JETPACK_IS_DISCONNECTED:
 				noticeValues.icon = 'link-break';
 				noticeValues.text = translate( 'Jetpack is currently disconnected.' );
 				return noticeValues;
 
-			case 'jetpackIsValid':
+			case JETPACK_IS_VALID:
 				noticeValues.status = 'is-success';
 				noticeValues.icon = 'plugins';
 				noticeValues.text = translate( 'Jetpack is connected.' );
 				return noticeValues;
 
-			case 'notJetpack':
+			case NOT_JETPACK:
 				noticeValues.status = 'is-notice';
 				noticeValues.icon = 'status';
 				noticeValues.text = translate( "Jetpack couldn't be found." );
 				return noticeValues;
 
-			case 'wordpress.com':
+			case WORDPRESS_DOT_COM:
 				noticeValues.text = translate( "Oops, that's us." );
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'status';
 				return noticeValues;
 
-			case 'retryingAuth':
+			case RETRYING_AUTH:
 				noticeValues.text = translate(
 					'Error authorizing. Page is refreshing for another attempt.'
 				);
@@ -112,7 +133,7 @@ export class JetpackConnectNotices extends Component {
 				noticeValues.userCanRetry = true;
 				return noticeValues;
 
-			case 'retryAuth':
+			case RETRY_AUTH:
 				noticeValues.text = translate(
 					'In some cases, authorization can take a few attempts. Please try again.'
 				);
@@ -121,13 +142,13 @@ export class JetpackConnectNotices extends Component {
 				noticeValues.userCanRetry = true;
 				return noticeValues;
 
-			case 'secretExpired':
+			case SECRET_EXPIRED:
 				noticeValues.text = translate( "Oops, that took a while. You'll have to try again." );
 				noticeValues.status = 'is-error';
 				noticeValues.icon = 'notice';
 				return noticeValues;
 
-			case 'defaultAuthorizeError':
+			case DEFAULT_AUTHORIZE_ERROR:
 				noticeValues.text = translate(
 					'Error authorizing your site. Please {{link}}contact support{{/link}}.',
 					{
@@ -146,7 +167,7 @@ export class JetpackConnectNotices extends Component {
 				noticeValues.icon = 'notice';
 				return noticeValues;
 
-			case 'alreadyConnectedByOtherUser':
+			case ALREADY_CONNECTED_BY_OTHER_USER:
 				noticeValues.text = translate(
 					'This site is already connected to a different WordPress.com user, ' +
 						'you need to disconnect that user before you can connect another.'
@@ -154,7 +175,8 @@ export class JetpackConnectNotices extends Component {
 				noticeValues.status = 'is-warning';
 				noticeValues.icon = 'notice';
 				return noticeValues;
-			case 'userIsAlreadyConnectedToSite':
+
+			case USER_IS_ALREADY_CONNECTED_TO_SITE:
 				noticeValues.text = translate(
 					'This WordPress.com account is already connected to another user on this site. ' +
 						'Please login to another WordPress.com account to complete the connection.'
@@ -183,14 +205,14 @@ export class JetpackConnectNotices extends Component {
 	}
 
 	render() {
-		const values = this.getNoticeValues();
+		const noticeValues = this.getNoticeValues();
 		if ( this.errorIsTerminal() && this.props.onTerminalError ) {
 			return null;
 		}
-		if ( values ) {
+		if ( noticeValues ) {
 			return (
 				<div className="jetpack-connect__notices-container">
-					<Notice { ...values } />
+					<Notice { ...noticeValues } />
 				</div>
 			);
 		}

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -42,6 +42,18 @@ import {
 	REMOTE_PATH_AUTH,
 	REMOTE_PATH_INSTALL,
 } from './constants';
+import {
+	ALREADY_CONNECTED,
+	ALREADY_OWNED,
+	IS_DOT_COM,
+	NOT_ACTIVE_JETPACK,
+	NOT_CONNECTED_JETPACK,
+	NOT_EXISTS,
+	NOT_JETPACK,
+	NOT_WORDPRESS,
+	OUTDATED_JETPACK,
+	WORDPRESS_DOT_COM,
+} from './connection-notice-types';
 
 const debug = debugModule( 'calypso:jetpack-connect:main' );
 
@@ -96,13 +108,13 @@ export class JetpackConnectMain extends Component {
 
 	componentDidUpdate() {
 		if (
-			this.getStatus() === 'notConnectedJetpack' &&
+			this.getStatus() === NOT_CONNECTED_JETPACK &&
 			this.isCurrentUrlFetched() &&
 			! this.redirecting
 		) {
 			return this.goToRemoteAuth( this.state.currentUrl );
 		}
-		if ( this.getStatus() === 'alreadyOwned' && ! this.redirecting ) {
+		if ( this.getStatus() === ALREADY_OWNED && ! this.redirecting ) {
 			if ( this.props.isMobileAppFlow ) {
 				return this.redirectToMobileApp( 'already-connected' );
 			}
@@ -253,50 +265,50 @@ export class JetpackConnectMain extends Component {
 		}
 
 		if ( this.checkProperty( 'userOwnsSite' ) ) {
-			return 'alreadyOwned';
+			return ALREADY_OWNED;
 		}
 
 		if ( this.props.jetpackConnectSite.installConfirmedByUser === false ) {
-			return 'notJetpack';
+			return NOT_JETPACK;
 		}
 
 		if ( this.props.jetpackConnectSite.installConfirmedByUser === true ) {
-			return 'notActiveJetpack';
+			return NOT_ACTIVE_JETPACK;
 		}
 
 		if (
 			this.state.currentUrl.toLowerCase() === 'http://wordpress.com' ||
 			this.state.currentUrl.toLowerCase() === 'https://wordpress.com'
 		) {
-			return 'wordpress.com';
+			return WORDPRESS_DOT_COM;
 		}
 		if ( this.checkProperty( 'isWordPressDotCom' ) ) {
-			return 'isDotCom';
+			return IS_DOT_COM;
 		}
 		if ( ! this.checkProperty( 'exists' ) ) {
-			return 'notExists';
+			return NOT_EXISTS;
 		}
 		if ( ! this.checkProperty( 'isWordPress' ) ) {
-			return 'notWordPress';
+			return NOT_WORDPRESS;
 		}
 		if ( ! this.checkProperty( 'hasJetpack' ) ) {
-			return 'notJetpack';
+			return NOT_JETPACK;
 		}
 		const jetpackVersion = this.checkProperty( 'jetpackVersion' );
 		if ( jetpackVersion && versionCompare( jetpackVersion, MINIMUM_JETPACK_VERSION, '<' ) ) {
-			return 'outdatedJetpack';
+			return OUTDATED_JETPACK;
 		}
 		if ( ! this.checkProperty( 'isJetpackActive' ) ) {
-			return 'notActiveJetpack';
+			return NOT_ACTIVE_JETPACK;
 		}
 		if (
 			! this.checkProperty( 'isJetpackConnected' ) ||
 			( this.checkProperty( 'isJetpackConnected' ) && ! this.checkProperty( 'userOwnsSite' ) )
 		) {
-			return 'notConnectedJetpack';
+			return NOT_CONNECTED_JETPACK;
 		}
 		if ( this.checkProperty( 'isJetpackConnected' ) && this.checkProperty( 'userOwnsSite' ) ) {
-			return 'alreadyConnected';
+			return ALREADY_CONNECTED;
 		}
 
 		return false;
@@ -374,19 +386,19 @@ export class JetpackConnectMain extends Component {
 		const { translate } = this.props;
 		return {
 			headerTitle:
-				'notJetpack' === status
+				NOT_JETPACK === status
 					? translate( 'Ready for installation' )
 					: translate( 'Ready for activation' ),
 			headerSubtitle: translate(
 				"We'll need to send you to your site dashboard for a few manual steps."
 			),
 			steps:
-				'notJetpack' === status
+				NOT_JETPACK === status
 					? [ 'installJetpack', 'activateJetpackAfterInstall', 'connectJetpackAfterInstall' ]
 					: [ 'activateJetpack', 'connectJetpack' ],
-			buttonOnClick: 'notJetpack' === status ? this.installJetpack : this.activateJetpack,
+			buttonOnClick: NOT_JETPACK === status ? this.installJetpack : this.activateJetpack,
 			buttonText:
-				'notJetpack' === status ? translate( 'Install Jetpack' ) : translate( 'Activate Jetpack' ),
+				NOT_JETPACK === status ? translate( 'Install Jetpack' ) : translate( 'Activate Jetpack' ),
 		};
 	}
 
@@ -533,7 +545,7 @@ export class JetpackConnectMain extends Component {
 	render() {
 		const status = this.getStatus();
 		if (
-			includes( [ 'notJetpack', 'notActiveJetpack' ], status ) &&
+			includes( [ NOT_JETPACK, NOT_ACTIVE_JETPACK ], status ) &&
 			! this.props.jetpackConnectSite.isDismissed
 		) {
 			return this.renderInstructions( this.getInstructionsData( status ) );


### PR DESCRIPTION
Don't expect string literals to match across files. Use exported shared constants. Modeled after redux action types.

No visual changes
No functional changes

## Testing
1. Visually verify the constants correspond to the names they replace
1. Try the connection flow with errors at the site input and authorize steps.
1. Notices should display as before.