### PR TITLE
Revert "Layout: Stop elements from the primary section from showing through the sidebar."

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -80,11 +80,6 @@
 	}
 }
 
-.layout:not(.is-section-post-editor,.is-section-customize) .layout__primary {
-	//in all sections except for the editor, create a z-index stacking context on primary, so elements don't bleed in mobile views.
-	transform: translate( 0, 0 );
-}
-
 .layout__content a {
 	text-decoration: none;
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#22271.

Found at least one visual regression in the post view of the Reader:

![screen shot 2018-02-14 at 4 06 59 pm](https://user-images.githubusercontent.com/349751/36234750-a7a0e94a-11a1-11e8-8627-c2ec293351a5.png)
