### PR TITLE
Rewind: Link to the credentials collection flow

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -539,8 +539,7 @@ class JetpackThankYouCard extends Component {
 	}
 
 	renderAction( progress = 0 ) {
-		const { jetpackAdminPageUrl, selectedSite: site, translate } = this.props;
-		const buttonUrl = site && jetpackAdminPageUrl;
+		const { siteId, translate } = this.props;
 		// We return instructions for setting up manually
 		// when we finish if something errored
 		if ( this.isErrored() && ! this.props.isInstalling ) {
@@ -562,12 +561,10 @@ class JetpackThankYouCard extends Component {
 			return (
 				<div className="checkout-thank-you__jetpack-action-buttons">
 					<a
-						className={ classNames( 'button', 'thank-you-card__button', {
-							'is-placeholder': ! buttonUrl,
-						} ) }
-						href={ buttonUrl }
+						className={ classNames( 'button', 'thank-you-card__button' ) }
+						href={ `/start/rewind-credentials?blogid=${ siteId }` }
 					>
-						{ translate( 'Explore your plan' ) }
+						{ translate( 'Set up backups' ) }
 					</a>
 					{ this.renderLiveChatButton() }
 				</div>
@@ -584,7 +581,7 @@ class JetpackThankYouCard extends Component {
 		);
 		if ( 100 === progress ) {
 			this.trackConfigFinished( 'calypso_plans_autoconfig_success' );
-			return translate( "You are powered up, it's time to see your site." );
+			return translate( "You are powered up. Now it's time to configure your backups settings." );
 		}
 
 		if ( this.isErrored() ) {


### PR DESCRIPTION
For use in conjunction with https://github.com/Automattic/wp-calypso/pull/21767.

This changes the signup complete screen for Jetpack plans to enable linking to the backup credentials collection flow.

**Testing instructions**
I will provide instructions on how to test this after #21767 is merged.