### PR TITLE
Me-Sites: implement endpoint v1.2

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -82,6 +82,7 @@ export function requestSites() {
 		return wpcom
 			.me()
 			.sites( {
+				apiVersion: '1.2',
 				site_visibility: 'all',
 				include_domain_only: true,
 				site_activity: 'active',

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -38,7 +38,6 @@ export const sitesSchema = {
 						product_id: { type: [ 'number', 'string' ] },
 						product_slug: { type: 'string' },
 						product_name_short: { type: [ 'string', 'null' ] },
-						free_trial: { type: 'boolean' },
 						expired: { type: 'boolean' },
 						user_is_owner: { type: 'boolean' },
 						is_free: { type: 'boolean' },


### PR DESCRIPTION
In D9411-code, we've created a new version of the `/me/sites` endpoint. It's much faster in retrieving the `plan` objects for sites while not missing any properties (except `free_trial` which is deprecated anyways).

In this PR, we are switching to that endpoint to take advantage of the speed improvements.

## Testing
Checkout this PR. Navigate to local Calypso and clear local states. Reload. Calypso should behave as before, all the plans data should be there.