### PR TITLE
Reposition guided tour under menu

### DIFF
--- a/client/layout/guided-tours/tours/checklist-site-icon-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour.js
@@ -31,6 +31,7 @@ export const ChecklistSiteIconTour = makeTour(
 			placement="below"
 			style={ {
 				animationDelay: '0.7s',
+				zIndex: 1,
 			} }
 		>
 			<p>


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/pull/22254

This PR fixes a bug for the site icon guided tour in the checklist. The tour currently appears over the nav bar when you scroll down the screen. 

## Before
![image](https://user-images.githubusercontent.com/6981253/35985254-38bf0606-0cc4-11e8-8ecb-cff11df62937.png)

## After
![image](https://user-images.githubusercontent.com/6981253/35985214-1e1b4062-0cc4-11e8-873c-e1957f139e8a.png)

## Testing
- Create a new site and make sure you're in the Checklist a/b test
- Start the Site icon tour
- Scroll down after the tour appears. Ensure the tour scrolls under the nav bar.

cc @taggon 