### PR TITLE
Jest: client: set testEnvironment to jsdom

### DIFF
--- a/test/client/jest.config.json
+++ b/test/client/jest.config.json
@@ -11,7 +11,7 @@
 	"roots": [
 		"<rootDir>/client/"
 	],
-	"testEnvironment": "node",
+	"testEnvironment": "jsdom",
 	"transformIgnorePatterns": ["node_modules[\\/\\\\](?!redux-form)"],
 	"testMatch": [ "<rootDir>/client/**/test/*.js?(x)" ],
 	"testURL": "https://example.com",


### PR DESCRIPTION
In order to test mounting of components that make use of the `window` global, this PR changes the jest [testEnvironment](https://facebook.github.io/jest/docs/en/configuration.html#testenvironment-string) to `jsdom`.

Example component:
```js
componentDidMount() {
    window.addEventListener( 'resize', this.handleResize );
}
```
