### PR TITLE
PostRevisions: fix esc keyboard shortcut when button is used to select latest or earliest revision

### DIFF
--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'react-modal';
 import classnames from 'classnames';
+import { get } from 'lodash';
 
 class DialogBase extends Component {
 	static propTypes = {
@@ -49,6 +50,7 @@ class DialogBase extends Component {
 				className={ dialogClassName }
 				role="dialog"
 				shouldCloseOnEsc={ shouldCloseOnEsc }
+				ref={ this._modalRef }
 			>
 				<div
 					className={ classnames( this.props.className, contentClassName ) }
@@ -125,6 +127,16 @@ class DialogBase extends Component {
 	_close = action => {
 		if ( this.props.onDialogClose ) {
 			this.props.onDialogClose( action );
+		}
+	};
+
+	_modalRef = modal => {
+		this.modal = modal;
+	};
+
+	focusModal = () => {
+		if ( get( this, 'modal.portal.content', false ) ) {
+			this.modal.portal.content.focus();
 		}
 	};
 }

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -4,7 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { defer, noop } from 'lodash';
+import { defer, get, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,6 +32,7 @@ class Dialog extends Component {
 		if ( null === ref ) {
 			defer( this.props.onClosed );
 		}
+		this.dialogBase = ref;
 	};
 
 	render() {
@@ -50,6 +51,12 @@ class Dialog extends Component {
 	onDialogClose = action => {
 		if ( this.props.onClose ) {
 			this.props.onClose( action );
+		}
+	};
+
+	focusModal = () => {
+		if ( get( this, 'dialogBase.focusModal', false ) ) {
+			this.dialogBase.focusModal();
 		}
 	};
 }

--- a/client/post-editor/editor-revisions-list/index.jsx
+++ b/client/post-editor/editor-revisions-list/index.jsx
@@ -28,6 +28,7 @@ class EditorRevisionsList extends PureComponent {
 		selectedRevisionId: PropTypes.number,
 		nextIsDisabled: PropTypes.bool,
 		prevIsDisabled: PropTypes.bool,
+		focusModal: PropTypes.func,
 	};
 
 	selectRevision = revisionId => {
@@ -130,6 +131,22 @@ class EditorRevisionsList extends PureComponent {
 		prevRevisionId && this.selectRevision( prevRevisionId );
 	};
 
+	onNavButtonFocus = value => {
+		const { nextIsDisabled, prevIsDisabled, focusModal } = this.props;
+		switch ( value ) {
+			case 'next':
+				if ( nextIsDisabled ) {
+					focusModal();
+				}
+				break;
+			case 'prev':
+				if ( prevIsDisabled ) {
+					focusModal();
+				}
+				break;
+		}
+	};
+
 	render() {
 		const {
 			comparisons,
@@ -152,6 +169,7 @@ class EditorRevisionsList extends PureComponent {
 					prevIsDisabled={ prevIsDisabled }
 					selectNextRevision={ this.selectNextRevision }
 					selectPreviousRevision={ this.selectPreviousRevision }
+					onNavButtonFocus={ this.onNavButtonFocus }
 				/>
 				<div className="editor-revisions-list__scroller">
 					<ul className="editor-revisions-list__list">

--- a/client/post-editor/editor-revisions-list/navigation.jsx
+++ b/client/post-editor/editor-revisions-list/navigation.jsx
@@ -18,6 +18,7 @@ const EditorRevisionsListNavigation = ( {
 	prevIsDisabled,
 	selectNextRevision,
 	selectPreviousRevision,
+	onNavButtonFocus,
 } ) => {
 	return (
 		<ButtonGroup className="editor-revisions-list__navigation">
@@ -27,6 +28,7 @@ const EditorRevisionsListNavigation = ( {
 				type="button"
 				onClick={ selectPreviousRevision }
 				disabled={ prevIsDisabled }
+				onFocus={ onNavButtonFocus( 'prev' ) }
 			>
 				<Gridicon icon="chevron-down" />
 			</Button>
@@ -36,6 +38,7 @@ const EditorRevisionsListNavigation = ( {
 				type="button"
 				onClick={ selectNextRevision }
 				disabled={ nextIsDisabled }
+				onFocus={ onNavButtonFocus( 'next' ) }
 			>
 				<Gridicon icon="chevron-up" />
 			</Button>
@@ -48,6 +51,7 @@ EditorRevisionsListNavigation.propTypes = {
 	selectPreviousRevision: PropTypes.func.isRequired,
 	nextIsDisabled: PropTypes.bool,
 	prevIsDisabled: PropTypes.bool,
+	onNavButtonFocus: PropTypes.func,
 };
 
 export default EditorRevisionsListNavigation;

--- a/client/post-editor/editor-revisions/dialog.jsx
+++ b/client/post-editor/editor-revisions/dialog.jsx
@@ -83,6 +83,16 @@ class PostRevisionsDialog extends PureComponent {
 		];
 	};
 
+	focusModal = () => {
+		if ( get( this, 'dialog.focusModal', false ) ) {
+			this.dialog.focusModal();
+		}
+	};
+
+	dialogRef = dialog => {
+		this.dialog = dialog;
+	};
+
 	render() {
 		const { isVisible, closeDialog } = this.props;
 
@@ -92,8 +102,9 @@ class PostRevisionsDialog extends PureComponent {
 				className="editor-revisions__dialog"
 				isVisible={ isVisible }
 				onClose={ closeDialog }
+				ref={ this.dialogRef }
 			>
-				<EditorRevisions />
+				<EditorRevisions focusModal={ this.focusModal } />
 			</Dialog>
 		);
 	}

--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -39,6 +39,7 @@ class EditorRevisions extends Component {
 			selectedDiff,
 			selectedRevisionId,
 			siteId,
+			focusModal,
 		} = this.props;
 
 		return (
@@ -61,6 +62,7 @@ class EditorRevisions extends Component {
 					revisions={ revisions }
 					selectedRevisionId={ selectedRevisionId }
 					siteId={ siteId }
+					focusModal={ focusModal }
 				/>
 			</div>
 		);
@@ -82,6 +84,9 @@ EditorRevisions.propTypes = {
 
 	// localize
 	translate: PropTypes.func.isRequired,
+
+	// own prop
+	focusModal: PropTypes.func,
 };
 
 export default flow(


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/issues/22231. When the first or last revision has been selected with the list nav buttons, the escape keypress no longer closes the revisions modal.

The issue happens because one of the buttons is disabled but still has focus. 

Add an onFocus handler on nav buttons which focuses the modal if a button receives focus when disabled.