### PR TITLE
Add status labels to spam and trash comments

### DIFF
--- a/client/my-sites/comments/comment/comment-content.jsx
+++ b/client/my-sites/comments/comment/comment-content.jsx
@@ -55,7 +55,7 @@ export class CommentContent extends Component {
 		const {
 			commentContent,
 			commentId,
-			commentIsPending,
+			commentStatus,
 			isBulkMode,
 			isParentCommentLoaded,
 			isPostView,
@@ -82,10 +82,16 @@ export class CommentContent extends Component {
 
 				{ ! isBulkMode && (
 					<div className="comment__content-full">
-						{ ( commentIsPending || parentCommentContent || ! isPostView ) && (
+						{ ( parentCommentContent || ! isPostView || 'approved' !== commentStatus ) && (
 							<div className="comment__content-info">
-								{ commentIsPending && (
-									<div className="comment__status-label">{ translate( 'Pending' ) }</div>
+								{ 'unapproved' === commentStatus && (
+									<div className="comment__status-label is-pending">{ translate( 'Pending' ) }</div>
+								) }
+								{ 'spam' === commentStatus && (
+									<div className="comment__status-label is-spam">{ translate( 'Spam' ) }</div>
+								) }
+								{ 'trash' === commentStatus && (
+									<div className="comment__status-label is-trash">{ translate( 'Trash' ) }</div>
 								) }
 
 								{ ! isPostView && <CommentPostLink { ...{ commentId, isBulkMode } } /> }
@@ -127,7 +133,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 
 	return {
 		commentContent: get( comment, 'content' ),
-		commentIsPending: 'unapproved' === get( comment, 'status' ),
+		commentStatus: get( comment, 'status' ),
 		isJetpack,
 		isParentCommentLoaded: ! parentCommentId || !! parentCommentContent,
 		parentCommentContent,

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -194,12 +194,19 @@
 	}
 
 	.comment__status-label {
-		background: lighten($alert-yellow, 18%);
 		border-radius: 9px;
 		float: right;
 		font-size: 12px;
 		margin-left: 8px;
 		padding: 0 10px;
+
+		&.is-pending {
+			background: lighten($alert-yellow, 18%);
+		}
+		&.is-spam,
+		&.is-trash {
+			background: lighten($alert-red, 18%);
+		}
 	}
 
 	.comment__in-reply-to {


### PR DESCRIPTION
Fix #22106

Add a status label to spam and trash comments.

Pinging @drw158 for the most appropriate colors to use!

<img width="790" alt="screen shot 2018-02-05 at 12 19 17" src="https://user-images.githubusercontent.com/2070010/35804240-daa2d2f2-0a6e-11e8-82a1-2ab319140814.png">

## Note

The issue states to add these labels only to single view.
I've tried to add them on any kind of views, and I think it works quite well.
Let me know your opinions, though!

## Testing instructions

- Open `/comments` and navigate to spam and/or trash.
- In both lists, comments should have a Spam or Trash red label (color pending approval).