### PR TITLE
Jetpack Onboarding: Indicate if contact form is present

### DIFF
--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -136,6 +136,10 @@
 
 	@include breakpoint( ">480px" ) {
 		margin-top: 10px;
+
+		&:first-child {
+			margin-bottom: 10px;
+		}
 	}
 }
 

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -34,16 +34,6 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'Would you like to get started with a Contact Us page?' );
 		const hasContactForm = !! get( settings, 'addContactForm' );
-		const tileProps = hasContactForm
-			? {
-					description: translate( 'Your contact form has been created.' ),
-				}
-			: {
-					buttonLabel: translate( 'Add a contact form' ),
-					description: translate(
-						'Not sure? You can skip this step and add a contact form later.'
-					),
-				};
 
 		return (
 			<div className="steps__main">
@@ -57,10 +47,15 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 
 				<TileGrid>
 					<Tile
+						buttonLabel={ ! hasContactForm ? translate( 'Add a contact form' ) : undefined }
+						description={
+							hasContactForm
+								? translate( 'Your contact form has been created.' )
+								: translate( 'Not sure? You can skip this step and add a contact form later.' )
+						}
 						image={ '/calypso/images/illustrations/contact-us.svg' }
 						onClick={ this.handleAddContactForm }
 						href={ getForwardUrl() }
-						{ ...tileProps }
 					/>
 				</TileGrid>
 			</div>

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -29,9 +30,20 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 	};
 
 	render() {
-		const { getForwardUrl, translate } = this.props;
+		const { getForwardUrl, settings, translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'Would you like to get started with a Contact Us page?' );
+		const hasContactForm = !! get( settings, 'addContactForm' );
+		const tileProps = hasContactForm
+			? {
+					description: translate( 'Your contact form has been created.' ),
+				}
+			: {
+					buttonLabel: translate( 'Add a contact form' ),
+					description: translate(
+						'Not sure? You can skip this step and add a contact form later.'
+					),
+				};
 
 		return (
 			<div className="steps__main">
@@ -45,13 +57,10 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 
 				<TileGrid>
 					<Tile
-						buttonLabel={ translate( 'Add a contact form' ) }
-						description={ translate(
-							'Not sure? You can skip this step and add a contact form later.'
-						) }
 						image={ '/calypso/images/illustrations/contact-us.svg' }
 						onClick={ this.handleAddContactForm }
 						href={ getForwardUrl() }
+						{ ...tileProps }
 					/>
 				</TileGrid>
 			</div>


### PR DESCRIPTION
This PR is part of #21684 - it updates the contact form step to display a different message if the form has already been created.

**Preview (when contact form hasn't been created yet):**
![](https://cldup.com/tO87m_xFsu.png)

**Preview (when contact form is created already):**

![](https://cldup.com/Xi6tuqCGBJ.png)

Fixes #21684.

To test:
* Start the onboarding flow for a fresh site.
* On the contact form step, verify it displays the "Add a contact form" button and the "Not sure? You can skip this step and add a contact form later." message below.
* Click the tile to add a contact form.
* Go back to the contact form step and verify it looks the new way.

cc @joanrho @MichaelArestad for opinion, as this particular case was not discussed in #21684.