### PR TITLE
Concierge chats: add name fields to the info step

### DIFF
--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -39,6 +39,8 @@ class CalendarStep extends Component {
 	onSubmit = timestamp => {
 		const { currentUserId, signupForm, site } = this.props;
 		const meta = {
+			firstname: signupForm.firstname,
+			lastname: signupForm.lastname,
 			message: signupForm.message,
 			timezone: signupForm.timezone,
 		};

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -78,7 +78,7 @@ class InfoStep extends Component {
 						<FormLabel htmlFor="firstname">{ translate( 'First Name' ) }</FormLabel>
 						<FormTextInput
 							name="firstname"
-							placeholder={ translate( 'Please tell us how you prefer us to call you.' ) }
+							placeholder={ translate( 'What may we call you?' ) }
 							onChange={ this.setFieldValue }
 							value={ firstname }
 						/>

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -112,7 +112,10 @@ class InfoStep extends Component {
 							{ translate( 'What are you hoping to accomplish with your site?' ) }
 						</FormLabel>
 						<FormTextarea
-							placeholder={ translate( 'Please be descriptive' ) }
+							placeholder={ translate(
+								'Sell products and services? Generate leads? Something else entirely?' +
+									' The more specific, the more we can help you.'
+							) }
 							name="message"
 							onChange={ this.setFieldValue }
 							value={ message }

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -51,16 +51,18 @@ class InfoStep extends Component {
 	};
 
 	componentDidMount() {
-		const { userSettings } = this.props;
+		const { userSettings, signupForm: { firstname, lastname } } = this.props;
 
 		this.props.recordTracksEvent( 'calypso_concierge_book_info_step' );
 
-		// Prefill the firstname & lastname fields by user settings.
-		this.props.updateConciergeSignupForm( {
-			...this.props.signupForm,
-			firstname: userSettings.first_name,
-			lastname: userSettings.last_name,
-		} );
+		if ( ! firstname && ! lastname ) {
+			// Prefill the firstname & lastname fields by user settings.
+			this.props.updateConciergeSignupForm( {
+				...this.props.signupForm,
+				firstname: userSettings.first_name,
+				lastname: userSettings.last_name,
+			} );
+		}
 	}
 
 	render() {

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -114,7 +114,7 @@ class InfoStep extends Component {
 						<FormTextarea
 							placeholder={ translate(
 								'Sell products and services? Generate leads? Something else entirely?' +
-									' The more specific, the more we can help you.'
+									" Be as specific as you can! It helps us provide the information you're looking for."
 							) }
 							name="message"
 							onChange={ this.setFieldValue }

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -28,6 +28,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 class InfoStep extends Component {
 	static propTypes = {
 		signupForm: PropTypes.object,
+		userSettings: PropTypes.object,
 		onComplete: PropTypes.func.isRequired,
 		site: PropTypes.object.isRequired,
 	};
@@ -44,23 +45,26 @@ class InfoStep extends Component {
 	};
 
 	canSubmitForm = () => {
-		const { signupForm } = this.props;
-		if ( ! signupForm.message ) {
-			return false;
-		}
-		return !! signupForm.message.trim();
+		const { signupForm: { firstname, message } } = this.props;
+
+		return !! firstname.trim() && !! message.trim();
 	};
 
 	componentDidMount() {
+		const { userSettings } = this.props;
+
 		this.props.recordTracksEvent( 'calypso_concierge_book_info_step' );
+
+		// Prefill the firstname & lastname fields by user settings.
+		this.props.updateConciergeSignupForm( {
+			...this.props.signupForm,
+			firstname: userSettings.first_name,
+			lastname: userSettings.last_name,
+		} );
 	}
 
 	render() {
-		const {
-			signupForm: { firstname, lastname, message, timezone },
-			userSettings,
-			translate,
-		} = this.props;
+		const { signupForm: { firstname, lastname, message, timezone }, translate } = this.props;
 
 		return (
 			<div>
@@ -74,7 +78,7 @@ class InfoStep extends Component {
 						<FormLabel htmlFor="firstname">{ translate( 'First Name' ) }</FormLabel>
 						<FormTextInput
 							name="firstname"
-							placeholder={ userSettings.first_name }
+							placeholder={ translate( 'Please tell us how you prefer us to call you.' ) }
 							onChange={ this.setFieldValue }
 							value={ firstname }
 						/>
@@ -83,7 +87,7 @@ class InfoStep extends Component {
 						<FormLabel htmlFor="lastname">{ translate( 'Last Name' ) }</FormLabel>
 						<FormTextInput
 							name="lastname"
-							placeholder={ userSettings.last_name }
+							placeholder={ translate( 'Optionally, please tell us your last name.' ) }
 							onChange={ this.setFieldValue }
 							value={ lastname }
 						/>

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -16,11 +16,12 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextarea from 'components/forms/form-textarea';
+import FormTextInput from 'components/forms/form-text-input';
 import Timezone from 'components/timezone';
 import Site from 'blocks/site';
 import { localize } from 'i18n-calypso';
 import { updateConciergeSignupForm } from 'state/concierge/actions';
-import { getConciergeSignupForm } from 'state/selectors';
+import { getConciergeSignupForm, getUserSettings } from 'state/selectors';
 import PrimaryHeader from '../shared/primary-header';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -55,7 +56,11 @@ class InfoStep extends Component {
 	}
 
 	render() {
-		const { signupForm: { message, timezone }, translate } = this.props;
+		const {
+			signupForm: { firstname, lastname, message, timezone },
+			userSettings,
+			translate,
+		} = this.props;
 
 		return (
 			<div>
@@ -65,6 +70,24 @@ class InfoStep extends Component {
 				</CompactCard>
 
 				<CompactCard>
+					<FormFieldset>
+						<FormLabel htmlFor="firstname">{ translate( 'First Name' ) }</FormLabel>
+						<FormTextInput
+							name="firstname"
+							placeholder={ userSettings.first_name }
+							onChange={ this.setFieldValue }
+							value={ firstname }
+						/>
+					</FormFieldset>
+					<FormFieldset>
+						<FormLabel htmlFor="lastname">{ translate( 'Last Name' ) }</FormLabel>
+						<FormTextInput
+							name="lastname"
+							placeholder={ userSettings.last_name }
+							onChange={ this.setFieldValue }
+							value={ lastname }
+						/>
+					</FormFieldset>
 					<FormFieldset>
 						<FormLabel>{ translate( "What's your timezone?" ) }</FormLabel>
 						<Timezone
@@ -107,6 +130,7 @@ class InfoStep extends Component {
 export default connect(
 	state => ( {
 		signupForm: getConciergeSignupForm( state ),
+		userSettings: getUserSettings( state ),
 	} ),
 	{
 		updateConciergeSignupForm,

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -22,10 +22,11 @@ import { connect } from 'react-redux';
  */
 import Main from 'components/main';
 import QueryConciergeAvailableTimes from 'components/data/query-concierge-available-times';
+import QueryUserSettings from 'components/data/query-user-settings';
 import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
-import { getConciergeAvailableTimes } from 'state/selectors';
+import { getConciergeAvailableTimes, getUserSettings } from 'state/selectors';
 import { WPCOM_CONCIERGE_SCHEDULE_ID } from './constants';
 import { getSite } from 'state/sites/selectors';
 import Upsell from './shared/upsell';
@@ -48,11 +49,12 @@ class ConciergeMain extends Component {
 	};
 
 	getDisplayComponent = () => {
-		const { appointmentId, availableTimes, site, steps } = this.props;
+		const { appointmentId, availableTimes, site, steps, userSettings } = this.props;
+
 		const CurrentStep = steps[ this.state.currentStep ];
 		const Skeleton = this.props.skeleton;
 
-		if ( ! availableTimes || ! site || ! site.plan ) {
+		if ( ! availableTimes || ! site || ! site.plan || ! userSettings ) {
 			return <Skeleton />;
 		}
 
@@ -77,6 +79,7 @@ class ConciergeMain extends Component {
 
 		return (
 			<Main>
+				<QueryUserSettings />
 				<QueryConciergeAvailableTimes scheduleId={ WPCOM_CONCIERGE_SCHEDULE_ID } />
 				<QuerySites />
 				{ site && <QuerySitePlans siteId={ site.ID } /> }
@@ -89,4 +92,5 @@ class ConciergeMain extends Component {
 export default connect( ( state, props ) => ( {
 	availableTimes: getConciergeAvailableTimes( state ),
 	site: getSite( state, props.siteSlug ),
+	userSettings: getUserSettings( state ),
 } ) )( ConciergeMain );

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -22,12 +22,13 @@ class PrimaryHeader extends Component {
 			<Card>
 				<img
 					className="shared__info-illustration"
+					alt="concierge session signup form header"
 					src={ '/calypso/images/illustrations/illustration-start.svg' }
 				/>
 				<FormattedHeader
 					headerText={ translate( 'WordPress.com Business Concierge Session' ) }
 					subHeaderText={ translate(
-						"In this 30 minute session we'll help you get started with your site."
+						"In this 30-minute session we'll help you get started with your site."
 					) }
 				/>
 				<ExternalLink

--- a/client/state/concierge/signup-form/reducer.js
+++ b/client/state/concierge/signup-form/reducer.js
@@ -19,6 +19,14 @@ export const timezone = createReducer( moment.tz.guess(), {
 	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.timezone,
 } );
 
+export const firstName = createReducer( '', {
+	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.firstName,
+} );
+
+export const lastName = createReducer( '', {
+	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.lastName,
+} );
+
 export const status = createReducer( null, {
 	[ CONCIERGE_UPDATE_BOOKING_STATUS ]: ( state, action ) => action.status,
 } );

--- a/client/state/concierge/signup-form/reducer.js
+++ b/client/state/concierge/signup-form/reducer.js
@@ -19,12 +19,12 @@ export const timezone = createReducer( moment.tz.guess(), {
 	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.timezone,
 } );
 
-export const firstName = createReducer( '', {
-	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.firstName,
+export const firstname = createReducer( '', {
+	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.firstname,
 } );
 
-export const lastName = createReducer( '', {
-	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.lastName,
+export const lastname = createReducer( '', {
+	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.lastname,
 } );
 
 export const status = createReducer( null, {
@@ -32,6 +32,8 @@ export const status = createReducer( null, {
 } );
 
 export default combineReducers( {
+	firstname,
+	lastname,
 	message,
 	timezone,
 	status,

--- a/client/state/concierge/signup-form/test/reducer.js
+++ b/client/state/concierge/signup-form/test/reducer.js
@@ -8,11 +8,13 @@ import moment from 'moment-timezone';
 /**
  * Internal dependencies
  */
-import signupForm, { timezone, message, status } from '../reducer';
+import signupForm, { firstname, lastname, timezone, message, status } from '../reducer';
 import { CONCIERGE_SIGNUP_FORM_UPDATE, CONCIERGE_UPDATE_BOOKING_STATUS } from 'state/action-types';
 
 describe( 'concierge/signupForm/reducer', () => {
 	const mockSignupForm = {
+		firstname: 'Foo',
+		lastname: 'Bar',
 		timezone: 'UTC',
 		message: 'hello',
 		status: 'booking',
@@ -28,6 +30,26 @@ describe( 'concierge/signupForm/reducer', () => {
 		type: CONCIERGE_UPDATE_BOOKING_STATUS,
 		status: mockStatus,
 	};
+
+	describe( 'firstname', () => {
+		test( 'should be default as empty string.', () => {
+			expect( firstname( undefined, {} ) ).toEqual( '' );
+		} );
+
+		test( 'should return the firstname of the update action.', () => {
+			expect( firstname( {}, updateForm ) ).toEqual( mockSignupForm.firstname );
+		} );
+	} );
+
+	describe( 'lastname', () => {
+		test( 'should be default as empty string.', () => {
+			expect( lastname( undefined, {} ) ).toEqual( '' );
+		} );
+
+		test( 'should return the lastname of the update action.', () => {
+			expect( lastname( {}, updateForm ) ).toEqual( mockSignupForm.lastname );
+		} );
+	} );
 
 	describe( 'timezone', () => {
 		test( 'should use the default detected timezone.', () => {
@@ -62,6 +84,8 @@ describe( 'concierge/signupForm/reducer', () => {
 	describe( 'signupForm', () => {
 		test( 'should combine all defaults as null.', () => {
 			expect( signupForm( undefined, {} ) ).toEqual( {
+				firstname: '',
+				lastname: '',
 				timezone: moment.tz.guess(),
 				message: '',
 				status: null,


### PR DESCRIPTION
## Summary
This PR attempts to resolve gh-hg-569. It adds the "First name" field and the "Last name" field to the concierge sign-up form:
<img width="775" alt="default" src="https://user-images.githubusercontent.com/1842898/35851785-ffa24f56-0b63-11e8-8b58-bb9bfb0d7cbe.png">

What it does is adding `firstname` and `lastname` properties in the `signupForm` substate, and store them in the `meta` field so we can override a customer's display name if they've provided.

## Test Plan
1. `npm run test-client concierge` should pass.
1. Go to `/me/concierge/` and the sign-up form should show you the First name and the Last name fields. If you use an account with the both set, the placeholders should be those stored in the profile. If you use an account without them, the placeholders should be empty.
1. Complete the flow, and an appointment should be made successfully.
1. Follow the instructions in gh-hg-569 for 
