### PR TITLE
Revert "Layout: Stop elements from the primary section from showing through the sidebar try 2"

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -134,11 +134,6 @@
 	overflow: hidden;
 }
 
-.layout.focus-sidebar:not(.is-section-post-editor) .layout__primary {
-	//when sidebar is focused, create a z-index stacking context on primary, so elements don't bleed in mobile views.
-	transform: translate( 0, 0 );
-}
-
 // site selector in the sidebar
 .layout__secondary .site-selector {
 	background: $gray-lighten-30;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#22478

Prepping this in case folks notice any regressions in prod that we missed in testing.