### PR TITLE
Domains: fix "no domains for jetpack sites" message not showing

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -56,14 +56,11 @@ import {
 	domainManagementTransferToOtherSite,
 } from 'my-sites/domains/paths';
 import SitesComponent from 'my-sites/sites';
-import { isATEnabled } from 'lib/automated-transfer';
 import { warningNotice } from 'state/notices/actions';
 import { makeLayout, render as clientRender } from 'controller';
 import NoSitesMessage from 'components/empty-content/no-sites-message';
 import EmptyContentComponent from 'components/empty-content';
 import DomainOnly from 'my-sites/domains/domain-management/list/domain-only';
-import Main from 'components/main';
-import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.
@@ -439,24 +436,6 @@ export function navigation( context, next ) {
 	// Render the My Sites navigation in #secondary
 	context.secondary = createNavigation( context );
 	next();
-}
-
-export function jetPackWarning( context, next ) {
-	const { getState } = getStore( context );
-	const basePath = sectionify( context.path );
-	const selectedSite = getSelectedSite( getState() );
-
-	if ( selectedSite && selectedSite.jetpack && ! isATEnabled( selectedSite ) ) {
-		context.primary = (
-			<Main>
-				<JetpackManageErrorPage template="noDomainsOnJetpack" siteId={ selectedSite.ID } />
-			</Main>
-		);
-
-		analytics.pageView.record( basePath, '> No Domains On Jetpack' );
-	} else {
-		next();
-	}
 }
 
 /**

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -7,7 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { jetPackWarning, navigation, siteSelection, sites } from 'my-sites/controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import domainsController from './controller';
 import domainManagementController from './domain-management/controller';
 import SiftScience from 'lib/siftscience';
@@ -30,7 +30,7 @@ function getCommonHandlers( {
 	}
 
 	if ( warnIfJetpack ) {
-		handlers.push( jetPackWarning );
+		handlers.push( domainsController.jetpackNoDomainsWarning );
 	}
 
 	return handlers;
@@ -192,7 +192,7 @@ export default function() {
 			siteSelection,
 			domainsController.domainsAddHeader,
 			domainsController.redirectToAddMappingIfVipSite(),
-			jetPackWarning,
+			domainsController.jetpackNoDomainsWarning,
 			sites,
 			makeLayout,
 			clientRender
@@ -202,7 +202,7 @@ export default function() {
 			'/domains/add/mapping',
 			siteSelection,
 			domainsController.domainsAddHeader,
-			jetPackWarning,
+			domainsController.jetpackNoDomainsWarning,
 			sites,
 			makeLayout,
 			clientRender
@@ -212,7 +212,7 @@ export default function() {
 			'/domains/add/transfer',
 			siteSelection,
 			domainsController.domainsAddHeader,
-			jetPackWarning,
+			domainsController.jetpackNoDomainsWarning,
 			sites,
 			makeLayout,
 			clientRender
@@ -222,7 +222,7 @@ export default function() {
 			'/domains/add/site-redirect',
 			siteSelection,
 			domainsController.domainsAddRedirectHeader,
-			jetPackWarning,
+			domainsController.jetpackNoDomainsWarning,
 			sites,
 			makeLayout,
 			clientRender
@@ -234,7 +234,7 @@ export default function() {
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
 			domainsController.redirectToAddMappingIfVipSite(),
-			jetPackWarning,
+			domainsController.jetpackNoDomainsWarning,
 			domainsController.domainSearch,
 			makeLayout,
 			clientRender
@@ -246,7 +246,7 @@ export default function() {
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
 			domainsController.redirectToAddMappingIfVipSite(),
-			jetPackWarning,
+			domainsController.jetpackNoDomainsWarning,
 			domainsController.redirectToDomainSearchSuggestion
 		);
 
@@ -255,7 +255,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
-			jetPackWarning,
+			domainsController.jetpackNoDomainsWarning,
 			domainsController.googleAppsWithRegistration,
 			makeLayout,
 			clientRender
@@ -266,7 +266,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add/mapping' ),
-			jetPackWarning,
+			domainsController.jetpackNoDomainsWarning,
 			domainsController.mapDomain,
 			makeLayout,
 			clientRender
@@ -277,7 +277,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add/site-redirect' ),
-			jetPackWarning,
+			domainsController.jetpackNoDomainsWarning,
 			domainsController.siteRedirect,
 			makeLayout,
 			clientRender
@@ -288,7 +288,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add/transfer' ),
-			jetPackWarning,
+			domainsController.jetpackNoDomainsWarning,
 			domainsController.transferDomain,
 			makeLayout,
 			clientRender
@@ -299,7 +299,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/manage' ),
-			jetPackWarning,
+			domainsController.jetpackNoDomainsWarning,
 			domainsController.transferDomainPrecheck,
 			makeLayout,
 			clientRender
@@ -312,7 +312,7 @@ export default function() {
 		'/domains/:site',
 		siteSelection,
 		navigation,
-		jetPackWarning,
+		domainsController.jetpackNoDomainsWarning,
 		domainManagementController.domainManagementIndex,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
Fixes routes which should show "Domains are not available for this site" when Jetpack site is selected:

<img width="749" alt="image" src="https://user-images.githubusercontent.com/87168/36635861-0025635e-19c5-11e8-9795-b558e02a015f.png">

In the current state, we had an empty broken page.

The actual fix is just to add `makeLayout` and `clientRender` middlewares from `my-sites/controller` — without those `react.render()` is never called.

Additionally, I moved `jetPackWarning()` from `my-sites-controller` to domains controller since it's domain specific logic and doesn't need to be loaded in the main bundle.

The bug was caused by switching to single tree rendering in #19494 

Kudos @jsnajdr for spotting the bug in https://github.com/Automattic/wp-calypso/pull/22706#discussion_r170003470

## Testing

1. Have a jetpack site
2. Have a free wp.com site
3. Go to domain paths such as `/domains/manage/:site`
4. By choosing a Jetpack site and confirm that before the change you have empty page and after the change correct error
5. By choosing a normal site domain management works just as usual
