### PR TITLE
SEO Settings: make support link external

### DIFF
--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -337,7 +337,13 @@ class SiteVerification extends Component {
 							{
 								components: {
 									b: <strong />,
-									support: <a href="https://en.support.wordpress.com/webmaster-tools/" />,
+									support: (
+										<ExternalLink
+											icon={ true }
+											target="_blank"
+											href="https://en.support.wordpress.com/webmaster-tools/"
+										/>
+									),
 									google: (
 										<ExternalLink
 											icon={ true }


### PR DESCRIPTION
Fixes #9339 

Before, the link opened in the same window and could cause a user to lose their place. This also makes the link consistent with the surrounding external links.

Before|After
---|---
![before](https://user-images.githubusercontent.com/618551/36267236-09b67496-1239-11e8-9d93-e2685757e7af.png)|![after](https://user-images.githubusercontent.com/618551/36267237-09c67076-1239-11e8-84db-d54f08c507af.png)
