### PR TITLE
Store: Launch product category management in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -133,7 +133,7 @@
 		"woocommerce/extension-orders-create": false,
 		"woocommerce/extension-orders-edit": true,
 		"woocommerce/extension-products": true,
-		"woocommerce/extension-product-categories": false,
+		"woocommerce/extension-product-categories": true,
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -139,7 +139,7 @@
 		"woocommerce/extension-orders-create": false,
 		"woocommerce/extension-orders-edit": true,
 		"woocommerce/extension-products": true,
-		"woocommerce/extension-product-categories": false,
+		"woocommerce/extension-product-categories": true,
 		"woocommerce/extension-promotions": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,


### PR DESCRIPTION
This PR launches product category management in production 🎉. This is to be merged after #21740 which fixes a couple reported issues.

@timmyc @kellychoffman #21740 fixes what I consider blockers for launching this, so I think we can go ahead and enable this for users once that is in and start tracking usage.

Unfixed issues surfaced from the call for testing thread (excluding other reports on that thread related to products and other sections of Calypso):

1) Issues selecting categories on the product page -- which is already an issue on production and not addressed by this project (https://github.com/Automattic/wp-calypso/issues/20977).
2) Issues selecting a parent category if you have a very, very deep structure. This is going to be present on Calypso's taxonomy management too, and I consider it an edge case. You can also still use the 'search' bar to select the proper parent. I've logged #21741, but I don't think this is a blocker and might require some changes to the root components to fix.