### PR TITLE
Add sku and quantity to GA ecommerce addItem

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -580,10 +580,12 @@ export function recordViewCheckout( cart ) {
  */
 export function recordOrder( cart, orderId ) {
 	if ( ! isAdTrackingAllowed() ) {
+		debug( 'recordOrder: skipping as ad tracking is disallowed' );
 		return;
 	}
 
 	// load the ecommerce plugin
+	debug( 'recordOrder: ga ecommerce plugin load' );
 	window.ga( 'require', 'ecommerce' );
 
 	// Purchase tracking happens in one of three ways:
@@ -604,6 +606,7 @@ export function recordOrder( cart, orderId ) {
 	} );
 
 	// Ensure we submit the cart to Google Analytics
+	debug( 'recordOrder: ga ecommerce send' );
 	window.ga( 'ecommerce:send' );
 
 	// 3. Fire a single tracking event without any details about what was purchased
@@ -660,13 +663,15 @@ function recordProduct( product, orderId ) {
 
 	try {
 		// Google Analytics
-		window.ga( 'ecommerce:addItem', {
+		const item = {
 			id: orderId,
 			name: product.product_slug,
 			price: product.cost,
 			currency: product.currency,
 			quantity: 1,
-		} );
+		};
+		debug( 'recordProduct: ga ecommerce add item', item );
+		window.ga( 'ecommerce:addItem', item );
 
 		// Google AdWords
 		if ( isAdwordsEnabled ) {
@@ -1195,15 +1200,18 @@ function criteoSiteType() {
  */
 function recordOrderInGoogleAnalytics( cart, orderId ) {
 	if ( ! isAdTrackingAllowed() ) {
+		debug( 'recordOrderInGoogleAnalytics: skipping as ad tracking is disallowed' );
 		return;
 	}
 
-	window.ga( 'ecommerce:addTransaction', {
+	const transaction = {
 		id: orderId,
 		affiliation: 'WordPress.com',
 		revenue: cart.total_cost,
 		currency: cart.currency,
-	} );
+	};
+	debug( 'recordOrderInGoogleAnalytics: ga ecommerce add transaction', transaction );
+	window.ga( 'ecommerce:addTransaction', transaction );
 }
 
 /**

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -664,10 +664,11 @@ function recordProduct( product, orderId ) {
 	try {
 		// Google Analytics
 		const item = {
+			currency: product.currency,
 			id: orderId,
 			name: product.product_slug,
 			price: product.cost,
-			currency: product.currency,
+			sku: product.product_slug,
 			quantity: 1,
 		};
 		debug( 'recordProduct: ga ecommerce add item', item );

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -665,6 +665,7 @@ function recordProduct( product, orderId ) {
 			name: product.product_slug,
 			price: product.cost,
 			currency: product.currency,
+			quantity: 1,
 		} );
 
 		// Google AdWords

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -16,7 +16,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
-		"ad-tracking": false,
+		"ad-tracking": true,
 		"automated-transfer": true,
 		"apple-pay": true,
 		"comments/management/threaded-view": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -177,7 +177,7 @@
 	"boom_analytics_enabled": true,
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "wpcalypso",
-	"google_analytics_enabled": false,
+	"google_analytics_enabled": true,
 	"google_analytics_key": "UA-10673494-32",
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -178,7 +178,7 @@
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "wpcalypso",
 	"google_analytics_enabled": false,
-	"google_analytics_key": "UA-10673494-15",
+	"google_analytics_key": "UA-10673494-32",
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
 	"hotjar_enabled": true

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -16,7 +16,7 @@
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
 	"support_locales": [ "en", "es", "pt-br" ],
 	"features": {
-		"ad-tracking": true,
+		"ad-tracking": false,
 		"automated-transfer": true,
 		"apple-pay": true,
 		"comments/management/threaded-view": false,
@@ -177,8 +177,8 @@
 	"boom_analytics_enabled": true,
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "wpcalypso",
-	"google_analytics_enabled": true,
-	"google_analytics_key": "UA-10673494-32",
+	"google_analytics_enabled": false,
+	"google_analytics_key": "UA-10673494-15",
 	"google_adwords_conversion_id": 1067250390,
 	"google_adwords_conversion_id_jetpack": 937115306,
 	"hotjar_enabled": true


### PR DESCRIPTION
GA does not correctly attribute revenue to ecommerce events without a sku and quantity (see [this discussion on stack overflow](https://stackoverflow.com/questions/19954083/google-analytics-ecommerce-sends-only-last-item-in-transaction)).

# Testing

Google analytics and ad tracking are disabled in development so you need to temporarily enable them locally in development (set google_analytics_enabled = true and features.ad-tracking = true).

Enable debugging for analytics events (`localStorage.setItem('debug', 'calypso:analytics:ad-tracking')`).

Now make a purchase, you should see the GA ecommerce event includes a quantity (always 1) and sku (the same as product slug).

(ignore the name of this branch - we were originally intending to switch to a new GA property but instead fixed some issues with the old events)