### PR TITLE
jsconfig: Update excludes (again) to quiet the VS Code "exclude large folders" warnings.

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -13,8 +13,9 @@
 		}
 	},
 	"exclude": [
-		"node_modules",
-		"**/node_modules/*",
+		[
+			"**/node_modules/*"
+		],
 		"public",
 		"build"
 	]


### PR DESCRIPTION
Looking further after https://github.com/Automattic/wp-calypso/pull/20926#issuecomment-358714320, I came across a [comment](https://github.com/Microsoft/vscode/issues/31188#issuecomment-317611881) that has the glob within an array (which doesn't seem to have been persisted to the [their docs update](https://github.com/Microsoft/vscode-docs/commit/4834f955cb286b739b0c729ebd6437a5a67aadc8) ). That said, I still get some node_modules files listed in `tsserver.log`, so ¯\_(ツ)_/¯. But I can now turn the warnings on and off with this PR.

**Testing**
* Load `master` and notice you get the warning.
* Load this branch, and the warning should not appear.