### PR TITLE
Store: Remove hard-coded fees from settings page.

### DIFF
--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -23,6 +23,7 @@ import {
 } from 'woocommerce/state/ui/payments/methods/actions';
 import { getCurrentlyEditingPaymentMethod } from 'woocommerce/state/ui/payments/methods/selectors';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import ExternalLink from 'components/external-link';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import { hasStripeKeyPairForMode } from './stripe/payment-method-stripe-utils';
@@ -215,9 +216,12 @@ class PaymentMethodItem extends Component {
 					<p className={ methodTitle }>{ method.title }</p>
 				</ListItemField>
 				<ListItemField className="payments__method-method-information-container">
+					{ method.fees && <p className="payments__method-information">{ method.fees }</p> }
 					{ method.informationUrl && (
 						<p className="payments__method-information">
-							<a href={ method.informationUrl }>{ translate( 'More Information' ) }</a>
+							<ExternalLink icon href={ method.informationUrl } target="_blank">
+								{ translate( 'More Information' ) }
+							</ExternalLink>
 						</p>
 					) }
 				</ListItemField>

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -215,7 +215,6 @@ class PaymentMethodItem extends Component {
 					<p className={ methodTitle }>{ method.title }</p>
 				</ListItemField>
 				<ListItemField className="payments__method-method-information-container">
-					{ method.fees && <p className="payments__method-information">{ method.fees }</p> }
 					{ method.informationUrl && (
 						<p className="payments__method-information">
 							<a href={ method.informationUrl }>{ translate( 'More Information' ) }</a>

--- a/client/extensions/woocommerce/lib/get-payment-method-details/details-mappings.json
+++ b/client/extensions/woocommerce/lib/get-payment-method-details/details-mappings.json
@@ -13,11 +13,13 @@
 		"methodType": "offline"
 	},
 	"paypal": {
+		"fees": "Fee varies based on country",
 		"informationUrl": "https://docs.woocommerce.com/document/paypal-standard/",
 		"isSuggested": true,
 		"methodType": "off-site"
 	},
 	"stripe": {
+		"fees": "Fee varies based on country",		
 		"informationUrl": "https://stripe.com/pricing",
 		"isSuggested": true,
 		"methodType": "on-site"

--- a/client/extensions/woocommerce/lib/get-payment-method-details/details-mappings.json
+++ b/client/extensions/woocommerce/lib/get-payment-method-details/details-mappings.json
@@ -13,13 +13,11 @@
 		"methodType": "offline"
 	},
 	"paypal": {
-		"fees": "2.9% + 30c per transaction",
 		"informationUrl": "https://docs.woocommerce.com/document/paypal-standard/",
 		"isSuggested": true,
 		"methodType": "off-site"
 	},
 	"stripe": {
-		"fees": "2.9% + 30c per transaction",
 		"informationUrl": "https://stripe.com/pricing",
 		"isSuggested": true,
 		"methodType": "on-site"


### PR DESCRIPTION
For #21556 and #21574

To prepare for allowing non US/CA countries to be supported in Store, this branch removes the hard-coded fee structures for PayPal and Stripe on the payment settings page. I looked at Woo core and verified that we do not show processing fees anywhere there, including in the setup wizard, so unsure of why we should do so on the payment settings page itself.

Furthermore, it seems like if we were to support this officially, it should be part of the `payment_gateways` API response, which it currently isn't. I think the links back to the relevant pricing pages are sufficient here, and takes away the potential for invalid fee information like what was reported in #21556

__Before__
![afterz](https://user-images.githubusercontent.com/22080/36621858-12ad2c4e-18af-11e8-8e80-f0ea7ab36c31.png)

__After__
![durrrrpz](https://user-images.githubusercontent.com/22080/36621896-40a01652-18af-11e8-9718-8d083afa8e48.png)

__Core Setup Wizard__
<img width="950" alt="core-wizard-payments" src="https://user-images.githubusercontent.com/22080/36621794-bb08d042-18ae-11e8-88fa-095f3bcdc159.png">

