### PR TITLE
Invites: Remove unnecessary `force=wpcom` from "resend invite" API call

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -408,12 +408,7 @@ Undocumented.prototype.sendInvites = function( siteId, usernamesOrEmails, role, 
 
 Undocumented.prototype.resendInvite = function( siteId, inviteId, fn ) {
 	debug( '/sites/:site_id:/invites/:invite_id:/resend query' );
-	return this.wpcom.req.post(
-		'/sites/' + siteId + '/invites/' + inviteId + '/resend',
-		{ force: 'wpcom' },
-		{},
-		fn
-	);
+	return this.wpcom.req.post( '/sites/' + siteId + '/invites/' + inviteId + '/resend', {}, {}, fn );
 };
 
 Undocumented.prototype.createInviteValidation = function( siteId, usernamesOrEmails, role, fn ) {


### PR DESCRIPTION
This PR reverts #22711, which is a good temporary fix, but we'll implement a better fix on the server-side API endpoint.

Merge this *after* D10431-code on the server, which forces the invites resend endpoint to always run on WP.com even if the `force: 'wpcom'` parameter is not present.

See https://github.com/Automattic/wp-calypso/pull/21778 for a previous, similar change.

To test this PR, verify that resending an invite still works as expected on Jetpack/Atomic sites.