### PR TITLE
Checkout: validate the CPF field in ebanx card details 

### DIFF
--- a/client/lib/credit-card-details/ebanx.js
+++ b/client/lib/credit-card-details/ebanx.js
@@ -3,7 +3,8 @@
  *
  * @format
  */
-import { isString, isUndefined } from 'lodash';
+import { isUndefined } from 'lodash';
+import { CPF } from 'cpf_cnpj';
 
 /**
  * Internal dependencies
@@ -27,13 +28,11 @@ export function isEbanxEnabledForCountry( countryCode = '' ) {
 /**
  * CPF number (Cadastrado de Pessoas Físicas) is the Brazilian tax identification number.
  * Total of 11 digits: 9 numbers followed by 2 verification numbers . E.g., 188.247.019-22
- * The following test is a weak test only.
  *
- * See algorithm at http://www.geradorcpf.com/algoritmo_do_cpf.htm
  * @param {String} cpf - a Brazilian tax identification number
  * @returns {Boolean} Whether the cpf is valid or not
  */
 
 export function isValidCPF( cpf = '' ) {
-	return isString( cpf ) && /^[0-9]{3}\.[0-9]{3}\.[0-9]{3}-[0-9]{2}$/.test( cpf );
+	return CPF.isValid( cpf );
 }

--- a/client/lib/credit-card-details/test/ebanx.js
+++ b/client/lib/credit-card-details/test/ebanx.js
@@ -40,11 +40,12 @@ describe( 'Ebanx payment processing methods', () => {
 
 	describe( 'isValidCPF', () => {
 		test( 'should return true for valid CPF (Brazilian tax identification number)', () => {
+			expect( isValidCPF( '85384484632' ) ).toEqual( true );
 			expect( isValidCPF( '853.513.468-93' ) ).toEqual( true );
 		} );
 		test( 'should return false for invalid CPF', () => {
-			expect( isValidCPF( '85384484632' ) ).toEqual( false );
-			expect( isValidCPF( '853.844.846.32' ) ).toEqual( false );
+			expect( isValidCPF( '85384484612' ) ).toEqual( false );
+			expect( isValidCPF( '853.844.846.12' ) ).toEqual( false );
 		} );
 	} );
 } );

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cookie": "0.1.2",
     "cookie-parser": "1.3.2",
     "copy-webpack-plugin": "4.0.1",
+    "cpf_cnpj": "0.2.0",
     "create-react-class": "15.6.2",
     "creditcards": "2.1.2",
     "cross-env": "5.1.1",


### PR DESCRIPTION
This is a 2nd attempt at validating CPF details for the CC details in EBANX form.

Previously: #21635 which was reverted in #22622 because the CPF module was using code incompatible with IE11

In this PR, I've switched to [another module](https://github.com/fnando/cpf_cnpj.js) which doesn't have this problem.

I've tested this with IE11 this time :)

 - To test the actual form validation, you need an A8C wpcom account with the currency set to BRL (using store admin), or by locally modifying the `isEbanxEnabled()` function (easier).
- The additional form should show up when you select Brasil as the card country.

