### PR TITLE
Site Settings: Enable language setting for Jetpack >= 5.9-alpha

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -573,7 +573,8 @@ const connectComponent = connect(
 		return {
 			siteIsJetpack,
 			siteSlug: getSelectedSiteSlug( state ),
-			supportsLanguageSelection: ! siteIsJetpack,
+			supportsLanguageSelection:
+				! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '5.8.1' ),
 			supportsHolidaySnowOption: ! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '4.0' ),
 		};
 	},

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -574,7 +574,7 @@ const connectComponent = connect(
 			siteIsJetpack,
 			siteSlug: getSelectedSiteSlug( state ),
 			supportsLanguageSelection:
-				! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '5.8.1' ),
+				! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '5.9-alpha' ),
 			supportsHolidaySnowOption: ! siteIsJetpack || isJetpackMinimumVersion( state, siteId, '4.0' ),
 		};
 	},


### PR DESCRIPTION
The language setting was disabled in #22174 to prevent errant behavior in the settings page while we determined the cause of https://github.com/Automattic/jetpack/pull/8775.

The change has been made in Jetpack and should land in 5.9.

This can wait to merge until it does so we can test against a live site first.

## To Test:

* Follow instructions in https://github.com/Automattic/jetpack/pull/8775 (while running this branch instead of 1a0bad3550)
* Also test with non-Jetpack sites. The setting should still work there as well.