### PR TITLE
Present different options in cancellation according to product

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -130,152 +130,90 @@ class CancelPurchaseForm extends React.Component {
 	renderQuestionOne = () => {
 		const reasons = {};
 		const { translate } = this.props;
+		const { questionOneOrder, questionOneRadio, questionOneText } = this.state;
 
-		const couldNotInstallInput = (
-			<FormTextInput
-				className="cancel-purchase-form__reason-input"
-				name="couldNotInstallInput"
-				id="couldNotInstallInput"
-				value={ this.state.questionOneText }
-				onChange={ this.onTextOneChange }
-				placeholder={ translate( 'What plugin/theme were you trying to install?' ) }
-			/>
-		);
-		reasons.couldNotInstall = (
-			<FormLabel key="couldNotInstall">
-				<FormRadio
-					name="couldNotInstall"
-					value="couldNotInstall"
-					checked={ 'couldNotInstall' === this.state.questionOneRadio }
-					onChange={ this.onRadioOneChange }
+		const radioOption = (
+			key,
+			radioValue,
+			textValue,
+			onRadioChange,
+			onTextChange,
+			radioPrompt,
+			textPlaceholder
+		) => {
+			const textInputKey = `${ key }Input`;
+
+			const textInput = (
+				<FormTextInput
+					className="cancel-purchase-form__reason-input"
+					name={ textInputKey }
+					id={ textInputKey }
+					value={ textValue }
+					onChange={ onTextChange }
+					placeholder={ textPlaceholder }
 				/>
-				<span>{ translate( "I couldn't install a plugin/theme I wanted." ) }</span>
-				{ 'couldNotInstall' === this.state.questionOneRadio && couldNotInstallInput }
-			</FormLabel>
+			);
+			return (
+				<FormLabel key={ key }>
+					<FormRadio
+						name={ key }
+						value={ key }
+						checked={ key === radioValue }
+						onChange={ onRadioChange }
+					/>
+					<span>{ radioPrompt }</span>
+					{ key === radioValue && textInput }
+				</FormLabel>
+			);
+		};
+
+		const radioOptionOne = ( key, radioPrompt, textPlaceholder ) =>
+			radioOption(
+				key,
+				questionOneRadio,
+				questionOneText,
+				this.onRadioOneChange,
+				this.onTextOneChange,
+				radioPrompt,
+				textPlaceholder
+			);
+
+		reasons.couldNotInstall = radioOptionOne(
+			'couldNotInstall',
+			translate( "I couldn't install a plugin/theme I wanted." ),
+			translate( 'What plugin/theme were you trying to install?' )
 		);
 
-		const tooHardInput = (
-			<FormTextInput
-				className="cancel-purchase-form__reason-input"
-				name="tooHardInput"
-				id="tooHardInput"
-				value={ this.state.questionOneText }
-				onChange={ this.onTextOneChange }
-				placeholder={ translate( 'Where did you run into problems?' ) }
-			/>
-		);
-		reasons.tooHard = (
-			<FormLabel key="tooHard">
-				<FormRadio
-					name="tooHard"
-					value="tooHard"
-					checked={ 'tooHard' === this.state.questionOneRadio }
-					onChange={ this.onRadioOneChange }
-				/>
-				<span>{ translate( 'It was too hard to set up my site.' ) }</span>
-				{ 'tooHard' === this.state.questionOneRadio && tooHardInput }
-			</FormLabel>
+		reasons.tooHard = radioOptionOne(
+			'tooHard',
+			translate( 'It was too hard to set up my site.' ),
+			translate( 'Where did you run into problems?' )
 		);
 
-		const didNotIncludeInput = (
-			<FormTextInput
-				className="cancel-purchase-form__reason-input"
-				name="didNotIncludeInput"
-				id="didNotIncludeInput"
-				value={ this.state.questionOneText }
-				onChange={ this.onTextOneChange }
-				placeholder={ translate( 'What are we missing that you need?' ) }
-			/>
-		);
-		reasons.didNotInclude = (
-			<FormLabel key="didNotInclude">
-				<FormRadio
-					name="didNotInclude"
-					value="didNotInclude"
-					checked={ 'didNotInclude' === this.state.questionOneRadio }
-					onChange={ this.onRadioOneChange }
-				/>
-				<span>{ translate( "This upgrade didn't include what I needed." ) }</span>
-				{ 'didNotInclude' === this.state.questionOneRadio && didNotIncludeInput }
-			</FormLabel>
+		reasons.didNotInclude = radioOptionOne(
+			'didNotInclude',
+			translate( "This upgrade didn't include what I needed." ),
+			translate( 'What are we missing that you need?' )
 		);
 
-		const onlyNeedFreeInput = (
-			<FormTextInput
-				className="cancel-purchase-form__reason-input"
-				name="onlyNeedFreeInput"
-				id="onlyNeedFreeInput"
-				value={ this.state.questionOneText }
-				onChange={ this.onTextOneChange }
-				placeholder={ translate( 'How can we improve our upgrades?' ) }
-			/>
-		);
-		reasons.onlyNeedFree = (
-			<FormLabel key="onlyNeedFree">
-				<FormRadio
-					name="onlyNeedFree"
-					value="onlyNeedFree"
-					checked={ 'onlyNeedFree' === this.state.questionOneRadio }
-					onChange={ this.onRadioOneChange }
-				/>
-				<span>{ translate( 'The plan was too expensive.' ) }</span>
-				{ 'onlyNeedFree' === this.state.questionOneRadio && onlyNeedFreeInput }
-			</FormLabel>
+		reasons.onlyNeedFreeInput = radioOptionOne(
+			'onlyNeedFree',
+			translate( 'The plan was too expensive.' ),
+			translate( 'How can we improve our upgrades?' )
 		);
 
-		const anotherReasonOneInput = (
-			<FormTextInput
-				className="cancel-purchase-form__reason-input"
-				name="anotherReasonOneInput"
-				value={ this.state.questionOneText }
-				onChange={ this.onTextOneChange }
-				id="anotherReasonOneInput"
-			/>
-		);
-		reasons.anotherReasonOne = (
-			<FormLabel key="anotherReasonOne">
-				<FormRadio
-					name="anotherReasonOne"
-					value="anotherReasonOne"
-					checked={ 'anotherReasonOne' === this.state.questionOneRadio }
-					onChange={ this.onRadioOneChange }
-				/>
-				<span>{ translate( 'Another reason…' ) }</span>
-				{ 'anotherReasonOne' === this.state.questionOneRadio && anotherReasonOneInput }
-			</FormLabel>
-		);
+		reasons.anotherReasonOne = radioOptionOne( 'anotherReasonOne', translate( 'Another reason…' ) );
 
-		// Survey questions only for Jetpack subscriptions
-		const couldNotActivateInput = (
-			<FormTextInput
-				className="cancel-purchase-form__reason-input"
-				name="couldNotActivateInput"
-				id="couldNotActivateInput"
-				value={ this.state.questionOneText }
-				onChange={ this.onTextOneChange }
-				placeholder={ translate( 'Where did you run into problems?' ) }
-			/>
+		reasons.couldNotActivate = radioOption(
+			'couldNotActivate',
+			translate( 'I was unable to activate or use the product.' ),
+			translate( 'Where did you run into problems?' )
 		);
-		reasons.couldNotActivate = (
-			<FormLabel key="couldNotActivate">
-				<FormRadio
-					name="couldNotActivate"
-					value="couldNotActivate"
-					checked={ 'couldNotActivate' === this.state.questionOneRadio }
-					onChange={ this.onRadioOneChange }
-				/>
-				<span>{ translate( 'I was unable to activate or use the product.' ) }</span>
-				{ 'couldNotActivate' === this.state.questionOneRadio && couldNotActivateInput }
-			</FormLabel>
-		);
-
-		const { questionOneOrder } = this.state,
-			orderedReasons = questionOneOrder.map( question => reasons[ question ] );
 
 		return (
 			<div>
 				<FormLegend>{ translate( 'Please tell us why you are canceling:' ) }</FormLegend>
-				{ orderedReasons }
+				{ questionOneOrder.map( question => reasons[ question ] ) }
 			</div>
 		);
 	};

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -25,8 +25,11 @@ import * as steps from './steps';
 import BusinessATStep from './stepComponents/business-at-step';
 import UpgradeATStep from './stepComponents/upgrade-at-step';
 import { getName } from 'lib/purchases';
-import { isJetpackPlan } from 'lib/products-values';
 import { radioOption } from './radioOption';
+import {
+	cancellationOptionsForPurchase,
+	nextAdventureOptionsForPurchase,
+} from './optionsForProduct';
 
 class CancelPurchaseForm extends React.Component {
 	static propTypes = {
@@ -43,27 +46,9 @@ class CancelPurchaseForm extends React.Component {
 	constructor( props ) {
 		super( props );
 
-		// shuffle reason order, but keep anotherReasonOne last
-		let questionOneOrder = shuffle( [
-			'couldNotInstall',
-			'tooHard',
-			'didNotInclude',
-			'onlyNeedFree',
-		] );
-
-		let questionTwoOrder = shuffle( [
-			'stayingHere',
-			'otherWordPress',
-			'differentService',
-			'noNeed',
-		] );
-
-		// set different reason groupings for Jetpack subscribers
-		if ( isJetpackPlan( props.purchase ) ) {
-			questionOneOrder = shuffle( [ 'couldNotActivate', 'didNotInclude', 'onlyNeedFree' ] );
-
-			questionTwoOrder = shuffle( [ 'stayingHere', 'otherPlugin', 'leavingWP', 'noNeed' ] );
-		}
+		const { purchase } = props;
+		const questionOneOrder = shuffle( cancellationOptionsForPurchase( purchase ) );
+		const questionTwoOrder = shuffle( nextAdventureOptionsForPurchase( purchase ) );
 
 		questionOneOrder.push( 'anotherReasonOne' );
 		questionTwoOrder.push( 'anotherReasonTwo' );

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -51,7 +51,10 @@ class CancelPurchaseForm extends React.Component {
 		const questionTwoOrder = shuffle( nextAdventureOptionsForPurchase( purchase ) );
 
 		questionOneOrder.push( 'anotherReasonOne' );
-		questionTwoOrder.push( 'anotherReasonTwo' );
+
+		if ( questionTwoOrder.length > 0 ) {
+			questionTwoOrder.push( 'anotherReasonTwo' );
+		}
 
 		this.state = {
 			questionOneRadio: null,
@@ -160,6 +163,21 @@ class CancelPurchaseForm extends React.Component {
 		);
 
 		appendRadioOption(
+			'noLongerWantToTransfer',
+			translate( 'I no longer want to transfer my domain.' )
+		);
+
+		appendRadioOption(
+			'couldNotCompleteTransfer',
+			translate( 'Something went wrong and I could not complete the transfer.' )
+		);
+
+		appendRadioOption(
+			'useDomainWithoutTransferring',
+			translate( 'I’m going to use my domain with WordPress.com without transferring it.' )
+		);
+
+		appendRadioOption(
 			'anotherReasonOne',
 			translate( 'Another reason…' ),
 			translate( 'How can we improve?' )
@@ -177,6 +195,10 @@ class CancelPurchaseForm extends React.Component {
 		const reasons = {};
 		const { translate } = this.props;
 		const { questionTwoOrder, questionTwoRadio, questionTwoText } = this.state;
+
+		if ( questionTwoOrder.length === 0 ) {
+			return null;
+		}
 
 		const appendRadioOption = ( key, radioPrompt, textPlaceholder ) =>
 			( reasons[ key ] = radioOption(

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -27,6 +27,41 @@ import * as steps from './steps';
 import BusinessATStep from './stepComponents/business-at-step';
 import UpgradeATStep from './stepComponents/upgrade-at-step';
 
+const radioOption = (
+	key,
+	radioValue,
+	textValue,
+	onRadioChange,
+	onTextChange,
+	radioPrompt,
+	textPlaceholder
+) => {
+	const textInputKey = `${ key }Input`;
+
+	const textInput = textPlaceholder && (
+		<FormTextInput
+			className="cancel-purchase-form__reason-input"
+			name={ textInputKey }
+			id={ textInputKey }
+			value={ textValue }
+			onChange={ onTextChange }
+			placeholder={ textPlaceholder }
+		/>
+	);
+	return (
+		<FormLabel key={ key }>
+			<FormRadio
+				name={ key }
+				value={ key }
+				checked={ key === radioValue }
+				onChange={ onRadioChange }
+			/>
+			<span>{ radioPrompt }</span>
+			{ key === radioValue && textInput }
+		</FormLabel>
+	);
+};
+
 class CancelPurchaseForm extends React.Component {
 	static propTypes = {
 		productName: PropTypes.string.isRequired,
@@ -132,43 +167,8 @@ class CancelPurchaseForm extends React.Component {
 		const { translate } = this.props;
 		const { questionOneOrder, questionOneRadio, questionOneText } = this.state;
 
-		const radioOption = (
-			key,
-			radioValue,
-			textValue,
-			onRadioChange,
-			onTextChange,
-			radioPrompt,
-			textPlaceholder
-		) => {
-			const textInputKey = `${ key }Input`;
-
-			const textInput = (
-				<FormTextInput
-					className="cancel-purchase-form__reason-input"
-					name={ textInputKey }
-					id={ textInputKey }
-					value={ textValue }
-					onChange={ onTextChange }
-					placeholder={ textPlaceholder }
-				/>
-			);
-			return (
-				<FormLabel key={ key }>
-					<FormRadio
-						name={ key }
-						value={ key }
-						checked={ key === radioValue }
-						onChange={ onRadioChange }
-					/>
-					<span>{ radioPrompt }</span>
-					{ key === radioValue && textInput }
-				</FormLabel>
-			);
-		};
-
-		const radioOptionOne = ( key, radioPrompt, textPlaceholder ) =>
-			radioOption(
+		const appendRadioOption = ( key, radioPrompt, textPlaceholder ) =>
+			( reasons[ key ] = radioOption(
 				key,
 				questionOneRadio,
 				questionOneText,
@@ -176,38 +176,42 @@ class CancelPurchaseForm extends React.Component {
 				this.onTextOneChange,
 				radioPrompt,
 				textPlaceholder
-			);
+			) );
 
-		reasons.couldNotInstall = radioOptionOne(
+		appendRadioOption(
 			'couldNotInstall',
 			translate( "I couldn't install a plugin/theme I wanted." ),
 			translate( 'What plugin/theme were you trying to install?' )
 		);
 
-		reasons.tooHard = radioOptionOne(
+		appendRadioOption(
 			'tooHard',
 			translate( 'It was too hard to set up my site.' ),
 			translate( 'Where did you run into problems?' )
 		);
 
-		reasons.didNotInclude = radioOptionOne(
+		appendRadioOption(
 			'didNotInclude',
 			translate( "This upgrade didn't include what I needed." ),
 			translate( 'What are we missing that you need?' )
 		);
 
-		reasons.onlyNeedFreeInput = radioOptionOne(
+		appendRadioOption(
 			'onlyNeedFree',
 			translate( 'The plan was too expensive.' ),
 			translate( 'How can we improve our upgrades?' )
 		);
 
-		reasons.anotherReasonOne = radioOptionOne( 'anotherReasonOne', translate( 'Another reason…' ) );
-
-		reasons.couldNotActivate = radioOption(
+		appendRadioOption(
 			'couldNotActivate',
 			translate( 'I was unable to activate or use the product.' ),
 			translate( 'Where did you run into problems?' )
+		);
+
+		appendRadioOption(
+			'anotherReasonOne',
+			translate( 'Another reason…' ),
+			translate( 'How can we improve?' )
 		);
 
 		return (
@@ -221,164 +225,61 @@ class CancelPurchaseForm extends React.Component {
 	renderQuestionTwo = () => {
 		const reasons = {};
 		const { translate } = this.props;
+		const { questionTwoOrder, questionTwoRadio, questionTwoText } = this.state;
 
-		reasons.stayingHere = (
-			<FormLabel key="stayingHere">
-				<FormRadio
-					name="stayingHere"
-					value="stayingHere"
-					checked={ 'stayingHere' === this.state.questionTwoRadio }
-					onChange={ this.onRadioTwoChange }
-				/>
-				<span>{ translate( "I'm staying here and using the free plan." ) }</span>
-			</FormLabel>
-		);
+		const appendRadioOption = ( key, radioPrompt, textPlaceholder ) =>
+			( reasons[ key ] = radioOption(
+				key,
+				questionTwoRadio,
+				questionTwoText,
+				this.onRadioTwoChange,
+				this.onTextTwoChange,
+				radioPrompt,
+				textPlaceholder
+			) );
 
-		const otherWordPressInput = (
-			<FormTextInput
-				className="cancel-purchase-form__reason-input"
-				name="otherWordPressInput"
-				id="otherWordPressInput"
-				value={ this.state.questionTwoText }
-				onChange={ this.onTextTwoChange }
-				placeholder={ translate( 'Mind telling us where?' ) }
-			/>
-		);
-		reasons.otherWordPress = (
-			<FormLabel key="otherWordPress">
-				<FormRadio
-					name="otherWordPress"
-					value="otherWordPress"
-					checked={ 'otherWordPress' === this.state.questionTwoRadio }
-					onChange={ this.onRadioTwoChange }
-				/>
-				<span>{ translate( "I'm going to use WordPress somewhere else." ) }</span>
-				{ 'otherWordPress' === this.state.questionTwoRadio && otherWordPressInput }
-			</FormLabel>
+		appendRadioOption( 'stayingHere', translate( "I'm staying here and using the free plan." ) );
+
+		appendRadioOption(
+			'otherWordPress',
+			translate( "I'm going to use WordPress somewhere else." ),
+			translate( 'Mind telling us where?' )
 		);
 
-		const differentServiceInput = (
-			<FormTextInput
-				className="cancel-purchase-form__reason-input"
-				name="differentServiceInput"
-				id="differentServiceInput"
-				value={ this.state.questionTwoText }
-				onChange={ this.onTextTwoChange }
-				placeholder={ translate( 'Mind telling us which one?' ) }
-			/>
-		);
-		reasons.differentService = (
-			<FormLabel key="differentService">
-				<FormRadio
-					name="differentService"
-					value="differentService"
-					checked={ 'differentService' === this.state.questionTwoRadio }
-					onChange={ this.onRadioTwoChange }
-				/>
-				<span>{ translate( "I'm going to use a different service for my website or blog." ) }</span>
-				{ 'differentService' === this.state.questionTwoRadio && differentServiceInput }
-			</FormLabel>
+		appendRadioOption(
+			'differentService',
+			translate( "I'm going to use a different service for my website or blog." ),
+			translate( 'Mind telling us which one?' )
 		);
 
-		const noNeedInput = (
-			<FormTextInput
-				className="cancel-purchase-form__reason-input"
-				name="noNeedInput"
-				id="noNeedInput"
-				value={ this.state.questionTwoText }
-				onChange={ this.onTextTwoChange }
-				placeholder={ translate( 'What will you do instead?' ) }
-			/>
-		);
-		reasons.noNeed = (
-			<FormLabel key="noNeed">
-				<FormRadio
-					name="noNeed"
-					value="noNeed"
-					checked={ 'noNeed' === this.state.questionTwoRadio }
-					onChange={ this.onRadioTwoChange }
-				/>
-				<span>{ translate( 'I no longer need a website or blog.' ) }</span>
-				{ 'noNeed' === this.state.questionTwoRadio && noNeedInput }
-			</FormLabel>
+		appendRadioOption(
+			'noNeed',
+			translate( 'I no longer need a website or blog.' ),
+			translate( 'What will you do instead?' )
 		);
 
-		const anotherReasonTwoInput = (
-			<FormTextInput
-				className="cancel-purchase-form__reason-input"
-				name="anotherReasonTwoInput"
-				value={ this.state.questionTwoText }
-				onChange={ this.onTextTwoChange }
-				id="anotherReasonTwoInput"
-			/>
-		);
-		reasons.anotherReasonTwo = (
-			<FormLabel key="anotherReasonTwo">
-				<FormRadio
-					name="anotherReasonTwo"
-					value="anotherReasonTwo"
-					checked={ 'anotherReasonTwo' === this.state.questionTwoRadio }
-					onChange={ this.onRadioTwoChange }
-				/>
-				<span>{ translate( 'Another reason…' ) }</span>
-				{ 'anotherReasonTwo' === this.state.questionTwoRadio && anotherReasonTwoInput }
-			</FormLabel>
+		appendRadioOption(
+			'otherPlugin',
+			translate( 'I found a better plugin or service.' ),
+			translate( 'Mind telling us which one(s)?' )
 		);
 
-		// Survey questions only for Jetpack subscriptions
-		const otherPluginInput = (
-			<FormTextInput
-				className="cancel-purchase-form__reason-input"
-				name="otherPluginInput"
-				id="otherPluginInput"
-				value={ this.state.questionTwoText }
-				onChange={ this.onTextTwoChange }
-				placeholder={ translate( 'Mind telling us which one(s)?' ) }
-			/>
-		);
-		reasons.otherPlugin = (
-			<FormLabel key="otherPlugin">
-				<FormRadio
-					name="otherPlugin"
-					value="otherPlugin"
-					checked={ 'otherPlugin' === this.state.questionTwoRadio }
-					onChange={ this.onRadioTwoChange }
-				/>
-				<span>{ translate( 'I found a better plugin or service.' ) }</span>
-				{ 'otherPlugin' === this.state.questionTwoRadio && otherPluginInput }
-			</FormLabel>
+		appendRadioOption(
+			'leavingWP',
+			translate( "I'm moving my site off of WordPress." ),
+			translate( 'Any particular reason(s)?' )
 		);
 
-		const leavingWPInput = (
-			<FormTextInput
-				className="cancel-purchase-form__reason-input"
-				name="leavingWPInput"
-				id="leavingWPInput"
-				value={ this.state.questionTwoText }
-				onChange={ this.onTextTwoChange }
-				placeholder={ translate( 'Any particular reason(s)?' ) }
-			/>
+		appendRadioOption(
+			'anotherReasonTwo',
+			translate( 'Another reason…' ),
+			translate( 'How can we improve?' )
 		);
-		reasons.leavingWP = (
-			<FormLabel key="leavingWP">
-				<FormRadio
-					name="leavingWP"
-					value="leavingWP"
-					checked={ 'leavingWP' === this.state.questionTwoRadio }
-					onChange={ this.onRadioTwoChange }
-				/>
-				<span>{ translate( "I'm moving my site off of WordPress." ) }</span>
-				{ 'leavingWP' === this.state.questionTwoRadio && leavingWPInput }
-			</FormLabel>
-		);
-
-		const { questionTwoOrder } = this.state,
-			orderedReasons = questionTwoOrder.map( question => reasons[ question ] );
 
 		return (
 			<div>
 				<FormLegend>{ translate( 'Where is your next adventure taking you?' ) }</FormLegend>
-				{ orderedReasons }
+				{ questionTwoOrder.map( question => reasons[ question ] ) }
 			</div>
 		);
 	};
@@ -461,7 +362,6 @@ class CancelPurchaseForm extends React.Component {
 				);
 			}
 
-			// Render concierge offer if appropriate
 			if ( surveyStep === steps.CONCIERGE_STEP ) {
 				return (
 					<div>
@@ -490,7 +390,6 @@ class CancelPurchaseForm extends React.Component {
 				return <UpgradeATStep />;
 			}
 
-			// Render cancellation step
 			return (
 				<div>
 					<FormSectionHeading>

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -16,8 +16,6 @@ import { localize } from 'i18n-calypso';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import FormLabel from 'components/forms/form-label';
-import FormRadio from 'components/forms/form-radio';
-import FormTextInput from 'components/forms/form-text-input';
 import FormTextarea from 'components/forms/form-textarea';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -28,41 +26,7 @@ import BusinessATStep from './stepComponents/business-at-step';
 import UpgradeATStep from './stepComponents/upgrade-at-step';
 import { getName } from 'lib/purchases';
 import { isJetpackPlan } from 'lib/products-values';
-
-const radioOption = (
-	key,
-	radioValue,
-	textValue,
-	onRadioChange,
-	onTextChange,
-	radioPrompt,
-	textPlaceholder
-) => {
-	const textInputKey = `${ key }Input`;
-
-	const textInput = textPlaceholder && (
-		<FormTextInput
-			className="cancel-purchase-form__reason-input"
-			name={ textInputKey }
-			id={ textInputKey }
-			value={ textValue }
-			onChange={ onTextChange }
-			placeholder={ textPlaceholder }
-		/>
-	);
-	return (
-		<FormLabel key={ key }>
-			<FormRadio
-				name={ key }
-				value={ key }
-				checked={ key === radioValue }
-				onChange={ onRadioChange }
-			/>
-			<span>{ radioPrompt }</span>
-			{ key === radioValue && textInput }
-		</FormLabel>
-	);
-};
+import { radioOption } from './radioOption';
 
 class CancelPurchaseForm extends React.Component {
 	static propTypes = {
@@ -78,6 +42,7 @@ class CancelPurchaseForm extends React.Component {
 
 	constructor( props ) {
 		super( props );
+
 		// shuffle reason order, but keep anotherReasonOne last
 		let questionOneOrder = shuffle( [
 			'couldNotInstall',

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -26,6 +26,8 @@ import HappychatButton from 'components/happychat/button';
 import * as steps from './steps';
 import BusinessATStep from './stepComponents/business-at-step';
 import UpgradeATStep from './stepComponents/upgrade-at-step';
+import { getName } from 'lib/purchases';
+import { isJetpackPlan } from 'lib/products-values';
 
 const radioOption = (
 	key,
@@ -64,15 +66,14 @@ const radioOption = (
 
 class CancelPurchaseForm extends React.Component {
 	static propTypes = {
-		productName: PropTypes.string.isRequired,
-		translate: PropTypes.func,
-		surveyStep: PropTypes.string.isRequired,
-		showSurvey: PropTypes.bool.isRequired,
-		selectedSite: PropTypes.object.isRequired,
+		chatInitiated: PropTypes.func.isRequired,
 		defaultContent: PropTypes.node.isRequired,
 		onInputChange: PropTypes.func.isRequired,
-		isJetpack: PropTypes.bool.isRequired,
-		chatInitiated: PropTypes.func.isRequired,
+		purchase: PropTypes.object.isRequired,
+		selectedSite: PropTypes.object.isRequired,
+		showSurvey: PropTypes.bool.isRequired,
+		surveyStep: PropTypes.string.isRequired,
+		translate: PropTypes.func,
 	};
 
 	constructor( props ) {
@@ -93,7 +94,7 @@ class CancelPurchaseForm extends React.Component {
 		] );
 
 		// set different reason groupings for Jetpack subscribers
-		if ( props.isJetpack ) {
+		if ( isJetpackPlan( props.purchase ) ) {
 			questionOneOrder = shuffle( [ 'couldNotActivate', 'didNotInclude', 'onlyNeedFree' ] );
 
 			questionTwoOrder = shuffle( [ 'stayingHere', 'otherPlugin', 'leavingWP', 'noNeed' ] );
@@ -324,7 +325,8 @@ class CancelPurchaseForm extends React.Component {
 	};
 
 	renderLiveChat = () => {
-		const { chatInitiated, productName, translate } = this.props;
+		const { chatInitiated, purchase, translate } = this.props;
+		const productName = getName( purchase );
 		return (
 			<FormFieldset>
 				<p>

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -177,11 +177,7 @@ class CancelPurchaseForm extends React.Component {
 			translate( 'I’m going to use my domain with WordPress.com without transferring it.' )
 		);
 
-		appendRadioOption(
-			'anotherReasonOne',
-			translate( 'Another reason…' ),
-			translate( 'How can we improve?' )
-		);
+		appendRadioOption( 'anotherReasonOne', translate( 'Another reason…' ), ' ' );
 
 		return (
 			<div>
@@ -243,11 +239,7 @@ class CancelPurchaseForm extends React.Component {
 			translate( 'Any particular reason(s)?' )
 		);
 
-		appendRadioOption(
-			'anotherReasonTwo',
-			translate( 'Another reason…' ),
-			translate( 'How can we improve?' )
-		);
+		appendRadioOption( 'anotherReasonTwo', translate( 'Another reason…' ), ' ' );
 
 		return (
 			<div>

--- a/client/components/marketing-survey/cancel-purchase-form/isSurveyFilledIn.js
+++ b/client/components/marketing-survey/cancel-purchase-form/isSurveyFilledIn.js
@@ -1,16 +1,25 @@
 /** @format */
+
 export default function isSurveyFilledIn( survey ) {
 	const answeredBothQuestions = survey.questionOneRadio && survey.questionTwoRadio;
-
-	if ( ! answeredBothQuestions ) {
-		return false;
-	}
 
 	if ( survey.questionOneRadio === 'anotherReasonOne' && survey.questionOneText === '' ) {
 		return false;
 	}
 
 	if ( survey.questionTwoRadio === 'anotherReasonTwo' && survey.questionTwoText === '' ) {
+		return false;
+	}
+
+	if (
+		survey.questionOneRadio &&
+		survey.questionTwoOrder &&
+		survey.questionTwoOrder.length === 0
+	) {
+		return true;
+	}
+
+	if ( ! answeredBothQuestions ) {
 		return false;
 	}
 

--- a/client/components/marketing-survey/cancel-purchase-form/optionsForProduct.js
+++ b/client/components/marketing-survey/cancel-purchase-form/optionsForProduct.js
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * Internal Dependencies
+ */
+
+import { isJetpackPlan } from 'lib/products-values';
+
+export const cancellationOptionsForPurchase = purchase => {
+	if ( isJetpackPlan( purchase ) ) {
+		return [ 'couldNotActivate', 'didNotInclude', 'onlyNeedFree' ];
+	}
+
+	return [ 'couldNotInstall', 'tooHard', 'didNotInclude', 'onlyNeedFree' ];
+};
+
+export const nextAdventureOptionsForPurchase = purchase => {
+	if ( isJetpackPlan( purchase ) ) {
+		return [ 'stayingHere', 'otherPlugin', 'leavingWP', 'noNeed' ];
+	}
+
+	return [ 'stayingHere', 'otherWordPress', 'differentService', 'noNeed' ];
+};

--- a/client/components/marketing-survey/cancel-purchase-form/optionsForProduct.js
+++ b/client/components/marketing-survey/cancel-purchase-form/optionsForProduct.js
@@ -4,11 +4,15 @@
  * Internal Dependencies
  */
 
-import { isJetpackPlan } from 'lib/products-values';
+import { isDomainTransfer, isJetpackPlan } from 'lib/products-values';
 
 export const cancellationOptionsForPurchase = purchase => {
 	if ( isJetpackPlan( purchase ) ) {
 		return [ 'couldNotActivate', 'didNotInclude', 'onlyNeedFree' ];
+	}
+
+	if ( isDomainTransfer( purchase ) ) {
+		return [ 'noLongerWantToTransfer', 'couldNotCompleteTransfer', 'useDomainWithoutTransferring' ];
 	}
 
 	return [ 'couldNotInstall', 'tooHard', 'didNotInclude', 'onlyNeedFree' ];
@@ -17,6 +21,10 @@ export const cancellationOptionsForPurchase = purchase => {
 export const nextAdventureOptionsForPurchase = purchase => {
 	if ( isJetpackPlan( purchase ) ) {
 		return [ 'stayingHere', 'otherPlugin', 'leavingWP', 'noNeed' ];
+	}
+
+	if ( isDomainTransfer( purchase ) ) {
+		return [];
 	}
 
 	return [ 'stayingHere', 'otherWordPress', 'differentService', 'noNeed' ];

--- a/client/components/marketing-survey/cancel-purchase-form/radioOption.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/radioOption.jsx
@@ -1,0 +1,50 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+import FormTextInput from 'components/forms/form-text-input';
+
+export const radioOption = (
+	key,
+	radioValue,
+	textValue,
+	onRadioChange,
+	onTextChange,
+	radioPrompt,
+	textPlaceholder
+) => {
+	const textInputKey = `${ key }Input`;
+
+	const textInput = textPlaceholder && (
+		<FormTextInput
+			className="cancel-purchase-form__reason-input"
+			name={ textInputKey }
+			id={ textInputKey }
+			value={ textValue }
+			onChange={ onTextChange }
+			placeholder={ textPlaceholder }
+		/>
+	);
+	return (
+		<FormLabel key={ key }>
+			<FormRadio
+				name={ key }
+				value={ key }
+				checked={ key === radioValue }
+				onChange={ onRadioChange }
+			/>
+			<span>{ radioPrompt }</span>
+			{ key === radioValue && textInput }
+		</FormLabel>
+	);
+};

--- a/client/components/marketing-survey/cancel-purchase-form/test/isSurveyFilledIn.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/isSurveyFilledIn.js
@@ -24,6 +24,15 @@ describe( 'isSurveyFilledIn', () => {
 		).to.equal( true );
 	} );
 
+	test( 'should return true when question one is answered and there are no options for question two', () => {
+		expect(
+			isSurveyFilledIn( {
+				questionOneRadio: 'tooHard',
+				questionTwoOrder: [],
+			} )
+		).to.equal( true );
+	} );
+
 	test( 'should return false when question one is another reason and there is no text', () => {
 		expect(
 			isSurveyFilledIn( {

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -34,7 +34,7 @@ import {
 	isRefundable,
 	isSubscription,
 } from 'lib/purchases';
-import { isDomainRegistration, isJetpackPlan } from 'lib/products-values';
+import { isDomainRegistration } from 'lib/products-values';
 import notices from 'notices';
 import { confirmCancelDomain, purchasesRoot } from 'me/purchases/paths';
 import { refreshSitePlans } from 'state/sites/plans/actions';
@@ -179,13 +179,12 @@ class CancelPurchaseButton extends Component {
 			>
 				<CancelPurchaseForm
 					chatInitiated={ this.chatInitiated }
-					productName={ getName( purchase ) }
-					surveyStep={ this.state.surveyStep }
-					selectedSite={ selectedSite }
-					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
 					defaultContent={ this.renderCancellationEffect() }
 					onInputChange={ this.onSurveyChange }
-					isJetpack={ isJetpackPlan( purchase ) }
+					purchase={ purchase }
+					selectedSite={ selectedSite }
+					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
+					surveyStep={ this.state.surveyStep }
 				/>
 			</Dialog>
 		);

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -28,13 +28,7 @@ import previousStep from 'components/marketing-survey/cancel-purchase-form/previ
 import { INITIAL_STEP, FINAL_STEP } from 'components/marketing-survey/cancel-purchase-form/steps';
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
 import { getPurchase, isDataLoading } from '../utils';
-import {
-	isDomainRegistration,
-	isPlan,
-	isBusiness,
-	isGoogleApps,
-	isJetpackPlan,
-} from 'lib/products-values';
+import { isDomainRegistration, isPlan, isBusiness, isGoogleApps } from 'lib/products-values';
 import notices from 'notices';
 import { purchasesRoot } from '../paths';
 import { getPurchasesError } from 'state/purchases/selectors';
@@ -385,13 +379,12 @@ class RemovePurchase extends Component {
 			>
 				<CancelPurchaseForm
 					chatInitiated={ this.chatInitiated }
-					productName={ getName( selectedPurchase ) }
-					surveyStep={ this.state.surveyStep }
-					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
 					defaultContent={ this.renderPlanDialogText() }
 					onInputChange={ this.onSurveyChange }
-					isJetpack={ isJetpackPlan( selectedPurchase ) }
+					purchase={ selectedPurchase }
 					selectedSite={ selectedSite }
+					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
+					surveyStep={ this.state.surveyStep }
 				/>
 			</Dialog>
 		);


### PR DESCRIPTION
Some of the reasons for cancelling do not really make sense for certain products.

This change ensures that a different set of options can be displayed per question.

Specifically, the following first page will be displayed when cancelling a domain transfer product:

<img width="544" alt="screen shot 2018-01-31 at 9 15 42 pm" src="https://user-images.githubusercontent.com/1926/35620165-08089548-06cc-11e8-9bff-fdf73b9086bd.png">

The following will be displayed when cancelling a jetpack plan:

<img width="541" alt="screen shot 2018-01-31 at 9 18 25 pm" src="https://user-images.githubusercontent.com/1926/35620240-4dfa3610-06cc-11e8-9191-b97d3a2942cd.png">

The following will be displayed in all other cases:

<img width="542" alt="screen shot 2018-01-31 at 9 19 13 pm" src="https://user-images.githubusercontent.com/1926/35620278-68968a28-06cc-11e8-9410-438b3a267b7b.png">

# Testing

* Attempt to cancel a domain transfer purchase
* Verify that you see the above options for question one and question two is not visible.
* Ensure that you can move to the next step in the survey (you do not need to actually cancel)