### PR TITLE
Notifications: Add EDIT_COMMENT event tracking

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -213,6 +213,17 @@ export class Notifications extends Component {
 					page( '/me/notifications' );
 				},
 			],
+			EDIT_COMMENT: [
+				( store, { siteId, postId, commentId } ) => {
+					this.props.checkToggle();
+					this.props.recordTracksEvent( 'calypso_notifications_edit_comment', {
+						site_id: siteId,
+						post_id: postId,
+						comment_id: commentId,
+					} );
+					page( `/comments/${ siteId }/${ commentId }?action=edit` );
+				},
+			],
 		};
 
 		return (


### PR DESCRIPTION
Contribute to https://github.com/Automattic/notifications-panel/pull/222
See also D9749-code

Add `EDIT_COMMENT` to the notifications panel events tracked by Calypso.