### PR TITLE
Update theme sheet caption styles

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -197,7 +197,7 @@
 			max-width: 100%;
 			display: block;
 			margin: 20px auto;
-			border: 1px solid $gray-light;
+			border: 1px solid lighten( $gray, 30% );
 		}
 
 		&.alignright,
@@ -218,7 +218,7 @@
 	}
 
 	.wp-caption {
-		border: 1px solid $gray-light;
+		border: 1px solid lighten( $gray, 30% );
 		background-color: $gray-light;
 		margin-bottom: 20px;
 	}

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -218,12 +218,15 @@
 	}
 
 	.wp-caption {
+		border: 1px solid lighten( $gray, 30% );
+		background-color: $gray-light;
 		margin-bottom: 20px;
 	}
 
 	.wp-caption-text {
 		color: $gray;
 		font-size: 12px;
+		padding: 3px 8px 6px;
 	}
 
 	h2 {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -218,7 +218,7 @@
 	}
 
 	.wp-caption {
-		border: 1px solid lighten( $gray, 30% );
+		border: 1px solid $gray-light;
 		background-color: $gray-light;
 		margin-bottom: 20px;
 	}

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -224,7 +224,7 @@
 	}
 
 	.wp-caption-text {
-		color: $gray;
+		color: darken( $gray, 20% );
 		font-size: 12px;
 		padding: 3px 8px 6px;
 	}


### PR DESCRIPTION
On theme detail pages, we often include images with white backgrounds. Without boundaries to the images, I find it’s hard to figure out what’s content and what’s an image sometimes.

This PR adds a light gray background  and stroke around the images to combat that. 


**Testing:**

Visit a few theme detail sheets, like 
- http://calypso.localhost:3000/theme/altofocus/
- http://calypso.localhost:3000/theme/small-business/
- http://calypso.localhost:3000/theme/intergalactic-2/


**Before/After GIFs:**

![example-01](https://user-images.githubusercontent.com/1202812/35880714-b0fbe5b8-0b4c-11e8-92dd-665ad58e668c.gif)

![example-02](https://user-images.githubusercontent.com/1202812/35880727-b3395e3c-0b4c-11e8-9de4-3dfd4bc438bc.gif)