### PR TITLE
Comments: Display Counts

### DIFF
--- a/client/components/count/README.md
+++ b/client/components/count/README.md
@@ -29,6 +29,10 @@ The number to be displayed. Make sure it's a number, not a string containing a n
 
 Boolean. Applies `is-primary` class and related styles.
 
+### `compact`
+
+Boolean. Displays counts with a localized compact variant. For example instead of 1234, we see 1.2K for `en` or 1.2 mil for `es`
+
 ## Custom Styling
 
 In some cases, it may be necessary to increase the font size or remove the border. In your component's style file, specify rules for the `.count` within your component's selector. For an example, see the `select-dropdown` component's style file.

--- a/client/components/count/index.jsx
+++ b/client/components/count/index.jsx
@@ -3,31 +3,39 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { omit } from 'lodash';
 
-export const Count = ( { count, numberFormat, primary, ...inheritProps } ) => (
-	// Omit props passed from the `localize` higher-order component that we don't need.
-	<span
-		className={ classnames( 'count', { 'is-primary': primary } ) }
-		{ ...omit( inheritProps, [ 'translate', 'moment' ] ) }
-	>
-		{ numberFormat( count ) }
-	</span>
-);
+/**
+ * Internal dependencies
+ */
+import formatNumberCompact from 'lib/format-number-compact';
+
+export const Count = ( { count, compact, numberFormat, primary, ...inheritProps } ) => {
+	return (
+		// Omit props passed from the `localize` higher-order component that we don't need.
+		<span
+			className={ classnames( 'count', { 'is-primary': primary } ) }
+			{ ...omit( inheritProps, [ 'translate', 'moment' ] ) }
+		>
+			{ compact ? formatNumberCompact( count ) || numberFormat( count ) : numberFormat( count ) }
+		</span>
+	);
+};
 
 Count.propTypes = {
 	count: PropTypes.number.isRequired,
 	numberFormat: PropTypes.func,
 	primary: PropTypes.bool,
+	compact: PropTypes.bool,
 };
 
 Count.defaultProps = {
 	primary: false,
+	compact: false,
 };
 
 export default localize( Count );

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -27,6 +27,7 @@ class NavItem extends PureComponent {
 		isExternalLink: PropTypes.bool,
 		disabled: PropTypes.bool,
 		count: PropTypes.oneOfType( [ PropTypes.number, PropTypes.bool ] ),
+		compactCount: PropTypes.bool,
 		className: PropTypes.string,
 		preloadSectionName: PropTypes.string,
 	};
