### PR TITLE
Activity Log: Add Get Help button in split menu

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -20,6 +20,7 @@ import SplitButton from 'components/split-button';
 import FoldableCard from 'components/foldable-card';
 import FormattedBlock from 'components/notes-formatted-block';
 import PopoverMenuItem from 'components/popover/menu-item';
+import PopoverMenuSeparator from 'components/popover/menu-separator';
 import {
 	rewindBackup,
 	rewindBackupDismiss,
@@ -36,7 +37,8 @@ import {
 	getSiteGmtOffset,
 	getSiteTimezoneValue,
 } from 'state/selectors';
-
+import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
+import { openChat } from 'state/happychat/ui/actions';
 import { adjustMoment } from '../activity-log/utils';
 
 class ActivityLogItem extends Component {
@@ -86,7 +88,15 @@ class ActivityLogItem extends Component {
 	}
 
 	renderRewindAction() {
-		const { createBackup, createRewind, disableRestore, disableBackup, translate } = this.props;
+		const {
+			createBackup,
+			createRewind,
+			disableRestore,
+			disableBackup,
+			isChatAvailable,
+			translate,
+			triggerChat,
+		} = this.props;
 
 		return (
 			<div className="activity-log-item__action">
@@ -105,6 +115,14 @@ class ActivityLogItem extends Component {
 						onClick={ createBackup }
 					>
 						{ translate( 'Download backup' ) }
+					</PopoverMenuItem>
+					<PopoverMenuSeparator />
+					<PopoverMenuItem
+						icon="help"
+						onClick={ isChatAvailable ? triggerChat : null }
+						href={ isChatAvailable ? null : '/help' }
+					>
+						{ translate( 'Get help' ) }
 					</PopoverMenuItem>
 				</SplitButton>
 			</div>
@@ -223,6 +241,7 @@ const mapStateToProps = ( state, { activityId, siteId } ) => ( {
 	mightBackup: activityId && activityId === getRequestedBackup( state, siteId ),
 	mightRewind: activityId && activityId === getRequestedRewind( state, siteId ),
 	timezone: getSiteTimezoneValue( state, siteId ),
+	isChatAvailable: isHappychatAvailable( state ),
 } );
 
 const mapDispatchToProps = ( dispatch, { activityId, siteId } ) => ( {
@@ -272,6 +291,10 @@ const mapDispatchToProps = ( dispatch, { activityId, siteId } ) => ( {
 			)
 		)
 	),
+	triggerChat: () =>
+		dispatch(
+			withAnalytics( recordTracksEvent( 'calypso_activitylog_splitbutton_get_help' ), openChat() )
+		),
 	getHelpClick: () => recordTracksEvent( 'calypso_activitylog_threat_get_help' ),
 } );
 


### PR DESCRIPTION
This PR adds a "Get help" button in the split-menu on rewindable Activity Log items. When Happychat is available, it will simply open a chat window. When Happychat is not available, it will link to `/help` instead.

![screen shot 2018-02-14 at 12 29 57 pm](https://user-images.githubusercontent.com/5528445/36218664-23d0f772-1183-11e8-8645-13960f6a9acf.png)

**Testing instructions**
1. Load the Activity Log on a rewindable site. 
2. Observe the "Get help" button in the split menu popover.
3. Clicking "Get help" should open a Happychat module when Happychat is available (test in hud-staging) and it should like to `/help` otherwise.
4. Ensure there are no additional disruptions to the UI.