### PR TITLE
JP Onboarding: Redirect if JP < v5.8

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -23,6 +23,7 @@ import JetpackSsoForm from './sso';
 import NoDirectAccessError from './no-direct-access-error';
 import Plans from './plans';
 import PlansLanding from './plans-landing';
+import versionCompare from 'lib/version-compare';
 import { authorizeQueryDataSchema } from './schema';
 import { authQueryTransformer } from './utils';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -106,6 +107,10 @@ export function redirectWithoutLocaleIfLoggedIn( context, next ) {
 
 export function maybeOnboard( { query, store }, next ) {
 	if ( ! isEmpty( query ) && query.onboarding ) {
+		if ( versionCompare( query.jp_version, '5.8-alpha', '>=' ) ) {
+			// Do something!
+		}
+
 		const siteId = parseInt( query.client_id, 10 );
 		const siteSlug = urlToSlug( query.site_url );
 		const credentials = {

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -107,7 +107,7 @@ export function redirectWithoutLocaleIfLoggedIn( context, next ) {
 
 export function maybeOnboard( { query, store }, next ) {
 	if ( ! isEmpty( query ) && query.onboarding ) {
-		if ( versionCompare( query.jp_version, '5.8', '<' ) ) {
+		if ( query.site_url && query.jp_version && versionCompare( query.jp_version, '5.8', '<' ) ) {
 			return externalRedirect( query.site_url + '/wp-admin/admin.php?page=jetpack#/dashboard' );
 		}
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -26,6 +26,7 @@ import PlansLanding from './plans-landing';
 import versionCompare from 'lib/version-compare';
 import { authorizeQueryDataSchema } from './schema';
 import { authQueryTransformer } from './utils';
+import { externalRedirect, sectionify } from 'lib/route';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
 import { hideMasterbar, setSection, showMasterbar } from 'state/ui/actions';
@@ -33,7 +34,6 @@ import { JPC_PATH_PLANS, MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
 import { login } from 'lib/paths';
 import { persistMobileRedirect, retrieveMobileRedirect, storePlan } from './persistence-utils';
 import { receiveJetpackOnboardingCredentials } from 'state/jetpack-onboarding/actions';
-import { sectionify } from 'lib/route';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { startAuthorizeStep } from 'state/jetpack-connect/actions';
 import { urlToSlug } from 'lib/url';
@@ -108,10 +108,7 @@ export function redirectWithoutLocaleIfLoggedIn( context, next ) {
 export function maybeOnboard( { query, store }, next ) {
 	if ( ! isEmpty( query ) && query.onboarding ) {
 		if ( versionCompare( query.jp_version, '5.8', '<' ) ) {
-			// page.redirect() doesn't work here because of the different domain
-			return window.location.replace(
-				query.site_url + '/wp-admin/admin.php?page=jetpack#/dashboard'
-			);
+			return externalRedirect( query.site_url + '/wp-admin/admin.php?page=jetpack#/dashboard' );
 		}
 
 		const siteId = parseInt( query.client_id, 10 );

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -107,8 +107,9 @@ export function redirectWithoutLocaleIfLoggedIn( context, next ) {
 
 export function maybeOnboard( { query, store }, next ) {
 	if ( ! isEmpty( query ) && query.onboarding ) {
-		if ( versionCompare( query.jp_version, '5.8-alpha', '>=' ) ) {
-			// Do something!
+		if ( versionCompare( query.jp_version, '5.8', '<' ) ) {
+			// page.redirect() doesn't work here because of the different domain
+			return window.location.replace( query.site_url + '/wp-admin/' );
 		}
 
 		const siteId = parseInt( query.client_id, 10 );

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -109,7 +109,9 @@ export function maybeOnboard( { query, store }, next ) {
 	if ( ! isEmpty( query ) && query.onboarding ) {
 		if ( versionCompare( query.jp_version, '5.8', '<' ) ) {
 			// page.redirect() doesn't work here because of the different domain
-			return window.location.replace( query.site_url + '/wp-admin/' );
+			return window.location.replace(
+				query.site_url + '/wp-admin/admin.php?page=jetpack#/dashboard'
+			);
 		}
 
 		const siteId = parseInt( query.client_id, 10 );


### PR DESCRIPTION
If the JP version installed is < 5.8, redirect to the site's wp-admin JP dashboard.

This is a cheap and slightly dirty workaround. However, since the route def lives in `/jetpack-connect`, it'd require quite a bit of code (and possibly new routes) to pass on the JP version to JPO and display a component there, so we're going with the easier fix for now.

To test:
* With a JP sandbox that has JP >= v5.8, land at `http://Yourwpsandbox.me/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` and verify you're redirected to `http://calypso.localhost:3000/jetpack/onboarding/Yourwpsandbox.me`, as before.
* Downgrade to JP < 5.8 (or change the version check in the code to 5.9 😛). Start at the same URL as above, and verify that this time, you're redirected to the site's wp-admin JP dashboard.

Fixes #21678.