### PR TITLE
Jetpack Connect: Always prompt for login in mobile app flow

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -29,6 +29,7 @@ import { authQueryTransformer } from './utils';
 import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
 import { hideMasterbar, setSection, showMasterbar } from 'state/ui/actions';
 import { JPC_PATH_PLANS, MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
+import { login } from 'lib/paths';
 import { persistMobileRedirect, retrieveMobileRedirect, storePlan } from './persistence-utils';
 import { receiveJetpackOnboardingCredentials } from 'state/jetpack-onboarding/actions';
 import { sectionify } from 'lib/route';
@@ -156,6 +157,11 @@ export function connect( context, next ) {
 	const analyticsPageTitle = get( type, analyticsPageTitleByType, 'Jetpack Connect' );
 
 	debug( 'entered connect flow with params %o', params );
+
+	if ( retrieveMobileRedirect() && ! userModule.get() ) {
+		// Force login for mobile app flow. App will intercept and prompt native login.
+		return page.redirect( login( { isNative: true, redirectTo: context.path } ) );
+	}
 
 	const planSlug = getPlanSlugFromFlowType( type, interval );
 	planSlug && storePlan( planSlug );


### PR DESCRIPTION
The mobile app should never come into the jetpack connection flow logged-out, because prompting for login natively in the app is a much better experience.

It is hard for the app to tell if it is logged into wordpress.com (checking cookies is hard) so one technique it can use is to intercept log-in urls in the webview. Unfortunately, the connection flow generally shows a signup screen instead of going to a log-in url, which the app cannot differentiate from the logged-in flow.

This change redirects to the login screen immediately when logged-out in the mobile app flow.

## Testing
* Logged out, start the mobile app connection flow with a url such as:
```
http://calypso.localhost:3000/jetpack/connect?mobile_redirect=wordpress://jetpack-connection
http://calypso.localhost:3000/jetpack/connect?mobile_redirect=wordpress://jetpackconnection&url=http://elated-eater-275.jurassic.ninja/
```
* You should be sent to the /log-in page, then onwards to the connection flow after logging in
* Starting logged-in should be unchanged
* All other connection flows should be unchanged

/cc @koke 