### PR TITLE
Invites: Fix an incorrectly displayed invite limit message

### DIFF
--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -130,7 +130,7 @@ export const counts = createReducer(
 		[ INVITES_DELETE_REQUEST_SUCCESS ]: ( state, action ) => {
 			return {
 				...state,
-				[ action.siteId ]: state[ action.sideId ] - action.inviteIds.length,
+				[ action.siteId ]: state[ action.siteId ] - action.inviteIds.length,
 			};
 		},
 	}

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -127,6 +127,12 @@ export const counts = createReducer(
 				[ action.siteId ]: action.found,
 			};
 		},
+		[ INVITES_DELETE_REQUEST_SUCCESS ]: ( state, action ) => {
+			return {
+				...state,
+				[ action.siteId ]: state[ action.sideId ] - action.inviteIds.length,
+			};
+		},
 	}
 );
 

--- a/client/state/invites/test/reducer.js
+++ b/client/state/invites/test/reducer.js
@@ -583,6 +583,19 @@ describe( 'reducer', () => {
 				67890: 12,
 			} );
 		} );
+
+		test( 'should reduce after successful deletes', () => {
+			const original = deepFreeze( { 12345: 678, 67890: 12 } );
+			const state = counts( original, {
+				type: INVITES_DELETE_REQUEST_SUCCESS,
+				siteId: 67890,
+				inviteIds: [ '123456asdf789', '789lkjh123456' ],
+			} );
+			expect( state ).to.eql( {
+				12345: 678,
+				67890: 10,
+			} );
+		} );
 	} );
 
 	describe( '#requestingResend()', () => {


### PR DESCRIPTION
#22663 introduced a bug where the invite limit message was displayed after clearing all invites.

It is visible after clearing in this gif:
![clearallaccepted](https://user-images.githubusercontent.com/363749/36504071-e1617686-1714-11e8-8fbd-f8fae0a8e5f5.gif)

This PR fixes the issue by reducing the invite counts for each site by the number of cleared invites.

To test:

* Send one or more invites to another user and accept them so that they show up in the accepted invites section within people management
* Verify that the "Clear All Invites" button appears in the accepted invites section
* Verify that clicking the button brings up a confirmation dialog
* Verify that canceling closes the dialog without clearing the invites
* Verify that confirming clearing removes all of your accepted invites and closes the dialog
* Verify that the invite limit message isn't shown unless it is still applicable (if there remain over 100 invites after clearing).