### PR TITLE
Bug: getSiteFragment checks second-to-last segment first

### DIFF
--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -28,14 +28,14 @@ export function getSiteFragment( path ) {
 	// last (most sections) and second-to-last (post ID is last in editor)
 
 	// Check last and second-to-last piece for site slug
-	for ( let i = 2; i > 0; i-- ) {
+	for ( let i = 1; i < 3; i++ ) {
 		const piece = pieces[ pieces.length - i ];
 		if ( piece && -1 !== piece.indexOf( '.' ) ) {
 			return piece;
 		}
 	}
 
-	// Check last and second-to-last piece for numeric site ID
+	// Check second-to-last and last piece for numeric site ID
 	for ( let i = 2; i > 0; i-- ) {
 		const piece = parseInt( pieces[ pieces.length - i ], 10 );
 		if ( Number.isSafeInteger( piece ) ) {

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -206,6 +206,13 @@ describe( 'route', function() {
 				expect( route.getSiteFragment( '/stats/day/1000000000000000000000' ) ).to.be.false;
 			} );
 		} );
+		describe( 'for domains paths', function() {
+			test( 'should return the site when second-to-last URL segment also contains a domain', function() {
+				expect(
+					route.getSiteFragment( '/domains/add/suggestion/example.com/example.wordpress.com' )
+				).to.equal( 'example.wordpress.com' );
+			} );
+		} );
 	} );
 
 	describe( 'addSiteFragment', function() {


### PR DESCRIPTION
I would like to be able to link to a URL like `/domains/add/suggestion/mytestsite.com/mytestsite.wordpress.com` and see the domain suggestion page pre-populated with `mytestsite.com`. What happens now, is `getSiteFragment()` picks `mytestsite.com` as the actual site domain because it checks last two segments of the URL, but starts with **second to last** segment. This commit makes it look into the **last** segment first.