### PR TITLE
Set default lang for logged out users using accept-language header

### DIFF
--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -11,7 +11,7 @@ import { getLocaleSlug } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { addLocaleToPath, getLanguage } from 'lib/i18n-utils';
+import { addLocaleToPath } from 'lib/i18n-utils';
 import LocaleSuggestionsListItem from './list-item';
 import QueryLocaleSuggestions from 'components/data/query-locale-suggestions';
 import Notice from 'components/notice';
@@ -33,22 +33,6 @@ export class LocaleSuggestions extends Component {
 	state = {
 		dismissed: false,
 	};
-
-	componentWillMount() {
-		let { locale } = this.props;
-
-		if ( ! locale && typeof navigator === 'object' && 'languages' in navigator ) {
-			for ( const langSlug of navigator.languages ) {
-				const language = getLanguage( langSlug.toLowerCase() );
-				if ( language ) {
-					locale = language.langSlug;
-					break;
-				}
-			}
-		}
-
-		switchLocale( locale );
-	}
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.locale !== nextProps.locale ) {

--- a/client/lib/redux-helpers/README.md
+++ b/client/lib/redux-helpers/README.md
@@ -1,4 +1,4 @@
 # Helpers for interoperability with redux store
 
 
-`setCurrentUserOnReduxStore` - sets current user id, current user id flags and adds the user to user's list
+`setCurrentUserOnReduxStore` - sets current user id, current user language, current user id flags and adds the user to user's list

--- a/client/lib/redux-helpers/index.js
+++ b/client/lib/redux-helpers/index.js
@@ -3,14 +3,16 @@
  */
 import { receiveUser } from 'state/users/actions';
 import { setCurrentUserId, setCurrentUserFlags } from 'state/current-user/actions';
+import { setLocale } from 'state/ui/language/actions';
 
 /**
  * Sets current user id, current user id flags and adds the user to user's list
- * @param {User} user user object as recivied from currentUser.get() singleton store
+ * @param {User} user user object as received from currentUser.get() singleton store
  * @param {ReduxStore} store redux store, an object with dispatch method
  */
 export const setCurrentUserOnReduxStore = ( user, store ) => {
 	store.dispatch( receiveUser( user ) );
 	store.dispatch( setCurrentUserId( user.ID ) );
 	store.dispatch( setCurrentUserFlags( user.meta.data.flags.active_flags ) );
+	store.dispatch( setLocale( user.localeSlug ) );
 };

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -30,7 +30,6 @@ import { login } from 'lib/paths';
 import { logSectionResponseTime } from './analytics';
 import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
 import analytics from '../lib/analytics';
-import { getLanguage } from 'lib/i18n-utils';
 import { getLanguage, getLocaleFromPath } from 'lib/i18n-utils';
 
 const debug = debugFactory( 'calypso:pages' );

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -30,6 +30,7 @@ import { login } from 'lib/paths';
 import { logSectionResponseTime } from './analytics';
 import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
 import analytics from '../lib/analytics';
+import { getLanguage } from 'lib/i18n-utils';
 
 const debug = debugFactory( 'calypso:pages' );
 
@@ -233,6 +234,15 @@ function getDefaultContext( request ) {
 }
 
 function setUpLoggedOutRoute( req, res, next ) {
+	req.context = getDefaultContext( req );
+
+	const acceptedLanguages = getAcceptedLanguagesFromHeader( req.headers[ 'accept-language' ] );
+	// check if the browser's first language is in config.languages
+	const language = getLanguage( acceptedLanguages[ 0 ] );
+	if ( language ) {
+		req.context.lang = language.langSlug;
+	}
+
 	res.set( {
 		'X-Frame-Options': 'SAMEORIGIN',
 	} );

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -31,6 +31,7 @@ import { logSectionResponseTime } from './analytics';
 import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
 import analytics from '../lib/analytics';
 import { getLanguage } from 'lib/i18n-utils';
+import { getLanguage, getLocaleFromPath } from 'lib/i18n-utils';
 
 const debug = debugFactory( 'calypso:pages' );
 
@@ -237,10 +238,17 @@ function setUpLoggedOutRoute( req, res, next ) {
 	req.context = getDefaultContext( req );
 
 	const acceptedLanguages = getAcceptedLanguagesFromHeader( req.headers[ 'accept-language' ] );
-	// check if the browser's first language is in config.languages
-	const language = getLanguage( acceptedLanguages[ 0 ] );
-	if ( language ) {
-		req.context.lang = language.langSlug;
+	const pathLocale = getLocaleFromPath( req.path );
+
+	// priority is the slug in the path
+	if ( pathLocale ) {
+		req.context.lang = pathLocale;
+	} else {
+		// check if the browser's first language is in config.languages
+		const language = getLanguage( acceptedLanguages[ 0 ] );
+		if ( language ) {
+			req.context.lang = language.langSlug;
+		}
 	}
 
 	res.set( {


### PR DESCRIPTION
❓Question to reviewers: Is this a reasonable approach to ensure that users receive our content in relevant locales?

## What this PR does
In #21138 we switched to the user's browser language via `navigator.languages` in `<LocaleSuggestions />`. This is because previously the page defaulted to English.

I believe there's merit in doing this on the server side using request headers.

I've done this by checking for a langSlug in `request.path`, then if none exists, looking to the headers for the preferred language. 

**Update**: Or should we check the cookie à la WordPress.com? See: 119164-pb

So, assuming your preferred browser language is Japanese:

<img width="400" alt="screen shot 2018-02-12 at 4 28 47 pm" src="https://user-images.githubusercontent.com/6458278/36084488-dd0d8d9a-1011-11e8-87e7-f10d5f08f7ef.png">

<img width="377" alt="screen shot 2018-02-12 at 4 28 59 pm" src="https://user-images.githubusercontent.com/6458278/36084487-dbf3b416-1011-11e8-9179-696cc4df11dd.png">

## UI locale persists after logging in 
The consequence of switching locales is that the langSlug is stored in `state.ui.localeSlug`, and persists even after login.

If you set your browser's primary language to something other your WordPress.com account language, visit https://wordpress.com/start, then log in, the UI language is the browser's language regardless of which language your account specifies.

Therefore we want to update this value to the user's saved locale as soon as he or she logs in. I'm doing this by adding `setLocale` to `setCurrentUserOnReduxStore` in [client/lib/redux-helpers/index.js](https://github.com/Automattic/wp-calypso/blob/ba6ebb9/client/lib/redux-helpers/index.js)

## Testing
1. Set your browser to another language (e.g., Japanese)
2. In a logged out state, visit **http://calypso.localhost:3000/start**
3. Change the url to **http://calypso.localhost:3000/start/fr** and refresh

**Expectation**
At 2: the UI should be Japanese
At 3: the UI should be in French

1. From **http://calypso.localhost:3000/start** or **http://calypso.localhost:3000/themes**, login

**Expectation**
The UI locale should switch to the locale you have saved in your settings

