### PR TITLE
Rewind Credentials: Allow creds type to fill with FTP instead of SSH

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -105,8 +105,7 @@ export class RewindCredentialsForm extends Component {
 		const nextForm = Object.assign( {}, this.state.form );
 
 		// Populate the fields with data from state if credentials are already saved
-		nextForm.protocol =
-			isEmpty( nextForm.protocol ) && credentials ? credentials.protocol : nextForm.protocol;
+		nextForm.protocol = credentials ? credentials.type : nextForm.protocol;
 		nextForm.host = isEmpty( nextForm.host ) && credentials ? credentials.host : nextForm.host;
 		nextForm.port = isEmpty( nextForm.port ) && credentials ? credentials.port : nextForm.port;
 		nextForm.user = isEmpty( nextForm.user ) && credentials ? credentials.user : nextForm.user;


### PR DESCRIPTION
Currently, even if you have FTP type credentials, the form will reflect SSH after you save and reload. This is due to `isEmpty()` not tripping for the protocol field, as well as an inconsistency in the protocol property name. It should be `credentials.type`, not `credentials.protocol`.

**Testing instructions**
Save some FTP credentials in the form, reload the page, observe that FTP is retained and shows in the form. Also, make sure that no other parts of the form are affected and everything is working as expected.