### PR TITLE
Jetpack Onboarding: Highlight selected site type and homepage format

### DIFF
--- a/client/components/tile-grid/README.md
+++ b/client/components/tile-grid/README.md
@@ -20,6 +20,7 @@ Component used to display a clickable tile with an image, call to action, and de
 * `buttonLabel`: Text of the button.
 * `className`: Add your own class to the tile.
 * `description`: Description text.
+* `highlighted`: Whether the tile should be highlighted.
 * `href`: URL that the item leads to upon click.
 * `image`: URL of the image.
 * `onClick`: Function, executed when the user clicks the tile.

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -77,6 +77,10 @@
 		}
 	}
 
+	&.is-highlighted {
+		box-shadow: 0 0 0 1px $blue-wordpress, 0 0 0 3px $blue-light;
+	}
+
 	a, svg {
 		display: block;
 		width: 100%; // Safari fix

--- a/client/components/tile-grid/tile.jsx
+++ b/client/components/tile-grid/tile.jsx
@@ -19,6 +19,7 @@ export default class extends React.PureComponent {
 		buttonLabel: PropTypes.string,
 		className: PropTypes.string,
 		description: PropTypes.string,
+		highlighted: PropTypes.bool,
 		href: PropTypes.string,
 		image: PropTypes.string,
 		onClick: PropTypes.func,
@@ -30,11 +31,18 @@ export default class extends React.PureComponent {
 			buttonLabel,
 			className,
 			description,
+			highlighted,
 			href,
 			image,
 			onClick,
 		} = this.props;
-		const tileClassName = classNames( 'tile-grid__item', className );
+		const tileClassName = classNames(
+			'tile-grid__item',
+			{
+				'is-highlighted': highlighted,
+			},
+			className
+		);
 
 		return (
 			<Card className={ tileClassName } href={ href } onClick={ onClick } tabIndex="-1">

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -30,10 +31,11 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 	};
 
 	render() {
-		const { getForwardUrl, translate } = this.props;
+		const { getForwardUrl, settings, translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'What should visitors see on your homepage?' );
 		const forwardUrl = getForwardUrl();
+		const homepageFormat = get( settings, 'homepageFormat' );
 
 		return (
 			<div className="steps__main">
@@ -52,6 +54,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 							'We can pull the latest information into your homepage for you.'
 						) }
 						image={ '/calypso/images/illustrations/homepage-news.svg' }
+						highlighted={ homepageFormat === 'posts' }
 						href={ forwardUrl }
 						onClick={ this.handleHomepageSelection( 'posts' ) }
 					/>
@@ -59,6 +62,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 						buttonLabel={ translate( 'A static welcome page' ) }
 						description={ translate( 'Have your homepage stay the same as time goes on.' ) }
 						image={ '/calypso/images/illustrations/homepage-static.svg' }
+						highlighted={ homepageFormat === 'page' }
 						href={ forwardUrl }
 						onClick={ this.handleHomepageSelection( 'page' ) }
 					/>

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -29,10 +30,11 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 	};
 
 	render() {
-		const { getForwardUrl, translate } = this.props;
+		const { getForwardUrl, settings, translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'What kind of site do you need? Choose an option below:' );
 		const forwardUrl = getForwardUrl();
+		const siteType = get( settings, 'siteType' );
 
 		return (
 			<div className="steps__main">
@@ -51,6 +53,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 							'To share your ideas, stories, photographs, or creative projects with your followers.'
 						) }
 						image={ '/calypso/images/illustrations/type-personal.svg' }
+						highlighted={ siteType === 'personal' }
 						href={ forwardUrl }
 						onClick={ this.handleSiteTypeSelection( 'personal' ) }
 					/>
@@ -60,6 +63,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 							'To promote your business, organization, or brand, sell products or services, or connect with your audience.'
 						) }
 						image={ '/calypso/images/illustrations/type-business.svg' }
+						highlighted={ siteType === 'business' }
 						href={ forwardUrl }
 						onClick={ this.handleSiteTypeSelection( 'business' ) }
 					/>


### PR DESCRIPTION
This PR is part of #21684 - it highlights the tiles that correspond to the selected site type and the selected homepage format (if any). It introduces a prop to the `TileGridItem` that allows it to be highlighted, using the same style that is used when focusing an input field.

**Preview (site type step):**

![](https://cldup.com/FbIznKsC1x.png)

**Preview (homepage format step):**

![](https://cldup.com/4Q5es84xam.png)

To test:
* Start the onboarding flow for a fresh site.
* Verify there is nothing highlighted in the site type and homepage format steps initially.
* Select a site type, select a homepage format.
* Go back to the Site Type step, verify your selection is highlighted as shown on the screenshot above.
* Go to the Homepage format step, verify your selection is highlighted as shown on the screenshot above.

Design-wise this is pretty straightforward, because we're strictly following what was suggested in https://github.com/Automattic/wp-calypso/issues/21684#issuecomment-359059269, but in any case it would be great to get design approval by @MichaelArestad @joanrho.