### PR TITLE
Plans: Start yearly discount promotion AB test

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -353,6 +353,7 @@
 @import 'my-sites/people/invite-people/style';
 @import 'my-sites/plan-compare-card/style';
 @import 'my-sites/plan-features/style';
+@import 'my-sites/plan-interval-discount/style';
 @import 'my-sites/plan-price/style';
 @import 'my-sites/plans-features-main/style';
 @import 'my-sites/plans/style';

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -117,4 +117,16 @@ export default {
 		defaultVariation: 'original',
 		allowExistingUsers: true,
 	},
+
+	// Must run at least 1 full week from commit time
+	// 2018-01-23 to 2018-01-30
+	promoteYearlyJetpackPlanSavings: {
+		datestamp: '20180123',
+		variations: {
+			original: 50,
+			promoteYearly: 50,
+		},
+		defaultVariation: 'original',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -119,9 +119,9 @@ export default {
 	},
 
 	// Must run at least 1 full week from commit time
-	// 2018-01-23 to 2018-01-30
+	// 2018-01-24 to 2018-01-31
 	promoteYearlyJetpackPlanSavings: {
-		datestamp: '20180123',
+		datestamp: '20180124',
 		variations: {
 			original: 50,
 			promoteYearly: 50,

--- a/client/my-sites/plan-interval-discount.js
+++ b/client/my-sites/plan-interval-discount.js
@@ -1,0 +1,80 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import { plansLink } from 'lib/plans';
+
+/**
+ * Internal Dependencies
+ **/
+import { getCurrencyObject } from 'lib/format-currency';
+
+class PlanIntervalDiscount extends Component {
+	static propTypes = {
+		currencyCode: PropTypes.string.isRequired,
+		discountPrice: PropTypes.number.isRequired,
+		isYearly: PropTypes.bool.isRequired,
+		originalPrice: PropTypes.number.isRequired,
+		site: PropTypes.object,
+	};
+
+	static defaultProps = {
+		currencyCode: 'USD',
+	};
+
+	getDiscountPriceObject() {
+		const { currencyCode, discountPrice, originalPrice } = this.props;
+		return getCurrencyObject( originalPrice - discountPrice, currencyCode );
+	}
+
+	renderYearlyViewDiscountInfo() {
+		const { currencyCode, discountPrice, originalPrice } = this.props;
+
+		// Ensure we have required props.
+		if ( ! currencyCode || ! discountPrice || ! originalPrice ) {
+			return null;
+		}
+
+		const price = this.getDiscountPriceObject();
+		const { translate } = this.props;
+		return translate( 'Save %(symbol)s%(integer)s%(fraction)s over monthly.', {
+			args: price,
+		} );
+	}
+
+	renderMonthlyViewDiscountInfo() {
+		const { currencyCode, discountPrice, originalPrice } = this.props;
+
+		// Ensure we have required props.
+		if ( ! currencyCode || ! discountPrice || ! originalPrice ) {
+			return null;
+		}
+
+		const price = this.getDiscountPriceObject();
+		const { site, translate } = this.props;
+		return translate(
+			'Save %(symbol)s%(integer)s%(fraction)s when you {{Link}}buy yearly{{/Link}}.',
+			{
+				args: price,
+				components: {
+					Link: <a href={ plansLink( '/jetpack/connect/plans', site, 'yearly' ) } />,
+				},
+			}
+		);
+	}
+
+	render() {
+		const { isYearly } = this.props;
+		return (
+			<div className="my-sites__plan-interval-discount">
+				{ isYearly ? this.renderYearlyViewDiscountInfo() : this.renderMonthlyViewDiscountInfo() }
+			</div>
+		);
+	}
+}
+
+export default localize( PlanIntervalDiscount );

--- a/client/my-sites/plan-interval-discount/index.js
+++ b/client/my-sites/plan-interval-discount/index.js
@@ -41,8 +41,9 @@ class PlanIntervalDiscount extends Component {
 
 		const price = this.getDiscountPriceObject();
 		const { translate } = this.props;
-		return translate( 'Save %(symbol)s%(integer)s%(fraction)s over monthly.', {
+		return translate( 'Save {{b}}%(symbol)s%(integer)s%(fraction)s{{/b}} over monthly.', {
 			args: price,
+			components: { b: <b /> },
 		} );
 	}
 
@@ -57,11 +58,12 @@ class PlanIntervalDiscount extends Component {
 		const price = this.getDiscountPriceObject();
 		const { site, translate } = this.props;
 		return translate(
-			'Save %(symbol)s%(integer)s%(fraction)s when you {{Link}}buy yearly{{/Link}}.',
+			'Save {{b}}%(symbol)s%(integer)s%(fraction)s{{/b}} when you {{Link}}buy yearly{{/Link}}.',
 			{
 				args: price,
 				components: {
 					Link: <a href={ plansLink( '/jetpack/connect/plans', site, 'yearly' ) } />,
+					b: <b />,
 				},
 			}
 		);

--- a/client/my-sites/plan-interval-discount/index.js
+++ b/client/my-sites/plan-interval-discount/index.js
@@ -1,5 +1,4 @@
 /** @format */
-
 /**
  * External dependencies
  */
@@ -72,7 +71,7 @@ class PlanIntervalDiscount extends Component {
 	render() {
 		const { isYearly } = this.props;
 		return (
-			<div className="my-sites__plan-interval-discount">
+			<div className="plan-interval-discount">
 				{ isYearly ? this.renderYearlyViewDiscountInfo() : this.renderMonthlyViewDiscountInfo() }
 			</div>
 		);

--- a/client/my-sites/plan-interval-discount/style.scss
+++ b/client/my-sites/plan-interval-discount/style.scss
@@ -1,0 +1,7 @@
+/** @format */
+
+.my-sites__plan-interval-discount {
+	color: $gray;
+	font-style: italic;
+	margin-top: 0.5em;
+}

--- a/client/my-sites/plan-interval-discount/style.scss
+++ b/client/my-sites/plan-interval-discount/style.scss
@@ -1,6 +1,6 @@
 /** @format */
 
-.my-sites__plan-interval-discount {
+.plan-interval-discount {
 	color: $gray;
 	font-style: italic;
 	margin-top: 0.5em;


### PR DESCRIPTION
Implements yearly plans promotions according to p7kMJG-47e-p2. Detailed in p7rd6c-1e7-p2

Adds an AB test `promoteYearlyJetpackPlanSavings`.

## Screens 

### Before (no test)

<img width="1068" alt="before" src="https://user-images.githubusercontent.com/841763/35232670-60c95d02-ff9c-11e7-9898-d147b4b70890.png">

### Yearly (in test)

<img width="1044" alt="yearly" src="https://user-images.githubusercontent.com/841763/35232669-60a23eb6-ff9c-11e7-9e6c-8ab99fa68525.png">

### Monthly (in test)
<img width="1052" alt="monthly" src="https://user-images.githubusercontent.com/841763/35232672-61773d3c-ff9c-11e7-94df-4d5b79ca91d5.png">



## Testing
1. WordPress.com plans pages should remain (signup flow and existing site /plans)
1. Existing, connected Jetpack site plans (/plans) should remain unchanged
1. No AB test should remain unchanged (`localStorage.ABTests = '{}'`
1. Set up the test and refresh `localStorage.ABTests = '{"promoteYearlyJetpackPlanSavings_20180123":"promoteYearly"}'`
1. `/jetpack/connect/store` should feature the changes when in the test
1. `/jetpack/connect/plans/:SITE` should feature changes when in the test
1. Monthly text should be correct and link to yearly plans on the same page
1. Yearly text should be correct