### PR TITLE
Domains: NUX Transfer Restriction screen

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -253,10 +253,14 @@ class TransferDomainStep extends React.Component {
 	transferIsRestricted = () => {
 		const { submittingAvailability, submittingWhois } = this.state;
 		const submitting = submittingAvailability || submittingWhois;
+		const transferRestrictionStatus = get(
+			this.state,
+			'inboundTransferStatus.transferRestrictionStatus',
+			false
+		);
 
 		return (
-			! submitting &&
-			'not_restricted' !== this.state.inboundTransferStatus.transferRestrictionStatus
+			! submitting && transferRestrictionStatus && 'not_restricted' !== transferRestrictionStatus
 		);
 	};
 
@@ -286,7 +290,12 @@ class TransferDomainStep extends React.Component {
 
 	goBack = () => {
 		if ( this.state.domain ) {
-			this.setState( { domain: null, precheck: false, supportsPrivacy: false } );
+			this.setState( {
+				domain: null,
+				inboundTransferStatus: {},
+				precheck: false,
+				supportsPrivacy: false,
+			} );
 		} else {
 			this.props.goBack();
 		}
@@ -296,13 +305,12 @@ class TransferDomainStep extends React.Component {
 		let content;
 		const { precheck } = this.state;
 		const { isSignupStep } = this.props;
+		const transferIsRestricted = this.transferIsRestricted();
 
-		if ( precheck && ! isSignupStep ) {
-			if ( this.transferIsRestricted() ) {
-				content = this.getTransferRestrictionMessage();
-			} else {
-				content = this.getTransferDomainPrecheck();
-			}
+		if ( transferIsRestricted ) {
+			content = this.getTransferRestrictionMessage();
+		} else if ( precheck && ! isSignupStep ) {
+			content = this.getTransferDomainPrecheck();
 		} else {
 			content = this.addTransfer();
 		}


### PR DESCRIPTION
Properly show the restriction screens in NUX when a domain is not eligible for transfer (e.g. 60 days after registration).

Test:
- Register a domain elsewhere.
- Go to calypso.localhost:3000/start/
- Give the site a name and topic and click “Continue.”
- Enter the domain from step 1 into the site address field.
- Click the “Yes, I own this domain” link.
- Click the “Transfer to WordPress.com” button.

Before: Nothing happens, stays on same screen.
After:
![test](https://user-images.githubusercontent.com/1103398/36098240-848d33cc-0ffe-11e8-924d-5e8a7dee608b.png)
