### PR TITLE
Manage persistence of createReducer with withSchemaValidation and withoutPersistence

### DIFF
--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -4,7 +4,7 @@
  */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
-import { stub, spy } from 'sinon';
+import { spy } from 'sinon';
 
 /**
  * Internal dependencies
@@ -233,31 +233,6 @@ describe( 'utils', () => {
 			test( 'should return overridden state when deserialize action type passed', () => {
 				expect( reducer( currentState, actionDeserialize ) ).to.be.deep.equal( overriddenState );
 			} );
-		} );
-
-		test( 'should cache the serialize result on custom serialization behavior', () => {
-			const monitor = stub().returnsArg( 0 );
-
-			reducer = createReducer(
-				[],
-				{
-					[ SERIALIZE ]: monitor,
-					TEST_ADD: state => [ ...state, state.length ],
-				},
-				testSchema
-			);
-
-			let state;
-			state = reducer( state, { type: SERIALIZE } );
-			state = reducer( state, { type: SERIALIZE } );
-			state = reducer( state, { type: 'TEST_ADD' } );
-			state = reducer( state, { type: SERIALIZE } );
-			state = reducer( state, { type: SERIALIZE } );
-			state = reducer( state, { type: 'TEST_ADD' } );
-			state = reducer( state, { type: SERIALIZE } );
-
-			expect( monitor ).to.have.been.calledThrice;
-			expect( state ).to.eql( [ 0, 1 ] );
 		} );
 	} );
 	describe( '#keyedReducer', () => {

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -121,27 +121,27 @@ describe( 'utils', () => {
 	} );
 
 	describe( '#createReducer()', () => {
-		describe( 'only default behavior', () => {
+		describe( 'with null initial state and no handlers', () => {
 			beforeAll( () => {
-				reducer = createReducer();
+				reducer = createReducer( null, {} );
 			} );
 
 			test( 'should return a function', () => {
 				expect( reducer ).to.be.a.function;
 			} );
 
-			test( 'should return initial state when invalid action passed', () => {
-				const invalidAction = {};
+			test( 'should return initial state when hydration action passed', () => {
+				expect( reducer( undefined, { type: '@@calypso/INIT' } ) ).to.be.null;
+			} );
 
-				expect( reducer( currentState, invalidAction ) ).to.be.deep.equal( currentState );
+			test( 'should return identical state when invalid action passed', () => {
+				const invalidAction = {};
+				expect( reducer( currentState, invalidAction ) ).to.equal( currentState );
 			} );
 
 			test( 'should return initial state when unknown action type passed', () => {
-				const unknownAction = {
-					type: 'UNKNOWN',
-				};
-
-				expect( reducer( currentState, unknownAction ) ).to.be.deep.equal( currentState );
+				const unknownAction = { type: 'UNKNOWN' };
+				expect( reducer( currentState, unknownAction ) ).to.equal( currentState );
 			} );
 
 			test( 'should return undefined when serialize action type passed', () => {

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -139,7 +139,7 @@ describe( 'utils', () => {
 				expect( reducer( currentState, invalidAction ) ).to.equal( currentState );
 			} );
 
-			test( 'should return initial state when unknown action type passed', () => {
+			test( 'should return identical state when unknown action type passed', () => {
 				const unknownAction = { type: 'UNKNOWN' };
 				expect( reducer( currentState, unknownAction ) ).to.equal( currentState );
 			} );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -308,35 +308,11 @@ export const withoutPersistence = reducer => {
  * serialization (persistence) handlers based on the presence of a schema.
  *
  * @param  {*}        initialState   Initial state
- * @param  {Object}   customHandlers Object mapping action types to state action handlers
+ * @param  {Object}   handlers       Object mapping action types to state action handlers
  * @param  {?Object}  schema         JSON schema object for deserialization validation
  * @return {Function}                Reducer function
  */
