### PR TITLE
Login: Remove client_id from log-in cacheQueryKeys

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -24,8 +24,6 @@ import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selecto
 const enhanceContextWithLogin = context => {
 	const { path, params: { flow, isJetpack, socialService, twoFactorAuthType } } = context;
 
-	context.cacheQueryKeys = [ 'client_id' ];
-
 	context.primary = (
 		<WPLogin
 			isJetpack={ isJetpack === 'jetpack' }


### PR DESCRIPTION
client_id must be used with redirect_to, which may contain sensitive
information. Do not server-side render requests with client_id.

See p1519133919000135-slack-amber-dev
Related: #22593 

## Testing
- Start up this branch with SSR debug:
  ```
  DEBUG='calypso:server-render' npm start
  ```
- Visit URLs that _should_ be SSR'ed and cached. You should see messages like on the console where Calypso is being served.
  ```
  calypso:server-render cache access for key +0ms /log-in
  ```
  - http://calypso.localhost:3000/log-in
  - http://calypso.localhost:3000/log-in/jetpack
- Visit URLs that should *not* be SSR'ed and cached. You should not see the cache access messages like above
  - http://calypso.localhost:3000/log-in?client_id=something&redirect_to=%2Fpath%3Fclient_id%3Dsomething
