### PR TITLE
SiteRename: Add validation to input

### DIFF
--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -47,17 +47,20 @@ export class SimpleSiteRenameForm extends Component {
 	getDomainValidationMessage( domain ) {
 		const { translate } = this.props;
 
-		if ( ! domain.match( /^[a-z0-9]+$/ ) ) {
-			return translate( 'Domain can only contain letters and numbers' );
+		if ( domain.match( /[^a-z0-9]/i ) ) {
+			return translate( 'Domain can only contain letters (a-z) and numbers.' );
 		}
 
 		if ( ! inRange( domain.length, SUBDOMAIN_LENGTH_MINIMUM, SUBDOMAIN_LENGTH_MAXIMUM ) ) {
-			return translate( 'Domain length should be between %(minimumLength)s and %(maximumLength)s', {
-				args: {
-					minimumLength: SUBDOMAIN_LENGTH_MINIMUM,
-					maximumLength: SUBDOMAIN_LENGTH_MAXIMUM,
-				},
-			} );
+			return translate(
+				'Domain length should be between %(minimumLength)s and %(maximumLength)s characters.',
+				{
+					args: {
+						minimumLength: SUBDOMAIN_LENGTH_MINIMUM,
+						maximumLength: SUBDOMAIN_LENGTH_MAXIMUM,
+					},
+				}
+			);
 		}
 
 		return '';

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -4,7 +4,7 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { get, flow, inRange } from 'lodash';
+import { get, flow, isEmpty, inRange } from 'lodash';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 
@@ -86,13 +86,13 @@ export class SimpleSiteRenameForm extends Component {
 
 	onFieldChange = event => {
 		const domainFieldValue = get( event, 'target.value' );
-		const maybeDomainFieldError = this.state.domainFieldError && {
-			domainFieldError: this.getDomainValidationMessage( domainFieldValue ),
-		};
+		const shouldUpdateError = ! isEmpty( this.state.domainFieldError );
 
 		this.setState( {
 			domainFieldValue,
-			...maybeDomainFieldError,
+			...( shouldUpdateError && {
+				domainFieldError: this.getDomainValidationMessage( domainFieldValue ),
+			} ),
 		} );
 	};
 

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -21,7 +21,7 @@ import { requestSiteRename } from 'state/site-rename/actions';
 import { isRequestingSiteRename } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
-const SUBDOMAIN_LENGTH_MINIMUM = 2;
+const SUBDOMAIN_LENGTH_MINIMUM = 4;
 const SUBDOMAIN_LENGTH_MAXIMUM = 50;
 
 export class SimpleSiteRenameForm extends Component {
@@ -47,7 +47,7 @@ export class SimpleSiteRenameForm extends Component {
 	getDomainValidationMessage( domain ) {
 		const { translate } = this.props;
 
-		if ( ! domain.match( /^[a-z0-9]+$/i ) ) {
+		if ( ! domain.match( /^[a-z0-9]+$/ ) ) {
 			return translate( 'Domain can only contain letters and numbers' );
 		}
 

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -4,7 +4,7 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { get, flow, isEmpty, inRange } from 'lodash';
+import { flow, get, isEmpty, inRange } from 'lodash';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 
@@ -85,7 +85,7 @@ export class SimpleSiteRenameForm extends Component {
 	};
 
 	onFieldChange = event => {
-		const domainFieldValue = get( event, 'target.value' );
+		const domainFieldValue = get( event, 'target.value', '' ).toLowerCase();
 		const shouldUpdateError = ! isEmpty( this.state.domainFieldError );
 
 		this.setState( {
@@ -100,19 +100,19 @@ export class SimpleSiteRenameForm extends Component {
 		const { currentDomain, currentDomainSuffix, isSiteRenameRequesting, translate } = this.props;
 		const currentDomainPrefix = get( currentDomain, 'name', '' ).replace( currentDomainSuffix, '' );
 		const isWPCOM = get( currentDomain, 'type' ) === 'WPCOM';
-		const { domainFieldError } = this.state;
+		const { domainFieldError, domainFieldValue } = this.state;
 		const isDisabled =
 			! isWPCOM ||
-			! this.state.domainFieldValue ||
+			! domainFieldValue ||
 			!! domainFieldError ||
-			this.state.domainFieldValue === currentDomainPrefix;
+			domainFieldValue === currentDomainPrefix;
 
 		return (
 			<div className="simple-site-rename-form">
 				<ConfirmationDialog
 					isVisible={ this.state.showDialog }
 					onClose={ this.onDialogClose }
-					newDomainName={ this.state.domainFieldValue }
+					newDomainName={ domainFieldValue }
 					currentDomainName={ currentDomainPrefix }
 					onConfirm={ this.onConfirm }
 				/>

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -4,7 +4,7 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { flow, get, isEmpty, inRange } from 'lodash';
+import { get, flow, inRange, isEmpty } from 'lodash';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 
@@ -46,6 +46,10 @@ export class SimpleSiteRenameForm extends Component {
 
 	getDomainValidationMessage( domain ) {
 		const { translate } = this.props;
+
+		if ( isEmpty( domain ) ) {
+			return '';
+		}
 
 		if ( domain.match( /[^a-z0-9]/i ) ) {
 			return translate( 'Domain can only contain letters (a-z) and numbers.' );


### PR DESCRIPTION
*Note that this PR bases from #21861, it'll be pointed to master once #21861 lands*

### Summary

This PR adds  simple validation to the site renamer component, validating against badly formed sub domain names.
Specifically it checks for and warns against entries that are less than 2 characters long, more than 50 characters long or containing any characters other than alphanumerics.

### Notes

I think there could be some improvements to the way we inform the person filling out this form of the validation issues.
I've taken an approach of "don't show any issue until they have attempted to submit the form" rather than "show errors as they're typed" in an effort to avoid showing an error as soon as somebody starts typing - a single character in the input would be deemed an input error, but showing red at this point is a little obnoxious since any input would have to start out with this 'error'.
I'm going to work on a nicer flow that's best-of-both, but I don't want that to be a blocker for moving forward.

### Testing

- Go to http://calypso.localhost:3000/domains/manage
- Switch to or create a site with a name you don't mind changing and losing.
- Type in some invalid domain names, covering the following:
  - contains spaces
  - contains `.`, this could be a common problem as people try to fill out a full domain name
  - contains any other invalid characters, examples: `*&^%$£@!`
  - is 1 character long
  - is over 50 characters long
- You should see 2 possible validation messages, one regarding length and one regarding invalid characters
- The validation should only show on attempting to submit, but will be hidden right away when the error is fixed.
- When the input is valid the confirmation dialog should appear, if not valid the dialog shouldn't appear

#### Some more intricate test flows:
- type a single letter or number, attempt to submit
  - You'll see a message to the effect of 'should be 2 chars or more'
- Attempt to fix this with an invalid character (`@` for example)
  - You'll see the error message change to the effect of 'invalid character'
- Remove this invalid char
  - You'll again see the message to the effect of 'should be 2 chars or more'
- Fix this with a valid character (alphanumerics)
 - You'll now see no validation errors.