### PR TITLE
Purchases: Add Tracks events for presales chat click

### DIFF
--- a/client/my-sites/checkout/checkout/payment-chat-button.jsx
+++ b/client/my-sites/checkout/checkout/payment-chat-button.jsx
@@ -4,7 +4,8 @@
  * External dependencies
  */
 
-import React from 'react';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -12,12 +13,23 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import HappychatButton from 'components/happychat/button';
+import { recordTracksEvent } from 'state/analytics/actions';
 
-export default localize( ( { translate } ) => {
-	return (
-		<HappychatButton className="checkout__payment-chat-button">
-			<Gridicon icon="chat" className="checkout__payment-chat-button-icon" />
-			{ translate( 'Need help? Chat with us' ) }
-		</HappychatButton>
-	);
-} );
+export class PaymentChatButton extends Component {
+	chatButtonClicked = () => {
+		this.props.recordTracksEvent( 'calypso_presales_chat_click' );
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<HappychatButton className="checkout__payment-chat-button" onClick={ this.chatButtonClicked }>
+				<Gridicon icon="chat" className="checkout__payment-chat-button-icon" />
+				{ translate( 'Need help? Chat with us' ) }
+			</HappychatButton>
+		);
+	}
+}
+
+export default connect( null, { recordTracksEvent } )( localize( PaymentChatButton ) );


### PR DESCRIPTION
#21200 added a presales chat option if the customer has a Business plan in their cart. This adds a Tracks event to record presales chat clicks. Precancellation is already tracked under `calypso_purchases_cancel_form_chat_initiated` (here for [cancel purchase](https://github.com/Automattic/wp-calypso/blob/master/client/me/purchases/cancel-purchase/button.jsx#L95) and here for [remove purchase](https://github.com/Automattic/wp-calypso/blob/master/client/me/purchases/remove-purchase/index.jsx#L109)).

The presales Tracks event will be `calypso_presales_chat_click`.

### To test
You can test this in one of two ways:

1. You can turn on the toggle for presales chat. The toggle is available in a link provided by this code review D8590-code. If you're familiar, it's under Network Admin in the Happiness settings.
2. Once you turn on presales chat, you can put a Business plan in your cart and try to go to checkout. Provided we have Happiness Engineers available in Happychat, you should see the chat option.

The second way is by checking out this pull request and doing the following:

1. Edit the `isPresalesChatAvailable` selector to return `true` under [`/state/happychat/selectors/is-presales-chat-available.js.`](https://github.com/Automattic/wp-calypso/blob/master/client/state/happychat/selectors/is-presales-chat-available.js)
2. Put a Business plan in your cart and try to checkout.

Either way, once you click the chat button on the payment form, you should see a Tracks call for `calypso_presales_chat_click`. Since we're adding it to the `PaymentChatButton`, it should work the same across all payment options.