### PR TITLE
 People: Invites: Avoid rendering recently-deleted invites in the list

### DIFF
--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -18,7 +18,11 @@ import CompactCard from 'components/card/compact';
 import PeopleProfile from 'my-sites/people/people-profile';
 import analytics from 'lib/analytics';
 import config from 'config';
-import { isRequestingInviteResend, didInviteResendSucceed } from 'state/invites/selectors';
+import {
+	isRequestingInviteResend,
+	didInviteResendSucceed,
+	didInviteDeletionSucceed,
+} from 'state/invites/selectors';
 import { resendInvite } from 'state/invites/actions';
 
 class PeopleListItem extends React.PureComponent {
@@ -117,9 +121,17 @@ class PeopleListItem extends React.PureComponent {
 	};
 
 	render() {
-		const { className, invite, onRemove, translate, type, user } = this.props;
+		const { className, invite, onRemove, translate, type, user, inviteWasDeleted } = this.props;
 
 		const isInvite = invite && ( 'invite' === type || 'invite-details' === type );
+
+		if ( isInvite && inviteWasDeleted ) {
+			// After an invite is deleted and the user is returned to the
+			// invites list, the invite can occasionally reappear in the next
+			// API call, so we need to check for this situation and avoid
+			// rendering an invite that we know is actually deleted.
+			return null;
+		}
 
 		const classes = classNames(
 			'people-list-item',
@@ -161,14 +173,18 @@ class PeopleListItem extends React.PureComponent {
 
 export default connect(
 	( state, ownProps ) => {
-		const siteId = ownProps.site && ownProps.site.ID;
-		const inviteKey = ownProps.invite && ownProps.invite.key;
+		const { site, invite } = ownProps;
+
+		const siteId = site && site.ID;
+		const inviteKey = invite && invite.key;
+		const inviteWasDeleted = inviteKey && didInviteDeletionSucceed( state, siteId, inviteKey );
 
 		return {
 			requestingResend: isRequestingInviteResend( state, siteId, inviteKey ),
 			resendSuccess: didInviteResendSucceed( state, siteId, inviteKey ),
 			siteId,
 			inviteKey,
+			inviteWasDeleted,
 		};
 	},
 	{ resendInvite }

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -128,8 +128,8 @@ export function isDeletingInvite( state, siteId, inviteId ) {
 }
 
 /**
- * Returns true if currently deleting an invite for the given site and
- * invite ID, or false otherwise.
+ * Returns true if the invite for the given site and invite ID was successfully
+ * deleted, or false otherwise.
  *
  * @param  {Object}  state    Global state tree
  * @param  {Number}  siteId   Site ID


### PR DESCRIPTION
Watch the invite `nylen+invite-109@automattic.com` reappear after it is deleted:

> ![deleted-invites-reappearing](https://user-images.githubusercontent.com/227022/36233571-539763f0-11ac-11e8-8e8e-e097ed79a787.gif)

This happens consistently for me with a site with a large number of invites.  I think this is what is happening:

- A request to delete an invite succeeds.
- Almost immediately, the invites list renders and requests the site's list of invites.
- This API call doesn't yet know that the invite has been deleted.  I think this is due to replication lag between the master DB servers (which handle writes) and the slaves (which handle the majority of queries but only handle reads).

We can work around it by checking `didInviteDeletionSucceed` before rendering an invite in the list.

After this PR, the symptoms of the issue described are as follows:

- The count may change after deleting an invite (for me it still shows 100, then 99, then 100 again).
- The invites in the list may re-order themselves after one of them is deleted (only possible when multiple invites were sent at the same time, and we could avoid this with an additional sort condition in the API or on the client).

Not ideal, but this should be a pretty uncommon situation.  As long as we avoid displaying an invite we know to be deleted, I think this is probably OK.