### PR TITLE
Fix malformatted POST data in mailing list (un)subscribe API requests

### DIFF
--- a/client/lib/wpcom-undocumented/lib/mailing-list.js
+++ b/client/lib/wpcom-undocumented/lib/mailing-list.js
@@ -111,10 +111,10 @@ function createSubscriberResourceUrl( category, emailAddress, method ) {
 }
 
 function createRequestBody( hmac, context ) {
-	return JSON.stringify( {
+	return {
 		hmac: hmac,
 		context: context,
-	} );
+	};
 }
 
 /*!


### PR DESCRIPTION
Calypso is currently submitting the POST data to the mailing-list endpoint incorrectly. The endpoint expects regular POST variables but we're instead sending a single JSON string.
This is resulting in unsubscribe links used in many of our emails to not work.
<img width="1640" alt="screen shot 2018-02-21 at 2 30 13 pm" src="https://user-images.githubusercontent.com/690843/36509241-e8701a28-1713-11e8-962b-93ab80c98d80.png">


Here's a couple of examples of `$input` from the PHP side.

Correct
```
stdClass Object
(
    [hmac] => 123456790
    [context] => stdClass Object()

)
```

Incorrect (current)
```
stdClass Object
(
    [scalar] => {"hmac":"123456790","context":{}}
)
```

This change just removes the code that turns the object into a string. I couldn't find anywhere else where we're stringify-ing the POST data before passing it to `wpcom.req.post`. All other examples I saw were passing a regular object.

I also haven't been able to find what was changed that originally broke this. 


## Test Plan

Generate an unsubscribe URL for your wpcom account email address
From `wpsh`:
```
echo Mailing_Lists::generate_unsubscribe_url( 'marketing', 'yourname@example.com' )
```

Visit that link, replacing `https://wordpress.com` with `http://calypso.localhost:3000`

Once that page loads, it automatically submits the POST request to the API.
If successful, you should see the message: "Unsubscribed from Suggestions"
<img width="1774" alt="screen shot 2018-02-21 at 2 22 53 pm" src="https://user-images.githubusercontent.com/690843/36509372-5a80a5d8-1714-11e8-8d03-12bfe0982bea.png">

Click the button that should now say "Resubscribe". You should see the message: "Subscribed to Suggestions"