### PR TITLE
 Define lighten|darken( $gray, 10|20|30% ) as SCSS variables

### DIFF
--- a/assets/stylesheets/_main.scss
+++ b/assets/stylesheets/_main.scss
@@ -6,7 +6,7 @@ $sidebar-width-max: 272px;
 $sidebar-width-min: 228px;
 
 .wpcom-site__logo {
-	color: lighten( $gray, 20% );
+	color: $gray-lighten-20;
 	font-size: 12vw;
 	position: fixed;
 		top: 50%;
@@ -148,7 +148,7 @@ h1,h2,h3,h4,h5,h6 {
 	clear: both;
 }
 hr {
-	background: lighten( $gray, 20% );
+	background: $gray-lighten-20;
 	border: 0;
 	height: 1px;
 	margin-bottom: 1.5em;
@@ -206,7 +206,7 @@ code, kbd, tt, var {
 	font: 15px $code;
 }
 abbr, acronym {
-	border-bottom: 1px dotted darken( $gray, 20% );
+	border-bottom: 1px dotted $gray-darken-20;
 	cursor: help;
 	// Prevent double underline in Chrome
 	text-decoration: none;

--- a/assets/stylesheets/directly.scss
+++ b/assets/stylesheets/directly.scss
@@ -125,7 +125,7 @@ textarea {
 /* HEADER */
 
 .header-container {
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 	box-shadow: none;
 	flex: 0 0 32px;
 	height: 32px;
@@ -183,7 +183,7 @@ textarea {
 }
 
 .chat-list-view-item-container {
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 	border-bottom: 1px solid lighten( $gray, 25% );
 	color: $gray-dark;
 	padding: 18px 10px 18px 24px;
@@ -311,7 +311,7 @@ textarea {
 		font-weight: 500;
 	}
 	.profile .reputation {
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 	}
 }
 .avatar {
@@ -320,7 +320,7 @@ textarea {
 
 .system-message {
 	border: 1px solid lighten( $gray, 25% );
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 	font-size: 14px;
 	margin-right: 0;
 	border-radius: 8px;
@@ -399,7 +399,7 @@ textarea {
 
 // Reply box and other tools in the thread view footer
 .thread-view-footer {
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	box-shadow: none;
 	background: $white;
 }
@@ -453,15 +453,15 @@ textarea {
 .toolbar-accepted-container,
 .toolbar-default-container,
 .toolbar-rate-container {
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 }
 .toolbar-container {
 	.tooltip-wrapper {
-		border-left: 1px solid lighten( $gray, 30% );
+		border-left: 1px solid $gray-lighten-30;
 	}
 	.toolbar-btn {
 		color: $gray;
-		border-left: 1px solid lighten( $gray, 30% );
+		border-left: 1px solid $gray-lighten-30;
 		.svg-icon {
 			color: $alert-green;
 		}

--- a/assets/stylesheets/shared/_animation.scss
+++ b/assets/stylesheets/shared/_animation.scss
@@ -250,7 +250,7 @@ html {
 }
 
 @keyframes pulse-light {
-	50% { background-color: lighten( $gray, 30% ); }
+	50% { background-color: $gray-lighten-30; }
 }
 
 @keyframes loading-dot-pulse {

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -13,12 +13,12 @@
 	--masterbar-toggle-drafts-editor-hover-background: darken( $blue-wordpress, 17% );
 
 	--sidebar-color: $gray-dark;
-	--sidebar-background: lighten( $gray, 30% );
+	--sidebar-background: $gray-lighten-30;
 	--sidebar-gridicon-fill: $gray;
-	--sidebar-heading-color: darken( $gray, 10% );
-	--sidebar-footer-button-color: darken( $gray, 10% );
-	--sidebar-menu-link-secondary-text-color: darken( $gray, 20% );
-	--sidebar-menu-a-first-child-after-background: hex-to-rgb( lighten( $gray, 30% ) );
+	--sidebar-heading-color: $gray-darken-10;
+	--sidebar-footer-button-color: $gray-darken-10;
+	--sidebar-menu-link-secondary-text-color: $gray-darken-20;
+	--sidebar-menu-a-first-child-after-background: hex-to-rgb( $gray-lighten-30 );
 	--sidebar-menu-selected-background-color: $gray-text-min;
 	--sidebar-menu-selected-a-color: $white;
 	--sidebar-menu-selected-a-first-child-after-background: hex-to-rgb( $gray-text-min );
@@ -26,24 +26,24 @@
 	--button-is-borderless-color: $gray-text-min;
 	--count-border-color: $gray;
 	--count-color: $gray-text-min;
-	--current-site-switch-sites-background: lighten( $gray, 30% );
-	--profile-gravatar-user-secondary-info-color: darken( $gray, 20% );
+	--current-site-switch-sites-background: $gray-lighten-30;
+	--profile-gravatar-user-secondary-info-color: $gray-darken-20;
 }
 
 //additional color schemes
 .color-scheme {
 	&.is-light {
 		--masterbar-color: $gray-text;
-		--masterbar-background: lighten( $gray, 20% );
-		--masterbar-border-color: lighten( $gray, 10% );
-		--masterbar-item-hover-background: lighten( $gray, 30% );
-		--masterbar-item-active-background: lighten( $gray, 10% );
+		--masterbar-background: $gray-lighten-20;
+		--masterbar-border-color: $gray-lighten-10;
+		--masterbar-item-hover-background: $gray-lighten-30;
+		--masterbar-item-active-background: $gray-lighten-10;
 		--masterbar-item-new-color: $gray-text;
-		--masterbar-item-new-editor-background: darken( $gray, 20% );
-		--masterbar-item-new-editor-hover-background: darken( $gray, 10% );
-		--masterbar-toggle-drafts-editor-background: darken( $gray, 10% );
-		--masterbar-toggle-drafts-editor-border-color: lighten( $gray, 20% );
-		--masterbar-toggle-drafts-editor-hover-background: darken( $gray, 10% );
+		--masterbar-item-new-editor-background: $gray-darken-20;
+		--masterbar-item-new-editor-hover-background: $gray-darken-10;
+		--masterbar-toggle-drafts-editor-background: $gray-darken-10;
+		--masterbar-toggle-drafts-editor-border-color: $gray-lighten-20;
+		--masterbar-toggle-drafts-editor-hover-background: $gray-darken-10;
 
 		--sidebar-color: $gray-dark;
 		--sidebar-background: $white;
@@ -52,9 +52,9 @@
 		--sidebar-footer-button-color: $gray-dark;
 		--sidebar-menu-link-secondary-text-color: $gray-dark;
 		--sidebar-menu-a-first-child-after-background: hex-to-rgb( $white );
-		--sidebar-menu-selected-background-color: lighten( $gray, 20% );
+		--sidebar-menu-selected-background-color: $gray-lighten-20;
 		--sidebar-menu-selected-a-color: $gray-dark;
-		--sidebar-menu-selected-a-first-child-after-background: hex-to-rgb( lighten( $gray, 20% ) );
+		--sidebar-menu-selected-a-first-child-after-background: hex-to-rgb( $gray-lighten-20 );
 
 		--button-is-borderless-color: $gray-dark;
 		--count-border-color: $gray-dark;
@@ -67,22 +67,22 @@
 		--masterbar-color: $white;
 		--masterbar-background: $gray-dark;
 		--masterbar-border-color: $white;
-		--masterbar-item-hover-background: darken( $gray, 10% );
+		--masterbar-item-hover-background: $gray-darken-10;
 		--masterbar-item-active-background: $gray-text-min;
 		--masterbar-item-new-color: $gray-dark;
 		--masterbar-item-new-editor-background: $gray-text-min;
 		--masterbar-item-new-editor-hover-background: lighten( $gray-text-min, 5% );
-		--masterbar-toggle-drafts-editor-background: darken( $gray, 10% );
+		--masterbar-toggle-drafts-editor-background: $gray-darken-10;
 		--masterbar-toggle-drafts-editor-border-color: $gray-dark;
 		--masterbar-toggle-drafts-editor-hover-background: lighten( $gray-text-min, 5% );
 
 		--sidebar-color: $white;
-		--sidebar-background: darken( $gray, 30% );
+		--sidebar-background: $gray-darken-30;
 		--sidebar-gridicon-fill: $white;
 		--sidebar-heading-color: $white;
 		--sidebar-footer-button-color: $white;
 		--sidebar-menu-link-secondary-text-color: $white;
-		--sidebar-menu-a-first-child-after-background: hex-to-rgb( darken( $gray, 30% ) );
+		--sidebar-menu-a-first-child-after-background: hex-to-rgb( $gray-darken-30 );
 		--sidebar-menu-selected-background-color: $gray-dark;
 		--sidebar-menu-selected-a-color: $white;
 		--sidebar-menu-selected-a-first-child-after-background: hex-to-rgb( $gray-dark );
@@ -90,7 +90,7 @@
 		--button-is-borderless-color: $white;
 		--count-border-color: $white;
 		--count-color: $white;
-		--current-site-switch-sites-background: darken( $gray, 30% );
+		--current-site-switch-sites-background: $gray-darken-30;
 		--profile-gravatar-user-secondary-info-color: $white;
 	}
 }

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -51,7 +51,7 @@ $green-text-min:          darken( $alert-green, 14% ); // #358649
 
 // Layout
 $masterbar-color:          $blue-wordpress;
-$sidebar-bg-color:         lighten( $gray, 30% );
+$sidebar-bg-color:         $gray-lighten-30;
 $sidebar-text-color:       $gray-dark;
 $sidebar-selected-color:   $gray-text-min;
 

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -17,13 +17,13 @@ $gray-dark:              darken( $gray, 38% ); //#2e4453
 $gray-text:              $gray-dark;
 $gray-text-min:          darken( $gray, 18% ); //#537994
 
-// $gray color functions:
-// lighten( $gray, 10% ) //#a8bece
-// lighten( $gray, 20% ) //#c8d7e1
-// lighten( $gray, 30% ) //#e9eff3
-// darken( $gray, 10% ) //#668eaa
-// darken( $gray, 20% ) //#4f748e
-// darken( $gray, 30% ) //#3d596d
+// Shades of gray
+$gray-lighten-10: lighten( $gray, 10% ); // #a8bece
+$gray-lighten-20: lighten( $gray, 20% ); // #c8d7e1
+$gray-lighten-30: lighten( $gray, 30% ); // #e9eff3
+$gray-darken-10:  darken( $gray, 10% );  // #668eaa
+$gray-darken-20:  darken( $gray, 20% );  // #4f748e
+$gray-darken-30:  darken( $gray, 30% );  // #3d596d
 //
 // See wordpress.com/design-handbook/colors/ for more info.
 

--- a/assets/stylesheets/shared/_dropdowns.scss
+++ b/assets/stylesheets/shared/_dropdowns.scss
@@ -88,14 +88,14 @@
 
 	&:after {
 		background: $gray-light;
-		border: 1px solid lighten( $gray, 20% );
+		border: 1px solid $gray-lighten-20;
 		border-radius: 3px;
 		display: inline-block;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
 		font: normal 18px/1 Noticons;
 		content: '\f445';
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		position: absolute;
 			top: 0;
 			left: 0;
@@ -108,7 +108,7 @@
 	}
 
 	&:hover:after {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 	}
 
 	&.gear-open {

--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -16,7 +16,7 @@
 	color: $gray-dark;
 	font-size: 16px;
 	line-height: 1.5;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	background-color: $white;
 	transition: all .15s ease-in-out;
 	box-sizing: border-box;
@@ -26,7 +26,7 @@
 	}
 
 	&:hover {
-		border-color: lighten( $gray, 10% );
+		border-color: $gray-lighten-10;
 	}
 
 	&:focus {
@@ -41,17 +41,17 @@
 
 	&:disabled {
 		background: $gray-light;
-		border-color: lighten( $gray, 30% );
-		color: lighten( $gray, 10% );
+		border-color: $gray-lighten-30;
+		color: $gray-lighten-10;
 		opacity: 1;
-		-webkit-text-fill-color: lighten( $gray, 10% );
+		-webkit-text-fill-color: $gray-lighten-10;
 
 		&:hover {
 			cursor: default;
 		}
 
 		&::placeholder {
-			color: lighten( $gray, 10% );
+			color: $gray-lighten-10;
 		}
 	}
 
@@ -173,7 +173,7 @@ input[type=checkbox] {
 		color: $blue-medium;
 	}
 	&:disabled:checked:before {
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 	}
 }
 
@@ -197,7 +197,7 @@ input[type=radio] {
 	}
 
 	&:disabled:checked:before {
-		background: lighten( $gray, 30% );
+		background: $gray-lighten-30;
 	}
 }
 
@@ -234,7 +234,7 @@ input[type=radio] {
 
 select {
 	background: $white url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==) no-repeat right 10px center;
-	border-color: lighten( $gray, 20% );
+	border-color: $gray-lighten-20;
 	border-style: solid;
 	border-radius: 4px;
 	border-width: 1px 1px 2px;

--- a/assets/stylesheets/shared/mixins/_heading.scss
+++ b/assets/stylesheets/shared/mixins/_heading.scss
@@ -3,7 +3,7 @@
 // ==========================================================================
 
 @mixin heading {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-size: 2rem;
 	font-weight: 300;
 	margin: 1em 0;

--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -140,7 +140,7 @@
 }
 
 .auth__lost-password a {
-	color: lighten( $gray, 20% );
+	color: $gray-lighten-20;
 }
 
 // should be a new component

--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -23,7 +23,7 @@
 	cursor: pointer;
 
 	svg {
-		fill: lighten( $gray, 20% );
+		fill: $gray-lighten-20;
 	}
 }
 
@@ -34,8 +34,8 @@
 	background-color: $white;
 	color: $blue-medium;
 	font-size: 12px;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 
 	&:hover {
 		text-decoration: underline;

--- a/client/blocks/author-selector/style.scss
+++ b/client/blocks/author-selector/style.scss
@@ -4,7 +4,7 @@
 	.gridicon {
 		display: inline;
 		vertical-align: middle;
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 	}
 
 	&.is-open .gridicon {
@@ -15,7 +15,7 @@
 	&.is-open {
 		.gridicon,
 		.editor-author__name {
-			color: darken( $gray, 30% );
+			color: $gray-darken-30;
 		}
 	}
 }

--- a/client/blocks/blog-stickers/style.scss
+++ b/client/blocks/blog-stickers/style.scss
@@ -22,7 +22,7 @@
 	position: relative;
 
 	&::before {
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 		content: " • ";
 		position: absolute;
 			left: 0;

--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -1,6 +1,6 @@
 // The main comment list wrapper
 .comments__comment-list {
-	border-top: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
 	clear: both;
 	margin: 36px 0 0;
 	padding-top: 11px;
@@ -89,7 +89,7 @@
 		font-size: 12px;
 		font-weight: 600;
 		text-transform: uppercase;
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {
@@ -119,7 +119,7 @@
 	margin-bottom: -3px;
 	font-family: $sans;
 	text-align: center;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	padding-top: 22px;
 	font-size: 14px;
 }
@@ -194,7 +194,7 @@
 		font-size: 12px;
 		font-weight: 600;
 		text-transform: uppercase;
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {
@@ -284,7 +284,7 @@
 }
 
 .comments__comment-author {
-	color: darken( $gray, 30% );
+	color: $gray-darken-30;
 	display: flex;
 	flex-wrap: wrap;
 	font-size: 14px;
@@ -310,7 +310,7 @@
 
 	.gridicon {
 		height: 24px;
-		fill: lighten( $gray, 10% );
+		fill: $gray-lighten-10;
 		margin-left: 4px;
 		margin-top: 4px;
 	}
@@ -361,7 +361,7 @@
 }
 
 .comments__comment-username {
-	color: darken( $gray, 30% );
+	color: $gray-darken-30;
 	height: 21px;
 	margin-right: 7px;
 }
@@ -399,7 +399,7 @@ a.comments__comment-username {
 	word-break: break-word;
 
 	p {
-		color: darken( $gray, 30% );
+		color: $gray-darken-30;
 
 		&:last-child {
 			margin-bottom: 0;
@@ -408,9 +408,9 @@ a.comments__comment-username {
 
 	blockquote {
 		background: $gray-light;
-		border-left: 2px solid lighten( $gray, 30% );
+		border-left: 2px solid $gray-lighten-30;
 		border-radius: 0;
-		color: darken( $gray, 30% );
+		color: $gray-darken-30;
 		margin: 8px 0 16px;
 		padding: 8px 16px;
 	}
@@ -543,7 +543,7 @@ a.comments__comment-username {
 	cursor: pointer;
 	background-color: $gray-light;
 	width: 100%;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	text-align: left;
 	margin-top: 15px;
 	padding: 5px 10px 10px 12px;

--- a/client/blocks/design-menu/style.scss
+++ b/client/blocks/design-menu/style.scss
@@ -29,7 +29,7 @@
 .design-menu {
 	transform: translateX( 0 );
 	transition: all 0.15s cubic-bezier(0.075, 0.820, 0.165, 1.000);
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 	position: fixed;
 		top: 0;
 		bottom: 0;

--- a/client/blocks/disconnect-jetpack/style.scss
+++ b/client/blocks/disconnect-jetpack/style.scss
@@ -3,7 +3,7 @@
 .disconnect-jetpack {
 	text-align: center;
 	max-width: 400px;
-	color: darken($gray, 20%);
+	color: $gray-darken-20;
 
 	.disconnect-jetpack__header {
 		color: $gray-dark;
@@ -17,7 +17,7 @@
 }
 
 .disconnect-jetpack__highlight {
-	color: darken($gray, 10%);
+	color: $gray-darken-10;
 	margin-bottom: 1.5em;
 	font-size: 16px;
 }
@@ -67,7 +67,7 @@
 
 .disconnect-jetpack-dialog__dialog__action-buttons {
 	overflow: hidden;
-	border-top: 1px solid lighten($gray, 30%);
+	border-top: 1px solid $gray-lighten-30;
 	padding: 16px;
 	margin: 0 -24px -24px;
 	text-align: right;

--- a/client/blocks/follow-button/style.scss
+++ b/client/blocks/follow-button/style.scss
@@ -1,4 +1,4 @@
-$follow-button-gray-disabled: lighten( $gray, 20% );
+$follow-button-gray-disabled: $gray-lighten-20;
 
 .follow-button,
 button.follow-button {

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -39,7 +39,7 @@
 		font-weight: 400;
 		width: 100%;
 		background: $gray-light;
-		border-top: 1px solid lighten( $gray, 20% );
+		border-top: 1px solid $gray-lighten-20;
 		padding: 16px 16px 16px 48px;
 		font-size: 16px;
 		line-height: 1;

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -50,8 +50,8 @@
 
 .nps-survey__recommendation-select-wrapper {
 	background-color: $gray-light;
-	border-top: 1px solid lighten( $gray, 20% );
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
+	border-bottom: 1px solid $gray-lighten-20;
 	padding: 16px 0;
 	text-align: center;
 

--- a/client/blocks/plan-thank-you-card/style.scss
+++ b/client/blocks/plan-thank-you-card/style.scss
@@ -94,7 +94,7 @@
 	}
 
 	.thank-you-card__price {
-		color: lighten( $gray, 30% );
+		color: $gray-lighten-30;
 	}
 
 	.thank-you-card__description {

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -45,7 +45,7 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	cursor: pointer;
 
 	&:hover .form-checkbox {
-		border-color: lighten( $gray, 10% );
+		border-color: $gray-lighten-10;
 	}
 
 	padding: 16px 16px 0;
@@ -92,7 +92,7 @@ a.post-item__title-link:visited {
 	padding-right: 8px;
 
 	&:hover {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 	}
 
 	.post-item__panel.is-untitled & {

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -41,7 +41,7 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 
 .post-share__wrapper.is-placeholder {
 	padding-bottom: 24px;
-	border-bottom: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+	border-bottom: 1px solid transparentize( $gray-lighten-20, .5 );
 }
 
 .post-share__placeholder {
@@ -123,7 +123,7 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	align-items: center;
 	cursor: pointer;
 	display: flex;
-	color: lighten( $gray, 20% );
+	color: $gray-lighten-20;
 	margin-top: 16px;
 
 	&:first-of-type {
@@ -422,14 +422,14 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 }
 
 .post-share__external-url {
-	color: lighten( $gray, 20% );
+	color: $gray-lighten-20;
 	transition: color 200ms;
 	height: 24px;
 	width: 24px;
 
 	&:hover,
 	&:focus {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 	}
 }
 

--- a/client/blocks/privacy-policy-banner/style.scss
+++ b/client/blocks/privacy-policy-banner/style.scss
@@ -22,7 +22,7 @@
 	padding: 0 24px;
 	background-color: #fbfcfd;
 	height: 80px;
-	box-shadow: 0 1px 0 0 lighten( $gray, 20% ),
+	box-shadow: 0 1px 0 0 $gray-lighten-20,
 		0 1px 0 lighten( $gray, 40% );
 }
 

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -242,7 +242,7 @@
 
 // Override standard .card styles in stream
 .reader-combined-card.card {
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	box-shadow: none;
 	margin: 0 15px;
 	padding: 18px 0 0;

--- a/client/blocks/reader-email-settings/style.scss
+++ b/client/blocks/reader-email-settings/style.scss
@@ -35,7 +35,7 @@
 }
 
 .reader-email-settings .gridicons-cog {
-	fill: lighten( $gray, 10% );
+	fill: $gray-lighten-10;
 	height: 18px;
 	position: relative;
 		left: 0;

--- a/client/blocks/reader-featured-image/style.scss
+++ b/client/blocks/reader-featured-image/style.scss
@@ -1,5 +1,5 @@
 .reader-featured-image {
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -218,7 +218,7 @@
 	.feed-header__description,
 	.feed-header__follow-count {
 		color: transparent;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -47,14 +47,14 @@
 	blockquote {
 		padding: 0 24px 0 32px;
 		margin: 16px 0 32px;
-		border-left: 3px solid lighten( $gray, 30% );
-		color: darken( $gray, 20% );
+		border-left: 3px solid $gray-lighten-30;
+		color: $gray-darken-20;
 		font-weight: normal;
 		background: transparent;
 	}
 
 	hr {
-		background: lighten( $gray, 30% );
+		background: $gray-lighten-30;
 		margin: 24px 0;
 	}
 
@@ -168,7 +168,7 @@
 		margin: 0;
 		font-size: 13px;
 		text-align: center;
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 	}
 
 	// placeholder for videopress videos

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -80,7 +80,7 @@
 	z-index: z-index( '.masterbar', '.reader-visit-site' );
 
 	.external-link .gridicons-external {
-		fill: darken( $gray, 10% );
+		fill: $gray-darken-10;
 		top: 5px;
 
 		@include breakpoint( ">660px" ) {
@@ -93,7 +93,7 @@
 	}
 
 	.external-link {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		display: block;
 		padding: 10px 10px 15px 6px;
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -9,7 +9,7 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 // Adds a top border to first card in the Site Stream
 .is-reader-page .is-site-stream .reader-post-card.card {
 	&:nth-child(2) {
-		border-top: 1px solid lighten( $gray, 20% );
+		border-top: 1px solid $gray-lighten-20;
 	}
 }
 
@@ -21,7 +21,7 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 }
 
 .reader-post-card.card {
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	box-shadow: none;
 	margin: 0 15px;
 	padding: 18px 0 20px;
@@ -239,7 +239,7 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 }
 
 .reader-post-card__photo {
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -702,7 +702,7 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 }
 
 .reader-post-card__gallery-item {
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	cursor: pointer;
 	flex: 1;
 	list-style-type: none;

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -18,7 +18,7 @@
 
 .reader-post-options-menu__hr {
 	margin: 8px 0;
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 }
 
 .reader-post-options-menu__popover {

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -10,7 +10,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-recommended-sites__header {
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 	font-size: 14px;
 	font-weight: 600;
 	letter-spacing: 0.01em;
@@ -23,7 +23,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	.gridicon {
-		fill: lighten( $gray, 10% );
+		fill: $gray-lighten-10;
 		margin-right: 5px;
 		position: relative;
 			left: -2px;
@@ -112,7 +112,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		.button.is-borderless .gridicon,
 		.gridicon,
 		.gridicons-cross {
-			fill: lighten( $gray, 10% );
+			fill: $gray-lighten-10;
 			width: 14px;
 			height: 14px;
 		}

--- a/client/blocks/reader-related-card-v2/style.scss
+++ b/client/blocks/reader-related-card-v2/style.scss
@@ -194,7 +194,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-related-card-v2__blocks {
-	border-top: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
 	padding-top: 11px;
 
 	.reader-related-card-v2__post {
@@ -395,7 +395,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 // Wrapper for entire recommended block
 .reader-related-card-v2__blocks {
-	border-top: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
 	padding-top: 11px;
 
 	// Wrapper for site title and excerpt
@@ -476,7 +476,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-related-card-v2__featured-image {
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	min-height: 153px;
 
 	@media #{$reader-related-card-v2-breakpoint-small} {

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -95,7 +95,7 @@
 }
 
 .reader-share__site-selector.site-selector {
-	border-top: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
 }
 
 .reader-share__site-selector .site-selector__sites {

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -34,7 +34,7 @@
 }
 
 .reader-site-notification-settings__popout-toggle {
-	border-top: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
 	color: $gray-dark;
 	font-size: 14px;
 	padding: 10px 0 10px 15px;
@@ -53,7 +53,7 @@
 }
 
 .reader-site-notification-settings .gridicons-cog {
-	fill: lighten( $gray, 10% );
+	fill: $gray-lighten-10;
 	height: 18px;
 	position: relative;
 		left: -4px;

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -4,7 +4,7 @@
 }
 
 .reader-subscription-list-item__byline {
-	color: darken( $gray, 30% );
+	color: $gray-darken-30;
 	margin-right: 16px;
 	flex: 1 1 0px;
 }
@@ -45,7 +45,7 @@
 }
 
 .reader-subscription-list-item__by-text .reader-subscription-list-item__link {
-	color: darken( $gray, 30% );
+	color: $gray-darken-30;
 }
 
 .reader-subscription-list-item .gravatar {
@@ -73,7 +73,7 @@
 .reader-subscription-list-item__site-url,
 .reader-subscription-list-item__site-url:visited,
 .reader-subscription-list-item__timestamp {
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 }
 
 .reader-subscription-list-item__site-title,

--- a/client/blocks/sharing-preview-pane/style.scss
+++ b/client/blocks/sharing-preview-pane/style.scss
@@ -31,13 +31,13 @@
 .post-share__sharing-preview-modal-header {
 	height: 48px;
 	background: $white;
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	border-radius: 4px 4px 0 0;
 	display: flex;
 }
 
 .post-share__sharing-preview-modal-close {
-	border-right: 1px solid lighten( $gray, 20% );
+	border-right: 1px solid $gray-lighten-20;
 	width: 48px;
 	height: 49px;
 	cursor: pointer;
@@ -107,7 +107,7 @@
 	}
 
 	@include breakpoint( ">660px" ) {
-		border-right: 1px solid lighten( $gray, 20% );
+		border-right: 1px solid $gray-lighten-20;
 		flex: 0 0 250px;
 	}
 }

--- a/client/blocks/site-icon/style.scss
+++ b/client/blocks/site-icon/style.scss
@@ -7,7 +7,7 @@
 
 	// Globe icon for sites without an icon
 	&.is-blank {
-		background: lighten( $gray, 20% );
+		background: $gray-lighten-20;
 		.gridicon {
 			color: $white;
 			z-index: z-index( 'root', '.site-icon.is-blank .gridicon' );

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -20,7 +20,7 @@
 		.site__title,
 		.site__domain {
 			animation: pulse-light 0.8s ease-in-out infinite;
-			background-color: lighten( $gray, 30% );
+			background-color: $gray-lighten-30;
 			color: transparent;
 			width: 95%;
 

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -1,12 +1,12 @@
 .taxonomy-manager {
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 }
 
 .taxonomy-manager__header {
 	display: flex;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 	background: $white;
 }
 
@@ -70,7 +70,7 @@
 
 		.taxonomy-manager__list-item.is-placeholder & {
 			color: transparent;
-			background-color: lighten( $gray, 30% );
+			background-color: $gray-lighten-30;
 			animation: loading-fade 1.6s ease-in-out infinite;
 		}
 

--- a/client/blocks/term-tree-selector/style.scss
+++ b/client/blocks/term-tree-selector/style.scss
@@ -3,7 +3,7 @@
 .term-tree-selector {
 	position: relative;
 	background-color: $white;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 
 	&.is-small {
 		background-color: transparent;
@@ -87,7 +87,7 @@ input[type=checkbox].term-tree-selector__input {
 
 	.term-tree-selector__list-item.is-placeholder & {
 		color: transparent;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }

--- a/client/blocks/upload-drop-zone/style.scss
+++ b/client/blocks/upload-drop-zone/style.scss
@@ -21,7 +21,7 @@
 	&:hover {
 		border-color: $gray-dark;
 		transform: translate3d( 0, -1px, 0 );
-		box-shadow: 0 2px 4px lighten( $gray, 20% );
+		box-shadow: 0 2px 4px $gray-lighten-20;
 
 		.upload-drop-zone__icon {
 			color: $gray-dark;

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -62,8 +62,8 @@
 	height: 200px;
 
 	&.is-uploaded, &.is-uploading {
-		border: 1px solid lighten( $gray, 10% );
-		background-color: lighten( $gray, 30% );
+		border: 1px solid $gray-lighten-10;
+		background-color: $gray-lighten-30;
 	}
 }
 
@@ -83,13 +83,13 @@
 	width: 24px;
 	height: 24px;
 	transform: translate(50%, -50%);
-	border: 1px solid lighten( $gray, 10% );
+	border: 1px solid $gray-lighten-10;
 	border-radius: 50%;
 	background-color: $gray-light;
 	cursor: pointer;
 
 	&:hover {
-		border-color: darken( $gray, 10% );
+		border-color: $gray-darken-10;
 	}
 }
 
@@ -101,10 +101,10 @@
 	width: 20px;
 	height: 20px;
 	margin: 0;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 
 	&:hover {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 	}
 }
 

--- a/client/blocks/video-editor/style.scss
+++ b/client/blocks/video-editor/style.scss
@@ -24,7 +24,7 @@
 .video-editor__preview-wrapper {
 	flex: 2 0 0%;
 	position: relative;
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 
 	@include breakpoint( ">660px" ) {
 		margin: 16px 24px;

--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -44,7 +44,7 @@ $accordion-background-expanded: $white;
 			top: 50%;
 			right: ( $accordion-padding - 4px );
 		transform: translateY( -50% );
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		height: 24px;
 		.gridicon {
 			transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -39,7 +39,7 @@
 	&:hover {
 		transition: all 100ms ease-in-out;
 		&.is-card-link {
-			box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20% );
+			box-shadow: 0 0 0 1px $gray, 0 2px 4px $gray-lighten-20;
 		}
 		.card__link-indicator {
 			color: $blue-dark;

--- a/client/components/button-group/style.scss
+++ b/client/components/button-group/style.scss
@@ -62,7 +62,7 @@
 	&.is-busy {
 		animation: button__busy-animation 3000ms infinite linear;
 		background-size: 120px 100%;
-		background-image: linear-gradient( -45deg, lighten( $gray, 30% ) 28%, $white 28%, $white 72%, lighten( $gray, 30% ) 72%);
+		background-image: linear-gradient( -45deg, $gray-lighten-30 28%, $white 28%, $white 72%, $gray-lighten-30 72%);
 		display: inline-block;
 		border-radius: 4px;
 

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -16,7 +16,7 @@ button {
 
 .button {
 	background: $white;
-	border-color: lighten( $gray, 20% );
+	border-color: $gray-lighten-20;
 	border-style: solid;
 	border-width: 1px 1px 2px;
 	color: $gray-dark;
@@ -38,7 +38,7 @@ button {
 	appearance: none;
 
 	&:hover {
-		border-color: lighten( $gray, 10% );
+		border-color: $gray-lighten-10;
 		color: $gray-dark;
 	}
 	&:active {
@@ -50,9 +50,9 @@ button {
 	&[disabled],
 	&:disabled,
 	&.disabled {
-		color: lighten( $gray, 30% );
+		color: $gray-lighten-30;
 		background: $white;
-		border-color: lighten( $gray, 30% );
+		border-color: $gray-lighten-30;
 		cursor: default;
 
 		&:active {
@@ -70,7 +70,7 @@ button {
 		line-height: 1;
 
 		&:disabled {
-			color: lighten( $gray, 30% );
+			color: $gray-lighten-30;
 		}
 		.gridicon {
 			top: 5px;
@@ -93,7 +93,7 @@ button {
 	&.is-busy {
 		animation: button__busy-animation 3000ms infinite linear;
 		background-size: 120px 100%;
-		background-image: linear-gradient( -45deg, lighten( $gray, 30% ) 28%, $white 28%, $white 72%, lighten( $gray, 30% ) 72%);
+		background-image: linear-gradient( -45deg, $gray-lighten-30 28%, $white 28%, $white 72%, $gray-lighten-30 72%);
 	}
 	&.hidden {
 		display: none;
@@ -124,9 +124,9 @@ button {
 	&[disabled],
 	&:disabled,
 	&.disabled {
-		color: lighten( $gray, 30% );
+		color: $gray-lighten-30;
 		background: $white;
-		border-color: lighten( $gray, 30% );
+		border-color: $gray-lighten-30;
 	}
 	&.is-busy {
 		background-size: 120px 100%;
@@ -151,7 +151,7 @@ button {
 	&[disabled],
 	&:disabled {
 		color: lighten( $alert-red, 30% );
-		border-color: lighten( $gray, 30% );
+		border-color: $gray-lighten-30;
 	}
 }
 
@@ -191,7 +191,7 @@ button {
 
 	&[disabled],
 	&:disabled {
-		color: lighten( $gray, 30% );
+		color: $gray-lighten-30;
 		cursor: default;
 
 		&:active {
@@ -221,7 +221,7 @@ button {
 		}
 
 		&[disabled] {
-			color: lighten( $gray, 30% );
+			color: $gray-lighten-30;
 		}
 	}
 

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -5,8 +5,8 @@
 	padding: 16px;
 	box-sizing: border-box;
 	background: $white;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 
 	@include clear-fix;
 

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -26,7 +26,7 @@
 		top: 0;
 	width: 100%;
 	height: 1px;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 }
 
 // Y-axis marker lines inside each chart__bar
@@ -37,7 +37,7 @@
 		top: 0;
 	width: 100%;
 	height: 1px;
-	border-top: 1px solid rgba( lighten( $gray, 30% ), .1 );
+	border-top: 1px solid rgba( $gray-lighten-30, .1 );
 }
 
 .chart__bar-marker,
@@ -61,7 +61,7 @@
 	height: 200px;
 	padding: 0 20px 0 10px;
 	font-size: 11px;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	margin-bottom: 30px;
 }
 
@@ -85,7 +85,7 @@
 	font-size: 0; // 1
 	padding: 5px 0;
 	min-height: 18px;
-	color: darken( $gray, 30% );
+	color: $gray-darken-30;
 }
 
 .chart__x-axis-label {
@@ -109,7 +109,7 @@
 	width: 1px;
 	height: 5px;
 	background: $gray-light;
-	background-image: linear-gradient(to bottom, $gray-light 0%, lighten( $gray, 20% ) 100%);
+	background-image: linear-gradient(to bottom, $gray-light 0%, $gray-lighten-20 100%);
 }
 
 // Bar wrapper
@@ -140,12 +140,12 @@
 
 
 	&.is-weekend {
-		background-color: rgba( lighten( $gray, 30% ), .5 );
+		background-color: rgba( $gray-lighten-30, .5 );
 	}
 
 	&:hover {
 		cursor: pointer;
-		background-color: rgba( lighten( $gray, 30% ), .3 );
+		background-color: rgba( $gray-lighten-30, .3 );
 	}
 
 	&.is-selected {
@@ -193,7 +193,7 @@
 		z-index: z-index( 'root', '.chart__bar-section.is-ghost::after' );
 		width: 100%;
 		height: 40px;
-		background-image: linear-gradient(to bottom, $transparent, rgba( lighten( $gray, 30% ), .5 ) ); // TODO: needs to use default color for gradient
+		background-image: linear-gradient(to bottom, $transparent, rgba( $gray-lighten-30, .5 ) ); // TODO: needs to use default color for gradient
 
 		.chart__bar:hover & {
 			display: none;
@@ -331,8 +331,8 @@
 	font-size: 14px;
 	line-height: 1.4285;
 	animation: appear .3s ease-in-out;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 
 	@include breakpoint( ">660px" ) {
 		padding: 13px 48px;
@@ -383,7 +383,7 @@
 					text-align: right;
 					float: right;
 					min-width: 22px;
-					color: lighten( $gray, 20% );
+					color: $gray-lighten-20;
 				}
 
 				.label {
@@ -446,7 +446,7 @@
 
 		.label {
 			text-transform: none;
-			color: lighten( $gray, 20% );
+			color: $gray-lighten-20;
 			overflow: hidden;
 			letter-spacing: 0;
 			height: 19px;

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -104,7 +104,7 @@
 		top: 0;
 		bottom: 0;
 		left: 34px;
-		border-left: 1px solid lighten($gray, 20%);
+		border-left: 1px solid $gray-lighten-20;
 	}
 
 	&-icon {
@@ -114,7 +114,7 @@
 		left: 24px;
 		width: 16px;
 		height: 16px;
-		border: 2px solid lighten($gray, 20%);
+		border: 2px solid $gray-lighten-20;
 		border-radius: 16px;
 		background: $white;
 		cursor: pointer;

--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -77,7 +77,7 @@
 	}
 
 	label {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		font-size: 11px;
 		font-weight: bold;
 		position: absolute;
@@ -89,7 +89,7 @@
 
 .credit-card-form-fields__info-text {
 	margin-left: 15px;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 	display: block;
 	font-size: 12px;
 	font-style: italic;

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -36,7 +36,7 @@ $date-picker_nav_button_size: 20px;
 	width: 100%;
 
 	&:after {
-		@include long-content-fade( $color: darken( $gray, 30% ) );
+		@include long-content-fade( $color: $gray-darken-30 );
 	}
 }
 
@@ -141,7 +141,7 @@ $date-picker_nav_button_size: 20px;
 	font-size: 11px;
 	text-align: center;
 	font-weight: 600;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	text-transform: uppercase;
 
 	abbr {
@@ -206,7 +206,7 @@ $date-picker_nav_button_size: 20px;
 	background-color: $gray-dark;
 
 	&:hover {
-		background-color: darken( $gray, 20% );
+		background-color: $gray-darken-20;
 	}
 }
 
@@ -218,7 +218,7 @@ $date-picker_nav_button_size: 20px;
 
 // `disabled` day
 .DayPicker-Day--disabled:not(.DayPicker-Day--outside) .date-picker__day {
-	color: lighten( $gray, 20% );
+	color: $gray-lighten-20;
 	cursor: default;
 }
 
@@ -247,7 +247,7 @@ $date-picker_nav_button_size: 20px;
 }
 
 .DayPicker-Day--events.DayPicker-Day--disabled:not(.DayPicker-Day--is-selected) .date-picker__day {
-	border-color: lighten( $gray, 20% );
+	border-color: $gray-lighten-20;
 }
 
 @keyframes isSelectedDay {

--- a/client/components/dialog/style.scss
+++ b/client/components/dialog/style.scss
@@ -12,13 +12,13 @@
 
 	&.dialog-enter,
 	&.dialog-leave.dialog-leave-active {
-		background-color: rgba( lighten( $gray, 30% ), 0 );
+		background-color: rgba( $gray-lighten-30, 0 );
 	}
 
 	&,
 	&.dialog-enter.dialog-enter-active,
 	&.dialog-leave {
-		background-color: rgba( lighten( $gray, 30% ), 0.8 );
+		background-color: rgba( $gray-lighten-30, 0.8 );
 	}
 
 	// covers the masterbar as well
@@ -74,7 +74,7 @@
 
 .dialog__action-buttons {
 	position: relative;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	padding: 16px;
 	margin: 0;
 	text-align: right;

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -1,5 +1,5 @@
 .domain-product-price {
-	color: darken( $gray, 30% );
+	color: $gray-darken-30;
 	display: inline-block;
 	font-size: 17px;
 	font-weight: 600;
@@ -80,7 +80,7 @@
 
 		@include breakpoint( "<660px" ) {
 			animation: loading-fade 1.6s ease-in-out infinite;
-			background-color: lighten( $gray, 30% );
+			background-color: $gray-lighten-30;
 			color: transparent;
 		}
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -69,7 +69,7 @@
 
 	.is-placeholder & {
 		animation: loading-fade 1.6s ease-in-out infinite;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		color: transparent;
 		min-height: 44px;
 	}
@@ -112,7 +112,7 @@
 
 	.is-placeholder & {
 		animation: loading-fade 1.6s ease-in-out infinite;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		border: none;
 		border-radius: 0;
 		color: transparent;
@@ -129,6 +129,6 @@
 
 	.is-placeholder & {
 		animation: loading-fade 1.6s ease-in-out infinite;
-		color: lighten( $gray, 30% );
+		color: $gray-lighten-30;
 	}
 }

--- a/client/components/domains/example-domain-suggestions/style.scss
+++ b/client/components/domains/example-domain-suggestions/style.scss
@@ -7,7 +7,7 @@
 	margin: 0 auto 60px auto;
 
 	p {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 		text-align: right;
 		margin-bottom: 8px;
 	}

--- a/client/components/domains/registrant-extra-info/style.scss
+++ b/client/components/domains/registrant-extra-info/style.scss
@@ -14,7 +14,7 @@
 	display: flex;
 
 	.registrant-extra-info__optional-label {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 		font-weight: 200;
 		margin-left: 5px;
 	}

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -94,7 +94,7 @@
 }
 
 .transfer-domain-step__map-option {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 }
 
 .transfer-domain-step__map-help {
@@ -108,9 +108,9 @@
 	height: 28px;
 	line-height: 28px;
 	border-radius: 50%;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	background-color: $gray-light;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-size: 18px;
 	text-align: center;
 	margin-right: 15px;
@@ -127,7 +127,7 @@
 	}
 
 	.transfer-domain-step__section-heading {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 		align-items: center;
 		display: flex;
 		font-size: 16px;
@@ -214,7 +214,7 @@
 
 .transfer-domain-step__continue-text {
 	p {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		font-size: 14px;
 	}
 }
@@ -243,7 +243,7 @@
 
 .transfer-domain-step__options {
 	label {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 	}
 
 	legend {

--- a/client/components/empty-content/style.scss
+++ b/client/components/empty-content/style.scss
@@ -29,7 +29,7 @@
 }
 
 .empty-content__line {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-size: 22px;
 	font-weight: 300;
 	margin-bottom: 40px;

--- a/client/components/faq/style.scss
+++ b/client/components/faq/style.scss
@@ -16,7 +16,7 @@ $faq-gutter-width: 24px;
 	margin-bottom: 32px;
 	font-size: 24px;
 	font-weight: 300;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 }
 
 .faq__list {
@@ -49,12 +49,12 @@ $faq-gutter-width: 24px;
 .faq__question {
 	margin-bottom: 12px;
 	font-weight: 600;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 }
 
 .faq__answer {
 	margin-bottom: 1em;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 
 	a {
 		color: $blue-medium;

--- a/client/components/first-view/style.scss
+++ b/client/components/first-view/style.scss
@@ -52,7 +52,7 @@
 	max-width: 575px;
 	opacity: 0;
 	padding: 20px 24px 20px ( 128px + 4px + 24px );
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), 0.5 ),
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ),
 		0 8px 30px rgba( $gray, 0.2 );
 	position: relative;
 	pointer-events: auto;

--- a/client/components/forms/counted-textarea/style.scss
+++ b/client/components/forms/counted-textarea/style.scss
@@ -1,5 +1,5 @@
 .counted-textarea {
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	background-color: $gray-light;
 
 	&.is-exceeding-acceptable-length {
@@ -22,5 +22,5 @@
 .counted-textarea__count-panel {
 	padding: 8px;
 	font-size: 12px;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 }

--- a/client/components/forms/form-currency-input/style.scss
+++ b/client/components/forms/form-currency-input/style.scss
@@ -16,7 +16,7 @@
 .form-text-input-with-affixes__prefix,
 .form-text-input-with-affixes__suffix {
 	&:hover .form-currency-input__select-icon {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 	}
 }
 

--- a/client/components/forms/form-password-input/style.scss
+++ b/client/components/forms/form-password-input/style.scss
@@ -18,10 +18,10 @@
 		user-select: none;
 
 		.gridicon {
-			fill: lighten( $gray, 10% );
+			fill: $gray-lighten-10;
 
 			&:hover {
-				fill: darken( $gray, 10% );
+				fill: $gray-darken-10;
 			}
 		}
 	}

--- a/client/components/forms/form-radio-with-thumbnail/style.scss
+++ b/client/components/forms/form-radio-with-thumbnail/style.scss
@@ -6,8 +6,8 @@
 	background-color: $white;
 	background-position: 50% 0;
 	background-size: cover;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 	transition: all 100ms ease-in-out;
 	overflow: hidden;
 

--- a/client/components/forms/form-range/style.scss
+++ b/client/components/forms/form-range/style.scss
@@ -5,13 +5,13 @@
 	height: 18px;
 	margin: 0;
 	padding: 0;
-	background: lighten( $gray, 20% );
+	background: $gray-lighten-20;
 	background: linear-gradient(
 		to bottom,
 		transparent,
 		transparent 8px,
-		lighten( $gray, 20% ) 8px,
-		lighten( $gray, 20% ) 10px,
+		$gray-lighten-20 8px,
+		$gray-lighten-20 10px,
 		transparent 10px
 	);
 }

--- a/client/components/forms/form-select/style.scss
+++ b/client/components/forms/form-select/style.scss
@@ -10,7 +10,7 @@
 	}
 
 	&:disabled {
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 	}
 
 	&:focus {

--- a/client/components/forms/form-text-input-with-action/style.scss
+++ b/client/components/forms/form-text-input-with-action/style.scss
@@ -27,17 +27,17 @@
 
 	&.is-disabled {
 		background: $gray-light;
-		border-color: lighten( $gray, 30% );
-		color: lighten( $gray, 10% );
+		border-color: $gray-lighten-30;
+		color: $gray-lighten-10;
 		opacity: 1;
-		-webkit-text-fill-color: lighten( $gray, 10% );
+		-webkit-text-fill-color: $gray-lighten-10;
 
 		&:hover {
 			cursor: default;
 		}
 
 		&::placeholder {
-			color: lighten( $gray, 10% );
+			color: $gray-lighten-10;
 		}
 	}
 

--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -29,7 +29,7 @@
 			border-right-width: 0;
 
 			& + .form-text-input-with-affixes__suffix {
-				border-left: 1px solid lighten( $gray, 20% );
+				border-left: 1px solid $gray-lighten-20;
 			}
 		}
 	}
@@ -51,8 +51,8 @@
 .form-text-input-with-affixes__suffix {
 	position: relative;
 	background: $gray-light;
-	border: 1px solid lighten( $gray, 20% );
-	color: darken( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
+	color: $gray-darken-20;
 	padding: 8px 14px;
 	white-space: nowrap;
 	flex: 1 0 auto;
@@ -84,7 +84,7 @@
 	& + input[type="text"],
 	& + input[type="number"] {
 		&:disabled {
-			border-left-color: lighten( $gray, 20% );
+			border-left-color: $gray-lighten-20;
 			border-right-width: 1px;
 		}
 	}

--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -66,12 +66,12 @@
 	}
 
 	& + .form-toggle__label .form-toggle__switch {
-		background: lighten( $gray, 10% );
+		background: $gray-lighten-10;
 	}
 
 	&:not( :disabled ) {
 		+ .form-toggle__label:hover .form-toggle__switch {
-			background: lighten( $gray, 20% );
+			background: $gray-lighten-20;
 		}
 	}
 
@@ -106,7 +106,7 @@
 	}
 	&:checked {
 		+ .form-toggle__label .form-toggle__switch {
-			background: lighten( $gray, 20% );
+			background: $gray-lighten-20;
 		}
 	}
 }

--- a/client/components/forms/sortable-list/index.scss
+++ b/client/components/forms/sortable-list/index.scss
@@ -45,7 +45,7 @@
 .sortable-list__navigation-button {
 	padding: 8px;
 	background-color: lighten( $gray, 33% );
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	color: $gray;
 
 	&:not( :disabled ):hover {

--- a/client/components/gauge/style.scss
+++ b/client/components/gauge/style.scss
@@ -4,14 +4,14 @@
 	text-align: center;
 
 	.gauge__number {
-		color: darken( $gray, 30% );
+		color: $gray-darken-30;
 		display: block;
 		margin-top: -5px;
 	}
 
 	.gauge__metric {
 		display: block;
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 		text-transform: uppercase;
 		font-size: 10px;
 		letter-spacing: 0.1em;

--- a/client/components/happiness-support/style.scss
+++ b/client/components/happiness-support/style.scss
@@ -24,7 +24,7 @@
 }
 
 .happiness-support__heading {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	clear: none;
 	font-size: 21px;
 }

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -61,7 +61,7 @@
 
 	&.is-open {
 		display: block;
-		background: lighten( $gray, 30% );
+		background: $gray-lighten-30;
 		bottom: 0;
 		z-index: z-index( 'root', '.happychat__container.is-open' );
 	}
@@ -85,7 +85,7 @@
 
 .happychat__notice {
 	padding: 12px;
-	border-top: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
 	color: $white;
 	background-color: lighten( $gray-dark, 20% );
 	margin: 0;
@@ -115,7 +115,7 @@
 
 	::-webkit-scrollbar-thumb {
 		border-radius: 10px;
-		background-color: lighten( $gray, 10% );
+		background-color: $gray-lighten-10;
 		border: 3px solid transparent;
 		background-clip: padding-box;
 
@@ -134,10 +134,10 @@
 
 .layout .happychat .happychat__container.is-open.is-minimizing {
 	box-shadow: none;
-	border-top: 1px solid lighten( $gray, 20% );
-	border-left: 1px solid lighten( $gray, 20% );
-	border-right: 1px solid lighten( $gray, 20% );
-	background: lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-20;
+	border-left: 1px solid $gray-lighten-20;
+	border-right: 1px solid $gray-lighten-20;
+	background: $gray-lighten-30;
 	animation: happychat-minimize .5s 1 forwards;
 
 	> .happychat__composer,

--- a/client/components/info-popover/style.scss
+++ b/client/components/info-popover/style.scss
@@ -1,6 +1,6 @@
 .info-popover .gridicon {
 	cursor: pointer;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 
 	&:hover {
 		color: $gray-dark;
@@ -13,7 +13,7 @@
 
 .popover.info-popover__tooltip {
 	.popover__inner {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 		font-size: 13px;
 		max-width: 220px;
 		padding: 16px;

--- a/client/components/input-chrono/style.scss
+++ b/client/components/input-chrono/style.scss
@@ -3,7 +3,7 @@
 	margin: 6px auto;
 
 	.gridicons-calendar {
-		color: lighten( $gray, 20% );
+		color: $gray-lighten-20;
 		z-index: z-index( '.popover', '.input-chrono__container .gridicons-calendar' );
 		font-size: 8px;
 		width: 20px;
@@ -19,7 +19,7 @@ input.input-chrono {
 	height: 36px;
 	line-height: 36px;
 	padding: 0 10px;
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	box-sizing: border-box;
 	background-color: $transparent;
 	color: $gray-text-min;

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -1,6 +1,6 @@
 .language-picker {
 	background: $white;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	border-width: 1px 1px 2px;
 	border-radius: 4px;
 	width: 300px;
@@ -21,19 +21,19 @@
 
 		&,
 		.language-picker__icon {
-			border-color: lighten( $gray, 30% );
+			border-color: $gray-lighten-30;
 		}
 
 		&,
 		.language-picker__name-change {
-			color: lighten( $gray, 30% );
+			color: $gray-lighten-30;
 		}
 	}
 
 	&:not( [disabled] ):hover {
 		&,
 		.language-picker__icon {
-			border-color: lighten( $gray, 10% );
+			border-color: $gray-lighten-10;
 		}
 	}
 
@@ -47,7 +47,7 @@
 		.language-picker__name-inner {
 			width: 100%;
 			height: 30px;
-			background-color: lighten( $gray, 30% );
+			background-color: $gray-lighten-30;
 		}
 	}
 
@@ -60,7 +60,7 @@
 	align-items: center;
 	justify-content: center;
 	flex: none;
-	border-right: 1px solid lighten( $gray, 20% );
+	border-right: 1px solid $gray-lighten-20;
 	transition: border-color 150ms ease-in-out;
 }
 
@@ -183,7 +183,7 @@
 .language-picker__modal-suggested {
 	flex: none;
 	background: $gray-light;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	padding: 8px 16px;
 	z-index: 1;
 	position: relative;

--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -6,7 +6,7 @@
 
 .logged-out-form__footer {
 	background: lighten( $gray, 34% );
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	box-shadow: none;
 	margin: 0 -16px -16px -16px;
 	padding: 16px;
@@ -30,8 +30,8 @@
 }
 
 .logged-out-form__link-item {
-	border-bottom: 1px solid lighten( $gray, 20% );
-	color: darken( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
+	color: $gray-darken-20;
 	display: block;
 	font-family: $sans;
 	font-size: 14px;
@@ -44,7 +44,7 @@
 	}
 
 	&:visited {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 	}
 
 	&:hover {

--- a/client/components/mobile-back-to-sidebar/style.scss
+++ b/client/components/mobile-back-to-sidebar/style.scss
@@ -4,7 +4,7 @@
 	padding: 15px 0 15px 36px;
 	position: relative;
 	background: $white;
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	cursor: pointer;
 
 	@include breakpoint( ">660px" ) {

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -143,7 +143,7 @@
 	}
 
 	.notice & {
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 
 		&:hover,
 		&:focus {
@@ -159,7 +159,7 @@ a.notice__action {
 	font-weight: 400;
 	text-decoration: none;
 	white-space: nowrap;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 	padding: 13px;
 	display: flex;
 	align-items: center;

--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -24,7 +24,7 @@
 		display: block;
 		padding: 8px 12px;
 		background-color: $white;
-		border: solid 1px lighten( $gray, 20% );
+		border: solid 1px $gray-lighten-20;
 		border-right: none;
 		font-size: 14px;
 		line-height: 18px;
@@ -45,7 +45,7 @@
 	}
 
 	&:last-child .button {
-		border-right: solid 1px lighten( $gray, 20% );
+		border-right: solid 1px $gray-lighten-20;
 		border-top-right-radius: 4px;
 		border-bottom-right-radius: 4px;
 	}

--- a/client/components/phone-input/style.scss
+++ b/client/components/phone-input/style.scss
@@ -3,11 +3,11 @@
 	max-width: 24px;
 	max-height: 18px;
 	align-self: center;
-	box-shadow: 0 0 1px lighten( $gray, 20% );
+	box-shadow: 0 0 1px $gray-lighten-20;
 }
 
 .phone-input__flag-selector-icon {
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 	margin-left: 3px;
 	align-self: center;
 }
@@ -33,7 +33,7 @@
 
 .phone-input__select-inner-container {
 	margin-top: 4px;
-	border-right: 1px solid lighten( $gray, 20% );
+	border-right: 1px solid $gray-lighten-20;
 	height: 32px;
 	display: flex;
 }

--- a/client/components/plans/plan-icon/style.scss
+++ b/client/components/plans/plan-icon/style.scss
@@ -15,26 +15,26 @@
 .plan-icon__personal {
 	.plan-icon__personal-0 { fill: $alert-yellow; }
 	.plan-icon__personal-1 { fill: $gray; }
-	.plan-icon__personal-2 { fill: lighten( $gray, 20% ); }
+	.plan-icon__personal-2 { fill: $gray-lighten-20; }
 	.plan-icon__personal-3 { fill: $white; }
-	.plan-icon__personal-4 { fill: darken( $gray, 10% ); }
-	.plan-icon__personal-5 { fill: darken( $gray, 20% ); }
+	.plan-icon__personal-4 { fill: $gray-darken-10; }
+	.plan-icon__personal-5 { fill: $gray-darken-20; }
 }
 
 .plan-icon__premium {
  	.plan-icon__premium-0 { fill: $alert-green; }
 	.plan-icon__premium-1 { fill: $gray; }
-	.plan-icon__premium-2 { fill: darken( $gray, 20% ); }
+	.plan-icon__premium-2 { fill: $gray-darken-20; }
 	.plan-icon__premium-3 { fill: $white; }
-	.plan-icon__premium-4 { fill: lighten( $gray, 20% ); }
-	.plan-icon__premium-5 { fill: darken( $gray, 20% ); }
-	.plan-icon__premium-6 { fill: darken( $gray, 30% ); }
+	.plan-icon__premium-4 { fill: $gray-lighten-20; }
+	.plan-icon__premium-5 { fill: $gray-darken-20; }
+	.plan-icon__premium-6 { fill: $gray-darken-30; }
 }
 
 .plan-icon__business {
 	.plan-icon__business-0 { fill: $alert-purple; }
 	.plan-icon__business-1 { fill: $white; }
-	.plan-icon__business-2 { fill: lighten( $gray, 30% ); }
+	.plan-icon__business-2 { fill: $gray-lighten-30; }
 	.plan-icon__business-3 { fill: $blue-wordpress; }
 	.plan-icon__business-4 { fill: $blue-dark; }
 }

--- a/client/components/plans/plan-price/style.scss
+++ b/client/components/plans/plan-price/style.scss
@@ -12,7 +12,7 @@
 .wpcom-plan-price__billing-period {
 	font-size: 12px;
 	font-style: italic;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 }
 
 .plan-header .plan-price__discount,

--- a/client/components/plans/premium-popover/style.scss
+++ b/client/components/plans/premium-popover/style.scss
@@ -28,7 +28,7 @@
 	}
 
 	.wpcom-plan-price__billing-period {
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 
 		&:before {
 			content: ' ';
@@ -37,7 +37,7 @@
 
 	.premium-popover__items {
 		background: lighten( $gray, 35% );
-		border-top: 1px solid lighten( $gray, 30% );
+		border-top: 1px solid $gray-lighten-30;
 		border-radius: 0 0 4px 4px;
 		font-size: 14px;
 		list-style: none;

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -12,7 +12,7 @@
 
 	.popover__inner {
 		background-color: $white;
-		border: 1px solid lighten( $gray, 20% );
+		border: 1px solid $gray-lighten-20;
 		border-radius: 4px;
 		box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.1 ),
 			0 0 56px rgba( 0, 0, 0, 0.075 );
@@ -21,7 +21,7 @@
 	}
 
 	.popover__arrow {
-		border: 10px dashed lighten( $gray, 20% );
+		border: 10px dashed $gray-lighten-20;
 		height: 0;
 		line-height: 0;
 		position: absolute;
@@ -180,9 +180,9 @@
 	}
 
 	&[ disabled ] {
-		color: lighten( $gray, 30% );
+		color: $gray-lighten-30;
 		.gridicon {
-			color: lighten( $gray, 30% );
+			color: $gray-lighten-30;
 		}
 	}
 

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -71,7 +71,7 @@
 	left: 0;
 	height: 16px;
 	cursor: pointer;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 
 	&:hover {
 		color: $gray;
@@ -94,14 +94,14 @@
 
 hr.post-schedule__hr {
 	height: 1px;
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 	margin: 0 -16px;
 }
 
 input[type="text"].post-schedule__clock-time {
 	height: 28px;
 	display: inline-block;
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	width: 42px;
 	text-align: center;
 	padding: 0;

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -23,7 +23,7 @@
 	display: inline-block;
 	position: relative;
 	height: 9px;
-	background-color: lighten( $gray, 20% );
+	background-color: $gray-lighten-20;
 	border-radius: 4.5px;
 
 	&.is-compact {

--- a/client/components/progress-indicator/style.scss
+++ b/client/components/progress-indicator/style.scss
@@ -26,7 +26,7 @@ $progress-indicator__transition-speed: .4s;
 	width: $progress-indicator__size;
 	height: $progress-indicator__size;
 	border-radius: 50%;
-	box-shadow: inset 0 0 0 1px darken( $gray, 10% );
+	box-shadow: inset 0 0 0 1px $gray-darken-10;
 	box-sizing: border-box;
 }
 
@@ -157,7 +157,7 @@ $progress-indicator--spin-time: 3.4s;
 	left: 0;
 	width: 100%;
 	height: 100%;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	text-align: center;
 	line-height: $progress-indicator__size;
 	text-decoration: none;
@@ -211,13 +211,13 @@ $progress-indicator--spin-time: 3.4s;
 }
 
 .progress-indicator .is-problem {
-	background: darken( $gray, 10% );
+	background: $gray-darken-10;
 	border: 0;
 	border-top-right-radius: 500px;
 	border-top-left-radius: 500px;
 
 	&:before,
 	&:after {
-		background: darken( $gray, 10% );
+		background: $gray-darken-10;
 	}
 }

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -1,6 +1,6 @@
 .purchase-detail {
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 	box-sizing: border-box;
 	color: $gray-text-min;
 	position: relative;
@@ -64,7 +64,7 @@
 }
 
 .purchase-detail__icon {
-	background: darken( $gray, 20% );
+	background: $gray-darken-20;
 	border-radius: 50%;
 	color: $white;
 	margin: 0 auto 10px;
@@ -135,7 +135,7 @@
 
 .purchase-detail__title {
 	clear: none;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	font-size: 21px;
 }
 

--- a/client/components/reader-infinite-stream/style.scss
+++ b/client/components/reader-infinite-stream/style.scss
@@ -1,5 +1,5 @@
 .reader-infinite-stream__row-wrapper {
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 
 	&:last-child {
 		border: 0;

--- a/client/components/reader-popover/style.scss
+++ b/client/components/reader-popover/style.scss
@@ -1,6 +1,6 @@
 .reader-popover.popover .popover__inner {
 	background-color: $gray-light;
-	border-color: lighten( $gray, 20% );
+	border-color: $gray-lighten-20;
 }
 
 // Popover arrows
@@ -60,7 +60,7 @@
 }
 
 .reader-popover__header {
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	color: $gray-dark;
 	display: flex;
 	font-size: 14px;

--- a/client/components/remove-button/style.scss
+++ b/client/components/remove-button/style.scss
@@ -6,7 +6,7 @@
 	width: 28px;
 	height: 28px;
 	transform: translate( 25%, -25% ); /*rtl:ignore*/
-	border: 1px solid lighten( $gray, 10% );
+	border: 1px solid $gray-lighten-10;
 	border-radius: 50%;
 	background-color: $gray-light;
 	cursor: pointer;
@@ -20,5 +20,5 @@
 	width: 24px;
 	height: 24px;
 	margin: 0;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 }

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -38,11 +38,11 @@
 	}
 
 	.search__open-icon:hover {
-		color: darken( $gray, 30% );
+		color: $gray-darken-30;
 	}
 
 	.search__close-icon {
-		color: darken( $gray, 30% );
+		color: $gray-darken-30;
 		opacity: 0;
 		transition: opacity .2s ease-in;
 	}
@@ -126,7 +126,7 @@
 	width: 100%;
 
 	.search__open-icon {
-		color: darken( $gray, 30% );
+		color: $gray-darken-30;
 	}
 
 	.search__close-icon {

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -10,8 +10,8 @@
 	margin: 0 0 17px 0;
 	background: $white;
 	box-sizing: border-box;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 
 	&.is-empty .section-nav__panel {
 		visibility: hidden;
@@ -106,7 +106,7 @@
 	@include breakpoint( "<480px" ) {
 		.section-nav.is-open & {
 			padding-bottom: 15px;
-			border-top: solid 1px lighten( $gray, 20% );
+			border-top: solid 1px $gray-lighten-20;
 			background: linear-gradient(to bottom, $gray-light 0%, $white 4px);
 		}
 	}
@@ -126,7 +126,7 @@
 	position: relative;
 	margin-top: 16px;
 	padding-top: 16px;
-	border-top: solid 1px lighten( $gray, 20% );
+	border-top: solid 1px $gray-lighten-20;
 
 	&:first-child {
 		padding-top: 0;
@@ -265,7 +265,7 @@
 
 	&[disabled],
 	.notouch &[disabled]:hover {
-		color: lighten( $gray, 30% );
+		color: $gray-lighten-30;
 		cursor: default;
 	}
 

--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -23,7 +23,7 @@
 
 	&:last-of-type {
 		.segmented-control__link {
-			border-right: solid 1px lighten( $gray, 20% );
+			border-right: solid 1px $gray-lighten-20;
 			border-top-right-radius: 4px;
 			border-bottom-right-radius: 4px;
 		}
@@ -39,7 +39,7 @@
 .segmented-control__link {
 	display: block;
 	padding: 8px 12px;
-	border: solid 1px lighten( $gray, 20% );
+	border: solid 1px $gray-lighten-20;
 	border-right: none;
 	font-size: 14px;
 	line-height: 18px;

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -57,7 +57,7 @@ $compact-header-height: 35;
 	box-sizing: border-box;
 
 	border-style: solid;
-	border-color: lighten( $gray, 20% );
+	border-color: $gray-lighten-20;
 	border-width: 1px 1px 2px;
 	border-radius: 4px;
 	background-color: $white;
@@ -148,7 +148,7 @@ $compact-header-height: 35;
 	list-style: none;
 	margin: 0;
 	background-color: $white;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	border-top: 0;
 	// $blue-wordpress for outer (with focus shadow), $gray for border with header
 	border-radius: 0 0 4px 4px;
@@ -158,7 +158,7 @@ $compact-header-height: 35;
 
 	.accessible-focus & {
 		border: solid 1px $blue-wordpress;
-		border-top-color: lighten( $gray, 20% );
+		border-top-color: $gray-lighten-20;
 	}
 
 	.select-dropdown.is-open & {
@@ -262,14 +262,14 @@ $compact-header-height: 35;
 }
 
 .select-dropdown__separator {
-	border-top: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
 	display: block;
 	margin: 8px 0;
 }
 
 .select-dropdown__label {
 	display: block;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 	line-height: 20px;
 
 	label {

--- a/client/components/seo-preview-pane/style.scss
+++ b/client/components/seo-preview-pane/style.scss
@@ -58,7 +58,7 @@
 	@include breakpoint( ">660px" ) {
 		width: 250px;
 		min-width: 250px;
-		border-right: 1px solid lighten( $gray, 20% );
+		border-right: 1px solid $gray-lighten-20;
 	}
 }
 

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -13,18 +13,18 @@
 	margin: 0;
 	padding: 8px 0;
 	background-color: $gray-light;
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	border-bottom: 0;
 	font-size: 11px;
 	line-height: 1;
 	font-weight: bold;
 	text-transform: uppercase;
 	text-align: center;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 }
 
 .seo-search-preview__display {
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	font-family: arial, sans-serif;
 	padding: 10px 20px;
 	word-wrap: break-word;

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -17,7 +17,7 @@
 	}
 
 	&.is-large .site-selector__sites {
-		border-top: 1px solid lighten( $gray, 20% );
+		border-top: 1px solid $gray-lighten-20;
 	}
 
 	.site.is-loading {
@@ -97,7 +97,7 @@
 	margin: 8px;
 	width: auto;
 	height: 33px;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	display: block;
 	opacity: 0;
 	position: absolute;
@@ -152,7 +152,7 @@
 	font-size: 11px;
 	font-weight: 600;
 	padding: 8px;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	line-height: 2.1;
 
 	&:hover {
@@ -178,11 +178,11 @@
 }
 
 .site-selector .all-sites {
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 }
 
 .site-selector__recent {
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 
 	&:empty {
 		border-bottom-width: 0;

--- a/client/components/site-title-example/style.scss
+++ b/client/components/site-title-example/style.scss
@@ -25,7 +25,7 @@
 }
 
 .site-title-example__description {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	text-align: right;
 	margin-bottom: 8px;
 	display: inline-block;

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -8,7 +8,7 @@
 
 	.gridicons-chevron-down {
 		align-self: center;
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 		flex-grow: 0;
 		flex-shrink: 0;
 		margin-right: 16px;
@@ -18,7 +18,7 @@
 
 .sites-dropdown__wrapper {
 	background: $white;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	border-width: 1px 1px 2px;
 	border-radius: 4px;
 	margin: 0;
@@ -31,7 +31,7 @@
 	}
 
 	&:hover {
-		border-color: lighten( $gray, 10% );
+		border-color: $gray-lighten-10;
 	}
 }
 
@@ -46,13 +46,13 @@
 	display: flex;
 
 	.is-open & {
-		border-bottom: 1px solid lighten( $gray, 30% );
+		border-bottom: 1px solid $gray-lighten-30;
 	}
 
 	&:hover {
 		.gridicons-chevron-down,
 		.gridicons-chevron-up {
-			color: darken( $gray, 20% );
+			color: $gray-darken-20;
 		}
 	}
 }

--- a/client/components/sites-popover/style.scss
+++ b/client/components/sites-popover/style.scss
@@ -22,8 +22,8 @@
 }
 
 .sites-popover.has-header .sites-popover__header {
-	border-bottom: 1px solid lighten( $gray, 30% );
-	color: darken( $gray, 10% );
+	border-bottom: 1px solid $gray-lighten-30;
+	color: $gray-darken-10;
 	font-size: 12px;
 	font-weight: bold;
 	padding: 10px 10px 8px 8px;

--- a/client/components/social-icons/style.scss
+++ b/client/components/social-icons/style.scss
@@ -5,6 +5,6 @@
 
 .social-icons--disabled {
 	path {
-		fill: lighten( $gray, 30% );
+		fill: $gray-lighten-30;
 	}
 }

--- a/client/components/spinner-line/style.scss
+++ b/client/components/spinner-line/style.scss
@@ -9,9 +9,9 @@ hr.spinner-line {
 	margin: 24px 0;
 	background-image: linear-gradient(
 		to right,
-		lighten( $gray, 10% ) 0%,
-		lighten( $gray, 20% ) 50%,
-		lighten( $gray, 10% ) 100%
+		$gray-lighten-10 0%,
+		$gray-lighten-20 50%,
+		$gray-lighten-10 100%
 	);
 	background-size: 300px 100%;
 	animation: spinner-line__animation 1.2s infinite linear;

--- a/client/components/spinner/style.scss
+++ b/client/components/spinner/style.scss
@@ -37,7 +37,7 @@
 .spinner.is-fallback {
 	position: relative;
 	border-radius: 100%;
-	background-color: lighten( $gray, 20% );
+	background-color: $gray-lighten-20;
 
 	&::before,
 	&::after {
@@ -67,7 +67,7 @@
 }
 
 .spinner__border {
-	fill: lighten( $gray, 20% );
+	fill: $gray-lighten-20;
 }
 
 .spinner__progress {

--- a/client/components/sub-masterbar-nav/style.scss
+++ b/client/components/sub-masterbar-nav/style.scss
@@ -149,7 +149,7 @@
 		align-content: center;
 		justify-content: center;
 		height: 62px;
-		color: lighten( $gray, 30% );
+		color: $gray-lighten-30;
 	}
 }
 
@@ -173,7 +173,7 @@
 	position: absolute;
 		top: 10px;
 		right: 15px;
-	color: lighten( $gray, 30% );
+	color: $gray-lighten-30;
 	cursor: pointer;
 	transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -47,7 +47,7 @@ $theme-info-height: 54px;
 	}
 
 	&.is-placeholder {
-		background-color: lighten( $gray, 20% );
+		background-color: $gray-lighten-20;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }
@@ -99,7 +99,7 @@ $theme-info-height: 54px;
 
 .theme__upsell-icon svg {
 	transform: scale( 0.8 );
-	border: 2px solid lighten( $gray, 10% );
+	border: 2px solid $gray-lighten-10;
 	border-radius: 100%;
 	display: inline-block;
 	width: 22px;
@@ -208,12 +208,12 @@ $theme-info-height: 54px;
 	bottom: 54px;
 	width: 100%;
 	padding-top: 36%;
-	background: lighten( $gray, 20% );
+	background: $gray-lighten-20;
 
 	.gridicon {
 		display: block;
 		margin: -5% auto;
-		fill: lighten( $gray, 30% );
+		fill: $gray-lighten-30;
 	}
 }
 

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -14,7 +14,7 @@
 .tile-grid__item {
 	transition: all 100ms ease-in-out;
 	position: relative;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	border-bottom: 0;
 	margin: 0 10px;
 
@@ -59,7 +59,7 @@
 
 	&:last-child {
 		margin-bottom: 20px;
-		border: 1px solid lighten( $gray, 20% );
+		border: 1px solid $gray-lighten-20;
 		border-bottom-right-radius: 6px;
 		border-bottom-left-radius: 6px;
 
@@ -93,8 +93,8 @@
 			top: 50%;
 			right: 15px;
 			margin-top: -6px;
-			border-top: 2px solid lighten( $gray, 20% );
-			border-right: 2px solid lighten( $gray, 20% );
+			border-top: 2px solid $gray-lighten-20;
+			border-right: 2px solid $gray-lighten-20;
 			transform: rotate(45deg);
 			color: $white;
 		}
@@ -118,7 +118,7 @@
 @include breakpoint( ">480px" ) {
 	.tile-grid__item-copy {
 		padding: 15px;
-		border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+		border-top: 1px solid transparentize( $gray-lighten-20, .5 );
 	}
 }
 

--- a/client/components/tinymce/iframe.scss
+++ b/client/components/tinymce/iframe.scss
@@ -103,7 +103,7 @@ a img {
 
 .wp-caption-dd {
 	background: $gray-light;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-size: 14px;
 	line-height: 1.7;
 	padding: 16px;
@@ -197,9 +197,9 @@ hr {
 	margin: 0;
 	border-radius: 2px;
 	color: $gray-dark;
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 }
 
 .mce-content-body code[data-mce-selected] {
-	background: lighten( $gray, 20% );
+	background: $gray-lighten-20;
 }

--- a/client/components/tinymce/plugins/contact-form/style.scss
+++ b/client/components/tinymce/plugins/contact-form/style.scss
@@ -87,7 +87,7 @@
 }
 
 .editor-contact-form-modal-field__remove {
-	color: lighten( $gray, 20% );
+	color: $gray-lighten-20;
 	cursor: pointer;
 	transition: color 200ms;
 

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -40,7 +40,7 @@
 }
 
 .mce-container .wpcom-insert-menu__menu-label {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	display: inline-block;
 	font-family: $sans;
 	font-size: 13px;

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -207,8 +207,8 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	border: 1px solid lighten( $gray, 10% );
-	background-color: lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-10;
+	background-color: $gray-lighten-30;
 
 	&.is-placeholder {
 		@include placeholder();

--- a/client/components/tinymce/plugins/wpcom-charmap/style.scss
+++ b/client/components/tinymce/plugins/wpcom-charmap/style.scss
@@ -28,7 +28,7 @@
 }
 
 .wpcom-charmap__character {
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	margin: 0 -1px -1px 0; /* prevent borders from doubling up at overlap */
 	font-weight: normal;
 	padding: 8px;
@@ -42,6 +42,6 @@
 }
 
 .wpcom-charmap__character:hover {
-	background-color: darken( $gray, 20% );
+	background-color: $gray-darken-20;
 	color: $white;
 }

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -18,8 +18,8 @@
 }
 
 .wpview-type-simple-payments__image-figure {
-	border: 1px solid lighten( $gray, 10% );
-	background-color: lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-10;
+	background-color: $gray-lighten-30;
 	margin: 0;
 	min-width: 70px;
 	padding-top: calc(100% - 2px);
@@ -77,7 +77,7 @@
 }
 
 .wpview-type-simple-payments__pay-quantity-input {
-	border: 1px solid lighten( $gray, 10% );
+	border: 1px solid $gray-lighten-10;
 	padding: 6px 8px;
 	max-width: 42px;
 }

--- a/client/components/tinymce/plugins/wplink/style.scss
+++ b/client/components/tinymce/plugins/wplink/style.scss
@@ -12,7 +12,7 @@
 	padding: 7px 0 9px;
 
 	&:hover {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 	}
 
 	.gridicon {

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -93,11 +93,11 @@
 	}
 
 	.mce-toolbar .mce-ico {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 	}
 
 	.mce-toolbar .mce-btn .gridicon {
-		fill: darken( $gray, 20% );
+		fill: $gray-darken-20;
 	}
 
 	.mce-colorbutton .mce-preview {
@@ -108,8 +108,8 @@
 		margin: 0 2px 0 0;
 		padding: 0 8px;
 		vertical-align: top;
-		border-left: 1px solid lighten( $gray, 30% );
-		border-right: 1px solid lighten( $gray, 30% );
+		border-left: 1px solid $gray-lighten-30;
+		border-right: 1px solid $gray-lighten-30;
 		height: 36px;
 
 		@include breakpoint( "<660px" ) {
@@ -145,7 +145,7 @@
 		top: -6px;
 		bottom: -6px;
 	width: 1px;
-	background-color: lighten( $gray, 20% );
+	background-color: $gray-lighten-20;
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-hidden {
@@ -221,7 +221,7 @@
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-wpcom-icon-button button {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	height: 38px;
 	padding: 0 8px;
 	margin-top: 0px;
@@ -231,7 +231,7 @@
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-wpcom-icon-button .gridicon {
-	fill: darken( $gray, 20% );
+	fill: $gray-darken-20;
 
 	&:hover {
 		fill: $gray-dark;
@@ -355,7 +355,7 @@
 .mce-container .mce-floatpanel.mce-popover {
 	z-index: auto !important;
 	background-color: $white;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	border-radius: 0 0 4px 4px;
 	box-shadow: none;
 	padding: 0;
@@ -392,7 +392,7 @@ div.mce-panel {
 }
 
 .mce-container .mce-panel.mce-menu {
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 }
 .mce-container .mce-menu-item .mce-text {
 	color: $gray-dark;
@@ -415,7 +415,7 @@ div.mce-toolbar-grp {
 
 div.mce-inline-toolbar-grp {
 	background-color: $white;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	border-radius: 4px;
 	box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.1 ),
 		0 0 56px rgba( 0, 0, 0, 0.075 );
@@ -461,14 +461,14 @@ div.mce-inline-toolbar-grp:after {
 
 div.mce-inline-toolbar-grp.mce-arrow-up:before {
 	top: -18px;
-	border-bottom-color: lighten( $gray, 20% );
+	border-bottom-color: $gray-lighten-20;
 	border-width: 9px;
 	margin-left: -9px;
 }
 
 div.mce-inline-toolbar-grp.mce-arrow-down:before {
 	bottom: -18px;
-	border-top-color: lighten( $gray, 20% );
+	border-top-color: $gray-lighten-20;
 	border-width: 9px;
 	margin-left: -9px;
 }
@@ -533,7 +533,7 @@ div.mce-inline-toolbar-grp.mce-arrow-full > div {
 
 .mce-tinymce .mce-stack-layout-item.mce-last {
 	@include breakpoint( ">960px" ) {
-		border-top: 1px solid lighten( $gray, 30% );
+		border-top: 1px solid $gray-lighten-30;
 	}
 }
 
@@ -555,7 +555,7 @@ div.mce-inline-toolbar-grp.mce-arrow-full > div {
 }
 
 div.mce-statusbar {
-	border-top: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
 }
 
 div.mce-path {
@@ -564,7 +564,7 @@ div.mce-path {
 }
 
 .post-editor .mce-path-item {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-family: $sans;
 }
 
@@ -628,13 +628,13 @@ div.mce-path {
 #wp-fullscreen-buttons .mce-btn:active,
 .qt-dfw.active {
 	color: $gray-dark;
-	border-color: lighten( $gray, 20% );
+	border-color: $gray-lighten-20;
 	background: $white;
 	box-shadow: none;
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-active:hover {
-	border-color: lighten( $gray, 20% );
+	border-color: $gray-lighten-20;
 	color: $gray-dark;
 }
 
@@ -644,7 +644,7 @@ div.mce-path {
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-disabled i.mce-ico {
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-disabled:hover,
@@ -712,7 +712,7 @@ div.mce-path {
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-listbox.mce-active {
 	border-color: $white;
-	border-right: 1px solid lighten( $gray, 30% );
+	border-right: 1px solid $gray-lighten-30;
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-listbox button {
@@ -730,7 +730,7 @@ div.mce-path {
 .mce-toolbar .mce-btn-group .mce-btn.mce-listbox button .mce-txt {
 	width: auto;
 	padding: 0;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-family: $sans;
 	font-size: 13px;
 	text-overflow: initial;
@@ -742,8 +742,8 @@ div.mce-path {
 
 .post-editor .mce-toolbar .mce-btn-group .mce-btn.mce-listbox:hover {
 	background-image: none;
-	border-left-color: lighten( $gray, 30% );
-	border-right-color: lighten( $gray, 30% );
+	border-left-color: $gray-lighten-30;
+	border-right-color: $gray-lighten-30;
 
 	@include breakpoint( "<660px" ) {
 		border-right-color: $white;
@@ -1015,7 +1015,7 @@ div.mce-menu .mce-menu-item-sep,
 .mce-toolbar .mce-btn:hover .mce-open,
 .mce-toolbar .mce-btn:focus .mce-open,
 .mce-toolbar .mce-btn.mce-active .mce-open {
-	border-left-color: lighten( $gray, 30% );
+	border-left-color: $gray-lighten-30;
 }
 
 i.mce-i-bold,

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -19,7 +19,7 @@
 
 	&.disabled {
 		.title-format-editor__editor-wrapper {
-			border: 1px solid lighten( $gray, 20% );
+			border: 1px solid $gray-lighten-20;
 			background-color: $gray-light;
 		}
 
@@ -51,8 +51,8 @@
 .title-format-editor__button {
 	border-radius: 3px;
 	background-color: $white;
-	color: darken( $gray, 30% );
-	border: 1px solid lighten( $gray, 20% );
+	color: $gray-darken-30;
+	border: 1px solid $gray-lighten-20;
 	padding: 3px 8px 3px 8px;
 	margin-left: 10px;
 	margin-top: 3px;
@@ -72,14 +72,14 @@
 }
 
 .title-format-editor__editor-wrapper {
-	border: 1px solid lighten( $gray, 10% );
+	border: 1px solid $gray-lighten-10;
 	padding: 7px 14px;
 	line-height: 24px;
 }
 
 .title-format-editor__token {
 	display: inline-block;
-	background-color: darken( $gray, 20% );
+	background-color: $gray-darken-20;
 	color: $white;
 	border-radius: 4px;
 	cursor: pointer;
@@ -92,7 +92,7 @@
 
 .title-format-editor__token-close {
 	margin-left: 10px;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 	font-size: 10px;
 }
 

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -6,18 +6,18 @@
 	margin: 0;
 	padding: 0;
 	background-color: $white;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	color: $gray-dark;
 	cursor: text;
 	transition: all .15s ease-in-out;
 
 	&:hover {
-		border-color: lighten( $gray, 10% );
+		border-color: $gray-lighten-10;
 	}
 
 	&.is-disabled {
 		background: $gray-light;
-		border-color: lighten( $gray, 30% );
+		border-color: $gray-lighten-30;
 	}
 
 	&.is-active {
@@ -131,7 +131,7 @@ input[type="text"].token-field__input {
 .token-field__remove-token {
 	display: inline-block;
 	line-height: 24px;
-	background: darken( $gray, 20% );
+	background: $gray-darken-20;
 	transition: all .2s cubic-bezier( .4, 1, .4, 1 );
 }
 
@@ -146,11 +146,11 @@ input[type="text"].token-field__input {
 .token-field__remove-token {
 	cursor: pointer;
 	border-radius: 0 4px 4px 0;
-	color: lighten( $gray, 20% );
+	color: $gray-lighten-20;
 
 	&:hover {
 		color: white;
-		background: darken( $gray, 10% );
+		background: $gray-darken-10;
 	}
 }
 
@@ -165,7 +165,7 @@ input[type="text"].token-field__input {
 
 	&.is-expanded {
 		background: $white;
-		border-top: 1px solid lighten( $gray, 20% );
+		border-top: 1px solid $gray-lighten-20;
 		max-height: 9em;
 		padding-top: 3px;
 	}

--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -7,7 +7,7 @@
 	&.is-bottom-left,
 	&.is-bottom {
 		.popover__arrow {
-			border-bottom-color: darken( $gray, 30% );
+			border-bottom-color: $gray-darken-30;
 			top: 4px;
 			right: 10px;
 
@@ -39,7 +39,7 @@
 	&.is-top-left,
 	&.is-top-right {
 		.popover__arrow {
-			border-top-color: darken( $gray, 30% );
+			border-top-color: $gray-darken-30;
 			bottom: 4px;
 			right: 10px;
 
@@ -107,14 +107,14 @@
 	&.is-left {
 		.popover__arrow {
 			margin-right: 4px;
-			border-left-color: darken( $gray, 30% );
+			border-left-color: $gray-darken-30;
 		}
 	}
 
 	&.is-right {
 		.popover__arrow {
 			margin-left: 4px;
-			border-right-color: darken( $gray, 30% );
+			border-right-color: $gray-darken-30;
 		}
 	}
 
@@ -123,7 +123,7 @@
 		box-shadow: none;
 		border-radius: 2px;
 		color: $white;
-		background: darken( $gray, 30% );
+		background: $gray-darken-30;
 		font-size: 12px;
 		padding: 6px 10px;
 		text-align: left;

--- a/client/components/update-post-status/style.scss
+++ b/client/components/update-post-status/style.scss
@@ -50,7 +50,7 @@
 			}
 			span {
 				display: inline-block;
-				border-bottom: solid 1px lighten( $gray, 20% );
+				border-bottom: solid 1px $gray-lighten-20;
 			}
 		}
 		.pages-list & {

--- a/client/components/upgrades/google-apps/google-apps-dialog/style.scss
+++ b/client/components/upgrades/google-apps/google-apps-dialog/style.scss
@@ -132,7 +132,7 @@ form.google-apps-dialog {
 	}
 
 	.google-apps-dialog__add-another-user-button {
-		border: 2px dashed lighten( $gray, 20% );
+		border: 2px dashed $gray-lighten-20;
 		color: $gray;
 		cursor: pointer;
 		margin: 0 0 30px;

--- a/client/components/user/style.scss
+++ b/client/components/user/style.scss
@@ -2,7 +2,7 @@
 	&.is-placeholder {
 		.user__name {
 			animation: pulse-light 0.8s ease-in-out infinite;
-			background: lighten( $gray, 20% );
+			background: $gray-lighten-20;
 			display: inline-block;
 			height: 14px;
 			width: 100px;

--- a/client/components/vertical-menu/style.scss
+++ b/client/components/vertical-menu/style.scss
@@ -9,7 +9,7 @@
 	display: flex;
 	height: 48px;
 
-	border-top: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
 	border-left: 3px solid transparent;
 	color: $gray-text-min;
 	font-size: 13px;
@@ -31,7 +31,7 @@
 	}
 
 	&:last-child {
-		border-bottom: 1px solid lighten( $gray, 20% );
+		border-bottom: 1px solid $gray-lighten-20;
 	}
 
 	&:not(.is-selected):hover {

--- a/client/components/vertical-nav/item/style.scss
+++ b/client/components/vertical-nav/item/style.scss
@@ -1,7 +1,7 @@
 .vertical-nav-item {
 	.gridicon {
 		box-sizing: border-box;
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 		display: block;
 		height: 100%;
 		position: absolute;

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -65,7 +65,7 @@
 .web-preview__toolbar {
 	height: 46px;
 	background: $white;
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	border-radius: 4px 4px 0 0;
 	display: flex;
 }
@@ -131,7 +131,7 @@ a.web-preview__external.button {
 	}
 
 	&:hover .form-text-input:not(:focus) {
-		border-color: lighten( $gray, 20% );
+		border-color: $gray-lighten-20;
 	}
 
 	.clipboard-button {
@@ -167,7 +167,7 @@ a.web-preview__external.button {
 	}
 
 	&.is-showing-device-switcher {
-		border-left: 1px solid lighten( $gray, 20% );
+		border-left: 1px solid $gray-lighten-20;
 		margin-left: 8px;
 	}
 }

--- a/client/devdocs/design/style.scss
+++ b/client/devdocs/design/style.scss
@@ -120,7 +120,7 @@
 }
 
 .state-value {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-size: 13px;
 	background-color: $white;
 	padding: 5px;

--- a/client/devdocs/docs-example/style.scss
+++ b/client/devdocs/docs-example/style.scss
@@ -27,7 +27,7 @@
 }
 
 .docs-example__stats {
-	border-bottom: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+	border-bottom: 1px solid transparentize( $gray-lighten-20, .5 );
 	font-size: 14px;
 	padding-bottom: 16px;
 }
@@ -94,7 +94,7 @@
 		border-spacing: 0;
 
 		th, td {
-			border-bottom: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+			border-bottom: 1px solid transparentize( $gray-lighten-20, .5 );
 			text-align: left;
 		}
 

--- a/client/devdocs/docs-selectors/style.scss
+++ b/client/devdocs/docs-selectors/style.scss
@@ -11,7 +11,7 @@
 }
 
 .docs-selectors__result {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 }
 
 .docs-selectors__result-name {
@@ -52,7 +52,7 @@
 
 .docs-selectors__result-label {
 	background: $gray-light;
-	border: 1px solid lighten( $gray, 10% );
+	border: 1px solid $gray-lighten-10;
 	text-transform: uppercase;
 	text-align: left;
 	font-size: 10px;
@@ -74,7 +74,7 @@
 	padding: 24px;
 	flex: 3;
 	background: $gray-light;
-	border: 1px solid lighten( $gray, 10% );
+	border: 1px solid $gray-lighten-10;
 	font-size: 14px;
 
 	.docs-selectors__result.is-expanded & {
@@ -94,7 +94,7 @@
 
 .docs-selectors__result-return {
 	background: $gray-light;
-	border: 1px solid lighten( $gray, 10% );
+	border: 1px solid $gray-lighten-10;
 	border-top-width: 0;
 	padding: 24px;
 	flex: 2;

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -13,7 +13,7 @@
 }
 
 .devdocs__title {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-weight: 300;
 	font-size: 24px;
 	padding: 24px;
@@ -51,7 +51,7 @@
 	}
 	margin: 0;
 	margin-top: 10px;
-	border-top: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
 	padding: 9px 18px;
 	font-size: ( 13 / 15 ) * 0.8em;
 	background-color: $white;

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -59,7 +59,7 @@
 	padding: 16px;
 	margin-left: -16px;
 	margin-right: -16px;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	display: flex;
 	position: relative;
 
@@ -95,7 +95,7 @@
 		left: 27px;
 		bottom: 0;
 		width: 1px;
-		background: lighten( $gray, 30% );
+		background: $gray-lighten-30;
 	}
 
 	@include breakpoint( ">480px" ) {
@@ -122,7 +122,7 @@
 	}
 
 	.dashboard__setup-task-status:empty {
-		background:  lighten( $gray, 30% );
+		background:  $gray-lighten-30;
 		border: 4px solid $white;
 		box-sizing: border-box;
 	}
@@ -236,7 +236,7 @@
 	border-top: none;
 	display: flex;
 	justify-content: center;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	padding: 24px 24px 0 24px;
 	margin-left: -24px;
 	margin-right: -24px;

--- a/client/extensions/woocommerce/app/order/order-activity-log/style.scss
+++ b/client/extensions/woocommerce/app/order/order-activity-log/style.scss
@@ -19,7 +19,7 @@
 		left: 45px;
 		bottom: 0;
 		width: 1px;
-		background: transparentize( lighten( $gray, 20% ), .5 );
+		background: transparentize( $gray-lighten-20, .5 );
 	}
 }
 
@@ -76,7 +76,7 @@
 		box-sizing: border-box;
 		margin-left: 16px;
 		padding: 12px 16px 16px;
-		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 );
+		box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 );
 	}
 
 	.order-activity-log__note-type {

--- a/client/extensions/woocommerce/app/order/order-created/style.scss
+++ b/client/extensions/woocommerce/app/order/order-created/style.scss
@@ -1,6 +1,6 @@
 .order-created {
 	border-top-width: 0;
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	padding-top: 16px;
 	padding-bottom: 16px;
 

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -2,7 +2,7 @@
 .order-details__table {
 	margin: 0 -24px;
 	box-shadow: none;
-	border-bottom: 1px solid lighten($gray, 30%);
+	border-bottom: 1px solid $gray-lighten-30;
 
 	.order-details__item-sku {
 		display: block;
@@ -22,7 +22,7 @@
 	}
 
 	thead .table-heading {
-		border-bottom: 1px solid lighten($gray, 30%);
+		border-bottom: 1px solid $gray-lighten-30;
 	}
 
 	.table-row {
@@ -70,7 +70,7 @@
 .order-details__actions {
 	margin: 0 -24px;
 	padding: 16px 80px 16px 24px;
-	border-bottom: 1px solid lighten($gray, 30%);
+	border-bottom: 1px solid $gray-lighten-30;
 
 	.button + .button {
 		margin-left: 24px;
@@ -111,12 +111,12 @@
 	.order-details__coupon-list {
 		.table-item {
 			padding-left: 24px;
-			border-bottom: 1px solid lighten($gray, 30%);
+			border-bottom: 1px solid $gray-lighten-30;
 			padding-bottom: 16px;
 		}
 
 		.table-item:not(.is-row-heading) {
-			border-bottom: 1px solid lighten($gray, 30%);
+			border-bottom: 1px solid $gray-lighten-30;
 			padding-top: 0;
 			vertical-align: top;
 		}
@@ -141,7 +141,7 @@
 		color: $alert-red;
 
 		.table-item {
-			border-bottom: 1px solid lighten($gray, 30%);
+			border-bottom: 1px solid $gray-lighten-30;
 			padding-bottom: 16px;
 		}
 

--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -44,7 +44,7 @@
 	justify-content: space-between;
 	margin: 0 -24px -24px;
 	padding: 24px;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	background: lighten( $gray, 35% );
 
 	.order-payment__note {
@@ -76,7 +76,7 @@
 		justify-content: space-between;
 		padding: 14px;
 		margin-bottom: 16px;
-		background: lighten( $gray, 30% );
+		background: $gray-lighten-30;
 		border: 1px solid lighten( $gray, 15% );
 	}
 

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -69,7 +69,7 @@
 .order-fulfillment {
 	margin: 0 -16px;
 	padding: 16px;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	display: flex;
 	align-items: center;
 

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -6,7 +6,7 @@
 }
 
 .product-categories__list-container {
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	border-bottom: 0;
 }
 
@@ -132,7 +132,7 @@
 		cursor: pointer;
 
 		figure {
-			border: 1px solid lighten( $gray, 30% );
+			border: 1px solid $gray-lighten-30;
 		}
 
 		img {
@@ -173,13 +173,13 @@
 		width: 28px;
 		height: 28px;
 		transform: translate( 25%, -25% );
-		border: 1px solid lighten( $gray, 10% );
+		border: 1px solid $gray-lighten-10;
 		border-radius: 50%;
 		background-color: $gray-light;
 		cursor: pointer;
 
 		&:hover {
-			background: lighten( $gray, 30% );
+			background: $gray-lighten-30;
 		}
 	}
 
@@ -191,7 +191,7 @@
 		width: 24px;
 		height: 24px;
 		margin: 0;
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 
 		&:hover {
 			color: $gray;

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -99,7 +99,7 @@
 		}
 
 		figure {
-			border: 1px solid lighten( $gray, 30% );
+			border: 1px solid $gray-lighten-30;
 		}
 
 		img {
@@ -188,13 +188,13 @@
 		width: 28px;
 		height: 28px;
 		transform: translate( 25%, -25% );
-		border: 1px solid lighten( $gray, 10% );
+		border: 1px solid $gray-lighten-10;
 		border-radius: 50%;
 		background-color: $gray-light;
 		cursor: pointer;
 
 		&:hover {
-			background: lighten( $gray, 30% );
+			background: $gray-lighten-30;
 		}
 	}
 
@@ -206,7 +206,7 @@
 		width: 24px;
 		height: 24px;
 		margin: 0;
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 
 		&:hover {
 			color: $gray;
@@ -263,7 +263,7 @@
 	@include placeholder();
 	background: lighten( $gray, 35% );
 	height: 225px;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 }
 
 .products__product-form-details-basic-description.form-fieldset {
@@ -379,7 +379,7 @@
 	border-collapse: collapse;
 
 	.products__product-form-variation-all-row {
-		background: lighten( $gray, 30% );
+		background: $gray-lighten-30;
 
 		.products__product-manage-stock-toggle {
 			display: inline;
@@ -513,7 +513,7 @@
 		width: 14px;
 		height: 14px;
 		transform: translate( 33%, -33% );
-		border: 1px solid lighten( $gray, 10% );
+		border: 1px solid $gray-lighten-10;
 		border-radius: 50%;
 		background-color: $gray-light;
 		cursor: pointer;
@@ -527,11 +527,11 @@
 		width: 12px;
 		height: 12px;
 		margin: 0;
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 	}
 
 	&:not(.uploader) {
-		border: 1px solid lighten( $gray, 30% );
+		border: 1px solid $gray-lighten-30;
 	}
 
 	figure {
@@ -738,7 +738,7 @@
 .products__additional-details-form-inputs {
 	background: $gray-light;
 	padding: 8px;
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	padding: 16px 0 0 0;
 	margin-bottom: 8px;
 	@include breakpoint( ">960px" ) {
@@ -776,23 +776,23 @@
 }
 
 .products__additional-details-preview-title {
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 	padding-bottom: 10px;
 	margin-bottom: 1em;
 }
 
 .products__additional-details-preview {
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	padding: 16px 16px 4px 16px;
 	margin-top: 4px;
 	font-size: 13px;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 }
 
 .products__additional-details-preview-row {
 	display: flex;
 	flex-direction: row;
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 	padding-bottom: 10px;
 	margin-bottom: 1em;
 }

--- a/client/extensions/woocommerce/app/promotions/fields/style.scss
+++ b/client/extensions/woocommerce/app/promotions/fields/style.scss
@@ -17,7 +17,7 @@
 
 	.date-picker {
 		max-width: 280px;
-		border: 1px solid lighten( $gray, 30% );
+		border: 1px solid $gray-lighten-30;
 		padding: 16px;
 
 		.DayPicker-NavBar {
@@ -63,7 +63,7 @@
 .promotion-applies-to-field {
 	.search {
 		margin-bottom: 0;
-		border: 1px solid lighten( $gray, 20% );
+		border: 1px solid $gray-lighten-20;
 		z-index: 0; // Keeps search from overlapping header above.
 		box-sizing: border-box;
 		z-index: 9;
@@ -83,7 +83,7 @@
 
 	.promotion-applies-to-field__list {
 		position: relative;
-		border: 1px solid lighten( $gray, 20% );
+		border: 1px solid $gray-lighten-20;
 		border-top: 0;
 		overflow-y: auto;
 		max-height: 250px;

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -32,14 +32,14 @@
 
 	.reviews__product-name {
 		padding: 16px;
-		border-bottom: 1px solid lighten( $gray, 30% );
+		border-bottom: 1px solid $gray-lighten-30;
 	}
 
 	&.is-expanded {
 		margin: 16px auto;
 
 		.reviews__header {
-			border-bottom: 1px solid lighten( $gray, 30% );
+			border-bottom: 1px solid $gray-lighten-30;
 		}
 
 		.reviews__content {
@@ -298,13 +298,13 @@
 
 
 .reviews__expanded-card-details-wrap {
-	border-left: 4px solid lighten( $gray, 30% );
+	border-left: 4px solid $gray-lighten-30;
 	margin-left: 16px;
 }
 
 .reviews__reply {
-	border-top: 1px solid lighten( $gray, 30% );
-	border-left: 4px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
+	border-left: 4px solid $gray-lighten-30;
 	margin-left: 16px;
 	padding-bottom: 16px;
 	background: lighten( $gray, 35% );
@@ -322,7 +322,7 @@
 	line-height: 0;
 	overflow: hidden;
 	position: relative;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 
 	textarea {
 		font-size: 14px;
@@ -390,7 +390,7 @@
 }
 
 .reviews__reply-edit {
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	padding: 8px;
 
 	.reviews__reply-edit-buttons {

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -102,7 +102,7 @@
 	.mailchimp__setup-dialog-progress {
 		margin: 0 -16px 16px;
 		padding: 16px;
-		border-bottom: 1px solid lighten( $gray, 30% );
+		border-bottom: 1px solid $gray-lighten-30;
 		display: flex;
 		align-items: center;
 		background: lighten( $gray-light, 1% );
@@ -192,7 +192,7 @@
 &.is-busy {
 	animation: button__busy-animation 3000ms infinite linear;
 	background-size: 120px 100%;
-	background-image: linear-gradient( -45deg, lighten( $gray, 30% ) 28%, $white 28%, $white 72%, lighten( $gray, 30% ) 72%);
+	background-image: linear-gradient( -45deg, $gray-lighten-30 28%, $white 28%, $white 72%, $gray-lighten-30 72%);
 }
 
 .mailchimp__dashboard{
@@ -217,8 +217,8 @@
 }
 
 .mailchimp__dashboard-title-and-slogan {
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 	flex-grow: 1;
 	padding: 16px;
 	display: flex;
@@ -231,8 +231,8 @@
 }
 
 .mailchimp__dashboard-sync-status {
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 	flex-grow: 0;
 	width: 255px;
 	font-size: 12px;
@@ -296,7 +296,7 @@
 	font-weight: 600;
 	padding: 4px 16px;
 	background: $gray-light;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 
 	@include breakpoint( ">480px" ) {
 		padding-left: 24px;
@@ -382,11 +382,11 @@
 }
 
 .mailchimp__dashboard-settings-preview-view {
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	padding: 12px;
 	margin-top: 4px;
 	font-size: 13px;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 
 	.form-label {
 		margin: 0;

--- a/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
@@ -14,7 +14,7 @@
 		.stripe__connect-account-logo-container {
 			align-items: center;
 			background: $white;
-			border: 1px solid lighten( $gray, 20% );
+			border: 1px solid $gray-lighten-20;
 			display: flex;
 			height: 46px;
 			justify-content: center;

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -236,7 +236,7 @@
 .payments__method-loading-feelink,
 .payments__method-loading-enabled,
 .payments__method-loading-settings {
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -223,7 +223,7 @@
 .shipping-zone__method-container {
 	position: relative;
 	padding: 20px;
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	margin-bottom: 24px;
 
 	.form-text-input-with-affixes {
@@ -246,7 +246,7 @@
 	}
 
 	input:disabled {
-		border-color: lighten( $gray, 20% );
+		border-color: $gray-lighten-20;
 	}
 }
 
@@ -336,7 +336,7 @@
 }
 
 .shipping-zone__location-dialog-list-item:hover {
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 }
 
 .shipping-zone__location-dialog-list-item-checkbox {

--- a/client/extensions/woocommerce/app/settings/shipping/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/style.scss
@@ -70,7 +70,7 @@
 	align-items: center;
 
 	&:not(:last-child) {
-		border-bottom: 1px solid lighten($gray, 20%);
+		border-bottom: 1px solid $gray-lighten-20;
 	}
 }
 

--- a/client/extensions/woocommerce/components/compact-tinymce/style.scss
+++ b/client/extensions/woocommerce/components/compact-tinymce/style.scss
@@ -1,11 +1,11 @@
 .compact-tinymce {
 	.mce-toolbar .mce-btn-group .mce-btn.mce-listbox:hover {
 		border-left-color: transparent;
-		border-right-color: lighten( $gray, 20% );
+		border-right-color: $gray-lighten-20;
 	}
 
 	.mce-edit-area {
-		border: 1px solid lighten( $gray, 20% ) !important;
+		border: 1px solid $gray-lighten-20 !important;
 		margin-bottom: 4px;
 		padding-top: 36px;
 		padding-left: 8px;
@@ -13,7 +13,7 @@
 
 	div.mce-toolbar-grp {
 		background-color: rgba( $white, 0.92 );
-		border-color: lighten( $gray, 20% );
+		border-color: $gray-lighten-20;
 		border-style: solid;
 		border-width: 1px;
 		padding: 0;
@@ -25,7 +25,7 @@
 		margin: 0 2px 0 0;
 		padding: 0 8px;
 		vertical-align: top;
-		border-right: 1px solid lighten( $gray, 20% );
+		border-right: 1px solid $gray-lighten-20;
 		height: 36px;
 
 		@include breakpoint( "<660px" ) {
@@ -59,11 +59,11 @@
 	}
 
 	.mce-toolbar .mce-btn-group .mce-ico {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 	}
 
 	.mce-toolbar .mce-btn-group .mce-btn .gridicon {
-		fill: darken( $gray, 20% );
+		fill: $gray-darken-20;
 	}
 
 	.mce-toolbar .mce-btn-group .mce-btn:hover .mce-ico,

--- a/client/extensions/woocommerce/components/filtered-list/style.scss
+++ b/client/extensions/woocommerce/components/filtered-list/style.scss
@@ -1,5 +1,5 @@
 .filtered-list__container {
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	border-top: none;
 	padding: 8px;
 	height: 190px;

--- a/client/extensions/woocommerce/components/list/list-header/style.scss
+++ b/client/extensions/woocommerce/components/list/list-header/style.scss
@@ -1,5 +1,5 @@
 .list-header {
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	display: flex;
 	flex-direction: row;
 	font-weight: normal;

--- a/client/extensions/woocommerce/components/order-status/style.scss
+++ b/client/extensions/woocommerce/components/order-status/style.scss
@@ -2,7 +2,7 @@
 	display: inline-flex;
 	padding: 0px 12px;
 	line-height: 32px;
-	background: lighten( $gray, 20% );
+	background: $gray-lighten-20;
 	border-radius: 4px;
 
 	&.is-processing {
@@ -30,7 +30,7 @@
 		color: $gray-dark;
 
 		span + span {
-			border-color: lighten( $gray, 20% );
+			border-color: $gray-lighten-20;
 		}
 	}
 

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -45,7 +45,7 @@
 		}
 
 		.gridicon {
-			color: darken( $gray, 10% );
+			color: $gray-darken-10;
 		}
 
 		p {
@@ -54,7 +54,7 @@
 
 		&:hover {
 			.gridicon {
-				color: darken( $gray, 30% );
+				color: $gray-darken-30;
 			}
 		}
 	}
@@ -112,13 +112,13 @@
 			top: 50%;
 			left: 50%;
 			transform: translate( -50%, -50% );
-			color: darken( $gray, 10% );
+			color: $gray-darken-10;
 		}
 	}
 
 	&:hover {
 		.gridicon {
-			color: darken( $gray, 30% );
+			color: $gray-darken-30;
 		}
 	}
 }

--- a/client/extensions/woocommerce/components/product-search/style.scss
+++ b/client/extensions/woocommerce/components/product-search/style.scss
@@ -1,7 +1,7 @@
 .product-search {
 	.search {
 		margin-bottom: 0;
-		border: 1px solid lighten( $gray, 20% );
+		border: 1px solid $gray-lighten-20;
 		box-sizing: border-box;
 		z-index: 9;
 	}
@@ -16,7 +16,7 @@
 
 	.product-search__list {
 		position: relative;
-		border: 1px solid lighten( $gray, 20% );
+		border: 1px solid $gray-lighten-20;
 		border-top: 0;
 		overflow-y: auto;
 		max-height: 350px;

--- a/client/extensions/woocommerce/components/reading-widget/style.scss
+++ b/client/extensions/woocommerce/components/reading-widget/style.scss
@@ -2,8 +2,8 @@
 	box-sizing: border-box;
 	background: $white;
 	padding-bottom: 0;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 
 	.reading-widget__heading {
 		h2 {
@@ -24,7 +24,7 @@
 		li {
 			margin-bottom: 12px;
 			padding-top: 12px;
-			border-top: 1px solid lighten( $gray, 30% );
+			border-top: 1px solid $gray-lighten-30;
 
 			&:first-child {
 				border-top: 0;
@@ -44,7 +44,7 @@
 
 	.reading-widget__subscription-form {
 		align-items: stretch;
-		border-top: 1px solid lighten( $gray, 30% );
+		border-top: 1px solid $gray-lighten-30;
 		background: $gray-light;
 		display: flex;
 		flex-direction: column;

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -7,12 +7,12 @@
 
 	thead .table-heading,
 	thead .table-item {
-		border-bottom: 1px solid lighten( $gray, 20% );
+		border-bottom: 1px solid $gray-lighten-20;
 	}
 
 	tbody .table-heading,
 	tbody .table-item {
-		border-bottom: 1px solid lighten( $gray, 30% );
+		border-bottom: 1px solid $gray-lighten-30;
 	}
 
 	// Remove the border from the last item in the body of the table.

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -64,7 +64,7 @@
 	}
 
 	&.packages__packages-header {
-		border-bottom-color: lighten( $gray, 20% );
+		border-bottom-color: $gray-lighten-20;
 	}
 
 	&.prefixed {
@@ -181,7 +181,7 @@
 	margin-bottom: 0;
 
 	.packages__packages-header {
-		border-top: 1px solid lighten( $gray, 20% );
+		border-top: 1px solid $gray-lighten-20;
 	}
 
 	.foldable-card__header {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
@@ -48,7 +48,7 @@
 .packages-step__list-package-count {
 	display: inline-block;
 	padding: 1px 6px;
-	border: solid 1px lighten( $gray, 10% );
+	border: solid 1px $gray-lighten-10;
 	border-radius: 12px;
 	font-size: 11px;
 	font-weight: 600;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -129,7 +129,7 @@
 }
 
 .label-purchase-modal__price-item-help {
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 	cursor: help;
 
 	svg {

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -131,7 +131,7 @@
 }
 
 .wp-super-cache__stat {
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 	color: $gray-dark;
 	font-size: 14px;
 	height: 30px;

--- a/client/extensions/zoninator/components/forms/zone-content-form/style.scss
+++ b/client/extensions/zoninator/components/forms/zone-content-form/style.scss
@@ -1,5 +1,5 @@
 .zoninator__zone-list-item {
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	white-space: nowrap;
 
 	.section-header__label-text {
@@ -28,7 +28,7 @@
 		height: 23px;
 		width: 60%;
 		margin: 3px 0;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;		
 	}
 }

--- a/client/extensions/zoninator/components/settings/zones-dashboard/style.scss
+++ b/client/extensions/zoninator/components/settings/zones-dashboard/style.scss
@@ -5,7 +5,7 @@
 	&.is-placeholder {
 		width: 38%;
 		height: 22px;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }
@@ -17,7 +17,7 @@
 
 	&.is-placeholder {
 		margin: 7px 0 0;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -44,8 +44,8 @@
 	&:hover {
 		z-index: 3;
 		transform: scale(1.075);
-		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% ), 0 7px 18px transparentize( lighten( $gray, 15% ), .5 );
+		box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30, 0 7px 18px transparentize( lighten( $gray, 15% ), .5 );
 		transition: transform .25s ease, box-shadow .35s ease, z-index .175s ease;
 	}
 
@@ -112,7 +112,7 @@
 			position: absolute;
 			top: 8px;
 			left: 8px;
-			color: lighten( $gray, 20% );
+			color: $gray-lighten-20;
 		}
 
 		.form-text-input {
@@ -198,7 +198,7 @@
 		z-index: 1;
 		width: 100%;
 		height: 1px;
-		background: transparentize( lighten( $gray, 20% ), .5 );
+		background: transparentize( $gray-lighten-20, .5 );
 	}
 
 	span {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -69,7 +69,7 @@
 			position: absolute;
 			top: 8px;
 			left: 8px;
-			color: lighten($gray, 20%);
+			color: $gray-lighten-20;
 		}
 
 		.form-text-input {
@@ -159,13 +159,13 @@
 	width: 100%;
 
 	&:hover > div {
-		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten($gray, 20%);
+		box-shadow: 0 0 0 1px $gray, 0 2px 4px $gray-lighten-20;
 	}
 }
 
 .example-components__browser-chrome {
 	padding: 8px;
-	background-color: lighten($gray, 30%);
+	background-color: $gray-lighten-30;
 	border-radius: 8px 8px 0 0;
 }
 
@@ -177,7 +177,7 @@
 .example-components__browser-chrome-dot {
 	display: inline-block;
 	margin-right: 8px;
-	background-color: lighten($gray, 10%);
+	background-color: $gray-lighten-10;
 	width: 8px;
 	height: 8px;
 	border-radius: 50%;
@@ -187,7 +187,7 @@
 	position: relative;
 	margin: 0;
 	line-height: 0;
-	box-shadow: 0 0 0 1px transparentize(lighten($gray, 20%), 0.5), 0 1px 2px lighten($gray, 30%);
+	box-shadow: 0 0 0 1px transparentize($gray-lighten-20, 0.5), 0 1px 2px $gray-lighten-30;
 }
 
 .example-components__install-plugin-header {
@@ -352,7 +352,7 @@
 }
 
 .jetpack-connect__sso-user-email {
-	color: lighten($gray, 10%);
+	color: $gray-lighten-10;
 	font-weight: 400;
 	text-align: center;
 }
@@ -389,7 +389,7 @@
 
 .jetpack-connect__connect-button-card {
 	background: lighten($gray, 34%);
-	border-top: 1px solid lighten($gray, 30%);
+	border-top: 1px solid $gray-lighten-30;
 	box-shadow: none;
 	margin: 16px -16px -16px -16px;
 	padding: 16px;
@@ -488,7 +488,7 @@
 .jetpack-connect__happychat-button {
 	background: none;
 	border: none;
-	color: darken($gray, 20%);
+	color: $gray-darken-20;
 	font-weight: normal;
 	padding: 16px 24px;
 	text-align: left;

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -61,7 +61,7 @@
 
 		&.completed,
 		&.completed a {
-			color: darken($gray, 20%);
+			color: $gray-darken-20;
 		}
 
 		&.todo,

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -45,12 +45,12 @@ body {
 		border-radius: 2px;
 		padding: 0;
 		text-align: inherit;
-		border-color: lighten( $gray, 20% );
+		border-color: $gray-lighten-20;
 		z-index: z-index( 'root', 'body .webui-popover' ); // Appear above dialog
 
 		.webui-popover-title {
-			background-color: lighten( $gray, 20% );
-			border-color: lighten( $gray, 30% );
+			background-color: $gray-lighten-20;
+			border-color: $gray-lighten-30;
 			border-radius: 1px 1px 0 0;
 		}
 
@@ -58,7 +58,7 @@ body {
 		&.top-right,
 		&.top-left {
 			.arrow {
-				border-top-color: lighten( $gray, 20% );
+				border-top-color: $gray-lighten-20;
 			}
 		}
 
@@ -66,7 +66,7 @@ body {
 		&.right-top,
 		&.right-bottom {
 			.arrow {
-				border-right-color: lighten( $gray, 20% );
+				border-right-color: $gray-lighten-20;
 			}
 		}
 
@@ -74,7 +74,7 @@ body {
 		&.left-top,
 		&.left-bottom {
 			.arrow {
-				border-left-color: lighten( $gray, 20% );
+				border-left-color: $gray-lighten-20;
 			}
 		}
 
@@ -82,9 +82,9 @@ body {
 		&.bottom-right,
 		&.bottom-left {
 			.arrow {
-				border-bottom-color: lighten( $gray, 20% );
+				border-bottom-color: $gray-lighten-20;
 				&:after {
-					border-bottom-color: lighten( $gray, 20% );
+					border-bottom-color: $gray-lighten-20;
 				}
 			}
 		}
@@ -114,7 +114,7 @@ body {
 		height: 1px;
 		margin-top: 35px;
 		z-index: z-index( 'root', '.community-translator__translator-invitation:before' );
-		background: linear-gradient( to right, fade-out( lighten( $gray, 20% ), 1 ) 0%, lighten( $gray, 20% ) 20%, lighten( $gray, 20% ) 80%, fade-out( lighten( $gray, 20% ), 1 ) 100% );
+		background: linear-gradient( to right, fade-out( $gray-lighten-20, 1 ) 0%, $gray-lighten-20 20%, $gray-lighten-20 80%, fade-out( $gray-lighten-20, 1 ) 100% );
 	}
 	.close-button {
 		padding: 6px;
@@ -168,7 +168,7 @@ body {
 
 .community-translator__translator-invitation__link {
 	color: $blue-medium;
-	text-shadow: 1px 0 lighten( $gray, 30% ), 2px 0 lighten( $gray, 30% ), -1px 0 lighten( $gray, 30% ), -2px 0 lighten( $gray, 30% );
+	text-shadow: 1px 0 $gray-lighten-30, 2px 0 $gray-lighten-30, -1px 0 $gray-lighten-30, -2px 0 $gray-lighten-30;
 	background-image: linear-gradient( to bottom, transparent 50%, $blue-medium 50% );
 	background-repeat: repeat-x;
 	background-size: 2px 2px;

--- a/client/layout/nux-welcome/style.scss
+++ b/client/layout/nux-welcome/style.scss
@@ -13,7 +13,7 @@
 		height: 1px;
 		margin-top: 35px;
 		z-index: z-index( 'root', '.NuxWelcome:before' );
-		background: linear-gradient(to right, fade-out(lighten( $gray, 20% ), 1) 0%, lighten( $gray, 20% ) 20%, lighten( $gray, 20% ) 80%, fade-out(lighten( $gray, 20% ), 1) 100%);
+		background: linear-gradient(to right, fade-out($gray-lighten-20, 1) 0%, $gray-lighten-20 20%, $gray-lighten-20 80%, fade-out($gray-lighten-20, 1) 100%);
 	}
 	&:after {
 		@include noticon( '\f205', 22px );
@@ -25,7 +25,7 @@
 		margin-top: 24px;
 		color: $gray;
 		padding: 0 8px;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		visibility: visible;
 	}
 	.close-button {
@@ -68,7 +68,7 @@
 .NuxWelcomeMessage__intro {
 	a {
 		color: $blue-medium;
-		text-shadow: 1px 0 lighten( $gray, 30% ), 2px 0 lighten( $gray, 30% ), -1px 0 lighten( $gray, 30% ), -2px 0 lighten( $gray, 30% );
+		text-shadow: 1px 0 $gray-lighten-30, 2px 0 $gray-lighten-30, -1px 0 $gray-lighten-30, -2px 0 $gray-lighten-30;
 		background-image: linear-gradient(to bottom, transparent 50%, $blue-medium 50%);
 		background-repeat: repeat-x;
 		background-size: 2px 2px;
@@ -109,12 +109,12 @@
 			&:before {
 				width: 108px;
 				height: 1px;
-				background: linear-gradient(to right, fade-out(lighten( $gray, 20% ), 1) 0%, lighten( $gray, 20% ) 100%);
+				background: linear-gradient(to right, fade-out($gray-lighten-20, 1) 0%, $gray-lighten-20 100%);
 			}
 			&:after {
 				width: 1px;
 				height: 108px;
-				background: linear-gradient(to bottom, lighten( $gray, 20% ) 0%, fade-out(lighten( $gray, 20% ), 1) 100%);
+				background: linear-gradient(to bottom, $gray-lighten-20 0%, fade-out($gray-lighten-20, 1) 100%);
 			}
 		}
 		.notouch & {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -91,14 +91,14 @@
 
 		@include breakpoint( "<660px" ) {
 			background-color: $gray-light;
-			border-bottom: 1px solid rgba( lighten( $gray, 20% ), 0.5 );
+			border-bottom: 1px solid rgba( $gray-lighten-20, 0.5 );
 
 			&:first-child {
-				border-top: 1px solid lighten( $gray, 20% );
+				border-top: 1px solid $gray-lighten-20;
 			}
 
 			&:last-child {
-				border-bottom: 1px solid lighten( $gray, 20% );
+				border-bottom: 1px solid $gray-lighten-20;
 			}
 		}
 	}
@@ -208,7 +208,7 @@ a.sidebar__button, form.sidebar__button {
 	margin-right: 8px;
 	line-height: 18px;
 	background-color: $gray-light;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-size: 12px;
 	font-weight: 600;
 	border-radius: 3px;
@@ -430,7 +430,7 @@ form.sidebar__button input {
 			left: 3px;
 			width: 10px;
 			height: 10px;
-			border: 2px solid lighten( $gray, 30% );
+			border: 2px solid $gray-lighten-30;
 			border-radius: 50%;
 			background: $orange-jazzy;
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -136,7 +136,7 @@
 
 // site selector in the sidebar
 .layout__secondary .site-selector {
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 	border-right: 1px solid lighten( $gray, 25% );
 	position: fixed;
 		top: 47px;
@@ -149,7 +149,7 @@
 	pointer-events: none;
 
 	.search {
-		border-bottom: 1px solid lighten( $gray, 20% );
+		border-bottom: 1px solid $gray-lighten-20;
 	}
 
 	.site,
@@ -157,7 +157,7 @@
 		.site__title,
 		.site__domain {
 			&::after {
-				@include long-content-fade( $color: lighten( $gray, 30% ) );
+				@include long-content-fade( $color: $gray-lighten-30 );
 			}
 		}
 	}
@@ -169,7 +169,7 @@
 	}
 
 	.site-selector__recent {
-		border-bottom-color: lighten( $gray, 20% );
+		border-bottom-color: $gray-lighten-20;
 	}
 }
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -58,7 +58,7 @@
 .magic-login__footer {
 	a {
 		border-bottom: 1px solid #c8d7e1;
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 		display: block;
 		line-height: 4em;
 		font-size: 14px;

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -15,7 +15,7 @@ $image-height: 47px;
 }
 
 .wp-login__header {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	font-size: 16px;
 	margin-bottom: 16px;
 	text-align: center;
@@ -24,14 +24,14 @@ $image-height: 47px;
 .wp-login__links,
 .wp-login__footer {
 	a, button {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 		text-decoration: none;
 	}
 }
 
 .wp-login__links {
 	a, button {
-		border-bottom: 1px solid lighten( $gray, 20% );
+		border-bottom: 1px solid $gray-lighten-20;
 		box-sizing: border-box;
 		cursor: pointer;
 		display: block;

--- a/client/me/action-remove/style.scss
+++ b/client/me/action-remove/style.scss
@@ -2,7 +2,7 @@
 	float: right;
 	padding-top: 8px;
 	display: inline-block;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 
 	&:hover {
 		cursor: pointer;

--- a/client/me/application-password-item/style.scss
+++ b/client/me/application-password-item/style.scss
@@ -7,7 +7,7 @@
 }
 
 .application-password-item__generated {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	font-size: .9em;
 }
 

--- a/client/me/application-passwords/style.scss
+++ b/client/me/application-passwords/style.scss
@@ -19,7 +19,7 @@
 }
 
 .application-passwords__new-password-display {
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 	border: 1px solid $border-ultra-light-gray;
 	font-size: 200%;
 	font-weight: 600;
@@ -32,7 +32,7 @@
 }
 
 .application-passwords__new-password-message {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	font-size: .9em;
 }
 

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -14,7 +14,7 @@
 }
 
 .billing-history__transactions thead {
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 }
 
 .billing-history__transactions thead .header-row {
@@ -41,7 +41,7 @@
 	padding: 3px 9px;
 	background-color: $white;
 	border-radius: 15px;
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	transition: width 0.25s ease-out;
 	outline: 0;
 
@@ -60,7 +60,7 @@
 	color: $gray-dark;
 	font-size: 14px;
 	height: 66px;
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 
 	&:last-child {
 		border-bottom: none;
@@ -336,7 +336,7 @@
 		}
 
 		strong {
-			color: darken( $gray, 20% );
+			color: $gray-darken-20;
 			display: block;
 			font-size: 12px;
 			font-weight: 600;
@@ -420,7 +420,7 @@
 
 		tbody tr {
 			td {
-				border-bottom: 1px solid lighten( $gray, 30% );
+				border-bottom: 1px solid $gray-lighten-30;
 			}
 
 			&:last-child td {

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -18,7 +18,7 @@
 
 .shared__available-time-card-header-icon {
 	color: $gray;
-	border: 1px solid lighten($gray, 20%);
+	border: 1px solid $gray-lighten-20;
 	border-radius: 100%;
 	padding: 6px;
 	margin-right: 12px;

--- a/client/me/connected-application-item/style.scss
+++ b/client/me/connected-application-item/style.scss
@@ -20,7 +20,7 @@
 		width: 36%;
 		line-height: 24px;
 		margin-top: 8px;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 
 		&:before {

--- a/client/me/get-apps/style.scss
+++ b/client/me/get-apps/style.scss
@@ -53,8 +53,8 @@
 
 .get-apps__illustration {
 	background-color: $white;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), 0.5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ),
+		0 1px 2px $gray-lighten-30;
 	box-sizing: border-box;
 	color: $blue-dark;
 	max-width: 980px;

--- a/client/me/help/help-contact/style.scss
+++ b/client/me/help/help-contact/style.scss
@@ -3,14 +3,14 @@
 
 	.help-contact__header {
 		@include placeholder();
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		height: 18px;
 		margin-bottom: 2px;
 		width: 150px;
 	}
 	.help-contact__textarea {
 		@include placeholder();
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		height: 50px;
 		margin-bottom: 32px;
 	}

--- a/client/me/help/help-happiness-engineers/style.scss
+++ b/client/me/help/help-happiness-engineers/style.scss
@@ -16,7 +16,7 @@
 .help-happiness-engineers__description {
 	margin: -16px 0px 12px 0px;
 	font: 14px/21px $sans;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	@include breakpoint( ">660px" ) {
 		margin: -16px 0px 20px 0px;
 	}

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -38,7 +38,7 @@
 }
 
 .help-result__description {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font: 14px/20px $sans;
 	margin: 2px 0px 0px 32px;
 }

--- a/client/me/next-steps/next-steps-box.scss
+++ b/client/me/next-steps/next-steps-box.scss
@@ -1,7 +1,7 @@
 .next-steps-box {
 	background: white;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 	box-sizing: border-box;
 	position: relative;
 	margin: 0 0 20px 0;

--- a/client/me/notification-settings/blogs-settings/style.scss
+++ b/client/me/notification-settings/blogs-settings/style.scss
@@ -39,7 +39,7 @@
 .blogs-settings__header-expand {
 	@extend %notification-settings-blog-settings-flexbox;
 	display: none;
-	color: lighten( $gray, 30% );
+	color: $gray-lighten-30;
 
 	@include breakpoint( ">480px" ) {
 		display: flex;
@@ -67,9 +67,9 @@
 
 .notification-settings-blog-settings-placeholder__blog__content__icon {
 	animation: loading-fade 1.6s ease-in-out infinite;
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 	position: relative;
-	background: lighten( $gray, 20% );
+	background: $gray-lighten-20;
 	border: 1px solid white;
 	height: 32px;
 	width: 32px;
@@ -92,7 +92,7 @@
 
 .notification-settings-blog-settings-placeholder__blog__info__title {
 	animation: loading-fade 1.6s ease-in-out infinite;
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 	width: 150px;
 	display: block;
 	font-weight: 400;
@@ -101,7 +101,7 @@
 
 .notification-settings-blog-settings-placeholder__blog__info__domain {
 	animation: loading-fade 1.6s ease-in-out infinite;
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 	display: block;
 	width: 250px;
 	font: {
@@ -120,7 +120,7 @@
 
 	em {
 		animation: loading-fade 1.6s ease-in-out infinite;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		width: 160px;
 		height: 22px;
 	}

--- a/client/me/notification-settings/comment-settings/style.scss
+++ b/client/me/notification-settings/comment-settings/style.scss
@@ -1,6 +1,6 @@
 .notification-settings-comment-settings__placeholder {
 	animation: loading-fade 1.6s ease-in-out infinite;
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 	line-height: 1;
 	margin-bottom: .5em;
 }

--- a/client/me/notification-settings/settings-form/style.scss
+++ b/client/me/notification-settings/settings-form/style.scss
@@ -138,5 +138,5 @@
 
 .notification-settings-form-actions__save-to-all {
 	background: transparent;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 }

--- a/client/me/notification-settings/wpcom-settings/style.scss
+++ b/client/me/notification-settings/wpcom-settings/style.scss
@@ -1,6 +1,6 @@
 .notification-settings-wpcom-settings__placeholder {
 	animation: loading-fade 1.6s ease-in-out infinite;
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 	line-height: 1;
 	margin-bottom: .5em;
 }

--- a/client/me/profile-link/style.scss
+++ b/client/me/profile-link/style.scss
@@ -10,7 +10,7 @@
 		.profile-link__url,
 		.profile-link__remove {
 			color: transparent;
-			background-color: lighten( $gray, 30% );
+			background-color: $gray-lighten-30;
 			animation: loading-fade 1.6s ease-in-out infinite;
 		}
 
@@ -40,7 +40,7 @@
 	position: absolute;
 	top: 0;
 	left: 0;
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 }
 
 .profile-link__link {

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -7,7 +7,7 @@
 	}
 
 	p {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		font-size: 14px;
 	}
 
@@ -57,7 +57,7 @@
 }
 
 .cancel-purchase__section {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	margin: 0;
 }
 

--- a/client/me/purchases/credit-cards/credit-cards.scss
+++ b/client/me/purchases/credit-cards/credit-cards.scss
@@ -8,10 +8,10 @@
 }
 
 .credit-cards__single-card {
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	border-top: none;
 
 	&:first-child {
-		border-top: 1px solid lighten( $gray, 30% );
+		border-top: 1px solid $gray-lighten-30;
 	}
 }

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -166,7 +166,7 @@
 .manage-purchase__meta,
 .manage-purchase__contact-support {
 	padding: 0 24px;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 
 	@include breakpoint( "<660px" ) {
 		padding: 0 16px;
@@ -185,7 +185,7 @@
 	}
 
 	li {
-		color: darken( $gray, 30% );
+		color: $gray-darken-30;
 		font-size: 13px;
 
 		@include breakpoint( "<660px" ) {
@@ -211,12 +211,12 @@
 
 		+ li {
 			@include breakpoint( ">660px" ) {
-				border-left: 1px solid lighten( $gray, 30% );
+				border-left: 1px solid $gray-lighten-30;
 			}
 		}
 
 		> a {
-			color: darken( $gray, 30% );
+			color: $gray-darken-30;
 			display: block;
 			text-decoration: none;
 		}
@@ -286,7 +286,7 @@
 }
 
 .manage-purchase__contact-support {
-	border-top: solid 1px lighten( $gray, 30% );
+	border-top: solid 1px $gray-lighten-30;
 	color: $gray;
 	margin-top: 15px;
 	padding-top: 10px;

--- a/client/me/security-2fa-backup-codes-list/style.scss
+++ b/client/me/security-2fa-backup-codes-list/style.scss
@@ -56,7 +56,7 @@ button.security-2fa-backups-codes-list__generate-button {
 
 	&.is-placeholder span {
 		color: transparent;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 
 		&:before {
@@ -67,7 +67,7 @@ button.security-2fa-backups-codes-list__generate-button {
 	}
 
 	&:before {
-		color: lighten( $gray, 20% );
+		color: $gray-lighten-20;
 		display: inline-block;
 		font-weight: normal;
 		margin-right: 10px;

--- a/client/me/security-2fa-progress/style.scss
+++ b/client/me/security-2fa-progress/style.scss
@@ -10,7 +10,7 @@
 		position: relative;
 
 		&:before {
-			background-color: lighten( $gray, 20% );
+			background-color: $gray-lighten-20;
 			content: " ";
 			display: block;
 			height: 1px;
@@ -61,7 +61,7 @@
 				}
 
 				.gridicon {
-					background: lighten( $gray, 20% );
+					background: $gray-lighten-20;
 					color: $gray;
 				}
 
@@ -72,9 +72,9 @@
 
 			.gridicon {
 				background: $white;
-				border: 1px lighten( $gray, 20% ) solid;
+				border: 1px $gray-lighten-20 solid;
 				border-radius: 50%;
-				color: lighten( $gray, 20% );
+				color: $gray-lighten-20;
 				display: block;
 				margin: 0 auto;
 				position: relative;
@@ -88,7 +88,7 @@
 			}
 
 			label {
-				color: lighten( $gray, 20% );
+				color: $gray-lighten-20;
 				display: inline-block;
 				font-size: 14px;
 				line-height: 1;

--- a/client/me/security-account-recovery/style.scss
+++ b/client/me/security-account-recovery/style.scss
@@ -46,7 +46,7 @@
 .security-account-recovery-contact__placeholder-heading,
 .security-account-recovery-contact__placeholder-text {
 	animation: loading-fade 1.6s ease-in-out infinite;
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 	line-height: 1;
 	margin-bottom: .5em;
 }
@@ -91,7 +91,7 @@
 	padding: 9px 0;
 
 	&:hover {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 	}
 
 	.gridicon {

--- a/client/me/two-step/style.scss
+++ b/client/me/two-step/style.scss
@@ -1,6 +1,6 @@
 .two-step__placeholder-text {
 	animation: loading-fade 1.6s ease-in-out infinite;
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 	line-height: 1;	// Set line-height to current font-size
 	margin-bottom: .5em;
 

--- a/client/my-sites/ads/style.scss
+++ b/client/my-sites/ads/style.scss
@@ -21,7 +21,7 @@
 
 .ads__earnings-breakdown-list {
 	margin: 0;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 }
 
 .ads__earnings-breakdown-item {
@@ -30,7 +30,7 @@
 	padding: 5px 0 10px;
 	list-style-type: none;
 	text-align: center;
-	border-left: 1px solid lighten( $gray, 30% );
+	border-left: 1px solid $gray-lighten-30;
 
 	@include breakpoint( "<480px" ) {
 		width: auto;
@@ -38,7 +38,7 @@
 		padding: 10px 24px;
 		text-align: left;
 		border: 0;
-		border-top: 1px solid lighten( $gray, 30% );
+		border-top: 1px solid $gray-lighten-30;
 	}
 
 	&:first-child {
@@ -47,7 +47,7 @@
 }
 
 .ads__earnings-breakdown-label {
-	color: darken( $gray, 30% );
+	color: $gray-darken-30;
 	font-size: 10px;
 	letter-spacing: 0.1em;
 	line-height: 1.6;

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -1,5 +1,5 @@
 .cart__header {
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 
 	&.is-compact {
 		padding: 11px 15px;
@@ -17,7 +17,7 @@
 	.cart-item {
 		list-style: none;
 		display: block;
-		border-bottom: 1px solid lighten( $gray, 30% );
+		border-bottom: 1px solid $gray-lighten-30;
 		padding-bottom: 15px;
 		margin-bottom: 15px;
 		position: relative;
@@ -34,7 +34,7 @@
 		}
 
 		.product-domain {
-			color: darken( $gray, 10% );
+			color: $gray-darken-10;
 			display: block;
 			font-size: 12px;
 			text-overflow: ellipsis;
@@ -46,7 +46,7 @@
 		}
 
 		.product-price {
-			color: darken( $gray, 10% );
+			color: $gray-darken-10;
 			display: block;
 			font-size: 13px;
 		}
@@ -91,7 +91,7 @@
 	}
 
 	.cart-total {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		font-weight: 600;
 		font-size: 14px;
 
@@ -121,7 +121,7 @@
 
 		form {
 			display: block;
-			border-top: 1px solid lighten( $gray, 30% );
+			border-top: 1px solid $gray-lighten-30;
 			margin: 15px -15px 0 -15px;
 			padding: 15px 15px 0 15px;
 
@@ -156,7 +156,7 @@
 
 .cart__cart-ad {
 	background: lighten( $gray, 34% );
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	border-radius: 4px;
 	font-size: 12px;
 	margin: 15px 15px 0px 15px;
@@ -266,7 +266,7 @@ div.popover-cart__popover {
 	}
 
 	.cart-total {
-		border-top: 1px solid lighten( $gray, 30% );
+		border-top: 1px solid $gray-lighten-30;
 		font-size: 16px;
 		padding: 15px;
 	}
@@ -284,7 +284,7 @@ div.popover-cart__popover {
 .popover-cart__mobile-cart {
 
 	background-color: $white;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.1 ),
 		0 0 56px rgba( 0, 0, 0, 0.075 );
 	margin: -1px;
@@ -312,7 +312,7 @@ div.popover-cart__popover {
 	}
 
 	.cart-total {
-		border-top: 1px solid lighten( $gray, 30% );
+		border-top: 1px solid $gray-lighten-30;
 		font-size: 16px;
 		padding: 15px;
 	}

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/style.scss
@@ -49,7 +49,7 @@
 	padding: 20px 24px 24px;
 	background-color: #fbfcfd;
 	height: 116px;
-	box-shadow: 0 1px 0 0 lighten( $gray, 20% ),
+	box-shadow: 0 1px 0 0 $gray-lighten-20,
 		0 1px 0 lighten( $gray, 40% );
 }
 
@@ -70,7 +70,7 @@
 }
 
 .google-voucher-dialog__footer {
-	box-shadow: 0 -1px 2px lighten( $gray, 20% );
+	box-shadow: 0 -1px 2px $gray-lighten-20;
 	margin-top: 15px;
 	text-align: right;
 	padding: 15px;
@@ -83,7 +83,7 @@
 
 li.google-voucher__terms-and-conditions {
 	line-height: 1.6em;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 	margin-bottom: 15px;
 }
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -37,7 +37,7 @@
 	}
 
 	&:last-child {
-		border-bottom: 1px solid lighten( $gray, 30% );
+		border-bottom: 1px solid $gray-lighten-30;
 		border-radius: 0 0 3px 3px;
 	}
 }
@@ -61,7 +61,7 @@
 }
 
 .checkout-thank-you__features-header {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-size: 24px;
 	font-weight: 300;
 	line-height: 32px;

--- a/client/my-sites/checkout/checkout/stored-card.scss
+++ b/client/my-sites/checkout/checkout/stored-card.scss
@@ -12,7 +12,7 @@
 	padding: 15px 15px 15px 95px;
 
 	.stored-card__name {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 	}
 
 	.stored-card__number {
@@ -22,7 +22,7 @@
 	}
 
 	.stored-card__expiration-date {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		font-style: italic;
 		opacity: 0.7;
 		white-space: nowrap;

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -31,7 +31,7 @@
 
 		.is-empty {
 			.payment-box-section, .checkout__payment-box-section {
-				border: 1px solid lighten( $gray, 30% );
+				border: 1px solid $gray-lighten-30;
 				margin: 5px 0;
 				display: flex;
 				flex-flow: row wrap;
@@ -42,7 +42,7 @@
 
 			.placeholder {
 				animation: pulse-light 800ms ease-in-out infinite;
-				background: lighten( $gray, 20% );
+				background: $gray-lighten-20;
 				width: 100%;
 				height: 100%;
 			}
@@ -122,7 +122,7 @@
 				margin: 40px 0 20px;
 				width: 100%;
 				height: 0;
-				border-bottom: 1px solid lighten( $gray, 30% );
+				border-bottom: 1px solid $gray-lighten-30;
 
 				@include breakpoint( '<480px' ) {
 					display: none;
@@ -140,7 +140,7 @@
 	}
 
 	h5 {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		font-size: 15px;
 		font-weight: 600;
 		opacity: 0.7;
@@ -231,7 +231,7 @@
 	// =============================================
 
 	.checkout-terms {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		margin: 16px 0;
 		padding: 0;
 
@@ -296,10 +296,10 @@
 
 		.payment-box-section {
 			cursor: pointer;
-			border-bottom: 1px solid lighten( $gray, 30% );
+			border-bottom: 1px solid $gray-lighten-30;
 
 			&:first-of-type {
-				border-top: 1px solid lighten( $gray, 30% );
+				border-top: 1px solid $gray-lighten-30;
 			}
 
 			&.selected {
@@ -308,10 +308,10 @@
 		}
 
 		.payment-box-section-inner {
-			border-left: 1px solid lighten( $gray, 30% );
+			border-left: 1px solid $gray-lighten-30;
 			padding-left: 2px;
 			position: relative;
-			border-right: 1px solid lighten( $gray, 30% );
+			border-right: 1px solid $gray-lighten-30;
 			min-height: 50px;
 		}
 
@@ -369,7 +369,7 @@
 		}
 
 		.all-fields-required {
-			color: lighten( $gray, 10% );
+			color: $gray-lighten-10;
 			display: block;
 			font-size: 12px;
 			font-style: italic;
@@ -411,7 +411,7 @@
 			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.075);
 
 			@include breakpoint( '>660px' ) {
-				border: 1px solid lighten( $gray, 30% );
+				border: 1px solid $gray-lighten-30;
 				box-shadow: none;
 			}
 		}
@@ -479,7 +479,7 @@
 				}
 
 				> span {
-					color: darken( $gray, 10% );
+					color: $gray-darken-10;
 					font-size: 15px;
 				}
 			}
@@ -489,7 +489,7 @@
 	// Supporting Text / Fine Print
 	// -----------------------------------
 	.supporting-text {
-		border-top: 1px solid lighten( $gray, 20% );
+		border-top: 1px solid $gray-lighten-20;
 		font-size: 13px;
 		list-style: none;
 		margin: 0;
@@ -497,12 +497,12 @@
 		@include clear-fix;
 
 		@include breakpoint( '>660px' ) {
-			border-bottom: 1px solid lighten( $gray, 20% );
+			border-bottom: 1px solid $gray-lighten-20;
 			margin: 30px 0;
 		}
 
 		li {
-			color: lighten( $gray, 10% );
+			color: $gray-lighten-10;
 			text-align: center;
 
 			@include breakpoint( '>660px' ) {
@@ -517,7 +517,7 @@
 			}
 
 			h6 {
-				color: darken( $gray, 20% );
+				color: $gray-darken-20;
 				font-size: 14px;
 				font-weight: 600;
 			}
@@ -532,7 +532,7 @@
 
 	.credit-card-supporting-text__refund-link {
 		white-space: nowrap;
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 		text-decoration: underline;
 	}
 
@@ -720,7 +720,7 @@
 	}
 
 	@include breakpoint( '<660px' ) {
-		border-bottom: 1px solid lighten( $gray, 30% );
+		border-bottom: 1px solid $gray-lighten-30;
 		margin: 10px 0 0;
 		text-align: center;
 	}
@@ -747,7 +747,7 @@
 
 .checkout__secure-payment {
 	margin-top: 10px;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 
 	@include breakpoint( '>660px' ) {
 		margin-left: 10px;
@@ -848,7 +848,7 @@
 }
 
 .checkout__privacy-protection-radio-text-description {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 }
 
 .checkout__privacy-protection-radio-price-text {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -14,8 +14,8 @@
 
 	&.is-pending {
 		background: mix($alert-yellow, $white, 8.5%);
-		box-shadow: inset 4px 0 0 0 $alert-yellow, 0 0 0 1px transparentize(lighten($gray, 20%), 0.5),
-			0 1px 2px lighten($gray, 30%);
+		box-shadow: inset 4px 0 0 0 $alert-yellow, 0 0 0 1px transparentize($gray-lighten-20, 0.5),
+			0 1px 2px $gray-lighten-30;
 	}
 
 	@include breakpoint( '>660px' ) {
@@ -210,7 +210,7 @@
 	}
 
 	.comment__in-reply-to {
-		border-left: 4px solid lighten($gray, 30%);
+		border-left: 4px solid $gray-lighten-30;
 		color: $gray-text-min;
 		margin-bottom: 16px;
 		overflow: hidden;
@@ -295,7 +295,7 @@
 
 .comment__actions {
 	align-items: center;
-	border-top: 1px solid lighten($gray, 30%);
+	border-top: 1px solid $gray-lighten-30;
 	display: flex;
 	flex-flow: row;
 	flex-wrap: nowrap;
@@ -365,11 +365,11 @@
 }
 
 .button[disabled].is-borderless.comment__action.is-approved {
-	color: lighten($gray, 30%);
+	color: $gray-lighten-30;
 }
 
 .button[disabled].is-borderless.comment__action:hover {
-	color: lighten($gray, 30%);
+	color: $gray-lighten-30;
 }
 
 // Comment Reply Block
@@ -477,7 +477,7 @@
 }
 
 .comment__edit-header {
-	border-bottom: 1px solid lighten($gray, 30%);
+	border-bottom: 1px solid $gray-lighten-30;
 	padding: 12px 16px;
 }
 
@@ -498,11 +498,11 @@
 	margin: 0 auto;
 
 	&:hover {
-		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten($gray, 20%);
+		box-shadow: 0 0 0 1px $gray, 0 2px 4px $gray-lighten-20;
 		z-index: z-index('root', '.card.comment.is-bulk-mode:hover');
 	}
 	&.is-pending:hover {
-		box-shadow: inset 4px 0 0 0 $alert-yellow, 0 0 0 1px $gray, 0 2px 4px lighten($gray, 20%);
+		box-shadow: inset 4px 0 0 0 $alert-yellow, 0 0 0 1px $gray, 0 2px 4px $gray-lighten-20;
 	}
 
 	a {
@@ -550,7 +550,7 @@
 	}
 
 	.comment__author-gravatar-placeholder {
-		background-color: lighten($gray, 30%);
+		background-color: $gray-lighten-30;
 		border-radius: 50%;
 		display: block;
 		height: 32px;
@@ -562,7 +562,7 @@
 	}
 
 	.comment__author-info-element {
-		background-color: lighten($gray, 30%);
+		background-color: $gray-lighten-30;
 		color: transparent;
 		height: 16px;
 

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -15,7 +15,7 @@
 		}
 
 		.site__title {
-			color: darken( $gray, 20% );
+			color: $gray-darken-20;
 			line-height: 35px;
 		}
 

--- a/client/my-sites/domains/domain-management/components/designated-agent-notice/style.scss
+++ b/client/my-sites/domains/domain-management/components/designated-agent-notice/style.scss
@@ -1,5 +1,5 @@
 .designated-agent-notice__container {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	margin: 16px 0;
 	padding: 0;
 	text-align: left;

--- a/client/my-sites/domains/domain-management/components/email-verification/style.scss
+++ b/client/my-sites/domains/domain-management/components/email-verification/style.scss
@@ -27,7 +27,7 @@
 }
 
 .email-verification__sent-to {
-	color: 	darken( $gray, 20% );
+	color: 	$gray-darken-20;
 	font-size: 14px;
 }
 
@@ -39,7 +39,7 @@
 }
 
 .email-verification__status-container {
-	border-top: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
 	margin: 25px -24px -16px -21px;
 	padding: 24px 24px 24px 21px;
 	position: relative;
@@ -53,7 +53,7 @@
 			margin-right: 0;
 		}
 		&.is-busy:disabled {
-			color: 	darken( $gray, 20% );
+			color: 	$gray-darken-20;
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/components/icann-verification/style.scss
+++ b/client/my-sites/domains/domain-management/components/icann-verification/style.scss
@@ -27,7 +27,7 @@
 }
 
 .icann-verification__sent-to {
-	color: 	darken( $gray, 20% );
+	color: 	$gray-darken-20;
 	font-size: 14px;
 }
 
@@ -39,7 +39,7 @@
 }
 
 .icann-verification__status-container {
-	border-top: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
 	margin: 25px -24px -16px -21px;
 	padding: 24px 24px 24px 21px;
 	position: relative;
@@ -53,7 +53,7 @@
 			margin-right: 0;
 		}
 		&.is-busy:disabled {
-			color: 	darken( $gray, 20% );
+			color: 	$gray-darken-20;
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/email/style.scss
+++ b/client/my-sites/domains/domain-management/email/style.scss
@@ -215,12 +215,12 @@
 }
 
 .domain-only-site__settings-notice {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	margin-top: 30px;
 	text-align: center;
 
 	&::before {
-		background: lighten( $gray, 20% );
+		background: $gray-lighten-20;
 		content: '';
 		display: block;
 		height: 1px;

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -82,7 +82,7 @@
 
 		.domain-management-list-item__title,
 		.domain-management-list-item__meta {
-			color: lighten( $gray, 20% );
+			color: $gray-lighten-20;
 		}
 	}
 }
@@ -162,7 +162,7 @@ input[type=radio].domain-management-list-item__radio {
 
 .domain-management-list-item__busy-message {
 	text-transform: uppercase;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-weight: 600;
 	font-size: 12px;
 	text-overflow: ellipsis;
@@ -188,7 +188,7 @@ input[type=radio].domain-management-list-item__radio {
 	}
 
 	.primary-domain-notice {
-		background: lighten( $gray, 30% );
+		background: $gray-lighten-30;
 		font-size: 13px;
 		color: $gray-dark;
 		&::before {
@@ -216,7 +216,7 @@ input[type=radio].domain-management-list-item__radio {
 	.contact-display {
 		h2 {
 			background-color: $gray-light;
-			border: 1px solid lighten( $gray, 30% );
+			border: 1px solid $gray-lighten-30;
 			border-bottom: 0;
 			color: $gray;
 			font-size: 11px;
@@ -229,7 +229,7 @@ input[type=radio].domain-management-list-item__radio {
 		}
 
 		.contact-display-content {
-			border: 1px solid lighten( $gray, 30% );
+			border: 1px solid $gray-lighten-30;
 			color: lighten( $gray-dark, 20% );
 			font-size: 12px;
 			line-height: 140%;
@@ -276,8 +276,8 @@ input[type=radio].domain-management-list-item__radio {
 		width: 100%;
 
 		&.is-busy:disabled {
-			border-color: lighten( $gray, 20% );
-			color: darken( $gray, 20% );
+			border-color: $gray-lighten-20;
+			color: $gray-darken-20;
 		}
 
 		@include breakpoint( '>480px' ) {
@@ -425,7 +425,7 @@ input[type=radio].domain-management-list-item__radio {
 
 	&.fetching input[type=text] {
 		animation: pulse-light 0.8s ease-in-out infinite;
-		background: lighten( $gray, 20% );
+		background: $gray-lighten-20;
 	}
 }
 
@@ -570,7 +570,7 @@ ul.email-forwarding__list {
 }
 
 .privacy-protection-card__header {
-	border-bottom: 2px solid lighten( $gray, 20% );
+	border-bottom: 2px solid $gray-lighten-20;
 	display: block;
 	overflow: auto;
 	padding: 16px 16px 20px;
@@ -656,7 +656,7 @@ ul.email-forwarding__list {
 	}
 
 	h5 {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		font-size: 12px;
 		line-height: 130%;
 		margin: 9px 0;
@@ -904,12 +904,12 @@ ul.domain-connect__dns-list
 }
 
 .domain-only-site__settings-notice {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	margin-top: 30px;
 	text-align: center;
 
 	&::before {
-		background: lighten( $gray, 20% );
+		background: $gray-lighten-20;
 		content: '';
 		display: block;
 		height: 1px;

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/style.scss
@@ -22,7 +22,7 @@
 
 .transfer-card {
 	p {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 	}
 }
 

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -14,7 +14,7 @@
 		background: lighten( $gray, 35 );
 
 		.draft__title {
-			color: darken( $gray, 20% );
+			color: $gray-darken-20;
 		}
 	}
 
@@ -106,7 +106,7 @@
 	}
 
 	.draft__title {
-		background: lighten( $gray, 20% );
+		background: $gray-lighten-20;
 		color: transparent;
 		height: 16px;
 		width: 30%;

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -171,7 +171,7 @@
 	height: 48px;
 	padding: 14px;
 	border-radius: 50%;
-	background-color: darken( $gray, 20% );
+	background-color: $gray-darken-20;
 	color: $gray-light;
 
 	@include breakpoint( ">660px" ) {

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -78,8 +78,8 @@
 	height: 150px;
 	margin-bottom: 24px;
 
-	border: 5px solid lighten( $gray, 30% );
-	fill: lighten( $gray, 10% );
+	border: 5px solid $gray-lighten-30;
+	fill: $gray-lighten-10;
 	font-size: 14px;
 	font-weight: 600;
 	color: $gray;
@@ -194,5 +194,5 @@
 
 .importer__mapping-relation {
 	float: left;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 }

--- a/client/my-sites/invites/invite-accept-logged-in/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-in/style.scss
@@ -1,5 +1,5 @@
 .invite-accept-logged-in__join-as {
-	color: darken( $gray, 30% );
+	color: $gray-darken-30;
 	font-family: $sans;
 	font-size: 21px;
 	font-weight: 300;

--- a/client/my-sites/invites/invite-form-header/style.scss
+++ b/client/my-sites/invites/invite-form-header/style.scss
@@ -1,5 +1,5 @@
 .invite-form-header__title {
-	color: darken( $gray, 30% );
+	color: $gray-darken-30;
 	font-family: $sans;
 	font-size: 21px;
 	font-weight: 300;

--- a/client/my-sites/media-library/list-item-file-details.scss
+++ b/client/my-sites/media-library/list-item-file-details.scss
@@ -13,7 +13,7 @@
 	margin: 0 auto;
 	padding-bottom: 25%;
 	line-height: .5;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 }
 
 .media-library__list-item-icon .gridicon {
@@ -31,17 +31,17 @@
 	max-width: 80%;
 	margin: 0 auto;
 	white-space: nowrap;
-	color: darken( $gray, 30% );
+	color: $gray-darken-30;
 
 	&::after {
-		@include long-content-fade( $color: lighten( $gray, 20% ) );
+		@include long-content-fade( $color: $gray-lighten-20 );
 	}
 }
 
 .media-library__list-item-details-separator {
 	width: 20%;
 	margin: 3% auto;
-	background-color: lighten( $gray, 20% );
+	background-color: $gray-lighten-20;
 }
 
 .media-library__list-item-file-extension {

--- a/client/my-sites/media-library/list-item.scss
+++ b/client/my-sites/media-library/list-item.scss
@@ -2,7 +2,7 @@
 	position: relative;
 	display: inline-block;
 	cursor: pointer;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	user-select: none;
 
 	&.is-selected::after {
@@ -50,21 +50,21 @@
 	overflow: hidden;
 	height: 0;
 	padding-bottom: 100%;
-	background-color: lighten( $gray, 20% );
+	background-color: $gray-lighten-20;
 }
 
 .media-library__list-item:hover .media-library__list-item-figure {
 	box-shadow: 0 0 0 1px $gray,
-				0 2px 4px lighten( $gray, 20% );
+				0 2px 4px $gray-lighten-20;
 }
 
 .media-library__list-item.is-selected .media-library__list-item-figure {
 	box-shadow: 0 0 0 2px $blue-medium,
-				0 4px 6px lighten( $gray, 20% );
+				0 4px 6px $gray-lighten-20;
 }
 
 .media-library__list-item.is-placeholder .media-library__list-item-figure {
-	background-color: lighten( $gray, 20% );
+	background-color: $gray-lighten-20;
 	animation: loading-fade 1.6s ease-in-out infinite;
 
 	&::before {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -77,8 +77,8 @@
 		display: none;
 		margin-bottom: 9px;
 		box-shadow:
-		  0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		  0 1px 2px lighten( $gray, 30% );
+		  0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		  0 1px 2px $gray-lighten-30;
 		background-color: $white;
 		padding-left: 24px;
 		padding-right: 24px;
@@ -101,8 +101,8 @@
 
 	.media-library__datasource {
 		box-shadow:
-		  0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		  0 1px 2px lighten( $gray, 30% );
+		  0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		  0 1px 2px $gray-lighten-30;
 		background-color: $white;
 		box-sizing: border-box;
 		display: flex;

--- a/client/my-sites/media-library/upload-url.scss
+++ b/client/my-sites/media-library/upload-url.scss
@@ -22,6 +22,6 @@
 	fill: $gray;
 
 	&:hover {
-		fill: darken( $gray, 10% );
+		fill: $gray-darken-10;
 	}
 }

--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -35,6 +35,6 @@
 	padding: 6px 12px;
 	background-color: $white;
 	box-sizing: border-box;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 }

--- a/client/my-sites/no-results/style.scss
+++ b/client/my-sites/no-results/style.scss
@@ -1,7 +1,7 @@
 // Display "no results" message on body content.
 // Used for searches.
 .no-results {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-size: 16px;
 	line-height: 56px;
 }

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -38,6 +38,6 @@
 	margin: 0 33px 0 0;
 
 	&.is-disabled {
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 	}
 }

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -6,14 +6,14 @@
 
 	.placeholder-text {
 		color: transparent;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 
 	.is-placeholder {
 		.noticon {
 			color: transparent;
-			background-color: lighten( $gray, 30% );
+			background-color: $gray-lighten-30;
 			animation: loading-fade 1.6s ease-in-out infinite;
 			opacity: 0.3;
 		}
@@ -22,7 +22,7 @@
 
 .pages__page-list-header {
 	background: $gray-light;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ), 0 1px 2px $gray-lighten-30;
 	color: $gray;
 	font-size: 11px;
 	padding: 6px 11px;
@@ -90,8 +90,8 @@
 	top: 0;
 	left: 0;
 	height: 100%;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 
 	&.is-indented {
 		width: 112px;

--- a/client/my-sites/people/edit-team-member-form/style.scss
+++ b/client/my-sites/people/edit-team-member-form/style.scss
@@ -1,5 +1,5 @@
 .edit-team-member-form__form {
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	padding-top: 24px;
 	margin-top: 24px;
 }

--- a/client/my-sites/people/people-invite-details/style.scss
+++ b/client/my-sites/people/people-invite-details/style.scss
@@ -3,7 +3,7 @@
 }
 
 .people-invite-details__meta {
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	padding-top: 24px;
 	margin-top: 24px;
 }

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -8,7 +8,7 @@
 		.people-profile__role-badge,
 		.gravatar.is-placeholder {
 			color: transparent;
-			background-color: lighten( $gray, 30% );
+			background-color: $gray-lighten-30;
 			animation: loading-fade 1.6s ease-in-out infinite;
 		}
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -178,7 +178,7 @@ $plan-features-sidebar-width: 272px;
 	display: flex;
 	align-items: flex-start;
 	padding: 12px 24px 0 15px;
-	border-bottom: solid 2px lighten( $gray, 20% );
+	border-bottom: solid 2px $gray-lighten-20;
 	background-color: $white;
 
 	@include breakpoint( "<960px" ) {

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -22,8 +22,8 @@
 .current-plan__header-item-content {
 	background-color: $white;
 	padding: 32px;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 
 	@include breakpoint( ">660px" ) {
 		text-align: left;

--- a/client/my-sites/plugins/jetpack-plugins-setup/style.scss
+++ b/client/my-sites/plugins/jetpack-plugins-setup/style.scss
@@ -5,8 +5,8 @@
 	h1.is-placeholder,
 	p.is-placeholder {
 		width: inherit;
-		background-color: lighten( $gray, 30% );
-		color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
+		color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 
 		&:before {
@@ -28,7 +28,7 @@
 
 .jetpack-plugins-setup__description {
 	margin-bottom: 3em;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	text-align: center;
 }
 

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -54,7 +54,7 @@
 	cursor: pointer;
 
 	.is-disabled & {
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 		cursor: default;
 	}
 

--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -12,11 +12,11 @@
 }
 
 .plugin-activate-toggle__disabled {
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 }
 
 .plugin-activate-toggle__disabled .plugin-activate-toggle__icon {
-	color: lighten( $gray, 30% );
+	color: $gray-lighten-30;
 }
 
 .plugin-activate-toggle__label {

--- a/client/my-sites/plugins/plugin-icon/style.scss
+++ b/client/my-sites/plugins/plugin-icon/style.scss
@@ -28,12 +28,12 @@
 		fill: $white;
 	}
 	&.is-placeholder {
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 		opacity: 0.3;
 	}
 	&.is-fallback {
-		background: lighten( $gray, 20% );
+		background: $gray-lighten-20;
 	}
 }
 

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -203,5 +203,5 @@
 
 .plugin-item {
 	box-sizing: border-box;
-	border: 0 solid lighten( $gray, 30% );
+	border: 0 solid $gray-lighten-30;
 }

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -47,7 +47,7 @@
 }
 
 .plugin-list-header__section-actions-close {
-	color: darken( $gray, 30% );
+	color: $gray-darken-30;
 	cursor: pointer;
 	display: flex;
 		align-items: center;

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -87,7 +87,7 @@
 }
 
 .plugin-meta__actions {
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	flex-grow: 1;
 	flex-shrink: 0;
 	margin-top: 16px;

--- a/client/my-sites/plugins/plugin-ratings/style.scss
+++ b/client/my-sites/plugins/plugin-ratings/style.scss
@@ -65,7 +65,7 @@
 		position: relative;
 		border-radius: 0;
 		height: 8px;
-		background-color: lighten( $gray, 20% );
+		background-color: $gray-lighten-20;
 	}
 
 	.progress-bar__progress {

--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -40,6 +40,6 @@
 }
 
 .plugin-remove-button__remove-link.is-disabled .plugin-remove-button__remove-icon .gridicons-trash {
-	color: lighten( $gray, 30% );
+	color: $gray-lighten-30;
 	cursor: default;
 }

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -1,5 +1,5 @@
 .plugins-browser-item {
-	border-left: 1px solid lighten( $gray, 30% );
+	border-left: 1px solid $gray-lighten-30;
 	box-sizing: border-box;
 	cursor: pointer;
 	display: block;
@@ -26,7 +26,7 @@
 		}
 
 		&:nth-child( n + 4 ) {
-			border-top: 1px solid lighten( $gray, 30% );
+			border-top: 1px solid $gray-lighten-30;
 		}
 	}
 
@@ -34,7 +34,7 @@
 		width: 100%;
 
 		&:nth-child( n + 2 ) {
-			border-top: 1px solid lighten( $gray, 30% );
+			border-top: 1px solid $gray-lighten-30;
 		}
 
 		&.is-empty {
@@ -67,7 +67,7 @@
 
 	.is-placeholder & {
 		color: transparent;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -1,7 +1,7 @@
 .plugins-browser-list {
 	margin-bottom: 16px;
 	background: $white;
-	box-shadow: 0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 1px 2px $gray-lighten-30;
 
 	.feature-example & {
 		margin: 0 0;
@@ -10,7 +10,7 @@
 
 .plugins-browser-list__header {
 	background: $gray-light;
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 	overflow: hidden; // lazy clearfix
 }
 

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -1,6 +1,6 @@
 .plugins-browser__main-header {
 	background: $white;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), 0.5 ), 0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ), 0 1px 2px $gray-lighten-30;
 	flex-direction: column;
 	display: flex;
 	margin-bottom: 9px;
@@ -12,7 +12,7 @@
 }
 
 .plugins-browser__main-header .section-nav {
-	border: 1px solid transparentize( lighten( $gray, 20% ), 0.5 );
+	border: 1px solid transparentize( $gray-lighten-20, 0.5 );
 	border-width: 0 0 1px;
 	box-shadow: none;
 	flex: auto;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -12,7 +12,7 @@
 
 .plugins__header {
 	background: $white;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), 0.5 ), 0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, 0.5 ), 0 1px 2px $gray-lighten-30;
 	flex-direction: column;
 	display: flex;
 	margin-bottom: 9px;
@@ -24,7 +24,7 @@
 }
 
 .plugins__header .section-nav {
-	border: 1px solid transparentize( lighten( $gray, 20% ), 0.5 );
+	border: 1px solid transparentize( $gray-lighten-20, 0.5 );
 	border-width: 0 0 1px;
 	box-shadow: none;
 	flex: auto;
@@ -43,7 +43,7 @@
 		flex-basis: 0;
 
 		&:not( :last-child ) {
-			border-right: 1px solid transparentize( lighten( $gray, 20% ), 0.5 );
+			border-right: 1px solid transparentize( $gray-lighten-20, 0.5 );
 		}
 
 		@include breakpoint( '>480px' ) {

--- a/client/my-sites/post-selector/style.scss
+++ b/client/my-sites/post-selector/style.scss
@@ -1,7 +1,7 @@
 .post-selector {
 	position: relative;
 	background-color: $white;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 
 	&.is-compact {
 		background-color: transparent;
@@ -96,7 +96,7 @@ input[type=checkbox].post-selector__input {
 
 	.post-selector__list-item.is-placeholder & {
 		color: transparent;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }

--- a/client/my-sites/post/post-image/style.scss
+++ b/client/my-sites/post/post-image/style.scss
@@ -37,7 +37,7 @@
 	}
 
 	&.is-placeholder {
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }

--- a/client/my-sites/sharing/connections/account-dialog.scss
+++ b/client/my-sites/sharing/connections/account-dialog.scss
@@ -30,7 +30,7 @@
 		display: inline-block;
 		width: 100%;
 		margin-left: 10px;
-		border-top: 1px solid lighten( $gray, 20% );
+		border-top: 1px solid $gray-lighten-20;
 	}
 }
 

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -121,7 +121,7 @@
 			padding-right: 4%;
 
 			@include breakpoint( "<660px" ) {
-				border-bottom: 1px solid lighten( $gray, 30% );
+				border-bottom: 1px solid $gray-lighten-30;
 				padding-bottom: 10px;
 			}
 
@@ -137,7 +137,7 @@
 	}
 
 	.sharing-service-example-screenshot {
-		border: 1px solid lighten( $gray, 30% );
+		border: 1px solid $gray-lighten-30;
 
 		img {
 			vertical-align: top;
@@ -252,7 +252,7 @@
 			right: 16px;
 			bottom: 16px;
 			left: 16px;
-		background-color: lighten( $gray, 20% );
+		background-color: $gray-lighten-20;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }
@@ -330,7 +330,7 @@
 
 .sharing-service__description {
 	margin: 0;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-size: 14px;
 
 	@include breakpoint( "<480px" ) {
@@ -362,8 +362,8 @@
 .sharing-service.is-placeholder .gridicons-share,
 .sharing-service.is-placeholder .sharing-service__name,
 .sharing-service.is-placeholder .sharing-service__description {
-	background-color: lighten( $gray, 30% );
-	color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
+	color: $gray-lighten-30;
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
@@ -502,7 +502,7 @@
 
 .sharing-settings.sharing-buttons {
 	.sharing-button-styles {
-		box-shadow: 0 -2px 0 lighten( $gray, 30% ) inset;
+		box-shadow: 0 -2px 0 $gray-lighten-30 inset;
 		padding-bottom: 0.5em;
 	}
 
@@ -595,7 +595,7 @@
 	margin-bottom: 20px;
 	padding: 20px 24px;
 	background: $white;
-	box-shadow: 0 0 0 1px rgba( lighten( $gray, 20% ), 0.5 ), 0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px rgba( $gray-lighten-20, 0.5 ), 0 1px 2px $gray-lighten-30;
 }
 
 .sharing-buttons__fieldset-group {
@@ -678,7 +678,7 @@
 }
 
 .sharing-buttons-preview__fake-user {
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	display: inline-block;
 	height: 24px;
 	width: 24px;
@@ -687,7 +687,7 @@
 }
 
 .sharing-buttons-preview__fake-like {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	font-size: 11px;
 	font-weight: 300;
 }
@@ -703,7 +703,7 @@
 	align-items: center;
 	padding: 8px;
 	cursor: pointer;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	border-radius: 4px;
 	box-shadow: 0 0 8px rgba( $gray-dark, 0.04 );
 	background-color: $white;
@@ -728,8 +728,8 @@
 
 	&:disabled {
 		cursor: default;
-		border-color: lighten( $gray, 30% );
-		color: lighten( $gray, 30% );
+		border-color: $gray-lighten-30;
+		color: $gray-lighten-30;
 	}
 
 	&.is-add::before {
@@ -744,14 +744,14 @@
 		display: block;
 		width: 12px;
 		height: 12px;
-		border: 1px solid lighten( $gray, 20% );
+		border: 1px solid $gray-lighten-20;
 		background-color: $white;
 		transform: rotate( 45deg );
 	}
 
 	&:disabled.is-top::after,
 	&:disabled.is-bottom::after {
-		border-color: lighten( $gray, 30% );
+		border-color: $gray-lighten-30;
 	}
 
 	&.is-top {
@@ -825,7 +825,7 @@
 
 .sharing-buttons-preview__display {
 	padding: 10px 20px;
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	box-shadow: 0 3px 6px -3px rgba( 0, 0, 0, 0.05 );
 }
 
@@ -833,7 +833,7 @@
 	margin: 0;
 	padding: 8px 0;
 	background-color: $gray-light;
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	border-bottom: 0;
 	font-size: 11px;
 	line-height: 1;
@@ -846,7 +846,7 @@
 .sharing-buttons-preview.is-placeholder .sharing-buttons-preview__label,
 .sharing-buttons-preview.is-placeholder .sharing-buttons-preview__buttons {
 	display: block;
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
@@ -991,14 +991,14 @@
 	position: relative;
 	display: none;
 	background: $white;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	border-radius: 4px;
 	box-shadow: 0 0 8px rgba( $gray-dark, 0.04 );
 
 	&::before {
 		content: '';
 		position: absolute;
-		border: 1px solid lighten( $gray, 20% );
+		border: 1px solid $gray-lighten-20;
 		border-right-width: 0  #{"/*rtl:ignore*/"};
 		border-bottom-width: 0;
 		background: $white;
@@ -1115,7 +1115,7 @@
 .sharing-buttons-preview__panel-actions {
 	padding: 10px 20px;
 	text-align: right;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 }
 
 .sharing-buttons-preview__panel-action {

--- a/client/my-sites/sidebar-navigation/style.scss
+++ b/client/my-sites/sidebar-navigation/style.scss
@@ -16,12 +16,12 @@
 		padding: 8px 0;
 		color: $gray-dark;
 		background: $white;
-		border-bottom: 1px solid lighten( $gray, 20% );
+		border-bottom: 1px solid $gray-lighten-20;
 	}
 
 	.current-section__site-title {
 		font-size: 10px;
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		margin: 2px 0 -3px;
 	}
 

--- a/client/my-sites/site-settings/action-panel/style.scss
+++ b/client/my-sites/site-settings/action-panel/style.scss
@@ -17,7 +17,7 @@
 .settings-action-panel__body {
 	font-size: 14px;
 	line-height: 20px;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	overflow: hidden;
 
 	p {

--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -14,7 +14,7 @@
 
 .delete-site__content-list {
 	margin: 0 0 20px;
-	border: solid 1px lighten( $gray, 20% );
+	border: solid 1px $gray-lighten-20;
 	border-radius: 4px;
 	list-style: none;
 	text-align: left;
@@ -24,7 +24,7 @@
 	box-sizing: border-box;
 	width: 100%;
 	padding: 12px 16px;
-	border-top: solid 1px lighten( $gray, 20% );
+	border-top: solid 1px $gray-lighten-20;
 	font-size: 14px;
 	line-height: 18px;
 	color: $gray-dark;

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
@@ -61,7 +61,7 @@
 }
 
 .credentials-setup-flow__popover .popover__inner {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-size: 13px;
 	max-width: 220px;
 	padding: 16px;

--- a/client/my-sites/site-settings/press-this/style.scss
+++ b/client/my-sites/site-settings/press-this/style.scss
@@ -19,9 +19,9 @@
 			font-size: 14px;
 			text-decoration: none;
 			color: $gray-dark;
-			background: lighten( $gray, 30% );
+			background: $gray-lighten-30;
 			border-radius: 3px;
-			border: 1px solid lighten( $gray, 20% );
+			border: 1px solid $gray-lighten-20;
 		}
 
 		a .gridicon {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -359,7 +359,7 @@
 .has-divider, .site-settings__has-divider {
 	margin: 0 -24px;
 	padding: 24px 24px 16px 24px;
-	border: 1px lighten( $gray, 30% ) solid;
+	border: 1px $gray-lighten-30 solid;
 	border-width: 1px 0;
 
 	&.is-top-only {
@@ -406,7 +406,7 @@
 
 	&.is-expanded .foldable-card__content {
 		padding: 8px 24px 24px;
-		border-top: 1px lighten( $gray, 20% ) solid;
+		border-top: 1px $gray-lighten-20 solid;
 	}
 
 	&.is-expanded.is-top-level .foldable-card__content {

--- a/client/my-sites/site-settings/theme-setup/style.scss
+++ b/client/my-sites/site-settings/theme-setup/style.scss
@@ -19,7 +19,7 @@
 }
 
 .theme-setup .active-theme-screenshot__image {
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	box-sizing: border-box;
 }
 

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -1,6 +1,6 @@
 .sites__select-heading {
 	clear: both;
-	color: darken( $gray, 30% );
+	color: $gray-darken-30;
 	display: block;
 	font-family: $sans;
 	font-size: 20px;

--- a/client/my-sites/stats/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/stats/activity-log-confirm-dialog/style.scss
@@ -7,8 +7,8 @@
 	.activity-log-item__card {
 		padding-bottom: 8px;
 		border-radius: 4px;
-		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 2px 5px lighten( $gray, 20% );
+		box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 2px 5px $gray-lighten-20;
 	}
 	.activity-log-item__activity-icon {
 		background: $blue-medium;
@@ -16,7 +16,7 @@
 }
 
 .activity-log-confirm-dialog .dialog__content {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 
 	h1 {
 		color: $gray-dark;
@@ -161,7 +161,7 @@
 
 .activity-log-confirm-dialog__dialog__action-buttons {
 	overflow: hidden;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	padding: 16px;
 	margin: 0 -24px -24px;
 	text-align: right;

--- a/client/my-sites/stats/activity-log-day/style.scss
+++ b/client/my-sites/stats/activity-log-day/style.scss
@@ -45,8 +45,8 @@
 
 	> .foldable-card__header {
 		background: $white;
-		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-			0 1px 2px lighten( $gray, 30% );
+		box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+			0 1px 2px $gray-lighten-30;
 	}
 
 	> .foldable-card__content.foldable-card__content { // Sad panda specificity override

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -61,7 +61,7 @@
 		top: 0;
 		left: 33px;
 		height: 100%;
-		border-left: 2px dotted lighten($gray, 20%);
+		border-left: 2px dotted $gray-lighten-20;
 
 		@include breakpoint( '<480px' ) {
 			left: 22px;
@@ -139,7 +139,7 @@
 	.is-discarded & {
 		color: $gray-text;
 		background: none;
-		border: 1px solid transparentize(lighten($gray, 20%), 0.5);
+		border: 1px solid transparentize($gray-lighten-20, 0.5);
 	}
 }
 
@@ -158,12 +158,12 @@
 	.foldable-card__content {
 		padding: 16px;
 		font-size: 14px;
-		color: darken($gray, 20%);
+		color: $gray-darken-20;
 	}
 
 	.is-discarded & {
 		background: none;
-		box-shadow: 0 0 0 1px transparentize(lighten($gray, 20%), 0.5);
+		box-shadow: 0 0 0 1px transparentize($gray-lighten-20, 0.5);
 	}
 }
 
@@ -205,7 +205,7 @@
 		width: 40px;
 		height: 40px;
 		margin-right: 16px;
-		fill: darken($gray, 10%);
+		fill: $gray-darken-10;
 
 		@include breakpoint( '<960px' ) {
 			width: 32px;

--- a/client/my-sites/stats/activity-log-switch/style.scss
+++ b/client/my-sites/stats/activity-log-switch/style.scss
@@ -46,7 +46,7 @@
 }
 
 .activity-log-switch__features-header {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-size: 24px;
 	font-weight: 300;
 	line-height: 32px;
@@ -77,7 +77,7 @@
 }
 
 .activity-log-switch__feature-heading {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	font-size: 21px;
 	margin-bottom: 8px;
 	width: 100%;

--- a/client/my-sites/stats/activity-log/style.scss
+++ b/client/my-sites/stats/activity-log/style.scss
@@ -10,7 +10,7 @@
 			left: 33px;
 		height: 100%;
 		width: 2px;
-		background: lighten( $gray, 20% );
+		background: $gray-lighten-20;
 
 		@include breakpoint( "<480px" ) {
 			left: 25px;

--- a/client/my-sites/stats/checklist-banner/style.scss
+++ b/client/my-sites/stats/checklist-banner/style.scss
@@ -32,7 +32,7 @@
 	text-align: center;
 	font-size: 10px;
 	font-weight: bold;
-	color: darken($gray, 20%);
+	color: $gray-darken-20;
 }
 
 .checklist-banner__progress {

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -73,8 +73,8 @@
 	font-size: 14px;
 	line-height: 1.4285;
 	animation: appear .3s ease-in-out;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-		0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+		0 1px 2px $gray-lighten-30;
 
 	@include breakpoint( ">660px" ) {
 		padding: 13px 48px;

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -9,7 +9,7 @@
 }
 
 .post-trends__title {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	margin-left: 11px;
 	height: 40px;
 	font-weight: 600;
@@ -21,7 +21,7 @@
 	text-align: center;
 	font-size: 16px;
 	font-weight: 300;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	margin: 20px 0 30px;
 }
 
@@ -130,7 +130,7 @@
 	width: 7px;
 	height: 7px;
 	border: 1px solid $gray-light;
-	background-color: lighten( $gray, 20% );
+	background-color: $gray-lighten-20;
 	margin: 0;
 }
 
@@ -142,7 +142,7 @@
 	}
 
 	&.is-today {
-		background-color: lighten( $gray, 20% );
+		background-color: $gray-lighten-20;
 	}
 
 	&.is-after-today {

--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -16,7 +16,7 @@
 
 	.stats-period-navigation__previous, .stats-period-navigation__next {
 		cursor: pointer;
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 
 		@include breakpoint( "<660px" ) {
 			display: none;

--- a/client/my-sites/stats/stats-post-summary/style.scss
+++ b/client/my-sites/stats/stats-post-summary/style.scss
@@ -1,9 +1,9 @@
 .stats-post-summary .section-nav {
 	margin-bottom: 0;
 	padding: 16px 0;
-	box-shadow: 0 -1px 0 0 transparentize( lighten( $gray, 20% ), .5 ),
-		-1px -1px 0 0 transparentize( lighten( $gray, 20% ), .5 ),
-		1px -1px 0 0 transparentize( lighten( $gray, 20% ), .5 );
+	box-shadow: 0 -1px 0 0 transparentize( $gray-lighten-20, .5 ),
+		-1px -1px 0 0 transparentize( $gray-lighten-20, .5 ),
+		1px -1px 0 0 transparentize( $gray-lighten-20, .5 );
 	z-index: z-index( '.stats-post-summary', '.section-nav' );
 	.segmented-control {
 		margin: 0 auto;

--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -260,7 +260,7 @@
 
 		&,
 		li {
-			border-color: lighten( $gray, 30% );
+			border-color: $gray-lighten-30;
 		}
 
 		a {

--- a/client/my-sites/stats/stats-views/style.scss
+++ b/client/my-sites/stats/stats-views/style.scss
@@ -35,11 +35,11 @@
 	}
 
 	&.level-0 {
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 	}
 
 	&.level-1 {
-		background-color: lighten( $gray, 20% );
+		background-color: $gray-lighten-20;
 	}
 
 	&.level-2 {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -349,7 +349,7 @@
 	a {
 		display: inline-block;
 		position: relative;
-		background: lighten( $gray, 30% );
+		background: $gray-lighten-30;
 		color: $gray-dark;
 		margin: 4px;
 		padding: 2px 12px;
@@ -403,7 +403,7 @@
 	}
 
 	.gridicon {
-		color: lighten( $gray, 20% );
+		color: $gray-lighten-20;
 		flex: 0 0 auto;
 	}
 
@@ -438,7 +438,7 @@
 	}
 
 	.gridicon {
-		color: lighten( $gray, 20% );
+		color: $gray-lighten-20;
 		flex: 0 0 auto;
 	}
 
@@ -463,8 +463,8 @@
 }
 
 .theme__sheet-footer-line {
-	color: lighten( $gray, 20% );
-	border-top: 1px solid lighten( $gray, 20% );
+	color: $gray-lighten-20;
+	border-top: 1px solid $gray-lighten-20;
 	margin: 32px 0 20px;
 
 	.gridicon {

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -1,6 +1,6 @@
 
 $current-theme-height: 56px;
-$current-theme-border: 1px solid transparentize( lighten( $gray, 20% ), .25 );
+$current-theme-border: 1px solid transparentize( $gray-lighten-20, .25 );
 
 .current-theme {
 	font-weight: 600;
@@ -37,7 +37,7 @@ $current-theme-border: 1px solid transparentize( lighten( $gray, 20% ), .25 );
 	}
 	width: 75px;
 	color: transparent;
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 	animation: loading-fade 1.6s ease-in-out infinite;
 	height: 100%;
 }
@@ -64,7 +64,7 @@ $current-theme-border: 1px solid transparentize( lighten( $gray, 20% ), .25 );
 
 .current-theme__placeholder {
 	color: transparent;
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -30,7 +30,7 @@
 		+ span {
 			display: block;
 			text-align: center;
-			color: lighten( $gray, 10% );
+			color: $gray-lighten-10;
 			margin-top: 0.3em;
 		}
 
@@ -92,8 +92,8 @@
 }
 
 .sticky-panel.is-sticky .themes__search-card {
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-	0 2px 4px lighten( $gray, 20% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ),
+	0 2px 4px $gray-lighten-20;
 }
 
 .themes__upload-button {

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -12,7 +12,7 @@
 .theme-upload__screenshot {
 	float: right;
 	width: 300px;
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	margin-left: 24px;
 
 	@include breakpoint( "<960px" ) {
@@ -29,7 +29,7 @@
 .theme-upload__action-buttons {
 	clear: both;
 	overflow: hidden;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	padding: 16px;
 	margin: 24px -24px -24px;
 

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -10,7 +10,7 @@
 	display: flex;
 	align-items: center;
 	background: white;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ), 0 1px 2px $gray-lighten-30;
 	transition: all 0.15s ease-in-out;
 
 	&.has-highlight {
@@ -35,7 +35,7 @@
 	}
 
 	.search .search-open__icon {
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 	}
 
 	.themes-magic-search-card__icon {
@@ -51,7 +51,7 @@
 
 		.themes-magic-search-card__icon-close {
 			flex: 0 0 auto;
-			color: darken( $gray, 30% );
+			color: $gray-darken-30;
 			align-items: center;
 		}
 	}
@@ -164,7 +164,7 @@
 .themes-magic-search-card__welcome {
 	color: $gray;
 	background-color: $white;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .5 ), 0 1px 2px $gray-lighten-30;
 	display: flex;
 	flex-direction: column;
 }

--- a/client/my-sites/themes/themes-selection-header/style.scss
+++ b/client/my-sites/themes/themes-selection-header/style.scss
@@ -22,7 +22,7 @@
 		.section-header__label-text,
 		.section-header__actions {
 			color: transparent;
-			background-color: lighten( $gray, 30% );
+			background-color: $gray-lighten-30;
 			animation: loading-fade 1.6s ease-in-out infinite;
 		}
 	}

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -27,7 +27,7 @@
 		text-transform: uppercase;
 		font-size: 11px;
 		line-height: 1;
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 		pointer-events: none;
 		z-index: z-index( 'root', '.editor-action-bar .editor-status-label' );
 
@@ -80,7 +80,7 @@
 }
 
 .editor-action-bar .button {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	background: transparent;
 	margin-left: 18px;
 	transition: color 200ms;
@@ -88,11 +88,11 @@
 
 	&:hover,
 	&:focus {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 	}
 
 	@include breakpoint( ">660px" ) {
-		color: lighten( $gray, 20% );
+		color: $gray-lighten-20;
 	}
 
 	.gridicon {

--- a/client/post-editor/editor-author/style.scss
+++ b/client/post-editor/editor-author/style.scss
@@ -1,6 +1,6 @@
 .editor-author.is-placeholder .editor-author__name {
 	animation: pulse-light 0.8s ease-in-out infinite;
-	background: lighten( $gray, 20% );
+	background: $gray-lighten-20;
 	display: inline-block;
 	height: 14px;
 	width: 100px;
@@ -13,7 +13,7 @@
 }
 
 .editor-author__name {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	font-size: 13px;
 	margin: 0 8px;
 

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -86,7 +86,7 @@
 	padding: 0 24px;
 	box-sizing: border-box;
 	background: $white;
-	box-shadow: 0 0 0 1px transparentize(lighten($gray, 20%), 0.5), 0 1px 2px lighten($gray, 30%);
+	box-shadow: 0 0 0 1px transparentize($gray-lighten-20, 0.5), 0 1px 2px $gray-lighten-30;
 }
 
 .editor-confirmation-sidebar__close {

--- a/client/post-editor/editor-drawer-well/style.scss
+++ b/client/post-editor/editor-drawer-well/style.scss
@@ -13,11 +13,11 @@
 	min-height: 150px;
 	padding: 24px;
 	margin: 0;
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 	cursor: pointer;
 
 	&:hover {
-		border-color: lighten( $gray, 10% );
+		border-color: $gray-lighten-10;
 		color: $gray-dark;
 	}
 }

--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -28,7 +28,7 @@
 			top: 1px;
 			bottom: 1px;
 		width: 60%;
-		background-color: lighten( $gray, 20% );
+		background-color: $gray-lighten-20;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -193,12 +193,12 @@
 
 .editor-ground-control__save-status {
 	text-decoration: none;
-	color: lighten( $gray, 20% );
+	color: $gray-lighten-20;
 }
 
 .editor-ground-control .edit-post-status {
-	border-top: 1px solid lighten( $gray, 30% );
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
+	border-bottom: 1px solid $gray-lighten-30;
 	margin: 0 -16px 16px;
 	padding: 16px;
 }
@@ -213,7 +213,7 @@
 	background: white;
 	position: relative;
 	color: $blue-wordpress;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	cursor: pointer;
 	fill: $blue-wordpress;
 	position: absolute;
@@ -235,8 +235,8 @@
 		top: -6px;
 		right: 48px;
 		transform: translate(-50%) rotate(45deg);
-		border-top: 1px solid lighten( $gray, 20% );
-		border-left: 1px solid lighten( $gray, 20% );
+		border-top: 1px solid $gray-lighten-20;
+		border-left: 1px solid $gray-lighten-20;
 	}
 
 	&:focus:not(:active) {

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -5,7 +5,7 @@
 
 	.editor-html-toolbar__wrapper {
 		background-color: rgba( $white, 0.92 );
-		border-color: lighten( $gray, 20% );
+		border-color: $gray-lighten-20;
 		border-style: solid;
 		border-left-width: 1px;
 		border-right-width: 1px;
@@ -101,8 +101,8 @@
 	}
 
 	.button {
-		border-right: 1px solid lighten( $gray, 30% );
-		color: darken( $gray, 20% );
+		border-right: 1px solid $gray-lighten-30;
+		color: $gray-darken-20;
 		height: 26px;
 		margin: 6px 0;
 		padding: 4px 12px;
@@ -135,7 +135,7 @@
 	height: 38px;
 
 	.editor-html-toolbar__button-insert-content-dropdown.button {
-		border-right: 1px solid lighten( $gray, 30% );
+		border-right: 1px solid $gray-lighten-30;
 		height: 38px;
 		margin: 0;
 		min-width: auto;
@@ -168,7 +168,7 @@
 
 .editor-html-toolbar__insert-content-dropdown {
 	background-color: $white;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	border-radius: 0 0 4px 4px;
 	display: none;
 	left: 0;
@@ -225,7 +225,7 @@
 	font-family: $code;
 }
 .editor-html-toolbar__button-close-tags.button[disabled]:hover {
-	color: lighten( $gray, 30% );
+	color: $gray-lighten-30;
 }
 
 .editor-html-toolbar__dialog {

--- a/client/post-editor/editor-location/style.scss
+++ b/client/post-editor/editor-location/style.scss
@@ -14,14 +14,14 @@
 	list-style-type: none;
 	margin: 0;
 	padding-left: 0;
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 }
 
 .editor-location__search-result {
 	padding: 8px;
 	margin: 0 -1px;
 	cursor: pointer;
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	border-top-width: 0;
 	border-bottom-width: 0;
 	font-size: 13px;

--- a/client/post-editor/editor-page-parent/style.scss
+++ b/client/post-editor/editor-page-parent/style.scss
@@ -19,7 +19,7 @@
 }
 
 .editor-page-parent__top-level-label {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	font-size: 13px;
 	line-height: 1.7;
 }

--- a/client/post-editor/editor-permalink/style.scss
+++ b/client/post-editor/editor-permalink/style.scss
@@ -26,7 +26,7 @@
 
 .editor-permalink__popover .editor-slug .form-text-input {
 	border: none;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	font-size: 13px;
 	padding: 4px 0;
 	min-width: 100px;
@@ -38,7 +38,7 @@
 }
 
 .editor-permalink__url-path {
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 	font-size: 13px;
 	margin-right: 0;
 }

--- a/client/post-editor/editor-post-formats/style.scss
+++ b/client/post-editor/editor-post-formats/style.scss
@@ -21,7 +21,7 @@
 		left: 0;
 	transform: translateY( -50% );
 	line-height: 1;
-	fill: darken( $gray, 20% );
+	fill: $gray-darken-20;
 
 	.gridicon {
 		margin-top: 3px;

--- a/client/post-editor/editor-post-type/style.scss
+++ b/client/post-editor/editor-post-type/style.scss
@@ -5,7 +5,7 @@
 
 	.post-status__text {
 		display: none;
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		margin-left: 4px;
 		vertical-align: baseline;
 	}

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -7,7 +7,7 @@
 
 .editor-publish-date__wrapper {
 	background: $white;
-	border: 1px solid lighten($gray, 20%);
+	border: 1px solid $gray-lighten-20;
 	border-width: 1px 1px 2px;
 	border-radius: 4px;
 	box-sizing: border-box;
@@ -131,7 +131,7 @@
 .editor-publish-date__schedule {
 	overflow-y: auto;
 	position: static;
-	border-top: 1px solid lighten($gray, 20%);
+	border-top: 1px solid $gray-lighten-20;
 	padding: 0 10px;
 
 	&.is-scheduled {

--- a/client/post-editor/editor-seo-accordion/style.scss
+++ b/client/post-editor/editor-seo-accordion/style.scss
@@ -5,7 +5,7 @@
 
 	.token-field__token-text {
 		border-radius: 4px;
-		background-color: lighten( $gray, 10% );
+		background-color: $gray-lighten-10;
 		padding: 0 6px;
 	}
 

--- a/client/post-editor/editor-sharing/style.scss
+++ b/client/post-editor/editor-sharing/style.scss
@@ -7,7 +7,7 @@
 }
 
 .editor-sharing__shortlink {
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 	color: $gray;
 	font-size: 11px;
 	margin: 16px -16px 0;
@@ -28,7 +28,7 @@
 }
 
 input[type="text"].editor-sharing__shortlink-field {
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 	color: $gray-dark;
 	flex-grow: 1;
 	font-size: 12px;

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -1,7 +1,7 @@
 .editor-sidebar {
 	@extend .sidebar;
 	z-index: z-index( 'root', '.editor-sidebar' );
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 	border-left: 1px solid darken( $sidebar-bg-color, 5% );
 	border-top: 1px solid darken( $sidebar-bg-color, 5% );
 	border-right: none;
@@ -71,7 +71,7 @@
 
 .editor-sidebar__header {
 	align-items: center;
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 	color: $gray-dark;
 	display: flex;
 	flex-shrink: 0;

--- a/client/post-editor/editor-slug/style.scss
+++ b/client/post-editor/editor-slug/style.scss
@@ -17,7 +17,7 @@
 
 .editor-slug .form-text-input {
 	border: none;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	font-size: 13px;
 	padding: 4px 0;
 	width: 200px;
@@ -28,7 +28,7 @@
 }
 
 .editor-slug__url-path {
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 	font-size: 13px;
 	margin-right: 0;
 	cursor: pointer;

--- a/client/post-editor/editor-status-label/style.scss
+++ b/client/post-editor/editor-status-label/style.scss
@@ -10,13 +10,13 @@
 
 	.gridicon {
 		display: inline-block;
-		fill: lighten( $gray, 10% );
+		fill: $gray-lighten-10;
 		position: absolute;
 			left: 14px;
 	}
 
 	strong {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 	}
 
 	&.is-publish strong {

--- a/client/post-editor/editor-term-selector/add-term.scss
+++ b/client/post-editor/editor-term-selector/add-term.scss
@@ -1,5 +1,5 @@
 .editor-term-selector__add-term {
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	border-top: 0px;
 	margin: 0 0 8px;
 	padding: 8px;

--- a/client/post-editor/editor-title/style.scss
+++ b/client/post-editor/editor-title/style.scss
@@ -9,7 +9,7 @@
 			bottom: 12px;
 			left: 10px;
 		animation: pulse-light 0.8s ease-in-out infinite;
-		background: lighten( $gray, 20% );
+		background: $gray-lighten-20;
 	}
 
 	.focus-sidebar & {

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -72,7 +72,7 @@
 	&.is-touch,
 	&:hover {
 		.editor-visibility__label {
-			color: darken( $gray, 10% );
+			color: $gray-darken-10;
 		}
 	}
 

--- a/client/post-editor/editor-word-count/style.scss
+++ b/client/post-editor/editor-word-count/style.scss
@@ -7,7 +7,7 @@
 	text-transform: uppercase;
 	font-size: 11px;
 	line-height: 1;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 	pointer-events: none;
 	z-index: z-index( 'root', '.editor-word-count' );
 
@@ -17,9 +17,9 @@
 }
 
 .editor-word-count__is-selected-text {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 }
 
 .editor-word-count__separator {
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 }

--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -16,7 +16,7 @@
 .editor-media-modal-detail__preview-wrapper {
 	flex: 0 0 35%;
 	position: relative;
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	background-color: $gray-light;
 	box-shadow: inset 0 0 2px 2px rgba( lighten( $gray, 10 ), 0.1 );
 
@@ -78,7 +78,7 @@
 	}
 
 	&:hover {
-		background-color: rgba( darken( $gray, 20% ), 0.9 );
+		background-color: rgba( $gray-darken-20, 0.9 );
 	}
 }
 
@@ -203,7 +203,7 @@
 			top: 0;
 			bottom: 0;
 		width: 80%;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }

--- a/client/post-editor/media-modal/gallery/style.scss
+++ b/client/post-editor/media-modal/gallery/style.scss
@@ -5,7 +5,7 @@
 	flex: 2 0 0%;
 	margin: 80px 0 0;
 	background-color: $gray-light;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 
 	@include breakpoint( ">660px" ) {
 		display: block;
@@ -40,7 +40,7 @@
 	}
 
 	.segmented-control__item .segmented-control__link {
-		border-color: lighten( $gray, 20% );
+		border-color: $gray-lighten-20;
 	}
 
 	.segmented-control__item:first-of-type .segmented-control__link {
@@ -49,7 +49,7 @@
 
 	.segmented-control__item:last-of-type .segmented-control__link {
 		border-bottom-right-radius: 0;
-		border-left-color: lighten( $gray, 20% );
+		border-left-color: $gray-lighten-20;
 	}
 
 	.segmented-control__item.is-selected .segmented-control__link {
@@ -84,10 +84,10 @@
 	height: 28px;
 	/*rtl:ignore*/
 	transform: translate( 25%, -25% );
-	border: 1px solid lighten( $gray, 10% );
+	border: 1px solid $gray-lighten-10;
 	border-radius: 50%;
 	background-color: $gray-light;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 	cursor: pointer;
 }
 
@@ -194,14 +194,14 @@ input.editor-media-modal-gallery__caption[type="text"] {
 			lighten( $gray, 25% ) 40%,
 			transparent 40%,
 			transparent 42%,
-			lighten( $gray, 20% ) 42%
+			$gray-lighten-20 42%
 		);
 	}
 
 	&::after {
 		top: calc( 146px + 2% );
 		height: 240px;
-		background: lighten( $gray, 10% );
+		background: $gray-lighten-10;
 	}
 
 	&.is-loading::before,
@@ -291,7 +291,7 @@ input[type].editor-media-modal-gallery__input-width-auto {
 
 .editor-media-modal-gallery__preview-individual .wp-caption-dd {
 	background: $gray-light;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-size: 14px;
 	line-height: 1.7;
 	padding: 16px;

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -203,7 +203,7 @@
 	float: left;
 	margin: 4px 12px 12px 0;
 	border-radius: 50%;
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 	color: $gray-dark;
 }
 
@@ -217,7 +217,7 @@
 .editor-media-modal__gallery-help-actions {
 	overflow-y: hidden;
 	padding: 8px 16px;
-	border-top: 1px solid lighten( $gray, 30% );
+	border-top: 1px solid $gray-lighten-30;
 }
 
 .editor-media-modal__gallery-help-remember-dismiss {

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -18,7 +18,7 @@
 @include breakpoint( "<660px" ) {
 	.is-group-editor.focus-sidebar::before,
 	.is-group-editor.focus-editor-confirmation-sidebar::before {
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 	}
 
 	.is-group-editor .sidebar {
@@ -69,7 +69,7 @@
 .post-editor__site {
 	display:  flex;
 	margin-bottom: 16px;
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 
 	@include breakpoint( ">660px" ) {
 		display: none;
@@ -83,7 +83,7 @@
 	.site__title,
 	.site__domain {
 		&::after {
-			@include long-content-fade( $color: lighten( $gray, 30% ) );
+			@include long-content-fade( $color: $gray-lighten-30 );
 		}
 	}
 
@@ -169,7 +169,7 @@
 	}
 
 	&:focus {
-		border-color: lighten( $gray, 20% );
+		border-color: $gray-lighten-20;
 		box-shadow: none;
 	}
 }
@@ -203,25 +203,25 @@
 
 	&:last-of-type {
 		.segmented-control__link {
-			border-right-color: lighten( $gray, 20% );
+			border-right-color: $gray-lighten-20;
 			border-bottom-right-radius: 0;
 		}
 	}
 
 	&.is-selected {
 		+ .segmented-control__item .segmented-control__link {
-			border-left-color: lighten( $gray, 20% );
+			border-left-color: $gray-lighten-20;
 		}
 	}
 }
 
 .post-editor__switch-mode .segmented-control__link {
 	background: $gray-light;
-	border-color: lighten( $gray, 20% );
+	border-color: $gray-lighten-20;
 }
 
 .post-editor__switch-mode .segmented-control__item.is-selected .segmented-control__link {
-	border-color: lighten( $gray, 20% );
+	border-color: $gray-lighten-20;
 	border-bottom-color: $white;
 	background-color: $white;
 }
@@ -237,7 +237,7 @@
 }
 
 .post-editor .drafts__list + .list-end::after {
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 }
 
 .post-editor .draft {

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -171,7 +171,7 @@
 		font-family: $sans;
 		font-size: 15px;
 		padding-top: 5px;
-		border-top: 1px solid lighten( $gray, 20% );
+		border-top: 1px solid $gray-lighten-20;
 
 		a {
 			padding: 5px 10px;

--- a/client/reader/conversations/style.scss
+++ b/client/reader/conversations/style.scss
@@ -1,6 +1,6 @@
 // Conversations intro
 .conversations__intro {
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 	color: $blue-dark;
 	display: flex;
 	min-height: 140px;
@@ -62,7 +62,7 @@
 	width: 24px;
 
 	.conversations__intro-close-icon {
-		fill: lighten( $gray, 10% );
+		fill: $gray-lighten-10;
 		position: absolute;
 
 		// Fix for 1px (0.5pt) misalignment in Safari under retina. See
@@ -71,7 +71,7 @@
 
 		&:hover {
 			cursor: pointer;
-			fill: darken( $gray, 20% );
+			fill: $gray-darken-20;
 		}
 	}
 }

--- a/client/reader/discover/style.scss
+++ b/client/reader/discover/style.scss
@@ -45,7 +45,7 @@
 
 	.site-icon {
 		margin-right: 6px;
-		background: lighten( $gray, 20% );
+		background: $gray-lighten-20;
 
 		.gridicon {
 			color: $white;
@@ -59,7 +59,7 @@
 	.follow-button {
 		background: transparent;
 		border: 0;
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 		float: none;
 		font-size: 13px;
 		padding: 0;

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -16,7 +16,7 @@
 }
 
 .following-manage__input-card.card.is-compact {
-	box-shadow: 0 0 0 2px lighten( $gray, 20% ), 0 1px 2px lighten( $gray, 20% );
+	box-shadow: 0 0 0 2px $gray-lighten-20, 0 1px 2px $gray-lighten-20;
 }
 
 .following-manage__subscriptions {
@@ -26,7 +26,7 @@
 
 // Load more results
 .following-manage__show-more {
-	border-top: 1px solid lighten( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
 	display: flex;
 	justify-content: center;
 	margin-top: 10px;
@@ -50,7 +50,7 @@
 	}
 
 	&:hover {
-		color: darken( $gray, 10% );
+		color: $gray-darken-10;
 		cursor: pointer;
 	}
 }
@@ -126,7 +126,7 @@
 	}
 
 	.following-manage__subscriptions-search .search-card {
-		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .3 );
+		box-shadow: 0 0 0 1px transparentize( $gray-lighten-20, .3 );
 
 		.following-manage__search-followed-input.is-compact {
 			height: 32px;
@@ -150,7 +150,7 @@
 		}
 
 		.gridicon.gridicons-ellipsis {
-			fill: lighten( $gray, 10% );
+			fill: $gray-lighten-10;
 			top: 0;
 		}
 	}
@@ -178,7 +178,7 @@
 }
 
 .following-manage .reader-recommended-sites {
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 }
 
 .following-manage__search-followed {
@@ -193,7 +193,7 @@
 }
 
 .following-manage__search-results > div {
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 
 	&:nth-last-child(2),
 	&:last-child {
@@ -203,7 +203,7 @@
 
 .following-manage__search-results.is-empty,
 .following-manage__subscriptions-list.is-empty {
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 }
 
 .following-manage__search-results .reader-subscription-list-item__options {
@@ -241,7 +241,7 @@
 }
 
 .following-manage__sites-window-scroller-row-wrapper {
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 
 	&:last-child {
 		border: 0;
@@ -251,11 +251,11 @@
 .following-manage__url-follow-no-search-results-message {
 	margin-top: -5px;
 	padding-bottom: 15px;
-	color: darken( $gray, 10% )
+	color: $gray-darken-10
 }
 
 .following-manage__url-follow {
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -4,14 +4,14 @@
 
 .following__search.card.is-compact {
 	padding: 0;
-	box-shadow: 0 0 0 2px lighten( $gray, 20% ), 0 1px 2px lighten( $gray, 20% );
+	box-shadow: 0 0 0 2px $gray-lighten-20, 0 1px 2px $gray-lighten-20;
 	z-index: z-index( 'root', '.reader-following-search' );
 }
 
 // Following intro
 .following__intro {
 	background: url( '/calypso/images/reader/reader-intro-background.svg' ) $white no-repeat 100% 20px;
-	border: 1px solid lighten( $gray, 30% );
+	border: 1px solid $gray-lighten-30;
 
 	.following__intro-copy {
 		color: #045182;
@@ -152,7 +152,7 @@
 .following__intro .following__intro-close {
 
 	.following__intro-close-icon {
-		fill: lighten( $gray, 10% );
+		fill: $gray-lighten-10;
 	}
 
 	.following__intro-close-icon-bg {

--- a/client/reader/list-gap/_style.scss
+++ b/client/reader/list-gap/_style.scss
@@ -1,5 +1,5 @@
 .reader-list-gap {
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	cursor: pointer;
 	margin-bottom: 16px;
 	padding: 30px 0;
@@ -25,7 +25,7 @@
 	}
 
 	&::before {
-		background: linear-gradient(-135deg, lighten( $gray, 30% ) 8px, transparent 0) 0 8px, linear-gradient( 135deg, lighten( $gray, 30% ) 8px, transparent 0) 0 8px;
+		background: linear-gradient(-135deg, $gray-lighten-30 8px, transparent 0) 0 8px, linear-gradient( 135deg, $gray-lighten-30 8px, transparent 0) 0 8px;
 		background-position: top left;
 		background-repeat: repeat-x;
 		background-size: 16px 16px;

--- a/client/reader/list-item/style.scss
+++ b/client/reader/list-item/style.scss
@@ -20,7 +20,7 @@
 		pointer-events: none;
 		user-select: none;
 		color: transparent;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -1,6 +1,6 @@
 .is-group-reader .card.list-stream__header {
 	box-shadow: none;
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	display: flex;
 	flex-direction: row;
 	min-height: 48px;
@@ -25,7 +25,7 @@
 .list-stream__header-icon {
 	height: 48px;
 	width: 48px;
-	background: lighten( $gray, 20% );
+	background: $gray-lighten-20;
 	text-align: center;
 
 	.gridicon {
@@ -109,7 +109,7 @@
 	.follow-button,
 	.follow-button__label {
 		color: transparent;
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-lighten-30;
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -28,7 +28,7 @@
 }
 
 .search-stream .search-stream__input-card.card {
-	box-shadow: 0 0 0 2px lighten( $gray, 20% ), 0 1px 2px lighten( $gray, 20% );
+	box-shadow: 0 0 0 2px $gray-lighten-20, 0 1px 2px $gray-lighten-20;
 	margin-bottom: 0;
 }
 
@@ -48,7 +48,7 @@
 
 // Search term suggestions
 .search-stream__blank-suggestions {
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	font-size: 13px;
 	color: $gray;
 	padding: 16px 0;
@@ -82,7 +82,7 @@
 
 .is-reader-page .search-stream__recommendation-list-item {
 	box-sizing: border-box;
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	display: flex;
 	flex-basis: calc( 50% - 15px );
 	margin-left: 15px;
@@ -229,7 +229,7 @@
 
 .search-stream__post-header,
 .search-stream__site-header {
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	padding-bottom: 15px;
 }
 
@@ -254,7 +254,7 @@
 
 .search-stream__header .section-nav {
 	background: inherit;
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	box-shadow: none;
 	height: 53px;
 	margin-bottom: 0;
@@ -442,7 +442,7 @@
 }
 
 .search-stream__url-follow {
-	border-bottom: 1px solid lighten( $gray, 30% );
+	border-bottom: 1px solid $gray-lighten-30;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -26,7 +26,7 @@
 			background-color: $gray-light;
 
 			.gridicon {
-				fill: darken( $gray, 20% );
+				fill: $gray-darken-20;
 			}
 
 			.sidebar__menu-item-label, .menu-link-text {
@@ -34,7 +34,7 @@
 			}
 
 			.sidebar__button {
-				background-color: darken( $gray, 10% );
+				background-color: $gray-darken-10;
 				color: $white;
 			}
 		}
@@ -123,9 +123,9 @@
 
 				.add-new {
 					background: $white;
-					border: 1px solid lighten( $gray, 20% );
+					border: 1px solid $gray-lighten-20;
 					border-radius: 3px;
-					color: darken( $gray, 10% );
+					color: $gray-darken-10;
 					font-size: 11px;
 					padding: 6px 7px;
 					position: absolute;
@@ -197,14 +197,14 @@
 		padding: 8px 16px 8px 55px;
 
 		&::after {
-			@include long-content-fade( $color: lighten( $gray, 30% ), $size: 20px );
+			@include long-content-fade( $color: $gray-lighten-30, $size: 20px );
 			padding-right: 50px;
 		}
 
 		.sidebar__menu-item-tagname {
 
 			&::after {
-				@include long-content-fade( $color: lighten( $gray, 30% ), $size: 20px );
+				@include long-content-fade( $color: $gray-lighten-30, $size: 20px );
 				right: 60px;
 			}
 		}
@@ -222,7 +222,7 @@
 			top: 7px;
 			right: 8px;
 		border-width: 1px;
-		border-color: lighten( $gray, 20% );
+		border-color: $gray-lighten-20;
 		padding: 6px 7px;
 		border-radius: 3px;
 		text-transform: none;

--- a/client/reader/site-stream/style.scss
+++ b/client/reader/site-stream/style.scss
@@ -48,7 +48,7 @@
 		min-height: 152px;
 
 		&:hover {
-			background-color: darken( $gray, 30% );
+			background-color: $gray-darken-30;
 		}
 	}
 }

--- a/client/reader/stream/_style.scss
+++ b/client/reader/stream/_style.scss
@@ -6,7 +6,7 @@
 }
 
 .is-reader-page .reader__card.card.is-placeholder {
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	box-shadow: none;
 	margin-bottom: 0;
 	padding: 6px 0 30px;
@@ -51,7 +51,7 @@
 		&.tag-afk.is-selected,
 		&.tag-afk:hover {
 			box-shadow: 0 0 0 1px $gray,
-						0 2px 4px lighten( $gray, 20% );
+						0 2px 4px $gray-lighten-20;
 		}
 	}
 
@@ -77,7 +77,7 @@
 		margin: 8px 0;
 		padding: 0;
 		font-size: 14px;
-		color: lighten( $gray, 10% );
+		color: $gray-lighten-10;
 
 		.gravatar {
 			height: 16px;
@@ -95,7 +95,7 @@
 		.reader__placeholder-text,
 		.site-icon {
 			color: transparent;
-			background-color: lighten( $gray, 30% );
+			background-color: $gray-lighten-30;
 			animation: loading-fade 1.6s ease-in-out infinite;
 		}
 
@@ -225,7 +225,7 @@
 .is-reader-page {
 
 	.reader__card.card.is-x-post {
-		border-bottom: 1px solid lighten( $gray, 20% );
+		border-bottom: 1px solid $gray-lighten-20;
 		margin: 0;
 		padding: 20px 42px;
 
@@ -235,7 +235,7 @@
 
 		.reader__post-title-link,
 		.reader__post-title-link:visited {
-			color: darken( $gray, 20% );
+			color: $gray-darken-20;
 		}
 
 		.reader__post-title-link:hover {
@@ -414,7 +414,7 @@ $reader-related-card-v2-breakpoint-medium: "( min-width: 661px ) and ( max-width
 $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 
 .reader-stream__recommended-posts {
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid $gray-lighten-20;
 	padding-bottom: 12px;
 
 	@include breakpoint( "<660px" ) {
@@ -423,7 +423,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 }
 
 .reader-stream__recommended-posts-header {
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 	font-size: 14px;
 	font-weight: 600;
 	letter-spacing: 0.01em;
@@ -432,7 +432,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	text-transform: uppercase;
 
 	.gridicon {
-		fill: lighten( $gray, 10% );
+		fill: $gray-lighten-10;
 		margin-right: -2px;
 		position: relative;
 			left: -2px;
@@ -509,7 +509,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 		}
 
 		.gridicon {
-			fill: lighten( $gray, 10% );
+			fill: $gray-lighten-10;
 			width: 14px;
 			height: 14px;
 			top: -3px;
@@ -650,7 +650,7 @@ $reader-related-card-v2-breakpoint-small: "( max-width: 535px )";
 	}
 
 	.reader-related-card-v2__featured-image {
-		border: 1px solid lighten( $gray, 30% );
+		border: 1px solid $gray-lighten-30;
 		margin: 0 0 14px;
 
 		@media #{$reader-related-card-v2-breakpoint-medium} {

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -27,7 +27,7 @@
 }
 
 .tag-stream__header-image {
-	background: lighten( $gray, 30% );
+	background: $gray-lighten-30;
 	background-size: cover;
 	background-repeat: no-repeat;
 	background-position: right center;

--- a/client/signup/processing-screen/style.scss
+++ b/client/signup/processing-screen/style.scss
@@ -354,7 +354,7 @@
 }
 .signup-pricessing__title-subdomain {
 	text-transform: uppercase;
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 	font-size: 0.7em;
 	margin: 3px;
 	text-align: left;
@@ -365,7 +365,7 @@
 }
 .signup-pricessing__address-bar {
 	display: flex;
-	background: darken( $gray, 10% );
+	background: $gray-darken-10;
 	border-radius: 8px;
 	flex-direction: row;
 	padding: 10px;
@@ -393,7 +393,7 @@
 .signup-pricessing__address-field.is-placeholder:after {
 	content: 'placeholder.wordpress.com';
 	color: transparent;
-	background-color: lighten( $gray, 30% );
+	background-color: $gray-lighten-30;
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 .signup-pricessing__bubble {
@@ -433,7 +433,7 @@
 .signup-pricessing__nudge-message {
 	width: 400px;
 	max-width: 96%;
-	color: darken( $gray, 10% );
+	color: $gray-darken-10;
 	margin: 1.5em auto;
 	box-sizing: border-box;
 }

--- a/client/signup/steps/about/style.scss
+++ b/client/signup/steps/about/style.scss
@@ -26,13 +26,13 @@
 }
 
 .about__checkboxes {
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	border-radius: 3px;
 }
 
 .about__checkbox-option {
-	border-top: 1px solid lighten( $gray, 20% );
-	color: darken( $gray, 20% );
+	border-top: 1px solid $gray-lighten-20;
+	color: $gray-darken-20;
 	display: block;
 	font-weight: normal;
 	margin: 0;
@@ -68,7 +68,7 @@
 }
 
 .about__segment-label {
-	color: darken( $gray, 20% );
+	color: $gray-darken-20;
 
 	&:hover {
 		cursor: pointer;

--- a/client/signup/steps/design-type-with-store/style.scss
+++ b/client/signup/steps/design-type-with-store/style.scss
@@ -43,7 +43,7 @@
 .design-type-with-store__choice {
 	transition: all 100ms ease-in-out;
 	position: relative;
-	border: 1px solid lighten( $gray, 20% );
+	border: 1px solid $gray-lighten-20;
 	border-bottom: 0;
 	margin: 0 10px;
 
@@ -86,7 +86,7 @@
 
 	&:last-of-type {
 		margin-bottom: 20px;
-		border: 1px solid lighten( $gray, 20% );
+		border: 1px solid $gray-lighten-20;
 		border-bottom-right-radius: 6px;
 		border-bottom-left-radius: 6px;
 
@@ -115,8 +115,8 @@
 		position: absolute;
 		top: 20px;
 		right: 15px;
-		border-top: 2px solid lighten( $gray, 20% );
-		border-right: 2px solid lighten( $gray, 20% );
+		border-top: 2px solid $gray-lighten-20;
+		border-right: 2px solid $gray-lighten-20;
 		transform: rotate(45deg);
 	}
 
@@ -145,7 +145,7 @@
 @include breakpoint( ">480px" ) {
 	.design-type-with-store__choice-copy {
 		padding: 15px;
-		border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+		border-top: 1px solid transparentize( $gray-lighten-20, .5 );
 	}
 }
 

--- a/client/signup/steps/design-type/style.scss
+++ b/client/signup/steps/design-type/style.scss
@@ -13,9 +13,9 @@
 	cursor: pointer;
 
 	h2 {
-		color: darken( $gray, 20% );
+		color: $gray-darken-20;
 		padding-left: 15px;
-		border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+		border-top: 1px solid transparentize( $gray-lighten-20, .5 );
 		line-height: 1.5em;
 		padding-top: 1em;
 		padding-bottom: 1em;
@@ -65,7 +65,7 @@
 	@at-root #{&}-copy {
 		text-align: center;
 		padding: 15px;
-		border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+		border-top: 1px solid transparentize( $gray-lighten-20, .5 );
 
 		@include breakpoint( "<480px" ) {
 			text-align: left;

--- a/client/signup/steps/survey/style.scss
+++ b/client/signup/steps/survey/style.scss
@@ -75,7 +75,7 @@
 	vertical-align: bottom;
 	margin-top: -2px;
 	margin-right: 16px;
-	color: lighten( $gray, 10% );
+	color: $gray-lighten-10;
 
 	.survey-step__vertical:hover & {
 		color: $gray;
@@ -102,18 +102,18 @@
 
 	&:active {
 		border-top-width: 1px;
-		background: lighten( $gray, 30% );
+		background: $gray-lighten-30;
 	}
 }
 
 .survey__vertical-label {
 	margin: 10px;
 	font-weight: 400;
-	color: darken( $gray, 30% )
+	color: $gray-darken-30
 }
 
 .survey__vertical-chevron {
-	color: lighten( $gray, 20% );
+	color: $gray-lighten-20;
 	pointer-events: none;
 }
 
@@ -144,7 +144,7 @@ input.survey__other-write-in {
 
 .survey__other-copy {
 	text-align: center;
-	color: lighten( $gray, 20% );
+	color: $gray-lighten-20;
 	padding-top: 0.5em;
 }
 


### PR DESCRIPTION
Originated from discussion around https://github.com/Automattic/wp-calypso/pull/22081.

In general we should prefer explicitly defined SCSS variables to color calculations.  This ensures more consistency in the code and might even improve CSS build time slightly.

This PR was prepared by first committing the new color values and then running the following commands using [an automated refactoring tool](https://github.com/facebook/codemod):

```sh
codemod --extensions css,scss --exclude-paths build,node_modules,public 'lighten\(\s*\$gray,\s*10%\s*\)' '$gray-lighten-10' --accept-all
codemod --extensions css,scss --exclude-paths build,node_modules,public 'lighten\(\s*\$gray,\s*20%\s*\)' '$gray-lighten-20' --accept-all
codemod --extensions css,scss --exclude-paths build,node_modules,public 'lighten\(\s*\$gray,\s*30%\s*\)' '$gray-lighten-30' --accept-all
codemod --extensions css,scss --exclude-paths build,node_modules,public 'darken\(\s*\$gray,\s*10%\s*\)' '$gray-darken-10' --accept-all
codemod --extensions css,scss --exclude-paths build,node_modules,public 'darken\(\s*\$gray,\s*20%\s*\)' '$gray-darken-20' --accept-all
codemod --extensions css,scss --exclude-paths build,node_modules,public 'darken\(\s*\$gray,\s*30%\s*\)' '$gray-darken-30' --accept-all
git checkout -p assets/stylesheets/shared/_colors.scss # and remove unwanted changes
```

What other changes need to be made to design guidelines at this point?

Potential future changes:

- Clean up & standardize other color calculations.
- Identify places where these colors are being used as text on white background and improve the contrast ratio (only the darkest two shades meet [WCAG AA guidelines](https://webaim.org/resources/contrastchecker/)).

## To test

Verify that the built CSS files are identical before and after this PR.  (Not done yet).