### PR TITLE
Domains: Remove notice styling of primary domain label

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/primary-flag.jsx
+++ b/client/my-sites/domains/domain-management/components/domain/primary-flag.jsx
@@ -1,12 +1,12 @@
 /** @format */
-
 /**
  * External dependencies
  */
 
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
+import { flow } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,23 +14,14 @@ import React, { Component } from 'react';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isDomainOnlySite } from 'state/selectors';
 import { localize } from 'i18n-calypso';
-import Notice from 'components/notice';
 
-class DomainPrimaryFlag extends Component {
-	render() {
-		const { isDomainOnly, domain, translate } = this.props;
-
-		if ( domain.isPrimary && ! isDomainOnly ) {
-			return (
-				<Notice isCompact status="is-success">
-					{ translate( 'Primary Domain' ) }
-				</Notice>
-			);
-		}
-
-		return null;
+const DomainPrimaryFlag = ( { isDomainOnly, domain, translate } ) => {
+	if ( domain.isPrimary && ! isDomainOnly ) {
+		return <strong className="domain__primary-flag">{ translate( 'Primary Domain' ) }</strong>;
 	}
-}
+
+	return null;
+};
 
 DomainPrimaryFlag.propTypes = {
 	domain: PropTypes.object.isRequired,
@@ -38,8 +29,9 @@ DomainPrimaryFlag.propTypes = {
 	translate: PropTypes.func.isRequired,
 };
 
-export default connect( state => {
-	return {
+export default flow(
+	localize,
+	connect( state => ( {
 		isDomainOnly: isDomainOnlySite( state, getSelectedSiteId( state ) ),
-	};
-} )( localize( DomainPrimaryFlag ) );
+	} ) )
+)( DomainPrimaryFlag );

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -91,6 +91,11 @@
 	cursor: pointer;
 	display: block;
 	overflow: hidden;
+
+	.domain__primary-flag {
+		vertical-align: middle;
+		margin-left: 8px;
+	}
 }
 
 .domain-management-list-item__title {


### PR DESCRIPTION
With the upcoming site-rename feature comes the use of a global notice that informs the customer of a successful site-rename request... Unfortunately this makes for some quite jarring visuals when combined with the `primary-domain` label seen in this view:

![image](https://user-images.githubusercontent.com/4335450/36192186-7c6d6b00-119b-11e8-9b35-068ed3660522.png)

This PR simply removes this styling, leaving a regular, label in it's place like so:

<img width="372" alt="screen shot 2018-02-14 at 15 29 54" src="https://user-images.githubusercontent.com/4335450/36192300-f503e3fa-119b-11e8-9fc1-0e50a80d4eac.png">

Personally, I'm a fan of the green text, no border option, though this could be a HTI / accessibility issue.

Make sure to check both:
Domain List View: http://calypso.localhost:3000/domains/manage/
Domain Item View: http://calypso.localhost:3000/domains/manage/{ domain }/edit/{ domain }

Also, the privacy protection icon suffers the same issue. I think it's less obnoxious though given that it's styling carries more meaning there, but I'm open to giving some treatment to this too.

cc: @shaunandrews for design review 🙏 
