### PR TITLE
Me: Language picker throws error when localized languages prop is not populated

### DIFF
--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -78,12 +78,12 @@ export class LanguagePickerModal extends PureComponent {
 
 	getLocalizedLanguageTitle( languageSlug ) {
 		const { localizedLanguageNames } = this.props;
-		return get( localizedLanguageNames[ languageSlug ], 'localized' ) || languageSlug;
+		return get( localizedLanguageNames, `${ languageSlug }.localized`, languageSlug );
 	}
 
 	getEnglishLanguageTitle( languageSlug ) {
 		const { localizedLanguageNames } = this.props;
-		return get( localizedLanguageNames[ languageSlug ], 'en' ) || languageSlug;
+		return get( localizedLanguageNames, `${ languageSlug }.en`, languageSlug );
 	}
 
 	getFilterLabel( filter ) {

--- a/client/components/language-picker/test/modal.js
+++ b/client/components/language-picker/test/modal.js
@@ -71,6 +71,13 @@ describe( 'LanguagePickerModal', () => {
 			expect( wrapper.instance().getLocalizedLanguageTitle( 'oops' ) ).toEqual( 'oops' );
 		} );
 
+		test( 'should return slug when localized language names are unavailable', () => {
+			const newProps = { ...defaultProps, localizedLanguageNames: undefined };
+			const wrapper = shallow( <LanguagePickerModal { ...newProps } /> );
+
+			expect( wrapper.instance().getLocalizedLanguageTitle( 'oops' ) ).toEqual( 'oops' );
+		} );
+
 		test( 'should return localized language', () => {
 			const wrapper = shallow( <LanguagePickerModal { ...defaultProps } /> );
 
@@ -81,6 +88,13 @@ describe( 'LanguagePickerModal', () => {
 	describe( 'getEnglishLanguageTitle()', () => {
 		test( 'should return slug when no English language translation available', () => {
 			const wrapper = shallow( <LanguagePickerModal { ...defaultProps } /> );
+
+			expect( wrapper.instance().getEnglishLanguageTitle( 'oops' ) ).toEqual( 'oops' );
+		} );
+
+		test( 'should return slug when localized language names are unavailable', () => {
+			const newProps = { ...defaultProps, localizedLanguageNames: undefined };
+			const wrapper = shallow( <LanguagePickerModal { ...newProps } /> );
 
 			expect( wrapper.instance().getEnglishLanguageTitle( 'oops' ) ).toEqual( 'oops' );
 		} );


### PR DESCRIPTION
This PR fixes a bug in #20694 whereby plucking the localized and English language titles from `this.props.localizedLanguageNames` fails when the prop is undefined or null.

Props to @frontdevde for catching it 👍 

## Testing
1. Fire up this branch locally and head to http://calypso.localhost:3000/me/account
2. In the console, enter `dispatch({ type: 'I18N_LANGUAGE_NAMES_ADD', items: null })`
3. Open the language picker and search for _Deutsch_ or _Italiano_

**Expectation**
Your results should include _Deutsch_ or _Italiano_ and nothing should break :)
