### PR TITLE
Login: Add Jetpack prop with branding

### DIFF
--- a/client/blocks/login/docs/example.jsx
+++ b/client/blocks/login/docs/example.jsx
@@ -14,6 +14,7 @@ import LoginBlock from 'blocks/login';
 const LoginExample = () => (
 	<React.Fragment>
 		<LoginBlock />
+		<p />
 		<LoginBlock jetpack />
 	</React.Fragment>
 );

--- a/client/blocks/login/docs/example.jsx
+++ b/client/blocks/login/docs/example.jsx
@@ -11,7 +11,12 @@ import React from 'react';
  */
 import LoginBlock from 'blocks/login';
 
-const LoginExample = () => <LoginBlock title={ 'Sign in to connect to WordPress.com' } />;
+const LoginExample = () => (
+	<React.Fragment>
+		<LoginBlock />
+		<LoginBlock jetpack />
+	</React.Fragment>
+);
 
 LoginExample.displayName = 'Login';
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -11,7 +11,7 @@ import Gridicon from 'gridicons';
 import { includes, capitalize } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import classname from 'classnames';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -273,7 +273,7 @@ class Login extends Component {
 
 	render() {
 		return (
-			<div className={ classname( 'login', { 'login--jetpack': this.props.jetpack } ) }>
+			<div className={ classNames( 'login', { 'login--jetpack': this.props.jetpack } ) }>
 				{ this.renderHeader() }
 
 				<ErrorNotice />

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -273,7 +273,7 @@ class Login extends Component {
 
 	render() {
 		return (
-			<div className={ classNames( 'login', { 'login--jetpack': this.props.jetpack } ) }>
+			<div className={ classNames( 'login', { 'is-jetpack': this.props.jetpack } ) }>
 				{ this.renderHeader() }
 
 				<ErrorNotice />

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -11,6 +11,7 @@ import Gridicon from 'gridicons';
 import { includes, capitalize } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
+import classname from 'classnames';
 
 /**
  * Internal dependencies
@@ -35,6 +36,7 @@ import Notice from 'components/notice';
 import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
 import userFactory from 'lib/user';
 import SocialConnectPrompt from './social-connect-prompt';
+import JetpackLogo from 'components/jetpack-logo';
 
 const user = userFactory();
 
@@ -129,17 +131,18 @@ class Login extends Component {
 
 	renderHeader() {
 		const {
+			jetpack,
+			linkingSocialService,
 			oauth2Client,
 			privateSite,
 			socialConnect,
 			translate,
 			twoStepNonce,
-			linkingSocialService,
 		} = this.props;
 
-		let headerText = translate( 'Log in to your account.' ),
-			preHeader = null,
-			postHeader = null;
+		let headerText = translate( 'Log in to your account.' );
+		let preHeader = null;
+		let postHeader = null;
 
 		if ( twoStepNonce ) {
 			headerText = translate( 'Two-Step Authentication' );
@@ -182,6 +185,13 @@ class Login extends Component {
 					</p>
 				);
 			}
+		} else if ( jetpack ) {
+			headerText = translate( 'Log in to your WordPress.com account to set up Jetpack.' );
+			preHeader = (
+				<div>
+					<JetpackLogo full size={ 45 } />
+				</div>
+			);
 		}
 
 		return (
@@ -260,7 +270,7 @@ class Login extends Component {
 
 	render() {
 		return (
-			<div>
+			<div className={ classname( 'login', { 'login--jetpack': this.props.jetpack } ) }>
 				{ this.renderHeader() }
 
 				<ErrorNotice />

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -42,20 +42,23 @@ const user = userFactory();
 
 class Login extends Component {
 	static propTypes = {
+		isLinking: PropTypes.bool,
+		jetpack: PropTypes.bool.isRequired,
+		linkingSocialService: PropTypes.string,
 		oauth2Client: PropTypes.object,
 		privateSite: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
 		redirectTo: PropTypes.string,
 		requestNotice: PropTypes.object,
+		socialConnect: PropTypes.bool,
+		socialService: PropTypes.string,
+		socialServiceResponse: PropTypes.object,
 		twoFactorAuthType: PropTypes.string,
 		twoFactorEnabled: PropTypes.bool,
 		twoFactorNotificationSent: PropTypes.string,
-		socialConnect: PropTypes.bool,
-		isLinking: PropTypes.bool,
-		linkingSocialService: PropTypes.string,
-		socialService: PropTypes.string,
-		socialServiceResponse: PropTypes.object,
 	};
+
+	static defaultProps = { jetpack: false };
 
 	componentDidMount = () => {
 		if ( ! this.props.twoFactorEnabled && this.props.twoFactorAuthType ) {

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -1,8 +1,11 @@
-.login--jetpack {
+.login {
+
 	.jetpack-logo__icon { fill: $green-jetpack }
-	.button.is-primary {
-		background-color: $green-jetpack;
-		border-color: darken( $green-jetpack, 5% );
+	&.is-jetpack {
+		.button.is-primary {
+			background-color: $green-jetpack;
+			border-color: darken( $green-jetpack, 5% );
+		}
 	}
 }
 

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -1,3 +1,11 @@
+.login--jetpack {
+	.jetpack-logo__icon { fill: $green-jetpack }
+	.button.is-primary {
+		background-color: $green-jetpack;
+		border-color: darken( $green-jetpack, 5% );
+	}
+}
+
 .card.login__form,
 .login__form-social .card {
 	margin-bottom: 0;


### PR DESCRIPTION
Adds Jetpack branding and customized header for login block. Preparation for #22218 

see p1HpG7-4Mw-p2


## Screens

### Before (no `jetpack` prop)

![before](https://user-images.githubusercontent.com/841763/35993623-3154a642-0d0e-11e8-937e-8abcabbd3595.png)

### After (with `jetpack` prop)

![after](https://user-images.githubusercontent.com/841763/35993625-3409048c-0d0e-11e8-923f-b1bd29037031.png)

## Demo

You can observe a "live" demo by finding the `Login` block (it will have class `login`) in React devtools and toggling its `jetpack` prop via [dserve](https://dserve.a8c.com/log-in?branch=add/jetpack-branded-login) or [calypso.live](https://calypso.live/log-in?branch=add/jetpack-branded-login):

![devtools](https://user-images.githubusercontent.com/841763/35993669-58442106-0d0e-11e8-8699-50553c8b81b1.png)

See it in the [devdocs](https://dserve.a8c.com/devdocs/blocks/login?branch=add/jetpack-branded-login)

## Testing
1. Normal login _must remain unaffected_! Behavior should be unchanged (visual changes only).
1. Test login, 2fa, Google login, etc.
1. The Jetpack version is not live anywhere outside of devdocs, so inspect the branding there (design).
