### PR TITLE
Invites: fix resending by forcing API call to WPCOM

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -408,7 +408,12 @@ Undocumented.prototype.sendInvites = function( siteId, usernamesOrEmails, role, 
 
 Undocumented.prototype.resendInvite = function( siteId, inviteId, fn ) {
 	debug( '/sites/:site_id:/invites/:invite_id:/resend query' );
-	return this.wpcom.req.post( '/sites/' + siteId + '/invites/' + inviteId + '/resend', {}, {}, fn );
+	return this.wpcom.req.post(
+		'/sites/' + siteId + '/invites/' + inviteId + '/resend',
+		{ force: 'wpcom' },
+		{},
+		fn
+	);
 };
 
 Undocumented.prototype.createInviteValidation = function( siteId, usernamesOrEmails, role, fn ) {


### PR DESCRIPTION
Resending an invite doesn't require any data on the Jetpack site. This PR forces the API call to WPCOM to fix an issue where resending of an invite failed for Jetpack sites.

Before:
![image](https://user-images.githubusercontent.com/363749/36549176-b8cfc530-17b7-11e8-83c2-4695208fa5ed.png)

After:
![image](https://user-images.githubusercontent.com/363749/36549131-9f0ae166-17b7-11e8-81ee-cd10479e61ea.png)

To test:
* Invite someone to a Jetpack site within people management
* From the Invites page within people management, attempt to resend the invite
* The invite resent should succeed
