### PR TITLE
Domains: normalize ccTLD Redux data

### DIFF
--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -86,7 +86,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 
 		this.props.updateContactDetailsCache( {
 			extra: {
-				registrantType: defaultRegistrantType,
+				fr: { registrantType: defaultRegistrantType },
 			},
 		} );
 	}
@@ -102,7 +102,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 	};
 
 	handleChangeContactExtraEvent = event => {
-		this.updateContactDetails( `extra.${ event.target.id }`, event.target.value );
+		this.updateContactDetails( `extra.fr.${ event.target.id }`, event.target.value );
 	};
 
 	render() {
@@ -301,6 +301,7 @@ export default connect(
 		const contactDetails = getContactDetailsCache( state );
 		return {
 			contactDetails,
+			ccTldDetails: get( contactDetails, 'extra.fr', {} ),
 			contactDetailsValidationErrors: validateContactDetails( contactDetails ),
 		};
 	},

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -59,6 +59,7 @@ function renderValidationError( message ) {
 class RegistrantExtraInfoFrForm extends React.PureComponent {
 	static propTypes = {
 		contactDetails: PropTypes.object,
+		ccTldDetails: PropTypes.object,
 		contactDetailsValidationErrors: PropTypes.object,
 		isVisible: PropTypes.bool,
 		onSubmit: PropTypes.func,

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -107,8 +107,8 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 	};
 
 	render() {
-		const { contactDetails, contactDetailsValidationErrors, translate } = this.props;
-		const registrantType = get( contactDetails, 'extra.registrantType', defaultRegistrantType );
+		const { ccTldDetails, contactDetailsValidationErrors, translate } = this.props;
+		const registrantType = get( ccTldDetails, 'registrantType', defaultRegistrantType );
 		const formIsValid = isEmpty( contactDetailsValidationErrors );
 
 		return (
@@ -149,13 +149,13 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 	}
 
 	renderOrganizationFields() {
-		const { contactDetails, contactDetailsValidationErrors, translate } = this.props;
+		const { contactDetails, ccTldDetails, contactDetailsValidationErrors, translate } = this.props;
 		const { registrantVatId, sirenSiret, trademarkNumber } = defaults(
 			{},
-			contactDetails.extra,
+			ccTldDetails,
 			emptyValues
 		);
-		const validationErrors = get( contactDetailsValidationErrors, 'extra', {} );
+		const validationErrors = get( contactDetailsValidationErrors, 'extra.fr', {} );
 		const registrantVatIdValidationMessage =
 			validationErrors.registrantVatId &&
 			renderValidationError(

--- a/client/components/domains/registrant-extra-info/fr-schema.json
+++ b/client/components/domains/registrant-extra-info/fr-schema.json
@@ -17,9 +17,14 @@
 					"extra": {
 						"type": "object",
 						"properties": {
-							"registrantType": {
-								"type": "string",
-								"enum": [ "organization" ]
+							"fr": {
+								"type": "object",
+								"properties": {
+									"registrantType": {
+										"type": "string",
+										"enum": [ "organization" ]
+									}
+								}
 							}
 						}
 					},
@@ -34,6 +39,7 @@
 		{ "$ref": "#/definitions/organizationIsRequiredWhenRegistrantTypeIsOrganization" },
 		{
 			"type": "object",
+			"required": [ "extra" ],
 			"properties": {
 				"organization": {
 					"type": "string",
@@ -43,66 +49,70 @@
 				"extra": {
 					"type": "object",
 					"properties": {
-						"sirenSiret": {
-							"type": "string",
-							"pattern": "^[0-9]*$",
-							"anyOf": [
-								{ "minLength": 9, "maxLength": 9 },
-								{ "minLength": 14, "maxLength": 14 },
-								{ "$ref": "#/definitions/empty" }
-							]
-						},
-						"registrantType": {
-							"type": "string",
-							"enum": [ "individual", "organization" ]
-						},
-						"registrantVatId": {
-							"type": "string",
-							"anyOf": [
-								{ "pattern": "^(AT)U[0-9]{8}$" },
-								{ "pattern": "^(BE)0[0-9]{9}$" },
-								{ "pattern": "^(BG)[0-9]{9,10}$" },
-								{ "pattern": "^(CY)[0-9]{8}L$" },
-								{ "pattern": "^(CZ)[0-9]{8,10}$" },
-								{ "pattern": "^(DE)[0-9]{9}$" },
-								{ "pattern": "^(DK)[0-9]{8}$" },
-								{ "pattern": "^(EE)[0-9]{9}$" },
-								{ "pattern": "^(EL|GR)[0-9]{9}$" },
-								{ "pattern": "^(ES)[0-9A-Z][0-9]{7}[0-9A-Z]$" },
-								{ "pattern": "^(FI)[0-9]{8}$" },
-								{ "pattern": "^(FR)[0-9A-Z]{2}[0-9]{9}$" },
-								{ "pattern": "^(GB)([0-9]{9}([0-9]{3})?|(GD|HA)[0-9]{3})$" },
-								{ "pattern": "^(HR)[0-9]{11}$" },
-								{ "pattern": "^(HU)[0-9]{8}$" },
-								{ "pattern": "^(IE)([0-9][0-9A-Z+*][0-9]{5}[A-Z]|[0-9]{7}[0-9A-Z]{1,2})$" },
-								{ "pattern": "^(IT)[0-9]{11}$" },
-								{ "pattern": "^(LT)[0-9]{9}([0-9]{3})?$" },
-								{ "pattern": "^(LU)[0-9]{8}$" },
-								{ "pattern": "^(LV)[0-9]{11}$" },
-								{ "pattern": "^(MT)[0-9]{8}$" },
-								{ "pattern": "^(NL)[0-9]{9}B[0-9]{2}$" },
-								{ "pattern": "^(PL)[0-9]{10}$" },
-								{ "pattern": "^(PT)[0-9]{9}$" },
-								{ "pattern": "^(RO)[0-9]{2,10}$" },
-								{ "pattern": "^(SE)[0-9]{12}$" },
-								{ "pattern": "^(SI)[0-9]{8}$" },
-								{ "pattern": "^(SK)[0-9]{10}$" },
-								{ "$ref": "#/definitions/empty" }
-							]
-						},
-						"trademarkNumber": {
-							"pattern": "^[0-9]*$",
-							"maxLength": 9,
-							"oneOf": [
-								{ "minLength": 9 },
-								{ "$ref": "#/definitions/empty" }
-							]
+						"fr": {
+							"type": "object",
+							"properties": {
+								"sirenSiret": {
+									"type": "string",
+									"pattern": "^[0-9]*$",
+									"anyOf": [
+										{ "minLength": 9, "maxLength": 9 },
+										{ "minLength": 14, "maxLength": 14 },
+										{ "$ref": "#/definitions/empty" }
+									]
+								},
+								"registrantType": {
+									"type": "string",
+									"enum": [ "individual", "organization" ]
+								},
+								"registrantVatId": {
+									"type": "string",
+									"anyOf": [
+										{ "pattern": "^(AT)U[0-9]{8}$" },
+										{ "pattern": "^(BE)0[0-9]{9}$" },
+										{ "pattern": "^(BG)[0-9]{9,10}$" },
+										{ "pattern": "^(CY)[0-9]{8}L$" },
+										{ "pattern": "^(CZ)[0-9]{8,10}$" },
+										{ "pattern": "^(DE)[0-9]{9}$" },
+										{ "pattern": "^(DK)[0-9]{8}$" },
+										{ "pattern": "^(EE)[0-9]{9}$" },
+										{ "pattern": "^(EL|GR)[0-9]{9}$" },
+										{ "pattern": "^(ES)[0-9A-Z][0-9]{7}[0-9A-Z]$" },
+										{ "pattern": "^(FI)[0-9]{8}$" },
+										{ "pattern": "^(FR)[0-9A-Z]{2}[0-9]{9}$" },
+										{ "pattern": "^(GB)([0-9]{9}([0-9]{3})?|(GD|HA)[0-9]{3})$" },
+										{ "pattern": "^(HR)[0-9]{11}$" },
+										{ "pattern": "^(HU)[0-9]{8}$" },
+										{ "pattern": "^(IE)([0-9][0-9A-Z+*][0-9]{5}[A-Z]|[0-9]{7}[0-9A-Z]{1,2})$" },
+										{ "pattern": "^(IT)[0-9]{11}$" },
+										{ "pattern": "^(LT)[0-9]{9}([0-9]{3})?$" },
+										{ "pattern": "^(LU)[0-9]{8}$" },
+										{ "pattern": "^(LV)[0-9]{11}$" },
+										{ "pattern": "^(MT)[0-9]{8}$" },
+										{ "pattern": "^(NL)[0-9]{9}B[0-9]{2}$" },
+										{ "pattern": "^(PL)[0-9]{10}$" },
+										{ "pattern": "^(PT)[0-9]{9}$" },
+										{ "pattern": "^(RO)[0-9]{2,10}$" },
+										{ "pattern": "^(SE)[0-9]{12}$" },
+										{ "pattern": "^(SI)[0-9]{8}$" },
+										{ "pattern": "^(SK)[0-9]{10}$" },
+										{ "$ref": "#/definitions/empty" }
+									]
+								},
+								"trademarkNumber": {
+									"pattern": "^[0-9]*$",
+									"maxLength": 9,
+									"oneOf": [
+										{ "minLength": 9 },
+										{ "$ref": "#/definitions/empty" }
+									]
+								}
+							},
+							"required": [ "registrantType" ]
 						}
-					},
-					"required": [ "registrantType" ]
+					}
 				}
-			},
-			"required": [ "extra" ]
+			}
 		}
 	],
 	"note": "We'll want to fetch this through the API, where wpcom.undocumented already has `mapKeysRecursively()` & `camelCase()`"

--- a/client/components/domains/registrant-extra-info/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/fr-validate-contact-details.js
@@ -59,7 +59,7 @@ function ruleNameFromMessage( message ) {
 }
 
 /*
- * @returns errors by field, like: { 'extra.field: name, errors: [ string ] }
+ * @returns errors by field, like: { 'extra.fr.field: name, errors: [ string ] }
  */
 export default function validateContactDetails( contactDetails ) {
 	// Populate validate.errors
@@ -75,7 +75,7 @@ export default function validateContactDetails( contactDetails ) {
 				.slice( 1 );
 
 			// In order to capture the relationship between the organization
-			// and extra.individualType fields, the rule ends up in the root
+			// and extra.fr.individualType fields, the rule ends up in the root
 			// path.
 			// We've only got one such case at the moment, so we can insert this
 			// hack, but if we need to tell multiple such rules apart, we're

--- a/client/components/domains/registrant-extra-info/test/ca-form.js
+++ b/client/components/domains/registrant-extra-info/test/ca-form.js
@@ -26,6 +26,7 @@ describe( 'ca-form', () => {
 		const testProps = {
 			...mockProps,
 			contactDetails: {},
+			ccTldDetails: {},
 		};
 
 		shallow( <RegistrantExtraInfoCaForm { ...testProps } /> );

--- a/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
@@ -25,18 +25,25 @@ describe( 'validateContactDetails', () => {
 		email: 'test@example.com',
 		phone: '+1.2506382995',
 		extra: {
-			registrantType: 'individual',
-			sirenSiret: '123456789',
-			registrantVatId: 'FRXX123456789',
-			trademarkNumber: '123456789',
+			fr: {
+				registrantType: 'individual',
+				sirenSiret: '123456789',
+				registrantVatId: 'FRXX123456789',
+				trademarkNumber: '123456789',
+			},
+			uk: {
+				registrantType: 'fake_stuff',
+			},
 		},
 	};
 
 	function contactWithExtraProperty( property, value ) {
 		return Object.assign( {}, contactDetails, {
 			extra: {
-				...contactDetails.extra,
-				[ property ]: value,
+				fr: {
+					...contactDetails.extra.fr,
+					[ property ]: value,
+				},
 			},
 		} );
 	}
@@ -76,7 +83,7 @@ describe( 'validateContactDetails', () => {
 	describe( 'organization', () => {
 		describe( 'with registrantType: organization', () => {
 			const organizationDetails = Object.assign( {}, contactDetails, {
-				extra: { registrantType: 'organization' },
+				extra: { fr: { registrantType: 'organization' } },
 			} );
 
 			test( 'should accept an organization', () => {
@@ -118,7 +125,7 @@ describe( 'validateContactDetails', () => {
 
 		describe( 'with registrantType: individual', () => {
 			const individualDetails = Object.assign( {}, contactDetails, {
-				extra: { registrantType: 'individual' },
+				extra: { fr: { registrantType: 'individual' } },
 			} );
 
 			test( 'should accept missing organization', () => {
@@ -163,11 +170,12 @@ describe( 'validateContactDetails', () => {
 			];
 
 			badSiretNumbers.forEach( ( [ sirenSiret ] ) => {
-				const testDetails = Object.assign( {}, contactDetails, { extra: { sirenSiret } } );
+				const testDetails = Object.assign( {}, contactDetails, { extra: { fr: { sirenSiret } } } );
 
 				const result = validateContactDetails( testDetails );
 				expect( result, `expected to reject '${ sirenSiret }'` )
 					.to.have.property( 'extra' )
+					.with.property( 'fr' )
 					.with.property( 'sirenSiret' );
 			} );
 		} );
@@ -182,7 +190,7 @@ describe( 'validateContactDetails', () => {
 		test( 'should accept a missing value', () => {
 			const testDetails = {
 				...contactDetails,
-				extra: omit( contactDetails.extra, 'sirenSiret' ),
+				extra: { fr: omit( contactDetails.extra.fr, 'sirenSiret' ) },
 			};
 
 			expect( validateContactDetails( testDetails ) ).to.eql( {} );
@@ -246,11 +254,14 @@ describe( 'validateContactDetails', () => {
 
 		test( 'should reject SIRET for VAT', () => {
 			realSiretNumbers.forEach( ( [ registrantVatId ] ) => {
-				const testDetails = Object.assign( {}, contactDetails, { extra: { registrantVatId } } );
+				const testDetails = Object.assign( {}, contactDetails, {
+					extra: { fr: { registrantVatId } },
+				} );
 
 				const result = validateContactDetails( testDetails );
 				expect( result, `expected to reject '${ registrantVatId }'` )
 					.to.have.property( 'extra' )
+					.with.property( 'fr' )
 					.with.property( 'registrantVatId' );
 			} );
 		} );
@@ -265,7 +276,7 @@ describe( 'validateContactDetails', () => {
 		test( 'should accept a missing value', () => {
 			const testDetails = {
 				...contactDetails,
-				extra: omit( contactDetails.extra, 'registrantVatId' ),
+				extra: { fr: omit( contactDetails.extra.fr, 'registrantVatId' ) },
 			};
 
 			expect( validateContactDetails( testDetails ) ).to.eql( {} );
@@ -288,11 +299,15 @@ describe( 'validateContactDetails', () => {
 
 		test( 'should reject our bad SIRET examples', () => {
 			badTrademarkNumbers.forEach( ( [ trademarkNumber ] ) => {
-				const testDetails = Object.assign( {}, contactDetails, { extra: { trademarkNumber } } );
+				const testDetails = Object.assign( {}, contactDetails, {
+					extra: { fr: { trademarkNumber } },
+				} );
 
 				const result = validateContactDetails( testDetails );
+
 				expect( result, `expected to reject '${ trademarkNumber }'` )
 					.to.have.property( 'extra' )
+					.with.property( 'fr' )
 					.with.property( 'trademarkNumber' );
 			} );
 		} );

--- a/client/components/domains/registrant-extra-info/test/uk-form.js
+++ b/client/components/domains/registrant-extra-info/test/uk-form.js
@@ -13,6 +13,7 @@ import { RegistrantExtraInfoUkForm } from '../uk-form';
 import FormInputValidation from 'components/forms/form-input-validation';
 
 const mockProps = {
+	contactDetails: {},
 	step: 'uk',
 	translate: identity,
 	updateContactDetailsCache: identity,
@@ -23,10 +24,12 @@ describe( 'uk-form', () => {
 		test( 'should render the correct registation errors', () => {
 			const testProps = {
 				...mockProps,
-				contactDetails: { extra: { registrantType: 'LLP' } },
+				ccTldDetails: { registrantType: 'LLP' },
 				validationErrors: {
 					extra: {
-						registrationNumber: [ 'testErrorCode' ],
+						uk: {
+							registrationNumber: [ 'testErrorCode' ],
+						},
 					},
 				},
 			};
@@ -36,14 +39,16 @@ describe( 'uk-form', () => {
 			expect( error.props() ).toHaveProperty( 'text', 'There was a problem with this field.' );
 		} );
 
-		test( 'should render multiple registation errors', () => {
+		test( 'should render multiple registration errors', () => {
 			const testProps = {
 				...mockProps,
-				contactDetails: { extra: { registrantType: 'LLP' } },
+				ccTldDetails: { registrantType: 'LLP' },
 				validationErrors: {
 					extra: {
-						registrationNumber: [ 'testErrorCode', 'testErrorCode' ],
-						tradingName: [ 'testErrorCode' ],
+						uk: {
+							registrationNumber: [ 'testErrorCode', 'testErrorCode' ],
+							tradingName: [ 'testErrorCode' ],
+						},
 					},
 				},
 			};
@@ -56,10 +61,12 @@ describe( 'uk-form', () => {
 		test( 'should convert error code to user-facing string', () => {
 			const testProps = {
 				...mockProps,
-				contactDetails: { extra: { registrantType: 'LLP' } },
+				ccTldDetails: { registrantType: 'LLP' },
 				validationErrors: {
 					extra: {
-						registrationNumber: [ 'dotukRegistrationNumberFormat' ],
+						uk: {
+							registrationNumber: [ 'dotukRegistrationNumberFormat' ],
+						},
 					},
 				},
 			};
@@ -75,10 +82,12 @@ describe( 'uk-form', () => {
 		test( 'Should disable submit button with validation errors', () => {
 			const testProps = {
 				...mockProps,
-				contactDetails: { extra: { registrantType: 'LLP' } },
+				ccTldDetails: { registrantType: 'LLP' },
 				validationErrors: {
 					extra: {
-						registrationNumber: [ 'dotukRegistrationNumberFormat' ],
+						uk: {
+							registrationNumber: [ 'dotukRegistrationNumberFormat' ],
+						},
 					},
 				},
 			};
@@ -95,10 +104,12 @@ describe( 'uk-form', () => {
 		test( 'Should not disable submit button with irrelevant validation errors', () => {
 			const testProps = {
 				...mockProps,
-				contactDetails: { extra: { registrantType: 'IND' } },
+				ccTldDetails: { registrantType: 'IND' },
 				validationErrors: {
 					extra: {
-						registrationNumber: [ 'dotukRegistrationNumberFormat' ],
+						uk: {
+							registrationNumber: [ 'dotukRegistrationNumberFormat' ],
+						},
 					},
 				},
 			};

--- a/client/components/domains/registrant-extra-info/test/uk-schema.json
+++ b/client/components/domains/registrant-extra-info/test/uk-schema.json
@@ -6,89 +6,101 @@
 	"properties": {
 		"extra": {
 			"type": "object",
-			"allOf": [
-				{
-					"errorCode": "dotukRegistrantTypeRequiresRegistrationNumber",
-					"errorField": "extra.registrationNumber",
-					"anyOf": [
+			"properties": {
+				"uk": {
+					"type": "object",
+					"allOf": [
+						{
+							"errorMessage": "A registration number is required for this registrant type.",
+							"errorCode": "dotukRegistrantTypeRequiresRegistrationNumber",
+							"errorField": "extra.uk.registrationNumber",
+							"anyOf": [
+								{
+									"properties": {
+										"registrationNumber": {
+											"minLength": 1
+										}
+									},
+									"required": [
+										"registrationNumber"
+									]
+								},
+								{
+									"not": {
+										"properties": {
+											"registrantType": {
+												"enum": [
+													"IP",
+													"LLP",
+													"LTD",
+													"PLC",
+													"RCHAR",
+													"SCH"
+												]
+											}
+										}
+									}
+								}
+							]
+						},
+						{
+							"errorMessage": "A trading name is required for this registrant type.",
+							"errorCode": "dotukRegistrantTypeRequiresTradingName",
+							"errorField": "extra.uk.tradingName",
+							"anyOf": [
+								{
+									"properties": {
+										"tradingName": {
+											"minLength": 1
+										}
+									},
+									"required": [
+										"tradingName"
+									]
+								},
+								{
+									"not": {
+										"properties": {
+											"registrantType": {
+												"enum": [
+													"LTD",
+													"PLC",
+													"LLP",
+													"IP",
+													"RCHAR",
+													"FCORP",
+													"OTHER",
+													"FOTHER",
+													"STRA"
+												]
+											}
+										}
+									}
+								}
+							]
+						},
 						{
 							"properties": {
 								"registrationNumber": {
-									"minLength": 1
-								}
-							},
-							"required": [
-								"registrationNumber"
-							]
-						},
-						{
-							"not": {
-								"properties": {
-									"registrantType": {
-										"enum": [
-											"IP",
-											"LLP",
-											"LTD",
-											"PLC",
-											"RCHAR",
-											"SCH"
-										]
-									}
+									"errorMessage": "A Company Registration Number is 8 numerals, or 2 letters followed by 6 numerals (e.g. AB123456 or 12345678).",
+									"errorCode": "dotukRegistrationNumberFormat",
+									"pattern": "^[a-zA-Z0-9]{2}[0-9]{6}$"
 								}
 							}
 						}
+					],
+					"required": [
+						"registrantType"
 					]
-				},
-				{
-					"errorCode": "dotukRegistrantTypeRequiresTradingName",
-					"errorField": "extra.tradingName",
-					"anyOf": [
-						{
-							"properties": {
-								"tradingName": {
-									"minLength": 1
-								}
-							},
-							"required": [
-								"tradingName"
-							]
-						},
-						{
-							"not": {
-								"properties": {
-									"registrantType": {
-										"enum": [
-											"LTD",
-											"PLC",
-											"LLP",
-											"IP",
-											"RCHAR",
-											"FCORP",
-											"OTHER",
-											"FOTHER",
-											"STRA"
-										]
-									}
-								}
-							}
-						}
-					]
-				},
-				{
-					"properties": {
-						"registrationNumber": {
-							"errorCode": "dotukRegistrationNumberFormat",
-							"pattern": "^[a-zA-Z0-9]{2}[0-9]{6}$"
-						}
-					}
 				}
-			],
+			},
 			"required": [
-				"registrantType"
+				"uk"
 			]
 		},
 		"organization": {
 			"type": "string",
+			"errorMessage": "Organization name must have at least 4 characters.",
 			"errorCode": "dotukOrganizationLength",
 			"anyOf": [
 				{
@@ -101,6 +113,7 @@
 		},
 		"address1": {
 			"type": "string",
+			"errorMessage": "First address field requires at least 1 non-numeric character.",
 			"errorCode": "dotukAddress1NonNumeric",
 			"not": {
 				"pattern": "^[0-9]*$"
@@ -109,6 +122,7 @@
 	},
 	"patternProperties": {
 		"^address": {
+			"errorMessage": "Nominet does not permit PO Boxes for .uk domains.",
 			"errorCode": "dotukNoPoBox",
 			"not": {
 				"pattern": "\\b[Pp](?:[Oo][Ss][Tt])?\\.? ?[Oo](?:[Ff][Ff][Ii][Cc][Ee])?\\.? ?[Bb](?:[Oo][Xx])? ?#?[0-9]{1,5}"

--- a/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
+++ b/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
@@ -85,7 +85,9 @@ describe( 'uk-form validation', () => {
 				).dive();
 
 				expect( wrapper.props() ).toHaveProperty( 'validationErrors', {
-					extra: { registrationNumber: [ 'dotukRegistrantTypeRequiresRegistrationNumber' ] },
+					extra: {
+						uk: { registrationNumber: [ 'dotukRegistrantTypeRequiresRegistrationNumber' ] },
+					},
 				} );
 			} );
 		} );
@@ -165,7 +167,7 @@ describe( 'uk-form validation', () => {
 				).dive();
 
 				expect( wrapper.props() ).toHaveProperty( 'validationErrors', {
-					extra: { tradingName: [ 'dotukRegistrantTypeRequiresTradingName' ] },
+					extra: { uk: { tradingName: [ 'dotukRegistrantTypeRequiresTradingName' ] } },
 				} );
 			} );
 		} );

--- a/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
+++ b/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
@@ -68,8 +68,10 @@ describe( 'uk-form validation', () => {
 		test( 'should be required for some values of registrantType', () => {
 			const testContactDetails = {
 				extra: {
-					registrantType: 'LLP',
-					tradingName: validTradingName,
+					uk: {
+						registrantType: 'LLP',
+						tradingName: validTradingName,
+					},
 				},
 			};
 
@@ -77,7 +79,8 @@ describe( 'uk-form validation', () => {
 				const wrapper = shallow(
 					<ValidatedRegistrantExtraInfoUkForm
 						{ ...mockProps }
-						contactDetails={ set( testContactDetails, 'extra.registrantType', registrantType ) }
+						contactDetails={ set( testContactDetails, 'extra.uk.registrantType', registrantType ) }
+						ccTldDetails={ { registrantType } }
 					/>
 				).dive();
 
@@ -90,8 +93,10 @@ describe( 'uk-form validation', () => {
 		test( 'should not be required for other values of registrantType', () => {
 			const testContactDetails = {
 				extra: {
-					registrantType: 'LLP',
-					tradingName: validTradingName,
+					uk: {
+						registrantType: 'LLP',
+						tradingName: validTradingName,
+					},
 				},
 			};
 
@@ -99,7 +104,8 @@ describe( 'uk-form validation', () => {
 				const wrapper = shallow(
 					<ValidatedRegistrantExtraInfoUkForm
 						{ ...mockProps }
-						contactDetails={ set( testContactDetails, 'extra.registrantType', registrantType ) }
+						contactDetails={ set( testContactDetails, 'extra.uk.registrantType', registrantType ) }
+						ccTldDetails={ { registrantType } }
 					/>
 				).dive();
 
@@ -110,8 +116,10 @@ describe( 'uk-form validation', () => {
 		test( 'should reject bad formats', () => {
 			const testContactDetails = {
 				extra: {
-					registrantType: 'LLP',
-					tradingName: validTradingName,
+					uk: {
+						registrantType: 'LLP',
+						tradingName: validTradingName,
+					},
 				},
 			};
 
@@ -123,13 +131,14 @@ describe( 'uk-form validation', () => {
 						{ ...mockProps }
 						contactDetails={ set(
 							testContactDetails,
-							'extra.registrationNumber',
+							'extra.uk.registrationNumber',
 							registrationNumber
 						) }
+						ccTldDetails={ { registrationNumber } }
 					/>
 				).dive();
 
-				expect( wrapper.props() ).toHaveProperty( 'validationErrors.extra.registrationNumber' );
+				expect( wrapper.props() ).toHaveProperty( 'validationErrors.extra.uk.registrationNumber' );
 			} );
 		} );
 	} );
@@ -138,9 +147,11 @@ describe( 'uk-form validation', () => {
 		test( 'should be required for some values of registrantType', () => {
 			const testContactDetails = {
 				extra: {
-					registrantType: 'LLP',
-					registrationNumber: validRegistrationNumber,
-					tradingName: '',
+					uk: {
+						registrantType: 'LLP',
+						registrationNumber: validRegistrationNumber,
+						tradingName: '',
+					},
 				},
 			};
 
@@ -148,7 +159,8 @@ describe( 'uk-form validation', () => {
 				const wrapper = shallow(
 					<ValidatedRegistrantExtraInfoUkForm
 						{ ...mockProps }
-						contactDetails={ set( testContactDetails, 'extra.registrantType', registrantType ) }
+						contactDetails={ set( testContactDetails, 'extra.uk.registrantType', registrantType ) }
+						ccTldDetails={ { registrantType } }
 					/>
 				).dive();
 
@@ -162,9 +174,11 @@ describe( 'uk-form validation', () => {
 			difference( allRegistrantTypes, needsTradingName ).forEach( registrantType => {
 				const testContactDetails = {
 					extra: {
-						registrantType,
-						registrationNumber: validRegistrationNumber,
-						tradingName: '',
+						uk: {
+							registrantType,
+							registrationNumber: validRegistrationNumber,
+							tradingName: '',
+						},
 					},
 				};
 
@@ -172,6 +186,7 @@ describe( 'uk-form validation', () => {
 					<ValidatedRegistrantExtraInfoUkForm
 						{ ...mockProps }
 						contactDetails={ testContactDetails }
+						ccTldDetails={ testContactDetails.extra.uk }
 					/>
 				).dive();
 

--- a/client/components/domains/registrant-extra-info/uk-form.jsx
+++ b/client/components/domains/registrant-extra-info/uk-form.jsx
@@ -31,6 +31,7 @@ const defaultValues = {
 export class RegistrantExtraInfoUkForm extends React.PureComponent {
 	static propTypes = {
 		contactDetails: PropTypes.object.isRequired,
+		ccTldDetails: PropTypes.object.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -79,7 +80,7 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 		// Add defaults to redux state to make accepting default values work.
 		const neededRequiredDetails = difference(
 			[ 'registrantType' ],
-			keys( this.props.contactDetails.extra )
+			keys( this.props.ccTldDetails )
 		);
 
 		// Bail early as we already have the details from a previous purchase.
@@ -88,13 +89,17 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 		}
 
 		this.props.updateContactDetailsCache( {
-			extra: pick( defaultValues, neededRequiredDetails ),
+			extra: {
+				uk: pick( defaultValues, neededRequiredDetails ),
+			},
 		} );
 	}
 
 	handleChangeEvent = event => {
 		this.props.updateContactDetailsCache( {
-			extra: { [ camelCase( event.target.id ) ]: event.target.value },
+			extra: {
+				uk: { [ camelCase( event.target.id ) ]: event.target.value },
+			},
 		} );
 	};
 
@@ -110,9 +115,13 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 	}
 
 	renderTradingNameField() {
-		const { contactDetails, translate } = this.props;
-		const tradingName = get( contactDetails, [ 'extra', 'tradingName' ], '' );
-		const tradingNameErrors = get( this.props.validationErrors, [ 'extra', 'tradingName' ], [] );
+		const { ccTldDetails, translate } = this.props;
+		const tradingName = get( ccTldDetails, 'tradingName', '' );
+		const tradingNameErrors = get(
+			this.props.validationErrors,
+			[ 'extra', 'uk', 'tradingName' ],
+			[]
+		);
 		const isError = ! isEmpty( tradingNameErrors );
 
 		return (
@@ -138,11 +147,11 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 	}
 
 	renderRegistrationNumberField() {
-		const { contactDetails, translate } = this.props;
-		const registrationNumber = get( contactDetails, [ 'extra', 'registrationNumber' ], '' );
+		const { ccTldDetails, translate } = this.props;
+		const registrationNumber = get( ccTldDetails, 'registrationNumber', '' );
 		const registrationNumberErrors = get(
 			this.props.validationErrors,
-			[ 'extra', 'registrationNumber' ],
+			[ 'extra', 'uk', 'registrationNumber' ],
 			[]
 		);
 
@@ -194,14 +203,14 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 		const { translate, validationErrors } = this.props;
 		const { registrantType } = {
 			...defaultValues,
-			...this.props.contactDetails.extra,
+			...this.props.ccTldDetails,
 		};
 
 		const relevantExtraFields = filter( [
 			this.isTradingNameRequired( registrantType ) && 'tradingName',
 			this.isRegistrationNumberRequired( registrantType ) && 'registrationNumber',
 		] );
-		const relevantErrors = pick( ( validationErrors || {} ).extra, relevantExtraFields );
+		const relevantErrors = pick( ( validationErrors || {} ).extra.uk, relevantExtraFields );
 		const isValid = isEmpty( relevantErrors );
 
 		return (
@@ -243,8 +252,12 @@ export const ValidatedRegistrantExtraInfoUkForm = WithContactDetailsValidation(
 );
 
 export default connect(
-	state => ( {
-		contactDetails: getContactDetailsCache( state ),
-	} ),
+	state => {
+		const contactDetails = getContactDetailsCache( state );
+		return {
+			contactDetails,
+			ccTldDetails: get( contactDetails, 'extra.uk', {} ),
+		};
+	},
 	{ updateContactDetailsCache }
 )( localize( ValidatedRegistrantExtraInfoUkForm ) );

--- a/client/components/domains/registrant-extra-info/uk-form.jsx
+++ b/client/components/domains/registrant-extra-info/uk-form.jsx
@@ -210,7 +210,7 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 			this.isTradingNameRequired( registrantType ) && 'tradingName',
 			this.isRegistrationNumberRequired( registrantType ) && 'registrationNumber',
 		] );
-		const relevantErrors = pick( ( validationErrors || {} ).extra.uk, relevantExtraFields );
+		const relevantErrors = pick( get( validationErrors, 'extra.uk', {} ), relevantExtraFields );
 		const isValid = isEmpty( relevantErrors );
 
 		return (

--- a/client/components/domains/registrant-extra-info/uk-schema.json
+++ b/client/components/domains/registrant-extra-info/uk-schema.json
@@ -6,86 +6,91 @@
 	"properties": {
 		"extra": {
 			"type": "object",
-			"allOf": [
-				{
-					"errorCode": "dotukRegistrantTypeRequiresRegistrationNumber",
-					"errorField": "extra.registrationNumber",
-					"anyOf": [
+			"properties": {
+				"uk": {
+					"type": "object",
+					"allOf": [
+						{
+							"errorCode": "dotukRegistrantTypeRequiresRegistrationNumber",
+							"errorField": "extra.registrationNumber",
+							"anyOf": [
+								{
+									"properties": {
+										"registrationNumber": {
+											"minLength": 1
+										}
+									},
+									"required": [
+										"registrationNumber"
+									]
+								},
+								{
+									"not": {
+										"properties": {
+											"registrantType": {
+												"enum": [
+													"IP",
+													"LLP",
+													"LTD",
+													"PLC",
+													"RCHAR",
+													"SCH"
+												]
+											}
+										}
+									}
+								}
+							]
+						},
+						{
+							"errorCode": "dotukRegistrantTypeRequiresTradingName",
+							"errorField": "extra.tradingName",
+							"anyOf": [
+								{
+									"properties": {
+										"tradingName": {
+											"minLength": 1
+										}
+									},
+								"required": [
+										"tradingName"
+									]
+								},
+								{
+									"not": {
+										"properties": {
+											"registrantType": {
+												"enum": [
+													"LTD",
+													"PLC",
+													"LLP",
+													"IP",
+													"RCHAR",
+													"FCORP",
+													"OTHER",
+													"FOTHER",
+													"STRA"
+												]
+											}
+										}
+									}
+								}
+							]
+						},
 						{
 							"properties": {
 								"registrationNumber": {
-									"minLength": 1
-								}
-							},
-							"required": [
-								"registrationNumber"
-							]
-						},
-						{
-							"not": {
-								"properties": {
-									"registrantType": {
-										"enum": [
-											"IP",
-											"LLP",
-											"LTD",
-											"PLC",
-											"RCHAR",
-											"SCH"
-										]
-									}
+									"errorCode": "dotukRegistrationNumberFormat",
+									"pattern": "^[a-zA-Z0-9]{2}[0-9]{6}$"
 								}
 							}
 						}
+					],
+					"required": [
+						"registrantType"
 					]
-				},
-				{
-					"errorCode": "dotukRegistrantTypeRequiresTradingName",
-					"errorField": "extra.tradingName",
-					"anyOf": [
-						{
-							"properties": {
-								"tradingName": {
-									"minLength": 1
-								}
-							},
-						"required": [
-								"tradingName"
-							]
-						},
-						{
-							"not": {
-								"properties": {
-									"registrantType": {
-										"enum": [
-											"LTD",
-											"PLC",
-											"LLP",
-											"IP",
-											"RCHAR",
-											"FCORP",
-											"OTHER",
-											"FOTHER",
-											"STRA"
-										]
-									}
-								}
-							}
-						}
-					]
-				},
-				{
-					"properties": {
-						"registrationNumber": {
-							"errorCode": "dotukRegistrationNumberFormat",
-							"pattern": "^[a-zA-Z0-9]{2}[0-9]{6}$"
-						}
-					}
 				}
-			],
-			"required": [
-				"registrantType"
-			]
+			}
 		},
 		"organization": {
 			"minimumLength": 4

--- a/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
+++ b/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
@@ -121,7 +121,7 @@ export default function WithContactDetailsValidation( tld, WrappedComponent ) {
 			}
 
 			// This is pretty fast, but is a candidate for memoization
-			debug( 'validating contactDetails' );
+			debug( 'validating contactDetails', this.props.contactDetails );
 			let isValid = false;
 			try {
 				isValid = this.validate( this.props.contactDetails );
@@ -154,6 +154,7 @@ export default function WithContactDetailsValidation( tld, WrappedComponent ) {
 
 			// TODO: error codes => localized strings
 			const result = formatIMJVErrors( this.validate.errors, this.props.validationSchema );
+			debug( 'validation errors:', result );
 
 			return result;
 		}


### PR DESCRIPTION
Right now we jumble all collected ccTLD data together in one big meta field. That bad — we get data collisions among other issues.

This change normalizes the structure by TLD to eliminate those concerns.

See the broken aspect of #22097 for background.

Backend companion is D10103-code.