### PR TITLE
Store: Only send back modified values back to the payment method API

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/payment-methods/index.js
+++ b/client/extensions/woocommerce/state/data-layer/payment-methods/index.js
@@ -18,36 +18,28 @@ export default {
 		( store, action ) => {
 			const { siteId, method, successAction, failureAction } = action;
 
-			const settings = {
-				enabled: method.enabled ? 'yes' : 'no',
-			};
-
+			const payload = {};
+			const settings = {};
 			Object.keys( method.settings ).map( settingKey => {
+				if ( 'enabled' === settingKey ) {
+					payload.enabled = method.settings.enabled;
+					return;
+				}
+
+				if ( 'title' === settingKey ) {
+					payload.title = method.settings.title.value;
+					return;
+				}
+
+				if ( 'description' === settingKey ) {
+					payload.description = method.settings.description.value;
+					return;
+				}
+
 				settings[ settingKey ] = method.settings[ settingKey ].value;
 			} );
 
-			// Temporary Fix.
-			// If blank values get passed back to the API (see https://github.com/Automattic/wp-calypso/pull/21618#issuecomment-358844061)
-			// the API call will fail. We can remove this hack when we stop the payment method saving code from passing up all fields, and
-			// only pass edited fields. See https://github.com/Automattic/wp-calypso/issues/21670
-			if ( 'stripe' === method.id ) {
-				if ( ! settings.payment_request_button_theme ) {
-					settings.payment_request_button_theme = 'dark';
-				}
-
-				if ( ! settings.payment_request_button_type ) {
-					settings.payment_request_button_type = 'buy';
-				}
-
-				if ( ! settings.payment_request_button_height ) {
-					settings.payment_request_button_height = '44';
-				}
-			}
-
-			const payload = {
-				settings,
-				description: method.description,
-			};
+			payload.settings = settings;
 
 			/**
 			 * A callback issued after a successful request

--- a/client/extensions/woocommerce/state/data-layer/ui/payments/index.js
+++ b/client/extensions/woocommerce/state/data-layer/ui/payments/index.js
@@ -5,7 +5,7 @@
  */
 
 import { translate } from 'i18n-calypso';
-import { isEmpty, isEqual } from 'lodash';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,12 +24,9 @@ import {
 } from 'woocommerce/state/sites/settings/general/selectors';
 import { getCurrencyWithEdits } from 'woocommerce/state/ui/payments/currency/selectors';
 import { saveCurrency } from 'woocommerce/state/sites/settings/general/actions';
-import {
-	getPaymentMethods,
-	arePaymentMethodsLoaded,
-} from 'woocommerce/state/sites/payment-methods/selectors';
+import { arePaymentMethodsLoaded } from 'woocommerce/state/sites/payment-methods/selectors';
 import { savePaymentMethod } from 'woocommerce/state/sites/payment-methods/actions';
-import { getPaymentMethodsWithEdits } from 'woocommerce/state/ui/payments/methods/selectors';
+import { getPaymentMethodsEdits } from 'woocommerce/state/ui/payments/methods/selectors';
 
 /**
  * Creates a list of actions required to save the currency settings.
@@ -81,23 +78,23 @@ const getSavePaymentMethodsSteps = ( state, siteId ) => {
 	}
 
 	const actions = [];
-	const serverMethods = getPaymentMethods( state, siteId );
-	const clientMethods = getPaymentMethodsWithEdits( state, siteId );
+	const edits = getPaymentMethodsEdits( state, siteId );
+	const { updates } = edits;
+	updates.forEach( update => {
+		const { id, ...settings } = update;
 
-	serverMethods.forEach( ( serverMethod, index ) => {
-		//todo: creates and deletes when we support them
-		const clientMethod = clientMethods[ index ];
-		if ( isEqual( serverMethod, clientMethod ) ) {
-			return;
-		}
+		const method = {
+			id,
+			settings,
+		};
 
 		actions.push( {
-			description: translate( 'Saving method: %s', { args: [ serverMethod.id ] } ),
+			description: translate( 'Saving method: %s', { args: [ id ] } ),
 			onStep: ( dispatch, actionList ) => {
 				dispatch(
 					savePaymentMethod(
 						siteId,
-						clientMethod,
+						method,
 						actionListStepSuccess( actionList ),
 						actionListStepFailure( actionList )
 					)

--- a/client/extensions/woocommerce/state/ui/payments/methods/reducer.js
+++ b/client/extensions/woocommerce/state/ui/payments/methods/reducer.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { isEmpty, isEqual } from 'lodash';
+import { isEmpty, isEqual, compact } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +16,7 @@ import {
 	WOOCOMMERCE_PAYMENT_METHOD_EDIT_FIELD,
 	WOOCOMMERCE_PAYMENT_METHOD_EDIT_ENABLED,
 	WOOCOMMERCE_PAYMENT_METHOD_OPEN,
+	WOOCOMMERCE_PAYMENT_METHOD_UPDATE_SUCCESS,
 } from '../../../action-types';
 import { getBucket } from '../../helpers';
 
@@ -113,10 +114,33 @@ function openAction( state, { id } ) {
 	};
 }
 
+function paymentMethodUpdatedAction( state, { data } ) {
+	const bucket = getBucket( { id: data.id } );
+
+	if ( bucket ) {
+		const prevEdits = state || {};
+		const prevBucketEdits = prevEdits[ bucket ] || [];
+
+		const newBucketEdits = compact(
+			prevBucketEdits.map( paymentEdit => {
+				return isEqual( data.id, paymentEdit.id ) ? undefined : paymentEdit;
+			} )
+		);
+
+		return {
+			...prevEdits,
+			[ bucket ]: newBucketEdits.length ? newBucketEdits : [],
+		};
+	}
+
+	return state;
+}
+
 export default createReducer( initialState, {
 	[ WOOCOMMERCE_PAYMENT_METHOD_CANCEL ]: cancelAction,
 	[ WOOCOMMERCE_PAYMENT_METHOD_CLOSE ]: closeAction,
 	[ WOOCOMMERCE_PAYMENT_METHOD_EDIT_FIELD ]: editFieldAction,
 	[ WOOCOMMERCE_PAYMENT_METHOD_EDIT_ENABLED ]: changeEnabledAction,
 	[ WOOCOMMERCE_PAYMENT_METHOD_OPEN ]: openAction,
+	[ WOOCOMMERCE_PAYMENT_METHOD_UPDATE_SUCCESS ]: paymentMethodUpdatedAction,
 } );

--- a/client/extensions/woocommerce/state/ui/payments/methods/selectors.js
+++ b/client/extensions/woocommerce/state/ui/payments/methods/selectors.js
@@ -15,7 +15,7 @@ import {
 	arePaymentMethodsLoaded,
 } from 'woocommerce/state/sites/payment-methods/selectors';
 
-const getPaymentMethodsEdits = ( state, siteId ) => {
+export const getPaymentMethodsEdits = ( state, siteId ) => {
 	return get( state, [ 'extensions', 'woocommerce', 'ui', 'payments', siteId, 'methods' ] );
 };
 

--- a/client/extensions/woocommerce/state/ui/payments/methods/test/reducer.js
+++ b/client/extensions/woocommerce/state/ui/payments/methods/test/reducer.js
@@ -201,4 +201,42 @@ describe( 'reducer', () => {
 			] );
 		} );
 	} );
+
+	describe( 'paymentMethodUpdatedAction', () => {
+		test( 'should clear edits update state on successful update', () => {
+			const state = {
+				updates: [ { id: 'stripe', name: 'Previous Value' } ],
+			};
+
+			const action = {
+				type: 'WOOCOMMERCE_PAYMENT_METHOD_UPDATE_SUCCESS',
+				siteId,
+				data: {
+					id: 'stripe',
+					method_title: 'Stripe',
+				},
+			};
+
+			const newState = reducer( state, action );
+			expect( newState.updates ).to.deep.equal( [] );
+		} );
+
+		test( 'should remove edits update state for a single payment method on successful update', () => {
+			const state = {
+				updates: [ { id: 'stripe', title: 'Testing Stripe' }, { id: 'paypal', title: 'PayPal' } ],
+			};
+
+			const action = {
+				type: 'WOOCOMMERCE_PAYMENT_METHOD_UPDATE_SUCCESS',
+				siteId,
+				data: {
+					id: 'stripe',
+					title: 'Stripe',
+				},
+			};
+
+			const newState = reducer( state, action );
+			expect( newState.updates ).to.deep.equal( [ { id: 'paypal', title: 'PayPal' } ] );
+		} );
+	} );
 } );


### PR DESCRIPTION
Fixes #21670.

This PR modifies the action list code to only send back modified values to the REST API, instead of the full payment method object.

It also clears out updates state from our edits object on successful save (so that you can make further changes without passing back existing edits over the API) like we do in other places like products state.

To Test:
* Run `npm run test-client client/extensions/woocommerce/state` and make sure all tests pass.
* Go to `http://calypso.localhost:3000/store/settings/payments/:store`
* Modify various payment methods. This includes titles, descriptions, settings (like BACs accounts), and toggling enabled/disabled for various payment methods. Make sure after saving, all values are displayed correctly.
* Do a hard refresh to verify your settings saved correctly and that there was no data loss.
* Do the above once more with different settings to make sure everything is 💯 .