### PR TITLE
JP Onboarding: Have JPC redirect back

### DIFF
--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -76,7 +76,7 @@ class JetpackOnboardingStatsStep extends React.Component {
 		const connectUrl = addQueryArgs(
 			{
 				from: 'jpo',
-				redirectAfterAuth: [ basePath, stepName, siteSlug ].join( '/' ),
+				redirect_after_auth: [ basePath, stepName, siteSlug ].join( '/' ),
 				url: siteUrl,
 				// TODO: add a parameter to the JPC to redirect back to this step after completion
 				// and in the redirect URL include the ?action=activate_stats parameter

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import ConnectSuccess from '../connect-success';
+import config from 'config';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import JetpackLogo from 'components/jetpack-logo';
@@ -66,7 +67,7 @@ class JetpackOnboardingStatsStep extends React.Component {
 	}
 
 	renderActionTile() {
-		const { basePath, isConnected, siteSlug, siteUrl, stepName, translate } = this.props;
+		const { isConnected, siteUrl, translate } = this.props;
 		const headerText = translate( 'Keep track of your visitors with Jetpack.' );
 		const subHeaderText = translate(
 			'Keep an eye on your success with simple, concise, and mobile-friendly stats. ' +
@@ -76,13 +77,10 @@ class JetpackOnboardingStatsStep extends React.Component {
 		const connectUrl = addQueryArgs(
 			{
 				from: 'jpo',
-				redirect_after_auth: [ basePath, stepName, siteSlug ].join( '/' ),
-				url: siteUrl,
-				// TODO: add a parameter to the JPC to redirect back to this step after completion
-				// and in the redirect URL include the ?action=activate_stats parameter
-				// to actually trigger the stats activation action after getting back to JPO
+				redirect_after_auth: addQueryArgs( { action: 'activate_stats' }, window.location.href ),
+				calypso_env: config( 'env_id' ),
 			},
-			'/jetpack/connect'
+			siteUrl + '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true'
 		);
 		const href = ! isConnected ? connectUrl : null;
 

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -66,14 +66,17 @@ class JetpackOnboardingStatsStep extends React.Component {
 	}
 
 	renderActionTile() {
-		const { isConnected, siteUrl, translate } = this.props;
+		const { basePath, isConnected, siteSlug, siteUrl, stepName, translate } = this.props;
 		const headerText = translate( 'Keep track of your visitors with Jetpack.' );
 		const subHeaderText = translate(
 			'Keep an eye on your success with simple, concise, and mobile-friendly stats. ' +
 				'Get updates on site traffic, successful posts, site searches, and comments, all in real time.'
 		);
+
 		const connectUrl = addQueryArgs(
 			{
+				from: 'jpo',
+				redirectAfterAuth: [ basePath, stepName, siteSlug ].join( '/' ),
 				url: siteUrl,
 				// TODO: add a parameter to the JPC to redirect back to this step after completion
 				// and in the redirect URL include the ?action=activate_stats parameter


### PR DESCRIPTION
This PR allows us to redirect back to JPO when trying to activate stats and JPC finishes. It is expected to work just fine for users who are logged into WP.com, but it **won't work for logged out users**.

Fixes #22533 

Test instructions:
* Checkout this branch on your local Calypso.
* Start a fresh JN site with https://github.com/Automattic/jetpack/pull/8915 on it (you can do that by loading https://jurassic.ninja/create?jetpack-beta&branch=update/jpc-respect-from-and-calypso-redirects)
* Make sure you are logged into WP.com and the Jetpack site.
* Start the onboarding flow by going to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development`
* Reach the Stats step.
* Click the "Activate stats" button.
* You should be redirected a few times, ending in JPC, where you have to authorize the connection.
* After authorizing, verify you're redirected to the stats page.
* Verify that after a short bit the module gets activated and you see the success screen.