### PR TITLE
Store Orders: Open new order creation to production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -130,7 +130,7 @@
 		"upgrades/presale-chat": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
-		"woocommerce/extension-orders-create": false,
+		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-orders-edit": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-product-categories": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -136,7 +136,7 @@
 		"upgrades/presale-chat": true,
 		"woocommerce/extension-dashboard": true,
 		"woocommerce/extension-orders": true,
-		"woocommerce/extension-orders-create": false,
+		"woocommerce/extension-orders-create": true,
 		"woocommerce/extension-orders-edit": true,
 		"woocommerce/extension-products": true,
 		"woocommerce/extension-product-categories": true,


### PR DESCRIPTION
This PR launches the first iteration of order creation in calypso 🎉

All the feedback from the call for testing post has been addressed & merged, so we're ready to open this up to general use 😄 

Once this PR is merged, I'm going to close #15679 & start a new tracking issue for the next iteration.