### PR TITLE
Jetpack Connect: Clear selected plan when visiting JPC URL input without a plan

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -32,7 +32,13 @@ import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
 import { hideMasterbar, setSection, showMasterbar } from 'state/ui/actions';
 import { JPC_PATH_PLANS, MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
 import { login } from 'lib/paths';
-import { persistMobileRedirect, retrieveMobileRedirect, storePlan } from './persistence-utils';
+import {
+	clearPlan,
+	persistMobileRedirect,
+	retrieveMobileRedirect,
+	retrievePlan,
+	storePlan,
+} from './persistence-utils';
 import { receiveJetpackOnboardingCredentials } from 'state/jetpack-onboarding/actions';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { startAuthorizeStep } from 'state/jetpack-connect/actions';
@@ -156,7 +162,13 @@ export function connect( context, next ) {
 	debug( 'entered connect flow with params %o', params );
 
 	const planSlug = getPlanSlugFromFlowType( type, interval );
-	planSlug && storePlan( planSlug );
+	const selectedPlan = retrievePlan();
+
+	if ( planSlug ) {
+		storePlan( planSlug );
+	} else if ( selectedPlan ) {
+		clearPlan();
+	}
 
 	analytics.pageView.record( pathname, analyticsPageTitle );
 


### PR DESCRIPTION
This PR resolves a bug that occurs when we have a selected plan and try to visit the site URL input step without a plan in it - `/jetpack/connect` or `/jetpack/connect/es`. In that case, the site URL input step will inadvertently show the previously selected plan (this is reflected in the header copy).

The suggested approach is to basically check whether we have a selected plan, when visiting a JPC site URL input URL that doesn't contain a plan in the route, and if we have a selected plan, delete it.

To test:
* Checkout this branch locally.
* Load a fresh browser session.
* Open your console and monitor for errors just in case.
* Go to `/jetpack/connect` and verify you can see the "Connect a self-hosted WordPress" heading.
* Go to `/jetpack/connect/personal` and verify you can see the "Get Jetpack Personal" heading.
* Go back to `/jetpack/connect` and verify you can see the "Connect a self-hosted WordPress" heading again.
* Grab a fresh Jurassic Ninja site.
* Go to `/jetpack/connect/personal` or any other paid plan (`/premium` or `/pro`)
* Input the site URL in the URL field.
* After the authorization process, verify you are redirected to the checkout page with the corresponding plan in the cart.