### PR TITLE
Link directly to precheck page from checkout thank you page.

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -26,7 +26,7 @@ import {
 import { recordTracksEvent } from 'state/analytics/actions';
 import { localize } from 'i18n-calypso';
 import { preventWidows } from 'lib/formatting';
-import { domainManagementTransferIn } from 'my-sites/domains/paths';
+import { domainManagementTransferInPrecheck } from 'my-sites/domains/paths';
 
 class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
@@ -212,7 +212,7 @@ class CheckoutThankYouHeader extends PureComponent {
 			meta: primaryPurchase.meta,
 		} );
 
-		page( domainManagementTransferIn( selectedSite.slug, primaryPurchase.meta ) );
+		page( domainManagementTransferInPrecheck( selectedSite.slug, primaryPurchase.meta ) );
 	};
 
 	getButton() {

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -69,7 +69,7 @@ import ThankYouCard from 'components/thank-you-card';
 import {
 	domainManagementEmail,
 	domainManagementList,
-	domainManagementTransferIn,
+	domainManagementTransferInPrecheck,
 } from 'my-sites/domains/paths';
 import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -316,7 +316,7 @@ class CheckoutThankYou extends React.Component {
 					description: translate(
 						"Now that we've taken care of the plan, let's get your domain transferred."
 					),
-					buttonUrl: domainManagementTransferIn(
+					buttonUrl: domainManagementTransferInPrecheck(
 						this.props.selectedSite.slug,
 						delayedTransferPurchase.meta
 					),


### PR DESCRIPTION
Purchase a transfer in from calypso.localhost:3000/start
when you get to the thank you screen the "start transfer" button should take you directly to the precheck screen

Try the same thing with a DWPO user. That screen should also take you directly to the precheck screen.