### PR TITLE
Feature: Allow domain suggestions containing a dot by using query parameter instead of a path segment

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -50,7 +50,7 @@ const domainsAddRedirectHeader = ( context, next ) => {
 	next();
 };
 
-const redirectToDomainSearchWithSuggestionAsQuery = context => {
+const redirectToDomainSearchSuggestion = context => {
 	return page.redirect(
 		`/domains/add/${ context.params.domain }?suggestion=${ context.params.suggestion }`
 	);
@@ -235,7 +235,7 @@ export default {
 	googleAppsWithRegistration,
 	redirectIfNoSite,
 	redirectToAddMappingIfVipSite,
-	redirectToDomainSearchWithSuggestionAsQuery,
+	redirectToDomainSearchSuggestion,
 	transferDomain,
 	transferDomainPrecheck,
 };

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -50,6 +50,12 @@ const domainsAddRedirectHeader = ( context, next ) => {
 	next();
 };
 
+const redirectToDomainSearchWithSuggestionAsQuery = context => {
+	return page.redirect(
+		`/domains/add/${ context.params.domain }?s=${ context.params.suggestion }`
+	);
+};
+
 const domainSearch = ( context, next ) => {
 	const basePath = sectionify( context.path );
 
@@ -229,6 +235,7 @@ export default {
 	googleAppsWithRegistration,
 	redirectIfNoSite,
 	redirectToAddMappingIfVipSite,
+	redirectToDomainSearchWithSuggestionAsQuery,
 	transferDomain,
 	transferDomainPrecheck,
 };

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -52,7 +52,7 @@ const domainsAddRedirectHeader = ( context, next ) => {
 
 const redirectToDomainSearchWithSuggestionAsQuery = context => {
 	return page.redirect(
-		`/domains/add/${ context.params.domain }?s=${ context.params.suggestion }`
+		`/domains/add/${ context.params.domain }?suggestion=${ context.params.suggestion }`
 	);
 };
 

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -143,7 +143,7 @@ class DomainSearch extends Component {
 						>
 							<RegisterDomainStep
 								path={ this.props.context.path }
-								suggestion={ this.props.context.params.suggestion }
+								suggestion={ this.props.context.query.s }
 								domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 								onDomainsAvailabilityChange={ this.handleDomainsAvailabilityChange }
 								onAddDomain={ this.handleAddRemoveDomain }

--- a/client/my-sites/domains/domain-search/domain-search.jsx
+++ b/client/my-sites/domains/domain-search/domain-search.jsx
@@ -143,7 +143,7 @@ class DomainSearch extends Component {
 						>
 							<RegisterDomainStep
 								path={ this.props.context.path }
-								suggestion={ this.props.context.query.s }
+								suggestion={ this.props.context.query.suggestion }
 								domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 								onDomainsAvailabilityChange={ this.handleDomainsAvailabilityChange }
 								onAddDomain={ this.handleAddRemoveDomain }

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -247,7 +247,7 @@ export default function() {
 			domainsController.redirectIfNoSite( '/domains/add' ),
 			domainsController.redirectToAddMappingIfVipSite(),
 			jetPackWarning,
-			domainsController.domainSearch,
+			domainsController.redirectToDomainSearchWithSuggestionAsQuery,
 			makeLayout,
 			clientRender
 		);

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -247,9 +247,7 @@ export default function() {
 			domainsController.redirectIfNoSite( '/domains/add' ),
 			domainsController.redirectToAddMappingIfVipSite(),
 			jetPackWarning,
-			domainsController.redirectToDomainSearchSuggestion,
-			makeLayout,
-			clientRender
+			domainsController.redirectToDomainSearchSuggestion
 		);
 
 		page(

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -247,7 +247,7 @@ export default function() {
 			domainsController.redirectIfNoSite( '/domains/add' ),
 			domainsController.redirectToAddMappingIfVipSite(),
 			jetPackWarning,
-			domainsController.redirectToDomainSearchWithSuggestionAsQuery,
+			domainsController.redirectToDomainSearchSuggestion,
 			makeLayout,
 			clientRender
 		);


### PR DESCRIPTION
I would like to be able to link to a domain suggestion page and suggest domain name containing dots. Currently it is not possible, because the URL would look like this: /domains/add/suggestion/mytestsite.com/mytestsite.wordpress.com and getSiteFragment() will think that site fragment is mytestsite.com. I issued a PR to fix it here:

#22493

But it's not getting a lot of thumbs up since the entire calypso would be affected and we don't really have tests to cover all of that :-) So I prepared this PR that touches just the parts I need to update.

As a side note, I wanted to prepare some tests cases, but we cannot really test controller.jsx. It imports some modules expecting documentElement to be defined and we don't have any shim for that in our test environment.