### PR TITLE
Jetpack connect: Add jetpack/connection-rebranding feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -59,6 +59,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
+		"jetpack/connection-rebranding": true,
 		"jetpack/happychat": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,


### PR DESCRIPTION
This PR just adds a feature flag, enabled in development: `jetpack/connection-rebranding`

The only real review point here is the feature flag name 🙂 