### PR TITLE
Reverting #22407 because of mobile regressions.

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -14,7 +14,7 @@
 
 	--sidebar-color: $gray-dark;
 	--sidebar-background: $gray-lighten-30;
-	--sidebar-gridicon-fill: $gray-darken-30;
+	--sidebar-gridicon-fill: $gray;
 	--sidebar-heading-color: $gray-darken-10;
 	--sidebar-footer-button-color: $gray-darken-10;
 	--sidebar-menu-link-secondary-text-color: $gray-darken-20;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -23,7 +23,6 @@
 	@include breakpoint( "<660px" ) {
 		left: -100%;
 		width: 100%;
-		background: $gray-light;
 		overflow-x: hidden;
 		max-height: calc( 100% - 47px );
 		pointer-events: none;
@@ -73,13 +72,10 @@
 // Sidebar group headings
 .sidebar__heading {
 	color: var( --sidebar-heading-color );
-	font-size: 14px;
-	margin: 16px 8px 6px 16px;
+	font-weight: 600;
+	font-size: 12px;
+	margin: 16px 8px 6px 14px;
 	display: flex;
-
-	@include breakpoint( ">660px" ) {
-		font-size: 13px;
-	}	
 }
 
 // Menu Links
@@ -94,10 +90,15 @@
 		display: flex;
 
 		@include breakpoint( "<660px" ) {
-			border-bottom: 1px solid lighten( $gray, 25 );
+			background-color: $gray-light;
+			border-bottom: 1px solid rgba( $gray-lighten-20, 0.5 );
 
 			&:first-child {
-				border-top: 1px solid lighten( $gray, 25 );
+				border-top: 1px solid $gray-lighten-20;
+			}
+
+			&:last-child {
+				border-bottom: 1px solid $gray-lighten-20;
 			}
 		}
 	}
@@ -117,6 +118,14 @@
 			width: 15%;
 
 			background: overflow-gradient( var( --sidebar-menu-a-first-child-after-background ) );
+
+			@include breakpoint( "<660px" ) {
+
+				background: linear-gradient(
+					to right,
+					rgba( $gray-light, 0 ),
+					rgba( $gray-light, 1 ) 50% );
+			}
 		}
 	}
 
@@ -166,6 +175,13 @@
 		margin-right: 6px;
 		flex-shrink: 0;
 
+		@include breakpoint( "<660px" ) {
+				top: 15px;
+				left: 16px;
+			height: 24px;
+			width: 24px;
+		}
+
 		// External indicator for sections that aren't available in Calypso
 		&.gridicons-external {
 			position: absolute;
@@ -191,12 +207,12 @@ a.sidebar__button, form.sidebar__button {
 	height: 24px;
 	margin-right: 8px;
 	line-height: 18px;
-	background-color: $white;
+	background-color: $gray-light;
 	color: $gray-darken-20;
 	font-size: 12px;
 	font-weight: 600;
 	border-radius: 3px;
-	border: 1px solid $gray-lighten-20;
+	border: 1px solid darken( $sidebar-bg-color, 10% );
 
 	@include breakpoint( "<660px" ) {
 		font-size: 14px;
@@ -236,7 +252,7 @@ form.sidebar__button input {
 
 		.sidebar__button {
 			color: $gray-dark;
-			border: 1px solid $gray-darken-30;
+			border: 1px solid darken( $sidebar-selected-color, 10% );
 
 			&:hover {
 				color: $blue-medium;
@@ -320,7 +336,7 @@ form.sidebar__button input {
 	}
 
 	a:hover, form:hover {
-		color: $blue-wordpress;
+		color: $blue-medium;
 
 		.sidebar__menu-link-secondary-text {
 			color: inherit;


### PR DESCRIPTION
`:after` elements are now showing through sidebar items. This was discovered when about to merge #22271 to deal with similar issues.

![screen shot 2018-02-14 at 1 20 10 pm](https://user-images.githubusercontent.com/349751/36229857-6ad35ad4-118d-11e8-9ee6-ad73fa55fc50.png)

This reverts commit d52a3b15da268834752c0a031cd45ae004073833.