### PR TITLE
Activity Log: link plugin and theme names to their page in Calypso

### DIFF
--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -16,6 +16,8 @@ export const FormattedBlock = ( { content = {} } ) => {
 		type,
 		siteSlug,
 		pluginSlug,
+		themeSlug,
+		themeUri,
 	} = content;
 
 	if ( 'string' === typeof content ) {
@@ -77,13 +79,17 @@ export const FormattedBlock = ( { content = {} } ) => {
 			return <pre>{ descent }</pre>;
 
 		case 'theme':
-			return (
-				<a href={ content.url } target="_blank" rel="noopener noreferrer">
-					<strong>
-						<em>{ descent }</em>
-					</strong>
-				</a>
-			);
+			if ( themeUri ) {
+				if ( -1 !== themeUri.indexOf( 'wordpress.com' ) ) {
+					return <a href={ `/theme/${ themeSlug }/${ siteSlug }` }>{ descent }</a>;
+				}
+				return (
+					<a href={ themeUri } target="_blank" rel="noopener noreferrer">
+						{ descent }
+					</a>
+				);
+			}
+			return descent;
 
 		default:
 			return descent;

--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -5,7 +5,18 @@
 import React from 'react';
 
 export const FormattedBlock = ( { content = {} } ) => {
-	const { siteId, children, commentId, isTrashed, name, postId, text = null, type } = content;
+	const {
+		siteId,
+		children,
+		commentId,
+		isTrashed,
+		name,
+		postId,
+		text = null,
+		type,
+		siteSlug,
+		pluginSlug,
+	} = content;
 
 	if ( 'string' === typeof content ) {
 		return content;
@@ -51,7 +62,7 @@ export const FormattedBlock = ( { content = {} } ) => {
 			);
 
 		case 'plugin':
-			return <a href={ `/plugins/${ name }/${ siteId }` }>{ descent }</a>;
+			return <a href={ `/plugins/${ pluginSlug }/${ siteSlug }` }>{ descent }</a>;
 
 		case 'post':
 			return isTrashed ? (

--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -79,17 +79,19 @@ export const FormattedBlock = ( { content = {} } ) => {
 			return <pre>{ descent }</pre>;
 
 		case 'theme':
-			if ( themeUri ) {
-				if ( -1 !== themeUri.indexOf( 'wordpress.com' ) ) {
-					return <a href={ `/theme/${ themeSlug }/${ siteSlug }` }>{ descent }</a>;
-				}
-				return (
-					<a href={ themeUri } target="_blank" rel="noopener noreferrer">
-						{ descent }
-					</a>
-				);
+			if ( ! themeUri ) {
+				return descent;
 			}
-			return descent;
+
+			if ( /wordpress\.com/.test( themeUri ) ) {
+				return <a href={ `/theme/${ themeSlug }/${ siteSlug }` }>{ descent }</a>;
+			}
+
+			return (
+				<a href={ themeUri } target="_blank" rel="noopener noreferrer">
+					{ descent }
+				</a>
+			);
 
 		default:
 			return descent;

--- a/client/lib/notifications/note-block-parser.js
+++ b/client/lib/notifications/note-block-parser.js
@@ -124,6 +124,14 @@ const pluginNode = ( { site_slug, slug, version } ) => ( {
 	version,
 } );
 
+const themeNode = ( { site_slug, slug, version, uri } ) => ( {
+	type: 'theme',
+	siteSlug: site_slug,
+	themeSlug: slug,
+	themeUri: uri,
+	version,
+} );
+
 const inferNode = range => {
 	const { type, url } = range;
 
@@ -164,6 +172,9 @@ const nodeMappings = type => {
 
 		case 'plugin':
 			return pluginNode;
+
+		case 'theme':
+			return themeNode;
 
 		default:
 			return inferNode;

--- a/client/lib/notifications/note-block-parser.js
+++ b/client/lib/notifications/note-block-parser.js
@@ -117,6 +117,13 @@ const userNode = ( { id: userId, name, site_id: siteId } ) => ( {
 	userId,
 } );
 
+const pluginNode = ( { site_slug, slug, version } ) => ( {
+	type: 'plugin',
+	siteSlug: site_slug,
+	pluginSlug: slug,
+	version,
+} );
+
 const inferNode = range => {
 	const { type, url } = range;
 
@@ -154,6 +161,9 @@ const nodeMappings = type => {
 
 		case 'user':
 			return userNode;
+
+		case 'plugin':
+			return pluginNode;
 
 		default:
 			return inferNode;


### PR DESCRIPTION
~~Companion to D10275-code~~ It was committed. Provides support for plugins.
Companion to D10307-code. Provides support for themes.
Related #22369 

This PR introduces support for new plugin and theme object formatting. This results in plugin and theme names linked to their page in Calypso.

<img width="837" alt="captura de pantalla 2018-02-16 a la s 20 44 22" src="https://user-images.githubusercontent.com/1041600/36341694-d48a2922-13d0-11e8-80e8-d62d8a576ad8.png">

In the case of themes, if the theme isn't in wordpress.com, it will be linked (and open in a new tab) to the URL defined in the `Theme URI` header found in the theme's stylesheet.

Also updated the style of the link since it was showing in italics and bold:
<img width="547" alt="captura de pantalla 2018-02-19 a la s 15 45 42" src="https://user-images.githubusercontent.com/1041600/36392870-023e4666-158c-11e8-9f0f-aac91eb2b759.png">

and now it's consistent with plugin links:
<img width="535" alt="captura de pantalla 2018-02-19 a la s 15 46 29" src="https://user-images.githubusercontent.com/1041600/36392883-15f75918-158c-11e8-924e-8b927a152a59.png">
