### PR TITLE
Update the subdomain flow to match main

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -153,10 +153,10 @@ const flows = {
 	},
 
 	subdomain: {
-		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'about', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'Provide a vertical for subdomains',
-		lastModified: '2016-10-31',
+		lastModified: '2018-02-21',
 	},
 
 	main: {


### PR DESCRIPTION
The subdomain sign up flow is currently different to the main sign up flow

This changes it to match the main flow

**Testing Instructions**

1. Visit https://calypso.live/start?vertical=a8c.19.0.1&branch=update/subdomain-signup-flow
2. Make sure you can create a `.code.blog` site
