### PR TITLE
Avoid lodash.merge in the me/settings data-layer handler

### DIFF
--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { includes, isEmpty, keys, mapValues, noop } from 'lodash';
+import { isEmpty, keys, mapValues, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,10 +22,10 @@ import { USER_SETTINGS_REQUEST, USER_SETTINGS_SAVE } from 'state/action-types';
  * Decodes entities in those specific user settings properties
  * that the REST API returns already HTML-encoded
  */
-const PROPERTIES_TO_DECODE = [ 'display_name', 'description', 'user_URL' ];
+const PROPERTIES_TO_DECODE = new Set( [ 'display_name', 'description', 'user_URL' ] );
 function fromApi( apiResponse ) {
 	return mapValues( apiResponse, ( value, name ) => {
-		if ( includes( PROPERTIES_TO_DECODE, name ) ) {
+		if ( PROPERTIES_TO_DECODE.has( name ) ) {
 			return decodeEntities( value );
 		}
 

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { isEmpty, keys, merge, noop } from 'lodash';
+import { includes, isEmpty, keys, mapValues, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,16 +22,15 @@ import { USER_SETTINGS_REQUEST, USER_SETTINGS_SAVE } from 'state/action-types';
  * Decodes entities in those specific user settings properties
  * that the REST API returns already HTML-encoded
  */
+const PROPERTIES_TO_DECODE = [ 'display_name', 'description', 'user_URL' ];
 function fromApi( apiResponse ) {
-	const decodedValues = {
-		display_name: apiResponse.display_name && decodeEntities( apiResponse.display_name ),
-		description: apiResponse.description && decodeEntities( apiResponse.description ),
-		user_URL: apiResponse.user_URL && decodeEntities( apiResponse.user_URL ),
-	};
+	return mapValues( apiResponse, ( value, name ) => {
+		if ( includes( PROPERTIES_TO_DECODE, name ) ) {
+			return decodeEntities( value );
+		}
 
-	// Some keys in the `decodedValues` can be undefined, and _.merge will ignore them,
-	// while Object.assign or object spread operator wouldn't.
-	return merge( {}, apiResponse, decodedValues );
+		return value;
+	} );
 }
 
 /*


### PR DESCRIPTION
I'd like to give another shot at upgrade of lodash to version 4.17.4, which was attempted
and abandoned in #13575. One of the breaking API changes is behavior of `_.merge`:

4.15.0
```js
_.merge( { a: 1 }, { a: undefined, b: undefined } ) = { a: 1 }
```

4.17.4
```js
_.merge( { a: 1 }, { a: undefined, b: undefined } ) = { a: 1, b: undefined }
```

I.e., property with `undefined` value doesn't overwrite a "better" value that's on the
object we're merging into. But if the property doesn't exist there at all, it's added
in the new version and is not in the old one.

This patch rewrites the `me/settings` data-layer handler to use `mapValues` instead of
`merge` and avoids dealing with that incompatibility.

**How to test:**
This handler is not used anywhere yet (I wrote it during my trial project) and there is only
unit test for it. Verify that the unit tests pass.