### PR TITLE
A/B Tests: Load assignments from API (take 2)

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -17,6 +17,7 @@ import analytics from 'lib/analytics';
 import config from 'config';
 import userFactory from 'lib/user';
 import wpcom from 'lib/wp';
+import { ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
 
 const debug = debugFactory( 'calypso:abtests' );
 const user = userFactory();
@@ -52,7 +53,7 @@ export const getABTestVariation = name => new ABTest( name ).getVariation();
  *
  * @returns {Object} - The user's variations, or an empty object if the user is not a participant
  */
-export const getSavedVariations = () => store.get( 'ABTests' ) || {};
+export const getSavedVariations = () => store.get( ABTEST_LOCALSTORAGE_KEY ) || {};
 
 export const getAllTests = () => keys( activeTests ).map( ABTest );
 
@@ -330,5 +331,5 @@ ABTest.prototype.saveVariationOnBackend = function( variation ) {
 ABTest.prototype.saveVariationInLocalStorage = function( variation ) {
 	const savedVariations = getSavedVariations();
 	savedVariations[ this.experimentId ] = variation;
-	store.set( 'ABTests', savedVariations );
+	store.set( ABTEST_LOCALSTORAGE_KEY, savedVariations );
 };

--- a/client/lib/abtest/test-helper/index.js
+++ b/client/lib/abtest/test-helper/index.js
@@ -12,6 +12,7 @@ import Debug from 'debug';
  */
 import TestList from './TestList';
 import { getAllTests } from 'lib/abtest';
+import { ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
 
 const debug = Debug( 'calypso:abtests:helper' );
 
@@ -20,10 +21,10 @@ export default function injectTestHelper( element ) {
 		React.createElement( TestList, {
 			tests: getAllTests(),
 			onChangeVariant: function( test, variation ) {
-				const testSettings = JSON.parse( localStorage.getItem( 'ABTests' ) ) || {};
+				const testSettings = JSON.parse( localStorage.getItem( ABTEST_LOCALSTORAGE_KEY ) ) || {};
 				testSettings[ test.experimentId ] = variation;
 				debug( 'Switching test variant', test.experimentId, variation );
-				localStorage.setItem( 'ABTests', JSON.stringify( testSettings ) );
+				localStorage.setItem( ABTEST_LOCALSTORAGE_KEY, JSON.stringify( testSettings ) );
 				window.location.reload();
 			},
 		} ),

--- a/client/lib/abtest/utility.js
+++ b/client/lib/abtest/utility.js
@@ -1,0 +1,19 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import activeTests from 'lib/abtest/active-tests';
+
+export const ABTEST_LOCALSTORAGE_KEY = 'ABTests';
+
+/**
+ * Returns all active test names
+ * @returns {String[]} All active test names with respective timestamp appended to the end
+ */
+export function getActiveTestNames( { appendDatestamp = false, asCSV = false } = {} ) {
+	const output = Object.keys( activeTests ).map(
+		key => appendDatestamp ? `${ key }_${ activeTests[ key ].datestamp }` : key
+	);
+	return asCSV ? output.join( ',' ) : output;
+}

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -19,11 +19,9 @@ import { withoutHttp } from 'lib/url';
 const languages = config( 'languages' );
 
 export function getLanguage( slug ) {
-	var len = languages.length,
-		language,
-		index;
-
-	for ( index = 0; index < len; index++ ) {
+	const { length: len } = languages;
+	let language;
+	for ( let index = 0; index < len; index++ ) {
 		if ( slug === languages[ index ].langSlug ) {
 			language = languages[ index ];
 			break;
@@ -34,36 +32,37 @@ export function getLanguage( slug ) {
 }
 
 function getSiteSlug( url ) {
-	var slug = withoutHttp( url );
+	const slug = withoutHttp( url );
 	return slug.replace( /\//g, '::' );
 }
 
 export function filterUserObject( obj ) {
-	var user = {},
-		allowedKeys = [
-			'ID',
-			'display_name',
-			'username',
-			'avatar_URL',
-			'site_count',
-			'visible_site_count',
-			'date',
-			'has_unseen_notes',
-			'newest_note_type',
-			'phone_account',
-			'email',
-			'email_verified',
-			'is_valid_google_apps_country',
-			'user_ip_country_code',
-			'logout_URL',
-			'primary_blog',
-			'primary_blog_is_jetpack',
-			'primary_blog_url',
-			'meta',
-			'is_new_reader',
-			'social_signup_service',
-		],
-		decodeWhitelist = [ 'display_name', 'description', 'user_URL' ];
+	const user = {};
+	const allowedKeys = [
+		'ID',
+		'display_name',
+		'username',
+		'avatar_URL',
+		'site_count',
+		'visible_site_count',
+		'date',
+		'has_unseen_notes',
+		'newest_note_type',
+		'phone_account',
+		'email',
+		'email_verified',
+		'is_valid_google_apps_country',
+		'user_ip_country_code',
+		'logout_URL',
+		'primary_blog',
+		'primary_blog_is_jetpack',
+		'primary_blog_url',
+		'meta',
+		'is_new_reader',
+		'social_signup_service',
+		'abtests',
+	];
+	const decodeWhitelist = [ 'display_name', 'description', 'user_URL' ];
 
 	allowedKeys.forEach( function( key ) {
 		user[ key ] =
@@ -74,10 +73,10 @@ export function filterUserObject( obj ) {
 }
 
 export function getComputedAttributes( attributes ) {
-	var language = getLanguage( attributes.language ),
-		primayBlogUrl = attributes.primary_blog_url || '';
+	const language = getLanguage( attributes.language );
+	const primaryBlogUrl = attributes.primary_blog_url || '';
 	return {
-		primarySiteSlug: getSiteSlug( primayBlogUrl ),
+		primarySiteSlug: getSiteSlug( primaryBlogUrl ),
 		localeSlug: attributes.language,
 		isRTL: !! ( language && language.rtl ),
 	};

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -63,18 +63,20 @@ User.prototype.initialize = function() {
 	}
 
 	if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
-		const bootstrappedData = window.currentUser || false;
+		this.data = window.currentUser || false;
+		debug( 'Bootstrapping user data:', this.data );
 
 		// Store the current user in localStorage so that we can use it to determine
 		// if the logged in user has changed when initializing in the future
-		if ( bootstrappedData ) {
-			this.handleFetchSuccess( bootstrappedData );
+		if ( this.data ) {
+			this.handleFetchSuccess( this.data );
 		}
 		this.initialized = true;
 		return;
 	}
 
 	this.data = store.get( 'wpcom_user' ) || false;
+	debug( 'User bootstrap disabled, checking localStorage:', this.data );
 
 	if ( this.data ) {
 		this.initialized = true;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1450,20 +1450,22 @@ Undocumented.prototype.readSitePostRelated = function( query, fn ) {
  *
  * @param {string} name - The name of the A/B test. No leading 'abtest_' needed
  * @param {string} variation - The variation the user is assigned to
- * @param {Function} fn - Function to invoke when request is complete
+ * @param {Function} callback - Function to invoke when request is complete
  * @api public
+ * @returns {Object} wpcomRequest
  */
-Undocumented.prototype.saveABTestData = function( name, variation, fn ) {
-	var data = {
-		name: name,
-		variation: variation,
+Undocumented.prototype.saveABTestData = function( name, variation, callback ) {
+	const body = {
+		name,
+		variation,
 	};
+	debug( `POST /me/abtests with ${ JSON.stringify( body ) }` );
 	return this.wpcom.req.post(
 		{
 			path: '/me/abtests',
-			body: data,
+			body,
 		},
-		fn
+		callback
 	);
 };
 

--- a/client/my-sites/stats/checklist-banner/index.jsx
+++ b/client/my-sites/stats/checklist-banner/index.jsx
@@ -26,6 +26,7 @@ import { launchTask, onboardingTasks } from 'my-sites/checklist/onboardingCheckl
 import ChecklistShowShare from 'my-sites/checklist/checklist-show/share';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
+import { ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
 
 const storeKeyForNeverShow = 'sitesNeverShowChecklistBanner';
 
@@ -110,7 +111,9 @@ export class ChecklistBanner extends Component {
 			return false;
 		}
 
-		const abtests = store.get( 'ABTests' );
+		// NOTE: Accessing localStorage directly for checking A/B variation assignment
+		//       is an anti-pattern. Please use lib/abtest instead.
+		const abtests = store.get( ABTEST_LOCALSTORAGE_KEY );
 		if (
 			get( abtests, 'checklistThankYouForPaidUser_20171204' ) !== 'show' &&
 			get( abtests, 'checklistThankYouForFreeUser_20171204' ) !== 'show'

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -2,18 +2,30 @@
 /**
  * External dependencies
  */
-import { filterUserObject } from 'lib/user/shared-utils';
-var superagent = require( 'superagent' ),
-	debug = require( 'debug' )( 'calypso:bootstrap' ),
-	crypto = require( 'crypto' );
+import qs from 'qs';
+import superagent from 'superagent';
+import debugFactory from 'debug';
+import crypto from 'crypto';
 
-var config = require( 'config' ),
+/**
+ * Internal dependencies
+ */
+import { filterUserObject } from 'lib/user/shared-utils';
+import { getActiveTestNames } from 'lib/abtest/utility';
+import config from 'config';
+
+const debug = debugFactory( 'calypso:bootstrap' ),
 	API_KEY = config( 'wpcom_calypso_rest_api_key' ),
 	AUTH_COOKIE_NAME = 'wordpress_logged_in',
 	/**
 	 * WordPress.com REST API /me endpoint.
 	 */
-	url = 'https://public-api.wordpress.com/rest/v1/me?meta=flags';
+	API_PATH = 'https://public-api.wordpress.com/rest/v1/me',
+	apiQuery = {
+		meta: 'flags',
+		abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ),
+	},
+	url = `${ API_PATH }?${ qs.stringify( apiQuery ) }`;
 
 module.exports = function( authCookieValue, geoCountry, callback ) {
 	// create HTTP Request object


### PR DESCRIPTION
Take 2 of #21709, fixes #20097.

This change fetches the user's assigned A/B test variations stored as user attributes from the wpcom REST API. In addition to changes introduced by #21709, this PR also [properly sets `this.data` in `lib/user/user.js` during instantiation of the User object](https://github.com/Automattic/wp-calypso/pull/22149/commits/bed557e5a515c009a66dd3af80380f3a046525ca). Not setting `this.data` in the initialization caused outages on `/log-in` and `/start` for logged-out users as well as canary test failures.

#### Testing instructions

1. Check out locally (`fix/load-ab-variations-take-2`) and start your server.
2. Set your localStorage debug flag to `calypso:user` like so:  
```javascript
localStorage.debug = 'calypso:user';
```
3. Open the [homepage](http://calypso.localhost:3000/) while logged in.
4. Verify that you see the following debug lines in your console:
```
calypso:user Initializing User
calypso:user User bootstrap disabled, checking localStorage
calypso:user Getting user from api
calypso:user User successfully retrieved
```

5. Ensure that localStorage has been populated with expected values. With my user, it looks like the following: (Please note that A/B test variation assignments will vary per user)

``` javascript
> localStorage.ABTests
"{"skipThemesSelectionModal_20170904":"show"}"

> JSON.parse(localStorage.wpcom_user).abtests
{ skipThemesSelectionModal_20170904: "show" }
```

6. Repeat step 3 logged out and ensure that the pages render properly. Also ensure that the [login](http://calypso.localhost:3000/log-in) and [start](http://calypso.localhost:3000/start) pages render properly.

7. If you'd like, you can also spin up a docker image of this change `npm run build-docker; and npm run docker;` and repeat the above steps. Doing so would enable you to test this change in a production-like setting and yield the following debug lines in your console:
```
calypso:user Initializing User
calypso:user Bootstrapping user data: { ... }
```