### PR TITLE
Fix: Rewind schema update typo

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -35,7 +35,7 @@ export const rewind = {
 		progress: { type: 'integer' },
 		reason: { type: 'string' },
 	},
-	required: [ 'restore_id', 'status' ],
+	required: [ 'rewind_id', 'status' ],
 };
 
 export const unavailable = {


### PR DESCRIPTION
In #21885 I updated the schema for Rewind API responses
but unfortunately forgot to update the `required` section
so the response was failing the parse.

In this patch I updated that to resolve the problem.