### PR TITLE
NUX: Don't allow adding unsupported TLD for transfer in NUX

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -400,7 +400,7 @@ class TransferDomainStep extends React.Component {
 					return { precheck: prevState.domain && ! submittingAvailability && ! submittingWhois };
 				} );
 
-				if ( this.props.isSignupStep && ! this.transferIsRestricted() ) {
+				if ( this.props.isSignupStep && this.state.domain && ! this.transferIsRestricted() ) {
 					this.props.onTransferDomain( domain );
 				}
 			}


### PR DESCRIPTION
Users were able to add an unsupported transfer TLD to cart in NUX.
It would fail on checkout, but shouldn't be able to do.

Fixes: https://github.com/Automattic/wp-calypso/issues/22558