### PR TITLE
Rewind Credentials: Load extra credentials fields into state

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -10,7 +10,15 @@ const transformCredential = data =>
 		{
 			type: data.type,
 		},
-		data.host && { host: data.host, port: data.port }
+		data.role && { role: data.role },
+		data.host && { host: data.host },
+		data.port && { port: data.port },
+		data.user && { user: data.user },
+		'undefined' !== typeof data.password && { password: data.password },
+		data.abspath && { abspath: data.abspath },
+		'undefined' !== typeof data.kpri && { kpri: data.kpri },
+		data.baseUrl && { baseUrl: data.baseUrl },
+		data.maxConcurrent && { maxConcurrent: data.maxConcurrent }
 	);
 
 const transformDownload = data =>

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -5,10 +5,17 @@ export const credential = {
 	properties: {
 		still_valid: { type: 'boolean' },
 		type: { type: 'string', enum: [ 'auto', 'ftp', 'sftp', 'ssh' ] },
+		role: { type: 'string' },
 		host: { type: 'string' },
 		port: { type: 'integer' },
+		user: { type: 'string' },
+		password: { type: 'boolean' },
+		abspath: { type: 'string' },
+		kpri: { type: 'boolean' },
+		baseUrl: { type: 'string' },
+		maxConcurrent: { type: 'integer' },
 	},
-	required: [ 'still_valid', 'type' ],
+	required: [ 'still_valid', 'type', 'role' ],
 };
 
 export const download = {


### PR DESCRIPTION
The credentials objects stored in redux state are not complete. When used in conjunction with D9431, this PR adds the additional fields from the API into state.

**Testing**
1. Apply D9431-wpcom
2. Load up the Activity Log for a site with credentials set and drop `state.rewind[ state.ui.selectedSiteId ].credentials[0]` into your console.
3. Ensure the resulting object contains all of the fields needed for a full credentials object as represented in D9431.
4. Just for good measure, attempt to save, view, and delete credentials from the settings interface.