### PR TITLE
Jetpack Connect: Redirect to jetpack-specific login page

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -8,7 +8,7 @@ import React from 'react';
 import { parse as parseUrl } from 'url';
 import page from 'page';
 import qs from 'qs';
-import { map } from 'lodash';
+import { includes, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -138,4 +138,14 @@ export function redirectDefaultLocale( context, next ) {
 	} else {
 		context.redirect( '/log-in' );
 	}
+}
+
+export function redirectJetpack( context, next ) {
+	const { isJetpack } = context.params;
+	const { redirect_to } = context.query;
+
+	if ( ! isJetpack === 'jetpack' && includes( redirect_to, 'jetpack/connect' ) ) {
+		return context.redirect( context.path.replace( 'log-in', 'log-in/jetpack' ) );
+	}
+	next();
 }

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -144,7 +144,7 @@ export function redirectJetpack( context, next ) {
 	const { isJetpack } = context.params;
 	const { redirect_to } = context.query;
 
-	if ( ! isJetpack === 'jetpack' && includes( redirect_to, 'jetpack/connect' ) ) {
+	if ( isJetpack !== 'jetpack' && includes( redirect_to, 'jetpack/connect' ) ) {
 		return context.redirect( context.path.replace( 'log-in', 'log-in/jetpack' ) );
 	}
 	next();

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -144,6 +144,14 @@ export function redirectJetpack( context, next ) {
 	const { isJetpack } = context.params;
 	const { redirect_to } = context.query;
 
+	/**
+	 * Send arrivals from the jetpack connect process (when site user email matches
+	 * a wpcom account) to the jetpack branded login.
+	 *
+	 * A direct redirect to /log-in/jetpack is not currently done at jetpack.wordpress.com
+	 * because the iOS app relies on seeing a request to /log-in$ to show its
+	 * native credentials form.
+	 */
 	if ( isJetpack !== 'jetpack' && includes( redirect_to, 'jetpack/connect' ) ) {
 		return context.redirect( context.path.replace( 'log-in', 'log-in/jetpack' ) );
 	}

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -4,7 +4,14 @@
  * Internal dependencies
  */
 import config from 'config';
-import { lang, login, magicLogin, magicLoginUse, redirectDefaultLocale } from './controller';
+import {
+	lang,
+	login,
+	magicLogin,
+	magicLoginUse,
+	redirectJetpack,
+	redirectDefaultLocale,
+} from './controller';
 import { makeLayout, redirectLoggedIn, setUpLocale } from 'controller';
 
 export default router => {
@@ -29,6 +36,7 @@ export default router => {
 				`/log-in/:isJetpack(jetpack)/${ lang }`,
 				`/log-in/${ lang }`,
 			],
+			redirectJetpack,
 			redirectDefaultLocale,
 			setUpLocale,
 			login,


### PR DESCRIPTION
Unfortunately, the current version of the iOS app relies on the login route in the jetpack connect process being wordpress.com/log-in (and not wordpress.com/log-in/jetpack) when it intercepts that request to show its native credentials form.

For this reason we've had to temporarily revert change that sends logged-out jetpack connect users with an account to /log-in/jetpack. See D10339-code.

This PR is a Calypso-side replacement for the jetpack.wordpress.com redirect to /log-in/jetpack, which checks for the presence of `jetpack/connect` in the `?redirect_to` query arg of /log-in routes, and redirects to /log-in/jetpack. This way, the mobile app will still see the request to /log-in, and all other flows will end up at /log-in/jetpack.

## Testing

On this branch (after restarting the build), any url with a `redirect_to` query arg that contains 'jetpack/connect', such as
```
http://calypso.localhost:3000/log-in?email_address=oskosk%2Bjurassicninja%2Bnew%2Bsite%2Bcreated%40gmail.com&redirect_to=https%3A%2F%2Fwordpress.com%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D143040320%26redirect_uri%3Dhttps%253A%252F%252Ffluttering-fennec-430.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Djetpack%2526action%253Dauthorize%2526_wpnonce%253Dcb5d6f2845%2526redirect%253Dhttps%25253A%25252F%25252Ffluttering-fennec-430.jurassic.ninja%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Djetpack%26state%3D1%26scope%3Dadministrator%253Aa34a39a1987296d1555fe75dd0e6777d%26user_email%3Doskosk%252Bjurassicninja%252Bnew%252Bsite%252Bcreated%2540gmail.com%26user_login%3Doskisaninja%26jp_version%3D5.8%26secret%3D2XQMULZ1DQTIHxdDXTM7s7y32yrgrtwM%26locale%3Den%26blogname%3DFluttering%2BFennec%2B430%26site_url%3Dhttps%253A%252F%252Ffluttering-fennec-430.jurassic.ninja%26home_url%3Dhttps%253A%252F%252Ffluttering-fennec-430.jurassic.ninja%26site_icon%26site_lang%3Den_US%26_ui%3Djetpack%253AL0vuQ%252FaQOr4eZxspoeFf4Nbi%26_ut%3Danon%26_as%3Dwp-cli%26from%3Dbanner-44-slide-1-dashboard%26already_authorized%3Dtrue%26_wp_nonce%3D92e35b97d6%26redirect_after_auth%3Dhttps%253A%252F%252Ffluttering-fennec-430.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Djetpack%26site%3Dhttps%253A%252F%252Ffluttering-fennec-430.jurassic.ninja
```

Should redirect (at the server) to
```
http://calypso.localhost:3000/log-in/jetpack?email_address=oskosk%2Bjurassicninja%2Bnew%2Bsite%2Bcreated%40gmail.com&redirect_to=https%3A%2F%2Fwordpress.com%2Fjetpack%2Fconnect%2Fauthorize%3Fclient_id%3D143040320%26redirect_uri%3Dhttps%253A%252F%252Ffluttering-fennec-430.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Djetpack%2526action%253Dauthorize%2526_wpnonce%253Dcb5d6f2845%2526redirect%253Dhttps%25253A%25252F%25252Ffluttering-fennec-430.jurassic.ninja%25252Fwp-admin%25252Fadmin.php%25253Fpage%25253Djetpack%26state%3D1%26scope%3Dadministrator%253Aa34a39a1987296d1555fe75dd0e6777d%26user_email%3Doskosk%252Bjurassicninja%252Bnew%252Bsite%252Bcreated%2540gmail.com%26user_login%3Doskisaninja%26jp_version%3D5.8%26secret%3D2XQMULZ1DQTIHxdDXTM7s7y32yrgrtwM%26locale%3Den%26blogname%3DFluttering%2BFennec%2B430%26site_url%3Dhttps%253A%252F%252Ffluttering-fennec-430.jurassic.ninja%26home_url%3Dhttps%253A%252F%252Ffluttering-fennec-430.jurassic.ninja%26site_icon%26site_lang%3Den_US%26_ui%3Djetpack%253AL0vuQ%252FaQOr4eZxspoeFf4Nbi%26_ut%3Danon%26_as%3Dwp-cli%26from%3Dbanner-44-slide-1-dashboard%26already_authorized%3Dtrue%26_wp_nonce%3D92e35b97d6%26redirect_after_auth%3Dhttps%253A%252F%252Ffluttering-fennec-430.jurassic.ninja%252Fwp-admin%252Fadmin.php%253Fpage%253Djetpack%26site%3Dhttps%253A%252F%252Ffluttering-fennec-430.jurassic.ninja
```

All other log-in routes should behave as before.
