### PR TITLE
Store Orders: Trash pickup

### DIFF
--- a/client/extensions/woocommerce/app/order/order-customer/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-customer/dialog.js
@@ -183,7 +183,7 @@ class CustomerAddressDialog extends Component {
 			return null;
 		}
 		return (
-			<div>
+			<div className="order-customer__billing-fields">
 				<FormFieldset>
 					<FormPhoneMediaInput
 						label={ translate( 'Phone Number' ) }

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -70,7 +70,7 @@
 		width: 100%;
 	}
 
-	.form-fieldset:last-child {
+	.order-customer__billing-fields .form-fieldset:last-child {
 		margin-bottom: 0;
 	}
 

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -17,7 +17,7 @@
 		font-style: italic;
 	}
 
-	&.hide-taxes.is-editing .order-details__item-tax {
+	&.hide-taxes .order-details__item-tax {
 		display: none;
 	}
 

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -189,6 +189,11 @@
 
 		.form-text-input-with-affixes {
 			max-width: 13em;
+
+			.form-currency-input {
+				// Fixed width fixes layout issue in Firefox
+				width: 7em;
+			}
 		}
 
 		.order-details__totals-tax {


### PR DESCRIPTION
This PR fixes a few existing issues around the orders screen:
- #21407 – Issues in firefox display
- #17911 – Tax col should be hidden when no taxes
- #18958 – Fulfill button not disabled during fulfillment (also some code cleanup of the order fulfillment card)

**To test**

- In Firefox:
- Edit an order, or create a new order at `/store/order/:site`
- Check that there is space between the Shipping input & edge of the card
- Click Add Billing Address (or edit the existing billing address)
- Check that the customer details modal is aligned correctly (specifically postal code)

-----

- Open an order with tax
- Verify that the tax column in both the line-item section and totals section displays
- Open an order without tax
- Verify that there is no tax column in either place
- Edit the order, make sure the alignment is still correct

-----

- Open an unfulfilled order
- Click "Fulfill" or "Fulfill without printing a label"
- Optionally enter tracking/email customer, click "Fulfill"
- Buttons should switch to disabled, busy state while the order updates
- I can't test the printed label flow because I can't get a successful label purchase