### PR TITLE
Add New Site: fix JP card autofocus

### DIFF
--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -106,6 +106,7 @@ class JetpackNewSite extends Component {
 								onSubmit={ this.handleJetpackSubmit }
 								handleOnClickTos={ this.handleOnClickTos }
 								url={ this.state.jetpackUrl }
+								autoFocus={ false }
 							/>
 						</Card>
 						<Card className="jetpack-new-site__mobile">
@@ -125,6 +126,7 @@ class JetpackNewSite extends Component {
 									onSubmit={ this.handleJetpackSubmit }
 									handleOnClickTos={ this.handleOnClickTos }
 									url={ this.state.jetpackUrl }
+									autoFocus={ false }
 								/>
 							</div>
 						</Card>

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -106,7 +106,7 @@ class JetpackNewSite extends Component {
 								onSubmit={ this.handleJetpackSubmit }
 								handleOnClickTos={ this.handleOnClickTos }
 								url={ this.state.jetpackUrl }
-								autoFocus={ false }
+								autoFocus={ false } // eslint-disable-line jsx-a11y/no-autofocus
 							/>
 						</Card>
 						<Card className="jetpack-new-site__mobile">
@@ -126,7 +126,7 @@ class JetpackNewSite extends Component {
 									onSubmit={ this.handleJetpackSubmit }
 									handleOnClickTos={ this.handleOnClickTos }
 									url={ this.state.jetpackUrl }
-									autoFocus={ false }
+									autoFocus={ false } // eslint-disable-line jsx-a11y/no-autofocus
 								/>
 							</div>
 						</Card>

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -27,11 +27,13 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 		onSubmit: PropTypes.func,
 		translate: PropTypes.func.isRequired,
 		url: PropTypes.string,
+		autoFocus: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		onChange: noop,
 		url: '',
+		autoFocus: true,
 	};
 
 	focusInput = noop;
@@ -107,7 +109,7 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 	}
 
 	render() {
-		const { isError, isFetching, onChange, onSubmit, translate, url } = this.props;
+		const { isError, isFetching, onChange, onSubmit, translate, url, autoFocus } = this.props;
 		const hasError = isError && 'notExists' !== isError;
 
 		return (
@@ -119,7 +121,7 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 						ref={ this.refInput }
 						id="siteUrl"
 						autoCapitalize="off"
-						autoFocus="autofocus"
+						autoFocus={ autoFocus }
 						onChange={ onChange }
 						disabled={ isFetching }
 						placeholder={ 'http://yourjetpack.blog' }

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -121,7 +121,7 @@ class JetpackConnectSiteUrlInput extends PureComponent {
 						ref={ this.refInput }
 						id="siteUrl"
 						autoCapitalize="off"
-						autoFocus={ autoFocus }
+						autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 						onChange={ onChange }
 						disabled={ isFetching }
 						placeholder={ 'http://yourjetpack.blog' }


### PR DESCRIPTION
This fixes some weirdness with the input autofocus in the Jetpack card on Add New Site. This was reported in p7kMJG-4nr-p2

This PR introduces an autoFocus prop in the `site-url-input` component, which allows us to target it differently depending on the view it’s presented. This is enabled by default, but disabled in this specific “Add New Site” view.

---

**Heads-up**: I had to add a `--no-verify` flag before I was able to commit. This was the thrown error:

```
/client/jetpack-connect/site-url-input.jsx
  124:7  error  The autoFocus prop should not be used, as it can reduce usability and accessibility for users  jsx-a11y/no-autofocus
```

### Before

![image](https://user-images.githubusercontent.com/390760/36555237-9c211662-17be-11e8-81c2-c44224bd95c9.png)

![image](https://user-images.githubusercontent.com/390760/36555279-b52c802e-17be-11e8-8a62-055d1e04d970.png)


### After

![image](https://user-images.githubusercontent.com/390760/36555181-7969ba7a-17be-11e8-91ec-b148c82b772a.png)

![image](https://user-images.githubusercontent.com/390760/36555267-aba75aa6-17be-11e8-8b47-a0157db679e9.png)


### Testing

- Go to http://calypso.localhost:3000/jetpack/new?ref=calypso-selector
- Ensure the input for a Jetpack URL is not autofocused
