### PR TITLE
Jetpack Onboarding: Redirect to Plans page after JPC free plan

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -34,6 +34,7 @@ import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 import {
 	canCurrentUser,
+	getUnconnectedSite,
 	hasInitializedSites,
 	isRtl,
 	isSiteAutomatedTransfer,
@@ -128,7 +129,9 @@ class Plans extends Component {
 		} );
 		mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_free' );
 
-		if ( this.props.calypsoStartedConnection ) {
+		if ( this.props.jpoSiteCredentials ) {
+			this.redirect( CALYPSO_PLANS_PAGE );
+		} else if ( this.props.calypsoStartedConnection ) {
 			this.redirect( CALYPSO_REDIRECTION_PAGE );
 		} else {
 			this.redirectToWpAdmin();
@@ -225,6 +228,7 @@ export default connect(
 			canPurchasePlans: selectedSite
 				? canCurrentUser( state, selectedSite.ID, 'manage_options' )
 				: true,
+			jpoSiteCredentials: selectedSite && getUnconnectedSite( state, selectedSite.ID ),
 			hasPlan: selectedSite ? isCurrentPlanPaid( state, selectedSite.ID ) : null,
 			isAutomatedTransfer: selectedSite ? isSiteAutomatedTransfer( state, selectedSite.ID ) : null,
 			isRtlLayout: isRtl( state ),


### PR DESCRIPTION
This PR updates the Jetpack Connect plans page Free plan button to redirect to `/plans/:site` page for sites that are going through the Jetpack Onboarding flow. 

Fixes #21916.

To test:
* Get this branch going locally.
* Start the onboarding flow for a fresh site (`/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`).
* Go through the flow and on the Summary step, click the link to connect your site.
* After connection finishes, on the plans page click the Free plan button.
* Verify you're redirected to `/plans/:site`.
* Start the onboarding flow for a fresh site.
* Go through the flow and on the Summary step, click the link to connect your site.
* On the plans page, select and purchase a plan. 
* Verify you're redirected to the plan setup page in Calypso, which after finishing provides a link to explore the plan (should link to `/wp-admin/admin.php?page=jetpack#/plans` or similar).
* Start the JPC flow for a fresh site.
* After connecting the site, click the Free plan.
* Verify you're directed to `/posts`.
* Start the JPC flow for a fresh site.
* After connecting the site, select a paid plan and purchase it.
* Verify you're redirected to the plan setup page in Calypso, which after finishing provides a link to explore the plan (should link to `/wp-admin/admin.php?page=jetpack#/plans` or similar).
