### PR TITLE
makeParser: lazy-initialize actual parser

### DIFF
--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -68,39 +68,49 @@ export class TransformerError extends Error {
 }
 
 export const makeParser = ( schema, schemaOptions = {}, transformer = identity ) => {
-	const options = Object.assign( { verbose: true }, schemaOptions );
-	const validator = schemaValidator( schema, options );
+	let transform;
+	let validate;
 
-	// filter out unwanted properties even though we may have let them slip past validation
-	// note: this property does not nest deeply into the data structure, that is, properties
-	// of a property that aren't in the schema could still come through since only the top
-	// level of properties are pruned
-	const filter = schemaValidator.filter(
-		Object.assign(
-			{},
-			schema,
-			schema.type && schema.type === 'object' && { additionalProperties: false }
-		)
-	);
+	const genParser = () => {
+		const options = Object.assign( { verbose: true }, schemaOptions );
+		const validator = schemaValidator( schema, options );
 
-	const validate = data => {
-		if ( ! validator( data ) ) {
-			throw new SchemaError( validator.errors );
-		}
+		// filter out unwanted properties even though we may have let them slip past validation
+		// note: this property does not nest deeply into the data structure, that is, properties
+		// of a property that aren't in the schema could still come through since only the top
+		// level of properties are pruned
+		const filter = schemaValidator.filter(
+			Object.assign(
+				{},
+				schema,
+				schema.type && schema.type === 'object' && { additionalProperties: false }
+			)
+		);
 
-		return filter( data );
+		validate = data => {
+			if ( ! validator( data ) ) {
+				throw new SchemaError( validator.errors );
+			}
+
+			return filter( data );
+		};
+
+		transform = data => {
+			try {
+				return transformer( data );
+			} catch ( e ) {
+				throw new TransformerError( e, data, transformer );
+			}
+		};
 	};
 
-	const transform = data => {
-		try {
-			return transformer( data );
-		} catch ( e ) {
-			throw new TransformerError( e, data, transformer );
+	return data => {
+		if ( ! transform ) {
+			genParser();
 		}
-	};
 
-	// the actual parser
-	return data => transform( validate( data ) );
+		return transform( validate( data ) );
+	};
 };
 
 const getRequestStatus = action => {


### PR DESCRIPTION
The costs of creating the schema parsers may be expensive as it compiles
the JSON schema into actual JavaScript code.

This change changes `makeParser()` so that instead of creating the
parser when it's initially called it waits to initialize the parser
until the returned function is called. This should amortize the cost of
that initialization across real uses and eliminate some of it when the
parser is never actually needed.

Open questions revolve around memory use of creating and maintaining the
closure in memory to initialize the parser and if this change is
significant at all in speeding up Calypso boot.