### PR TITLE
Store Servies - added label receipt links

### DIFF
--- a/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/selectors.js
@@ -154,6 +154,7 @@ export const getActivityLogEvents = ( state, orderId, siteId = getSelectedSiteId
 				// TODO: Currently we only store the names of the items & packages, we need to store more data to show dimensions etc
 				productNames: label.product_names,
 				packageName: label.package_name,
+				receiptId: label.main_receipt_id,
 				serviceName: label.service_name,
 				tracking: label.tracking,
 				carrierId: label.carrier_id,

--- a/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/orders/activity-log/test/selectors.js
@@ -107,6 +107,7 @@ const labelsLoadedSubtree = {
 			tracking: '12345',
 			carrier_id: 'canada_post',
 			service_name: 'Xpress',
+			main_receipt_id: 12345,
 			refund: {
 				status: 'rejected',
 				request_date: 4100000,
@@ -127,6 +128,7 @@ const labelsLoadedSubtree = {
 			tracking: '12345',
 			carrier_id: 'usps',
 			service_name: 'First Class',
+			main_receipt_id: 12345,
 			refund: {
 				status: 'complete',
 				request_date: 3100000,
@@ -148,6 +150,7 @@ const labelsLoadedSubtree = {
 			tracking: '12345',
 			carrier_id: 'canada_post',
 			service_name: 'Xpress',
+			main_receipt_id: 67890,
 			refund: {
 				status: 'pending',
 				request_date: 2100000,
@@ -167,6 +170,7 @@ const labelsLoadedSubtree = {
 			tracking: '12345',
 			carrier_id: 'usps',
 			service_name: 'First Class',
+			main_receipt_id: 654321,
 		},
 		{
 			label_id: 10000,
@@ -182,6 +186,7 @@ const labelsLoadedSubtree = {
 			tracking: '12345',
 			carrier_id: 'usps',
 			service_name: 'First Class',
+			main_receipt_id: 123456789,
 		},
 		{
 			label_id: 10001,
@@ -384,6 +389,7 @@ describe( 'selectors', () => {
 					tracking: '12345',
 					carrierId: 'canada_post',
 					serviceName: 'Xpress',
+					receiptId: 12345,
 				},
 				{
 					key: 3,
@@ -411,6 +417,7 @@ describe( 'selectors', () => {
 					tracking: '12345',
 					carrierId: 'usps',
 					serviceName: 'First Class',
+					receiptId: 12345,
 				},
 				{
 					key: 2,
@@ -438,6 +445,7 @@ describe( 'selectors', () => {
 					tracking: '12345',
 					carrierId: 'canada_post',
 					serviceName: 'Xpress',
+					receiptId: 67890,
 				},
 				{
 					key: 1,
@@ -457,6 +465,7 @@ describe( 'selectors', () => {
 					tracking: '12345',
 					carrierId: 'usps',
 					serviceName: 'First Class',
+					receiptId: 654321,
 				},
 			] );
 		} );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-details-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-details-modal.js
@@ -12,16 +12,41 @@ import { localize } from 'i18n-calypso';
  */
 import Dialog from 'components/dialog';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import { getOrigin } from 'woocommerce/lib/nav-utils';
+import { userCanManagePayments } from 'woocommerce/woocommerce-services/state/label-settings/selectors';
 import { closeDetailsDialog } from 'woocommerce/woocommerce-services/state/shipping-label/actions';
 import { isLoaded, getShippingLabel } from 'woocommerce/woocommerce-services/state/shipping-label/selectors';
 
 const DetailsDialog = ( props ) => {
-	const { orderId, siteId, isVisible, labelIndex, serviceName, packageName, productNames, translate } = props;
+	const {
+		orderId,
+		siteId,
+		isVisible,
+		labelIndex,
+		serviceName,
+		packageName,
+		productNames,
+		canManagePayments,
+		receiptId,
+		translate,
+	} = props;
 
 	const onClose = () => props.closeDetailsDialog( orderId, siteId );
 	const buttons = [
 		{ action: 'close', label: translate( 'Close' ), onClick: onClose },
 	];
+
+	const renderReceiptLink = () => {
+		if ( ! canManagePayments || ! receiptId ) {
+			return <span />;
+		}
+
+		return <a
+			href={ `${ getOrigin() }/me/purchases/billing/${ receiptId }` }
+			target="_blank">
+			{ translate( 'Receipt' ) }
+		</a>;
+	};
 
 	return (
 		<Dialog
@@ -29,8 +54,11 @@ const DetailsDialog = ( props ) => {
 			isVisible={ isVisible }
 			onClose={ onClose }
 			buttons={ buttons }>
-			<FormSectionHeading>
-				{ translate( 'Label #%(labelIndex)s details', { args: { labelIndex: labelIndex + 1 } } ) }
+			<FormSectionHeading className="shipping-label__label-details-modal-heading">
+				<span className="shipping-label__label-details-modal-heading-title">
+					{ translate( 'Label #%(labelIndex)s details', { args: { labelIndex: labelIndex + 1 } } ) }
+				</span>
+				{ renderReceiptLink() }
 			</FormSectionHeading>
 			<dl>
 				<dt>{ translate( 'Service' ) }</dt>
@@ -58,6 +86,7 @@ DetailsDialog.propTypes = {
 	packageName: PropTypes.string,
 	productNames: PropTypes.array,
 	closeDetailsDialog: PropTypes.func.isRequired,
+	receiptId: PropTypes.number,
 };
 
 const mapStateToProps = ( state, { orderId, siteId, labelId } ) => {
@@ -65,6 +94,7 @@ const mapStateToProps = ( state, { orderId, siteId, labelId } ) => {
 	const { detailsDialog } = getShippingLabel( state, orderId, siteId );
 	return {
 		isVisible: Boolean( loaded && detailsDialog && detailsDialog.labelId === labelId ),
+		canManagePayments: userCanManagePayments( state, siteId ),
 	};
 };
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-details-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-details-modal.js
@@ -38,7 +38,7 @@ const DetailsDialog = ( props ) => {
 
 	const renderReceiptLink = () => {
 		if ( ! canManagePayments || ! receiptId ) {
-			return <span />;
+			return null;
 		}
 
 		return <a

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
@@ -100,3 +100,11 @@
 	margin: 8px auto;
 	text-align: center;
 }
+
+.shipping-label__label-details-modal-heading {
+	display: flex;
+}
+
+.shipping-label__label-details-modal-heading-title {
+	flex-grow: 1;
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1275

To test:
* no changes should be observed on store on Calypso
* to test in the WCS plugin, `npm link` this branch and use 1046-gh-woocommerce-connect-server running on the server
* you should see the link in the label modal:
<img width="494" alt="screen shot 2018-02-23 at 16 05 55" src="https://user-images.githubusercontent.com/800604/36603830-f148afce-18b3-11e8-8934-32c097e8ba16.png">
Clicking on the link might take you to wordpress.com and display the whole receipts history, but if you load the same link on the local calypso running this branch, the receipt should load (this was added in #22442 which is the base branch for this PR)