### PR TITLE
Update the wpcom-proxy-request package to v5.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -16027,8 +16027,8 @@
       }
     },
     "wpcom-proxy-request": {
-      "version": "4.0.5",
-      "integrity": "sha512-eTt+n4qDvNNybYOMNXCPSehcQUCFENWLANp6th3ST+cwuKjzF6wKuMGQko1sHVPz0VKOCksOf/Ye8+rGPa6eAQ==",
+      "version": "5.0.0",
+      "integrity": "sha512-dHCBAWDi/DMVQ+bF2PZ+ySDuBVjobFXMHGJdqAjcGoM8H4O7f046I0qf9tvhuzcKsjBBhK8SEIdK0PU979gh9w==",
       "requires": {
         "component-event": "0.1.4",
         "debug": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "webpack-hot-middleware": "2.15.0",
     "wpcom": "5.4.0",
     "wpcom-oauth": "0.3.3",
-    "wpcom-proxy-request": "4.0.5",
+    "wpcom-proxy-request": "5.0.0",
     "wpcom-xhr-request": "1.1.1"
   },
   "engines": {


### PR DESCRIPTION
Second attempt at landing the new REST Proxy 2.0 (introduced on backend in D9537). See the post mortem post and its comments at p4TIVU-8Pc-p2
