### PR TITLE
Editor: Fix sidebar positioning

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -316,6 +316,7 @@ form.sidebar__button input {
 	display: flex;
 	flex-direction: row;
 	padding-left: 10px;
+	min-height: 42px;
 }
 
 .sidebar .sidebar__footer .button {

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -1,12 +1,16 @@
 .editor-sidebar {
-	@extend .sidebar;
+    position: fixed;
+    top: 46px;
+    right: -$sidebar-width-max;
+    bottom: 0px;
+	display: flex;
+	flex-direction: column;
 	z-index: z-index( 'root', '.editor-sidebar' );
 	background: $gray-lighten-30;
 	border-left: 1px solid darken( $sidebar-bg-color, 5% );
 	border-top: 1px solid darken( $sidebar-bg-color, 5% );
 	border-right: none;
 	box-sizing: border-box;
-	right: $sidebar-width-max;
 	left: auto;
 	transition: all 0.15s cubic-bezier(0.075, 0.82, 0.165, 1);
 	overflow-x: hidden;
@@ -41,30 +45,40 @@
 	}
 }
 
-.editor-sidebar .sidebar__footer .button {
-	&.inline-help {
-		border-radius: 0;
-		border-left: 1px solid #c8d7e1;
-		flex: 0 1 60px;
-		margin-right: 0;
-		margin-left: auto;
-		outline: 0;
+.editor-sidebar .sidebar__footer {
+	align-items: center;
+	padding: 0;
+	border-top: 1px solid darken( $sidebar-bg-color, 10% );
+	margin: auto 0 0;
+	display: flex;
+	flex-direction: row;
+	padding-left: 10px;
 
-		@include breakpoint( "<660px" ) {
-			flex: 0 1 56px;
+	.button {
+		&.inline-help {
+			border-radius: 0;
+			border-left: 1px solid #c8d7e1;
+			flex: 0 1 60px;
+			margin-right: 0;
+			margin-left: auto;
+			outline: 0;
+
+			@include breakpoint( "<660px" ) {
+				flex: 0 1 56px;
+			}
+
+			.gridicon {
+				margin: 0 auto;
+				float: none;
+			}
 		}
 
-		.gridicon {
-			margin: 0 auto;
-			float: none;
-		}
-	}
+		&.is-active {
+			background: $blue-medium;
 
-	&.is-active {
-		background: $blue-medium;
-
-		.gridicon {
-			fill: $white;
+			.gridicon {
+				fill: $white;
+			}
 		}
 	}
 }


### PR DESCRIPTION
I broke the editor's sidebar in #22507 — I didn't realize it `@exted`'s the `.sidebar`. This is problematic since they don't really share many styles. To fix, I removed the `@extend` and updated the styles as needed to `position: fixed;` the sidebar and clean up the footer.

Before, scrolled down:
<img width="1302" alt="screen shot 2018-02-22 at 2 30 08 pm" src="https://user-images.githubusercontent.com/191598/36560173-0a6c0248-17de-11e8-9cf1-dff10ee7e392.png">

After, scrolled down:
<img width="1302" alt="screen shot 2018-02-22 at 2 30 20 pm" src="https://user-images.githubusercontent.com/191598/36560188-1527cbcc-17de-11e8-9b8f-902275c74528.png">
