### PR TITLE
Comments: Keep comment on screen after entering Edit mode

### DIFF
--- a/client/my-sites/comments/comment/comment-actions.jsx
+++ b/client/my-sites/comments/comment/comment-actions.jsx
@@ -14,6 +14,7 @@ import { get, includes, isEqual, isUndefined, noop } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
+import scrollTo from 'lib/scroll-to';
 import { getMinimumComment } from 'my-sites/comments/comment/utils';
 import {
 	bumpStat,
@@ -44,6 +45,7 @@ export class CommentActions extends Component {
 		commentId: PropTypes.number,
 		canModerateComment: PropTypes.bool,
 		commentsListQuery: PropTypes.object,
+		getCommentOffsetTop: PropTypes.func,
 		redirect: PropTypes.func,
 		toggleEditMode: PropTypes.func,
 		toggleReply: PropTypes.func,
@@ -140,6 +142,11 @@ export class CommentActions extends Component {
 
 	toggleApproved = () => this.setStatus( this.props.commentIsApproved ? 'unapproved' : 'approved' );
 
+	toggleEditMode = () => {
+		this.props.toggleEditMode();
+		scrollTo( { x: 0, y: this.props.getCommentOffsetTop() } );
+	};
+
 	toggleLike = () => {
 		const { commentIsLiked, commentStatus, like, unlike } = this.props;
 
@@ -161,7 +168,6 @@ export class CommentActions extends Component {
 			canModerateComment,
 			commentIsApproved,
 			commentIsLiked,
-			toggleEditMode,
 			toggleReply,
 			translate,
 		} = this.props;
@@ -241,7 +247,7 @@ export class CommentActions extends Component {
 					<Button
 						borderless
 						className="comment__action comment__action-pencil"
-						onClick={ toggleEditMode }
+						onClick={ this.toggleEditMode }
 						tabIndex="0"
 						disabled={ ! canModerateComment }
 					>

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -61,10 +61,15 @@ export class Comment extends Component {
 		const { isBulkMode: wasBulkMode, isPostView: wasPostView } = this.props;
 		const { isBulkMode, isPostView } = nextProps;
 
+		const offsetTop =
+			wasPostView !== isPostView || `#comment-${ this.props.commentId }` !== window.location.hash
+				? 0
+				: this.getCommentOffsetTop();
+
 		this.setState( ( { isEditMode, isReplyVisible } ) => ( {
 			isEditMode: wasBulkMode !== isBulkMode ? false : isEditMode,
 			isReplyVisible: wasBulkMode !== isBulkMode ? false : isReplyVisible,
-			offsetTop: wasPostView !== isPostView ? 0 : this.getCommentOffsetTop(),
+			offsetTop,
 		} ) );
 	}
 
@@ -99,7 +104,7 @@ export class Comment extends Component {
 	};
 
 	getCommentOffsetTop = () => {
-		if ( ! window || `#comment-${ this.props.commentId }` !== window.location.hash ) {
+		if ( ! window ) {
 			return 0;
 		}
 
@@ -185,6 +190,7 @@ export class Comment extends Component {
 						{ ! isBulkMode && (
 							<CommentActions
 								{ ...{ siteId, postId, commentId, commentsListQuery, redirect, updateLastUndo } }
+								getCommentOffsetTop={ this.getCommentOffsetTop }
 								toggleEditMode={ this.toggleEditMode }
 								toggleReply={ this.toggleReply }
 							/>


### PR DESCRIPTION
In the Comments Management section, when we enter in Edit mode for a comment, its content is replaced by a small textarea.

Currently, if the content (in View mode) is longer than the window, and we scrolled all the way down to the bottom of the comment to click on the Edit button, the textarea could end up quite far above our current scroll position.

This PR fixes this oversight by simply scrolling up to the comment's `offsetTop`, by reusing the same logic already in place for the back navigation scrolling.

![feb-05-2018 11-52-58](https://user-images.githubusercontent.com/2070010/35803299-3393683a-0a6b-11e8-811a-cd7c5bb8704d.gif)

## Testing instructions

Open `/comments` and find a comment longer than the window.
Scroll down to its Edit button and click it.
The window should scroll back up to keep the comment (now in Edit mode) on screen.