### PR TITLE
SSR: Drop server-side webpack config stubs

### DIFF
--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -176,10 +176,6 @@ const webpackConfig = {
 			/^client[\/\\]layout[\/\\]guided-tours[\/\\]config$/,
 			'components/empty-component'
 		), // should never be required server side
-		new webpack.NormalModuleReplacementPlugin(
-			/^components[\/\\]site-selector$/,
-			'components/null-component'
-		), // Depends on BOM
 	] ),
 	externals: getExternals(),
 };

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -171,10 +171,6 @@ const webpackConfig = {
 			/^my-sites[\/\\]themes[\/\\]theme-upload$/,
 			'components/empty-component'
 		), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin(
-			/^client[\/\\]layout[\/\\]guided-tours[\/\\]config$/,
-			'components/empty-component'
-		), // should never be required server side
 	] ),
 	externals: getExternals(),
 };

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -154,7 +154,6 @@ const webpackConfig = {
 		new HappyPack( { loaders: [ babelLoader ] } ),
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]abtest$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]analytics$/, 'lodash/noop' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]sites-list$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]user$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin(
 			/^lib[\/\\]post-normalizer[\/\\]rule-create-better-excerpt$/,

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -153,6 +153,7 @@ const webpackConfig = {
 		} ),
 		new HappyPack( { loaders: [ babelLoader ] } ),
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]abtest$/, 'lodash/noop' ), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]user$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin(
 			/^components[\/\\]popover$/,

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -156,10 +156,6 @@ const webpackConfig = {
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]user$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin(
-			/^lib[\/\\]post-normalizer[\/\\]rule-create-better-excerpt$/,
-			'lodash/noop'
-		), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin(
 			/^components[\/\\]popover$/,
 			'components/null-component'
 		), // Depends on BOM and interactions don't work without JS

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -153,7 +153,6 @@ const webpackConfig = {
 		} ),
 		new HappyPack( { loaders: [ babelLoader ] } ),
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]abtest$/, 'lodash/noop' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]user$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin(
 			/^components[\/\\]popover$/,

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -160,10 +160,6 @@ const webpackConfig = {
 			'lodash/noop'
 		), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin(
-			/^components[\/\\]seo[\/\\]reader-preview$/,
-			'components/empty-component'
-		), // Conflicts with component-closest module
-		new webpack.NormalModuleReplacementPlugin(
 			/^components[\/\\]popover$/,
 			'components/null-component'
 		), // Depends on BOM and interactions don't work without JS


### PR DESCRIPTION
Rip it all out ((c) @dmsnell)

To test:
* Restart Calypso! (Verify that it starts at all 😅 )
* Test SSR'd stuff, logged-out and in:
  * http://calypso.localhost:3000/themes
  * http://calypso.localhost:3000/theme/mood
  * http://calypso.localhost:3000/log-in
* Also via docker, test SSR'd stuff, logged-out and in:
  * http://wpcalypso.wordpress.com/themes
  * http://wpcalypso.wordpress.com/theme/mood
  * http://wpcalypso.wordpress.com/log-in

Follow-up TODO: Carry over to Automattic/wp-desktop :roll_eyes: 