### PR TITLE
Activity Log: display month navigation regardless of the state of Rewind

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -516,7 +516,7 @@ class ActivityLog extends Component {
 					/>
 				) }
 				{ this.renderErrorMessage() }
-				{ 'active' === rewindState.state && this.renderMonthNavigation() }
+				{ this.renderMonthNavigation() }
 				{ this.renderActionProgress() }
 				{ isEmpty( logs ) ? (
 					noLogsContent
@@ -578,7 +578,7 @@ class ActivityLog extends Component {
 						) }
 					</section>
 				) }
-				{ 'active' === rewindState.state && this.renderMonthNavigation( 'bottom' ) }
+				{ this.renderMonthNavigation( 'bottom' ) }
 				<JetpackColophon />
 			</Main>
 		);


### PR DESCRIPTION
This PR makes the month navigation always available, regardless of Rewind state, since the month navigation is something inherent to Activity Log.

### Testing

Test this in a site with at least two months of activities and without Rewind active.