### PR TITLE
Rewind: fix help link in credentials form footer

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
@@ -31,7 +31,7 @@ class SetupFooter extends Component {
 	hidePopover = () => this.setState( { isPopoverVisible: false } );
 
 	render() {
-		const { happychatAvailable, translate } = this.props;
+		const { happychatIsAvailable, translate } = this.props;
 		const { isPopoverVisible, popoverContext } = this.state;
 
 		return (
@@ -61,7 +61,7 @@ class SetupFooter extends Component {
 					}
 				</Popover>
 
-				{ happychatAvailable && (
+				{ happychatIsAvailable && (
 					<HappychatButton
 						onClick={ this.props.happychatEvent }
 					>
@@ -76,12 +76,11 @@ class SetupFooter extends Component {
 	}
 }
 
-const mapStateToProps = state => ( {
-	isHappychatAvailable: isHappychatAvailable( state ),
-} );
-
-const mapDispatchToProps = () => ( {
-	happychatEvent: () => recordTracksEvent( 'rewind_credentials_get_help' ),
-} );
-
-export default connect( mapStateToProps, mapDispatchToProps )( localize( SetupFooter ) );
+export default connect(
+	state => ( {
+		happychatIsAvailable: isHappychatAvailable( state ),
+	} ),
+	{
+		happychatEvent: () => recordTracksEvent( 'rewind_credentials_get_help' ),
+	}
+)( localize( SetupFooter ) );


### PR DESCRIPTION
This PR:
- fixes an issue that was causing the Get help button to never appear since the prop names were different: `happychatAvailable` vs `isHappychatAvailable `
    With this fix, the Get help button will now show up when HappyChat is available.
    <img width="761" alt="captura de pantalla 2018-01-26 a la s 11 21 21" src="https://user-images.githubusercontent.com/1041600/35444077-1be8bb86-028c-11e8-9539-6777fde2bd50.png">

- removes unnecessary constants and inserts the value directly in `connect`. 

