### PR TITLE
Delegate happychat.chat reducer schema validation to framework

### DIFF
--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -71,20 +71,17 @@ const timelineEvent = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case HAPPYCHAT_IO_RECEIVE_MESSAGE:
 			const { message } = action;
-			return Object.assign(
-				{},
-				{
-					id: message.id,
-					source: message.source,
-					message: message.text,
-					name: message.user.name,
-					image: message.user.avatarURL,
-					timestamp: message.timestamp,
-					user_id: message.user.id,
-					type: get( message, 'type', 'message' ),
-					links: get( message, 'meta.links' ),
-				}
-			);
+			return {
+				id: message.id,
+				source: message.source,
+				message: message.text,
+				name: message.user.name,
+				image: message.user.avatarURL,
+				timestamp: message.timestamp,
+				user_id: message.user.id,
+				type: get( message, 'type', 'message' ),
+				links: get( message, 'meta.links' ),
+			};
 	}
 	return state;
 };
@@ -128,19 +125,17 @@ export const timeline = ( state = [], action ) => {
 			} );
 			return sortTimeline(
 				state.concat(
-					map( messages, message => {
-						return Object.assign( {
-							id: message.id,
-							source: message.source,
-							message: message.text,
-							name: message.user.name,
-							image: message.user.picture,
-							timestamp: message.timestamp,
-							user_id: message.user.id,
-							type: get( message, 'type', 'message' ),
-							links: get( message, 'meta.links' ),
-						} );
-					} )
+					map( messages, message => ( {
+						id: message.id,
+						source: message.source,
+						message: message.text,
+						name: message.user.name,
+						image: message.user.picture,
+						timestamp: message.timestamp,
+						user_id: message.user.id,
+						type: get( message, 'type', 'message' ),
+						links: get( message, 'meta.links' ),
+					} ) )
 				)
 			);
 	}

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -6,14 +6,12 @@
  * External dependencies
  */
 import { concat, filter, find, map, get, sortBy, takeRight } from 'lodash';
-import validator from 'is-my-json-valid';
 
 /**
  * Internal dependencies
  */
 import {
 	SERIALIZE,
-	DESERIALIZE,
 	HAPPYCHAT_IO_RECEIVE_MESSAGE,
 	HAPPYCHAT_IO_RECEIVE_STATUS,
 	HAPPYCHAT_IO_REQUEST_TRANSCRIPT_RECEIVE,
@@ -91,7 +89,6 @@ const timelineEvent = ( state = {}, action ) => {
 	return state;
 };
 
-const validateTimeline = validator( timelineSchema );
 const sortTimeline = timeline => sortBy( timeline, event => parseInt( event.timestamp, 10 ) );
 
 /**
@@ -106,12 +103,6 @@ export const timeline = ( state = [], action ) => {
 	switch ( action.type ) {
 		case SERIALIZE:
 			return takeRight( state, HAPPYCHAT_MAX_STORED_MESSAGES );
-		case DESERIALIZE:
-			const valid = validateTimeline( state );
-			if ( valid ) {
-				return state;
-			}
-			return [];
 		case HAPPYCHAT_IO_RECEIVE_MESSAGE:
 			// if meta.forOperator is set, skip so won't show to user
 			if ( get( action, 'message.meta.forOperator', false ) ) {
@@ -155,7 +146,7 @@ export const timeline = ( state = [], action ) => {
 	}
 	return state;
 };
-timeline.hasCustomPersistence = true;
+timeline.schema = timelineSchema;
 
 export default combineReducers( {
 	status,


### PR DESCRIPTION
Instead of directly validating against schema in DESERIALIZE handler, just set a `schema` property on the reducer and let the framework (i.e., `combineReducers`) do the rest. Optimizations from #22521 can be done there.

Only the SERIALIZE custom handler remains.

There is a second drive-by commit that removes unneeded calls to `Object.assign`.