### PR TITLE
Jetpack Onboarding: Introduce a Stats step

### DIFF
--- a/client/jetpack-onboarding/constants.js
+++ b/client/jetpack-onboarding/constants.js
@@ -14,6 +14,7 @@ import JetpackOnboardingContactFormStep from './steps/contact-form';
 import JetpackOnboardingHomepageStep from './steps/homepage';
 import JetpackOnboardingSiteTitleStep from './steps/site-title';
 import JetpackOnboardingSiteTypeStep from './steps/site-type';
+import JetpackOnboardingStatsStep from './steps/stats';
 import JetpackOnboardingSummaryStep from './steps/summary';
 import JetpackOnboardingWoocommerceStep from './steps/woocommerce';
 
@@ -24,6 +25,7 @@ export const JETPACK_ONBOARDING_STEPS = {
 	CONTACT_FORM: 'contact-form',
 	BUSINESS_ADDRESS: 'business-address',
 	WOOCOMMERCE: 'woocommerce',
+	STATS: 'stats',
 	SUMMARY: 'summary',
 };
 
@@ -34,6 +36,7 @@ export const JETPACK_ONBOARDING_STEP_TITLES = {
 	[ JETPACK_ONBOARDING_STEPS.CONTACT_FORM ]: translate( 'Contact Us Form' ),
 	[ JETPACK_ONBOARDING_STEPS.BUSINESS_ADDRESS ]: translate( 'Business Address' ),
 	[ JETPACK_ONBOARDING_STEPS.WOOCOMMERCE ]: translate( 'Add a Store' ),
+	[ JETPACK_ONBOARDING_STEPS.STATS ]: translate( 'Jetpack Stats' ),
 	[ JETPACK_ONBOARDING_STEPS.SUMMARY ]: translate( 'Summary' ),
 };
 
@@ -44,5 +47,6 @@ export const JETPACK_ONBOARDING_COMPONENTS = {
 	[ JETPACK_ONBOARDING_STEPS.CONTACT_FORM ]: <JetpackOnboardingContactFormStep />,
 	[ JETPACK_ONBOARDING_STEPS.BUSINESS_ADDRESS ]: <JetpackOnboardingBusinessAddressStep />,
 	[ JETPACK_ONBOARDING_STEPS.WOOCOMMERCE ]: <JetpackOnboardingWoocommerceStep />,
+	[ JETPACK_ONBOARDING_STEPS.STATS ]: <JetpackOnboardingStatsStep />,
 	[ JETPACK_ONBOARDING_STEPS.SUMMARY ]: <JetpackOnboardingSummaryStep />,
 };

