### PR TITLE
SiteTitle Component: Validation Copy and Styling Fixes

### DIFF
--- a/client/components/site-title/index.jsx
+++ b/client/components/site-title/index.jsx
@@ -55,6 +55,9 @@ class SiteTitleControl extends React.Component {
 			isBlognameRequired,
 			translate,
 		} = this.props;
+
+		const isValidSiteTitle = isBlognameRequired && !! blogname;
+
 		return (
 			<div className="site-title">
 				<FormFieldset>
@@ -63,6 +66,8 @@ class SiteTitleControl extends React.Component {
 						autoFocus={ autoFocusBlogname }
 						disabled={ disabled }
 						id="blogname"
+						isError={ ! isValidSiteTitle && ! disabled }
+						isValid={ isValidSiteTitle && ! disabled }
 						onChange={ this.onChangeSiteTitle }
 						value={ blogname }
 					/>

--- a/client/components/site-title/index.jsx
+++ b/client/components/site-title/index.jsx
@@ -68,7 +68,10 @@ class SiteTitleControl extends React.Component {
 					/>
 					{ isBlognameRequired &&
 						! disabled && (
-							<FormInputValidation isError={ ! blogname } text={ translate( 'Required field.' ) } />
+							<FormInputValidation
+								isError={ ! blogname }
+								text={ translate( 'Please enter a site title' ) }
+							/>
 						) }
 				</FormFieldset>
 				<FormFieldset>

--- a/client/components/site-title/index.jsx
+++ b/client/components/site-title/index.jsx
@@ -56,8 +56,6 @@ class SiteTitleControl extends React.Component {
 			translate,
 		} = this.props;
 
-		const isValidSiteTitle = isBlognameRequired && !! blogname;
-
 		return (
 			<div className="site-title">
 				<FormFieldset>
@@ -66,13 +64,14 @@ class SiteTitleControl extends React.Component {
 						autoFocus={ autoFocusBlogname }
 						disabled={ disabled }
 						id="blogname"
-						isError={ ! isValidSiteTitle && ! disabled }
-						isValid={ isValidSiteTitle && ! disabled }
+						isError={ ! disabled && isBlognameRequired && ! blogname }
+						isValid={ ! disabled && isBlognameRequired && !! blogname }
 						onChange={ this.onChangeSiteTitle }
 						value={ blogname }
 					/>
-					{ ! isValidSiteTitle &&
-						! disabled && (
+					{ ! disabled &&
+						isBlognameRequired &&
+						! blogname && (
 							<FormInputValidation isError text={ translate( 'Please enter a site title' ) } />
 						) }
 				</FormFieldset>

--- a/client/components/site-title/index.jsx
+++ b/client/components/site-title/index.jsx
@@ -71,12 +71,9 @@ class SiteTitleControl extends React.Component {
 						onChange={ this.onChangeSiteTitle }
 						value={ blogname }
 					/>
-					{ isBlognameRequired &&
+					{ ! isValidSiteTitle &&
 						! disabled && (
-							<FormInputValidation
-								isError={ ! blogname }
-								text={ translate( 'Please enter a site title' ) }
-							/>
+							<FormInputValidation isError text={ translate( 'Please enter a site title' ) } />
 						) }
 				</FormFieldset>
 				<FormFieldset>


### PR DESCRIPTION
Implement's @joanrho's https://github.com/Automattic/wp-calypso/issues/21870#issuecomment-363836398:

>  - **Required field** on error should be "Please enter a site title" (no icons) with a red border color on the field.
> - **Required field** on success should be removed altogether with a green border color on the field.

* Use `<FormTextInput />`'s `isValid` and an `isError` props for border styling.
* Only show `<FormInputValidation />` component on validation error.
* Change validation copy to 'Please enter a site title'.

Fixes whatever is left to do in #21870.

To test: 
* Verify that http://calypso.localhost:3000/devdocs/design/site-title-control (which doesn't set the form validation prop) looks the same as https://wpcalypso.wordpress.com/devdocs/design/site-title-control
* Try the JPO flow's site title steps. Compare with screenshots below.

**Before:**

Invalid:

![image](https://user-images.githubusercontent.com/96308/36099489-cbf3c1c6-0ffa-11e8-9012-05f5eae16e11.png)

Valid:

![image](https://user-images.githubusercontent.com/96308/36099484-c42465b8-0ffa-11e8-8a59-fb75b39b8097.png)

**After:**

Invalid:

![image](https://user-images.githubusercontent.com/96308/36099368-4f94e466-0ffa-11e8-913b-4688561f3909.png)

Valid:

![image](https://user-images.githubusercontent.com/96308/36099349-40c73a06-0ffa-11e8-822d-762a4b801dd1.png)

Loading state is unchanged:

![image](https://user-images.githubusercontent.com/96308/36099400-728b7e58-0ffa-11e8-83fa-489d274084f6.png)