### PR TITLE
Search: Fixing focus state for search inputs

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -22,7 +22,7 @@
 		height: 100%;
 
 		&:focus {
-			box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
+			box-shadow: inset 0 0 0 2px $blue-light;
 			position: relative;
 			z-index: 9999;
 		}
@@ -35,10 +35,6 @@
 		z-index: z-index( '.search', '.search .search__open-icon' );
 		color: $blue-wordpress;
 		cursor: pointer;
-
-		.accessible-focus &:focus {
-			outline: dotted 1px $blue-wordpress;
-		}
 	}
 
 	.search__open-icon:hover {
@@ -51,7 +47,7 @@
 		transition: opacity .2s ease-in;
 	}
 
-	.accessible-focus &.has-focus {
+	&.has-focus {
 		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
 	}
 

--- a/client/components/sticky-panel/style.scss
+++ b/client/components/sticky-panel/style.scss
@@ -1,7 +1,8 @@
 .sticky-panel {
 	// Force a new block formatting context to prevent margin collapsing. It's needed for
 	// correct measurement of `.sticky_panel__content` height and setting the spacer height.
-
+	// This seems to only affect the stats section. Applying it everywhere causes issue with
+	// :focus on child elements. (i.e. themes)
 	.is-section-stats & {
 		overflow: hidden;
 	}

--- a/client/components/sticky-panel/style.scss
+++ b/client/components/sticky-panel/style.scss
@@ -1,7 +1,10 @@
 .sticky-panel {
 	// Force a new block formatting context to prevent margin collapsing. It's needed for
 	// correct measurement of `.sticky_panel__content` height and setting the spacer height.
-	overflow: hidden;
+
+	.is-section-stats & {
+		overflow: hidden;
+	}
 }
 
 .sticky-panel__content {

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -39,6 +39,7 @@
 	}
 
 	.themes-magic-search-card__icon {
+		margin-left: 8px;
 		display: flex;
 		color: $blue-wordpress;
 		cursor: pointer;


### PR DESCRIPTION
Search inputs currently don't have a normal `:focus` state like other inputs in Calypso:

<img width="753" alt="screen shot 2018-01-26 at 10 46 59 am" src="https://user-images.githubusercontent.com/191598/35447670-4c83ee6a-0286-11e8-9943-2c9313212413.png">

This PR aims to resolve that, ending up with this:

<img width="754" alt="screen shot 2018-01-26 at 10 47 28 am" src="https://user-images.githubusercontent.com/191598/35447695-5bef6f1e-0286-11e8-9bab-36b2743c5618.png">

This will affect all search inputs. Themes requires a little more finesse, as it uses `sticky-panel`, which has its own quirks.