### PR TITLE
Remove the first step from about and contact page tours.

### DIFF
--- a/client/layout/guided-tours/tours/checklist-about-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour.js
@@ -23,24 +23,7 @@ import {
 
 export const ChecklistAboutPageTour = makeTour(
 	<Tour name="checklistAboutPage" version="20171205" path="/non-existent-route" when={ noop }>
-		<Step
-			name="init"
-			placement="beside"
-			arrow="left-top"
-			target="side-menu-page"
-			style={ {
-				animationDelay: '0s',
-			} }
-		>
-			<p>
-				{ translate( 'Click on {{b}}Site Pages{{/b}} to see all the pages on our site.', {
-					components: { b: <strong /> },
-				} ) }
-			</p>
-			<Continue target="side-menu-page" step="choose-page" click hidden />
-		</Step>
-
-		<Step name="choose-page" target="page-about" arrow="top-left" placement="below">
+		<Step name="init" target="page-about" arrow="top-left" placement="below">
 			<p>
 				{ translate( 'Click {{b}}About{{/b}} to edit this page.', {
 					components: { b: <strong /> },

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -12,8 +12,10 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import { getSectionName } from 'state/ui/selectors';
 import {
 	Continue,
+	ButtonRow,
 	makeTour,
 	Next,
 	SiteLink,
@@ -21,18 +23,21 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 
+function isPostEditorSection( state ) {
+	return getSectionName( state ) === 'post-editor';
+}
+
 export const ChecklistContactPageTour = makeTour(
 	<Tour name="checklistContactPage" version="20171205" path="/non-existent-route" when={ noop }>
-		<Step name="init" target="page-contact" arrow="top-left" placement="below">
-			<p>
-				{ translate( 'Click {{b}}Contact{{/b}} to edit this page.', {
-					components: { b: <strong /> },
-				} ) }
-			</p>
-			<Continue target="page-contact" step="contact-page" click hidden />
-		</Step>
-
-		<Step name="contact-page" placement="right">
+		<Step
+			name="init"
+			placement="right"
+			style={ {
+				animationDelay: '0.7s',
+			} }
+			when={ isPostEditorSection }
+			canSkip={ false }
+		>
 			<p>
 				{ translate(
 					'Your contact page makes it easy for people to get in touch. Let’s personalize ' +
@@ -40,7 +45,11 @@ export const ChecklistContactPageTour = makeTour(
 						'Click in the text area below to get started.'
 				) }
 			</p>
-			<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
+			<ButtonRow>
+				<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
+				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+				<Continue step="featured-images" hidden />
+			</ButtonRow>
 		</Step>
 
 		<Step

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -23,26 +23,7 @@ import {
 
 export const ChecklistContactPageTour = makeTour(
 	<Tour name="checklistContactPage" version="20171205" path="/non-existent-route" when={ noop }>
-		<Step
-			name="init"
-			placement="beside"
-			arrow="left-top"
-			target="side-menu-page"
-			style={ {
-				animationDelay: '0s',
-				marginLeft: '-60px',
-				marginTop: '-4px',
-			} }
-		>
-			<p>
-				{ translate( 'Click on {{b}}Site Pages{{/b}} to see all the pages on your site.', {
-					components: { b: <strong /> },
-				} ) }
-			</p>
-			<Continue target="side-menu-page" step="choose-page" click hidden />
-		</Step>
-
-		<Step name="choose-page" target="page-contact" arrow="top-left" placement="below">
+		<Step name="init" target="page-contact" arrow="top-left" placement="below">
 			<p>
 				{ translate( 'Click {{b}}Contact{{/b}} to edit this page.', {
 					components: { b: <strong /> },

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -18,6 +18,7 @@ const tasks = {
 		completedTitle: 'You updated your About page',
 		completedButtonText: 'Change',
 		image: '/calypso/images/stats/tasks/about.svg',
+		url: '/pages/$siteSlug',
 		tour: 'checklistAboutPage',
 	},
 	avatar_uploaded: {
@@ -58,6 +59,7 @@ const tasks = {
 		completedTitle: 'You updated your Contact page',
 		completedButtonText: 'Edit',
 		image: '/calypso/images/stats/tasks/contact.svg',
+		url: '/pages/$siteSlug',
 		tour: 'checklistContactPage',
 	},
 	custom_domain_registered: {

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -59,7 +59,7 @@ const tasks = {
 		completedTitle: 'You updated your Contact page',
 		completedButtonText: 'Edit',
 		image: '/calypso/images/stats/tasks/contact.svg',
-		url: '/pages/$siteSlug',
+		url: '/post/$siteSlug/2',
 		tour: 'checklistContactPage',
 	},
 	custom_domain_registered: {


### PR DESCRIPTION
We plan to remove the explicit navigation steps from page tours.

# Testing

* create a new site
* verify that the contact page tour steps on the `/pages/$site` and highlights the contact page.