### PR TITLE
DocumentHead: Update the title when it is different than the saved title

### DIFF
--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -16,6 +16,7 @@ import {
 	getDocumentHeadFormattedTitle,
 	getDocumentHeadLink,
 	getDocumentHeadMeta,
+	getDocumentHeadTitle,
 } from 'state/document-head/selectors';
 import {
 	setDocumentHeadTitle as setTitle,
@@ -53,7 +54,7 @@ class DocumentHead extends Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.title !== undefined && this.props.title !== nextProps.title ) {
+		if ( nextProps.title !== undefined && nextProps.title !== nextProps.savedTitle ) {
 			this.props.setTitle( nextProps.title );
 		}
 
@@ -133,6 +134,7 @@ export default connect(
 		formattedTitle: getDocumentHeadFormattedTitle( state ),
 		allLinks: getDocumentHeadLink( state ),
 		allMeta: getDocumentHeadMeta( state ),
+		savedTitle: getDocumentHeadTitle( state ),
 	} ),
 	{
 		setTitle,


### PR DESCRIPTION
In working on the WooCommerce extension on smaller screens, I noticed that sometimes the title would disappear from the page title & this section:

<img width="334" alt="screen shot 2018-02-15 at 2 04 40 pm" src="https://user-images.githubusercontent.com/541093/36275560-2fa0d8ca-1259-11e8-8ed6-98a91f46e4ff.png">

_Note, this section isn't currently visible in Store, to test you'll need to watch the title itself._

I tracked this to `documentHead.title` in redux state, which is cleared when the route is changed. In other sections of calypso, this is set either by directly calling an action, or using `<DocumentHead>`. In WC, we use the `<DocumentHead>` approach [in our parent component](https://github.com/Automattic/wp-calypso/blob/master/client/extensions/woocommerce/app/index.js#L109), so this doesn't unmount/remount like some other sections of Calypso (settings, for example). This means if the document title doesn't change from section-to-section, the logic in `componentWillReceiveProps` considers it "unchanged" and won't fire the action to update it (even though it's _actually_ an empty string).

This PR updates `DocumentHead` to check against the title currently saved in redux.

**To test**

- View a section in Store where this happens: `/store/orders/:site`, or `/store/reviews/:site` are good cases
- Check the page title, it should say `Orders < Site Title – WordPress.com` (or Reviews < …)
- Change the filter on the page, click into "Awaiting Payment" (on Orders) or "Approved" (on Reviews)
- Before this PR, the title would update to `Site Title – WordPress.com`
- After this PR, the title should stay the same.
- If you open the Redux inspector, you'll see the `DOCUMENT_HEAD_TITLE_SET` action fire.