### PR TITLE
Activity Log: Happychat event cleanup

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
@@ -81,6 +81,6 @@ export default connect(
 		happychatIsAvailable: isHappychatAvailable( state ),
 	} ),
 	{
-		happychatEvent: () => recordTracksEvent( 'rewind_credentials_get_help' ),
+		happychatEvent: () => recordTracksEvent( 'calypso_rewind_credentials_get_help' ),
 	}
 )( localize( SetupFooter ) );

--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import Button from 'components/button';
 import Card from 'components/card';
 import Gridicon from 'gridicons';
 import HappychatButton from 'components/happychat/button';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const ActivityLogConfirmDialog = ( {
@@ -25,6 +27,7 @@ const ActivityLogConfirmDialog = ( {
 	supportLink,
 	title,
 	translate,
+	happychatEvent,
 } ) => (
 	<div className="activity-log-item activity-log-item__restore-confirm">
 		<div className="activity-log-item__type">
@@ -60,7 +63,10 @@ const ActivityLogConfirmDialog = ( {
 							{ translate( 'More info' ) }
 						</span>
 					</Button>
-					<HappychatButton className="activity-log-confirm-dialog__more-info-link">
+					<HappychatButton
+						className="activity-log-confirm-dialog__more-info-link"
+						onClick={ happychatEvent }
+					>
 						<Gridicon icon="chat" />
 						<span className="activity-log-confirm-dialog__more-info-link-text">
 							{ translate( 'Any Questions?' ) }
@@ -73,4 +79,8 @@ const ActivityLogConfirmDialog = ( {
 );
 /* eslint-enable wpcalypso/jsx-classname-namespace */
 
-export default localize( ActivityLogConfirmDialog );
+const mapDispatchToProps = {
+	happychatEvent: () => recordTracksEvent( 'calypso_activitylog_rewind_confirm_dialog' ),
+};
+
+export default connect( null, mapDispatchToProps )( localize( ActivityLogConfirmDialog ) );

--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -80,7 +80,7 @@ const ActivityLogConfirmDialog = ( {
 /* eslint-enable wpcalypso/jsx-classname-namespace */
 
 const mapDispatchToProps = {
-	happychatEvent: () => recordTracksEvent( 'calypso_activitylog_rewind_confirm_dialog' ),
+	happychatEvent: () => recordTracksEvent( 'calypso_activitylog_confirm_dialog' ),
 };
 
 export default connect( null, mapDispatchToProps )( localize( ActivityLogConfirmDialog ) );


### PR DESCRIPTION
This PR does two things:
1. Adds a tracks event on the Rewind confirm dialog help button
2. Fixes the tracks event name in the credentials setup footer
