### PR TITLE
Site Settings: Jetpack: Add lazy images setting for Jetpack sites

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -78,6 +78,7 @@ class SiteSettingsFormWriting extends Component {
 			siteIsJetpack,
 			translate,
 			updateFields,
+			jetpackVersionSupportsLazyImages,
 		} = this.props;
 
 		const jetpackSettingsUI = siteIsJetpack && jetpackSettingsUISupported;
@@ -130,23 +131,26 @@ class SiteSettingsFormWriting extends Component {
 							isSavingSettings={ isSavingSettings }
 							isRequestingSettings={ isRequestingSettings }
 							fields={ fields }
+							jetpackVersionSupportsLazyImages={ jetpackVersionSupportsLazyImages }
 						/>
 					</div>
 				) }
 
-				{ jetpackSettingsUI && (
-					<div>
-						{ this.renderSectionHeader( translate( 'Speed up your site' ), false ) }
-						<SpeedUpYourSite
-							siteId={ siteId }
-							handleAutosavingToggle={ handleAutosavingToggle }
-							onChangeField={ onChangeField }
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-							fields={ fields }
-						/>
-					</div>
-				) }
+				{ jetpackSettingsUI &&
+					jetpackVersionSupportsLazyImages && (
+						<div>
+							{ this.renderSectionHeader( translate( 'Speed up your site' ), false ) }
+							<SpeedUpYourSite
+								siteId={ siteId }
+								handleAutosavingToggle={ handleAutosavingToggle }
+								onChangeField={ onChangeField }
+								isSavingSettings={ isSavingSettings }
+								isRequestingSettings={ isRequestingSettings }
+								fields={ fields }
+								jetpackVersionSupportsLazyImages={ jetpackVersionSupportsLazyImages }
+							/>
+						</div>
+					) }
 
 				{ this.renderSectionHeader( translate( 'Content types' ) ) }
 
@@ -217,6 +221,7 @@ const connectComponent = connect(
 			jetpackMasterbarSupported: isJetpackMinimumVersion( state, siteId, '4.8' ),
 			siteIsJetpack: isJetpackSite( state, siteId ),
 			siteId,
+			jetpackVersionSupportsLazyImages: isJetpackMinimumVersion( state, siteId, '5.8-alpha' ),
 		};
 	},
 	{ requestPostTypes },

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -33,6 +33,7 @@ import MediaSettings from './media-settings';
 import ThemeEnhancements from './theme-enhancements';
 import PublishingTools from './publishing-tools';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
