### PR TITLE
Fix theme banners color issue.

### DIFF
--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -4,13 +4,13 @@
 	display: block;
 	position: relative;
 	background: no-repeat $blue-medium;
-	color: white ! important;
+	color: white !important;
 	padding: 0.8em;
 	overflow: hidden;
 	user-select: none;
 	
-	&:hover, &:focus {
-		color: white;
+	&:hover, &:focus, &:visited {
+		color: white !important;
 	}
 	
 	&:before {

--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -4,7 +4,7 @@
 	display: block;
 	position: relative;
 	background: no-repeat $blue-medium;
-	color: white;
+	color: white ! important;
 	padding: 0.8em;
 	overflow: hidden;
 	user-select: none;


### PR DESCRIPTION
Fixes an issue with the theme banners color. On Firefox, the banner would show the normal link color instead of white.

To test, go to My Sites > Themes, click on the Banner's "See the theme" button. Then, click on the
"<- All Themes" button.  The fix should be working if the banner is always showing white text color. 