### PR TITLE
/comments: blockquote spacing

### DIFF
--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -239,6 +239,12 @@
 	.comment__content-body *:last-child {
 		margin-bottom: 0;
 	}
+
+	.comment__content-body blockquote {
+		padding: 8px 16px;
+		margin: 8px 0 16px;
+		border-left: 2px solid $gray-lighten-30;
+	}
 }
 
 .comment__content-preview {


### PR DESCRIPTION
This adds spacing to the blockquote element in the comment body in
/comments.

Before|After
---|---
![before](https://user-images.githubusercontent.com/618551/36266667-a65707c2-1237-11e8-86d1-bcda82b2eaec.png)|![after](https://user-images.githubusercontent.com/618551/36266693-b44b9f82-1237-11e8-8ca1-4f728368e9c3.png)

Here's what it looks like in the Reader:

![screen shot 2018-02-15 at 9 59 25 am](https://user-images.githubusercontent.com/618551/36266729-cdb28cb0-1237-11e8-8350-3fbe6067e68c.png)

