### PR TITLE
TreeSelect: fix example fn

### DIFF
--- a/client/lib/tree-select/README.md
+++ b/client/lib/tree-select/README.md
@@ -7,7 +7,7 @@ It is called `treeSelect` because it internally uses a tree of dependencies to a
 
 `treeSelect` accepts the following arguments:
 
-* **getDependents**: A function which maps over `state` and returns all of the relevant parts of state the selector needs. You should be creating an object whose values are all the returns of other selectors -- no computations allowed here.
+* **getDependents**: A function which maps over `state` and returns all of the relevant parts of state the selector needs. You should be creating an array whose elements are all return values of other selectors -- no computations allowed here.
 * **selector**: A function which takes in the same args as `getDependents` with one catch. Instead of being passed state as its first arg, it is given the results of getDependents. This forces you to declare all of your state-dependencies.
 
 For example, imagine that our state contains post objects, each of which are assigned to a particular site. Retrieving an array of posts for a specific site would require us to filter over all of the known posts. While this would normally trigger a re-render in React, we can use `treeSelect` to create a cached version of the selector which can return a referentially equal object:

--- a/client/lib/tree-select/README.md
+++ b/client/lib/tree-select/README.md
@@ -7,13 +7,13 @@ It is called `treeSelect` because it internally uses a tree of dependencies to a
 
 `treeSelect` accepts the following arguments:
 
-* **getDependents**: A function which maps over `state` and returns all of the relevant parts of state the selector needs. You should be creating an object whose values are all the return of other selectors -- no computations allowed here.
+* **getDependents**: A function which maps over `state` and returns all of the relevant parts of state the selector needs. You should be creating an object whose values are all the returns of other selectors -- no computations allowed here.
 * **selector**: A function which takes in the same args as `getDependents` with one catch. Instead of being passed state as its first arg, it is given the results of getDependents. This forces you to declare all of your state-dependencies.
 
 For example, imagine that our state contains post objects, each of which are assigned to a particular site. Retrieving an array of posts for a specific site would require us to filter over all of the known posts. While this would normally trigger a re-render in React, we can use `treeSelect` to create a cached version of the selector which can return a referentially equal object:
 
 ```js
-const getDependents = state => ( { posts: state.posts } );
+const getDependents = state => ( [ state.posts ] );
 const selector = ( [ posts ], siteId ) => filter( posts, { siteId } );
 
 const getSitePosts = treeSelect( selector, getDependents );


### PR DESCRIPTION
I was reading `treeSelect`'s [README](https://github.com/Automattic/wp-calypso/blob/master/client/lib/tree-select/README.md), trying to understand this genius function when I stumbled upon a bug in the README's code example.

In this PR, we fix that!