### PR TITLE
Remove references to moment-timezone

### DIFF
--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -6,7 +6,6 @@
 
 import url from 'url';
 import i18n from 'i18n-calypso';
-import moment from 'moment-timezone';
 import { includes } from 'lodash';
 
 /**
@@ -76,7 +75,7 @@ export const isBackDatedPublished = function( post ) {
 		return false;
 	}
 
-	return moment( post.date ).isBefore( moment() );
+	return i18n.moment( post.date ).isBefore( i18n.moment() );
 };
 
 export const isPublished = function( post ) {
@@ -121,7 +120,7 @@ export const isBackDated = function( post ) {
 		return false;
 	}
 
-	return moment( post.date ).isBefore( moment( post.modified ) );
+	return i18n.moment( post.date ).isBefore( i18n.moment( post.modified ) );
 };
 
 export const isPage = function( post ) {
@@ -249,5 +248,5 @@ export const getOffsetDate = function( date, tz ) {
 		return i18n.moment( date );
 	}
 
-	return i18n.moment( moment.tz( date, tz ) );
+	return i18n.moment( i18n.moment.tz( date, tz ) );
 };

--- a/client/my-sites/stats/activity-log/utils.js
+++ b/client/my-sites/stats/activity-log/utils.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import momentLib from 'moment-timezone';
+import i18n from 'i18n-calypso';
 
 /**
  * @typedef OffsetParams
@@ -43,20 +43,20 @@ export function adjustMoment( { timezone, gmtOffset, moment } ) {
 export function getStartMoment( { gmtOffset, startDate, timezone } ) {
 	if ( timezone ) {
 		if ( ! startDate ) {
-			return momentLib().tz( timezone );
+			return i18n.moment().tz( timezone );
 		}
 
-		return momentLib.tz( startDate, timezone );
+		return i18n.moment.tz( startDate, timezone );
 	}
 
 	if ( null !== gmtOffset ) {
-		return momentLib
+		return i18n.moment
 			.utc( startDate )
 			.subtract( gmtOffset, 'hours' )
 			.utcOffset( gmtOffset );
 	}
 
-	return momentLib.utc( startDate );
+	return i18n.moment.utc( startDate );
 }
 
 /**

--- a/client/state/concierge/signup-form/reducer.js
+++ b/client/state/concierge/signup-form/reducer.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import moment from 'moment-timezone';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ export const message = createReducer( '', {
 	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.message,
 } );
 
-export const timezone = createReducer( moment.tz.guess(), {
+export const timezone = createReducer( i18n.moment.tz.guess(), {
 	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.timezone,
 } );
 

--- a/client/state/concierge/signup-form/test/reducer.js
+++ b/client/state/concierge/signup-form/test/reducer.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import moment from 'moment-timezone';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -53,7 +53,7 @@ describe( 'concierge/signupForm/reducer', () => {
 
 	describe( 'timezone', () => {
 		test( 'should use the default detected timezone.', () => {
-			expect( timezone( undefined, {} ) ).toEqual( moment.tz.guess() );
+			expect( timezone( undefined, {} ) ).toEqual( i18n.moment.tz.guess() );
 		} );
 
 		test( 'should return the timezone of the update action', () => {
@@ -86,7 +86,7 @@ describe( 'concierge/signupForm/reducer', () => {
 			expect( signupForm( undefined, {} ) ).toEqual( {
 				firstname: '',
 				lastname: '',
-				timezone: moment.tz.guess(),
+				timezone: i18n.moment.tz.guess(),
 				message: '',
 				status: null,
 			} );

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -5,7 +5,7 @@
  */
 import { filter, find, has, get, includes, isEqual, omit, some } from 'lodash';
 import createSelector from 'lib/create-selector';
-import moment from 'moment-timezone';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -411,7 +411,7 @@ export const isEditedPostDirty = createSelector(
 			if ( post ) {
 				switch ( key ) {
 					case 'date': {
-						return ! moment( value ).isSame( post.date );
+						return ! i18n.moment( value ).isSame( post.date );
 					}
 					case 'parent': {
 						return get( post, 'parent.ID', 0 ) !== value;
@@ -446,7 +446,7 @@ export const isPostPublished = createSelector( ( state, siteId, postId ) => {
 
 	return (
 		includes( [ 'publish', 'private' ], post.status ) ||
-		( post.status === 'future' && moment( post.date ).isBefore( moment() ) )
+		( post.status === 'future' && i18n.moment( post.date ).isBefore( i18n.moment() ) )
 	);
 }, state => state.posts.queries );
 


### PR DESCRIPTION
The `moment-timezone` package is imported from, but not specified in `package.json`. It works because a dependency (`i18n-calypso`) requires it so it's bundled with webpack.

So I think the best way is to use the `moment` object provided by `i18n-calypso` and remove the `moment-timezone` references.

http://iscalypsofastyet.com/branch?branch=remove/moment-timezone
```
Delta:
chunk     stat_size           parsed_size           gzip_size
build         -13 B  (-0.0%)        -60 B  (-0.0%)      -19 B  (-0.0%)
manifest       +0 B                  +0 B                +3 B  (+0.1%)
stats          -5 B  (-0.0%)        -35 B  (-0.0%)      -20 B  (-0.0%)
```