### PR TITLE
Guided Tours: add a light border to steps so they're distinguishable against a dark background

### DIFF
--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -5,6 +5,7 @@
 	z-index: z-index( 'root', '.guided-tours__step' );
 	background: darken( $gray, 52 );
 	box-shadow: 0 2px 24px 0 rgba( darken( $gray, 52 ), 0.5 );
+	border: 1px solid rgba(255, 255, 255, 0.6);
 	border-radius: 4px;
 	padding-top: 19px;
 	margin-left: 5px;

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -4,8 +4,8 @@
 	max-width: 410px;
 	z-index: z-index( 'root', '.guided-tours__step' );
 	background: darken( $gray, 52 );
-	box-shadow: 0 2px 24px 0 rgba( darken( $gray, 52 ), 0.5 );
-	border: 1px solid rgba(255, 255, 255, 0.6);
+	box-shadow: 0 0 0 1px rgbs( 255, 255, 255, 0.6 ),
+		0 2px 24px 0 rgba( darken( $gray, 52 ), 0.5 );
 	border-radius: 4px;
 	padding-top: 19px;
 	margin-left: 5px;


### PR DESCRIPTION
So that Guided Tours steps are better distinguishable against a dark background, this PR adds a light border around steps (`border: 1px solid rgba(255, 255, 255, 0.6)`). 

Before, against a light background:

<img width="483" alt="screen shot 2018-01-19 at 1 38 08 pm" src="https://user-images.githubusercontent.com/23619/35151542-03034392-fd1f-11e7-95e7-0e3f06770fea.png">

Before, against a dark background: 

<img width="487" alt="screen shot 2018-01-19 at 1 52 01 pm" src="https://user-images.githubusercontent.com/23619/35151817-0f94fd66-fd20-11e7-9c24-7b9b22712bdf.png">

After, against a light background:

<img width="450" alt="screen shot 2018-01-19 at 1 38 04 pm" src="https://user-images.githubusercontent.com/23619/35151613-4ed26db6-fd1f-11e7-8756-ba5210b152ff.png">

After, against a dark background: 

<img width="511" alt="screen shot 2018-01-19 at 1 52 23 pm" src="https://user-images.githubusercontent.com/23619/35151805-0873947a-fd20-11e7-9372-78c78d6abd95.png">

To test:
- go through a tour or two — e.g. `http://calypso.localhost:3000/?tour=main` — and see whether this looks acceptable. use the web inspector to change the background color of the element(s) behind the tour around a bit to see if you find cases in which this doesn't look acceptable. Note: the Guided Tours steps' background color is `#151e25`. 

Feel free to tweak the CSS if you can come up with something that looks better in these diverse situations. 

Note — this is a case in which I'm on the fence. It does look a bit weird because the tour step covers very different backgrounds, but I think it's an acceptable trade-off: 

<img width="524" alt="screen shot 2018-01-19 at 1 43 37 pm" src="https://user-images.githubusercontent.com/23619/35151858-35069b18-fd20-11e7-9c09-898bc501e112.png">