### PR TITLE
Site Rename: Fetch and use a nonce for the API call

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2515,21 +2515,34 @@ Undocumented.prototype.getFeaturedPlugins = function( fn ) {
 };
 
 /**
+ * Fetch a nonce to use in the `updateSiteName` call
+ * @param {int}   siteId  The ID of the site for which to get a nonce.
+ * @returns {Promise}     A promise
+ */
+Undocumented.prototype.getRequestSiteRenameNonce = function( siteId ) {
+	return this.wpcom.req.get( {
+		path: `/sites/${ siteId }/site-rename/nonce`,
+		apiNamespace: 'wpcom/v2',
+	} );
+};
+
+/**
  * Request a new .wordpress.com subdomain change with the option to discard the current.
  *
  * @param {int} [siteId] The siteId for which to rename
  * @param {object} [blogname]	The desired new subdomain
  * @param {bool} [discard]			Should the old blog name be discarded?
+ * @param {string} [nonce]		A nonce provided by the API
  * @returns {Promise}  A promise
  */
-Undocumented.prototype.updateSiteName = function( siteId, blogname, discard ) {
+Undocumented.prototype.updateSiteName = function( siteId, blogname, discard, nonce ) {
 	return this.wpcom.req.post(
 		{
 			path: `/sites/${ siteId }/site-rename`,
 			apiNamespace: 'wpcom/v2',
 		},
 		{},
-		{ blogname, discard }
+		{ blogname, discard, nonce }
 	);
 };
 


### PR DESCRIPTION
NOTE: This is targeting the `add/sites-rename-2` branch being worked on in #21861.

The endpoint patch has been updated to use a [nonce](https://codex.wordpress.org/WordPress_Nonces) in order to mitigate CSRF attacks.

This fetches a fresh nonce immediately prior to issuing the request to change the site.