### PR TITLE
Add missing validation message & Component Key

### DIFF
--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -177,6 +177,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		const trademarkNumberStrings = {
 			maxLength: this.props.translate( 'Too long. An EU Trademark number has 9 digits.' ),
 			oneOf: this.props.translate( 'Too short. An EU Trademark number has 9 digits.' ),
+			pattern: this.props.translate( 'An EU Trademark number uses only digits.' ),
 		};
 
 		const trademarkNumberValidationMessage = map( validationErrors.trademarkNumber, error =>


### PR DESCRIPTION
This PR fixes a missing validation message in the Domains Contact Details `fr-form`

![checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/35842479-1d76cec8-0b4e-11e8-9a98-3af826c7abb2.jpg)


To reproduce:

1. add a .fr domain to your cart
2. go through the process until the fr-form 
3. Choose "A company or organization"
4. Enter a non-numeric character into the EU Trademark Number field

The EU Trademark Number field validates it's content (numbers only), but is missing a message, so if you enter an 'a' you get an odd red '!' with no message.

The string is also being used as the key for a react component, so adding it also resolves a react warning about that missing key.