### PR TITLE
Jetpack Onboarding: Delete credentials upon successful connection

### DIFF
--- a/client/state/jetpack-onboarding/reducer.js
+++ b/client/state/jetpack-onboarding/reducer.js
@@ -6,6 +6,7 @@
 import { createReducer, combineReducers, keyedReducer } from 'state/utils';
 import { jetpackOnboardingCredentialsSchema, jetpackOnboardingSettingsSchema } from './schema';
 import {
+	JETPACK_CONNECT_AUTHORIZE_RECEIVE,
 	JETPACK_ONBOARDING_CREDENTIALS_RECEIVE,
 	JETPACK_ONBOARDING_SETTINGS_UPDATE,
 } from 'state/action-types';
@@ -16,6 +17,7 @@ export const credentialsReducer = keyedReducer(
 		{},
 		{
 			[ JETPACK_ONBOARDING_CREDENTIALS_RECEIVE ]: ( state, { credentials } ) => credentials,
+			[ JETPACK_CONNECT_AUTHORIZE_RECEIVE ]: () => undefined,
 		},
 		jetpackOnboardingCredentialsSchema
 	)

--- a/client/state/jetpack-onboarding/test/reducer.js
+++ b/client/state/jetpack-onboarding/test/reducer.js
@@ -11,6 +11,7 @@ import deepFreeze from 'deep-freeze';
 import reducer, { credentialsReducer, settingsReducer } from '../reducer';
 import {
 	DESERIALIZE,
+	JETPACK_CONNECT_AUTHORIZE_RECEIVE,
 	JETPACK_ONBOARDING_CREDENTIALS_RECEIVE,
 	JETPACK_ONBOARDING_SETTINGS_UPDATE,
 	SERIALIZE,
@@ -92,6 +93,19 @@ describe( 'reducer', () => {
 				...initialState,
 				[ siteId ]: newCredentials,
 			} );
+		} );
+
+		test( 'should remove credentials when site connects successfully', () => {
+			const siteId = 12345678;
+			const original = deepFreeze( {
+				[ siteId ]: siteCredentials,
+			} );
+			const state = credentialsReducer( original, {
+				type: JETPACK_CONNECT_AUTHORIZE_RECEIVE,
+				siteId,
+			} );
+
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should persist state', () => {


### PR DESCRIPTION
Since we'll be updating JPO to be able to perform requests when connected (see #22578), it makes sense to delete the onboarding token after successful connection. As we discussed with @ockham, for now it's best if we delete the token at the Jetpack site - this is done by https://github.com/Automattic/jetpack/pull/8933, so this PR takes care of deleting the JPO site credentials from the Redux store.

Fixes #21680.

**Note: in order to avoid issues when testing JPO, we should land this one after the solution for #22578 lands.**

To test:
* Checkout this branch
* Start a fresh JN site with https://github.com/Automattic/jetpack/pull/8933 on it.
* Start the onboarding flow in order to load credentials in Calypso.
* Run `state.jetpackOnboarding.credentials` in your Calypso console to verify the credentials are in the Redux state.
* Go to http://calypso.localhost:3000/jetpack/connect and connect the site.
* You'll be redirected to the plans or my plan page.
* Run `state.jetpackOnboarding.credentials` in your Calypso console to verify the credentials are **no longer** in the Redux state.
* Start another fresh JN site with the latest Jetpack.
* Monitor the HTTP requests and connect the new site.
* Verify there is no HTTP request sent to delete the token upon successful connection.
* Finally, verify all tests pass:
  * `npm run test-client client/state/jetpack-onboarding/`