### PR TITLE
Signup: Add signup form back link

### DIFF
--- a/client/components/logged-out-form/back-link.jsx
+++ b/client/components/logged-out-form/back-link.jsx
@@ -6,6 +6,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -14,7 +15,7 @@ import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import safeProtocolUrl from 'lib/safe-protocol-url';
 import Gridicon from 'gridicons';
 
-export default function LoggedOutFormBackLink( props ) {
+function LoggedOutFormBackLink( props ) {
 	const { locale, oauth2Client, translate, recordClick } = props;
 
 	let url = addLocaleToWpcomUrl( 'https://wordpress.com', locale );
@@ -56,8 +57,10 @@ export default function LoggedOutFormBackLink( props ) {
 }
 LoggedOutFormBackLink.propTypes = {
 	classes: PropTypes.object,
-	locale: PropTypes.string.isRequired,
+	locale: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 	recordClick: PropTypes.func.isRequired,
 	oauth2Client: PropTypes.object,
 };
+
+export default localize( LoggedOutFormBackLink );

--- a/client/components/logged-out-form/back-link.jsx
+++ b/client/components/logged-out-form/back-link.jsx
@@ -1,0 +1,63 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
+import safeProtocolUrl from 'lib/safe-protocol-url';
+import Gridicon from 'gridicons';
+
+export default function LoggedOutFormBackLink( props ) {
+	const { locale, oauth2Client, translate, recordClick } = props;
+
+	let url = addLocaleToWpcomUrl( 'https://wordpress.com', locale );
+	let message = translate( 'Back to WordPress.com' );
+
+	if ( oauth2Client ) {
+		url = safeProtocolUrl( oauth2Client.url );
+		if ( ! url || url === 'http:' ) {
+			return null;
+		}
+
+		message = translate( 'Back to %(clientTitle)s', {
+			args: {
+				clientTitle: oauth2Client.title,
+			},
+		} );
+	}
+
+	return (
+		<a
+			href={ url }
+			key="return-to-wpcom-link"
+			onClick={ recordClick }
+			rel="external"
+			className={ classnames(
+				Object.assign(
+					{
+						'logged-out-form__link-item': true,
+						'logged-out-form__back-link': true,
+					},
+					props.classes
+				)
+			) }
+		>
+			<Gridicon icon="arrow-left" size={ 18 } />
+			{ message }
+		</a>
+	);
+}
+LoggedOutFormBackLink.propTypes = {
+	classes: PropTypes.object,
+	locale: PropTypes.string.isRequired,
+	translate: PropTypes.func.isRequired,
+	recordClick: PropTypes.func.isRequired,
+	oauth2Client: PropTypes.object,
+};

--- a/client/components/logged-out-form/back-link.jsx
+++ b/client/components/logged-out-form/back-link.jsx
@@ -40,15 +40,11 @@ function LoggedOutFormBackLink( props ) {
 			key="return-to-wpcom-link"
 			onClick={ recordClick }
 			rel="external"
-			className={ classnames(
-				Object.assign(
-					{
-						'logged-out-form__link-item': true,
-						'logged-out-form__back-link': true,
-					},
-					props.classes
-				)
-			) }
+			className={ classnames( {
+				'logged-out-form__link-item': true,
+				'logged-out-form__back-link': true,
+				...props.classes,
+			} ) }
 		>
 			<Gridicon icon="arrow-left" size={ 18 } />
 			{ message }

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -585,9 +585,7 @@ class SignupForm extends Component {
 				</LoggedOutFormLinkItem>
 				{ this.props.oauth2Client && (
 					<LoggedOutFormBackLink
-						locale={ this.props.locale }
 						oauth2Client={ this.props.oauth2Client }
-						translate={ this.props.translate }
 						recordClick={ this.recordBackLinkClick }
 					/>
 				) }

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -33,6 +33,7 @@ import { login } from 'lib/paths';
 import formState from 'lib/form-state';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
+import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import { mergeFormWithValue } from 'signup/utils';
 import SocialSignupForm from './social';
@@ -105,6 +106,10 @@ class SignupForm extends Component {
 			fieldValue: this.props.suggestedUsername || '',
 		} );
 	}
+
+	recordBackLinkClick = () => {
+		analytics.tracks.recordEvent( 'calypso_signup_back_link_click' );
+	};
 
 	componentWillMount() {
 		debug( 'Mounting the SignupForm React component.' );
@@ -578,6 +583,14 @@ class SignupForm extends Component {
 				<LoggedOutFormLinkItem href={ logInUrl }>
 					{ this.props.translate( 'Already have a WordPress.com account? Log in now.' ) }
 				</LoggedOutFormLinkItem>
+				{ this.props.oauth2Client && (
+					<LoggedOutFormBackLink
+						locale={ this.props.locale }
+						oauth2Client={ this.props.oauth2Client }
+						translate={ this.props.translate }
+						recordClick={ this.recordBackLinkClick }
+					/>
+				) }
 			</LoggedOutFormLinks>
 		);
 	}

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -140,9 +140,7 @@ export class LoginLinks extends React.Component {
 				{ this.renderMagicLoginLink() }
 				{ this.renderResetPasswordLink() }
 				<LoggedOutFormBackLink
-					locale={ this.props.locale }
 					oauth2Client={ this.props.oauth2Client }
-					translate={ this.props.translate }
 					recordClick={ this.recordBackToWpcomLinkClick }
 					classes={ { 'logged-out-form__link-item': false } }
 				/>

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -14,11 +14,9 @@ import page from 'page';
  * Internal dependencies
  */
 import { addQueryArgs } from 'lib/url';
-import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import { isEnabled } from 'config';
-import safeProtocolUrl from 'lib/safe-protocol-url';
 import ExternalLink from 'components/external-link';
-import Gridicon from 'gridicons';
+import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'state/login/magic-login/actions';
@@ -65,38 +63,6 @@ export class LoginLinks extends React.Component {
 	recordResetPasswordLinkClick = () => {
 		this.props.recordTracksEvent( 'calypso_login_reset_password_link_click' );
 	};
-
-	renderBackLink() {
-		const { locale, oauth2Client, translate } = this.props;
-
-		let url = addLocaleToWpcomUrl( 'https://wordpress.com', locale );
-		let message = translate( 'Back to WordPress.com' );
-
-		if ( oauth2Client ) {
-			url = safeProtocolUrl( oauth2Client.url );
-			if ( ! url || url === 'http:' ) {
-				return null;
-			}
-
-			message = translate( 'Back to %(clientTitle)s', {
-				args: {
-					clientTitle: oauth2Client.title,
-				},
-			} );
-		}
-
-		return (
-			<a
-				href={ url }
-				key="return-to-wpcom-link"
-				onClick={ this.recordBackToWpcomLinkClick }
-				rel="external"
-			>
-				<Gridicon icon="arrow-left" size={ 18 } />
-				{ message }
-			</a>
-		);
-	}
 
 	renderHelpLink() {
 		if ( ! this.props.twoFactorAuthType ) {
@@ -173,7 +139,13 @@ export class LoginLinks extends React.Component {
 				{ this.renderHelpLink() }
 				{ this.renderMagicLoginLink() }
 				{ this.renderResetPasswordLink() }
-				{ this.renderBackLink() }
+				<LoggedOutFormBackLink
+					locale={ this.props.locale }
+					oauth2Client={ this.props.oauth2Client }
+					translate={ this.props.translate }
+					recordClick={ this.recordBackToWpcomLinkClick }
+					classes={ { 'logged-out-form__link-item': false } }
+				/>
 			</div>
 		);
 	}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { identity, isEmpty, omit } from 'lodash';
+import { identity, isEmpty, omit, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -76,7 +76,7 @@ export class UserStep extends Component {
 	componentWillMount() {
 		const { oauth2Signup, initialContext } = this.props,
 			clientId =
-				initialContext && initialContext.query && initialContext.query.oauth2_client_id
+				get( initialContext, [ 'query', 'oauth2_client_id' ] )
 					? initialContext.query.oauth2_client_id
 					: null;
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -76,7 +76,7 @@ export class UserStep extends Component {
 	componentWillMount() {
 		const { oauth2Signup, initialContext } = this.props,
 			clientId =
-				get( initialContext, [ 'query', 'oauth2_client_id' ] )
+				get( initialContext, 'query.oauth2_client_id', null )
 					? initialContext.query.oauth2_client_id
 					: null;
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -4,7 +4,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { identity, isEmpty, omit } from 'lodash';
@@ -75,12 +74,16 @@ export class UserStep extends Component {
 	}
 
 	componentWillMount() {
-		let { oauth2Signup, oauth2Client } = this.props;
+		const { oauth2Signup, initialContext } = this.props,
+			clientId =
+				initialContext && initialContext.query && initialContext.query.oauth2_client_id
+					? initialContext.query.oauth2_client_id
+					: null;
 
 		this.setSubHeaderText( this.props );
 
-		if ( oauth2Signup && oauth2Client.id ) {
-			this.props.fetchOAuth2ClientData( oauth2Client.id );
+		if ( oauth2Signup && clientId ) {
+			this.props.fetchOAuth2ClientData( clientId );
 		}
 	}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -74,11 +74,8 @@ export class UserStep extends Component {
 	}
 
 	componentWillMount() {
-		const { oauth2Signup, initialContext } = this.props,
-			clientId =
-				get( initialContext, 'query.oauth2_client_id', null )
-					? initialContext.query.oauth2_client_id
-					: null;
+		const { oauth2Signup, initialContext } = this.props;
+		const clientId = get( initialContext, 'query.oauth2_client_id', null );
 
 		this.setSubHeaderText( this.props );
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -4,6 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { identity, isEmpty, omit } from 'lodash';
@@ -16,6 +17,7 @@ import StepWrapper from 'signup/step-wrapper';
 import SignupForm from 'components/signup-form';
 import { getFlowSteps, getNextStepName, getPreviousStepName, getStepUrl } from 'signup/utils';
 import SignupActions from 'lib/signup/actions';
+import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import { getSuggestedUsername } from 'state/signup/optional-dependencies/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -73,7 +75,13 @@ export class UserStep extends Component {
 	}
 
 	componentWillMount() {
+		let { oauth2Signup, oauth2Client } = this.props;
+
 		this.setSubHeaderText( this.props );
+
+		if ( oauth2Signup && oauth2Client.id ) {
+			this.props.fetchOAuth2ClientData( oauth2Client.id );
+		}
 	}
 
 	setSubHeaderText( props ) {
@@ -299,5 +307,6 @@ export default connect(
 	} ),
 	{
 		recordTracksEvent,
+		fetchOAuth2ClientData,
 	}
 )( localize( UserStep ) );


### PR DESCRIPTION
On the login form for WordPress Connect (OAuth) there's a 'Back to...' link to give users the ability to get back to the website that is requesting authorisation. Alternatively it's a link back to WordPress.com. 

This change replicates this link on the signup form.

### Testing
1. Build a local version based on this code
2. Go to a login form (while logged out) for one of the WP Connect sites, for example Akismet.com - https://wordpress.com/log-in?client_id=973&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D973%26response_type%3Dcode%26blog_id%3D0%26state%3De8ff1872b182796b89e07be6107ef7ef42c49d1ba855732059947f0ee1775669%26redirect_uri%3Dhttps%253A%252F%252Fakismet.com%252Faccount%252Flogin%252F%253Faction%253Drequest_access_token%26implicit%3Dtrue%26new-user%3D0
3. Note the "Back to Akismet" link displayed (or as appropriate for the site you're using).
4. Follow the create an account link.
5. Notice the lack of the "Back to Akismet" link.
6. Replace "https://wordpress.com" with "http://calypso.localhost:3000" in the URL, or as appropriate for your local installation of Calypso.
7. Observe the addition of a "Back to Akismet" link on the sign up form that takes you back to the originating site.

The link may take a second or two to appear as it relies on additional information about the OAuth client which is retrieved in the background. To keep the interface reactive, the form is displayed first and the link added as the information becomes available.

