### PR TITLE
Jetpack connect: Unify multiple requests into single request

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -113,17 +113,11 @@ export function checkUrl( url, isUrlOnSites ) {
 				url: url,
 			} );
 		}, 1 );
-		Promise.all( [
-			wpcom.undocumented().getSiteConnectInfo( url, 'exists' ),
-			wpcom.undocumented().getSiteConnectInfo( url, 'isWordPress' ),
-			wpcom.undocumented().getSiteConnectInfo( url, 'hasJetpack' ),
-			wpcom.undocumented().getSiteConnectInfo( url, 'isJetpackActive' ),
-			wpcom.undocumented().getSiteConnectInfo( url, 'isWordPressDotCom' ),
-			wpcom.undocumented().getSiteConnectInfo( url, 'isJetpackConnected' ),
-		] )
+		wpcom
+			.undocumented()
+			.getSiteConnectInfo( url )
 			.then( data => {
 				_fetching[ url ] = null;
-				data = data ? Object.assign.apply( Object, data ) : null;
 				debug( 'jetpack-connect state checked for url', url, data );
 				dispatch( {
 					type: JETPACK_CONNECT_CHECK_URL_RECEIVE,


### PR DESCRIPTION
This PR replaces multiple calls to a single endpoint requesting a single property with a single call to an endpoint that already returns all the required property 😎 

The endpoint already handles multiple returns. The response is already
an object with the desired properties. Remove the redundant independent
requests and unification.

Watch the response (filter network requests for `site-info`).

## Examples

### Exists, not WordPress:

#### Branch

Single request, single response, all the data:

[google.com](https://dserve.a8c.com/jetpack/connect?branch=update/jetpack-connect/single-site-check-call&url=google.com)

```
{"code":200,"headers":[{"name":"Content-Type","value":"application\/json"}],"body":{"exists":true,"isWordPress":false,"hasJetpack":false,"isJetpackActive":false,"isJetpackConnected":false,"isWordPressDotCom":false}}
```

#### Production

6 requests, 6 responses, 1 property each:

[google.com](https://wordpress.com/jetpack/connect?url=google.com)

<img width="1094" alt="notwordpress" src="https://user-images.githubusercontent.com/841763/35818484-7978e9b2-0aa0-11e8-8b72-df72c85ab1c1.png">

### Testing

Make sure all of the following production and branches work the same. PLEASE DON'T COMPLETE ANY MORE STEPS!


* Exists, not WordPress:
* * branch [google.com](https://dserve.a8c.com/jetpack/connect?branch=update/jetpack-connect/single-site-check-call&url=google.com)
* * production [google.com](https://wordpress.com/jetpack/connect?url=google.com)
* WordPress.com site
* * branch [support.wordpress.com](https://dserve.a8c.com/jetpack/connect?branch=update/jetpack-connect/single-site-check-call&url=support.wordpress.com)
* * production [support.wordpress.com](https://wordpress.com/jetpack/connect?url=support.wordpress.com)
* WordPress.org, no Jetpack
* * branch [.org no Jetpack](https://dserve.a8c.com/jetpack/connect?branch=update/jetpack-connect/single-site-check-call&url=http://ill-ibis.jurassic.ninja/)
* * production [.org no Jetpack](https://wordpress.com/jetpack/connect?url=http://ill-ibis.jurassic.ninja/)
* WordPress.org, inactive Jetpack
* * branch [.org inactive Jetpack](https://dserve.a8c.com/jetpack/connect?branch=update/jetpack-connect/single-site-check-call&url=http://clever-camel.jurassic.ninja/)
* * production [.org inactive Jetpack](https://wordpress.com/jetpack/connect?url=http://clever-camel.jurassic.ninja/)
* WordPress.org, active Jetpack
* * branch [.org active Jetpack](https://dserve.a8c.com/jetpack/connect?branch=update/jetpack-connect/single-site-check-call&url=http://clean-cottonmouth.jurassic.ninja/)
* * production [.org active Jetpack](https://wordpress.com/jetpack/connect?url=http://clean-cottonmouth.jurassic.ninja/)
* Bad url
* * branch [foobar](https://dserve.a8c.com/jetpack/connect?branch=update/jetpack-connect/single-site-check-call&url=foobar)
* * production [foobar](https://wordpress.com/jetpack/connect?url=foobar)
