### PR TITLE
Plugin Information: JS console warning due to a wrong prop

### DIFF
--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -283,7 +283,6 @@ class PluginInformation extends React.Component {
 							{ Object.keys( actionLinks ).map( ( linkTitle, index ) => (
 								<Button
 									compact
-									icon
 									href={ actionLinks[ linkTitle ] }
 									target="_blank"
 									key={ 'action-link-' + index }


### PR DESCRIPTION
Upon visiting the plugin information screen at

http://calypso.localhost:3000/plugins/jetpack/some-site-slug

the JS console throws this warning:

```
index.jsx:81 Warning: Received `true` for a non-boolean attribute `icon`.

If you want to write it to the DOM, pass a string instead: icon="true" or icon={value.toString()}.
    in a (created by Button)
    in Button (created by PluginInformation)
    in div (created by PluginInformation)
    in div (created by PluginInformation)
    in div (created by Card)
    in Card (created by PluginInformation)
    in PluginInformation (created by Localized(PluginInformation))
    in Localized(PluginInformation) (created by PluginMeta)
    in div (created by PluginMeta)
    in PluginMeta (created by Localized(PluginMeta))
    in Localized(PluginMeta) (created by Connect(Localized(PluginMeta)))
    in Connect(Localized(PluginMeta)) (created by SinglePlugin)
```

due to the `icon` prop passed to the Button component and not recognized in it.

This PR solves this by removing this prop unknown to the component.