### PR TITLE
state/utils: swap lru-cache for lru

### DIFF
--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -20,7 +20,7 @@ import {
 	reduce,
 } from 'lodash';
 import { combineReducers as combine } from 'redux'; // eslint-disable-line wpcalypso/import-no-redux-combine-reducers
-import LRU from 'lru-cache';
+import LRU from 'lru';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
[cachingActionCreatorFactory](https://github.com/Automattic/wp-calypso/blob/master/client/state/utils.js#L531) in state/utils uses `lru-cache`, which is not a declared dependency in package.json.

lru-cache was written for node, and since we conveneniently already have a package `lru` that looks to have an equivalent api, I've created this PR to swap them.

**testing instructions**
- @yurynix: do you have any idea for testing instructions? Is it just unit tests and trying to log in using oauth (google).

**chunk deltas**: http://iscalypsofastyet.com/branch?branch=update/dependency/lrucache
```
Message: state/utils: swap lru-cache for lru

Delta:
chunk     stat_size           parsed_size           gzip_size
build      -20622 B  (-0.6%)     -10876 B  (-0.7%)    -2924 B  (-0.8%)
manifest       +0 B                  +0 B                +1 B  (+0.0%)
```