### PR TITLE
Domains: Check for privacy support before adding subscription to cart...2nd try.

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -439,6 +439,17 @@ export function businessPlan( slug, properties ) {
 }
 
 /**
+ * Determines whether a domain Item supports purchasing a privacy subscription
+ * @param {string} slug - e.g. domain_reg, dotblog_domain
+ * @param {array} productsList - The list of products retrieved using getProductsList from state/products-list/selectors
+ * @return {boolean} true if the domainItem supports privacy protection purchase
+ */
+export function supportsPrivacyProtectionPurchase( productSlug, productsList ) {
+	const product = find( productsList, [ 'product_slug', productSlug ] ) || {};
+	return get( product, 'is_privacy_protection_product_purchase_allowed', false );
+}
+
+/**
  * Creates a new shopping cart item for a domain.
  *
  * @param {Object} productSlug - the unique string that identifies the product
@@ -1000,6 +1011,7 @@ export default {
 	siteRedirect,
 	shouldBundleDomainWithPlan,
 	spaceUpgradeItem,
+	supportsPrivacyProtectionPurchase,
 	themeItem,
 	unlimitedSpaceItem,
 	unlimitedThemesItem,

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -154,19 +154,22 @@ export function createSiteWithCart(
 			};
 			const addToCartAndProceed = () => {
 				let privacyItem = null;
-				const { product_slug: productSlug } = domainItem;
-				const productsList = getProductsList( reduxStore.getState() );
-				if ( domainItem && supportsPrivacyProtectionPurchase( productSlug, productsList ) ) {
-					if ( isDomainTransfer( domainItem ) ) {
-						privacyItem = cartItems.domainTransferPrivacy( {
-							domain: domainItem.meta,
-							source: 'signup',
-						} );
-					} else {
-						privacyItem = cartItems.domainPrivacyProtection( {
-							domain: domainItem.meta,
-							source: 'signup',
-						} );
+
+				if ( domainItem ) {
+					const { product_slug: productSlug } = domainItem;
+					const productsList = getProductsList( reduxStore.getState() );
+					if ( supportsPrivacyProtectionPurchase( productSlug, productsList ) ) {
+						if ( isDomainTransfer( domainItem ) ) {
+							privacyItem = cartItems.domainTransferPrivacy( {
+								domain: domainItem.meta,
+								source: 'signup',
+							} );
+						} else {
+							privacyItem = cartItems.domainPrivacyProtection( {
+								domain: domainItem.meta,
+								source: 'signup',
+							} );
+						}
 					}
 				}
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -48,15 +48,17 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 		};
 
 		const domainChoiceCart = [ domainItem ];
-		const { product_slug: productSlug } = domainItem;
-		const productsList = getProductsList( reduxStore.getState() );
-		if ( domainItem && supportsPrivacyProtectionPurchase( productSlug, productsList ) ) {
-			domainChoiceCart.push(
-				cartItems.domainPrivacyProtection( {
-					domain: domainItem.meta,
-					source: 'signup',
-				} )
-			);
+		if ( domainItem ) {
+			const { product_slug: productSlug } = domainItem;
+			const productsList = getProductsList( reduxStore.getState() );
+			if ( supportsPrivacyProtectionPurchase( productSlug, productsList ) ) {
+				domainChoiceCart.push(
+					cartItems.domainPrivacyProtection( {
+						domain: domainItem.meta,
+						source: 'signup',
+					} )
+				);
+			}
 		}
 
 		SignupCart.createCart( cartKey, domainChoiceCart, error =>

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -29,6 +29,8 @@ import { getSiteId } from 'state/selectors';
 import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
 import { getUserExperience } from 'state/signup/steps/user-experience/selectors';
 import { requestSites } from 'state/sites/actions';
+import { supportsPrivacyProtectionPurchase } from 'lib/cart-values/cart-items';
+import { getProductsList } from 'state/products-list/selectors';
 
 const debug = debugFactory( 'calypso:signup:step-actions' );
 
@@ -46,7 +48,9 @@ export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
 		};
 
 		const domainChoiceCart = [ domainItem ];
-		if ( domainItem ) {
+		const { product_slug: productSlug } = domainItem;
+		const productsList = getProductsList( reduxStore.getState() );
+		if ( domainItem && supportsPrivacyProtectionPurchase( productSlug, productsList ) ) {
 			domainChoiceCart.push(
 				cartItems.domainPrivacyProtection( {
 					domain: domainItem.meta,
@@ -150,7 +154,9 @@ export function createSiteWithCart(
 			};
 			const addToCartAndProceed = () => {
 				let privacyItem = null;
-				if ( domainItem ) {
+				const { product_slug: productSlug } = domainItem;
+				const productsList = getProductsList( reduxStore.getState() );
+				if ( domainItem && supportsPrivacyProtectionPurchase( productSlug, productsList ) ) {
 					if ( isDomainTransfer( domainItem ) ) {
 						privacyItem = cartItems.domainTransferPrivacy( {
 							domain: domainItem.meta,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#22804 (which reverted #22600)

If a domain doesn't support a privacy subscription we shouldn't add it to the cart. This PR checks domains added to the cart in the signup flow and prevents them from being added if the domain doesn't support a privacy purchase.

Depends on D9363-code.

Build calypso locally and browse to:
calypso.localhost:3000/start/domain-first?new=asdfasdfasdfasdf.blog
Select "New Site".
Repeat, but select "Just Buy A Domain".
For both of these options, when you get to the checkout screen, you should have a privacy subscription in the cart.

Now browse to:
calypso.localhost:3000/start/domain-first?new=asdfasdfasdfasdf.ca
Select "New Site".
Repeat, but select "Just Buy A Domain".
Now you should now have a privacy subscription in the cart since .ca doesn't support purchasing privacy separately. 

Also test to make sure that selecting a free site/plan works as expected. (This is what the problem was with #22600.