### PR TITLE
Jetpack connect: Update login links

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -610,7 +610,13 @@ export class JetpackAuthorize extends Component {
 		return (
 			<LoggedOutFormLinks>
 				{ this.isWaitingForConfirmation() ? backToWpAdminLink : null }
-				<LoggedOutFormLinkItem href={ login( { redirectTo: window.location.href } ) }>
+				<LoggedOutFormLinkItem
+					href={ login( {
+						isJetpack: true,
+						isNative: config.isEnabled( 'login/native-login-links' ),
+						redirectTo: window.location.href,
+					} ) }
+				>
 					{ translate( 'Sign in as a different user' ) }
 				</LoggedOutFormLinkItem>
 				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -117,9 +117,10 @@ export class JetpackSignup extends Component {
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem
 					href={ login( {
+						emailAddress,
+						isJetpack: true,
 						isNative: config.isEnabled( 'login/native-login-links' ),
 						redirectTo: window.location.href,
-						emailAddress,
 					} ) }
 				>
 					{ this.props.translate( 'Already have an account? Sign in' ) }

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -9,6 +9,7 @@ import { addLocaleToPath, addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import config, { isEnabled } from 'config';
 
 export function login( {
+	isJetpack,
 	isNative,
 	locale,
 	redirectTo,
@@ -29,6 +30,8 @@ export function login( {
 			url += '/' + twoFactorAuthType;
 		} else if ( socialConnect ) {
 			url += '/social-connect';
+		} else if ( isJetpack ) {
+			url += '/jetpack';
 		}
 	}
 

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -69,5 +69,11 @@ describe( 'index', () => {
 
 			expect( url ).to.equal( '/log-in?client_id=12345' );
 		} );
+
+		test( 'should return the login url for Jetpck specific login', () => {
+			const url = login( { isNative: true, isJetpack: true } );
+
+			expect( url ).to.equal( '/log-in/jetpack' );
+		} );
 	} );
 } );

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -70,7 +70,7 @@ describe( 'index', () => {
 			expect( url ).to.equal( '/log-in?client_id=12345' );
 		} );
 
-		test( 'should return the login url for Jetpck specific login', () => {
+		test( 'should return the login url for Jetpack specific login', () => {
 			const url = login( { isNative: true, isJetpack: true } );
 
 			expect( url ).to.equal( '/log-in/jetpack' );


### PR DESCRIPTION
Change Jetpack Connect components which currently point to `/log-in` to point to `/log-in/jetpack`

Extracted from #22218 

These links are present in the footer of the signup and authorize views in the Jetpack connect flow (`/jetpack/connect/authorize`).

These are the affected links:

![auth](https://user-images.githubusercontent.com/841763/36255560-d19405a8-124f-11e8-953c-8a156569a2c9.png)
![signup](https://user-images.githubusercontent.com/841763/36255562-d1bbd524-124f-11e8-8544-66702a63bff2.png)

## Testing
1. Begin logged out of WordPress.com with a user who does not have an email associated with a WordPress.com account.
1. Verify the footer link in the signup form points to `/log-in/jetpack` and not `/log-in`.
1. You can copy the url from the above step and paste it into a logged-in WordPress.com session to see the authorize form
1. Verify the url in the footer of the authorize from points to `/log-in/jetpack` and not `/log-in`.