### PR TITLE
Reader: Remove non-standard breakpoints

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -1,11 +1,3 @@
-// Custom breakpoints needed to match original design
-
-$reader-post-card-breakpoint-xxlarge: '( min-width: 1100px )';
-$reader-post-card-breakpoint-xlarge: '( min-width: 1040px )';
-$reader-post-card-breakpoint-large: '( min-width: 961px ) and ( max-width: 1040px )';
-$reader-post-card-breakpoint-medium: '( min-width: 661px ) and ( max-width: 940px )';
-$reader-post-card-breakpoint-small: '( max-width: 550px )';
-
 // Adds a top border to first card in the Site Stream
 .is-reader-page .is-site-stream .reader-post-card.card {
 	&:nth-child(2) {
@@ -57,20 +49,6 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 
 			@include breakpoint( '>960px' ) {
 				max-width: 250px;
-			}
-
-			@media #{$reader-post-card-breakpoint-medium} {
-				height: 100px;
-				max-width: none;
-				width: 100%;
-				margin-bottom: 10px;
-			}
-
-			@media #{$reader-post-card-breakpoint-small} {
-				height: 100px;
-				max-width: none;
-				width: 100%;
-				margin-bottom: 10px;
 			}
 		}
 
@@ -131,18 +109,6 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 
 		.reader-post-card__post-details {
 			flex: 1;
-
-			@media #{$reader-post-card-breakpoint-medium} {
-				flex: 0 auto;
-				margin-top: 7px;
-				width: 100%;
-			}
-
-			@media #{$reader-post-card-breakpoint-small} {
-				flex: 0 auto;
-				margin-top: 7px;
-				width: 100%;
-			}
 		}
 	}
 
@@ -439,18 +405,6 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 		flex: 1 auto;
 		width: 100%;
 	}
-
-	@media #{$reader-post-card-breakpoint-large} {
-		flex-direction: row;
-	}
-
-	@media #{$reader-post-card-breakpoint-medium} {
-		flex-direction: column;
-	}
-
-	@media #{$reader-post-card-breakpoint-small} {
-		flex-direction: column;
-	}
 }
 
 .reader-post-card.is-expanded-video .reader-post-card__post {
@@ -586,32 +540,12 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 		@include breakpoint( '>960px' ) {
 			top: 1px;
 		}
-
-		@media #{$reader-post-card-breakpoint-xxlarge} {
-			top: 0;
-		}
-
-		@media #{$reader-post-card-breakpoint-medium} {
-			top: 1px;
-		}
-
-		@include breakpoint( '<660px' ) {
-			top: 1px;
-		}
 	}
 
 	.reader-share__button-label,
 	.comment-button__label-status,
 	.like-button__label-status {
 		@include breakpoint( '>960px' ) {
-			display: none;
-		}
-
-		@media #{$reader-post-card-breakpoint-xxlarge} {
-			display: inline;
-		}
-
-		@include breakpoint( '<660px' ) {
 			display: none;
 		}
 	}
@@ -665,40 +599,11 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 	}
 }
 
-// If chat window is open
-.is-group-reader.has-chat {
-	@media #{$reader-post-card-breakpoint-xlarge} {
-		.reader-post-card__post {
-			flex-direction: column;
-		}
-
-		.reader-post-card__post .reader-featured-image {
-			height: 100px;
-			margin-right: 0;
-			max-width: 100%;
-		}
-
-		.reader-share__button-label,
-		.comment-button__label-status,
-		.like-button__label-status {
-			display: none;
-		}
-	}
-}
-
 // Gallery cards
 .reader-post-card__gallery {
 	display: flex;
 	margin: 0 0 17px;
 	padding: 0;
-
-	@media #{$reader-post-card-breakpoint-medium} {
-		margin: 0 0 10px;
-	}
-
-	@media #{$reader-post-card-breakpoint-small} {
-		margin: 0 0 10px;
-	}
 }
 
 .reader-post-card__gallery-item {
@@ -712,12 +617,6 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 		margin-right: 0;
 	}
 
-	&:last-child {
-		@media #{$reader-post-card-breakpoint-medium} {
-			display: none;
-		}
-	}
-
 	&:nth-last-of-type(-n + 2) {
 		@include breakpoint( '<480px' ) {
 			display: none;
@@ -727,14 +626,6 @@ $reader-post-card-breakpoint-small: '( max-width: 550px )';
 
 .reader-post-card .reader-featured-video__video {
 	padding-bottom: 17px;
-
-	@media #{$reader-post-card-breakpoint-medium} {
-		padding-bottom: 10px;
-	}
-
-	@media #{$reader-post-card-breakpoint-small} {
-		padding-bottom: 10px;
-	}
 }
 
 .reader-post-card__gallery-image {

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -1,7 +1,3 @@
-// Custom breakpoints
-$reader-related-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";
-$reader-related-card-breakpoint-small: "( max-width: 535px )";
-
 .reader-related-card__heading {
 	color: $gray;
 	font-size: 14px;
@@ -42,16 +38,8 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	margin: 0;
 	padding: 0;
 
-	@media #{$reader-related-card-breakpoint-medium} {
-		display: block;
-	}
-
 	@include breakpoint( "<660px" ) {
 		flex-direction: row;
-	}
-
-	@media #{$reader-related-card-breakpoint-small} {
-		display: block;
 	}
 }
 
