### PR TITLE
Data-Layer: Warn when no default action or success handler is supplied

### DIFF
--- a/client/state/data-layer/wpcom-http/actions.js
+++ b/client/state/data-layer/wpcom-http/actions.js
@@ -46,6 +46,16 @@ export const http = (
 ) => {
 	const version = apiNamespace ? { apiNamespace } : { apiVersion };
 
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( ! ( action || onSuccess ) ) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				'No success handler or default action supplied to the http action. You probably want one or the other. Path: %s',
+				path
+			);
+		}
+	}
+
 	return {
 		type: WPCOM_HTTP_REQUEST,
 		body,

--- a/client/state/data-layer/wpcom-http/actions.js
+++ b/client/state/data-layer/wpcom-http/actions.js
@@ -46,7 +46,7 @@ export const http = (
 ) => {
 	const version = apiNamespace ? { apiNamespace } : { apiVersion };
 
-	if ( process.env.NODE_ENV !== 'production' ) {
+	if ( process.env.NODE_ENV === 'development' ) {
 		if ( ! ( action || onSuccess ) ) {
 			// eslint-disable-next-line no-console
 			console.warn(


### PR DESCRIPTION
You generally need to supply one or the other when using the http action. If you do not, no handlers will be called when the request succeeds.

I've been bitten a few times by neglecting to supply the optional action. A warning would have helped me suss out where my error lie and why my handlers using `dispatchRequestEx` were not being called.