### PR TITLE
Config: Jetpack Connection: Redirect Pressable to credential approval in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -34,7 +34,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/api-cache": false,
-		"jetpack/connect-redirect-pressable-credential-approval": false,
+		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,


### PR DESCRIPTION
When we shipped #20025 to redirect users from the Jetpack Connection flow to the credential approval screen, it was turned on in staging but off in production. This made sense for testing, but we should have flipped it to production when we were ready for other users to go through the flow.

Expected flow:

- Add `partner_id=49640` to end of connection URL after attempting to connect Jetpack to WordPress.com
- Ensure that you see Pressable cobranded connection flow
- Ensure that after connecting that you are forwarded to the credential approval screen

