### PR TITLE
Rewind Credentials: Report more specific errors on credentials updates

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -27,6 +27,22 @@ import {
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
 
+/**
+ * Makes sure that we can initialize a connection
+ * to HappyChat. We'll need this on the API response
+ *
+ * @param {function} dispatch Redux dispatcher
+ * @param {function} getState Redux getState
+ */
+export const primeHappychat = ( { dispatch, getState } ) => {
+	const state = getState();
+	const getAuth = getHappychatAuth( state );
+
+	if ( isHappychatConnectionUninitialized( state ) ) {
+		dispatch( initConnection( getAuth() ) );
+	}
+};
+
 export const request = ( { dispatch }, action ) => {
 	const notice = successNotice( i18n.translate( 'Testing connection…' ), { duration: 30000 } );
 	const { notice: { noticeId } } = notice;
@@ -89,16 +105,9 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 		siteId: action.siteId,
 	} );
 
-	const state = getState();
-	const getAuth = getHappychatAuth( state );
-
-	if ( isHappychatConnectionUninitialized( state ) ) {
-		dispatch( initConnection( getAuth() ) );
-	}
-
 	const getHelp = () => {
-		const clickState = getState();
-		const canChat = isHappychatAvailable( clickState ) || hasActiveHappychatSession( clickState );
+		const state = getState();
+		const canChat = isHappychatAvailable( state ) || hasActiveHappychatSession( state );
 
 		return canChat ? dispatch( openChat() ) : page( '/help' );
 	};
@@ -173,5 +182,5 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 };
 
 export default {
-	[ JETPACK_CREDENTIALS_UPDATE ]: [ dispatchRequest( request, success, failure ) ],
+	[ JETPACK_CREDENTIALS_UPDATE ]: [ primeHappychat, dispatchRequest( request, success, failure ) ],
 };

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import i18n from 'i18n-calypso';
-import page from 'page';
 import { get } from 'lodash';
 
 /**
@@ -109,7 +108,9 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 		const state = getState();
 		const canChat = isHappychatAvailable( state ) || hasActiveHappychatSession( state );
 
-		return canChat ? dispatch( openChat() ) : page( '/help' );
+		return canChat
+			? dispatch( openChat() )
+			: undefined !== window && window.open( '/help', '_blank' );
 	};
 
 	const { translate } = i18n;

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import i18n from 'i18n-calypso';
+import page from 'page';
 import { get } from 'lodash';
 
 /**
@@ -25,6 +26,9 @@ import {
 } from 'state/action-types';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
+
+const navigateTo =
+	undefined !== typeof window ? path => window.open( path, '_blank' ) : path => page( path );
 
 /**
  * Makes sure that we can initialize a connection
@@ -108,9 +112,7 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 		const state = getState();
 		const canChat = isHappychatAvailable( state ) || hasActiveHappychatSession( state );
 
-		return canChat
-			? dispatch( openChat() )
-			: undefined !== window && window.open( '/help', '_blank' );
+		return canChat ? dispatch( openChat() ) : navigateTo( '/help' );
 	};
 
 	const { translate } = i18n;

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -108,26 +108,37 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 		{
 			service_unavailable: () => [
 				translate(
-					"Our service is down. We're working to get things up and running. Please try again later."
+					"Our service isn't working at the moment. " +
+						"We'll get it up and running as fast as we can, so please try again later."
 				),
 				{
 					button: translate( 'Try again' ),
 					onClick: () => dispatch( action ),
 				},
 			],
-			missing_args: () => [ translate( 'Please fill out the required fields.' ), null ],
+			missing_args: () => [
+				translate( 'Something seems to be missing — please fill out all the required fields.' ),
+				null,
+			],
 			invalid_args: () => [
 				translate(
-					'Something is wrong with the credentials. Please make sure each field is correct.'
+					'The information you entered seems to be incorrect. ' +
+						"Let's take another look to ensure everything is in the right place."
 				),
 				null,
 			],
 			invalid_credentials: () => [
-				translate( 'We could not connect to your site with these credentials. Please try again.' ),
+				translate(
+					"Oops! We couldn't connect to your site with these credentials " +
+						"— let's give it another try."
+				),
 				null,
 			],
 			invalid_wordpress_path: () => [
-				translate( 'We could not find wp-config.php in the supplied WordPress installation path.' ),
+				translate(
+					'We looked for `wp-config.php` in the WordPress installation path you provided ' +
+						"but couldn't find it."
+				),
 				{
 					button: translate( 'Get help' ),
 					onClick: getHelp,
@@ -135,8 +146,8 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 			],
 			read_only_install: () => [
 				translate(
-					'The server is read-only. Without permission to write to the server, ' +
-						'we cannot perform backups and rewinds.'
+					'It looks like your server is read-only. ' +
+						'To create backups and rewind your site, we need permission to write to your server.'
 				),
 				{
 					button: translate( 'Get help' ),
@@ -145,8 +156,8 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 			],
 			unreachable_path: () => [
 				translate(
-					'We were unable to access the WordPress installation path with its publicly-available URL. ' +
-						'Please make sure the directory is accessible and try again.'
+					'We tried to access your WordPress installation through its publicly available URL, ' +
+						"but it didn't work. Please make sure the directory is accessible and try again."
 				),
 				null,
 			],


### PR DESCRIPTION
Previously we had one generic message to indicate that we failed to
update a site's credentials for Rewind.

In this patch we're adding specific messages when the server reports a
specific kind of failure condition.

**Testing**
Try and submit credentials in **My Sites** > **Settings** > **Security** on
a site where **Rewind** is available. Different failure modes should return
different error notices. Work on the remote site may be necessary to test
each one or alternatively the API calls could be faked on a sandbox.