### PR TITLE
Post Normalizer: Deduce height & width for Photon images

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -3,6 +3,7 @@
  * External Dependencies
  */
 import { find, forEach, some, endsWith, findIndex } from 'lodash';
+import qs from 'qs';
 import url from 'url';
 
 /**
@@ -248,6 +249,22 @@ export function deduceImageWidthAndHeight( image ) {
 			height,
 		};
 	}
+
+	let parsed;
+	try {
+		parsed = url.parse( image.src );
+	} catch ( e ) {
+		return null;
+	}
+
+	if ( isPhotonHost( parsed.host ) ) {
+		const queryArgs = qs.parse( parsed.query );
+		return {
+			width: queryArgs.w,
+			height: queryArgs.h,
+		};
+	}
+
 	return null;
 }
 


### PR DESCRIPTION
I noticed for my personal Jetpack site, the Posts List was not showing "canonical" images for some posts. It turns out, `isCandidateForCanonicalImage` was [returning false](https://github.com/Automattic/wp-calypso/blob/6f67b1f16c0e4091e22c4b232cb7080b6a71330d/client/lib/post-normalizer/utils.js#L192) because the media were not annotated with size info for images loaded from the [Photon](https://developer.wordpress.com/docs/photon/) CDN.

This updates `deduceImageWidthAndHeight` to pull the info out of the Photon query arguments if present (if they have not been deduced by other means).

## Before

<img width="741" alt="screen shot 2018-02-02 at 11 08 51 am" src="https://user-images.githubusercontent.com/1587282/35747288-b6aeb518-0817-11e8-955b-0b3bcd696e52.png">

## After

<img width="740" alt="screen shot 2018-02-02 at 12 45 04 pm" src="https://user-images.githubusercontent.com/1587282/35747292-bbb33386-0817-11e8-8dca-5f5a5e446648.png">

## To Test

* Apply branch
* Browse to the posts lists: `/posts/`
* Select a Jetpack site with some recent posts without a "featured image" / thumbnail
* You should see thumbnails (where previously there would not be).
