### PR TITLE
Posts: Disable search in all-sites mode

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -153,6 +153,8 @@ const PostTypeFilter = createReactClass( {
 			return null;
 		}
 
+		const isSingleSite = !! siteId;
+
 		const navItems = this.getNavItems();
 		const selectedItem = find( navItems, 'selected' ) || {};
 
@@ -185,13 +187,16 @@ const PostTypeFilter = createReactClass( {
 					{ ! authorToggleHidden && (
 						<AuthorSegmented author={ query.author } siteId={ siteId } statusSlug={ statusSlug } />
 					) }
-					<Search
-						pinned
-						fitsContainer
-						onSearch={ this.doSearch }
-						placeholder={ this.props.translate( 'Search…' ) }
-						delaySearch={ true }
-					/>
+					{ /* Disable search in all-sites mode because it doesn't work. */ }
+					{ isSingleSite && (
+						<Search
+							pinned
+							fitsContainer
+							onSearch={ this.doSearch }
+							placeholder={ this.props.translate( 'Search…' ) }
+							delaySearch={ true }
+						/>
+					) }
 					{ this.renderMultiSelectButton() }
 				</SectionNav>
 			</div>

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -32,7 +32,7 @@ export default {
 		const siteID = getSiteFragment( context.path );
 		const author = context.params.author === 'my' ? getCurrentUserId( state ) : null;
 		let statusSlug = author ? context.params.status : context.params.author;
-		let search = context.query.s;
+		let search = context.query.s || '';
 		const category = context.query.category;
 		const tag = context.query.tag;
 		const basePath = sectionify( context.path );
@@ -57,7 +57,11 @@ export default {
 		statusSlug = ! statusSlug || statusSlug === 'my' || statusSlug === siteID ? '' : statusSlug;
 		debug( 'statusSlug: `%s`', statusSlug );
 
-		search = 'undefined' !== typeof search ? search : '';
+		// Disable search in all-sites mode because it doesn't work.
+		if ( ! siteId ) {
+			search = '';
+		}
+
 		debug( 'search: `%s`', search );
 
 		if ( shouldRedirectMyPosts() ) {


### PR DESCRIPTION
Searching for specific post content in all-sites mode has been broken for at least 11 months (#12670).

Let's not pretend to support features that we know are broken.  Accordingly, when viewing the posts list in all-sites mode, this PR disables the search bar and the code that parses the `?s=` query argument out of the URL.

| Before | After |
|--|--|
| ![2018-02-21t21 43 39-0600](https://user-images.githubusercontent.com/227022/36519311-5c892396-1750-11e8-90e6-3a86b381e91c.png) | ![2018-02-21t21 43 52-0600](https://user-images.githubusercontent.com/227022/36519313-625a46e2-1750-11e8-96ec-a9ff6ae1653b.png) |