### PR TITLE
Jetpack Onboarding: Fix event additional prop names

### DIFF
--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -23,7 +23,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 		const { siteId } = this.props;
 
 		this.props.recordJpoEvent( 'calypso_jpo_homepage_format_clicked', {
-			homepageFormat,
+			homepage_format: homepageFormat,
 		} );
 
 		return () => {

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -21,7 +21,7 @@ import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions'
 class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 	handleSiteTypeSelection = siteType => () => {
 		this.props.recordJpoEvent( 'calypso_jpo_site_type_clicked', {
-			siteType,
+			site_type: siteType,
 		} );
 		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
 			siteType,


### PR DESCRIPTION
It seems that when we were working on JPO events we used camel case when we should have used snake case for additional event properties. This PR fixes the names of those properties.