### PR TITLE
Components: Site Title- display form validation notice only after the data has been fetched.

### DIFF
--- a/client/components/site-title/index.jsx
+++ b/client/components/site-title/index.jsx
@@ -66,9 +66,10 @@ class SiteTitleControl extends React.Component {
 						onChange={ this.onChangeSiteTitle }
 						value={ blogname }
 					/>
-					{ isBlognameRequired && (
-						<FormInputValidation isError={ ! blogname } text={ translate( 'Required field.' ) } />
-					) }
+					{ isBlognameRequired &&
+						! disabled && (
+							<FormInputValidation isError={ ! blogname } text={ translate( 'Required field.' ) } />
+						) }
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="blogdescription">{ translate( 'Tagline' ) }</FormLabel>


### PR DESCRIPTION
Addresses the initial topic of https://github.com/Automattic/wp-calypso/issues/21870.

Currently an empty field notice is displayed during the data request. This commit improves this UX and does not render notice until the data has been loaded.

**To test:**
- access the JPO flow from a site that has a Site Title set,
- verify that there is no `Required field` text displayed in the form while the data is still being fetched.