### PR TITLE
Chekcout: use existing module for card type detection

### DIFF
--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -17,44 +17,24 @@ jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-function getRandomInt( min, max ) {
-	return Math.floor( Math.random() * ( max - min + 1 ) ) + min;
-}
-
 describe( 'index', () => {
 	describe( 'Validation', () => {
-		describe( 'Discover Card: range 622126-622925', () => {
-			const randomNumberBetweenRange = getRandomInt( 622126, 622925 ).toString();
-
-			test( 'should return null for 622125', () => {
-				assert.equal( getCreditCardType( '622125' ), null );
+		describe( 'Discover Card: starts with 6011, 64, 65', () => {
+			test( 'should not return Discover for 622125', () => {
+				assert.notEqual( getCreditCardType( '622125' ), 'discover' );
+			} );
+			test( 'should return `discover` for 6011000990139424', () => {
+				assert.equal( getCreditCardType( '6011000990139424' ), 'discover' );
 			} );
 
-			test( 'should return `discover` for 622126', () => {
-				assert.equal( getCreditCardType( '622126' ), 'discover' );
-			} );
-
-			test(
-				'should return `discover` for ' +
-					randomNumberBetweenRange +
-					' (a random number between 622126 and 622925)',
-				() => {
-					assert.equal( getCreditCardType( randomNumberBetweenRange ), 'discover' );
-				}
-			);
-
-			test( 'should return `discover` for 622925', () => {
-				assert.equal( getCreditCardType( '622925' ), 'discover' );
-			} );
-
-			test( 'should return null for 622926', () => {
-				assert.equal( getCreditCardType( '622926' ), null );
+			test( 'should return `discover` for 6445644564456445', () => {
+				assert.equal( getCreditCardType( '6445644564456445' ), 'discover' );
 			} );
 		} );
 
 		describe( 'Mastercard: range 2221-2720', () => {
-			test( 'should return null for 2220990000000000', () => {
-				assert.equal( getCreditCardType( '2220990000000000' ), null );
+			test( 'should return null for 2000990000000000', () => {
+				assert.equal( getCreditCardType( '2000990000000000' ), null );
 			} );
 
 			test( 'should return `mastercard` for 2221000000000000', () => {
@@ -65,14 +45,14 @@ describe( 'index', () => {
 				assert.equal( getCreditCardType( '2720990000000000' ), 'mastercard' );
 			} );
 
-			test( 'should return null for 2721000000000000', () => {
-				assert.equal( getCreditCardType( '2721000000000000' ), null );
+			test( 'should return `mastercard` for 2223003122003222', () => {
+				assert.equal( getCreditCardType( '2223003122003222' ), 'mastercard' );
 			} );
 		} );
 
 		describe( 'Mastercard: range 51-55', () => {
-			test( 'should return null for 5099999999999999', () => {
-				assert.equal( getCreditCardType( '5099999999999999' ), null );
+			test( 'should not return mastercard for 5099999999999999', () => {
+				assert.notEqual( getCreditCardType( '5099999999999999' ), 'mastercard' );
 			} );
 
 			test( 'should return `mastercard` for 5100000000000000', () => {
@@ -83,8 +63,8 @@ describe( 'index', () => {
 				assert.equal( getCreditCardType( '5599000000000000' ), 'mastercard' );
 			} );
 
-			test( 'should return null for 5600000000000000', () => {
-				assert.equal( getCreditCardType( '5600000000000000' ), null );
+			test( 'should not return mastercard for 5600000000000000', () => {
+				assert.notEqual( getCreditCardType( '5600000000000000' ), 'mastercard' );
 			} );
 		} );
 	} );

--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -67,5 +67,19 @@ describe( 'index', () => {
 				assert.notEqual( getCreditCardType( '5600000000000000' ), 'mastercard' );
 			} );
 		} );
+
+		describe( 'American Express', () => {
+			test( 'should return `amex` for 370000000000002', () => {
+				assert.equal( getCreditCardType( '370000000000002' ), 'amex' );
+			} );
+
+			test( 'should return `amex` for 378282246310005', () => {
+				assert.equal( getCreditCardType( '378282246310005' ), 'amex' );
+			} );
+
+			test( 'should NOT return `amex` for 34343434343434', () => {
+				assert.notEqual( getCreditCardType( '34343434343434' ), 'amex' );
+			} );
+		} );
 	} );
 } );

--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -90,11 +90,11 @@ describe( 'index', () => {
 			} );
 
 			test( 'should return `diners` for 30569309025904', () => {
-				assert.equal( getCreditCardType( '30569309025904' ), 'diners-club' );
+				assert.equal( getCreditCardType( '30569309025904' ), 'diners' );
 			} );
 
 			test( 'should return `diners` for 38520000023237', () => {
-				assert.equal( getCreditCardType( '38520000023237' ), 'diners-club' );
+				assert.equal( getCreditCardType( '38520000023237' ), 'diners' );
 			} );
 
 			test( 'should return `unionpay` for 6240008631401148', () => {

--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -33,10 +33,6 @@ describe( 'index', () => {
 		} );
 
 		describe( 'Mastercard: range 2221-2720', () => {
-			test( 'should return null for 2000990000000000', () => {
-				assert.equal( getCreditCardType( '2000990000000000' ), null );
-			} );
-
 			test( 'should return `mastercard` for 2221000000000000', () => {
 				assert.equal( getCreditCardType( '2221000000000000' ), 'mastercard' );
 			} );
@@ -76,9 +72,33 @@ describe( 'index', () => {
 			test( 'should return `amex` for 378282246310005', () => {
 				assert.equal( getCreditCardType( '378282246310005' ), 'amex' );
 			} );
+		} );
 
-			test( 'should NOT return `amex` for 34343434343434', () => {
-				assert.notEqual( getCreditCardType( '34343434343434' ), 'amex' );
+		describe( 'Visa', () => {
+			test( 'should return `visa` for 4242424242424242', () => {
+				assert.equal( getCreditCardType( '4242424242424242' ), 'visa' );
+			} );
+
+			test( 'should return `visa` for 4000000400000008', () => {
+				assert.equal( getCreditCardType( '4000000400000008' ), 'visa' );
+			} );
+		} );
+
+		describe( 'Other Brands', () => {
+			test( 'should return `jcb` for 3530111333300000', () => {
+				assert.equal( getCreditCardType( '3530111333300000' ), 'jcb' );
+			} );
+
+			test( 'should return `diners` for 30569309025904', () => {
+				assert.equal( getCreditCardType( '30569309025904' ), 'diners-club' );
+			} );
+
+			test( 'should return `diners` for 38520000023237', () => {
+				assert.equal( getCreditCardType( '38520000023237' ), 'diners-club' );
+			} );
+
+			test( 'should return `unionpay` for 6240008631401148', () => {
+				assert.equal( getCreditCardType( '6240008631401148' ), 'unionpay' );
 			} );
 		} );
 	} );

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -8,6 +8,7 @@ import compact from 'lodash/compact';
 import isArray from 'lodash/isArray';
 import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
+import kebabCase from 'lodash/kebabCase';
 import i18n from 'i18n-calypso';
 
 /**
@@ -203,7 +204,7 @@ export function getCreditCardType( number ) {
 	if ( number ) {
 		number = number.replace( / /g, '' );
 
-		let cardType = creditcards.card.type( number, false );
+		let cardType = creditcards.card.type( number, true );
 
 		if ( typeof cardType === 'undefined' ) {
 			return null;
@@ -214,7 +215,7 @@ export function getCreditCardType( number ) {
 			cardType = 'amex';
 		}
 
-		return cardType.toLowerCase();
+		return kebabCase( cardType.toLowerCase() );
 	}
 
 	return null;

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -5,7 +5,6 @@
 import creditcards from 'creditcards';
 import capitalize from 'lodash/capitalize';
 import compact from 'lodash/compact';
-import inRange from 'lodash/inRange';
 import isArray from 'lodash/isArray';
 import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
@@ -204,24 +203,12 @@ export function getCreditCardType( number ) {
 	if ( number ) {
 		number = number.replace( / /g, '' );
 
-		if ( number.match( /^3[47]\d{0,13}$/ ) ) {
-			return 'amex';
-		} else if ( number.match( /^4\d{0,12}$/ ) || number.match( /^4\d{15}$/ ) ) {
-			return 'visa';
-		} else if (
-			number.match( /^5[1-5]\d{0,14}|^2(?:2(?:2[1-9]|[3-9]\d)|[3-6]\d\d|7(?:[01]\d|20))\d{0,12}$/ )
-		) {
-			//valid 2-series range: 2221 - 2720
-			//valid 5-series range: 51 - 55
-			return 'mastercard';
-		} else if (
-			number.match( /^6011\d{0,12}$/ ) ||
-			inRange( parseInt( number, 10 ), 622126, 622926 ) || // valid range is 622126-622925
-			number.match( /^64[4-9]\d{0,13}$/ ) ||
-			number.match( /^65\d{0,14}$/ )
-		) {
-			return 'discover';
+		const cardType = creditcards.card.type( number, true ).toLowerCase();
+		if ( cardType === '' ) {
+			return null;
 		}
+
+		return cardType;
 	}
 
 	return null;

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -214,7 +214,7 @@ export function getCreditCardType( number ) {
 			cardType = 'amex';
 		}
 
-		// Normalize diners as wee
+		// Normalize Diners as well
 		if ( cardType === 'Diners Club' ) {
 			cardType = 'diners';
 		}

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -203,10 +203,15 @@ export function getCreditCardType( number ) {
 	if ( number ) {
 		number = number.replace( / /g, '' );
 
-		const cardType = creditcards.card.type( number, false );
+		let cardType = creditcards.card.type( number, false );
 
 		if ( typeof cardType === 'undefined' ) {
 			return null;
+		}
+
+		// We already use 'amex' for American Express everywhere else
+		if ( cardType === 'American Express' ) {
+			cardType = 'amex';
 		}
 
 		return cardType.toLowerCase();

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -8,7 +8,6 @@ import compact from 'lodash/compact';
 import isArray from 'lodash/isArray';
 import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
-import kebabCase from 'lodash/kebabCase';
 import i18n from 'i18n-calypso';
 
 /**
@@ -215,7 +214,12 @@ export function getCreditCardType( number ) {
 			cardType = 'amex';
 		}
 
-		return kebabCase( cardType.toLowerCase() );
+		// Normalize diners as wee
+		if ( cardType === 'Diners Club' ) {
+			cardType = 'diners';
+		}
+
+		return cardType.toLowerCase();
 	}
 
 	return null;

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -196,19 +196,20 @@ export function validateCardDetails( cardDetails ) {
  * Retrieves the type of credit card from the specified number.
  *
  * @param {string} number - credit card number
- * @returns {string} the type of the credit card
+ * @returns {string|null} the type of the credit card
  * @see {@link http://en.wikipedia.org/wiki/Bank_card_number} for more information
  */
 export function getCreditCardType( number ) {
 	if ( number ) {
 		number = number.replace( / /g, '' );
 
-		const cardType = creditcards.card.type( number, true ).toLowerCase();
-		if ( cardType === '' ) {
+		const cardType = creditcards.card.type( number, false );
+
+		if ( typeof cardType === 'undefined' ) {
 			return null;
 		}
 
-		return cardType;
+		return cardType.toLowerCase();
 	}
 
 	return null;


### PR DESCRIPTION
We already load the [creditcards module](https://github.com/bendrucker/creditcards) for other purposes, and I see no reason why not use it for validation. 

I updated the tests, since of the cards we were expecting to return `null` now return other types of cards we've previously ignored.

This is prep work for adding support to additional card brands.

*Testing*
- Running the test suite: `npm run test-client client/lib/credit-card-details/test/index.js`
- Try the [test numbers from stripe](https://stripe.com/docs/testing#cards) in the checkout form and make sure the icon in the input matches the card types. Note: icons for jcb/diners/unionpay not supported yet
