### PR TITLE
Rewind: Fix mistake in reporting failed credentials attempts

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -126,13 +126,13 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 			siteId: action.siteId,
 			error: error.error,
 			statusCode: error.statusCode,
-			host: action.host,
-			kpri: action.krpi ? 'provided but [omitted here]' : 'not provided',
-			pass: action.pass ? 'provided but [omitted here]' : 'not provided',
-			path: action.path,
-			port: action.port,
-			protocol: action.protocol,
-			user: action.user,
+			host: action.credentials.host,
+			kpri: action.credentials.krpi ? 'provided but [omitted here]' : 'not provided',
+			pass: action.credentials.pass ? 'provided but [omitted here]' : 'not provided',
+			path: action.credentials.path,
+			port: action.credentials.port,
+			protocol: action.credentials.protocol,
+			user: action.credentials.user,
 		} );
 
 		dispatch(


### PR DESCRIPTION
When we started tracking failed credentials updates we were trying to
send undefined properties because we weren't accessing the inner
`credentials` object on the originating action.

In this patch we fix the glitch by fixing those property accesses.

This was detected because all the failed credentials events were being
rejected by Tracks.