### PR TITLE
Rewind: update flow return path to what is sent by the JITM

### DIFF
--- a/client/my-sites/stats/activity-log-switch/index.jsx
+++ b/client/my-sites/stats/activity-log-switch/index.jsx
@@ -104,7 +104,7 @@ class ActivityLogSwitch extends Component {
 				<div>
 					<a
 						className="activity-log-switch__no-thanks"
-						href={ `//${ siteSlug }/wp-admin/${ redirect }` }>
+						href={ `//${ siteSlug }${ redirect }` }>
 						{ translate( 'No thanks' ) }
 					</a>
 				</div>


### PR DESCRIPTION
This PR makes a small update to avoid assuming the WP Admin is in /wp-admin/ and instead use whatever the JITM passes as the return URL for the WP Admin.


#### Testing
- use this PR with D9909-code and https://github.com/Automattic/jetpack/pull/8762
- check the WP Admin of a site that doesn't have Rewind active (but available). It should show a JITM. When clicked, it should go to Calypso and display the Rewind activation flow