### PR TITLE
Tighten up Community Translator's appearance logic

### DIFF
--- a/client/layout/community-translator/invitation-utils.js
+++ b/client/layout/community-translator/invitation-utils.js
@@ -44,6 +44,15 @@ const debug = Debug( 'calypso:community-translator-invitation' ),
 		'ar',
 		'sv',
 	];
+const visibileSectionWhitelist = [
+	'comments',
+	'people',
+	'plugins',
+	'posts-pages',
+	'settings',
+	'sharing',
+	'stats',
+];
 let invitationPending = store.get( 'calypsoTranslatorInvitationIsPending' );
 
 function maybeInvite() {
@@ -68,7 +77,7 @@ function maybeInvite() {
 		return;
 	}
 
-	if ( includes( excludedLocales, locale ) ) {
+	if ( ! locale || includes( excludedLocales, locale ) ) {
 		debug( 'Not inviting because of user locale', locale );
 		return;
 	}
@@ -89,10 +98,8 @@ const invitationUtils = {
 		return invitationPending;
 	},
 
-	// The calypso editor is styled flush to the top, and makes the invitation
-	// look bad, so don't show it there
 	isValidSection: function( section ) {
-		return section !== 'post';
+		return includes( visibileSectionWhitelist, section );
 	},
 
 	dismiss: function() {


### PR DESCRIPTION
This PR changes the community translator invitation's visibility from using a blacklist to a whitelist, significantly reducing where it will appear.

We're not in any rush to show the invitation, it's just hard to stumble across. We continue to check until the user interacts with it (accept or reject), so we can afford to be quite conservative with where we show it.

In addition, we're adding new contexts all the time. This PR was prompted by a request to turn off the invitation during jetpack connection, which didn't exist at the time the invitation was written.

For the whitelist, I've started with the the top-level pages you can reach from "My Sites", and excluded "View Site", "Plan", "Media" and "Themes" because these are very visual displays that suffer more from the lost space.

I also excluded "domains" because of a quirk where the domains tab in Plans page uses the same section name, so leaving it out avoids an unpleasant jump changing tabs there.

The other change is to add a check for an empty user locale. Normally, this should be impossible as a user is initialized with a locale, but something in the jetpack connect process can result in a user with an undefined locale:

![community-translator-locale-undefined](https://user-images.githubusercontent.com/5952255/35718641-2c800a4e-0831-11e8-8513-4acd8f2671fe.jpg)

You can test the new behaviour by:
1. `localStorage.setItem( 'calypsoTranslatorInvitationIsPending', true );`
2. Refreshing the page

This will bypass the checks for locale and previous interactions with the invitation and show you where it appears or not. (Just click "No thanks" to get rid of it forever.)

I would expect this change to have realtively little impact on the invitations activity or effectiveness - it will just be displayed a few clicks later for most users, and we can check the `calypso_community_translator_invitation_displayed` and `calypso_community_translator_invitation_accepted` later to make sure.
