### PR TITLE
Refactor schema validation in the happychat.ui reducer

### DIFF
--- a/client/state/happychat/ui/reducer.js
+++ b/client/state/happychat/ui/reducer.js
@@ -5,7 +5,6 @@
  */
 import {
 	SERIALIZE,
-	DESERIALIZE,
 	HAPPYCHAT_OPEN,
 	HAPPYCHAT_MINIMIZING,
 	HAPPYCHAT_BLUR,
@@ -13,7 +12,7 @@ import {
 	HAPPYCHAT_IO_SEND_MESSAGE_MESSAGE,
 	HAPPYCHAT_SET_CURRENT_MESSAGE,
 } from 'state/action-types';
-import { combineReducers, isValidStateWithSchema } from 'state/utils';
+import { combineReducers } from 'state/utils';
 
 /**
  * Tracks the current message the user has typed into the happychat client
@@ -50,11 +49,6 @@ export const lostFocusAt = ( state = null, action ) => {
 				return Date.now();
 			}
 			return state;
-		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, { type: [ 'null', 'number' ] } ) ) {
-				return state;
-			}
-			return null;
 		case HAPPYCHAT_BLUR:
 			return Date.now();
 		case HAPPYCHAT_FOCUS:
@@ -62,7 +56,7 @@ export const lostFocusAt = ( state = null, action ) => {
 	}
 	return state;
 };
-lostFocusAt.hasCustomPersistence = true;
+lostFocusAt.schema = { type: 'number' };
 
 const isOpen = ( state = false, action ) => {
 	switch ( action.type ) {

--- a/client/state/happychat/ui/test/index.js
+++ b/client/state/happychat/ui/test/index.js
@@ -10,12 +10,20 @@ import { expect } from 'chai';
  */
 import {
 	SERIALIZE,
+	DESERIALIZE,
 	HAPPYCHAT_BLUR,
 	HAPPYCHAT_FOCUS,
 	HAPPYCHAT_IO_SEND_MESSAGE_MESSAGE,
 	HAPPYCHAT_SET_CURRENT_MESSAGE,
 } from 'state/action-types';
-import { lostFocusAt, currentMessage } from '../reducer';
+import { lostFocusAt as lostFocusAtWithoutValidation, currentMessage } from '../reducer';
+import { withSchemaValidation } from 'state/utils';
+jest.mock( 'lib/warn', () => () => {} );
+
+const lostFocusAt = withSchemaValidation(
+	lostFocusAtWithoutValidation.schema,
+	lostFocusAtWithoutValidation
+);
 
 // Simulate the time Feb 27, 2017 05:25 UTC
 const NOW = 1488173100125;
@@ -31,6 +39,15 @@ describe( 'reducers', () => {
 
 		test( 'SERIALIZEs to Date.now() if state is null', () => {
 			expect( lostFocusAt( null, { type: SERIALIZE } ) ).to.eql( NOW );
+		} );
+
+		test( 'DESERIALIZEs a valid value', () => {
+			expect( lostFocusAt( 1, { type: DESERIALIZE } ) ).eql( 1 );
+		} );
+
+		test( 'does not DESERIALIZEs invalid values', () => {
+			expect( lostFocusAt( {}, { type: DESERIALIZE } ) ).eql( null );
+			expect( lostFocusAt( '1', { type: DESERIALIZE } ) ).eql( null );
 		} );
 
 		test( 'returns Date.now() on HAPPYCHAT_BLUR actions', () => {


### PR DESCRIPTION
Instead of manually validating the persisted `lostFocusAt` state, just set a `schema` property and let the framework (`combineReducers`) do the work. It will handle the `DESERIALIZE` action and will also pass control to our custom `SERIALIZE` handler.

The type required in the schema is just `number`, never `null`. When serializing, a valid timestamp is always saved no matter what.