### PR TITLE
Layout: Add Skip Navigation link to sidebar (#3155)

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -175,11 +175,11 @@ const Layout = createReactClass( {
 						forcePinned={ 'post' === this.props.section.name }
 					/>
 
-					<div id="primary" className="layout__primary">
-						{ this.props.primary }
-					</div>
 					<div id="secondary" className="layout__secondary">
 						{ this.props.secondary }
+					</div>
+					<div id="primary" className="layout__primary">
+						{ this.props.primary }
 					</div>
 				</div>
 				<TranslatorLauncher

--- a/client/layout/sidebar/region.jsx
+++ b/client/layout/sidebar/region.jsx
@@ -7,8 +7,16 @@
 import React from 'react';
 import classNames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import SkipNavigation from './skip-navigation';
+
 const SidebarRegion = ( { children, className } ) => (
-	<div className={ classNames( 'sidebar__region', className ) }>{ children }</div>
+	<div className={ classNames( 'sidebar__region', className ) }>
+		<SkipNavigation skipToElementId="primary" />
+		{ children }
+	</div>
 );
 
 export default SidebarRegion;

--- a/client/layout/sidebar/skip-navigation.jsx
+++ b/client/layout/sidebar/skip-navigation.jsx
@@ -15,11 +15,7 @@ class SkipNavigation extends React.Component {
 
 	render() {
 		return (
-			<a
-				href={ '#' + this.props.skipToElementId }
-				className="sidebar__skip-navigation"
-				data-tip-target={ this.props.tipTarget }
-			>
+			<a href={ '#' + this.props.skipToElementId } className="sidebar__skip-navigation">
 				{ this.props.translate( 'Skip navigation' ) }
 			</a>
 		);

--- a/client/layout/sidebar/skip-navigation.jsx
+++ b/client/layout/sidebar/skip-navigation.jsx
@@ -1,0 +1,29 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+
+class SkipNavigation extends React.Component {
+	static propTypes = {
+		skipToElementId: PropTypes.string,
+	};
+
+	render() {
+		return (
+			<a
+				href={ '#' + this.props.skipToElementId }
+				className="sidebar__skip-navigation"
+				data-tip-target={ this.props.tipTarget }
+			>
+				{ this.props.translate( 'Skip navigation' ) }
+			</a>
+		);
+	}
+}
+
+export default localize( SkipNavigation );

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -422,6 +422,39 @@ form.sidebar__button input {
 	-webkit-overflow-scrolling: touch;
 }
 
+.sidebar__skip-navigation {
+	position: absolute;
+	left: -10000px;
+	top: auto;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+	flex-shrink: 0;
+
+	&:focus {
+		position: static;
+		width: auto;
+		height: auto;
+		padding: 11px 16px 11px 18px;
+		outline: none;
+		box-shadow: inset 0 0 0 2px $blue-light;
+		font-size: 14px;
+		line-height: 1;
+		color: var( --sidebar-color );
+		box-sizing: border-box;
+		white-space: nowrap;
+		overflow: hidden;
+		display: flex;
+		align-items: center;
+
+		&:after {
+			top: 2px;
+			right: 2px;
+			bottom: 2px;
+		}
+	}
+}
+
 .sidebar__menu {
 	.is-placeholder {
 		cursor: default;

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -170,8 +170,8 @@ export default {
 
 		const activeFilter = find( filters(), filter => {
 			return (
-				context.pathname === filter.path ||
-				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
+				context.path === filter.path ||
+				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.path ) )
 			);
 		} );
 
@@ -187,7 +187,7 @@ export default {
 
 			const props = {
 				period: activeFilter.period,
-				path: context.pathname,
+				path: context.path,
 			};
 			context.primary = <StatsOverview { ...props } />;
 			next();
@@ -213,8 +213,8 @@ export default {
 
 		const activeFilter = find( filters, filter => {
 			return (
-				context.pathname === filter.path ||
-				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
+				context.path === filter.path ||
+				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.path ) )
 			);
 		} );
 
@@ -260,7 +260,7 @@ export default {
 			chartTab = queryOptions.tab || 'views';
 
 			const props = {
-				path: context.pathname,
+				path: context.path,
 				date,
 				chartTab,
 				context,
@@ -311,8 +311,8 @@ export default {
 
 		const activeFilter = find( filters, filter => {
 			return (
-				context.pathname === filter.path ||
-				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
+				context.path === filter.path ||
+				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.path ) )
 			);
 		} );
 
@@ -356,7 +356,7 @@ export default {
 			);
 
 			const props = {
-				path: context.pathname,
+				path: context.path,
 				statsQueryOptions,
 				date,
 				context,


### PR DESCRIPTION
Screen readers couldn't get to the sidebar in Reader because of the
order of layout__primary and layout__secondary columns and the infinite scrolling 

This PR:
  - Reverses the order of those two columns
  - Adds a skip navigation link that gets visible only when it gets focus, e.g. when the user tabs to it by keyboard

It affects my-sites, layout, sidebar, and stats. 

This is how this PR looks in action, I'm just pressing tab on the keyboard during the recording

![navigation-skip](https://user-images.githubusercontent.com/7697632/36646342-16cca9e0-1a7f-11e8-8d38-f2a3f58b0fde.gif)
 