### PR TITLE
Site Settings: Jetpack: Update lazy images description to match marketing

### DIFF
--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -87,7 +87,7 @@ class SpeedUpSiteSettings extends Component {
 							<JetpackModuleToggle
 								siteId={ siteId }
 								moduleSlug="lazy-images"
-								label={ translate( '"Lazy-load" images' ) }
+								label={ translate( 'Lazy load images' ) }
 								description={ translate(
 									"Improve your site's speed by only loading images visible on the screen. New images will " +
 										'load just before they scroll into view. This prevents viewers from having to download ' +


### PR DESCRIPTION
For the Jetpack 5.8 release, our marketing is going to be using the phrase "Lazy load images".

See: p9mQOq-hy-ps
See: Automattic/jetpack#8747

This PR updates the module description to match what marketing is using.

To test:

- Checkout branch
- Ensure that you have a connected Jetpack site with the latest beta
- Go to `/settings/writing/$site_slug`
- Ensure that the phrasing is correct

Screenshot:

<img width="767" alt="screen shot 2018-02-02 at 1 56 36 pm" src="https://user-images.githubusercontent.com/1126811/35752317-13c533f4-0821-11e8-8f1c-b9fc225530e8.png">

