### PR TITLE
JP Onboarding: Increase delay and attempts in retryPolicy of Save action

### DIFF
--- a/client/state/data-layer/wpcom/jetpack-onboarding/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/index.js
@@ -156,7 +156,7 @@ export const retryOrAnnounceSaveFailure = ( { dispatch }, action ) => {
 		return announceSaveFailure( { dispatch }, { siteId } );
 	}
 
-	// We cannot use `extendAction( action, ... )` here, since `meta.datayLayer` now includes error information,
+	// We cannot use `extendAction( action, ... )` here, since `meta.dataLayer` now includes error information,
 	// which we would propagate, causing the data layer to think there's been an error on the subsequent attempt.
 	// Instead, we have to re-assemble our action.
 	dispatch( {

--- a/client/state/data-layer/wpcom/jetpack-onboarding/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/index.js
@@ -153,8 +153,9 @@ export const announceSaveFailure = ( { dispatch }, action ) => {
 	}
 
 	// We cannot use `extendAction( action, ... )` here, since `meta.datayLayer` now includes error information,
-	// which we would propagate.
-	const updatedAction = {
+	// which we would propagate, causing the data layer to think there's been an error on the subsequent attempt.
+	// Instead, we have to re-assemble our action.
+	dispatch( {
 		settings,
 		siteId,
 		type,
@@ -164,11 +165,7 @@ export const announceSaveFailure = ( { dispatch }, action ) => {
 				trackRequest: true,
 			},
 		},
-	};
-
-	console.log( 'updatedAction', updatedAction );
-
-	dispatch( updatedAction );
+	} );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/jetpack-onboarding/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/index.js
@@ -141,7 +141,7 @@ export const announceSaveFailure = ( { dispatch }, { siteId } ) => {
 };
 
 export const retryOrAnnounceSaveFailure = ( { dispatch }, action ) => {
-	const MAX_WOOCOMMERCE_INSTALL_RETRIES = 3;
+	const MAX_WOOCOMMERCE_INSTALL_RETRIES = 2;
 	const { settings, siteId, type, meta: { dataLayer } } = action;
 	const { error, retryCount = 0 } = dataLayer;
 

--- a/client/state/data-layer/wpcom/jetpack-onboarding/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/index.js
@@ -140,10 +140,10 @@ export const announceSaveFailure = ( { dispatch }, { siteId } ) => {
 	);
 };
 
-export const retryOrAnnounceSaveFailure = ( { dispatch }, action ) => {
+export const retryOrAnnounceSaveFailure = ( { dispatch }, action, error ) => {
 	const MAX_WOOCOMMERCE_INSTALL_RETRIES = 2;
 	const { settings, siteId, type, meta: { dataLayer } } = action;
-	const { error, retryCount = 0 } = dataLayer;
+	const { retryCount = 0 } = dataLayer;
 
 	// If we got a timeout on WooCommerce installation, try again (up to 3 times),
 	// since it might just be a slow server that actually ends up installing it

--- a/client/state/data-layer/wpcom/jetpack-onboarding/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/index.js
@@ -133,14 +133,13 @@ export const saveJetpackOnboardingSettings = ( { dispatch, getState }, action ) 
 export const handleSaveSuccess = ( { dispatch }, { siteId, settings } ) =>
 	dispatch( saveJetpackOnboardingSettingsSuccess( siteId, settings ) );
 
-export const announceSaveFailure = ( { dispatch }, { siteId } ) => {
+export const announceSaveFailure = ( { dispatch }, { siteId } ) =>
 	dispatch(
 		errorNotice( translate( 'An unexpected error occurred. Please try again later.' ), {
 			id: `jpo-notice-error-${ siteId }`,
 			duration: 5000,
 		} )
 	);
-};
 
 export const retryOrAnnounceSaveFailure = ( { dispatch }, action, { message: errorMessage } ) => {
 	const { settings, siteId, type, meta: { dataLayer } } = action;

--- a/client/state/data-layer/wpcom/jetpack-onboarding/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, startsWith } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -151,7 +151,7 @@ export const retryOrAnnounceSaveFailure = ( { dispatch }, action, error ) => {
 	// properly, in which case a subsequent request will return 'success'.
 	if (
 		get( settings, 'installWooCommerce' ) !== true ||
-		error.error !== 'http_request_failed' ||
+		! startsWith( error.message, 'cURL error 28' ) || // cURL timeout
 		retryCount > MAX_WOOCOMMERCE_INSTALL_RETRIES
 	) {
 		return announceSaveFailure( { dispatch }, { siteId } );

--- a/client/state/data-layer/wpcom/jetpack-onboarding/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/index.js
@@ -140,7 +140,7 @@ export const announceSaveFailure = ( { dispatch }, { siteId } ) => {
 	);
 };
 
-export const retryOrAnnounceFailure = ( { dispatch }, action ) => {
+export const retryOrAnnounceSaveFailure = ( { dispatch }, action ) => {
 	const MAX_WOOCOMMERCE_INSTALL_RETRIES = 3;
 	const { settings, siteId, type, meta: { dataLayer } } = action;
 	const { error, retryCount = 0 } = dataLayer;
@@ -184,6 +184,6 @@ export default {
 		),
 	],
 	[ JETPACK_ONBOARDING_SETTINGS_SAVE ]: [
-		dispatchRequest( saveJetpackOnboardingSettings, handleSaveSuccess, retryOrAnnounceFailure ),
+		dispatchRequest( saveJetpackOnboardingSettings, handleSaveSuccess, retryOrAnnounceSaveFailure ),
 	],
 };

--- a/client/state/data-layer/wpcom/jetpack-onboarding/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/index.js
@@ -149,7 +149,7 @@ export const retryOrAnnounceSaveFailure = ( { dispatch }, action ) => {
 	// since it might just be a slow server that actually ends up installing it
 	// properly, in which case a subsequent request will return 'success'.
 	if (
-		settings.installWooCommerce !== true ||
+		get( settings, 'installWooCommerce' ) !== true ||
 		error.error !== 'http_request_failed' ||
 		retryCount > MAX_WOOCOMMERCE_INSTALL_RETRIES
 	) {

--- a/client/state/data-layer/wpcom/jetpack-onboarding/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/index.js
@@ -23,6 +23,8 @@ import {
 } from 'state/jetpack-onboarding/actions';
 import { trailingslashit } from 'lib/route';
 
+export const MAX_WOOCOMMERCE_INSTALL_RETRIES = 2;
+
 export const fromApi = response => {
 	if ( ! response.data || ! response.data.onboarding ) {
 		throw new Error( 'missing onboarding settings' );
@@ -141,7 +143,6 @@ export const announceSaveFailure = ( { dispatch }, { siteId } ) => {
 };
 
 export const retryOrAnnounceSaveFailure = ( { dispatch }, action, error ) => {
-	const MAX_WOOCOMMERCE_INSTALL_RETRIES = 2;
 	const { settings, siteId, type, meta: { dataLayer } } = action;
 	const { retryCount = 0 } = dataLayer;
 

--- a/client/state/data-layer/wpcom/jetpack-onboarding/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/index.js
@@ -142,7 +142,7 @@ export const announceSaveFailure = ( { dispatch }, { siteId } ) => {
 	);
 };
 
-export const retryOrAnnounceSaveFailure = ( { dispatch }, action, error ) => {
+export const retryOrAnnounceSaveFailure = ( { dispatch }, action, { message: errorMessage } ) => {
 	const { settings, siteId, type, meta: { dataLayer } } = action;
 	const { retryCount = 0 } = dataLayer;
 
@@ -151,7 +151,7 @@ export const retryOrAnnounceSaveFailure = ( { dispatch }, action, error ) => {
 	// properly, in which case a subsequent request will return 'success'.
 	if (
 		get( settings, 'installWooCommerce' ) !== true ||
-		! startsWith( error.message, 'cURL error 28' ) || // cURL timeout
+		! startsWith( errorMessage, 'cURL error 28' ) || // cURL timeout
 		retryCount > MAX_WOOCOMMERCE_INSTALL_RETRIES
 	) {
 		return announceSaveFailure( { dispatch }, { siteId } );

--- a/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
@@ -10,6 +10,7 @@ import {
 	handleSaveSuccess,
 	announceRequestFailure,
 	announceSaveFailure,
+	retryOrAnnounceSaveFailure,
 	fromApi,
 } from '../';
 import {
@@ -277,6 +278,45 @@ describe( 'announceSaveFailure()', () => {
 					noticeId: `jpo-notice-error-${ siteId }`,
 					duration: 5000,
 				} ),
+			} )
+		);
+	} );
+} );
+
+describe( 'retryOrAnnounceSaveFailure()', () => {
+	const dispatch = jest.fn();
+	const siteId = 12345678;
+	const settings = {
+		installWooCommerce: true,
+	};
+	const action = {
+		type: JETPACK_ONBOARDING_SETTINGS_SAVE,
+		siteId,
+		settings,
+		meta: {
+			dataLayer: {
+				error: {
+					error: 'http_request_failed',
+				},
+				trackRequest: true,
+			},
+		},
+	};
+
+	test( 'should trigger saveJetpackOnboardingSettings action with retryCount === 1 upon WooCommerce install timeout', () => {
+		retryOrAnnounceSaveFailure( { dispatch }, action );
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				settings,
+				siteId,
+				type: JETPACK_ONBOARDING_SETTINGS_SAVE,
+				meta: {
+					dataLayer: {
+						retryCount: 1,
+						trackRequest: true,
+					},
+				},
 			} )
 		);
 	} );

--- a/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
@@ -5,6 +5,7 @@
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
 import {
+	MAX_WOOCOMMERCE_INSTALL_RETRIES,
 	requestJetpackOnboardingSettings,
 	saveJetpackOnboardingSettings,
 	handleSaveSuccess,
@@ -321,14 +322,14 @@ describe( 'retryOrAnnounceSaveFailure()', () => {
 		);
 	} );
 
-	test( 'should trigger announceSaveFailure upon third WooCommerce install timeout', () => {
+	test( 'should trigger announceSaveFailure upon max number of WooCommerce install timeout', () => {
 		const thirdAttemptAction = {
 			...action,
 			meta: {
 				...action.meta,
 				dataLayer: {
 					...action.meta.dataLayer,
-					retryCount: 3,
+					retryCount: MAX_WOOCOMMERCE_INSTALL_RETRIES + 1,
 				},
 			},
 		};

--- a/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
@@ -303,7 +303,7 @@ describe( 'retryOrAnnounceSaveFailure()', () => {
 		},
 	};
 
-	test( 'should trigger saveJetpackOnboardingSettings action with retryCount === 1 upon WooCommerce install timeout', () => {
+	test( 'should trigger saveJetpackOnboardingSettings upon first WooCommerce install timeout', () => {
 		retryOrAnnounceSaveFailure( { dispatch }, action );
 
 		expect( dispatch ).toHaveBeenCalledWith(
@@ -317,6 +317,32 @@ describe( 'retryOrAnnounceSaveFailure()', () => {
 						trackRequest: true,
 					},
 				},
+			} )
+		);
+	} );
+
+	test( 'should trigger announceSaveFailure upon third WooCommerce install timeout', () => {
+		const thirdAttemptAction = {
+			...action,
+			meta: {
+				...action.meta,
+				dataLayer: {
+					...action.meta.dataLayer,
+					retryCount: 4,
+				},
+			},
+		};
+
+		retryOrAnnounceSaveFailure( { dispatch }, thirdAttemptAction );
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				notice: expect.objectContaining( {
+					status: 'is-error',
+					text: 'An unexpected error occurred. Please try again later.',
+					noticeId: `jpo-notice-error-${ siteId }`,
+					duration: 5000,
+				} ),
 			} )
 		);
 	} );

--- a/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
@@ -302,6 +302,7 @@ describe( 'retryOrAnnounceSaveFailure()', () => {
 	};
 	const error = {
 		error: 'http_request_failed',
+		message: 'cURL error 28: Operation timed out after 5001 milliseconds with 0 bytes received',
 	};
 
 	test( 'should trigger saveJetpackOnboardingSettings upon first WooCommerce install timeout', () => {

--- a/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
@@ -328,7 +328,7 @@ describe( 'retryOrAnnounceSaveFailure()', () => {
 				...action.meta,
 				dataLayer: {
 					...action.meta.dataLayer,
-					retryCount: 4,
+					retryCount: 3,
 				},
 			},
 		};

--- a/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-onboarding/test/index.js
@@ -295,16 +295,16 @@ describe( 'retryOrAnnounceSaveFailure()', () => {
 		settings,
 		meta: {
 			dataLayer: {
-				error: {
-					error: 'http_request_failed',
-				},
 				trackRequest: true,
 			},
 		},
 	};
+	const error = {
+		error: 'http_request_failed',
+	};
 
 	test( 'should trigger saveJetpackOnboardingSettings upon first WooCommerce install timeout', () => {
-		retryOrAnnounceSaveFailure( { dispatch }, action );
+		retryOrAnnounceSaveFailure( { dispatch }, action, error );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
@@ -333,7 +333,7 @@ describe( 'retryOrAnnounceSaveFailure()', () => {
 			},
 		};
 
-		retryOrAnnounceSaveFailure( { dispatch }, thirdAttemptAction );
+		retryOrAnnounceSaveFailure( { dispatch }, thirdAttemptAction, error );
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			expect.objectContaining( {

--- a/client/state/jetpack-onboarding/actions.js
+++ b/client/state/jetpack-onboarding/actions.js
@@ -27,14 +27,13 @@ export const requestJetpackOnboardingSettings = siteId => ( {
 	},
 } );
 
-export const saveJetpackOnboardingSettings = ( siteId, settings, attempt = 3 ) => ( {
+export const saveJetpackOnboardingSettings = ( siteId, settings ) => ( {
 	type: JETPACK_ONBOARDING_SETTINGS_SAVE,
 	siteId,
 	settings,
 	meta: {
 		dataLayer: {
 			trackRequest: true,
-			retryCount: attempt,
 		},
 	},
 } );

--- a/client/state/jetpack-onboarding/actions.js
+++ b/client/state/jetpack-onboarding/actions.js
@@ -27,13 +27,14 @@ export const requestJetpackOnboardingSettings = siteId => ( {
 	},
 } );
 
-export const saveJetpackOnboardingSettings = ( siteId, settings ) => ( {
+export const saveJetpackOnboardingSettings = ( siteId, settings, attempt = 3 ) => ( {
 	type: JETPACK_ONBOARDING_SETTINGS_SAVE,
 	siteId,
 	settings,
 	meta: {
 		dataLayer: {
 			trackRequest: true,
+			retryCount: attempt,
 		},
 	},
 } );


### PR DESCRIPTION
If WooCommerce installation times out on the self-hosted site (because it was too slow to fetch the plugin via `curl` from WordPress.org servers), instead of showing an error message, retry two more times. The `POST` action we're performing won't break anything upon subsequent attempts (and is actually idempotent AFAICT), and plugin fetching and installation might have been successful by the time we try again, and thus return a 'success' code.

I'm essentially mimicking behavior that the data-layer's [`retry-on-failure` ](https://github.com/Automattic/wp-calypso/tree/master/client/state/data-layer/wpcom-http/pipeline/retry-on-failure) would give us, if we [weren't dealing](https://github.com/Automattic/wp-calypso/blob/f8b29158dc801399f4b91a32cda9cef1fc94bffd/client/state/data-layer/wpcom-http/pipeline/retry-on-failure/index.jsx#L23-L26) with a `POST` request here.

Fixes #21929.

To test:
* You need a self-hosted WP install that somewhat reproducibly times out on WooCommerce install during JPO: Pressable seems to do the trick.
* Verify on `master` or wpcalypso/staging that you get the error documented in #21929.
* Check out this branch in your local Calypso dev environment.
* Make sure WooCommerce is not installed on your self-hosted site.
* Start the JPO flow at https://yourslow.mystagingwebsite.com/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development
* When prompted, select 'Business Site' as site type.
* Skip thru to the WooCommerce installation step, click the 'Yes' button there.
* On the summary page, wait a little. You shouldn't see any error notice. Then, check Redux dev tools: among the last actions dispatched, there should be a`JETPACK_ONBOARDING_SETTINGS_SAVE_SUCCESS` action with `settings: {installWooCommerce: true }` payload, indicating that installation was successful.
* On your site's `wp-admin`, verify that WooCommerce has been successfully installed and activated.

## Possible alternative approach:
This PR doesn't do a very faithful job in mimicking `retry-on-failure` (e.g. when it comes to timeouts), and it might not make sense to actually copy that fancy implementation over b/c redundancy sucks. Maybe it's instead worth considering adding a flag to `retry-on-failure` to enable retries for `POST` requests. I think the relevant criterion is idempotency, so I'd probably make it a boolean flag called `idempotent` in `meta.dataLayer`. 