### PR TITLE
Invites: Display invites in people management

### DIFF
--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -33,6 +33,8 @@ export default function() {
 		);
 
 		if ( isEnabled( 'manage/people/invites' ) ) {
+			page( '/people/invites', siteSelection, sites, makeLayout, clientRender );
+
 			page(
 				'/people/invites/:site_id',
 				peopleController.enforceSiteEnding,

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -41,8 +41,10 @@ class PeopleInvites extends React.PureComponent {
 		return (
 			<PeopleListItem
 				key={ invite.invite_key }
+				invite={ invite }
 				user={ user }
 				site={ site }
+				type="invite"
 				isSelectable={ false }
 			/>
 		);

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -36,7 +36,6 @@ class PeopleInvites extends React.PureComponent {
 		// the email).
 		const user = invite.user;
 		const gravatarUser = pick( user, 'ID', 'display_name', 'avatar_URL' );
-		const userNameOrEmail = user.name || user.login || user.email;
 
 		const { site } = this.props;
 
@@ -44,6 +43,7 @@ class PeopleInvites extends React.PureComponent {
 			<PeopleListItem
 				key={ invite.invite_key }
 				invite={ invite }
+				gravatarUser={ gravatarUser }
 				user={ user }
 				site={ site }
 				type="invite"

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -13,7 +13,9 @@ import { pick } from 'lodash';
  * Internal dependencies
  */
 import Main from 'components/main';
+import EmptyContent from 'components/empty-content';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import PeopleListSectionHeader from 'my-sites/people/people-list-section-header';
 import PeopleSectionNav from 'my-sites/people/people-section-nav';
 import PeopleListItem from 'my-sites/people/people-list-item';
 import Card from 'components/card';
@@ -57,14 +59,32 @@ class PeopleInvites extends React.PureComponent {
 		);
 	};
 
+	renderEmptyContent() {
+		const { translate } = this.props;
+
+		return <EmptyContent title={ translate( "You haven't sent any invites yet." ) } />;
+	}
+
+	renderPlaceholder() {
+		return (
+			<Card>
+				<PeopleListItem key="people-list-item-placeholder" />
+			</Card>
+		);
+	}
+
 	render() {
-		const { site, requesting, invites } = this.props;
+		const { invites, requesting, site, translate } = this.props;
 
 		if ( ! site || ! site.ID ) {
 			return null;
 		}
 
 		const hasInvites = !! ( invites && invites.length );
+		const count = ( ! requesting && hasInvites && invites.length ) || null;
+		const showPlaceholder = requesting && ! hasInvites;
+		const showEmptyContent = ! requesting && ! hasInvites;
+		const showSectionHeader = requesting || hasInvites;
 
 		return (
 			<Main className="people-invites">
@@ -73,8 +93,17 @@ class PeopleInvites extends React.PureComponent {
 
 				<div>
 					<PeopleSectionNav filter="invites" site={ site } />
-					{ requesting && ! hasInvites && <Card>Loading invites...</Card> }
-					{ hasInvites && invites.map( this.renderInvite ) }
+
+					{ showSectionHeader && (
+						<PeopleListSectionHeader
+							label={ translate( 'Invites' ) }
+							site={ site }
+							count={ count }
+						/>
+					) }
+					{ showPlaceholder && this.renderPlaceholder() }
+					{ showEmptyContent && this.renderEmptyContent() }
+					{ hasInvites && <Card>{ invites.map( this.renderInvite ) }</Card> }
 				</div>
 			</Main>
 		);

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -60,9 +60,15 @@ class PeopleInvites extends React.PureComponent {
 	};
 
 	renderEmptyContent() {
-		const { translate } = this.props;
+		const { site, translate } = this.props;
 
-		return <EmptyContent title={ translate( "You haven't sent any invites yet." ) } />;
+		return (
+			<EmptyContent
+				title={ translate( "You haven't sent any invites yet." ) }
+				action={ translate( 'Send Invite' ) }
+				actionURL={ `/people/new/${ site.slug }` }
+			/>
+		);
 	}
 
 	renderPlaceholder() {

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -19,7 +19,6 @@ import PeopleListSectionHeader from 'my-sites/people/people-list-section-header'
 import PeopleSectionNav from 'my-sites/people/people-section-nav';
 import PeopleListItem from 'my-sites/people/people-list-item';
 import Card from 'components/card';
-import Gravatar from 'components/gravatar';
 import QuerySiteInvites from 'components/data/query-site-invites';
 import { isRequestingInvitesForSite, getInvitesForSite } from 'state/invites/selectors';
 
@@ -49,13 +48,6 @@ class PeopleInvites extends React.PureComponent {
 				type="invite"
 				isSelectable={ false }
 			/>
-		);
-
-		return (
-			<Card key={ invite.invite_key }>
-				Invited <Gravatar user={ gravatarUser } /> <strong>{ userNameOrEmail }</strong> as{' '}
-				<strong>{ invite.role }</strong>
-			</Card>
 		);
 	};
 

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,13 +27,7 @@ class PeopleInvites extends React.PureComponent {
 	};
 
 	renderInvite = invite => {
-		// If an invite was sent to a WP.com user, the invite object will have
-		// either a display name (if set) or the WP.com username.  Invites can
-		// also be sent to any email address, in which case the other details
-		// will not be set (but the server will still set `avatar_URL` based on
-		// the email).
 		const user = invite.user;
-		const gravatarUser = pick( user, 'ID', 'display_name', 'avatar_URL' );
 
 		const { site } = this.props;
 
@@ -42,7 +35,6 @@ class PeopleInvites extends React.PureComponent {
 			<PeopleListItem
 				key={ invite.invite_key }
 				invite={ invite }
-				gravatarUser={ gravatarUser }
 				user={ user }
 				site={ site }
 				type="invite"

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -15,6 +15,7 @@ import { pick } from 'lodash';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PeopleSectionNav from 'my-sites/people/people-section-nav';
+import PeopleListItem from 'my-sites/people/people-list-item';
 import Card from 'components/card';
 import Gravatar from 'components/gravatar';
 import QuerySiteInvites from 'components/data/query-site-invites';
@@ -25,7 +26,7 @@ class PeopleInvites extends React.PureComponent {
 		site: PropTypes.object.isRequired,
 	};
 
-	renderInvite( invite ) {
+	renderInvite = invite => {
 		// If an invite was sent to a WP.com user, the invite object will have
 		// either a display name (if set) or the WP.com username.  Invites can
 		// also be sent to any email address, in which case the other details
@@ -35,13 +36,24 @@ class PeopleInvites extends React.PureComponent {
 		const gravatarUser = pick( user, 'ID', 'display_name', 'avatar_URL' );
 		const userNameOrEmail = user.name || user.login || user.email;
 
+		const { site } = this.props;
+
+		return (
+			<PeopleListItem
+				key={ invite.invite_key }
+				user={ user }
+				site={ site }
+				isSelectable={ false }
+			/>
+		);
+
 		return (
 			<Card key={ invite.invite_key }>
 				Invited <Gravatar user={ gravatarUser } /> <strong>{ userNameOrEmail }</strong> as{' '}
 				<strong>{ invite.role }</strong>
 			</Card>
 		);
-	}
+	};
 
 	render() {
 		const { site, requesting, invites } = this.props;
@@ -50,7 +62,7 @@ class PeopleInvites extends React.PureComponent {
 			return null;
 		}
 
-		const hasInvites = invites && invites.length;
+		const hasInvites = !! ( invites && invites.length );
 
 		return (
 			<Main className="people-invites">

--- a/client/my-sites/people/people-list-item/README.md
+++ b/client/my-sites/people/people-list-item/README.md
@@ -1,5 +1,5 @@
 PeopleListItem
 ==============
 
-This component is used to render items within the ViewersList, the TeamList, and the FollowersList.
-It will display a person's avatar, a small stack of information about the user, as well as an action button for followers and viewers. TeamList does not require an action button.
+This component is used to render items within the ViewersList, the TeamList, the FollowersList, and PeopleInvites.
+It will display a person's avatar, a small stack of information about the user, as well as an action button for followers, viewers, and invites. TeamList does not require an action button.

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -53,6 +53,7 @@ class PeopleListItem extends React.PureComponent {
 	};
 
 	render() {
+		const { className, gravatarUser, invite, onRemove, translate, type, user } = this.props;
 		const canLinkToProfile = this.canLinkToProfile();
 		const tagName = canLinkToProfile ? 'a' : 'span';
 
@@ -61,29 +62,34 @@ class PeopleListItem extends React.PureComponent {
 				{ ...omit(
 					this.props,
 					'className',
+					'gravatarUser',
+					'invite',
 					'user',
 					'site',
 					'isSelectable',
 					'onRemove',
 					'moment',
 					'numberFormat',
-					'translate'
+					'translate',
+					'type'
 				) }
-				className={ classNames( 'people-list-item', this.props.className ) }
+				className={ classNames( 'people-list-item', className ) }
 				tagName={ tagName }
 				href={ this.getCardLink() }
 				onClick={ canLinkToProfile && this.navigateToUser }
 			>
 				<div className="people-list-item__profile-container">
-					<PeopleProfile user={ this.props.user } />
+					<PeopleProfile
+						invite={ invite }
+						gravatarUser={ gravatarUser }
+						type={ type }
+						user={ user }
+					/>
 				</div>
-				{ this.props.onRemove && (
+				{ onRemove && (
 					<div className="people-list-item__actions">
-						<button
-							className="button is-link people-list-item__remove-button"
-							onClick={ this.props.onRemove }
-						>
-							{ this.props.translate( 'Remove', {
+						<button className="button is-link people-list-item__remove-button" onClick={ onRemove }>
+							{ translate( 'Remove', {
 								context: 'Verb: Remove a user or follower from the blog.',
 							} ) }
 						</button>

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -44,6 +44,14 @@ class PeopleListItem extends React.PureComponent {
 		);
 	};
 
+	getCardLink = () => {
+		const { invite, site, type, user } = this.props;
+		const editLink = this.canLinkToProfile() && `/people/edit/${ site.slug }/${ user.login }`;
+		const inviteLink = invite && `/people/invites/${ site.slug }/${ invite.invite_key }`;
+
+		return type === 'invite' ? inviteLink : editLink;
+	};
+
 	render() {
 		const canLinkToProfile = this.canLinkToProfile();
 		const tagName = canLinkToProfile ? 'a' : 'span';
@@ -63,9 +71,7 @@ class PeopleListItem extends React.PureComponent {
 				) }
 				className={ classNames( 'people-list-item', this.props.className ) }
 				tagName={ tagName }
-				href={
-					canLinkToProfile && '/people/edit/' + this.props.site.slug + '/' + this.props.user.login
-				}
+				href={ this.getCardLink() }
 				onClick={ canLinkToProfile && this.navigateToUser }
 			>
 				<div className="people-list-item__profile-container">

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -53,7 +53,7 @@ class PeopleListItem extends React.PureComponent {
 	};
 
 	render() {
-		const { className, gravatarUser, invite, onRemove, translate, type, user } = this.props;
+		const { className, invite, onRemove, translate, type, user } = this.props;
 		const canLinkToProfile = this.canLinkToProfile();
 		const tagName = canLinkToProfile ? 'a' : 'span';
 
@@ -62,7 +62,6 @@ class PeopleListItem extends React.PureComponent {
 				{ ...omit(
 					this.props,
 					'className',
-					'gravatarUser',
 					'invite',
 					'user',
 					'site',
@@ -79,12 +78,7 @@ class PeopleListItem extends React.PureComponent {
 				onClick={ canLinkToProfile && this.navigateToUser }
 			>
 				<div className="people-list-item__profile-container">
-					<PeopleProfile
-						invite={ invite }
-						gravatarUser={ gravatarUser }
-						type={ type }
-						user={ user }
-					/>
+					<PeopleProfile invite={ invite } type={ type } user={ user } />
 				</div>
 				{ onRemove && (
 					<div className="people-list-item__actions">

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -7,7 +7,6 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -59,19 +58,6 @@ class PeopleListItem extends React.PureComponent {
 
 		return (
 			<CompactCard
-				{ ...omit(
-					this.props,
-					'className',
-					'invite',
-					'user',
-					'site',
-					'isSelectable',
-					'onRemove',
-					'moment',
-					'numberFormat',
-					'translate',
-					'type'
-				) }
 				className={ classNames( 'people-list-item', className ) }
 				tagName={ tagName }
 				href={ this.getCardLink() }

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -7,10 +7,12 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import PeopleProfile from 'my-sites/people/people-profile';
 import analytics from 'lib/analytics';
@@ -51,10 +53,32 @@ class PeopleListItem extends React.PureComponent {
 		return type === 'invite' ? inviteLink : editLink;
 	};
 
+	renderInviteStatus = () => {
+		const { invite, translate } = this.props;
+		const { is_pending: isPending } = invite;
+		const statusClasses = {
+			'is-pending': isPending,
+		};
+		const className = classNames( 'people-list-item__invite-status', statusClasses );
+
+		return (
+			<div className={ className }>
+				{ ! isPending && <Gridicon icon="checkmark" size={ 18 } /> }
+				{ isPending ? translate( 'Pending' ) : translate( 'Accepted' ) }
+				{ isPending && (
+					<Button className="people-list-item__invite-resend" compact>
+						{ translate( 'Resend Invite' ) }
+					</Button>
+				) }
+			</div>
+		);
+	};
+
 	render() {
 		const { className, invite, onRemove, translate, type, user } = this.props;
 		const canLinkToProfile = this.canLinkToProfile();
 		const tagName = canLinkToProfile ? 'a' : 'span';
+		const isInvite = invite && 'invite' === type;
 
 		return (
 			<CompactCard
@@ -66,6 +90,9 @@ class PeopleListItem extends React.PureComponent {
 				<div className="people-list-item__profile-container">
 					<PeopleProfile invite={ invite } type={ type } user={ user } />
 				</div>
+
+				{ isInvite && this.renderInviteStatus() }
+
 				{ onRemove && (
 					<div className="people-list-item__actions">
 						<button className="button is-link people-list-item__remove-button" onClick={ onRemove }>

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -84,3 +84,26 @@
 	right: 0px;
 	z-index: z-index( 'root', '.people-list-item .card__link-indicator' );
 }
+
+.people-list-item__invite-status {
+	align-self: center;
+	display: block;
+	flex-grow: 0;
+	flex-shrink: 0;
+	margin-right: 30px;
+
+	color: $alert-green;
+
+	&.is-pending {
+		color: $gray;
+	}
+
+	.gridicon {
+		vertical-align: text-bottom;
+		margin-right: 4px;
+	}
+}
+
+.people-list-item__invite-resend {
+	margin-left: 12px;
+}

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -20,13 +20,18 @@ class PeopleProfile extends React.PureComponent {
 	static displayName = 'PeopleProfile';
 
 	getRole = () => {
-		const user = this.props.user;
+		const { invite, user } = this.props;
+
+		if ( invite && invite.role ) {
+			return invite.role;
+		}
+
 		if ( ! user ) {
 			return 'subscriber';
 		}
 
 		if ( user && user.roles && user.roles[ 0 ] ) {
-			return this.props.user.roles[ 0 ];
+			return user.roles[ 0 ];
 		}
 
 		return;
@@ -101,17 +106,20 @@ class PeopleProfile extends React.PureComponent {
 		page( `/read/blogs/${ blogId }` );
 	};
 
-	renderName = () => {
-		const user = this.props.user;
+	renderNameOrEmail = () => {
+		const { translate, type, user } = this.props;
+
 		let name;
 		if ( ! user ) {
-			name = this.props.translate( 'Loading Users', {
+			name = translate( 'Loading Users', {
 				context: 'Placeholder text while fetching users.',
 			} );
 		} else if ( user.name ) {
 			name = user.name;
 		} else if ( user.label ) {
 			name = user.label;
+		} else if ( 'invite' === type && user.email ) {
+			name = user.email;
 		}
 
 		const blogId = get( user, 'follow_data.params.blog_id', false );
@@ -204,21 +212,31 @@ class PeopleProfile extends React.PureComponent {
 	};
 
 	render() {
-		const user = this.props.user,
-			classes = classNames( 'people-profile', {
-				'is-placeholder': ! user,
-			} );
+		const { gravatarUser, user } = this.props;
+		const classes = classNames( 'people-profile', {
+			'is-placeholder': ! user,
+		} );
 
 		return (
 			<div
-				{ ...omit( this.props, 'className', 'user', 'moment', 'numberFormat', 'translate' ) }
+				{ ...omit(
+					this.props,
+					'className',
+					'invite',
+					'type',
+					'gravatarUser',
+					'user',
+					'moment',
+					'numberFormat',
+					'translate'
+				) }
 				className={ classes }
 			>
 				<div className="people-profile__gravatar">
-					<Gravatar user={ user } size={ 72 } />
+					<Gravatar user={ gravatarUser || user } size={ 72 } />
 				</div>
 				<div className="people-profile__detail">
-					{ this.renderName() }
+					{ this.renderNameOrEmail() }
 					{ this.renderLogin() }
 					{ this.isFollowerType() ? this.renderSubscribedDate() : this.renderRole() }
 				</div>

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -119,6 +119,10 @@ class PeopleProfile extends React.PureComponent {
 		} else if ( user.label ) {
 			name = user.label;
 		} else if ( 'invite' === type && user.email ) {
+			// If an invite was sent to a WP.com user, the invite object will have
+			// either a display name (if set) or the WP.com username. Invites can
+			// also be sent to any email address, in which case the other details
+			// will not be set and we therefore display the user's email.
 			name = user.email;
 		}
 
@@ -212,7 +216,8 @@ class PeopleProfile extends React.PureComponent {
 	};
 
 	render() {
-		const { gravatarUser, user } = this.props;
+		const { user } = this.props;
+
 		const classes = classNames( 'people-profile', {
 			'is-placeholder': ! user,
 		} );
@@ -224,7 +229,6 @@ class PeopleProfile extends React.PureComponent {
 					'className',
 					'invite',
 					'type',
-					'gravatarUser',
 					'user',
 					'moment',
 					'numberFormat',
@@ -233,7 +237,7 @@ class PeopleProfile extends React.PureComponent {
 				className={ classes }
 			>
 				<div className="people-profile__gravatar">
-					<Gravatar user={ gravatarUser || user } size={ 72 } />
+					<Gravatar user={ user } size={ 72 } />
 				</div>
 				<div className="people-profile__detail">
 					{ this.renderNameOrEmail() }

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -118,7 +118,7 @@ class PeopleProfile extends React.PureComponent {
 			name = user.name;
 		} else if ( user.label ) {
 			name = user.label;
-		} else if ( 'invite' === type && user.email ) {
+		} else if ( 'invite' === type ) {
 			// If an invite was sent to a WP.com user, the invite object will have
 			// either a display name (if set) or the WP.com username. Invites can
 			// also be sent to any email address, in which case the other details

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -72,6 +72,9 @@ class PeopleProfile extends React.PureComponent {
 					context: 'Noun: A user role displayed in a badge',
 				} );
 				break;
+			case 'follower':
+				text = this.props.translate( 'Follower' );
+				break;
 			default:
 				text = role;
 		}

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { omit, get } from 'lodash';
+import { get } from 'lodash';
 import { recordTrack } from 'reader/stats';
 import page from 'page';
 
@@ -223,19 +223,7 @@ class PeopleProfile extends React.PureComponent {
 		} );
 
 		return (
-			<div
-				{ ...omit(
-					this.props,
-					'className',
-					'invite',
-					'type',
-					'user',
-					'moment',
-					'numberFormat',
-					'translate'
-				) }
-				className={ classes }
-			>
+			<div className={ classes }>
 				<div className="people-profile__gravatar">
 					<Gravatar user={ user } size={ 72 } />
 				</div>

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -123,7 +123,7 @@ class PeopleProfile extends React.PureComponent {
 			// either a display name (if set) or the WP.com username. Invites can
 			// also be sent to any email address, in which case the other details
 			// will not be set and we therefore display the user's email.
-			name = user.email;
+			name = user.login || user.email;
 		}
 
 		const blogId = get( user, 'follow_data.params.blog_id', false );


### PR DESCRIPTION
This PR adds the populated Invites tab to people management.

This section is behind a feature-flag. See p3Ex-32O-p2. Clicking on an invite row or the "Resend Invite" button is intentionally incomplete.

This PR assumes that you've applied D9507-code.

![image](https://user-images.githubusercontent.com/363749/35302094-fa5278d0-0052-11e8-9f65-7a3bef826075.png)

To test:
* Sandbox the API and apply D9507-code.
* Visit the "People" section, and then click on the "Invites" tab.
* Verify the list of invites renders appropriately.
