### PR TITLE
Rewind: Update rewind state when changing credentials

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/rewind/activate/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/activate/index.js
@@ -11,8 +11,13 @@ import i18n from 'i18n-calypso';
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { JETPACK_CREDENTIALS_AUTOCONFIGURE, JETPACK_CREDENTIALS_STORE } from 'state/action-types';
+import {
+	JETPACK_CREDENTIALS_AUTOCONFIGURE,
+	JETPACK_CREDENTIALS_STORE,
+	REWIND_STATE_UPDATE,
+} from 'state/action-types';
 import { successNotice, errorNotice } from 'state/notices/actions';
+import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
 
 export const fetch = ( { dispatch }, action ) => {
 	const notice = successNotice( i18n.translate( 'Obtaining your credentials…' ) );
@@ -32,7 +37,7 @@ export const fetch = ( { dispatch }, action ) => {
 	);
 };
 
-export const storeAndAnnounce = ( { dispatch }, { siteId, noticeId } ) => {
+export const storeAndAnnounce = ( { dispatch }, { siteId, noticeId }, { rewind_state } ) => {
 	dispatch( {
 		type: JETPACK_CREDENTIALS_STORE,
 		credentials: { main: { type: 'auto' } }, // fake for now until data actually comes through
@@ -45,6 +50,17 @@ export const storeAndAnnounce = ( { dispatch }, { siteId, noticeId } ) => {
 			id: noticeId,
 		} )
 	);
+
+	// the API transform could fail and the rewind data might
+	// be unavailable so if that's the case just let it go
+	// for now. we'll improve our rigor as time goes by.
+	try {
+		dispatch( {
+			type: REWIND_STATE_UPDATE,
+			siteId,
+			data: transformApi( rewind_state ),
+		} );
+	} catch ( e ) {}
 };
 
 export const announceFailure = ( { dispatch }, { noticeId } ) => {

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -16,8 +16,10 @@ import {
 	JETPACK_CREDENTIALS_UPDATE_SUCCESS,
 	JETPACK_CREDENTIALS_UPDATE_FAILURE,
 	JETPACK_CREDENTIALS_STORE,
+	REWIND_STATE_UPDATE,
 } from 'state/action-types';
 import { successNotice, errorNotice } from 'state/notices/actions';
+import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
 
 export const request = ( { dispatch }, action ) => {
 	const notice = successNotice( i18n.translate( 'Testing connection…' ), { duration: 4000 } );
@@ -38,7 +40,7 @@ export const request = ( { dispatch }, action ) => {
 	);
 };
 
-export const success = ( { dispatch }, action ) => {
+export const success = ( { dispatch }, action, { rewind_state } ) => {
 	dispatch( {
 		type: JETPACK_CREDENTIALS_UPDATE_SUCCESS,
 		siteId: action.siteId,
@@ -58,6 +60,17 @@ export const success = ( { dispatch }, action ) => {
 			id: action.noticeId,
 		} )
 	);
+
+	// the API transform could fail and the rewind data might
+	// be unavailable so if that's the case just let it go
+	// for now. we'll improve our rigor as time goes by.
+	try {
+		dispatch( {
+			type: REWIND_STATE_UPDATE,
+			siteId: action.siteId,
+			data: transformApi( rewind_state ),
+		} );
+	} catch ( e ) {}
 };
 
 export const failure = ( { dispatch }, action, error ) => {


### PR DESCRIPTION
The credentials banner and credentials form are still dependent on old
API calls we have decided to stop relying on. Their logic is replicated
in here in an almost-identical way as it is in the server, but it's not
entirely the same, plus it's duplicated.

In D9399 we're returning the `rewind_state` as an additional property on
calls to the credentials endpoints so that we can start gradually
replacing the old API calls with the centralized `/rewind` API.

This patch incorporates our ability to read and inject that response
into Calypso. It shouldn't have any effect until the server starts
sending those updates.

This is part of ongoing work to harmonize behaviors across Activity Log
and Rewind against the centralized "state machine" API

**Testing**

Right now there should be no visual changes to the app.
To test though, apply D9399 and sandbox `public-api.wordperss.com`
In **My Sites** > **Settings** > **Security** for a site with Rewindability
you should be able to play around with the credentials form.

Check on the Redux state under `state.rewind[ siteId ]`.
After each call to add, remove, or auto-configure the credentials you
should see updates to the Rewind state.

Without D9399 applied there should be no errors after these credentials
changes. The state will probably not be updated (but may due to stray polling).

http://iscalypsofastyet.com/branch?branch=rewind/update-state-on-credentials-work
https://dserve.a8c.com/?branch=rewind/update-state-on-credentials-work

```
Delta:
chunk     stat_size           parsed_size           gzip_size
build       +1376 B  (+0.0%)       +534 B  (+0.0%)      +78 B  (+0.0%)
manifest       +0 B                  +0 B                -1 B  (-0.0%)
```