### PR TITLE
Jetpack Onboarding: Require JPC for contact form and display success screen

### DIFF
--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -28,8 +28,8 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 		} );
 	};
 
-	render() {
-		const { basePath, getForwardUrl, settings, translate } = this.props;
+	renderActionTile() {
+		const { getForwardUrl, settings, translate } = this.props;
 		const headerText = translate( "Let's grow your audience with Jetpack." );
 		const subHeaderText = (
 			<Fragment>
@@ -43,15 +43,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 		const hasContactForm = !! get( settings, 'addContactForm' );
 
 		return (
-			<div className="steps__main">
-				<DocumentHead title={ translate( 'Contact Form ‹ Jetpack Start' ) } />
-				<PageViewTracker
-					path={ [ basePath, STEPS.CONTACT_FORM, ':site' ].join( '/' ) }
-					title="Contact Form ‹ Jetpack Start"
-				/>
-
-				<JetpackLogo full size={ 45 } />
-
+			<Fragment>
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<TileGrid>
@@ -65,6 +57,24 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 						href={ getForwardUrl() }
 					/>
 				</TileGrid>
+			</Fragment>
+		);
+	}
+
+	render() {
+		const { basePath, translate } = this.props;
+
+		return (
+			<div className="steps__main">
+				<DocumentHead title={ translate( 'Contact Form ‹ Jetpack Start' ) } />
+				<PageViewTracker
+					path={ [ basePath, STEPS.CONTACT_FORM, ':site' ].join( '/' ) }
+					title="Contact Form ‹ Jetpack Start"
+				/>
+
+				<JetpackLogo full size={ 45 } />
+
+				{ this.renderActionTile() }
 			</div>
 		);
 	}

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import ConnectSuccess from '../connect-success';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import JetpackLogo from 'components/jetpack-logo';
@@ -51,6 +52,10 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 		}
 
 		this.addContactForm();
+	};
+
+	handleNextButton = () => {
+		this.props.recordJpoEvent( 'calypso_jpo_contact_form_next_clicked' );
 	};
 
 	addContactForm() {
@@ -102,7 +107,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 	}
 
 	render() {
-		const { basePath, siteId, translate } = this.props;
+		const { basePath, getForwardUrl, hasContactForm, siteId, translate } = this.props;
 
 		return (
 			<div className="steps__main">
@@ -115,7 +120,16 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 
 				<JetpackLogo full size={ 45 } />
 
-				{ this.renderActionTile() }
+				{ hasContactForm ? (
+					<ConnectSuccess
+						href={ getForwardUrl() }
+						illustration="/calypso/images/illustrations/contact-us.svg"
+						onClick={ this.handleNextButton }
+						title={ translate( 'Success! Jetpack has added a "Contact us" page to your site.' ) }
+					/>
+				) : (
+					this.renderActionTile()
+				) }
 			</div>
 		);
 	}

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -14,22 +15,52 @@ import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import JetpackLogo from 'components/jetpack-logo';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QuerySites from 'components/data/query-sites';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
+import { addQueryArgs } from 'lib/route';
+import { getJetpackOnboardingPendingSteps, getUnconnectedSiteUrl } from 'state/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingContactFormStep extends React.PureComponent {
+	componentDidUpdate() {
+		this.maybeAddContactForm();
+	}
+
+	maybeAddContactForm() {
+		const { action, hasContactForm, isConnected, isRequestingSettings, stepsPending } = this.props;
+		const isPending = get( stepsPending, STEPS.CONTACT_FORM );
+
+		if (
+			! isPending &&
+			! isRequestingSettings &&
+			isConnected &&
+			hasContactForm === false &&
+			action === 'add_contact_form'
+		) {
+			this.addContactForm();
+		}
+	}
+
 	handleAddContactForm = () => {
-		const { siteId } = this.props;
 		this.props.recordJpoEvent( 'calypso_jpo_contact_form_clicked' );
 
-		this.props.saveJpoSettings( siteId, {
-			addContactForm: true,
-		} );
+		if ( ! this.props.isConnected ) {
+			return;
+		}
+
+		this.addContactForm();
 	};
 
+	addContactForm() {
+		this.props.saveJpoSettings( this.props.siteId, {
+			addContactForm: true,
+		} );
+	}
+
 	renderActionTile() {
-		const { getForwardUrl, settings, translate } = this.props;
+		const { hasContactForm, isConnected, siteUrl, translate } = this.props;
 		const headerText = translate( "Let's grow your audience with Jetpack." );
 		const subHeaderText = (
 			<Fragment>
@@ -40,7 +71,16 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 				) }
 			</Fragment>
 		);
