### PR TITLE
Stats: make defaultProps static

### DIFF
--- a/client/my-sites/stats/stats-views/months.jsx
+++ b/client/my-sites/stats/stats-views/months.jsx
@@ -30,7 +30,7 @@ class Month extends PureComponent {
 		showPopover: false,
 	};
 
-	defaultProps = {
+	static defaultProps = {
 		position: 'top',
 	};
 


### PR DESCRIPTION
There were plenty of React warnings on the Stats Insights page due to not making `defaultProps` static. In this PR, we fix that.

Props to @jsnajdr for noticing this.

## Testing

Navigate to `/stats/insights/site` and open console. Do you still see the warnings?