### PR TITLE
Checkout: pass card brand to paygate config

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -66,6 +66,7 @@ class CreditCardForm extends Component {
 		'city',
 		'state',
 		'document',
+		'brand',
 	];
 
 	componentWillMount() {

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -16,7 +16,7 @@ import { isEmpty, noop } from 'lodash';
 import CreditCardNumberInput from 'components/upgrades/credit-card-number-input';
 import { CountrySelect, StateSelect, Input, HiddenInput } from 'my-sites/domains/components/form';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
-import { maskField, unmaskField } from 'lib/credit-card-details';
+import { maskField, unmaskField, getCreditCardType } from 'lib/credit-card-details';
 import { isEbanxEnabledForCountry } from 'lib/credit-card-details/ebanx';
 
 export class CreditCardFormFields extends React.Component {
@@ -78,6 +78,10 @@ export class CreditCardFormFields extends React.Component {
 		const maskedDetails = {
 			[ fieldName ]: maskField( fieldName, previousValue, nextValue ),
 		};
+
+		if ( fieldName === 'number' ) {
+			rawDetails.brand = getCreditCardType( rawDetails[ fieldName ] );
+		}
 
 		onFieldChange( rawDetails, maskedDetails );
 	}

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -221,6 +221,7 @@ function createPaygateToken( requestType, cardDetails, callback ) {
 		{
 			request_type: requestType,
 			country: cardDetails.country,
+			card_brand: cardDetails.brand,
 		},
 		function( configError, configuration ) {
 			if ( configError ) {


### PR DESCRIPTION
`paygate-configuration` will use the card brand to decide which provider to use.

See D9603-code for the use on the backend.
Related: #21831