### PR TITLE
Remove unneeded globalActions param from keyedReducers

### DIFF
--- a/client/state/activity-log/log/reducer.js
+++ b/client/state/activity-log/log/reducer.js
@@ -25,5 +25,5 @@ export const logItem = ( state = undefined, { type, data, found, query } ) => {
 	}
 };
 
-export const logItems = keyedReducer( 'siteId', logItem, [ DESERIALIZE, SERIALIZE ] );
+export const logItems = keyedReducer( 'siteId', logItem );
 logItems.hasCustomPersistence = true;

--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -5,52 +5,39 @@
  */
 import { keyedReducer, combineReducers } from 'state/utils';
 import { itemsSchema } from './schema';
-import {
-	READER_STREAMS_PAGE_RECEIVE,
-	READER_STREAMS_SELECT_ITEM,
-	SERIALIZE,
-	DESERIALIZE,
-} from 'state/action-types';
+import { READER_STREAMS_PAGE_RECEIVE, READER_STREAMS_SELECT_ITEM } from 'state/action-types';
 
-export const items = keyedReducer(
-	'payload.streamId',
-	( state = [], action ) => {
-		switch ( action.type ) {
-			case READER_STREAMS_PAGE_RECEIVE:
-				const { posts } = action.payload;
+export const items = keyedReducer( 'payload.streamId', ( state = [], action ) => {
+	switch ( action.type ) {
+		case READER_STREAMS_PAGE_RECEIVE:
+			const { posts } = action.payload;
 
-				// if action doesnt have any posts then exit
-				if ( ! posts ) {
-					return state;
-				}
-
-				// if state didnt exist before now, then the list of postKeys is good enough
-				if ( ! state ) {
-					return posts;
-				}
-
-				return state.concat( posts );
-			default:
+			// if action doesnt have any posts then exit
+			if ( ! posts ) {
 				return state;
-		}
-	},
-	[ SERIALIZE, DESERIALIZE ]
-);
+			}
+
+			// if state didnt exist before now, then the list of postKeys is good enough
+			if ( ! state ) {
+				return posts;
+			}
+
+			return state.concat( posts );
+		default:
+			return state;
+	}
+} );
 
 items.schema = itemsSchema;
 
-export const selected = keyedReducer(
-	'payload.streamId',
-	( state = [], action ) => {
-		switch ( action.type ) {
-			case READER_STREAMS_SELECT_ITEM:
-				return action.payload.index;
-			default:
-				return state;
-		}
-	},
-	[ SERIALIZE, DESERIALIZE ]
-);
+export const selected = keyedReducer( 'payload.streamId', ( state = [], action ) => {
+	switch ( action.type ) {
+		case READER_STREAMS_SELECT_ITEM:
+			return action.payload.index;
+		default:
+			return state;
+	}
+} );
 
 export default combineReducers( {
 	items,


### PR DESCRIPTION
The default value of the `globalActions` param of the `keyedReducer` function is `[ SERIALIZE, DESERIALIZE ]`. Some usages pass the same value explicity, which is not needed. This janitorial patch removes the parameter from these calls.

It opens some options how to refactor `keyedReducer` further -- the `globalActions` param is not used anywhere in Calypso codebase, so it might be removed. And there might be better ways to handle persistence in `keyedReducer` -- like behaving similarly to `combineReducers`, i.e., looking at the wrapped reducer's `schema` and `hasCustomPersistence` flags and and handling them.