### PR TITLE
Jetpack Onboarding: Indicate when WooCommerce is installed or installing

### DIFF
--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,6 +16,10 @@ import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
+import {
+	getJetpackOnboardingCompletedSteps,
+	getJetpackOnboardingPendingSteps,
+} from 'state/selectors';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 class JetpackOnboardingWoocommerceStep extends React.PureComponent {
@@ -25,12 +30,14 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 	};
 
 	render() {
-		const { getForwardUrl, translate } = this.props;
+		const { getForwardUrl, stepsCompleted, stepsPending, translate } = this.props;
 		const headerText = translate( 'Are you looking to sell online?' );
 		const subHeaderText = translate(
 			"We'll set you up with WooCommerce for all of your online selling needs."
 		);
 		const forwardUrl = getForwardUrl();
+		const isPending = get( stepsPending, STEPS.WOOCOMMERCE );
+		const isCompleted = get( stepsCompleted, STEPS.WOOCOMMERCE ) === true;
 
 		return (
 			<div className="steps__main">
@@ -43,16 +50,28 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<div className="steps__button-group">
-					<Button href={ forwardUrl } onClick={ this.handleWooCommerceInstallation } primary>
-						{ translate( 'Yes, I am' ) }
-					</Button>
-					<Button href={ forwardUrl }>{ translate( 'Not right now' ) }</Button>
+					{ isPending || isCompleted ? (
+						<Button disabled>
+							{ isPending ? translate( 'Installing…' ) : translate( 'Installed' ) }
+						</Button>
+					) : (
+						<div>
+							<Button href={ forwardUrl } onClick={ this.handleWooCommerceInstallation } primary>
+								{ translate( 'Yes, I am' ) }
+							</Button>
+							<Button href={ forwardUrl }>{ translate( 'Not right now' ) }</Button>
+						</div>
+					) }
 				</div>
 			</div>
 		);
 	}
 }
 
-export default connect( null, { saveJetpackOnboardingSettings } )(
-	localize( JetpackOnboardingWoocommerceStep )
-);
+export default connect(
+	( state, { siteId, steps } ) => ( {
+		stepsCompleted: getJetpackOnboardingCompletedSteps( state, siteId, steps ),
+		stepsPending: getJetpackOnboardingPendingSteps( state, siteId, steps ),
+	} ),
+	{ saveJetpackOnboardingSettings }
+)( localize( JetpackOnboardingWoocommerceStep ) );


### PR DESCRIPTION
This PR is part of #21684 - it displays the WooCommerce step in a different state when WooCommerce is installing or has been installed already.

**Preview (WooCommerce not installing and not installed)**

![](https://cldup.com/HUKSP99Gr9.png)

**Preview (WooCommerce already installed)**

![](https://cldup.com/PUpu4PKv46.png)

**Preview (WooCommerce not installing and not installed)**

![](https://cldup.com/VyLFItcDgC.png)

To test:
* Start the onboarding flow for a fresh site.
* Select a Business site type
* Reach the WooCommerce step.
* Verify it appears as on the first screenshot and allows you to install WooCommerce or skip.
* Click the button to install WooCommerce and quickly go back using the "Back" button in the bottom nav.
* Verify the page now displays a disabled "Installing..." button.
* Wait until after WooCommerce is installed.
* Verify the page now displays a disabled "Installed" button.

Design-wise this is pretty straightforward, because we're strictly following what was suggested in https://github.com/Automattic/wp-calypso/issues/21684#issuecomment-359059269, but in any case it would be great to get design approval by @MichaelArestad @joanrho.
