### PR TITLE
Plans: Setup A/B test for upgrade pricing display

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -94,4 +94,13 @@ export default {
 		defaultVariation: 'original',
 		allowExistingUsers: true,
 	},
+	upgradePricingDisplay: {
+		datestamp: '20180213',
+		variations: {
+			original: 50,
+			modified: 50,
+		},
+		defaultVariation: 'original',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -229,7 +229,13 @@ export const PLANS_LIST = {
 			FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP,
 			FEATURE_ALL_FREE_FEATURES,
 		],
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
+		getBillingTimeFrame: abtest => {
+			if ( abtest && abtest( 'upgradePricingDisplay' ) === 'modified' ) {
+				// Note: Don't make this translatable because it's only visible to English-language users
+				return '/month, billed annually';
+			}
+			return i18n.translate( 'per month, billed yearly' );
+		},
 	},
 
 	[ PLAN_PREMIUM ]: {
@@ -293,7 +299,13 @@ export const PLANS_LIST = {
 			FEATURE_PREMIUM_THEMES,
 			FEATURE_ALL_PERSONAL_FEATURES,
 		],
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
+		getBillingTimeFrame: abtest => {
+			if ( abtest && abtest( 'upgradePricingDisplay' ) === 'modified' ) {
+				// Note: Don't make this translatable because it's only visible to English-language users
+				return '/month, billed annually';
+			}
+			return i18n.translate( 'per month, billed yearly' );
+		},
 	},
 
 	[ PLAN_BUSINESS ]: {
@@ -323,6 +335,7 @@ export const PLANS_LIST = {
 					}
 				);
 			}
+			0;
 			return i18n.translate(
 				'{{strong}}Best for Small Business:{{/strong}} Power your' +
 					' business website with unlimited premium and business theme templates, Google Analytics support, unlimited' +
@@ -385,7 +398,13 @@ export const PLANS_LIST = {
 			FEATURE_UNLIMITED_STORAGE_SIGNUP,
 			FEATURE_ALL_PREMIUM_FEATURES,
 		],
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed yearly' ),
+		getBillingTimeFrame: abtest => {
+			if ( abtest && abtest( 'upgradePricingDisplay' ) === 'modified' ) {
+				// Note: Don't make this translatable because it's only visible to English-language users
+				return '/month, billed annually';
+			}
+			return i18n.translate( 'per month, billed yearly' );
+		},
 	},
 
 	[ PLAN_JETPACK_FREE ]: {
@@ -523,7 +542,13 @@ export const PLANS_LIST = {
 				FEATURE_CONCIERGE_SETUP,
 				FEATURE_ALL_PERSONAL_FEATURES,
 			] ),
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
+		getBillingTimeFrame: abtest => {
+			if ( abtest && abtest( 'upgradePricingDisplay' ) === 'modified' ) {
+				// Note: Don't make this translatable because it's only visible to English-language users
+				return '/month, billed annually';
+			}
+			return i18n.translate( 'per month, billed yearly' );
+		},
 		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
 	},
 
@@ -597,7 +622,13 @@ export const PLANS_LIST = {
 			FEATURE_PREMIUM_SUPPORT,
 			FEATURE_ALL_FREE_FEATURES,
 		],
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
+		getBillingTimeFrame: abtest => {
+			if ( abtest && abtest( 'upgradePricingDisplay' ) === 'modified' ) {
+				// Note: Don't make this translatable because it's only visible to English-language users
+				return '/month, billed annually';
+			}
+			return i18n.translate( 'per month, billed yearly' );
+		},
 		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
 	},
 
@@ -712,7 +743,13 @@ export const PLANS_LIST = {
 				FEATURE_SEARCH,
 				FEATURE_ALL_PREMIUM_FEATURES,
 			] ),
