### PR TITLE
Invites: Add message when max number of invites is exceeded

### DIFF
--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -100,7 +100,10 @@ class PeopleInvites extends React.PureComponent {
 				) }
 
 				{ ( hasPendingInvites || hasAcceptedInvites ) && (
-					<InvitesListEnd found={ totalInvitesFound } />
+					<InvitesListEnd
+						shown={ pendingInviteCount + acceptedInviteCount }
+						found={ totalInvitesFound }
+					/>
 				) }
 			</React.Fragment>
 		);

--- a/client/my-sites/people/people-invites/invites-list-end.jsx
+++ b/client/my-sites/people/people-invites/invites-list-end.jsx
@@ -6,6 +6,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,25 +14,44 @@ import { connect } from 'react-redux';
 import ListEnd from 'components/list-end';
 import { bumpStat } from 'state/analytics/actions';
 
-/**
- * Constants
- */
-const MAX_INVITES_DISPLAYED = 100;
-
 class InvitesListEnd extends React.PureComponent {
 	static propTypes = {
+		shown: PropTypes.number,
 		found: PropTypes.number,
 	};
 
+	constructor( props ) {
+		super( props );
+		this.bumpedStat = false;
+	}
+
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.found !== this.props.found && nextProps.found > MAX_INVITES_DISPLAYED ) {
+		if ( nextProps.found > nextProps.shown && ! this.bumpedStat ) {
 			this.props.bumpStat( 'calypso_people_invite_list', 'displayed_max' );
+			this.bumpedStat = true;
 		}
 	}
 
 	render() {
-		return <ListEnd />;
+		const { shown, found, translate } = this.props;
+
+		return (
+			<React.Fragment>
+				{ shown < found && (
+					<div className="people-invites__max-items-notice">
+						{ translate(
+							'Showing %(shown)d invite of %(found)d.',
+							'Showing %(shown)d invites of %(found)d.',
+							{ args: { shown, found } }
+						) }
+						<br />
+						{ translate( 'To view more invites, clear some of your existing invites first.' ) }
+					</div>
+				) }
+				<ListEnd />
+			</React.Fragment>
+		);
 	}
 }
 
-export default connect( null, { bumpStat } )( InvitesListEnd );
+export default connect( null, { bumpStat } )( localize( InvitesListEnd ) );

--- a/client/my-sites/people/people-invites/style.scss
+++ b/client/my-sites/people/people-invites/style.scss
@@ -26,3 +26,10 @@
 		}
 	}
 }
+
+.people-invites__max-items-notice {
+	text-align: center;
+	margin: 16px 0;
+	font-size: 14px;
+	color: $gray-text-min;
+}


### PR DESCRIPTION
The Invites screen can only display up to 100 invites at a time (this is the limit imposed by the API, and we don't need to implement pagination here).  If this limit is exceeded (as indicated by the `found` property in the API response), show a message informing the user:

> ![invites-max-items-notice](https://user-images.githubusercontent.com/227022/36185749-78e6bca2-1100-11e8-9e22-afb09040c340.png)

I also removed a constant introduced in #21884 that I don't think we don't need:  we always know how many invites were shown, and we can bump the stat if the number shown is less than the number found.