### PR TITLE
Stop supporting null schema in withSchemaValidation 

### DIFF
--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -472,7 +472,6 @@ describe( 'utils', () => {
 
 	describe( '#withSchemaValidation', () => {
 		const load = { type: DESERIALIZE };
-		const write = { type: SERIALIZE };
 		const normal = { type: 'NORMAL' };
 		const grow = { type: 'GROW' };
 		const schema = {
@@ -499,16 +498,6 @@ describe( 'utils', () => {
 		};
 		date.hasCustomPersistence = true;
 
-		test( 'should return undefined without a schema on SERIALIZE', () => {
-			const validated = withSchemaValidation( null, age );
-			expect( validated( 5, write ) ).to.be.undefined;
-		} );
-
-		test( 'should return initial state without a schema on DESERIALIZE', () => {
-			const validated = withSchemaValidation( null, age );
-			expect( validated( 5, load ) ).to.equal( 0 );
-		} );
-
 		test( 'should invalidate DESERIALIZED state', () => {
 			const validated = withSchemaValidation( schema, age );
 
@@ -529,11 +518,6 @@ describe( 'utils', () => {
 
 		test( 'actions work as expected with schema', () => {
 			const validated = withSchemaValidation( schema, age );
-			expect( validated( 5, grow ) ).to.equal( 6 );
-		} );
-
-		test( 'actions work as expected without schema', () => {
-			const validated = withSchemaValidation( null, age );
 			expect( validated( 5, grow ) ).to.equal( 6 );
 		} );
 	} );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -468,10 +468,18 @@ export const withoutPersistence = reducer => {
  * @returns {function} - Returns the combined reducer function
  */
 export function combineReducers( reducers ) {
-	const validatedReducers = mapValues(
-		reducers,
-		next => ( next.hasCustomPersistence ? next : withSchemaValidation( next.schema, next ) )
-	);
+	const validatedReducers = mapValues( reducers, next => {
+		if ( next.hasCustomPersistence ) {
+			return next;
+		}
+
+		if ( next.schema ) {
+			return withSchemaValidation( next.schema, next );
+		}
+
+		return withoutPersistence( next );
+	} );
+
 	const combined = combine( validatedReducers );
 	const combinedWithSerializer = ( state, action ) => {
 		// SERIALIZE needs behavior that's slightly different from `combineReducers` from Redux:


### PR DESCRIPTION
The `withSchemaValidation` function has been doing two jobs at once: it validated a JSON schema on DESERIALIZE, and it disabled persistence of the wrapped reducer when schema is `null`.

The second job is sufficiently covered by the `withoutPersistence` function. This PR starts using both of them in `combineReducers` and simplifies `withSchemaValidation` to only validate a valid schema and nothing else.

There are three commits that can stand on their own and can be reviewed separately.

**How to test:**
- run the unit tests
- run Calypso and verify that no reducer throws the "null schema passed to `withSchemaValidation`" error that now guards against passing the legacy null schema.
