### PR TITLE
Site Rename: A new batch of fixes against the feature branch

### DIFF
--- a/client/blocks/simple-site-rename-form/dialog.jsx
+++ b/client/blocks/simple-site-rename-form/dialog.jsx
@@ -92,9 +92,15 @@ class SiteRenamerConfirmationDialog extends PureComponent {
 					) }
 				</p>
 				<div className="simple-site-rename-form__confirmation-detail">
-					<Gridicon icon="cross-circle" size={ 18 } className="simple-site-rename-form__copy-red" />
+					<Gridicon
+						icon="cross-circle"
+						size={ 18 }
+						className="simple-site-rename-form__copy-deletion"
+					/>
 					<p className="simple-site-rename-form__confirmation-detail-copy">
-						<strong className="simple-site-rename-form__copy-red">{ currentDomainName }</strong>
+						<strong className="simple-site-rename-form__copy-deletion">
+							{ currentDomainName }
+						</strong>
 						{ currentDomainSuffix }
 						<br />
 						{ translate( 'Will be removed and unavailable for use.' ) }
@@ -104,10 +110,10 @@ class SiteRenamerConfirmationDialog extends PureComponent {
 					<Gridicon
 						icon="checkmark-circle"
 						size={ 18 }
-						className="simple-site-rename-form__copy-green"
+						className="simple-site-rename-form__copy-addition"
 					/>
 					<p className="simple-site-rename-form__confirmation-detail-copy">
-						<strong className="simple-site-rename-form__copy-green">{ newDomainName }</strong>
+						<strong className="simple-site-rename-form__copy-addition">{ newDomainName }</strong>
 						{ newDomainSuffix }
 						<br />
 						{ translate( 'Will be your new site address.' ) }

--- a/client/blocks/simple-site-rename-form/dialog.jsx
+++ b/client/blocks/simple-site-rename-form/dialog.jsx
@@ -87,8 +87,8 @@ class SiteRenamerConfirmationDialog extends PureComponent {
 				<h1>{ translate( "Let's Review" ) }</h1>
 				<p>
 					{ translate(
-						'You are about to change your domain name. Once changed, ' +
-							'your previous domain name will be unavailable for you or anyone else.'
+						'You are about to change your site address. Once changed, ' +
+							'your previous site address will be unavailable for you or anyone else.'
 					) }
 				</p>
 				<div className="simple-site-rename-form__confirmation-detail">

--- a/client/blocks/simple-site-rename-form/dialog.jsx
+++ b/client/blocks/simple-site-rename-form/dialog.jsx
@@ -110,7 +110,7 @@ class SiteRenamerConfirmationDialog extends PureComponent {
 						<strong className="simple-site-rename-form__copy-green">{ newDomainName }</strong>
 						{ newDomainSuffix }
 						<br />
-						{ translate( 'Will be your new primary domain.' ) }
+						{ translate( 'Will be your new site address.' ) }
 					</p>
 				</div>
 				<h1>{ translate( 'Check the box to confirm' ) }</h1>

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -38,7 +38,7 @@ export class SimpleSiteRenameForm extends Component {
 
 	onConfirm = () => {
 		const { selectedSiteId } = this.props;
-		// @TODO: Give ability to chose whether or not to discard the original domain name.
+		// @TODO: Give ability to chose whether or not to discard the original site address.
 		const discard = true;
 
 		this.props.requestSiteRename( selectedSiteId, this.state.domainFieldValue, discard );
@@ -52,12 +52,12 @@ export class SimpleSiteRenameForm extends Component {
 		}
 
 		if ( domain.match( /[^a-z0-9]/i ) ) {
-			return translate( 'Domain can only contain letters (a-z) and numbers.' );
+			return translate( 'Site address can only contain letters (a-z) and numbers.' );
 		}
 
 		if ( ! inRange( domain.length, SUBDOMAIN_LENGTH_MINIMUM, SUBDOMAIN_LENGTH_MAXIMUM ) ) {
 			return translate(
-				'Domain length should be between %(minimumLength)s and %(maximumLength)s characters.',
+				'Site address length should be between %(minimumLength)s and %(maximumLength)s characters.',
 				{
 					args: {
 						minimumLength: SUBDOMAIN_LENGTH_MINIMUM,
@@ -126,7 +126,7 @@ export class SimpleSiteRenameForm extends Component {
 				/>
 				<form onSubmit={ this.onSubmit }>
 					<Card className="simple-site-rename-form__content">
-						<FormSectionHeading>{ translate( 'Edit Domain Name' ) }</FormSectionHeading>
+						<FormSectionHeading>{ translate( 'Edit Site Address' ) }</FormSectionHeading>
 						<FormTextInputWithAffixes
 							type="text"
 							value={ this.state.domainFieldValue }
@@ -141,7 +141,7 @@ export class SimpleSiteRenameForm extends Component {
 								<Gridicon icon="info-outline" size={ 18 } />
 								<p>
 									{ translate(
-										'Once changed, the current domain name %(currentDomainName)s will no longer be available.',
+										'Once changed, the current site address %(currentDomainName)s will no longer be available.',
 										{
 											args: { currentDomainName },
 										}

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -105,7 +105,8 @@ export class SimpleSiteRenameForm extends Component {
 
 	render() {
 		const { currentDomain, currentDomainSuffix, isSiteRenameRequesting, translate } = this.props;
-		const currentDomainPrefix = get( currentDomain, 'name', '' ).replace( currentDomainSuffix, '' );
+		const currentDomainName = get( currentDomain, 'name', '' );
+		const currentDomainPrefix = currentDomainName.replace( currentDomainSuffix, '' );
 		const isWPCOM = get( currentDomain, 'type' ) === 'WPCOM';
 		const { domainFieldError, domainFieldValue } = this.state;
 		const isDisabled =
@@ -140,7 +141,10 @@ export class SimpleSiteRenameForm extends Component {
 								<Gridicon icon="info-outline" size={ 18 } />
 								<p>
 									{ translate(
-										'Once changed, previous domain names will no longer be available.'
+										'Once changed, the current domain name %(currentDomainName)s will no longer be available.',
+										{
+											args: { currentDomainName },
+										}
 									) }
 								</p>
 							</div>

--- a/client/blocks/simple-site-rename-form/style.scss
+++ b/client/blocks/simple-site-rename-form/style.scss
@@ -25,7 +25,6 @@
 	text-align: center;
 
 	@include breakpoint( '>660px' ) {
-		padding: 0;
 		text-align: left;
 	}
 

--- a/client/blocks/simple-site-rename-form/style.scss
+++ b/client/blocks/simple-site-rename-form/style.scss
@@ -6,11 +6,11 @@
 	color: darken($gray, 20%);
 }
 
-.simple-site-rename-form__copy-green {
+.simple-site-rename-form__copy-addition {
 	color: $alert-green;
 }
 
-.simple-site-rename-form__copy-red {
+.simple-site-rename-form__copy-deletion {
 	color: $alert-red;
 }
 

--- a/client/blocks/simple-site-rename-form/style.scss
+++ b/client/blocks/simple-site-rename-form/style.scss
@@ -20,11 +20,15 @@
 
 .simple-site-rename-form__info {
 	color: $gray-text-min;
+	flex-basis: 400px;
+	flex-shrink: 1;
 	margin: 5px 0 0 0;
 	padding: 0;
 	text-align: center;
+	word-break: break-word;
 
 	@include breakpoint( '>660px' ) {
+		margin-right: 15px;
 		text-align: left;
 	}
 
@@ -55,6 +59,7 @@
 	margin-top: 24px;
 
 	button {
+		flex-shrink: 0;
 		margin-left: auto;
 	}
 

--- a/client/blocks/simple-site-rename-form/style.scss
+++ b/client/blocks/simple-site-rename-form/style.scss
@@ -95,6 +95,8 @@
 	}
 
 	.simple-site-rename-form__confirmation-detail-copy {
+		word-break: break-word;
+
 		@include breakpoint( '>660px' ) {
 			margin-left: 24px;
 		}


### PR DESCRIPTION
## This PR
- Is introducing some changes requested in reviews on https://github.com/Automattic/wp-calypso/pull/21861 and targets `add/sites-rename-2`
- changes all copy occurrences of `domain` to `site address`
- changes the info message and its styling to include current domain
- changes class names to represent function not the current style
- ensures long domains wrap to next line in the dialog
- removes the mention of `primary domain`
- removes an unnecessary style rule

## To Test

Follow instructions in #21861 -- this should behave identically

### Visual changes

#### Before:

<img width="597" alt="screen shot 2018-02-21 at 17 35 35" src="https://user-images.githubusercontent.com/1562646/36514760-b5486ba0-173b-11e8-9e62-e8eb68b15c50.png">

<img width="756" alt="screen shot 2018-02-21 at 18 11 05" src="https://user-images.githubusercontent.com/1562646/36514783-d5872758-173b-11e8-9635-9272796ddc24.png">

#### After:

<img width="538" alt="screen shot 2018-02-21 at 19 04 21" src="https://user-images.githubusercontent.com/1562646/36514808-f97191f8-173b-11e8-8fff-0daac0942db7.png">

<img width="743" alt="screen shot 2018-02-21 at 18 55 34" src="https://user-images.githubusercontent.com/1562646/36514824-1bbffd80-173c-11e8-8fb0-5872a8de511d.png">

