### PR TITLE
Rewind: when users can auto-config, send them to a new flow

### DIFF
--- a/client/my-sites/stats/activity-log-switch/index.jsx
+++ b/client/my-sites/stats/activity-log-switch/index.jsx
@@ -39,6 +39,7 @@ class ActivityLogSwitch extends Component {
 			siteId,
 			siteSlug,
 			translate,
+			canAutoconfigure,
 		} = this.props;
 		switch ( this.props.failureReason ) {
 			case 'vp_can_transfer':
@@ -66,7 +67,11 @@ class ActivityLogSwitch extends Component {
 				return (
 					<Button
 						primary
-						href={ `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ siteSlug }` }
+						href={
+							canAutoconfigure
+								? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ siteSlug }`
+								: `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ siteSlug }`
+						}
 						>
 						{ translate( 'Continue setup' ) }
 					</Button>
@@ -183,6 +188,7 @@ export default connect(
 			siteUrl: getSiteUrl( state, siteId ),
 			rewindState: rewindState.state,
 			failureReason: rewindState.reason || '',
+			canAutoconfigure: rewindState.canAutoconfigure,
 		};
 	}
 )( localize( ActivityLogSwitch ) );

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -492,7 +492,7 @@ class ActivityLog extends Component {
 						icon="history"
 						href={
 							rewindState.canAutoconfigure
-								? `/settings/security/${ slug }`
+								? `/start/rewind-setup/?blogid=${ siteId }&siteSlug=${ slug }`
 								: `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ slug }`
 						}
 						title={ translate( 'Add site credentials' ) }

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -492,7 +492,7 @@ class ActivityLog extends Component {
 						icon="history"
 						href={
 							rewindState.canAutoconfigure
-								? `/start/rewind-setup/?blogid=${ siteId }&siteSlug=${ slug }`
+								? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ slug }`
 								: `/start/rewind-setup/?siteId=${ siteId }&siteSlug=${ slug }`
 						}
 						title={ translate( 'Add site credentials' ) }

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -276,6 +276,19 @@ const flows = {
 		allowContinue: false,
 		hideFlowProgress: true,
 	},
+
+	'rewind-auto-config': {
+		steps: [ 'creds-permission', 'creds-confirm', 'rewind-were-backing' ],
+		destination: () => {
+			return '/stats/activity';
+		},
+		description:
+			'Allow users of sites that can auto-config to grant permission to server credentials',
+		lastModified: '2018-02-13',
+		disallowResume: true,
+		allowContinue: false,
+		hideFlowProgress: true,
+	},
 };
 
 if ( config.isEnabled( 'signup/atomic-store-flow' ) ) {

--- a/client/signup/steps/creds-confirm/index.jsx
+++ b/client/signup/steps/creds-confirm/index.jsx
@@ -44,7 +44,9 @@ class CredsConfirmStep extends Component {
 			stepName: this.props.stepName,
 		} );
 
-		this.props.goToStep( 'creds-complete' );
+		this.props.goToStep(
+			'pressable-nux' === this.props.flowName ? 'creds-complete' : 'rewind-were-backing'
+		);
 	};
 
 	renderStepContent = () => {

--- a/client/signup/steps/creds-permission/index.jsx
+++ b/client/signup/steps/creds-permission/index.jsx
@@ -42,7 +42,9 @@ class CredsPermissionStep extends Component {
 			stepName: this.props.stepName,
 		} );
 
