### PR TITLE
Translatable: PropType for "translatable strings" instead of only plain strings

### DIFF
--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -23,6 +23,7 @@ import {
 	setDocumentHeadMeta as setMeta,
 	setDocumentHeadUnreadCount as setUnreadCount,
 } from 'state/document-head/actions';
+import TranslatableString from 'components/translatable/proptype';
 
 class DocumentHead extends Component {
 	componentWillMount() {
@@ -117,7 +118,7 @@ class DocumentHead extends Component {
 }
 
 DocumentHead.propTypes = {
-	title: PropTypes.string,
+	title: TranslatableString,
 	unreadCount: PropTypes.number,
 	link: PropTypes.array,
 	meta: PropTypes.array,

--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -18,6 +18,7 @@ import { identity, includes, noop, without } from 'lodash';
  */
 import RootChild from 'components/root-child';
 import { hideDropZone, showDropZone } from 'state/ui/drop-zone/actions';
+import TranslatableString from 'components/translatable/proptype';
 
 export class DropZone extends React.Component {
 	static propTypes = {
@@ -27,7 +28,7 @@ export class DropZone extends React.Component {
 		onDrop: PropTypes.func,
 		onVerifyValidTransfer: PropTypes.func,
 		onFilesDrop: PropTypes.func,
-		textLabel: PropTypes.string,
+		textLabel: TranslatableString,
 		translate: PropTypes.func,
 		showDropZone: PropTypes.func.isRequired,
 		hideDropZone: PropTypes.func.isRequired,

--- a/client/components/forms/form-radio-with-thumbnail/index.jsx
+++ b/client/components/forms/form-radio-with-thumbnail/index.jsx
@@ -11,6 +11,7 @@ import classnames from 'classnames';
  */
 import FormRadio from 'components/forms/form-radio';
 import FormLabel from 'components/forms/form-label';
+import TranslatableString from 'components/translatable/proptype';
 
 const FormRadioWithThumbnail = ( { label, thumbnail, ...otherProps } ) => {
 	const { cssClass, cssColor, imageUrl } = thumbnail;
@@ -32,7 +33,7 @@ const FormRadioWithThumbnail = ( { label, thumbnail, ...otherProps } ) => {
 };
 
 FormRadioWithThumbnail.propTypes = {
-	label: PropTypes.string,
+	label: TranslatableString,
 	thumbnail: PropTypes.object.isRequired,
 };
 

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -18,6 +18,7 @@ import Gridicon from 'gridicons';
 import analytics from 'lib/analytics';
 import Spinner from 'components/spinner';
 import { isMobile } from 'lib/viewport';
+import TranslatableString from 'components/translatable/proptype';
 
 /**
  * Internal variables
@@ -41,7 +42,7 @@ class Search extends Component {
 		additionalClasses: PropTypes.string,
 		initialValue: PropTypes.string,
 		value: PropTypes.string,
-		placeholder: PropTypes.string,
+		placeholder: TranslatableString,
 		pinned: PropTypes.bool,
 		delaySearch: PropTypes.bool,
 		delayTimeout: PropTypes.number,

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -17,6 +17,7 @@ import DropdownItem from 'components/select-dropdown/item';
 import SelectDropdown from 'components/select-dropdown';
 import { getWindowInnerWidth } from 'lib/viewport';
 import afterLayoutFlush from 'lib/after-layout-flush';
+import TranslatableString from 'components/translatable/proptype';
 
 /**
  * Internal Variables
@@ -28,7 +29,7 @@ const MOBILE_PANEL_THRESHOLD = 480;
  */
 class NavTabs extends Component {
 	static propTypes = {
-		selectedText: PropTypes.string,
+		selectedText: TranslatableString,
 		selectedCount: PropTypes.number,
 		label: PropTypes.string,
 		hasSiblingControls: PropTypes.bool,
@@ -115,7 +116,6 @@ class NavTabs extends Component {
 				</DropdownItem>
 			);
 		} );
-
 		return (
 			<SelectDropdown
 				className="section-nav-tabs__dropdown"

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -18,13 +18,14 @@ import DropdownItem from 'components/select-dropdown/item';
 import DropdownSeparator from 'components/select-dropdown/separator';
 import DropdownLabel from 'components/select-dropdown/label';
 import Count from 'components/count';
+import TranslatableString from 'components/translatable/proptype';
 
 /**
  * SelectDropdown
  */
 class SelectDropdown extends Component {
 	static propTypes = {
-		selectedText: PropTypes.string,
+		selectedText: TranslatableString,
 		selectedIcon: PropTypes.element,
 		selectedCount: PropTypes.number,
 		initialSelected: PropTypes.string,
@@ -37,7 +38,7 @@ class SelectDropdown extends Component {
 		options: PropTypes.arrayOf(
 			PropTypes.shape( {
 				value: PropTypes.string.isRequired,
-				label: PropTypes.string.isRequired,
+				label: TranslatableString.isRequired,
 				path: PropTypes.string,
 				icon: PropTypes.element,
 			} )

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -13,10 +13,11 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import Count from 'components/count';
+import TranslatableString from 'components/translatable/proptype';
 
 class SelectDropdownItem extends Component {
 	static propTypes = {
-		children: PropTypes.string.isRequired,
+		children: TranslatableString.isRequired,
 		compactCount: PropTypes.bool,
 		path: PropTypes.string,
 		isDropdownOpen: PropTypes.bool,

--- a/client/components/sidebar-navigation/index.jsx
+++ b/client/components/sidebar-navigation/index.jsx
@@ -14,6 +14,7 @@ import Gridicon from 'gridicons';
  */
 import { getDocumentHeadTitle } from 'state/document-head/selectors';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import TranslatableString from 'components/translatable/proptype';
 
 class SidebarNavigation extends React.Component {
 	constructor( props ) {
@@ -47,7 +48,7 @@ class SidebarNavigation extends React.Component {
 SidebarNavigation.propTypes = {
 	title: PropTypes.string,
 	linkClassName: PropTypes.string,
-	sectionTitle: PropTypes.string,
+	sectionTitle: TranslatableString,
 	sectionName: PropTypes.string.isRequired,
 	setLayoutFocus: PropTypes.func.isRequired,
 };

--- a/client/components/sidebar-navigation/index.jsx
+++ b/client/components/sidebar-navigation/index.jsx
@@ -46,7 +46,7 @@ class SidebarNavigation extends React.Component {
 }
 
 SidebarNavigation.propTypes = {
-	title: PropTypes.string,
+	title: TranslatableString,
 	linkClassName: PropTypes.string,
 	sectionTitle: TranslatableString,
 	sectionName: PropTypes.string.isRequired,

--- a/client/components/translatable/proptype.js
+++ b/client/components/translatable/proptype.js
@@ -3,9 +3,9 @@
 function translatableStringChecker( props, propName, componentName ) {
 	componentName = componentName || 'ANONYMOUS';
 
-	if ( props[ propName ] ) {
-		const value = props[ propName ];
-		if ( 'string' === typeof props[ propName ] ) {
+	const value = props[ propName ];
+	if ( value !== undefined && value !== null ) {
+		if ( 'string' === typeof value ) {
 			return null;
 		}
 
@@ -37,7 +37,7 @@ function translatableStringChecker( props, propName, componentName ) {
 function createChainableTypeChecker( validate ) {
 	function checkType( isRequired, props, propName, componentName, location ) {
 		componentName = componentName || 'ANONYMOUS';
-		if ( props[ propName ] == null ) {
+		if ( props[ propName ] === undefined ) {
 			if ( isRequired ) {
 				return new Error(
 					'Required ' +

--- a/client/components/translatable/proptype.js
+++ b/client/components/translatable/proptype.js
@@ -1,0 +1,56 @@
+/** @format */
+
+function translatableStringChecker( props, propName, componentName ) {
+	componentName = componentName || 'ANONYMOUS';
+
+	if ( props[ propName ] ) {
+		const value = props[ propName ];
+		if ( 'string' === typeof props[ propName ] ) {
+			return null;
+		}
+
+		if (
+			'object' === typeof value &&
+			'function' === typeof value.type &&
+			'data' === value.type.name
+		) {
+			return null;
+		}
+
+		return new Error(
+			'Invalid value for Translatable string in `' +
+				componentName +
+				'`. Please pass a translate() call.'
+		);
+	}
+
+	// assume all ok
+	return null;
+}
+
+function createChainableTypeChecker( validate ) {
+	function checkType( isRequired, props, propName, componentName, location ) {
+		componentName = componentName || 'ANONYMOUS';
+		if ( props[ propName ] == null ) {
+			if ( isRequired ) {
+				return new Error(
+					'Required ' +
+						location +
+						' `' +
+						propName +
+						'` was not specified in ' +
+						( '`' + componentName + '`.' )
+				);
+			}
+			return null;
+		}
+		return validate( props, propName, componentName, location );
+	}
+
+	const chainedCheckType = checkType.bind( null, false );
+	chainedCheckType.isRequired = checkType.bind( null, true );
+
+	return chainedCheckType;
+}
+
+export default createChainableTypeChecker( translatableStringChecker );

--- a/client/components/translatable/proptype.js
+++ b/client/components/translatable/proptype.js
@@ -11,8 +11,9 @@ function translatableStringChecker( props, propName, componentName ) {
 
 		if (
 			'object' === typeof value &&
-			'function' === typeof value.type &&
-			'data' === value.type.name
+			'data' === value.type
+			// 'function' === typeof value.type &&
+			// 'Translatable' === value.type.name
 		) {
 			return null;
 		}

--- a/client/components/translatable/proptype.js
+++ b/client/components/translatable/proptype.js
@@ -9,11 +9,16 @@ function translatableStringChecker( props, propName, componentName ) {
 			return null;
 		}
 
+		// Translator Jumpstart old-style
+		if ( 'object' === typeof value && 'data' === value.type ) {
+			return null;
+		}
+
+		// Translator Jumpstart after #21591
 		if (
 			'object' === typeof value &&
-			'data' === value.type
-			// 'function' === typeof value.type &&
-			// 'Translatable' === value.type.name
+			'function' === typeof value.type &&
+			'Translatable' === value.type.name
 		) {
 			return null;
 		}

--- a/client/components/translatable/test/proptype.js
+++ b/client/components/translatable/test/proptype.js
@@ -44,8 +44,7 @@ describe( 'translatable proptype', () => {
 	} );
 
 	test( 'should fail on numbers', () => {
-		// should it fail on '0'?
-		// assertFails( translatableString, <legend translatableString={ 0 } /> );
+		assertFails( translatableString, <legend translatableString={ 0 } /> );
 		assertFails( translatableString, <legend translatableString={ 2 } /> );
 	} );
 
@@ -55,11 +54,16 @@ describe( 'translatable proptype', () => {
 	test( 'should fail on unexpected objects', () =>
 		assertFails( translatableString, <legend translatableString={ {} } /> ) );
 
-	it( 'should pass with valid value when required', () =>
+	it( 'should pass with valid value when required', () => {
 		assertPasses(
 			translatableString.isRequired,
 			<legend translatableString={ <Translatable /> } />
-		) );
+		);
+		assertPasses(
+			translatableString.isRequired,
+			<legend translatableString={ 'Los pollos hermanos' } />
+		);
+	} );
 
 	it( 'should fail when required', () => assertFails( translatableString.isRequired, <legend /> ) );
 } );

--- a/client/components/translatable/test/proptype.js
+++ b/client/components/translatable/test/proptype.js
@@ -1,0 +1,65 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+
+import translatableString from '../proptype';
+
+function assertPasses( validator, { props }, propName = 'translatableString' ) {
+	expect( validator( props, 'translatableString', propName ) ).toBeNull();
+}
+
+function assertFails( validator, { props }, propName = 'translatableString' ) {
+	expect( validator( props, propName ) ).toBeInstanceOf( Error );
+}
+
+const Translatable = () => <span />;
+
+describe( 'translatable proptype', () => {
+	test( 'should pass when no propType Name declared', () => {
+		assertPasses( translatableString, <legend />, '' );
+	} );
+
+	test( 'should pass with string ', () =>
+		assertPasses( translatableString, <legend translatableString={ 'Los pollos hermanos' } /> ) );
+
+	test( 'should pass with <Translatable /> component ', () =>
+		assertPasses( translatableString, <legend translatableString={ <Translatable /> } /> ) );
+
+	test( 'should pass on <data /> object', () =>
+		assertPasses( translatableString, Object.assign( {}, <data /> ) ) );
+
+	test( 'should pass on nil/false values', () => {
+		assertPasses( translatableString, <legend translatableString={ null } /> );
+		assertPasses( translatableString, <legend translatableString={ undefined } /> );
+	} );
+
+	test( 'should fail on numbers', () => {
+		// should it fail on '0'?
+		// assertFails( translatableString, <legend translatableString={ 0 } /> );
+		assertFails( translatableString, <legend translatableString={ 2 } /> );
+	} );
+
+	test( 'should fail on unexpected functions', () =>
+		assertFails( translatableString, <legend translatableString={ function() {} } /> ) );
+
+	test( 'should fail on unexpected objects', () =>
+		assertFails( translatableString, <legend translatableString={ {} } /> ) );
+
+	it( 'should pass with valid value when required', () =>
+		assertPasses(
+			translatableString.isRequired,
+			<legend translatableString={ <Translatable /> } />
+		) );
+
+	it( 'should fail when required', () => assertFails( translatableString.isRequired, <legend /> ) );
+} );

--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -9,12 +9,13 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { isFunction, noop } from 'lodash';
 import Gridicon from 'gridicons';
+import TranslatableString from 'components/translatable/proptype';
 
 class MasterbarItem extends Component {
 	static propTypes = {
 		url: PropTypes.string,
 		onClick: PropTypes.func,
-		tooltip: PropTypes.string,
+		tooltip: TranslatableString,
 		icon: PropTypes.string,
 		className: PropTypes.string,
 		isActive: PropTypes.bool,

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -88,9 +88,7 @@ class MasterbarLoggedIn extends React.Component {
 					icon={ this.wordpressIcon() }
 					onClick={ this.clickMySites }
 					isActive={ this.isActive( 'sites' ) }
-					tooltip={ translate( 'View a list of your sites and access their dashboards', {
-						textOnly: true,
-					} ) }
+					tooltip={ translate( 'View a list of your sites and access their dashboards' ) }
 					preloadSection={ this.preloadMySites }
 				>
 					{ this.props.user.get().site_count > 1
@@ -104,7 +102,7 @@ class MasterbarLoggedIn extends React.Component {
 					icon="reader"
 					onClick={ this.clickReader }
 					isActive={ this.isActive( 'reader' ) }
-					tooltip={ translate( 'Read the blogs and topics you follow', { textOnly: true } ) }
+					tooltip={ translate( 'Read the blogs and topics you follow' ) }
 					preloadSection={ this.preloadReader }
 				>
 					{ translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
@@ -115,7 +113,7 @@ class MasterbarLoggedIn extends React.Component {
 						user={ this.props.user }
 						isActive={ this.isActive( 'post' ) }
 						className="masterbar__item-new"
-						tooltip={ translate( 'Create a New Post', { textOnly: true } ) }
+						tooltip={ translate( 'Create a New Post' ) }
 					>
 						{ translate( 'Write' ) }
 					</Publish>
@@ -127,9 +125,7 @@ class MasterbarLoggedIn extends React.Component {
 					onClick={ this.clickMe }
 					isActive={ this.isActive( 'me' ) }
 					className="masterbar__item-me"
-					tooltip={ translate( 'Update your profile, personal settings, and more', {
-						textOnly: true,
-					} ) }
+					tooltip={ translate( 'Update your profile, personal settings, and more' ) }
 					preloadSection={ this.preloadMe }
 				>
 					<Gravatar user={ this.props.user.get() } alt="Me" size={ 18 } />
@@ -142,7 +138,7 @@ class MasterbarLoggedIn extends React.Component {
 					isShowing={ this.props.isNotificationsShowing }
 					isActive={ this.isActive( 'notifications' ) }
 					className="masterbar__item-notifications"
-					tooltip={ translate( 'Manage your notifications', { textOnly: true } ) }
+					tooltip={ translate( 'Manage your notifications' ) }
 				>
 					<span className="masterbar__item-notifications-label">
 						{ translate( 'Notifications', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }

--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -20,13 +20,14 @@ import store from 'store';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { toggleNotificationsPanel } from 'state/ui/actions';
 import { isNotificationsOpen } from 'state/selectors';
+import TranslatableString from 'components/translatable/proptype';
 
 class MasterbarItemNotifications extends Component {
 	static propTypes = {
 		user: PropTypes.object.isRequired,
 		isActive: PropTypes.bool,
 		className: PropTypes.string,
-		tooltip: PropTypes.string,
+		tooltip: TranslatableString,
 		//connected
 		isNotificationsOpen: PropTypes.bool,
 	};

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -19,13 +19,14 @@ import { preload } from 'sections-preload';
 import { getSelectedSite } from 'state/ui/selectors';
 import MasterbarDrafts from './drafts';
 import { isRtl as isRtlSelector } from 'state/selectors';
+import TranslatableString from 'components/translatable/proptype';
 
 class MasterbarItemNew extends React.Component {
 	static propTypes = {
 		user: PropTypes.object,
 		isActive: PropTypes.bool,
 		className: PropTypes.string,
-		tooltip: PropTypes.string,
+		tooltip: TranslatableString,
 		// connected props
 		selectedSite: PropTypes.object,
 	};

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -14,10 +14,11 @@ import Gridicon from 'gridicons';
  */
 import { isExternal } from 'lib/url';
 import { preload } from 'sections-preload';
+import TranslatableString from 'components/translatable/proptype';
 
 export default class SidebarItem extends React.Component {
 	static propTypes = {
-		label: PropTypes.string.isRequired,
+		label: TranslatableString.isRequired,
 		className: PropTypes.string,
 		link: PropTypes.string.isRequired,
 		onNavigate: PropTypes.func,

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -91,6 +91,12 @@ const communityTranslatorJumpstart = {
 			return displayedTranslationFromPage;
 		}
 
+		if ( 'boolean' === typeof optionsFromPage.textOnly && optionsFromPage.textOnly ) {
+			debug( 'respecting textOnly for string "' + originalFromPage + '"' );
+			return displayedTranslationFromPage;
+		}
+
+		const original_string = {};
 		const props = {
 			className: 'translatable',
 			'data-singular': originalFromPage,

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -39,7 +39,7 @@ const user = new User(),
  * Local variables
  */
 
-var injectUrl,
+let injectUrl,
 	initialized,
 	previousEnabledSetting,
 	_shouldWrapTranslations = false;
@@ -96,7 +96,6 @@ const communityTranslatorJumpstart = {
 			return displayedTranslationFromPage;
 		}
 
-		const original_string = {};
 		const props = {
 			className: 'translatable',
 			'data-singular': originalFromPage,

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -175,7 +175,7 @@ export class Login extends React.Component {
 					{ this.renderLocaleSuggestions() }
 
 					<DocumentHead
-						title={ translate( 'Log In', { textOnly: true } ) }
+						title={ translate( 'Log In' ) }
 						link={ [ { rel: 'canonical', href: canonicalUrl } ] }
 					/>
 

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -166,9 +166,7 @@ const ConnectedApplications = createReactClass( {
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<MeSidebarNavigation />
 
-				<DocumentHead
-					title={ this.props.translate( 'Connected Applications', { textOnly: true } ) }
-				/>
+				<DocumentHead title={ this.props.translate( 'Connected Applications' ) } />
 
 				{ this.renderConnectedAppsList() }
 			</Main>

--- a/client/me/get-apps/apps-badge.jsx
+++ b/client/me/get-apps/apps-badge.jsx
@@ -15,6 +15,7 @@ import classNames from 'classnames';
  */
 import { getLocaleSlug } from 'lib/i18n-utils';
 import { recordTracksEvent } from 'state/analytics/actions';
+import TranslatableString from 'components/translatable/proptype';
 
 // the locale slugs for each stores' image paths follow different rules
 // therefore we have to perform some trickery in getLocaleSlug()
@@ -40,10 +41,10 @@ const APP_STORE_BADGE_URLS = {
 
 export class AppsBadge extends PureComponent {
 	static propTypes = {
-		altText: PropTypes.string,
+		altText: TranslatableString,
 		storeLink: PropTypes.string,
 		storeName: PropTypes.oneOf( [ 'ios', 'android' ] ).isRequired,
-		titleText: PropTypes.string,
+		titleText: TranslatableString,
 		translate: PropTypes.func,
 	};
 

--- a/client/me/security-account-recovery/index.jsx
+++ b/client/me/security-account-recovery/index.jsx
@@ -59,7 +59,7 @@ const SecurityAccountRecovery = props => (
 
 		<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
-		<DocumentHead title={ props.translate( 'Account Recovery', { textOnly: true } ) } />
+		<DocumentHead title={ props.translate( 'Account Recovery' ) } />
 
 		<CompactCard>
 			<p className="security-account-recovery__text">

--- a/client/me/security-section-nav/index.jsx
+++ b/client/me/security-section-nav/index.jsx
@@ -27,28 +27,28 @@ export default class extends React.Component {
 	getNavtabs = () => {
 		const tabs = [
 			{
-				title: i18n.translate( 'Password', { textOnly: true } ),
+				title: i18n.translate( 'Password' ),
 				path: '/me/security',
 			},
 			config.isEnabled( 'signup/social-management' )
 				? {
-						title: i18n.translate( 'Social Login', { textOnly: true } ),
+						title: i18n.translate( 'Social Login' ),
 						path: '/me/security/social-login',
 					}
 				: null,
 			{
-				title: i18n.translate( 'Two-Step Authentication', { textOnly: true } ),
+				title: i18n.translate( 'Two-Step Authentication' ),
 				path: '/me/security/two-step',
 			},
 			{
 				title: config.isEnabled( 'signup/social-management' )
 					? // This was shortened from 'Connected Applications' due to space constraints.
-						i18n.translate( 'Connected Apps', { textOnly: true } )
-					: i18n.translate( 'Connected Applications', { textOnly: true } ),
+						i18n.translate( 'Connected Apps' )
+					: i18n.translate( 'Connected Applications' ),
 				path: '/me/security/connected-applications',
 			},
 			{
-				title: i18n.translate( 'Account Recovery', { textOnly: true } ),
+				title: i18n.translate( 'Account Recovery' ),
 				path: '/me/security/account-recovery',
 			},
 		].filter( tab => tab !== null );
@@ -67,7 +67,7 @@ export default class extends React.Component {
 			found = find( this.getNavtabs(), { path: filteredPath } );
 
 		if ( 'undefined' !== typeof found ) {
-			text = found.title;
+			text = String( found.title );
 		}
 
 		return text;

--- a/client/me/security/main.jsx
+++ b/client/me/security/main.jsx
@@ -43,7 +43,7 @@ class Security extends React.Component {
 
 		return (
 			<Main className="security">
-				<DocumentHead title={ translate( 'Password', { textOnly: true } ) } />
+				<DocumentHead title={ translate( 'Password' ) } />
 				<MeSidebarNavigation />
 
 				<SecuritySectionNav path={ this.props.path } />

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -123,7 +123,7 @@ class MeSidebar extends React.Component {
 							compact
 							className="sidebar__me-signout-button"
 							onClick={ this.onSignOut }
-							title={ translate( 'Sign out of WordPress.com', { textOnly: true } ) }
+							title={ translate( 'Sign out of WordPress.com' ) }
 						>
 							{ translate( 'Sign Out' ) }
 						</Button>
@@ -211,7 +211,6 @@ class MeSidebar extends React.Component {
 						</ul>
 					</SidebarMenu>
 				</SidebarRegion>
-
 				<SidebarFooter />
 			</Sidebar>
 		);

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -151,7 +151,7 @@ class SocialLogin extends Component {
 	}
 
 	render() {
-		const title = this.props.translate( 'Social Login', { textOnly: true } );
+		const title = this.props.translate( 'Social Login' );
 
 		return (
 			<Main className="social-login">

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -156,9 +156,7 @@ class TwoStep extends Component {
 
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
-				<DocumentHead
-					title={ this.props.translate( 'Two-Step Authentication', { textOnly: true } ) }
-				/>
+				<DocumentHead title={ this.props.translate( 'Two-Step Authentication' ) } />
 
 				<Card>{ this.renderTwoStepSection() }</Card>
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -102,7 +102,7 @@ class CurrentPlan extends Component {
 		return (
 			<Main className="current-plan" wideLayout>
 				<SidebarNavigation />
-				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
+				<DocumentHead title={ translate( 'Plans' ) } />
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }

--- a/client/reader/sidebar/expandable-add-form.jsx
+++ b/client/reader/sidebar/expandable-add-form.jsx
@@ -13,11 +13,12 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import Button from 'components/button';
+import TranslatableString from 'components/translatable/proptype';
 
 export class ExpandableSidebarAddForm extends Component {
 	static propTypes = {
-		addLabel: PropTypes.string,
-		addPlaceholder: PropTypes.string,
+		addLabel: TranslatableString,
+		addPlaceholder: TranslatableString,
 		onAddSubmit: PropTypes.func,
 		onAddClick: PropTypes.func,
 		hideAddButton: PropTypes.bool,

--- a/client/reader/sidebar/expandable-heading.jsx
+++ b/client/reader/sidebar/expandable-heading.jsx
@@ -12,6 +12,7 @@ import React from 'react';
  */
 import Count from 'components/count';
 import SidebarHeading from 'layout/sidebar/heading';
+import TranslatableString from 'components/translatable/proptype';
 
 const ExpandableSidebarHeading = ( { title, count, onClick } ) => (
 	<SidebarHeading onClick={ onClick }>
@@ -22,7 +23,7 @@ const ExpandableSidebarHeading = ( { title, count, onClick } ) => (
 );
 
 ExpandableSidebarHeading.propTypes = {
-	title: PropTypes.string.isRequired,
+	title: TranslatableString.isRequired,
 	count: PropTypes.number,
 	onClick: PropTypes.func,
 };

--- a/client/reader/sidebar/expandable.jsx
+++ b/client/reader/sidebar/expandable.jsx
@@ -12,6 +12,7 @@ import React from 'react';
 import ExpandableSidebarAddForm from './expandable-add-form';
 import ExpandableSidebarHeading from './expandable-heading';
 import SidebarMenu from 'layout/sidebar/menu';
+import TranslatableString from 'components/translatable/proptype';
 
 export const ExpandableSidebarMenu = props => {
 	const {
@@ -48,8 +49,8 @@ export const ExpandableSidebarMenu = props => {
 ExpandableSidebarMenu.propTypes = {
 	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ).isRequired,
 	count: PropTypes.number,
-	addLabel: PropTypes.string,
-	addPlaceholder: PropTypes.string,
+	addLabel: TranslatableString,
+	addPlaceholder: TranslatableString,
 	onAddSubmit: PropTypes.func,
 	onAddClick: PropTypes.func,
 	onClick: PropTypes.func,


### PR DESCRIPTION
This addresses warnings like
```
Warning: Failed prop type: Invalid prop `sectionTitle` of type `object` supplied to `SidebarNavigation`, expected `string`.
```

When the Community Translator is activated the return value of `translate()` is not guaranteed to be a `string` but can be a React component, thus a `PropTypes.string` check fails.

By introducing a new PropType that allows both a string and a component named ~`Translatable`~ `data`, we can still guarantee the correctness of the prop.

This also re-introduces support for `textOnly` (whose error message was useful to remove still existing textOnly uses) but we might be able to remove this as well.