@@ -75,7 +76,9 @@ class NavItem extends PureComponent {
 				>
 					<span className={ 'section-nav-' + itemClassPrefix + '__text' }>
 						{ this.props.children }
-						{ 'number' === typeof this.props.count && <Count count={ this.props.count } /> }
+						{ 'number' === typeof this.props.count && (
+							<Count count={ this.props.count } compact={ this.props.compactCount } />
+						) }
 					</span>
 				</a>
 			</li>

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -17,6 +17,7 @@ import Count from 'components/count';
 class SelectDropdownItem extends Component {
 	static propTypes = {
 		children: PropTypes.string.isRequired,
+		compactCount: PropTypes.bool,
 		path: PropTypes.string,
 		isDropdownOpen: PropTypes.bool,
 		selected: PropTypes.bool,
@@ -58,7 +59,7 @@ class SelectDropdownItem extends Component {
 					</span>
 					{ 'number' === typeof this.props.count && (
 						<span data-text={ this.props.count } className="select-dropdown__item-count">
-							<Count count={ this.props.count } />
+							<Count count={ this.props.count } compact={ this.props.compactCount } />
 						</span>
 					) }
 				</a>

--- a/client/lib/format-number-compact/README.md
+++ b/client/lib/format-number-compact/README.md
@@ -1,0 +1,33 @@
+Format Number Compact
+==========
+Given a language code, this library will take in a number and display it in a compact format.
+
+Usage
+==========
+```javascript
+import formatNumberCompact from 'lib/format-number-compact';
+
+const noChange = formatNumberCompact( 999, 'en' ); // '999'
+const shortEn = formatNumberCompact( 1234, 'en' ); // '1.2K'
+const shortEs = formatNumberCompact( 12567, 'es' ); // '12,6 mil'
+```
+
+## Parameters
+
+### `number`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The number to format.
+
+### `code`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The language code to format with.

--- a/client/lib/format-number-compact/index.js
+++ b/client/lib/format-number-compact/index.js
@@ -1,0 +1,46 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import i18n, { numberFormat } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { THOUSANDS } from './thousands';
+
+/**
+ * Formats a number to a short format given a language code
+ * @param   {Number}     number              number to format
+ * @param   {String}     code                language code e.g. 'es'
+ * @returns {?String}                        A formatted string.
+ */
+export default function formatNumberCompact( number, code = i18n.getLocaleSlug() ) {
+	//use numberFormat directly from i18n in this case!
+	if ( isNaN( number ) || ! THOUSANDS[ code ] ) {
+		return null;
+	}
+
+	const { decimal, grouping, symbol, unitValue = 1000 } = THOUSANDS[ code ];
+
+	const sign = number < 0 ? '-' : '';
+	const absNumber = Math.abs( number );
+
+	// no-op if we have a small number
+	if ( absNumber < unitValue ) {
+		return `${ sign }${ absNumber }`;
+	}
+
+	//show 2 sig figs, otherwise take leading sig figs.
+	const decimals = absNumber < unitValue * 10 ? 1 : 0;
+
+	const value = numberFormat( absNumber / unitValue, {
+		decimals,
+		thousandsSep: grouping,
+		decPoint: decimal,
+	} );
+
+	return `${ sign }${ value }${ symbol }`;
+}

--- a/client/lib/format-number-compact/test/index.js
+++ b/client/lib/format-number-compact/test/index.js
@@ -1,0 +1,197 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import formatNumberCompact from 'lib/format-number-compact';
+
+describe( 'formatNumberCompact', () => {
+	test( 'does nothing if number is < 1000', () => {
+		const counts = formatNumberCompact( 999, 'en' );
+		expect( counts ).toEqual( '999' );
+	} );
+	test( 'shows 2 sig figs for counts < 10000', () => {
+		const counts = formatNumberCompact( 1234, 'en' );
+		expect( counts ).toEqual( '1.2K' );
+	} );
+	test( 'shows leading sig figs for counts > 10000', () => {
+		const counts = formatNumberCompact( 123456, 'en' );
+		expect( counts ).toEqual( '123K' );
+	} );
+	test( 'rounds abbreviated counts', () => {
+		const counts = formatNumberCompact( 1897, 'en' );
+		expect( counts ).toEqual( '1.9K' );
+	} );
+	test( 'shows groupings for huge numbers', () => {
+		const counts = formatNumberCompact( 123456789, 'en' );
+		expect( counts ).toEqual( '123,457K' );
+	} );
+	test( 'handles negative numbers', () => {
+		const counts = formatNumberCompact( -123456789, 'en' );
+		expect( counts ).toEqual( '-123,457K' );
+	} );
+	describe( 'es', () => {
+		test( 'shows 2 sig figs for counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'es' );
+			expect( counts ).toEqual( '1,2 mil' );
+		} );
+		test( 'shows leading sig figs for counts > 10000', () => {
+			const counts = formatNumberCompact( 123456, 'es' );
+			expect( counts ).toEqual( '123 mil' );
+		} );
+	} );
+	describe( 'pt-br', () => {
+		test( 'shows 2 sig figs for counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'pt-br' );
+			expect( counts ).toEqual( '1,2 mil' );
+		} );
+		test( 'shows leading sig figs for counts > 10000', () => {
+			const counts = formatNumberCompact( 123456, 'pt-br' );
+			expect( counts ).toEqual( '123 mil' );
+		} );
+	} );
+	describe( 'de', () => {
+		test( 'shows 2 sig figs for counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'de' );
+			expect( counts ).toEqual( '1,2 Tsd.' );
+		} );
+		test( 'shows leading sig figs for counts > 10000', () => {
+			const counts = formatNumberCompact( 123456, 'de' );
+			expect( counts ).toEqual( '123 Tsd.' );
+		} );
+	} );
+	describe( 'fr', () => {
+		test( 'shows 2 sig figs for counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'fr' );
+			expect( counts ).toEqual( '1,2 k' );
+		} );
+		test( 'shows leading sig figs for counts > 10000', () => {
+			const counts = formatNumberCompact( 123456, 'fr' );
+			expect( counts ).toEqual( '123 k' );
+		} );
+	} );
+	describe( 'he', () => {
+		test( 'shows 2 sig figs for counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'he' );
+			expect( counts ).toEqual( '1.2K' );
+		} );
+		test( 'shows leading sig figs for counts > 10000', () => {
+			const counts = formatNumberCompact( 123456, 'he' );
+			expect( counts ).toEqual( '123K' );
+		} );
+	} );
+	describe( 'ja', () => {
+		test( 'does not modify counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'ja' );
+			expect( counts ).toEqual( '1234' );
+		} );
+		test( 'shows 2 sig figs for counts just over 10000', () => {
+			const counts = formatNumberCompact( 12345, 'ja' );
+			expect( counts ).toEqual( '1.2万' );
+		} );
+		test( 'shows leading sig figs for counts > 100000', () => {
+			const counts = formatNumberCompact( 1234567, 'ja' );
+			expect( counts ).toEqual( '123万' );
+		} );
+	} );
+	describe( 'it', () => {
+		test( 'does not support a compact format, use numberFormat directly from i18n', () => {
+			const counts = formatNumberCompact( 1234, 'it' );
+			expect( counts ).toEqual( null );
+		} );
+	} );
+	describe( 'nl', () => {
+		test( 'shows 2 sig figs for counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'nl' );
+			expect( counts ).toEqual( '1,2K' );
+		} );
+		test( 'shows leading sig figs for counts > 10000', () => {
+			const counts = formatNumberCompact( 123456, 'nl' );
+			expect( counts ).toEqual( '123K' );
+		} );
+	} );
+	describe( 'ru', () => {
+		test( 'the short form is too long to be useful, use numberFormat directly from i18n', () => {
+			const counts = formatNumberCompact( 1234, 'ru' );
+			expect( counts ).toEqual( null );
+		} );
+	} );
+	describe( 'tr', () => {
+		test( 'shows 2 sig figs for counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'tr' );
+			expect( counts ).toEqual( '1,2 B' );
+		} );
+		test( 'shows leading sig figs for counts > 10000', () => {
+			const counts = formatNumberCompact( 123456, 'tr' );
+			expect( counts ).toEqual( '123 B' );
+		} );
+	} );
+	describe( 'id', () => {
+		test( 'shows 2 sig figs for counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'id' );
+			expect( counts ).toEqual( '1,2 rb' );
+		} );
+		test( 'shows leading sig figs for counts > 10000', () => {
+			const counts = formatNumberCompact( 123456, 'id' );
+			expect( counts ).toEqual( '123 rb' );
+		} );
+	} );
+	describe( 'zh-cn', () => {
+		test( 'does not modify counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'zh-cn' );
+			expect( counts ).toEqual( '1234' );
+		} );
+		test( 'shows 2 sig figs for counts just over 10000', () => {
+			const counts = formatNumberCompact( 12345, 'zh-cn' );
+			expect( counts ).toEqual( '1.2万' );
+		} );
+		test( 'shows leading sig figs for counts > 100000', () => {
+			const counts = formatNumberCompact( 1234567, 'zh-cn' );
+			expect( counts ).toEqual( '123万' );
+		} );
+	} );
+	describe( 'zh-tw', () => {
+		test( 'does not modify counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'zh-tw' );
+			expect( counts ).toEqual( '1234' );
+		} );
+		test( 'shows 2 sig figs for counts just over 10000', () => {
+			const counts = formatNumberCompact( 12345, 'zh-tw' );
+			expect( counts ).toEqual( '1.2萬' );
+		} );
+		test( 'shows leading sig figs for counts > 100000', () => {
+			const counts = formatNumberCompact( 1234567, 'zh-tw' );
+			expect( counts ).toEqual( '123萬' );
+		} );
+	} );
+	describe( 'ko', () => {
+		test( 'shows 2 sig figs for counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'ko' );
+			expect( counts ).toEqual( '1.2천' );
+		} );
+		test( 'shows leading sig figs for counts > 10000', () => {
+			const counts = formatNumberCompact( 123456, 'ko' );
+			expect( counts ).toEqual( '123천' );
+		} );
+	} );
+	describe( 'ar', () => {
+		test( 'shows 2 sig figs for counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'ar' );
+			expect( counts ).toEqual( '1٫2 ألف' );
+		} );
+		test( 'shows leading sig figs for counts > 10000', () => {
+			const counts = formatNumberCompact( 123456, 'ar' );
+			expect( counts ).toEqual( '123 ألف' );
+		} );
+	} );
+	describe( 'sv', () => {
+		test( 'shows 2 sig figs for counts < 10000', () => {
+			const counts = formatNumberCompact( 1234, 'sv' );
+			expect( counts ).toEqual( '1,2 tn' );
+		} );
+		test( 'shows leading sig figs for counts > 10000', () => {
+			const counts = formatNumberCompact( 123456, 'sv' );
+			expect( counts ).toEqual( '123 tn' );
+		} );
+	} );
+} );

