### PR TITLE
Jetpack Onboading: Track ToS click

### DIFF
--- a/client/jetpack-onboarding/disclaimer.jsx
+++ b/client/jetpack-onboarding/disclaimer.jsx
@@ -11,14 +11,21 @@ import { localize } from 'i18n-calypso';
  */
 import Gridicon from 'gridicons';
 
-const JetpackOnboardingDisclaimer = ( { translate } ) => (
+const JetpackOnboardingDisclaimer = ( { handleTosClick, translate } ) => (
 	<p className="jetpack-onboarding__disclaimer">
 		<Gridicon icon="info-outline" size={ 18 } />
 		{ translate(
 			'By continuing, you agree to our {{link}}fascinating terms and conditions{{/link}}.',
 			{
 				components: {
-					link: <a href="//wordpress.com/tos/" target="_blank" rel="noopener noreferrer" />,
+					link: (
+						<a
+							href="//wordpress.com/tos/"
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={ handleTosClick }
+						/>
+					),
 				},
 			}
 		) }

--- a/client/jetpack-onboarding/disclaimer.jsx
+++ b/client/jetpack-onboarding/disclaimer.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,25 +12,40 @@ import { localize } from 'i18n-calypso';
  */
 import Gridicon from 'gridicons';
 
-const JetpackOnboardingDisclaimer = ( { handleTosClick, translate } ) => (
-	<p className="jetpack-onboarding__disclaimer">
-		<Gridicon icon="info-outline" size={ 18 } />
-		{ translate(
-			'By continuing, you agree to our {{link}}fascinating terms and conditions{{/link}}.',
-			{
-				components: {
-					link: (
-						<a
-							href="//wordpress.com/tos/"
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ handleTosClick }
-						/>
-					),
-				},
-			}
-		) }
-	</p>
-);
+class JetpackOnboardingDisclaimer extends React.PureComponent {
+	static propTypes = {
+		recordJpoEvent: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	handleTosClick = () => {
+		this.props.recordJpoEvent( 'calypso_jpo_tos_clicked' );
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<p className="jetpack-onboarding__disclaimer">
+				<Gridicon icon="info-outline" size={ 18 } />
+				{ translate(
+					'By continuing, you agree to our {{link}}fascinating terms and conditions{{/link}}.',
+					{
+						components: {
+							link: (
+								<a
+									href="//wordpress.com/tos/"
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ this.handleTosClick }
+								/>
+							),
+						},
+					}
+				) }
+			</p>
+		);
+	}
+}
 
 export default localize( JetpackOnboardingDisclaimer );

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -54,6 +54,10 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 		page( this.props.getForwardUrl() );
 	};
 
+	handleTosClick = () => {
+		this.props.recordJpoEvent( 'calypso_jpo_tos_clicked' );
+	};
+
 	render() {
 		const { basePath, isRequestingSettings, translate } = this.props;
 		const headerText = translate( "Let's get started." );
@@ -92,7 +96,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 					</form>
 				</Card>
 
-				<JetpackOnboardingDisclaimer />
+				<JetpackOnboardingDisclaimer handleTosClick={ this.handleTosClick } />
 			</div>
 		);
 	}

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -54,10 +54,6 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 		page( this.props.getForwardUrl() );
 	};
 
-	handleTosClick = () => {
-		this.props.recordJpoEvent( 'calypso_jpo_tos_clicked' );
-	};
-
 	render() {
 		const { basePath, isRequestingSettings, translate } = this.props;
 		const headerText = translate( "Let's get started." );
@@ -96,7 +92,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 					</form>
 				</Card>
 
-				<JetpackOnboardingDisclaimer handleTosClick={ this.handleTosClick } />
+				<JetpackOnboardingDisclaimer recordJpoEvent={ this.props.recordJpoEvent } />
 			</div>
 		);
 	}


### PR DESCRIPTION
This PR introduces a simple event tracking for the ToS click on the site title page.

This PR is part of #21686.

To test:
* Checkout this branch
* Start the onboarding flow for a Jetpack site by going to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`
* Enable debug of tracks in Calypso by typing this in your browser console: `localStorage.setItem('debug', 'calypso:analytics:tracks' )`
* On the site title step, click on the **fascinating terms and conditions** link.
* Observing the console, verify the `calypso_jpo_tos_clicked` event is being recorded.