### PR TITLE
Remove the "chown" on the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN        bash /tmp/env-config.sh
 COPY       ./package.json ./npm-shrinkwrap.json /calypso/
 RUN        true \
            && npm install --production \
-           && chown -R nobody node_modules \
            && rm -rf /root/.npm \
            && true
 
@@ -57,10 +56,7 @@ RUN        touch node_modules
 ARG        commit_sha="(unknown)"
 ENV        COMMIT_SHA $commit_sha
 
-RUN        true \
-           && CALYPSO_ENV=production npm run build \
-           && find . -not -path './node_modules/*' -print0 | xargs -0 chown nobody \
-           && true
+RUN        CALYPSO_ENV=production npm run build
 
 USER       nobody
 CMD        NODE_ENV=production node build/bundle.js


### PR DESCRIPTION
Right now, in the Dockerfile:
* Build the whole Calypso with `root` permissions.
* `chown` everything to `nobody`.
* Change the current user to `nobody`.
* Run the server as `nobody`.

This PR removes the `chown` operation, which is an expensive one. All the built files and source files will be owned by `root`, with default permissions (`664`), which means they are read-only for the `nobody` user.

By definition, only the `build` steps should write files into the filesystem. If the server process is writing files, it means that those operations should be done in the `build` steps so the server is as performant as possible at runtime. This PR has the added advantage that, if any subsequent PR introduces logic that writes files at runtime, it will blow up in an spectacular way.

Test: https://dserve.a8c.com/?branch=try/remove-docker-chown
I've done a smoke test in `dserve` and everything seems to be working as expected, even the `devdocs`.