### PR TITLE
Domains: Add path for precheck page

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -50,7 +50,7 @@ class TransferDomainStep extends React.Component {
 		initialQuery: PropTypes.string,
 		isSignupStep: PropTypes.bool,
 		onRegisterDomain: PropTypes.func,
-		onTransferDomain: PropTypes.func.isRequired,
+		onTransferDomain: PropTypes.func,
 		onSave: PropTypes.func,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		forcePrecheck: PropTypes.bool,
@@ -242,6 +242,10 @@ class TransferDomainStep extends React.Component {
 			searchQuery,
 		} = this.state;
 
+		const onSetValid = this.props.forcePrecheck
+			? this.startPendingInboundTransfer
+			: this.props.onTransferDomain;
+
 		return (
 			<div>
 				{ inboundTransferStartError && this.startTransferErrorNotice() }
@@ -254,7 +258,7 @@ class TransferDomainStep extends React.Component {
 					privacy={ inboundTransferStatus.privacy }
 					refreshStatus={ this.getInboundTransferStatus }
 					selectedSiteId={ get( this.props, 'selectedSite.ID', null ) }
-					setValid={ this.startPendingInboundTransfer }
+					setValid={ onSetValid }
 					supportsPrivacy={ this.state.supportsPrivacy }
 					unlocked={ inboundTransferStatus.unlocked }
 				/>

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -213,9 +213,8 @@ class TransferDomainStep extends React.Component {
 		);
 	}
 
-	startPendingInboundTransfer = transferInfo => {
-		const { domain, selectedSite } = transferInfo;
-		const { translate } = this.props;
+	startPendingInboundTransfer = domain => {
+		const { selectedSite, translate } = this.props;
 
 		startInboundTransfer( selectedSite.ID, domain, ( error, result ) => {
 			if ( result ) {
@@ -235,21 +234,19 @@ class TransferDomainStep extends React.Component {
 			: this.props.onTransferDomain;
 
 		return (
-			<div>
-				<TransferDomainPrecheck
-					domain={ domain || searchQuery }
-					email={ inboundTransferStatus.email }
-					loading={ submittingWhois }
-					losingRegistrar={ inboundTransferStatus.losingRegistrar }
-					losingRegistrarIanaId={ inboundTransferStatus.losingRegistrarIanaId }
-					privacy={ inboundTransferStatus.privacy }
-					refreshStatus={ this.getInboundTransferStatus }
-					selectedSite={ this.props.selectedSite }
-					setValid={ onSetValid }
-					supportsPrivacy={ this.state.supportsPrivacy }
-					unlocked={ inboundTransferStatus.unlocked }
-				/>
-			</div>
+			<TransferDomainPrecheck
+				domain={ domain || searchQuery }
+				email={ inboundTransferStatus.email }
+				loading={ submittingWhois }
+				losingRegistrar={ inboundTransferStatus.losingRegistrar }
+				losingRegistrarIanaId={ inboundTransferStatus.losingRegistrarIanaId }
+				privacy={ inboundTransferStatus.privacy }
+				refreshStatus={ this.getInboundTransferStatus }
+				selectedSiteSlug={ get( this.props, 'selectedSite.slug', null ) }
+				setValid={ onSetValid }
+				supportsPrivacy={ this.state.supportsPrivacy }
+				unlocked={ inboundTransferStatus.unlocked }
+			/>
 		);
 	}
 

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -392,7 +392,7 @@ class TransferDomainStep extends React.Component {
 				} );
 
 				if ( this.props.isSignupStep && ! this.transferIsRestricted() ) {
-					this.props.onTransferDomain( { domain } );
+					this.props.onTransferDomain( domain );
 				}
 			}
 		);

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -222,19 +222,10 @@ class TransferDomainStep extends React.Component {
 				fetchDomains( domain );
 				page( domainManagementTransferIn( selectedSite.slug, domain ) );
 			} else {
-				this.props.errorNotice(
-					error.message || translate( 'We were unable to start the transfer.' )
-				);
+				this.props.errorNotice( error || translate( 'We were unable to start the transfer.' ) );
 			}
 		} );
 	};
-
-	startTransferErrorNotice() {
-		const { inboundTransferStartError } = this.state;
-		if ( inboundTransferStartError ) {
-			return <Notice text={ inboundTransferStartError } status="is-error" showDismiss={ false } />;
-		}
-	}
 
 	getTransferDomainPrecheck() {
 		const { domain, inboundTransferStatus, submittingWhois, searchQuery } = this.state;

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -33,7 +33,7 @@ class TransferDomainPrecheck extends React.Component {
 		losingRegistrar: PropTypes.string,
 		losingRegistrarIanaId: PropTypes.string,
 		privacy: PropTypes.bool,
-		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
+		selectedSiteSlug: PropTypes.string,
 		setValid: PropTypes.func,
 		supportsPrivacy: PropTypes.bool,
 		unlocked: PropTypes.bool,
@@ -59,17 +59,11 @@ class TransferDomainPrecheck extends React.Component {
 	}
 
 	onClick = () => {
-		const {
-			losingRegistrar,
-			losingRegistrarIanaId,
-			domain,
-			supportsPrivacy,
-			selectedSite,
-		} = this.props;
+		const { losingRegistrar, losingRegistrarIanaId, domain, supportsPrivacy } = this.props;
 
 		this.props.recordContinueButtonClick( domain, losingRegistrar, losingRegistrarIanaId );
 
-		this.props.setValid( { domain, selectedSite, supportsPrivacy } );
+		this.props.setValid( domain, supportsPrivacy );
 	};
 
 	resetSteps = () => {

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -33,7 +33,7 @@ class TransferDomainPrecheck extends React.Component {
 		losingRegistrar: PropTypes.string,
 		losingRegistrarIanaId: PropTypes.string,
 		privacy: PropTypes.bool,
-		selectedSiteSlug: PropTypes.string,
+		selectedSiteId: PropTypes.number,
 		setValid: PropTypes.func,
 		supportsPrivacy: PropTypes.bool,
 		unlocked: PropTypes.bool,
@@ -59,11 +59,17 @@ class TransferDomainPrecheck extends React.Component {
 	}
 
 	onClick = () => {
-		const { losingRegistrar, losingRegistrarIanaId, domain, supportsPrivacy } = this.props;
+		const {
+			losingRegistrar,
+			losingRegistrarIanaId,
+			domain,
+			supportsPrivacy,
+			selectedSiteId,
+		} = this.props;
 
 		this.props.recordContinueButtonClick( domain, losingRegistrar, losingRegistrarIanaId );
 
-		this.props.setValid( domain, supportsPrivacy );
+		this.props.setValid( { domain, selectedSiteId, supportsPrivacy } );
 	};
 
 	resetSteps = () => {
@@ -129,6 +135,9 @@ class TransferDomainPrecheck extends React.Component {
 		} else if ( false === unlocked ) {
 			heading = translate( 'Unlock the domain.' );
 		}
+		if ( loading ) {
+			heading = translate( 'Checking domain lock status.' );
+		}
 
 		let message = translate(
 			"{{notice}}We couldn't get the lock status of your domain from your current registrar.{{/notice}} If you're sure your " +
@@ -168,6 +177,10 @@ class TransferDomainPrecheck extends React.Component {
 					},
 				}
 			);
+		}
+
+		if ( loading ) {
+			message = translate( 'Please wait while we check the lock staus of your domain.' );
 		}
 
 		const buttonText = translate( "I've unlocked my domain" );

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -33,7 +33,7 @@ class TransferDomainPrecheck extends React.Component {
 		losingRegistrar: PropTypes.string,
 		losingRegistrarIanaId: PropTypes.string,
 		privacy: PropTypes.bool,
-		selectedSiteId: PropTypes.number,
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		setValid: PropTypes.func,
 		supportsPrivacy: PropTypes.bool,
 		unlocked: PropTypes.bool,
@@ -64,12 +64,12 @@ class TransferDomainPrecheck extends React.Component {
 			losingRegistrarIanaId,
 			domain,
 			supportsPrivacy,
-			selectedSiteId,
+			selectedSite,
 		} = this.props;
 
 		this.props.recordContinueButtonClick( domain, losingRegistrar, losingRegistrarIanaId );
 
-		this.props.setValid( { domain, selectedSiteId, supportsPrivacy } );
+		this.props.setValid( { domain, selectedSite, supportsPrivacy } );
 	};
 
 	resetSteps = () => {
@@ -135,7 +135,7 @@ class TransferDomainPrecheck extends React.Component {
 		} else if ( false === unlocked ) {
 			heading = translate( 'Unlock the domain.' );
 		}
-		if ( loading ) {
+		if ( loading && ! isStepFinished ) {
 			heading = translate( 'Checking domain lock status.' );
 		}
 
@@ -179,7 +179,7 @@ class TransferDomainPrecheck extends React.Component {
 			);
 		}
 
-		if ( loading ) {
+		if ( loading && ! isStepFinished ) {
 			message = translate( 'Please wait while we check the lock staus of your domain.' );
 		}
 

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -27,6 +27,7 @@ import MapDomain from 'my-sites/domains/map-domain';
 import TransferDomain from 'my-sites/domains/transfer-domain';
 import TransferDomainStep from 'components/domains/transfer-domain-step';
 import GoogleApps from 'components/upgrades/google-apps';
+import { domainManagementTransferIn } from 'my-sites/domains/paths';
 
 /**
  * Module variables
@@ -119,13 +120,24 @@ const transferDomain = ( context, next ) => {
 
 const transferDomainPrecheck = ( context, next ) => {
 	const basePath = sectionify( context.path );
+	const state = context.store.getState();
+	const siteSlug = getSelectedSiteSlug( state ) || '';
+	const domain = get( context, 'params.domain', '' );
+
+	const handleGoBack = () => {
+		page( domainManagementTransferIn( siteSlug, domain ) );
+	};
 
 	analytics.pageView.record( basePath, 'My Sites > Domains > Selected Domain' );
 	context.primary = (
 		<Main>
 			<CartData>
 				<div>
-					<TransferDomainStep forcePrecheck={ true } initialQuery={ context.params.domain } />
+					<TransferDomainStep
+						forcePrecheck={ true }
+						initialQuery={ domain }
+						goBack={ handleGoBack }
+					/>
 				</div>
 			</CartData>
 		</Main>

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -25,7 +25,10 @@ import DomainSearch from './domain-search';
 import SiteRedirect from './domain-search/site-redirect';
 import MapDomain from 'my-sites/domains/map-domain';
 import TransferDomain from 'my-sites/domains/transfer-domain';
+import TransferDomainStep from 'components/domains/transfer-domain-step';
 import GoogleApps from 'components/upgrades/google-apps';
+// TODO: Uncomment this after merging in other PR
+// import { startInboundTransfer } from 'lib/domains';
 
 /**
  * Module variables
@@ -110,6 +113,42 @@ const transferDomain = ( context, next ) => {
 			<DocumentHead title={ translate( 'Transfer a Domain' ) } />
 			<CartData>
 				<TransferDomain basePath={ basePath } initialQuery={ context.query.initialQuery } />
+			</CartData>
+		</Main>
+	);
+	next();
+};
+
+const transferDomainPrecheck = ( context, next ) => {
+	const basePath = sectionify( context.path );
+
+	const goBack = () => {
+		// TODO: Add goBack functionality
+	};
+
+	const onTransferDomain = transferInfo => {
+		const { domain, selectedSiteId } = transferInfo;
+		// startInboundTransfer( selectedSiteId, domain, ( error, result ) => {
+		// 	if ( result ) {
+		// 		// TODO: Load next steps page page
+		// 	} else {
+		// 		// TODO: Show error notice
+		// 	}
+		// } );
+	};
+
+	analytics.pageView.record( basePath, 'My Sites > Domains > Selected Domain' );
+	context.primary = (
+		<Main>
+			<CartData>
+				<div>
+					<TransferDomainStep
+						forcePrecheck={ true }
+						goBack={ goBack }
+						initialQuery={ context.params.domain }
+						onTransferDomain={ onTransferDomain }
+					/>
+				</div>
 			</CartData>
 		</Main>
 	);
@@ -201,4 +240,5 @@ export default {
 	redirectIfNoSite,
 	redirectToAddMappingIfVipSite,
 	transferDomain,
+	transferDomainPrecheck,
 };

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -27,8 +27,7 @@ import MapDomain from 'my-sites/domains/map-domain';
 import TransferDomain from 'my-sites/domains/transfer-domain';
 import TransferDomainStep from 'components/domains/transfer-domain-step';
 import GoogleApps from 'components/upgrades/google-apps';
-// TODO: Uncomment this after merging in other PR
-// import { startInboundTransfer } from 'lib/domains';
+import { startInboundTransfer } from 'lib/domains';
 
 /**
  * Module variables
@@ -128,13 +127,13 @@ const transferDomainPrecheck = ( context, next ) => {
 
 	const onTransferDomain = transferInfo => {
 		const { domain, selectedSiteId } = transferInfo;
-		// startInboundTransfer( selectedSiteId, domain, ( error, result ) => {
-		// 	if ( result ) {
-		// 		// TODO: Load next steps page page
-		// 	} else {
-		// 		// TODO: Show error notice
-		// 	}
-		// } );
+		startInboundTransfer( selectedSiteId, domain, ( error, result ) => {
+			if ( result ) {
+				// TODO: Load next steps page page
+			} else {
+				// TODO: Show error notice
+			}
+		} );
 	};
 
 	analytics.pageView.record( basePath, 'My Sites > Domains > Selected Domain' );

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -27,7 +27,6 @@ import MapDomain from 'my-sites/domains/map-domain';
 import TransferDomain from 'my-sites/domains/transfer-domain';
 import TransferDomainStep from 'components/domains/transfer-domain-step';
 import GoogleApps from 'components/upgrades/google-apps';
-import { startInboundTransfer } from 'lib/domains';
 
 /**
  * Module variables
@@ -121,32 +120,12 @@ const transferDomain = ( context, next ) => {
 const transferDomainPrecheck = ( context, next ) => {
 	const basePath = sectionify( context.path );
 
-	const goBack = () => {
-		// TODO: Add goBack functionality
-	};
-
-	const onTransferDomain = transferInfo => {
-		const { domain, selectedSiteId } = transferInfo;
-		startInboundTransfer( selectedSiteId, domain, ( error, result ) => {
-			if ( result ) {
-				// TODO: Load next steps page page
-			} else {
-				// TODO: Show error notice
-			}
-		} );
-	};
-
 	analytics.pageView.record( basePath, 'My Sites > Domains > Selected Domain' );
 	context.primary = (
 		<Main>
 			<CartData>
 				<div>
-					<TransferDomainStep
-						forcePrecheck={ true }
-						goBack={ goBack }
-						initialQuery={ context.params.domain }
-						onTransferDomain={ onTransferDomain }
-					/>
+					<TransferDomainStep forcePrecheck={ true } initialQuery={ context.params.domain } />
 				</div>
 			</CartData>
 		</Main>

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -134,7 +134,7 @@ class Transfer extends React.PureComponent {
 
 	startTransfer = () => {
 		const { domain, selectedSite } = this.props;
-		page( transferInPrecheckLink( selectedSite.slug, domain ) );
+		page( transferInPrecheckLink( selectedSite.slug, domain.name ) );
 	};
 
 	restartTransfer = () => {

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -29,7 +29,7 @@ import { cancelPurchase as cancelPurchaseLink } from 'me/purchases/paths';
 import { Notice } from 'components/notice';
 import { get } from 'lodash';
 import InboundTransferEmailVerificationCard from 'my-sites/domains/domain-management/components/inbound-transfer-verification';
-import { domainManagementTransferInPrecheck as transferInPrecheckLink } from 'my-sites/domains/paths';
+import { domainManagementTransferInPrecheck } from 'my-sites/domains/paths';
 
 class Transfer extends React.PureComponent {
 	state = {
@@ -134,7 +134,7 @@ class Transfer extends React.PureComponent {
 
 	startTransfer = () => {
 		const { domain, selectedSite } = this.props;
-		page( transferInPrecheckLink( selectedSite.slug, domain.name ) );
+		page( domainManagementTransferInPrecheck( selectedSite.slug, domain.name ) );
 	};
 
 	restartTransfer = () => {

--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -19,7 +20,7 @@ import SubscriptionSettings from './card/subscription-settings';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { transferStatus } from 'lib/domains/constants';
 import { CALYPSO_CONTACT, INCOMING_DOMAIN_TRANSFER_STATUSES_FAILED } from 'lib/url/support';
-import { restartInboundTransfer, startInboundTransfer } from 'lib/domains';
+import { restartInboundTransfer } from 'lib/domains';
 import { fetchDomains } from 'lib/upgrades/actions';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import VerticalNav from 'components/vertical-nav';
@@ -28,6 +29,7 @@ import { cancelPurchase as cancelPurchaseLink } from 'me/purchases/paths';
 import { Notice } from 'components/notice';
 import { get } from 'lodash';
 import InboundTransferEmailVerificationCard from 'my-sites/domains/domain-management/components/inbound-transfer-verification';
+import { domainManagementTransferInPrecheck as transferInPrecheckLink } from 'my-sites/domains/paths';
 
 class Transfer extends React.PureComponent {
 	state = {
@@ -131,26 +133,8 @@ class Transfer extends React.PureComponent {
 	};
 
 	startTransfer = () => {
-		const { domain, selectedSite, translate } = this.props;
-		this.toggleSubmittingState();
-
-		startInboundTransfer( selectedSite.ID, domain.name, ( error, result ) => {
-			if ( result ) {
-				this.props.successNotice( translate( 'The transfer has been successfully started.' ), {
-					duration: 5000,
-				} );
-				fetchDomains( selectedSite.ID );
-				this.toggleSubmittingState();
-			} else {
-				this.props.errorNotice(
-					error.message || translate( 'We were unable to start the transfer.' ),
-					{
-						duration: 5000,
-					}
-				);
-				this.toggleSubmittingState();
-			}
-		} );
+		const { domain, selectedSite } = this.props;
+		page( transferInPrecheckLink( selectedSite.slug, domain ) );
 	};
 
 	restartTransfer = () => {

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -295,6 +295,17 @@ export default function() {
 			makeLayout,
 			clientRender
 		);
+
+		page(
+			paths.domainManagementTransferInPrecheck( ':site', ':domain' ),
+			siteSelection,
+			navigation,
+			domainsController.redirectIfNoSite( '/domains/manage' ),
+			jetPackWarning,
+			domainsController.transferDomainPrecheck,
+			makeLayout,
+			clientRender
+		);
 	}
 
 	page( '/domains', siteSelection, sites, makeLayout, clientRender );

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -96,6 +96,10 @@ export function domainManagementTransferIn( siteName, domainName ) {
 	return domainManagementTransfer( siteName, domainName, 'in' );
 }
 
+export function domainManagementTransferInPrecheck( siteName, domainName ) {
+	return domainManagementTransfer( siteName, domainName, 'precheck' );
+}
+
 export function domainManagementTransferOut( siteName, domainName ) {
 	return domainManagementTransfer( siteName, domainName, 'out' );
 }

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -62,8 +62,8 @@ export class TransferDomain extends Component {
 		page( '/checkout/' + selectedSiteSlug );
 	};
 
-	handleTransferDomain = transferInfo => {
-		const { domain, selectedSite, supportsPrivacy } = transferInfo;
+	handleTransferDomain = ( domain, supportsPrivacy ) => {
+		const { selectedSiteSlug } = this.props;
 
 		this.setState( { errorMessage: null } );
 
@@ -86,7 +86,7 @@ export class TransferDomain extends Component {
 
 		addItems( transferItems );
 
-		page( '/checkout/' + selectedSite.slug );
+		page( '/checkout/' + selectedSiteSlug );
 	};
 
 	componentWillMount() {

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -63,8 +63,7 @@ export class TransferDomain extends Component {
 	};
 
 	handleTransferDomain = transferInfo => {
-		const { domain, supportsPrivacy } = transferInfo;
-		const { selectedSiteSlug } = this.props;
+		const { domain, selectedSite, supportsPrivacy } = transferInfo;
 
 		this.setState( { errorMessage: null } );
 
@@ -87,7 +86,7 @@ export class TransferDomain extends Component {
 
 		addItems( transferItems );
 
-		page( '/checkout/' + selectedSiteSlug );
+		page( '/checkout/' + selectedSite.slug );
 	};
 
 	componentWillMount() {

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -62,7 +62,8 @@ export class TransferDomain extends Component {
 		page( '/checkout/' + selectedSiteSlug );
 	};
 
-	handleTransferDomain = ( domain, supportsPrivacy ) => {
+	handleTransferDomain = transferInfo => {
+		const { domain, supportsPrivacy } = transferInfo;
 		const { selectedSiteSlug } = this.props;
 
 		this.setState( { errorMessage: null } );
@@ -104,7 +105,7 @@ export class TransferDomain extends Component {
 	}
 
 	render() {
-		const { cart, domainsWithPlansOnly, initialQuery, productsList, selectedSite } = this.props;
+		const { cart, domainsWithPlansOnly, initialQuery, selectedSite } = this.props;
 
 		const { errorMessage } = this.state;
 
@@ -119,7 +120,6 @@ export class TransferDomain extends Component {
 					domainsWithPlansOnly={ domainsWithPlansOnly }
 					goBack={ this.goBack }
 					initialQuery={ initialQuery }
-					products={ productsList }
 					selectedSite={ selectedSite }
 					onRegisterDomain={ this.handleRegisterDomain }
 					onTransferDomain={ this.handleTransferDomain }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -184,8 +184,7 @@ class DomainsStep extends React.Component {
 		this.props.goToNextStep();
 	};
 
-	handleAddTransfer = transferInfo => {
-		const { domain } = transferInfo;
+	handleAddTransfer = domain => {
 		const domainItem = cartItems.domainTransfer( { domain, extra: { signup: true } } );
 		const isPurchasingItem = true;
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -184,7 +184,8 @@ class DomainsStep extends React.Component {
 		this.props.goToNextStep();
 	};
 
-	handleAddTransfer = domain => {
+	handleAddTransfer = transferInfo => {
+		const { domain } = transferInfo;
 		const domainItem = cartItems.domainTransfer( { domain, extra: { signup: true } } );
 		const isPurchasingItem = true;
 


### PR DESCRIPTION
Add a new path to load the precheck component for inbound transfers that are pending start due to being purchased during signup.

Create a transfer subscription with `'delayed_provisioning' => true`
Make sure that the link from the domain management screen goes to the transfer in screen
Make sure that the start transfer button takes you to the precheck screen
Make sure that the continue button from precheck calls the start transfer endpoint.