### PR TITLE
Reorganize masterbar drafts for better async loading

### DIFF
--- a/client/layout/masterbar/drafts-popover.jsx
+++ b/client/layout/masterbar/drafts-popover.jsx
@@ -1,0 +1,116 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { newPost } from 'lib/paths';
+import Popover from 'components/popover';
+import Count from 'components/count';
+import { getPostsForQueryIgnoringPage, isRequestingPostsForQuery } from 'state/posts/selectors';
+import Draft from 'my-sites/draft';
+import QueryPosts from 'components/data/query-posts';
+import Button from 'components/button';
+import { getSite } from 'state/sites/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
+
+class MasterbarDraftsPopover extends Component {
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<Popover
+				isVisible
+				onClose={ this.props.closeDrafts }
+				position="bottom left"
+				context={ this.props.context }
+				className="masterbar__recent-drafts"
+			>
+				<QueryPosts siteId={ this.props.site.ID } query={ this.props.draftsQuery } />
+
+				<div className="masterbar__recent-drafts-heading">
+					<h3>{ translate( 'Recent Drafts' ) }</h3>
+
+					<Button
+						compact
+						className="masterbar__recent-drafts-add-new"
+						href={ newPost( this.props.site ) }
+						onClick={ this.props.newDraftClicked }
+					>
+						{ translate( 'New Draft' ) }
+					</Button>
+				</div>
+
+				<div className="masterbar__recent-drafts-list">
+					{ this.renderDrafts() }
+
+					{ this.props.loadingDrafts && <Draft isPlaceholder /> }
+
+					<Button
+						compact
+						borderless
+						className="masterbar__recent-drafts-see-all"
+						href={ `/posts/drafts/${ this.props.site.slug }` }
+						onClick={ this.props.seeAllDraftsClicked }
+					>
+						{ translate( 'See All' ) }
+						{ this.props.draftCount ? <Count count={ this.props.draftCount } /> : null }
+					</Button>
+				</div>
+			</Popover>
+		);
+	}
+
+	renderDrafts() {
+		const { site, drafts } = this.props;
+
+		if ( ! drafts ) {
+			return null;
+		}
+
+		return drafts.map( draft => (
+			<Draft
+				key={ draft.global_ID }
+				post={ draft }
+				siteId={ site.ID }
+				showAuthor={ ! site.single_user_site && ! this.props.userId }
+				onTitleClick={ this.props.draftClicked }
+			/>
+		) );
+	}
+}
+
+// Memoizes the last value of the `draftsQuery` object if the dependencies (userId and siteId)
+// didn't change. Prevents rerenders of the component.
+const getDraftsQuery = createSelector(
+	( state, siteId ) => {
+		const userId = getCurrentUserId( state );
+		const site = getSite( state, siteId );
+
+		return {
+			type: 'post',
+			status: 'draft',
+			number: 5,
+			order_by: 'modified',
+			author: ! site.jetpack && ! site.single_user_site ? userId : null,
+		};
+	},
+	( state, siteId ) => [ getCurrentUserId( state ), getSite( state, siteId ) ]
+);
+
+export default connect( ( state, { siteId } ) => {
+	const draftsQuery = getDraftsQuery( state, siteId );
+
+	return {
+		site: getSite( state, siteId ),
+		draftsQuery,
+		drafts: getPostsForQueryIgnoringPage( state, siteId, draftsQuery ),
+		loadingDrafts: isRequestingPostsForQuery( state, siteId, draftsQuery ),
+	};
+} )( localize( MasterbarDraftsPopover ) );

--- a/client/layout/masterbar/drafts.jsx
+++ b/client/layout/masterbar/drafts.jsx
@@ -10,37 +10,43 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import Popover from 'components/popover';
-import Count from 'components/count';
-import { getMyPostCounts } from 'state/posts/counts/selectors';
-import { getPostsForQueryIgnoringPage, isRequestingPostsForQuery } from 'state/posts/selectors';
-import { newPost } from 'lib/paths';
-import Draft from 'my-sites/draft';
-import QueryPosts from 'components/data/query-posts';
+import AsyncLoad from 'components/async-load';
 import QueryPostCounts from 'components/data/query-post-counts';
 import Button from 'components/button';
