### PR TITLE
Store Orders: Convert notes actions to use data-layer

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -64,7 +64,7 @@ class Order extends Component {
 
 		if ( this.props.isEditing && ! newProps.isEditing ) {
 			// Leaving edit state should re-fetch notes
-			this.props.fetchNotes( newSiteId, newOrderId, true );
+			this.props.fetchNotes( newSiteId, newOrderId );
 		}
 	}
 

--- a/client/extensions/woocommerce/state/data-layer/index.js
+++ b/client/extensions/woocommerce/state/data-layer/index.js
@@ -10,6 +10,7 @@ import actionList from './action-list';
 import coupons from '../sites/coupons/handlers';
 import customers from './customers';
 import orderNotes from './orders/notes';
+import orderRefunds from './orders/refunds';
 import orders from './orders';
 import paymentMethods from './payment-methods';
 import products from './products';
@@ -34,6 +35,7 @@ const handlers = mergeHandlers(
 	coupons,
 	customers,
 	orderNotes,
+	orderRefunds,
 	orders,
 	paymentMethods,
 	productCategories,

--- a/client/extensions/woocommerce/state/data-layer/index.js
+++ b/client/extensions/woocommerce/state/data-layer/index.js
@@ -9,6 +9,7 @@ import { addHandlers } from 'state/data-layer/extensions-middleware';
 import actionList from './action-list';
 import coupons from '../sites/coupons/handlers';
 import customers from './customers';
+import orderNotes from './orders/notes';
 import orders from './orders';
 import paymentMethods from './payment-methods';
 import products from './products';
@@ -32,6 +33,7 @@ const handlers = mergeHandlers(
 	actionList,
 	coupons,
 	customers,
+	orderNotes,
 	orders,
 	paymentMethods,
 	productCategories,

--- a/client/extensions/woocommerce/state/data-layer/orders/notes/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/notes/index.js
@@ -3,17 +3,43 @@
  * Internal dependencies
  */
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
-import { fetchNotesFailure, fetchNotesSuccess } from 'woocommerce/state/sites/orders/notes/actions';
+import {
+	createNoteFailure,
+	createNoteSuccess,
+	fetchNotesFailure,
+	fetchNotesSuccess,
+} from 'woocommerce/state/sites/orders/notes/actions';
 import request from 'woocommerce/state/sites/http-request';
 import {
-	// WOOCOMMERCE_ORDER_NOTE_CREATE,
+	WOOCOMMERCE_ORDER_NOTE_CREATE,
 	WOOCOMMERCE_ORDER_NOTES_REQUEST,
 } from 'woocommerce/state/action-types';
 import { verifyResponseHasData } from 'woocommerce/state/data-layer/utils';
 
+export const create = action => {
+	const { siteId, orderId, note } = action;
+	return request( siteId, action ).post( `orders/${ orderId }/notes`, note );
+};
+
 export const fetch = action => {
 	const { siteId, orderId } = action;
 	return request( siteId, action ).get( `orders/${ orderId }/notes` );
+};
+
+const onCreateError = ( action, error ) => dispatch => {
+	const { siteId, orderId } = action;
+	dispatch( createNoteFailure( siteId, orderId, error ) );
+	if ( action.onFailure ) {
+		dispatch( action.onFailure );
+	}
+};
+
+const onCreateSuccess = ( action, { data } ) => dispatch => {
+	const { siteId, orderId } = action;
+	dispatch( createNoteSuccess( siteId, orderId, data ) );
+	if ( action.onSuccess ) {
+		dispatch( action.onSuccess );
+	}
 };
 
 const onError = ( action, error ) => dispatch => {
@@ -41,7 +67,13 @@ export default {
 			fromApi: verifyResponseHasData,
 		} ),
 	],
-	// [ WOOCOMMERCE_ORDER_NOTE_CREATE ] : [
-	//	dispatchRequestEx( { fetch, onSuccess, onError, fromApi: verifyResponseHasData } ),
-	// ]
+	[ WOOCOMMERCE_ORDER_NOTE_CREATE ]: [
+		dispatchRequestEx( {
+			// fetch used in dispatchRequestEx to create the http request
+			fetch: create,
+			onSuccess: onCreateSuccess,
+			onError: onCreateError,
+			fromApi: verifyResponseHasData,
+		} ),
+	],
 };

