### PR TITLE
JPO: display empty string in form fields instead of `false` when no data is present.

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -100,7 +100,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 									id={ fieldName }
 									onChange={ this.getChangeHandler( fieldName ) }
 									required={ fieldName !== 'state' }
-									value={ this.state[ fieldName ] }
+									value={ this.state[ fieldName ] ? this.state[ fieldName ] : '' }
 								/>
 								{ fieldName !== 'state' && (
 									<FormInputValidation

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -100,7 +100,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 									id={ fieldName }
 									onChange={ this.getChangeHandler( fieldName ) }
 									required={ fieldName !== 'state' }
-									value={ this.state[ fieldName ] ? this.state[ fieldName ] : '' }
+									value={ this.state[ fieldName ] || '' }
 								/>
 								{ fieldName !== 'state' && (
 									<FormInputValidation

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -75,8 +75,8 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 					<form onSubmit={ this.handleSubmit }>
 						<SiteTitle
 							autoFocusBlogname
-							blogname={ this.state.blogname }
-							blogdescription={ this.state.blogdescription }
+							blogname={ this.state.blogname ? this.state.blogname : '' }
+							blogdescription={ this.state.blogdescription ? this.state.blogdescription : '' }
 							disabled={ isRequestingSettings }
 							isBlognameRequired
 							onChange={ this.handleChange }

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -75,8 +75,8 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 					<form onSubmit={ this.handleSubmit }>
 						<SiteTitle
 							autoFocusBlogname
-							blogname={ this.state.blogname ? this.state.blogname : '' }
-							blogdescription={ this.state.blogdescription ? this.state.blogdescription : '' }
+							blogname={ this.state.blogname || '' }
+							blogdescription={ this.state.blogdescription || '' }
 							disabled={ isRequestingSettings }
 							isBlognameRequired
 							onChange={ this.handleChange }


### PR DESCRIPTION
The fields in the JPO forms are currently populated with `false` when corresponding options are empty ( which is returned from the JP onboard settings GET endpoint ).  

This patch replaces `false` with empty strings for empty options.

**To test:**
- Checkout this branch on local Calypso.
- Go to `https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`, where `YourJetpackSandbox.com` is the domain of your JP sandbox
* Add data to the form in the first screen, press Next Step. 
* On your sandbox delete the corresponding option `wp option delete blogname` and/or  `wp option delete blogdescription`.
* Access the flow again using the above url and verify that the fields with deleted options are empty 
 (and do not display `false`).
* Skip through the flow till the `Add a business address` step.
* Fill-in the required fields, press Next Step.
* Remove the option `wp option delete jpo_business_address` .
* Access url to trigger the flow again, skip to the `Add a business address` step
and verify the fields are empty.

**Note:**
This will only work on initial render (re-accessing the flow via url as done above). Once the state is populated with field data, it renders the content irrespective of whether JP options are empty. Separate issue follows.