### PR TITLE
Plans: Fix property access on undefined

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { noop } from 'lodash';
+import { get, noop } from 'lodash';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 
@@ -254,16 +254,19 @@ class PlanFeaturesHeader extends Component {
 		if ( site.jetpack ) {
 			const [ discountPrice, originalPrice ] = isYearly
 				? [ relatedMonthlyPlan.raw_price * 12, rawPrice ]
-				: [ rawPrice * 12, relatedYearlyPlan.raw_price ];
+				: [ rawPrice * 12, get( relatedYearlyPlan, 'raw_price' ) ];
 
 			return (
-				<PlanIntervalDiscount
-					currencyCode={ currencyCode }
-					discountPrice={ discountPrice }
-					isYearly={ isYearly }
-					originalPrice={ originalPrice }
-					site={ site }
-				/>
+				!! discountPrice &&
+				!! originalPrice && (
+					<PlanIntervalDiscount
+						currencyCode={ currencyCode }
+						discountPrice={ discountPrice }
+						isYearly={ isYearly }
+						originalPrice={ originalPrice }
+						site={ site }
+					/>
+				)
 			);
 		}
 		return null;


### PR DESCRIPTION
There appears to have been a race condition introduced in #21725 where plans data may be accessed before it is ready. This PR protects against this by adding safe property access to prevent the observed error.

## Testing
1. The issue can be observed by visiting `/jetpack/connect/store` when running with persistence disabled `ENABLE_FEATURES=force-sympathy npm start`
1. Ensure the page loads correctly when running this PR.