### PR TITLE
Rewind: Fix bug where credential failures were opening chats

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -136,7 +136,7 @@ export const failure = ( { dispatch, getState }, action, error ) => {
 		} );
 
 		dispatch(
-			isHappychatAvailable( getState() )
+			hasActiveHappychatSession( getState() )
 				? withAnalytics( tracksEvent, sendEvent( message ) )
 				: tracksEvent
 		);


### PR DESCRIPTION
In #22269 we attempted to resolve an issue where failures in the
credentials form were opening chat sessions.

The bug was a misuse or a typo where I used `isHappychatAvailable()`
when I should have used `hasActiveHappychatSession()`. Since I thought I
remembered using `hasActiveHappychatSession()` I believe this was a typo
that went unnoticed.

In this patch the function is swapped out for its intended function
which should fix the bug that #22269 was supposd to fix originally.

**Testing**

Well we seem to test #22269 but it was insufficient. I think I was confused
with things. That being said, this is actively broken and my suggestion for
testing is nothing more than manual code review. Should be effective.