### PR TITLE
Jetpack connect: Remove redundant object creation from reducer

### DIFF
--- a/client/state/jetpack-connect/reducer/jetpack-connect-site.js
+++ b/client/state/jetpack-connect/reducer/jetpack-connect-site.js
@@ -11,24 +11,17 @@ import {
 } from 'state/action-types';
 
 export default function jetpackConnectSite( state = {}, action ) {
-	const defaultState = {
-		url: null,
-		isFetching: false,
-		isFetched: false,
-		isDismissed: false,
-		installConfirmedByUser: null,
-		data: {},
-	};
 	switch ( action.type ) {
 		case JETPACK_CONNECT_CHECK_URL:
-			return Object.assign( {}, defaultState, {
+			return {
 				url: action.url,
 				isFetching: true,
 				isFetched: false,
 				isDismissed: false,
 				installConfirmedByUser: null,
 				data: {},
-			} );
+			};
+
 		case JETPACK_CONNECT_CHECK_URL_RECEIVE:
 			if ( action.url === state.url ) {
 				return Object.assign( {}, state, {
@@ -38,13 +31,16 @@ export default function jetpackConnectSite( state = {}, action ) {
 				} );
 			}
 			return state;
+
 		case JETPACK_CONNECT_DISMISS_URL_STATUS:
 			if ( action.url === state.url ) {
 				return Object.assign( {}, state, { installConfirmedByUser: null, isDismissed: true } );
 			}
 			return state;
+
 		case JETPACK_CONNECT_CONFIRM_JETPACK_STATUS:
 			return Object.assign( {}, state, { installConfirmedByUser: action.status } );
+
 		case JETPACK_CONNECT_COMPLETE_FLOW:
 			return {};
 	}


### PR DESCRIPTION
This object was created on every single state dispatch and, while it was
"used", its properties were all immediately overwritten!

## Testing
1. Tests pass