### PR TITLE
Don't use back end error messages.

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -221,7 +221,7 @@ class TransferDomainStep extends React.Component {
 				fetchDomains( domain );
 				page( domainManagementTransferIn( selectedSite.slug, domain ) );
 			} else {
-				this.props.errorNotice( error || translate( 'We were unable to start the transfer.' ) );
+				this.props.errorNotice( translate( 'We were unable to start the transfer.' ) );
 			}
 		} );
 	};


### PR DESCRIPTION
We shouldn't show the back-end error code, but instead use a translated string for errors when a transfer fails to start.

Start a delayed_start transfer.
Hack the back-end to return an error in the `inbound-transfer-start` endpoint.
Make sure that the generic error text is returned when the transfer is started.