### PR TITLE
Framework: Cleaning up layout styles

### DIFF
--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -25,10 +25,6 @@
 	&.is-wide-layout {
 		max-width: 1040px;
 	}
-
-	@include breakpoint( "<660px" ) {
-		perspective: 1000;
-	}
 }
 
 // Used on views (ex posts & pages ) where the empty-content is already inside a padded div

--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -2,7 +2,6 @@
 	margin: auto;
 	max-width: 720px;
 	z-index: z-index( 'root', '.main' );
-	backface-visibility: hidden;
 
 	// Themes is a great example of using all this new space ;)
 	&.themes {
@@ -28,7 +27,6 @@
 	}
 
 	@include breakpoint( "<660px" ) {
-		backface-visibility: hidden;
 		perspective: 1000;
 	}
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -5,7 +5,6 @@
 .site-selector {
 	overflow: visible;
 	position: static;
-	pointer-events: auto;
 	border: none;
 	z-index: z-index( 'root', '.site-selector' );
 
@@ -13,7 +12,6 @@
 		display: flex;
 		position: relative;
 		opacity: 1;
-		pointer-events: initial;
 	}
 
 	&.is-large .site-selector__sites {

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -14,6 +14,10 @@
 		opacity: 1;
 	}
 
+	&:not(.is-large) .search {
+		pointer-events: none;
+	}
+
 	&.is-large .site-selector__sites {
 		border-top: 1px solid $gray-lighten-20;
 	}

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -99,7 +99,6 @@
 	display: block;
 	opacity: 0;
 	position: absolute;
