### PR TITLE
Rewind - Credentials Form: add link to go to Activity Log 

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/style.scss
@@ -1,3 +1,7 @@
+.credentials-configured {
+	margin-bottom: 0;
+}
+
 .credentials-configured__header {
 	width: 85%;
 }

--- a/client/my-sites/site-settings/jetpack-credentials/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/index.jsx
@@ -17,10 +17,11 @@ import Gridicon from 'gridicons';
 import QueryRewindState from 'components/data/query-rewind-state';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getRewindState } from 'state/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 
 class JetpackCredentials extends Component {
 	render() {
-		const { credentials, rewindState, siteId, translate } = this.props;
+		const { credentials, rewindState, siteId, translate, siteSlug } = this.props;
 		const hasAuthorized = rewindState === 'provisioning' || rewindState === 'active';
 		const hasCredentials = some( credentials, { role: 'main' } );
 
@@ -45,6 +46,11 @@ class JetpackCredentials extends Component {
 				) : (
 					<CredentialsSetupFlow siteId={ siteId } />
 				) }
+				{ hasCredentials && (
+					<CompactCard href={ `/stats/activity/${ siteSlug }` }>
+						{ translate( "View your site's backups and activity" ) }
+					</CompactCard>
+				) }
 			</div>
 		);
 	}
@@ -58,5 +64,6 @@ export default connect( state => {
 		credentials,
 		rewindState,
 		siteId,
+		siteSlug: getSiteSlug( state, siteId ),
 	};
 } )( localize( JetpackCredentials ) );


### PR DESCRIPTION
Fixes #22167

This PR introduces a link in the credentials form found in Settings > Security so after the credentials are entered and accepted, users can go back to Activity Log.

### Auto-config creds

<img width="734" alt="captura de pantalla 2018-02-09 a la s 13 41 23" src="https://user-images.githubusercontent.com/1041600/36039162-7738d9de-0da0-11e8-8522-a0ff0aa4a7ee.png">

### Manual config creds

<img width="734" alt="captura de pantalla 2018-02-09 a la s 13 47 02" src="https://user-images.githubusercontent.com/1041600/36039164-77c6325c-0da0-11e8-8241-40d079747999.png">

### Testing

Test with a site that can auto-configure credentials and another that has to manually enter credentials. When credentials are ok, they should both display the link to go back to Activity Log.