### PR TITLE
Jetpack Plans: Add a 'Best Value' plan designation and use it to highlight the Premium plan.

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -30,7 +30,8 @@ export const PLAN_WPCOM_ENTERPRISE = 'wpcom-enterprise';
 export const PLAN_CHARGEBACK = 'chargeback';
 
 export const POPULAR_PLANS = [ PLAN_PREMIUM ];
-export const NEW_PLANS = [ PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ];
+export const NEW_PLANS = [];
+export const BEST_VALUE_PLANS = [ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ];
 export const JETPACK_PLANS = [
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
@@ -1411,6 +1412,10 @@ export function isPopular( plan ) {
 
 export function isNew( plan ) {
 	return includes( NEW_PLANS, plan );
+}
+
+export function isBestValue( plan ) {
+	return includes( BEST_VALUE_PLANS, plan );
 }
 
 export function getPlanClass( plan ) {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -56,7 +56,7 @@ class PlanFeaturesHeader extends Component {
 	}
 
 	renderPlansHeader() {
-		const { newPlan, planType, popular, selectedPlan, title, translate } = this.props;
+		const { newPlan, bestValue, planType, popular, selectedPlan, title, translate } = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 
@@ -67,6 +67,7 @@ class PlanFeaturesHeader extends Component {
 				) }
 				{ popular && ! selectedPlan && <Ribbon>{ translate( 'Popular' ) }</Ribbon> }
 				{ newPlan && ! selectedPlan && <Ribbon>{ translate( 'New' ) }</Ribbon> }
+				{ bestValue && ! selectedPlan && <Ribbon>{ translate( 'Best Value' ) }</Ribbon> }
 				{ this.isPlanCurrent() && <Ribbon>{ translate( 'Your Plan' ) }</Ribbon> }
 				<div className="plan-features__header-figure">
 					<PlanIcon plan={ planType } />
@@ -81,7 +82,7 @@ class PlanFeaturesHeader extends Component {
 	}
 
 	renderSignupHeader() {
-		const { planType, popular, newPlan, title, audience, translate } = this.props;
+		const { planType, popular, newPlan, bestValue, title, audience, translate } = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 
@@ -90,6 +91,7 @@ class PlanFeaturesHeader extends Component {
 				<header className={ headerClasses } onClick={ this.props.onClick }>
 					{ newPlan && <Ribbon>{ translate( 'New' ) }</Ribbon> }
 					{ popular && <Ribbon>{ translate( 'Popular' ) }</Ribbon> }
+					{ bestValue && <Ribbon>{ translate( 'Best Value' ) }</Ribbon> }
 					<div className="plan-features__header-text">
 						<h4 className="plan-features__header-title">{ title }</h4>
 						{ audience }
@@ -292,6 +294,7 @@ PlanFeaturesHeader.propTypes = {
 	] ).isRequired,
 	popular: PropTypes.bool,
 	newPlan: PropTypes.bool,
+	bestValue: PropTypes.bool,
 	rawPrice: PropTypes.number,
 	discountPrice: PropTypes.number,
 	currencyCode: PropTypes.string,
@@ -313,6 +316,7 @@ PlanFeaturesHeader.defaultProps = {
 	onClick: noop,
 	popular: false,
 	newPlan: false,
+	bestValue: false,
 	isPlaceholder: false,
 	site: {},
 	basePlansPath: null,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -32,6 +32,7 @@ import { getPlanRawPrice, getPlan, getPlanSlug, getPlanBySlug } from 'state/plan
 import {
 	isPopular,
 	isNew,
+	isBestValue,
 	isMonthly,
 	getPlanFeaturesObject,
 	getPlanClass,
@@ -150,6 +151,7 @@ class PlanFeatures extends Component {
 				planName,
 				popular,
 				newPlan,
+				bestValue,
 				relatedMonthlyPlan,
 				primaryUpgrade,
 				isPlaceholder,
@@ -163,6 +165,7 @@ class PlanFeatures extends Component {
 						currencyCode={ currencyCode }
 						popular={ popular }
 						newPlan={ newPlan }
+						bestValue={ bestValue }
 						title={ planConstantObj.getTitle() }
 						planType={ planName }
 						rawPrice={ rawPrice }
@@ -226,6 +229,7 @@ class PlanFeatures extends Component {
 				planName,
 				popular,
 				newPlan,
+				bestValue,
 				relatedMonthlyPlan,
 				isPlaceholder,
 				hideMonthly,
@@ -268,6 +272,7 @@ class PlanFeatures extends Component {
 						isInSignup={ isInSignup }
 						isPlaceholder={ isPlaceholder }
 						newPlan={ newPlan }
+						bestValue={ bestValue }
 						planType={ planName }
 						popular={ popular }
 						rawPrice={ rawPrice }
@@ -530,6 +535,7 @@ export default connect(
 					: null;
 				const popular = isPopular( plan ) && ! isPaid;
 				const newPlan = isNew( plan ) && ! isPaid;
+				const bestValue = isBestValue( plan ) && ! isPaid;
 				const currentPlan = sitePlan && sitePlan.product_slug;
 				const showMonthlyPrice = ! relatedMonthlyPlan && showMonthly;
 				let planFeatures = getPlanFeaturesObject( planConstantObj.getFeatures( abtest ) );
@@ -596,12 +602,14 @@ export default connect(
 					planObject: planObject,
 					popular: popular,
 					newPlan: newPlan,
+					bestValue: bestValue,
 					hideMonthly: false,
 					primaryUpgrade:
 						( currentPlan === PLAN_PERSONAL && plan === PLAN_PREMIUM ) ||
 						( currentPlan === PLAN_PREMIUM && plan === PLAN_BUSINESS ) ||
 						popular ||
 						newPlan ||
+						bestValue ||
 						plans.length === 1,
 					rawPrice: getPlanRawPrice( state, planProductId, showMonthlyPrice ),
 					relatedMonthlyPlan: relatedMonthlyPlan,


### PR DESCRIPTION
This change adds a new ‘Best Value’ designation (via the ribbon) that
is available to all plans. It also removes the ‘New’ ribbon designation
from the Personal plan, which is…well, no longer new.

Test plan:
* Go to the Plans page for any Jetpack site.
* Confirm that the ‘New’ ribbon no longer applies to the Personal plan.
* Confirm that the ‘Best Value’ ribbon is now applied to the Personal plan, and that the CTAs are correctly highlighted (they should be blue).