### PR TITLE
Activity Log: add buttons to update a plugin in their respective update events

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -3,10 +3,12 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import scrollTo from 'lib/scroll-to';
 import { localize } from 'i18n-calypso';
+import { get, map, merge, forEach, every, includes, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -39,12 +41,127 @@ import {
 	getRewindState,
 } from 'state/selectors';
 import { adjustMoment } from '../activity-log/utils';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSite } from 'state/sites/selectors';
+import { updatePlugin } from 'state/plugins/installed/actions';
+import { getPluginOnSite, getStatusForPlugin } from 'state/plugins/installed/selectors';
+import PluginNotices from 'lib/plugins/notices';
+import { errorNotice, infoNotice, successNotice, removeNotice } from 'state/notices/actions';
 
 class ActivityLogItem extends Component {
+	static propTypes = {
+		siteId: PropTypes.number.isRequired,
+
+		// Connected props
+		siteSlug: PropTypes.string.isRequired,
+
+		// localize
+		translate: PropTypes.func.isRequired,
+	};
+
+	state = {
+		// keyed by plugin id, like "hello-dolly/hello"
+		pluginUpdateNotice: null,
+	};
+
 	confirmBackup = () => this.props.confirmBackup( this.props.activity.rewindId );
 
 	confirmRewind = () => this.props.confirmRewind( this.props.activity.rewindId );
+
+	updatePlugins = ( singlePlugin = false ) => {
+		const { removeThisNotice, showInfoNotice, site, updateSinglePlugin } = this.props;
+		const noticesToShow = {};
+
+		forEach( singlePlugin.id ? [ singlePlugin ] : this.props.pluginsToUpdate, plugin => {
+			// Use id: "hello-dolly/hello", slug: "hello-dolly", name: "Hello Dolly", updateStatus: bool|object,
+			const updateNoticeId = get(
+				this.state.pluginUpdateNotice,
+				[ plugin.id, 'notice', 'noticeId' ],
+				null
+			);
+
+			if ( updateNoticeId ) {
+				removeThisNotice( updateNoticeId );
+			}
+
+			updateSinglePlugin( plugin );
+
+			noticesToShow[ plugin.id ] = showInfoNotice(
+				PluginNotices.inProgressMessage( 'UPDATE_PLUGIN', '1 site 1 plugin', {
+					plugin: plugin.name,
+					site: site.name,
+				} ),
+				{
+					showDismiss: false,
+				}
+			);
+		} );
+
+		if ( ! isEmpty( noticesToShow ) ) {
+			this.setState( {
+				pluginUpdateNotice: merge( {}, this.state.pluginUpdateNotice, noticesToShow ),
+			} );
+		}
+	};
+
+	componentWillReceiveProps( nextProps ) {
+		const noticesToShow = {};
+
+		forEach( nextProps.pluginsToUpdate, ( plugin, key ) => {
+			if (
+				this.props.pluginsToUpdate[ key ].updateStatus.status === plugin.updateStatus.status ||
+				'inProgress' === plugin.updateStatus.status
+			) {
+				return;
+			}
+
+			const updateStatus = plugin.updateStatus;
+			const updateNoticeId = get(
+				this.state.pluginUpdateNotice,
+				[ plugin.id, 'notice', 'noticeId' ],
+				null
+			);
+
+			// If there is no notice displayed
+			if ( ! updateNoticeId ) {
+				return;
+			}
+
+			const { removeThisNotice, showErrorNotice, showSuccessNotice, site, translate } = nextProps;
+
+			// If it errored, clear and show error notice
+			const pluginData = {
+				plugin: plugin.name,
+				site: site.name,
+			};
+
+			switch ( updateStatus.status ) {
+				case 'error':
+					removeThisNotice( updateNoticeId );
+					noticesToShow[ plugin.id ] = showErrorNotice(
+						PluginNotices.singleErrorMessage( 'UPDATE_PLUGIN', pluginData, {
+							error: updateStatus,
+						} ),
+						{
+							button: translate( 'Try again' ),
+							onClick: () => this.updatePlugins( plugin ),
+						}
+					);
+					break;
+				case 'completed':
+					removeThisNotice( updateNoticeId );
+					noticesToShow[ plugin.id ] = showSuccessNotice(
+						PluginNotices.successMessage( 'UPDATE_PLUGIN', '1 site 1 plugin', pluginData )
+					);
+					break;
+			}
+		} );
+
+		if ( ! isEmpty( noticesToShow ) ) {
+			this.setState( {
+				pluginUpdateNotice: merge( {}, this.state.pluginUpdateNotice, noticesToShow ),
+			} );
+		}
+	}
 
 	renderHeader() {
 		const { activityTitle, actorAvatarUrl, actorName, actorRole, actorType } = this.props.activity;
@@ -98,9 +215,33 @@ class ActivityLogItem extends Component {
 		const {
 			hideRestore,
 			activity: { activityIsRewindable, activityName, activityMeta },
+			plugin,
+			translate,
+			pluginsToUpdate,
 		} = this.props;
 
 		switch ( activityName ) {
+			case 'plugin__update_available':
+				// If every plugin is either still updating or finished successfully, hide the button.
+				if (
+					every( map( pluginsToUpdate, ( { updateStatus } ) => updateStatus.status ), status =>
+						includes( [ 'inProgress', 'completed' ], status )
+					)
+				) {
+					return null;
+				}
+				return (
+					plugin.update && (
+						<Button
+							primary
+							compact
+							className="activity-log-item__action"
+							onClick={ this.updatePlugins }
+						>
+							{ translate( 'Update plugin', 'Update plugins', { count: pluginsToUpdate.length } ) }
+						</Button>
+					)
+				);
 			case 'plugin__update_failed':
 			case 'rewind__scan_result_found':
 				return this.renderHelpAction();
@@ -277,17 +418,50 @@ class ActivityLogItem extends Component {
 	}
 }
 
+/**
+ * Creates a numeric indexed array of objects with props
+ * {
+ * 		pluginId   string       Plugin directory and base file name without extension
+ * 		pluginSlug string       Plugin directory
+ * 		status     object|false Current update status
+ * }
+ * @param {array}  pluginList List of plugins that will be updated
+ * @param {object} state      Progress of plugin update as found in status.plugins.installed.state.
+ * @param {number} siteId     ID of the site where the plugin is installed
+ *
+ * @returns {array} List of plugins to update with their status.
+ */
+const makeListPluginsToUpdate = ( pluginList, state, siteId ) =>
+	map( pluginList, plugin =>
+		merge(
+			{ updateStatus: getStatusForPlugin( state, siteId, plugin.pluginId ) },
+			getPluginOnSite( state, siteId, plugin.pluginSlug )
+		)
+	);
+
 const mapStateToProps = ( state, { activityId, siteId } ) => {
 	const rewindState = getRewindState( state, siteId );
+	const activity = getActivityLog( state, siteId, activityId );
+	const pluginSlug = get( activity.activityMeta, 'pluginSlug', {} );
+	const pluginId = get( activity.activityMeta, 'pluginId', {} );
+	const site = getSite( state, siteId );
 	return {
-		activity: getActivityLog( state, siteId, activityId ),
+		activity,
 		gmtOffset: getSiteGmtOffset( state, siteId ),
 		mightBackup: activityId && activityId === getRequestedBackup( state, siteId ),
 		mightRewind: activityId && activityId === getRequestedRewind( state, siteId ),
 		timezone: getSiteTimezoneValue( state, siteId ),
-		siteSlug: getSiteSlug( state, siteId ),
+		siteSlug: site.slug,
 		rewindIsActive: 'active' === rewindState.state || 'provisioning' === rewindState.state,
 		canAutoconfigure: rewindState.canAutoconfigure,
+		site,
+		plugin: getPluginOnSite( state, siteId, pluginSlug ),
+		pluginStatus: getStatusForPlugin( state, siteId, pluginId ),
+		pluginsToUpdate: makeListPluginsToUpdate(
+			get( activity.activityMeta, 'pluginsToUpdate', [] ),
+			state,
+			siteId
+		),
 	};
 };
 
@@ -343,6 +517,11 @@ const mapDispatchToProps = ( dispatch, { activityId, siteId } ) => ( {
 			recordTracksEvent( 'calypso_activitylog_event_get_help', { activity_name: activityName } )
 		),
 	trackFixCreds: () => dispatch( recordTracksEvent( 'calypso_activitylog_event_fix_credentials' ) ),
+	updateSinglePlugin: plugin => dispatch( updatePlugin( siteId, plugin ) ),
+	showErrorNotice: ( error, options ) => dispatch( errorNotice( error, options ) ),
+	showInfoNotice: ( info, options ) => dispatch( infoNotice( info, options ) ),
+	showSuccessNotice: ( success, options ) => dispatch( successNotice( success, options ) ),
+	removeThisNotice: noticeId => dispatch( removeNotice( noticeId ) ),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( ActivityLogItem ) );

--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -319,3 +319,27 @@
 		margin-top: 1.5rem;
 	}
 }
+
+.activity-log-item__quick-action-progress {
+}
+
+.activity-log-item__quick-action-success {
+	color: $alert-green;
+	animation-name: fade-out-success;
+	animation-fill-mode: forwards;
+	animation-delay: 2s;
+	animation-duration: 2s;
+}
+
+.activity-log-item__quick-action-error {
+	color: $alert-red;
+}
+
+@keyframes fade-out-success {
+	0% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+	}
+}

