### PR TITLE
Activity Log: don't show dialog for Stats first view

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -30,7 +30,6 @@ import QueryRewindState from 'components/data/query-rewind-state';
 import QuerySiteSettings from 'components/data/query-site-settings'; // For site time offset
 import QueryRewindBackupStatus from 'components/data/query-rewind-backup-status';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
-import StatsFirstView from '../stats-first-view';
 import StatsNavigation from 'blocks/stats-navigation';
 import StatsPeriodNavigation from 'my-sites/stats/stats-period-navigation';
 import SuccessBanner from '../activity-log-banner/success-banner';
@@ -481,7 +480,6 @@ class ActivityLog extends Component {
 				{ siteId &&
 					'active' === rewindState.state && <QueryRewindBackupStatus siteId={ siteId } /> }
 				<QuerySiteSettings siteId={ siteId } />
-				<StatsFirstView />
 				<SidebarNavigation />
 				<StatsNavigation selectedItem={ 'activity' } siteId={ siteId } slug={ slug } />
 				{ siteId && <ActivityLogUpgradeNotice siteId={ siteId } /> }


### PR DESCRIPTION
This PR fixes #22168 by removing the component that shows for new user accounts the first time they access Stats. 

<img width="636" alt="captura de pantalla 2018-02-20 a la s 15 16 03" src="https://user-images.githubusercontent.com/1041600/36441610-dc5becde-1651-11e8-87b9-4baa6f26746c.png">

_Before: the Stats dialog is shown, out of context, in Activity Log_

Since Activity Log is fundamentally different from site metrics, it's not relevant to display this welcome dialog in the Activity Log context:

<img width="740" alt="captura de pantalla 2018-02-20 a la s 15 16 37" src="https://user-images.githubusercontent.com/1041600/36441611-dc852f0e-1651-11e8-9285-d317016d1840.png">

_After: the Stats dialog is no longer shown in Activity Log_