### PR TITLE
Jetpack Onboarding: Track business address field change

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -7,7 +7,7 @@ import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import { get, map, omit, some, transform } from 'lodash';
+import { get, map, omit, reduce, some } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -68,11 +68,12 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 
 		this.props.recordJpoEvent(
 			'calypso_jpo_business_address_submitted',
-			transform(
+			reduce(
 				this.fields,
 				( eventProps, value, field ) => {
 					const changed = get( settings, [ 'businessAddress', field ] ) !== this.state[ field ];
 					eventProps[ `${ field }_changed` ] = changed;
+					return eventProps;
 				},
 				{}
 			)

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -7,7 +7,7 @@ import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
-import { get, map, omit, some } from 'lodash';
+import { get, map, omit, some, transform } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -64,9 +64,19 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 			return;
 		}
 
-		const { siteId } = this.props;
+		const { settings, siteId } = this.props;
 
-		this.props.recordJpoEvent( 'calypso_jpo_business_address_submitted' );
+		this.props.recordJpoEvent(
+			'calypso_jpo_business_address_submitted',
+			transform(
+				this.fields,
+				( eventProps, value, field ) => {
+					const changed = get( settings, [ 'businessAddress', field ] ) !== this.state[ field ];
+					eventProps[ `${ field }_changed` ] = changed;
+				},
+				{}
+			)
+		);
 
 		this.props.saveJetpackOnboardingSettings( siteId, { businessAddress: this.state } );
 


### PR DESCRIPTION
This PR updates the business address step to track when any of the form fields are changed. We don't need to track every single change (adding or removing a character) - that would result in a ton of events anyway; we only need to know whether the user typed in a field at some point (at least once). That is why this PR only tracks the first change of each of the fields; we're not interested in any subsequent changes.

Note: we're using a non-static property because this way we'll track the change event every time 
the business address step is loaded, and not just the first time (that matters only if the user goes back to the business address step, of course). 

This PR is last part needed to finish and close #21686.

To test:
* Checkout this branch
* Start the onboarding flow for a Jetpack site by going to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`
* Enable debug of tracks in Calypso by typing this in your browser console: `localStorage.setItem('debug', 'calypso:analytics:tracks' )`
* Skip to the site type step.
* Select **Business**.
* Skip to the Business Address step.
* Input something in any of the fields and observe the console.
* Verify you can see the `calypso_jpo_FIELD_changed` event being queued for recording (where `FIELD` is the field name).
* Verify the event is only recorded only once, and if you continue typing/deleting, it's no longer recorded.
* Go to the next step.
* Go back to the business address step.
* Type something in each of the fields, and verify the change event is being recorded again, but just once.