### PR TITLE
SSR: Fix reconciliation error on Masterbar login link

### DIFF
--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -24,16 +24,12 @@ export function makeLayoutMiddleware( LayoutComponent ) {
 
 		// On server, only render LoggedOutLayout when logged-out.
 		if ( ! context.isServerSide || ! getCurrentUser( context.store.getState() ) ) {
-			let redirectUri;
-			if ( context.isServerSide ) {
-				redirectUri = context.originalUrl;
-			}
 			context.layout = (
 				<LayoutComponent
 					store={ store }
 					primary={ primary }
 					secondary={ secondary }
-					redirectUri={ redirectUri }
+					redirectUri={ context.isServerSide ? context.originalUrl : null }
 				/>
 			);
 		}

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -26,7 +26,7 @@ export function makeLayoutMiddleware( LayoutComponent ) {
 		if ( ! context.isServerSide || ! getCurrentUser( context.store.getState() ) ) {
 			let redirectUri;
 			if ( context.isServerSide ) {
-				redirectUri = `${ context.protocol }://${ context.host }${ context.originalUrl }`;
+				redirectUri = context.originalUrl;
 			}
 			context.layout = (
 				<LayoutComponent

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -29,7 +29,7 @@ export function makeLayoutMiddleware( LayoutComponent ) {
 					store={ store }
 					primary={ primary }
 					secondary={ secondary }
-					redirectUri={ context.isServerSide ? context.originalUrl : null }
+					redirectUri={ context.originalUrl }
 				/>
 			);
 		}

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -71,8 +71,6 @@ function getEnhancedContext( req, res ) {
 		pathname: req.path,
 		params: req.params,
 		query: req.query,
-		protocol: req.protocol,
-		host: req.headers.host,
 		redirect: res.redirect.bind( res ),
 		res,
 	} );


### PR DESCRIPTION
A recent PR #22488 changed the `redirect_to` arg in masterbar login links to be relative links [instead of absolute links](https://github.com/Automattic/wp-calypso/pull/22488/files#diff-39da1f06991c32f58998c22e5300b1ceL28) generated from `window.location.href`.

For server renders, where there was no access to `window`, this arg was historically being generated as an absolute link to match. This PR changes the server-generated links to be relative to match the client side, fixing some SSR reconciliation errors.

## Testing
Logged-out, visit various places that show a _Login_ link on the masterbar, checking that the login link works and you arrive back where you were after logging in, and that there are no reconciliation errors in the console such as `Warning: Prop `href` did not match. Server: “/log-in?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fthemes” Client: “/log-in?redirect_to=%2Fthemes”`

For example:
* https://calypso.live/start?branch=fix/masterbar-reconciliation
* https://calypso.live/themes?branch=fix/masterbar-reconciliation
* https://calypso.live/jetpack/connect?branch=fix/masterbar-reconciliation


/cc @sirreal 
