### PR TITLE
Editor: Gallery: reordering images on touch screen devices 

### DIFF
--- a/client/components/forms/sortable-list/index.jsx
+++ b/client/components/forms/sortable-list/index.jsx
@@ -41,8 +41,10 @@ class SortableList extends React.Component {
 	}
 
 	componentDidMount() {
-		document.addEventListener( 'mousemove', this.onMouseMove );
-		document.addEventListener( 'mouseup', this.onMouseUp );
+		if ( ! hasTouch() ) {
+			document.addEventListener( 'mousemove', this.onMouseMove );
+			document.addEventListener( 'mouseup', this.onMouseUp );
+		}
 	}
 
 	componentWillUnmount() {


### PR DESCRIPTION
This PR represents what I'm hoping to be a quick fix for #21215.

In `componentDidMount` we're adding `this.onMouseUp` as an event listener to the document mouseup event. This is overwriting the active index with `null` in touch devices, which we set `onClick`. We need this index to reorder the image list.

![feb-15-2018 17-58-54](https://user-images.githubusercontent.com/6458278/36244437-4a8cb246-127a-11e8-90fa-9f72fba04874.gif)

## Testing
Follow the steps in #21215 in a touch-enabled device

### Expectation
You should be able to re-order your gallery items using the arrows.

In a desktop browser (touch-disabled), you should be able to sort the items using mouse drag and drop as per normal.
