### PR TITLE
Language: add isRtl reducer

### DIFF
--- a/client/state/selectors/is-rtl.js
+++ b/client/state/selectors/is-rtl.js
@@ -11,4 +11,4 @@ import { get } from 'lodash';
  * @param  {Object}   state      Global state tree
  * @return {Boolean}             Current user is rtl
  */
-export default state => get( state, 'ui.language.isRtl', false );
+export default state => get( state, 'ui.language.isRtl', null );

--- a/client/state/selectors/is-rtl.js
+++ b/client/state/selectors/is-rtl.js
@@ -1,30 +1,14 @@
 /** @format */
 
 /**
- * Internal dependencies
+ * External dependencies
  */
-
-import { getLanguage } from 'lib/i18n-utils';
-import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+import { get } from 'lodash';
 
 /**
  * Returns whether the current uses right-to-left directionality.
  *
  * @param  {Object}   state      Global state tree
- * @return {?Boolean}            Current user is rtl
+ * @return {Boolean}             Current user is rtl
  */
-export default function isRtl( state ) {
-	const localeSlug = getCurrentLocaleSlug( state );
-
-	if ( ! localeSlug ) {
-		return null;
-	}
-
-	const language = getLanguage( localeSlug );
-
-	if ( ! language ) {
-		return null;
-	}
-
-	return Boolean( language.rtl );
-}
+export default state => get( state, 'ui.language.isRtl', false );

