### PR TITLE
Reader: optimistically turn off new post notifications when unfollowing a feed

### DIFF
--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -160,9 +160,15 @@ export const items = createReducer(
 			// Respect the existing state of the new post notification toggle.
 			// User may have toggled it on immediately after subscribing and
 			// action.payload.follow may overwrite it with the old value
-			newValues.delivery_methods = {
-				notification: get( state[ urlKey ], 'delivery_methods.notification' ),
-			};
+			const existingNotificationState = get( state[ urlKey ], [
+				'delivery_methods',
+				'notification',
+			] );
+			if ( existingNotificationState ) {
+				newValues.delivery_methods = {
+					notification: existingNotificationState,
+				};
+			}
 
 			return Object.assign( newState, {
 				[ urlKey ]: merge(

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -157,6 +157,13 @@ export const items = createReducer(
 				newValues.error = null;
 			}
 
+			// Respect the existing state of the new post notification toggle.
+			// User may have toggled it on immediately after subscribing and
+			// action.payload.follow may overwrite it with the old value
+			newValues.delivery_methods = {
+				notification: get( state[ urlKey ], 'delivery_methods.notification' ),
+			};
+
 			return Object.assign( newState, {
 				[ urlKey ]: merge(
 					{ feed_URL: actualFeedUrl },

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -172,9 +172,15 @@ export const items = createReducer(
 			if ( ! ( currentFollow && currentFollow.is_following ) ) {
 				return state;
 			}
+
 			return {
 				...state,
-				[ urlKey ]: merge( {}, currentFollow, { is_following: false } ),
+				[ urlKey ]: merge( {}, currentFollow, {
+					is_following: false,
+					delivery_methods: {
+						notification: { send_posts: false },
+					},
+				} ),
 			};
 		},
 		[ READER_FOLLOWS_RECEIVE ]: ( state, action ) => {

--- a/client/state/reader/follows/test/reducer.js
+++ b/client/state/reader/follows/test/reducer.js
@@ -21,6 +21,7 @@ import {
 } from '../actions';
 import { items, itemsCount } from '../reducer';
 import {
+	READER_UNFOLLOW,
 	READER_RECORD_FOLLOW,
 	READER_RECORD_UNFOLLOW,
 	READER_FOLLOWS_RECEIVE,
@@ -89,6 +90,20 @@ describe( 'reducer', () => {
 			expect( state[ 'discover.wordpress.com' ] ).toEqual( {
 				blog_ID: 123,
 				is_following: false,
+			} );
+		} );
+
+		test( 'should optimistically turn off new post notifications when unfollowed', () => {
+			const original = deepFreeze( {
+				'example.com': { is_following: true },
+			} );
+			const state = items( original, {
+				type: READER_UNFOLLOW,
+				payload: { feedUrl: 'http://example.com' },
+			} );
+			expect( state[ 'example.com' ] ).toMatchObject( {
+				is_following: false,
+				delivery_methods: { notification: { send_posts: false } },
 			} );
 		} );
 
@@ -842,7 +857,7 @@ describe( 'reducer', () => {
 			} );
 
 			const state = items( original, unfollow( 'http://example.com' ) );
-			expect( state ).toEqual( {
+			expect( state ).toMatchObject( {
 				'example.com': {
 					...exampleFollow,
 					is_following: false,


### PR DESCRIPTION
Since r168825-wpcom we now turn off new post notifications in the backend when a user unsubscribes from a feed (props to @jancavan for discovering the bug). However, it can take a little while for the toggle to update when re-subscribing quickly. 

This PR optimistically sets post notifications to off when unsubscribing, meaning that the toggle reflects the new state instantly.

Fixes #21813.

### To test

On a site stream like http://calypso.localhost:3000/read/feeds/18743358, subscribe to new post notifications, then unfollow the feed. Quickly resubscribe and check that the post notifications toggle is set to 'off'.

<img width="504" alt="screen shot 2018-01-25 at 14 16 23" src="https://user-images.githubusercontent.com/17325/35378883-5a5992f8-01da-11e8-9614-a93daac511a4.png">
