### PR TITLE
Remove site segment a/b test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -64,14 +64,6 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	signupSiteSegmentStep: {
-		datestamp: '20170329',
-		variations: {
-			control: 0,
-			variant: 100,
-		},
-		defaultVariation: 'control',
-	},
 	checklistThankYouForFreeUser: {
 		datestamp: '20171204',
 		variations: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -13,7 +13,6 @@ import i18n from 'i18n-calypso';
 import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
-import { abtest } from 'lib/abtest';
 const user = userFactory();
 
 function getCheckoutUrl( dependencies ) {
@@ -60,50 +59,43 @@ const flows = {
 	},
 
 	business: {
-		steps: [ 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'about', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
 		description: 'Create an account and a blog and then add the business plan to the users cart.',
-		lastModified: '2016-06-02',
+		lastModified: '2018-01-24',
 		meta: {
 			skipBundlingPlan: true,
 		},
 	},
 
-	segment: {
-		steps: [ 'about', 'domains', 'plans', 'user' ],
-		destination: getSiteDestination,
-		description: 'A new signup flow for segmenting our users',
-		lastModified: '2017-11-11',
-	},
-
 	premium: {
-		steps: [ 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'about', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
 		description: 'Create an account and a blog and then add the premium plan to the users cart.',
-		lastModified: '2016-06-02',
+		lastModified: '2018-01-24',
 		meta: {
 			skipBundlingPlan: true,
 		},
 	},
 
 	personal: {
-		steps: [ 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'about', 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/personal/' + dependencies.siteSlug;
 		},
 		description: 'Create an account and a blog and then add the personal plan to the users cart.',
-		lastModified: '2016-01-21',
+		lastModified: '2018-01-24',
 	},
 
 	free: {
-		steps: [ 'design-type', 'themes', 'domains', 'user' ],
+		steps: [ 'about', 'themes', 'domains', 'user' ],
 		destination: getSiteDestination,
 		description: 'Create an account and a blog and default to the free plan.',
-		lastModified: '2016-06-02',
+		lastModified: '2018-01-24',
 	},
 
 	blog: {
@@ -128,10 +120,10 @@ const flows = {
 	},
 
 	store: {
-		steps: [ 'design-type-with-store', 'domains', 'plans', 'user' ],
+		steps: [ 'about', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'Signup flow for creating an online store',
-		lastModified: '2016-06-27',
+		lastModified: '2018-01-24',
 	},
 
 	'rebrand-cities': {
@@ -168,10 +160,10 @@ const flows = {
 	},
 
 	main: {
-		steps: [ 'design-type', 'domains', 'plans', 'user' ],
+		steps: [ 'about', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'The current best performing flow in AB tests',
-		lastModified: '2016-05-23',
+		lastModified: '2018-01-24',
 	},
 
 	surveystep: {
@@ -198,28 +190,28 @@ const flows = {
 	},
 
 	'delta-blog': {
-		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description:
 			'A copy of the `blog` flow for the Delta email campaigns. Half of users who go ' +
 			'through this flow receive a blogging-specific drip email series.',
-		lastModified: '2016-03-09',
+		lastModified: '2018-01-24',
 	},
 
 	'delta-site': {
-		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description:
 			'A copy of the `website` flow for the Delta email campaigns. Half of users who go ' +
 			'through this flow receive a website-specific drip email series.',
-		lastModified: '2016-03-09',
+		lastModified: '2018-01-24',
 	},
 
 	desktop: {
-		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
 		destination: getPostsDestination,
 		description: 'Signup flow for desktop app',
-		lastModified: '2016-05-30',
+		lastModified: '2018-01-24',
 	},
 
 	developer: {
@@ -263,18 +255,10 @@ const flows = {
 
 if ( config.isEnabled( 'signup/atomic-store-flow' ) ) {
 	flows[ 'store-nux' ] = {
-		steps: [ 'design-type-with-store-nux', 'themes', 'domains', 'plans-store-nux', 'user' ],
-		destination: getSiteDestination,
-		description: 'Signup flow for creating an online store with an Atomic site',
-		lastModified: '2017-09-27',
-	};
-
-	flows[ 'segmented-store-nux' ] = {
 		steps: [ 'about', 'themes', 'domains', 'plans-store-nux', 'user' ],
 		destination: getSiteDestination,
-		description:
-			'Signup flow for creating an online store with an Atomic site from the new site segementing step',
-		lastModified: '2017-12-15',
+		description: 'Signup flow for creating an online store with an Atomic site',
+		lastModified: '2018-01-24',
 	};
 }
 
@@ -342,14 +326,6 @@ function replaceStepInFlow( flow, oldStepName, newStepName ) {
 function filterDesignTypeInFlow( flowName, flow ) {
 	if ( ! flow ) {
 		return;
-	}
-
-	if (
-		includes( flow.steps, 'design-type' ) &&
-		abtest( 'signupSiteSegmentStep' ) === 'variant' &&
-		flowName !== 'subdomain'
-	) {
-		return replaceStepInFlow( flow, 'design-type', 'about' );
 	}
 
 	if ( config.isEnabled( 'signup/atomic-store-flow' ) ) {

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -284,7 +284,7 @@ class AboutStep extends Component {
 		//Site Goals
 		this.props.setSiteGoals( siteGoalsInput );
 		themeRepo = getThemeForSiteGoals( siteGoalsInput );
-		designType = getSiteTypeForSiteGoals( siteGoalsInput );
+		designType = getSiteTypeForSiteGoals( siteGoalsInput, this.props.flowName );
 
 		for ( let i = 0; i < siteGoalsArray.length; i++ ) {
 			this.props.recordTracksEvent( 'calypso_signup_actions_user_input', {
@@ -316,7 +316,7 @@ class AboutStep extends Component {
 
 		//Store
 		const nextFlowName =
-			designType === DESIGN_TYPE_STORE ? 'segmented-store-nux' : this.props.flowName;
+			designType === DESIGN_TYPE_STORE ? 'store-nux' : this.props.flowName;
 
 		//Pressable
 		if (

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -166,11 +166,11 @@ export function getThemeForSiteGoals( siteGoals ) {
 	return 'pub/independent-publisher-2';
 }
 
-export function getSiteTypeForSiteGoals( siteGoals ) {
+export function getSiteTypeForSiteGoals( siteGoals, flow ) {
 	const siteGoalsValue = siteGoals.split( ',' );
 
 	//Identify stores for the store signup flow
-	if ( siteGoals === 'sell' ) {
+	if ( siteGoals === 'sell' || flow === 'store-nux' ) {
 		return 'store';
 	}
 


### PR DESCRIPTION
We recently tested a new site segment step in signup and it beat our existing design-type step. This PR removes the a/b test and replaces the `design-type` step in all cases but one, for subdomains. 

## Screenshot

![image](https://user-images.githubusercontent.com/6981253/35345240-1ba6f506-00fd-11e8-8109-4e4bd1d99b67.png)

## Testing instructions
There are a couple cases to test here:

**Regular flow**
- Visit `/start`
- You should see the new site segmenting step as your first screen

**Store flow**
- Visit `/start/store-nux`
- Pick any options from site segmenting screen then click "Continue"
- You should see themes as next step after segmenting step
- Then when you proceed to the domain step, you should not see any free .wordpress sub domains
- On plans step, you should only see the Business plan

**Plan flows**
- Ensure you are in the `hide` bucket for `checklistThankYouForFreeUser` A/B test 
- Visit `/start/business`, `/start/premium`, or `/start/personal`
- Continue through signup flow, your plan should show up in the cart after your site has been created.

**Subdomains**
This should behave as it currently does.

- Visit `/start/subdomain?vertical=a8c.3`
- You should see the old site type step with four options, the site segmenting step doesn't work for this flow yet.
- proceed to the domain step and ensure that your first result is a .business.blog domain. 


cc @allendav @taggon 