### PR TITLE
JP Remote Install: Add selectors

### DIFF
--- a/client/state/selectors/get-jetpack-remote-install-error.js
+++ b/client/state/selectors/get-jetpack-remote-install-error.js
@@ -1,0 +1,19 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns any error that has resulted from requesting
+ * a remote install of the jetpack plugin on the .org
+ * site at the given url.
+ *
+ * @param {Object} state - Global state tree
+ * @param {String} url - .org site URL
+ * @return {?String} - Error code, if any
+ */
+export default function getJetpackRemoteInstallError( state, url ) {
+	return get( state.jetpackRemoteInstall.error, url, null );
+}

--- a/client/state/selectors/get-jetpack-remote-install-error.js
+++ b/client/state/selectors/get-jetpack-remote-install-error.js
@@ -10,9 +10,9 @@ import { get } from 'lodash';
  * a remote install of the jetpack plugin on the .org
  * site at the given url.
  *
- * @param {Object} state - Global state tree
- * @param {String} url - .org site URL
- * @return {?String} - Error code, if any
+ * @param {Object} state Global state tree
+ * @param {String} url .org site URL
+ * @return {?String} Error code, if any
  */
 export default function getJetpackRemoteInstallError( state, url ) {
 	return get( state.jetpackRemoteInstall.error, url, null );

--- a/client/state/selectors/is-jetpack-remote-install-complete.js
+++ b/client/state/selectors/is-jetpack-remote-install-complete.js
@@ -9,10 +9,10 @@ import { get } from 'lodash';
  * Returns success status of an attempted remote install
  * of the jetpack plugin to the .org site at the given url.
  *
- * @param {Object} state - Global state tree
- * @param {String} url - .org site URL
- * @return {bool} - True if installation and activation was successful
+ * @param {Object} state Global state tree
+ * @param {String} url .org site URL
+ * @return {bool} True if installation and activation was successful
  */
 export default function isJetpackRemoteInstallComplete( state, url ) {
-	return !! get( state.jetpackRemoteInstall.isComplete, [ url ], false );
+	return !! get( state.jetpackRemoteInstall.isComplete, url, false );
 }

--- a/client/state/selectors/is-jetpack-remote-install-complete.js
+++ b/client/state/selectors/is-jetpack-remote-install-complete.js
@@ -11,7 +11,7 @@ import { get } from 'lodash';
  *
  * @param {Object} state - Global state tree
  * @param {String} url - .org site URL
- * @return {bool} - true if installation and activation was successful
+ * @return {bool} - True if installation and activation was successful
  */
 export default function isJetpackRemoteInstallComplete( state, url ) {
 	return !! get( state.jetpackRemoteInstall.isComplete, [ url ], false );

--- a/client/state/selectors/is-jetpack-remote-install-complete.js
+++ b/client/state/selectors/is-jetpack-remote-install-complete.js
@@ -1,0 +1,18 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns success status of an attempted remote install
+ * of the jetpack plugin to the .org site at the given url.
+ *
+ * @param {Object} state - Global state tree
+ * @param {String} url - .org site URL
+ * @return {bool} - true if installation and activation was successful
+ */
+export default function isJetpackRemoteInstallComplete( state, url ) {
+	return !! get( state.jetpackRemoteInstall.isComplete, [ url ], false );
+}

--- a/client/state/selectors/test/get-jetpack-remote-install-error.js
+++ b/client/state/selectors/test/get-jetpack-remote-install-error.js
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getJetpackRemoteInstallError } from 'state/selectors';
+
+const url = 'https://yourgroovydomain.com';
+
+describe( 'getJetpackRemoteInstallError()', () => {
+	test( 'should return null if no errors', () => {
+		const state = {
+			jetpackRemoteInstall: {
+				error: {},
+			},
+		};
+		expect( getJetpackRemoteInstallError( state, url ) ).toBe( null );
+	} );
+	test( 'should return any existing error', () => {
+		const state = {
+			jetpackRemoteInstall: {
+				error: {
+					[ url ]: 'SOME_ERROR',
+				},
+			},
+		};
+		expect( getJetpackRemoteInstallError( state, url ) ).toEqual( 'SOME_ERROR' );
+	} );
+} );

--- a/client/state/selectors/test/is-jetpack-remote-install-complete.js
+++ b/client/state/selectors/test/is-jetpack-remote-install-complete.js
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { isJetpackRemoteInstallComplete } from 'state/selectors';
+
+const url = 'https://yourgroovydomain.com';
+
+describe( 'isJetpackRemoteInstallComplete()', () => {
+	test( 'should return true if install is complete', () => {
+		const state = {
+			jetpackRemoteInstall: {
+				isComplete: {
+					[ url ]: true,
+				},
+			},
+		};
+		expect( isJetpackRemoteInstallComplete( state, url ) ).toBe( true );
+	} );
+	test( 'should return false if install is not complete', () => {
+		const state = {
+			jetpackRemoteInstall: {
+				isComplete: {},
+			},
+		};
+		expect( isJetpackRemoteInstallComplete( state, url ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
No visual differences.

Add selectors for the state that tracks remotely installing the jetpack plugin on a .org site. State was added in #22400. For wider context on jetpack remote installs, see p7rd6c-1dS-p2.

Once this PR is merged we'll be able to add UI that requests an install and handles the response with the following calls:
* [`jetpackRemoteInstall( url, user, password )`](https://github.com/Automattic/wp-calypso/blob/4b4583df01f3002b539ecddde3da1adb32d073cb/client/state/jetpack-remote-install/actions.js#L20) to request an install on a site
* `isJetpackRemoteInstallComplete( state, url )` (this PR) to determine success
* `getJetpackRemoteInstallError( state, url )` (this PR) for any error code

## Testing
* Contains unit tests

