### PR TITLE
Jetpack remote install: Add reducers

### DIFF
--- a/client/state/index.js
+++ b/client/state/index.js
@@ -47,6 +47,7 @@ import inlineHelpSearchResults from './inline-help/reducer';
 import jetpackConnect from './jetpack-connect/reducer';
 import jetpackOnboarding from './jetpack-onboarding/reducer';
 import jetpack from './jetpack/reducer';
+import jetpackRemoteInstall from './jetpack-remote-install/reducer';
 import jetpackSync from './jetpack-sync/reducer';
 import jitm from './jitm/reducer';
 import happinessEngineers from './happiness-engineers/reducer';
@@ -134,6 +135,7 @@ const reducers = {
 	jetpackConnect,
 	jetpackOnboarding,
 	jetpack,
+	jetpackRemoteInstall,
 	jetpackSync,
 	jitm,
 	login,

--- a/client/state/jetpack-remote-install/reducer.js
+++ b/client/state/jetpack-remote-install/reducer.js
@@ -1,0 +1,33 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { createReducer, combineReducers, keyedReducer } from 'state/utils';
+import {
+	JETPACK_REMOTE_INSTALL,
+	JETPACK_REMOTE_INSTALL_FAILURE,
+	JETPACK_REMOTE_INSTALL_SUCCESS,
+} from 'state/action-types';
+
+export const isComplete = keyedReducer(
+	'url',
+	createReducer( false, {
+		[ JETPACK_REMOTE_INSTALL_SUCCESS ]: () => true,
+		[ JETPACK_REMOTE_INSTALL ]: () => false,
+	} )
+);
+
+export const error = keyedReducer(
+	'url',
+	createReducer( '', {
+		[ JETPACK_REMOTE_INSTALL_FAILURE ]: ( state, { errorCode } ) => errorCode,
+		[ JETPACK_REMOTE_INSTALL_SUCCESS ]: () => '',
+		[ JETPACK_REMOTE_INSTALL ]: () => '',
+	} )
+);
+
+export default combineReducers( {
+	isComplete,
+	error,
+} );

--- a/client/state/jetpack-remote-install/reducer.js
+++ b/client/state/jetpack-remote-install/reducer.js
@@ -3,29 +3,35 @@
 /**
  * Internal dependencies
  */
-import { createReducer, combineReducers, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer } from 'state/utils';
 import {
 	JETPACK_REMOTE_INSTALL,
 	JETPACK_REMOTE_INSTALL_FAILURE,
 	JETPACK_REMOTE_INSTALL_SUCCESS,
 } from 'state/action-types';
 
-export const isComplete = keyedReducer(
-	'url',
-	createReducer( false, {
-		[ JETPACK_REMOTE_INSTALL_SUCCESS ]: () => true,
-		[ JETPACK_REMOTE_INSTALL ]: () => false,
-	} )
-);
+export const isComplete = keyedReducer( 'url', ( state = false, { type } ) => {
+	switch ( type ) {
+		case JETPACK_REMOTE_INSTALL_SUCCESS:
+			return true;
+		case JETPACK_REMOTE_INSTALL:
+			return false;
+		default:
+			return state;
+	}
+} );
 
-export const error = keyedReducer(
-	'url',
-	createReducer( null, {
-		[ JETPACK_REMOTE_INSTALL_FAILURE ]: ( state, { errorCode } ) => errorCode,
-		[ JETPACK_REMOTE_INSTALL_SUCCESS ]: () => null,
-		[ JETPACK_REMOTE_INSTALL ]: () => null,
-	} )
-);
+export const error = keyedReducer( 'url', ( state = null, { type, errorCode } ) => {
+	switch ( type ) {
+		case JETPACK_REMOTE_INSTALL_FAILURE:
+			return errorCode;
+		case JETPACK_REMOTE_INSTALL_SUCCESS:
+		case JETPACK_REMOTE_INSTALL:
+			return null;
+		default:
+			return state;
+	}
+} );
 
 export default combineReducers( {
 	error,

--- a/client/state/jetpack-remote-install/reducer.js
+++ b/client/state/jetpack-remote-install/reducer.js
@@ -18,15 +18,6 @@ export const isComplete = keyedReducer(
 	} )
 );
 
-export const inProgress = keyedReducer(
-	'url',
-	createReducer( false, {
-		[ JETPACK_REMOTE_INSTALL ]: () => true,
-		[ JETPACK_REMOTE_INSTALL_SUCCESS ]: () => false,
-		[ JETPACK_REMOTE_INSTALL_FAILURE ]: () => false,
-	} )
-);
-
 export const error = keyedReducer(
 	'url',
 	createReducer( null, {
@@ -38,6 +29,5 @@ export const error = keyedReducer(
 
 export default combineReducers( {
 	error,
-	inProgress,
 	isComplete,
 } );

--- a/client/state/jetpack-remote-install/reducer.js
+++ b/client/state/jetpack-remote-install/reducer.js
@@ -29,10 +29,10 @@ export const inProgress = keyedReducer(
 
 export const error = keyedReducer(
 	'url',
-	createReducer( '', {
+	createReducer( null, {
 		[ JETPACK_REMOTE_INSTALL_FAILURE ]: ( state, { errorCode } ) => errorCode,
-		[ JETPACK_REMOTE_INSTALL_SUCCESS ]: () => '',
-		[ JETPACK_REMOTE_INSTALL ]: () => '',
+		[ JETPACK_REMOTE_INSTALL_SUCCESS ]: () => null,
+		[ JETPACK_REMOTE_INSTALL ]: () => null,
 	} )
 );
 

--- a/client/state/jetpack-remote-install/reducer.js
+++ b/client/state/jetpack-remote-install/reducer.js
@@ -18,6 +18,15 @@ export const isComplete = keyedReducer(
 	} )
 );
 
+export const inProgress = keyedReducer(
+	'url',
+	createReducer( false, {
+		[ JETPACK_REMOTE_INSTALL ]: () => true,
+		[ JETPACK_REMOTE_INSTALL_SUCCESS ]: () => false,
+		[ JETPACK_REMOTE_INSTALL_FAILURE ]: () => false,
+	} )
+);
+
 export const error = keyedReducer(
 	'url',
 	createReducer( '', {
@@ -28,6 +37,7 @@ export const error = keyedReducer(
 );
 
 export default combineReducers( {
-	isComplete,
 	error,
+	inProgress,
+	isComplete,
 } );

--- a/client/state/jetpack-remote-install/test/reducer.js
+++ b/client/state/jetpack-remote-install/test/reducer.js
@@ -1,0 +1,62 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import reducer, { error, isComplete } from '../reducer';
+import {
+	jetpackRemoteInstall,
+	jetpackRemoteInstallComplete,
+	jetpackRemoteInstallUpdateError,
+} from '../actions';
+
+const url = 'https://yourgroovydomain.com';
+const errorCode = 'INVALID_CREDENTIALS';
+
+describe( 'reducer', () => {
+	test( 'should export expected reducer keys', () => {
+		const state = reducer( undefined, {} );
+
+		expect( state ).toHaveProperty( 'isComplete' );
+		expect( state ).toHaveProperty( 'error' );
+	} );
+
+	describe( 'isComplete', () => {
+		test( 'should store install complete by url', () => {
+			const state = isComplete( undefined, jetpackRemoteInstallComplete( url ) );
+			expect( state[ url ] ).toBe( true );
+		} );
+
+		test( 'should be cleared on install request', () => {
+			const initialState = {
+				[ url ]: {
+					isComplete: true,
+				},
+			};
+			const state = isComplete( initialState, jetpackRemoteInstall( url ) );
+			expect( state[ url ] ).toBeFalsy();
+		} );
+	} );
+
+	describe( 'error', () => {
+		const errorState = {
+			[ url ]: {
+				error: errorCode,
+			},
+		};
+
+		test( 'should store error by url', () => {
+			const state = error( undefined, jetpackRemoteInstallUpdateError( url, errorCode ) );
+			expect( state[ url ] ).toEqual( errorCode );
+		} );
+
+		test( 'should be cleared on successful install', () => {
+			const state = error( errorState, jetpackRemoteInstallComplete( url ) );
+			expect( state[ url ] ).toBeFalsy();
+		} );
+
+		test( 'should be cleared on install request', () => {
+			const state = error( errorState, jetpackRemoteInstall( url ) );
+			expect( state[ url ] ).toBeFalsy();
+		} );
+	} );
+} );

--- a/client/state/jetpack-remote-install/test/reducer.js
+++ b/client/state/jetpack-remote-install/test/reducer.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import reducer, { error, inProgress, isComplete } from '../reducer';
+import reducer, { error, isComplete } from '../reducer';
 import {
 	jetpackRemoteInstall,
 	jetpackRemoteInstallComplete,
@@ -17,7 +17,6 @@ describe( 'reducer', () => {
 		const state = reducer( undefined, {} );
 
 		expect( state ).toHaveProperty( 'isComplete' );
-		expect( state ).toHaveProperty( 'inProgress' );
 		expect( state ).toHaveProperty( 'error' );
 	} );
 
@@ -34,32 +33,6 @@ describe( 'reducer', () => {
 				},
 			};
 			const state = isComplete( initialState, jetpackRemoteInstall( url ) );
-			expect( state[ url ] ).not.toBeDefined();
-		} );
-	} );
-
-	describe( 'inProgress', () => {
-		const inProgressState = {
-			[ url ]: {
-				inProgress: true,
-			},
-		};
-
-		test( 'should be set on install request', () => {
-			const state = inProgress( undefined, jetpackRemoteInstall( url ) );
-			expect( state[ url ] ).toBe( true );
-		} );
-
-		test( 'should be cleared on install success', () => {
-			const state = inProgress( inProgressState, jetpackRemoteInstallComplete( url ) );
-			expect( state[ url ] ).not.toBeDefined();
-		} );
-
-		test( 'should be cleared on install error', () => {
-			const state = inProgress(
-				inProgressState,
-				jetpackRemoteInstallUpdateError( url, errorCode )
-			);
 			expect( state[ url ] ).not.toBeDefined();
 		} );
 	} );

--- a/client/state/jetpack-remote-install/test/reducer.js
+++ b/client/state/jetpack-remote-install/test/reducer.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import reducer, { error, isComplete } from '../reducer';
+import reducer, { error, inProgress, isComplete } from '../reducer';
 import {
 	jetpackRemoteInstall,
 	jetpackRemoteInstallComplete,
@@ -17,6 +17,7 @@ describe( 'reducer', () => {
 		const state = reducer( undefined, {} );
 
 		expect( state ).toHaveProperty( 'isComplete' );
+		expect( state ).toHaveProperty( 'inProgress' );
 		expect( state ).toHaveProperty( 'error' );
 	} );
 
@@ -33,6 +34,32 @@ describe( 'reducer', () => {
 				},
 			};
 			const state = isComplete( initialState, jetpackRemoteInstall( url ) );
+			expect( state[ url ] ).toBeFalsy();
+		} );
+	} );
+
+	describe( 'inProgress', () => {
+		const inProgressState = {
+			[ url ]: {
+				inProgress: true,
+			},
+		};
+
+		test( 'should be set on install request', () => {
+			const state = inProgress( undefined, jetpackRemoteInstall( url ) );
+			expect( state[ url ] ).toBeTruthy();
+		} );
+
+		test( 'should be cleared on install success', () => {
+			const state = inProgress( inProgressState, jetpackRemoteInstallComplete( url ) );
+			expect( state[ url ] ).toBeFalsy();
+		} );
+
+		test( 'should be cleared on install error', () => {
+			const state = inProgress(
+				inProgressState,
+				jetpackRemoteInstallUpdateError( url, errorCode )
+			);
 			expect( state[ url ] ).toBeFalsy();
 		} );
 	} );

--- a/client/state/jetpack-remote-install/test/reducer.js
+++ b/client/state/jetpack-remote-install/test/reducer.js
@@ -4,10 +4,10 @@
  */
 import reducer, { error, isComplete } from '../reducer';
 import {
-	jetpackRemoteInstall,
-	jetpackRemoteInstallComplete,
-	jetpackRemoteInstallUpdateError,
-} from '../actions';
+	JETPACK_REMOTE_INSTALL,
+	JETPACK_REMOTE_INSTALL_FAILURE,
+	JETPACK_REMOTE_INSTALL_SUCCESS,
+} from 'state/action-types';
 
 const url = 'https://yourgroovydomain.com';
 const errorCode = 'INVALID_CREDENTIALS';
@@ -22,7 +22,7 @@ describe( 'reducer', () => {
 
 	describe( 'isComplete', () => {
 		test( 'should store install complete by url', () => {
-			const state = isComplete( undefined, jetpackRemoteInstallComplete( url ) );
+			const state = isComplete( undefined, { type: JETPACK_REMOTE_INSTALL_SUCCESS, url } );
 			expect( state[ url ] ).toBe( true );
 		} );
 
@@ -32,7 +32,7 @@ describe( 'reducer', () => {
 					isComplete: true,
 				},
 			};
-			const state = isComplete( initialState, jetpackRemoteInstall( url ) );
+			const state = isComplete( initialState, { type: JETPACK_REMOTE_INSTALL, url } );
 			expect( state[ url ] ).not.toBeDefined();
 		} );
 	} );
@@ -45,17 +45,17 @@ describe( 'reducer', () => {
 		};
 
 		test( 'should store error by url', () => {
-			const state = error( undefined, jetpackRemoteInstallUpdateError( url, errorCode ) );
+			const state = error( undefined, { type: JETPACK_REMOTE_INSTALL_FAILURE, url, errorCode } );
 			expect( state[ url ] ).toEqual( errorCode );
 		} );
 
 		test( 'should be cleared on successful install', () => {
-			const state = error( errorState, jetpackRemoteInstallComplete( url ) );
+			const state = error( errorState, { type: JETPACK_REMOTE_INSTALL_SUCCESS, url } );
 			expect( state[ url ] ).not.toBeDefined();
 		} );
 
 		test( 'should be cleared on install request', () => {
-			const state = error( errorState, jetpackRemoteInstall( url ) );
+			const state = error( errorState, { type: JETPACK_REMOTE_INSTALL, url } );
 			expect( state[ url ] ).not.toBeDefined();
 		} );
 	} );

--- a/client/state/jetpack-remote-install/test/reducer.js
+++ b/client/state/jetpack-remote-install/test/reducer.js
@@ -34,7 +34,7 @@ describe( 'reducer', () => {
 				},
 			};
 			const state = isComplete( initialState, jetpackRemoteInstall( url ) );
-			expect( state[ url ] ).toBeFalsy();
+			expect( state[ url ] ).not.toBeDefined();
 		} );
 	} );
 
