### PR TITLE
Remove isElement function from components/popover/util.js

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -22,7 +22,6 @@ import {
 	unbindWindowListeners,
 	suggested as suggestPosition,
 	constrainLeft,
-	isElement as isDOMElement,
 	offset,
 } from './util';
 import { isRtl as isRtlSelector } from 'state/selectors';
@@ -109,11 +108,7 @@ class Popover extends Component {
 
 	componentWillReceiveProps( nextProps ) {
 		// update context (target) reference into a property
-		if ( ! isDOMElement( nextProps.context ) ) {
-			this.domContext = ReactDom.findDOMNode( nextProps.context );
-		} else {
-			this.domContext = nextProps.context;
-		}
+		this.domContext = ReactDom.findDOMNode( nextProps.context );
 
 		if ( ! nextProps.isVisible ) {
 			return null;
@@ -273,11 +268,7 @@ class Popover extends Component {
 		this.domContainer = domContainer;
 
 		// store context (target) reference into a property
-		if ( ! isDOMElement( this.props.context ) ) {
-			this.domContext = ReactDom.findDOMNode( this.props.context );
-		} else {
-			this.domContext = this.props.context;
-		}
+		this.domContext = ReactDom.findDOMNode( this.props.context );
 
 		this.setPosition();
 	}

--- a/client/components/popover/util.js
+++ b/client/components/popover/util.js
@@ -342,18 +342,4 @@ const constrainLeft = function( off, el ) {
 	return off;
 };
 
-const isElement = obj => {
-	try {
-		//Using W3 DOM2 (works for FF, Opera and Chrom)
-		return obj instanceof HTMLElement;
-	} catch ( error ) {
-		return (
-			typeof obj === 'object' &&
-			obj.nodeType === 1 &&
-			typeof obj.style === 'object' &&
-			typeof obj.ownerDocument === 'object'
-		);
-	}
-};
-
-export { constrainLeft, bindWindowListeners, unbindWindowListeners, suggested, offset, isElement };
+export { constrainLeft, bindWindowListeners, unbindWindowListeners, suggested, offset };


### PR DESCRIPTION
Because `ReactDom.findDOMNode` [can detect](https://github.com/facebook/react/blob/master/packages/react-dom/src/client/ReactDOM.js#L1147-L1149) that it has been passed a DOM node and returns the argument unchanged in that case, the `isElement` function is not needed.

**How to test:**
Check that all popovers still work and are correctly positioned.