### PR TITLE
Framework: Make incremental rebuilds 5x faster*

### DIFF
--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -107,7 +107,6 @@ class WebpackBuildMonitor extends React.PureComponent {
 				className={ classNames( 'webpack-build-monitor', {
 					'is-error': hasError || ! isConnected,
 					'is-warning': needsReload,
-					'is-busy': isBusy,
 				} ) }
 			>
 				{ getMessage( this.state ) }

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -107,6 +107,7 @@ class WebpackBuildMonitor extends React.PureComponent {
 				className={ classNames( 'webpack-build-monitor', {
 					'is-error': hasError || ! isConnected,
 					'is-warning': needsReload,
+					'is-busy': isBusy,
 				} ) }
 			>
 				{ getMessage( this.state ) }

--- a/client/components/webpack-build-monitor/index.jsx
+++ b/client/components/webpack-build-monitor/index.jsx
@@ -8,11 +8,6 @@ import React from 'react';
 import classNames from 'classnames';
 import { find, startsWith } from 'lodash';
 
-/**
- * Internal dependencies
- */
-import Spinner from 'components/spinner';
-
 const MESSAGE_STATUS_MAP = {
 	'[HMR] connected': { isConnected: true },
 	'[WDS] Disconnected!': { isConnected: false },
@@ -53,23 +48,23 @@ const interceptConsole = ( consoleObject, updater ) => {
 
 const getMessage = ( { hasError, isBuildingCss, isBuildingJs, isConnected } ) => {
 	if ( ! isConnected ) {
-		return 'Dev Server disconnected';
+		return 'Dev Server disconnected!';
 	}
 
 	if ( hasError ) {
-		return 'Build error';
+		return 'Build error!';
 	}
 
 	if ( isBuildingCss && isBuildingJs ) {
-		return 'Rebuilding JS and CSS';
+		return 'Rebuilding JS and CSS…';
 	}
 
 	if ( isBuildingCss ) {
-		return 'Building CSS';
+		return 'Building CSS…';
 	}
 
 	if ( isBuildingJs ) {
-		return 'Rebuilding JavaScript';
+		return 'Rebuilding JavaScript…';
 	}
 
 	return '';
@@ -114,7 +109,6 @@ class WebpackBuildMonitor extends React.PureComponent {
 					'is-warning': needsReload,
 				} ) }
 			>
-				{ isBusy && <Spinner size={ 11 } className="webpack-build-monitor__spinner" /> }
 				{ getMessage( this.state ) }
 			</div>
 		);

--- a/client/components/webpack-build-monitor/style.scss
+++ b/client/components/webpack-build-monitor/style.scss
@@ -21,16 +21,6 @@
 	&.is-error {
 		background: $alert-red;
 	}
-
-	&.is-busy {
-		animation: blink 1s linear infinite;
-	}
-}
-
-@keyframes blink {
-	0% { visibility: hidden; }
-	20% { visibility: hidden; }
-	100% { visibility: visible; }
 }
 
 .webpack-build-monitor__text {

--- a/client/components/webpack-build-monitor/style.scss
+++ b/client/components/webpack-build-monitor/style.scss
@@ -21,21 +21,13 @@
 	&.is-error {
 		background: $alert-red;
 	}
-}
 
-.webpack-build-monitor__spinner {
-	margin-right: 6px;
+	&.is-busy {
+		animation: loading-fade 1.6s ease-in-out infinite;
+	}
 }
 
 .webpack-build-monitor__text {
 	margin-left: 6px;
 	display: block;
-}
-
-.webpack-build-monitor .spinner__progress {
-	fill: currentColor;
-}
-
-.webpack-build-monitor .spinner__border {
-	fill: lighten( $alert-green, 30% );
 }

--- a/client/components/webpack-build-monitor/style.scss
+++ b/client/components/webpack-build-monitor/style.scss
@@ -23,8 +23,14 @@
 	}
 
 	&.is-busy {
-		animation: loading-fade 1.6s ease-in-out infinite;
+		animation: blink 1s linear infinite;
 	}
+}
+
+@keyframes blink {
+	0% { visibility: hidden; }
+	20% { visibility: hidden; }
+	100% { visibility: visible; }
 }
 
 .webpack-build-monitor__text {


### PR DESCRIPTION
\* on my computer (Chrome running on 64-bit Debian Linux).

The presence of a `<Spinner>` in the `WebpackBuildMonitor` component (or anywhere, really) causes high CPU usage and constant browser re-renders during a rebuild:

> <img src="https://user-images.githubusercontent.com/227022/36186110-7d574d5e-1102-11e8-87fb-7e63be51f6af.png" width="400">

For me, this is enough to slow down an incremental rebuild from 7s to 35s.  Removing the `Spinner` entirely fixes the issue for me, and we can remove it here without loss of functionality.  This PR replaces it with an ellipsis.

We should be careful of using `Spinner` and other constantly-running animations where they are not necessary.  In my testing, any use of `Spinner` will cause a lot of re-rendering:

> <img src="https://user-images.githubusercontent.com/227022/36186167-d912d2ee-1102-11e8-98e5-3f5cf56d118a.png" width="400">

Things are a bit better if we go back to the "fallback" (non-SVG) mode of `Spinner`, but at least on my machine this is still enough to significantly slow down incremental rebuilds:

> <img src="https://user-images.githubusercontent.com/227022/36186200-0618d9be-1103-11e8-9f41-4cca59e98875.png" width="400">

In general, I think a simpler animation with three dots is more than sufficient to indicate loading, and it's much more performant.  Example:  https://codepen.io/anon/pen/parLbw