### PR TITLE
Rewind Credentials: Shuffle props around (Take 2)

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 
@@ -14,6 +15,8 @@ import FoldableCard from 'components/foldable-card';
 import CompactCard from 'components/card/compact';
 import CredentialsForm from '../credentials-form/index';
 import Button from 'components/button';
+import { deleteCredentials } from 'state/jetpack/credentials/actions';
+import { getJetpackCredentials, isSitePressable } from 'state/selectors';
 
 class CredentialsConfigured extends Component {
 	componentWillMount() {
@@ -42,16 +45,7 @@ class CredentialsConfigured extends Component {
 	toggleRevoking = () => this.setState( { isRevoking: ! this.state.isRevoking } );
 
 	render() {
-		const {
-			isPressable,
-			credentialsUpdating,
-			mainCredentials,
-			formIsSubmitting,
-			siteId,
-			updateCredentials,
-			deleteCredentials,
-			translate,
-		} = this.props;
+		const { isPressable, mainCredentials, siteId, translate } = this.props;
 
 		const isRevoking = this.state.isRevoking;
 		const protocol = get( this.props.mainCredentials, 'protocol', 'SSH' ).toUpperCase();
@@ -122,7 +116,6 @@ class CredentialsConfigured extends Component {
 			<FoldableCard header={ header } className="credentials-configured">
 				<CredentialsForm
 					{ ...{
-						credentialsUpdating,
 						protocol: get( mainCredentials, 'protocol', 'ssh' ),
 						host: get( mainCredentials, 'host', '' ),
 						port: get( mainCredentials, 'port', '' ),
@@ -131,12 +124,9 @@ class CredentialsConfigured extends Component {
 						abspath: get( mainCredentials, 'abspath', '' ),
 						kpri: get( mainCredentials, 'kpri', '' ),
 						role: 'main',
-						formIsSubmitting,
 						siteId,
-						updateCredentials,
 						showCancelButton: false,
 						showDeleteButton: true,
-						deleteCredentials,
 					} }
 				/>
 			</FoldableCard>
@@ -144,4 +134,11 @@ class CredentialsConfigured extends Component {
 	}
 }
 
-export default localize( CredentialsConfigured );
+const mapStateToProps = ( state, { siteId } ) => ( {
+	mainCredentials: getJetpackCredentials( state, siteId, 'main' ),
+	isPressable: isSitePressable( state, siteId ),
+} );
+
+export default connect( mapStateToProps, { deleteCredentials } )(
+	localize( CredentialsConfigured )
+);

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -4,6 +4,7 @@
  * External dependendies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { get, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -19,6 +20,9 @@ import FormTextArea from 'components/forms/form-textarea';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormPasswordInput from 'components/forms/form-password-input';
 import Gridicon from 'gridicons';
+import { deleteCredentials, updateCredentials } from 'state/jetpack/credentials/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isUpdatingJetpackCredentials } from 'state/selectors';
 
 export class CredentialsForm extends Component {
 	state = {
@@ -237,4 +241,10 @@ export class CredentialsForm extends Component {
 	}
 }
 
-export default localize( CredentialsForm );
+const mapStateToProps = state => ( {
+	formIsSubmitting: isUpdatingJetpackCredentials( state, getSelectedSiteId( state ) ),
+} );
+
+export default connect( mapStateToProps, { deleteCredentials, updateCredentials } )(
+	localize( CredentialsForm )
+);

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/index.jsx
@@ -1,6 +1,9 @@
 /**
  * External dependencies
+ *
+ * @format
  */
+
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
@@ -16,64 +19,41 @@ import SetupFooter from './setup-footer';
 
 class CredentialsSetupFlow extends Component {
 	static propTypes = {
-		isPressable: PropTypes.bool,
-		formIsSubmitting: PropTypes.bool,
 		siteId: PropTypes.number,
-		updateCredentials: PropTypes.func,
-		autoConfigCredentials: PropTypes.func,
-		autoConfigStatus: PropTypes.string
 	};
 
 	componentWillMount() {
 		this.setState( { currentStep: 'start', showPopover: false } );
 	}
 
-	togglePopover = () => this.setState( { showPopover: ! this.state.showPopover } );
-
 	reset = () => this.setState( { currentStep: 'start' } );
 
-	getNextStep = step => get( {
-		start: 'tos',
-		tos: 'form',
-	}, step, step );
+	getNextStep = step =>
+		get(
+			{
+				start: 'tos',
+				tos: 'form',
+			},
+			step,
+			step
+		);
 
-	goToNextStep = () => this.setState( {
-		currentStep: this.getNextStep( this.state.currentStep )
-	} );
-
-	autoConfigure = () => this.props.autoConfigCredentials( this.props.siteId );
+	goToNextStep = () =>
+		this.setState( {
+			currentStep: this.getNextStep( this.state.currentStep ),
+		} );
 
 	render() {
-		const {
-			isPressable,
-			formIsSubmitting,
-			updateCredentials,
-			siteId
-		} = this.props;
+		const { siteId } = this.props;
 
 		return (
 			<div className="credentials-setup-flow">
-				{ 'start' === this.state.currentStep && (
-					<SetupStart
-						goToNextStep={ this.goToNextStep }
-					/>
-				) }
+				{ 'start' === this.state.currentStep && <SetupStart goToNextStep={ this.goToNextStep } /> }
 				{ 'tos' === this.state.currentStep && (
-					<SetupTos
-						autoConfigure={ this.autoConfigure }
-						isPressable={ isPressable }
-						reset={ this.reset }
-						goToNextStep={ this.goToNextStep }
-					/>
+					<SetupTos siteId={ siteId } reset={ this.reset } goToNextStep={ this.goToNextStep } />
 				) }
 				{ 'form' === this.state.currentStep && [
-					<SetupForm
-						key="credentials-flow-setup-form"
-						formIsSubmitting={ formIsSubmitting }
-						reset={ this.reset }
-						siteId={ siteId }
-						updateCredentials={ updateCredentials }
-					/>,
+					<SetupForm key="credentials-flow-setup-form" reset={ this.reset } siteId={ siteId } />,
 					<SetupFooter key="credentials-flow-setup-form-footer" />,
 				] }
 			</div>

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-form.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-form.jsx
@@ -1,30 +1,34 @@
 /**
  * External dependencies
+ *
+ * @format
  */
+
 import React from 'react';
 
 /**
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import CredentialsForm from '../credentials-form/index';
+import CredentialsForm from '../credentials-form';
 
-const SetupForm = ( { formIsSubmitting, reset, siteId, updateCredentials } ) => (
+const SetupForm = ( { reset, siteId } ) => (
 	<CompactCard>
-		<CredentialsForm { ...{
-			formIsSubmitting,
-			protocol: 'ssh',
-			host: '',
-			port: '22',
-			user: '',
-			pass: '',
-			abspath: '',
-			kpri: '',
-			onCancel: reset,
-			siteId,
-			updateCredentials,
-			showCancelButton: true
-		} } />
+		<CredentialsForm
+			{ ...{
+				protocol: 'ssh',
+				host: '',
+				port: '22',
+				user: '',
+				pass: '',
+				abspath: '',
+				kpri: '',
+				onCancel: reset,
+				role: 'main',
+				siteId,
+				showCancelButton: true,
+			} }
+		/>
 	</CompactCard>
 );
 

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-tos.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-tos.jsx
@@ -1,7 +1,9 @@
+/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -10,35 +12,50 @@ import { localize } from 'i18n-calypso';
 import CompactCard from 'components/card/compact';
 import Gridicon from 'gridicons';
 import Button from 'components/button';
+import { autoConfigCredentials } from 'state/jetpack/credentials/actions';
+import { isSitePressable } from 'state/selectors';
 
 const SetupTos = ( { autoConfigure, isPressable, reset, translate, goToNextStep } ) => (
-	<CompactCard
-		className="credentials-setup-flow__tos"
-		highlight="info"
-	>
+	<CompactCard className="credentials-setup-flow__tos" highlight="info">
 		<Gridicon icon="info" size={ 48 } className="credentials-setup-flow__tos-gridicon" />
 		<div className="credentials-setup-flow__tos-text">
-			{
-				isPressable
-					? translate( 'WordPress.com can obtain the credentials from your ' +
-					'current host which are necessary to perform site backups and ' +
-					'restores. Do you want to give WordPress.com access to your ' +
-					'host\'s server?' )
-					: translate( 'By adding your site credentials, you are giving ' +
-					'WordPress.com access to perform automatic actions on your ' +
-					'server including backing up your site, restoring your site, ' +
-					'as well as manually accessing your site in case of an emergency.' )
-			}
+			{ isPressable
+				? translate(
+						'WordPress.com can obtain the credentials from your ' +
+							'current host which are necessary to perform site backups and ' +
+							'restores. Do you want to give WordPress.com access to your ' +
+							"host's server?"
+					)
+				: translate(
+						'By adding your site credentials, you are giving ' +
+							'WordPress.com access to perform automatic actions on your ' +
+							'server including backing up your site, restoring your site, ' +
+							'as well as manually accessing your site in case of an emergency.'
+					) }
 		</div>
 		<div className="credentials-setup-flow__tos-buttons">
-			<Button borderless={ true } onClick={ reset }>{ translate( 'Cancel' ) }</Button>
-			{
-				isPressable
-					? <Button primary onClick={ autoConfigure }>{ translate( 'Auto Configure' ) }</Button>
-					: <Button primary onClick={ goToNextStep }>{ translate( 'Ok, I understand' ) }</Button>
-			}
+			<Button borderless={ true } onClick={ reset }>
+				{ translate( 'Cancel' ) }
+			</Button>
+			{ isPressable ? (
+				<Button primary onClick={ autoConfigure }>
+					{ translate( 'Auto Configure' ) }
+				</Button>
+			) : (
+				<Button primary onClick={ goToNextStep }>
+					{ translate( 'Ok, I understand' ) }
+				</Button>
+			) }
 		</div>
 	</CompactCard>
 );
 
-export default localize( SetupTos );
+const mapStateToProps = ( state, { siteId } ) => ( {
+	isPressable: isSitePressable( state, siteId ),
+} );
+
+const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
+	autoConfigure: () => dispatch( autoConfigCredentials( siteId ) ),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( SetupTos ) );

--- a/client/my-sites/site-settings/jetpack-credentials/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/index.jsx
@@ -1,3 +1,4 @@
+/** @format */
 /**
  * External dependencies
  */
@@ -10,48 +11,27 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import CredentialsSetupFlow from './credentials-setup-flow/index';
-import CredentialsConfigured from './credentials-configured/index';
+import CredentialsSetupFlow from './credentials-setup-flow';
+import CredentialsConfigured from './credentials-configured';
 import Gridicon from 'gridicons';
 import QueryRewindStatus from 'components/data/query-rewind-status';
 import QueryJetpackCredentials from 'components/data/query-jetpack-credentials';
-import { isRewindActive } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import {
-	getJetpackCredentials,
-	isUpdatingJetpackCredentials,
-	hasMainCredentials,
-	isSitePressable,
-	getCredentialsAutoConfigStatus
-} from 'state/selectors';
-import {
-	updateCredentials,
-	autoConfigCredentials,
-	deleteCredentials,
-} from 'state/jetpack/credentials/actions';
+import { hasMainCredentials, isRewindActive } from 'state/selectors';
 
 class Backups extends Component {
 	static propTypes = {
-		autoConfigStatus: PropTypes.string,
-		formIsSubmitting: PropTypes.bool,
 		hasMainCredentials: PropTypes.bool,
-		mainCredentials: PropTypes.object,
-		isPressable: PropTypes.bool,
 		isRewindActive: PropTypes.bool,
-		siteId: PropTypes.number.isRequired
+		siteId: PropTypes.number.isRequired,
 	};
 
 	render() {
 		const {
-			autoConfigStatus,
 			hasMainCredentials, // eslint-disable-line no-shadow
-			isPressable,
 			isRewindActive, // eslint-disable-line no-shadow
 			translate,
-			formIsSubmitting,
-			updateCredentials,
 			siteId,
-			autoConfigCredentials
 		} = this.props;
 
 		return (
@@ -61,51 +41,31 @@ class Backups extends Component {
 				{ isRewindActive && (
 					<CompactCard className="jetpack-credentials__header">
 						<span>{ translate( 'Backups and security scans' ) }</span>
-							{ hasMainCredentials && (
-								<span className="jetpack-credentials__connected">
-									<Gridicon icon="checkmark" size={ 18 } className="jetpack-credentials__connected-checkmark" />
-									{ translate( 'Connected' ) }
-								</span>
-							) }
+						{ hasMainCredentials && (
+							<span className="jetpack-credentials__connected">
+								<Gridicon
+									icon="checkmark"
+									size={ 18 }
+									className="jetpack-credentials__connected-checkmark"
+								/>
+								{ translate( 'Connected' ) }
+							</span>
+						) }
 					</CompactCard>
 				) }
-
-				{ isRewindActive && ! hasMainCredentials && (
-					<CredentialsSetupFlow { ...{
-						isPressable,
-						formIsSubmitting,
-						siteId,
-						updateCredentials,
-						autoConfigCredentials,
-						autoConfigStatus
-					} } />
-				) }
-
-				{ isRewindActive && hasMainCredentials && (
-					<CredentialsConfigured { ...this.props } />
-				) }
+				{ isRewindActive && ! hasMainCredentials && <CredentialsSetupFlow siteId={ siteId } /> }
+				{ isRewindActive && hasMainCredentials && <CredentialsConfigured siteId={ siteId } /> }
 			</div>
 		);
 	}
 }
 
-export default connect(
-	( state ) => {
-		const siteId = getSelectedSiteId( state );
-		const credentials = getJetpackCredentials( state, siteId, 'main' );
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
 
-		return {
-			autoConfigStatus: getCredentialsAutoConfigStatus( state, siteId ),
-			formIsSubmitting: isUpdatingJetpackCredentials( state, siteId ),
-			hasMainCredentials: hasMainCredentials( state, siteId ),
-			mainCredentials: credentials,
-			isPressable: isSitePressable( state, siteId ),
-			isRewindActive: isRewindActive( state, siteId ),
-			siteId,
-		};
-	}, {
-		autoConfigCredentials,
-		updateCredentials,
-		deleteCredentials,
-	}
-)( localize( Backups ) );
+	return {
+		hasMainCredentials: hasMainCredentials( state, siteId ),
+		isRewindActive: isRewindActive( state, siteId ),
+		siteId,
+	};
+} )( localize( Backups ) );


### PR DESCRIPTION
See #21516 where I tried and failed.

This is part of a mini-project to untangle data flows within the
Activity Log and Rewind system so that each component operates more
independently of its parents and can be worked on in isolation.

Many of the props and callbacks relevant to Jetpack Rewind credentials
get passed down through multiple chains of React component props. In
this patch we're disconnecting some of those parent-child relationships.

This is preparatory work further to deprecate and eventually remove code
dependent on the older and also-deprecated Rewind APIs, preferring
instead to move to the specified and centralized "state machine" API

**There should be no visual changes in this PR from master**

**Testing**

Since this patch impacts Jetpack Rewind credentials, navigate to
**My Sites** > **Settings** > **Security** for a site with a Jetpack
connection and also one which can activate **Rewind**. Try activating
auto-credentials and revoke credentials, try adding custom credentials.
Make sure everything works as expected.

http://iscalypsofastyet.com/branch?branch=rewind/shuffle-credentials-state-and-dispatches
```
Delta:
chunk              stat_size           parsed_size           gzip_size
build                   +0 B                  +0 B                +1 B  (+0.0%)
manifest                +0 B                  +0 B                +1 B  (+0.0%)
settings-security    -1290 B  (-0.5%)       -829 B  (-0.6%)     -197 B  (-0.9%)
```