-import { getCurrentUserId } from 'state/current-user/selectors';
+import Count from 'components/count';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getMyPostCount } from 'state/posts/counts/selectors';
+
+const MasterbarDraftsPopover = props => (
+	<AsyncLoad { ...props } require="layout/masterbar/drafts-popover" placeholder={ null } />
+);
 
 class MasterbarDrafts extends Component {
 	static propTypes = {
-		user: PropTypes.object,
-		isActive: PropTypes.bool,
-		className: PropTypes.string,
-		tooltip: PropTypes.string,
-		selectedSite: PropTypes.object,
+		selectedSiteId: PropTypes.number,
 	};
 
 	state = {
 		showDrafts: false,
 	};
 
+	preloaded = false;
+
+	// Preload the async chunk on mouse hover or touch start
+	preload = () => {
+		if ( this.preloaded ) {
+			return;
+		}
+
+		asyncRequire( 'layout/masterbar/drafts-popover' );
+		this.preloaded = true;
+	};
+
 	toggleDrafts = () => {
-		const { showDrafts } = this.state;
-		this.setState( {
-			showDrafts: ! showDrafts,
-		} );
+		this.setState( state => ( {
+			showDrafts: ! state.showDrafts,
+		} ) );
 	};
 
 	closeDrafts = () => {
@@ -48,138 +54,87 @@ class MasterbarDrafts extends Component {
 	};
 
 	draftClicked = () => {
-		this.props.recordDraftSelected();
+		this.props.recordTracksEvent( 'calypso_masterbar_draft_selected' );
 		this.closeDrafts();
 	};
 
 	newDraftClicked = () => {
-		this.props.recordNewDraftClicked();
+		this.props.recordTracksEvent( 'calypso_masterbar_drafts_new_draft_clicked' );
 		this.closeDrafts();
 	};
 
 	seeAllDraftsClicked = () => {
-		this.props.recordSeeAllDraftsClicked();
+		this.props.recordTracksEvent( 'calypso_masterbar_drafts_see_all_drafts_clicked' );
 		this.closeDrafts();
 	};
 
-	render() {
-		const { selectedSite, draftCount, loadingDrafts, translate } = this.props;
-		const isLoading = draftCount === 0 && loadingDrafts;
+	setDraftsRef = el => {
+		this.draftsRef = el;
+	};
 
-		if ( ! selectedSite ) {
+	renderButton() {
+		if ( ! this.props.selectedSiteId || ! this.props.draftCount ) {
+			return null;
+		}
+
+		return (
+			<Button
+				compact
+				borderless
+				className="masterbar__toggle-drafts"
+				title={ this.props.translate( 'Latest Drafts' ) }
+				onClick={ this.toggleDrafts }
+				onTouchStart={ this.preload }
+				onMouseEnter={ this.preload }
+				ref={ this.setDraftsRef }
+			>
+				<Count count={ this.props.draftCount } />
+			</Button>
+		);
+	}
+
+	renderPopover() {
+		if ( ! this.state.showDrafts ) {
+			return null;
+		}
+
+		return (
+			<MasterbarDraftsPopover
+				siteId={ this.props.selectedSiteId }
+				draftCount={ this.props.draftCount }
+				context={ this.draftsRef }
+				closeDrafts={ this.closeDrafts }
+				draftClicked={ this.draftClicked }
+				newDraftClicked={ this.newDraftClicked }
+				seeAllDraftsClicked={ this.seeAllDraftsClicked }
+			/>
+		);
+	}
+
+	render() {
+		if ( ! this.props.selectedSiteId ) {
 			return null;
 		}
 
 		return (
 			<div>
-				<QueryPostCounts siteId={ selectedSite.ID } type="post" />
-				{ this.props.draftCount > 0 && (
-					<Button
-						compact
-						borderless
-						className="masterbar__toggle-drafts"
-						onClick={ this.toggleDrafts }
-						ref="drafts"
-						title={ translate( 'Latest Drafts' ) }
-					>
-						<Count count={ this.props.draftCount } />
-					</Button>
-				) }
-				<Popover
-					isVisible={ this.state.showDrafts }
-					onClose={ this.closeDrafts }
-					position="bottom left"
-					context={ this.refs && this.refs.drafts }
-					className="masterbar__recent-drafts"
-				>
-					<QueryPosts siteId={ selectedSite.ID } query={ this.props.draftsQuery } />
-
-					<div className="masterbar__recent-drafts-heading">
-						<h3>{ translate( 'Recent Drafts' ) }</h3>
-
-						<Button
-							compact
-							className="masterbar__recent-drafts-add-new"
-							href={ newPost( selectedSite ) }
-							onClick={ this.newDraftClicked }
-						>
-							{ translate( 'New Draft' ) }
-						</Button>
-					</div>
-
-					<div className="masterbar__recent-drafts-list">
-						{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
-
-						{ isLoading && <Draft isPlaceholder /> }
-
-						<Button
-							compact
-							borderless
-							className="masterbar__recent-drafts-see-all"
-							href={ `/posts/drafts/${ selectedSite.slug }` }
-							onClick={ this.seeAllDraftsClicked }
-						>
-							{ translate( 'See All' ) }
-							{ this.props.draftCount ? <Count count={ this.props.draftCount } /> : null }
-						</Button>
-					</div>
-				</Popover>
+				<QueryPostCounts siteId={ this.props.selectedSiteId } type="post" />
+				{ this.renderButton() }
+				{ this.renderPopover() }
 			</div>
-		);
-	}
-
-	renderDraft( draft ) {
-		if ( ! draft ) {
-			return null;
-		}
-
-		const site = this.props.selectedSite;
-
-		return (
-			<Draft
-				key={ draft.global_ID }
-				post={ draft }
-				siteId={ site && site.ID }
-				showAuthor={ site && ! site.single_user_site && ! this.props.userId }
-				onTitleClick={ this.draftClicked }
-			/>
 		);
 	}
 }
 
-const mapStateToProps = state => {
-	const siteId = getSelectedSiteId( state );
-	const userId = getCurrentUserId( state );
-	const site = getSelectedSite( state );
-	const draftsQuery = {
-		type: 'post',
-		status: 'draft',
-		number: 5,
-		order_by: 'modified',
-		author: site && ! site.jetpack && ! site.single_user_site ? userId : null,
-	};
+export default connect(
+	state => {
+		const selectedSiteId = getSelectedSiteId( state );
+		const draftCount = getMyPostCount( state, selectedSiteId, 'post', 'draft' );
 
-	const myPostCounts = getMyPostCounts( state, siteId, 'post' );
-
-	return {
-		drafts: getPostsForQueryIgnoringPage( state, siteId, draftsQuery ),
-		loadingDrafts: isRequestingPostsForQuery( state, siteId, draftsQuery ),
-		draftsQuery: draftsQuery,
-		draftCount: myPostCounts && myPostCounts.draft,
-		selectedSite: site,
-	};
-};
-
-const mapDispatchToProps = dispatch => ( {
-	recordDraftSelected: () => {
-		dispatch( recordTracksEvent( 'calypso_masterbar_draft_selected' ) );
+		return {
+			selectedSiteId,
+			draftCount,
+		};
 	},
-	recordNewDraftClicked: () => {
-		dispatch( recordTracksEvent( 'calypso_masterbar_drafts_new_draft_clicked' ) );
-	},
-	recordSeeAllDraftsClicked: () => {
-		dispatch( recordTracksEvent( 'calypso_masterbar_drafts_see_all_drafts_clicked' ) );
-	},
-} );
-
-export default connect( mapStateToProps, mapDispatchToProps )( localize( MasterbarDrafts ) );
+	{ recordTracksEvent }
+)( localize( MasterbarDrafts ) );

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -17,7 +17,7 @@ import { newPost } from 'lib/paths';
 import { isMobile } from 'lib/viewport';
 import { preload } from 'sections-preload';
 import { getSelectedSite } from 'state/ui/selectors';
-import AsyncLoad from 'components/async-load';
+import MasterbarDrafts from './drafts';
 
 class MasterbarItemNew extends React.Component {
 	static propTypes = {
@@ -94,7 +94,7 @@ class MasterbarItemNew extends React.Component {
 						position={ this.getPopoverPosition() }
 					/>
 				</MasterbarItem>
-				<AsyncLoad require="layout/masterbar/drafts" placeholder={ null } />
+				<MasterbarDrafts />
 			</div>
 		);
 	}


### PR DESCRIPTION
Divides the masterbar drafts button into two components:
- button that is shown next to "Write" and shows the number of drafts. This component is part of the `build` bundle and is not async loaded.
- popover that is displayed on button click: only after the first click the `drafts-popover` chunk is async loaded and used. The chunk is preloaded on mouseenter or touchstart events to make the clicking experience feel faster.

This reorg prevents a situation where the `async-load-layout-masterbar-drafts` chunk was always async loaded on Calypso load, because it also contained the code for the button, which is always displayed.

Now the async load is postponed until the user actually shows interest in seeing the drafts popover.

There is also an improvement how the `draftsQuery` object is created: instead of creating a new instance on every `mapStateToProps` call (and causing rerenders), the value is memoized using `createSelector`.

**How to test:**
Select a site that has several draft posts and go to "My Sites"

You should see a draft count next to the "Write" button in masterbar:

<img width="134" alt="masterbar-drafts" src="https://user-images.githubusercontent.com/664258/35506514-d17a6eea-04e9-11e8-8a89-4fe95de430e3.png">

In the Network panel, verify that the `async-load-layout-masterbar-drafts` chunk was not loaded from server.

With Network panel still open, verify that the `async-load-layout-masterbar-drafts-popover` chunk gets loaded when your mouse hovers over the drafts button.

After clicking on the button, verify that the popover with drafts list is displayed.

This PR doesn't intend to change any behavior of the Drafts Popover -- it's only the internal implementation that was optimized. Verify that it still works as expected. @shaunandrews and @lsinger did a few design changes recently, so they should be most likely to spot any potential bugs.