### PR TITLE
Add copy to explain pre-filled domain contact information

### DIFF
--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -89,7 +89,6 @@ export class DomainDetailsForm extends PureComponent {
 
 		this.state = {
 			form: null,
-			hasAutoFilledContactDetails: !! this.props.contactDetails,
 			submissionCount: 0,
 			phoneCountryCode: 'US',
 			steps,
@@ -604,12 +603,10 @@ export class DomainDetailsForm extends PureComponent {
 			title = this.props.translate( 'G Suite Account Information' );
 		} else {
 			title = this.props.translate( 'Domain Contact Information' );
-			message =
-				this.state.hasAutoFilledContactDetails &&
-				this.props.translate(
-					'For your convenience, we have pre-filled your WordPress.com contact information. Please ' +
-						"review this to be sure it's the correct information you want to use for this domain."
-				);
+			message = this.props.translate(
+				'For your convenience, we have pre-filled your WordPress.com contact information. Please ' +
+					"review this to be sure it's the correct information you want to use for this domain."
+			);
 		}
 
 		const renderPrivacy =

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -89,6 +89,7 @@ export class DomainDetailsForm extends PureComponent {
 
 		this.state = {
 			form: null,
+			hasAutoFilledContactDetails: !! this.props.contactDetails,
 			submissionCount: 0,
 			phoneCountryCode: 'US',
 			steps,
@@ -603,11 +604,12 @@ export class DomainDetailsForm extends PureComponent {
 			title = this.props.translate( 'G Suite Account Information' );
 		} else {
 			title = this.props.translate( 'Domain Contact Information' );
-			message = this.props.translate(
-				'For your convenience, we have pre-filled your WordPress.com ' +
-					"contact information. Please review this to be sure it's the correct information you want " +
-					'to use for this domain.'
-			);
+			message =
+				this.state.hasAutoFilledContactDetails &&
+				this.props.translate(
+					'For your convenience, we have pre-filled your WordPress.com contact information. Please ' +
+						"review this to be sure it's the correct information you want to use for this domain."
+				);
 		}
 
 		const renderPrivacy =

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -595,6 +595,7 @@ export class DomainDetailsForm extends PureComponent {
 		} );
 
 		let title;
+		let message;
 		// TODO: gather up tld specific stuff
 		if ( this.state.currentStep === 'fr' ) {
 			title = this.props.translate( '.FR Registration' );
@@ -602,6 +603,11 @@ export class DomainDetailsForm extends PureComponent {
 			title = this.props.translate( 'G Suite Account Information' );
 		} else {
 			title = this.props.translate( 'Domain Contact Information' );
+			message = this.props.translate(
+				'For your convenience, we have pre-filled your WordPress.com ' +
+					"contact information. Please review this to be sure it's the correct information you want " +
+					'to use for this domain.'
+			);
 		}
 
 		const renderPrivacy =
@@ -614,6 +620,7 @@ export class DomainDetailsForm extends PureComponent {
 				<QueryTldValidationSchemas tlds={ this.getTldsWithAdditionalForm() } />
 				{ renderPrivacy && this.renderPrivacySection() }
 				<PaymentBox currentPage={ this.state.currentStep } classSet={ classSet } title={ title }>
+					{ message && <p>{ message }</p> }
 					{ this.renderCurrentForm() }
 				</PaymentBox>
 			</div>


### PR DESCRIPTION
This addresses #22262 which aims to help people understand that the pre-filled contact information came from their WordPress.com contact information rather than their public contact information when transferring a domain. 

Add a domain to the cart.
On the checkout page, you should see the new text in the "Domain Contact Information" section:
<img width="733" alt="checkout_ _a8c_test_site_ _wordpress_com" src="https://user-images.githubusercontent.com/1379730/36111771-3dd45810-0ff5-11e8-968f-dd3183f4e6d3.png">