@@ -80,17 +68,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	&:first-child,
 	&:last-child {
 
-		@media #{$reader-related-card-breakpoint-medium} {
-			margin: 0 0 20px 0;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			margin: 0 0 20px 0;
-		}
-
-		@include breakpoint( "<480px" ) {
-			margin: 0 0 20px 0;
-		}
 	}
 
 	&:only-child {
@@ -105,16 +82,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 	padding: 0;
 
 	@include breakpoint( "<480px" ) {
-		display: flex;
-		flex-direction: column;
-	}
-
-	@media #{$reader-related-card-breakpoint-medium} {
-		display: flex;
-		flex-direction: column;
-	}
-
-	@media #{$reader-related-card-breakpoint-small} {
 		display: flex;
 		flex-direction: column;
 	}
@@ -145,14 +112,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 		display: block;
 		overflow: hidden;
 
-		@media #{$reader-related-card-breakpoint-medium} {
-			display: flex;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			display: flex;
-		}
-
 		&::after {
 			@include long-content-fade( $size: 35px );
 				bottom: 0;
@@ -166,17 +125,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 
 		.reader-related-card__meta {
 			margin-bottom: 16px;
-		}
-
-		.reader-related-card__site-info {
-
-			@media #{$reader-related-card-breakpoint-small} {
-				flex: 3 0 0;
-			}
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				flex: 3 0 0;
-			}
 		}
 
 		.reader-related-card__title {
@@ -227,26 +175,11 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 
 			.reader-related-card__post {
 				max-height: 17px * 1.6 * 4;
-
-				@media #{$reader-related-card-breakpoint-medium} {
-					max-height: 17px * 1.6 * 4;
-				}
-
-				@media #{$reader-related-card-breakpoint-small} {
-					max-height: 17px * 1.6 * 4;
-				}
 			}
 		}
 
 		.reader-related-card__post {
 
-			@media #{$reader-related-card-breakpoint-medium} {
-				flex: 3 0 0;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				flex: 3 0 0;
-			}
 		}
 
 		.reader-related-card.has-thumbnail {
@@ -259,97 +192,20 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 
 		.reader-related-card__post {
 			max-height: 17px * 1.6 * 7.5;
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				max-height: 17px * 1.6 * 4;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				max-height: 17px * 1.6 * 4;
-			}
-
-			@include breakpoint( "<480px" ) {
-				max-height: 17px * 1.6 * 4;
-			}
 		}
 
 		.reader-related-card__featured-image {
 
-			@media #{$reader-related-card-breakpoint-medium} {
-				margin: 0 15px 0 0;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				margin: 0 15px 0 0;
-			}
 		}
 
 		.reader-related-card__meta {
 
-			@media #{$reader-related-card-breakpoint-medium} {
-				position: absolute;
-				width: 100%;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				position: absolute;
-			}
-		}
-
-		.reader-related-card__post {
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				margin-top: 50px;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				margin-top: 50px;
-			}
 		}
 
 		.has-thumbnail {
 
 			.reader-related-card__site-info {
 
-				@media #{$reader-related-card-breakpoint-medium} {
-					margin-top: 20px;
-				}
-
-				@media #{$reader-related-card-breakpoint-small} {
-					margin-top: 20px;
-				}
-			}
-
-			.reader-related-card__meta {
-				margin-bottom: 19px;
-
-				@media #{$reader-related-card-breakpoint-medium} {
-					margin-top: -4px;
-					right: 0;
-					width: calc( 100% - 97px );
-				}
-
-				@media #{$reader-related-card-breakpoint-small} {
-					margin-top: -4px;
-					right: 0;
-					width: calc( 100% - 97px );
-				}
-			}
-
-			.reader-related-card__post {
-				max-height: 17px * 1.6 * 4;
-
-				@media #{$reader-related-card-breakpoint-medium} {
-					flex: 3 0 0;
-					margin-top: 25px;
-					max-height: 17px * 1.6 * 4.7;
-				}
-
-				@media #{$reader-related-card-breakpoint-small} {
-					flex: 3 0 0;
-					margin-top: 25px;
-					max-height: 17px * 1.6 * 4.7;
-				}
 			}
 		}
 
@@ -367,28 +223,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 
 		.reader-related-card {
 
-			@media #{$reader-related-card-breakpoint-medium} {
-				flex-direction: row;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				flex-direction: row;
-			}
-		}
-
-		.reader-related-card__featured-image {
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				flex: 0 0 80px;
-				margin: 0 15px 0 0;
-				width: 80px;
-			}
-
-			@media #{$reader-related-card-breakpoint-small} {
-				flex: 0 0 80px;
-				margin: 0 15px 0 0;
-				width: 80px;
-			}
 		}
 	}
 }
@@ -458,18 +292,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 		max-width: 145px;
 	}
 
