### PR TITLE
Hide other importers when there is one in progress

### DIFF
--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import config from 'config';
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,6 +27,8 @@ import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import Placeholder from 'my-sites/site-settings/placeholder';
+
+const hasActiveImports = imports => !! find( imports, i => i.importerState !== appStates.INACTIVE );
 
 class SiteSettingsImport extends Component {
 	static propTypes = {
@@ -102,6 +105,14 @@ class SiteSettingsImport extends Component {
 			}
 		);
 
+		const wpImports = this.getImports( WORDPRESS );
+		const mediumImports = config.isEnabled( 'manage/import/medium' )
+			? this.getImports( MEDIUM )
+			: [];
+
+		const hasWpActiveImports = hasActiveImports( wpImports );
+		const hasMediumActiveImports = hasActiveImports( mediumImports );
+
 		return (
 			<Main>
 				<HeaderCake backHref={ '/settings/general/' + siteSlug }>
@@ -129,18 +140,26 @@ class SiteSettingsImport extends Component {
 							</header>
 						</CompactCard>
 
-						{ this.getImports( WORDPRESS ).map( ( importerStatus, key ) => (
-							<WordPressImporter { ...{ key, site, importerStatus } } />
-						) ) }
+						{ ( ! hasMediumActiveImports || hasWpActiveImports ) &&
+							wpImports.map( ( importerStatus, key ) => (
+								<WordPressImporter { ...{ key, site, importerStatus } } />
+							) ) }
 
-						{ config.isEnabled( 'manage/import/medium' ) &&
-							this.getImports( MEDIUM ).map( ( importerStatus, key ) => (
+						{ ( ! hasWpActiveImports || hasMediumActiveImports ) &&
+							mediumImports.map( ( importerStatus, key ) => (
 								<MediumImporter { ...{ key, site, importerStatus } } />
 							) ) }
 
-						<CompactCard href={ adminUrl + 'import.php' } target="_blank" rel="noopener noreferrer">
-							{ translate( 'Other importers' ) }
-						</CompactCard>
+						{ ! hasWpActiveImports &&
+							! hasMediumActiveImports && (
+								<CompactCard
+									href={ adminUrl + 'import.php' }
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									{ translate( 'Other importers' ) }
+								</CompactCard>
+							) }
 					</EmailVerificationGate>
 				) }
 			</Main>

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -28,7 +28,10 @@ import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import Placeholder from 'my-sites/site-settings/placeholder';
 
-const hasActiveImports = imports => !! find( imports, i => i.importerState !== appStates.INACTIVE );
+const hasActiveImports = imports =>
+	!! find( imports, ( { importerState } ) => {
+		return importerState !== appStates.INACTIVE && importerState !== appStates.READY_FOR_UPLOAD;
+	} );
 
 class SiteSettingsImport extends Component {
 	static propTypes = {


### PR DESCRIPTION
When there is an import in progress, hide other importers. The code is not most elegant but at this stage, we don't have support for other importers and we are using Flux so I expect a nicer (more dynamic) rewrite soon, as our team is focusing on importers now. This could be a quick win in the meantime.

| Before | After | 
| --- | --- |
| <img width="786" alt="screen shot 2018-01-19 at 10 45 13" src="https://user-images.githubusercontent.com/156676/35145887-af7b67be-fd09-11e7-8bd1-0e95f406348f.png"> | <img width="743" alt="screen shot 2018-01-19 at 11 13 15" src="https://user-images.githubusercontent.com/156676/35145914-c72dd68a-fd09-11e7-9145-4cc58d5dfae9.png"> | 

