### PR TITLE
SSR: Disable cache when query params are not whitelisted

### DIFF
--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -1,6 +1,12 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { parse as parseUrl } from 'url';
+import { parse } from 'qs';
+
+/**
  * Internal dependencies
  */
 import config from 'config';
@@ -13,6 +19,38 @@ import {
 	redirectDefaultLocale,
 } from './controller';
 import { makeLayout, redirectLoggedIn, setUpLocale } from 'controller';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
+
+function checkRedirectToIsValid( context, next ) {
+	const { isServerSide, query: { client_id, redirect_to } } = context;
+
+	if ( isServerSide ) {
+		return next();
+	}
+
+	if ( ! redirect_to ) {
+		const error = new Error( 'The `redirect_to` query parameter is missing.' );
+		error.status = 401;
+		return next( error );
+	}
+
+	if ( client_id ) {
+		const parsedRedirectUrl = parseUrl( redirect_to );
+		const redirectQueryString = parse( parsedRedirectUrl.query );
+
+		if ( client_id !== redirectQueryString.client_id ) {
+			recordTracksEvent( 'calypso_login_phishing_attempt', context.query );
+
+			const error = new Error(
+				'The `redirect_to` query parameter is invalid with the given `client_id`.'
+			);
+			error.status = 401;
+			return next( error );
+		}
+	}
+
+	return next();
+}
 
 export default router => {
 	if ( config.isEnabled( 'login/magic-login' ) ) {
@@ -39,6 +77,7 @@ export default router => {
 			redirectJetpack,
 			redirectDefaultLocale,
 			setUpLocale,
+			checkRedirectToIsValid,
 			login,
 			makeLayout
 		);

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -10,6 +10,7 @@ import { createStore, applyMiddleware, compose } from 'redux';
 // library into the `build` chunk.
 // TODO: change this back to `from 'redux-form'` after upgrade to Webpack 4.0 and a version
 //       of Redux Form that uses the `sideEffects: false` flag
+//       Also update server/isomorphic-routing/test/index.js jest.mock accordingly.
 import form from 'redux-form/es/reducer';
 import { mapValues } from 'lodash';
 

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -374,6 +374,7 @@ sections.push( {
 	secondary: false,
 	isomorphic: true,
 	css: 'login',
+	cacheQueryKeys: [ 'client_id' ],
 } );
 
 sections.push( {

--- a/docs/server-side-rendering.md
+++ b/docs/server-side-rendering.md
@@ -24,7 +24,9 @@ React components used on the server will be rendered to HTML by being passed to 
 
 Because it is necessary to serve the redux state along with a server-rendered page, we use two levels of cache on the server: one to [store the redux state](https://github.com/Automattic/wp-calypso/blob/master/server/state-cache/index.js), and one to [store rendered layouts](https://github.com/Automattic/wp-calypso/blob/7ded1642a5b95a30b64fe0a3e462ddd2317c0df2/server/render/index.js#L33).
 
-Both caches use the same key, which is the pathname of the URL. URLs with query args are not cached unless the arg name is present in `context.queryCacheKeys`, in which case the argument or arguments are appended to the key.
+Both caches use the same key, which is the pathname of the URL. URLs with query args are not cached unless all the args are present in `context.queryCacheKeys`, in which case the argument or arguments are appended to the key. If query arguments _not in_ `queryCacheKeys` are detected, server-side rendering is disabled for the request.
+
+This means that all data that was fetched to render a given page is available the next time the corresponding route is hit. A section controller thus only needs to check if the required data is available (using selectors), and dispatch the corresponding fetching action if it isn't; see the [themes controller](../client/my-sites/themes/controller.jsx) for an example.
 
 The render cache will also use error messages as the key, allowing pages such as "Not found" to be cached.
 

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-
 import { isEmpty, pick } from 'lodash';
 import { stringify } from 'qs';
 
@@ -93,7 +92,16 @@ function compose( ...functions ) {
 	return functions.reduceRight( ( composed, f ) => () => f( composed ), () => {} );
 }
 
-export function getCacheKey( context ) {
+/**
+ * Get a key used to cache SSR result for the request, or null to disable the cache.
+ *
+ * @param  {Object}        context                The request context
+ * @param  {Array<string>} context.cacheQueryKeys Query parameter keys that should be cached
+ * @param  {string}        context.pathname       Request path
+ * @param  {Object}        context.query          Query parameters
+ * @return {?string}                              The cache key or null to disable cache
+ */
+export function getCacheKey( { cacheQueryKeys, pathname, query } ) {
 	if ( isEmpty( context.query ) || isEmpty( context.cacheQueryKeys ) ) {
 		return context.pathname;
 	}

--- a/server/isomorphic-routing/test/index.js
+++ b/server/isomorphic-routing/test/index.js
@@ -5,6 +5,8 @@
  */
 import { getCacheKey } from '..';
 
+jest.mock( 'redux-form/es/reducer', () => require( 'lodash' ).identity );
+
 describe( 'getCacheKey', () => {
 	test( 'should return pathname for routes with no query', () => {
 		const context = {

--- a/server/isomorphic-routing/test/index.js
+++ b/server/isomorphic-routing/test/index.js
@@ -14,17 +14,28 @@ describe( 'getCacheKey', () => {
 			query: {},
 			cacheQueryKeys: [],
 		};
+
 		expect( getCacheKey( context ) ).toBe( '/my/path' );
 	} );
 
-	test( 'should return cacheKey for known query params', () => {
+	test( 'should return cacheKey for a known query param', () => {
 		const context = {
 			pathname: '/my/path',
 			query: { cache_me: '1' },
 			cacheQueryKeys: [ 'cache_me' ],
 		};
 
-		expect( getCacheKey( context ) ).toBe( '/my/path?cache_me=1' );
+		expect( getCacheKey( context ) ).toBe( '/my/path?{"cache_me":"1"}' );
+	} );
+
+	test( 'should return cacheKey for multiple known query params', () => {
+		const context = {
+			pathname: '/my/path',
+			query: { cache_me: '1', and_me: '2', me_too: '3' },
+			cacheQueryKeys: [ 'and_me', 'cache_me', 'me_too' ],
+		};
+
+		expect( getCacheKey( context ) ).toBe( '/my/path?{"and_me":"2","cache_me":"1","me_too":"3"}' );
 	} );
 
 	test( 'should return a stable key pathname', () => {
@@ -33,12 +44,19 @@ describe( 'getCacheKey', () => {
 			query: { a: '1', b: '2' },
 			cacheQueryKeys: [ 'a', 'b' ],
 		};
-		const contextSwapped = {
+		const querySwapped = {
 			pathname: '/my/path',
 			query: { b: '2', a: '1' },
 			cacheQueryKeys: [ 'a', 'b' ],
 		};
-		expect( getCacheKey( context ) ).toEqual( getCacheKey( contextSwapped ) );
+		const keysSwapped = {
+			pathname: '/my/path',
+			query: { a: '1', b: '2' },
+			cacheQueryKeys: [ 'b', 'a' ],
+		};
+
+		expect( getCacheKey( context ) ).toEqual( getCacheKey( querySwapped ) );
+		expect( getCacheKey( context ) ).toEqual( getCacheKey( keysSwapped ) );
 	} );
 
 	test( 'should return null if unknown and cahceable query params are mixed', () => {

--- a/server/isomorphic-routing/test/index.js
+++ b/server/isomorphic-routing/test/index.js
@@ -1,0 +1,61 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getCacheKey } from '..';
+
+describe( 'getCacheKey', () => {
+	test( 'should return pathname for routes with no query', () => {
+		const context = {
+			pathname: '/my/path',
+			query: {},
+			cacheQueryKeys: [],
+		};
+		expect( getCacheKey( context ) ).toBe( '/my/path' );
+	} );
+
+	test( 'should return cacheKey for known query params', () => {
+		const context = {
+			pathname: '/my/path',
+			query: { cache_me: '1' },
+			cacheQueryKeys: [ 'cache_me' ],
+		};
+
+		expect( getCacheKey( context ) ).toBe( '/my/path?cache_me=1' );
+	} );
+
+	test( 'should return a stable key pathname', () => {
+		const context = {
+			pathname: '/my/path',
+			query: { a: '1', b: '2' },
+			cacheQueryKeys: [ 'a', 'b' ],
+		};
+		const contextSwapped = {
+			pathname: '/my/path',
+			query: { b: '2', a: '1' },
+			cacheQueryKeys: [ 'a', 'b' ],
+		};
+		expect( getCacheKey( context ) ).toEqual( getCacheKey( contextSwapped ) );
+	} );
+
+	test( 'should return null if unknown and cahceable query params are mixed', () => {
+		const context = {
+			pathname: '/my/path',
+			query: { cache_me: 1, do_not_cache: 'abcd' },
+			cacheQueryKeys: [ 'cache_me' ],
+		};
+
+		expect( getCacheKey( context ) ).toBeNull();
+	} );
+
+	test( 'should return null if unknown query params are detected', () => {
+		const context = {
+			pathname: '/my/path',
+			query: { do_not_cache: 'abcd' },
+			cacheQueryKeys: [],
+		};
+
+		expect( getCacheKey( context ) ).toBeNull();
+	} );
+} );

--- a/server/isomorphic-routing/test/index.js
+++ b/server/isomorphic-routing/test/index.js
@@ -59,7 +59,7 @@ describe( 'getCacheKey', () => {
 		expect( getCacheKey( context ) ).toEqual( getCacheKey( keysSwapped ) );
 	} );
 
-	test( 'should return null if unknown and cahceable query params are mixed', () => {
+	test( 'should return null if unknown and cacheable query params are mixed', () => {
 		const context = {
 			pathname: '/my/path',
 			query: { cache_me: 1, do_not_cache: 'abcd' },

--- a/server/isomorphic-routing/test/index.js
+++ b/server/isomorphic-routing/test/index.js
@@ -6,6 +6,7 @@
 import { getCacheKey, getEnhancedContext } from '..';
 import { pick } from 'lodash';
 
+jest.mock( 'store/store', () => ( { get: () => {} } ) );
 jest.mock( 'redux-form/es/reducer', () => require( 'lodash' ).identity );
 
 describe( 'getEnhancedContext', () => {

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -143,8 +143,7 @@ export function serverRender( req, res ) {
 		context.layout &&
 		! context.user &&
 		cacheKey &&
-		isDefaultLocale( context.lang ) &&
-		! context.query.email_address // Don't do SSR when PIIs are present at the request
+		isDefaultLocale( context.lang )
 	) {
 		context.renderedLayout = render(
 			context.layout,


### PR DESCRIPTION
Disable SSR cache by returning `null` from `getCacheKey` when the query parameters do not match the whitelisted `context.cacheQueryParams`.

Inspired by problems detected in p3btAN-SU-p2

## Testing
- Start up this branch with SSR debug:
  ```
  DEBUG='calypso:server-render' npm start
  ```
- Visit URLs that _should_ be SSR'ed and cached. You should see messages like on the console where Calypso is being served.
  ```
  calypso:server-render cache access for key +0ms /log-in
  ```
  - http://calypso.localhost:3000/log-in
  - http://calypso.localhost:3000/log-in/jetpack
  - http://calypso.localhost:3000/log-in?client_id=someId (you can run the following command: `curl "http://calypso.localhost:3000/log-in?client_id=50916&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D3007b07829b1bf38eb89f6c0f8aab624%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.com%252Fwc-api%252Fwpcom-signin%253Fnext%253Dmy-dashboard%26blog_id%3D0%26wpcom_connect%3D1" | grep redirect_to` to test this, the cache key here should be `/log-in?{"client_id":"50916"}` and redirect_to value should not leak anywhere into the page)
- Visit URLs that should *not* be SSR'ed and cached. You should not see the cache access messages like above
  - http://calypso.localhost:3000/log-in?dont_cache=me
  - http://calypso.localhost:3000/log-in/jetpack?bad_news=param
  - http://calypso.localhost:3000/log-in/jetpack?boolean_param
  - http://calypso.localhost:3000/log-in?client_id=someId&another_param=invalidates_ssr