### PR TITLE
Google Apps: Introduce safeguards when domain is not registered

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -5,7 +5,7 @@
  */
 
 import inherits from 'inherits';
-import { includes, find, replace, some } from 'lodash';
+import { includes, find, get, replace, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -164,7 +164,7 @@ function isInitialized( state, siteId ) {
 }
 
 function hasGoogleApps( domain ) {
-	return domain.googleAppsSubscription.status !== 'no_subscription';
+	return 'no_subscription' !== get( domain, 'googleAppsSubscription.status', '' );
 }
 
 function isMappedDomain( domain ) {
@@ -185,11 +185,7 @@ function hasGoogleAppsSupportedDomain( domains ) {
 }
 
 function hasPendingGoogleAppsUsers( domain ) {
-	return (
-		domain.googleAppsSubscription &&
-		domain.googleAppsSubscription.pendingUsers &&
-		domain.googleAppsSubscription.pendingUsers.length !== 0
-	);
+	return get( domain, 'googleAppsSubscription.pendingUsers.length', 0 ) !== 0;
 }
 
 function getSelectedDomain( { domains, selectedDomainName, isTransfer } ) {


### PR DESCRIPTION
Related issue: #8572
If a domain registration fails, the G Suite provisioning is still performed and Google actually accepts it (even though the domain is not registered). This creates a situation that breaks some of the assumptions that we've made in the code, so I've added safeguards to prevent fatal errors that completely break Calypso.

### Testing
Steps to reproduce the edge case behaviour:
* Ensure that the domain registration will fail (the actual API call to Tucows). Either sandbox and just return a `WP_Error` in `register` or use one of the existing bugs ;)
* Easiest to do with an existing site.
* Add a new domain to cart and add a G Suite account as well to it.
* Checkout.
* Verify that the domain registration failed, but the G Suite purchase succeeded.

Of course, at this point, the G Suite purchase is "broken" - the domain its tied to is not returned by the `domains` endpoint, which is why the changes in this PR are needed. The assumption was that if there's a domain subscription (even with an error), the domain must be present. I've fixed that with a small change of logic and using lodash' `get`.

Before this PR, it was not possible to visit Domains -> Email, it would lead to a blank screen and errors in console.
After applying this patch, it should properly show the error (no G Suite errors) and the button to add new G Suite users should be hidden as well (since it doesn't make sense at this point):
<img width="944" alt="screen shot 2018-02-12 at 09 29 25" src="https://user-images.githubusercontent.com/3392497/36123540-4ee30c0c-104d-11e8-8c48-4138bd73a024.png">
The above screenshot contains two domains: `foobar.com` has been set up properly, while `example.com` is actually missing (but the G Suite subscription is active).

From my testing, if the domain is registered afterwards, the G Suite is automatically provisioned (because we retry a few times), though if the user/HE waited too long, it might not. But at least they'll be able to see the notice and know that something is wrong and that they should contact support.