-		getBillingTimeFrame: () => i18n.translate( 'per month, billed monthly' ),
+		getBillingTimeFrame: abtest => {
+			if ( abtest && abtest( 'upgradePricingDisplay' ) === 'modified' ) {
+				// Note: Don't make this translatable because it's only visible to English-language users
+				return '/month, billed annually';
+			}
+			return i18n.translate( 'per month, billed yearly' );
+		},
 		getSignupBillingTimeFrame: () => i18n.translate( 'per month' ),
 	},
 };

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -70,7 +70,10 @@ class PlanFeaturesHeader extends Component {
 					<PlanIcon plan={ planType } />
 				</div>
 				<div className="plan-features__header-text">
-					<h4 className="plan-features__header-title">{ title }</h4>
+					<h4 className="plan-features__header-title">
+						{ title }
+						{ this.getCreditLabel() }
+					</h4>
 					{ this.getPlanFeaturesPrices() }
 					{ this.getBillingTimeframe() }
 				</div>
@@ -103,6 +106,31 @@ class PlanFeaturesHeader extends Component {
 				</div>
 			</div>
 		);
+	}
+
+	getCreditLabel() {
+		const {
+			available,
+			showModifiedPricingDisplay,
+			discountPrice,
+			rawPrice,
+			relatedMonthlyPlan,
+		} = this.props;
+
+		if ( ! showModifiedPricingDisplay || ! available || this.isPlanCurrent() ) {
+			return null;
+		}
+
+		if ( ! discountPrice && ! relatedMonthlyPlan ) {
+			return null;
+		}
+
+		if ( relatedMonthlyPlan && relatedMonthlyPlan.raw_price * 12 === rawPrice ) {
+			return null;
+		}
+
+		// Note: Don't make this translatable because it's only visible to English-language users
+		return <span className="plan-features__header-credit-label">Credit available</span>;
 	}
 
 	getDiscountTooltipMessage() {
@@ -184,6 +212,7 @@ class PlanFeaturesHeader extends Component {
 			relatedMonthlyPlan,
 			site,
 			isInSignup,
+			showModifiedPricingDisplay,
 		} = this.props;
 
 		if ( isPlaceholder && ! isInSignup ) {
@@ -221,7 +250,9 @@ class PlanFeaturesHeader extends Component {
 				<span className="plan-features__header-price-group">
 					<PlanPrice
 						currencyCode={ currencyCode }
-						rawPrice={ originalPrice }
+						rawPrice={
+							showModifiedPricingDisplay && this.isPlanCurrent() ? rawPrice : originalPrice
+						}
 						isInSignup={ isInSignup }
 						original
 					/>
@@ -272,6 +303,7 @@ class PlanFeaturesHeader extends Component {
 }
 
 PlanFeaturesHeader.propTypes = {
+	available: PropTypes.bool,
 	billingTimeFrame: PropTypes.string.isRequired,
 	current: PropTypes.bool,
 	onClick: PropTypes.func,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -686,7 +686,7 @@ export default connect(
 		const siteType = signupDependencies.designType;
 		const canPurchase = ! isPaid || isCurrentUserCurrentPlanOwner( state, selectedSiteId );
 		const showModifiedPricingDisplay =
-			!isInSignup && abtest('upgradePricingDisplay') === 'modified';
+			! isInSignup && abtest( 'upgradePricingDisplay' ) === 'modified';
 		let freePlanProperties = null;
 		let planProperties = compact(
 			map( plans, plan => {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -6,6 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
 import { map, reduce, noop, compact, filter, reject } from 'lodash';
 import page from 'page';
@@ -19,6 +20,7 @@ import PlanFeaturesHeader from './header';
 import PlanFeaturesItem from './item';
 import PlanFeaturesActions from './actions';
 import PlanFeaturesBottom from './bottom';
+import PlanFeaturesSummary from './summary';
 import {
 	isCurrentPlanPaid,
 	isCurrentSitePlan,
@@ -48,17 +50,21 @@ import Notice from 'components/notice';
 import SpinnerLine from 'components/spinner-line';
 import FoldableCard from 'components/foldable-card';
 import { recordTracksEvent } from 'state/analytics/actions';
+import formatCurrency from 'lib/format-currency';
 import { retargetViewPlans } from 'lib/analytics/ad-tracking';
-import { abtest } from 'lib/abtest';
+import { abtest, getABTestVariation } from 'lib/abtest';
 
 class PlanFeatures extends Component {
 	render() {
-		const { planProperties, isInSignup } = this.props;
+		const { planProperties, isInSignup, showModifiedPricingDisplay } = this.props;
 		const tableClasses = classNames(
 			'plan-features__table',
 			`has-${ planProperties.length }-cols`
 		);
-		const planClasses = classNames( 'plan-features', { 'plan-features--signup': isInSignup } );
+		const planClasses = classNames( 'plan-features', {
+			'plan-features--signup': isInSignup,
+			'abtest-pricing-display': showModifiedPricingDisplay,
+		} );
 		const planWrapperClasses = classNames( { 'plans-wrapper': isInSignup } );
 		let mobileView, planDescriptions;
 		let bottomButtons = null;
@@ -73,6 +79,7 @@ class PlanFeatures extends Component {
 
 		return (
 			<div className={ planWrapperClasses } ref={ this.setScrollLeft }>
+				{ showModifiedPricingDisplay && this.renderCreditNotice() }
 				<div className={ planClasses }>
 					{ this.renderUpgradeDisabledNotice() }
 					<div className="plan-features__content">
@@ -81,6 +88,7 @@ class PlanFeatures extends Component {
 							<tbody>
 								<tr>{ this.renderPlanHeaders() }</tr>
 								{ planDescriptions }
+								<tr>{ showModifiedPricingDisplay && this.renderCreditSummary() }</tr>
 								<tr>{ this.renderTopButtons() }</tr>
 								{ this.renderPlanFeatureRows() }
 								{ bottomButtons }
@@ -101,6 +109,101 @@ class PlanFeatures extends Component {
 			displayJetpackPlans ? ( plansWrapper.scrollLeft = 190 ) : ( plansWrapper.scrollLeft = 495 );
 		}
 	};
+
+	renderCreditNotice() {
+		const { canPurchase, hasPlaceholders, planProperties, site, translate } = this.props;
+		const bannerContainer = document.querySelector( '.plans-features-main__notice' );
+
+		if ( hasPlaceholders || ! canPurchase || ! bannerContainer ) {
+			return null;
+		}
+
+		const credits = planProperties.reduce(
+			( prev, prop ) => {
+				let current = 0;
+				if ( prop.discountPrice ) {
+					current = prop.rawPrice - prop.discountPrice;
+					if ( ! site.jetpack ) {
+						current = current * 12;
+					}
+				} else if ( prop.relatedMonthlyPlan ) {
+					current = prop.relatedMonthlyPlan.raw_price * 12 - prop.rawPrice;
+				}
+
+				if ( current > prev.amount ) {
+					return {
+						amount: current,
+						currencyCode: prop.currencyCode,
+					};
+				}
+
+				return prev;
+			},
+			{ amount: 0, currencyCode: '' }
+		);
+
+		if ( ! credits.amount ) {
+			return null;
+		}
+
+		return ReactDOM.createPortal(
+			<Notice
+				className="plan-features__notice-credits"
+				showDismiss={ false }
+				icon="info-outline"
+				status="is-success"
+			>
+				{ translate(
+					'You have {{b}}%(credits)s{{/b}} in upgrade credits available! ' +
+						'Apply the value of your current plan towards an upgrade before your credits expire!',
+					{
+						args: {
+							credits: formatCurrency( credits.amount, credits.currencyCode ),
+						},
+						components: {
+							b: <strong />,
+						},
+					}
+				) }
+			</Notice>,
+			bannerContainer
+		);
+	}
+
+	renderCreditSummary() {
+		const { canPurchase, planProperties, site, sitePlan } = this.props;
+
+		return map( planProperties, properties => {
+			const {
+				available,
+				currencyCode,
+				current,
+				discountPrice,
+				planConstantObj,
+				planName,
+				rawPrice,
+				relatedMonthlyPlan,
+			} = properties;
+
+			return (
+				<td key={ planName } className="plan-features__table-item">
+					<PlanFeaturesSummary
+						available={ available }
+						canPurchase={ canPurchase }
+						currencyCode={ currencyCode }
+						current={ current }
+						currentPlanTitle={ sitePlan.product_name_short }
+						discountPrice={ discountPrice }
+						planTitle={ planConstantObj.getTitle() }
+						planType={ planName }
+						rawPrice={ rawPrice }
+						relatedMonthlyPlan={ relatedMonthlyPlan }
+						site={ site }
+					/>
+				</td>
+			);
+		} );
+	}
 
 	renderUpgradeDisabledNotice() {
 		const { canPurchase, hasPlaceholders, translate } = this.props;
@@ -158,11 +261,13 @@ class PlanFeatures extends Component {
 				primaryUpgrade,
 				isPlaceholder,
 				hideMonthly,
+				showModifiedPricingDisplay,
 			} = properties;
 			const { rawPrice, discountPrice } = properties;
 			return (
 				<div className="plan-features__mobile-plan" key={ planName }>
 					<PlanFeaturesHeader
+						available={ available }
 						current={ current }
 						currencyCode={ currencyCode }
 						popular={ popular }
@@ -172,7 +277,7 @@ class PlanFeatures extends Component {
 						planType={ planName }
 						rawPrice={ rawPrice }
 						discountPrice={ discountPrice }
-						billingTimeFrame={ planConstantObj.getBillingTimeFrame() }
+						billingTimeFrame={ planConstantObj.getBillingTimeFrame( getABTestVariation ) }
 						hideMonthly={ hideMonthly }
 						isPlaceholder={ isPlaceholder }
 						site={ site }
@@ -180,6 +285,7 @@ class PlanFeatures extends Component {
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 						isInSignup={ isInSignup }
 						selectedPlan={ selectedPlan }
+						showModifiedPricingDisplay={ showModifiedPricingDisplay }
 					/>
 					<p className="plan-features__description">{ planConstantObj.getDescription( abtest ) }</p>
 					<PlanFeaturesActions
@@ -221,10 +327,12 @@ class PlanFeatures extends Component {
 			selectedPlan,
 			site,
 			siteType,
+			showModifiedPricingDisplay,
 		} = this.props;
 
 		return map( planProperties, properties => {
 			const {
+				available,
 				currencyCode,
 				current,
 				planConstantObj,
@@ -239,7 +347,7 @@ class PlanFeatures extends Component {
 			const { rawPrice, discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
 			let audience = planConstantObj.getAudience();
-			let billingTimeFrame = planConstantObj.getBillingTimeFrame();
+			let billingTimeFrame = planConstantObj.getBillingTimeFrame( abtest );
 
 			if ( isInSignup && ! displayJetpackPlans ) {
 				switch ( siteType ) {
@@ -258,13 +366,14 @@ class PlanFeatures extends Component {
 			}
 
 			if ( isInSignup && displayJetpackPlans ) {
-				billingTimeFrame = planConstantObj.getSignupBillingTimeFrame();
+				billingTimeFrame = planConstantObj.getSignupBillingTimeFrame( abtest );
 			}
 
 			return (
 				<td key={ planName } className={ classes }>
 					<PlanFeaturesHeader
 						audience={ audience }
+						available={ available }
 						basePlansPath={ basePlansPath }
 						billingTimeFrame={ billingTimeFrame }
 						current={ current }
@@ -282,6 +391,7 @@ class PlanFeatures extends Component {
 						site={ site }
 						selectedPlan={ selectedPlan }
 						title={ planConstantObj.getTitle() }
+						showModifiedPricingDisplay={ showModifiedPricingDisplay }
 					/>
 				</td>
 			);
@@ -575,6 +685,8 @@ export default connect(
 		const signupDependencies = getSignupDependencyStore( state );
 		const siteType = signupDependencies.designType;
 		const canPurchase = ! isPaid || isCurrentUserCurrentPlanOwner( state, selectedSiteId );
+		const showModifiedPricingDisplay =
+			!isInSignup && abtest('upgradePricingDisplay') === 'modified';
 		let freePlanProperties = null;
 		let planProperties = compact(
 			map( plans, plan => {
@@ -667,7 +779,7 @@ export default connect(
 						bestValue ||
 						plans.length === 1,
 					rawPrice: getPlanRawPrice( state, planProductId, showMonthlyPrice ),
-					relatedMonthlyPlan: relatedMonthlyPlan,
+					relatedMonthlyPlan,
 				};
 			} )
 		);
@@ -683,6 +795,8 @@ export default connect(
 			planProperties,
 			freePlanProperties,
 			siteType,
+			sitePlan,
+			showModifiedPricingDisplay,
 		};
 	},
 	{

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -327,6 +327,7 @@ $plan-features-sidebar-width: 272px;
 	text-overflow: ellipsis;
 }
 
+.plan-features__summary,
 .plan-features__description {
 	margin: 0;
 	padding: 24px 24px 0 24px;
@@ -542,4 +543,100 @@ $plan-features-sidebar-width: 272px;
 }
 .plans-features-main__bottom .plan-features__actions-button {
 	width: auto;
+}
+/**
+ * A/B test for upgrade pricing display
+ */
+.abtest-pricing-display {
+	.plan-price {
+		font-size: 16px;
+		margin: 3px 0 3px;
+	}
+	.plan-price__currency-symbol {
+		font-size: inherit;
+		vertical-align: initial;
+		color: inherit;
+	}
+	.plan-price__fraction {
+		font-size: inherit;
+		vertical-align: initial;
+		font-weight: inherit;
+	}
+	.plan-features__header-timeframe {
+		font-style: normal;
+		color: $gray;
+	}
+	.plan-price.is-original {
+		color: $gray-dark;
+	}
+	.plan-price.is-discounted,
+	.plan-price.is-original:before,
+	.plan-features__header-tip-info {
+		display: none;
+	}
+}
+
+.plan-features__notice-credits {
+	margin: 0 0 16px;
+}
+
+.plan-features__summary {
+	&-title,
+	&-price-row {
+		display: block;
+		margin-bottom: .3em;
+	}
+	&-price-row::after {
+		content: '';
+		display: block;
+		clear: both;
+	}
+	&-item {
+		float: left;
+	}
+	&-price {
+		float: right;
+		text-align: right;
+	}
+	&-discount {
+		color: $alert-green;
+	}
+	&-total {
+		font-weight: 500;
+	}
+	&-price-desc {
+		clear: both;
+		font-size: 12px;
+		color: $gray;
+	}
+	&-policy {
+		font-size: 12px;
+		color: $gray;
+	}
+}
+
+.plan-features__header-credit-label {
+	position: absolute;
+	font-size: 11px;
+	line-height: 20px;
+	height: 20px;
+	border-radius: 10px;
+	color: #fff;
+	font-weight: normal;
+	vertical-align: middle;
+	padding: 0 8px;
+	margin-left: 8px;
+	margin-top: -2px;
+
+	.is-personal-plan & {
+		background: darken( #fcd56e, 20% );
+	}
+
+	.is-business-plan & {
+		background: darken( #c879cc, 20% );
+	}
+
+	.is-premium-plan & {
+		background: darken( #44d0a3, 20% );
+	}
 }

--- a/client/my-sites/plan-features/summary.jsx
+++ b/client/my-sites/plan-features/summary.jsx
@@ -1,0 +1,110 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ **/
+import formatCurrency from 'lib/format-currency';
+
+class PlanFeaturesSummary extends Component {
+	static propTypes = {
+		available: PropTypes.bool.isRequired,
+		currencyCode: PropTypes.string,
+		current: PropTypes.bool,
+		currentPlanTitle: PropTypes.string,
+		planTitle: PropTypes.string.isRequired,
+		rawPrice: PropTypes.number,
+		relatedMonthlyPlan: PropTypes.object,
+		site: PropTypes.object.isRequired,
+	};
+
+	render() {
+		const {
+			available,
+			currencyCode,
+			current,
+			currentPlanTitle,
+			discountPrice,
+			planTitle,
+			rawPrice,
+			relatedMonthlyPlan,
+			site,
+		} = this.props;
+		const isJetpackSite = !! site.jetpack;
+
+		let monthlyPrice, yearlyPrice, discountYearlyPrice;
+
+		if ( ! current && ! available ) {
+			return null;
+		}
+
+		if ( isJetpackSite && current ) {
+			return null;
+		}
+
+		if ( discountPrice ) {
+			if ( isJetpackSite ) {
+				yearlyPrice = rawPrice;
+				discountYearlyPrice = discountPrice;
+			} else {
+				monthlyPrice = rawPrice;
+				yearlyPrice = monthlyPrice * 12;
+				discountYearlyPrice = discountPrice * 12;
+			}
+		} else if ( relatedMonthlyPlan ) {
+			yearlyPrice = relatedMonthlyPlan.raw_price * 12;
+			discountYearlyPrice = rawPrice;
+		}
+
+		if ( ! yearlyPrice || ! discountYearlyPrice ) {
+			return null;
+		}
+
+		return (
+			<div className="plan-features__summary">
+				<strong className="plan-features__summary-title">
+					{ current ? 'Plan summary' : 'Credit summary' }
+				</strong>
+				<div className="plan-features__summary-price-row">
+					<span className="plan-features__summary-item">{ planTitle } plan</span>
+					<span className="plan-features__summary-price">
+						{ formatCurrency( yearlyPrice, currencyCode ) }
+					</span>
+					{ monthlyPrice && (
+						<div className="plan-features__summary-price-desc">
+							({ formatCurrency( monthlyPrice, currencyCode ) } x 12 months)
+						</div>
+					) }
+				</div>
+				{ !! discountYearlyPrice && (
+					<div className="plan-features__summary-price-row plan-features__summary-discount">
+						<span className="plan-features__summary-item">
+							{ isJetpackSite ? 'Jetpack credits' : `${ currentPlanTitle } plan credits` }
+						</span>
+						<span className="plan-features__summary-price">
+							{ formatCurrency( discountYearlyPrice - yearlyPrice, currencyCode ) }
+						</span>
+					</div>
+				) }
+				<div className="plan-features__summary-price-row plan-features__summary-total">
+					<span className="plan-features__summary-item">Total</span>
+					<span className="plan-features__summary-price">
+						{ formatCurrency( discountYearlyPrice || yearlyPrice, currencyCode ) }
+					</span>
+				</div>
+				{ ! current && (
+					<div className="plan-features__summary-policy">30-day money-back gurantee included</div>
+				) }
+			</div>
+		);
+	}
+}
+
+export default localize( PlanFeaturesSummary );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -396,6 +396,7 @@ class PlansFeaturesMain extends Component {
 
 		return (
 			<div className="plans-features-main">
+				<div className="plans-features-main__notice" />
 				{ displayJetpackPlans ? this.getIntervalTypeToggle() : null }
 				<QueryPlans />
 				<QuerySitePlans siteId={ get( site, 'ID' ) } />


### PR DESCRIPTION
This PR will update the plans page to reduce the confusion about the pricing of the plans. The changes introduce new credit summary. See p9jf6J-b5-p2 for more detail.

## How to test

1. Set `upgradePricingDisplay` test to `modified`.
1-1. You can set the test by running the following script in browser console.
```
localStorage.setItem( 'ABTests', '{"upgradePricingDisplay_20180213": "modified"}' );
```
2. Pick a WP.com site and go to the plans page.
3. You should be able to see the credit summary as follows:
<img width="1109" alt="taggon_on_wordpress_ _wordpress_com" src="https://user-images.githubusercontent.com/212034/36146938-a0303d26-10f9-11e8-9599-5ccdae1b5664.png">
4. Move to the plans page of a Jetpack connected site and check if it looks like the followings:
<img width="1109" alt="taggon_at_pressable_ _wordpress_com 2" src="https://user-images.githubusercontent.com/212034/36146949-ac5b7e76-10f9-11e8-8f35-57f74ee98fda.png">
<img width="1109" alt="taggon_at_pressable_ _wordpress_com" src="https://user-images.githubusercontent.com/212034/36147952-91b5445e-10fd-11e8-8c46-36286887ff65.png">

Here are some details for testing:

* The price label in the plan features header should display the original one, not the discount price.
* Current plan should not have the "Credit available" label.
* Jetpack pricing can be different based on the site.
* The plan title just below the "Credit summary" should not display capitalized "Plan". It should be lowercased "plan".
* The current Jetpack plan should show the discount price in the header and should not display the summary section.