### PR TITLE
NUX: Hide free plan after selected mapped domain

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -55,7 +55,7 @@ import { recordSignupStart, recordSignupCompletion } from 'lib/analytics/ad-trac
 import { disableCart } from 'lib/upgrades/actions';
 import { loadTrackingTool } from 'state/analytics/actions';
 import { affiliateReferral } from 'state/refer/actions';
-import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
+import { isDomainRegistration, isDomainTransfer, isDomainMapping } from 'lib/products-values';
 
 /**
  * Constants
@@ -466,7 +466,9 @@ class Signup extends React.Component {
 			flow = flows.getFlow( this.props.flowName ),
 			hideFreePlan = !! (
 				this.state.plans ||
-				( ( isDomainRegistration( domainItem ) || isDomainTransfer( domainItem ) ) &&
+				( ( isDomainRegistration( domainItem ) ||
+					isDomainTransfer( domainItem ) ||
+					isDomainMapping( domainItem ) ) &&
 					this.props.domainsWithPlansOnly )
 			);
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -178,7 +178,9 @@ class DomainsStep extends React.Component {
 					stepSectionName: this.props.stepSectionName,
 				},
 				this.getThemeArgs()
-			)
+			),
+			[],
+			{ domainItem }
 		);
 
 		this.props.goToNextStep();


### PR DESCRIPTION
This PR address #11948. When signing up with a mapped domain, the free plan is still displayed as an option. Mapping is not available with free plans.

## What this PR does

1. Passes mapped domain information (`domainItem`) to `SignupActions.submitSignupStep`
2. Runs a `isDomainMapping()` check on `domainItem` to [check for the slug](https://github.com/Automattic/wp-calypso/blob/d93b182/client/lib/products-values/index.js#L230)
 and [hides the free plan accordingly](https://github.com/Automattic/wp-calypso/blob/d93b182/client/signup/main.jsx#L467).

![feb-14-2018 17-10-17](https://user-images.githubusercontent.com/6458278/36190059-0f9a3364-11aa-11e8-9197-12d33253d4d2.gif)

## Testing
1. Open http://calypso.localhost:3000/start (for signed out and signed in users)
2. Create a new site and, on Step 2 select _Already own a domain?_
3. Enter a domain – crocodile.com is nice 🐊 –  and continue to the plans step
4. Go back to the start and search for free site name, such as _crocaduck-go-go_
5. Select the `*.wordpress.com` free domain and continue to the plans step

### Expectations
**At 3**: The page _should not_ present the Free Plan option
**At 5**: The page _should_ present the Free Plan option


