### PR TITLE
Jetpack Connect: Simplify plugin install instructions

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -390,9 +390,7 @@ export class JetpackConnectMain extends Component {
 				NOT_JETPACK === status
 					? translate( 'Ready for installation' )
 					: translate( 'Ready for activation' ),
-			headerSubtitle: translate(
-				"We'll need to send you to your site dashboard for a few manual steps."
-			),
+			headerSubtitle: translate( "We'll need you to complete a few manual steps." ),
 			steps:
 				NOT_JETPACK === status
 					? [ 'installJetpack', 'activateJetpackAfterInstall', 'connectJetpackAfterInstall' ]


### PR DESCRIPTION
Remove some technical language from the installation instructions during the jetpack connection process to better reflect the flow. Found during testing of the mobile app connection flow: p5T066-AH-p2

Before: _We'll need to send you to your site dashboard for a few manual steps._
After: _We'll need you to complete a few manual steps._

**Before/After**
 <img width="200" alt="screen shot 2018-02-02 at 15 39 38" src="https://user-images.githubusercontent.com/7767559/35738524-68c7780e-082f-11e8-8fcc-ce60af5387fa.png"> <img width="200" alt="screen shot 2018-02-02 at 15 38 24" src="https://user-images.githubusercontent.com/7767559/35738529-6af40b10-082f-11e8-8c74-e8068111f617.png">



## Testing
* Connect a .org site _without_ the jetpack plugin installed by going to calypso.localhost:3000/jetpack/connect and entering the URL
