### PR TITLE
Annual Site Stats: fix error with undefined years

### DIFF
--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -172,6 +172,7 @@ class AnnualSiteStats extends Component {
 					{ isWidget && previousYearData && this.renderWidgetContent( previousYearData, strings ) }
 					{ ! isWidget && years && this.renderTable( years, strings ) }
 					{ isWidget &&
+						years &&
 						years.length && (
 							<div className="module-expand">
 								<a href={ viewAllLink }>


### PR DESCRIPTION
@jsnajdr noticed that if you navigate to `/stats/insights/site1`, then click on Switch Site and navigate to a different site (which was previously not opened), it might crash the page with the following error:

![screen shot on 2018-02-05 at 16 09 35](https://user-images.githubusercontent.com/4988512/35812516-7d735e08-0a91-11e8-93ff-c70a256efa6b.png)

In this PR, we fix that.