### PR TITLE
Fix: Invalid import from Happychat schema

### DIFF
--- a/client/state/happychat/user/reducer.js
+++ b/client/state/happychat/user/reducer.js
@@ -12,7 +12,7 @@ import { combineReducers, createReducer } from 'state/utils';
 import {
 	geoLocationSchema,
 	isEligibleSchema,
-	isPresalesPrecancellationEligibleSchema,
+	isPresalesPrecancellationEligible as isPresalesPrecancellationEligibleSchema,
 } from './schema';
 
 /**


### PR DESCRIPTION
This import was a typo and so it was `undefined`

Once we turned off compiling to CommonJS webpack was able to identify
and complain about this. This patch fixes the import.

**Testing**

This was just broken before and I'm not sure how to test it but I'm fairly
confident that this is the fix because it's statically-analyzable.

Testing here should actually try to reveal if the existing bug was hiding
other bugs.