### PR TITLE
Disable the Community Translator Invitation

### DIFF
--- a/client/layout/community-translator/invitation-utils.js
+++ b/client/layout/community-translator/invitation-utils.js
@@ -45,8 +45,10 @@ const debug = Debug( 'calypso:community-translator-invitation' ),
 		'sv',
 	];
 let invitationPending = store.get( 'calypsoTranslatorInvitationIsPending' );
+invitationPending = false;
 
 function maybeInvite() {
+	return false;
 	const preferences = preferencesStore.getAll(),
 		locale = user.get().localeSlug;
 


### PR DESCRIPTION
It became apparent during #22082 that this code is in pretty bad, so this PR is an alternative to that one that simply disables the invitation completely as a precursor to a re-write.