### PR TITLE
Try: explore app shell improvements

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -14,6 +14,7 @@ import { get } from 'lodash';
 import { default as appConfig } from 'config';
 import { jsonStringifyForHtml } from '../../server/sanitize';
 import Head from '../components/head';
+import MasterbarShell from '../layout/masterbar/shell';
 import getStylesheet from './utils/stylesheet';
 
 class Document extends React.Component {
@@ -49,6 +50,7 @@ class Document extends React.Component {
 			feedbackURL,
 			inlineScriptNonce,
 			analyticsScriptNonce,
+			isLoggedIn,
 		} = this.props;
 
 		const inlineScript =
@@ -104,7 +106,7 @@ class Document extends React.Component {
 									[ 'is-group-' + sectionGroup ]: sectionGroup,
 								} ) }
 							>
-								<div className="masterbar" />
+								{ isLoggedIn ? <MasterbarShell /> : <div className="masterbar" /> }
 								<div className="layout__content">
 									<div className="wpcom-site__logo noticon noticon-wordpress" />
 									{ hasSecondary && (

--- a/client/layout/masterbar/shell.jsx
+++ b/client/layout/masterbar/shell.jsx
@@ -1,0 +1,34 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Masterbar from './masterbar.jsx';
+import Item from './item.jsx';
+
+class MasterbarShell extends React.Component {
+	render() {
+		return (
+			<Masterbar>
+				<Item icon="my-sites">
+					<span className="masterbar__item-placeholder">My Sites</span>
+				</Item>
+				<Item icon="reader" className="masterbar__reader">
+					<span className="masterbar__item-placeholder">Reader</span>
+				</Item>
+				<div className="masterbar__publish">
+					<Item icon="create" className="masterbar__item-new" />
+				</div>
+				<Item icon="user-circle" className="masterbar__item-me" />
+				<Item icon="bell" className="masterbar__item-notifications" />
+			</Masterbar>
+		);
+	}
+}
+
+export default MasterbarShell;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -92,6 +92,12 @@ $autobar-height: 20px;
 		color: var( --masterbar-color );
 	}
 
+	.masterbar__item-placeholder {
+		display: block;
+		@include placeholder;
+		line-height: 1;
+	}
+
 	.gridicon + .masterbar__item-content {
 		padding: 0 0 0 6px;
 	}

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -413,6 +413,14 @@ function setUpCSP( req, res, next ) {
 
 function setUpRoute( req, res, next ) {
 	req.context = getDefaultContext( req );
+
+	// @TODO don't merge this (!), only for testing purposes
+	if ( 'development' === process.env.NODE_ENV && req.query.login ) {
+		req.context.isLoggedIn = true;
+		setUpCSP( req, res, () => setUpLoggedInRoute( req, res, next ) );
+		return;
+	}
+
 	setUpCSP(
 		req,
 		res,


### PR DESCRIPTION
⚠️ **Don't merge**, explorations.

Regarding #19833 I want to explore how to improve the shell visually which is currently an empty layout (which is already better than a blank screen imo).

### Add placeholders to the masterbar

![calypso localhost_3000__login true iphone 5_se 1](https://user-images.githubusercontent.com/9202899/36493925-0235ef38-1731-11e8-8451-86a2b3d26c8a.png)
![calypso localhost_3000__login true iphone 5_se](https://user-images.githubusercontent.com/9202899/36493927-02778f4c-1731-11e8-9b5f-5138e84c91e4.png)

Afaik it's not possible to use translated strings on the server which is why I re-use a placeholder class known from other places around Calypso.

### Discussion

- How can we determine whether a user is _probably_ logged in? Do we track this in `req.context` in a way? [I've made adjustments for testing](https://github.com/Automattic/wp-calypso/compare/update/app-shell?expand=1#diff-b2d6784517d1151d7e75f0287d0c6478), but this is clearly not the way.
- Is "just" adding placeholders (this PR) already an improvement for users in terms of _perceived_ performance?

### Going futher

Iterate and make improvements over what this PR provides. For example:

- Adding an active class for the current route
![calypso localhost_3000__login true iphone 5_se 2](https://user-images.githubusercontent.com/9202899/36494883-b8ade3cc-1733-11e8-9857-086eadc57e36.png)
- Make the links clickable via `url` prop
![kapture 2018-02-21 at 18 44 14](https://user-images.githubusercontent.com/9202899/36496038-60c97046-1737-11e8-86e4-0c171298bad5.gif)
- Display the users avatar - [it seems we get user data depending on the environment](https://github.com/Automattic/wp-calypso/blob/master/server/pages/index.js#L300) - , could not test this yet though because I need to find out how to do this in dev
- ...