### PR TITLE
Update wording on screen to start pending transfer.

### DIFF
--- a/client/my-sites/domains/domain-management/edit/transfer.jsx
+++ b/client/my-sites/domains/domain-management/edit/transfer.jsx
@@ -71,13 +71,20 @@ class Transfer extends React.PureComponent {
 				<Card compact={ false } highlight={ 'warning' }>
 					<div>
 						<h2 className="edit__transfer-text-fail">
-							{ translate( 'Important: Start Your Domain Transfer' ) }
+							{ translate(
+								'Important: Finish Moving {{strong}}%(domain)s{{/strong}} to WordPress.com',
+								{
+									components: {
+										strong: <strong />,
+									},
+									args: { domain: domain.name },
+								}
+							) }
 						</h2>
 						<p>
 							{ translate(
-								'We need you to complete a few steps to initiate and authorize the transfer of ' +
-									'{{strong}}%(domain)s{{/strong}} from your current domain provider to WordPress.com. Your domain ' +
-									'will stay at your current provider until the transfer is started.',
+								'Start the transfer to get your domain {{strong}}%(domain)s{{/strong}} moved to WordPress.com. ' +
+									'Your domain will stay at your current provider until the transfer is complete.',
 								{
 									components: {
 										strong: <strong />,

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -267,6 +267,7 @@ input[type=radio].domain-management-list-item__radio {
 	.edit__transfer-text-fail {
 		font-size: 18px;
 		font-weight: 500;
+		margin-bottom: 1em;
 	}
 
 	.edit__transfer-button-fail {


### PR DESCRIPTION
Start a transfer from `calypso.localhost:3000/start`
From the "Domain transfer waiting" nudge, go to the screen to start your pending transfer
The wording should now be:

> ### Important: Finish Moving **example.com** to WordPress.com
> Start the transfer to get your domain **example.com** moved to WordPress.com. Your domain will stay at your current provider until the transfer is complete.

