### PR TITLE
Rewind Credentials: Expose more information on the update request

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -275,7 +275,6 @@ export class RewindCredentialsForm extends Component {
 
 const mapStateToProps = ( state, { siteId } ) => ( {
 	formIsSubmitting: 'pending' === getJetpackCredentialsUpdateStatus( state, siteId ),
-	requestStatus: getJetpackCredentialsUpdateStatus( state, siteId ),
 	siteSlug: getSiteSlug( state, siteId ),
 	rewindState: getRewindState( state, siteId ),
 } );

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -24,7 +24,7 @@ import Gridicon from 'gridicons';
 import QueryRewindState from 'components/data/query-rewind-state';
 import { deleteCredentials, updateCredentials } from 'state/jetpack/credentials/actions';
 import { getSiteSlug } from 'state/sites/selectors';
-import { getRewindState, isUpdatingJetpackCredentials } from 'state/selectors';
+import { getRewindState, getJetpackCredentialsUpdateStatus } from 'state/selectors';
 
 export class RewindCredentialsForm extends Component {
 	static propTypes = {
@@ -274,7 +274,8 @@ export class RewindCredentialsForm extends Component {
 }
 
 const mapStateToProps = ( state, { siteId } ) => ( {
-	formIsSubmitting: isUpdatingJetpackCredentials( state, siteId ),
+	formIsSubmitting: 'pending' === getJetpackCredentialsUpdateStatus( state, siteId ),
+	requestStatus: getJetpackCredentialsUpdateStatus( state, siteId ),
 	siteSlug: getSiteSlug( state, siteId ),
 	rewindState: getRewindState( state, siteId ),
 } );

--- a/client/state/jetpack/credentials/reducer.js
+++ b/client/state/jetpack/credentials/reducer.js
@@ -20,14 +20,16 @@ export const items = keyedReducer( 'siteId', ( state, { type, credentials } ) =>
 } );
 items.schema = itemsSchema;
 
-export const updateRequesting = keyedReducer( 'siteId', ( state, { type } ) => {
+export const requestStatus = keyedReducer( 'siteId', ( state, { type } ) => {
 	switch ( type ) {
 		case JETPACK_CREDENTIALS_UPDATE:
-			return true;
+			return 'pending';
 
 		case JETPACK_CREDENTIALS_UPDATE_SUCCESS:
+			return 'success';
+
 		case JETPACK_CREDENTIALS_UPDATE_FAILURE:
-			return false;
+			return 'failed';
 	}
 
 	return state;
@@ -35,5 +37,5 @@ export const updateRequesting = keyedReducer( 'siteId', ( state, { type } ) => {
 
 export const reducer = combineReducers( {
 	items,
-	updateRequesting,
+	requestStatus,
 } );

--- a/client/state/selectors/get-jetpack-credentials-update-status.js
+++ b/client/state/selectors/get-jetpack-credentials-update-status.js
@@ -4,5 +4,5 @@
 import { get } from 'lodash';
 
 export default function getJetpackCredentialsUpdateStatus( state, siteId ) {
-	return get( state, [ 'jetpack', 'credentials', 'requestStatus', siteId ], 'unknown' );
+	return get( state, [ 'jetpack', 'credentials', 'requestStatus', siteId ], 'unsubmitted' );
 }

--- a/client/state/selectors/get-jetpack-credentials-update-status.js
+++ b/client/state/selectors/get-jetpack-credentials-update-status.js
@@ -1,0 +1,8 @@
+/**
+ * External Dependencies
+ */
+import { get } from 'lodash';
+
+export default function getJetpackCredentialsUpdateStatus( state, siteId ) {
+	return get( state, [ 'jetpack', 'credentials', 'requestStatus', siteId ], 'unknown' );
+}

--- a/client/state/selectors/is-updating-jetpack-credentials.js
+++ b/client/state/selectors/is-updating-jetpack-credentials.js
@@ -1,8 +1,0 @@
-/**
- * External Dependencies
- */
-import { get } from 'lodash';
-
-export default function isUpdatingJetpackCredentials( state, siteId ) {
-	return get( state, [ 'jetpack', 'credentials', 'updateRequesting', siteId ], false );
-}


### PR DESCRIPTION
This PR replaces the `isUpdatingJetpackCredentials` selector and reducer with `getJetpackCredentialsUpdateStatus` which exposes more information on the request lifecycle stage. This gives us the platform to update the app instead of just the `RewindCredentialsForm` component when a request is successful or failed.

**Testing Instructions**
There should be no functional or visual changes in this PR, so go update or add some credentials. Everything should work normally.