### PR TITLE
Reader: Update Conversations Caterpillar text and gravatars

### DIFF
--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -133,7 +133,7 @@ class ConversationCaterpillarComponent extends React.Component {
 				>
 					{ commentCount > 1 &&
 						uniqueAuthorsCount > 1 &&
-						translate( 'Load %(count)d previous comments from %(commenterName)s and others', {
+						translate( 'Load previous comments from %(commenterName)s and others', {
 							args: {
 								commenterName: lastAuthorName,
 								count: commentCount,

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -133,7 +133,7 @@ class ConversationCaterpillarComponent extends React.Component {
 				>
 					{ commentCount > 1 &&
 						uniqueAuthorsCount > 1 &&
-						translate( 'Load previous comments from %(commenterName)s and %(count)d others', {
+						translate( 'Load %(count)d previous comments from %(commenterName)s and others', {
 							args: {
 								commenterName: lastAuthorName,
 								count: commentCount,

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -133,7 +133,7 @@ class ConversationCaterpillarComponent extends React.Component {
 				>
 					{ commentCount > 1 &&
 						uniqueAuthorsCount > 1 &&
-						translate( '%(count)d comments from %(commenterName)s and others', {
+						translate( 'Load previous comments from %(commenterName)s and %(count)d others', {
 							args: {
 								commenterName: lastAuthorName,
 								count: commentCount,
@@ -141,14 +141,14 @@ class ConversationCaterpillarComponent extends React.Component {
 						} ) }
 					{ commentCount > 1 &&
 						uniqueAuthorsCount === 1 &&
-						translate( '%(count)d comments from %(commenterName)s', {
+						translate( 'Load previous comments from %(commenterName)s', {
 							args: {
 								commenterName: lastAuthorName,
 								count: commentCount,
 							},
 						} ) }
 					{ commentCount === 1 &&
-						translate( '1 comment from %(commenterName)s', {
+						translate( 'Load previous comment from %(commenterName)s', {
 							args: {
 								commenterName: lastAuthorName,
 							},

--- a/client/blocks/conversation-caterpillar/style.scss
+++ b/client/blocks/conversation-caterpillar/style.scss
@@ -10,7 +10,7 @@
 
 .conversation-caterpillar__count {
 	cursor: pointer;
-	color: $gray;
+	color: $blue-medium;
 	display: flex;
 	margin-left: 8px;
 	flex: 1 1 auto;
@@ -21,7 +21,7 @@
 	white-space: nowrap;
 
 	&:hover {
-		color: $blue-medium;
+		color: $blue-light;
 	}
 
 	&::after {
@@ -40,9 +40,10 @@
 .conversation-caterpillar__gravatar {
 	cursor: pointer;
 	border: 2px solid $white;
-	height: 32px;
+	height: 24px;
 	margin-left: -8px;
 	vertical-align: middle;
+	width: 24px;
 
 	&:first-child {
 		margin-left: -2px;


### PR DESCRIPTION
This PR:

- [x] Updates caterpillar text and color so it's more obvious that it's clickable.
- [x] Updates caterpillar gravatar sizes from 32px to 24px to introduce visual hierarchy; so it doesn't get lost within the list of gravatars below it.
- [ ] ~The comment count needs to be corrected to only include "others".~

**Before:**
![screenshot 2018-01-19 14 43 42](https://user-images.githubusercontent.com/4924246/35175145-3776dbd6-fd27-11e7-9464-ca3eb203471e.png)

**After:**
![screenshot 2018-01-19 14 43 54](https://user-images.githubusercontent.com/4924246/35175147-39f8d3aa-fd27-11e7-96a5-be37a402aa7c.png)

/cc @shaunandrews 