### PR TITLE
JP Onboarding: Update Next Steps on Summary Page

### DIFF
--- a/client/jetpack-onboarding/constants.js
+++ b/client/jetpack-onboarding/constants.js
@@ -30,7 +30,8 @@ export const JETPACK_ONBOARDING_STEPS = {
 export const JETPACK_ONBOARDING_SUMMARY_STEPS = {
 	JETPACK_CONNECTION: translate( 'Connect to WordPress.com' ),
 	THEME: translate( 'Choose a Theme' ),
-	BLOG: translate( 'Start a Blog' ),
+	PAGES: translate( 'Add additional pages' ),
+	BLOG: translate( 'Write your first blog post' ),
 };
 
 export const JETPACK_ONBOARDING_STEP_TITLES = {

--- a/client/jetpack-onboarding/constants.js
+++ b/client/jetpack-onboarding/constants.js
@@ -30,8 +30,6 @@ export const JETPACK_ONBOARDING_STEPS = {
 export const JETPACK_ONBOARDING_SUMMARY_STEPS = {
 	JETPACK_CONNECTION: translate( 'Connect to WordPress.com' ),
 	THEME: translate( 'Choose a Theme' ),
-	SITE_ADDRESS: translate( 'Add a Site Address' ),
-	STORE: translate( 'Add a Store' ),
 	BLOG: translate( 'Start a Blog' ),
 };
 

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -52,18 +52,10 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	};
 
 	renderTodo = () => {
-		const stepsTodo = [
-			SUMMARY_STEPS.JETPACK_CONNECTION,
-			SUMMARY_STEPS.THEME,
-			SUMMARY_STEPS.SITE_ADDRESS,
-			SUMMARY_STEPS.STORE,
-			SUMMARY_STEPS.BLOG,
-		];
+		const stepsTodo = [ SUMMARY_STEPS.JETPACK_CONNECTION, SUMMARY_STEPS.THEME, SUMMARY_STEPS.BLOG ];
 		const stepLinks = [
 			'/jetpack/connect?url=' + this.props.siteUrl,
 			// TODO: update the following with relevant links
-			'#',
-			'#',
 			'#',
 			'#',
 		];

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -52,18 +52,20 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	};
 
 	renderTodo = () => {
+		const { siteUrl } = this.props;
 		const stepsTodo = [
 			SUMMARY_STEPS.JETPACK_CONNECTION,
 			SUMMARY_STEPS.THEME,
 			SUMMARY_STEPS.PAGES,
 			SUMMARY_STEPS.BLOG,
 		];
+		// If we're not connected, we cannot use selectors from `sites/selectors`.
 		const stepLinks = [
-			'/jetpack/connect?url=' + this.props.siteUrl,
+			'/jetpack/connect?url=' + siteUrl,
 			// TODO: update the following with relevant links
-			'#',
-			'#',
-			'#',
+			siteUrl + '/wp-admin/themes.php',
+			siteUrl + '/wp-admin/post-new.php?post_type=page',
+			siteUrl + '/wp-admin/post-new.php',
 		];
 
 		return map( stepsTodo, ( fieldLabel, fieldIndex ) => (

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -52,10 +52,16 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	};
 
 	renderTodo = () => {
-		const stepsTodo = [ SUMMARY_STEPS.JETPACK_CONNECTION, SUMMARY_STEPS.THEME, SUMMARY_STEPS.BLOG ];
+		const stepsTodo = [
+			SUMMARY_STEPS.JETPACK_CONNECTION,
+			SUMMARY_STEPS.THEME,
+			SUMMARY_STEPS.PAGES,
+			SUMMARY_STEPS.BLOG,
+		];
 		const stepLinks = [
 			'/jetpack/connect?url=' + this.props.siteUrl,
 			// TODO: update the following with relevant links
+			'#',
 			'#',
 			'#',
 		];


### PR DESCRIPTION
Fixes #17650, implementing results from the discussion there.

**Before:**

![image](https://user-images.githubusercontent.com/96308/35224825-9e95a8ae-ff86-11e7-9403-71c17b505836.png)

**After:**

![image](https://user-images.githubusercontent.com/96308/35224758-5f4ccf60-ff86-11e7-97f5-617a37438e75.png)

Changes introduced in this PR:

* Drop WooCommerce, Site Address from Summary Next Steps
* Rename 'Start Blog' to 'Write your first blog post'
* Add 'Add additional pages' step
* Add wp-admin link for all of the above; we can't point to Calypso if we don't know whether we're even connected.

Possible follow-up PR:
* Point links to Calypso if connected (fall back to wp-admin otherwise).