### PR TITLE
Store: Simplify tax rate presentation, stop using per-state flags

### DIFF
--- a/client/extensions/woocommerce/app/settings/taxes/style.scss
+++ b/client/extensions/woocommerce/app/settings/taxes/style.scss
@@ -22,10 +22,6 @@
 		color: $gray;
 	}
 
-	.notice.is-error {
-		margin-bottom: 0;
-	}
-
 	a.external-link {
 		margin-left: 8px;
 	}

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -55,7 +55,7 @@ class TaxesRates extends Component {
 		this.maybeFetchRates( nextProps );
 	};
 
-	renderIntro = () => {
+	renderLocation = () => {
 		const { address, areTaxesEnabled, translate } = this.props;
 		if ( ! areTaxesEnabled ) {
 			return null;
@@ -249,8 +249,8 @@ class TaxesRates extends Component {
 					</FormToggle>
 				</ExtendedHeader>
 				<Card>
-					{ this.renderIntro() }
 					{ this.renderCalculationStatus() }
+					{ this.renderLocation() }
 					{ this.possiblyRenderRates() }
 					{ this.renderPolicyNotice() }
 				</Card>

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -22,11 +22,6 @@ import {
 } from 'woocommerce/state/sites/settings/general/selectors';
 import { areTaxRatesLoaded, getTaxRates } from 'woocommerce/state/sites/meta/taxrates/selectors';
 import Card from 'components/card';
-import {
-	DESTINATION_BASED_SALES_TAX,
-	NO_SALES_TAX,
-	ORIGIN_BASED_SALES_TAX,
-} from 'woocommerce/lib/countries/constants';
 import { getCountryData, getStateData } from 'woocommerce/lib/countries';
 import ExtendedHeader from 'woocommerce/components/extended-header';
 import ExternalLink from 'components/external-link';
@@ -60,8 +55,12 @@ class TaxesRates extends Component {
 		this.maybeFetchRates( nextProps );
 	};
 
-	renderInfo = () => {
-		const { address, translate } = this.props;
+	renderIntro = () => {
+		const { address, areTaxesEnabled, translate } = this.props;
+		if ( ! areTaxesEnabled ) {
+			return null;
+		}
+
 		const countryData = getCountryData( address.country );
 		if ( ! countryData ) {
 			return (
@@ -89,42 +88,11 @@ class TaxesRates extends Component {
 
 		const stateName = stateData.name;
 
-		if ( NO_SALES_TAX === stateData.salesTaxBasis ) {
-			return (
-				<p>
-					{ translate(
-						'Since your store is located in {{strong}}%(stateName)s, ' +
-							"%(countryName)s{{/strong}} you're not required to collect sales tax.",
-						{
-							args: { stateName, countryName },
-							components: { strong: <strong /> },
-						}
-					) }
-				</p>
-			);
-		}
-
-		if ( ORIGIN_BASED_SALES_TAX === stateData.salesTaxBasis ) {
-			return (
-				<p>
-					{ translate(
-						"Since your store is located in {{strong}}%(stateName)s, %(countryName)s{{/strong}} you're " +
-							'required to charge sales tax based on your business address.',
-						{
-							args: { stateName, countryName },
-							components: { strong: <strong /> },
-						}
-					) }
-				</p>
-			);
-		}
-
-		// Default - DESTINATION_BASED_SALES_TAX
 		return (
 			<p>
 				{ translate(
-					"Since your store is located in {{strong}}%(stateName)s, %(countryName)s{{/strong}} you're " +
-						"required to charge sales tax based on the customer's shipping address.",
+					"The following tax rates are in effect at your store's location in " +
+						'{{strong}}%(stateName)s, %(countryName)s{{/strong}}',
 					{
 						args: { stateName, countryName },
 						components: { strong: <strong /> },
@@ -142,16 +110,12 @@ class TaxesRates extends Component {
 			return null;
 		}
 
-		if ( NO_SALES_TAX === stateData.salesTaxBasis ) {
-			return null;
-		}
-
 		if ( ! areTaxesEnabled ) {
 			return (
-				<Notice showDismiss={ false } status="is-error">
+				<Notice showDismiss={ false } status="is-warning">
 					{ translate(
 						'Sales taxes are not currently being charged. Unless ' +
-							'your products are exempt from sales tax we recommend that you ' +
+							'your store or products are exempt from sales tax we recommend that you ' +
 							'{{strong}}enable automatic tax calculation and charging{{/strong}}',
 						{
 							components: { strong: <strong /> },
@@ -161,24 +125,11 @@ class TaxesRates extends Component {
 			);
 		}
 
-		if ( DESTINATION_BASED_SALES_TAX === stateData.salesTaxBasis ) {
-			return (
-				<div className="taxes__taxes-calculate">
-					<Gridicon icon="checkmark" />
-					{ translate(
-						"We'll automatically calculate and charge the " +
-							'correct rate of tax for you each time a customer checks out.'
-					) }
-				</div>
-			);
-		}
-
 		return (
 			<div className="taxes__taxes-calculate">
 				<Gridicon icon="checkmark" />
 				{ translate(
-					"We'll automatically calculate and charge sales tax " +
-						'at the following rate each time a customer checks out.'
+					"We'll automatically calculate and charge sales tax " + 'each time a customer checks out.'
 				) }
 			</div>
 		);
@@ -195,15 +146,11 @@ class TaxesRates extends Component {
 			return null;
 		}
 
-		if ( ORIGIN_BASED_SALES_TAX !== stateData.salesTaxBasis ) {
-			return null;
-		}
-
 		if ( isEmpty( taxRates ) ) {
 			return (
 				<Notice showDismiss={ false } status="is-error">
 					{ translate(
-						'The WordPress.com sales tax rate service is not ' + 'available for this site.'
+						'The WordPress.com sales tax rate service is not available for this site.'
 					) }
 				</Notice>
 			);
@@ -302,7 +249,7 @@ class TaxesRates extends Component {
 					</FormToggle>
 				</ExtendedHeader>
 				<Card>
-					{ this.renderInfo() }
+					{ this.renderIntro() }
 					{ this.renderCalculationStatus() }
 					{ this.possiblyRenderRates() }
 					{ this.renderPolicyNotice() }

--- a/client/extensions/woocommerce/lib/countries/CA.js
+++ b/client/extensions/woocommerce/lib/countries/CA.js
@@ -6,11 +6,6 @@
 
 import { translate } from 'i18n-calypso';
 
-/**
- * Internal dependencies
- */
-import { DESTINATION_BASED_SALES_TAX } from './constants';
-
 export default () => {
 	return {
 		code: 'CA',
@@ -23,67 +18,54 @@ export default () => {
 			{
 				code: 'AB',
 				name: translate( 'Alberta' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'BC',
 				name: translate( 'British Columbia' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'MB',
 				name: translate( 'Manitoba' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'NB',
 				name: translate( 'New Brunswick' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'NL',
 				name: translate( 'Newfoundland and Labrador' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'NT',
 				name: translate( 'Northwest Territories' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'NS',
 				name: translate( 'Nova Scotia' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'NU',
 				name: translate( 'Nunavut' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'ON',
 				name: translate( 'Ontario' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'PE',
 				name: translate( 'Prince Edward Island' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'QC',
 				name: translate( 'Quebec' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'SK',
 				name: translate( 'Saskatchewan' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'YT',
 				name: translate( 'Yukon Territory' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 		],
 		statesLabel: translate( 'Province' ),

--- a/client/extensions/woocommerce/lib/countries/US.js
+++ b/client/extensions/woocommerce/lib/countries/US.js
@@ -6,11 +6,6 @@
 
 import { translate } from 'i18n-calypso';
 
-/**
- * Internal dependencies
- */
-import { DESTINATION_BASED_SALES_TAX, NO_SALES_TAX, ORIGIN_BASED_SALES_TAX } from './constants';
-
 export default () => {
 	return {
 		code: 'US',
@@ -23,257 +18,206 @@ export default () => {
 			{
 				code: 'AL',
 				name: translate( 'Alabama' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'AK',
 				name: translate( 'Alaska' ),
-				salesTaxBasis: NO_SALES_TAX,
 			},
 			{
 				code: 'AZ',
 				name: translate( 'Arizona' ),
-				salesTaxBasis: ORIGIN_BASED_SALES_TAX,
 			},
 			{
 				code: 'AR',
 				name: translate( 'Arkansas' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'CA',
 				name: translate( 'California' ),
-				salesTaxBasis: ORIGIN_BASED_SALES_TAX,
 			},
 			{
 				code: 'CO',
 				name: translate( 'Colorado' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'CT',
 				name: translate( 'Connecticut' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'DE',
 				name: translate( 'Delaware' ),
-				salesTaxBasis: NO_SALES_TAX,
 			},
 			{
 				code: 'DC',
 				name: translate( 'District Of Columbia' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'FL',
 				name: translate( 'Florida' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'GA',
 				name: translate( 'Georgia' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'HI',
 				name: translate( 'Hawaii' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'ID',
 				name: translate( 'Idaho' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'IL',
 				name: translate( 'Illinois' ),
-				salesTaxBasis: ORIGIN_BASED_SALES_TAX,
 			},
 			{
 				code: 'IN',
 				name: translate( 'Indiana' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'IA',
 				name: translate( 'Iowa' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'KS',
 				name: translate( 'Kansas' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'KY',
 				name: translate( 'Kentucky' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'LA',
 				name: translate( 'Louisiana' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'ME',
 				name: translate( 'Maine' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'MD',
 				name: translate( 'Maryland' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'MA',
 				name: translate( 'Massachusetts' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'MI',
 				name: translate( 'Michigan' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'MN',
 				name: translate( 'Minnesota' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'MS',
 				name: translate( 'Mississippi' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'MO',
 				name: translate( 'Missouri' ),
-				salesTaxBasis: ORIGIN_BASED_SALES_TAX,
 			},
 			{
 				code: 'MT',
 				name: translate( 'Montana' ),
-				salesTaxBasis: NO_SALES_TAX,
 			},
 			{
 				code: 'NE',
 				name: translate( 'Nebraska' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'NV',
 				name: translate( 'Nevada' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'NH',
 				name: translate( 'New Hampshire' ),
-				salesTaxBasis: NO_SALES_TAX,
 			},
 			{
 				code: 'NJ',
 				name: translate( 'New Jersey' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'NM',
 				name: translate( 'New Mexico' ),
-				salesTaxBasis: ORIGIN_BASED_SALES_TAX,
 			},
 			{
 				code: 'NY',
 				name: translate( 'New York' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'NC',
 				name: translate( 'North Carolina' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'ND',
 				name: translate( 'North Dakota' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'OH',
 				name: translate( 'Ohio' ),
-				salesTaxBasis: ORIGIN_BASED_SALES_TAX,
 			},
 			{
 				code: 'OK',
 				name: translate( 'Oklahoma' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'OR',
 				name: translate( 'Oregon' ),
-				salesTaxBasis: NO_SALES_TAX,
 			},
 			{
 				code: 'PA',
 				name: translate( 'Pennsylvania' ),
-				salesTaxBasis: ORIGIN_BASED_SALES_TAX,
 			},
 			{
 				code: 'RI',
 				name: translate( 'Rhode Island' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'SC',
 				name: translate( 'South Carolina' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'SD',
 				name: translate( 'South Dakota' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'TN',
 				name: translate( 'Tennessee' ),
-				salesTaxBasis: ORIGIN_BASED_SALES_TAX,
 			},
 			{
 				code: 'TX',
 				name: translate( 'Texas' ),
-				salesTaxBasis: ORIGIN_BASED_SALES_TAX,
 			},
 			{
 				code: 'UT',
 				name: translate( 'Utah' ),
-				salesTaxBasis: ORIGIN_BASED_SALES_TAX,
 			},
 			{
 				code: 'VT',
 				name: translate( 'Vermont' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'VA',
 				name: translate( 'Virginia' ),
-				salesTaxBasis: ORIGIN_BASED_SALES_TAX,
 			},
 			{
 				code: 'WA',
 				name: translate( 'Washington' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'WV',
 				name: translate( 'West Virginia' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'WI',
 				name: translate( 'Wisconsin' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 			{
 				code: 'WY',
 				name: translate( 'Wyoming' ),
-				salesTaxBasis: DESTINATION_BASED_SALES_TAX,
 			},
 		],
 		statesLabel: translate( 'State' ),

--- a/client/extensions/woocommerce/lib/countries/constants.js
+++ b/client/extensions/woocommerce/lib/countries/constants.js
@@ -1,9 +1,0 @@
-/**
- * This file contains helper constants for countries.
- *
- * @format
- */
-
-export const DESTINATION_BASED_SALES_TAX = 'DESTINATION_BASED_SALES_TAX';
-export const NO_SALES_TAX = 'NO_SALES_TAX';
-export const ORIGIN_BASED_SALES_TAX = 'ORIGIN_BASED_SALES_TAX';


### PR DESCRIPTION
Another piece needed for #22062 and #21574 

Design notes: As part of removing our dependency on the calypso woocommerce countries blob, we needed to stop doing special things based on the tax rate flags ( `ORIGIN_BASED_SALES_TAX`, `DESTINATION_BASED_SALES_TAX` and `NO_SALES_TAX` ) - it wasn't a great idea to start with since states can change and doing this for outside the US and CA wasn't going to scale well

So... the consumer of all that data was the `TaxesRates` component in `client/extensions/woocommerce/app/settings/taxes/taxes-rates.js`

Instead of presenting unique language for the three situations, I consolidated things and tweaked the wording a bit to make it work for all three cases (by saying "in effect at your location" it covers the example rates for origin based, destination based and zero nicely).

Here's the new visuals (I used an Alabama address (a destination based state), an Arizona address (an origin based state) and an Alaskan address (a zero tax state) to cover all three cases). I also tweaked the "tax calculations are disabled" to be a warning instead of an error (since states like Alaska are perfectly fine not having sales tax calculations enabled.)

**Washington State Examples (a destination state)**

<img width="519" alt="screen shot 2018-02-22 at 12 41 12 pm" src="https://user-images.githubusercontent.com/1595739/36563845-43b9f2e8-17d0-11e8-989d-1542437b16cc.png">

<img width="527" alt="screen shot 2018-02-22 at 12 48 24 pm" src="https://user-images.githubusercontent.com/1595739/36563850-4419f972-17d0-11e8-99fe-0ad97373f0fa.png">

**Alabama Examples (also a destination state)**

<img width="523" alt="screen shot 2018-02-22 at 12 47 36 pm" src="https://user-images.githubusercontent.com/1595739/36563846-43e97ff4-17d0-11e8-8d0a-c485b0e3db66.png">

<img width="528" alt="screen shot 2018-02-22 at 12 47 51 pm" src="https://user-images.githubusercontent.com/1595739/36563849-4402f5c4-17d0-11e8-8acd-cca7788be88d.png">

**Alaska Examples (a zero tax state)**

<img width="526" alt="screen shot 2018-02-22 at 12 48 53 pm" src="https://user-images.githubusercontent.com/1595739/36563852-443411e0-17d0-11e8-9f81-f02eeeefc499.png">

<img width="525" alt="screen shot 2018-02-22 at 12 51 38 pm" src="https://user-images.githubusercontent.com/1595739/36563853-44526de8-17d0-11e8-98cb-4119c88c7d9a.png">

**Arizona Example (an origin based state)**

<img width="536" alt="screen shot 2018-02-22 at 1 07 10 pm" src="https://user-images.githubusercontent.com/1595739/36564214-653a67a8-17d1-11e8-9a7b-fccc1e26fd99.png">
