### PR TITLE
Rewind: update wording of the provisioning notice

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -526,10 +526,10 @@ class ActivityLog extends Component {
 					<Banner
 						icon="history"
 						disableHref
-						title={ translate( 'Site configuration underway' ) }
+						title={ translate( 'Your backup is underway' ) }
 						description={ translate(
-							"There's nothing more you need to do right now. " +
-								"You'll be able to restore backups soon."
+							"We're currently backing up your site for the first time, and we'll let you know when we're finished. " +
+								"After this initial backup, we'll save future changes in real time."
 						) }
 					/>
 				) }


### PR DESCRIPTION
This PR updates the text in the notice shown when the site is properly configured and currently provisioning and creating the first backup.
Copy given by Ben Huberman at p9rlnk-43-activitylogrewind-p2

### Before

<img width="751" alt="captura de pantalla 2018-01-25 a la s 17 55 25" src="https://user-images.githubusercontent.com/1041600/35411965-74eb0a2e-01f9-11e8-8815-c9c808e78535.png">

### After

<img width="750" alt="captura de pantalla 2018-01-25 a la s 17 56 10" src="https://user-images.githubusercontent.com/1041600/35411966-7526075a-01f9-11e8-8543-dc080f901a65.png">

