### PR TITLE
Jetpack Onboarding: Improve wording in the Summary heading

### DIFF
--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -84,9 +84,10 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 	render() {
 		const { siteUrl, translate } = this.props;
 
-		const headerText = translate( 'Congratulations! Your site is on its way.' );
+		const headerText = translate( "You're ready to go!" );
 		const subHeaderText = translate(
-			'You enabled Jetpack and unlocked dozens of website-bolstering features. Continue preparing your site below.'
+			"You've enabled Jetpack and unlocked powerful website tools that are ready for you to use. " +
+				"Let's continue getting your site set up:"
 		);
 
 		return (


### PR DESCRIPTION
This PR enhances the copy of the Summary heading area, as suggested by @joanrho in p1HpG7-4O1-p2 #comment-24340

Before:
![](https://cldup.com/sF7_AMRB90.png)

After:
![](https://cldup.com/YcaCo6GMAM.png)

To test:
* Checkout this branch
* Start the JPO flow.
* Go to the Summary page and have a look at the heading.