### PR TITLE
Stats: Insights: Add View All page for Annual Site Stats

### DIFF
--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -17,8 +17,10 @@ import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteStatsNormalizedData } from 'state/stats/lists/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import StatsModulePlaceholder from 'my-sites/stats/stats-module/placeholder';
 import ErrorPanel from 'my-sites/stats/stats-error';
+import QuerySiteStats from 'components/data/query-site-stats';
 
 class AnnualSiteStats extends Component {
 	static propTypes = {
@@ -27,58 +29,115 @@ class AnnualSiteStats extends Component {
 		translate: PropTypes.func,
 		numberFormat: PropTypes.func,
 		moment: PropTypes.func,
+		isWidget: PropTypes.bool,
+		siteId: PropTypes.number,
+		siteSlug: PropTypes.string,
 	};
 
-	renderContent( data ) {
-		const { translate, numberFormat } = this.props;
+	static defaultProps = {
+		isWidget: false,
+	};
+
+	renderWidgetContent( data, strings ) {
+		const { numberFormat } = this.props;
 		return (
 			<div className="annual-site-stats__content">
 				<div className="annual-site-stats__stat is-year">
-					<div className="annual-site-stats__stat-title">{ translate( 'year' ) }</div>
+					<div className="annual-site-stats__stat-title">{ strings.year }</div>
 					<div className="annual-site-stats__stat-figure is-large">{ data.year }</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">{ translate( 'total posts' ) }</div>
+					<div className="annual-site-stats__stat-title">{ strings.total_posts }</div>
 					<div className="annual-site-stats__stat-figure is-large">
 						{ numberFormat( data.total_posts ) }
 					</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">{ translate( 'total comments' ) }</div>
+					<div className="annual-site-stats__stat-title">{ strings.total_comments }</div>
 					<div className="annual-site-stats__stat-figure">
 						{ numberFormat( data.total_comments ) }
 					</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">
-						{ translate( 'avg comments per post' ) }
-					</div>
+					<div className="annual-site-stats__stat-title">{ strings.avg_comments }</div>
 					<div className="annual-site-stats__stat-figure">
 						{ numberFormat( data.avg_comments ) }
 					</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">{ translate( 'total likes' ) }</div>
+					<div className="annual-site-stats__stat-title">{ strings.total_likes }</div>
 					<div className="annual-site-stats__stat-figure">{ numberFormat( data.total_likes ) }</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">{ translate( 'avg likes per post' ) }</div>
+					<div className="annual-site-stats__stat-title">{ strings.avg_likes }</div>
 					<div className="annual-site-stats__stat-figure">{ numberFormat( data.avg_likes ) }</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">{ translate( 'total words' ) }</div>
+					<div className="annual-site-stats__stat-title">{ strings.total_words }</div>
 					<div className="annual-site-stats__stat-figure">{ numberFormat( data.total_words ) }</div>
 				</div>
 				<div className="annual-site-stats__stat">
-					<div className="annual-site-stats__stat-title">{ translate( 'avg words per post' ) }</div>
+					<div className="annual-site-stats__stat-title">{ strings.avg_words }</div>
 					<div className="annual-site-stats__stat-figure">{ numberFormat( data.avg_words ) }</div>
 				</div>
 			</div>
 		);
 	}
 
+	renderTable( data, strings ) {
+		const keys = Object.keys( strings );
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		return (
+			<div className="module-content-table is-fixed-row-header">
+				<div className="module-content-table-scroll">
+					<table cellPadding="0" cellSpacing="0">
+						<thead>
+							<tr>
+								{ keys.map( key => (
+									<th scope="col" key={ key }>
+										{ strings[ key ] }
+									</th>
+								) ) }
+							</tr>
+						</thead>
+						<tbody>
+							{ data.map( ( row, i ) => (
+								<tr key={ i }>
+									{ keys.map( ( key, j ) => {
+										const Cell = j === 0 ? 'th' : 'td';
+										return (
+											<Cell scope={ j === 0 ? 'row' : null } key={ j }>
+												{ row[ key ] }
+											</Cell>
+										);
+									} ) }
+								</tr>
+							) ) }
+						</tbody>
+					</table>
+				</div>
+			</div>
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	}
+
+	getStrings() {
+		const { translate } = this.props;
+		return {
+			year: translate( 'Year' ),
+			total_posts: translate( 'Total Posts' ),
+			total_comments: translate( 'Total Comments' ),
+			avg_comments: translate( 'Avg Comments per Post' ),
+			total_likes: translate( 'Total Likes' ),
+			avg_likes: translate( 'Avg Likes per Post' ),
+			total_words: translate( 'Total Words' ),
+			avg_words: translate( 'Avg Words per Post' ),
+		};
+	}
+
 	render() {
-		const { years, translate, moment } = this.props;
+		const { years, translate, moment, isWidget, siteId, siteSlug } = this.props;
+		const strings = this.getStrings();
 		const now = moment();
 		const currentYear = now.format( 'YYYY' );
 		let previousYear = null;
@@ -89,19 +148,38 @@ class AnnualSiteStats extends Component {
 		const previousYearData = previousYear && years && find( years, y => y.year === previousYear );
 		const isLoading = ! years;
 		const isError = ! isLoading && years.errors;
-		const noData = ! isLoading && ! isError && ! ( currentYearData || previousYearData );
+		const hasData = isWidget ? currentYearData || previousYearData : years;
+		const noData = ! isLoading && ! isError && ! hasData;
+		const noDataMsg = isWidget
+			? translate( 'No annual stats recorded for this year' )
+			: translate( 'No annual stats recorded' );
+		const viewAllLink = `/stats/annualstats/${ siteSlug }`;
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Annual Site Stats', { args: [ currentYear ] } ) } />
+				{ ! isWidget && siteId && <QuerySiteStats siteId={ siteId } statType="statsInsights" /> }
+				{ isWidget && (
+					<SectionHeader
+						href={ viewAllLink }
+						label={ translate( 'Annual Site Stats', { args: [ currentYear ] } ) }
+					/>
+				) }
 				<Card className="stats-module">
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					{ isError && <ErrorPanel message={ translate( 'Oops! Something went wrong.' ) } /> }
-					{ noData && (
-						<ErrorPanel message={ translate( 'No annual stats recorded for this year' ) } />
-					) }
-					{ currentYearData && this.renderContent( currentYearData ) }
-					{ previousYearData && this.renderContent( previousYearData ) }
+					{ noData && <ErrorPanel message={ noDataMsg } /> }
+					{ isWidget && currentYearData && this.renderWidgetContent( currentYearData, strings ) }
+					{ isWidget && previousYearData && this.renderWidgetContent( previousYearData, strings ) }
+					{ ! isWidget && years && this.renderTable( years, strings ) }
+					{ isWidget &&
+						years.length && (
+							<div className="module-expand">
+								<a href={ viewAllLink }>
+									{ translate( 'View All', { context: 'Stats: Button label to expand a panel' } ) }
+									<span className="right" />
+								</a>
+							</div>
+						) }
 				</Card>
 			</div>
 		);
@@ -112,9 +190,12 @@ class AnnualSiteStats extends Component {
 export default connect( state => {
 	const statType = 'statsInsights';
 	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSiteSlug( state, siteId );
 	const insights = getSiteStatsNormalizedData( state, siteId, statType, {} );
 
 	return {
 		years: insights.years,
+		siteId,
+		siteSlug,
 	};
 } )( localize( AnnualSiteStats ) );

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -316,6 +316,7 @@ export default {
 			'videodetails',
 			'podcastdownloads',
 			'searchterms',
+			'annualstats',
 		];
 		let momentSiteZone = i18n.moment();
 		const basePath = sectionify( context.path );

--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -67,7 +67,7 @@ const StatsInsights = props => {
 							<LatestPostSummary />
 							<MostPopular />
 							{ tagsList }
-							<AnnualSiteStats />
+							<AnnualSiteStats isWidget />
 						</div>
 						<div className="stats__module-column">
 							<Reach />

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -430,6 +430,28 @@ ul.module-header-actions {
 		z-index: z-index( 'root', '.module-content-table tbody th:first-child' );
 	}
 
+	&.is-fixed-row-header {
+		/**
+		Use of .is-fixed-row-header requires the first cell in each row to be `th` element
+		 */
+		th:first-child {
+			width: 34px; // 24 (margin-left) + 12 (margin-right) + 1 (border) + 34 = 70
+			transform: translateX(-70px);
+			background: $white;
+			position: fixed;
+			z-index: z-index('root', '.module-content-table tbody th:first-child');
+		}
+
+		.module-content-table-scroll {
+			margin-left: 70px;
+		}
+
+		th,
+		td {
+			vertical-align: bottom; // Doesn't work in FireFox without this bit
+		}
+	}
+
 	// Left this modifier as-is because these tables are likely going to change
 	// a lot or otherwise be removed, and at least it's directly dependent on
 	// being associated with a td in this structure

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -25,6 +25,7 @@ import QueryMedia from 'components/data/query-media';
 import JetpackColophon from 'components/jetpack-colophon';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getMediaItem } from 'state/selectors';
+import AnnualSiteStats from 'my-sites/stats/annual-site-stats';
 
 const StatsStrings = statsStringsFactory();
 
@@ -211,6 +212,10 @@ class StatsSummary extends Component {
 						summary
 					/>
 				);
+				break;
+			case 'annualstats':
+				title = translate( 'Annual Site Stats' );
+				summaryView = <AnnualSiteStats key="annualstats" />;
 				break;
 		}
 


### PR DESCRIPTION
Display Annual Site Stats for all years of a site on its own page. Previous work included a widget on Insights page. 

### Method
* Use the existing Site Stats modules and routing to add a `/stats/annualstats/<site>` path
* Re-use the `AnnualSiteStats` component found as a widget on the `insights` page. 