### PR TITLE
Jetpack Onboarding: Refresh site title step

### DIFF
--- a/client/jetpack-onboarding/disclaimer.jsx
+++ b/client/jetpack-onboarding/disclaimer.jsx
@@ -28,21 +28,18 @@ class JetpackOnboardingDisclaimer extends React.PureComponent {
 		return (
 			<p className="jetpack-onboarding__disclaimer">
 				<Gridicon icon="info-outline" size={ 18 } />
-				{ translate(
-					'By continuing, you agree to our {{link}}fascinating terms and conditions{{/link}}.',
-					{
-						components: {
-							link: (
-								<a
-									href="//wordpress.com/tos/"
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={ this.handleTosClick }
-								/>
-							),
-						},
-					}
-				) }
+				{ translate( 'By continuing, you agree to our {{link}}Terms of Service{{/link}}.', {
+					components: {
+						link: (
+							<a
+								href="//wordpress.com/tos/"
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ this.handleTosClick }
+							/>
+						),
+					},
+				} ) }
 			</p>
 		);
 	}

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -89,7 +89,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 						<p>{ translate( "Let's help you get set up." ) }</p>
 						<p>
 							{ translate(
-								'First, what would you like to name your site and have as its public description?'
+								'First up, what would you like to name your site and have as its public description?'
 							) }
 						</p>
 					</div>

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -85,6 +85,15 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 						alt=""
 					/>
 
+					<div className="steps__description">
+						<p>{ translate( "Let's help you get set up." ) }</p>
+						<p>
+							{ translate(
+								'First, what would you like to name your site and have as its public description?'
+							) }
+						</p>
+					</div>
+
 					<form onSubmit={ this.handleSubmit }>
 						<SiteTitle
 							autoFocusBlogname

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -66,10 +66,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 
 	render() {
 		const { basePath, isRequestingSettings, translate } = this.props;
-		const headerText = translate( "Let's get started." );
-		const subHeaderText = translate(
-			'First up, what would you like to name your site and have as its public description?'
-		);
+		const headerText = translate( 'Welcome to WordPress!' );
 
 		return (
 			<div className="steps__main">
@@ -79,7 +76,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 					title="Site Title ‹ Jetpack Start"
 				/>
 
-				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+				<FormattedHeader headerText={ headerText } />
 
 				<Card className="steps__form">
 					<form onSubmit={ this.handleSubmit }>

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -111,7 +111,7 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 							primary
 							type="submit"
 						>
-							{ translate( 'Next Step' ) }
+							{ translate( 'Continue' ) }
 						</Button>
 					</form>
 				</Card>

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -79,6 +79,12 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 				<FormattedHeader headerText={ headerText } />
 
 				<Card className="steps__form">
+					<img
+						className="steps__illustration"
+						src={ '/calypso/images/illustrations/illustration-start.svg' }
+						alt=""
+					/>
+
 					<form onSubmit={ this.handleSubmit }>
 						<SiteTitle
 							autoFocusBlogname

--- a/client/jetpack-onboarding/steps/site-title.jsx
+++ b/client/jetpack-onboarding/steps/site-title.jsx
@@ -104,6 +104,8 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 							onChange={ this.handleChange }
 						/>
 
+						<JetpackOnboardingDisclaimer recordJpoEvent={ this.props.recordJpoEvent } />
+
 						<Button
 							disabled={ isRequestingSettings || ! this.state.blogname }
 							primary
@@ -113,8 +115,6 @@ class JetpackOnboardingSiteTitleStep extends React.PureComponent {
 						</Button>
 					</form>
 				</Card>
-
-				<JetpackOnboardingDisclaimer recordJpoEvent={ this.props.recordJpoEvent } />
 			</div>
 		);
 	}

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -98,9 +98,13 @@
 	text-align: center;
 	font-size: 12px;
 
+	a {
+		display: inline-block;
+	}
+
 	.gridicon {
 		position: relative;
 		top: 4px;
-		margin-right: 12px;
+		margin-right: 8px;
 	}
 }

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -23,6 +23,17 @@
 		margin-bottom: 20px;
 	}
 
+	.steps__description {
+		color: $gray-darken-20;
+		font-size: 12px;
+		margin-bottom: 30px;
+		text-align: center;
+
+		p {
+			margin-bottom: 0;
+		}
+	}
+
 	.steps__summary-columns {
 		display: flex;
 		justify-content: center;

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -19,6 +19,10 @@
 		}
 	}
 
+	.steps__illustration {
+		margin-bottom: 20px;
+	}
+
 	.steps__summary-columns {
 		display: flex;
 		justify-content: center;


### PR DESCRIPTION
This PR updates the site title step and makes it more welcoming to users. It contains mostly cosmetic changes and enhancements, as suggested in p6TEKc-1Rd-p2 and #22048.

Changes that are included in this PR are all to the site title step, and are as follows:
* Updating header copy (removing description and changing title)
* Adding illustration to the top of the card.
* Inserting a new description in the card.
* Updating the disclaimer link copy.
* Moving the disclaimer inside the card so it will be above the submit button.
* Updating the submit button copy.

Note that there are some intentional differences with the mockup that is suggested in #22048, mainly to keep consistency. Such differences are:

* Card is more narrow, because we are using the same width that we've been using for all of JPO steps (320 px)
* Illustration is a little different, because we're reusing the one that already exists in Calypso.
* Site Description field is a single line text field, because we decided to be consistent with WP-admin.
* Disclaimer copy is displayed on two lines because there isn't enough space to fit it on one line with the narrow card width.
* Description is a little different (`First up` instead of `first`) so we can reuse some translations.
* Spacing is a little different here and there in order to keep styles minimal and consistent.

Before:
![](https://cldup.com/ByfgjJ-ab8.png)

After:
![](https://cldup.com/ShwqHYJJlm.png)

To test:
* Checkout this branch
* Start the onboarding flow for the Jetpack site by going to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`
* Reach the site title step.
* Verify it looks as shown on the "After" screenshot.
* Verify all controls and clickable elements work like they did before.

Fixes #22048.