@@ -47,12 +47,12 @@ describe( 'reducer', () => {
 
 		test( 'should be set on install request', () => {
 			const state = inProgress( undefined, jetpackRemoteInstall( url ) );
-			expect( state[ url ] ).toBeTruthy();
+			expect( state[ url ] ).toBe( true );
 		} );
 
 		test( 'should be cleared on install success', () => {
 			const state = inProgress( inProgressState, jetpackRemoteInstallComplete( url ) );
-			expect( state[ url ] ).toBeFalsy();
+			expect( state[ url ] ).not.toBeDefined();
 		} );
 
 		test( 'should be cleared on install error', () => {
@@ -60,7 +60,7 @@ describe( 'reducer', () => {
 				inProgressState,
 				jetpackRemoteInstallUpdateError( url, errorCode )
 			);
-			expect( state[ url ] ).toBeFalsy();
+			expect( state[ url ] ).not.toBeDefined();
 		} );
 	} );
 
@@ -78,12 +78,12 @@ describe( 'reducer', () => {
 
 		test( 'should be cleared on successful install', () => {
 			const state = error( errorState, jetpackRemoteInstallComplete( url ) );
-			expect( state[ url ] ).toBeFalsy();
+			expect( state[ url ] ).not.toBeDefined();
 		} );
 
 		test( 'should be cleared on install request', () => {
 			const state = error( errorState, jetpackRemoteInstall( url ) );
-			expect( state[ url ] ).toBeFalsy();
+			expect( state[ url ] ).not.toBeDefined();
 		} );
 	} );
 } );


### PR DESCRIPTION
Adds redux state for tracking installation of the jetpack plugin on .org sites via the new endpoint being added in D10065-code. This is a new part of the jetpack connect process for sites that do not yet have the Jetpack plugin installed. This PR builds on the actions and data-layer handlers added in #22295.

For wider context, see p7rd6c-1dS-p2.


Anticipating that we'll have 4 possible UI states:
1) Credentials entry form
2) Install in progress
3) Install completed successfully
4) Error encountered

The in-progress state can be determined by using the data-layer `getRequest()` selector, so these new reducers need to cover the three other UI states:

```
UI State         ||          Redux State
                 || isComplete | error
=====================================================
entry form       || 0          | 0
-----------------------------------------------------
finished success || 1          |
-----------------------------------------------------
finished error   ||            | 1
-----------------------------------------------------
```

We may need to change these assumptions as the design becomes clearer.

## Testing
* The new unit tests are run automatically as part of this PR

