### PR TITLE
Reader: remove success notice when following and unfollowing a feed

### DIFF
--- a/client/state/data-layer/wpcom/read/following/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/index.js
@@ -11,7 +11,7 @@ import config from 'config';
 import { READER_UNFOLLOW } from 'state/action-types';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { createNotice, errorNotice } from 'state/notices/actions';
+import { errorNotice } from 'state/notices/actions';
 import { follow } from 'state/reader/follows/actions';
 import { getFeedByFeedUrl } from 'state/reader/feeds/selectors';
 import { getSiteByFeedUrl } from 'state/reader/sites/selectors';
@@ -32,20 +32,6 @@ export function requestUnfollow( { dispatch, getState }, action ) {
 			onSuccess: action,
 			onFailure: action,
 		} )
-	);
-
-	// build up a notice to show
-	const site = getSiteByFeedUrl( getState(), feedUrl );
-	const feed = getFeedByFeedUrl( getState(), feedUrl );
-	const siteTitle = getSiteName( { feed, site } ) || feedUrl;
-	dispatch(
-		createNotice(
-			null,
-			translate( "You're no longer following %(siteTitle)s", { args: { siteTitle } } ),
-			{
-				duration: 5000,
-			}
-		)
 	);
 }
 

--- a/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/test/index.js
@@ -43,8 +43,6 @@ describe( 'following/mine/delete', () => {
 					onFailure: action,
 				} )
 			);
-
-			expect( dispatch ).to.be.calledWithMatch( { type: NOTICE_CREATE, notice: { status: null } } );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/read/following/mine/new/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/index.js
@@ -11,12 +11,9 @@ import config from 'config';
 import { READER_FOLLOW } from 'state/action-types';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
-import { successNotice, errorNotice } from 'state/notices/actions';
+import { errorNotice } from 'state/notices/actions';
 import { follow, unfollow, recordFollowError } from 'state/reader/follows/actions';
 import { subscriptionFromApi } from 'state/data-layer/wpcom/read/following/mine/utils';
-import { getFeedByFeedUrl } from 'state/reader/feeds/selectors';
-import { getSiteByFeedUrl } from 'state/reader/sites/selectors';
-import { getSiteName } from 'reader/get-helpers';
 import { bypassDataLayer } from 'state/data-layer/utils';
 
 export function requestFollow( { dispatch, getState }, action ) {
@@ -33,16 +30,6 @@ export function requestFollow( { dispatch, getState }, action ) {
 			},
 			onSuccess: action,
 			onFailure: action,
-		} )
-	);
-
-	// build up a notice to show
-	const site = getSiteByFeedUrl( getState(), feedUrl );
-	const feed = getFeedByFeedUrl( getState(), feedUrl );
-	const siteTitle = getSiteName( { feed, site } ) || feedUrl;
-	dispatch(
-		successNotice( translate( "You're now following %(siteTitle)s", { args: { siteTitle } } ), {
-			duration: 5000,
 		} )
 	);
 }

--- a/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/new/test/index.js
@@ -43,11 +43,6 @@ describe( 'requestFollow', () => {
 				onFailure: action,
 			} )
 		);
-
-		expect( dispatch ).to.be.calledWithMatch( {
-			type: NOTICE_CREATE,
-			notice: { status: 'is-success' },
-		} );
 	} );
 } );
 


### PR DESCRIPTION
@jancavan explains in https://github.com/Automattic/wp-calypso/issues/21668:

> "After Following a site from its Site Stream, a global notice appears on the upper right corner. It's really obtrusive and it doesn't help in making the Settings button more discoverable."

This PR removes the success notice when following and unfollowing a feed.

### To test

Use the follow button to follow and unfollow a feed. Ensure no notice is shown.

Fixes #21668.