### PR TITLE
JP Onboarding: Different Next Steps on Summary Page When Connected

### DIFF
--- a/client/jetpack-onboarding/steps/summary-next-steps.jsx
+++ b/client/jetpack-onboarding/steps/summary-next-steps.jsx
@@ -15,7 +15,7 @@ import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
 // We discard all other props in connect() to make sure the component only receives step objects.
-const TodoLinks = steps =>
+const NextSteps = steps =>
 	map( steps, ( { label, url }, stepName ) => (
 		<div key={ stepName } className="steps__summary-entry todo">
 			<a href={ url }>{ label }</a>
@@ -64,5 +64,5 @@ export default localize(
 		},
 		null,
 		stateProps => stateProps // Discard ownProps
-	)( TodoLinks )
+	)( NextSteps )
 );

--- a/client/jetpack-onboarding/steps/summary-next-steps.jsx
+++ b/client/jetpack-onboarding/steps/summary-next-steps.jsx
@@ -14,8 +14,7 @@ import { localize } from 'i18n-calypso';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
-// We discard all other props in connect() to make sure the component only receives step objects.
-const NextSteps = steps =>
+const NextSteps = ( { steps } ) =>
 	map( steps, ( { label, url }, stepName ) => (
 		<div key={ stepName } className="steps__summary-entry todo">
 			<a href={ url }>{ label }</a>
@@ -23,11 +22,11 @@ const NextSteps = steps =>
 	) );
 
 export default localize(
-	connect(
-		( state, { siteId, siteSlug, siteUrl, translate } ) => {
-			const isConnected = isJetpackSite( state, siteId ); // Will only return true if the site is connected to WP.com
-			if ( isConnected ) {
-				return {
+	connect( ( state, { siteId, siteSlug, siteUrl, translate } ) => {
+		const isConnected = isJetpackSite( state, siteId ); // Will only return true if the site is connected to WP.com
+		if ( isConnected ) {
+			return {
+				steps: {
 					THEME: {
 						label: translate( 'Choose a Theme' ),
 						url: '/themes/' + siteSlug,
@@ -40,10 +39,12 @@ export default localize(
 						label: translate( 'Write your first blog post' ),
 						url: getEditorNewPostPath( state, siteId, 'post' ),
 					},
-				};
-			}
+				},
+			};
+		}
 
-			return {
+		return {
+			steps: {
 				JETPACK_CONNECTION: {
 					label: translate( 'Connect to WordPress.com' ),
 					url: '/jetpack/connect?url=' + siteUrl,
@@ -60,9 +61,7 @@ export default localize(
 					label: translate( 'Write your first blog post' ),
 					url: siteUrl + '/wp-admin/post-new.php',
 				},
-			};
-		},
-		null,
-		stateProps => stateProps // Discard ownProps
-	)( NextSteps )
+			},
+		};
+	} )( NextSteps )
 );

--- a/client/jetpack-onboarding/steps/summary-next-steps.jsx
+++ b/client/jetpack-onboarding/steps/summary-next-steps.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { map } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -11,15 +11,20 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import QuerySites from 'components/data/query-sites';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
-const NextSteps = ( { steps } ) =>
-	map( steps, ( { label, url }, stepName ) => (
-		<div key={ stepName } className="steps__summary-entry todo">
-			<a href={ url }>{ label }</a>
-		</div>
-	) );
+const NextSteps = ( { siteId, steps } ) => (
+	<Fragment>
+		<QuerySites siteId={ siteId } />
+		{ map( steps, ( { label, url }, stepName ) => (
+			<div key={ stepName } className="steps__summary-entry todo">
+				<a href={ url }>{ label }</a>
+			</div>
+		) ) }
+	</Fragment>
+);
 
 export default localize(
 	connect( ( state, { siteId, siteSlug, siteUrl, translate } ) => {

--- a/client/jetpack-onboarding/steps/summary-todo-links.jsx
+++ b/client/jetpack-onboarding/steps/summary-todo-links.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { map } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -20,41 +21,43 @@ const TodoLinks = steps =>
 		</div>
 	) );
 
-export default connect( ( state, { siteId, siteSlug, siteUrl, translate } ) => {
-	const isConnected = isJetpackSite( state, siteId ); // Will only return true if it's connected to WP.com
-	if ( isConnected ) {
+export default localize(
+	connect( ( state, { siteId, siteSlug, siteUrl, translate } ) => {
+		const isConnected = isJetpackSite( state, siteId ); // Will only return true if it's connected to WP.com
+		if ( isConnected ) {
+			return {
+				THEME: {
+					label: translate( 'Choose a Theme' ),
+					url: '/themes/' + siteSlug,
+				},
+				PAGES: {
+					label: translate( 'Add additional pages' ),
+					url: getEditorNewPostPath( state, siteId, 'page' ),
+				},
+				BLOG: {
+					label: translate( 'Write your first blog post' ),
+					url: getEditorNewPostPath( state, siteId, 'post' ),
+				},
+			};
+		}
+
 		return {
+			JETPACK_CONNECTION: {
+				label: translate( 'Connect to WordPress.com' ),
+				url: '/jetpack/connect?url=' + siteUrl,
+			},
 			THEME: {
 				label: translate( 'Choose a Theme' ),
-				url: '/themes/' + siteSlug,
+				url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
 			},
 			PAGES: {
 				label: translate( 'Add additional pages' ),
-				url: getEditorNewPostPath( state, siteId, 'page' ),
+				url: siteUrl + '/wp-admin/post-new.php?post_type=page',
 			},
 			BLOG: {
 				label: translate( 'Write your first blog post' ),
-				url: getEditorNewPostPath( state, siteId, 'post' ),
+				url: siteUrl + '/wp-admin/post-new.php',
 			},
 		};
-	}
-
-	return {
-		JETPACK_CONNECTION: {
-			label: translate( 'Connect to WordPress.com' ),
-			url: '/jetpack/connect?url=' + siteUrl,
-		},
-		THEME: {
-			label: translate( 'Choose a Theme' ),
-			url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
-		},
-		PAGES: {
-			label: translate( 'Add additional pages' ),
-			url: siteUrl + '/wp-admin/post-new.php?post_type=page',
-		},
-		BLOG: {
-			label: translate( 'Write your first blog post' ),
-			url: siteUrl + '/wp-admin/post-new.php',
-		},
-	};
-} )( TodoLinks );
+	} )( TodoLinks )
+);

--- a/client/jetpack-onboarding/steps/summary-todo-links.jsx
+++ b/client/jetpack-onboarding/steps/summary-todo-links.jsx
@@ -25,7 +25,7 @@ const TodoLinks = steps =>
 export default localize(
 	connect(
 		( state, { siteId, siteSlug, siteUrl, translate } ) => {
-			const isConnected = isJetpackSite( state, siteId ); // Will only return true if it's connected to WP.com
+			const isConnected = isJetpackSite( state, siteId ); // Will only return true if the site is connected to WP.com
 			if ( isConnected ) {
 				return {
 					THEME: {

--- a/client/jetpack-onboarding/steps/summary-todo-links.jsx
+++ b/client/jetpack-onboarding/steps/summary-todo-links.jsx
@@ -12,7 +12,7 @@ import { map } from 'lodash';
  */
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 
-const TodoLinks = ( { steps } ) =>
+const TodoLinks = steps =>
 	map( steps, ( { label, url }, stepName ) => (
 		<div key={ stepName } className="steps__summary-entry todo">
 			<a href={ url }>{ label }</a>
@@ -20,39 +20,35 @@ const TodoLinks = ( { steps } ) =>
 	) );
 
 export const TodoLinksConnected = connect( ( state, { siteId, siteSlug, translate } ) => ( {
-	steps: {
-		THEME: {
-			label: translate( 'Choose a Theme' ),
-			url: '/themes/' + siteSlug,
-		},
-		PAGES: {
-			label: translate( 'Add additional pages' ),
-			url: getEditorNewPostPath( state, siteId, 'page' ),
-		},
-		BLOG: {
-			label: translate( 'Write your first blog post' ),
-			url: getEditorNewPostPath( state, siteId, 'post' ),
-		},
+	THEME: {
+		label: translate( 'Choose a Theme' ),
+		url: '/themes/' + siteSlug,
+	},
+	PAGES: {
+		label: translate( 'Add additional pages' ),
+		url: getEditorNewPostPath( state, siteId, 'page' ),
+	},
+	BLOG: {
+		label: translate( 'Write your first blog post' ),
+		url: getEditorNewPostPath( state, siteId, 'post' ),
 	},
 } ) )( TodoLinks );
 
 export const TodoLinksUnconnected = connect( ( state, { siteUrl, translate } ) => ( {
-	steps: {
-		JETPACK_CONNECTION: {
-			label: translate( 'Connect to WordPress.com' ),
-			url: '/jetpack/connect?url=' + siteUrl,
-		},
-		THEME: {
-			label: translate( 'Choose a Theme' ),
-			url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
-		},
-		PAGES: {
-			label: translate( 'Add additional pages' ),
-			url: siteUrl + '/wp-admin/post-new.php?post_type=page',
-		},
-		BLOG: {
-			label: translate( 'Write your first blog post' ),
-			url: siteUrl + '/wp-admin/post-new.php',
-		},
+	JETPACK_CONNECTION: {
+		label: translate( 'Connect to WordPress.com' ),
+		url: '/jetpack/connect?url=' + siteUrl,
+	},
+	THEME: {
+		label: translate( 'Choose a Theme' ),
+		url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
+	},
+	PAGES: {
+		label: translate( 'Add additional pages' ),
+		url: siteUrl + '/wp-admin/post-new.php?post_type=page',
+	},
+	BLOG: {
+		label: translate( 'Write your first blog post' ),
+		url: siteUrl + '/wp-admin/post-new.php',
 	},
 } ) )( TodoLinks );

--- a/client/jetpack-onboarding/steps/summary-todo-links.jsx
+++ b/client/jetpack-onboarding/steps/summary-todo-links.jsx
@@ -1,0 +1,58 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getEditorNewPostPath } from 'state/ui/editor/selectors';
+
+const TodoLinks = ( { steps } ) =>
+	map( steps, ( { label, url }, stepName ) => (
+		<div key={ stepName } className="steps__summary-entry todo">
+			<a href={ url }>{ label }</a>
+		</div>
+	) );
+
+export const TodoLinksConnected = connect( ( state, { siteId, siteSlug, translate } ) => ( {
+	steps: {
+		THEME: {
+			label: translate( 'Choose a Theme' ),
+			url: '/themes/' + siteSlug,
+		},
+		PAGES: {
+			label: translate( 'Add additional pages' ),
+			url: getEditorNewPostPath( state, siteId, 'page' ),
+		},
+		BLOG: {
+			label: translate( 'Write your first blog post' ),
+			url: getEditorNewPostPath( state, siteId, 'post' ),
+		},
+	},
+} ) )( TodoLinks );
+
+export const TodoLinksUnconnected = connect( ( state, { siteUrl, translate } ) => ( {
+	steps: {
+		JETPACK_CONNECTION: {
+			label: translate( 'Connect to WordPress.com' ),
+			url: '/jetpack/connect?url=' + siteUrl,
+		},
+		THEME: {
+			label: translate( 'Choose a Theme' ),
+			url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
+		},
+		PAGES: {
+			label: translate( 'Add additional pages' ),
+			url: siteUrl + '/wp-admin/post-new.php?post_type=page',
+		},
+		BLOG: {
+			label: translate( 'Write your first blog post' ),
+			url: siteUrl + '/wp-admin/post-new.php',
+		},
+	},
+} ) )( TodoLinks );

--- a/client/jetpack-onboarding/steps/summary-todo-links.jsx
+++ b/client/jetpack-onboarding/steps/summary-todo-links.jsx
@@ -11,6 +11,7 @@ import { map } from 'lodash';
  * Internal dependencies
  */
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 const TodoLinks = steps =>
 	map( steps, ( { label, url }, stepName ) => (
@@ -19,36 +20,41 @@ const TodoLinks = steps =>
 		</div>
 	) );
 
-export const TodoLinksConnected = connect( ( state, { siteId, siteSlug, translate } ) => ( {
-	THEME: {
-		label: translate( 'Choose a Theme' ),
-		url: '/themes/' + siteSlug,
-	},
-	PAGES: {
-		label: translate( 'Add additional pages' ),
-		url: getEditorNewPostPath( state, siteId, 'page' ),
-	},
-	BLOG: {
-		label: translate( 'Write your first blog post' ),
-		url: getEditorNewPostPath( state, siteId, 'post' ),
-	},
-} ) )( TodoLinks );
+export default connect( ( state, { siteId, siteSlug, siteUrl, translate } ) => {
+	const isConnected = isJetpackSite( state, siteId ); // Will only return true if it's connected to WP.com
+	if ( isConnected ) {
+		return {
+			THEME: {
+				label: translate( 'Choose a Theme' ),
+				url: '/themes/' + siteSlug,
+			},
+			PAGES: {
+				label: translate( 'Add additional pages' ),
+				url: getEditorNewPostPath( state, siteId, 'page' ),
+			},
+			BLOG: {
+				label: translate( 'Write your first blog post' ),
+				url: getEditorNewPostPath( state, siteId, 'post' ),
+			},
+		};
+	}
 
-export const TodoLinksUnconnected = connect( ( state, { siteUrl, translate } ) => ( {
-	JETPACK_CONNECTION: {
-		label: translate( 'Connect to WordPress.com' ),
-		url: '/jetpack/connect?url=' + siteUrl,
-	},
-	THEME: {
-		label: translate( 'Choose a Theme' ),
-		url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
-	},
-	PAGES: {
-		label: translate( 'Add additional pages' ),
-		url: siteUrl + '/wp-admin/post-new.php?post_type=page',
-	},
-	BLOG: {
-		label: translate( 'Write your first blog post' ),
-		url: siteUrl + '/wp-admin/post-new.php',
-	},
-} ) )( TodoLinks );
+	return {
+		JETPACK_CONNECTION: {
+			label: translate( 'Connect to WordPress.com' ),
+			url: '/jetpack/connect?url=' + siteUrl,
+		},
+		THEME: {
+			label: translate( 'Choose a Theme' ),
+			url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
+		},
+		PAGES: {
+			label: translate( 'Add additional pages' ),
+			url: siteUrl + '/wp-admin/post-new.php?post_type=page',
+		},
+		BLOG: {
+			label: translate( 'Write your first blog post' ),
+			url: siteUrl + '/wp-admin/post-new.php',
+		},
+	};
+} )( TodoLinks );

--- a/client/jetpack-onboarding/steps/summary-todo-links.jsx
+++ b/client/jetpack-onboarding/steps/summary-todo-links.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
+// We discard all other props in connect() to make sure the component only receives step objects.
 const TodoLinks = steps =>
 	map( steps, ( { label, url }, stepName ) => (
 		<div key={ stepName } className="steps__summary-entry todo">
@@ -22,42 +23,46 @@ const TodoLinks = steps =>
 	) );
 
 export default localize(
-	connect( ( state, { siteId, siteSlug, siteUrl, translate } ) => {
-		const isConnected = isJetpackSite( state, siteId ); // Will only return true if it's connected to WP.com
-		if ( isConnected ) {
+	connect(
+		( state, { siteId, siteSlug, siteUrl, translate } ) => {
+			const isConnected = isJetpackSite( state, siteId ); // Will only return true if it's connected to WP.com
+			if ( isConnected ) {
+				return {
+					THEME: {
+						label: translate( 'Choose a Theme' ),
+						url: '/themes/' + siteSlug,
+					},
+					PAGES: {
+						label: translate( 'Add additional pages' ),
+						url: getEditorNewPostPath( state, siteId, 'page' ),
+					},
+					BLOG: {
+						label: translate( 'Write your first blog post' ),
+						url: getEditorNewPostPath( state, siteId, 'post' ),
+					},
+				};
+			}
+
 			return {
+				JETPACK_CONNECTION: {
+					label: translate( 'Connect to WordPress.com' ),
+					url: '/jetpack/connect?url=' + siteUrl,
+				},
 				THEME: {
 					label: translate( 'Choose a Theme' ),
-					url: '/themes/' + siteSlug,
+					url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
 				},
 				PAGES: {
 					label: translate( 'Add additional pages' ),
-					url: getEditorNewPostPath( state, siteId, 'page' ),
+					url: siteUrl + '/wp-admin/post-new.php?post_type=page',
 				},
 				BLOG: {
 					label: translate( 'Write your first blog post' ),
-					url: getEditorNewPostPath( state, siteId, 'post' ),
+					url: siteUrl + '/wp-admin/post-new.php',
 				},
 			};
-		}
-
-		return {
-			JETPACK_CONNECTION: {
-				label: translate( 'Connect to WordPress.com' ),
-				url: '/jetpack/connect?url=' + siteUrl,
-			},
-			THEME: {
-				label: translate( 'Choose a Theme' ),
-				url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
-			},
-			PAGES: {
-				label: translate( 'Add additional pages' ),
-				url: siteUrl + '/wp-admin/post-new.php?post_type=page',
-			},
-			BLOG: {
-				label: translate( 'Write your first blog post' ),
-				url: siteUrl + '/wp-admin/post-new.php',
-			},
-		};
-	} )( TodoLinks )
+		},
+		null,
+		stateProps => stateProps // Discard ownProps
+	)( TodoLinks )
 );

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -19,13 +19,12 @@ import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySites from 'components/data/query-sites';
 import Spinner from 'components/spinner';
-import { TodoLinksConnected, TodoLinksUnconnected } from './summary-todo-links';
+import TodoLinks from './summary-todo-links';
 import {
 	getJetpackOnboardingPendingSteps,
 	getJetpackOnboardingCompletedSteps,
 	getUnconnectedSiteUrl,
 } from 'state/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
 import {
 	JETPACK_ONBOARDING_STEP_TITLES as STEP_TITLES,
 	JETPACK_ONBOARDING_STEPS as STEPS,
@@ -56,8 +55,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	};
 
 	render() {
-		const { isConnected, siteId, siteSlug, siteUrl, translate } = this.props;
-		const TodoLinksComponent = isConnected ? TodoLinksConnected : TodoLinksUnconnected;
+		const { siteId, siteSlug, siteUrl, translate } = this.props;
 
 		const headerText = translate( "You're ready to go!" );
 		const subHeaderText = translate(
@@ -82,7 +80,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 					</div>
 					<div className="steps__summary-column">
 						<h3 className="steps__summary-heading">{ translate( 'Continue your site setup:' ) }</h3>
-						<TodoLinksComponent
+						<TodoLinks
 							siteId={ siteId }
 							siteSlug={ siteSlug }
 							siteUrl={ siteUrl }
@@ -101,7 +99,6 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 }
 
 export default connect( ( state, { siteId, steps } ) => ( {
-	isConnected: isJetpackSite( state, siteId ), // Will only return true if it's connected to WP.com
 	siteUrl: getUnconnectedSiteUrl( state, siteId ),
 	stepsCompleted: getJetpackOnboardingCompletedSteps( state, siteId, steps ),
 	stepsPending: getJetpackOnboardingPendingSteps( state, siteId, steps ),

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -23,6 +23,7 @@ import {
 	getJetpackOnboardingCompletedSteps,
 	getUnconnectedSiteUrl,
 } from 'state/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import {
 	JETPACK_ONBOARDING_STEP_TITLES as STEP_TITLES,
 	JETPACK_ONBOARDING_STEPS as STEPS,
@@ -120,6 +121,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 }
 
 export default connect( ( state, { siteId, steps } ) => ( {
+	isConnected: isJetpackSite( state, siteId ), // Will only return true if it's connected to WP.com
 	siteUrl: getUnconnectedSiteUrl( state, siteId ),
 	stepsCompleted: getJetpackOnboardingCompletedSteps( state, siteId, steps ),
 	stepsPending: getJetpackOnboardingPendingSteps( state, siteId, steps ),

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -19,6 +19,7 @@ import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySites from 'components/data/query-sites';
 import Spinner from 'components/spinner';
+import { TodoLinksConnected, TodoLinksUnconnected } from './summary-todo-links';
 import {
 	getJetpackOnboardingPendingSteps,
 	getJetpackOnboardingCompletedSteps,
@@ -54,55 +55,9 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 		} );
 	};
 
-	renderTodo = () => {
-		const { isConnected, siteUrl, translate } = this.props;
-
-		const stepsTodoUnconnected = {
-			JETPACK_CONNECTION: {
-				label: translate( 'Connect to WordPress.com' ),
-				url: '/jetpack/connect?url=' + siteUrl,
-			},
-			THEME: {
-				label: translate( 'Choose a Theme' ),
-				url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
-			},
-			PAGES: {
-				label: translate( 'Add additional pages' ),
-				url: siteUrl + '/wp-admin/post-new.php?post_type=page',
-			},
-			BLOG: {
-				label: translate( 'Write your first blog post' ),
-				url: siteUrl + '/wp-admin/post-new.php',
-			},
-		};
-
-		// TODO: Point to Calypso
-		const stepsTodoConnected = {
-			THEME: {
-				label: translate( 'Choose a Theme' ),
-				url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
-			},
-			PAGES: {
-				label: translate( 'Add additional pages' ),
-				url: siteUrl + '/wp-admin/post-new.php?post_type=page',
-			},
-			BLOG: {
-				label: translate( 'Write your first blog post' ),
-				url: siteUrl + '/wp-admin/post-new.php',
-			},
-		};
-
-		const stepsTodo = isConnected ? stepsTodoConnected : stepsTodoUnconnected;
-
-		return map( stepsTodo, ( { label, url }, stepName ) => (
-			<div key={ stepName } className="steps__summary-entry todo">
-				<a href={ url }>{ label }</a>
-			</div>
-		) );
-	};
-
 	render() {
-		const { siteId, siteUrl, translate } = this.props;
+		const { isConnected, siteId, siteSlug, siteUrl, translate } = this.props;
+		const TodoLinksComponent = isConnected ? TodoLinksConnected : TodoLinksUnconnected;
 
 		const headerText = translate( "You're ready to go!" );
 		const subHeaderText = translate(
@@ -127,7 +82,12 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 					</div>
 					<div className="steps__summary-column">
 						<h3 className="steps__summary-heading">{ translate( 'Continue your site setup:' ) }</h3>
-						{ this.renderTodo() }
+						<TodoLinksComponent
+							siteId={ siteId }
+							siteSlug={ siteSlug }
+							siteUrl={ siteUrl }
+							translate={ translate }
+						/>
 					</div>
 				</div>
 				<div className="steps__button-group">

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -17,6 +17,7 @@ import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QuerySites from 'components/data/query-sites';
 import Spinner from 'components/spinner';
 import {
 	getJetpackOnboardingPendingSteps,
@@ -101,7 +102,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	};
 
 	render() {
-		const { siteUrl, translate } = this.props;
+		const { siteId, siteUrl, translate } = this.props;
 
 		const headerText = translate( "You're ready to go!" );
 		const subHeaderText = translate(
@@ -117,6 +118,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 					title="Summary ‹ Jetpack Onboarding"
 				/>
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+				<QuerySites siteId={ siteId } />
 
 				<div className="steps__summary-columns">
 					<div className="steps__summary-column">

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -17,7 +17,6 @@ import Button from 'components/button';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QuerySites from 'components/data/query-sites';
 import Spinner from 'components/spinner';
 import NextSteps from './summary-next-steps';
 import {
@@ -71,7 +70,6 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 					title="Summary ‹ Jetpack Onboarding"
 				/>
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
-				<QuerySites siteId={ siteId } />
 
 				<div className="steps__summary-columns">
 					<div className="steps__summary-column">

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -54,7 +54,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	};
 
 	renderTodo = () => {
-		const { siteUrl, translate } = this.props;
+		const { isConnected, siteUrl, translate } = this.props;
 
 		const stepsTodoUnconnected = {
 			JETPACK_CONNECTION: {
@@ -75,7 +75,25 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 			},
 		};
 
-		return map( stepsTodoUnconnected, ( { label, url }, stepName ) => (
+		// TODO: Point to Calypso
+		const stepsTodoConnected = {
+			THEME: {
+				label: translate( 'Choose a Theme' ),
+				url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
+			},
+			PAGES: {
+				label: translate( 'Add additional pages' ),
+				url: siteUrl + '/wp-admin/post-new.php?post_type=page',
+			},
+			BLOG: {
+				label: translate( 'Write your first blog post' ),
+				url: siteUrl + '/wp-admin/post-new.php',
+			},
+		};
+
+		const stepsTodo = isConnected ? stepsTodoConnected : stepsTodoUnconnected;
+
+		return map( stepsTodo, ( { label, url }, stepName ) => (
 			<div key={ stepName } className="steps__summary-entry todo">
 				<a href={ url }>{ label }</a>
 			</div>

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -56,7 +56,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	renderTodo = () => {
 		const { siteUrl, translate } = this.props;
 
-		const stepsTodo = {
+		const stepsTodoUnconnected = {
 			JETPACK_CONNECTION: {
 				label: translate( 'Connect to WordPress.com' ),
 				url: '/jetpack/connect?url=' + siteUrl,
@@ -75,7 +75,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 			},
 		};
 
-		return map( stepsTodo, ( { label, url }, stepName ) => (
+		return map( stepsTodoUnconnected, ( { label, url }, stepName ) => (
 			<div key={ stepName } className="steps__summary-entry todo">
 				<a href={ url }>{ label }</a>
 			</div>

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -19,7 +19,7 @@ import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySites from 'components/data/query-sites';
 import Spinner from 'components/spinner';
-import TodoLinks from './summary-todo-links';
+import NextSteps from './summary-next-steps';
 import {
 	getJetpackOnboardingPendingSteps,
 	getJetpackOnboardingCompletedSteps,
@@ -80,7 +80,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 					</div>
 					<div className="steps__summary-column">
 						<h3 className="steps__summary-heading">{ translate( 'Continue your site setup:' ) }</h3>
-						<TodoLinks siteId={ siteId } siteSlug={ siteSlug } siteUrl={ siteUrl } />
+						<NextSteps siteId={ siteId } siteSlug={ siteSlug } siteUrl={ siteUrl } />
 					</div>
 				</div>
 				<div className="steps__button-group">

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -80,12 +80,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 					</div>
 					<div className="steps__summary-column">
 						<h3 className="steps__summary-heading">{ translate( 'Continue your site setup:' ) }</h3>
-						<TodoLinks
-							siteId={ siteId }
-							siteSlug={ siteSlug }
-							siteUrl={ siteUrl }
-							translate={ translate }
-						/>
+						<TodoLinks siteId={ siteId } siteSlug={ siteSlug } siteUrl={ siteUrl } />
 					</div>
 				</div>
 				<div className="steps__button-group">


### PR DESCRIPTION
Follow-up to #21723. Fixes #21681.

![image](https://user-images.githubusercontent.com/96308/35859393-d444f6aa-0b37-11e8-9e09-27e425f0a155.png)

To test:
* Make sure your JP sandbox isn't connected.
* Go thru the JPO flow.
* Verify that the links in the right column on the summary page are the same as before, and that they work.
* Click 'Connect to WordPress.com'.
* Go thru the JPO flow again.
* Verify that this time, the 'Connect to WordPress.com' link is gone, and that the other three links point to the Calypso theme showcase, the 'New Page', and the 'New Post' screens, respectively.