### PR TITLE
Reader: fix unliking post to actually send out request

### DIFF
--- a/client/lib/like-store/actions.js
+++ b/client/lib/like-store/actions.js
@@ -87,8 +87,8 @@ export function unlikePost( siteId, postId ) {
 		.site( siteId )
 		.post( postId )
 		.like()
-		.add( getQuery(), function( error, data ) {
-			receiveLikeResponse( error, siteId, postId, data );
+		.del( getQuery(), function( error, data ) {
+			receiveUnlikeResponse( error, siteId, postId, data );
 		} );
 }
 

--- a/client/lib/like-store/actions.js
+++ b/client/lib/like-store/actions.js
@@ -82,6 +82,14 @@ export function unlikePost( siteId, postId ) {
 		siteId: siteId,
 		postId: postId,
 	} );
+
+	wpcom
+		.site( siteId )
+		.post( postId )
+		.like()
+		.add( getQuery(), function( error, data ) {
+			receiveLikeResponse( error, siteId, postId, data );
+		} );
 }
 
 export function receivePostLikes( error, siteId, postId, data ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/22178 which is a bug introduced in https://github.com/Automattic/wp-calypso/pull/21182.

**to test**
> 1. Starting at URL:  https://wordpress.com/
> 2. Open the Reader
> 3. Like a post
> 4. Unlike the post
> 5. Refresh page

