### PR TITLE
Store: fix credit card formatting for amex and other unusual length cards

### DIFF
--- a/client/lib/credit-card-details/masking.js
+++ b/client/lib/credit-card-details/masking.js
@@ -42,7 +42,7 @@ fieldMasks[ 'expiration-date' ] = {
 };
 
 export const formatAmexCreditCard = function( cardNumber ) {
-	const digits = cardNumber.replace( /[^0-9]/g, '' );
+	const digits = cardNumber.replace( /[^0-9]/g, '' ).slice( 0, 15 );
 	const formattedNumber = `${ digits.slice( 0, 4 ) } ${ digits.slice( 4, 10 ) } ${ digits.slice(
 		10,
 		15
@@ -51,7 +51,7 @@ export const formatAmexCreditCard = function( cardNumber ) {
 };
 
 export const formatCreditCard = function( cardNumber ) {
-	const digits = cardNumber.replace( /[^0-9]/g, '' );
+	const digits = cardNumber.replace( /[^0-9]/g, '' ).slice( 0, 19 );
 	const formattedNumber = `${ digits.slice( 0, 4 ) } ${ digits.slice( 4, 8 ) } ${ digits.slice(
 		8,
 		12

--- a/client/lib/credit-card-details/masking.js
+++ b/client/lib/credit-card-details/masking.js
@@ -51,6 +51,9 @@ export const formatAmexCreditCard = function( cardNumber ) {
 };
 
 export const formatCreditCard = function( cardNumber ) {
+	if ( getCreditCardType( cardNumber ) === 'amex' ) {
+		return formatAmexCreditCard( cardNumber );
+	}
 	const digits = cardNumber.replace( /[^0-9]/g, '' ).slice( 0, 19 );
 	const formattedNumber = `${ digits.slice( 0, 4 ) } ${ digits.slice( 4, 8 ) } ${ digits.slice(
 		8,
@@ -61,9 +64,6 @@ export const formatCreditCard = function( cardNumber ) {
 
 fieldMasks.number = {
 	mask: function( previousValue, nextValue ) {
-		if ( getCreditCardType( nextValue ) === 'amex' ) {
-			return formatAmexCreditCard( nextValue );
-		}
 		return formatCreditCard( nextValue );
 	},
 

--- a/client/lib/credit-card-details/masking.js
+++ b/client/lib/credit-card-details/masking.js
@@ -4,6 +4,11 @@
  */
 import { identity } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import { getCreditCardType } from 'lib/credit-card-details';
+
 const fieldMasks = {};
 
 fieldMasks[ 'expiration-date' ] = {
@@ -36,19 +41,30 @@ fieldMasks[ 'expiration-date' ] = {
 	unmask: identity,
 };
 
+export const formatAmexCreditCard = function( cardNumber ) {
+	const digits = cardNumber.replace( /[^0-9]/g, '' );
+	const formattedNumber = `${ digits.slice( 0, 4 ) } ${ digits.slice( 4, 10 ) } ${ digits.slice(
+		10,
+		15
+	) }`;
+	return formattedNumber.trim();
+};
+
+export const formatCreditCard = function( cardNumber ) {
+	const digits = cardNumber.replace( /[^0-9]/g, '' );
+	const formattedNumber = `${ digits.slice( 0, 4 ) } ${ digits.slice( 4, 8 ) } ${ digits.slice(
+		8,
+		12
+	) } ${ digits.slice( 12 ) }`;
+	return formattedNumber.trim();
+};
+
 fieldMasks.number = {
 	mask: function( previousValue, nextValue ) {
-		const digits = nextValue.replace( /[^0-9]/g, '' ),
-			string =
-				digits.slice( 0, 4 ) +
-				' ' +
-				digits.slice( 4, 8 ) +
-				' ' +
-				digits.slice( 8, 12 ) +
-				' ' +
-				digits.slice( 12, 16 );
-
-		return string.trim();
+		if ( getCreditCardType( nextValue ) === 'amex' ) {
+			return formatAmexCreditCard( nextValue );
+		}
+		return formatCreditCard( nextValue );
 	},
 
 	unmask: function( value ) {

--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -111,6 +111,9 @@ describe( 'index', () => {
 			test( 'formats a number as 4-6-5 with any sort of whitespace', () => {
 				expect( formatAmexCreditCard( ' 3782 8224 6310 005 ' ) ).toEqual( '3782 822463 10005' );
 			} );
+			test( 'formats a number as 4-6-5 and trims to 15 digits', () => {
+				expect( formatAmexCreditCard( '37828224631000512345' ) ).toEqual( '3782 822463 10005' );
+			} );
 		} );
 		describe( 'Diner Credit Cards', () => {
 			test( 'formats a number as 4-4-4-2', () => {
@@ -129,6 +132,11 @@ describe( 'index', () => {
 			} );
 			test( '19 digit cards format as 4-4-4-7', () => {
 				expect( formatCreditCard( '6011496233608973938' ) ).toEqual( '6011 4962 3360 8973938' );
+			} );
+			test( 'has a maximum length of 19', () => {
+				expect( formatCreditCard( '6011496233608973938123456789' ) ).toEqual(
+					'6011 4962 3360 8973938'
+				);
 			} );
 		} );
 	} );

--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -12,7 +12,7 @@ import assert from 'assert';
  * Internal dependencies
  */
 import { getCreditCardType } from '../';
-import { formatAmexCreditCard, formatCreditCard } from '../masking';
+import { formatCreditCard } from '../masking';
 
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',
@@ -106,13 +106,13 @@ describe( 'index', () => {
 	describe( 'Masking', () => {
 		describe( 'American Express Card', () => {
 			test( 'formats a number as 4-6-5', () => {
-				expect( formatAmexCreditCard( '378282246310005' ) ).toEqual( '3782 822463 10005' );
+				expect( formatCreditCard( '378282246310005' ) ).toEqual( '3782 822463 10005' );
 			} );
 			test( 'formats a number as 4-6-5 with any sort of whitespace', () => {
-				expect( formatAmexCreditCard( ' 3782 8224 6310 005 ' ) ).toEqual( '3782 822463 10005' );
+				expect( formatCreditCard( ' 3782 8224 6310 005 ' ) ).toEqual( '3782 822463 10005' );
 			} );
 			test( 'formats a number as 4-6-5 and trims to 15 digits', () => {
-				expect( formatAmexCreditCard( '37828224631000512345' ) ).toEqual( '3782 822463 10005' );
+				expect( formatCreditCard( '37828224631000512345' ) ).toEqual( '3782 822463 10005' );
 			} );
 		} );
 		describe( 'Diner Credit Cards', () => {

--- a/client/lib/credit-card-details/test/index.js
+++ b/client/lib/credit-card-details/test/index.js
@@ -12,6 +12,7 @@ import assert from 'assert';
  * Internal dependencies
  */
 import { getCreditCardType } from '../';
+import { formatAmexCreditCard, formatCreditCard } from '../masking';
 
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',
@@ -99,6 +100,35 @@ describe( 'index', () => {
 
 			test( 'should return `unionpay` for 6240008631401148', () => {
 				assert.equal( getCreditCardType( '6240008631401148' ), 'unionpay' );
+			} );
+		} );
+	} );
+	describe( 'Masking', () => {
+		describe( 'American Express Card', () => {
+			test( 'formats a number as 4-6-5', () => {
+				expect( formatAmexCreditCard( '378282246310005' ) ).toEqual( '3782 822463 10005' );
+			} );
+			test( 'formats a number as 4-6-5 with any sort of whitespace', () => {
+				expect( formatAmexCreditCard( ' 3782 8224 6310 005 ' ) ).toEqual( '3782 822463 10005' );
+			} );
+		} );
+		describe( 'Diner Credit Cards', () => {
+			test( 'formats a number as 4-4-4-2', () => {
+				expect( formatCreditCard( '30569309025904' ) ).toEqual( '3056 9309 0259 04' );
+			} );
+			test( 'formats a number as 4-4-4-2 with any sort of whitespace', () => {
+				expect( formatCreditCard( '3056 9309 025   904' ) ).toEqual( '3056 9309 0259 04' );
+			} );
+		} );
+		describe( 'All Other Credit Cards', () => {
+			test( 'formats a number as 4-4-4-4', () => {
+				expect( formatCreditCard( '2223003122003222' ) ).toEqual( '2223 0031 2200 3222' );
+			} );
+			test( 'formats a number as 4-4-4-4 with any sort of whitespace', () => {
+				expect( formatCreditCard( '2223 0031220     03222' ) ).toEqual( '2223 0031 2200 3222' );
+			} );
+			test( '19 digit cards format as 4-4-4-7', () => {
+				expect( formatCreditCard( '6011496233608973938' ) ).toEqual( '6011 4962 3360 8973938' );
 			} );
 		} );
 	} );


### PR DESCRIPTION
Fixes #21924 where American Express cards were incorrectly formatted as 4-4-4-3 instead of 4-6-5 digit groupings. This also handles 19 digit cards as 4-4-4-7 groupings.

<img width="700" alt="screen shot 2018-02-23 at 5 20 15 pm" src="https://user-images.githubusercontent.com/1270189/36624205-2b727fd8-18c1-11e8-89df-af4c2be11b86.png">

<img width="737" alt="screen shot 2018-02-23 at 5 20 30 pm" src="https://user-images.githubusercontent.com/1270189/36624213-3667acce-18c1-11e8-8bb1-d85d66431c31.png">

### Testing Instructions
- No regressions in checkout
- Navigate to /plans select a site that has a free plan
- Select a plan to upgrade
- Try using different credit card types
- Visa and other 16 digit cards should be grouped in 4-4-4-4
- American Express as 4-6-5
- A 19 digit test card as 4-4-4-7
- Try checking out normally