### PR TITLE
JP Onboarding: Change Public-facing URL to /jetpack/start

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -121,7 +121,7 @@ export function maybeOnboard( { query, store }, next ) {
 
 		store.dispatch( receiveJetpackOnboardingCredentials( siteId, credentials ) );
 
-		return page.redirect( '/jetpack/onboarding/' + siteSlug );
+		return page.redirect( '/jetpack/start/' + siteSlug );
 	}
 
 	next();

--- a/client/jetpack-onboarding/index.js
+++ b/client/jetpack-onboarding/index.js
@@ -17,7 +17,7 @@ export default function() {
 	if ( isEnabled( 'jetpack/onboarding' ) ) {
 		const validStepNames = values( JETPACK_ONBOARDING_STEPS );
 		page(
-			`/jetpack/onboarding/:stepName(${ validStepNames.join( '|' ) })?/:site`,
+			`/jetpack/start/:stepName(${ validStepNames.join( '|' ) })?/:site`,
 			onboarding,
 			makeLayout,
 			clientRender

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -71,7 +71,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 				<QueryJetpackOnboardingSettings siteId={ siteId } />
 				{ siteId ? (
 					<Wizard
-						basePath="/jetpack/onboarding"
+						basePath="/jetpack/start"
 						baseSuffix={ siteSlug }
 						components={ COMPONENTS }
 						hideNavigation={ stepName === STEPS.SUMMARY }

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -81,10 +81,10 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		);
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'Business Address ‹ Jetpack Onboarding' ) } />
+				<DocumentHead title={ translate( 'Business Address ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.BUSINESS_ADDRESS, ':site' ].join( '/' ) }
-					title="Business Address ‹ Jetpack Onboarding"
+					title="Business Address ‹ Jetpack Start"
 				/>
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -37,10 +37,10 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'Contact Form ‹ Jetpack Onboarding' ) } />
+				<DocumentHead title={ translate( 'Contact Form ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.CONTACT_FORM, ':site' ].join( '/' ) }
-					title="Contact Form ‹ Jetpack Onboarding"
+					title="Contact Form ‹ Jetpack Start"
 				/>
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -39,10 +39,10 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'Homepage ‹ Jetpack Onboarding' ) } />
+				<DocumentHead title={ translate( 'Homepage ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.HOMEPAGE, ':site' ].join( '/' ) }
-					title="Homepage ‹ Jetpack Onboarding"
+					title="Homepage ‹ Jetpack Start"
 				/>
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -63,10 +63,10 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'Site Title ‹ Jetpack Onboarding' ) } />
+				<DocumentHead title={ translate( 'Site Title ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.SITE_TITLE, ':site' ].join( '/' ) }
-					title="Site Title ‹ Jetpack Onboarding"
+					title="Site Title ‹ Jetpack Start"
 				/>
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -38,10 +38,10 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'Site Type ‹ Jetpack Onboarding' ) } />
+				<DocumentHead title={ translate( 'Site Type ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.SITE_TYPE, ':site' ].join( '/' ) }
-					title="Site Type ‹ Jetpack Onboarding"
+					title="Site Type ‹ Jetpack Start"
 				/>
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -31,10 +31,10 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'Summary ‹ Jetpack Onboarding' ) } />
+				<DocumentHead title={ translate( 'Summary ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.SUMMARY, ':site' ].join( '/' ) }
-					title="Summary ‹ Jetpack Onboarding"
+					title="Summary ‹ Jetpack Start"
 				/>
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 

--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -41,10 +41,10 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 
 		return (
 			<div className="steps__main">
-				<DocumentHead title={ translate( 'WooCommerce ‹ Jetpack Onboarding' ) } />
+				<DocumentHead title={ translate( 'WooCommerce ‹ Jetpack Start' ) } />
 				<PageViewTracker
 					path={ [ basePath, STEPS.WOOCOMMERCE, ':site' ].join( '/' ) }
-					title="WooCommerce ‹ Jetpack Onboarding"
+					title="WooCommerce ‹ Jetpack Start"
 				/>
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -160,7 +160,7 @@ const sections = [
 	},
 	{
 		name: 'jetpack-onboarding',
-		paths: [ '/jetpack/onboarding' ],
+		paths: [ '/jetpack/start' ],
 		module: 'jetpack-onboarding',
 		secondary: false,
 		enableLoggedOut: true,


### PR DESCRIPTION
Also, change a number of public-facing strings (mostly page titles) to 'Jetpack Start'.

To test -- Verify that JPO still works (when triggered from http://your.wpsandbox.me/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development)

Fixes #22219.