### PR TITLE
Taxonomy Manager: fix RTL view

### DIFF
--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -26,6 +26,10 @@
 	padding: 16px 24px;
 }
 
+.taxonomy-manager .ReactVirtualized__List {
+	direction: ltr !important;
+}
+
 .taxonomy-manager__nested-list {
 	margin-left: 2em;
 }


### PR DESCRIPTION
Similar to #21094, #21096 - react-virtualized is lacking proper RTL support, so we need to work around that.

Fixes #22476
