### PR TITLE
Store Orders: Update `isOrderEditable` to consider any new order “editable”

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/index.js
+++ b/client/extensions/woocommerce/app/order/order-details/index.js
@@ -72,7 +72,7 @@ class OrderDetails extends Component {
 				<OrderDetailsTable
 					order={ order }
 					site={ site }
-					isEditing={ isOrderEditable( order.status ) }
+					isEditing={ isOrderEditable( order ) }
 					onChange={ this.updateOrder }
 				/>
 			);

--- a/client/extensions/woocommerce/lib/order-status/index.js
+++ b/client/extensions/woocommerce/lib/order-status/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
+import { isObject } from 'lodash';
 
 /**
  * Custom statuses for Calypso
@@ -96,8 +97,8 @@ export function isOrderWaitingPayment( status ) {
  * @param {String} status Order status
  * @return {Boolean} true if the status is editable
  */
-export function isOrderEditable( status ) {
-	return -1 !== statusEditable.indexOf( status );
+export function isOrderEditable( { id, status } ) {
+	return isObject( id ) || -1 !== statusEditable.indexOf( status );
 }
 
 /**

--- a/client/extensions/woocommerce/lib/order-status/test/index.js
+++ b/client/extensions/woocommerce/lib/order-status/test/index.js
@@ -17,27 +17,35 @@ import {
 
 describe( 'isOrderEditable', () => {
 	test( 'should be true for a pending order', () => {
-		expect( isOrderEditable( 'pending' ) ).to.be.true;
+		expect( isOrderEditable( { id: 1, status: 'pending' } ) ).to.be.true;
 	} );
 
 	test( 'should be true for an on-hold order', () => {
-		expect( isOrderEditable( 'on-hold' ) ).to.be.true;
+		expect( isOrderEditable( { id: 1, status: 'on-hold' } ) ).to.be.true;
 	} );
 
 	test( 'should be false for a processing order', () => {
-		expect( isOrderEditable( 'processing' ) ).to.be.false;
+		expect( isOrderEditable( { id: 1, status: 'processing' } ) ).to.be.false;
 	} );
 
 	test( 'should be false for a completed order', () => {
-		expect( isOrderEditable( 'completed' ) ).to.be.false;
+		expect( isOrderEditable( { id: 1, status: 'completed' } ) ).to.be.false;
 	} );
 
 	test( 'should be false for a failed order', () => {
-		expect( isOrderEditable( 'failed' ) ).to.be.false;
+		expect( isOrderEditable( { id: 1, status: 'failed' } ) ).to.be.false;
+	} );
+
+	test( 'should be true for an unsaved pending order', () => {
+		expect( isOrderEditable( { id: { placeholder: 'order_1' }, status: 'pending' } ) ).to.be.true;
+	} );
+
+	test( 'should be true for an unsaved completed order', () => {
+		expect( isOrderEditable( { id: { placeholder: 'order_1' }, status: 'completed' } ) ).to.be.true;
 	} );
 
 	test( 'should be false for a fake order status', () => {
-		expect( isOrderEditable( 'fake' ) ).to.be.false;
+		expect( isOrderEditable( { id: 1, status: 'fake' } ) ).to.be.false;
 	} );
 } );
 


### PR DESCRIPTION
Currently, we restrict adding/editing items on orders that are already paid (based on order status). This makes sense in the context of editing an existing order, but not when creating new orders. A store owner might want to enter in an order that a user has already paid for, but if they change the order status before adding items, the product section is frozen.

This PR changes the logic used to figure out if an order is "editable", to always return true when working on a new order (regardless of status).

**To test**

The tests have been updated, so you can run those manually with: 

```
npm run test-client client/extensions/woocommerce/lib/order-status
```

- Test manually by creating a new order: `/store/order/:site`
- Change the status to "Completed"
- Verify that you can still add products to the order
- Go to an existing order pending payment, and click Edit Order
- Verify that you can add products to the order
- Change the status to "Completed"
- Verify that you cannot add products now