### PR TITLE
Settings: Jetpack returns an error when saving settings

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -136,7 +136,10 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 						break;
 				}
 			} );
-
+			// Jetpack returns an error if we try to save options that can't be changed.
+			if ( 'error_const' === fields.lang_id || 'error_cap' === fields.lang_id ) {
+				delete this.props.fields.lang_id;
+			}
 			this.submitForm();
 			this.props.trackEvent( 'Clicked Save Settings Button' );
 		};


### PR DESCRIPTION
Currently when we save a settings Jepack returns an error if the site has defigned the constant define( 'WPLANG', 'en_CA' ) defined.

This PR fixes this by making sure that we don't send the data to Jetpack if the site has the constant set.

Related to https://github.com/Automattic/wp-calypso/pull/21482

Fixes 1763-gh-jpop-issues

**To test**

Add `define( 'WPLANG', 'en_CA' );` to you jetpack sites wp-config.php
Notice that you get a an error saving a setting. 
Notice that this is not the case with this PR. 

This PR fixed this by removing the attribute error states specified. So that the data doesn't get sent to the endpoint in the first place. 


