### PR TITLE
Jetpack Connect: On free plan, redirect to plans page with main tour if enough caps

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -98,6 +98,8 @@ class Plans extends Component {
 		const { canPurchasePlans, selectedSiteSlug } = this.props;
 
 		if ( selectedSiteSlug && canPurchasePlans ) {
+			// Redirect to "My Plan" page with the "Main Tour" guided tour enabled.
+			// For more details about guided tours, see layout/guided-tours/README.md
 			return this.redirect( CALYPSO_MY_PLAN_PAGE, { tour: 'main' } );
 		}
 

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -21,6 +21,7 @@ import PlansSkipButton from './plans-skip-button';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { addItem } from 'lib/upgrades/actions';
+import { addQueryArgs } from 'lib/route';
 import { clearPlan, isCalypsoStartedConnection, retrievePlan } from './persistence-utils';
 import { completeFlow } from 'state/jetpack-connect/actions';
 import { externalRedirect } from 'lib/route/path';
@@ -85,11 +86,21 @@ class Plans extends Component {
 		}
 		if ( ! this.props.canPurchasePlans ) {
 			if ( this.props.calypsoStartedConnection ) {
-				this.redirect( CALYPSO_REDIRECTION_PAGE );
+				this.redirectToCalypso();
 			} else {
 				this.redirectToWpAdmin();
 			}
 		}
+	}
+
+	redirectToCalypso() {
+		const { canPurchasePlans, selectedSiteSlug } = this.props;
+
+		if ( selectedSiteSlug && canPurchasePlans ) {
+			return this.redirect( CALYPSO_PLANS_PAGE, { tour: 'main' } );
+		}
+
+		return this.redirect( CALYPSO_REDIRECTION_PAGE );
 	}
 
 	handleSkipButtonClick = () => {
@@ -115,8 +126,14 @@ class Plans extends Component {
 		}
 	}
 
-	redirect( path ) {
-		page.redirect( path + this.props.selectedSiteSlug );
+	redirect( path, args ) {
+		let redirectTo = path + this.props.selectedSiteSlug;
+
+		if ( args ) {
+			redirectTo = addQueryArgs( args, redirectTo );
+		}
+
+		page.redirect( redirectTo );
 		this.redirecting = true;
 		this.props.completeFlow();
 	}
@@ -129,7 +146,7 @@ class Plans extends Component {
 		mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_free' );
 
 		if ( this.props.calypsoStartedConnection ) {
-			this.redirect( CALYPSO_REDIRECTION_PAGE );
+			this.redirectToCalypso();
 		} else {
 			this.redirectToWpAdmin();
 		}

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -41,6 +41,7 @@ import {
 } from 'state/selectors';
 
 const CALYPSO_PLANS_PAGE = '/plans/';
+const CALYPSO_MY_PLAN_PAGE = '/plans/my-plan/';
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 const JETPACK_ADMIN_PATH = '/wp-admin/admin.php?page=jetpack';
 
@@ -97,7 +98,7 @@ class Plans extends Component {
 		const { canPurchasePlans, selectedSiteSlug } = this.props;
 
 		if ( selectedSiteSlug && canPurchasePlans ) {
-			return this.redirect( CALYPSO_PLANS_PAGE, { tour: 'main' } );
+			return this.redirect( CALYPSO_MY_PLAN_PAGE, { tour: 'main' } );
 		}
 
 		return this.redirect( CALYPSO_REDIRECTION_PAGE );


### PR DESCRIPTION
Right now, after connection, if the user clicks on the free plan, we redirect them to `/posts/:site`, which isn't very helpful. This is also outlined in #21916, where the user is thrown in `/posts` after the onboarding flow after a successful connection.

After @ockham suggested us enabling a guided tour for the user (https://github.com/Automattic/wp-calypso/issues/21916#issuecomment-364934098), and a brief discussion with him and @seear on Slack, we concluded that it would be an improvement for both standalone JPC and JPO + JPC, because it would show some basics to the user so they know where to start from.

So this PR suggests redirecting to `/plans/my-plan/:site?tour=main`, which basically enables the main guided tour with the WP.com basics.

For users that don't have the capability to purchase plans, redirection to `/plans/my-plan` doesn't make sense - so we can just keep redirecting them to `/posts/:site`.

Fixes #21916.

To test:
* Checkout this branch
* Go through the onboarding flow for a fresh site where you are an administrator.
* After reaching the last onboarding step, click the link to start the connection flow.
* After connecting, click the "Free" plan button.
* Verify you're redirected to `/plans/my-plan/:site?tour=main` and you can see the guided tour.
* Run JPC starting from WP.com for a fresh site.
* After connecting, click the "Free" plan button.
* Verify you're redirected to `/plans/my-plan/:site?tour=main` and you can see the guided tour.
* Go through the JPC flow for the same site, but this time logged in as a subscriber.
* After connecting, click the "Free" plan button.
* Verify you are redirected to `/posts/:site`.