### PR TITLE
Ensure server url is able to override client url for checklist tasks.

### DIFF
--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -127,24 +127,10 @@ const sequence = [
 	'post_published',
 ];
 
-export const urlForTask = ( id, siteSlug ) => {
-	const task = tasks[ id ];
-	if ( task && task.url ) {
-		return task.url.replace( '$siteSlug', siteSlug );
-	}
-};
-
-export const tourForTask = id => {
-	const task = tasks[ id ];
-	if ( task ) {
-		return task.tour;
-	}
-};
-
 export function launchTask( { task, location, requestTour, siteSlug, track } ) {
 	const checklist_name = 'new_blog';
-	const url = urlForTask( task.id, siteSlug );
-	const tour = tourForTask( task.id );
+	const url = task.url && task.url.replace( '$siteSlug', siteSlug );
+	const tour = task.tour;
 
 	if ( task.completed ) {
 		if ( url ) {

--- a/client/my-sites/checklist/onboardingChecklist.js
+++ b/client/my-sites/checklist/onboardingChecklist.js
@@ -85,7 +85,7 @@ const tasks = {
 		duration: '10 mins',
 		completedTitle: 'You published your first blog post',
 		completedButtonText: 'Edit',
-		url: '/post/$siteSlug/3',
+		url: '/post/$siteSlug',
 		image: '/calypso/images/stats/tasks/first-post.svg',
 		tour: 'checklistPublishPost',
 	},


### PR DESCRIPTION
This solves a bug with the checklist where the url for a task sent by the server was always being ignored.

This only relates to the first post task where the server attempts to determine the correct url for the task which requires the id of the post for the site (which will vary according to the order of page/post creation by headstart).

# Testing

for any site with a post that does not have an id of 3 (a site created prior to recent headstart changes):
- view the checklist
- trigger the first post task
- ensure you are not taken to `/post/$site/3`
