### PR TITLE
Rewind: Stop showing credentials form to everyone

### DIFF
--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -94,7 +94,10 @@ export default connect( state => {
 	const rewindState = getRewindState( state, siteId ).state;
 
 	return {
-		showRewindCredentials: rewindState.state !== 'unavailable',
+		showRewindCredentials:
+			rewindState === 'awaitingCredentials' ||
+			rewindState === 'provisioning' ||
+			rewindState === 'active',
 		site,
 		siteId,
 		siteIsJetpack: isJetpackSite( state, siteId ),


### PR DESCRIPTION
In the settings page where we determine whether or not to show
the credentials form we were using a blacklist of Rewind states
when we should have been using a whitelist _and_ we had a bug
in the logic which resulted in checking `rewindState.state.state`
instead of `rewindState.state` by itself. This meant that the
form always showed regardless of the real conditions.

This patch fixes the bug and flips the logic so we only show the
form when we know we want to, at risk of not showing it when we
should instead of risking showing it when we shouldn't.