### PR TITLE
Replace cryptic notice with tracking events

### DIFF
--- a/client/state/data-layer/wpcom/domains/validation-schemas/index.js
+++ b/client/state/data-layer/wpcom/domains/validation-schemas/index.js
@@ -2,8 +2,7 @@
 /**
  * External dependencies
  */
-import { translate } from 'i18n-calypso';
-import { get, join } from 'lodash';
+import { flatten, get, join, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,7 +11,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { DOMAIN_MANAGEMENT_VALIDATION_SCHEMAS_REQUEST } from 'state/action-types';
 import { addValidationSchemas } from 'state/domains/management/validation-schemas/actions';
-import { errorNotice } from 'state/notices/actions';
+import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Convert an application level request action for domain contact information
@@ -44,13 +43,19 @@ export const onSuccess = ( action, schemas ) => addValidationSchemas( schemas );
 /**
  * Create an error notice action when the request fails
  *
- * @param   {Object} action   Originating action (unused).
- * @param   {Object} error    Error information (unused).
- * @returns {Object}          error notice action
+ * @param   {Object} tlds   Originating action with the original list of requested tlds
+ * @param   {Object} error  Error information (query path, error message etc).
+ * @returns {[Action]}      An array of mc and tracks analytics events, one each per tld
  */
-export const onError = () =>
-	errorNotice(
-		translate( "We couldn't load the data for validating ccTLD specific requirements." )
+export const onError = ( { tlds }, error ) =>
+	flatten(
+		map( tlds, tld => [
+			bumpStat( 'form_validation_schema_exceptions', `load_${ tld }` ),
+			recordTracksEvent( 'calypso_domain_contact_validation_schema_load_failure', {
+				tld,
+				error: JSON.stringify( error ),
+			} ),
+		] )
 	);
 
 export default {

--- a/client/state/data-layer/wpcom/domains/validation-schemas/index.js
+++ b/client/state/data-layer/wpcom/domains/validation-schemas/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { flatten, get, join, map } from 'lodash';
+import { get, join, flatMap } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,7 +11,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { DOMAIN_MANAGEMENT_VALIDATION_SCHEMAS_REQUEST } from 'state/action-types';
 import { addValidationSchemas } from 'state/domains/management/validation-schemas/actions';
-import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Convert an application level request action for domain contact information
@@ -48,8 +48,8 @@ export const onSuccess = ( action, schemas ) => addValidationSchemas( schemas );
  * @returns {[Action]}      An array of mc and tracks analytics events, one each per tld
  */
 export const onError = ( { tlds }, error ) =>
-	flatten(
-		map( tlds, tld => [
+	composeAnalytics(
+		...flatMap( tlds, tld => [
 			bumpStat( 'form_validation_schema_exceptions', `load_${ tld }` ),
 			recordTracksEvent( 'calypso_domain_contact_validation_schema_load_failure', {
 				tld,


### PR DESCRIPTION
Following up from #21910, this PR replaces the error notice with some events logging:
You'll need http errors to test it. The easiest way is probably to break the path in [`client/state/data-layer/wpcom/domains/validation-schemas/index.js:29`](https://github.com/Automattic/wp-calypso/blob/update/domains/validation-schema-load-failure-handling/client/state/data-layer/wpcom/domains/validation-schemas/index.js#L29), but there are lots of alternatives (note that spurious tlds will not cause an error).

`localStorage.setItem('debug', "calypso:analytics:mc,calypso:analytics:tracks")` is also super helpful, as mc events will go there, but not go to the server from `dev`


![checkout_ _julesauspremiumtest_ _wordpress_com_and_slay_the_spire](https://user-images.githubusercontent.com/5952255/36026994-1b103982-0de5-11e8-97ad-c1744e807839.jpg)
