### PR TITLE
Jetpack onboarding: Avoid access by index, use zipped array

### DIFF
--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -55,24 +55,19 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 
 	renderTodo = () => {
 		const { siteUrl } = this.props;
-		const stepsTodo = [
-			SUMMARY_STEPS.JETPACK_CONNECTION,
-			SUMMARY_STEPS.THEME,
-			SUMMARY_STEPS.PAGES,
-			SUMMARY_STEPS.BLOG,
-		];
+
 		// If we're not connected, we cannot use selectors from `sites/selectors`.
-		const stepLinks = [
-			'/jetpack/connect?url=' + siteUrl,
+		const stepsTodo = [
+			[ SUMMARY_STEPS.JETPACK_CONNECTION, '/jetpack/connect?url=' + siteUrl ],
 			// TODO: update the following with relevant links
-			siteUrl + '/wp-admin/themes.php',
-			siteUrl + '/wp-admin/post-new.php?post_type=page',
-			siteUrl + '/wp-admin/post-new.php',
+			[ SUMMARY_STEPS.THEME, siteUrl + '/wp-admin/themes.php' ],
+			[ SUMMARY_STEPS.PAGES, siteUrl + '/wp-admin/post-new.php?post_type=page' ],
+			[ SUMMARY_STEPS.BLOG, siteUrl + '/wp-admin/post-new.php' ],
 		];
 
-		return map( stepsTodo, ( fieldLabel, fieldIndex ) => (
+		return map( stepsTodo, ( [ fieldLabel, fieldLink ], fieldIndex ) => (
 			<div key={ fieldIndex } className="steps__summary-entry todo">
-				<a href={ stepLinks[ fieldIndex ] }>{ fieldLabel }</a>
+				<a href={ fieldLink }>{ fieldLabel }</a>
 			</div>
 		) );
 	};


### PR DESCRIPTION
This PR _zips_ two arrays so that iteration ocurrs over an array of arrays, as opposed to `map` on a single array and expecting the index to match a second array, which seems more fragile.

## Testing
1. Complete the onboarding flow
1. Ensure that the links remain correct.