### PR TITLE
Activity Log: Send Pressable users to the correct place from credentials banner

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -484,7 +484,11 @@ class ActivityLog extends Component {
 				{ 'awaitingCredentials' === rewindState.state && (
 					<Banner
 						icon="history"
-						href={ `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ slug }` }
+						href={
+							rewindState.canAutoconfigure
+								? `/settings/security/${ slug }`
+								: `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ slug }`
+						}
 						title={ translate( 'Add site credentials' ) }
 						description={ translate(
 							'Backups and security scans require access to your site to work properly.'


### PR DESCRIPTION
Currently, Pressable sites are directed to the setup flow from the Activity Log when they lack credentials. This is okay for self-hosted users, but since Pressable credentials are only available via autoconfiguration, we're sending them on a path to an abrupt dead end.

<img width="819" alt="screen shot 2018-02-12 at 2 13 29 pm" src="https://user-images.githubusercontent.com/5528445/36114847-3617e114-0fff-11e8-99b2-a4b016e9bb21.png">

This PR will instead send users to Settings > Security when `rewindState.canAutoconfigure` is truthy. We will think about retrofitting the setup flow with the `CredentialsSetupFlow` component in the future.

**Testing**
1. Remove credentials from a Pressable site, and go to the activity log. Follow the link in the banner above and ensure you land on Settings > Security and are able to fully configure your credentials with no issues.
2. Do the same for a non-Pressable site. Ensure you are directed to the setup flow and are able to successfully complete the flow to save credentials.
