### PR TITLE
Themes: Remove bad boolean icon property

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -226,7 +226,6 @@ class ThemeShowcase extends React.Component {
 						<Button
 							className="themes__upload-button"
 							compact
-							icon
 							onClick={ this.onUploadClick }
 							href={ siteSlug ? `/themes/upload/${ siteSlug }` : '/themes/upload' }
 						>


### PR DESCRIPTION
This PR removes a bad `icon` property that was causing warnings in development:

![warning](https://user-images.githubusercontent.com/841763/35286223-af20a190-005f-11e8-8c6d-69314c827357.png)

The culprit:

![thebutton](https://user-images.githubusercontent.com/841763/35286224-af48acd0-005f-11e8-8511-7d7435d61dcb.png)


No visual or functional changes.

## Testing
1. Verify the warning is no longer displayed - `/themes/:SITE_SLUG_WITH_THEME_UPLOADS`
1. Verify no unexpected changes have been introduced.