### PR TITLE
Store: Disable email setting on empty input.

### DIFF
--- a/client/extensions/woocommerce/state/sites/settings/email/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/actions.js
@@ -106,7 +106,7 @@ export const emailSettingsSubmitSettings = ( siteId, settings ) => dispatch => {
 	// disable if user has emptied the input field
 	forEach( [ 'email_new_order', 'email_cancelled_order', 'email_failed_order' ], option => {
 		if ( get( settings, [ option, 'recipient', 'value' ], '' ).trim() === '' ) {
-			if ( has( settings[ option ], 'enabled ' ) ) {
+			if ( has( settings, [ option, 'enabled' ] ) ) {
 				settings[ option ].enabled.value = 'no';
 			}
 		}


### PR DESCRIPTION
### Information 
When input field in store email setting is empty the setting should be disabled on Save and copy text should be shown. This feature was initially implemented in https://github.com/Automattic/wp-calypso/pull/21648 but during addressing review findings this functionality was lost. 

### Testing
Go to store, settings, email. In one of the fields: New Order, Canceled Order, Failed Order, clean the input and leave the `Enabled` switch ON. Click Save. Switch should auto switch to disabled. 