### PR TITLE
Build: Remove tests from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,7 @@ Dockerfile
 /server/devdocs/components-usage-stats.json
 /server/devdocs/proptypes-index.json
 /server/devdocs/search-index.js
+
+# Tests do not need to be included in build
+/server/**/test/**
+/client/**/test/**

--- a/client/blocks/daily-post-button/docs/example.jsx
+++ b/client/blocks/daily-post-button/docs/example.jsx
@@ -10,12 +10,23 @@ import React from 'react';
  * Internal dependencies
  */
 import DailyPostButton from 'blocks/daily-post-button';
-import { dailyPromptPost } from 'blocks/daily-post-button/test/fixtures';
-
 const DailyPostButtonExample = () => {
 	return (
 		<div className="design-assets__group">
-			<DailyPostButton post={ dailyPromptPost } />
+			<DailyPostButton
+				post={ {
+					site_ID: 489937,
+					tags: {
+						'daily prompts': {
+							slug: 'daily-prompts-2',
+						},
+					},
+					type: 'dp_prompt',
+					title: 'Crisis',
+					URL: 'https://dailypost.wordpress.com/2016/07/27/crisis/',
+					short_url: 'http://wp.me/p23sd-12Mf',
+				} }
+			/>
 		</div>
 	);
 };


### PR DESCRIPTION
This PR removes tests from the docker context. It trims the build size down as well as isolates layers from changes to tests which may allow them to cache better.

Comparing with master size: `1090085203` vs `1085272154`, or approx `4.8 MB`

d60df495bef2fcbff6f973d31ab7d9f0efff3dc5 removes tests from the Docker context, which should break builds until 558de26c36954391f72404b743b290899fb6f403 fixes the problem. Oddly, dserve doesn't seem to have a problem:

https://dserve.a8c.com/?hash=d60df495bef2fcbff6f973d31ab7d9f0efff3dc5

Locally, this should fail:

```
git checkout d60df495bef2fcbff6f973d31ab7d9f0efff3dc5 && npm run build-docker
```

## Testing
1. Build it!
   ```sh
   npm run build-docker && npm run docker
   ```
1. Does it work? Smoke test