### PR TITLE
Update a few createReducer usages to not validate schema manually

### DIFF
--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -12,36 +12,16 @@ import {
 	READER_FEED_REQUEST_SUCCESS,
 	READER_FEED_REQUEST_FAILURE,
 	READER_FEED_UPDATE,
-	DESERIALIZE,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { decodeEntities } from 'lib/formatting';
 import { itemsSchema } from './schema';
 import { safeLink } from 'lib/post-normalizer/utils';
 
-const actionMap = {
-	[ SERIALIZE ]: handleSerialize,
-	[ DESERIALIZE ]: handleDeserialize,
-	[ READER_FEED_REQUEST_SUCCESS ]: handleRequestSuccess,
-	[ READER_FEED_REQUEST_FAILURE ]: handleRequestFailure,
-	[ READER_FEED_UPDATE ]: handleFeedUpdate,
-};
-
-function defaultHandler( state ) {
-	return state;
-}
-
 function handleSerialize( state ) {
 	// remove errors from the serialized state
 	return omitBy( state, 'is_error' );
-}
-
-function handleDeserialize( state ) {
-	if ( isValidStateWithSchema( state, itemsSchema ) ) {
-		return state;
-	}
-	return {};
 }
 
 function handleRequestFailure( state, action ) {
@@ -84,10 +64,16 @@ function handleFeedUpdate( state, action ) {
 	return assign( {}, state, keyBy( feeds, 'feed_ID' ) );
 }
 
-export function items( state = {}, action ) {
-	const handler = actionMap[ action.type ] || defaultHandler;
-	return handler( state, action );
-}
+export const items = createReducer(
+	{},
+	{
+		[ SERIALIZE ]: handleSerialize,
+		[ READER_FEED_REQUEST_SUCCESS ]: handleRequestSuccess,
+		[ READER_FEED_REQUEST_FAILURE ]: handleRequestFailure,
+		[ READER_FEED_UPDATE ]: handleFeedUpdate,
+	},
+	itemsSchema
+);
 
 export function queuedRequests( state = {}, action ) {
 	switch ( action.type ) {

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -12,36 +12,16 @@ import {
 	READER_SITE_REQUEST_SUCCESS,
 	READER_SITE_REQUEST_FAILURE,
 	READER_SITE_UPDATE,
-	DESERIALIZE,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import { readerSitesSchema } from './schema';
 import { withoutHttp } from 'lib/url';
 import { decodeEntities } from 'lib/formatting';
 
-const actionMap = {
-	[ SERIALIZE ]: handleSerialize,
-	[ DESERIALIZE ]: handleDeserialize,
-	[ READER_SITE_REQUEST_SUCCESS ]: handleRequestSuccess,
-	[ READER_SITE_REQUEST_FAILURE ]: handleRequestFailure,
-	[ READER_SITE_UPDATE ]: handleSiteUpdate,
-};
-
-function defaultHandler( state ) {
-	return state;
-}
-
 function handleSerialize( state ) {
 	// remove errors from the serialized state
 	return omitBy( state, 'is_error' );
-}
-
-function handleDeserialize( state ) {
-	if ( isValidStateWithSchema( state, readerSitesSchema ) ) {
-		return state;
-	}
-	return {};
 }
 
 function handleRequestFailure( state, action ) {
@@ -103,11 +83,16 @@ function handleSiteUpdate( state, action ) {
 	return assign( {}, state, keyBy( sites, 'ID' ) );
 }
 
-export function items( state = {}, action ) {
-	const handler = actionMap[ action.type ] || defaultHandler;
-	return handler( state, action );
-}
-items.hasCustomPersistence = true;
+export const items = createReducer(
+	{},
+	{
+		[ SERIALIZE ]: handleSerialize,
+		[ READER_SITE_REQUEST_SUCCESS ]: handleRequestSuccess,
+		[ READER_SITE_REQUEST_FAILURE ]: handleRequestFailure,
+		[ READER_SITE_UPDATE ]: handleSiteUpdate,
+	},
+	readerSitesSchema
+);
 
 export function queuedRequests( state = {}, action ) {
 	switch ( action.type ) {

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -18,7 +18,7 @@ import {
 	TERMS_REQUEST_SUCCESS,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import TermQueryManager from 'lib/query-manager/term';
 import { getSerializedTermsQuery } from './utils';
 import { queriesSchema } from './schema';
@@ -103,17 +103,14 @@ export const queries = createReducer(
 			} );
 		},
 		[ DESERIALIZE ]: state => {
-			if ( ! isValidStateWithSchema( state, queriesSchema ) ) {
-				return {};
-			}
-
 			return mapValues( state, taxonomies => {
 				return mapValues( taxonomies, ( { data, options } ) => {
 					return new TermQueryManager( data, options );
 				} );
 			} );
 		},
-	}
+	},
+	queriesSchema
 );
 
 export default combineReducers( {

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -10,7 +10,7 @@ import { mapValues, omit } from 'lodash';
  * Internal dependencies
  */
 import ThemeQueryManager from 'lib/query-manager/theme';
-import { combineReducers, createReducer, isValidStateWithSchema } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import {
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
@@ -325,22 +325,20 @@ export const queries = ( () => {
 			},
 			[ SERIALIZE ]: state => {
 				const serializedState = mapValues( state, ( { data, options } ) => ( { data, options } ) );
-				return { ...serializedState, _timestamp: Date.now() };
+				serializedState._timestamp = Date.now();
+				return serializedState;
 			},
 			[ DESERIALIZE ]: state => {
 				if ( state._timestamp && state._timestamp + MAX_THEMES_AGE < Date.now() ) {
 					return {};
 				}
 				const noTimestampState = omit( state, '_timestamp' );
-				if ( ! isValidStateWithSchema( noTimestampState, queriesSchema ) ) {
-					return {};
-				}
-
 				return mapValues( noTimestampState, ( { data, options } ) => {
 					return new ThemeQueryManager( data, options );
 				} );
 			},
-		}
+		},
+		queriesSchema
 	);
 } )();
 

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -19,6 +19,9 @@ const themeSchema = {
 
 export const queriesSchema = {
 	type: 'object',
+	properties: {
+		_timestamp: { type: 'number' },
+	},
 	patternProperties: {
 		// Site ID
 		'^(wpcom|wporg|\\d+)$': {


### PR DESCRIPTION
After merging #22471, `createReducer` can validate schema that's been passed as its third argument, and call the custom `DESERIALIZE` handler after that. There's no longer necessary to call `isValidStateWithSchema` explicitly in such a handler.

This PR updates several reducers that did this.

After this patch is merged, all schema validation in Calypso is done in framework (i.e., in `withSchemaValidation`) and there are no longer any explicit calls to `isValidStateWithSchema` anywhere.

**How to test:**
Covered well with unit tests.