-export function createReducer( initialState, customHandlers, schema ) {
-	let handlers = customHandlers;
-
-	// When custom serialization behavior is provided, we assume that it may
-	// involve heavy logic (mapping, converting from Immutable instance), so
-	// we cache the result and only regenerate when state has changed.
-	const customSerializeHandler = customHandlers[ SERIALIZE ];
-	if ( customSerializeHandler ) {
-		let lastState, lastSerialized;
-		const cachedSerializeHandler = ( state, action ) => {
-			if ( state === lastState ) {
-				return lastSerialized;
-			}
-
-			const serialized = customSerializeHandler( state, action );
-			lastState = state;
-			lastSerialized = serialized;
-			return serialized;
-		};
-		handlers = {
-			...handlers,
-			[ SERIALIZE ]: cachedSerializeHandler,
-		};
-	}
-
+export function createReducer( initialState, handlers, schema ) {
 	const reducer = ( state = initialState, action ) => {
 		const { type } = action;
 

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -228,7 +228,7 @@ function getInitialState( reducer ) {
  *                                   validation
  * @return {Function}                Reducer function
  */
-export function createReducer( initialState = null, customHandlers = {}, schema = null ) {
+export function createReducer( initialState, customHandlers, schema ) {
 	// Define default handlers for serialization actions. If no schema is
 	// provided, always return the initial state. Otherwise, allow for
 	// serialization and validate on deserialize.

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -216,87 +216,6 @@ function getInitialState( reducer ) {
 }
 
 /**
- * Returns a reducer function with state calculation determined by the result
- * of invoking the handler key corresponding with the dispatched action type,
- * passing both the current state and action object. Defines default
- * serialization (persistence) handlers based on the presence of a schema.
- *
- * @param  {*}        initialState   Initial state
- * @param  {Object}   customHandlers Object mapping action types to state
- *                                   action handlers
- * @param  {?Object}  schema         JSON schema object for deserialization
- *                                   validation
- * @return {Function}                Reducer function
- */
-export function createReducer( initialState, customHandlers, schema ) {
-	// Define default handlers for serialization actions. If no schema is
-	// provided, always return the initial state. Otherwise, allow for
-	// serialization and validate on deserialize.
-	let defaultHandlers;
-	if ( schema ) {
-		defaultHandlers = {
-			[ SERIALIZE ]: state => state,
-			[ DESERIALIZE ]: state => {
-				if ( isValidStateWithSchema( state, schema, customHandlers ) ) {
-					return state;
-				}
-
-				return initialState;
-			},
-		};
-	} else {
-		defaultHandlers = {
-			[ SERIALIZE ]: () => undefined,
-			[ DESERIALIZE ]: () => initialState,
-		};
-	}
-
-	const handlers = {
-		...defaultHandlers,
-		...customHandlers,
-	};
-
-	// When custom serialization behavior is provided, we assume that it may
-	// involve heavy logic (mapping, converting from Immutable instance), so
-	// we cache the result and only regenerate when state has changed.
-	if ( customHandlers[ SERIALIZE ] ) {
-		let lastState, lastSerialized;
-		handlers[ SERIALIZE ] = ( state, action ) => {
-			if ( state === lastState ) {
-				return lastSerialized;
-			}
-
-			const serialized = customHandlers[ SERIALIZE ]( state, action );
-			lastState = state;
-			lastSerialized = serialized;
-			return serialized;
-		};
-	}
-
-	const reducer = ( state = initialState, action ) => {
-		const { type } = action;
-
-		if ( 'production' !== process.env.NODE_ENV && 'type' in action && ! type ) {
-			throw new TypeError(
-				'Reducer called with undefined type.' +
-					' Verify that the action type is defined in state/action-types.js'
-			);
-		}
-
-		if ( handlers.hasOwnProperty( type ) ) {
-			return handlers[ type ]( state, action );
-		}
-
-		return state;
-	};
-
-	//used to propagate actions properly when combined in combineReducersWithPersistence
-	reducer.hasCustomPersistence = true;
-
-	return reducer;
-}
-
-/**
  * Creates a schema-validating reducer
  *
  * Use this to wrap simple reducers with a schema-based
@@ -381,6 +300,87 @@ export const withoutPersistence = reducer => {
 
 	return wrappedReducer;
 };
+
+/**
+ * Returns a reducer function with state calculation determined by the result
+ * of invoking the handler key corresponding with the dispatched action type,
+ * passing both the current state and action object. Defines default
+ * serialization (persistence) handlers based on the presence of a schema.
+ *
+ * @param  {*}        initialState   Initial state
+ * @param  {Object}   customHandlers Object mapping action types to state
+ *                                   action handlers
+ * @param  {?Object}  schema         JSON schema object for deserialization
+ *                                   validation
+ * @return {Function}                Reducer function
+ */
+export function createReducer( initialState, customHandlers, schema ) {
+	// Define default handlers for serialization actions. If no schema is
+	// provided, always return the initial state. Otherwise, allow for
+	// serialization and validate on deserialize.
+	let defaultHandlers;
+	if ( schema ) {
+		defaultHandlers = {
+			[ SERIALIZE ]: state => state,
+			[ DESERIALIZE ]: state => {
+				if ( isValidStateWithSchema( state, schema, customHandlers ) ) {
+					return state;
+				}
+
+				return initialState;
+			},
+		};
+	} else {
+		defaultHandlers = {
+			[ SERIALIZE ]: () => undefined,
+			[ DESERIALIZE ]: () => initialState,
+		};
+	}
+
+	const handlers = {
+		...defaultHandlers,
+		...customHandlers,
+	};
+
+	// When custom serialization behavior is provided, we assume that it may
+	// involve heavy logic (mapping, converting from Immutable instance), so
+	// we cache the result and only regenerate when state has changed.
+	if ( customHandlers[ SERIALIZE ] ) {
+		let lastState, lastSerialized;
+		handlers[ SERIALIZE ] = ( state, action ) => {
+			if ( state === lastState ) {
+				return lastSerialized;
+			}
+
+			const serialized = customHandlers[ SERIALIZE ]( state, action );
+			lastState = state;
+			lastSerialized = serialized;
+			return serialized;
+		};
+	}
+
+	const reducer = ( state = initialState, action ) => {
+		const { type } = action;
+
+		if ( 'production' !== process.env.NODE_ENV && 'type' in action && ! type ) {
+			throw new TypeError(
+				'Reducer called with undefined type.' +
+					' Verify that the action type is defined in state/action-types.js'
+			);
+		}
+
+		if ( handlers.hasOwnProperty( type ) ) {
+			return handlers[ type ]( state, action );
+		}
+
+		return state;
+	};
+
+	//used to propagate actions properly when combined in combineReducersWithPersistence
+	reducer.hasCustomPersistence = true;
+
+	return reducer;
+}
 
 /**
  * Returns a single reducing function that ensures that persistence is opt-in.


### PR DESCRIPTION
Don't duplicate the already implemented functionality and use `withSchemaValidation` and `withoutPersistence` in `createReducer`, too.

There's a behavior change similar to #22410: previously, `createReducer` provided default (DE)SERIALIZE handlers that either validate a schema or disable persistence. The custom handlers could freely override them and, for example, disabling completely the schema validation enabled by the `schema` parameter:
```js
createReducer( null, {
  [ DESERIALIZE ]: ( state, action ) => { ...ignores the schema }
}, schemaThatIsNotUsed )
```
 Now, after schema validation, control is passed to the optional DESERIALIZE handler. That lets us do a composed deserialization:
```js
createReducer( null, {
  [ DESERIALIZE ]: ( state, action ) => { ...only validated state gets passed here }
}, schemaThatIsAlwaysUsed )
```
(I will patch a few reducers to use this new capability soon)

I checked if there are any existing `createReducer` calls that both supply a schema and have a custom DESERIALIZE handler. There aren't any, so the change doesn't affect any existing code.

There are three commits that can stand on its own and be separately reviewed.

**How to test:**
- run the unit tests
