### PR TITLE
Rewind: add placeholder and replace 'unavailable' state with 'uninitialized'

### DIFF
--- a/client/my-sites/stats/activity-log-switch/index.jsx
+++ b/client/my-sites/stats/activity-log-switch/index.jsx
@@ -75,8 +75,20 @@ class ActivityLogSwitch extends Component {
 	}
 
 	render() {
-		if ( 'vp_active_on_site' === this.props.failureReason || 'uninitialized' === this.props.rewindState ) {
+		if ( 'vp_active_on_site' === this.props.failureReason ) {
 			return false;
+		}
+
+		if ( 'uninitialized' === this.props.rewindState ) {
+			return (
+				<Card className="activity-log-switch activity-log-switch__placeholder">
+					<div className="activity-log-switch__header">
+						<div className="activity-log-switch__header-header" />
+					</div>
+					<div className="activity-log-switch__img-placeholder" />
+					<p className="activity-log-switch__header-text" />
+				</Card>
+			);
 		}
 
 		const {

--- a/client/my-sites/stats/activity-log-switch/style.scss
+++ b/client/my-sites/stats/activity-log-switch/style.scss
@@ -107,3 +107,21 @@
 		padding: 4%;
 	}
 }
+
+.activity-log-switch__placeholder {
+	.activity-log-switch__header-header {
+		padding-bottom: 0;
+		@include placeholder();
+	}
+
+	.activity-log-switch__header-text {
+		height: 100px;
+		@include placeholder();
+	}
+}
+.activity-log-switch__img-placeholder {
+	max-width: 150px;
+	height: 100px;
+	margin: 0 auto;
+	@include placeholder();
+}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -589,18 +589,16 @@ class ActivityLog extends Component {
 
 		const rewindNoThanks = get( context, 'query.rewind-redirect', '' );
 		const rewindIsNotReady = includes(
-			[ 'unavailable', 'awaitingCredentials' ],
+			[ 'uninitialized', 'awaitingCredentials' ],
 			rewindState.state
 		);
 
 		return (
 			<Main wideLayout>
 				<QueryRewindState siteId={ siteId } />
-				{ siteId && '' !== rewindNoThanks && rewindIsNotReady ? (
-					<ActivityLogSwitch siteId={ siteId } redirect={ rewindNoThanks } />
-				) : (
-					this.getActivityLog()
-				) }
+				{ '' !== rewindNoThanks && rewindIsNotReady
+					? siteId && <ActivityLogSwitch siteId={ siteId } redirect={ rewindNoThanks } />
+					: this.getActivityLog() }
 				<JetpackColophon />
 			</Main>
 		);


### PR DESCRIPTION
- This PR fixes an issue that caused that AL was shown briefly when site was awaiting credentials. Now it works properly by never displaying AL when the flow is/is going to be shown.

- It also introduces a placeholder, so when the flow is loading, we don't have an empty page with only the Jetpack colophon

![flow-placeholder](https://user-images.githubusercontent.com/1041600/35991808-207bf590-0ce7-11e8-9dd8-e84978da9bf2.gif)

### Testing

Test with a site with Rewind enabled, but in an awaiting credentials state.
Verify that when the flow initiator is reached with a URL like

http://calypso.localhost:3000/stats/activity/fine-fox.jurassic.ninja?rewind-redirect=%2Fwp-admin%2Fadmin.php%3Fpage%3Djetpack&cta&site=fine-fox.jurassic.ninja&u=1

1. you do not see AL briefly
2. you see the placeholder, before it's replaced with the flow initiator