### PR TITLE
Calypso.live: feature flag control via query parameters

### DIFF
--- a/client/config/index.js
+++ b/client/config/index.js
@@ -18,7 +18,11 @@ if ( 'undefined' === typeof window || ! window.configData ) {
 
 const configData = window.configData;
 
-if ( process.env.NODE_ENV === 'development' || configData.env_id === 'stage' ) {
+if (
+	process.env.NODE_ENV === 'development' ||
+	configData.env_id === 'stage' ||
+	( window && window.location.href.indexOf( 'https://calypso.live' ) === 0 )
+) {
 	const match =
 		document.location.search && document.location.search.match( /[?&]flags=([^&]+)(&|$)/ );
 	if ( match ) {


### PR DESCRIPTION
This PR is for allowing the `flags` query parameter to be used on calypso.live.
Currently it is only allowed when the `env` is development or when on the `staging` environment.

This PR would allow it for any url beginning with `https://calypso.live`

**To Test**
go to https://calypso.live/?branch=update/flags-calypso.live and make sure you can use the `flags=` query param.

One example would be [disabling devdocs]( https://calypso.live/?branch=update/flags-calypso.live&flags=-devdocs)