### PR TITLE
Store: Product Trash Pickup

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { head } from 'lodash';
+import { head, isNumber } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 
@@ -70,12 +70,10 @@ class ProductCreate extends React.Component {
 	};
 
 	componentDidMount() {
-		const { product, site } = this.props;
+		const { site } = this.props;
 
 		if ( site && site.ID ) {
-			if ( ! product ) {
-				this.props.editProduct( site.ID, null, {} );
-			}
+			this.props.editProduct( site.ID, null, {} );
 			this.props.fetchProductCategories( site.ID );
 		}
 	}
@@ -189,6 +187,10 @@ class ProductCreate extends React.Component {
 		const isValid = 'undefined' !== site && this.isProductValid();
 		const isBusy = Boolean( actionList ); // If there's an action list present, we're trying to save.
 		const saveEnabled = isValid && ! isBusy && 0 === this.state.isUploading.length;
+
+		if ( ! product || isNumber( product.id ) ) {
+			return null;
+		}
 
 		return (
 			<Main className={ className } wideLayout>

--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -47,6 +47,7 @@ import ProductForm from './product-form';
 import ProductHeader from './product-header';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { withAnalytics, recordTracksEvent } from 'state/analytics/actions';
+import { getSaveErrorMessage } from './save-error-message';
 
 class ProductCreate extends React.Component {
 	static propTypes = {
@@ -156,11 +157,13 @@ class ProductCreate extends React.Component {
 			return getSuccessNotice( newProduct );
 		};
 
-		const failureAction = errorNotice(
-			translate( 'There was a problem saving %(product)s. Please try again.', {
-				args: { product: product.name },
-			} )
-		);
+		const failureAction = error => {
+			const errorSlug = ( error && error.error ) || undefined;
+
+			return errorNotice( getSaveErrorMessage( errorSlug, product.name, translate ), {
+				duration: 8000,
+			} );
+		};
 
 		if ( ! product.type ) {
 			// Product type was never switched, so set it before we save.

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
 import config from 'config';
 import i18n from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { trim, debounce, isNumber } from 'lodash';
+import { trim, isNumber } from 'lodash';
 
 /**
  * Internal dependencies
@@ -45,7 +45,6 @@ export default class ProductFormDetailsCard extends Component {
 
 		this.setName = this.setName.bind( this );
 		this.setDescription = this.setDescription.bind( this );
-		this.debouncedSetDescription = debounce( this.setDescription, 200 );
 	}
 
 	// TODO: Consider consolidating the following set functions
@@ -108,7 +107,7 @@ export default class ProductFormDetailsCard extends Component {
 		return (
 			<CompactTinyMCE
 				initialValue={ product.description || '' }
-				onContentsChange={ this.debouncedSetDescription }
+				onContentsChange={ this.setDescription }
 			/>
 		);
 	};

--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -48,6 +48,7 @@ import {
 	clearProductCategoryEdits,
 } from 'woocommerce/state/ui/product-categories/actions';
 import { getProductCategoriesWithLocalEdits } from 'woocommerce/state/ui/product-categories/selectors';
+import { getSaveErrorMessage } from './save-error-message';
 import page from 'page';
 import ProductForm from './product-form';
 import ProductHeader from './product-header';
@@ -174,11 +175,13 @@ class ProductUpdate extends React.Component {
 			);
 		};
 
-		const failureAction = errorNotice(
-			translate( 'There was a problem saving %(product)s. Please try again.', {
-				args: { product: product.name },
-			} )
-		);
+		const failureAction = error => {
+			const errorSlug = ( error && error.error ) || undefined;
+
+			return errorNotice( getSaveErrorMessage( errorSlug, product.name, translate ), {
+				duration: 8000,
+			} );
+		};
 
 		this.props.createProductActionList( successAction, failureAction );
 	};

--- a/client/extensions/woocommerce/app/products/save-error-message.js
+++ b/client/extensions/woocommerce/app/products/save-error-message.js
@@ -1,0 +1,12 @@
+export function getSaveErrorMessage( slug, productName, translate ) {
+	switch ( slug ) {
+		case 'product_invalid_sku':
+			return translate( 'There was a problem saving %(product)s. A product already exists with this SKU.', {
+				args: { product: productName },
+			} );
+		default:
+			return translate( 'There was a problem saving %(product)s. Please try again.', {
+				args: { product: productName },
+			} );
+	}
+}

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/index.js
@@ -107,11 +107,7 @@ class FormClickToEditInput extends Component {
 				</span>
 
 				{ ! disabled && (
-					<Button
-						borderless
-						onClick={ this.editStart ? this.ediStart : undefined }
-						aria-label={ editAriaLabel }
-					>
+					<Button borderless onClick={ this.editStart } aria-label={ editAriaLabel }>
 						<Gridicon icon="pencil" />
 					</Button>
 				) }

--- a/client/extensions/woocommerce/components/form-click-to-edit-input/style.scss
+++ b/client/extensions/woocommerce/components/form-click-to-edit-input/style.scss
@@ -1,7 +1,7 @@
 .form-click-to-edit-input__wrapper {
 
 	.gridicon {
-		margin-left: 8px;
+		margin-left: 4px;
 		width: 13px;
 		height: 13px;
 		top: 0;

--- a/client/extensions/woocommerce/state/data-layer/ui/products/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/products/index.js
@@ -90,8 +90,12 @@ export function handleProductActionListCreate( store, action ) {
 		}
 		return dispatch( successAction );
 	};
-	const onFailure = dispatch => {
-		dispatch( failureAction );
+	const onFailure = ( dispatch, { productError } ) => {
+		if ( isFunction( failureAction ) ) {
+			dispatch( failureAction( productError ) );
+		} else {
+			dispatch( failureAction );
+		}
 		dispatch( actionListClear() );
 	};
 	const actionList = makeProductActionList(
@@ -240,6 +244,15 @@ const productSuccess = ( actionList, type ) => (
 	dispatch( actionListStepSuccess( newActionList ) );
 };
 
+const productFailure = actionList => ( dispatch, getState, { error } ) => {
+	const newActionList = {
+		...actionList,
+		productError: error,
+	};
+
+	dispatch( actionListStepFailure( newActionList ) );
+};
+
 export function makeProductSteps( rootState, siteId, productEdits ) {
 	if ( ! productEdits ) {
 		return [];
@@ -261,7 +274,7 @@ export function makeProductSteps( rootState, siteId, productEdits ) {
 							siteId,
 							getCorrectedProduct( product, categoryIdMapping ),
 							productSuccess( actionList, 'create' ),
-							actionListStepFailure( actionList )
+							productFailure( actionList )
 						)
 					);
 				},
@@ -288,7 +301,7 @@ export function makeProductSteps( rootState, siteId, productEdits ) {
 								siteId,
 								getCorrectedProduct( product, categoryIdMapping ),
 								productSuccess( actionList, 'update' ),
-								actionListStepFailure( actionList )
+								productFailure( actionList )
 							)
 						);
 					},

--- a/client/extensions/woocommerce/state/data-layer/ui/products/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/products/test/index.js
@@ -15,7 +15,6 @@ import {
 	handleProductCategoryEdit,
 	makeProductActionList,
 } from '../';
-import { actionListStepFailure } from 'woocommerce/state/action-list/actions';
 import {
 	WOOCOMMERCE_PRODUCT_CREATE,
 	WOOCOMMERCE_PRODUCT_UPDATE,
@@ -267,8 +266,9 @@ describe( 'handlers', () => {
 					type: WOOCOMMERCE_PRODUCT_CREATE,
 					siteId: 123,
 					product: product1,
-					failureAction: actionListStepFailure( actionList ),
-				} ).and( match.has( 'successAction' ) )
+				} )
+					.and( match.has( 'successAction' ) )
+					.and( match.has( 'failureAction' ) )
 			);
 		} );
 
@@ -292,8 +292,9 @@ describe( 'handlers', () => {
 					type: WOOCOMMERCE_PRODUCT_CREATE,
 					siteId: 123,
 					product: product1,
-					failureAction: actionListStepFailure( actionList ),
-				} ).and( match.has( 'successAction' ) )
+				} )
+					.and( match.has( 'successAction' ) )
+					.and( match.has( 'failureAction' ) )
 			);
 
 			expect( dispatch ).to.have.been.calledWith(
@@ -301,8 +302,9 @@ describe( 'handlers', () => {
 					type: WOOCOMMERCE_PRODUCT_CREATE,
 					siteId: 123,
 					product: product2,
-					failureAction: actionListStepFailure( actionList ),
-				} ).and( match.has( 'successAction' ) )
+				} )
+					.and( match.has( 'successAction' ) )
+					.and( match.has( 'failureAction' ) )
 			);
 		} );
 

--- a/client/extensions/woocommerce/state/sites/products/reducer.js
+++ b/client/extensions/woocommerce/state/sites/products/reducer.js
@@ -18,6 +18,7 @@ import {
 	WOOCOMMERCE_PRODUCTS_REQUEST_FAILURE,
 	WOOCOMMERCE_PRODUCT_UPDATED,
 } from 'woocommerce/state/action-types';
+import { decodeEntities } from 'lib/formatting';
 
 export default createReducer(
 	{},
@@ -39,16 +40,17 @@ export default createReducer(
  */
 function updateCachedProduct( products, product ) {
 	let found = false;
+	const updatedProduct = { ...product, name: decodeEntities( product.name ) };
 	const newProducts = products.map( p => {
 		if ( p.id === product.id ) {
 			found = true;
-			return product;
+			return updatedProduct;
 		}
 		return p;
 	} );
 
 	if ( ! found ) {
-		newProducts.push( product );
+		newProducts.push( updatedProduct );
 	}
 
 	return newProducts;


### PR DESCRIPTION
This PR does some trash pickup around products. The following issues are addressed:

* Fixes #20774 “SKU pencil doesn't activate edit mode”.
* Fixes #20490 “Clicking Add Product after editing product description causes crash”.
* Fixes #16218 “Show a proper error message when a duplicate SKU is found.”
* Fixes #21036 "Product Name Encoding Entities”.

To Test:

* Run `npm run test-client client/extensions/woocommerce` and make sure all tests pass.
* Go to an existing product and click the pencil icon, verifying that the SKU input becomes editable. Close the input.
* Add an entity ( & ) to your title and click save. Verify that the success message and input field don’t replace your & with &amp;.
* Open your dev console.
* Click “Add” on the sidebar, and verify that you are taken to the add a product form. Verify that the form loads and there is not a huge warning explosion in your console.
* Create a new product and give it a SKU that matches an existing SKU. Save and verify you get the duplicate SKU error message. Change your SKU, save, and verify the product saves.
* When you are redirected to the products list, verify products are correctly listed.
