### PR TITLE
JP Onboarding: Remove Distractions from Masterbar

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -85,16 +85,14 @@ const Layout = createReactClass( {
 	},
 
 	renderMasterbar: function() {
-		const { section } = this.props;
-
-		if ( ! this.props.user || section.name === 'jetpack-onboarding' ) {
-			return <MasterbarLoggedOut sectionName={ section.name } />;
+		if ( ! this.props.user ) {
+			return <MasterbarLoggedOut sectionName={ this.props.section.name } />;
 		}
 
 		return (
 			<MasterbarLoggedIn
 				user={ this.props.user }
-				section={ section.group }
+				section={ this.props.section.group }
 				sites={ this.props.sites }
 			/>
 		);

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -85,14 +85,16 @@ const Layout = createReactClass( {
 	},
 
 	renderMasterbar: function() {
-		if ( ! this.props.user ) {
-			return <MasterbarLoggedOut sectionName={ this.props.section.name } />;
+		const { section } = this.props;
+
+		if ( ! this.props.user || section.name === 'jetpack-onboarding' ) {
+			return <MasterbarLoggedOut sectionName={ section.name } />;
 		}
 
 		return (
 			<MasterbarLoggedIn
 				user={ this.props.user }
-				section={ this.props.section.group }
+				section={ section.group }
 				sites={ this.props.sites }
 			/>
 		);

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Masterbar from './masterbar';
 import { getLocaleSlug, localize } from 'i18n-calypso';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,7 +39,7 @@ const MasterbarLoggedOut = ( { title, sectionName, translate, redirectUri } ) =>
 		</Item>
 		<Item className="masterbar__item-title">{ title }</Item>
 		<div className="masterbar__login-links">
-			{ 'signup' !== sectionName ? (
+			{ ! includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) ? (
 				<Item url={ config( 'signup_url' ) }>
 					{ translate( 'Sign Up', {
 						context: 'Toolbar',
@@ -47,7 +48,7 @@ const MasterbarLoggedOut = ( { title, sectionName, translate, redirectUri } ) =>
 				</Item>
 			) : null }
 
-			{ 'login' !== sectionName ? (
+			{ ! includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ? (
 				<Item url={ getLoginUrl( redirectUri ) }>
 					{ translate( 'Log In', {
 						context: 'Toolbar',


### PR DESCRIPTION
Addresses https://github.com/Automattic/wp-calypso/pull/21793#issuecomment-361665530.

**Logged-out:**

Before:

![image](https://user-images.githubusercontent.com/96308/36031250-06a945ee-0da2-11e8-8703-d25d05ca758f.png)

After: 
![image](https://user-images.githubusercontent.com/96308/36031223-ed664d70-0da1-11e8-84e7-98ac45e27fc0.png)

**Logged-in:**

Before:

![image](https://user-images.githubusercontent.com/96308/36031986-6cf7e376-0da4-11e8-8ad2-529e4f73305e.png)

~~After:~~ (unchanged)

![image](https://user-images.githubusercontent.com/96308/36032497-1e631120-0da6-11e8-83fc-1b254cd2cdc5.png)

Design question: Do we really want to remove all those items from the logged-in masterbar as well? Feels a bit dirty... /cc @rickybanister *edit*: We don't, see https://github.com/Automattic/wp-calypso/pull/22288#issuecomment-364525700

To test:
* Logged-out:
  * While logged-out of WP.com (e.g. in an incognito window), land at `http://Your.wpsandbox.me/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` (make sure you have JP >= 5.8 installed and activated), and wait to be redirected.
  * Verify that there are no 'Sign Up' and 'Log In' links in the masterbar.
  * Try different logged-out sections (e.g. `http://calypso.localhost:3000/themes`), and verify the 'Sign Up' and 'Log In' links are still there.
* ~~Logged-in:~~
  * ~~Repeat the same steps while logged into WP.com. Verify that the masterbar also only has the WordPress.com logotype. Try other sections and verify that the masterbar is intact there.~~