-	pointer-events: none;
 
 	.search__input[type="search"] {
 		font-size: 13px;
@@ -137,10 +136,6 @@
 	display: flex;
 	flex-direction: row;
 	padding-left: 10px;
-
-	@include breakpoint( "<660px" ) {
-		margin-top: 16px;
-	}
 }
 
 .site-selector__add-new-site .button {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -27,10 +27,6 @@ $autobar-height: 20px;
 	.is-section-themes.has-no-sidebar & {
 		border: none;
 	}
-
-	@include breakpoint( ">660px" ) {
-		backface-visibility: hidden;
-	}
 }
 
 .pride .masterbar {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -3,7 +3,6 @@
 	flex-direction: column;
 	overflow: auto;
 	padding: 0;
-	overflow-x: hidden;
 	position: absolute;
 		top: 0;
 		right: 0;
@@ -158,7 +157,7 @@ form.sidebar__button {
 	position: relative;
 	align-self: center;
 	box-sizing: border-box;
-	overflow: visible;
+	overflow: hidden;
 	padding: 2px 8px 3px 8px;
 	height: 24px;
 	margin-right: 8px;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -1,52 +1,19 @@
 .sidebar {
-	color: var( --sidebar-color );
 	display: flex;
 	flex-direction: column;
 	overflow: auto;
 	padding: 0;
-	background: var( --sidebar-background );
-	position: fixed;
-		top: 47px;
+	overflow-x: hidden;
+	position: absolute;
+		top: 0;
+		right: 0;
 		bottom: 0;
 		left: 0;
 
-	@include breakpoint( "<960px" ) {
-		border-right: 1px solid darken( $sidebar-bg-color, 5% );
-		width: $sidebar-width-min;
-	}
-
-	@include breakpoint( ">960px" ) {
-		border-right: 1px solid darken( $sidebar-bg-color, 5% );
-		width: $sidebar-width-max;
-	}
-
 	@include breakpoint( "<660px" ) {
-		left: -100%;
-		width: 100%;
-		overflow-x: hidden;
-		max-height: calc( 100% - 47px );
-		pointer-events: none;
-		transform: translateX( 0 );
-		transition: all 0.15s cubic-bezier(0.770, 0.000, 0.175, 1.000);
-
-		.focus-sidebar & {
-			pointer-events: auto;
-			-webkit-overflow-scrolling: touch;
-			transform: translateX( 100% );
-		}
-
-		.focus-sites & {
-			transform: translateX( 100% );
-		}
-	}
-
-	@include breakpoint( ">660px" ) {
-		&.has-regions {
-			overflow: hidden;
-		}
+		-webkit-overflow-scrolling: touch;
 	}
 }
-
 
 // Clearing out the sidebar list styles
 .sidebar {
@@ -185,7 +152,8 @@
 	}
 }
 
-a.sidebar__button, form.sidebar__button {
+a.sidebar__button,
+form.sidebar__button {
 	display: flex;
 	position: relative;
 	align-self: center;
@@ -353,7 +321,6 @@ form.sidebar__button input {
 	@include breakpoint( "<660px" ) {
 		margin-top: 16px;
 	}
-
 }
 
 .sidebar .sidebar__footer .button {
@@ -485,6 +452,7 @@ form.sidebar__button input {
 		}
 	}
 }
+
 .sidebar__chevron-right {
 	position: absolute;
 	right: 0;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -317,10 +317,6 @@ form.sidebar__button input {
 	display: flex;
 	flex-direction: row;
 	padding-left: 10px;
-
-	@include breakpoint( "<660px" ) {
-		margin-top: 16px;
-	}
 }
 
 .sidebar .sidebar__footer .button {
@@ -418,15 +414,12 @@ form.sidebar__button input {
 
 .sidebar__region {
 	flex-shrink: 0;
-	@include breakpoint( ">660px" ) {
-		display: flex;
-		flex-direction: column;
-		overflow-y: auto;
-		overflow-x: hidden;
-		flex: 1;
-		transform: translateX( 0 ); /* workaround for safari scrollbar rendering bug */
-		-webkit-overflow-scrolling: touch;
-	}
+	display: flex;
+	flex-direction: column;
+	overflow-y: auto;
+	overflow-x: hidden;
+	flex: 1;
+	-webkit-overflow-scrolling: touch;
 }
 
 .sidebar__menu {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -34,6 +34,10 @@
 	@include breakpoint( "<660px" ) {
 		width: 100%;
 	}
+
+	.is-section-post-editor & {
+		display: none;
+	}
 }
 
 .sidebar {}
@@ -55,8 +59,8 @@
 */
 
 // Adjust the content as needed when focused on the site selector or sidebar
-.layout.focus-sites,
-.layout.focus-sidebar {
+.layout.focus-sites:not(.is-section-post-editor),
+.layout.focus-sidebar:not(.is-section-post-editor) {
 	.layout__primary {
 		pointer-events: none;
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -1,218 +1,21 @@
 /*
 	Layout Elements
 	.layout__loading - Displays when loading Claypso
-	.layout__content - Contains primary and secondary
-		.layout__primary - The main content area
-		.layout__secondary - Contains the site selector and sidebar
+	.layout__content - Contains primary and secondary elements
+		.layout__primary - Where the main content lives
+		.layout__secondary - Contains the site selector and sidebar elements
 			.sidebar
 			.site-selector
 */
 
+// Set transitons for layout elements
 .layout__primary,
 .layout__secondary,
-.sidebar,
-.site-selector {
+.layout__secondary .sidebar,
+.layout__secondary .site-selector {
 	transition: transform 0.2s cubic-bezier(0.770, 0.000, 0.175, 1.000),
 				opacity 0.2s ease-in-out;
 }
-
-.layout__secondary {
-	position: fixed;
-		top: 47px;
-		left: 0;
-		bottom: 0;
-	color: var( --sidebar-color );
-	background: var( --sidebar-background );
-	border-right: 1px solid darken( $sidebar-bg-color, 5% );
-	width: $sidebar-width-max;
-	overflow: hidden;
-
-	@include breakpoint( "<960px" ) {
-		width: $sidebar-width-min;
-	}
-
-	@include breakpoint( "<660px" ) {
-		width: 100%;
-	}
-
-	.is-section-post-editor & {
-		display: none;
-	}
-}
-
-.sidebar {}
-
-.site-selector {
-	transform: translateX( -$sidebar-width-max );
-	pointer-events: none;
-
-	@include breakpoint( "<660px" ) {
-		transform: translateX( -100% );
-	}
-}
-
-/*
-	Focus States
-	Sites - Site Selector for those with multiple sites
-	Sidebar - The sidebar is the current focus
-	Content - The content is the furrent focus
-*/
-
-// Adjust the content as needed when focused on the site selector or sidebar
-.layout.focus-sites:not(.is-section-post-editor),
-.layout.focus-sidebar:not(.is-section-post-editor) {
-	.layout__primary {
-		pointer-events: none;
-
-		@include breakpoint( "<660px" ) {
-			transform: translateX( 100% );
-			overflow: hidden;
-			height: calc( 100% - 47px );
-		}
-	}
-}
-
-.layout.focus-sites {
-	.site-selector {
-		pointer-events: auto;
-		transform: translateX( 0 );
-	}
-
-	.sidebar {
-		pointer-events: none;
-		transform: translateX( $sidebar-width-max );
-
-		@include breakpoint( "<660px" ) {
-			transform: translateX( 100% );
-		}
-	}
-
-	.layout__primary {
-		@include breakpoint( ">660px" ) {
-			opacity: 0.25;
-		}
-	}
-}
-
-.layout.focus-content {
-	@include breakpoint( "<660px" ) {
-		.layout__secondary {
-			transform: translateX( -100% );
-		}
-	}
-}
-
-
-
-
-
-.layout__content {
-	@include clear-fix;
-	position: relative;
-	margin: 0;
-	padding: 79px 32px 32px ( $sidebar-width-max + 32px );
-	box-sizing: border-box;
-	overflow: hidden;
-	transition: opacity 0.3s;
-
-	.has-no-sidebar & {
-		padding-left: 32px;
-	}
-
-	.is-section-theme &,
-	.is-section-themes.has-no-sidebar & {
-		padding: 0;
-		margin: 0;
-	}
-
-	.is-section-preview & {
-		height: 100%;
-		padding: 47px 0 0 $sidebar-width-max;
-	}
-
-	@media print {
-		padding: 0;
-	}
-}
-
-// Tablets
-@include breakpoint( "<960px" ) {
-	.layout__content {
-		padding: 71px 24px 24px ( $sidebar-width-min + 24px );
-
-		.has-no-sidebar & {
-			padding-left: 24px;
-		}
-
-		.is-section-theme &,
-		.is-section-themes.has-no-sidebar & {
-			padding: 0;
-			margin: 0;
-		}
-
-		.is-section-preview & {
-			padding: 47px 0px 0px 228px;
-		}
-	}
-}
-
-// Mobile (Full Width)
-@include breakpoint( "<660px" ) {
-	.layout__content {
-		margin-left: 0;
-		padding: 0;
-		padding-top: 47px;
-
-		.has-no-sidebar & {
-			padding-left: 0;
-		}
-
-		.is-section-preview & {
-			padding: 47px 0 0 0;
-		}
-	}
-}
-
-// Use all available space for the WebPreview component on /view
-.layout.is-section-preview {
-	height: 100%;
-	overflow: hidden;
-
-	.layout__primary {
-		height: 100%;
-	}
-}
-
-
-.layout__content a {
-	text-decoration: none;
-}
-
-
-// site selector in the sidebar
-.layout__secondary .site-selector {
-	position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-	pointer-events: none;
-
-	.site,
-	.all-sites {
-		.site__title,
-		.site__domain {
-			&::after {
-				@include long-content-fade( $color: $gray-lighten-30 );
-			}
-		}
-	}
-
-	@include breakpoint( "<660px" ) {
-		-webkit-overflow-scrolling: touch;
-	}
-}
-
 
 // If things take a bit to load...
 .layout__loader {
@@ -242,13 +45,210 @@
 	}
 }
 
+// Setup the content element to adapt to the sidebar,
+// lack of sidebar, or the WebPreview component.
+.layout__content {
+	@include clear-fix;
+	position: relative;
+	margin: 0;
+	padding: 79px 32px 32px ( $sidebar-width-max + 32px );
+	box-sizing: border-box;
+	overflow: hidden;
+	transition: opacity 0.3s;
 
-// Hide the sidebar and masterbar when printing
+	// I guess we dont want links to look like links.
+	a {
+		text-decoration: none;
+	}
+
+	// Various screens dont use a sidebar.
+	.has-no-sidebar & {
+		padding-left: 32px;
+	}
+
+	// Themes sets it own padding/margin
+	.is-section-theme &,
+	.is-section-themes.has-no-sidebar & {
+		padding: 0;
+		margin: 0;
+	}
+
+	// This is needed to ensure the WebPreview component
+	// displays at full height.
+	.is-section-preview & {
+		height: 100%;
+		padding: 47px 0 0 $sidebar-width-max;
+	}
+
+	// Tablets
+	@include breakpoint( "<960px" ) {
+		padding: 71px 24px 24px ( $sidebar-width-min + 24px );
+
+		.has-no-sidebar & {
+			padding-left: 24px;
+		}
+
+		.is-section-theme &,
+		.is-section-themes.has-no-sidebar & {
+			padding: 0;
+			margin: 0;
+		}
+
+		.is-section-preview & {
+			padding: 47px 0px 0px 228px;
+		}
+	}
+
+	// Mobile (Full Width)
+	@include breakpoint( "<660px" ) {
+		margin-left: 0;
+		padding: 0;
+		padding-top: 47px;
+
+		.has-no-sidebar & {
+			padding-left: 0;
+		}
+
+		.is-section-preview & {
+			padding: 47px 0 0 0;
+		}
+	}
+}
+
+// Setup the secondary element, which contains the sidebar and
+// the site-selector elements.
+.layout__secondary {
+	position: fixed;
+		top: 47px;
+		left: 0;
+		bottom: 0;
+	color: var( --sidebar-color );
+	background: var( --sidebar-background );
+	border-right: 1px solid darken( $sidebar-bg-color, 5% );
+	width: $sidebar-width-max;
+	overflow: hidden;
+
+	@include breakpoint( "<960px" ) {
+		width: $sidebar-width-min;
+	}
+
+	@include breakpoint( "<660px" ) {
+		width: 100%;
+	}
+
+	// The editor has its own sidebar which doesnt
+	// use the secondary element.
+	.is-section-post-editor & {
+		display: none;
+	}
+}
+
+// Setup the site-selector element. Its default
+// position is off screen.
+.layout__secondary .site-selector {
+	position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+	pointer-events: none;
+	transform: translateX( -$sidebar-width-max );
+	pointer-events: none;
+
+	.site,
+	.all-sites {
+		.site__title,
+		.site__domain {
+			&::after {
+				@include long-content-fade( $color: $gray-lighten-30 );
+			}
+		}
+	}
+
+	@include breakpoint( "<660px" ) {
+		-webkit-overflow-scrolling: touch;
+		transform: translateX( -100% );
+	}
+}
+
+
+/*
+	Focus States
+	Sites - Site Selector for those with multiple sites
+	Sidebar - The sidebar is the current focus
+	Content - The content is the furrent focus
+*/
+
+// Adjust the content as needed when focused on the site selector
+// or sidebar, but never in the editor.
+.layout.focus-sites:not(.is-section-post-editor),
+.layout.focus-sidebar:not(.is-section-post-editor) {
+	.layout__primary {
+		pointer-events: none;
+
+		@include breakpoint( "<660px" ) {
+			transform: translateX( 100% );
+			overflow: hidden;
+			height: calc( 100% - 47px );
+		}
+	}
+}
+
+// Adjust elements when the site-selector is visible.
+.layout.focus-sites {
+	.layout__secondary .site-selector {
+		pointer-events: auto;
+		transform: translateX( 0 );
+	}
+
+	.layout__secondary .sidebar {
+		pointer-events: none;
+		transform: translateX( $sidebar-width-max );
+
+		@include breakpoint( "<660px" ) {
+			transform: translateX( 100% );
+		}
+	}
+
+	.layout__primary {
+		@include breakpoint( ">660px" ) {
+			opacity: 0.25;
+		}
+	}
+}
+
+// Move the secondary element off screen when focused
+// on the content. This only applies to small screens.
+.layout.focus-content {
+	@include breakpoint( "<660px" ) {
+		.layout__secondary {
+			transform: translateX( -100% );
+		}
+	}
+}
+
+// Use all available space for the WebPreview component on /view
+.layout.is-section-preview {
+	height: 100%;
+	overflow: hidden;
+
+	.layout__primary {
+		height: 100%;
+	}
+}
+
+// Try to clean things up a bit when printing.
 .layout {
-	.sidebar,
-	.masterbar {
+	.masterbar,
+	.layout__secondary {
 		@media print {
 			display: none;
+		}
+	}
+
+	.layout__content {
+		@media print {
+			padding: 0;
 		}
 	}
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -1,9 +1,106 @@
-.layout {
-	&.is-section-preview {
-		height: 100%;
-		overflow: hidden;
+/*
+	Layout Elements
+	.layout__loading - Displays when loading Claypso
+	.layout__content - Contains primary and secondary
+		.layout__primary - The main content area
+		.layout__secondary - Contains the site selector and sidebar
+			.sidebar
+			.site-selector
+*/
+
+.layout__primary,
+.layout__secondary,
+.sidebar,
+.site-selector {
+	transition: transform 0.2s cubic-bezier(0.770, 0.000, 0.175, 1.000),
+				opacity 0.2s ease-in-out;
+}
+
+.layout__secondary {
+	position: fixed;
+		top: 47px;
+		left: 0;
+		bottom: 0;
+	color: var( --sidebar-color );
+	background: var( --sidebar-background );
+	border-right: 1px solid darken( $sidebar-bg-color, 5% );
+	width: $sidebar-width-max;
+	overflow: hidden;
+
+	@include breakpoint( "<960px" ) {
+		width: $sidebar-width-min;
+	}
+
+	@include breakpoint( "<660px" ) {
+		width: 100%;
 	}
 }
+
+.sidebar {}
+
+.site-selector {
+	transform: translateX( -$sidebar-width-max );
+	pointer-events: none;
+
+	@include breakpoint( "<660px" ) {
+		transform: translateX( -100% );
+	}
+}
+
+/*
+	Focus States
+	Sites - Site Selector for those with multiple sites
+	Sidebar - The sidebar is the current focus
+	Content - The content is the furrent focus
+*/
+
+// Adjust the content as needed when focused on the site selector or sidebar
+.layout.focus-sites,
+.layout.focus-sidebar {
+	.layout__primary {
+		pointer-events: none;
+
+		@include breakpoint( "<660px" ) {
+			transform: translateX( 100% );
+			overflow: hidden;
+			height: calc( 100% - 47px );
+		}
+	}
+}
+
+.layout.focus-sites {
+	.site-selector {
+		pointer-events: auto;
+		transform: translateX( 0 );
+	}
+
+	.sidebar {
+		pointer-events: none;
+		transform: translateX( $sidebar-width-max );
+
+		@include breakpoint( "<660px" ) {
+			transform: translateX( 100% );
+		}
+	}
+
+	.layout__primary {
+		@include breakpoint( ">660px" ) {
+			opacity: 0.25;
+		}
+	}
+}
+
+.layout.focus-content {
+	@include breakpoint( "<660px" ) {
+		.layout__secondary {
+			transform: translateX( -100% );
+		}
+	}
+}
+
+
+
+
 
 .layout__content {
 	@include clear-fix;
@@ -72,90 +169,30 @@
 	}
 }
 
-.layout__primary {
-	transition: all 0.15s ease-in-out;
+// Use all available space for the WebPreview component on /view
+.layout.is-section-preview {
+	height: 100%;
+	overflow: hidden;
 
-	.is-section-preview & {
+	.layout__primary {
 		height: 100%;
 	}
 }
+
 
 .layout__content a {
 	text-decoration: none;
 }
 
-.layout {
-	.sidebar,
-	.layout__secondary .site-selector,
-	.current-site,
-	.sidebar__menu {
-		transform: translateX( 0 );
-		transition: all 0.15s cubic-bezier(0.075, 0.820, 0.165, 1.000);
-	}
-}
-
-.layout {
-	.sidebar,
-	.masterbar {
-		@media print {
-			display: none;
-		}
-	}
-}
-
-.layout.focus-sites {
-	.layout__primary {
-		opacity: 0.2;
-		pointer-events: none;
-	}
-
-	.layout__secondary .site-selector {
-		opacity: 1;
-		transform: translateX( 272px );
-		pointer-events: auto;
-
-		@include breakpoint( "<660px" ) {
-			transform: translateX( 100% );
-		}
-	}
-
-	.sidebar {
-		pointer-events: none;
-	}
-
-	.current-site,
-	.sidebar__menu {
-		opacity: 0;
-		transform: translateX( 64px );
-	}
-}
-
-.layout.focus-sidebar {
-	overflow: hidden;
-}
-
-.layout.focus-sidebar:not(.is-section-post-editor) .layout__primary {
-	//when sidebar is focused, create a z-index stacking context on primary, so elements don't bleed in mobile views.
-	transform: translate( 0, 0 );
-}
 
 // site selector in the sidebar
 .layout__secondary .site-selector {
-	background: $gray-lighten-30;
-	border-right: 1px solid lighten( $gray, 25% );
-	position: fixed;
-		top: 47px;
+	position: absolute;
+		top: 0;
+		right: 0;
 		bottom: 0;
-		left: -272px;
-	width: 272px;
-	overflow: hidden;
-	z-index: z-index( 'root', '.layout__secondary .site-selector' );
-	opacity: 0;
+		left: 0;
 	pointer-events: none;
-
-	.search {
-		border-bottom: 1px solid $gray-lighten-20;
-	}
 
 	.site,
 	.all-sites {
@@ -168,16 +205,12 @@
 	}
 
 	@include breakpoint( "<660px" ) {
-		width: 100%;
-		left: -100%;
 		-webkit-overflow-scrolling: touch;
-	}
-
-	.site-selector__recent {
-		border-bottom-color: $gray-lighten-20;
 	}
 }
 
+
+// If things take a bit to load...
 .layout__loader {
 	border-bottom: 1px solid var( --masterbar-border-color );
 	height: 46px;
@@ -198,9 +231,20 @@
 	@include breakpoint( "<480px" ) {
 		background: var( --masterbar-background );
 	}
+
+	&.is-active {
+		visibility: visible;
+		opacity: 1;
+	}
 }
 
-.layout__loader.is-active {
-	visibility: visible;
-	opacity: 1;
+
+// Hide the sidebar and masterbar when printing
+.layout {
+	.sidebar,
+	.masterbar {
+		@media print {
+			display: none;
+		}
+	}
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -9,7 +9,7 @@
 */
 
 // Set transitons for layout elements
-.layout__primary,
+.layout__primary .main,
 .layout__secondary,
 .layout__secondary .sidebar,
 .layout__secondary .site-selector {
@@ -19,6 +19,7 @@
 
 // If things take a bit to load...
 .layout__loader {
+	background: var( --masterbar-background );
 	border-bottom: 1px solid var( --masterbar-border-color );
 	height: 46px;
 	margin-left: -10%;
@@ -28,19 +29,15 @@
 	width: 20%;
 	z-index: z-index( 'root', '.layout__loader' );
 
-	// set a delay threshold for opacity changes
-	// prevents showing loader on fast connections
-	visibility: hidden;
+	// The transition-delay avoids showing the loader
+	// too often on faster connections.
+	display: none;
 	opacity: 0;
 	transition: opacity 0.1s linear;
-	transition-delay: 0.4s;
-
-	@include breakpoint( "<480px" ) {
-		background: var( --masterbar-background );
-	}
+	transition-delay: 0.8s;
 
 	&.is-active {
-		visibility: visible;
+		display: block;
 		opacity: 1;
 	}
 }
@@ -54,7 +51,6 @@
 	padding: 79px 32px 32px ( $sidebar-width-max + 32px );
 	box-sizing: border-box;
 	overflow: hidden;
-	transition: opacity 0.3s;
 
 	// I guess we dont want links to look like links.
 	a {
@@ -138,7 +134,10 @@
 
 	// The editor has its own sidebar which doesnt
 	// use the secondary element.
-	.is-section-post-editor & {
+	.is-section-post-editor &,
+	// Some screens (like /theme/) simply dont have
+	// a sidebar.
+	.has-no-sidebar & {
 		display: none;
 	}
 }
@@ -153,7 +152,6 @@
 		left: 0;
 	pointer-events: none;
 	transform: translateX( -$sidebar-width-max );
-	pointer-events: none;
 
 	.site,
 	.all-sites {
@@ -183,13 +181,15 @@
 // or sidebar, but never in the editor.
 .layout.focus-sites:not(.is-section-post-editor),
 .layout.focus-sidebar:not(.is-section-post-editor) {
-	.layout__primary {
-		pointer-events: none;
-
+	.layout__primary .main {
 		@include breakpoint( "<660px" ) {
-			transform: translateX( 100% );
+			pointer-events: none;
 			overflow: hidden;
-			height: calc( 100% - 47px );
+			max-height: calc( 100vh - 47px );
+
+			// Removing this transform could have unintended side-affects
+			// related to z-index and elements showing through on mobile.
+			transform: translateX( 100% );
 		}
 	}
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -210,8 +210,9 @@
 		}
 	}
 
-	.layout__primary {
+	.layout__primary .main {
 		@include breakpoint( ">660px" ) {
+			pointer-events: none;
 			opacity: 0.25;
 		}
 	}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -13,8 +13,8 @@
 .layout__secondary,
 .layout__secondary .sidebar,
 .layout__secondary .site-selector {
-	transition: transform 0.2s cubic-bezier(0.770, 0.000, 0.175, 1.000),
-				opacity 0.2s ease-in-out;
+	transition: transform 0.15s ease-in-out,
+				opacity 0.15s ease-out;
 }
 
 // If things take a bit to load...


### PR DESCRIPTION
The Layout "module handles the base page layout for Calypso leveraged by all other
sub-views, including the WordPress.com masterbar." The CSS is a little messy and fragile.

This PR aims to make the CSS easier to understand and ensure smoother transitions between layout focus states. The only visual changes you should see are related to the transition of the site-selector and sidebar — the animations are the same, but they should be smoother.

This will affect every screen within Calypso and needs some thorough testing.