### PR TITLE
Jetpack Onboarding: Apply Jetpack branding to contact form step

### DIFF
--- a/client/components/tile-grid/tile.jsx
+++ b/client/components/tile-grid/tile.jsx
@@ -53,7 +53,10 @@ export default class extends React.PureComponent {
 				) }
 				<div className="tile-grid__item-copy">
 					{ buttonLabel && (
-						<Button className={ classNames( 'tile-grid__cta', buttonClassName ) } compact>
+						<Button
+							className={ classNames( 'tile-grid__cta', buttonClassName ) }
+							compact={ !! description }
+						>
 							{ buttonLabel }
 						</Button>
 					) }

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -58,9 +58,9 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 
 				<TileGrid>
 					<Tile
-						buttonLabel={ ! hasContactForm ? translate( 'Add a contact form' ) : undefined }
+						buttonLabel={ ! hasContactForm ? translate( 'Add a contact form' ) : null }
 						description={
-							hasContactForm ? translate( 'Your contact form has been created.' ) : undefined
+							hasContactForm ? translate( 'Your contact form has been created.' ) : null
 						}
 						image={ '/calypso/images/illustrations/contact-us.svg' }
 						onClick={ this.handleAddContactForm }

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -60,9 +60,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 					<Tile
 						buttonLabel={ ! hasContactForm ? translate( 'Add a contact form' ) : undefined }
 						description={
-							hasContactForm
-								? translate( 'Your contact form has been created.' )
-								: translate( 'Not sure? You can skip this step and add a contact form later.' )
+							hasContactForm ? translate( 'Your contact form has been created.' ) : undefined
 						}
 						image={ '/calypso/images/illustrations/contact-us.svg' }
 						onClick={ this.handleAddContactForm }

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -32,13 +32,13 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 
 	render() {
 		const { basePath, getForwardUrl, settings, translate } = this.props;
-		const headerText = translate( "Let's shape your new site." );
+		const headerText = translate( "Let's grow your audience with Jetpack." );
 		const subHeaderText = (
 			<Fragment>
-				{ translate( 'Would you like to create a Contact Us page with a contact form on it?' ) }
+				{ translate( "A great first step is adding Jetpack's contact form." ) }
 				<br />
 				{ translate(
-					'This form will allow visitors to contact you with their name, email, website, and a message.'
+					'Create a Jetpack account to get started and unlock this and dozens of other features.'
 				) }
 			</Fragment>
 		);

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
+import JetpackLogo from 'components/jetpack-logo';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
@@ -50,6 +51,8 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 					path={ [ basePath, STEPS.CONTACT_FORM, ':site' ].join( '/' ) }
 					title="Contact Form ‹ Jetpack Start"
 				/>
+
+				<JetpackLogo full size={ 45 } />
 
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 

--- a/client/jetpack-onboarding/style.scss
+++ b/client/jetpack-onboarding/style.scss
@@ -77,6 +77,15 @@
 			margin: 0 8px 20px;
 		}
 	}
+
+	.jetpack-logo {
+		display: block;
+		margin: 20px auto;
+
+		.jetpack-logo__icon {
+			fill: $green-jetpack;
+		}
+	}
 }
 
 .jetpack-onboarding__disclaimer {


### PR DESCRIPTION
### Purpose

This PR applies some Jetpack branding to the contact form, as suggested in #22525 and p6TEKc-1Rd-p2. Fixes #22525.

### What this PR suggests

This PR suggests some changes to the contact form step:

* Updating the `<Tile />` component to display the button as compact only if there is a description.
* Adding the Jetpack logo to the top of the step.
* Updating the header copy to make it clear that this functionality is provided by Jetpack.
* Removing the description from the contact form tile, which makes the button non-compact.

### Preview

**Before (before creating a contact form)**
![](https://cldup.com/atfbEA-Qcc.png)

**After (before creating a contact form)**
![](https://cldup.com/OZH-JTUgHW.png)

**Before (after creating a contact form)**
![](https://cldup.com/JpumezTsGt.png)

**After (after creating a contact form)**
![](https://cldup.com/ztzpj_4hs1.png)

### Testing

* Checkout this branch
* Get a fresh Jetpack site.
* Start the onboarding flow for the Jetpack site by going to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`
* Reach the contact form step.
* Verify it looks as shown on the **After (before creating a contact form)** screenshot.
* Click the button to insert your form.
* Go back to the contact form step.
* Verify it looks as shown on the **After (after creating a contact form)** screenshot.