### PR TITLE
Jetpack connect: Jetpack branding

### DIFF
--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -90,7 +90,7 @@
 }
 
 .jetpack-new-site__wpcom-site {
-	
+
 	.button {
 		align-self: flex-end;
 		width: 100%;
@@ -140,24 +140,8 @@
 	.button {
 		width: 100%;
 		margin-top: 16px;
-		background: $green-jetpack;
-		border-color: darken( $green-jetpack, 15% );
 
-		&:hover,
-		&:focus {
-			border-color: darken( $green-jetpack, 30% );
-		}
-
-		&:focus {
-			box-shadow: 0 0 0 2px lighten( $green-jetpack, 25% );
-		}
-
-		&[disabled],
-		&:disabled {
-			background: tint( $green-jetpack, 50% );
-			border-color: tint( $green-jetpack, 35% );
-			color: $white;
-		}
+		@extend .jetpack-connect__main.jetpack-branded .button.is-primary;
 	}
 }
 

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -90,7 +90,6 @@
 }
 
 .jetpack-new-site__wpcom-site {
-
 	.button {
 		align-self: flex-end;
 		width: 100%;

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -138,10 +138,26 @@
 	}
 
 	.button {
-		width: 100%;
+		background-color: $green-jetpack;
+		border-color: darken($green-jetpack, 5%);
 		margin-top: 16px;
+		width: 100%;
 
-		@extend .jetpack-connect__main.jetpack-branded .button.is-primary;
+		&:hover,
+		&:focus {
+			border-color: darken($green-jetpack, 30%);
+		}
+
+		&:focus {
+			box-shadow: 0 0 0 2px lighten($green-jetpack, 25%);
+		}
+
+		&[disabled],
+		&:disabled {
+			background: tint($green-jetpack, 50%);
+			border-color: tint($green-jetpack, 35%);
+			color: $white;
+		}
 	}
 }
 

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -9,15 +9,28 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import JetpackLogo from 'components/jetpack-logo';
 import Main from 'components/main';
+import { isEnabled } from 'config';
 import { retrieveMobileRedirect } from './persistence-utils';
 
 const JetpackConnectMainWrapper = ( { isWide, className, children } ) => {
+	const jetpackBranded = isEnabled( 'jetpack/connection-rebranding' );
 	const wrapperClassName = classNames( 'jetpack-connect__main', {
 		'is-wide': isWide,
 		'is-mobile-app-flow': !! retrieveMobileRedirect(),
+		'jetpack-branded': jetpackBranded,
 	} );
-	return <Main className={ classNames( className, wrapperClassName ) }>{ children }</Main>;
+	return (
+		<Main className={ classNames( className, wrapperClassName ) }>
+			{ jetpackBranded && (
+				<div className="jetpack-connect__main-logo">
+					<JetpackLogo full size={ 100 /* @todo get real size from designs */ } />
+				</div>
+			) }
+			{ children }
+		</Main>
+	);
 };
 
 JetpackConnectMainWrapper.propTypes = {

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -25,7 +25,7 @@ const JetpackConnectMainWrapper = ( { isWide, className, children } ) => {
 		<Main className={ classNames( className, wrapperClassName ) }>
 			{ jetpackBranded && (
 				<div className="jetpack-connect__main-logo">
-					<JetpackLogo full size={ 100 /* @todo get real size from designs */ } />
+					<JetpackLogo full size={ 45 } />
 				</div>
 			) }
 			{ children }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -148,7 +148,7 @@ export class JetpackSignup extends Component {
 							{ auth_approved: true },
 							window.location.href
 						) }
-						submitButtonText={ this.props.translate( 'Sign Up and Connect Jetpack' ) }
+						submitButtonText={ this.props.translate( 'Create your account' ) }
 						submitForm={ this.handleSubmitSignup }
 						submitting={ isAuthorizing }
 						suggestedUsername={ get( userData, 'username', '' ) }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -19,6 +19,21 @@
 			display: none;
 		}
 	}
