### PR TITLE
JPC: Register link for jetpack sites

### DIFF
--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -20,7 +20,6 @@ import WordPressLogo from 'components/wordpress-logo';
 
 function getLoginUrl( redirectUri ) {
 	const params = { locale: getLocaleSlug() };
-
 	if ( redirectUri ) {
 		params.redirectTo = redirectUri;
 	} else if ( typeof window !== 'undefined' ) {
@@ -28,6 +27,13 @@ function getLoginUrl( redirectUri ) {
 	}
 
 	return login( { ...params, isNative: config.isEnabled( 'login/native-login-links' ) } );
+}
+
+function getSignupUrl() {
+	const isJetpack =
+		typeof window !== 'undefined' &&
+		window.location.href.indexOf( 'jetpack%2Fconnect%2Fauthorize' ) >= 0;
+	return isJetpack ? '/jetpack/connect/authorize' : config( 'signup_url' );
 }
 
 const MasterbarLoggedOut = ( { title, sectionName, translate, redirectUri } ) => (
@@ -39,7 +45,7 @@ const MasterbarLoggedOut = ( { title, sectionName, translate, redirectUri } ) =>
 		<Item className="masterbar__item-title">{ title }</Item>
 		<div className="masterbar__login-links">
 			{ 'signup' !== sectionName ? (
-				<Item url={ config( 'signup_url' ) }>
+				<Item url={ getSignupUrl() }>
 					{ translate( 'Sign Up', {
 						context: 'Toolbar',
 						comment: 'Should be shorter than ~12 chars',


### PR DESCRIPTION
fixes https://github.com/orgs/Automattic/projects/12#card-6999106
Fixes https://github.com/Automattic/jetpack/issues/8759

Right now, the `Sign Up` link we show on the JPC login page is linking to the wpcom NUX flow. This, of course, derails any attempt to create a new account from there during a jetpack connection flow

![image](https://user-images.githubusercontent.com/1554855/35481672-31c42ec0-0428-11e8-851b-bf749417634b.png)


This PR starts exploring how to detect we are in a jetpack flow so we can change where that link points to. 

This first approach is quite shoddy, but it should work (it would be nice to have this in production as quick as possible since it's already breaking users' attempt to connect). But it doesn't work because of SSR, which I don't have any clue about how to deal with :/

