### PR TITLE
JP Onboarding: Fix Business Address Step Validation

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -99,25 +99,27 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 
 				<Card className="steps__form">
 					<form onSubmit={ this.handleSubmit }>
-						{ map( this.fields, ( fieldLabel, fieldName ) => (
-							<FormFieldset key={ fieldName }>
-								<FormLabel htmlFor={ fieldName }>{ fieldLabel }</FormLabel>
-								<FormTextInput
-									autoFocus={ fieldName === 'name' }
-									disabled={ isRequestingSettings }
-									id={ fieldName }
-									onChange={ this.getChangeHandler( fieldName ) }
-									value={ this.state[ fieldName ] || '' }
-								/>
-								{ fieldName !== 'state' &&
-									! isRequestingSettings && (
-										<FormInputValidation
-											isError={ this.state[ fieldName ] === '' }
-											text={ translate( 'Required field.' ) }
-										/>
-									) }
-							</FormFieldset>
-						) ) }
+						{ map( this.fields, ( fieldLabel, fieldName ) => {
+							const isValid = this.state[ fieldName ] !== '' || fieldName === 'state';
+							return (
+								<FormFieldset key={ fieldName }>
+									<FormLabel htmlFor={ fieldName }>{ fieldLabel }</FormLabel>
+									<FormTextInput
+										autoFocus={ fieldName === 'name' }
+										disabled={ isRequestingSettings }
+										id={ fieldName }
+										isError={ ! isValid && ! isRequestingSettings }
+										isValid={ isValid && ! isRequestingSettings }
+										onChange={ this.getChangeHandler( fieldName ) }
+										value={ this.state[ fieldName ] || '' }
+									/>
+									{ ! isValid &&
+										! isRequestingSettings && (
+											<FormInputValidation isError text={ translate( 'Required field.' ) } />
+										) }
+								</FormFieldset>
+							);
+						} ) }
 						<Button
 							disabled={ isRequestingSettings || this.hasEmptyFields() }
 							primary

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -100,7 +100,9 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 				<Card className="steps__form">
 					<form onSubmit={ this.handleSubmit }>
 						{ map( this.fields, ( fieldLabel, fieldName ) => {
-							const isValid = this.state[ fieldName ] !== '' || fieldName === 'state';
+							const isValidatingField = ! isRequestingSettings && fieldName !== 'state';
+							const isValidField = this.state[ fieldName ] !== '';
+
 							return (
 								<FormFieldset key={ fieldName }>
 									<FormLabel htmlFor={ fieldName }>{ fieldLabel }</FormLabel>
@@ -108,13 +110,13 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 										autoFocus={ fieldName === 'name' }
 										disabled={ isRequestingSettings }
 										id={ fieldName }
-										isError={ ! isValid && ! isRequestingSettings }
-										isValid={ isValid && ! isRequestingSettings }
+										isError={ isValidatingField && ! isValidField }
+										isValid={ isValidatingField && isValidField }
 										onChange={ this.getChangeHandler( fieldName ) }
 										value={ this.state[ fieldName ] || '' }
 									/>
-									{ ! isValid &&
-										! isRequestingSettings && (
+									{ isValidatingField &&
+										! isValidField && (
 											<FormInputValidation
 												isError
 												text={ translate( 'Please enter a %(fieldLabel)s', {

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -115,7 +115,12 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 									/>
 									{ ! isValid &&
 										! isRequestingSettings && (
-											<FormInputValidation isError text={ translate( 'Required field.' ) } />
+											<FormInputValidation
+												isError
+												text={ translate( 'Please enter a %(fieldLabel)s', {
+													args: { fieldLabel },
+												} ) }
+											/>
 										) }
 								</FormFieldset>
 							);


### PR DESCRIPTION
Somewhat akin to #22336.

* Use `<FormTextInput />`'s `isValid` and an `isError` props for border styling.
* Only show `<FormInputValidation />` component on validation error.
* Change validation copy to 'Please enter a `<fieldLabel>`'.

To test: 
* Check the JPO flow's Business Address step.
* Note that all fields except for 'State' are being validated -- they either have a red border and warning, or a green border. 'State' always has a grey border, since it's not being validated.

Before:

![image](https://user-images.githubusercontent.com/96308/36106251-b7247592-100e-11e8-800a-0dfd08079c7e.png)

After:

![image](https://user-images.githubusercontent.com/96308/36107170-27a220b0-1011-11e8-912c-8f4e1facb998.png)