### PR TITLE
Plans: Fix plansLink get param handling

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -290,7 +290,6 @@ export function plansLanding( context, next ) {
 			context={ context }
 			destinationType={ context.params.destinationType }
 			interval={ context.params.interval }
-			basePlansPath={ '/jetpack/connect/store' }
 			url={ context.query.site }
 		/>
 	);

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -26,9 +26,9 @@ import OrgCredentialsForm from './remote-credentials';
 import Plans from './plans';
 import PlansLanding from './plans-landing';
 import versionCompare from 'lib/version-compare';
+import { addQueryArgs, externalRedirect, sectionify } from 'lib/route';
 import { authorizeQueryDataSchema } from './schema';
 import { authQueryTransformer } from './utils';
-import { externalRedirect, sectionify } from 'lib/route';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
 import { hideMasterbar, setSection, showMasterbar } from 'state/ui/actions';
@@ -313,7 +313,11 @@ export function plansSelection( context, next ) {
 	context.primary = (
 		<CheckoutData>
 			<Plans
-				basePlansPath={ JPC_PATH_PLANS }
+				basePlansPath={
+					context.query.redirect
+						? addQueryArgs( { redirect: context.query.redirect }, JPC_PATH_PLANS )
+						: JPC_PATH_PLANS
+				}
 				context={ context }
 				destinationType={ context.params.destinationType }
 				interval={ context.params.interval }

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -28,7 +28,6 @@ const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';
 
 class PlansLanding extends Component {
 	static propTypes = {
-		basePlansPath: PropTypes.string,
 		interval: PropTypes.string,
 		url: PropTypes.string,
 	};
@@ -87,7 +86,7 @@ class PlansLanding extends Component {
 	};
 
 	render() {
-		const { basePlansPath, interval, requestingSites, site, url } = this.props;
+		const { interval, requestingSites, site, url } = this.props;
 
 		// We're redirecting in componentDidMount if the site is already connected
 		// so don't bother rendering any markup if this is the case
@@ -100,7 +99,7 @@ class PlansLanding extends Component {
 				<QueryPlans />
 
 				<PlansGrid
-					basePlansPath={ basePlansPath }
+					basePlansPath={ '/jetpack/connect/store' }
 					calypsoStartedConnection={ true }
 					hideFreePlan={ true }
 					interval={ interval }

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -207,7 +207,7 @@ class Plans extends Component {
 				<QueryPlans />
 				{ selectedSite && <QuerySitePlans siteId={ selectedSite.ID } /> }
 				<PlansGrid
-					basePlansPath={ '/jetpack/connect/plans' }
+					basePlansPath={ this.props.basePlansPath }
 					onSelect={ this.selectPlan }
 					hideFreePlan={ true }
 					isLanding={ false }

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import moment from 'moment';
-import urlModule from 'url';
+import { format as urlFormat, parse as urlParse } from 'url';
 import { difference, find, get, includes, invoke, pick, values } from 'lodash';
 
 /**
@@ -335,7 +335,7 @@ export const isPlanFeaturesEnabled = () => {
 };
 
 export function plansLink( url, site, intervalType ) {
-	const parsedUrl = urlModule.parse( url );
+	const parsedUrl = urlParse( url );
 	if ( 'monthly' === intervalType ) {
 		parsedUrl.pathname += '/monthly';
 	}
@@ -344,7 +344,7 @@ export function plansLink( url, site, intervalType ) {
 		parsedUrl.pathname += '/' + site.slug;
 	}
 
-	return urlModule.format( parsedUrl );
+	return urlFormat( parsedUrl );
 }
 
 export function applyTestFiltersToPlansList( planName, abtest ) {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -3,8 +3,8 @@
 /**
  * External dependencies
  */
-
 import moment from 'moment';
+import urlModule from 'url';
 import { difference, find, get, includes, invoke, pick, values } from 'lodash';
 
 /**
@@ -335,15 +335,16 @@ export const isPlanFeaturesEnabled = () => {
 };
 
 export function plansLink( url, site, intervalType ) {
+	const parsedUrl = urlModule.parse( url );
 	if ( 'monthly' === intervalType ) {
-		url += '/monthly';
+		parsedUrl.pathname += '/monthly';
 	}
 
 	if ( site && site.slug ) {
-		url += '/' + site.slug;
+		parsedUrl.pathname += '/' + site.slug;
 	}
 
-	return url;
+	return urlModule.format( parsedUrl );
 }
 
 export function applyTestFiltersToPlansList( planName, abtest ) {

--- a/client/lib/plans/test/plans-link.js
+++ b/client/lib/plans/test/plans-link.js
@@ -26,4 +26,10 @@ describe( 'plansLink', () => {
 	test( 'should append site slug if provided and yearly', () => {
 		expect( plansLink( '/plans', { slug: 'example.com' }, 'yearly' ) ).toBe( '/plans/example.com' );
 	} );
+
+	test( 'should leave query string untouched when modifying url', () => {
+		expect( plansLink( '/plans?query-key=query-value', { slug: 'example.com' }, 'monthly' ) ).toBe(
+			'/plans/monthly/example.com?query-key=query-value'
+		);
+	} );
 } );

--- a/client/lib/plans/test/plans-link.js
+++ b/client/lib/plans/test/plans-link.js
@@ -1,0 +1,29 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { plansLink } from '..';
+
+describe( 'plansLink', () => {
+	test( 'should return url unchanged for yearly no-site', () => {
+		expect( plansLink( '/plans' ) ).toBe( '/plans' );
+	} );
+
+	test( 'should append monthly to url when required', () => {
+		expect( plansLink( '/plans', undefined, 'monthly' ) ).toBe( '/plans/monthly' );
+	} );
+
+	test( 'should append site slug if provided', () => {
+		expect( plansLink( '/plans', { slug: 'example.com' } ) ).toBe( '/plans/example.com' );
+	} );
+
+	test( 'should append monthly followed by site slug if provided', () => {
+		expect( plansLink( '/plans', { slug: 'example.com' }, 'monthly' ) ).toBe(
+			'/plans/monthly/example.com'
+		);
+	} );
+
+	test( 'should append site slug if provided and yearly', () => {
+		expect( plansLink( '/plans', { slug: 'example.com' }, 'yearly' ) ).toBe( '/plans/example.com' );
+	} );
+} );

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -278,12 +278,13 @@ class PlanFeaturesHeader extends Component {
 
 	getIntervalDiscount() {
 		const {
+			basePlansPath,
 			currencyCode,
 			isYearly,
 			rawPrice,
 			relatedMonthlyPlan,
-			site,
 			relatedYearlyPlan,
+			site,
 		} = this.props;
 		if ( site.jetpack ) {
 			const [ discountPrice, originalPrice ] = isYearly
@@ -294,6 +295,7 @@ class PlanFeaturesHeader extends Component {
 				!! discountPrice &&
 				!! originalPrice && (
 					<PlanIntervalDiscount
+						basePlansPath={ basePlansPath }
 						currencyCode={ currencyCode }
 						discountPrice={ discountPrice }
 						isYearly={ isYearly }

--- a/client/my-sites/plan-interval-discount/index.js
+++ b/client/my-sites/plan-interval-discount/index.js
@@ -14,6 +14,7 @@ import { getCurrencyObject } from 'lib/format-currency';
 
 class PlanIntervalDiscount extends Component {
 	static propTypes = {
+		basePlansPath: PropTypes.string.isRequired,
 		currencyCode: PropTypes.string.isRequired,
 		discountPrice: PropTypes.number.isRequired,
 		isYearly: PropTypes.bool.isRequired,
@@ -47,10 +48,10 @@ class PlanIntervalDiscount extends Component {
 	}
 
 	renderMonthlyViewDiscountInfo() {
-		const { currencyCode, discountPrice, originalPrice } = this.props;
+		const { basePlansPath, currencyCode, discountPrice, originalPrice } = this.props;
 
 		// Ensure we have required props.
-		if ( ! currencyCode || ! discountPrice || ! originalPrice ) {
+		if ( ! basePlansPath || ! currencyCode || ! discountPrice || ! originalPrice ) {
 			return null;
 		}
 
@@ -61,7 +62,7 @@ class PlanIntervalDiscount extends Component {
 			{
 				args: price,
 				components: {
-					Link: <a href={ plansLink( '/jetpack/connect/plans', site, 'yearly' ) } />,
+					Link: <a href={ plansLink( basePlansPath, site, 'yearly' ) } />,
 					b: <b />,
 				},
 			}


### PR DESCRIPTION
Fix `plansLink` issues handling get parameters detected in #22135 

Notably, this test fails before `plansLink` is improved on this branch:

https://github.com/Automattic/wp-calypso/blob/7d399d23ae0321bed153d607bf2eb96e8bc70597/client/lib/plans/test/plans-link.js#L30-L34

## Testing
1. Tests pass
1. Can be tested with #22135:
   1. Start a connection from WP Admin for a new site.
   1. When you're sent to WordPress.com for authorization, modify the url to point to `https://calypso.live` without modifying the path and add `&branch=fix/plans-link-get-params` to the query string.
   1. Follow steps until plans is reached.
   1. Notice that the `redirect` parameter is maintained when toggling between `monthly` plans.
1. Verify there are no regressions for other plans pages:
   * `/plans` for a WordPress.com site
   * `/plans` for a Jetpack site with upgrades available (test the monthly/yearly toggle)