### PR TITLE
Add stacktrace-translate tool

### DIFF
--- a/bin/stacktrace-translate.js
+++ b/bin/stacktrace-translate.js
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+/**
+ * Script to translate a minified stack trace to a real one.
+ *
+ * Usage:
+ * stacktrace-translate
+ *
+ * Paste stacktrace array from error log into stdin.
+ */
+
+const _ = require( 'lodash' );
+const readline = require( 'readline' );
+const fs = require( 'fs' );
+const sourceMap = require( 'source-map' );
+const StackTraceGPS = require( 'stacktrace-gps' );
+const SourceMap = require( 'source-map' );
+const StackFrame = require( 'stackframe' );
+const glob = require( 'glob' );
+
+const BUNDLE_URL_ROOT = 'https://wordpress.com/calypso/';
+const SOURCE_PATTERN = './public/*.js';
+const SOURCEMAP_PATTERN = './public/*.js.map';
+
+let verbose = false;
+const loadedMaps = {};
+
+function loadSources() {
+	const filePrefixChars = SOURCE_PATTERN.indexOf( '*' );
+	const fileNames = glob.sync( SOURCE_PATTERN );
+	const files = {};
+
+	fileNames.forEach( ( fileName ) => {
+		const relativeFileName = fileName.substring( filePrefixChars );
+		const url = BUNDLE_URL_ROOT + relativeFileName;
+		const text = fs.readFileSync( fileName );
+		const textWithMapping = text + '\n//# sourceMappingURL=' + url + '.map';
+		files[ url ] = textWithMapping;
+	} );
+
+	return files;
+}
+
+function loadSourceMaps() {
+	const filePrefixChars = SOURCEMAP_PATTERN.indexOf( '*' );
+	const fileNames = glob.sync( SOURCEMAP_PATTERN );
+	const files = {};
+
+	fileNames.forEach( ( fileName ) => {
+		const url = BUNDLE_URL_ROOT + fileName.substring( filePrefixChars );
+		const text = fs.readFileSync( fileName );
+		const data = JSON.parse( text );
+		files[ url ] = new SourceMap.SourceMapConsumer( data );
+	} );
+
+	return files;
+}
+
+function loadFiles( filePattern, urlPrefix ) {
+	const filePrefixChars = filePattern.indexOf( '*' );
+	const fileNames = glob.sync( filePattern );
+	const files = {};
+
+	fileNames.forEach( ( fileName ) => {
+		const url = urlPrefix + fileName.substring( filePrefixChars );
+		const data = fs.readFileSync( fileName );
+		files[ url ] = data;
+	} );
+
+	return files;
+}
+
+function readStackTraceText( text, sourceCache, sourceMapConsumerCache ) {
+	const originalStack = JSON.parse( text );
+
+	const gps = new StackTraceGPS( { offline: true, sourceCache, sourceMapConsumerCache } );
+
+	originalStack.forEach( ( originalStackFrame, index ) => {
+		const stackFrame = new StackFrame( {
+			fileName: originalStackFrame.url,
+			lineNumber: originalStackFrame.line,
+			columnNumber: originalStackFrame.column,
+		} );
+
+		gps.getMappedLocation( stackFrame ).then( ( mappedStackFrame ) => {
+			printStackFrame( originalStackFrame, mappedStackFrame, index );
+		} );
+	} );
+}
+
+function printStackFrame( minified, mapped, index ) {
+	console.log( '------------------------------------------------------------' );
+	console.log( ' Stack Frame [ ' + index + ' ]' );
+	console.log( '------------------------------------------------------------' );
+	console.log( ' minified source: \t' + minified.url );
+	console.log( '          function: \t' + minified.func );
+	console.log( '          args: \t' + JSON.stringify( minified.args ) );
+	console.log( '          location: \t' + minified.line + ':' + minified.column );
+	console.log( '' );
+	console.log( ' translated source: \t' + mapped.fileName );
+	console.log( '            function: \t' + mapped.functionName );
+	console.log( '            location: \t' + mapped.lineNumber + ':' + mapped.columnNumber );
+	console.log( '' );
+}
+
+function translatePosition( rawSourceMap, line, column ) {
+	const consumerCreate = new sourceMap.SourceMapConsumer( rawSourceMap );
+
+	return consumerCreate.then( ( consumer ) => {
+		const info = consumer.originalPositionFor( { line, column } );
+		consumer.destroy();
+		return info;
+	} );
+}
+
+function loadBuild() {
+	if ( verbose ) {
+		console.log( 'Loading sources and maps...' );
+	}
+
+	const sources = loadSources();
+	const sourceMaps = loadSourceMaps();
+
+	if ( verbose ) {
+		console.log(
+			Object.keys( sources ).length + ' sources and ' +
+			Object.keys( sourceMaps ).length + ' maps loaded.'
+		);
+	}
+
+	return {
+		sources,
+		sourceMaps
+	};
+}
+
+function readFromFile( fileName ) {
+	const { sources, sourceMaps } = loadBuild();
+
+	if ( verbose ) {
+		console.log( 'Reading from file: ' + fileName );
+	}
+
+	const text = String( fs.readFileSync( fileName ) );
+
+	readStackTraceText( text, sources, sourceMaps );
+}
+
+function readFromStdin() {
+	const { sources, sourceMaps } = loadBuild();
+
+	const rl = readline.createInterface( {
+		input: process.stdin,
+		output: process.stdout,
+		terminal: true,
+		prompt: '',
+	} );
+
+	if ( verbose ) {
+		console.log( 'Paste stacktrace array from error log: ' );
+	}
+	rl.on( 'line', ( line ) => {
+		readStackTraceText( line, sources, sourceMaps );
+		rl.close();
+	} );
+}
+
+function showUsage( bin, script ) {
+	console.log( 'Usage: stacktrace-translate.js [options] <json file>' );
+	console.log( '' );
+	console.log( '<json file>: Stack trace file (if not provided stdin will be used.)' );
+	console.log( '' );
+	console.log( 'Options:' );
+	console.log( ' -?, --help\t\t\tShow usage' );
+	console.log( ' -v, --verbose\t\t\tVerbose output' );
+}
+
+function run( args ) {
+	const usage = _.includes( args, '-?' ) || _.includes( args, '--help' );
+
+	if ( usage ) {
+		showUsage( args[ 0 ], args[ 1 ] );
+		process.exit( 0 );
+	}
+
+	verbose = _.includes( args, '-v' ) || _.includes( args, '--verbose' );
+	const fileName = _.find( args, ( el, index ) => {
+		return ( 2 <= index && ! el.startsWith( '-' ) );
+	} );
+
+	if ( fileName ) {
+		readFromFile( fileName );
+	} else {
+		readFromStdin();
+	}
+}
+
+run( process.argv );
+

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -43,16 +43,16 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.0.0-beta.42",
-      "integrity": "sha512-L8i94FLSyaLQpRfDo/qqSm8Ndb44zMtXParXo0MebJICG1zoCCL4+GkzUOlB4BNTRSXXQdb3feam/qw7bKPipQ==",
+      "version": "7.0.0-beta.44",
+      "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.42"
+        "@babel/highlight": "7.0.0-beta.44"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.42",
-      "integrity": "sha512-X3Ur/A/lIbbP8W0pmwgqtDXIxhQmxPaiwY9SKP7kF9wvZfjZRwMvbJE92ozUhF3UDK3DCKaV7oGqmI1rP/zqWA==",
+      "version": "7.0.0-beta.44",
+      "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
       "dev": true,
       "requires": {
         "chalk": "2.3.2",
@@ -99,8 +99,8 @@
       }
     },
     "@types/node": {
-      "version": "9.6.1",
-      "integrity": "sha512-xwlHq5DXQFRpe+u6hmmNkzYk/3oxxqDp71a/AJMupOQYmxyaBetqrVMqdNlSQfbg7XTJYD8vARjf3Op06OzdtQ==",
+      "version": "6.0.104",
+      "integrity": "sha512-xPuI3Yeyc3u5SY7aFu6ILTJHFXo820DSfqNqYi1gxPmbpul+vLSfo3vhrY80d0+SdOYR9KdXHg6ozx4i/02LCg==",
       "dev": true
     },
     "JSONStream": {
@@ -497,7 +497,7 @@
       "integrity": "sha1-a8vQOKM3xwYn5/zkQ4+lgYjwk3s=",
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000821",
+        "caniuse-db": "1.0.30000823",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1353,7 +1353,7 @@
           "version": "2.11.3",
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "requires": {
-            "caniuse-lite": "1.0.30000821",
+            "caniuse-lite": "1.0.30000823",
             "electron-to-chromium": "1.3.41"
           }
         },
