### PR TITLE
Invite List: add invite details

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -349,6 +349,7 @@
 @import 'my-sites/pages/page-card-info/style';
 @import 'my-sites/people/delete-user/style';
 @import 'my-sites/people/edit-team-member-form/style';
+@import 'my-sites/people/people-invite-details/style';
 @import 'my-sites/people/people-list-item/style';
 @import 'my-sites/people/people-profile/style';
 @import 'my-sites/people/people-notices/style';

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -17,6 +17,7 @@ import PeopleLogStore from 'lib/people/log-store';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import InvitePeople from './invite-people';
 import PeopleInvites from './people-invites';
+import PeopleInviteDetails from './people-invite-details';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -49,6 +50,10 @@ export default {
 
 	peopleInvites( context, next ) {
 		renderPeopleInvites( context, next );
+	},
+
+	renderPeopleInviteDetails( context, next ) {
+		renderPeopleInviteDetails( context, next );
 	},
 };
 
@@ -96,6 +101,19 @@ function renderPeopleInvites( context, next ) {
 
 	context.primary = React.createElement( PeopleInvites, {
 		site,
+	} );
+	next();
+}
+
+function renderPeopleInviteDetails( context, next ) {
+	const state = context.store.getState();
+	const site = getSelectedSite( state );
+
+	context.store.dispatch( setTitle( i18n.translate( 'Invites', { textOnly: true } ) ) );
+
+	context.primary = React.createElement( PeopleInviteDetails, {
+		site,
+		inviteKey: context.params.invite_key,
 	} );
 	next();
 }

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -52,7 +52,7 @@ export default {
 		renderPeopleInvites( context, next );
 	},
 
-	renderPeopleInviteDetails( context, next ) {
+	peopleInviteDetails( context, next ) {
 		renderPeopleInviteDetails( context, next );
 	},
 };

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -44,6 +44,16 @@ export default function() {
 				makeLayout,
 				clientRender
 			);
+
+			page(
+				'/people/invites/:site_id/:invite_key',
+				peopleController.enforceSiteEnding,
+				siteSelection,
+				navigation,
+				peopleController.renderPeopleInviteDetails,
+				makeLayout,
+				clientRender
+			);
 		}
 
 		page(

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -50,7 +50,7 @@ export default function() {
 				peopleController.enforceSiteEnding,
 				siteSelection,
 				navigation,
-				peopleController.renderPeopleInviteDetails,
+				peopleController.peopleInviteDetails,
 				makeLayout,
 				clientRender
 			);

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -1,0 +1,59 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import PeopleListSectionHeader from 'my-sites/people/people-list-section-header';
+import QuerySiteInvites from 'components/data/query-site-invites';
+import { getSelectedInvite, isRequestingInvitesForSite } from 'state/invites/selectors';
+
+class PeopleInviteDetails extends React.PureComponent {
+	static propTypes = {
+		site: PropTypes.object.isRequired,
+		inviteKey: PropTypes.string.isRequired,
+	};
+
+	render() {
+		const { selectedInvite, requesting, site, translate } = this.props;
+
+		if ( ! site || ! site.ID ) {
+			return null;
+		}
+
+		const hasInvite = selectedInvite;
+		const showSectionHeader = requesting || hasInvite;
+
+		return (
+			<Main className="people-invite-details">
+				<QuerySiteInvites siteId={ site.ID } />
+				<SidebarNavigation />
+
+				<div>
+					{ showSectionHeader && (
+						<PeopleListSectionHeader label={ translate( 'Invite' ) } site={ site } />
+					) }
+					{ /*console.log( this.props.selectedInvite )*/ }
+				</div>
+			</Main>
+		);
+	}
+}
+
+export default connect( ( state, ownProps ) => {
+	const siteId = ownProps.site && ownProps.site.ID;
+
+	return {
+		selectedInvite: getSelectedInvite( state, siteId, ownProps.inviteKey ),
+		requesting: isRequestingInvitesForSite( state, siteId ),
+	};
+} )( localize( PeopleInviteDetails ) );

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -5,6 +5,8 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+import page from 'page';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -13,7 +15,9 @@ import { connect } from 'react-redux';
  */
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
-import PeopleListSectionHeader from 'my-sites/people/people-list-section-header';
+import HeaderCake from 'components/header-cake';
+import Card from 'components/card';
+import PeopleListItem from 'my-sites/people/people-list-item';
 import QuerySiteInvites from 'components/data/query-site-invites';
 import { getSelectedInvite, isRequestingInvitesForSite } from 'state/invites/selectors';
 
@@ -23,27 +27,48 @@ class PeopleInviteDetails extends React.PureComponent {
 		inviteKey: PropTypes.string.isRequired,
 	};
 
+	goBack = () => {
+		const siteSlug = get( this.props, 'site.slug' );
+		const fallback = siteSlug ? '/people/invites/' + siteSlug : '/people/invites/';
+
+		// Go back to last route with /people/invites as the fallback
+		page.back( fallback );
+	};
+
+	renderInvite = () => {
+		const { site, invite } = this.props;
+
+		return (
+			<Card>
+				<PeopleListItem
+					key={ invite.key }
+					invite={ invite }
+					user={ invite.user }
+					site={ site }
+					type="invite"
+					isSelectable={ false }
+				/>
+			</Card>
+		);
+	};
+
 	render() {
-		const { selectedInvite, requesting, site, translate } = this.props;
+		const { site, translate, invite } = this.props;
 
 		if ( ! site || ! site.ID ) {
 			return null;
 		}
-
-		const hasInvite = selectedInvite;
-		const showSectionHeader = requesting || hasInvite;
 
 		return (
 			<Main className="people-invite-details">
 				<QuerySiteInvites siteId={ site.ID } />
 				<SidebarNavigation />
 
-				<div>
-					{ showSectionHeader && (
-						<PeopleListSectionHeader label={ translate( 'Invite' ) } site={ site } />
-					) }
-					{ /*console.log( this.props.selectedInvite )*/ }
-				</div>
+				<HeaderCake isCompact onClick={ this.goBack }>
+					{ translate( 'Invite' ) }
+				</HeaderCake>
+
+				{ invite && this.renderInvite() }
 			</Main>
 		);
 	}
@@ -53,7 +78,7 @@ export default connect( ( state, ownProps ) => {
 	const siteId = ownProps.site && ownProps.site.ID;
 
 	return {
-		selectedInvite: getSelectedInvite( state, siteId, ownProps.inviteKey ),
+		invite: getSelectedInvite( state, siteId, ownProps.inviteKey ),
 		requesting: isRequestingInvitesForSite( state, siteId ),
 	};
 } )( localize( PeopleInviteDetails ) );

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -49,7 +49,7 @@ class PeopleInviteDetails extends React.PureComponent {
 					type="invite-details"
 					isSelectable={ false }
 				/>
-				{ invite && this.renderInviteDetails() }
+				{ this.renderInviteDetails() }
 			</Card>
 		);
 	};
