### PR TITLE
Fix the revisions list auto-scroll when the list is horizontal

### DIFF
--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -74,22 +74,47 @@ class EditorRevisionsList extends PureComponent {
 		if ( ! ( scrollerNode && selectedNode && listNode ) ) {
 			return;
 		}
-		const { bottom: selectedBottom, top: selectedTop } = selectedNode.getBoundingClientRect();
-		const { top: listTop } = listNode.getBoundingClientRect();
 		const {
+			top: selectedTop,
+			right: selectedRight,
+			bottom: selectedBottom,
+			left: selectedLeft,
+		} = selectedNode.getBoundingClientRect();
+		const {
+			top: listTop,
+			left: listLeft,
+			width: listWidth,
+			height: listHeight,
+		} = listNode.getBoundingClientRect();
+		const {
+			top: scrollerTop,
 			bottom: scrollerBottom,
 			height: scrollerHeight,
-			top: scrollerTop,
+			left: scrollerLeft,
+			right: scrollerRight,
+			width: scrollerWidth,
 		} = scrollerNode.getBoundingClientRect();
 
-		const isAboveBounds = selectedTop < scrollerTop;
-		const isBelowBounds = selectedBottom > scrollerBottom;
+		if ( listWidth > listHeight ) {
+			const isLeftOfBounds = selectedLeft < scrollerLeft;
+			const isRightOfBounds = selectedRight > scrollerRight;
 
-		const targetWhenAbove = selectedTop - listTop;
-		const targetWhenBelow = Math.abs( scrollerHeight - ( selectedBottom - listTop ) );
+			const targetWhenLeft = selectedLeft - listLeft;
+			const targetWhenRight = Math.abs( scrollerWidth - ( selectedRight - listLeft ) );
 
-		if ( isAboveBounds || isBelowBounds ) {
-			scrollerNode.scrollTop = isAboveBounds ? targetWhenAbove : targetWhenBelow;
+			if ( isLeftOfBounds || isRightOfBounds ) {
+				scrollerNode.scrollLeft = isLeftOfBounds ? targetWhenLeft : targetWhenRight;
+			}
+		} else {
+			const isAboveBounds = selectedTop < scrollerTop;
+			const isBelowBounds = selectedBottom > scrollerBottom;
+
+			const targetWhenAbove = selectedTop - listTop;
+			const targetWhenBelow = Math.abs( scrollerHeight - ( selectedBottom - listTop ) );
+
+			if ( isAboveBounds || isBelowBounds ) {
+				scrollerNode.scrollTop = isAboveBounds ? targetWhenAbove : targetWhenBelow;
+			}
 		}
 	}
 

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -14,6 +14,7 @@ import { get, head, isEmpty, map } from 'lodash';
  * Internal dependencies
  */
 import EditorRevisionsListHeader from './header';
+import EditorRevisionsListNavigation from './navigation';
 import EditorRevisionsListItem from './item';
 import { selectPostRevision } from 'state/posts/revisions/actions';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
@@ -115,6 +116,10 @@ class EditorRevisionsList extends PureComponent {
 		return (
 			<div className={ classes }>
 				<EditorRevisionsListHeader numRevisions={ revisions.length } />
+				<EditorRevisionsListNavigation
+					selectNextRevision={ this.selectNextRevision }
+					selectPreviousRevision={ this.selectPreviousRevision }
+				/>
 				<div className="editor-revisions-list__scroller">
 					<ul className="editor-revisions-list__list">
 						{ map( revisions, revision => {

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -8,7 +8,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get, head, isEmpty, map } from 'lodash';
+import { get, head, isEmpty, last, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -107,6 +107,20 @@ class EditorRevisionsList extends PureComponent {
 		prevRevisionId && this.selectRevision( prevRevisionId );
 	};
 
+	selectedRevisionOrder = () => {
+		const { selectedRevisionId, revisions } = this.props;
+		const firstRevision = head( revisions );
+		const lastRevision = last( revisions );
+
+		if ( firstRevision && selectedRevisionId === firstRevision.id ) {
+			return 'latest';
+		}
+		if ( lastRevision && selectedRevisionId === lastRevision.id ) {
+			return 'earliest';
+		}
+		return '';
+	};
+
 	render() {
 		const { comparisons, postId, revisions, selectedRevisionId, siteId } = this.props;
 		const classes = classNames( 'editor-revisions-list', {
@@ -119,6 +133,7 @@ class EditorRevisionsList extends PureComponent {
 				<EditorRevisionsListNavigation
 					selectNextRevision={ this.selectNextRevision }
 					selectPreviousRevision={ this.selectPreviousRevision }
+					selectedRevisionOrder={ this.selectedRevisionOrder() }
 				/>
 				<div className="editor-revisions-list__scroller">
 					<ul className="editor-revisions-list__list">

--- a/client/post-editor/editor-revisions-list/navigation.jsx
+++ b/client/post-editor/editor-revisions-list/navigation.jsx
@@ -1,0 +1,46 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import ButtonGroup from 'components/button-group';
+
+const EditorRevisionsListNavigation = ( { selectNextRevision, selectPreviousRevision } ) => {
+	return (
+		<ButtonGroup className="editor-revisions-list__navigation">
+			<Button
+				compact
+				borderless
+				className="editor-revisions-list__prev-button"
+				type="button"
+				onClick={ selectPreviousRevision }
+			>
+				<Gridicon icon="chevron-down" />
+			</Button>
+			<Button
+				compact
+				borderless
+				className="editor-revisions-list__next-button"
+				type="button"
+				onClick={ selectNextRevision }
+			>
+				<Gridicon icon="chevron-up" />
+			</Button>
+		</ButtonGroup>
+	);
+};
+
+EditorRevisionsListNavigation.propTypes = {
+	selectNextRevision: PropTypes.func.isRequired,
+	selectPreviousRevision: PropTypes.func.isRequired,
+};
+
+export default EditorRevisionsListNavigation;

--- a/client/post-editor/editor-revisions-list/navigation.jsx
+++ b/client/post-editor/editor-revisions-list/navigation.jsx
@@ -13,24 +13,28 @@ import Gridicon from 'gridicons';
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
 
-const EditorRevisionsListNavigation = ( { selectNextRevision, selectPreviousRevision } ) => {
+const EditorRevisionsListNavigation = ( {
+	selectNextRevision,
+	selectPreviousRevision,
+	selectedRevisionOrder,
+} ) => {
 	return (
 		<ButtonGroup className="editor-revisions-list__navigation">
 			<Button
 				compact
-				borderless
 				className="editor-revisions-list__prev-button"
 				type="button"
 				onClick={ selectPreviousRevision }
+				disabled={ selectedRevisionOrder === 'earliest' }
 			>
 				<Gridicon icon="chevron-down" />
 			</Button>
 			<Button
 				compact
-				borderless
 				className="editor-revisions-list__next-button"
 				type="button"
 				onClick={ selectNextRevision }
+				disabled={ selectedRevisionOrder === 'latest' }
 			>
 				<Gridicon icon="chevron-up" />
 			</Button>
@@ -39,6 +43,7 @@ const EditorRevisionsListNavigation = ( { selectNextRevision, selectPreviousRevi
 };
 
 EditorRevisionsListNavigation.propTypes = {
+	selectedRevisionOrder: PropTypes.string,
 	selectNextRevision: PropTypes.func.isRequired,
 	selectPreviousRevision: PropTypes.func.isRequired,
 };

--- a/client/post-editor/editor-revisions-list/navigation.jsx
+++ b/client/post-editor/editor-revisions-list/navigation.jsx
@@ -14,9 +14,10 @@ import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
 
 const EditorRevisionsListNavigation = ( {
+	latestRevisionIsSelected,
+	earliestRevisionIsSelected,
 	selectNextRevision,
 	selectPreviousRevision,
-	selectedRevisionOrder,
 } ) => {
 	return (
 		<ButtonGroup className="editor-revisions-list__navigation">
@@ -25,7 +26,7 @@ const EditorRevisionsListNavigation = ( {
 				className="editor-revisions-list__prev-button"
 				type="button"
 				onClick={ selectPreviousRevision }
-				disabled={ selectedRevisionOrder === 'earliest' }
+				disabled={ earliestRevisionIsSelected }
 			>
 				<Gridicon icon="chevron-down" />
 			</Button>
@@ -34,7 +35,7 @@ const EditorRevisionsListNavigation = ( {
 				className="editor-revisions-list__next-button"
 				type="button"
 				onClick={ selectNextRevision }
-				disabled={ selectedRevisionOrder === 'latest' }
+				disabled={ latestRevisionIsSelected }
 			>
 				<Gridicon icon="chevron-up" />
 			</Button>

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -5,18 +5,18 @@
 .editor-revisions-list {
 	position: relative;
 	background: $gray-light;
-	flex-basis: 120px;
+	flex-basis: 162px;
 	flex-grow: 0;
 	flex-shrink: 0;
 
 	@include breakpoint( '>660px' ) {
 		border-left: 1px solid darken($sidebar-bg-color, 5%);
-		z-index: 1; // Put the list above the action-buttons:before overlay gradient. -shaun
+		z-index: 1; // Put the list above the action-buttons::before overlay gradient. -shaun
 		flex-basis: 230px;
 	}
 
 	@include breakpoint( '<660px' ) {
-		&:after {
+		&::after {
 			$editor-revisions-list-fade-height: 20px;
 			content: '';
 			position: absolute;
@@ -36,11 +36,14 @@
 }
 
 .editor-revisions-list__header {
+	$editor-revisions-list-header-height: 46px;
+	$editor-revisions-list-header-font-size: 16px;
 	padding: 0 16px;
-	height: 46px;
-	line-height: 64px;
+	height: $editor-revisions-list-header-height;
+	line-height: $editor-revisions-list-header-height;
 	color: $gray-text-min;
 	background: $white;
+	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
 
 	.editor-revisions-list.is-loading & {
 		position: relative;
@@ -49,9 +52,9 @@
 			content: '';
 			display: block;
 			position: absolute;
-			top: 25px;
+			top: ($editor-revisions-list-header-height - $editor-revisions-list-header-font-size) / 2;
 			width: 50%;
-			height: 16px;
+			height: $editor-revisions-list-header-font-size;
 			@include placeholder(23%);
 		}
 	}
@@ -59,25 +62,69 @@
 
 // Revision Navigation Buttons
 .editor-revisions-list__navigation {
-	display: block;
-	height: 36px;
-	padding: 0 11px;
+	display: flex;
+	flex-direction: row-reverse;
+	height: 40px;
 	color: $gray-text-min;
-	background: $white;
 	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
+	.button:first-child,
+	.button:last-child {
+		border-radius: 0;
+	}
+
+	@include breakpoint( '>660px' ) {
+		flex-direction: row;
+		height: 24px;
+	}
 }
 
 .editor-revisions-list__prev-button,
 .editor-revisions-list__next-button {
-	width: 28px;
-	height: 24px;
+	display: inline-block;
+	width: 50%;
+	height: 40px;
 	vertical-align: middle;
+	background: transparent;
+	border: none;
+	&.button:disabled,
+	&.button[disabled],
+	&.button.disabled {
+		background: transparent;
+		color: lighten($gray-text-min, 30%);
+		border-color: darken($sidebar-bg-color, 5%);
+	}
+	.gridicon {
+		transform: rotate(-90deg);
+	}
+
+	@include breakpoint( '>660px' ) {
+		height: 24px;
+		.gridicon {
+			transform: none;
+		}
+	}
+}
+
+@include breakpoint( '<660px' ) {
+	.editor-revisions-list__next-button,
+	.editor-revisions-list__next-button:hover,
+	.editor-revisions-list__next-button:active {
+		border-right: 1px solid darken($sidebar-bg-color, 5%);
+	}
+}
+
+@include breakpoint( '>660px' ) {
+	.editor-revisions-list__prev-button,
+	.editor-revisions-list__prev-button:hover,
+	.editor-revisions-list__prev-button:active {
+		border-right: 1px solid darken($sidebar-bg-color, 5%);
+	}
 }
 
 // Scrollable Box for Revisions List
 .editor-revisions-list__scroller {
 	position: absolute;
-	top: 83px;
+	top: 72px;
 	right: 0;
 	bottom: 0;
 	left: 0;
@@ -85,6 +132,7 @@
 	-webkit-overflow-scrolling: touch;
 
 	@include breakpoint( '<660px' ) {
+		top: 88px;
 		overflow-y: hidden;
 	}
 }
@@ -98,7 +146,7 @@
 		white-space: nowrap;
 	}
 
-	&:before {
+	&::before {
 		content: '';
 		display: block;
 		box-sizing: border-box;
@@ -115,7 +163,7 @@
 }
 
 // Individual Revision List Item
-.editor-revisions-list.is-loading .editor-revisions-list__list:before,
+.editor-revisions-list.is-loading .editor-revisions-list__list::before,
 .editor-revisions-list__button {
 	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
 	border-right: 1px solid darken($sidebar-bg-color, 5%);

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -105,6 +105,27 @@
 	}
 }
 
+.button-group {
+	.editor-revisions-list__prev-button,
+	.editor-revisions-list__prev-button:first-child,
+	.editor-revisions-list__next-button {
+		&:focus {
+			box-shadow: none;
+		}
+	}
+}
+
+.accessible-focus {
+	.editor-revisions-list__prev-button,
+	.editor-revisions-list__prev-button:first-child,
+	.editor-revisions-list__next-button {
+		&:focus {
+			outline: solid 2px $blue-light;
+			outline-offset: -2px;
+		}
+	}
+}
+
 @include breakpoint( '<660px' ) {
 	.editor-revisions-list__next-button,
 	.editor-revisions-list__next-button:hover,
@@ -115,9 +136,13 @@
 
 @include breakpoint( '>660px' ) {
 	.editor-revisions-list__prev-button,
-	.editor-revisions-list__prev-button:hover,
-	.editor-revisions-list__prev-button:active {
+	.editor-revisions-list__prev-button:hover {
 		border-right: 1px solid darken($sidebar-bg-color, 5%);
+	}
+	.button-group {
+		.editor-revisions-list__prev-button:first-child:active {
+			border-right: 1px solid darken($sidebar-bg-color, 5%);
+		}
 	}
 }
 

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -199,7 +199,7 @@
 	padding: 8px 16px;
 	margin: 0;
 	min-height: 73px;
-	width: 60vw;
+	width: 45vw;
 
 	@include breakpoint( '>660px' ) {
 		display: block;

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -36,14 +36,11 @@
 }
 
 .editor-revisions-list__header {
-	$editor-revisions-list-header-height: 46px;
-	$editor-revisions-list-header-font-size: 16px;
 	padding: 0 16px;
-	height: $editor-revisions-list-header-height;
-	line-height: $editor-revisions-list-header-height;
+	height: 46px;
+	line-height: 64px;
 	color: $gray-text-min;
 	background: $white;
-	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
 
 	.editor-revisions-list.is-loading & {
 		position: relative;
@@ -52,18 +49,35 @@
 			content: '';
 			display: block;
 			position: absolute;
-			top: ($editor-revisions-list-header-height - $editor-revisions-list-header-font-size) / 2;
+			top: 25px;
 			width: 50%;
-			height: $editor-revisions-list-header-font-size;
+			height: 16px;
 			@include placeholder(23%);
 		}
 	}
 }
 
+// Revision Navigation Buttons
+.editor-revisions-list__navigation {
+	display: block;
+	height: 36px;
+	padding: 0 11px;
+	color: $gray-text-min;
+	background: $white;
+	border-bottom: 1px solid darken($sidebar-bg-color, 5%);
+}
+
+.editor-revisions-list__prev-button,
+.editor-revisions-list__next-button {
+	width: 28px;
+	height: 24px;
+	vertical-align: middle;
+}
+
 // Scrollable Box for Revisions List
 .editor-revisions-list__scroller {
 	position: absolute;
-	top: 47px;
+	top: 83px;
 	right: 0;
 	bottom: 0;
 	left: 0;


### PR DESCRIPTION
The `EditorRevisionsList`'s `scrollToSelectedItem` method currently scrolls the vertical list on desktop to keep the chosen item in view. This change adds the functionality to the horizontal view.

The current width of the revisions list buttons means that sometimes no content is visible in the button that's not selected.

![image](https://user-images.githubusercontent.com/1647564/35536969-74606712-0540-11e8-8c82-f54c739b0b06.png)

I've reduced the width to give the user more context.

![image](https://user-images.githubusercontent.com/1647564/35537045-bde245f4-0540-11e8-89a2-5311a36d5045.png)

This change is related to the revisions nav buttons PR https://github.com/Automattic/wp-calypso/pull/21712.