### PR TITLE
Rewind: display the flow initiator when inactive due to vp_can_transfer

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -598,10 +598,9 @@ class ActivityLog extends Component {
 		const { siteId, context, rewindState } = this.props;
 
 		const rewindNoThanks = get( context, 'query.rewind-redirect', '' );
-		const rewindIsNotReady = includes(
-			[ 'uninitialized', 'awaitingCredentials' ],
-			rewindState.state
-		);
+		const rewindIsNotReady =
+			includes( [ 'uninitialized', 'awaitingCredentials' ], rewindState.state ) ||
+			'vp_can_transfer' === rewindState.reason;
 
 		return (
 			<Main wideLayout>


### PR DESCRIPTION
This fixes the issue where the flow initiator isn't displayed when Rewind is inactive because the site has VP active, fails with `vp_can_transfer` reason, and can be switched from VP to R.

This will now allow the flow initiator to be correctly shown in those cases:

<img width="553" alt="captura de pantalla 2018-02-13 a la s 12 42 35" src="https://user-images.githubusercontent.com/1041600/36158674-a44a0fa6-10bb-11e8-8425-1e58cffbaea7.png">
