### PR TITLE
Reader: guard against missing author name

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -4,7 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get, has, map, take, values } from 'lodash';
+import { get, map, take, values } from 'lodash';
 import Gridicon from 'gridicons';
 
 /**
@@ -77,7 +77,7 @@ class PostByline extends React.Component {
 		const feedId = get( post, 'feed_ID' );
 		const siteId = get( site, 'ID' );
 		const siteName = getSiteName( { site, feed, post } );
-		const hasAuthorName = has( post, 'author.name' );
+		const hasAuthorName = get( post, 'author.name', null ) !== null;
 		const hasMatchingAuthorAndSiteNames =
 			hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, post.author.name );
 		const shouldDisplayAuthor =

--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -77,7 +77,7 @@ class PostByline extends React.Component {
 		const feedId = get( post, 'feed_ID' );
 		const siteId = get( site, 'ID' );
 		const siteName = getSiteName( { site, feed, post } );
-		const hasAuthorName = get( post, 'author.name', null ) !== null;
+		const hasAuthorName = !! get( post, 'author.name', null );
 		const hasMatchingAuthorAndSiteNames =
 			hasAuthorName && areEqualIgnoringWhitespaceAndCase( siteName, post.author.name );
 		const shouldDisplayAuthor =

--- a/client/lib/string/index.js
+++ b/client/lib/string/index.js
@@ -8,7 +8,13 @@
  * @returns
  */
 export function areEqualIgnoringWhitespaceAndCase( a, b ) {
-	if ( ! a || ! b ) {
+	// Are they equal without any manipulation?
+	if ( a === b ) {
+		return true;
+	}
+
+	// If we don't have strings for this part, bail out
+	if ( a === null || b === null ) {
 		return false;
 	}
 

--- a/client/lib/string/index.js
+++ b/client/lib/string/index.js
@@ -1,13 +1,4 @@
 /** @format */
-
-/**
- * External dependencies
- */
-
-/**
- * Internal Dependencies
- */
-
 /**
  * Are two strings equal, when ignoring whitespace and case?
  *
@@ -17,6 +8,10 @@
  * @returns
  */
 export function areEqualIgnoringWhitespaceAndCase( a, b ) {
+	if ( ! a || ! b ) {
+		return false;
+	}
+
 	a = a.replace( /[\s'.\-_"]/g, '' );
 	b = b.replace( /[\s'.\-_"]/g, '' );
 	return a.toLowerCase() === b.toLowerCase();

--- a/client/lib/string/index.js
+++ b/client/lib/string/index.js
@@ -14,7 +14,7 @@ export function areEqualIgnoringWhitespaceAndCase( a, b ) {
 	}
 
 	// If we don't have strings for this part, bail out
-	if ( a === null || b === null ) {
+	if ( ! a || ! b ) {
 		return false;
 	}
 

--- a/client/lib/string/test/index.js
+++ b/client/lib/string/test/index.js
@@ -14,6 +14,7 @@ describe( 'lib/string/areEqualIgnoringWhitespaceAndCase', () => {
 	test( 'should match', () => {
 		const pairs = [
 			// actual, expected
+			[ null, null ],
 			[ '', '' ],
 			[ 'hi there', 'Hi There' ],
 			[ 'hithere', 'Hi There' ],

--- a/client/reader/lib/author-name-blacklist/index.js
+++ b/client/reader/lib/author-name-blacklist/index.js
@@ -13,5 +13,9 @@ const authorNameBlacklist = [ 'admin' ];
  * @returns {boolean} True if blacklisted
  */
 export const isAuthorNameBlacklisted = authorName => {
+	if ( ! authorName ) {
+		return false;
+	}
+
 	return includes( authorNameBlacklist, authorName.toLowerCase() );
 };


### PR DESCRIPTION
We had a report of the following feed causing a blank screen after loading in Reader:

http://wordpress.com/read/feeds/52656883

![screen recording 2018-01-31 at 11 20 am](https://user-images.githubusercontent.com/17325/35621503-83a852e6-06aa-11e8-870e-cfe8e232f890.gif)

It looks to have a null author name, which is breaking in a couple of spots.

### To test

Load the feed above, and make sure it doesn't cause a blank screen.