### PR TITLE
Documentation: update markdown examples to es6. batch7

### DIFF
--- a/client/my-sites/plugins/plugin-sections/README.md
+++ b/client/my-sites/plugins/plugin-sections/README.md
@@ -6,9 +6,9 @@ This component is used to display the sections for a plugin as returned from the
 #### How to use:
 
 ```js
-var PluginSections = require( 'my-sites/plugins/plugin-sections' );
+import PluginSections from 'my-sites/plugins/plugin-sections';
 
-render: function() {
+render() {
 	return
 		<PluginSections
 			plugin={ plugin }

--- a/client/my-sites/plugins/plugin-site-disabled-manage/README.md
+++ b/client/my-sites/plugins/plugin-site-disabled-manage/README.md
@@ -6,9 +6,9 @@ This component is used to display a warning when a site has not enabled jetpack 
 #### How to use:
 
 ```js
-var PluginSiteDisabledManage = require( 'my-sites/plugins/plugin-site-disabled-manage' );
+import PluginSiteDisabledManage from 'my-sites/plugins/plugin-site-disabled-manage';
 
-render: function() {
+render() {
     return ( <PluginSiteDisabledManage
                 site={ this.props.site }
                 plugin={ this.props.plugin }

--- a/client/my-sites/plugins/plugin-site-jetpack/README.md
+++ b/client/my-sites/plugins/plugin-site-jetpack/README.md
@@ -6,9 +6,9 @@ This component is used to display a single instance of a plugin within a jetpack
 #### How to use:
 
 ```js
-var PluginSiteJetpack = require( 'my-sites/plugins/plugin-site/plugin-site-jetpack' );
+import PluginSiteJetpack from 'my-sites/plugins/plugin-site/plugin-site-jetpack';
 
-render: function() {
+render() {
     return (
         <PluginSiteJetpack
             site={ site }

--- a/client/my-sites/plugins/plugin-site-list/README.md
+++ b/client/my-sites/plugins/plugin-site-list/README.md
@@ -6,13 +6,14 @@ This component is used to represent a list of `Plugin-Site`, with a `Section-Hea
 #### How to use:
 
 ```jsx
-var PluginSiteList = require( 'my-sites/plugins/plugin-site-list' );
+import PluginSiteList from 'my-sites/plugins/plugin-site-list';
 
 return <PluginSiteList
-        sites={ sites }
-        plugin={ this.state.plugin }
-        notices={ this.state.notices }
-        title={ title } />;
+			sites={ sites }
+			plugin={ this.state.plugin }
+			notices={ this.state.notices }
+			title={ title }
+		/>;
 ```
 
 #### Props

--- a/client/my-sites/plugins/plugin-site-network/README.md
+++ b/client/my-sites/plugins/plugin-site-network/README.md
@@ -6,17 +6,17 @@ This component is used to display a single instance of a plugin within a multisi
 #### How to use:
 
 ```js
-var PluginSiteNetwork = require( 'my-sites/plugins/plugin-site/plugin-site-network' );
+import PluginSiteNetwork from 'my-sites/plugins/plugin-site/plugin-site-network';
 
-render: function() {
+render() {
     return (
-        <PluginSiteNetwork
-            site={ site }
-            plugin={ plugin }
-            notices={ notices }
-            secondarySites={ secondarySites }
-            />
-    );
+		<PluginSiteNetwork
+			site={ site }
+			plugin={ plugin }
+			notices={ notices }
+			secondarySites={ secondarySites }
+		/>
+	);
 }
 ```
 

--- a/client/my-sites/plugins/plugin-site-update-indicator/README.md
+++ b/client/my-sites/plugins/plugin-site-update-indicator/README.md
@@ -6,17 +6,17 @@ This component is used to display a update indicator which can be turned into a 
 #### How to use:
 
 ```js
-var PluginSiteUpdateIndicator= require( 'my-sites/plugins/plugin-site-update-indicator' );
+import PluginSiteUpdateIndicator from 'my-sites/plugins/plugin-site-update-indicator';
 
-render: function() {
-    return (
-        <PluginSiteUpdateIndicator
-            site={ this.props.site }
-            plugin={ this.props.plugin }
-            notices={ this.props.notices }
-            expanded={ false }
-        />
-    );
+render() {
+	return (
+		<PluginSiteUpdateIndicator
+			site={ this.props.site }
+			plugin={ this.props.plugin }
+			notices={ this.props.notices }
+			expanded={ false }
+		/>
+	);
 }
 ```
 

--- a/client/my-sites/plugins/plugins-browser-item/README.md
+++ b/client/my-sites/plugins/plugins-browser-item/README.md
@@ -6,9 +6,9 @@ This component is used to display small infobox with the data of a plugin.
 #### How to use:
 
 ```js
-var PluginListItem = require( 'my-sites/plugins-browser-item' );
+import PluginListItem from 'my-sites/plugins-browser-item';
 
-render: function() {
+render() {
 	return (
 		<div>
 			<PluginListItem

--- a/client/my-sites/plugins/plugins-browser/README.md
+++ b/client/my-sites/plugins/plugins-browser/README.md
@@ -6,9 +6,9 @@ This component renders the main plugins browser page.
 #### How to use:
 
 ```js
-var BrowserMainView = require( 'my-sites/plugins/plugins-browser' );
+import BrowserMainView from 'my-sites/plugins/plugins-browser';
 
-render: function() {
+render() {
 	return (
 		<div>
 			<BrowserMainView

--- a/client/my-sites/sidebar-navigation/README.md
+++ b/client/my-sites/sidebar-navigation/README.md
@@ -8,13 +8,13 @@ This component is used to display the mobile sidebar navigation header at the to
 Put the component in your `Main` component. It handles detecting the selected site.
 
 ```js
-var SidebarNavigation = require( 'my-sites/sidebar-navigation' );
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
-render: function() {
-    return(
-        <Main>
-		      <SidebarNavigation />
-        </Main>
-    );
+render() {
+	return(
+		<Main>
+			<SidebarNavigation />
+		</Main>
+	);
 }
 ```

--- a/client/my-sites/site-indicator/README.md
+++ b/client/my-sites/site-indicator/README.md
@@ -6,12 +6,12 @@ This component is used to display a round badge next to a site with information 
 #### How to use
 
 ```js
-var SiteIndicator = require( 'my-sites/site-indicator' );
+import SiteIndicator from 'my-sites/site-indicator';
 
-render: function() {
-    return(
-        <SiteIndicator site={ siteObject } />
-    );
+render() {
+	return(
+		<SiteIndicator site={ siteObject } />
+	);
 }
 ```
 

--- a/client/my-sites/sites/README.md
+++ b/client/my-sites/sites/README.md
@@ -12,13 +12,11 @@ The sites-list view component and puts together the various filters.
 Handles the single site view. It can be used by any compoenent that needs to render a site card by passing a `site` property object of a single site from sites-list.
 
 ```javascript
-var Site = require( 'my-sites/sites/site' );
+import Site from 'my-sites/sites/site';
 
-const Component = React.createClass({
-  render: function() {
-    return (
-      <Site site={ site } />
-    );
-  }
-)};
+class Component extends React.Component {
+	render() {
+		return <Site site={ site } />
+	}
+}
 ```

--- a/client/my-sites/stats/post-performance/README.md
+++ b/client/my-sites/stats/post-performance/README.md
@@ -6,12 +6,12 @@ This component creates an insights card that displays stats about the last post 
 #### How to use:
 
 ```js
-var PostPerformance = require( 'my-sites/stats/post-performance' );
+import PostPerformance from 'my-sites/stats/post-performance';
 
-render: function() {
-    return (
-  		<PostPerformance site={ <Object> } />
-    );
+render() {
+	return (
+		<PostPerformance site={ <Object> } />
+	);
 }
 ```
 

--- a/client/notices/README.md
+++ b/client/notices/README.md
@@ -8,7 +8,7 @@ Provides some helper functions to render a notice on the UI. Types of notices ar
 Once you require the component you have access to .
 
 ```javascript
-var notices = require( 'notices' );
+import notices from 'notices';
 
 // Success notice when saving settings
 notices.success(

--- a/client/post-editor/editor-fieldset/README.md
+++ b/client/post-editor/editor-fieldset/README.md
@@ -8,11 +8,11 @@ Editor Fieldset is a React component to wrap a set of related options under a si
 The `<EditorFieldset />` component accepts a single `legend` prop to specify the heading text. Each child of the rendered component is treated and styled as a single option in the group.
 
 ```jsx
-var React = require( 'react' ),
-	EditorFieldset = require( 'post-editor/editor-fieldset' );
+import React from 'react';
+import EditorFieldset from 'post-editor/editor-fieldset';
 
-React.createClass( {
-	render: function() {
+class MyComponent extends React.Component {
+	render() {
 		return (
 			<EditorFieldset legend="Settings">
 				<label><input type="checkbox"> Option One</label>
@@ -20,7 +20,8 @@ React.createClass( {
 			</EditorFieldset>
 		);
 	}
-} );
+
+}
 ```
 
 ## Props

--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -49,7 +49,7 @@ The React component for a step should be implemented in `/signup/steps/`, in its
 Steps must use the `SignupActions` module, by requiring it as an internal dependency:
 
 ```javascript
-var SignupActions = require( 'lib/signup/actions' )
+import SignupActions from 'lib/signup/actions';
 ```
 
 `SignupActions` allows the Modular Framework to handle the data collected by a step. This means your step must include a UI element that allows users to move to the next step in the flow, and that the function handling this element must use the method `submitSignupStep` from `SignupActions`.
@@ -118,12 +118,12 @@ The steps below guide you through creating a new flow and step:
 3 - add a simple React component to `index.jsx`:
 
 ```javascript
-var React = require( 'react' );
+import React from 'react';
 
-module.exports = React.createClass( {
-	displayName: 'HelloWorld',
+export default class extends React.Component { 
+	static displayName = 'HelloWorld';
 
-	render: function() {
+	render() {
 		return <span>Hello world</span>;
 	}
 } );
@@ -131,7 +131,7 @@ module.exports = React.createClass( {
 
 4 - add the new step to `/client/signup/config/step-components.js`. Include the component:
 ```javascript
-var helloWorldComponent = require( 'signup/steps/hello-world' );
+import helloWorldComponent from 'signup/steps/hello-world';
 ```
 
 ... and then create a new property for it:
@@ -162,7 +162,7 @@ hello: { // This will be the slug for the flow, i.e.: wordpress.com/start/hello
 8 - now we need a way for users to move to the next step of the flow. Let's add a button and a form to the step's `render` method:
 
 ```javascript
-render: function() {
+render() {
 	return (
 		<form onSubmit={ this.handleSubmit }>
 			<p>This is the step named { this.props.stepName }</p>
@@ -174,13 +174,13 @@ render: function() {
 
 Make sure to require `SignupActions`:
 ```javascript
-var SignupActions = require( 'lib/signup/actions' );
+import SignupActions from 'lib/signup/actions';
 ```
 
 ... and to create a function to handle what happens when the form is submitted:
 
 ```javascript
-handleSubmit: function( event ) {
+handleSubmit = ( event ) => {
 	event.preventDefault();
 
 	SignupActions.submitSignupStep( {

--- a/config/README.md
+++ b/config/README.md
@@ -8,7 +8,7 @@ If it is necessary to access a `config` value on the client-side, add the proper
 Server-side and client-side code can retrieve a config value by invoking the `config()` exported function with the desired key name:
 
 ```js
-var config = require( 'config' );
+import config from 'config';
 console.log( config( 'redirect_uri' ) );
 ```
 


### PR DESCRIPTION
This PR is part of a collection of small documentation updates.
The end goal is to get rid of all references to createClass and require.

For more details, see https://github.com/Automattic/wp-calypso/pull/21698