### PR TITLE
Jetpack Onboarding: Add tracking to wizard nav link clicks

### DIFF
--- a/client/components/wizard/README.md
+++ b/client/components/wizard/README.md
@@ -82,6 +82,24 @@ Link text for navigating to the next step in the wizard.
 
 Whether to hide the navigation links.
 
+### `onBackClick`
+
+<table>
+	<tr><td>Type</td><td>Function</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+A callback to be called when the "Back" navigation link is clicked.
+
+### `onForwardClick`
+
+<table>
+	<tr><td>Type</td><td>Function</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+</table>
+
+A callback to be called when the "Forward" navigation link is clicked.
+
 ### `steps`
 
 <table>

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -22,6 +22,8 @@ class Wizard extends Component {
 		components: PropTypes.objectOf( PropTypes.element ).isRequired,
 		forwardText: PropTypes.string,
 		hideNavigation: PropTypes.bool,
+		onBackClick: PropTypes.func,
+		onForwardClick: PropTypes.func,
 		steps: PropTypes.arrayOf( PropTypes.string ).isRequired,
 		stepName: PropTypes.string.isRequired,
 	};
@@ -75,6 +77,8 @@ class Wizard extends Component {
 			components,
 			forwardText,
 			hideNavigation,
+			onBackClick,
+			onForwardClick,
 			steps,
 			stepName,
 			...otherProps
@@ -103,11 +107,21 @@ class Wizard extends Component {
 					totalSteps > 1 && (
 						<div className="wizard__navigation-links">
 							{ stepIndex > 0 && (
-								<NavigationLink direction="back" href={ backUrl } text={ backText } />
+								<NavigationLink
+									direction="back"
+									href={ backUrl }
+									text={ backText }
+									onClick={ onBackClick }
+								/>
 							) }
 
 							{ stepIndex < totalSteps - 1 && (
-								<NavigationLink direction="forward" href={ forwardUrl } text={ forwardText } />
+								<NavigationLink
+									direction="forward"
+									href={ forwardUrl }
+									text={ forwardText }
+									onClick={ onForwardClick }
+								/>
 							) }
 						</div>
 					) }

--- a/client/components/wizard/navigation-link.jsx
+++ b/client/components/wizard/navigation-link.jsx
@@ -6,8 +6,9 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,8 +19,13 @@ class NavigationLink extends Component {
 	static propTypes = {
 		direction: PropTypes.oneOf( [ 'back', 'forward' ] ).isRequired,
 		href: PropTypes.string,
+		onClick: PropTypes.func,
 		text: PropTypes.string,
 		translate: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		onClick: noop,
 	};
 
 	getText = () => {
@@ -29,10 +35,16 @@ class NavigationLink extends Component {
 	};
 
 	render() {
-		const { direction, href } = this.props;
+		const { direction, href, onClick } = this.props;
 
 		return (
-			<Button compact borderless className="wizard__navigation-link" href={ href }>
+			<Button
+				compact
+				borderless
+				className="wizard__navigation-link"
+				href={ href }
+				onClick={ onClick }
+			>
 				{ direction === 'back' && <Gridicon icon="arrow-left" size={ 18 } /> }
 				{ this.getText() }
 				{ direction === 'forward' && <Gridicon icon="arrow-right" size={ 18 } /> }

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -59,8 +59,9 @@ class JetpackOnboardingMain extends React.PureComponent {
 	getNavigationLinkClickHandler = direction => () => {
 		const { recordJpoEvent, stepName } = this.props;
 
-		recordJpoEvent( `calypso_jpo_navigation_${ direction }_clicked`, {
+		recordJpoEvent( 'calypso_jpo_navigation_link_clicked', {
 			current_step: stepName,
+			direction,
 		} );
 	};
 

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -56,6 +56,14 @@ class JetpackOnboardingMain extends React.PureComponent {
 		}
 	}
 
+	getNavigationLinkClickHandler = direction => () => {
+		const { recordJpoEvent, stepName } = this.props;
+
+		recordJpoEvent( `calypso_jpo_navigation_${ direction }_clicked`, {
+			current_step: stepName,
+		} );
+	};
+
 	render() {
 		const {
 			isRequestingSettings,
@@ -76,6 +84,8 @@ class JetpackOnboardingMain extends React.PureComponent {
 						components={ COMPONENTS }
 						hideNavigation={ stepName === STEPS.SUMMARY }
 						isRequestingSettings={ isRequestingSettings }
+						onBackClick={ this.getNavigationLinkClickHandler( 'back' ) }
+						onForwardClick={ this.getNavigationLinkClickHandler( 'forward' ) }
 						recordJpoEvent={ recordJpoEvent }
 						siteId={ siteId }
 						siteSlug={ siteSlug }


### PR DESCRIPTION
This PR introduces `<Wizard />` support for navigation back and forward link click handlers, and updates Jetpack Onboarding to take advantage of it and track when the user clicks on any of those links.

This PR is part of #21686.

To test:
* Checkout this branch
* Go to http://calypso.localhost:3000/devdocs/design/wizard
* Verify the prev/next links work without the back/forward callbacks specified.
* Start the onboarding flow for a Jetpack site by going to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`
* Enable debug of tracks in Calypso by typing this in your browser console: `localStorage.setItem('debug', 'calypso:analytics:tracks' )`
* Use the "Skip for now" and "Back" (not available on 1st step) links and verify they queue recording of the right event (`calypso_jpo_navigation_back_clicked` or `calypso_jpo_navigation_forward_clicked`) with the right `current_step` as an additional property.