### PR TITLE
Store: Emails Settings inform about default value

### DIFF
--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
@@ -15,7 +15,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import ListItem from 'woocommerce/components/list/list-item';
 import ListItemField from 'woocommerce/components/list/list-item-field';
 
-const CustomerNotification = ( { item, checked, onChange, isPlaceholder } ) => {
+const CustomerNotification = ( { item, checked, onChange, loading } ) => {
 	//Add field name to returned value
 	const toggle = value => {
 		onChange( {
@@ -28,19 +28,19 @@ const CustomerNotification = ( { item, checked, onChange, isPlaceholder } ) => {
 	return (
 		<ListItem className="components__notification-component-item">
 			<ListItemField className="components__notification-component-title-long">
-				{ ! isPlaceholder ? (
+				{ ! loading ? (
 					<FormLabel>{ item.title }</FormLabel>
 				) : (
 					<p className="components__is-placeholder" />
 				) }
-				{ ! isPlaceholder ? (
+				{ ! loading ? (
 					<FormSettingExplanation>{ item.subtitle }</FormSettingExplanation>
 				) : (
 					<p className="components__is-placeholder" />
 				) }
 			</ListItemField>
 			<ListItemField className="components__notification-component-toggle">
-				{ ! isPlaceholder ? (
+				{ ! loading ? (
 					<CompactFormToggle checked={ checked } onChange={ toggle } id={ item.field } />
 				) : (
 					<p className="components__is-placeholder" />

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/customer-notification.js
@@ -15,7 +15,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import ListItem from 'woocommerce/components/list/list-item';
 import ListItemField from 'woocommerce/components/list/list-item-field';
 
-const CustomerNotification = ( { item, checked, onChange, loading } ) => {
+const CustomerNotification = ( { item, checked, onChange, loaded } ) => {
 	//Add field name to returned value
 	const toggle = value => {
 		onChange( {
@@ -28,19 +28,19 @@ const CustomerNotification = ( { item, checked, onChange, loading } ) => {
 	return (
 		<ListItem className="components__notification-component-item">
 			<ListItemField className="components__notification-component-title-long">
-				{ ! loading ? (
+				{ loaded ? (
 					<FormLabel>{ item.title }</FormLabel>
 				) : (
 					<p className="components__is-placeholder" />
 				) }
-				{ ! loading ? (
+				{ loaded ? (
 					<FormSettingExplanation>{ item.subtitle }</FormSettingExplanation>
 				) : (
 					<p className="components__is-placeholder" />
 				) }
 			</ListItemField>
 			<ListItemField className="components__notification-component-toggle">
-				{ ! loading ? (
+				{ loaded ? (
 					<CompactFormToggle checked={ checked } onChange={ toggle } id={ item.field } />
 				) : (
 					<p className="components__is-placeholder" />
@@ -54,6 +54,7 @@ CustomerNotification.propTypes = {
 	checked: PropTypes.bool,
 	item: PropTypes.object,
 	onChange: PropTypes.func.isRequired,
+	loaded: PropTypes.bool,
 };
 
 export default CustomerNotification;

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -3,9 +3,9 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -26,6 +26,7 @@ const InternalNotification = ( {
 	onChange,
 	isPlaceholder,
 	placeholder,
+	translate,
 } ) => {
 	//Add field name to returned value
 	const toggle = value => {
@@ -61,15 +62,19 @@ const InternalNotification = ( {
 			<ListItemField className="components__notification-component-input">
 				<FormTextInput
 					className={ isPlaceholder ? 'components__is-placeholder' : null }
-					isError={ emailValidationError }
+					isError={ checked && emailValidationError }
 					name={ item.field }
 					onChange={ change }
 					value={ recipient }
 					placeholder={ placeholder }
 				/>
-				{ emailValidationError && (
-					<FormTextValidation isError={ true } text={ checkedEmails.messages[ 0 ].msg } />
-				) }
+				{ ! recipient &&
+					placeholder &&
+					checked && <FormTextValidation isWarning text={ translate( 'Default values used.' ) } /> }
+				{ checked &&
+					emailValidationError && (
+						<FormTextValidation isError text={ checkedEmails.messages[ 0 ].msg } />
+					) }
 			</ListItemField>
 			<ListItemField className="components__notification-component-toggle">
 				{ ! isPlaceholder ? (
@@ -89,4 +94,4 @@ InternalNotification.propTypes = {
 	onChange: PropTypes.func.isRequired,
 };
 
-export default InternalNotification;
+export default localize( InternalNotification );

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -19,7 +19,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextValidation from 'components/forms/form-input-validation';
 import { checkEmails } from './helpers';
 
-const InternalNotification = ( { item, recipient, checked, onChange, loading, translate } ) => {
+const InternalNotification = ( { item, recipient, checked, onChange, loaded, translate } ) => {
 	//Add field name to returned value
 	const toggle = value => {
 		onChange( {
@@ -44,8 +44,8 @@ const InternalNotification = ( { item, recipient, checked, onChange, loading, tr
 	return (
 		<ListItem className="components__notification-component-item">
 			<ListItemField className="components__notification-component-title">
-				{ ! loading ? <FormLabel>{ item.title }</FormLabel> : placeholderComponent }
-				{ ! loading ? (
+				{ loaded ? <FormLabel>{ item.title }</FormLabel> : placeholderComponent }
+				{ loaded ? (
 					<FormSettingExplanation>{ item.subtitle }</FormSettingExplanation>
 				) : (
 					placeholderComponent
@@ -53,7 +53,7 @@ const InternalNotification = ( { item, recipient, checked, onChange, loading, tr
 			</ListItemField>
 			<ListItemField className="components__notification-component-input">
 				<FormTextInput
-					className={ loading ? 'components__is-placeholder' : null }
+					className={ ! loaded ? 'components__is-placeholder' : null }
 					isError={ checked && emailValidationError }
 					name={ item.field }
 					onChange={ change }
@@ -65,7 +65,7 @@ const InternalNotification = ( { item, recipient, checked, onChange, loading, tr
 				) }
 			</ListItemField>
 			<ListItemField className="components__notification-component-toggle">
-				{ ! loading ? (
+				{ loaded ? (
 					<CompactFormToggle checked={ checked } onChange={ toggle } id={ item.field } />
 				) : (
 					placeholderComponent
@@ -79,6 +79,7 @@ InternalNotification.propTypes = {
 	checked: PropTypes.bool,
 	recipient: PropTypes.string,
 	item: PropTypes.object,
+	loaded: PropTypes.bool,
 	onChange: PropTypes.func.isRequired,
 };
 

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -65,7 +65,7 @@ const InternalNotification = ( {
 					name={ item.field }
 					onChange={ change }
 					value={ recipient }
-					placeholder={ isPlaceholder ? '' : translate( 'Enter recipients. Comma separated.' ) }
+					placeholder={ isPlaceholder ? '' : translate( 'Recipient email address.' ) }
 				/>
 				{ emailValidationError && (
 					<FormTextValidation isError text={ checkedEmails.messages[ 0 ].msg } />

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -65,7 +65,7 @@ const InternalNotification = ( {
 					name={ item.field }
 					onChange={ change }
 					value={ recipient }
-					placeholder={ isPlaceholder ? '' : translate( 'Recipient email address.' ) }
+					placeholder={ isPlaceholder ? '' : translate( 'Recipient email address(es).' ) }
 				/>
 				{ emailValidationError && (
 					<FormTextValidation isError text={ checkedEmails.messages[ 0 ].msg } />

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -5,6 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -24,7 +25,7 @@ const InternalNotification = ( {
 	checked,
 	onChange,
 	isPlaceholder,
-	placeholder,
+	translate,
 } ) => {
 	//Add field name to returned value
 	const toggle = value => {
@@ -64,12 +65,11 @@ const InternalNotification = ( {
 					name={ item.field }
 					onChange={ change }
 					value={ recipient }
-					placeholder={ placeholder }
+					placeholder={ isPlaceholder ? '' : translate( 'Enter recipients. Comma separated.' ) }
 				/>
-				{ checked &&
-					emailValidationError && (
-						<FormTextValidation isError text={ checkedEmails.messages[ 0 ].msg } />
-					) }
+				{ emailValidationError && (
+					<FormTextValidation isError text={ checkedEmails.messages[ 0 ].msg } />
+				) }
 			</ListItemField>
 			<ListItemField className="components__notification-component-toggle">
 				{ ! isPlaceholder ? (
@@ -89,4 +89,4 @@ InternalNotification.propTypes = {
 	onChange: PropTypes.func.isRequired,
 };
 
-export default InternalNotification;
+export default localize( InternalNotification );

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -19,14 +19,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextValidation from 'components/forms/form-input-validation';
 import { checkEmails } from './helpers';
 
-const InternalNotification = ( {
-	item,
-	recipient,
-	checked,
-	onChange,
-	isPlaceholder,
-	translate,
-} ) => {
+const InternalNotification = ( { item, recipient, checked, onChange, loading, translate } ) => {
 	//Add field name to returned value
 	const toggle = value => {
 		onChange( {
@@ -51,8 +44,8 @@ const InternalNotification = ( {
 	return (
 		<ListItem className="components__notification-component-item">
 			<ListItemField className="components__notification-component-title">
-				{ ! isPlaceholder ? <FormLabel>{ item.title }</FormLabel> : placeholderComponent }
-				{ ! isPlaceholder ? (
+				{ ! loading ? <FormLabel>{ item.title }</FormLabel> : placeholderComponent }
+				{ ! loading ? (
 					<FormSettingExplanation>{ item.subtitle }</FormSettingExplanation>
 				) : (
 					placeholderComponent
@@ -60,7 +53,7 @@ const InternalNotification = ( {
 			</ListItemField>
 			<ListItemField className="components__notification-component-input">
 				<FormTextInput
-					className={ isPlaceholder ? 'components__is-placeholder' : null }
+					className={ loading ? 'components__is-placeholder' : null }
 					isError={ checked && emailValidationError }
 					name={ item.field }
 					onChange={ change }
@@ -72,7 +65,7 @@ const InternalNotification = ( {
 				) }
 			</ListItemField>
 			<ListItemField className="components__notification-component-toggle">
-				{ ! isPlaceholder ? (
+				{ ! loading ? (
 					<CompactFormToggle checked={ checked } onChange={ toggle } id={ item.field } />
 				) : (
 					placeholderComponent

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -65,7 +65,7 @@ const InternalNotification = ( {
 					name={ item.field }
 					onChange={ change }
 					value={ recipient }
-					placeholder={ isPlaceholder ? '' : translate( 'Recipient email address(es).' ) }
+					placeholder={ translate( 'Recipient email address(es).' ) }
 				/>
 				{ emailValidationError && (
 					<FormTextValidation isError text={ checkedEmails.messages[ 0 ].msg } />

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/internal-notification.js
@@ -5,7 +5,6 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -26,7 +25,6 @@ const InternalNotification = ( {
 	onChange,
 	isPlaceholder,
 	placeholder,
-	translate,
 } ) => {
 	//Add field name to returned value
 	const toggle = value => {
@@ -68,9 +66,6 @@ const InternalNotification = ( {
 					value={ recipient }
 					placeholder={ placeholder }
 				/>
-				{ ! recipient &&
-					placeholder &&
-					checked && <FormTextValidation isWarning text={ translate( 'Default values used.' ) } /> }
 				{ checked &&
 					emailValidationError && (
 						<FormTextValidation isError text={ checkedEmails.messages[ 0 ].msg } />
@@ -94,4 +89,4 @@ InternalNotification.propTypes = {
 	onChange: PropTypes.func.isRequired,
 };
 
-export default localize( InternalNotification );
+export default InternalNotification;

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
@@ -20,7 +20,7 @@ const NotificationsOrigin = ( {
 	item,
 	recipient,
 	onChange,
-	isPlaceholder,
+	loading,
 	checkEmail,
 	translate,
 	placeholder,
@@ -40,9 +40,9 @@ const NotificationsOrigin = ( {
 
 	return (
 		<div className="components__notification-origin">
-			{ ! isPlaceholder ? <FormLabel>{ item.title }</FormLabel> : placeholderComponent }
+			{ ! loading ? <FormLabel>{ item.title }</FormLabel> : placeholderComponent }
 			<FormTextInput
-				className={ isPlaceholder ? 'components__is-placeholder' : null }
+				className={ loading ? 'components__is-placeholder' : null }
 				isError={ emailValidationError }
 				name={ item.field }
 				onChange={ change }
@@ -57,7 +57,7 @@ const NotificationsOrigin = ( {
 					} ) }
 				/>
 			) }
-			{ ! isPlaceholder ? (
+			{ ! loading ? (
 				<FormSettingExplanation>{ item.subtitle }</FormSettingExplanation>
 			) : (
 				placeholderComponent

--- a/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/components/notifications-origin.js
@@ -20,7 +20,7 @@ const NotificationsOrigin = ( {
 	item,
 	recipient,
 	onChange,
-	loading,
+	loaded,
 	checkEmail,
 	translate,
 	placeholder,
@@ -40,9 +40,9 @@ const NotificationsOrigin = ( {
 
 	return (
 		<div className="components__notification-origin">
-			{ ! loading ? <FormLabel>{ item.title }</FormLabel> : placeholderComponent }
+			{ loaded ? <FormLabel>{ item.title }</FormLabel> : placeholderComponent }
 			<FormTextInput
-				className={ loading ? 'components__is-placeholder' : null }
+				className={ ! loaded ? 'components__is-placeholder' : null }
 				isError={ emailValidationError }
 				name={ item.field }
 				onChange={ change }
@@ -57,7 +57,7 @@ const NotificationsOrigin = ( {
 					} ) }
 				/>
 			) }
-			{ ! loading ? (
+			{ loaded ? (
 				<FormSettingExplanation>{ item.subtitle }</FormSettingExplanation>
 			) : (
 				placeholderComponent
@@ -71,7 +71,7 @@ NotificationsOrigin.propTypes = {
 	item: PropTypes.object,
 	onChange: PropTypes.func.isRequired,
 	placeholder: PropTypes.string,
-	isPlaceholder: PropTypes.bool,
+	loaded: PropTypes.bool,
 	checkEmail: PropTypes.bool,
 };
 

--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -185,7 +185,6 @@ class Settings extends React.Component {
 				item={ item }
 				checked={ 'yes' === get( settings, [ item.field, 'enabled', 'value' ], '' ) }
 				recipient={ get( settings, [ item.field, 'recipient', 'value' ], '' ) }
-				placeholder={ get( settings, [ item.field, 'recipient', 'default' ], '' ) }
 				isPlaceholder={ loading }
 				onChange={ this.onChange }
 			/>

--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -163,12 +163,12 @@ class Settings extends React.Component {
 	};
 
 	renderOriginNotification = ( item, index ) => {
-		const { settings, loading } = this.props;
+		const { settings, loaded } = this.props;
 		return (
 			<NotificationsOrigin
 				key={ index }
 				item={ item }
-				loading={ loading }
+				loaded={ loaded }
 				recipient={ get( settings, [ item.field, item.option, 'value' ], '' ) }
 				placeholder={ get( settings, [ item.field, item.option, 'default' ], '' ) }
 				onChange={ this.onChange }
@@ -178,26 +178,26 @@ class Settings extends React.Component {
 	};
 
 	renderInternalNotification = ( item, index ) => {
-		const { settings, loading } = this.props;
+		const { settings, loaded } = this.props;
 		return (
 			<InternalNotification
 				key={ index }
 				item={ item }
 				checked={ 'yes' === get( settings, [ item.field, 'enabled', 'value' ], '' ) }
 				recipient={ get( settings, [ item.field, 'recipient', 'value' ], '' ) }
-				loading={ loading }
+				loaded={ loaded }
 				onChange={ this.onChange }
 			/>
 		);
 	};
 
 	renderCustomerNotification = ( item, index ) => {
-		const { settings, loading } = this.props;
+		const { settings, loaded } = this.props;
 		return (
 			<CustomerNotification
 				key={ index }
 				item={ item }
-				loading={ loading }
+				loaded={ loaded }
 				checked={ 'yes' === get( settings, [ item.field, 'enabled', 'value' ], '' ) }
 				onChange={ this.onChange }
 			/>

--- a/client/extensions/woocommerce/app/settings/email/email-settings/index.js
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/index.js
@@ -168,7 +168,7 @@ class Settings extends React.Component {
 			<NotificationsOrigin
 				key={ index }
 				item={ item }
-				isPlaceholder={ loading }
+				loading={ loading }
 				recipient={ get( settings, [ item.field, item.option, 'value' ], '' ) }
 				placeholder={ get( settings, [ item.field, item.option, 'default' ], '' ) }
 				onChange={ this.onChange }
@@ -185,7 +185,7 @@ class Settings extends React.Component {
 				item={ item }
 				checked={ 'yes' === get( settings, [ item.field, 'enabled', 'value' ], '' ) }
 				recipient={ get( settings, [ item.field, 'recipient', 'value' ], '' ) }
-				isPlaceholder={ loading }
+				loading={ loading }
 				onChange={ this.onChange }
 			/>
 		);
@@ -197,7 +197,7 @@ class Settings extends React.Component {
 			<CustomerNotification
 				key={ index }
 				item={ item }
-				isPlaceholder={ loading }
+				loading={ loading }
 				checked={ 'yes' === get( settings, [ item.field, 'enabled', 'value' ], '' ) }
 				onChange={ this.onChange }
 			/>

--- a/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
@@ -73,5 +73,8 @@
 		background-color: lighten($gray, 25%);
 		color: transparent;
 		cursor: default;
+		&::placeholder {
+			color: transparent;
+		}
 	}
 }

--- a/client/extensions/woocommerce/state/sites/settings/email/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/actions.js
@@ -4,7 +4,7 @@
  * @format
  */
 
-import { forEach, reduce, omit, get } from 'lodash';
+import { forEach, reduce, omit, get, has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -106,7 +106,9 @@ export const emailSettingsSubmitSettings = ( siteId, settings ) => dispatch => {
 	// disable if user has emptied the input field
 	forEach( [ 'email_new_order', 'email_cancelled_order', 'email_failed_order' ], option => {
 		if ( get( settings, [ option, 'recipient', 'value' ], '' ).trim() === '' ) {
-			settings[ option ].enabled.value = 'no';
+			if ( has( settings[ option ], 'enabled ' ) ) {
+				settings[ option ].enabled.value = 'no';
+			}
 		}
 	} );
 

--- a/client/extensions/woocommerce/state/sites/settings/email/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/actions.js
@@ -105,7 +105,7 @@ export const emailSettingsSubmitSettings = ( siteId, settings ) => dispatch => {
 
 	// disable if user has emptied the input field
 	forEach( [ 'email_new_order', 'email_cancelled_order', 'email_failed_order' ], option => {
-		if ( get( settings, [ option, 'recipient', 'value' ] ) === '' ) {
+		if ( get( settings, [ option, 'recipient', 'value' ], '' ).trim() === '' ) {
 			settings[ option ].enabled.value = 'no';
 		}
 	} );
@@ -117,7 +117,7 @@ export const emailSettingsSubmitSettings = ( siteId, settings ) => dispatch => {
 				result.push( {
 					group_id,
 					id,
-					value: option.value,
+					value: option.value.trim(),
 				} );
 			} );
 			return result;

--- a/client/extensions/woocommerce/state/sites/settings/email/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/actions.js
@@ -4,7 +4,7 @@
  * @format
  */
 
-import { forEach, reduce, omit } from 'lodash';
+import { forEach, reduce, omit, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -105,7 +105,7 @@ export const emailSettingsSubmitSettings = ( siteId, settings ) => dispatch => {
 
 	// disable if user has emptied the input field
 	forEach( [ 'email_new_order', 'email_cancelled_order', 'email_failed_order' ], option => {
-		if ( settings[ option ].recipient.value === '' ) {
+		if ( get( settings, [ option, 'recipient', 'value' ] ) === '' ) {
 			settings[ option ].enabled.value = 'no';
 		}
 	} );

--- a/client/extensions/woocommerce/state/sites/settings/email/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/actions.js
@@ -84,10 +84,10 @@ const settingsSubmit = siteId => ( {
 	siteId,
 } );
 
-const settingsSubmitSuccess = ( siteId, settings ) => ( {
+const settingsSubmitSuccess = ( siteId, update ) => ( {
 	type: WOOCOMMERCE_EMAIL_SETTINGS_SUBMIT_SUCCESS,
 	siteId,
-	settings,
+	update,
 } );
 
 const settingsSubmitFailure = ( siteId, { error } ) => ( {
@@ -103,6 +103,13 @@ export const emailSettingsSubmitSettings = ( siteId, settings ) => dispatch => {
 
 	dispatch( settingsSubmit( siteId ) );
 
+	// disable if user has emptied the input field
+	forEach( [ 'email_new_order', 'email_cancelled_order', 'email_failed_order' ], option => {
+		if ( settings[ option ].recipient.value === '' ) {
+			settings[ option ].enabled.value = 'no';
+		}
+	} );
+
 	const update = reduce(
 		omit( settings, [ 'save', 'isSaving', 'error' ] ),
 		( result, options, group_id ) => {
@@ -110,7 +117,7 @@ export const emailSettingsSubmitSettings = ( siteId, settings ) => dispatch => {
 				result.push( {
 					group_id,
 					id,
-					value: option.value || option.default,
+					value: option.value,
 				} );
 			} );
 			return result;

--- a/client/extensions/woocommerce/state/sites/settings/email/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/reducer.js
@@ -43,17 +43,14 @@ const process_data = data => {
 	} );
 
 	forEach( [ 'email_new_order', 'email_cancelled_order', 'email_failed_order' ], key => {
-		const option = get( options, [ key ], {} );
-		const def = get( option, [ 'recipient', 'default' ], false ) || defaultEmail;
-		const value = get( option, [ 'recipient', 'value' ], '' );
-		const noValue = value === '';
-		const updatedValue = noValue ? def : value;
-		const enabled = get( option, [ 'enabled', 'value' ], false ) === 'yes';
-		options[ key ] && ( options[ key ].recipient.default = def );
-
-		if ( enabled && noValue ) {
-			options[ key ].recipient.value = updatedValue;
+		if ( get( options, [ key, 'enabled', 'value' ] ) !== 'yes' ) {
+			return;
 		}
+		const _default = get( options, [ key, 'recipient', 'default' ] ) || defaultEmail;
+		options[ key ].recipient = {
+			default: _default,
+			value: get( options, [ key, 'recipient', 'value' ] ) || _default,
+		};
 	} );
 
 	// Decode1: &, <, > entities.

--- a/client/extensions/woocommerce/state/sites/settings/email/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/reducer.js
@@ -53,7 +53,7 @@ const process_data = data => {
 		};
 	} );
 
-	// Decode1: &, <, > entities.
+	// Decode: &, <, > entities.
 	const from_name = get( options, [ 'email', 'woocommerce_email_from_name', 'value' ], false );
 	if ( from_name ) {
 		options.email.woocommerce_email_from_name.value = decodeEntities( from_name );

--- a/client/extensions/woocommerce/state/sites/settings/email/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/test/actions.js
@@ -253,7 +253,7 @@ describe( 'actions', () => {
 				expect( dispatch ).to.have.been.calledWith( {
 					type: WOOCOMMERCE_EMAIL_SETTINGS_SUBMIT_SUCCESS,
 					siteId,
-					settings: data,
+					update: data,
 				} );
 			} );
 		} );

--- a/client/extensions/woocommerce/state/sites/settings/email/test/reducer.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/test/reducer.js
@@ -92,7 +92,7 @@ describe( 'reducer', () => {
 		expect( newState[ siteId ].settings.email ).to.deep.equal( expectedResult );
 	} );
 
-	test( 'should use default value from woocommerce_email_from_address for settings with no value or default.', () => {
+	test( 'should not use default value for settings with no value or default if option is disabled', () => {
 		const siteId = 123;
 		const settings = [
 			{
@@ -119,7 +119,61 @@ describe( 'reducer', () => {
 			email_new_order: {
 				recipient: {
 					value: '',
+					default: '',
+				},
+			},
+		};
+
+		const action = {
+			type: WOOCOMMERCE_EMAIL_SETTINGS_REQUEST_SUCCESS,
+			siteId,
+			data: settings,
+		};
+
+		const newState = reducer( {}, action );
+		expect( newState[ siteId ] ).to.exist;
+		expect( newState[ siteId ].settings ).to.exist;
+		expect( newState[ siteId ].settings.email ).to.deep.equal( expectedResult );
+	} );
+
+	test( 'should use default value for settings with no value or default if option is enabled', () => {
+		const siteId = 123;
+		const settings = [
+			{
+				id: 'woocommerce_email_from_address',
+				value: 'test@test.com',
+				group_id: 'email',
+				default: 'd@e.f',
+			},
+			{
+				id: 'recipient',
+				value: '',
+				group_id: 'email_new_order',
+				default: '',
+			},
+			{
+				id: 'enabled',
+				value: 'yes',
+				group_id: 'email_new_order',
+				default: 'yes',
+			},
+		];
+
+		const expectedResult = {
+			email: {
+				woocommerce_email_from_address: {
+					value: 'test@test.com',
 					default: 'd@e.f',
+				},
+			},
+			email_new_order: {
+				recipient: {
+					value: 'd@e.f',
+					default: 'd@e.f',
+				},
+				enabled: {
+					value: 'yes',
+					default: 'yes',
 				},
 			},
 		};


### PR DESCRIPTION
### Information
This is a proposal of a solution for a problem discussed in https://github.com/Automattic/wp-calypso/pull/21363#issuecomment-356450985 

### Testing
Go to: store -> settings -> email. In `Internal Notifications` section remove/add email values in text field. Disable/enable setting. Especially observe what happens when the field is empty.

![notices](https://user-images.githubusercontent.com/17271089/35108933-3511d0b0-fc75-11e7-8ce7-8ce5e24d28f1.gif)

Fixes #21837 