### PR TITLE
Jetpack Onboarding: Make Jetpack Connect a more obvious next step

### DIFF
--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -56,10 +56,6 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 		const { siteUrl, translate } = this.props;
 
 		const stepsTodo = {
-			JETPACK_CONNECTION: {
-				label: translate( 'Connect to WordPress.com' ),
-				url: '/jetpack/connect?url=' + siteUrl,
-			},
 			THEME: {
 				label: translate( 'Choose a Theme' ),
 				url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
@@ -71,6 +67,10 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 			BLOG: {
 				label: translate( 'Write your first blog post' ),
 				url: siteUrl + '/wp-admin/post-new.php',
+			},
+			VISIT_SITE: {
+				label: translate( 'Visit your site' ),
+				url: siteUrl,
 			},
 		};
 
@@ -110,8 +110,8 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 					</div>
 				</div>
 				<div className="steps__button-group">
-					<Button href={ siteUrl } primary>
-						{ translate( 'Visit your site' ) }
+					<Button href={ '/jetpack/connect?url=' + siteUrl } primary>
+						{ translate( 'Connect to WordPress.com' ) }
 					</Button>
 				</div>
 			</div>


### PR DESCRIPTION
This PR makes JPC a more obvious step forward in favor of visiting a site. It also moves the "visit your site" option at the bottom, as it probably doesn't make sense to direct them to the frontend of the site as a first suggestion.

Before:

![](https://cldup.com/kWG7T-_xc1.png)

After:

![](https://cldup.com/3M3xZ-Yd-D.png)

To test:
* Checkout this branch
* Go through the onboarding flow
* Reach the summary step
* Verify it appears as on the "After" screenshot
* Verify the "Visit your site" link leads to the site.
* Verify the "Connect to WordPress.com" link leads to the JPC flow.