### PR TITLE
Rewind: Start collecting status from state machine API

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
@@ -13,6 +13,7 @@ import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { errorNotice } from 'state/notices/actions';
 import { SchemaError, dispatchRequestEx } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { requestRewindState } from 'state/rewind/actions';
 
 const fromApi = data => {
 	const restoreId = parseInt( data.restore_id, 10 );
@@ -34,8 +35,10 @@ const requestRestore = action =>
 		action
 	);
 
-export const receiveRestoreSuccess = ( { siteId, timestamp }, restoreId ) =>
-	getRewindRestoreProgress( siteId, restoreId );
+export const receiveRestoreSuccess = ( { siteId, timestamp }, restoreId ) => [
+	getRewindRestoreProgress( siteId, restoreId ),
+	requestRewindState( siteId ),
+];
 
 export const receiveRestoreError = ( { siteId, timestamp }, error ) =>
 	error.hasOwnProperty( 'schemaErrors' )

--- a/client/state/data-layer/wpcom/activity-log/rewind/to/test/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/test/index.js
@@ -4,6 +4,7 @@
  */
 import { receiveRestoreSuccess } from '../';
 import { getRewindRestoreProgress } from 'state/activity-log/actions';
+import { requestRewindState } from 'state/rewind/actions';
 
 const siteId = 77203074;
 const timestamp = 1496768464;
@@ -11,8 +12,9 @@ const restoreId = 12345;
 
 describe( 'receiveRestoreSuccess', () => {
 	test( 'should dispatch get restore progress on success', () => {
-		expect( receiveRestoreSuccess( { siteId, timestamp }, restoreId ) ).toEqual(
-			getRewindRestoreProgress( siteId, restoreId )
-		);
+		expect( receiveRestoreSuccess( { siteId, timestamp }, restoreId ) ).toEqual( [
+			getRewindRestoreProgress( siteId, restoreId ),
+			requestRewindState( siteId ),
+		] );
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -4,6 +4,12 @@
  */
 import { camelCase } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { requestRewindState } from 'state/rewind/actions';
+
 const transformCredential = data =>
 	Object.assign(
 		{
@@ -28,6 +34,15 @@ const transformDownload = data =>
 		data.validUntil && { validUntil: new Date( data.validUntil * 1000 ) }
 	);
 
+const makeRewindDismisser = data =>
+	http( {
+		apiVersion: data.apiVersion,
+		method: data.method,
+		path: data.path,
+		onSuccess: requestRewindState( data.site_id ),
+		onFailure: requestRewindState( data.site_id ),
+	} );
+
 const transformRewind = data =>
 	Object.assign(
 		{
@@ -36,7 +51,8 @@ const transformRewind = data =>
 			status: data.status,
 		},
 		data.progress && { progress: data.progress },
-		data.reason && { reason: data.reason }
+		data.reason && { reason: data.reason },
+		data.links && data.links.dismiss && { dismiss: makeRewindDismisser( data.links.dismiss ) }
 	);
 
 export const transformApi = data =>

--- a/client/state/data-layer/wpcom/sites/rewind/index.js
+++ b/client/state/data-layer/wpcom/sites/rewind/index.js
@@ -34,7 +34,8 @@ const updateRewindState = ( { siteId }, data ) => {
 		data,
 	};
 
-	const hasRunningRewind = data.rewind && data.rewind.status === 'running';
+	const hasRunningRewind =
+		data.rewind && ( data.rewind.status === 'queued' || data.rewind.status === 'running' );
 
 	if ( ! hasRunningRewind ) {
 		return stateUpdate;

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -44,6 +44,7 @@ export const download = {
 export const rewind = {
 	type: 'object',
 	properties: {
+		links: { type: 'object' },
 		rewind_id: { type: 'string' },
 		status: { type: 'string', enum: [ 'failed', 'finished', 'queued', 'running' ] },
 		started_at: { type: 'string' },


### PR DESCRIPTION
See #21855

In the long process of deprecating the old Rewind status API we have to
get information about recent Rewind operations from the "state machine"
API instead of `/rewind/status`.

In this patch we're starting to poll both endpoints whenever a Rewind is
in progress or is started. In further PRs we'll slowly move
functionality from the old data into the new data.

In the meantime we will have some duplication of data and network
activity but this gradual approach will allow us to make small and
incremental changes without risking too much breakage.

This patch only exist to make sure the necessary data is loaded into
Calypso; it does not attempt to change the behavior of the UI.

**Testing**

This change should trigger polling of `/sites/{ site }/rewind` as soon as
a new Rewind operation is started. Navigate to **My Sites** > **Stats** > **Activity**
on a site with Rewind and then start a restore operation.

In **master** it should start polling `restore-status` but in this branch
it should _also_ be polling `rewind` until the restore is complete.

---

http://iscalypsofastyet.com/branch?branch=rewind/start-collecting-status-from-state-machine
```
Delta:
chunk                     stat_size           parsed_size           gzip_size
async-load-design-blocks     -279 B  (-0.0%)        -40 B  (-0.0%)      -33 B  (-0.0%)
build                        +900 B  (+0.0%)       +519 B  (+0.0%)     +163 B  (+0.0%)
manifest                       +0 B                  +0 B                +4 B  (+0.1%)
plans                        -279 B  (-0.1%)        -40 B  (-0.0%)      -39 B  (-0.1%)
plugins                      -279 B  (-0.0%)        -40 B  (-0.0%)      -40 B  (-0.1%)
settings                     -279 B  (-0.1%)        -40 B  (-0.0%)      -29 B  (-0.0%)
settings-security            -279 B  (-0.1%)        -40 B  (-0.0%)      -50 B  (-0.2%)
signup                       -279 B  (-0.0%)        -40 B  (-0.0%)      -35 B  (-0.0%)
stats                        -279 B  (-0.0%)        -40 B  (-0.0%)      -27 B  (-0.0%)
```