### PR TITLE
Fix: Checklist: some guided tours are not working in wpcalypso.

### DIFF
--- a/client/layout/guided-tours/config-elements/continue.js
+++ b/client/layout/guided-tours/config-elements/continue.js
@@ -16,6 +16,8 @@ import { targetForSlug } from '../positioning';
 import contextTypes from '../context-types';
 
 export default class Continue extends Component {
+	static displayName = 'Continue';
+
 	static contextTypes = contextTypes;
 
 	static propTypes = {

--- a/client/layout/guided-tours/config-elements/link-quit.js
+++ b/client/layout/guided-tours/config-elements/link-quit.js
@@ -16,6 +16,8 @@ import Button from 'components/button';
 import contextTypes from '../context-types';
 
 export default class LinkQuit extends Component {
+	static displayName = 'LinkQuit';
+
 	static propTypes = {
 		primary: PropTypes.bool,
 		subtle: PropTypes.bool,

--- a/client/layout/guided-tours/config-elements/link.js
+++ b/client/layout/guided-tours/config-elements/link.js
@@ -12,6 +12,8 @@ import React, { Component } from 'react';
 import ExternalLink from 'components/external-link';
 
 class Link extends Component {
+	static displayName = 'Link';
+
 	constructor( props ) {
 		super( props );
 	}

--- a/client/layout/guided-tours/config-elements/next.js
+++ b/client/layout/guided-tours/config-elements/next.js
@@ -15,6 +15,8 @@ import Button from 'components/button';
 import contextTypes from '../context-types';
 
 export default class Next extends Component {
+	static displayName = 'Next';
+
 	static propTypes = {
 		step: PropTypes.string.isRequired,
 	};

--- a/client/layout/guided-tours/config-elements/quit.js
+++ b/client/layout/guided-tours/config-elements/quit.js
@@ -15,6 +15,8 @@ import Button from 'components/button';
 import contextTypes from '../context-types';
 
 export default class Quit extends Component {
+	static displayName = 'Quit';
+
 	static propTypes = {
 		primary: PropTypes.bool,
 		subtle: PropTypes.bool,

--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -33,6 +33,8 @@ const anyFrom = obj => {
 };
 
 export default class Step extends Component {
+	static displayName = 'Step';
+
 	static propTypes = {
 		name: PropTypes.string.isRequired,
 		placement: PropTypes.oneOf( [ 'below', 'above', 'beside', 'center', 'middle', 'right' ] ),

--- a/client/layout/guided-tours/config-parsing.js
+++ b/client/layout/guided-tours/config-parsing.js
@@ -60,7 +60,8 @@ const branching = element => {
 	}
 
 	if ( element.props.step ) {
-		return [ element.type.name.toLowerCase(), element.props.step ];
+		const typeName = element.type.displayName || element.type.name;
+		return [ typeName.toLowerCase(), element.props.step ];
 	}
 
 	return flatMap( Children.toArray( element.props.children ), c => branching( c ) || [] );


### PR DESCRIPTION
Some Guided Tour steps won't work in production. Because most React components renamed to `t` in stage/production, the Guided Tour config parser does not properly detect the children's name of each `Step` component. In the consequence of that, GT works as if it has no children components and sometimes steps don't appear.

This PR will resolve #20915 

## How to test

1. You need to build a docker image of Calypso first. It will take a long time. Go grab your coffee ☕️ 😄 
2. Run the image in wpcalypso environment:
```
docker run -it --name wp-calypso --rm -p 80:3000 -e NODE_ENV='production' -e CALYPSO_ENV='wpcalypso' wp-calypso
```
3. Point `wpcalypso.wordpress.com` to `127.0.0.1`
4. Create a new website and move to `/checklist/YOUR_SITE_DOMAIN`.
5. Follow the `Personalize your Contact page` tour.
6. See if the second step appears as follows:
<img width="1037" alt="2018-01-29 11 19 14" src="https://user-images.githubusercontent.com/212034/35514857-e329e8a8-054a-11e8-871a-b65366927b5b.png">

cc @markryall @fditrapani 