### PR TITLE
Community Translator: double-wrapped translation cannot be stringified

### DIFF
--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -78,7 +78,7 @@ const communityTranslatorJumpstart = {
 	},
 
 	wrapTranslation( originalFromPage, displayedTranslationFromPage, optionsFromPage ) {
-		if ( ! this.isEnabled() || ! this.isActivated() ) {
+		if ( ! this.isEnabled() || ! this.isActivated() || optionsFromPage.textOnly ) {
 			return displayedTranslationFromPage;
 		}
 

--- a/client/reader/liked-stream/main.jsx
+++ b/client/reader/liked-stream/main.jsx
@@ -14,8 +14,8 @@ import DocumentHead from 'components/data/document-head';
 
 class LikedStream extends React.Component {
 	render() {
-		var title = this.props.translate( 'My Likes' ),
-			emptyContent = <EmptyContent />;
+		const title = this.props.translate( 'My Likes', { textOnly: true } );
+		const emptyContent = <EmptyContent />;
 
 		return (
 			<Stream


### PR DESCRIPTION
On the **[My Likes](https://wordpress.com/activities/likes)** activity feed, activating the Community Translator breaks the site.

![feb-12-2018 20-03-47](https://user-images.githubusercontent.com/6458278/36089407-e2886d12-102f-11e8-8d34-26fb8f7dc935.gif)

It happens when an already-wrapped translation is passed as an argument to a new translation call ([example](https://github.com/Automattic/wp-calypso/blob/ba6ebb9/client/reader/liked-stream/main.jsx)). 

Here's the object that we're passing to `I18N.prototype.translate` –

<img width="1200" alt="screen shot 2018-02-12 at 6 10 14 pm" src="https://user-images.githubusercontent.com/6458278/36089276-2cfff3de-102f-11e8-9cec-0fa95079622e.png">

It creates a circular reference on [JSON.stringify](https://github.com/Automattic/i18n-calypso/blob/master/lib/index.js#L262)

<img width="787" alt="screen shot 2018-02-12 at 6 10 27 pm" src="https://user-images.githubusercontent.com/6458278/36089248-fd4070d8-102e-11e8-9f8c-eb1efe2df3fc.png">

The other option would be to check for an invalid argument value in https://github.com/Automattic/i18n-calypso @akirk Which do you think is better?