+
+	&.jetpack-branded {
+		.button.is-primary {
+			background-color: $green-jetpack;
+			border-color: #00a523;
+		}
+	}
+}
+
+.jetpack-connect__main-logo {
+	text-align: center;
+
+	.jetpack-logo__icon {
+		fill: $green-jetpack;
+	}
 }
 
 .jetpack-connect__main.is-wide {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -23,7 +23,7 @@
 	&.jetpack-branded {
 		.button.is-primary {
 			background-color: $green-jetpack;
-			border-color: #00a523;
+			border-color: darken($green-jetpack, 5%);
 		}
 	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -22,7 +22,6 @@
 
 	// @todo
 	// Remove extra .jetpack-branded class when feature flag is removed.
-	// Update jetpack-new-site/style.scss button @extend accordingly
 	&.jetpack-branded {
 		.button.is-primary {
 			background-color: $green-jetpack;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -20,15 +20,28 @@
 		}
 	}
 
+	// @todo
+	// Remove extra .jetpack-branded class when feature flag is removed.
+	// Update jetpack-new-site/style.scss button @extend accordingly
 	&.jetpack-branded {
 		.button.is-primary {
 			background-color: $green-jetpack;
 			border-color: darken($green-jetpack, 5%);
 
+			&:hover,
+			&:focus {
+				border-color: darken($green-jetpack, 30%);
+			}
+
+			&:focus {
+				box-shadow: 0 0 0 2px lighten($green-jetpack, 25%);
+			}
+
 			&[disabled],
-			&:disabled,
-			&.disabled {
-				@extend .button[disabled];
+			&:disabled {
+				background: tint($green-jetpack, 50%);
+				border-color: tint($green-jetpack, 35%);
+				color: $white;
 			}
 		}
 	}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -24,6 +24,12 @@
 		.button.is-primary {
 			background-color: $green-jetpack;
 			border-color: darken($green-jetpack, 5%);
+
+			&[disabled],
+			&:disabled,
+			&.disabled {
+				@extend .button[disabled];
+			}
 		}
 	}
 }

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -45,7 +45,7 @@ exports[`JetpackSignup should render 1`] = `
         </LoggedOutFormLinks>
       }
       redirectToAfterLoginUrl="https://example.com/?auth_approved=true"
-      submitButtonText="Sign Up and Connect Jetpack"
+      submitButtonText="Create your account"
       submitForm={[Function]}
       submitting={false}
       suggestedUsername=""
@@ -104,7 +104,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
       }
       locale="es"
       redirectToAfterLoginUrl="https://example.com/?auth_approved=true"
-      submitButtonText="Sign Up and Connect Jetpack"
+      submitButtonText="Create your account"
       submitForm={[Function]}
       submitting={false}
       suggestedUsername=""


### PR DESCRIPTION
Add the logo to the top of the Jetpack connect main wrapper.
Make the primary button in Jetpack connect green.

Plans page is unaffected, header text changes in another pr (#22523)

see p1HpG7-4Mw-p2

## Screens

### Button states

I've updated the primary button states based on some existing work at https://wordpress.com/jetpack/new —
 7b8e637

I've also updated the button there to leverage the styles defined here which are slightly different using `@extend`.

#### Disabled

![disabled](https://user-images.githubusercontent.com/841763/36370828-5f63b186-1560-11e8-8313-1efb7a32f9c7.png)

#### Hover

![hover](https://user-images.githubusercontent.com/841763/36370829-5f8aaea8-1560-11e8-9f12-0c9860bf99f2.png)

#### Focus

![focus](https://user-images.githubusercontent.com/841763/36370801-4d13a400-1560-11e8-8f52-0c4cfc4872b1.png)


### Site entry (`/jetpack/connect`)

This wasn't included in designs, but I assume that was an oversight and included it here.

#### Before

![b-entry](https://user-images.githubusercontent.com/841763/36369204-b14c2a6a-155a-11e8-9d24-c0108b2a81e7.png)

#### After

![a-entry](https://user-images.githubusercontent.com/841763/36369208-b3052b22-155a-11e8-92ba-5facd0195ba7.png)

### Signup

#### Before

![b-signup](https://user-images.githubusercontent.com/841763/36369222-bc9c5480-155a-11e8-86fa-78b2939b6e16.png)

#### After

![a-signup](https://user-images.githubusercontent.com/841763/36369216-b8940216-155a-11e8-851c-e16e60ed6e5f.png)

### Authorize

#### Before

![b-auth](https://user-images.githubusercontent.com/841763/36369270-f7d1d1ec-155a-11e8-8d74-fc7cbdd2145e.png)

#### After

![a-auth](https://user-images.githubusercontent.com/841763/36369268-f582c946-155a-11e8-8784-88d2c9d8912b.png)

## Testing

Go through the flow and validate designs (p1HpG7-4Mw-p2). Changes are visual (no functional changes) and only available in development and wpcalypso environments. They can be seen on [calypso.live](https://calypso.live/jetpack/connect?branch=update/jetpack/branded-logo-jpc)