### PR TITLE
Site Settings: hide site language selector in Jetpack

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -573,8 +573,7 @@ const connectComponent = connect(
 		return {
 			siteIsJetpack,
 			siteSlug: getSelectedSiteSlug( state ),
-			supportsLanguageSelection:
-				! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '5.8-alpha' ),
+			supportsLanguageSelection: ! siteIsJetpack,
 			supportsHolidaySnowOption: ! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '4.0' ),
 		};
 	},


### PR DESCRIPTION
## This PR
- hides the language selector in Jetpack while we're investigating an issue where the language settings aren't saving

## How to test
- Navigate to the Site settings on a Jetpack site
- The Language Selector shouldn't be visible