### PR TITLE
Checkout: Fix domain privacy keyboard navigability (#21954)

### DIFF
--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -369,7 +369,6 @@ export class DomainDetailsForm extends PureComponent {
 		return (
 			<div>
 				<Input
-					autoFocus
 					label={ this.props.translate( 'First Name' ) }
 					{ ...this.getFieldProps( 'first-name' ) }
 				/>


### PR DESCRIPTION
Screen readers skipped the privacy selection radio boxes because the
first name field stole the focus using the autofocus attribute.