### PR TITLE
JP Onboarding: Hide Masterbar

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -471,6 +471,7 @@ $autobar-height: 20px;
 	transition: all 0.3s ease-in-out;
 }
 
+.is-section-jetpack-onboarding .masterbar,
 .is-section-post-editor .masterbar {
 	opacity: 0;
 	pointer-events: none;


### PR DESCRIPTION
As suggested by testers on the JPO Call for Testing, p1HpG7-4O1-p2:

@beaulebens (#comment-24217):

> I was actually going to comment about the masterbar, and about if we even want it there at all? It seems like a distraction from the process, and somewhat incongruous if we assume that most people following this flow will be logged out, and likely have no exposure to/context around WP.com at all.

@alisterscott (#comment-24207):

> Also, the My Sites and Reader links take away from the focus of the set up flow IMO, and there isn’t an easy way to return to the flow if you use these links. Could we remove them?

This needs some serious design signoff 😅 (design-off?)

To test:

After logging into your self hosted site, go to `http://yourgroovydomain.com/wp-admin/admin.php?page=jetpack&action=onboard` where `yourgroovydomain.com` is the domain of your remote site. You will be redirected to the Jetpack Onboarding flow in Calypso.

Before:

![image](https://user-images.githubusercontent.com/96308/35343422-e782d06e-012a-11e8-95dd-d90973fdb667.png)

After:

![image](https://user-images.githubusercontent.com/96308/35343393-d2a7dd38-012a-11e8-9bb1-d1d5c874de2c.png)
