### PR TITLE
[WIP] Add 2.0 config for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,85 @@
+version: 2
+jobs:
+  build:
+    parallelism: 4
+    working_directory: ~/wp-calypso
+    docker:
+      - image: circleci/node:8.9.4-browsers
+        environment:
+          CIRCLE_ARTIFACTS: /tmp/artifacts
+          CIRCLE_TEST_REPORTS: /tmp/test_results
+
+    steps:
+      - checkout
+
+      - run:
+          name: Create Directories for Results and Artifacts
+          command: |
+            mkdir -p $CIRCLE_ARTIFACTS
+            mkdir -p $CIRCLE_TEST_REPORTS
+
+      - restore_cache:
+          key: v1-{{ .Branch }}-{{ checksum "package.json" }}
+
+      - run: npm install
+
+      - save_cache:
+          key: v1-{{ .Branch }}-{{ checksum "package.json" }}
+          paths:
+            - "node_modules"
+
+      - run: NODE_ENV=test npm run build-server
+      - run:
+          command: |
+            npm run translate; mkdir -p $CIRCLE_ARTIFACTS/translate
+            mv calypso-strings.pot $CIRCLE_ARTIFACTS/translate
+
+      - run:
+          command: |
+            git clone https://github.com/Automattic/gp-localci-client.git
+            bash gp-localci-client/generate-new-strings-pot.sh $CIRCLE_BRANCH $CIRCLE_SHA1 $CIRCLE_ARTIFACTS/translate
+            rm -rf gp-localci-client
+
+      - run:
+          name: Run Integration Tests
+          command: |
+            bin/run-integration $(circleci tests glob "bin/**/integration/*.js" "client/**/integration/*.js" "server/**/integration/*.js" | circleci tests split --split-by=timings)
+
+      - run:
+          name: Lint
+          command: npm run lint:config-defaults
+
+      - run:
+          name: Lint Client and Server
+          command: |
+            ./node_modules/.bin/eslint-eslines $(circleci tests glob "client/**/*.js" "client/**/*.jsx" "server/**/*.js" "server/**/*.jsx" | circleci tests split)
+
+      - run:
+          name: Run Client Tests
+          command: |
+              npm run test-client:ci $(circleci tests glob "client/**/test/*.js" "client/**/test/*.jsx" | circleci tests split --split-by=timings)
+
+      - run:
+          name: Run Server Tests
+          command: |
+              npm run test-server:ci $(circleci tests glob "server/**/test/*.js" "server/**/test/*.jsx" | circleci tests split --split-by=timings)
+
+      - run:
+          name: Gather Test Results
+          command: |
+            find . -type f -regex  ".*/test-results.*\.xml" -exec cp {} $CIRCLE_TEST_REPORTS/ \;
+          when: always
+
+      - store_test_results:
+          path: /tmp/test_results
+      - store_artifacts:
+          path: /tmp/test_results
+      - store_artifacts:
+          path: /tmp/artifacts
+
+# We need to work around this bit because
+# the notification system in 2.0 is a bit flakey
+# and is not yet working as expected.
+# notify:
+#   webhooks:
+#     - url: https://translate.wordpress.com/api/localci/-relay-new-strings-to-gh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
             - "node_modules"
 
       - run: NODE_ENV=test npm run build-server
+
       - run:
           command: |
             npm run translate; mkdir -p $CIRCLE_ARTIFACTS/translate


### PR DESCRIPTION
This PR stems from a conversation I had with Dennis Snell via CircleCI support. 

CircleCI 2.0 is a new docker based platform for CircleCI. One bug from CircleCI 1.0 was an issue with the way that globs were being parsed that led to the creation of [this workaround](https://github.com/Automattic/wp-calypso/pull/21518). 

You can view this project building on CircleCI 2.0 on my own fork: https://circleci.com/gh/levlaz/wp-calypso/30 (most recent passing build). 

Marking this as a WIP because there are some outstanding questions that I want to work through before handing this off. 

If anyone has any other questions about the implications of moving over to 2.0 please feel free to ask. 

## Open Questions 

2. I am unable to test out the gp-localci-client process since I am not 100% sure what the proper values for LOCALCI_APP_ID and LOCALCI_APP_SECRET should be. Can someone give me a pointer? (for example this happens on a non master branch build: https://circleci.com/gh/levlaz/wp-calypso/32)

3. I see quite a few warnings on 2.0 that did not seem to exist on 1.0. Could someone double check the build output (specifically the client tests) and make sure that these warnings are expected?

4. Lastly, could someone let me know what data this endpoint expects? 

```
notify:
  webhooks:
    - url: https://translate.wordpress.com/api/localci/-relay-new-strings-to-gh
```

The notify feature has been a bit flakey lately, I wanted to test to make sure that we can either get it to work properly or work around it.

## Resolved Questions

1. What is the best way to get integration test to run?

On my builds I just see:

```
Regular build: skipping tests.
```

I see `if [[ "$RUN_ARGS" != "--nightly" ]];` in `bin/run-integration` does $RUN_ARGS refer to something in a commit label?

 