### PR TITLE
SEO: add SEO description field to editor if site has a JP Premium plan

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flow, get } from 'lodash';
+import { flow, get, overSome } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,7 +22,7 @@ import PostMetadata from 'lib/post-metadata';
 import TrackInputChanges from 'components/track-input-changes';
 import actions from 'lib/posts/actions';
 import { recordStat, recordEvent } from 'lib/posts/stats';
-import { isBusiness, isEnterprise } from 'lib/products-values';
+import { isBusiness, isEnterprise, isJetpackPremium } from 'lib/products-values';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import QueryPostTypes from 'components/data/query-post-types';
 import QuerySiteSettings from 'components/data/query-site-settings';
@@ -48,6 +48,7 @@ import { getFirstConflictingPlugin } from 'lib/seo';
 /**
  * Constants
  */
+const hasSupportingPlan = overSome( isBusiness, isEnterprise, isJetpackPremium );
 
 /**
  * A mapping of post type to hard-coded post types support. These values are
@@ -269,10 +270,7 @@ class EditorDrawer extends Component {
 			}
 		}
 
-		const { plan } = site;
-		const hasBusinessPlan = isBusiness( plan ) || isEnterprise( plan );
-
-		if ( ! hasBusinessPlan ) {
+		if ( ! hasSupportingPlan( site.plan ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #22333

We want to check for Business, Enterprise, and Premium plans now.
Related: #21730

To test:
1. Start from a site using Jetpack Premium, and where the SEO Tools are active.
2. Go to https://wordpress.com/post/
3. The SEO Description slider should be displayed in the editor's sidebar.