### PR TITLE
Framework: Bump eslint-config-wpcalypso to v2.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4267,8 +4267,8 @@
       }
     },
     "eslint-config-wpcalypso": {
-      "version": "1.2.0",
-      "integrity": "sha1-l3XWQrSD/4e0bF9tlXC1Q5gK16E=",
+      "version": "2.0.0",
+      "integrity": "sha512-m/G31U8K2U5qV/u/BOHSTNtJGOBDR7Y84rH5hRBMhg/jWcXnJCEPy1sA0tFKfPL1GMJkJOosRVGTdMqMjiZJoQ==",
       "dev": true
     },
     "eslint-eslines": {
@@ -6097,8 +6097,8 @@
       }
     },
     "glogg": {
-      "version": "1.0.0",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "version": "1.0.1",
+      "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "dev": true,
       "requires": {
         "sparkles": "1.0.0"
@@ -6246,7 +6246,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "gzip-size": {
@@ -10084,7 +10084,7 @@
         "stream-browserify": "2.0.1",
         "stream-http": "2.8.0",
         "string_decoder": "1.0.3",
-        "timers-browserify": "2.0.4",
+        "timers-browserify": "2.0.5",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
         "util": "0.10.3",
@@ -14879,8 +14879,8 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.4",
-      "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+      "version": "2.0.5",
+      "integrity": "sha512-BMeI1W6E2/mSaPVLUnH9rjEY1Ys2FEC/GKmE/101wusU3byZO5g68BJ5hpJEP8iD1qAJ6SzYAShGA+urHMxOzQ==",
       "requires": {
         "setimmediate": "1.0.5"
       }

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "esformatter-special-bangs": "1.0.1",
     "eslines": "1.1.0",
     "eslint": "3.8.1",
-    "eslint-config-wpcalypso": "1.2.0",
+    "eslint-config-wpcalypso": "2.0.0",
     "eslint-eslines": "0.0.6",
     "eslint-plugin-jest": "21.2.0",
     "eslint-plugin-jsx-a11y": "6.0.3",


### PR DESCRIPTION
The new version [is dropping the a11y ruleset](https://github.com/Automattic/eslint-config-wpcalypso/pull/15), which has been enabled in Calypso independently per #21687.

To test: Run this branch (and don't forget to `npm i`). In your eslint-enabled editor, verify that you get errors flagged by the `jsx-a11y/` ruleset.