### PR TITLE
Fixes weird image spacing in Activity Log transition flow view

### DIFF
--- a/client/my-sites/stats/activity-log-switch/style.scss
+++ b/client/my-sites/stats/activity-log-switch/style.scss
@@ -89,6 +89,7 @@
 
 .activity-log-switch__img {
 	max-width: 33%;
+	max-height: 110px;
 	box-sizing: border-box;
 
 	@include breakpoint( "<960px" ) {
@@ -100,11 +101,11 @@
 	}
 
 	&.is-backup {
-		padding: 8%;
+		padding: 0 8%;
 	}
 
 	&.is-security-issue {
-		padding: 4%;
+		padding: 0 4%;
 	}
 }
 

--- a/client/my-sites/stats/activity-log-switch/style.scss
+++ b/client/my-sites/stats/activity-log-switch/style.scss
@@ -65,6 +65,7 @@
 .activity-log-switch__feature-content {
 	@include breakpoint( ">960px" ) {
 		flex-basis: 66%;
+		text-align: left;
 	}
 
 	@include breakpoint( "<960px" ) {


### PR DESCRIPTION
Fixes #22601

Note: it was only buggy in Chrome.

#### Before
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/1123119/36433597-15f4e33e-161a-11e8-92dd-52c4a90ad9f2.png">


#### After
<img width="1113" alt="image" src="https://user-images.githubusercontent.com/1123119/36433519-f08979ac-1619-11e8-9f73-a0e7b279d13b.png">
