### PR TITLE
Invites: Remove unnecessary `force=wpcom` from API call

### DIFF
--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -25,7 +25,7 @@ export function requestSiteInvites( siteId ) {
 
 		wpcom
 			.undocumented()
-			.invitesList( siteId, { force: 'wpcom', status: 'all', number: 100 } )
+			.invitesList( siteId, { status: 'all', number: 100 } )
 			.then( ( { found, invites } ) => {
 				dispatch( {
 					type: INVITES_REQUEST_SUCCESS,


### PR DESCRIPTION
Merge this *after* D9507-code on the server, which forces the invites list endpoint to always run on WP.com (this is the only way it can work correctly).  See also https://github.com/Automattic/jetpack/pull/8515.