### PR TITLE
State: tidy getHelpSelectedSite to early return

### DIFF
--- a/client/state/help/selectors.js
+++ b/client/state/help/selectors.js
@@ -25,14 +25,17 @@ export const getHelpSiteId = state => state.help.selectedSiteId;
 export const getHelpSelectedSite = state => {
 	const siteId = getHelpSiteId( state ) || getSelectedOrPrimarySiteId( state );
 	const helpSite = getSite( state, siteId );
+	if ( helpSite ) {
+		return helpSite;
+	}
 	// Are sites loaded but the help site is not available? We may have a bad site or primary.
 	const sites = get( state, 'sites.items' );
 	const siteKeys = sites && Object.keys( sites );
-	if ( ! helpSite && siteKeys && siteKeys.length > 0 ) {
+	if ( siteKeys && siteKeys.length > 0 ) {
 		const firstSiteId = siteKeys[ 0 ];
 		return getSite( state, firstSiteId );
 	}
-	return helpSite;
+	return null;
 };
 
 /*

--- a/client/state/help/selectors.js
+++ b/client/state/help/selectors.js
@@ -29,13 +29,8 @@ export const getHelpSelectedSite = state => {
 		return helpSite;
 	}
 	// Are sites loaded but the help site is not available? We may have a bad site or primary.
-	const sites = get( state, 'sites.items' );
-	const siteKeys = sites && Object.keys( sites );
-	if ( siteKeys && siteKeys.length > 0 ) {
-		const firstSiteId = siteKeys[ 0 ];
-		return getSite( state, firstSiteId );
-	}
-	return null;
+	const siteKeys = Object.keys( get( state, 'sites.items' ) || {} );
+	return siteKeys.length > 0 ? getSite( state, siteKeys[ 0 ] ) : null;
 };
 
 /*


### PR DESCRIPTION
Adds an early return as requested in https://github.com/Automattic/wp-calypso/pull/21769#discussion_r163402557

### Testing Instructions
- unit tests pass
- no regressions when contacting support at /help/contact 