--- a/client/jetpack-onboarding/controller.js
+++ b/client/jetpack-onboarding/controller.js
@@ -19,7 +19,11 @@ export const onboarding = ( context, next ) => {
 
 	// We validate siteSlug inside the component
 	context.primary = (
-		<JetpackOnboardingMain siteSlug={ context.params.site } stepName={ context.params.stepName } />
+		<JetpackOnboardingMain
+			action={ context.query.action }
+			siteSlug={ context.params.site }
+			stepName={ context.params.stepName }
+		/>
 	);
 	next();
 };

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -120,6 +120,7 @@ export default connect(
 			STEPS.CONTACT_FORM,
 			isBusiness && STEPS.BUSINESS_ADDRESS,
 			isBusiness && STEPS.WOOCOMMERCE,
+			STEPS.STATS,
 			STEPS.SUMMARY,
 		] );
 		return {

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -67,6 +67,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 
 	render() {
 		const {
+			action,
 			isRequestingSettings,
 			recordJpoEvent,
 			settings,
@@ -80,6 +81,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 				<QueryJetpackOnboardingSettings siteId={ siteId } />
 				{ siteId ? (
 					<Wizard
+						action={ action }
 						basePath="/jetpack/start"
 						baseSuffix={ siteSlug }
 						components={ COMPONENTS }

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -3,13 +3,145 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
+/**
+ * Internal dependencies
+ */
+import DocumentHead from 'components/data/document-head';
+import FormattedHeader from 'components/formatted-header';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QuerySites from 'components/data/query-sites';
+import Tile from 'components/tile-grid/tile';
+import TileGrid from 'components/tile-grid';
+import { addQueryArgs } from 'lib/route';
+import { getJetpackOnboardingPendingSteps, getUnconnectedSiteUrl } from 'state/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
+import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
+
 class JetpackOnboardingStatsStep extends React.Component {
+	componentDidUpdate() {
+		this.maybeActivateStats();
+	}
+
+	maybeActivateStats() {
+		const { action, activatedStats, isConnected, isRequestingSettings, stepsPending } = this.props;
+		const isPending = get( stepsPending, STEPS.STATS );
+
+		if (
+			! isPending &&
+			! isRequestingSettings &&
+			isConnected &&
+			activatedStats === false &&
+			action === 'activate_stats'
+		) {
+			this.activateStats();
+		}
+	}
+
+	handleActivateStats = () => {
+		this.props.recordJpoEvent( 'calypso_jpo_stats_clicked' );
+
+		if ( ! this.props.isConnected ) {
+			return;
+		}
+
+		this.activateStats();
+	};
+
+	handleStatsNextButton = () => {
+		this.props.recordJpoEvent( 'calypso_jpo_stats_next_clicked' );
+	};
+
+	activateStats() {
+		this.props.saveJetpackOnboardingSettings( this.props.siteId, {
+			stats: true,
+		} );
+	}
+
+	renderSuccess() {
+		const { getForwardUrl, translate } = this.props;
+
+		return (
+			<Fragment>
+				<FormattedHeader
+					headerText={ translate( 'Success! Jetpack is now collecting valuable stats.' ) }
+				/>
+
+				<TileGrid>
+					<Tile
+						buttonLabel={ translate( 'Continue' ) }
+						image="/calypso/images/illustrations/type-business.svg"
+						onClick={ this.handleStatsNextButton }
+						href={ getForwardUrl() }
+					/>
+				</TileGrid>
+			</Fragment>
+		);
+	}
+
+	renderActionTile() {
+		const { isConnected, siteUrl, translate } = this.props;
+		const headerText = translate( 'Keep track of your visitors with Jetpack.' );
+		const subHeaderText = translate(
+			'Keep an eye on your success with simple, concise, and mobile-friendly stats. ' +
+				'Get updates on site traffic, successful posts, site searches, and comments, all in real time.'
+		);
+		const connectUrl = addQueryArgs(
+			{
+				url: siteUrl,
+				// TODO: add a parameter to the JPC to redirect back to this step after completion
+				// and in the redirect URL include the ?action=activate_stats parameter
+				// to actually trigger the stats activation action after getting back to JPO
+			},
+			'/jetpack/connect'
+		);
+		const href = ! isConnected ? connectUrl : null;
+
+		return (
+			<Fragment>
+				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+
+				<TileGrid>
+					<Tile
+						buttonLabel={ translate( 'Activate stats' ) }
+						image="/calypso/images/illustrations/type-business.svg"
+						onClick={ this.handleActivateStats }
+						href={ href }
+					/>
+				</TileGrid>
+			</Fragment>
+		);
+	}
+
 	render() {
-		return <div className="steps__main" />;
+		const { activatedStats, basePath, siteId, translate } = this.props;
+
+		return (
+			<div className="steps__main">
+				<DocumentHead title={ translate( 'Jetpack Stats ‹ Jetpack Start' ) } />
+				<PageViewTracker
+					path={ [ basePath, STEPS.STATS, ':site' ].join( '/' ) }
+					title="Jetpack Stats ‹ Jetpack Start"
+				/>
+				<QuerySites siteId={ siteId } />
+
+				{ activatedStats ? this.renderSuccess() : this.renderActionTile() }
+			</div>
+		);
 	}
 }
 
-export default localize( JetpackOnboardingStatsStep );
+export default connect(
+	( state, { settings, siteId, steps } ) => ( {
+		activatedStats: get( settings, 'stats' ) === true,
+		isConnected: isJetpackSite( state, siteId ),
+		siteUrl: getUnconnectedSiteUrl( state, siteId ),
+		stepsPending: getJetpackOnboardingPendingSteps( state, siteId, steps ),
+	} ),
+	{ saveJetpackOnboardingSettings }
+)( localize( JetpackOnboardingStatsStep ) );

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
+import JetpackLogo from 'components/jetpack-logo';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySites from 'components/data/query-sites';
 import Tile from 'components/tile-grid/tile';
@@ -129,6 +130,8 @@ class JetpackOnboardingStatsStep extends React.Component {
 					title="Jetpack Stats ‹ Jetpack Start"
 				/>
 				<QuerySites siteId={ siteId } />
+
+				<JetpackLogo full size={ 45 } />
 
 				{ activatedStats ? this.renderSuccess() : this.renderActionTile() }
 			</div>

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -1,0 +1,15 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+class JetpackOnboardingStatsStep extends React.Component {
+	render() {
+		return <div className="steps__main" />;
+	}
+}
+
+export default localize( JetpackOnboardingStatsStep );

--- a/client/state/jetpack-onboarding/schema.js
+++ b/client/state/jetpack-onboarding/schema.js
@@ -50,5 +50,6 @@ export const jetpackOnboardingSettingsSchema = {
 			],
 		},
 		installWooCommerce: { type: 'boolean' },
+		stats: { type: 'boolean' },
 	},
 };

--- a/client/state/selectors/get-jetpack-onboarding-pending-steps.js
+++ b/client/state/selectors/get-jetpack-onboarding-pending-steps.js
@@ -17,6 +17,9 @@ export default function getJetpackOnboardingPendingSteps( state, siteId, steps )
 		[ STEPS.WOOCOMMERCE ]: {
 			installWooCommerce: true,
 		},
+		[ STEPS.STATS ]: {
+			stats: true,
+		},
 	};
 
 	return reduce(

--- a/client/state/selectors/is-jetpack-onboarding-step-completed.js
+++ b/client/state/selectors/is-jetpack-onboarding-step-completed.js
@@ -46,6 +46,8 @@ export default createSelector(
 				return !! get( settings, 'businessAddress' );
 			case STEPS.WOOCOMMERCE:
 				return !! get( settings, 'installWooCommerce' );
+			case STEPS.STATS:
+				return !! get( settings, 'stats' );
 			default:
 				return false;
 		}

--- a/client/state/selectors/test/get-jetpack-onboarding-pending-steps.js
+++ b/client/state/selectors/test/get-jetpack-onboarding-pending-steps.js
@@ -9,9 +9,11 @@ import { getRequestKey } from 'state/data-layer/wpcom-http/utils';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 describe( 'getJetpackOnboardingPendingSteps()', () => {
-	test( 'should return pending status for the specified steps', () => {
+	test( 'should return pending status for the woocommerce step', () => {
 		const siteId = 2916284;
-		const action = saveJetpackOnboardingSettings( siteId, { installWooCommerce: true } );
+		const action = saveJetpackOnboardingSettings( siteId, {
+			installWooCommerce: true,
+		} );
 		const state = {
 			dataRequests: {
 				[ getRequestKey( action ) ]: {
@@ -20,11 +22,36 @@ describe( 'getJetpackOnboardingPendingSteps()', () => {
 			},
 		};
 
-		const steps = [ STEPS.SITE_TITLE, STEPS.SITE_TYPE, STEPS.WOOCOMMERCE ];
+		const steps = [ STEPS.SITE_TITLE, STEPS.SITE_TYPE, STEPS.WOOCOMMERCE, STEPS.STATS ];
 		const expected = {
 			[ STEPS.SITE_TITLE ]: false,
 			[ STEPS.SITE_TYPE ]: false,
 			[ STEPS.WOOCOMMERCE ]: true,
+			[ STEPS.STATS ]: false,
+		};
+		const pending = getJetpackOnboardingPendingSteps( state, siteId, steps );
+		expect( pending ).toEqual( expected );
+	} );
+
+	test( 'should return pending status for the stats step', () => {
+		const siteId = 2916284;
+		const action = saveJetpackOnboardingSettings( siteId, {
+			stats: true,
+		} );
+		const state = {
+			dataRequests: {
+				[ getRequestKey( action ) ]: {
+					status: 'pending',
+				},
+			},
+		};
+
+		const steps = [ STEPS.SITE_TITLE, STEPS.SITE_TYPE, STEPS.WOOCOMMERCE, STEPS.STATS ];
+		const expected = {
+			[ STEPS.SITE_TITLE ]: false,
+			[ STEPS.SITE_TYPE ]: false,
+			[ STEPS.WOOCOMMERCE ]: false,
+			[ STEPS.STATS ]: true,
 		};
 		const pending = getJetpackOnboardingPendingSteps( state, siteId, steps );
 		expect( pending ).toEqual( expected );

--- a/client/state/selectors/test/is-jetpack-onboarding-step-completed.js
+++ b/client/state/selectors/test/is-jetpack-onboarding-step-completed.js
@@ -325,4 +325,49 @@ describe( 'isJetpackOnboardingStepCompleted()', () => {
 
 		expect( completed ).toBe( false );
 	} );
+
+	test( 'should return true for stats step if we have chosen to activate stats', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						stats: true,
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.STATS );
+
+		expect( completed ).toBe( true );
+	} );
+
+	test( 'should return false for stats step if we have not activated stats', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						siteTitle: 'My awesome site',
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.STATS );
+
+		expect( completed ).toBe( false );
+	} );
+
+	test( 'should return false for stats step if it is specified as not activated', () => {
+		const state = {
+			jetpackOnboarding: {
+				settings: {
+					2916284: {
+						stats: false,
+					},
+				},
+			},
+		};
+		const completed = isJetpackOnboardingStepCompleted( state, 2916284, STEPS.STATS );
+
+		expect( completed ).toBe( false );
+	} );
 } );


### PR DESCRIPTION
### Purpose

This PR introduces a new Stats step, as suggested in #22532 and p6TEKc-1Rd-p2. It is used to enable the stats module in Jetpack, but also requires the site to be connected to activate the module. Later we can reuse the same logic for the Business Address and Contact steps.

Fixes #22532.

### How it works

* The user loads the new step and sees a CTA.
* Clicking the button will behave differently, depending on whether the site is currently connected or not:
  * If connected, will activate the stats module and show a success screen.
  * If not connected, will redirect to Jetpack Connect and will start the connection flow. After finishing connection, will redirect back to same step, and initiate the activation of the module, followed by showing the success screen.

**Note 1:** right now, after connecting, Jetpack Connect will not redirect to the stats step. This requires additional changes to Jetpack Connect that we'll handle in a separate PR. This will work by passing a URL parameter to JPC so it knows where to redirect to. That URL will consist of the JPO stats page URL with a `action=activate_stats` parameter, which will trigger activation of the stats module for connected sites immediately, showing the success screen to the user.

**Note 2:** right now the PR will display the buttons as small ones, but after we land #22585, they'll appear non-compact. This is properly reflected on the screenshots.

### Preview:

**Stats step - initial state**
![](https://cldup.com/hMg-LqNugR.png)

**Stats step - success state**
![](https://cldup.com/-3Ead06-iq.png)

**Summary step - showing the Stats step**
![](https://cldup.com/ymxEyzsAGA.png)

### Contents of the PR

In addition to the step itself, this PR introduces several changes that are necessary for each aspect of the new Stats step to function properly. Commits are atomic and can be used to highlight distinct changes, but here is a detailed list of what this PR suggests:

* Add `stats` to JPO settings schema
* Register `stats` as a known step
* Add `stats` step to `isJetpackOnboardingStepCompleted` selector
* Introduce support for the `action` query parameter
* Add `stats` step to main wizard
* Introduce the stats step component

### Testing
* Checkout this branch on your local Calypso.
* Start with a fresh Jetpack site with the latest **Jetpack master**
* Head to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` on the Jetpack site to start the onboarding flow.
* Skip steps until you reach the new Stats step (it's the last one before "Summary").
* Verify the step appears properly as shown on the screenshots.
* Click the **Activate stats** button.
* You will be redirected to Jetpack Connect and connection process will start automatically.
* After connecting, it will redirect you to the default redirection place of JPC (this is expected, see the note above).
* Visit `http://calypso.localhost:3000/jetpack/start/stats/YOURJETPACKSITE.COM?action=activate_stats` to simulate coming back from Jetpack Connect after a successful connection.
* Verify you can see the success screen (as shown on the screenshot)
* Verify the Stats module was activated (you can check by calling this command on your Jetpack site's terminal: `wp jetpack module list`)
* Refresh the page and verify you can still see the success screen.
* Verify the **Continue** button leads to the next page (**Summary**)
* Go back to other steps and visit the Stats page; verify you can still see the success screen.
* Deactivate the `stats` module (you can do it by calling the following command on your Jetpack site's terminal: `wp jetpack module deactivate stats`).
* Skip to the Summary step, verify the **Jetpack Stats** step is shown as incomplete.
* Make sure your site is still connected.
* Go to `http://calypso.localhost:3000/jetpack/start/stats/YOURJETPACKSITE.COM` and verify you can see the initial screen again, with the **Activate stats** button.
* Click the **Activate stats** button.
* Verify you can see the success screen immediately, without being redirected to Jetpack Connect.
* Verify the Stats module was activated (you can check by calling this command on your Jetpack site's terminal: `wp jetpack module list`)
* Skip to the Summary step, verify the **Jetpack Stats** step is shown as complete.