### PR TITLE
Enable perfmon on production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -82,7 +82,7 @@
 		"nps-survey/dev-trigger": false,
 		"nps-survey/notice": true,
 		"onboarding-checklist": true,
-		"perfmon": false,
+		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
 		"plans/jetpack-config-v2": true,


### PR DESCRIPTION
It's been enabled on staging for almost a month, not causing any problems. Let's start collecting data about Stats page loading on production, too.