### PR TITLE
Ask the API to return the `site_goals` option for every sites

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -90,7 +90,7 @@ export function requestSites() {
 				fields:
 					'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
 				options:
-					'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset,is_wpcom_store,signup_is_store,has_pending_automated_transfer,woocommerce_is_active,design_type', //eslint-disable-line max-len
+					'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset,is_wpcom_store,signup_is_store,has_pending_automated_transfer,woocommerce_is_active,design_type,site_goals', //eslint-disable-line max-len
 			} )
 			.then( response => {
 				dispatch( receiveSites( response.sites ) );


### PR DESCRIPTION
Requires server-side patch D9970.

This PR updates the requestSites action to return the `site_goals` option as selected during site creation by our users.

For Google My Business (GMB), we will need that information to display a nudge to connect with GMB if the goal of the site is `"promote"`.

### Testing Instructions
- Apply the server patch and proxy
- Checkout this branch locally and boot your server `npm start`)
- Load http://calypso.localhost:3000/
- Login if you are not
- Inspect the network request in chrome devtools
- Find `/me/sites` and check that the `options` attribute of each sites now has a `site_goals` property

![image](https://user-images.githubusercontent.com/230230/35865600-3c285a4c-0b55-11e8-99b4-c28726987293.png)

### Reviews
- [ ] Code
- [ ] Product