--- a/client/extensions/woocommerce/state/data-layer/orders/notes/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/notes/index.js
@@ -1,0 +1,47 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import { fetchNotesFailure, fetchNotesSuccess } from 'woocommerce/state/sites/orders/notes/actions';
+import request from 'woocommerce/state/sites/http-request';
+import {
+	// WOOCOMMERCE_ORDER_NOTE_CREATE,
+	WOOCOMMERCE_ORDER_NOTES_REQUEST,
+} from 'woocommerce/state/action-types';
+import { verifyResponseHasData } from 'woocommerce/state/data-layer/utils';
+
+export const fetch = action => {
+	const { siteId, orderId } = action;
+	return request( siteId, action ).get( `orders/${ orderId }/notes` );
+};
+
+const onError = ( action, error ) => dispatch => {
+	const { siteId, orderId } = action;
+	dispatch( fetchNotesFailure( siteId, orderId, error ) );
+	if ( action.onFailure ) {
+		dispatch( action.onFailure );
+	}
+};
+
+const onSuccess = ( action, { data } ) => dispatch => {
+	const { siteId, orderId } = action;
+	dispatch( fetchNotesSuccess( siteId, orderId, data ) );
+	if ( action.onSuccess ) {
+		dispatch( action.onSuccess );
+	}
+};
+
+export default {
+	[ WOOCOMMERCE_ORDER_NOTES_REQUEST ]: [
+		dispatchRequestEx( {
+			fetch,
+			onSuccess,
+			onError,
+			fromApi: verifyResponseHasData,
+		} ),
+	],
+	// [ WOOCOMMERCE_ORDER_NOTE_CREATE ] : [
+	//	dispatchRequestEx( { fetch, onSuccess, onError, fromApi: verifyResponseHasData } ),
+	// ]
+};

--- a/client/extensions/woocommerce/state/data-layer/orders/notes/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/notes/test/index.js
@@ -1,0 +1,37 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
+import { fetch } from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
+
+describe( 'handlers', () => {
+	describe( '#fetch', () => {
+		test( 'should dispatch a get action to the API via the jetpack proxy for this siteId & orderId', () => {
+			const action = fetchNotes( 123, 74 );
+			const result = fetch( action );
+
+			expect( result ).to.eql(
+				http(
+					{
+						method: 'GET',
+						path: '/jetpack-blogs/123/rest-api/',
+						apiVersion: '1.1',
+						body: null,
+						query: {
+							json: true,
+							path: '/wc/v3/orders/74/notes&_method=GET',
+						},
+					},
+					action
+				)
+			);
+		} );
+	} );
+} );

