### PR TITLE
Post Likes: Add reducer support for new actions

### DIFF
--- a/client/state/posts/likes/reducer.js
+++ b/client/state/posts/likes/reducer.js
@@ -3,14 +3,21 @@
 /**
  * External dependencies
  */
-import { pick } from 'lodash';
+
+import { get, pick } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import itemsSchema from './schema';
 import { combineReducers, createReducer } from 'state/utils';
-import { POST_LIKES_RECEIVE } from 'state/action-types';
+import {
+	POST_LIKES_ADD_LIKER,
+	POST_LIKES_RECEIVE,
+	POST_LIKES_REMOVE_LIKER,
+	POST_LIKE,
+	POST_UNLIKE,
+} from 'state/action-types';
 
 /**
  * Returns the updated items state after an action has been dispatched. The
@@ -38,6 +45,32 @@ export const items = createReducer(
 				},
 			};
 		},
+		[ POST_LIKE ]: ( state, { siteId, postId } ) => {
+			const currentLike = get( state, [ siteId, postId ], {
+				likes: undefined,
+				iLike: false,
+				found: 0,
+			} );
+
+			if ( currentLike.iLike ) {
+				return state;
+			}
+
+			return {
+				...state,
+				[ siteId ]: {
+					...state[ siteId ],
+					[ postId ]: {
+						likes: undefined,
+						iLike: true,
+						found: currentLike.found + 1,
+					},
+				},
+			};
+		},
+		[ POST_UNLIKE ]: ( state, { siteId, postId } ) => {},
+		[ POST_LIKES_ADD_LIKER ]: ( state, { siteId, postId, likeCount, liker } ) => {},
+		[ POST_LIKES_REMOVE_LIKER ]: ( state, { siteId, postId, likeCount, liker } ) => {},
 	},
 	itemsSchema
 );

--- a/client/state/posts/likes/schema.js
+++ b/client/state/posts/likes/schema.js
@@ -2,33 +2,19 @@
 export default {
 	type: 'object',
 	additionalProperties: false,
-	patternProperties: {
-		// Site ID
-		'^\\d+$': {
-			type: 'object',
-			additionalProperties: false,
-			patternProperties: {
-				// Post ID
-				'^\\d+$': {
-					type: 'object',
-					additionalProperties: false,
-					required: [ 'likes', 'iLike', 'found' ],
-					properties: {
-						likes: {
-							type: 'array',
-							description: 'List of post likes',
-						},
-						iLike: {
-							type: 'boolean',
-							description: 'Whether the current authenticated user likes the post or not',
-						},
-						found: {
-							type: 'number',
-							description: 'The total of post likes',
-						},
-					},
-				},
-			},
+	required: [ 'likes', 'iLike', 'found' ],
+	properties: {
+		likes: {
+			type: 'array',
+			description: 'List of post likes',
+		},
+		iLike: {
+			type: 'boolean',
+			description: 'Whether the current authenticated user likes the post or not',
+		},
+		found: {
+			type: 'number',
+			description: 'The total of post likes',
 		},
 	},
 };

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -19,14 +18,14 @@ describe( 'reducer', () => {
 	} );
 
 	test( 'should include expected keys in return value', () => {
-		expect( reducer( undefined, {} ) ).to.have.keys( [ 'items' ] );
+		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual( [ 'items' ] );
 	} );
 
 	describe( 'items()', () => {
 		test( 'should default to an empty object', () => {
 			const state = items( undefined, {} );
 
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should index post likes by site ID, post Id', () => {
@@ -43,7 +42,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				12345678: {
 					50: {
 						likes,
@@ -77,7 +76,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				12345678: {
 					50: {
 						likes,
@@ -118,7 +117,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				12345678: {
 					50: {
 						likes,
@@ -157,7 +156,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				12345678: {
 					50: {
 						likes: likes2,
@@ -192,7 +191,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				12345678: {
 					50: {
 						likes: [
@@ -229,7 +228,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				12345678: {
 					50: {
 						likes,
@@ -257,7 +256,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				12345678: {
 					50: {
 						likes,
@@ -278,7 +277,7 @@ describe( 'reducer', () => {
 				}
 			);
 
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 	} );
 } );

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -185,7 +185,7 @@ describe( 'reducer', () => {
 					some_other_property: 'aaaaa',
 				},
 			];
-			const state = itemReducer( DEFAULT_ITEM_STATE, {
+			const state = itemReducer( undefined, {
 				type: POST_LIKES_RECEIVE,
 				siteId: 12345678,
 				postId: 50,
@@ -281,7 +281,7 @@ describe( 'reducer', () => {
 
 		describe( 'a POST_LIKE action', () => {
 			test( 'should create a new state item if none is found', () => {
-				const state = itemReducer( DEFAULT_ITEM_STATE, like( 1, 1 ) );
+				const state = itemReducer( undefined, like( 1, 1 ) );
 				expect( state ).toEqual( {
 					likes: undefined,
 					iLike: true,
@@ -354,7 +354,7 @@ describe( 'reducer', () => {
 				ID: 10,
 			} );
 			test( 'should create a new entry when no entry is present', () => {
-				expect( itemReducer( DEFAULT_ITEM_STATE, addLiker( 1, 1, 5, liker ) ) ).toEqual( {
+				expect( itemReducer( undefined, addLiker( 1, 1, 5, liker ) ) ).toEqual( {
 					likes: [ liker ],
 					found: 5,
 					iLike: false,
@@ -421,7 +421,7 @@ describe( 'reducer', () => {
 				ID: 10,
 			} );
 			test( 'should creat a new entry if none is present', () => {
-				expect( itemReducer( DEFAULT_ITEM_STATE, removeLiker( 1, 1, 5, liker ) ) ).toEqual( {
+				expect( itemReducer( undefined, removeLiker( 1, 1, 5, liker ) ) ).toEqual( {
 					likes: undefined,
 					found: 5,
 					iLike: false,

--- a/client/state/posts/likes/test/reducer.js
+++ b/client/state/posts/likes/test/reducer.js
@@ -10,6 +10,7 @@ import deepFreeze from 'deep-freeze';
  */
 import reducer, { items } from '../reducer';
 import { POST_LIKES_RECEIVE, SERIALIZE, DESERIALIZE } from 'state/action-types';
