### PR TITLE
Simplify the getSiteBySlug selector: avoid parseInt call

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -58,12 +58,7 @@ export const getRawSite = ( state, siteId ) => {
  */
 export const getSiteBySlug = createSelector(
 	( state, siteSlug ) =>
-		find(
-			getSitesItems( state ),
-			( item, siteId ) =>
-				// find always passes the siteId as a string. We need it as a integer
-				getSiteSlug( state, parseInt( siteId, 10 ) ) === siteSlug
-		) || null,
+		find( getSitesItems( state ), site => getSiteSlug( state, site.ID ) === siteSlug ) || null,
 	getSitesItems
 );
 


### PR DESCRIPTION
`Object.keys` converts all numeric keys of an object to strings. Therefore, all
Lodash functions that use it (`find`, `findKey`, `map`, `mapValues`, ...) pass
a string to their callbacks.

Avoid looking at the `key` param by directly using `site.ID`. Should make the selector
a little bit faster, too.