### PR TITLE
Jetpack Connect: Fetch only the connected site after authorize

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -314,7 +314,13 @@ export function authorize( queryObject ) {
 				// Update the user now that we are fully connected.
 				userFactory().fetch();
 				// Site may not be accessible yet, so force fetch from wpcom
-				return wpcom.site( client_id ).get( { force: 'wpcom' } );
+				return wpcom.site( client_id ).get( {
+					force: 'wpcom',
+					fields:
+						'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
+					options:
+						'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset,design_type', //eslint-disable-line max-len
+				} );
 			} )
 			.then( data => {
 				dispatch(

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -36,10 +36,10 @@ import {
 	JETPACK_CONNECT_SSO_VALIDATION_REQUEST,
 	JETPACK_CONNECT_SSO_VALIDATION_SUCCESS,
 	JETPACK_CONNECT_USER_ALREADY_CONNECTED,
+	SITE_RECEIVE,
 	SITE_REQUEST,
 	SITE_REQUEST_FAILURE,
 	SITE_REQUEST_SUCCESS,
-	SITES_RECEIVE,
 } from 'state/action-types';
 import userFactory from 'lib/user';
 import config from 'config';
@@ -313,14 +313,8 @@ export function authorize( queryObject ) {
 				} );
 				// Update the user now that we are fully connected.
 				userFactory().fetch();
-				return wpcom.me().sites( {
-					site_visibility: 'all',
-					include_domain_only: true,
-					fields:
-						'ID,URL,name,capabilities,jetpack,visible,is_private,is_vip,icon,plan,jetpack_modules,single_user_site,is_multisite,options', //eslint-disable-line max-len
-					options:
-						'is_mapped_domain,unmapped_url,admin_url,is_redirect,is_automated_transfer,allowed_file_types,show_on_front,main_network_site,jetpack_version,software_version,default_post_format,created_at,frame_nonce,publicize_permanently_disabled,page_on_front,page_for_posts,advanced_seo_front_page_description,advanced_seo_title_formats,verification_services_codes,podcasting_archive,is_domain_only,default_sharing_status,default_likes_enabled,wordads,upgraded_filetypes_enabled,videopress_enabled,permalink_structure,gmt_offset,design_type', //eslint-disable-line max-len
-				} );
+				// Site may not be accessible yet, so force fetch from wpcom
+				return wpcom.site( client_id ).get( { force: 'wpcom' } );
 			} )
 			.then( data => {
 				dispatch(
@@ -328,14 +322,13 @@ export function authorize( queryObject ) {
 						site: client_id,
 					} )
 				);
-				debug( 'Sites list updated!', data );
+				debug( 'Site updated', data );
 				dispatch( {
-					type: SITES_RECEIVE,
-					sites: data.sites,
+					type: SITE_RECEIVE,
+					site: data,
 				} );
 				dispatch( {
 					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST,
-					data: data,
 				} );
 			} )
 			.then( () => {

--- a/client/state/jetpack-connect/test/actions.js
+++ b/client/state/jetpack-connect/test/actions.js
@@ -21,14 +21,13 @@ import {
 	JETPACK_CONNECT_SSO_VALIDATION_REQUEST,
 	JETPACK_CONNECT_SSO_VALIDATION_SUCCESS,
 	JETPACK_CONNECT_SSO_VALIDATION_ERROR,
-	SITES_RECEIVE,
+	SITE_RECEIVE,
 } from 'state/action-types';
 
 jest.mock( 'lib/localforage', () => require( 'lib/localforage/localforage-bypass' ) );
 
 describe( 'actions', () => {
-	const mySitesPath =
-		'/rest/v1.1/me/sites?site_visibility=all&include_domain_only=true&site_activity=active';
+	const mySitesPath = '/rest/v1.1/me/sites';
 
 	describe( '#confirmJetpackInstallStatus()', () => {
 		test( 'should dispatch confirm status action when called', () => {
@@ -129,7 +128,7 @@ describe( 'actions', () => {
 					.reply(
 						200,
 						{
-							sites: [ client_id ],
+							ID: client_id,
 						},
 						{
 							'Content-Type': 'application/json',
@@ -186,8 +185,8 @@ describe( 'actions', () => {
 
 				return authorize( queryObject )( spy ).then( () => {
 					expect( spy ).toHaveBeenCalledWith( {
-						type: SITES_RECEIVE,
-						sites: [ client_id ],
+						type: SITE_RECEIVE,
+						site: { ID: client_id },
 					} );
 				} );
 			} );
@@ -199,9 +198,6 @@ describe( 'actions', () => {
 				return authorize( queryObject )( spy ).then( () => {
 					expect( spy ).toHaveBeenCalledWith( {
 						type: JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST,
-						data: {
-							sites: [ client_id ],
-						},
 					} );
 				} );
 			} );


### PR DESCRIPTION
Instead of all the sites! We need to force the API to fetch from wpcom instead of the .org site, which may not yet be accessible.

## Testing
* Check that a site can still be connected at /jetpack/connect, or from wp-admin
* The newly connected site should be present in the sites list in the calypso sidebar after connection
* Check the other connection flows listed at PCYsg-dek-p2
