### PR TITLE
Signup: Add the OAuth client ID to the login links on the signup form

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -326,6 +326,7 @@ class SignupForm extends Component {
 		return login( {
 			isNative: config.isEnabled( 'login/native-login-links' ),
 			redirectTo: this.props.redirectToAfterLoginUrl,
+			locale: this.props.locale,
 			oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
 		} );
 	}
@@ -619,6 +620,7 @@ export default connect(
 		oauth2Client: getCurrentOAuth2Client( state ),
 	} ),
 	{
-	trackLoginMidFlow: () => recordTracksEvent( 'calypso_signup_login_midflow' ),
-	createSocialUserFailed,
-} )( localize( SignupForm ) );
+		trackLoginMidFlow: () => recordTracksEvent( 'calypso_signup_login_midflow' ),
+		createSocialUserFailed,
+	}
+)( localize( SignupForm ) );

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -322,7 +322,7 @@ class SignupForm extends Component {
 		} );
 	};
 
-	loginLink() {
+	getLoginLink() {
 		return login( {
 			isNative: config.isEnabled( 'login/native-login-links' ),
 			redirectTo: this.props.redirectToAfterLoginUrl,
@@ -332,7 +332,7 @@ class SignupForm extends Component {
 	}
 
 	getNoticeMessageWithLogin( notice ) {
-		const link = this.loginLink();
+		const link = this.getLoginLink();
 
 		if ( notice.error === '2FA_enabled' ) {
 			return (
@@ -376,7 +376,7 @@ class SignupForm extends Component {
 			return;
 		}
 
-		let link = this.loginLink();
+		let link = this.getLoginLink();
 
 		return map( messages, ( message, error_code ) => {
 			if ( error_code === 'taken' ) {
@@ -570,7 +570,7 @@ class SignupForm extends Component {
 		}
 
 		const logInUrl = config.isEnabled( 'login/native-login-links' )
-			? this.loginLink()
+			? this.getLoginLink()
 			: addLocaleToWpcomUrl( config( 'login_url' ), this.props.locale );
 
 		return (

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -16,6 +16,7 @@ export function login( {
 	socialConnect,
 	emailAddress,
 	socialService,
+	oauth2ClientId,
 } = {} ) {
 	let url = config( 'login_url' );
 
@@ -49,6 +50,10 @@ export function login( {
 
 	if ( emailAddress ) {
 		url = addQueryArgs( { email_address: emailAddress }, url );
+	}
+
+	if ( oauth2ClientId ) {
+		url = addQueryArgs( { client_id: oauth2ClientId }, url );
 	}
 
 	return url;

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -52,7 +52,7 @@ export function login( {
 		url = addQueryArgs( { email_address: emailAddress }, url );
 	}
 
-	if ( oauth2ClientId ) {
+	if ( oauth2ClientId && ! isNaN( oauth2ClientId ) ) {
 		url = addQueryArgs( { client_id: oauth2ClientId }, url );
 	}
 

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -63,5 +63,11 @@ describe( 'index', () => {
 
 			expect( url ).to.equal( '/log-in?email_address=foo%40bar.com' );
 		} );
+
+		test( 'should return the login url with encoded OAuth2 client ID param', () => {
+			const url = login( { isNative: true, oauth2ClientId: 12345 } );
+
+			expect( url ).to.equal( '/log-in?client_id=12345' );
+		} );
 	} );
 } );


### PR DESCRIPTION
Attempt to rebase #21716

Copied instructions from #21716:
This hopefully, fixes #21710, an issue I opened after noticing that the client ID is not part of the URL in the login form links displayed on the sign up form. This means that if the user follows one of these links and refreshes the page, then the ID is lost from the state and the generic unbranded login page is displayed.

I've also put the generation of the link URL in its own method to reduce the repeated code. I realise this means that the code is not the minimum required to fix this bug, but I'm not sure if that's a problem or not. It would be quite straightforward to break it apart, but in my view would create unnecessary commits.

### Testing
1. Build a local version based on this code.
2. Go to http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D3073eba04c6018e59238c17d39565c35%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1
3. Click on the link to create an account
4. Click on the link to log in to an existing account
5. Reload the page and observe that you still see a login screen with Woocommerce styling.

Additionally it would be worth going through the first few steps of a standard sign up (http://calypso.localhost:3000/start) and checking that everything works as expected.
