### PR TITLE
Special case for inserting media when text is selected (#15033)

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -27,6 +27,7 @@ import EditorMediaModal from 'post-editor/editor-media-modal';
 import notices from 'notices';
 import TinyMCEDropZone from './drop-zone';
 import restrictSize from './restrict-size';
+import { insertMediaAsLink, insertMedia } from './utils';
 import advanced from './advanced';
 import config from 'config';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -57,10 +58,6 @@ function mediaButton( editor ) {
 		updateMedia; // eslint-disable-line
 
 	const getSelectedSiteFromState = () => getSelectedSite( getState() );
-
-	function insertMedia( markup ) {
-		editor.execCommand( 'mceInsertContent', false, markup );
-	}
 
 	function renderModal( props = {}, options = {} ) {
 		const selectedSite = getSelectedSiteFromState();
@@ -94,8 +91,13 @@ function mediaButton( editor ) {
 				/* eslint-disable react/jsx-no-bind */
 				onClose={ renderModal.bind( null, { visible: false } ) }
 				/* eslint-disable react/jsx-no-bind */
-				onInsertMedia={ markup => {
-					insertMedia( markup );
+				onInsertMedia={ ( markup, media ) => {
+					const selectedText = editor.selection.getContent( { format: 'text' } );
+					if ( media.length === 1 && selectedText ) {
+						insertMediaAsLink( editor, media[ 0 ] );
+					} else {
+						insertMedia( editor, markup );
+					}
 					renderModal( { visible: false } );
 				} }
 			/>,

--- a/client/components/tinymce/plugins/media/test/utils.js
+++ b/client/components/tinymce/plugins/media/test/utils.js
@@ -1,0 +1,37 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { insertMediaAsLink } from '../utils';
+
+describe( 'Media button commands', () => {
+	let editor, media;
+
+	beforeAll( () => {
+		media = {
+			URL: '/puppy.gif',
+			title: 'When I use " I cause mischief.',
+		};
+		editor = { execCommand: spy() };
+	} );
+
+	describe( '#insertMediaAsLink()', () => {
+		test( 'title is escaped', () => {
+			insertMediaAsLink( editor, media );
+			expect(
+				editor.execCommand.args[ 0 ][ 2 ].indexOf( '"When I use &quot; I cause mischief."' ) > -1
+			).to.be.true;
+		} );
+		test( 'selection is text of link', () => {
+			insertMediaAsLink( editor, media );
+			expect( editor.execCommand.args[ 0 ][ 2 ].indexOf( '>{$selection}<' ) > -1 ).to.be.true;
+		} );
+	} );
+} );

--- a/client/components/tinymce/plugins/media/utils.js
+++ b/client/components/tinymce/plugins/media/utils.js
@@ -1,0 +1,16 @@
+/** @format */
+
+export function insertMediaAsLink( editor, media ) {
+	const mediaUrl = media.URL;
+	const title = media.title.replace( /"/g, '&quot;' );
+	editor.execCommand(
+		'mceReplaceContent',
+		false,
+		`<a href="${ mediaUrl }"
+			title="${ title }">{$selection}</a>`
+	);
+}
+
+export function insertMedia( editor, markup ) {
+	editor.execCommand( 'mceInsertContent', false, markup );
+}

--- a/client/post-editor/editor-media-modal/index.jsx
+++ b/client/post-editor/editor-media-modal/index.jsx
@@ -60,7 +60,7 @@ class EditorMediaModal extends Component {
 		}
 
 		if ( media ) {
-			this.props.onInsertMedia( media );
+			this.props.onInsertMedia( media, items );
 
 			if ( stat ) {
 				this.props.bumpStat( 'editor_media_actions', stat );


### PR DESCRIPTION
If some text has been selected and only one media item is selected
exec the replaceContent command in tinymce.

Changes:
* The onInsertMedia function callback now takes a second parameter
- the raw list of media. This allows other uses to simply embedding the
media item in the article post.
* Split out execCommand commands from TinyMCE media  plugin into separate module to allow testing
to ensure title attributes are properly escaped