### PR TITLE
Framework: Disable `?retry=1` page retries in development mode

### DIFF
--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -84,7 +84,7 @@ function createPageDefinition( path, sectionDefinition ) {
 			} )
 			.catch( error => {
 				console.error( error ); // eslint-disable-line
-				if ( ! LoadingError.isRetry() ) {
+				if ( ! LoadingError.isRetry() && process.env.NODE_ENV !== 'development' ) {
 					LoadingError.retry( sectionDefinition.name );
 				} else {
 					dispatch( { type: 'SECTION_SET', isLoading: false } );

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -88,7 +88,7 @@ function createPageDefinition( path, sectionDefinition ) {
 					LoadingError.retry( sectionDefinition.name );
 				} else {
 					dispatch( { type: 'SECTION_SET', isLoading: false } );
-					LoadingError.show( sectionDefinition.name );
+					LoadingError.show( context, sectionDefinition.name );
 				}
 			} );
 	} );


### PR DESCRIPTION
Calypso has a feature that reloads the page and tries again if a JavaScript error occurs during load.

This may be a benefit for production users with intermittent errors (though I'm skeptical, and the code that collects stats about this is broken), but in the development environment, this only makes it more difficult to tell what error I just caused.

Accordingly, this PR:

- Disables the retry feature in development
- Fixes the stat collection for chunk failures in production

As follow-up steps, we should consider the following:

- Fix the error display that should occur in these cases.  The behavior of this code likely changed significantly with the move to single-tree rendering in #19494, and it seems to be broken now.  A React error boundary should be a good, clean way of doing this.
- Remove this retry feature entirely.  I expect that when this code path is triggered, it is usually a persistent error rather than an intermittent issue.  Even if stats show otherwise, users can be expected to refresh a page themselves.

You can test the behavior of this PR by doing something silly like this:

```diff
diff --git a/client/my-sites/people/main.jsx b/client/my-sites/people/main.jsx
index e2232df..e1c5f1c 100644
--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -67,6 +67,8 @@ export const People = createReactClass( {
 	},
 
 	render: function() {
+		window.thisIsNotAFunciionAndEvenIfItWas_ItsSpelledWring();
+
 		const {
 			isJetpack,
 			jetpackPeopleSupported,
```