### PR TITLE
Manually dispatch recordTracksEvent() on all Happychat clicks

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
@@ -76,11 +76,14 @@ class SetupFooter extends Component {
 	}
 }
 
-export default connect(
-	state => ( {
-		happychatIsAvailable: isHappychatAvailable( state ),
-	} ),
-	{
-		happychatEvent: () => recordTracksEvent( 'calypso_rewind_credentials_get_help' ),
-	}
-)( localize( SetupFooter ) );
+const mapStateToProps = state => ( {
+	happychatIsAvailable: isHappychatAvailable( state ),
+} );
+
+const mapDispatchToProps = dispatch => ( {
+	happychatEvent: () => dispatch(
+		recordTracksEvent( 'calypso_rewind_credentials_get_help' )
+	),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( SetupFooter ) );

--- a/client/my-sites/stats/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/error-banner.jsx
@@ -121,8 +121,12 @@ class ErrorBanner extends PureComponent {
 	}
 }
 
-export default connect( null, {
+const mapDispatchToProps = dispatch => ( {
 	dismissRewindRestoreProgress: dismissRewindRestoreProgressAction,
-	trackHappyChatBackup: () => recordTracksEvent( 'calypso_activitylog_error_banner_backup' ),
-	trackHappyChatRestore: () => recordTracksEvent( 'calypso_activitylog_error_banner_restore' ),
-} )( localize( ErrorBanner ) );
+	trackHappyChatBackup: () =>
+		dispatch( recordTracksEvent( 'calypso_activitylog_error_banner_backup' ) ),
+	trackHappyChatRestore: () =>
+		dispatch( recordTracksEvent( 'calypso_activitylog_error_banner_restore' ) ),
+} );
+
+export default connect( null, mapDispatchToProps )( localize( ErrorBanner ) );

--- a/client/my-sites/stats/activity-log-banner/success-banner.jsx
+++ b/client/my-sites/stats/activity-log-banner/success-banner.jsx
@@ -149,15 +149,18 @@ class SuccessBanner extends PureComponent {
 	}
 }
 
-export default connect(
-	( state, { siteId } ) => ( {
-		siteUrl: getSiteUrl( state, siteId ),
-	} ),
-	{
-		dismissRestoreProgress: dismissRewindRestoreProgress,
-		dismissBackupProgress: dismissRewindBackupProgress,
-		recordTracksEvent: recordTracksEvent,
-		trackHappyChatBackup: () => recordTracksEvent( 'calypso_activitylog_success_banner_backup' ),
-		trackHappyChatRestore: () => recordTracksEvent( 'calypso_activitylog_success_banner_restore' ),
-	}
-)( localize( SuccessBanner ) );
+const mapStateToProps = ( state, { siteId } ) => ( {
+	siteUrl: getSiteUrl( state, siteId ),
+} );
+
+const mapDispatchToProps = dispatch => ( {
+	dismissRestoreProgress: dismissRewindRestoreProgress,
+	dismissBackupProgress: dismissRewindBackupProgress,
+	recordTracksEvent: recordTracksEvent,
+	trackHappyChatBackup: () =>
+		dispatch( recordTracksEvent( 'calypso_activitylog_success_banner_backup' ) ),
+	trackHappyChatRestore: () =>
+		dispatch( recordTracksEvent( 'calypso_activitylog_success_banner_restore' ) ),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( localize( SuccessBanner ) );

--- a/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/stats/activity-log-confirm-dialog/index.jsx
@@ -79,8 +79,8 @@ const ActivityLogConfirmDialog = ( {
 );
 /* eslint-enable wpcalypso/jsx-classname-namespace */
 
-const mapDispatchToProps = {
-	happychatEvent: () => recordTracksEvent( 'calypso_activitylog_confirm_dialog' ),
-};
+const mapDispatchToProps = dispatch => ( {
+	happychatEvent: () => dispatch( recordTracksEvent( 'calypso_activitylog_confirm_dialog' ) ),
+} );
 
 export default connect( null, mapDispatchToProps )( localize( ActivityLogConfirmDialog ) );

--- a/client/my-sites/stats/activity-log-item/index.jsx
+++ b/client/my-sites/stats/activity-log-item/index.jsx
@@ -282,8 +282,9 @@ const mapDispatchToProps = ( dispatch, { activityId, siteId } ) => ( {
 			)
 		)
 	),
-	trackHelpThreat: () => recordTracksEvent( 'calypso_activitylog_threat_get_help' ),
-	trackHelpBackupFail: () => recordTracksEvent( 'calypso_activitylog_backup_fail_get_help' ),
+	trackHelpThreat: () => dispatch( recordTracksEvent( 'calypso_activitylog_threat_get_help' ) ),
+	trackHelpBackupFail: () =>
+		dispatch( recordTracksEvent( 'calypso_activitylog_backup_fail_get_help' ) ),
 } );
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( ActivityLogItem ) );


### PR DESCRIPTION
It seems like none of the tracks events on Happychat buttons are actually recording. This is most likely due to them needing to be manually dispatched. This PR addresses that by dispatching those events which will hopefully fix the issue.

**Testing**
1. Check to be sure all of the Happychat buttons affected by this PR still in fact open a Happychat window.
2. Ensure there are no visual or functional disruptions to any of the UIs touched in this PR. This includes the following:

- The credentials setup flow in Site Settings > Security
- The backup error banner
- The restore error banner
- The backup download success banner
- The restore confirmation dialog
- Happychat button on threats in the activity log
- Happychat button on failed backups in the activity log