### PR TITLE
Framework: Refactor adding sympathy

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -57,7 +57,7 @@ function deserialize( state ) {
  *
  * If both of these flags are set, then `force-sympathy` takes precedence.
  *
- * @returns {bool} Whether to clear persistent state on page load
+ * @returns {boolean} Whether to clear persistent state on page load
  */
 function shouldAddSympathy() {
 	// If `force-sympathy` flag is enabled, always clear persistent state.
@@ -79,29 +79,7 @@ function shouldAddSympathy() {
 	return false;
 }
 
-/**
- * Augments the initial state loader to clear persistent state if
- * `shouldAddSympathy()` returns true.
- *
- * @param {Function} initialStateLoader normal unsympathetic state loader
- * @returns {Function} maybe-augmented initial state loader
- */
-function maybeAddSympathy( initialStateLoader ) {
-	if ( ! shouldAddSympathy() ) {
-		return initialStateLoader;
-	}
-
-	console.log(
-		// eslint-disable-line no-console
-		'%cSkipping initial state rehydration to recreate first-load experience.',
-		'font-size: 14px; color: red;'
-	);
-
-	localforage.clear();
-	return () => createReduxStore( getInitialServerState() );
-}
-
-const loadInitialState = maybeAddSympathy( initialState => {
+const loadInitialState = initialState => {
 	debug( 'loading initial state', initialState );
 	if ( initialState === null ) {
 		debug( 'no initial state found in localforage' );
@@ -115,7 +93,7 @@ const loadInitialState = maybeAddSympathy( initialState => {
 	const serverState = getInitialServerState();
 	const mergedState = Object.assign( {}, localforageState, serverState );
 	return createReduxStore( mergedState );
-} );
+};
 
 function loadInitialStateFailed( error ) {
 	debug( 'failed to load initial redux-store state', error );
@@ -163,15 +141,36 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 }
 
 export default function createReduxStoreFromPersistedInitialState( reduxStoreReady ) {
-	if ( config.isEnabled( 'persist-redux' ) && isLoggedIn() && ! isSupportUserSession() ) {
-		localforage
+	const shouldPersist =
+		config.isEnabled( 'persist-redux' ) && isLoggedIn() && ! isSupportUserSession();
+
+	if ( 'development' === process.env.NODE_ENV ) {
+		window.resetState = () => localforage.clear( () => location.reload( true ) );
+
+		if ( shouldAddSympathy() ) {
+			// eslint-disable-next-line no-console
+			console.log(
+				'%cSkipping initial state rehydration to recreate first-load experience.',
+				'font-size: 14px; color: red;'
+			);
+
+			localforage.clear();
+
+			return shouldPersist
+				? reduxStoreReady( persistOnChange( createReduxStore( getInitialServerState() ) ) )
+				: reduxStoreReady( createReduxStore( getInitialServerState() ) );
+		}
+	}
+
+	if ( shouldPersist ) {
+		return localforage
 			.getItem( 'redux-state-' + user.get().ID )
 			.then( loadInitialState )
 			.catch( loadInitialStateFailed )
 			.then( persistOnChange )
 			.then( reduxStoreReady );
-	} else {
-		debug( 'persist-redux is not enabled, building state from scratch' );
-		reduxStoreReady( loadInitialState( {} ) );
 	}
+
+	debug( 'persist-redux is not enabled, building state from scratch' );
+	reduxStoreReady( loadInitialState( {} ) );
 }


### PR DESCRIPTION
After some questions arose about clearing out persistent state I wrote
this PR to update the behavior and make a few small improvements.

 - Isolate the code behind static traps that uglify will remove in
production. Previously we were shipping the dead code.
 - Add `window.resetState()` as a way to manually clear state and
refresh the browser. Previously it could be hard to do this since Redux
would persist state once every five seconds. It was possible to clear
out state and have it reappear unexpectedly.
 - Prevent loading from local storage if we are sympathizing. Previously
we were loading first and then clearing it. There's no need for that
additonal work.

**Testing**

Please somebody help out here. ~I not only didn't test but I didn't even
build these changes to see if they compile~ 🤷‍♂️

**update** they compile and run fine in my smoke tests.

Using `window.resetState()` in local dev mode should clear the state
and reload. After reload it should be fresh. It should throw a type
error in any other environment.

http://iscalypsofastyet.com/branch?branch=framework/sympathize-easier
```
Delta:
chunk     stat_size           parsed_size           gzip_size
build         -24 B  (-0.0%)       -231 B  (-0.0%)     -117 B  (-0.0%)
manifest       +0 B                  +0 B                +1 B  (+0.0%)
```