### PR TITLE
Traffic settings: trim Google Analytics Tracking ID

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -60,7 +60,7 @@ class GoogleAnalyticsForm extends Component {
 	};
 
 	handleCodeChange = event => {
-		const code = event.target.value;
+		const code = event.target.value.trim();
 
 		this.setState( {
 			isCodeValid: validateGoogleAnalyticsCode( code ),


### PR DESCRIPTION
Trim whitespace from "Google Analytics Tracking ID" input value.

You know, it's _sooooo_ easy and annoying to slip in a space when copy-pasting the ID from somewhere... :-)

<img width="323" alt="screen shot 2018-02-03 at 01 57 43" src="https://user-images.githubusercontent.com/87168/35760015-0e2d1b36-0886-11e8-9f65-613387c66cbd.png">

## Testing
- Have a site with the Business/Pro plan.
- Go to `http://calypso.localhost:3000/settings/traffic/:site`
- Copy this to GA input: UA-12345678-0&nbsp;👈 that space!

**Before:** ⚠️ 
**After:** 🙌 