### PR TITLE
Reader: add FollowMenu block

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -39,6 +39,7 @@
 @import 'blocks/domain-to-plan-nudge/style';
 @import 'blocks/edit-gravatar/style';
 @import 'blocks/follow-button/style';
+@import 'blocks/follow-menu/style';
 @import 'blocks/eligibility-warnings/style';
 @import 'blocks/image-editor/style';
 @import 'blocks/inline-help/style';

--- a/client/blocks/follow-menu/README.md
+++ b/client/blocks/follow-menu/README.md
@@ -1,0 +1,3 @@
+# Follow Menu
+
+This component is used to display a follow/unfollow button with an attached menu for managing notification settings.

--- a/client/blocks/follow-menu/button.jsx
+++ b/client/blocks/follow-menu/button.jsx
@@ -71,8 +71,17 @@ class FollowMenuButton extends React.Component {
 			menuClasses.push( 'is-disabled' );
 		}
 
-		const followingIcon = <Gridicon key="following" icon="reader-following" size={ iconSize } />;
-		const followIcon = <Gridicon key="follow" icon="reader-follow" size={ iconSize } />;
+		const followingIcon = (
+			<Gridicon
+				className="follow-menu__icon"
+				key="following"
+				icon="reader-following"
+				size={ iconSize }
+			/>
+		);
+		const followIcon = (
+			<Gridicon className="follow-menu__icon" key="follow" icon="reader-follow" size={ iconSize } />
+		);
 		const followLabelElement = (
 			<span key="label" className="follow-menu__label">
 				{ label }
@@ -82,17 +91,16 @@ class FollowMenuButton extends React.Component {
 		return (
 			<ButtonGroup className={ menuClasses.join( ' ' ) }>
 				<Button
-					primary
 					compact={ this.props.compact }
 					onClick={ this.toggleFollow }
 					title={ label }
-					className="follow-menu__follow-button"
+					className="follow-menu__button"
 				>
 					{ [ followingIcon, followIcon, followLabelElement ] }
 				</Button>
 				{ this.props.following && (
-					<Button primary compact={ this.props.compact }>
-						<Gridicon icon="chevron-down" />
+					<Button compact={ this.props.compact } className="follow-menu__button">
+						<Gridicon className="follow-menu__icon" icon="chevron-down" />
 					</Button>
 				) }
 			</ButtonGroup>

--- a/client/blocks/follow-menu/button.jsx
+++ b/client/blocks/follow-menu/button.jsx
@@ -74,7 +74,7 @@ class FollowMenuButton extends React.Component {
 		const followingIcon = <Gridicon key="following" icon="reader-following" size={ iconSize } />;
 		const followIcon = <Gridicon key="follow" icon="reader-follow" size={ iconSize } />;
 		const followLabelElement = (
-			<span key="label" className="follow-button__label">
+			<span key="label" className="follow-menu__label">
 				{ label }
 			</span>
 		);
@@ -86,7 +86,7 @@ class FollowMenuButton extends React.Component {
 					compact={ this.props.compact }
 					onClick={ this.toggleFollow }
 					title={ label }
-					className="follow-menu-follow-button"
+					className="follow-menu__follow-button"
 				>
 					{ [ followingIcon, followIcon, followLabelElement ] }
 				</Button>

--- a/client/blocks/follow-menu/button.jsx
+++ b/client/blocks/follow-menu/button.jsx
@@ -24,7 +24,7 @@ class FollowMenuButton extends React.Component {
 		disabled: PropTypes.bool,
 		followLabel: PropTypes.string,
 		followingLabel: PropTypes.string,
-		isCompact: PropTypes.bool,
+		compact: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -33,7 +33,7 @@ class FollowMenuButton extends React.Component {
 		iconSize: 20,
 		tagName: 'button',
 		disabled: false,
-		isCompact: false,
+		compact: false,
 	};
 
 	componentWillMount() {
@@ -59,7 +59,7 @@ class FollowMenuButton extends React.Component {
 
 	render() {
 		let label = this.props.followLabel ? this.props.followLabel : this.strings.FOLLOW;
-		const menuClasses = [ 'button', 'follow-menu', 'has-icon', this.props.className ];
+		const menuClasses = [ 'follow-menu', this.props.className ];
 		const iconSize = this.props.iconSize;
 
 		if ( this.props.following ) {
@@ -80,18 +80,21 @@ class FollowMenuButton extends React.Component {
 		);
 
 		return (
-			<ButtonGroup className="follow-menu">
+			<ButtonGroup className={ menuClasses.join( ' ' ) }>
 				<Button
 					primary
-					compact={ this.props.isCompact }
+					compact={ this.props.compact }
 					onClick={ this.toggleFollow }
 					title={ label }
+					className="follow-menu-follow-button"
 				>
 					{ [ followingIcon, followIcon, followLabelElement ] }
 				</Button>
-				<Button primary compact={ this.props.isCompact }>
-					<Gridicon icon="chevron-down" />
-				</Button>
+				{ this.props.following && (
+					<Button primary compact={ this.props.compact }>
+						<Gridicon icon="chevron-down" />
+					</Button>
+				) }
 			</ButtonGroup>
 		);
 	}

--- a/client/blocks/follow-menu/button.jsx
+++ b/client/blocks/follow-menu/button.jsx
@@ -1,0 +1,100 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { noop } from 'lodash';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import ButtonGroup from 'components/button-group';
+import Button from 'components/button';
+
+class FollowMenuButton extends React.Component {
+	static propTypes = {
+		following: PropTypes.bool.isRequired,
+		onFollowToggle: PropTypes.func,
+		iconSize: PropTypes.number,
+		tagName: PropTypes.oneOfType( [ PropTypes.string, PropTypes.func ] ),
+		disabled: PropTypes.bool,
+		followLabel: PropTypes.string,
+		followingLabel: PropTypes.string,
+		isCompact: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		following: false,
+		onFollowToggle: noop,
+		iconSize: 20,
+		tagName: 'button',
+		disabled: false,
+		isCompact: false,
+	};
+
+	componentWillMount() {
+		this.strings = {
+			FOLLOW: this.props.translate( 'Follow' ),
+			FOLLOWING: this.props.translate( 'Following' ),
+		};
+	}
+
+	toggleFollow = event => {
+		if ( event ) {
+			event.preventDefault();
+		}
+
+		if ( this.props.disabled ) {
+			return;
+		}
+
+		if ( this.props.onFollowToggle ) {
+			this.props.onFollowToggle( ! this.props.following );
+		}
+	};
+
+	render() {
+		let label = this.props.followLabel ? this.props.followLabel : this.strings.FOLLOW;
+		const menuClasses = [ 'button', 'follow-menu', 'has-icon', this.props.className ];
+		const iconSize = this.props.iconSize;
+
+		if ( this.props.following ) {
+			menuClasses.push( 'is-following' );
+			label = this.props.followingLabel ? this.props.followingLabel : this.strings.FOLLOWING;
+		}
+
+		if ( this.props.disabled ) {
+			menuClasses.push( 'is-disabled' );
+		}
+
+		const followingIcon = <Gridicon key="following" icon="reader-following" size={ iconSize } />;
+		const followIcon = <Gridicon key="follow" icon="reader-follow" size={ iconSize } />;
+		const followLabelElement = (
+			<span key="label" className="follow-button__label">
+				{ label }
+			</span>
+		);
+
+		return (
+			<ButtonGroup className="follow-menu">
+				<Button
+					primary
+					compact={ this.props.isCompact }
+					onClick={ this.toggleFollow }
+					title={ label }
+				>
+					{ [ followingIcon, followIcon, followLabelElement ] }
+				</Button>
+				<Button primary compact={ this.props.isCompact }>
+					<Gridicon icon="chevron-down" />
+				</Button>
+			</ButtonGroup>
+		);
+	}
+}
+
+export default localize( FollowMenuButton );

--- a/client/blocks/follow-menu/docs/example.jsx
+++ b/client/blocks/follow-menu/docs/example.jsx
@@ -24,7 +24,17 @@ export default class FollowMenuExample extends React.PureComponent {
 					<FollowMenu following={ true } />
 				</Card>
 				<Card compact>
+					<h3>Disabled</h3>
 					<FollowMenu disabled={ true } />
+				</Card>
+				<Card compact>
+					<h3>Compact</h3>
+					<div>
+						<FollowMenu compact />
+					</div>
+					<div style={ { marginTop: 1 + 'em' } }>
+						<FollowMenu compact following={ true } />
+					</div>
 				</Card>
 				<Card compact>
 					<h3>With custom label</h3>

--- a/client/blocks/follow-menu/docs/example.jsx
+++ b/client/blocks/follow-menu/docs/example.jsx
@@ -1,0 +1,36 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FollowMenu from 'blocks/follow-menu/button';
+import Card from 'components/card/compact';
+
+export default class FollowMenuExample extends React.PureComponent {
+	static displayName = 'FollowMenuExample';
+
+	render() {
+		return (
+			<div>
+				<Card compact>
+					<FollowMenu following={ false } />
+				</Card>
+				<Card compact>
+					<FollowMenu following={ true } />
+				</Card>
+				<Card compact>
+					<FollowMenu disabled={ true } />
+				</Card>
+				<Card compact>
+					<h3>With custom label</h3>
+					<FollowMenu followLabel="Follow Tag" />
+				</Card>
+			</div>
+		);
+	}
+}

--- a/client/blocks/follow-menu/style.scss
+++ b/client/blocks/follow-menu/style.scss
@@ -1,18 +1,98 @@
+$follow-menu-gray-disabled: $gray-lighten-20;
+
 .follow-menu {
 	.gridicons-reader-follow {
 		display: inline;
+		pointer-events: auto;
 	}
 
 	.gridicons-reader-following {
 		display: none;
 	}
 
+	.follow-menu__icon {
+		fill: $blue-medium;
+	}
+
+	.follow-menu__label {
+		color: $blue-medium;
+		padding-left: 2px;
+
+		&:hover {
+			color: $blue-medium;
+		}
+
+		@include breakpoint( "<660px" ) {
+			display: none;
+		}
+	}
+
+	.follow-menu__button {
+		border-color: $blue-medium;
+
+		&:hover {
+			border-color: $blue-medium;
+		}
+
+		&.is-compact {
+			.follow-menu__label {
+				padding-left: 0;
+			}
+
+			.follow-menu__icon {
+				margin-right: 2px;
+			}
+		}
+	}
+
 	&.is-following {
 		.gridicons-reader-follow {
 			display: none;
 		}
+
 		.gridicons-reader-following {
 			display: inline;
+			pointer-events: auto;
+		}
+
+		.follow-menu__icon {
+			fill: $alert-green;
+		}
+
+		.follow-menu__label {
+			color: $alert-green;
+		}
+
+		.follow-menu__button {
+			border-color: $alert-green;
+		}
+	}
+
+	&.is-disabled {
+		@include no-select();
+		color: $follow-menu-gray-disabled;
+		border-color: $follow-menu-gray-disabled;
+		pointer-events: none;
+
+		.follow-menu__label {
+			color: $follow-menu-gray-disabled;
+		}
+
+		.follow-menu__icon {
+			fill: $follow-menu-gray-disabled;
+		}
+
+		.follow-menu__button {
+			border-color: $follow-menu-gray-disabled;
+		}
+
+		&:hover {
+			color: $follow-menu-gray-disabled;
+			cursor: default;
+
+			.follow-menu__icon {
+				fill: $follow-menu-gray-disabled;
+			}
 		}
 	}
 }

--- a/client/blocks/follow-menu/style.scss
+++ b/client/blocks/follow-menu/style.scss
@@ -1,6 +1,7 @@
-$follow-menu-gray-disabled: $gray-lighten-20;
+$follow-menu-gray-disabled: lighten( $gray, 20% );
 
 .follow-menu {
+
 	.gridicons-reader-follow {
 		display: inline;
 		pointer-events: auto;
@@ -10,13 +11,14 @@ $follow-menu-gray-disabled: $gray-lighten-20;
 		display: none;
 	}
 
-	.follow-menu__icon {
+	.gridicon.follow-menu__icon {
 		fill: $blue-medium;
+		top: 5px;
 	}
 
 	.follow-menu__label {
 		color: $blue-medium;
-		padding-left: 2px;
+		padding-left: 3px;
 
 		&:hover {
 			color: $blue-medium;
@@ -35,17 +37,23 @@ $follow-menu-gray-disabled: $gray-lighten-20;
 		}
 
 		&.is-compact {
-			.follow-menu__label {
-				padding-left: 0;
+
+			.gridicon.follow-menu__icon {
+				top: 6px;
 			}
 
-			.follow-menu__icon {
-				margin-right: 2px;
+			.gridicon.gridicons-chevron-down {
+				left: 1px;
+			}
+
+			.follow-menu__label {
+				padding-left: 0;
 			}
 		}
 	}
 
 	&.is-following {
+
 		.gridicons-reader-follow {
 			display: none;
 		}
@@ -69,9 +77,10 @@ $follow-menu-gray-disabled: $gray-lighten-20;
 	}
 
 	&.is-disabled {
+
 		@include no-select();
-		color: $follow-menu-gray-disabled;
 		border-color: $follow-menu-gray-disabled;
+		color: $follow-menu-gray-disabled;
 		pointer-events: none;
 
 		.follow-menu__label {

--- a/client/blocks/follow-menu/style.scss
+++ b/client/blocks/follow-menu/style.scss
@@ -1,0 +1,18 @@
+.follow-menu {
+	.gridicons-reader-follow {
+		display: inline;
+	}
+
+	.gridicons-reader-following {
+		display: none;
+	}
+
+	&.is-following {
+		.gridicons-reader-follow {
+			display: none;
+		}
+		.gridicons-reader-following {
+			display: inline;
+		}
+	}
+}

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -27,6 +27,7 @@ import AuthorSelector from 'blocks/author-selector/docs/example';
 import CommentButtons from 'blocks/comment-button/docs/example';
 import DisconnectJetpackDialog from 'blocks/disconnect-jetpack/docs/example';
 import FollowButton from 'blocks/follow-button/docs/example';
+import FollowMenu from 'blocks/follow-menu/docs/example';
 import LikeButtons from 'blocks/like-button/docs/example';
 import PostSchedule from 'components/post-schedule/docs/example';
 import PostSelector from 'my-sites/post-selector/docs/example';
@@ -122,6 +123,7 @@ export default class AppComponents extends React.Component {
 					<DisconnectJetpackDialog />
 					<CreditCardForm />
 					<FollowButton />
+					<FollowMenu />
 					<HappinessSupport />
 					<ImageEditor />
 					<VideoEditor />


### PR DESCRIPTION
Adds a new block that combines the follow button with email and notification settings, as designed by @jancavan.

This PR adds the button only and is not yet connected to following state. The dropdown menu for extra options when following will also be added later.

![cards1](https://user-images.githubusercontent.com/17325/36407193-a3406f66-1650-11e8-9112-906fe09db8a8.png)
![fullpost](https://user-images.githubusercontent.com/17325/36407191-a3015cea-1650-11e8-90d0-50fcd450973e.png)
![site-results-search](https://user-images.githubusercontent.com/17325/36407194-a37c3226-1650-11e8-9177-07d6e3be3784.png)

### To test

Visit http://calypso.localhost:3000/devdocs/blocks/follow-menu.
