### PR TITLE
Happychat: unify contact form button labelling

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -270,10 +270,9 @@ class HelpContact extends React.Component {
 
 		switch ( variationSlug ) {
 			case SUPPORT_HAPPYCHAT:
-				const isDev = process.env.NODE_ENV === 'development' || config( 'env_id' ) === 'stage';
 				return {
 					onSubmit: this.startHappychat,
-					buttonLabel: isDev ? 'Happychat' : translate( 'Chat with us' ),
+					buttonLabel: translate( 'Chat with us' ),
 					showSubjectField: false,
 					showHowCanWeHelpField: true,
 					showHowYouFeelField: true,


### PR DESCRIPTION
@mattwondra reported that having a different label for Happychat chat on dev vs on prod causes discrepancies, especially when HEs are talking with customers and see a different label.

In this PR, we unify the button label to say `Chat with us` in all places.

## Testing

Navigate to `/help/contact` while being logged into HUD. You should see `Chat with us` instead of `Happychat`.