### PR TITLE
Editor: Default the editor’s preview to desktop

### DIFF
--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -135,7 +135,6 @@ class EditorPreview extends React.Component {
 						showEdit={ true }
 						showExternal={ true }
 						showUrl={ true }
-						defaultViewportDevice={ this.props.defaultViewportDevice }
 						onClose={ this.props.onClose }
 						onEdit={ this.props.onEdit }
 						previewUrl={ this.state.iframeUrl }
@@ -149,7 +148,6 @@ class EditorPreview extends React.Component {
 				) : (
 					<WebPreview
 						showPreview={ this.props.showPreview }
-						defaultViewportDevice={ this.props.defaultViewportDevice }
 						onClose={ this.props.onClose }
 						previewUrl={ this.state.iframeUrl }
 						externalUrl={ this.cleanExternalUrl( this.props.externalUrl ) }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -442,7 +442,7 @@ export const PostEditor = createReactClass( {
 							postId={ this.props.postId }
 							externalUrl={ this.getExternalUrl() }
 							editUrl={ this.props.editPath }
-							defaultViewportDevice={ this.state.isPostPublishPreview ? 'computer' : 'tablet' }
+							defaultViewportDevice={ 'computer' }
 							revision={ get( this.state, 'post.revisions.length', 0 ) }
 						/>
 					) : null }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -442,7 +442,6 @@ export const PostEditor = createReactClass( {
 							postId={ this.props.postId }
 							externalUrl={ this.getExternalUrl() }
 							editUrl={ this.props.editPath }
-							defaultViewportDevice={ 'computer' }
 							revision={ get( this.state, 'post.revisions.length', 0 ) }
 						/>
 					) : null }


### PR DESCRIPTION
For some reason, the editor's preview feature defaults to showing the tablet view. I don't know why. But this PR makes it default to the desktop view, which happens to scale as you would expect for small and large screens.

To test:
- Start a new post/page, or edit an existing one
- Click/Tap on the Preview button
- Confirm that the preview defaults to the "Desktop" view (Note, on mobile, the device picker is hidden.)

Before:
<img width="1408" alt="screen shot 2018-02-14 at 2 00 03 pm" src="https://user-images.githubusercontent.com/191598/36222537-9386f254-118f-11e8-9070-1d673c69ee28.png">

After:
<img width="1408" alt="screen shot 2018-02-14 at 1 59 45 pm" src="https://user-images.githubusercontent.com/191598/36222547-984172f6-118f-11e8-8009-6f24d2338669.png">

Fixes #22420 