### PR TITLE
Fix: Rewind `rewindState.rewind.rewindId` name and type

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -31,7 +31,7 @@ const transformDownload = data =>
 const transformRewind = data =>
 	Object.assign(
 		{
-			restoreId: data.restore_id,
+			rewindId: data.rewind_id,
 			startedAt: new Date( data.started_at ),
 			status: data.status,
 		},

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -29,7 +29,7 @@ export const download = {
 export const rewind = {
 	type: 'object',
 	properties: {
-		rewind_id: { type: 'integer' },
+		rewind_id: { type: 'string' },
 		status: { type: 'string', enum: [ 'failed', 'finished', 'running' ] },
 		started_at: { type: 'string' },
 		progress: { type: 'integer' },


### PR DESCRIPTION
Previously this was created in conflict with the name and type being
used elsewhere and so this patch brings Calypso into harmony and
consistency with existing usage.

**Testing**

This property isn't currently used so it shouldn't cause any behavioral
changes yet. A simple smoke-test when updating `/rewind` should do.