### PR TITLE
JP Onboarding: Link completed steps in Summary

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -58,6 +58,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 					isRequestingSettings={ isRequestingSettings }
 					recordJpoEvent={ recordJpoEvent }
 					siteId={ siteId }
+					siteSlug={ siteSlug }
 					settings={ settings }
 					stepName={ stepName }
 					steps={ steps }

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -31,7 +31,7 @@ import {
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
 	renderCompleted = () => {
-		const { steps, stepsCompleted, stepsPending } = this.props;
+		const { siteSlug, steps, stepsCompleted, stepsPending } = this.props;
 
 		return map( without( steps, STEPS.SUMMARY ), stepName => {
 			const isCompleted = get( stepsCompleted, stepName ) === true;
@@ -45,7 +45,9 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 					) : (
 						<Gridicon icon={ isCompleted ? 'checkmark' : 'cross' } size={ 18 } />
 					) }
-					{ STEP_TITLES[ stepName ] }
+					<a href={ `/jetpack/onboarding/${ stepName }/${ siteSlug }` }>
+						{ STEP_TITLES[ stepName ] }
+					</a>
 				</div>
 			);
 		} );

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -61,12 +61,12 @@
 
 		&.completed,
 		&.completed a {
-			color: $gray;
+			color: darken($gray, 20%);
 		}
 
 		&.todo,
 		&.todo a {
-			color: $blue-medium;
+			color: $blue-wordpress;
 		}
 	}
 

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -59,11 +59,13 @@
 			margin-right: 12px;
 		}
 
-		&.completed {
+		&.completed,
+		&.completed a {
 			color: $gray;
 		}
 
-		&.todo {
+		&.todo,
+		&.todo a {
 			color: $blue-medium;
 		}
 	}


### PR DESCRIPTION
Fixes #21689; also changes link colors a bit, per https://github.com/Automattic/wp-calypso/issues/21689#issuecomment-359031987. Adding @MichaelArestad for design review of the new colors :slightly_smiling_face: 

**Before:**

![image](https://user-images.githubusercontent.com/96308/35222814-6e9d4af0-ff7f-11e7-8aa3-62376009ad5b.png)

**After:**

![image](https://user-images.githubusercontent.com/96308/35222605-c210e030-ff7e-11e7-8ff9-eec7ce5e707a.png)

To test:
* Checkout this branch on your local Calypso.
* Make sure you're running latest `master` on your JP sandbox.
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
* Wait until being redirected to the JPO flow in Calypso.
* Skip some steps, fill in some others, until you arrive at the 'Summary' page.
* Verify that all items in the left column are now links that point to the respective step.