### PR TITLE
Store: Refetch label settings after returning from external add credit card form

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/label-settings/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/label-settings/actions.js
@@ -11,7 +11,7 @@ import {
 	WOOCOMMERCE_SERVICES_LABELS_OPEN_ADD_CARD_DIALOG,
 	WOOCOMMERCE_SERVICES_LABELS_CLOSE_ADD_CARD_DIALOG,
 } from '../action-types';
-import { getLabelSettingsForm, getLabelSettingsFormData } from './selectors';
+import { getLabelSettingsFormData } from './selectors';
 
 export const initForm = ( siteId, storeOptions, formData, formMeta ) => {
 	return {
@@ -39,12 +39,7 @@ export const setFormMetaProperty = ( siteId, key, value ) => {
 	};
 };
 
-export const fetchSettings = siteId => ( dispatch, getState ) => {
-	const form = getLabelSettingsForm( getState(), siteId );
-
-	if ( form && ( form.data || form.meta.isFetching ) ) {
-		return;
-	}
+export const fetchSettings = siteId => dispatch => {
 	dispatch( setFormMetaProperty( siteId, 'isFetching', true ) );
 
 	api

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -44,7 +44,6 @@ import AddCardDialog from './add-credit-card-modal';
 class ShippingLabels extends Component {
 	componentWillMount() {
 		this.setState( { expanded: this.isExpanded( this.props ) } );
-		this.onVisibilityChange = this.onVisibilityChange.bind( this );
 	}
 
 	componentWillReceiveProps( props ) {

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -233,10 +233,13 @@ class ShippingLabels extends Component {
 				{ this.renderPaymentPermissionNotice() }
 				<p className="label-settings__credit-card-description">{ description }</p>
 
-				{ ! isReloading ? null : (
+				{ isReloading ? (
 					<div className="label-settings__placeholder">
 						<PaymentMethod selected={ false } isLoading={ true } />
+						<PaymentMethod selected={ false } isLoading={ true } />
 					</div>
+				) : (
+					paymentMethods.map( renderPaymentMethod )
 				) }
 				<QueryStoredCards />
 				{ paymentMethods.map( renderPaymentMethod ) }

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -233,6 +233,7 @@ class ShippingLabels extends Component {
 				{ this.renderPaymentPermissionNotice() }
 				<p className="label-settings__credit-card-description">{ description }</p>
 
+				<QueryStoredCards />
 				{ isReloading ? (
 					<div className="label-settings__placeholder">
 						<PaymentMethod selected={ false } isLoading={ true } />
@@ -241,8 +242,6 @@ class ShippingLabels extends Component {
 				) : (
 					paymentMethods.map( renderPaymentMethod )
 				) }
-				<QueryStoredCards />
-				{ paymentMethods.map( renderPaymentMethod ) }
 
 				<AddCardDialog siteId={ siteId } />
 				<Button onClick={ openDialog } compact>{ buttonLabel }</Button>


### PR DESCRIPTION
After clicking "Add credit card" in label settings — up to and including the point when the external form window is closed — check to see if a new card has been added each time the window is refocused.

Refetching placeholder and update, after saving card and returning to original tab:

![credit-card-refetch](https://user-images.githubusercontent.com/1867547/35825294-61427cae-0a83-11e8-8e9a-99dc84803490.gif)

Tested in Chrome, Firefox, and Safari 10.1.1.