### PR TITLE
SiteRenamer: Show Error Notice On Unsuccessful Response

### DIFF
--- a/client/state/site-rename/actions.js
+++ b/client/state/site-rename/actions.js
@@ -4,7 +4,6 @@
  */
 import page from 'page';
 import { get } from 'lodash';
-import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,7 +14,7 @@ import {
 	SITE_RENAME_REQUEST_FAILURE,
 	SITE_RENAME_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { successNotice } from 'state/notices/actions';
+import { errorNotice, successNotice } from 'state/notices/actions';
 import { domainManagementEdit } from 'my-sites/domains/paths';
 import { requestSite } from 'state/sites/actions';
 
@@ -24,6 +23,15 @@ function fetchNonce( siteId ) {
 	return wpcom.undocumented().getRequestSiteRenameNonce( siteId );
 }
 
+export const getErrorNotice = message =>
+	errorNotice( message, {
+		id: 'siteRenameUnsuccessful',
+		duration: 5000,
+		showDismiss: true,
+		isPersistent: true,
+	} );
+
+// @TODO translate copy throughout once copy is finalised
 export const requestSiteRename = ( siteId, newBlogName, discard ) => dispatch => {
 	dispatch( {
 		type: SITE_RENAME_REQUEST,
@@ -44,7 +52,7 @@ export const requestSiteRename = ( siteId, newBlogName, discard ) => dispatch =>
 							page( domainManagementEdit( newAddress, newAddress ) );
 
 							dispatch(
-								successNotice( translate( 'Your new domain name is ready to go!' ), {
+								successNotice( 'Your new domain name is ready to go!', {
 									id: 'siteRenameSuccessful',
 									duration: 5000,
 									showDismiss: true,
@@ -61,6 +69,13 @@ export const requestSiteRename = ( siteId, newBlogName, discard ) => dispatch =>
 					} );
 				} )
 				.catch( error => {
+					dispatch(
+						getErrorNotice(
+							error.message ||
+								"Sorry, we we're unable to complete your domain change. Please try again."
+						)
+					);
+
 					dispatch( {
 						type: SITE_RENAME_REQUEST_FAILURE,
 						error: error.message,

--- a/client/state/site-rename/actions.js
+++ b/client/state/site-rename/actions.js
@@ -31,7 +31,14 @@ export const getErrorNotice = message =>
 		isPersistent: true,
 	} );
 
-// @TODO translate copy throughout once copy is finalised
+const dispatchErrorNotice = ( dispatch, error ) =>
+	dispatch(
+		getErrorNotice(
+			// @TODO translate copy once finalised
+			error.message || "Sorry, we we're unable to complete your domain change. Please try again."
+		)
+	);
+
 export const requestSiteRename = ( siteId, newBlogName, discard ) => dispatch => {
 	dispatch( {
 		type: SITE_RENAME_REQUEST,
@@ -52,6 +59,7 @@ export const requestSiteRename = ( siteId, newBlogName, discard ) => dispatch =>
 							page( domainManagementEdit( newAddress, newAddress ) );
 
 							dispatch(
+								// @TODO translate copy once finalised
 								successNotice( 'Your new domain name is ready to go!', {
 									id: 'siteRenameSuccessful',
 									duration: 5000,
@@ -69,13 +77,7 @@ export const requestSiteRename = ( siteId, newBlogName, discard ) => dispatch =>
 					} );
 				} )
 				.catch( error => {
-					dispatch(
-						getErrorNotice(
-							error.message ||
-								"Sorry, we we're unable to complete your domain change. Please try again."
-						)
-					);
-
+					dispatchErrorNotice( dispatch, error );
 					dispatch( {
 						type: SITE_RENAME_REQUEST_FAILURE,
 						error: error.message,
@@ -84,6 +86,7 @@ export const requestSiteRename = ( siteId, newBlogName, discard ) => dispatch =>
 				} );
 		} )
 		.catch( error => {
+			dispatchErrorNotice( dispatch, error );
 			dispatch( {
 				type: SITE_RENAME_REQUEST_FAILURE,
 				error: error.message,


### PR DESCRIPTION
*Note that this PR bases from #21861, it'll be pointed to master once #21861 lands*

### Summary

This PR aims to add error notices to show the customer that their request to update their domain name failed.
It does so by showing a `GlobalNotice` with a message that reflects the problem found with the request.

### Notes

As of writing, all bad requests show a global notice which disappears after a set time (5s). We might wish to improve on this experience by handling invalid domain name cases different to, say, an internal server error, instead showing this message as we would with client side form validation. That way, the person making the request isn't left without some reason as to why their change wasn't made.

I'd also really like to be able to differentiate between the domain being invalid in terms of shape and invalid because it's already taken. This would allow us to better inform the customer, helping them to better follow up on the failed response.

### Testing
First, make sure you're working with WPCOM sandboxed and patched to `D9400`.

- Testing invalid domain names
  - This needs discussion and work on the backend.

- Testing generic server errors
  - An easy way to test this is to switch back to using production WPCOM.
  - Make a request, the endpoint should be missing and so will throw an error.
  - You should see a `GlobalNotice` appear in the top right with error styling, showing a generic message.

- Testing Authorisation errors
  - Attempt to to rename your site to something that's already knowingly taken.
  - You should see a message showing that this domain is invalid.