### PR TITLE
Jetpack connect: Provide real log-in redirect url

### DIFF
--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -138,7 +138,10 @@ export class JetpackSignup extends Component {
 					{ this.renderLocaleSuggestions() }
 					<AuthFormHeader authQuery={ this.props.authQuery } />
 					<SignupForm
-						redirectToAfterLoginUrl="!! THIS PROP IS REQUIRED BUT UNUSED !!"
+						redirectToAfterLoginUrl={ addQueryArgs(
+							{ auth_approved: true },
+							window.location.href
+						) }
 						disabled={ isAuthorizing }
 						submitting={ isAuthorizing }
 						submitForm={ this.handleSubmitSignup }

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -44,7 +44,7 @@ exports[`JetpackSignup should render 1`] = `
           />
         </LoggedOutFormLinks>
       }
-      redirectToAfterLoginUrl="!! THIS PROP IS REQUIRED BUT UNUSED !!"
+      redirectToAfterLoginUrl="https://example.com/?auth_approved=true"
       submitButtonText="Sign Up and Connect Jetpack"
       submitForm={[Function]}
       submitting={false}
@@ -102,7 +102,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
           />
         </LoggedOutFormLinks>
       }
-      redirectToAfterLoginUrl="!! THIS PROP IS REQUIRED BUT UNUSED !!"
+      redirectToAfterLoginUrl="https://example.com/?auth_approved=true"
       submitButtonText="Sign Up and Connect Jetpack"
       submitForm={[Function]}
       submitting={false}


### PR DESCRIPTION
An apparently unused prop was removed with the intention of simplifying components. This PR reintroduces the prop which _is_ used.

It is used to produce a link in an error message.

This was hidden by that fact that there's no clear way to navigate from `log-in` back into the Jetpack connection flow (`/jetpack/connect/authorize`). #22218 exposes the problem, this is a blocker.

![not-unused](https://user-images.githubusercontent.com/841763/36152072-ec1ad10e-10c9-11e8-81be-010d193ea20f.png)

## Testing
1. Log out of WordPress.com
1. Connect a new site with an email associated with an existing WordPress.com account
1. You should land at `/log-in`
1. This is pretty difficult to test. You need to manually get the `redirect_to` param from login, URL decode it, and visit that link. Then you'll see the ~error~ fix. Paste this into your browser from `log-in`:
   ```js
   window.location = new URLSearchParams( document.location.search ).get('redirect_to')
   ```
1. You should see a warning on the form. Look at the provided link to log-in. Does it look right?
1. Test the link in the warning.
1. Can you complete the connection flow successfully?