### PR TITLE
Ensure esc keyboard shortcut closes revisions modal when revisions nav button is disabled

### DIFF
--- a/client/post-editor/editor-revisions/dialog.jsx
+++ b/client/post-editor/editor-revisions/dialog.jsx
@@ -18,6 +18,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { closePostRevisionsDialog, selectPostRevision } from 'state/posts/revisions/actions';
 import EditorRevisions from 'post-editor/editor-revisions';
 import Dialog from 'components/dialog';
+import CloseOnEscape from 'components/close-on-escape';
 
 class PostRevisionsDialog extends PureComponent {
 	static propTypes = {
@@ -93,6 +94,7 @@ class PostRevisionsDialog extends PureComponent {
 				isVisible={ isVisible }
 				onClose={ closeDialog }
 			>
+				<CloseOnEscape onEscape={ closeDialog } />
 				<EditorRevisions />
 			</Dialog>
 		);


### PR DESCRIPTION
Addressing issue where `esc` keyboard shortcut stops working when a revisions nav button is disabled but retains focus. Adding `CloseOnEsc` component to the `PostRevisionsDialog` ensures it will handle the `esc` keypress in this situation. 

h/t @spen for the neat fix

https://github.com/Automattic/wp-calypso/issues/22231