### PR TITLE
Rewrite store-transactions submit to not use Readable

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -7,7 +7,6 @@
 import { isEmpty, omit } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:store-transactions' );
-import { Readable } from 'stream';
 import inherits from 'inherits';
 
 /**
@@ -37,8 +36,8 @@ const wpcom = wp.undocumented();
  * @param {object} domainDetails - Optional domain registration details if the shopping cart contains a domain registration product
  *   transaction.
  */
-export function submit( params ) {
-	return new TransactionFlow( params );
+export function submit( params, onStep ) {
+	return new TransactionFlow( params, onStep );
 }
 
 function ValidationError( code, message ) {
@@ -47,29 +46,9 @@ function ValidationError( code, message ) {
 }
 inherits( ValidationError, Error );
 
-function TransactionFlow( initialData ) {
-	Readable.call( this, { objectMode: true } );
+function TransactionFlow( initialData, onStep ) {
 	this._initialData = initialData;
-	this._hasStarted = false;
-}
-inherits( TransactionFlow, Readable );
-
-/**
- * Pushes new data onto the stream. Whenever someone wants to read from the
- * stream of steps, this method will get called because we inherited the
- * functionality of `Readable`.
- *
- * Our goal is to capture the flow of the asynchronous callback functions as a
- * linear sequence of steps. When we get the first request for data, we begin
- * the chain of asynchronous functions. On future requests for data, there is
- * no need to start another asynchronous process, so we just return immediately
- * while the first one finises.
- */
-TransactionFlow.prototype._read = function() {
-	if ( this._hasStarted ) {
-		return false;
-	}
-	this._hasStarted = true;
+	this._onStep = onStep;
 
 	const paymentMethod = this._initialData.payment.paymentMethod;
 	const paymentHandler = this._paymentHandlers[ paymentMethod ];
@@ -78,7 +57,7 @@ TransactionFlow.prototype._read = function() {
 	}
 
 	paymentHandler.call( this );
-};
+}
 
 TransactionFlow.prototype._pushStep = function( options ) {
 	const defaults = {
@@ -87,7 +66,7 @@ TransactionFlow.prototype._pushStep = function( options ) {
 		timestamp: Date.now(),
 	};
 
-	this.push( Object.assign( defaults, options ) );
+	this._onStep( Object.assign( defaults, options ) );
 };
 
 TransactionFlow.prototype._paymentHandlers = {
@@ -184,7 +163,6 @@ TransactionFlow.prototype._createCardToken = function( callback ) {
 };
 
 TransactionFlow.prototype._submitWithPayment = function( payment ) {
-	const onComplete = this.push.bind( this, null ); // End the stream when the transaction has finished
 	const transaction = {
 		cart: omit( this._initialData.cart, [ 'messages' ] ), // messages contain reference to DOMNode
 		domain_details: this._initialData.domainDetails,
@@ -193,26 +171,21 @@ TransactionFlow.prototype._submitWithPayment = function( payment ) {
 
 	this._pushStep( { name: SUBMITTING_WPCOM_REQUEST } );
 
-	wpcom.transactions(
-		'POST',
-		transaction,
-		function( error, data ) {
-			if ( error ) {
-				return this._pushStep( {
-					name: RECEIVED_WPCOM_RESPONSE,
-					error: error,
-					last: true,
-				} );
-			}
-
-			this._pushStep( {
+	wpcom.transactions( 'POST', transaction, ( error, data ) => {
+		if ( error ) {
+			return this._pushStep( {
 				name: RECEIVED_WPCOM_RESPONSE,
-				data: data,
+				error,
 				last: true,
 			} );
-			onComplete();
-		}.bind( this )
-	);
+		}
+
+		this._pushStep( {
+			name: RECEIVED_WPCOM_RESPONSE,
+			data,
+			last: true,
+		} );
+	} );
 };
 
 function createPaygateToken( requestType, cardDetails, callback ) {

--- a/client/lib/upgrades/actions/checkout.js
+++ b/client/lib/upgrades/actions/checkout.js
@@ -31,22 +31,23 @@ export function setNewCreditCardDetails( options ) {
 }
 
 export function submitTransaction( { cart, transaction }, onComplete ) {
-	const steps = submit( {
-		cart: cart,
-		payment: transaction.payment,
-		domainDetails: transaction.domainDetails,
-	} );
+	submit(
+		{
+			cart: cart,
+			payment: transaction.payment,
+			domainDetails: transaction.domainDetails,
+		},
+		step => {
+			Dispatcher.handleViewAction( {
+				type: ActionTypes.TRANSACTION_STEP_SET,
+				step,
+			} );
 
-	steps.on( 'data', step => {
-		Dispatcher.handleViewAction( {
-			type: ActionTypes.TRANSACTION_STEP_SET,
-			step,
-		} );
-
-		if ( onComplete && step.name === 'received-wpcom-response' ) {
-			onComplete( step.error, step.data );
+			if ( onComplete && step.name === 'received-wpcom-response' ) {
+				onComplete( step.error, step.data );
+			}
 		}
-	} );
+	);
 }
 
 export function resetTransaction() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -182,6 +182,7 @@ const webpackConfig = {
 		__dirname: 'mock',
 		fs: 'empty',
 		crypto: false,
+		stream: false,
 	},
 	plugins: _.compact( [
 		new webpack.DefinePlugin( {


### PR DESCRIPTION
The `TransactionFlow` class in `lib/store-transactions` uses the `streams` Node module to implement a `Readable` stream of async events that happen when processing the transaction.

Because we are in browser, not in Node.js, we need to ship a big `stream-browserify` polyfill library that implements these Node APIs.

The `Readable` is not needed at all though -- a simple callback does the job equally well. `Readable` has some fancy features that serve to read from source data only when the consumer actually needs them:
- don't start reading from source (i.e., start the purchase transaction) until someone calls `read` on the stream, or, in our case, attaches a `data` event listener. We attach the listener immediately, so we don't need to wait for anything.
- signal the end of stream by pushing a `null` object. We don't need this, as we have other means to signal the end of the transaction, and we are not listening for the stream's `end` event anyway.
- support reading by repeated calls to `stream.read()` and also by subscribing to `data` event. We don't use the `read()` style at all.

Removing the `stream-browserify` removes quite a lot of code from Calypso builds:
```
chunk            stat_size            parsed_size            gzip_size
build                 +0 B                   +0 B                 +3 B   (+0.0%)
checkout         -142648 B  (-12.2%)     -58632 B   (-9.6%)   -15319 B  (-11.4%)
domains          -142648 B  (-12.0%)     -58632 B   (-9.7%)   -15279 B  (-11.9%)
jetpack-connect  -142648 B  (-20.3%)     -58632 B  (-16.6%)   -15309 B  (-18.5%)
manifest              +0 B                   +0 B                 -2 B   (-0.1%)
plans            -142648 B  (-21.8%)     -58632 B  (-17.7%)   -15289 B  (-20.4%)
purchases        -142648 B  (-12.1%)     -58632 B   (-9.6%)   -15346 B  (-11.6%)
settings         -142648 B  (-19.2%)     -58632 B  (-16.6%)   -15342 B  (-18.8%)
signup           -142648 B  (-13.3%)     -58632 B  (-10.1%)   -15290 B  (-11.3%)
```

**How to test:**
- purchase something on WP.com using credits (payment method `WPCOM_Billing_WPCOM`). I tested this myself.
- purchase something using a real credit card (stored or unstored, payment methods `WPCOM_Billing_MoneyPress_Stored` and  `WPCOM_Billing_MoneyPress_Paygate`). I didn't test this.