### PR TITLE
Rewind Credentials: Send failures to Happychat

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -4,16 +4,16 @@
  */
 import i18n from 'i18n-calypso';
 import page from 'page';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { getHappychatAuth } from 'state/happychat/utils';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import isHappychatConnectionUninitialized from 'state/happychat/selectors/is-happychat-connection-uninitialized';
-import { initConnection } from 'state/happychat/connection/actions';
+import { initConnection, sendEvent } from 'state/happychat/connection/actions';
 import { openChat } from 'state/happychat/ui/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
@@ -116,72 +116,105 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 	};
 
 	const { translate } = i18n;
-	const [ errorMessage, extraOptions ] = get(
-		{
-			service_unavailable: () => [
+	const baseOptions = { duration: 4000, id: action.noticeId };
+	const announce = ( message, options ) =>
+		dispatch( errorNotice( message, options ? { ...baseOptions, ...options } : baseOptions ) );
+	const spreadHappiness = message => {
+		dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_rewind_creds_update_failure', {
+					siteId: action.siteId,
+					error: error.error,
+					statusCode: error.statusCode,
+					host: action.host,
+					kpri: action.krpi ? 'provided but [omitted here]' : 'not provided',
+					pass: action.pass ? 'provided but [omitted here]' : 'not provided',
+					path: action.path,
+					port: action.port,
+					protocol: action.protocol,
+					user: action.user,
+				} ),
+				sendEvent( message )
+			)
+		);
+	};
+
+	switch ( error.error ) {
+		case 'service_unavailable':
+			announce(
 				translate(
-					"Our service isn't working at the moment. " +
-						"We'll get it up and running as fast as we can, so please try again later."
+					"Our service isn't working at the moment. We'll get it up and " +
+						'running as fast as we can, so please try again later.'
 				),
-				{
-					button: translate( 'Try again' ),
-					onClick: () => dispatch( action ),
-				},
-			],
-			missing_args: () => [
-				translate( 'Something seems to be missing — please fill out all the required fields.' ),
-				null,
-			],
-			invalid_args: () => [
+				{ button: translate( 'Try again' ), onClick: () => dispatch( action ) }
+			);
+			spreadHappiness(
+				'Rewind Credentials: update request failed on timeout (could be us or remote site)'
+			);
+			break;
+
+		case 'missing_args':
+			announce(
+				translate( 'Something seems to be missing — please fill out all the required fields.' )
+			);
+			spreadHappiness( 'Rewind Credentials: missing API args (contact a dev)' );
+			break;
+
+		case 'invalid_args':
+			announce(
 				translate(
-					'The information you entered seems to be incorrect. ' +
-						"Let's take another look to ensure everything is in the right place."
-				),
-				null,
-			],
-			invalid_credentials: () => [
+					"The information you entered seems to be incorrect. Let's take " +
+						'another look to ensure everything is in the right place.'
+				)
+			);
+			spreadHappiness( 'Rewind Credentials: invalid API args (contact a dev)' );
+			break;
+
+		case 'invalid_credentials':
+			announce(
 				translate(
-					"Oops! We couldn't connect to your site with these credentials " +
-						"— let's give it another try."
-				),
-				null,
-			],
-			invalid_wordpress_path: () => [
+					"Oops! We couldn't connect to your site with these credentials — let's give it another try."
+				)
+			);
+			spreadHappiness( 'Rewind Credentials: invalid credentials' );
+			break;
+
+		case 'invalid_wordpress_path':
+			announce(
 				translate(
-					'We looked for `wp-config.php` in the WordPress installation path you provided ' +
-						"but couldn't find it."
+					'We looked for `wp-config.php` in the WordPress installation ' +
+						"path you provided but couldn't find it."
 				),
-				{
-					button: translate( 'Get help' ),
-					onClick: getHelp,
-				},
-			],
-			read_only_install: () => [
+				{ button: translate( 'Get help' ), onClick: getHelp }
+			);
+			spreadHappiness( "Rewind Credentials: can't find WordPress installation files" );
+			break;
+
+		case 'read_only_install':
+			announce(
 				translate(
 					'It looks like your server is read-only. ' +
 						'To create backups and rewind your site, we need permission to write to your server.'
 				),
-				{
-					button: translate( 'Get help' ),
-					onClick: getHelp,
-				},
-			],
-			unreachable_path: () => [
+				{ button: translate( 'Get help' ), onClick: getHelp }
+			);
+			spreadHappiness( 'Rewind Credentials: creds only seem to provide read-only access' );
+			break;
+
+		case 'unreachable_path':
+			announce(
 				translate(
 					'We tried to access your WordPress installation through its publicly available URL, ' +
 						"but it didn't work. Please make sure the directory is accessible and try again."
-				),
-				null,
-			],
-		},
-		error.error,
-		() => [ translate( 'Error saving. Please check your credentials and try again.' ), null ]
-	)();
+				)
+			);
+			spreadHappiness( 'Rewind Credentials: creds might be for wrong site on right server' );
+			break;
 
-	const baseOptions = { duration: 4000, id: action.noticeId };
-	dispatch(
-		errorNotice( errorMessage, extraOptions ? { ...baseOptions, ...extraOptions } : baseOptions )
-	);
+		default:
+			announce( translate( 'Error saving. Please check your credentials and try again.' ) );
+			spreadHappiness( 'Rewind Credentials: unknown failure saving credentials' );
+	}
 };
 
 export default {


### PR DESCRIPTION
We are already doing a fair job reporting errors to credentials updates
to our customers but that can still leave Happiness Engineers in the
dark when someone starts a chat session.

In this PR we're additionally sending an event into Happychat on these
failures and additionally sending data to Tracks for the failures.

The Tracks data contains the submitted credentials information but it
doesn't reveal the password or private keys - it will show whether any
were supplied but won't reveal the supplied values.

There should be no visible changes to our customers with this but
operators in Happychat should start seeing alerts when a customer tries
to updat their Rewind credentials and the requests fail for some reason.

**Testing**

Load up the local Happychat environment and login with Jetpack skills.
Attempt to update credentials in Calypso in a way that will fail.
Start a chat session and look for the alerts of credential failures.

http://iscalypsofastyet.com/branch?branch=rewind/spread-credentials-happiness
```
Delta:
chunk     stat_size           parsed_size           gzip_size
build        +917 B  (+0.0%)       +767 B  (+0.0%)     +255 B  (+0.1%)
manifest       +0 B                  +0 B                -1 B  (-0.0%)
```