### PR TITLE
UrlSearch: Remove redundant copied code

### DIFF
--- a/client/lib/url-search/index.js
+++ b/client/lib/url-search/index.js
@@ -64,11 +64,6 @@ const UrlSearch = Component =>
 				searchOpen: false !== query,
 			} );
 
-			if ( this.onSearch ) {
-				this.onSearch( query );
-				return;
-			}
-
 			const searchURL = buildSearchUrl( {
 				uri: window.location.href,
 				search: query,


### PR DESCRIPTION
I noticed some code that has been copied from the mixin that I'm fairly sure is redundant now that this functionality has been translated in to a higher-order component.

In the mixin, we were checking for the existence of a `this.onSearch` method on the class which was having the mixin applied to it, with a HoC, `this.onSearch` would not access that same method. The context would be HoC itself, which does not have a `onSearch` method.

As far as I'm aware, achieving the exact same behaviour here wouldn't be quite as simple. We would have to invoke the method on the wrapped component using refs - something we should probably try to avoid doing in this case.

I've decided to remove this code as it advertises behaviour inaccurately. 

Tagging @samouri & @dmsnell as you were last to touch the file it seems, but feel free to sign off :)