### PR TITLE
Masterbar and Sidebar: Adding focus states

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -56,9 +56,16 @@ $autobar-height: 20px;
 			background: rgba( $blue-wordpress, 0.85 );
 		}
 
-		&:hover,
-		&:focus {
+		&:hover {
 			background: lighten( $masterbar-color, 5% );
+		}
+
+		&:focus {
+			outline: none;
+
+			.accessible-focus & {
+				box-shadow: inset 0 0 0 2px $blue-light;
+			}
 		}
 	}
 }
@@ -93,11 +100,19 @@ $autobar-height: 20px;
 		padding: 0 0 0 6px;
 	}
 
-	&:hover,
-	&:focus {
+	&:hover {
 		background: var( --masterbar-item-hover-background );
 		color: var( --masterbar-color );
-		outline: 0;
+	}
+
+	&:focus {
+		outline: none;
+
+		.accessible-focus & {
+			box-shadow: inset 0 0 0 2px $blue-light;
+			color: var( --masterbar-color );
+			box-shadow: inset 0 0 0 2px $blue-light;
+		}
 	}
 
 	&.is-active {
@@ -202,10 +217,20 @@ $autobar-height: 20px;
 		color: $white;
 	}
 
-	&:hover,
-	&:focus {
+	&:hover {
 		background: $gray-light;
 		color: var( --masterbar-item-new-color );
+	}
+
+	&:focus {
+		outline: none;
+
+		.accessible-focus & {
+			background: $white;
+			color: var( --masterbar-item-new-color );
+			box-shadow: 0 0 0 2px $blue-light;
+			z-index: 1;
+		}
 	}
 
 	.masterbar__item-content {
@@ -370,7 +395,7 @@ $autobar-height: 20px;
 	height: 36px;
 	margin: 5px 8px 5px -10px;
 	padding: 0 8px;
-	border-radius: 0 3px 3px 0;
+	border-radius: 3px;
 	position: relative;
 	transition: all 0.2s ease-out;
 

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -140,8 +140,15 @@
 		display: flex;
 		align-items: center;
 
-		&:focus {
+		.accessible-focus &:focus {
 			outline: none;
+			box-shadow: inset 0 0 0 2px $blue-light;
+
+			&:after {
+				top: 2px;
+				right: 2px;
+				bottom: 2px;
+			}
 		}
 
 		-webkit-tap-highlight-color: rgba( $gray-dark, .2 );


### PR DESCRIPTION
`:focus` states for the masterbar are inconsistent. On the sidebar, they're mostly non-existant. Here's a few screenshots of things:

<img width="308" alt="screen shot 2018-01-29 at 3 55 15 pm" src="https://user-images.githubusercontent.com/191598/35533880-d68e5af4-050c-11e8-9a10-6990954d1f42.png">

In the above screenshot the My Sites button is currently focused — `:focus` and `:hover` are mostly the same across the masterbar items. This PR updates the focus states, using `.accessible-focus` where required, to be more consistent:

<img width="309" alt="screen shot 2018-01-29 at 3 57 24 pm" src="https://user-images.githubusercontent.com/191598/35533991-1dcf6ea8-050d-11e8-8975-1b2ecfbe194f.png">

<img width="1039" alt="screen shot 2018-01-29 at 3 57 42 pm" src="https://user-images.githubusercontent.com/191598/35534024-37455442-050d-11e8-96df-e643495a9379.png">
<img width="1037" alt="screen shot 2018-01-29 at 3 57 49 pm" src="https://user-images.githubusercontent.com/191598/35534025-37573dce-050d-11e8-97b2-2c08b24e342c.png">
<img width="1037" alt="screen shot 2018-01-29 at 3 57 56 pm" src="https://user-images.githubusercontent.com/191598/35534026-376d030c-050d-11e8-92f5-b42ca3b4182a.png">
<img width="1032" alt="screen shot 2018-01-29 at 3 58 03 pm" src="https://user-images.githubusercontent.com/191598/35534027-37817238-050d-11e8-98da-0713d98847c1.png">

The sidebar today simply doesn't have any `:focus` styles in place. This PR adds some, which end up looking like this:

<img width="272" alt="screen shot 2018-01-29 at 4 00 55 pm" src="https://user-images.githubusercontent.com/191598/35534157-9ec8f326-050d-11e8-80dc-590fb9f88101.png">
<img width="272" alt="screen shot 2018-01-29 at 4 00 41 pm" src="https://user-images.githubusercontent.com/191598/35534158-9edf8528-050d-11e8-91ad-4f243d4fb6ab.png">
<img width="275" alt="screen shot 2018-01-29 at 4 00 20 pm" src="https://user-images.githubusercontent.com/191598/35534159-9ef0ff92-050d-11e8-9f5f-513100fe3239.png">
