### PR TITLE
Update affiliate tracking

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -24,6 +24,7 @@ import {
 } from 'lodash';
 import { connect } from 'react-redux';
 import { setSurvey } from 'state/signup/steps/survey/actions';
+import cookie from 'cookie';
 
 /**
  * Internal dependencies
@@ -200,9 +201,6 @@ class Signup extends React.Component {
 	}
 
 	componentWillReceiveProps( { signupDependencies, stepName, flowName } ) {
-		const urlPath = location.href;
-		const query = url.parse( urlPath, true ).query;
-
 		if ( this.props.stepName !== stepName ) {
 			this.recordStep( stepName );
 		}
@@ -211,7 +209,7 @@ class Signup extends React.Component {
 			this.setState( { resumingStep: undefined } );
 		}
 
-		if ( query.plans ) {
+		if ( cookie.parse( document.cookie )[ 'wp-affiliate-tracker' ] ) {
 			this.setState( { plans: true } );
 		}
 


### PR DESCRIPTION
This PR changes the way we track for affiliates in signup so that we can hide the free plan without using a query string parameter. 

## Testing
* Visit `calypso.localhost:3000/start`
* Add the following cookie to your browser:
 Name: `wp-affiliate-tracker` 
 Value: `%7B%2267402%22%3A%7B%22id%22%3A%229175a7366b2a80043.56970258%22%2C%22affiliate_id%22%3A5617%7D%7D`
* Proceed through signup until you get to the plans page where there should be no free plan.
* Remove the cookie and refresh the page to see the free plan listed.

cc @travisw 