### PR TITLE
Sign up: Switching to browser language shouldn't save the lang slug to state

### DIFF
--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -5,7 +5,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { getLocaleSlug } from 'i18n-calypso';
 
 /**
@@ -15,13 +14,12 @@ import { addLocaleToPath, getLanguage } from 'lib/i18n-utils';
 import LocaleSuggestionsListItem from './list-item';
 import LocaleSuggestionStore from 'lib/locale-suggestions';
 import Notice from 'components/notice';
-import { setLocale } from 'state/ui/language/actions';
+import switchLocale from 'lib/i18n-utils/switch-locale';
 
 class LocaleSuggestions extends Component {
 	static propTypes = {
 		locale: PropTypes.string,
 		path: PropTypes.string.isRequired,
-		setLocale: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -42,7 +40,7 @@ class LocaleSuggestions extends Component {
 			}
 		}
 
-		this.props.setLocale( locale );
+		switchLocale( locale );
 	}
 
 	componentDidMount() {
@@ -57,7 +55,7 @@ class LocaleSuggestions extends Component {
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.locale !== nextProps.locale ) {
-			this.props.setLocale( nextProps.locale );
+			switchLocale( nextProps.locale );
 		}
 	}
 
@@ -107,6 +105,4 @@ class LocaleSuggestions extends Component {
 	}
 }
 
-export default connect( null, {
-	setLocale,
-} )( LocaleSuggestions );
+export default LocaleSuggestions;

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -61,7 +61,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
   <div
     className="jetpack-connect__authorize-form"
   >
-    <Connect(LocaleSuggestions)
+    <LocaleSuggestions
       locale="es"
       path="/jetpack/connect/authorize/es"
     />


### PR DESCRIPTION
#21138 introduced a minor bug (sorry!) in that when a valid `langSlug` is passed as a prop to `<LocaleSuggestions />` it saves it to the redux store. 

The result is that a language other than that which a user has chosen in `/me/settings` will persist. In this case, the primary browser language.

For example: 

1. Set your browser's primary language to something other your WordPress.com account language. I chose German. __Ja!__
2. Visit https://wordpress.com/  (the page redirects you to  https://de.wordpress.com/)
3. Click on __Get Started__. The `langSlug` is passed to the next page.
 (https://wordpress.com/start/about/de?ref=homepage)
4. Now log in. The UI language is German regardless of which language your account uses.

Reason? The `langSlug` is saved to the redux store at step 3.

## Testing
1. Set your browser's primary language to German.
2. When logged out, go to http://calypso.localhost:3000/start/de. This simulates steps 2-3 above.
3. Now log in.

**Expectations**
At Step 2 the page will still be in German, however after having logged in, the UI will switch to your previously-saved account language.

#manual-testing
