### PR TITLE
Store: Disable MailChimp Integration

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -143,9 +143,6 @@ class RequiredPluginsInstallView extends Component {
 			woocommerce: translate( 'WooCommerce' ),
 			'woocommerce-gateway-stripe': translate( 'WooCommerce Stripe Gateway' ),
 			'woocommerce-services': translate( 'WooCommerce Services' ),
-			'mailchimp-for-woocommerce': translate(
-				'MailChimp is the world’s largest marketing automation platform'
-			),
 		};
 	};
 

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/index.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/index.js
@@ -66,20 +66,13 @@ class MailChimp extends React.Component {
 		// Special case for store dashboard where we want to only show MailChimpGetingStarted in case
 		// when user has not finished settup. We show nothing in other cases.
 		if ( dashboardView ) {
-			return (
-				<div className="mailchimp">
-					{ ! isRequestingMailChimpSettings &&
-						( settings && settings.active_tab !== 'sync' ) && (
-							<MailChimpGettingStarted
-								siteId={ siteId }
-								site={ site }
-								isPlaceholder={ isRequestingData }
-								onClick={ this.startWizard }
-								redirectToSettings
-							/>
-						) }
-				</div>
-			);
+			// Disabling due to performance issues with the plugin.
+			return null;
+		}
+
+		// Disable setup view for now
+		if ( ! isRequestingData && gettingStarted ) {
+			return null;
 		}
 
 		return (


### PR DESCRIPTION
@seanosh reported ( p1518448281000106-slack-opers ) that the latest version of the MailChimp integration plugin has been creating some resource issues on various Atomic sites. It appears to be hammering the queue tables, and creating MySql issues.

This PR prevents MailChimp from being installed on *new* Store sites, and disables the promotion widget shown on the Dashboard and Settings | Email tab for sites that have it installed, but not configured.

_Promotion widget that will no longer be shown_
![before](https://user-images.githubusercontent.com/22080/36114469-f7749b4c-0fe4-11e8-85ed-169a65506a61.png)

If the site has already configured the integration, the interface will still be shown under Settings | Email.

__To Test__
- On an existing Store site that does not have MailChimp configured, verify that the setup widget is not shown on the dashboard or the Settings | Email tab
- For a site that already has MailChimp integration configured, verify that it is still shown under Settings | Email
