### PR TITLE
Adjust tour positions for onboarding checklist

### DIFF
--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -30,6 +30,8 @@ export const ChecklistContactPageTour = makeTour(
 			target="side-menu-page"
 			style={ {
 				animationDelay: '0s',
+				marginLeft: '-60px',
+				marginTop: '-4px',
 			} }
 		>
 			<p>
@@ -81,6 +83,7 @@ export const ChecklistContactPageTour = makeTour(
 			target="media-library-upload-more"
 			placement="beside"
 			arrow="left-top"
+			style={ { marginTop: '-10px' } }
 		>
 			<p>{ translate( 'Either pick an image below or add a new one from your computer.' ) }</p>
 			<Next step="click-set-featured-image">{ translate( 'All done, continue' ) }</Next>
@@ -91,6 +94,7 @@ export const ChecklistContactPageTour = makeTour(
 			target="dialog-base-action-confirm"
 			arrow="right-top"
 			placement="beside"
+			style={ { marginTop: '-10px' } }
 		>
 			<Continue target="dialog-base-action-confirm" step="click-update" click>
 				{ translate(
@@ -102,7 +106,13 @@ export const ChecklistContactPageTour = makeTour(
 			</Continue>
 		</Step>
 
-		<Step name="click-update" target="editor-publish-button" arrow="right-top" placement="beside">
+		<Step
+			name="click-update"
+			target="editor-publish-button"
+			arrow="right-top"
+			placement="beside"
+			style={ { marginTop: '-10px' } }
+		>
 			<Continue target="editor-publish-button" step="finish" click>
 				{ translate( 'Almost done, press the {{b}}Update{{/b}} button to save your changes.', {
 					components: { b: <strong /> },

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour.js
@@ -56,6 +56,7 @@ export const ChecklistPublishPostTour = makeTour(
 			target="accordion-categories-tags"
 			arrow="right-top"
 			placement="beside"
+			style={ { marginTop: '-10px' } }
 		>
 			<p>
 				{ translate(
@@ -96,6 +97,7 @@ export const ChecklistPublishPostTour = makeTour(
 			target="media-library-upload-more"
 			placement="beside"
 			arrow="left-top"
+			style={ { marginTop: '-10px' } }
 		>
 			<p>{ translate( 'Either pick an image below or add a new one from your computer.' ) }</p>
 			<Next step="click-set-featured-image">{ translate( 'All done, continue' ) }</Next>
@@ -106,6 +108,7 @@ export const ChecklistPublishPostTour = makeTour(
 			target="dialog-base-action-confirm"
 			arrow="right-top"
 			placement="beside"
+			style={ { marginTop: '-10px' } }
 		>
 			<Continue target="dialog-base-action-confirm" step="click-update" click>
 				{ translate(
@@ -117,7 +120,13 @@ export const ChecklistPublishPostTour = makeTour(
 			</Continue>
 		</Step>
 
-		<Step name="click-update" target="editor-publish-button" arrow="right-top" placement="beside">
+		<Step
+			name="click-update"
+			target="editor-publish-button"
+			arrow="right-top"
+			placement="beside"
+			style={ { marginTop: '-10px' } }
+		>
 			<Continue target="editor-publish-button" step="finish" click>
 				{ translate( 'Almost done, press the {{b}}Update{{/b}} button to save your changes.', {
 					components: { b: <strong /> },

--- a/client/layout/guided-tours/tours/checklist-site-icon-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour.js
@@ -51,6 +51,7 @@ export const ChecklistSiteIconTour = makeTour(
 			target="media-library-upload-more"
 			placement="beside"
 			arrow="left-top"
+			style={ { marginTop: '-10px' } }
 		>
 			<p>
 				{ translate( 'Pick or drag a file from your computer to add it to your media library.' ) }
@@ -63,6 +64,7 @@ export const ChecklistSiteIconTour = makeTour(
 			target="dialog-base-action-confirm"
 			arrow="bottom-center"
 			placement="above"
+			style={ { marginTop: '40px', marginLeft: '60px' } }
 		>
 			<Continue target="dialog-base-action-confirm" step="click-done" click>
 				{ translate( 'Good choice, press {{b}}Continue{{/b}} to use it as your Site Icon.', {
@@ -76,6 +78,7 @@ export const ChecklistSiteIconTour = makeTour(
 			target="image-editor-button-done"
 			arrow="bottom-center"
 			placement="above"
+			style={ { marginTop: '30px', marginLeft: '90px' } }
 		>
 			<Continue target="image_editor_button_done" step="finish" click>
 				{ translate(


### PR DESCRIPTION
This PR adds some polish to our checklist tours by adjusting the positions of the tours. 

## Before
<img width="1431" alt="screen shot 2018-01-26 at 10 20 54 am" src="https://user-images.githubusercontent.com/6981253/35446771-cf605830-0283-11e8-9c5a-216b9719fe7a.png">

## After
<img width="1431" alt="screen shot 2018-01-26 at 10 21 04 am" src="https://user-images.githubusercontent.com/6981253/35446768-cc84fada-0283-11e8-83be-5579b13c2527.png">

## Testing
- Create a new site and ensure you'r in the Checklist A/B test
- Run through all the tours and comment if anything looks out of place

@markryall @taggon can you please take a look?

