### PR TITLE
JP Onboarding: Guard more tightly against empty business address settings

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -31,11 +31,11 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		zip: '',
 	};
 
-	state = get( this.props.settings, 'businessAddress', this.constructor.emptyState );
+	state = get( this.props.settings, 'businessAddress' ) || this.constructor.emptyState;
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.isRequestingSettings && ! nextProps.isRequestingSettings ) {
-			this.setState( get( nextProps.settings, 'businessAddress', this.constructor.emptyState ) );
+			this.setState( get( nextProps.settings, 'businessAddress' ) || this.constructor.emptyState );
 		}
 	}
 

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -23,21 +23,19 @@ import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
-	state = get( this.props.settings, 'businessAddress', {
+	static emptyState = {
 		city: '',
 		name: '',
 		state: '',
 		street: '',
 		zip: '',
-	} );
+	};
+
+	state = get( this.props.settings, 'businessAddress', this.constructor.emptyState );
 
 	componentWillReceiveProps( nextProps ) {
-		if (
-			this.props.isRequestingSettings &&
-			! nextProps.isRequestingSettings &&
-			nextProps.settings.businessAddress
-		) {
-			this.setState( nextProps.settings.businessAddress );
+		if ( this.props.isRequestingSettings && ! nextProps.isRequestingSettings ) {
+			this.setState( get( nextProps.settings, 'businessAddress', this.constructor.emptyState ) );
 		}
 	}
 


### PR DESCRIPTION
As reported by @beaulebens on the Call for Testing (p1HpG7-4O1-p2):

> I tried it out on an existing site (running Jetpack beta, already connected), and when I got to the adding a Contact Form page, I asked it to add one, which resulted in an error. The screen re-rendered as nothing (just the Calypso-blue background), and I see this in my console:
> 
> ![screen-shot-2018-01-23-at-10-31-12-am](https://user-images.githubusercontent.com/96308/35330923-abf634a2-0105-11e8-9a7c-23d4d8a741e7.png)

Turns out the guards I introduced with #21645 weren't quite tight enough.

**Test setup:**
* Apply https://github.com/Automattic/jetpack/pull/8596 to your JP sandbox.

**To repro the issue:**
* Checkout Calypso master
* Log into your JP sandbox
* ` wp option delete jpo_business_address`
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
* Wait until being redirected to the JPO flow in Calypso.
* Skip through the flow till the `Add a business address` step
* You'll get a blank screen and the errors in the browser console as described above.

**To verify the fix:**
* Checkout this Calypso branch.
* Repeat instructions from above. This time, there should be no blank screen and errors, but a working empty 'Business Address' form.
* Enter some information into that from, click the CTA.
* Click 'Back', verify the information you entered is in the form.
* Modify, repeat the previous step.