+import { addLiker, removeLiker, like, unlike } from '../actions';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'reducer', () => {
@@ -278,6 +279,297 @@ describe( 'reducer', () => {
 			);
 
 			expect( state ).toEqual( {} );
+		} );
+
+		describe( 'a POST_LIKE action', () => {
+			test( 'should create a new state item if none is found', () => {
+				const state = items( deepFreeze( {} ), like( 1, 1 ) );
+				expect( state ).toEqual( {
+					1: {
+						1: {
+							likes: undefined,
+							iLike: true,
+							found: 1,
+						},
+					},
+				} );
+			} );
+
+			test( 'should update the current state if it is present', () => {
+				const state = items(
+					deepFreeze( {
+						1: {
+							1: {
+								likes: [],
+								iLike: false,
+								found: 1,
+							},
+						},
+					} ),
+					like( 1, 1 )
+				);
+				expect( state ).toEqual( {
+					1: {
+						1: {
+							likes: [],
+							iLike: true,
+							found: 2,
+						},
+					},
+				} );
+			} );
+
+			test( 'should not change the state if the user already likes the post', () => {
+				const initialState = deepFreeze( {
+					1: {
+						1: {
+							likes: [],
+							iLike: true,
+							found: 1,
+						},
+					},
+				} );
+				const state = items( initialState, like( 1, 1 ) );
+				expect( state ).toBe( initialState );
+			} );
+		} );
+
+		describe( 'a POST_UNLIKE action', () => {
+			test( 'should not create a new state item if none is found', () => {
+				const initialState = deepFreeze( {} );
+				const state = items( initialState, unlike( 1, 1 ) );
+				expect( state ).toBe( initialState );
+			} );
+
+			test( 'should update the current state if it is present', () => {
+				const state = items(
+					deepFreeze( {
+						1: {
+							1: {
+								likes: [],
+								iLike: true,
+								found: 1,
+							},
+						},
+					} ),
+					unlike( 1, 1 )
+				);
+				expect( state ).toEqual( {
+					1: {
+						1: {
+							likes: [],
+							iLike: false,
+							found: 0,
+						},
+					},
+				} );
+			} );
+
+			test( 'should not change the state if the user does not like the post', () => {
+				const initialState = deepFreeze( {
+					1: {
+						1: {
+							likes: [],
+							iLike: false,
+							found: 1,
+						},
+					},
+				} );
+				const state = items( initialState, unlike( 1, 1 ) );
+				expect( state ).toBe( initialState );
+			} );
+		} );
+
+		describe( 'a POST_LIKES_ADD_LIKER action', () => {
+			const liker = deepFreeze( {
+				ID: 10,
+			} );
+			test( 'should create a new entry when no entry is present', () => {
+				expect( items( deepFreeze( {} ), addLiker( 1, 1, 5, liker ) ) ).toEqual( {
+					1: {
+						1: {
+							likes: [ liker ],
+							found: 5,
+							iLike: false,
+						},
+					},
+				} );
+			} );
+
+			test( 'should make a new array if one is not present', () => {
+				expect(
+					items(
+						deepFreeze( {
+							1: {
+								1: {
+									likes: undefined,
+									found: 5,
+									iLike: false,
+								},
+							},
+						} ),
+						addLiker( 1, 1, 6, liker )
+					)
+				).toEqual( {
+					1: {
+						1: {
+							likes: [ liker ],
+							found: 6,
+							iLike: false,
+						},
+					},
+				} );
+			} );
+
+			test( 'should prepend to the existing array if present', () => {
+				expect(
+					items(
+						deepFreeze( {
+							1: {
+								1: {
+									likes: [ { ID: 5 } ],
+									found: 5,
+									iLike: false,
+								},
+							},
+						} ),
+						addLiker( 1, 1, 6, liker )
+					)
+				).toEqual( {
+					1: {
+						1: {
+							likes: [ liker, { ID: 5 } ],
+							found: 6,
+							iLike: false,
+						},
+					},
+				} );
+			} );
+
+			test( 'should leave the likes array alone if the liker is already present', () => {
+				const initialState = deepFreeze( {
+					1: {
+						1: {
+							likes: [ { ID: 2 }, liker ],
+							found: 5,
+							iLike: false,
+						},
+					},
+				} );
+				const state = items(
+					initialState,
+					// same liker, new count!
+					addLiker( 1, 1, 6, liker )
+				);
+
+				expect( state ).toEqual( {
+					1: {
+						1: {
+							likes: [ { ID: 2 }, liker ],
+							found: 6,
+							iLike: false,
+						},
+					},
+				} );
+				expect( state[ '1' ][ '1' ].likes ).toBe( initialState[ '1' ][ '1' ].likes );
+			} );
+		} );
+
+		describe( 'a POST_LIKES_REMOVE_LIKER action', () => {
+			const liker = deepFreeze( {
+				ID: 10,
+			} );
+			test( 'should creat a new entry if none is present', () => {
+				const initialState = deepFreeze( {} );
+				expect( items( initialState, removeLiker( 1, 1, 5, liker ) ) ).toEqual( {
+					1: {
+						1: {
+							likes: undefined,
+							found: 5,
+							iLike: false,
+						},
+					},
+				} );
+			} );
+
+			test( 'should not update the likes array if none is present, but should update the count', () => {
+				expect(
+					items(
+						deepFreeze( {
+							1: {
+								1: {
+									likes: undefined,
+									found: 5,
+									iLike: false,
+								},
+							},
+						} ),
+						removeLiker( 1, 1, 6, liker )
+					)
+				).toEqual( {
+					1: {
+						1: {
+							likes: undefined,
+							found: 6,
+							iLike: false,
+						},
+					},
+				} );
+			} );
+
+			test( 'should remove from the existing array if present', () => {
+				expect(
+					items(
+						deepFreeze( {
+							1: {
+								1: {
+									likes: [ liker ],
+									found: 5,
+									iLike: false,
+								},
+							},
+						} ),
+						removeLiker( 1, 1, 5, liker )
+					)
+				).toEqual( {
+					1: {
+						1: {
+							likes: [],
+							found: 5,
+							iLike: false,
+						},
+					},
+				} );
+			} );
+
+			test( 'should leave the likes array alone if the liker is already missing', () => {
+				const initialState = deepFreeze( {
+					1: {
+						1: {
+							likes: [ { ID: 2 } ],
+							found: 5,
+							iLike: false,
+						},
+					},
+				} );
+
+				const state = items(
+					initialState,
+					// same liker, new count!
+					removeLiker( 1, 1, 3, liker )
+				);
+
+				expect( state ).toEqual( {
+					1: {
+						1: {
+							likes: [ { ID: 2 } ],
+							found: 3,
+							iLike: false,
+						},
+					},
+				} );
+				expect( state[ '1' ][ '1' ].likes ).toBe( initialState[ '1' ][ '1' ].likes );
+			} );
 		} );
 	} );
 } );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -119,7 +119,7 @@ export function isValidStateWithSchema( state, schema, debugInfo ) {
  *
  * @example
  * const reducer = keyedReducer( 'username', userReducer, [ DESERIALIZE, SERIALIZE ] );
- * reducer.hasCustomerPersistence = true;
+ * reducer.hasCustomPersistence = true;
  *
  * // now every item can decide what to do for persistence
  *


### PR DESCRIPTION
Adds reducer support for POST_LIKE, POST_UNLIKE, POST_LIKES_ADD_LIKER, POST_LIKES_REMOVE_LIKER.

To test, run the tests.
 
You can also test in the console by dispatching POST_LIKE and POST_UNLIKE events and watch the network and redux flow.