### PR TITLE
Contact: add fallback when primary site does not load

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -26,7 +26,7 @@ import FormButton from 'components/forms/form-button';
 import SitesDropdown from 'components/sites-dropdown';
 import ChatBusinessConciergeNotice from '../chat-business-concierge-notice';
 import { selectSiteId } from 'state/help/actions';
-import { getHelpSelectedSite } from 'state/help/selectors';
+import { getHelpSelectedSite, getHelpSelectedSiteId } from 'state/help/selectors';
 import wpcomLib from 'lib/wp';
 import HelpResults from 'me/help/help-results';
 import { bumpStat, recordTracksEvent, composeAnalytics } from 'state/analytics/actions';
@@ -57,7 +57,8 @@ export class HelpContactForm extends React.PureComponent {
 		showSubjectField: PropTypes.bool,
 		showSiteField: PropTypes.bool,
 		showHelpLanguagePrompt: PropTypes.bool,
-		selectedSite: PropTypes.object,
+		helpSite: PropTypes.object,
+		helpSiteId: PropTypes.number,
 		siteFilter: PropTypes.func,
 		siteList: PropTypes.object,
 		disabled: PropTypes.bool,
@@ -242,7 +243,7 @@ export class HelpContactForm extends React.PureComponent {
 			howYouFeel,
 			message,
 			subject,
-			site: this.props.selectedSite,
+			site: this.props.helpSite,
 		} );
 	};
 
@@ -307,16 +308,15 @@ export class HelpContactForm extends React.PureComponent {
 					</div>
 				) }
 
