### PR TITLE
Login: Feature gate branded login

### DIFF
--- a/client/blocks/login/docs/example.jsx
+++ b/client/blocks/login/docs/example.jsx
@@ -15,7 +15,7 @@ const LoginExample = () => (
 	<React.Fragment>
 		<LoginBlock />
 		<p />
-		<LoginBlock jetpack />
+		<LoginBlock isJetpack />
 	</React.Fragment>
 );
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -43,7 +43,7 @@ const user = userFactory();
 class Login extends Component {
 	static propTypes = {
 		isLinking: PropTypes.bool,
-		jetpack: PropTypes.bool.isRequired,
+		isJetpack: PropTypes.bool.isRequired,
 		linkingSocialService: PropTypes.string,
 		oauth2Client: PropTypes.object,
 		privateSite: PropTypes.bool,
@@ -58,7 +58,7 @@ class Login extends Component {
 		twoFactorNotificationSent: PropTypes.string,
 	};
 
-	static defaultProps = { jetpack: false };
+	static defaultProps = { isJetpack: false };
 
 	componentDidMount = () => {
 		if ( ! this.props.twoFactorEnabled && this.props.twoFactorAuthType ) {
@@ -134,7 +134,7 @@ class Login extends Component {
 
 	renderHeader() {
 		const {
-			jetpack,
+			isJetpack,
 			linkingSocialService,
 			oauth2Client,
 			privateSite,
@@ -188,7 +188,7 @@ class Login extends Component {
 					</p>
 				);
 			}
-		} else if ( jetpack ) {
+		} else if ( isJetpack ) {
 			headerText = translate( 'Log in to your WordPress.com account to set up Jetpack.' );
 			preHeader = (
 				<div>
@@ -273,7 +273,7 @@ class Login extends Component {
 
 	render() {
 		return (
-			<div className={ classNames( 'login', { 'is-jetpack': this.props.jetpack } ) }>
+			<div className={ classNames( 'login', { 'is-jetpack': this.props.isJetpack } ) }>
 				{ this.renderHeader() }
 
 				<ErrorNotice />

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -37,6 +37,7 @@ import PushNotificationApprovalPoller from './two-factor-authentication/push-not
 import userFactory from 'lib/user';
 import SocialConnectPrompt from './social-connect-prompt';
 import JetpackLogo from 'components/jetpack-logo';
+import { isEnabled } from 'config';
 
 const user = userFactory();
 
@@ -188,7 +189,7 @@ class Login extends Component {
 					</p>
 				);
 			}
-		} else if ( isJetpack ) {
+		} else if ( isJetpack && isEnabled( 'jetpack/connection-rebranding' ) ) {
 			headerText = translate( 'Log in to your WordPress.com account to set up Jetpack.' );
 			preHeader = (
 				<div>
@@ -272,8 +273,13 @@ class Login extends Component {
 	}
 
 	render() {
+		const { isJetpack } = this.props;
 		return (
-			<div className={ classNames( 'login', { 'is-jetpack': this.props.isJetpack } ) }>
+			<div
+				className={ classNames( 'login', {
+					'is-jetpack': isJetpack && isEnabled( 'jetpack/connection-rebranding' ),
+				} ) }
+			>
 				{ this.renderHeader() }
 
 				<ErrorNotice />


### PR DESCRIPTION
This PR updates the Jetpack prop from `jetpack` to `isJetpack` which will be more consistent across components.

It also hides the Jetpack branding behind a feature flag.

## Testing
1. Ensure the branded version is seen on enabled environments (https://calypso.live/devdocs/blocks/login?branch=update/jetpack/branding-login-block&flags=jetpack/connection-rebranding)
1. Ensure the branded flow is not seen when the feature flag is disabled (https://calypso.live/devdocs/blocks/login?branch=update/jetpack/branding-login-block&flags=-jetpack/connection-rebranding)