### PR TITLE
Help: update the help link for uploading plugins and themes

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -40,7 +40,7 @@ class InlineHelpSearchResults extends Component {
 		// copied from client/me/help/main for now
 		const helpfulResults = [
 			{
-				link: 'https://en.support.wordpress.com/com-vs-org/',
+				link: 'https://en.support.wordpress.com/business-plan/',
 				title: this.props.translate( 'Uploading custom plugins and themes' ),
 				description: this.props.translate(
 					'Learn more about installing a custom theme or plugin using the Business plan.'

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -40,7 +40,7 @@ class Help extends React.PureComponent {
 	getHelpfulArticles = () => {
 		const helpfulResults = [
 			{
-				link: 'https://en.support.wordpress.com/com-vs-org/',
+				link: 'https://en.support.wordpress.com/business-plan/',
 				title: this.props.translate( 'Uploading custom plugins and themes' ),
 				description: this.props.translate(
 					'Learn more about installing a custom theme or plugin using the Business plan.'


### PR DESCRIPTION
This PR updates one of the default help links we show in Inline Help and on the `/help` page. 

It replaces the URL for the "Uploading custom plugins and themes" link from "https://en.support.wordpress.com/com-vs-org/" to "https://en.support.wordpress.com/business-plan/" (which has recently been revised in preparation of this change — context: p2-p7DVsv-4g9).

To test:
- Check that the link is updated in Inline Help and on `/help`

/cc @sararosso @kristenzuck 