### PR TITLE
Fix: add missing siteSelection middlewares

### DIFF
--- a/client/extensions/wp-job-manager/index.js
+++ b/client/extensions/wp-job-manager/index.js
@@ -27,7 +27,7 @@ export default function() {
 	const jobSubmissionSlug = get( Tabs, 'JOB_SUBMISSION.slug', '' );
 	const pagesSlug = get( Tabs, 'PAGES.slug', '' );
 
-	page( '/extensions/wp-job-manager', sites, makeLayout, clientRender );
+	page( '/extensions/wp-job-manager', siteSelection, sites, makeLayout, clientRender );
 	page(
 		'/extensions/wp-job-manager/:site',
 		siteSelection,

--- a/client/extensions/wp-super-cache/index.js
+++ b/client/extensions/wp-super-cache/index.js
@@ -17,7 +17,7 @@ import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	const validTabSlugs = compact( map( Tabs, ( { slug } ) => slug ) ).join( '|' );
-	page( '/extensions/wp-super-cache', sites, makeLayout, clientRender );
+	page( '/extensions/wp-super-cache', siteSelection, sites, makeLayout, clientRender );
 	page(
 		`/extensions/wp-super-cache/:tab(${ validTabSlugs })?/:site`,
 		siteSelection,

--- a/client/extensions/zoninator/index.js
+++ b/client/extensions/zoninator/index.js
@@ -18,9 +18,9 @@ import installActionHandlers from './state/data-layer';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/extensions/zoninator', sites, makeLayout, clientRender );
-	page( '/extensions/zoninator/new', sites, makeLayout, clientRender );
-	page( '/extensions/zoninator/zone', sites, makeLayout, clientRender );
+	page( '/extensions/zoninator', siteSelection, sites, makeLayout, clientRender );
+	page( '/extensions/zoninator/new', siteSelection, sites, makeLayout, clientRender );
+	page( '/extensions/zoninator/zone', siteSelection, sites, makeLayout, clientRender );
 
 	page(
 		'/extensions/zoninator/:site',

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -59,7 +59,7 @@ export default function() {
 		} );
 
 		if ( config.isEnabled( 'manage/plugins/upload' ) ) {
-			page( '/plugins/upload', sites, makeLayout, clientRender );
+			page( '/plugins/upload', siteSelection, sites, makeLayout, clientRender );
 			page(
 				'/plugins/upload/:site_id',
 				siteSelection,

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -22,7 +22,7 @@ export default function( router ) {
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( isLoggedIn ) {
 			if ( config.isEnabled( 'manage/themes/upload' ) ) {
-				router( '/themes/upload', sites, makeLayout );
+				router( '/themes/upload', siteSelection, sites, makeLayout );
 				router( '/themes/upload/:site_id?', siteSelection, upload, navigation, makeLayout );
 			}
 			const loggedInRoutes = [


### PR DESCRIPTION
Add missing `siteSelection` middleware to several routes to:

- Show nicer _"You don't have any WordPress sites yet."_-message and "Create Site" button for users without any sites:

    ![screen shot 2018-01-25 at 12 14 18](https://user-images.githubusercontent.com/87168/35382929-689dac98-01c9-11e8-9b9e-a65b7b3874f0.png)

    ... instead of a bit blunt _"No sites found"_ dead end:

    ![screen shot 2018-01-25 at 12 14 10](https://user-images.githubusercontent.com/87168/35382935-6acd2e76-01c9-11e8-98dd-38831b8386ce.png)

- Redirect to `/route/:site` directly instead of showing pointless selector for just one site:

    ![screen shot 2018-01-29 at 12 06 19](https://user-images.githubusercontent.com/87168/35505662-77170fde-04ef-11e8-994f-5ffc28787be1.png)

Middleware's name `siteSelection` kinda implies it should be used only when `:site` slug is present in route but as it turns out, it's needed anyway to help in situations where user has a single site or has no sites at all.

## Testing

Prepare users 1) without site 2) with one site 3) with multiple sites

Routes to test:
- `/plugins/upload`
- `/themes/upload`
- `/extensions/wp-job-manager`
- `/extensions/wp-super-cache`
- `/extensions/zoninator`
- `/extensions/zoninator/new`
- `/extensions/zoninator/zone`

#### 1) Without sites:
* Before: shows site selector with "No sites found" dead end
* After: shows _"You don't have any WordPress sites yet."_-message with "create site" button

#### 2) One site:
* Before: shows selector for one site
* After: redirects to `/route/:thatOneSite`

#### 3) Multiple sites:
* Before: shows site selector
* After: shows site selector (no changes here)