-		const hasContactForm = !! get( settings, 'addContactForm' );
+		const connectUrl = addQueryArgs(
+			{
+				url: siteUrl,
+				// TODO: add a parameter to the JPC to redirect back to this step after completion
+				// and in the redirect URL include the ?action=add_contact_form parameter
+				// to actually trigger the page and form creation action after getting back to JPO
+			},
+			'/jetpack/connect'
+		);
+		const href = ! isConnected ? connectUrl : null;
 
 		return (
 			<Fragment>
@@ -54,7 +94,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 						}
 						image={ '/calypso/images/illustrations/contact-us.svg' }
 						onClick={ this.handleAddContactForm }
-						href={ getForwardUrl() }
+						href={ href }
 					/>
 				</TileGrid>
 			</Fragment>
@@ -62,7 +102,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 	}
 
 	render() {
-		const { basePath, translate } = this.props;
+		const { basePath, siteId, translate } = this.props;
 
 		return (
 			<div className="steps__main">
@@ -71,6 +111,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 					path={ [ basePath, STEPS.CONTACT_FORM, ':site' ].join( '/' ) }
 					title="Contact Form ‹ Jetpack Start"
 				/>
+				<QuerySites siteId={ siteId } />
 
 				<JetpackLogo full size={ 45 } />
 
@@ -80,4 +121,11 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 	}
 }
 
-export default localize( JetpackOnboardingContactFormStep );
+export default connect(
+	( state, { settings, siteId, steps } ) => ( {
+		hasContactForm: !! get( settings, 'addContactForm' ),
+		isConnected: isJetpackSite( state, siteId ),
+		siteUrl: getUnconnectedSiteUrl( state, siteId ),
+		stepsPending: getJetpackOnboardingPendingSteps( state, siteId, steps ),
+	} ),
+)( localize( JetpackOnboardingContactFormStep ) );

