### PR TITLE
Fix a buggy state update in Post Type Taxonomies reducer

### DIFF
--- a/client/state/post-types/taxonomies/reducer.js
+++ b/client/state/post-types/taxonomies/reducer.js
@@ -53,11 +53,13 @@ export function requesting( state = {}, action ) {
 export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case POST_TYPES_TAXONOMIES_RECEIVE:
-			return Object.assign( {}, state, {
+			return {
+				...state,
 				[ action.siteId ]: {
+					...state[ action.siteId ],
 					[ action.postType ]: keyBy( action.taxonomies, 'name' ),
 				},
-			} );
+			};
 
 		default:
 			return state;

--- a/client/state/post-types/taxonomies/test/reducer.js
+++ b/client/state/post-types/taxonomies/test/reducer.js
@@ -10,6 +10,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import reducer, { requesting, items } from '../reducer';
+import { receivePostTypeTaxonomies } from '../actions';
 import {
 	POST_TYPES_TAXONOMIES_RECEIVE,
 	POST_TYPES_TAXONOMIES_REQUEST,
@@ -200,6 +201,26 @@ describe( 'reducer', () => {
 
 			expect( updatedState ).to.eql( {
 				2916284: {
+					page: {},
+				},
+			} );
+		} );
+
+		test( 'should accumulate items for multiple sites and post types', () => {
+			const actions = [
+				receivePostTypeTaxonomies( 2916284, 'page', [] ),
+				receivePostTypeTaxonomies( 2916285, 'page', [] ),
+				receivePostTypeTaxonomies( 2916284, 'post', [] ),
+			];
+
+			const finalState = actions.reduce( items, undefined );
+
+			expect( finalState ).to.eql( {
+				2916284: {
+					page: {},
+					post: {},
+				},
+				2916285: {
 					page: {},
 				},
 			} );


### PR DESCRIPTION
When the reducer receives a taxonomies response for another post type within the same site, it does the deep immutable update of the state incorrectly. The state for existing post type is lost. For example,
```
{
  page: ...
}
```
becomes
```
{
  post: ...
}
```
but the desired result is:
```
{
  page: ...
  post: ...
}
```

The `requesting` reducer uses `_.merge` to implement a similar goal. However, that works only for primitive booleans and cannot be used here. `_.merge` would also merge the taxonomy list object in the leafs and that's not wanted: we need to replace the lists on update, not to merge the new one into the old.

I noticed this bug while working on #22306.

**How to test:**
There's a new unit test that checks the behavior.

A more complex way to test would be:
- open a post in editor and open the taxonomies accordion
- then go to a page editor, open the accordion there, too
- go back to the post editor
- see if the already available taxonomies list is displayed, as opposed to waiting for server response

It's arguably very hard to spot the difference. Maybe being offline could make the bug more visible.