@@ -1675,7 +1675,7 @@
         "content-type": "1.0.4",
         "debug": "2.6.7",
         "depd": "1.1.2",
-        "http-errors": "1.6.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.15",
         "on-finished": "2.3.0",
         "qs": "6.4.0",
@@ -1770,8 +1770,8 @@
       }
     },
     "browserify-aes": {
-      "version": "1.1.1",
-      "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+      "version": "1.2.0",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "1.0.3",
         "cipher-base": "1.0.4",
@@ -1785,7 +1785,7 @@
       "version": "1.0.0",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "requires": {
-        "browserify-aes": "1.1.1",
+        "browserify-aes": "1.2.0",
         "browserify-des": "1.0.0",
         "evp_bytestokey": "1.0.3"
       }
@@ -1831,7 +1831,7 @@
       "version": "1.3.6",
       "integrity": "sha1-lS/0jVZGPTtTj4XvL46t39KEsTM=",
       "requires": {
-        "caniuse-db": "1.0.30000821"
+        "caniuse-db": "1.0.30000823"
       }
     },
     "bser": {
@@ -1977,12 +1977,12 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000821",
-      "integrity": "sha1-P83GfERqlKnN2Egkik4+VLLadBk="
+      "version": "1.0.30000823",
+      "integrity": "sha1-5o5fjHB4PvQFnS6g3oH1UWUdpvw="
     },
     "caniuse-lite": {
-      "version": "1.0.30000821",
-      "integrity": "sha512-qyYay02wr/5k7PO86W+LKFaEUZfWIvT65PaXuPP16jkSpgZGIsSstHKiYAPVLjTj98j2WnWwZg8CjXPx7UIPYg=="
+      "version": "1.0.30000823",
+      "integrity": "sha512-3rrhqUxwBgrwNlWVUEwIJfqdZNwLPX18eTo7MGXb3gueDpbOFW6w5OXyHscdBd6IJcu9wnKmKVd7nSl+r7fmgw=="
     },
     "cardinal": {
       "version": "1.0.0",
@@ -3110,6 +3110,16 @@
       "integrity": "sha1-GK6XmmoMqZSwYlhTkW0mYruuCxo=",
       "dev": true
     },
