### PR TITLE
Fix: Rewind: Wrap credentials in `update-credentials` API call

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -36,7 +36,7 @@ export const request = ( { dispatch }, action ) => {
 				apiVersion: '1.1',
 				method: 'POST',
 				path: `/activity-log/${ action.siteId }/update-credentials`,
-				body: credentials,
+				body: { credentials },
 			},
 			{ ...action, noticeId }
 		)


### PR DESCRIPTION
In #21747 I accidentally unwrapped the `credentials` object from the
`credentials` property. This patch fixes it by putting it back.

The bug was preventing us from submitting credentials because the
backend would be missing properties on the submitted data.

**Testing**

Submit credentials (SSH, SFTP, or FTP) for a site.
In **master** the request should fail but in this branch it should succeed.