### PR TITLE
Jetpack Onboarding: Fix Homepage format selection event tracking

### DIFF
--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -19,18 +19,14 @@ import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingHomepageStep extends React.PureComponent {
-	handleHomepageSelection = homepageFormat => {
-		const { siteId } = this.props;
-
+	handleHomepageSelection = homepageFormat => () => {
 		this.props.recordJpoEvent( 'calypso_jpo_homepage_format_clicked', {
 			homepageFormat,
 		} );
 
-		return () => {
-			this.props.saveJetpackOnboardingSettings( siteId, {
-				homepageFormat,
-			} );
-		};
+		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
+			homepageFormat,
+		} );
 	};
 
 	render() {


### PR DESCRIPTION
It seems that we've been wrongly calling the homepage format selection event upon loading the step, rather than when actually selecting a homepage format:

![](https://cldup.com/3yxgAvXLX4.png)

This PR fixes this, and updates the homepage selection event to be triggered when actually clicking a homepage format tile:

![](https://cldup.com/jG0bUtG34o.png)

To test:
* Checkout this branch
* Initiate the JPO flow.
* Reach the Homepage step.
* Verify the homepage step selection format events are no longer triggered.
* Click on one of the tiles.
* Verify the homepage format selection event is properly recorded.

Note: To test analytics events easily, you can use `localStorage.setItem('debug', 'calypso:analytics:*' )` in your console.