### PR TITLE
Reimplement Spinner with a simple single-element CSS animation

### DIFF
--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -21,8 +21,7 @@
 	height: 150px;
 }
 
-.edit-gravatar__spinner,
-.edit-gravatar__spinner.is-fallback.spinner {
+.edit-gravatar__spinner {
 	position: absolute;
 		top: 50%;
 		left: 50%;

--- a/client/blocks/site-icon/style.scss
+++ b/client/blocks/site-icon/style.scss
@@ -22,13 +22,6 @@
 		bottom: 0;
 		left: 0;
 	background-color: rgba( $white, 0.75 );
-
-	.spinner__image {
-		position: absolute;
-			top: 50%;
-			left: 50%;
-		transform: translate( -50%, -50% );
-	}
 }
 
 .site-icon__img {

--- a/client/components/email-verification/email-verification-dialog/style.css
+++ b/client/components/email-verification/email-verification-dialog/style.css
@@ -46,6 +46,6 @@
 }
 
 .email-verification-dialog__confirmation-dialog-spinner {
-	display: inline-block;
+	display: inline-flex;
 	vertical-align: -25%;
 }

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -198,13 +198,10 @@
 .search.is-searching .spinner {
 	flex: 0 0 auto;
 	display: flex;
-	align-items: center;
+	width: 50px;
 	height: 100%;
+	background-color: $white;
 	z-index: z-index( '.search', '.search.is-searching .spinner' );
-
-	.spinner__image {
-		width: 50px;
-	}
 }
 
 .animating.search-opening .search input {

--- a/client/components/spinner/README.md
+++ b/client/components/spinner/README.md
@@ -3,8 +3,6 @@ Spinner
 
 Spinner is a React component for rendering a loading indicator.
 
-<img src="https://cldup.com/H27NKdxFBN.gif" alt="Demo" />
-
 __Please exercise caution in deciding to use a spinner in your component.__ A lone spinner is a poor user-experience and conveys little context to what the user should expect from the page. Refer to [the _Reactivity and Loading States_ guide](https://github.com/Automattic/wp-calypso/blob/master/docs/reactivity.md) for more information on building fast interfaces and making the most of data already available to use.
 
 ## Usage
@@ -16,7 +14,7 @@ import Spinner from 'components/spinner';
 export default class extends React.Component {
 	render() {
 		return <Spinner />;
-	} 
+	}
 }
 ```
 
@@ -27,4 +25,3 @@ The following props can be passed to the Spinner component:
 | PROPERTY     | TYPE     | REQUIRED | DEFAULT | DESCRIPTION |
 | ------------ | -------- | -------- | ------- | ----------- |
 | **size**     | *number* | no       | `20`    | The width and height of the spinner, in pixels. |
-| **duration** | *number* | no       | `3000`  | The duration of a single spin animation, in milliseconds. |

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -24,7 +24,7 @@ export default class Spinner extends PureComponent {
 		const style = {
 			width: this.props.size,
 			height: this.props.size,
-			'font-size': this.props.size, // allows border-width to be specified in em units
+			fontSize: this.props.size, // allows border-width to be specified in em units
 		};
 
 		return (

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -27,6 +27,12 @@ export default class Spinner extends PureComponent {
 			'font-size': this.props.size, // allows border-width to be specified in em units
 		};
 
-		return <div className={ className } style={ style } />;
+		return (
+			<div className={ className } style={ style }>
+				<div className="spinner__outer">
+					<div className="spinner__inner" />
+				</div>
+			</div>
+		);
 	}
 }

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -28,8 +28,8 @@ export default class Spinner extends PureComponent {
 		};
 
 		return (
-			<div className={ className } style={ style }>
-				<div className="spinner__outer">
+			<div className={ className }>
+				<div className="spinner__outer" style={ style }>
 					<div className="spinner__inner" />
 				</div>
 			</div>

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -8,141 +8,25 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 
-/**
- * Constants
- */
-
-/**
- * Defines whether the current browser supports CSS animations for SVG
- * elements. Specifically, this returns false for Internet Explorer and Edge.
- *
- * @type {Boolean} True if the browser supports CSS animations for SVG
- *                 elements, or false otherwise.
- */
-const isSVGCSSAnimationSupported = ( () => {
-	if ( ! global.window ) {
-		return false;
-	}
-
-	return ! /(MSIE |Trident\/|Edge\/)/.test( global.window.navigator.userAgent );
-} )();
-
 export default class Spinner extends PureComponent {
 	static propTypes = {
 		className: PropTypes.string,
 		size: PropTypes.number,
-		duration: PropTypes.number,
 	};
-
-	static instances = 0;
 
 	static defaultProps = {
 		size: 20,
-		duration: 3000,
 	};
 
-	constructor() {
-		super();
-		this.state = {
-			// We won't always have access to user-agent in server-side context, so
-			// initialize the spinner with fallback animations and check for support
-			// in componentDidMount()
-			isSVGCSSAnimationSupported: false,
-		};
-	}
+	render() {
+		const className = classNames( 'spinner', this.props.className );
 
-	componentWillMount() {
-		this.setState( {
-			instanceId: ++Spinner.instances,
-		} );
-	}
-
-	componentDidMount() {
-		if ( isSVGCSSAnimationSupported ) {
-			// Turning off eslint rule on this line as an exception — we want to trigger
-			// a re-render if we're progressively enhancing with SVG animations.
-			// eslint-disable-next-line react/no-did-mount-set-state
-			this.setState( {
-				isSVGCSSAnimationSupported: isSVGCSSAnimationSupported,
-			} );
-		}
-	}
-
-	getClassName() {
-		return classNames( 'spinner', this.props.className, {
-			'is-fallback': ! this.state.isSVGCSSAnimationSupported,
-		} );
-	}
-
-	renderFallback() {
 		const style = {
 			width: this.props.size,
 			height: this.props.size,
+			'font-size': this.props.size, // allows border-width to be specified in em units
 		};
 
-		return (
-			<div className={ this.getClassName() } style={ style }>
-				<span className="spinner__progress is-left" />
-				<span className="spinner__progress is-right" />
-			</div>
-		);
-	}
-
-	render() {
-		if ( ! this.state.isSVGCSSAnimationSupported ) {
-			return this.renderFallback();
-		}
-
-		const { instanceId } = this.state;
-
-		return (
-			<div className={ this.getClassName() }>
-				<svg
-					className="spinner__image"
-					width={ this.props.size }
-					height={ this.props.size }
-					viewBox="0 0 100 100"
-				>
-					<defs>
-						<mask id={ `maskBorder${ instanceId }` }>
-							<rect x="0" y="0" width="100%" height="100%" fill="white" />
-							<circle r="46%" cx="50%" cy="50%" fill="black" />
-						</mask>
-						<mask id={ `maskDonut${ instanceId }` }>
-							<rect x="0" y="0" width="100%" height="100%" fill="black" />
-							<circle r="46%" cx="50%" cy="50%" fill="white" />
-							<circle r="30%" cx="50%" cy="50%" fill="black" />
-						</mask>
-						<mask id={ `maskLeft${ instanceId }` }>
-							<rect x="0" y="0" width="50%" height="100%" fill="white" />
-						</mask>
-						<mask id={ `maskRight${ instanceId }` }>
-							<rect x="50%" y="0" width="50%" height="100%" fill="white" />
-						</mask>
-					</defs>
-					<circle
-						className="spinner__border"
-						r="50%"
-						cx="50%"
-						cy="50%"
-						mask={ `url( #maskBorder${ instanceId } )` }
-					/>
-					<g mask={ `url( #maskDonut${ instanceId } )` }>
-						<g mask={ `url( #maskLeft${ instanceId } )` }>
-							<rect className="spinner__progress is-left" x="0" y="0" width="50%" height="100%" />
-						</g>
-						<g mask={ `url( #maskRight${ instanceId } )` }>
-							<rect
-								className="spinner__progress is-right"
-								x="50%"
-								y="0"
-								width="50%"
-								height="100%"
-							/>
-						</g>
-					</g>
-				</svg>
-			</div>
-		);
+		return <div className={ className } style={ style } />;
 	}
 }

