### PR TITLE
Translation Invitation. Make sure the invitation isn't shown on the post edit page.

### DIFF
--- a/client/layout/community-translator/invitation-utils.js
+++ b/client/layout/community-translator/invitation-utils.js
@@ -94,7 +94,7 @@ const invitationUtils = {
 	// The calypso editor is styled flush to the top, and makes the invitation
 	// look bad, so don't show it there
 	isValidSection: function( section ) {
-		return section !== 'post';
+		return section !== 'post-editor';
 	},
 
 	dismiss: function() {


### PR DESCRIPTION
The community translation invitation isn't properly styled to appear on the post edit page, and looks bad when it does. It seems it was never intended to show this component in that context. We need to fix the `isValidSection` function so it looks for the section `post-editor` instead of `post`.

Testing the issue locally is tricky without some hackiness, because the invitation requires user settings to load. I had to isolate the third condition on my local by commenting out the other two in lines 110-113 of `client/layout/index.jsx`:

```
	const showInvitation =
		// ! showWelcome &&
		// translatorInvitation.isPending() &&
		translatorInvitation.isValidSection( this.props.section.name );
```

Without the fix, this causes the invitation to appear on pages including the post edit page; with the fix, the invitation disappears from the post edit page.

https://github.com/Automattic/wp-calypso/issues/17426