### PR TITLE
Rewind: use the complete site URL for the link to dismiss the flow

### DIFF
--- a/client/my-sites/stats/activity-log-switch/index.jsx
+++ b/client/my-sites/stats/activity-log-switch/index.jsx
@@ -13,6 +13,7 @@ import Card from 'components/card';
 import Button from 'components/button';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { getRewindState } from 'state/selectors';
+import { getSiteUrl } from 'state/sites/selectors';
 
 class ActivityLogSwitch extends Component {
 	static propTypes = {
@@ -81,7 +82,7 @@ class ActivityLogSwitch extends Component {
 		const {
 			translate,
 			redirect,
-			siteSlug,
+			siteUrl,
 		} = this.props;
 
 		return (
@@ -101,7 +102,7 @@ class ActivityLogSwitch extends Component {
 					<div>
 						<a
 							className="activity-log-switch__no-thanks"
-							href={ `//${ siteSlug }${ redirect }` }>
+							href={ `${ siteUrl }${ redirect }` }>
 							{ translate( 'No thanks' ) }
 						</a>
 					</div>
@@ -167,6 +168,7 @@ export default connect(
 		const rewindState = getRewindState( state, siteId );
 		return {
 			siteSlug: getSelectedSiteSlug( state, siteId ),
+			siteUrl: getSiteUrl( state, siteId ),
 			rewindState: rewindState.state,
 			failureReason: rewindState.failureReason || '',
 		};

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -293,6 +293,27 @@ export function getSiteTitle( state, siteId ) {
 }
 
 /**
+ * Returns the URL for a site, or null if the site is unknown.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?String}        Site Url
+ */
+export function getSiteUrl( state, siteId ) {
+	if ( getSiteOption( state, siteId, 'is_redirect' ) || isSiteConflicting( state, siteId ) ) {
+		return getSiteSlug( state, siteId );
+	}
+
+	const site = getRawSite( state, siteId );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	return site.URL;
+}
+
+/**
  * Returns true if the site can be previewed, false if the site cannot be
  * previewed, or null if preview ability cannot be determined. This indicates
  * whether it is safe to embed iframe previews for the site.


### PR DESCRIPTION
This phenomenon with Chrome was found while doing the flow demo today: the "No thanks" link to return to WP Admin caused Chrome to display the security alert page.

<img width="303" alt="captura de pantalla 2018-02-05 a la s 20 11 52" src="https://user-images.githubusercontent.com/1041600/35833655-d67810ba-0ab0-11e8-9745-5905c544d08f.png">

This PR now fixes it using the complete site URL and the link to return to WP Admin now has the right schema set.