### PR TITLE
Help: Support urls should link to localized pages where available

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -5,7 +5,7 @@
  */
 
 import { find } from 'lodash';
-import { localize } from 'i18n-calypso';
+import { getLocaleSlug, localize } from 'i18n-calypso';
 import React from 'react';
 import debugModule from 'debug';
 import { connect } from 'react-redux';
@@ -34,6 +34,14 @@ import QueryUserPurchases from 'components/data/query-user-purchases';
  */
 const debug = debugModule( 'calypso:help-search' );
 
+const getSupportLocale = () => {
+	const localeSlug = getLocaleSlug();
+	if ( [ 'es', 'pt-br' ].indexOf( getLocaleSlug() ) > -1 ) {
+		return localeSlug;
+	}
+	return 'en';
+};
+
 class Help extends React.PureComponent {
 	static displayName = 'Help';
 
@@ -54,7 +62,7 @@ class Help extends React.PureComponent {
 				),
 			},
 			{
-				link: 'https://en.support.wordpress.com/start/',
+				link: `https://${ getSupportLocale() }.support.wordpress.com/start`,
 				title: this.props.translate( 'Get Started' ),
 				description: this.props.translate(
 					'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.'
@@ -99,7 +107,7 @@ class Help extends React.PureComponent {
 			<div className="help__support-links">
 				<CompactCard
 					className="help__support-link"
-					href="https://support.wordpress.com/"
+					href={ `https://${ getSupportLocale() }.support.wordpress.com` }
 					target="__blank"
 				>
 					<div className="help__support-link-section">

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -28,6 +28,7 @@ import HelpUnverifiedWarning from './help-unverified-warning';
 import { getUserPurchases, isFetchingUserPurchases } from 'state/purchases/selectors';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
 import QueryUserPurchases from 'components/data/query-user-purchases';
+import config from 'config';
 
 /**
  * Module variables
@@ -36,7 +37,7 @@ const debug = debugModule( 'calypso:help-search' );
 
 const getSupportLocale = () => {
 	const localeSlug = getLocaleSlug();
-	if ( [ 'es', 'pt-br' ].indexOf( getLocaleSlug() ) > -1 ) {
+	if ( config( 'support_locales' ).indexOf( getLocaleSlug() ) > -1 ) {
 		return localeSlug;
 	}
 	return 'en';

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -63,7 +63,7 @@ class Help extends React.PureComponent {
 				),
 			},
 			{
-				link: `https://${ getSupportLocale() }.support.wordpress.com/start`,
+				link: `https://${ getSupportLocale() }.support.wordpress.com/start/`,
 				title: this.props.translate( 'Get Started' ),
 				description: this.props.translate(
 					'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.'

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -37,7 +37,7 @@ const debug = debugModule( 'calypso:help-search' );
 
 const getSupportLocale = () => {
 	const localeSlug = getLocaleSlug();
-	if ( config( 'support_locales' ).indexOf( getLocaleSlug() ) > -1 ) {
+	if ( config( 'support_locales' ).indexOf( localeSlug ) > -1 ) {
 		return localeSlug;
 	}
 	return 'en';


### PR DESCRIPTION
This PR addresses #11520.

This is not an ideal solution, but it's a quick win for `es` and `pt-br`. The support links are as patchy as the support translations, and I can't seem to find a definitive list.

I'll investigate whether we can use server-side redirects, but for now a manual check might have to suffice.

## Testing
1. Switch your language to Spanish
2. Go to `/help`
3. Return to step 1 and set the language to Brazilian Portuguese. Go to `/help`
4. Return to step 1 and set the language to English. Go to `/help`
5. Return to step 1 and set the language to any other. Go to `/help`

**Expectation**
_Step 2:_ The links **Empieza ya** and **Todos los artículos de ayuda** should link to the respective Spanish-language versions. 
_Step 3:_ The links should go to the `br` versions
_Step 4 and 5:_ The default is English.