### PR TITLE
Add Jetpack log-in route handling

### DIFF
--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -26,6 +26,7 @@ export default router => {
 				`/log-in/:twoFactorAuthType(authenticator|backup|sms|push)/${ lang }`,
 				`/log-in/:flow(social-connect|private-site)/${ lang }`,
 				`/log-in/:socialService(google)/callback/${ lang }`,
+				`/log-in/:isJetpack(jetpack)/${ lang }`,
 				`/log-in/${ lang }`,
 			],
 			redirectDefaultLocale,


### PR DESCRIPTION
This PR adds a new route to the existing log-in handler, making `/log-in/jetpack` be treated the same as `/log-in`.

This will make the new route addition (D10062-code) safe to land anytime.

In the future, the new route will be used to add branding the the log-in page and adjust some navigation that is incoherent as part of the Jetpack connection flow.

## Testing
* Ensure there are no regressions with existing functionality.
* Try logging in with the new flow. It should behave the same. https://calypso.live/log-in/jetpack?branch=add/jetpack/log-in-route
* Optional. Sandbox, apply the patch, and test connections hitting the log-in route.
