### PR TITLE
Fix: Rewind: Use `progress` name instead of `percent`

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -35,7 +35,7 @@ const transformRewind = data =>
 			startedAt: new Date( data.started_at ),
 			status: data.status,
 		},
-		data.percent && { percent: data.percent },
+		data.progress && { progress: data.progress },
 		data.reason && { reason: data.reason }
 	);
 


### PR DESCRIPTION
The use of `percent` as a property name for rewind objects doesn't match
the specification-designated name of `progress`. This patch corrects
that name. Since `rewindState.rewind` hasn't yet been used in Calypso
this shouldn't impact anything yet

**Testing**

Smoke test on the Activity Log and on the Jetpack Rewind Credentials Settings page.
If it goes bad it should totally blow up.