### PR TITLE
JP Onboarding: Make Generic Success Component

### DIFF
--- a/client/jetpack-onboarding/connect-success.jsx
+++ b/client/jetpack-onboarding/connect-success.jsx
@@ -1,0 +1,52 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Fragment, PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import FormattedHeader from 'components/formatted-header';
+import Tile from 'components/tile-grid/tile';
+import TileGrid from 'components/tile-grid';
+
+class ConnectSuccess extends PureComponent {
+	static propTypes = {
+		href: PropTypes.string,
+		illustration: PropTypes.string,
+		onClick: PropTypes.func,
+		title: PropTypes.string,
+		// from HOCs
+		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		onClick: noop,
+	};
+
+	render() {
+		const { href, illustration, onClick, title, translate } = this.props;
+
+		return (
+			<Fragment>
+				<FormattedHeader headerText={ title } />
+
+				<TileGrid>
+					<Tile
+						buttonLabel={ translate( 'Continue' ) }
+						image={ illustration }
+						onClick={ onClick }
+						href={ href }
+					/>
+				</TileGrid>
+			</Fragment>
+		);
+	}
+}
+
+export default localize( ConnectSuccess );

--- a/client/jetpack-onboarding/connect-success.jsx
+++ b/client/jetpack-onboarding/connect-success.jsx
@@ -6,7 +6,6 @@
 import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,10 +22,6 @@ class ConnectSuccess extends PureComponent {
 		title: PropTypes.string,
 		// from HOCs
 		translate: PropTypes.func,
-	};
-
-	static defaultProps = {
-		onClick: noop,
 	};
 
 	render() {

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import ConnectSuccess from '../connect-success';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import JetpackLogo from 'components/jetpack-logo';
@@ -64,27 +65,6 @@ class JetpackOnboardingStatsStep extends React.Component {
 		} );
 	}
 
-	renderSuccess() {
-		const { getForwardUrl, translate } = this.props;
-
-		return (
-			<Fragment>
-				<FormattedHeader
-					headerText={ translate( 'Success! Jetpack is now collecting valuable stats.' ) }
-				/>
-
-				<TileGrid>
-					<Tile
-						buttonLabel={ translate( 'Continue' ) }
-						image="/calypso/images/illustrations/type-business.svg"
-						onClick={ this.handleStatsNextButton }
-						href={ getForwardUrl() }
-					/>
-				</TileGrid>
-			</Fragment>
-		);
-	}
-
 	renderActionTile() {
 		const { isConnected, siteUrl, translate } = this.props;
 		const headerText = translate( 'Keep track of your visitors with Jetpack.' );
@@ -120,7 +100,7 @@ class JetpackOnboardingStatsStep extends React.Component {
 	}
 
 	render() {
-		const { activatedStats, basePath, siteId, translate } = this.props;
+		const { activatedStats, basePath, getForwardUrl, siteId, translate } = this.props;
 
 		return (
 			<div className="steps__main">
@@ -133,7 +113,16 @@ class JetpackOnboardingStatsStep extends React.Component {
 
 				<JetpackLogo full size={ 45 } />
 
-				{ activatedStats ? this.renderSuccess() : this.renderActionTile() }
+				{ activatedStats ? (
+					<ConnectSuccess
+						href={ getForwardUrl() }
+						illustration="/calypso/images/illustrations/type-business.svg"
+						onClick={ this.handleStatsNextButton }
+						title={ translate( 'Success! Jetpack is now collecting valuable stats.' ) }
+					/>
+				) : (
+					this.renderActionTile()
+				) }
 			</div>
 		);
 	}


### PR DESCRIPTION
For re-use with other steps (#22527, #22660)

See #22621 for testing instructions. Specifically, make sure the 'Success' screen still works.