### PR TITLE
WordAds: Update number format on Ads Served metric

### DIFF
--- a/client/my-sites/ads/form-earnings.jsx
+++ b/client/my-sites/ads/form-earnings.jsx
@@ -316,7 +316,9 @@ class AdsFormEarnings extends Component {
 						<td className="ads__earnings-history-value">
 							${ numberFormat( earnings[ period ].amount, 2 ) }
 						</td>
-						<td className="ads__earnings-history-value">{ earnings[ period ].pageviews }</td>
+						<td className="ads__earnings-history-value">
+							{ numberFormat( earnings[ period ].pageviews ) }
+						</td>
 						<td className="ads__earnings-history-value">
 							{ this.getStatus( earnings[ period ].status ) }
 						</td>


### PR DESCRIPTION
This PR ads number formatting (comma separators) to the values in the "Ads Served" column on the WordAds earnings report.

There was previously no number formatting.

To Test: select a site with WordAds earnings and visit the earnings report. Check the Ads served column and make sure that any values over 999 contain a thousands-separator.