### PR TITLE
Store: Add _via_calypso as a query param to all WC API requests

### DIFF
--- a/client/extensions/woocommerce/state/data-layer/request/test/index.js
+++ b/client/extensions/woocommerce/state/data-layer/request/test/index.js
@@ -27,7 +27,7 @@ describe( 'handlers', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/placeholder_endpoint&_method=get', json: true } )
+				.query( { path: '/wc/v3/placeholder_endpoint&_via_calypso&_method=get', json: true } )
 				.reply( 200, { data: getResponse } );
 		} );
 
@@ -82,7 +82,7 @@ describe( 'handlers', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/placeholder_endpoint&_method=get', json: true } )
+				.query( { path: '/wc/v3/placeholder_endpoint&_via_calypso&_method=get', json: true } )
 				.reply( 200, { data: getResponse } );
 		} );
 
@@ -147,7 +147,7 @@ describe( 'handlers', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/placeholder_endpoint&_method=post', json: true } )
+				.query( { path: '/wc/v3/placeholder_endpoint&_via_calypso&_method=post', json: true } )
 				.reply( 200, { data: postResponse } );
 		} );
 
@@ -208,7 +208,7 @@ describe( 'handlers', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/placeholder_endpoint&_method=put', json: true } )
+				.query( { path: '/wc/v3/placeholder_endpoint&_via_calypso&_method=put', json: true } )
 				.reply( 200, { data: putResponse } );
 		} );
 
@@ -269,7 +269,7 @@ describe( 'handlers', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/placeholder_endpoint&_method=delete', json: true } )
+				.query( { path: '/wc/v3/placeholder_endpoint&_via_calypso&_method=delete', json: true } )
 				.reply( 200, { data: deleteResponse } );
 		} );
 

