### PR TITLE
Store: Set a default price of 0 if no price is entered on product create

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -169,6 +169,11 @@ class ProductCreate extends React.Component {
 			// Product type was never switched, so set it before we save.
 			this.props.editProduct( site.ID, product, { type: 'simple' } );
 		}
+
+		if ( ! product.regular_price ) {
+			this.props.editProduct( site.ID, product, { regular_price: '0' } );
+		}
+
 		this.props.createProductActionList( successAction, failureAction );
 	};
 


### PR DESCRIPTION
See #21938 and https://github.com/Automattic/wp-calypso/issues/21938#issuecomment-362014323.

If you don't enter a price, but save the product, a product appears "free" but can cause issues on the front-end and with orders. This makes sure to set a price of 0 via the API if no price has been entered.

To Test:
* Create a product and leave the field empty.
* View your product and make sure the price was set to 0.