### PR TITLE
Jetpack onboarding: Try direct authentication

### DIFF
--- a/client/jetpack-onboarding/summary-next-steps.jsx
+++ b/client/jetpack-onboarding/summary-next-steps.jsx
@@ -12,9 +12,11 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import QuerySites from 'components/data/query-sites';
+import { addCalypsoEnvQueryArg } from 'jetpack-connect/utils';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getJetpackOnboardingSettings } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import { REMOTE_PATH_AUTH } from 'jetpack-connect/constants';
 
 const NextSteps = ( { siteId, steps } ) => (
 	<Fragment>
@@ -66,7 +68,7 @@ export default localize(
 			steps: {
 				JETPACK_CONNECTION: {
 					label: translate( 'Connect to WordPress.com' ),
-					url: '/jetpack/connect?url=' + siteUrl,
+					url: addCalypsoEnvQueryArg( siteUrl + REMOTE_PATH_AUTH ),
 				},
 				THEME: {
 					label: translate( 'Choose a Theme' ),


### PR DESCRIPTION
This is a starting point for proceeding directly to Jetpack Connect authentication from Jetpack onboarding. It is a rough idea and can be used for inspiration, iterated on, or abandoned.

The goal is to skip the site entry screen at Jetpack Connect (`/jetpack/connect/?url=…`) given that we know there's an active Jetpack site at a given URL.

This should not be shipped "as-is" 🙂 

Via p7rd6c-1dN-p2 #comment-1985