### PR TITLE
Fix initial-state tests after postTypes and withSchemaValidation changes

### DIFF
--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -190,7 +190,7 @@ describe( 'initial-state', () => {
 					expect( state._timestamp ).to.equal( undefined );
 				} );
 				test( 'server state shallowly overrides local forage state', () => {
-					expect( state.postTypes.items ).to.equal( serverState.postTypes.items );
+					expect( state.postTypes.items ).to.eql( serverState.postTypes.items );
 				} );
 			} );
 			describe( 'with stale persisted data and initial server data', () => {
@@ -240,7 +240,7 @@ describe( 'initial-state', () => {
 					expect( console.error.called ).to.equal( false ); // eslint-disable-line no-console
 				} );
 				test( 'builds using server state', () => {
-					expect( state.postTypes.items ).to.equal( serverState.postTypes.items );
+					expect( state.postTypes.items ).to.eql( serverState.postTypes.items );
 				} );
 				test( 'does not build using local forage state', () => {
 					expect( state.currentUser.id ).to.equal( null );
@@ -290,7 +290,7 @@ describe( 'initial-state', () => {
 				} );
 				test( 'builds state using local forage state', () => {
 					expect( state.currentUser.id ).to.equal( 123456789 );
-					expect( state.postTypes.items ).to.equal( savedState.postTypes.items );
+					expect( state.postTypes.items ).to.eql( savedState.postTypes.items );
 				} );
 				test( 'does not add timestamp to store', () => {
 					expect( state._timestamp ).to.equal( undefined );


### PR DESCRIPTION
Fixes test failures that started to happen after #22410 and #22409, which as indepenent PRs worked flawlessy, were merged together.

Why?

In #22409, the `postTypes` reducer is updated to use `keyedReducer`. When `keyedReducer` handles a DESERIALIZE action, it always creates a new object, never just returns `state`.

In #22410, the `withSchemaValidation` function was changed to call the wrapped reducer on DESERIALIZE, i.e., in `postTypes` case, to call `keyedReducer`.

Result: DESERIALIZE of `postTypes` states no longer returns identical object, but rather its copy. The equality checks in the tests need to be changed to deep equals instead of `===` (or, in Chai parlance, `equal` to `eql`)