--- a/client/state/selectors/test/is-rtl.js
+++ b/client/state/selectors/test/is-rtl.js
@@ -11,10 +11,10 @@ import { expect } from 'chai';
 import { isRtl } from 'state/selectors';
 
 describe( 'isRtl()', () => {
-	test( 'should return false if the value is not known', () => {
+	test( 'should return null if the value is not known', () => {
 		const result = isRtl( { ui: { language: {} } } );
 
-		expect( result ).to.be.false;
+		expect( result ).to.be.null;
 	} );
 
 	test( 'should return false if the isRtl reducer is false', () => {

--- a/client/state/selectors/test/is-rtl.js
+++ b/client/state/selectors/test/is-rtl.js
@@ -11,33 +11,33 @@ import { expect } from 'chai';
 import { isRtl } from 'state/selectors';
 
 describe( 'isRtl()', () => {
-	test( 'should return null if the value is not known', () => {
+	test( 'should return false if the value is not known', () => {
 		const result = isRtl( { ui: { language: {} } } );
 
-		expect( result ).to.be.null;
+		expect( result ).to.be.false;
 	} );
 
-	test( 'should return true if the localeSlug is RTL language', () => {
+	test( 'should return false if the isRtl reducer is false', () => {
 		const result = isRtl( {
 			ui: {
 				language: {
-					localeSlug: 'he',
-				},
-			},
-		} );
-
-		expect( result ).to.be.true;
-	} );
-
-	test( 'should return true if the localeSlug is LTR language', () => {
-		const result = isRtl( {
-			ui: {
-				language: {
-					localeSlug: 'fr',
+					isRtl: false,
 				},
 			},
 		} );
 
 		expect( result ).to.be.false;
+	} );
+
+	test( 'should return true if the isRtl reducer is true', () => {
+		const result = isRtl( {
+			ui: {
+				language: {
+					isRtl: true,
+				},
+			},
+		} );
+
+		expect( result ).to.be.true;
 	} );
 } );

--- a/client/state/ui/language/reducer.js
+++ b/client/state/ui/language/reducer.js
@@ -6,7 +6,8 @@
 
 import { combineReducers, createReducer } from 'state/utils';
 import { LOCALE_SET } from 'state/action-types';
-import { localeSlugSchema } from './schema';
+import { localeSlugSchema, isRtlSchema } from './schema';
+import { getLanguage } from 'lib/i18n-utils/utils';
 
 /**
  * Tracks the state of the ui locale
@@ -24,4 +25,34 @@ export const localeSlug = createReducer(
 	localeSlugSchema
 );
 
-export default combineReducers( { localeSlug } );
+/**
+ * Tracks the state of the ui locale
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ *
+ */
+export const isRtl = createReducer(
+	false,
+	{
+		[ LOCALE_SET ]: ( state, action ) => {
+			const localeSlugFromAction = action.localeSlug;
+
+			if ( ! localeSlugFromAction ) {
+				return state;
+			}
+
+			const language = getLanguage( localeSlugFromAction );
+
+			if ( ! language ) {
+				return state;
+			}
+
+			return Boolean( language.rtl );
+		},
+	},
+	isRtlSchema
+);
+
+export default combineReducers( { localeSlug, isRtl } );

--- a/client/state/ui/language/reducer.js
+++ b/client/state/ui/language/reducer.js
@@ -40,13 +40,13 @@ export const isRtl = createReducer(
 			const localeSlugFromAction = action.localeSlug;
 
 			if ( ! localeSlugFromAction ) {
-				return state;
+				return null;
 			}
 
 			const language = getLanguage( localeSlugFromAction );
 
 			if ( ! language ) {
-				return state;
+				return null;
 			}
 
 			return Boolean( language.rtl );

--- a/client/state/ui/language/reducer.js
+++ b/client/state/ui/language/reducer.js
@@ -26,7 +26,7 @@ export const localeSlug = createReducer(
 );
 
 /**
- * Tracks the state of the ui locale
+ * Tracks the state of the ui language isRtl.
  *
  * @param  {Object} state  Current state
  * @param  {Object} action Action payload
@@ -34,7 +34,7 @@ export const localeSlug = createReducer(
  *
  */
 export const isRtl = createReducer(
-	false,
+	null,
 	{
 		[ LOCALE_SET ]: ( state, action ) => {
 			const localeSlugFromAction = action.localeSlug;

--- a/client/state/ui/language/schema.js
+++ b/client/state/ui/language/schema.js
@@ -1,4 +1,4 @@
 /** @format */
 export const localeSlugSchema = { type: [ 'string', 'null' ] };
 
-export const isRtlSchema = { type: [ 'boolean', 'false' ] };
+export const isRtlSchema = { type: [ 'boolean', 'null' ] };

--- a/client/state/ui/language/schema.js
+++ b/client/state/ui/language/schema.js
@@ -1,2 +1,4 @@
 /** @format */
 export const localeSlugSchema = { type: [ 'string', 'null' ] };
+
+export const isRtlSchema = { type: [ 'boolean', 'false' ] };

--- a/client/state/ui/language/test/reducer.js
+++ b/client/state/ui/language/test/reducer.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { localeSlug } from '../reducer';
+import { localeSlug, isRtl } from '../reducer';
 import { LOCALE_SET } from 'state/action-types';
 
 describe( 'reducer', () => {
@@ -34,6 +34,38 @@ describe( 'reducer', () => {
 			const action = { type: LOCALE_SET, localeSlug: 'he' };
 
 			expect( localeSlug( state, action ) ).to.eql( 'he' );
+		} );
+	} );
+
+	describe( 'isRtl', () => {
+		test( 'returns default state with undefined state and empty action', () => {
+			expect( isRtl( undefined, {} ) ).to.be.false;
+		} );
+
+		test( 'returns previous state with empty action', () => {
+			expect( isRtl( true, {} ) ).to.be.true;
+		} );
+
+		test( 'returns default state with undefined state and invalid action type', () => {
+			expect( isRtl( undefined, { type: 'foobar' } ) ).to.be.false;
+		} );
+
+		test( 'returns true when localeSlug is a RTL language', () => {
+			const action = { type: LOCALE_SET, localeSlug: 'ar' };
+
+			expect( isRtl( false, action ) ).to.be.true;
+		} );
+
+		test( 'returns false when localeSlug is a LTR language', () => {
+			const action = { type: LOCALE_SET, localeSlug: 'fr' };
+
+			expect( isRtl( true, action ) ).to.be.false;
+		} );
+
+		test( 'returns default state when localeSlug is unknown language', () => {
+			const action = { type: LOCALE_SET, localeSlug: 'language' };
+
+			expect( isRtl( undefined, action ) ).to.be.false;
 		} );
 	} );
 } );

--- a/client/state/ui/language/test/reducer.js
+++ b/client/state/ui/language/test/reducer.js
@@ -38,7 +38,7 @@ describe( 'reducer', () => {
 	} );
 
 	describe( 'isRtl', () => {
-		test( 'returns default state with undefined state and empty action', () => {
+		test( 'returns null with undefined state and empty action', () => {
 			expect( isRtl( undefined, {} ) ).to.be.null;
 		} );
 
@@ -46,7 +46,7 @@ describe( 'reducer', () => {
 			expect( isRtl( true, {} ) ).to.be.true;
 		} );
 
-		test( 'returns default state with undefined state and invalid action type', () => {
+		test( 'returns null with undefined state and invalid action type', () => {
 			expect( isRtl( undefined, { type: 'foobar' } ) ).to.be.null;
 		} );
 
@@ -62,7 +62,7 @@ describe( 'reducer', () => {
 			expect( isRtl( true, action ) ).to.be.false;
 		} );
 
-		test( 'returns default state when localeSlug is unknown language', () => {
+		test( 'returns null when localeSlug is unknown language', () => {
 			const action = { type: LOCALE_SET, localeSlug: 'language' };
 
 			expect( isRtl( undefined, action ) ).to.be.null;

--- a/client/state/ui/language/test/reducer.js
+++ b/client/state/ui/language/test/reducer.js
@@ -39,7 +39,7 @@ describe( 'reducer', () => {
 
 	describe( 'isRtl', () => {
 		test( 'returns default state with undefined state and empty action', () => {
-			expect( isRtl( undefined, {} ) ).to.be.false;
+			expect( isRtl( undefined, {} ) ).to.be.null;
 		} );
 
 		test( 'returns previous state with empty action', () => {
@@ -47,7 +47,7 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'returns default state with undefined state and invalid action type', () => {
-			expect( isRtl( undefined, { type: 'foobar' } ) ).to.be.false;
+			expect( isRtl( undefined, { type: 'foobar' } ) ).to.be.null;
 		} );
 
 		test( 'returns true when localeSlug is a RTL language', () => {
@@ -65,7 +65,7 @@ describe( 'reducer', () => {
 		test( 'returns default state when localeSlug is unknown language', () => {
 			const action = { type: LOCALE_SET, localeSlug: 'language' };
 
-			expect( isRtl( undefined, action ) ).to.be.false;
+			expect( isRtl( undefined, action ) ).to.be.null;
 		} );
 	} );
 } );


### PR DESCRIPTION
Currently, the [isRtl](https://github.com/Automattic/wp-calypso/blob/master/client/state/selectors/is-rtl.js#L16) selector does some unnecessarily heavy computation each time it's called. In this PR, we are adding `isRtl` reducer which does the computation only once when locale slug is changed and then just access this value when needed.

## Testing

Verify things look and work as before. Now, in your account, change the language to a RTL one:

![screen shot 2018-01-31 at 16 34 16](https://user-images.githubusercontent.com/4988512/35631610-99a2ed46-06a4-11e8-9f46-f3a9cde6a502.png)

Save the settings and navigate to My Sites. You should see everything in RTL. Also, hover over some charts on Stats page. They should also display in RTL.