### PR TITLE
Update copy

### DIFF
--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -72,13 +72,13 @@ class JetpackNewSite extends Component {
 						<Card className="jetpack-new-site__wpcom-site">
 							<WordPressLogo />
 							<h3 className="jetpack-new-site__card-title">
-								{ this.props.translate( 'Create a new shiny WordPress.com site' ) }
+								{ this.props.translate( 'Create a shiny new WordPress.com site' ) }
 							</h3>
 							<div className="jetpack-new-site__card-description">
 								<p>
 									{ this.props.translate(
-										'Start telling your story in just 2 minutes. Pick a visual theme and a domain — ' +
-											'we’ll take care of the entire setup. If you need help we’ve got you covered with 24/7 support.'
+										"Tell us what type of site you need and we'll get you setup. " +
+											'If you need help we’ve got you covered with 24/7 support.'
 									) }
 								</p>
 							</div>


### PR DESCRIPTION
There is some out of date copy on the site start screen. This PR updates the copy and addresses this isssue: https://github.com/Automattic/wp-calypso/issues/21724

## Before
![image](https://user-images.githubusercontent.com/6981253/35716176-fb4464c0-07a4-11e8-808f-40855b3bcb94.png)

## After
![image](https://user-images.githubusercontent.com/6981253/35716184-118bb7ec-07a5-11e8-908d-5f74a4cd3a2e.png)

## Testing
- View screenshots or visit `/jetpack/new`

@ianstewart can you take a look?