### PR TITLE
ensure tours only show on desktop

### DIFF
--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -4,6 +4,7 @@
  * @format
  */
 import page from 'page';
+import { isDesktop } from 'lib/viewport';
 
 /**
  * Internal dependencies
@@ -164,7 +165,7 @@ export function launchTask( { task, location, requestTour, siteSlug, track } ) {
 		page( url );
 	}
 
-	if ( tour ) {
+	if ( tour && isDesktop() ) {
 		requestTour( tour );
 	}
 }


### PR DESCRIPTION
The guided tours for the checklist are not currently working reliably on the checklist page - this change will ensure they do not appear unless on desktop.

# Testing

* View the checklist page on desktop device width
* Trigger any task and verify that the tour is launched
* View the checklist page on mobile device width
* Trigger any task and verify that no tour is launched