### PR TITLE
Reader: use 1.2 api for following and a8cfollowing

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -83,7 +83,7 @@ class ReaderCombinedCard extends React.Component {
 		const siteName = getSiteName( { site, post: posts[ 0 ] } );
 		const isSelectedPost = post => keysAreEqual( keyForPost( post ), selectedPostKey );
 		const followUrl = ( feed && feed.URL ) || ( site && site.URL );
-		const mediaCount = filter( posts, post => ! isEmpty( post.canonical_media ) ).length;
+		const mediaCount = filter( posts, post => post && ! isEmpty( post.canonical_media ) ).length;
 
 		return (
 			<Card className="reader-combined-card">
@@ -118,9 +118,9 @@ class ReaderCombinedCard extends React.Component {
 						) }
 				</header>
 				<ul className="reader-combined-card__post-list">
-					{ posts.map( post => (
+					{ posts.map( ( post, i ) => (
 						<ReaderCombinedCardPost
-							key={ `post-${ post.ID }` }
+							key={ `post-${ i }-${ post && post.ID }` }
 							post={ post }
 							streamUrl={ streamUrl }
 							onClick={ onClick }

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -118,9 +118,9 @@ class ReaderCombinedCard extends React.Component {
 						) }
 				</header>
 				<ul className="reader-combined-card__post-list">
-					{ posts.map( post => (
+					{ posts.map( ( post, i ) => (
 						<ReaderCombinedCardPost
-							key={ `post-${ postKey.feedId || postKey.blogId }-${ postKey.postId }` }
+							key={ `post-${ postKey.feedId || postKey.blogId }-${ postKey.postIds[ i ] }` }
 							post={ post }
 							streamUrl={ streamUrl }
 							onClick={ onClick }

--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -118,9 +118,9 @@ class ReaderCombinedCard extends React.Component {
 						) }
 				</header>
 				<ul className="reader-combined-card__post-list">
-					{ posts.map( ( post, i ) => (
+					{ posts.map( post => (
 						<ReaderCombinedCardPost
-							key={ `post-${ i }-${ post && post.ID }` }
+							key={ `post-${ postKey.feedId || postKey.blogId }-${ postKey.postId }` }
 							post={ post }
 							streamUrl={ streamUrl }
 							onClick={ onClick }

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -22,13 +22,12 @@ import { recordPermalinkClick } from 'reader/stats';
 import TimeSince from 'components/time-since';
 import ReaderFeaturedImage from 'blocks/reader-featured-image';
 import ReaderFeaturedVideo from 'blocks/reader-featured-video';
-import * as stats from 'reader/stats';
 import ReaderCombinedCardPostPlaceholder from 'blocks/reader-combined-card/placeholders/post';
 import { isAuthorNameBlacklisted } from 'reader/lib/author-name-blacklist';
 
 class ReaderCombinedCardPost extends React.Component {
 	static propTypes = {
-		post: PropTypes.object.isRequired,
+		post: PropTypes.object,
 		streamUrl: PropTypes.string,
 		onClick: PropTypes.func,
 		showFeaturedAsset: PropTypes.bool,
@@ -45,7 +44,7 @@ class ReaderCombinedCardPost extends React.Component {
 		// if the click has modifier or was not primary, ignore it
 		if ( event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey ) {
 			if ( closest( event.target, '.reader-combined-card__post-title-link', true, rootNode ) ) {
-				stats.recordPermalinkClick( 'card_title_with_modifier', this.props.post );
+				recordPermalinkClick( 'card_title_with_modifier', this.props.post );
 			}
 			return;
 		}

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -88,7 +88,7 @@ function addMetaToNextPageFetch( params ) {
 }
 
 function limitSiteParams( params ) {
-	params.fields = 'ID,site_ID,date';
+	params.fields = 'ID,site_ID,date,feed_ID,feed_item_ID';
 }
 
 function limitSiteParamsForLikes( params ) {

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -88,7 +88,7 @@ function addMetaToNextPageFetch( params ) {
 }
 
 function limitSiteParams( params ) {
-	params.fields = 'ID,site_ID,date,feed_ID,feed_item_ID';
+	params.fields = 'ID,site_ID,date,feed_ID,feed_item_ID,global_ID';
 }
 
 function limitSiteParamsForLikes( params ) {

--- a/client/lib/feed-stream-store/post-key.js
+++ b/client/lib/feed-stream-store/post-key.js
@@ -1,5 +1,9 @@
 /** @format */
 export function keyForPost( post ) {
+	if ( ! post ) {
+		return;
+	}
+
 	if ( post.feed_ID && post.feed_item_ID ) {
 		return {
 			feedId: post.feed_ID,
@@ -22,7 +26,7 @@ export function keysAreEqual( a, b ) {
 	if ( a === b ) {
 		return true;
 	}
-	if ( ( ! a && b ) || ( a && ! b ) ) {
+	if ( ( ! a && b ) || ( a && ! b ) || ( ! a && ! b && a !== b ) ) {
 		return false;
 	}
 	if ( ( a.isGap && ! b.isGap ) || ( ! a.isGap && b.isGap ) ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1236,14 +1236,14 @@ function addReaderContentWidth( params ) {
 
 Undocumented.prototype.readFollowing = function( query, fn ) {
 	debug( '/read/following' );
-	query.apiVersion = '1.3';
+	query.apiVersion = '1.2';
 	addReaderContentWidth( query );
 	return this.wpcom.req.get( '/read/following', query, fn );
 };
 
 Undocumented.prototype.readA8C = function( query, fn ) {
 	debug( '/read/a8c' );
-	query.apiVersion = '1.3';
+	query.apiVersion = '1.2';
 	addReaderContentWidth( query );
 	return this.wpcom.req.get( '/read/a8c', query, fn );
 };
@@ -1317,11 +1317,7 @@ Undocumented.prototype.readSearch = function( query, fn ) {
 Undocumented.prototype.readTagPosts = function( query, fn ) {
 	var params = omit( query, 'tag' );
 	debug( '/read/tags/' + query.tag + '/posts' );
-	if ( config.isEnabled( 'reader/tags-with-elasticsearch' ) ) {
-		params.apiVersion = '1.3';
-	} else {
-		params.apiVersion = '1.2';
-	}
+	params.apiVersion = '1.2';
 	addReaderContentWidth( params );
 
 	return this.wpcom.req.get(

--- a/config/development.json
+++ b/config/development.json
@@ -144,7 +144,6 @@
 		"reader/related-posts": true,
 		"reader/search": true,
 		"reader/high-watermark": true,
-		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,
 		"republicize": true,
 		"restore-last-location": false,

--- a/config/production.json
+++ b/config/production.json
@@ -101,7 +101,6 @@
 		"reader/full-errors": false,
 		"reader/nesting-arrow": true,
 		"reader/new-post-notifications": true,
-		"reader/tags-with-elasticsearch": false,
 		"reader/related-posts": true,
 		"reader/search": true,
 		"resume-editing": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -106,7 +106,6 @@
 		"reader/new-post-notifications": true,
 		"reader/recommendations/posts": true,
 		"reader/related-posts": true,
-		"reader/tags-with-elasticsearch": false,
 		"reader/search": true,
 		"resume-editing": true,
 		"republicize": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -115,7 +115,6 @@
 		"reader/related-posts": true,
 		"reader/search": true,
 		"reader/high-watermark": true,
-		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,
 		"republicize": true,
 		"restore-last-location": false,


### PR DESCRIPTION
Following in the footsteps of https://github.com/Automattic/wp-calypso/pull/18931, it'll be good if we use the same api consistently.

To test:
Following and A8C Streams.  Particularly:
- loading the stream
- clicking gaps and pills (use the at= notation to trigger it faster)