### PR TITLE
JP Onboarding: Homepage Step: Don't call method when re-rendering

### DIFF
--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -19,7 +19,7 @@ import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingHomepageStep extends React.PureComponent {
-	handleHomepageSelection = homepageFormat => {
+	handleHomepageSelection = homepageFormat => () => {
 		const { siteId } = this.props;
 
 		this.props.recordJpoEvent( 'calypso_jpo_homepage_format_clicked', {

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -26,11 +26,9 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 			homepageFormat,
 		} );
 
-		return () => {
-			this.props.saveJetpackOnboardingSettings( siteId, {
-				homepageFormat,
-			} );
-		};
+		this.props.saveJetpackOnboardingSettings( siteId, {
+			homepageFormat,
+		} );
 	};
 
 	render() {


### PR DESCRIPTION
Discovered here: https://github.com/Automattic/wp-calypso/pull/21907#issuecomment-362608494

> I discovered a bug while testing this: The `calypso_jpo_homepage_format_clicked` event is fired (multiple times!) as soon as the homepage format step is loaded. This is because we're missing a level of indirection here https://github.com/Automattic/wp-calypso/blob/0b6000693a4095688b700914c6a316096a7ff5ca/client/jetpack-onboarding/steps/homepage.jsx#L22 which means the method is executed https://github.com/Automattic/wp-calypso/blob/0b6000693a4095688b700914c6a316096a7ff5ca/client/jetpack-onboarding/steps/homepage.jsx#L60 whenever the component is re-rendered.
> 
> Compare that to https://github.com/Automattic/wp-calypso/blob/0b6000693a4095688b700914c6a316096a7ff5ca/client/jetpack-onboarding/steps/site-type.jsx#L22 which has an additional `() =>`.

To test: Go thru the JPO Flow until you hit the 'Let's shape your new site' step. Verify that the `calypso_jpo_homepage_format_clicked` event isn't called immediately (nor multiple times), but only upon clicking either of the homepage format buttons (note you'll see two events however, one `called with props`, and one `with actual props`).