### PR TITLE
Domains: Allow NUX Transfers for all users

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -18,15 +18,12 @@ import { endsWith, get, includes, times } from 'lodash';
  */
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
 import DomainTransferSuggestion from 'components/domains/domain-transfer-suggestion';
-import DomainMappingSuggestion from 'components/domains/domain-mapping-suggestion';
 import DomainSuggestion from 'components/domains/domain-suggestion';
 import { isNextDomainFree } from 'lib/cart-values/cart-items';
 import Notice from 'components/notice';
 import Card from 'components/card';
 import { getTld } from 'lib/domains';
 import { domainAvailability } from 'lib/domains/constants';
-import { currentUserHasFlag } from 'state/current-user/selectors';
-import { TRANSFER_IN_NUX } from 'state/current-user/constants';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import { abtest } from 'lib/abtest';
@@ -139,12 +136,9 @@ class DomainSearchResults extends React.Component {
 						args: { domain },
 						components: { strong: <strong /> },
 					} );
+
 			if ( this.props.offerUnavailableOption ) {
-				if (
-					this.props.siteDesignType !== DESIGN_TYPE_STORE &&
-					( ! this.props.isSignupStep || this.props.transferInNuxAllowed ) &&
-					lastDomainIsTransferrable
-				) {
+				if ( this.props.siteDesignType !== DESIGN_TYPE_STORE && lastDomainIsTransferrable ) {
 					availabilityElement = (
 						<Card className="domain-search-results__transfer-card" highlight="info">
 							<div className="domain-search-results__transfer-card-copy">
@@ -231,24 +225,11 @@ class DomainSearchResults extends React.Component {
 
 			if ( this.props.offerUnavailableOption && this.props.siteDesignType !== DESIGN_TYPE_STORE ) {
 				unavailableOffer = (
-					<DomainMappingSuggestion
-						onButtonClick={ this.props.onClickMapping }
-						products={ this.props.products }
-						selectedSite={ this.props.selectedSite }
-						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						isSignupStep={ this.props.isSignupStep }
-						cart={ this.props.cart }
+					<DomainTransferSuggestion
+						onButtonClick={ this.props.onClickTransfer }
+						tracksButtonClickSource="search-suggestions-bottom"
 					/>
 				);
-
-				if ( ! this.props.isSignupStep || this.props.transferInNuxAllowed ) {
-					unavailableOffer = (
-						<DomainTransferSuggestion
-							onButtonClick={ this.props.onClickTransfer }
-							tracksButtonClickSource="search-suggestions-bottom"
-						/>
-					);
-				}
 			}
 		} else {
 			suggestionElements = this.renderPlaceholders();
@@ -276,7 +257,6 @@ const mapStateToProps = state => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
 		isSiteOnPaidPlan: isSiteOnPaidPlan( state, selectedSiteId ),
-		transferInNuxAllowed: currentUserHasFlag( state, TRANSFER_IN_NUX ),
 		siteDesignType: getDesignType( state ),
 	};
 };

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -35,12 +35,11 @@ import { domainAvailability } from 'lib/domains/constants';
 import { getAvailabilityNotice } from 'lib/domains/registration/availability-messages';
 import SearchCard from 'components/search-card';
 import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
-import DomainMappingSuggestion from 'components/domains/domain-mapping-suggestion';
 import DomainTransferSuggestion from 'components/domains/domain-transfer-suggestion';
 import DomainSuggestion from 'components/domains/domain-suggestion';
 import DomainSearchResults from 'components/domains/domain-search-results';
 import ExampleDomainSuggestions from 'components/domains/example-domain-suggestions';
-import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
 import {
@@ -48,7 +47,6 @@ import {
 	getDomainsSuggestionsError,
 } from 'state/domains/suggestions/selectors';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
-import { TRANSFER_IN_NUX } from 'state/current-user/constants';
 import { abtest } from 'lib/abtest';
 
 const domains = wpcom.domains();
@@ -636,24 +634,11 @@ class RegisterDomainStep extends React.Component {
 			}, this );
 
 			domainUnavailableSuggestion = (
-				<DomainMappingSuggestion
-					isSignupStep={ this.props.isSignupStep }
-					onButtonClick={ this.goToMapDomainStep }
-					selectedSite={ this.props.selectedSite }
-					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-					cart={ this.props.cart }
-					products={ this.props.products }
+				<DomainTransferSuggestion
+					onButtonClick={ this.goToTransferDomainStep }
+					tracksButtonClickSource="initial-suggestions-bottom"
 				/>
 			);
-
-			if ( ! this.props.isSignupStep || this.props.transferInNuxAllowed ) {
-				domainUnavailableSuggestion = (
-					<DomainTransferSuggestion
-						onButtonClick={ this.goToTransferDomainStep }
-						tracksButtonClickSource="initial-suggestions-bottom"
-					/>
-				);
-			}
 		}
 
 		return (
@@ -668,15 +653,10 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	getExampleSuggestions() {
-		const alreadyOwnUrl =
-			! this.props.isSignupStep || this.props.transferInNuxAllowed
-				? this.getTransferDomainUrl()
-				: this.getMapDomainUrl();
-
 		return (
 			<ExampleDomainSuggestions
 				onClickExampleSuggestion={ this.handleClickExampleSuggestion }
-				url={ alreadyOwnUrl }
+				url={ this.getTransferDomainUrl() }
 				path={ this.props.path }
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 				products={ this.props.products }
@@ -895,7 +875,6 @@ export default connect(
 			currentUser: getCurrentUser( state ),
 			defaultSuggestions: getDomainsSuggestions( state, queryObject ),
 			defaultSuggestionsError: getDomainsSuggestionsError( state, queryObject ),
-			transferInNuxAllowed: currentUserHasFlag( state, TRANSFER_IN_NUX ),
 		};
 	},
 	{

--- a/client/state/current-user/constants.js
+++ b/client/state/current-user/constants.js
@@ -1,4 +1,3 @@
 /** @format */
 
 export const DOMAINS_WITH_PLANS_ONLY = 'calypso_domains_with_plans_only';
-export const TRANSFER_IN_NUX = 'calypso_transfer_in_nux';


### PR DESCRIPTION
Remove NUX Transfer flag and remove non transfer options.
Before, we allowed the flow only for registered users that are a12s.