### PR TITLE
Bundle all stats components in one chunk

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -20,9 +20,14 @@ import { getSite, isJetpackSite, getSiteOption } from 'state/sites/selectors';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import AsyncLoad from 'components/async-load';
-import StatsPagePlaceholder from 'my-sites/stats/stats-page-placeholder';
 import FollowList from 'lib/follow-list';
+import StatsInsights from './stats-insights';
+import StatsOverview from './overview';
+import StatsSite from './site';
+import StatsSummary from './summary';
+import StatsPostDetail from './stats-post-detail';
+import StatsCommentFollows from './comment-follows';
+import ActivityLog from './activity-log';
 
 const analyticsPageTitle = 'Stats';
 
@@ -126,21 +131,13 @@ export default {
 
 	insights: function( context, next ) {
 		const basePath = sectionify( context.path );
-		const followList = new FollowList();
 
 		// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 		context.store.dispatch( setTitle( i18n.translate( 'Stats', { textOnly: true } ) ) );
 
 		analytics.pageView.record( basePath, analyticsPageTitle + ' > Insights' );
 
-		const props = { followList };
-		context.primary = (
-			<AsyncLoad
-				require="my-sites/stats/stats-insights"
-				placeholder={ <StatsPagePlaceholder /> }
-				{ ...props }
-			/>
-		);
+		context.primary = <StatsInsights followList={ new FollowList() } />;
 		next();
 	},
 
@@ -192,13 +189,7 @@ export default {
 				period: activeFilter.period,
 				path: context.pathname,
 			};
-			context.primary = (
-				<AsyncLoad
-					placeholder={ <StatsPagePlaceholder /> }
-					require="my-sites/stats/overview"
-					{ ...props }
-				/>
-			);
+			context.primary = <StatsOverview { ...props } />;
 			next();
 		}
 	},
@@ -268,7 +259,7 @@ export default {
 			period = rangeOfPeriod( activeFilter.period, date );
 			chartTab = queryOptions.tab || 'views';
 
-			const siteComponentChildren = {
+			const props = {
 				path: context.pathname,
 				date,
 				chartTab,
@@ -276,13 +267,7 @@ export default {
 				period,
 			};
 
-			context.primary = (
-				<AsyncLoad
-					placeholder={ <StatsPagePlaceholder /> }
-					require="my-sites/stats/site"
-					{ ...siteComponentChildren }
-				/>
-			);
+			context.primary = <StatsSite { ...props } />;
 			next();
 		}
 	},
@@ -378,13 +363,7 @@ export default {
 				period,
 				...extraProps,
 			};
-			context.primary = (
-				<AsyncLoad
-					placeholder={ <StatsPagePlaceholder /> }
-					require="my-sites/stats/summary"
-					{ ...props }
-				/>
-			);
+			context.primary = <StatsSummary { ...props } />;
 			next();
 		}
 	},
@@ -411,13 +390,7 @@ export default {
 				postId,
 				context,
 			};
-			context.primary = (
-				<AsyncLoad
-					placeholder={ <StatsPagePlaceholder /> }
-					require="my-sites/stats/stats-post-detail"
-					{ ...props }
-				/>
-			);
+			context.primary = <StatsPostDetail { ...props } />;
 		}
 		next();
 	},
@@ -457,13 +430,7 @@ export default {
 				siteId,
 				followList,
 			};
-			context.primary = (
-				<AsyncLoad
-					placeholder={ <StatsPagePlaceholder /> }
-					require="my-sites/stats/comment-follows"
-					{ ...props }
-				/>
-			);
+			context.primary = <StatsCommentFollows { ...props } />;
 		}
 		next();
 	},
@@ -487,13 +454,7 @@ export default {
 				context,
 				startDate,
 			};
-			context.primary = (
-				<AsyncLoad
-					placeholder={ <StatsPagePlaceholder /> }
-					require="my-sites/stats/activity-log"
-					{ ...props }
-				/>
-			);
+			context.primary = <ActivityLog { ...props } />;
 		}
 		next();
 	},


