### PR TITLE
JPO: add tracking to the Summary step.

### DIFF
--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -26,6 +26,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 			nextStep: stepName,
 		} );
 	};
+
 	handleCompletedStepClick = stepName => () => {
 		const { recordJpoEvent } = this.props;
 		recordJpoEvent( 'calypso_jpo_completed_step_clicked', {

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -20,10 +20,16 @@ import { getUnconnectedSiteUrl } from 'state/selectors';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
-	handleNextStepSelection = stepName => () => {
+	handleNextStepClick = stepName => () => {
 		const { recordJpoEvent } = this.props;
 		recordJpoEvent( 'calypso_jpo_next_step_clicked', {
 			nextStep: stepName,
+		} );
+	};
+	handleCompletedStepClick = stepName => () => {
+		const { recordJpoEvent } = this.props;
+		recordJpoEvent( 'calypso_jpo_completed_step_clicked', {
+			completedStep: stepName,
 		} );
 	};
 
@@ -50,6 +56,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 						<h3 className="steps__summary-heading">{ translate( "Steps you've completed:" ) }</h3>
 						<CompletedSteps
 							basePath={ basePath }
+							handleCompletedStepClick={ this.handleCompletedStepClick }
 							siteId={ siteId }
 							siteSlug={ siteSlug }
 							steps={ steps }
@@ -58,7 +65,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 					<div className="steps__summary-column">
 						<h3 className="steps__summary-heading">{ translate( 'Continue your site setup:' ) }</h3>
 						<NextSteps
-							handleNextStepSelection={ this.handleNextStepSelection }
+							handleNextStepClick={ this.handleNextStepClick }
 							siteId={ siteId }
 							siteSlug={ siteSlug }
 							siteUrl={ siteUrl }

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -20,6 +20,13 @@ import { getUnconnectedSiteUrl } from 'state/selectors';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
+	handleNextStepSelection = stepName => () => {
+		const { recordJpoEvent } = this.props;
+		recordJpoEvent( 'calypso_jpo_next_step_clicked', {
+			nextStep: stepName,
+		} );
+	};
+
 	render() {
 		const { basePath, siteId, siteSlug, siteUrl, steps, translate } = this.props;
 
@@ -50,7 +57,12 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 					</div>
 					<div className="steps__summary-column">
 						<h3 className="steps__summary-heading">{ translate( 'Continue your site setup:' ) }</h3>
-						<NextSteps siteId={ siteId } siteSlug={ siteSlug } siteUrl={ siteUrl } />
+						<NextSteps
+							handleNextStepSelection={ this.handleNextStepSelection }
+							siteId={ siteId }
+							siteSlug={ siteSlug }
+							siteUrl={ siteUrl }
+						/>
 					</div>
 				</div>
 				<div className="steps__button-group">

--- a/client/jetpack-onboarding/summary-completed-steps.jsx
+++ b/client/jetpack-onboarding/summary-completed-steps.jsx
@@ -24,6 +24,8 @@ import {
 } from './constants';
 
 const CompletedSteps = ( {
+	basePath,
+	handleCompletedStepClick,
 	siteSlug,
 	steps,
 	stepsCompleted,
@@ -43,7 +45,12 @@ const CompletedSteps = ( {
 				) : (
 					<Gridicon icon={ isCompleted ? 'checkmark' : 'cross' } size={ 18 } />
 				) }
-				<a href={ [ basePath, stepName, siteSlug ].join( '/' ) }>{ STEP_TITLES[ stepName ] }</a>
+				<a
+					href={ [ basePath, stepName, siteSlug ].join( '/' ) }
+					onClick={ handleCompletedStepClick( stepName ) }
+				>
+					{ STEP_TITLES[ stepName ] }
+				</a>
 			</div>
 		);
 	} );

--- a/client/jetpack-onboarding/summary-completed-steps.jsx
+++ b/client/jetpack-onboarding/summary-completed-steps.jsx
@@ -4,9 +4,10 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { get, map, without } from 'lodash';
+import { get, map, noop, without } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -54,6 +55,14 @@ const CompletedSteps = ( {
 			</div>
 		);
 	} );
+
+CompletedSteps.propTypes = {
+	handleCompletedStepClick: PropTypes.func,
+};
+
+CompletedSteps.defaultProps = {
+	handleCompletedStepClick: noop,
+};
 
 export default connect( ( state, { siteId, steps } ) => ( {
 	stepsCompleted: getJetpackOnboardingCompletedSteps( state, siteId, steps ),

--- a/client/jetpack-onboarding/summary-completed-steps.jsx
+++ b/client/jetpack-onboarding/summary-completed-steps.jsx
@@ -23,7 +23,12 @@ import {
 	JETPACK_ONBOARDING_STEPS as STEPS,
 } from './constants';
 
-const CompletedSteps = ( { basePath, siteSlug, steps, stepsCompleted, stepsPending } ) =>
+const CompletedSteps = ( {
+	siteSlug,
+	steps,
+	stepsCompleted,
+	stepsPending,
+} ) =>
 	map( without( steps, STEPS.SUMMARY ), stepName => {
 		const isCompleted = get( stepsCompleted, stepName ) === true;
 		const isPending = get( stepsPending, stepName );
@@ -31,7 +36,6 @@ const CompletedSteps = ( { basePath, siteSlug, steps, stepsCompleted, stepsPendi
 			'jetpack-onboarding__summary-entry',
 			isCompleted ? 'completed' : 'todo'
 		);
-
 		return (
 			<div key={ stepName } className={ className }>
 				{ isPending ? (

--- a/client/jetpack-onboarding/summary-next-steps.jsx
+++ b/client/jetpack-onboarding/summary-next-steps.jsx
@@ -4,8 +4,9 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { get, map } from 'lodash';
+import { get, map, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -28,6 +29,14 @@ const NextSteps = ( { handleNextStepClick, siteId, steps } ) => (
 		) ) }
 	</Fragment>
 );
+
+NextSteps.propTypes = {
+	handleNextStepClick: PropTypes.func,
+};
+
+NextSteps.defaultProps = {
+	handleNextStepClick: noop,
+};
 
 export default localize(
 	connect( ( state, { siteId, siteSlug, siteUrl, translate } ) => {

--- a/client/jetpack-onboarding/summary-next-steps.jsx
+++ b/client/jetpack-onboarding/summary-next-steps.jsx
@@ -16,12 +16,12 @@ import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getJetpackOnboardingSettings } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
-const NextSteps = ( { handleNextStepSelection, siteId, steps } ) => (
+const NextSteps = ( { handleNextStepClick, siteId, steps } ) => (
 	<Fragment>
 		<QuerySites siteId={ siteId } />
 		{ map( steps, ( { label, url }, stepName ) => (
 			<div key={ stepName } className="jetpack-onboarding__summary-entry todo">
-				<a href={ url } onClick={ handleNextStepSelection( stepName ) }>
+				<a href={ url } onClick={ handleNextStepClick( stepName ) }>
 					{ label }
 				</a>
 			</div>

--- a/client/jetpack-onboarding/summary-next-steps.jsx
+++ b/client/jetpack-onboarding/summary-next-steps.jsx
@@ -16,12 +16,14 @@ import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getJetpackOnboardingSettings } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
-const NextSteps = ( { siteId, steps } ) => (
+const NextSteps = ( { handleNextStepSelection, siteId, steps } ) => (
 	<Fragment>
 		<QuerySites siteId={ siteId } />
 		{ map( steps, ( { label, url }, stepName ) => (
 			<div key={ stepName } className="jetpack-onboarding__summary-entry todo">
-				<a href={ url }>{ label }</a>
+				<a href={ url } onClick={ handleNextStepSelection( stepName ) }>
+					{ label }
+				</a>
 			</div>
 		) ) }
 	</Fragment>


### PR DESCRIPTION
Add event tracking to the `Summary step` of the flow.

**To test:**
- use localStorage.debug = 'calypso:analytics:tracks' to confirm that a relevant event `calypso_jpo_completed_step_clicked` or `calypso_jpo_next_step_clicked` fires with the correct step name under `completedStep` and `nextStep`, respectively.
