### PR TITLE
Jetpack Onboarding: Improve Business Address field labels

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -50,11 +50,11 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		const { translate } = this.props;
 
 		return {
-			name: translate( 'Business Name' ),
-			street: translate( 'Street Address' ),
+			name: translate( 'Business name' ),
+			street: translate( 'Street address' ),
 			city: translate( 'City' ),
-			state: translate( 'State' ),
-			zip: translate( 'ZIP Code' ),
+			state: translate( 'State / Region / Province' ),
+			zip: translate( 'ZIP code' ),
 		};
 	}
 


### PR DESCRIPTION
This PR updates the labels of the Business Address step as suggested in p6TEKc-1Rd-p2 and #22530. Changes are basically:

* `Business Name` to `Business name`
* `Street Address` to `Street address`
* `State` to `State / Region / Province`
* `ZIP Code` to `ZIP code`

Before:
![](https://cldup.com/h4LY2w-lvX.png)

After:
![](https://cldup.com/fcraAh782w.png)

To test:
* Checkout this branch
* Checkout the Jetpack branch from https://github.com/Automattic/jetpack/pull/8874 on your Jetpack site.
* Start the onboarding flow for the Jetpack site by going to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`
* On the site type step, choose **Business**
* Skip to the Business Address step.
* Verify the field labels appear as shown on the "After" screenshot.