### PR TITLE
Search: Only show the focus state when it makes sense.

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -21,7 +21,7 @@
 		border-radius: inherit;
 		height: 100%;
 
-		&:focus {
+		.accessible-focus &:focus {
 			box-shadow: inset 0 0 0 2px $blue-light;
 			position: relative;
 			z-index: 9999;
@@ -47,7 +47,7 @@
 		transition: opacity .2s ease-in;
 	}
 
-	&.has-focus {
+	&.is-open.has-focus {
 		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 4px $blue-light;
 	}
 


### PR DESCRIPTION
This PR covers two bugs related to the focus state of the search input and search button.

If you tab around, you may find yourself getting the focus state of the `.search` element (not the button, or the input, but their parent element), which looks super strange:

<img width="231" alt="screen shot 2018-01-29 at 1 30 02 pm" src="https://user-images.githubusercontent.com/191598/35527378-90c0f5fe-04f8-11e8-855b-3230a0ae0804.png">

This PR adds the `.is-open` selector to the focus state of `.search` ensuring that it's only applied when the search is actually visible.

Related, if you click the search icon while the search is already open, you can end up with this:

<img width="753" alt="screen shot 2018-01-29 at 1 28 38 pm" src="https://user-images.githubusercontent.com/191598/35527372-8ac612ce-04f8-11e8-9bc0-1e4a5e2ca189.png">

This PR adds the `.accessible-focus` selector to the `.search__icon-navigation` element, avoiding the unintentional focus state.