### PR TITLE
2FA: TwoStepAuthorization.fetch no longer sends a code via SMS.

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -50,10 +50,6 @@ TwoStepAuthorization.prototype.fetch = function( callback ) {
 			if ( ! error ) {
 				this.data = data;
 
-				// if ( this.isReauthRequired() && this.isTwoStepSMSEnabled() && ! this.initialized ) {
-				// 	this.sendSMSCode();
-				// }
-
 				if ( this.isReauthRequired() && ! this.initialized ) {
 					this.bumpMCStat( 'reauth-required' );
 				}

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -50,9 +50,9 @@ TwoStepAuthorization.prototype.fetch = function( callback ) {
 			if ( ! error ) {
 				this.data = data;
 
-				if ( this.isReauthRequired() && this.isTwoStepSMSEnabled() && ! this.initialized ) {
-					this.sendSMSCode();
-				}
+				// if ( this.isReauthRequired() && this.isTwoStepSMSEnabled() && ! this.initialized ) {
+				// 	this.sendSMSCode();
+				// }
 
 				if ( this.isReauthRequired() && ! this.initialized ) {
 					this.bumpMCStat( 'reauth-required' );

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -110,23 +110,7 @@ const ReauthRequired = createReactClass( {
 	},
 
 	renderSendSMSButton: function() {
-		var button;
-		// if ( this.props.twoStepAuthorization.isTwoStepSMSEnabled() ) {
-		// 	button = (
-		// 		<FormButton
-		// 			disabled={ ! this.state.smsRequestsAllowed }
-		// 			isPrimary={ false }
-		// 			onClick={ this.recordClickEvent(
-		// 				'Resend SMS Code Button on Reauth Required',
-		// 				this.sendSMSCode
-		// 			) }
-		// 			type="button"
-		// 		>
-		// 			{ this.props.translate( 'Resend SMS Code' ) }
-		// 		</FormButton>
-		// 	);
-		// } else {
-		button = (
+		return (
 			<FormButton
 				disabled={ ! this.state.smsRequestsAllowed }
 				isPrimary={ false }
@@ -139,9 +123,6 @@ const ReauthRequired = createReactClass( {
 				{ this.props.translate( 'Send SMS Code' ) }
 			</FormButton>
 		);
-		// }
-
-		return button;
 	},
 
 	renderFailedValidationMsg: function() {

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -111,35 +111,35 @@ const ReauthRequired = createReactClass( {
 
 	renderSendSMSButton: function() {
 		var button;
-		if ( this.props.twoStepAuthorization.isTwoStepSMSEnabled() ) {
-			button = (
-				<FormButton
-					disabled={ ! this.state.smsRequestsAllowed }
-					isPrimary={ false }
-					onClick={ this.recordClickEvent(
-						'Resend SMS Code Button on Reauth Required',
-						this.sendSMSCode
-					) }
-					type="button"
-				>
-					{ this.props.translate( 'Resend SMS Code' ) }
-				</FormButton>
-			);
-		} else {
-			button = (
-				<FormButton
-					disabled={ ! this.state.smsRequestsAllowed }
-					isPrimary={ false }
-					onClick={ this.recordClickEvent(
-						'Send SMS Code Button on Reauth Required',
-						this.sendSMSCode
-					) }
-					type="button"
-				>
-					{ this.props.translate( 'Send SMS Code' ) }
-				</FormButton>
-			);
-		}
+		// if ( this.props.twoStepAuthorization.isTwoStepSMSEnabled() ) {
+		// 	button = (
+		// 		<FormButton
+		// 			disabled={ ! this.state.smsRequestsAllowed }
+		// 			isPrimary={ false }
+		// 			onClick={ this.recordClickEvent(
+		// 				'Resend SMS Code Button on Reauth Required',
+		// 				this.sendSMSCode
+		// 			) }
+		// 			type="button"
+		// 		>
+		// 			{ this.props.translate( 'Resend SMS Code' ) }
+		// 		</FormButton>
+		// 	);
+		// } else {
+		button = (
+			<FormButton
+				disabled={ ! this.state.smsRequestsAllowed }
+				isPrimary={ false }
+				onClick={ this.recordClickEvent(
+					'Send SMS Code Button on Reauth Required',
+					this.sendSMSCode
+				) }
+				type="button"
+			>
+				{ this.props.translate( 'Send SMS Code' ) }
+			</FormButton>
+		);
+		// }
 
 		return button;
 	},

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -38,6 +38,7 @@ const ReauthRequired = createReactClass( {
 			remember2fa: false, // Should the 2fa be remembered for 30 days?
 			code: '', // User's generated 2fa code
 			smsRequestsAllowed: true, // Can the user request another SMS code?
+			smsCodeSent: false,
 		};
 	},
 
@@ -46,8 +47,9 @@ const ReauthRequired = createReactClass( {
 
 		if ( this.props.twoStepAuthorization.isTwoStepSMSEnabled() ) {
 			codeMessage = this.props.translate(
-				'Please check your text messages at the phone number ending with {{strong}}%(smsLastFour)s{{/strong}} ' +
-					'and enter the verification code below.',
+				'Press the button below to request an SMS verification code. ' +
+					'Once you receive our text message at your phone number ending with ' +
+					'{{strong}}%(smsLastFour)s{{/strong}} , enter the code below.',
 				{
 					args: {
 						smsLastFour: this.props.twoStepAuthorization.getSMSLastFour(),
@@ -93,7 +95,7 @@ const ReauthRequired = createReactClass( {
 	},
 
 	sendSMSCode: function() {
-		this.setState( { smsRequestsAllowed: false } );
+		this.setState( { smsRequestsAllowed: false, smsCodeSent: true } );
 		this.codeRequestTimer = setTimeout( this.allowSMSRequests, 60000 );
 
 		this.props.twoStepAuthorization.sendSMSCode( function( error, data ) {
@@ -110,17 +112,20 @@ const ReauthRequired = createReactClass( {
 	},
 
 	renderSendSMSButton: function() {
+		const { smsRequestsAllowed, smsCodeSent } = this.state;
+
+		const [ clickAction, buttonLabel ] = ! smsCodeSent
+			? [ 'Send SMS Code Button on Reauth Required', this.props.translate( 'Send SMS Code' ) ]
+			: [ 'Resend SMS Code Button on Reauth Required', this.props.translate( 'Resend SMS Code' ) ];
+
 		return (
 			<FormButton
-				disabled={ ! this.state.smsRequestsAllowed }
+				disabled={ ! smsRequestsAllowed }
 				isPrimary={ false }
-				onClick={ this.recordClickEvent(
-					'Send SMS Code Button on Reauth Required',
-					this.sendSMSCode
-				) }
+				onClick={ this.recordClickEvent( clickAction, this.sendSMSCode ) }
 				type="button"
 			>
-				{ this.props.translate( 'Send SMS Code' ) }
+				{ buttonLabel }
 			</FormButton>
 		);
 	},


### PR DESCRIPTION
Part of #22100 

How to test:

- Start a session with a WordPress.com user with SMS only Two-Factor Authentication enabled.
- Delete the 2FA cookie.
- Navigate to the `/me` section.

The 2FA dialog should show with a _Send SMS Code_ button, and no SMS should be sent unless that button is clicked.

| | SMS Only | App + SMS |
| - | - | - |
| Initial State | ![screen shot 2018-02-16 at 17 26 03](https://user-images.githubusercontent.com/233601/36327933-f6c986e6-133e-11e8-91c5-85eb3cead732.png) | ![screen shot 2018-02-16 at 17 08 45](https://user-images.githubusercontent.com/233601/36327932-f6a971b2-133e-11e8-82a3-62525feba79c.png) |
| | ![screen shot 2018-02-16 at 17 08 10](https://user-images.githubusercontent.com/233601/36327931-f686fb5a-133e-11e8-80fd-2982aaab3c51.png) | ![screen shot 2018-02-16 at 17 27 27](https://user-images.githubusercontent.com/233601/36327934-f6ea740a-133e-11e8-876f-e112e6ab70f8.png) |
| Resend Code | ![screen shot 2018-02-16 at 17 28 28](https://user-images.githubusercontent.com/233601/36327935-f7094e0c-133e-11e8-8699-5f14e68b5e8d.png) | ![screen shot 2018-02-16 at 17 07 13](https://user-images.githubusercontent.com/233601/36327929-f6630c04-133e-11e8-9188-db666eafb274.png) |
