### PR TITLE
Checklist: Do not show checklist in some flows.

### DIFF
--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -303,13 +303,6 @@ const Checkout = createReactClass( {
 			return '/checkout/thank-you/features';
 		}
 
-		if (
-			this.props.isEligibleForCheckoutToChecklist &&
-			'show' === abtest( 'checklistThankYouForPaidUser' )
-		) {
-			return `/checklist/${ selectedSiteSlug }/paid`;
-		}
-
 		if ( domainReceiptId && receiptId && abtest( 'gsuiteUpsellV2' ) === 'modified' ) {
 			return `/checkout/thank-you/${ selectedSiteSlug }/${ domainReceiptId }/with-gsuite/${ receiptId }`;
 		}
@@ -329,6 +322,13 @@ const Checkout = createReactClass( {
 					domainsForGsuite[ 0 ].meta
 				}/${ receiptId }`;
 			}
+		}
+
+		if (
+			this.props.isEligibleForCheckoutToChecklist &&
+			'show' === abtest( 'checklistThankYouForPaidUser' )
+		) {
+			return `/checklist/${ selectedSiteSlug }/paid`;
 		}
 
 		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -475,6 +475,7 @@ class Signup extends React.Component {
 						user={ this.state.user }
 						loginHandler={ this.state.loginHandler }
 						signupDependencies={ this.props.signupDependencies }
+						flowName={ this.props.flowName }
 						flowSteps={ flow.steps }
 					/>
 				) : (

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -293,7 +293,11 @@ export class SignupProcessingScreen extends Component {
 			return accumulator || ( step.providedDependencies && step.providedDependencies.designType );
 		}, null );
 
-		return config.isEnabled( 'onboarding-checklist' ) && 'blog' === designType;
+		return (
+			config.isEnabled( 'onboarding-checklist' ) &&
+			'blog' === designType &&
+			[ 'personal', 'premium', 'business' ].indexOf( this.props.flowName ) === -1
+		);
 	}
 
 	renderActionButton() {


### PR DESCRIPTION
The onboarding checklist should *NOT* show up in some flows such as `personal`, `premium` and `business`, it should take you to the cart after the site creation completes.

## Test plan

1. Create a new website from one of the below entry points:
  * `/start/personal`
  * `/start/premium`
  * `/start/business`
2. The last step of the site creation flow should be the cart instead of the thank you page with the onboarding checklist.