-				{ showSiteField &&
-					this.props.selectedSite && (
-						<div className="help-contact-form__site-selection">
-							<FormLabel>{ translate( 'Which site do you need help with?' ) }</FormLabel>
-							<SitesDropdown
-								selectedSiteId={ this.props.selectedSite.ID }
-								onSiteSelect={ this.props.onChangeSite }
-							/>
-						</div>
-					) }
+				{ showSiteField && (
+					<div className="help-contact-form__site-selection">
+						<FormLabel>{ translate( 'Which site do you need help with?' ) }</FormLabel>
+						<SitesDropdown
+							selectedSiteId={ this.props.helpSiteID }
+							onSiteSelect={ this.props.onChangeSite }
+						/>
+					</div>
+				) }
 
 				{ showSubjectField && (
 					<div className="help-contact-form__subject">
@@ -364,7 +364,8 @@ export class HelpContactForm extends React.PureComponent {
 }
 
 const mapStateToProps = state => ( {
-	selectedSite: getHelpSelectedSite( state ),
+	helpSite: getHelpSelectedSite( state ),
+	helpSiteId: getHelpSelectedSiteId( state ),
 } );
 
 const mapDispatchToProps = {

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -312,7 +312,7 @@ export class HelpContactForm extends React.PureComponent {
 					<div className="help-contact-form__site-selection">
 						<FormLabel>{ translate( 'Which site do you need help with?' ) }</FormLabel>
 						<SitesDropdown
-							selectedSiteId={ this.props.helpSiteID }
+							selectedSiteId={ this.props.helpSiteId }
 							onSiteSelect={ this.props.onChangeSite }
 						/>
 					</div>

--- a/client/state/help/selectors.js
+++ b/client/state/help/selectors.js
@@ -1,25 +1,48 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
-
 import { getSelectedOrPrimarySiteId } from 'state/selectors';
 import { getSite } from 'state/sites/selectors';
 
 export const getHelpSiteId = state => state.help.selectedSiteId;
 
+/*
+ * Returns the site the customer wishes to request help for. Returns in order of preference:
+ *  - The site the customer has explicitly selected
+ *  - A selected site
+ *  - The primary site (which may not be available).
+ * @param state - global state
+ * @returns {?Object} the help site or null
+ */
 export const getHelpSelectedSite = state => {
 	const siteId = getHelpSiteId( state ) || getSelectedOrPrimarySiteId( state );
-
-	return getSite( state, siteId );
+	const helpSite = getSite( state, siteId );
+	// Are sites loaded but the help site is not available? We may have a bad site or primary.
+	const sites = get( state, 'sites.items' );
+	const siteKeys = sites && Object.keys( sites );
+	if ( ! helpSite && siteKeys && siteKeys.length > 0 ) {
+		const firstSiteId = siteKeys[ 0 ];
+		return getSite( state, firstSiteId );
+	}
+	return helpSite;
 };
 
+/*
+ * Returns the siteId the customer wishes to request help for. Returns in order of preference:
+ *  - The siteId the customer has explicitly selected
+ *  - A selected site id
+ *  - The Primary Site (which may not be available).
+ * @param state - global state
+ * @returns {?Object} the help site or null
+ */
 export const getHelpSelectedSiteId = state => {
 	const site = getHelpSelectedSite( state );
-
-	if ( site && site.ID ) {
-		return site.ID;
-	}
-	return null;
+	return get( site, 'ID', null );
 };

--- a/client/state/help/selectors.js
+++ b/client/state/help/selectors.js
@@ -18,6 +18,7 @@ export const getHelpSiteId = state => state.help.selectedSiteId;
  *  - The site the customer has explicitly selected
  *  - A selected site
  *  - The primary site (which may not be available).
+ *  - If any of the above is requested, but the full site object is not available, return the site with the lowest siteId.
  * @param state - global state
  * @returns {?Object} the help site or null
  */
@@ -39,6 +40,7 @@ export const getHelpSelectedSite = state => {
  *  - The siteId the customer has explicitly selected
  *  - A selected site id
  *  - The Primary Site (which may not be available).
+ *  - If any of the above is requested, but the full site object is not available, return the site with the lowest siteId.
  * @param state - global state
  * @returns {?Object} the help site or null
  */

--- a/client/state/help/test/selectors.js
+++ b/client/state/help/test/selectors.js
@@ -3,13 +3,12 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
-import { getHelpSiteId } from '../selectors';
+import { getHelpSiteId, getHelpSelectedSiteId } from '../selectors';
 
 describe( 'selectors', () => {
 	describe( '#getHelpSiteId()', () => {
@@ -20,7 +19,7 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getHelpSiteId( state ) ).to.be.null;
+			expect( getHelpSiteId( state ) ).toEqual( null );
 		} );
 
 		test( 'should return courses for given state', () => {
@@ -30,7 +29,187 @@ describe( 'selectors', () => {
 				},
 			} );
 
-			expect( getHelpSiteId( state ) ).to.eql( state.help.selectedSiteId );
+			expect( getHelpSiteId( state ) ).toEqual( state.help.selectedSiteId );
+		} );
+	} );
+	describe( '#getHelpSelectedSiteId()', () => {
+		test( 'defaults to customer chosen site', () => {
+			const state = deepFreeze( {
+				help: {
+					selectedSiteId: 1234,
+				},
+				sites: {
+					items: {
+						1234: { ID: 1234 },
+						77203074: { ID: 77203074 },
+						2916284: { ID: 2916284 },
+					},
+				},
+				ui: {
+					selectedSiteId: 2916284,
+				},
+				currentUser: {
+					id: 5678,
+					capabilities: {},
+				},
+				users: {
+					items: {
+						5678: {
+							ID: 5678,
+							primary_blog: 77203074,
+						},
+					},
+				},
+			} );
+			expect( getHelpSelectedSiteId( state ) ).toEqual( 1234 );
+		} );
+
+		test( 'uses selected site if customer selected site is not available', () => {
+			const state = deepFreeze( {
+				help: {
+					selectedSiteId: null,
+				},
+				sites: {
+					items: {
+						1234: { ID: 1234 },
+						2916284: { ID: 2916284 },
+						77203074: { ID: 77203074 },
+					},
+				},
+				ui: {
+					selectedSiteId: 2916284,
+				},
+				currentUser: {
+					id: 5678,
+					capabilities: {},
+				},
+				users: {
+					items: {
+						5678: {
+							ID: 5678,
+							primary_blog: 77203074,
+						},
+					},
+				},
+			} );
+			expect( getHelpSelectedSiteId( state ) ).toEqual( 2916284 );
+		} );
+
+		test( 'uses primary site if customer selected site or global selected site is not available', () => {
+			const state = deepFreeze( {
+				help: {
+					selectedSiteId: null,
+				},
+				sites: {
+					items: {
+						1234: { ID: 1234 },
+						2916284: { ID: 2916284 },
+						77203074: { ID: 77203074 },
+					},
+				},
+				ui: {
+					selectedSiteId: null,
+				},
+				currentUser: {
+					id: 5678,
+					capabilities: {},
+				},
+				users: {
+					items: {
+						5678: {
+							ID: 5678,
+							primary_blog: 77203074,
+						},
+					},
+				},
+			} );
+			expect( getHelpSelectedSiteId( state ) ).toEqual( 77203074 );
+		} );
+
+		test( 'if customer selected site is not available, uses first site', () => {
+			const state = deepFreeze( {
+				help: {
+					selectedSiteId: 1234,
+				},
+				sites: {
+					items: {
+						2916284: { ID: 2916284 },
+						77203074: { ID: 77203074 },
+					},
+				},
+				ui: {
+					selectedSiteId: null,
+				},
+				currentUser: {
+					id: 5678,
+					capabilities: {},
+				},
+				users: {
+					items: {
+						5678: {
+							ID: 5678,
+							primary_blog: 77203074,
+						},
+					},
+				},
+			} );
+			expect( getHelpSelectedSiteId( state ) ).toEqual( 2916284 );
+		} );
+
+		test( 'if selected site is not available, uses first site', () => {
+			const state = deepFreeze( {
+				help: {
+					selectedSiteId: null,
+				},
+				sites: {
+					items: {
+						77203074: { ID: 77203074 },
+					},
+				},
+				ui: {
+					selectedSiteId: 2916284,
+				},
+				currentUser: {
+					id: 5678,
+					capabilities: {},
+				},
+				users: {
+					items: {
+						5678: {
+							ID: 5678,
+							primary_blog: 1234,
+						},
+					},
+				},
+			} );
+			expect( getHelpSelectedSiteId( state ) ).toEqual( 77203074 );
+		} );
+
+		test( 'if sites are not loaded, returns null', () => {
+			const state = deepFreeze( {
+				help: {
+					selectedSiteId: 1234,
+				},
+				sites: {
+					items: null,
+				},
+				ui: {
+					selectedSiteId: 2916284,
+				},
+				currentUser: {
+					id: 5678,
+					capabilities: {},
+				},
+				users: {
+					items: {
+						5678: {
+							ID: 5678,
+							primary_blog: 1234,
+						},
+					},
+				},
+			} );
+			expect( getHelpSelectedSiteId( state ) ).toEqual( null );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR updates the `getHelpSelectedSite` selector to handle cases where a site may be selected but unavailable. This should fix #19121

This selector returns in favor of preference:
- What the customer has explicitly set
- The global selected site
- The primary site
- null if sites are not available
- if sites are available but full site information is missing for the above, we return the site with the lowest siteId

### Testing Instructions
- unit tests pass
- navigate to /help/contact
- set `state.help.selectedSiteId` to a siteId that you do not own, or set your primary to a garbage id
- we should still be able to contact support