### PR TITLE
Signup: Add the OAuth client ID to the login links on the signup form

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -39,6 +39,8 @@ import SocialSignupForm from './social';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { createSocialUserFailed } from 'state/login/actions';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
+import Card from 'components/card';
+import { preventWidows } from 'lib/formatting';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
 	debug = debugModule( 'calypso:signup-form:form' );
@@ -66,6 +68,7 @@ class SignupForm extends Component {
 		goToNextStep: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
 		isSocialSignupEnabled: PropTypes.bool,
+		isSocialFirst: PropTypes.bool,
 		locale: PropTypes.string,
 		positionInFlow: PropTypes.number,
 		save: PropTypes.func,
@@ -80,6 +83,7 @@ class SignupForm extends Component {
 
 	static defaultProps = {
 		isSocialSignupEnabled: false,
+		isSocialFirst: false,
 	};
 
 	state = {
@@ -591,6 +595,20 @@ class SignupForm extends Component {
 			<div className={ classNames( 'signup-form', this.props.className ) }>
 				{ this.getNotice() }
 
+				{ this.props.isSocialSignupEnabled &&
+					this.props.isSocialFirst && (
+						<Card className="signup-form__social logged-out-form">
+							<SocialSignupForm
+								handleResponse={ this.props.handleSocialResponse }
+								socialService={ this.props.socialService }
+								socialServiceResponse={ this.props.socialServiceResponse }
+							/>
+							<p>
+								{ preventWidows( this.props.translate( 'Or register with your e-mail address.' ) ) }
+							</p>
+						</Card>
+					) }
+
 				<LoggedOutForm onSubmit={ this.handleSubmit } noValidate={ true }>
 					{ this.props.formHeader && (
 						<header className="signup-form__header">{ this.props.formHeader }</header>
@@ -601,13 +619,21 @@ class SignupForm extends Component {
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
 
-				{ this.props.isSocialSignupEnabled && (
-					<SocialSignupForm
-						handleResponse={ this.props.handleSocialResponse }
-						socialService={ this.props.socialService }
-						socialServiceResponse={ this.props.socialServiceResponse }
-					/>
-				) }
+				{ this.props.isSocialSignupEnabled &&
+					! this.props.isSocialFirst && (
+						<Card className="signup-form__social">
+							<p>
+								{ preventWidows(
+									this.props.translate( 'Or connect your existing profile to get started faster.' )
+								) }
+							</p>
+							<SocialSignupForm
+								handleResponse={ this.props.handleSocialResponse }
+								socialService={ this.props.socialService }
+								socialServiceResponse={ this.props.socialServiceResponse }
+							/>
+						</Card>
+					) }
 
 				{ this.props.footerLink || this.footerLink() }
 			</div>

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -326,6 +326,7 @@ class SignupForm extends Component {
 		return login( {
 			isNative: config.isEnabled( 'login/native-login-links' ),
 			redirectTo: this.props.redirectToAfterLoginUrl,
+			locale: this.props.locale,
 			oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
 		} );
 	}
@@ -619,6 +620,7 @@ export default connect(
 		oauth2Client: getCurrentOAuth2Client( state ),
 	} ),
 	{
-	trackLoginMidFlow: () => recordTracksEvent( 'calypso_signup_login_midflow' ),
-	createSocialUserFailed,
-} )( localize( SignupForm ) );
+		trackLoginMidFlow: () => recordTracksEvent( 'calypso_signup_login_midflow' ),
+		createSocialUserFailed,
+	}
+)( localize( SignupForm ) );

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -326,7 +326,7 @@ class SignupForm extends Component {
 		} );
 	};
 
-	loginLink() {
+	getLoginLink() {
 		return login( {
 			isNative: config.isEnabled( 'login/native-login-links' ),
 			redirectTo: this.props.redirectToAfterLoginUrl,
@@ -336,7 +336,7 @@ class SignupForm extends Component {
 	}
 
 	getNoticeMessageWithLogin( notice ) {
-		const link = this.loginLink();
+		const link = this.getLoginLink();
 
 		if ( notice.error === '2FA_enabled' ) {
 			return (
@@ -380,7 +380,7 @@ class SignupForm extends Component {
 			return;
 		}
 
-		let link = this.loginLink();
+		let link = this.getLoginLink();
 
 		return map( messages, ( message, error_code ) => {
 			if ( error_code === 'taken' ) {
@@ -574,7 +574,7 @@ class SignupForm extends Component {
 		}
 
 		const logInUrl = config.isEnabled( 'login/native-login-links' )
-			? this.loginLink()
+			? this.getLoginLink()
 			: addLocaleToWpcomUrl( config( 'login_url' ), this.props.locale );
 
 		return (

--- a/client/components/signup-form/social.jsx
+++ b/client/components/signup-form/social.jsx
@@ -12,9 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import config from 'config';
-import { preventWidows } from 'lib/formatting';
 
 class SocialSignupForm extends Component {
 	static propTypes = {
@@ -48,22 +46,14 @@ class SocialSignupForm extends Component {
 		const redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
 
 		return (
-			<Card className="signup-form__social">
-				<p>
-					{ preventWidows(
-						this.props.translate( 'Or connect your existing profile to get started faster.' )
-					) }
-				</p>
-
-				<div className="signup-form__social-buttons">
-					<GoogleLoginButton
-						clientId={ config( 'google_oauth_client_id' ) }
-						responseHandler={ this.handleGoogleResponse }
-						redirectUri={ redirectUri }
-						uxMode={ uxMode }
-					/>
-				</div>
-			</Card>
+			<div className="signup-form__social-buttons">
+				<GoogleLoginButton
+					clientId={ config( 'google_oauth_client_id' ) }
+					responseHandler={ this.handleGoogleResponse }
+					redirectUri={ redirectUri }
+					uxMode={ uxMode }
+				/>
+			</div>
 		);
 	}
 }

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -16,6 +16,7 @@ export function login( {
 	socialConnect,
 	emailAddress,
 	socialService,
+	oauth2ClientId,
 } = {} ) {
 	let url = config( 'login_url' );
 
@@ -49,6 +50,10 @@ export function login( {
 
 	if ( emailAddress ) {
 		url = addQueryArgs( { email_address: emailAddress }, url );
+	}
+
+	if ( oauth2ClientId ) {
+		url = addQueryArgs( { client_id: oauth2ClientId }, url );
 	}
 
 	return url;

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -52,7 +52,7 @@ export function login( {
 		url = addQueryArgs( { email_address: emailAddress }, url );
 	}
 
-	if ( oauth2ClientId ) {
+	if ( oauth2ClientId && ! isNaN( oauth2ClientId ) ) {
 		url = addQueryArgs( { client_id: oauth2ClientId }, url );
 	}
 

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -63,5 +63,11 @@ describe( 'index', () => {
 
 			expect( url ).to.equal( '/log-in?email_address=foo%40bar.com' );
 		} );
+
+		test( 'should return the login url with encoded OAuth2 client ID param', () => {
+			const url = login( { isNative: true, oauth2ClientId: 12345 } );
+
+			expect( url ).to.equal( '/log-in?client_id=12345' );
+		} );
 	} );
 } );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -257,6 +257,7 @@ export class UserStep extends Component {
 				socialServiceResponse = hashObject;
 			}
 		}
+		const isSocialFirst = this.props.initialContext && this.props.initialContext.query.social_first;
 
 		return (
 			<SignupForm
@@ -270,6 +271,7 @@ export class UserStep extends Component {
 				suggestedUsername={ this.props.suggestedUsername }
 				handleSocialResponse={ this.handleSocialResponse }
 				isSocialSignupEnabled={ this.props.isSocialSignupEnabled }
+				isSocialFirst={ isSocialFirst }
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }
 			/>


### PR DESCRIPTION
This hopefully, fixes #21710, an issue I opened after noticing that the client ID is not part of the URL in the login form links displayed on the sign up form. This means that if the user follows one of these links and refreshes the page, then the ID is lost from the state and the generic unbranded login page is displayed.

I've also put the generation of the link URL in its own method to reduce the repeated code. I realise this means that the code is not the minimum required to fix this bug, but I'm not sure if that's a problem or not. It would be quite straightforward to break it apart, but in my view would create unnecessary commits.

### Testing
1. Build a local version based on this code.
2. Go to http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D3073eba04c6018e59238c17d39565c35%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1
3. Click on the link to create an account
4. Click on the link to log in to an existing account
5. Reload the page and observe that you still see a login screen with Woocommerce styling.

Additionally it would be worth going through the first few steps of a standard sign up (http://calypso.localhost:3000/start) and checking that everything works as expected.
