### PR TITLE
State: Persist Jetpack Onboarding credentials and settings

### DIFF
--- a/client/state/jetpack-onboarding/reducer.js
+++ b/client/state/jetpack-onboarding/reducer.js
@@ -4,6 +4,7 @@
  * Internal dependencies
  */
 import { createReducer, combineReducers, keyedReducer } from 'state/utils';
+import { jetpackOnboardingCredentialsSchema, jetpackOnboardingSettingsSchema } from './schema';
 import {
 	JETPACK_ONBOARDING_CREDENTIALS_RECEIVE,
 	JETPACK_ONBOARDING_SETTINGS_UPDATE,
@@ -15,9 +16,11 @@ export const credentialsReducer = keyedReducer(
 		{},
 		{
 			[ JETPACK_ONBOARDING_CREDENTIALS_RECEIVE ]: ( state, { credentials } ) => credentials,
-		}
+		},
+		jetpackOnboardingCredentialsSchema
 	)
 );
+credentialsReducer.hasCustomPersistence = true;
 
 export const settingsReducer = keyedReducer(
 	'siteId',
@@ -28,9 +31,11 @@ export const settingsReducer = keyedReducer(
 				...state,
 				...settings,
 			} ),
-		}
+		},
+		jetpackOnboardingSettingsSchema
 	)
 );
+settingsReducer.hasCustomPersistence = true;
 
 export default combineReducers( {
 	credentials: credentialsReducer,

--- a/client/state/jetpack-onboarding/schema.js
+++ b/client/state/jetpack-onboarding/schema.js
@@ -1,0 +1,53 @@
+/** @format */
+
+export const jetpackOnboardingCredentialsSchema = {
+	type: 'object',
+	additionalProperties: false,
+	required: [ 'siteUrl', 'token', 'userEmail' ],
+	properties: {
+		siteUrl: { type: 'string' },
+		token: { type: 'string' },
+		userEmail: { type: 'string' },
+	},
+};
+
+export const jetpackOnboardingSettingsSchema = {
+	type: 'object',
+	additionalProperties: false,
+	properties: {
+		siteTitle: { type: 'string' },
+		siteDescription: { type: 'string' },
+		siteType: {
+			anyOf: [ { type: 'string' }, { type: 'boolean' } ],
+		},
+		homepageFormat: {
+			anyOf: [ { type: 'string' }, { type: 'boolean' } ],
+		},
+		addContactForm: {
+			anyOf: [
+				{
+					type: 'integer',
+					minimum: 0,
+				},
+				{ type: 'boolean' },
+			],
+		},
+		businessAddress: {
+			anyOf: [
+				{ type: 'boolean' },
+				{
+					type: 'object',
+					additionalProperties: false,
+					properties: {
+						name: { type: 'string' },
+						street: { type: 'string' },
+						city: { type: 'string' },
+						state: { type: 'string' },
+						zip: { type: 'string' },
+					},
+				},
+			],
+		},
+		installWooCommerce: { type: 'boolean' },
+	},
+};

--- a/client/state/jetpack-onboarding/test/reducer.js
+++ b/client/state/jetpack-onboarding/test/reducer.js
@@ -10,11 +10,18 @@ import deepFreeze from 'deep-freeze';
  */
 import reducer, { credentialsReducer, settingsReducer } from '../reducer';
 import {
+	DESERIALIZE,
 	JETPACK_ONBOARDING_CREDENTIALS_RECEIVE,
 	JETPACK_ONBOARDING_SETTINGS_UPDATE,
+	SERIALIZE,
 } from 'state/action-types';
+import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'reducer', () => {
+	useSandbox( sandbox => {
+		sandbox.stub( console, 'warn' );
+	} );
+
 	test( 'should export expected reducer keys', () => {
 		const state = reducer( undefined, {} );
 
@@ -85,6 +92,37 @@ describe( 'reducer', () => {
 				...initialState,
 				[ siteId ]: newCredentials,
 			} );
+		} );
+
+		test( 'should persist state', () => {
+			const original = deepFreeze( {
+				[ 12345678 ]: siteCredentials,
+			} );
+			const state = credentialsReducer( original, { type: SERIALIZE } );
+
+			expect( state ).toEqual( original );
+		} );
+
+		test( 'should load valid persisted state', () => {
+			const original = deepFreeze( {
+				[ 12345678 ]: siteCredentials,
+			} );
+
+			const state = credentialsReducer( original, { type: DESERIALIZE } );
+
+			expect( state ).toEqual( original );
+		} );
+
+		test( 'should not load invalid persisted state', () => {
+			const original = deepFreeze( {
+				[ 12345678 ]: {
+					...siteCredentials,
+					token: {},
+				},
+			} );
+			const state = credentialsReducer( original, { type: DESERIALIZE } );
+
+			expect( state ).toEqual( {} );
 		} );
 	} );
 
@@ -172,6 +210,37 @@ describe( 'reducer', () => {
 				...initialState,
 				[ siteId ]: newSettings,
 			} );
+		} );
+
+		test( 'should persist state', () => {
+			const original = deepFreeze( {
+				[ 12345678 ]: settings,
+			} );
+			const state = settingsReducer( original, { type: SERIALIZE } );
+
+			expect( state ).toEqual( original );
+		} );
+
+		test( 'should load valid persisted state', () => {
+			const original = deepFreeze( {
+				[ 12345678 ]: settings,
+			} );
+
+			const state = settingsReducer( original, { type: DESERIALIZE } );
+
+			expect( state ).toEqual( original );
+		} );
+
+		test( 'should not load invalid persisted state', () => {
+			const original = deepFreeze( {
+				[ 12345678 ]: {
+					...settings,
+					siteTitle: {},
+				},
+			} );
+			const state = settingsReducer( original, { type: DESERIALIZE } );
+
+			expect( state ).toEqual( {} );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR updates the Jetpack Onboarding credentials and settings reducers to embrace persistence.

Fixes #21914.

To test:
* Checkout this branch
* Verify all tests pass: `npm run test-client client/state/jetpack-onboarding`
* After loading the first page for an onboarding site, try refreshing. 
* Verify onboarding credentials and settings are still there.