### PR TITLE
Site Rename: A batch of fixes against the feature branch

### DIFF
--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { get, flow, inRange, isEmpty } from 'lodash';
 import Gridicon from 'gridicons';
@@ -25,6 +26,15 @@ const SUBDOMAIN_LENGTH_MINIMUM = 4;
 const SUBDOMAIN_LENGTH_MAXIMUM = 50;
 
 export class SimpleSiteRenameForm extends Component {
+	static propTypes = {
+		currentDomainSuffix: PropTypes.string.isRequired,
+		currentDomain: PropTypes.object.isRequired,
+
+		// `connect`ed
+		isSiteRenameRequesting: PropTypes.bool,
+		selectedSiteId: PropTypes.number,
+	};
+
 	static defaultProps = {
 		currentDomainSuffix: '.wordpress.com',
 		currentDomain: {},

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -116,13 +116,9 @@ export class SimpleSiteRenameForm extends Component {
 	render() {
 		const { currentDomain, currentDomainSuffix, isSiteRenameRequesting, translate } = this.props;
 		const currentDomainPrefix = get( currentDomain, 'name', '' ).replace( currentDomainSuffix, '' );
-		const isWPCOM = get( currentDomain, 'type' ) === 'WPCOM';
 		const { domainFieldError, domainFieldValue } = this.state;
 		const isDisabled =
-			! isWPCOM ||
-			! domainFieldValue ||
-			!! domainFieldError ||
-			domainFieldValue === currentDomainPrefix;
+			! domainFieldValue || !! domainFieldError || domainFieldValue === currentDomainPrefix;
 
 		return (
 			<div className="simple-site-rename-form">

--- a/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { flow } from 'lodash';
+import { flow, get } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -22,6 +22,7 @@ import VerticalNavItem from 'components/vertical-nav/item';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestSiteRename } from 'state/site-rename/actions';
 import SiteRenamer from 'blocks/simple-site-rename-form';
+import { type as domainTypes } from 'lib/domains/constants';
 
 const WpcomDomain = createReactClass( {
 	displayName: 'WpcomDomain',
@@ -32,6 +33,19 @@ const WpcomDomain = createReactClass( {
 	},
 
 	getEditSiteAddressBlock() {
+		const { domain } = this.props;
+
+		/**
+		 * Hide Edit site address for .blog subdomains as this is unsupported for now.
+		 */
+		if ( get( domain, 'name', '' ).match( /\.\w+\.blog$/ ) ) {
+			return null;
+		}
+
+		if ( isEnabled( 'site-renamer' ) && get( domain, 'type' ) === domainTypes.WPCOM ) {
+			return <SiteRenamer currentDomain={ domain } />;
+		}
+
 		return (
 			<VerticalNav>
 				<VerticalNavItem
@@ -48,12 +62,6 @@ const WpcomDomain = createReactClass( {
 	},
 
 	render() {
-		const { domain } = this.props;
-		/**
-		 * Hide Edit site address for .blog subdomains as this is unsupported for now.
-		 */
-		const isDotBlogDomain = domain.name.match( /\.\w+\.blog$/ );
-
 		return (
 			<div>
 				<div className="domain-details-card">
@@ -74,12 +82,7 @@ const WpcomDomain = createReactClass( {
 						</Property>
 					</Card>
 				</div>
-				{ ! isDotBlogDomain &&
-					( isEnabled( 'site-renamer' ) ? (
-						<SiteRenamer currentDomain={ domain } />
-					) : (
-						this.getEditSiteAddressBlock()
-					) ) }
+				{ this.getEditSiteAddressBlock() }
 			</div>
 		);
 	},

--- a/client/state/site-rename/actions.js
+++ b/client/state/site-rename/actions.js
@@ -35,7 +35,7 @@ const dispatchErrorNotice = ( dispatch, error ) =>
 	dispatch(
 		getErrorNotice(
 			// @TODO translate copy once finalised
-			error.message || "Sorry, we we're unable to complete your domain change. Please try again."
+			error.message || 'Sorry, we were unable to complete your domain change. Please try again.'
 		)
 	);
 


### PR DESCRIPTION
This is targeting `add/sites-rename-2` / #21861.

Changes in this branch:
* Add propTypes to SimpleSiteRenameForm
* Compare against `WPCOM` constant from lib/domains
* Don't render `SiteRenamer` at all when `domain.type !== WPCOM`
* Tidy up `WpcomDomain`'s render -- conditionally render in `getEditSiteAddressBlock`
* Fix up a typo in generic error message (we're => were)

## To Test

Follow instructions in #21861 -- this should behave identically