### PR TITLE
Layout: Stop elements from the primary section from showing through the sidebar try 2

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -134,6 +134,11 @@
 	overflow: hidden;
 }
 
+.layout.focus-sidebar:not(.is-section-post-editor) .layout__primary {
+	//when sidebar is focused, create a z-index stacking context on primary, so elements don't bleed in mobile views.
+	transform: translate( 0, 0 );
+}
+
 // site selector in the sidebar
 .layout__secondary .site-selector {
 	background: $gray-lighten-30;


### PR DESCRIPTION
When a user in the mobile views goes from a `primary`-focussed view (eg. Stats or Plans) to the sidebar (`secondary`) view, elements from `primary` with z-indices higher than 0 will show through:

![screen shot 2018-02-08 at 11 45 56 am](https://user-images.githubusercontent.com/349751/36001459-2dc0d696-0cdb-11e8-88aa-57dc5b675138.png)

For now I'm forcing us to create a z-index stacking context on the primary div, so elements don't leak through when only viewing the sidebar. If anyone has a cleaner solution, by all means, please let us know.

Fixes #22258 .

**Testing**
 - On `master`, use devtools to go into a mobile view of Stats.
 - Click the `<` arrow in the header section, and see the stats showing through.
 - Switch to this branch, and go to Stats.
 - Click the `<` arrow again, and notice no stats show through.
 - Verify that popups, global notices, and other z-indexy things work okay
 - Verify that no regressions occur in the editor.