### PR TITLE
Rewind: Prevent credentials form submission when server user is root

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -79,11 +79,22 @@ export class RewindCredentialsForm extends Component {
 			...this.state.form,
 		};
 
+		let userError = '';
+
+		if ( ! payload.user ) {
+			userError = translate( 'Please enter your server username.' );
+		} else if ( 'root' === payload.user ) {
+			userError = translate(
+				"We can't accept credentials for the root user. " +
+					'Please acquire or create credentials for another user with access to your server.'
+			);
+		}
+
 		const errors = Object.assign(
 			! payload.host && { host: translate( 'Please enter a valid server address.' ) },
 			! payload.port && { port: translate( 'Please enter a valid server port.' ) },
 			isNaN( payload.port ) && { port: translate( 'Port number must be numeric.' ) },
-			! payload.user && { user: translate( 'Please enter your server username.' ) },
+			userError && { user: userError },
 			! payload.pass &&
 				! payload.kpri && { pass: translate( 'Please enter your server password.' ) }
 		);

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -86,7 +86,7 @@ export class RewindCredentialsForm extends Component {
 		} else if ( 'root' === payload.user ) {
 			userError = translate(
 				"We can't accept credentials for the root user. " +
-					'Please acquire or create credentials for another user with access to your server.'
+					'Please provide or create credentials for another user with access to your server.'
 			);
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/21026

I think [we're all in agreement](https://github.com/Automattic/wp-calypso/issues/21026) that we should not accept root credentials for Rewind. This PR prevents the credentials form from being submitted when the user field is "root".

![screen shot 2018-01-30 at 11 36 11 pm](https://user-images.githubusercontent.com/5528445/35605369-70d51f58-0616-11e8-99a3-3d11113f9b7b.png)

**Testing instructions**
1. Try to submit the form with a username set to `root`. The form should not be submitted and should include a descriptive error message.
2. Ensure all other parts of the form function normally.