### PR TITLE
Rewind: Only send Happychat events when a chat session is already active

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -117,25 +117,28 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 
 	const { translate } = i18n;
 	const baseOptions = { duration: 4000, id: action.noticeId };
+
 	const announce = ( message, options ) =>
 		dispatch( errorNotice( message, options ? { ...baseOptions, ...options } : baseOptions ) );
+
 	const spreadHappiness = message => {
+		const tracksEvent = recordTracksEvent( 'calypso_rewind_creds_update_failure', {
+			siteId: action.siteId,
+			error: error.error,
+			statusCode: error.statusCode,
+			host: action.host,
+			kpri: action.krpi ? 'provided but [omitted here]' : 'not provided',
+			pass: action.pass ? 'provided but [omitted here]' : 'not provided',
+			path: action.path,
+			port: action.port,
+			protocol: action.protocol,
+			user: action.user,
+		} );
+
 		dispatch(
-			withAnalytics(
-				recordTracksEvent( 'calypso_rewind_creds_update_failure', {
-					siteId: action.siteId,
-					error: error.error,
-					statusCode: error.statusCode,
-					host: action.host,
-					kpri: action.krpi ? 'provided but [omitted here]' : 'not provided',
-					pass: action.pass ? 'provided but [omitted here]' : 'not provided',
-					path: action.path,
-					port: action.port,
-					protocol: action.protocol,
-					user: action.user,
-				} ),
-				sendEvent( message )
-			)
+			isHappychatAvailable( getState() )
+				? withAnalytics( tracksEvent, sendEvent( message ) )
+				: tracksEvent
 		);
 	};
 


### PR DESCRIPTION
Previously we were sending events about failed credential updates in
order to provide background context to a Happiness Engineer who might
start a chat with a customer. The idea was that if they could see the
recent failures it would start by providing important context.

It turns out that the act of sending the event was also opening the chat
session itself which was unexpected and noisy.

In this patch we should only be sending the events after a chat has started.