### PR TITLE
Fix position of tour

### DIFF
--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -73,7 +73,10 @@ export const ChecklistContactPageTour = makeTour(
 			target="media-library-upload-more"
 			placement="beside"
 			arrow="left-top"
-			style={ { marginTop: '-10px' } }
+			style={ {
+				marginTop: '-10px',
+				marginLeft: '-40px',
+			} }
 		>
 			<p>{ translate( 'Either pick an image below or add a new one from your computer.' ) }</p>
 			<Next step="click-set-featured-image">{ translate( 'All done, continue' ) }</Next>

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour.js
@@ -58,7 +58,10 @@ export const ChecklistPublishPostTour = makeTour(
 			target="accordion-categories-tags"
 			arrow="right-top"
 			placement="beside"
-			style={ { marginTop: '-10px' } }
+			style={ {
+				marginTop: '-10px',
+				marginLeft: '-40px',
+			} }
 		>
 			<p>
 				{ translate(

--- a/client/layout/guided-tours/tours/checklist-site-icon-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour.js
@@ -51,7 +51,10 @@ export const ChecklistSiteIconTour = makeTour(
 			target="media-library-upload-more"
 			placement="beside"
 			arrow="left-top"
-			style={ { marginTop: '-10px' } }
+			style={ {
+				marginTop: '-10px',
+				marginLeft: '-40px',
+			} }
 		>
 			<p>
 				{ translate( 'Pick or drag a file from your computer to add it to your media library.' ) }


### PR DESCRIPTION
I got some reports that one of the tours was covering the UI and lead to some confusion. Exposing the element leads to some weird behaviours so this PR updates the tour to completely cover the element as to not have people get tripped up on it. 

## Before
![image](https://user-images.githubusercontent.com/6981253/35644373-c78a4c3a-0696-11e8-9915-b1113a70d16a.png)

![image](https://user-images.githubusercontent.com/6981253/35644387-cbd43b16-0696-11e8-8220-4d88bed03ec7.png)

![image](https://user-images.githubusercontent.com/6981253/35644397-d0c5ba1e-0696-11e8-890b-459363ad29ac.png)

## After
![image](https://user-images.githubusercontent.com/6981253/35644362-bfdd0478-0696-11e8-92d1-0644bc6e1bf3.png)

@markryall can you please take a look?