### PR TITLE
Activity Log: Hide the menu item and page when site is not on a paid plan

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -14,7 +14,7 @@ import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
 import Intervals from './intervals';
 import FollowersCount from 'blocks/followers-count';
-import { isSiteStore } from 'state/selectors';
+import { isSiteOnPaidPlan, isSiteStore } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { navItems, intervals as intervalConstants } from './constants';
 
@@ -32,7 +32,7 @@ class StatsNavigation extends Component {
 		const { isStore, isJetpack } = this.props;
 		switch ( item ) {
 			case 'activity':
-				return isJetpack;
+				return isJetpack && this.props.isSiteOnPaidPlan;
 			case 'store':
 				return isStore;
 			default:
@@ -76,6 +76,7 @@ class StatsNavigation extends Component {
 export default connect( ( state, { siteId } ) => {
 	return {
 		isJetpack: isJetpackSite( state, siteId ),
+		isSiteOnPaidPlan: isSiteOnPaidPlan( state, siteId ),
 		isStore: isSiteStore( state, siteId ),
 		siteId,
 	};

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -29,10 +29,10 @@ class StatsNavigation extends Component {
 	};
 
 	isValidItem = item => {
-		const { isStore, isJetpack } = this.props;
+		const { isStore, isJetpack, isPaidPlan } = this.props;
 		switch ( item ) {
 			case 'activity':
-				return isJetpack && this.props.isSiteOnPaidPlan;
+				return isJetpack && isPaidPlan;
 			case 'store':
 				return isStore;
 			default:
@@ -76,7 +76,7 @@ class StatsNavigation extends Component {
 export default connect( ( state, { siteId } ) => {
 	return {
 		isJetpack: isJetpackSite( state, siteId ),
-		isSiteOnPaidPlan: isSiteOnPaidPlan( state, siteId ),
+		isPaidPlan: isSiteOnPaidPlan( state, siteId ),
 		isStore: isSiteStore( state, siteId ),
 		siteId,
 	};

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -20,6 +20,7 @@ import { getSite, isJetpackSite, getSiteOption } from 'state/sites/selectors';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { isSiteOnPaidPlan } from 'state/selectors';
 import AsyncLoad from 'components/async-load';
 import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
 import FollowList from 'lib/follow-list';
@@ -472,11 +473,12 @@ export default {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
+		const isPaidPlan = isSiteOnPaidPlan( state, siteId );
 		const startDate = i18n.moment( context.query.startDate, 'YYYY-MM-DD' ).isValid()
 			? context.query.startDate
 			: undefined;
 
-		if ( siteId && ! isJetpack ) {
+		if ( ( siteId && ! isJetpack ) || ! isPaidPlan ) {
 			page.redirect( '/stats' );
 		} else {
 			analytics.pageView.record( '/stats/activity/:site', analyticsPageTitle + ' > Activity ' );


### PR DESCRIPTION
The Activity Log menu and page should only be visible and usable to paid sites. This PR removes the link and page from non-paid sites.

**Testing Instructions**
- Try to navigate to the Activity Log on a site without a paid plan. Ensure that you are redirected to `/stats` instead.
- Ensure the `Activity` link is removed from the stats overview.
- Ensure you are able to see the Activity Log from all your eligible sites, including Atomic sites, Pressable site, and self-hosted Jetpack sites.