### PR TITLE
When serializing Redux state, completely skip the parts that don't have persistence defined

### DIFF
--- a/client/extensions/wp-super-cache/state/cache/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/cache/test/reducer.js
@@ -113,7 +113,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state.deleteStatus ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -188,7 +188,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state.testing ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -263,7 +263,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state.preloading ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -366,7 +366,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state.items ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/extensions/wp-super-cache/state/plugins/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/plugins/test/reducer.js
@@ -91,7 +91,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -169,7 +169,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/extensions/wp-super-cache/state/settings/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/test/reducer.js
@@ -97,7 +97,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state.requesting ).to.eql( {} );
+			expect( state.requesting ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -197,7 +197,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state.saveStatus ).to.eql( {} );
+			expect( state.saveStatus ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -270,7 +270,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/extensions/wp-super-cache/state/stats/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/test/reducer.js
@@ -92,7 +92,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -189,7 +189,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state.deleting ).to.eql( {} );
+			expect( state.deleting ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/extensions/wp-super-cache/state/status/test/reducer.js
+++ b/client/extensions/wp-super-cache/state/status/test/reducer.js
@@ -89,7 +89,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state.requesting ).to.eql( {} );
+			expect( state.requesting ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/extensions/zoninator/state/zones/test/reducer.js
+++ b/client/extensions/zoninator/state/zones/test/reducer.js
@@ -87,7 +87,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.deep.equal( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/application/test/reducer.js
+++ b/client/state/application/test/reducer.js
@@ -27,12 +27,12 @@ describe( 'state/application reducer', () => {
 
 		test( 'never persists online state', () => {
 			const state = connectionState( 'ONLINE', { type: SERIALIZE } );
-			expect( state ).to.eql( 'CHECKING' );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'never persists offline state', () => {
 			const state = connectionState( 'OFFLINE', { type: SERIALIZE } );
-			expect( state ).to.eql( 'CHECKING' );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'always uses initialState, even if given offline', () => {

--- a/client/state/automated-transfer/test/reducer.js
+++ b/client/state/automated-transfer/test/reducer.js
@@ -53,7 +53,7 @@ describe( 'state', () => {
 						fetchingStatus( true, {
 							type: SERIALIZE,
 						} )
-					).to.be.null;
+					).to.be.undefined;
 
 					expect(
 						fetchingStatus( true, {

--- a/client/state/billing-transactions/test/reducer.js
+++ b/client/state/billing-transactions/test/reducer.js
@@ -72,7 +72,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.eql( false );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -224,7 +224,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/country-states/test/reducer.js
+++ b/client/state/country-states/test/reducer.js
@@ -120,7 +120,7 @@ describe( 'reducer', () => {
 		test( 'should never persist state', () => {
 			const state = isFetching( true, { type: SERIALIZE } );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should never load persisted state', () => {

--- a/client/state/current-user/gravatar-status/test/reducer.js
+++ b/client/state/current-user/gravatar-status/test/reducer.js
@@ -58,7 +58,7 @@ describe( 'reducer', () => {
 				isUploading( true, {
 					type: SERIALIZE,
 				} )
-			).to.equal( false );
+			).to.be.undefined;
 
 			expect(
 				isUploading( true, {
@@ -90,7 +90,7 @@ describe( 'reducer', () => {
 			const state = {
 				src: imageSrc,
 			};
-			expect( tempImage( state, { type: SERIALIZE } ) ).to.eql( {} );
+			expect( tempImage( state, { type: SERIALIZE } ) ).to.be.undefined;
 			expect( tempImage( state, { type: DESERIALIZE } ) ).to.eql( {} );
 		} );
 	} );

--- a/client/state/jetpack/jumpstart/test/reducer.js
+++ b/client/state/jetpack/jumpstart/test/reducer.js
@@ -110,7 +110,7 @@ describe( 'reducer', () => {
 					type: SERIALIZE,
 				};
 			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
-			expect( stateOut ).to.eql( {} );
+			expect( stateOut ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -288,7 +288,7 @@ describe( 'reducer', () => {
 					type: SERIALIZE,
 				};
 			const stateOut = requestsReducer( deepFreeze( stateIn ), action );
-			expect( stateOut ).to.eql( {} );
+			expect( stateOut ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/jetpack/modules/test/reducer.js
+++ b/client/state/jetpack/modules/test/reducer.js
@@ -65,7 +65,7 @@ describe( 'reducer', () => {
 					type: SERIALIZE,
 				};
 			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
-			expect( stateOut ).to.eql( {} );
+			expect( stateOut ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -286,7 +286,7 @@ describe( 'reducer', () => {
 						type: SERIALIZE,
 					};
 				const stateOut = requestsReducer( deepFreeze( stateIn ), action );
-				expect( stateOut ).to.eql( {} );
+				expect( stateOut ).to.be.undefined;
 			} );
 
 			test( 'should not load persisted state', () => {

--- a/client/state/jetpack/settings/test/reducer.js
+++ b/client/state/jetpack/settings/test/reducer.js
@@ -253,7 +253,7 @@ describe( 'reducer', () => {
 					type: SERIALIZE,
 				};
 			const stateOut = itemsReducer( deepFreeze( stateIn ), action );
-			expect( stateOut ).to.eql( {} );
+			expect( stateOut ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -378,7 +378,7 @@ describe( 'reducer', () => {
 					type: SERIALIZE,
 				};
 			const stateOut = requestsReducer( deepFreeze( stateIn ), action );
-			expect( stateOut ).to.eql( {} );
+			expect( stateOut ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -461,7 +461,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/login/magic-login/test/reducer.js
+++ b/client/state/login/magic-login/test/reducer.js
@@ -68,12 +68,12 @@ describe( 'reducer', () => {
 			expect( state ).to.be.false;
 		} );
 
-		test( 'should be false on SERIALIZE', () => {
+		test( 'should not persist on SERIALIZE', () => {
 			const state = isFetchingAuth( undefined, {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.false;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should be true on fetch', () => {
@@ -112,12 +112,12 @@ describe( 'reducer', () => {
 			expect( state ).to.be.false;
 		} );
 
-		test( 'should be false on SERIALIZE', () => {
+		test( 'should not persist on SERIALIZE', () => {
 			const state = isFetchingEmail( undefined, {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.false;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should be true on fetch', () => {
@@ -156,12 +156,12 @@ describe( 'reducer', () => {
 			expect( state ).to.be.false;
 		} );
 
-		test( 'should be false on SERIALIZE', () => {
+		test( 'should not persist on SERIALIZE', () => {
 			const state = requestAuthSuccess( undefined, {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.false;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should be false on fetch', () => {
@@ -201,12 +201,12 @@ describe( 'reducer', () => {
 			expect( state ).to.be.null;
 		} );
 
-		test( 'should be null on SERIALIZE', () => {
+		test( 'should not persist on SERIALIZE', () => {
 			const state = requestAuthError( undefined, {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.null;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should be null on fetch', () => {
@@ -246,12 +246,12 @@ describe( 'reducer', () => {
 			expect( state ).to.be.null;
 		} );
 
-		test( 'should be null on SERIALIZE', () => {
+		test( 'should not persist on SERIALIZE', () => {
 			const state = requestEmailError( undefined, {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.null;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should be null on fetch', () => {
@@ -298,12 +298,12 @@ describe( 'reducer', () => {
 			expect( state ).to.be.false;
 		} );
 
-		test( 'should be false on SERIALIZE', () => {
+		test( 'should not persist on SERIALIZE', () => {
 			const state = requestEmailSuccess( undefined, {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.false;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should be false on fetch action', () => {
@@ -342,12 +342,12 @@ describe( 'reducer', () => {
 			expect( state ).to.be.null;
 		} );
 
-		test( 'should be null on SERIALIZE', () => {
+		test( 'should not persist on SERIALIZE', () => {
 			const state = currentView( undefined, {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.null;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should be check email page on show check email', () => {

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -119,7 +119,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.false;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -209,7 +209,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.false;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -285,7 +285,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.null;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -342,7 +342,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.null;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -400,7 +400,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.null;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -448,7 +448,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.null;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -550,7 +550,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.be.null;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/media/test/reducer.js
+++ b/client/state/media/test/reducer.js
@@ -207,7 +207,7 @@ describe( 'reducer', () => {
 		test( 'should never persist state', () => {
 			const state = queryRequests( deepFreeze( state1 ), { type: SERIALIZE } );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should never load persisted state', () => {
@@ -280,7 +280,7 @@ describe( 'reducer', () => {
 		test( 'should never persist state', () => {
 			const state = mediaItemRequests( deepFreeze( state1 ), { type: SERIALIZE } );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should never load persisted state', () => {

--- a/client/state/oauth2-clients/test/reducer.js
+++ b/client/state/oauth2-clients/test/reducer.js
@@ -113,11 +113,11 @@ describe( 'reducer', () => {
 	} );
 
 	test( 'should not persist state', () => {
-		const newState = reducer( undefined, {
+		const newState = reducer( initialClientsData, {
 			type: SERIALIZE,
 		} );
 
-		expect( newState ).to.deep.equal( initialClientsData );
+		expect( newState ).to.be.undefined;
 	} );
 
 	test( 'should not load persisted state', () => {

--- a/client/state/page-templates/test/reducer.js
+++ b/client/state/page-templates/test/reducer.js
@@ -96,7 +96,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/post-formats/test/reducer.js
+++ b/client/state/post-formats/test/reducer.js
@@ -106,7 +106,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -150,7 +150,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/preferences/test/reducer.js
+++ b/client/state/preferences/test/reducer.js
@@ -161,7 +161,7 @@ describe( 'reducer', () => {
 			const state = fetching( true, {
 				type: SERIALIZE,
 			} );
-			expect( state ).to.eql( false );
+			expect( state ).to.be.undefined;
 		} );
 		test( 'should never load persisted state', () => {
 			const state = fetching( true, {

--- a/client/state/products-list/test/reducer.js
+++ b/client/state/products-list/test/reducer.js
@@ -140,7 +140,7 @@ describe( 'reducer', () => {
 		test( 'should never persist state', () => {
 			const state = isFetching( true, { type: SERIALIZE } );
 
-			expect( state ).to.eql( false );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should never load persisted state', () => {

--- a/client/state/reader/streams/test/reducer.js
+++ b/client/state/reader/streams/test/reducer.js
@@ -93,8 +93,8 @@ describe( 'streams combined reducer', () => {
 	} );
 
 	it( 'should never serialize the selected data', () => {
-		expect( streamsReducer( validState, saveAction ).selected ).toEqual( {} );
-		expect( streamsReducer( invalidState, saveAction ).selected ).toEqual( {} );
+		expect( streamsReducer( validState, saveAction ).selected ).toBeUndefined();
+		expect( streamsReducer( invalidState, saveAction ).selected ).toBeUndefined();
 	} );
 
 	it( 'should never deserialize the selected data', () => {

--- a/client/state/sharing/keyring/test/reducer.js
+++ b/client/state/sharing/keyring/test/reducer.js
@@ -63,7 +63,7 @@ describe( 'reducers', () => {
 				const persistedState = isFetching( state, {
 					type: SERIALIZE,
 				} );
-				expect( persistedState ).to.eql( false );
+				expect( persistedState ).to.be.undefined;
 			} );
 		} );
 	} );

--- a/client/state/sharing/publicize/test/reducer.js
+++ b/client/state/sharing/publicize/test/reducer.js
@@ -78,7 +78,7 @@ describe( 'reducer', () => {
 				const persistedState = fetchingConnection( state, {
 					type: SERIALIZE,
 				} );
-				expect( persistedState ).to.eql( {} );
+				expect( persistedState ).to.be.undefined;
 			} );
 		} );
 	} );
@@ -131,7 +131,7 @@ describe( 'reducer', () => {
 				const persistedState = fetchingConnections( state, {
 					type: SERIALIZE,
 				} );
-				expect( persistedState ).to.eql( {} );
+				expect( persistedState ).to.be.undefined;
 			} );
 		} );
 	} );

--- a/client/state/sharing/services/test/reducer.js
+++ b/client/state/sharing/services/test/reducer.js
@@ -135,7 +135,7 @@ describe( 'reducer', () => {
 		test( 'should never persist state', () => {
 			const state = isFetching( true, { type: SERIALIZE } );
 
-			expect( state ).to.eql( false );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should never load persisted state', () => {

--- a/client/state/shortcodes/test/reducer.js
+++ b/client/state/shortcodes/test/reducer.js
@@ -195,7 +195,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/site-roles/test/reducer.js
+++ b/client/state/site-roles/test/reducer.js
@@ -88,7 +88,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/site-settings/test/reducer.js
+++ b/client/state/site-settings/test/reducer.js
@@ -99,7 +99,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -184,7 +184,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/sites/connection/test/reducer.js
+++ b/client/state/sites/connection/test/reducer.js
@@ -87,7 +87,7 @@ describe( 'reducer', () => {
 			} );
 			const state = items( original, { type: SERIALIZE } );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -171,7 +171,7 @@ describe( 'reducer', () => {
 			} );
 			const state = requesting( original, { type: SERIALIZE } );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/sites/guided-transfer/test/reducer.js
+++ b/client/state/sites/guided-transfer/test/reducer.js
@@ -139,7 +139,7 @@ describe( 'reducer', () => {
 				{ type: SERIALIZE }
 			);
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should never load persisted state', () => {

--- a/client/state/sites/monitor/test/reducer.js
+++ b/client/state/sites/monitor/test/reducer.js
@@ -100,7 +100,7 @@ describe( 'reducer', () => {
 			} );
 			const state = items( original, { type: SERIALIZE } );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/sites/sharing-buttons/test/reducer.js
+++ b/client/state/sites/sharing-buttons/test/reducer.js
@@ -98,7 +98,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {
@@ -182,7 +182,7 @@ describe( 'reducer', () => {
 				type: SERIALIZE,
 			} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/stats/lists/test/reducer.js
+++ b/client/state/stats/lists/test/reducer.js
@@ -172,7 +172,7 @@ describe( 'reducer', () => {
 
 			const state = requests( original, { type: SERIALIZE } );
 
-			expect( state ).to.eql( {} );
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -614,6 +614,19 @@ describe( 'utils', () => {
 			expect( state ).to.eql( { age: 21, height: 172 } );
 		} );
 
+		test( 'undefined or missing state is not serialized and does not cause errors', () => {
+			const empty = reducers( undefined, write );
+			expect( empty ).to.be.undefined;
+
+			const nested = combineReducers( {
+				person: reducers,
+				date,
+			} );
+
+			const missingPerson = nested( { date: new Date( 100 ) }, write );
+			expect( missingPerson ).to.eql( { date: 100 } );
+		} );
+
 		test( 'nested reducers work on load', () => {
 			reducers = combineReducers( {
 				age,

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -144,8 +144,8 @@ describe( 'utils', () => {
 				expect( reducer( currentState, unknownAction ) ).to.be.deep.equal( currentState );
 			} );
 
-			test( 'should return default null state when serialize action type passed', () => {
-				expect( reducer( currentState, actionSerialize ) ).to.be.null;
+			test( 'should return undefined when serialize action type passed', () => {
+				expect( reducer( currentState, actionSerialize ) ).to.be.undefined;
 			} );
 
 			test( 'should return default null state when deserialize action type passed', () => {
@@ -171,8 +171,8 @@ describe( 'utils', () => {
 				} );
 			} );
 
-			test( 'should return default {} state when SERIALIZE action type passed', () => {
-				expect( reducer( currentState, actionSerialize ) ).to.be.equal( initialState );
+			test( 'should return undefined state when SERIALIZE action type passed', () => {
+				expect( reducer( currentState, actionSerialize ) ).to.be.undefined;
 			} );
 
 			test( 'should return default {} state when DESERIALIZE action type passed', () => {
@@ -201,7 +201,7 @@ describe( 'utils', () => {
 				reducer = createReducer( initialState, {}, testSchema );
 			} );
 
-			test( 'should return initial state when serialize action type passed', () => {
+			test( 'should return current state when serialize action type passed', () => {
 				expect( reducer( currentState, actionSerialize ) ).to.be.deep.equal( currentState );
 			} );
 
@@ -499,9 +499,9 @@ describe( 'utils', () => {
 		};
 		date.hasCustomPersistence = true;
 
-		test( 'should return initial state without a schema on SERIALIZE', () => {
+		test( 'should return undefined without a schema on SERIALIZE', () => {
 			const validated = withSchemaValidation( null, age );
-			expect( validated( 5, write ) ).to.equal( 0 );
+			expect( validated( 5, write ) ).to.be.undefined;
 		} );
 
 		test( 'should return initial state without a schema on DESERIALIZE', () => {
@@ -585,13 +585,18 @@ describe( 'utils', () => {
 		} );
 
 		test( 'should return initial state on init', () => {
-			const state = reducers( undefined, write );
+			const state = reducers( undefined, { type: '@@calypso/INIT' } );
+			expect( state ).to.eql( { age: 0, height: 160 } );
+		} );
+
+		test( 'should return initial state on DESERIALIZE', () => {
+			const state = reducers( undefined, load );
 			expect( state ).to.eql( { age: 0, height: 160 } );
 		} );
 
 		test( 'should not persist height, because it is missing a schema', () => {
 			const state = reducers( appState, write );
-			expect( state ).to.eql( { age: 20, height: 160 } );
+			expect( state ).to.eql( { age: 20 } );
 		} );
 
 		test( 'should not load height, because it is missing a schema', () => {
@@ -643,10 +648,33 @@ describe( 'utils', () => {
 				count,
 			} );
 			const valid = nested( { person: { age: 22, date: new Date( 224 ) } }, write );
-			expect( valid ).to.eql( { person: { age: 22, height: 160, date: 224 }, count: 1 } );
+			expect( valid ).to.eql( { person: { age: 22, date: 224 } } );
 
 			const invalid = nested( { person: { age: -5, height: 100, date: new Date( -500 ) } }, write );
-			expect( invalid ).to.eql( { person: { age: -5, height: 160, date: -500 }, count: 1 } );
+			expect( invalid ).to.eql( { person: { age: -5, date: -500 } } );
+		} );
+
+		test( 'nested reducers leave out a state slice where none of the children is persisted', () => {
+			const ephemeral = combineReducers( {
+				height,
+				count,
+			} );
+
+			const nestedEphemeral = combineReducers( {
+				ephemeral,
+				age,
+			} );
+
+			const stored = nestedEphemeral(
+				{
+					// the `ephemeral` object should not be stored at all
+					ephemeral: { height: 100, count: 5 },
+					// `age` should be persisted, as it has a schema defined
+					age: 40,
+				},
+				write
+			);
+			expect( stored ).to.eql( { age: 40 } );
 		} );
 
 		test( 'deeply nested reducers work on load', () => {
@@ -695,13 +723,13 @@ describe( 'utils', () => {
 				{ bob: { person: { age: 22, date: new Date( 234 ) } }, count: 122 },
 				write
 			);
-			expect( valid ).to.eql( { bob: { person: { age: 22, height: 160, date: 234 } }, count: 1 } );
+			expect( valid ).to.eql( { bob: { person: { age: 22, date: 234 } } } );
 
 			const invalid = veryNested(
 				{ bob: { person: { age: -5, height: 22, date: new Date( -5 ) } }, count: 123 },
 				write
 			);
-			expect( invalid ).to.eql( { bob: { person: { age: -5, height: 160, date: -5 } }, count: 1 } );
+			expect( invalid ).to.eql( { bob: { person: { age: -5, date: -5 } } } );
 		} );
 
 		test( 'deeply nested reducers work with reducer with a custom handler', () => {
@@ -717,13 +745,13 @@ describe( 'utils', () => {
 				count,
 			} );
 			const valid = veryNested( { bob: { person: { date: new Date( 234 ) } }, count: 122 }, write );
-			expect( valid ).to.eql( { bob: { person: { height: 160, date: 234 } }, count: 1 } );
+			expect( valid ).to.eql( { bob: { person: { date: 234 } } } );
 
 			const invalid = veryNested(
 				{ bob: { person: { height: 22, date: new Date( -5 ) } }, count: 123 },
 				write
 			);
-			expect( invalid ).to.eql( { bob: { person: { height: 160, date: -5 } }, count: 1 } );
+			expect( invalid ).to.eql( { bob: { person: { date: -5 } } } );
 		} );
 
 		test( 'uses the provided validation from withSchemaValidation', () => {
@@ -733,7 +761,7 @@ describe( 'utils', () => {
 			} );
 
 			const valid = reducers( { height: 22, count: 44 }, write );
-			expect( valid ).to.eql( { height: 22, count: 1 } );
+			expect( valid ).to.eql( { height: 22 } );
 
 			const invalid = reducers( { height: -1, count: 44 }, load );
 			expect( invalid ).to.eql( { height: 160, count: 1 } );
@@ -746,7 +774,7 @@ describe( 'utils', () => {
 			} );
 
 			const valid = reducers( { height: 22, count: 44 }, write );
-			expect( valid ).to.eql( { height: 22, count: 1 } );
+			expect( valid ).to.eql( { height: 22 } );
 
 			const invalid = reducers( { height: -1, count: 44 }, load );
 			expect( invalid ).to.eql( { height: 160, count: 1 } );
@@ -782,8 +810,8 @@ describe( 'utils', () => {
 			expect( wrapped( 10, { type: DESERIALIZE } ) ).to.equal( 0 );
 		} );
 
-		test( 'should SERIALIZE to `null`', () => {
-			expect( wrapped( 10, { type: SERIALIZE } ) ).to.be.null;
+		test( 'should SERIALIZE to `undefined`', () => {
+			expect( wrapped( 10, { type: SERIALIZE } ) ).to.be.undefined;
 		} );
 	} );
 

--- a/client/state/ui/oauth2-clients/test/reducer.js
+++ b/client/state/ui/oauth2-clients/test/reducer.js
@@ -40,7 +40,7 @@ describe( 'reducer', () => {
 			const state = currentClientId( true, {
 				type: SERIALIZE,
 			} );
-			expect( state ).to.be.null;
+			expect( state ).to.be.undefined;
 		} );
 
 		test( 'should not load persisted state', () => {

--- a/client/state/users/suggestions/test/reducer.js
+++ b/client/state/users/suggestions/test/reducer.js
@@ -96,7 +96,7 @@ describe( 'reducer', () => {
 					123: true,
 				} );
 				const state = requesting( original, { type: SERIALIZE } );
-				expect( state ).to.eql( {} );
+				expect( state ).to.be.undefined;
 			} );
 
 			test( 'never loads persisted state', () => {

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -442,7 +442,12 @@ export function combineReducers( reducers ) {
 		//   in the result object at all.
 		// - if none of the subreducers produced anything to persist, the combined result will be
 		//   `undefined` rather than an empty object.
+		// - if the state to serialize is `undefined` (happens when some key in state is missing)
+		//   the serialized value is `undefined` and there's no need to reduce anything.
 		if ( action.type === SERIALIZE ) {
+			if ( state === undefined ) {
+				return undefined;
+			}
 			return reduce(
 				validatedReducers,
 				( result, reducer, key ) => {


### PR DESCRIPTION


This patch changes behavior of Redux state serialization when dealing with a reducer that
has no persistence defined. Until now, we were storing initial state (in case of `createReducer`
without a schema or `withSchemaValidation` with `null` schema) or `null` (in case of the
`withoutPersistence` wrapper).

The new behavior is to return `undefined` and change `combineReducer` in such a way that the
properties with `undefined` serialized values are not included in the output at all.

The net outcome is that the object stored in Indexed DB won't have any junk properties coming from unpersisted reducers.

There are several benefits:
- the behavior is unified between `createReducer`, `withSchemaValidation` and `withoutPersistence`
- we store significantly less data into Indexed DB, as the irrelevant parts of state are omitted
- storing initial state is not correct for reducers that store nontrivial objects like ImmutableJS
  structures, `Date` objects or `Query` objects like `ActivityQuery`. These would leak into the
  serialized state and could prevent the state from being stored if they were of type that is not
  possible to store into Indexed DB
- if a Calypso upgrade starts persisting a part of state that wasn't persisted before, there
  are no migration problems while reading the persisted old initial state and converting it into
  a valid state object

**How to test:**
Open devtools and look at the `redux-state-*` object stored in the `calypso_store` Indexed DB database. Before this patch, it contains a lot of properties like `ui.masterbarVisibility` that will be ignored on load, because their respective reducers are not persisted.

After the patch, the number of persisted properties is significantly smaller.