### PR TITLE
JP Onboarding: Lowercase Summary Next Steps object keys

### DIFF
--- a/client/jetpack-onboarding/summary-next-steps.jsx
+++ b/client/jetpack-onboarding/summary-next-steps.jsx
@@ -56,15 +56,15 @@ export default localize(
 		if ( isConnected ) {
 			return {
 				steps: {
-					THEME: {
+					theme: {
 						label: translate( 'Choose a Theme' ),
 						url: '/themes/' + siteSlug,
 					},
-					PAGES: {
+					pages: {
 						label: translate( 'Add additional pages' ),
 						url: getEditorNewPostPath( state, siteId, 'page' ),
 					},
-					BLOG: {
+					blog: {
 						label: translate( 'Write your first blog post' ),
 						url: getEditorNewPostPath( state, siteId, 'post' ),
 					},
@@ -75,19 +75,19 @@ export default localize(
 
 		return {
 			steps: {
-				JETPACK_CONNECTION: {
+				jetpack_connection: {
 					label: translate( 'Connect to WordPress.com' ),
 					url: '/jetpack/connect?url=' + siteUrl,
 				},
-				THEME: {
+				theme: {
 					label: translate( 'Choose a Theme' ),
 					url: siteUrl + '/wp-admin/theme-install.php?browse=featured',
 				},
-				PAGES: {
+				pages: {
 					label: translate( 'Add additional pages' ),
 					url: siteUrl + '/wp-admin/post-new.php?post_type=page',
 				},
-				BLOG: {
+				blog: {
 					label: translate( 'Write your first blog post' ),
 					url: siteUrl + '/wp-admin/post-new.php',
 				},

--- a/client/jetpack-onboarding/summary-next-steps.jsx
+++ b/client/jetpack-onboarding/summary-next-steps.jsx
@@ -75,7 +75,7 @@ export default localize(
 
 		return {
 			steps: {
-				jetpack_connection: {
+				'jetpack-connect': {
 					label: translate( 'Connect to WordPress.com' ),
 					url: '/jetpack/connect?url=' + siteUrl,
 				},


### PR DESCRIPTION
These are actual strings (not referring any constants defined elsewhere). They're used e.g. for events tracking, where they feel inconsistent e.g. with the lowercase completed steps names -- see #22398:

> The `step` argument passed to the event is currently somewhat inconsistent for completed vs next steps, since the latter use uppercase object keys.

To test:
* Verify that the JPO summary page still works as before
* and that the events fired clicking on any of the 'Next Steps' links include lowercase step names (e.g. `theme`, `page`, `post`, `jetpack_connection`).

Should we change `jetpack_connection` to `jetpack-connect` (dash instead of underscore, no `...ion`) while we're at it?