### PR TITLE
Prevent charts from showing over menu

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -123,6 +123,7 @@
 	overflow: hidden;
 	display: -ms-flex;
 	display: flex;
+	z-index: 0;
 }
 
 // Individual bar


### PR DESCRIPTION
I use WordPress.com in a browser on a my mobile device and over the last couple days, I noticed the stats were appearing over the menu. What's weird is that I noticed the issue doesn't replicate in my local dev environment. I therefore tested the fix by applying it through the inspector in Chrome and Firefox — Safari doesn't seem to have this issue. I then rested the update in all three browsers to make sure there were not weird side effects. 

## Before

![image](https://user-images.githubusercontent.com/6981253/36156376-cd8831ca-10a4-11e8-9aa6-454275c98f34.png)


## After
![image](https://user-images.githubusercontent.com/6981253/36156388-dc774fc2-10a4-11e8-9e88-2f9c596cf5f8.png)


## Testing
- Open `Wordpress.com` in either Chrome or Firefox
- Visit your stats page
- Reduce window to "mobile" width
- Toggle the menu open and closed
- Use inspector to apply `z-index: 0` to `.chart__bars`
- Notice the stats don't appear over the menu

Now load `calypso.localhost:3000` with the branch loaded and visit the stats on various browsers. Toggle the menu and see if you can find any weird side effects due to the update. 