### PR TITLE
Activity Log: track Get help button in failed backup events

### DIFF
--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import scrollTo from 'lib/scroll-to';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -77,8 +76,12 @@ class ActivityLogItem extends Component {
 	renderItemAction() {
 		const { hideRestore, activity: { activityIsRewindable, activityName } } = this.props;
 
-		if ( includes( [ 'rewind__scan_result_found', 'rewind__backup_error' ], activityName ) ) {
-			return this.renderHelpAction();
+		switch ( activityName ) {
+			case 'rewind__scan_result_found':
+				return this.renderHelpAction( this.props.trackHelpThreat );
+
+			case 'rewind__backup_error':
+				return this.renderHelpAction( this.props.trackHelpBackupFail );
 		}
 
 		if ( ! hideRestore && activityIsRewindable ) {
@@ -112,14 +115,20 @@ class ActivityLogItem extends Component {
 		);
 	}
 
-	renderHelpAction() {
-		const { getHelpClick, translate } = this.props;
+	/**
+	 * Displays a button for users to get help. Tracks button click based on the function passed.
+	 *
+	 * @param {function} trackHelp Method to call and track the button click.
+	 * @returns {Object} Get help button.
+	 */
+	renderHelpAction( trackHelp ) {
+		const { translate } = this.props;
 
 		return (
 			<HappychatButton
 				className="activity-log-item__help-action"
 				borderless={ false }
-				onClick={ getHelpClick }
+				onClick={ trackHelp }
 			>
 				<Gridicon icon="chat" size={ 18 } />
 				{ translate( 'Get Help' ) }
@@ -273,7 +282,8 @@ const mapDispatchToProps = ( dispatch, { activityId, siteId } ) => ( {
 			)
 		)
 	),
-	getHelpClick: () => recordTracksEvent( 'calypso_activitylog_threat_get_help' ),
+	trackHelpThreat: () => recordTracksEvent( 'calypso_activitylog_threat_get_help' ),
+	trackHelpBackupFail: () => recordTracksEvent( 'calypso_activitylog_backup_fail_get_help' ),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( ActivityLogItem ) );


### PR DESCRIPTION
This PR adds a separate track event with its own name when users click the button to get help in a backup failed event.

### Testing

<img width="692" alt="happychat-failed-backup" src="https://user-images.githubusercontent.com/1041600/36266925-7c186162-1251-11e8-8e72-fa2e4c88066c.png">

Click the Get help button in a failed backup event. Make sure the tracking is fired by watching if the related Redux action `ANALYTICS_EVENT_RECORD` is fired with the right name `calypso_activitylog_backup_fail_get_help`.