### PR TITLE
Reader: fix unsubscribe error message and set a display duration

### DIFF
--- a/client/state/data-layer/wpcom/read/following/mine/delete/index.js
+++ b/client/state/data-layer/wpcom/read/following/mine/delete/index.js
@@ -50,11 +50,12 @@ export function unfollowError( { dispatch, getState }, action ) {
 	const siteTitle = getSiteName( { feed, site } ) || feedUrl;
 	dispatch(
 		errorNotice(
-			translate( 'Sorry, there was a problem unfollowing that %(siteTitle)s. Please try again.', {
+			translate( 'Sorry, there was a problem unfollowing %(siteTitle)s. Please try again.', {
 				args: {
 					siteTitle,
 				},
-			} )
+			} ),
+			{ duration: 5000 }
 		)
 	);
 	dispatch( bypassDataLayer( follow( action.payload.feedUrl ) ) );


### PR DESCRIPTION
Whilst fixing a backend unsubscribe bug, I noticed that the error message contains an extraneous "that".

I've also set a display duration of 5s on the notice.

### To test

Sabotage the `/read/following/mine/delete` endpoint (`WPCOM_JSON_API_Read_Follows_Endpoint`) in your sandbox. Try unsubscribing from a blog.
