### PR TITLE
Inline Help: add TrainTracks render and interact events

### DIFF
--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -59,7 +59,7 @@ class InlineHelpSearchCard extends Component {
 
 	onSearch = searchQuery => {
 		debug( 'search query received: ', searchQuery );
-		this.props.recordTracksEvent( 'calypso_inlinehelp_search', { searchQuery } );
+		this.props.recordTracksEvent( 'calypso_inlinehelp_search', { search_query: searchQuery } );
 		this.props.requestInlineHelpSearchResults( searchQuery );
 	};
 

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
  * Internal Dependencies
  */
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getNewRailcarSeed } from 'state/analytics/utils';
 import QueryInlineHelpSearch from 'components/data/query-inline-help-search';
 import PlaceholderLines from './placeholder-lines';
 import TrackComponentView from 'lib/analytics/track-component-view';
@@ -37,13 +38,13 @@ class InlineHelpSearchResults extends Component {
 	};
 
 	state = {
-		railcarSeed: this.getNewRailcarSeed(),
+		railcarSeed: getNewRailcarSeed(),
 	};
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.searchQuery !== nextProps.searchQuery ) {
 			this.setState( {
-				railcarSeed: this.getNewRailcarSeed(),
+				railcarSeed: getNewRailcarSeed(),
 			} );
 		}
 	}
@@ -198,13 +199,6 @@ class InlineHelpSearchResults extends Component {
 				</a>
 			</li>
 		);
-	}
-
-	getNewRailcarSeed() {
-		// Generate a 7 character random hash on base16. E.g. ac618a3
-		return Math.floor( ( 1 + Math.random() ) * 0x10000000 )
-			.toString( 16 )
-			.substring( 1 );
 	}
 
 	getRailcarForIndex( index ) {

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -136,13 +136,12 @@ class InlineHelpSearchResults extends Component {
 	}
 
 	followHelpLink = ( url ) => {
-		const payload = {
-			searchQuery: this.props.searchQuery,
-			currentUrl: window.location.href,
-			resultUrl: url,
-		};
 		return () => {
-			this.props.recordTracksEvent( 'calypso_inlinehelp_link_open', payload );
+			this.props.recordTracksEvent( 'calypso_inlinehelp_link_open', {
+				search_query: this.props.searchQuery,
+				current_url: window.location.href,
+				result_url: url,
+			} );
 		};
 	}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -48,6 +48,7 @@ import {
 	getDomainsSuggestionsError,
 } from 'state/domains/suggestions/selectors';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import { getNewRailcarSeed } from 'state/analytics/utils';
 import { TRANSFER_IN_NUX } from 'state/current-user/constants';
 
 const domains = wpcom.domains();
@@ -173,13 +174,6 @@ class RegisterDomainStep extends React.Component {
 		};
 	}
 
-	getNewRailcarSeed() {
-		// Generate a 7 character random hash on base16. E.g. ac618a3
-		return Math.floor( ( 1 + Math.random() ) * 0x10000000 )
-			.toString( 16 )
-			.substring( 1 );
-	}
-
 	componentWillReceiveProps( nextProps ) {
 		// Reset state on site change
 		if (
@@ -218,7 +212,7 @@ class RegisterDomainStep extends React.Component {
 		searchCount = 0; // reset the counter
 
 		if ( this.props.initialState ) {
-			const state = { ...this.props.initialState, railcarSeed: this.getNewRailcarSeed() };
+			const state = { ...this.props.initialState, railcarSeed: getNewRailcarSeed() };
 
 			if ( state.lastSurveyVertical && state.lastSurveyVertical !== this.props.surveyVertical ) {
 				state.loadingResults = true;
@@ -371,7 +365,7 @@ class RegisterDomainStep extends React.Component {
 			lastDomainSearched: domain,
 			searchResults: [],
 			subdomainSearchResults: [],
-			railcarSeed: this.getNewRailcarSeed(),
+			railcarSeed: getNewRailcarSeed(),
 		} );
 
 		const timestamp = Date.now();

--- a/client/state/analytics/utils.js
+++ b/client/state/analytics/utils.js
@@ -1,0 +1,9 @@
+/**
+ * Generate a 7-character random hash on base16 for use with TrainTracks as part
+ * of the Railcar ID. E.g. ac618a3.
+ *
+ * @returns {String}  A 7-character random hash.
+ */
+export function getNewRailcarSeed() {
+	return Math.floor( ( 1 + Math.random() ) * 0x10000000 ).toString( 16 ).substring( 1 );
+}


### PR DESCRIPTION
This PR adds TrainTracks events to Inline Help (when rendering and clicking results) so we can improve our search suggestions in the future. 

![traintracks](https://user-images.githubusercontent.com/23619/35734512-bcb02a5a-0821-11e8-8977-8f1eebd64e8f.gif)

To test:
- make sure the TrainTracks events get sent (with the payloads given in the code) when a) search results get rendered and b) a search result is followed. 
- make sure the `railcar` makes sense — it should be the same "base string" (everything except the index at the end) for all render events of a single search and the interact events of those results. A new search should have a different `railcar` base string. The appended `index` should be the same for a render event and its associated interact event. 

To show Tracks events in the console, use the following: 

`localStorage.debug = 'calypso:analytics:tracks';`
