### PR TITLE
Fix: Show site-picker for taxonomies settings

### DIFF
--- a/client/my-sites/site-settings/settings-writing/index.js
+++ b/client/my-sites/site-settings/settings-writing/index.js
@@ -10,7 +10,7 @@ import page from 'page';
 import config from 'config';
 import controller from './controller';
 import settingsController from 'my-sites/site-settings/settings-controller';
-import { navigation, siteSelection } from 'my-sites/controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
@@ -25,6 +25,8 @@ export default function() {
 	);
 
 	if ( config.isEnabled( 'manage/site-settings/categories' ) ) {
+		page( '/settings/taxonomies/:taxonomy', siteSelection, sites, makeLayout, clientRender );
+
 		page(
 			'/settings/taxonomies/:taxonomy/:site_id',
 			siteSelection,


### PR DESCRIPTION
Resolves #22151

It was pointed out that if we navigate to the taxonomy settings
for a given term but don't have a site selected then an empty page
renders.

No path was provided for URLs without the site. When I first tried to
resolve this by making the site parameter optional it still failed by
showing a messed-up form.  The reason for this is that without a site
selected no API calls are able to issue and return with taxonomy
information.

In this patch I'm copying behavior found in the `/domains` section which
creates a separate route for paths without the site parameter.

**Testing**

I'm not familiar with routing and I would appreciate some scrutiny of my fix.

Load the following link in Calypso.

http://calypso.localhost:3000/settings/taxonomies/category

You can pass any taxonomy there.

In **master** it should render an empty page.
In this branch it should request that you choose a site
and then start loading in the taxonomy after you do so.

cc: @arunsathiya - thanks for pointing this out and reporting it!