### PR TITLE
Add concierge cancel confirm page

### DIFF
--- a/client/me/concierge/book/confirmation-step.js
+++ b/client/me/concierge/book/confirmation-step.js
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
+import Button from 'components/button';
 import Confirmation from '../shared/confirmation';
 
 class ConfirmationStep extends Component {
@@ -17,13 +18,19 @@ class ConfirmationStep extends Component {
 
 		return (
 			<Confirmation
-				buttonLabel={ translate( 'Return to your dashboard' ) }
-				buttonUrl={ `/stats/day/${ site.slug }` }
 				description={ translate(
 					'We will send you an email with information on how to get prepared.'
 				) }
 				title={ translate( 'Your Concierge session is booked!' ) }
-			/>
+			>
+				<Button
+					className="book__schedule-button"
+					href={ `/stats/day/${ site.slug }` }
+					primary={ true }
+				>
+					{ translate( 'Return to your dashboard' ) }
+				</Button>
+			</Confirmation>
 		);
 	}
 }

--- a/client/me/concierge/cancel/index.js
+++ b/client/me/concierge/cancel/index.js
@@ -6,20 +6,20 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Main from 'components/main';
-import Card from 'components/card';
 import { localize } from 'i18n-calypso';
 import Confirmation from '../shared/confirmation';
-import Skeleton from './skeleton';
 import { cancelConciergeAppointment } from 'state/concierge/actions';
 import {
 	WPCOM_CONCIERGE_SCHEDULE_ID,
 	CONCIERGE_STATUS_CANCELLED,
-	CONCIERGE_STATUS_CANCELLING_ERROR,
+	CONCIERGE_STATUS_CANCELLING,
 } from '../constants';
 import { getConciergeSignupForm } from 'state/selectors';
 
@@ -29,36 +29,63 @@ class ConciergeCancel extends Component {
 		siteSlug: PropTypes.string.isRequired,
 	};
 
+	cancelAppointment = () => {
+		const { appointmentId } = this.props;
+		this.props.cancelConciergeAppointment( WPCOM_CONCIERGE_SCHEDULE_ID, appointmentId );
+	};
+
 	getDisplayComponent = () => {
-		const { siteSlug, signupForm, translate } = this.props;
+		const { appointmentId, siteSlug, signupForm, translate } = this.props;
 
 		switch ( signupForm.status ) {
 			case CONCIERGE_STATUS_CANCELLED:
 				return (
 					<Confirmation
-						buttonLabel={ translate( 'Schedule' ) }
-						buttonUrl={ `/me/concierge/${ siteSlug }/book` }
 						description={ translate( 'Would you like to schedule a new session?' ) }
 						title={ translate( 'Your Concierge session has been cancelled.' ) }
-					/>
-				);
-
-			case CONCIERGE_STATUS_CANCELLING_ERROR:
-				return (
-					<Card highlight="error">
-						{ translate( "We couldn't cancel your session, please try again later." ) }
-					</Card>
+					>
+						<Button
+							className="cancel__schedule-button"
+							href={ `/me/concierge/${ siteSlug }/book` }
+							primary={ true }
+						>
+							{ translate( 'Schedule' ) }
+						</Button>
+					</Confirmation>
 				);
 
 			default:
-				return <Skeleton />;
+				return (
+					<Confirmation
+						description={ translate(
+							'You can also reschedule your session. What would you like to?'
+						) }
+						title={ translate( 'Cancel your Concierge session' ) }
+					>
+						<Button
+							className="cancel__reschedule-button"
+							disabled={ signupForm.status === CONCIERGE_STATUS_CANCELLING }
+							href={ `/me/concierge/${ siteSlug }/${ appointmentId }/reschedule` }
+						>
+							{ translate( 'Reschedule session' ) }
+						</Button>
+
+						<Button
+							className="cancel__confirmation-button"
+							disabled={ includes(
+								[ CONCIERGE_STATUS_CANCELLED, CONCIERGE_STATUS_CANCELLING ],
+								signupForm.status
+							) }
+							onClick={ this.cancelAppointment }
+							primary={ true }
+							scary={ true }
+						>
+							{ translate( 'Cancel session' ) }
+						</Button>
+					</Confirmation>
+				);
 		}
 	};