--- a/client/extensions/woocommerce/state/data-layer/orders/notes/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/notes/test/index.js
@@ -7,8 +7,8 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
-import { fetch } from '../';
+import { createNote, fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
+import { create, fetch } from '../';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
 describe( 'handlers', () => {
@@ -27,6 +27,35 @@ describe( 'handlers', () => {
 						query: {
 							json: true,
 							path: '/wc/v3/orders/74/notes&_method=GET',
+						},
+					},
+					action
+				)
+			);
+		} );
+	} );
+
+	describe( '#create', () => {
+		test( 'should dispatch a post action to the API via the jetpack proxy for this siteId & orderId', () => {
+			const note = {
+				note: 'Testing',
+			};
+			const action = createNote( 123, 74, note );
+			const result = create( action );
+
+			expect( result ).to.eql(
+				http(
+					{
+						method: 'POST',
+						path: '/jetpack-blogs/123/rest-api/',
+						apiVersion: '1.1',
+						body: {
+							json: true,
+							path: '/wc/v3/orders/74/notes&_method=POST',
+							body: JSON.stringify( note ),
+						},
+						query: {
+							json: true,
 						},
 					},
 					action

--- a/client/extensions/woocommerce/state/data-layer/orders/refunds/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/refunds/index.js
@@ -1,0 +1,50 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import {
+	createRefundFailure,
+	createRefundSuccess,
+} from 'woocommerce/state/sites/orders/refunds/actions';
+import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
+import { fetchOrder } from 'woocommerce/state/sites/orders/actions';
+import request from 'woocommerce/state/sites/http-request';
+import { WOOCOMMERCE_ORDER_REFUND_CREATE } from 'woocommerce/state/action-types';
+import { verifyResponseHasData } from 'woocommerce/state/data-layer/utils';
+
+export const create = action => {
+	const { siteId, orderId, refund } = action;
+	return request( siteId, action ).post( `orders/${ orderId }/refunds`, refund );
+};
+
+const onCreateError = ( action, error ) => dispatch => {
+	const { siteId, orderId } = action;
+	dispatch( createRefundFailure( siteId, orderId, error ) );
+	if ( action.onFailure ) {
+		dispatch( action.onFailure );
+	}
+};
+
+const onCreateSuccess = ( action, { data } ) => dispatch => {
+	const { siteId, orderId } = action;
+	dispatch( createRefundSuccess( siteId, orderId, data ) );
+	// Success! Re-fetch order & notes
+	dispatch( fetchOrder( siteId, orderId ) );
+	dispatch( fetchNotes( siteId, orderId ) );
+	if ( action.onSuccess ) {
+		dispatch( action.onSuccess );
+	}
+};
+
+export default {
+	[ WOOCOMMERCE_ORDER_REFUND_CREATE ]: [
+		dispatchRequestEx( {
+			// fetch used in dispatchRequestEx to create the http request
+			fetch: create,
+			onSuccess: onCreateSuccess,
+			onError: onCreateError,
+			fromApi: verifyResponseHasData,
+		} ),
+	],
+};

--- a/client/extensions/woocommerce/state/data-layer/orders/refunds/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/refunds/test/index.js
@@ -1,0 +1,45 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { sendRefund } from 'woocommerce/state/sites/orders/refunds/actions';
+import { create } from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
+
+describe( 'handlers', () => {
+	describe( '#create', () => {
+		test( 'should dispatch a post action to the API via the jetpack proxy for this siteId & orderId', () => {
+			const refund = {
+				amount: 10,
+				reason: 'Testing',
+				api_refund: false,
+			};
+			const action = sendRefund( 123, 74, refund );
+			const result = create( action );
+
+			expect( result ).to.eql(
+				http(
+					{
+						method: 'POST',
+						path: '/jetpack-blogs/123/rest-api/',
+						apiVersion: '1.1',
+						body: {
+							json: true,
+							path: '/wc/v3/orders/74/refunds&_method=POST',
+							body: JSON.stringify( refund ),
+						},
+						query: {
+							json: true,
+						},
+					},
+					action
+				)
+			);
+		} );
+	} );
+} );

--- a/client/extensions/woocommerce/state/data-layer/orders/send-invoice/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/send-invoice/index.js
@@ -10,19 +10,12 @@ import {
 } from 'woocommerce/state/sites/orders/send-invoice/actions';
 import request from 'woocommerce/state/sites/http-request';
 import { WOOCOMMERCE_ORDER_INVOICE_SEND } from 'woocommerce/state/action-types';
+import { verifyResponseHasData } from 'woocommerce/state/data-layer/utils';
 
 export const fetch = action => {
 	const { siteId, orderId } = action;
 	return request( siteId, action ).post( `orders/${ orderId }/send_invoice` );
 };
-
-export function fromApi( response ) {
-	// Check if the request failed at the remote site.
-	if ( ! response.data ) {
-		throw new Error( 'Unable to send invoice', response );
-	}
-	return response;
-}
 
 export const onError = ( action, error ) => dispatch => {
 	const { siteId, orderId } = action;
@@ -43,6 +36,6 @@ export const onSuccess = ( action, { data } ) => dispatch => {
 
 export default {
 	[ WOOCOMMERCE_ORDER_INVOICE_SEND ]: [
-		dispatchRequestEx( { fetch, onSuccess, onError, fromApi } ),
+		dispatchRequestEx( { fetch, onSuccess, onError, fromApi: verifyResponseHasData } ),
 	],
 };

--- a/client/extensions/woocommerce/state/data-layer/utils.js
+++ b/client/extensions/woocommerce/state/data-layer/utils.js
@@ -1,0 +1,15 @@
+/**
+ * Verify that this response has data (is not an error).
+ *
+ * If the response object has a data property, it has data from
+ * the site. Otherwise it has an error message from the remote site.
+ *
+ * @param  {Object} response Response from an API call
+ * @return {Object}          Verified response
+ */
+export function verifyResponseHasData( response ) {
+	if ( ! response.data ) {
+		throw new Error( 'Failure at remote site.', response );
+	}
+	return response;
+}

--- a/client/extensions/woocommerce/state/sites/orders/notes/README.md
+++ b/client/extensions/woocommerce/state/sites/orders/notes/README.md
@@ -5,13 +5,21 @@ This module is used to manage order notes on a site.
 
 ## Actions
 
-### `fetchNotes( siteId: number, orderId: number )`
+### `fetchNotes( siteId: number, orderId: number, onSuccess: object, onFailure: object )`
 
 Fetch notes from the remote site. Does not run if this order's notes are loading or already loaded.
 
-### `createNote( siteId: number, orderId: number, note: object )`
+### `createNote( siteId: number, orderId: number, note: object, onSuccess: object, onFailure: object )`
 
 Create a note for an order on the remote site.
+
+### `onSuccess`, `onFailure`
+
+These parameters should be actions dispatched in the case of success or failure. For example,
+
+```js
+	onSuccess: successNotice( translate( 'Note created for order.' ) ),
+```
 
 ## Reducer
 

--- a/client/extensions/woocommerce/state/sites/orders/notes/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/notes/actions.js
@@ -3,8 +3,6 @@
 /**
  * Internal dependencies
  */
-
-import { areOrderNotesLoaded, areOrderNotesLoading } from './selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import request from 'woocommerce/state/sites/request';
 import {
@@ -16,43 +14,32 @@ import {
 	WOOCOMMERCE_ORDER_NOTES_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
 
-export const fetchNotes = ( siteId, orderId, refresh = false ) => ( dispatch, getState ) => {
-	const state = getState();
-	if ( ! siteId ) {
-		siteId = getSelectedSiteId( state );
-	}
-	if ( areOrderNotesLoading( state, orderId, siteId ) ) {
-		return;
-	}
-	// Bail if the order notes are loaded, and we don't want to force a refresh
-	if ( ! refresh && areOrderNotesLoaded( state, orderId, siteId ) ) {
-		return;
-	}
-
-	dispatch( {
+export const fetchNotes = ( siteId, orderId, onSuccess = false, onFailure = false ) => {
+	return {
 		type: WOOCOMMERCE_ORDER_NOTES_REQUEST,
 		siteId,
 		orderId,
-	} );
+		onSuccess,
+		onFailure,
+	};
+};
 
-	return request( siteId )
-		.get( `orders/${ orderId }/notes` )
-		.then( data => {
-			dispatch( {
-				type: WOOCOMMERCE_ORDER_NOTES_REQUEST_SUCCESS,
-				siteId,
-				orderId,
-				notes: data,
-			} );
-		} )
-		.catch( error => {
-			dispatch( {
-				type: WOOCOMMERCE_ORDER_NOTES_REQUEST_FAILURE,
-				siteId,
-				orderId,
-				error,
-			} );
-		} );
+export const fetchNotesFailure = ( siteId, orderId, error = {} ) => {
+	return {
+		type: WOOCOMMERCE_ORDER_NOTES_REQUEST_FAILURE,
+		siteId,
+		orderId,
+		error,
+	};
+};
+
+export const fetchNotesSuccess = ( siteId, orderId, notes ) => {
+	return {
+		type: WOOCOMMERCE_ORDER_NOTES_REQUEST_SUCCESS,
+		siteId,
+		orderId,
+		notes,
+	};
 };
 
 export const createNoteSuccess = ( siteId, orderId, note ) => {

--- a/client/extensions/woocommerce/state/sites/orders/notes/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/notes/actions.js
@@ -3,8 +3,6 @@
 /**
  * Internal dependencies
  */
-import { getSelectedSiteId } from 'state/ui/selectors';
-import request from 'woocommerce/state/sites/request';
 import {
 	WOOCOMMERCE_ORDER_NOTE_CREATE,
 	WOOCOMMERCE_ORDER_NOTE_CREATE_SUCCESS,
@@ -13,6 +11,35 @@ import {
 	WOOCOMMERCE_ORDER_NOTES_REQUEST_FAILURE,
 	WOOCOMMERCE_ORDER_NOTES_REQUEST_SUCCESS,
 } from 'woocommerce/state/action-types';
+
+export const createNote = ( siteId, orderId, note, onSuccess = false, onFailure = false ) => {
+	return {
+		type: WOOCOMMERCE_ORDER_NOTE_CREATE,
+		siteId,
+		orderId,
+		note,
+		onSuccess,
+		onFailure,
+	};
+};
+
+export const createNoteFailure = ( siteId, orderId, error = {} ) => {
+	return {
+		type: WOOCOMMERCE_ORDER_NOTE_CREATE_FAILURE,
+		siteId,
+		orderId,
+		error,
+	};
+};
+
+export const createNoteSuccess = ( siteId, orderId, note ) => {
+	return {
+		type: WOOCOMMERCE_ORDER_NOTE_CREATE_SUCCESS,
+		siteId,
+		orderId,
+		note,
+	};
+};
 
 export const fetchNotes = ( siteId, orderId, onSuccess = false, onFailure = false ) => {
 	return {
@@ -40,42 +67,4 @@ export const fetchNotesSuccess = ( siteId, orderId, notes ) => {
 		orderId,
 		notes,
 	};
-};
-
-export const createNoteSuccess = ( siteId, orderId, note ) => {
-	return {
-		type: WOOCOMMERCE_ORDER_NOTE_CREATE_SUCCESS,
-		siteId,
-		orderId,
-		note,
-	};
-};
-
-export const createNote = ( siteId, orderId, note ) => ( dispatch, getState ) => {
-	const state = getState();
-	if ( ! siteId ) {
-		siteId = getSelectedSiteId( state );
-	}
-
-	dispatch( {
-		type: WOOCOMMERCE_ORDER_NOTE_CREATE,
-		siteId,
-		orderId,
-	} );
-
-	return request( siteId )
-		.post( `orders/${ orderId }/notes`, note )
-		.then( data => {
-			// If note is customer note, maybe add a notice
-			// dispatch( successNotice( translate( 'Notified customer.' ), { duration: 5000 } ) );
-			dispatch( createNoteSuccess( siteId, orderId, data ) );
-		} )
-		.catch( error => {
-			dispatch( {
-				type: WOOCOMMERCE_ORDER_NOTE_CREATE_FAILURE,
-				siteId,
-				orderId,
-				error,
-			} );
-		} );
 };

--- a/client/extensions/woocommerce/state/sites/orders/notes/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/orders/notes/test/actions.js
@@ -4,13 +4,18 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { spy } from 'sinon';
 
 /**
  * Internal dependencies
  */
-import { fetchNotes, fetchNotesSuccess, fetchNotesFailure, createNote } from '../actions';
-import useNock from 'test/helpers/use-nock';
+import {
+	createNote,
+	createNoteSuccess,
+	createNoteFailure,
+	fetchNotes,
+	fetchNotesSuccess,
+	fetchNotesFailure,
+} from '../actions';
 import {
 	WOOCOMMERCE_ORDER_NOTE_CREATE,
 	WOOCOMMERCE_ORDER_NOTE_CREATE_FAILURE,
@@ -37,7 +42,7 @@ describe( 'actions', () => {
 	} );
 
 	describe( '#fetchNotesSuccess', () => {
-		test( 'should return a success action with the customer list when request completes', () => {
+		test( 'should return a success action with the notes when request completes', () => {
 			const notes = [
 				{
 					id: 16,
@@ -70,66 +75,52 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( '#createNote()', () => {
-		const siteId = '123';
-		const orderId = 45;
+	describe( 'create', () => {
 		const note = {
-			note: 'A note to the customer.',
+			note: 'Testing customer note',
 			customer_note: true,
 		};
 
-		useNock( nock => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.post( `/rest/v1.1/jetpack-blogs/${ siteId }/rest-api/` )
-				.query( { path: '/wc/v3/orders/45/notes&_method=post', body: note, json: true } )
-				.reply( 201, { data: note } )
-				.post( '/rest/v1.1/jetpack-blogs/234/rest-api/' )
-				.query( { path: '/wc/v3/orders/0/notes&_method=post', body: note, json: true } )
-				.reply( 400, {
-					data: {
-						error: 'rest_missing_callback_param',
-						message: 'Missing parameter(s): note',
-					},
+		describe( '#createNote()', () => {
+			test( 'should return an action', () => {
+				const onSuccess = { type: WOOCOMMERCE_ORDER_NOTE_CREATE_SUCCESS };
+				const onFailure = { type: WOOCOMMERCE_ORDER_NOTE_CREATE_FAILURE };
+				const action = createNote( 123, 38, note, onSuccess, onFailure );
+				expect( action ).to.eql( {
+					type: WOOCOMMERCE_ORDER_NOTE_CREATE,
+					siteId: 123,
+					orderId: 38,
+					note,
+					onSuccess,
+					onFailure,
 				} );
-		} );
-
-		test( 'should dispatch an action', () => {
-			const getState = () => ( {} );
-			const dispatch = spy();
-			createNote( siteId, orderId, note )( dispatch, getState );
-			expect( dispatch ).to.have.been.calledWith( {
-				type: WOOCOMMERCE_ORDER_NOTE_CREATE,
-				siteId,
-				orderId,
 			} );
 		} );
 
-		test( 'should dispatch a success action with the notes list when request completes', () => {
-			const getState = () => ( {} );
-			const dispatch = spy();
-			const response = createNote( siteId, orderId, note )( dispatch, getState );
-
-			return response.then( () => {
-				expect( dispatch ).to.have.been.calledWith( {
+		describe( '#createNoteSuccess', () => {
+			test( 'should return a success action with the note when request completes', () => {
+				const action = createNoteSuccess( 123, 38, note );
+				expect( action ).to.eql( {
 					type: WOOCOMMERCE_ORDER_NOTE_CREATE_SUCCESS,
-					siteId,
-					orderId,
+					siteId: 123,
+					orderId: 38,
 					note,
 				} );
 			} );
 		} );
 
-		test( 'should dispatch a failure action with the error when a the request fails', () => {
-			const getState = () => ( {} );
-			const dispatch = spy();
-			const response = createNote( 234, 0, {} )( dispatch, getState );
-
-			return response.then( () => {
-				expect( dispatch ).to.have.been.calledWithMatch( {
+		describe( '#createNoteFailure', () => {
+			test( 'should return a failure action with the error when a the request fails', () => {
+				const error = new Error( 'Unable to create note', {
+					error: 'bad_json',
+					message: 'Could not parse JSON request body.',
+				} );
+				const action = createNoteFailure( 234, 21, error );
+				expect( action ).to.eql( {
 					type: WOOCOMMERCE_ORDER_NOTE_CREATE_FAILURE,
 					siteId: 234,
-					orderId: 0,
+					orderId: 21,
+					error,
 				} );
 			} );
 		} );

--- a/client/extensions/woocommerce/state/sites/orders/refunds/README.md
+++ b/client/extensions/woocommerce/state/sites/orders/refunds/README.md
@@ -5,9 +5,9 @@ This module is used to manage refunds for orders on a site.
 
 ## Actions
 
-### `sendRefund( siteId: number, orderId: number, refund: object )`
+### `sendRefund( siteId: number, orderId: number, refund: object, onSuccess: object, onFailure: object )`
 
-Create a refund for the given order. Refund should have `amount` & an optional `reason`, both strings. Does not run if there's already a refund request for this order.
+Create a refund for the given order. Refund should have `amount` & an optional `reason`, both strings. Does not run if there's already a refund request for this order. `onSuccess` & `onFailure` are optional; if not set, they default to triggering a success or error notice.
 
 ## Reducer
 


### PR DESCRIPTION
This PR is some cleanup for orders actions. This moves the API request functionality to use the data layer, for fetching the note list on an order, and for creating a new note on an order.

I've also added a new `utils` file, since I've been using the same API response verification in each handler: `verifyResponseHasData` can be used as an API "transform" in `fromApi`, since error responses on the remote site (in the "envelope" of the wpcom API response) are considered successful. This function throws an error if the response does not have a data property - errors don't have data. This error tells the handler to use the `onError` callback.

**To test**

- Check that notes still work correctly
- View an order, its notes should load in the Activity Log section
- Add a note, it should save to the remote site & show up in the activity log.