### PR TITLE
Remove unneeded selectors from stats/utils

### DIFF
--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { throttle } from 'lodash';
+import { max, throttle, values } from 'lodash';
 import i18n, { localize } from 'i18n-calypso';
 
 /**
@@ -21,7 +21,7 @@ import SectionHeader from 'components/section-header';
 import QuerySiteStats from 'components/data/query-site-stats';
 import { getSiteOption } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteStatsPostStreakData, getSiteStatsMaxPostsByDay } from 'state/stats/lists/selectors';
+import { getSiteStatsPostStreakData } from 'state/stats/lists/selectors';
 
 class PostTrends extends React.Component {
 	static displayName = 'PostTrends';
@@ -115,22 +115,18 @@ class PostTrends extends React.Component {
 	};
 
 	getMonthComponents = () => {
-		var i,
-			months = [],
-			startDate;
+		const { streakData } = this.props;
+		// Compute maximum per-day post count from the streakData. It's used to scale the chart.
+		const maxPosts = max( values( streakData ) );
+		const months = [];
 
-		for ( i = 11; i >= 0; i-- ) {
-			startDate = i18n
+		for ( let i = 11; i >= 0; i-- ) {
+			const startDate = i18n
 				.moment()
 				.subtract( i, 'months' )
 				.startOf( 'month' );
 			months.push(
-				<Month
-					key={ startDate.format( 'YYYYMM' ) }
-					startDate={ startDate }
-					streakData={ this.props.streakData }
-					max={ this.props.max }
-				/>
+				<Month key={ i } startDate={ startDate } streakData={ streakData } max={ maxPosts } />
 			);
 		}
 
@@ -209,7 +205,6 @@ const mapStateToProps = state => {
 
 	return {
 		streakData: getSiteStatsPostStreakData( state, siteId, query ),
-		max: getSiteStatsMaxPostsByDay( state, siteId, query ),
 		query,
 		siteId,
 	};

--- a/client/my-sites/stats/post-trends/index.jsx
+++ b/client/my-sites/stats/post-trends/index.jsx
@@ -21,11 +21,7 @@ import SectionHeader from 'components/section-header';
 import QuerySiteStats from 'components/data/query-site-stats';
 import { getSiteOption } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import {
-	getSiteStatsPostStreakData,
-	getSiteStatsMaxPostsByDay,
-	getSiteStatsTotalPostsForStreakQuery,
-} from 'state/stats/lists/selectors';
+import { getSiteStatsPostStreakData, getSiteStatsMaxPostsByDay } from 'state/stats/lists/selectors';
 
 class PostTrends extends React.Component {
 	static displayName = 'PostTrends';
@@ -60,14 +56,6 @@ class PostTrends extends React.Component {
 	// Remove listener
 	componentWillUnmount() {
 		window.removeEventListener( 'resize', this.resize );
-	}
-
-	shouldComponentUpdate( nextProps ) {
-		// only update if the total number of posts, or query.endDate has changed
-		return (
-			nextProps.totalPosts !== this.props.totalPosts ||
-			nextProps.query.endDate !== this.props.query.endDate
-		);
 	}
 
 	resize = () => {
@@ -222,7 +210,6 @@ const mapStateToProps = state => {
 	return {
 		streakData: getSiteStatsPostStreakData( state, siteId, query ),
 		max: getSiteStatsMaxPostsByDay( state, siteId, query ),
-		totalPosts: getSiteStatsTotalPostsForStreakQuery( state, siteId, query ),
 		query,
 		siteId,
 	};

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -98,20 +98,6 @@ export const getSiteStatsPostStreakData = treeSelect(
 );
 
 /**
- * Returns a number representing the posts made during a day for a given query
- *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @param  {Object}  query  Stats query object
- * @param  {String}  date   Date in YYYY-MM-DD format
- * @return {?Number}        Number of posts made on date
- */
-export function getSiteStatsPostsCountByDay( state, siteId, query, date ) {
-	const data = getSiteStatsPostStreakData( state, siteId, query );
-	return data[ date ] || null;
-}
-
-/**
  * Returns normalized stats data for a given query and stat type, or the un-normalized response
  * from the API if no normalizer method for that stats type exists in ./utils
  *

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { get, reduce, isArray, map, flatten } from 'lodash';
+import { get, isArray, map, flatten } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**
@@ -92,23 +92,6 @@ export const getSiteStatsPostStreakData = treeSelect(
 
 		return response;
 	},
-	{
-		getCacheKey: ( siteId, query ) => [ siteId, getSerializedStatsQuery( query ) ].join(),
-	}
-);
-
-/**
- * Returns a number representing the most posts made during a day for a given query
- *
- * @param  {Object}  state    Global state tree
- * @param  {Number}  siteId   Site ID
- * @param  {Object}  query    Stats query object
- * @return {?Number}          Max number of posts by day
- */
-export const getSiteStatsMaxPostsByDay = treeSelect(
-	( state, siteId, query ) => [ getSiteStatsPostStreakData( state, siteId, query ) ],
-	( [ postStreakData ] ) =>
-		reduce( postStreakData, ( max, count ) => ( count > max ? count : max ), 0 ) || null,
 	{
 		getCacheKey: ( siteId, query ) => [ siteId, getSerializedStatsQuery( query ) ].join(),
 	}

--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -115,22 +115,6 @@ export const getSiteStatsMaxPostsByDay = treeSelect(
 );
 
 /**
- * Returns the total number of posts per streak data for a query
- *
- * @param  {Object}  state    Global state tree
- * @param  {Number}  siteId   Site ID
- * @param  {Object}  query    Stats query object
- * @return {?Number}          Max number of posts by day
- */
-export const getSiteStatsTotalPostsForStreakQuery = treeSelect(
-	( state, siteId, query ) => [ getSiteStatsPostStreakData( state, siteId, query ) ],
-	( [ postStreakData ] ) => reduce( postStreakData, ( sum, posts ) => sum + posts, 0 ),
-	{
-		getCacheKey: ( siteId, query ) => [ siteId, getSerializedStatsQuery( query ) ].join(),
-	}
-);
-
-/**
  * Returns a number representing the posts made during a day for a given query
  *
  * @param  {Object}  state  Global state tree

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -9,7 +9,6 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
-	getSiteStatsMaxPostsByDay,
 	getSiteStatsForQuery,
 	getSiteStatsPostStreakData,
 	getSiteStatsPostsCountByDay,
@@ -23,7 +22,6 @@ import { userState } from 'state/selectors/test/fixtures/user-state';
 describe( 'selectors', () => {
 	beforeEach( () => {
 		getSiteStatsPostStreakData.clearCache();
-		getSiteStatsMaxPostsByDay.clearCache();
 		getSiteStatsNormalizedData.clearCache();
 	} );
 
@@ -359,79 +357,6 @@ describe( 'selectors', () => {
 				'2016-04-30': 1,
 				'2016-05-01': 1,
 			} );
-		} );
-	} );
-
-	describe( 'getSiteStatsMaxPostsByDay()', () => {
-		test( 'should return null if no matching query results exist', () => {
-			const stats = getSiteStatsMaxPostsByDay(
-				{
-					stats: {
-						lists: {
-							items: {},
-						},
-					},
-				},
-				2916284,
-				{}
-			);
-
-			expect( stats ).to.be.null;
-		} );
-
-		test( 'should properly correct number of max posts grouped by day', () => {
-			const stats = getSiteStatsMaxPostsByDay(
-				{
-					stats: {
-						lists: {
-							items: {
-								2916284: {
-									statsStreak: {
-										'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
-											data: {
-												1461889800: 1, // 2016-04-29 00:30:00 (UTC)
-												1461972600: 1, // 2016-04-29 23:30:00 (UTC)
-												1462059000: 1, // 2016-04-30 23:30:00 (UTC)
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				2916284,
-				{ startDate: '2015-06-01', endDate: '2016-06-01' }
-			);
-
-			expect( stats ).to.eql( 2 );
-		} );
-
-		test( 'should compare numerically rather than lexically', () => {
-			const stats = getSiteStatsMaxPostsByDay(
-				{
-					stats: {
-						lists: {
-							items: {
-								2916284: {
-									statsStreak: {
-										'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
-											data: {
-												1461889800: 12, // 2016-04-29 00:30:00 (UTC)
-												1462059000: 2, // 2016-04-30 23:30:00 (UTC)
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				2916284,
-				{ startDate: '2015-06-01', endDate: '2016-06-01' }
-			);
-
-			expect( stats ).to.eql( 12 );
 		} );
 	} );
 

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -11,7 +11,6 @@ import { expect } from 'chai';
 import {
 	getSiteStatsForQuery,
 	getSiteStatsPostStreakData,
-	getSiteStatsPostsCountByDay,
 	getSiteStatsNormalizedData,
 	isRequestingSiteStatsForQuery,
 	getSiteStatsCSVData,
@@ -357,54 +356,6 @@ describe( 'selectors', () => {
 				'2016-04-30': 1,
 				'2016-05-01': 1,
 			} );
-		} );
-	} );
-
-	describe( 'getSiteStatsPostsCountByDay()', () => {
-		test( 'should return null if no matching query results exist', () => {
-			const stats = getSiteStatsPostsCountByDay(
-				{
-					stats: {
-						lists: {
-							items: {},
-						},
-					},
-				},
-				2916284,
-				{},
-				'2016-06-01'
-			);
-
-			expect( stats ).to.be.null;
-		} );
-
-		test( 'should properly correct number of max posts for a day', () => {
-			const stats = getSiteStatsPostsCountByDay(
-				{
-					stats: {
-						lists: {
-							items: {
-								2916284: {
-									statsStreak: {
-										'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
-											data: {
-												1461889800: 1, // 2016-04-29 00:30:00 (UTC)
-												1461972600: 1, // 2016-04-29 23:30:00 (UTC)
-												1462059000: 1, // 2016-04-30 23:30:00 (UTC)
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				2916284,
-				{ startDate: '2015-06-01', endDate: '2016-06-01' },
-				'2016-04-29'
-			);
-
-			expect( stats ).to.eql( 2 );
 		} );
 	} );
 

--- a/client/state/stats/lists/test/selectors.js
+++ b/client/state/stats/lists/test/selectors.js
@@ -13,7 +13,6 @@ import {
 	getSiteStatsForQuery,
 	getSiteStatsPostStreakData,
 	getSiteStatsPostsCountByDay,
-	getSiteStatsTotalPostsForStreakQuery,
 	getSiteStatsNormalizedData,
 	isRequestingSiteStatsForQuery,
 	getSiteStatsCSVData,
@@ -25,7 +24,6 @@ describe( 'selectors', () => {
 	beforeEach( () => {
 		getSiteStatsPostStreakData.clearCache();
 		getSiteStatsMaxPostsByDay.clearCache();
-		getSiteStatsTotalPostsForStreakQuery.clearCache();
 		getSiteStatsNormalizedData.clearCache();
 	} );
 
@@ -361,52 +359,6 @@ describe( 'selectors', () => {
 				'2016-04-30': 1,
 				'2016-05-01': 1,
 			} );
-		} );
-	} );
-
-	describe( 'getSiteStatsTotalPostsForStreakQuery()', () => {
-		test( 'should return null if no matching query results exist', () => {
-			const stats = getSiteStatsTotalPostsForStreakQuery(
-				{
-					stats: {
-						lists: {
-							items: {},
-						},
-					},
-				},
-				2916284,
-				{}
-			);
-
-			expect( stats ).to.eql( 0 );
-		} );
-
-		test( 'should properly correct number of total posts', () => {
-			const stats = getSiteStatsTotalPostsForStreakQuery(
-				{
-					stats: {
-						lists: {
-							items: {
-								2916284: {
-									statsStreak: {
-										'[["endDate","2016-06-01"],["startDate","2015-06-01"]]': {
-											data: {
-												1461961382: 1,
-												1464110402: 1,
-												1464110448: 1,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				2916284,
-				{ startDate: '2015-06-01', endDate: '2016-06-01' }
-			);
-
-			expect( stats ).to.eql( 3 );
 		} );
 	} );
 


### PR DESCRIPTION
While working on #21507 and getting familiar with the Stats code, I realized that there are few selectors that can be removed. They are either not used, or can be replaced with something better:
- getSiteStatsTotalPostsForStreakQuery
- getSiteStatsMaxPostsByDay
- getSiteStatsPostsCountByDay

Read the commit messages for details.

**How to test:**
Go to `/stats/insights/a8c.tv` and play with the "Posting Activity" chart:

<img width="547" alt="posting-activity-chart" src="https://user-images.githubusercontent.com/664258/35097226-8d0fcdf6-fc4f-11e7-9123-dc0e9432d4e6.png">

When the width of the viewport is small, the chart should scroll and the scrolling arrows on the left and right site should switch between the "active" and "inactive" states. That verifies that the `PostTrends` component is rerendered when its state changes. That didn't work before, because its `shouldComponentUpdate` was broken and prevented the rerender.

Also, verify that the "dots" in the chart use the full spectrum of colors. That's what the `getSiteStatsMaxPostsByDay` selector used to help achieve and is now replaced by a computation directly in the `render` method.