### PR TITLE
Invites: Fix issues with data loading order

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -94,25 +94,16 @@ function renderInvitePeople( context, next ) {
 }
 
 function renderPeopleInvites( context, next ) {
-	const state = context.store.getState();
-	const site = getSelectedSite( state );
-
 	context.store.dispatch( setTitle( i18n.translate( 'Invites', { textOnly: true } ) ) );
 
-	context.primary = React.createElement( PeopleInvites, {
-		site,
-	} );
+	context.primary = React.createElement( PeopleInvites );
 	next();
 }
 
 function renderPeopleInviteDetails( context, next ) {
-	const state = context.store.getState();
-	const site = getSelectedSite( state );
-
-	context.store.dispatch( setTitle( i18n.translate( 'Invites', { textOnly: true } ) ) );
+	context.store.dispatch( setTitle( i18n.translate( 'Invite Details', { textOnly: true } ) ) );
 
 	context.primary = React.createElement( PeopleInviteDetails, {
-		site,
 		inviteKey: context.params.invite_key,
 	} );
 	next();

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -20,8 +20,9 @@ import Card from 'components/card';
 import PeopleListItem from 'my-sites/people/people-list-item';
 import Gravatar from 'components/gravatar';
 import QuerySiteInvites from 'components/data/query-site-invites';
+import EmptyContent from 'components/empty-content';
 import { getSelectedSite } from 'state/ui/selectors';
-import { getInviteForSite } from 'state/invites/selectors';
+import { isRequestingInvitesForSite, getInviteForSite } from 'state/invites/selectors';
 
 class PeopleInviteDetails extends React.PureComponent {
 	static propTypes = {
@@ -37,8 +38,29 @@ class PeopleInviteDetails extends React.PureComponent {
 		page.back( fallback );
 	};
 
-	renderInvite = () => {
-		const { site, invite } = this.props;
+	renderPlaceholder() {
+		return (
+			<Card>
+				<PeopleListItem key="people-list-item-placeholder" />
+			</Card>
+		);
+	}
+
+	renderInvite() {
+		const { site, requesting, invite, translate } = this.props;
+
+		if ( ! site || ! site.ID ) {
+			return this.renderPlaceholder();
+		}
+
+		if ( ! invite ) {
+			if ( requesting ) {
+				return this.renderPlaceholder();
+			} else {
+				const message = translate( 'The requested invite does not exist.' );
+				return <EmptyContent title={ message } />;
+			}
+		}
 
 		return (
 			<Card>
@@ -53,9 +75,9 @@ class PeopleInviteDetails extends React.PureComponent {
 				{ this.renderInviteDetails() }
 			</Card>
 		);
-	};
+	}
 
-	renderInviteDetails = () => {
+	renderInviteDetails() {
 		const { invite, translate, moment } = this.props;
 		const showName = invite.invitedBy.login !== invite.invitedBy.name;
 
@@ -91,25 +113,21 @@ class PeopleInviteDetails extends React.PureComponent {
 				) }
 			</div>
 		);
-	};
+	}
 
 	render() {
 		const { site, translate, invite } = this.props;
 
-		if ( ! site || ! site.ID ) {
-			return null;
-		}
-
 		return (
 			<Main className="people-invite-details">
-				<QuerySiteInvites siteId={ site.ID } />
+				{ site && site.ID && <QuerySiteInvites siteId={ site.ID } /> }
 				<SidebarNavigation />
 
 				<HeaderCake isCompact onClick={ this.goBack }>
 					{ translate( 'Invite Details' ) }
 				</HeaderCake>
 
-				{ invite && this.renderInvite() }
+				{ this.renderInvite() }
 			</Main>
 		);
 	}
@@ -121,6 +139,7 @@ export default connect( ( state, ownProps ) => {
 
 	return {
 		site,
+		requesting: isRequestingInvitesForSite( state, siteId ),
 		invite: getInviteForSite( state, siteId, ownProps.inviteKey ),
 	};
 } )( localize( PeopleInviteDetails ) );

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -56,10 +56,10 @@ class PeopleInviteDetails extends React.PureComponent {
 		if ( ! invite ) {
 			if ( requesting ) {
 				return this.renderPlaceholder();
-			} else {
-				const message = translate( 'The requested invite does not exist.' );
-				return <EmptyContent title={ message } />;
 			}
+
+			const message = translate( 'The requested invite does not exist.' );
+			return <EmptyContent title={ message } />;
 		}
 
 		return (
@@ -116,7 +116,7 @@ class PeopleInviteDetails extends React.PureComponent {
 	}
 
 	render() {
-		const { site, translate, invite } = this.props;
+		const { site, translate } = this.props;
 
 		return (
 			<Main className="people-invite-details">

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -20,11 +20,12 @@ import Card from 'components/card';
 import PeopleListItem from 'my-sites/people/people-list-item';
 import Gravatar from 'components/gravatar';
 import QuerySiteInvites from 'components/data/query-site-invites';
+import { getSelectedSite } from 'state/ui/selectors';
 import { getInviteForSite } from 'state/invites/selectors';
 
 class PeopleInviteDetails extends React.PureComponent {
 	static propTypes = {
-		site: PropTypes.object.isRequired,
+		site: PropTypes.object,
 		inviteKey: PropTypes.string.isRequired,
 	};
 
@@ -115,9 +116,11 @@ class PeopleInviteDetails extends React.PureComponent {
 }
 
 export default connect( ( state, ownProps ) => {
-	const siteId = ownProps.site && ownProps.site.ID;
+	const site = getSelectedSite( state );
+	const siteId = site && site.ID;
 
 	return {
+		site,
 		invite: getInviteForSite( state, siteId, ownProps.inviteKey ),
 	};
 } )( localize( PeopleInviteDetails ) );

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -22,6 +22,7 @@ import Card from 'components/card';
 import Button from 'components/button';
 import QuerySiteInvites from 'components/data/query-site-invites';
 import InvitesListEnd from './invites-list-end';
+import { getSelectedSite } from 'state/ui/selectors';
 import {
 	isRequestingInvitesForSite,
 	getPendingInvitesForSite,
@@ -31,19 +32,16 @@ import {
 
 class PeopleInvites extends React.PureComponent {
 	static propTypes = {
-		site: PropTypes.object.isRequired,
+		site: PropTypes.object,
 	};
 
 	render() {
 		const { site } = this.props;
-
-		if ( ! site || ! site.ID ) {
-			return null;
-		}
+		const siteId = site && site.ID;
 
 		return (
 			<Main className="people-invites">
-				<QuerySiteInvites siteId={ site.ID } />
+				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
 				<SidebarNavigation />
 				<PeopleSectionNav filter="invites" site={ site } />
 				{ this.renderInvitesList() }
@@ -60,6 +58,10 @@ class PeopleInvites extends React.PureComponent {
 			site,
 			translate,
 		} = this.props;
+
+		if ( ! site || ! site.ID ) {
+			return this.renderPlaceholder();
+		}
 
 		const hasAcceptedInvites = acceptedInvites && acceptedInvites.length > 0;
 		const acceptedInviteCount = hasAcceptedInvites ? acceptedInvites.length : null;
@@ -150,10 +152,12 @@ class PeopleInvites extends React.PureComponent {
 	};
 }
 
-export default connect( ( state, ownProps ) => {
-	const siteId = ownProps.site && ownProps.site.ID;
+export default connect( state => {
+	const site = getSelectedSite( state );
+	const siteId = site && site.ID;
 
 	return {
+		site,
 		requesting: isRequestingInvitesForSite( state, siteId ),
 		pendingInvites: getPendingInvitesForSite( state, siteId ),
 		acceptedInvites: getAcceptedInvitesForSite( state, siteId ),


### PR DESCRIPTION
This PR fixes a few issues with data loading order for the invites list screen and the invite details screen.

First, if the invites screens happen to render before the site object is loaded (this is very possible with users who have large numbers of sites and/or there is currently no persisted state), then they will display a blank screen and will not successfully re-render, even after the site object loads.

- The top-level components for these screens currently receive the `site` object as a property [in the controller](https://github.com/Automattic/wp-calypso/blob/0a91c1e8/client/my-sites/people/controller.js#L86).
- Then, they pull several properties related to site invites [in a `connect` callback](https://github.com/Automattic/wp-calypso/blob/0a91c1e8/client/my-sites/people/people-invites/index.jsx#L153-L162).
- Then, both the [invites list](https://github.com/Automattic/wp-calypso/blob/0a91c1e8/client/my-sites/people/people-invites/index.jsx#L40-L42
) and the [invite details screen](https://github.com/Automattic/wp-calypso/blob/0a91c1e88ea95a3b7587eb0c07b7d7583b5ead39/client/my-sites/people/people-invite-details/index.jsx#L98-L100) return `null` if there is no site ID.
- When the site object appears, there is no change in any Redux-connected properties (because they are all related to invites).  The `site` object was originally set in the controller, which isn't called again, so the `site` prop passed to the component is still `null`.  Since all props are equal, and the components are both `extends React.PureComponent`, they don't re-render and they remain blank.

The simplest way to fix that is to move the `site` property out of the controller and into the Redux `connect` callback via `getSelectedSite`.  (Yes It would be better if we only pulled the necessary properties from the site object, but the full `site` is passed down through a big tree of People components, and refactoring that code is too big a task for this PR.)

This is pretty surprising behavior; the lesson is to be sure to test our code with the `site` object loading after the initial render.  (Testing with other data loaded but not the `site` object could also be interesting; fortunately, this isn't a problem for these screens because we need the site ID in order to request invites.)

After I noticed this issue, I started thinking of other ways that unexpected load order and/or missing data could break these screens.  I came up with these:

- Invite list: Site is loaded after first render
- Invite list: Site is not valid at all
- Invite details: Site is loaded after first render, valid site and invite
- Invite details: Site is not valid at all
- Invite details: Site and/or invite are loaded after first render
- Invite details: Site is already loaded, invalid invite ID
- Invite details: Site is loaded after first render, invalid invite ID

I think they are all fixed now:

- With this PR, if the site object is still loading, we'll display a placeholder and re-render (including a `QuerySiteInvites`) when the site object loads.
- Invalid sites are handled [elsewhere in the code](https://github.com/Automattic/wp-calypso/blob/0a91c1e8/client/my-sites/people/controller.js#L86) after `/me/sites` finishes loading.
- It's not possible for invites to load before the site object, since we need the site ID in order to query invites.
- If we request an invalid invite ID for a valid site, this PR adds an error screen for that condition:

![2018-02-08t23 09 25-0600](https://user-images.githubusercontent.com/227022/36012643-21fe07da-0d25-11e8-986d-1fa86e6b8145.png)

To clean up the UX a bit, this PR also renders the section heading(s) and adds placeholders while sites and/or invites are loading, for both the invites list and the invite details screen:

![2018-02-08t23 12 36-0600](https://user-images.githubusercontent.com/227022/36012689-9046a74c-0d25-11e8-976c-7badb8b6ecea.png)