### PR TITLE
i18n: Adding missing translation to manage plugins page

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -301,7 +301,9 @@ const PluginsMain = createReactClass( {
 		);
 
 		const morePluginsHeader = showInstalledPluginList &&
-			showSuggestedPluginsList && <h3 className="plugins__more-header">More Plugins</h3>;
+			showSuggestedPluginsList && (
+				<h3 className="plugins__more-header">{ this.props.translate( 'More Plugins' ) }</h3>
+			);
 
 		let searchTitle;
 		if ( search ) {


### PR DESCRIPTION
This PR wraps a previously-untranslated string on the **Manage Plugins** page: http://calypso.localhost:3000/plugins/manage/{your domain}