### PR TITLE
Add skip buttons to featured image tours

### DIFF
--- a/client/layout/guided-tours/config-elements/next.js
+++ b/client/layout/guided-tours/config-elements/next.js
@@ -17,6 +17,11 @@ import contextTypes from '../context-types';
 export default class Next extends Component {
 	static propTypes = {
 		step: PropTypes.string.isRequired,
+		isButton: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		isButton: true,
 	};
 
 	static contextTypes = contextTypes;
@@ -32,9 +37,11 @@ export default class Next extends Component {
 	};
 
 	render() {
-		const { children } = this.props;
+		const { children, isButton } = this.props;
+		const buttonClass = ! isButton ? 'config-elements__text-button' : '';
+
 		return (
-			<Button primary onClick={ this.onClick }>
+			<Button primary onClick={ this.onClick } className={ buttonClass }>
 				{ children || translate( 'Next' ) }
 			</Button>
 		);

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -141,6 +141,21 @@ a.config-elements__text-link,
 	}
 }
 
+.config-elements__text-button,
+button.config-elements__text-button,
+.is-primary.config-elements__text-button {
+	color: $white;
+	background: none;
+	text-decoration: underline;
+	padding: 0;
+	border: 0;
+	font-weight: normal;
+
+	&:hover {
+		text-decoration: none;
+	}
+}
+
 .guided-tours__single-button-row {
 	.button {
 		width: 100%;

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -73,6 +73,11 @@ export const ChecklistContactPageTour = makeTour(
 				) }
 			</p>
 			<p>{ translate( 'Press anywhere on this image so we can change it.' ) }</p>
+
+			<Next step="click-update" isButton={ false }>
+				{ translate( 'Skip this step' ) }
+			</Next>
+
 			<Continue target="editor-featured-image-current-image" step="choose-image" click hidden />
 		</Step>
 

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour.js
@@ -80,15 +80,18 @@ export const ChecklistPublishPostTour = makeTour(
 			arrow="top-left"
 			placement="below"
 		>
-			<Continue target="editor-featured-image-current-image" step="choose-image" click>
-				<p>
-					{ translate(
-						'Featured images are a great way to add more personality to your pages. ' +
-							'Let’s add something a little more relevant to your blog post.'
-					) }
-				</p>
-				<p>{ translate( 'Press anywhere on this image so we can change it.' ) }</p>
-			</Continue>
+			<p>
+				{ translate(
+					'Featured images are a great way to add more personality to your pages. ' +
+						'Let’s add something a little more relevant to your blog post.'
+				) }
+			</p>
+			<p>{ translate( 'Press anywhere on this image so we can change it.' ) }</p>
+
+			<Next step="click-update" isButton={ false }>
+				{ translate( 'Skip this step' ) }
+			</Next>
+			<Continue target="editor-featured-image-current-image" step="choose-image" click hidden />
 		</Step>
 
 		<Step


### PR DESCRIPTION
This PR adds a skip button to the featured image tasks within the Contact and First post tours. I also found an error in one of these where the content was nested in the continue element that caused it to place `<p>` tags in a `<span>`. 
 
## Screenshot
![image](https://user-images.githubusercontent.com/6981253/35400108-ee596eea-01c3-11e8-9b49-43aafd95b98d.png)

## Testing
- Visit `/start` and make sure you have the free and paid checklist a/b tests set to `show`
- Create a new site
- Run through the contact and first post tasks. You should be able to skip past the featured image prompts.

@taggon can you take a look?

cc @markryall 