### PR TITLE
On inbound transfer precheck page, change unlock check button text after first click.

### DIFF
--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -42,7 +42,6 @@ class TransferDomainPrecheck extends React.Component {
 
 	state = {
 		currentStep: 1,
-		initialRefreshComplete: false,
 		unlockCheckClicked: false,
 	};
 
@@ -58,10 +57,6 @@ class TransferDomainPrecheck extends React.Component {
 
 		if ( nextProps.unlocked && 1 === this.state.currentStep ) {
 			this.showNextStep();
-		}
-
-		if ( ! this.props.loading && ! this.state.initialRefreshComplete ) {
-			this.setState( { initialRefreshComplete: true } );
 		}
 	}
 
@@ -134,7 +129,7 @@ class TransferDomainPrecheck extends React.Component {
 
 	getStatusMessage() {
 		const { loading, translate, unlocked } = this.props;
-		const { currentStep, initialRefreshComplete, unlockCheckClicked } = this.state;
+		const { currentStep, unlockCheckClicked } = this.state;
 		const step = 1;
 		const isStepFinished = currentStep > step;
 
@@ -144,7 +139,7 @@ class TransferDomainPrecheck extends React.Component {
 		} else if ( false === unlocked ) {
 			heading = translate( 'Unlock the domain.' );
 		}
-		if ( loading && ! isStepFinished && ! initialRefreshComplete ) {
+		if ( loading && ! isStepFinished ) {
 			heading = translate( 'Checking domain lock status.' );
 		}
 
@@ -187,7 +182,7 @@ class TransferDomainPrecheck extends React.Component {
 				}
 			);
 		}
-		if ( loading && ! isStepFinished && ! initialRefreshComplete ) {
+		if ( loading && ! isStepFinished ) {
 			message = translate( 'Please wait while we check the lock staus of your domain.' );
 		}
 

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -79,8 +79,7 @@ class TransferDomainPrecheck extends React.Component {
 	};
 
 	refreshStatus = () => {
-		this.setState( { unlockCheckClicked: true } );
-		this.props.refreshStatus();
+		this.props.refreshStatus( () => this.setState( { unlockCheckClicked: true } ) );
 	};
 
 	getSection( heading, message, buttonText, step, stepStatus ) {
@@ -132,11 +131,8 @@ class TransferDomainPrecheck extends React.Component {
 		let heading = translate( "Can't get the domain's lock status." );
 		if ( true === unlocked ) {
 			heading = translate( 'Domain is unlocked.' );
-		} else if ( false === unlocked ) {
+		} else if ( false === unlocked || loading ) {
 			heading = translate( 'Unlock the domain.' );
-		}
-		if ( loading && ! isStepFinished && ! unlockCheckClicked ) {
-			heading = translate( 'Checking domain lock status.' );
 		}
 
 		let message = translate(
@@ -160,7 +156,7 @@ class TransferDomainPrecheck extends React.Component {
 
 		if ( true === unlocked ) {
 			message = translate( 'Your domain is unlocked at your current registrar.' );
-		} else if ( false === unlocked ) {
+		} else if ( false === unlocked || loading ) {
 			message = translate(
 				"Your domain is locked to prevent unauthorized transfers. You'll need to unlock " +
 					'it at your current domain provider before we can move it. {{a}}Here are instructions for unlocking it{{/a}}. ' +
@@ -177,10 +173,6 @@ class TransferDomainPrecheck extends React.Component {
 					},
 				}
 			);
-		}
-
-		if ( loading && ! isStepFinished && ! unlockCheckClicked ) {
-			message = translate( 'Please wait while we check the lock staus of your domain.' );
 		}
 
 		const buttonText = unlockCheckClicked

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -41,6 +41,7 @@ class TransferDomainPrecheck extends React.Component {
 
 	state = {
 		currentStep: 1,
+		unlockCheckClicked: false,
 	};
 
 	componentWillMount() {
@@ -77,6 +78,11 @@ class TransferDomainPrecheck extends React.Component {
 		this.setState( { currentStep: this.state.currentStep + 1 } );
 	};
 
+	refreshStatus = () => {
+		this.setState( { unlockCheckClicked: true } );
+		this.props.refreshStatus();
+	};
+
 	getSection( heading, message, buttonText, step, stepStatus ) {
 		const { currentStep } = this.state;
 		const { loading, unlocked } = this.props;
@@ -89,7 +95,7 @@ class TransferDomainPrecheck extends React.Component {
 
 		const sectionIcon = isStepFinished ? <Gridicon icon="checkmark-circle" size={ 36 } /> : step;
 		const onButtonClick =
-			true === unlocked || null === unlocked ? this.showNextStep : this.props.refreshStatus;
+			true === unlocked || null === unlocked ? this.showNextStep : this.refreshStatus;
 
 		return (
 			<Card compact>
@@ -119,7 +125,7 @@ class TransferDomainPrecheck extends React.Component {
 
 	getStatusMessage() {
 		const { loading, translate, unlocked } = this.props;
-		const { currentStep } = this.state;
+		const { currentStep, unlockCheckClicked } = this.state;
 		const step = 1;
 		const isStepFinished = currentStep > step;
 
@@ -129,7 +135,7 @@ class TransferDomainPrecheck extends React.Component {
 		} else if ( false === unlocked ) {
 			heading = translate( 'Unlock the domain.' );
 		}
-		if ( loading && ! isStepFinished ) {
+		if ( loading && ! isStepFinished && ! unlockCheckClicked ) {
 			heading = translate( 'Checking domain lock status.' );
 		}
 
@@ -173,11 +179,13 @@ class TransferDomainPrecheck extends React.Component {
 			);
 		}
 
-		if ( loading && ! isStepFinished ) {
+		if ( loading && ! isStepFinished && ! unlockCheckClicked ) {
 			message = translate( 'Please wait while we check the lock staus of your domain.' );
 		}
 
-		const buttonText = translate( "I've unlocked my domain" );
+		const buttonText = unlockCheckClicked
+			? translate( 'Check again' )
+			: translate( "I've unlocked my domain" );
 
 		let lockStatusClasses = 'transfer-domain-step__lock-status transfer-domain-step__unavailable';
 		if ( true === unlocked ) {

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -134,7 +134,7 @@ class TransferDomainPrecheck extends React.Component {
 
 	getStatusMessage() {
 		const { loading, translate, unlocked } = this.props;
-		const { currentStep, unlockCheckClicked } = this.state;
+		const { currentStep, initialRefreshComplete, unlockCheckClicked } = this.state;
 		const step = 1;
 		const isStepFinished = currentStep > step;
 
@@ -144,7 +144,7 @@ class TransferDomainPrecheck extends React.Component {
 		} else if ( false === unlocked ) {
 			heading = translate( 'Unlock the domain.' );
 		}
-		if ( loading && ! isStepFinished && ! this.state.initialRefreshComplete ) {
+		if ( loading && ! isStepFinished && ! initialRefreshComplete ) {
 			heading = translate( 'Checking domain lock status.' );
 		}
 
@@ -187,7 +187,7 @@ class TransferDomainPrecheck extends React.Component {
 				}
 			);
 		}
-		if ( loading && ! isStepFinished && ! this.state.initialRefreshComplete ) {
+		if ( loading && ! isStepFinished && ! initialRefreshComplete ) {
 			message = translate( 'Please wait while we check the lock staus of your domain.' );
 		}
 


### PR DESCRIPTION
Start a transfer in using a domain that is transfer locked.
On the pre-check screen, the button text in the first step should read "I've unlocked my domain"
Click the button, and the button text should change to "Check again".