### PR TITLE
Jetpack Connect: Revert change that cleared cookies mid-flow

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -32,13 +32,7 @@ import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
 import { hideMasterbar, setSection, showMasterbar } from 'state/ui/actions';
 import { JPC_PATH_PLANS, MOBILE_APP_REDIRECT_URL_WHITELIST } from './constants';
 import { login } from 'lib/paths';
-import {
-	clearPlan,
-	persistMobileRedirect,
-	retrieveMobileRedirect,
-	retrievePlan,
-	storePlan,
-} from './persistence-utils';
+import { persistMobileRedirect, retrieveMobileRedirect, storePlan } from './persistence-utils';
 import { receiveJetpackOnboardingCredentials } from 'state/jetpack-onboarding/actions';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { startAuthorizeStep } from 'state/jetpack-connect/actions';
@@ -162,13 +156,9 @@ export function connect( context, next ) {
 	debug( 'entered connect flow with params %o', params );
 
 	const planSlug = getPlanSlugFromFlowType( type, interval );
-	const selectedPlan = retrievePlan();
 
-	if ( planSlug ) {
-		storePlan( planSlug );
-	} else if ( selectedPlan ) {
-		clearPlan();
-	}
+	// Not clearing the plan here, because other flows can set the cookie before arriving here.
+	planSlug && storePlan( planSlug );
 
 	analytics.pageView.record( pathname, analyticsPageTitle );
 


### PR DESCRIPTION
#22689 broke flows starting at /jetpack/connect/store by clearing the plan cookie at the /jetpack/connect step. This PR reverts that change and adds a comment the code to explain why the cookie cannot be cleared based on url.

## Testing
* Go to https://calypso.live/jetpack/connect/store?branch=fix/jetpack-connect/store-to-connect, and choose the Pro plan
* On the next screen, you should see "Get Jetpack Professional", and not "Connect a self-hosted WordPress"
* Connection should complete as normal
