### PR TITLE
Extensions: Zoninator - Add a minimum version requirement for Zoninator's extension

### DIFF
--- a/client/extensions/zoninator/app/constants.js
+++ b/client/extensions/zoninator/app/constants.js
@@ -1,0 +1,1 @@
+export const ZONINATOR_MIN_VERSION = '0.8';

--- a/client/extensions/zoninator/components/settings/index.jsx
+++ b/client/extensions/zoninator/components/settings/index.jsx
@@ -16,6 +16,7 @@ import ExtensionRedirect from 'blocks/extension-redirect';
 import DocumentHead from 'components/data/document-head';
 import Main from 'components/main';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { ZONINATOR_MIN_VERSION } from '../../app/constants';
 import QueryZones from '../data/query-zones';
 
 const Settings = ( { children, siteId, translate } ) => {
@@ -23,7 +24,11 @@ const Settings = ( { children, siteId, translate } ) => {
 
 	return (
 		<Main className={ mainClassName }>
-			<ExtensionRedirect pluginId="zoninator" siteId={ siteId } />
+			<ExtensionRedirect
+				pluginId="zoninator"
+				siteId={ siteId }
+				minimumVersion={ ZONINATOR_MIN_VERSION }
+			/>
 			<QueryZones siteId={ siteId } />
 			<DocumentHead title={ translate( 'WP Zone Manager' ) } />
 			{ children }


### PR DESCRIPTION
This PR sets `0.8` as the minimum plugin version for Zoninator's calypso extension to work.

# Testing

- Go to `/plugins/zoninator` on a site with Zoninator `0.7` or less.
- Click `Edit plugin settings`.
- You should be redirected back to the plugin page.
- Update the plugin to `0.8`, you should be able to access the extension settings.