### PR TITLE
Invites: Polish Redux code; add persistence; add missing tests

### DIFF
--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -33,7 +33,7 @@ class PeopleInvites extends React.PureComponent {
 
 		return (
 			<PeopleListItem
-				key={ invite.invite_key }
+				key={ invite.key }
 				invite={ invite }
 				user={ user }
 				site={ site }

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -48,14 +48,14 @@ class PeopleListItem extends React.PureComponent {
 	getCardLink = () => {
 		const { invite, site, type, user } = this.props;
 		const editLink = this.canLinkToProfile() && `/people/edit/${ site.slug }/${ user.login }`;
-		const inviteLink = invite && `/people/invites/${ site.slug }/${ invite.invite_key }`;
+		const inviteLink = invite && `/people/invites/${ site.slug }/${ invite.key }`;
 
 		return type === 'invite' ? inviteLink : editLink;
 	};
 
 	renderInviteStatus = () => {
 		const { invite, translate } = this.props;
-		const { is_pending: isPending } = invite;
+		const { isPending } = invite;
 		const statusClasses = {
 			'is-pending': isPending,
 		};

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -1,6 +1,11 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { pick } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { combineReducers, createReducer } from 'state/utils';
@@ -49,7 +54,17 @@ export const items = createReducer(
 		[ INVITES_REQUEST_SUCCESS ]: ( state, action ) => {
 			return {
 				...state,
-				[ action.siteId ]: action.invites,
+				[ action.siteId ]: action.invites.map( invite => {
+					// Not renaming `avatar_URL` because it is used as-is by <Gravatar>
+					const user = pick( invite.user, 'login', 'email', 'name', 'avatar_URL' );
+
+					return {
+						key: invite.invite_key,
+						role: invite.role,
+						isPending: invite.is_pending,
+						user,
+					};
+				} ),
 			};
 		},
 	}

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -17,6 +17,7 @@ import {
 	INVITE_RESEND_REQUEST_FAILURE,
 	INVITE_RESEND_REQUEST_SUCCESS,
 } from 'state/action-types';
+import { inviteItemsSchema } from './schema';
 
 /**
  * Returns the updated site invites requests state after an action has been
@@ -67,7 +68,8 @@ export const items = createReducer(
 				} ),
 			};
 		},
-	}
+	},
+	inviteItemsSchema
 );
 
 /**

--- a/client/state/invites/schema.js
+++ b/client/state/invites/schema.js
@@ -1,0 +1,30 @@
+/** @format */
+
+export const inviteItemsSchema = {
+	type: 'object',
+	patternProperties: {
+		// Site ID
+		'^\\d+$': {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					key: { type: 'string' },
+					role: { type: 'string' },
+					isPending: { type: 'boolean' },
+					user: {
+						type: 'object',
+						properties: {
+							login: { type: 'string' },
+							email: { anyOf: [ { type: 'string' }, { enum: [ false ] } ] },
+							name: { type: 'string' },
+							avatar_URL: { type: 'string' },
+						},
+						additionalProperties: false,
+					},
+				},
+				additionalProperties: false,
+			},
+		},
+	},
+};

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -27,7 +27,7 @@ describe( 'reducer', () => {
 							email: false,
 							name: 'Pollo',
 							avatar_URL:
-								'https://0.gravatar.com/avatar/0c4d46844039ba935f69208615e9010c?s=96&d=identicon&r=G',
+								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
 						},
 					},
 				],
@@ -49,7 +49,7 @@ describe( 'reducer', () => {
 							email: false,
 							name: 'Pollo',
 							avatar_URL:
-								'https://0.gravatar.com/avatar/0c4d46844039ba935f69208615e9010c?s=96&d=identicon&r=G',
+								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
 						},
 					},
 				],
@@ -76,7 +76,7 @@ describe( 'reducer', () => {
 								email: false,
 								name: 'Pollo',
 								avatar_URL:
-									'https://0.gravatar.com/avatar/0c4d46844039ba935f69208615e9010c?s=96&d=identicon&r=G',
+									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
 							},
 							hasExtraInvalidProperty: true,
 						},
