### PR TITLE
Analytics: Use redux for sidebar analytics

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -15,9 +15,7 @@ import Gridicon from 'gridicons';
 import { isExternal } from 'lib/url';
 import { preload } from 'sections-preload';
 
-export default class extends React.Component {
-	static displayName = 'SidebarItem';
-
+export default class SidebarItem extends React.Component {
 	static propTypes = {
 		label: PropTypes.string.isRequired,
 		className: PropTypes.string,

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -14,7 +14,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
 import Button from 'components/button';
 import config from 'config';
 import CurrentSite from 'my-sites/current-site';
@@ -53,6 +52,8 @@ import { getStatsPathForTab } from 'lib/route';
 import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
 import { transferStates } from 'state/automated-transfer/constants';
 import { itemLinkMatches } from './utils';
+import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+
 /**
  * Module variables
  */
@@ -82,17 +83,17 @@ export class MySitesSidebar extends Component {
 		const { isPreviewable, siteSuffix } = this.props;
 
 		if ( ! isPreviewable ) {
-			analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site | Unpreviewable' );
+			this.props.recordGoogleEvent( 'Sidebar', 'Clicked View Site | Unpreviewable' );
 			return;
 		}
 
 		if ( event.altKey || event.ctrlKey || event.metaKey || event.shiftKey ) {
-			analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site | Modifier Key' );
+			this.props.recordGoogleEvent( 'Sidebar', 'Clicked View Site | Modifier Key' );
 			return;
 		}
 
 		event.preventDefault();
-		analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site | Calypso' );
+		this.props.recordGoogleEvent( 'Sidebar', 'Clicked View Site | Calypso' );
 		page( '/view' + siteSuffix );
 	};
 
@@ -323,7 +324,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	trackStoreClick = () => {
-		analytics.tracks.recordEvent( 'calypso_woocommerce_store_nav_item_click' );
+		this.props.recordTracksEvent( 'calypso_woocommerce_store_nav_item_click' );
 		this.onNavigate();
 	};
 
@@ -366,7 +367,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	trackUpgradeClick = () => {
-		analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', {
+		this.props.recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
 			cta_name: 'sidebar_upgrade_default',
 		} );
 		this.onNavigate();
@@ -511,7 +512,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	trackWpadminClick = () => {
-		analytics.ga.recordEvent( 'Sidebar', 'Clicked WP Admin' );
+		this.props.recordGoogleEvent( 'Sidebar', 'Clicked WP Admin' );
 	};
 
 	focusContent = () => {
@@ -660,6 +661,9 @@ function mapStateToProps( state ) {
 	};
 }
 
-export default connect( mapStateToProps, { setNextLayoutFocus, setLayoutFocus } )(
-	localize( MySitesSidebar )
-);
+export default connect( mapStateToProps, {
+	recordGoogleEvent,
+	recordTracksEvent,
+	setLayoutFocus,
+	setNextLayoutFocus,
+} )( localize( MySitesSidebar ) );


### PR DESCRIPTION
This PR updates sidebar to use Redux analytics over direct calls to `lib/analytics` functions. It also updates a component class to a named class and removes the redundant `displayName` static property.

## Context

Some janitorial fixes encountered when exploring #21760

## Testing
1. ```js
   localStorage.debug = 'calypso:analytics:tracks,calypso:analytics:ga'
   ```
1. Ensure the sites sidebar continues to dispatch the relevant actions