### PR TITLE
Split the 'lib/happychat/connection' module into a separate chunk and lazy-load it

### DIFF
--- a/client/lib/happychat/connection-async.js
+++ b/client/lib/happychat/connection-async.js
@@ -1,0 +1,35 @@
+/** @format */
+
+/*
+ * This function creates a stub `Connection` object that dynamically loads the chunk
+ * with the `happychat/connection` library only after the first method call.
+ */
+export default function buildConnection() {
+	// Promise with a lazy initialized `Connection`
+	let connection = null;
+
+	// Async load the connection library and return a promise with its default export.
+	// That's a factory function that creates and returns the `Connection` class instance.
+	function importConnectionLib() {
+		return new Promise( resolve => asyncRequire( 'lib/happychat/connection', resolve ) );
+	}
+
+	function getConnection() {
+		if ( ! connection ) {
+			connection = importConnectionLib().then( createConnection => createConnection() );
+		}
+		return connection;
+	}
+
+	// Forward a method call to the implementation. Works only for methods that return promises,
+	// which, fortunately, is the case for all `Connection` methods.
+	function forwardMethod( name ) {
+		return ( ...args ) => getConnection().then( conn => conn[ name ]( ...args ) );
+	}
+
+	return {
+		init: forwardMethod( 'init' ),
+		request: forwardMethod( 'request' ),
+		send: forwardMethod( 'send' ),
+	};
+}

--- a/client/state/happychat/middleware.js
+++ b/client/state/happychat/middleware.js
@@ -21,7 +21,7 @@ import {
 	HAPPYCHAT_IO_SEND_TYPING,
 } from 'state/action-types';
 import { sendEvent } from 'state/happychat/connection/actions';
-import buildConnection from 'lib/happychat/connection';
+import buildConnection from 'lib/happychat/connection-async';
 import isHappychatClientConnected from 'state/happychat/selectors/is-happychat-client-connected';
 import isHappychatChatAssigned from 'state/happychat/selectors/is-happychat-chat-assigned';
 


### PR DESCRIPTION
The HappyChat client uses the socket.io library, which is rather big. This patch separates the `lib/happychat/connection` library into separate Webpack chunk and async loads it only when really needed, i.e., first time any method on `Connection` is called.

The resulting `build` chunk reduction is very nice:
```
chunk                                     stat_size           parsed_size           gzip_size
async-load-my-sites-stats-site                +82 B  (+0.0%)        +87 B  (+0.0%)      +22 B  (+0.1%)
async-load-my-sites-stats-stats-insights      +82 B  (+0.0%)       +101 B  (+0.1%)      +18 B  (+0.0%)
async-load-my-sites-stats-summary             +82 B  (+0.0%)       +101 B  (+0.1%)      +17 B  (+0.1%)
async-load-reader-following-manage          +2280 B  (+0.5%)       +952 B  (+0.5%)     +295 B  (+0.7%)
build                                     -172616 B  (-4.6%)     -68677 B  (-4.3%)   -19519 B  (-5.0%)
devdocs                                     +2280 B  (+0.1%)       +952 B  (+0.0%)     +298 B  (+0.1%)
manifest                                       +0 B                +137 B  (+1.3%)      +26 B  (+0.8%)
security                                      +82 B  (+0.0%)       +101 B  (+0.0%)      +23 B  (+0.0%)
settings-traffic                              +82 B  (+0.0%)       +101 B  (+0.0%)      +19 B  (+0.0%)
async-load-lib-happychat-connection       +174118 B    (new)     +69623 B    (new)   +20369 B    (new)
```

The new chunk is 68kB parsed and 20kB gzipped big. Quite a lot of NPM packages there, needed only by socket.io and nothing else:

<img width="752" alt="happychat-connection-chunk" src="https://user-images.githubusercontent.com/664258/35622882-bd63967e-0689-11e8-964e-ee47c303e5d7.png">

**How to test:**
Test that HappyChat still works without any regressions. Establish a chat, check that you can send and receive messages, that the HE on the other side sees all the information they are supposed to see, that the chat is re-established after page reload... There are surely other HappyChat workflows I'm not aware of -- @nosolosw please could you have a look with your team?