### PR TITLE
Stats: refactor Chart to use only one tooltip

### DIFF
--- a/client/components/chart/bar-container.jsx
+++ b/client/components/chart/bar-container.jsx
@@ -25,8 +25,6 @@ export default class extends React.Component {
 	};
 
 	buildBars = max => {
-		const numberBars = this.props.data.length;
-
 		return this.props.data.map( function( item, index ) {
 			return (
 				<Bar
@@ -37,7 +35,7 @@ export default class extends React.Component {
 					clickHandler={ this.props.barClick }
 					data={ item }
 					max={ max }
-					count={ numberBars }
+					count={ this.props.data.length }
 					chartWidth={ this.props.chartWidth }
 					setTooltip={ this.props.setTooltip }
 				/>

--- a/client/components/chart/bar-container.jsx
+++ b/client/components/chart/bar-container.jsx
@@ -12,12 +12,6 @@ import React from 'react';
  */
 import Bar from './bar';
 import XAxis from './x-axis';
-import userModule from 'lib/user';
-
-/**
- * Module variables
- */
-const user = userModule();
 
 export default class extends React.Component {
 	static displayName = 'ModuleChartBarContainer';
@@ -31,34 +25,24 @@ export default class extends React.Component {
 	};
 
 	buildBars = max => {
-		const numberBars = this.props.data.length,
-			width = this.props.chartWidth,
-			barWidth = width / numberBars;
-		let tooltipPosition = user.isRTL() ? 'bottom left' : 'bottom right';
+		const numberBars = this.props.data.length;
 
-		const bars = this.props.data.map( function( item, index ) {
-			const barOffset = barWidth * ( index + 1 );
-
-			if ( barOffset + 230 > width && barOffset + barWidth - 230 > 0 ) {
-				tooltipPosition = user.isRTL() ? 'bottom right' : 'bottom left';
-			}
-
+		return this.props.data.map( function( item, index ) {
 			return (
 				<Bar
 					index={ index }
 					key={ index }
 					isTouch={ this.props.isTouch }
-					tooltipPosition={ tooltipPosition }
 					className={ item.className }
 					clickHandler={ this.props.barClick }
 					data={ item }
 					max={ max }
 					count={ numberBars }
+					chartWidth={ this.props.chartWidth }
+					setTooltip={ this.props.setTooltip }
 				/>
 			);
 		}, this );
-
-		return bars;
 	};
 
 	render() {

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -3,25 +3,18 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import userModule from 'lib/user';
+import { isRtl as isRtlSelector } from 'state/selectors';
 
-/**
- * Module variables
- */
-const user = userModule();
-
-export default class extends React.Component {
-	static displayName = 'ModuleChartBar';
-
+class ModuleChartBar extends Component {
 	static propTypes = {
 		isTouch: PropTypes.bool,
 		tooltipPosition: PropTypes.string,
@@ -100,15 +93,15 @@ export default class extends React.Component {
 	};
 
 	computeTooltipPosition() {
-		const { chartWidth, index, count } = this.props;
+		const { chartWidth, index, count, isRtl } = this.props;
 
 		const barWidth = chartWidth / count;
 		const barOffset = barWidth * ( index + 1 );
 
-		let tooltipPosition = user.isRTL() ? 'bottom left' : 'bottom right';
+		let tooltipPosition = isRtl ? 'bottom left' : 'bottom right';
 
 		if ( barOffset + 230 > chartWidth && barOffset + barWidth - 230 > 0 ) {
-			tooltipPosition = user.isRTL() ? 'bottom right' : 'bottom left';
+			tooltipPosition = isRtl ? 'bottom right' : 'bottom left';
 		}
 
 		return tooltipPosition;
@@ -182,3 +175,7 @@ export default class extends React.Component {
 		);
 	}
 }
+
+export default connect( state => ( {
+	isRtl: isRtlSelector( state ),
+} ) )( ModuleChartBar );

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -12,7 +12,12 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import Tooltip from 'components/tooltip';
+import userModule from 'lib/user';
+
+/**
+ * Module variables
+ */
+const user = userModule();
 
 export default class extends React.Component {
 	static displayName = 'ModuleChartBar';
@@ -69,7 +74,12 @@ export default class extends React.Component {
 		}
 
 		sections.push(
-			<div ref="valueBar" key="value" className="chart__bar-section is-bar" style={ valueStyle }>
+			<div
+				ref={ this.setRef }
+				key="value"
+				className="chart__bar-section is-bar"
+				style={ valueStyle }
+			>
 				{ nestedBar }
 			</div>
 		);
@@ -89,15 +99,22 @@ export default class extends React.Component {
 		}
 	};
 
+	computeTooltipPosition() {
+		const { chartWidth, index, count } = this.props;
+
+		const barWidth = chartWidth / count;
+		const barOffset = barWidth * ( index + 1 );
+
+		let tooltipPosition = user.isRTL() ? 'bottom left' : 'bottom right';
+
+		if ( barOffset + 230 > chartWidth && barOffset + barWidth - 230 > 0 ) {
+			tooltipPosition = user.isRTL() ? 'bottom right' : 'bottom left';
+		}
+
+		return tooltipPosition;
+	}
+
 	mouseEnter = () => {
-		this.setState( { showPopover: true } );
-	};
-
-	mouseLeave = () => {
-		this.setState( { showPopover: false } );
-	};
-
-	renderTooltip = () => {
 		if (
 			! this.props.data.tooltipData ||
 			! this.props.data.tooltipData.length ||
@@ -106,9 +123,17 @@ export default class extends React.Component {
 			return null;
 		}
 
+		this.props.setTooltip( this.bar, this.computeTooltipPosition(), this.getTooltipData() );
+	};
+
+	mouseLeave = () => {
+		this.props.setTooltip( null );
+	};
+
+	getTooltipData() {
 		const { tooltipData } = this.props.data;
 
-		const listItemElements = tooltipData.map( function( options, i ) {
+		return tooltipData.map( function( options, i ) {
 			const wrapperClasses = [ 'module-content-list-item' ];
 			let gridiconSpan;
 
@@ -130,20 +155,9 @@ export default class extends React.Component {
 				</li>
 			);
 		} );
+	}
 
-		return (
-			<Tooltip
-				className="chart__tooltip"
-				id="popover__chart-bar"
-				showDelay={ 200 }
-				context={ this.refs && this.refs.valueBar }
-				isVisible={ this.state.showPopover }
-				position={ this.props.tooltipPosition }
-			>
-				<ul>{ listItemElements }</ul>
-			</Tooltip>
-		);
-	};
+	setRef = ref => ( this.bar = ref );
 
 	render() {
 		const barClass = classNames( 'chart__bar', this.props.className );
@@ -164,7 +178,6 @@ export default class extends React.Component {
 				<div className="chart__bar-marker is-hundred" />
 				<div className="chart__bar-marker is-fifty" />
 				<div className="chart__bar-marker is-zero" />
-				{ this.renderTooltip() }
 			</div>
 		);
 	}

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -14,7 +14,7 @@ import BarContainer from './bar-container';
 import { hasTouch } from 'lib/touch-detect';
 import Tooltip from 'components/tooltip';
 
-class Chart extends React.PureComponent {
+class Chart extends React.Component {
 	state = {
 		data: [],
 		isEmptyChart: false,

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -21,9 +21,7 @@ class Chart extends React.PureComponent {
 		maxBars: 100, // arbitrarily high number. This will be calculated by resize method
 		width: 650,
 		yMax: 0,
-		tooltipContext: null,
-		tooltipPosition: 'bottom left',
-		tooltipData: null,
+		isTooltipVisible: false,
 	};
 
 	static propTypes = {
@@ -104,12 +102,25 @@ class Chart extends React.PureComponent {
 	};
 
 	setTooltip = ( tooltipContext, tooltipPosition, tooltipData ) => {
-		this.setState( { tooltipContext, tooltipPosition, tooltipData } );
+		if ( ! tooltipContext || ! tooltipPosition || ! tooltipData ) {
+			return this.setState( { isTooltipVisible: false } );
+		}
+
+		this.setState( { tooltipContext, tooltipPosition, tooltipData, isTooltipVisible: true } );
 	};
 
 	render() {
 		const { barClick, translate, numberFormat } = this.props;
-		const { data, isEmptyChart, width, yMax } = this.state;
+		const {
+			data,
+			isEmptyChart,
+			width,
+			yMax,
+			isTooltipVisible,
+			tooltipContext,
+			tooltipPosition,
+			tooltipData,
+		} = this.state;
 
 		return (
 			<div ref={ this.storeChart } className="chart">
@@ -132,15 +143,17 @@ class Chart extends React.PureComponent {
 					chartWidth={ width }
 					setTooltip={ this.setTooltip }
 				/>
-				<Tooltip
-					className="chart__tooltip"
-					id="popover__chart-bar"
-					context={ this.state.tooltipContext }
-					isVisible={ !! this.state.tooltipContext }
-					position={ this.state.tooltipPosition }
-				>
-					<ul>{ this.state.tooltipData }</ul>
-				</Tooltip>
+				{ isTooltipVisible && (
+					<Tooltip
+						className="chart__tooltip"
+						id="popover__chart-bar"
+						context={ tooltipContext }
+						isVisible={ isTooltipVisible }
+						position={ tooltipPosition }
+					>
+						<ul>{ tooltipData }</ul>
+					</Tooltip>
+				) }
 				{ isEmptyChart && (
 					<div className="chart__empty">
 						{ /* @todo this message needs to either use a <Notice> or make a custom "chart__notice" class */ }

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -12,6 +12,7 @@ import { noop, throttle } from 'lodash';
  */
 import BarContainer from './bar-container';
 import { hasTouch } from 'lib/touch-detect';
+import Tooltip from 'components/tooltip';
 
 class Chart extends React.PureComponent {
 	state = {
@@ -20,6 +21,9 @@ class Chart extends React.PureComponent {
 		maxBars: 100, // arbitrarily high number. This will be calculated by resize method
 		width: 650,
 		yMax: 0,
+		tooltipContext: null,
+		tooltipPosition: 'bottom left',
+		tooltipData: null,
 	};
 
 	static propTypes = {
@@ -99,6 +103,10 @@ class Chart extends React.PureComponent {
 		} );
 	};
 
+	setTooltip = ( tooltipContext, tooltipPosition, tooltipData ) => {
+		this.setState( { tooltipContext, tooltipPosition, tooltipData } );
+	};
+
 	render() {
 		const { barClick, translate, numberFormat } = this.props;
 		const { data, isEmptyChart, width, yMax } = this.state;
@@ -122,8 +130,17 @@ class Chart extends React.PureComponent {
 					yAxisMax={ yMax }
 					isTouch={ hasTouch() }
 					chartWidth={ width }
-					setTooltip={ this.props.setTooltip }
+					setTooltip={ this.setTooltip }
 				/>
+				<Tooltip
+					className="stats-chart-tabs__tooltip chart__tooltip"
+					id="popover__chart-bar"
+					context={ this.state.tooltipContext }
+					isVisible={ !! this.state.tooltipContext }
+					position={ this.state.tooltipPosition }
+				>
+					<ul>{ this.state.tooltipData }</ul>
+				</Tooltip>
 				{ isEmptyChart && (
 					<div className="chart__empty">
 						{ /* @todo this message needs to either use a <Notice> or make a custom "chart__notice" class */ }

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -133,7 +133,7 @@ class Chart extends React.PureComponent {
 					setTooltip={ this.setTooltip }
 				/>
 				<Tooltip
-					className="stats-chart-tabs__tooltip chart__tooltip"
+					className="chart__tooltip"
 					id="popover__chart-bar"
 					context={ this.state.tooltipContext }
 					isVisible={ !! this.state.tooltipContext }

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -13,7 +13,7 @@ import { noop, throttle } from 'lodash';
 import BarContainer from './bar-container';
 import { hasTouch } from 'lib/touch-detect';
 
-class Chart extends React.Component {
+class Chart extends React.PureComponent {
 	state = {
 		data: [],
 		isEmptyChart: false,
@@ -120,8 +120,9 @@ class Chart extends React.Component {
 					barClick={ barClick }
 					data={ data }
 					yAxisMax={ yMax }
-					chartWidth={ width }
 					isTouch={ hasTouch() }
+					chartWidth={ width }
+					setTooltip={ this.props.setTooltip }
 				/>
 				{ isEmptyChart && (
 					<div className="chart__empty">

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -152,6 +152,16 @@ class Popover extends Component {
 			// see https://github.com/Automattic/wp-calypso/commit/38e779cfebf6dd42bb30d8be7127951b0c531ae2
 			this.debug( 'requesting to update position after render completes' );
 			requestAnimationFrame( () => {
+				// Prevent updating Popover position if it's already unmounted.
+				if (
+					! __popovers.has( this.id ) ||
+					! this.domContainer ||
+					! this.domContext ||
+					! isVisible
+				) {
+					return;
+				}
+
 				this.setPosition();
 				this.isUpdatingPosition = false;
 			} );

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -28,6 +28,7 @@ import {
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { rangeOfPeriod } from 'state/stats/lists/utils';
 import { getSiteOption } from 'state/sites/selectors';
+import Tooltip from 'components/tooltip';
 
 class StatModuleChartTabs extends Component {
 	constructor( props ) {
@@ -37,6 +38,9 @@ class StatModuleChartTabs extends Component {
 		this.state = {
 			activeLegendCharts: activeCharts,
 			activeTab: activeTab,
+			tooltipContext: null,
+			tooltipPosition: 'bottom left',
+			tooltipData: null,
 		};
 	}
 
@@ -219,6 +223,10 @@ class StatModuleChartTabs extends Component {
 		} );
 	}
 
+	setTooltip = ( tooltipContext, tooltipPosition, tooltipData ) => {
+		this.setState( { tooltipContext, tooltipPosition, tooltipData } );
+	};
+
 	render() {
 		const { fullQuery, quickQuery, quickQueryRequesting, fullQueryRequesting, siteId } = this.props;
 		const chartData = this.buildChartData();
@@ -259,6 +267,7 @@ class StatModuleChartTabs extends Component {
 						loading={ activeTabLoading }
 						data={ chartData }
 						barClick={ this.props.barClick }
+						setTooltip={ this.setTooltip }
 					/>
 					<StatTabs
 						data={ data }
@@ -268,6 +277,15 @@ class StatModuleChartTabs extends Component {
 						activeIndex={ this.props.queryDate }
 						activeKey="period"
 					/>
+					<Tooltip
+						className="stats-chart-tabs__tooltip chart__tooltip"
+						id="popover__chart-bar"
+						context={ this.state.tooltipContext }
+						isVisible={ !! this.state.tooltipContext }
+						position={ this.state.tooltipPosition }
+					>
+						<ul>{ this.state.tooltipData }</ul>
+					</Tooltip>
 				</Card>
 			</div>
 		);

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -28,7 +28,6 @@ import {
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { rangeOfPeriod } from 'state/stats/lists/utils';
 import { getSiteOption } from 'state/sites/selectors';
-import Tooltip from 'components/tooltip';
 
 class StatModuleChartTabs extends Component {
 	constructor( props ) {
@@ -38,9 +37,6 @@ class StatModuleChartTabs extends Component {
 		this.state = {
 			activeLegendCharts: activeCharts,
 			activeTab: activeTab,
-			tooltipContext: null,
-			tooltipPosition: 'bottom left',
-			tooltipData: null,
 		};
 	}
 
@@ -223,10 +219,6 @@ class StatModuleChartTabs extends Component {
 		} );
 	}
 
-	setTooltip = ( tooltipContext, tooltipPosition, tooltipData ) => {
-		this.setState( { tooltipContext, tooltipPosition, tooltipData } );
-	};
-
 	render() {
 		const { fullQuery, quickQuery, quickQueryRequesting, fullQueryRequesting, siteId } = this.props;
 		const chartData = this.buildChartData();
@@ -267,7 +259,6 @@ class StatModuleChartTabs extends Component {
 						loading={ activeTabLoading }
 						data={ chartData }
 						barClick={ this.props.barClick }
-						setTooltip={ this.setTooltip }
 					/>
 					<StatTabs
 						data={ data }
@@ -277,15 +268,6 @@ class StatModuleChartTabs extends Component {
 						activeIndex={ this.props.queryDate }
 						activeKey="period"
 					/>
-					<Tooltip
-						className="stats-chart-tabs__tooltip chart__tooltip"
-						id="popover__chart-bar"
-						context={ this.state.tooltipContext }
-						isVisible={ !! this.state.tooltipContext }
-						position={ this.state.tooltipPosition }
-					>
-						<ul>{ this.state.tooltipData }</ul>
-					</Tooltip>
 				</Card>
 			</div>
 		);


### PR DESCRIPTION
In this PR, we are trying to refactor the Stats page and `Chart` component to use only single `Tooltip` component instead of creating tooltip for every bar in the chart.

## Testing

Test both site stats and store stats. Select a site with some visitors so the chart is filled with data. Move around the bars in the chart and see if the tooltip behaves in the same way or better as on prod. To test the Store stats, select `mercantile.wordpress.org` as the site and navigate to `/store/stats/orders/day/mercantile.wordpress.org`.