### PR TITLE
Build: enable scope hoisting

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -201,6 +201,7 @@ const webpackConfig = {
 			filename: 'assets.json',
 			path: path.join( __dirname, 'server', 'bundler' ),
 		} ),
+		process.env.NODE_ENV === 'production' && new webpack.optimize.ModuleConcatenationPlugin(),
 	] ),
 	externals: [ 'electron' ],
 };


### PR DESCRIPTION
Dependent on merging: https://github.com/Automattic/wp-calypso/pull/16057

[Scope hoisting](https://webpack.js.org/plugins/module-concatenation-plugin/#src/components/Sidebar/Sidebar.jsx) was the flagship feature of Webpack3 and generates smaller code and a faster runtime by removing wepback wrapper funcs in favor of direct inlining when possible.
It should only be enabled in production.  Once we finish ditching CJS in 16057, we can test it out!