### PR TITLE
Build: Allow build-client to use more memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "build-docker": "node bin/build-docker.js",
     "prebuild-server": "mkdirp build",
     "build-server": "npm run -s env -- webpack --display-error-details --config webpack.config.node.js",
-    "build-client": "npm run -s env -- webpack --display-error-details --config webpack.config.js",
+    "build-client": "npm run -s env -- node --max_old_space_size=8192 ./node_modules/.bin/webpack --display-error-details --config webpack.config.js",
     "build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || npm run build-client",
     "build-client-if-desktop": "node -e \"process.env.CALYPSO_ENV === 'desktop' && process.exit(1)\" || npm run build-client",
     "clean": "npm run -s clean:build && npm run -s clean:devdocs && npm run -s clean:public",


### PR DESCRIPTION
This sets the build space to 8192 for build-client, like
preanalyze-bundles already is at. This is because when building with
sourcemaps, build-client would run out of memory.

_I tested this for any build time changes, and from several runs both after a `distclean` and after having been built before, I saw no trends outside the normal noise of a few seconds difference._

To Test:
1. `npm run distclean`
2. `npm run build`
3. `CALYPSO_ENV=production npm run build`
4. `CALYPSO_ENV=production SOURCEMAP=hidden-source-map npm run build` (this works on this branch, but will run out of memory on master.)
