### PR TITLE
Domains: Refactor Transfer Steps

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -263,9 +263,9 @@ class TransferDomainStep extends React.Component {
 
 	render() {
 		let content;
-		const { domain, precheck, submittingAvailability, submittingWhois } = this.state;
+		const { precheck } = this.state;
 
-		if ( precheck || ( domain && ! submittingAvailability && ! submittingWhois ) ) {
+		if ( precheck ) {
 			if ( this.transferIsRestricted() ) {
 				content = this.getTransferRestrictionMessage();
 			} else {

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -201,12 +201,11 @@ class TransferDomainStep extends React.Component {
 		);
 	}
 
-	transferDomainPrecheck() {
+	getTransferDomainPrecheck() {
 		const { inboundTransferStatus, submittingWhois } = this.state;
 
 		return (
 			<TransferDomainPrecheck
-				creationDate={ inboundTransferStatus.creationDate }
 				domain={ this.state.domain }
 				email={ inboundTransferStatus.email }
 				loading={ submittingWhois }
@@ -214,13 +213,10 @@ class TransferDomainStep extends React.Component {
 				losingRegistrarIanaId={ inboundTransferStatus.losingRegistrarIanaId }
 				privacy={ inboundTransferStatus.privacy }
 				refreshStatus={ this.getInboundTransferStatus }
-				termMaximumInYears={ inboundTransferStatus.termMaximumInYears }
-				transferEligibleDate={ inboundTransferStatus.transferEligibleDate }
-				transferRestrictionStatus={ inboundTransferStatus.transferRestrictionStatus }
-				unlocked={ inboundTransferStatus.unlocked }
 				selectedSiteSlug={ get( this.props, 'selectedSite.slug', null ) }
 				setValid={ this.props.onTransferDomain }
 				supportsPrivacy={ this.state.supportsPrivacy }
+				unlocked={ inboundTransferStatus.unlocked }
 			/>
 		);
 	}
@@ -269,14 +265,10 @@ class TransferDomainStep extends React.Component {
 		const { domain, precheck, submittingAvailability, submittingWhois } = this.state;
 
 		if ( precheck || ( domain && ! submittingAvailability && ! submittingWhois ) ) {
-			if ( ! precheck ) {
-				this.setState( { precheck: true } );
-			}
-
 			if ( this.transferIsRestricted() ) {
 				content = this.getTransferRestrictionMessage();
 			} else {
-				content = this.transferDomainPrecheck();
+				content = this.getTransferDomainPrecheck();
 			}
 		} else {
 			content = this.addTransfer();

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -39,31 +39,31 @@ import TransferRestrictionMessage from 'components/domains/transfer-domain-step/
 
 class TransferDomainStep extends React.Component {
 	static propTypes = {
-		products: PropTypes.object.isRequired,
-		cart: PropTypes.object,
-		goBack: PropTypes.func,
-		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
-		initialQuery: PropTypes.string,
 		analyticsSection: PropTypes.string.isRequired,
+		cart: PropTypes.object,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
+		goBack: PropTypes.func,
+		initialQuery: PropTypes.string,
 		onRegisterDomain: PropTypes.func.isRequired,
 		onTransferDomain: PropTypes.func.isRequired,
 		onSave: PropTypes.func,
+		products: PropTypes.object.isRequired,
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 	};
 
 	static defaultProps = {
-		onSave: noop,
 		analyticsSection: 'domains',
+		onSave: noop,
 	};
 
 	state = this.getDefaultState();
 
 	getDefaultState() {
 		return {
-			searchQuery: this.props.initialQuery || '',
 			domain: null,
 			inboundTransferStatus: {},
 			precheck: false,
+			searchQuery: this.props.initialQuery || '',
 			submittingAvailability: false,
 			submittingWhois: false,
 			supportsPrivacy: false,
@@ -299,12 +299,12 @@ class TransferDomainStep extends React.Component {
 					} ) }
 				</Notice>
 				<DomainRegistrationSuggestion
-					suggestion={ suggestion }
-					selectedSite={ this.props.selectedSite }
+					cart={ this.props.cart }
 					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 					key={ suggestion.domain_name }
-					cart={ this.props.cart }
 					onButtonClick={ this.registerSuggestedDomain }
+					selectedSite={ this.props.selectedSite }
+					suggestion={ suggestion }
 				/>
 			</div>
 		);

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import async from 'async';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -338,73 +339,89 @@ class TransferDomainStep extends React.Component {
 			this.props.analyticsSection
 		);
 
-		this.getInboundTransferStatus();
+		async.parallel(
+			[
+				callback => {
+					this.getInboundTransferStatus();
+					callback();
+				},
+				callback => {
+					checkDomainAvailability(
+						{ domainName: domain, blogId: get( this.props, 'selectedSite.ID', null ) },
+						( error, result ) => {
+							const status = get( result, 'status', error );
+							switch ( status ) {
+								case domainAvailability.AVAILABLE:
+									this.setState( { suggestion: result } );
+									break;
+								case domainAvailability.TRANSFERRABLE:
+								case domainAvailability.MAPPED_SAME_SITE_TRANSFERRABLE:
+									this.setState( {
+										domain,
+										supportsPrivacy: get( result, 'supports_privacy', false ),
+									} );
+									break;
+								case domainAvailability.MAPPABLE:
+								case domainAvailability.TLD_NOT_SUPPORTED:
+									const tld = getTld( domain );
 
-		checkDomainAvailability(
-			{ domainName: domain, blogId: get( this.props, 'selectedSite.ID', null ) },
-			( error, result ) => {
-				const status = get( result, 'status', error );
-				switch ( status ) {
-					case domainAvailability.AVAILABLE:
-						this.setState( { suggestion: result } );
-						break;
-					case domainAvailability.TRANSFERRABLE:
-					case domainAvailability.MAPPED_SAME_SITE_TRANSFERRABLE:
-						this.setState( {
-							domain,
-							supportsPrivacy: get( result, 'supports_privacy', false ),
-						} );
-						break;
-					case domainAvailability.MAPPABLE:
-					case domainAvailability.TLD_NOT_SUPPORTED:
-						const tld = getTld( domain );
+									this.setState( {
+										notice: this.props.translate(
+											"We don't support transfers for domains ending with {{strong}}.%(tld)s{{/strong}}, " +
+												'but you can {{a}}map it{{/a}} instead.',
+											{
+												args: { tld },
+												components: {
+													strong: <strong />,
+													a: <a href="#" onClick={ this.goToMapDomainStep } />,
+												},
+											}
+										),
+										noticeSeverity: 'info',
+									} );
+									break;
+								case domainAvailability.UNKNOWN:
+									const mappableStatus = get( result, 'mappable', error );
 
-						this.setState( {
-							notice: this.props.translate(
-								"We don't support transfers for domains ending with {{strong}}.%(tld)s{{/strong}}, " +
-									'but you can {{a}}map it{{/a}} instead.',
-								{
-									args: { tld },
-									components: {
-										strong: <strong />,
-										a: <a href="#" onClick={ this.goToMapDomainStep } />,
-									},
-								}
-							),
-							noticeSeverity: 'info',
-						} );
-						break;
-					case domainAvailability.UNKNOWN:
-						const mappableStatus = get( result, 'mappable', error );
-
-						if ( domainAvailability.MAPPABLE === mappableStatus ) {
-							this.setState( {
-								notice: this.props.translate(
-									"{{strong}}%(domain)s{{/strong}} can't be transferred. " +
-										'You can {{a}}manually connect it{{/a}} if you still want to use it for your site.',
-									{
-										args: { domain },
-										components: {
-											strong: <strong />,
-											a: <a href="#" onClick={ this.goToMapDomainStep } />,
-										},
+									if ( domainAvailability.MAPPABLE === mappableStatus ) {
+										this.setState( {
+											notice: this.props.translate(
+												"{{strong}}%(domain)s{{/strong}} can't be transferred. " +
+													'You can {{a}}manually connect it{{/a}} if you still want to use it for your site.',
+												{
+													args: { domain },
+													components: {
+														strong: <strong />,
+														a: <a href="#" onClick={ this.goToMapDomainStep } />,
+													},
+												}
+											),
+											noticeSeverity: 'info',
+										} );
+										break;
 									}
-								),
-								noticeSeverity: 'info',
-							} );
-							break;
-						}
-					default:
-						let site = get( result, 'other_site_domain', null );
-						if ( ! site ) {
-							site = get( this.props, 'selectedSite.slug', null );
-						}
+								default:
+									let site = get( result, 'other_site_domain', null );
+									if ( ! site ) {
+										site = get( this.props, 'selectedSite.slug', null );
+									}
 
-						const { message, severity } = getAvailabilityNotice( domain, status, site );
-						this.setState( { notice: message, noticeSeverity: severity } );
-				}
+									const { message, severity } = getAvailabilityNotice( domain, status, site );
+									this.setState( { notice: message, noticeSeverity: severity } );
+							}
 
-				this.setState( { submittingAvailability: false } );
+							this.setState( { submittingAvailability: false } );
+							callback();
+						}
+					);
+				},
+			],
+			() => {
+				this.setState( prevState => {
+					const { submittingAvailability, submittingWhois } = prevState;
+
+					return { precheck: prevState.domain && ! submittingAvailability && ! submittingWhois };
+				} );
 			}
 		);
 	};

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -118,7 +118,7 @@ class TransferDomainPrecheck extends React.Component {
 	}
 
 	getStatusMessage() {
-		const { translate, unlocked, loading } = this.props;
+		const { loading, translate, unlocked } = this.props;
 		const { currentStep } = this.state;
 		const step = 1;
 		const isStepFinished = currentStep > step;
@@ -210,7 +210,7 @@ class TransferDomainPrecheck extends React.Component {
 	}
 
 	getPrivacyMessage() {
-		const { translate, email, loading, privacy } = this.props;
+		const { email, loading, privacy, translate } = this.props;
 		const { currentStep } = this.state;
 		const step = 2;
 		const isStepFinished = currentStep > step;

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -25,17 +25,17 @@ import {
 	INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK,
 } from 'lib/url/support';
 
-class TransferDomainPrecheck extends React.PureComponent {
+class TransferDomainPrecheck extends React.Component {
 	static propTypes = {
 		domain: PropTypes.string,
-		selectedSiteSlug: PropTypes.string,
-		setValid: PropTypes.func,
-		supportsPrivacy: PropTypes.bool,
 		email: PropTypes.string,
 		loading: PropTypes.bool,
 		losingRegistrar: PropTypes.string,
 		losingRegistrarIanaId: PropTypes.string,
 		privacy: PropTypes.bool,
+		selectedSiteSlug: PropTypes.string,
+		setValid: PropTypes.func,
+		supportsPrivacy: PropTypes.bool,
 		unlocked: PropTypes.bool,
 	};
 

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isEmpty } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -19,14 +18,12 @@ import Card from 'components/card';
 import Notice from 'components/notice';
 import { recordTracksEvent } from 'state/analytics/actions';
 import FormattedHeader from 'components/formatted-header';
-import { checkInboundTransferStatus } from 'lib/domains';
 import {
 	CALYPSO_CONTACT,
 	INCOMING_DOMAIN_TRANSFER_PREPARE_AUTH_CODE,
 	INCOMING_DOMAIN_TRANSFER_PREPARE_PRIVACY,
 	INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK,
 } from 'lib/url/support';
-import TransferRestrictionMessage from 'components/domains/transfer-domain-step/transfer-restriction-message';
 
 class TransferDomainPrecheck extends React.PureComponent {
 	static propTypes = {
@@ -34,78 +31,39 @@ class TransferDomainPrecheck extends React.PureComponent {
 		selectedSiteSlug: PropTypes.string,
 		setValid: PropTypes.func,
 		supportsPrivacy: PropTypes.bool,
+		email: PropTypes.string,
+		loading: PropTypes.bool,
+		losingRegistrar: PropTypes.string,
+		losingRegistrarIanaId: PropTypes.string,
+		privacy: PropTypes.bool,
+		unlocked: PropTypes.bool,
 	};
 
 	state = {
-		creationDate: '',
 		currentStep: 1,
-		email: '',
-		loading: true,
-		losingRegistrar: '',
-		losingRegistrarIanaId: '',
-		privacy: false,
-		termMaximumInYears: 10,
-		transferEligibleDate: '',
-		transferRestrictionStatus: '',
-		unlocked: false,
 	};
 
 	componentWillMount() {
-		this.refreshStatus();
+		this.componentWillReceiveProps( this.props );
 	}
 
-	componentWillUpdate( nextProps ) {
-		if ( nextProps.domain !== this.props.domain ) {
-			this.refreshStatus();
+	componentWillReceiveProps( nextProps ) {
+		// Reset steps if domain became locked again
+		if ( false === nextProps.unlocked ) {
+			this.resetSteps();
+		}
+
+		if ( nextProps.unlocked && 1 === this.state.currentStep ) {
+			this.showNextStep();
 		}
 	}
 
 	onClick = () => {
-		const { domain, supportsPrivacy } = this.props;
-		const { losingRegistrar, losingRegistrarIanaId } = this.state;
+		const { losingRegistrar, losingRegistrarIanaId, domain, supportsPrivacy } = this.props;
 
 		this.props.recordContinueButtonClick( domain, losingRegistrar, losingRegistrarIanaId );
 
 		this.props.setValid( domain, supportsPrivacy );
-	};
-
-	transferIsRestricted = () =>
-		! this.state.loading && 'not_restricted' !== this.state.transferRestrictionStatus;
-
-	refreshStatus = ( proceedToNextStep = true ) => {
-		this.setState( { loading: true } );
-
-		checkInboundTransferStatus( this.props.domain, ( error, result ) => {
-			if ( ! isEmpty( error ) ) {
-				return;
-			}
-
-			if ( proceedToNextStep && result.unlocked ) {
-				this.showNextStep();
-			}
-
-			// Reset steps if domain became locked again
-			if ( false === result.unlocked ) {
-				this.resetSteps();
-			}
-
-			this.setState( {
-				creationDate: result.creation_date,
-				email: result.admin_email,
-				loading: false,
-				losingRegistrar: result.registrar,
-				losingRegistrarIanaId: result.registrar_iana_id,
-				privacy: result.privacy,
-				termMaximumInYears: result.term_maximum_in_years,
-				transferEligibleDate: result.transfer_eligible_date,
-				transferRestrictionStatus: result.transfer_restriction_status,
-				unlocked: result.unlocked,
-			} );
-		} );
-	};
-
-	refreshStatusOnly = () => {
-		this.refreshStatus( false );
 	};
 
 	resetSteps = () => {
@@ -120,7 +78,8 @@ class TransferDomainPrecheck extends React.PureComponent {
 	};
 
 	getSection( heading, message, buttonText, step, stepStatus ) {
-		const { currentStep, loading, unlocked } = this.state;
+		const { currentStep } = this.state;
+		const { loading, unlocked } = this.props;
 		const isAtCurrentStep = step === currentStep;
 		const isStepFinished = currentStep > step;
 		const sectionClasses = classNames( 'transfer-domain-step__section', {
@@ -130,7 +89,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 
 		const sectionIcon = isStepFinished ? <Gridicon icon="checkmark-circle" size={ 36 } /> : step;
 		const onButtonClick =
-			true === unlocked || null === unlocked ? this.showNextStep : this.refreshStatus;
+			true === unlocked || null === unlocked ? this.showNextStep : this.props.refreshStatus;
 
 		return (
 			<Card compact>
@@ -158,30 +117,9 @@ class TransferDomainPrecheck extends React.PureComponent {
 		);
 	}
 
-	getTransferRestrictionMessage() {
-		const { domain, selectedSiteSlug } = this.props;
-		const {
-			creationDate,
-			termMaximumInYears,
-			transferEligibleDate,
-			transferRestrictionStatus,
-		} = this.state;
-
-		return (
-			<TransferRestrictionMessage
-				creationDate={ creationDate }
-				domain={ domain }
-				selectedSiteSlug={ selectedSiteSlug }
-				termMaximumInYears={ termMaximumInYears }
-				transferEligibleDate={ transferEligibleDate }
-				transferRestrictionStatus={ transferRestrictionStatus }
-			/>
-		);
-	}
-
 	getStatusMessage() {
-		const { translate } = this.props;
-		const { currentStep, unlocked, loading } = this.state;
+		const { translate, unlocked, loading } = this.props;
+		const { currentStep } = this.state;
 		const step = 1;
 		const isStepFinished = currentStep > step;
 
@@ -272,8 +210,8 @@ class TransferDomainPrecheck extends React.PureComponent {
 	}
 
 	getPrivacyMessage() {
-		const { translate } = this.props;
-		const { currentStep, email, loading, privacy } = this.state;
+		const { translate, email, loading, privacy } = this.props;
+		const { currentStep } = this.state;
 		const step = 2;
 		const isStepFinished = currentStep > step;
 
@@ -371,7 +309,7 @@ class TransferDomainPrecheck extends React.PureComponent {
 		const statusText = loading ? translate( 'Checking…' ) : translate( 'Refresh email address' );
 
 		const stepStatus = ! isStepFinished && (
-			<a className={ statusClasses } onClick={ this.refreshStatusOnly }>
+			<a className={ statusClasses } onClick={ this.props.refreshStatus }>
 				<Gridicon icon={ statusIcon } size={ 12 } />
 				<span>{ statusText }</span>
 			</a>
@@ -429,12 +367,8 @@ class TransferDomainPrecheck extends React.PureComponent {
 	}
 
 	render() {
-		const { translate } = this.props;
-		const { unlocked, currentStep } = this.state;
-
-		if ( this.transferIsRestricted() ) {
-			return this.getTransferRestrictionMessage();
-		}
+		const { translate, unlocked } = this.props;
+		const { currentStep } = this.state;
 
 		return (
 			<div className="transfer-domain-step__precheck">


### PR DESCRIPTION
We want to show the transfer restrictions in signup right after inputting a domain.
Need to move the API call to TransferStep for this.
Also nicely eliminates the flicker on precheck screen when we land on it, and are immediately sent to restriction component.
Also faster, as the calls end up in parallel, tho might have more endpoint calls.

Test:
- Make sure transfer step, precheck and restrictions work as before.