+    "data-urls": {
+      "version": "1.0.0",
+      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+      "dev": true,
+      "requires": {
+        "abab": "1.0.4",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.4.0"
+      }
+    },
     "date-now": {
       "version": "0.1.4",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
@@ -3366,7 +3376,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.3.6",
-        "caniuse-db": "1.0.30000821",
+        "caniuse-db": "1.0.30000823",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
@@ -4150,8 +4160,8 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.1.1",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "version": "2.2.0",
+      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -4208,7 +4218,7 @@
         "debug": "2.6.9",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.1.1",
+        "eslint-module-utils": "2.2.0",
         "has": "1.0.1",
         "lodash": "4.17.5",
         "minimatch": "3.0.4",
@@ -6558,19 +6568,15 @@
       }
     },
     "http-errors": {
-      "version": "1.6.2",
-      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "version": "1.6.3",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
+        "setprototypeof": "1.1.0",
         "statuses": "1.5.0"
       },
       "dependencies": {
-        "depd": {
-          "version": "1.1.1",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
-        },
         "inherits": {
           "version": "2.0.3",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
@@ -7196,7 +7202,7 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
         "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "whatwg-fetch": "2.0.4"
       }
     },
     "isstream": {
@@ -7767,7 +7773,7 @@
       "requires": {
         "jest-mock": "22.4.3",
         "jest-util": "22.4.3",
-        "jsdom": "11.6.2"
+        "jsdom": "11.7.0"
       }
     },
     "jest-environment-node": {
@@ -8023,7 +8029,7 @@
       "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.42",
+        "@babel/code-frame": "7.0.0-beta.44",
         "chalk": "2.3.2",
         "micromatch": "2.3.11",
         "slash": "1.0.0",
@@ -8734,18 +8740,17 @@
       }
     },
     "jsdom": {
-      "version": "11.6.2",
-      "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+      "version": "11.7.0",
+      "integrity": "sha512-9NzSc4Iz4gN9p4uoPbBUzro21QdgL32swaWIaWS8eEVQ2I69fRJAy/MKyvlEIk0V7HtKgfMbbOKyTZUrzR2Hsw==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
         "acorn": "5.5.3",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
-        "browser-process-hrtime": "0.1.2",
-        "content-type-parser": "1.0.2",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
+        "data-urls": "1.0.0",
         "domexception": "1.0.1",
         "escodegen": "1.9.1",
         "html-encoding-sniffer": "1.0.2",
@@ -8761,6 +8766,7 @@
         "w3c-hr-time": "1.0.1",
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
+        "whatwg-mimetype": "2.1.0",
         "whatwg-url": "6.4.0",
         "ws": "4.1.0",
         "xml-name-validator": "3.0.0"
@@ -10033,7 +10039,7 @@
         "readable-stream": "2.3.5",
         "stream-browserify": "2.0.1",
         "stream-http": "2.8.1",
-        "string_decoder": "1.1.0",
+        "string_decoder": "1.1.1",
         "timers-browserify": "2.0.6",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
@@ -10072,8 +10078,8 @@
           }
         },
         "string_decoder": {
-          "version": "1.1.0",
-          "integrity": "sha512-8zQpRF6juocE69ae7CSPmYEGJe4VCXwP6S6dxUWI7i53Gwv54/ec41fiUA+X7BPGGv7fRSQJjBQVa0gomGaOgg==",
+          "version": "1.1.1",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -10770,7 +10776,7 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "requires": {
         "asn1.js": "4.10.1",
-        "browserify-aes": "1.1.1",
+        "browserify-aes": "1.2.0",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
         "pbkdf2": "3.0.14"
@@ -10847,7 +10853,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.1"
+        "@types/node": "6.0.104"
       }
     },
     "parsejson": {
@@ -13822,8 +13828,8 @@
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
-      "version": "1.0.3",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+      "version": "1.1.0",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -14269,6 +14275,27 @@
       "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
       "dev": true
     },