--- a/client/state/selectors/get-jetpack-onboarding-pending-steps.js
+++ b/client/state/selectors/get-jetpack-onboarding-pending-steps.js
@@ -14,6 +14,9 @@ import { getRequest } from 'state/selectors';
 
 export default function getJetpackOnboardingPendingSteps( state, siteId, steps ) {
 	const stepActionsMap = {
+		[ STEPS.CONTACT_FORM ]: {
+			addContactForm: true,
+		},
 		[ STEPS.WOOCOMMERCE ]: {
 			installWooCommerce: true,
 		},

--- a/client/state/selectors/test/get-jetpack-onboarding-pending-steps.js
+++ b/client/state/selectors/test/get-jetpack-onboarding-pending-steps.js
@@ -9,6 +9,37 @@ import { getRequestKey } from 'state/data-layer/wpcom-http/utils';
 import { saveJetpackOnboardingSettings } from 'state/jetpack-onboarding/actions';
 
 describe( 'getJetpackOnboardingPendingSteps()', () => {
+	test( 'should return pending status for the contact form step', () => {
+		const siteId = 2916284;
+		const action = saveJetpackOnboardingSettings( siteId, {
+			addContactForm: true,
+		} );
+		const state = {
+			dataRequests: {
+				[ getRequestKey( action ) ]: {
+					status: 'pending',
+				},
+			},
+		};
+
+		const steps = [
+			STEPS.SITE_TITLE,
+			STEPS.SITE_TYPE,
+			STEPS.CONTACT_FORM,
+			STEPS.WOOCOMMERCE,
+			STEPS.STATS,
+		];
+		const expected = {
+			[ STEPS.SITE_TITLE ]: false,
+			[ STEPS.SITE_TYPE ]: false,
+			[ STEPS.CONTACT_FORM ]: true,
+			[ STEPS.WOOCOMMERCE ]: false,
+			[ STEPS.STATS ]: false,
+		};
+		const pending = getJetpackOnboardingPendingSteps( state, siteId, steps );
+		expect( pending ).toEqual( expected );
+	} );
+
 	test( 'should return pending status for the woocommerce step', () => {
 		const siteId = 2916284;
 		const action = saveJetpackOnboardingSettings( siteId, {
@@ -22,10 +53,17 @@ describe( 'getJetpackOnboardingPendingSteps()', () => {
 			},
 		};
 
-		const steps = [ STEPS.SITE_TITLE, STEPS.SITE_TYPE, STEPS.WOOCOMMERCE, STEPS.STATS ];
+		const steps = [
+			STEPS.SITE_TITLE,
+			STEPS.SITE_TYPE,
+			STEPS.CONTACT_FORM,
+			STEPS.WOOCOMMERCE,
+			STEPS.STATS,
+		];
 		const expected = {
 			[ STEPS.SITE_TITLE ]: false,
 			[ STEPS.SITE_TYPE ]: false,
+			[ STEPS.CONTACT_FORM ]: false,
 			[ STEPS.WOOCOMMERCE ]: true,
 			[ STEPS.STATS ]: false,
 		};
@@ -46,10 +84,17 @@ describe( 'getJetpackOnboardingPendingSteps()', () => {
 			},
 		};
 
-		const steps = [ STEPS.SITE_TITLE, STEPS.SITE_TYPE, STEPS.WOOCOMMERCE, STEPS.STATS ];
+		const steps = [
+			STEPS.SITE_TITLE,
+			STEPS.SITE_TYPE,
+			STEPS.CONTACT_FORM,
+			STEPS.WOOCOMMERCE,
+			STEPS.STATS,
+		];
 		const expected = {
 			[ STEPS.SITE_TITLE ]: false,
 			[ STEPS.SITE_TYPE ]: false,
+			[ STEPS.CONTACT_FORM ]: false,
 			[ STEPS.WOOCOMMERCE ]: false,
 			[ STEPS.STATS ]: true,
 		};


### PR DESCRIPTION
### Purpose

This PR updates the contact form step to require Jetpack Connect (see #22526) and introduces a success screen (see #22527), as suggested in p6TEKc-1Rd-p2. Uses some of the logic we applied in #22621.

Fixes #22526
Fixes #22527

### How it works

* The user loads the new step and sees a CTA.
* Clicking the button will behave differently, depending on whether the site is currently connected or not:
  * If connected, will insert the page with the contact form shortcode and show a success screen.
  * If not connected, will redirect to Jetpack Connect and will start the connection flow. After finishing connection, will redirect back to same step, and initiate the creation of the page with the contact form shortcode, followed by showing the success screen.

**Note 1:** right now, after connecting, Jetpack Connect will not redirect to the contact form step. This requires additional changes to Jetpack Connect that we'll handle in a separate PR. This will work by passing a URL parameter to JPC so it knows where to redirect to. That URL will consist of the JPO contact form page URL with a `action=add_contact_form` parameter, which will trigger creation of the contact form page with a shortcode for connected sites immediately, showing the success screen to the user.

**Note 2:** right now the PR will display the "Skip" links in the footer, contrary to the design mockups - this will be addressed separately, see #22641.

### Preview:

**Contact form step - initial state**
![](https://cldup.com/ILDPbaLCGz.png)

**Contact form step - success state**
![](https://cldup.com/kpfZlT7qTn.png)

### Contents of the PR

This PR introduces several changes that are necessary for each aspect of the new functionality to work. Commits are atomic and can be used to highlight distinct changes, but here is a detailed list of what this PR suggests:

* Moving the action tile in a separate method.
* Add `contact-form` step to `getJetpackOnboardingPendingSteps` selector.
* Update the step to require connection before actually inserting the form.
* Introduce the success screen.

### Testing
* Checkout this branch on your local Calypso.
* Start with a fresh Jetpack site with the latest **Jetpack master**
* Head to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` on the Jetpack site to start the onboarding flow.
* Skip steps until you reach the new Contact form step.
* Verify the step appears properly as shown on the screenshots.
* Click the **Add a contact form** button.
* You will be redirected to Jetpack Connect and connection process will start automatically.
* After connecting, it will redirect you to the default redirection place of JPC (this is expected, see the note above).
* Visit `http://calypso.localhost:3000/jetpack/start/contact-form/YOURJETPACKSITE.COM?action=add_contact_form` to simulate coming back from Jetpack Connect after a successful connection.
* Verify you can see the success screen (as shown on the screenshot)
* Verify the Contact Us page was created on your remote site.
* Refresh the page and verify you can still see the success screen.
* Verify the **Continue** button leads to the next step.
* Go back to other steps and visit the Contact Form step; verify you can still see the success screen.