### PR TITLE
RewindCredentialsForm - updated advanced settings spacing and added explanation text

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -225,9 +225,6 @@ export class RewindCredentialsForm extends Component {
 									disabled={ formIsSubmitting }
 									isError={ !! formErrors.path }
 								/>
-								<p className="form-setting-explanation">
-									{ translate( 'Only non-encrypted private keys are supported.' ) }
-								</p>
 							</FormFieldset>
 
 							<FormFieldset className="rewind-credentials-form__kpri">
@@ -240,6 +237,9 @@ export class RewindCredentialsForm extends Component {
 									disabled={ formIsSubmitting }
 									className="rewind-credentials-form__private-key"
 								/>
+								<p className="form-setting-explanation">
+									{ translate( 'Only non-encrypted private keys are supported.' ) }
+								</p>
 							</FormFieldset>
 						</div>
 					) }

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -205,15 +205,16 @@ export class RewindCredentialsForm extends Component {
 						disabled={ formIsSubmitting }
 						onClick={ this.toggleAdvancedSettings }
 						borderless={ true }
+						primary={ true }
 						className="rewind-credentials-form__advanced-button"
 					>
 						{ translate( 'Advanced settings' ) }
 					</Button>
 					{ showAdvancedSettings && (
-						<div>
+						<div className="rewind-credentials-form__advanced-settings">
 							<FormFieldset className="rewind-credentials-form__path">
 								<FormLabel htmlFor="wordpress-path">
-									{ translate( 'WordPress Installation Path' ) }
+									{ translate( 'WordPress installation path' ) }
 								</FormLabel>
 								<FormTextInput
 									name="path"
@@ -224,6 +225,9 @@ export class RewindCredentialsForm extends Component {
 									disabled={ formIsSubmitting }
 									isError={ !! formErrors.path }
 								/>
+								<p className="form-setting-explanation">
+									{ translate( 'Only non-encrypted private keys are supported.' ) }
+								</p>
 							</FormFieldset>
 
 							<FormFieldset className="rewind-credentials-form__kpri">

--- a/client/components/rewind-credentials-form/style.scss
+++ b/client/components/rewind-credentials-form/style.scss
@@ -40,7 +40,11 @@
 	float: left;
 }
 
-.rewind-credentials-form__advanced-button.button.is-borderless {
-	margin-top: -10px;
-	color: $blue-wordpress;
+.rewind-credentials-form__advanced-button.button.button {
+	float: none;
+	margin-top: -8px;
+}
+
+.rewind-credentials-form__advanced-settings {
+	margin-top: 24px;
 }


### PR DESCRIPTION
**Note:** The Advanced Settings button being blue is now dependent on https://github.com/Automattic/wp-calypso/pull/21947

#### Before
![image](https://user-images.githubusercontent.com/1123119/35537298-f00ba564-0506-11e8-929d-92b41d013055.png)

![image](https://user-images.githubusercontent.com/1123119/35537284-e9d5641e-0506-11e8-813f-6733d2129055.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/35537077-3d3e8096-0506-11e8-92ca-6b23eeee103f.png)

![image](https://user-images.githubusercontent.com/1123119/35543891-ca9143e8-0524-11e8-9ad9-c5f7f8c82773.png)


