### PR TITLE
Rewind: Fix host hint for subdirectory-installed sites

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -115,7 +115,8 @@ export class RewindCredentialsForm extends Component {
 		nextForm.path = isEmpty( nextForm.path ) && credentials ? credentials.path : nextForm.path;
 
 		// Populate the host field with the site slug if needed
-		nextForm.host = isEmpty( nextForm.host ) && siteSlug ? siteSlug : nextForm.host;
+		nextForm.host =
+			isEmpty( nextForm.host ) && siteSlug ? siteSlug.split( '::' )[ 0 ] : nextForm.host;
 
 		this.setState( { form: nextForm } );
 	}


### PR DESCRIPTION
The `siteSlug` stored in state for subdirectory-installed sites is formatted as `host::directory`, which is incorrect for use as the host hint in the credentials form. This PR simply strips the `::directory` part from the siteSlug so that the host hint is appropriate for these sites.

**Testing instructions**
1. For a subdirectory site with no credentials, attempt to add credentials and observe if the host field is pre-filled correctly.
2. Make sure there are no other disruptions to this field and that the form submits and saves correctly.