### PR TITLE
Save data for new site segmenting fields

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -26,6 +26,8 @@ import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
 import { getSiteId } from 'state/selectors';
+import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
+import { getUserExperience } from 'state/signup/steps/user-experience/selectors';
 import { requestSites } from 'state/sites/actions';
 
 const debug = debugFactory( 'calypso:signup:step-actions' );
@@ -110,6 +112,7 @@ export function createSiteWithCart(
 	const designType = getDesignType( reduxStore.getState() ).trim();
 	const siteTitle = getSiteTitle( reduxStore.getState() ).trim();
 	const surveyVertical = getSurveyVertical( reduxStore.getState() ).trim();
+	const siteGoals = getSiteGoals( reduxStore.getState() ).trim();
 
 	wpcom.undocumented().sitesNew(
 		{
@@ -122,6 +125,7 @@ export function createSiteWithCart(
 				// query. See `getThemeSlug` in `DomainsStep`.
 				theme: dependencies.themeSlugWithRepo || themeSlugWithRepo,
 				vertical: surveyVertical || undefined,
+				siteGoals: siteGoals || undefined,
 			},
 			validate: false,
 			find_available_url: isPurchasingItem,
@@ -314,6 +318,7 @@ export function createAccount(
 ) {
 	const surveyVertical = getSurveyVertical( reduxStore.getState() ).trim();
 	const surveySiteType = getSurveySiteType( reduxStore.getState() ).trim();
+	const userExperience = getUserExperience( reduxStore.getState() );
 
 	if ( service ) {
 		// We're creating a new social account
@@ -348,6 +353,7 @@ export function createAccount(
 					signup_flow_name: flowName,
 					nux_q_site_type: surveySiteType,
 					nux_q_question_primary: surveyVertical,
+					nux_q_question_experience: userExperience || undefined,
 					// url sent in the confirmation email
 					jetpack_redirect: queryArgs.jetpack_redirect,
 				},


### PR DESCRIPTION
This PR adds code that saves the values entered on the new site segmenting screen into `blog options` and `user attributes`. It will need to be tested in conjunction with the following DIF: https://code.a8c.com/D9574

# Test instructions
- Connect to your sandbox for `public-api.wordpress.com`
- run `arc patch D9574`
- Checkout this branch and visit `/start` in an incognito window
- Create a new site + user and remember the values you entered on step one.
- Return to your sandbox and:
 - Use `wp shell` to view blog options `switch_to_blog(BLOG_ID)`, then `get_option('options')`. Where BLOG_ID is equal to the new site's ID you created.
 - Then use `wpsh` to view the user attributes `gpr select * from wp_user_attributes where user_id=USERID`, where USERID is equal to the new user id you created

@velesin @taggon 