--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -30,6 +30,7 @@ import QueryActivityLog from 'components/data/query-activity-log';
 import QueryRewindState from 'components/data/query-rewind-state';
 import QuerySiteSettings from 'components/data/query-site-settings'; // For site time offset
 import QueryRewindBackupStatus from 'components/data/query-rewind-backup-status';
+import QueryJetpackPlugins from 'components/data/query-jetpack-plugins/';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsNavigation from 'blocks/stats-navigation';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
@@ -614,6 +615,7 @@ class ActivityLog extends Component {
 				<PageViewTracker path="/stats/activity/:site" title="Stats > Activity" />
 				<DocumentHead title={ translate( 'Stats' ) } />
 				<QueryRewindState siteId={ siteId } />
+				<QueryJetpackPlugins siteIds={ [ siteId ] } />
 				{ '' !== rewindNoThanks && rewindIsNotReady
 					? siteId && <ActivityLogSwitch siteId={ siteId } redirect={ rewindNoThanks } />
 					: this.getActivityLog() }


### PR DESCRIPTION
Fixes #22369 

This PR introduces inline buttons inside an event to update it when there's an update available.

<img width="755" alt="captura de pantalla 2018-04-11 a la s 20 02 09" src="https://user-images.githubusercontent.com/1041600/38647691-053e5cb0-3dc4-11e8-8b27-ad897ca47b72.png">
<img width="760" alt="captura de pantalla 2018-04-11 a la s 20 01 52" src="https://user-images.githubusercontent.com/1041600/38647693-05c98164-3dc4-11e8-876c-1edf6bc7c03d.png">
<img width="749" alt="captura de pantalla 2018-04-11 a la s 20 02 13" src="https://user-images.githubusercontent.com/1041600/38647694-05f4fa38-3dc4-11e8-91f7-4d51aa5e9bed.png">

For multiple plugin updates, their statuses are handled separately:
<img width="682" alt="captura de pantalla 2018-04-12 a la s 19 59 21" src="https://user-images.githubusercontent.com/1041600/38744692-db2e968c-3f18-11e8-922a-4d2fbf6eb6c8.png">

### Testing

Force a plugin update available event by editing the plugin version number in your `wp-admin/plugin-editor.php`. If you do two simultaneously, they will show up as a multiple updates available event.

Go to AL and make sure you see the button.

Before updating, you might want to try the error case: you can access the `wp-content/plugins/` directory and change the permissions to 555 for the directory of some of the edited plugins that have updates available so the directory is non writable. This will trigger the error `Could not remove the old plugin. (remove_old_failed)` because WP won't be able to remove the plugin directory.

Once you verify the error case is working, revert the permission and try again.