### PR TITLE
Add Tracks events to Reader site notification settings

### DIFF
--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -26,6 +26,7 @@ import {
 	subscribeToNewPostNotifications,
 	unsubscribeToNewPostNotifications,
 } from 'state/reader/follows/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class ReaderSiteNotificationSettings extends Component {
 	static displayName = 'ReaderSiteNotificationSettings';
@@ -59,30 +60,54 @@ class ReaderSiteNotificationSettings extends Component {
 		const { siteId } = this.props;
 		this.setState( { selected: text } );
 		this.props.updateNewPostEmailSubscription( siteId, text );
+
+		const tracksProperties = { site_id: siteId, delivery_frequency: text };
+		this.props.recordTracksEvent( 'calypso_reader_post_emails_set_frequency', tracksProperties );
 	};
 
 	toggleNewPostEmail = () => {
-		const toggleSubscription = this.props.sendNewPostsByEmail
-			? this.props.unsubscribeToNewPostEmail
-			: this.props.subscribeToNewPostEmail;
+		const { siteId } = this.props;
+		const tracksProperties = { site_id: siteId };
 
-		toggleSubscription( this.props.siteId );
+		if ( this.props.sendNewPostsByEmail ) {
+			this.props.unsubscribeToNewPostEmail( siteId );
+			this.props.recordTracksEvent( 'calypso_reader_post_emails_toggle_off', tracksProperties );
+		} else {
+			this.props.subscribeToNewPostEmail( siteId );
+			this.props.recordTracksEvent( 'calypso_reader_post_emails_toggle_on', tracksProperties );
+		}
 	};
 
 	toggleNewCommentEmail = () => {
-		const toggleSubscription = this.props.sendNewCommentsByEmail
-			? this.props.unsubscribeToNewCommentEmail
-			: this.props.subscribeToNewCommentEmail;
+		const { siteId } = this.props;
+		const tracksProperties = { site_id: siteId };
 
-		toggleSubscription( this.props.siteId );
+		if ( this.props.sendNewCommentsByEmail ) {
+			this.props.unsubscribeToNewCommentEmail( siteId );
+			this.props.recordTracksEvent( 'calypso_reader_comment_emails_toggle_off', tracksProperties );
+		} else {
+			this.props.subscribeToNewCommentEmail( siteId );
+			this.props.recordTracksEvent( 'calypso_reader_comment_emails_toggle_on', tracksProperties );
+		}
 	};
 
 	toggleNewPostNotification = () => {
-		const toggleSubscription = this.props.sendNewPostsByNotification
-			? this.props.unsubscribeToNewPostNotifications
-			: this.props.subscribeToNewPostNotifications;
+		const { siteId } = this.props;
+		const tracksProperties = { site_id: siteId };
 
-		toggleSubscription( this.props.siteId );
+		if ( this.props.sendNewPostsByNotification ) {
+			this.props.unsubscribeToNewPostNotifications( siteId );
+			this.props.recordTracksEvent(
+				'calypso_reader_post_notifications_toggle_off',
+				tracksProperties
+			);
+		} else {
+			this.props.subscribeToNewPostNotifications( siteId );
+			this.props.recordTracksEvent(
+				'calypso_reader_post_notifications_toggle_on',
+				tracksProperties
+			);
+		}
 	};
 
 	render() {
@@ -201,4 +226,5 @@ export default connect( mapStateToProps, {
 	unsubscribeToNewCommentEmail,
 	subscribeToNewPostNotifications,
 	unsubscribeToNewPostNotifications,
+	recordTracksEvent,
 } )( localize( ReaderSiteNotificationSettings ) );


### PR DESCRIPTION
Adds Tracks events to the notification settings popover in Reader. Specifically:
- calypso_reader_post_emails_set_frequency
- calypso_reader_post_emails_toggle_off/calypso_reader_post_emails_toggle_on
- calypso_reader_comment_emails_toggle_off/calypso_reader_comment_emails_toggle_on
- calypso_reader_post_notifications_toggle_off/calypso_reader_post_notifications_toggle_on

### To test

Turn on analytics debugging in your console with `localStorage.setItem('debug', 'calypso:analytics*');`.

Ensure that the correct Tracks event is fired when using each form control in the popover.

<img width="524" alt="screen shot 2018-01-18 at 19 02 54" src="https://user-images.githubusercontent.com/17325/35113582-35e87b1c-fc82-11e7-8ebe-f4b8b34b0a2b.png">
