### PR TITLE
Remove usages of the JS exponentiation operator

### DIFF
--- a/client/lib/format-number-compact/index.js
+++ b/client/lib/format-number-compact/index.js
@@ -45,23 +45,27 @@ export default function formatNumberCompact( number, code = i18n.getLocaleSlug()
 	return `${ sign }${ value }${ symbol }`;
 }
 
+const ONE_K = 1000;
+const ONE_M = ONE_K * 1000;
+const ONE_G = ONE_M * 1000;
+
 /*
  * Format a number larger than 1000 by appending a metric unit (K, M, G) and rounding to
  * one decimal point.
  * TODO: merge with formatNumberCompact by adding support for metric units other than 'K'
  */
 export function formatNumberMetric( number ) {
-	if ( number < 1000 ) {
+	if ( number < ONE_K ) {
 		return String( number );
 	}
 
-	if ( number < 1000 ** 2 ) {
-		return ( number / 1000 ).toFixed( 1 ) + 'K';
+	if ( number < ONE_M ) {
+		return ( number / ONE_K ).toFixed( 1 ) + 'K';
 	}
 
-	if ( number < 1000 ** 3 ) {
-		return ( number / 1000 ** 2 ).toFixed( 1 ) + 'M';
+	if ( number < ONE_G ) {
+		return ( number / ONE_M ).toFixed( 1 ) + 'M';
 	}
 
-	return ( number / 1000 ** 3 ).toFixed( 1 ) + 'G';
+	return ( number / ONE_G ).toFixed( 1 ) + 'G';
 }


### PR DESCRIPTION
Some of our tools (`i18n-calypso`, `xgettext-js`) use an old version of `babylon` that
don't know the `**` operator yet.