### PR TITLE
Sites: wait for `/me/sites` on direct navigation to A collision

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -20,6 +20,7 @@ import {
 	isJetpackSite,
 	isRequestingSites,
 	isRequestingSite,
+	hasAllSitesList,
 } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { setSelectedSiteId, setSection, setAllSitesSelected } from 'state/ui/actions';
@@ -383,12 +384,12 @@ export function siteSelection( context, next ) {
 	} else {
 		const selectOnSitesChange = () => {
 			const freshSiteId = getSiteId( getState(), siteFragment );
-			dispatch( setSelectedSiteId( freshSiteId ) );
 
 			if ( getSite( getState(), freshSiteId ) ) {
+				dispatch( setSelectedSiteId( freshSiteId ) );
 				onSelectedSiteAvailable( context );
-			} else {
-				// if sites have loaded, but siteId is invalid, redirect to allSitesPath
+			} else if ( hasAllSitesList( getState() ) ) {
+				// If all sites have loaded, but siteId is still invalid, redirect to allSitesPath.
 				page.redirect( allSitesPath );
 			}
 		};


### PR DESCRIPTION
Fixing bug introduced in #21738.

If you have a mapped wpcom site and you decide to move the domain to a JP site and connecting it, `/sites/domain` will return the JP site. That's the correct behavior. Say you also don't care about removing the domain mapping from the old wpcom domain. It will still behave correctly.

After some time, you want to get back to your previous wpcom site. You decide to take down the JP site without disconnecting it first, or the site is simply not accessible. When you do `/sites/domain`, WP.com APIs will return "API calls to this blog have been disabled." as the APIs can still see the JP site in WP.com's DB but the site itself and its APIs are not accessible.

Now, imagine you navigated directly to such a site (`/pages/domain`). Before #21738, Calypso would wait for all sites to load. The `/me/sites` response doesn't contain the broken JP site, only the previous wpcom site so Calypso would wait for all sites data and then switch to it; all fine, all good.

However, after #21738, Calypso can't load the site, so it redirects to the all sites view immediately and then when all sites data arrive, it shows the site with its pages but keeping the URL for all sites view (`/pages` instead of `/pages/domain): http://cld.wthms.co/ogbMRM

In this PR, we fix that by using the `hasAllSitesList` selector: redirect to all sites view only if all sites has loaded and we didn't get a valid site response previously. We also have to move the `dispatch( setSelectedSiteId( freshSiteId ) );` inside the condition. If we don't, it will be called with `null` instead of site ID which triggers all sites view for some pages (such as `/pages`).

## Testing

In order to be able to test fully, you would need to replicate the behavior I described. However, if you don't have some VPS or server to test with, I think it's enough to just test whether everything else works as before as this is a recent bug and I don't want to waste time.