-		this.props.goToStep( 'creds-complete' );
+		this.props.goToStep(
+			'pressable-nux' === this.props.flowName ? 'creds-complete' : 'rewind-were-backing'
+		);
 	};
 
 	renderStepContent = () => {

--- a/client/signup/steps/rewind-add-creds/style.scss
+++ b/client/signup/steps/rewind-add-creds/style.scss
@@ -1,6 +1,7 @@
 .rewind-add-creds__card {
 	img {
-		max-width: 140px;
-		margin-bottom: 24px;
+		max-width: 200px;
+		display: block;
+		margin: 2rem auto;
 	}
 }

--- a/client/signup/steps/rewind-form-creds/style.scss
+++ b/client/signup/steps/rewind-form-creds/style.scss
@@ -1,7 +1,8 @@
 .rewind-form-creds__card {
 	img {
-		max-width: 140px;
-		margin-bottom: 24px;
+		max-width: 200px;
+		display: block;
+		margin: 2rem auto;
 	}
 
 	.rewind-credentials-form {

--- a/client/signup/steps/rewind-migrate/style.scss
+++ b/client/signup/steps/rewind-migrate/style.scss
@@ -4,14 +4,17 @@
 	display: none;
 }
 
-.rewind-switch__card {
+.rewind-switch__card, .rewind-auto-config__card {
 	text-align: center;
+	margin: 1px auto;
+	max-width: 640px;
 }
 
 .rewind-migrate__card {
 	img {
-		max-width: 260px;
-		margin-bottom: 24px;
+		max-width: 200px;
+		display: block;
+		margin: 2rem auto;
 	}
 }
 
@@ -19,15 +22,23 @@
 	display: flex;
 	align-items: center;
 	flex-direction: column;
+	padding: 4rem 4rem 3rem;
 }
 
 .rewind-switch__heading {
-	font-size: 24px;
-	margin: 8px 0 32px;
+	display: inline-block;
+	font-size: 2.5rem;
+	font-weight: 300;
+	letter-spacing: .15rem;
+	color: $gray-dark;
 }
 
 .rewind-switch__description {
 	max-width: 600px;
+	color: $gray-text-min;
+	font-size: 1.35rem;
+	font-weight: 100;
+	line-height: 2.5rem;
 }
 
 .rewind-migrate__warning {

--- a/client/signup/steps/rewind-migrate/style.scss
+++ b/client/signup/steps/rewind-migrate/style.scss
@@ -1,4 +1,5 @@
 .flow-progress-indicator__rewind-setup,
+.flow-progress-indicator__rewind-auto-config,
 .flow-progress-indicator__rewind-switch {
 	display: none;
 }

--- a/client/signup/steps/rewind-were-backing/style.scss
+++ b/client/signup/steps/rewind-were-backing/style.scss
@@ -1,6 +1,7 @@
 .rewind-were-backing__card {
 	img {
-		max-width: 140px;
-		margin-bottom: 24px;
+		max-width: 200px;
+		display: block;
+		margin: 2rem auto;
 	}
 }


### PR DESCRIPTION
Fixes #22380 

This PR sends users of sites whose credentials can be auto-configured to a new flow in
`/start/rewind-auto-config`.

a. This will show them a button to share credentials so Rewind is auto-configured. Once it's done, it will show a panel so they can go back to Activity Log.

b. It also updates the notice in AL that prompts user to add credentials so it goes to this new flow.

c. Updates the styling of the steps created for most recent flows rewind-migrate and rewind-setup since we're using the last one rewind-were-backing and it needed to match the style of the `pressable-nux` flow steps

#### A pressable-nux step showing its style
<img width="300" alt="captura de pantalla 2018-02-13 a la s 14 33 04" src="https://user-images.githubusercontent.com/1041600/36164347-d624daf6-10ca-11e8-9821-d0bc67c422d8.png">

#### Steps from rewind-migrate and rewind-setup flows with updated style
<img width="300" alt="captura de pantalla 2018-02-13 a la s 15 56 58" src="https://user-images.githubusercontent.com/1041600/36168437-d680b8aa-10d7-11e8-9e83-b3f14c525834.png"><img width="300" alt="captura de pantalla 2018-02-13 a la s 15 59 08" src="https://user-images.githubusercontent.com/1041600/36168438-d6aa0e76-10d7-11e8-989c-380ca472b4dc.png"><img width="300" alt="captura de pantalla 2018-02-13 a la s 16 02 44" src="https://user-images.githubusercontent.com/1041600/36168439-d6e28b52-10d7-11e8-80ce-11c64aae98e5.png"><img width="300" alt="captura de pantalla 2018-02-13 a la s 16 02 53" src="https://user-images.githubusercontent.com/1041600/36168440-d70b0d2a-10d7-11e8-9bdb-d15ee0b92534.png">


### Testing

#### Landing

This can be triggered in a site that can auto-config, and its Rewind state is `awaiting_credentials`. The flow initiator can be shown with a URL like
```
http://calypso.localhost:3000/stats/activity/COOLSITE.TLD?rewind-redirect=admin.php%3Fpage%3Djetpack
```
Clicking the **Continue setup** button should take users to the flow:
<img width="497" alt="captura de pantalla 2018-02-13 a la s 14 32 44" src="https://user-images.githubusercontent.com/1041600/36164329-c8116268-10ca-11e8-85cd-c82cf9a8d149.png">


#### Notice

Clicking the Add Credentials notice in Activity Log should send users straight into the `/start/rewind-auto-config` flow 

<img width="714" alt="captura de pantalla 2018-02-13 a la s 14 32 08" src="https://user-images.githubusercontent.com/1041600/36164303-b4608b86-10ca-11e8-856d-182e7499d9f5.png">
