### PR TITLE
JP Onboarding: Merge Summary Step Click Handlers

### DIFF
--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -21,7 +21,7 @@ import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
 	handleSummaryStepClick = ( stepName, stepType ) => () => {
-		this.props.recordJpoEvent( 'calypso_jpo_summary_step_clicked', {
+		this.props.recordJpoEvent( 'calypso_jpo_summary_step_link_clicked', {
 			step: stepName,
 			type: stepType,
 		} );

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -50,7 +50,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 						<h3 className="steps__summary-heading">{ translate( "Steps you've completed:" ) }</h3>
 						<CompletedSteps
 							basePath={ basePath }
-							handleSummaryStepClick={ this.handleSummaryStepClick }
+							onClick={ this.handleSummaryStepClick }
 							siteId={ siteId }
 							siteSlug={ siteSlug }
 							steps={ steps }
@@ -59,7 +59,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 					<div className="steps__summary-column">
 						<h3 className="steps__summary-heading">{ translate( 'Continue your site setup:' ) }</h3>
 						<NextSteps
-							handleSummaryStepClick={ this.handleSummaryStepClick }
+							onClick={ this.handleSummaryStepClick }
 							siteId={ siteId }
 							siteSlug={ siteSlug }
 							siteUrl={ siteUrl }

--- a/client/jetpack-onboarding/steps/summary.jsx
+++ b/client/jetpack-onboarding/steps/summary.jsx
@@ -20,17 +20,10 @@ import { getUnconnectedSiteUrl } from 'state/selectors';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingSummaryStep extends React.PureComponent {
-	handleNextStepClick = stepName => () => {
-		const { recordJpoEvent } = this.props;
-		recordJpoEvent( 'calypso_jpo_next_step_clicked', {
-			nextStep: stepName,
-		} );
-	};
-
-	handleCompletedStepClick = stepName => () => {
-		const { recordJpoEvent } = this.props;
-		recordJpoEvent( 'calypso_jpo_completed_step_clicked', {
-			completedStep: stepName,
+	handleSummaryStepClick = ( stepName, stepType ) => () => {
+		this.props.recordJpoEvent( 'calypso_jpo_summary_step_clicked', {
+			step: stepName,
+			type: stepType,
 		} );
 	};
 
@@ -57,7 +50,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 						<h3 className="steps__summary-heading">{ translate( "Steps you've completed:" ) }</h3>
 						<CompletedSteps
 							basePath={ basePath }
-							handleCompletedStepClick={ this.handleCompletedStepClick }
+							handleSummaryStepClick={ this.handleSummaryStepClick }
 							siteId={ siteId }
 							siteSlug={ siteSlug }
 							steps={ steps }
@@ -66,7 +59,7 @@ class JetpackOnboardingSummaryStep extends React.PureComponent {
 					<div className="steps__summary-column">
 						<h3 className="steps__summary-heading">{ translate( 'Continue your site setup:' ) }</h3>
 						<NextSteps
-							handleNextStepClick={ this.handleNextStepClick }
+							handleSummaryStepClick={ this.handleSummaryStepClick }
 							siteId={ siteId }
 							siteSlug={ siteSlug }
 							siteUrl={ siteUrl }

--- a/client/jetpack-onboarding/summary-completed-steps.jsx
+++ b/client/jetpack-onboarding/summary-completed-steps.jsx
@@ -26,7 +26,7 @@ import {
 
 const CompletedSteps = ( {
 	basePath,
-	handleCompletedStepClick,
+	handleSummaryStepClick,
 	siteSlug,
 	steps,
 	stepsCompleted,
@@ -48,7 +48,7 @@ const CompletedSteps = ( {
 				) }
 				<a
 					href={ [ basePath, stepName, siteSlug ].join( '/' ) }
-					onClick={ handleCompletedStepClick( stepName ) }
+					onClick={ handleSummaryStepClick( stepName, 'completed' ) }
 				>
 					{ STEP_TITLES[ stepName ] }
 				</a>
@@ -57,11 +57,11 @@ const CompletedSteps = ( {
 	} );
 
 CompletedSteps.propTypes = {
-	handleCompletedStepClick: PropTypes.func,
+	handleSummaryStepClick: PropTypes.func,
 };
 
 CompletedSteps.defaultProps = {
-	handleCompletedStepClick: noop,
+	handleSummaryStepClick: noop,
 };
 
 export default connect( ( state, { siteId, steps } ) => ( {

--- a/client/jetpack-onboarding/summary-completed-steps.jsx
+++ b/client/jetpack-onboarding/summary-completed-steps.jsx
@@ -24,14 +24,7 @@ import {
 	JETPACK_ONBOARDING_STEPS as STEPS,
 } from './constants';
 
-const CompletedSteps = ( {
-	basePath,
-	handleSummaryStepClick,
-	siteSlug,
-	steps,
-	stepsCompleted,
-	stepsPending,
-} ) =>
+const CompletedSteps = ( { basePath, onClick, siteSlug, steps, stepsCompleted, stepsPending } ) =>
 	map( without( steps, STEPS.SUMMARY ), stepName => {
 		const isCompleted = get( stepsCompleted, stepName ) === true;
 		const isPending = get( stepsPending, stepName );
@@ -48,7 +41,7 @@ const CompletedSteps = ( {
 				) }
 				<a
 					href={ [ basePath, stepName, siteSlug ].join( '/' ) }
-					onClick={ handleSummaryStepClick( stepName, 'completed' ) }
+					onClick={ onClick( stepName, 'completed' ) }
 				>
 					{ STEP_TITLES[ stepName ] }
 				</a>
@@ -57,11 +50,11 @@ const CompletedSteps = ( {
 	} );
 
 CompletedSteps.propTypes = {
-	handleSummaryStepClick: PropTypes.func,
+	onClick: PropTypes.func,
 };
 
 CompletedSteps.defaultProps = {
-	handleSummaryStepClick: noop,
+	onClick: noop,
 };
 
 export default connect( ( state, { siteId, steps } ) => ( {

--- a/client/jetpack-onboarding/summary-next-steps.jsx
+++ b/client/jetpack-onboarding/summary-next-steps.jsx
@@ -17,12 +17,12 @@ import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getJetpackOnboardingSettings } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
-const NextSteps = ( { handleSummaryStepClick, siteId, steps } ) => (
+const NextSteps = ( { onClick, siteId, steps } ) => (
 	<Fragment>
 		<QuerySites siteId={ siteId } />
 		{ map( steps, ( { label, url }, stepName ) => (
 			<div key={ stepName } className="jetpack-onboarding__summary-entry todo">
-				<a href={ url } onClick={ handleSummaryStepClick( stepName, 'next' ) }>
+				<a href={ url } onClick={ onClick( stepName, 'next' ) }>
 					{ label }
 				</a>
 			</div>
@@ -31,11 +31,11 @@ const NextSteps = ( { handleSummaryStepClick, siteId, steps } ) => (
 );
 
 NextSteps.propTypes = {
-	handleSummaryStepClick: PropTypes.func,
+	onClick: PropTypes.func,
 };
 
 NextSteps.defaultProps = {
-	handleSummaryStepClick: noop,
+	onClick: noop,
 };
 
 export default localize(

--- a/client/jetpack-onboarding/summary-next-steps.jsx
+++ b/client/jetpack-onboarding/summary-next-steps.jsx
@@ -17,12 +17,12 @@ import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getJetpackOnboardingSettings } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
-const NextSteps = ( { handleNextStepClick, siteId, steps } ) => (
+const NextSteps = ( { handleSummaryStepClick, siteId, steps } ) => (
 	<Fragment>
 		<QuerySites siteId={ siteId } />
 		{ map( steps, ( { label, url }, stepName ) => (
 			<div key={ stepName } className="jetpack-onboarding__summary-entry todo">
-				<a href={ url } onClick={ handleNextStepClick( stepName ) }>
+				<a href={ url } onClick={ handleSummaryStepClick( stepName, 'next' ) }>
 					{ label }
 				</a>
 			</div>
@@ -31,11 +31,11 @@ const NextSteps = ( { handleNextStepClick, siteId, steps } ) => (
 );
 
 NextSteps.propTypes = {
-	handleNextStepClick: PropTypes.func,
+	handleSummaryStepClick: PropTypes.func,
 };
 
 NextSteps.defaultProps = {
-	handleNextStepClick: noop,
+	handleSummaryStepClick: noop,
 };
 
 export default localize(


### PR DESCRIPTION
Implements the changes I suggested at https://github.com/Automattic/wp-calypso/pull/22320#discussion_r167610963:

> What about using only _one_ handler and event, and passing `completed` or `next` as `stepType`? [...]

This PR also renames the `handle...StepClick` _props_ of the `<CompletedSteps />` and `<NextSteps />` components to `onClick`, since that seems more intuitive and permissive for the prop name. (`<Summary>`'s _method_ that we pass as that prop is still called `handleSummaryStepClick`, because context.) 

Furthermore, I'm renaming the event to include `_link_`, i.e. `calypso_jpo_summary_step_link_clicked`. Happy to discuss if you feel that's not a good idea.

The `step` argument passed to the event is currently somewhat inconsistent for completed vs next steps, since the latter use uppercase object keys. I've filed #22399 to address that.

**To test:**
- use localStorage.debug = 'calypso:analytics:tracks' to confirm that a relevant event `calypso_jpo_summary_step_clicked` or fires with the `step` arg set to the correct step name, and `type` correctly set to either `completed` or `next`, respectively.
