### PR TITLE
Activity Log: Show for all Jetpack-connected sites

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -14,7 +14,7 @@ import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
 import Intervals from './intervals';
 import FollowersCount from 'blocks/followers-count';
-import { isSiteAutomatedTransfer, isSiteStore } from 'state/selectors';
+import { isSiteStore } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { navItems, intervals as intervalConstants } from './constants';
 
@@ -29,10 +29,10 @@ class StatsNavigation extends Component {
 	};
 
 	isValidItem = item => {
-		const { isStore, isAtomic, isJetpack } = this.props;
+		const { isStore, isJetpack } = this.props;
 		switch ( item ) {
 			case 'activity':
-				return isJetpack && ! isAtomic;
+				return isJetpack;
 			case 'store':
 				return isStore;
 			default:
@@ -76,7 +76,6 @@ class StatsNavigation extends Component {
 export default connect( ( state, { siteId } ) => {
 	return {
 		isJetpack: isJetpackSite( state, siteId ),
-		isAtomic: isSiteAutomatedTransfer( state, siteId ),
 		isStore: isSiteStore( state, siteId ),
 		siteId,
 	};


### PR DESCRIPTION
Previously we have been only showing the Activity view under Stats for
sites connected with Jetpack that aren't Atomic sites.

In this patch we're removing the constraint on Atomic sites so that all
connected Jetpack sites can see the Activity Log.

**Testing**

This should be easy to verify: we're only turning on the Activity Log in
this PR - we're not wanting to block on general Activity Log issues.

Test with existing sites where Activity is enabled. In this branch they
should continue to show **Stats** > **Activity**.

Test with Atomic sites. In **master** the **Activity** tab should be
missing but on this branch it should appear.

http://iscalypsofastyet.com/branch?branch=activity-log/stop-hiding-from-atomic
```
Delta:
chunk                                              stat_size           parsed_size           gzip_size
async-load-extensions-woocommerce-app-store-stats     -192 B  (-0.1%)       -105 B  (-0.1%)      -42 B  (-0.1%)
async-load-my-sites-stats-activity-log                -192 B  (-0.1%)       -105 B  (-0.1%)      -42 B  (-0.1%)
async-load-my-sites-stats-overview                    -192 B  (-0.1%)       -105 B  (-0.1%)      -43 B  (-0.3%)
async-load-my-sites-stats-site                        -192 B  (-0.1%)       -105 B  (-0.1%)      -41 B  (-0.1%)
async-load-my-sites-stats-stats-insights              -192 B  (-0.1%)       -105 B  (-0.1%)      -44 B  (-0.1%)
build                                                   +0 B                  +8 B  (+0.0%)      -22 B  (-0.0%)
manifest                                                +0 B                  +0 B                -1 B  (-0.0%)
```