### PR TITLE
Checkout: Thank You page for delayed transfers

### DIFF
--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -89,8 +89,26 @@ class PlanThankYouCard extends Component {
 		return translate( 'Thank you for your purchase!' );
 	}
 
+	renderButtonText() {
+		const { buttonText, translate } = this.props;
+		if ( buttonText ) {
+			return buttonText;
+		}
+
+		return translate( 'Visit Your Site' );
+	}
+
+	getButtonUrl() {
+		const { buttonUrl, siteUrl } = this.props;
+		if ( buttonUrl ) {
+			return buttonUrl;
+		}
+
+		return siteUrl;
+	}
+
 	render() {
-		const { siteUrl, siteId, translate } = this.props;
+		const { siteId } = this.props;
 		return (
 			<div className={ classnames( 'plan-thank-you-card', this.getPlanClass() ) }>
 				<QuerySites siteId={ siteId } />
@@ -101,8 +119,8 @@ class PlanThankYouCard extends Component {
 					price={ this.renderPlanPrice() }
 					heading={ this.renderHeading() }
 					description={ this.renderDescription() }
-					buttonUrl={ siteUrl }
-					buttonText={ translate( 'Visit Your Site' ) }
+					buttonUrl={ this.getButtonUrl() }
+					buttonText={ this.renderButtonText() }
 					icon={ this.renderPlanIcon() }
 					action={ this.renderAction() }
 				/>
@@ -112,13 +130,15 @@ class PlanThankYouCard extends Component {
 }
 
 PlanThankYouCard.propTypes = {
+	action: PropTypes.node,
+	buttonText: PropTypes.string,
+	buttonUrl: PropTypes.string,
+	description: PropTypes.string,
 	heading: PropTypes.string,
 	plan: PropTypes.object,
 	siteId: PropTypes.number.isRequired,
 	siteUrl: PropTypes.string,
 	translate: PropTypes.func.isRequired,
-	action: PropTypes.node,
-	description: PropTypes.string,
 };
 
 export default connect( ( state, ownProps ) => {

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -265,6 +265,10 @@ export function isDomainTransferPrivacy( product ) {
 	return product.product_slug === domainProductSlugs.TRANSFER_IN_PRIVACY;
 }
 
+export function isDelayedDomainTransfer( product ) {
+	return isDomainTransfer( product ) && product.delayedProvisioning;
+}
+
 export function isBundled( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
@@ -408,6 +412,7 @@ export default {
 	isCredits,
 	isCustomDesign,
 	isDependentProduct,
+	isDelayedDomainTransfer,
 	isDomainMapping,
 	isDomainProduct,
 	isDomainRedemption,

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -52,7 +52,7 @@ class CheckoutThankYouHeader extends PureComponent {
 
 		if ( primaryPurchase && isDomainTransfer( primaryPurchase ) ) {
 			if ( isDelayedDomainTransfer( primaryPurchase ) ) {
-				return preventWidows( translate( 'Some other message provided by Dan. :P' ) );
+				return preventWidows( translate( 'Congratulations! Your site is live.' ) );
 			}
 
 			return preventWidows(
@@ -152,7 +152,14 @@ class CheckoutThankYouHeader extends PureComponent {
 
 		if ( isDomainTransfer( primaryPurchase ) ) {
 			if ( isDelayedDomainTransfer( primaryPurchase ) ) {
-				return translate( 'also by dan' );
+				return translate(
+					"Your new site is all set up. There's just a few things left to do to get your domain " +
+						'{{strong}}%(domainName)s{{/strong}} moved to WordPress.com.',
+					{
+						args: { domainName: primaryPurchase.meta },
+						components: { strong: <strong /> },
+					}
+				);
 			}
 
 			return translate(
@@ -230,7 +237,7 @@ class CheckoutThankYouHeader extends PureComponent {
 			return (
 				<div className="checkout-thank-you__header-button">
 					<button className={ headerButtonClassName } onClick={ this.startTransfer }>
-						{ translate( 'Start the transfer' ) }
+						{ translate( 'Start the domain transfer' ) }
 					</button>
 				</div>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -3,17 +3,18 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
 import {
 	isChargeback,
+	isDelayedDomainTransfer,
 	isDomainMapping,
 	isDomainRegistration,
 	isDomainTransfer,
@@ -25,6 +26,7 @@ import {
 import { recordTracksEvent } from 'state/analytics/actions';
 import { localize } from 'i18n-calypso';
 import { preventWidows } from 'lib/formatting';
+import { domainManagementTransferIn } from 'my-sites/domains/paths';
 
 class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
@@ -49,6 +51,10 @@ class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( primaryPurchase && isDomainTransfer( primaryPurchase ) ) {
+			if ( isDelayedDomainTransfer( primaryPurchase ) ) {
+				return preventWidows( translate( 'Some other message provided by Dan. :P' ) );
+			}
+
 			return preventWidows(
 				translate( 'Check your email! There are important next steps waiting in your inbox.' )
 			);
@@ -145,6 +151,10 @@ class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( isDomainTransfer( primaryPurchase ) ) {
+			if ( isDelayedDomainTransfer( primaryPurchase ) ) {
+				return translate( 'also by dan' );
+			}
+
 			return translate(
 				'We sent an email with an important link. Please open the email and click the link to confirm ' +
 					'that you want to transfer {{strong}}%(domainName)s{{/strong}} to WordPress.com. ' +
@@ -186,21 +196,41 @@ class CheckoutThankYouHeader extends PureComponent {
 		window.location.href = selectedSite.URL;
 	};
 
+	startTransfer = event => {
+		event.preventDefault();
+
+		const { primaryPurchase, selectedSite } = this.props;
+
+		this.props.recordTracksEvent( 'calypso_thank_you_start_transfer', {
+			meta: primaryPurchase.meta,
+		} );
+
+		page( domainManagementTransferIn( selectedSite.slug, primaryPurchase.meta ) );
+	};
+
 	getButton() {
 		const { hasFailedPurchases, translate, primaryPurchase, selectedSite } = this.props;
 		const headerButtonClassName = 'button is-primary';
 
-		if (
-			! hasFailedPurchases &&
-			primaryPurchase &&
-			isPlan( primaryPurchase ) &&
-			selectedSite &&
-			! selectedSite.jetpack
-		) {
+		if ( hasFailedPurchases || ! primaryPurchase || ! selectedSite || selectedSite.jetpack ) {
+			return null;
+		}
+
+		if ( isPlan( primaryPurchase ) ) {
 			return (
 				<div className="checkout-thank-you__header-button">
 					<button className={ headerButtonClassName } onClick={ this.visitSite }>
 						{ translate( 'View your site' ) }
+					</button>
+				</div>
+			);
+		}
+
+		if ( isDelayedDomainTransfer( primaryPurchase ) ) {
+			return (
+				<div className="checkout-thank-you__header-button">
+					<button className={ headerButtonClassName } onClick={ this.startTransfer }>
+						{ translate( 'Start the transfer' ) }
 					</button>
 				</div>
 			);
@@ -216,7 +246,11 @@ class CheckoutThankYouHeader extends PureComponent {
 		let svg = 'thank-you.svg';
 		if ( hasFailedPurchases ) {
 			svg = 'items-failed.svg';
-		} else if ( primaryPurchase && isDomainTransfer( primaryPurchase ) ) {
+		} else if (
+			primaryPurchase &&
+			isDomainTransfer( primaryPurchase ) &&
+			! isDelayedDomainTransfer( primaryPurchase )
+		) {
 			svg = 'check-emails-desktop.svg';
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -37,6 +37,7 @@ import JetpackThankYouCard from './jetpack-thank-you-card';
 import AtomicStoreThankYouCard from './atomic-store-thank-you-card';
 import {
 	isChargeback,
+	isDelayedDomainTransfer,
 	isDomainMapping,
 	isDomainProduct,
 	isDomainRedemption,
@@ -295,7 +296,10 @@ class CheckoutThankYou extends React.Component {
 					<AtomicStoreThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
 			);
-		} else if ( this.isNewUser() && wasDotcomPlanPurchased ) {
+		} else if (
+			wasDotcomPlanPurchased &&
+			( purchases.some( isDelayedDomainTransfer ) || this.isNewUser() )
+		) {
 			// streamlined paid NUX thanks page
 			return (
 				<Main className="checkout-thank-you">

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -66,7 +66,11 @@ import RebrandCitiesThankYou from './rebrand-cities-thank-you';
 import SiteRedirectDetails from './site-redirect-details';
 import Notice from 'components/notice';
 import ThankYouCard from 'components/thank-you-card';
-import { domainManagementEmail, domainManagementList } from 'my-sites/domains/paths';
+import {
+	domainManagementEmail,
+	domainManagementList,
+	domainManagementTransferIn,
+} from 'my-sites/domains/paths';
 import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isRebrandCitiesSiteUrl } from 'lib/rebrand-cities';
@@ -76,7 +80,6 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 } from 'lib/plans/constants';
 import { hasSitePendingAutomatedTransfer, isSiteAutomatedTransfer } from 'state/selectors';
-import { domainManagementTransferIn } from '../../domains/paths';
 
 function getPurchases( props ) {
 	return [
@@ -311,7 +314,7 @@ class CheckoutThankYou extends React.Component {
 				planProps = {
 					buttonText: translate( 'Start Domain Transfer' ),
 					description: translate(
-						"Now that we've taken care of the plan, " + "let's get your domain transferred."
+						"Now that we've taken care of the plan, let's get your domain transferred."
 					),
 					buttonUrl: domainManagementTransferIn(
 						this.props.selectedSite.slug,

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -5,6 +5,7 @@ export function createReceiptObject( data ) {
 		displayPrice: data.display_price,
 		purchases: data.purchases.map( purchase => {
 			return {
+				delayedProvisioning: Boolean( purchase.delayed_provisioning ),
 				freeTrial: purchase.free_trial,
 				isDomainRegistration: Boolean( purchase.is_domain_registration ),
 				meta: purchase.meta,


### PR DESCRIPTION
We want to update thank you pages for delayed transfers. They have different messaging and links.

2 screens.
- one for NUX Plan + Transfer
<img width="537" alt="screen shot 2018-01-30 at 15 37 41" src="https://user-images.githubusercontent.com/1103398/35571850-87749498-05d3-11e8-8a85-8056c5881ea0.png">

- one for transfer only NUX
<img width="988" alt="screen shot 2018-01-30 at 15 10 43" src="https://user-images.githubusercontent.com/448298/35589311-6a7887a2-05d1-11e8-97f1-dda54d5dba77.png">


Test:
- Create a new user
- and buy a plan with a transfer in
- See first screen
- Make sure copy and buttons are 👍 
--------------------------
- Use a pre DWPO account
- Create new site with only a transfer in
- See second copy

Dependency: D9675