### PR TITLE
Signup: add promote local business option to signup site goals

### DIFF
--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -389,6 +389,21 @@ class AboutStep extends Component {
 					</span>
 				</FormLabel>
 
+				<FormLabel htmlFor="promote" className="about__checkbox-option">
+					<FormInputCheckbox
+						name="siteGoals"
+						id="promote"
+						onChange={ this.checkBoxHandleChange }
+						defaultChecked={ this.isCheckBoxChecked( 'promote_local_business' ) }
+						value="promote_local_business"
+						className="about__checkbox"
+						onKeyDown={ this.handleCheckboxKeyDown }
+					/>
+					<span className="about__checkbox-label">
+						{ translate( 'Promote your local business' ) }
+					</span>
+				</FormLabel>
+
 				<FormLabel htmlFor="educate" className="about__checkbox-option">
 					<FormInputCheckbox
 						name="siteGoals"

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -389,10 +389,10 @@ class AboutStep extends Component {
 					</span>
 				</FormLabel>
 
-				<FormLabel htmlFor="promote" className="about__checkbox-option">
+				<FormLabel htmlFor="promoteLocalBusiness" className="about__checkbox-option">
 					<FormInputCheckbox
 						name="siteGoals"
-						id="promote"
+						id="promoteLocalBusiness"
 						onChange={ this.checkBoxHandleChange }
 						defaultChecked={ this.isCheckBoxChecked( 'promote_local_business' ) }
 						value="promote_local_business"

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -394,8 +394,8 @@ class AboutStep extends Component {
 						name="siteGoals"
 						id="promoteLocalBusiness"
 						onChange={ this.checkBoxHandleChange }
-						defaultChecked={ this.isCheckBoxChecked( 'promote_local_business' ) }
-						value="promote_local_business"
+						defaultChecked={ this.isCheckBoxChecked( 'promote-local-business' ) }
+						value="promote-local-business"
 						className="about__checkbox"
 						onKeyDown={ this.handleCheckboxKeyDown }
 					/>

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -400,7 +400,7 @@ class AboutStep extends Component {
 						onKeyDown={ this.handleCheckboxKeyDown }
 					/>
 					<span className="about__checkbox-label">
-						{ translate( 'Promote your local business' ) }
+						{ translate( 'Advertise your local business' ) }
 					</span>
 				</FormLabel>
 

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -151,6 +151,10 @@ export function getThemeForSiteGoals( siteGoals ) {
 		return 'pub/dara';
 	}
 
+	if ( siteGoalsValue.indexof( 'promote-local-business' ) ) {
+		return 'pub/radcliffe-2';
+	}
+
 	if ( siteGoalsValue.indexOf( 'promote' ) !== -1 ) {
 		return 'pub/dara';
 	}
@@ -178,7 +182,7 @@ export function getSiteTypeForSiteGoals( siteGoals, flow ) {
 		return 'page';
 	}
 
-	if ( siteGoalsValue.indexOf( 'promote' ) !== -1 ) {
+	if ( siteGoalsValue.indexOf( 'promote-local-business' ) !== -1 || siteGoalsValue.indexOf( 'promote' ) !== -1 ) {
 		return 'page';
 	}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/326402/35910046-0507862e-0bfe-11e8-8a5e-3ac4d786d734.png)
  
#### Testing instructions
  
1. Run `git checkout add/promote-local-biz-goal` and start your server, or open a [live branch](https://calypso.live/?branch=add/promote-local-biz-goal)
2. Open the [`Signup` page](http://calypso.localhost:3000/start)
3. Check that you can choose `promote local business` as one of your site's goals
  
#### Reviews
  
- [ ] Code
- [ ] Product

