### PR TITLE
JPO: use Calypso-style form validation in the Business Address form.

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import { get, map } from 'lodash';
+import { get, map, omit, some } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -18,6 +18,7 @@ import FormattedHeader from 'components/formatted-header';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
+import FormInputValidation from 'components/forms/form-input-validation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
@@ -68,13 +69,16 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		page( this.props.getForwardUrl() );
 	};
 
+	checkForEmptyFields = () => {
+		some( omit( this.state, 'state' ), val => val === '' );
+	};
+
 	render() {
 		const { isRequestingSettings, translate } = this.props;
 		const headerText = translate( 'Add a business address.' );
 		const subHeaderText = translate(
 			'Enter your business address to have a map added to your website.'
 		);
-
 		return (
 			<div className="steps__main">
 				<DocumentHead title={ translate( 'Business Address ‹ Jetpack Onboarding' ) } />
@@ -98,9 +102,19 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 									required={ fieldName !== 'state' }
 									value={ this.state[ fieldName ] }
 								/>
+								{ fieldName !== 'state' && (
+									<FormInputValidation
+										isError={ this.state[ fieldName ] === '' }
+										text={ translate( 'Required field.' ) }
+									/>
+								) }
 							</FormFieldset>
 						) ) }
-						<Button disabled={ isRequestingSettings } primary type="submit">
+						<Button
+							disabled={ isRequestingSettings || this.checkForEmptyFields() }
+							primary
+							type="submit"
+						>
 							{ translate( 'Next Step' ) }
 						</Button>
 					</form>


### PR DESCRIPTION
Follow up to #21582.
Addresses part of #21685.

Replaces the HTML5 `required` attribute used to validate fields in JPO Business Address form with the Calypso style validation. The Next Step button is disabled until the required fields are filled-in.

**To test**
Follow the instructions on #21582 for the Business Address step using a Business site.

![screen shot 2018-01-25 at 12 53 46](https://user-images.githubusercontent.com/13561163/35389169-8f4715aa-01ce-11e8-8e35-18fe25da4a25.png)
![screen shot 2018-01-25 at 12 53 58](https://user-images.githubusercontent.com/13561163/35389168-8e64a2f6-01ce-11e8-9c6c-051eedc7ae8d.png)

