### PR TITLE
Refactor persistence in the plugins.premium reducer

### DIFF
--- a/client/state/plugins/premium/reducer.js
+++ b/client/state/plugins/premium/reducer.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { forEach } from 'lodash';
+import { mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,9 +18,8 @@ import {
 	PLUGIN_SETUP_FINISH,
 	PLUGIN_SETUP_ERROR,
 	SERIALIZE,
-	DESERIALIZE,
 } from 'state/action-types';
-import { combineReducers, isValidStateWithSchema } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { pluginInstructionSchema } from './schema';
 
 /*
@@ -71,27 +70,20 @@ export function plugins( state = {}, action ) {
 			}
 			return state;
 		case SERIALIZE:
-			const processedState = {};
 			// Save the error state as a string message.
-			forEach( state, ( pluginList, key ) => {
-				processedState[ key ] = pluginList.map( item => {
+			return mapValues( state, pluginList =>
+				pluginList.map( item => {
 					if ( item.error !== null ) {
 						return Object.assign( {}, item, { error: item.error.toString() } );
 					}
 					return item;
-				} );
-			} );
-			return processedState;
-		case DESERIALIZE:
-			if ( ! isValidStateWithSchema( state, pluginInstructionSchema ) ) {
-				return {};
-			}
-			return state;
+				} )
+			);
 		default:
 			return state;
 	}
 }
-plugins.hasCustomPersistence = true;
+plugins.schema = pluginInstructionSchema;
 
 /*
  * Tracks the list of premium plugin objects for a single site

--- a/client/state/plugins/premium/test/reducer.js
+++ b/client/state/plugins/premium/test/reducer.js
@@ -27,6 +27,7 @@ import {
 	PLUGIN_SETUP_CONFIGURE,
 	PLUGIN_SETUP_FINISH,
 	PLUGIN_SETUP_ERROR,
+	SERIALIZE,
 } from 'state/action-types';
 
 describe( 'premium reducer', () => {
@@ -190,6 +191,49 @@ describe( 'premium reducer', () => {
 				error: { name: 'ErrorCode', message: 'Something went wrong.' },
 			} );
 			expect( state ).to.eql( { 'one.site': siteWithError } );
+		} );
+
+		test( 'should serialize non-error state using identity function', () => {
+			const originalState = deepFreeze( {
+				'one.site': [
+					{
+						slug: 'vaultpress',
+						name: 'VaultPress',
+						key: 'vp-api-key',
+						status: 'done',
+						error: null,
+					},
+				],
+			} );
+
+			const nextState = plugins( originalState, { type: SERIALIZE } );
+			expect( nextState ).eql( originalState );
+		} );
+
+		test( 'should serialize just the error for errored plugins', () => {
+			const originalState = deepFreeze( {
+				'error-site': [
+					{
+						slug: 'vaultpress',
+						name: 'VaultPress',
+						key: 'vp-api-key',
+						status: 'done',
+						error: { name: 'ErrorCode', message: 'Something went wrong.' },
+					},
+				],
+			} );
+			const nextState = plugins( originalState, { type: SERIALIZE } );
+			expect( nextState ).eql( {
+				'error-site': [
+					{
+						slug: 'vaultpress',
+						name: 'VaultPress',
+						key: 'vp-api-key',
+						status: 'done',
+						error: '[object Object]',
+					},
+				],
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Move schema validation to framework by declaring a `schema` property on the reducer.
Rewrite the serialize object transformation to use `_.mapValues`.