### PR TITLE
Framework: Update Gridicons to v.2.1.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -791,12 +791,12 @@
       }
     },
     "babel-jest": {
-      "version": "22.4.0",
-      "integrity": "sha512-A/safCd5jSf1D98XoHCN3YYuGurtUPntuPh8b7UxsLNfEp/QC8UwdL+VEGSLN5Fk3+tS/Jdbf5NK/T2it8RGYw==",
+      "version": "22.4.1",
+      "integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.5",
-        "babel-preset-jest": "22.2.0"
+        "babel-preset-jest": "22.4.1"
       }
     },
     "babel-loader": {
@@ -857,8 +857,8 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "22.2.0",
-      "integrity": "sha512-NwicD5n1YQaj6sM3PVULdPBDk1XdlWvh8xBeUJg3nqZwp79Vofb8Q7GOVeWoZZ/RMlMuJMMrEAgSQl/p392nLA==",
+      "version": "22.4.1",
+      "integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg==",
       "dev": true
     },
     "babel-plugin-jscript": {
@@ -1383,7 +1383,7 @@
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "requires": {
             "caniuse-lite": "1.0.30000810",
-            "electron-to-chromium": "1.3.33"
+            "electron-to-chromium": "1.3.34"
           }
         },
         "semver": {
@@ -1455,11 +1455,11 @@
       }
     },
     "babel-preset-jest": {
-      "version": "22.2.0",
-      "integrity": "sha512-p61cPMGYlSgfNScn1yQuVnLguWE4bjhB/br4KQDMbYZG+v6ryE5Ch7TKukjA6mRuIQj1zhyou7Sbpqrh4/N6Pg==",
+      "version": "22.4.1",
+      "integrity": "sha512-gW3+spyB8fkSAI9fX+41BQMwar5LjR+nyKa2QRvK22snxnI29+jJVAMfId+osucFJzJJvhlvzKWnfwX8Omodvg==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "22.2.0",
+        "babel-plugin-jest-hoist": "22.4.1",
         "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
@@ -2295,13 +2295,13 @@
       "integrity": "sha512-x/Q52iLSZsRrRb2ePmTsVYXrGcrPQ8G4yRAY7QpMlumxAfPVrnDOH2X6Z5s8qsAX7AA7YuIi8AXFrvH0wWEesA==",
       "dev": true,
       "requires": {
-        "marked": "0.3.15",
+        "marked": "0.3.16",
         "marked-terminal": "2.0.0"
       },
       "dependencies": {
         "marked": {
-          "version": "0.3.15",
-          "integrity": "sha512-PToZtmCYVf4mlkmfoDPpsg3VJhkEvCHeTXSxbG3FBBxEoLAlxAsYPCADWx4+XBebMXCowDW7vaOGfRVjmFDM5w==",
+          "version": "0.3.16",
+          "integrity": "sha512-diLiAxHidES67uJ1P5unXBUB4CyOFwodKrctuK0U4Ogw865N9Aw4dLmY0BK0tGKOy3xvkdMGgUXPD6W9z1Ne0Q==",
           "dev": true
         }
       }
@@ -3493,8 +3493,8 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.33",
-      "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU="
+      "version": "1.3.34",
+      "integrity": "sha1-2TSY9AORuwwWpgPYJBuZUUBBV+0="
     },
     "elliptic": {
       "version": "6.4.0",
@@ -4859,7 +4859,7 @@
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
+        "nan": "2.9.1",
         "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
@@ -5928,12 +5928,12 @@
       "integrity": "sha512-Q7cx22DiLhwHsEfUnUip1Ww/Vfx7FS0w6+iHItNuN61+XpegHSa3k5U0+6M5BcpavQImBwFiy0z3uYwY7cXMLQ==",
       "dev": true,
       "requires": {
-        "iterall": "1.2.0"
+        "iterall": "1.2.1"
       }
     },
     "gridicons": {
-      "version": "2.1.2",
-      "integrity": "sha512-IDfjWa7QIla6KMRUUiv4TrOZsqjZWDvG0xfjw+a6/rgEaqxlPTJDRvTUXh96/TekXM440h+Mks1JGBwO9AD3zA==",
+      "version": "2.1.3-alpha.1",
+      "integrity": "sha512-2VBVdv5AwHda9sD/UhRqmjj9dmXXeCN2Gayw49r2yPrVqdqxbx8n3qedkWAAVk+I5nIJTDCnqWwYRPrBBYwzjQ==",
       "requires": {
         "prop-types": "15.5.10"
       }
@@ -7159,8 +7159,8 @@
       }
     },
     "iterall": {
-      "version": "1.2.0",
-      "integrity": "sha512-FB8k5B8otDib0rFysEP5G/oOY6aBF48Y9crLxyZ43eHsk/SfMVH1JqvzU0badSu/WR5nkk3ihp8VQlyBP3SJxg==",
+      "version": "1.2.1",
+      "integrity": "sha512-XH2awY4PboL5tG5i2P7wZ2E6oet/JkmEUpUhjcroXxBUy7bPsUOXRDMAAZe+rnH2azSXboqvyDIp5n2f7GtlCQ==",
       "dev": true
     },
     "jed": {
@@ -7172,7 +7172,7 @@
       "integrity": "sha512-90H1wLqiNR3tLhQUgwhC6GWHfRCG+Da14m7vxD608Mt/QTKR0TA751D+QH09x5bvcrLfvxLtxArtA0VEC0ORow==",
       "dev": true,
       "requires": {
-        "jest-cli": "22.4.0"
+        "jest-cli": "22.4.1"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -7247,8 +7247,8 @@
           "dev": true
         },
         "jest-cli": {
-          "version": "22.4.0",
-          "integrity": "sha512-0JlBb/PvHGQZR2I9GZwsycHgWHhriBmvBWPaaPYUT186oiIIDY4ezDxFOFt2Ts0yNTRg3iY9mTyHsfWbT5VRWA==",
+          "version": "22.4.1",
+          "integrity": "sha512-YrluVb3tHX1Ej2jYelcC68Gi8qMEXnTrCfW/l8oN6mw3RWYkfkKXGjb6AnVuu0t1vG1Q2onGDSn7K8s/+Ilrew==",
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
@@ -7263,18 +7263,18 @@
             "istanbul-lib-instrument": "1.9.2",
             "istanbul-lib-source-maps": "1.2.3",
             "jest-changed-files": "22.2.0",
-            "jest-config": "22.4.0",
-            "jest-environment-jsdom": "22.4.0",
+            "jest-config": "22.4.1",
+            "jest-environment-jsdom": "22.4.1",
             "jest-get-type": "22.1.0",
-            "jest-haste-map": "22.4.0",
+            "jest-haste-map": "22.4.1",
             "jest-message-util": "22.4.0",
             "jest-regex-util": "22.1.0",
             "jest-resolve-dependencies": "22.1.0",
-            "jest-runner": "22.4.0",
-            "jest-runtime": "22.4.0",
+            "jest-runner": "22.4.1",
+            "jest-runtime": "22.4.1",
             "jest-snapshot": "22.4.0",
-            "jest-util": "22.4.0",
-            "jest-validate": "22.4.0",
+            "jest-util": "22.4.1",
+            "jest-validate": "22.4.1",
             "jest-worker": "22.2.2",
             "micromatch": "2.3.11",
             "node-notifier": "5.2.1",
@@ -7365,20 +7365,20 @@
       }
     },
     "jest-config": {
-      "version": "22.4.0",
-      "integrity": "sha512-hZs8qHjCybOpqni0Kwt40eAavYN/3KnJJwYxSJsBRedJ98IgGSiI18SjybCSccKayA7eHgw1A+dLkHcfI4LItQ==",
+      "version": "22.4.1",
+      "integrity": "sha512-yfyHvLTiZ7IOvl75LeUV1bGF0chQdMdSiDb/B1Gr9LRQH2y3ADPWfyrNUo94cbBaD6g2oLeHSlH8Cm+NLNYDSQ==",
       "dev": true,
       "requires": {
         "chalk": "2.3.1",
         "glob": "7.1.2",
-        "jest-environment-jsdom": "22.4.0",
-        "jest-environment-node": "22.4.0",
+        "jest-environment-jsdom": "22.4.1",
+        "jest-environment-node": "22.4.1",
         "jest-get-type": "22.1.0",
-        "jest-jasmine2": "22.4.0",
+        "jest-jasmine2": "22.4.1",
         "jest-regex-util": "22.1.0",
-        "jest-resolve": "22.4.0",
-        "jest-util": "22.4.0",
-        "jest-validate": "22.4.0",
+        "jest-resolve": "22.4.1",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.1",
         "pretty-format": "22.4.0"
       },
       "dependencies": {
@@ -7491,22 +7491,22 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "22.4.0",
-      "integrity": "sha512-SAUCte4KFLaD2YhYwHFVEI2GkR4BHqHJsnbFgmQMGgHnZ2CfjSZE8Bnb+jlarbxIG4GXl31+2e9rjBpzbY9gKQ==",
+      "version": "22.4.1",
+      "integrity": "sha512-x/JzAoH+dWPBnIMv5OQKiIR0TYf6UvbRjsIuDZ11yDFXkHKGJZg6jNnLAsokAm3cq9kUa2hH5BPUC9XU4n1ELQ==",
       "dev": true,
       "requires": {
         "jest-mock": "22.2.0",
-        "jest-util": "22.4.0",
+        "jest-util": "22.4.1",
         "jsdom": "11.6.2"
       }
     },
     "jest-environment-node": {
-      "version": "22.4.0",
-      "integrity": "sha512-ihSKa2MU5jkAhmRJ17FU4nisbbfW6spvl6Jtwmm5W9kmTVa2sa9UoHWbOWAb7HXuLi3PGGjzTfEt5o3uIzisnQ==",
+      "version": "22.4.1",
+      "integrity": "sha512-wj9+zzfRgnUbm5VwFOCGgG1QmbucUyrjPKBKUJdLW8K5Ss5zrNc1k+v6feZhFg6sS3ZGnjgtIyklaxEARxu+LQ==",
       "dev": true,
       "requires": {
         "jest-mock": "22.2.0",
-        "jest-util": "22.4.0"
+        "jest-util": "22.4.1"
       }
     },
     "jest-file-exists": {
@@ -7520,8 +7520,8 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "22.4.0",
-      "integrity": "sha512-znYomZ+GaRcuFLQz7hmwQOfLkHY2Y2Aoyd29ZcXLrwBEWts5U/c7lFsqo54XUJUlMhrM5M2IOaAUWjZ1CRqAOQ==",
+      "version": "22.4.1",
+      "integrity": "sha512-VWLkRCMSaU34YftLp0zfbb+gUNm+ZcM5ridzAnd5WTR+zUnP8RUGAiDh2YtPPaM5MbgCY0VPC+I0Ti6XN1UmhA==",
       "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
@@ -7544,11 +7544,10 @@
       }
     },
     "jest-jasmine2": {
-      "version": "22.4.0",
-      "integrity": "sha512-oL7bNLfEL9jPVjmiwqQuwrAJ/5ddmKHSpns0kCpAmv1uQ47Q5aC9zBTXZbDWP5GVbVHj2hbYtNbkwTiXJr0e8w==",
+      "version": "22.4.1",
+      "integrity": "sha512-02y0W+Y4b2RjnNJQwV2zVyD+nNMYcunNFpbMf9QcCxMrErAelYXBS2SOUWZTlZfoE2Z/pk9HLBCJ96V2M3nJaw==",
       "dev": true,
       "requires": {
-        "callsites": "2.0.0",
         "chalk": "2.3.1",
         "co": "4.6.0",
         "expect": "22.4.0",
@@ -7558,6 +7557,7 @@
         "jest-matcher-utils": "22.4.0",
         "jest-message-util": "22.4.0",
         "jest-snapshot": "22.4.0",
+        "jest-util": "22.4.1",
         "source-map-support": "0.5.3"
       },
       "dependencies": {
@@ -7568,11 +7568,6 @@
           "requires": {
             "color-convert": "1.9.1"
           }
-        },
-        "callsites": {
-          "version": "2.0.0",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
         },
         "chalk": {
           "version": "2.3.1",
@@ -7814,8 +7809,8 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "22.4.0",
-      "integrity": "sha512-Vs/5VeJEHLpB0ubpYuU9QpBjcCUZRHoHnoV58ZC+N3EXyMJr/MgoqUNpo4OHGQERWlUpvl4YLAAO5uxSMF2VIg==",
+      "version": "22.4.1",
+      "integrity": "sha512-PT1ujfwGoE/jwFo17fpiXVUiTmtiEgu5kuq7AUD7cK3MAM/KfT0GQ1R+RM1Y7W0VW4C8koRiiA/4hB4WvX/v0Q==",
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
@@ -7869,19 +7864,19 @@
       }
     },
     "jest-runner": {
-      "version": "22.4.0",
-      "integrity": "sha512-x5QJQrSQs/oaZq2UxtKJxCjGq3fNF7guKRLxAIS39QIaRSAynS4agniMyvHMnLaYsBh6yzUea2SDeNHayQh+TQ==",
+      "version": "22.4.1",
+      "integrity": "sha512-0Ke/FYv8KbqQ2kVZVLPlj72Epi1snmpbV41lwPeuJ9Y7jkH4BzNS4fKznc6kOYoLsMEbr0WyYqoOysCrmhoXeQ==",
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "jest-config": "22.4.0",
+        "jest-config": "22.4.1",
         "jest-docblock": "22.4.0",
-        "jest-haste-map": "22.4.0",
-        "jest-jasmine2": "22.4.0",
+        "jest-haste-map": "22.4.1",
+        "jest-jasmine2": "22.4.1",
         "jest-leak-detector": "22.4.0",
         "jest-message-util": "22.4.0",
-        "jest-runtime": "22.4.0",
-        "jest-util": "22.4.0",
+        "jest-runtime": "22.4.1",
+        "jest-util": "22.4.1",
         "jest-worker": "22.2.2",
         "throat": "4.1.0"
       },
