### PR TITLE
Devdocs: Removing the max-width and padding to let devdocs breathe a little.

### DIFF
--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -5,13 +5,7 @@
 	line-height: 1.618;
 	color: $gray-dark;
 	margin: 0 auto;
-	max-width: 960px;
-	padding: 1.777em 8.184em;
-
-	@include breakpoint( "<960px" ) {
-		padding: 24px;
-		max-width: 100%;
-	}
+	padding: 0;
 }
 
 .is-section-devdocs-start .layout__primary {


### PR DESCRIPTION
Before:
<img width="1148" alt="screen shot 2018-02-01 at 1 25 58 pm" src="https://user-images.githubusercontent.com/191598/35695762-7909df7c-0753-11e8-82e0-7788b3e2ed13.png">

After:
<img width="1148" alt="screen shot 2018-02-01 at 1 26 01 pm" src="https://user-images.githubusercontent.com/191598/35695768-7e4ea986-0753-11e8-8bcf-ad87458c8d31.png">
