### PR TITLE
Store: Fix product categories description box and unsaved edits prompt on delete

### DIFF
--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -9,17 +9,17 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import { debounce, isNumber, head, isNull } from 'lodash';
+import { isNumber, head, isNull } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
 import Card from 'components/card';
-import CompactTinyMCE from 'woocommerce/components/compact-tinymce';
 import FormFieldSet from 'components/forms/form-fieldset';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
+import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 import ImagePreloader from 'components/image-preloader';
 import ProductImageUploader from 'woocommerce/components/product-image-uploader';
@@ -56,8 +56,6 @@ class ProductCategoryForm extends Component {
 			selectedParent,
 			isTopLevel,
 		};
-
-		this.debouncedSetDescription = debounce( this.setDescription, 200 );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -92,9 +90,9 @@ class ProductCategoryForm extends Component {
 		editProductCategory( siteId, category, { name } );
 	};
 
-	setDescription = description => {
+	setDescription = event => {
 		const { siteId, category, editProductCategory } = this.props;
-		editProductCategory( siteId, category, { description } );
+		editProductCategory( siteId, category, { description: event.target.value } );
 	};
 
 	setParent = parent => {
@@ -229,24 +227,6 @@ class ProductCategoryForm extends Component {
 		);
 	}
 
-	renderTinyMCE() {
-		const { category } = this.props;
-
-		if (
-			( isNumber( category.id ) && 'undefined' === typeof category.description ) ||
-			'undefined' === typeof category.id
-		) {
-			return <div className="product-categories__form-tinymce-placeholder" />;
-		}
-
-		return (
-			<CompactTinyMCE
-				initialValue={ category.description || '' }
-				onContentsChange={ this.debouncedSetDescription }
-			/>
-		);
-	}
-
 	render() {
 		const { siteId, category, translate } = this.props;
 		const { search, selectedParent, isTopLevel } = this.state;
@@ -274,7 +254,11 @@ class ProductCategoryForm extends Component {
 							</FormFieldSet>
 							<FormFieldSet>
 								<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
-								{ this.renderTinyMCE() }
+								<FormTextarea
+									id="description"
+									value={ category.description || '' }
+									onChange={ this.setDescription }
+								/>
 							</FormFieldSet>
 							<FormFieldSet>
 								<FormLabel>

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -108,17 +108,6 @@
 	}
 }
 
-.product-categories__form-tinymce-placeholder {
-	@include placeholder();
-	background: lighten( $gray, 35% );
-	height: 225px;
-	border: 1px solid lighten( $gray, 20% );
-}
-
-.product-categories__form .compact-tinymce  .mce-container.mce-tinymce {
-	max-width: initial;
-}
-
 .product-categories__form-info-fields {
 	display: flex;
 	flex-direction: column;

--- a/client/extensions/woocommerce/app/product-categories/update.js
+++ b/client/extensions/woocommerce/app/product-categories/update.js
@@ -101,7 +101,13 @@ class ProductCategoryUpdate extends React.Component {
 	};
 
 	onDelete = () => {
-		const { translate, site, category, deleteProductCategory: dispatchDelete } = this.props;
+		const {
+			translate,
+			site,
+			category,
+			deleteProductCategory: dispatchDelete,
+			clearProductCategoryEdits: clearEdits,
+		} = this.props;
 		const areYouSure = translate( "Are you sure you want to permanently delete '%(name)s'?", {
 			args: { name: category.name },
 		} );
@@ -109,6 +115,9 @@ class ProductCategoryUpdate extends React.Component {
 			if ( ! accepted ) {
 				return;
 			}
+
+			clearEdits( site.ID );
+
 			const successAction = () => {
 				debounce( () => {
 					page.redirect( getLink( '/store/products/categories/:site/', site ) );

--- a/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-additional-details-card.js
@@ -58,7 +58,7 @@ class ProductFormAdditionalDetailsCard extends Component {
 
 	addAttribute = () => {
 		const { siteId, product, editProductAttribute } = this.props;
-		editProductAttribute( siteId, product, null, { name: '', options: [] } );
+		editProductAttribute( siteId, product, null, { name: '', options: [], visible: true } );
 	};
 
 	cardOpen = () => {
@@ -94,7 +94,7 @@ class ProductFormAdditionalDetailsCard extends Component {
 
 	updateValues = ( values, attribute ) => {
 		const { siteId, product, editProductAttribute } = this.props;
-		editProductAttribute( siteId, product, attribute, { options: values } );
+		editProductAttribute( siteId, product, attribute, { options: values, visible: true } );
 	};
 
 	updateNameHandler = e => {


### PR DESCRIPTION
This PR fixes the two larger issues reported in the call for testing thread (see p90Yrv-vr-p2):

* Product category description don't support most HTML (including <br /> or paragraph tags) making TinyMCE virtually useless since styles get dropped. This PR uses a simple textarea for descriptions now. 
* Edits are cleared out after a delete as been confirmed, so that if you delete a category that you made a couple unsaved edits to, you aren't stuck on the page because of the prompt.
* It also fixes a reported issue with attributes, where we are missing a 'visible' flag to make them visible on the product page.

To Test:
* Edit and create categories and type in a description. Test multi-line descriptions.
* Open an existing category, make an edit, hit delete, and then confirm you want to delete. Make sure you are redirected off of the page.
* Edit/Create a product and click "add additional details". Create an attribute, publish the product, and make sure it is visible on the product page.