### PR TITLE
Enable overriding backend A/B variations in non-production environments

### DIFF
--- a/client/lib/e2e/index.js
+++ b/client/lib/e2e/index.js
@@ -1,0 +1,6 @@
+// All end-to-end tests use a custom user agent containing this string.
+export const E2E_USER_AGENT = 'wp-e2e-tests';
+
+export function isE2ETest() {
+	return new RegExp( E2E_USER_AGENT ).test( navigator.userAgent );
+}

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -178,7 +178,19 @@ User.prototype.handleFetchSuccess = function( userData ) {
 	// Store user info in `this.data` and localstorage as `wpcom_user`
 	store.set( 'wpcom_user', userData );
 	if ( userData.abtests ) {
-		store.set( ABTEST_LOCALSTORAGE_KEY, userData.abtests );
+		if ( config.isEnabled( 'dev/test-helper' ) ) {
+			// Preserve existing localStorage A/B variation values for
+			// A/B test helper component.
+			const initialVariationsFromStore = store.get( ABTEST_LOCALSTORAGE_KEY );
+			const initialVariations =
+				typeof initialVariationsFromStore === 'object' ? initialVariationsFromStore : undefined;
+			store.set( ABTEST_LOCALSTORAGE_KEY, {
+				...userData.abtests,
+				...initialVariations,
+			} );
+		} else {
+			store.set( ABTEST_LOCALSTORAGE_KEY, userData.abtests );
+		}
 	}
 	this.data = userData;
 	if ( this.settings ) {

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -17,6 +17,7 @@ import qs from 'qs';
 import { isSupportUserSession, boot as supportUserBoot } from 'lib/user/support-user-interop';
 import wpcom from 'lib/wp';
 import Emitter from 'lib/mixins/emitter';
+import { isE2ETest } from 'lib/e2e';
 import { getComputedAttributes, filterUserObject } from './shared-utils';
 import localforage from 'lib/localforage';
 import { getActiveTestNames, ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
@@ -178,9 +179,9 @@ User.prototype.handleFetchSuccess = function( userData ) {
 	// Store user info in `this.data` and localstorage as `wpcom_user`
 	store.set( 'wpcom_user', userData );
 	if ( userData.abtests ) {
-		if ( config.isEnabled( 'dev/test-helper' ) ) {
-			// Preserve existing localStorage A/B variation values for
-			// A/B test helper component.
+		if ( config.isEnabled( 'dev/test-helper' ) || isE2ETest() ) {
+			// This section will preserve the existing localStorage A/B variation values,
+			// This is necessary for the A/B test helper component and e2e tests..
 			const initialVariationsFromStore = store.get( ABTEST_LOCALSTORAGE_KEY );
 			const initialVariations =
 				typeof initialVariationsFromStore === 'object' ? initialVariationsFromStore : undefined;


### PR DESCRIPTION
This change fixes A/B Test Helper component's functionality by preserving localStorage data for A/B tests when the `dev/test-helper` flag is enabled. 

(This flag is enabled only for development and wpcalypso environments.)

#### Testing instructions

1) Spin up this branch locally and start your server.
2) Locate the A/B test helper and manually select a variation for any of the A/B tests.
![a_b_test_helper](https://user-images.githubusercontent.com/4044428/36170341-5186b066-10bc-11e8-81ea-1ef32b807551.png)
3) Ensure that your selected variation from (2) has persisted following the page refresh caused by the variation selection.
