### PR TITLE
Rewind Credentials: Prefill server host field with site slug when possible

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-form/index.jsx
@@ -21,7 +21,7 @@ import FormInputValidation from 'components/forms/form-input-validation';
 import FormPasswordInput from 'components/forms/form-password-input';
 import Gridicon from 'gridicons';
 import { deleteCredentials, updateCredentials } from 'state/jetpack/credentials/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isUpdatingJetpackCredentials } from 'state/selectors';
 
 export class CredentialsForm extends Component {
@@ -241,9 +241,11 @@ export class CredentialsForm extends Component {
 	}
 }
 
-const mapStateToProps = state => ( {
-	formIsSubmitting: isUpdatingJetpackCredentials( state, getSelectedSiteId( state ) ),
-} );
+const mapStateToProps = ( state, { host } ) =>
+	Object.assign(
+		{ formIsSubmitting: isUpdatingJetpackCredentials( state, getSelectedSiteId( state ) ) },
+		! host && { host: getSelectedSiteSlug( state, getSelectedSiteId( state ) ) }
+	);
 
 export default connect( mapStateToProps, { deleteCredentials, updateCredentials } )(
 	localize( CredentialsForm )


### PR DESCRIPTION
Replaces #21733 

This is part of an attempt to help make credentials entry easier for customers. We'll use Calypso's siteSlug value as the server address by default, since this is likely to be correct in most cases.

**Testing**

1. Attempt to add credentials for a non-Pressable site. Ensure the host field is pre-filled with the server address.
2. Make sure the address saves correctly and Rewind works.
3. Make sure you can change the address from what is prefilled, and it saves and persists on a new page load.