### PR TITLE
Checkout: fix tracks logging of payment errors

### DIFF
--- a/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react'; // eslint-disable-line no-unused-vars
 import debugFactory from 'debug';
-import { defer, isEqual, pick, map } from 'lodash';
+import { defer, isEqual, pick } from 'lodash';
 
 const debug = debugFactory( 'calypso:my-sites:upgrades:checkout:transaction-steps-mixin' );
 
@@ -80,7 +80,7 @@ const TransactionStepsMixin = {
 			case 'received-wpcom-response':
 				if ( step.error ) {
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_error', {
-						reason: this._formatError( step.error.message ),
+						reason: this._formatError( step.error ),
 					} );
 
 					this._recordDomainRegistrationAnalytics( {
@@ -118,7 +118,7 @@ const TransactionStepsMixin = {
 			default:
 				if ( step.error ) {
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_error', {
-						reason: this._formatError( step.error.message ),
+						reason: this._formatError( step.error ),
 					} );
 				}
 		}
@@ -147,14 +147,17 @@ const TransactionStepsMixin = {
 		} );
 	},
 
-	_formatError: function( errorMessage ) {
-		let formatedMessage = errorMessage;
+	_formatError: function( error ) {
+		let formatedMessage = '';
 
-		if ( typeof errorMessage === 'object' ) {
-			formatedMessage = map( errorMessage, function( error, key ) {
-				return key + ': ' + error;
-			} );
-			formatedMessage = formatedMessage.join( ', ' );
+		if ( typeof error.message === 'object' ) {
+			formatedMessage += Object.keys( error.message ).join( ', ' );
+		} else if ( typeof error.message === 'string' ) {
+			formatedMessage += error.message;
+		}
+
+		if ( error.error ) {
+			formatedMessage = error.error + ': ' + formatedMessage;
 		}
 
 		return formatedMessage;

--- a/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/checkout/checkout/transaction-steps-mixin.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react'; // eslint-disable-line no-unused-vars
 import debugFactory from 'debug';
-import { defer, isEqual, pick } from 'lodash';
+import { defer, isEqual, pick, map } from 'lodash';
 
 const debug = debugFactory( 'calypso:my-sites:upgrades:checkout:transaction-steps-mixin' );
 
@@ -80,7 +80,7 @@ const TransactionStepsMixin = {
 			case 'received-wpcom-response':
 				if ( step.error ) {
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_error', {
-						reason: step.error.message,
+						reason: this._formatError( step.error.message ),
 					} );
 
 					this._recordDomainRegistrationAnalytics( {
@@ -118,7 +118,7 @@ const TransactionStepsMixin = {
 			default:
 				if ( step.error ) {
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_error', {
-						reason: step.error.message,
+						reason: this._formatError( step.error.message ),
 					} );
 				}
 		}
@@ -145,6 +145,19 @@ const TransactionStepsMixin = {
 			// The Thank You page throws a rendering error if this is not in a defer.
 			this.props.handleCheckoutCompleteRedirect();
 		} );
+	},
+
+	_formatError: function( errorMessage ) {
+		let formatedMessage = errorMessage;
+
+		if ( typeof errorMessage === 'object' ) {
+			formatedMessage = map( errorMessage, function( error, key ) {
+				return key + ': ' + error;
+			} );
+			formatedMessage = formatedMessage.join( ', ' );
+		}
+
+		return formatedMessage;
 	},
 };
 


### PR DESCRIPTION
Currently, a lot of payment errors are not logged because `reason` isn't being passed a string, but an object, for example
`{ cvv: 'Invalid credit card CVV number' }`

<img width="677" alt="screen shot 2018-01-21 at 15 19 38" src="https://user-images.githubusercontent.com/844866/35917553-3f19991a-0c17-11e8-8faa-caac032bd421.png">

This PR flattens the errors and joins them in case there are more than one.
Testing can be done with [these error specific test cards](https://stripe.com/docs/testing#cards-responses).
