### PR TITLE
Inline Help: clean up Tracks events payloads

### DIFF
--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -59,7 +59,7 @@ class InlineHelpSearchCard extends Component {
 
 	onSearch = searchQuery => {
 		debug( 'search query received: ', searchQuery );
-		this.props.recordTracksEvent( 'calypso_inlinehelp_search', { searchQuery } );
+		this.props.recordTracksEvent( 'calypso_inlinehelp_search', { search_query: searchQuery } );
 		this.props.requestInlineHelpSearchResults( searchQuery );
 	};
 

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -140,7 +140,6 @@ class InlineHelpSearchResults extends Component {
 	followHelpLink = ( url ) => {
 		const payload = {
 			search_query: this.props.searchQuery,
-			current_url: window.location.href,
 			result_url: url,
 		};
 		return () => {

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -139,9 +139,9 @@ class InlineHelpSearchResults extends Component {
 
 	followHelpLink = ( url ) => {
 		const payload = {
-			searchQuery: this.props.searchQuery,
-			currentUrl: window.location.href,
-			resultUrl: url,
+			search_query: this.props.searchQuery,
+			current_url: window.location.href,
+			result_url: url,
 		};
 		return () => {
 			this.props.recordTracksEvent( 'calypso_inlinehelp_link_open', payload );

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -27,10 +27,12 @@ import { didOpenResult, setSearchResults } from 'state/inline-help/actions';
 class InlineHelpSearchResults extends Component {
 	static propTypes = {
 		translate: PropTypes.func,
+		searchQuery: PropTypes.string,
 	};
 
 	static defaultProps = {
 		translate: identity,
+		searchQuery: '',
 	};
 
 	getContextResults = () => {


### PR DESCRIPTION
This PR updates the Tracks events' payloads in Inline Help to use snake_case to conform with the Tracks naming conventions. 

To test:
- Use Inline Help (open / close, search, follow a search result); monitor the Tracks events that get sent and their properties to see whether they match naming conventions now. 