### PR TITLE
Login: Use mutually exclusive branches for path construction

### DIFF
--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -25,13 +25,9 @@ export function login( {
 
 		if ( socialService ) {
 			url += '/' + socialService + '/callback';
-		}
-
-		if ( twoFactorAuthType ) {
+		} else if ( twoFactorAuthType ) {
 			url += '/' + twoFactorAuthType;
-		}
-
-		if ( socialConnect ) {
+		} else if ( socialConnect ) {
 			url += '/social-connect';
 		}
 	}


### PR DESCRIPTION
The intentions of building a URL from these parameters is unclear
looking at the code. It could result in several fragments being appended
to the same URL. Looking at the log-in routes, it appears that is not
the desired behavior.

The following is an example of a possible erroneous usage:

```js
login( {
  isNative: true,
  socialConnect: true,
  socialService: 'my-service',
  twoFactorAuthType: 'code',
} );

// produces
"/log-in/my-service/callback/code/social-connect"
```

Since return short-circuiting is not an option, use exclusive branches
with else-if chaining.

Spotted while working on #22218 

## Testing
1. Verify the basic ideas behind this PR are accurate. Are there situations where we'd want to generate those urls?
1. Tests should continue to pass

Route definitions:

https://github.com/Automattic/wp-calypso/blob/ba6ebb919cab37644f841ab7dcf72f30aa5e3c81/client/login/index.node.js#L12-L19
https://github.com/Automattic/wp-calypso/blob/ba6ebb919cab37644f841ab7dcf72f30aa5e3c81/client/login/index.web.js#L10-L37