### PR TITLE
Me: Accessibility: Allow tabbing through Interface Language options using keyboard

### DIFF
--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -87,9 +87,15 @@ export class LanguagePicker extends PureComponent {
 		}
 	};
 
-	handleClose = () => {
-		this.setState( { open: false } );
+	handleKeyPress = event => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.preventDefault();
+			this.props.onClick( event );
+			this.toggleOpen();
+		}
 	};
+
+	handleClose = () => this.setState( { open: false } );
 
 	renderPlaceholder() {
 		const classes = classNames( 'language-picker', 'is-loading' );
@@ -134,7 +140,14 @@ export class LanguagePicker extends PureComponent {
 		const { disabled, translate } = this.props;
 
 		return (
-			<div className="language-picker" onClick={ this.handleClick } disabled={ disabled }>
+			<div
+				tabIndex="0"
+				role="button"
+				className="language-picker"
+				onKeyPress={ this.handleKeyPress }
+				onClick={ this.handleClick }
+				disabled={ disabled }
+			>
 				<div className="language-picker__icon">
 					<div className="language-picker__icon-inner">
 						{ langCode }

--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 import {
 	capitalize,
 	deburr,
@@ -64,6 +64,7 @@ export class LanguagePickerModal extends PureComponent {
 			search: false,
 			selectedLanguageSlug: this.props.selected,
 			suggestedLanguages: this.getSuggestedLanguages(),
+			localeSlug: getLocaleSlug(),
 		};
 	}
 
@@ -245,10 +246,11 @@ export class LanguagePickerModal extends PureComponent {
 				title={ titleText }
 				tabIndex="0"
 				role="button"
-				aria-label={ titleText }
 				onKeyPress={ partial( this.handleLanguageItemKeyPress, language.langSlug ) }
 			>
-				<span className={ classes }>{ language.name }</span>
+				<span className={ classes } lang={ language.langSlug }>
+					{ language.name }
+				</span>
 			</div>
 		);
 	};
@@ -320,8 +322,6 @@ export class LanguagePickerModal extends PureComponent {
 	}
 }
 
-export default connect(
-	state => ( {
-		localizedLanguageNames: getLocalizedLanguageNames( state ),
-	} )
-)( localize( LanguagePickerModal ) );
+export default connect( state => ( {
+	localizedLanguageNames: getLocalizedLanguageNames( state ),
+} ) )( localize( LanguagePickerModal ) );

--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -179,8 +179,17 @@ export class LanguagePickerModal extends PureComponent {
 		this.setState( { search } );
 	};
 
-	handleClick = selectedLanguageSlug => {
+	handleLanguageItemClick = ( selectedLanguageSlug, event ) => {
+		event.preventDefault();
 		this.setState( { selectedLanguageSlug } );
+	};
+
+	handleLanguageItemKeyPress = ( selectedLanguageSlug, event ) => {
+		event.preventDefault();
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.preventDefault();
+			this.setState( { selectedLanguageSlug } );
+		}
 	};
 
 	handleSelectLanguage = () => {
@@ -232,12 +241,12 @@ export class LanguagePickerModal extends PureComponent {
 			<div
 				className="language-picker__modal-item"
 				key={ language.langSlug }
-				onClick={ partial( this.handleClick, language.langSlug ) }
+				onClick={ partial( this.handleLanguageItemClick, language.langSlug ) }
 				title={ titleText }
-				tabindex="0"
+				tabIndex="0"
 				role="button"
 				aria-label={ titleText }
-				onKeyPress={ partial( this.handleClick, language.langSlug ) }
+				onKeyPress={ partial( this.handleLanguageItemKeyPress, language.langSlug ) }
 			>
 				<span className={ classes }>{ language.name }</span>
 			</div>

--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -227,13 +227,17 @@ export class LanguagePickerModal extends PureComponent {
 		const classes = classNames( 'language-picker__modal-text', {
 			'is-selected': isSelected,
 		} );
-
+		const titleText = capitalize( this.getLocalizedLanguageTitle( language.langSlug ) );
 		return (
 			<div
 				className="language-picker__modal-item"
 				key={ language.langSlug }
 				onClick={ partial( this.handleClick, language.langSlug ) }
-				title={ capitalize( this.getLocalizedLanguageTitle( language.langSlug ) ) }
+				title={ titleText }
+				tabindex="0"
+				role="button"
+				aria-label={ titleText }
+				onKeyPress={ partial( this.handleClick, language.langSlug ) }
 			>
 				<span className={ classes }>{ language.name }</span>
 			</div>

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -142,6 +142,9 @@
 	display: inline-block;
 	white-space: nowrap;
 	overflow: hidden;
+	&:focus {
+		outline: solid $gray 1px;
+	}
 }
 
 .language-picker__modal-list {

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -51,6 +51,10 @@
 		}
 	}
 
+	&:focus {
+		border-color: $blue-medium;
+		box-shadow: 0 0 0 2px $blue-light;
+	}
 }
 
 .language-picker__icon {

--- a/client/components/language-picker/test/__snapshots__/modal.js.snap
+++ b/client/components/language-picker/test/__snapshots__/modal.js.snap
@@ -99,7 +99,6 @@ exports[`LanguagePickerModal should render 1`] = `
     className="language-picker__modal-list"
   >
     <div
-      aria-label="En"
       className="language-picker__modal-item"
       key="en"
       onClick={[Function]}
@@ -110,12 +109,12 @@ exports[`LanguagePickerModal should render 1`] = `
     >
       <span
         className="language-picker__modal-text is-selected"
+        lang="en"
       >
         English
       </span>
     </div>
     <div
-      aria-label="Italienisch"
       className="language-picker__modal-item"
       key="it"
       onClick={[Function]}
@@ -126,6 +125,7 @@ exports[`LanguagePickerModal should render 1`] = `
     >
       <span
         className="language-picker__modal-text"
+        lang="it"
       >
         Italiano
       </span>
@@ -149,7 +149,6 @@ exports[`LanguagePickerModal should render 1`] = `
           className="language-picker__modal-suggested-list-inner"
         >
           <div
-            aria-label="En"
             className="language-picker__modal-item"
             key="en"
             onClick={[Function]}
@@ -160,6 +159,7 @@ exports[`LanguagePickerModal should render 1`] = `
           >
             <span
               className="language-picker__modal-text is-selected"
+              lang="en"
             >
               English
             </span>

--- a/client/components/language-picker/test/__snapshots__/modal.js.snap
+++ b/client/components/language-picker/test/__snapshots__/modal.js.snap
@@ -99,9 +99,13 @@ exports[`LanguagePickerModal should render 1`] = `
     className="language-picker__modal-list"
   >
     <div
+      aria-label="En"
       className="language-picker__modal-item"
       key="en"
       onClick={[Function]}
+      onKeyPress={[Function]}
+      role="button"
+      tabIndex="0"
       title="En"
     >
       <span
@@ -111,9 +115,13 @@ exports[`LanguagePickerModal should render 1`] = `
       </span>
     </div>
     <div
+      aria-label="Italienisch"
       className="language-picker__modal-item"
       key="it"
       onClick={[Function]}
+      onKeyPress={[Function]}
+      role="button"
+      tabIndex="0"
       title="Italienisch"
     >
       <span
@@ -141,9 +149,13 @@ exports[`LanguagePickerModal should render 1`] = `
           className="language-picker__modal-suggested-list-inner"
         >
           <div
+            aria-label="En"
             className="language-picker__modal-item"
             key="en"
             onClick={[Function]}
+            onKeyPress={[Function]}
+            role="button"
+            tabIndex="0"
             title="En"
           >
             <span


### PR DESCRIPTION
This PR address #21222 by adding interactive/focusable capabilities to the list of languages in the language picker.

![jan-24-2018 13-11-48](https://user-images.githubusercontent.com/6458278/35311622-8b1b94a6-010b-11e8-9ad6-a3cfb44b6894.gif)

## Testing

1. Open the language picker and tab through the languages

**Expectation**
You should be able to tab through the language items, and select them by hitting the 'space' or 'enter' keys.

