### PR TITLE
Documentation: remove remaining references to React.createClass in example code

### DIFF
--- a/client/components/data/domain-management/README.md
+++ b/client/components/data/domain-management/README.md
@@ -30,7 +30,7 @@ import MyChildComponent from 'components/my-child-component';
 
 // initialize rest of the variables
 
-const MyComponent = React.createClass( {
+class MyComponent extends React.Component {
 	render() {
 		return (
 			<DomainManagementData
@@ -40,7 +40,7 @@ const MyComponent = React.createClass( {
 				sites={ sites } />
 		);
 	}
-} );
+}
 
 export default MyComponent;
 ```

--- a/client/components/data/domain-management/dns/README.md
+++ b/client/components/data/domain-management/dns/README.md
@@ -15,7 +15,7 @@ import MyChildComponent from 'components/my-child-component';
 
 // initialize rest of the variables
 
-const MyComponent = React.createClass( {
+class MyComponent extends React.Component {
 	render() {
 		return (
 			<DnsData
@@ -24,7 +24,7 @@ const MyComponent = React.createClass( {
 				sites={ sites } />
 		);
 	}
-} );
+}
 
 export default MyComponent;
 ```

--- a/client/components/data/domain-management/email-forwarding/README.md
+++ b/client/components/data/domain-management/email-forwarding/README.md
@@ -15,7 +15,7 @@ import MyChildComponent from 'components/my-child-component';
 
 // initialize rest of the variables
 
-const MyComponent = React.createClass( {
+class MyComponent extends React.Component {
 	render() {
 		return (
 			<EmailForwardingData
@@ -24,7 +24,7 @@ const MyComponent = React.createClass( {
 				sites={ sites } />
 		);
 	}
-} );
+}
 
 export default MyComponent;
 ```

--- a/client/components/data/domain-management/email/README.md
+++ b/client/components/data/domain-management/email/README.md
@@ -15,7 +15,7 @@ import MyChildComponent from 'components/my-child-component';
 
 // initialize rest of the variables
 
-const MyComponent = React.createClass( {
+class MyComponent extends React.Component {
 	render() {
 		return (
 			<EmailData
@@ -26,7 +26,7 @@ const MyComponent = React.createClass( {
 				sites={ sites } />
 		);
 	}
-} );
+}
 
 export default MyComponent;
 ```

--- a/client/components/data/domain-management/nameservers/README.md
+++ b/client/components/data/domain-management/nameservers/README.md
@@ -15,7 +15,7 @@ import MyChildComponent from 'components/my-child-component';
 
 // initialize rest of the variables
 
-const MyComponent = React.createClass( {
+class MyComponent extends React.Component {
 	render() {
 		return (
 			<NameserversData
@@ -24,7 +24,7 @@ const MyComponent = React.createClass( {
 				sites={ sites } />
 		);
 	}
-} );
+}
 
 export default MyComponent;
 ```

--- a/client/components/data/domain-management/site-redirect/README.md
+++ b/client/components/data/domain-management/site-redirect/README.md
@@ -15,7 +15,7 @@ import MyChildComponent from 'components/my-child-component';
 
 // initialize rest of the variables
 
-const MyComponent = React.createClass( {
+class MyComponent extends React.Component {
 	render() {
 		return (
 			<SiteRedirectData
@@ -23,7 +23,7 @@ const MyComponent = React.createClass( {
 				selectedDomainName={ selectedDomainName } />
 		);
 	}
-} );
+}
 
 export default MyComponent;
 ```

--- a/client/components/data/domain-management/transfer/README.md
+++ b/client/components/data/domain-management/transfer/README.md
@@ -15,7 +15,7 @@ import MyChildComponent from 'components/my-child-component';
 
 // initialize rest of the variables
 
-const MyComponent = React.createClass( {
+class MyComponent extends React.Component {
 	render() {
 		return (
 			<TransferData
@@ -23,7 +23,7 @@ const MyComponent = React.createClass( {
 				selectedDomainName={ selectedDomainName } />
 		);
 	}
-} );
+}
 
 export default MyComponent;
 ```

--- a/client/components/data/domain-management/whois/README.md
+++ b/client/components/data/domain-management/whois/README.md
@@ -15,7 +15,7 @@ import MyChildComponent from 'components/my-child-component';
 
 // initialize rest of the variables
 
-const MyComponent = React.createClass( {
+class MyComponent extends React.Component {
 	render() {
 		return (
 			<WhoisData
@@ -24,7 +24,7 @@ const MyComponent = React.createClass( {
 				selectedDomainName={ selectedDomainName } />
 		);
 	}
-} );
+}
 
 export default MyComponent;
 ```

--- a/client/components/data/query-site-domains/README.md
+++ b/client/components/data/query-site-domains/README.md
@@ -10,9 +10,9 @@ Render the component, passing `siteId`. It does not accept any children, nor doe
 ```es6
 import QuerySiteDomains from 'components/data/query-site-domains';
 
-const MyReactComponent = React.createClass( {
+class MyComponent extends React.Component {
 	render() {
-	const { site, domains } = this.props;
+		const { site, domains } = this.props;
 
 		return (
 			<div>
@@ -27,6 +27,6 @@ const MyReactComponent = React.createClass( {
 			</div>
 		);
 	}
-} );
+}
 ```
 

--- a/client/components/external-link/README.md
+++ b/client/components/external-link/README.md
@@ -10,11 +10,11 @@ External Link is a React component for rendering an external link.
 import React from 'react';
 import ExternalLink from 'components/external-link';
 
-React.createClass( {
+class MyComponent extends React.Component {
 	render() {
 		return <ExternalLink icon={ true } href="https://wordpress.org" onClick="somefunction()">WordPress.org</ExternalLink>;
 	}
-} );
+}
 ```
 
 ## Props

--- a/client/components/faq/README.md
+++ b/client/components/faq/README.md
@@ -15,8 +15,8 @@ import FAQ from 'components/faq';
 import FAQItem from 'components/faq/faq-item';
 import i18n from 'i18n-calypso';
 
-export default React.createClass( {
-	displayName: 'MyFAQ',
+class MyComponent extends React.Component {
+	static displayName = 'MyComponent';
 
 	render() {
 		return (
@@ -32,7 +32,7 @@ export default React.createClass( {
 			</FAQ>
 		);
 	}
-} );
+}
 
 ```
 

--- a/client/components/faq/README.md
+++ b/client/components/faq/README.md
@@ -15,8 +15,8 @@ import FAQ from 'components/faq';
 import FAQItem from 'components/faq/faq-item';
 import i18n from 'i18n-calypso';
 
-class MyComponent extends React.Component {
-	static displayName = 'MyComponent';
+export default class MyFaq extends React.Component {
+	static displayName = 'MyFaq';
 
 	render() {
 		return (

--- a/client/components/feature-example/README.md
+++ b/client/components/feature-example/README.md
@@ -11,7 +11,7 @@ import React from 'react';
 import ExternalLink from 'components/feature-example';
 import EmptyContent from 'components/empty-content';
 
-React.createClass( {
+class MyComponent extends React.Component {
 	render() {
 		return (
 			<FeatureExample>
@@ -19,5 +19,5 @@ React.createClass( {
 			</FeatureExample>
 		);
 	}
-} );
+}
 ```

--- a/client/components/gallery-shortcode/README.md
+++ b/client/components/gallery-shortcode/README.md
@@ -11,8 +11,9 @@ Simply pass a site ID and an array of media items.
 import React from 'react';
 import GalleryShortcode from 'components/gallery-shortcode';
 
-export default React.createClass( {
-	displayName: 'MyComponent',
+
+export default class extends React.Component {
+	static displayName = 'MyComponent';
 
 	render() {
 		return (
@@ -22,7 +23,7 @@ export default React.createClass( {
 				className="my-component" />
 		);
 	}
-} );
+}
 ```
 
 ## Props

--- a/client/components/infinite-list/README.md
+++ b/client/components/infinite-list/README.md
@@ -35,27 +35,27 @@ If you need to track when user scrolls to another page, do it in `fetchNextPage`
 
 ```jsx
 
-const Listing = React.createClass( {
+class Listing extends React.Component {
 	...
-	fetchNextPage: funciton ( options ) {
+	fetchNextPage: ( options ) => {
 		if ( options.triggeredByScroll ) {
 			// track analytics events
 		}
 		actions.fetchNextPage();
-	},
+	}
 
-	getItemRef: function( item ) {
+	getItemRef: ( item ) => {
 		return 'item-' + item.id;
-	},
+	}
 
-	renderItem: function( item ) {
+	renderItem: ( item ) => {
 		var itemKey = this.getItemRef( item );
 		return (
 			<Item ref={ itemKey } key={ itemKey } ... />
 		);
-	},
+	}
 
-	renderLoadingPlaceholders: function() {
+	renderLoadingPlaceholders: () => {
 		var count = this.props.list.get().length ? 2 : this.props.list.perPage,
 			placeholders = [];
 		times( count, function( i ) {
@@ -63,9 +63,9 @@ const Listing = React.createClass( {
 		});
 
 		return placeholders;
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<InfiniteList className="main main-column reader__content" role="main"
 				items={ this.state.items }
@@ -79,10 +79,8 @@ const Listing = React.createClass( {
 				renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
 			/>
 		);
-	}
-
-} );
-
+	} 
+} 
 ```
 
 If you need reset scroll state of `InfiniteList` component, e.g. because the using component received list with different content, assign it different `key`, so that React creates new instance for it.

--- a/client/components/input-chrono/README.md
+++ b/client/components/input-chrono/README.md
@@ -8,8 +8,7 @@ React component that creates a Date object from a user-entered textual date desc
 ```js
 import InputChrono from 'components/input-chrono';
 
-export default React.createClass( {
-
+export default class extends React.Component {
 	// ...
 
 	onSet( date ) {
@@ -17,14 +16,9 @@ export default React.createClass( {
 	},
 
 	render() {
-		return (
-			<InputChrono
-				onSet={ this.onSet }
-			</InputChrono>
-		);
-	}
-
-} );
+		return <InputChrono onSet={ this.onSet }/>;
+	} 
+}
 ```
 
 ---

--- a/client/components/logged-out-form/README.md
+++ b/client/components/logged-out-form/README.md
@@ -13,8 +13,8 @@ import config from 'config';
 import Button from 'components/button';
 import FormTextInput from 'components/forms/form-text-input';
 
-const MyLoggedOutForm = React.createClass( {
-	handleSubmit( event ) {
+class MyLoggedOutForm extends React.Component {
+	handleSubmit = ( event ) => {
 		event.preventDefault();
 
 		// Handle form submit
@@ -37,6 +37,5 @@ const MyLoggedOutForm = React.createClass( {
 			</LoggedOutFormLinks>
 		);
 	}
-} );
-
+} 
 ```

--- a/client/components/shortcode/README.md
+++ b/client/components/shortcode/README.md
@@ -13,15 +13,15 @@ Simply pass a site ID and a shortcode string child. The component will automatic
 import React from 'react';
 import Shortcode from 'components/shortcode';
 
-export default React.createClass( {
-	displayName: 'MyComponent',
+export default class extends React.Component {
+	static displayName = 'MyComponent';
 
 	render() {
 		return (
 			<Shortcode siteId={ 6393289 }>[gallery ids="31860,31856"]</Shortcode>
 		);
 	}
-} );
+}
 ```
 
 ## Props

--- a/client/components/token-field/README.md
+++ b/client/components/token-field/README.md
@@ -55,18 +55,18 @@ The `value` property is handled in a manner similar to controlled form component
 ### Example
 
 ```jsx
-React.createClass( {
-	render: function() {
+class MyComponent extends React.Component {
+	onTokensChange: ( event ) => {
+		this.setState( { tokens: event.value } );
+	}
+
+	render() {
 		return (
 			<TokenField
 				value={ this.state.tokens }
 				onChange={ this.onTokensChange }
 				suggestions={ this.state.suggestions } />
 		);
-	},
-
-	onTokensChange: function( event ) {
-		this.setState( { tokens: event.value } );
 	}
-} );
+}
 ```

--- a/client/components/track-input-changes/README.md
+++ b/client/components/track-input-changes/README.md
@@ -12,7 +12,7 @@ action of making a change to a text field.
 ### Usage
 
 ```js
-export default React.createClass( {
+export default class extends React.Component {
 	render() {
 		return (
 			<TrackInputChanges onNewValue={ this.recordSomeStat }>
@@ -24,5 +24,5 @@ export default React.createClass( {
 			</TrackInputChanges>
 		);
 	}
-} );
+}
 ```

--- a/client/components/upgrades/credit-card-number-input/README.md
+++ b/client/components/upgrades/credit-card-number-input/README.md
@@ -10,13 +10,13 @@ CreditCardNumberInput
 import React from 'react';
 import CreditCardNumberInput from 'components/upgrades/credit-card-number-input';
 
-React.createClass( {
-	render: function() {
+class MyComponent extends React.Component {
+	render() {
 		return (
 			<CreditCardNumberInput value={ this.state.card.number } />
 		);
 	}
-} );
+}
 ```
 
 ## Properties

--- a/client/components/upgrades/google-apps/README.md
+++ b/client/components/upgrades/google-apps/README.md
@@ -14,8 +14,8 @@ import productsListFactory from 'lib/products-list';
 
 const productsList = productsListFactory();
 
-React.createClass( {
-	render: function() {
+class MyComponent extends React.Component {
+	render() {
 		return <GoogleApps
 			productsList={ productsList }
 			domain={ domain }
@@ -23,7 +23,7 @@ React.createClass( {
 			onAddGoogleApps={ handleAddGoogleApps }
 			onClickSkip={ handleClickSkip } />
 	}
-} );
+}
 ```
 
 ## Props

--- a/client/components/version/README.md
+++ b/client/components/version/README.md
@@ -10,11 +10,11 @@ Version is a React component for rendering a version number
 import React from 'react';
 import Version from 'components/version';
 
-React.createClass( {
-	render: function() {
+class MyComponent extends React.Component {
+	render() {
 		return <Version version={ 123 } icon="plugins" />;
 	}
-} );
+}
 ```
 
 ## Props

--- a/client/devdocs/design/README.md
+++ b/client/devdocs/design/README.md
@@ -19,19 +19,9 @@ The file of the example component should reside into a `/docs` folder in the sam
 
 #### Component name convention
 
-By convention the name of example component should ends with the `Example` word so for in the Popover case the name should be `PopoverExample`. The Devdocs-design component will take over to clean and show the right name in the web page.
+By convention the name of example component should ends with the `Example` word so for in the Popover case the name should be `PopoverExample`. The Devdocs-design component will take over to clean and show the right name in the web page. 
 
-If the example component is created using `React.createClass` then use `displayName` to define its name:
-
-```js
-module.exports = React.createClass( {
-	displayName: 'PopoverExample',
-
-	// ...
-} );
-```
-
-If you use ES6 `class` then define the name as a static `displayName` property:
+When using ES6 `class`, define the name as a static `displayName` property:
 
 ```es6
 class PopoverExample extends PureComponent {

--- a/client/my-sites/plan-price/README.md
+++ b/client/my-sites/plan-price/README.md
@@ -12,8 +12,8 @@ flexbox container.
 ```jsx
 import PlanPrice from 'my-sites/plan-price';
 
-export default React.createClass( {
-	displayName: 'MyPlanPrice',
+export default class extends React.Component {
+	static displayName = 'MyPlanPrice';
 
 	render() {
 		return (
@@ -23,8 +23,7 @@ export default React.createClass( {
 			</span>
 		);
 	}
-} );
-
+}
 ```
 
 ## Props

--- a/client/state/push-notifications/README.md
+++ b/client/state/push-notifications/README.md
@@ -34,11 +34,11 @@ const mapDispatchToProps = {
 	toggleEnabled
 };
 
-const YourReactClass = React.createClass( {
-	toggleEnabled() {
+class YourReactClass extends React.Component {
+	toggleEnabled = () => {
 		this.props.toggleEnabled();
 	}
-} );
+}
 
 export default connect(
 	mapStateToProps,

--- a/docs/coding-guidelines/html.md
+++ b/docs/coding-guidelines/html.md
@@ -42,10 +42,9 @@ When mixing JavaScript and HTML (via JSX) together, indent JavaScript blocks to 
 Correct:
 
 ```js
-const Post = React.createClass({
-
-	render: function() {
-		var post = this.props.post;
+class Post extends React.Component {
+	render() {
+		const post = this.props.post;
 
 		return (
 			<div id={ 'post-' + post.ID } className="post">
@@ -56,16 +55,15 @@ const Post = React.createClass({
 			</div>
 		);
 	}
-});
+}
 ```
 
 Incorrect:
 
 ```js
-const Post = React.createClass({
-
-	render: function() {
-		var post = this.props.post;
+class Post extends React.Component {
+	render() {
+		const post = this.props.post;
 
 		return (
 			<div id={ 'post-' + post.ID } className="post">
@@ -76,6 +74,6 @@ const Post = React.createClass({
 			</div>
 		);
 	}
-});
+}
 ```
 


### PR DESCRIPTION
Removes all references to `React.createClass` in favor of es6 classes in Calypsos markdown examples