### PR TITLE
Remove (Beta) label from Search

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-search.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-search.jsx
@@ -17,7 +17,7 @@ export default localize( ( { selectedSite, translate } ) => {
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon="search"
-				title={ translate( 'Search (Beta)' ) }
+				title={ translate( 'Search' ) }
 				description={ translate(
 					'Replace the default WordPress search with better results ' +
 						'and filtering that will help your users find what they are looking for.'

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -110,7 +110,7 @@ class Search extends Component {
 					siteId={ siteId }
 					moduleSlug="search"
 					label={ translate(
-						'Replace WordPress built-in search with an improved search experience (Beta)'
+						'Replace WordPress built-in search with an improved search experience'
 					) }
 					disabled={ isRequestingSettings || isSavingSettings }
 				/>


### PR DESCRIPTION
Search is coming out of Beta with this Jetpack release. This change just removes the (Beta) label.