### PR TITLE
Chart: don't resize multiple times on initial load

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -44,7 +44,11 @@ class Chart extends React.Component {
 		this.resize = throttle( this.resize, 400 );
 		window.addEventListener( 'resize', this.resize );
 
-		this.resize( this.props );
+		const { data, loading } = this.props;
+
+		if ( data && data.length && ! loading ) {
+			this.resize( this.props );
+		}
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
@jsnajdr noticed that `components/chart` is resized/updated multiple times on Stats initial load. In this PR, we are adding some checks so that Chart won't call `resize` unnecessarily.

## Testing

You can add `console.log` into `Chart`'s `resize` method and see if it's called just once on Stats initial load — both with empty local state and cached local state.