### PR TITLE
Change tour zindex

### DIFF
--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -34,6 +34,7 @@ export const ChecklistContactPageTour = makeTour(
 			placement="right"
 			style={ {
 				animationDelay: '0.7s',
+				zIndex: 1,
 			} }
 			when={ isPostEditorSection }
 			canSkip={ false }

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour.js
@@ -67,6 +67,7 @@ export const ChecklistPublishPostTour = makeTour(
 			placement="right"
 			style={ {
 				animationDelay: '0.7s',
+				zIndex: 2,
 			} }
 			when={ inSection( 'post-editor' ) }
 			canSkip={ false }
@@ -96,7 +97,7 @@ export const ChecklistPublishPostTour = makeTour(
 				marginLeft: '-40px',
 			} }
 			wait={ openSidebar }
-			>
+		>
 			<p>
 				{ translate(
 					'Categories and Tags not only help organize your content but also bring people to ' +


### PR DESCRIPTION
Our guided tours appear over our email verification messaging for new users. This PR repositions two guided tours below the email verification message.

## Before
<img width="1767" alt="screen shot 2018-02-01 at 9 52 24 pm" src="https://user-images.githubusercontent.com/6981253/35714528-3ee87306-079b-11e8-9066-432ea60cd66b.png">
<img width="1767" alt="screen shot 2018-02-01 at 9 56 50 pm" src="https://user-images.githubusercontent.com/6981253/35714529-3efe5f68-079b-11e8-80c6-b03929358c8e.png">

## After
<img width="1767" alt="screen shot 2018-02-01 at 9 54 09 pm" src="https://user-images.githubusercontent.com/6981253/35714536-47df728e-079b-11e8-9b09-5ecfc2de2136.png">
<img width="1767" alt="screen shot 2018-02-01 at 9 56 38 pm" src="https://user-images.githubusercontent.com/6981253/35714537-47f3b6c2-079b-11e8-812d-20d34d0fccec.png">

It would be nice to update the messaging if the email is not verified as well as adding a verify email task. But those things could be done in separate PRs.

## Testing
- Create a new account in an incognito window.
- Visit checklist and do contact/blog tasks.
- Guided tours should appear under email verification messaging.

@markryall @taggon 
