### PR TITLE
Documentation: update markdown examples to es6

### DIFF
--- a/bin/codemods/README.md
+++ b/bin/codemods/README.md
@@ -13,7 +13,7 @@ touch ./bin/codemods/src/your-transformation-name.js
 
 Here's a stub to begin with:
 ```js
-const config = require( './config' );
+import config from 'config';
 
 export default function transformer( file, api ) {
 	const j = api.jscodeshift;

--- a/client/blocks/app-promo/README.md
+++ b/client/blocks/app-promo/README.md
@@ -6,7 +6,7 @@ This component is used to suggest the desktop app to users.
 #### How to use:
 
 ```js
-var AppPromo = require( 'components/app-promo' );
+import AppPromo from 'components/app-promo'
 
 render: function() {
 	return (

--- a/client/blocks/like-button/README.md
+++ b/client/blocks/like-button/README.md
@@ -8,7 +8,7 @@ For most usage, the container is the easiest route.
 #### How to use the container:
 
 ```js
-var LikeButtonContainer = require( 'blocks/like-button' );
+import LikeButtonContainer from 'blocks/like-button';
 
 render: function() {
 	return (
@@ -27,7 +27,7 @@ render: function() {
 
 #### How to use the button directly:
 ```js
-var LikeButton = require( 'blocks/like-button/button' );
+import LikeButton from 'blocks/like-button/button';
 
 render: function() {
 	return (

--- a/client/components/data/cart/README.md
+++ b/client/components/data/cart/README.md
@@ -1,5 +1,4 @@
-CartData
-========
+# CartData
 
 `CartData` is a React component intended to be used as a controller-view to simplify binding and interacting with the [cart Flux module](../../../lib/cart/).
 
@@ -8,21 +7,21 @@ CartData
 Wrap a child component with `<CartData />`. [As a controller-view](https://facebook.github.io/flux/docs/overview.html#views-and-controller-views), CartData does not render any content of its own; instead, it simply renders the child component. When mounted, the component will automatically trigger a network request for data if data hasn't yet been retrieved for the site.
 
 ```jsx
-var React = require( 'react' ),
-	CartData = require( 'components/data/cart-data' ),
-	MyChildComponent = require( './my-child-component' );
+import React from 'react';
+import CartData from 'components/data/cart-data';
+import MyChildComponent from './my-child-component';
 
-module.exports = React.createClass( {
-	displayName: 'MyComponent',
+export default class extends React.Component {
+	static displayName = 'MyComponent';
 
-	render: function() {
+	render() {
 		return (
 			<CartData>
 				<MyChildComponent />
 			</CartData>
 		);
 	}
-} );
+}
 ```
 
 The child component should expect to receive any props defined during the render.

--- a/client/components/data/checkout/README.md
+++ b/client/components/data/checkout/README.md
@@ -8,21 +8,21 @@ CheckoutData
 Wrap a child component with `<CheckoutData />`. [As a controller-view](https://facebook.github.io/flux/docs/overview.html#views-and-controller-views), `CheckoutData` does not render any content of its own; instead, it simply renders the child component. When mounted, the component will automatically trigger a network request for data if data hasn't yet been retrieved for the site.
 
 ```jsx
-var React = require( 'react' ),
-	CheckoutData = require( 'components/data/checkout' ),
-	MyChildComponent = require( './my-child-component' );
+import React from 'react';
+import CheckoutData from 'components/data/checkout';
+import MyChildComponent from './my-child-component';
 
-module.exports = React.createClass( {
-	displayName: 'MyComponent',
+export default class extends React.component {
+	static displayName = 'MyComponent';
 
-	render: function() {
+	render() {
 		return (
 			<CheckoutData>
 				<MyChildComponent />
 			</CheckoutData>
 		);
 	}
-} );
+}
 ```
 
 The child component should expect to receive any props defined during the render.

--- a/client/components/data/media-library-selected-data/README.md
+++ b/client/components/data/media-library-selected-data/README.md
@@ -8,21 +8,21 @@ MediaLibrarySelectedData is a React component intended to be used as a controlle
 Wrap a child component with `<MediaLibrarySelectedData />`, passing a `siteId`. [As a controller-view](https://facebook.github.io/flux/docs/overview.html#views-and-controller-views), MediaLibrarySelectedData does not render any content of its own; instead, it simply renders the child component.
 
 ```jsx
-var React = require( 'react' ),
-	MediaLibrarySelectedData = require( 'components/data/media-library-selected-data' ),
-	MyChildComponent = require( './my-child-component' );
+import React from 'react';
+import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
+import MyChildComponent from './my-child-component';
 
-module.exports = React.createClass( {
-	displayName: 'MyComponent',
+export default class extends React.Component {
+	static displayName = 'MyComponent',
 
-	render: function() {
+	render() {
 		return (
 			<MediaLibrarySelectedData siteId={ this.props.siteId }>
 				<MyChildComponent />
 			</MediaLibrarySelectedData>
 		);
 	}
-} );
+}
 ```
 
 The child component should expect to receive any props defined during the render, as well as the following additional props:

--- a/client/components/data/media-list-data/README.md
+++ b/client/components/data/media-list-data/README.md
@@ -8,21 +8,21 @@ MediaListData is a React component intended to be used as a controller-view to s
 Wrap a child component with `<MediaListData />`, passing a `siteId` and optional `filter`, `postId` and `search` values. [As a controller-view](https://facebook.github.io/flux/docs/overview.html#views-and-controller-views), MediaListData does not render any content of its own; instead, it simply renders the child component.
 
 ```jsx
-var React = require( 'react' ),
-	MediaListData = require( 'components/data/media-list-data' ),
-	MyChildComponent = require( './my-child-component' );
+import React from 'react';
+import MediaListData from 'components/data/media-list-data';
+import MyChildComponent from './my-child-component';
 
-module.exports = React.createClass( {
-	displayName: 'MyComponent',
+export default class extends React.Component {
+	static displayName = 'MyComponent';
 
-	render: function() {
+	render() {
 		return (
 			<MediaListData siteId={ this.props.siteId }>
 				<MyChildComponent />
 			</MediaListData>
 		);
 	}
-} );
+}
 ```
 
 The child component should expect to receive any props defined during the render, as well as the following additional props:

--- a/client/components/data/media-validation-data/README.md
+++ b/client/components/data/media-validation-data/README.md
@@ -8,14 +8,14 @@ MediaValidationData is a React component intended to be used as a controller-vie
 Wrap a child component with `<MediaValidationData />`, passing a `siteId`. [As a controller-view](https://facebook.github.io/flux/docs/overview.html#views-and-controller-views), MediaValidationData does not render any content of its own; instead, it simply renders the child component.
 
 ```jsx
-var React = require( 'react' ),
-	MediaValidationData = require( 'components/data/media-validation-data' ),
-	MyChildComponent = require( './my-child-component' );
+import React from 'react';
+import MediaValidationData from 'components/data/media-validation-data';
+import MyChildComponent from './my-child-component';
 
-module.exports = React.createClass( {
-	displayName: 'MyComponent',
+export default class extends React.Component {
+	static displayName = 'MyComponent';
 
-	render: function() {
+	render() {
 		return (
 			<MediaValidationData siteId={ this.props.siteId }>
 				<MyChildComponent />

--- a/client/components/date-picker/README.md
+++ b/client/components/date-picker/README.md
@@ -8,17 +8,17 @@ React component used to display a Date Picker.
 ## Example Usage
 
 ```js
-var DatePicker = require( 'components/date-picker' );
+import React from 'react';
+import DatePicker from 'components/date-picker';
 
-module.exports = React.createClass( {
-
+export default class extends React.Component {
 	// ...
 
 	this.onSelectDay: function( date ) {
 		this.setState( { date: date } );
 	},
 
-	render: function() {
+	render() {
 		var events = [
 			{
 				title: '1 other post scheduled',
@@ -41,8 +41,7 @@ module.exports = React.createClass( {
 				selectedDay= { this.state.date } />
 		);
 	}
-
-} );
+}
 ```
 
 ---

--- a/client/components/emojify/README.md
+++ b/client/components/emojify/README.md
@@ -8,8 +8,9 @@ This is desirable since implementations are inconsistent or non-existant.
 ## Usage
 ```js
 // require the module
-var Emojify = require( 'components/emojify' ),
-	textToEmojify = 'This will be converted 🙈🙉🙊';
+import Emojify from 'components/emojify';
+
+const textToEmojify = 'This will be converted 🙈🙉🙊';
 
 	// more component stuff
 	// ...

--- a/client/components/file-picker/README.md
+++ b/client/components/file-picker/README.md
@@ -8,9 +8,9 @@ It is a very thin wrapper around
 #### How to use:
 
 ```js
-var FilePicker = require( 'components/file-picker' );
+import FilePicker from 'components/file-picker';
 
-render: function() {
+render() {
 	return (
 		<FilePicker multiple accept="image/*" onPick={ console.log.bind(console) } >
 			<a href="#">Select a few images!</a>

--- a/client/components/foldable-card/README.md
+++ b/client/components/foldable-card/README.md
@@ -6,9 +6,9 @@ This component is used to display a box that can be clicked to expand a hidden s
 #### How to use:
 
 ```js
-var FoldableCard = require( 'components/foldable-card' );
+import FoldableCard from 'components/foldable-card';
 
-render: function() {
+render() {
 	return (
 		<div>
 			 <FoldableCard

--- a/client/components/gauge/README.md
+++ b/client/components/gauge/README.md
@@ -6,9 +6,9 @@ This component renders a simple gauge using a `<canvas/>` element that shows a p
 #### How to use:
 
 ```js
-var Gauge = require( 'components/gauge' );
+import Gauge from 'components/gauge';
 
-render: function() {
+render() {
     return (
   		<Gauge percentage={ 40 } metric={ 'Visits' } />
     );

--- a/client/components/header-cake/README.md
+++ b/client/components/header-cake/README.md
@@ -6,9 +6,9 @@ The "header cake" component should be used at the top of an item's detail page. 
 ## Usage
 
 ```js
-	var HeaderCake = require( 'components/header-cake' );
+import HeaderCake from 'components/header-cake';
 
-	<HeaderCake onClick={ callback }>Item Details</HeaderCake>
+<HeaderCake onClick={ callback }>Item Details</HeaderCake>
 ```
 
 ## Props

--- a/client/components/image-preloader/README.md
+++ b/client/components/image-preloader/README.md
@@ -8,18 +8,19 @@ http://codepen.io/aduth/pen/doqovP?editors=001
 ## Usage
 
 ```jsx
-var React = require( 'react' ),
-	ImagePreloader = require( 'components/image-preloader' );
+import React from 'react';
+import ImagePreloader from 'components/image-preloader';
 
-React.createClass( {
-	render: function() {
+export default class extends React.Component {
+	render() {
 		return (
 			<ImagePreloader
 				placeholder={ <div>Loading...</div> }
-				src="http://lorempixel.com/200/200" />
+				src="http://lorempixel.com/200/200" 
+			/>
 		);
 	}
-} );
+}
 ```
 
 ## Props

--- a/client/components/main/README.md
+++ b/client/components/main/README.md
@@ -6,9 +6,9 @@ Component used to declare the main area of any given section — it's the main w
 #### How to use:
 
 ```js
-var Main = require( 'components/main' );
+import Main from 'components/main';
 
-render: function() {
+render() {
 	return (
 		<Main (optional) className="your-component">
 			Your section content...

--- a/client/components/post-schedule/README.md
+++ b/client/components/post-schedule/README.md
@@ -8,17 +8,16 @@ This React component implements a small calendar (shown by month) which allows u
 ## Example Usage
 
 ```js
-var PostSchedule = require( 'components/post-schedule' );
+import PostSchedule from 'components/post-schedule';
 
-module.exports = React.createClass( {
-
+export default class extends React.Component {
 	// ...
 
 	onDateChange: function( date ) {
 		console.log( 'current date: ', date );
 	},
 
-	render: function() {
+	render() {
 		var events = [
 			{
 				id: 1,
@@ -44,7 +43,7 @@ module.exports = React.createClass( {
 	
 	// ...
 
-} );
+}
 ```
 
 ---

--- a/client/components/progress-bar/README.md
+++ b/client/components/progress-bar/README.md
@@ -9,9 +9,9 @@ Once this component is mounted, it will always progress forward, never backward:
 #### How to use:
 
 ```js
-var ProgressBar = require( 'components/progress-bar' );
+import ProgressBar from 'components/progress-bar';
 
-render: function() {
+render() {
 	return <ProgressBar
 		value={ amount }
 		total={ total }

--- a/client/components/progress-indicator/README.md
+++ b/client/components/progress-indicator/README.md
@@ -8,9 +8,9 @@ has completed or has failed.
 #### How to use:
 
 ```js
-var ProgressIndicator = require( 'components/progress-indicator' );
+import ProgressIndicator from 'components/progress-indicator';
 
-render: function() {
+render() {
     return (
 		<ProgressIndicator state='inactive' key='unique-key' />
     );

--- a/client/components/rating/README.md
+++ b/client/components/rating/README.md
@@ -7,9 +7,9 @@ that represents a rating in a scale between 0 and 5.
 #### How to use:
 
 ```js
-var Rating = require( 'components/rating' );
+import Rating from 'components/rating';
 
-render: function() {
+render() {
 	return (
 		<Rating
 			rating={ 65 }

--- a/client/components/root-child/README.md
+++ b/client/components/root-child/README.md
@@ -9,13 +9,13 @@ positioning may impact the child's style.
 ## Usage
 
 ```jsx
-var React = require( 'react' ),
-	RootChild = require( 'components/root-child' );
+import React from 'react';
+import RootChild from 'components/root-child';
 
-module.exports = React.createClass( {
-	displayName: 'MyComponent',
+export default class extends React.Component {
+	static displayName ='MyComponent';
 
-	render: function() {
+	render() {
 		return (
 			<div className="my-component">
 				<span>This text will be a child of MyComponent</span>
@@ -25,7 +25,7 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 ```
 
 ## Notes

--- a/client/components/section-nav/README.md
+++ b/client/components/section-nav/README.md
@@ -10,17 +10,16 @@ React component used to display a particular section's navigation bar. Or more t
 ## Example Usage
 
 ```js
-var SectionNav = require( 'components/section-nav' ),
-	NavTabs = require( 'components/section-nav/tabs' ),
-	NavSegmented = require( 'components/section-nav/segmented' ),
-	NavItem = require( 'components/section-nav/item' ),
-	Search = require( 'components/search' );
+import SectionNav from 'components/section-nav' );
+import NavTabs from 'components/section-nav/tabs';
+import NavSegmented from 'components/section-nav/segmented';
+import NavItem from 'components/section-nav/item';
+import Search from 'components/search';
 
-module.exports = React.createClass( {
-
+export default class extends React.Component { 
 	// ...
 
-	render: function() {
+	render() {
 		var sectionNavSelectedText = (
 			<span>
 				<span>Published</span>
@@ -54,7 +53,7 @@ module.exports = React.createClass( {
 			</SectionNav>
 		);
 	}
-} );
+}
 ```
 
 Keep in mind that every `prop` referenced in the example can and *should* be dynamic. The parent component decides selection logic, text display, and hierarchy. Take a look at [pages](/client/my-sites/pages/pages.jsx) & [post types]((/client/my-sites/post-type-filter/index.jsx)) for more working examples.

--- a/client/components/segmented-control/README.md
+++ b/client/components/segmented-control/README.md
@@ -16,14 +16,14 @@ The children technique is appropriate when you'd like to define the "selection" 
 A good example for this case is navigation. Sometimes the option that is selected is defined by the route, other times it's a state value, external prop, etc.
 
 ```js
-var SegmentedControl = require( 'components/segmented-control' ),
-	ControlItem = require( 'components/segmented-control/item' );
+import React from 'react';
+import SegmentedControl from 'components/segmented-control';
+import ControlItem from 'components/segmented-control/item';
 
-module.exports = React.createClass( {
-
+export default class extends React.Component {
 	// ...
 
-	render: function() {
+	render() {
 		return (
 			<SegmentedControl>
 				<ControlItem
@@ -75,7 +75,7 @@ module.exports = React.createClass( {
 			} );
 		}.bind( this );
 	}
-} );
+}
 ```
 
 The key here is that it's up to the parent component to explicitly define things like: which item is selected, and potentially `onClick` callbacks, etc.
@@ -127,7 +127,9 @@ A good example for this case is a form element. You don't want to have to write 
 > **NOTE** - there is still more work here in order to be fully functional as a form element, not recommended use case... yet.
 
 ```js
-var SegmentedControl = require( 'components/segmented-control' );
+import React from 'react';
+import SegmentedControl from 'components/segmented-control';
+
 var options = [
 	{ value: 'all', label: 'All' },
 	{ value: 'unread', label: 'Unread' },
@@ -136,21 +138,19 @@ var options = [
 	{ value: 'likes', label: 'Likes' }
 ];
 
-module.exports = React.createClass( {
-
+export default class extends React.Component {
 	// ...
-
-	render: function() {
-		return (
-			<SegmentedControl options={ options } onSelect={ this.handleOnSelect } />
-		);
-	},
-
-	handleOnSelect: function( option ) {
+	
+	handleOnSelect = ( option ) => {
 		console.log( 'selected option:', option ); // full object of selected option
 	}
 
-} );
+	render() {
+		return (
+			<SegmentedControl options={ options } onSelect={ this.handleOnSelect } />
+		);
+	}, 
+}
 ```
 
 Note that all the "selection" logic will be applied in `SegmentedControl` itself using a simple `selected` value comparison in state. It will update itself when an option has been clicked.

--- a/client/components/select-dropdown/README.md
+++ b/client/components/select-dropdown/README.md
@@ -14,14 +14,14 @@ The children technique is appropriate when you'd like to define the "selection" 
 A good example for this case is navigation. Sometimes the option that is selected is defined by the route, other times it's a state value, external prop, etc.
 
 ```js
-var SelectDropdown = require( 'components/select-dropdown' ),
-	DropdownItem = require( 'components/select-dropdown/item' );
+import React from 'react';
+import SelectDropdown from 'components/select-dropdown';
+import DropdownItem from 'components/select-dropdown/item';
 
-module.exports = React.createClass( {
-
+export default class extends React.Component {
 	// ...
 
-	render: function() {
+	render() {
 		return (
 			<SelectDropdown selectedText="Published">
 				<DropdownItem selected={ true } path="/published">Published</DropdownItem>
@@ -30,9 +30,8 @@ module.exports = React.createClass( {
 				<DropdownItem path="/trashed">Trashed</DropdownItem>
 			</SelectDropdown>
 		);
-	}
-
-} );
+	} 
+}
 ```
 
 The key here is that it's up to the parent component to explicitly define things like: which item is selected, what the selected text is (used in the dropdown header), and potentially `onClick` callbacks, etc.
@@ -104,15 +103,15 @@ As a sibling to `DropdownItem`, an item "separator" or horizontal line can be us
 ![separator example screenshot](https://cldup.com/CWEH2K9PUf.png)
 
 ```js
-var SelectDropdown = require( 'components/select-dropdown' ),
-	DropdownItem = require( 'components/select-dropdown/item' ),
-	DropdownSeparator = require( 'components/select-dropdown/separator' );
+import SelectDropdown from 'components/select-dropdown';
+import DropdownItem from 'components/select-dropdown/item';
+import DropdownSeparator from 'components/select-dropdown/separator';
 
-module.exports = React.createClass( {
+export default class extends React.Component {
 
 	// ...
 
-	render: function() {
+	render() {
 		return (
 			<SelectDropdown selectedText="Published">
 				<DropdownLabel><em>Post status<em></DropdownLabel>
@@ -124,7 +123,7 @@ module.exports = React.createClass( {
 			</SelectDropdown>
 		);
 	}
-} );
+}
 ```
 
 ---
@@ -138,7 +137,7 @@ A good example for this case is a form element. You don't want to have to write 
 > **NOTE** - there is still more work here in order to be fully functional as a form element, not recommended use case... yet.
 
 ```js
-var SelectDropdown = require( 'components/select-dropdown' );
+import SelectDropdown from 'components/select-dropdown';
 var options = [
 	{ label: 'Post status', isLabel: true },
 	{ value: 'published', label: 'Published' },
@@ -147,21 +146,19 @@ var options = [
 	{ value: 'trashed', label: 'Trashed' }
 ];
 
-module.exports = React.createClass( {
-
+export default class extends React.Component {
 	 // ...
 
-	render: function() {
+	handleOnSelect = ( option ) => {
+		console.log( 'selected option:', option ); // full object of selected option
+	}
+
+	render() {
 		return (
 			<SelectDropdown options={ options } onSelect={ this.handleOnSelect } />
 		);
 	},
-
-	handleOnSelect: function( option ) {
-		console.log( 'selected option:', option ); // full object of selected option
-	}
-
-} );
+}
 ```
 
 Note that all the "selection" logic will be applied in `SelectDropdown` itself using a simple `selected` value comparison in state. It will update itself when an option has been clicked.

--- a/client/components/sidebar-navigation/README.md
+++ b/client/components/sidebar-navigation/README.md
@@ -8,19 +8,20 @@ This component is used to display the mobile sidebar navigation header at the to
 Put the component in your `Main` component, and wrap it around any components you want it to display as its children. It relies on the [`document-head`](/client/state/document-head) Redux subtree, whose fields you can set through the [`DocumentHead`](/client/components/data/document-head) component. It handles detecting the selected site.
 
 ```js
-var SidebarNavigation = require( 'components/sidebar-navigation' ),
-	Gridicon = require( 'gridicons' );
+import SidebarNavigation from 'components/sidebar-navigation';
+import Gridicon from 'gridicons';
 
-render: function() {
-    return (
-        <Main>
+
+render() {
+	return (
+		<Main>
 		<SidebarNavigation
 			title="Themes"
 			sectionName="site"
 			sectionTitle="My Sites">
 			<Gridicon icon="my-sites" size={ 30 } />
 		</SidebarNavigation>
-        </Main>
-    );
+		</Main>
+	);
 }
 ```

--- a/client/components/signup-form/README.md
+++ b/client/components/signup-form/README.md
@@ -12,9 +12,9 @@ disabled={ this.isDisabled() }
 submitting={ this.isSubmitting() }
 
 ```js
-var SignupForm = require( 'components/signup-form' ),
+import SignupForm from 'components/signup-form';
 
-render: function() {
+render() {
 	return (
 		<SignupForm
 			{ ...this.props }

--- a/client/components/spinner/README.md
+++ b/client/components/spinner/README.md
@@ -10,14 +10,14 @@ __Please exercise caution in deciding to use a spinner in your component.__ A lo
 ## Usage
 
 ```jsx
-var React = require( 'react' ),
-	Spinner = require( 'components/spinner' );
+import React from 'react';
+import Spinner from 'components/spinner';
 
-React.createClass( {
-	render: function() {
+export default class extends React.Component {
+	render() {
 		return <Spinner />;
-	}
-} );
+	} 
+}
 ```
 
 ## Props

--- a/client/components/sub-masterbar-nav/README.md
+++ b/client/components/sub-masterbar-nav/README.md
@@ -13,7 +13,7 @@ In case no option is selected, the `fallback` value will be shown in the dropdow
 If no `icon` is provided, `star` will be used by default.
 
 ```js
-const SubMasterbarNav = require( 'components/sub-masterbar-nav' );
+import SubMasterbarNav from 'components/sub-masterbar-nav';
 
 const options = [
     {
@@ -24,14 +24,16 @@ const options = [
     ...
 ];
 
-render: function() {
-    return {
-        <Main>
-            <SubMasterbarNav
-                options={ options }
-                fallback={ options[ 0 ] }
-                uri={ '/foo/bar' } />
-        </Main>
-    };
+export default class extends React.Component {
+	render() {
+		return {
+			<Main>
+				<SubMasterbarNav
+					options={ options }
+					fallback={ options[ 0 ] }
+					uri={ '/foo/bar' } />
+			</Main>
+		};
+	}
 }
 ```

--- a/client/components/timezone/README.md
+++ b/client/components/timezone/README.md
@@ -6,15 +6,14 @@ Select timezone react component.
 ---
 
 ```jsx
-var Timezone = require( 'components/timezone' );
+import Timezone from 'components/timezone';
 
-module.exports = React.createClass( {
-
+export default class extends React.Component {
 	// ...
 	
-	onTimezoneSelect( zone ) {
+	onTimezoneSelect = ( zone ) => {
 		console.log( `timezone selected: %s`, zone.value );
-	},
+	}
 
 	render() {
 		return (
@@ -25,7 +24,7 @@ module.exports = React.createClass( {
 		);
 	}
 
-} );
+}
 ```
 ## Timezone
 

--- a/client/config/README.md
+++ b/client/config/README.md
@@ -20,7 +20,7 @@ in-progress features without launching them to production.
 Is a feature enabled?
 
 ``` js
-var config = require( 'config' );
+import config from 'config';
 
 if ( config.isEnabled( 'myFeature') ) {
 	// do something only when myFeature is enabled

--- a/client/lib/accept/README.md
+++ b/client/lib/accept/README.md
@@ -22,7 +22,7 @@ Accept is a stylized substitute to the browser `confirm` dialog.
 While `confirm` returns a value synchronously, Accept must be performed asynchronously. In addition to your message, you must pass a function which will be executed upon a user's selection with the result of the confirmation.
 
 ```js
-var accept = require( 'lib/accept' );
+import accept from 'lib/accept'
 
 accept( 'Are you sure you want to perform this action?', function( accepted ) {
 	if ( accepted ) {
@@ -36,7 +36,7 @@ accept( 'Are you sure you want to perform this action?', function( accepted ) {
 This will make the confirmation button look scary:
 
 ```js
-var accept = require( 'lib/accept' );
+import accept from 'lib/accept'
 
 accept( 'Are you sure you want to perform this action?', function( accepted ) {
 	if ( accepted ) {

--- a/client/lib/ads/README.md
+++ b/client/lib/ads/README.md
@@ -3,9 +3,9 @@ Users
 
 A [flux](https://facebook.github.io/flux/docs/overview.html#content) approach for interacting with a site's WordAds data.
 
-###The Data
+### The Data
 The Data is stored in a private variable but can be accessed though the stores public methods.
-####Earnings
+#### Earnings
 The Data that is stored in a site's WordAds earnings store looks like this:
 ```
 {
@@ -39,7 +39,7 @@ The Data that is stored in a site's WordAds earnings store looks like this:
 	}, etc.
 }
 ```
-####Settings
+#### Settings
 The Data that is stored in a site's WordAds settings store looks like this:
 ```
 {
@@ -60,7 +60,7 @@ The Data that is stored in a site's WordAds settings store looks like this:
 	}, etc
 }
 ```
-####TOS
+#### TOS
 The Data that is stored in a site's WordAds TOS store looks like this:
 ```
 {
@@ -68,7 +68,7 @@ The Data that is stored in a site's WordAds TOS store looks like this:
 	123456 : 'signed', etc.
 }
 ```
-####Public Methods
+#### Public Methods
 
 **EarningsStore.getById( site.ID )**
 Returns object with earnings data and some flags:
@@ -119,10 +119,10 @@ Returns object with tos data and some flags:
 }
 ```
 
-###Actions
+### Actions
 Actions get triggered by views and stores.
 
-####Public methods.
+#### Public methods.
 
 **WordadsActions.fetchEarnings( site );**
 
@@ -134,50 +134,49 @@ Actions get triggered by views and stores.
 
 **WordadsActions.signTos( site );**
 
-###Example Component Code
+### Example Component Code
 
-```
+```js
 /**
  * External dependencies
  */
-var React = require( 'react' );
+
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var SettingsStore = require( 'lib/ads/settings-store' );
+import SettingsStore from 'lib/ads/settings-store';
 
-module.exports = React.createClass( {
+export default class extends React.Component { 
+	static displayName = 'yourComponent'; 
 
-	displayName: 'yourComponent',
+	state = this.getSettingsFromStore();
 
-	componentDidMount: function() {
+	componentDidMount() {
 		SettingsStore.on( 'change', this.updateSettings );
 		this._fetchIfEmpty();
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		SettingsStore.removeListener( 'change', this.updateSettings );
-	},
+	}
 
-	getInitialState: function() {
-		return this.getSettingsFromStore();
-	},
 
-	getSettingsFromStore: function( siteInstance ) {
+	getSettingsFromStore: ( siteInstance ) => {
 		var site = siteInstance || this.props.site;
 		return SettingsStore.getById( site.ID );
-	},
+	}
 
-	updateSettings: function() {
+	updateSettings: () => {
 		this.setState( this.getSettingsFromStore() );
-	},
+	}
 
-	render: function() {
+	render() {
 		...
 	}
 
-	_fetchIfEmpty: function( site ) {
+	fetchIfEmpty: ( site ) => {
 		site = site || this.props.site;
 		if ( ! site || ! site.ID ) {
 			return;
@@ -193,5 +192,5 @@ module.exports = React.createClass( {
 			SettingsStore.fetchSettings( site );
 		}, 0 );
 	}
-} );
+}
 ```

--- a/client/lib/data-poller/README.md
+++ b/client/lib/data-poller/README.md
@@ -32,10 +32,11 @@ Add a new poller that fetches updates
 Example
 =======
 ```js
-var PollerPool = require( 'lib/data-poller' ),
-	SitesList = require( 'lib/sites-list/list' ),
-	sites = new SitesList(),
-	poller;
+import PollerPool from 'lib/data-poller' );
+import SitesList from 'lib/sites-list/list';
+
+const sites = new SitesList();
+let poller;
 
 // 'interval' is the time between polling requests and 'leading' is a flag that controls whether the `fetch` method
 // is called when the poller is started when it is added

--- a/client/lib/email-followers/README.md
+++ b/client/lib/email-followers/README.md
@@ -30,50 +30,45 @@ Fetches followers in batches of 100 starting from the given page, which defaults
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
- */
-var EmailFollowersStore = require( 'lib/followers/wpcom-followers-store' ),
-	EmailFollowersActions = require( 'lib/followers/actions' );
+ */ 
+import EmailFollowersStore from 'lib/followers/wpcom-followers-store';
+import EmailFollowersActions from 'lib/followers/actions';
 
-module.exports = React.createClass( {
+export default class extends React.Component {
+	static displayName = 'yourComponent';
+	state = this.getFollowers();
 
-	displayName: 'yourComponent',
+	fetchOptions = {
+		siteId: this.props.siteId,
+		type: 'email'
+	}
 
-	fetchOptions: {
-	    siteId: this.props.siteId,
-	    type: 'email'
-	},
-
-	componentDidMount: function() {
+	componentDidMount() {
 		EmailFollowersActions.fetchFollowers( this.fetchOptions );
 		EmailFollowersStore.on( 'change', this.refreshFollowers );
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		EmailFollowersStore.removeListener( 'change', this.refreshFollowers );
-	},
+	}
 
-	getInitialState: function() {
-		return this.getFollowers();
-	},
-
-	getFollowers: function() {
+	getFollowers = () => {
 		return {
 			followers: EmailFollowersStore.getFollowers( this.props.fetchOptions )
 		};
-	},
-
-	refreshFollowers: function() {
-		this.setState( this.getFollowers() );
-	},
-
-	render: function() {
-
 	}
 
+	refreshFollowers = () => {
+		this.setState( this.getFollowers() );
+	}
+
+	render() {
+
+	} 
 } );
 
 ```

--- a/client/lib/follow-list/README.md
+++ b/client/lib/follow-list/README.md
@@ -3,7 +3,8 @@ FollowList
 If you have components that utlize 'Follow' actions for users, the follow-list acts as a central store for all site/follow data.  So if a user clicks follow within one component, all other associated follow buttons can be updated by an emitted change event.
 
 ```js
-var follow-list = require( 'follow-list' )();
+import FollowList from 'follow-list';
+var follow-list = FollowList();
 ```
 
 ### add( { site_id: site.ID, is_following: true } )

--- a/client/lib/followers/README.md
+++ b/client/lib/followers/README.md
@@ -30,50 +30,45 @@ Fetches followers in batches of 100 starting from the given page, which defaults
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var FollowersStore = require( 'lib/followers/wpcom-followers-store' ),
-	FollowersActions = require( 'lib/followers/actions' );
+import FollowersStore from 'lib/followers/wpcom-followers-store';
+import FollowersActions from 'lib/followers/actions';
 
-module.exports = React.createClass( { 
+export default class extends React.Component {
+	static displayName = 'yourComponent';
 
-	displayName: 'yourComponent',
+	state = this.getFollowers();
 	
 	fetchOptions: {
 	    siteId: this.props.siteId,
 	    type: 'email'
-	},
+	}
 	
-	componentDidMount: function() {
+	componentDidMount() {
 		FollowersActions.fetchFollowers( this.fetchOptions );
 		FollowersStore.on( 'change', this.refreshFollowers );
-	},
+	}
 	
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		FollowersStore.removeListener( 'change', this.refreshFollowers );
-	},
-
-	getInitialState: function() {
-		return this.getFollowers();
-	},
+	} 
 	
-	getFollowers: function() {
+	getFollowers = () => {
 		return {
 			followers: FollowersStore.getFollowers( this.props.fetchOptions )
 		};
 	},
 
-	refreshFollowers: function() {
+	refreshFollowers = () => {
 		this.setState( this.getFollowers() );
-	},
-	
-	render: function() {
-		
 	}
 	
-} );
-
+	render() {
+		
+	} 
+} 
 ```

--- a/client/lib/i18n-utils/README.md
+++ b/client/lib/i18n-utils/README.md
@@ -6,5 +6,5 @@ I18n-related utilities, for use both client- and server-side.
 ## Usage
 
 ```js
-var i18nUtils = require( 'lib/i18n-utils' );
+import i18nUtils from 'lib/i18n-utils';
 ```

--- a/client/lib/keyboard-shortcuts/README.md
+++ b/client/lib/keyboard-shortcuts/README.md
@@ -9,19 +9,18 @@ Usage
 This module can be used outside of React, but this is a typical use within React:
 
 ```js
-var KeyboardShortcuts = require( 'lib/keyboard-shortcuts' );
+import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 
-MyComponent = React.createClass( {
-
-	componentWillMount: function() {
+class MyComponent extends React.Component {
+	componentWillMount() {
 		KeyboardShortcuts.on( 'open-selection', this.openSelectedPost )
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		KeyboardShortcuts.off( 'open-selection', this.openSelectedPost );
 	}
 
-	openSelectedPost: function() {
+	openSelectedPost() {
 	...
 ```
 

--- a/client/lib/local-list/README.md
+++ b/client/lib/local-list/README.md
@@ -23,7 +23,7 @@ Setup
 First require the module:
 
 ```es6
-LocalList = require( 'local-list' )
+import LocalList from 'local-list';
 ```
 
 Then create an instance of LocalList:

--- a/client/lib/local-storage/README.md
+++ b/client/lib/local-storage/README.md
@@ -14,5 +14,5 @@ localStorage.length
 Just require and call this once into the page (prior to any calls to these methods) and it will either create or augment the `window.localStorage` object as necessary.
 
 ```es6
-var localStoragePolyfill = require( 'lib/local-storage' )();
+import localStorePolyfill from 'lib/local-storage';
 ```

--- a/client/lib/media/README.md
+++ b/client/lib/media/README.md
@@ -20,15 +20,17 @@ Whereas the MediaStore has no concept of ordering and is unaware of querying and
 The stores are singleton objects, which offer `get` and `getAll` methods to retrieve data.
 
 ```js
-var MediaStore = require( 'lib/media/store' )(),
-	allMedia = MediaStore.getAll( siteId ),
-	singleMedia = MediaStore.get( siteId, postId );
+import MediaStoreFactory from 'lib/media/store';
+const MediaStore = MediaStoreFactory();
+
+const allMedia = MediaStore.getAll( siteId );
+const singleMedia = MediaStore.get( siteId, postId );
 ```
 
 To interact with the store, use the actions made available in `actions.js`.
 
 ```js
-var MediaActions = require( 'lib/media/actions' );
+import MediaActions from 'lib/media/actions';
 
 MediaActions.fetchNextPage( siteId );
 ```
@@ -36,8 +38,8 @@ MediaActions.fetchNextPage( siteId );
 You should monitor the store for changes in case another module interacts with the store:
 
 ```js
-var MediaStore = require( 'lib/media/store' ),
-	mediaScale = MediaStore.get( 'media-scale' );
+import MediaStore 'lib/media/store';
+const mediaScale = MediaStore.get( 'media-scale' );
 
 MediaStore.on( 'change', function() {
 	mediaScale = MediaStore.get( 'media-scale' );

--- a/client/lib/mixins/data-observe/README.md
+++ b/client/lib/mixins/data-observe/README.md
@@ -10,9 +10,10 @@ A React mixin that makes it easy to trigger re-rendering of a component when a `
 
 
 ```js
-var observe = require( 'lib/mixins/data-observe' );
+import observe from 'lib/mixins/data-observe';
+import createReactClass from 'create-react-class';
 
-const Component = React.createClass({
+const Component = createReactClass({
 	mixins: [ observe( 'sites', 'user' ) ]
 });
 ```

--- a/client/lib/mixins/infinite-scroll/README.md
+++ b/client/lib/mixins/infinite-scroll/README.md
@@ -7,7 +7,12 @@ There is an alternative implementaion called [InfiniteList](../../../components/
 
 ### How to use
 
-First, require the component with `var infiniteScroll = require( 'lib/mixins/infinite-scroll' )` and in your `React.createClass` add it as a mixin, passing a name of method that fetches next page.
+First, require the component with 
+```js
+import infiniteScroll from 'lib/mixins/infinite-scroll'; 
+```
+
+and in your `createReactClass` add it as a mixin, passing a name of method that fetches next page.
 
 If there are conditions when next page should not be loaded (e.g. next page is already loading, or last page was reached, it must be checked in that method.
 

--- a/client/lib/mixins/searchable/README.md
+++ b/client/lib/mixins/searchable/README.md
@@ -1,6 +1,8 @@
 Searchable
 ==========
 
+## Deprecation Notice: mixins are deprecated! Please try to find an alternative way to accomplish the same goal
+
 `searchable` is a mixin that adds a text-based `search` method to filter a collection module.
 
 Pass the collections prototype into Searchable, along with an object to specify which nodes on each list-item should be searchable. The `search` method will do an initial `get()` on the collection, so make sure the collection supports a `get()` that will return an array of all items contained in the collection.
@@ -14,7 +16,7 @@ Adding mixin to a Collection:
  * Internal dependencies
  */
 
-var Searchable = require( 'searchable' );
+import Searchable from 'searchable';
 
 /**
  * SomeCollection component
@@ -38,14 +40,14 @@ Searchable( SomeCollection.prototype, [ 'title', 'description', 'author' ] );
  * Expose `SomeCollection`
  */
 
-module.exports = SomeCollection;
+export default SomeCollection;
 ```
 
 Example usage:
 
 ```js
-var list = require( 'some-collection' )(),
-    results = list.search( 'test' );
+import list from 'some-collection';
+const results = list.search( 'test' );
 ```
 
 When you add the mixin, you need to pass in a set of `searchNodes` where you specify which nodes on the item are available to search. We don't necessarily want to filter on every single node... for example, we may not want to return a result just because it has a header image whose filename matches the search term. We also cannot assume the list item will be a flat object. It could contain nested nodes that we want to search.

--- a/client/lib/mixins/url-search/README.md
+++ b/client/lib/mixins/url-search/README.md
@@ -27,11 +27,9 @@ Then in the component, apply the mixin:
 /**
  * Internal dependencies
  */
+import URLSearch from 'lib/mixins/url-search';
 
-var URLSearch = require( 'lib/mixins/url-search' );
-
-module.exports = React.createClass({
-
+export default createReactClass({
 	displayName: 'Posts',
 
 	mixins: [ URLSearch ],

--- a/client/lib/network-connection/README.md
+++ b/client/lib/network-connection/README.md
@@ -8,7 +8,7 @@ Network connection
 Public API can be used through main file:
 
 ```js
-var NetworkConnectionApp = require( 'lib/network-connection' );
+import NetworkConnectionApp from 'lib/network-connection';
 ```
 
 To init default handler which shows/hides error notice when connection lost/restored simply call:

--- a/client/lib/payment-gateway-loader/README.md
+++ b/client/lib/payment-gateway-loader/README.md
@@ -9,7 +9,7 @@ You can access the `Paygate` class from within the callback of `PaygateLoader.re
 
 
 ```es6
-var paymentGatewayLoader = require( 'lib/payment-gateway-loader' );
+import paymentGatewayLoader 'lib/payment-gateway-loader';
 
 function onSuccess( token ) {
 	// Do something with the Paygate token

--- a/client/lib/plugins/README.md
+++ b/client/lib/plugins/README.md
@@ -81,46 +81,41 @@ Returns an array of sites that have a particular plugin.
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var PluginsStore = require( 'lib/plugins/store' );
+import PluginsStore 'lib/plugins/store';
 
-module.exports = React.createClass( {
+export default class extends React.Component {
+	static displayName = 'yourComponent';
 
-	displayName: 'yourComponent',
+	state = this.getPlugins();
 
-	componentDidMount: function() {
+	componentDidMount() {
 		PluginsStore.on( 'change', this.refreshSitesAndPlugins );
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		PluginsStore.removeListener( 'change', this.refreshSitesAndPlugins );
-	},
+	}
 
-	getInitialState: function() {
-		return this.getPlugins();
-	},
-
-	getPlugins: function() {
-
-		var sites = this.props.sites.getSelectedOrAllWithPlugins();
+	getPlugins = () => { 
+		let sites = this.props.sites.getSelectedOrAllWithPlugins();
 
 		return {
 			plugins: PluginsStore.getPlugins( sites )
 		};
 	},
 
-	refreshSitesAndPlugins: function() {
+	refreshSitesAndPlugins = () => {
 		this.setState( this.getPlugins() );
 	},
 
-	render: function() {
+	render() {
 
-	}
-
+	} 
 } );
 
 ```
@@ -184,27 +179,25 @@ Toggle AutoUpdates for a plugin on a site.
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var PluginsActions = require( 'lib/plugins/actions' );
+import PluginsActions from 'lib/plugins/actions';
 
-module.exports = React.createClass( {
+export default class extends React.Component {
+	static displayName = 'yourComponent';
 
-	displayName: 'yourComponent',
-
-	updatePlugin: function() {
+	updatePlugin = () => {
 		PluginsActions.updatePlugin( this.props.site, this.props.plugin );
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<button onClick={ this.updatePlugin } >Update { this.props.plugin.name }</button>
 		)
-	}
-
+	} 
 } );
 
 ```

--- a/client/lib/popup-monitor/README.md
+++ b/client/lib/popup-monitor/README.md
@@ -8,8 +8,9 @@ Popup Monitor is a small utility to facilitate the monitoring of a popup window 
 A Popup Monitor instance offers an `open` function which accepts an identical set of arguments as the standard `window.open` browser offering. When the window is closed, a `close` event is emitted to the instance with the name of the closed window.
 
 ```js
-var PopupMonitor = require( 'lib/popup-monitor' ),
-	popupMonitor = new PopupMonitor();
+import PopupMonitor 'lib/popup-monitor';
+
+const popupMonitor = new PopupMonitor();
 
 popupMonitor.open( 'https://wordpress.com/', 'my-popup' );
 

--- a/client/lib/post-metadata/README.md
+++ b/client/lib/post-metadata/README.md
@@ -8,6 +8,7 @@ Post Metadata is a set of helper functions to assist in extracting metadata from
 Each function in the module expects to receive a post object, and will return either the value, or `undefined` if the value could be not be determined from the object.
 
 ```js
-var PostMetadata = require( 'lib/post-metadata' ),
-	geoCoordinate = PostMetadata.geoCoordinate( post );
+import PostMetadata from 'lib/post-metadata' );
+
+const geoCoordinate = PostMetadata.geoCoordinate( post );
 ```

--- a/client/lib/preferences/README.md
+++ b/client/lib/preferences/README.md
@@ -10,15 +10,17 @@ The Preferences store extends the EventEmitter interface and can be monitored fo
 The store is a singleton object which offers `get` and `getAll` methods to retrieve data from the store.
 
 ```js
-var PreferencesStore = require( 'lib/preferences/store' )(),
-	allPreferences = PreferencesStore.getAll(),
-	singlePreference = PreferenceStore.get( 'media-scale' );
+import PreferencesStoreFactory from 'lib/preferences/store' );
+
+const PreferencesStore = PreferencesStoreFactory();
+const allPreferences = PreferencesStore.getAll();
+const singlePreference = PreferenceStore.get( 'media-scale' );
 ```
 
 To interact with the store, use the actions made available in `actions.js`.
 
 ```js
-var PreferencesActions = require( 'lib/preferences/actions' );
+import PreferencesActions from 'lib/preferences/actions';
 
 PreferencesActions.fetch();
 
@@ -28,10 +30,12 @@ PreferencesActions.set( 'media-scale', 0.75 );
 You should monitor the store for changes in case another module interacts with the store:
 
 ```js
-var PreferencesStore = require( 'lib/preferences/store' )(),
-	mediaScale = PreferencesStore.get( 'media-scale' );
+import PreferencesStoreFactory from 'lib/preferences/store' );
 
-PreferencesStore.on( 'change', function() {
-	mediaScale = PreferencesStore.get( 'media-scale' );
+const PreferencesStore = PreferencesStoreFactory();
+let mediaScale = PreferencesStore.get( 'media-scale' );
+
+PreferencesStore.on( 'change', () => {
+	mediaScale = PreferencesStore.get( 'media-scale' )
 } );
 ```

--- a/client/lib/react-pass-to-children/README.md
+++ b/client/lib/react-pass-to-children/README.md
@@ -8,14 +8,14 @@ Pass to Children is a utility method to assist in creating a React pass-through 
 The exposed method expects to receive the current react element instance, and an object of props to pass to the child in addition to the props of the instance itself.
 
 ```es6
-var React = require( 'react' ),
-	passToChildren = require( 'lib/react-pass-to-children' );
+import React from 'react';
+import passToChildren from 'lib/react-pass-to-children';
 
-module.exports = React.createClass( {
-	render: function() {
+export default class extends React.Component {
+	render() {
 		return passToChildren( this, { 
 			data: [ 1, 2, 3 ]
 		} );
 	}
-} );
+}
 ```

--- a/client/lib/signup/README.md
+++ b/client/lib/signup/README.md
@@ -45,8 +45,8 @@ If `errors` has a non-zero length, it will be attached to the step and the step'
 Actions which provide a `providedDependencies` object will have this information added to the dependency store.
 
 ```js
-var SignupDependencyStore = require( 'lib/signup/dependency-store' ),
-	SignupActions = require( 'lib/signup/actions' );
+import SignupDependencyStore from 'lib/signup/dependency-store' );
+import SignupActions from 'lib/signup/actions';
 
 SignupActions.processedSignupStep( { stepName: 'example' }, [], { userId: 1337 } );
 
@@ -60,21 +60,21 @@ SignupDependencyStore.get() // => { userId: 1337 }
 `SignupFlowController` accepts an object with a `flowName` property and begins the signup flow with the given name.
 
 ```js
-var SignupFlowController = require( 'lib/signup/flow-controller' );
+import SignupFlowController from 'lib/signup/flow-controller';
 
 // this is the component that renders the signup flow
-const SignupComponent = React.createClass( {
-	componentWillMount: function() {
+class SignupComponent extends React.Component {
+	componentWillMount() {
 		this.signupFlowController = SignupFlowController( {
 			flowName: 'default', // the name of the flow to begin, from flows.json
 			onComplete: function() { // optional callback, called when the flow is completed
 				console.log( 'The user completed the flow. Redirect or log them in here.' );
 			}
 		} );
-	},
+	}
 
-	render: function() {
-		var CurrentStepComponent = this.signupFlowController.currentStep().component; // the component from steps.js
+	render() {
+		let CurrentStepComponent = this.signupFlowController.currentStep().component; // the component from steps.js
 
 		return <CurrentStepComponent />;
 	}

--- a/client/lib/user/README.md
+++ b/client/lib/user/README.md
@@ -5,7 +5,8 @@ This component is a wrapper module for interacting with the wpcom.js `/me` endpo
 
 ## User
 ```es6
-var user = require( 'lib/user' )();
+import userFactory from 'lib/user';
+const user = userFactory();
 ```
 
 ### `User#get()`
@@ -22,7 +23,7 @@ Clears user stored data and handles relevant redirects based on type of authenti
 
 ## UserUtilities
 ```es6
-var user = require( 'lib/user/utilities' );
+import user from 'lib/user/utilities';
 ```
 
 ### `UserUtilities#logout()`

--- a/client/lib/users/README.md
+++ b/client/lib/users/README.md
@@ -42,43 +42,35 @@ Actions get triggered by views and stores.
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var UsersStore = require( 'lib/users/store' );
+import UsersStore from 'lib/users/store';
 
-module.exports = React.createClass( { 
-
-	displayName: 'yourComponent',
+export default class extends React.Component {
+	static displayName = 'yourComponent';
+	state = this.getUsers();
 	
-	componentDidMount: function() {
+	componentDidMount() {
 		UsersStore.on( 'change', this.refreshUsers );
-	},
+	}
 	
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		UsersStore.removeListener( 'change', this.refreshUsers );
-	},
-
-	getInitialState: function() {
-		return this.getUsers();
-	},
+	} 
 	
-	getUsers: function() {
+	getUsers = () => {
 		return {
 			users: UsersStore.fetch( { siteId: this.props.site.ID } )
 		};
 	},
 
-	refreshUsers: function() {
-		this.setState( this.getUsers() );
-	},
+	refreshUsers = () => this.setState( this.getUsers() );
 	
-	render: function() {
+	render() {
 		
-	}
-	
-} );
-
+	} 
+} 
 ```

--- a/client/lib/wpcom-undocumented/README.md
+++ b/client/lib/wpcom-undocumented/README.md
@@ -6,7 +6,7 @@ wpcom-undocumented
 These undocumented endpoints are automatically added to your `wpcom.js` instance when you use the `wp` constructor.
 
 ```javascript
-var wpcom = require( 'lib/wp' );
+import wpcom from 'lib/wp';
 
 wpcom.undocumented().readLists( function( err, data ) {
     debug( 'Posts:', data );

--- a/client/me/sidebar-navigation/README.md
+++ b/client/me/sidebar-navigation/README.md
@@ -8,9 +8,9 @@ This component is used to display the mobile sidebar navigation header at the to
 Put the component in your `Main` component. It handles detecting the selected site.
 
 ```js
-var SidebarNavigation = require( './sidebar-navigation' );
+import SidebarNavigation from './sidebar-navigation';
 
-render: function() {
+render() {
     return (
         <Main>
 		<SidebarNavigation />

--- a/client/my-sites/all-sites-icon/README.md
+++ b/client/my-sites/all-sites-icon/README.md
@@ -6,9 +6,9 @@ This component is used to display a composite grid of site icons from the user's
 #### How to use:
 
 ```js
-var AllSitesIcon = require( 'my-sites/all-sites-icon' );
+import AllSitesIcon from 'my-sites/all-sites-icon';
 
-render: function() {
+render() {
 	return (
 		<div className="your-stuff">
 			<AllSitesIcon sites={ sitesList } />

--- a/client/my-sites/all-sites/README.md
+++ b/client/my-sites/all-sites/README.md
@@ -6,9 +6,9 @@ This component displays the All Sites item. It's used in the Sidebar as the curr
 #### How to use:
 
 ```js
-var AllSites = require( 'my-sites/all-sites' );
+import AllSites from 'my-sites/all-sites';
 
-render: function() {
+render() {
 	return (
 		<AllSites sites={ sitesArray } />
 	);

--- a/client/my-sites/current-site/README.md
+++ b/client/my-sites/current-site/README.md
@@ -6,9 +6,9 @@ This component displays the currently selected site. It's used in the My Sites S
 #### How to use:
 
 ```js
-var CurrentSite = require( 'my-sites/current-site' );
+import CurrentSite from 'my-sites/current-site';
 
-render: function() {
+render() {
 	return (
 		<CurrentSite sites={ sitesListObject } />
 	);

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/README.md
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/README.md
@@ -6,9 +6,9 @@ This component is used to display a plugin autupdate toggle.
 #### How to use:
 
 ```js
-var PluginAutoupdateToggle = require( 'my-sites/plugins/plugin-autoupdate-toggle' );
+import PluginAutoupdateToggle 'my-sites/plugins/plugin-autoupdate-toggle';
 
-render: function() {
+render() {
 	return (
 		<div className="your-plugins-list">
 			<PluginAutoupdateToggle

--- a/client/my-sites/plugins/plugin-install-button/README.md
+++ b/client/my-sites/plugins/plugin-install-button/README.md
@@ -6,9 +6,9 @@ This component is used to display a button that launch a install action when cli
 #### How to use:
 
 ```js
-var PluginInstallButton = require( 'my-sites/plugins/plugin-install-button' );
+import PluginInstallButton 'my-sites/plugins/plugin-install-button';
 
-render: function() {
+render() {
     return <PluginInstallButton
             plugin={ plugin }
             selectedSite={ site }

--- a/client/my-sites/plugins/plugin-item/README.md
+++ b/client/my-sites/plugins/plugin-item/README.md
@@ -6,9 +6,9 @@ This component is used to display a plugin card in a list of plugins.
 #### How to use:
 
 ```js
-var  = require( 'my-sites/plugins/plugin-item/plugin-item' );
+import PluginItem from 'my-sites/plugins/plugin-item/plugin-item';
 
-render: function() {
+render() {
     return (
         <div className="your-plugins-list">
             <PluginItem 

--- a/client/my-sites/plugins/plugin-meta/README.md
+++ b/client/my-sites/plugins/plugin-meta/README.md
@@ -6,9 +6,9 @@ This component is used to display the meta information of a single plugin. Inclu
 #### How to use:
 
 ```js
-var PluginMeta = require( 'my-sites/plugins/plugin-meta' );
+import PluginMeta 'my-sites/plugins/plugin-meta';
 
-render: function() {
+render() {
 	return
 		<PluginMeta
 		    plugin={ plugin }

--- a/client/my-sites/plugins/plugin-ratings/README.md
+++ b/client/my-sites/plugins/plugin-ratings/README.md
@@ -6,9 +6,9 @@ This component is used to display the detail of how the ratings of a plugin are 
 #### How to use:
 
 ```js
-var PluginRatings = require( 'my-sites/plugins/plugin-ratings' );
+import PluginRatings from 'my-sites/plugins/plugin-ratings';
 
-render: function() {
+render() {
 	return <PluginRatings
 			plugin={ this.props.plugin }
 			barWidth={ 100 }

--- a/client/my-sites/plugins/plugin-remove-button/README.md
+++ b/client/my-sites/plugins/plugin-remove-button/README.md
@@ -6,14 +6,14 @@ This component is used to display a button that launch a remove action when clic
 #### How to use:
 
 ```js
-var PluginRemoveButton = require( 'my-sites/plugins/plugin-remove-button' );
+import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
 
-render: function() {
-    return <PluginRemoveButton
-            plugin={ plugin }
-            site={ site }
-            notices={ notices }
-        />;
+render() {
+	return <PluginRemoveButton
+				plugin={ plugin }
+				site={ site }
+				notices={ notices }
+			/>;
 }
 ```
 

--- a/client/my-sites/plugins/plugin-sections/README.md
+++ b/client/my-sites/plugins/plugin-sections/README.md
@@ -6,9 +6,9 @@ This component is used to display the sections for a plugin as returned from the
 #### How to use:
 
 ```js
-var PluginSections = require( 'my-sites/plugins/plugin-sections' );
+import PluginSections from 'my-sites/plugins/plugin-sections';
 
-render: function() {
+render() {
 	return
 		<PluginSections
 			plugin={ plugin }

--- a/client/my-sites/plugins/plugin-site-disabled-manage/README.md
+++ b/client/my-sites/plugins/plugin-site-disabled-manage/README.md
@@ -6,9 +6,9 @@ This component is used to display a warning when a site has not enabled jetpack 
 #### How to use:
 
 ```js
-var PluginSiteDisabledManage = require( 'my-sites/plugins/plugin-site-disabled-manage' );
+import PluginSiteDisabledManage from 'my-sites/plugins/plugin-site-disabled-manage';
 
-render: function() {
+render() {
     return ( <PluginSiteDisabledManage
                 site={ this.props.site }
                 plugin={ this.props.plugin }

--- a/client/my-sites/plugins/plugin-site-jetpack/README.md
+++ b/client/my-sites/plugins/plugin-site-jetpack/README.md
@@ -6,9 +6,9 @@ This component is used to display a single instance of a plugin within a jetpack
 #### How to use:
 
 ```js
-var PluginSiteJetpack = require( 'my-sites/plugins/plugin-site/plugin-site-jetpack' );
+import PluginSiteJetpack from 'my-sites/plugins/plugin-site/plugin-site-jetpack';
 
-render: function() {
+render() {
     return (
         <PluginSiteJetpack
             site={ site }

--- a/client/my-sites/plugins/plugin-site-list/README.md
+++ b/client/my-sites/plugins/plugin-site-list/README.md
@@ -6,13 +6,14 @@ This component is used to represent a list of `Plugin-Site`, with a `Section-Hea
 #### How to use:
 
 ```jsx
-var PluginSiteList = require( 'my-sites/plugins/plugin-site-list' );
+import PluginSiteList from 'my-sites/plugins/plugin-site-list';
 
 return <PluginSiteList
-        sites={ sites }
-        plugin={ this.state.plugin }
-        notices={ this.state.notices }
-        title={ title } />;
+			sites={ sites }
+			plugin={ this.state.plugin }
+			notices={ this.state.notices }
+			title={ title }
+		/>;
 ```
 
 #### Props

--- a/client/my-sites/plugins/plugin-site-network/README.md
+++ b/client/my-sites/plugins/plugin-site-network/README.md
@@ -6,17 +6,17 @@ This component is used to display a single instance of a plugin within a multisi
 #### How to use:
 
 ```js
-var PluginSiteNetwork = require( 'my-sites/plugins/plugin-site/plugin-site-network' );
+import PluginSiteNetwork from 'my-sites/plugins/plugin-site/plugin-site-network';
 
-render: function() {
+render() {
     return (
-        <PluginSiteNetwork
-            site={ site }
-            plugin={ plugin }
-            notices={ notices }
-            secondarySites={ secondarySites }
-            />
-    );
+		<PluginSiteNetwork
+			site={ site }
+			plugin={ plugin }
+			notices={ notices }
+			secondarySites={ secondarySites }
+		/>
+	);
 }
 ```
 

--- a/client/my-sites/plugins/plugin-site-update-indicator/README.md
+++ b/client/my-sites/plugins/plugin-site-update-indicator/README.md
@@ -6,17 +6,17 @@ This component is used to display a update indicator which can be turned into a 
 #### How to use:
 
 ```js
-var PluginSiteUpdateIndicator= require( 'my-sites/plugins/plugin-site-update-indicator' );
+import PluginSiteUpdateIndicator from 'my-sites/plugins/plugin-site-update-indicator';
 
-render: function() {
-    return (
-        <PluginSiteUpdateIndicator
-            site={ this.props.site }
-            plugin={ this.props.plugin }
-            notices={ this.props.notices }
-            expanded={ false }
-        />
-    );
+render() {
+	return (
+		<PluginSiteUpdateIndicator
+			site={ this.props.site }
+			plugin={ this.props.plugin }
+			notices={ this.props.notices }
+			expanded={ false }
+		/>
+	);
 }
 ```
 

--- a/client/my-sites/plugins/plugins-browser-item/README.md
+++ b/client/my-sites/plugins/plugins-browser-item/README.md
@@ -6,9 +6,9 @@ This component is used to display small infobox with the data of a plugin.
 #### How to use:
 
 ```js
-var PluginListItem = require( 'my-sites/plugins-browser-item' );
+import PluginListItem from 'my-sites/plugins-browser-item';
 
-render: function() {
+render() {
 	return (
 		<div>
 			<PluginListItem

--- a/client/my-sites/plugins/plugins-browser/README.md
+++ b/client/my-sites/plugins/plugins-browser/README.md
@@ -6,9 +6,9 @@ This component renders the main plugins browser page.
 #### How to use:
 
 ```js
-var BrowserMainView = require( 'my-sites/plugins/plugins-browser' );
+import BrowserMainView from 'my-sites/plugins/plugins-browser';
 
-render: function() {
+render() {
 	return (
 		<div>
 			<BrowserMainView

--- a/client/my-sites/sidebar-navigation/README.md
+++ b/client/my-sites/sidebar-navigation/README.md
@@ -8,13 +8,13 @@ This component is used to display the mobile sidebar navigation header at the to
 Put the component in your `Main` component. It handles detecting the selected site.
 
 ```js
-var SidebarNavigation = require( 'my-sites/sidebar-navigation' );
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
-render: function() {
-    return(
-        <Main>
-		      <SidebarNavigation />
-        </Main>
-    );
+render() {
+	return(
+		<Main>
+			<SidebarNavigation />
+		</Main>
+	);
 }
 ```

--- a/client/my-sites/site-indicator/README.md
+++ b/client/my-sites/site-indicator/README.md
@@ -6,12 +6,12 @@ This component is used to display a round badge next to a site with information 
 #### How to use
 
 ```js
-var SiteIndicator = require( 'my-sites/site-indicator' );
+import SiteIndicator from 'my-sites/site-indicator';
 
-render: function() {
-    return(
-        <SiteIndicator site={ siteObject } />
-    );
+render() {
+	return(
+		<SiteIndicator site={ siteObject } />
+	);
 }
 ```
 

--- a/client/my-sites/sites/README.md
+++ b/client/my-sites/sites/README.md
@@ -12,13 +12,11 @@ The sites-list view component and puts together the various filters.
 Handles the single site view. It can be used by any compoenent that needs to render a site card by passing a `site` property object of a single site from sites-list.
 
 ```javascript
-var Site = require( 'my-sites/sites/site' );
+import Site from 'my-sites/sites/site';
 
-const Component = React.createClass({
-  render: function() {
-    return (
-      <Site site={ site } />
-    );
-  }
-)};
+class Component extends React.Component {
+	render() {
+		return <Site site={ site } />
+	}
+}
 ```

--- a/client/my-sites/stats/post-performance/README.md
+++ b/client/my-sites/stats/post-performance/README.md
@@ -6,12 +6,12 @@ This component creates an insights card that displays stats about the last post 
 #### How to use:
 
 ```js
-var PostPerformance = require( 'my-sites/stats/post-performance' );
+import PostPerformance from 'my-sites/stats/post-performance';
 
-render: function() {
-    return (
-  		<PostPerformance site={ <Object> } />
-    );
+render() {
+	return (
+		<PostPerformance site={ <Object> } />
+	);
 }
 ```
 

--- a/client/notices/README.md
+++ b/client/notices/README.md
@@ -8,7 +8,7 @@ Provides some helper functions to render a notice on the UI. Types of notices ar
 Once you require the component you have access to .
 
 ```javascript
-var notices = require( 'notices' );
+import notices from 'notices';
 
 // Success notice when saving settings
 notices.success(

--- a/client/post-editor/editor-fieldset/README.md
+++ b/client/post-editor/editor-fieldset/README.md
@@ -8,11 +8,11 @@ Editor Fieldset is a React component to wrap a set of related options under a si
 The `<EditorFieldset />` component accepts a single `legend` prop to specify the heading text. Each child of the rendered component is treated and styled as a single option in the group.
 
 ```jsx
-var React = require( 'react' ),
-	EditorFieldset = require( 'post-editor/editor-fieldset' );
+import React from 'react';
+import EditorFieldset from 'post-editor/editor-fieldset';
 
-React.createClass( {
-	render: function() {
+class MyComponent extends React.Component {
+	render() {
 		return (
 			<EditorFieldset legend="Settings">
 				<label><input type="checkbox"> Option One</label>
@@ -20,7 +20,8 @@ React.createClass( {
 			</EditorFieldset>
 		);
 	}
-} );
+
+}
 ```
 
 ## Props

--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -49,7 +49,7 @@ The React component for a step should be implemented in `/signup/steps/`, in its
 Steps must use the `SignupActions` module, by requiring it as an internal dependency:
 
 ```javascript
-var SignupActions = require( 'lib/signup/actions' )
+import SignupActions from 'lib/signup/actions';
 ```
 
 `SignupActions` allows the Modular Framework to handle the data collected by a step. This means your step must include a UI element that allows users to move to the next step in the flow, and that the function handling this element must use the method `submitSignupStep` from `SignupActions`.
@@ -118,12 +118,12 @@ The steps below guide you through creating a new flow and step:
 3 - add a simple React component to `index.jsx`:
 
 ```javascript
-var React = require( 'react' );
+import React from 'react';
 
-module.exports = React.createClass( {
-	displayName: 'HelloWorld',
+export default class extends React.Component { 
+	static displayName = 'HelloWorld';
 
-	render: function() {
+	render() {
 		return <span>Hello world</span>;
 	}
 } );
@@ -131,7 +131,7 @@ module.exports = React.createClass( {
 
 4 - add the new step to `/client/signup/config/step-components.js`. Include the component:
 ```javascript
-var helloWorldComponent = require( 'signup/steps/hello-world' );
+import helloWorldComponent from 'signup/steps/hello-world';
 ```
 
 ... and then create a new property for it:
@@ -162,7 +162,7 @@ hello: { // This will be the slug for the flow, i.e.: wordpress.com/start/hello
 8 - now we need a way for users to move to the next step of the flow. Let's add a button and a form to the step's `render` method:
 
 ```javascript
-render: function() {
+render() {
 	return (
 		<form onSubmit={ this.handleSubmit }>
 			<p>This is the step named { this.props.stepName }</p>
@@ -174,13 +174,13 @@ render: function() {
 
 Make sure to require `SignupActions`:
 ```javascript
-var SignupActions = require( 'lib/signup/actions' );
+import SignupActions from 'lib/signup/actions';
 ```
 
 ... and to create a function to handle what happens when the form is submitted:
 
 ```javascript
-handleSubmit: function( event ) {
+handleSubmit = ( event ) => {
 	event.preventDefault();
 
 	SignupActions.submitSignupStep( {

--- a/config/README.md
+++ b/config/README.md
@@ -8,7 +8,7 @@ If it is necessary to access a `config` value on the client-side, add the proper
 Server-side and client-side code can retrieve a config value by invoking the `config()` exported function with the desired key name:
 
 ```js
-var config = require( 'config' );
+import config from 'config';
 console.log( config( 'redirect_uri' ) );
 ```
 


### PR DESCRIPTION
This PR is part of a collection of small documentation updates.

We currently have many markdown files that contain javascript looking like this:
```js
var React = require( 'react' ),  // BAD
	CartData = require( 'components/data/cart-data' ),
	MyChildComponent = require( './my-child-component' );

module.exports = React.createClass( { // BAD
	displayName: 'MyComponent',

	render: function() {
		return (
			<CartData>
				<MyChildComponent />
			</CartData>
		);
	}
} );
```

The problem with that documentation is that it encourages two bad practices:
1. `createClass` is no longer supported in React 16
2. `require` should be avoided unless absolutely necessary. favor `import` instead.

So the documentation should be changed into:
```js
import React from 'react';
import CartData from 'components/data/cart-data';
import MyChildComponent from './my-child-component';

export default class extends React.Component {
	static displayName = 'MyComponent';

	render() {
		return (
			<CartData>
				<MyChildComponent />
			</CartData>
		);
	}
}
```


I recommend reviewing all of the PRs in reverse order

Stacked Parts:
1. This One
2. https://github.com/Automattic/wp-calypso/pull/21699
3. https://github.com/Automattic/wp-calypso/pull/21701
4. https://github.com/Automattic/wp-calypso/pull/21702
5. https://github.com/Automattic/wp-calypso/pull/21703
6. https://github.com/Automattic/wp-calypso/pull/21704
7. https://github.com/Automattic/wp-calypso/pull/21705

**To Test**: since only documentation has changed, there is no need to do any real testing. visual inspection should be enough!