@@ -58,17 +58,13 @@ class PeopleInviteDetails extends React.PureComponent {
 		const { invite, translate, moment } = this.props;
 		const showName = invite.invitedBy.login !== invite.invitedBy.name;
 
-		if ( ! invite ) {
-			return null;
-		}
-
 		return (
 			<div className="people-invite-details__meta">
 				<div className="people-invite-details__meta-item">
 					<span className="people-invite-details__meta-item-label">
 						{ translate( 'Invited By' ) }
 					</span>
-					{ invite.invitedBy && <Gravatar user={ invite.invitedBy } size={ 24 } /> }
+					<Gravatar user={ invite.invitedBy } size={ 24 } />
 					{ showName && (
 						<span className="people-invite-details__meta-item-user">{ invite.invitedBy.name }</span>
 					) }

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -46,7 +46,7 @@ class PeopleInviteDetails extends React.PureComponent {
 					invite={ invite }
 					user={ invite.user }
 					site={ site }
-					type="invite-details"
+					type="invite"
 					isSelectable={ false }
 				/>
 				{ invite && this.renderInviteDetails() }

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -46,7 +46,7 @@ class PeopleInviteDetails extends React.PureComponent {
 					invite={ invite }
 					user={ invite.user }
 					site={ site }
-					type="invite"
+					type="invite-details"
 					isSelectable={ false }
 				/>
 				{ invite && this.renderInviteDetails() }

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -20,7 +20,7 @@ import Card from 'components/card';
 import PeopleListItem from 'my-sites/people/people-list-item';
 import Gravatar from 'components/gravatar';
 import QuerySiteInvites from 'components/data/query-site-invites';
-import { getSelectedInvite, isRequestingInvitesForSite } from 'state/invites/selectors';
+import { getSelectedInvite } from 'state/invites/selectors';
 
 class PeopleInviteDetails extends React.PureComponent {
 	static propTypes = {
@@ -66,18 +66,18 @@ class PeopleInviteDetails extends React.PureComponent {
 			<div className="people-invite-details__meta">
 				<div className="people-invite-details__meta-item">
 					<span className="people-invite-details__meta-item-label">
-						{ translate( 'Invited By:' ) }
+						{ translate( 'Invited By' ) }
 					</span>
 					{ invite.invitedBy && <Gravatar user={ invite.invitedBy } size={ 24 } /> }
 					{ showName && (
 						<span className="people-invite-details__meta-item-user">{ invite.invitedBy.name }</span>
 					) }
-					<span className="people-invite-details__meta-item-user">
+					<span className="people-invite-details__meta-item-username">
 						{ '@' + invite.invitedBy.login }
 					</span>
 				</div>
 				<div className="people-invite-details__meta-item">
-					<span className="people-invite-details__meta-item-label">{ translate( 'Sent:' ) }</span>
+					<span className="people-invite-details__meta-item-label">{ translate( 'Sent' ) }</span>
 					<span className="people-invite-details__meta-item-date">
 						{ moment( invite.inviteDate ).format( 'LLL' ) }
 					</span>
@@ -85,7 +85,7 @@ class PeopleInviteDetails extends React.PureComponent {
 				{ invite.acceptedDate && (
 					<div className="people-invite-details__meta-item">
 						<span className="people-invite-details__meta-item-label">
-							{ translate( 'Accepted:' ) }
+							{ translate( 'Accepted' ) }
 						</span>
 						<span className="people-invite-details__meta-item-date">
 							{ moment( invite.acceptedDate ).format( 'LLL' ) }
@@ -123,6 +123,5 @@ export default connect( ( state, ownProps ) => {
 
 	return {
 		invite: getSelectedInvite( state, siteId, ownProps.inviteKey ),
-		requesting: isRequestingInvitesForSite( state, siteId ),
 	};
 } )( localize( PeopleInviteDetails ) );

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -70,7 +70,7 @@ class PeopleInviteDetails extends React.PureComponent {
 					</span>
 					{ invite.invitedBy && <Gravatar user={ invite.invitedBy } size={ 24 } /> }
 					{ showName && (
-						<span className="people-invite-details__meta-item-user">invite.invitedBy.name</span>
+						<span className="people-invite-details__meta-item-user">{ invite.invitedBy.name }</span>
 					) }
 					<span className="people-invite-details__meta-item-user">
 						{ '@' + invite.invitedBy.login }

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -18,6 +18,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import HeaderCake from 'components/header-cake';
 import Card from 'components/card';
 import PeopleListItem from 'my-sites/people/people-list-item';
+import Gravatar from 'components/gravatar';
 import QuerySiteInvites from 'components/data/query-site-invites';
 import { getSelectedInvite, isRequestingInvitesForSite } from 'state/invites/selectors';
 
@@ -45,10 +46,45 @@ class PeopleInviteDetails extends React.PureComponent {
 					invite={ invite }
 					user={ invite.user }
 					site={ site }
-					type="invite"
+					type="invite-details"
 					isSelectable={ false }
 				/>
+				{ invite && this.renderInviteDetails() }
 			</Card>
+		);
+	};
+
+	renderInviteDetails = () => {
+		const { invite, translate, moment } = this.props;
+		const showName = invite.invitedBy.login !== invite.invitedBy.name;
+
+		if ( ! invite ) {
+			return null;
+		}
+
+		return (
+			<div className="people-invite-details__meta">
+				<div className="people-invite-details__meta-item">
+					<span className="people-invite-details__meta-item-label">
+						{ translate( 'Invited By:' ) }
+					</span>
+					{ invite.invitedBy && <Gravatar user={ invite.invitedBy } size={ 24 } /> }
+					{ showName && (
+						<span className="people-invite-details__meta-item-user">invite.invitedBy.name</span>
+					) }
+					<span className="people-invite-details__meta-item-user">
+						{ '@' + invite.invitedBy.login }
+					</span>
+				</div>
+				<div className="people-invite-details__meta-item">
+					<span className="people-invite-details__meta-item-label">
+						{ translate( 'Last Sent:' ) }
+					</span>
+					<span className="people-invite-details__meta-item-date">
+						{ moment( invite.inviteDate ).format( 'LLL' ) }
+					</span>
+				</div>
+			</div>
 		);
 	};
 

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -77,13 +77,21 @@ class PeopleInviteDetails extends React.PureComponent {
 					</span>
 				</div>
 				<div className="people-invite-details__meta-item">
-					<span className="people-invite-details__meta-item-label">
-						{ translate( 'Last Sent:' ) }
-					</span>
+					<span className="people-invite-details__meta-item-label">{ translate( 'Sent:' ) }</span>
 					<span className="people-invite-details__meta-item-date">
 						{ moment( invite.inviteDate ).format( 'LLL' ) }
 					</span>
 				</div>
+				{ invite.acceptedDate && (
+					<div className="people-invite-details__meta-item">
+						<span className="people-invite-details__meta-item-label">
+							{ translate( 'Accepted:' ) }
+						</span>
+						<span className="people-invite-details__meta-item-date">
+							{ moment( invite.acceptedDate ).format( 'LLL' ) }
+						</span>
+					</div>
+				) }
 			</div>
 		);
 	};

--- a/client/my-sites/people/people-invite-details/style.scss
+++ b/client/my-sites/people/people-invite-details/style.scss
@@ -10,13 +10,13 @@
 
 .people-invite-details__meta-item {
 	margin-bottom: 12px;
-	color: $gray;
+	color: $gray-text-min;
 
 	.people-invite-details__meta-item-label {
 		display: inline-block;
 		width: 130px;
 		margin-right: 16px;
-		color: $gray-dark;
+		color: $gray-text;
 		font-weight: 600;
 		text-align: right;
 	}
@@ -26,7 +26,7 @@
 		font-family: $serif;
 		font-size: 16px;
 		font-weight: 700;
-		color: $gray-dark;
+		color: $gray-text;
 	}
 
 	.gravatar {

--- a/client/my-sites/people/people-invite-details/style.scss
+++ b/client/my-sites/people/people-invite-details/style.scss
@@ -10,13 +10,23 @@
 
 .people-invite-details__meta-item {
 	margin-bottom: 12px;
+	color: $gray;
 
 	.people-invite-details__meta-item-label {
 		display: inline-block;
 		width: 130px;
 		margin-right: 16px;
+		color: $gray-dark;
 		font-weight: 600;
 		text-align: right;
+	}
+
+	.people-invite-details__meta-item-user {
+		margin-right: 6px;
+		font-family: $serif;
+		font-size: 16px;
+		font-weight: 700;
+		color: $gray-dark;
 	}
 
 	.gravatar {

--- a/client/my-sites/people/people-invite-details/style.scss
+++ b/client/my-sites/people/people-invite-details/style.scss
@@ -1,3 +1,7 @@
+.people-invite-details .people-list-item__invite-status {
+	margin-right: 0;
+}
+
 .people-invite-details__meta {
 	border-top: 1px solid lighten( $gray, 30% );
 	padding-top: 24px;

--- a/client/my-sites/people/people-invite-details/style.scss
+++ b/client/my-sites/people/people-invite-details/style.scss
@@ -1,0 +1,22 @@
+.people-invite-details__meta {
+	border-top: 1px solid lighten( $gray, 30% );
+	padding-top: 24px;
+	margin-top: 24px;
+}
+
+.people-invite-details__meta-item {
+	margin-bottom: 12px;
+
+	.people-invite-details__meta-item-label {
+		display: inline-block;
+		width: 130px;
+		margin-right: 16px;
+		font-weight: 600;
+		text-align: right;
+	}
+
+	.gravatar {
+		vertical-align: middle;
+		margin-right: 6px;
+	}
+}

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -54,8 +54,13 @@ class PeopleListItem extends React.PureComponent {
 		);
 	};
 
-	getCardLink = () => {
+	maybeGetCardLink = () => {
 		const { invite, site, type, user } = this.props;
+
+		if ( 'invite-details' === type ) {
+			return null;
+		}
+
 		const editLink = this.canLinkToProfile() && `/people/edit/${ site.slug }/${ user.login }`;
 		const inviteLink = invite && `/people/invites/${ site.slug }/${ invite.key }`;
 
@@ -108,13 +113,13 @@ class PeopleListItem extends React.PureComponent {
 		const { className, invite, onRemove, translate, type, user } = this.props;
 		const canLinkToProfile = this.canLinkToProfile();
 		const tagName = canLinkToProfile ? 'a' : 'span';
-		const isInvite = invite && 'invite' === type;
+		const isInvite = invite && ( 'invite' === type || 'invite-details' === type );
 
 		return (
 			<CompactCard
 				className={ classNames( 'people-list-item', className ) }
 				tagName={ tagName }
-				href={ this.getCardLink() }
+				href={ this.maybeGetCardLink() }
 				onClick={ canLinkToProfile && this.navigateToUser }
 			>
 				<div className="people-list-item__profile-container">

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -91,6 +91,7 @@
 	flex-grow: 0;
 	flex-shrink: 0;
 	margin-right: 30px;
+	margin-left: 12px;
 
 	color: $alert-green;
 

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -122,7 +122,7 @@ class PeopleProfile extends React.PureComponent {
 			name = user.name;
 		} else if ( user.label ) {
 			name = user.label;
-		} else if ( 'invite' === type ) {
+		} else if ( 'invite' === type || 'invite-details' === type ) {
 			// If an invite was sent to a WP.com user, the invite object will have
 			// either a display name (if set) or the WP.com username. Invites can
 			// also be sent to any email address, in which case the other details

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -63,7 +63,7 @@
 }
 
 .people-profile__login {
-	color: $gray-dark;
+	color: $gray-text-min;
 	font-size: 13px;
 
 	@include breakpoint( '>480px' ) {

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -63,6 +63,8 @@ export const items = createReducer(
 						key: invite.invite_key,
 						role: invite.role,
 						isPending: invite.is_pending,
+						inviteDate: invite.invite_date,
+						acceptedDate: invite.accepted_date,
 						user,
 					};
 				} ),

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -58,6 +58,7 @@ export const items = createReducer(
 				[ action.siteId ]: action.invites.map( invite => {
 					// Not renaming `avatar_URL` because it is used as-is by <Gravatar>
 					const user = pick( invite.user, 'login', 'email', 'name', 'avatar_URL' );
+					const invitedBy = pick( invite.invited_by, 'name', 'login', 'avatar_URL' );
 
 					return {
 						key: invite.invite_key,
@@ -66,6 +67,7 @@ export const items = createReducer(
 						inviteDate: invite.invite_date,
 						acceptedDate: invite.accepted_date,
 						user,
+						invitedBy,
 					};
 				} ),
 			};

--- a/client/state/invites/schema.js
+++ b/client/state/invites/schema.js
@@ -12,6 +12,8 @@ export const inviteItemsSchema = {
 					key: { type: 'string' },
 					role: { type: 'string' },
 					isPending: { type: 'boolean' },
+					inviteDate: { type: 'string' },
+					acceptedDate: { anyOf: [ { type: 'string' }, { enum: [ null ] } ] },
 					user: {
 						type: 'object',
 						properties: {

--- a/client/state/invites/schema.js
+++ b/client/state/invites/schema.js
@@ -24,6 +24,15 @@ export const inviteItemsSchema = {
 						},
 						additionalProperties: false,
 					},
+					invitedBy: {
+						type: 'object',
+						properties: {
+							login: { type: 'string' },
+							name: { type: 'string' },
+							avatar_URL: { type: 'string' },
+						},
+						additionalProperties: false,
+					},
 				},
 				additionalProperties: false,
 			},

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -41,7 +41,7 @@ export function getInvitesForSite( state, siteId ) {
  * @return {?Number}        The number of invites found for the given site
  */
 export function getNumberOfInvitesFoundForSite( state, siteId ) {
-	return state.invites.counts[siteId] || null;
+	return state.invites.counts[ siteId ] || null;
 }
 
 /*

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -3,7 +3,12 @@
 /**
  * External dependencies
  */
-import { get, findIndex } from 'lodash';
+import { get, find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import treeSelect from 'lib/tree-select';
 
 /**
  * Returns true if currently requesting invites for the given site, or false
@@ -54,11 +59,12 @@ export function getNumberOfInvitesFoundForSite( state, siteId ) {
  * @param  {String}  inviteId Invite ID
  * @return {Object}           Invite object
  */
-export function getSelectedInvite( state, siteId, inviteId ) {
-	const siteInvites = getInvitesForSite( state, siteId );
-	const selectedIndex = findIndex( siteInvites, [ 'key', inviteId ] );
-	return get( state, [ 'invites', 'items', siteId, selectedIndex ], null );
-}
+export const getSelectedInvite = treeSelect(
+	( state, siteId ) => [ state.invites.items[ siteId ] ],
+	( [ siteInvites ], siteId, inviteId ) => {
+		return find( siteInvites, { key: inviteId } );
+	}
+);
 
 /**
  * Returns true if currently requesting an invite resend for the given site and

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -55,9 +55,9 @@ export function getNumberOfInvitesFoundForSite( state, siteId ) {
  * @return {Object}           Invite object
  */
 export function getSelectedInvite( state, siteId, inviteId ) {
-	const items = get( state, [ 'invites', 'items', siteId ], false );
-	const selectedIndex = findIndex( items, [ 'key', inviteId ] );
-	return get( state, [ 'invites', 'items', siteId, selectedIndex ], false );
+	const siteInvites = getInvitesForSite( state, siteId );
+	const selectedIndex = findIndex( siteInvites, [ 'key', inviteId ] );
+	return get( state, [ 'invites', 'items', siteId, selectedIndex ], null );
 }
 
 /**

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, findIndex } from 'lodash';
 
 /**
  * Returns true if currently requesting invites for the given site, or false
@@ -41,7 +41,23 @@ export function getInvitesForSite( state, siteId ) {
  * @return {?Number}        The number of invites found for the given site
  */
 export function getNumberOfInvitesFoundForSite( state, siteId ) {
-	return state.invites.counts[ siteId ] || null;
+	return state.invites.counts[siteId] || null;
+}
+
+/*
+ * Returns an invite object for the given site and invite ID, or false otherwise.
+ *
+ * TODO: searching the object can probably be done in a cleaner manner.
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+ * @param  {String}  inviteId Invite ID
+ * @return {Object}           Invite object
+ */
+export function getSelectedInvite( state, siteId, inviteId ) {
+	const items = get( state, [ 'invites', 'items', siteId ], false );
+	const selectedIndex = findIndex( items, [ 'key', inviteId ] );
+	return get( state, [ 'invites', 'items', siteId, selectedIndex ], false );
 }
 
 /**

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -70,6 +70,12 @@ describe( 'reducer', () => {
 								avatar_URL:
 									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
 							},
+							invited_by: {
+								login: 'cow',
+								name: 'Vaca',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+							},
 						},
 					],
 				}
@@ -88,6 +94,12 @@ describe( 'reducer', () => {
 							name: 'Pollo',
 							avatar_URL:
 								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+						},
+						invitedBy: {
+							login: 'cow',
+							name: 'Vaca',
+							avatar_URL:
+								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
 						},
 					},
 				],
@@ -110,6 +122,12 @@ describe( 'reducer', () => {
 							avatar_URL:
 								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
 						},
+						invitedBy: {
+							login: 'cow',
+							name: 'Vaca',
+							avatar_URL:
+								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+						},
 					},
 				],
 			};
@@ -127,6 +145,12 @@ describe( 'reducer', () => {
 							login: 'celery',
 							email: false,
 							name: 'Apio',
+							avatar_URL:
+								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+						},
+						invited_by: {
+							login: 'cow',
+							name: 'Vaca',
 							avatar_URL:
 								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
 						},
@@ -148,6 +172,12 @@ describe( 'reducer', () => {
 							avatar_URL:
 								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
 						},
+						invitedBy: {
+							login: 'cow',
+							name: 'Vaca',
+							avatar_URL:
+								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+						},
 					},
 				],
 				67890: [
@@ -161,6 +191,12 @@ describe( 'reducer', () => {
 							login: 'celery',
 							email: false,
 							name: 'Apio',
+							avatar_URL:
+								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+						},
+						invitedBy: {
+							login: 'cow',
+							name: 'Vaca',
 							avatar_URL:
 								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
 						},
@@ -185,6 +221,12 @@ describe( 'reducer', () => {
 							avatar_URL:
 								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
 						},
+						invitedBy: {
+							login: 'cow',
+							name: 'Vaca',
+							avatar_URL:
+								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+						},
 					},
 				],
 			} );
@@ -208,6 +250,12 @@ describe( 'reducer', () => {
 							name: 'Pollo',
 							avatar_URL:
 								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+						},
+						invitedBy: {
+							login: 'cow',
+							name: 'Vaca',
+							avatar_URL:
+								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
 						},
 					},
 				],
@@ -238,6 +286,12 @@ describe( 'reducer', () => {
 								avatar_URL:
 									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
 							},
+							invitedBy: {
+								login: 'cow',
+								name: 'Vaca',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+							},
 							hasExtraInvalidProperty: true,
 						},
 					],
@@ -262,6 +316,12 @@ describe( 'reducer', () => {
 								name: 'Pollo',
 								avatar_URL:
 									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+							},
+							invitedBy: {
+								login: 'cow',
+								name: 'Vaca',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
 							},
 						},
 					],

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -61,6 +61,8 @@ describe( 'reducer', () => {
 							invite_key: '123456asdf789',
 							role: 'follower',
 							is_pending: true,
+							invite_date: '2018-01-28T17:22:16+00:00',
+							accepted_date: '2018-01-28T17:22:20+00:00',
 							user: {
 								login: 'chicken',
 								email: false,
@@ -78,6 +80,8 @@ describe( 'reducer', () => {
 						key: '123456asdf789',
 						role: 'follower',
 						isPending: true,
+						inviteDate: '2018-01-28T17:22:16+00:00',
+						acceptedDate: '2018-01-28T17:22:20+00:00',
 						user: {
 							login: 'chicken',
 							email: false,
@@ -97,6 +101,8 @@ describe( 'reducer', () => {
 						key: '123456asdf789',
 						role: 'follower',
 						isPending: true,
+						inviteDate: '2018-01-28T17:22:16+00:00',
+						acceptedDate: '2018-01-28T17:22:20+00:00',
 						user: {
 							login: 'chicken',
 							email: false,
@@ -115,6 +121,8 @@ describe( 'reducer', () => {
 						invite_key: '9876fdas54321',
 						role: 'follower',
 						is_pending: true,
+						invite_date: '2018-01-28T17:22:16+00:00',
+						accepted_date: '2018-01-28T17:22:20+00:00',
 						user: {
 							login: 'celery',
 							email: false,
@@ -131,6 +139,8 @@ describe( 'reducer', () => {
 						key: '123456asdf789',
 						role: 'follower',
 						isPending: true,
+						inviteDate: '2018-01-28T17:22:16+00:00',
+						acceptedDate: '2018-01-28T17:22:20+00:00',
 						user: {
 							login: 'chicken',
 							email: false,
@@ -145,6 +155,8 @@ describe( 'reducer', () => {
 						key: '9876fdas54321',
 						role: 'follower',
 						isPending: true,
+						inviteDate: '2018-01-28T17:22:16+00:00',
+						acceptedDate: '2018-01-28T17:22:20+00:00',
 						user: {
 							login: 'celery',
 							email: false,
@@ -164,6 +176,8 @@ describe( 'reducer', () => {
 						key: '123456asdf789',
 						role: 'follower',
 						isPending: true,
+						inviteDate: '2018-01-28T17:22:16+00:00',
+						acceptedDate: '2018-01-28T17:22:20+00:00',
 						user: {
 							login: 'chicken',
 							email: false,
@@ -186,6 +200,8 @@ describe( 'reducer', () => {
 						key: '123456asdf789',
 						role: 'follower',
 						isPending: true,
+						inviteDate: '2018-01-28T17:22:16+00:00',
+						acceptedDate: '2018-01-28T17:22:20+00:00',
 						user: {
 							login: 'chicken',
 							email: false,
@@ -213,6 +229,8 @@ describe( 'reducer', () => {
 							key: '123456asdf789',
 							role: 'follower',
 							isPending: true,
+							inviteDate: '2018-01-28T17:22:16+00:00',
+							acceptedDate: '2018-01-28T17:22:20+00:00',
 							user: {
 								login: 'chicken',
 								email: false,
@@ -236,6 +254,8 @@ describe( 'reducer', () => {
 							key: '123456asdf789',
 							role: 'follower',
 							isPending: null,
+							inviteDate: '2018-01-28T17:22:16+00:00',
+							acceptedDate: '2018-01-28T17:22:20+00:00',
 							user: {
 								login: 'chicken',
 								email: false,

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -130,6 +130,40 @@ describe( 'selectors', () => {
 			);
 		} );
 
+		test( 'should return the same object given the same input', () => {
+			const state = {
+				invites: {
+					items: {
+						12345: [
+							{
+								key: '123456asdf789',
+								role: 'follower',
+								isPending: null,
+								inviteDate: '2018-01-28T17:22:16+00:00',
+								acceptedDate: '2018-01-28T17:22:20+00:00',
+								user: {
+									login: 'chicken',
+									email: false,
+									name: 'Pollo',
+									avatar_URL:
+										'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+								},
+								invitedBy: {
+									login: 'cow',
+									name: 'Vaca',
+									avatar_URL:
+										'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+								},
+							},
+						],
+					},
+				},
+			};
+			const call1 = getSelectedInvite( state, 12345, '123456asdf789' );
+			const call2 = getSelectedInvite( state, 12345, '123456asdf789' );
+			expect( call1 ).equal( call2 );
+		} );
+
 		test( 'should return undefined when invites do not exist for site', () => {
 			const state = {
 				invites: {

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -61,6 +61,8 @@ describe( 'selectors', () => {
 								key: '123456asdf789',
 								role: 'follower',
 								isPending: null,
+								inviteDate: '2018-01-28T17:22:16+00:00',
+								acceptedDate: '2018-01-28T17:22:20+00:00',
 								user: {
 									login: 'chicken',
 									email: false,

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -13,6 +13,7 @@ import {
 	isRequestingResend,
 	getNumberOfInvitesFoundForSite,
 	didResendSucceed,
+	getSelectedInvite,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -70,6 +71,12 @@ describe( 'selectors', () => {
 									avatar_URL:
 										'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
 								},
+								invitedBy: {
+									login: 'cow',
+									name: 'Vaca',
+									avatar_URL:
+										'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+								},
 							},
 						],
 					},
@@ -85,6 +92,51 @@ describe( 'selectors', () => {
 				},
 			};
 			expect( getInvitesForSite( state, 12345 ) ).to.equal( null );
+		} );
+	} );
+
+	describe( '#getSelectedInvite()', () => {
+		test( 'should return invite', () => {
+			const state = {
+				invites: {
+					items: {
+						12345: [
+							{
+								key: '123456asdf789',
+								role: 'follower',
+								isPending: null,
+								inviteDate: '2018-01-28T17:22:16+00:00',
+								acceptedDate: '2018-01-28T17:22:20+00:00',
+								user: {
+									login: 'chicken',
+									email: false,
+									name: 'Pollo',
+									avatar_URL:
+										'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+								},
+								invitedBy: {
+									login: 'cow',
+									name: 'Vaca',
+									avatar_URL:
+										'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+								},
+							},
+						],
+					},
+				},
+			};
+			expect( getSelectedInvite( state, 12345, '123456asdf789' ) ).to.eql(
+				state.invites.items[ 12345 ][ 0 ]
+			);
+		} );
+
+		test( 'should return null when invites do not exist for site', () => {
+			const state = {
+				invites: {
+					items: {},
+				},
+			};
+			expect( getSelectedInvite( state, 12345, '123456asdf789' ) ).to.equal( null );
 		} );
 	} );
 

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -3,6 +3,8 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import sinon from 'sinon';
+import lodash from 'lodash';
 
 /**
  * Internal dependencies
@@ -96,6 +98,14 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getSelectedInvite()', () => {
+		beforeAll( () => {
+			sinon.spy( lodash, 'find' );
+		} );
+
+		afterEach( () => {
+			lodash.find.reset();
+		} );
+
 		test( 'should return invite', () => {
 			const state = {
 				invites: {
@@ -130,7 +140,7 @@ describe( 'selectors', () => {
 			);
 		} );
 
-		test( 'should return the same object given the same input', () => {
+		test( 'should memoize return values given the same input', () => {
 			const state = {
 				invites: {
 					items: {
@@ -159,9 +169,16 @@ describe( 'selectors', () => {
 					},
 				},
 			};
+			expect( lodash.find.callCount ).to.equal( 0 );
 			const call1 = getSelectedInvite( state, 12345, '123456asdf789' );
+			expect( lodash.find.callCount ).to.equal( 1 );
 			const call2 = getSelectedInvite( state, 12345, '123456asdf789' );
-			expect( call1 ).equal( call2 );
+			expect( lodash.find.callCount ).to.equal( 1 );
+			expect( call1 ).to.equal( call2 );
+			const newState = lodash.cloneDeep( state );
+			const call3 = getSelectedInvite( newState, 12345, '123456asdf789' );
+			expect( lodash.find.callCount ).to.equal( 2 );
+			expect( call3 ).not.to.equal( call2 );
 		} );
 
 		test( 'should return undefined when invites do not exist for site', () => {

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -130,13 +130,13 @@ describe( 'selectors', () => {
 			);
 		} );
 
-		test( 'should return null when invites do not exist for site', () => {
+		test( 'should return undefined when invites do not exist for site', () => {
 			const state = {
 				invites: {
 					items: {},
 				},
 			};
-			expect( getSelectedInvite( state, 12345, '123456asdf789' ) ).to.equal( null );
+			expect( getSelectedInvite( state, 12345, '123456asdf789' ) ).to.equal( undefined );
 		} );
 	} );
 


### PR DESCRIPTION
This adds a new screen to view and manage individual invite details. The following data should be available when applicable:

- Invite Gravatar, username and/or email address
- Invite role
- Invite status (pending/accepted)
- Invite resend button
- Sent by Gravatar, name and/or username
- Invite sent date (updated with resends)
- Invite accepted date

This is being developed behind a feature flag.

Ref: p3Ex-32O-p2

<img width="739" alt="invite-details" src="https://user-images.githubusercontent.com/942359/35737254-e9e4e82c-07f8-11e8-8efe-0fd18e1119e2.png">

**To Test:**
- Visit `/people/invites` for a site with existing invites (you can add invites from `/people`).
- Click on an invite in the invite list.
- This should take you to the invite details screen.
- Verify the existing profile information for an invite.
- Verify the invite status.
- If the invite is pending, a resend button should be available.
- Verify that resending the invite works.
- Verify the invitedBy details.
- Verify the invite date.

