### PR TITLE
Credit card: Updating credit card used to make purchase causes JS errors

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { noop, camelCase, forOwn, kebabCase, mapKeys, values } from 'lodash';
+import { camelCase, forOwn, kebabCase, mapKeys, values } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -41,7 +41,7 @@ class CreditCardForm extends Component {
 	static defaultProps = {
 		apiParams: {},
 		initialValues: {},
-		saveStoredCard: noop,
+		saveStoredCard: null,
 		showUsedForExistingPurchasesInfo: false,
 	};
 


### PR DESCRIPTION
pNPgK-3l4-p2 reported an error when a user attempted to update his/her credit card details.

The cause was the check for `saveStoredCard`, which, as `noop` , was always truthy (introduced in #21521)



