### PR TITLE
Analytics: Add required calypso_ prefix to rewind_state_parse_error tracks

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -53,7 +53,7 @@ const updateRewindState = ( { siteId }, data ) => {
 
 const setUnknownState = ( { siteId }, error ) =>
 	withAnalytics(
-		recordTracksEvent( 'rewind_state_parse_error', {
+		recordTracksEvent( 'calypso_rewind_state_parse_error', {
 			error: JSON.stringify( error, null, 2 ),
 		} ),
 		{


### PR DESCRIPTION
This PR adds the required `calypso_` prefix to the tracks event name. The name will be rejected by the Calypso tracks lib if it's not present. For what it's worth, the event would be discarded by tracks even if it were sent from Calypso.

See PCYsg-4S2-p2

Spotted while reviewing #22198

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/35906539-32857a56-0beb-11e8-89c8-13205fb0d52c.png)

### After

![after](https://user-images.githubusercontent.com/841763/35906517-1e00533a-0beb-11e8-8262-c3795b890dfc.png)

## Testing
1. Run in the console:
   ```js
   localStorage.debug = 'calypso:analytics:tracks'
   ```
1. Reload
1. Run in the console:
   ```js
   dispatch( {
     type: 'REWIND_STATE_REQUEST',
     siteId: YOUR_SITE_ID_HERE,
     meta: {
     dataLayer: {
       trackRequest: true,
       data: {
         state: 'active',
         downloads: [],
         last_updated: 'Calypso',
         },
       },
     },
   } )
   ```
1. Verify that the console reports the event being sent rather than the error message (see before capture).