### PR TITLE
JPO: remove HTML5 `required` styling from the Business Address form.

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -69,8 +69,8 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		page( this.props.getForwardUrl() );
 	};
 
-	checkForEmptyFields = () => {
-		some( omit( this.state, 'state' ), val => val === '' );
+	hasEmptyFields = () => {
+		return some( omit( this.state, 'state' ), val => val === '' );
 	};
 
 	render() {
@@ -99,7 +99,6 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 									disabled={ isRequestingSettings }
 									id={ fieldName }
 									onChange={ this.getChangeHandler( fieldName ) }
-									required={ fieldName !== 'state' }
 									value={ this.state[ fieldName ] || '' }
 								/>
 								{ fieldName !== 'state' && (
@@ -111,7 +110,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 							</FormFieldset>
 						) ) }
 						<Button
-							disabled={ isRequestingSettings || this.checkForEmptyFields() }
+							disabled={ isRequestingSettings || this.hasEmptyFields() }
 							primary
 							type="submit"
 						>


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/21776 introduced a couple of regressions after the review feedback was incorporated.

This PR corrects it:
- maintains the Button disabled ( =  remove `required` prop ) until all required fields are filled in,
- add omitted return value to the function checking for empty fields.

**To test**
 Follow the instructions on #21582 for the Business Address step using a Business site.
