### PR TITLE
Rewind - Credentials: update explanation text shown when manually configuring

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-tos.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-tos.jsx
@@ -27,10 +27,9 @@ const SetupTos = ( { autoConfigure, canAutoconfigure, reset, translate, goToNext
 							"host's server?"
 					)
 				: translate(
-						'By adding your site credentials, you are giving ' +
-							'WordPress.com access to perform automatic actions on your ' +
-							'server including backing up your site, restoring your site, ' +
-							'as well as manually accessing your site in case of an emergency.'
+						'By adding credentials, you are providing us with access to your server ' +
+							'to perform automatic actions (such as backing up or restoring your site) ' +
+							'or to manually access your site in case of an emergency.'
 					) }
 		</div>
 		<div className="credentials-setup-flow__tos-buttons">


### PR DESCRIPTION
Fixes #22192

This PR updates the text shown to users manually configuring credentials that explains what happens when adding the credentials.

### Before

![screen shot 2018-02-06 at 3 43 43 pm](https://user-images.githubusercontent.com/108942/35888349-89f1b76a-0b54-11e8-96f9-3a4d70f2ef85.png)

### After

<img width="732" alt="captura de pantalla 2018-02-09 a la s 14 39 06" src="https://user-images.githubusercontent.com/1041600/36041359-01bf3ae8-0da7-11e8-95e2-0ace38ffea53.png">
