### PR TITLE
Jetpack Connect: Fix and improve authAttempts schema

### DIFF
--- a/client/state/jetpack-connect/reducer/schema.js
+++ b/client/state/jetpack-connect/reducer/schema.js
@@ -34,9 +34,15 @@ export const jetpackAuthAttemptsSchema = {
 	patternProperties: {
 		'^.+$': {
 			type: 'object',
+			additionalProperties: false,
 			required: [ 'attempt', 'timestamp' ],
-			attempt: { type: 'integer' },
-			timestamp: { type: 'integer' },
+			properties: {
+				attempt: {
+					type: 'integer',
+					minimum: 0,
+				},
+				timestamp: { type: 'integer' },
+			},
 		},
 	},
 };


### PR DESCRIPTION
Properties were not being validated, they must be in a properties
object.

Add `additionalProperties: false`.

Add `minimum: 0` to attempts.

## Testing
[Validate](https://www.jsonschemavalidator.net/) expected and invalid states against the schema:

### Schema

```json
{
  "type": "object",
  "additionalProperties": false,
  "patternProperties": {
    "^.+$": {
      "type": "object",
      "required": [
        "attempt",
        "timestamp"
      ],
      "properties": {
        "attempt": {
          "type": "integer",
          "minimum": 0
        },
        "timestamp": {
          "type": "integer"
        }
      }
    }
  }
}
```

### expected

```
{
  "example.com": {
    "attempt": 1,
    "timestamp": 1234,
  }
}
```