### PR TITLE
When making follow requests via /sites/%s/follows/new set the source of the follow.

### DIFF
--- a/client/lib/follow-list/site.js
+++ b/client/lib/follow-list/site.js
@@ -64,7 +64,7 @@ FollowListSite.prototype.unfollow = function() {
 		wpcom
 			.site( this.site_id )
 			.follow()
-			.del( function( resp ) {
+			.del( { source: config( 'readerFollowingSource' ) }, function( resp ) {
 				debug( 'unfollow success', resp );
 			} );
 	}

--- a/client/lib/follow-list/site.js
+++ b/client/lib/follow-list/site.js
@@ -11,6 +11,7 @@ const debug = debugFactory( 'calypso:follow-list:site' );
 /**
  * Internal dependencies
  */
+import config from 'config';
 import wpcom from 'lib/wp';
 import Emitter from 'lib/mixins/emitter';
 
@@ -46,7 +47,7 @@ FollowListSite.prototype.follow = function() {
 		wpcom
 			.site( this.site_id )
 			.follow()
-			.add( function( resp ) {
+			.add( { source: config( 'readerFollowingSource' ) }, function( resp ) {
 				debug( 'follow success', resp );
 			} );
 	}

--- a/client/lib/follow-list/test/mocks/lib/wp.js
+++ b/client/lib/follow-list/test/mocks/lib/wp.js
@@ -8,7 +8,7 @@ const endpoints = [ 'add', 'del' ];
  **/
 const successRequestStub = function() {
 	const args = Array.prototype.slice.call( arguments );
-	args[ 0 ].apply( undefined, [ null, { some: 'data' } ] );
+	args[ 1 ].apply( undefined, [ null, { some: 'data' } ] );
 };
 
 export default {


### PR DESCRIPTION
When you follow a site from the stats pages we don't pass in the source of the follow to the API so they can't be correctlt attributed to calypso or the desktop app.