### PR TITLE
Add New Site: fix back button styling

### DIFF
--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -231,7 +231,7 @@
 		padding: 18px 40px 18px 20px;
 
 		@include breakpoint( "<660px" ) {
-			padding: 20px 8px 16px;
+			padding: 18px 8px 16px;
 		}
 	}
 
@@ -242,5 +242,9 @@
 		height: 46px;
 		background: $white;
 		border-bottom: 1px solid $gray-light;
+	}
+
+	span {
+		vertical-align: 1px;
 	}
 }

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -3,6 +3,10 @@
 	max-width: 960px;
 	margin: 35px auto 0;
 	text-align: center;
+
+	@include breakpoint( "<660px" ) {
+		margin-top: 15px;
+	}
 }
 
 .jetpack-new-site__header {
@@ -211,5 +215,32 @@
 
 	@include breakpoint( "<660px" ) {
 		display: block;
+	}
+}
+
+// Include Reader Back styles because they're not part of the main bundle
+// See: https://github.com/Automattic/wp-calypso/pull/19147
+.reader-full-post__back-container {
+	margin: 0;
+	position: fixed;
+		top: 47px;
+		left: 0;
+	z-index: z-index( '.masterbar', '.reader-back'	);
+
+	.button.is-compact.is-borderless {
+		padding: 18px 40px 18px 20px;
+
+		@include breakpoint( "<660px" ) {
+			padding: 20px 8px 16px;
+		}
+	}
+
+	@include breakpoint( "<660px" ) {
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 46px;
+		background: $white;
+		border-bottom: 1px solid $gray-light;
 	}
 }


### PR DESCRIPTION
Includes Reader Back styles explicitly because they're not part of the
main bundle. See: https://github.com/Automattic/wp-calypso/pull/19147

It probably makes more sense to duplicate the back button element and
start using a dedicated one. Thoughts?

### Before

![image](https://user-images.githubusercontent.com/390760/36558569-a557fbc4-17c8-11e8-9c27-381c757a5923.png)

### After

![image](https://user-images.githubusercontent.com/390760/36558543-9295aad6-17c8-11e8-995b-8720fc561cd6.png)

### Testing

- Go to http://calypso.localhost:3000/jetpack/new?ref=calypso-selector
- Ensure the back button behaves as expected in small screen devices