### PR TITLE
Jetpack Connect: Add additional tracking properties to the URL form

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -171,6 +171,8 @@ export function connect( context, next ) {
 		path,
 		type,
 		url: query.url,
+		ctaId: query.cta_id, // origin tracking params
+		ctaFrom: query.cta_from,
 	} );
 	next();
 }

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -88,6 +88,22 @@ export class JetpackConnectMain extends Component {
 		}
 	}
 
+	getCtaTrackingDetails() {
+		const parts = window.location.search.substr( 1 ).split( '&' );
+		const params = {};
+		for ( let i = 0; i < parts.length; i++ ) {
+			const ctaProp = parts[ i ].split( '=' );
+			params[ decodeURIComponent( ctaProp[ 0 ] ) ] = decodeURIComponent( ctaProp[ 1 ] );
+		}
+
+		const ctaProps = {
+			cta_id: params.cta_id,
+			cta_from: params.cta_from,
+		};
+
+		return ctaProps;
+	}
+
 	componentDidMount() {
 		let from = 'direct';
 		if ( this.props.type === 'install' ) {
@@ -102,8 +118,13 @@ export class JetpackConnectMain extends Component {
 		if ( this.props.type === 'personal' ) {
 			from = 'ad';
 		}
+
+		const ctaProps = this.getCtaTrackingDetails();
+
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
 			jpc_from: from,
+			cta_id: ctaProps.cta_id,
+			cta_from: ctaProps.cta_from,
 		} );
 	}
 

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -88,22 +88,6 @@ export class JetpackConnectMain extends Component {
 		}
 	}
 
-	getCtaTrackingDetails() {
-		const parts = window.location.search.substr( 1 ).split( '&' );
-		const params = {};
-		for ( let i = 0; i < parts.length; i++ ) {
-			const ctaProp = parts[ i ].split( '=' );
-			params[ decodeURIComponent( ctaProp[ 0 ] ) ] = decodeURIComponent( ctaProp[ 1 ] );
-		}
-
-		const ctaProps = {
-			cta_id: params.cta_id,
-			cta_from: params.cta_from,
-		};
-
-		return ctaProps;
-	}
-
 	componentDidMount() {
 		let from = 'direct';
 		if ( this.props.type === 'install' ) {
@@ -119,12 +103,10 @@ export class JetpackConnectMain extends Component {
 			from = 'ad';
 		}
 
-		const ctaProps = this.getCtaTrackingDetails();
-
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
 			jpc_from: from,
-			cta_id: ctaProps.cta_id,
-			cta_from: ctaProps.cta_from,
+			cta_id: this.props.ctaId,
+			cta_from: this.props.ctaFrom,
 		} );
 	}
 


### PR DESCRIPTION
This change adds a few additional properties to the event that fires
when the Jetpack Connect URL submission form is viewed. These two
parameters found in the URL will be sent primarily from the CTAs around
jetpack.com.

Test plan:
* Go to http://calypso.localhost:3000/jetpack/connect?cta_id=thisIsTheCtaID&cta_from=thisIsTheCtaFrom (you can change the cta_id and cta_from values as you wish).
* Confirm that the event fires as expected with the correct properties pulled from the URL.