### PR TITLE
Jetpack connect: Track submitted urls ending with /wp-admin

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
-import { concat, flowRight, includes } from 'lodash';
+import { concat, endsWith, flowRight, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -221,6 +221,7 @@ export class JetpackConnectMain extends Component {
 	handleUrlSubmit = () => {
 		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
 			jetpack_url: this.state.currentUrl,
+			url_ends_with_wpadmin: endsWith( this.state.currentUrl, '/wp-admin' ),
 		} );
 		if ( this.props.isRequestingSites ) {
 			this.setState( { waitingForSites: true } );


### PR DESCRIPTION
Submitted URLs such as `http://fair-fiordland-42.jurassic.ninja/wp-admin/` will not be connected. Let's see how big a problem this is so we can fix if necessary.

## Testing
* `localStorage.setItem( 'debug', 'calypso:analytics:tracks' );`
* Submit a URL at http://calypso.localhost:3000/jetpack/connect
