### PR TITLE
Jetpack Onboarding: Add Summary next step to setup Woo

### DIFF
--- a/client/jetpack-onboarding/summary-next-steps.jsx
+++ b/client/jetpack-onboarding/summary-next-steps.jsx
@@ -37,7 +37,7 @@ export default localize(
 
 		if ( isBusiness && wantsWoo ) {
 			additionalSteps.STORE = {
-				label: translate( 'Setup your store' ),
+				label: translate( 'Set up your store' ),
 				url: siteUrl + '/wp-admin/index.php?page=wc-setup',
 			};
 		}

--- a/client/jetpack-onboarding/summary-next-steps.jsx
+++ b/client/jetpack-onboarding/summary-next-steps.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-import { map } from 'lodash';
+import { get, map } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import QuerySites from 'components/data/query-sites';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
+import { getJetpackOnboardingSettings } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
 const NextSteps = ( { siteId, steps } ) => (
@@ -29,6 +30,18 @@ const NextSteps = ( { siteId, steps } ) => (
 export default localize(
 	connect( ( state, { siteId, siteSlug, siteUrl, translate } ) => {
 		const isConnected = isJetpackSite( state, siteId ); // Will only return true if the site is connected to WP.com
+		const settings = getJetpackOnboardingSettings( state, siteId );
+		const additionalSteps = {};
+		const isBusiness = get( settings, 'siteType' ) === 'business';
+		const wantsWoo = get( settings, 'installWooCommerce' ) === true;
+
+		if ( isBusiness && wantsWoo ) {
+			additionalSteps.STORE = {
+				label: translate( 'Setup your store' ),
+				url: siteUrl + '/wp-admin/index.php?page=wc-setup',
+			};
+		}
+
 		if ( isConnected ) {
 			return {
 				steps: {
@@ -44,6 +57,7 @@ export default localize(
 						label: translate( 'Write your first blog post' ),
 						url: getEditorNewPostPath( state, siteId, 'post' ),
 					},
+					...additionalSteps,
 				},
 			};
 		}
@@ -66,6 +80,7 @@ export default localize(
 					label: translate( 'Write your first blog post' ),
 					url: siteUrl + '/wp-admin/post-new.php',
 				},
+				...additionalSteps,
 			},
 		};
 	} )( NextSteps )


### PR DESCRIPTION
This PR adds a "Setup your store" next task in the Summary step of Jetpack Onboarding when the user has selected a "Business" site type and has selected to install WooCommerce. Since we disable the automatic redirect to the WooCommerce initial setup wizard, it makes sense to give the user an easy and quick way to setup their WooCommerce - it's probably the most obvious starting point for someone who's setting up an online store.

Preview (see the last item):
![](https://cldup.com/Raw8z7YS4e.png)

Fixes #22206.

To test:
1. Checkout this branch on your local Calypso.
2. Make sure your JP sandbox is disconnected.
3. Make sure your JP sandbox is running the latest Jetpack (5.8).
4. Go to https://YourJetpackSandbox.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development where `YourJetpackSandbox.com` is the domain of your Jetpack sandbox.
5. In the Site Type step, choose "Business".
6. In the WooCommerce step, click the button to install WooCommerce.
7.  In the Summary step, verify you can see the link to setup the store and it leads you to the WooCommerce setup wizard.
8. Try steps 3-7, but this time while your site is connected. Verify the link is shown properly in the Summary step.
9. Try with a non-connected "Personal" Site Type and verify the link isn't shown.
10. Start clean (by deleting the Redux state and WooCommerce), then try with a non-connected Business site but skipping WooCommerce step and verify the link isn't shown.
11. Try 9. and 10. for a connected site and verify they behave the same way.