### PR TITLE
remove unlimitedThemeNudge a/b test and show nudge for all users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -55,15 +55,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-	unlimitedThemeNudge: {
-		datestamp: '20171016',
-		variations: {
-			hide: 50,
-			show: 50,
-		},
-		defaultVariation: 'hide',
-		allowExistingUsers: true,
-	},
 	checklistThankYouForFreeUser: {
 		datestamp: '20171204',
 		variations: {

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -11,7 +11,6 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import CurrentTheme from 'my-sites/themes/current-theme';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
@@ -27,7 +26,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 const ConnectedSingleSiteWpcom = connectOptions( props => {
 	const { siteId, siteSlug, currentPlanSlug, translate } = props;
 
-	const upsellUrl = abtest( 'unlimitedThemeNudge' ) === 'show' && `/plans/${ siteSlug }`;
+	const upsellUrl = `/plans/${ siteSlug }`;
 	return (
 		<div>
 			<SidebarNavigation />


### PR DESCRIPTION
The unlimitedThemeNudge on the themes page is considered an improvement on not mentioning that all premium themes are available on a premium plan or above.

This change just removes the a/b test around whether to show this nudge.  Future iterations will make this nudge more obvious.