### PR TITLE
Jetpack plans: Complete plans promotion AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -102,16 +102,4 @@ export default {
 		defaultVariation: 'group_0',
 		allowExistingUsers: true,
 	},
-
-	// Must run at least 1 full week from commit time
-	// 2018-01-24 to 2018-01-31
-	promoteYearlyJetpackPlanSavings: {
-		datestamp: '20180124',
-		variations: {
-			original: 50,
-			promoteYearly: 50,
-		},
-		defaultVariation: 'original',
-		allowExistingUsers: true,
-	},
 };

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -1,9 +1,7 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { get, noop } from 'lodash';
@@ -35,7 +33,6 @@ import {
 	PLAN_PERSONAL,
 	getPlanClass,
 } from 'lib/plans/constants';
-import { abtest } from 'lib/abtest';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlanBySlug } from 'state/plans/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -102,8 +99,7 @@ class PlanFeaturesHeader extends Component {
 				</div>
 				<div className="plan-features__pricing">
 					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }
-					{ 'promoteYearly' === abtest( 'promoteYearlyJetpackPlanSavings' ) &&
-						this.getIntervalDiscount() }
+					{ this.getIntervalDiscount() }
 				</div>
 			</div>
 		);


### PR DESCRIPTION
Close AB test from #21725, keep better-performing challenger. See p7rd6c-1e7-p2



## Testing
1. `/jetpack/connect/store` should feature the new version -- [live](https://dserve.a8c.com/jetpack/connect/store?branch=update/keep-jetpack-plans-ab-challenger)
1. `/jetpack/connect/plans/:SITE_SLUG` should feature the new version (Jetpack site on the free plan) -- [live](https://dserve.a8c.com/jetpack/connect?branch=update/keep-jetpack-plans-ab-challenger)
1. Monthly text should be correct and link to yearly plans on the same page
1. Yearly text should be correct