### PR TITLE
Editor: Fix setting an existing page to "top level"

### DIFF
--- a/client/post-editor/editor-page-parent/index.jsx
+++ b/client/post-editor/editor-page-parent/index.jsx
@@ -40,7 +40,7 @@ class EditorPageParent extends Component {
 
 	updatePageParent( item ) {
 		const { siteId, postId } = this.props;
-		const parentId = item && item.ID ? item.ID : null;
+		const parentId = item && item.ID ? item.ID : 0;
 		this.props.editPost( siteId, postId, { parent: parentId } );
 	}
 

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -414,8 +414,7 @@ export const isEditedPostDirty = createSelector(
 						return ! moment( value ).isSame( post.date );
 					}
 					case 'parent': {
-						const parent = post.parent || 0;
-						return get( parent, 'ID', 0 ) !== value;
+						return get( post, 'parent.ID', 0 ) !== value;
 					}
 				}
 				return post[ key ] !== value;

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -414,7 +414,8 @@ export const isEditedPostDirty = createSelector(
 						return ! moment( value ).isSame( post.date );
 					}
 					case 'parent': {
-						return get( post, 'parent.ID', null ) !== value;
+						const parent = post.parent || 0;
+						return get( parent, 'ID', 0 ) !== value;
 					}
 				}
 				return post[ key ] !== value;


### PR DESCRIPTION
This was either caused or uncovered by #21937.

Attempting to set an existing "child" page back to "top level" is failing:

<img width="322" alt="screen shot 2018-01-30 at 11 58 40 am" src="https://user-images.githubusercontent.com/1587282/35579593-01da869e-05b5-11e8-9d3f-e8fa3c4d8c87.png">

...with error `{error: "invalid_input", message: "Invalid request input"}`

The API expects to be provided an integer `0` for this param.  This makes sure we send as such.

See #9833

## TO TEST

Follow instructions in #21937 on a new and existing page.  Setting top level and a hierarchical relationship should all work and not show the "are you sure" dialog.
