### PR TITLE
LogInForm: Add disableAutoFocus props, disable in devdocs

### DIFF
--- a/client/blocks/login/docs/example.jsx
+++ b/client/blocks/login/docs/example.jsx
@@ -13,9 +13,9 @@ import LoginBlock from 'blocks/login';
 
 const LoginExample = () => (
 	<React.Fragment>
-		<LoginBlock />
+		<LoginBlock disableAutoFocus />
 		<p />
-		<LoginBlock isJetpack />
+		<LoginBlock disableAutoFocus isJetpack />
 	</React.Fragment>
 );
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -43,6 +43,7 @@ const user = userFactory();
 
 class Login extends Component {
 	static propTypes = {
+		disableAutoFocus: PropTypes.bool,
 		isLinking: PropTypes.bool,
 		isJetpack: PropTypes.bool.isRequired,
 		linkingSocialService: PropTypes.string,
@@ -230,6 +231,7 @@ class Login extends Component {
 			socialConnect,
 			socialService,
 			socialServiceResponse,
+			disableAutoFocus,
 		} = this.props;
 
 		let poller;
@@ -264,6 +266,7 @@ class Login extends Component {
 
 		return (
 			<LoginForm
+				disableAutoFocus={ disableAutoFocus }
 				onSuccess={ this.handleValidLogin }
 				privateSite={ privateSite }
 				socialService={ socialService }

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -51,6 +51,7 @@ import SocialLoginForm from './social';
 export class LoginForm extends Component {
 	static propTypes = {
 		accountType: PropTypes.string,
+		disableAutoFocus: PropTypes.bool,
 		fetchMagicLoginRequestEmail: PropTypes.func.isRequired,
 		formUpdate: PropTypes.func.isRequired,
 		getAuthAccountType: PropTypes.func.isRequired,
@@ -80,29 +81,32 @@ export class LoginForm extends Component {
 	};
 
 	componentDidMount() {
+		const { disableAutoFocus } = this.props;
 		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { isFormDisabledWhileLoading: false }, () => {
-			this.usernameOrEmail && this.usernameOrEmail.focus();
+			! disableAutoFocus && this.usernameOrEmail && this.usernameOrEmail.focus();
 		} );
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { requestError } = this.props;
+		const { disableAutoFocus, requestError } = this.props;
 
 		if ( prevProps.requestError || ! requestError ) {
 			return;
 		}
 
 		if ( requestError.field === 'password' ) {
-			defer( () => this.password && this.password.focus() );
+			! disableAutoFocus && defer( () => this.password && this.password.focus() );
 		}
 
 		if ( requestError.field === 'usernameOrEmail' ) {
-			defer( () => this.usernameOrEmail && this.usernameOrEmail.focus() );
+			! disableAutoFocus && defer( () => this.usernameOrEmail && this.usernameOrEmail.focus() );
 		}
 	}
 
 	componentWillReceiveProps( nextProps ) {
+		const { disableAutoFocus } = this.props;
+
 		if (
 			this.props.socialAccountIsLinking !== nextProps.socialAccountIsLinking &&
 			nextProps.socialAccountIsLinking
@@ -115,11 +119,11 @@ export class LoginForm extends Component {
 		if ( this.props.hasAccountTypeLoaded && ! nextProps.hasAccountTypeLoaded ) {
 			this.setState( { password: '' } );
 
-			defer( () => this.usernameOrEmail && this.usernameOrEmail.focus() );
+			! disableAutoFocus && defer( () => this.usernameOrEmail && this.usernameOrEmail.focus() );
 		}
 
 		if ( ! this.props.hasAccountTypeLoaded && isRegularAccount( nextProps.accountType ) ) {
-			defer( () => this.password && this.password.focus() );
+			! disableAutoFocus && defer( () => this.password && this.password.focus() );
 		}
 
 		if ( ! this.props.hasAccountTypeLoaded && isPasswordlessAccount( nextProps.accountType ) ) {


### PR DESCRIPTION
### Summary

Lately, I've been taking the approach of working from the devdocs first more often. It's generally a good experience but there are a few nuisance cases that get in the way of it being a better experience.

One such issue, is that the login form auto focuses each time you open [devdocs/blocks](https://wpcalypso.wordpress.com/devdocs/blocks). 
Of course, this auto focusing makes some sense in situ, but scroll midway down the page is a little inconvenient when developing a new component and confusing when visiting the page to browse.

In this PR I've added a new prop that allows this effect to be disabled. Unfortunately, I had to prop-drill a little 😬 but I don't see an alternative and I can't see this being an issue in this case.

### Testing

- First, observe the current behaviour by visiting [devdocs/blocks](https://wpcalypso.wordpress.com/devdocs/blocks). 
- Go to [devdocs/blocks](http://calypso.localhost:3000/devdocs/blocks) ([calypso.live](https://calypso.live/devdocs/blocks?branch=update/log-in-form/disable-auto-focus-in-devdocs))
  - Notice that the scroll position is right at the top when the page loads, as it should be.
- Now, check that the intended behaviour still works in situ by visiting [the log in page](http://calypso.localhost:3000/log-in) ([calypso.live](https://calypso.live/log-in?branch=update/log-in-form/disable-auto-focus-in-devdocs))
  - You should notice that the email address field auto focuses once ready.