### PR TITLE
Jetpack connect: Update to safe site url placeholder

### DIFF
--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -122,7 +122,7 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 						autoFocus="autofocus"
 						onChange={ onChange }
 						disabled={ isFetching }
-						placeholder={ translate( 'http://yourjetpack.blog' ) }
+						placeholder={ 'http://yourjetpack.blog' }
 						onKeyUp={ this.handleKeyPress }
 						value={ url }
 					/>

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -122,7 +122,7 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 						autoFocus="autofocus"
 						onChange={ onChange }
 						disabled={ isFetching }
-						placeholder={ translate( 'http://www.yoursite.com' ) }
+						placeholder={ translate( 'http://yourjetpack.blog' ) }
 						onKeyUp={ this.handleKeyPress }
 						value={ url }
 					/>


### PR DESCRIPTION
Use a safer URL placeholder

/cc @shaunandrews via comment at p7kMJG-4nr-p2

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/36428813-3d993c50-1651-11e8-863c-542d117f0fc6.png)

### After

![after](https://user-images.githubusercontent.com/841763/36429079-f1399e26-1651-11e8-83e1-3621c3d6138f.png)

## Testing
- Check the placeholder at https://calypso.live/jetpack/new?branch=update/jetpack-connect/site-placeholder