### PR TITLE
Reader: handle 404 responses from /read/site/:site

### DIFF
--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -41,7 +41,7 @@ class FeedStream extends React.Component {
 		const emptyContent = <EmptyContent />;
 		const title = getSiteName( { feed, site } ) || this.props.translate( 'Loading Feed' );
 
-		if ( ( feed && feed.is_error ) || ( site && site.is_error && site.error.code === 410 ) ) {
+		if ( ( feed && feed.is_error ) || ( site && site.is_error ) ) {
 			return <FeedError sidebarTitle={ title } />;
 		}
 

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -46,7 +46,7 @@ function handleDeserialize( state ) {
 
 function handleRequestFailure( state, action ) {
 	// 410 means site moved - site used to be on wpcom but is no longer
-	const handledStatusCodes = [ 403, 410 ];
+	const handledStatusCodes = [ 403, 404, 410 ];
 
 	if ( action.error && ! includes( handledStatusCodes, action.error.statusCode ) ) {
 		return state;


### PR DESCRIPTION
In r169976-wpcom, I started returning a 404 when a blog is not "presentable" - i.e. it has been flagged on wpcom for dubious content.

This PR starts handling these 404s in Calypso, showing the generic error below:

<img width="502" alt="screen shot 2018-02-13 at 12 12 27" src="https://user-images.githubusercontent.com/17325/36128574-2e5078e8-10b7-11e8-83f9-03cb05af7ed3.png">

### To test

Try this feed + blog, which is orange-flagged:

http://calypso.localhost:3000/read/blogs/21000959

http://calypso.localhost:3000/read/feeds/51629

You should see the error page above.

Try some other unflagged blog and feed streams and make sure they're unaffected.
