### PR TITLE
Rewind: if it's active/provisioning and user reaches the flow starter, show AL normally

### DIFF
--- a/client/my-sites/stats/activity-log-switch/index.jsx
+++ b/client/my-sites/stats/activity-log-switch/index.jsx
@@ -5,7 +5,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -75,10 +74,7 @@ class ActivityLogSwitch extends Component {
 	}
 
 	render() {
-		if (
-			'vp_active_on_site' === this.props.failureReason ||
-			includes( [ 'uninitialized', 'active', 'provisioning' ], this.props.rewindState )
-		) {
+		if ( 'vp_active_on_site' === this.props.failureReason || 'uninitialized' === this.props.rewindState ) {
 			return false;
 		}
 

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -585,14 +585,15 @@ class ActivityLog extends Component {
 			);
 		}
 
-		const { siteId, context } = this.props;
+		const { siteId, context, rewindState } = this.props;
 
 		const rewindNoThanks = get( context, 'query.rewind-redirect', '' );
+		const rewindIsNotReady = ! includes( [ 'active', 'provisioning' ], rewindState.state );
 
 		return (
 			<Main wideLayout>
 				<QueryRewindState siteId={ siteId } />
-				{ siteId && '' !== rewindNoThanks ? (
+				{ siteId && '' !== rewindNoThanks && rewindIsNotReady ? (
 					<ActivityLogSwitch siteId={ siteId } redirect={ rewindNoThanks } />
 				) : (
 					this.getActivityLog()


### PR DESCRIPTION
This PR fixes an issue where an empty screen was shown when user arrived to the dialog that initiates the setup/switch flow but Rewind was **active** or **provisioning**.
Now the AL will be displayed normally.

#### Before

<img width="742" alt="captura de pantalla 2018-02-02 a la s 01 50 09" src="https://user-images.githubusercontent.com/1041600/35717080-af00ba20-07bb-11e8-9340-a86ce26c96ee.png">

#### After

<img width="730" alt="captura de pantalla 2018-02-02 a la s 01 48 44" src="https://user-images.githubusercontent.com/1041600/35717081-b15e5980-07bb-11e8-9918-9caff4f5299b.png">

### Testing

1. Setup credentials in the site so you ensure that Rewind is active.
2. trigger the flow with a link like 
```
http://calypso.localhost:3000/stats/activity/cool-site.blog?rewind-redirect=admin.php%3Fpage%3Djetpack
```
3. without this PR, the screen will look empty, with only the Jetpack colophon. With this PR, the Activity Log will be displayed