### PR TITLE
WIP: GIVE ME BACK MY CONSOLE

### DIFF
--- a/server/bundler/hot-reloader.js
+++ b/server/bundler/hot-reloader.js
@@ -67,6 +67,9 @@ const hotReloader = {
 		} );
 
 		cssHotReloader( io );
+
+		// WBM announcements
+		global.wbmChannel = io.of( '/webpack-build-monitor' );
 	},
 
 	close: function() {

--- a/server/bundler/index.js
+++ b/server/bundler/index.js
@@ -2,7 +2,6 @@
 /**
  * External dependecies
  */
-
 const webpackMiddleware = require( 'webpack-dev-middleware' );
 const webpack = require( 'webpack' );
 const chalk = require( 'chalk' );
@@ -19,7 +18,12 @@ function middleware( app ) {
 	let built = false;
 	let beforeFirstCompile = true;
 
-	app.use( hotMiddleware( compiler ) );
+	app.use(
+		hotMiddleware( compiler, {
+			log: ( ...args ) =>
+				global.wbmChannel ? global.wbmChannel.emit( 'message', args ) : console.log( ...args ),
+		} )
+	);
 
 	app.set( 'compiler', compiler );
 


### PR DESCRIPTION
Because NOBODY wants to jump [here](https://github.com/Automattic/wp-calypso/blob/0653b6db2f8b88a2aa47f997afe88b9d2f2f219d/client/components/webpack-build-monitor/index.jsx#L49) when looking up from whence a console message originated.

**Todo**
 - [ ] Figure out how to trap connected/disconnected messages (and how to reproduce them)
 - [ ] Trap "Nothing changed"
 - [ ] Verify "Needs reload"
 - [ ] Verify we don't need "The following modules couldn't be hot updated"
 - [ ] Scale back complexity once we know what's going on
 - [ ] Figure out if we can tap into these messages at a lower level - the socket.io channel has sparse messages and they don't account for the `[HMR]` messages - where are those coming from? (besides from `node_modules/webpack-hot-middleware/{client,process-update}.js`)