### PR TITLE
Jetpack connect: Update signup header text

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -106,7 +106,7 @@ export class AuthFormHeader extends Component {
 
 		switch ( this.getState() ) {
 			case 'logged-out':
-				return translate( 'Create your account' );
+				return translate( 'Create an account to set up Jetpack' );
 			case 'logged-in-success':
 				return translate( 'You are connected!' );
 			case 'logged-in':

--- a/client/jetpack-connect/test/__snapshots__/auth-form-header.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/auth-form-header.js.snap
@@ -3,7 +3,7 @@
 exports[`AuthFormHeader renders as expected 1`] = `
 <div>
   <FormattedHeader
-    headerText="Create your account"
+    headerText="Create an account to set up Jetpack"
     subHeaderText="You are moments away from connecting your site."
   />
   <CompactCard


### PR DESCRIPTION
Updates Jetpack Connect signup header from "Create your account" to "Create an account to set up Jetpack"

See p1HpG7-4Mw-p2

Can we go ahead and ship this independent of other rebranding?

## Screens

### Before

<img width="579" alt="before" src="https://user-images.githubusercontent.com/841763/35885818-65882428-0b8f-11e8-9c35-d192ac1455ed.png">

### After

<img width="601" alt="after" src="https://user-images.githubusercontent.com/841763/35885823-6967bc5c-0b8f-11e8-8bb3-3691781034ac.png">

## Testing
1. Ensure you're not logged in to WordPress.com
1. Make sure your wp-admin user's email does not match an existing WordPress.com account email
1. Start a connection flow for a new site from WP Admin
1. Copy the `/jetpack/connect/authorize...` bit from the url
1. Paste that after the `calypso.live` or `calypso.localhost:3000` url
1. Verify the text is updated correctly.