### PR TITLE
PostRevisions: add controls component with buttons to select split or unified view

### DIFF
--- a/client/post-editor/editor-revisions-list/controls.jsx
+++ b/client/post-editor/editor-revisions-list/controls.jsx
@@ -1,0 +1,34 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+const EditorRevisionsListControls = ( { translate } ) => {
+	return (
+		<div className="editor-revisions-list__controls">
+			<Button className="editor-revisions-list__split-button" compact>
+				{ translate( 'Split' ) }
+			</Button>
+			<Button className="editor-revisions-list__unified-button" compact>
+				{ translate( 'Unified' ) }
+			</Button>
+		</div>
+	);
+};
+
+EditorRevisionsListControls.propTypes = {
+	// localize
+	translate: PropTypes.func.isRequired,
+};
+
+export default localize( EditorRevisionsListControls );

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -14,6 +14,7 @@ import { get, head, isEmpty, map } from 'lodash';
  * Internal dependencies
  */
 import EditorRevisionsListHeader from './header';
+import EditorRevisionsListControls from './controls';
 import EditorRevisionsListItem from './item';
 import { selectPostRevision } from 'state/posts/revisions/actions';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
@@ -115,6 +116,7 @@ class EditorRevisionsList extends PureComponent {
 		return (
 			<div className={ classes }>
 				<EditorRevisionsListHeader numRevisions={ revisions.length } />
+				<EditorRevisionsListControls />
 				<div className="editor-revisions-list__scroller">
 					<ul className="editor-revisions-list__list">
 						{ map( revisions, revision => {

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -18,6 +18,7 @@ import EditorRevisionsListControls from './controls';
 import EditorRevisionsListItem from './item';
 import { selectPostRevision } from 'state/posts/revisions/actions';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
+import config from 'config';
 
 class EditorRevisionsList extends PureComponent {
 	static propTypes = {
@@ -111,12 +112,13 @@ class EditorRevisionsList extends PureComponent {
 		const { comparisons, postId, revisions, selectedRevisionId, siteId } = this.props;
 		const classes = classNames( 'editor-revisions-list', {
 			'is-loading': isEmpty( revisions ),
+			'has-controls': config.isEnabled( 'post-editor/revisions-views' ),
 		} );
 
 		return (
 			<div className={ classes }>
 				<EditorRevisionsListHeader numRevisions={ revisions.length } />
-				<EditorRevisionsListControls />
+				{ config.isEnabled( 'post-editor/revisions-views' ) && <EditorRevisionsListControls /> }
 				<div className="editor-revisions-list__scroller">
 					<ul className="editor-revisions-list__list">
 						{ map( revisions, revision => {

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -60,10 +60,21 @@
 	}
 }
 
+.editor-revisions-list__controls {
+	padding: 16px;
+	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
+	background: $white;
+	color: $gray-text-min;
+}
+
+.editor-revisions-list__unified-button {
+	margin-left: 10px;
+}
+
 // Scrollable Box for Revisions List
 .editor-revisions-list__scroller {
 	position: absolute;
-	top: 47px;
+	top: 109px;
 	right: 0;
 	bottom: 0;
 	left: 0;

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -74,7 +74,7 @@
 // Scrollable Box for Revisions List
 .editor-revisions-list__scroller {
 	position: absolute;
-	top: 109px;
+	top: 47px;
 	right: 0;
 	bottom: 0;
 	left: 0;
@@ -84,6 +84,10 @@
 	@include breakpoint( '<660px' ) {
 		overflow-y: hidden;
 	}
+}
+
+.editor-revisions-list.has-controls .editor-revisions-list__scroller {
+	top: 109px;
 }
 
 .editor-revisions-list__list {

--- a/config/development.json
+++ b/config/development.json
@@ -129,6 +129,7 @@
 		"post-editor/image-editor": true,
 		"post-editor/media-advanced": false,
 		"post-editor/revisions": true,
+        "post-editor/revisions-views": true,
 		"posts/post-type-list/bulk-edit": false,
 		"press-this": true,
 		"privacy-policy": true,


### PR DESCRIPTION
We would like to give users the choice of viewing the diff for a particular revision in side-by-side view as well as in the current unified view.

To prepare for this change, we need to add controls for the user to select the view. This branch adds a control component below the revisions list header.

![image](https://user-images.githubusercontent.com/1647564/35199459-c3892cbc-fef5-11e7-82b1-c32752dfdaa8.png)

The feature has the feature flag `post-editor/revisions-views`. The buttons have no `onClick` handlers at the moment.

Related to https://trello.com/c/7wajn6uY/5-post-revisions-add-side-by-side-comparison-in-addition-to-the-current-unified.