### PR TITLE
Jetpack connect: Purify auth attempt reducer

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -181,6 +181,7 @@ export function retryAuth( url, attemptNumber ) {
 			type: JETPACK_CONNECT_RETRY_AUTH,
 			attemptNumber: attemptNumber,
 			slug: urlToSlug( url ),
+			timestamp: Date.now(),
 		} );
 		dispatch(
 			recordTracksEvent( 'calypso_jpc_retry_auth', {

--- a/client/state/jetpack-connect/reducer/jetpack-auth-attempts.js
+++ b/client/state/jetpack-connect/reducer/jetpack-auth-attempts.js
@@ -8,13 +8,13 @@ import { JETPACK_CONNECT_COMPLETE_FLOW, JETPACK_CONNECT_RETRY_AUTH } from 'state
 import { jetpackAuthAttemptsSchema } from './schema';
 import { keyedReducer } from 'state/utils';
 
-export function authAttempts( state = undefined, { type, attemptNumber } ) {
+export function authAttempts( state = undefined, { type, attemptNumber, timestamp } ) {
 	switch ( type ) {
 		case JETPACK_CONNECT_RETRY_AUTH:
 			if ( ! state || isStale( state.timestamp, AUTH_ATTEMPS_TTL ) ) {
 				return {
 					attempt: 0,
-					timestamp: Date.now(),
+					timestamp,
 				};
 			}
 			return {

--- a/client/state/jetpack-connect/reducer/test/jetpack-auth-attempts.js
+++ b/client/state/jetpack-connect/reducer/test/jetpack-auth-attempts.js
@@ -4,54 +4,60 @@
  */
 import { authAttempts, reducer } from '../jetpack-auth-attempts';
 import { JETPACK_CONNECT_COMPLETE_FLOW, JETPACK_CONNECT_RETRY_AUTH } from 'state/action-types';
+import { isStale } from 'state/jetpack-connect/utils';
+
+// The reducer relies on isStale, which compares a timestamp against Date.now().
+// Nothing is stale in the default mock. Force stale as follows:
+//
+// isStale.mockImplementationOnce( () => true );
+//
+jest.mock( 'state/jetpack-connect/utils', () => ( {
+	isStale: jest.fn( () => false ),
+} ) );
 
 describe( '#authAttempts()', () => {
-	test( 'should update the timestamp when adding an existent slug with stale timestamp', () => {
+	test( 'should update the timestamp and reset the count when retrying with a stale timestamp', () => {
+		isStale.mockImplementationOnce( () => true );
 		const state = authAttempts(
-			{ timestamp: 1, attempt: 1 },
+			{ timestamp: 1234, attempt: 1 },
 			{
 				type: JETPACK_CONNECT_RETRY_AUTH,
-				slug: 'example.com',
 				attemptNumber: 2,
+				slug: 'example.com',
+				timestamp: 5678,
 			}
 		);
-		expect( state ).toMatchObject( {
-			timestamp: expect.any( Number ),
+		expect( state ).toEqual( {
+			attempt: 0,
+			timestamp: 5678,
 		} );
 	} );
 
-	test( 'should reset the attempt number to 0 when adding an existent slug with stale timestamp', () => {
+	test( 'should store the attempt number and ignore the timestamp when retrying with a fresh timestamp', () => {
 		const state = authAttempts(
-			{ timestamp: 1, attempt: 1 },
+			{ timestamp: 1234, attempt: 1 },
 			{
 				type: JETPACK_CONNECT_RETRY_AUTH,
-				slug: 'example.com',
 				attemptNumber: 2,
+				slug: 'example.com',
+				timestamp: 5678,
 			}
 		);
 
-		expect( state ).toMatchObject( { attempt: 0 } );
-	} );
-
-	test( 'should store the attempt number when adding an existent slug with non-stale timestamp', () => {
-		const state = authAttempts(
-			{ timestamp: Date.now(), attempt: 1 },
-			{
-				type: JETPACK_CONNECT_RETRY_AUTH,
-				slug: 'example.com',
-				attemptNumber: 2,
-			}
-		);
-
-		expect( state ).toMatchObject( { attempt: 2 } );
+		expect( state ).toEqual( {
+			attempt: 2,
+			timestamp: 1234,
+		} );
 	} );
 
 	test( 'should clear state on completion', () => {
 		const state = authAttempts(
-			{ timestamp: Date.now(), attempt: 1 },
+			{ timestamp: 1234, attempt: 1 },
 			{
 				type: JETPACK_CONNECT_COMPLETE_FLOW,
+				attemptNumber: 2,
 				slug: 'example.com',
+				timestamp: 5678,
 			}
 		);
 
@@ -64,23 +70,24 @@ describe( '#reducer()', () => {
 		const previousState = {
 			nonMatchingSlug: {
 				attempt: 1,
-				timestamp: 12345,
+				timestamp: 1234,
 			},
 			'example.com': {
 				attempt: 1,
-				timestamp: Infinity,
+				timestamp: 1234,
 			},
 		};
 		const nextState = reducer( previousState, {
 			type: JETPACK_CONNECT_RETRY_AUTH,
 			attemptNumber: 2,
 			slug: 'example.com',
+			timestamp: 5678,
 		} );
 		expect( nextState ).toMatchObject( {
 			nonMatchingSlug: previousState.nonMatchingSlug,
 			'example.com': {
 				attempt: 2,
-				timestamp: expect.any( Number ),
+				timestamp: 1234,
 			},
 		} );
 	} );

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -64,8 +64,9 @@ describe( 'actions', () => {
 
 			expect( spy ).toHaveBeenCalledWith( {
 				type: JETPACK_CONNECT_RETRY_AUTH,
-				slug: 'example.com',
 				attemptNumber: 0,
+				slug: 'example.com',
+				timestamp: expect.any( Number ),
 			} );
 		} );
 	} );

--- a/client/state/jetpack-connect/utils.js
+++ b/client/state/jetpack-connect/utils.js
@@ -6,7 +6,7 @@
 
 import { JETPACK_CONNECT_TTL } from './constants';
 
-/***
+/**
  * Whether a Jetpack Connect store timestamp is stale.
  * @param   {Number} timestamp  Item to check.
  * @param   {Number} expiration Expiration to compare with, in milliseconds. Default is JETPACK_CONNECT_TTL.


### PR DESCRIPTION
Reducers should be pure. This is a step in that direction.

Not sure how I feel about this. The change is fairly invasive and `isStale` is also impure (calls `Date.now()`) and is used by the reducer.

I've avoided refactoring a pure version of `isStale` for now as that's used in more places.