+    "stackframe": {
+      "version": "1.0.4",
+      "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==",
+      "dev": true
+    },
+    "stacktrace-gps": {
+      "version": "3.0.2",
+      "integrity": "sha512-9o+nWhiz5wFnrB3hBHs2PTyYrS60M1vvpSzHxwxnIbtY2q9Nt51hZvhrG1+2AxD374ecwyS+IUwfkHRE/2zuGg==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "1.0.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        }
+      }
+    },
     "state-toggle": {
       "version": "1.0.0",
       "integrity": "sha1-0g+aYWu08MO5i5GSLSW2QKorxCU=",
@@ -14427,8 +14454,8 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "string-kit": {
-      "version": "0.6.9",
-      "integrity": "sha512-AHrcOjKBQhS9zuLC/Cocljl39NfNlgGHljQ8z8YmDcuuep3r2GMQ/GhiJCTyVhFUqOt6mB9zrBc4nB91loxV/g==",
+      "version": "0.6.11",
+      "integrity": "sha512-aMGp2i+0QlFwtKfCx1tLCFkvqHYtCE0TKebNo7yU3LJVOdkJNqiOznPfBv8rugsqBeE3++PE8oc5EZyDhK88kQ==",
       "dev": true,
       "requires": {
         "xregexp": "3.2.0"
@@ -14894,7 +14921,7 @@
         "get-pixels": "3.3.0",
         "ndarray": "1.0.18",
         "nextgen-events": "0.10.2",
-        "string-kit": "0.6.9",
+        "string-kit": "0.6.11",
         "tree-kit": "0.5.26"
       }
     },
@@ -16591,7 +16618,7 @@
             "content-type": "1.0.4",
             "debug": "2.6.9",
             "depd": "1.1.2",
-            "http-errors": "1.6.2",
+            "http-errors": "1.6.3",
             "iconv-lite": "0.4.19",
             "on-finished": "2.3.0",
             "qs": "6.5.1",
@@ -16725,6 +16752,11 @@
           "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
           "dev": true
         },
