### PR TITLE
Cleanup the EditorGroundControl component

### DIFF
--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -62,12 +62,6 @@ const userUtils = {
 	isLoggedIn() {
 		return Boolean( user.data );
 	},
-
-	needsVerificationForSite( site ) {
-		// do not allow publish for unverified e-mails,
-		// but allow if the site is VIP
-		return ! user.get().email_verified && ! ( site && site.is_vip );
-	},
 };
 
 export default userUtils;

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -18,7 +18,6 @@ import { map, pick, reduce, startsWith } from 'lodash';
 import actions from 'lib/posts/actions';
 import { addSiteFragment } from 'lib/route';
 import User from 'lib/user';
-import userUtils from 'lib/user/utils';
 import analytics from 'lib/analytics';
 import { decodeEntities } from 'lib/formatting';
 import PostEditor from './post-editor';
@@ -55,10 +54,7 @@ function determinePostType( context ) {
 }
 
 function renderEditor( context ) {
-	context.primary = React.createElement( PostEditor, {
-		user: user,
-		userUtils: userUtils,
-	} );
+	context.primary = React.createElement( PostEditor );
 }
 
 function maybeRedirect( context ) {

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { PureComponent } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { identity, noop, get, findLast } from 'lodash';
 import moment from 'moment';
@@ -26,7 +26,7 @@ import { canCurrentUser, isVipSite } from 'state/selectors';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { getRouteHistory } from 'state/ui/action-log/selectors';
 
-export class EditorGroundControl extends PureComponent {
+export class EditorGroundControl extends React.Component {
 	static propTypes = {
 		hasContent: PropTypes.bool,
 		isConfirmationSidebarEnabled: PropTypes.bool,

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -47,8 +47,6 @@ export class EditorGroundControl extends PureComponent {
 		savedPost: PropTypes.object,
 		setPostDate: PropTypes.func,
 		site: PropTypes.object,
-		user: PropTypes.object,
-		userUtils: PropTypes.object,
 		toggleSidebar: PropTypes.func,
 		translate: PropTypes.func,
 	};
@@ -67,8 +65,6 @@ export class EditorGroundControl extends PureComponent {
 		savedPost: null,
 		site: {},
 		translate: identity,
-		user: null,
-		userUtils: null,
 		setPostDate: noop,
 	};
 

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -166,7 +166,7 @@ export class EditorGroundControl extends PureComponent {
 	onPreviewButtonClick = event => {
 		if ( this.isPreviewEnabled() ) {
 			this.props.onPreview( event );
-			this.props.recordPreviewButtonClick();
+			this.props.recordPreviewButtonClick( this.props.post );
 		}
 	};
 
@@ -302,18 +302,18 @@ const mapStateToProps = ( state, ownProps ) => {
 };
 
 const mapDispatchToProps = {
-	recordPreviewButtonClick: () =>
-		composeAnalytics(
-			recordTracksEvent(
-				`calypso_editor_${ postUtils.isPage( page ) ? 'page' : 'post' }_preview_button_click`
-			),
+	recordPreviewButtonClick: post => {
+		const postIsPage = postUtils.isPage( post );
+		return composeAnalytics(
+			recordTracksEvent( `calypso_editor_${ postIsPage ? 'page' : 'post' }_preview_button_click` ),
 			recordGoogleEvent(
 				'Editor',
-				`Clicked Preview ${ postUtils.isPage( page ) ? 'Page' : 'Post' } Button`,
-				`Editor Preview ${ postUtils.isPage( page ) ? 'Page' : 'Post' } Button Clicked`,
-				`editor${ postUtils.isPage( page ) ? 'Page' : 'Post' }ButtonClicked`
+				`Clicked Preview ${ postIsPage ? 'Page' : 'Post' } Button`,
+				`Editor Preview ${ postIsPage ? 'Page' : 'Post' } Button Clicked`,
+				`editor${ postIsPage ? 'Page' : 'Post' }ButtonClicked`
 			)
-		),
+		);
+	},
 	recordSiteButtonClick: () => recordTracksEvent( 'calypso_editor_site_button_click' ),
 	recordCloseButtonClick: () => recordTracksEvent( 'calypso_editor_close_button_click' ),
 };

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -16,7 +16,7 @@ import { connect } from 'react-redux';
  */
 import Card from 'components/card';
 import Site from 'blocks/site';
-import * as postUtils from 'lib/posts/utils';
+import { isPage, isPublished } from 'lib/posts/utils';
 import EditorPublishButton, { getPublishButtonStatus } from 'post-editor/editor-publish-button';
 import Button from 'components/button';
 import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-buttons';
@@ -148,7 +148,7 @@ export class EditorGroundControl extends PureComponent {
 	shouldShowStatusLabel() {
 		const { isSaving, post } = this.props;
 
-		return isSaving || ( post && post.ID && ! postUtils.isPublished( post ) );
+		return isSaving || ( post && post.ID && ! isPublished( post ) );
 	}
 
 	isPreviewEnabled() {
@@ -207,7 +207,7 @@ export class EditorGroundControl extends PureComponent {
 						needsVerification={ this.state.needsVerification }
 						busy={
 							this.props.isPublishing ||
-							( postUtils.isPublished( this.props.savedPost ) && this.props.isSaving )
+							( isPublished( this.props.savedPost ) && this.props.isSaving )
 						}
 					/>
 				</div>
@@ -303,7 +303,7 @@ const mapStateToProps = ( state, ownProps ) => {
 
 const mapDispatchToProps = {
 	recordPreviewButtonClick: post => {
-		const postIsPage = postUtils.isPage( post );
+		const postIsPage = isPage( post );
 		return composeAnalytics(
 			recordTracksEvent( `calypso_editor_${ postIsPage ? 'page' : 'post' }_preview_button_click` ),
 			recordGoogleEvent(

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -4,7 +4,7 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { identity, noop, get, last } from 'lodash';
+import { identity, noop, get, findLast } from 'lodash';
 import moment from 'moment';
 import page from 'page';
 import i18n, { localize } from 'i18n-calypso';
@@ -216,13 +216,12 @@ export class EditorGroundControl extends PureComponent {
 	}
 
 	getCloseButtonPath() {
-		// find the first non-editor path in routeHistory, default to "all posts"
-		const nonEditorPaths = this.props.routeHistory.filter( action => {
-			return ! action.path.match( /^\/(post|page|(edit\/[^\/]+))\/[^\/]+(\/\d+)?$/i );
-		} );
-		return nonEditorPaths && last( nonEditorPaths ) && last( nonEditorPaths ).path
-			? last( nonEditorPaths ).path
-			: this.props.allPostsUrl;
+		// find the last non-editor path in routeHistory, default to "all posts"
+		const lastNonEditorPath = findLast(
+			this.props.routeHistory,
+			action => ! action.path.match( /^\/(post|page|(edit\/[^\/]+))\/[^\/]+(\/\d+)?$/i )
+		);
+		return lastNonEditorPath ? lastNonEditorPath.path : this.props.allPostsUrl;
 	}
 
 	onCloseButtonClick = () => {

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -302,24 +302,21 @@ const mapStateToProps = ( state, ownProps ) => {
 	};
 };
 
-const mapDispatchToProps = dispatch => ( {
+const mapDispatchToProps = {
 	recordPreviewButtonClick: () =>
-		dispatch(
-			composeAnalytics(
-				recordTracksEvent(
-					`calypso_editor_${ postUtils.isPage( page ) ? 'page' : 'post' }_preview_button_click`
-				),
-				recordGoogleEvent(
-					'Editor',
-					`Clicked Preview ${ postUtils.isPage( page ) ? 'Page' : 'Post' } Button`,
-					`Editor Preview ${ postUtils.isPage( page ) ? 'Page' : 'Post' } Button Clicked`,
-					`editor${ postUtils.isPage( page ) ? 'Page' : 'Post' }ButtonClicked`
-				)
+		composeAnalytics(
+			recordTracksEvent(
+				`calypso_editor_${ postUtils.isPage( page ) ? 'page' : 'post' }_preview_button_click`
+			),
+			recordGoogleEvent(
+				'Editor',
+				`Clicked Preview ${ postUtils.isPage( page ) ? 'Page' : 'Post' } Button`,
+				`Editor Preview ${ postUtils.isPage( page ) ? 'Page' : 'Post' } Button Clicked`,
+				`editor${ postUtils.isPage( page ) ? 'Page' : 'Post' }ButtonClicked`
 			)
 		),
-	recordSiteButtonClick: () => dispatch( recordTracksEvent( 'calypso_editor_site_button_click' ) ),
-	recordCloseButtonClick: () =>
-		dispatch( recordTracksEvent( 'calypso_editor_close_button_click' ) ),
-} );
+	recordSiteButtonClick: () => recordTracksEvent( 'calypso_editor_site_button_click' ),
+	recordCloseButtonClick: () => recordTracksEvent( 'calypso_editor_close_button_click' ),
+};
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( EditorGroundControl ) );

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { identity, noop, get, findLast } from 'lodash';
 import moment from 'moment';
 import page from 'page';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 
@@ -73,21 +73,24 @@ export class EditorGroundControl extends PureComponent {
 	}
 
 	getVerificationNoticeLabel() {
+		const { translate } = this.props;
 		const primaryButtonState = getPublishButtonStatus(
-				this.props.post,
-				this.props.savedPost,
-				this.props.canUserPublishPosts
-			),
-			buttonLabels = {
-				update: i18n.translate( 'To update, check your email and confirm your address.' ),
-				schedule: i18n.translate( 'To schedule, check your email and confirm your address.' ),
-				publish: i18n.translate( 'To publish, check your email and confirm your address.' ),
-				requestReview: i18n.translate(
-					'To submit for review, check your email and confirm your address.'
-				),
-			};
-
-		return buttonLabels[ primaryButtonState ];
+			this.props.post,
+			this.props.savedPost,
+			this.props.canUserPublishPosts
+		);
+		switch ( primaryButtonState ) {
+			case 'update':
+				return translate( 'To update, check your email and confirm your address.' );
+			case 'schedule':
+				return translate( 'To schedule, check your email and confirm your address.' );
+			case 'publish':
+				return translate( 'To publish, check your email and confirm your address.' );
+			case 'requestReview':
+				return translate( 'To submit for review, check your email and confirm your address.' );
+			default:
+				return null;
+		}
 	}
 
 	shouldShowStatusLabel() {

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -72,7 +72,6 @@ export class EditorGroundControl extends PureComponent {
 	};
 
 	state = {
-		showAdvanceStatus: false,
 		needsVerification:
 			this.props.userUtils && this.props.userUtils.needsVerificationForSite( this.props.site ),
 	};
@@ -158,10 +157,6 @@ export class EditorGroundControl extends PureComponent {
 			! this.props.isSaveBlocked
 		);
 	}
-
-	toggleAdvancedStatus = () => {
-		this.setState( { showAdvanceStatus: ! this.state.showAdvanceStatus } );
-	};
 
 	onPreviewButtonClick = event => {
 		if ( this.isPreviewEnabled() ) {

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -28,7 +28,6 @@ jest.mock( 'lib/posts/actions', () => ( {
 	recordEvent: () => {},
 	recordStat: () => {},
 } ) );
-jest.mock( 'lib/user', () => () => {} );
 jest.mock( 'post-editor/edit-post-status', () => require( 'components/empty-component' ) );
 jest.mock( 'post-editor/editor-status-label', () => require( 'components/empty-component' ) );
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -81,8 +81,6 @@ export const PostEditor = createReactClass( {
 		setNextLayoutFocus: PropTypes.func.isRequired,
 		editorModePreference: PropTypes.string,
 		editorSidebarPreference: PropTypes.string,
-		user: PropTypes.object,
-		userUtils: PropTypes.object,
 		editPath: PropTypes.string,
 		markChanged: PropTypes.func.isRequired,
 		markSaved: PropTypes.func.isRequired,
@@ -324,8 +322,6 @@ export const PostEditor = createReactClass( {
 						post={ this.state.post }
 						savedPost={ this.state.savedPost }
 						site={ site }
-						user={ this.props.user }
-						userUtils={ this.props.userUtils }
 						toggleSidebar={ this.toggleSidebar }
 						onMoreInfoAboutEmailVerify={ this.onMoreInfoAboutEmailVerify }
 						allPostsUrl={ this.getAllPostsUrl() }


### PR DESCRIPTION
While working on #22617, I did one small fix in the `EditorGroundControl` component (the UI that replaces masterbar when editing a post in "full-screen" mode) and noticed quite a few eyebrow-raising bugs and legacy practices. This PR does a little cleanup of the component.

Each of the 10 commits can be reviewed as a standalone small change.

The main changes are:
- cleanup and bugfix recording analytics events
- stop using `lib/user` in favor of Redux
- stop using global `i18n.translate`

**How to test:**
- check that the post editor works in general
- fake unverified email address by changing the `userNeedsVerification` connected prop and check the behavior for users with unverified emails
