### PR TITLE
i18n: Switch to using smaller language JS(ON) files

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -140,14 +140,13 @@ const unsavedFormsMiddleware = () => {
 export const locales = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso locales.' );
 
-	if ( window.i18nLocaleStrings ) {
-		const i18nLocaleStringsObject = JSON.parse( window.i18nLocaleStrings );
-		reduxStore.dispatch( setLocaleRawData( i18nLocaleStringsObject ) );
+	if ( window.i18nLocaleObject ) {
+		reduxStore.dispatch( setLocaleRawData( window.i18nLocaleObject ) );
 	}
 
 	// Use current user's locale if it was not bootstrapped (non-ssr pages)
 	if (
-		! window.i18nLocaleStrings &&
+		! window.i18nLocaleObject &&
 		! config.isEnabled( 'wpcom-user-bootstrap' ) &&
 		currentUser.get()
 	) {

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -142,6 +142,7 @@ export const locales = ( currentUser, reduxStore ) => {
 
 	if ( window.i18nLocaleObject ) {
 		reduxStore.dispatch( setLocaleRawData( window.i18nLocaleObject ) );
+		delete window.i18nLocaleObject;
 	}
 
 	// Use current user's locale if it was not bootstrapped (non-ssr pages)

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -18,7 +18,7 @@ const debug = debugFactory( 'calypso:i18n' );
 function languageFileUrl( localeSlug ) {
 	const protocol = typeof window === 'undefined' ? 'https://' : '//'; // use a protocol-relative path in the browser
 
-	return `${ protocol }widgets.wp.com/languages/calypso/${ localeSlug }.json`;
+	return `${ protocol }widgets.wp.com/languages/calypso/${ localeSlug }.utf8.json`;
 }
 
 function setLocaleInDOM( localeSlug, isRTL ) {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "he": "0.5.0",
     "html-loader": "0.4.0",
     "html-to-react": "1.3.1",
-    "i18n-calypso": "1.8.4",
+    "i18n-calypso": "1.9.0",
     "immutability-helper": "2.4.0",
     "immutable": "3.7.6",
     "imports-loader": "0.6.5",

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -135,7 +135,7 @@ export function serverRender( req, res ) {
 
 	if ( ! isDefaultLocale( context.lang ) ) {
 		const langFileName = getCurrentLocaleVariant( context.store.getState() ) || context.lang;
-		context.i18nLocaleScript = '//widgets.wp.com/languages/calypso/' + langFileName + '.js';
+		context.i18nLocaleScript = '//widgets.wp.com/languages/calypso/' + langFileName + '.utf8.js';
 	}
 
 	if (


### PR DESCRIPTION
Up until now we have generated our server-side language files with UTF-8 characters escaped (e.g. `\u00e4` instead of `ä`). By switching to use the UTF-8 representation we can save quite a few bytes.

Also, when booting up Calypso, we use a `.js` instead of `.json` file that we load inline. For historical reasons, we use a construct like `var i18nLocaleStrings = '[...]';` and `JSON.parse()` this when ready. Encoding a JSON in a string requires a lot of escaping while we could simply have the browser load the object.

Calypso just consumes these files that we create on the server-side, so this needed adaptation of our language deploy process. Therefore, in order to test this using a PR, we deploy the new format files in addition to the old files, using an infix `.utf8.`.

We also implemented key hashing as per https://github.com/Automattic/i18n-calypso/pull/49. This means that the English strings no longer appear in the JSON files but a (variably truncated) SHA1 sum is used for lookup.

Here are some examples of file sizes (.js is the old version, .utf8.js the new version), the sizes are all of the gzipped variant (which we usually ship):
```
ar.js           258k
ar.utf8.js      136k

el-po.js        118k 
el-po.utf8.js   65K 

de.js           190k
de.utf8.js      123k

zh-tw.js        201k
zh-tw.utf8.js   114k
```

So, to make use of these new versions of deployed files, this PR changes the file names to be loaded, as well as simply use the JSON object, instead of parsing it.

We are currently still shipping both files in parallel so that we can transition when we deem it ready.

**Testing**

I'd ask for help with testing these changes in all the browsers that Calypso supports, as historically JSON with UTF-8 characters seemed to have problems being loaded, which is why (presumably) we originally opted for the escaped approach.

**Note:** be sure to use the Docker version so that the boot process actually uses the JS files, when switching languages on `/me/account` the JSON file is used (please verify in the dev console of your browser which file is loaded).