### PR TITLE
UK-Schema Add type clause to extra data to avoid dereferencing null

### DIFF
--- a/client/components/domains/registrant-extra-info/uk-schema.json
+++ b/client/components/domains/registrant-extra-info/uk-schema.json
@@ -5,6 +5,7 @@
 	"type": "object",
 	"properties": {
 		"extra": {
+			"type": "object",
 			"allOf": [
 				{
 					"errorCode": "dotukRegistrantTypeRequiresRegistrationNumber",


### PR DESCRIPTION
To reproduce, You'll need "null" as extra data. You can acheive this by completing a domain purchase, or by dispatching this action:

`dispatch( { type: 'DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE', data: { extra:null } } )`
 Then add a .uk domain:

![checkout_ _julesaus-bundle-cctld-test_ _wordpress_com](https://user-images.githubusercontent.com/5952255/35783469-657cc912-0a53-11e8-99b3-d263beb23a22.jpg)

What's happening here is that we're setting the extra data to `null` when we clear contact details after a purchase. JSON Schema ignores missing properties, so when the extra is `undefined`, no problem, but when the extra is `null`, we try and validate it and boom.

Adding the `"type": "object"` clause changes the validator we generate so that it type-checks and then skips the subsequent tests.

This PR is just a quick "fix it now", #21524 includes exception handling to more robustly prevent this type of problem in future