### PR TITLE
JP Onboarding: Prepopulate Business Address Fields

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import { map } from 'lodash';
+import { get, map } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -23,13 +23,13 @@ import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
-	state = {
-		city: '',
-		name: '',
-		state: '',
-		street: '',
-		zip: '',
-	};
+	state = get( this.props.settings, 'businessAddress' );
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.isRequestingSettings && ! nextProps.isRequestingSettings ) {
+			this.setState( nextProps.settings.businessAddress );
+		}
+	}
 
 	getChangeHandler = field => event => {
 		this.setState( { [ field ]: event.target.value } );

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -51,6 +51,10 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 
 	handleSubmit = event => {
 		event.preventDefault();
+		if ( this.props.isRequestingSettings ) {
+			return;
+		}
+
 		const { siteId } = this.props;
 		this.props.saveJetpackOnboardingSettings( siteId, { businessAddress: this.state } );
 		page( this.props.getForwardUrl() );

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -61,7 +61,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { isRequestingSettings, translate } = this.props;
 		const headerText = translate( 'Add a business address.' );
 		const subHeaderText = translate(
 			'Enter your business address to have a map added to your website.'
@@ -84,6 +84,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 								<FormLabel htmlFor={ fieldName }>{ fieldLabel }</FormLabel>
 								<FormTextInput
 									autoFocus={ fieldName === 'name' }
+									disabled={ isRequestingSettings }
 									id={ fieldName }
 									onChange={ this.getChangeHandler( fieldName ) }
 									required={ fieldName !== 'state' }
@@ -91,7 +92,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 								/>
 							</FormFieldset>
 						) ) }
-						<Button primary type="submit">
+						<Button disabled={ isRequestingSettings } primary type="submit">
 							{ translate( 'Next Step' ) }
 						</Button>
 					</form>

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -23,10 +23,20 @@ import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
-	state = get( this.props.settings, 'businessAddress' );
+	state = get( this.props.settings, 'businessAddress', {
+		city: '',
+		name: '',
+		state: '',
+		street: '',
+		zip: '',
+	} );
 
 	componentWillReceiveProps( nextProps ) {
-		if ( this.props.isRequestingSettings && ! nextProps.isRequestingSettings ) {
+		if (
+			this.props.isRequestingSettings &&
+			! nextProps.isRequestingSettings &&
+			nextProps.settings.businessAddress
+		) {
 			this.setState( nextProps.settings.businessAddress );
 		}
 	}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/96308/35104226-83960c2c-fc68-11e7-90b8-807cfb83982b.png)

Addresses some of #21684.

To test:
* Checkout this branch on your local Calypso.
* Make sure you're running latest `master` on your JP sandbox.
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
* Wait until being redirected to the JPO flow in Calypso.
* Skip through the flow till the `Add a business address` step
* Add input data and move to the `Next step`
* Click 'Back' -- verify that input fields show your updated settings.