### PR TITLE
Defer translation of strings in lib/protect-form

### DIFF
--- a/client/lib/protect-form/index.jsx
+++ b/client/lib/protect-form/index.jsx
@@ -15,10 +15,6 @@ import { includes, without } from 'lodash';
  * Module variables
  */
 const debug = debugModule( 'calypso:protect-form' );
-const confirmText = i18n.translate(
-	'You have unsaved changes. Are you sure you want to leave this page?'
-);
-const beforeUnloadText = i18n.translate( 'You have unsaved changes.' );
 let formsChanged = [];
 let listenerCount = 0;
 
@@ -27,6 +23,7 @@ function warnIfChanged( event ) {
 		return;
 	}
 	debug( 'unsaved form changes detected' );
+	const beforeUnloadText = i18n.translate( 'You have unsaved changes.' );
 	( event || window.event ).returnValue = beforeUnloadText;
 	return beforeUnloadText;
 }
@@ -115,12 +112,22 @@ export class ProtectFormGuard extends Component {
 	}
 }
 
+function windowConfirm() {
+	if ( typeof window === 'undefined' ) {
+		return true;
+	}
+	const confirmText = i18n.translate(
+		'You have unsaved changes. Are you sure you want to leave this page?'
+	);
+	return window.confirm( confirmText );
+}
+
 export const checkFormHandler = ( context, next ) => {
 	if ( ! formsChanged.length ) {
 		return next();
 	}
 	debug( 'unsaved form changes detected' );
-	if ( typeof window === 'undefined' || window.confirm( confirmText ) ) {
+	if ( windowConfirm() ) {
 		formsChanged = [];
 		next();
 	} else {


### PR DESCRIPTION
Call `i18.translate` on modal dialog text only immediately before the modal is actually displayed, not statically at Calypso boot. This has two advantages:

- makes the initial load infinitesimally faster by not translating something rarely displayed.
- a properly localized message is displayed. As translations are loaded asynchronously after initial load, the displayed message when leaving an unsaved form was always in English.

**How to test:**
1. Switch your Calypso to non-English language.
2. Go to `/me/account` and change your email address. Don't save.
3. Click on the "Reader" link in masterbar.
4. Verify that a warning about leaving an unsaved form is displayed and that it has the correct language (i.e., localized)
