### PR TITLE
Masterbar: cleanup and optimize the "Write" button code

### DIFF
--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -33,14 +33,18 @@ class MasterbarItemNew extends React.Component {
 		isShowingPopover: false,
 	};
 
-	setPostButtonContext = component => {
-		this.setState( {
-			postButtonContext: component,
-		} );
+	setPostButtonRef = component => {
+		this.postButtonRef = component;
 	};
 
-	toggleSitesPopover = ( isShowingPopover = ! this.state.isShowingPopover ) => {
-		this.setState( { isShowingPopover } );
+	toggleSitesPopover = () => {
+		this.setState( state => ( {
+			isShowingPopover: ! state.isShowingPopover,
+		} ) );
+	};
+
+	closeSitesPopover = () => {
+		this.setState( { isShowingPopover: false } );
 	};
 
 	onClick = event => {
@@ -54,7 +58,9 @@ class MasterbarItemNew extends React.Component {
 		}
 	};
 
-	getPopoverPosition = () => {
+	preloadPostEditor = () => preload( 'post-editor' );
+
+	getPopoverPosition() {
 		if ( isMobile() ) {
 			return 'bottom';
 		}
@@ -64,7 +70,25 @@ class MasterbarItemNew extends React.Component {
 		}
 
 		return 'bottom left';
-	};
+	}
+
+	renderPopover() {
+		if ( ! this.state.isShowingPopover ) {
+			return null;
+		}
+
+		return (
+			<SitesPopover
+				id="popover__sites-popover-masterbar"
+				visible
+				groups
+				context={ this.postButtonRef }
+				onClose={ this.closeSitesPopover }
+				onSiteSelect={ this.props.siteSelected }
+				position={ this.getPopoverPosition() }
+			/>
+		);
+	}
 
 	render() {
 		const classes = classNames( this.props.className );
@@ -74,25 +98,17 @@ class MasterbarItemNew extends React.Component {
 		return (
 			<div className="masterbar__publish">
 				<MasterbarItem
-					ref={ this.setPostButtonContext }
+					ref={ this.setPostButtonRef }
 					url={ newPostPath }
 					icon="create"
 					onClick={ this.onClick }
 					isActive={ this.props.isActive }
 					tooltip={ this.props.tooltip }
 					className={ classes }
-					preloadSection={ () => preload( 'post-editor' ) }
+					preloadSection={ this.preloadPostEditor }
 				>
 					{ this.props.children }
-					<SitesPopover
-						id="popover__sites-popover-masterbar"
-						visible={ this.state.isShowingPopover }
-						context={ this.state.postButtonContext }
-						onClose={ this.toggleSitesPopover.bind( this, false ) }
-						onSiteSelect={ this.props.siteSelected }
-						groups={ true }
-						position={ this.getPopoverPosition() }
-					/>
+					{ this.renderPopover() }
 				</MasterbarItem>
 				<MasterbarDrafts />
 			</div>


### PR DESCRIPTION
- avoid doing any wasted work on the `SitesPopover` component when the popover is not displayed
- `setPostButtonRef` sets an instance property when called, instead of updating component state -- that's not needed when setting/unsetting refs
- avoid ESlint warnings by creating `preloadPostEditor` and `closeSitesPopover` methods. That avoids creating a new function instance on each render.

**How to test:**
No behavior change intended: check that the "Write" button in masterbar works as intended and clicking on it shows the site selector. Or, in case of single-site account, opens the post editor directly.