### PR TITLE
JP Onboarding: Point Summary 'Visit Site' button to site

### DIFF
--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -82,15 +82,12 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { siteUrl, translate } = this.props;
 
 		const headerText = translate( 'Congratulations! Your site is on its way.' );
 		const subHeaderText = translate(
 			'You enabled Jetpack and unlocked dozens of website-bolstering features. Continue preparing your site below.'
 		);
-
-		// TODO: adapt when we have more info
-		const buttonRedirectHref = '#';
 
 		return (
 			<div className="steps__main">
@@ -112,7 +109,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 					</div>
 				</div>
 				<div className="steps__button-group">
-					<Button href={ buttonRedirectHref } primary>
+					<Button href={ siteUrl } primary>
 						{ translate( 'Visit your site' ) }
 					</Button>
 				</div>


### PR DESCRIPTION
😳 As reported by @rachelmcr and @beaulebens on the Call for Testing (p1HpG7-4O1-p2).

![image](https://user-images.githubusercontent.com/96308/35224825-9e95a8ae-ff86-11e7-9403-71c17b505836.png)

To test:
* Checkout this branch on your local Calypso.
* Make sure you're running latest `master` on your JP sandbox.
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
* Wait until being redirected to the JPO flow in Calypso.
* Skip some steps, fill in some others, until you arrive at the 'Summary' page.
* Verify that clicking the 'Visit your site' button actually takes you to your site.