### PR TITLE
Site Settings: Jetpack: Remove unused props

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -141,9 +141,6 @@ class SiteSettingsFormWriting extends Component {
 						<div>
 							{ this.renderSectionHeader( translate( 'Speed up your site' ), false ) }
 							<SpeedUpYourSite
-								siteId={ siteId }
-								handleAutosavingToggle={ handleAutosavingToggle }
-								onChangeField={ onChangeField }
 								isSavingSettings={ isSavingSettings }
 								isRequestingSettings={ isRequestingSettings }
 								fields={ fields }

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -27,11 +27,8 @@ import InfoPopover from 'components/info-popover';
 class SpeedUpSiteSettings extends Component {
 	static propTypes = {
 		fields: PropTypes.object,
-		handleAutosavingToggle: PropTypes.func.isRequired,
 		isRequestingSettings: PropTypes.bool,
 		isSavingSettings: PropTypes.bool,
-		onChangeField: PropTypes.func.isRequired,
-		siteId: PropTypes.number.isRequired,
 		jetpackVersionSupportsLazyImages: PropTypes.bool,
 
 		// Connected props
@@ -42,7 +39,7 @@ class SpeedUpSiteSettings extends Component {
 
 	render() {
 		const {
-			siteId,
+			selectedSiteId,
 			photonModuleUnavailable,
 			isRequestingSettings,
 			isSavingSettings,
@@ -63,7 +60,7 @@ class SpeedUpSiteSettings extends Component {
 							</InfoPopover>
 						</div>
 						<JetpackModuleToggle
-							siteId={ siteId }
+							siteId={ selectedSiteId }
 							moduleSlug="photon"
 							label={ translate( 'Serve images from our servers' ) }
 							description={ translate(
@@ -85,7 +82,7 @@ class SpeedUpSiteSettings extends Component {
 								</InfoPopover>
 							</div>
 							<JetpackModuleToggle
-								siteId={ siteId }
+								siteId={ selectedSiteId }
 								moduleSlug="lazy-images"
 								label={ translate( '"Lazy-load" images' ) }
 								description={ translate(


### PR DESCRIPTION
This PR addresses some feedback from @tyxla in #22053, specifically it removes some unused props.

To test: 

- Check out branch
- Select a Jetpack site with Jetpack 5.8
- Go to `/settings/writing/$site_slug` and ensure that you see the new "Speed up your site" section
- Check that toggling the photon and lazy images settings works
- Switch to a Jetpack site with version 5.7 and ensure that you do not see the "Speed up your site" section and that the photon setting is in the Media section
- Check that toggling the photon setting works