### PR TITLE
 Invites: Add ListEnd component and track max display

### DIFF
--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -19,7 +19,12 @@ import PeopleSectionNav from 'my-sites/people/people-section-nav';
 import PeopleListItem from 'my-sites/people/people-list-item';
 import Card from 'components/card';
 import QuerySiteInvites from 'components/data/query-site-invites';
-import { isRequestingInvitesForSite, getInvitesForSite } from 'state/invites/selectors';
+import InvitesListEnd from './invites-list-end';
+import {
+	isRequestingInvitesForSite,
+	getInvitesForSite,
+	getNumberOfInvitesFoundForSite,
+} from 'state/invites/selectors';
 
 class PeopleInvites extends React.PureComponent {
 	static propTypes = {
@@ -64,7 +69,7 @@ class PeopleInvites extends React.PureComponent {
 	}
 
 	render() {
-		const { invites, requesting, site, translate } = this.props;
+		const { invites, invitesFound, requesting, site, translate } = this.props;
 
 		if ( ! site || ! site.ID ) {
 			return null;
@@ -94,6 +99,7 @@ class PeopleInvites extends React.PureComponent {
 					{ showPlaceholder && this.renderPlaceholder() }
 					{ showEmptyContent && this.renderEmptyContent() }
 					{ hasInvites && <Card>{ invites.map( this.renderInvite ) }</Card> }
+					{ hasInvites && <InvitesListEnd found={ invitesFound } /> }
 				</div>
 			</Main>
 		);
@@ -106,5 +112,6 @@ export default connect( ( state, ownProps ) => {
 	return {
 		requesting: isRequestingInvitesForSite( state, siteId ),
 		invites: getInvitesForSite( state, siteId ),
+		invitesFound: getNumberOfInvitesFoundForSite( state, siteId ),
 	};
 } )( localize( PeopleInvites ) );

--- a/client/my-sites/people/people-invites/invites-list-end.jsx
+++ b/client/my-sites/people/people-invites/invites-list-end.jsx
@@ -13,13 +13,18 @@ import { connect } from 'react-redux';
 import ListEnd from 'components/list-end';
 import { bumpStat } from 'state/analytics/actions';
 
+/**
+ * Constants
+ */
+const MAX_INVITES_DISPLAYED = 100;
+
 class InvitesListEnd extends React.PureComponent {
 	static propTypes = {
 		found: PropTypes.number,
 	};
 
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.found !== this.props.found && nextProps.found > 100 ) {
+		if ( nextProps.found !== this.props.found && nextProps.found > MAX_INVITES_DISPLAYED ) {
 			this.props.bumpStat( 'calypso_people_invite_list', 'displayed_max' );
 		}
 	}

--- a/client/my-sites/people/people-invites/invites-list-end.jsx
+++ b/client/my-sites/people/people-invites/invites-list-end.jsx
@@ -1,0 +1,32 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import ListEnd from 'components/list-end';
+import { bumpStat } from 'state/analytics/actions';
+
+class InvitesListEnd extends React.PureComponent {
+	static propTypes = {
+		found: PropTypes.number,
+	};
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.found !== this.props.found && nextProps.found > 100 ) {
+			this.props.bumpStat( 'calypso_people_invite_list', 'displayed_max' );
+		}
+	}
+
+	render() {
+		return <ListEnd />;
+	}
+}
+
+export default connect( null, { bumpStat } )( InvitesListEnd );

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -73,6 +73,26 @@ export const items = createReducer(
 );
 
 /**
+ * Tracks the total number of invites the API says a given siteId has.
+ * This count can be greater than the number of invites queried.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export const counts = createReducer(
+	{},
+	{
+		[ INVITES_REQUEST_SUCCESS ]: ( state, action ) => {
+			return {
+				...state,
+				[ action.siteId ]: action.found,
+			};
+		},
+	}
+);
+
+/**
  * Returns the updated site invites resend requests state after an action has been
  * dispatched. The state reflects an object keyed by site ID, consisting of requested
  * resend invite IDs, with a boolean representing request status.
@@ -97,4 +117,4 @@ export function requestingResend( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( { requesting, items, requestingResend } );
+export default combineReducers( { requesting, items, counts, requestingResend } );

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -34,6 +34,17 @@ export function getInvitesForSite( state, siteId ) {
 }
 
 /**
+ * Returns the total number of invites found for the given site, or `null`.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?Number}        The number of invites found for the given site
+ */
+export function getNumberOfInvitesFoundForSite( state, siteId ) {
+	return state.invites.counts[ siteId ] || null;
+}
+
+/**
  * Returns true if currently requesting an invite resend for the given site and
  * invite ID, or false otherwise.
  *

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -9,7 +9,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { requesting, items, requestingResend } from '../reducer';
+import { requesting, items, counts, requestingResend } from '../reducer';
 import {
 	INVITES_REQUEST,
 	INVITES_REQUEST_SUCCESS,
@@ -247,6 +247,35 @@ describe( 'reducer', () => {
 				const state = items( original, { type: DESERIALIZE } );
 
 				expect( state ).to.eql( {} );
+			} );
+		} );
+	} );
+
+	describe( '#counts()', () => {
+		test( 'should key requests by site ID', () => {
+			const state = counts(
+				{},
+				{
+					type: INVITES_REQUEST_SUCCESS,
+					siteId: 12345,
+					found: 678,
+				}
+			);
+			expect( state ).to.eql( {
+				12345: 678,
+			} );
+		} );
+
+		test( 'should accumulate sites', () => {
+			const original = deepFreeze( { 12345: 678 } );
+			const state = counts( original, {
+				type: INVITES_REQUEST_SUCCESS,
+				siteId: 67890,
+				found: 12,
+			} );
+			expect( state ).to.eql( {
+				12345: 678,
+				67890: 12,
 			} );
 		} );
 	} );

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -7,7 +7,12 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { isRequestingInvitesForSite, getInvitesForSite, isRequestingResend } from '../selectors';
+import {
+	isRequestingInvitesForSite,
+	getInvitesForSite,
+	isRequestingResend,
+	getNumberOfInvitesFoundForSite,
+} from '../selectors';
 
 describe( 'selectors', () => {
 	describe( '#isRequestingInvitesForSite()', () => {
@@ -112,6 +117,28 @@ describe( 'selectors', () => {
 				},
 			};
 			expect( isRequestingResend( state, 12345, '9876asdf54321' ) ).to.equal( false );
+		} );
+	} );
+
+	describe( '#getNumberOfInvitesFoundForSite()', () => {
+		test( 'should return null when count is unknown', () => {
+			const state = {
+				invites: {
+					counts: {},
+				},
+			};
+			expect( getNumberOfInvitesFoundForSite( state, 12345 ) ).to.equal( null );
+		} );
+
+		test( 'should return the number found when count is known', () => {
+			const state = {
+				invites: {
+					counts: {
+						12345: 678,
+					},
+				},
+			};
+			expect( getNumberOfInvitesFoundForSite( state, 12345 ) ).to.equal( 678 );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds the ListEnd component to the end of the Invites list. It also bumps a stat when the maximum number of invites has been displayed.

![image](https://user-images.githubusercontent.com/363749/35460928-4eb55ce4-02ab-11e8-9fa0-d924ca9a15ec.png)

![image](https://user-images.githubusercontent.com/363749/35460979-75c89c06-02ab-11e8-9db4-8fda083fc0ac.png)

To test:
* Visit invites in the people section. Make sure that regardless of the number of invites shown (non-zero) that the `ListEnd` component is shown
* In your console, set debugging to show analytics: `localStorage.setItem('debug','calypso:analytics:mc')`
* Visit the invite list for a site with more than 100 invites. Verified that the console shows a stat being bumped.
* Verify that new tests pass: `npm run test-client client/state/invites/`