### PR TITLE
Components: Fix notice action visited color

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -179,6 +179,10 @@ a.notice__action {
 		}
 	}
 
+	&:visited {
+		color: $gray-lighten-10;
+	}
+
 	&:hover {
 		color: $white;
 	}


### PR DESCRIPTION
It seems that with the updated notice color scheme when we have a notice with a link that is already visited it appears in blue (because of the default `:visited` color):

![](https://cldup.com/KPgLVB91MR.png)

This PR updates the color of the visited links in a notice to be the same like the regular notice action link color:

![](https://cldup.com/JCGpZ2dUcl.png)

To test:
* Follow the instructions in #22443
