### PR TITLE
Store Services - Fixed saving of the label settings

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -54,7 +54,7 @@ class AccountSettingsRootView extends Component {
 			);
 		}
 
-		return <LabelSettings siteId={ siteId } />;
+		return <LabelSettings siteId={ siteId } setValue={ this.setValue } />;
 	};
 
 	render() {

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -6,7 +6,6 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { find, isBoolean } from 'lodash';
@@ -23,7 +22,6 @@ import FormSelect from 'components/forms/form-select';
 import Notice from 'components/notice';
 import PaymentMethod, { getPaymentMethodTitle } from './label-payment-method';
 import { getOrigin } from 'woocommerce/lib/nav-utils';
-import { setFormDataValue } from '../../state/label-settings/actions';
 import {
 	areSettingsFetching,
 	getEmailReceipts,
@@ -127,13 +125,7 @@ class ShippingLabels extends Component {
 	};
 
 	renderPaymentsSection = () => {
-		const {
-			siteId,
-			canEditPayments,
-			paymentMethods,
-			selectedPaymentMethod,
-			translate,
-		} = this.props;
+		const { canEditPayments, paymentMethods, selectedPaymentMethod, translate } = this.props;
 
 		if ( ! this.state.expanded ) {
 			const expand = event => {
@@ -177,7 +169,7 @@ class ShippingLabels extends Component {
 		}
 
 		const onPaymentMethodChange = value =>
-			this.props.setFormDataValue( siteId, 'selected_payment_method_id', value );
+			this.props.setValue( 'selected_payment_method_id', value );
 
 		let description, buttonLabel;
 		if ( paymentMethods.length ) {
@@ -219,7 +211,6 @@ class ShippingLabels extends Component {
 
 	renderEmailReceiptsSection = () => {
 		const {
-			siteId,
 			emailReceipts,
 			translate,
 			masterUserName,
@@ -233,7 +224,7 @@ class ShippingLabels extends Component {
 			return null;
 		}
 
-		const onChange = () => this.props.setFormDataValue( siteId, 'email_receipts', ! emailReceipts );
+		const onChange = () => this.props.setValue( 'email_receipts', ! emailReceipts );
 
 		return (
 			<FormFieldSet>
@@ -264,14 +255,13 @@ class ShippingLabels extends Component {
 	};
 
 	renderContent = () => {
-		const { siteId, canEditSettings, isLoading, paperSize, storeOptions, translate } = this.props;
+		const { canEditSettings, isLoading, paperSize, storeOptions, translate } = this.props;
 
 		if ( isLoading ) {
 			return this.renderPlaceholder();
 		}
 
-		const onPaperSizeChange = event =>
-			this.props.setFormDataValue( siteId, 'paper_size', event.target.value );
+		const onPaperSizeChange = event => this.props.setValue( 'paper_size', event.target.value );
 		const paperSizes = getPaperSizes( storeOptions.origin_country );
 
 		return (
@@ -309,29 +299,20 @@ class ShippingLabels extends Component {
 
 ShippingLabels.propTypes = {
 	siteId: PropTypes.number.isRequired,
+	setValue: PropTypes.func.isRequired,
 };
 
-export default connect(
-	( state, { siteId } ) => {
-		return {
-			isLoading: areSettingsFetching( state, siteId ),
-			pristine: isPristine( state, siteId ),
-			paymentMethods: getPaymentMethods( state, siteId ),
-			selectedPaymentMethod: getSelectedPaymentMethodId( state, siteId ),
-			paperSize: getPaperSize( state, siteId ),
-			storeOptions: getLabelSettingsStoreOptions( state, siteId ),
-			canEditPayments: userCanManagePayments( state, siteId ),
-			canEditSettings:
-				userCanManagePayments( state, siteId ) || userCanEditSettings( state, siteId ),
-			emailReceipts: getEmailReceipts( state, siteId ),
-			...getMasterUserInfo( state, siteId ),
-		};
-	},
-	dispatch =>
-		bindActionCreators(
-			{
-				setFormDataValue,
-			},
-			dispatch
-		)
-)( localize( ShippingLabels ) );
+export default connect( ( state, { siteId } ) => {
+	return {
+		isLoading: areSettingsFetching( state, siteId ),
+		pristine: isPristine( state, siteId ),
+		paymentMethods: getPaymentMethods( state, siteId ),
+		selectedPaymentMethod: getSelectedPaymentMethodId( state, siteId ),
+		paperSize: getPaperSize( state, siteId ),
+		storeOptions: getLabelSettingsStoreOptions( state, siteId ),
+		canEditPayments: userCanManagePayments( state, siteId ),
+		canEditSettings: userCanManagePayments( state, siteId ) || userCanEditSettings( state, siteId ),
+		emailReceipts: getEmailReceipts( state, siteId ),
+		...getMasterUserInfo( state, siteId ),
+	};
+} )( localize( ShippingLabels ) );


### PR DESCRIPTION
A combination of recent changes introduced a bug where it wasn't possible to save the shipping settings page if the only thing that was modified on it was the labels paper size or payment method. This PR fixes it.

To test:
* open the shipping settings page
* change the payment method or paper size only 
* save button should work