--- a/client/extensions/woocommerce/state/sites/payment-methods/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/payment-methods/test/actions.js
@@ -22,7 +22,7 @@ describe( 'actions', () => {
 		nock( 'https://public-api.wordpress.com:443' )
 			.persist()
 			.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-			.query( { path: '/wc/v3/payment_gateways&_method=get', json: true } )
+			.query( { path: '/wc/v3/payment_gateways&_via_calypso&_method=get', json: true } )
 			.reply( 200, {
 				data: [
 					{
@@ -37,7 +37,7 @@ describe( 'actions', () => {
 				],
 			} )
 			.get( '/rest/v1.1/jetpack-blogs/456/rest-api/' )
-			.query( { path: '/wc/v3/payment_gateways&_method=get', json: true } )
+			.query( { path: '/wc/v3/payment_gateways&_via_calypso&_method=get', json: true } )
 			.reply( 200, {
 				data: [
 					{

--- a/client/extensions/woocommerce/state/sites/request.js
+++ b/client/extensions/woocommerce/state/sites/request.js
@@ -32,7 +32,7 @@ const _request = ( method, path, siteId, body, namespace = 'wc/v3' ) => {
 			path: `/jetpack-blogs/${ siteId }/rest-api/`,
 		},
 		{
-			path: `/${ namespace }/${ path }&_method=${ method }`,
+			path: `/${ namespace }/${ path }&_via_calypso&_method=${ method }`,
 			body: body && JSON.stringify( body ),
 			json: true,
 		}

--- a/client/extensions/woocommerce/state/sites/settings/email/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/email/test/actions.js
@@ -104,7 +104,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/settings_email_groups&_method=get', json: true } )
+				.query( { path: '/wc/v3/settings_email_groups&_via_calypso&_method=get', json: true } )
 				.reply( 200, { data } );
 		} );
 
@@ -234,7 +234,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/settings_batch&_method=post', json: true } )
+				.query( { path: '/wc/v3/settings_batch&_via_calypso&_method=post', json: true } )
 				.reply( 200, { data } );
 		} );
 

--- a/client/extensions/woocommerce/state/sites/settings/mailchimp/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/mailchimp/test/actions.js
@@ -40,7 +40,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/mailchimp&_method=get', json: true } )
+				.query( { path: '/wc/v3/mailchimp&_via_calypso&_method=get', json: true } )
 				.reply( 200, {
 					data: {
 						mailchimp_api_key: '6e46d0621d-us16',
@@ -108,7 +108,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/mailchimp/api_key&_method=put', json: true } )
+				.query( { path: '/wc/v3/mailchimp/api_key&_via_calypso&_method=put', json: true } )
 				.reply( 200, {
 					data: {
 						mailchimp_api_key: '12345testing',
@@ -160,7 +160,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/mailchimp/store_info&_method=put', json: true } )
+				.query( { path: '/wc/v3/mailchimp/store_info&_via_calypso&_method=put', json: true } )
 				.reply( 200, {
 					data: {
 						mailchimp_api_key: '12345testing',
@@ -222,7 +222,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/mailchimp/store_info&_method=put', json: true } )
+				.query( { path: '/wc/v3/mailchimp/store_info&_via_calypso&_method=put', json: true } )
 				.reply( 200, {
 					data: {
 						mailchimp_api_key: '12345testing',
@@ -293,7 +293,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/mailchimp/sync&_method=get', json: true } )
+				.query( { path: '/wc/v3/mailchimp/sync&_via_calypso&_method=get', json: true } )
 				.reply( 200, {
 					data: {
 						last_updated_time: '2017-10-17T22:22:44',

--- a/client/extensions/woocommerce/state/sites/settings/products/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/products/test/actions.js
@@ -44,7 +44,7 @@ describe( 'actions', () => {
 				.persist()
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
 				.query( {
-					path: '/wc/v3/settings/products/batch&_method=post',
+					path: '/wc/v3/settings/products/batch&_via_calypso&_method=post',
 					json: true,
 					body: { update: settingsPayload },
 				} )
@@ -102,7 +102,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/settings/products&_method=get', json: true } )
+				.query( { path: '/wc/v3/settings/products&_via_calypso&_method=get', json: true } )
 				.reply( 200, {
 					data: [
 						{
@@ -217,7 +217,7 @@ describe( 'actions', () => {
 				.persist()
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
 				.query( {
-					path: '/wc/v3/settings/products/batch&_method=post',
+					path: '/wc/v3/settings/products/batch&_via_calypso&_method=post',
 					json: true,
 					body: { update: settingsPayload },
 				} )

--- a/client/extensions/woocommerce/state/sites/settings/stripe-connect-account/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/settings/stripe-connect-account/test/actions.js
@@ -70,7 +70,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v1/connect/stripe/account&_method=post', json: true } )
+				.query( { path: '/wc/v1/connect/stripe/account&_via_calypso&_method=post', json: true } )
 				.reply( 200, {
 					data: {
 						success: true,
@@ -114,7 +114,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v1/connect/stripe/account&_method=get', json: true } )
+				.query( { path: '/wc/v1/connect/stripe/account&_via_calypso&_method=get', json: true } )
 				.reply( 200, {
 					data: {
 						success: true,
@@ -169,7 +169,10 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v1/connect/stripe/account/deauthorize&_method=post', json: true } )
+				.query( {
+					path: '/wc/v1/connect/stripe/account/deauthorize&_via_calypso&_method=post',
+					json: true,
+				} )
 				.reply( 200, {
 					data: {
 						success: true,
@@ -209,7 +212,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v1/connect/stripe/oauth/init&_method=post', json: true } )
+				.query( { path: '/wc/v1/connect/stripe/oauth/init&_via_calypso&_method=post', json: true } )
 				.reply( 200, {
 					data: {
 						success: true,
@@ -253,7 +256,10 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v1/connect/stripe/oauth/connect&_method=post', json: true } )
+				.query( {
+					path: '/wc/v1/connect/stripe/oauth/connect&_via_calypso&_method=post',
+					json: true,
+				} )
 				.reply( 200, {
 					data: {
 						success: true,

--- a/client/extensions/woocommerce/state/sites/shipping-zones/test/actions.js
+++ b/client/extensions/woocommerce/state/sites/shipping-zones/test/actions.js
@@ -25,7 +25,7 @@ describe( 'actions', () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
 				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/shipping/zones&_method=get', json: true } )
+				.query( { path: '/wc/v3/shipping/zones&_via_calypso&_method=get', json: true } )
 				.reply( 200, {
 					data: [
 						{

--- a/client/extensions/woocommerce/state/sites/test/request.js
+++ b/client/extensions/woocommerce/state/sites/test/request.js
@@ -19,7 +19,7 @@ describe( 'request', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.get( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/placeholder_endpoint&_method=get', json: true } )
+				.query( { path: '/wc/v3/placeholder_endpoint&_via_calypso&_method=get', json: true } )
 				.reply( 200, { data: getResponse } );
 		} );
 
@@ -48,7 +48,7 @@ describe( 'request', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/placeholder_endpoint&_method=post', json: true } )
+				.query( { path: '/wc/v3/placeholder_endpoint&_via_calypso&_method=post', json: true } )
 				.reply( 201, { data: postResponse } );
 		} );
 
@@ -77,7 +77,7 @@ describe( 'request', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/placeholder_endpoint&_method=put', json: true } )
+				.query( { path: '/wc/v3/placeholder_endpoint&_via_calypso&_method=put', json: true } )
 				.reply( 200, { data: putResponse } );
 		} );
 
@@ -105,7 +105,7 @@ describe( 'request', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.post( '/rest/v1.1/jetpack-blogs/123/rest-api/' )
-				.query( { path: '/wc/v3/placeholder_endpoint&_method=delete', json: true } )
+				.query( { path: '/wc/v3/placeholder_endpoint&_via_calypso&_method=delete', json: true } )
 				.reply( 200, { data: deleteResponse } );
 		} );
 


### PR DESCRIPTION
Fixes #22596 

See also https://github.com/Automattic/wc-calypso-bridge/pull/32

To test:
* Run this branch locally
* Since this change touches EVERY WC API call, test all the things - creating, reading, updating and deleting products, promotions, orders and settings
* Install and activate https://github.com/Automattic/wc-calypso-bridge/pull/32 on an automated test + atomic + store site

THEN

* Follow testing instructions on D10144 to confirm that `created_via` is set to `calypso` 

OR

* Install and activate https://github.com/allendav/wp-simple-admin-logger
* Add the wp_simple_admin_logger lines you see below to https://github.com/Automattic/wc-calypso-bridge/pull/32:

```
	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
	$known_fragments = array(
		'&_via_calypso'           => 'calypso',
		'/wp-json/wc/v2'          => 'rest-api-v2',
		'/?rest_route=%2Fwc%2Fv2' => 'rest-api-v2-rest-route',
		'/wp-json/wc/v3'          => 'rest-api-v3',
		'/?rest_route=%2Fwc%2Fv3' => 'rest-api-v3-rest-route',
		'/post-new.php'           => 'post-new',
	);

	foreach ( $known_fragments as $known_fragment => $context ) {
		if ( false !== strpos( $request_uri, $known_fragment ) ) {
			function_exists( 'wp_simple_admin_logger' ) && wp_simple_admin_logger( "request_uri: $request_uri" );
			function_exists( 'wp_simple_admin_logger' ) && wp_simple_admin_logger( "--> context = $context" );
			return $context;
		}
	}

	return 'unknown';
```
* Create a new product using calypso
* Ensure you see log entries with context = calypso under wp-admin > Tools > WP Simple Admin Logger, e.g. like these:

```
2018-02-19T12:46:39+00:00 --> context = calypso
2018-02-19T12:46:39+00:00 request_uri: /?rest_route=%2Fwc%2Fv3%2Fproducts&_via_calypso&_method=post&_for=jetpack&token=ZS%28%4
```