### PR TITLE
Jetpack connect: Strip any trailing "/wp-admin" from entered URL

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -211,6 +211,7 @@ export class JetpackConnectMain extends Component {
 		if ( url && url.substr( 0, 4 ) !== 'http' ) {
 			url = 'http://' + url;
 		}
+		url = url.replace( /wp-admin\/?$/, '' );
 		return untrailingslashit( url );
 	}
 

--- a/client/jetpack-connect/test/main.js
+++ b/client/jetpack-connect/test/main.js
@@ -34,6 +34,21 @@ jest.mock( 'lib/route/path', () => ( {
 } ) );
 
 describe( 'JetpackConnectMain', () => {
+	describe( 'cleanUrl', () => {
+		test( 'should prepare entered urls for network access', () => {
+			const cleanUrl = new JetpackConnectMain( REQUIRED_PROPS ).cleanUrl;
+			const results = [
+				{ actual: cleanUrl( 'example.com' ), expected: 'http://example.com' },
+				{ actual: cleanUrl( '  example.com   ' ), expected: 'http://example.com' },
+				{ actual: cleanUrl( 'http://example.com/' ), expected: 'http://example.com' },
+				{ actual: cleanUrl( 'eXAmple.com' ), expected: 'http://example.com' },
+				{ actual: cleanUrl( 'example.com/wp-admin' ), expected: 'http://example.com' },
+			];
+
+			results.forEach( ( { actual, expected } ) => expect( actual ).toBe( expected ) );
+		} );
+	} );
+
 	describe( 'makeSafeRedirectionFunction', () => {
 		const component = new JetpackConnectMain( REQUIRED_PROPS );
 

--- a/client/jetpack-connect/test/main.js
+++ b/client/jetpack-connect/test/main.js
@@ -38,6 +38,8 @@ describe( 'JetpackConnectMain', () => {
 		test( 'should prepare entered urls for network access', () => {
 			const cleanUrl = new JetpackConnectMain( REQUIRED_PROPS ).cleanUrl;
 			const results = [
+				{ input: '', expected: '' },
+				{ input: 'a', expected: 'http://a' },
 				{ input: 'example.com', expected: 'http://example.com' },
 				{ input: '  example.com   ', expected: 'http://example.com' },
 				{ input: 'http://example.com/', expected: 'http://example.com' },

--- a/client/jetpack-connect/test/main.js
+++ b/client/jetpack-connect/test/main.js
@@ -38,14 +38,14 @@ describe( 'JetpackConnectMain', () => {
 		test( 'should prepare entered urls for network access', () => {
 			const cleanUrl = new JetpackConnectMain( REQUIRED_PROPS ).cleanUrl;
 			const results = [
-				{ actual: cleanUrl( 'example.com' ), expected: 'http://example.com' },
-				{ actual: cleanUrl( '  example.com   ' ), expected: 'http://example.com' },
-				{ actual: cleanUrl( 'http://example.com/' ), expected: 'http://example.com' },
-				{ actual: cleanUrl( 'eXAmple.com' ), expected: 'http://example.com' },
-				{ actual: cleanUrl( 'example.com/wp-admin' ), expected: 'http://example.com' },
+				{ input: 'example.com', expected: 'http://example.com' },
+				{ input: '  example.com   ', expected: 'http://example.com' },
+				{ input: 'http://example.com/', expected: 'http://example.com' },
+				{ input: 'eXAmple.com', expected: 'http://example.com' },
+				{ input: 'example.com/wp-admin', expected: 'http://example.com' },
 			];
 
-			results.forEach( ( { actual, expected } ) => expect( actual ).toBe( expected ) );
+			results.forEach( ( { input, expected } ) => expect( cleanUrl( input ) ).toBe( expected ) );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #22211

This allows entering of a site URL including the wp-admin part for connecting a site from Calypso.

Possible risk is that this prevents sites installed in a /wp-admin subdir. Workaround for those sites is to connect from wp-admin.

Test as per #22211 