### PR DESCRIPTION
When loading route like `/stats/day/:site`, it might be faster to download more code in a big `stats` chunk, rather that wait for a network roundtrip when async-loading the smaller `async-load-my-sites-stats-site` chunk later. This PR removes the async loading of Stats subcomponents and bundles them all together.

This screenshot from the Chrome profiler illustrates the issue:
<img width="716" alt="stats-async-loading" src="https://user-images.githubusercontent.com/664258/36201432-3d58790c-1180-11e8-9b30-4e5b83ec2377.png">

There are several steps that must happen before Calypso issues the REST API requests to get the stats for the site:
- `build` and `vendor` chunks are downloaded from the server. The SSR code is smart enough to know that the route `/stats/day/:site` will be rendered and it knows the browser will need the `stats` chunk, too. So it includes a `script` tag in `index.html` to start downloading the chunk ASAP.
- the downloaded code (and there is a lot of it!) is executed and Calypso is initialized: Redux state is created, initial render happens
- only when the respective `page` handler is being executed, it realizes that it needs the `stats-site` async chunk and starts downloading it. This extra network roundtrip takes 280ms to happen.
- after the `stats-site` chunk is downloaded and executed, REST API requests are issued.

In the profile, notice that a large part of the chunk network request is spent sending the request and waiting for the server (light yellow) rather than actually downloading (dark yellow).

I believe that by bundling all Stats code into one larger bundle that's downloaded very early, we can remove about 200ms from the initial load time.

Here is how chunk sizes are affected:
```
chunk                                        stat_size              parsed_size              gzip_size
async-load-my-sites-stats-activity-log       -249189 B   (deleted)    -131346 B   (deleted)   -28892 B   (deleted)
async-load-my-sites-stats-comment-follows    -138512 B   (deleted)     -71269 B   (deleted)   -17653 B   (deleted)
async-load-my-sites-stats-overview           -131043 B   (deleted)     -76725 B   (deleted)   -17015 B   (deleted)
async-load-my-sites-stats-site               -323765 B   (deleted)    -180750 B   (deleted)   -41295 B   (deleted)
async-load-my-sites-stats-stats-insights     -353705 B   (deleted)    -181752 B   (deleted)   -42516 B   (deleted)
async-load-my-sites-stats-stats-post-detail  -206048 B   (deleted)    -110314 B   (deleted)   -25138 B   (deleted)
async-load-my-sites-stats-summary            -269147 B   (deleted)    -146891 B   (deleted)   -33175 B   (deleted)
build                                             +0 B                     +0 B                   +0 B
manifest                                          +0 B                  -1001 B     (-9.7%)     -214 B     (-6.2%)
stats                                        +684948 B  (+2744.8%)    +334849 B  (+2407.6%)   +75570 B  (+2038.0%)
woocommerce                                       -5 B     (-0.0%)       -343 B     (-0.0%)      -54 B     (-0.0%)
```

We got rid of the `async-load-my-sites-stats-site` chunk that's 41kBgz big, but the `stats` chunk got 75kBgz bigger. Will this tradeoff work in our favor? Does the extra 34kBgz download take more time than we saved by removing the extra network roundtrip? That's very hard to decide -- it depends on what your network latency and download speeds are.

I experimented with various settings in Chrome devtools' network throttling (fast Wifi, regular 3G, slow 3G, ...) and wasn't able to make a clear conclusion.

I'd like to merge this PR as an experiment and watch how it affects the Grafana charts that measure the Stats page loading. Navigation to `/stats/day/:site` takes approx 1.0s (median) now, so a bump on scale of 200ms should be very visible there.

We could also merge just the `stats-site` chunk and keep async-loading all the others, but I'd like to try out the simple merge-them-all approach first and refine it later.

This work was inspired by an observation by @josephscott in a P2 comment, where he pointed out the unfavorable ratio between "waiting for the first byte" and "downloading". Thank you!