### PR TITLE
Editor: Don't show the "unsaved content" dialog when scheduling posts

### DIFF
--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -409,13 +409,14 @@ export const isEditedPostDirty = createSelector(
 			}
 
 			if ( post ) {
-				if ( key === 'parent' ) {
-					return get( post, 'parent.ID', null ) !== value;
+				switch ( key ) {
+					case 'date': {
+						return ! moment( value ).isSame( post.date );
+					}
+					case 'parent': {
+						return get( post, 'parent.ID', null ) !== value;
+					}
 				}
-				if ( key === 'date' ) {
-					return ! moment( value ).isSame( post.date );
-				}
-
 				return post[ key ] !== value;
 			}
 

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -412,6 +412,10 @@ export const isEditedPostDirty = createSelector(
 				if ( key === 'parent' ) {
 					return get( post, 'parent.ID', null ) !== value;
 				}
+				if ( key === 'date' ) {
+					return ! moment( value ).isSame( post.date );
+				}
+
 				return post[ key ] !== value;
 			}
 


### PR DESCRIPTION
As @beaulebens reported [here](https://github.com/Automattic/wp-calypso/issues/9833#issuecomment-361273233), updating the publish date for a scheduled post results in the message that there are unsaved changes:
<img width="510" alt="screen shot 2018-01-29 at 2 13 45 pm" src="https://user-images.githubusercontent.com/1587282/35529316-ac1dfbf2-04fe-11e8-8f84-fcb4221260eb.png">

## To reproduce

- Go to editor
- Enter content
- Set publish date
- Hit Publish / Update (and confirm)
- Click "Close" in the top left so that I could do the next one
- Get a warning of modified content

---

This change uses [`moment#isSame`](https://momentjs.com/docs/#/query/is-same/) to do the comparison of the values being checked for sameness to account for time zone variations (UTC on the server vs. the editor's local time.

## To Test

- Apply this branch
- Go to editor (while your system time is not set to UTC)
- Enter content
- Set publish date
- Hit Publish / Update (and confirm)
- Click "Close" in the top left so that I could do the next one
- You should _NOT_ get a warning of modified content
