### PR TITLE
Rewind: update notice for VP is running so it takes user to the flow to switch to Rewind

### DIFF
--- a/client/my-sites/stats/activity-log/unavailability-notice.jsx
+++ b/client/my-sites/stats/activity-log/unavailability-notice.jsx
@@ -44,9 +44,9 @@ export const UnavailabilityNotice = ( {
 				<Banner
 					icon="history"
 					href={ `/start/rewind-switch/?siteId=${ siteId }&siteSlug=${ slug }` }
-					title={ translate( 'VaultPress is running.' ) }
+					title={ translate( 'Try our new backup service' ) }
 					description={ translate(
-						'We are unable to create backups and Rewind while VaultPress is running.'
+						'Get real-time backups with one-click restores to any event in time.'
 					) }
 				/>
 			);

--- a/client/my-sites/stats/activity-log/unavailability-notice.jsx
+++ b/client/my-sites/stats/activity-log/unavailability-notice.jsx
@@ -14,7 +14,14 @@ import { getSiteAdminUrl } from 'state/sites/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { getRewindState } from 'state/selectors';
 
-export const UnavailabilityNotice = ( { adminUrl, reason, rewindState, slug, translate } ) => {
+export const UnavailabilityNotice = ( {
+	adminUrl,
+	reason,
+	rewindState,
+	slug,
+	translate,
+	siteId,
+} ) => {
 	if ( rewindState !== 'unavailable' ) {
 		return null;
 	}
@@ -36,7 +43,7 @@ export const UnavailabilityNotice = ( { adminUrl, reason, rewindState, slug, tra
 			return (
 				<Banner
 					icon="history"
-					href={ `/settings/security/${ slug }` }
+					href={ `/start/rewind-switch/?siteId=${ siteId }&siteSlug=${ slug }` }
 					title={ translate( 'VaultPress is running.' ) }
 					description={ translate(
 						'We are unable to create backups and Rewind while VaultPress is running.'
@@ -57,6 +64,7 @@ const mapStateToProps = ( state, { siteId } ) => {
 		reason,
 		rewindState,
 		slug: getSelectedSiteSlug( state ),
+		siteId,
 	};
 };
 


### PR DESCRIPTION
Fixes #22697

This PR:
- updates the link of the `VaultPress is running.` notice so when the site has VP running but can be switched to Rewind, the link takes the user to the flow to switch to Rewind
- updates the heading and body of the notice

### Previous wording
<img width="704" alt="captura de pantalla 2018-02-22 a la s 10 36 02" src="https://user-images.githubusercontent.com/1041600/36541409-91987f70-17bc-11e8-8a3b-fbfcdca150a4.png">

### New wording
<img width="752" alt="captura de pantalla 2018-02-27 a la s 10 41 45" src="https://user-images.githubusercontent.com/1041600/36731903-e849b1d0-1baa-11e8-9e76-aaa2bd70b3af.png">

### Testing

Use a site where VP is active but can be switched, that is, where Rewind is not active due to the reason `vp_can_transfer`:
- go to Activity Log and make sure the notice is shown with the updated text
- click the notice and make sure you're taken to the flow to enter creds