### PR TITLE
Invites: enable invite management from wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -61,6 +61,7 @@
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
+		"manage/people/invites": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/setup": true,


### PR DESCRIPTION
This PR enables the Invites screen within People management in wpcalypso.

The feature flag is already enabled in other environments. This will help in testing.