### PR TITLE
Rewind: Allow string representation of `last_updated` value

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -43,7 +43,11 @@ export const transformApi = data =>
 	Object.assign(
 		{
 			state: camelCase( data.state ),
-			lastUpdated: new Date( data.last_updated * 1000 ),
+			lastUpdated: new Date(
+				'string' === typeof data.last_updated
+					? Date.parse( data.last_updated )
+					: data.last_updated * 1000
+			),
 		},
 		data.can_autoconfigure && { canAutoconfigure: !! data.can_autoconfigure },
 		data.credentials && { credentials: data.credentials.map( transformCredential ) },

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -48,7 +48,7 @@ export const unavailable = {
 		reason: {
 			type: 'string',
 		},
-		last_updated: { type: [ 'integer', 'string' ] },
+		last_updated: { oneOf: [ { type: 'integer' }, { type: 'string', format: 'date-time' } ] },
 	},
 	required: [ 'state', 'last_updated' ],
 };
@@ -64,7 +64,7 @@ export const inactive = {
 			type: 'array',
 			items: credential,
 		},
-		last_updated: { type: [ 'integer', 'string' ] },
+		last_updated: { oneOf: [ { type: 'integer' }, { type: 'string', format: 'date-time' } ] },
 	},
 	required: [ 'state', 'last_updated' ],
 };
@@ -76,7 +76,7 @@ export const awaitingCredentials = {
 			type: 'string',
 			pattern: '^awaiting_credentials$',
 		},
-		last_updated: { type: [ 'integer', 'string' ] },
+		last_updated: { oneOf: [ { type: 'integer' }, { type: 'string', format: 'date-time' } ] },
 	},
 	required: [ 'state', 'last_updated' ],
 };
@@ -92,7 +92,7 @@ export const provisioning = {
 			type: 'array',
 			items: credential,
 		},
-		last_updated: { type: [ 'integer', 'string' ] },
+		last_updated: { oneOf: [ { type: 'integer' }, { type: 'string', format: 'date-time' } ] },
 	},
 	required: [ 'state', 'last_updated' ],
 };
@@ -113,7 +113,7 @@ export const active = {
 			items: download,
 		},
 		rewind,
-		last_updated: { type: [ 'integer', 'string' ] },
+		last_updated: { oneOf: [ { type: 'integer' }, { type: 'string', format: 'date-time' } ] },
 	},
 	required: [ 'state', 'last_updated' ],
 };

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -48,7 +48,7 @@ export const unavailable = {
 		reason: {
 			type: 'string',
 		},
-		last_updated: { type: 'integer' },
+		last_updated: { type: [ 'integer', 'string' ] },
 	},
 	required: [ 'state', 'last_updated' ],
 };
@@ -64,7 +64,7 @@ export const inactive = {
 			type: 'array',
 			items: credential,
 		},
-		last_updated: { type: 'integer' },
+		last_updated: { type: [ 'integer', 'string' ] },
 	},
 	required: [ 'state', 'last_updated' ],
 };
@@ -76,7 +76,7 @@ export const awaitingCredentials = {
 			type: 'string',
 			pattern: '^awaiting_credentials$',
 		},
-		last_updated: { type: 'integer' },
+		last_updated: { type: [ 'integer', 'string' ] },
 	},
 	required: [ 'state', 'last_updated' ],
 };
@@ -92,7 +92,7 @@ export const provisioning = {
 			type: 'array',
 			items: credential,
 		},
-		last_updated: { type: 'integer' },
+		last_updated: { type: [ 'integer', 'string' ] },
 	},
 	required: [ 'state', 'last_updated' ],
 };
@@ -113,7 +113,7 @@ export const active = {
 			items: download,
 		},
 		rewind,
-		last_updated: { type: 'integer' },
+		last_updated: { type: [ 'integer', 'string' ] },
 	},
 	required: [ 'state', 'last_updated' ],
 };


### PR DESCRIPTION
Previously we have been sending an integer value in the `/rewind` API to
indicate the time that the status information was prepared.

In conversation we have decided that it would be more consistent and
probably less surprising if we serialized that date value as an ISO
string in the API response.

This patch updates Calypso to handle both possibilities so that we can
make a change on the backend without triggering errors in the client.

**Testing**

Inject a fake API response into the system with the string format of the date.
In this branch it should continue to work as expect.
In **master** it should fail to update due to a schema validation failure.
Test again with a string that fails to validate as a `Date` in JavaScript;
this invalid string value should also fail to update in this branch for `fromApi` failure.

```js
// should work
dispatch( {
	type: 'REWIND_STATE_REQUEST',
	siteId: YOUR_SITE_ID_HERE,
	meta: {
		dataLayer: {
			trackRequest: true,
			data: {
				state: 'active',
				downloads: [],
				last_updated: '2018-01-06T14:58:13.000Z',
			}
		},
	},
} )

// should work
dispatch( {
	type: 'REWIND_STATE_REQUEST',
	siteId: YOUR_SITE_ID_HERE,
	meta: {
		dataLayer: {
			trackRequest: true,
			data: {
				state: 'active',
				downloads: [],
				last_updated: 1357222358,
			}
		},
	},
} )

// should fail - state will be `unknown`
dispatch( {
	type: 'REWIND_STATE_REQUEST',
	siteId: YOUR_SITE_ID_HERE,
	meta: {
		dataLayer: {
			trackRequest: true,
			data: {
				state: 'active',
				downloads: [],
				last_updated: 'Calypso',
			}
		},
	},
} )
```