### PR TITLE
Try Save/Restoring redux state

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -106,7 +106,7 @@ function isLoggedIn() {
 }
 
 function saveState( key, state, serializeState = serialize ) {
-	localforage.setItem( key, serializeState( state ) ).catch( setError => {
+	return localforage.setItem( key, serializeState( state ) ).catch( setError => {
 		debug( 'failed to set redux-store state as ' + key, setError );
 	} );
 }
@@ -151,10 +151,12 @@ export default function createReduxStoreFromPersistedInitialState( reduxStoreRea
 		window.saveState = saveState;
 
 		const savedStateId = ( get( window, 'location.search', '' ).match(
-			/[?&]restoreState2=(.*?)(?:&|$)/
-		) || [] )[ 2 ];
+			/[?&]restoreState=(.*?)(?:&|$)/
+		) || [] )[ 1 ];
+		debug( 'Saved state id', savedStateId );
+
 		if ( savedStateId ) {
-			debug( 'Loading saved state. Found saved state id', savedStateId );
+			debug( 'Loading saved state.', savedStateId );
 			return localforage
 				.getItem( 'redux-state-saved' )
 				.then( loadInitialState )

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -149,6 +149,7 @@ export default function createReduxStoreFromPersistedInitialState( reduxStoreRea
 	if ( 'development' === process.env.NODE_ENV ) {
 		window.resetState = () => localforage.clear( () => location.reload( true ) );
 		window.saveState = saveState;
+		window.localforage = localforage;
 
 		const savedStateId = ( get( window, 'location.search', '' ).match(
 			/[?&]restoreState=(.*?)(?:&|$)/


### PR DESCRIPTION
This PR explores saving/restoring calypso state. The primary goal is to be able to display translations in context. Secondarily, it has the potential to be a useful tool for development and/or support (e.g. enable HE's to bring up the screen as the user sees it, potentially including any corruption due to bugs).


The safe version runs the state through `SERIALIZE`/`DESERIALIZE` actions, basically the same as the existing persistence:
Save with `saveState( 'redux-state-saved', state ).then( console.log )` in the console.
reload by appending the restore state query-arg `?restoreState=1` in the url.

We drop a lot of state in the `SERIALIZE`, though. If we skip the `DE/SERIALIZE`, we get a lot more power and a lot less safety. A notice is a nice clear marker:

```
dispatch( { type: "NOTICE_CREATE", notice: { isPersistent: true, noticeId: "-1", status: "is-info", text: "Loaded Full Stored State" } } )
saveState( 'redux-full-state-saved', JSON.parse( JSON.stringify( state ) ), x=>x ).then( console.log )
```
Then load the url with a `?restoreFullState=1` query arg.  The JSON there cleans out functions that `localforage` can't handle, so this still isn't even the whole redux state, but it's pretty close.

Even so, There's also a lot of state that's not in the redux:

- Component `state`. It seems like this is going to be key for something that works like a screenshot.
- Backend data (retrieved through API calls)
- Data on the backing instances, both static and individually.
- State contained in older flux stores/module level variables/closures
- url
- navigation history (with state object cache)
- localStorage/sessionStorage/store
- cookies
- ???

Naturally, there are some security implications to watch out for too.

(This all reminds me of this article: [Local State Is Posion](https://awelonblue.wordpress.com/2012/10/21/local-state-is-poison))