### PR TITLE
Popover: listen to events only if Popover is visible

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -93,12 +93,6 @@ class Popover extends Component {
 		};
 	}
 
-	componentDidMount() {
-		this.bindEscKeyListener();
-		this.bindDebouncedReposition();
-		bindWindowListeners();
-	}
-
 	componentWillReceiveProps( nextProps ) {
 		// update context (target) reference into a property
 		if ( ! isDOMElement( nextProps.context ) ) {
@@ -140,6 +134,7 @@ class Popover extends Component {
 
 	componentWillUnmount() {
 		this.debug( 'unmounting .... ' );
+
 		this.unbindClickoutHandler();
 		this.unbindDebouncedReposition();
 		this.unbindEscKeyListener();
@@ -155,21 +150,12 @@ class Popover extends Component {
 			return null;
 		}
 
-		if ( this.escEventHandlerAdded ) {
-			return null;
-		}
-
 		this.debug( 'adding escKey listener ...' );
-		this.escEventHandlerAdded = true;
 		document.addEventListener( 'keydown', this.onKeydown, true );
 	}
 
 	unbindEscKeyListener() {
 		if ( ! this.props.closeOnEsc ) {
-			return null;
-		}
-
-		if ( ! this.escEventHandlerAdded ) {
 			return null;
 		}
 
@@ -381,6 +367,10 @@ class Popover extends Component {
 	}
 
 	show() {
+		this.bindEscKeyListener();
+		this.bindDebouncedReposition();
+		bindWindowListeners();
+
 		if ( ! this.props.showDelay ) {
 			this.setState( { show: true } );
 			return null;
@@ -397,6 +387,10 @@ class Popover extends Component {
 	hide() {
 		// unbind clickout-side event every time the component is hidden.
 		this.unbindClickoutHandler();
+		this.unbindDebouncedReposition();
+		this.unbindEscKeyListener();
+		unbindWindowListeners();
+
 		this.setState( { show: false } );
 		this.clearShowTimer();
 	}

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -93,6 +93,14 @@ class Popover extends Component {
 		};
 	}
 
+	componentDidMount() {
+		if ( this.state.show ) {
+			this.bindEscKeyListener();
+			this.bindDebouncedReposition();
+			bindWindowListeners();
+		}
+	}
+
 	componentWillReceiveProps( nextProps ) {
 		// update context (target) reference into a property
 		if ( ! isDOMElement( nextProps.context ) ) {
@@ -108,8 +116,14 @@ class Popover extends Component {
 		this.setPosition();
 	}
 
-	componentDidUpdate( prevProps ) {
+	componentDidUpdate( prevProps, prevState ) {
 		const { isVisible } = this.props;
+
+		if ( ! prevState.show && this.state.show ) {
+			this.bindEscKeyListener();
+			this.bindDebouncedReposition();
+			bindWindowListeners();
+		}
 
 		if ( isVisible !== prevProps.isVisible ) {
 			if ( isVisible ) {
@@ -367,10 +381,6 @@ class Popover extends Component {
 	}
 
 	show() {
-		this.bindEscKeyListener();
-		this.bindDebouncedReposition();
-		bindWindowListeners();
-
 		if ( ! this.props.showDelay ) {
 			this.setState( { show: true } );
 			return null;


### PR DESCRIPTION
Part of optimizing the Stats page.

@jsnajdr noticed that on the Stats page, we render lots of `Popover`s (30+) for the charts. Each one of them listens to some window events such as `scroll`, `resize`, etc. It is unnecessary for the popovers to listen to these events if they are not visible.

## Testing

Don't checkout this branch. In your dev console, execute the following: `localStorage.setItem('debug', 'calypso:popover*')`. Reload the Stats page and scroll. You should see plenty of logs on every scroll. Now, if you checkout this branch and do the same, you should not see any of the logs when scrolling (you'll still see some initial ones). When you hover over the chart on Stats page, you should see some logs that the events are being listened to.

It's important to also test different usages of `Popover`. For example, in Media library, if you click on the following:

![screen shot 2018-01-30 at 18 29 59](https://user-images.githubusercontent.com/4988512/35581282-9de1ad48-05eb-11e8-813d-7645694f659d.png)

it should work as before. Try hitting the Esc key. It should close the popover.