### PR TITLE
Rewind API: Allow `queued` status for Rewind operation

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -45,7 +45,7 @@ export const rewind = {
 	type: 'object',
 	properties: {
 		rewind_id: { type: 'string' },
-		status: { type: 'string', enum: [ 'failed', 'finished', 'running' ] },
+		status: { type: 'string', enum: [ 'failed', 'finished', 'queued', 'running' ] },
 		started_at: { type: 'string' },
 		progress: { type: 'integer' },
 		reason: { type: 'string' },


### PR DESCRIPTION
Previously we were failing to validate a response if it included
a Rewind operation with the `queued` status. This existed but we
had no enumeration on the server what states were possible and
we didn't see it in development.

This patch adds the state in so it parses successfully.

**Testing**

Load a site with **Rewind** and inject a state with `queued` Rewind
Make sure it parses in `state.rewind[ siteId ]`

```js
dispatch( {
	type: 'REWIND_STATE_REQUEST',
	siteId: MY_SITE_ID,
	meta: {
		dataLayer: {
			trackRequest: true,
			data: {
				credentials: [
					{
						still_valid: true,
						type: 'managed',
						role: 'main',
					},
				],
				rewind: {
					status: 'queued',
					rewind_id: '123456',
					started_at: '2018-01-09 17:54:56',
				},
				state: 'active',
				last_updated: 1518197797,
			},
		},
	},
} );
```