### PR TITLE
Jetpack Onboarding: Track WooCommerce step button clicks

### DIFF
--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -27,6 +27,12 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
 			installWooCommerce: true,
 		} );
+
+		this.props.recordJpoEvent( 'calypso_jpo_woocommerce_install_clicked' );
+	};
+
+	handleWooCommerceInstallationSkip = () => {
+		this.props.recordJpoEvent( 'calypso_jpo_woocommerce_dont_install_clicked' );
 	};
 
 	render() {
@@ -59,7 +65,9 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 							<Button href={ forwardUrl } onClick={ this.handleWooCommerceInstallation } primary>
 								{ translate( 'Yes, I am' ) }
 							</Button>
-							<Button href={ forwardUrl }>{ translate( 'Not right now' ) }</Button>
+							<Button href={ forwardUrl } onClick={ this.handleWooCommerceInstallationSkip }>
+								{ translate( 'Not right now' ) }
+							</Button>
 						</div>
 					) }
 				</div>

--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -24,11 +24,11 @@ import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions'
 
 class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 	handleWooCommerceInstallation = () => {
+		this.props.recordJpoEvent( 'calypso_jpo_woocommerce_install_clicked' );
+
 		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
 			installWooCommerce: true,
 		} );
-
-		this.props.recordJpoEvent( 'calypso_jpo_woocommerce_install_clicked' );
 	};
 
 	handleWooCommerceInstallationSkip = () => {

--- a/client/jetpack-onboarding/steps/woocommerce.jsx
+++ b/client/jetpack-onboarding/steps/woocommerce.jsx
@@ -32,7 +32,7 @@ class JetpackOnboardingWoocommerceStep extends React.PureComponent {
 	};
 
 	handleWooCommerceInstallationSkip = () => {
-		this.props.recordJpoEvent( 'calypso_jpo_woocommerce_dont_install_clicked' );
+		this.props.recordJpoEvent( 'calypso_jpo_woocommerce_skip_install_clicked' );
 	};
 
 	render() {


### PR DESCRIPTION
This PR introduces a simple event tracking for the enabled buttons on the WooCommerce page.

The PR is part of #21686.

To test:
* Checkout this branch.
* Start the onboarding flow for a Jetpack site by going to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`.
* Enable debug of tracks in Calypso by typing this in your browser console: `localStorage.setItem('debug', 'calypso:analytics:tracks' )`
* On the site type step, select **Business**.
* Make sure WooCommerce isn't installed, or if installed, make sure it's deactivated.
* Skip to the WooCommerce step.
* Click the **Yes, I am** button.
* Observing the console, verify the `calypso_jpo_woocommerce_install_clicked` event is being recorded.
* Deactivate or uninstall WooCommerce.
* Restart the flow and go to the WooCommerce step.
* Click the **Not right now** button.
* Observing the console, verify the `calypso_jpo_woocommerce_dont_install_clicked` event is being recorded.