### PR TITLE
Store: Add new getAllCountries selector, rename old getCountries selector to getCountriesByContinent

### DIFF
--- a/client/extensions/woocommerce/components/form-location-select/countries.js
+++ b/client/extensions/woocommerce/components/form-location-select/countries.js
@@ -16,7 +16,7 @@ import { bindActionCreators } from 'redux';
 import {
 	areLocationsLoaded,
 	getContinents,
-	getCountries,
+	getCountriesByContinent,
 } from 'woocommerce/state/sites/locations/selectors';
 import {
 	areSettingsGeneralLoaded,
@@ -104,7 +104,7 @@ export default connect(
 		const isLoaded = areLocationsLoaded( state, siteId );
 		const continents = getContinents( state, siteId );
 		continents.forEach( continent => {
-			const countries = getCountries( state, continent.code, siteId );
+			const countries = getCountriesByContinent( state, continent.code, siteId );
 			locationsList.push(
 				...countries.map( country => ( {
 					...country,

--- a/client/extensions/woocommerce/state/sites/locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/locations/selectors.js
@@ -68,7 +68,7 @@ export const getContinents = createSelector(
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @return {Array} A list of countries in the given country, represented by { code, name } pairs. Sorted alphabetically by name.
  */
-export const getCountries = createSelector(
+export const getCountriesByContinent = createSelector(
 	( state, continentCode, siteId = getSelectedSiteId( state ) ) => {
 		if ( ! areLocationsLoaded( state, siteId ) ) {
 			return [];

--- a/client/extensions/woocommerce/state/sites/locations/selectors.js
+++ b/client/extensions/woocommerce/state/sites/locations/selectors.js
@@ -64,9 +64,23 @@ export const getContinents = createSelector(
 
 /**
  * @param {Object} state Whole Redux state tree
+ * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
+ * @return {Array} An array of all countries represented by { code, name, states } objects. Sorted alphabetically by name.
+ */
+export const getAllCountries = ( state, siteId = getSelectedSiteId( state ) ) => {
+	if ( ! areLocationsLoaded( state, siteId ) ) {
+		return [];
+	}
+
+	const allCountries = flatMap( getRawLocations( state, siteId ), 'countries' );
+	return sortBy( allCountries, 'name' );
+};
+
+/**
+ * @param {Object} state Whole Redux state tree
  * @param {String} continentCode 2-letter continent code
  * @param {Number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
- * @return {Array} A list of countries in the given country, represented by { code, name } pairs. Sorted alphabetically by name.
+ * @return {Array} A list of countries in the given continent, represented by { code, name } pairs. Sorted alphabetically by name.
  */
 export const getCountriesByContinent = createSelector(
 	( state, continentCode, siteId = getSelectedSiteId( state ) ) => {
@@ -121,7 +135,7 @@ export const getCountriesWithStates = ( state, siteId = getSelectedSiteId( state
 		return [];
 	}
 
-	const allCountries = flatMap( getRawLocations( state, siteId ), 'countries' );
+	const allCountries = getAllCountries( state, siteId );
 	const countriesWithStates = filter( allCountries, country => {
 		return ! isEmpty( country.states );
 	} );

--- a/client/extensions/woocommerce/state/sites/locations/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/locations/test/selectors.js
@@ -12,6 +12,7 @@ import {
 	areLocationsLoaded,
 	areLocationsLoading,
 	getContinents,
+	getAllCountries,
 	getCountriesByContinent,
 	getCountryName,
 	getCountriesWithStates,
@@ -174,6 +175,53 @@ describe( 'selectors', () => {
 			expect( getContinents( loadedState ) ).to.deep.equal( [
 				{ code: 'AF', name: 'Africa' },
 				{ code: 'NA', name: 'North America' },
+			] );
+		} );
+	} );
+
+	describe( '#getAllCountries', () => {
+		test( 'should return an empty list if the locations are not loaded', () => {
+			expect( getAllCountries( emptyState ) ).to.deep.equal( [] );
+		} );
+		test( 'should return an empty list if the locations are being loaded', () => {
+			expect( getAllCountries( loadingState ) ).to.deep.equal( [] );
+		} );
+		test( 'should return all countries, sorted by name', () => {
+			expect( getAllCountries( loadedState ) ).to.deep.equal( [
+				{
+					code: 'CA',
+					name: 'Canada',
+					states: [
+						{
+							code: 'BC',
+							name: 'British Columbia',
+						},
+						{
+							code: 'ON',
+							name: 'Ontario',
+						},
+					],
+				},
+				{ code: 'EG', name: 'Egypt', states: [] },
+				{ code: 'SA', name: 'South Africa', states: [] },
+				{
+					code: 'US',
+					name: 'United States',
+					states: [
+						{
+							code: 'UT',
+							name: 'Utah',
+						},
+						{
+							code: 'AL',
+							name: 'Alabama',
+						},
+						{
+							code: 'CA',
+							name: 'California',
+						},
+					],
+				},
 			] );
 		} );
 	} );

--- a/client/extensions/woocommerce/state/sites/locations/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/locations/test/selectors.js
@@ -12,7 +12,7 @@ import {
 	areLocationsLoaded,
 	areLocationsLoading,
 	getContinents,
-	getCountries,
+	getCountriesByContinent,
 	getCountryName,
 	getCountriesWithStates,
 	getStates,
@@ -178,21 +178,21 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getCountries', () => {
+	describe( '#getCountriesByContinent', () => {
 		test( 'should return an empty list if the locations are not loaded', () => {
-			expect( getCountries( emptyState, 'NA' ) ).to.deep.equal( [] );
+			expect( getCountriesByContinent( emptyState, 'NA' ) ).to.deep.equal( [] );
 		} );
 
 		test( 'should return an empty list if the locations are being loaded', () => {
-			expect( getCountries( loadingState, 'NA' ) ).to.deep.equal( [] );
+			expect( getCountriesByContinent( loadingState, 'NA' ) ).to.deep.equal( [] );
 		} );
 
 		test( 'should return an empty list if the continent does not exist', () => {
-			expect( getCountries( loadedState, 'XX' ) ).to.deep.equal( [] );
+			expect( getCountriesByContinent( loadedState, 'XX' ) ).to.deep.equal( [] );
 		} );
 
 		test( 'should return the countries from a continent, sorted by name', () => {
-			expect( getCountries( loadedState, 'NA' ) ).to.deep.equal( [
+			expect( getCountriesByContinent( loadedState, 'NA' ) ).to.deep.equal( [
 				{ code: 'CA', name: 'Canada' },
 				{ code: 'US', name: 'United States' },
 			] );

--- a/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
+++ b/client/extensions/woocommerce/state/ui/shipping/zones/locations/selectors.js
@@ -19,7 +19,7 @@ import { getRawShippingZoneLocations } from 'woocommerce/state/sites/shipping-zo
 import { getShippingZonesEdits, getCurrentlyEditingShippingZone } from '../selectors';
 import {
 	getContinents,
-	getCountries,
+	getCountriesByContinent,
 	getCountryName,
 	getStates,
 	hasStates,
@@ -219,12 +219,12 @@ export const getShippingZoneLocationsWithEdits = createSelector(
 			switch ( action ) {
 				case JOURNAL_ACTIONS.ADD_CONTINENT:
 					// When selecting a whole continent, remove all its countries from the selection
-					getCountries( state, code, siteId ).forEach( country =>
+					getCountriesByContinent( state, code, siteId ).forEach( country =>
 						countries.delete( country.code )
 					);
 					if ( countries.size ) {
 						// If the zone has countries selected, then instead of selecting the continent we select all its countries
-						getCountries( state, code, siteId ).forEach( country => {
+						getCountriesByContinent( state, code, siteId ).forEach( country => {
 							if ( ! forbiddenCountries.has( country.code ) ) {
 								countries.add( country.code );
 							}
@@ -235,7 +235,7 @@ export const getShippingZoneLocationsWithEdits = createSelector(
 					break;
 				case JOURNAL_ACTIONS.REMOVE_CONTINENT:
 					continents.delete( code );
-					getCountries( state, code, siteId ).forEach( country =>
+					getCountriesByContinent( state, code, siteId ).forEach( country =>
 						countries.delete( country.code )
 					);
 					break;
@@ -246,7 +246,7 @@ export const getShippingZoneLocationsWithEdits = createSelector(
 					countries.add( code );
 					// If the zone has continents selected, then we need to replace them with their respective countries
 					continents.forEach( continentCode => {
-						getCountries( state, continentCode, siteId ).forEach( country => {
+						getCountriesByContinent( state, continentCode, siteId ).forEach( country => {
 							if ( ! forbiddenCountries.has( country.code ) ) {
 								countries.add( country.code );
 							}
@@ -261,7 +261,7 @@ export const getShippingZoneLocationsWithEdits = createSelector(
 						if ( insideSelectedContinent ) {
 							break;
 						}
-						for ( const country of getCountries( state, continentCode, siteId ) ) {
+						for ( const country of getCountriesByContinent( state, continentCode, siteId ) ) {
 							if ( country.code === code ) {
 								insideSelectedContinent = true;
 								break;
@@ -271,7 +271,7 @@ export const getShippingZoneLocationsWithEdits = createSelector(
 					// If the user unselected a country that was inside a selected continent, replace the continent for its countries
 					if ( insideSelectedContinent ) {
 						continents.forEach( continentCode => {
-							getCountries( state, continentCode, siteId ).forEach( country => {
+							getCountriesByContinent( state, continentCode, siteId ).forEach( country => {
 								if ( ! forbiddenCountries.has( country.code ) ) {
 									countries.add( country.code );
 								}
@@ -554,7 +554,7 @@ const getShippingZoneLocationsListFromLocations = (
 	//if there are more than maxCountries per continent, group them into a continent
 	let result = [];
 	getContinents( state, siteId ).forEach( ( { code: continentCode, name: continentName } ) => {
-		const continentCountries = getCountries( state, continentCode, siteId );
+		const continentCountries = getCountriesByContinent( state, continentCode, siteId );
 		const selectedContinentCountries = continentCountries
 			.filter( ( { code } ) => selectedCountries.has( code ) )
 			.map( ( { code, name } ) => ( {
@@ -651,7 +651,7 @@ export const getCurrentlyEditingShippingZoneCountries = createSelector(
 
 		getContinents( state, siteId ).forEach( ( { code: continentCode, name: continentName } ) => {
 			const continentSelected = selectedContinents.has( continentCode );
-			const continentCountries = getCountries( state, continentCode, siteId );
+			const continentCountries = getCountriesByContinent( state, continentCode, siteId );
 			let selectedCount = 0;
 			const continentI = locationsList.push( {
 				code: continentCode,


### PR DESCRIPTION
...to help with review/clarity for next round of internationalization

Related: #22062 

To test:
* `npm run test-client /client/extensions/woocommerce/`
* Open various editable addresses (new order, edit order, settings) and make sure they still work
* Add new shipping zone and make sure continent and country list appears
