### PR TITLE
JP Onboarding: Use `basePath` to construct PageViewTracker's `path`

### DIFF
--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -71,6 +71,7 @@ class Wizard extends Component {
 	render() {
 		const {
 			backText,
+			basePath,
 			components,
 			forwardText,
 			hideNavigation,
@@ -91,6 +92,7 @@ class Wizard extends Component {
 				) }
 
 				{ React.cloneElement( component, {
+					basePath,
 					getBackUrl: this.getBackUrl,
 					getForwardUrl: this.getForwardUrl,
 					steps,

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -74,7 +74,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 	};
 
 	render() {
-		const { isRequestingSettings, translate } = this.props;
+		const { basePath, isRequestingSettings, translate } = this.props;
 		const headerText = translate( 'Add a business address.' );
 		const subHeaderText = translate(
 			'Enter your business address to have a map added to your website.'
@@ -83,7 +83,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 			<div className="steps__main">
 				<DocumentHead title={ translate( 'Business Address ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
-					path={ '/jetpack/onboarding/' + STEPS.BUSINESS_ADDRESS + '/:site' }
+					path={ [ basePath, STEPS.BUSINESS_ADDRESS, ':site' ].join( '/' ) }
 					title="Business Address ‹ Jetpack Onboarding"
 				/>
 

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -30,7 +30,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 	};
 
 	render() {
-		const { getForwardUrl, settings, translate } = this.props;
+		const { basePath, getForwardUrl, settings, translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'Would you like to get started with a Contact Us page?' );
 		const hasContactForm = !! get( settings, 'addContactForm' );
@@ -39,7 +39,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 			<div className="steps__main">
 				<DocumentHead title={ translate( 'Contact Form ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
-					path={ '/jetpack/onboarding/' + STEPS.CONTACT_FORM + '/:site' }
+					path={ [ basePath, STEPS.CONTACT_FORM, ':site' ].join( '/' ) }
 					title="Contact Form ‹ Jetpack Onboarding"
 				/>
 

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -31,7 +31,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 	};
 
 	render() {
-		const { getForwardUrl, settings, translate } = this.props;
+		const { basePath, getForwardUrl, settings, translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'What should visitors see on your homepage?' );
 		const forwardUrl = getForwardUrl();
@@ -41,7 +41,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 			<div className="steps__main">
 				<DocumentHead title={ translate( 'Homepage ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
-					path={ '/jetpack/onboarding/' + STEPS.HOMEPAGE + '/:site' }
+					path={ [ basePath, STEPS.HOMEPAGE, ':site' ].join( '/' ) }
 					title="Homepage ‹ Jetpack Onboarding"
 				/>
 

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -55,7 +55,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	};
 
 	render() {
-		const { isRequestingSettings, translate } = this.props;
+		const { basePath, isRequestingSettings, translate } = this.props;
 		const headerText = translate( "Let's get started." );
 		const subHeaderText = translate(
 			'First up, what would you like to name your site and have as its public description?'
@@ -65,7 +65,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 			<div className="steps__main">
 				<DocumentHead title={ translate( 'Site Title ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
-					path={ '/jetpack/onboarding/' + STEPS.SITE_TITLE + '/:site' }
+					path={ [ basePath, STEPS.SITE_TITLE, ':site' ].join( '/' ) }
 					title="Site Title ‹ Jetpack Onboarding"
 				/>
 

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -30,7 +30,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 	};
 
 	render() {
-		const { getForwardUrl, settings, translate } = this.props;
+		const { basePath, getForwardUrl, settings, translate } = this.props;
 		const headerText = translate( "Let's shape your new site." );
 		const subHeaderText = translate( 'What kind of site do you need? Choose an option below:' );
 		const forwardUrl = getForwardUrl();
@@ -40,7 +40,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 			<div className="steps__main">
 				<DocumentHead title={ translate( 'Site Type ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
-					path={ '/jetpack/onboarding/' + STEPS.SITE_TYPE + '/:site' }
+					path={ [ basePath, STEPS.SITE_TYPE, ':site' ].join( '/' ) }
 					title="Site Type ‹ Jetpack Onboarding"
 				/>
 

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -21,7 +21,7 @@ import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
 	render() {
-		const { siteId, siteSlug, siteUrl, steps, translate } = this.props;
+		const { basePath, siteId, siteSlug, siteUrl, steps, translate } = this.props;
 
 		const headerText = translate( "You're ready to go!" );
 		const subHeaderText = translate(
@@ -33,7 +33,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 			<div className="steps__main">
 				<DocumentHead title={ translate( 'Summary ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
-					path={ '/jetpack/onboarding/' + STEPS.SUMMARY + '/:site' }
+					path={ [ basePath, STEPS.SUMMARY, ':site' ].join( '/' ) }
 					title="Summary ‹ Jetpack Onboarding"
 				/>
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -41,7 +41,12 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 				<div className="steps__summary-columns">
 					<div className="steps__summary-column">
 						<h3 className="steps__summary-heading">{ translate( "Steps you've completed:" ) }</h3>
-						<CompletedSteps siteId={ siteId } siteSlug={ siteSlug } steps={ steps } />
+						<CompletedSteps
+							basePath={ basePath }
+							siteId={ siteId }
+							siteSlug={ siteSlug }
+							steps={ steps }
+						/>
 					</div>
 					<div className="steps__summary-column">
 						<h3 className="steps__summary-heading">{ translate( 'Continue your site setup:' ) }</h3>

--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -30,7 +30,7 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 	};
 
 	render() {
-		const { getForwardUrl, stepsCompleted, stepsPending, translate } = this.props;
+		const { basePath, getForwardUrl, stepsCompleted, stepsPending, translate } = this.props;
 		const headerText = translate( 'Are you looking to sell online?' );
 		const subHeaderText = translate(
 			"We'll set you up with WooCommerce for all of your online selling needs."
@@ -43,7 +43,7 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 			<div className="steps__main">
 				<DocumentHead title={ translate( 'WooCommerce ‹ Jetpack Onboarding' ) } />
 				<PageViewTracker
-					path={ '/jetpack/onboarding/' + STEPS.WOOCOMMERCE + '/:site' }
+					path={ [ basePath, STEPS.WOOCOMMERCE, ':site' ].join( '/' ) }
 					title="WooCommerce ‹ Jetpack Onboarding"
 				/>
 

--- a/client/jetpack-onboarding/summary-completed-steps.jsx
+++ b/client/jetpack-onboarding/summary-completed-steps.jsx
@@ -23,7 +23,7 @@ import {
 	JETPACK_ONBOARDING_STEPS as STEPS,
 } from './constants';
 
-const CompletedSteps = ( { siteSlug, steps, stepsCompleted, stepsPending } ) =>
+const CompletedSteps = ( { basePath, siteSlug, steps, stepsCompleted, stepsPending } ) =>
 	map( without( steps, STEPS.SUMMARY ), stepName => {
 		const isCompleted = get( stepsCompleted, stepName ) === true;
 		const isPending = get( stepsPending, stepName );
@@ -39,9 +39,7 @@ const CompletedSteps = ( { siteSlug, steps, stepsCompleted, stepsPending } ) =>
 				) : (
 					<Gridicon icon={ isCompleted ? 'checkmark' : 'cross' } size={ 18 } />
 				) }
-				<a href={ `/jetpack/onboarding/${ stepName }/${ siteSlug }` }>
-					{ STEP_TITLES[ stepName ] }
-				</a>
+				<a href={ [ basePath, stepName, siteSlug ].join( '/' ) }>{ STEP_TITLES[ stepName ] }</a>
 			</div>
 		);
 	} );


### PR DESCRIPTION
Prep for #22302.

Have the `Wizard` component pass `basePath` as a prop to individual steps, and use it to construct the `PageViewTracker` component's `path` prop from it dynamically (instead of hardcoding `/jetpack/onboarding` there). Also, use `basePath` to construct the 'Completed Steps' links on the Summary Page.

To test:
* Enable analytics debugging for the `PageViewTracker`: `localStorage.setItem( 'debug', 'calypso:analytics:PageViewTracker' )`
* Land at http://your.wpsandbox.me/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development, and navigate thru all steps (choose Business site during the site type step).
* In the browser console, verify that upon entering each step, an event named containing the string `Queuing Page View` is fired. Check that it's correct in each case. Example:

```
calypso:analytics:PageViewTracker Queuing Page View: "Site Title ‹ Jetpack Onboarding" at "/jetpack/onboarding/site-title/:site" with 0ms delay +4ms
```
* On the Summary Page, verify that the 'Completed Steps' links still point to the correct targets (i.e. the individual steps).