### PR TITLE
Settings: Add accessible controls to delete site dialog elements

### DIFF
--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -340,7 +340,7 @@ class DeleteSite extends Component {
 						className="delete-site__confirm-dialog"
 					>
 						<h1 className="delete-site__confirm-header">{ strings.confirmDeleteSite }</h1>
-						<p className="delete-site__confirm-paragraph">
+						<label for="confirmDomainChangeInput" className="delete-site__confirm-paragraph">
 							{ translate(
 								'Please type in {{warn}}%(siteAddress)s{{/warn}} in the field below to confirm. ' +
 									'Your site will then be gone forever.',
@@ -353,7 +353,7 @@ class DeleteSite extends Component {
 									},
 								}
 							) }
-						</p>
+						</label>
 
 						<input
 							autoCapitalize="off"
@@ -361,6 +361,9 @@ class DeleteSite extends Component {
 							type="text"
 							onChange={ this.onConfirmDomainChange }
 							value={ this.state.confirmDomain }
+							aria-required="true"
+							tabIndex="0"
+							id="confirmDomainChangeInput"
 						/>
 					</Dialog>
 				</ActionPanel>

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -32,6 +32,7 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 import { deleteSite } from 'state/sites/actions';
 import { setSelectedSiteId } from 'state/ui/actions';
 import { isSiteAutomatedTransfer } from 'state/selectors';
+import FormLabel from 'components/forms/form-label';
 
 class DeleteSite extends Component {
 	static propTypes = {
@@ -340,7 +341,7 @@ class DeleteSite extends Component {
 						className="delete-site__confirm-dialog"
 					>
 						<h1 className="delete-site__confirm-header">{ strings.confirmDeleteSite }</h1>
-						<label for="confirmDomainChangeInput" className="delete-site__confirm-paragraph">
+						<FormLabel htmlFor="confirmDomainChangeInput" className="delete-site__confirm-label">
 							{ translate(
 								'Please type in {{warn}}%(siteAddress)s{{/warn}} in the field below to confirm. ' +
 									'Your site will then be gone forever.',
@@ -353,7 +354,7 @@ class DeleteSite extends Component {
 									},
 								}
 							) }
-						</label>
+						</FormLabel>
 
 						<input
 							autoCapitalize="off"
@@ -362,7 +363,6 @@ class DeleteSite extends Component {
 							onChange={ this.onConfirmDomainChange }
 							value={ this.state.confirmDomain }
 							aria-required="true"
-							tabIndex="0"
 							id="confirmDomainChangeInput"
 						/>
 					</Dialog>

--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -54,6 +54,7 @@ h1.delete-site__confirm-header {
 	font-size: 14px;
 	line-height: 24px;
 	color: $gray-text-min;
+	display: block;
 }
 
 .delete-site__target-domain {

--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -49,12 +49,11 @@ h1.delete-site__confirm-header {
 	color: $gray-dark;
 }
 
-.delete-site__confirm-paragraph {
+.delete-site__confirm-label {
 	margin-bottom: 8px;
-	font-size: 14px;
 	line-height: 24px;
 	color: $gray-text-min;
-	display: block;
+	font-weight: normal;
 }
 
 .delete-site__target-domain {


### PR DESCRIPTION
This PR partly addresses Issue #21223 (the Language Picker component is addressed by PR #21753)

![jan-24-2018 13-59-20](https://user-images.githubusercontent.com/6458278/35312386-3eb04c52-010f-11e8-92ec-268495662aba.gif)

## Testing
1. Open the delete site dialog and tab through the form controls.

**Expectations**
You should be able to tab through the form controls, and select them with the keyboard. 

🛑 Be careful not to delete important sites! :)