### PR TITLE
Purchases: only show 'Deleting' state for credit cards being deleted

### DIFF
--- a/client/me/purchases/credit-cards/credit-card-delete.jsx
+++ b/client/me/purchases/credit-cards/credit-card-delete.jsx
@@ -56,9 +56,9 @@ class CreditCardDelete extends React.Component {
 }
 
 export default connect(
-	state => {
+	( state, props ) => {
 		return {
-			isDeleting: isDeletingStoredCard( state ),
+			isDeleting: isDeletingStoredCard( state, props.card.stored_details_id ),
 		};
 	},
 	{

--- a/client/state/stored-cards/actions.js
+++ b/client/state/stored-cards/actions.js
@@ -77,6 +77,7 @@ export const deleteStoredCard = card => dispatch => {
 		.catch( error => {
 			dispatch( {
 				type: STORED_CARDS_DELETE_FAILED,
+				card,
 				error: error.message || i18n.translate( 'There was a problem deleting the stored card.' ),
 			} );
 		} );

--- a/client/state/stored-cards/actions.js
+++ b/client/state/stored-cards/actions.js
@@ -57,6 +57,7 @@ export const fetchStoredCards = () => dispatch => {
 export const deleteStoredCard = card => dispatch => {
 	dispatch( {
 		type: STORED_CARDS_DELETE,
+		card,
 	} );
 
 	return new Promise( ( resolve, reject ) => {

--- a/client/state/stored-cards/reducer.js
+++ b/client/state/stored-cards/reducer.js
@@ -82,14 +82,19 @@ export const isFetching = ( state = false, action ) => {
  * @param {Object} action - storedCard action
  * @return {Object} updated state
  */
-export const isDeleting = ( state = false, action ) => {
+export const isDeleting = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case STORED_CARDS_DELETE:
-			return true;
+			return {
+				...state,
+				[ action.card.stored_details_id ]: true,
+			};
 
 		case STORED_CARDS_DELETE_FAILED:
 		case STORED_CARDS_DELETE_COMPLETED:
-			return false;
+			const nextState = { ...state };
+			delete nextState[ action.card.stored_details_id ];
+			return nextState;
 	}
 
 	return state;

--- a/client/state/stored-cards/selectors.js
+++ b/client/state/stored-cards/selectors.js
@@ -22,5 +22,6 @@ export const getStoredCardById = ( state, cardId ) =>
 
 export const hasLoadedStoredCardsFromServer = state => state.storedCards.hasLoadedFromServer;
 
-export const isDeletingStoredCard = state => state.storedCards.isDeleting;
+export const isDeletingStoredCard = ( state, cardId ) =>
+	Boolean( state.storedCards.isDeleting[ cardId ] );
 export const isFetchingStoredCards = state => state.storedCards.isFetching;

--- a/client/state/stored-cards/test/actions.js
+++ b/client/state/stored-cards/test/actions.js
@@ -129,6 +129,7 @@ describe( 'actions', () => {
 
 				expect( spy ).to.have.been.calledWith( {
 					type: STORED_CARDS_DELETE,
+					card,
 				} );
 
 				return promise.then( () => {
@@ -152,11 +153,13 @@ describe( 'actions', () => {
 
 				expect( spy ).to.have.been.calledWith( {
 					type: STORED_CARDS_DELETE,
+					card,
 				} );
 
 				return promise.then( () => {
 					expect( spy ).to.have.been.calledWith( {
 						type: STORED_CARDS_DELETE_FAILED,
+						card,
 						error: error.message,
 					} );
 				} );

--- a/client/state/stored-cards/test/reducer.js
+++ b/client/state/stored-cards/test/reducer.js
@@ -33,7 +33,7 @@ describe( 'items', () => {
 		expect( reducer( undefined, { type: 'UNRELATED' } ) ).to.be.eql( {
 			items: [],
 			isFetching: false,
-			isDeleting: false,
+			isDeleting: {},
 			hasLoadedFromServer: false,
 		} );
 	} );
@@ -42,7 +42,7 @@ describe( 'items', () => {
 		expect( reducer( undefined, { type: STORED_CARDS_FETCH } ) ).to.be.eql( {
 			items: [],
 			isFetching: true,
-			isDeleting: false,
+			isDeleting: {},
 			hasLoadedFromServer: false,
 		} );
 	} );
@@ -56,7 +56,7 @@ describe( 'items', () => {
 		expect( state ).to.be.eql( {
 			items: STORED_CARDS_FROM_API,
 			isFetching: false,
-			isDeleting: false,
+			isDeleting: {},
 			hasLoadedFromServer: true,
 		} );
 	} );
@@ -69,7 +69,7 @@ describe( 'items', () => {
 		expect( state ).to.be.eql( {
 			items: [],
 			isFetching: false,
-			isDeleting: false,
+			isDeleting: {},
 			hasLoadedFromServer: false,
 		} );
 	} );
@@ -90,7 +90,7 @@ describe( 'items', () => {
 		expect( state ).to.be.eql( {
 			items: STORED_CARDS_FROM_API,
 			isFetching: false,
-			isDeleting: false,
+			isDeleting: {},
 			hasLoadedFromServer: true,
 		} );
 	} );
@@ -100,7 +100,7 @@ describe( 'items', () => {
 			deepFreeze( {
 				items: STORED_CARDS_FROM_API,
 				isFetching: false,
-				isDeleting: false,
+				isDeleting: {},
 				hasLoadedFromServer: true,
 			} ),
 			{
@@ -112,7 +112,7 @@ describe( 'items', () => {
 		expect( state ).to.be.eql( {
 			items: STORED_CARDS_FROM_API,
 			isFetching: false,
-			isDeleting: true,
+			isDeleting: { 1234567: true },
 			hasLoadedFromServer: true,
 		} );
 	} );
@@ -134,7 +134,7 @@ describe( 'items', () => {
 		expect( state ).to.be.eql( {
 			items: [ STORED_CARDS_FROM_API[ 1 ] ],
 			isFetching: false,
-			isDeleting: false,
+			isDeleting: {},
 			hasLoadedFromServer: true,
 		} );
 	} );
@@ -144,18 +144,19 @@ describe( 'items', () => {
 			deepFreeze( {
 				items: STORED_CARDS_FROM_API,
 				isFetching: false,
-				isDeleting: true,
+				isDeleting: { 1234567: true },
 				hasLoadedFromServer: true,
 			} ),
 			{
 				type: STORED_CARDS_DELETE_FAILED,
+				card: STORED_CARDS_FROM_API[ 0 ],
 			}
 		);
 
 		expect( state ).to.be.eql( {
 			items: STORED_CARDS_FROM_API,
 			isFetching: false,
-			isDeleting: false,
+			isDeleting: {},
 			hasLoadedFromServer: true,
 		} );
 	} );


### PR DESCRIPTION
Currently the credit card `isDeleting` state is recorded as a single boolean and doesn't differentiate among different cards, not all of which are necessarily being deleted. The existing UI could make you think all of your cards are being deleted:

![credit-card-deleting-master](https://user-images.githubusercontent.com/1867547/35826388-9909f376-0a86-11e8-9857-b3adb37cca80.gif)

This PR changes the `isDeleting` state to a object lookup by card ID, and updates the individual cards' button states accordingly:

![credit-card-deleting](https://user-images.githubusercontent.com/1867547/35826493-ddd20390-0a86-11e8-842a-981363fecb69.gif)

... a) avoiding the potential miscommunication noted above, and b) making it possible to begin deleting one card before another card has finished deleting.

<s>Tests need to be updated: marking in-progress.</s> (Done.)