### PR TITLE
makeParser: Provide better feedback in console on parse failure

### DIFF
--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -122,6 +122,24 @@ export const makeParser = ( schema, schemaOptions = {}, transformer = identity )
 			try {
 				return transformer( data );
 			} catch ( e ) {
+				if ( 'development' === process.env.NODE_ENV ) {
+					// eslint-disable-next-line no-console
+					console.warn( 'Data Transformation Failure' );
+
+					// eslint-disable-next-line no-console
+					console.warn( {
+						inputData: data,
+						error: e,
+					} );
+
+					if ( undefined !== window ) {
+						// eslint-disable-next-line no-console
+						console.log( 'updated `lastTransformer` and `lastTransformed` in console' );
+						window.lastTransformer = transformer;
+						window.lastTransformed = data;
+					}
+				}
+
 				throw new TransformerError( e, data, transformer );
 			}
 		};

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -107,6 +107,8 @@ export const makeParser = ( schema, schemaOptions = {}, transformer = identity )
 					if ( undefined !== window ) {
 						// eslint-disable-next-line no-console
 						console.log( 'updated `lastValidator` and `lastValidated` in console' );
+						// eslint-disable-next-line no-console
+						console.log( 'run `lastValidator( lastValidated )` to reproduce failing validation' );
 						window.lastValidator = validator;
 						window.lastValidated = data;
 					}
@@ -135,6 +137,10 @@ export const makeParser = ( schema, schemaOptions = {}, transformer = identity )
 					if ( undefined !== window ) {
 						// eslint-disable-next-line no-console
 						console.log( 'updated `lastTransformer` and `lastTransformed` in console' );
+						// eslint-disable-next-line no-console
+						console.log(
+							'run `lastTransformer( lastTransformed )` to reproduce failing transform'
+						);
 						window.lastTransformer = transformer;
 						window.lastTransformed = data;
 					}


### PR DESCRIPTION
Previously it has been difficult to debug issues when developing and
API response come back and fail to validate with `makeParser()` and
a given JSON schema. The failures were trapped and not reported on
the console where they would be clearly visible.

In this patch we're adding new logging when in a development build
to try and surface these validation errors in a meaningful and
helpful way.

**Testing**

Inject an invalid API response. Compare the messaging in **master** vs.
in this branch. On `dserve` the messaging should mirror what's in **master**
because we should only be providing the enhanced message in development.

```js
// should fail - state will be `unknown`
dispatch( {
	type: 'REWIND_STATE_REQUEST',
	siteId: YOUR_SITE_ID_HERE,
	meta: {
		dataLayer: {
			trackRequest: true,
			data: {
				state: 'active',
				downloads: [],
				last_updated: 'Calypso',
			}
		},
	},
} )
```