### PR TITLE
Store: Replace product category token selector with a proper category component

### DIFF
--- a/client/extensions/woocommerce/app/products/product-create.js
+++ b/client/extensions/woocommerce/app/products/product-create.js
@@ -25,10 +25,6 @@ import {
 	editProductAttribute,
 	createProductActionList,
 } from 'woocommerce/state/ui/products/actions';
-import {
-	clearProductCategoryEdits,
-	editProductCategory,
-} from 'woocommerce/state/ui/product-categories/actions';
 import { getActionList } from 'woocommerce/state/action-list/selectors';
 import {
 	getCurrentlyEditingId,
@@ -37,12 +33,10 @@ import {
 } from 'woocommerce/state/ui/products/selectors';
 import { getFinishedInitialSetup } from 'woocommerce/state/sites/setup-choices/selectors';
 import { getProductVariationsWithLocalEdits } from 'woocommerce/state/ui/products/variations/selectors';
-import { fetchProductCategories } from 'woocommerce/state/sites/product-categories/actions';
 import {
 	clearProductVariationEdits,
 	editProductVariation,
 } from 'woocommerce/state/ui/products/variations/actions';
-import { getProductCategoriesWithLocalEdits } from 'woocommerce/state/ui/product-categories/selectors';
 import ProductForm from './product-form';
 import ProductHeader from './product-header';
 import { getLink } from 'woocommerce/lib/nav-utils';
@@ -59,9 +53,7 @@ class ProductCreate extends React.Component {
 		product: PropTypes.shape( {
 			id: PropTypes.isRequired,
 		} ),
-		fetchProductCategories: PropTypes.func.isRequired,
 		editProduct: PropTypes.func.isRequired,
-		editProductCategory: PropTypes.func.isRequired,
 		editProductAttribute: PropTypes.func.isRequired,
 		editProductVariation: PropTypes.func.isRequired,
 	};
@@ -75,7 +67,6 @@ class ProductCreate extends React.Component {
 
 		if ( site && site.ID ) {
 			this.props.editProduct( site.ID, null, {} );
-			this.props.fetchProductCategories( site.ID );
 		}
 	}
 
@@ -85,7 +76,6 @@ class ProductCreate extends React.Component {
 		const oldSiteId = ( site && site.ID ) || null;
 		if ( oldSiteId !== newSiteId ) {
 			this.props.editProduct( newSiteId, null, {} );
-			this.props.fetchProductCategories( newSiteId );
 		}
 	}
 
@@ -94,7 +84,6 @@ class ProductCreate extends React.Component {
 
 		if ( site ) {
 			this.props.clearProductEdits( site.ID );
-			this.props.clearProductCategoryEdits( site.ID );
 			this.props.clearProductVariationEdits( site.ID );
 		}
 	}
@@ -182,15 +171,7 @@ class ProductCreate extends React.Component {
 	}
 
 	render() {
-		const {
-			site,
-			product,
-			hasEdits,
-			className,
-			variations,
-			productCategories,
-			actionList,
-		} = this.props;
+		const { site, product, hasEdits, className, variations, actionList } = this.props;
 
 		const isValid = 'undefined' !== site && this.isProductValid();
 		const isBusy = Boolean( actionList ); // If there's an action list present, we're trying to save.
@@ -213,9 +194,7 @@ class ProductCreate extends React.Component {
 					siteId={ site && site.ID }
 					product={ product || { type: 'simple' } }
 					variations={ variations }
-					productCategories={ productCategories }
 					editProduct={ this.props.editProduct }
-					editProductCategory={ this.props.editProductCategory }
 					editProductAttribute={ this.props.editProductAttribute }
 					editProductVariation={ this.props.editProductVariation }
 					onUploadStart={ this.onUploadStart }
@@ -233,7 +212,6 @@ function mapStateToProps( state ) {
 	const product = combinedProduct || ( productId && { id: productId } );
 	const hasEdits = Boolean( getProductEdits( state, productId ) );
 	const variations = product && getProductVariationsWithLocalEdits( state, product.id );
-	const productCategories = getProductCategoriesWithLocalEdits( state );
 	const actionList = getActionList( state );
 	const finishedInitialSetup = getFinishedInitialSetup( state );
 
@@ -242,7 +220,6 @@ function mapStateToProps( state ) {
 		product,
 		hasEdits,
 		variations,
-		productCategories,
 		actionList,
 		finishedInitialSetup,
 	};
@@ -257,12 +234,9 @@ function mapDispatchToProps( dispatch ) {
 					createProductActionList( ...args )
 				),
 			editProduct,
-			editProductCategory,
 			editProductAttribute,
 			editProductVariation,
-			fetchProductCategories,
 			clearProductEdits,
-			clearProductCategoryEdits,
 			clearProductVariationEdits,
 		},
 		dispatch

--- a/client/extensions/woocommerce/app/products/product-form-categories-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-categories-card.js
@@ -14,6 +14,7 @@ import { compact } from 'lodash';
  */
 import FoldableCard from 'components/foldable-card';
 import FormFieldSet from 'components/forms/form-fieldset';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import TermSelector from 'woocommerce/components/term-selector';
 
 const ProductFormCategoriesCard = ( { siteId, product, editProduct, translate } ) => {
@@ -49,24 +50,26 @@ const ProductFormCategoriesCard = ( { siteId, product, editProduct, translate } 
 			className="products__categories-card"
 			header={ translate( 'Categories' ) }
 			clickableHeader
+			expanded
 		>
-			<p>
-				{ translate(
-					'Categories let you group similar products so customers can find them more easily.'
-				) }
-			</p>
-
 			<FormFieldSet>
 				<TermSelector
 					siteId={ siteId }
+					postType="product"
 					taxonomy="product_cat"
 					selected={ selectedCategoryIds }
 					onChange={ handleChange }
 					multiple
+					showAddTerm
+					onAddTerm={ handleChange }
 					emptyMessage={ translate( 'No categories found.' ) }
-					searchThreshold={ 0 }
 				/>
 			</FormFieldSet>
+			<FormSettingExplanation>
+				{ translate(
+					'Categories let you group similar products so customers can find them more easily.'
+				) }
+			</FormSettingExplanation>
 		</FoldableCard>
 	);
 };

--- a/client/extensions/woocommerce/app/products/product-form-details-card.js
+++ b/client/extensions/woocommerce/app/products/product-form-details-card.js
@@ -6,14 +6,15 @@
 
 import React, { Component } from 'react';
 import config from 'config';
-import i18n from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { trim, isNumber } from 'lodash';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import CompactTinyMCE from 'woocommerce/components/compact-tinymce';
 import FormClickToEditInput from 'woocommerce/components/form-click-to-edit-input';
 import FormFieldSet from 'components/forms/form-fieldset';
@@ -22,7 +23,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import ProductFormImages from './product-form-images';
 import ProductReviewsWidget from 'woocommerce/components/product-reviews-widget';
 
-export default class ProductFormDetailsCard extends Component {
+class ProductFormDetailsCard extends Component {
 	static propTypes = {
 		siteId: PropTypes.number,
 		product: PropTypes.shape( {
@@ -94,6 +95,11 @@ export default class ProductFormDetailsCard extends Component {
 		editProduct( siteId, product, { images } );
 	};
 
+	toggleFeatured = () => {
+		const { siteId, product, editProduct } = this.props;
+		editProduct( siteId, product, { featured: ! product.featured } );
+	};
+
 	renderTinyMCE = () => {
 		const { product } = this.props;
 
@@ -113,7 +119,7 @@ export default class ProductFormDetailsCard extends Component {
 	};
 
 	render() {
-		const { product } = this.props;
+		const { product, translate } = this.props;
 
 		let productReviewsWidget = null;
 
@@ -122,7 +128,6 @@ export default class ProductFormDetailsCard extends Component {
 		}
 
 		const images = product.images || [];
-		const __ = i18n.translate;
 
 		return (
 			<Card className="products__product-form-details">
@@ -136,24 +141,32 @@ export default class ProductFormDetailsCard extends Component {
 					/>
 					<div className="products__product-form-details-basic">
 						<FormFieldSet className="products__product-form-details-basic-name">
-							<FormLabel htmlFor="name">{ __( 'Product name' ) }</FormLabel>
+							<FormLabel htmlFor="name">{ translate( 'Product name' ) }</FormLabel>
 							<FormTextInput id="name" value={ product.name || '' } onChange={ this.setName } />
 						</FormFieldSet>
 						<FormFieldSet className="products__product-form-details-basic-sku">
-							<FormLabel htmlFor="sku">{ __( 'SKU:' ) }</FormLabel>
+							<FormLabel htmlFor="sku">{ translate( 'SKU:' ) }</FormLabel>
 							<FormClickToEditInput
 								id="sku"
 								value={ product.sku || '' }
 								placeholder="-"
-								updateAriaLabel={ __( 'Update SKU' ) }
-								editAriaLabel={ __( 'Edit SKU' ) }
+								updateAriaLabel={ translate( 'Update SKU' ) }
+								editAriaLabel={ translate( 'Edit SKU' ) }
 								onChange={ this.setSku }
 								disabled={ product.name || product.sku ? false : true }
 							/>
 						</FormFieldSet>
 						<FormFieldSet className="products__product-form-details-basic-description">
-							<FormLabel htmlFor="description">{ __( 'Description' ) }</FormLabel>
+							<FormLabel htmlFor="description">{ translate( 'Description' ) }</FormLabel>
 							{ this.renderTinyMCE() }
+						</FormFieldSet>
+						<FormFieldSet className="products__product-form-featured">
+							<FormLabel htmlFor="featured">
+								{ translate( 'Featured' ) }
+								<CompactFormToggle onChange={ this.toggleFeatured } checked={ product.featured }>
+									{ translate( 'Promote this product across the store' ) }
+								</CompactFormToggle>
+							</FormLabel>
 						</FormFieldSet>
 						{ productReviewsWidget }
 					</div>
@@ -162,3 +175,5 @@ export default class ProductFormDetailsCard extends Component {
 		);
 	}
 }
+
+export default localize( ProductFormDetailsCard );

--- a/client/extensions/woocommerce/app/products/product-form.js
+++ b/client/extensions/woocommerce/app/products/product-form.js
@@ -27,9 +27,7 @@ export default class ProductForm extends Component {
 			name: PropTypes.string,
 		} ),
 		variations: PropTypes.array,
-		productCategories: PropTypes.array.isRequired,
 		editProduct: PropTypes.func.isRequired,
-		editProductCategory: PropTypes.func.isRequired,
 		editProductAttribute: PropTypes.func.isRequired,
 		editProductVariation: PropTypes.func.isRequired,
 		onUploadStart: PropTypes.func.isRequired,
@@ -48,13 +46,8 @@ export default class ProductForm extends Component {
 	}
 
 	render() {
-		const { siteId, product, productCategories, variations } = this.props;
-		const {
-			editProduct,
-			editProductCategory,
-			editProductVariation,
-			editProductAttribute,
-		} = this.props;
+		const { siteId, product, variations } = this.props;
+		const { editProduct, editProductVariation, editProductAttribute } = this.props;
 		const type = product.type || 'simple';
 
 		if ( ! siteId ) {
@@ -79,16 +72,13 @@ export default class ProductForm extends Component {
 				<ProductFormCategoriesCard
 					siteId={ siteId }
 					product={ product }
-					productCategories={ productCategories }
 					editProduct={ editProduct }
-					editProductCategory={ editProductCategory }
 				/>
 				<ProductFormVariationsCard
 					siteId={ siteId }
 					product={ product }
 					variations={ variations }
 					editProduct={ editProduct }
-					editProductCategory={ editProductCategory }
 					editProductAttribute={ editProductAttribute }
 					editProductVariation={ editProductVariation }
 					onUploadStart={ this.props.onUploadStart }

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -59,6 +59,7 @@
 }
 
 .products__product-form-featured {
+	margin-top: 16px;
 	.form-toggle__label {
 		font-weight: 400;
 	}
@@ -268,25 +269,6 @@
 
 .products__product-form-details-basic-description.form-fieldset {
 	margin-bottom: 0;
-}
-
-.products__categories-card {
-	.form-fieldset {
-		&:last-child {
-			margin-bottom: 0;
-		}
-	}
-
-	@include breakpoint( ">1040px" ) {
-		display: flex;
-
-		>.form-fieldset {
-			width: 339px;
-			margin-right: 24px;
-			margin-bottom: 0;
-		}
-
-	}
 }
 
 .products__product-form-details-basic-name {
@@ -666,16 +648,13 @@
 	}
 }
 
-.products__additional-details-card {
+.products__additional-details-card,
+.products__categories-card {
 	border-top: 0;
-	margin-top: -10px;
-
-	@include breakpoint( ">480px" ) {
-		margin-top: -16px;
-	}
+	margin-top: -16px;
 
 	&.is-expanded {
-		margin-bottom: 16px;
+		margin-top: -16px;
 	}
 
 	.foldable-card__header {
@@ -698,6 +677,7 @@
 		}
 	}
 }
+
 
 .products__additional-details-form-labels {
 	display: flex;

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -648,8 +648,13 @@
 	}
 }
 
-.products__additional-details-card,
-.products__categories-card {
+.products__categories-card .term-tree-selector.is-small {
+    border: 1px solid $gray-lighten-20;
+    padding-top: 4px;
+    padding-bottom: 4px;
+}
+
+.products__additional-details-card {
 	border-top: 0;
 	margin-top: -16px;
 
@@ -658,7 +663,6 @@
 	}
 
 	.foldable-card__header {
-		padding: 16px;
 
 		@include breakpoint( ">480px" ) {
 			padding: 24px;

--- a/client/extensions/woocommerce/app/products/product-update.js
+++ b/client/extensions/woocommerce/app/products/product-update.js
@@ -25,7 +25,6 @@ import {
 	fetchProduct,
 	deleteProduct as deleteProductAction,
 } from 'woocommerce/state/sites/products/actions';
-import { fetchProductCategories } from 'woocommerce/state/sites/product-categories/actions';
 import { fetchProductVariations } from 'woocommerce/state/sites/product-variations/actions';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import {
@@ -43,11 +42,6 @@ import {
 	getProductVariationsWithLocalEdits,
 	getVariationEditsStateForProduct,
 } from 'woocommerce/state/ui/products/variations/selectors';
-import {
-	editProductCategory,
-	clearProductCategoryEdits,
-} from 'woocommerce/state/ui/product-categories/actions';
-import { getProductCategoriesWithLocalEdits } from 'woocommerce/state/ui/product-categories/selectors';
 import { getSaveErrorMessage } from './save-error-message';
 import page from 'page';
 import ProductForm from './product-form';
@@ -63,9 +57,7 @@ class ProductUpdate extends React.Component {
 		} ),
 		fetchProduct: PropTypes.func.isRequired,
 		fetchProductVariations: PropTypes.func.isRequired,
-		fetchProductCategories: PropTypes.func.isRequired,
 		editProduct: PropTypes.func.isRequired,
-		editProductCategory: PropTypes.func.isRequired,
 		editProductAttribute: PropTypes.func.isRequired,
 		editProductVariation: PropTypes.func.isRequired,
 	};
@@ -86,7 +78,6 @@ class ProductUpdate extends React.Component {
 			if ( ! variations ) {
 				this.props.fetchProductVariations( site.ID, productId );
 			}
-			this.props.fetchProductCategories( site.ID );
 		}
 	}
 
@@ -99,7 +90,6 @@ class ProductUpdate extends React.Component {
 			this.props.fetchProduct( newSiteId, productId );
 			this.props.fetchProductVariations( newSiteId, productId );
 			this.props.editProduct( newSiteId, { id: productId }, {} );
-			this.props.fetchProductCategories( newSiteId );
 		}
 	}
 
@@ -108,7 +98,6 @@ class ProductUpdate extends React.Component {
 
 		if ( site ) {
 			this.props.clearProductEdits( site.ID );
-			this.props.clearProductCategoryEdits( site.ID );
 			this.props.clearProductVariationEdits( site.ID );
 		}
 	}
@@ -158,9 +147,8 @@ class ProductUpdate extends React.Component {
 	};
 
 	onSave = () => {
-		const { product, translate, site, fetchProductCategories: fetch } = this.props;
+		const { product, translate } = this.props;
 		const successAction = () => {
-			fetch( site.ID );
 			return successNotice(
 				translate( '%(product)s successfully updated.', {
 					args: { product: product.name },
@@ -191,15 +179,7 @@ class ProductUpdate extends React.Component {
 	}
 
 	render() {
-		const {
-			site,
-			product,
-			hasEdits,
-			className,
-			variations,
-			productCategories,
-			actionList,
-		} = this.props;
+		const { site, product, hasEdits, className, variations, actionList } = this.props;
 
 		const isValid = 'undefined' !== site && this.isProductValid();
 		const isBusy = Boolean( actionList ); // If there's an action list present, we're trying to save.
@@ -221,9 +201,7 @@ class ProductUpdate extends React.Component {
 					siteId={ site && site.ID }
 					product={ product || { type: 'simple' } }
 					variations={ variations }
-					productCategories={ productCategories }
 					editProduct={ this.props.editProduct }
-					editProductCategory={ this.props.editProductCategory }
 					editProductAttribute={ this.props.editProductAttribute }
 					editProductVariation={ this.props.editProductVariation }
 					onUploadStart={ this.onUploadStart }
@@ -243,7 +221,6 @@ function mapStateToProps( state, ownProps ) {
 		Boolean( getProductEdits( state, productId ) ) ||
 		Boolean( getVariationEditsStateForProduct( state, productId ) );
 	const variations = product && getProductVariationsWithLocalEdits( state, product.id );
-	const productCategories = getProductCategoriesWithLocalEdits( state );
 	const actionList = getActionList( state );
 
 	return {
@@ -251,7 +228,6 @@ function mapStateToProps( state, ownProps ) {
 		product,
 		hasEdits,
 		variations,
-		productCategories,
 		actionList,
 	};
 }
@@ -266,14 +242,11 @@ function mapDispatchToProps( dispatch ) {
 				),
 			deleteProduct: deleteProductAction,
 			editProduct,
-			editProductCategory,
 			editProductAttribute,
 			editProductVariation,
 			fetchProduct,
 			fetchProductVariations,
-			fetchProductCategories,
 			clearProductEdits,
-			clearProductCategoryEdits,
 			clearProductVariationEdits,
 		},
 		dispatch

--- a/client/extensions/woocommerce/components/term-selector/add-term.js
+++ b/client/extensions/woocommerce/components/term-selector/add-term.js
@@ -1,0 +1,81 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { get, noop } from 'lodash';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import TermFormDialog from 'blocks/term-form-dialog';
+import QueryTaxonomies from 'components/data/query-taxonomies';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getPostTypeTaxonomy } from 'state/post-types/taxonomies/selectors';
+
+class TermSelectorAddTerm extends Component {
+	static propTypes = {
+		onSuccess: PropTypes.func,
+		postType: PropTypes.string,
+		taxonomy: PropTypes.string,
+		terms: PropTypes.array,
+		type: PropTypes.string,
+	};
+
+	static defaultProps = {
+		onSuccess: noop,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			showDialog: false,
+		};
+	}
+
+	openDialog = event => {
+		event.preventDefault();
+		this.setState( { showDialog: true } );
+	};
+
+	closeDialog = () => {
+		this.setState( { showDialog: false } );
+	};
+
+	render() {
+		const { siteId, onSuccess, taxonomy, labels, postType } = this.props;
+		return (
+			<div className="term-selector__add-term">
+				{ siteId && <QueryTaxonomies { ...{ siteId, postType } } /> }
+				<Button borderless compact onClick={ this.openDialog }>
+					<Gridicon icon="folder" /> { labels.add_new_item }
+				</Button>
+				<TermFormDialog
+					showDialog={ this.state.showDialog }
+					onClose={ this.closeDialog }
+					postType="product"
+					taxonomy={ taxonomy }
+					onSuccess={ onSuccess }
+					showDescriptionInput
+				/>
+			</div>
+		);
+	}
+}
+
+export default connect( ( state, { postType, taxonomy } ) => {
+	const siteId = getSelectedSiteId( state );
+	const taxonomyDetails = getPostTypeTaxonomy( state, siteId, postType, taxonomy );
+	const labels = get( taxonomyDetails, 'labels', {} );
+
+	return {
+		siteId,
+		labels,
+	};
+} )( TermSelectorAddTerm );

--- a/client/extensions/woocommerce/components/term-selector/index.js
+++ b/client/extensions/woocommerce/components/term-selector/index.js
@@ -1,0 +1,72 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+/**
+ * Internal dependencies
+ */
+import TermTreeSelectorTerms from 'blocks/term-tree-selector/terms';
+import withDimensions from 'lib/with-dimensions';
+
+/**
+ * This is a wrapper around <TermTreeSelectorTerms>
+ * which only accepts a static width. If you resize the window, the display can get warped,
+ * or you can only scroll half the component. This wrapped component uses `withDimensions` to get the width of a sibling node
+ * to pass along.
+ */
+
+class TermSelector extends Component {
+	state = {
+		search: '',
+	};
+
+	onSearch = searchTerm => {
+		if ( searchTerm !== this.state.search ) {
+			this.setState( {
+				search: searchTerm,
+			} );
+		}
+	};
+
+	render() {
+		const { search } = this.state;
+		const query = {};
+		if ( search && search.length ) {
+			query.search = search;
+		}
+
+		return (
+			<Fragment>
+				<div className="term-selector__dimensions" ref={ this.props.setWithDimensionsRef } />
+				<TermTreeSelectorTerms
+					{ ...this.props }
+					height={ 300 }
+					query={ query }
+					onSearch={ this.onSearch }
+				/>
+			</Fragment>
+		);
+	}
+}
+
+TermSelector.propTypes = {
+	hideTermAndChildren: PropTypes.number,
+	terms: PropTypes.array,
+	taxonomy: PropTypes.string,
+	multiple: PropTypes.bool,
+	selected: PropTypes.array,
+	search: PropTypes.string,
+	siteId: PropTypes.number,
+	defaultTermId: PropTypes.number,
+	lastPage: PropTypes.number,
+	onChange: PropTypes.func,
+	isError: PropTypes.bool,
+	width: PropTypes.number,
+	searchThreshold: PropTypes.number,
+	emptyMessage: PropTypes.string,
+};
+
+export default withDimensions( TermSelector );

--- a/client/extensions/woocommerce/components/term-selector/index.js
+++ b/client/extensions/woocommerce/components/term-selector/index.js
@@ -5,9 +5,12 @@
  */
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
+import { omit } from 'lodash';
+
 /**
  * Internal dependencies
  */
+import AddTerm from './add-term';
 import TermTreeSelectorTerms from 'blocks/term-tree-selector/terms';
 import withDimensions from 'lib/with-dimensions';
 
@@ -32,21 +35,24 @@ class TermSelector extends Component {
 	};
 
 	render() {
+		const { taxonomy, postType, onAddTerm, setWithDimensionsRef } = this.props;
 		const { search } = this.state;
 		const query = {};
 		if ( search && search.length ) {
 			query.search = search;
 		}
-
 		return (
 			<Fragment>
-				<div className="term-selector__dimensions" ref={ this.props.setWithDimensionsRef } />
+				<div className="term-selector__dimensions" ref={ setWithDimensionsRef } />
 				<TermTreeSelectorTerms
-					{ ...this.props }
+					{ ...omit( this.props, 'setWithDimensionsRef', 'height', 'showAddTerm', 'onAddTerm' ) }
 					height={ 300 }
 					query={ query }
 					onSearch={ this.onSearch }
 				/>
+				{ this.props.showAddTerm && (
+					<AddTerm postType={ postType } taxonomy={ taxonomy } onSuccess={ onAddTerm } />
+				) }
 			</Fragment>
 		);
 	}
@@ -54,7 +60,10 @@ class TermSelector extends Component {
 
 TermSelector.propTypes = {
 	hideTermAndChildren: PropTypes.number,
+	showAddTerm: PropTypes.bool,
+	onAddTerm: PropTypes.func,
 	terms: PropTypes.array,
+	postType: PropTypes.string,
 	taxonomy: PropTypes.string,
 	multiple: PropTypes.bool,
 	selected: PropTypes.array,

--- a/client/extensions/woocommerce/components/term-selector/style.scss
+++ b/client/extensions/woocommerce/components/term-selector/style.scss
@@ -1,0 +1,5 @@
+.term-selector__dimensions {
+    width: auto;
+    display: block;
+    max-width: 95%;
+}

--- a/client/extensions/woocommerce/components/term-selector/style.scss
+++ b/client/extensions/woocommerce/components/term-selector/style.scss
@@ -2,4 +2,25 @@
     width: auto;
     display: block;
     max-width: 95%;
+    height: 90%;
+
+    @include breakpoint( '660px-960px' ) {
+		max-width: 80%;
+    }
+
+    @include breakpoint( '1040px-1280px' ) {
+        max-width: 90%;
+    }
+}
+
+.term-tree-selector input[type="search"]:focus {
+    border: 1px solid $blue-wordpress;
+	outline: initial;
+    box-shadow: 0 0 0 2px $blue-light;
+}
+
+.term-selector__add-term {
+    border: 1px solid $gray-lighten-20;
+    border-top: 0;
+    padding: 8px;
 }

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -53,6 +53,7 @@
 	@import 'components/sparkline/style';
 	@import 'components/store-address/style';
 	@import 'components/table/style';
+	@import 'components/term-selector/style';
 	@import 'components/widget-group/style';
 
 	@import 'woocommerce-services/style';


### PR DESCRIPTION
It was really bothering me that the product category selector on the product page does not work well with hierarchical categories, and doesn't load all categories.

This branch is my attempt to fix that. See #20339 and #20977 which are both partially fixed by this. I say partially fixed because this fixes the products experience, but not the promotions experience.

It uses the same term selector we are using for product category management, and other management in Calypso.

To make room for this component (since it is bigger then the token component), I moved categories to it's own expandable card, just like attributes. I also moved the "featured" toggle out of the category card and put it under the description.

cc @kellychoffman @jameskoster since there are some big UI changes here.

To Test:
* Test product category selection in both edit and create contexts. Select categories, unselect categories, use the search, etc. Save and make sure selections stick.
* Test the 'featured' toggle to make sure it still works.

<img width="707" alt="screen shot 2018-02-19 at 1 40 08 pm" src="https://user-images.githubusercontent.com/689165/36398146-82a9cf12-157a-11e8-9791-f5fa497f45e2.png">