--- a/client/components/spinner/style.scss
+++ b/client/components/spinner/style.scss
@@ -15,11 +15,11 @@
 }
 
 .spinner__outer {
-	border-top-color: #00aadc;
+	border-top-color: $blue-medium;
 }
 
 .spinner__inner {
-	border-top-color: #00aadc;
-  border-right-color: #00aadc;
+	border-top-color: $blue-medium;
+  border-right-color: $blue-medium;
   opacity: 0.4;
 }

--- a/client/components/spinner/style.scss
+++ b/client/components/spinner/style.scss
@@ -4,9 +4,13 @@
 	}
 }
 
+.spinner {
+	display: flex;
+	align-items: center;
+}
+
 .spinner__outer, .spinner__inner {
-	width: 100%;
-  height: 100%;
+	margin: auto;
 	box-sizing: border-box;
   border: 0.1em solid transparent;
 	border-radius: 50%;
@@ -19,6 +23,8 @@
 }
 
 .spinner__inner {
+	width: 100%;
+  height: 100%;
 	border-top-color: $blue-medium;
   border-right-color: $blue-medium;
   opacity: 0.4;

--- a/client/components/spinner/style.scss
+++ b/client/components/spinner/style.scss
@@ -1,128 +1,16 @@
-@keyframes rotate-spinner__right {
-	0% {
-		transform: rotate( 0deg );
-	}
-	25% {
-		transform: rotate( 180deg );
-	}
-	50% {
-		transform: rotate( 180deg );
-	}
-	75% {
-		transform: rotate( 360deg );
-	}
+@keyframes rotate-spinner {
 	100% {
 		transform: rotate( 360deg );
 	}
 }
 
-@keyframes rotate-spinner__left {
-	0% {
-		transform: rotate( 0deg );
-	}
-	25% {
-		transform: rotate( 0deg );
-	}
-	50% {
-		transform: rotate( 180deg );
-	}
-	75% {
-		transform: rotate( 180deg );
-	}
-	100% {
-		transform: rotate( 360deg );
-	}
-}
-
-.spinner.is-fallback {
-	position: relative;
-	border-radius: 100%;
-	background-color: $gray-lighten-20;
-
-	&::before,
-	&::after {
-		content: '';
-		position: absolute;
-		background-color: $white;
-		border-radius: 50%;
-	}
-
-	&::before {
-		width: 90%;
-		height: 90%;
-		top: 5%;
-		left: 5%;
-	}
-
-	&::after {
-		width: 70%;
-		height: 70%;
-		top: 15%;
-		left: 15%;
-	}
-}
-
-.spinner__image {
-	display: block;
-}
-
-.spinner__border {
-	fill: $gray-lighten-20;
-}
-
-.spinner__progress {
-	animation: 3s linear infinite;
-	transform-origin: 50px 50px;
-	fill: $blue-medium;
-}
-
-.spinner.is-fallback .spinner__progress {
-	position: absolute;
-	overflow: hidden;
-	width: 50%;
-	height: 100%;
-	animation: none;
-
-	&::before {
-		content: '';
-		position: absolute;
-		width: 100%;
-		height: 100%;
-		animation: 3s linear infinite;
-		border-radius: 9999px;
-		background-color: $blue-medium;
-		fill: none;
-	}
-
-	&.is-left {
-		left: 0;
-
-		&::before {
-			left: 100%;
-			border-top-left-radius: 0;
-			border-bottom-left-radius: 0;
-			transform-origin: 0 50%;
-		}
-	}
-
-	&.is-right {
-		left: 50%;
-
-		&::before {
-			left: -100%;
-			border-top-right-radius: 0;
-			border-bottom-right-radius: 0;
-			transform-origin: 100% 50%;
-		}
-	}
-}
-
-.spinner__progress.is-left,
-.spinner.is-fallback .spinner__progress.is-left::before {
-	animation-name: rotate-spinner__left;
-}
-
-.spinner__progress.is-right,
-.spinner.is-fallback .spinner__progress.is-right::before {
-	animation-name: rotate-spinner__right;
+.spinner {
+	box-sizing: border-box;
+	border-radius: 50%;
+	border-width: 0.1em;
+	border-style: solid;
+	border-color: transparent;
+	border-top-color: $blue-medium;
+	animation: 1.5s linear infinite;
+	animation-name: rotate-spinner;
 }

--- a/client/components/spinner/style.scss
+++ b/client/components/spinner/style.scss
@@ -4,13 +4,22 @@
 	}
 }
 
-.spinner {
+.spinner__outer, .spinner__inner {
+	width: 100%;
+  height: 100%;
 	box-sizing: border-box;
+  border: 0.1em solid transparent;
 	border-radius: 50%;
-	border-width: 0.1em;
-	border-style: solid;
-	border-color: transparent;
-	border-top-color: $blue-medium;
-	animation: 1.5s linear infinite;
+	animation: 3s linear infinite;
 	animation-name: rotate-spinner;
+}
+
+.spinner__outer {
+	border-top-color: #00aadc;
+}
+
+.spinner__inner {
+	border-top-color: #00aadc;
+  border-right-color: #00aadc;
+  opacity: 0.4;
 }

--- a/client/components/tinymce/plugins/embed/dialog.jsx
+++ b/client/components/tinymce/plugins/embed/dialog.jsx
@@ -305,7 +305,7 @@ export class EmbedDialog extends React.Component {
 				<div className="embed__preview-container">
 					{ ( isLoading || isError ) && (
 						<div className={ statusClassNames }>
-							{ isLoading && <Spinner className="embed__loading-spinner" size={ 20 } /> }
+							{ isLoading && <Spinner /> }
 							{ isError && (
 								<div className="embed__status-error">
 									{ this.getError( cachedMarkup.renderMarkup ) }

--- a/client/components/tinymce/plugins/embed/style.scss
+++ b/client/components/tinymce/plugins/embed/style.scss
@@ -46,11 +46,7 @@
 					left: 50%;
 					width: auto;
 					padding: 0;
-					margin-top: -10px; // move the spinner 10px upwards, to offset centering
-				}
-
-				.embed__loading-spinner .spinner__image {
-					vertical-align: middle;
+					transform: translate( -50%, -50% );
 				}
 			}
 

--- a/client/components/webpack-build-monitor/style.scss
+++ b/client/components/webpack-build-monitor/style.scss
@@ -32,10 +32,6 @@
 	display: block;
 }
 
-.webpack-build-monitor .spinner__progress {
-	fill: currentColor;
-}
-
-.webpack-build-monitor .spinner__border {
-	fill: lighten( $alert-green, 30% );
+.webpack-build-monitor .spinner {
+	border-top-color: currentColor;
 }

--- a/client/components/webpack-build-monitor/style.scss
+++ b/client/components/webpack-build-monitor/style.scss
@@ -32,6 +32,13 @@
 	display: block;
 }
 
-.webpack-build-monitor .spinner {
-	border-top-color: currentColor;
+.webpack-build-monitor {
+	.spinner__outer {
+		border-top-color: currentColor;
+	}
+
+	.spinner__inner {
+		border-top-color: currentColor;
+		border-right-color: currentColor;
+	}
 }


### PR DESCRIPTION
Reimplements the complicated SVG Spinner that doesn't perform well (requires painting the SVG into a new texture on each animation frame) with a very simple rotated CSS element that's painted only once, uploaded to the GPU and animated with a matrix transform there. See p9oQ9f-23-p2 for context.

Here's how it looks like:

![screen capture on 2018-02-19 at 23-10-09](https://user-images.githubusercontent.com/664258/36398998-2431ae64-15ca-11e8-9c32-0b477b8b867b.gif)

Ccing @iamtakashi and @folletto for a design review. Any change suggestions are welcome, just keep in mind that to keep the spinner simple and performant, it should be a single bitmap that is animated by applying matrix transforms to it: translations and rotations.

Reimplementing the original spinner would be possible using two clipped elements with two independent animations, but let's first see if a single-elem version is acceptable.

Before this can be merged, more work is needed. Namely, updating all the custom `.spinner` CSS styles used at quite a few places.