### PR TITLE
Store Orders: Correctly calculate item prices after deleting & re-adding product

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/product-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/product-dialog.js
@@ -30,10 +30,13 @@ function getExistingLineItem( item, order ) {
 	const existingLineItem = find( lineItems, matchedItem );
 	if ( existingLineItem ) {
 		const quantity = existingLineItem.quantity + 1;
-		const subtotal = getOrderItemCost( order, existingLineItem.id ) * quantity;
-		existingLineItem.quantity = quantity;
+		let subtotal = getOrderItemCost( order, existingLineItem.id ) * quantity;
+		if ( 0 === subtotal ) {
+			subtotal = item.price * quantity;
+		}
 		existingLineItem.subtotal = subtotal;
 		existingLineItem.total = subtotal;
+		existingLineItem.quantity = quantity;
 		return existingLineItem;
 	}
 	return false;


### PR DESCRIPTION
This PR fixes a bug where a line_item is accidentally flagged as being discounted from `$0.00` when editing an order.

**To test**

- Create a new order, or edit a pending-payment order
- Add an item (with a non-zero cost) to the order
- Delete the item from the order
- Re-add the item
- Increase the quantity of the item

Before applying this PR, you'd see a crossed-out `0.00` below the correct price. Now you should see the correct price by itself, and the price should be correct with each quantity change.

Before | After
------- | -----
<img width="353" alt="screen shot 2018-01-22 at 5 19 36 pm" src="https://user-images.githubusercontent.com/541093/35247453-71b053b8-ff98-11e7-8093-667acaabcb82.png"> | <img width="311" alt="screen shot 2018-01-22 at 5 18 31 pm" src="https://user-images.githubusercontent.com/541093/35247417-4b4d615c-ff98-11e7-8a01-fadc49dfd64a.png">
