### PR TITLE
Domains: enable admin buttons for AT sites

### DIFF
--- a/client/my-sites/domains/domain-management/edit/card/header/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/header/index.jsx
@@ -6,6 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,19 +30,23 @@ class Header extends React.Component {
 			return null;
 		}
 
+		const isJetpackSite = get( this.props, 'selectedSite.jetpack' );
+		const isAtomicSite = get( this.props, 'selectedSite.options.is_automated_transfer' );
+
+		const renderButton = this.props.selectedSite && ( ! isJetpackSite || isAtomicSite );
+
 		return (
 			<SectionHeader label={ domain.name }>
 				<DomainPrimaryFlag domain={ domain } />
 				<DomainTransferFlag domain={ domain } />
 
-				{ this.props.selectedSite &&
-					! this.props.selectedSite.jetpack && (
-						<PrimaryDomainButton
-							domain={ domain }
-							selectedSite={ this.props.selectedSite }
-							settingPrimaryDomain={ this.props.settingPrimaryDomain }
-						/>
-					) }
+				{ renderButton && (
+					<PrimaryDomainButton
+						domain={ domain }
+						selectedSite={ this.props.selectedSite }
+						settingPrimaryDomain={ this.props.settingPrimaryDomain }
+					/>
+				) }
 			</SectionHeader>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -39,7 +39,8 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
-import { isDomainOnlySite } from 'state/selectors';
+import { isDomainOnlySite, isSiteAutomatedTransfer } from 'state/selectors';
+
 import { isPlanFeaturesEnabled } from 'lib/plans';
 import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
 import { type } from 'lib/domains/constants';
@@ -254,7 +255,7 @@ export class List extends React.Component {
 	};
 
 	headerButtons() {
-		if ( this.props.selectedSite && this.props.selectedSite.jetpack ) {
+		if ( this.props.selectedSite && this.props.selectedSite.jetpack && ! this.props.isAtomicSite ) {
 			return null;
 		}
 
@@ -466,6 +467,7 @@ export default connect(
 		return {
 			hasDomainCredit: !! ownProps.selectedSite && hasDomainCredit( state, siteId ),
 			isDomainOnly: isDomainOnlySite( state, siteId ),
+			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
 		};
 	},
 	dispatch => {


### PR DESCRIPTION
This branch enables the domains management sections for Atomic sites.

### How to test

After applying the changes on this branch, go to the admin domains section with an Atomic site.
`http://calypso.localhost:3000/domains/manage/<at-site>`

You should be able to see the admin sections:

![image](https://user-images.githubusercontent.com/77539/36383996-905f2dea-156c-11e8-8d89-681da24bd46c.png)

Also, in the domain edit section you should be able to see the `Make Primary` button.

![set-primary-button](https://user-images.githubusercontent.com/77539/36483816-f6ef5d8e-16f5-11e8-9922-1c41a9c62609.png)
