### PR TITLE
Jetpack connect: Update connected plans header

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -34,8 +34,8 @@ class JetpackPlansGrid extends Component {
 	renderConnectHeader() {
 		const { isLanding, translate } = this.props;
 
-		let headerText = translate( 'Your site is now connected!' );
-		let subheaderText = translate( "Now pick a plan that's right for you." );
+		let headerText = translate( 'Explore our Jetpack plans' );
+		let subheaderText = translate( "Now that you're connected, pick a plan that fits your needs." );
 
 		if ( isLanding ) {
 			headerText = translate( "Pick a plan that's right for you." );

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -34,12 +34,11 @@ class JetpackPlansGrid extends Component {
 	renderConnectHeader() {
 		const { isLanding, translate } = this.props;
 
-		let headerText = translate( 'Explore our Jetpack plans' );
+		const headerText = translate( 'Explore our Jetpack plans' );
 		let subheaderText = translate( "Now that you're connected, pick a plan that fits your needs." );
 
 		if ( isLanding ) {
-			headerText = translate( "Pick a plan that's right for you." );
-			subheaderText = '';
+			subheaderText = translate( 'Pick a plan that fits your needs.' );
 		}
 		return <FormattedHeader headerText={ headerText } subHeaderText={ subheaderText } />;
 	}


### PR DESCRIPTION
Updates copy for `/jetpack/connect/plans/:SITE_SLUG` Plans page according to p1HpG7-4Mw-p2 (point 7)

> **Explore our Jetpack Plans**
> Now that you’re connected, pick a plan that fits your needs.

Updates copy for `/jetpack/connect/store`

> **Explore our Jetpack Plans**
> Pick a plan that fits your needs.

## Screens

### Before `/jetpack/connect/plans/:SITE_SLUG`

![before](https://user-images.githubusercontent.com/841763/36308577-8f056b78-1321-11e8-9a3c-ab96eef60df1.png)

### After `/jetpack/connect/plans/:SITE_SLUG`

![after](https://user-images.githubusercontent.com/841763/36308547-7591876c-1321-11e8-8de7-a70e0ab66ce8.png)

### Before `/jetpack/connect/store`

![plans](https://user-images.githubusercontent.com/841763/36328567-de619dfe-1362-11e8-8fc4-9335096f2ed2.png)

### After `/jetpack/connect/store`

![after](https://user-images.githubusercontent.com/841763/36328670-525e4072-1363-11e8-809b-b35d29d4ff6b.png)

## Testing
1. Connect a new site
1. Verify text is correct
1. Verify store page text is correct: https://calypso.live/jetpack/connect/store?branch=update/jetpack/plans-header