### PR TITLE
Jetpack Onboading: Make Contact/Business Address verbiage less confusing

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
@@ -76,8 +76,16 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 	render() {
 		const { isRequestingSettings, translate } = this.props;
 		const headerText = translate( 'Add a business address.' );
-		const subHeaderText = translate(
-			'Enter your business address to have a map added to your website.'
+		const subHeaderText = (
+			<Fragment>
+				{ translate(
+					'Enter your business address to add a widget containing your address to your website.'
+				) }
+				<br />
+				{ translate(
+					'You can add a map based on this information and change where this widget is located later on.'
+				) }
+			</Fragment>
 		);
 		return (
 			<div className="steps__main">

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -32,7 +32,15 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 	render() {
 		const { getForwardUrl, settings, translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
-		const subHeaderText = translate( 'Would you like to get started with a Contact Us page?' );
+		const subHeaderText = (
+			<Fragment>
+				{ translate( 'Would you like to create a Contact Us page with a contact form on it?' ) }
+				<br />
+				{ translate(
+					'This form will allow visitors to contact you with their name, email, website, and a message.'
+				) }
+			</Fragment>
+		);
 		const hasContactForm = !! get( settings, 'addContactForm' );
 
 		return (


### PR DESCRIPTION
### Purpose

As mentioned in https://github.com/Automattic/wp-calypso/pull/22247#issuecomment-364281460, it's not very clear what the Contact Form and Business Address steps do and that can cause confusion for users. This PR implements the suggested copy changes.

### Preview

**Contact Form (before)**
![](https://cldup.com/rFOebpJ4Jh.png)

**Contact Form (after)**
![](https://cldup.com/gzKA8KAR9D.png)

**Business Address (before)**
![](https://cldup.com/9EV7nU80ZA.png)

**Business Address (after)**
![](https://cldup.com/jPgmdhPURi.png)

### Testing
* Checkout this branch
* Run the onboarding flow
* Reach the Contact form step and verify the header content looks good.
* Reach the Business Address step and verify the header content looks good.