### PR TITLE
Updated copy for /start/domains/transfer step

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -148,8 +148,8 @@ class TransferDomainStep extends React.Component {
 						<div>
 							{ translate(
 								'Move your domain from your current provider to WordPress.com so you can update settings, ' +
-									"renew your domain, and more right in your dashboard. We'll renew it for another year " +
-									'when the transfer is successful. {{a}}Learn More{{/a}}',
+									"renew your domain, and more \u2013 right in your dashboard. We'll renew it for another year " +
+									'when the transfer is successful. {{a}}Learn more{{/a}}.',
 								{
 									components: {
 										a: (


### PR DESCRIPTION
Start a transfer in from NUX. When you get to the transfer step, make sure the copy reads as in this screenshot.

<img width="733" alt="wordpress_com" src="https://user-images.githubusercontent.com/1379730/36052278-00f3fd56-0dbb-11e8-8d1c-be595bd42ead.png">

(There should be a dash after "and more", a period after "Learn more", and  "more" should not be capitalized.)