### PR TITLE
Update Jetpack Premium plan

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -20,7 +20,7 @@ import SearchPreview from 'components/seo/search-preview';
 import VerticalMenu from 'components/vertical-menu';
 import PostMetadata from 'lib/post-metadata';
 import { formatExcerpt } from 'lib/post-normalizer/rule-create-better-excerpt';
-import { isBusiness, isEnterprise } from 'lib/products-values';
+import { isBusiness, isEnterprise, isJetpackPremium } from 'lib/products-values';
 import { parseHtml } from 'lib/formatting';
 import { SocialItem } from 'components/vertical-menu/items';
 import { getEditorPostId } from 'state/ui/editor/selectors';
@@ -30,7 +30,7 @@ import { getSectionName, getSelectedSite } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 const PREVIEW_IMAGE_WIDTH = 512;
-const hasBusinessPlan = overSome( isBusiness, isEnterprise );
+const hasSupportingPlan = overSome( isBusiness, isEnterprise, isJetpackPremium );
 
 const largeBlavatar = site => {
 	const siteIcon = get( site, 'icon.img' );
@@ -264,7 +264,7 @@ const mapStateToProps = state => {
 			...post,
 			seoTitle: getSeoTitle( state, 'posts', { site, post } ),
 		},
-		showNudge: site && site.plan && ! hasBusinessPlan( site.plan ),
+		showNudge: site && site.plan && ! hasSupportingPlan( site.plan ),
 	};
 };
 

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -457,15 +457,17 @@ export const PLANS_LIST = {
 				isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 				isEnabled( 'simple-payments' ) && FEATURE_SIMPLE_PAYMENTS,
 				FEATURE_WORDADS_INSTANT,
-				FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
+				FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 				FEATURE_MALWARE_SCANNING_DAILY,
+				FEATURE_ADVANCED_SEO,
+				FEATURE_GOOGLE_ANALYTICS,
 			] ),
 		getSignupFeatures: () =>
 			compact( [
 				FEATURE_MALWARE_SCANNING_DAILY,
 				FEATURE_MARKETING_AUTOMATION,
 				FEATURE_WORDADS_INSTANT,
-				FEATURE_VIDEO_CDN_LIMITED,
+				FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 				FEATURE_ALL_PERSONAL_FEATURES,
 			] ),
 		getBillingTimeFrame: () => i18n.translate( 'per year' ),
@@ -502,15 +504,17 @@ export const PLANS_LIST = {
 				isEnabled( 'republicize' ) && FEATURE_REPUBLICIZE,
 				isEnabled( 'simple-payments' ) && FEATURE_SIMPLE_PAYMENTS,
 				FEATURE_WORDADS_INSTANT,
-				FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM,
+				FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 				FEATURE_MALWARE_SCANNING_DAILY,
+				FEATURE_ADVANCED_SEO,
+				FEATURE_GOOGLE_ANALYTICS,
 			] ),
 		getSignupFeatures: () =>
 			compact( [
 				FEATURE_MALWARE_SCANNING_DAILY,
 				FEATURE_MARKETING_AUTOMATION,
 				FEATURE_WORDADS_INSTANT,
-				FEATURE_VIDEO_CDN_LIMITED,
+				FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 				FEATURE_ALL_PERSONAL_FEATURES,
 			] ),
 		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
@@ -917,7 +921,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_VIDEO_UPLOADS_JETPACK_PRO ]: {
 		getSlug: () => FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
-		getTitle: () => i18n.translate( 'VideoPress Support' ),
+		getTitle: () => i18n.translate( 'Unlimited Video Hosting' ),
 		getDescription: () =>
 			i18n.translate(
 				'The easiest way to upload videos to your website and display them ' +

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -40,7 +40,7 @@ import { toApi as seoTitleToApi } from 'components/seo/meta-title-editor/mapping
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestSite } from 'state/sites/actions';
 import { activateModule } from 'state/jetpack/modules/actions';
-import { isBusiness, isEnterprise, isJetpackBusiness } from 'lib/products-values';
+import { isBusiness, isEnterprise, isJetpackBusiness, isJetpackPremium } from 'lib/products-values';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { getPlugins } from 'state/plugins/installed/selectors';
 import {
@@ -60,7 +60,7 @@ import { getFirstConflictingPlugin } from 'lib/seo';
 // Not perfect but meets the needs of this component well
 const anyHtmlTag = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
 
-const hasBusinessPlan = overSome( isBusiness, isEnterprise, isJetpackBusiness );
+const hasSupportingPlan = overSome( isBusiness, isEnterprise, isJetpackBusiness, isJetpackPremium );
 
 function getGeneralTabUrl( slug ) {
 	return `/settings/general/${ slug }`;
@@ -320,7 +320,7 @@ export class SeoForm extends React.Component {
 				{ siteIsJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				<PageViewTracker path="/settings/seo/:site" title="Site Settings > SEO" />
 				{ ( isSitePrivate || isSiteHidden ) &&
-					hasBusinessPlan( site.plan ) && (
+					hasSupportingPlan( site.plan ) && (
 						<Notice
 							status="is-warning"
 							showDismiss={ false }
@@ -363,7 +363,7 @@ export class SeoForm extends React.Component {
 					</Notice>
 				) }
 				{ siteIsJetpack &&
-					hasBusinessPlan( site.plan ) &&
+					hasSupportingPlan( site.plan ) &&
 					isSeoToolsActive === false && (
 						<Notice
 							status="is-warning"
@@ -482,7 +482,7 @@ export class SeoForm extends React.Component {
 const mapStateToProps = ( state, ownProps ) => {
 	const { site } = ownProps;
 	// SEO Tools are available with Business plan on WordPress.com, and with Premium plan on Jetpack sites
-	const isAdvancedSeoEligible = site && site.plan && hasBusinessPlan( site.plan );
+	const isAdvancedSeoEligible = site && site.plan && hasSupportingPlan( site.plan );
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
 	const jetpackVersionSupportsSeo = isJetpackMinimumVersion( state, siteId, '4.4-beta1' );


### PR DESCRIPTION
We are improving the feature matrix for the Jetpack Premium plan to include unlimited video hosting and also access to the SEO Tools. These were previously only available in the Jetpack Professional plan.

Testing:

1. the new features show up in the Plans route for a Jetpack site.
2. for a site on the Jetpack Premium plan: 1) "Search and Social" shows up in the preview dropdown of a post preview, 2) The following sections appear and are enabled under Settings → Traffic: Page Title Structure, Website Meta, and Google Analytics.

The updates for unlimited video storage will happen on the server side, so nothing to test there outside of the plans page as that switch will be flipped elsewhere.