### PR TITLE
Reader QueryReaderPost: fix bad postKey handling

### DIFF
--- a/client/components/data/query-reader-post/index.jsx
+++ b/client/components/data/query-reader-post/index.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
  */
 import { fetchPost } from 'lib/feed-post-store/actions';
 import { getPostByKey } from 'state/reader/posts/selectors';
+import { isPostKeyLike } from 'lib/feed-stream-store/post-key';
 
 class QueryReaderPost extends Component {
 	static propTypes = {
@@ -28,7 +29,7 @@ class QueryReaderPost extends Component {
 	}
 
 	maybeFetch = ( props = this.props ) => {
-		if ( ! props.post || props.post._state === 'minimal' ) {
+		if ( isPostKeyLike( props.postKey ) && ( ! props.post || props.post._state === 'minimal' ) ) {
 			fetchPost( props.postKey );
 		}
 	};

--- a/client/lib/feed-stream-store/post-key.js
+++ b/client/lib/feed-stream-store/post-key.js
@@ -64,3 +64,7 @@ export function keyToString( postKey ) {
 
 	return null; // should never happen!
 }
+
+export function isPostKeyLike( postKey ) {
+	return postKey && postKey.postId && ( postKey.blogId || postKey.feedId );
+}


### PR DESCRIPTION
Fix for a sometimes empty `postKey` within the `QueryReaderPost` component.
While theoretically, a postKey should never be empty -- there are cases where it will happen and this change guards from breaking all of Calypso when it does.