-	@media #{$reader-related-card-breakpoint-medium} {
-		max-width: 200px;
-	}
-
-	@include breakpoint( "<660px" ) {
-		max-width: 145px;
-	}
-
-	@media #{$reader-related-card-breakpoint-small} {
-		max-width: 200px;
-	}
-
 	@include breakpoint( "<480px" ) {
 		max-width: 110px;
 	}
@@ -478,20 +300,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 .reader-related-card__featured-image {
 	border: 1px solid $gray-lighten-30;
 	min-height: 153px;
-
-	@media #{$reader-related-card-breakpoint-small} {
-		flex: 1 1 0;
-		height: auto;
-		margin: 0 15px 0 0;
-		min-height: 78px;
-	}
-
-	@media #{$reader-related-card-breakpoint-medium} {
-		height: auto;
-		flex: 1 1 0;
-		margin: 0 15px 0 0;
-		min-height: 78px;
-	}
 
 	@include breakpoint( "<660px" ) {
 		min-height: 78px;
@@ -615,13 +423,6 @@ $reader-related-card-breakpoint-small: "( max-width: 535px )";
 
 	.reader-related-card__site-info {
 
-		@media #{$reader-related-card-breakpoint-medium} {
-			flex: 3 0 0;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			flex: 3 0 0;
-		}
 	}
 
 	.reader-related-card__post {

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -88,19 +88,8 @@
 	margin-left: 15px;
 	padding: 18px 0 21px 0;
 
-	@media #{$reader-related-card-breakpoint-medium} {
-		flex-basis: 100%;
-		margin: 0;
-	}
-
 	@include breakpoint( "<660px" ) {
 		flex-basis: calc( 50% - 30px );
-		margin-left: 15px;
-		margin-right: 15px;
-	}
-
-	@media #{$reader-related-card-breakpoint-small}  {
-		flex-basis: 100%;
 		margin-left: 15px;
 		margin-right: 15px;
 	}
@@ -110,19 +99,9 @@
 		margin-left: 0;
 		margin-right: 15px;
 
-		@media #{$reader-related-card-breakpoint-medium} {
-			flex-basis: 100%;
-			margin-right: 0;
-		}
 
 		@include breakpoint( "<660px" ) {
 			flex-basis: calc( 50% - 30px );
-			margin-left: 15px;
-			margin-right: 15px;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			flex-basis: 100%;
 			margin-left: 15px;
 			margin-right: 15px;
 		}
@@ -131,16 +110,8 @@
 	.reader-related-card__post {
 		max-height: 208px;
 
-		@media #{$reader-related-card-breakpoint-medium} {
-			max-height: 105px;
-		}
-
 		@include breakpoint( "<660px" ) {
 			max-height: 206px;
-		}
-
-		@media #{$reader-related-card-breakpoint-small} {
-			max-height: 103px;
 		}
 
 		.reader-related-card__excerpt {
@@ -152,14 +123,6 @@
 
 		.reader-related-card__post {
 			max-height: 110px;
-
-			@media #{$reader-related-card-breakpoint-small} {
-				max-height: 104px;
-			}
-
-			@media #{$reader-related-card-breakpoint-medium} {
-				max-height: 104px;
-			}
 		}
 
 		.reader-related-card__meta {
@@ -367,22 +330,9 @@
 
 	.reader-post-card__post {
 
-		@media #{$reader-post-card-breakpoint-large} {
-			flex-direction: column;
-		}
-
-		@include breakpoint( "<960px" ) {
-			flex-direction: column;
-		}
 	}
 
 	.reader-post-card.card.has-thumbnail .reader-featured-image {
-
-		@media #{$reader-post-card-breakpoint-large} {
-			height: 80px;
-			margin: 0 0 20px;
-			max-width: 100%;
-		}
 
 		@include breakpoint( "<960px" ) {
 			height: 80px;
@@ -396,10 +346,6 @@
 	}
 
 	.reader-post-card.is-gallery .reader-post-card__gallery-item:last-child {
-
-		@media #{$reader-post-card-breakpoint-large} {
-			display: none;
-		}
 
 		@include breakpoint( "<960px" ) {
 			display: block;


### PR DESCRIPTION
In Reader, we use several custom media queries:

```-$reader-post-card-breakpoint-xxlarge:` '( min-width: 1100px )';```
```-$reader-post-card-breakpoint-xlarge: '( min-width: 1040px )';```
```-$reader-post-card-breakpoint-large: '( min-width: 961px ) and ( max-width: 1040px )';```
```-$reader-post-card-breakpoint-medium: '( min-width: 661px ) and ( max-width: 940px )';```
```-$reader-post-card-breakpoint-small: '( max-width: 550px )';```
```-$reader-related-card-breakpoint-medium: "( min-width: 661px ) and ( max-width: 730px )";```
```-$reader-related-card-breakpoint-small: "( max-width: 535px `)";```

This PR removes these and make sure we use standard Calypso breakpoint mixins.

We also want to make sure if we can still somehow retain the same layout using standard breakpoints.