### PR TITLE
Store: Add prompt and link for enabling basic ecommerce on google analytics

### DIFF
--- a/client/my-sites/site-settings/form-analytics-stores.jsx
+++ b/client/my-sites/site-settings/form-analytics-stores.jsx
@@ -77,6 +77,13 @@ class FormAnalyticsStores extends Component {
 			{
 				key: 'ec_track_add_to_cart',
 				label: translate( 'Add to cart events' ),
+				explanation: translate(
+					'Before enabling these, turn on eCommerce in your Google Analytics dashboard.'
+				),
+				link: {
+					label: translate( 'Learn how' ),
+					url: 'https://support.google.com/analytics/answer/1009612#Enable',
+				},
 			},
 		];
 


### PR DESCRIPTION
Fixes #18669

To test:
* Navigate to http://calypso.localhost:3000/settings/traffic/{DOMAIN}
* Scroll down and revel in the newly added text. Try the link. You'll love it.

<img width="738" alt="these" src="https://user-images.githubusercontent.com/1595739/35407934-4004bada-01c2-11e8-9724-0bfde3e188a8.png">

cc @kellychoffman and @jameskoster - cause the description i've added applies to both items, so I used the word "these" to reinforce that it isn't just the item it follows - does that work?