### PR TITLE
A/B Tests: Propagate backend-loaded A/B assignments into client

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -17,6 +17,7 @@ import analytics from 'lib/analytics';
 import config from 'config';
 import userFactory from 'lib/user';
 import wpcom from 'lib/wp';
+import { ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
 
 const debug = debugFactory( 'calypso:abtests' );
 const user = userFactory();
@@ -52,7 +53,7 @@ export const getABTestVariation = name => new ABTest( name ).getVariation();
  *
  * @returns {Object} - The user's variations, or an empty object if the user is not a participant
  */
-export const getSavedVariations = () => store.get( 'ABTests' ) || {};
+export const getSavedVariations = () => store.get( ABTEST_LOCALSTORAGE_KEY ) || {};
 
 export const getAllTests = () => keys( activeTests ).map( ABTest );
 
@@ -330,5 +331,5 @@ ABTest.prototype.saveVariationOnBackend = function( variation ) {
 ABTest.prototype.saveVariationInLocalStorage = function( variation ) {
 	const savedVariations = getSavedVariations();
 	savedVariations[ this.experimentId ] = variation;
-	store.set( 'ABTests', savedVariations );
+	store.set( ABTEST_LOCALSTORAGE_KEY, savedVariations );
 };

--- a/client/lib/abtest/test-helper/index.js
+++ b/client/lib/abtest/test-helper/index.js
@@ -12,6 +12,7 @@ import Debug from 'debug';
  */
 import TestList from './TestList';
 import { getAllTests } from 'lib/abtest';
+import { ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
 
 const debug = Debug( 'calypso:abtests:helper' );
 
@@ -20,10 +21,10 @@ export default function injectTestHelper( element ) {
 		React.createElement( TestList, {
 			tests: getAllTests(),
 			onChangeVariant: function( test, variation ) {
-				const testSettings = JSON.parse( localStorage.getItem( 'ABTests' ) ) || {};
+				const testSettings = JSON.parse( localStorage.getItem( ABTEST_LOCALSTORAGE_KEY ) ) || {};
 				testSettings[ test.experimentId ] = variation;
 				debug( 'Switching test variant', test.experimentId, variation );
-				localStorage.setItem( 'ABTests', JSON.stringify( testSettings ) );
+				localStorage.setItem( ABTEST_LOCALSTORAGE_KEY, JSON.stringify( testSettings ) );
 				window.location.reload();
 			},
 		} ),

--- a/client/lib/abtest/utility.js
+++ b/client/lib/abtest/utility.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import activeTests from 'lib/abtest/active-tests';
+
+/**
+ * Returns all active test names
+ * @returns {String[]} All active test names with respective timestamp appended to the end
+ */
+export function getActiveTestNames( { asCSV = true } = {} ) {
+	const output = Object.keys( activeTests ).map(
+		key => `${ key }_${ activeTests[ key ].datestamp }`
+	);
+	return asCSV ? output.join( ',' ) : output;
+}

--- a/client/lib/abtest/utility.js
+++ b/client/lib/abtest/utility.js
@@ -5,6 +5,8 @@
  */
 import activeTests from 'lib/abtest/active-tests';
 
+export const ABTEST_LOCALSTORAGE_KEY = 'ABTests';
+
 /**
  * Returns all active test names
  * @returns {String[]} All active test names with respective timestamp appended to the end

--- a/client/lib/abtest/utility.js
+++ b/client/lib/abtest/utility.js
@@ -11,9 +11,9 @@ export const ABTEST_LOCALSTORAGE_KEY = 'ABTests';
  * Returns all active test names
  * @returns {String[]} All active test names with respective timestamp appended to the end
  */
-export function getActiveTestNames( { asCSV = true } = {} ) {
+export function getActiveTestNames( { appendDatestamp = false, asCSV = false } = {} ) {
 	const output = Object.keys( activeTests ).map(
-		key => `${ key }_${ activeTests[ key ].datestamp }`
+		key => appendDatestamp ? `${ key }_${ activeTests[ key ].datestamp }` : key
 	);
 	return asCSV ? output.join( ',' ) : output;
 }

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -19,11 +19,9 @@ import { withoutHttp } from 'lib/url';
 const languages = config( 'languages' );
 
 export function getLanguage( slug ) {
-	var len = languages.length,
-		language,
-		index;
-
-	for ( index = 0; index < len; index++ ) {
+	const { length: len } = languages;
+	let language;
+	for ( let index = 0; index < len; index++ ) {
 		if ( slug === languages[ index ].langSlug ) {
 			language = languages[ index ];
 			break;
@@ -34,36 +32,36 @@ export function getLanguage( slug ) {
 }
 
 function getSiteSlug( url ) {
-	var slug = withoutHttp( url );
+	const slug = withoutHttp( url );
 	return slug.replace( /\//g, '::' );
 }
 
 export function filterUserObject( obj ) {
-	var user = {},
-		allowedKeys = [
-			'ID',
-			'display_name',
-			'username',
-			'avatar_URL',
-			'site_count',
-			'visible_site_count',
-			'date',
-			'has_unseen_notes',
-			'newest_note_type',
-			'phone_account',
-			'email',
-			'email_verified',
-			'is_valid_google_apps_country',
-			'user_ip_country_code',
-			'logout_URL',
-			'primary_blog',
-			'primary_blog_is_jetpack',
-			'primary_blog_url',
-			'meta',
-			'is_new_reader',
-			'social_signup_service',
-		],
-		decodeWhitelist = [ 'display_name', 'description', 'user_URL' ];
+	const user = {};
+	const allowedKeys = [
+		'ID',
+		'display_name',
+		'username',
+		'avatar_URL',
+		'site_count',
+		'visible_site_count',
+		'date',
+		'has_unseen_notes',
+		'newest_note_type',
+		'phone_account',
+		'email',
+		'email_verified',
+		'is_valid_google_apps_country',
+		'user_ip_country_code',
+		'logout_URL',
+		'primary_blog',
+		'primary_blog_is_jetpack',
+		'primary_blog_url',
+		'meta',
+		'is_new_reader',
+		'social_signup_service',
+	];
+	const decodeWhitelist = [ 'display_name', 'description', 'user_URL' ];
 
 	allowedKeys.forEach( function( key ) {
 		user[ key ] =
@@ -74,10 +72,10 @@ export function filterUserObject( obj ) {
 }
 
 export function getComputedAttributes( attributes ) {
-	var language = getLanguage( attributes.language ),
-		primayBlogUrl = attributes.primary_blog_url || '';
+	const language = getLanguage( attributes.language );
+	const primaryBlogUrl = attributes.primary_blog_url || '';
 	return {
-		primarySiteSlug: getSiteSlug( primayBlogUrl ),
+		primarySiteSlug: getSiteSlug( primaryBlogUrl ),
 		localeSlug: attributes.language,
 		isRTL: !! ( language && language.rtl ),
 	};

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -60,6 +60,7 @@ export function filterUserObject( obj ) {
 		'meta',
 		'is_new_reader',
 		'social_signup_service',
+		'abtests',
 	];
 	const decodeWhitelist = [ 'display_name', 'description', 'user_URL' ];
 

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -63,31 +63,26 @@ User.prototype.initialize = function() {
 	}
 
 	if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
-		this.data = window.currentUser || false;
+		const bootstrappedData = window.currentUser || false;
 
 		// Store the current user in localStorage so that we can use it to determine
 		// if the logged in user has changed when initializing in the future
-		if ( this.data ) {
-			this.clearStoreIfChanged( this.data.ID );
-			store.set( 'wpcom_user', this.data );
-			if ( this.data.abtests ) {
-				store.set( ABTEST_LOCALSTORAGE_KEY, this.data.abtests );
-			}
-		} else {
-			// The user is logged out
-			this.initialized = true;
+		if ( bootstrappedData ) {
+			this.handleFetchSuccess( bootstrappedData );
 		}
-	} else {
-		this.data = store.get( 'wpcom_user' ) || false;
-
-		// Make sure that the user stored in localStorage matches the logged-in user
-		this.fetch();
+		this.initialized = true;
+		return;
 	}
+
+	this.data = store.get( 'wpcom_user' ) || false;
 
 	if ( this.data ) {
 		this.initialized = true;
 		this.emit( 'change' );
 	}
+
+	// Make sure that the user stored in localStorage matches the logged-in user
+	this.fetch();
 };
 
 /**
@@ -140,6 +135,7 @@ User.prototype.fetch = function() {
 
 			const userData = filterUserObject( data );
 			this.handleFetchSuccess( userData );
+			debug( 'User successfully retrieved' );
 		}
 	);
 };
@@ -189,7 +185,6 @@ User.prototype.handleFetchSuccess = function( userData ) {
 	}
 	this.initialized = true;
 	this.emit( 'change' );
-	debug( 'User successfully retrieved' );
 };
 
 User.prototype.getLanguage = function() {

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -130,24 +130,9 @@ User.prototype.fetch = function() {
 		{ meta: 'flags' },
 		function( error, data ) {
 			if ( error ) {
-				if (
-					! config.isEnabled( 'wpcom-user-bootstrap' ) &&
-					error.error === 'authorization_required'
-				) {
-					/**
-					 * if the user bootstrap is disabled (in development), we need to rely on a request to
-					 * /me to determine if the user is logged in.
-					 */
-					debug( 'The user is not logged in.' );
-
-					this.initialized = true;
-					this.emit( 'change' );
-				} else {
-					debug( 'Something went wrong trying to get the user.' );
-				}
+				this.handleFetchFailure( error );
 				return;
 			}
-
 
 			// Release lock from subsequent fetches
 			this.fetching = false;
@@ -169,6 +154,27 @@ User.prototype.fetch = function() {
 			debug( 'User successfully retrieved' );
 		}.bind( this )
 	);
+};
+
+/**
+ * Handles user fetch failure from WordPress.com REST API by updating User's state
+ * and emitting a change event.
+ *
+ * @param {Error} error network response error
+ */
+User.prototype.handleFetchFailure = function( error ) {
+	if ( ! config.isEnabled( 'wpcom-user-bootstrap' ) && error.error === 'authorization_required' ) {
+		/**
+		 * if the user bootstrap is disabled (in development), we need to rely on a request to
+		 * /me to determine if the user is logged in.
+		 */
+		debug( 'The user is not logged in.' );
+
+		this.initialized = true;
+		this.emit( 'change' );
+	} else {
+		debug( 'Something went wrong trying to get the user.' );
+	}
 };
 
 User.prototype.getLanguage = function() {

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -19,7 +19,7 @@ import wpcom from 'lib/wp';
 import Emitter from 'lib/mixins/emitter';
 import { getComputedAttributes, filterUserObject } from './shared-utils';
 import localforage from 'lib/localforage';
-import { getActiveTestNames } from 'lib/abtest/utility';
+import { getActiveTestNames, ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
 
 /**
  * User component
@@ -71,7 +71,7 @@ User.prototype.initialize = function() {
 			this.clearStoreIfChanged( this.data.ID );
 			store.set( 'wpcom_user', this.data );
 			if ( this.data.abtests ) {
-				store.set( 'ABTests', this.data.abtests );
+				store.set( ABTEST_LOCALSTORAGE_KEY, this.data.abtests );
 			}
 		} else {
 			// The user is logged out
@@ -180,7 +180,7 @@ User.prototype.handleFetchSuccess = function( userData ) {
 	// Store user info in `this.data` and localstorage as `wpcom_user`
 	store.set( 'wpcom_user', userData );
 	if ( userData.abtests ) {
-		store.set( 'ABTests', userData.abtests );
+		store.set( ABTEST_LOCALSTORAGE_KEY, userData.abtests );
 	}
 	this.data = userData;
 	if ( this.settings ) {

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -131,7 +131,7 @@ User.prototype.fetch = function() {
 	debug( 'Getting user from api' );
 
 	me.get(
-		{ meta: 'flags', abtests: getActiveTestNames() },
+		{ meta: 'flags', abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ) },
 		( error, data ) => {
 			if ( error ) {
 				this.handleFetchFailure( error );

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -91,7 +91,7 @@ User.prototype.initialize = function() {
  * of the user stored in localStorage and the current user ID
  **/
 User.prototype.clearStoreIfChanged = function( userId ) {
-	var storedUser = store.get( 'wpcom_user' );
+	const storedUser = store.get( 'wpcom_user' );
 
 	if ( storedUser && storedUser.ID !== userId ) {
 		debug( 'Clearing localStorage because user changed' );
@@ -120,7 +120,7 @@ User.prototype.fetch = function() {
 		return;
 	}
 
-	var me = wpcom.me();
+	const me = wpcom.me();
 
 	// Request current user info
 	this.fetching = true;
@@ -148,10 +148,10 @@ User.prototype.fetch = function() {
 				return;
 			}
 
-			var userData = filterUserObject( data );
 
 			// Release lock from subsequent fetches
 			this.fetching = false;
+			const userData = filterUserObject( data );
 
 			this.clearStoreIfChanged( userData.ID );
 
@@ -172,10 +172,9 @@ User.prototype.fetch = function() {
 };
 
 User.prototype.getLanguage = function() {
-	var languages = config( 'languages' ),
-		len = languages.length,
-		language,
-		index;
+	const languages = config( 'languages' );
+	const len = languages.length;
+	let language, index;
 
 	if ( ! this.data.localeSlug ) {
 		return;
@@ -197,13 +196,13 @@ User.prototype.getLanguage = function() {
  * @param {Object} options Options per https://secure.gravatar.com/site/implement/images/
  */
 User.prototype.getAvatarUrl = function( options ) {
-	var default_options = {
-			s: 80,
-			d: 'mm',
-			r: 'G',
-		},
-		avatar_URL = this.get().avatar_URL,
-		avatar = typeof avatar_URL === 'string' ? avatar_URL.split( '?' )[ 0 ] : '';
+	const default_options = {
+		s: 80,
+		d: 'mm',
+		r: 'G',
+	};
+	const avatar_URL = this.get().avatar_URL;
+	const avatar = typeof avatar_URL === 'string' ? avatar_URL.split( '?' )[ 0 ] : '';
 
 	options = options || {};
 	options = Object.assign( {}, options, default_options );
@@ -212,14 +211,8 @@ User.prototype.getAvatarUrl = function( options ) {
 };
 
 User.prototype.isRTL = function() {
-	var isRTL = false,
-		language = this.getLanguage();
-
-	if ( language && language.rtl ) {
-		isRTL = true;
-	}
-
-	return isRTL;
+	const language = this.getLanguage();
+	return language && language.rtl;
 };
 
 /**

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -134,25 +134,9 @@ User.prototype.fetch = function() {
 				return;
 			}
 
-			// Release lock from subsequent fetches
-			this.fetching = false;
 			const userData = filterUserObject( data );
-
-			this.clearStoreIfChanged( userData.ID );
-
-			// Store user info in `this.data` and localstorage as `wpcom_user`
-			store.set( 'wpcom_user', userData );
-			this.data = userData;
-			if ( this.settings ) {
-				debug( 'Retaining fetched settings data in new user data' );
-				this.data.settings = this.settings;
-			}
-			this.initialized = true;
-
-			this.emit( 'change' );
-
-			debug( 'User successfully retrieved' );
-		}.bind( this )
+			this.handleFetchSuccess( userData );
+		}
 	);
 };
 
@@ -175,6 +159,30 @@ User.prototype.handleFetchFailure = function( error ) {
 	} else {
 		debug( 'Something went wrong trying to get the user.' );
 	}
+};
+
+/**
+ * Handles user fetch success from WordPress.com REST API by persisting the user data
+ * in the browser's localStorage. It also changes the User's fetching and initialized states
+ * and emits a change event.
+ *
+ * @param {Object} userData an object containing the user's information.
+ */
+User.prototype.handleFetchSuccess = function( userData ) {
+	// Release lock from subsequent fetches
+	this.fetching = false;
+	this.clearStoreIfChanged( userData.ID );
+
+	// Store user info in `this.data` and localstorage as `wpcom_user`
+	store.set( 'wpcom_user', userData );
+	this.data = userData;
+	if ( this.settings ) {
+		debug( 'Retaining fetched settings data in new user data' );
+		this.data.settings = this.settings;
+	}
+	this.initialized = true;
+	this.emit( 'change' );
+	debug( 'User successfully retrieved' );
 };
 
 User.prototype.getLanguage = function() {

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -19,6 +19,7 @@ import wpcom from 'lib/wp';
 import Emitter from 'lib/mixins/emitter';
 import { getComputedAttributes, filterUserObject } from './shared-utils';
 import localforage from 'lib/localforage';
+import { getActiveTestNames } from 'lib/abtest/utility';
 
 /**
  * User component
@@ -69,6 +70,9 @@ User.prototype.initialize = function() {
 		if ( this.data ) {
 			this.clearStoreIfChanged( this.data.ID );
 			store.set( 'wpcom_user', this.data );
+			if ( this.data.abtests ) {
+				store.set( 'ABTests', this.data.abtests );
+			}
 		} else {
 			// The user is logged out
 			this.initialized = true;
@@ -127,8 +131,8 @@ User.prototype.fetch = function() {
 	debug( 'Getting user from api' );
 
 	me.get(
-		{ meta: 'flags' },
-		function( error, data ) {
+		{ meta: 'flags', abtests: getActiveTestNames() },
+		( error, data ) => {
 			if ( error ) {
 				this.handleFetchFailure( error );
 				return;
@@ -175,6 +179,9 @@ User.prototype.handleFetchSuccess = function( userData ) {
 
 	// Store user info in `this.data` and localstorage as `wpcom_user`
 	store.set( 'wpcom_user', userData );
+	if ( userData.abtests ) {
+		store.set( 'ABTests', userData.abtests );
+	}
 	this.data = userData;
 	if ( this.settings ) {
 		debug( 'Retaining fetched settings data in new user data' );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1450,20 +1450,22 @@ Undocumented.prototype.readSitePostRelated = function( query, fn ) {
  *
  * @param {string} name - The name of the A/B test. No leading 'abtest_' needed
  * @param {string} variation - The variation the user is assigned to
- * @param {Function} fn - Function to invoke when request is complete
+ * @param {Function} callback - Function to invoke when request is complete
  * @api public
+ * @returns {Object} wpcomRequest
  */
-Undocumented.prototype.saveABTestData = function( name, variation, fn ) {
-	var data = {
-		name: name,
-		variation: variation,
+Undocumented.prototype.saveABTestData = function( name, variation, callback ) {
+	const body = {
+		name,
+		variation,
 	};
+	debug( `POST /me/abtests with ${ JSON.stringify( body ) }` );
 	return this.wpcom.req.post(
 		{
 			path: '/me/abtests',
-			body: data,
+			body,
 		},
-		fn
+		callback
 	);
 };
 

--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -111,6 +111,8 @@ export class ChecklistBanner extends Component {
 			return false;
 		}
 
+		// NOTE: Accessing localStorage directly for checking A/B variation assignment
+		//       is an anti-pattern. Please use lib/abtest instead.
 		const abtests = store.get( ABTEST_LOCALSTORAGE_KEY );
 		if (
 			get( abtests, 'checklistThankYouForPaidUser_20171204' ) !== 'show' &&

--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -26,6 +26,7 @@ import { launchTask, onboardingTasks } from 'my-sites/checklist/onboardingCheckl
 import ChecklistShowShare from 'my-sites/checklist/checklist-show/share';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
+import { ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
 
 const storeKeyForNeverShow = 'sitesNeverShowChecklistBanner';
 
@@ -110,7 +111,7 @@ export class ChecklistBanner extends Component {
 			return false;
 		}
 
-		const abtests = store.get( 'ABTests' );
+		const abtests = store.get( ABTEST_LOCALSTORAGE_KEY );
 		if (
 			get( abtests, 'checklistThankYouForPaidUser_20171204' ) !== 'show' &&
 			get( abtests, 'checklistThankYouForFreeUser_20171204' ) !== 'show'

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import qs from 'qs';
 import superagent from 'superagent';
 import debugFactory from 'debug';
 import crypto from 'crypto';
@@ -10,6 +11,7 @@ import crypto from 'crypto';
  * Internal dependencies
  */
 import { filterUserObject } from 'lib/user/shared-utils';
+import { getActiveTestNames } from 'lib/abtest/utility';
 import config from 'config';
 
 const debug = debugFactory( 'calypso:bootstrap' ),
@@ -18,7 +20,12 @@ const debug = debugFactory( 'calypso:bootstrap' ),
 	/**
 	 * WordPress.com REST API /me endpoint.
 	 */
-	url = 'https://public-api.wordpress.com/rest/v1/me?meta=flags';
+	API_PATH = 'https://public-api.wordpress.com/rest/v1/me',
+	apiQuery = {
+		meta: 'flags',
+		abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
+	},
+	url = `${ API_PATH }?${ qs.stringify( apiQuery ) }`;
 
 module.exports = function( authCookieValue, geoCountry, callback ) {
 	// create HTTP Request object

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -2,12 +2,17 @@
 /**
  * External dependencies
  */
-import { filterUserObject } from 'lib/user/shared-utils';
-var superagent = require( 'superagent' ),
-	debug = require( 'debug' )( 'calypso:bootstrap' ),
-	crypto = require( 'crypto' );
+import superagent from 'superagent';
+import debugFactory from 'debug';
+import crypto from 'crypto';
 
-var config = require( 'config' ),
+/**
+ * Internal dependencies
+ */
+import { filterUserObject } from 'lib/user/shared-utils';
+import config from 'config';
+
+const debug = debugFactory( 'calypso:bootstrap' ),
 	API_KEY = config( 'wpcom_calypso_rest_api_key' ),
 	AUTH_COOKIE_NAME = 'wordpress_logged_in',
 	/**


### PR DESCRIPTION
Fixes #20097.

This change, in conjunction with `D9429-code`, enables users to fetch their assigned A/B test variations stored as user attributes from wpcom REST API. Specifically, this is done by adding A/B variation data into the API request to `wpcom.me().get( ... )`.


#### Testing instructions

0. Apply `D9429-code` to your sandbox and sandbox `public-api.wordpress.com`.
1. Check out locally (`fix/load-ab-variations-into-backend`) and start your server.
2. Set your localStorage debug flag to `calypso:user` like so:  
```javascript
localStorage.debug = 'calypso:user';
```
3. Open the [homepage](http://calypso.localhost:3000/).
4. Verify that you see the following debug lines:
```
calypso:user Initializing User
calypso:user Getting user from api
calypso:user User successfully retrieved
```
5. Find the corresponding network request for variation assignments, which should look like this:

![me_request_with_a_b_variations](https://user-images.githubusercontent.com/4044428/35293933-7ca21cee-0032-11e8-8668-934e8e58bbd3.png)

6. Ensure that localStorage has been populated with expected values. With my user, it looks like the following:

``` javascript
> localStorage.ABTests
"{"abtest_skipThemesSelectionModal_20170904":"show"}"

> JSON.parse(localStorage.wpcom_user).abtests
{ abtest_skipThemesSelectionModal_20170904: "show" }
```

#### Reviews

- [x] Code (ensure that the code changes are reasonable)
- [x] Product (ensure that the product works as intended)
