### PR TITLE
JP Onboarding: Change target for 'Choose a Theme' link

### DIFF
--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -62,7 +62,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 			},
 			THEME: {
 				label: translate( 'Choose a Theme' ),
-				url: siteUrl + '/wp-admin/themes.php',
+				url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
 			},
 			PAGES: {
 				label: translate( 'Add additional pages' ),


### PR DESCRIPTION
As requested by @gravityrail on the the Call for Testing (p1HpG7-4O1-p2):

> When I clicked to select a theme, it took me to the themes that are already installed. Typically a new user will want to go to the theme directory – or if they’re already connected to Jetpack they might want to select from WPCOM themes

To test:
* Checkout this branch on your local Calypso.
* Make sure you're running latest `master` on your JP sandbox.
* Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
* Wait until being redirected to the JPO flow in Calypso.
* Skip some steps, fill in some others, until you arrive at the 'Summary' page.
* Verify that clicking the 'Choose a Theme' link takes you to `https://YourJetpackSandbox.com/wp-admin/theme-install.php?browse=featured`