### PR TITLE
Preferences: Save post request unstringify payload

### DIFF
--- a/client/state/preferences/actions.js
+++ b/client/state/preferences/actions.js
@@ -86,11 +86,11 @@ export const savePreference = ( key, value ) => dispatch => {
 		value,
 	} );
 
-	const payload = JSON.stringify( {
+	const payload = {
 		[ USER_SETTING_KEY ]: {
 			[ key ]: value,
 		},
-	} );
+	};
 
 	return wpcom
 		.me()


### PR DESCRIPTION
Preferences are not being saved. Attempts to post data to `/me/preferences` are returned with a 400 error
```
{"code":400,"headers":[{"name":"Content-Type","value":"application\/json"}],"body":{"error":"invalid_input","message":"No preferences were provided for the endpoint to set."}}
```

### Fix
Remove stringification of the payload. This is a reversal of https://github.com/Automattic/wp-calypso/commit/fa3e254464cf5f591de8987906bd3db20b96e3fb. I can't figure out what's changed without deeper digging. @aduth, offhand do you know?

### Testing
* Switch to a test user (or not, but this will reset your settings)
* Visit `/stats/reset-first-view` with the Network tab open
* See a POST request made to `/me/preferences` with a `200` response
* Visit `/stats` and confirm the "See how your site is performing" dialog box appears and does not reappear once you've clicked "Got it!".

cc @rachelmcr @designsimply 

Fixes https://github.com/Automattic/wp-calypso/issues/22462
Fixes https://github.com/Automattic/wp-calypso/issues/22386