### PR TITLE
Send a uuid identifying the load start/end for easier accounting

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -84,6 +84,7 @@ export class LoginForm extends Component {
 			if ( window && window.calypsoLoadStartTime && window.calypsoLoadStartTime[ 'log-in' ] ) {
 				this.props.recordTracksEvent( 'calypso_load_end', {
 					elapsed_ms: window.performance.now() - window.calypsoLoadStartTime[ 'log-in' ].startTimestamp,
+					load_id: window.calypsoLoadStartTime[ 'log-in' ].loadId,
 					path: '/log-in',
 				} );
 

--- a/server/pages/index.pug
+++ b/server/pages/index.pug
@@ -275,7 +275,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 					var pixel = document.createElement( 'img' );
 					pixel.src = statsPixel + '?' + Object.keys( stats ).map( function (key) {
 						return encodeURIComponent( key ) + '=' + encodeURIComponent( stats[ key ] );
-					} ).join( '& ' );
+					} ).join( '&' );
 
 					var body = document.getElementsByTagName( 'body' )[ 0 ];
 					body.appendChild( pixel );

--- a/server/pages/index.pug
+++ b/server/pages/index.pug
@@ -238,8 +238,18 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 
 		script(type='text/javascript').
 			(function () {
+				function getUUID() {
+					var d = new Date().getTime();
+					var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace( /[xy]/g, function ( char ) {
+						var r = (d + Math.random() * 16) % 16 | 0;
+						d = Math.floor(d / 16);
+						return (char == 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+					} );
+					return uuid;
+				}
+
 				// Mini tracks
-				function recordTracksEvent( eventName, pathName ) {
+				function recordTracksEvent( eventName, pathName, loadId ) {
 					var statsPixel = '//pixel.wp.com/t.gif';
 					var stats = {
 						_pf: navigator.platform,
@@ -253,6 +263,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 						_tz: new Date().getTimezoneOffset() / 60,
 						_rt: Date.now(),
 						path: pathName,
+						load_id: loadId
 					};
 
 					if ( window.currentUser ) {
@@ -262,7 +273,9 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 					}
 
 					var pixel = document.createElement( 'img' );
-					pixel.src = statsPixel + '?' + Object.keys( stats ).map( key => encodeURIComponent( key ) + '=' + encodeURIComponent( stats[ key ] ) ).join( '& ' );
+					pixel.src = statsPixel + '?' + Object.keys( stats ).map( function (key) {
+						return encodeURIComponent( key ) + '=' + encodeURIComponent( stats[ key ] );
+					} ).join( '& ' );
 
 					var body = document.getElementsByTagName( 'body' )[ 0 ];
 					body.appendChild( pixel );
@@ -271,15 +284,24 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				}
 
 				try {
+					// exclude e2e tests
+					if ( navigator.userAgent.indexOf( 'wp-e2e-test' ) !== -1 ) {
+						return;
+					}
+
 					var pathName = window.location.pathname.split( "/" ).slice( 1, 2 )[ 0 ];
 					if ( pathName === 'log-in' && 'production' === window.configData.env ) {
+						var loadId = getUUID();
+						
+						var stats = recordTracksEvent( 'calypso_load_start', '/' + pathName, loadId );
 
-						var stats = recordTracksEvent( 'calypso_load_start', '/' + pathName );
 						if ( ! window.calypsoLoadStartTime ) {
 							window.calypsoLoadStartTime = {};
 						}
+
 						window.calypsoLoadStartTime[ pathName ] = {
 							startTimestamp: window.performance.now(),
+							loadId: loadId,
 						};
 
 					}


### PR DESCRIPTION
Followup to #21393

* Remove usage of arrow function
* Exclude e2e test from analytics
* Add (fake) uuid to identify the start/end couple 

#### Testing instructions
1. Run `git checkout update/load-events` and start your server, or open a [live branch](https://calypso.live/?branch=update/load-events)

2. comment out index.pug:273: `'production' === window.configData.env`

3. Assert event is sent via the pixel with load_id param ( on start and end event ) and elapsed_ms ( on the end event )
