### PR TITLE
Purchases: clean up Atomic cancelation dialog

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -462,7 +462,7 @@ class RemovePurchase extends Component {
 				<p>
 					{ translate(
 						'To cancel your %(productName)s plan, please contact our support team' +
-							'-- a Happiness Engineer will take care of it.',
+							' — a Happiness Engineer will take care of it.',
 						{
 							args: { productName },
 						}


### PR DESCRIPTION
The replaces the `--` with a proper `—` and adds the back a missing whitespace.

![screen shot 2018-02-02 at 11 27 51 am](https://user-images.githubusercontent.com/744755/35751129-272d199e-080c-11e8-9e21-50807e32ad78.png)

cc @lancewillett 