### PR TITLE
Jetpack Onboarding: Add country field to business address step

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -30,6 +30,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		state: '',
 		street: '',
 		zip: '',
+		country: '',
 	};
 
 	state = get( this.props.settings, 'businessAddress' ) || this.constructor.emptyState;
@@ -55,6 +56,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 			city: translate( 'City' ),
 			state: translate( 'State / Region / Province' ),
 			zip: translate( 'ZIP code' ),
+			country: translate( 'Country' ),
 		};
 	}
 

--- a/client/state/jetpack-onboarding/schema.js
+++ b/client/state/jetpack-onboarding/schema.js
@@ -44,6 +44,7 @@ export const jetpackOnboardingSettingsSchema = {
 						city: { type: 'string' },
 						state: { type: 'string' },
 						zip: { type: 'string' },
+						country: { type: 'string' },
 					},
 				},
 			],


### PR DESCRIPTION
This PR adds a country field to the business address step. It also updates the settings schema to respect that field. Suggested in p6TEKc-1Rd-p2 and #22530.

Fixes #22530.

Preview:
![](https://cldup.com/RsWYz1mbHy.png)

To test:
* Checkout this branch
* Checkout the Jetpack branch from https://github.com/Automattic/jetpack/pull/8874 on your Jetpack site.
* Start the onboarding flow for the Jetpack site by going to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`
* On the site type step, choose **Business**
* Skip to the Business Address step.
* Verify the country field appears properly.
* Input some data in it, and save the step. 
* Verify the country saves properly and goes straight to the address widget.
* Verify a fresh load of this step loads the setting properly.