### PR TITLE
Jetpack Connect: Hide 'back' button in mobile app flow

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -14,6 +14,10 @@
 		.logged-out-form__links {
 			display: none;
 		}
+
+		.jetpack-connect__back-button {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
The mobile app has its own navigation when using the Jetpack connection flow in a webview, so all nav buttons should be hidden.

**Before / After**

<img width="202" alt="screen shot 2018-01-31 at 10 23 46" src="https://user-images.githubusercontent.com/7767559/35614899-dbc65a3e-0670-11e8-83c8-35f86519c0e7.png"> <img width="200" alt="screen shot 2018-01-31 at 10 21 45" src="https://user-images.githubusercontent.com/7767559/35614851-b6b7351a-0670-11e8-84f4-9af67b605c81.png">

## Testing

* Start the mobile app connection flow at http://calypso.localhost:3000/jetpack/connect?mobile_redirect=wordpress://jetpack-connection
* Paste in a site that does not have jetpack plugin installed
* Check that the back button does not show at the bottom of the install instructions


