### PR TITLE
Move dev menu overhang to the left instead of the right.

### DIFF
--- a/client/lib/abtest/test-helper/style.scss
+++ b/client/lib/abtest/test-helper/style.scss
@@ -25,7 +25,7 @@
 	overflow-y: scroll;
 	position: absolute;
 	bottom: 100%;
-	left: 0px;
+	right: 0px;
 	margin: 0;
 	font-size: 11px;
 }

--- a/client/lib/preferences-helper/style.scss
+++ b/client/lib/preferences-helper/style.scss
@@ -36,7 +36,7 @@
 	overflow-y: scroll;
 	position: absolute;
 	bottom: 100%;
-	left: 0px;
+	right: 0px;
 	margin: 0;
 	font-size: 11px;
 }


### PR DESCRIPTION

## Specs

Change the direction of the dev menu overhangs so that it goes to the left instead of to the right where it is hidden off of the page.

<img width="663" alt="screen shot 2018-02-23 at 9 38 29 am" src="https://user-images.githubusercontent.com/2810519/36608016-53123b76-187d-11e8-9124-64d3ea05adae.png">

## Testing

- Boot this branch locally or use the calypso.live link below
- Navigate to any page
- Hover over the dev menu
- Notice that the menus are fully visible and overhang the menu to the left