### PR TITLE
Domains/cctlds: Use error messages out of schemas

### DIFF
--- a/client/components/domains/registrant-extra-info/test/uk-form.js
+++ b/client/components/domains/registrant-extra-info/test/uk-form.js
@@ -28,7 +28,7 @@ describe( 'uk-form', () => {
 				validationErrors: {
 					extra: {
 						uk: {
-							registrationNumber: [ 'Test error message.' ],
+							registrationNumber: [ { errorMessage: 'Test error message.' } ],
 						},
 					},
 				},
@@ -46,8 +46,11 @@ describe( 'uk-form', () => {
 				validationErrors: {
 					extra: {
 						uk: {
-							registrationNumber: [ 'testErrorCode', 'testErrorCode' ],
-							tradingName: [ 'testErrorCode' ],
+							registrationNumber: [
+								{ errorMessage: 'Test error message 1.' },
+								{ errorMessage: 'Test error message 2.' },
+							],
+							tradingName: [ { errorMessage: 'Test Error Message 3.' } ],
 						},
 					},
 				},

--- a/client/components/domains/registrant-extra-info/test/uk-form.js
+++ b/client/components/domains/registrant-extra-info/test/uk-form.js
@@ -28,7 +28,7 @@ describe( 'uk-form', () => {
 				validationErrors: {
 					extra: {
 						uk: {
-							registrationNumber: [ 'testErrorCode' ],
+							registrationNumber: [ 'Test error message.' ],
 						},
 					},
 				},
@@ -36,7 +36,7 @@ describe( 'uk-form', () => {
 
 			const wrapper = shallow( <RegistrantExtraInfoUkForm { ...testProps } /> );
 			const error = wrapper.find( FormInputValidation );
-			expect( error.props() ).toHaveProperty( 'text', 'There was a problem with this field.' );
+			expect( error.props() ).toHaveProperty( 'text', 'Test error message.' );
 		} );
 
 		test( 'should render multiple registration errors', () => {
@@ -56,27 +56,6 @@ describe( 'uk-form', () => {
 			const wrapper = shallow( <RegistrantExtraInfoUkForm { ...testProps } /> );
 			const error = wrapper.find( FormInputValidation );
 			expect( error ).toHaveProperty( 'length', 3 );
-		} );
-
-		test( 'should convert error code to user-facing string', () => {
-			const testProps = {
-				...mockProps,
-				ccTldDetails: { registrantType: 'LLP' },
-				validationErrors: {
-					extra: {
-						uk: {
-							registrationNumber: [ 'dotukRegistrationNumberFormat' ],
-						},
-					},
-				},
-			};
-
-			const wrapper = shallow( <RegistrantExtraInfoUkForm { ...testProps } /> );
-			const error = wrapper.find( FormInputValidation );
-			expect( error.props() ).toHaveProperty(
-				'text',
-				'A Company Registration Number is 8 numerals, or 2 letters followed by 6 numerals (e.g. AB123456 or 12345678).'
-			);
 		} );
 
 		test( 'Should disable submit button with validation errors', () => {

--- a/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
+++ b/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
@@ -84,10 +84,14 @@ describe( 'uk-form validation', () => {
 					/>
 				).dive();
 
-				expect( wrapper.props() ).toHaveProperty( 'validationErrors', {
-					extra: {
-						uk: {
-							registrationNumber: [ 'A registration number is required for this registrant type.' ],
+				expect( wrapper.props() ).toMatchObject( {
+					validationErrors: {
+						extra: {
+							uk: {
+								registrationNumber: [
+									{ errorMessage: 'A registration number is required for this registrant type.' },
+								],
+							},
 						},
 					},
 				} );
@@ -168,9 +172,15 @@ describe( 'uk-form validation', () => {
 					/>
 				).dive();
 
-				expect( wrapper.props() ).toHaveProperty( 'validationErrors', {
-					extra: {
-						uk: { tradingName: [ 'A trading name is required for this registrant type.' ] },
+				expect( wrapper.props() ).toMatchObject( {
+					validationErrors: {
+						extra: {
+							uk: {
+								tradingName: [
+									{ errorMessage: 'A trading name is required for this registrant type.' },
+								],
+							},
+						},
 					},
 				} );
 			} );

--- a/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
+++ b/client/components/domains/registrant-extra-info/test/with-contact-details-validation.js
@@ -86,7 +86,9 @@ describe( 'uk-form validation', () => {
 
 				expect( wrapper.props() ).toHaveProperty( 'validationErrors', {
 					extra: {
-						uk: { registrationNumber: [ 'dotukRegistrantTypeRequiresRegistrationNumber' ] },
+						uk: {
+							registrationNumber: [ 'A registration number is required for this registrant type.' ],
+						},
 					},
 				} );
 			} );
@@ -167,7 +169,9 @@ describe( 'uk-form validation', () => {
 				).dive();
 
 				expect( wrapper.props() ).toHaveProperty( 'validationErrors', {
-					extra: { uk: { tradingName: [ 'dotukRegistrantTypeRequiresTradingName' ] } },
+					extra: {
+						uk: { tradingName: [ 'A trading name is required for this registrant type.' ] },
+					},
 				} );
 			} );
 		} );

--- a/client/components/domains/registrant-extra-info/uk-form.jsx
+++ b/client/components/domains/registrant-extra-info/uk-form.jsx
@@ -63,17 +63,6 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 				{ text }
 			</option>
 		) );
-		this.errorMessages = {
-			dotukRegistrationNumberFormat: translate(
-				'A Company Registration Number is 8 numerals, or 2 letters followed by 6 numerals (e.g. AB123456 or 12345678).'
-			),
-			dotukRegistrantTypeRequiresRegistrationNumber: translate(
-				'A registration number is required for this registrant type.'
-			),
-			dotukRegistrantTypeRequiresTradingName: translate(
-				'A trading name is required for this registrant type.'
-			),
-		};
 	}
 
 	componentWillMount() {
@@ -182,21 +171,8 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 		);
 	}
 
-	errorMessageFromCode( errorCode ) {
-		return (
-			this.errorMessages[ errorCode ] ||
-			this.props.translate( 'There was a problem with this field.' )
-		);
-	}
-
-	renderValidationError = errorCode => {
-		return (
-			<FormInputValidation
-				isError
-				key={ errorCode }
-				text={ this.errorMessageFromCode( errorCode ) }
-			/>
-		);
+	renderValidationError = errorMessage => {
+		return <FormInputValidation isError key={ errorMessage } text={ errorMessage } />;
 	};
 
 	render() {

--- a/client/components/domains/registrant-extra-info/uk-form.jsx
+++ b/client/components/domains/registrant-extra-info/uk-form.jsx
@@ -171,8 +171,15 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 		);
 	}
 
-	renderValidationError = errorMessage => {
-		return <FormInputValidation isError key={ errorMessage } text={ errorMessage } />;
+	renderValidationError = ( { errorCode, errorMessage } ) => {
+		const { translate } = this.props;
+		return (
+			<FormInputValidation
+				isError
+				key={ errorCode }
+				text={ errorMessage || translate( 'There was a problem with this field.' ) }
+			/>
+		);
 	};
 
 	render() {

--- a/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
+++ b/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
@@ -51,13 +51,9 @@ export function interpretIMJVError( error, schema ) {
 	}
 
 	// use field from error
-	const inferredPath = replace( error.field, /^data\./, '' );
+	const path = explicitPath || replace( error.field, /^data\./, '' );
 
-	return {
-		errorMessage,
-		errorCode: errorCode || error.message,
-		path: explicitPath || inferredPath,
-	};
+	return { errorMessage, errorCode, path };
 }
 
 /*

--- a/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
+++ b/client/components/domains/registrant-extra-info/with-contact-details-validation.jsx
@@ -8,8 +8,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import validatorFactory from 'is-my-json-valid';
-import { castArray, get, isEmpty, map, once, reduce, replace } from 'lodash';
-import { update } from 'lodash/fp';
+import { castArray, get, isEmpty, map, once, reduce, replace, update } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:domains:with-contact-details-validation' );
 
@@ -77,11 +76,11 @@ export function formatIMJVErrors( errors, schema ) {
 			// Compare the error to the schema and try to find an appropriate
 			// error message
 			const error = interpretIMJVError( rawError, schema );
-			return update(
-				error.path,
-				errorsForField => [ ...( errorsForField || [] ), error ],
-				accumulatedErrors
-			);
+
+			return update( accumulatedErrors, error.path, errorsForField => [
+				...( errorsForField || [] ),
+				error,
+			] );
 		},
 		{}
 	);


### PR DESCRIPTION
This PR uses error messages from the schemas, using backend changes in code-D10197

**Testing:**

The key thing is that the error messages appear correctly, and in the UI language:
![checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/39184182-cccaff40-4805-11e8-87fa-652a77a8a5d9.jpg)

The tests already cover pulling the right string out of the schema, so I've just updated the existing tests for the new data.

You can confirm the where the messages are coming from by tweaking the values on the back end (tip: tweak `$localized_message` in `TLD_Validator`), or by updating one or more of the `errorMessage` properties in the validation schema in the redux state. The easiest way to do this is probably by grabbing the `DOMAIN_MANAGEMENT_VALIDATION_SCHEMAS_ADD` action from the redux DevTools and tweaking that (we don't manipulate the schemas, so we don't have much in the way of convenient actions).

e.g. I added the "From API:" prefix on my sandbox:
![checkout_ _julesauspremiumtest_ _wordpress_com](https://user-images.githubusercontent.com/5952255/39186166-eba7fb96-480c-11e8-846f-a30b6fc6d781.jpg)
