### PR TITLE
Build: Remove unused runtime directories after build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ Dockerfile
 .vscode
 /.babel-cache
 /build
+/build/.babel-client-cache
+/build/.babel-server-cache
 /cached-requests.json
 /node_modules
 /public/*.css

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN        true                                 && \
                /calypso/bin                        \
                /calypso/client                     \
                /calypso/build/.babel-server-cache  \
+               /calypso/build/.babel-client-cache  \
                                                 && \
            true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ ENV        COMMIT_SHA $commit_sha
 RUN        true                                 && \
            CALYPSO_ENV=production npm run build && \
            rm -r                                   \
+               ~/.npm                              \
                /calypso/assets                     \
                /calypso/bin                        \
                /calypso/client                     \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,11 @@ ENV        COMMIT_SHA $commit_sha
 
 RUN        true                                 && \
            CALYPSO_ENV=production npm run build && \
-           rm -r               \
-               /calypso/assets \
-               /calypso/bin    \
-               /calypso/client \
+           rm -r                                   \
+               /calypso/assets                     \
+               /calypso/bin                        \
+               /calypso/client                     \
+               /calypso/build/.babel-server-cache  \
                                                 && \
            true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,14 @@ RUN        npm ci --only=production
 ARG        commit_sha="(unknown)"
 ENV        COMMIT_SHA $commit_sha
 
-RUN        CALYPSO_ENV=production npm run build
+RUN        true                                 && \
+           CALYPSO_ENV=production npm run build && \
+           rm -r               \
+               /calypso/assets \
+               /calypso/bin    \
+               /calypso/client \
+                                                && \
+           true
 
 USER       nobody
 CMD        NODE_ENV=production node build/bundle.js


### PR DESCRIPTION
By removing directories that are not required at runtime for the app after build, we can save storage and bandwidth. Most notably, that can improve Calypso deploy time.

It can be surprisingly difficult to know what runtime dependencies are. After #19962, these are the directories that are apparently safe to clean. There are likely more. See https://github.com/Automattic/wp-calypso/pull/19962#issuecomment-349923547

## Testing

Does is build and run?

https://calypso.live/?branch=try/docker/clean-up-build

Look at obscure corners of Calypso not covered by e2e tests (devdocs and READMEs are a good place).

[E2E look good?](https://circleci.com/gh/Automattic/wp-e2e-tests-for-branches/12782)

