### PR TITLE
Jetpack Onboarding: Track title and description change

### DIFF
--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -47,7 +47,11 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 			return;
 		}
 
-		this.props.recordJpoEvent( 'calypso_jpo_site_title_submitted' );
+		this.props.recordJpoEvent( 'calypso_jpo_site_title_submitted', {
+			title_changed: this.state.blogname !== get( this.props.settings, 'siteTitle' ),
+			description_changed:
+				this.state.blogdescription !== get( this.props.settings, 'siteDescription' ),
+		} );
 
 		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
 			siteTitle: this.state.blogname,

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -24,8 +24,8 @@ import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions'
 
 class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 	state = {
-		blogname: get( this.props.settings, 'siteTitle' ),
-		blogdescription: get( this.props.settings, 'siteDescription' ),
+		blogname: this.getFieldValue( 'siteTitle' ),
+		blogdescription: this.getFieldValue( 'siteDescription' ),
 	};
 
 	componentWillReceiveProps( nextProps ) {
@@ -35,6 +35,10 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 				blogdescription: nextProps.settings.siteDescription,
 			} );
 		}
+	}
+
+	getFieldValue( fieldName ) {
+		return get( this.props.settings, fieldName );
 	}
 
 	handleChange = ( { blogname, blogdescription } ) => {
@@ -48,9 +52,8 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 		}
 
 		this.props.recordJpoEvent( 'calypso_jpo_site_title_submitted', {
-			title_changed: this.state.blogname !== get( this.props.settings, 'siteTitle' ),
-			description_changed:
-				this.state.blogdescription !== get( this.props.settings, 'siteDescription' ),
+			title_changed: this.state.blogname !== this.getFieldValue( 'siteTitle' ),
+			description_changed: this.state.blogdescription !== this.getFieldValue( 'siteDescription' ),
 		} );
 
 		this.props.saveJetpackOnboardingSettings( this.props.siteId, {


### PR DESCRIPTION
This PR updates the site title step to track when any of the site title and site description fields are changed. We don't need to track every single change (adding or removing a character) - that would result in a ton of events anyway; we only need to know whether the user typed in a field at some point (at least once). That is why this PR only tracks the first change of each of the fields; we're not interested in any subsequent changes.

Note: we're using a non-static property because this way we'll track the change event every time 
the site title step is loaded, and not just the first time (that matters only if the user goes back to the site title step, of course). 

This PR is part of #21686.

To test:
* Checkout this branch
* Start the onboarding flow for a Jetpack site by going to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`
* Enable debug of tracks in Calypso by typing this in your browser console: `localStorage.setItem('debug', 'calypso:analytics:tracks' )`
* Input something in the site title field and observe the console.
* Verify you can see the `calypso_jpo_blogname_changed` event being queued for recording.
* Verify the event is only recorded only once, and if you continue typing/deleting, it's no longer recorded.
* Input something in the site description field and observe the console.
* Verify you can see the `calypso_jpo_blogdescription_changed` event being queued for recording.
* Verify the event is only recorded only once, and if you continue typing/deleting, it's no longer recorded.
* Go to the next step.
* Go back to the site title step.
* Type something in each of the fields, and verify the change event is being recorded again, but just once.