### PR TITLE
SectionNav: Updating :focus state

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -281,11 +281,9 @@
 		}
 	}
 
-	&:focus {
+	.accessible-focus &:focus {
 		outline: none;
-		.accessible-focus & {
-			outline: solid $gray 1px;
-		}
+		box-shadow: inset 0 0 0 2px $blue-light;
 	}
 
 	.is-external & {


### PR DESCRIPTION
The current `:focus` state for the SectionNav component is really subtle, and kind of hidden for the current tab:

<img width="747" alt="screen shot 2018-01-29 at 1 47 20 pm" src="https://user-images.githubusercontent.com/191598/35528293-704c17ba-04fb-11e8-8a7a-46990263d656.png">

<img width="734" alt="screen shot 2018-01-29 at 1 47 45 pm" src="https://user-images.githubusercontent.com/191598/35528300-73164718-04fb-11e8-83c2-7d6e0ae72d83.png">

This PR updates the focus state to match the search component, which is often uses within the SectionNav. Here's what it looks like:

<img width="740" alt="screen shot 2018-01-29 at 1 47 06 pm" src="https://user-images.githubusercontent.com/191598/35528329-8510baac-04fb-11e8-8601-70ed623d8a4c.png">

<img width="747" alt="screen shot 2018-01-29 at 1 47 00 pm" src="https://user-images.githubusercontent.com/191598/35528332-881c1bc4-04fb-11e8-859d-e2e2b6e9f3ed.png">

<img width="727" alt="screen shot 2018-01-29 at 1 52 08 pm" src="https://user-images.githubusercontent.com/191598/35528365-a267138a-04fb-11e8-8649-e1e1ca3b7ee0.png">
