### PR TITLE
Don't show free plan with DWPO and transfer.

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -460,7 +460,9 @@ class Signup extends React.Component {
 				( this.props.signupDependencies &&
 					this.props.signupDependencies.domainItem &&
 					this.props.signupDependencies.domainItem.is_domain_registration &&
-					this.props.domainsWithPlansOnly )
+					this.props.domainsWithPlansOnly ) ||
+				( this.props.domainsWithPlansOnly &&
+					find( this.state.progress, { domainItem: { product_slug: 'domain_transfer' } } ) )
 			);
 
 		return (

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -14,6 +14,7 @@ import {
 	delay,
 	filter,
 	find,
+	get,
 	indexOf,
 	isEmpty,
 	last,
@@ -54,6 +55,7 @@ import { recordSignupStart, recordSignupCompletion } from 'lib/analytics/ad-trac
 import { disableCart } from 'lib/upgrades/actions';
 import { loadTrackingTool } from 'state/analytics/actions';
 import { affiliateReferral } from 'state/refer/actions';
+import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
 
 /**
  * Constants
@@ -450,6 +452,7 @@ class Signup extends React.Component {
 	};
 
 	currentStep = () => {
+		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 		const currentStepProgress = find( this.state.progress, { stepName: this.props.stepName } ),
 			CurrentComponent = stepComponents[ this.props.stepName ],
 			propsFromConfig = assign( {}, this.props, steps[ this.props.stepName ].props ),
@@ -457,12 +460,8 @@ class Signup extends React.Component {
 			flow = flows.getFlow( this.props.flowName ),
 			hideFreePlan = !! (
 				this.state.plans ||
-				( this.props.signupDependencies &&
-					this.props.signupDependencies.domainItem &&
-					this.props.signupDependencies.domainItem.is_domain_registration &&
-					this.props.domainsWithPlansOnly ) ||
-				( this.props.domainsWithPlansOnly &&
-					find( this.state.progress, { domainItem: { product_slug: 'domain_transfer' } } ) )
+				( ( isDomainRegistration( domainItem ) || isDomainTransfer( domainItem ) ) &&
+					this.props.domainsWithPlansOnly )
 			);
 
 		return (

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -202,7 +202,9 @@ class DomainsStep extends React.Component {
 					stepSectionName: this.props.stepSectionName,
 				},
 				this.getThemeArgs()
-			)
+			),
+			[],
+			{ domainItem }
 		);
 
 		this.props.goToNextStep();


### PR DESCRIPTION
From `calypso.localhost:3000/start` search for a taken domain name
Select "Yes, I own this domain"
Click "Transfer to WordPress.com"
In step 3, the free plan option should not be shown

Make sure that the free plan is still shown when selecting a free subdomain.