### PR TITLE
Jetpack Connect: Force mobile app flow login *after* activate

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -180,7 +180,7 @@ export function signupForm( context, next ) {
 
 	const isLoggedIn = !! getCurrentUserId( context.store.getState() );
 	if ( retrieveMobileRedirect() && ! isLoggedIn ) {
-		// Force login for mobile app flow. App will this request and prompt native login.
+		// Force login for mobile app flow. App will intercept this request and prompt native login.
 		return window.location.replace( login( { isNative: true, redirectTo: context.path } ) );
 	}
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -158,12 +158,6 @@ export function connect( context, next ) {
 
 	debug( 'entered connect flow with params %o', params );
 
-	const isLoggedIn = !! getCurrentUserId( context.store.getState() );
-	if ( retrieveMobileRedirect() && ! isLoggedIn ) {
-		// Force login for mobile app flow. App will intercept and prompt native login.
-		return page.redirect( login( { isNative: true, redirectTo: context.path } ) );
-	}
-
 	const planSlug = getPlanSlugFromFlowType( type, interval );
 	planSlug && storePlan( planSlug );
 
@@ -183,6 +177,12 @@ export function connect( context, next ) {
 
 export function signupForm( context, next ) {
 	analytics.pageView.record( 'jetpack/connect/authorize', 'Jetpack Authorize' );
+
+	const isLoggedIn = !! getCurrentUserId( context.store.getState() );
+	if ( retrieveMobileRedirect() && ! isLoggedIn ) {
+		// Force login for mobile app flow. App will this request and prompt native login.
+		return window.location.replace( login( { isNative: true, redirectTo: context.path } ) );
+	}
 
 	removeSidebar( context );
 


### PR DESCRIPTION
Tweak the mobile flow so that the redirect to the login form does not occur until after plugin install/activate, to match the regular flow. Effectively we are replacing the signup-form with a server request for the log-in form, which the mobile app will intercept to show a native log-in form instead.

Previously we were forcing login on arrival for the mobile app, which differed from the regular flow.

## Testing
* Logged-out, start the mobile connection flow with a url such as:
`http://calypso.localhost:3000/jetpack/connect?url=http://amused-aardvark-154.jurassic.ninja&&mobile_redirect=wordpress://jetpack-connection`
* If jetpack is not already activated on the site, the /log-in page will not appear until you have activated the plugin
* (When arriving back at Calypso from wp-admin, it will be necessary to replace `https://wordpress.com` with `http://calypso.localhost:3000` to continue testing this branch.

/cc @koke 