### PR TITLE
Editor: Improve Post normalization & "dirty" alerting

### DIFF
--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -409,15 +409,7 @@ export const isEditedPostDirty = createSelector(
 			}
 
 			if ( post ) {
-				switch ( key ) {
-					case 'date': {
-						return ! moment( value ).isSame( post.date );
-					}
-					case 'parent': {
-						return get( post, 'parent.ID', 0 ) !== value;
-					}
-				}
-				return post[ key ] !== value;
+				return ! isEqual( post[ key ], value );
 			}
 
 			return (

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -1844,7 +1844,9 @@ describe( 'selectors', () => {
 						edits: {
 							2916284: {
 								841: {
-									parent: 10,
+									parent: {
+										ID: 66,
+									},
 								},
 							},
 						},
@@ -1878,7 +1880,9 @@ describe( 'selectors', () => {
 						edits: {
 							2916284: {
 								841: {
-									parent: 10,
+									parent: {
+										ID: 10,
+									},
 								},
 							},
 						},
@@ -1902,7 +1906,7 @@ describe( 'selectors', () => {
 										ID: 841,
 										site_ID: 2916284,
 										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
-										date: moment( '2016-09-14T15:47:33-04:00' ),
+										date: '2016-09-14T15:47:33Z',
 									},
 								},
 							} ),
@@ -1910,7 +1914,7 @@ describe( 'selectors', () => {
 						edits: {
 							2916284: {
 								841: {
-									date: moment( '2017-09-14T15:47:33-04:00' ),
+									date: '2018-01-31T00:00:00Z',
 								},
 							},
 						},
@@ -1934,7 +1938,7 @@ describe( 'selectors', () => {
 										ID: 841,
 										site_ID: 2916284,
 										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
-										date: moment( '2016-09-14T15:47:33-04:00' ),
+										date: '2016-09-14T15:47:33Z',
 									},
 								},
 							} ),
@@ -1942,7 +1946,7 @@ describe( 'selectors', () => {
 						edits: {
 							2916284: {
 								841: {
-									date: moment( '2016-09-14T15:47:33-04:00' ),
+									date: '2016-09-14T15:47:33Z',
 								},
 							},
 						},
@@ -2259,7 +2263,9 @@ describe( 'selectors', () => {
 
 		test( 'should return false if the post status is future and date is in future', () => {
 			const tenMinutes = 1000 * 60;
-			const postDate = Date.now() + tenMinutes;
+			const postDate = moment( Date.now() + tenMinutes )
+				.utc()
+				.format();
 			const isPublished = isPostPublished(
 				{
 					posts: {
@@ -2287,7 +2293,9 @@ describe( 'selectors', () => {
 
 		test( 'should return true if the post status is future and date is in past', () => {
 			const tenMinutes = 1000 * 60;
-			const postDate = Date.now() - tenMinutes;
+			const postDate = moment( Date.now() - tenMinutes )
+				.utc()
+				.format();
 			const isPublished = isPostPublished(
 				{
 					posts: {

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -6,6 +6,7 @@
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import { values } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -1813,6 +1814,69 @@ describe( 'selectors', () => {
 							2916284: {
 								841: {
 									title: 'Hello World!',
+								},
+							},
+						},
+					},
+				},
+				2916284,
+				841
+			);
+
+			expect( isDirty ).to.be.true;
+		} );
+
+		test( 'should return true if saved post parent attr changes', () => {
+			const isDirty = isEditedPostDirty(
+				{
+					posts: {
+						queries: {
+							2916284: new PostQueryManager( {
+								items: {
+									841: {
+										ID: 841,
+										site_ID: 2916284,
+										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+									},
+								},
+							} ),
+						},
+						edits: {
+							2916284: {
+								841: {
+									parent: 10,
+								},
+							},
+						},
+					},
+				},
+				2916284,
+				841
+			);
+
+			expect( isDirty ).to.be.true;
+		} );
+
+		test( 'should return true if saved post date changes', () => {
+			const isDirty = isEditedPostDirty(
+				{
+					posts: {
+						queries: {
+							2916284: new PostQueryManager( {
+								items: {
+									841: {
+										ID: 841,
+										site_ID: 2916284,
+										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+										date: moment( '2016-09-14T15:47:33-04:00' ),
+									},
+								},
+							} ),
+						},
+						edits: {
+							2916284: {
+								841: {
+									date: moment( '2017-09-14T15:47:33-04:00' ),
 								},
 							},
 						},

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -1857,6 +1857,40 @@ describe( 'selectors', () => {
 			expect( isDirty ).to.be.true;
 		} );
 
+		test( "should return false if saved post parent attr doesn't change", () => {
+			const isDirty = isEditedPostDirty(
+				{
+					posts: {
+						queries: {
+							2916284: new PostQueryManager( {
+								items: {
+									841: {
+										ID: 841,
+										site_ID: 2916284,
+										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+										parent: {
+											ID: 10,
+										},
+									},
+								},
+							} ),
+						},
+						edits: {
+							2916284: {
+								841: {
+									parent: 10,
+								},
+							},
+						},
+					},
+				},
+				2916284,
+				841
+			);
+
+			expect( isDirty ).to.be.false;
+		} );
+
 		test( 'should return true if saved post date changes', () => {
 			const isDirty = isEditedPostDirty(
 				{
@@ -1887,6 +1921,38 @@ describe( 'selectors', () => {
 			);
 
 			expect( isDirty ).to.be.true;
+		} );
+
+		test( "should return false if saved post date doesn't change", () => {
+			const isDirty = isEditedPostDirty(
+				{
+					posts: {
+						queries: {
+							2916284: new PostQueryManager( {
+								items: {
+									841: {
+										ID: 841,
+										site_ID: 2916284,
+										global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+										date: moment( '2016-09-14T15:47:33-04:00' ),
+									},
+								},
+							} ),
+						},
+						edits: {
+							2916284: {
+								841: {
+									date: moment( '2016-09-14T15:47:33-04:00' ),
+								},
+							},
+						},
+					},
+				},
+				2916284,
+				841
+			);
+
+			expect( isDirty ).to.be.false;
 		} );
 	} );
 

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -250,6 +250,30 @@ describe( 'utils', () => {
 				},
 			} );
 		} );
+
+		test( 'should store post date as UTC', () => {
+			const original = deepFreeze( {
+				date: '2018-01-01T00:00:00-04:00',
+			} );
+			const revised = normalizePostForState( original );
+
+			expect( revised ).to.not.equal( original );
+			expect( revised ).to.eql( {
+				date: '2018-01-01T04:00:00Z',
+			} );
+		} );
+
+		test( 'should store post parent as object', () => {
+			const original = deepFreeze( {
+				parent: 1492,
+			} );
+			const revised = normalizePostForState( original );
+
+			expect( revised ).to.not.equal( original );
+			expect( revised ).to.eql( {
+				parent: { ID: 1492 },
+			} );
+		} );
 	} );
 
 	describe( '#getNormalizedPostsQuery()', () => {

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -3,9 +3,10 @@
 /**
  * External dependencies
  */
-
+import moment from 'moment-timezone';
 import {
 	isEmpty,
+	isInteger,
 	isPlainObject,
 	flow,
 	map,
@@ -182,6 +183,19 @@ export function normalizePostForEditing( post ) {
  */
 export function normalizePostForState( post ) {
 	const normalizedPost = cloneDeep( post );
+
+	if ( ! isEmpty( normalizedPost.date ) ) {
+		normalizedPost.date = moment( post.date )
+			.utc()
+			.format();
+	}
+
+	if ( isInteger( normalizedPost.parent ) ) {
+		normalizedPost.parent = {
+			ID: normalizedPost.parent,
+		};
+	}
+
 	return reduce(
 		[
 			[],


### PR DESCRIPTION
~~**NOTE:** This is targeting the branch in #21995.~~

Use `lodash#isEqual` to establish if post values need saving or not vs. a strict equality check so objects and arrays can be property compared.

### Changes to post state normalization

* post `date`s are converted to UTC
* post `parent`s are converted to an object with an ID property (when the action sends an integer for the parent)

### Changes to Tests

* Adapt tests to use normalized date & parent formats
* Test against date strings instead of comparing `moment` objects.
* Add assertions:
  * Other date formats get converted to UTC
  * Integers get promoted to objects w/ appropriate ID
