### PR TITLE
Jetpack Connect: Jetpack log in

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -40,6 +40,7 @@ import SocialSignupForm from './social';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { createSocialUserFailed } from 'state/login/actions';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
+import { getSectionName } from 'state/ui/selectors';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
 	debug = debugModule( 'calypso:signup-form:form' );
@@ -76,7 +77,10 @@ class SignupForm extends Component {
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+
+		// Connected props
 		oauth2Client: PropTypes.object,
+		sectionName: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -329,6 +333,7 @@ class SignupForm extends Component {
 
 	getLoginLink() {
 		return login( {
+			isJetpack: 'jetpack-connect' === this.props.sectionName,
 			isNative: config.isEnabled( 'login/native-login-links' ),
 			redirectTo: this.props.redirectToAfterLoginUrl,
 			locale: this.props.locale,
@@ -629,6 +634,7 @@ class SignupForm extends Component {
 export default connect(
 	state => ( {
 		oauth2Client: getCurrentOAuth2Client( state ),
+		sectionName: getSectionName( state ),
 	} ),
 	{
 		trackLoginMidFlow: () => recordTracksEvent( 'calypso_signup_login_midflow' ),

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -610,7 +610,13 @@ export class JetpackAuthorize extends Component {
 		return (
 			<LoggedOutFormLinks>
 				{ this.isWaitingForConfirmation() ? backToWpAdminLink : null }
-				<LoggedOutFormLinkItem href={ login( { redirectTo: window.location.href } ) }>
+				<LoggedOutFormLinkItem
+					href={ login( {
+						isJetpack: true,
+						isNative: config.isEnabled( 'login/native-login-links' ),
+						redirectTo: window.location.href,
+					} ) }
+				>
 					{ translate( 'Sign in as a different user' ) }
 				</LoggedOutFormLinkItem>
 				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -91,6 +91,8 @@ export class JetpackAuthorize extends Component {
 		} ).isRequired,
 		authorize: PropTypes.func.isRequired,
 		calypsoStartedConnection: PropTypes.bool,
+		currentQuery: PropTypes.object,
+		currentRoute: PropTypes.string,
 		hasExpiredSecretError: PropTypes.bool,
 		hasXmlrpcError: PropTypes.bool,
 		isAlreadyOnSitesList: PropTypes.bool,

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -36,6 +36,7 @@ import userUtilities from 'lib/user/utils';
 import { addQueryArgs, externalRedirect } from 'lib/route';
 import { authQueryPropTypes, getRoleFromScope } from './utils';
 import { decodeEntities } from 'lib/formatting';
+import { getCurrentQueryArguments, getCurrentRoute } from 'state/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { isRequestingSite, isRequestingSites } from 'state/sites/selectors';
 import { JPC_PATH_PLANS, REMOTE_PATH_AUTH } from './constants';
@@ -181,6 +182,16 @@ export class JetpackAuthorize extends Component {
 		}
 	}
 
+	getLoginRedirect = () => {
+		return addQueryArgs(
+			{
+				...this.props.currentQuery,
+				auth_approved: true,
+			},
+			this.props.currentRoute
+		);
+	};
+
 	redirect() {
 		const { isMobileAppFlow, mobileAppRedirect } = this.props;
 		const { from, redirectAfterAuth, scope } = this.props.authQuery;
@@ -281,7 +292,7 @@ export class JetpackAuthorize extends Component {
 	handleSignOut = () => {
 		const { recordTracksEvent } = this.props;
 		recordTracksEvent( 'calypso_jpc_signout_click' );
-		userUtilities.logout( window.location.href );
+		userUtilities.logout( this.getLoginRedirect() );
 	};
 
 	handleResolve = () => {
@@ -614,7 +625,7 @@ export class JetpackAuthorize extends Component {
 					href={ login( {
 						isJetpack: true,
 						isNative: config.isEnabled( 'login/native-login-links' ),
-						redirectTo: window.location.href,
+						redirectTo: this.getLoginRedirect(),
 					} ) }
 				>
 					{ translate( 'Sign in as a different user' ) }
@@ -692,6 +703,8 @@ export default connect(
 			authAttempts: getAuthAttempts( state, urlToSlug( authQuery.site ) ),
 			authorizationData: getAuthorizationData( state ),
 			calypsoStartedConnection: isCalypsoStartedConnection( authQuery.site ),
+			currentQuery: getCurrentQueryArguments( state ),
+			currentRoute: getCurrentRoute( state ),
 			hasExpiredSecretError: hasExpiredSecretErrorSelector( state ),
 			hasXmlrpcError: hasXmlrpcErrorSelector( state ),
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state, authQuery.site ),

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -117,9 +117,10 @@ export class JetpackSignup extends Component {
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem
 					href={ login( {
+						emailAddress,
+						isJetpack: true,
 						isNative: config.isEnabled( 'login/native-login-links' ),
 						redirectTo: window.location.href,
-						emailAddress,
 					} ) }
 				>
 					{ this.props.translate( 'Already have an account? Sign in' ) }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -139,16 +139,17 @@ export class JetpackSignup extends Component {
 					{ this.renderLocaleSuggestions() }
 					<AuthFormHeader authQuery={ this.props.authQuery } />
 					<SignupForm
+						disabled={ isAuthorizing }
+						email={ this.props.authQuery.userEmail }
+						footerLink={ this.renderFooterLink() }
+						locale={ this.props.locale }
 						redirectToAfterLoginUrl={ addQueryArgs(
 							{ auth_approved: true },
 							window.location.href
 						) }
-						disabled={ isAuthorizing }
-						submitting={ isAuthorizing }
-						submitForm={ this.handleSubmitSignup }
 						submitButtonText={ this.props.translate( 'Sign Up and Connect Jetpack' ) }
-						footerLink={ this.renderFooterLink() }
-						email={ this.props.authQuery.userEmail }
+						submitForm={ this.handleSubmitSignup }
+						submitting={ isAuthorizing }
 						suggestedUsername={ get( userData, 'username', '' ) }
 					/>
 					{ userData && this.renderLoginUser() }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -23,7 +23,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { addQueryArgs } from 'lib/route';
 import AuthFormHeader from './auth-form-header';
 import config from 'config';
 import HelpButton from './help-button';
@@ -33,9 +32,11 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import MainWrapper from './main-wrapper';
 import SignupForm from 'components/signup-form';
 import WpcomLoginForm from 'signup/wpcom-login-form';
+import { addQueryArgs } from 'lib/route';
 import { authQueryPropTypes } from './utils';
 import { createAccount as createAccountAction } from 'state/jetpack-connect/actions';
 import { getAuthorizationData } from 'state/jetpack-connect/selectors';
+import { getCurrentQueryArguments, getCurrentRoute } from 'state/selectors';
 import { login } from 'lib/paths';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
@@ -74,6 +75,16 @@ export class JetpackSignup extends Component {
 		} );
 	}
 
+	getLoginRedirect = () => {
+		return addQueryArgs(
+			{
+				...this.props.currentQuery,
+				auth_approved: true,
+			},
+			this.props.currentRoute
+		);
+	};
+
 	handleSubmitSignup = ( form, userData ) => {
 		debug( 'submiting new account', form, userData );
 		this.props.createAccount( userData );
@@ -99,7 +110,7 @@ export class JetpackSignup extends Component {
 				log={ userData.username }
 				authorization={ 'Bearer ' + bearerToken }
 				emailAddress={ this.props.authQuery.userEmail }
-				redirectTo={ addQueryArgs( { auth_approved: true }, window.location.href ) }
+				redirectTo={ this.getLoginRedirect() }
 			/>
 		);
 	}
@@ -121,7 +132,7 @@ export class JetpackSignup extends Component {
 						isJetpack: true,
 						isNative: config.isEnabled( 'login/native-login-links' ),
 						locale: this.props.locale,
-						redirectTo: window.location.href,
+						redirectTo: this.getLoginRedirect(),
 					} ) }
 				>
 					{ this.props.translate( 'Already have an account? Sign in' ) }
@@ -144,10 +155,7 @@ export class JetpackSignup extends Component {
 						email={ this.props.authQuery.userEmail }
 						footerLink={ this.renderFooterLink() }
 						locale={ this.props.locale }
-						redirectToAfterLoginUrl={ addQueryArgs(
-							{ auth_approved: true },
-							window.location.href
-						) }
+						redirectToAfterLoginUrl={ this.getLoginRedirect() }
 						submitButtonText={ this.props.translate( 'Sign Up and Connect Jetpack' ) }
 						submitForm={ this.handleSubmitSignup }
 						submitting={ isAuthorizing }
@@ -163,6 +171,8 @@ export class JetpackSignup extends Component {
 export default connect(
 	state => ( {
 		authorizationData: getAuthorizationData( state ),
+		currentQuery: getCurrentQueryArguments( state ),
+		currentRoute: getCurrentRoute( state ),
 	} ),
 	{
 		recordTracksEvent: recordTracksEventAction,

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -55,6 +55,8 @@ export class JetpackSignup extends Component {
 			userData: PropTypes.object,
 		} ).isRequired,
 		createAccount: PropTypes.func.isRequired,
+		currentQuery: PropTypes.object,
+		currentRoute: PropTypes.string,
 		recordTracksEvent: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -120,6 +120,7 @@ export class JetpackSignup extends Component {
 						emailAddress,
 						isJetpack: true,
 						isNative: config.isEnabled( 'login/native-login-links' ),
+						locale: this.props.locale,
 						redirectTo: window.location.href,
 					} ) }
 				>

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -83,7 +83,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
           Return to %(sitename)s
         </LoggedOutFormLinkItem>
         <LoggedOutFormLinkItem
-          href="https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fexample.com%2F"
+          href="https://wordpress.com/wp-login.php?redirect_to=%2Fjetpack%2Fconnect%2Fauthorize%3Fauth_approved%3Dtrue"
         >
           Sign in as a different user
         </LoggedOutFormLinkItem>

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -35,7 +35,7 @@ exports[`JetpackSignup should render 1`] = `
       footerLink={
         <LoggedOutFormLinks>
           <LoggedOutFormLinkItem
-            href="https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site"
+            href="https://wordpress.com/wp-login.php?redirect_to=%2Fjetpack%2Fconnect%2Fauthorize%3Fauth_approved%3Dtrue&email_address=email%40an.example.site"
           >
             Already have an account? Sign in
           </LoggedOutFormLinkItem>
@@ -44,7 +44,7 @@ exports[`JetpackSignup should render 1`] = `
           />
         </LoggedOutFormLinks>
       }
-      redirectToAfterLoginUrl="https://example.com/?auth_approved=true"
+      redirectToAfterLoginUrl="/jetpack/connect/authorize?auth_approved=true"
       submitButtonText="Sign Up and Connect Jetpack"
       submitForm={[Function]}
       submitting={false}
@@ -93,7 +93,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
       footerLink={
         <LoggedOutFormLinks>
           <LoggedOutFormLinkItem
-            href="https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site"
+            href="https://es.wordpress.com/wp-login.php?redirect_to=%2Fjetpack%2Fconnect%2Fauthorize%3Fauth_approved%3Dtrue&email_address=email%40an.example.site"
           >
             Already have an account? Sign in
           </LoggedOutFormLinkItem>
@@ -102,7 +102,8 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
           />
         </LoggedOutFormLinks>
       }
-      redirectToAfterLoginUrl="https://example.com/?auth_approved=true"
+      locale="es"
+      redirectToAfterLoginUrl="/jetpack/connect/authorize?auth_approved=true"
       submitButtonText="Sign Up and Connect Jetpack"
       submitForm={[Function]}
       submitting={false}

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -50,6 +50,8 @@ const DEFAULT_PROPS = deepFreeze( {
 		userEmail: `email@${ SITE_SLUG }`,
 	},
 	calypsoStartedConnection: false,
+	currentQuery: {},
+	currentRoute: '/jetpack/connect/authorize',
 	hasExpiredSecretError: false,
 	hasXmlrpcError: false,
 	isAlreadyOnSitesList: false,

--- a/client/jetpack-connect/test/signup.js
+++ b/client/jetpack-connect/test/signup.js
@@ -49,6 +49,8 @@ const DEFAULT_PROPS = deepFreeze( {
 		userEmail: `email@${ SITE_SLUG }`,
 	},
 	createAccount: noop,
+	currentQuery: {},
+	currentRoute: '/jetpack/connect/authorize',
 	path: '/jetpack/connect/authorize',
 	recordTracksEvent: noop,
 	translate: identity,

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { PureComponent } from 'react';
 import Masterbar from './masterbar';
 import { connect } from 'react-redux';
 import { getLocaleSlug, localize } from 'i18n-calypso';
@@ -33,61 +33,63 @@ function getLoginUrl( redirectUri ) {
 	return login( { ...params, isNative: config.isEnabled( 'login/native-login-links' ) } );
 }
 
-function getSignupUrl( currentRoute, query ) {
-	if ( '/log-in/jetpack' === currentRoute && query.redirect_to ) {
-		return query.redirect_to;
+function getSignupUrl( currentRoute, currentQuery ) {
+	if ( '/log-in/jetpack' === currentRoute && currentQuery.redirect_to ) {
+		return currentQuery.redirect_to;
 	}
 	return config( 'signup_url' );
 }
 
-const MasterbarLoggedOut = ( {
-	currentRoute,
-	query,
-	title,
-	sectionName,
-	translate,
-	redirectUri,
-} ) => (
-	<Masterbar>
-		<Item className="masterbar__item-logo">
-			<WordPressLogo className="masterbar__wpcom-logo" />
-			<WordPressWordmark className="masterbar__wpcom-wordmark" />
-		</Item>
-		<Item className="masterbar__item-title">{ title }</Item>
-		<div className="masterbar__login-links">
-			{ ! includes( [ 'signup', 'jetpack-onboarding', 'jetpack-connect' ], sectionName ) ? (
-				<Item url={ getSignupUrl( currentRoute, query ) }>
-					{ translate( 'Sign Up', {
-						context: 'Toolbar',
-						comment: 'Should be shorter than ~12 chars',
-					} ) }
+class MasterbarLoggedOut extends PureComponent {
+	static propTypes = {
+		redirectUri: PropTypes.string,
+		sectionName: PropTypes.string,
+		title: PropTypes.string,
+
+		// Connected props
+		currentQuery: PropTypes.object,
+		currentRoute: PropTypes.string,
+	};
+
+	static defaultProps = {
+		sectionName: '',
+		title: '',
+	};
+
+	render() {
+		const { currentQuery, currentRoute, title, sectionName, translate, redirectUri } = this.props;
+		return (
+			<Masterbar>
+				<Item className="masterbar__item-logo">
+					<WordPressLogo className="masterbar__wpcom-logo" />
+					<WordPressWordmark className="masterbar__wpcom-wordmark" />
 				</Item>
-			) : null }
+				<Item className="masterbar__item-title">{ title }</Item>
+				<div className="masterbar__login-links">
+					{ ! includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) ? (
+						<Item url={ getSignupUrl( currentRoute, currentQuery ) }>
+							{ translate( 'Sign Up', {
+								context: 'Toolbar',
+								comment: 'Should be shorter than ~12 chars',
+							} ) }
+						</Item>
+					) : null }
 
-			{ ! includes( [ 'login', 'jetpack-onboarding', 'jetpack-connect' ], sectionName ) ? (
-				<Item url={ getLoginUrl( redirectUri ) }>
-					{ translate( 'Log In', {
-						context: 'Toolbar',
-						comment: 'Should be shorter than ~12 chars',
-					} ) }
-				</Item>
-			) : null }
-		</div>
-	</Masterbar>
-);
-
-MasterbarLoggedOut.propTypes = {
-	title: PropTypes.string,
-	sectionName: PropTypes.string,
-	redirectUri: PropTypes.string,
-};
-
-MasterbarLoggedOut.defaultProps = {
-	title: '',
-	sectionName: '',
-};
+					{ ! includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ? (
+						<Item url={ getLoginUrl( redirectUri ) }>
+							{ translate( 'Log In', {
+								context: 'Toolbar',
+								comment: 'Should be shorter than ~12 chars',
+							} ) }
+						</Item>
+					) : null }
+				</div>
+			</Masterbar>
+		);
+	}
+}
 
 export default connect( state => ( {
+	currentQuery: getCurrentQueryArguments( state ),
 	currentRoute: getCurrentRoute( state ),
-	query: getCurrentQueryArguments( state ),
 } ) )( localize( MasterbarLoggedOut ) );

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -78,7 +78,11 @@ class MasterbarLoggedOut extends PureComponent {
 		}
 
 		let signupUrl = config( 'signup_url' );
-		if ( '/log-in/jetpack' === currentRoute && get( currentQuery, 'redirect_to', false ) ) {
+		if (
+			'/log-in/jetpack' === currentRoute &&
+			// Ensure our redirection is to Jetpack Connect
+			includes( get( currentQuery, 'redirect_to' ), '/jetpack/connect/authorize' )
+		) {
 			signupUrl = currentQuery.redirect_to;
 		}
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Masterbar from './masterbar';
+import { connect } from 'react-redux';
 import { getLocaleSlug, localize } from 'i18n-calypso';
 import { includes } from 'lodash';
 
@@ -18,6 +19,7 @@ import config from 'config';
 import { login } from 'lib/paths';
 import WordPressWordmark from 'components/wordpress-wordmark';
 import WordPressLogo from 'components/wordpress-logo';
+import { getCurrentQueryArguments, getCurrentRoute } from 'state/selectors';
 
 function getLoginUrl( redirectUri ) {
 	const params = { locale: getLocaleSlug() };
@@ -31,7 +33,21 @@ function getLoginUrl( redirectUri ) {
 	return login( { ...params, isNative: config.isEnabled( 'login/native-login-links' ) } );
 }
 
-const MasterbarLoggedOut = ( { title, sectionName, translate, redirectUri } ) => (
+function getSignupUrl( currentRoute, query ) {
+	if ( '/log-in/jetpack' === currentRoute && query.redirect_to ) {
+		return query.redirect_to;
+	}
+	return config( 'signup_url' );
+}
+
+const MasterbarLoggedOut = ( {
+	currentRoute,
+	query,
+	title,
+	sectionName,
+	translate,
+	redirectUri,
+} ) => (
 	<Masterbar>
 		<Item className="masterbar__item-logo">
 			<WordPressLogo className="masterbar__wpcom-logo" />
@@ -39,8 +55,8 @@ const MasterbarLoggedOut = ( { title, sectionName, translate, redirectUri } ) =>
 		</Item>
 		<Item className="masterbar__item-title">{ title }</Item>
 		<div className="masterbar__login-links">
-			{ ! includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) ? (
-				<Item url={ config( 'signup_url' ) }>
+			{ ! includes( [ 'signup', 'jetpack-onboarding', 'jetpack-connect' ], sectionName ) ? (
+				<Item url={ getSignupUrl( currentRoute, query ) }>
 					{ translate( 'Sign Up', {
 						context: 'Toolbar',
 						comment: 'Should be shorter than ~12 chars',
@@ -48,7 +64,7 @@ const MasterbarLoggedOut = ( { title, sectionName, translate, redirectUri } ) =>
 				</Item>
 			) : null }
 
-			{ ! includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ? (
+			{ ! includes( [ 'login', 'jetpack-onboarding', 'jetpack-connect' ], sectionName ) ? (
 				<Item url={ getLoginUrl( redirectUri ) }>
 					{ translate( 'Log In', {
 						context: 'Toolbar',
@@ -71,4 +87,7 @@ MasterbarLoggedOut.defaultProps = {
 	sectionName: '',
 };
 
-export default localize( MasterbarLoggedOut );
+export default connect( state => ( {
+	currentRoute: getCurrentRoute( state ),
+	query: getCurrentQueryArguments( state ),
+} ) )( localize( MasterbarLoggedOut ) );

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -38,7 +38,7 @@ class MasterbarLoggedOut extends PureComponent {
 	};
 
 	renderLoginItem() {
-		const { sectionName, translate, redirectUri } = this.props;
+		const { currentQuery, sectionName, translate, redirectUri } = this.props;
 
 		if ( includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ) {
 			return null;
@@ -54,6 +54,8 @@ class MasterbarLoggedOut extends PureComponent {
 
 		const loginUrl = login( {
 			...params,
+			// We may know the email from Jetpack connection details
+			emailAddress: get( currentQuery, 'user_email' ),
 			isJetpack: 'jetpack-connect' === sectionName,
 			isNative: config.isEnabled( 'login/native-login-links' ),
 		} );

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -9,7 +9,7 @@ import React, { PureComponent } from 'react';
 import Masterbar from './masterbar';
 import { connect } from 'react-redux';
 import { getLocaleSlug, localize } from 'i18n-calypso';
-import { get, includes } from 'lodash';
+import { get, includes, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -79,7 +79,8 @@ class MasterbarLoggedOut extends PureComponent {
 
 		let signupUrl = config( 'signup_url' );
 		if (
-			'/log-in/jetpack' === currentRoute &&
+			// Match locales like `/log-in/jetpack/es`
+			startsWith( currentRoute, '/log-in/jetpack' ) &&
 			// Ensure our redirection is to Jetpack Connect
 			includes( get( currentQuery, 'redirect_to' ), '/jetpack/connect/authorize' )
 		) {

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -54,6 +54,7 @@ class MasterbarLoggedOut extends PureComponent {
 
 		const loginUrl = login( {
 			...params,
+			isJetpack: 'jetpack-connect' === sectionName,
 			isNative: config.isEnabled( 'login/native-login-links' ),
 		} );
 
@@ -70,7 +71,7 @@ class MasterbarLoggedOut extends PureComponent {
 	renderSignupItem() {
 		const { currentQuery, currentRoute, sectionName, translate } = this.props;
 
-		if ( includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) ) {
+		if ( includes( [ 'signup', 'jetpack-onboarding', 'jetpack-connect' ], sectionName ) ) {
 			return null;
 		}
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -21,18 +21,6 @@ import WordPressWordmark from 'components/wordpress-wordmark';
 import WordPressLogo from 'components/wordpress-logo';
 import { getCurrentQueryArguments, getCurrentRoute } from 'state/selectors';
 
-function getLoginUrl( redirectUri ) {
-	const params = { locale: getLocaleSlug() };
-
-	if ( redirectUri ) {
-		params.redirectTo = redirectUri;
-	} else if ( typeof window !== 'undefined' ) {
-		params.redirectTo = window.location.href;
-	}
-
-	return login( { ...params, isNative: config.isEnabled( 'login/native-login-links' ) } );
-}
-
 class MasterbarLoggedOut extends PureComponent {
 	static propTypes = {
 		redirectUri: PropTypes.string,
@@ -51,15 +39,31 @@ class MasterbarLoggedOut extends PureComponent {
 
 	renderLoginItem() {
 		const { sectionName, translate, redirectUri } = this.props;
+
+		if ( includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ) {
+			return null;
+		}
+
+		const params = { locale: getLocaleSlug() };
+
+		if ( redirectUri ) {
+			params.redirectTo = redirectUri;
+		} else if ( typeof window !== 'undefined' ) {
+			params.redirectTo = window.location.href;
+		}
+
+		const loginUrl = login( {
+			...params,
+			isNative: config.isEnabled( 'login/native-login-links' ),
+		} );
+
 		return (
-			! includes( [ 'login', 'jetpack-onboarding' ], sectionName ) && (
-				<Item url={ getLoginUrl( redirectUri ) }>
-					{ translate( 'Log In', {
-						context: 'Toolbar',
-						comment: 'Should be shorter than ~12 chars',
-					} ) }
-				</Item>
-			)
+			<Item url={ loginUrl }>
+				{ translate( 'Log In', {
+					context: 'Toolbar',
+					comment: 'Should be shorter than ~12 chars',
+				} ) }
+			</Item>
 		);
 	}
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -9,7 +9,7 @@ import React, { PureComponent } from 'react';
 import Masterbar from './masterbar';
 import { connect } from 'react-redux';
 import { getLocaleSlug, localize } from 'i18n-calypso';
-import { includes } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,13 +31,6 @@ function getLoginUrl( redirectUri ) {
 	}
 
 	return login( { ...params, isNative: config.isEnabled( 'login/native-login-links' ) } );
-}
-
-function getSignupUrl( currentRoute, currentQuery ) {
-	if ( '/log-in/jetpack' === currentRoute && currentQuery.redirect_to ) {
-		return currentQuery.redirect_to;
-	}
-	return config( 'signup_url' );
 }
 
 class MasterbarLoggedOut extends PureComponent {
@@ -72,15 +65,23 @@ class MasterbarLoggedOut extends PureComponent {
 
 	renderSignupItem() {
 		const { currentQuery, currentRoute, sectionName, translate } = this.props;
+
+		if ( includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) ) {
+			return null;
+		}
+
+		let signupUrl = config( 'signup_url' );
+		if ( '/log-in/jetpack' === currentRoute && get( currentQuery, 'redirect_to', false ) ) {
+			signupUrl = currentQuery.redirect_to;
+		}
+
 		return (
-			! includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) && (
-				<Item url={ getSignupUrl( currentRoute, currentQuery ) }>
-					{ translate( 'Sign Up', {
-						context: 'Toolbar',
-						comment: 'Should be shorter than ~12 chars',
-					} ) }
-				</Item>
-			)
+			<Item url={ signupUrl }>
+				{ translate( 'Sign Up', {
+					context: 'Toolbar',
+					comment: 'Should be shorter than ~12 chars',
+				} ) }
+			</Item>
 		);
 	}
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -56,8 +56,36 @@ class MasterbarLoggedOut extends PureComponent {
 		title: '',
 	};
 
+	renderLoginItem() {
+		const { sectionName, translate, redirectUri } = this.props;
+		return (
+			! includes( [ 'login', 'jetpack-onboarding' ], sectionName ) && (
+				<Item url={ getLoginUrl( redirectUri ) }>
+					{ translate( 'Log In', {
+						context: 'Toolbar',
+						comment: 'Should be shorter than ~12 chars',
+					} ) }
+				</Item>
+			)
+		);
+	}
+
+	renderSignupItem() {
+		const { currentQuery, currentRoute, sectionName, translate } = this.props;
+		return (
+			! includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) && (
+				<Item url={ getSignupUrl( currentRoute, currentQuery ) }>
+					{ translate( 'Sign Up', {
+						context: 'Toolbar',
+						comment: 'Should be shorter than ~12 chars',
+					} ) }
+				</Item>
+			)
+		);
+	}
+
 	render() {
-		const { currentQuery, currentRoute, title, sectionName, translate, redirectUri } = this.props;
+		const { title } = this.props;
 		return (
 			<Masterbar>
 				<Item className="masterbar__item-logo">
@@ -66,23 +94,8 @@ class MasterbarLoggedOut extends PureComponent {
 				</Item>
 				<Item className="masterbar__item-title">{ title }</Item>
 				<div className="masterbar__login-links">
-					{ ! includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) ? (
-						<Item url={ getSignupUrl( currentRoute, currentQuery ) }>
-							{ translate( 'Sign Up', {
-								context: 'Toolbar',
-								comment: 'Should be shorter than ~12 chars',
-							} ) }
-						</Item>
-					) : null }
-
-					{ ! includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ? (
-						<Item url={ getLoginUrl( redirectUri ) }>
-							{ translate( 'Log In', {
-								context: 'Toolbar',
-								comment: 'Should be shorter than ~12 chars',
-							} ) }
-						</Item>
-					) : null }
+					{ this.renderSignupItem() }
+					{ this.renderLoginItem() }
 				</div>
 			</Masterbar>
 		);

--- a/client/layout/test/index.js
+++ b/client/layout/test/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React from 'react';
+import { Provider } from 'react-redux';
 import { renderToString } from 'react-dom/server';
 
 /**
@@ -15,7 +16,7 @@ describe( 'index', () => {
 		test( "doesn't throw an exception", () => {
 			expect( () => {
 				renderToString(
-					<LayoutLoggedOut
+					<Provider
 						store={ {
 							dispatch: () => {},
 							getState: () => ( {
@@ -23,7 +24,9 @@ describe( 'index', () => {
 							} ),
 							subscribe: () => {},
 						} }
-					/>
+					>
+						<LayoutLoggedOut />
+					</Provider>
 				);
 			} ).not.toThrow();
 		} );

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -9,6 +9,7 @@ import { addLocaleToPath, addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import config, { isEnabled } from 'config';
 
 export function login( {
+	isJetpack,
 	isNative,
 	locale,
 	redirectTo,
@@ -29,6 +30,8 @@ export function login( {
 			url += '/' + twoFactorAuthType;
 		} else if ( socialConnect ) {
 			url += '/social-connect';
+		} else if ( isJetpack ) {
+			url += '/jetpack';
 		}
 	}
 

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -69,5 +69,11 @@ describe( 'index', () => {
 
 			expect( url ).to.equal( '/log-in?client_id=12345' );
 		} );
+
+		test( 'should return the login url for Jetpck specific login', () => {
+			const url = login( { isNative: true, isJetpack: true } );
+
+			expect( url ).to.equal( '/log-in/jetpack' );
+		} );
 	} );
 } );

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -22,12 +22,13 @@ import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analyt
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 
 const enhanceContextWithLogin = context => {
-	const { path, params: { flow, twoFactorAuthType, socialService } } = context;
+	const { path, params: { flow, isJetpack, socialService, twoFactorAuthType } } = context;
 
 	context.cacheQueryKeys = [ 'client_id' ];
 
 	context.primary = (
 		<WPLogin
+			isJetpack={ isJetpack === 'jetpack' }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }
 			socialService={ socialService }

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -113,8 +113,8 @@ export function magicLoginUse( context, next ) {
 }
 
 export function redirectDefaultLocale( context, next ) {
-	// only redirect `/log-in/en` to `/log-in`
-	if ( context.pathname !== '/log-in/en' ) {
+	// Only handle simple routes
+	if ( context.pathname !== '/log-in/en' && context.pathname !== '/log-in/jetpack/en' ) {
 		return next();
 	}
 
@@ -133,5 +133,9 @@ export function redirectDefaultLocale( context, next ) {
 		return next();
 	}
 
-	context.redirect( '/log-in' );
+	if ( context.params.isJetpack === 'jetpack' ) {
+		context.redirect( '/log-in/jetpack' );
+	} else {
+		context.redirect( '/log-in' );
+	}
 }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -32,6 +32,7 @@ export class Login extends React.Component {
 	static propTypes = {
 		clientId: PropTypes.string,
 		isLoggedIn: PropTypes.bool.isRequired,
+		isJetpack: PropTypes.bool.isRequired,
 		locale: PropTypes.string.isRequired,
 		oauth2Client: PropTypes.object,
 		path: PropTypes.string.isRequired,
@@ -43,6 +44,8 @@ export class Login extends React.Component {
 		translate: PropTypes.func.isRequired,
 		twoFactorAuthType: PropTypes.string,
 	};
+
+	static defaultProps = { isJetpack: false };
 
 	componentDidMount() {
 		this.recordPageView( this.props );
@@ -135,6 +138,7 @@ export class Login extends React.Component {
 		const {
 			clientId,
 			isLoggedIn,
+			isJetpack,
 			oauth2Client,
 			privateSite,
 			socialConnect,
@@ -153,6 +157,7 @@ export class Login extends React.Component {
 				socialConnect={ socialConnect }
 				privateSite={ privateSite }
 				clientId={ clientId }
+				isJetpack={ isJetpack }
 				oauth2Client={ oauth2Client }
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }


### PR DESCRIPTION
This PR adds special handling for a new login route at `/log-in/jetpack`.

- Links in the masterbar from within Jetpack Connect should now use the `/log-in/jetpack` route
- Links in the masterbar from `/log-in/jetpack` point to Jetpack Connect path
- Footer links from Jetpack Connect signup (`/jetpack/connect/authorize` when logged out) use the `/log-in/jetpack` route
- Email is preserved when moving between signup (`/jetpack/connect/authorize`) <-> login (`/log-in/jetpack`)
- Locales are preserved moving between forms
- Login form is styled when feature is enabled (development env)

See p1HpG7-4Qr-p2

✅ Related patch D10062-code is deployed.

Supersedes #21901 

## Known issues

If you toggle back and forth between login/Jetpack Connect signup via the masterbar, sometimes the redirection is wrong and the masterbar signup points to `/start` 😕 

It seems to occur when navigating back and forth too fast, I haven't found a solution yet but will look more soon. You can see the issue at the end of the gif

## Screens

![jpc](https://user-images.githubusercontent.com/841763/36207924-bbae2bd2-1197-11e8-8821-359713ed4fa7.gif)

## Testing

Try these flows starting with both default `en` locale, and changing the test site URL before starting. D10100-code will be merged soon, but for now you'll land on an unlocalized login page when starting connection from WP Admin. Just append the desired locale like `/log-in/jetpack/es`. From there, the locale should be maintained when moving around.

1. Get a new site with Jetpack installed and activated
1. Ensure you're logged out of WordPress.com
1. Ensure the site user's email is associated with a WordPress.com email
1. Ensure moving with masterbar links stays within the flow
1. Ensure email is maintained when moving between login and Jetpack Connect
1. Try to "escape" these flows (see p1HpG7-4P7-p2)
1. Change the login page `redirect_to` to something else (not a `/jetpack/connect/authorize` url) and ensure that the default signup url is used (`/start`).
