### PR TITLE
Devtools: Re-insert console dispatcher

### DIFF
--- a/client/state/console-dispatch/index.js
+++ b/client/state/console-dispatch/index.js
@@ -17,6 +17,8 @@ export const consoleDispatcher = next => ( ...args ) => {
 	const store = next( ...args );
 
 	if ( 'undefined' !== typeof window ) {
+		Object.assign( window, store );
+
 		Object.defineProperty( window, 'state', {
 			enumerable: true,
 			get: store.getState,


### PR DESCRIPTION
In #21015 we [stopped exporting the action types](https://github.com/Automattic/wp-calypso/pull/21015/files#diff-b5287c8e411f9b84e6c5f9baab18fbcfL24) as a separate
global in the console dispatcher. It was decided that doing so
wasn't all that valuable in practice and we were eliminating the
entire `action-types` module so we wanted to remove this dependency
on it.

In that patch I accidentally also removed the console dispatcher.
This adds it back.