### PR TITLE
Support user: clean up old SU format from Happychat middleware

### DIFF
--- a/client/state/happychat/middleware-calypso.js
+++ b/client/state/happychat/middleware-calypso.js
@@ -32,11 +32,10 @@ import getGroups from 'state/happychat/selectors/get-groups';
 import getSkills from 'state/happychat/selectors/get-skills';
 import isHappychatChatAssigned from 'state/happychat/selectors/is-happychat-chat-assigned';
 import isHappychatClientConnected from 'state/happychat/selectors/is-happychat-client-connected';
-import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
+import { getCurrentUserLocale } from 'state/current-user/selectors';
 
 const getRouteSetMessage = ( state, action ) => {
-	const currentUser = getCurrentUser( state );
-	return `Looking at https://wordpress.com${ action.path }?support_user=${ currentUser.username }`;
+	return `Looking at https://wordpress.com${ action.path }`;
 };
 
 export const getEventMessageFromActionData = action => {

--- a/client/state/happychat/test/middleware-calypso.js
+++ b/client/state/happychat/test/middleware-calypso.js
@@ -127,7 +127,7 @@ describe( 'middleware', () => {
 			test( 'should dispatch a sendEvent action if client connected and chat assigned', () => {
 				actionMiddleware( action );
 				expect( store.dispatch.mock.calls[ 0 ][ 0 ].payload.text ).toBe(
-					'Looking at https://wordpress.com/me?support_user=Link'
+					'Looking at https://wordpress.com/me'
 				);
 			} );
 


### PR DESCRIPTION
This parameter will become obsolete once we remove the old SU dialog.

### Testing instructions

1. Run this branch with Happychat HUD locally.
2. Verify that `Looking at` links in chat header and messages no longer have `support_user` parameter appended to them.