### PR TITLE
Add Switch Site keyboard shortcut

### DIFF
--- a/client/lib/keyboard-shortcuts/global.js
+++ b/client/lib/keyboard-shortcuts/global.js
@@ -10,6 +10,9 @@ import page from 'page';
 import config from 'config';
 import { getStatsDefaultSitePage } from 'lib/route';
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
+import { reduxDispatch, reduxGetState } from 'lib/redux-bridge';
+import { getSectionGroup } from 'state/ui/selectors';
+import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 
 let singleton;
 
@@ -33,6 +36,7 @@ GlobalShortcuts.prototype.bindShortcuts = function() {
 	KeyboardShortcuts.on( 'open-help', this.openHelp.bind( this ) );
 	KeyboardShortcuts.on( 'go-to-reader', this.goToReader.bind( this ) );
 	KeyboardShortcuts.on( 'go-to-my-likes', this.goToMyLikes.bind( this ) );
+	KeyboardShortcuts.on( 'open-site-selector', this.openSiteSelector.bind( this ) );
 	KeyboardShortcuts.on( 'go-to-stats', this.goToStats.bind( this ) );
 	KeyboardShortcuts.on( 'go-to-blog-posts', this.goToBlogPosts.bind( this ) );
 	KeyboardShortcuts.on( 'go-to-pages', this.goToPages.bind( this ) );
@@ -47,8 +51,17 @@ GlobalShortcuts.prototype.setSelectedSite = function( site ) {
 };
 
 GlobalShortcuts.prototype.openHelp = function() {
+	// the inline help component is responsible for injecting this
 	if ( this.showInlineHelp ) {
 		this.showInlineHelp();
+	}
+};
+
+GlobalShortcuts.prototype.openSiteSelector = function() {
+	if ( 'sites' === getSectionGroup( reduxGetState() ) ) {
+		reduxDispatch( setLayoutFocus( 'sites' ) );
+	} else {
+		page( '/sites' );
 	}
 };
 

--- a/client/lib/keyboard-shortcuts/key-bindings.js
+++ b/client/lib/keyboard-shortcuts/key-bindings.js
@@ -79,6 +79,15 @@ const KEY_BINDINGS = {
 			},
 		},
 		{
+			eventName: 'open-site-selector',
+			keys: [ 'g', 'w' ],
+			type: 'sequence',
+			description: {
+				keys: [ 'g', 'w' ],
+				text: translate( 'Switch Site' ),
+			},
+		},
+		{
 			eventName: 'go-to-stats',
 			keys: [ 'g', 's' ],
 			type: 'sequence',


### PR DESCRIPTION
`gw` shows the site selector when under My Sites, otherwise opens `/sites`

The biggest design decision was to `redux-bridge` to be able to interact
with the redux state & actions. I am bit conflicted, so here is what else
I considered:

0. Mimic inline-help and let the component being shown inject a method.

In my world, the components shouldn’t know that they’re participating in
any keyboard shortcut shenanigans.

1. Mimic tracking other state changes.

Let the middleware be responsible for keeping the shortcuts state
up to date. Unfortunately we also need to dispatch.

2. Move the shortcuts initialization out of the middleware.

We can do it when we create the store and keep a reference here. Doesn’t seem much
different than using `redux-bridge`.