### PR TITLE
Rewind: Handle some API response issues better

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -12,6 +12,8 @@ import { rewindStatus } from './schema';
 
 import downloads from './downloads';
 
+const getType = o => ( o && o.constructor && o.constructor.name ) || typeof o;
+
 const fetchRewindState = action =>
 	http(
 		{
@@ -51,10 +53,38 @@ const updateRewindState = ( { siteId }, data ) => {
 	return [ stateUpdate, delayedStateRequest ];
 };
 
-const setUnknownState = ( { siteId }, error ) =>
-	withAnalytics(
+const setUnknownState = ( { siteId }, error ) => {
+	const httpStatus = error.hasOwnProperty( 'status' ) ? parseInt( error.status, 10 ) : null;
+
+	// these are indicative of a network request
+	if (
+		error.hasOwnProperty( 'code' ) &&
+		error.hasOwnProperty( 'message' ) &&
+		httpStatus &&
+		httpStatus >= 400 // bad HTTP responses, could be 4xx or 5xx
+	) {
+		return withAnalytics(
+			recordTracksEvent( 'calypso_rewind_state_bad_response', {
+				code: error.code,
+				message: error.message,
+				status: error.status,
+			} ),
+			{
+				type: REWIND_STATE_UPDATE,
+				siteId,
+				data: {
+					state: 'unavailable',
+					reason: 'unknown',
+					lastUpdated: new Date(),
+				},
+			}
+		);
+	}
+
+	return withAnalytics(
 		recordTracksEvent( 'calypso_rewind_state_parse_error', {
-			error: JSON.stringify( error, null, 2 ),
+			type: getType( error ),
+			error: JSON.stringify( error ),
 		} ),
 		{
 			type: REWIND_STATE_UPDATE,
@@ -65,6 +95,7 @@ const setUnknownState = ( { siteId }, error ) =>
 			},
 		}
 	);
+};
 
 export default mergeHandlers( downloads, {
 	[ REWIND_STATE_REQUEST ]: [


### PR DESCRIPTION
After investigating some of the parse failures we've been seeing I made
this patch to better seggregate them and report them.

Surprisingly we have errors of a type I didn't anticipate and we will
need to investigate these.

Nonetheless these errors aren't parse errors - they were network errors,
or more specifically, network requests returning with 4xx error codes.

This patch just cleans up some things to make continued investigation
easier.

**Testing**

In local dev mode open up a site with **Activity Log** and navigate
to **My Sites** > **Stats** > **Activity**

You can fake network responses in the developer console.

```js
dispatch( {
	type: 'REWIND_STATE_REQUEST',
	siteId: MY_SITE_ID,
	meta: {
		dataLayer: {
			trackRequest: true,
			error: {
				code: 'no_connected_jetpack',
				status: 412,
				message: 'what'
			}
		},
	},
} )
```

In **master** this should show `state: unknown` but in
this branch it should show `state: unauthorized, reason: unknown`

the distinction is subtle but for these kinds of errors we're saying
that Rewind isn't available but we don't know why and that's different
than getting a response we can't parse where Rewind _could_ be
available or running and we just don't realize it.