### PR TITLE
Inline Help: fix keyboard navigation for context results when state is empty

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -121,6 +121,10 @@ class InlineHelpSearchResults extends Component {
 		return selectedLink.link;
 	}
 
+	componentDidMount() {
+		this.props.setSearchResults( '', this.getContextResults() );
+	}
+
 	componentWillUpdate( nextProps ) {
 		if ( nextProps.shouldOpenSelectedResult ) {
 			const url = this.getSelectedUrl();

--- a/client/state/inline-help/reducer.js
+++ b/client/state/inline-help/reducer.js
@@ -58,8 +58,8 @@ export const search = createReducer(
 			} );
 		},
 		[ INLINE_HELP_SELECT_PREVIOUS_RESULT ]: state => {
-			const newResult = ( state.selectedResult - 1 ) % state.items[ state.searchQuery ].length;
 			if ( state.items[ state.searchQuery ] && state.items[ state.searchQuery ].length ) {
+				const newResult = ( state.selectedResult - 1 ) % state.items[ state.searchQuery ].length;
 				return Object.assign( {}, state, {
 					selectedResult: newResult < 0 ? state.items[ state.searchQuery ].length - 1 : newResult,
 				} );


### PR DESCRIPTION
#21495 introduced Inline Help, but came with a bug that manifests only when its redux state is still empty. The results for the empty query — the "context results" we show when a user opens Inline Help and doesn't enter a search query — didn't get set in the redux state, so keyboard navigation didn't work. 

This PR fixes this problem by setting those results when the component mounts. 

To test:
- open inline help
- use the keyboard to navigate the default results (arrow up / down) and make sure that that works