### PR TITLE
Comments: Add HTML toolbar to the edit textarea (2nd attempt)

### DIFF
--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
-import { get, pick } from 'lodash';
+import { get, noop, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -52,7 +52,8 @@ export class CommentEdit extends Component {
 
 	setAuthorUrlValue = event => this.setState( { authorUrl: event.target.value } );
 
-	setCommentContentValue = event => this.setState( { commentContent: event.target.value } );
+	setCommentContentValue = ( event, callback = noop ) =>
+		this.setState( { commentContent: event.target.value }, callback );
 
 	showNotice = () => {
 		const { translate } = this.props;

--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -12,10 +12,10 @@ import { get, pick } from 'lodash';
 /**
  * Internal dependencies
  */
+import CommentHtmlEditor from 'my-sites/comments/comment/comment-html-editor';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
-import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 import InfoPopover from 'components/info-popover';
 import { decodeEntities } from 'lib/formatting';
@@ -136,10 +136,10 @@ export class CommentEdit extends Component {
 						/>
 					</FormFieldset>
 
-					<FormTextarea
+					<CommentHtmlEditor
+						commentContent={ commentContent }
 						disabled={ ! isEditCommentSupported }
 						onChange={ this.setCommentContentValue }
-						value={ commentContent }
 					/>
 
 					{ ! isEditCommentSupported && (

--- a/client/my-sites/comments/comment/comment-html-editor.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor.jsx
@@ -138,14 +138,14 @@ export class CommentHtmlEditor extends Component {
 
 	closeLinkDialog = () => {
 		this.setState( { showLinkDialog: false } );
-		delay( () => this.textarea.focus(), 500 );
+		delay( () => this.textarea.focus(), 300 );
 	};
 
 	openImageDialog = () => this.setState( { showImageDialog: true } );
 
 	closeImageDialog = () => {
 		this.setState( { showImageDialog: false } );
-		delay( () => this.textarea.focus(), 500 );
+		delay( () => this.textarea.focus(), 300 );
 	};
 	render() {
 		const { commentContent, onChange } = this.props;

--- a/client/my-sites/comments/comment/comment-html-editor.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor.jsx
@@ -1,0 +1,65 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+export class CommentHtmlEditor extends Component {
+	static propTypes = {
+		commentContent: PropTypes.string,
+		disabled: PropTypes.bool,
+		onChange: PropTypes.func,
+	};
+
+	state = {
+		selectedText: '',
+		showImageDialog: false,
+		showLinkDialog: false,
+	};
+
+	storeTextareaRef = textarea => ( this.textarea = textarea );
+
+	isTagOpen = tag => ! tag;
+
+	render() {
+		const { commentContent, disabled, onChange } = this.props;
+
+		return (
+			<div className="comment__html-editor">
+				<div className="comment__html-toolbar">
+					<Button
+						borderless
+						className={ classNames( 'comment__html-toolbar-button-strong', {
+							'is-tag-open': this.isTagOpen( 'strong' ),
+						} ) }
+						compact
+						disabled={ disabled }
+						key="strong"
+						onClick={ noop }
+					>
+						b
+					</Button>
+				</div>
+
+				<textarea
+					className="comment__edit-textarea form-textarea"
+					disabled={ disabled }
+					onChange={ onChange }
+					ref={ this.storeTextareaRef }
+					value={ commentContent }
+				/>
+			</div>
+		);
+	}
+}
+
+export default localize( CommentHtmlEditor );

--- a/client/my-sites/comments/comment/comment-html-editor.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { noop } from 'lodash';
+import { each } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,7 +28,56 @@ export class CommentHtmlEditor extends Component {
 
 	storeTextareaRef = textarea => ( this.textarea = textarea );
 
-	isTagOpen = tag => ! tag;
+	isTagOpen = tag => {
+		const { commentContent } = this.props;
+		const openers = commentContent.match( new RegExp( `<${ tag }.*?>`, 'gi' ) ) || [];
+		const closers = commentContent.match( new RegExp( `<\/${ tag }>`, 'gi' ) ) || [];
+		return openers.length > closers.length;
+	};
+
+	setCursorPosition = ( selectionEnd, insertedContentLength ) => {
+		this.textarea.selectionEnd = this.textarea.selectionStart =
+			selectionEnd + insertedContentLength;
+	};
+
+	splitSelectedContent = () => {
+		const { selectionEnd, selectionStart, value } = this.textarea;
+		return {
+			before: value.substring( 0, selectionStart ),
+			inner: value.substring( selectionStart, selectionEnd ),
+			after: value.substring( selectionEnd, value.length ),
+		};
+	};
+
+	insertHtml = ( tag, attributes ) => {
+		const element = document.createElement( tag );
+		const isOpen = this.isTagOpen( tag );
+		const { inner } = this.splitSelectedContent();
+
+		if ( ! isOpen ) {
+			each( attributes, ( value, key ) => element.setAttribute( key, value ) );
+		}
+
+		if ( inner.length ) {
+			element.innerHTML = inner;
+			return this.insertContent( element.outerHTML );
+		}
+
+		element.innerHTML = '<!---->';
+		const [ opener, closer ] = element.outerHTML.split( '<!---->' );
+
+		if ( isOpen ) {
+			return this.insertContent( closer );
+		}
+		return this.insertContent( opener );
+	};
+
+	insertContent = content => {
+		this.textarea.focus();
+		document.execCommand( 'insertText', false, content );
+	};
+
+	insertStrongTag = () => this.insertHtml( 'strong' );
 
 	render() {
 		const { commentContent, disabled, onChange } = this.props;
@@ -44,7 +93,7 @@ export class CommentHtmlEditor extends Component {
 						compact
 						disabled={ disabled }
 						key="strong"
-						onClick={ noop }
+						onClick={ this.insertStrongTag }
 					>
 						b
 					</Button>

--- a/client/my-sites/comments/comment/comment-html-editor/add-image-dialog.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/add-image-dialog.jsx
@@ -34,14 +34,15 @@ export class AddImageDialog extends Component {
 
 	setImageUrl = event => this.setState( { imageUrl: event.target.value } );
 
-	closeDialog = () => {
-		this.setState( {
-			imageAlt: '',
-			imageTitle: '',
-			imageUrl: '',
-		} );
-		this.props.onClose();
-	};
+	closeDialog = () =>
+		this.setState(
+			{
+				imageAlt: '',
+				imageTitle: '',
+				imageUrl: '',
+			},
+			this.props.onClose
+		);
 
 	insertImgTag = () => {
 		const { imageAlt: alt, imageTitle: title, imageUrl: src } = this.state;

--- a/client/my-sites/comments/comment/comment-html-editor/add-image-dialog.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/add-image-dialog.jsx
@@ -1,0 +1,93 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+
+export class AddImageDialog extends Component {
+	static propTypes = {
+		onClose: PropTypes.func,
+		onInsert: PropTypes.func,
+		shouldDisplay: PropTypes.bool,
+		translate: PropTypes.func,
+	};
+
+	state = {
+		imageAlt: '',
+		imageTitle: '',
+		imageUrl: '',
+	};
+
+	setImageAlt = event => this.setState( { imageAlt: event.target.value } );
+
+	setImageTitle = event => this.setState( { imageTitle: event.target.value } );
+
+	setImageUrl = event => this.setState( { imageUrl: event.target.value } );
+
+	closeDialog = () => {
+		this.setState( {
+			imageAlt: '',
+			imageTitle: '',
+			imageUrl: '',
+		} );
+		this.props.onClose();
+	};
+
+	insertImgTag = () => {
+		const { imageAlt: alt, imageTitle: title, imageUrl: src } = this.state;
+		this.props.onInsert( { alt, src, title } );
+		this.closeDialog();
+	};
+
+	render() {
+		const { shouldDisplay, translate } = this.props;
+		const { imageAlt, imageTitle, imageUrl } = this.state;
+
+		const buttons = [
+			{
+				action: 'cancel',
+				label: translate( 'Cancel' ),
+			},
+			{
+				action: 'add-image',
+				isPrimary: true,
+				label: translate( 'Add Image' ),
+				onClick: this.insertImgTag,
+			},
+		];
+
+		return (
+			<Dialog
+				isVisible={ shouldDisplay }
+				buttons={ buttons }
+				onClose={ this.closeDialog }
+				additionalClassNames="comment-html-editor__dialog"
+			>
+				<FormFieldset>
+					<FormLabel htmlFor="image_url">{ translate( 'URL' ) }</FormLabel>
+					<FormTextInput name="image_url" onChange={ this.setImageUrl } value={ imageUrl } />
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="image_title">{ translate( 'Title' ) }</FormLabel>
+					<FormTextInput name="image_title" onChange={ this.setImageTitle } value={ imageTitle } />
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="image_alt">{ translate( 'Alt Text' ) }</FormLabel>
+					<FormTextInput name="image_alt" onChange={ this.setImageAlt } value={ imageAlt } />
+				</FormFieldset>
+			</Dialog>
+		);
+	}
+}
+
+export default localize( AddImageDialog );

--- a/client/my-sites/comments/comment/comment-html-editor/add-link-dialog.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/add-link-dialog.jsx
@@ -67,14 +67,15 @@ export class AddLinkDialog extends Component {
 
 	setLinkNewTab = event => this.setState( { linkNewTab: event.target.checked } );
 
-	closeDialog = () => {
-		this.setState( {
-			linkNewTab: false,
-			linkText: '',
-			linkUrl: '',
-		} );
-		this.props.onClose();
-	};
+	closeDialog = () =>
+		this.setState(
+			{
+				linkNewTab: false,
+				linkText: '',
+				linkUrl: '',
+			},
+			this.props.onClose
+		);
 
 	insertATag = () => {
 		const { linkNewTab, linkText } = this.state;

--- a/client/my-sites/comments/comment/comment-html-editor/add-link-dialog.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/add-link-dialog.jsx
@@ -1,0 +1,138 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import FormCheckbox from 'components/forms/form-checkbox';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+
+const REGEXP_EMAIL = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i;
+const REGEXP_URL = /^(https?|ftp):\/\/[A-Z0-9.-]+\.[A-Z]{2,4}[^ "]*$/i;
+const REGEXP_STANDALONE_URL = /^(?:[a-z]+:|#|\?|\.|\/)/;
+
+export class AddLinkDialog extends Component {
+	static propTypes = {
+		onClose: PropTypes.func,
+		onInsert: PropTypes.func,
+		selectedText: PropTypes.string,
+		shouldDisplay: PropTypes.bool,
+		translate: PropTypes.func,
+	};
+
+	state = {
+		linkNewTab: false,
+		linkText: '',
+		linkUrl: '',
+	};
+
+	componentWillReceiveProps( newProps ) {
+		this.setState( {
+			linkUrl: this.inferUrl( newProps.selectedText ),
+			linkText: newProps.selectedText,
+		} );
+	}
+
+	correctUrl() {
+		const url = this.state.linkUrl.trim();
+		if ( REGEXP_EMAIL.test( url ) ) {
+			return `mailto:${ url }`;
+		}
+		if ( ! REGEXP_STANDALONE_URL.test( url ) ) {
+			return `http://${ url }`;
+		}
+		return url;
+	}
+
+	inferUrl( selectedText ) {
+		if ( REGEXP_EMAIL.test( selectedText ) ) {
+			return 'mailto:' + selectedText;
+		} else if ( REGEXP_URL.test( selectedText ) ) {
+			return selectedText.replace( /&amp;|&#0?38;/gi, '&' );
+		}
+		return '';
+	}
+
+	setLinkUrl = event => this.setState( { linkUrl: event.target.value } );
+
+	setLinkText = event => this.setState( { linkText: event.target.value } );
+
+	setLinkNewTab = event => this.setState( { linkNewTab: event.target.checked } );
+
+	closeDialog = () => {
+		this.setState( {
+			linkNewTab: false,
+			linkText: '',
+			linkUrl: '',
+		} );
+		this.props.onClose();
+	};
+
+	insertATag = () => {
+		const { linkNewTab, linkText } = this.state;
+		this.props.onInsert(
+			{
+				href: this.correctUrl(),
+				...( linkNewTab ? { target: '_blank' } : {} ),
+			},
+			linkText
+		);
+		this.closeDialog();
+	};
+
+	render() {
+		const { shouldDisplay, translate } = this.props;
+		const { linkNewTab, linkText, linkUrl } = this.state;
+
+		const buttons = [
+			{
+				action: 'cancel',
+				label: translate( 'Cancel' ),
+			},
+			{
+				action: 'add-link',
+				isPrimary: true,
+				label: translate( 'Add Link' ),
+				onClick: this.insertATag,
+			},
+		];
+
+		return (
+			<Dialog
+				isVisible={ shouldDisplay }
+				buttons={ buttons }
+				onClose={ this.closeDialog }
+				additionalClassNames="comment-html-editor__dialog"
+			>
+				<FormFieldset>
+					<FormLabel htmlFor="link_url">{ translate( 'URL' ) }</FormLabel>
+					<FormTextInput name="link_url" onChange={ this.setLinkUrl } value={ linkUrl } />
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="link_text">{ translate( 'Link Text' ) }</FormLabel>
+					<FormTextInput name="link_text" onChange={ this.setLinkText } value={ linkText } />
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel>
+						<FormCheckbox
+							checked={ linkNewTab }
+							name="link_new_tab"
+							onChange={ this.setLinkNewTab }
+						/>
+						<span>{ translate( 'Open link in a new window/tab' ) }</span>
+					</FormLabel>
+				</FormFieldset>
+			</Dialog>
+		);
+	}
+}
+
+export default localize( AddLinkDialog );

--- a/client/my-sites/comments/comment/comment-html-editor/add-link-dialog.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/add-link-dialog.jsx
@@ -15,6 +15,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 
+// @see components/tinymce/plugins/wplink/dialog.jsx
 const REGEXP_EMAIL = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i;
 const REGEXP_URL = /^(https?|ftp):\/\/[A-Z0-9.-]+\.[A-Z]{2,4}[^ "]*$/i;
 const REGEXP_STANDALONE_URL = /^(?:[a-z]+:|#|\?|\.|\/)/;

--- a/client/my-sites/comments/comment/comment-html-editor/index.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/index.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import { delay, each, filter, get, map, reduce } from 'lodash';
+import { delay, each, get, map, reduce, reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -77,7 +77,9 @@ export class CommentHtmlEditor extends Component {
 		}
 
 		if ( !! fragments[ 1 ] && this.isTagOpen( tag ) ) {
-			this.setState( ( { openTags } ) => ( { openTags: filter( openTags, tag ) } ) );
+			this.setState( ( { openTags } ) => ( {
+				openTags: reject( openTags, openTag => openTag === tag ),
+			} ) );
 			return this.insertContent( closer, options.adjustCursorPosition );
 		}
 

--- a/client/my-sites/comments/comment/comment-html-editor/index.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/index.jsx
@@ -56,7 +56,6 @@ export class CommentHtmlEditor extends Component {
 			indent: false,
 			newLineAfter: false,
 			paragraph: false,
-			selfClosed: false,
 			text: null,
 		}
 	) => {
@@ -77,12 +76,12 @@ export class CommentHtmlEditor extends Component {
 			return this.insertContent( opener + inner + closer, options.adjustCursorPosition );
 		}
 
-		if ( ! options.selfClosed && this.isTagOpen( tag ) ) {
+		if ( !! fragments[ 1 ] && this.isTagOpen( tag ) ) {
 			this.setState( ( { openTags } ) => ( { openTags: filter( openTags, tag ) } ) );
 			return this.insertContent( closer, options.adjustCursorPosition );
 		}
 
-		if ( ! options.selfClosed ) {
+		if ( !! fragments[ 1 ] ) {
 			this.setState( ( { openTags } ) => ( { openTags: openTags.concat( tag ) } ) );
 		}
 		return this.insertContent( opener, options.adjustCursorPosition );
@@ -137,7 +136,7 @@ export class CommentHtmlEditor extends Component {
 
 	insertInsTag = () => this.insertHtmlTag( 'ins', { datetime: this.props.moment().format() } );
 
-	insertImgTag = attributes => this.insertHtmlTag( 'img', attributes, { selfClosed: true } );
+	insertImgTag = attributes => this.insertHtmlTag( 'img', attributes );
 
 	insertUlTag = () => this.insertHtmlTag( 'ul', {}, { paragraph: true } );
 
@@ -184,7 +183,7 @@ export class CommentHtmlEditor extends Component {
 			blockquote: { label: 'b-quote', onClick: this.insertBlockquoteTag },
 			del: { onClick: this.insertDelTag },
 			ins: { onClick: this.insertInsTag },
-			img: { onClick: this.openImageDialog, selfClosed: true },
+			img: { onClick: this.openImageDialog },
 			ul: { onClick: this.insertUlTag },
 			ol: { onClick: this.insertOlTag },
 			li: { onClick: this.insertLiTag },
@@ -198,11 +197,11 @@ export class CommentHtmlEditor extends Component {
 		return (
 			<div className="comment-html-editor">
 				<div className="comment-html-editor__toolbar">
-					{ map( buttons, ( { disabled, label, onClick, selfClosed }, tag ) => (
+					{ map( buttons, ( { disabled, label, onClick }, tag ) => (
 						<Button
 							borderless
 							className={ classNames( `comment-html-editor__toolbar-button-${ tag }`, {
-								'is-tag-open': ! selfClosed && this.isTagOpen( tag ),
+								'is-tag-open': this.isTagOpen( tag ),
 							} ) }
 							compact
 							disabled={ disabled }

--- a/client/my-sites/comments/comment/comment-html-editor/index.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/index.jsx
@@ -11,8 +11,8 @@ import { delay, each, filter, get, map, reduce } from 'lodash';
 /**
  * Internal dependencies
  */
-import AddImageDialog from 'post-editor/editor-html-toolbar/add-image-dialog';
-import AddLinkDialog from 'post-editor/editor-html-toolbar/add-link-dialog';
+import AddImageDialog from 'my-sites/comments/comment/comment-html-editor/add-image-dialog';
+import AddLinkDialog from 'my-sites/comments/comment/comment-html-editor/add-link-dialog';
 import Button from 'components/button';
 
 export class CommentHtmlEditor extends Component {

--- a/client/my-sites/comments/comment/comment-html-editor/index.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/index.jsx
@@ -196,12 +196,12 @@ export class CommentHtmlEditor extends Component {
 		};
 
 		return (
-			<div className="comment__html-editor">
-				<div className="comment__html-toolbar">
+			<div className="comment-html-editor">
+				<div className="comment-html-editor__toolbar">
 					{ map( buttons, ( { disabled, label, onClick, selfClosed }, tag ) => (
 						<Button
 							borderless
-							className={ classNames( `comment__html-toolbar-button-${ tag }`, {
+							className={ classNames( `comment-html-editor__toolbar-button-${ tag }`, {
 								'is-tag-open': ! selfClosed && this.isTagOpen( tag ),
 							} ) }
 							compact
@@ -215,7 +215,7 @@ export class CommentHtmlEditor extends Component {
 				</div>
 
 				<textarea
-					className="comment__edit-textarea form-textarea"
+					className="comment-html-editor__textarea form-textarea"
 					disabled={ this.props.disabled }
 					onChange={ onChange }
 					ref={ this.storeTextareaRef }

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -552,7 +552,7 @@
 	color: lighten($gray, 30%);
 }
 
-.editor-html-toolbar__dialog {
+.comment-html-editor__dialog {
 	max-height: 90%;
 
 	.dialog__content {

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -495,12 +495,12 @@
 
 // HTML Editor
 
-.comment__html-editor {
+.comment-html-editor {
 	margin: 0 8px;
 	width: 100%;
 }
 
-.comment__html-toolbar .button {
+.comment-html-editor__toolbar .button {
 	border-right: 1px solid lighten($gray, 30%);
 	border-radius: 0px;
 	color: darken($gray, 20%);
@@ -529,26 +529,26 @@
 	}
 }
 
-.comment__html-toolbar-button-strong {
+.comment-html-editor__toolbar-button-strong {
 	font-weight: bold;
 }
-.comment__html-toolbar-button-em {
+.comment-html-editor__toolbar-button-em {
 	font-style: italic;
 }
-.comment__html-toolbar-button-a.button {
+.comment-html-editor__toolbar-button-a.button {
 	color: $blue-wordpress;
 	text-decoration: underline;
 }
-.comment__html-toolbar-button-del {
+.comment-html-editor__toolbar-button-del {
 	text-decoration: line-through;
 }
-.comment__html-toolbar-button-ins {
+.comment-html-editor__toolbar-button-ins {
 	text-decoration: underline;
 }
-.comment__html-toolbar-button-code {
+.comment-html-editor__toolbar-button-code {
 	font-family: $code;
 }
-.comment__html-toolbar-button-close-tags.button[disabled]:hover {
+.comment-html-editor__toolbar-button-close-tags.button[disabled]:hover {
 	color: lighten($gray, 30%);
 }
 

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -437,7 +437,7 @@
 	}
 
 	.form-textarea {
-		margin: 0px 8px 20px 8px;
+		margin: 0 0 20px 0;
 		resize: vertical;
 		transition: none;
 		width: 100%;
@@ -490,6 +490,89 @@
 .comment__edit-buttons {
 	padding: 0 8px 16px 8px;
 	width: 100%;
+}
+
+// HTML Editor
+
+.comment__html-editor {
+	margin: 0 8px;
+	width: 100%;
+}
+
+.comment__html-toolbar .button {
+	border-right: 1px solid lighten($gray, 30%);
+	border-radius: 0px;
+	color: darken($gray, 20%);
+	margin-bottom: 8px;
+	min-width: 30px;
+	padding: 4px 8px;
+	position: relative;
+	text-transform: lowercase;
+
+	&:hover {
+		color: $gray-dark;
+	}
+
+	&:last-child {
+		border-right: none;
+	}
+
+	&.is-tag-open {
+		padding-left: 12px;
+		padding-right: 4px;
+		&::before {
+			content: '/';
+			left: 8px;
+			position: absolute;
+		}
+	}
+}
+
+.comment__html-toolbar-button-strong {
+	font-weight: bold;
+}
+.comment__html-toolbar-button-em {
+	font-style: italic;
+}
+.comment__html-toolbar-button-a.button {
+	color: $blue-wordpress;
+	text-decoration: underline;
+}
+.comment__html-toolbar-button-del {
+	text-decoration: line-through;
+}
+.comment__html-toolbar-button-ins {
+	text-decoration: underline;
+}
+.comment__html-toolbar-button-code {
+	font-family: $code;
+}
+.comment__html-toolbar-button-close-tags.button[disabled]:hover {
+	color: lighten($gray, 30%);
+}
+
+.editor-html-toolbar__dialog {
+	max-height: 90%;
+
+	.dialog__content {
+		min-width: 40vw;
+	}
+	.form-fieldset {
+		margin-bottom: 8px;
+	}
+	.post-selector {
+		margin-bottom: 16px;
+		.post-selector__results {
+			height: 24vh;
+		}
+	}
+
+	@include breakpoint( '<660px' ) {
+		width: 90%;
+		.dialog__content {
+			min-width: none;
+		}
+	}
 }
 
 // Bulk Mode View

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -437,6 +437,7 @@
 	}
 
 	.form-textarea {
+		height: 184px; // 8 lines
 		margin: 0 0 20px 0;
 		resize: vertical;
 		transition: none;


### PR DESCRIPTION
Fix #21663
Supersede #22040 

Add an HTML toolbar to help adding quick tags when editing comments in the Comments Management section.

<img width="856" alt="screen shot 2018-02-01 at 12 07 16" src="https://user-images.githubusercontent.com/2070010/35677671-789b3078-0748-11e8-97f8-4a569949c9c4.png">

All props for this new take go to @dmsnell!

## Testing instructions

Open `/comments` and click on Edit on some comments.
Use the new HTML toolbar to open and close tags.
Make sure the inserted tags feel "right" (e.g. the expected newlines or indents).

### Testing Notes

I've tried my best to fix all the issues reported in the previous flow patrol call for testing (p6jOYE-1ww-p2), but it's still possible some of them slipped through the cracks.
Either way, this is a list of what this PR **won't** attempt to fix.

- The toolbar is only aware of the toolbar itself.
This means that an open tag manually written, won't be closed when clicking on its button.
This also mean that the close tags button won't close any tags manually written (or added via the toolbar during a previous edit).
This is what happens in wp-admin, but also not the best behaviour possible. Though, changes might be too complicated, likely overkill for this use case. Let's leave thinking about improving for another time. 🙂 

- "If I don't close an HTML tag, it isn't auto-closed for me. (on save)" (reported by @rachelmcr).
For now let's try to have the same behaviour of wp-admin, and then iterate on top of that.
This kind of auto-closing could make use of the internal open tags tracker or of a regular expressions. Either can be done in a separate PR.

- "When adding not closed tag it get's URL encoded in Edit field: `<a` -> `&lt;a`" (reported by @brbrr)
This should indeed be the expected outcome.
The backend parse the comment and attempt to sanitize it. `<a` by itself is not necessarily a malformed tag, but it can be a "less then a" expression.

- The toolbar is only on the Edit textarea. It will be added to the Reply textarea as well in a follow up PR. We'll think about a Preview too in the future. (cc @hoverduck @brbrr)

## Dev Notes

This approach does two things differently than the post editor HTML toolbar.

- It builds the tags by taking advantage of the `Document.createElement`, `Element.setAttribute`, and `Element.outerHTML` methods, instead of manually creating the strings.
This way, we get to both decrease the file size and complexity, and also minimize the human error chances.
(Again, all props to @dmsnell for the clever solution)

- Instead of jumping through multiple hoops to make `document.execCommand( 'insertText' )` (needed for the undo history) behave in all browsers as it does in Chrome, I've just decided to throw in the towel, and embrace the incompatibilities.

### Chrome
It uses `execCommand`, which triggers the textarea `onChange`, which updates the comment content in the component internal state.
Inserted tags are part of the undo history.
All is well in the world.

### Firefox, IE11, Edge
`execCommand` doesn't work, doesn't trigger the textarea `onChange`, and doesn't update the comment content in the component internal state.
As far as I know, there is just no simple way to keep the undo history.
So, we just manually trigger the textarea `onChange`, which updates the content in state, which in turn updates it in the textarea itself.
Then we pass a callback to the `setState`, which sets the cursor position appropriately (usually right after the inserted content), and finally gives the focus back to the textarea.