### PR TITLE
Memoize the getDecoratedSiteDomains selector

### DIFF
--- a/client/state/sites/domains/selectors.js
+++ b/client/state/sites/domains/selectors.js
@@ -6,6 +6,15 @@
 import { moment } from 'i18n-calypso';
 
 /**
+ * Internal dependencies
+ */
+import treeSelect from 'lib/tree-select';
+
+// static empty array to ensure that empty return values from selectors are
+// identical to each other ( rv1 === rv2 )
+const EMPTY_SITE_DOMAINS = Object.freeze( [] );
+
+/**
  * Return site domains getting from state object and
  * the given siteId
  *
@@ -15,11 +24,10 @@ import { moment } from 'i18n-calypso';
  */
 export const getDomainsBySiteId = ( state, siteId ) => {
 	if ( ! siteId ) {
-		return [];
+		return EMPTY_SITE_DOMAINS;
 	}
 
-	const { items } = state.sites.domains;
-	return items[ siteId ] || [];
+	return state.sites.domains.items[ siteId ] || EMPTY_SITE_DOMAINS;
 };
 
 /**
@@ -32,8 +40,9 @@ export const getDomainsBySiteId = ( state, siteId ) => {
  */
 export const getDomainsBySite = ( state, site ) => {
 	if ( ! site ) {
-		return [];
+		return EMPTY_SITE_DOMAINS;
 	}
+
 	return getDomainsBySiteId( state, site.ID );
 };
 
@@ -45,8 +54,7 @@ export const getDomainsBySite = ( state, site ) => {
  * @return {Boolean} is site-domains requesting?
  */
 export const isRequestingSiteDomains = ( state, siteId ) => {
-	const { requesting } = state.sites.domains;
-	return requesting[ siteId ] || false;
+	return state.sites.domains.requesting[ siteId ] || false;
 };
 
 /**
@@ -56,22 +64,18 @@ export const isRequestingSiteDomains = ( state, siteId ) => {
  * @param  {Number}  siteId the site id
  * @return {?Object}        decorated site domains
  */
-export function getDecoratedSiteDomains( state, siteId ) {
-	const domains = getDomainsBySiteId( state, siteId );
+export const getDecoratedSiteDomains = treeSelect(
+	( state, siteId ) => [ getDomainsBySiteId( state, siteId ) ],
+	( [ domains ] ) => {
+		if ( ! domains ) {
+			return null;
+		}
 
-	if ( ! domains ) {
-		return null;
-	}
-
-	return domains.map( domain => {
-		return {
+		return domains.map( domain => ( {
 			...domain,
-
 			autoRenewalMoment: domain.autoRenewalDate ? moment( domain.autoRenewalDate ) : null,
-
 			registrationMoment: domain.registrationDate ? moment( domain.registrationDate ) : null,
-
 			expirationMoment: domain.expiry ? moment( domain.expiry ) : null,
-		};
-	} );
-}
+		} ) );
+	}
+);

--- a/client/state/sites/domains/test/selectors.js
+++ b/client/state/sites/domains/test/selectors.js
@@ -95,5 +95,18 @@ describe( 'selectors', () => {
 				domainExpirationMoment.date()
 			);
 		} );
+
+		test( 'should memoize the return value on repeated calls', () => {
+			const state = getStateInstance();
+
+			const domainsSite1call1 = getDecoratedSiteDomains( state, firstSiteId );
+			const domainsSite2call1 = getDecoratedSiteDomains( state, secondSiteId );
+			const domainsSite1call2 = getDecoratedSiteDomains( state, firstSiteId );
+			const domainsSite2call2 = getDecoratedSiteDomains( state, secondSiteId );
+
+			// The returned arrays on repeated calls must be strictly equal (===) to each other
+			expect( domainsSite1call1 ).to.equal( domainsSite1call2 );
+			expect( domainsSite2call1 ).to.equal( domainsSite2call2 );
+		} );
 	} );
 } );


### PR DESCRIPTION
Optimizes the selector to cache the return value and return an identical array when called with the same argument and there is no change in the Redux state. Uses `treeSelect` to cache values by `siteId`.

**How to test:**

A. there is a new unit test that checks the memoization. It should fail without this patch, and succeed after the memoization is implemented.

B. put a `console.count()` statement into the render method of `CurrentSiteDomainWarnings`. Before the patch, it would rerender ~40 times when loading `/stats/day/:site` and continue to rerender many times any time you navigate around "My Sites". After applying this patch, that component is rerendered 2 or 3 times on load and then never again. The `CurrentSiteDomainWarnings` component is always rendered when you are in "My Sites", so optimizing it and its dependencies has high impact.

C. check that the domain warnings are still displayed correctly.