-
-	componentDidMount() {
-		const { appointmentId } = this.props;
-		this.props.cancelConciergeAppointment( WPCOM_CONCIERGE_SCHEDULE_ID, appointmentId );
-	}
 
 	render() {
 		return <Main> { this.getDisplayComponent() } </Main>;

--- a/client/me/concierge/cancel/index.js
+++ b/client/me/concierge/cancel/index.js
@@ -58,7 +58,7 @@ class ConciergeCancel extends Component {
 				return (
 					<Confirmation
 						description={ translate(
-							'You can also reschedule your session. What would you like to?'
+							'You can also reschedule your session. What would you like to do?'
 						) }
 						title={ translate( 'Cancel your Concierge session' ) }
 					>

--- a/client/me/concierge/reschedule/confirmation-step.js
+++ b/client/me/concierge/reschedule/confirmation-step.js
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
+import Button from 'components/button';
 import Confirmation from '../shared/confirmation';
 
 class ConfirmationStep extends Component {
@@ -17,13 +18,19 @@ class ConfirmationStep extends Component {
 
 		return (
 			<Confirmation
-				buttonLabel={ translate( 'Return to your dashboard' ) }
-				buttonUrl={ `/stats/day/${ site.slug }` }
 				description={ translate(
 					'We will send you an email with information on how to get prepared.'
 				) }
 				title={ translate( 'Your Concierge session has been rescheduled!' ) }
-			/>
+			>
+				<Button
+					className="reschedule__schedule-button"
+					href={ `/stats/day/${ site.slug }` }
+					primary={ true }
+				>
+					{ translate( 'Return to your dashboard' ) }
+				</Button>
+			</Confirmation>
 		);
 	}
 }

--- a/client/me/concierge/shared/confirmation.js
+++ b/client/me/concierge/shared/confirmation.js
@@ -9,20 +9,17 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
 
 class Confirmation extends Component {
 	static propTypes = {
-		buttonLabel: PropTypes.string.isRequired,
-		buttonUrl: PropTypes.string.isRequired,
 		description: PropTypes.string.isRequired,
 		title: PropTypes.string.isRequired,
 	};
 
 	render() {
-		const { buttonLabel, buttonUrl, description, title } = this.props;
+		const { children, description, title } = this.props;
 
 		return (
 			<Card className="shared__confirmation">
@@ -33,9 +30,7 @@ class Confirmation extends Component {
 
 				<FormattedHeader headerText={ title } subHeaderText={ description } />
 
-				<Button className="shared__confirmation-button" primary={ true } href={ buttonUrl }>
-					{ buttonLabel }
-				</Button>
+				{ children }
 			</Card>
 		);
 	}

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -47,6 +47,13 @@
 	max-width: 182px;
 }
 
-.shared__confirmation-button {
+.cancel__reschedule-button {
+	margin-right: 10px;
+}
+
+.book__schedule-button,
+.cancel__schedule-button,
+.reschedule__schedule-button,
+.cancel__confirmation-button {
 	margin-bottom: 40px;
 }

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/index.js
@@ -56,8 +56,10 @@ export const cancelConciergeAppointment = ( { dispatch }, action ) => {
 export const markSlotAsCancelled = ( { dispatch } ) =>
 	dispatch( updateConciergeBookingStatus( CONCIERGE_STATUS_CANCELLED ) );
 
-export const handleCancellingError = ( { dispatch } ) =>
+export const handleCancellingError = ( { dispatch } ) => {
 	dispatch( updateConciergeBookingStatus( CONCIERGE_STATUS_CANCELLING_ERROR ) );
+	dispatch( errorNotice( "We couldn't cancel your session, please try again later." ) );
+};
 
 export const bookConciergeAppointment = ( { dispatch }, action ) => {
 	dispatch( updateConciergeBookingStatus( CONCIERGE_STATUS_BOOKING ) );


### PR DESCRIPTION
## Summary
This PR introduces a cancel landing page that will require customer confirmation before actually cancelling a concierge appointment. The confirmation shared component was refactored to be more generic so that multiple buttons are allowed as children components.

**More context 540-hg-gh.**

Succesfull cancellation flow: https://cloudup.com/cjsQ7bd7ItM
Cancellation error flow: https://cloudup.com/cJZZngWUQib

## Testing
1. Book an appointment by following the steps in https://github.com/Automattic/wp-calypso/pull/21364
2. Access the MC happiness/concierge page, under the `Lighthouse Only` tab you should see your appointment
3. Grab the id of your appointment, for now the only way to do that is by inspecting the element https://cloudup.com/c8dX8XZ2kOf and copying the `data-appointment-id` value
4. Access `http://calypso.localhost:3000/me/concierge/<business-site-slug>/<appointmentId>/cancel`
5. Cancel the appointment
6. It should show the confirmation page
7. Refresh the page and try to cancel again
8. An error should be shown

  