### PR TITLE
Change withSchemaValidation to call the wrapped reducer on DESERIALIZE

### DIFF
--- a/client/state/activity-log/log/reducer.js
+++ b/client/state/activity-log/log/reducer.js
@@ -5,26 +5,27 @@
  */
 import ActivityQueryManager from 'lib/query-manager/activity';
 import { ACTIVITY_LOG_UPDATE, DESERIALIZE, SERIALIZE } from 'state/action-types';
-import { isValidStateWithSchema, keyedReducer } from 'state/utils';
+import { withSchemaValidation, keyedReducer } from 'state/utils';
 import { logItemsSchema } from './schema';
 
-export const logItem = ( state = undefined, { type, data, found, query } ) => {
-	switch ( type ) {
-		case ACTIVITY_LOG_UPDATE:
-			return ( state || new ActivityQueryManager() ).receive( data, { found, query } );
+export const logItem = withSchemaValidation(
+	logItemsSchema,
+	( state = new ActivityQueryManager(), { type, data, found, query } ) => {
+		switch ( type ) {
+			case ACTIVITY_LOG_UPDATE:
+				return state.receive( data, { found, query } );
 
-		case DESERIALIZE:
-			return isValidStateWithSchema( state, logItemsSchema )
-				? new ActivityQueryManager( state.data, state.options )
-				: undefined;
+			case DESERIALIZE:
+				return new ActivityQueryManager( state.data, state.options );
 
-		case SERIALIZE:
-			return { data: state.data, options: state.options };
+			case SERIALIZE:
+				return { data: state.data, options: state.options };
 
-		default:
-			return state;
+			default:
+				return state;
+		}
 	}
-};
+);
 
 export const logItems = keyedReducer( 'siteId', logItem );
 logItems.hasCustomPersistence = true;

--- a/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
+++ b/client/state/jetpack-connect/reducer/jetpack-connect-authorize.js
@@ -8,7 +8,7 @@ import { get, isEmpty, omit } from 'lodash';
  * Internal dependencies
  */
 import { isStale } from '../utils';
-import { isValidStateWithSchema } from 'state/utils';
+import { withSchemaValidation } from 'state/utils';
 import { JETPACK_CONNECT_AUTHORIZE_TTL } from '../constants';
 import { jetpackConnectAuthorizeSchema } from './schema';
 import {
@@ -22,11 +22,10 @@ import {
 	JETPACK_CONNECT_CREATE_ACCOUNT_RECEIVE,
 	JETPACK_CONNECT_QUERY_SET,
 	JETPACK_CONNECT_USER_ALREADY_CONNECTED,
-	SERIALIZE,
 	SITE_REQUEST_FAILURE,
 } from 'state/action-types';
 
-export default function jetpackConnectAuthorize( state = {}, action ) {
+function jetpackConnectAuthorize( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_AUTHORIZE:
 			return Object.assign( omit( state, 'userData', 'bearerToken' ), {
@@ -106,16 +105,14 @@ export default function jetpackConnectAuthorize( state = {}, action ) {
 			return {};
 
 		case DESERIALIZE:
-			return isValidStateWithSchema( state, jetpackConnectAuthorizeSchema ) &&
-				! isStale( state.timestamp, JETPACK_CONNECT_AUTHORIZE_TTL )
-				? state
-				: {};
+			if ( isStale( state.timestamp, JETPACK_CONNECT_AUTHORIZE_TTL ) ) {
+				return {};
+			}
+			return state;
 
-		case SERIALIZE:
+		default:
 			return state;
 	}
-
-	return state;
 }
 
-jetpackConnectAuthorize.hasCustomPersistence = true;
+export default withSchemaValidation( jetpackConnectAuthorizeSchema, jetpackConnectAuthorize );

--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -10,7 +10,7 @@ import { omit } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, isValidStateWithSchema } from 'state/utils';
+import { combineReducers } from 'state/utils';
 import { settingsSchema, systemSchema } from './schema';
 
 import {
@@ -32,23 +32,11 @@ const UNPERSISTED_SYSTEM_NODES = [ 'apiReady', 'authorized', 'authorizationLoade
 function system( state = {}, action ) {
 	switch ( action.type ) {
 		// System state is not persisted
-		case DESERIALIZE: {
-			const newState = omit( state, UNPERSISTED_SYSTEM_NODES );
-			if ( isValidStateWithSchema( newState, systemSchema ) ) {
-				return newState;
-			}
-			debug( 'INVALID system state during DESERIALIZE', newState );
-			return {};
-		}
+		case DESERIALIZE:
+			return omit( state, UNPERSISTED_SYSTEM_NODES );
 
-		case SERIALIZE: {
-			const newState = omit( state, UNPERSISTED_SYSTEM_NODES );
-			if ( isValidStateWithSchema( newState, systemSchema ) ) {
-				return newState;
-			}
-			debug( 'INVALID system state during SERIALIZE', newState );
-			return {};
-		}
+		case SERIALIZE:
+			return omit( state, UNPERSISTED_SYSTEM_NODES );
 
 		case PUSH_NOTIFICATIONS_API_READY: {
 			debug( 'API is ready' );
@@ -110,7 +98,7 @@ function system( state = {}, action ) {
 
 	return state;
 }
-system.hasCustomPersistence = true;
+system.schema = systemSchema;
 
 // If you change this, also change the corresponding test
 const UNPERSISTED_SETTINGS_NODES = [
@@ -118,28 +106,14 @@ const UNPERSISTED_SETTINGS_NODES = [
 	'showingUnblockInstructions',
 ];
 
-function settings( state = {}, action ) {
+function settings( state = { enabled: false }, action ) {
 	switch ( action.type ) {
 		case DESERIALIZE: {
-			const newState = omit( state, UNPERSISTED_SETTINGS_NODES );
-			if ( isValidStateWithSchema( newState, settingsSchema ) ) {
-				return newState;
-			}
-			debug( 'INVALID settings state during DESERIALIZE', newState );
-			return {
-				enabled: false,
-			};
+			return omit( state, UNPERSISTED_SETTINGS_NODES );
 		}
 
 		case SERIALIZE: {
-			const newState = omit( state, UNPERSISTED_SETTINGS_NODES );
-			if ( isValidStateWithSchema( newState, settingsSchema ) ) {
-				return newState;
-			}
-			debug( 'INVALID settings state during SERIALIZE', newState );
-			return {
-				enabled: false,
-			};
+			return omit( state, UNPERSISTED_SETTINGS_NODES );
 		}
 
 		case PUSH_NOTIFICATIONS_TOGGLE_ENABLED: {
@@ -163,7 +137,7 @@ function settings( state = {}, action ) {
 
 	return state;
 }
-settings.hasCustomPersistence = true;
+settings.schema = settingsSchema;
 
 export default combineReducers( {
 	settings,

--- a/client/state/reader/streams/test/reducer.js
+++ b/client/state/reader/streams/test/reducer.js
@@ -70,7 +70,7 @@ describe( 'streams combined reducer', () => {
 	const loadAction = { type: DESERIALIZE };
 
 	const validState = deepfreeze( {
-		items: { following: [], 'feed:123': [ {}, {} ] },
+		items: { following: [ {} ], 'feed:123': [ {}, {} ] },
 		selected: { following: 0, 'feed:123': 42, elmo: 'is red' },
 	} );
 

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -154,7 +154,7 @@ export const keyedReducer = ( keyPath, reducer, globalActions = [ SERIALIZE, DES
 		if ( globalActions && includes( globalActions, action.type ) ) {
 			return omitBy(
 				mapValues( state, item => reducer( item, action ) ),
-				a => a === undefined || a === initialState
+				a => a === undefined || isEqual( a, initialState )
 			);
 		}
 
@@ -348,7 +348,7 @@ export const withSchemaValidation = ( schema, reducer ) => {
 			}
 
 			return state && isValidStateWithSchema( state, schema )
-				? state
+				? reducer( state, action )
 				: reducer( undefined, { type: '@@calypso/INIT' } );
 		}
 


### PR DESCRIPTION
After `withSchemaValidation` successfully validates schema of the deserialized
object, call the wrapped reducer instead of immediately returning `state`. This
lets the wrapped reducer continue with other validation and deserialization.
And allows nice composition of the reducer functions.

There are a few additional commits that refactor several reducers to use this new capability. And another batch of schema validations gets moved to the framework from the individual reducers.

To make all tests pass, a little change to `keyedReducer` is needed, too: it's an
established behavior of `keyedReducer` that it doesn't keep sub-key values that
are equal to initial state. See the `isEqual( newItemState, initialState )` check
in its code. I patch the `keyedReducer` here to do exactly the same thing when
handling a global action, too, changing an `===` check to `isEqual`. Strict identity
check detects the initial state only very rarely, because of the common form where
reducer is written as `( state = {}, action ) => ...` -- the `{}` object has a
different identity on every call.

If the reviewer wishes to understand better why the change to `keyedReducer` was needed, I recommend to temporarily revert that one-line change and try to run the `client/state/activity-log/log/test/reducer.js`. Try to figure out why it fails and how the `keyedReducer` patch fixes it. **Hint:** Before this PR, the reducer returned `undefined` when the schema validation failed. Now it returns the initial state.

The test for reader.streams reducer needed to be updated to not work with initial
state of `following` -- the value gets omitted, and that not quite what the test
expects.

**How to test:**
This PR touches various pieces of functionality across Calypso and it might be hard to test manually. But we can rely on unit tests and reasoning about the code changes.