### PR TITLE
Activity Log: Fix gravatar showing up correctly

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -46,7 +46,7 @@ class ActivityLogItem extends Component {
 		const {
 			activityDescription,
 			activityTitle,
-			actorActivityUrl,
+			actorAvatarUrl,
 			actorName,
 			actorRole,
 			actorType,
@@ -54,7 +54,7 @@ class ActivityLogItem extends Component {
 
 		return (
 			<div className="activity-log-item__card-header">
-				<ActivityActor { ...{ actorActivityUrl, actorName, actorRole, actorType } } />
+				<ActivityActor { ...{ actorAvatarUrl, actorName, actorRole, actorType } } />
 				<div className="activity-log-item__description">
 					<div className="activity-log-item__description-content">
 						{ /* There is no great way to generate a more valid React key here


### PR DESCRIPTION
Fixes missing gravatar . cc @beaulebens 

Before:
![screen_shot_2018-01-26_at_2_09_15_pm](https://user-images.githubusercontent.com/115071/35462841-a452ef9e-02a2-11e8-9675-d23b61d85c6f.png)

After:

![aaaaa_test_site_hello_ _wordpress_com](https://user-images.githubusercontent.com/115071/35462886-e05bc8c6-02a2-11e8-8545-b100b55fbc4b.png)

