### PR TITLE
Invites: Add ability to clear all accepted invites

### DIFF
--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -22,6 +22,7 @@ import PeopleListItem from 'my-sites/people/people-list-item';
 import Card from 'components/card';
 import Button from 'components/button';
 import QuerySiteInvites from 'components/data/query-site-invites';
+import Dialog from 'components/dialog';
 import InvitesListEnd from './invites-list-end';
 import { getSelectedSite } from 'state/ui/selectors';
 import {
@@ -38,6 +39,19 @@ class PeopleInvites extends React.PureComponent {
 		site: PropTypes.object,
 	};
 
+	constructor( props ) {
+		super( props );
+		this.state = {
+			showClearAllConfirmation: false,
+		};
+	}
+
+	toggleClearAllConfirmation = () => {
+		this.setState( {
+			showClearAllConfirmation: ! this.state.showClearAllConfirmation,
+		} );
+	};
+
 	handleClearAll = () => {
 		const { acceptedInvites, deleting, site } = this.props;
 
@@ -46,6 +60,7 @@ class PeopleInvites extends React.PureComponent {
 		}
 
 		this.props.deleteInvites( site.ID, map( acceptedInvites, 'key' ) );
+		this.toggleClearAllConfirmation();
 	};
 
 	render() {
@@ -127,10 +142,25 @@ class PeopleInvites extends React.PureComponent {
 	renderClearAll() {
 		const { deleting, translate } = this.props;
 
+		const dialogButtons = [
+			<Button busy={ deleting } primary onClick={ this.handleClearAll }>
+				{ translate( 'Clear All' ) }
+			</Button>,
+			<Button busy={ deleting } onClick={ this.toggleClearAllConfirmation }>
+				{ translate( 'Cancel' ) }
+			</Button>,
+		];
+
 		return (
-			<Button busy={ deleting } compact onClick={ this.handleClearAll }>
-				{ translate( 'Clear All Accepted' ) }
-			</Button>
+			<React.Fragment>
+				<Button busy={ deleting } compact onClick={ this.toggleClearAllConfirmation }>
+					{ translate( 'Clear All Accepted' ) }
+				</Button>
+				<Dialog isVisible={ this.state.showClearAllConfirmation } buttons={ dialogButtons }>
+					<h1>{ translate( 'Clear All Accepted' ) }</h1>
+					<p>{ translate( 'Are you sure you wish to clear all accepted invites?' ) }</p>
+				</Dialog>
+			</React.Fragment>
 		);
 	}
 

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { get, find } from 'lodash';
+import { get, find, indexOf, values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -138,4 +138,19 @@ export function isDeletingInvite( state, siteId, inviteId ) {
  */
 export function didInviteDeletionSucceed( state, siteId, inviteId ) {
 	return 'success' === get( state, [ 'invites', 'deleting', siteId, inviteId ], false );
+}
+
+/**
+ * Returns true if currently deleting any invite for the given site,
+ * or false otherwise.
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+
+ * @return {Boolean}          Whether an invite is being deleted
+ */
+export function isDeletingAnyInvite( state, siteId ) {
+	return (
+		-1 !== indexOf( values( get( state, [ 'invites', 'deleting', siteId ], {} ) ), 'requesting' )
+	);
 }

--- a/client/state/invites/test/selectors.js
+++ b/client/state/invites/test/selectors.js
@@ -19,6 +19,7 @@ import {
 	getInviteForSite,
 	isDeletingInvite,
 	didInviteDeletionSucceed,
+	isDeletingAnyInvite,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -521,6 +522,45 @@ describe( 'selectors', () => {
 				},
 			};
 			expect( isDeletingInvite( state, 12345, '9876asdf54321' ) ).to.equal( false );
+		} );
+	} );
+
+	describe( '#isDeletingAnyInvite()', () => {
+		test( 'should return true when requesting deletion for any invite on the site', () => {
+			const state = {
+				invites: {
+					deleting: {
+						12345: {
+							'123456asdf789': 'requesting',
+							'9876asdf54321': 'success',
+						},
+					},
+				},
+			};
+			expect( isDeletingAnyInvite( state, 12345 ) ).to.equal( true );
+		} );
+
+		test( 'should return false when all deletion requests are complete', () => {
+			const state = {
+				invites: {
+					deleting: {
+						12345: {
+							'123456asdf789': 'success',
+							'9876asdf54321': 'success',
+						},
+					},
+				},
+			};
+			expect( isDeletingAnyInvite( state, 12345 ) ).to.equal( false );
+		} );
+
+		test( 'should return false when deletion has not been requested', () => {
+			const state = {
+				invites: {
+					deleting: {},
+				},
+			};
+			expect( isDeletingAnyInvite( state, 12345 ) ).to.equal( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds the ability to clear all accepted invites from the Invites page within people management.

See p3Ex-32O-p2.

![clearallaccepted](https://user-images.githubusercontent.com/363749/36504071-e1617686-1714-11e8-8fbd-f8fae0a8e5f5.gif)

To test:

* Send one or more invites to another user and accept them so that they show up in the accepted invites section within people management
* Verify that the "Clear All Invites" button appears in the accepted invites section
* Verify that clicking the button brings up a confirmation dialog
* Verify that canceling closes the dialog without clearing the invites
* Verify that confirming clearing removes all of your accepted invites and closes the dialog