### PR TITLE
Store Services - Add option to email receipt after purchasing a label

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
@@ -62,3 +62,8 @@ export const isPristine = ( state, siteId = getSelectedSiteId( state ) ) => {
 	const meta = getLabelSettingsFormMeta( state, siteId );
 	return meta && meta.pristine;
 };
+
+export const getEmailReceipts = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const data = getLabelSettingsFormData( state, siteId );
+	return data && data.email_receipts;
+};

--- a/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/label-settings/selectors.js
@@ -67,3 +67,32 @@ export const getEmailReceipts = ( state, siteId = getSelectedSiteId( state ) ) =
 	const data = getLabelSettingsFormData( state, siteId );
 	return data && data.email_receipts;
 };
+
+export const userCanManagePayments = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const meta = getLabelSettingsFormMeta( state, siteId );
+	return meta && meta.can_manage_payments;
+};
+
+export const userCanEditSettings = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const meta = getLabelSettingsFormMeta( state, siteId );
+	return meta && meta.can_edit_settings;
+};
+
+export const getPaperSize = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const data = getLabelSettingsFormData( state, siteId );
+	return data && data.paper_size;
+};
+
+export const getPaymentMethods = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const meta = getLabelSettingsFormMeta( state, siteId );
+	return meta && meta.payment_methods;
+};
+
+export const getMasterUserInfo = ( state, siteId = getSelectedSiteId( state ) ) => {
+	const meta = getLabelSettingsFormMeta( state, siteId );
+	return {
+		masterUserName: meta && meta.master_user_name,
+		masterUserLogin: meta && meta.master_user_login,
+		masterUserEmail: meta && meta.master_user_email,
+	};
+};

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import { every, fill, find, first, flatten, includes, isEqual, map, noop, pick } from 'lodash';
+import { every, fill, find, first, flatten, includes, isBoolean, isEqual, map, noop, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -661,7 +661,6 @@ export const purchaseLabel = ( orderId, siteId ) => ( dispatch, getState ) => {
 		form = state.form;
 		const formData = {
 			async: true,
-			email_receipt: Boolean( getEmailReceipts( getState(), siteId ) ),
 			origin: form.origin.selectNormalized ? form.origin.normalized : form.origin.values,
 			destination: form.destination.selectNormalized ? form.destination.normalized : form.destination.values,
 			packages: map( form.packages.selected, ( pckg, pckgId ) => {
@@ -677,6 +676,12 @@ export const purchaseLabel = ( orderId, siteId ) => ( dispatch, getState ) => {
 				};
 			} ),
 		};
+
+		//compatibility - only add the email_receipt if the plugin and the server support it
+		const emailReceipt = getEmailReceipts( getState(), siteId );
+		if ( isBoolean( emailReceipt ) ) {
+			formData.email_receipt = emailReceipt;
+		}
 
 		setIsSaving( true );
 		api.post( siteId, api.url.orderLabels( orderId ), formData )

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -21,6 +21,7 @@ import { getFirstErroneousStep, getShippingLabel, getFormErrors, shouldFulfillOr
 import { createNote } from 'woocommerce/state/sites/orders/notes/actions';
 import { saveOrder } from 'woocommerce/state/sites/orders/actions';
 import { getAllPackageDefinitions } from 'woocommerce/woocommerce-services/state/packages/selectors';
+import { getEmailReceipts } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
 
 import {
 	WOOCOMMERCE_SERVICES_SHIPPING_LABEL_INIT,
@@ -660,6 +661,7 @@ export const purchaseLabel = ( orderId, siteId ) => ( dispatch, getState ) => {
 		form = state.form;
 		const formData = {
 			async: true,
+			email_receipt: Boolean( getEmailReceipts( getState(), siteId ) ),
 			origin: form.origin.selectNormalized ? form.origin.normalized : form.origin.values,
 			destination: form.destination.selectNormalized ? form.destination.normalized : form.destination.values,
 			packages: map( form.packages.selected, ( pckg, pckgId ) => {

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -67,6 +67,7 @@ class AccountSettingsRootView extends Component {
 					setFormDataValue={ setValue }
 					selectedPaymentMethod={ ( formData || {} ).selected_payment_method_id }
 					paperSize={ ( formData || {} ).paper_size }
+					emailReceipts={ ( formData || {} ).email_receipts }
 					storeOptions={ storeOptions }
 					canEditPayments={ formMeta.can_manage_payments }
 					canEditSettings={ Boolean( formMeta.can_manage_payments || formMeta.can_edit_settings ) }

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -73,6 +73,7 @@ class AccountSettingsRootView extends Component {
 					canEditSettings={ Boolean( formMeta.can_manage_payments || formMeta.can_edit_settings ) }
 					masterUserName={ formMeta.master_user_name }
 					masterUserLogin={ formMeta.master_user_login }
+					masterUserEmail={ formMeta.master_user_email }
 				/>
 			);
 		};

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-payment-method.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-payment-method.js
@@ -79,7 +79,7 @@ const PaymentMethod = ( {
 				checked={ selected }
 				onChange={ onSelect }
 			/>
-			<PaymentLogo className="label-settings__card-logo" type={ typeId } altText={ '' } />
+			<PaymentLogo className="label-settings__card-logo" type={ typeId } altText={ typeTitle } />
 			<div className="label-settings__card-details">
 				<p className="label-settings__card-number">{ typeName }</p>
 				<p className="label-settings__card-name">{ name }</p>

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -7,13 +7,14 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { find } from 'lodash';
+import { find, isBoolean } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { getPaperSizes } from 'woocommerce/woocommerce-services/lib/pdf-label-utils';
 import Button from 'components/button';
+import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
@@ -200,6 +201,47 @@ class ShippingLabels extends Component {
 		);
 	};
 
+	renderEmailReceiptsSection = () => {
+		const {
+			emailReceipts,
+			translate,
+			masterUserName,
+			masterUserLogin,
+			canEditSettings,
+			canEditPayments,
+			setFormDataValue,
+		} = this.props;
+
+		if ( ! isBoolean( emailReceipts ) ) {
+			return null;
+		}
+
+		const onChange = () => setFormDataValue( 'email_receipts', ! emailReceipts );
+
+		return (
+			<FormFieldSet>
+				<FormLabel className="label-settings__cards-label">
+					{ translate( 'Email Receipts' ) }
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox
+						checked={ emailReceipts }
+						onChange={ onChange }
+						disabled={ ! canEditPayments && ! canEditSettings }
+					/>
+					<span className="label-settings__credit-card-description">
+						{ translate( 'Email the label purchase receipts to %(ownerName)s (%(ownerLogin)s)', {
+							args: {
+								ownerName: masterUserName,
+								ownerLogin: masterUserLogin,
+							},
+						} ) }
+					</span>
+				</FormLabel>
+			</FormFieldSet>
+		);
+	};
+
 	renderContent = () => {
 		const {
 			canEditSettings,
@@ -240,6 +282,7 @@ class ShippingLabels extends Component {
 					<FormLabel className="label-settings__cards-label">{ translate( 'Payment' ) }</FormLabel>
 					{ this.renderPaymentsSection() }
 				</FormFieldSet>
+				{ this.renderEmailReceiptsSection() }
 			</div>
 		);
 	};
@@ -261,6 +304,7 @@ ShippingLabels.propTypes = {
 	canEditSettings: PropTypes.bool,
 	masterUserName: PropTypes.string,
 	masterUserLogin: PropTypes.string,
+	emailReceipts: PropTypes.bool,
 };
 
 export default localize( ShippingLabels );

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -207,6 +207,7 @@ class ShippingLabels extends Component {
 			translate,
 			masterUserName,
 			masterUserLogin,
+			masterUserEmail,
 			canEditSettings,
 			canEditPayments,
 			setFormDataValue,
@@ -230,12 +231,16 @@ class ShippingLabels extends Component {
 						disabled={ ! canEditPayments && ! canEditSettings }
 					/>
 					<span className="label-settings__credit-card-description">
-						{ translate( 'Email the label purchase receipts to %(ownerName)s (%(ownerLogin)s)', {
-							args: {
-								ownerName: masterUserName,
-								ownerLogin: masterUserLogin,
-							},
-						} ) }
+						{ translate(
+							'Email the label purchase receipts to %(ownerName)s (%(ownerLogin)s) at %(ownerEmail)s',
+							{
+								args: {
+									ownerName: masterUserName,
+									ownerLogin: masterUserLogin,
+									ownerEmail: masterUserEmail,
+								},
+							}
+						) }
 					</span>
 				</FormLabel>
 			</FormFieldSet>
@@ -304,6 +309,7 @@ ShippingLabels.propTypes = {
 	canEditSettings: PropTypes.bool,
 	masterUserName: PropTypes.string,
 	masterUserLogin: PropTypes.string,
+	masterUserEmail: PropTypes.string,
 	emailReceipts: PropTypes.bool,
 };
 


### PR DESCRIPTION
Adds the email receipts setting to the WCS shipping settings (CC @kellychoffman, @jameskoster):
<img width="722" alt="screen shot 2018-01-22 at 13 17 26" src="https://user-images.githubusercontent.com/800604/35227305-abca320c-ff85-11e7-9685-460b5aa0fb58.png">

To test:
* the changes should be backwards compatible, so while the plugin and server are not released, the option should not appear in Calypso, and the label purchases should work as before on staging/prod server (no emails)
* checkout https://github.com/Automattic/woocommerce-services/pull/1284 and 1026-gh-woocommerce-connect-server
* `npm link` this branch to the client
* verify that the option appears and is enabled by default
* verify that the label purchases with the option enabled result in an email in the inbox tied to your wpcom account
* verify that no email is sent if the option is disabled