### PR TITLE
Jetpack Connect: Use correct site slug for subdir installs

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -88,7 +88,6 @@ export class JetpackAuthorize extends Component {
 		isFetchingSites: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
 		retryAuth: PropTypes.func.isRequired,
-		siteSlug: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 		user: PropTypes.object.isRequired,
 		userAlreadyConnected: PropTypes.bool.isRequired,
@@ -520,8 +519,7 @@ export class JetpackAuthorize extends Component {
 	}
 
 	getRedirectionTarget() {
-		const { siteSlug } = this.props;
-		const { clientId, partnerId, redirectAfterAuth } = this.props.authQuery;
+		const { clientId, homeUrl, partnerId, redirectAfterAuth } = this.props.authQuery;
 
 		// Redirect sites hosted on Pressable with a partner plan to some URL.
 		if (
@@ -531,7 +529,10 @@ export class JetpackAuthorize extends Component {
 			return `/start/pressable-nux?blogid=${ clientId }`;
 		}
 
-		return addQueryArgs( { redirect: redirectAfterAuth }, `${ JPC_PATH_PLANS }/${ siteSlug }` );
+		return addQueryArgs(
+			{ redirect: redirectAfterAuth },
+			`${ JPC_PATH_PLANS }/${ urlToSlug( homeUrl ) }`
+		);
 	}
 
 	renderFooterLinks() {
@@ -632,8 +633,6 @@ export class JetpackAuthorize extends Component {
 
 export default connect(
 	( state, { authQuery } ) => {
-		const siteSlug = urlToSlug( authQuery.homeUrl );
-
 		// Note: reading from a cookie here rather than redux state,
 		// so any change in value will not execute connect().
 		const mobileAppRedirect = retrieveMobileRedirect();
@@ -650,7 +649,6 @@ export default connect(
 			isFetchingSites: isRequestingSites( state ),
 			isMobileAppFlow,
 			mobileAppRedirect,
-			siteSlug,
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),
 		};

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -14,7 +14,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { addQueryArgs, externalRedirect } from 'lib/route';
 import AuthFormHeader from './auth-form-header';
 import Button from 'components/button';
 import Card from 'components/card';
@@ -34,6 +33,7 @@ import NoticeAction from 'components/notice/notice-action';
 import QueryUserConnection from 'components/data/query-user-connection';
 import Spinner from 'components/spinner';
 import userUtilities from 'lib/user/utils';
+import { addQueryArgs, externalRedirect } from 'lib/route';
 import { authQueryPropTypes, getRoleFromScope } from './utils';
 import { decodeEntities } from 'lib/formatting';
 import { getCurrentUser } from 'state/current-user/selectors';

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -632,7 +632,7 @@ export class JetpackAuthorize extends Component {
 
 export default connect(
 	( state, { authQuery } ) => {
-		const siteSlug = urlToSlug( authQuery.site );
+		const siteSlug = urlToSlug( authQuery.homeUrl );
 
 		// Note: reading from a cookie here rather than redux state,
 		// so any change in value will not execute connect().
@@ -640,7 +640,7 @@ export default connect(
 		const isMobileAppFlow = !! mobileAppRedirect;
 
 		return {
-			authAttempts: getAuthAttempts( state, siteSlug ),
+			authAttempts: getAuthAttempts( state, urlToSlug( authQuery.site ) ),
 			authorizationData: getAuthorizationData( state ),
 			calypsoStartedConnection: isCalypsoStartedConnection( authQuery.site ),
 			hasExpiredSecretError: hasExpiredSecretErrorSelector( state ),

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -11,6 +11,7 @@ export function authQueryTransformer( queryObject ) {
 	return {
 		// Required
 		clientId: parseInt( queryObject.client_id, 10 ),
+		homeUrl: queryObject.home_url,
 		nonce: queryObject._wp_nonce,
 		redirectUri: queryObject.redirect_uri,
 		scope: queryObject.scope,
@@ -24,7 +25,6 @@ export function authQueryTransformer( queryObject ) {
 		alreadyAuthorized: !! queryObject.already_authorized,
 		blogname: queryObject.blogname || null,
 		from: queryObject.from || '[unknown]',
-		homeUrl: queryObject.home_url || null,
 		jpVersion: queryObject.jp_version || null,
 		partnerId: parseInt( queryObject.partner_id, 10 ) || null,
 		redirectAfterAuth: queryObject.redirect_after_auth || null,
@@ -40,7 +40,7 @@ export const authQueryPropTypes = PropTypes.shape( {
 	blogname: PropTypes.string,
 	clientId: PropTypes.number.isRequired,
 	from: PropTypes.string.isRequired,
-	homeUrl: PropTypes.string,
+	homeUrl: PropTypes.string.isRequired,
 	jpVersion: PropTypes.string,
 	nonce: PropTypes.string.isRequired,
 	partnerId: PropTypes.number,


### PR DESCRIPTION
Fixes #13509

For sites where WordPress is installed in a subdirectory but the home url is top-level, the Calypso site slug does not contain the subdir part. Take this into account when redirecting after connection by using the home url instead of site url to generate a Calypso-style slug.

## Testing

* Test as-per #13509 
* Also test connecting a regular top-level site
* Also test connecting a site where the home url has a subdir

All of these scenarios should connect properly, then redirect to the plans page, then on to wp-admin after choosing a free plan.