@@ -7897,23 +7892,23 @@
       }
     },
     "jest-runtime": {
-      "version": "22.4.0",
-      "integrity": "sha512-aixL2DIXoFQ2ubnurzK4kbNXLl3+m0m7wIBb5VWaJdl1/3nV1UCSjZ9/dJZzpWGGfXsoGw2RZd8sS0nS5s+tdw==",
+      "version": "22.4.1",
+      "integrity": "sha512-JFB3IUNAqlUKQWdYwwAjnsuKjAzWRWsCpDKYvuAQVGDC2/tI1VjScEtUmAickERdXLQQAWZrdFuXjE1wsLkk/A==",
       "dev": true,
       "requires": {
         "babel-core": "6.25.0",
-        "babel-jest": "22.4.0",
+        "babel-jest": "22.4.1",
         "babel-plugin-istanbul": "4.1.5",
         "chalk": "2.3.1",
         "convert-source-map": "1.5.1",
         "exit": "0.1.2",
         "graceful-fs": "4.1.11",
-        "jest-config": "22.4.0",
-        "jest-haste-map": "22.4.0",
+        "jest-config": "22.4.1",
+        "jest-haste-map": "22.4.1",
         "jest-regex-util": "22.1.0",
-        "jest-resolve": "22.4.0",
-        "jest-util": "22.4.0",
-        "jest-validate": "22.4.0",
+        "jest-resolve": "22.4.1",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.1",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
         "realpath-native": "1.0.0",
@@ -8117,8 +8112,8 @@
       }
     },
     "jest-util": {
-      "version": "22.4.0",
-      "integrity": "sha512-652EArz3XScAGAUMhbny7FrFGlmJkp+56CO+9RTrKPtGfbtVDF2WB2D8G+6D6zorDmDW5hNtKNIGNdGfG2kj1g==",
+      "version": "22.4.1",
+      "integrity": "sha512-9ySBdJY2qVWpg0OvZbGcFXE2NgwccpZVj384E9bx7brKFc7l5anpqah15mseWcz7FLDk7/N+LyYgqFme7Rez2Q==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
@@ -8126,7 +8121,8 @@
         "graceful-fs": "4.1.11",
         "is-ci": "1.1.0",
         "jest-message-util": "22.4.0",
-        "mkdirp": "0.5.1"
+        "mkdirp": "0.5.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8162,6 +8158,11 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
+        "source-map": {
+          "version": "0.6.1",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.2.0",
           "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
@@ -8173,12 +8174,12 @@
       }
     },
     "jest-validate": {
-      "version": "22.4.0",
-      "integrity": "sha512-l5JwbIAso8jGp/5/Dy86BCVjOra/Rb81wyXcFTGa4VxbtIh4AEOp2WixgprHLwp+YlUrHugZwaGyuagjB+iB+A==",
+      "version": "22.4.1",
+      "integrity": "sha512-lZb7lIgNiA1egFxRCBzsBmE/R5M9Ai7zzuabsqd3SvsCffkMSB0imSZOaeAdmAbUvsxHliCdJ2tpBavAjCXo1A==",
       "dev": true,
       "requires": {
         "chalk": "2.3.1",
-        "jest-config": "22.4.0",
+        "jest-config": "22.4.1",
         "jest-get-type": "22.1.0",
         "leven": "2.1.0",
         "pretty-format": "22.4.0"
@@ -8500,7 +8501,7 @@
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
         "whatwg-url": "6.4.0",
-        "ws": "4.0.0",
+        "ws": "4.1.0",
         "xml-name-validator": "3.0.0"
       },
       "dependencies": {
@@ -8522,19 +8523,13 @@
           "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
           "dev": true
         },
-        "ultron": {
-          "version": "1.1.1",
-          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-          "dev": true
-        },
         "ws": {
-          "version": "4.0.0",
-          "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+          "version": "4.1.0",
+          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
           "dev": true,
           "requires": {
             "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.1",
-            "ultron": "1.1.1"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -9650,8 +9645,8 @@
       "integrity": "sha1-Cr+2rYNXGLn7Te8GdOBmV6lUN1w="
     },
     "nan": {
-      "version": "2.8.0",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+      "version": "2.9.1",
+      "integrity": "sha512-c609vVPyCEuuzqOjx3hwsSZMXLg5QTzbTfgBmEx6N444ymBt1+Yg/rTGr2+4S3VJ3btXI8m1TZ7nLcYcRTZYuQ=="
     },
     "natives": {
       "version": "1.1.1",
@@ -9949,7 +9944,7 @@
         "lodash.mergewith": "4.6.1",
         "meow": "3.7.0",
         "mkdirp": "0.5.1",
-        "nan": "2.8.0",
+        "nan": "2.9.1",
         "node-gyp": "3.6.2",
         "npmlog": "4.1.2",
         "request": "2.83.0",
@@ -15525,7 +15520,7 @@
         "lodash": "4.17.5",
         "mkdirp": "0.5.1",
         "opener": "1.4.3",
-        "ws": "4.0.0"
+        "ws": "4.1.0"
       },
       "dependencies": {
         "accepts": {
@@ -15786,11 +15781,6 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
-        "ultron": {
-          "version": "1.1.1",
-          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-          "dev": true
-        },
         "utils-merge": {
           "version": "1.0.1",
           "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
@@ -15802,13 +15792,12 @@
           "dev": true
         },
         "ws": {
-          "version": "4.0.0",
-          "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+          "version": "4.1.0",
+          "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
           "dev": true,
           "requires": {
             "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.1",
-            "ultron": "1.1.1"
+            "safe-buffer": "5.1.1"
           }
         }
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5932,8 +5932,8 @@
       }
     },
     "gridicons": {
-      "version": "2.1.3-alpha.1",
-      "integrity": "sha512-2VBVdv5AwHda9sD/UhRqmjj9dmXXeCN2Gayw49r2yPrVqdqxbx8n3qedkWAAVk+I5nIJTDCnqWwYRPrBBYwzjQ==",
+      "version": "2.1.3",
+      "integrity": "sha512-3gvt0TAKUKt+BBJ0vboxuaSPriGfJP5aRIyxLPJzlVYzCd3mVHxHFMMzf9UUVb1tv/jzTicakHFo9a9YLTnZCw==",
       "requires": {
         "prop-types": "15.5.10"
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4859,7 +4859,7 @@
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "optional": true,
       "requires": {
-        "nan": "2.9.1",
+        "nan": "2.9.2",
         "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
@@ -7172,7 +7172,7 @@
       "integrity": "sha512-90H1wLqiNR3tLhQUgwhC6GWHfRCG+Da14m7vxD608Mt/QTKR0TA751D+QH09x5bvcrLfvxLtxArtA0VEC0ORow==",
       "dev": true,
       "requires": {
-        "jest-cli": "22.4.1"
+        "jest-cli": "22.4.2"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -7247,8 +7247,8 @@
           "dev": true
         },
         "jest-cli": {
-          "version": "22.4.1",
-          "integrity": "sha512-YrluVb3tHX1Ej2jYelcC68Gi8qMEXnTrCfW/l8oN6mw3RWYkfkKXGjb6AnVuu0t1vG1Q2onGDSn7K8s/+Ilrew==",
+          "version": "22.4.2",
+          "integrity": "sha512-ebo6ZWK2xDSs7LGnLvM16SZOIJ2dj0B6/oERmGcal32NHkks450nNfGrGTyOSPgJDgH8DFhVdBXgSamN7mtZ0Q==",
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
@@ -7263,18 +7263,18 @@
             "istanbul-lib-instrument": "1.9.2",
             "istanbul-lib-source-maps": "1.2.3",
             "jest-changed-files": "22.2.0",
-            "jest-config": "22.4.1",
+            "jest-config": "22.4.2",
             "jest-environment-jsdom": "22.4.1",
             "jest-get-type": "22.1.0",
-            "jest-haste-map": "22.4.1",
+            "jest-haste-map": "22.4.2",
             "jest-message-util": "22.4.0",
             "jest-regex-util": "22.1.0",
             "jest-resolve-dependencies": "22.1.0",
-            "jest-runner": "22.4.1",
-            "jest-runtime": "22.4.1",
+            "jest-runner": "22.4.2",
+            "jest-runtime": "22.4.2",
             "jest-snapshot": "22.4.0",
             "jest-util": "22.4.1",
-            "jest-validate": "22.4.1",
+            "jest-validate": "22.4.2",
             "jest-worker": "22.2.2",
             "micromatch": "2.3.11",
             "node-notifier": "5.2.1",
@@ -7365,8 +7365,8 @@
       }
     },
     "jest-config": {
-      "version": "22.4.1",
-      "integrity": "sha512-yfyHvLTiZ7IOvl75LeUV1bGF0chQdMdSiDb/B1Gr9LRQH2y3ADPWfyrNUo94cbBaD6g2oLeHSlH8Cm+NLNYDSQ==",
+      "version": "22.4.2",
+      "integrity": "sha512-oG31qYO73/3vj/Q8aM2RgzmHndTkz9nRk8ISybfuJqqbf0RW7OUjHVOZPLOUiwLWtz52Yq2HkjIblsyhbA7vrg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.1",
@@ -7374,11 +7374,11 @@
         "jest-environment-jsdom": "22.4.1",
         "jest-environment-node": "22.4.1",
         "jest-get-type": "22.1.0",
-        "jest-jasmine2": "22.4.1",
+        "jest-jasmine2": "22.4.2",
         "jest-regex-util": "22.1.0",
-        "jest-resolve": "22.4.1",
+        "jest-resolve": "22.4.2",
         "jest-util": "22.4.1",
-        "jest-validate": "22.4.1",
+        "jest-validate": "22.4.2",
         "pretty-format": "22.4.0"
       },
       "dependencies": {
@@ -7520,8 +7520,8 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "22.4.1",
-      "integrity": "sha512-VWLkRCMSaU34YftLp0zfbb+gUNm+ZcM5ridzAnd5WTR+zUnP8RUGAiDh2YtPPaM5MbgCY0VPC+I0Ti6XN1UmhA==",
+      "version": "22.4.2",
+      "integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
       "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
@@ -7544,8 +7544,8 @@
       }
     },
     "jest-jasmine2": {
-      "version": "22.4.1",
-      "integrity": "sha512-02y0W+Y4b2RjnNJQwV2zVyD+nNMYcunNFpbMf9QcCxMrErAelYXBS2SOUWZTlZfoE2Z/pk9HLBCJ96V2M3nJaw==",
+      "version": "22.4.2",
+      "integrity": "sha512-KZaIHpXQ0AIlvQJFCU0uoXxtz5GG47X14r9upMe7VXE55UazoMZBFnQb9TX2HoYX2/AxJYnjHuvwKVCFqOrEtw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.1",
@@ -7809,8 +7809,8 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "22.4.1",
-      "integrity": "sha512-PT1ujfwGoE/jwFo17fpiXVUiTmtiEgu5kuq7AUD7cK3MAM/KfT0GQ1R+RM1Y7W0VW4C8koRiiA/4hB4WvX/v0Q==",
+      "version": "22.4.2",
+      "integrity": "sha512-P1hSfcc2HJYT5t+WPu/11OfFMa7m8pBb2Gf2vm6W9OVs7YTXQ5RCC3nDqaYZQaTqxEM1ZZaTcQGcE6U2xMOsqQ==",
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
@@ -7864,18 +7864,18 @@
       }
     },
     "jest-runner": {
-      "version": "22.4.1",
-      "integrity": "sha512-0Ke/FYv8KbqQ2kVZVLPlj72Epi1snmpbV41lwPeuJ9Y7jkH4BzNS4fKznc6kOYoLsMEbr0WyYqoOysCrmhoXeQ==",
+      "version": "22.4.2",
+      "integrity": "sha512-W4vwgiVQS0NyXt8hgpw7i0YUtsfoChiQcoHWBJeq2ocV4VF2osEZx8HYgpH5HfNe1Cb5LZeZWxX8Dr3hesbGFg==",
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "jest-config": "22.4.1",
+        "jest-config": "22.4.2",
         "jest-docblock": "22.4.0",
-        "jest-haste-map": "22.4.1",
-        "jest-jasmine2": "22.4.1",
+        "jest-haste-map": "22.4.2",
+        "jest-jasmine2": "22.4.2",
         "jest-leak-detector": "22.4.0",
         "jest-message-util": "22.4.0",
-        "jest-runtime": "22.4.1",
+        "jest-runtime": "22.4.2",
         "jest-util": "22.4.1",
         "jest-worker": "22.2.2",
         "throat": "4.1.0"
@@ -7892,8 +7892,8 @@
       }
     },
     "jest-runtime": {
-      "version": "22.4.1",
-      "integrity": "sha512-JFB3IUNAqlUKQWdYwwAjnsuKjAzWRWsCpDKYvuAQVGDC2/tI1VjScEtUmAickERdXLQQAWZrdFuXjE1wsLkk/A==",
+      "version": "22.4.2",
+      "integrity": "sha512-9/Fxbj99cqxI7o2nTNzevnI38eDBstkwve8ZeaAD/Kz0fbU3i3eRv2QPEmzbmyCyBvUWxCT7BzNLTzTqH1+pyA==",
       "dev": true,
       "requires": {
         "babel-core": "6.25.0",
@@ -7903,12 +7903,12 @@
         "convert-source-map": "1.5.1",
         "exit": "0.1.2",
         "graceful-fs": "4.1.11",
-        "jest-config": "22.4.1",
-        "jest-haste-map": "22.4.1",
+        "jest-config": "22.4.2",
+        "jest-haste-map": "22.4.2",
         "jest-regex-util": "22.1.0",
-        "jest-resolve": "22.4.1",
+        "jest-resolve": "22.4.2",
         "jest-util": "22.4.1",
-        "jest-validate": "22.4.1",
+        "jest-validate": "22.4.2",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
         "realpath-native": "1.0.0",
@@ -8174,12 +8174,12 @@
       }
     },
     "jest-validate": {
-      "version": "22.4.1",
-      "integrity": "sha512-lZb7lIgNiA1egFxRCBzsBmE/R5M9Ai7zzuabsqd3SvsCffkMSB0imSZOaeAdmAbUvsxHliCdJ2tpBavAjCXo1A==",
+      "version": "22.4.2",
+      "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
       "dev": true,
       "requires": {
         "chalk": "2.3.1",
-        "jest-config": "22.4.1",
+        "jest-config": "22.4.2",
         "jest-get-type": "22.1.0",
         "leven": "2.1.0",
         "pretty-format": "22.4.0"
@@ -9645,8 +9645,8 @@
       "integrity": "sha1-Cr+2rYNXGLn7Te8GdOBmV6lUN1w="
     },
     "nan": {
-      "version": "2.9.1",
-      "integrity": "sha512-c609vVPyCEuuzqOjx3hwsSZMXLg5QTzbTfgBmEx6N444ymBt1+Yg/rTGr2+4S3VJ3btXI8m1TZ7nLcYcRTZYuQ=="
+      "version": "2.9.2",
+      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw=="
     },
     "natives": {
       "version": "1.1.1",
@@ -9944,7 +9944,7 @@
         "lodash.mergewith": "4.6.1",
         "meow": "3.7.0",
         "mkdirp": "0.5.1",
-        "nan": "2.9.1",
+        "nan": "2.9.2",
         "node-gyp": "3.6.2",
         "npmlog": "4.1.2",
         "request": "2.83.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "fuse.js": "2.6.1",
     "get-video-id": "2.1.4",
     "globby": "6.1.0",
-    "gridicons": "2.1.2",
+    "gridicons": "2.1.3",
     "happypack": "4.0.0",
     "hard-source-webpack-plugin": "0.3.12",
     "hash.js": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "fuse.js": "2.6.1",
     "get-video-id": "2.1.4",
     "globby": "6.1.0",
-    "gridicons": "2.1.3-alpha.1",
+    "gridicons": "2.1.3",
     "happypack": "4.0.0",
     "hard-source-webpack-plugin": "0.3.12",
     "hash.js": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "fuse.js": "2.6.1",
     "get-video-id": "2.1.4",
     "globby": "6.1.0",
-    "gridicons": "2.1.3",
+    "gridicons": "2.1.3-alpha.1",
     "happypack": "4.0.0",
     "hard-source-webpack-plugin": "0.3.12",
     "hash.js": "1.1.3",


### PR DESCRIPTION
This PR updates Gridicons to v2.1.3 following this change: https://github.com/Automattic/gridicons/pull/281