### PR TITLE
Split "node_modules/tinymce/*" into its own chunk.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -249,6 +249,10 @@ if ( calypsoEnv === 'desktop' ) {
 	// NOTE: order matters. vendor must be before manifest.
 	webpackConfig.plugins = webpackConfig.plugins.concat( [
 		new webpack.optimize.CommonsChunkPlugin( { name: 'vendor', minChunks: Infinity } ),
+		new webpack.optimize.CommonsChunkPlugin( {
+			async: 'tinymce',
+			minChunks: ( { resource } ) => resource && /node_modules[\/\\]tinymce/.test( resource ),
+		} ),
 		new webpack.optimize.CommonsChunkPlugin( { name: 'manifest' } ),
 	] );
 


### PR DESCRIPTION
The Store uses a simplified re-implementation of the Post Editor (called `compact-tinymce`) for writing product descriptions. Since `tinymce` isn't on the `build` or `vendor` chunks, it means that it was being included in both the `woocommerce` and `post-editor` chunks, and it's **not** a small dependency.

This PR moves all `node_modules/tinymce/*` files to its own chunk. It will work as a `vendor` chunk (it will be cached for a long time because we don't update the `tinymce` dependency frequently), but it's required on-demand (when the `woocommerce` or `post-editor` chunks are required).

The data on ICFY aligns with my expectations: http://iscalypsofastyet.com/branch?branch=update/split-tinymce

A new chunk was created, the same amount of code was removed from the `post-editor` chunk, and a bit less than that was removed from the `woocommerce` chunk. The reason is that the editor in the `woocommerce` chunk doesn't use as many bells and whistles (tinyMCE plugins) as `post-editor`. Even though it would be possible to make the build a wee bit smaller (only put into the `tinymce` chunk the parts that are used by both `woocommerce` and `post-editor`), I prefer it this way because the `tinymce` chunk can be cached for a long time (similar to `vendor`) in the users' computers.

To test:
* Check that you can write a blog post.
* Check that you can write a product description (in the Store panel).
* Check that when you open the Post Editor (or you hover on the "Add post" button), both the `post-editor` and `tinymce-build` JS files are requested to the server.
* Check that when you open the "Store" section, both the `woocommerce` and the `tinymce-build` JS files are requested to the server.