### PR TITLE
Settings: Prevent an error notice when saving JP settings in certain cases

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -157,7 +157,10 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			const apiVersion = siteIsJetpack ? jetpackSiteSettingsAPIVersion : '1.4';
 			this.props.saveSiteSettings( siteId, { ...siteFields, apiVersion } );
 			if ( jetpackSettingsUISupported ) {
-				this.props.updateSettings( siteId, pick( fields, settingsFields.jetpack ) );
+				const fieldsToUpdate = /^error_/.test( fields.lang_id )
+					? omit( fields, 'lang_id' )
+					: fields;
+				this.props.updateSettings( siteId, pick( fieldsToUpdate, settingsFields.jetpack ) );
 			}
 		};
 


### PR DESCRIPTION
This picks up from #22638 with the suggestion from @tyxla.

Currently when we save a settings Jepack returns an error if the site has defigned the constant define( 'WPLANG', 'en_CA' ) defined.

This PR fixes this by making sure that we don't send the data to Jetpack if the site has the constant set.

Related to #21482

Fixes 1763-gh-jpop-issues

To test

Add define( 'WPLANG', 'en_CA' ); to you jetpack sites wp-config.php
Notice that you get a an error saving a setting.
Notice that this is not the case with this PR.

This PR fixed this by removing the `lang_id` field from those which get saved when an error condition exists so that the data doesn't get sent to the endpoint in the first place.