### PR TITLE
Add hotjar script to checklist

### DIFF
--- a/client/components/checklist/index.jsx
+++ b/client/components/checklist/index.jsx
@@ -16,6 +16,7 @@ import classNames from 'classnames';
 import ChecklistHeader from './checklist-header';
 import ChecklistTask from './checklist-task';
 import ChecklistPlaceholder from './checklist-placeholder';
+import { loadTrackingTool } from 'state/analytics/actions';
 
 export class Checklist extends Component {
 	static propTypes = {
@@ -37,6 +38,10 @@ export class Checklist extends Component {
 	state = {
 		hideCompleted: false,
 	};
+
+	componentDidMount() {
+		this.props.loadTrackingTool( 'HotJar' );
+	}
 
 	toggleCompleted = () => {
 		this.setState( { hideCompleted: ! this.state.hideCompleted } );
@@ -100,4 +105,4 @@ export class Checklist extends Component {
 	}
 }
 
-export default connect( null, null )( Checklist );
+export default connect( null, { loadTrackingTool } )( Checklist );


### PR DESCRIPTION
This PR adds hotjar to the checklist component so we can run polls on the checklist screen. 

## Testing
* Create a site and make sure you're in the Checklist A/B test
* When viewing the checklist, open the console on the network tab and search for hotjar. This is what you'll see:

![image](https://user-images.githubusercontent.com/6981253/36240130-56d8f32c-11dd-11e8-8599-57544ee66b54.png)
