### PR TITLE
Avoid wasted rerenders of ManageMenu component in sidebar

### DIFF
--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { compact, includes, omit, reduce, get, mapValues } from 'lodash';
+import { compact, includes, omit, reduce, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -16,11 +16,12 @@ import { localize } from 'i18n-calypso';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarButton from 'layout/sidebar/button';
 import config from 'config';
-import { getEditorPath } from 'state/ui/editor/selectors';
+import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getPostTypes } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import analytics from 'lib/analytics';
 import { decodeEntities } from 'lib/formatting';
+import compareProps from 'lib/compare-props';
 import MediaLibraryUploadButton from 'my-sites/media-library/upload-button';
 import {
 	getSite,
@@ -38,11 +39,11 @@ class ManageMenu extends PureComponent {
 		siteId: PropTypes.number,
 		// connected props
 		allSingleSites: PropTypes.bool,
-		canUser: PropTypes.func,
+		canCurrentUserFn: PropTypes.func,
 		isJetpack: PropTypes.bool,
 		isSingleUser: PropTypes.bool,
 		postTypes: PropTypes.object,
-		postTypeLinks: PropTypes.object,
+		getNewPostPathFn: PropTypes.func,
 		siteAdminUrl: PropTypes.string,
 		site: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		siteSlug: PropTypes.string,
@@ -129,9 +130,9 @@ class ManageMenu extends PureComponent {
 	};
 
 	renderMenuItem( menuItem ) {
-		const { canUser, site, siteId, siteAdminUrl } = this.props;
+		const { canCurrentUserFn, site, siteId, siteAdminUrl } = this.props;
 
-		if ( siteId && ! canUser( menuItem.capability ) ) {
+		if ( siteId && ! canCurrentUserFn( menuItem.capability ) ) {
 			return null;
 		}
 
@@ -232,7 +233,7 @@ class ManageMenu extends PureComponent {
 
 				let buttonLink;
 				if ( config.isEnabled( 'manage/custom-post-types' ) && postType.api_queryable ) {
-					buttonLink = this.props.postTypeLinks[ postTypeSlug ];
+					buttonLink = this.props.getNewPostPathFn( postTypeSlug );
 				}
 
 				return memo.concat( {
@@ -269,23 +270,35 @@ class ManageMenu extends PureComponent {
 	}
 }
 
-export default connect( ( state, { siteId } ) => {
-	const postTypes = getPostTypes( state, siteId );
+/*
+ * A functional selector that returns a function that takes `capability` as a parameter
+ * and returns a boolean. Returns a new function on each invocation, so must be excluded
+ * from the shallow prop comparison.
+ */
+const canCurrentUserFn = ( state, siteId ) => capability =>
+	canCurrentUser( state, siteId, capability );
 
-	return {
+/*
+ * A functional selector similar to `canCurrentUserFn`, this time for generating editor URL
+ * from a post type.
+ */
+const getNewPostPathFn = ( state, siteId ) => postTypeSlug =>
+	getEditorNewPostPath( state, siteId, postTypeSlug );
+
+export default connect(
+	( state, { siteId } ) => ( {
 		allSingleSites: areAllSitesSingleUser( state ),
-		// TODO: Instead of passing a canUser function prop, we should compute and filter
-		// the list of menuItems inside `connect` and pass it to `PostList` as a prop.
-		canUser: cap => canCurrentUser( state, siteId, cap ),
+		canCurrentUserFn: canCurrentUserFn( state, siteId ),
 		isJetpack: isJetpackSite( state, siteId ),
 		isSingleUser: isSingleUserSite( state, siteId ),
-		postTypes,
-		postTypeLinks: mapValues( postTypes, ( postType, postTypeSlug ) => {
-			return getEditorPath( state, siteId, null, postTypeSlug );
-		} ),
+		postTypes: getPostTypes( state, siteId ),
+		getNewPostPathFn: getNewPostPathFn( state, siteId ),
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		site: getSite( state, siteId ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
-	};
-} )( localize( ManageMenu ) );
+	} ),
+	null,
+	null,
+	{ areStatePropsEqual: compareProps( { ignore: [ 'canCurrentUserFn', 'getNewPostPathFn' ] } ) }
+)( localize( ManageMenu ) );


### PR DESCRIPTION
This component's `mapStateToProps` returned two properties that were different on each invocation and therefore caused a rerender on every action dispatch:

- `canUser` is a function for checking capabilities: a curried version of `canCurrentUser`.
- `postTypeLinks` is a object that maps post type slug to an editor URL, recreated on each call.

I renamed `canUser` to `canCurrentUserFn` and replaced `postTypeLinks` with a functional getter `getNewPostPathFn`. I also use `getEditorNewPostPath` to implement it, as it's a better fit here than `getEditorPath` -- the `postId` param is always `null`.

Finally I exclude these functional props from shallow comparison.

**How to test:**
1. Enable "Highlight updates" in React devtool.
2. Cause some irrelevant action to be dispatched, e.g., open and close notifications
3. Watch if the "Site Pages" and "Blog Posts" items in sidebar get rerendered.

Before this patch, they are rerendered, after they aren't.