### PR TITLE
Devdocs: Add postIds to fix broken devdocs

### DIFF
--- a/client/blocks/reader-combined-card/docs/example.jsx
+++ b/client/blocks/reader-combined-card/docs/example.jsx
@@ -12,7 +12,10 @@ import React from 'react';
 import ReaderCombinedCardBlock from 'blocks/reader-combined-card';
 import { posts, feed, site } from 'blocks/reader-post-card/docs/fixtures';
 
-const postKey = { blogId: site.ID };
+const postKey = {
+	blogId: site.ID,
+	postIds: posts.map( ( { global_ID } ) => global_ID ),
+};
 
 const ReaderCombinedCard = () => (
 	<div className="design-assets__group">


### PR DESCRIPTION
#22110 changes the required shape of some properties and broke devdocs. This PR adds the required props from existing fixtures

spotted in https://github.com/Automattic/wp-calypso/pull/22250#issuecomment-364267922

## Testing
1. You can verify devdocs are broken https://wpcalypso.wordpress.com/devdocs/blocks
1. Verify they're not broken on this branch: https://calypso.live/devdocs/blocks?branch=fix/devdocs/reader-combined-card