### PR TITLE
Adding a privacy section in account settings behind feature flag `me/privacy`

### DIFF
--- a/client/me/privacy/controller.js
+++ b/client/me/privacy/controller.js
@@ -14,10 +14,8 @@ import PrivacyComponent from 'me/privacy/main';
 
 export default function privacyController( context, next ) {
 	if ( ! config.isEnabled( 'me/privacy' ) ) {
-		page.redirect( '/me' );
-	} else {
-		context.primary = React.createElement( PrivacyComponent );
+		return page.redirect( '/me' );
 	}
-
+	context.primary = React.createElement( PrivacyComponent );
 	next();
 }

--- a/client/me/privacy/controller.js
+++ b/client/me/privacy/controller.js
@@ -1,0 +1,19 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import userSettings from 'lib/user-settings';
+import PrivacyComponent from 'me/privacy/main';
+
+export default function privacyController( context, next ) {
+	context.primary = React.createElement( PrivacyComponent, {
+		userSettings: userSettings,
+	} );
+	next();
+}

--- a/client/me/privacy/controller.js
+++ b/client/me/privacy/controller.js
@@ -8,12 +8,9 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import userSettings from 'lib/user-settings';
 import PrivacyComponent from 'me/privacy/main';
 
 export default function privacyController( context, next ) {
-	context.primary = React.createElement( PrivacyComponent, {
-		userSettings: userSettings,
-	} );
+	context.primary = React.createElement( PrivacyComponent );
 	next();
 }

--- a/client/me/privacy/controller.js
+++ b/client/me/privacy/controller.js
@@ -4,13 +4,20 @@
  * External dependencies
  */
 import React from 'react';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
+import config from 'config';
 import PrivacyComponent from 'me/privacy/main';
 
 export default function privacyController( context, next ) {
-	context.primary = React.createElement( PrivacyComponent );
+	if ( ! config.isEnabled( 'me/privacy' ) ) {
+		page.redirect( '/me' );
+	} else {
+		context.primary = React.createElement( PrivacyComponent );
+	}
+
 	next();
 }

--- a/client/me/privacy/index.js
+++ b/client/me/privacy/index.js
@@ -1,0 +1,18 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import meController from 'me/controller';
+import privacyController from './controller';
+import { makeLayout, render as clientRender } from 'controller';
+
+export default function() {
+	page( '/me/privacy', meController.sidebar, privacyController, makeLayout, clientRender );
+}

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -3,31 +3,17 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-import React from 'react';
-import createReactClass from 'create-react-class';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { protectForm } from 'lib/protect-form';
-import formBase from 'me/form-base';
 import DocumentHead from 'components/data/document-head';
 import Main from 'components/main';
 
-// NOTE: disabling it since we need to use the `formBase` mixin
-// eslint-disable-next-line react/prefer-es6-class
-const Privacy = createReactClass( {
-	displayName: 'Privacy',
-
-	mixins: [ formBase ],
-
-	propTypes: {
-		userSettings: PropTypes.object.isRequired,
-	},
-
+class Privacy extends Component {
 	render() {
 		return (
 			<Main className="privacy">
@@ -35,7 +21,7 @@ const Privacy = createReactClass( {
 				Privacy form incoming
 			</Main>
 		);
-	},
-} );
+	}
+}
 
-export default compose( localize, protectForm )( Privacy );
+export default compose( localize )( Privacy );

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -1,0 +1,41 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import createReactClass from 'create-react-class';
+import { localize } from 'i18n-calypso';
+import { flowRight as compose } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { protectForm } from 'lib/protect-form';
+import formBase from 'me/form-base';
+import DocumentHead from 'components/data/document-head';
+import Main from 'components/main';
+
+// NOTE: disabling it since we need to use the `formBase` mixin
+// eslint-disable-next-line react/prefer-es6-class
+const Privacy = createReactClass( {
+	displayName: 'Privacy',
+
+	mixins: [ formBase ],
+
+	propTypes: {
+		userSettings: PropTypes.object.isRequired,
+	},
+
+	render() {
+		return (
+			<Main className="privacy">
+				<DocumentHead title={ this.props.translate( 'Privacy Settings' ) } />
+				Privacy form incoming
+			</Main>
+		);
+	},
+} );
+
+export default compose( localize, protectForm )( Privacy );

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -87,6 +87,7 @@ class MeSidebar extends React.Component {
 			'/me/security/connected-applications': 'security',
 			'/me/security/social-login': 'security',
 			'/me/security/two-step': 'security',
+			'me/privacy': 'privacy',
 			'/me/notifications/comments': 'notifications',
 			'/me/notifications/updates': 'notifications',
 			'/me/notifications/subscriptions': 'notifications',
@@ -164,6 +165,15 @@ class MeSidebar extends React.Component {
 							icon="lock"
 							onNavigate={ this.onNavigate }
 							preloadSectionName="security"
+						/>
+
+						<SidebarItem
+							selected={ selected === 'privacy' }
+							link={ '/me/privacy' }
+							label={ translate( 'Privacy' ) }
+							icon="visible"
+							onNavigate={ this.onNavigate }
+							preloadSectionName="privacy"
 						/>
 
 						<SidebarItem

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -167,14 +167,16 @@ class MeSidebar extends React.Component {
 							preloadSectionName="security"
 						/>
 
-						<SidebarItem
-							selected={ selected === 'privacy' }
-							link={ '/me/privacy' }
-							label={ translate( 'Privacy' ) }
-							icon="visible"
-							onNavigate={ this.onNavigate }
-							preloadSectionName="privacy"
-						/>
+						{ config.isEnabled( 'me/privacy' ) && (
+							<SidebarItem
+								selected={ selected === 'privacy' }
+								link={ '/me/privacy' }
+								label={ translate( 'Privacy' ) }
+								icon="visible"
+								onNavigate={ this.onNavigate }
+								preloadSectionName="privacy"
+							/>
+						) }
 
 						<SidebarItem
 							selected={ selected === 'notifications' }

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -48,6 +48,13 @@ const sections = [
 		secondary: true,
 	},
 	{
+		name: 'privacy',
+		paths: [ '/me/privacy' ],
+		module: 'me/privacy',
+		group: 'me',
+		secondary: true,
+	},
+	{
 		name: 'purchases',
 		paths: [ '/me/purchases', '/purchases', '/me/billing', '/payment-methods/add-credit-card' ],
 		module: 'me/purchases',

--- a/config/development.json
+++ b/config/development.json
@@ -106,6 +106,7 @@
 		"me/my-profile": true,
 		"me/next-steps": true,
 		"me/notifications": true,
+		"me/privacy": true,
 		"me/trophies": false,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,


### PR DESCRIPTION
Introduces a new section in the user settings called `privacy` with a placeholder text for now. It's only available behind the `me/privacy` feature flag, enabled only in `development.json` for now.

<img width="494" alt="screen shot 2018-02-21 at 14 47 16" src="https://user-images.githubusercontent.com/1145270/36483376-37f67c52-1716-11e8-88b9-a9a24849e909.png">

Open questions:

- The `visible` GridIcon might not be the best choice, ideas welcomed.
- I tried to trim as much as possible the controller / main component for now ( compared to other part of `/me` ), but it's still using the `formBase` mixin which might not be ideal?
- It introduces a second `DocumentHead` in the react tree since there is one coming from the default layout. I don't think it's an issue as other places work fine with 2 `DocumentHead`s ( like the Reader ) If we accept this way of doing it, I'll create another PR to remove the `setTitle` dispatched via the context in other controllers under `/me`.