### PR TITLE
SitesPopover: a few janitorial cleanups

### DIFF
--- a/client/components/sites-popover/index.jsx
+++ b/client/components/sites-popover/index.jsx
@@ -16,9 +16,7 @@ import Popover from 'components/popover';
 import { hasTouch } from 'lib/touch-detect';
 import SiteSelector from 'components/site-selector';
 
-export default class extends React.Component {
-	static displayName = 'SitesPopover';
-
+class SitesPopover extends React.Component {
 	static propTypes = {
 		showDelay: PropTypes.number,
 		context: PropTypes.object,
@@ -39,31 +37,11 @@ export default class extends React.Component {
 		className: '',
 	};
 
-	state = {
-		popoverVisible: false,
-	};
-
-	componentDidMount() {
-		this.updatePopoverVisibilityState();
-	}
-
-	componentDidUpdate( prevProps ) {
-		if ( this.props.visible !== prevProps.visible ) {
-			this.updatePopoverVisibilityState();
-		}
-	}
-
-	updatePopoverVisibilityState = () => {
-		this.setState( {
-			popoverVisible: this.props.visible,
-		} );
-	};
-
-	renderHeader = () => {
+	renderHeader() {
 		return <div className="sites-popover__header">{ this.props.header }</div>;
-	};
+	}
 
-	renderSiteSelector = () => {
+	renderSiteSelector() {
 		return (
 			<SiteSelector
 				siteBasePath="/post"
@@ -75,10 +53,10 @@ export default class extends React.Component {
 				onClose={ this.props.onClose }
 			/>
 		);
-	};
+	}
 
 	render() {
-		let classes = classnames(
+		const classes = classnames(
 			this.props.className,
 			'popover sites-popover',
 			this.props.header && 'has-header'
@@ -100,3 +78,5 @@ export default class extends React.Component {
 		);
 	}
 }
+
+export default SitesPopover;


### PR DESCRIPTION
- remove the `popoverVisible` state property and the code that updates it. It's not used
  and the `visible` prop provides exactly the same information anyway.
- change the `renderHeader` and `renderSiteSelector` class properties to class methods.
  They don't need a `this` binding and classic methods are somewhat faster.
- fix one ESlint warning (`let` vs `const`)
- remove `displayName` property and replace it with giving the class a name

**How to test:**
There should be no behavior change. Verify that the sites popover that appears when you click "Write" in masterbar:

<img width="362" alt="sites-popover" src="https://user-images.githubusercontent.com/664258/35559777-d4e77448-05ab-11e8-96c5-e4df0176392e.png">

continues to work as expected.