### PR TITLE
Reader: Fix Site Results in Search Settings button

### DIFF
--- a/client/blocks/follow-button/style.scss
+++ b/client/blocks/follow-button/style.scss
@@ -65,7 +65,7 @@ button.follow-button {
 
 	.gridicon {
 		height: 18px;
-		padding-right: 4px;
+		padding-right: 6px;
 		top: 5px;
 		width: 18px;
 	}

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -8,9 +8,8 @@
 
 .reader-site-notification-settings__button-label {
 	font-size: 14px;
-	margin-left: -2px;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoint( "<660px" ) {
 		display: none;
 	}
 }

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -223,6 +223,13 @@
 	}
 }
 
+.reader-site-notification-settings .gridicons-cog {
+
+	@include breakpoint( "<660px" ) {
+		left: -1px;
+	}
+}
+
 .following-manage__search-results.is-empty {
 	margin-top: 10px;
 	word-wrap: break-word;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -316,6 +316,17 @@
 	.reader-subscription-list-item__settings-label {
 		display: none;
 	}
+
+	.reader-site-notification-settings__button-label {
+		display: none;
+	}
+}
+
+.search-stream .search-stream__single-column-results .reader-site-notification-settings__button-label {
+
+	@include breakpoint ( "<660px" ) {
+		display: none;
+	}
 }
 
 .search-stream__results.is-two-columns .reader-subscription-list-item__byline {
@@ -339,10 +350,6 @@
 // Hide the last updated date for the moment - see https://github.com/Automattic/wp-calypso/issues/15121
 .search-stream__single-column-results .reader-subscription-list-item__timestamp {
 	display: none;
-}
-
-.search-stream__results.is-two-columns .gridicons-reader-follow {
-	left: 2px;
 }
 
 // Custom styling for cards in post results
@@ -411,8 +418,8 @@
 }
 
 .search-stream__results.is-two-columns .search-stream__site-results {
+
 	.gridicons-cog {
-		left: -2px;
 		top: 8px;
 	}
 
@@ -422,8 +429,9 @@
 }
 
 .search-stream .reader-subscription-list-item .gridicons-cog {
+
 	@include breakpoint( "<660px" ) {
-		left: 1px;
+		left: -1px;
 	}
 }
 


### PR DESCRIPTION
**Before:**
![screenshot 2018-01-18 20 11 07](https://user-images.githubusercontent.com/4924246/35134569-f2331ac6-fc8b-11e7-9ef8-1651be7cbafb.png)

**After:**
![screenshot 2018-01-18 20 11 24](https://user-images.githubusercontent.com/4924246/35134570-f57c05ee-fc8b-11e7-9aa0-58063da89732.png)

The Follow button's icon also moves about a pixel to the left after you click it. That's also been fixed in this PR.