### PR TITLE
Http: Escape query string keys

### DIFF
--- a/client/state/http/index.js
+++ b/client/state/http/index.js
@@ -61,7 +61,10 @@ export const httpHandler = ( { dispatch }, action ) => {
 	}
 
 	const queryString = queryParams
-		.map( ( [ queryKey, queryValue ] ) => queryKey + '=' + encodeURIComponent( queryValue ) )
+		.map(
+			( [ queryKey, queryValue ] ) =>
+				encodeURIComponent( queryKey ) + '=' + encodeURIComponent( queryValue )
+		)
 		.join( '&' );
 
 	if ( queryString.length > 0 ) {

--- a/client/state/http/test/index.js
+++ b/client/state/http/test/index.js
@@ -107,9 +107,15 @@ describe( '#httpHandler', () => {
 	} );
 
 	test( 'should set appropriate query string', () => {
-		const queryParams = [ [ 'statement', 'hello world' ], [ 'regex', '/.$/' ] ];
+		const queryParams = [
+			[ 'statement', 'hello world' ],
+			[ 'regex', '/.$/' ],
+			[ 'spaced key', 'spaced value' ],
+			[ 'plus+', 'plus+' ],
+		];
 
-		const queryString = 'statement=hello%20world&regex=%2F.%24%2F';
+		const queryString =
+			'statement=hello%20world&regex=%2F.%24%2F&spaced%20key=spaced%20value&plus%2B=plus%2B';
 
 		superagentMock.setResponse( true, {} );
 


### PR DESCRIPTION
Query string keys were not being escaped. This PR adds a test and escapes the keys correctly.

Verify the escaped behavior in modern browsers:

```js
const u = new URL('https://example.com?query=string&spaced%20key=spaced%20value')
u.searchParams.has('spaced key')
// true
u.searchParams.get('spaced key')
// "spaced value"
u.searchParams.has('spaced%20key')
// false
u.searchParams.has('spaced+key')
// false
```

## Testing
1. Tests pass
1. Note the failing test for bee0e7d