### PR TITLE
Add detection of Gutenberg paragraphs and try to work around

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -25,6 +25,7 @@ import 'tinymce/plugins/textcolor/plugin.js';
 
 // TinyMCE plugins that we've forked or written ourselves
 import wpcomPlugin from './plugins/wpcom/plugin.js';
+
 import wpcomAutoresizePlugin from './plugins/wpcom-autoresize/plugin.js';
 import wpcomHelpPlugin from './plugins/wpcom-help/plugin.js';
 import wpcomCharmapPlugin from './plugins/wpcom-charmap/plugin.js';
@@ -90,7 +91,7 @@ import i18n from './i18n';
 import { isMobile } from 'lib/viewport';
 import config from 'config';
 import { decodeEntities, wpautop, removep } from 'lib/formatting';
-
+import { hasGutenPs } from './plugins/wpcom/wpcom-utils.js';
 /**
  * Internal Variables
  */
@@ -436,7 +437,9 @@ export default class extends React.Component {
 			// TODO: fix code duplication between the wordpress plugin and the React component
 			content = content.replace( /<p>(?:<br ?\/?>|\u00a0|\uFEFF| )*<\/p>/g, '<p>&nbsp;</p>' );
 
-			content = removep( content );
+			if ( ! hasGutenPs( content ) ) {
+				content = removep( content );
+			}
 		}
 
 		return content;
@@ -461,7 +464,10 @@ export default class extends React.Component {
 	setEditorContent = ( content, args = {} ) => {
 		if ( this._editor ) {
 			const { mode } = this.props;
-			this._editor.setContent( wpautop( content ), { ...args, mode } );
+			if ( ! hasGutenPs( content ) ) {
+				content = wpautop( content );
+			}
+			this._editor.setContent( content, { ...args, mode } );
 			if ( args.initial ) {
 				// Clear the undo stack when initially setting content
 				this._editor.undoManager.clear();

--- a/client/components/tinymce/plugins/wpcom/plugin.js
+++ b/client/components/tinymce/plugins/wpcom/plugin.js
@@ -15,7 +15,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { removep, wpautop } from 'lib/formatting';
-import { removeEmptySpacesInParagraphs } from './wpcom-utils';
+import { removeEmptySpacesInParagraphs, hasGutenPs } from './wpcom-utils';
 
 /* eslint-disable */
 function wpcomPlugin( editor ) {
@@ -63,7 +63,7 @@ function wpcomPlugin( editor ) {
 				);
 			}
 
-			if ( event.load && event.format !== 'raw' ) {
+			if ( event.load && event.format !== 'raw' && ! hasGutenPs( event.content ) ) {
 				event.content = wpautop( event.content );
 			}
 		}
@@ -337,7 +337,10 @@ function wpcomPlugin( editor ) {
 		// Keep empty paragraphs :(
 		e.content = e.content.replace( /<p>(?:<br ?\/?>|\u00a0|\uFEFF| )*<\/p>/g, '<p>&nbsp;</p>' );
 
-		e.content = removep( e.content );
+		// Leave p if in Gutenberg
+		if ( ! hasGutenPs( e.content ) ) {
+			e.content = removep( e.content );
+		}
 	} );
 
 	// Remove spaces from empty paragraphs.

--- a/client/components/tinymce/plugins/wpcom/wpcom-utils.js
+++ b/client/components/tinymce/plugins/wpcom/wpcom-utils.js
@@ -19,3 +19,14 @@ export function removeEmptySpacesInParagraphs( content ) {
 		return tag;
 	} );
 }
+
+/**
+ * Checks content to see if it contains Gutenberg paragraphs.
+ *
+ * @format
+ * @param {String}   content Editor content
+ * @return {Boolean}         True if contains Gutenberg paragraph
+ */
+export function hasGutenPs( content ) {
+	return content.includes( '<!-- wp:paragraph -->' );
+}


### PR DESCRIPTION
Adds a new utility function, hasGutenPs which detects if the content
contains Gutenberg Paragraph block. This function is then used to no run
the wpautop and removep functions that modify the content in away that
breaks Gutenberg blocks.