### PR TITLE
add missing space to match other use of copy

### DIFF
--- a/client/signup/steps/creds-complete/index.jsx
+++ b/client/signup/steps/creds-complete/index.jsx
@@ -37,7 +37,7 @@ class CredsCompleteStep extends Component {
 						translate(
 							'Your site is being backed up because it is set up with ' +
 								'Jetpack Premium at no additional cost to you.'
-						) }
+						) + ' ' }
 					{ translate(
 						'Finish setting up Jetpack and your site is ready to be ' +
 							'transformed into the site of your dreams.'


### PR DESCRIPTION
Fixes #22545 

We use the same copy in:
client/signup/steps/rewind-were-backing/index.jsx:43
this `rewind-were-backing/index.jsx` contains the space that I have added to this file.