### PR TITLE
Fix: decode ampersand in author name on stats & followers page

### DIFF
--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 import { get } from 'lodash';
 import { recordTrack } from 'reader/stats';
 import page from 'page';
+import { decodeEntities } from 'lib/formatting';
 
 /**
  * Internal dependencies
@@ -135,12 +136,12 @@ class PeopleProfile extends React.PureComponent {
 			name = (
 				<div className="people-profile__username">
 					<a href={ user.url } onClick={ this.handleLinkToReaderSiteStream }>
-						{ name }
+						{ decodeEntities( name ) }
 					</a>
 				</div>
 			);
 		} else if ( name ) {
-			name = <div className="people-profile__username">{ name }</div>;
+			name = <div className="people-profile__username">{ decodeEntities( name ) }</div>;
 		}
 		return name;
 	};

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -256,7 +256,7 @@ class StatsListItem extends React.Component {
 				}
 				itemLabel = (
 					<a onClick={ onClickHandler } href={ href }>
-						{ labelItem.label }
+						{ decodeEntities( labelItem.label ) }
 					</a>
 				);
 			} else {

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -24,6 +24,7 @@ import analytics from 'lib/analytics';
 import Gridicon from 'gridicons';
 import { get } from 'lodash';
 import { recordTrack } from 'reader/stats';
+import { decodeEntities } from 'lib/formatting';
 
 class StatsListItem extends React.Component {
 	static displayName = 'StatsListItem';
@@ -259,7 +260,7 @@ class StatsListItem extends React.Component {
 					</a>
 				);
 			} else {
-				itemLabel = <Emojify>{ labelItem.label }</Emojify>;
+				itemLabel = <Emojify>{ decodeEntities( labelItem.label ) }</Emojify>;
 			}
 
 			return (


### PR DESCRIPTION
This PR will resolve issue [#21296](https://github.com/Automattic/wp-calypso/issues/21296)

**To test:**
1. Starting at URL: https://some-domain.com/me
2. Change your display name to something with an ampersand (&) and save
3. Go to a site you manage, and visit:
4. People > Followers; AND
5. Your stats page, under the Authors box
6. Check your name

cc @samouri