### PR TITLE
Remove lodash duplication from lib/credit-card-details

### DIFF
--- a/client/components/credit-card-form-fields/test/index.js
+++ b/client/components/credit-card-form-fields/test/index.js
@@ -8,8 +8,8 @@
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import noop from 'lodash/noop';
-import identity from 'lodash/identity';
+import { identity, noop } from 'lodash';
+
 /**
  * Internal dependencies
  */

--- a/client/components/head/test/index.jsx
+++ b/client/components/head/test/index.jsx
@@ -8,7 +8,7 @@
  */
 import { shallow } from 'enzyme';
 import React from 'react';
-import merge from 'lodash/merge';
+import { merge } from 'lodash';
 
 describe( 'Head', () => {
 	let Head;

--- a/client/lib/credit-card-details/ebanx.js
+++ b/client/lib/credit-card-details/ebanx.js
@@ -3,7 +3,7 @@
  *
  * @format
  */
-import isUndefined from 'lodash/isUndefined';
+import { isUndefined } from 'lodash';
 import { isValid } from 'cpf';
 
 /**

--- a/client/lib/credit-card-details/validation.js
+++ b/client/lib/credit-card-details/validation.js
@@ -3,11 +3,7 @@
  * External dependencies
  */
 import creditcards from 'creditcards';
-import capitalize from 'lodash/capitalize';
-import compact from 'lodash/compact';
-import isArray from 'lodash/isArray';
-import isEmpty from 'lodash/isEmpty';
-import pick from 'lodash/pick';
+import { capitalize, compact, isArray, isEmpty, pick } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**


### PR DESCRIPTION
There were a few `import noop from 'lodash/noop'` calls, which caused duplication.

http://iscalypsofastyet.com/branch?branch=fix/lodash-duplication