### PR TITLE
Checklist: Fire tracks event when users try to share their site.

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -3,7 +3,6 @@
  *
  * @format
  */
-
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { find } from 'lodash';
@@ -11,12 +10,10 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-
 import FormattedHeader from 'components/formatted-header';
 import Checklist from 'components/checklist';
 import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
-import ShareButton from 'components/share-button';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteChecklist } from 'state/selectors';
@@ -26,6 +23,7 @@ import { launchTask, launchCompletedTask, onboardingTasks } from '../onboardingC
 import { recordTracksEvent } from 'state/analytics/actions';
 import { createNotice } from 'state/notices/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
+import ChecklistShowShare from './share';
 
 class ChecklistShow extends PureComponent {
 	onAction = id => {
@@ -59,8 +57,6 @@ class ChecklistShow extends PureComponent {
 	};
 
 	renderHeader( completed, displayMode ) {
-		const shareTo = [ 'facebook', 'twitter', 'linkedin', 'google-plus', 'pinterest' ];
-
 		if ( ! completed ) {
 			if ( displayMode ) {
 				const title =
@@ -103,17 +99,11 @@ class ChecklistShow extends PureComponent {
 					headerText="Congratulations!"
 					subHeaderText="You have completed all your tasks. Now let's tell people about it. Share your site."
 				/>
-				<div className="checklist-show__share">
-					{ shareTo.map( option => (
-						<ShareButton
-							key={ option }
-							url={ `https://${ this.props.siteSlug }` }
-							title="Delighted to announce my new website is live today - please take a look."
-							siteSlug={ this.props.siteSlug }
-							service={ option }
-						/>
-					) ) }
-				</div>
+				<ChecklistShowShare
+					className="checklist-show__share"
+					siteSlug={ this.props.siteSlug }
+					recordTracksEvent={ this.props.track }
+				/>
 			</Fragment>
 		);
 	}

--- a/client/my-sites/checklist/checklist-show/share.jsx
+++ b/client/my-sites/checklist/checklist-show/share.jsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import ShareButton from 'components/share-button';
+
+const services = [ 'facebook', 'twitter', 'linkedin', 'google-plus', 'pinterest' ];
+
+export default class ChecklistShowShare extends PureComponent {
+	static propTypes = {
+		siteSlug: PropTypes.string.isRequired,
+		recordTracksEvent: PropTypes.func,
+	};
+
+	boundClickHandler = {};
+
+	handleClick( service ) {
+		this.props.recordTracksEvent( 'calypso_checklist_completed_site_share', {
+			checklist_name: 'new_blog',
+			service,
+		} );
+	}
+
+	getClickHandlerFor( service ) {
+		if ( ! this.props.recordTracksEvent ) {
+			return;
+		}
+
+		if ( ! this.boundClickHandler[ service ] ) {
+			this.boundClickHandler[ service ] = () => this.handleClick( service );
+		}
+
+		return this.boundClickHandler[ service ];
+	}
+
+	render() {
+		return (
+			<div className={ this.props.className }>
+				{ services.map( service => (
+					<ShareButton
+						key={ service }
+						url={ `https://${ this.props.siteSlug }` }
+						title="Delighted to announce my new website is live today - please take a look."
+						siteSlug={ this.props.siteSlug }
+						service={ service }
+						onClick={ this.getClickHandlerFor( service ) }
+					/>
+				) ) }
+			</div>
+		);
+	}
+}

--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -19,11 +19,11 @@ import Button from 'components/button';
 import Card from 'components/card';
 import Gauge from 'components/gauge';
 import ProgressBar from 'components/progress-bar';
-import ShareButton from 'components/share-button';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import { getSiteChecklist } from 'state/selectors';
 import { getSite, getSiteSlug } from 'state/sites/selectors';
 import { launchTask, onboardingTasks } from 'my-sites/checklist/onboardingChecklist';
+import ChecklistShowShare from 'my-sites/checklist/checklist-show/share';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 
@@ -127,23 +127,12 @@ export class ChecklistBanner extends Component {
 	}
 
 	renderShareButtons() {
-		const { siteSlug, translate } = this.props;
-		const socialMedia = [ 'facebook', 'twitter', 'linkedin', 'google-plus', 'pinterest' ];
-
 		return (
-			<div className="checklist-banner__actions">
-				{ socialMedia.map( medium => (
-					<ShareButton
-						key={ medium }
-						url={ `https://${ siteSlug }` }
-						title={ translate(
-							'Delighted to announce my new website is live today — please take a look.'
-						) }
-						siteSlug={ siteSlug }
-						service={ medium }
-					/>
-				) ) }
-			</div>
+			<ChecklistShowShare
+				className="checklist-banner__actions"
+				siteSlug={ this.props.siteSlug }
+				recordTracksEvent={ this.props.track }
+			/>
 		);
 	}
 


### PR DESCRIPTION
This PR will create a shared component for the social share buttons in the checklist and fire the `calypso_checklist_completed_site_share` tracks event when users try to share their site through the buttons.

## How to test

1. Run `localStorage.setItem('debug', 'calypso:analytics*');` in the browser console to monitor the events.
2. Create a new site and complete the checklist. You will find the checklist on the stats page.
3. Click on any social share button in the completed checklist.
<img width="969" alt="2018-01-23 11 34 45" src="https://user-images.githubusercontent.com/212034/35281348-1101e3a2-0096-11e8-84e2-b5a86e88cf7b.png">
4. The console should display related logs as follows:
<img width="956" alt="2018-01-23 11 36 26" src="https://user-images.githubusercontent.com/212034/35281455-47b98c10-0096-11e8-821f-46c945c4cd01.png">


