### PR TITLE
Disconnect: if Rewind is active, prompt user to try rewind before disconnecting

### DIFF
--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -236,7 +236,7 @@ class DisconnectJetpack extends PureComponent {
 		}
 
 		return [
-			<Card key="disconnect-jetpack" className="disconnect-jetpack">
+			<Card key="disconnect-jetpack" className="disconnect-jetpack__block">
 				{ siteId && <QueryRewindState siteId={ siteId } /> }
 				{ showTitle && (
 					<h1 className="disconnect-jetpack__header">
@@ -273,7 +273,7 @@ class DisconnectJetpack extends PureComponent {
 			'active' === rewindState && (
 				<Card
 					key="disconnect-jetpack__try-rewind"
-					className="disconnect-jetpack__try-rewind disconnect-jetpack"
+					className="disconnect-jetpack__try-rewind disconnect-jetpack__block"
 				>
 					<p className="disconnect-jetpack__highlight">
 						{ translate( 'Experiencing connection issues? Try to go back and rewind your site.' ) }

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -10,6 +10,7 @@ import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -202,6 +203,8 @@ class DisconnectJetpack extends PureComponent {
 		);
 	};
 
+	handleTryRewind = () => this.props.trackTryRewind( this.props.siteSlug );
+
 	render() {
 		const {
 			disconnectHref,
@@ -276,7 +279,7 @@ class DisconnectJetpack extends PureComponent {
 						{ translate( 'Experiencing connection issues? Try to go back and rewind your site.' ) }
 					</p>
 					<div className="disconnect-jetpack__try-rewind-button-wrap">
-						<Button href={ `/stats/activity/${ siteSlug }` } onClick={ this.props.trackTryRewind }>
+						<Button href={ `/stats/activity/${ siteSlug }` } onClick={ this.handleTryRewind }>
 							{ translate( 'Rewind site' ) }
 						</Button>
 						<HappychatButton borderless={ false } onClick={ this.props.trackTryRewindHelp } primary>
@@ -302,17 +305,20 @@ export default connect(
 			rewindState: rewindState.state,
 		};
 	},
-	{
-		setAllSitesSelected,
-		recordGoogleEvent: recordGoogleEventAction,
-		recordTracksEvent: recordTracksEventAction,
-		disconnect,
-		successNotice,
-		errorNotice,
-		infoNotice,
-		removeNotice,
-		trackTryRewind: () => recordTracksEventAction( 'calypso_disconnect_jetpack_try_rewind' ),
+	dispatch => ( {
+		setAllSitesSelected: () => dispatch( setAllSitesSelected ),
+		recordGoogleEvent: () => dispatch( recordGoogleEventAction ),
+		recordTracksEvent: () => dispatch( recordTracksEventAction ),
+		disconnect: () => dispatch( disconnect ),
+		successNotice: () => dispatch( successNotice ),
+		errorNotice: () => dispatch( errorNotice ),
+		infoNotice: () => dispatch( infoNotice ),
+		removeNotice: () => dispatch( removeNotice ),
+		trackTryRewind: siteSlug => {
+			dispatch( recordTracksEventAction( 'calypso_disconnect_jetpack_try_rewind' ) );
+			page.redirect( `/stats/activity/${ siteSlug }` );
+		},
 		trackTryRewindHelp: () =>
-			recordTracksEventAction( 'calypso_disconnect_jetpack_try_rewind_help' ),
-	}
+			dispatch( recordTracksEventAction( 'calypso_disconnect_jetpack_try_rewind_help' ) ),
+	} )
 )( localize( DisconnectJetpack ) );

--- a/client/blocks/disconnect-jetpack/style.scss
+++ b/client/blocks/disconnect-jetpack/style.scss
@@ -49,6 +49,16 @@
 	}
 }
 
+.disconnect-jetpack__try-rewind-button-wrap {
+	.button {
+		margin: 0 4px;
+	}
+
+	.gridicon {
+		margin-right: 5px;
+	}
+}
+
 .disconnect-jetpack__more-info-link {
 	font-size: 13px;
 }

--- a/client/blocks/disconnect-jetpack/style.scss
+++ b/client/blocks/disconnect-jetpack/style.scss
@@ -1,6 +1,6 @@
 /** @format */
 
-.disconnect-jetpack {
+.disconnect-jetpack__block {
 	text-align: center;
 	max-width: 400px;
 	color: $gray-darken-20;
@@ -70,7 +70,7 @@
 }
 
 .disconnect-jetpack-dialog {
-	.disconnect-jetpack {
+	.disconnect-jetpack__block {
 		margin-bottom: 0;
 	}
 }

--- a/client/components/happychat/button.jsx
+++ b/client/components/happychat/button.jsx
@@ -30,6 +30,7 @@ export class HappychatButton extends Component {
 	static propTypes = {
 		allowMobileRedirect: PropTypes.bool,
 		borderless: PropTypes.bool,
+		primary: PropTypes.bool,
 		getAuth: PropTypes.func,
 		initConnection: PropTypes.func,
 		isChatActive: PropTypes.bool,


### PR DESCRIPTION
Fixes #22364

This PR introduces a new box prompting user to try Rewind to fix their site when they're having issues with it:

- introduces a button to go to Activity Log and another to launch a Happychat
- both buttons have tracking
- implements the copy fixes suggested by @clucasrowlands (this plan is different from the one used for the issue but the code shows that all issues have been addressed)
- declares the property `primary` in the `HappychatButton` component. It was already in use, it just wasn't declared

<img width="422" alt="captura de pantalla 2018-02-22 a la s 18 14 52" src="https://user-images.githubusercontent.com/1041600/36564509-50d7c870-17fc-11e8-8c65-293a05df6326.png">

#### Testing

In a connected Jetpack site that has Rewind active, go to the disconnection dialog and verify things look good.
