### PR TITLE
Card tests: update order of params so test results (on failures) make sense

### DIFF
--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -27,11 +27,11 @@ describe( 'index', () => {
 			const randomNumberBetweenRange = getRandomInt( 622126, 622925 ).toString();
 
 			test( 'should return null for 622125', () => {
-				assert.equal( null, getCreditCardType( '622125' ) );
+				assert.equal( getCreditCardType( '622125' ), null );
 			} );
 
 			test( 'should return `discover` for 622126', () => {
-				assert.equal( 'discover', getCreditCardType( '622126' ) );
+				assert.equal( getCreditCardType( '622126' ), 'discover' );
 			} );
 
 			test(
@@ -39,52 +39,52 @@ describe( 'index', () => {
 					randomNumberBetweenRange +
 					' (a random number between 622126 and 622925)',
 				() => {
-					assert.equal( 'discover', getCreditCardType( randomNumberBetweenRange ) );
+					assert.equal( getCreditCardType( randomNumberBetweenRange ), 'discover' );
 				}
 			);
 
 			test( 'should return `discover` for 622925', () => {
-				assert.equal( 'discover', getCreditCardType( '622925' ) );
+				assert.equal( getCreditCardType( '622925' ), 'discover' );
 			} );
 
 			test( 'should return null for 622926', () => {
-				assert.equal( null, getCreditCardType( '622926' ) );
+				assert.equal( getCreditCardType( '622926' ), null );
 			} );
 		} );
 
 		describe( 'Mastercard: range 2221-2720', () => {
 			test( 'should return null for 2220990000000000', () => {
-				assert.equal( null, getCreditCardType( '2220990000000000' ) );
+				assert.equal( getCreditCardType( '2220990000000000' ), null );
 			} );
 
 			test( 'should return `mastercard` for 2221000000000000', () => {
-				assert.equal( 'mastercard', getCreditCardType( '2221000000000000' ) );
+				assert.equal( getCreditCardType( '2221000000000000' ), 'mastercard' );
 			} );
 
 			test( 'should return `mastercard` for 2720990000000000', () => {
-				assert.equal( 'mastercard', getCreditCardType( '2720990000000000' ) );
+				assert.equal( getCreditCardType( '2720990000000000' ), 'mastercard' );
 			} );
 
 			test( 'should return null for 2721000000000000', () => {
-				assert.equal( null, getCreditCardType( '2721000000000000' ) );
+				assert.equal( getCreditCardType( '2721000000000000' ), null );
 			} );
 		} );
 
 		describe( 'Mastercard: range 51-55', () => {
 			test( 'should return null for 5099999999999999', () => {
-				assert.equal( null, getCreditCardType( '5099999999999999' ) );
+				assert.equal( getCreditCardType( '5099999999999999' ), null );
 			} );
 
 			test( 'should return `mastercard` for 5100000000000000', () => {
-				assert.equal( 'mastercard', getCreditCardType( '5599000000000000' ) );
+				assert.equal( getCreditCardType( '5599000000000000' ), 'mastercard' );
 			} );
 
 			test( 'should return `mastercard` for 5599000000000000', () => {
-				assert.equal( 'mastercard', getCreditCardType( '5599000000000000' ) );
+				assert.equal( getCreditCardType( '5599000000000000' ), 'mastercard' );
 			} );
 
 			test( 'should return null for 5600000000000000', () => {
-				assert.equal( null, getCreditCardType( '5600000000000000' ) );
+				assert.equal( getCreditCardType( '5600000000000000' ), null );
 			} );
 		} );
 	} );


### PR DESCRIPTION
This only updates the tests to use the proper param order, otherwise the results _Received_ and _expected value_  are backward.

Doing this in a separate PR so that when I update the tests themselves in another PR the diff isn't useless.

test with:
`npm run test-client client/lib/credit-card-details/test/index.js`
