### PR TITLE
People: Invites: Launch in production

### DIFF
--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -31,29 +31,27 @@ export default function() {
 		clientRender
 	);
 
-	if ( isEnabled( 'manage/people/invites' ) ) {
-		page( '/people/invites', siteSelection, sites, makeLayout, clientRender );
+	page( '/people/invites', siteSelection, sites, makeLayout, clientRender );
 
-		page(
-			'/people/invites/:site_id',
-			peopleController.enforceSiteEnding,
-			siteSelection,
-			navigation,
-			peopleController.peopleInvites,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/people/invites/:site_id',
+		peopleController.enforceSiteEnding,
+		siteSelection,
+		navigation,
+		peopleController.peopleInvites,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/people/invites/:site_id/:invite_key',
-			peopleController.enforceSiteEnding,
-			siteSelection,
-			navigation,
-			peopleController.peopleInviteDetails,
-			makeLayout,
-			clientRender
-		);
-	}
+	page(
+		'/people/invites/:site_id/:invite_key',
+		peopleController.enforceSiteEnding,
+		siteSelection,
+		navigation,
+		peopleController.peopleInviteDetails,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		'/people/new/:site_id',

--- a/client/my-sites/people/index.js
+++ b/client/my-sites/people/index.js
@@ -8,7 +8,6 @@ import page from 'page';
  * Internal dependencies
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
-import { isEnabled } from 'config';
 import peopleController from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -74,11 +73,5 @@ export default function() {
 	);
 
 	// Anything else is unexpected and should be redirected to the default people management URL: /people/team
-	page(
-		'/people/(.*)?',
-		siteSelection,
-		peopleController.redirectToTeam,
-		makeLayout,
-		clientRender
-	);
+	page( '/people/(.*)?', siteSelection, peopleController.redirectToTeam, makeLayout, clientRender );
 }

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -6,7 +6,6 @@
 
 import React, { Component } from 'react';
 import createReactClass from 'create-react-class';
-import { isEnabled } from 'config';
 import { find, get, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -122,14 +122,10 @@ class PeopleSectionNav extends Component {
 	}
 
 	getNavigableFilters() {
-		const allowedFilterIds = [ 'team', 'followers', 'email-followers' ];
+		const allowedFilterIds = [ 'team', 'followers', 'email-followers', 'invites' ];
 
 		if ( this.shouldDisplayViewers() ) {
 			allowedFilterIds.push( 'viewers' );
-		}
-
-		if ( isEnabled( 'manage/people/invites' ) ) {
-			allowedFilterIds.push( 'invites' );
 		}
 
 		return this.getFilters().filter(

--- a/config/development.json
+++ b/config/development.json
@@ -83,7 +83,6 @@
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
-		"manage/people/invites": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/compatibility-warning": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -57,7 +57,6 @@
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,
 		"manage/payment-methods": true,
-		"manage/people/invites": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/setup": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -61,7 +61,6 @@
 		"manage/option_sync_non_public_post_stati": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
-		"manage/people/invites": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/setup": true,


### PR DESCRIPTION
This PR removes the feature flag `manage/people/invites` and all references to it, enabling this feature in production and all other supported environments.