### PR TITLE
ActivityLogItem - updated styles with a focus on mobile

### DIFF
--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -6,70 +6,71 @@
 	@include breakpoint( '<480px' ) {
 		margin-left: 8px;
 	}
+}
 
-	.card {
-		flex: 1;
-		margin-top: 8px;
-		margin-bottom: 16px;
+.activity-log-item .card {
+	flex: 1;
+	margin-top: 8px;
+	margin-bottom: 16px;
+}
+
+.activity-log-item .foldable-card {
+	.foldable-card__expand .gridicon {
+		transform: none;
 	}
 
-	.foldable-card {
+	&.is-expanded {
+		margin-bottom: 24px;
+
 		.foldable-card__expand .gridicon {
-			transform: none;
-		}
-
-		&.is-expanded {
-			margin-bottom: 24px;
-
-			.foldable-card__expand .gridicon {
-				transform: rotate(180deg);
-			}
+			transform: rotate(180deg);
 		}
 	}
+}
 
-	.foldable-card__header {
+.activity-log-item .foldable-card__header {
+	@include breakpoint( '<480px' ) {
+		padding: 12px;
+		display: block;
+	}
+
+	// TODO: Remove when foldable cards become "expandable"
+	.is-clickable {
+		cursor: default;
+	}
+}
+
+.activity-log-item .foldable-card__secondary {
+	flex-grow: 0;
+
+	.foldable-card__summary-expanded {
+		margin-right: 0;
+	}
+}
+
+.activity-log-item .is-discarded {
+	margin-left: 80px;
+
+	@include breakpoint( '<480px' ) {
+		margin-left: 60px;
+	}
+
+	&:before {
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 33px;
+		height: 100%;
+		border-left: 2px dotted lighten($gray, 20%);
+
 		@include breakpoint( '<480px' ) {
-			padding: 12px;
-		}
-
-		// TODO: Remove when foldable cards become "expandable"
-		.is-clickable {
-			cursor: default;
+			left: 22px;
 		}
 	}
 
-	.foldable-card__secondary {
-		flex-grow: 0;
-
-		.foldable-card__summary-expanded {
-			margin-right: 0;
-		}
-	}
-
-	&.is-discarded {
-		margin-left: 80px;
-
-		@include breakpoint( '<480px' ) {
-			margin-left: 60px;
-		}
-
+	&:last-of-type {
 		&:before {
-			content: '';
-			position: absolute;
-			top: 0;
-			left: 33px;
-			height: 100%;
-			border-left: 2px dotted lighten($gray, 20%);
-
-			@include breakpoint( '<480px' ) {
-				left: 22px;
-			}
-		}
-
-		&:last-of-type {
-			&:before {
-				display: none;
-			}
+			display: none;
 		}
 	}
 }
@@ -108,7 +109,16 @@
 	margin-top: 2px;
 
 	@include breakpoint( '<480px' ) {
-		padding: 10px;
+		padding: 7px;
+		box-sizing: border-box;
+		width: 32px;
+		height: 32px;
+		display: inline-block;
+
+		.gridicon {
+			width: 18px;
+			height: 18px;
+		}
 	}
 
 	// Success
@@ -138,6 +148,11 @@
 
 	.foldable-card__main {
 		min-width: 0;
+
+		@include breakpoint( '<480px' ) {
+			max-width: none;
+			margin: 0;
+		}
 	}
 
 	.foldable-card__content {
@@ -164,7 +179,11 @@
 	@include breakpoint( '<960px' ) {
 		flex-direction: column;
 		align-items: flex-start;
-		padding-left: 40px;
+		padding-left: 0;
+	}
+
+	@include breakpoint( '<480px' ) {
+		margin-right: 0;
 	}
 }
 
@@ -174,7 +193,6 @@
 	min-width: 180px;
 	max-width: 100%;
 	margin-right: 32px;
-	margin-left: -40px;
 	align-items: center;
 
 	@include breakpoint( '>960px' ) {
@@ -192,6 +210,11 @@
 		@include breakpoint( '<960px' ) {
 			width: 32px;
 			height: 32px;
+			margin-right: 8px;
+		}
+		@include breakpoint( '<480px' ) {
+			width: 24px;
+			height: 24px;
 			margin-right: 8px;
 		}
 	}
@@ -222,6 +245,17 @@
 		margin-top: 2px;
 		line-height: 1;
 	}
+
+	@include breakpoint( '<480px' ) {
+		display: inline-block;
+	}
+}
+
+.activity-log-item__actor-role {
+	@include breakpoint( '<480px' ) {
+		display: inline-block;
+		margin-left: 8px;
+	}
 }
 
 .activity-log-item__actor-role,
@@ -229,6 +263,10 @@
 	text-transform: capitalize;
 	font-size: 12px;
 	color: $gray-text-min;
+
+	@include breakpoint( '<480px' ) {
+		font-size: 14px;
+	}
 }
 
 .activity-log-item__description {
@@ -241,9 +279,16 @@
 	}
 }
 
+.activity-log-item__description-content {
+	margin-bottom: 8px;
+}
+
 .activity-log-item__action {
-	.split-button {
-		/* 8 x 15 so split button doesn't break */
-		min-width: 128px;
+	// Mild hack so split button doesn't break
+	white-space: pre;
+
+	@include breakpoint( '<480px' ) {
+		margin-top: 16px;
+		text-align: left;
 	}
 }

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -13,7 +13,7 @@
 		background: lighten( $gray, 20% );
 
 		@include breakpoint( "<480px" ) {
-			left: 29px;
+			left: 25px;
 		}
 	}
 }


### PR DESCRIPTION
A few things are happening here.

* I split up the `.activity-log-item` selector's children for improved readability.
* I dramatically improved the styles on small screens by wrapping the button below, adjusting the spacing, making icons smaller, and making slightly better use of screen real estate.
* I added a more resiliant hack for keeping the split button from splitting. It's now using `white-space: pre` which prevents it from wrapping.

#### Before
![image](https://user-images.githubusercontent.com/1123119/35710187-4ea50db8-0773-11e8-9768-6ab313775abe.png)

![image](https://user-images.githubusercontent.com/1123119/35710177-462fce8e-0773-11e8-9038-408281fb439a.png)

![image](https://user-images.githubusercontent.com/1123119/35710161-358c5aa2-0773-11e8-89b7-933f51619a05.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/35710077-c243fd2a-0772-11e8-8326-ce7f0d41b834.png)

![image](https://user-images.githubusercontent.com/1123119/35710092-d1ceb942-0772-11e8-9cb0-a2401be9532f.png)

![image](https://user-images.githubusercontent.com/1123119/35710102-e093cd5a-0772-11e8-806b-9cbbb01bcff4.png)

![image](https://user-images.githubusercontent.com/1123119/35710112-ef9c41b0-0772-11e8-8d6f-5b51f4550755.png)
