### PR TITLE
Payments: fix translation by coercing to int as expected by stringify

### DIFF
--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -184,7 +184,7 @@ class PurchaseNotice extends Component {
 						{
 							args: {
 								cardType: creditCard.type.toUpperCase(),
-								cardNumber: creditCard.number,
+								cardNumber: parseInt( creditCard.number, 10 ),
 								cardExpiry: creditCard.expiryMoment.format( 'MMMM YYYY' ),
 							},
 							components: {


### PR DESCRIPTION
This change fixes #21843, an issue showing a busted translation without any string interpolation because we have a type mismatch. I tried to find the history where this first happened, but the history of this file was pretty hard to track as it moved around.

_Technically_ I think the variable should be treated as a string as we're using it as an identifier here, not an actual number. But that would result in a new translation request and effectively nullify the existing translations so in this case it's probably best to just coerce the value to the expected type.

@hewsut I wrote a lot of this dang i18n stuff a while ago, but I'm pretty rusty. Shouldn't there be a louder complaint when the types are mismatched? Is there something we can do to make these types of errors more visible? I suspect this has been around for a long time.

## Testing
Grab the user from the zendesk entry linked from the original issue, login as the user, and navigate to the URL as described in the original issue. The translation should work correctly.