### PR TITLE
Fire a Tracks event for affiliate referrals in signup

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -296,10 +296,16 @@ class Signup extends React.Component {
 		SignupProgressStore.on( 'change', this.loadProgressFromStore );
 		this.props.loadTrackingTool( 'HotJar' );
 		const urlPath = location.href;
-		const query = url.parse( urlPath, true ).query;
-		const affiliateId = query.aff;
+		const parsedUrl = url.parse( urlPath, true );
+		const affiliateId = parsedUrl.query.aff;
 		if ( affiliateId && ! isNaN( affiliateId ) ) {
 			this.props.affiliateReferral( { urlPath, affiliateId } );
+			// Record the referral in Tracks
+			analytics.tracks.recordEvent( 'calypso_refer_visit', {
+				flow: this.props.flowName,
+				// The current page without any query params
+				page: parsedUrl.host + parsedUrl.pathname,
+			} );
 		}
 	}
 


### PR DESCRIPTION
Fire a Tracks event when an affiliate ID (`aff`) is passed as a URL param during signup.

* Load: http://calypso.localhost:3000/start/?aff=36
* In the network tab of your browser's console search for `calypso_refer_visit`.
* You should see the `t.gif` Tracks request being made. Look to make sure the `page` param is correct. It should be the host and path of the current page.
We need this page URL, minus the params, to be able to segment by page for these referrals.

<img width="1062" alt="screen shot 2018-02-08 at 5 09 38 pm" src="https://user-images.githubusercontent.com/690843/36006652-13a508be-0cf3-11e8-9c7b-7c3c99b5e41b.png">
