### PR TITLE
Add Tracks Events to Google My Business Stats Nudge

### DIFF
--- a/client/components/google-my-business/stats-nudge.js
+++ b/client/components/google-my-business/stats-nudge.js
@@ -4,25 +4,22 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 
 /**
  * Internal Dependencies
  */
-import analytics from 'lib/analytics';
+import { recordTracksEvent } from 'state/analytics/actions';
 import Button from 'components/button';
 import DismissibleCard from 'blocks/dismissible-card';
 import SectionHeader from 'components/section-header';
 
-class GMBStatsNudge extends Component {
+class GoogleMyBusinessStatsNudge extends Component {
 	static propTypes = {
 		translate: PropTypes.func.isRequired,
 	};
-
-	recordNudgeShown() {
-		analytics.tracks.recordEvent( 'calypso_test_google_my_business_stats_nudge_shown' );
-	}
 
 	render() {
 		return (
@@ -30,6 +27,7 @@ class GMBStatsNudge extends Component {
 				className="google-my-business__stats-nudge"
 				preferenceName="show-google-my-business-nudge"
 				temporary
+				onClick={ this.props.trackNudgeDismissed }
 			>
 				<SectionHeader
 					className="google-my-business__stats-nudge-header"
@@ -53,8 +51,12 @@ class GMBStatsNudge extends Component {
 							) }
 						</h2>
 						<div className="google-my-business__stats-nudge-button-row">
-							<Button primary>{ this.props.translate( 'Start Now' ) }</Button>
-							<Button>{ this.props.translate( "I've Already Listed" ) }</Button>
+							<Button primary onClick={ this.props.trackNudgeStartNowClicked }>
+								{ this.props.translate( 'Start Now' ) }
+							</Button>
+							<Button onClick={ this.props.trackNudgeAlreadyListedClicked }>
+								{ this.props.translate( "I've Already Listed" ) }
+							</Button>
 						</div>
 					</div>
 				</div>
@@ -63,8 +65,16 @@ class GMBStatsNudge extends Component {
 	}
 
 	componentWillMount() {
-		this.recordNudgeShown();
+		this.props.trackNudgeShown();
 	}
 }
 
-export default localize( GMBStatsNudge );
+export default connect( () => ( {} ), {
+	trackNudgeShown: () => recordTracksEvent( 'calypso_test_google_my_business_stats_nudge_shown' ),
+	trackNudgeDismissed: () =>
+		recordTracksEvent( 'calypso_test_google_my_business_stats_nudge_dismissed' ),
+	trackNudgeStartNowClicked: () =>
+		recordTracksEvent( 'calypso_test_google_my_business_stats_nudge_start_now_clicked' ),
+	trackNudgeAlreadyListedClicked: () =>
+		recordTracksEvent( 'calypso_test_google_my_business_stats_nudge_already_listed_clicked' ),
+} )( localize( GoogleMyBusinessStatsNudge ) );

--- a/client/components/google-my-business/stats-nudge.js
+++ b/client/components/google-my-business/stats-nudge.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal Dependencies
  */
+import analytics from 'lib/analytics';
 import Button from 'components/button';
 import DismissibleCard from 'blocks/dismissible-card';
 import SectionHeader from 'components/section-header';
@@ -18,6 +19,10 @@ class GMBStatsNudge extends Component {
 	static propTypes = {
 		translate: PropTypes.func.isRequired,
 	};
+
+	recordNudgeShown() {
+		analytics.tracks.recordEvent( 'calypso_test_google_my_business_stats_nudge_shown' );
+	}
 
 	render() {
 		return (
@@ -55,6 +60,10 @@ class GMBStatsNudge extends Component {
 				</div>
 			</DismissibleCard>
 		);
+	}
+
+	componentWillMount() {
+		this.recordNudgeShown();
 	}
 }
 

--- a/client/components/google-my-business/stats-nudge.js
+++ b/client/components/google-my-business/stats-nudge.js
@@ -3,8 +3,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 
 /**
  * Internal Dependencies
@@ -13,42 +14,48 @@ import Button from 'components/button';
 import DismissibleCard from 'blocks/dismissible-card';
 import SectionHeader from 'components/section-header';
 
-const GMBStatsNudge = ( { translate } ) => {
-	return (
-		<DismissibleCard
-			className="google-my-business__stats-nudge"
-			preferenceName="show-google-my-business-nudge"
-			temporary
-		>
-			<SectionHeader
-				className="google-my-business__stats-nudge-header"
-				label={ translate( 'Recommendation from WordPress.com' ) }
-			/>
-			<div className="google-my-business__stats-nudge-body">
-				<div className="google-my-business__stats-nudge-image-wrapper">
-					<img
-						className="google-my-business__stats-nudge-image"
-						src="/calypso/images/google-my-business/phone-screenshot.png"
-						alt={ translate( 'Your business with Google My Business' ) }
-					/>
-				</div>
-				<div className="google-my-business__stats-nudge-info">
-					<h1 className="google-my-business__stats-nudge-title">
-						{ translate( 'Reach more customers with Google My Business' ) }
-					</h1>
-					<h2 className="google-my-business__stats-nudge-description">
-						{ translate(
-							'Show up when customers search for businesses like yours on Google Search and Maps.'
-						) }
-					</h2>
-					<div className="google-my-business__stats-nudge-button-row">
-						<Button primary>{ translate( 'Start Now' ) }</Button>
-						<Button>{ translate( "I've Already Listed" ) }</Button>
+class GMBStatsNudge extends Component {
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
+	};
+
+	render() {
+		return (
+			<DismissibleCard
+				className="google-my-business__stats-nudge"
+				preferenceName="show-google-my-business-nudge"
+				temporary
+			>
+				<SectionHeader
+					className="google-my-business__stats-nudge-header"
+					label={ this.props.translate( 'Recommendation from WordPress.com' ) }
+				/>
+				<div className="google-my-business__stats-nudge-body">
+					<div className="google-my-business__stats-nudge-image-wrapper">
+						<img
+							className="google-my-business__stats-nudge-image"
+							src="/calypso/images/google-my-business/phone-screenshot.png"
+							alt={ this.props.translate( 'Your business with Google My Business' ) }
+						/>
+					</div>
+					<div className="google-my-business__stats-nudge-info">
+						<h1 className="google-my-business__stats-nudge-title">
+							{ this.props.translate( 'Reach more customers with Google My Business' ) }
+						</h1>
+						<h2 className="google-my-business__stats-nudge-description">
+							{ this.props.translate(
+								'Show up when customers search for businesses like yours on Google Search and Maps.'
+							) }
+						</h2>
+						<div className="google-my-business__stats-nudge-button-row">
+							<Button primary>{ this.props.translate( 'Start Now' ) }</Button>
+							<Button>{ this.props.translate( "I've Already Listed" ) }</Button>
+						</div>
 					</div>
 				</div>
-			</div>
-		</DismissibleCard>
-	);
-};
+			</DismissibleCard>
+		);
+	}
+}
 
 export default localize( GMBStatsNudge );

--- a/client/components/google-my-business/stats-nudge.js
+++ b/client/components/google-my-business/stats-nudge.js
@@ -11,21 +11,29 @@ import PropTypes from 'prop-types';
 /**
  * Internal Dependencies
  */
-import { recordTracksEvent } from 'state/analytics/actions';
 import Button from 'components/button';
 import DismissibleCard from 'blocks/dismissible-card';
+import { recordTracksEvent } from 'state/analytics/actions';
 import SectionHeader from 'components/section-header';
 
 class GoogleMyBusinessStatsNudge extends Component {
 	static propTypes = {
+		trackNudgeShown: PropTypes.func.isRequired,
+		trackNudgeDismissed: PropTypes.func.isRequired,
+		trackNudgeStartNowClicked: PropTypes.func.isRequired,
+		trackNudgeAlreadyListedClicked: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
+
+	componentWillMount() {
+		this.props.trackNudgeShown();
+	}
 
 	render() {
 		return (
 			<DismissibleCard
 				className="google-my-business__stats-nudge"
-				preferenceName="show-google-my-business-nudge"
+				preferenceName="google-my-business-nudge"
 				temporary
 				onClick={ this.props.trackNudgeDismissed }
 			>
@@ -62,10 +70,6 @@ class GoogleMyBusinessStatsNudge extends Component {
 				</div>
 			</DismissibleCard>
 		);
-	}
-
-	componentWillMount() {
-		this.props.trackNudgeShown();
 	}
 }
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -31,7 +31,7 @@ import { getSiteOption, isJetpackSite } from 'state/sites/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import PrivacyPolicyBanner from 'blocks/privacy-policy-banner';
 import ChecklistBanner from './checklist-banner';
-import GMBStatsNudge from 'components/google-my-business/stats-nudge';
+import GoogleMyBusinessStatsNudge from 'components/google-my-business/stats-nudge';
 import { isGmbNudgeVisible } from 'state/selectors';
 
 class StatsSite extends Component {
@@ -134,7 +134,8 @@ class StatsSite extends Component {
 				/>
 				<div id="my-stats-content">
 					{ config.isEnabled( 'onboarding-checklist' ) && <ChecklistBanner siteId={ siteId } /> }
-					{ config.isEnabled( 'google-my-business' ) && isGMBNudgeVisible && <GMBStatsNudge /> }
+					{ config.isEnabled( 'google-my-business' ) &&
+						isGMBNudgeVisible && <GoogleMyBusinessStatsNudge /> }
 					<ChartTabs
 						barClick={ this.barClick }
 						switchTab={ this.switchChart }


### PR DESCRIPTION
This PR adds Tracks Events to the new Google My Business Stats Nudge (#22221) 

## Specs

The events to be added are labeled on the below image:

![m1-nudge1-events](https://user-images.githubusercontent.com/2810519/36279496-2972aad0-124c-11e8-95b8-ac0850362322.png)

1. `calypso_google_my_business_stats_nudge_shown` whenever the nudge is shown
2. `calypso_google_my_business_stats_nudge_dismissed` whenever the nudge is dismissed via the x in the corner
3. `calypso_google_my_business_stats_nudge_start_now_clicked` whenever the user clicks the "Start Now" button to proceed to the next part of the flow.
4. `calypso_google_my_business_stats_nudge_already_listed_clicked` whenever the user clicks the "I've already listed" button.

The events will have no special properties initially.

## Testing

- Boot this branch locally or use the calypso.live link below
- Enable debug of tracks in Calypso by typing this in your browser console:  `localStorage.setItem('debug', 'calypso:analytics:tracks' )`
- Create a site with a `promote` siteGoals if you don't have one. This can be done from the `http://calypso.localhost:3000/start/about` page by selecting at least the "Promote your business, skills, organization, or events" option.
- Upgrade your site plan to business or premium
- Navigate to this site stats page `/stats/day/:site_slug`
- Notice the Google My Business nudge
- Notice in the console if a `calypso_test_google_my_business_stats_nudge_shown` event was recorded
- Press the two buttons on the nudge and dismiss it and notice in the console if the correct events were recorded for each.

`localStorage.removeItem(  'debug' )` will stop the event logging

## Before Merging
- [ ] Remove `test_` from each event name


