### PR TITLE
Jetpack: Update /log-in/jetpack styling

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -22,12 +22,13 @@ import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analyt
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 
 const enhanceContextWithLogin = context => {
-	const { path, params: { flow, twoFactorAuthType, socialService } } = context;
+	const { path, params: { flow, isJetpack, socialService, twoFactorAuthType } } = context;
 
 	context.cacheQueryKeys = [ 'client_id' ];
 
 	context.primary = (
 		<WPLogin
+			isJetpack={ isJetpack === 'jetpack' }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }
 			socialService={ socialService }

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -112,8 +112,8 @@ export function magicLoginUse( context, next ) {
 }
 
 export function redirectDefaultLocale( context, next ) {
-	// only redirect `/log-in/en` to `/log-in`
-	if ( context.pathname !== '/log-in/en' ) {
+	// Only handle simple routes
+	if ( context.pathname !== '/log-in/en' && context.pathname !== '/log-in/jetpack/en' ) {
 		return next();
 	}
 
@@ -132,5 +132,9 @@ export function redirectDefaultLocale( context, next ) {
 		return next();
 	}
 
-	context.redirect( '/log-in' );
+	if ( context.params.isJetpack === 'jetpack' ) {
+		context.redirect( '/log-in/jetpack' );
+	} else {
+		context.redirect( '/log-in' );
+	}
 }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -32,6 +32,7 @@ export class Login extends React.Component {
 	static propTypes = {
 		clientId: PropTypes.string,
 		isLoggedIn: PropTypes.bool.isRequired,
+		isJetpack: PropTypes.bool.isRequired,
 		locale: PropTypes.string.isRequired,
 		oauth2Client: PropTypes.object,
 		path: PropTypes.string.isRequired,
@@ -43,6 +44,8 @@ export class Login extends React.Component {
 		translate: PropTypes.func.isRequired,
 		twoFactorAuthType: PropTypes.string,
 	};
+
+	static defaultProps = { isJetpack: false };
 
 	componentDidMount() {
 		this.recordPageView( this.props );
@@ -135,6 +138,7 @@ export class Login extends React.Component {
 		const {
 			clientId,
 			isLoggedIn,
+			isJetpack,
 			oauth2Client,
 			privateSite,
 			socialConnect,
@@ -153,6 +157,7 @@ export class Login extends React.Component {
 				socialConnect={ socialConnect }
 				privateSite={ privateSite }
 				clientId={ clientId }
+				isJetpack={ isJetpack }
 				oauth2Client={ oauth2Client }
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -40,6 +40,7 @@
 		"help/courses": true,
 		"jetpack/api-cache": true,
 		"jetpack/connect/mobile-app-flow": true,
+		"jetpack/connection-rebranding": true,
 		"jetpack/happychat": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,


### PR DESCRIPTION
This PR applies the branded styling from #22250 on the `/log-in/jetpack` route.

It also enables the branding feature flag on wpcalypso which will allow us to see the branding on [calypso.live](https://calypso.live/log-in/jetpack?branch=update/jetpack/log-in-styling).

Extracted from #22218

* No functional changes
* Design changes -- development and wpcalypso environments only

## Screens

### Before (current production)

![before](https://user-images.githubusercontent.com/841763/36247914-f94157dc-1235-11e8-84ba-3ba3aa65472a.png)

### After (will be live on [wpcalypso](https://wpcalypso.wordpress.com/log-in/jetpack))

![after](https://user-images.githubusercontent.com/841763/36247913-f91ce08c-1235-11e8-9469-60c890daa85a.png)

## Testing
* Verify the styling for the [login page](https://calypso.live/log-in/jetpack?branch=update/jetpack/log-in-styling)
* Verify other [log-ins](https://calypso.live/log-in?branch=update/jetpack/log-in-styling) are unaffected.