### PR TITLE
JPO: display form validation in the Business Address step after the data has been recieved.

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -101,12 +101,13 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 									onChange={ this.getChangeHandler( fieldName ) }
 									value={ this.state[ fieldName ] || '' }
 								/>
-								{ fieldName !== 'state' && (
-									<FormInputValidation
-										isError={ this.state[ fieldName ] === '' }
-										text={ translate( 'Required field.' ) }
-									/>
-								) }
+								{ fieldName !== 'state' &&
+									! isRequestingSettings && (
+										<FormInputValidation
+											isError={ this.state[ fieldName ] === '' }
+											text={ translate( 'Required field.' ) }
+										/>
+									) }
 							</FormFieldset>
 						) ) }
 						<Button


### PR DESCRIPTION
Addresses https://github.com/Automattic/wp-calypso/issues/21870 for the Business Address step.

Currently an empty field notice is displayed during the data request. This commit improves this UX and does not render notice until the data has been loaded.

**To test:**
- access the JPO flow from a site that has (at least one) of the required Business Address fields set,
- click through to the Business Address step,
- verify that there is no `Required field` text displayed for the fields set in the form while the data is still being fetched.