### PR TITLE
Domains: Ensure the redemption product is always added when applicable

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -512,16 +512,6 @@ export function domainPrivacyProtection( properties ) {
 }
 
 /**
- * Creates a new shopping cart item for a domain redemption late fee.
- *
- * @param {Object} properties - list of properties
- * @returns {Object} the new item as `CartItemValue` object
- */
-export function domainRedemption( properties ) {
-	return domainItem( 'domain_redemption', properties.domain, properties.source );
-}
-
-/**
  * Creates a new shopping cart item for an incoming domain transfer.
  *
  * @param {Object} properties - list of properties
@@ -958,7 +948,6 @@ export default {
 	customDesignItem,
 	domainMapping,
 	domainPrivacyProtection,
-	domainRedemption,
 	domainRegistration,
 	domainTransfer,
 	domainTransferPrivacy,

--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -31,7 +31,6 @@ function createPurchaseObject( purchase ) {
 		includedDomain: purchase.included_domain,
 		isCancelable: Boolean( purchase.is_cancelable ),
 		isDomainRegistration: Boolean( purchase.is_domain_registration ),
-		isRedeemable: Boolean( purchase.is_redeemable ),
 		isRefundable: Boolean( purchase.is_refundable ),
 		isRenewable: Boolean( purchase.is_renewable ),
 		isRenewal: Boolean( purchase.is_renewal ),

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -138,10 +138,6 @@ function isPendingTransfer( purchase ) {
 	return purchase.pendingTransfer;
 }
 
-function isRedeemable( purchase ) {
-	return purchase.isRedeemable;
-}
-
 /**
  * Checks if a purchase credit card number can be updated
  * Payments done via CC & Paygate can have their CC updated, but this
@@ -328,7 +324,6 @@ export {
 	isExpiring,
 	isIncludedWithPlan,
 	isOneTimePurchase,
-	isRedeemable,
 	isRefundable,
 	isRemovable,
 	isRenewable,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -29,7 +29,6 @@ import {
 	isExpired,
 	isExpiring,
 	isOneTimePurchase,
-	isRedeemable,
 	isRefundable,
 	isRenewable,
 	isRenewal,
@@ -144,20 +143,6 @@ class ManagePurchase extends Component {
 			);
 
 			renewItems.push( privacyItem );
-		}
-
-		if ( isRedeemable( purchase ) ) {
-			const redemptionItem = cartItems.getRenewalItemFromCartItem(
-				cartItems.domainRedemption( {
-					domain: purchase.meta,
-				} ),
-				{
-					id: purchase.id,
-					domain: purchase.domain,
-				}
-			);
-
-			renewItems.push( redemptionItem );
 		}
 
 		addItems( renewItems );

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -22,7 +22,6 @@ import {
 	isExpiring,
 	isIncludedWithPlan,
 	isOneTimePurchase,
-	isRedeemable,
 	isRenewable,
 	showCreditCardExpiringWarning,
 } from 'lib/purchases';
@@ -209,7 +208,7 @@ class PurchaseNotice extends Component {
 		const purchase = getPurchase( this.props );
 		const { translate } = this.props;
 
-		if ( ! isRenewable( purchase ) && ! isRedeemable( purchase ) ) {
+		if ( ! isRenewable( purchase ) ) {
 			return null;
 		}
 

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -93,7 +93,6 @@ describe( 'selectors', () => {
 				includedDomain: undefined,
 				isCancelable: false,
 				isDomainRegistration: false,
-				isRedeemable: false,
 				isRefundable: false,
 				isRenewable: false,
 				isRenewal: false,


### PR DESCRIPTION
As reported in p2MSmN-6et-p2, some checkout flows don't trigger adding the redemption product.
The root issue here is that we're doing it on the frontend to begin with. So I've moved that logic to the backend, where it should have been from the start. This way, no-one will be able to tamper with the shopping cart as well.

### Testing
You need D10377-code on your sandbox.

* `/me/purchases` -> Test Domain -> Renew now -> Redemption Fee should be automatically added to cart.
* Go to the site the domain is mapped to, and click on the Renew now link in the sidebar or in Domain Management -> Redemption Fee should be automatically added to cart.
* Verify that for domains that are _not_ in redemption, the redemption fee is not added.