### PR TITLE
Layout: Make Logged-out Masterbar links Jetpack aware

### DIFF
--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { PureComponent } from 'react';
 import Masterbar from './masterbar';
 import { connect } from 'react-redux';
 import { getLocaleSlug, localize } from 'i18n-calypso';
@@ -33,61 +33,63 @@ function getLoginUrl( redirectUri ) {
 	return login( { ...params, isNative: config.isEnabled( 'login/native-login-links' ) } );
 }
 
-function getSignupUrl( currentRoute, query ) {
-	if ( '/log-in/jetpack' === currentRoute && query.redirect_to ) {
-		return query.redirect_to;
+function getSignupUrl( currentRoute, currentQuery ) {
+	if ( '/log-in/jetpack' === currentRoute && currentQuery.redirect_to ) {
+		return currentQuery.redirect_to;
 	}
 	return config( 'signup_url' );
 }
 
-const MasterbarLoggedOut = ( {
-	currentRoute,
-	query,
-	title,
-	sectionName,
-	translate,
-	redirectUri,
-} ) => (
-	<Masterbar>
-		<Item className="masterbar__item-logo">
-			<WordPressLogo className="masterbar__wpcom-logo" />
-			<WordPressWordmark className="masterbar__wpcom-wordmark" />
-		</Item>
-		<Item className="masterbar__item-title">{ title }</Item>
-		<div className="masterbar__login-links">
-			{ ! includes( [ 'signup', 'jetpack-onboarding', 'jetpack-connect' ], sectionName ) ? (
-				<Item url={ getSignupUrl( currentRoute, query ) }>
-					{ translate( 'Sign Up', {
-						context: 'Toolbar',
-						comment: 'Should be shorter than ~12 chars',
-					} ) }
+class MasterbarLoggedOut extends PureComponent {
+	static propTypes = {
+		redirectUri: PropTypes.string,
+		sectionName: PropTypes.string,
+		title: PropTypes.string,
+
+		// Connected props
+		currentQuery: PropTypes.object,
+		currentRoute: PropTypes.string,
+	};
+
+	static defaultProps = {
+		sectionName: '',
+		title: '',
+	};
+
+	render() {
+		const { currentQuery, currentRoute, title, sectionName, translate, redirectUri } = this.props;
+		return (
+			<Masterbar>
+				<Item className="masterbar__item-logo">
+					<WordPressLogo className="masterbar__wpcom-logo" />
+					<WordPressWordmark className="masterbar__wpcom-wordmark" />
 				</Item>
-			) : null }
+				<Item className="masterbar__item-title">{ title }</Item>
+				<div className="masterbar__login-links">
+					{ ! includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) ? (
+						<Item url={ getSignupUrl( currentRoute, currentQuery ) }>
+							{ translate( 'Sign Up', {
+								context: 'Toolbar',
+								comment: 'Should be shorter than ~12 chars',
+							} ) }
+						</Item>
+					) : null }
 
-			{ ! includes( [ 'login', 'jetpack-onboarding', 'jetpack-connect' ], sectionName ) ? (
-				<Item url={ getLoginUrl( redirectUri ) }>
-					{ translate( 'Log In', {
-						context: 'Toolbar',
-						comment: 'Should be shorter than ~12 chars',
-					} ) }
-				</Item>
-			) : null }
-		</div>
-	</Masterbar>
-);
-
-MasterbarLoggedOut.propTypes = {
-	title: PropTypes.string,
-	sectionName: PropTypes.string,
-	redirectUri: PropTypes.string,
-};
-
-MasterbarLoggedOut.defaultProps = {
-	title: '',
-	sectionName: '',
-};
+					{ ! includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ? (
+						<Item url={ getLoginUrl( redirectUri ) }>
+							{ translate( 'Log In', {
+								context: 'Toolbar',
+								comment: 'Should be shorter than ~12 chars',
+							} ) }
+						</Item>
+					) : null }
+				</div>
+			</Masterbar>
+		);
+	}
+}
 
 export default connect( state => ( {
+	currentQuery: getCurrentQueryArguments( state ),
 	currentRoute: getCurrentRoute( state ),
-	query: getCurrentQueryArguments( state ),
 } ) )( localize( MasterbarLoggedOut ) );

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -78,7 +78,11 @@ class MasterbarLoggedOut extends PureComponent {
 		}
 
 		let signupUrl = config( 'signup_url' );
-		if ( '/log-in/jetpack' === currentRoute && get( currentQuery, 'redirect_to', false ) ) {
+		if (
+			'/log-in/jetpack' === currentRoute &&
+			// Ensure our redirection is to Jetpack Connect
+			includes( get( currentQuery, 'redirect_to' ), '/jetpack/connect/authorize' )
+		) {
 			signupUrl = currentQuery.redirect_to;
 		}
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Masterbar from './masterbar';
+import { connect } from 'react-redux';
 import { getLocaleSlug, localize } from 'i18n-calypso';
 import { includes } from 'lodash';
 
@@ -18,6 +19,7 @@ import config from 'config';
 import { login } from 'lib/paths';
 import WordPressWordmark from 'components/wordpress-wordmark';
 import WordPressLogo from 'components/wordpress-logo';
+import { getCurrentQueryArguments, getCurrentRoute } from 'state/selectors';
 
 function getLoginUrl( redirectUri ) {
 	const params = { locale: getLocaleSlug() };
@@ -31,7 +33,21 @@ function getLoginUrl( redirectUri ) {
 	return login( { ...params, isNative: config.isEnabled( 'login/native-login-links' ) } );
 }
 
-const MasterbarLoggedOut = ( { title, sectionName, translate, redirectUri } ) => (
+function getSignupUrl( currentRoute, query ) {
+	if ( '/log-in/jetpack' === currentRoute && query.redirect_to ) {
+		return query.redirect_to;
+	}
+	return config( 'signup_url' );
+}
+
+const MasterbarLoggedOut = ( {
+	currentRoute,
+	query,
+	title,
+	sectionName,
+	translate,
+	redirectUri,
+} ) => (
 	<Masterbar>
 		<Item className="masterbar__item-logo">
 			<WordPressLogo className="masterbar__wpcom-logo" />
@@ -39,8 +55,8 @@ const MasterbarLoggedOut = ( { title, sectionName, translate, redirectUri } ) =>
 		</Item>
 		<Item className="masterbar__item-title">{ title }</Item>
 		<div className="masterbar__login-links">
-			{ ! includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) ? (
-				<Item url={ config( 'signup_url' ) }>
+			{ ! includes( [ 'signup', 'jetpack-onboarding', 'jetpack-connect' ], sectionName ) ? (
+				<Item url={ getSignupUrl( currentRoute, query ) }>
 					{ translate( 'Sign Up', {
 						context: 'Toolbar',
 						comment: 'Should be shorter than ~12 chars',
@@ -48,7 +64,7 @@ const MasterbarLoggedOut = ( { title, sectionName, translate, redirectUri } ) =>
 				</Item>
 			) : null }
 
-			{ ! includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ? (
+			{ ! includes( [ 'login', 'jetpack-onboarding', 'jetpack-connect' ], sectionName ) ? (
 				<Item url={ getLoginUrl( redirectUri ) }>
 					{ translate( 'Log In', {
 						context: 'Toolbar',
@@ -71,4 +87,7 @@ MasterbarLoggedOut.defaultProps = {
 	sectionName: '',
 };
 
-export default localize( MasterbarLoggedOut );
+export default connect( state => ( {
+	currentRoute: getCurrentRoute( state ),
+	query: getCurrentQueryArguments( state ),
+} ) )( localize( MasterbarLoggedOut ) );

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -38,7 +38,7 @@ class MasterbarLoggedOut extends PureComponent {
 	};
 
 	renderLoginItem() {
-		const { sectionName, translate, redirectUri } = this.props;
+		const { currentQuery, sectionName, translate, redirectUri } = this.props;
 
 		if ( includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ) {
 			return null;
@@ -54,6 +54,8 @@ class MasterbarLoggedOut extends PureComponent {
 
 		const loginUrl = login( {
 			...params,
+			// We may know the email from Jetpack connection details
+			emailAddress: get( currentQuery, 'user_email' ),
 			isJetpack: 'jetpack-connect' === sectionName,
 			isNative: config.isEnabled( 'login/native-login-links' ),
 		} );

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -9,7 +9,7 @@ import React, { PureComponent } from 'react';
 import Masterbar from './masterbar';
 import { connect } from 'react-redux';
 import { getLocaleSlug, localize } from 'i18n-calypso';
-import { get, includes } from 'lodash';
+import { get, includes, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -79,7 +79,8 @@ class MasterbarLoggedOut extends PureComponent {
 
 		let signupUrl = config( 'signup_url' );
 		if (
-			'/log-in/jetpack' === currentRoute &&
+			// Match locales like `/log-in/jetpack/es`
+			startsWith( currentRoute, '/log-in/jetpack' ) &&
 			// Ensure our redirection is to Jetpack Connect
 			includes( get( currentQuery, 'redirect_to' ), '/jetpack/connect/authorize' )
 		) {

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -54,6 +54,7 @@ class MasterbarLoggedOut extends PureComponent {
 
 		const loginUrl = login( {
 			...params,
+			isJetpack: 'jetpack-connect' === sectionName,
 			isNative: config.isEnabled( 'login/native-login-links' ),
 		} );
 
@@ -70,7 +71,7 @@ class MasterbarLoggedOut extends PureComponent {
 	renderSignupItem() {
 		const { currentQuery, currentRoute, sectionName, translate } = this.props;
 
-		if ( includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) ) {
+		if ( includes( [ 'signup', 'jetpack-onboarding', 'jetpack-connect' ], sectionName ) ) {
 			return null;
 		}
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -21,18 +21,6 @@ import WordPressWordmark from 'components/wordpress-wordmark';
 import WordPressLogo from 'components/wordpress-logo';
 import { getCurrentQueryArguments, getCurrentRoute } from 'state/selectors';
 
-function getLoginUrl( redirectUri ) {
-	const params = { locale: getLocaleSlug() };
-
-	if ( redirectUri ) {
-		params.redirectTo = redirectUri;
-	} else if ( typeof window !== 'undefined' ) {
-		params.redirectTo = window.location.href;
-	}
-
-	return login( { ...params, isNative: config.isEnabled( 'login/native-login-links' ) } );
-}
-
 class MasterbarLoggedOut extends PureComponent {
 	static propTypes = {
 		redirectUri: PropTypes.string,
@@ -51,15 +39,31 @@ class MasterbarLoggedOut extends PureComponent {
 
 	renderLoginItem() {
 		const { sectionName, translate, redirectUri } = this.props;
+
+		if ( includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ) {
+			return null;
+		}
+
+		const params = { locale: getLocaleSlug() };
+
+		if ( redirectUri ) {
+			params.redirectTo = redirectUri;
+		} else if ( typeof window !== 'undefined' ) {
+			params.redirectTo = window.location.href;
+		}
+
+		const loginUrl = login( {
+			...params,
+			isNative: config.isEnabled( 'login/native-login-links' ),
+		} );
+
 		return (
-			! includes( [ 'login', 'jetpack-onboarding' ], sectionName ) && (
-				<Item url={ getLoginUrl( redirectUri ) }>
-					{ translate( 'Log In', {
-						context: 'Toolbar',
-						comment: 'Should be shorter than ~12 chars',
-					} ) }
-				</Item>
-			)
+			<Item url={ loginUrl }>
+				{ translate( 'Log In', {
+					context: 'Toolbar',
+					comment: 'Should be shorter than ~12 chars',
+				} ) }
+			</Item>
 		);
 	}
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -9,7 +9,7 @@ import React, { PureComponent } from 'react';
 import Masterbar from './masterbar';
 import { connect } from 'react-redux';
 import { getLocaleSlug, localize } from 'i18n-calypso';
-import { includes } from 'lodash';
+import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -31,13 +31,6 @@ function getLoginUrl( redirectUri ) {
 	}
 
 	return login( { ...params, isNative: config.isEnabled( 'login/native-login-links' ) } );
-}
-
-function getSignupUrl( currentRoute, currentQuery ) {
-	if ( '/log-in/jetpack' === currentRoute && currentQuery.redirect_to ) {
-		return currentQuery.redirect_to;
-	}
-	return config( 'signup_url' );
 }
 
 class MasterbarLoggedOut extends PureComponent {
@@ -72,15 +65,23 @@ class MasterbarLoggedOut extends PureComponent {
 
 	renderSignupItem() {
 		const { currentQuery, currentRoute, sectionName, translate } = this.props;
+
+		if ( includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) ) {
+			return null;
+		}
+
+		let signupUrl = config( 'signup_url' );
+		if ( '/log-in/jetpack' === currentRoute && get( currentQuery, 'redirect_to', false ) ) {
+			signupUrl = currentQuery.redirect_to;
+		}
+
 		return (
-			! includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) && (
-				<Item url={ getSignupUrl( currentRoute, currentQuery ) }>
-					{ translate( 'Sign Up', {
-						context: 'Toolbar',
-						comment: 'Should be shorter than ~12 chars',
-					} ) }
-				</Item>
-			)
+			<Item url={ signupUrl }>
+				{ translate( 'Sign Up', {
+					context: 'Toolbar',
+					comment: 'Should be shorter than ~12 chars',
+				} ) }
+			</Item>
 		);
 	}
 

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -56,8 +56,36 @@ class MasterbarLoggedOut extends PureComponent {
 		title: '',
 	};
 
+	renderLoginItem() {
+		const { sectionName, translate, redirectUri } = this.props;
+		return (
+			! includes( [ 'login', 'jetpack-onboarding' ], sectionName ) && (
+				<Item url={ getLoginUrl( redirectUri ) }>
+					{ translate( 'Log In', {
+						context: 'Toolbar',
+						comment: 'Should be shorter than ~12 chars',
+					} ) }
+				</Item>
+			)
+		);
+	}
+
+	renderSignupItem() {
+		const { currentQuery, currentRoute, sectionName, translate } = this.props;
+		return (
+			! includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) && (
+				<Item url={ getSignupUrl( currentRoute, currentQuery ) }>
+					{ translate( 'Sign Up', {
+						context: 'Toolbar',
+						comment: 'Should be shorter than ~12 chars',
+					} ) }
+				</Item>
+			)
+		);
+	}
+
 	render() {
-		const { currentQuery, currentRoute, title, sectionName, translate, redirectUri } = this.props;
+		const { title } = this.props;
 		return (
 			<Masterbar>
 				<Item className="masterbar__item-logo">
@@ -66,23 +94,8 @@ class MasterbarLoggedOut extends PureComponent {
 				</Item>
 				<Item className="masterbar__item-title">{ title }</Item>
 				<div className="masterbar__login-links">
-					{ ! includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) ? (
-						<Item url={ getSignupUrl( currentRoute, currentQuery ) }>
-							{ translate( 'Sign Up', {
-								context: 'Toolbar',
-								comment: 'Should be shorter than ~12 chars',
-							} ) }
-						</Item>
-					) : null }
-
-					{ ! includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ? (
-						<Item url={ getLoginUrl( redirectUri ) }>
-							{ translate( 'Log In', {
-								context: 'Toolbar',
-								comment: 'Should be shorter than ~12 chars',
-							} ) }
-						</Item>
-					) : null }
+					{ this.renderSignupItem() }
+					{ this.renderLoginItem() }
 				</div>
 			</Masterbar>
 		);

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -45,6 +45,13 @@ class MasterbarLoggedOut extends PureComponent {
 			return null;
 		}
 
+		let redirectTo = null;
+		if ( redirectUri ) {
+			redirectTo = redirectUri;
+		} else if ( currentRoute ) {
+			redirectTo = currentQuery ? addQueryArgs( currentQuery, currentRoute ) : currentRoute;
+		}
+
 		const isJetpack = 'jetpack-connect' === sectionName;
 
 		const loginUrl = login( {
@@ -53,7 +60,7 @@ class MasterbarLoggedOut extends PureComponent {
 			isJetpack,
 			isNative: config.isEnabled( 'login/native-login-links' ),
 			locale: getLocaleSlug(),
-			redirectTo: redirectUri || addQueryArgs( currentQuery, currentRoute ),
+			redirectTo,
 		} );
 
 		return (

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -45,20 +45,15 @@ class MasterbarLoggedOut extends PureComponent {
 			return null;
 		}
 
-		const params = { locale: getLocaleSlug() };
-
-		if ( redirectUri ) {
-			params.redirectTo = redirectUri;
-		} else {
-			params.redirectTo = addQueryArgs( currentQuery, currentRoute );
-		}
+		const isJetpack = 'jetpack-connect' === sectionName;
 
 		const loginUrl = login( {
-			...params,
 			// We may know the email from Jetpack connection details
-			emailAddress: get( currentQuery, 'user_email' ),
-			isJetpack: 'jetpack-connect' === sectionName,
+			emailAddress: isJetpack && get( currentQuery, 'user_email', false ),
+			isJetpack,
 			isNative: config.isEnabled( 'login/native-login-links' ),
+			locale: getLocaleSlug(),
+			redirectTo: redirectUri || addQueryArgs( currentQuery, currentRoute ),
 		} );
 
 		return (

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -76,11 +76,33 @@ class MasterbarLoggedOut extends PureComponent {
 	renderSignupItem() {
 		const { currentQuery, currentRoute, sectionName, translate } = this.props;
 
-		if ( includes( [ 'signup', 'jetpack-onboarding', 'jetpack-connect' ], sectionName ) ) {
+		// Hide for some sections
+		if ( includes( [ 'signup', 'jetpack-onboarding' ], sectionName ) ) {
+			return null;
+		}
+
+		/**
+		 * Hide signup from Jetpack connect authorization step. This step handles signup as part of
+		 * the flow.
+		 */
+		if ( startsWith( currentRoute, '/jetpack/connect/authorize' ) ) {
+			return null;
+		}
+
+		/**
+		 * Hide signup from from New Site screen. This allows starting with a new Jetpack or
+		 * WordPress.com site.
+		 */
+		if ( startsWith( currentRoute, '/jetpack/new' ) ) {
 			return null;
 		}
 
 		let signupUrl = config( 'signup_url' );
+		/**
+		 * log-in/jetpack/:locale is reached as part of the Jetpack connection flow. In this case,
+		 * the redirect_to will handle signups as part of the flow. Use the redirect_to parameter
+		 * directly for signup.
+		 */
 		if (
 			// Match locales like `/log-in/jetpack/es`
 			startsWith( currentRoute, '/log-in/jetpack' ) &&
@@ -88,6 +110,8 @@ class MasterbarLoggedOut extends PureComponent {
 			includes( get( currentQuery, 'redirect_to' ), '/jetpack/connect/authorize' )
 		) {
 			signupUrl = currentQuery.redirect_to;
+		} else if ( 'jetpack-connect' === sectionName ) {
+			signupUrl = '/jetpack/new';
 		}
 
 		return (

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -98,18 +98,20 @@ class MasterbarLoggedOut extends PureComponent {
 		}
 
 		let signupUrl = config( 'signup_url' );
-		/**
-		 * log-in/jetpack/:locale is reached as part of the Jetpack connection flow. In this case,
-		 * the redirect_to will handle signups as part of the flow. Use the redirect_to parameter
-		 * directly for signup.
-		 */
 		if (
 			// Match locales like `/log-in/jetpack/es`
-			startsWith( currentRoute, '/log-in/jetpack' ) &&
-			// Ensure our redirection is to Jetpack Connect
-			includes( get( currentQuery, 'redirect_to' ), '/jetpack/connect/authorize' )
+			startsWith( currentRoute, '/log-in/jetpack' )
 		) {
-			signupUrl = currentQuery.redirect_to;
+			if ( includes( get( currentQuery, 'redirect_to' ), '/jetpack/connect/authorize' ) ) {
+				/**
+				 * `log-in/jetpack/:locale` is reached as part of the Jetpack connection flow. In
+				 * this case, the redirect_to will handle signups as part of the flow. Use the
+				 * `redirect_to` parameter directly for signup.
+				 */
+				signupUrl = currentQuery.redirect_to;
+			} else {
+				signupUrl = '/jetpack/new';
+			}
 		} else if ( 'jetpack-connect' === sectionName ) {
 			signupUrl = '/jetpack/new';
 		}

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -14,12 +14,13 @@ import { get, includes, startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
-import Item from './item';
 import config from 'config';
-import { login } from 'lib/paths';
-import WordPressWordmark from 'components/wordpress-wordmark';
+import Item from './item';
 import WordPressLogo from 'components/wordpress-logo';
+import WordPressWordmark from 'components/wordpress-wordmark';
+import { addQueryArgs } from 'lib/route';
 import { getCurrentQueryArguments, getCurrentRoute } from 'state/selectors';
+import { login } from 'lib/paths';
 
 class MasterbarLoggedOut extends PureComponent {
 	static propTypes = {
@@ -38,7 +39,7 @@ class MasterbarLoggedOut extends PureComponent {
 	};
 
 	renderLoginItem() {
-		const { currentQuery, sectionName, translate, redirectUri } = this.props;
+		const { currentQuery, currentRoute, sectionName, translate, redirectUri } = this.props;
 
 		if ( includes( [ 'login', 'jetpack-onboarding' ], sectionName ) ) {
 			return null;
@@ -48,8 +49,8 @@ class MasterbarLoggedOut extends PureComponent {
 
 		if ( redirectUri ) {
 			params.redirectTo = redirectUri;
-		} else if ( typeof window !== 'undefined' ) {
-			params.redirectTo = window.location.href;
+		} else {
+			params.redirectTo = addQueryArgs( currentQuery, currentRoute );
 		}
 
 		const loginUrl = login( {

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -102,7 +102,11 @@ class MasterbarLoggedOut extends PureComponent {
 			// Match locales like `/log-in/jetpack/es`
 			startsWith( currentRoute, '/log-in/jetpack' )
 		) {
-			if ( includes( get( currentQuery, 'redirect_to' ), '/jetpack/connect/authorize' ) ) {
+			// Basic validation that we're in a valid Jetpack Authorization flow
+			if (
+				includes( get( currentQuery, 'redirect_to' ), '/jetpack/connect/authorize' ) &&
+				includes( get( currentQuery, 'redirect_to' ), '_wp_nonce' )
+			) {
 				/**
 				 * `log-in/jetpack/:locale` is reached as part of the Jetpack connection flow. In
 				 * this case, the redirect_to will handle signups as part of the flow. Use the

--- a/client/layout/test/index.js
+++ b/client/layout/test/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React from 'react';
+import { Provider } from 'react-redux';
 import { renderToString } from 'react-dom/server';
 
 /**
@@ -15,7 +16,7 @@ describe( 'index', () => {
 		test( "doesn't throw an exception", () => {
 			expect( () => {
 				renderToString(
-					<LayoutLoggedOut
+					<Provider
 						store={ {
 							dispatch: () => {},
 							getState: () => ( {
@@ -23,7 +24,9 @@ describe( 'index', () => {
 							} ),
 							subscribe: () => {},
 						} }
-					/>
+					>
+						<LayoutLoggedOut />
+					</Provider>
 				);
 			} ).not.toThrow();
 		} );


### PR DESCRIPTION
This PR updates the logged out masterbar links to behave in an appropriate way from the Jetpack connection flow:

- Signup is removed from signup paths (`/jetpack/connect/authorize` and `/jetpack/new`).
- Signup in the `jetpack-connect` section now points to `/jetpack/new`.
- Login links from `jetpack-connect` section use the `log-in/jetpack` login page.
- Preserves email when navigating to log-in from the Jetpack connect signup form.
- Fixes a bug with render race conditions by using redux state over `window.location`.

See p1HpG7-4P7-p2

Extracted from #22218

## Testing

Changes are limited to the Logged Out Masterbar. Ensure you're logged out of WordPress.com. Emails with and without associated WordPress.com accounts should behave in a coherent way. This changes are all here:

![this](https://user-images.githubusercontent.com/841763/36306047-63a45148-1316-11e8-8dbe-b1723d29809d.png)

Clicking "Log In" should always land you at `log-in/jetpack`.
"Sign up" may be hidden depending on where you are (authorize or the new site screen).
"Sign

This should have _no impact at all_ outside of the `jetpack-connect` section, except for improving the "Sign Up" link from `log-in/jetpack`.

1. Connect a new site
1. You can swap out `calypso.live` and add the branch param `branch=update/masterbar-jetpack-login` once you arrive in Calypso for testing.
1. Use the masterbar to navigate between "Log In" (`log-in/jetpack`) and "Sign up" (`/jetpack/connect/authorize`)
1. All good?
1. Try visiting other URLs and check the behavior:
   - https://calypso.live/log-in/jetpack?branch=update/masterbar-jetpack-login
   - https://calypso.live/jetpack/new?branch=update/masterbar-jetpack-login
   - https://calypso.live/jetpack/connect/store?branch=update/masterbar-jetpack-login
   - https://calypso.live/jetpack/connect?branch=update/masterbar-jetpack-login
1. Other logged out URLs unaffected
   - https://calypso.live/log-in?branch=update/masterbar-jetpack-login
   - https://calypso.live/start?branch=update/masterbar-jetpack-login
   - …