### PR TITLE
Rewind: Try to fix missing credentials failure events

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -123,9 +123,9 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 
 	const spreadHappiness = message => {
 		const tracksEvent = recordTracksEvent( 'calypso_rewind_creds_update_failure', {
-			siteId: action.siteId,
+			site_id: action.siteId,
 			error: error.error,
-			statusCode: error.statusCode,
+			status_code: error.statusCode,
 			host: action.credentials.host,
 			kpri: action.credentials.krpi ? 'provided but [omitted here]' : 'not provided',
 			pass: action.credentials.pass ? 'provided but [omitted here]' : 'not provided',


### PR DESCRIPTION
Events are still being rejected by Tracks and I'm not sure why.

This patch renames some properties being sent to see if the events are
being rejected on account of the camelCase names.