### PR TITLE
Framework: add support-user route

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -9,7 +9,7 @@ import qs from 'qs';
 import { execSync } from 'child_process';
 import cookieParser from 'cookie-parser';
 import debugFactory from 'debug';
-import { get, pick, forEach, intersection } from 'lodash';
+import { get, includes, pick, forEach, intersection } from 'lodash';
 
 /**
  * Internal dependencies
@@ -525,6 +525,56 @@ module.exports = function() {
 		res.render( 'browsehappy', {
 			...req.context,
 			dashboardUrl,
+		} );
+	} );
+
+	app.get( '/support-user', function( req, res ) {
+		// Do not iframe
+		res.set( {
+			'X-Frame-Options': 'DENY',
+		} );
+
+		if ( ! req.cookies.wordpress_logged_in ) {
+			return res.render( 'support-user', {
+				authorized: false,
+			} );
+		}
+
+		// Maybe not logged in, note that you need docker to test this properly
+		if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
+			const user = require( 'user-bootstrap' );
+
+			debug( 'Issuing API call to fetch user object' );
+			const geoCountry = req.get( 'x-geoip-country-code' ) || '';
+			user( req.cookies.wordpress_logged_in, geoCountry, function( error, data ) {
+				if ( error ) {
+					res.clearCookie( 'wordpress_logged_in', {
+						path: '/',
+						httpOnly: true,
+						domain: '.wordpress.com',
+					} );
+
+					return res.render( 'support-user', {
+						authorized: false,
+					} );
+				}
+
+				const activeFlags = get( data, 'meta.data.flags.active_flags', [] );
+
+				// A8C check
+				if ( ! includes( activeFlags, 'calypso_support_user' ) ) {
+					return res.render( 'support-user', {
+						authorized: false,
+					} );
+				}
+			} );
+		}
+
+		// Passed all checks, prepare support user session
+		return res.render( 'support-user', {
+			authorized: true,
+			supportUser: req.query.support_user,
+			supportToken: req.query._support_token,
 		} );
 	} );
 

--- a/server/pages/support-user.pug
+++ b/server/pages/support-user.pug
@@ -1,0 +1,23 @@
+doctype html
+
+html
+	head
+		script.
+			const user = "#{supportUser}";
+			const token = "#{supportToken}";
+			const authorized = #{authorized};
+
+			const url = window.location.toString();
+
+			if ( url.indexOf('?') > 0 ) {
+				const cleanUrl = url.substring( 0, url.indexOf( '?' ) );
+				window.history.replaceState( {}, document.title, cleanUrl );
+			}
+
+			if ( authorized ) {
+				window.sessionStorage.setItem( 'boot_support_user', JSON.stringify( { user, token } ) );
+			}
+
+			window.location.replace( '/' );
+
+body


### PR DESCRIPTION
Splits out the `support-user` route code from https://github.com/Automattic/wp-calypso/pull/21674 and aims to implement additional checks. This will also enable us to whitelist this route in advance and make the deploy process smoother, removing the SU downtime in transition.

### Testing instructions

For complete flow please follow the instructions available in D9046-code.