### PR TITLE
Site Settings: remove feature flag for language selector

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -574,9 +574,7 @@ const connectComponent = connect(
 			siteIsJetpack,
 			siteSlug: getSelectedSiteSlug( state ),
 			supportsLanguageSelection:
-				! siteIsJetpack ||
-				( isJetpackMinimumVersion( state, siteId, '5.8-alpha' ) &&
-					config.isEnabled( 'jetpack/site-settings-language-selection' ) ),
+				! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '5.8-alpha' ),
 			supportsHolidaySnowOption: ! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '4.0' ),
 		};
 	},

--- a/config/development.json
+++ b/config/development.json
@@ -65,7 +65,6 @@
 		"jetpack/google-analytics-for-stores": true,
 		"jetpack/google-analytics-for-stores-enhanced": true,
 		"jetpack/onboarding": true,
-		"jetpack/site-settings-language-selection": true,
 		"jetpack_core_inline_update": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,


### PR DESCRIPTION
## This PR
- removes the feature flag for the language selector in Jetpack
- fixes #11316

We're a version check for the minimum version of Jetpack, which makes the feature flag obsolete.

## How to test

Follow the instructions in https://github.com/Automattic/wp-calypso/pull/21482
