### PR TITLE
Checklist: Load extra checklist server-side information.

### DIFF
--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -3,14 +3,11 @@
  *
  * @format
  */
-
-import { assign, map } from 'lodash';
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-
 const tasks = {
 	about_page_updated: {
 		title: 'Create your About page',
@@ -85,7 +82,7 @@ const tasks = {
 		duration: '10 mins',
 		completedTitle: 'You published your first blog post',
 		completedButtonText: 'Edit',
-		url: '/post/$siteSlug/4',
+		url: '/post/$siteSlug/3',
 		image: '/calypso/images/stats/tasks/first-post.svg',
 		tour: 'checklistPublishPost',
 	},
@@ -144,17 +141,17 @@ export const tourForTask = id => {
 	}
 };
 
-export const onboardingTasks = currentState =>
-	map( sequence, id => {
-		const completed = currentState[ id ];
-		const task = tasks[ id ];
-		return assign( { id, completed }, task );
-	} );
-
-export const launchTask = ( { id, location, requestTour, siteSlug, track } ) => {
+export function launchTask( { task, location, requestTour, siteSlug, track } ) {
 	const checklist_name = 'new_blog';
-	const tour = tourForTask( id );
-	const url = urlForTask( id, siteSlug );
+	const url = urlForTask( task.id, siteSlug );
+	const tour = tourForTask( task.id );
+
+	if ( task.completed ) {
+		if ( url ) {
+			page( url );
+		}
+		return;
+	}
 
 	if ( ! tour && ! url ) {
 		return;
@@ -162,21 +159,28 @@ export const launchTask = ( { id, location, requestTour, siteSlug, track } ) => 
 
 	track( 'calypso_checklist_task_start', {
 		checklist_name,
-		step_name: id,
+		step_name: task.id,
 		location,
 	} );
 
 	if ( url ) {
 		page( url );
 	}
+
 	if ( tour ) {
 		requestTour( tour );
 	}
-};
+}
 
-export const launchCompletedTask = ( { id, siteSlug } ) => {
-	const url = urlForTask( id, siteSlug );
-	if ( url ) {
-		page( url );
+export function onboardingTasks( checklist ) {
+	if ( ! checklist || ! checklist.tasks ) {
+		return null;
 	}
-};
+
+	return sequence.map( id => {
+		const task = tasks[ id ];
+		const taskFromServer = checklist.tasks[ id ];
+
+		return { id, ...task, ...taskFromServer };
+	} );
+}

--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -58,7 +58,7 @@ export class ChecklistBanner extends Component {
 		const { requestTour, task, track, siteSlug } = this.props;
 
 		launchTask( {
-			id: task.id,
+			task,
 			location: 'checklist_banner',
 			requestTour,
 			siteSlug,
@@ -211,9 +211,8 @@ export class ChecklistBanner extends Component {
 }
 
 const mapStateToProps = ( state, { siteId } ) => {
-	const siteChecklist = getSiteChecklist( state, siteId );
-	const tasks = siteChecklist && siteChecklist.tasks && onboardingTasks( siteChecklist.tasks );
-	const task = find( tasks, [ 'completed', false ] );
+	const tasks = onboardingTasks( getSiteChecklist( state, siteId ) );
+	const task = find( tasks, { completed: false } );
 	const { true: completed } = countBy( tasks, 'completed' );
 	const siteSlug = getSiteSlug( state, siteId );
 	const siteDesignType = get( getSite( state, siteId ), 'options.design_type' );


### PR DESCRIPTION
Sometimes onboarding checklist needs to load some information from server-side. To achieve this, the D9563-code will add extra information to the existing API endpoint `/rest/v1/sites/YOUR_SITE_ID/checklist/` and this PR will help the checklist components use the additional data.

## Test plan

1. Apply D9563-code to your sandbox and point `public-api.wordpress.com` to the server.
2. Create a new website and move to `/checklist/YOUR_SITE_SLUG`.
3. The checklist should show up as follows.

<img width="1098" alt="2018-01-24 11 33 05" src="https://user-images.githubusercontent.com/212034/35337592-006910f0-015f-11e8-8dea-2307a2b45e3e.png">
