### PR TITLE
Activity Log: Add unavailability banner

### DIFF
--- a/client/my-sites/stats/activity-log-switch/index.jsx
+++ b/client/my-sites/stats/activity-log-switch/index.jsx
@@ -182,7 +182,7 @@ export default connect(
 			siteSlug: getSelectedSiteSlug( state, siteId ),
 			siteUrl: getSiteUrl( state, siteId ),
 			rewindState: rewindState.state,
-			failureReason: rewindState.failureReason || '',
+			failureReason: rewindState.reason || '',
 		};
 	}
 )( localize( ActivityLogSwitch ) );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -34,6 +34,7 @@ import StatsFirstView from '../stats-first-view';
 import StatsNavigation from 'blocks/stats-navigation';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import SuccessBanner from '../activity-log-banner/success-banner';
+import UnavailabilityNotice from './unavailability-notice';
 import { adjustMoment, getActivityLogQuery, getStartMoment } from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
@@ -481,6 +482,7 @@ class ActivityLog extends Component {
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />
 				{ siteId && <ActivityLogUpgradeNotice siteId={ siteId } /> }
+				{ 'unavailable' === rewindState.state && <UnavailabilityNotice siteId={ siteId } /> }
 				{ 'awaitingCredentials' === rewindState.state && (
 					<Banner
 						icon="history"

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -482,7 +482,8 @@ class ActivityLog extends Component {
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />
 				{ siteId && <ActivityLogUpgradeNotice siteId={ siteId } /> }
-				{ 'unavailable' === rewindState.state && <UnavailabilityNotice siteId={ siteId } /> }
+				{ siteId &&
+					'unavailable' === rewindState.state && <UnavailabilityNotice siteId={ siteId } /> }
 				{ 'awaitingCredentials' === rewindState.state && (
 					<Banner
 						icon="history"

--- a/client/my-sites/stats/activity-log/unavailability-notice.jsx
+++ b/client/my-sites/stats/activity-log/unavailability-notice.jsx
@@ -25,7 +25,7 @@ export const UnavailabilityNotice = ( { adminUrl, reason, rewindState, slug, tra
 				<Banner
 					icon="history"
 					href={ adminUrl }
-					title={ translate( 'The site is not connected' ) }
+					title={ translate( 'The site is not connected.' ) }
 					description={ translate(
 						"We can't back up or rewind your site until it has been reconnected."
 					) }
@@ -37,7 +37,7 @@ export const UnavailabilityNotice = ( { adminUrl, reason, rewindState, slug, tra
 				<Banner
 					icon="history"
 					href={ `/settings/security/${ slug }` }
-					title={ translate( 'VaultPress is running' ) }
+					title={ translate( 'VaultPress is running.' ) }
 					description={ translate(
 						'We are unable to create backups and Rewind while VaultPress is running.'
 					) }

--- a/client/my-sites/stats/activity-log/unavailability-notice.jsx
+++ b/client/my-sites/stats/activity-log/unavailability-notice.jsx
@@ -25,9 +25,9 @@ export const UnavailabilityNotice = ( { adminUrl, reason, rewindState, slug, tra
 				<Banner
 					icon="history"
 					href={ adminUrl }
-					title={ translate( 'The site cannot be accessed' ) }
+					title={ translate( 'The site is not connected' ) }
 					description={ translate(
-						'We are unable to create backups and Rewind because we cannot access your site.'
+						"We can't back up or rewind your site until it has been reconnected."
 					) }
 				/>
 			);

--- a/client/my-sites/stats/activity-log/unavailability-notice.jsx
+++ b/client/my-sites/stats/activity-log/unavailability-notice.jsx
@@ -1,0 +1,60 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Banner from 'components/banner';
+import { getSiteAdminUrl } from 'state/sites/selectors';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getRewindState } from 'state/selectors';
+
+export const UnavailabilityNotice = ( { adminUrl, reason, rewindState, slug, translate } ) => {
+	if ( rewindState !== 'unavailable' ) {
+		return null;
+	}
+
+	switch ( reason ) {
+		case 'no_connected_jetpack':
+			return (
+				<Banner
+					icon="history"
+					href={ adminUrl }
+					title={ translate( 'The site cannot be accessed' ) }
+					description={ translate(
+						'We are unable to create backups and Rewind because we cannot access your site.'
+					) }
+				/>
+			);
+
+		case 'vp_can_transfer':
+			return (
+				<Banner
+					icon="history"
+					href={ `/settings/security/${ slug }` }
+					title={ translate( 'VaultPress is running' ) }
+					description={ translate(
+						'We are unable to create backups and Rewind while VaultPress is running.'
+					) }
+				/>
+			);
+	}
+};
+
+const mapStateToProps = ( state, { siteId } ) => {
+	const { reason, state: rewindState } = getRewindState( state, siteId );
+
+	return {
+		adminUrl: getSiteAdminUrl( state, siteId ),
+		reason,
+		rewindState,
+		slug: getSelectedSiteSlug( state ),
+	};
+};
+
+export default connect( mapStateToProps )( localize( UnavailabilityNotice ) );

--- a/client/my-sites/stats/activity-log/unavailability-notice.jsx
+++ b/client/my-sites/stats/activity-log/unavailability-notice.jsx
@@ -43,6 +43,9 @@ export const UnavailabilityNotice = ( { adminUrl, reason, rewindState, slug, tra
 					) }
 				/>
 			);
+
+		default:
+			return null;
 	}
 };
 

--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -52,6 +52,6 @@ export const transformApi = data =>
 		data.can_autoconfigure && { canAutoconfigure: !! data.can_autoconfigure },
 		data.credentials && { credentials: data.credentials.map( transformCredential ) },
 		data.downloads && { downloads: data.downloads.map( transformDownload ) },
-		data.reason && { failureReason: data.reason },
+		data.reason && { reason: data.reason },
 		data.rewind && { rewind: transformRewind( data.rewind ) }
 	);


### PR DESCRIPTION
In certain circumstances Rewind is unavailable and yet there is
something the customer can do about it. In these cases we want to
provide them a hint at what that might be and an opportunity to
act on that.

In this patch we're creting a banner to display in the Activity Log
to show when a Jetpack site is disconnected and also when VaultPress
is active but also able to transfer to Rewind.

<img width="657" alt="screen shot 2018-01-31 at 4 25 13 pm" src="https://user-images.githubusercontent.com/5431237/35648555-19265662-06a4-11e8-833e-12ba8927c602.png">

<img width="653" alt="screen shot 2018-01-31 at 4 22 42 pm" src="https://user-images.githubusercontent.com/5431237/35648558-1a82fa10-06a4-11e8-8833-07e54801163d.png">

**Questions**
 - Although I wrote up the JSX here I have no idea what we should be saying. I would appreciate some recommendations for the banner titles and descriptions.
 - @MichaelArestad can you recommend appropriate icons for the banner?
 - Are these banners even appropriate? There's a sync-issue here with disconnected Jetpack sites because it appears like the backend isn't as aware of sites disconnecting and reconnecting as Calypso itself it. Should we instead have some kind of more-global notice of degraded service while disconnected and leave this banner out of here?
 - The VaultPress banner links to the credentials form and the disconnected notice links to the `wp-admin` of the Jetpack site. Is this right?