### PR TITLE
Add `data-e2e-link` attributes to 2fa options.

### DIFF
--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -109,7 +109,7 @@
 }
 
 .wp-login__links {
-	a {
+	a, button {
 		font-size: 14px;
 
 		&:hover {
@@ -133,6 +133,15 @@
 
 .card.two-factor-authentication__form-action {
 	background: $white;
+
+	button {
+		color: $link-highlight;
+		cursor: pointer;
+
+		&:hover {
+			color: $blue-medium;
+		}
+	}
 }
 
 .two-factor-authentication__small-print {

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -64,7 +64,7 @@ class TwoFactorActions extends Component {
 
 				{ isSmsAvailable && (
 					<p>
-						<a href="#" onClick={ this.sendSmsCode }>
+						<a href="#" data-e2e-link="2fa-sms-link" onClick={ this.sendSmsCode }>
 							{ translate( 'Code via text message' ) }
 						</a>
 					</p>
@@ -72,7 +72,7 @@ class TwoFactorActions extends Component {
 
 				{ isAuthenticatorAvailable && (
 					<p>
-						<a href="#" onClick={ this.recordAuthenticatorLinkClick }>
+						<a href="#" data-e2e-link="2fa-otp-link" onClick={ this.recordAuthenticatorLinkClick }>
 							{ translate( 'Your authenticator app' ) }
 						</a>
 					</p>

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -64,17 +64,17 @@ class TwoFactorActions extends Component {
 
 				{ isSmsAvailable && (
 					<p>
-						<a href="#" data-e2e-link="2fa-sms-link" onClick={ this.sendSmsCode }>
+						<button data-e2e-link="2fa-sms-link" onClick={ this.sendSmsCode }>
 							{ translate( 'Code via text message' ) }
-						</a>
+						</button>
 					</p>
 				) }
 
 				{ isAuthenticatorAvailable && (
 					<p>
-						<a href="#" data-e2e-link="2fa-otp-link" onClick={ this.recordAuthenticatorLinkClick }>
+						<button data-e2e-link="2fa-otp-link" onClick={ this.recordAuthenticatorLinkClick }>
 							{ translate( 'Your authenticator app' ) }
-						</a>
+						</button>
 					</p>
 				) }
 			</Card>

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -122,7 +122,12 @@ export class LoginLinks extends React.Component {
 		}
 
 		return (
-			<a href="#" key="lost-phone-link" onClick={ this.handleLostPhoneLinkClick }>
+			<a
+				href="#"
+				key="lost-phone-link"
+				data-e2e-link="lost-phone-link"
+				onClick={ this.handleLostPhoneLinkClick }
+			>
 				{ this.props.translate( "I can't access my phone" ) }
 			</a>
 		);

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -122,14 +122,13 @@ export class LoginLinks extends React.Component {
 		}
 
 		return (
-			<a
-				href="#"
+			<button
 				key="lost-phone-link"
 				data-e2e-link="lost-phone-link"
 				onClick={ this.handleLostPhoneLinkClick }
 			>
 				{ this.props.translate( "I can't access my phone" ) }
-			</a>
+			</button>
 		);
 	}
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -23,19 +23,23 @@ $image-height: 47px;
 
 .wp-login__links,
 .wp-login__footer {
-	a {
+	a, button {
 		color: darken( $gray, 20% );
 		text-decoration: none;
 	}
 }
 
 .wp-login__links {
-	a {
+	a, button {
 		border-bottom: 1px solid lighten( $gray, 20% );
+		box-sizing: border-box;
+		cursor: pointer;
 		display: block;
 		font-weight: 500;
 		line-height: 4em;
 		padding: 0 24px;
+		text-align: left;
+		width: 100%;
 	}
 
 	a:last-of-type {


### PR DESCRIPTION
We need attributes to grab 2fa links on the 2fa login page from wp-e2e-tests.
See Automattic/wp-e2e-tests#906

### Testing Instructions
- Boot the branch
- Go to the login page, inspect the page and check that the "Email me a login link" as a `data-e2e-link` attribute
- Login with a 2fa account with a valid number, check that both options (text and authenticator) have a `data-e2e-link` attribute.

### Reviews
- [x] Code
- [x] Product