### PR TITLE
Autofill host field with site slug in credentials form

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -6,6 +6,7 @@
 import React, { Component } from 'react';
 import { get, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -19,13 +20,14 @@ import FormTextArea from 'components/forms/form-textarea';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormPasswordInput from 'components/forms/form-password-input';
 import Gridicon from 'gridicons';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 export class CredentialsForm extends Component {
 	state = {
 		showPrivateKeyField: false,
 		form: {
 			protocol: this.props.protocol,
-			host: this.props.host,
+			host: this.props.host ? this.props.host : this.props.siteSlug,
 			port: this.props.port,
 			user: this.props.user,
 			pass: this.props.pass,
@@ -237,4 +239,10 @@ export class CredentialsForm extends Component {
 	}
 }
 
-export default localize( CredentialsForm );
+export default connect( state => {
+	const siteSlug = getSelectedSiteSlug( state );
+
+	return {
+		siteSlug,
+	};
+} )( localize( CredentialsForm ) );


### PR DESCRIPTION
This is part of an attempt to help make credentials entry easier for customers. We'll use Calypso's `siteSlug` value as the server address by default, since this is likely to be correct in most cases.

**Testing**

1. Attempt to add credentials for a non-Pressable site. Ensure the host field is pre-filled with the server address.
2. Make sure the address saves correctly and Rewind works.
3. Make sure you can change the address from what is prefilled, and it saves and persists on a new page load.