### PR TITLE
Store: Remove country testing from segmented sign up flow

### DIFF
--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { includes, invoke, noop, findKey } from 'lodash';
+import { invoke, noop, findKey } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -28,9 +28,6 @@ import { getSurveyVertical } from 'state/signup/steps/survey/selectors';
 import { hints } from 'lib/signup/hint-data';
 import userFactory from 'lib/user';
 const user = userFactory();
-import { getCurrentUserCountryCode } from 'state/current-user/selectors';
-import { getGeoCountryShort } from 'state/geo/selectors';
-import QueryGeo from 'components/data/query-geo';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import PressableStoreStep from '../design-type-with-store/pressable-store';
 import { abtest } from 'lib/abtest';
@@ -318,17 +315,13 @@ class AboutStep extends Component {
 		}
 
 		//Store
-		const isCountryAllowed =
-			includes( [ 'US', 'CA' ], this.props.countryCode ) || process.env.NODE_ENV === 'development';
 		const nextFlowName =
-			designType === DESIGN_TYPE_STORE && isCountryAllowed
-				? 'segmented-store-nux'
-				: this.props.flowName;
+			designType === DESIGN_TYPE_STORE ? 'segmented-store-nux' : this.props.flowName;
 
 		//Pressable
 		if (
 			designType === DESIGN_TYPE_STORE &&
-			( abtest( 'signupAtomicStoreVsPressable' ) === 'pressable' || ! isCountryAllowed )
+			abtest( 'signupAtomicStoreVsPressable' ) === 'pressable'
 		) {
 			this.scrollUp();
 
@@ -527,7 +520,6 @@ class AboutStep extends Component {
 
 		return (
 			<div className="about__wrapper">
-				<QueryGeo />
 				<div className={ pressableWrapperClassName }>
 					<PressableStoreStep
 						{ ...this.props }
@@ -618,7 +610,6 @@ export default connect(
 		siteGoals: getSiteGoals( state ),
 		siteTopic: getSurveyVertical( state ),
 		userExperience: getUserExperience( state ),
-		countryCode: getCurrentUserCountryCode( state ) || getGeoCountryShort( state ),
 	} ),
 	{ setSiteTitle, setDesignType, setSiteGoals, setSurvey, setUserExperience, recordTracksEvent }
 )( localize( AboutStep ) );


### PR DESCRIPTION
Fixes #21569 

To test:
* Open an incognito window
* Navigate to http://calypso.localhost:3000/start
* You'll probably be redirected to http://calypso.localhost:3000/start/design-type-with-store-nux
* Hover over the DEV widget in the bottom right of the calypso window
* Slide left to AB TESTS and then left and then up to signupSiteSegmentStep
* Click on variant
* Verify you are redirected to http://calypso.localhost:3000/start/about
* Navigate to http://calypso.localhost:3000/start
* Verify you are redirected to http://calypso.localhost:3000/start/about
* Give your site a name (e.g. ALLENDAV20180122)
* Check "Sell products or collect payments" and nothing else
* Click on Continue
* Verify you are prompted to "Choose a Store Theme"
* That's as far as you need to go - you're good.
