### PR TITLE
Activity Log: add a Get help button in failed backup events

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import scrollTo from 'lib/scroll-to';
 import { localize } from 'i18n-calypso';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -76,12 +77,12 @@ class ActivityLogItem extends Component {
 	renderItemAction() {
 		const { hideRestore, activity: { activityIsRewindable, activityName } } = this.props;
 
-		if ( ! hideRestore && activityIsRewindable ) {
-			return this.renderRewindAction();
+		if ( includes( [ 'rewind__scan_result_found', 'rewind__backup_error' ], activityName ) ) {
+			return this.renderHelpAction();
 		}
 
-		if ( 'rewind__scan_result_found' === activityName ) {
-			return this.renderHelpAction();
+		if ( ! hideRestore && activityIsRewindable ) {
+			return this.renderRewindAction();
 		}
 	}
 


### PR DESCRIPTION
Fixes #22357

This PR introduces a Get help button for failed backup events.

<img width="692" alt="captura de pantalla 2018-02-14 a la s 15 26 49" src="https://user-images.githubusercontent.com/1041600/36221190-0e81afb0-119c-11e8-95d9-e8f41f766bf0.png">

It also moves the logic to add a Get help button for failed backup or threats above the condition that checks if an event is rewindable since these events are intrinsically not rewindable so we can exit earlier if one shows up.

### Testing

Should work with any kind of site. Happychat will probably not shown in Calypso dev, so log into the staging Happychat site or fake it by setting the prop
```
isChatAvailable: true
```
in the HappychatButton component using React dev tools.