### PR TITLE
Fix/jetpack back text

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -311,6 +311,10 @@ class JetpackThankYouCard extends Component {
 		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_chat_initiated' );
 	};
 
+	onBackToYourSiteClick = () => {
+		analytics.tracks.recordEvent( 'calypso_plans_autoconfig_backtoyoursite' );
+	};
+
 	isEligibleForLiveChat() {
 		const { planSlug } = this.props;
 		return (
@@ -565,6 +569,7 @@ class JetpackThankYouCard extends Component {
 						className={ classNames( 'button', 'thank-you-card__button', {
 							'is-placeholder': ! buttonUrl,
 						} ) }
+						onclick={ this.onBackToYourSiteClick }
 						href={ buttonUrl }
 					>
 						{ translate( 'Back to your site' ) }

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -567,7 +567,7 @@ class JetpackThankYouCard extends Component {
 						} ) }
 						href={ buttonUrl }
 					>
-						{ translate( 'Explore your plan' ) }
+						{ translate( 'Back to your site' ) }
 					</a>
 					{ this.renderLiveChatButton() }
 				</div>


### PR DESCRIPTION
Changes the button that takes the user back to their sites after a jetpack plan successful configuration process from "explore your plan" to "back to your site" to match the actual action
![image](https://user-images.githubusercontent.com/1554855/36386852-77b5caee-1597-11e8-9e97-e5265e739846.png)

fixes https://github.com/Automattic/wp-calypso/issues/22588

