### PR TITLE
Analytics: send Floodlight `u4` params as string, not number

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -965,7 +965,7 @@ function floodlightUserParams() {
 
 	const currentUser = user.get();
 	if ( currentUser ) {
-		params.u4 = currentUser.ID;
+		params.u4 = currentUser.ID.toString();
 	}
 
 	const anonymousUserId = tracksAnonymousUserId();


### PR DESCRIPTION
Floodlight `u4` custom parameter has to be sent as a string, not as number, in order to be used as a "dimension" as opposed to a "metric".
