### PR TITLE
Rewind: Refresh the Activity Log after a Rewind operation

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
@@ -10,9 +10,10 @@ import { translate } from 'i18n-calypso';
 import { REWIND_RESTORE } from 'state/action-types';
 import { getRewindRestoreProgress } from 'state/activity-log/actions';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
-import { errorNotice } from 'state/notices/actions';
 import { SchemaError, dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { errorNotice } from 'state/notices/actions';
+import { requestRewindState } from 'state/rewind/actions';
 
 const fromApi = data => {
 	const restoreId = parseInt( data.restore_id, 10 );
@@ -34,8 +35,13 @@ const requestRestore = action =>
 		action
 	);
 
-export const receiveRestoreSuccess = ( { siteId, timestamp }, restoreId ) =>
-	getRewindRestoreProgress( siteId, restoreId );
+export const receiveRestoreSuccess = ( { siteId, timestamp }, restoreId ) => [
+	getRewindRestoreProgress( siteId, restoreId ),
+
+	// once we start Rewinding we want to ensure that we
+	// start tracking it and updating the "state machine"
+	requestRewindState( siteId ),
+];
 
 export const receiveRestoreError = ( { siteId, timestamp }, error ) =>
 	error.hasOwnProperty( 'schemaErrors' )

--- a/client/state/data-layer/wpcom/activity-log/rewind/to/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/test/index.js
@@ -12,7 +12,7 @@ const restoreId = 12345;
 describe( 'receiveRestoreSuccess', () => {
 	test( 'should dispatch get restore progress on success', () => {
 		expect( receiveRestoreSuccess( { siteId, timestamp }, restoreId ) ).toEqual(
-			getRewindRestoreProgress( siteId, restoreId )
+			expect.arrayContaining( [ getRewindRestoreProgress( siteId, restoreId ) ] )
 		);
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -66,8 +66,7 @@ const refreshActivityLogAfterRewind = ( siteId, rewind ) => ( dispatch, getState
 		return;
 	}
 
-	const queries = logItems.data.queries;
-	Object.keys( queries ).forEach( query =>
+	Object.keys( logItems.data.queries ).forEach( query =>
 		dispatch( activityLogRequest( siteId, fromPairs( JSON.parse( query ) ) ) )
 	);
 };

--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -41,7 +41,7 @@ const fetchRewindState = action =>
  * of Activity Log and Rewind state!
  *
  * It will not grab events we haven't already
- * gotten. Instead it will reissue the same reqeusts
+ * gotten. Instead it will re-issue the same requests
  * as previously made so that we get updates on
  * things like the `isDiscarded` status of events.
  *
@@ -87,7 +87,7 @@ const updateRewindState = ( { siteId }, data ) => {
 			 * When we finish a Rewind operation we may have
 			 * changed the `isDiscarded` value for previous
 			 * events in the Activity Log. Thus, we'll need to
-			 * reissue the requests which pulld all of the
+			 * reissue the requests which pulled all of the
 			 * previous events into Calypso.
 			 *
 			 * This _must_ go before the state update because
@@ -96,7 +96,7 @@ const updateRewindState = ( { siteId }, data ) => {
 			 * operation running to a time when we no longer
 			 * have that.
 			 *
-			 * If we wait until after state is updatd then it
+			 * If we wait until after state is updated then it
 			 * will never look like we had on.
 			 */
 			refreshActivityLogAfterRewind( siteId, data.rewind ),

--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -66,9 +66,10 @@ const refreshActivityLogAfterRewind = ( siteId, rewind ) => ( dispatch, getState
 		number: 1000,
 	};
 
-	// queue an update to them as well to grab more authoritative
-	// data just wait because it takes much longer on the server
-	// for all of the changes to propagate back
+	// queue to update all local activity log events
+	// we are waiting so long because it takes much
+	// longer on the server for all of the changes
+	// to propagate back than we would expect
 	setTimeout( () => dispatch( activityLogRequest( siteId, query ) ), 15000 );
 };
 

--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -54,22 +54,22 @@ const refreshActivityLogAfterRewind = ( siteId, rewind ) => ( dispatch, getState
 		return;
 	}
 
-	const dateStart = getActivityLogs( state, siteId ).reduce(
+	const events = getActivityLogs( state, siteId );
+	const dateStart = events.reduce(
 		( oldest, { activityTs: ts } ) => Math.min( oldest, ts ),
 		Infinity
 	);
 
-	setTimeout(
-		() =>
-			dispatch(
-				activityLogRequest( siteId, {
-					dateStart,
-					dateEnd: Date.now(),
-					number: 1000,
-				} )
-			),
-		15000
-	);
+	const query = {
+		dateStart,
+		dateEnd: Date.now(),
+		number: 1000,
+	};
+
+	// queue an update to them as well to grab more authoritative
+	// data just wait because it takes much longer on the server
+	// for all of the changes to propagate back
+	setTimeout( () => dispatch( activityLogRequest( siteId, query ) ), 15000 );
 };
 
 const updateRewindState = ( { siteId }, data ) => {


### PR DESCRIPTION
After a Rewind operation finishes then the entire list of
events in the Activity Log could be stale. The `isDiscarded`
property is affected by all future rewinds.

Therefore in this patch I'm attempting to refresh all of the
previously-fetched Activity Log events once we transition from
_Rewinding_ to _Not Rewinding_. This should clear up the stale
state.

This system relies on the fact that the Rewind API itself is going to
poll for updates whenever the Rewind status is `running`. That is, it
will automatically keep itself up-to-date until the Rewind finishes,
upon which we can make a decision whether or not to refresh the
Activity Log.

Future work needs to additionally make sure we pull in new events
because the very act of Rewinding creates a completion event. Those are
currently being overlooked.

Additionally, the complexity here is somewhat increased due to the way
that the `ActivityQueryManager` stores its own state. We are introducing
code that is strongly couples to several different implementation
details in order to perform the data refreshses. In the future it would
be nice if we had a clearer way to do this; I could be missing important
semantics of the `QueryManager` though.

@gwwar and @samouri I included you here because I feel like this is an
interesting use of the data layer handlers. the reason I did it here is that
it means the UI can be completely unaware of this data need. still, I would
appreciate some thought on the pattern and idea as a check against my
intuition and bias. much obliged!

**Testing**

Start a Rewind operation on a site with *Rewind* from **My Sites** > **Stats** > **Activity**
Watch the list of activity log entries. After the Rewind finishes you should
see a flood of network requests to `/sites/{ site }/activity` and hopefully
the **Activity** page itself will update showing new discarded states.

> Because of lag on the updates in the backend we are waiting 15 seconds to poll for updates. In my own testing I found that if we requested the updates much sooner then we wouldn't get any updated data in the API responses. This could be tuned and we could re-issue the requests again if things didn't change, but I find that excessive at this point.

http://iscalypsofastyet.com/branch?branch=rewind/refresh-activity-log-after-rewind
```
Delta:
chunk              stat_size           parsed_size           gzip_size
build                +2486 B  (+0.1%)       +582 B  (+0.0%)     +176 B  (+0.0%)
manifest                +0 B                  +0 B                +0 B
plans                 -279 B  (-0.0%)        -40 B  (-0.0%)      -43 B  (-0.1%)
settings-security     -279 B  (-0.1%)        -40 B  (-0.0%)      -46 B  (-0.2%)
signup                -279 B  (-0.0%)        -40 B  (-0.0%)      -31 B  (-0.0%)
stats                 -279 B  (-0.0%)        -40 B  (-0.0%)      -28 B  (-0.0%)
```