### PR TITLE
Invites: Split invites by pending/accepted status

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -349,11 +349,12 @@
 @import 'my-sites/pages/page-card-info/style';
 @import 'my-sites/people/delete-user/style';
 @import 'my-sites/people/edit-team-member-form/style';
-@import 'my-sites/people/people-invite-details/style';
-@import 'my-sites/people/people-list-item/style';
-@import 'my-sites/people/people-profile/style';
-@import 'my-sites/people/people-notices/style';
 @import 'my-sites/people/invite-people/style';
+@import 'my-sites/people/people-invite-details/style';
+@import 'my-sites/people/people-invites/style';
+@import 'my-sites/people/people-list-item/style';
+@import 'my-sites/people/people-notices/style';
+@import 'my-sites/people/people-profile/style';
 @import 'my-sites/plan-compare-card/style';
 @import 'my-sites/plan-features/style';
 @import 'my-sites/plan-interval-discount/style';

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -46,6 +46,8 @@ $transparent:            rgba(255,255,255,0);
 
 // Uncommon
 $border-ultra-light-gray: #e8f0f5;
+// $green-text-min: minimum contrast needed for WCAG 2.0 AA on white background
+$green-text-min:          darken( $alert-green, 14% ); // #358649
 
 // Layout
 $masterbar-color:          $blue-wordpress;

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -57,7 +57,7 @@
 
 // Clickable Card
 .card__link-indicator {
-	color: lighten( $gray, 20% );
+	color: $gray-text-min;
 	display: block;
 	height: 100%;
 	position: absolute;
@@ -74,7 +74,7 @@
 
 a.card:hover {
 	.card__link-indicator {
-		color: lighten( $gray, 10% );
+		color: $gray-text;
 	}
 }
 

--- a/client/components/data/query-site-invites/README.md
+++ b/client/components/data/query-site-invites/README.md
@@ -36,7 +36,7 @@ function MyInvitesList( { invites } ) {
 export default connect(
 	state => {
 		return {
-			invites: getInvitesForSite( state, SITE_ID ),
+			pendingInvites: getPendingInvitesForSite( state, SITE_ID ),
 		};
 	}
 )( MyInvitesList );

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -105,7 +105,7 @@ class PeopleInviteDetails extends React.PureComponent {
 				<SidebarNavigation />
 
 				<HeaderCake isCompact onClick={ this.goBack }>
-					{ translate( 'Invite' ) }
+					{ translate( 'Invite Details' ) }
 				</HeaderCake>
 
 				{ invite && this.renderInvite() }

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -20,7 +20,7 @@ import Card from 'components/card';
 import PeopleListItem from 'my-sites/people/people-list-item';
 import Gravatar from 'components/gravatar';
 import QuerySiteInvites from 'components/data/query-site-invites';
-import { getSelectedInvite } from 'state/invites/selectors';
+import { getInviteForSite } from 'state/invites/selectors';
 
 class PeopleInviteDetails extends React.PureComponent {
 	static propTypes = {
@@ -118,6 +118,6 @@ export default connect( ( state, ownProps ) => {
 	const siteId = ownProps.site && ownProps.site.ID;
 
 	return {
-		invite: getSelectedInvite( state, siteId, ownProps.inviteKey ),
+		invite: getInviteForSite( state, siteId, ownProps.inviteKey ),
 	};
 } )( localize( PeopleInviteDetails ) );

--- a/client/my-sites/people/people-invite-details/style.scss
+++ b/client/my-sites/people/people-invite-details/style.scss
@@ -11,6 +11,9 @@
 .people-invite-details__meta-item {
 	margin-bottom: 12px;
 	color: $gray-text-min;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 
 	.people-invite-details__meta-item-label {
 		display: inline-block;

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -83,9 +83,7 @@ class PeopleInvites extends React.PureComponent {
 						<Card>{ pendingInvites.map( this.renderInvite ) }</Card>
 					</div>
 				) : (
-					<div className="people-invites__pending">
-						{ this.renderInviteUsersAction( false ) }
-					</div>
+					<div className="people-invites__pending">{ this.renderInviteUsersAction( false ) }</div>
 				) }
 
 				{ hasAcceptedInvites && (
@@ -107,9 +105,7 @@ class PeopleInvites extends React.PureComponent {
 	}
 
 	renderEmptyContent() {
-		return (
-			<EmptyContent title={ null } action={ this.renderInviteUsersAction() } />
-		);
+		return <EmptyContent title={ null } action={ this.renderInviteUsersAction() } />;
 	}
 
 	renderInviteUsersAction( isPrimary = true ) {
@@ -120,10 +116,7 @@ class PeopleInvites extends React.PureComponent {
 				<div className="people-invites__invite-users-message">
 					{ translate( 'Invite people to follow your site or help you manage it.' ) }
 				</div>
-				<Button
-					primary={ isPrimary }
-					href={ `/people/new/${ site.slug }` }
-				>
+				<Button primary={ isPrimary } href={ `/people/new/${ site.slug }` }>
 					<Gridicon icon="user-add" />
 					{ translate( 'Invite user', { context: 'button label' } ) }
 				</Button>

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -62,10 +62,10 @@ class PeopleInvites extends React.PureComponent {
 		} = this.props;
 
 		const hasAcceptedInvites = acceptedInvites && acceptedInvites.length > 0;
-		const acceptedInviteCount = ! requesting && hasAcceptedInvites ? acceptedInvites.length : null;
+		const acceptedInviteCount = hasAcceptedInvites ? acceptedInvites.length : null;
 
 		const hasPendingInvites = pendingInvites && pendingInvites.length > 0;
-		const pendingInviteCount = ! requesting && hasPendingInvites ? pendingInvites.length : null;
+		const pendingInviteCount = hasPendingInvites ? pendingInvites.length : null;
 
 		if ( ! hasPendingInvites && ! hasAcceptedInvites ) {
 			return requesting ? this.renderPlaceholder() : this.renderEmptyContent();

--- a/client/my-sites/people/people-invites/style.scss
+++ b/client/my-sites/people/people-invites/style.scss
@@ -1,0 +1,28 @@
+.people-invites__invite-users-action {
+	.people-invites__invite-users-message {
+		margin-bottom: 16px;
+
+		.empty-content & {
+			font-size: 22px;
+		}
+	}
+
+	.button {
+		padding: 6px 16px 6px 12px;
+
+		.gridicon {
+			margin-right: 8px;
+		}
+	}
+
+	.people-invites__pending & {
+		text-align: center;
+		margin: 50px 0;
+		@include breakpoint( "<960px" ) {
+			margin: 40px 0;
+		}
+		@include breakpoint( "<480px" ) {
+			margin: 30px 0;
+		}
+	}
+}

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -3,13 +3,11 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -81,31 +79,27 @@ class PeopleListItem extends React.PureComponent {
 		this.props.resendInvite( siteId, inviteKey );
 	};
 
-	renderInviteStatus = () => {
+	renderInviteActions = () => {
 		const { invite, translate, requestingResend, resendSuccess } = this.props;
 		const { isPending } = invite;
-		const className = classNames( 'people-list-item__invite-status', {
-			'is-pending': isPending,
-		} );
+
+		if ( ! isPending ) {
+			return null;
+		}
+
 		const buttonClassName = classNames( 'people-list-item__invite-resend', {
 			'is-success': resendSuccess,
 		} );
 
 		return (
-			<div className={ className }>
-				{ ! isPending && <Gridicon icon="checkmark" size={ 18 } /> }
-				{ isPending ? translate( 'Pending' ) : translate( 'Accepted' ) }
-				{ isPending && (
-					<Button
-						className={ buttonClassName }
-						onClick={ this.onResend }
-						busy={ requestingResend }
-						compact
-					>
-						{ resendSuccess ? translate( 'Invite Sent!' ) : translate( 'Resend Invite' ) }
-					</Button>
-				) }
-			</div>
+			<Button
+				className={ buttonClassName }
+				onClick={ this.onResend }
+				busy={ requestingResend }
+				compact
+			>
+				{ resendSuccess ? translate( 'Invite Sent!' ) : translate( 'Resend Invite' ) }
+			</Button>
 		);
 	};
 
@@ -126,7 +120,7 @@ class PeopleListItem extends React.PureComponent {
 					<PeopleProfile invite={ invite } type={ type } user={ user } />
 				</div>
 
-				{ isInvite && this.renderInviteStatus() }
+				{ isInvite && this.renderInviteActions() }
 
 				{ onRemove && (
 					<div className="people-list-item__actions">

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -81,10 +81,11 @@ class PeopleListItem extends React.PureComponent {
 	};
 
 	renderInviteStatus = () => {
-		const { invite, translate, requestingResend, resendSuccess } = this.props;
+		const { type, invite, translate, requestingResend, resendSuccess } = this.props;
 		const { isPending } = invite;
 		const className = classNames( 'people-list-item__invite-status', {
 			'is-pending': isPending,
+			'is-invite-details': type === 'invite-details',
 		} );
 		const buttonClassName = classNames( 'people-list-item__invite-resend', {
 			'is-success': resendSuccess,
@@ -92,8 +93,15 @@ class PeopleListItem extends React.PureComponent {
 
 		return (
 			<div className={ className }>
-				{ ! isPending && <Gridicon icon="checkmark" size={ 18 } /> }
-				{ isPending ? translate( 'Pending' ) : translate( 'Accepted' ) }
+				{ type === 'invite-details' &&
+					( isPending ? (
+						translate( 'Pending' )
+					) : (
+						<React.Fragment>
+							<Gridicon icon="checkmark" size={ 18 } />
+							{ translate( 'Accepted' ) }
+						</React.Fragment>
+					) ) }
 				{ isPending && (
 					<Button
 						className={ buttonClassName }

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -118,13 +118,22 @@ class PeopleListItem extends React.PureComponent {
 
 	render() {
 		const { className, invite, onRemove, translate, type, user } = this.props;
+
+		const isInvite = invite && ( 'invite' === type || 'invite-details' === type );
+
+		const classes = classNames(
+			'people-list-item',
+			{
+				'is-invite': isInvite,
+			},
+			className
+		);
 		const canLinkToProfile = this.canLinkToProfile();
 		const tagName = canLinkToProfile ? 'a' : 'span';
-		const isInvite = invite && ( 'invite' === type || 'invite-details' === type );
 
 		return (
 			<CompactCard
-				className={ classNames( 'people-list-item', className ) }
+				className={ classes }
 				tagName={ tagName }
 				href={ this.maybeGetCardLink() }
 				onClick={ canLinkToProfile && this.navigateToUser }

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -79,27 +80,31 @@ class PeopleListItem extends React.PureComponent {
 		this.props.resendInvite( siteId, inviteKey );
 	};
 
-	renderInviteActions = () => {
+	renderInviteStatus = () => {
 		const { invite, translate, requestingResend, resendSuccess } = this.props;
 		const { isPending } = invite;
-
-		if ( ! isPending ) {
-			return null;
-		}
-
+		const className = classNames( 'people-list-item__invite-status', {
+			'is-pending': isPending,
+		} );
 		const buttonClassName = classNames( 'people-list-item__invite-resend', {
 			'is-success': resendSuccess,
 		} );
 
 		return (
-			<Button
-				className={ buttonClassName }
-				onClick={ this.onResend }
-				busy={ requestingResend }
-				compact
-			>
-				{ resendSuccess ? translate( 'Invite Sent!' ) : translate( 'Resend Invite' ) }
-			</Button>
+			<div className={ className }>
+				{ ! isPending && <Gridicon icon="checkmark" size={ 18 } /> }
+				{ isPending ? translate( 'Pending' ) : translate( 'Accepted' ) }
+				{ isPending && (
+					<Button
+						className={ buttonClassName }
+						onClick={ this.onResend }
+						busy={ requestingResend }
+						compact
+					>
+						{ resendSuccess ? translate( 'Invite Sent!' ) : translate( 'Resend Invite' ) }
+					</Button>
+				) }
+			</div>
 		);
 	};
 
@@ -120,7 +125,7 @@ class PeopleListItem extends React.PureComponent {
 					<PeopleProfile invite={ invite } type={ type } user={ user } />
 				</div>
 
-				{ isInvite && this.renderInviteActions() }
+				{ isInvite && this.renderInviteStatus() }
 
 				{ onRemove && (
 					<div className="people-list-item__actions">

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -125,6 +125,7 @@ class PeopleListItem extends React.PureComponent {
 			'people-list-item',
 			{
 				'is-invite': isInvite,
+				'is-invite-details': type === 'invite-details',
 			},
 			className
 		);

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -107,12 +107,12 @@
 
 .people-list-item__invite-resend {
 	display: none;
-	min-width: 95px;
 	height: 30px;
 	margin-left: 12px;
-	margin-right: 30px;
 	align-self: center;
 	vertical-align: baseline;
+
+	min-width: 100px; // So success notice matches width of the button
 
 	@include breakpoint( '>480px' ) {
 		display: inline-block;

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -107,12 +107,12 @@
 
 .people-list-item__invite-resend {
 	display: none;
+	min-width: 95px;
 	height: 30px;
 	margin-left: 12px;
+	margin-right: 30px;
 	align-self: center;
 	vertical-align: baseline;
-
-	min-width: 100px; // So success notice matches width of the button
 
 	@include breakpoint( '>480px' ) {
 		display: inline-block;
@@ -125,4 +125,3 @@
 		cursor: default;
 	}
 }
-

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -122,10 +122,10 @@
 		}
 	}
 
-	color: darken( $alert-green, 10% );
+	color: $green-text-min;
 
 	&.is-pending {
-		color: darken( $gray, 20% );
+		color: $gray-text-min;
 	}
 
 	.gridicon {

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -87,11 +87,18 @@
 
 .people-list-item__invite-status {
 	align-self: center;
-	display: block;
-	flex-grow: 0;
 	flex-shrink: 0;
-	margin-right: 30px;
 	margin-left: 12px;
+
+	&:not( .is-invite-details ) {
+		// Get out of the way of the link to the invite details page
+		margin-right: 30px;
+
+		// Hide on small screens
+		@include breakpoint( '<480px' ) {
+			display: none;
+		}
+	}
 
 	color: $alert-green;
 
@@ -106,17 +113,11 @@
 }
 
 .people-list-item__invite-resend {
-	display: none;
+	display: inline-block;
+	min-width: 95px;
 	height: 30px;
 	margin-left: 12px;
-	align-self: center;
 	vertical-align: baseline;
-
-	min-width: 100px; // So success notice matches width of the button
-
-	@include breakpoint( '>480px' ) {
-		display: inline-block;
-	}
 
 	&.is-success {
 		background-color: $gray-light;

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -91,6 +91,13 @@
 	}
 }
 
+.people-list-item.is-invite-details {
+	// Make extra space for invite status on small screens
+	@include breakpoint( '<480px' ) {
+		padding-bottom: 34px;
+	}
+}
+
 .people-list-item__invite-status {
 	align-self: center;
 	flex-shrink: 0;
@@ -103,6 +110,15 @@
 		// Hide on small screens
 		@include breakpoint( '<480px' ) {
 			display: none;
+		}
+	}
+
+	&.is-invite-details {
+		// Show below the name and role on small screens
+		@include breakpoint( '<480px' ) {
+			position: absolute;
+			bottom: 4px;
+			margin-left: 80px;
 		}
 	}
 

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -85,6 +85,12 @@
 	z-index: z-index( 'root', '.people-list-item .card__link-indicator' );
 }
 
+.people-list-item.is-invite .people-profile__username {
+	@include breakpoint( '>480px' ) {
+		font-size: 18px;
+	}
+}
+
 .people-list-item__invite-status {
 	align-self: center;
 	flex-shrink: 0;

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -106,10 +106,10 @@
 		}
 	}
 
-	color: $alert-green;
+	color: darken( $alert-green, 10% );
 
 	&.is-pending {
-		color: $gray;
+		color: darken( $gray, 20% );
 	}
 
 	.gridicon {

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -114,6 +114,7 @@ class PeopleProfile extends React.PureComponent {
 		const { translate, type, user } = this.props;
 
 		let name;
+		let userTitle = null;
 		if ( ! user ) {
 			name = translate( 'Loading Users', {
 				context: 'Placeholder text while fetching users.',
@@ -128,22 +129,29 @@ class PeopleProfile extends React.PureComponent {
 			// also be sent to any email address, in which case the other details
 			// will not be set and we therefore display the user's email.
 			name = user.login || user.email;
+			if ( ! user.login ) {
+				// Long email addresses may not show fully in the space provided.
+				userTitle = user.email;
+			}
+		}
+
+		if ( ! name ) {
+			return null;
 		}
 
 		const blogId = get( user, 'follow_data.params.blog_id', false );
 
-		if ( name && blogId ) {
-			name = (
-				<div className="people-profile__username">
+		return (
+			<div className="people-profile__username" title={ userTitle }>
+				{ blogId ? (
 					<a href={ user.url } onClick={ this.handleLinkToReaderSiteStream }>
 						{ decodeEntities( name ) }
 					</a>
-				</div>
-			);
-		} else if ( name ) {
-			name = <div className="people-profile__username">{ decodeEntities( name ) }</div>;
-		}
-		return name;
+				) : (
+					decodeEntities( name )
+				) }
+			</div>
+		);
 	};
 
 	renderLogin = () => {

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -89,7 +89,7 @@
 	background: $white;
 	border: 1px solid $gray;
 	border-radius: 2px;
-	color: $gray;
+	color: $gray-text-min;
 	display: inline-block;
 	font-size: 11px;
 	margin-left: 8px;

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -65,6 +65,8 @@ export const items = createReducer(
 					key: invite.invite_key,
 					role: invite.role,
 					isPending: invite.is_pending,
+					inviteDate: invite.invite_date,
+					acceptedDate: invite.accepted_date,
 					user,
 					invitedBy,
 				};

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -53,23 +53,32 @@ export const items = createReducer(
 	{},
 	{
 		[ INVITES_REQUEST_SUCCESS ]: ( state, action ) => {
+			// Invites are returned from the API in descending order by
+			// `invite_date`, which is what we want here.
+
+			const siteInvites = { pending: [], accepted: [] };
+			action.invites.forEach( invite => {
+				// Not renaming `avatar_URL` because it is used as-is by <Gravatar>
+				const user = pick( invite.user, 'login', 'email', 'name', 'avatar_URL' );
+				const invitedBy = pick( invite.invited_by, 'name', 'login', 'avatar_URL' );
+				const inviteForState = {
+					key: invite.invite_key,
+					role: invite.role,
+					isPending: invite.is_pending,
+					user,
+					invitedBy,
+				};
+
+				if ( inviteForState.isPending ) {
+					siteInvites.pending.push( inviteForState );
+				} else {
+					siteInvites.accepted.push( inviteForState );
+				}
+			} );
+
 			return {
 				...state,
-				[ action.siteId ]: action.invites.map( invite => {
-					// Not renaming `avatar_URL` because it is used as-is by <Gravatar>
-					const user = pick( invite.user, 'login', 'email', 'name', 'avatar_URL' );
-					const invitedBy = pick( invite.invited_by, 'name', 'login', 'avatar_URL' );
-
-					return {
-						key: invite.invite_key,
-						role: invite.role,
-						isPending: invite.is_pending,
-						inviteDate: invite.invite_date,
-						acceptedDate: invite.accepted_date,
-						user,
-						invitedBy,
-					};
-				} ),
+				[ action.siteId ]: siteInvites,
 			};
 		},
 	},

--- a/client/state/invites/schema.js
+++ b/client/state/invites/schema.js
@@ -1,41 +1,51 @@
 /** @format */
 
+const invitesArraySchema = {
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			key: { type: 'string' },
+			role: { type: 'string' },
+			isPending: { type: 'boolean' },
+			inviteDate: { type: 'string' },
+			acceptedDate: { anyOf: [ { type: 'string' }, { enum: [ null ] } ] },
+			user: {
+				type: 'object',
+				properties: {
+					login: { type: 'string' },
+					email: { anyOf: [ { type: 'string' }, { enum: [ false ] } ] },
+					name: { type: 'string' },
+					avatar_URL: { type: 'string' },
+				},
+				additionalProperties: false,
+			},
+			invitedBy: {
+				type: 'object',
+				properties: {
+					login: { type: 'string' },
+					name: { type: 'string' },
+					avatar_URL: { type: 'string' },
+				},
+				additionalProperties: false,
+			},
+		},
+		additionalProperties: false,
+	},
+};
+
 export const inviteItemsSchema = {
 	type: 'object',
 	patternProperties: {
 		// Site ID
 		'^\\d+$': {
-			type: 'array',
-			items: {
-				type: 'object',
-				properties: {
-					key: { type: 'string' },
-					role: { type: 'string' },
-					isPending: { type: 'boolean' },
-					inviteDate: { type: 'string' },
-					acceptedDate: { anyOf: [ { type: 'string' }, { enum: [ null ] } ] },
-					user: {
-						type: 'object',
-						properties: {
-							login: { type: 'string' },
-							email: { anyOf: [ { type: 'string' }, { enum: [ false ] } ] },
-							name: { type: 'string' },
-							avatar_URL: { type: 'string' },
-						},
-						additionalProperties: false,
-					},
-					invitedBy: {
-						type: 'object',
-						properties: {
-							login: { type: 'string' },
-							name: { type: 'string' },
-							avatar_URL: { type: 'string' },
-						},
-						additionalProperties: false,
-					},
-				},
-				additionalProperties: false,
+			type: 'object',
+			properties: {
+				pending: invitesArraySchema,
+				accepted: invitesArraySchema,
 			},
+			required: [ 'pending', 'accepted' ],
+			additionalProperties: false,
 		},
 	},
 };

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -65,20 +65,25 @@ export function getNumberOfInvitesFoundForSite( state, siteId ) {
 	return state.invites.counts[ siteId ] || null;
 }
 
-/*
- * Returns an invite object for the given site and invite ID, or false otherwise.
- *
- * TODO: searching the object can probably be done in a cleaner manner.
+/**
+ * Returns an invite object for the given site and invite ID, or `null` if no
+ * invite with the given ID exists for the site.
  *
  * @param  {Object}  state    Global state tree
  * @param  {Number}  siteId   Site ID
  * @param  {String}  inviteId Invite ID
- * @return {Object}           Invite object
+ * @return {?Object}          Invite object (if found)
  */
-export const getSelectedInvite = treeSelect(
+export const getInviteForSite = treeSelect(
 	( state, siteId ) => [ state.invites.items[ siteId ] ],
 	( [ siteInvites ], siteId, inviteId ) => {
-		return find( siteInvites, { key: inviteId } );
+		if ( ! siteInvites ) {
+			return null;
+		}
+		return (
+			find( siteInvites.pending, { key: inviteId } ) ||
+			find( siteInvites.accepted, { key: inviteId } )
+		);
 	}
 );
 

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -82,7 +82,8 @@ export const getInviteForSite = treeSelect(
 		}
 		return (
 			find( siteInvites.pending, { key: inviteId } ) ||
-			find( siteInvites.accepted, { key: inviteId } )
+			find( siteInvites.accepted, { key: inviteId } ) ||
+			null
 		);
 	}
 );

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -23,19 +23,35 @@ export function isRequestingInvitesForSite( state, siteId ) {
 }
 
 /**
- * Returns an array of all invite objects known for the given site, or `null`
- * if there is no data for that site.
+ * Returns an array of all pending invite objects known for the given site, or
+ * `null` if there is no data for that site.
  *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @return {?Array}         The list of invite objects for the given site
+ * @param  {Object} state  Global state tree
+ * @param  {Number} siteId Site ID
+ * @return {?Array}        The list of pending invites for the given site
  */
-export function getInvitesForSite( state, siteId ) {
+export function getPendingInvitesForSite( state, siteId ) {
 	const invites = state.invites.items[ siteId ];
 	if ( ! invites ) {
 		return null;
 	}
-	return invites;
+	return invites.pending;
+}
+
+/**
+ * Returns an array of all accepted invite objects known for the given site, or
+ * `null` if there is no data for that site.
+ *
+ * @param  {Object} state  Global state tree
+ * @param  {Number} siteId Site ID
+ * @return {?Array}        The list of accepted invites for the given site
+ */
+export function getAcceptedInvitesForSite( state, siteId ) {
+	const invites = state.invites.items[ siteId ];
+	if ( ! invites ) {
+		return null;
+	}
+	return invites.accepted;
 }
 
 /**

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -50,7 +50,7 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#items()', () => {
-		test( 'should key invites by site ID', () => {
+		test( 'should key invites by site ID and pending/accepted status', () => {
 			const state = items(
 				{},
 				{
@@ -77,59 +77,90 @@ describe( 'reducer', () => {
 									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
 							},
 						},
+						{
+							invite_key: 'jkl789asd12345',
+							role: 'subscriber',
+							is_pending: false,
+							user: {
+								login: 'grilledchicken',
+								email: false,
+								name: 'Pollo Asado',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+							},
+						},
 					],
 				}
 			);
 			expect( state ).to.eql( {
-				12345: [
-					{
-						key: '123456asdf789',
-						role: 'follower',
-						isPending: true,
-						inviteDate: '2018-01-28T17:22:16+00:00',
-						acceptedDate: '2018-01-28T17:22:20+00:00',
-						user: {
-							login: 'chicken',
-							email: false,
-							name: 'Pollo',
-							avatar_URL:
-								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+				12345: {
+					pending: [
+						{
+							key: '123456asdf789',
+							role: 'follower',
+							isPending: true,
+							inviteDate: '2018-01-28T17:22:16+00:00',
+							acceptedDate: null,
+							user: {
+								login: 'chicken',
+								email: false,
+								name: 'Pollo',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+							},
+							invitedBy: {
+								login: 'cow',
+								name: 'Vaca',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+							},
 						},
-						invitedBy: {
-							login: 'cow',
-							name: 'Vaca',
-							avatar_URL:
-								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+					],
+					accepted: [
+						{
+							key: 'jkl789asd12345',
+							role: 'subscriber',
+							isPending: false,
+							user: {
+								login: 'grilledchicken',
+								email: false,
+								name: 'Pollo Asado',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+							},
 						},
-					},
-				],
+					],
+				},
 			} );
 		} );
 
 		test( 'should accumulate sites', () => {
 			const original = {
-				12345: [
-					{
-						key: '123456asdf789',
-						role: 'follower',
-						isPending: true,
-						inviteDate: '2018-01-28T17:22:16+00:00',
-						acceptedDate: '2018-01-28T17:22:20+00:00',
-						user: {
-							login: 'chicken',
-							email: false,
-							name: 'Pollo',
-							avatar_URL:
-								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+				12345: {
+					pending: [
+						{
+							key: '123456asdf789',
+							role: 'follower',
+							isPending: true,
+							inviteDate: '2018-01-28T17:22:16+00:00',
+							acceptedDate: null,
+							user: {
+								login: 'chicken',
+								email: false,
+								name: 'Pollo',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+							},
+							invitedBy: {
+								login: 'cow',
+								name: 'Vaca',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+							},
 						},
-						invitedBy: {
-							login: 'cow',
-							name: 'Vaca',
-							avatar_URL:
-								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
-						},
-					},
-				],
+					],
+					accepted: [],
+				},
 			};
 			const state = items( original, {
 				type: INVITES_REQUEST_SUCCESS,
@@ -158,77 +189,107 @@ describe( 'reducer', () => {
 				],
 			} );
 			expect( state ).to.eql( {
-				12345: [
-					{
-						key: '123456asdf789',
-						role: 'follower',
-						isPending: true,
-						inviteDate: '2018-01-28T17:22:16+00:00',
-						acceptedDate: '2018-01-28T17:22:20+00:00',
-						user: {
-							login: 'chicken',
-							email: false,
-							name: 'Pollo',
-							avatar_URL:
-								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+				12345: {
+					pending: [
+						{
+							key: '123456asdf789',
+							role: 'follower',
+							isPending: true,
+							inviteDate: '2018-01-28T17:22:16+00:00',
+							acceptedDate: null,
+							user: {
+								login: 'chicken',
+								email: false,
+								name: 'Pollo',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+							},
+							invitedBy: {
+								login: 'cow',
+								name: 'Vaca',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+							},
 						},
-						invitedBy: {
-							login: 'cow',
-							name: 'Vaca',
-							avatar_URL:
-								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+					],
+					accepted: [],
+				},
+				67890: {
+					pending: [
+						{
+							key: '9876fdas54321',
+							role: 'follower',
+							isPending: true,
+							inviteDate: '2018-01-28T17:22:16+00:00',
+							acceptedDate: null,
+							user: {
+								login: 'celery',
+								email: false,
+								name: 'Apio',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+							},
+							invitedBy: {
+								login: 'cow',
+								name: 'Vaca',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+							},
 						},
-					},
-				],
-				67890: [
-					{
-						key: '9876fdas54321',
-						role: 'follower',
-						isPending: true,
-						inviteDate: '2018-01-28T17:22:16+00:00',
-						acceptedDate: '2018-01-28T17:22:20+00:00',
-						user: {
-							login: 'celery',
-							email: false,
-							name: 'Apio',
-							avatar_URL:
-								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
-						},
-						invitedBy: {
-							login: 'cow',
-							name: 'Vaca',
-							avatar_URL:
-								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
-						},
-					},
-				],
+					],
+					accepted: [],
+				},
 			} );
 		} );
 
 		test( 'should persist state', () => {
 			const original = deepFreeze( {
-				12345: [
-					{
-						key: '123456asdf789',
-						role: 'follower',
-						isPending: true,
-						inviteDate: '2018-01-28T17:22:16+00:00',
-						acceptedDate: '2018-01-28T17:22:20+00:00',
-						user: {
-							login: 'chicken',
-							email: false,
-							name: 'Pollo',
-							avatar_URL:
-								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+				12345: {
+					pending: [
+						{
+							key: '123456asdf789',
+							role: 'follower',
+							isPending: true,
+							inviteDate: '2018-01-28T17:22:16+00:00',
+							acceptedDate: null,
+							user: {
+								login: 'chicken',
+								email: false,
+								name: 'Pollo',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+							},
+							invitedBy: {
+								login: 'cow',
+								name: 'Vaca',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+							},
 						},
-						invitedBy: {
-							login: 'cow',
-							name: 'Vaca',
-							avatar_URL:
-								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+					],
+					accepted: [
+						{
+							key: 'jkl789asd12345',
+							role: 'subscriber',
+							isPending: false,
+							inviteDate: '2018-01-28T17:22:16+00:00',
+							acceptedDate: '2018-01-28T17:22:20+00:00',
+							user: {
+								login: 'grilledchicken',
+								email: false,
+								name: 'Pollo Asado',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+							},
+							invitedBy: {
+								login: 'cow',
+								name: 'Vaca',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+							},
 						},
-					},
-				],
+					],
+				},
 			} );
 			const state = items( original, { type: SERIALIZE } );
 
@@ -237,28 +298,44 @@ describe( 'reducer', () => {
 
 		test( 'should load valid persisted state', () => {
 			const original = deepFreeze( {
-				12345: [
-					{
-						key: '123456asdf789',
-						role: 'follower',
-						isPending: true,
-						inviteDate: '2018-01-28T17:22:16+00:00',
-						acceptedDate: '2018-01-28T17:22:20+00:00',
-						user: {
-							login: 'chicken',
-							email: false,
-							name: 'Pollo',
-							avatar_URL:
-								'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+				12345: {
+					pending: [
+						{
+							key: '123456asdf789',
+							role: 'follower',
+							isPending: true,
+							inviteDate: '2018-01-28T17:22:16+00:00',
+							acceptedDate: null,
+							user: {
+								login: 'chicken',
+								email: false,
+								name: 'Pollo',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+							},
+							invitedBy: {
+								login: 'cow',
+								name: 'Vaca',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+							},
 						},
-						invitedBy: {
-							login: 'cow',
-							name: 'Vaca',
-							avatar_URL:
-								'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+					],
+					accepted: [
+						{
+							key: 'jkl789asd12345',
+							role: 'subscriber',
+							isPending: false,
+							user: {
+								login: 'grilledchicken',
+								email: false,
+								name: 'Pollo Asado',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+							},
 						},
-					},
-				],
+					],
+				},
 			} );
 			const state = items( original, { type: DESERIALIZE } );
 
@@ -272,29 +349,32 @@ describe( 'reducer', () => {
 
 			test( 'should not load invalid persisted state (1)', () => {
 				const original = deepFreeze( {
-					12345: [
-						{
-							key: '123456asdf789',
-							role: 'follower',
-							isPending: true,
-							inviteDate: '2018-01-28T17:22:16+00:00',
-							acceptedDate: '2018-01-28T17:22:20+00:00',
-							user: {
-								login: 'chicken',
-								email: false,
-								name: 'Pollo',
-								avatar_URL:
-									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+					12345: {
+						pending: [
+							{
+								key: '123456asdf789',
+								role: 'follower',
+								isPending: true,
+								inviteDate: '2018-01-28T17:22:16+00:00',
+								acceptedDate: null,
+								user: {
+									login: 'chicken',
+									email: false,
+									name: 'Pollo',
+									avatar_URL:
+										'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+								},
+								invitedBy: {
+									login: 'cow',
+									name: 'Vaca',
+									avatar_URL:
+										'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+								},
+								hasExtraInvalidProperty: true,
 							},
-							invitedBy: {
-								login: 'cow',
-								name: 'Vaca',
-								avatar_URL:
-									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
-							},
-							hasExtraInvalidProperty: true,
-						},
-					],
+						],
+						accepted: [],
+					},
 				} );
 				const state = items( original, { type: DESERIALIZE } );
 
@@ -303,28 +383,49 @@ describe( 'reducer', () => {
 
 			test( 'should not load invalid persisted state (2)', () => {
 				const original = deepFreeze( {
-					12345: [
-						{
-							key: '123456asdf789',
-							role: 'follower',
-							isPending: null,
-							inviteDate: '2018-01-28T17:22:16+00:00',
-							acceptedDate: '2018-01-28T17:22:20+00:00',
-							user: {
-								login: 'chicken',
-								email: false,
-								name: 'Pollo',
-								avatar_URL:
-									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+					12345: {
+						pending: [],
+						accepted: [
+							{
+								key: '123456asdf789',
+								role: 'follower',
+								isPending: null,
+								inviteDate: '2018-01-28T17:22:16+00:00',
+								acceptedDate: '2018-01-28T17:22:20+00:00',
+								user: {
+									login: 'chicken',
+									email: false,
+									name: 'Pollo',
+									avatar_URL:
+										'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+								},
+								invitedBy: {
+									login: 'cow',
+									name: 'Vaca',
+									avatar_URL:
+										'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+								},
 							},
-							invitedBy: {
-								login: 'cow',
-								name: 'Vaca',
-								avatar_URL:
-									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
-							},
-						},
-					],
+						],
+					},
+				} );
+				const state = items( original, { type: DESERIALIZE } );
+
+				expect( state ).to.eql( {} );
+			} );
+
+			test( 'should not load invalid persisted state (3)', () => {
+				const original = deepFreeze( {
+					12345: { pending: [] /* accepted: missing */ },
+				} );
+				const state = items( original, { type: DESERIALIZE } );
+
+				expect( state ).to.eql( {} );
+			} );
+
+			test( 'should not load invalid persisted state (4)', () => {
+				const original = deepFreeze( {
+					12345: { pending: [], accepted: [], fileNotFound: [] },
 				} );
 				const state = items( original, { type: DESERIALIZE } );
 

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -62,7 +62,7 @@ describe( 'reducer', () => {
 							role: 'follower',
 							is_pending: true,
 							invite_date: '2018-01-28T17:22:16+00:00',
-							accepted_date: '2018-01-28T17:22:20+00:00',
+							accepted_date: null,
 							user: {
 								login: 'chicken',
 								email: false,
@@ -81,12 +81,20 @@ describe( 'reducer', () => {
 							invite_key: 'jkl789asd12345',
 							role: 'subscriber',
 							is_pending: false,
+							invite_date: '2018-01-28T17:22:16+00:00',
+							accepted_date: '2018-01-28T17:22:20+00:00',
 							user: {
 								login: 'grilledchicken',
 								email: false,
 								name: 'Pollo Asado',
 								avatar_URL:
 									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+							},
+							invited_by: {
+								login: 'cow',
+								name: 'Vaca',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
 							},
 						},
 					],
@@ -121,12 +129,20 @@ describe( 'reducer', () => {
 							key: 'jkl789asd12345',
 							role: 'subscriber',
 							isPending: false,
+							inviteDate: '2018-01-28T17:22:16+00:00',
+							acceptedDate: '2018-01-28T17:22:20+00:00',
 							user: {
 								login: 'grilledchicken',
 								email: false,
 								name: 'Pollo Asado',
 								avatar_URL:
 									'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+							},
+							invitedBy: {
+								login: 'cow',
+								name: 'Vaca',
+								avatar_URL:
+									'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
 							},
 						},
 					],
@@ -171,7 +187,7 @@ describe( 'reducer', () => {
 						role: 'follower',
 						is_pending: true,
 						invite_date: '2018-01-28T17:22:16+00:00',
-						accepted_date: '2018-01-28T17:22:20+00:00',
+						accepted_date: null,
 						user: {
 							login: 'celery',
 							email: false,

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -16,7 +16,7 @@ import {
 	isRequestingResend,
 	getNumberOfInvitesFoundForSite,
 	didResendSucceed,
-	getSelectedInvite,
+	getInviteForSite,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -197,7 +197,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getSelectedInvite()', () => {
+	describe( '#getInviteForSite()', () => {
 		beforeAll( () => {
 			sinon.spy( lodash, 'find' );
 		} );
@@ -210,33 +210,36 @@ describe( 'selectors', () => {
 			const state = {
 				invites: {
 					items: {
-						12345: [
-							{
-								key: '123456asdf789',
-								role: 'follower',
-								isPending: null,
-								inviteDate: '2018-01-28T17:22:16+00:00',
-								acceptedDate: '2018-01-28T17:22:20+00:00',
-								user: {
-									login: 'chicken',
-									email: false,
-									name: 'Pollo',
-									avatar_URL:
-										'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+						12345: {
+							pending: [
+								{
+									key: '123456asdf789',
+									role: 'follower',
+									isPending: true,
+									inviteDate: '2018-01-28T17:22:16+00:00',
+									acceptedDate: null,
+									user: {
+										login: 'chicken',
+										email: false,
+										name: 'Pollo',
+										avatar_URL:
+											'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+									},
+									invitedBy: {
+										login: 'cow',
+										name: 'Vaca',
+										avatar_URL:
+											'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+									},
 								},
-								invitedBy: {
-									login: 'cow',
-									name: 'Vaca',
-									avatar_URL:
-										'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
-								},
-							},
-						],
+							],
+							accepted: [],
+						},
 					},
 				},
 			};
-			expect( getSelectedInvite( state, 12345, '123456asdf789' ) ).to.eql(
-				state.invites.items[ 12345 ][ 0 ]
+			expect( getInviteForSite( state, 12345, '123456asdf789' ) ).to.equal(
+				state.invites.items[ 12345 ].pending[ 0 ]
 			);
 		} );
 
@@ -244,50 +247,59 @@ describe( 'selectors', () => {
 			const state = {
 				invites: {
 					items: {
-						12345: [
-							{
-								key: '123456asdf789',
-								role: 'follower',
-								isPending: null,
-								inviteDate: '2018-01-28T17:22:16+00:00',
-								acceptedDate: '2018-01-28T17:22:20+00:00',
-								user: {
-									login: 'chicken',
-									email: false,
-									name: 'Pollo',
-									avatar_URL:
-										'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+						12345: {
+							pending: [],
+							accepted: [
+								{
+									key: '123456asdf789',
+									role: 'follower',
+									isPending: false,
+									inviteDate: '2018-01-28T17:22:16+00:00',
+									acceptedDate: '2018-01-28T17:22:20+00:00',
+									user: {
+										login: 'chicken',
+										email: false,
+										name: 'Pollo',
+										avatar_URL:
+											'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+									},
+									invitedBy: {
+										login: 'cow',
+										name: 'Vaca',
+										avatar_URL:
+											'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+									},
 								},
-								invitedBy: {
-									login: 'cow',
-									name: 'Vaca',
-									avatar_URL:
-										'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
-								},
-							},
-						],
+							],
+						},
 					},
 				},
 			};
+
 			expect( lodash.find.callCount ).to.equal( 0 );
-			const call1 = getSelectedInvite( state, 12345, '123456asdf789' );
-			expect( lodash.find.callCount ).to.equal( 1 );
-			const call2 = getSelectedInvite( state, 12345, '123456asdf789' );
-			expect( lodash.find.callCount ).to.equal( 1 );
-			expect( call1 ).to.equal( call2 );
-			const newState = lodash.cloneDeep( state );
-			const call3 = getSelectedInvite( newState, 12345, '123456asdf789' );
+
+			const call1 = getInviteForSite( state, 12345, '123456asdf789' );
 			expect( lodash.find.callCount ).to.equal( 2 );
+			expect( call1 ).to.equal( state.invites.items[ 12345 ].accepted[ 0 ] );
+
+			const call2 = getInviteForSite( state, 12345, '123456asdf789' );
+			expect( lodash.find.callCount ).to.equal( 2 );
+			expect( call1 ).to.equal( call2 );
+
+			const newState = lodash.cloneDeep( state );
+			const call3 = getInviteForSite( newState, 12345, '123456asdf789' );
+			expect( lodash.find.callCount ).to.equal( 4 );
+			expect( call3 ).to.equal( newState.invites.items[ 12345 ].accepted[ 0 ] );
 			expect( call3 ).not.to.equal( call2 );
 		} );
 
-		test( 'should return undefined when invites do not exist for site', () => {
+		test( 'should return null when invites do not exist for site', () => {
 			const state = {
 				invites: {
 					items: {},
 				},
 			};
-			expect( getSelectedInvite( state, 12345, '123456asdf789' ) ).to.equal( undefined );
+			expect( getInviteForSite( state, 12345, '123456asdf789' ) ).to.equal( null );
 		} );
 	} );
 

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -301,6 +301,41 @@ describe( 'selectors', () => {
 			};
 			expect( getInviteForSite( state, 12345, '123456asdf789' ) ).to.equal( null );
 		} );
+
+		test( 'should return null if the given invite key is not valid for site', () => {
+			const state = {
+				invites: {
+					items: {
+						12345: {
+							pending: [
+								{
+									key: '123456asdf789',
+									role: 'follower',
+									isPending: true,
+									inviteDate: '2018-01-28T17:22:16+00:00',
+									acceptedDate: null,
+									user: {
+										login: 'chicken',
+										email: false,
+										name: 'Pollo',
+										avatar_URL:
+											'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+									},
+									invitedBy: {
+										login: 'cow',
+										name: 'Vaca',
+										avatar_URL:
+											'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+									},
+								},
+							],
+							accepted: [],
+						},
+					},
+				},
+			};
+			expect( getInviteForSite( state, 12345, '123456asdf000' ) ).to.equal( null );
+		} );
 	} );
 
 	describe( '#isRequestingResend()', () => {

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -11,7 +11,8 @@ import lodash from 'lodash';
  */
 import {
 	isRequestingInvitesForSite,
-	getInvitesForSite,
+	getPendingInvitesForSite,
+	getAcceptedInvitesForSite,
 	isRequestingResend,
 	getNumberOfInvitesFoundForSite,
 	didResendSucceed,
@@ -54,46 +55,145 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#getInvitesForSite()', () => {
-		test( 'should return invites when invites exist for site', () => {
+	describe( '#getPendingInvitesForSite()', () => {
+		test( 'should return invites when pending invites exist for site', () => {
 			const state = {
 				invites: {
 					items: {
-						12345: [
-							{
-								key: '123456asdf789',
-								role: 'follower',
-								isPending: null,
-								inviteDate: '2018-01-28T17:22:16+00:00',
-								acceptedDate: '2018-01-28T17:22:20+00:00',
-								user: {
-									login: 'chicken',
-									email: false,
-									name: 'Pollo',
-									avatar_URL:
-										'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+						12345: {
+							pending: [
+								{
+									key: '123456asdf789',
+									role: 'follower',
+									isPending: true,
+									inviteDate: '2018-01-28T17:22:16+00:00',
+									acceptedDate: null,
+									user: {
+										login: 'chicken',
+										email: false,
+										name: 'Pollo',
+										avatar_URL:
+											'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+									},
+									invitedBy: {
+										login: 'cow',
+										name: 'Vaca',
+										avatar_URL:
+											'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
+									},
 								},
-								invitedBy: {
-									login: 'cow',
-									name: 'Vaca',
-									avatar_URL:
-										'https://2.gravatar.com/avatar/e2c5df270c7adcd0f6a70fa9cfde7d0f?s=96&d=identicon&r=G',
-								},
-							},
-						],
+							],
+							accepted: [],
+						},
 					},
 				},
 			};
-			expect( getInvitesForSite( state, 12345 ) ).to.eql( state.invites.items[ 12345 ] );
+			expect( getPendingInvitesForSite( state, 12345 ) ).to.eql(
+				state.invites.items[ 12345 ].pending
+			);
 		} );
 
-		test( 'should return null when invites do not exist for site', () => {
+		test( 'should return an empty array if no pending invites for site', () => {
+			const state = {
+				invites: {
+					items: {
+						12345: {
+							pending: [],
+							accepted: [
+								{
+									key: 'jkl789asd12345',
+									role: 'subscriber',
+									isPending: false,
+									user: {
+										login: 'grilledchicken',
+										email: false,
+										name: 'Pollo Asado',
+										avatar_URL:
+											'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+									},
+								},
+							],
+						},
+					},
+				},
+			};
+			expect( getPendingInvitesForSite( state, 12345 ) ).to.eql( [] );
+		} );
+
+		test( 'should return null if no invites for site', () => {
 			const state = {
 				invites: {
 					items: {},
 				},
 			};
-			expect( getInvitesForSite( state, 12345 ) ).to.equal( null );
+			expect( getPendingInvitesForSite( state, 12345 ) ).to.equal( null );
+		} );
+	} );
+
+	describe( '#getAcceptedInvitesForSite()', () => {
+		test( 'should return invites when accepted invites exist for site', () => {
+			const state = {
+				invites: {
+					items: {
+						12345: {
+							pending: [],
+							accepted: [
+								{
+									key: 'jkl789asd12345',
+									role: 'subscriber',
+									isPending: false,
+									user: {
+										login: 'grilledchicken',
+										email: false,
+										name: 'Pollo Asado',
+										avatar_URL:
+											'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+									},
+								},
+							],
+						},
+					},
+				},
+			};
+			expect( getAcceptedInvitesForSite( state, 12345 ) ).to.eql(
+				state.invites.items[ 12345 ].accepted
+			);
+		} );
+
+		test( 'should return an empty array if no accepted invites for site', () => {
+			const state = {
+				invites: {
+					items: {
+						12345: {
+							pending: [
+								{
+									key: '123456asdf789',
+									role: 'follower',
+									isPending: true,
+									user: {
+										login: 'chicken',
+										email: false,
+										name: 'Pollo',
+										avatar_URL:
+											'https://2.gravatar.com/avatar/eba3ff8480f481053bbd52b2a08c6136?s=96&d=identicon&r=G',
+									},
+								},
+							],
+							accepted: [],
+						},
+					},
+				},
+			};
+			expect( getAcceptedInvitesForSite( state, 12345 ) ).to.eql( [] );
+		} );
+
+		test( 'should return null if no invites for site', () => {
+			const state = {
+				invites: {
+					items: {},
+				},
+			};
+			expect( getAcceptedInvitesForSite( state, 12345 ) ).to.equal( null );
 		} );
 	} );
 


### PR DESCRIPTION
This PR will modify the Invites section of People (behind the `manage/people/invites` feature flag for now) to split accepted from pending invites.

The initial version of the PR restructures the Redux state to store invites split by `pending` and `accepted`, so that we don't have to perform this calculation in a selector.