### PR TITLE
Rewind: update the URL of the notice to add credentials

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -484,7 +484,7 @@ class ActivityLog extends Component {
 				{ 'awaitingCredentials' === rewindState.state && (
 					<Banner
 						icon="history"
-						href={ `/settings/security/${ slug }` }
+						href={ `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ slug }` }
 						title={ translate( 'Add site credentials' ) }
 						description={ translate(
 							'Backups and security scans require access to your site to work properly.'


### PR DESCRIPTION
This PR updates the URL so it points to the new flow to add credentials.

<img width="731" alt="captura de pantalla 2018-02-02 a la s 11 12 04" src="https://user-images.githubusercontent.com/1041600/35737348-eec95f1a-0809-11e8-987f-fdac13b41662.png">

<strike>NOTE: must be merged **after** https://github.com/Automattic/wp-calypso/pull/21802 is merged.</strike>

#21802 is now merged.

### Testing

- Remove creds in a site, and visit AL. You should get the notice.
- Verify that the link takes you to the new flow.