### PR TITLE
Rewind: Update `/rewind` endpoint schema

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -25,8 +25,16 @@ const transformDownload = data =>
 		data.validUntil && { validUntil: new Date( data.validUntil * 1000 ) }
 	);
 
-const transformRestore = data =>
-	Object.assign( { status: data.status }, data.percent && { percent: data.percent } );
+const transformRewind = data =>
+	Object.assign(
+		{
+			restoreId: data.restore_id,
+			startedAt: new Date( data.started_at ),
+			status: data.status,
+		},
+		data.percent && { percent: data.percent },
+		data.reason && { reason: data.reason }
+	);
 
 export const transformApi = data =>
 	Object.assign(
@@ -37,5 +45,5 @@ export const transformApi = data =>
 		data.credentials && { credentials: data.credentials.map( transformCredential ) },
 		data.downloads && { downloads: data.downloads.map( transformDownload ) },
 		data.reason && { failureReason: data.reason },
-		data.rewinds && { rewinds: data.rewinds.map( transformRestore ) }
+		data.rewind && { rewind: transformRewind( data.rewind ) }
 	);

--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -8,7 +8,7 @@ import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx, makeParser } from 'state/data-layer/wpcom-http/utils';
 import { transformApi } from './api-transformer';
-import { rewind } from './schema';
+import { rewindStatus } from './schema';
 
 import downloads from './downloads';
 
@@ -52,7 +52,7 @@ export default mergeHandlers( downloads, {
 			fetch: fetchRewindState,
 			onSuccess: updateRewindState,
 			onError: setUnknownState,
-			fromApi: makeParser( rewind, {}, transformApi ),
+			fromApi: makeParser( rewindStatus, {}, transformApi ),
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -27,13 +27,13 @@ export const download = {
 export const rewind = {
 	type: 'object',
 	properties: {
-		rewindId: { type: 'number' },
+		rewind_id: { type: 'integer' },
 		status: { type: 'string', enum: [ 'failed', 'finished', 'running' ] },
-		startedAt: { type: 'string' },
+		started_at: { type: 'string' },
 		progress: { type: 'integer' },
 		reason: { type: 'string' },
 	},
-	required: [ 'restoreId', 'status' ],
+	required: [ 'restore_id', 'status' ],
 };
 
 export const unavailable = {

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -24,13 +24,16 @@ export const download = {
 	required: [ 'downloadId', 'rewindId', 'backupPoint', 'startedAt' ],
 };
 
-export const restore = {
+export const rewind = {
 	type: 'object',
 	properties: {
-		status: { type: 'string', enum: [ 'finished', 'inactive', 'queued', 'running' ] },
-		percent: { type: 'integer' },
+		rewindId: { type: 'number' },
+		status: { type: 'string', enum: [ 'failed', 'finished', 'running' ] },
+		startedAt: { type: 'string' },
+		progress: { type: 'integer' },
+		reason: { type: 'string' },
 	},
-	required: [ 'status' ],
+	required: [ 'restoreId', 'status' ],
 };
 
 export const unavailable = {
@@ -107,12 +110,12 @@ export const active = {
 			type: 'array',
 			items: download,
 		},
-		rewinds: { type: 'array', items: restore },
+		rewind,
 		last_updated: { type: 'integer' },
 	},
 	required: [ 'state', 'last_updated' ],
 };
 
-export const rewind = {
+export const rewindStatus = {
 	oneOf: [ unavailable, inactive, awaitingCredentials, provisioning, active ],
 };


### PR DESCRIPTION
We are making cahnges in D9410 and this allows those to happen without
breaking Calypso. We aren't currently using the value of the
`rewindState.rewind` property so it should be otherwise safe.