### PR TITLE
Store: Add altText for PaymentLogo in PaymentMethod.

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-payment-method.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-payment-method.js
@@ -53,7 +53,11 @@ const PaymentMethod = ( {
 	const renderPlaceholder = () => (
 		<CompactCard className="label-settings__card">
 			<FormCheckbox className="label-settings__card-checkbox" />
-			<PaymentLogo className="label-settings__card-logo" type="placeholder" />
+			<PaymentLogo
+				className="label-settings__card-logo"
+				type="placeholder"
+				altText={ translate( 'Payment logo placeholder.' ) }
+			/>
 			<div className="label-settings__card-details">
 				<p className="label-settings__card-number" />
 				<p className="label-settings__card-name" />
@@ -79,7 +83,15 @@ const PaymentMethod = ( {
 				checked={ selected }
 				onChange={ onSelect }
 			/>
-			<PaymentLogo className="label-settings__card-logo" type={ typeId } />
+			<PaymentLogo
+				className="label-settings__card-logo"
+				type={ typeId }
+				altText={ translate( 'Payment %(typeName)s', {
+					args: {
+						typeName,
+					},
+				} ) }
+			/>
 			<div className="label-settings__card-details">
 				<p className="label-settings__card-number">{ typeName }</p>
 				<p className="label-settings__card-name">{ name }</p>

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-payment-method.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-payment-method.js
@@ -53,11 +53,7 @@ const PaymentMethod = ( {
 	const renderPlaceholder = () => (
 		<CompactCard className="label-settings__card">
 			<FormCheckbox className="label-settings__card-checkbox" />
-			<PaymentLogo
-				className="label-settings__card-logo"
-				type="placeholder"
-				altText={ translate( 'Payment logo placeholder.' ) }
-			/>
+			<PaymentLogo className="label-settings__card-logo" type="placeholder" altText={ '' } />
 			<div className="label-settings__card-details">
 				<p className="label-settings__card-number" />
 				<p className="label-settings__card-name" />
@@ -83,15 +79,7 @@ const PaymentMethod = ( {
 				checked={ selected }
 				onChange={ onSelect }
 			/>
-			<PaymentLogo
-				className="label-settings__card-logo"
-				type={ typeId }
-				altText={ translate( 'Payment %(typeName)s', {
-					args: {
-						typeName,
-					},
-				} ) }
-			/>
+			<PaymentLogo className="label-settings__card-logo" type={ typeId } altText={ '' } />
 			<div className="label-settings__card-details">
 				<p className="label-settings__card-number">{ typeName }</p>
 				<p className="label-settings__card-name">{ name }</p>


### PR DESCRIPTION
### Information 
AltText is now required for in `PaymentLogo` https://github.com/Automattic/wp-calypso/blame/master/client/components/payment-logo/index.jsx#L14 this results in following `Warnign`
![image](https://user-images.githubusercontent.com/17271089/35348475-79d0764e-0138-11e8-8b61-f44a0c7dad0c.png)
This PR adds missing altText. I am not 100% that this is proper altText but it feels OK.

### Testing
1. Go to Store
2. Go to Settings
3. Go to Shipping Settings
4. Observe browser console - there should be no ^ warning. 