### PR TITLE
Plugin Item: Remove styles so that the info icon shows up

### DIFF
--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -22,12 +22,6 @@
 	.plugins-list &.is-compact:last-child {
 		margin-bottom: 0;
 	}
-
-	.notice.is-info {
-		.notice__icon {
-			display: none;
-		}
-	}
 }
 
 .plugin-item {


### PR DESCRIPTION
Currently the info icon doesn't show up as expected.

Before:
![screen shot 2018-01-30 at 10 16 50 am](https://user-images.githubusercontent.com/115071/35583430-bf51f784-05a6-11e8-83fc-cee3d50a2b93.png)

After:
![screen shot 2018-01-30 at 10 14 47 am](https://user-images.githubusercontent.com/115071/35583389-a42ea9ca-05a6-11e8-92c3-5445344c3ca0.png)

To test:
Go to the manage section of the plugin list: (single site plugin list view) 
Notice that the icon appears as expected when you perform an action on a plugin in the list


