### PR TITLE
Jetpack connect: Use keyedReducer for authorizeAttempts

### DIFF
--- a/client/state/jetpack-connect/reducer/jetpack-auth-attempts.js
+++ b/client/state/jetpack-connect/reducer/jetpack-auth-attempts.js
@@ -28,7 +28,7 @@ export function authAttempts( state = undefined, { type, attemptNumber } ) {
 	return state;
 }
 
-const reducer = keyedReducer( 'slug', authAttempts );
+export const reducer = keyedReducer( 'slug', authAttempts );
 reducer.schema = jetpackAuthAttemptsSchema;
 
 export default reducer;

--- a/client/state/jetpack-connect/reducer/jetpack-auth-attempts.js
+++ b/client/state/jetpack-connect/reducer/jetpack-auth-attempts.js
@@ -8,29 +8,27 @@ import { JETPACK_CONNECT_COMPLETE_FLOW, JETPACK_CONNECT_RETRY_AUTH } from 'state
 import { jetpackAuthAttemptsSchema } from './schema';
 import { keyedReducer } from 'state/utils';
 
-const jetpackAuthAttempts = keyedReducer(
-	'slug',
-	( state = undefined, { type, attemptNumber } ) => {
-		switch ( type ) {
-			case JETPACK_CONNECT_RETRY_AUTH:
-				const currentTimestamp = state ? state.timestamp : Date.now();
-				if ( attemptNumber > 0 && isStale( currentTimestamp, AUTH_ATTEMPS_TTL ) ) {
-					return {
-						attempt: 0,
-						timestamp: Date.now(),
-					};
-				}
+export function authAttempts( state = undefined, { type, attemptNumber } ) {
+	switch ( type ) {
+		case JETPACK_CONNECT_RETRY_AUTH:
+			if ( ! state || isStale( state.timestamp, AUTH_ATTEMPS_TTL ) ) {
 				return {
-					attempt: attemptNumber,
-					timestamp: currentTimestamp,
+					attempt: 0,
+					timestamp: Date.now(),
 				};
+			}
+			return {
+				attempt: attemptNumber,
+				timestamp: state.timestamp,
+			};
 
-			case JETPACK_CONNECT_COMPLETE_FLOW:
-				return undefined;
-		}
-		return state;
+		case JETPACK_CONNECT_COMPLETE_FLOW:
+			return undefined;
 	}
-);
-jetpackAuthAttempts.schema = jetpackAuthAttemptsSchema;
+	return state;
+}
 
-export default jetpackAuthAttempts;
+const reducer = keyedReducer( 'slug', authAttempts );
+reducer.schema = jetpackAuthAttemptsSchema;
+
+export default reducer;

--- a/client/state/jetpack-connect/reducer/test/jetpack-auth-attempts.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-auth-attempts.js
@@ -3,7 +3,7 @@
  * Internal dependencies
  */
 import jetpackAuthAttempts from '../jetpack-auth-attempts';
-import { JETPACK_CONNECT_RETRY_AUTH } from 'state/action-types';
+import { JETPACK_CONNECT_COMPLETE_FLOW, JETPACK_CONNECT_RETRY_AUTH } from 'state/action-types';
 
 describe( '#jetpackAuthAttempts()', () => {
 	test( 'should default to an empty object', () => {
@@ -49,5 +49,18 @@ describe( '#jetpackAuthAttempts()', () => {
 		);
 
 		expect( state[ 'example.com' ] ).toMatchObject( { attempt: 2 } );
+	} );
+
+	test( 'should clear state on completion', () => {
+		const slug = 'example.com';
+		const state = jetpackAuthAttempts(
+			{ [ slug ]: { timestamp: Date.now(), attempt: 1 } },
+			{
+				type: JETPACK_CONNECT_COMPLETE_FLOW,
+				slug,
+			}
+		);
+
+		expect( state ).not.toHaveProperty( slug );
 	} );
 } );

--- a/client/state/jetpack-connect/reducer/test/jetpack-auth-attempts.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-auth-attempts.js
@@ -2,27 +2,27 @@
 /**
  * Internal dependencies
  */
-import jetpackAuthAttempts from '../jetpack-auth-attempts';
+import { authAttempts } from '../jetpack-auth-attempts';
 import { JETPACK_CONNECT_COMPLETE_FLOW, JETPACK_CONNECT_RETRY_AUTH } from 'state/action-types';
 
-describe( '#jetpackAuthAttempts()', () => {
+describe( '#authAttempts()', () => {
 	test( 'should update the timestamp when adding an existent slug with stale timestamp', () => {
-		const state = jetpackAuthAttempts(
-			{ 'example.com': { timestamp: 1, attempt: 1 } },
+		const state = authAttempts(
+			{ timestamp: 1, attempt: 1 },
 			{
 				type: JETPACK_CONNECT_RETRY_AUTH,
 				slug: 'example.com',
 				attemptNumber: 2,
 			}
 		);
-		expect( state[ 'example.com' ] ).toMatchObject( {
+		expect( state ).toMatchObject( {
 			timestamp: expect.any( Number ),
 		} );
 	} );
 
 	test( 'should reset the attempt number to 0 when adding an existent slug with stale timestamp', () => {
-		const state = jetpackAuthAttempts(
-			{ 'example.com': { timestamp: 1, attempt: 1 } },
+		const state = authAttempts(
+			{ timestamp: 1, attempt: 1 },
 			{
 				type: JETPACK_CONNECT_RETRY_AUTH,
 				slug: 'example.com',
@@ -30,12 +30,12 @@ describe( '#jetpackAuthAttempts()', () => {
 			}
 		);
 
-		expect( state[ 'example.com' ] ).toMatchObject( { attempt: 0 } );
+		expect( state ).toMatchObject( { attempt: 0 } );
 	} );
 
 	test( 'should store the attempt number when adding an existent slug with non-stale timestamp', () => {
-		const state = jetpackAuthAttempts(
-			{ 'example.com': { timestamp: Date.now(), attempt: 1 } },
+		const state = authAttempts(
+			{ timestamp: Date.now(), attempt: 1 },
 			{
 				type: JETPACK_CONNECT_RETRY_AUTH,
 				slug: 'example.com',
@@ -43,19 +43,18 @@ describe( '#jetpackAuthAttempts()', () => {
 			}
 		);
 
-		expect( state[ 'example.com' ] ).toMatchObject( { attempt: 2 } );
+		expect( state ).toMatchObject( { attempt: 2 } );
 	} );
 
 	test( 'should clear state on completion', () => {
-		const slug = 'example.com';
-		const state = jetpackAuthAttempts(
-			{ [ slug ]: { timestamp: Date.now(), attempt: 1 } },
+		const state = authAttempts(
+			{ timestamp: Date.now(), attempt: 1 },
 			{
 				type: JETPACK_CONNECT_COMPLETE_FLOW,
-				slug,
+				slug: 'example.com',
 			}
 		);
 
-		expect( state ).not.toHaveProperty( slug );
+		expect( state ).not.toBeDefined();
 	} );
 } );

--- a/client/state/jetpack-connect/reducer/test/jetpack-auth-attempts.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-auth-attempts.js
@@ -6,11 +6,6 @@ import jetpackAuthAttempts from '../jetpack-auth-attempts';
 import { JETPACK_CONNECT_COMPLETE_FLOW, JETPACK_CONNECT_RETRY_AUTH } from 'state/action-types';
 
 describe( '#jetpackAuthAttempts()', () => {
-	test( 'should default to an empty object', () => {
-		const state = jetpackAuthAttempts( undefined, {} );
-		expect( state ).toEqual( {} );
-	} );
-
 	test( 'should update the timestamp when adding an existent slug with stale timestamp', () => {
 		const state = jetpackAuthAttempts(
 			{ 'example.com': { timestamp: 1, attempt: 1 } },

--- a/client/state/jetpack-connect/reducer/test/jetpack-auth-attempts.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-auth-attempts.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import { authAttempts } from '../jetpack-auth-attempts';
+import { authAttempts, reducer } from '../jetpack-auth-attempts';
 import { JETPACK_CONNECT_COMPLETE_FLOW, JETPACK_CONNECT_RETRY_AUTH } from 'state/action-types';
 
 describe( '#authAttempts()', () => {
@@ -56,5 +56,32 @@ describe( '#authAttempts()', () => {
 		);
 
 		expect( state ).not.toBeDefined();
+	} );
+} );
+
+describe( '#reducer()', () => {
+	test( 'should be keyed by slug', () => {
+		const previousState = {
+			nonMatchingSlug: {
+				attempt: 1,
+				timestamp: 12345,
+			},
+			'example.com': {
+				attempt: 1,
+				timestamp: Infinity,
+			},
+		};
+		const nextState = reducer( previousState, {
+			type: JETPACK_CONNECT_RETRY_AUTH,
+			attemptNumber: 2,
+			slug: 'example.com',
+		} );
+		expect( nextState ).toMatchObject( {
+			nonMatchingSlug: previousState.nonMatchingSlug,
+			'example.com': {
+				attempt: 2,
+				timestamp: expect.any( Number ),
+			},
+		} );
 	} );
 } );


### PR DESCRIPTION
The authorizeAttempts reducer was implementing its own version of a `keyedReducer`. This PR updates the reducer to use the `keyedReducer` supplied by Calypso's `state/utils`.

Tests are updated accordingly to test the unwrapped reducer rather than the functionality provided by `keyedReducer`.

## Follow-up

Rework the logic so that incrementing state occurs inside the reducer rather than expecting updated state to be passed in.