### PR TITLE
Display address normalization errors in notice or per field, as appropriate

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/components/dropdown/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/dropdown/index.js
@@ -36,7 +36,7 @@ const Dropdown = ( { id, valuesMap, title, description, value, updateValue, erro
 					);
 				} ) }
 			</FormSelect>
-			{ error && <FieldError text={ error } /> }
+			{ error && typeof error === 'string' && <FieldError text={ error } /> }
 			{ ! error && description && <FormSettingExplanation>{ description }</FormSettingExplanation> }
 		</FormFieldset>
 	);

--- a/client/extensions/woocommerce/woocommerce-services/components/text-field/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/text-field/index.js
@@ -27,7 +27,7 @@ const TextField = ( { id, title, description, value, placeholder, updateValue, e
 				onChange={ handleChangeEvent }
 				isError={ Boolean( error ) }
 			/>
-			{ error && <FieldError text={ error } /> }
+			{ error && typeof error === 'string' && <FieldError text={ error } /> }
 			{ ! error && description && <FormSettingExplanation>{ description }</FormSettingExplanation> }
 		</FormFieldset>
 	);

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/normalize-address.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/normalize-address.js
@@ -20,8 +20,8 @@ export default ( orderId, siteId, dispatch, address, group ) => {
 		let error = null, fieldErrors = null;
 		const setError = ( err ) => error = err;
 		const setSuccess = ( json ) => {
-			if ( json.fieldErrors ) {
-				fieldErrors = json.fieldErrors;
+			if ( json.field_errors ) {
+				fieldErrors = json.field_errors;
 				return;
 			}
 			dispatch( {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -126,14 +126,17 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP ] = ( state, { stepNam
 };
 
 reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_UPDATE_ADDRESS_VALUE ] = ( state, { group, name, value } ) => {
+	const isAddressField = name !== 'name' && name !== 'company' && name !== 'phone';
 	const newState = { ...state,
 		form: { ...state.form,
 			[ group ]: { ...state.form[ group ],
 				values: { ...state.form[ group ].values,
 					[ name ]: value,
 				},
-				isNormalized: false,
-				normalized: null,
+				...( isAddressField && {
+					isNormalized: false,
+					normalized: null,
+				} ),
 			},
 		},
 	};

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -183,12 +183,13 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_SET_NORMALIZED_ADDRESS ] = ( state
 	return newState;
 };
 
-reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_ADDRESS_NORMALIZATION_COMPLETED ] = ( state, { group } ) => {
+reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_ADDRESS_NORMALIZATION_COMPLETED ] = ( state, { group, completed, fieldErrors } ) => {
 	return { ...state,
 		form: { ...state.form,
 			[ group ]: { ...state.form[ group ],
-				isNormalized: true,
+				isNormalized: completed,
 				normalizationInProgress: false,
+				fieldErrors,
 			},
 		},
 	};

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/reducer.js
@@ -126,17 +126,14 @@ reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_TOGGLE_STEP ] = ( state, { stepNam
 };
 
 reducers[ WOOCOMMERCE_SERVICES_SHIPPING_LABEL_UPDATE_ADDRESS_VALUE ] = ( state, { group, name, value } ) => {
-	const isAddressField = name !== 'name' && name !== 'company' && name !== 'phone';
 	const newState = { ...state,
 		form: { ...state.form,
 			[ group ]: { ...state.form[ group ],
 				values: { ...state.form[ group ].values,
 					[ name ]: value,
 				},
-				...( isAddressField && {
-					isNormalized: false,
-					normalized: null,
-				} ),
+				isNormalized: false,
+				normalized: null,
 			},
 		},
 	};

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -112,8 +112,10 @@ export const getTotalPriceBreakdown = ( state, orderId, siteId = getSelectedSite
 	} : null;
 };
 
-const getAddressErrors = ( { values, isNormalized, normalized, selectNormalized, ignoreValidation }, countriesData ) => {
-	if ( isNormalized && ! normalized ) {
+const getAddressErrors = ( { values, isNormalized, normalized, selectNormalized, ignoreValidation, fieldErrors }, countriesData ) => {
+	if ( isNormalized && ! normalized && fieldErrors ) {
+		return fieldErrors;
+	} else if ( isNormalized && ! normalized ) {
 		// If the address is normalized but the server didn't return a normalized address, then it's
 		// invalid and must register as an error
 		return {

--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/selectors.js
@@ -112,17 +112,25 @@ export const getTotalPriceBreakdown = ( state, orderId, siteId = getSelectedSite
 	} : null;
 };
 
-const getAddressErrors = ( { values, isNormalized, normalized, selectNormalized, ignoreValidation, fieldErrors }, countriesData ) => {
-	if ( isNormalized && ! normalized && fieldErrors ) {
+const getAddressErrors = ( {
+	values,
+	isNormalized,
+	normalized: normalizedValues,
+	selectNormalized,
+	ignoreValidation,
+	fieldErrors,
+}, countriesData ) => {
+	if ( isNormalized && ! normalizedValues && fieldErrors ) {
 		return fieldErrors;
-	} else if ( isNormalized && ! normalized ) {
+	} else if ( isNormalized && ! normalizedValues ) {
 		// If the address is normalized but the server didn't return a normalized address, then it's
 		// invalid and must register as an error
 		return {
 			address: translate( 'This address is not recognized. Please try another.' ),
 		};
 	}
-	const { postcode, state, country } = ( isNormalized && selectNormalized ) ? normalized : values;
+
+	const { postcode, state, country } = ( isNormalized && selectNormalized ) ? normalizedValues : values;
 	const requiredFields = [ 'name', 'address', 'city', 'postcode', 'country' ];
 	const errors = {};
 	requiredFields.forEach( ( field ) => {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
@@ -94,7 +94,9 @@ const AddressFields = ( props ) => {
 					updateValue={ updateValue( 'phone' ) }
 					className="address-step__phone" />
 			</div>
-			{ generalErrorOnly && <Notice status="is-error" showDismiss={ false }>{ fieldErrors.general }</Notice> }
+			{ generalErrorOnly && <Notice status="is-error" showDismiss={ false }>
+				{ translate( '%(message)s. Please modify the address and try again.', { args: { message: fieldErrors.general } } ) }
+			</Notice> }
 			<TextField
 				id={ getId( 'address' ) }
 				title={ translate( 'Address' ) }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
@@ -12,7 +12,7 @@ import { isEqual, isObject, omit } from 'lodash';
  * Internal dependencies
  */
 import TextField from 'woocommerce/woocommerce-services/components/text-field';
-import FieldError from 'woocommerce/woocommerce-services/components/field-error';
+import Notice from 'components/notice';
 import StepConfirmationButton from '../step-confirmation-button';
 import CountryDropdown from 'woocommerce/woocommerce-services/components/country-dropdown';
 import StateDropdown from 'woocommerce/woocommerce-services/components/state-dropdown';
@@ -94,7 +94,7 @@ const AddressFields = ( props ) => {
 					updateValue={ updateValue( 'phone' ) }
 					className="address-step__phone" />
 			</div>
-			{ generalErrorOnly && <FieldError text={ fieldErrors.general } /> }
+			{ generalErrorOnly && <Notice status="is-error" showDismiss={ false }>{ fieldErrors.general }</Notice> }
 			<TextField
 				id={ getId( 'address' ) }
 				title={ translate( 'Address' ) }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
@@ -6,12 +6,13 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { isEqual, isObject } from 'lodash';
+import { isEqual, isObject, omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import TextField from 'woocommerce/woocommerce-services/components/text-field';
+import FieldError from 'woocommerce/woocommerce-services/components/field-error';
 import StepConfirmationButton from '../step-confirmation-button';
 import CountryDropdown from 'woocommerce/woocommerce-services/components/country-dropdown';
 import StateDropdown from 'woocommerce/woocommerce-services/components/state-dropdown';
@@ -64,6 +65,7 @@ const AddressFields = ( props ) => {
 	}
 
 	const fieldErrors = isObject( errors ) ? errors : {};
+	const generalErrorOnly = fieldErrors.general && Object.keys( omit( fieldErrors, 'general' ) ).length === 0;
 	const getId = ( fieldName ) => group + '_' + fieldName;
 	const getValue = ( fieldName ) => values[ fieldName ] ? decodeEntities( values[ fieldName ] ) : '';
 	const updateValue = ( fieldName ) => ( newValue ) => props.updateAddressValue( orderId, siteId, group, fieldName, newValue );
@@ -92,18 +94,19 @@ const AddressFields = ( props ) => {
 					updateValue={ updateValue( 'phone' ) }
 					className="address-step__phone" />
 			</div>
+			{ generalErrorOnly && <FieldError text={ fieldErrors.general } /> }
 			<TextField
 				id={ getId( 'address' ) }
 				title={ translate( 'Address' ) }
 				value={ getValue( 'address' ) }
 				updateValue={ updateValue( 'address' ) }
 				className="address-step__address-1"
-				error={ fieldErrors.address } />
+				error={ fieldErrors.address || generalErrorOnly } />
 			<TextField
 				id={ getId( 'address_2' ) }
 				value={ getValue( 'address_2' ) }
 				updateValue={ updateValue( 'address_2' ) }
-				error={ fieldErrors.address_2 } />
+				error={ fieldErrors.address_2 || generalErrorOnly } />
 			<div className="address-step__city-state-postal-code">
 				<TextField
 					id={ getId( 'city' ) }
@@ -111,7 +114,7 @@ const AddressFields = ( props ) => {
 					value={ getValue( 'city' ) }
 					updateValue={ updateValue( 'city' ) }
 					className="address-step__city"
-					error={ fieldErrors.city } />
+					error={ fieldErrors.city || generalErrorOnly } />
 				<StateDropdown
 					id={ getId( 'state' ) }
 					title={ translate( 'State' ) }
@@ -120,14 +123,14 @@ const AddressFields = ( props ) => {
 					countriesData={ storeOptions.countriesData }
 					updateValue={ updateValue( 'state' ) }
 					className="address-step__state"
-					error={ fieldErrors.state } />
+					error={ fieldErrors.state || generalErrorOnly } />
 				<TextField
 					id={ getId( 'postcode' ) }
 					title={ translate( 'Postal code' ) }
 					value={ getValue( 'postcode' ) }
 					updateValue={ updateValue( 'postcode' ) }
 					className="address-step__postal-code"
-					error={ fieldErrors.postcode } />
+					error={ fieldErrors.postcode || generalErrorOnly } />
 			</div>
 			<CountryDropdown
 				id={ getId( 'country' ) }
@@ -136,7 +139,7 @@ const AddressFields = ( props ) => {
 				disabled={ ! allowChangeCountry }
 				countriesData={ storeOptions.countriesData }
 				updateValue={ updateValue( 'country' ) }
-				error={ fieldErrors.country } />
+				error={ fieldErrors.country || generalErrorOnly } />
 			<StepConfirmationButton
 				disabled={ hasNonEmptyLeaves( errors ) || normalizationInProgress }
 				onClick={ submitAddressForNormalizationHandler } >

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/fields.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { isEqual, isObject, omit } from 'lodash';
+import { isEqual, isObject, size } from 'lodash';
 
 /**
  * Internal dependencies
@@ -65,7 +65,7 @@ const AddressFields = ( props ) => {
 	}
 
 	const fieldErrors = isObject( errors ) ? errors : {};
-	const generalErrorOnly = fieldErrors.general && Object.keys( omit( fieldErrors, 'general' ) ).length === 0;
+	const generalErrorOnly = fieldErrors.general && size( fieldErrors ) === 1;
 	const getId = ( fieldName ) => group + '_' + fieldName;
 	const getValue = ( fieldName ) => values[ fieldName ] ? decodeEntities( values[ fieldName ] ) : '';
 	const updateValue = ( fieldName ) => ( newValue ) => props.updateAddressValue( orderId, siteId, group, fieldName, newValue );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/index.js
@@ -36,7 +36,7 @@ const renderSummary = ( {
 		return translate( 'Validating address…' );
 	}
 	if ( hasNonEmptyLeaves( errors ) || ( isNormalized && ! normalized ) ) {
-		return translate( 'Invalid address' );
+		return errors && errors.general || translate( 'Invalid address' );
 	}
 	if ( ! isNormalized ) {
 		return translate( "You've edited the address, please revalidate it for accurate rates" );
@@ -71,12 +71,12 @@ const getNormalizationStatus = ( { normalizationInProgress, errors, isNormalized
 
 const AddressStep = ( props ) => {
 	const toggleStepHandler = () => props.toggleStep( props.orderId, props.siteId, props.type );
-	const { form, storeOptions, error, showCountryInSummary, translate } = props;
+	const { form, storeOptions, errors, showCountryInSummary, translate } = props;
 
 	return (
 		<StepContainer
 			title={ props.title }
-			summary={ renderSummary( { ...form, storeOptions, errors: error, translate }, showCountryInSummary ) }
+			summary={ renderSummary( { ...form, storeOptions, errors, translate }, showCountryInSummary ) }
 			expanded={ props.expanded }
 			toggleStep={ toggleStepHandler }
 			{ ...props.normalizationStatus } >

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
@@ -11,6 +11,9 @@
 .address-step__address-1.form-fieldset {
 	margin-bottom: 8px;
 }
+.field-error + .address-step__address-1.form-fieldset {
+	margin-top: 6px;
+}
 
 .address-step__city,
 .address-step__state,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
@@ -8,11 +8,12 @@
 	}
 }
 
+.notice.is-error {
+	margin: 6px 0 16px;
+}
+
 .address-step__address-1.form-fieldset {
 	margin-bottom: 8px;
-}
-.field-error + .address-step__address-1.form-fieldset {
-	margin-top: 6px;
 }
 
 .address-step__city,

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -44,7 +44,7 @@
 		color: $alert-yellow;
 	}
 
-	.is-error {
+	.is-error:not(.notice) {
 		color: $alert-red;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/540
Fixes https://github.com/Automattic/woocommerce-services/issues/913

If the address normalization requests results in an error (e.g., or), an error notice shows up indicating what it was trying to do and what the problem is, according to the error response.

Scenario | Error notice
-- | --
WCS server unreachable (wp-admin) | <img width="543" alt="screen shot 2018-02-14 at 5 36 23 pm" src="https://user-images.githubusercontent.com/1867547/36272322-2daa85c0-124f-11e8-8475-7bee41e28315.png">
WCS server unreachable (wp-calypso) | <img width="569" alt="screen shot 2018-02-15 at 12 49 20 pm" src="https://user-images.githubusercontent.com/1867547/36272311-26b592d2-124f-11e8-99b5-8cdf13eb910c.png">
Primary address validation error in existing plugin versions | <img width="500" alt="screen shot 2018-02-15 at 12 55 34 pm" src="https://user-images.githubusercontent.com/1867547/36272467-9a359fb8-124f-11e8-98d7-493bb0853624.png">

If validation errors specific to address fields are returned (depends on https://github.com/Automattic/woocommerce-services/pull/1311), the errors are displayed in the context of the relevant address field, and/or in the section heading in the case of an error applying to the whole address:

<img width="400" alt="screen shot 2018-02-15 at 11 29 25 am" src="https://user-images.githubusercontent.com/1867547/36272374-5d419f8a-124f-11e8-927f-7b0f347d4cf9.png">
----
<img width="400" alt="screen shot 2018-02-15 at 1 10 07 pm" src="https://user-images.githubusercontent.com/1867547/36273365-40997e4a-1252-11e8-9d6f-ccbe81380bc0.png">

_(Note: I omitted the slight error style tweak in those screenshots from this PR, as a) I'm not sure if it's desirable and b) it's not strictly in scope)_