### PR TITLE
Devdocs: Fix login style precedence issue

### DIFF
--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -14,7 +14,7 @@
 	margin-bottom: 0;
 }
 
-.login__form-userdata {
+.login__form .login__form-userdata {
 	label {
 		color: $gray-dark;
 		display: block;


### PR DESCRIPTION
Fix #21159. In the issue the username/email field was mentioned but this would happen to the password field as well, because the `margin-bottom: 20px;` was being overridden by other styles.

### Before
<img width="422" alt="screenshot 2018-02-23 00 42 01" src="https://user-images.githubusercontent.com/90871/36572229-6abd7236-1832-11e8-995c-d0c9a2e0258a.png">
<img width="453" alt="screenshot 2018-02-23 00 42 15" src="https://user-images.githubusercontent.com/90871/36572228-6a9e7f8e-1832-11e8-836f-5fd46423e138.png">

### After
<img width="441" alt="screenshot 2018-02-23 00 08 31" src="https://user-images.githubusercontent.com/90871/36571850-c39f534e-1830-11e8-862f-4b3ee91716ba.png">
<img width="430" alt="screenshot 2018-02-23 00 08 22" src="https://user-images.githubusercontent.com/90871/36571851-c3b9391c-1830-11e8-9d81-237cd54ed46b.png">