### PR TITLE
Jetpack Onboarding: Display an error notice when there is a communication error

### DIFF
--- a/client/state/data-layer/wpcom/jetpack-onboarding/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { get, noop } from 'lodash';
+import { get } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -75,17 +75,16 @@ export const requestJetpackOnboardingSettings = ( { dispatch, getState }, action
 
 export const announceRequestFailure = ( { dispatch, getState }, { siteId } ) => {
 	const url = getUnconnectedSiteUrl( getState(), siteId );
-	if ( ! url ) {
-		return noop;
+	const noticeOptions = {
+		id: `jpo-communication-error-${ siteId }`,
+	};
+
+	if ( url ) {
+		noticeOptions.button = translate( 'Visit site admin' );
+		noticeOptions.href = trailingslashit( url ) + 'wp-admin/admin.php?page=jetpack';
 	}
 
-	return dispatch(
-		errorNotice( translate( 'Something went wrong.' ), {
-			button: translate( 'Visit site admin' ),
-			href: trailingslashit( url ) + 'wp-admin/admin.php?page=jetpack',
-			id: `jpo-communication-error-${ siteId }`,
-		} )
-	);
+	return dispatch( errorNotice( translate( 'Something went wrong.' ), noticeOptions ) );
 };
 
 /**

--- a/client/state/data-layer/wpcom/jetpack-onboarding/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/index.js
@@ -80,7 +80,7 @@ export const announceRequestFailure = ( { dispatch, getState }, { siteId } ) => 
 	}
 
 	return dispatch(
-		errorNotice( translate( 'An unexpected error occurred.' ), {
+		errorNotice( translate( 'Something went wrong.' ), {
 			button: translate( 'Visit site admin' ),
 			href: trailingslashit( url ) + 'wp-admin/admin.php?page=jetpack',
 			id: `jpo-communication-error-${ siteId }`,

--- a/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
@@ -8,6 +8,7 @@ import {
 	requestJetpackOnboardingSettings,
 	saveJetpackOnboardingSettings,
 	handleSaveSuccess,
+	announceRequestFailure,
 	announceSaveFailure,
 	fromApi,
 } from '../';
@@ -95,6 +96,57 @@ describe( 'requestJetpackOnboardingSettings()', () => {
 				},
 				action
 			)
+		);
+	} );
+} );
+
+describe( 'announceRequestFailure()', () => {
+	const dispatch = jest.fn();
+	const siteId = 12345678;
+	const siteUrl = 'http://yourgroovydomain.com';
+
+	test( 'should not do anything when url is missing', () => {
+		const getState = () => ( {
+			jetpackOnboarding: {
+				credentials: {
+					[ siteId ]: {
+						token: 'abcd1234',
+						userEmail: 'example@yourgroovydomain.com',
+					},
+				},
+			},
+		} );
+
+		announceRequestFailure( { dispatch, getState }, { siteId } );
+
+		expect( dispatch ).toHaveBeenCalledTimes( 0 );
+	} );
+
+	test( 'should trigger an error notice when request fails', () => {
+		const getState = () => ( {
+			jetpackOnboarding: {
+				credentials: {
+					[ siteId ]: {
+						siteUrl,
+						token: 'abcd1234',
+						userEmail: 'example@yourgroovydomain.com',
+					},
+				},
+			},
+		} );
+
+		announceRequestFailure( { dispatch, getState }, { siteId } );
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				notice: expect.objectContaining( {
+					button: 'Visit site admin',
+					href: siteUrl + '/wp-admin/admin.php?page=jetpack',
+					noticeId: `jpo-communication-error-${ siteId }`,
+					status: 'is-error',
+					text: 'An unexpected error occurred.',
+				} ),
+			} )
 		);
 	} );
 } );

--- a/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
@@ -144,7 +144,7 @@ describe( 'announceRequestFailure()', () => {
 					href: siteUrl + '/wp-admin/admin.php?page=jetpack',
 					noticeId: `jpo-communication-error-${ siteId }`,
 					status: 'is-error',
-					text: 'An unexpected error occurred.',
+					text: 'Something went wrong.',
 				} ),
 			} )
 		);

--- a/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
@@ -105,24 +105,7 @@ describe( 'announceRequestFailure()', () => {
 	const siteId = 12345678;
 	const siteUrl = 'http://yourgroovydomain.com';
 
-	test( 'should not do anything when url is missing', () => {
-		const getState = () => ( {
-			jetpackOnboarding: {
-				credentials: {
-					[ siteId ]: {
-						token: 'abcd1234',
-						userEmail: 'example@yourgroovydomain.com',
-					},
-				},
-			},
-		} );
-
-		announceRequestFailure( { dispatch, getState }, { siteId } );
-
-		expect( dispatch ).toHaveBeenCalledTimes( 0 );
-	} );
-
-	test( 'should trigger an error notice when request fails', () => {
+	test( 'should trigger an error notice with an action button when request fails', () => {
 		const getState = () => ( {
 			jetpackOnboarding: {
 				credentials: {
@@ -142,6 +125,31 @@ describe( 'announceRequestFailure()', () => {
 				notice: expect.objectContaining( {
 					button: 'Visit site admin',
 					href: siteUrl + '/wp-admin/admin.php?page=jetpack',
+					noticeId: `jpo-communication-error-${ siteId }`,
+					status: 'is-error',
+					text: 'Something went wrong.',
+				} ),
+			} )
+		);
+	} );
+
+	test( 'should trigger an error notice without action button if url is missing', () => {
+		const getState = () => ( {
+			jetpackOnboarding: {
+				credentials: {
+					[ siteId ]: {
+						token: 'abcd1234',
+						userEmail: 'example@yourgroovydomain.com',
+					},
+				},
+			},
+		} );
+
+		announceRequestFailure( { dispatch, getState }, { siteId } );
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				notice: expect.objectContaining( {
 					noticeId: `jpo-communication-error-${ siteId }`,
 					status: 'is-error',
 					text: 'Something went wrong.',


### PR DESCRIPTION
This PR suggests that we display an error notice with a link to wp-admin in the case when there is a communication error. Such edge cases happen when there is something wrong with the communication, or when we have credentials for a site, but they are not valid for some reason, or the remote site consistently does not respond at this time. 

Fixes #21677.

Preview:
![](https://cldup.com/9GQOdWYNLS.png)

To test:
* Checkout this branch
* Pick a Jetpack site that you have CLI access to.
* Start the onboarding flow for the Jetpack site by going to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`
* Wait for the onboarding flow site title step to load.
* Open your Jetpack sandbox console and type the following command `wp jetpack options delete onboarding` to delete your onboarding token. 
* It will prompt you to confirm, type `yes`.
* Refresh the onboarding flow.
* Wait for a bit (after the first request fails, it retries 3 times before displaying a notice).
* Verify you can see the error notice as shown on the screenshot.
* Click on the notice action link and verify you're led to the Jetpack main page in wp-admin.

Also cc @kristastevens - we'd appreciate if you could verify the copy of the notice and the notice action look good, thanks in advance!