### PR TITLE
Jetpack Onboarding: Track form submissions

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -66,9 +66,9 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 
 		const { siteId } = this.props;
 
-		this.props.saveJetpackOnboardingSettings( siteId, { businessAddress: this.state } );
-
 		this.props.recordJpoEvent( 'calypso_jpo_business_address_submitted' );
+
+		this.props.saveJetpackOnboardingSettings( siteId, { businessAddress: this.state } );
 
 		page( this.props.getForwardUrl() );
 	};

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -65,7 +65,11 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		}
 
 		const { siteId } = this.props;
+
 		this.props.saveJetpackOnboardingSettings( siteId, { businessAddress: this.state } );
+
+		this.props.recordJpoEvent( 'calypso_jpo_business_address_submitted' );
+
 		page( this.props.getForwardUrl() );
 	};
 

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -47,12 +47,12 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 			return;
 		}
 
+		this.props.recordJpoEvent( 'calypso_jpo_site_title_submitted' );
+
 		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
 			siteTitle: this.state.blogname,
 			siteDescription: this.state.blogdescription,
 		} );
-
-		this.props.recordJpoEvent( 'calypso_jpo_site_title_submitted' );
 
 		page( this.props.getForwardUrl() );
 	};

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -51,6 +51,9 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 			siteTitle: this.state.blogname,
 			siteDescription: this.state.blogdescription,
 		} );
+
+		this.props.recordJpoEvent( 'calypso_jpo_site_title_submitted' );
+
 		page( this.props.getForwardUrl() );
 	};
 


### PR DESCRIPTION
This PR introduces a simple event tracking for both the site title and the business address forms.

This PR is part of #21686.

To test:
* Checkout this branch
* Start the onboarding flow for a Jetpack site by going to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`
* Enable debug of tracks in Calypso by typing this in your browser console: `localStorage.setItem('debug', 'calypso:analytics:tracks' )`
* On the site title step, input something in the site title step.
* Submit the form.
* Observing the console, verify the `calypso_jpo_site_title_submitted` event is being recorded.
* On the site type step, select **Business**.
* Skip to the Business Address step.
* In the Business Address form, input something in each of the fields.
* Submit the form.
* Observing the console, verify the `calypso_jpo_business_address_submitted` event is being recorded.