### PR TITLE
i18n: utilize the moment provided by i18n-calypso

### DIFF
--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -5,9 +5,8 @@
  */
 
 import url from 'url';
-import i18n from 'i18n-calypso';
+import { moment } from 'i18n-calypso';
 import { includes } from 'lodash';
-const moment = i18n.moment;
 
 /**
  * Internal dependencies
@@ -246,8 +245,8 @@ export const getFeaturedImageId = function( post ) {
  */
 export const getOffsetDate = function( date, tz ) {
 	if ( ! tz ) {
-		return i18n.moment( date );
+		return moment( date );
 	}
 
-	return i18n.moment( moment.tz( date, tz ) );
+	return moment( moment.tz( date, tz ) );
 };

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -6,8 +6,8 @@
 
 import url from 'url';
 import i18n from 'i18n-calypso';
-import moment from 'moment-timezone';
 import { includes } from 'lodash';
+const moment = i18n.moment;
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/activity-log/utils.js
+++ b/client/my-sites/stats/activity-log/utils.js
@@ -2,7 +2,8 @@
 /**
  * External dependencies
  */
-import momentLib from 'moment-timezone';
+import i18n from 'i18n-calypso';
+const momentLib = i18n.moment;
 
 /**
  * @typedef OffsetParams

--- a/client/my-sites/stats/activity-log/utils.js
+++ b/client/my-sites/stats/activity-log/utils.js
@@ -2,8 +2,7 @@
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
-const momentLib = i18n.moment;
+import { momentLib } from 'i18n-calypso';
 
 /**
  * @typedef OffsetParams

--- a/client/my-sites/stats/activity-log/utils.js
+++ b/client/my-sites/stats/activity-log/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { momentLib } from 'i18n-calypso';
+import { moment as momentLib } from 'i18n-calypso';
 
 /**
  * @typedef OffsetParams

--- a/client/state/concierge/signup-form/reducer.js
+++ b/client/state/concierge/signup-form/reducer.js
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-import moment from 'moment-timezone';
+import i18n from 'i18n-calypso';
+const moment = i18n.moment;
 
 /**
  * Internal dependencies

--- a/client/state/concierge/signup-form/reducer.js
+++ b/client/state/concierge/signup-form/reducer.js
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
-const moment = i18n.moment;
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/state/concierge/signup-form/test/reducer.js
+++ b/client/state/concierge/signup-form/test/reducer.js
@@ -3,7 +3,8 @@
 /**
  * External dependencies
  */
-import moment from 'moment-timezone';
+import i18n from 'i18n-calypso';
+const moment = i18n.moment;
 
 /**
  * Internal dependencies

--- a/client/state/concierge/signup-form/test/reducer.js
+++ b/client/state/concierge/signup-form/test/reducer.js
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-import i18n from 'i18n-calypso';
-const moment = i18n.moment;
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -5,7 +5,8 @@
  */
 import { filter, find, has, get, includes, isEqual, omit, some } from 'lodash';
 import createSelector from 'lib/create-selector';
-import moment from 'moment-timezone';
+import i18n from 'i18n-calypso';
+const moment = i18n.moment;
 
 /**
  * Internal dependencies

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -5,8 +5,7 @@
  */
 import { filter, find, has, get, includes, isEqual, omit, some } from 'lodash';
 import createSelector from 'lib/create-selector';
-import i18n from 'i18n-calypso';
-const moment = i18n.moment;
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
I found 5 different cases where Calypso was directly depending on `moment-timezone` which is just a transitive dependency.  This is bad practice and can lead to myriad issues like:

1. accidentally duplicating moment-timezone and bundling multiple versions
2. break the build if we swap out implementation details and transitive deps change

This pr swaps it out for the version of moment handed by the `i18n-calypso` package which is the correct way of grabbing the dependency.

The permanent fix to make sure we don't do this again is coming in: https://github.com/Automattic/wp-calypso/pull/22630

**to test**
- ensure you can still signup for a concierge chat
- ensure you can still see your lists of posts