### PR TITLE
Fix site icon tour

### DIFF
--- a/client/layout/guided-tours/tours/checklist-site-icon-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour.js
@@ -80,7 +80,7 @@ export const ChecklistSiteIconTour = makeTour(
 			placement="above"
 			style={ { marginTop: '30px', marginLeft: '90px' } }
 		>
-			<Continue target="image_editor_button_done" step="finish" click>
+			<Continue target="image-editor-button-done" step="finish" click>
 				{ translate(
 					'Let’s make sure it looks right before you press {{b}}Done{{/b}} to save your changes.',
 					{ components: { b: <strong /> } }


### PR DESCRIPTION
The last step of the site icon tour does not display. This PR adds a fix so that it now shows. 

## Before
![image](https://user-images.githubusercontent.com/6981253/35644765-e5d0b8a4-0697-11e8-8c04-40a42a191950.png)


## After
![image](https://user-images.githubusercontent.com/6981253/35644710-ba67e3fe-0697-11e8-8888-78a505de1264.png)

@markryall can you take a look?