### PR TITLE
Change subheader text in nux step 2 when transfer is selected.

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -304,6 +304,10 @@ class DomainsStep extends React.Component {
 		const backUrl = this.props.stepSectionName
 			? getStepUrl( this.props.flowName, this.props.stepName, undefined, getLocaleSlug() )
 			: undefined;
+		let fallbackSubHeaderText = translate(
+			"Enter your site's name, or some key words that describe it - " +
+				"we'll use this to create your new site's address."
+		);
 
 		if ( 'mapping' === this.props.stepSectionName ) {
 			content = this.mappingForm();
@@ -311,6 +315,9 @@ class DomainsStep extends React.Component {
 
 		if ( 'transfer' === this.props.stepSectionName ) {
 			content = this.transferForm();
+			fallbackSubHeaderText = translate(
+				'Use a domain you already own with your new WordPress.com site.'
+			);
 		}
 
 		if ( ! this.props.stepSectionName ) {
@@ -337,10 +344,7 @@ class DomainsStep extends React.Component {
 				signupProgress={ this.props.signupProgress }
 				subHeaderText={ translate( "First up, let's find a domain." ) }
 				fallbackHeaderText={ translate( "Let's give your site an address." ) }
-				fallbackSubHeaderText={ translate(
-					"Enter your site's name, or some key words that describe it - " +
-						"we'll use this to create your new site's address."
-				) }
+				fallbackSubHeaderText={ fallbackSubHeaderText }
 				stepContent={ content }
 			/>
 		);


### PR DESCRIPTION
When transferring a domain in during signup, the subheader text reads "Enter your site's name, or some key words that describe it - we'll use this to create your new site's address." This is misleading once a user has already selected a domain transfer on the first screen during the "Let's give your site an address." step.

This PR updates the text to read "Use a domain you already own with your new WordPress.com site." when an inbound transfer is selected.

<img width="722" alt="wordpress_com" src="https://user-images.githubusercontent.com/1379730/36154688-3d847b3c-10a0-11e8-8fb6-fa80b6e7256d.png">

To test, browse to `calypso.localhost:3000/start`, enter an unavailable domain that is eligible for inbound transfer during step 2. Make sure that the subheader text displayed is the same as in the image above.

