### PR TITLE
Purchases: Fix alignment of chat button in payment box

### DIFF
--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -778,7 +778,10 @@
 	}
 
 	@include breakpoint( '>960px' ) {
-		float: right;
+		display: flex;
+		flex-grow: 1;
+		align-items: center;
+		justify-content: right;
 	}
 }
 


### PR DESCRIPTION
As part of #21200, we now have toggles for presales and precancellation chat. In the payment box though currently, the presales chat button overlaps existing text. This PR positions the chat button in the payments box correctly on the right.

It still hits some weird breakpoints <960px but >660px. I'd love a bit of design advice on how to better tackle this.

## To test
You can test this in one of two ways:

1. You can turn on the toggle for presales chat. The toggle is available in a link provided by this code review D8590-code. If you're familiar, it's under Network Admin in the Happiness settings.
2. Once you turn on presales chat, you can put a Business plan in your cart and try to go to checkout.

The second way is by checking out this pull request and doing the following:

1. Edit the `isPresalesChatAvailable` selector to return `true` under [`/state/happychat/selectors/is-presales-chat-available.js.`](https://github.com/Automattic/wp-calypso/blob/master/client/state/happychat/selectors/is-presales-chat-available.js)
2. Put a Business plan in your cart and try to checkout.

The mobile layout and laptop and larger screens look fine. The ~700px layout wraps as shown below. I'm not sure if this is a deal breaker or not.

## Screenshots

**Current**

<img width="858" alt="screen shot 2018-01-24 at 2 27 14 pm" src="https://user-images.githubusercontent.com/7240478/35358452-f30eab7c-0113-11e8-8185-24626118bc4e.png">

**Updated**
<img width="790" alt="screen shot 2018-01-24 at 2 28 54 pm" src="https://user-images.githubusercontent.com/7240478/35358462-fe51d0d6-0113-11e8-876f-6859febfc71e.png">

**700px**
Issue with wrapping text.

<img width="495" alt="screen shot 2018-01-24 at 2 28 41 pm" src="https://user-images.githubusercontent.com/7240478/35358486-11ad4278-0114-11e8-922f-97294c437119.png">

**Mobile**
<img width="600" alt="screen shot 2018-01-24 at 2 28 47 pm" src="https://user-images.githubusercontent.com/7240478/35358507-1b89a7d2-0114-11e8-9d9e-5da68ad5e83a.png">
