### PR TITLE
Add mobile navbar to checklist screen

### DIFF
--- a/client/my-sites/checklist/checklist-show/index.jsx
+++ b/client/my-sites/checklist/checklist-show/index.jsx
@@ -24,6 +24,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { createNotice } from 'state/notices/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import ChecklistShowShare from './share';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 class ChecklistShow extends PureComponent {
 	onAction = id => {
@@ -113,6 +114,7 @@ class ChecklistShow extends PureComponent {
 
 		return (
 			<Main className="checklist-show">
+				<SidebarNavigation />
 				<DocumentHead title={ title } />
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
 				{ this.renderHeader( completed, displayMode ) }


### PR DESCRIPTION
Our current checklist screen doesn't have a way for people to access the menu on a mobile device. This PR adds the mobile-nav bar to the checklist screen so you can access the sidebar.

## Before
![image](https://user-images.githubusercontent.com/6981253/36317231-90db5802-130a-11e8-81a5-462ec046d2d3.png)


## After
![image](https://user-images.githubusercontent.com/6981253/36317134-3afbd344-130a-11e8-98bc-d31c54bf4b23.png)

## Testing
- If you haven't already create a new site and make sure you're in the A/B testing group
- View the checklist on a mobile screen and ensure you can get back to the menu from there. 

Thanks to @shaunandrews for pointing this out. 