### PR TITLE
Rewind - Signup flow: don't say that backups are ready if user skips the steps

### DIFF
--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -262,12 +262,12 @@ export default {
 
 	'creds-confirm': {
 		stepName: 'creds-confirm',
-		providesDependencies: [],
+		providesDependencies: [ 'rewindconfig' ],
 	},
 
 	'creds-permission': {
 		stepName: 'creds-permission',
-		providesDependencies: [],
+		providesDependencies: [ 'rewindconfig' ],
 	},
 
 	'rewind-migrate': {

--- a/client/signup/steps/creds-complete/index.jsx
+++ b/client/signup/steps/creds-complete/index.jsx
@@ -35,8 +35,8 @@ class CredsCompleteStep extends Component {
 				<p className="creds-complete__description">
 					{ get( signupDependencies, 'rewindconfig', false ) &&
 						translate(
-							'Your site is backing up because your site is set up with Jetpack Premium plan at ' +
-								'no additional cost to you.'
+							'Your site is being backed up because it is set up with ' +
+								'Jetpack Premium at no additional cost to you.'
 						) }
 					{ translate(
 						'Finish setting up Jetpack and your site is ready to be ' +

--- a/client/signup/steps/creds-complete/index.jsx
+++ b/client/signup/steps/creds-complete/index.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
  */
 import StepWrapper from 'signup/step-wrapper';
 import Card from 'components/card';
+import Button from 'components/button';
 
 class CredsCompleteStep extends Component {
 	static propTypes = {
@@ -21,25 +22,30 @@ class CredsCompleteStep extends Component {
 		positionInFlow: PropTypes.number,
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
+		signupDependencies: PropTypes.object,
 	};
 
 	renderStepContent = () => {
-		const { translate, wpAdminUrl } = this.props;
+		const { translate, wpAdminUrl, signupDependencies } = this.props;
 
 		return (
 			<Card className="creds-complete__card">
 				<h3 className="creds-complete__title">{ translate( 'Your site is set up and ready!' ) }</h3>
 				<img className="creds-complete__image" src="/calypso/images/upgrades/thank-you.svg" />
 				<p className="creds-complete__description">
+					{ get( signupDependencies, 'rewindconfig', false ) &&
+						translate(
+							'Your site is backing up because your site is set up with Jetpack Premium plan at ' +
+								'no additional cost to you.'
+						) }
 					{ translate(
-						'Your site is backing up because your site is set up with Jetpack Premium plan at ' +
-							'no additional cost to you. Finish setting up Jetpack and your site is ready to be ' +
+						'Finish setting up Jetpack and your site is ready to be ' +
 							'transformed into the site of your dreams.'
 					) }
 				</p>
-				<a className="creds-complete__button" href={ wpAdminUrl }>
+				<Button primary className="creds-complete__button" href={ wpAdminUrl }>
 					{ translate( 'Continue' ) }
-				</a>
+				</Button>
 			</Card>
 		);
 	};

--- a/client/signup/steps/creds-confirm/index.jsx
+++ b/client/signup/steps/creds-confirm/index.jsx
@@ -39,10 +39,14 @@ class CredsConfirmStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_pressable_nux_credentials_share', {} );
 
-		SignupActions.submitSignupStep( {
-			processingMessage: this.props.translate( 'Setting up your site' ),
-			stepName: this.props.stepName,
-		} );
+		SignupActions.submitSignupStep(
+			{
+				processingMessage: this.props.translate( 'Setting up your site' ),
+				stepName: this.props.stepName,
+			},
+			undefined,
+			{ rewindconfig: true }
+		);
 
 		this.props.goToStep(
 			'pressable-nux' === this.props.flowName ? 'creds-complete' : 'rewind-were-backing'

--- a/client/signup/steps/creds-confirm/index.jsx
+++ b/client/signup/steps/creds-confirm/index.jsx
@@ -6,6 +6,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -16,6 +18,7 @@ import Button from 'components/button';
 import SignupActions from 'lib/signup/actions';
 import { autoConfigCredentials } from 'state/jetpack/credentials/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 class CredsConfirmStep extends Component {
 	static propTypes = {
@@ -24,14 +27,25 @@ class CredsConfirmStep extends Component {
 		positionInFlow: PropTypes.number,
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
+
+		// Connected props
+		siteSlug: PropTypes.string.isRequired,
+
+		// localize
+		translate: PropTypes.func.isRequired,
 	};
 
-	autoConfigCredentials = () =>
-		this.props.autoConfigCredentials( this.props.initialContext.query.blogid );
+	autoConfigCredentials = () => this.props.autoConfigCredentials( this.props.siteId );
 
 	skipStep = () => {
 		this.props.recordTracksEvent( 'calypso_pressable_nux_credentials_skip', {} );
-		this.props.goToNextStep();
+
+		if ( 'pressable-nux' === this.props.flowName ) {
+			this.props.goToNextStep();
+		} else {
+			// The flow /start/rewind-auto-config exits back to AL on the second skip
+			return page.redirect( `/stats/activity/${ this.props.siteSlug }` );
+		}
 	};
 
 	shareCredentials = () => {
@@ -90,7 +104,16 @@ class CredsConfirmStep extends Component {
 	}
 }
 
-export default connect( null, {
-	autoConfigCredentials,
-	recordTracksEvent,
-} )( localize( CredsConfirmStep ) );
+export default connect(
+	( state, ownProps ) => {
+		const siteId = get( ownProps, [ 'initialContext', 'query', 'blogid' ], 0 );
+		return {
+			siteId,
+			siteSlug: getSelectedSiteSlug( state, siteId ),
+		};
+	},
+	{
+		autoConfigCredentials,
+		recordTracksEvent,
+	}
+)( localize( CredsConfirmStep ) );

--- a/client/signup/steps/creds-permission/index.jsx
+++ b/client/signup/steps/creds-permission/index.jsx
@@ -37,10 +37,14 @@ class CredsPermissionStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_pressable_nux_credentials_share', {} );
 
-		SignupActions.submitSignupStep( {
-			processingMessage: this.props.translate( 'Setting up your site' ),
-			stepName: this.props.stepName,
-		} );
+		SignupActions.submitSignupStep(
+			{
+				processingMessage: this.props.translate( 'Setting up your site' ),
+				stepName: this.props.stepName,
+			},
+			undefined,
+			{ rewindconfig: true }
+		);
 
 		this.props.goToStep(
 			'pressable-nux' === this.props.flowName ? 'creds-complete' : 'rewind-were-backing'

--- a/client/signup/steps/rewind-form-creds/index.jsx
+++ b/client/signup/steps/rewind-form-creds/index.jsx
@@ -37,10 +37,14 @@ class RewindFormCreds extends Component {
 	 */
 	componentWillUpdate( nextProps ) {
 		if ( nextProps.rewindIsNowActive ) {
-			SignupActions.submitSignupStep( {
-				processingMessage: this.props.translate( 'Migrating your credentials' ),
-				stepName: this.props.stepName,
-			} );
+			SignupActions.submitSignupStep(
+				{
+					processingMessage: this.props.translate( 'Migrating your credentials' ),
+					stepName: this.props.stepName,
+				},
+				undefined,
+				{ rewindconfig: true }
+			);
 			this.props.goToNextStep();
 		}
 	}

--- a/client/signup/steps/rewind-migrate/index.jsx
+++ b/client/signup/steps/rewind-migrate/index.jsx
@@ -38,10 +38,14 @@ class RewindMigrate extends Component {
 	 */
 	componentWillUpdate( nextProps ) {
 		if ( this.props.rewindIsNowActive !== nextProps.rewindIsNowActive ) {
-			SignupActions.submitSignupStep( {
-				processingMessage: this.props.translate( 'Migrating your credentials' ),
-				stepName: this.props.stepName,
-			} );
+			SignupActions.submitSignupStep(
+				{
+					processingMessage: this.props.translate( 'Migrating your credentials' ),
+					stepName: this.props.stepName,
+				},
+				undefined,
+				{ rewindconfig: true }
+			);
 			this.props.goToNextStep();
 		}
 	}

--- a/client/signup/steps/rewind-were-backing/index.jsx
+++ b/client/signup/steps/rewind-were-backing/index.jsx
@@ -14,6 +14,7 @@ import { get } from 'lodash';
 import StepWrapper from 'signup/step-wrapper';
 import Card from 'components/card';
 import Button from 'components/button';
+import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 
 class RewindWereBacking extends Component {
 	static propTypes = {
@@ -25,21 +26,27 @@ class RewindWereBacking extends Component {
 
 		// Connected props
 		siteSlug: PropTypes.string.isRequired,
+		dependencyStore: PropTypes.object,
 	};
 
 	stepContent = () => {
-		const { translate, siteSlug } = this.props;
+		const { translate, siteSlug, dependencyStore } = this.props;
 
 		return (
 			<Card className="rewind-were-backing__card rewind-switch__card rewind-switch__content">
 				<h3 className="rewind-were-backing__title rewind-switch__heading">
-					{ translate( "We're backing up your site!" ) }
+					{ translate( 'Your site is set up and ready!' ) }
 				</h3>
 				<img src="/calypso/images/illustrations/thankYou.svg" alt="" />
 				<p className="rewind-were-backing__description rewind-switch__description">
+					{ get( dependencyStore, 'rewindconfig', false ) &&
+						translate(
+							'Your site is backing up because your site is set up with Jetpack Premium plan at ' +
+								'no additional cost to you.'
+						) }
 					{ translate(
-						'Welcome to your Jetpack Premium plan! ' +
-							"That sound you're hearing? It's your website doing backflips with excitement!"
+						'Finish setting up Jetpack and your site is ready to be ' +
+							'transformed into the site of your dreams.'
 					) }
 				</p>
 				<Button primary href={ `/stats/activity/${ siteSlug }` }>
@@ -68,6 +75,7 @@ class RewindWereBacking extends Component {
 export default connect(
 	( state, ownProps ) => ( {
 		siteSlug: get( ownProps, [ 'initialContext', 'query', 'siteSlug' ], 0 ),
+		dependencyStore: getSignupDependencyStore( state ),
 	} ),
 	null
 )( localize( RewindWereBacking ) );

--- a/client/signup/steps/rewind-were-backing/index.jsx
+++ b/client/signup/steps/rewind-were-backing/index.jsx
@@ -41,9 +41,9 @@ class RewindWereBacking extends Component {
 				<p className="rewind-were-backing__description rewind-switch__description">
 					{ get( dependencyStore, 'rewindconfig', false ) &&
 						translate(
-							'Your site is backing up because your site is set up with Jetpack Premium plan at ' +
-								'no additional cost to you.'
-						) }
+							'Your site is being backed up because it is set up with ' +
+								'Jetpack Premium at no additional cost to you.'
+						) + ' ' }
 					{ translate(
 						'Finish setting up Jetpack and your site is ready to be ' +
 							'transformed into the site of your dreams.'


### PR DESCRIPTION
Fixes #22293

This PR fixes the issue where the text saying that backups were ready and backing up the site was shown **even if the user skipped the setup steps**.

With this PR:
- the text is no longer shown when user skips the steps. Applies to `/start/pressable-nux` and `/start/rewind-auto-config` flows
- the button in the last step for the `/start/pressable-nux` is now a proper primary button

### Step when backups were not configured

<img width="653" alt="captura de pantalla 2018-02-13 a la s 18 18 58" src="https://user-images.githubusercontent.com/1041600/36175944-d84989d8-10ef-11e8-80e3-c10943242a70.png">

### Step when backups are configured

<img width="652" alt="captura de pantalla 2018-02-13 a la s 18 19 14" src="https://user-images.githubusercontent.com/1041600/36175956-e51e3852-10ef-11e8-8e48-4e95ec0dcece.png">

### Testing

Please test with a Pressable site and a non-Pressable site
- site that doesn't have Rewind active because of the reason `vp_can_transfer`
- site in `awaiting_credentials` mode that requires the creds to be enter with the form
- site that can be auto-configured

If you need to re-test, make sure you clean Calypso's Local Storage and Indexed DB
<img width="244" alt="captura de pantalla 2018-02-13 a la s 18 20 31" src="https://user-images.githubusercontent.com/1041600/36176264-cabb760e-10f0-11e8-81b6-41310286fe04.png">
