### PR TITLE
Store Order: Clean up table view on smaller screens

### DIFF
--- a/client/extensions/woocommerce/app/order/index.js
+++ b/client/extensions/woocommerce/app/order/index.js
@@ -76,8 +76,8 @@ class Order extends Component {
 					<LabelsSetupNotice />
 					{ isEditing && <ProtectFormGuard isChanged={ hasOrderEdits } /> }
 					<OrderDetails orderId={ orderId } />
-					<OrderActivityLog orderId={ orderId } siteId={ siteId } />
 					<OrderCustomer orderId={ orderId } />
+					<OrderActivityLog orderId={ orderId } siteId={ siteId } />
 				</div>
 			</Main>
 		);

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -57,6 +57,45 @@
 			color: $alert-red;
 		}
 	}
+
+	@include breakpoint( "<660px" ) {
+		table,
+		tbody,
+		thead {
+			display: block;
+		}
+		.table-row {
+			width: 100%;
+			display: flex;
+			justify-content: space-between;
+			flex-wrap: wrap;
+
+			* {
+				box-sizing: border-box;
+			}
+
+			.table-heading,
+			.table-item {
+				flex: 1 0;
+			}
+
+			.order-details__item-product {
+				flex: 1 0 100%;
+				padding-bottom: 0;
+				border-bottom: none;
+			}
+
+			.order-details__item-cost {
+				padding-left: 24px;
+				text-align: left;
+			}
+		}
+		.table-row.order-details__header {
+			.order-details__item-product {
+				display: none;
+			}
+		}
+	}
 }
 
 .order-details__item-cost,

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -57,45 +57,6 @@
 			color: $alert-red;
 		}
 	}
-
-	@include breakpoint( "<660px" ) {
-		table,
-		tbody,
-		thead {
-			display: block;
-		}
-		.table-row {
-			width: 100%;
-			display: flex;
-			justify-content: space-between;
-			flex-wrap: wrap;
-
-			* {
-				box-sizing: border-box;
-			}
-
-			.table-heading,
-			.table-item {
-				flex: 1 0;
-			}
-
-			.order-details__item-product {
-				flex: 1 0 100%;
-				padding-bottom: 0;
-				border-bottom: none;
-			}
-
-			.order-details__item-cost {
-				padding-left: 24px;
-				text-align: left;
-			}
-		}
-		.table-row.order-details__header {
-			.order-details__item-product {
-				display: none;
-			}
-		}
-	}
 }
 
 .order-details__item-cost,
@@ -245,4 +206,56 @@
 .order-details__card .form-setting-explanation {
 	margin: -8px 0 16px;
 	text-align: right;
+}
+
+@include breakpoint( '<660px' ) {
+	.order-details__table,
+	.order-details__totals {
+		table,
+		tbody,
+		thead {
+			display: block;
+		}
+
+		.table-row {
+			width: 100%;
+			display: flex;
+			justify-content: flex-end;
+			flex-wrap: wrap;
+
+			.table-heading,
+			.table-item {
+				flex: 1 0;
+			}
+		}
+	}
+
+	.order-details__table .table-row {
+		.order-details__item-product {
+			flex: 1 0 100%;
+			padding-bottom: 0;
+			border-bottom: none;
+		}
+
+		.order-details__item-cost {
+			padding-left: 24px;
+			text-align: left;
+		}
+
+		&.order-details__header {
+			.order-details__item-product {
+				display: none;
+			}
+		}
+	}
+
+	.order-details__totals .table-row {
+		&.order-details__coupon-list {
+			.table-item.order-details__coupon-list-label {
+				flex: 1 0 100%;
+				padding-bottom: 0;
+				border-bottom: none;
+			}
+		}
+	}
 }

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -1,11 +1,17 @@
+/** @format */
+
 .order__container {
 	padding-bottom: 0;
 
-	@include breakpoint( ">660px" ) {
+	* {
+		box-sizing: border-box;
+	}
+
+	@include breakpoint( '>660px' ) {
 		margin-top: 58px;
 	}
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoint( '>960px' ) {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
@@ -24,7 +30,7 @@
 		}
 	}
 
-	@include breakpoint( ">1040px" ) {
+	@include breakpoint( '>1040px' ) {
 		.order-details {
 			order: 1;
 			flex: 2;
@@ -71,9 +77,10 @@
 	padding: 16px;
 	border-top: 1px solid $gray-lighten-30;
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoint( '>480px' ) {
 		margin: 0 -24px;
 		padding: 24px;
 	}
@@ -97,12 +104,16 @@
 
 	.order-payment__action,
 	.order-fulfillment__action {
+		display: flex;
+		justify-content: center;
 		flex-grow: 0;
 
 		.button {
-			float: left;
 			white-space: nowrap;
-			margin-left: 12px;
+
+			& + .button {
+				margin-left: 12px;
+			}
 
 			&.is-placeholder {
 				@include placeholder();
@@ -121,7 +132,24 @@
 		}
 	}
 
+	.order-fulfillment__print-container {
+		flex-wrap: wrap;
+		justify-content: center;
+	}
+
 	.gridicon {
 		margin-right: 8px;
+	}
+
+	@include breakpoint( '<660px' ) {
+		.order-payment__label,
+		.order-fulfillment__label,
+		.order-payment__action,
+		.order-fulfillment__action {
+			width: 100%;
+		}
+		.order-payment__label + .order-payment__action {
+			margin-top: 8px;
+		}
 	}
 }

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -21,11 +21,13 @@
 		}
 
 		.order-activity-log {
+			order: 2;
 			flex: 2;
 			margin-right: 16px;
 		}
 
 		.order-customer {
+			order: 3;
 			flex: 1;
 		}
 	}


### PR DESCRIPTION
Fixes #17910 - improves the layout of the order details page on small screens. This updates the line items so that the product name spans the full width, any coupons applied also span the full width of the screen, and the payment & fulfillment buttons wrap to a new line. The "activity log" & address sections work without any adjustments.

| Before | After |
| --- | --- |
| ![screen shot 2018-02-16 at 16 51 48](https://user-images.githubusercontent.com/541093/36330888-b5cacb50-1339-11e8-94c5-089d2fedd668.png) | ![order](https://user-images.githubusercontent.com/541093/36328607-b7a2f758-1330-11e8-868c-64e5bdc60ee9.png) |


**To test**

On a screen or browser smaller than 660px wide…

- View a single order on your store: `/store/order/:site/:id`
- Make sure the product details look ok 👍 
- See #22541 for header & actions improvements

This doesn't help the create or edit screen, or refunds, or the shipping label modal, this is just for the single order view.