### PR TITLE
Reader FullPost, fix infinite request loop

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -98,6 +98,13 @@ class PostCommentList extends React.Component {
 		! this.alreadyLoadedInitialSet;
 
 	shouldNormalFetchAfterPropsChange = nextProps => {
+		if (
+			nextProps.commentsFetchingStatus.haveEarlierCommentsToFetch &&
+			nextProps.commentsFetchingStatus.haveLaterCommentsToFetch
+		) {
+			return true;
+		}
+
 		const currentSiteId = get( this.props, 'post.site_ID' );
 		const currentPostId = get( this.props, 'post.ID' );
 		const currentCommentsFilter = this.props.commentsFilter;
@@ -138,14 +145,14 @@ class PostCommentList extends React.Component {
 			if ( this.props.commentsTree ) {
 				this.viewEarlierCommentsHandler();
 			} else {
-				this.props.requestComment( { siteId, commentId: props.startingCommentId } );
+				props.requestComment( { siteId, commentId: props.startingCommentId } );
 			}
 		} else if ( this.shouldFetchInitialPages( props ) ) {
 			this.viewEarlierCommentsHandler();
 			this.viewLaterCommentsHandler();
 			this.alreadyLoadedInitialSet = true;
-		} else {
-			this.props.requestPostComments( { siteId, postId, status } );
+		} else if ( this.shouldNormalFetchAfterPropsChange( props ) ) {
+			props.requestPostComments( { siteId, postId, status } );
 		}
 	};
 

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -98,6 +98,7 @@ class PostCommentList extends React.Component {
 		! this.alreadyLoadedInitialSet;
 
 	shouldNormalFetchAfterPropsChange = nextProps => {
+		// this next check essentially looks out for whether we've ever requested comments for the post
 		if (
 			nextProps.commentsFetchingStatus.haveEarlierCommentsToFetch &&
 			nextProps.commentsFetchingStatus.haveLaterCommentsToFetch


### PR DESCRIPTION
When going to certain full-post pages, an infinite loop is created where`/replies` is requested over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and over and....

**To Test**
- Verify that this link creates an inf loop in prod and is fixed in this branch: https://wordpress.com/read/blogs/48006755/posts/24519
- also test everything you can do with loading comments on fp. that means deep links, loading after deep links, and clicking notifications.