### PR TITLE
Signup: Set up A/B test for minimizing the Free plan on the plans page.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -84,4 +84,13 @@ export default {
 		defaultVariation: 'group_0',
 		allowExistingUsers: true,
 	},
+	minimizeFreePlan: {
+		datestamp: '20180219',
+		variations: {
+			original: 50,
+			minimized: 50,
+		},
+		defaultVariation: 'original',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/plan-features/bottom.jsx
+++ b/client/my-sites/plan-features/bottom.jsx
@@ -1,0 +1,27 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export default class PlanFeaturesBottom extends React.PureComponent {
+	getContainer() {
+		if ( ! this.container || ! this.container.offsetWidth ) {
+			this.container = document.querySelector( '.plans-features-main__bottom' );
+		}
+
+		return this.container;
+	}
+
+	render() {
+		const { children } = this.props;
+		const container = this.getContainer();
+
+		if ( ! children || ! container ) {
+			return null;
+		}
+
+		return ReactDOM.createPortal( children, container );
+	}
+}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -536,3 +536,10 @@ $plan-features-sidebar-width: 272px;
 		border-bottom: solid 1px lighten( $gray, 27% );
 	}
 }
+
+.plans-features-main__bottom .plan-features__actions {
+	padding-bottom: 0;
+}
+.plans-features-main__bottom .plan-features__actions-button {
+	width: auto;
+}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -402,6 +402,7 @@ class PlansFeaturesMain extends Component {
 				{ this.getPlanFeatures() }
 				<PaymentMethods />
 				{ faqs }
+				<div className="plans-features-main__bottom" />
 			</div>
 		);
 	}


### PR DESCRIPTION
This PR sets up an A/B test for minimizing the Free plan on the plans plage in sign up. See p8Eqe3-nL-p2 for more detail about the test.

## How to test

1. Set `minimizeFreePlan` A/B test to `minimized` by running the follow script in browser console:
```
localStorage.setItem( 'ABTests', '{"minimizeFreePlan_20180219": "minimized"}' );
```
2. Create a new website. Follow the signup flow and you will notice the free plan card disappeared. Instead, an action button for the free plan shows up at the far bottom of the page as follows:
<img width="1116" alt="wordpress_com" src="https://user-images.githubusercontent.com/212034/36153591-1a890a2c-1112-11e8-955c-a8eab1684257.png">

cc @anneforbush @fditrapani 