### PR TITLE
JP Onboarding: Summary Steps: One object to rule them all

### DIFF
--- a/client/jetpack-onboarding/constants.js
+++ b/client/jetpack-onboarding/constants.js
@@ -27,13 +27,6 @@ export const JETPACK_ONBOARDING_STEPS = {
 	SUMMARY: 'summary',
 };
 
-export const JETPACK_ONBOARDING_SUMMARY_STEPS = {
-	JETPACK_CONNECTION: translate( 'Connect to WordPress.com' ),
-	THEME: translate( 'Choose a Theme' ),
-	PAGES: translate( 'Add additional pages' ),
-	BLOG: translate( 'Write your first blog post' ),
-};
-
 export const JETPACK_ONBOARDING_STEP_TITLES = {
 	[ JETPACK_ONBOARDING_STEPS.SITE_TITLE ]: translate( 'Site Title & Description' ),
 	[ JETPACK_ONBOARDING_STEPS.SITE_TYPE ]: translate( 'Type of Site' ),

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
-import { compact, get, map, without } from 'lodash';
+import { get, map, without } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -118,14 +118,9 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 }
 
 export default connect( ( state, { siteId, steps } ) => {
-	const tasks = compact( [] );
-	const stepsCompleted = getJetpackOnboardingCompletedSteps( state, siteId, steps );
-	const stepsPending = getJetpackOnboardingPendingSteps( state, siteId, steps );
-
 	return {
 		siteUrl: getUnconnectedSiteUrl( state, siteId ),
-		stepsCompleted,
-		stepsPending,
-		tasks,
+		stepsCompleted: getJetpackOnboardingCompletedSteps( state, siteId, steps ),
+		stepsPending: getJetpackOnboardingPendingSteps( state, siteId, steps ),
 	};
 } )( localize( JetpackOnboardingSummaryStep ) );

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -26,7 +26,6 @@ import {
 import {
 	JETPACK_ONBOARDING_STEP_TITLES as STEP_TITLES,
 	JETPACK_ONBOARDING_STEPS as STEPS,
-	JETPACK_ONBOARDING_SUMMARY_STEPS as SUMMARY_STEPS,
 } from '../constants';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
@@ -54,18 +53,30 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	};
 
 	renderTodo = () => {
-		const { siteUrl } = this.props;
+		const { siteUrl, translate } = this.props;
 
 		const stepsTodo = {
-			[ SUMMARY_STEPS.JETPACK_CONNECTION ]: '/jetpack/connect?url=' + siteUrl,
-			[ SUMMARY_STEPS.THEME ]: siteUrl + '/wp-admin/themes.php',
-			[ SUMMARY_STEPS.PAGES ]: siteUrl + '/wp-admin/post-new.php?post_type=page',
-			[ SUMMARY_STEPS.BLOG ]: siteUrl + '/wp-admin/post-new.php',
+			JETPACK_CONNECTION: {
+				label: translate( 'Connect to WordPress.com' ),
+				url: '/jetpack/connect?url=' + siteUrl,
+			},
+			THEME: {
+				label: translate( 'Choose a Theme' ),
+				url: siteUrl + '/wp-admin/themes.php',
+			},
+			PAGES: {
+				label: translate( 'Add additional pages' ),
+				url: siteUrl + '/wp-admin/post-new.php?post_type=page',
+			},
+			BLOG: {
+				label: translate( 'Write your first blog post' ),
+				url: siteUrl + '/wp-admin/post-new.php',
+			},
 		};
 
-		return map( stepsTodo, ( stepUrl, fieldLabel ) => (
-			<div key={ stepUrl } className="steps__summary-entry todo">
-				<a href={ stepUrl }>{ fieldLabel }</a>
+		return map( stepsTodo, ( { label, url }, stepName ) => (
+			<div key={ stepName } className="steps__summary-entry todo">
+				<a href={ url }>{ label }</a>
 			</div>
 		) );
 	};

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -55,24 +55,17 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 
 	renderTodo = () => {
 		const { siteUrl } = this.props;
-		const stepsTodo = [
-			SUMMARY_STEPS.JETPACK_CONNECTION,
-			SUMMARY_STEPS.THEME,
-			SUMMARY_STEPS.PAGES,
-			SUMMARY_STEPS.BLOG,
-		];
-		// If we're not connected, we cannot use selectors from `sites/selectors`.
-		const stepLinks = [
-			'/jetpack/connect?url=' + siteUrl,
-			// TODO: update the following with relevant links
-			siteUrl + '/wp-admin/themes.php',
-			siteUrl + '/wp-admin/post-new.php?post_type=page',
-			siteUrl + '/wp-admin/post-new.php',
-		];
 
-		return map( stepsTodo, ( fieldLabel, fieldIndex ) => (
-			<div key={ fieldIndex } className="steps__summary-entry todo">
-				<a href={ stepLinks[ fieldIndex ] }>{ fieldLabel }</a>
+		const stepsTodo = {
+			[ SUMMARY_STEPS.JETPACK_CONNECTION ]: '/jetpack/connect?url=' + siteUrl,
+			[ SUMMARY_STEPS.THEME ]: siteUrl + '/wp-admin/themes.php',
+			[ SUMMARY_STEPS.PAGES ]: siteUrl + '/wp-admin/post-new.php?post_type=page',
+			[ SUMMARY_STEPS.BLOG ]: siteUrl + '/wp-admin/post-new.php',
+		};
+
+		return map( stepsTodo, ( stepUrl, fieldLabel ) => (
+			<div key={ stepUrl } className="steps__summary-entry todo">
+				<a href={ stepUrl }>{ fieldLabel }</a>
 			</div>
 		) );
 	};
@@ -117,10 +110,8 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	}
 }
 
-export default connect( ( state, { siteId, steps } ) => {
-	return {
-		siteUrl: getUnconnectedSiteUrl( state, siteId ),
-		stepsCompleted: getJetpackOnboardingCompletedSteps( state, siteId, steps ),
-		stepsPending: getJetpackOnboardingPendingSteps( state, siteId, steps ),
-	};
-} )( localize( JetpackOnboardingSummaryStep ) );
+export default connect( ( state, { siteId, steps } ) => ( {
+	siteUrl: getUnconnectedSiteUrl( state, siteId ),
+	stepsCompleted: getJetpackOnboardingCompletedSteps( state, siteId, steps ),
+	stepsPending: getJetpackOnboardingPendingSteps( state, siteId, steps ),
+} ) )( localize( JetpackOnboardingSummaryStep ) );


### PR DESCRIPTION
Alternative to #21754 (see discussion there), factored out of #21728.

This removes `JETPACK_ONBOARDING_SUMMARY_STEPS` from the constants definition file, and merges its information into the `stepsTodo` object in the summary step, which is the only place where it is used anyway. The rationale is that we need a `siteUrl` argument for the `url` fields, so if we were to keep the object definition in the constants file, we'd have to turn them into functions, which I'd find a bit meh.

No visual changes.

To test:
* Checkout this branch on your local Calypso.
* Make sure you're running latest `master` on your JP sandbox.
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
* Wait until being redirected to the JPO flow in Calypso.
* Skip some steps, fill in some others, until you arrive at the 'Summary' page.
* Verify that all items in the right column are still links that point to the correct targets.