### PR TITLE
Jetpack connect: Use Jetpack login from signup form

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -40,6 +40,7 @@ import SocialSignupForm from './social';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { createSocialUserFailed } from 'state/login/actions';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
+import { getSectionName } from 'state/ui/selectors';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
 	debug = debugModule( 'calypso:signup-form:form' );
@@ -76,7 +77,10 @@ class SignupForm extends Component {
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+
+		// Connected props
 		oauth2Client: PropTypes.object,
+		sectionName: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -329,6 +333,7 @@ class SignupForm extends Component {
 
 	getLoginLink() {
 		return login( {
+			isJetpack: 'jetpack-connect' === this.props.sectionName,
 			isNative: config.isEnabled( 'login/native-login-links' ),
 			redirectTo: this.props.redirectToAfterLoginUrl,
 			locale: this.props.locale,
@@ -629,6 +634,7 @@ class SignupForm extends Component {
 export default connect(
 	state => ( {
 		oauth2Client: getCurrentOAuth2Client( state ),
+		sectionName: getSectionName( state ),
 	} ),
 	{
 		trackLoginMidFlow: () => recordTracksEvent( 'calypso_signup_login_midflow' ),


### PR DESCRIPTION
This PR changes the signup form to use `isJetpack` for login (point to `/log-in/jetpack`) when in the `jetpack-connect` section.

Extracted from #22218 
Related to #22490 

The path is used in this link:

![unavailable-link](https://user-images.githubusercontent.com/841763/36250658-bfd43aa6-123e-11e8-8fac-5bfe78e6245e.png)

## Testing
1. Log out of WordPress.com
1. Connect a new Jetpack site with a user without a matching WordPress.com email
1. You will be presented with a signup form
1. Enter an email that is associated with an existing account.
1. You will be shown a warning that the email is unavailable
1. Verify that link in the warning points to `/log-in/jetpack`