### PR TITLE
State: do not add sites to state if we cannot manage them — take 2

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -208,7 +208,8 @@ function onSelectedSiteAvailable( context ) {
 	// Currently, sites are only made available in Redux state by the receive
 	// here (i.e. only selected sites). If a site is already known in state,
 	// avoid receiving since we risk overriding changes made more recently.
-	if ( ! getSite( state, selectedSite.ID ) ) {
+	// Also, if we can't manage the site, don't add it to state.
+	if ( ! getSite( state, selectedSite.ID ) && selectedSite.capabilities ) {
 		context.store.dispatch( receiveSite( selectedSite ) );
 	}
 

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -126,20 +126,20 @@ export function requestSite( siteFragment ) {
 			.get()
 			.then( site => {
 				// If we can't manage the site, don't add it to state.
-				if ( site && site.capabilities ) {
-					dispatch( receiveSite( omit( site, '_headers' ) ) );
-
-					dispatch( {
-						type: SITE_REQUEST_SUCCESS,
-						siteId: siteFragment,
-					} );
-				} else {
-					dispatch( {
+				if ( ! ( site && site.capabilities ) ) {
+					return dispatch( {
 						type: SITE_REQUEST_FAILURE,
 						siteId: siteFragment,
 						error: i18n.translate( 'No access to manage the site' ),
 					} );
 				}
+
+				dispatch( receiveSite( omit( site, '_headers' ) ) );
+
+				dispatch( {
+					type: SITE_REQUEST_SUCCESS,
+					siteId: siteFragment,
+				} );
 			} )
 			.catch( error => {
 				dispatch( {

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -5,6 +5,7 @@
  */
 
 import { omit } from 'lodash';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -131,6 +132,12 @@ export function requestSite( siteFragment ) {
 					dispatch( {
 						type: SITE_REQUEST_SUCCESS,
 						siteId: siteFragment,
+					} );
+				} else {
+					dispatch( {
+						type: SITE_REQUEST_FAILURE,
+						siteId: siteFragment,
+						error: i18n.translate( 'No access to manage the site' ),
 					} );
 				}
 			} )

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -124,11 +124,15 @@ export function requestSite( siteFragment ) {
 			.site( siteFragment )
 			.get()
 			.then( site => {
-				dispatch( receiveSite( omit( site, '_headers' ) ) );
-				dispatch( {
-					type: SITE_REQUEST_SUCCESS,
-					siteId: siteFragment,
-				} );
+				// If we can't manage the site, don't add it to state.
+				if ( site && site.capabilities ) {
+					dispatch( receiveSite( omit( site, '_headers' ) ) );
+
+					dispatch( {
+						type: SITE_REQUEST_SUCCESS,
+						siteId: siteFragment,
+					} );
+				}
 			} )
 			.catch( error => {
 				dispatch( {

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -73,13 +73,7 @@ export function items( state = null, action ) {
 		case SITE_RECEIVE:
 		case SITES_RECEIVE:
 			// Normalize incoming site(s) to array
-			const maybeUnmanageableSites = action.site ? [ action.site ] : action.sites;
-			// filter out anything the current user can't manage
-			const sites = maybeUnmanageableSites.filter( site => site && site.capabilities );
-
-			if ( sites.length === 0 ) {
-				return state;
-			}
+			const sites = action.site ? [ action.site ] : action.sites;
 
 			// SITES_RECEIVE occurs when we receive the entire set of user
 			// sites (replace existing state). Otherwise merge into state.

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -140,11 +140,17 @@ describe( 'actions', () => {
 				.reply( 200, {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
+					capabilities: {},
 				} )
 				.get( '/rest/v1.1/sites/77203074' )
 				.reply( 403, {
 					error: 'authorization_required',
 					message: 'User cannot access this private blog.',
+				} )
+				.get( '/rest/v1.1/sites/8894098' )
+				.reply( 200, {
+					ID: 8894098,
+					name: 'Some random site I dont have access to',
 				} );
 		} );
 
@@ -162,6 +168,18 @@ describe( 'actions', () => {
 				expect( spy ).to.have.been.calledWith(
 					receiveSite( {
 						ID: 2916284,
+						name: 'WordPress.com Example Blog',
+						capabilities: {},
+					} )
+				);
+			} );
+		} );
+
+		test( "should not dispatch receive site when request completes with site we can't manage", () => {
+			return requestSite( 8894098 )( spy ).then( () => {
+				expect( spy ).to.have.not.been.calledWith(
+					receiveSite( {
+						ID: 8894098,
 						name: 'WordPress.com Example Blog',
 					} )
 				);
@@ -183,6 +201,15 @@ describe( 'actions', () => {
 					type: SITE_REQUEST_FAILURE,
 					siteId: 77203074,
 					error: match( { message: 'User cannot access this private blog.' } ),
+				} );
+			} );
+		} );
+
+		test( "should not dispatch request success action when request completes with site we can't manage", () => {
+			return requestSite( 8894098 )( spy ).then( () => {
+				expect( spy ).to.have.not.been.calledWith( {
+					type: SITE_REQUEST_SUCCESS,
+					siteId: 8894098,
 				} );
 			} );
 		} );

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -111,37 +111,37 @@ describe( 'reducer', () => {
 			const state = items( undefined, {
 				type: SITES_RECEIVE,
 				sites: [
-					{ ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
-					{ ID: 77203074, name: 'Another test site', capabilities: {} },
+					{ ID: 2916284, name: 'WordPress.com Example Blog' },
+					{ ID: 77203074, name: 'Another test site' },
 				],
 			} );
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
-				77203074: { ID: 77203074, name: 'Another test site', capabilities: {} },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
+				77203074: { ID: 77203074, name: 'Another test site' },
 			} );
 		} );
 
 		test( 'overwrites sites when all sites are received', () => {
 			const original = deepFreeze( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
-				77203074: { ID: 77203074, name: 'Another test site', capabilities: {} },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
+				77203074: { ID: 77203074, name: 'Another test site' },
 			} );
 			const state = items( original, {
 				type: SITES_RECEIVE,
-				sites: [ { ID: 77203074, name: 'A Bowl of Pho', capabilities: {} } ],
+				sites: [ { ID: 77203074, name: 'A Bowl of Pho' } ],
 			} );
 			expect( state ).to.eql( {
-				77203074: { ID: 77203074, name: 'A Bowl of Pho', capabilities: {} },
+				77203074: { ID: 77203074, name: 'A Bowl of Pho' },
 			} );
 		} );
 
 		test( 'should return same state if received site matches existing', () => {
 			const original = deepFreeze( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
 			} );
 			const state = items( original, {
 				type: SITE_RECEIVE,
-				sites: [ { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} } ],
+				sites: [ { ID: 2916284, name: 'WordPress.com Example Blog' } ],
 			} );
 
 			expect( state ).to.equal( original );
@@ -150,26 +150,26 @@ describe( 'reducer', () => {
 		test( 'should index sites by ID', () => {
 			const state = items( undefined, {
 				type: SITE_RECEIVE,
-				site: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+				site: { ID: 2916284, name: 'WordPress.com Example Blog' },
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
 			} );
 		} );
 
 		test( 'should accumulate sites', () => {
 			const original = deepFreeze( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
 			} );
 			const state = items( original, {
 				type: SITE_RECEIVE,
-				site: { ID: 77203074, name: 'Just You Wait', capabilities: {} },
+				site: { ID: 77203074, name: 'Just You Wait' },
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
-				77203074: { ID: 77203074, name: 'Just You Wait', capabilities: {} },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
+				77203074: { ID: 77203074, name: 'Just You Wait' },
 			} );
 		} );
 
@@ -208,8 +208,8 @@ describe( 'reducer', () => {
 
 		test( 'should return the original state when deleting a site that is not present', () => {
 			const original = deepFreeze( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
-				77203074: { ID: 77203074, name: 'Just You Wait', capabilities: {} },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
+				77203074: { ID: 77203074, name: 'Just You Wait' },
 			} );
 
 			const state = items( original, {
@@ -222,15 +222,15 @@ describe( 'reducer', () => {
 
 		test( 'should override previous site of same ID', () => {
 			const original = deepFreeze( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
 			} );
 			const state = items( original, {
 				type: SITE_RECEIVE,
-				site: { ID: 2916284, name: 'Just You Wait', capabilities: {} },
+				site: { ID: 2916284, name: 'Just You Wait' },
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'Just You Wait', capabilities: {} },
+				2916284: { ID: 2916284, name: 'Just You Wait' },
 			} );
 		} );
 
@@ -241,13 +241,12 @@ describe( 'reducer', () => {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
 					slug: 'example.wordpress.com',
-					capabilities: {},
 					updateComputedAttributes() {},
 				},
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
 			} );
 		} );
 
@@ -259,14 +258,13 @@ describe( 'reducer', () => {
 						ID: 2916284,
 						name: 'WordPress.com Example Blog',
 						slug: 'example.wordpress.com',
-						capabilities: {},
 						updateComputedAttributes() {},
 					},
 				],
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' },
 			} );
 		} );
 
@@ -617,30 +615,6 @@ describe( 'reducer', () => {
 			const state = items( original, { type: DESERIALIZE } );
 
 			expect( state ).to.be.null;
-		} );
-
-		test( 'should not store sites we cannot manage', () => {
-			const state = items( undefined, {
-				type: SITES_RECEIVE,
-				sites: [
-					{ ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
-					{ ID: 77203074, name: 'A Site I do not own' },
-				],
-			} );
-			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', capabilities: {} },
-			} );
-		} );
-
-		test( 'ignores all sites if we cannot manage them', () => {
-			const state = items( undefined, {
-				type: SITES_RECEIVE,
-				sites: [
-					{ ID: 2916284, name: 'WordPress.com Example Blog' },
-					{ ID: 77203074, name: 'A Site I do not own' },
-				],
-			} );
-			expect( state ).to.eql( null );
 		} );
 	} );
 


### PR DESCRIPTION
Another take on #21894. Instead of having to loop through all the sites when we receive them to see if we can manage them, we don't dispatch `SITE_RECEIVE` if we can't manage a site. The `/me/sites` endpoint has always returned only sites we can manage so we don't need to do that (expensive) check for that case.

Props @gwwar for the idea.

## Testing

See testing of #21894.