### PR TITLE
Jetpack Connect: Don't show auth button once connection complete

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -635,12 +635,12 @@ export class JetpackAuthorize extends Component {
 	}
 
 	renderStateAction() {
-		const { authorizeSuccess, siteReceived } = this.props.authorizationData;
+		const { authorizeSuccess } = this.props.authorizationData;
 		if (
 			this.props.isFetchingAuthorizationSite ||
 			this.isAuthorizing() ||
 			this.retryingAuth ||
-			( authorizeSuccess && ! siteReceived )
+			authorizeSuccess
 		) {
 			return (
 				<div className="jetpack-connect__logged-in-form-loading">


### PR DESCRIPTION
Instead of showing an active button after auth is complete, let the spinner display while the redirect occurs. This is especially noticeable in the mobile app flow.

Found during mobile app testing: p5T066-AH-p2

**Before**
![auth_button_before](https://user-images.githubusercontent.com/7767559/35730533-ca5d24aa-0812-11e8-892f-278f82a5840e.gif)

**After**
![auth_button_after](https://user-images.githubusercontent.com/7767559/35730537-cf548e12-0812-11e8-8280-ae8e075b1a47.gif)

## Testing
Test the jetpack connection flow, starting at:
`http://calypso.localhost:3000/jetpack/connect`
or, for mobile app:
`http://calypso.localhost:3000/jetpack/connect?mobile_redirect=wordpress://jetpack-connection`
or from wp-admin

The _Finishing up!_ spinner should show until arriving at the plans page, or forever in the mobile app flow (the app will take over in the real flow).
