### PR TITLE
Use withSchemaValidation for persistence of Post Type Taxonomies reducer

### DIFF
--- a/client/state/post-types/taxonomies/reducer.js
+++ b/client/state/post-types/taxonomies/reducer.js
@@ -14,10 +14,8 @@ import {
 	POST_TYPES_TAXONOMIES_REQUEST,
 	POST_TYPES_TAXONOMIES_REQUEST_FAILURE,
 	POST_TYPES_TAXONOMIES_REQUEST_SUCCESS,
-	SERIALIZE,
-	DESERIALIZE,
 } from 'state/action-types';
-import { combineReducers, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -52,7 +50,7 @@ export function requesting( state = {}, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function items( state = {}, action ) {
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case POST_TYPES_TAXONOMIES_RECEIVE:
 			return Object.assign( {}, state, {
@@ -61,18 +59,10 @@ export function items( state = {}, action ) {
 				},
 			} );
 
-		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, itemsSchema ) ) {
-				return state;
-			}
-
-			return {};
-		case SERIALIZE:
+		default:
 			return state;
 	}
-
-	return state;
-}
+} );
 
 export default combineReducers( {
 	requesting,


### PR DESCRIPTION
Instead of coding the schema validation logic manually in the reducer, use the `withSchemaValidation` HoR helper instead.

Alternative approach would be to set the `schema` property on the reducer function, but that would require change in the tests, as the `schema` property comes into life only after the reducer is wrapped with `combineReducers`. The "naked" reducer doesn't do any schema validation on its own.

**How to test:**
The reducer has very good unit tests for the persistence behavior, it should be enough to run them.