### PR TITLE
Fix: Contact form assumes `selectedSite` exists

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -307,15 +307,16 @@ export class HelpContactForm extends React.PureComponent {
 					</div>
 				) }
 
-				{ showSiteField && (
-					<div className="help-contact-form__site-selection">
-						<FormLabel>{ translate( 'Which site do you need help with?' ) }</FormLabel>
-						<SitesDropdown
-							selectedSiteId={ this.props.selectedSite.ID }
-							onSiteSelect={ this.props.onChangeSite }
-						/>
-					</div>
-				) }
+				{ showSiteField &&
+					this.props.selectedSite && (
+						<div className="help-contact-form__site-selection">
+							<FormLabel>{ translate( 'Which site do you need help with?' ) }</FormLabel>
+							<SitesDropdown
+								selectedSiteId={ this.props.selectedSite.ID }
+								onSiteSelect={ this.props.onChangeSite }
+							/>
+						</div>
+					) }
 
 				{ showSubjectField && (
 					<div className="help-contact-form__subject">


### PR DESCRIPTION
Reported in Slack, we saw messages in the console for `TypeError`s
in the contact form from `this.props.selectedSite.ID` but where
`this.props.selectedSite` was `null`

This patch performs a safety-check at runtime to make sure we don't
try to access data that may not be available.