### PR TITLE
Store Orders: Check if shipping value is NaN, display empty input

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import { every, find, findIndex, get, noop, isNaN } from 'lodash';
+import { every, find, findIndex, get, isNaN, noop } from 'lodash';
 
 /**
  * Internal dependencies

--- a/client/extensions/woocommerce/app/order/order-details/table.js
+++ b/client/extensions/woocommerce/app/order/order-details/table.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import { every, find, findIndex, get, noop } from 'lodash';
+import { every, find, findIndex, get, noop, isNaN } from 'lodash';
 
 /**
  * Internal dependencies
@@ -344,6 +344,7 @@ class OrderDetailsTable extends Component {
 
 		const showTax = this.shouldShowTax();
 		const initialShippingValue = getCurrencyFormatDecimal( order.shipping_total, order.currency );
+		const currentShippingValue = getOrderShippingTotal( order );
 		const refundValue = getOrderRefundTotal( order );
 		const totalTaxValue = getOrderTotalTax( order );
 		const totalValue = isEditing ? getOrderTotal( order ) + totalTaxValue : order.total;
@@ -386,7 +387,7 @@ class OrderDetailsTable extends Component {
 						currency={ order.currency }
 						label={ translate( 'Shipping' ) }
 						initialValue={ initialShippingValue }
-						value={ getOrderShippingTotal( order ) }
+						value={ isNaN( currentShippingValue ) ? '' : currentShippingValue }
 						taxValue={ getOrderShippingTax( order ) }
 						showTax={ showTax }
 						isEditable={ isEditing }


### PR DESCRIPTION
Fixes #21976  – In the create/edit mode, the shipping value is forced to zero even when the input value is `''`. This was due to how the input displayed `NaN`, the result from `getOrderShippingTotal`. This fix detects that `NaN`, which is caused by erasing the shipping input, and displays the empty string - as the user would expect when they hit delete.

To test:

- Start a new order: `/store/order/:site`
- Click into the shipping input
- Delete the value
- It should delete 👍 

You can enter in other values, and delete those too.