### PR TITLE
Rewind: add missing spacing between sentences in flow step

### DIFF
--- a/client/signup/steps/rewind-migrate/index.jsx
+++ b/client/signup/steps/rewind-migrate/index.jsx
@@ -63,7 +63,7 @@ class RewindMigrate extends Component {
 					<p className="rewind-migrate__description rewind-switch__description">
 						{ translate(
 							"You've already configured VaultPress correctly, " +
-								"so we're ready to migrate your credentials over to Jetpack with just one click." +
+								"so we're ready to migrate your credentials over to Jetpack with just one click. " +
 								"Are you ready to switch to our faster, more powerful system? Let's go!"
 						) }
 					</p>
@@ -76,7 +76,7 @@ class RewindMigrate extends Component {
 					<p>
 						{ translate(
 							'Note: Moving to Jetpack backups and security is final, ' +
-								'and the VaultPress backups previously generated will not be migrated to the new system.' +
+								'and the VaultPress backups previously generated will not be migrated to the new system. ' +
 								'We will retain the data in case you need to restore to a backup made before you switched.'
 						) }
 					</p>


### PR DESCRIPTION
This PR adds a space between sentences in the step to migrate credentials, in the flow to switch from VP to Rewind.
- `just one click.Are you ready to` in main text
- `the new system.We will retain the` in fine print

#### Before

<img width="279" alt="captura de pantalla 2018-02-22 a la s 10 48 58" src="https://user-images.githubusercontent.com/1041600/36542012-6a678098-17be-11e8-985a-ef9846a2d9e9.png">

#### After

<img width="287" alt="captura de pantalla 2018-02-22 a la s 10 49 46" src="https://user-images.githubusercontent.com/1041600/36542023-6ef69bf8-17be-11e8-82a1-967726677708.png">
