### PR TITLE
Signup: Fix blank page on Internet Explorer

### DIFF
--- a/client/lib/credit-card-details/ebanx.js
+++ b/client/lib/credit-card-details/ebanx.js
@@ -3,8 +3,7 @@
  *
  * @format
  */
-import { isUndefined } from 'lodash';
-import { isValid } from 'cpf';
+import { isString, isUndefined } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,11 +27,13 @@ export function isEbanxEnabledForCountry( countryCode = '' ) {
 /**
  * CPF number (Cadastrado de Pessoas Físicas) is the Brazilian tax identification number.
  * Total of 11 digits: 9 numbers followed by 2 verification numbers . E.g., 188.247.019-22
+ * The following test is a weak test only.
  *
+ * See algorithm at http://www.geradorcpf.com/algoritmo_do_cpf.htm
  * @param {String} cpf - a Brazilian tax identification number
  * @returns {Boolean} Whether the cpf is valid or not
  */
 
 export function isValidCPF( cpf = '' ) {
-	return isValid( cpf );
+	return isString( cpf ) && /^[0-9]{3}\.[0-9]{3}\.[0-9]{3}-[0-9]{2}$/.test( cpf );
 }

--- a/client/lib/credit-card-details/test/ebanx.js
+++ b/client/lib/credit-card-details/test/ebanx.js
@@ -40,12 +40,11 @@ describe( 'Ebanx payment processing methods', () => {
 
 	describe( 'isValidCPF', () => {
 		test( 'should return true for valid CPF (Brazilian tax identification number)', () => {
-			expect( isValidCPF( '85384484632' ) ).toEqual( true );
 			expect( isValidCPF( '853.513.468-93' ) ).toEqual( true );
 		} );
 		test( 'should return false for invalid CPF', () => {
-			expect( isValidCPF( '85384484612' ) ).toEqual( false );
-			expect( isValidCPF( '853.844.846.12' ) ).toEqual( false );
+			expect( isValidCPF( '85384484632' ) ).toEqual( false );
+			expect( isValidCPF( '853.844.846.32' ) ).toEqual( false );
 		} );
 	} );
 } );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2744,10 +2744,6 @@
         }
       }
     },
-    "cpf": {
-      "version": "1.0.0",
-      "integrity": "sha1-geCsZajzSfRuuHZYkFFzt3TuTJY="
-    },
     "crc32": {
       "version": "0.2.2",
       "integrity": "sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo="

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "cookie": "0.1.2",
     "cookie-parser": "1.3.2",
     "copy-webpack-plugin": "4.0.1",
-    "cpf": "1.0.0",
     "create-react-class": "15.6.2",
     "creditcards": "2.1.2",
     "cross-env": "5.1.1",


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/22618 by reverting most of https://github.com/Automattic/wp-calypso/pull/21635. More specifically, it removes the [`cpf`](https://github.com/theuves/cpf) NPM module which uses [function default parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters), something that is not supported by Internet Explorer and that is not transpiled by Babel.

#### Testing instructions

1. Run `git checkout fix/signup` and start your server, or open a [live branch](https://calypso.live/?branch=fix/signup)
2. Open the [`Signup` page](http://calypso.localhost:3000/start) in Internet Explorer
3. Check that the page loads correctly, and that you can sign up

#### Reviews

- [ ] Code
- [ ] Product