### PR TITLE
Store: autoselect shipping label purchase rate if only one is available

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -619,11 +619,11 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_RATES ] = ( state, { rates } )
 		form: { ...state.form,
 			rates: {
 				values: mapValues( rates, ( rate ) => {
-					const rates = get( rate, 'rates', [] );
+					const packageRates = get( rate, 'rates', [] );
 					const selected =
-						rates.length === 1
-							? rates[ 0 ]
-							: find( rates, ( r ) => r.is_selected );
+						packageRates.length === 1
+							? packageRates[ 0 ]
+							: find( packageRates, ( r ) => r.is_selected );
 
 					if ( selected ) {
 						return selected.service_id;

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -619,10 +619,11 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_RATES ] = ( state, { rates } )
 		form: { ...state.form,
 			rates: {
 				values: mapValues( rates, ( rate ) => {
-					const selected = find(
-						get( rate, 'rates', [] ),
-						( r ) => r.is_selected
-					);
+					const rates = get( rate, 'rates', [] );
+					const selected =
+						rates.length === 1
+							? rates[ 0 ]
+							: find( rates, ( r ) => r.is_selected );
 
 					if ( selected ) {
 						return selected.service_id;


### PR DESCRIPTION
On the label purchase screen, automatically select a package's rate when only one is available, to avoid the extra interaction of selecting it.

![label-purchase-single-rate](https://user-images.githubusercontent.com/1867547/35888921-7eb02cc0-0b67-11e8-9ea1-e9e9b08384de.gif)