--- a/client/lib/format-number-compact/thousands.js
+++ b/client/lib/format-number-compact/thousands.js
@@ -1,0 +1,81 @@
+/** @format */
+export const THOUSANDS = {
+	en: {
+		symbol: 'K',
+		grouping: ',',
+		decimal: '.',
+	},
+	es: {
+		symbol: ' mil',
+		grouping: '.',
+		decimal: ',',
+	},
+	'pt-br': {
+		symbol: ' mil',
+		grouping: '.',
+		decimal: ',',
+	},
+	de: {
+		symbol: ' Tsd.',
+		grouping: '.',
+		decimal: ',',
+	},
+	fr: {
+		symbol: ' k',
+		grouping: ' ',
+		decimal: ',',
+	},
+	he: {
+		symbol: 'K',
+		grouping: ',',
+		decimal: '.',
+	},
+	ja: {
+		symbol: '万',
+		unitValue: 10000,
+		grouping: ',',
+		decimal: '.',
+	},
+	nl: {
+		symbol: 'K',
+		grouping: '.',
+		decimal: ',',
+	},
+	tr: {
+		symbol: ' B',
+		grouping: '.',
+		decimal: ',',
+	},
+	id: {
+		symbol: ' rb',
+		grouping: '.',
+		decimal: ',',
+	},
+	'zh-cn': {
+		symbol: '万',
+		unitValue: 10000,
+		grouping: ',',
+		decimal: '.',
+	},
+	'zh-tw': {
+		symbol: '萬',
+		unitValue: 10000,
+		grouping: ',',
+		decimal: '.',
+	},
+	ko: {
+		symbol: '천',
+		grouping: ',',
+		decimal: '.',
+	},
+	ar: {
+		symbol: ' ألف',
+		grouping: '٬',
+		decimal: '٫',
+	},
+	sv: {
+		symbol: ' tn',
+		grouping: ' ',
+		decimal: ',',
+	},
+};

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -30,6 +30,8 @@ export class CommentList extends Component {
 	static propTypes = {
 		changePage: PropTypes.func,
 		comments: PropTypes.array,
+		commentsCount: PropTypes.number,
+		counts: PropTypes.object,
 		order: PropTypes.string,
 		recordChangePage: PropTypes.func,
 		replyComment: PropTypes.func,
@@ -127,6 +129,7 @@ export class CommentList extends Component {
 		const {
 			comments,
 			commentsCount,
+			counts,
 			isLoading,
 			isPostView,
 			order,
@@ -168,6 +171,7 @@ export class CommentList extends Component {
 				<CommentNavigation
 					commentsListQuery={ commentsListQuery }
 					commentsPage={ comments }
+					counts={ counts }
 					isBulkMode={ isBulkMode }
 					isSelectedAll={ this.isSelectedAll() }
 					order={ order }
@@ -230,16 +234,15 @@ export class CommentList extends Component {
 
 const mapStateToProps = ( state, { order, page, postId, siteId, status } ) => {
 	const comments = getCommentsPage( state, siteId, { order, page, postId, status } );
-	const commentsCount = get(
-		getSiteCommentCounts( state, siteId, postId ),
-		'unapproved' === status ? 'pending' : status
-	);
+	const counts = getSiteCommentCounts( state, siteId, postId );
+	const commentsCount = get( counts, 'unapproved' === status ? 'pending' : status );
 	const isLoading = isUndefined( comments );
 	const isPostView = !! postId;
 
 	return {
 		comments: comments || [],
 		commentsCount,
+		counts,
 		isLoading,
 		isPostView,
 	};

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -81,22 +81,27 @@ export class CommentNavigation extends Component {
 	changeFilter = status => () => this.props.recordChangeFilter( status );
 
 	getNavItems = () => {
-		const { translate } = this.props;
+		const { translate, counts } = this.props;
 		const navItems = {
 			all: {
 				label: translate( 'All' ),
+				count: get( counts, 'all' ),
 			},
 			unapproved: {
 				label: translate( 'Pending' ),
+				count: get( counts, 'pending' ),
 			},
 			approved: {
 				label: translate( 'Approved' ),
+				count: get( counts, 'approved' ),
 			},
 			spam: {
 				label: translate( 'Spam' ),
+				count: get( counts, 'spam' ),
 			},
 			trash: {
 				label: translate( 'Trash' ),
+				count: get( counts, 'trash' ),
 			},
 		};
 
@@ -276,9 +281,10 @@ export class CommentNavigation extends Component {
 		return (
 			<SectionNav className="comment-navigation" selectedText={ navItems[ queryStatus ].label }>
 				<NavTabs selectedText={ navItems[ queryStatus ].label }>
-					{ map( navItems, ( { label }, status ) => (
+					{ map( navItems, ( { label, count }, status ) => (
 						<NavItem
 							key={ status }
+							count={ count }
 							onClick={ this.changeFilter( status ) }
 							path={ this.getStatusPath( status ) }
 							selected={ queryStatus === status }

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -285,6 +285,7 @@ export class CommentNavigation extends Component {
 						<NavItem
 							key={ status }
 							count={ count }
+							compactCount={ true }
 							onClick={ this.changeFilter( status ) }
 							path={ this.getStatusPath( status ) }
 							selected={ queryStatus === status }


### PR DESCRIPTION
This PR displays comment counts, and shows a localized thousands compact variant if available. If we don't provide one, or such a shorthand does not exist for the locale it falls back to our usual number localization. 

<img width="1006" alt="screen shot 2018-01-27 at 5 12 44 pm" src="https://user-images.githubusercontent.com/1270189/35478002-eb5c1070-0386-11e8-8d78-fab2d6aecb7f.png">

<img width="203" alt="screen shot 2018-01-27 at 5 20 04 pm" src="https://user-images.githubusercontent.com/1270189/35478005-f2218390-0386-11e8-9499-577e4b264f06.png">

<img width="941" alt="screen shot 2018-01-27 at 5 20 34 pm" src="https://user-images.githubusercontent.com/1270189/35478007-0c967136-0387-11e8-84e2-5be564449395.png">

<img width="1035" alt="screen shot 2018-01-30 at 3 57 22 pm" src="https://user-images.githubusercontent.com/1270189/35598297-6d45eeec-05d7-11e8-82c5-b10ac873303f.png">


### Testing Instructions
- Navigate to /comments
- Select a site with < 1000 comments
- Perform moderation actions, comment counts should update appropriately
- Select a site with > 1000 comments
- We should see expected shortening of counts as shown in images.

