### PR TITLE
Build: do not generate css links from an object

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -166,10 +166,7 @@ function getDefaultContext( request ) {
 	}
 
 	if ( request.context && request.context.sectionCss ) {
-		sectionCss = {
-			id: request.context.sectionCss,
-			urls: utils.getCssUrls( request.context.sectionCss ),
-		};
+		sectionCss = request.context.sectionCss;
 	}
 
 	const shouldUseSingleCDN =


### PR DESCRIPTION
This fixes #21666 where an object was being passed to `getCssUrls` https://github.com/Automattic/wp-calypso/blob/409289d8e6a707d643da336c37c0e6a27cd52632/server/bundler/utils.js#L45 causing a bad link to be added to head, which 404s. I added a quick fix here, but @samouri feel free to take over if you have a better idea.

Before:
<img width="747" alt="screen shot 2018-01-18 at 5 59 06 pm" src="https://user-images.githubusercontent.com/1270189/35131225-ac7dee32-fc79-11e7-8766-9a0c2ba0d4ff.png">

After:
<img width="739" alt="screen shot 2018-01-18 at 5 58 23 pm" src="https://user-images.githubusercontent.com/1270189/35131216-9f9cde80-fc79-11e7-8484-a0bd8ea3a798.png">

### Testing Instructions
- Switch to an atomic site
- Navigate to store/settings/{mysite}
- Network request for the following no longer fires /calypso/sections/[object%20Object].css?v=