### PR TITLE
Plans: change copy about free themes.

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -784,7 +784,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_FREE_THEMES_SIGNUP ]: {
 		getSlug: () => FEATURE_FREE_THEMES_SIGNUP,
-		getTitle: () => i18n.translate( '100+ Free Themes' ),
+		getTitle: () => i18n.translate( 'Dozens of Free Themes' ),
 	},
 
 	[ FEATURE_WP_SUBDOMAIN_SIGNUP ]: {
@@ -1059,7 +1059,7 @@ export const FEATURES_LIST = {
 
 	[ FEATURE_FREE_THEMES ]: {
 		getSlug: () => FEATURE_FREE_THEMES,
-		getTitle: () => i18n.translate( '100+ Free Themes' ),
+		getTitle: () => i18n.translate( 'Dozens of Free Themes' ),
 		getDescription: () =>
 			i18n.translate(
 				'Access to a wide range of professional theme templates ' +


### PR DESCRIPTION
Since the number of free themes has been changed( see p9jf6J-bi-p2 ), we need to tweak the copy about free themes. The new copy will be "Dozens of Free Themes" instead of "100+ of Free Themes" as follows:
![image](https://user-images.githubusercontent.com/212034/35608356-1f0c3a40-069c-11e8-9f0f-e69c2209be9c.png)

This change will affect both the free and personal plans.

## How to test

1. Follow the site creation flow.
2. You should be able to see the plans page contains the updated copy.

cc @anneforbush 
