### PR TITLE
Payment methods: Checking allowed payment methods array when selecting Brazil

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { extend } from 'lodash';
+import { extend, isArray } from 'lodash';
 import update from 'immutability-helper';
 import i18n from 'i18n-calypso';
 import config from 'config';
@@ -209,7 +209,10 @@ function isPaymentMethodEnabled( cart, method ) {
 		return false;
 	}
 
-	return cart.allowed_payment_methods.indexOf( methodClassName ) >= 0;
+	return (
+		isArray( cart.allowed_payment_methods ) &&
+		cart.allowed_payment_methods.indexOf( methodClassName ) >= 0
+	);
 }
 
 export {


### PR DESCRIPTION
Previously, when selecting Brazil as your payment country, we were checking for the existence of a payment method in a non-existent array (`cart.allowed_payment_methods`). 

This PR simply checks if the array exists before we do an `indexOf` check.

![feb-20-2018 16-56-59](https://user-images.githubusercontent.com/6458278/36421650-5d4c51d2-165f-11e8-96db-eb3db03fcf36.gif)

## Testing
1. Try to update or add a credit card at http://calypso.localhost:3000/me/purchases
2. Select __Brazil__ as the payment country

### Expectations
You should be able to use/submit the form

Error reported in pNPgK-3od-p2