### PR TITLE
isEditedPostDirty: add tests for date and parent changes

### DIFF
--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -6,6 +6,7 @@
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import { values } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -1813,6 +1814,69 @@ describe( 'selectors', () => {
 							2916284: {
 								841: {
 									title: 'Hello World!',
+								},
+							},
+						},
+					},
+				},
+				2916284,
+				841
+			);
+
+			expect( isDirty ).to.be.true;
+		} );
+
+		test( 'should return true if saved post parent attr changes', () => {
+			const isDirty = isEditedPostDirty(
+				{
+					posts: {
+						queries: {
+							2916284: new PostQueryManager( {
+								items: {
+									841: {
+										ID: 841,
+										site_ID: 2916284,
+										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+									},
+								},
+							} ),
+						},
+						edits: {
+							2916284: {
+								841: {
+									parent: 10,
+								},
+							},
+						},
+					},
+				},
+				2916284,
+				841
+			);
+
+			expect( isDirty ).to.be.true;
+		} );
+
+		test( 'should return true if saved post date changes', () => {
+			const isDirty = isEditedPostDirty(
+				{
+					posts: {
+						queries: {
+							2916284: new PostQueryManager( {
+								items: {
+									841: {
+										ID: 841,
+										site_ID: 2916284,
+										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+										date: moment( '2016-09-14T15:47:33-04:00' ),
+									},
+								},
+							} ),
+						},
+						edits: {
+							2916284: {
+								841: {
+									date: moment( '2017-09-14T15:47:33-04:00' ),
 								},
 							},
 						},

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -1857,6 +1857,40 @@ describe( 'selectors', () => {
 			expect( isDirty ).to.be.true;
 		} );
 
+		test( "should return false if saved post parent attr doesn't change", () => {
+			const isDirty = isEditedPostDirty(
+				{
+					posts: {
+						queries: {
+							2916284: new PostQueryManager( {
+								items: {
+									841: {
+										ID: 841,
+										site_ID: 2916284,
+										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+										parent: {
+											ID: 10,
+										},
+									},
+								},
+							} ),
+						},
+						edits: {
+							2916284: {
+								841: {
+									parent: 10,
+								},
+							},
+						},
+					},
+				},
+				2916284,
+				841
+			);
+
+			expect( isDirty ).to.be.false;
+		} );
+
 		test( 'should return true if saved post date changes', () => {
 			const isDirty = isEditedPostDirty(
 				{
@@ -1887,6 +1921,38 @@ describe( 'selectors', () => {
 			);
 
 			expect( isDirty ).to.be.true;
+		} );
+
+		test( "should return false if saved post date doesn't change", () => {
+			const isDirty = isEditedPostDirty(
+				{
+					posts: {
+						queries: {
+							2916284: new PostQueryManager( {
+								items: {
+									841: {
+										ID: 841,
+										site_ID: 2916284,
+										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+										date: moment( '2016-09-14T15:47:33-04:00' ),
+									},
+								},
+							} ),
+						},
+						edits: {
+							2916284: {
+								841: {
+									date: moment( '2016-09-14T15:47:33-04:00' ),
+								},
+							},
+						},
+					},
+				},
+				2916284,
+				841
+			);
+
+			expect( isDirty ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
In this PR, we are adding additional tests for `isEditedPostDirty` selector as the selector was modified recently in #21937 and #21967.

## Testing

Run `npm run test-client client/state/posts/test/selectors.js` from your Calypso root dir. Tests should pass.