### PR TITLE
Update `react-modal` to fix accessibility bug

### DIFF
--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -44,6 +44,7 @@ class DialogBase extends Component {
 				onRequestClose={ this._close }
 				closeTimeoutMS={ this.props.leaveTimeout }
 				contentLabel={ this.props.label }
+				appElement={ document.getElementById( 'wpcom' ) }
 				overlayClassName={ backdropClassName } // We use flex here which react-modal doesn't
 				className={ dialogClassName }
 				role="dialog"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -504,7 +504,7 @@
       "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000798",
+        "caniuse-db": "1.0.30000799",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1883,7 +1883,7 @@
       "version": "1.3.6",
       "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
       "requires": {
-        "caniuse-db": "1.0.30000798"
+        "caniuse-db": "1.0.30000799"
       }
     },
     "bser": {
@@ -2000,8 +2000,8 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000798",
-      "integrity": "sha1-kvJvd/icwqTWBIf0Hgs9Kmw/40E="
+      "version": "1.0.30000799",
+      "integrity": "sha1-CQSVPek/P0kmR+WMGhvaenOgyws="
     },
     "caniuse-lite": {
       "version": "1.0.30000792",
@@ -3334,7 +3334,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000798",
+        "caniuse-db": "1.0.30000799",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -7716,7 +7716,7 @@
       "requires": {
         "jest-mock": "22.1.0",
         "jest-util": "22.1.4",
-        "jsdom": "11.6.1"
+        "jsdom": "11.6.2"
       }
     },
     "jest-environment-node": {
@@ -8684,8 +8684,8 @@
       }
     },
     "jsdom": {
-      "version": "11.6.1",
-      "integrity": "sha512-x1vDo5CQuwsuP0w3kuU04vQdem9Q8apRV2PXp8GeSFQpgtYvSwbcypIbNgRrXu82O4TMroGYSAbu9wyVZHcehw==",
+      "version": "11.6.2",
+      "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
@@ -12673,11 +12673,12 @@
       }
     },
     "react-modal": {
-      "version": "3.1.0",
-      "integrity": "sha512-4sVW7Flm6sdaQeWr8OxXqMOuothdg+jnCA4MqloP65g2iWtOtho8VeI+z3SCsqunWefbuCHCnncxIBmDgPehQQ==",
+      "version": "3.1.11",
+      "integrity": "sha512-Pm4QAc+sWYrfRC+WRERV+JGeGZIfodZGdbvWmjPzeSWqP+EW5ATK4N1U/btNHZWFzKL1UOmkmNtozEQlEg7c+A==",
       "requires": {
         "exenv": "1.2.2",
-        "prop-types": "15.5.10"
+        "prop-types": "15.5.10",
+        "warning": "3.0.0"
       }
     },
     "react-pure-render": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "react-day-picker": "6.2.1",
     "react-dom": "16.2.0",
     "react-hot-loader": "1.3.1",
-    "react-modal": "3.1.0",
+    "react-modal": "3.1.11",
     "react-pure-render": "1.0.2",
     "react-redux": "5.0.6",
     "react-transition-group": "1.2.1",


### PR DESCRIPTION
This fixes the issue raised in #21223, where screen reader users have trouble navigating into modals. I tracked the problem to [this issue on react-modal](https://github.com/reactjs/react-modal/issues/359), which was [fixed in v3.1.6](https://github.com/reactjs/react-modal/blob/master/CHANGELOG.md). This PR updates react-modal to the current version, 3.1.11.

A summary of the issue: the modal we currently use puts `aria-hidden` on the body tag, which interferes with the way screen readers read the page. It should set `aria-hidden` on the element containing the app (`#wpcom`, for us). Currently, this locks up the screen reader – for example, VoiceOver stops reading anything on the page.

This PR updates react-modal, and adds the `appElement` to the modal component in DialogBase, so that the `aria-hidden` attribute is put on the correct element (this prevents screen reader users from interacting with the rest of the page while the modal is open, like the overlay does for visual users).

**To test:**

Check pages that use a dialog with a screen reader, for example:

- Visit `/settings/delete-site/:site`
- Navigate to "Delete site" button
- Click, you should hear "Confirm Delete Site", and only be able to navigate inside the modal.
- Cancelling out of the modal should put you back into the calypso screen.

I've checked:

- Delete site
- Sharing settings
- Media modal
- Store product variations
- Store orders, adding product & fee

Reviews requested based on github's suggestions, but feel free to tag other people 🙂 