### PR TITLE
Rewind: fix issue where after saving creds it didn't proceed to next step

### DIFF
--- a/client/signup/steps/rewind-form-creds/index.jsx
+++ b/client/signup/steps/rewind-form-creds/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -94,6 +94,6 @@ export default connect( ( state, ownProps ) => {
 	const rewindState = getRewindState( state, siteId );
 	return {
 		siteId,
-		rewindIsNowActive: 'active' === rewindState.state,
+		rewindIsNowActive: includes( [ 'active', 'provisioning' ], rewindState.state ),
 	};
 }, null )( localize( RewindFormCreds ) );


### PR DESCRIPTION
This PR fixes an issue seen only on new sites and only on the flow to add credentials: during the flow, user got stuck in the creds form step because right after adding creds for a new site puts the Rewind state into `provisioning` and the check for this transition was expecting the `active` state.
