### PR TITLE
Checklist: Remove the About page tour.

### DIFF
--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -120,11 +120,8 @@ const sequence = [
 	'site_icon_set',
 	'blogdescription_set',
 	'avatar_uploaded',
-	// 'social_links_set',
-	'about_page_updated',
 	'contact_page_updated',
 	'post_published',
-	// 'custom_domain_registered',
 ];
 
 export const urlForTask = ( id, siteSlug ) => {


### PR DESCRIPTION
Recent updates to the Headstart annotations caused About page tour to break. After having some discussions, we've decided to remove the tour for now.

## Test plan

1. Create a new website.
2. Move to `/checklist/YOUR_SITE_DOMAIN`.
3. The About tour should *NOT* be on the checklist. It was located immediately above "Personalize your Contact page" task.

cc @fditrapani @markryall 