### PR TITLE
Layout: Stop elements from the primary section from showing through the sidebar.

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -80,7 +80,7 @@
 	}
 }
 
-.layout:not(.is-section-post-editor) .layout__primary {
+.layout:not(.is-section-post-editor,.is-section-customize) .layout__primary {
 	//in all sections except for the editor, create a z-index stacking context on primary, so elements don't bleed in mobile views.
 	transform: translate( 0, 0 );
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -80,6 +80,11 @@
 	}
 }
 
+.layout:not(.is-section-post-editor) .layout__primary {
+	//in all sections except for the editor, create a z-index stacking context on primary, so elements don't bleed in mobile views.
+	transform: translate( 0, 0 );
+}
+
 .layout__content a {
 	text-decoration: none;
 }


### PR DESCRIPTION
When a user in the mobile views goes from a `primary`-focussed view (eg. Stats or Plans) to the sidebar (`secondary`) view, elements from `primary` with z-indices higher than 0 will show through:

![screen shot 2018-02-08 at 11 45 56 am](https://user-images.githubusercontent.com/349751/36001459-2dc0d696-0cdb-11e8-88aa-57dc5b675138.png)

Edit by @gwwar: For now I'm forcing us to create a z-index stacking context on the primary div, so elements don't leak through when only viewing the sidebar. A more ideal solution is to not render primary content in this state, but don't know how reasonable this is.

Fixes #22258 .

**Testing**
 - On `master`, use devtools to go into a mobile view of Stats.
 - Click the `<` arrow in the header section, and see the stats showing through.
 - Switch to this branch, and go to Stats.
 - Click the `<` arrow again, and notice no stats show through.
 - Verify that popups, global notices, and other z-indexy things work okay
 - Verify that no regressions occur in the editor.