### PR TITLE
Store: Settings trash pickup

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup-tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup-tasks.js
@@ -25,7 +25,6 @@ import { fetchPaymentMethods } from 'woocommerce/state/sites/payment-methods/act
 import {
 	setOptedOutOfShippingSetup,
 	setTriedCustomizerDuringInitialSetup,
-	setCheckedTaxSetup,
 } from 'woocommerce/state/sites/setup-choices/actions';
 import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
 import { arePaymentsSetup } from 'woocommerce/state/ui/payments/methods/selectors';
@@ -79,10 +78,6 @@ class SetupTasks extends Component {
 			showShippingTask: false,
 		} );
 		this.props.setOptedOutOfShippingSetup( this.props.site.ID, true );
-	};
-
-	onClickTaxSettings = () => {
-		this.props.setCheckedTaxSetup( this.props.site.ID, true );
 	};
 
 	onClickOpenCustomizer = () => {
@@ -165,7 +160,6 @@ class SetupTasks extends Component {
 					{
 						label: translate( 'Review taxes' ),
 						path: getLink( '/store/settings/taxes/:site', site ),
-						onClick: this.onClickTaxSettings,
 						analyticsProp: 'set-up-taxes',
 					},
 				],
@@ -234,7 +228,6 @@ function mapDispatchToProps( dispatch ) {
 			fetchPaymentMethods,
 			fetchProducts,
 			setOptedOutOfShippingSetup,
-			setCheckedTaxSetup,
 			setTriedCustomizerDuringInitialSetup,
 		},
 		dispatch

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
@@ -55,9 +55,9 @@ const SyncTab = localize( ( { siteId, translate, syncState, resync, isRequesting
 	const { account_name, store_syncing, product_count, mailchimp_total_products,
 		mailchimp_total_orders, order_count } = syncState;
 	const hasProductInfo = ( undefined !== product_count ) && ( undefined !== mailchimp_total_products );
-	const products = hasProductInfo ? ( product_count + '/' + mailchimp_total_products ) : '';
+	const products = hasProductInfo ? ( mailchimp_total_products + '/' + product_count ) : '';
 	const hasOrdersInfo = ( undefined !== order_count ) && ( undefined !== mailchimp_total_orders );
-	const orders = hasOrdersInfo ? ( order_count + '/' + mailchimp_total_orders ) : '';
+	const orders = hasOrdersInfo ? ( mailchimp_total_orders + '/' + order_count ) : '';
 
 	const synced = () => (
 		<Notice

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -1,6 +1,7 @@
 &.payments__dialog {
+	min-width: 90%;
 	@include breakpoint( ">660px" ) {
-		width: 660px;
+		min-width: 660px;
 	}
 
 	.dialog__content {

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -52,6 +52,7 @@
 		margin: 0;
 		padding: 0;
 		box-shadow: none;
+		padding-right: 24px;
 	}
 }
 
@@ -62,7 +63,6 @@
 	padding-top: 24px;
 
 	@include breakpoint( ">960px" ) {
-		padding-left: 24px;
 		padding-top: 0;
 	}
 }

--- a/client/extensions/woocommerce/app/settings/shipping/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/style.scss
@@ -21,6 +21,7 @@
 		padding: 0;
 		box-shadow: none;
 		flex-shrink: 1;
+		padding-right: 24px;
 	}
 
 	@include breakpoint( '>960px' ) {

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -22,6 +22,11 @@ import Main from 'components/main';
 import SettingsTaxesPlaceholder from './taxes-placeholder';
 import SettingsTaxesTaxJar from './taxes-taxjar';
 import SettingsTaxesWooCommerceServices from './taxes-wcs';
+import {
+	areSetupChoicesLoaded,
+	getCheckedTaxSetup,
+} from 'woocommerce/state/sites/setup-choices/selectors';
+import { setCheckedTaxSetup } from 'woocommerce/state/sites/setup-choices/actions';
 
 class SettingsTaxes extends Component {
 	static propTypes = {
@@ -31,6 +36,9 @@ class SettingsTaxes extends Component {
 		sitePluginsLoaded: PropTypes.bool,
 		siteSlug: PropTypes.string,
 		taxJarPluginActive: PropTypes.bool,
+		setupChoicesLoaded: PropTypes.bool,
+		taxesAreSetUp: PropTypes.bool,
+		setCheckedTaxSetup: PropTypes.func,
 	};
 
 	maybeFetchPlugins = ( props, force = false ) => {
@@ -45,10 +53,28 @@ class SettingsTaxes extends Component {
 
 	componentDidMount = () => {
 		this.maybeFetchPlugins( this.props, true );
+
+		if ( true === this.props.setupChoicesLoaded ) {
+			this.maybeSetCheckedTaxSetup();
+		}
 	};
 
 	componentWillReceiveProps = newProps => {
 		this.maybeFetchPlugins( newProps );
+	};
+
+	componentDidUpdate = prevProps => {
+		if ( true === this.props.setupChoicesLoaded && false === prevProps.setupChoicesLoaded ) {
+			this.maybeSetCheckedTaxSetup();
+		}
+	};
+
+	maybeSetCheckedTaxSetup = () => {
+		const { taxesAreSetUp, site } = this.props;
+		if ( taxesAreSetUp ) {
+			return;
+		}
+		this.props.setCheckedTaxSetup( site.ID, true );
 	};
 
 	render = () => {
@@ -83,6 +109,9 @@ function mapStateToProps( state ) {
 		active: true,
 	} );
 
+	const setupChoicesLoaded = areSetupChoicesLoaded( state, siteId );
+	const taxesAreSetUp = getCheckedTaxSetup( state, siteId );
+
 	return {
 		isRequestingSitePlugins,
 		site,
@@ -90,6 +119,8 @@ function mapStateToProps( state ) {
 		sitePluginsLoaded,
 		siteSlug,
 		taxJarPluginActive,
+		setupChoicesLoaded,
+		taxesAreSetUp,
 	};
 }
 
@@ -97,6 +128,7 @@ function mapDispatchToProps( dispatch ) {
 	return bindActionCreators(
 		{
 			fetchPlugins,
+			setCheckedTaxSetup,
 		},
 		dispatch
 	);

--- a/client/extensions/woocommerce/app/settings/taxes/index.js
+++ b/client/extensions/woocommerce/app/settings/taxes/index.js
@@ -54,7 +54,7 @@ class SettingsTaxes extends Component {
 	componentDidMount = () => {
 		this.maybeFetchPlugins( this.props, true );
 
-		if ( true === this.props.setupChoicesLoaded ) {
+		if ( this.props.setupChoicesLoaded ) {
 			this.maybeSetCheckedTaxSetup();
 		}
 	};
@@ -64,17 +64,17 @@ class SettingsTaxes extends Component {
 	};
 
 	componentDidUpdate = prevProps => {
-		if ( true === this.props.setupChoicesLoaded && false === prevProps.setupChoicesLoaded ) {
+		if ( this.props.setupChoicesLoaded && ! prevProps.setupChoicesLoaded ) {
 			this.maybeSetCheckedTaxSetup();
 		}
 	};
 
 	maybeSetCheckedTaxSetup = () => {
-		const { taxesAreSetUp, site } = this.props;
+		const { taxesAreSetUp, siteId } = this.props;
 		if ( taxesAreSetUp ) {
 			return;
 		}
-		this.props.setCheckedTaxSetup( site.ID, true );
+		this.props.setCheckedTaxSetup( siteId, true );
 	};
 
 	render = () => {

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-options.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-options.js
@@ -16,16 +16,37 @@ import ExtendedHeader from 'woocommerce/components/extended-header';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
 class TaxesOptions extends Component {
 	static propTypes = {
 		onCheckboxChange: PropTypes.func.isRequired,
 		pricesIncludeTaxes: PropTypes.bool,
 		shippingIsTaxable: PropTypes.bool,
+		shipToCountry: PropTypes.shape( {
+			value: PropTypes.string,
+		} ),
 	};
 
 	render = () => {
-		const { onCheckboxChange, pricesIncludeTaxes, shippingIsTaxable, translate } = this.props;
+		const {
+			onCheckboxChange,
+			pricesIncludeTaxes,
+			shippingIsTaxable,
+			shipToCountry,
+			translate,
+		} = this.props;
+
+		let shippingDisabled = false;
+		let shippingDisabledMessage = null;
+		if ( shipToCountry && shipToCountry.value && 'disabled' === shipToCountry.value ) {
+			shippingDisabled = true;
+			shippingDisabledMessage = (
+				<FormSettingExplanation>
+					{ translate( 'Shipping has been disabled for this site.' ) }
+				</FormSettingExplanation>
+			);
+		}
 
 		return (
 			<div className="taxes__taxes-options">
@@ -48,8 +69,10 @@ class TaxesOptions extends Component {
 								checked={ shippingIsTaxable || false }
 								name="shippingIsTaxable"
 								onChange={ onCheckboxChange }
+								disabled={ shippingDisabled }
 							/>
 							<span>{ translate( 'Charge taxes on shipping costs' ) }</span>
+							{ shippingDisabledMessage }
 						</FormLabel>
 					</FormFieldset>
 				</Card>

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-options.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-options.js
@@ -37,16 +37,15 @@ class TaxesOptions extends Component {
 			translate,
 		} = this.props;
 
-		let shippingDisabled = false;
-		let shippingDisabledMessage = null;
-		if ( shipToCountry && shipToCountry.value && 'disabled' === shipToCountry.value ) {
-			shippingDisabled = true;
-			shippingDisabledMessage = (
+		const shippingDisabled =
+			( shipToCountry && shipToCountry.value && 'disabled' === shipToCountry.value ) || false;
+		const shippingDisabledMessage =
+			( shippingDisabled && (
 				<FormSettingExplanation>
 					{ translate( 'Shipping has been disabled for this site.' ) }
 				</FormSettingExplanation>
-			);
-		}
+			) ) ||
+			null;
 
 		return (
 			<div className="taxes__taxes-options">

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-wcs.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-wcs.js
@@ -18,6 +18,7 @@ import ActionHeader from 'woocommerce/components/action-header';
 import {
 	areSettingsGeneralLoaded,
 	areTaxCalculationsEnabled,
+	getShipToCountrySetting,
 } from 'woocommerce/state/sites/settings/general/selectors';
 import {
 	areTaxSettingsLoaded,
@@ -59,6 +60,9 @@ class SettingsTaxesWooCommerceServices extends Component {
 		siteSlug: PropTypes.string.isRequired,
 		siteId: PropTypes.number.isRequired,
 		taxesEnabled: PropTypes.bool,
+		shipToCountry: PropTypes.shape( {
+			value: PropTypes.string,
+		} ),
 	};
 
 	componentDidMount = () => {
@@ -174,6 +178,7 @@ class SettingsTaxesWooCommerceServices extends Component {
 				onCheckboxChange={ this.onCheckboxChange }
 				pricesIncludeTaxes={ this.state.pricesIncludeTaxes }
 				shippingIsTaxable={ this.state.shippingIsTaxable }
+				shipToCountry={ this.props.shipToCountry }
 			/>
 		);
 	};
@@ -207,12 +212,14 @@ class SettingsTaxesWooCommerceServices extends Component {
 function mapStateToProps( state ) {
 	const loaded = areTaxSettingsLoaded( state ) && areSettingsGeneralLoaded( state );
 	const pricesIncludeTaxes = getPricesIncludeTax( state );
+	const shipToCountry = getShipToCountrySetting( state );
 	const shippingIsTaxable = ! getShippingIsTaxFree( state ); // note the inversion
 	const taxesEnabled = areTaxCalculationsEnabled( state );
 
 	return {
 		loaded,
 		pricesIncludeTaxes,
+		shipToCountry,
 		shippingIsTaxable,
 		taxesEnabled,
 	};

--- a/client/extensions/woocommerce/state/sites/settings/general/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/selectors.js
@@ -56,6 +56,19 @@ export function getPaymentCurrencySettings( state, siteId = getSelectedSiteId( s
 	return currency || {};
 }
 
+/**
+ * Gets ship to country setting from API data.
+ *
+ * @param {Object} state Global state tree
+ * @param {Number} siteId wpcom site id. If not provided, the Site ID selected in the UI will be used
+ * @return {Object} Value of the "Shipping location(s)" Setting
+ */
+export function getShipToCountrySetting( state, siteId = getSelectedSiteId( state ) ) {
+	const generalSettings = getRawGeneralSettings( state, siteId );
+	const setting = find( generalSettings, item => item.id === 'woocommerce_ship_to_countries' );
+	return setting || {};
+}
+
 export const getStoreLocation = ( state, siteId = getSelectedSiteId( state ) ) => {
 	const defaultLocation = {
 		street: '',

--- a/client/extensions/woocommerce/state/sites/settings/general/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/settings/general/test/selectors.js
@@ -12,6 +12,7 @@ import {
 	areSettingsGeneralLoaded,
 	areSettingsGeneralLoading,
 	getPaymentCurrencySettings,
+	getShipToCountrySetting,
 } from '../selectors';
 import { LOADING } from 'woocommerce/state/constants';
 
@@ -48,13 +49,22 @@ const currencySetting = {
 	default: 'GBP',
 	value: 'USD',
 };
+
+const shipToCountrySetting = {
+	id: 'woocommerce_ship_to_countries',
+	label: 'Shipping location(s)',
+	type: 'select',
+	default: '',
+	value: 'disabled',
+};
+
 const loadedState = {
 	extensions: {
 		woocommerce: {
 			sites: {
 				123: {
 					settings: {
-						general: [ currencySetting ],
+						general: [ currencySetting, shipToCountrySetting ],
 					},
 				},
 			},
@@ -117,6 +127,16 @@ describe( 'selectors', () => {
 
 		test( 'should get the siteId from the UI tree if not provided.', () => {
 			expect( getPaymentCurrencySettings( loadedStateWithUi ) ).to.eql( currencySetting );
+		} );
+	} );
+
+	describe( 'getShipToCountrySetting', () => {
+		test( 'should get the setting from state.', () => {
+			expect( getShipToCountrySetting( loadedState, 123 ) ).to.eql( shipToCountrySetting );
+		} );
+
+		test( 'should get the siteId from the UI tree if not provided.', () => {
+			expect( getShipToCountrySetting( loadedStateWithUi ) ).to.eql( shipToCountrySetting );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR does some trash pickup around the settings screen. The following issues are addressed:

* Fixes #20304. “Stripe Loading Placeholder got scrunched”
* Fixes #19857. “Charge Taxes on Shipping Costs setting changes might not stick”
* Fixes #16972.  “Tax Settings saved, not checked off setup list”
* Fixes #19549. "MailChimp Synced Orders greater than Total Orders "
* Fixes #21942. "Address loading indicator needs spacing between unit inputs"

To Test:

* Run `npm run test-client client/extensions/woocommerce` and make sure all tests run.
* Go to payment settings for a site that is connected to Stripe using Stripe connect (not API key mode), and open the dialog. Make sure the loading indicator is the same size as the modal when it opens and is not shrunk. Make your screen size smaller (mobile breakpoint) and verify things look OK here too.
* Go to `wp-admin` under general settings and set `Shipping location(s)` to `Disable shipping & shipping calculations`.  Go to your tax settings in Calypso, and verify that the `Charge taxes on shipping costs` input box is disabled and a explanation is shown.
* Go back to `wp-admin` and turn shipping back on. Go to your tax settings and make sure the input is selectable.
* Using the developer console, set your `calypso-preferences`: `finished_initial_setup` to `0`,  `checked_tax_setup` to `0`.
* Go to the tax settings page directly (`http://calypso.localhost:3000/store/settings/taxes/:site`) and make sure that the `WOOCOMMERCE_SETUP_CHOICE_UPDATE_REQUEST` request fires using Redux dev tools. Go to the dashboard view and make sure that the taxes task is checked off. 
* Go back to the tax settings page directly (i.e. hard refresh) and make sure that the `WOOCOMMERCE_SETUP_CHOICE_UPDATE_REQUEST`  action does not fire.
* Reset your `calypso-preferences` flags again, and this time navigate to the tax settings page from another route (i.e. payment settings or dashboard view). Make sure the action fires when `checked_tax_setup` is false, and that it doesn’t fire when true.
* Go to your email settings with a MailChimp connected account, and make sure the product/orders count matches what you see in `wp-admin`.
* Go to shipping and payment settings, and make sure there is spacing between the loading indicator for the address, and the dropdown inputs.