### PR TITLE
Editor: Don't break shortcodes when they're selected in the editor

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -69,7 +69,7 @@ import { isSitePreviewable } from 'state/sites/selectors';
 import { removep } from 'lib/formatting';
 import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-buttons';
 import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
-import { regexp as ShortCodeRegexp } from 'lib/shortcode';
+import { regexp as shortCodeRegexp } from 'lib/shortcode';
 
 export const PostEditor = createReactClass( {
 	displayName: 'PostEditor',
@@ -1183,7 +1183,7 @@ export const PostEditor = createReactClass( {
 			return [];
 		}
 
-		const shortcodeDetailsRegexp = ShortCodeRegexp( allShortcodes.join( '|' ) );
+		const shortcodeDetailsRegexp = shortCodeRegexp( allShortcodes.join( '|' ) );
 		const shortcodesDetails = [];
 
 		let shortcodeInfo;


### PR DESCRIPTION
This PR backports some of the WordPress.org core functionality that keeps the editor selection when switching between Visual and HTML modes. 

Originally reported in https://core.trac.wordpress.org/ticket/42908

The code in Calypso was an earlier version of the code that shipped in WordPress.org and didn't take in account how shortcodes work. This resulted in the selection marker being inserted in the middle of a shortcode, which broke shortcodes that had live rendering enabled for them (e.g. Gallery).

The way it was handled in Core was to move the cursor/s to the edge of the shortcode, if it was inside a shortcode. This way the whole shortcode is selected, to avoid inserting the marker inside the shortcode and therefore breaking it when switching to Visual mode.

The backport brings only the functionality to move the cursor to select the whole shortcode. See Known Issues below for a slight regression. 

To test:
1. Create post with a Gallery or another shortcode
2. Switch to HTML mode
3. Select some part of the Gallery shortcode (e.g. click in the middle of it or select some of the image ids)
4. Switch to Visual mode
5. Verify the Gallery is rendered properly, without breaking. 

Known issues:
Right now when a selection is made in HTML mode, switched to Visual and there are embeds in the content, the selection will be completely lost. That's an unfortunate side effect from the code that loads embeds and can be addressed in a separate PR.

cc @lizkarkoski @azaozz 