### PR TITLE
Login: Enable login/native-login-links in test config

### DIFF
--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -83,7 +83,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
           Return to %(sitename)s
         </LoggedOutFormLinkItem>
         <LoggedOutFormLinkItem
-          href="https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fexample.com%2F"
+          href="/log-in/jetpack?redirect_to=https%3A%2F%2Fexample.com%2F"
         >
           Sign in as a different user
         </LoggedOutFormLinkItem>

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -35,7 +35,7 @@ exports[`JetpackSignup should render 1`] = `
       footerLink={
         <LoggedOutFormLinks>
           <LoggedOutFormLinkItem
-            href="https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site"
+            href="/log-in/jetpack?redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site"
           >
             Already have an account? Sign in
           </LoggedOutFormLinkItem>
@@ -93,7 +93,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
       footerLink={
         <LoggedOutFormLinks>
           <LoggedOutFormLinkItem
-            href="https://es.wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site"
+            href="/log-in/jetpack/es?redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site"
           >
             Already have an account? Sign in
           </LoggedOutFormLinkItem>

--- a/config/test.json
+++ b/config/test.json
@@ -40,6 +40,7 @@
 		"jetpack/onboarding": true,
 		"jetpack_core_inline_update": true,
 		"jitms": true,
+		"login/native-login-links": true,
 		"login/wp-login": true,
 		"keyboard-shortcuts": true,
 		"manage/customize": true,


### PR DESCRIPTION
Enable `login/native-login-links` in test config and update snapshots.

This is nice because it impacts snapshots to include values we expect to see in production (see https://github.com/Automattic/wp-calypso/pull/22484#discussion_r168413176)

## Testing
* Tests pass?