+        "inherits": {
+          "version": "2.0.3",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
         "ipaddr.js": {
           "version": "1.6.0",
           "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
@@ -16773,6 +16805,29 @@
             "http-errors": "1.6.2",
             "iconv-lite": "0.4.19",
             "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+              "dev": true
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+              "dev": true,
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+              "dev": true
+            }
           }
         },
         "send": {
@@ -16787,7 +16842,7 @@
             "escape-html": "1.0.3",
             "etag": "1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "1.6.2",
+            "http-errors": "1.6.3",
             "mime": "1.4.1",
             "ms": "2.0.0",
             "on-finished": "2.3.0",
@@ -16805,11 +16860,6 @@
             "parseurl": "1.3.2",
             "send": "0.16.2"
           }
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
         },
         "statuses": {
           "version": "1.4.0",
@@ -16896,8 +16946,13 @@
       }
     },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "version": "2.0.4",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+    },
+    "whatwg-mimetype": {
+      "version": "2.1.0",
+      "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+      "dev": true
     },
     "whatwg-url": {
       "version": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -276,6 +276,7 @@
     "sinon": "1.17.7",
     "sinon-chai": "2.8.0",
     "socket.io": "1.4.5",
+    "stacktrace-gps": "3.0.2",
     "stylelint": "6.9.0",
     "supertest": "2.0.0",
     "terminal-kit": "1.13.13",


### PR DESCRIPTION
This adds a tool to translate a minified stacktrace to a meaningful one.

To Test:

1. Find an error from logstash in kibana that you want to investigate.
2. Copy the commit sha from the "commit" field.
3. Run `git checkout <commit sha>`
4. Run `CALYPSO_ENV=production SOURCEMAP=hidden-source-map npm run build`
5. Run `git checkout add/stacktrace-translate-tool` (only necessary until this PR is merged)
6. Run `npm install` (to ensure the extra npm dependency is present)
7. Going back to kibana, copy the "trace" field to your clipboard. (I use triple-click to select)
8. Run `./bin/stacktrace-translate.js -v`
9. Paste the trace into the terminal.
10. Observe the results.

I've checked the results for several errors, and while some do work exactly as expected, others do not yet because of minified `node_module`bundles that are re-bundled into our own. Also, the traces seem to be one stack frame below the actual error, so if you search for error text, you likely won't find it in stack frame [0] code.

Further work may be needed to perhaps improve the stack traces given to logstash, and to un-minify dependent modules (if that's what we really want to do).
