### PR TITLE
Login: Accept back_to param to define back link behavior

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -22,12 +22,17 @@ import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analyt
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 
 const enhanceContextWithLogin = context => {
-	const { path, params: { flow, isJetpack, socialService, twoFactorAuthType } } = context;
+	const {
+		path,
+		params: { flow, isJetpack, socialService, twoFactorAuthType },
+		query: { back_to },
+	} = context;
 
 	context.cacheQueryKeys = [ 'client_id' ];
 
 	context.primary = (
 		<WPLogin
+			backTo={ back_to }
 			isJetpack={ isJetpack === 'jetpack' }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -3,28 +3,27 @@
 /**
  * External dependencies
  */
-
-import React from 'react';
-import { parse as parseUrl } from 'url';
 import page from 'page';
 import qs from 'qs';
+import React from 'react';
 import { includes, map } from 'lodash';
+import { parse as parseUrl } from 'url';
 
 /**
  * Internal dependencies
  */
 import config from 'config';
-import WPLogin from './wp-login';
-import MagicLogin from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
+import MagicLogin from './magic-login';
+import WPLogin from './wp-login';
 import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 
 const enhanceContextWithLogin = context => {
 	const {
-		path,
 		params: { flow, isJetpack, socialService, twoFactorAuthType },
+		path,
 		query: { back_to },
 	} = context;
 

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -3,30 +3,29 @@
 /**
  * External dependencies
  */
-
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { startCase } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { startCase } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
 import DocumentHead from 'components/data/document-head';
-import LoginLinks from './login-links';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
-import Main from 'components/main';
+import GlobalNotices from 'components/global-notices';
 import LocaleSuggestions from 'components/locale-suggestions';
 import LoginBlock from 'blocks/login';
-import { recordPageViewWithClientId as recordPageView } from 'state/analytics/actions';
-import GlobalNotices from 'components/global-notices';
+import LoginLinks from './login-links';
+import Main from 'components/main';
 import notices from 'notices';
 import PrivateSite from './private-site';
+import { addLocaleToWpcomUrl } from 'lib/i18n-utils';
+import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { recordPageViewWithClientId as recordPageView } from 'state/analytics/actions';
 
 export class Login extends React.Component {
 	static propTypes = {
@@ -189,8 +188,8 @@ export class Login extends React.Component {
 							<LoginLinks
 								backTo={ backTo }
 								locale={ locale }
-								twoFactorAuthType={ twoFactorAuthType }
 								privateSite={ privateSite }
+								twoFactorAuthType={ twoFactorAuthType }
 							/>
 						) }
 					</div>

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -30,6 +30,7 @@ import PrivateSite from './private-site';
 
 export class Login extends React.Component {
 	static propTypes = {
+		backTo: PropTypes.string,
 		clientId: PropTypes.string,
 		isLoggedIn: PropTypes.bool.isRequired,
 		isJetpack: PropTypes.bool.isRequired,
@@ -166,7 +167,7 @@ export class Login extends React.Component {
 	}
 
 	render() {
-		const { locale, privateSite, socialConnect, translate, twoFactorAuthType } = this.props;
+		const { backTo, locale, privateSite, socialConnect, translate, twoFactorAuthType } = this.props;
 		const canonicalUrl = addLocaleToWpcomUrl( 'https://wordpress.com/login', locale );
 
 		return (
@@ -186,6 +187,7 @@ export class Login extends React.Component {
 
 						{ ! socialConnect && (
 							<LoginLinks
+								backTo={ backTo }
 								locale={ locale }
 								twoFactorAuthType={ twoFactorAuthType }
 								privateSite={ privateSite }

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import urlModule from 'url';
 import Gridicon from 'gridicons';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -77,7 +76,7 @@ export class LoginLinks extends React.Component {
 
 			// Ensure we've got a relative URL (null) or an http[s] protocol
 			// We don't want to allow `javascript:…`
-			if ( includes( [ null, 'http:', 'https:' ], protocol ) ) {
+			if ( null === protocol || 'http:' === protocol || 'https:' === protocol ) {
 				const linkText = hostname
 					? translate( 'Back to %(hostname)s', { args: { hostname } } )
 					: translate( 'Back' );

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -70,7 +70,7 @@ export class LoginLinks extends React.Component {
 	renderBackLink() {
 		const { backTo, translate } = this.props;
 
-		// Log-ins from may include backTo, allowing them to return to the site
+		// A backTo prop may be supplied, allowing the back button href to be controlled.
 		if ( backTo ) {
 			const url = urlModule.parse( backTo );
 

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import urlModule from 'url';
 import Gridicon from 'gridicons';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -72,15 +73,13 @@ export class LoginLinks extends React.Component {
 
 		// A backTo prop may be supplied, allowing the back button href to be controlled.
 		if ( backTo ) {
-			const url = urlModule.parse( backTo );
+			const { hostname, protocol } = urlModule.parse( backTo );
 
 			// Ensure we've got a relative URL (null) or an http[s] protocol
 			// We don't want to allow `javascript:…`
-			if ( null === url.protocol || 'http:' === url.protocol || 'https:' === url.protocol ) {
-				const linkText = url.hostname
-					? translate( 'Back to %(hostname)s', {
-							args: { hostname: url.hostname },
-						} )
+			if ( includes( [ null, 'http:', 'https:' ], protocol ) ) {
+				const linkText = hostname
+					? translate( 'Back to %(hostname)s', { args: { hostname } } )
 					: translate( 'Back' );
 				return (
 					<ExternalLink href={ backTo }>

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -3,27 +3,26 @@
 /**
  * External dependencies
  */
-
+import Gridicon from 'gridicons';
+import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
+import urlModule from 'url';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import page from 'page';
-import urlModule from 'url';
-import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
  */
-import { addQueryArgs } from 'lib/url';
-import { isEnabled } from 'config';
 import ExternalLink from 'components/external-link';
 import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
+import { addQueryArgs } from 'lib/url';
+import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
+import { isEnabled } from 'config';
+import { login } from 'lib/paths';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'state/login/magic-login/actions';
-import { login } from 'lib/paths';
-import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 
 export class LoginLinks extends React.Component {
 	static propTypes = {
@@ -90,9 +89,9 @@ export class LoginLinks extends React.Component {
 		}
 		return (
 			<LoggedOutFormBackLink
+				classes={ { 'logged-out-form__link-item': false } }
 				oauth2Client={ this.props.oauth2Client }
 				recordClick={ this.recordBackToWpcomLinkClick }
-				classes={ { 'logged-out-form__link-item': false } }
 			/>
 		);
 	}

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -64,6 +64,16 @@ export class LoginLinks extends React.Component {
 		this.props.recordTracksEvent( 'calypso_login_reset_password_link_click' );
 	};
 
+	renderBackLink() {
+		return (
+			<LoggedOutFormBackLink
+				oauth2Client={ this.props.oauth2Client }
+				recordClick={ this.recordBackToWpcomLinkClick }
+				classes={ { 'logged-out-form__link-item': false } }
+			/>
+		);
+	}
+
 	renderHelpLink() {
 		if ( ! this.props.twoFactorAuthType ) {
 			return null;
@@ -143,11 +153,7 @@ export class LoginLinks extends React.Component {
 				{ this.renderHelpLink() }
 				{ this.renderMagicLoginLink() }
 				{ this.renderResetPasswordLink() }
-				<LoggedOutFormBackLink
-					oauth2Client={ this.props.oauth2Client }
-					recordClick={ this.recordBackToWpcomLinkClick }
-					classes={ { 'logged-out-form__link-item': false } }
-				/>
+				{ this.renderBackLink() }
 			</div>
 		);
 	}

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -9,6 +9,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
+import urlModule from 'url';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -25,6 +27,7 @@ import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 
 export class LoginLinks extends React.Component {
 	static propTypes = {
+		backTo: PropTypes.string,
 		isLoggedIn: PropTypes.bool.isRequired,
 		locale: PropTypes.string.isRequired,
 		oauth2Client: PropTypes.object,
@@ -65,6 +68,28 @@ export class LoginLinks extends React.Component {
 	};
 
 	renderBackLink() {
+		const { backTo, translate } = this.props;
+
+		// Log-ins from may include backTo, allowing them to return to the site
+		if ( backTo ) {
+			const url = urlModule.parse( backTo );
+
+			// Ensure we've got a relative URL (null) or an http[s] protocol
+			// We don't want to allow `javascript:…`
+			if ( null === url.protocol || 'http:' === url.protocol || 'https:' === url.protocol ) {
+				const linkText = url.hostname
+					? translate( 'Back to %(hostname)s', {
+							args: { hostname: url.hostname },
+						} )
+					: translate( 'Back' );
+				return (
+					<ExternalLink href={ backTo }>
+						<Gridicon icon="arrow-left" size={ 18 } />
+						{ linkText }
+					</ExternalLink>
+				);
+			}
+		}
 		return (
 			<LoggedOutFormBackLink
 				oauth2Client={ this.props.oauth2Client }


### PR DESCRIPTION
This change allows a `back_to` param to be specificed on the `/log-in` route.

If the provided value passes a few checks (http, https or no protocol), it will be used by the link in place of the default "Back to WordPress.com" link.

Can be tested with D10366-code, which provides Jetpack functionality to return to the site. Together, #22518 is solved.

See p1HpG7-4Mw-p2

## Screens

### Before

![before](https://user-images.githubusercontent.com/841763/36480537-f599d754-170c-11e8-88fc-962fd15b4680.png)

### After

![after](https://user-images.githubusercontent.com/841763/36480530-f29eb024-170c-11e8-8c64-39b8283a4313.png)

## Testing
- Default (no change)
  - https://calypso.live/log-in?branch=update/jetpack/connect-login-back
- Good links (see customized back link)
  - https://calypso.live/log-in?branch=update/jetpack/connect-login-back&back_to=http%3A%2F%2Fyourgroovydomain.com
  - https://calypso.live/log-in?branch=update/jetpack/connect-login-back&back_to=%2Fjetpack%2Fconnect
- Bad links (Should see default Back to WordPress.com)
  - https://calypso.live/log-in?branch=update/jetpack/connect-login-back&back_to=javascript%3Aalert(%22You've%20been%20pwned!%22)"
  - https://calypso.live/log-in?branch=update/jetpack/connect-login-back&back_to=ftp%3A%2F%2Fno-ftp-allowed

Fixes #22518