### PR TITLE
Purchases: Prevent Atomic Business plan cancellation

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -242,7 +242,10 @@ class ManagePurchase extends Component {
 		let text,
 			link = cancelPurchase( this.props.selectedSite.slug, id );
 
-		if ( isRefundable( purchase ) ) {
+		if ( isAtomicSite && isSubscription( purchase ) ) {
+			text = translate( 'Contact Support to Cancel your Subscription' );
+			link = CALYPSO_CONTACT;
+		} else if ( isRefundable( purchase ) ) {
 			if ( isDomainRegistration( purchase ) ) {
 				if ( isRenewal( purchase ) ) {
 					text = translate( 'Contact Support to Cancel Domain and Refund' );
@@ -251,17 +254,13 @@ class ManagePurchase extends Component {
 					text = translate( 'Cancel Domain and Refund' );
 				}
 			}
-			if ( isAtomicSite ) {
-				text = translate( 'Contact Support to Cancel Subscription and Refund' );
-				link = CALYPSO_CONTACT;
-			} else {
-				if ( isSubscription( purchase ) ) {
-					text = translate( 'Cancel Subscription and Refund' );
-				}
 
-				if ( isOneTimePurchase( purchase ) ) {
-					text = translate( 'Cancel and Refund' );
-				}
+			if ( isSubscription( purchase ) ) {
+				text = translate( 'Cancel Subscription and Refund' );
+			}
+
+			if ( isOneTimePurchase( purchase ) ) {
+				text = translate( 'Cancel and Refund' );
 			}
 		} else {
 			if ( isDomainTransfer( purchase ) ) {


### PR DESCRIPTION
This is a follow up to #15918 which only covers the situation when a plan can be removed. This PR covers when a plan can be canceled and/or refunded. 

The changes here do not introduce a dialog as in #15918 but do follow the same flow when the customer wants to cancel a [renewable domain purchase](https://github.com/Automattic/wp-calypso/blob/d56dd64489d6821a25d4290e3e39735b77b7368f/client/me/purchases/manage-purchase/index.jsx#L248)

![purchases_ _manage_purchase_ _wordpress_com](https://user-images.githubusercontent.com/744755/35708571-9880432c-0763-11e8-89ca-9baeba528abf.png)

This PR also adds analytics click tracking to the cancel plan nav item.

## Testing
1. Create a site and add a Business plan using a credit card ( this will not work with credits )
2. Transfer the site to Atomic
3. Visit http://calypso.localhost:3000/me/purchases and click on the Business Plan for the site
4. The option to cancel the plan should say "Contact Support to Cancel your Subscription"
5. Clicking on the link should open the contact form and send a tracks event with the key `calypso_purchases_manage_purchase_cancel_click`

cc @sararosso 