### PR TITLE
Jetpack connect: Add site to tracks analytics

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -8,7 +8,7 @@ import debugModule from 'debug';
 import Gridicon from 'gridicons';
 import page from 'page';
 import { connect } from 'react-redux';
-import { get, includes, pick, startsWith } from 'lodash';
+import { get, includes, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -107,10 +107,14 @@ export class JetpackAuthorize extends Component {
 	retryingAuth = false;
 
 	componentWillMount() {
-		const { recordTracksEvent } = this.props;
+		const { recordTracksEvent, isMobileAppFlow } = this.props;
 
-		const tracksProperties = pick( this.props.authQuery, 'from' );
-		tracksProperties.is_mobile_app_flow = this.props.isMobileAppFlow;
+		const { from, clientId } = this.props.authQuery;
+		const tracksProperties = {
+			from,
+			is_mobile_app_flow: isMobileAppFlow,
+			site: clientId,
+		};
 
 		recordTracksEvent( 'calypso_jpc_authorize_form_view', tracksProperties );
 		recordTracksEvent( 'calypso_jpc_auth_view', tracksProperties );

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -17,7 +17,7 @@ import React, { Component } from 'react';
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { get, pick } from 'lodash';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -59,14 +59,19 @@ export class JetpackSignup extends Component {
 	};
 
 	componentWillMount() {
-		this.props.recordTracksEvent(
-			'calypso_jpc_authorize_form_view',
-			pick( this.props.authQuery, 'from' )
-		);
+		const { from, clientId } = this.props.authQuery;
+		this.props.recordTracksEvent( 'calypso_jpc_authorize_form_view', {
+			from,
+			site: clientId,
+		} );
 	}
 
 	componentDidMount() {
-		this.props.recordTracksEvent( 'calypso_jpc_signup_view', pick( this.props.authQuery, 'from' ) );
+		const { from, clientId } = this.props.authQuery;
+		this.props.recordTracksEvent( 'calypso_jpc_signup_view', {
+			from,
+			site: clientId,
+		} );
 	}
 
 	handleSubmitSignup = ( form, userData ) => {

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -282,7 +282,7 @@ export function authorize( queryObject ) {
 	return dispatch => {
 		const { _wp_nonce, client_id, redirect_uri, scope, secret, state, jp_version } = queryObject;
 		debug( 'Trying Jetpack login.', _wp_nonce, redirect_uri, scope, state );
-		dispatch( recordTracksEvent( 'calypso_jpc_authorize' ) );
+		dispatch( recordTracksEvent( 'calypso_jpc_authorize', { site: client_id } ) );
 		dispatch( {
 			type: JETPACK_CONNECT_AUTHORIZE,
 			queryObject: queryObject,


### PR DESCRIPTION
This PR adds `site` to some tracks analytics events. `site` already existed in some places with reference to `client_id`, so it made sense to maintain the property name:

https://github.com/Automattic/wp-calypso/blob/c2fa55bf547c5470b2695cd56e4ab080cab96b71/client/state/jetpack-connect/actions.js#L324-L326

https://github.com/Automattic/wp-calypso/blob/c2fa55bf547c5470b2695cd56e4ab080cab96b71/client/state/jetpack-connect/actions.js#L340-L343

https://github.com/Automattic/wp-calypso/blob/c2fa55bf547c5470b2695cd56e4ab080cab96b71/client/state/jetpack-connect/actions.js#L349-L356

## Testing
1. `localStorage.debug = `calypso:analytics:tracks`
1. Run the connection flow and look for `site` on the updated events:
   * `calypso_jpc_authorize_form_view`
   * `calypso_jpc_auth_view`
   * `calypso_jpc_authorize_form_view`
   * `calypso_jpc_signup_view`
   * `calypso_jpc_authorize`