### PR TITLE
Make redirect work for signup

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -38,6 +38,8 @@ import { mergeFormWithValue } from 'signup/utils';
 import SocialSignupForm from './social';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { createSocialUserFailed } from 'state/login/actions';
+import Card from 'components/card';
+import { preventWidows } from 'lib/formatting';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
 	debug = debugModule( 'calypso:signup-form:form' );
@@ -65,6 +67,7 @@ class SignupForm extends Component {
 		goToNextStep: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
 		isSocialSignupEnabled: PropTypes.bool,
+		isSocialFirst: PropTypes.bool,
 		locale: PropTypes.string,
 		positionInFlow: PropTypes.number,
 		save: PropTypes.func,
@@ -78,6 +81,7 @@ class SignupForm extends Component {
 
 	static defaultProps = {
 		isSocialSignupEnabled: false,
+		isSocialFirst: false,
 	};
 
 	state = {
@@ -591,6 +595,20 @@ class SignupForm extends Component {
 			<div className={ classNames( 'signup-form', this.props.className ) }>
 				{ this.getNotice() }
 
+				{ this.props.isSocialSignupEnabled &&
+					this.props.isSocialFirst && (
+						<Card className="signup-form__social logged-out-form">
+							<SocialSignupForm
+								handleResponse={ this.props.handleSocialResponse }
+								socialService={ this.props.socialService }
+								socialServiceResponse={ this.props.socialServiceResponse }
+							/>
+							<p>
+								{ preventWidows( this.props.translate( 'Or register with your e-mail address.' ) ) }
+							</p>
+						</Card>
+					) }
+
 				<LoggedOutForm onSubmit={ this.handleSubmit } noValidate={ true }>
 					{ this.props.formHeader && (
 						<header className="signup-form__header">{ this.props.formHeader }</header>
@@ -601,13 +619,21 @@ class SignupForm extends Component {
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
 
-				{ this.props.isSocialSignupEnabled && (
-					<SocialSignupForm
-						handleResponse={ this.props.handleSocialResponse }
-						socialService={ this.props.socialService }
-						socialServiceResponse={ this.props.socialServiceResponse }
-					/>
-				) }
+				{ this.props.isSocialSignupEnabled &&
+					! this.props.isSocialFirst && (
+						<Card className="signup-form__social">
+							<p>
+								{ preventWidows(
+									this.props.translate( 'Or connect your existing profile to get started faster.' )
+								) }
+							</p>
+							<SocialSignupForm
+								handleResponse={ this.props.handleSocialResponse }
+								socialService={ this.props.socialService }
+								socialServiceResponse={ this.props.socialServiceResponse }
+							/>
+						</Card>
+					) }
 
 				{ this.props.footerLink || this.footerLink() }
 			</div>

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -604,7 +604,7 @@ class SignupForm extends Component {
 								socialServiceResponse={ this.props.socialServiceResponse }
 							/>
 							<p>
-								{ preventWidows( this.props.translate( 'Or register with your e-mail address.' ) ) }
+								{ preventWidows( this.props.translate( 'Or sign up with your email address.' ) ) }
 							</p>
 						</Card>
 					) }

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -604,7 +604,7 @@ class SignupForm extends Component {
 								socialServiceResponse={ this.props.socialServiceResponse }
 							/>
 							<p>
-								{ preventWidows( this.props.translate( 'Or sign up with your email address.' ) ) }
+								{ preventWidows( this.props.translate( 'Or sign up with your email address:' ) ) }
 							</p>
 						</Card>
 					) }

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -67,7 +67,7 @@ class SignupForm extends Component {
 		goToNextStep: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
 		isSocialSignupEnabled: PropTypes.bool,
-		isSocialFirst: PropTypes.bool,
+		isSocialSignupFirst: PropTypes.bool,
 		locale: PropTypes.string,
 		positionInFlow: PropTypes.number,
 		save: PropTypes.func,
@@ -81,7 +81,7 @@ class SignupForm extends Component {
 
 	static defaultProps = {
 		isSocialSignupEnabled: false,
-		isSocialFirst: false,
+		isSocialSignupFirst: false,
 	};
 
 	state = {
@@ -596,7 +596,7 @@ class SignupForm extends Component {
 				{ this.getNotice() }
 
 				{ this.props.isSocialSignupEnabled &&
-					this.props.isSocialFirst && (
+					this.props.isSocialSignupFirst && (
 						<Card className="signup-form__social logged-out-form">
 							<SocialSignupForm
 								handleResponse={ this.props.handleSocialResponse }
@@ -620,7 +620,7 @@ class SignupForm extends Component {
 				</LoggedOutForm>
 
 				{ this.props.isSocialSignupEnabled &&
-					! this.props.isSocialFirst && (
+					! this.props.isSocialSignupFirst && (
 						<Card className="signup-form__social">
 							<p>
 								{ preventWidows(

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -12,9 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import config from 'config';
-import { preventWidows } from 'lib/formatting';
 
 class SocialSignupForm extends Component {
 	static propTypes = {
@@ -48,22 +46,14 @@ class SocialSignupForm extends Component {
 		const redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
 
 		return (
-			<Card className="signup-form__social">
-				<p>
-					{ preventWidows(
-						this.props.translate( 'Or connect your existing profile to get started faster.' )
-					) }
-				</p>
-
-				<div className="signup-form__social-buttons">
-					<GoogleLoginButton
-						clientId={ config( 'google_oauth_client_id' ) }
-						responseHandler={ this.handleGoogleResponse }
-						redirectUri={ redirectUri }
-						uxMode={ uxMode }
-					/>
-				</div>
-			</Card>
+			<div className="signup-form__social-buttons">
+				<GoogleLoginButton
+					clientId={ config( 'google_oauth_client_id' ) }
+					responseHandler={ this.handleGoogleResponse }
+					redirectUri={ redirectUri }
+					uxMode={ uxMode }
+				/>
+			</div>
 		);
 	}
 }

--- a/client/components/signup-form/style.scss
+++ b/client/components/signup-form/style.scss
@@ -26,7 +26,7 @@
 }
 
 .signup-form__social {
-	p {;
+	p {
 		margin: 0 0 20px 0;
 		text-align: center;
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -333,7 +333,7 @@ export function createAccount(
 				if ( errors ) {
 					callback( errors );
 				} else {
-					callback( undefined, response );
+					callback( undefined, pick( response, [ 'username', 'bearer_token' ] ) );
 				}
 			}
 		);

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -190,6 +190,7 @@ export default {
 		apiRequestFunction: createAccount,
 		props: {
 			oauth2Signup: true,
+			isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 		},
 		providesToken: true,
 		providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id', 'oauth2_redirect' ],

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -252,6 +252,7 @@ export class UserStep extends Component {
 				socialServiceResponse = hashObject;
 			}
 		}
+		const isSocialFirst = this.props.initialContext && this.props.initialContext.query.social_first;
 
 		return (
 			<SignupForm
@@ -265,6 +266,7 @@ export class UserStep extends Component {
 				suggestedUsername={ this.props.suggestedUsername }
 				handleSocialResponse={ this.handleSocialResponse }
 				isSocialSignupEnabled={ this.props.isSocialSignupEnabled }
+				isSocialFirst={ isSocialFirst }
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }
 			/>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -260,6 +260,14 @@ export class UserStep extends Component {
 		const isSocialSignupFirst =
 			this.props.initialContext && !! this.props.initialContext.query.social_first;
 
+		// Temporary HACK to hide the Log In button on signup when oauth2_client_id is not given
+		if ( isSocialSignupFirst ) {
+			const loginButtonMasterbar = document.querySelector( '.masterbar__login-links > a' );
+			if ( loginButtonMasterbar ) {
+				loginButtonMasterbar.style.display = 'none';
+			}
+		}
+
 		return (
 			<SignupForm
 				{ ...omit( this.props, [ 'translate' ] ) }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -252,7 +252,8 @@ export class UserStep extends Component {
 				socialServiceResponse = hashObject;
 			}
 		}
-		const isSocialFirst = this.props.initialContext && this.props.initialContext.query.social_first;
+		const isSocialSignupFirst =
+			this.props.initialContext && !! this.props.initialContext.query.social_first;
 
 		return (
 			<SignupForm
@@ -266,7 +267,7 @@ export class UserStep extends Component {
 				suggestedUsername={ this.props.suggestedUsername }
 				handleSocialResponse={ this.handleSocialResponse }
 				isSocialSignupEnabled={ this.props.isSocialSignupEnabled }
-				isSocialFirst={ isSocialFirst }
+				isSocialSignupFirst={ isSocialSignupFirst }
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }
 			/>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -174,7 +174,12 @@ export class UserStep extends Component {
 	 *                              So our server doesn't have to request the user profile on its end.
 	 */
 	handleSocialResponse = ( service, access_token, id_token = null ) => {
-		this.submit( { service, access_token, id_token } );
+		this.submit( {
+			service,
+			access_token,
+			id_token,
+			queryArgs: ( this.props.initialContext && this.props.initialContext.query ) || {},
+		} );
 	};
 
 	userCreationComplete() {


### PR DESCRIPTION
We need to have a signup flow where users can be redirected to an external wpcom websites after signing up. This is already possible thanks to the oauth2 signup flow, so this PR updates it to display the google connect button as well for this flow.

### Testing Instructions
- Checkout this branch locally
- Apply server patch D9265-code
- Follow instructions on the patch description
- On the signup page assert that you see the google connect option first and that it works as expected
- Assert that you are redirected to the site

### Reviews
- [ ] Code
- [ ] Product