+import SpeedUpYourSite from './speed-up-site-settings';
 
 class SiteSettingsFormWriting extends Component {
 	renderSectionHeader( title, showButton = true ) {
@@ -123,6 +124,20 @@ class SiteSettingsFormWriting extends Component {
 					<div>
 						{ this.renderSectionHeader( translate( 'Media' ) ) }
 						<MediaSettings
+							siteId={ siteId }
+							handleAutosavingToggle={ handleAutosavingToggle }
+							onChangeField={ onChangeField }
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+							fields={ fields }
+						/>
+					</div>
+				) }
+
+				{ jetpackSettingsUI && (
+					<div>
+						{ this.renderSectionHeader( translate( 'Speed up your site' ), false ) }
+						<SpeedUpYourSite
 							siteId={ siteId }
 							handleAutosavingToggle={ handleAutosavingToggle }
 							onChangeField={ onChangeField }
@@ -251,6 +266,7 @@ const getFormSettings = settings => {
 		'start_of_week',
 		'time_format',
 		'timezone_string',
+		'lazy-images',
 	] );
 
 	// handling `gmt_offset` and `timezone_string` values

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -30,14 +30,21 @@ import {
 	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 } from 'lib/plans/constants';
 import { hasFeature } from 'state/sites/plans/selectors';
+import {
+	isJetpackModuleActive,
+	isJetpackModuleUnavailableInDevelopmentMode,
+	isJetpackSiteInDevelopmentMode,
+	getMediaStorageLimit,
+	getMediaStorageUsed,
+} from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getMediaStorageLimit, getMediaStorageUsed, isJetpackModuleActive } from 'state/selectors';
 import { getSitePlanSlug, getSiteSlug } from 'state/sites/selectors';
 import { updateSettings } from 'state/jetpack/settings/actions';
 import QueryMediaStorage from 'components/data/query-media-storage';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import PlanStorageBar from 'blocks/plan-storage/bar';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import classNames from 'classnames';
 
 class MediaSettings extends Component {
 	static propTypes = {
@@ -47,6 +54,7 @@ class MediaSettings extends Component {
 		isSavingSettings: PropTypes.bool,
 		onChangeField: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
+		jetpackVersionSupportsLazyImages: PropTypes.bool,
 
 		// Connected props
 		carouselActive: PropTypes.bool.isRequired,
@@ -54,6 +62,7 @@ class MediaSettings extends Component {
 		isVideoPressAvailable: PropTypes.bool,
 		mediaStorageLimit: PropTypes.number,
 		mediaStorageUsed: PropTypes.number,
+		photonModuleUnavailable: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
 		sitePlanSlug: PropTypes.string,
 		siteSlug: PropTypes.string,
@@ -163,18 +172,47 @@ class MediaSettings extends Component {
 			isRequestingSettings,
 			isSavingSettings,
 			onChangeField,
+			photonModuleUnavailable,
 			selectedSiteId,
 			siteId,
 			translate,
+			jetpackVersionSupportsLazyImages,
 		} = this.props;
 		const labelClassName = isSavingSettings || ! carouselActive ? 'is-disabled' : null;
 		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
+		const carouselFieldsetClasses = classNames( 'site-settings__formfieldset', {
+			'has-divider': ! jetpackVersionSupportsLazyImages,
+			'is-top-only': ! jetpackVersionSupportsLazyImages,
+		} );
 
 		return (
 			<div className="site-settings__module-settings site-settings__media-settings">
 				<Card>
 					<QueryJetpackConnection siteId={ selectedSiteId } />
-					<FormFieldset className="site-settings__formfieldset">
+					{ /**
+					 * In Jetpack 5.8-alpha, we introduced Lazy Images, created a new "Speed up your site" section,
+					 * and moved the photon setting there. To minimize confusion, if this Jetpack site doesn't have 5.8-alpha,
+					 * let's show the Photon setting here instead of in the "Speed up your site" section.
+					 */ }
+					{ ! jetpackVersionSupportsLazyImages && (
+						<FormFieldset>
+							<div className="site-settings__info-link-container">
+								<InfoPopover position="left">
+									<ExternalLink target="_blank" icon href="https://jetpack.com/support/photon">
+										{ translate( 'Learn more' ) }
+									</ExternalLink>
+								</InfoPopover>
+							</div>
+							<JetpackModuleToggle
+								siteId={ siteId }
+								moduleSlug="photon"
+								label={ translate( 'Speed up images and photos' ) }
+								description={ translate( 'Must be enabled to use tiled galleries.' ) }
+								disabled={ isRequestingOrSaving || photonModuleUnavailable }
+							/>
+						</FormFieldset>
+					) }
+					<FormFieldset className={ carouselFieldsetClasses }>
 						<div className="site-settings__info-link-container">
 							<InfoPopover position="left">
 								<ExternalLink target="_blank" icon href="https://jetpack.com/support/carousel">
@@ -228,7 +266,13 @@ class MediaSettings extends Component {
 export default connect(
 	state => {
 		const selectedSiteId = getSelectedSiteId( state );
+		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
 		const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
+		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
+			state,
+			selectedSiteId,
+			'photon'
+		);
 		const isVideoPressAvailable =
 			hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS ) ||
 			hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM ) ||
@@ -240,6 +284,7 @@ export default connect(
 			isVideoPressAvailable,
 			mediaStorageLimit: getMediaStorageLimit( state, selectedSiteId ),
 			mediaStorageUsed: getMediaStorageUsed( state, selectedSiteId ),
+			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 			selectedSiteId,
 			sitePlanSlug,
 			siteSlug: getSiteSlug( state, selectedSiteId ),

--- a/client/my-sites/site-settings/media-settings.jsx
+++ b/client/my-sites/site-settings/media-settings.jsx
@@ -30,13 +30,8 @@ import {
 	FEATURE_VIDEO_UPLOADS_JETPACK_PRO,
 } from 'lib/plans/constants';
 import { hasFeature } from 'state/sites/plans/selectors';
-import {
-	isJetpackModuleActive,
-	isJetpackModuleUnavailableInDevelopmentMode,
-	isJetpackSiteInDevelopmentMode,
-} from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getMediaStorageLimit, getMediaStorageUsed } from 'state/selectors';
+import { getMediaStorageLimit, getMediaStorageUsed, isJetpackModuleActive } from 'state/selectors';
 import { getSitePlanSlug, getSiteSlug } from 'state/sites/selectors';
 import { updateSettings } from 'state/jetpack/settings/actions';
 import QueryMediaStorage from 'components/data/query-media-storage';
@@ -59,7 +54,6 @@ class MediaSettings extends Component {
 		isVideoPressAvailable: PropTypes.bool,
 		mediaStorageLimit: PropTypes.number,
 		mediaStorageUsed: PropTypes.number,
-		photonModuleUnavailable: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
 		sitePlanSlug: PropTypes.string,
 		siteSlug: PropTypes.string,
@@ -169,7 +163,6 @@ class MediaSettings extends Component {
 			isRequestingSettings,
 			isSavingSettings,
 			onChangeField,
-			photonModuleUnavailable,
 			selectedSiteId,
 			siteId,
 			translate,
@@ -181,23 +174,7 @@ class MediaSettings extends Component {
 			<div className="site-settings__module-settings site-settings__media-settings">
 				<Card>
 					<QueryJetpackConnection siteId={ selectedSiteId } />
-					<FormFieldset>
-						<div className="site-settings__info-link-container">
-							<InfoPopover position="left">
-								<ExternalLink target="_blank" icon href="https://jetpack.com/support/photon">
-									{ translate( 'Learn more' ) }
-								</ExternalLink>
-							</InfoPopover>
-						</div>
-						<JetpackModuleToggle
-							siteId={ siteId }
-							moduleSlug="photon"
-							label={ translate( 'Speed up images and photos' ) }
-							description={ translate( 'Must be enabled to use tiled galleries.' ) }
-							disabled={ isRequestingOrSaving || photonModuleUnavailable }
-						/>
-					</FormFieldset>
-					<FormFieldset className="site-settings__formfieldset has-divider is-top-only">
+					<FormFieldset className="site-settings__formfieldset">
 						<div className="site-settings__info-link-container">
 							<InfoPopover position="left">
 								<ExternalLink target="_blank" icon href="https://jetpack.com/support/carousel">
@@ -251,13 +228,7 @@ class MediaSettings extends Component {
 export default connect(
 	state => {
 		const selectedSiteId = getSelectedSiteId( state );
-		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
 		const sitePlanSlug = getSitePlanSlug( state, selectedSiteId );
-		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
-			state,
-			selectedSiteId,
-			'photon'
-		);
 		const isVideoPressAvailable =
 			hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS ) ||
 			hasFeature( state, selectedSiteId, FEATURE_VIDEO_UPLOADS_JETPACK_PREMIUM ) ||
@@ -269,7 +240,6 @@ export default connect(
 			isVideoPressAvailable,
 			mediaStorageLimit: getMediaStorageLimit( state, selectedSiteId ),
 			mediaStorageUsed: getMediaStorageUsed( state, selectedSiteId ),
-			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 			selectedSiteId,
 			sitePlanSlug,
 			siteSlug: getSiteSlug( state, selectedSiteId ),

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -1,0 +1,130 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
+import FormFieldset from 'components/forms/form-fieldset';
+import ExternalLink from 'components/external-link';
+import {
+	isJetpackModuleUnavailableInDevelopmentMode,
+	isJetpackSiteInDevelopmentMode,
+} from 'state/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { updateSettings } from 'state/jetpack/settings/actions';
+import { getSiteSlug, isJetpackMinimumVersion } from 'state/sites/selectors';
+import InfoPopover from 'components/info-popover';
+
+class SpeedUpSiteSettings extends Component {
+	static propTypes = {
+		fields: PropTypes.object,
+		handleAutosavingToggle: PropTypes.func.isRequired,
+		isRequestingSettings: PropTypes.bool,
+		isSavingSettings: PropTypes.bool,
+		onChangeField: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
+
+		// Connected props
+		photonModuleUnavailable: PropTypes.bool,
+		selectedSiteId: PropTypes.number,
+		siteSlug: PropTypes.string,
+		jetpackVersionSupportsLazyImages: PropTypes.bool,
+	};
+
+	render() {
+		const {
+			siteId,
+			photonModuleUnavailable,
+			isRequestingSettings,
+			isSavingSettings,
+			translate,
+			jetpackVersionSupportsLazyImages,
+		} = this.props;
+		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
+
+		return (
+			<div className="site-settings__module-settings site-settings__speed-up-site-settings">
+				<Card>
+					<FormFieldset className="site-settings__formfieldset">
+						<div className="site-settings__info-link-container">
+							<InfoPopover position="left">
+								<ExternalLink target="_blank" icon href="https://jetpack.com/support/photon">
+									{ translate( 'Learn more' ) }
+								</ExternalLink>
+							</InfoPopover>
+						</div>
+						<JetpackModuleToggle
+							siteId={ siteId }
+							moduleSlug="photon"
+							label={ translate( 'Serve images from our servers' ) }
+							description={ translate(
+								'Jetpack will optimize your images and server them from the server ' +
+									'location nearest to your visitors. Using our global content delivery ' +
+									'network will boost the loading speed of your site.'
+							) }
+							disabled={ isRequestingOrSaving || photonModuleUnavailable }
+						/>
+					</FormFieldset>
+
+					{ jetpackVersionSupportsLazyImages && (
+						<FormFieldset className="site-settings__formfieldset has-divider is-top-only">
+							<div className="site-settings__info-link-container">
+								<InfoPopover position="left">
+									<ExternalLink target="_blank" icon href="https://jetpack.com/support/lazy-images">
+										{ translate( 'Learn more' ) }
+									</ExternalLink>
+								</InfoPopover>
+							</div>
+							<JetpackModuleToggle
+								siteId={ siteId }
+								moduleSlug="lazy-images"
+								label={ translate( '"Lazy-load" images' ) }
+								description={ translate(
+									"Improve your site's speed by only loading images visible on the screen. New images will " +
+										'load just before they scroll into view. This prevents viewers from having to download ' +
+										"all the images on a page all at once, even ones they can't see."
+								) }
+								disabled={ isRequestingOrSaving }
+							/>
+						</FormFieldset>
+					) }
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	state => {
+		const selectedSiteId = getSelectedSiteId( state );
+		const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+		const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
+			state,
+			selectedSiteId,
+			'photon'
+		);
+
+		return {
+			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+			selectedSiteId,
+			siteSlug: getSiteSlug( state, selectedSiteId ),
+			jetpackVersionSupportsLazyImages: isJetpackMinimumVersion(
+				state,
+				selectedSiteId,
+				'5.8-alpha'
+			),
+		};
+	},
+	{
+		updateSettings,
+	}
+)( localize( SpeedUpSiteSettings ) );

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -21,7 +21,7 @@ import {
 } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { updateSettings } from 'state/jetpack/settings/actions';
-import { getSiteSlug, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 import InfoPopover from 'components/info-popover';
 
 class SpeedUpSiteSettings extends Component {
@@ -32,12 +32,12 @@ class SpeedUpSiteSettings extends Component {
 		isSavingSettings: PropTypes.bool,
 		onChangeField: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
+		jetpackVersionSupportsLazyImages: PropTypes.bool,
 
 		// Connected props
 		photonModuleUnavailable: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
 		siteSlug: PropTypes.string,
-		jetpackVersionSupportsLazyImages: PropTypes.bool,
 	};
 
 	render() {
@@ -117,11 +117,6 @@ export default connect(
 			photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 			selectedSiteId,
 			siteSlug: getSiteSlug( state, selectedSiteId ),
-			jetpackVersionSupportsLazyImages: isJetpackMinimumVersion(
-				state,
-				selectedSiteId,
-				'5.8-alpha'
-			),
 		};
 	},
 	{


### PR DESCRIPTION
Fixes #21867

With the release of Jetpack 5.8, Jetpack will have a new feature named Lazy Images. Information can be found here: https://jetpack.com/support/lazy-images/

Along with this new feature, we updated the UI that is displayed in Jetpack with Automattic/jetpack#8463 so that it looked like this:

<img width="744" alt="screen shot 2018-02-01 at 10 52 06 am" src="https://user-images.githubusercontent.com/1126811/35691590-7d23d596-073e-11e8-8a79-b08e2d8220b3.png">

This PR ports that design over to WordPress.com

Here is a before screenshot of the relevant section for a Jetpack site (also for a Jetpack site with a version < 5.8-alpha):

<img width="761" alt="screen shot 2018-02-01 at 10 52 54 am" src="https://user-images.githubusercontent.com/1126811/35691727-dea70a86-073e-11e8-8e29-5cd0f17fc523.png">


Here is a screenshot of the relevant sections for a Jetpack site with at least version 5.8-alpha.

<img width="643" alt="screen shot 2018-02-01 at 10 53 03 am" src="https://user-images.githubusercontent.com/1126811/35691720-db5cf3cc-073e-11e8-983f-834a10887f34.png">

To test: 

- Check out branch
- Select a Jetpack site with the latest beta
- Go to `/settings/writing/$site_slug` and ensure that you see the new "Speed up your site" section
- Check that toggling the photon and lazy images settings works
- Switch to a Jetpack site with version 5.7 and ensure that you do not see the "Speed up your site" section and that the photon setting is in the Media section
- Check that toggling the photon setting works
- Switch to a WordPress.com site and ensure that you don't see a mention of Photon or Lazy Images