### PR TITLE
WebPreview: don't load the async chunk until it's really needed

### DIFF
--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -174,8 +174,10 @@ const ConnectedWebPreviewModal = connect( null, { setPreviewShowing } )(
 	localize( WebPreviewModal )
 );
 
-export default ( { isContentOnly, ...restProps } ) => {
+const WebPreviewInner = ( { isContentOnly, ...restProps } ) => {
 	const WebPreviewComponent = isContentOnly ? WebPreviewContent : ConnectedWebPreviewModal;
 
 	return <WebPreviewComponent { ...restProps } />;
 };
+
+export default WebPreviewInner;

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -10,4 +10,12 @@ import React from 'react';
  */
 import AsyncLoad from 'components/async-load';
 
-export default props => <AsyncLoad { ...props } require="components/web-preview/component" />;
+const WebPreview = props => {
+	if ( ! props.showPreview ) {
+		return null;
+	}
+
+	return <AsyncLoad { ...props } require="components/web-preview/component" />;
+};
+
+export default WebPreview;

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -137,6 +137,7 @@ class PreviewMain extends React.Component {
 			<Main className="preview">
 				<DocumentHead title={ translate( 'Your Site' ) } />
 				<WebPreview
+					showPreview
 					isContentOnly
 					onLocationUpdate={ this.updateSiteLocation }
 					showUrl={ !! this.state.externalUrl }


### PR DESCRIPTION
Currently, the `WebPreview` component is async loaded on Calypso startup even if
no preview is displayed. If the component is just rendered as inactive:
```jsx
<WebPreview showPreview={ false } />
```
It shouldn't be loaded -- only when `showPreview` is flipped to `true` it should load.

I had to fix the `my-sites/preview/main.jsx` component where the `showPreview` prop was missing.

I also did a little drive-by refactoring of how the components are exported. Instead of:
```jsx
export default props => ( ... );
```
I now write:
```jsx
const WebPreview = props => ( ... );
export default WebPreview;
```
The reason that if the function is named, the name is shown in React devtool. For anonymous
functions, I see `<Unknown>`.

**How to test:**
Check that all previews still work as expected, especially these ones:
- "View Site" at `/view/:site_id
- post preview after publishing and updating a post. Check both publishing a new post and updating an existing one. The preview is slightly different in both cases: one is fullscreen, one is modal dialog.

In the Network devtool, check that the `async-load-components-web-preview-component` chunk is not loaded on initial load, and it loads only after you click on "View Site".