@@ -99,7 +99,7 @@ describe( 'reducer', () => {
 								email: false,
 								name: 'Pollo',
 								avatar_URL:
-									'https://0.gravatar.com/avatar/0c4d46844039ba935f69208615e9010c?s=96&d=identicon&r=G',
+									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
 							},
 						},
 					],

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -125,6 +125,7 @@ describe( 'reducer', () => {
 				12345: { '123456asdf789': true },
 			} );
 		} );
+
 		test( 'should accumulate invites', () => {
 			const original = deepFreeze( { 12345: { '123456asdf789': false } } );
 			const state = requestingResend( original, {
@@ -136,6 +137,7 @@ describe( 'reducer', () => {
 				12345: { '123456asdf789': false, '789lkjh123456': true },
 			} );
 		} );
+
 		test( 'should accumulate sites', () => {
 			const original = deepFreeze( { 12345: { '123456asdf789': false } } );
 			const state = requestingResend( original, {

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -10,7 +10,13 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import { requesting, items, requestingResend } from '../reducer';
-import { INVITES_REQUEST, INVITE_RESEND_REQUEST, SERIALIZE, DESERIALIZE } from 'state/action-types';
+import {
+	INVITES_REQUEST,
+	INVITES_REQUEST_SUCCESS,
+	INVITE_RESEND_REQUEST,
+	SERIALIZE,
+	DESERIALIZE,
+} from 'state/action-types';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -42,6 +48,113 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#items()', () => {
+		test( 'should key invites by site ID', () => {
+			const state = items(
+				{},
+				{
+					type: INVITES_REQUEST_SUCCESS,
+					siteId: 12345,
+					invites: [
+						{
+							invite_key: '123456asdf789',
+							role: 'follower',
+							is_pending: true,
+							user: {
+								login: 'chicken',
+								email: false,
+								name: 'Pollo',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+							},
+						},
+					],
+				}
+			);
+			expect( state ).to.eql( {
+				12345: [
+					{
+						key: '123456asdf789',
+						role: 'follower',
+						isPending: true,
+						user: {
+							login: 'chicken',
+							email: false,
+							name: 'Pollo',
+							avatar_URL:
+								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+						},
+					},
+				],
+			} );
+		} );
+
+		test( 'should accumulate sites', () => {
+			const original = {
+				12345: [
+					{
+						key: '123456asdf789',
+						role: 'follower',
+						isPending: true,
+						user: {
+							login: 'chicken',
+							email: false,
+							name: 'Pollo',
+							avatar_URL:
+								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+						},
+					},
+				],
+			};
+			const state = items( original, {
+				type: INVITES_REQUEST_SUCCESS,
+				siteId: 67890,
+				invites: [
+					{
+						invite_key: '9876fdas54321',
+						role: 'follower',
+						is_pending: true,
+						user: {
+							login: 'celery',
+							email: false,
+							name: 'Apio',
+							avatar_URL:
+								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+						},
+					},
+				],
+			} );
+			expect( state ).to.eql( {
+				12345: [
+					{
+						key: '123456asdf789',
+						role: 'follower',
+						isPending: true,
+						user: {
+							login: 'chicken',
+							email: false,
+							name: 'Pollo',
+							avatar_URL:
+								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+						},
+					},
+				],
+				67890: [
+					{
+						key: '9876fdas54321',
+						role: 'follower',
+						isPending: true,
+						user: {
+							login: 'celery',
+							email: false,
+							name: 'Apio',
+							avatar_URL:
+								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+						},
+					},
+				],
+			} );
+		} );
+
 		test( 'should persist state', () => {
 			const original = deepFreeze( {
 				12345: [

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -9,10 +9,108 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { requestingResend } from '../reducer';
-import { INVITE_RESEND_REQUEST } from 'state/action-types';
+import { items, requestingResend } from '../reducer';
+import { INVITE_RESEND_REQUEST, SERIALIZE, DESERIALIZE } from 'state/action-types';
+import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'reducer', () => {
+	describe( '#items()', () => {
+		test( 'should persist state', () => {
+			const original = deepFreeze( {
+				12345: [
+					{
+						key: '123456asdf789',
+						role: 'follower',
+						isPending: true,
+						user: {
+							login: 'chicken',
+							email: false,
+							name: 'Pollo',
+							avatar_URL:
+								'https://0.gravatar.com/avatar/0c4d46844039ba935f69208615e9010c?s=96&d=identicon&r=G',
+						},
+					},
+				],
+			} );
+			const state = items( original, { type: SERIALIZE } );
+
+			expect( state ).to.eql( original );
+		} );
+
+		test( 'should load valid persisted state', () => {
+			const original = deepFreeze( {
+				12345: [
+					{
+						key: '123456asdf789',
+						role: 'follower',
+						isPending: true,
+						user: {
+							login: 'chicken',
+							email: false,
+							name: 'Pollo',
+							avatar_URL:
+								'https://0.gravatar.com/avatar/0c4d46844039ba935f69208615e9010c?s=96&d=identicon&r=G',
+						},
+					},
+				],
+			} );
+			const state = items( original, { type: DESERIALIZE } );
+
+			expect( state ).to.eql( original );
+		} );
+
+		describe( 'invalid state tests', () => {
+			useSandbox( sandbox => {
+				sandbox.stub( console, 'warn' );
+			} );
+
+			test( 'should not load invalid persisted state (1)', () => {
+				const original = deepFreeze( {
+					12345: [
+						{
+							key: '123456asdf789',
+							role: 'follower',
+							isPending: true,
+							user: {
+								login: 'chicken',
+								email: false,
+								name: 'Pollo',
+								avatar_URL:
+									'https://0.gravatar.com/avatar/0c4d46844039ba935f69208615e9010c?s=96&d=identicon&r=G',
+							},
+							hasExtraInvalidProperty: true,
+						},
+					],
+				} );
+				const state = items( original, { type: DESERIALIZE } );
+
+				expect( state ).to.eql( {} );
+			} );
+
+			test( 'should not load invalid persisted state (2)', () => {
+				const original = deepFreeze( {
+					12345: [
+						{
+							key: '123456asdf789',
+							role: 'follower',
+							isPending: null,
+							user: {
+								login: 'chicken',
+								email: false,
+								name: 'Pollo',
+								avatar_URL:
+									'https://0.gravatar.com/avatar/0c4d46844039ba935f69208615e9010c?s=96&d=identicon&r=G',
+							},
+						},
+					],
+				} );
+				const state = items( original, { type: DESERIALIZE } );
+
+				expect( state ).to.eql( {} );
+			} );
+		} );
+	} );
+
 	describe( '#resendRequests()', () => {
 		test( 'should key requests by site ID and invite ID', () => {
 			const state = requestingResend(

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -9,11 +9,38 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { items, requestingResend } from '../reducer';
-import { INVITE_RESEND_REQUEST, SERIALIZE, DESERIALIZE } from 'state/action-types';
+import { requesting, items, requestingResend } from '../reducer';
+import { INVITES_REQUEST, INVITE_RESEND_REQUEST, SERIALIZE, DESERIALIZE } from 'state/action-types';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'reducer', () => {
+	describe( '#requesting()', () => {
+		test( 'should key requests by site ID', () => {
+			const state = requesting(
+				{},
+				{
+					type: INVITES_REQUEST,
+					siteId: 12345,
+				}
+			);
+			expect( state ).to.eql( {
+				12345: true,
+			} );
+		} );
+
+		test( 'should accumulate sites', () => {
+			const original = deepFreeze( { 12345: false } );
+			const state = requesting( original, {
+				type: INVITES_REQUEST,
+				siteId: 67890,
+			} );
+			expect( state ).to.eql( {
+				12345: false,
+				67890: true,
+			} );
+		} );
+	} );
+
 	describe( '#items()', () => {
 		test( 'should persist state', () => {
 			const original = deepFreeze( {

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -22,6 +22,7 @@ describe( 'selectors', () => {
 			};
 			expect( isRequestingResend( state, 67890, '789lkjh123456' ) ).to.equal( true );
 		} );
+
 		test( 'should return false when resend request is complete', () => {
 			const state = {
 				invites: {
@@ -33,6 +34,7 @@ describe( 'selectors', () => {
 			};
 			expect( isRequestingResend( state, 12345, '123456asdf789' ) ).to.equal( false );
 		} );
+
 		test( 'should return false when resend has not been requested', () => {
 			const state = {
 				invites: {

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -7,9 +7,79 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { isRequestingResend } from '../selectors';
+import { isRequestingInvitesForSite, getInvitesForSite, isRequestingResend } from '../selectors';
 
 describe( 'selectors', () => {
+	describe( '#isRequestingInvitesForSite()', () => {
+		test( 'should return true when requesting invites', () => {
+			const state = {
+				invites: {
+					requesting: {
+						12345: false,
+						67890: true,
+					},
+				},
+			};
+			expect( isRequestingInvitesForSite( state, 67890 ) ).to.equal( true );
+		} );
+
+		test( 'should return false when request is complete', () => {
+			const state = {
+				invites: {
+					requesting: {
+						12345: false,
+						67890: true,
+					},
+				},
+			};
+			expect( isRequestingInvitesForSite( state, 12345 ) ).to.equal( false );
+		} );
+
+		test( 'should return false when invites have not been requested', () => {
+			const state = {
+				invites: {
+					requesting: {},
+				},
+			};
+			expect( isRequestingInvitesForSite( state, 12345 ) ).to.equal( false );
+		} );
+	} );
+
+	describe( '#getInvitesForSite()', () => {
+		test( 'should return invites when invites exist for site', () => {
+			const state = {
+				invites: {
+					items: {
+						12345: [
+							{
+								key: '123456asdf789',
+								role: 'follower',
+								isPending: null,
+								user: {
+									login: 'chicken',
+									email: false,
+									name: 'Pollo',
+									avatar_URL:
+										'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+								},
+							},
+						],
+					},
+				},
+			};
+			expect( getInvitesForSite( state, 12345 ) ).to.eql( state.invites.items[ 12345 ] );
+		} );
+
+		test( 'should return null when invites do not exist for site', () => {
+			const state = {
+				invites: {
+					items: {},
+				},
+			};
+			expect( getInvitesForSite( state, 12345 ) ).to.equal( null );
+		} );
+	} );
+
 	describe( '#isRequestingResend()', () => {
 		test( 'should return true when requesting resend', () => {
 			const state = {

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -36,10 +36,7 @@ describe( 'selectors', () => {
 		test( 'should return false when resend has not been requested', () => {
 			const state = {
 				invites: {
-					requestingResend: {
-						12345: { '123456asdf789': false },
-						67890: { '789lkjh123456': true },
-					},
+					requestingResend: {},
 				},
 			};
 			expect( isRequestingResend( state, 12345, '9876asdf54321' ) ).to.equal( false );


### PR DESCRIPTION
- [x] Update invites reducer to only store whitelisted properties of invite objects (https://github.com/Automattic/wp-calypso/pull/21505#discussion_r161935011)
- [x] Add persistence to invites reducer (`items` branch only)
- [x] Add tests for invites reducer persistence
- [x] Minor updates to invites `requestingResend` tests (see comments at end of https://github.com/Automattic/wp-calypso/pull/21538)
- [x] Add tests for invites `items` and `requesting` reducer
- [x] Add tests for invites `isRequestingInvitesForSite` and `getInvitesForSite` selectors

**To test:**
- `npm run test-client client/state/invites/`