### PR TITLE
Jetpack Connect: Remove flash of text in footer on auth success

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -592,7 +592,7 @@ export class JetpackAuthorize extends Component {
 
 	renderFooterLinks() {
 		const { translate } = this.props;
-		const { isAuthorizing } = this.props.authorizationData;
+		const { authorizeSuccess, isAuthorizing } = this.props.authorizationData;
 		const { blogname, redirectAfterAuth } = this.props.authQuery;
 		const backToWpAdminLink = (
 			<LoggedOutFormLinkItem href={ redirectAfterAuth }>
@@ -603,7 +603,7 @@ export class JetpackAuthorize extends Component {
 			</LoggedOutFormLinkItem>
 		);
 
-		if ( this.retryingAuth || isAuthorizing || this.redirecting ) {
+		if ( this.retryingAuth || isAuthorizing || authorizeSuccess || this.redirecting ) {
 			return null;
 		}
 

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -592,7 +592,7 @@ export class JetpackAuthorize extends Component {
 
 	renderFooterLinks() {
 		const { translate } = this.props;
-		const { authorizeSuccess, isAuthorizing } = this.props.authorizationData;
+		const { isAuthorizing } = this.props.authorizationData;
 		const { blogname, redirectAfterAuth } = this.props.authQuery;
 		const backToWpAdminLink = (
 			<LoggedOutFormLinkItem href={ redirectAfterAuth }>
@@ -605,17 +605,6 @@ export class JetpackAuthorize extends Component {
 
 		if ( this.retryingAuth || isAuthorizing || this.redirecting ) {
 			return null;
-		}
-
-		if ( authorizeSuccess ) {
-			return (
-				<LoggedOutFormLinks>
-					{ this.isWaitingForConfirmation() ? backToWpAdminLink : null }
-					<LoggedOutFormLinkItem href={ this.getRedirectionTarget() }>
-						{ translate( "I'm not interested in upgrades" ) }
-					</LoggedOutFormLinkItem>
-				</LoggedOutFormLinks>
-			);
 		}
 
 		return (


### PR DESCRIPTION
Remove the "I'm not interested in upgrades" link that flashes past too quickly to read while being redirected to the plans selection step after connecting a site.

**Before**

![footer_flash](https://user-images.githubusercontent.com/7767559/35926711-b0bd1854-0c20-11e8-887b-2a97475c4264.gif)

**After**

![footer_flash_after](https://user-images.githubusercontent.com/7767559/35926715-b34c1b2e-0c20-11e8-91c0-ad1c34b0d102.gif)

## Testing
Connect a wporg/Jetpack site to wpcom, either at wordpress.com/jetpack/connect, or from wp-admin. There should be no flash of text in the footer of the page on completion of the connection, just before arriving at plans selection.

