### PR TITLE
Stop bundling the whole Redux Form library in the 'build' chunk

### DIFF
--- a/client/state/index.js
+++ b/client/state/index.js
@@ -6,7 +6,11 @@
 
 import thunkMiddleware from 'redux-thunk';
 import { createStore, applyMiddleware, compose } from 'redux';
-import { reducer as form } from 'redux-form';
+// import the reducer directly from a submodule to prevent bundling the whole Redux Form
+// library into the `build` chunk.
+// TODO: change this back to `from 'redux-form'` after upgrade to Webpack 4.0 and a version
+//       of Redux Form that uses the `sideEffects: false` flag
+import form from 'redux-form/es/reducer';
 import { mapValues } from 'lodash';
 
 /**

--- a/test/client/jest.config.json
+++ b/test/client/jest.config.json
@@ -12,6 +12,7 @@
 		"<rootDir>/client/"
 	],
 	"testEnvironment": "node",
+	"transformIgnorePatterns": ["node_modules[\\/\\\\](?!redux-form|lodash-es)"],
 	"testMatch": [ "<rootDir>/client/**/test/*.js?(x)" ],
 	"testURL": "https://example.com",
 	"setupTestFrameworkScriptFile": "<rootDir>/test/client/setup-test-framework.js",


### PR DESCRIPTION
This patch is an alternative (and much simpler) way how to implement the changes attempted in #21203.

From the Redux Form library, only the reducer is used in the `build` chunk. That's why we import it there directly from the `redux-form/es/reducer` submodule.

Everything else (selectors, React components, ...) will be moved into the chunks that use these parts of the library and should pay the costs.

This is how the chunk sizes are affected:
```
chunk           stat_size             parsed_size             gzip_size
build           -189913 B    (-4.9%)     -62707 B    (-3.8%)   -14073 B    (-3.5%)
devdocs         +190264 B    (+5.7%)     +70328 B    (+3.5%)   +15203 B    (+3.7%)
manifest             +0 B                    +0 B                  -1 B    (-0.0%)
post-editor     +190264 B    (+4.5%)     +70328 B    (+4.3%)   +15113 B    (+3.6%)
wp-job-manager  +190264 B  (+109.3%)     +70328 B   (+81.6%)   +15563 B   (+83.4%)
zoninator       +190264 B  (+132.0%)     +70328 B  (+106.5%)   +15551 B  (+106.5%)
```

Why do we need to do tricks like this and why doesn't it "just work" out of the box with tree shaking? And why did @dmsnell's attempt to remove the selector import transforms in #21811 inflate the `build` size again? There are two reasons.

The first is that Webpack cannot split a single module into multiple parts and ship them separately in different chunks. For example, a module like this:
```js
// used only in `build` code
export utilFoo = () => { ... }
// used only in `stats` code
export utilBar = () => { ... }
// not used anywhere
export utilBaz = () => { ... }
```
will be bundled as a whole in the `build` chunk, because that chunk uses at least one function from it. The `stats` chunk will not ship the `utilBar` function separately, but will use the copy that's bundled in `build`. All that Webpack can do (in cooperation with UglifyJS) is to drop the `utilBaz` function that's not imported anywhere.

The second reason is related to a special kind of modules that are often used as `index.js` in libraries like Lodash or Redux Form:
```
export { reducer } from './reducer';
export { Field } from './Field';
export { FieldArray } from './FieldArray';
```
They don't contain any real code -- they just reexport submodules under different names.

Webpack doesn't work very well with modules like this. Not only it will bundle the whole module into `build` every time a single export is used there, but it will even fail to shake off the unused submodules. If the `FieldArray` above wasn't imported anywhere, it would still be shipped.

Why? Because module imports can have side effects. The `./FieldArray.js` module can add something to `window`, call some other functions etc. Webpack must perform the import, because it cannot know if there are side effects or not. And once a module is imported, it cannot be removed by tree shaking.

Webpack 4 has a solution to this: if a module specifies a `sideEffects` flag in its `package.json`:
```json
{
  "sideEffects": false
}
```
that's a hint for Webpack that it can optimize the unused imports away. I tested this feature on a toy project with version 4.0.0-beta.0 and it works beautifully! 🌲 👍 