### PR TITLE
Store Orders: Convert refunds actions to use data-layer

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/index.js
+++ b/client/extensions/woocommerce/state/data-layer/index.js
@@ -10,6 +10,7 @@ import actionList from './action-list';
 import coupons from '../sites/coupons/handlers';
 import customers from './customers';
 import orderNotes from './orders/notes';
+import orderRefunds from './orders/refunds';
 import orders from './orders';
 import paymentMethods from './payment-methods';
 import products from './products';
@@ -34,6 +35,7 @@ const handlers = mergeHandlers(
 	coupons,
 	customers,
 	orderNotes,
+	orderRefunds,
 	orders,
 	paymentMethods,
 	productCategories,

--- a/client/extensions/woocommerce/state/data-layer/orders/refunds/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/refunds/index.js
@@ -7,6 +7,7 @@ import {
 	createRefundFailure,
 	createRefundSuccess,
 } from 'woocommerce/state/sites/orders/refunds/actions';
+import { fetchNotes } from 'woocommerce/state/sites/orders/notes/actions';
 import { fetchOrder } from 'woocommerce/state/sites/orders/actions';
 import request from 'woocommerce/state/sites/http-request';
 import { WOOCOMMERCE_ORDER_REFUND_CREATE } from 'woocommerce/state/action-types';
@@ -28,7 +29,9 @@ const onCreateError = ( action, error ) => dispatch => {
 const onCreateSuccess = ( action, { data } ) => dispatch => {
 	const { siteId, orderId } = action;
 	dispatch( createRefundSuccess( siteId, orderId, data ) );
+	// Success! Re-fetch order & notes
 	dispatch( fetchOrder( siteId, orderId ) );
+	dispatch( fetchNotes( siteId, orderId ) );
 	if ( action.onSuccess ) {
 		dispatch( action.onSuccess );
 	}

--- a/client/extensions/woocommerce/state/data-layer/orders/refunds/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/refunds/index.js
@@ -1,0 +1,47 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
+import {
+	createRefundFailure,
+	createRefundSuccess,
+} from 'woocommerce/state/sites/orders/refunds/actions';
+import { fetchOrder } from 'woocommerce/state/sites/orders/actions';
+import request from 'woocommerce/state/sites/http-request';
+import { WOOCOMMERCE_ORDER_REFUND_CREATE } from 'woocommerce/state/action-types';
+import { verifyResponseHasData } from 'woocommerce/state/data-layer/utils';
+
+export const create = action => {
+	const { siteId, orderId, refund } = action;
+	return request( siteId, action ).post( `orders/${ orderId }/refunds`, refund );
+};
+
+const onCreateError = ( action, error ) => dispatch => {
+	const { siteId, orderId } = action;
+	dispatch( createRefundFailure( siteId, orderId, error ) );
+	if ( action.onFailure ) {
+		dispatch( action.onFailure );
+	}
+};
+
+const onCreateSuccess = ( action, { data } ) => dispatch => {
+	const { siteId, orderId } = action;
+	dispatch( createRefundSuccess( siteId, orderId, data ) );
+	dispatch( fetchOrder( siteId, orderId ) );
+	if ( action.onSuccess ) {
+		dispatch( action.onSuccess );
+	}
+};
+
+export default {
+	[ WOOCOMMERCE_ORDER_REFUND_CREATE ]: [
+		dispatchRequestEx( {
+			// fetch used in dispatchRequestEx to create the http request
+			fetch: create,
+			onSuccess: onCreateSuccess,
+			onError: onCreateError,
+			fromApi: verifyResponseHasData,
+		} ),
+	],
+};

--- a/client/extensions/woocommerce/state/data-layer/orders/refunds/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/orders/refunds/test/index.js
@@ -1,0 +1,45 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { sendRefund } from 'woocommerce/state/sites/orders/refunds/actions';
+import { create } from '../';
+import { http } from 'state/data-layer/wpcom-http/actions';
+
+describe( 'handlers', () => {
+	describe( '#create', () => {
+		test( 'should dispatch a post action to the API via the jetpack proxy for this siteId & orderId', () => {
+			const refund = {
+				amount: 10,
+				reason: 'Testing',
+				api_refund: false,
+			};
+			const action = sendRefund( 123, 74, refund );
+			const result = create( action );
+
+			expect( result ).to.eql(
+				http(
+					{
+						method: 'POST',
+						path: '/jetpack-blogs/123/rest-api/',
+						apiVersion: '1.1',
+						body: {
+							json: true,
+							path: '/wc/v3/orders/74/refunds&_method=POST',
+							body: JSON.stringify( refund ),
+						},
+						query: {
+							json: true,
+						},
+					},
+					action
+				)
+			);
+		} );
+	} );
+} );

--- a/client/extensions/woocommerce/state/sites/orders/refunds/README.md
+++ b/client/extensions/woocommerce/state/sites/orders/refunds/README.md
@@ -5,9 +5,9 @@ This module is used to manage refunds for orders on a site.
 
 ## Actions
 
-### `sendRefund( siteId: number, orderId: number, refund: object )`
+### `sendRefund( siteId: number, orderId: number, refund: object, onSuccess: object, onFailure: object )`
 
-Create a refund for the given order. Refund should have `amount` & an optional `reason`, both strings. Does not run if there's already a refund request for this order.
+Create a refund for the given order. Refund should have `amount` & an optional `reason`, both strings. Does not run if there's already a refund request for this order. `onSuccess` & `onFailure` are optional; if not set, they default to triggering a success or error notice.
 
 ## Reducer
 


### PR DESCRIPTION
This builds on #21887. This creates data-layer handlers for the `sendRefund` action.

**To test**

- Check that refunds are working as expected
- View an order with a manual payment (check, etc)
- Grant a refund
- You should see the order update, with the refund applied
- View an order with an API payment (stripe, etc)
- Grant a refund
- You should see the order update, with the refund applied
- You should _also_ see a note in the Activity Log that the refund was applied (this is only true for API refunds)
- Check that both orders are refunded on the remote site