### PR TITLE
Comments: Fix incorrect <img> tag in the HTML editor

### DIFF
--- a/client/my-sites/comments/comment/comment-html-editor/index.jsx
+++ b/client/my-sites/comments/comment/comment-html-editor/index.jsx
@@ -73,7 +73,10 @@ export class CommentHtmlEditor extends Component {
 		const inner = options.text || this.splitSelectedContent().inner;
 
 		if ( inner.length || options.alsoClose ) {
-			return this.insertContent( opener + inner + closer, options.adjustCursorPosition );
+			return this.insertContent(
+				fragments[ 1 ] ? opener + inner + closer : inner + opener,
+				options.adjustCursorPosition
+			);
 		}
 
 		if ( !! fragments[ 1 ] && this.isTagOpen( tag ) ) {


### PR DESCRIPTION
If we insert an `<img>` tag while some text is selected, we end up trying to enclose the selected text between `<img>` and an `undefined` closer.

This PR fixes this bug, forcing self-closed tags to be inserted _after_ the text selection (if any).
This is the same behaviour of wp-admin.

### Example

| | Before | After |
| --- | --- | --- |
| Editor content with "b" selected | `abc` | `abc` |
| After `img` insertion | `a<img>bundefinedc` | `ab<img>c` |

## Testing instructions

Try editing a comment in `/comments` and insert the `img` tag via the HTML toolbar.

If no text were selected, the tag should appear at the cursor position.
If some text were selected, the tag should appear right after it.