### PR TITLE
Sites: fetch single site on direct navigation

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -12,13 +12,14 @@ import { noop, some, startsWith, uniq } from 'lodash';
  */
 import { SITES_ONCE_CHANGED } from 'state/action-types';
 import userFactory from 'lib/user';
-import { receiveSite, requestSites } from 'state/sites/actions';
+import { receiveSite, requestSites, requestSite } from 'state/sites/actions';
 import {
 	getSite,
 	getSiteSlug,
 	isJetpackModuleActive,
 	isJetpackSite,
 	isRequestingSites,
+	isRequestingSite,
 } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { setSelectedSiteId, setSection, setAllSitesSelected } from 'state/ui/actions';
@@ -381,9 +382,20 @@ export function siteSelection( context, next ) {
 			return;
 		}
 	} else {
+		// Fetch the site from siteFragment.
+		dispatch( requestSite( siteFragment ) ).then( () => {
+			const initialSiteId = getSiteId( getState(), siteFragment );
+
+			dispatch( setSelectedSiteId( initialSiteId ) );
+
+			if ( getSite( getState(), initialSiteId ) ) {
+				onSelectedSiteAvailable( context );
+			}
+		} );
+
 		// if sites has fresh data and siteId is invalid
 		// redirect to allSitesPath
-		if ( ! isRequestingSites( getState() ) ) {
+		if ( ! isRequestingSites( getState() ) && ! isRequestingSite( getState(), siteFragment ) ) {
 			return page.redirect( allSitesPath );
 		}
 

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -110,30 +110,30 @@ export function requestSites() {
  * Returns a function which, when invoked, triggers a network request to fetch
  * a site.
  *
- * @param  {Number}   siteId Site ID
- * @return {Function}        Action thunk
+ * @param  {Number}   siteFragment Site ID or slug
+ * @return {Function}              Action thunk
  */
-export function requestSite( siteId ) {
+export function requestSite( siteFragment ) {
 	return dispatch => {
 		dispatch( {
 			type: SITE_REQUEST,
-			siteId,
+			siteId: siteFragment,
 		} );
 
 		return wpcom
-			.site( siteId )
+			.site( siteFragment )
 			.get()
 			.then( site => {
 				dispatch( receiveSite( omit( site, '_headers' ) ) );
 				dispatch( {
 					type: SITE_REQUEST_SUCCESS,
-					siteId,
+					siteId: siteFragment,
 				} );
 			} )
 			.catch( error => {
 				dispatch( {
 					type: SITE_REQUEST_FAILURE,
-					siteId,
+					siteId: siteFragment,
 					error,
 				} );
 			} );


### PR DESCRIPTION
To improve the speed of initial Calypso load (with no local state) when navigated to a site directly (ie `/pages/lamosty.com`), we can pre-fetch the single site before loading all the sites so our customers can work with the site straight away.

The main blocker to this undertaking is resolving site conflicts/collisions: what if a customer has two sites with the same custom URL (e.g. a Jetpack and a WP.com site)? Calypso [solves it](https://github.com/Automattic/wp-calypso/blob/master/client/state/sites/selectors.js#L132) by looking into the list of all sites and preferring the Jetpack one if multiple sites share the same custom URL. The problem is that Calypso can't do that without the list of all sites.

Fortunately, when requesting `/sites/siteFragment`, the WP.com backend does the same thing: tries to get the JP site first and only if not found, looks for a WP.com site. If this situation happens, the WP.com backend also adds the `is_redirect` site option to the WP.com site. That, in turn, [makes](https://github.com/Automattic/wp-calypso/blob/master/client/state/sites/selectors.js#L247) Calypso use the unmapped URL (`.wordpress.com`) for the WP.com site and the custom one for the Jetpack site.

All in all, a JP site is always favored when a collision occurs. More info: p58i-6Ru-p2

## Testing

Clear local state and navigate to a site directly. Observe how it's loaded and selected immediately, without having to wait for all sites to load.

If possible, try to create a site collision by first buying a WP.com site with a custom domain and then reusing the domain for a JP site. Connect the JP site and see whether Calypso prefers the JP site when navigated to it directly.