### PR TITLE
JP Remote Install: Add request tracking

### DIFF
--- a/client/state/jetpack-remote-install/actions.js
+++ b/client/state/jetpack-remote-install/actions.js
@@ -22,6 +22,11 @@ export const jetpackRemoteInstall = ( url, user, password ) => ( {
 	url,
 	user,
 	password,
+	meta: {
+		dataLayer: {
+			trackRequest: true,
+		},
+	},
 } );
 
 /**


### PR DESCRIPTION
No visual changes—there is not yet any UI for jetpack remote install.

Add data-layer request tracking to the jetpack plugin remote install API call, allowing us to show progress in the UI with the `getRequest()` selector.