### PR TITLE
Jetpack Settings: Fix connection endpoint requests

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -271,12 +271,8 @@ Undocumented.prototype.testConnectionJetpack = function( siteId, fn ) {
  */
 Undocumented.prototype.getJetpackConnectionStatus = function( siteId, fn ) {
 	return this.wpcom.req.get(
-		{
-			path: '/jetpack-blogs/' + siteId + '/rest-api/',
-			body: {
-				path: '/jetpack/v4/connection/',
-			},
-		},
+		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
+		{ path: '/jetpack/v4/connection/' },
 		fn
 	);
 };
@@ -290,12 +286,8 @@ Undocumented.prototype.getJetpackConnectionStatus = function( siteId, fn ) {
  */
 Undocumented.prototype.getJetpackUserConnectionData = function( siteId, fn ) {
 	return this.wpcom.req.get(
-		{
-			path: '/jetpack-blogs/' + siteId + '/rest-api/',
-			body: {
-				path: '/jetpack/v4/connection/data/',
-			},
-		},
+		{ path: '/jetpack-blogs/' + siteId + '/rest-api/' },
+		{ path: '/jetpack/v4/connection/data/' },
 		fn
 	);
 };


### PR DESCRIPTION
It seems that we've been using a deprecated syntax for a couple of `this.wpcom.req.get()` instances. This resulted in those requests not being handed to the Jetpack proxy endpoint correctly, thus requests were failing.

This PR updates to the more granular syntax.

Fixes #22720.
Also #21999 seems to be related.

To test:
* Checkout this branch.
* Go to `http://calypso.localhost:3000/settings/manage-connection/:site`, where `:site` is a Jetpack site.
* Verify the Site Ownership card loads properly.
* Verify all requests to the `/rest-api` of the site are successful.
* Verify all JP state tests still pass: `npm run test-client client/state/jetpack/`