### PR TITLE
Rewind: allow to restart a failed restore

### DIFF
--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -27,7 +27,7 @@ class ErrorBanner extends PureComponent {
 		siteId: PropTypes.number.isRequired,
 		timestamp: PropTypes.string,
 		downloadId: PropTypes.number,
-		requestedRestoreActivityId: PropTypes.string,
+		requestedRestoreId: PropTypes.string,
 		createBackup: PropTypes.func,
 		rewindRestore: PropTypes.func,
 
@@ -42,22 +42,16 @@ class ErrorBanner extends PureComponent {
 		errorCode: '',
 		failureReason: '',
 		downloadId: undefined,
-		requestedRestoreActivityId: undefined,
+		requestedRestoreId: undefined,
 	};
 
 	handleClickRestart = () => {
-		const {
-			siteId,
-			downloadId,
-			requestedRestoreActivityId,
-			rewindRestore,
-			createBackup,
-		} = this.props;
+		const { siteId, downloadId, requestedRestoreId, rewindRestore, createBackup } = this.props;
 		if ( downloadId ) {
 			return createBackup( siteId, downloadId );
 		}
-		if ( requestedRestoreActivityId ) {
-			return rewindRestore( siteId, requestedRestoreActivityId );
+		if ( requestedRestoreId ) {
+			return rewindRestore( siteId, requestedRestoreId );
 		}
 	};
 


### PR DESCRIPTION
This PR fixes an issue where the Try again button in the error banner shown after a failed restore didn't do anything. It uses the right property `requestedRestoreId` instead of the no longer existent `requestedRestoreActivityId`.

### Testing

You can visit the MC VP for a site, and click `Fail Rewinds: off toggle` towards the end of the page. Initiate a rewind and verify it fails.
You can quickly verify the **Try again** button now works by clicking it and monitoring the network request or the Redux action. Note that it will still fail since it's set to fail in MC VP.
You can visit MC VP again, reload, and go back, and now the restore will proceed normally (provided there's nothing else preventing the restore).