### PR TITLE
Masterbar: Ensure that the notification gridicon is always white.

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -298,6 +298,10 @@ $autobar-height: 20px;
 		margin-right: 0;
 	}
 
+	.gridicon {
+		fill: $white;
+	}
+
 	.gridicon + .masterbar__item-content {
 		padding: 0;
 


### PR DESCRIPTION
Currently the notifications icon will change color when active:

<img width="192" alt="screen shot 2018-02-05 at 11 48 42 am" src="https://user-images.githubusercontent.com/191598/35817132-920aa424-0a6a-11e8-8701-cf42fb719f6d.png">

It should be white all the time. This PR fixes it:

<img width="197" alt="screen shot 2018-02-05 at 11 48 22 am" src="https://user-images.githubusercontent.com/191598/35817140-99f14760-0a6a-11e8-9ea6-480f5b0475c3.png">
