### PR TITLE
Store: Stats: Referrer Widget

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/index.js
+++ b/client/extensions/woocommerce/app/store-stats/index.js
@@ -33,6 +33,8 @@ import {
 } from 'woocommerce/app/store-stats/constants';
 import { getUnitPeriod, getEndPeriod } from './utils';
 import QuerySiteStats from 'components/data/query-site-stats';
+import config from 'config';
+import StoreStatsReferrerWidget from './store-stats-referrer-widget';
 
 class StoreStats extends Component {
 	static propTypes = {
@@ -49,7 +51,7 @@ class StoreStats extends Component {
 		const unitQueryDate = getUnitPeriod( queryDate, unit );
 		const unitSelectedDate = getUnitPeriod( selectedDate, unit );
 		const endSelectedDate = getEndPeriod( selectedDate, unit );
-		const ordersQuery = {
+		const query = {
 			unit,
 			date: unitQueryDate,
 			quantity: UNITS[ unit ].quantity,
@@ -60,13 +62,12 @@ class StoreStats extends Component {
 			limit: 10,
 		};
 		const topWidgets = [ topProducts, topCategories, topCoupons ];
-		const widgetPath = `/${ unit }/${ slug }${ querystring ? '?' : '' }${ querystring || '' }`;
+		const slugAndQuery = `/${ slug }${ querystring ? '?' + querystring : '' }`;
+		const widgetPath = `/${ unit }${ slugAndQuery }`;
 
 		return (
 			<Main className="store-stats woocommerce" wideLayout={ true }>
-				{ siteId && (
-					<QuerySiteStats statType="statsOrders" siteId={ siteId } query={ ordersQuery } />
-				) }
+				{ siteId && <QuerySiteStats statType="statsOrders" siteId={ siteId } query={ query } /> }
 				<div className="store-stats__sidebar-nav">
 					<SidebarNavigation />
 				</div>
@@ -78,7 +79,7 @@ class StoreStats extends Component {
 				/>
 				<Chart
 					path={ path }
-					query={ ordersQuery }
+					query={ query }
 					selectedDate={ endSelectedDate }
 					siteId={ siteId }
 					unit={ unit }
@@ -98,23 +99,50 @@ class StoreStats extends Component {
 										.format( 'YYYY-MM-DD' )
 								: selectedDate
 						}
-						query={ ordersQuery }
+						query={ query }
 						statsType="statsOrders"
 						showQueryDate
 					/>
 				</StatsPeriodNavigation>
+				{ config.isEnabled( 'woocommerce/extension-referrers' ) && (
+					<div>
+						{ siteId && (
+							<QuerySiteStats statType="statsStoreReferrers" siteId={ siteId } query={ query } />
+						) }
+						<Module
+							siteId={ siteId }
+							emptyMessage={ translate( 'No data found' ) }
+							query={ query }
+							statType="statsStoreReferrers"
+							header={
+								<SectionHeader
+									href={ `/store/stats/referrers${ widgetPath }` }
+									label={ 'Store Referrers' }
+								/>
+							}
+						>
+							<StoreStatsReferrerWidget
+								siteId={ siteId }
+								query={ query }
+								statType="statsStoreReferrers"
+								selectedDate={ unitSelectedDate }
+								slugAndQuery={ slugAndQuery }
+							/>
+						</Module>
+					</div>
+				) }
 				<div className="store-stats__widgets">
 					{ sparkWidgets.map( ( widget, index ) => (
-						<div className="store-stats__widgets-column spark-widgets" key={ index }>
+						<div className="store-stats__widgets-column widgets" key={ index }>
 							<Module
 								siteId={ siteId }
 								emptyMessage={ translate( 'No data found' ) }
-								query={ ordersQuery }
+								query={ query }
 								statType="statsOrders"
 							>
 								<WidgetList
 									siteId={ siteId }
-									query={ ordersQuery }
+									query={ query }
 									selectedDate={ endSelectedDate }
 									statType="statsOrders"
 									widgets={ widget }

--- a/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/index.js
@@ -1,0 +1,114 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { find, sortBy } from 'lodash';
+import { max as d3Max } from 'd3-array';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
+import Table from 'woocommerce/components/table';
+import TableRow from 'woocommerce/components/table/table-row';
+import TableItem from 'woocommerce/components/table/table-item';
+import HorizontalBar from 'woocommerce/components/d3/horizontal-bar';
+import Card from 'components/card';
+import ErrorPanel from 'my-sites/stats/stats-error';
+
+class StoreStatsReferrerWidget extends Component {
+	static propTypes = {
+		data: PropTypes.array.isRequired,
+		query: PropTypes.object.isRequired,
+		siteId: PropTypes.number,
+		statType: PropTypes.string.isRequired,
+		selectedDate: PropTypes.string.isRequired,
+	};
+
+	isPreCollection( selectedData ) {
+		const { moment } = this.props;
+		return moment( selectedData.date ).isBefore( moment( '2018-02-01' ) );
+	}
+
+	hasNosaraJobRun( selectedData ) {
+		const { moment } = this.props;
+		const nowUtc = moment().utc();
+		const daysOffsetFromUtc = nowUtc.hour() >= 10 ? 1 : 2;
+		const lastValidDay = nowUtc.subtract( daysOffsetFromUtc, 'days' );
+		return lastValidDay.isAfter( moment( selectedData.date ) );
+	}
+
+	getEmptyDataMessage( selectedData ) {
+		const { slugAndQuery, translate } = this.props;
+		if ( ! this.hasNosaraJobRun( selectedData ) ) {
+			const href = `/store/stats/orders/week${ slugAndQuery }`;
+			const primary = translate( 'Data is being processed – check back soon' );
+			const secondary = translate(
+				'Expand to a {{a}}wider{{/a}} view to see your latest referrers',
+				{
+					components: {
+						a: <a href={ href } />,
+					},
+				}
+			);
+			return [ primary, <p key="link">{ secondary }</p> ];
+		}
+		return this.isPreCollection( selectedData )
+			? [ translate( 'Referral data isn’t available before Jetpack v5.9 (March 2018)' ) ]
+			: [ translate( 'No referral activity on this date' ) ];
+	}
+
+	render() {
+		const { data, selectedDate, translate } = this.props;
+		const selectedData = find( data, d => d.date === selectedDate ) || { data: [] };
+		if ( selectedData.data.length === 0 ) {
+			const messages = this.getEmptyDataMessage( selectedData );
+			return (
+				<Card className="store-stats-referrer-widget stats-module is-showing-error has-no-data">
+					<ErrorPanel message={ messages.shift() }>{ messages }</ErrorPanel>
+				</Card>
+			);
+		}
+		const sortedAndTrimmedData = sortBy( selectedData.data, d => -d.sales ).slice( 0, 5 );
+		const extent = [ 0, d3Max( sortedAndTrimmedData.map( d => d.sales ) ) ];
+		const header = (
+			<TableRow isHeader>
+				<TableItem isHeader isTitle>
+					{ translate( 'Source' ) }
+				</TableItem>
+				<TableItem isHeader>{ translate( 'Gross Sales' ) }</TableItem>
+			</TableRow>
+		);
+		return (
+			<Table className="store-stats-referrer-widget" header={ header } compact>
+				{ sortedAndTrimmedData.map( d => {
+					return (
+						<TableRow key={ d.referrer }>
+							<TableItem isTitle>{ d.referrer }</TableItem>
+							<TableItem>
+								<HorizontalBar
+									extent={ extent }
+									data={ d.sales }
+									currency={ d.currency }
+									height={ 20 }
+								/>
+							</TableItem>
+						</TableRow>
+					);
+				} ) }
+			</Table>
+		);
+	}
+}
+
+export default connect( ( state, { siteId, statType, query } ) => {
+	return {
+		data: getSiteStatsNormalizedData( state, siteId, statType, query ),
+	};
+} )( localize( StoreStatsReferrerWidget ) );

--- a/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-referrer-widget/style.scss
@@ -1,0 +1,9 @@
+.store-stats-referrer-widget  {
+	&.table.is-compact-table th.table-heading.is-title-cell,
+	&.table.is-compact-table td.table-item.is-title-cell {
+		width: 30%;
+	}
+	&.table.is-compact-table th.table-heading {
+		text-align: left;
+	}
+}

--- a/client/extensions/woocommerce/app/store-stats/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/style.scss
@@ -19,7 +19,7 @@
 	.store-stats__widgets-column {
 		width: calc( 33% - 3px );
 
-		&.spark-widgets {
+		&.widgets {
 			width: calc( 50% - 6px );
 		}
 	}

--- a/client/extensions/woocommerce/components/d3/horizontal-bar/index.js
+++ b/client/extensions/woocommerce/components/d3/horizontal-bar/index.js
@@ -1,0 +1,78 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { scaleLinear as d3ScaleLinear } from 'd3-scale';
+
+/**
+ * Internal dependencies
+ */
+import D3Base from 'woocommerce/components/d3/base';
+import { formatValue } from 'woocommerce/app/store-stats/utils';
+
+const HorizontalBar = ( { className, data, extent, currency, height, width } ) => {
+	const numberFormat = currency ? 'currency' : 'number';
+	const drawChart = ( svg, { scale, height: calculatedHeight } ) => {
+		const xPos = scale( data );
+		svg
+			.append( 'rect' )
+			.attr( 'x', 0 )
+			.attr( 'y', 0 )
+			.attr( 'width', xPos )
+			.attr( 'height', calculatedHeight );
+
+		const text = svg
+			.append( 'text' )
+			// Render text offscreen to aquire its length
+			.attr( 'x', -9999 )
+			.attr( 'y', -9999 )
+			.attr( 'text-anchor', 'end' )
+			.attr( 'fill', 'white' )
+			.text( formatValue( data, numberFormat, currency ) );
+		const textMargin = data === 0 ? 0 : 5;
+		const isOffsetText = xPos - ( text.node().getBoundingClientRect().width + textMargin ) <= 0;
+		text
+			.attr( 'class', isOffsetText ? 'is-offset-text' : '' )
+			.attr( 'text-anchor', isOffsetText ? 'start' : 'end' )
+			.attr( 'x', isOffsetText ? xPos + textMargin : xPos - textMargin )
+			.attr( 'y', calculatedHeight / 2 )
+			.attr( 'dy', '0.4em' );
+
+		return svg;
+	};
+
+	const getParams = node => {
+		const calculatedWidth = width || node.offsetWidth;
+		return {
+			width: calculatedWidth,
+			height: height || node.offsetHeight,
+			scale: d3ScaleLinear()
+				.domain( extent )
+				.range( [ 0, calculatedWidth ] ),
+		};
+	};
+
+	return (
+		<D3Base
+			className={ classNames( 'horizontal-bar', className ) }
+			drawChart={ drawChart }
+			getParams={ getParams }
+		/>
+	);
+};
+
+HorizontalBar.propTypes = {
+	className: PropTypes.string,
+	currency: PropTypes.string,
+	data: PropTypes.number.isRequired,
+	extent: PropTypes.arrayOf( PropTypes.number ).isRequired,
+	height: PropTypes.number,
+	width: PropTypes.number,
+};
+
+export default HorizontalBar;

--- a/client/extensions/woocommerce/components/d3/horizontal-bar/style.scss
+++ b/client/extensions/woocommerce/components/d3/horizontal-bar/style.scss
@@ -1,0 +1,14 @@
+/** @format */
+
+.horizontal-bar {
+	rect {
+		fill: $blue-wordpress;
+	}
+	text {
+		fill: $white;
+
+		&.is-offset-text {
+			fill: $gray-dark;
+		}
+	}
+}

--- a/client/extensions/woocommerce/components/d3/horizontal-bar/test/index.js
+++ b/client/extensions/woocommerce/components/d3/horizontal-bar/test/index.js
@@ -1,0 +1,85 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import { mount } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import HorizontalBar from '../index';
+
+describe( 'HorizontalBar', () => {
+	test( 'should render a bar with correct dimensions', () => {
+		const width = 34;
+		const height = 15;
+		const bar = mount(
+			<HorizontalBar width={ width } height={ height } data={ 10 } extent={ [ 0, 10 ] } />
+		);
+		const rect = bar.render().find( 'rect' );
+		const rectAttribures = rect.attr();
+		assert.equal( rectAttribures.width, width );
+		assert.equal( rectAttribures.height, height );
+	} );
+
+	test( 'should render a bar with correctly scaled width', () => {
+		const width = 10;
+		const data = 50;
+		const dataMax = 100;
+		const extent = [ 0, dataMax ];
+		const bar = mount( <HorizontalBar width={ width } data={ data } extent={ extent } /> );
+		const correctWidth = data / dataMax * width;
+		const rectAttribures = bar
+			.render()
+			.find( 'rect' )
+			.attr();
+		assert.equal( rectAttribures.width, correctWidth );
+	} );
+
+	test( 'should render text within the bar if there is room', () => {
+		const width = 100;
+		const data = 100;
+		const dataMax = 100;
+		const extent = [ 0, dataMax ];
+		const bar = mount( <HorizontalBar width={ width } data={ data } extent={ extent } /> );
+		const textAttribures = bar
+			.render()
+			.find( 'text' )
+			.attr();
+		assert.equal( textAttribures[ 'text-anchor' ], 'end' );
+	} );
+
+	test( 'should render text outside the bar if there is no room', () => {
+		const width = 100;
+		const data = 0.001;
+		const dataMax = 100;
+		const extent = [ 0, dataMax ];
+		const bar = mount( <HorizontalBar width={ width } data={ data } extent={ extent } /> );
+		const textAttribures = bar
+			.render()
+			.find( 'text' )
+			.attr();
+		assert.equal( textAttribures[ 'text-anchor' ], 'start' );
+	} );
+
+	test( 'should render text currency formatted if supplied', () => {
+		const width = 100;
+		const data = 0.001;
+		const dataMax = 100;
+		const extent = [ 0, dataMax ];
+		const bar = mount(
+			<HorizontalBar width={ width } data={ data } extent={ extent } currency="NZD" />
+		);
+		const text = bar
+			.render()
+			.find( 'text' )
+			.text();
+		assert.match( text, /NZ\$\d/ );
+	} );
+} );

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -25,6 +25,7 @@
 	@import 'app/settings/taxes/style';
 	@import 'app/store-stats/store-stats-chart/style';
 	@import 'app/store-stats/store-stats-module/style';
+	@import 'app/store-stats/store-stats-referrer-widget/style';
 	@import 'app/store-stats/store-stats-widget-list/style';
 	@import 'app/store-stats/style';
 
@@ -33,6 +34,8 @@
 	@import 'components/bulk-select/style';
 	@import 'components/compact-tinymce/style';
 	@import 'components/d3/base/style';
+	@import 'components/d3/horizontal-bar/style';
+	@import 'components/d3/sparkline/style';
 	@import 'components/dashboard-widget/style';
 	@import 'components/delta/style';
 	@import 'components/extended-header/style';
@@ -49,7 +52,6 @@
 	@import 'components/product-search/style';
 	@import 'components/reading-widget/style';
 	@import 'components/share-widget/style';
-	@import 'components/d3/sparkline/style';
 	@import 'components/store-address/style';
 	@import 'components/table/style';
 

--- a/client/my-sites/stats/stats-error/index.jsx
+++ b/client/my-sites/stats/stats-error/index.jsx
@@ -24,7 +24,7 @@ class StatsError extends React.PureComponent {
 
 		return (
 			<div className={ classNames( 'module-content-text', 'is-error', className ) }>
-				<p>{ displayedMessage }</p>
+				<p key="primary">{ displayedMessage }</p>
 				{ children }
 			</div>
 		);

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1966,6 +1966,7 @@ describe( 'utils', () => {
 				] );
 			} );
 		} );
+
 		describe( 'parseStoreStatsReferrers', () => {
 			const validData = {
 				data: [

--- a/config/development.json
+++ b/config/development.json
@@ -185,6 +185,7 @@
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-product-categories": true,
 		"woocommerce/extension-promotions": true,
+		"woocommerce/extension-referrers": true,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,

--- a/config/production.json
+++ b/config/production.json
@@ -133,6 +133,7 @@
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-product-categories": true,
 		"woocommerce/extension-promotions": true,
+		"woocommerce/extension-referrers": false,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -138,6 +138,7 @@
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-product-categories": true,
 		"woocommerce/extension-promotions": true,
+		"woocommerce/extension-referrers": false,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -155,6 +155,7 @@
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-product-categories": true,
 		"woocommerce/extension-promotions": true,
+		"woocommerce/extension-referrers": false,
 		"woocommerce/extension-reviews": true,
 		"woocommerce/extension-settings": true,
 		"woocommerce/extension-settings-email": true,


### PR DESCRIPTION
Add a referrer widget to the Store Stats Dashboard

### End Goal
![screen shot 2018-01-23 at 3 49 08 pm](https://user-images.githubusercontent.com/1922453/35255662-fad4879c-0054-11e8-957d-477843867aa3.png)

### Current Status
![screen shot 2018-01-23 at 3 47 25 pm](https://user-images.githubusercontent.com/1922453/35255656-ee163582-0054-11e8-9794-600d478df664.png)
* API data is not ready, this branch uses [hard-coded data](https://github.com/Automattic/wp-calypso/compare/add/store-stats-referrer-widget?expand=1#diff-354be0f2a21c771289dfc262bfafed84)
