### PR TITLE
Activity Log: Add HappychatButton on threat items in activity log

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -14,6 +14,8 @@ import { localize } from 'i18n-calypso';
 import ActivityActor from './activity-actor';
 import ActivityIcon from './activity-icon';
 import ActivityLogConfirmDialog from '../activity-log-confirm-dialog';
+import Gridicon from 'gridicons';
+import HappychatButton from 'components/happychat/button';
 import SplitButton from 'components/split-button';
 import FoldableCard from 'components/foldable-card';
 import FormattedBlock from 'components/notes-formatted-block';
@@ -72,19 +74,19 @@ class ActivityLogItem extends Component {
 	}
 
 	renderItemAction() {
-		const {
-			createBackup,
-			createRewind,
-			disableRestore,
-			disableBackup,
-			hideRestore,
-			translate,
-			activity: { activityIsRewindable },
-		} = this.props;
+		const { hideRestore, activity: { activityIsRewindable, activityName } } = this.props;
 
-		if ( hideRestore || ! activityIsRewindable ) {
-			return null;
+		if ( ! hideRestore && activityIsRewindable ) {
+			return this.renderRewindAction();
 		}
+
+		if ( 'rewind__scan_result_found' === activityName ) {
+			return this.renderHelpAction();
+		}
+	}
+
+	renderRewindAction() {
+		const { createBackup, createRewind, disableRestore, disableBackup, translate } = this.props;
 
 		return (
 			<div className="activity-log-item__action">
@@ -106,6 +108,21 @@ class ActivityLogItem extends Component {
 					</PopoverMenuItem>
 				</SplitButton>
 			</div>
+		);
+	}
+
+	renderHelpAction() {
+		const { getHelpClick, translate } = this.props;
+
+		return (
+			<HappychatButton
+				className="activity-log-item__help-action"
+				borderless={ false }
+				onClick={ getHelpClick }
+			>
+				<Gridicon icon="chat" size={ 18 } />
+				{ translate( 'Get Help' ) }
+			</HappychatButton>
 		);
 	}
 
@@ -255,6 +272,7 @@ const mapDispatchToProps = ( dispatch, { activityId, siteId } ) => ( {
 			)
 		)
 	),
+	getHelpClick: () => recordTracksEvent( 'calypso_activitylog_threat_get_help' ),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( ActivityLogItem ) );

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -292,3 +292,14 @@
 		text-align: left;
 	}
 }
+
+.activity-log-item__help-action {
+	color: $gray;
+	width: 110px;
+	font-weight: normal;
+	font-size: 1.3rem;
+}
+
+.activity-log-item__help-action .gridicon {
+	margin-right: 5px;
+}

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -295,9 +295,16 @@
 
 .activity-log-item__help-action {
 	color: $gray;
-	width: 110px;
+	width: 117px;
+	height: 29px;
 	font-weight: normal;
 	font-size: 1.3rem;
+	padding-top: 2px;
+
+	@include breakpoint( '<480px' ) {
+		display: block;
+		margin-top: 1.5rem;
+	}
 }
 
 .activity-log-item__help-action .gridicon {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/21350

Security threats in the activity log should have an associated action. This PR adds a Happychat button to those items:

![screen shot 2018-01-31 at 9 43 07 am](https://user-images.githubusercontent.com/5528445/35629336-5f13d25e-066c-11e8-8d2f-573c28621bf1.png)
![screen shot 2018-01-31 at 9 42 57 am](https://user-images.githubusercontent.com/5528445/35629337-5f22eabe-066c-11e8-8279-bf95bf1513e8.png)

**Testing instructions:**
1. You will need to be logged into Calypso as a non-a11n (or in Happychat test mode) so that the button shows.
2. View the activity log for a site with an active security threat. Note that the button shows on threat items, and clicking loads the chat interface.
3. Since we are changing the way that _all_ log item actions are determined, please also check to ensure there is no disruption to rewind buttons, ability to rewind, ability to download backups, etc.