### PR TITLE
Kracken: Implement styling changes from i2 designs

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import PremiumPopover from 'components/plans/premium-popover';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
@@ -61,13 +62,13 @@ class DomainProductPrice extends React.Component {
 	}
 
 	renderIncludedInPremium() {
+		const textLabel = config.isEnabled( 'domains/kracken-ui' )
+			? this.props.translate( 'Included in Paid Plans' )
+			: this.props.translate( 'Included in WordPress.com Premium' );
 		return (
 			<div className="domain-product-price is-with-plans-only">
 				<small className="domain-product-price__premium-text" ref="subMessage">
-					<PremiumPopover
-						position="bottom left"
-						textLabel={ this.props.translate( 'Included in WordPress.com Premium' ) }
-					/>
+					<PremiumPopover position="bottom left" textLabel={ textLabel } />
 				</small>
 			</div>
 		);

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -12,19 +12,28 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import DomainProductPrice from 'components/domains/domain-product-price';
 import Button from 'components/button';
 
 class DomainSuggestion extends React.Component {
 	static propTypes = {
 		buttonContent: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ).isRequired,
-		buttonClasses: PropTypes.string,
+		buttonProps: PropTypes.object,
 		extraClasses: PropTypes.string,
 		onButtonClick: PropTypes.func.isRequired,
 		priceRule: PropTypes.string,
 		price: PropTypes.string,
 		domain: PropTypes.string,
 		hidePrice: PropTypes.bool,
+		showChevron: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		buttonProps: config.isEnabled( 'domains/kracken-ui' )
+			? { primary: true }
+			: { borderless: true },
+		showChevron: ! config.isEnabled( 'domains/kracken-ui' ),
 	};
 
 	render() {
@@ -36,6 +45,7 @@ class DomainSuggestion extends React.Component {
 			'is-clickable',
 			{
 				'is-added': isAdded,
+				'is-kracken-ui': config.isEnabled( 'domains/kracken-ui' ),
 			},
 			extraClasses
 		);
@@ -52,10 +62,12 @@ class DomainSuggestion extends React.Component {
 					{ children }
 					{ ! hidePrice && <DomainProductPrice rule={ priceRule } price={ price } /> }
 				</div>
-				<Button borderless className="domain-suggestion__action">
+				<Button className="domain-suggestion__action" { ...this.props.buttonProps }>
 					{ this.props.buttonContent }
 				</Button>
-				<Gridicon className="domain-suggestion__chevron" icon="chevron-right" />
+				{ this.props.showChevron && (
+					<Gridicon className="domain-suggestion__chevron" icon="chevron-right" />
+				) }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -110,6 +110,13 @@
 	text-align: center;
 	color: $blue-medium;
 
+	// NOTE: .is-kracken-ui can be removed once feature is deployed.
+	.is-kracken-ui &.is-primary {
+		color: $white;
+		padding-left: 3em;
+		padding-right: 3em;
+	}
+
 	.is-placeholder & {
 		animation: loading-fade 1.6s ease-in-out infinite;
 		background-color: $gray-lighten-30;

--- a/client/components/domains/domain-transfer-suggestion/index.jsx
+++ b/client/components/domains/domain-transfer-suggestion/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import DomainSuggestion from 'components/domains/domain-suggestion';
 
 class DomainTransferSuggestion extends React.Component {
@@ -23,6 +24,14 @@ class DomainTransferSuggestion extends React.Component {
 			context: 'Domain transfer or mapping suggestion button',
 		} );
 
+		const props = config.isEnabled( 'domains/kracken-ui' )
+			? {
+					buttonProps: { borderless: true },
+					extraClasses: 'is-visible domain-transfer-suggestion is-kracken-ui',
+					showChevron: true,
+				}
+			: {};
+
 		return (
 			<DomainSuggestion
 				extraClasses="is-visible domain-transfer-suggestion"
@@ -30,6 +39,7 @@ class DomainTransferSuggestion extends React.Component {
 				onButtonClick={ this.props.onButtonClick }
 				tracksButtonClickSource={ this.props.tracksButtonClickSource }
 				hidePrice={ true }
+				{ ...props }
 			>
 				<div className="domain-transfer-suggestion__domain-description">
 					<h3>

--- a/client/components/domains/domain-transfer-suggestion/style.scss
+++ b/client/components/domains/domain-transfer-suggestion/style.scss
@@ -1,5 +1,9 @@
 .domain-transfer-suggestion {
 	display: flex;
+
+	&.is-kracken-ui .button.domain-suggestion__action {
+		color: $blue-medium;
+	}
 }
 
 .domain-transfer-suggestion__domain-description {

--- a/config/development.json
+++ b/config/development.json
@@ -49,6 +49,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domains/kracken-ui": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -29,6 +29,7 @@
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,
 		"domains/cctlds/uk": true,
+		"domains/kracken-ui": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
This change implements styling changes from i2 designs behind a feature gate `domains/kracken-ui`. It accomplishes the following:

- Changes domain suggestion text buttons into primary buttons
- Removes right carets from domain suggestion results
- Preserves appearance of domain transfer suggestion
- Changes `Included in WordPress.com Premium` to `Included in Paid Plans`. (Note that this part is the most likely to change in the next design iteration. We could drop this change from the PR if any reviewer has a strong opinion on the matter.)

------

Before the change:
![before](https://user-images.githubusercontent.com/4044428/36507907-4c199b04-1718-11e8-91c8-e1d9c2212f07.png)

After the change, with the feature gate enabled:
![after](https://user-images.githubusercontent.com/4044428/36507878-3b0108d4-1718-11e8-92f6-a60a9f7f58b0.png)

Domain transfer suggestion, unchanged both before and after:
![same](https://user-images.githubusercontent.com/4044428/36508087-dc9d3a00-1718-11e8-99fb-8b3c9fd147e6.png)

Design discussion: p989we-cM-p2