### PR TITLE
Domains: Added transfer start functionality for domains in pending_start state.

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -13,6 +13,7 @@ export const transferStatus = {
 	PENDING_REGISTRY: 'PENDING_REGISTRY',
 	CANCELLED: 'CANCELLED',
 	COMPLETED: 'COMPLETED',
+	PENDING_START: 'PENDING_START',
 };
 
 export const registrar = {

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -83,6 +83,22 @@ function restartInboundTransfer( siteId, domainName, onComplete ) {
 	} );
 }
 
+function startInboundTransfer( siteId, domainName, onComplete ) {
+	if ( ! domainName || ! siteId ) {
+		onComplete( null );
+		return;
+	}
+
+	wpcom.undocumented().startInboundTransfer( siteId, domainName, function( serverError, result ) {
+		if ( serverError ) {
+			onComplete( serverError.error );
+			return;
+		}
+
+		onComplete( null, result );
+	} );
+}
+
 function resendInboundTransferEmail( domainName, onComplete ) {
 	if ( ! domainName ) {
 		onComplete( null );
@@ -252,10 +268,10 @@ export {
 	getDomainProductSlug,
 	getFixedDomainSearch,
 	getGoogleAppsSupportedDomains,
-	getPrimaryDomain,
-	getSelectedDomain,
-	getRegisteredDomains,
 	getMappedDomains,
+	getPrimaryDomain,
+	getRegisteredDomains,
+	getSelectedDomain,
 	getTld,
 	hasGoogleApps,
 	hasGoogleAppsSupportedDomain,
@@ -265,6 +281,7 @@ export {
 	isMappedDomain,
 	isRegisteredDomain,
 	isSubdomain,
-	restartInboundTransfer,
 	resendInboundTransferEmail,
+	restartInboundTransfer,
+	startInboundTransfer,
 };

--- a/client/lib/domains/utils.js
+++ b/client/lib/domains/utils.js
@@ -49,6 +49,10 @@ function getTransferStatus( domainFromApi ) {
 		return transferStatus.COMPLETED;
 	}
 
+	if ( domainFromApi.transfer_status === 'pending_start' ) {
+		return transferStatus.PENDING_START;
+	}
+
 	return null;
 }
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -521,6 +521,24 @@ Undocumented.prototype.restartInboundTransfer = function( siteId, domain, fn ) {
 };
 
 /**
+ * Starts an inbound domain transfer that is in the pending_start state.
+ *
+ * @param {int|string} siteId The site ID
+ * @param {string} domain The domain name
+ * @param {Function} fn The callback function
+ * @returns {Promise} A promise that resolves when the request completes
+ * @api public
+ */
+Undocumented.prototype.startInboundTransfer = function( siteId, domain, fn ) {
+	return this.wpcom.req.get(
+		{
+			path: `/domains/${ encodeURIComponent( domain ) }/inbound-transfer-start/${ siteId }`,
+		},
+		fn
+	);
+};
+
+/**
  * Initiates a resend of the inbound transfer verification email.
  * @param {string} domain - The domain name to check.
  * @param {Function} fn The callback function

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -843,6 +843,25 @@ export class DomainWarnings extends React.PureComponent {
 					}
 				);
 				break;
+			case transferStatus.PENDING_START:
+				compactMessage = translate( 'Domain transfer waiting' );
+				message = translate(
+					'Your domain {{strong}}%(domain)s{{/strong}} is witing for you to start the transfer. {{a}}More info{{/a}}',
+					{
+						components: {
+							strong: <strong />,
+							a: (
+								<a
+									href={ INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS }
+									rel="noopener noreferrer"
+									target="_blank"
+								/>
+							),
+						},
+						args: { domain: domainInTransfer.name },
+					}
+				);
+				break;
 			case transferStatus.CANCELLED:
 				status = 'is-error';
 				compactMessage = translate( 'Domain transfer failed' );

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -846,7 +846,7 @@ export class DomainWarnings extends React.PureComponent {
 			case transferStatus.PENDING_START:
 				compactMessage = translate( 'Domain transfer waiting' );
 				message = translate(
-					'Your domain {{strong}}%(domain)s{{/strong}} is witing for you to start the transfer. {{a}}More info{{/a}}',
+					'Your domain {{strong}}%(domain)s{{/strong}} is waiting for you to start the transfer. {{a}}More info{{/a}}',
 					{
 						components: {
 							strong: <strong />,

--- a/client/my-sites/domains/domain-management/components/domain/transfer-flag.jsx
+++ b/client/my-sites/domains/domain-management/components/domain/transfer-flag.jsx
@@ -34,6 +34,9 @@ class DomainTransferFlag extends PureComponent {
 			case transferStatus.PENDING_OWNER:
 				message = translate( 'Email Confirmation Required' );
 				break;
+			case transferStatus.PENDING_START:
+				message = translate( 'Action Required' );
+				break;
 			case transferStatus.CANCELLED:
 				status = 'is-error';
 				message = translate( 'Transfer Failed' );

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -231,50 +231,6 @@ class Transfer extends React.PureComponent {
 		);
 	}
 
-	getStartPendingContent() {
-		const { domain, translate } = this.props;
-		const { isSumitting } = this.state;
-
-		return (
-			<Card>
-				<div>
-					<h2 className="edit__transfer-text-fail">
-						{ translate( 'Important: Start Your Domain Transfer' ) }
-					</h2>
-					<p>
-						{ translate(
-							'We need you to complete a few steps to initiate and authorize the transfer of ' +
-								'{{strong}}%(domain)s{{/strong}} from your current domain provider to WordPress.com. Your domain will ' +
-								'stay at your current provider until the transfer is started.',
-							{
-								components: {
-									strong: <strong />,
-								},
-								args: { domain: domain.name },
-							}
-						) }
-					</p>
-				</div>
-				<div>
-					<Button
-						className="edit__transfer-button-fail"
-						onClick={ this.startTransfer }
-						busy={ isSumitting }
-						disabled={ isSumitting }
-					>
-						{ isSumitting ? translate( 'Starting Transfer…' ) : translate( 'Start Transfer' ) }
-					</Button>
-					<Button
-						className="edit__transfer-button-fail edit__transfer-button-fail-margin"
-						href={ CALYPSO_CONTACT }
-					>
-						{ this.props.translate( 'Contact Support' ) }
-					</Button>
-				</div>
-			</Card>
-		);
-	}
-
 	getDomainDetailsCard() {
 		const { domain, selectedSite, translate } = this.props;
 

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -31,12 +31,12 @@ import InboundTransferEmailVerificationCard from 'my-sites/domains/domain-manage
 
 class Transfer extends React.PureComponent {
 	state = {
-		isSumitting: false,
+		isSubmitting: false,
 	};
 
 	render() {
 		const { domain, selectedSite, translate } = this.props;
-		const { isSumitting } = this.state;
+		const { isSubmitting } = this.state;
 		let content = this.getDomainDetailsCard();
 
 		if ( domain.transferStatus === transferStatus.CANCELLED ) {
@@ -89,10 +89,10 @@ class Transfer extends React.PureComponent {
 						<Button
 							className="edit__transfer-button-fail"
 							onClick={ this.startTransfer }
-							busy={ isSumitting }
-							disabled={ isSumitting }
+							busy={ isSubmitting }
+							disabled={ isSubmitting }
 						>
-							{ isSumitting ? translate( 'Starting Transfer…' ) : translate( 'Start Transfer' ) }
+							{ isSubmitting ? translate( 'Starting Transfer…' ) : translate( 'Start Transfer' ) }
 						</Button>
 					</div>
 				</Card>
@@ -176,12 +176,12 @@ class Transfer extends React.PureComponent {
 	};
 
 	toggleSubmittingState() {
-		this.setState( { isSumitting: ! this.state.isSumitting } );
+		this.setState( { isSubmitting: ! this.state.isSubmitting } );
 	}
 
 	getCancelledContent() {
 		const { domain, translate } = this.props;
-		const { isSumitting } = this.state;
+		const { isSubmitting } = this.state;
 
 		return (
 			<Card>
@@ -213,10 +213,10 @@ class Transfer extends React.PureComponent {
 					<Button
 						className="edit__transfer-button-fail"
 						onClick={ this.restartTransfer }
-						busy={ isSumitting }
-						disabled={ isSumitting }
+						busy={ isSubmitting }
+						disabled={ isSubmitting }
 					>
-						{ isSumitting
+						{ isSubmitting
 							? translate( 'Restarting Transfer…' )
 							: translate( 'Start Transfer Again' ) }
 					</Button>


### PR DESCRIPTION
Depends on D9660-code.
 Testing:

Hack the back end to start a transfer with delayed transfer start state
Make sure the domains api returns `pending_start` for the domain.

Visit the manage domains page for the site.
Make sure the "Domain transfer waiting" notice is shown.
Make sure the "Action required" flag is shown.
Make sure the card with the "Start transfer" button is shown.
Make sure that "Start transfer" successfully calls the `inbound-transfer-start` endpoint.