### PR TITLE
Fix Following Manage 'no subs found' error when a search hasn't been performed

### DIFF
--- a/client/reader/following-manage/subscriptions.jsx
+++ b/client/reader/following-manage/subscriptions.jsx
@@ -144,10 +144,12 @@ class FollowingManageSubscriptions extends Component {
 					) }
 					{ noSitesMatchQuery && (
 						<span>
-							{ translate( 'Sorry, no followed sites match {{italic}}%s.{{/italic}}', {
-								components: { italic: <i /> },
-								args: query,
-							} ) }
+							{ query
+								? translate( 'Sorry, no followed sites match {{italic}}%s.{{/italic}}', {
+										components: { italic: <i /> },
+										args: query,
+									} )
+								: translate( 'Sorry, no followed sites found.' ) }
 						</span>
 					) }
 				</div>


### PR DESCRIPTION
We've found an edge case where a user can have > 0 subscriptions but we're not able to display them. When this happens, the error message shown doesn't make sense:

<img width="776" alt="screen-shot-2018-02-08-at-16-48-55" src="https://user-images.githubusercontent.com/17325/36084618-11af1432-1013-11e8-89df-55125c26ae75.png">

This PR shows a slightly different message if we don't have a search query:

<img width="766" alt="screen shot 2018-02-12 at 16 35 01" src="https://user-images.githubusercontent.com/17325/36084625-212fe7ec-1013-11e8-971f-d27f78329b77.png">

### To test

Switch user to the one mentioned in P2 post `p5PDj3-4oJ`. Make sure the error message doesn't include an unexpanded `%s` placeholder.