### PR TITLE
Jetpack Connect: Stop overwriting section name to hide sidebar

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -57,16 +57,8 @@ const analyticsPageTitleByType = {
 	pro: 'Jetpack Install Pro',
 };
 
-const removeSidebar = context => {
-	context.store.dispatch(
-		setSection(
-			{ name: 'jetpackConnect' },
-			{
-				hasSidebar: false,
-			}
-		)
-	);
-};
+const removeSidebar = context =>
+	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 
 const jetpackNewSiteSelector = context => {
 	removeSidebar( context );

--- a/client/state/happychat/selectors/get-groups.js
+++ b/client/state/happychat/selectors/get-groups.js
@@ -20,7 +20,7 @@ export default ( state, siteId ) => {
 
 	// For Jetpack Connect we need to direct chat users to the JPOP group, to account for cases
 	// when the user does not have a site yet, or their primary site is not a Jetpack site.
-	if ( isEnabled( 'jetpack/happychat' ) && getSectionName( state ) === 'jetpackConnect' ) {
+	if ( isEnabled( 'jetpack/happychat' ) && getSectionName( state ) === 'jetpack-connect' ) {
 		groups.push( HAPPYCHAT_GROUP_JPOP );
 		return groups;
 	}

--- a/client/state/happychat/selectors/test/get-groups.js
+++ b/client/state/happychat/selectors/test/get-groups.js
@@ -114,7 +114,7 @@ describe( 'selectors', () => {
 		} );
 
 		if ( isEnabled( 'jetpack/happychat' ) ) {
-			test( 'should return JPOP group if within the jetpackConnect section', () => {
+			test( 'should return JPOP group if within the jetpack-connect section', () => {
 				const state = {
 					...userState,
 					sites: {
@@ -124,7 +124,7 @@ describe( 'selectors', () => {
 					},
 					ui: {
 						section: {
-							name: 'jetpackConnect',
+							name: 'jetpack-connect',
 						},
 					},
 				};
@@ -132,7 +132,7 @@ describe( 'selectors', () => {
 				expect( getGroups( state ) ).toMatchObject( [ HAPPYCHAT_GROUP_JPOP ] );
 			} );
 		} else {
-			test.skip( 'should not return JPOP group if within the jetpackConnect section' );
+			test.skip( 'should not return JPOP group if within the jetpack-connect section' );
 		}
 	} );
 } );

--- a/client/state/happychat/test/utils.js
+++ b/client/state/happychat/test/utils.js
@@ -20,7 +20,7 @@ describe( 'auth promise', () => {
 		},
 		ui: {
 			section: {
-				name: 'jetpackConnect',
+				name: 'jetpack-connect',
 			},
 		},
 	};


### PR DESCRIPTION
This PR removes a section name overwrite in the Jetpack Connect controller. The purpose is to hide the sidebar, but it also has the unintended side-effect of changing the section name.

Section names should be defined in [`wordpress-com.js`](https://github.com/Automattic/wp-calypso/blob/3c3cfe42da0b1ae1fd0b2e66ee3663eb0fdec33d/client/wordpress-com.js):
https://github.com/Automattic/wp-calypso/blob/3c3cfe42da0b1ae1fd0b2e66ee3663eb0fdec33d/client/wordpress-com.js#L154-L160

Part of #22218 

## Testing
1. Look for usage of the [section name](https://github.com/Automattic/wp-calypso/search?q=jetpackConnect)
1. Verify that and sectionName usage is now `jetpack-connect` as defined in `wordpress-com.js`.
1. Verify HappyChat within the Jetpack Connection flow is correctly sent to JPOP group (Please avoid this in production: PCYsg-b99-p2)
   1. Log in
   1. Ensure you're accepting chats for the JPOP group
   1. Toggling your availability should determine whether you see chat options during the connection flow