### PR TITLE
Rewind credential form - update form labels

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -183,7 +183,7 @@ export class RewindCredentialsForm extends Component {
 
 				<div className="rewind-credentials-form__row">
 					<FormFieldset className="rewind-credentials-form__username">
-						<FormLabel htmlFor="server-username">{ translate( 'Username' ) }</FormLabel>
+						<FormLabel htmlFor="server-username">{ translate( 'Server username' ) }</FormLabel>
 						<FormTextInput
 							name="user"
 							id="server-username"
@@ -197,7 +197,7 @@ export class RewindCredentialsForm extends Component {
 					</FormFieldset>
 
 					<FormFieldset className="rewind-credentials-form__password">
-						<FormLabel htmlFor="server-password">{ translate( 'Password' ) }</FormLabel>
+						<FormLabel htmlFor="server-password">{ translate( 'Server password' ) }</FormLabel>
 						<FormPasswordInput
 							name="pass"
 							id="server-password"


### PR DESCRIPTION
Updated the form labels from "Username" and "Password" to "Server username" and "Server password".

Testing instructions

Navigate to Settings -> Security -> Credential form on self-hosted site (jurassic.ninja)

#### Before
![image](https://user-images.githubusercontent.com/36741426/36557767-6d5ebd54-17c6-11e8-94ce-624564a32678.png)

#### After
![image](https://user-images.githubusercontent.com/36741426/36557719-44beb598-17c6-11e8-8294-74e4b0312265.png)
