### PR TITLE
Jetpack connect: Respect locale in login links

### DIFF
--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -118,6 +118,7 @@ export class JetpackSignup extends Component {
 				<LoggedOutFormLinkItem
 					href={ login( {
 						isNative: config.isEnabled( 'login/native-login-links' ),
+						locale: this.props.locale,
 						redirectTo: window.location.href,
 						emailAddress,
 					} ) }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -138,16 +138,17 @@ export class JetpackSignup extends Component {
 					{ this.renderLocaleSuggestions() }
 					<AuthFormHeader authQuery={ this.props.authQuery } />
 					<SignupForm
+						disabled={ isAuthorizing }
+						email={ this.props.authQuery.userEmail }
+						footerLink={ this.renderFooterLink() }
+						locale={ this.props.locale }
 						redirectToAfterLoginUrl={ addQueryArgs(
 							{ auth_approved: true },
 							window.location.href
 						) }
-						disabled={ isAuthorizing }
-						submitting={ isAuthorizing }
-						submitForm={ this.handleSubmitSignup }
 						submitButtonText={ this.props.translate( 'Sign Up and Connect Jetpack' ) }
-						footerLink={ this.renderFooterLink() }
-						email={ this.props.authQuery.userEmail }
+						submitForm={ this.handleSubmitSignup }
+						submitting={ isAuthorizing }
 						suggestedUsername={ get( userData, 'username', '' ) }
 					/>
 					{ userData && this.renderLoginUser() }

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -93,7 +93,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
       footerLink={
         <LoggedOutFormLinks>
           <LoggedOutFormLinkItem
-            href="https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site"
+            href="https://es.wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site"
           >
             Already have an account? Sign in
           </LoggedOutFormLinkItem>
@@ -102,6 +102,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
           />
         </LoggedOutFormLinks>
       }
+      locale="es"
       redirectToAfterLoginUrl="https://example.com/?auth_approved=true"
       submitButtonText="Sign Up and Connect Jetpack"
       submitForm={[Function]}


### PR DESCRIPTION
This PR adds the locale to log-in links from Jetpack Connect signup and authorize steps (`/jetpack/connect/authorize`).

Extracted from #22218 

## Screens (`es` locale Español)

### Footer link (test step 7)
![signup](https://user-images.githubusercontent.com/841763/36250537-65cff4a0-123e-11e8-9f20-24c2ce5381c4.png)

### Warning link (test step 8)

![unavailable](https://user-images.githubusercontent.com/841763/36250658-bfd43aa6-123e-11e8-8fac-5bfe78e6245e.png)

## Testing

1. Logged out of WordPress.com (private window)
1. Get a new Jetpack site
1. Ensure your site user _does not_ have an associated email on WordPress.com.
1. Change the site locale from English (Settings > General > Site Language)
1. Connect via WP Admin
1. Swap the url to point at `calypso.live` and add the query param `&branch=update/jetpack/connect-locales`
1. Verify the footer link to create a new account points to a localized log-in page (see screen)
1. Enter an email associated with an existing account and verify the warning link points to a localized log-in (see screen)


