### PR TITLE
Rewind: rename Backups component so it's more descriptive

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/index.jsx
@@ -19,7 +19,7 @@ import QueryJetpackCredentials from 'components/data/query-jetpack-credentials';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { hasMainCredentials, isRewindActive } from 'state/selectors';
 
-class Backups extends Component {
+class JetpackCredentials extends Component {
 	static propTypes = {
 		hasMainCredentials: PropTypes.bool,
 		isRewindActive: PropTypes.bool,
@@ -68,4 +68,4 @@ export default connect( state => {
 		isRewindActive: isRewindActive( state, siteId ),
 		siteId,
 	};
-} )( localize( Backups ) );
+} )( localize( JetpackCredentials ) );

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -24,7 +24,7 @@ import JetpackDevModeNotice from 'my-sites/site-settings/jetpack-dev-mode-notice
 import JetpackMonitor from 'my-sites/site-settings/form-jetpack-monitor';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import Placeholder from 'my-sites/site-settings/placeholder';
-import Backups from 'my-sites/site-settings/jetpack-credentials';
+import JetpackCredentials from 'my-sites/site-settings/jetpack-credentials';
 import QueryRewindStatus from 'components/data/query-rewind-status';
 
 const SiteSettingsSecurity = ( { rewindActive, site, siteId, siteIsJetpack, translate } ) => {
@@ -68,7 +68,7 @@ const SiteSettingsSecurity = ( { rewindActive, site, siteId, siteIsJetpack, tran
 			<JetpackDevModeNotice />
 			<SidebarNavigation />
 			<SiteSettingsNavigation site={ site } section="security" />
-			{ rewindActive && <Backups /> }
+			{ rewindActive && <JetpackCredentials /> }
 			<JetpackMonitor />
 			<FormSecurity />
 		</Main>


### PR DESCRIPTION
This PR renames the `Backups` component to `JetpackCredentials` so its purpose is more clear.