### PR TITLE
fix(head): provide unique key prop for meta & link elements

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -67,8 +67,8 @@ class Document extends React.Component {
 				className={ classNames( { 'is-fluid-width': isFluidWidth } ) }
 			>
 				<Head title={ head.title } faviconURL={ faviconURL } cdn={ '//s1.wp.com' }>
-					{ head.metas.map( props => <meta { ...props } /> ) }
-					{ head.links.map( props => <link { ...props } /> ) }
+					{ head.metas.map( ( props, index ) => <meta { ...props } key={ index } /> ) }
+					{ head.links.map( ( props, index ) => <link { ...props } key={ index } /> ) }
 
 					<link
 						rel="stylesheet"


### PR DESCRIPTION
closes #22728 

I missed to provide a unique `key` prop (React requirement) for elements which are generated as part of an array.

My solution is to just pass the `index` param which is provided by `.map`. [This is generally discouraged](https://reactjs.org/docs/lists-and-keys.html#keys) but as this only rendered with `React.renderToStaticMarkup` _once_ this should be a fair trade-off.

### testing

1. Start Calypso locally with `npm start` and make sure it builds successfully
2. Make a request to `http://calypso.localhost:3000` e.g. with `$ curl http://calypso.localhost:3000`
3. Make sure the only console output is something like `GET / 200 108.285 ms - 25107` and nothing else (like described in https://github.com/Automattic/wp-calypso/issues/22728)