### PR TITLE
State: do not add sites to state if we cannot manage them

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -231,10 +231,7 @@ function onSelectedSiteAvailable( context ) {
 			//also filter recent sites if not available locally
 			const updatedRecentSites = uniq( [ selectedSite.ID, ...recentSites ] )
 				.slice( 0, 5 )
-				.filter( recentId => {
-					const site = getSite( state, recentId );
-					return !! site;
-				} );
+				.filter( recentId => !! getSite( state, recentId ) );
 			context.store.dispatch( savePreference( 'recentSites', updatedRecentSites ) );
 		}
 	}

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -205,11 +205,6 @@ function onSelectedSiteAvailable( context ) {
 	const state = getState();
 	const selectedSite = getSelectedSite( state );
 
-	//temporary check when SU'ing
-	if ( ! selectedSite.capabilities ) {
-		return false;
-	}
-
 	// Currently, sites are only made available in Redux state by the receive
 	// here (i.e. only selected sites). If a site is already known in state,
 	// avoid receiving since we risk overriding changes made more recently.
@@ -238,7 +233,7 @@ function onSelectedSiteAvailable( context ) {
 				.slice( 0, 5 )
 				.filter( recentId => {
 					const site = getSite( state, recentId );
-					return site && site.capabilities;
+					return !! site;
 				} );
 			context.store.dispatch( savePreference( 'recentSites', updatedRecentSites ) );
 		}

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -73,7 +73,15 @@ export function items( state = null, action ) {
 		case SITE_RECEIVE:
 		case SITES_RECEIVE:
 			// Normalize incoming site(s) to array
-			const sites = action.site ? [ action.site ] : action.sites;
+			const maybeUnmanageableSites = action.site ? [ action.site ] : action.sites;
+			// filter out anything the current user can't manage
+			const sites = maybeUnmanageableSites.filter( site => {
+				return site && site.capabilities;
+			} );
+
+			if ( sites.length === 0 ) {
+				return state;
+			}
 
 			// SITES_RECEIVE occurs when we receive the entire set of user
 			// sites (replace existing state). Otherwise merge into state.

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -75,9 +75,7 @@ export function items( state = null, action ) {
 			// Normalize incoming site(s) to array
 			const maybeUnmanageableSites = action.site ? [ action.site ] : action.sites;
 			// filter out anything the current user can't manage
-			const sites = maybeUnmanageableSites.filter( site => {
-				return site && site.capabilities;
-			} );
+			const sites = maybeUnmanageableSites.filter( site => site && site.capabilities );
 
 			if ( sites.length === 0 ) {
 				return state;

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -111,37 +111,37 @@ describe( 'reducer', () => {
 			const state = items( undefined, {
 				type: SITES_RECEIVE,
 				sites: [
-					{ ID: 2916284, name: 'WordPress.com Example Blog' },
-					{ ID: 77203074, name: 'Another test site' },
+					{ ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+					{ ID: 77203074, name: 'Another test site', capabilities: {} },
 				],
 			} );
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
-				77203074: { ID: 77203074, name: 'Another test site' },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+				77203074: { ID: 77203074, name: 'Another test site', capabilities: {} },
 			} );
 		} );
 
 		test( 'overwrites sites when all sites are received', () => {
 			const original = deepFreeze( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
-				77203074: { ID: 77203074, name: 'Another test site' },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+				77203074: { ID: 77203074, name: 'Another test site', capabilities: {} },
 			} );
 			const state = items( original, {
 				type: SITES_RECEIVE,
-				sites: [ { ID: 77203074, name: 'A Bowl of Pho' } ],
+				sites: [ { ID: 77203074, name: 'A Bowl of Pho', capabilities: {} } ],
 			} );
 			expect( state ).to.eql( {
-				77203074: { ID: 77203074, name: 'A Bowl of Pho' },
+				77203074: { ID: 77203074, name: 'A Bowl of Pho', capabilities: {} },
 			} );
 		} );
 
 		test( 'should return same state if received site matches existing', () => {
 			const original = deepFreeze( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
 			} );
 			const state = items( original, {
 				type: SITE_RECEIVE,
-				sites: [ { ID: 2916284, name: 'WordPress.com Example Blog' } ],
+				sites: [ { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} } ],
 			} );
 
 			expect( state ).to.equal( original );
@@ -150,26 +150,26 @@ describe( 'reducer', () => {
 		test( 'should index sites by ID', () => {
 			const state = items( undefined, {
 				type: SITE_RECEIVE,
-				site: { ID: 2916284, name: 'WordPress.com Example Blog' },
+				site: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
 			} );
 		} );
 
 		test( 'should accumulate sites', () => {
 			const original = deepFreeze( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
 			} );
 			const state = items( original, {
 				type: SITE_RECEIVE,
-				site: { ID: 77203074, name: 'Just You Wait' },
+				site: { ID: 77203074, name: 'Just You Wait', capabilities: {} },
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
-				77203074: { ID: 77203074, name: 'Just You Wait' },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+				77203074: { ID: 77203074, name: 'Just You Wait', capabilities: {} },
 			} );
 		} );
 
@@ -208,8 +208,8 @@ describe( 'reducer', () => {
 
 		test( 'should return the original state when deleting a site that is not present', () => {
 			const original = deepFreeze( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
-				77203074: { ID: 77203074, name: 'Just You Wait' },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+				77203074: { ID: 77203074, name: 'Just You Wait', capabilities: {} },
 			} );
 
 			const state = items( original, {
@@ -222,15 +222,15 @@ describe( 'reducer', () => {
 
 		test( 'should override previous site of same ID', () => {
 			const original = deepFreeze( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
 			} );
 			const state = items( original, {
 				type: SITE_RECEIVE,
-				site: { ID: 2916284, name: 'Just You Wait' },
+				site: { ID: 2916284, name: 'Just You Wait', capabilities: {} },
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'Just You Wait' },
+				2916284: { ID: 2916284, name: 'Just You Wait', capabilities: {} },
 			} );
 		} );
 
@@ -241,12 +241,13 @@ describe( 'reducer', () => {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
 					slug: 'example.wordpress.com',
+					capabilities: {},
 					updateComputedAttributes() {},
 				},
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
 			} );
 		} );
 
@@ -258,13 +259,14 @@ describe( 'reducer', () => {
 						ID: 2916284,
 						name: 'WordPress.com Example Blog',
 						slug: 'example.wordpress.com',
+						capabilities: {},
 						updateComputedAttributes() {},
 					},
 				],
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
 			} );
 		} );
 
@@ -615,6 +617,30 @@ describe( 'reducer', () => {
 			const state = items( original, { type: DESERIALIZE } );
 
 			expect( state ).to.be.null;
+		} );
+
+		test( 'should not store sites we cannot manage', () => {
+			const state = items( undefined, {
+				type: SITES_RECEIVE,
+				sites: [
+					{ ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+					{ ID: 77203074, name: 'A Site I do not own' },
+				],
+			} );
+			expect( state ).to.eql( {
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+			} );
+		} );
+
+		test( 'ignores all sites if we cannot manage them', () => {
+			const state = items( undefined, {
+				type: SITES_RECEIVE,
+				sites: [
+					{ ID: 2916284, name: 'WordPress.com Example Blog' },
+					{ ID: 77203074, name: 'A Site I do not own' },
+				],
+			} );
+			expect( state ).to.eql( null );
 		} );
 	} );
 


### PR DESCRIPTION
In some situations we may request a site that does not belong to the current user. For example, when we [query for a site given a site fragment](https://github.com/Automattic/wp-calypso/blob/c56872055c3eac4b7b7d8f5900047255e6b47690/client/my-sites/controller.js#L409).

If this happens, let's make sure the reducer throws these values out, since these sites may be added to the sites sidebar. This is confusing since users are not actually able to manage those sites. I've updated the sites reducer to check for the capabilities property, and not update redux state when this is the case.

### Testing Instructions
- No regressions to switching sites, or recent sites
- We still cannot recreate the case in pbg9X-cvt-p2#comment-51123