### PR TITLE
Fix jetpack site disconnect

### DIFF
--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -204,7 +204,7 @@ class DisconnectJetpack extends PureComponent {
 	};
 
 	handleTryRewind = () => {
-		this.props.recordTracksEvent( 'calypso_disconnect_jetpack_try_rewind' );
+		this.props.recordTracksEventAction( 'calypso_disconnect_jetpack_try_rewind' );
 		page.redirect( `/stats/activity/${ this.props.siteSlug }` );
 	};
 

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -204,9 +204,8 @@ class DisconnectJetpack extends PureComponent {
 	};
 
 	handleTryRewind = () => {
-		const { siteSlug } = this.props;
 		this.props.recordTracksEvent( 'calypso_disconnect_jetpack_try_rewind' );
-		page.redirect( `/stats/activity/${ siteSlug }` );
+		page.redirect( `/stats/activity/${ this.props.siteSlug }` );
 	};
 
 	trackTryRewindHelp = () => {

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -203,7 +203,15 @@ class DisconnectJetpack extends PureComponent {
 		);
 	};
 
-	handleTryRewind = () => this.props.trackTryRewind( this.props.siteSlug );
+	handleTryRewind = () => {
+		const { siteSlug } = this.props;
+		this.props.recordTracksEvent( 'calypso_disconnect_jetpack_try_rewind' );
+		page.redirect( `/stats/activity/${ siteSlug }` );
+	};
+
+	trackTryRewindHelp = () => {
+		this.props.recordTracksEventAction( 'calypso_disconnect_jetpack_try_rewind_help' );
+	};
 
 	render() {
 		const {
@@ -282,7 +290,7 @@ class DisconnectJetpack extends PureComponent {
 						<Button href={ `/stats/activity/${ siteSlug }` } onClick={ this.handleTryRewind }>
 							{ translate( 'Rewind site' ) }
 						</Button>
-						<HappychatButton borderless={ false } onClick={ this.props.trackTryRewindHelp } primary>
+						<HappychatButton borderless={ false } onClick={ this.trackTryRewindHelp } primary>
 							<Gridicon icon="chat" size={ 18 } />
 							{ translate( 'Get help' ) }
 						</HappychatButton>
@@ -305,20 +313,14 @@ export default connect(
 			rewindState: rewindState.state,
 		};
 	},
-	dispatch => ( {
-		setAllSitesSelected: () => dispatch( setAllSitesSelected ),
-		recordGoogleEvent: () => dispatch( recordGoogleEventAction ),
-		recordTracksEvent: () => dispatch( recordTracksEventAction ),
-		disconnect: () => dispatch( disconnect ),
-		successNotice: () => dispatch( successNotice ),
-		errorNotice: () => dispatch( errorNotice ),
-		infoNotice: () => dispatch( infoNotice ),
-		removeNotice: () => dispatch( removeNotice ),
-		trackTryRewind: siteSlug => {
-			dispatch( recordTracksEventAction( 'calypso_disconnect_jetpack_try_rewind' ) );
-			page.redirect( `/stats/activity/${ siteSlug }` );
-		},
-		trackTryRewindHelp: () =>
-			dispatch( recordTracksEventAction( 'calypso_disconnect_jetpack_try_rewind_help' ) ),
-	} )
+	{
+		setAllSitesSelected,
+		recordGoogleEvent: recordGoogleEventAction,
+		recordTracksEvent: recordTracksEventAction,
+		disconnect,
+		successNotice,
+		errorNotice,
+		infoNotice,
+		removeNotice,
+	}
 )( localize( DisconnectJetpack ) );

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -204,12 +204,12 @@ class DisconnectJetpack extends PureComponent {
 	};
 
 	handleTryRewind = () => {
-		this.props.recordTracksEventAction( 'calypso_disconnect_jetpack_try_rewind' );
+		this.props.recordTracksEvent( 'calypso_disconnect_jetpack_try_rewind' );
 		page.redirect( `/stats/activity/${ this.props.siteSlug }` );
 	};
 
 	trackTryRewindHelp = () => {
-		this.props.recordTracksEventAction( 'calypso_disconnect_jetpack_try_rewind_help' );
+		this.props.recordTracksEvent( 'calypso_disconnect_jetpack_try_rewind_help' );
 	};
 
 	render() {

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -242,7 +242,14 @@ class SiteIndicator extends Component {
 		};
 	};
 
-	trackSiteDisconnect = () => this.props.trackSiteDisconnect( this.props.site.ID );
+	trackSiteDisconnect = () => {
+		const siteId = this.props.site.ID;
+		this.props.recordGoogleEvent(
+			'Jetpack',
+			'Clicked in site indicator to start Jetpack Disconnect flow'
+		);
+		this.props.recordTracksEvent( 'calypso_jetpack_site_indicator_disconnect_start', { siteId } );
+	};
 
 	errorAccessing() {
 		const { site, translate } = this.props;
@@ -417,9 +424,7 @@ export default connect(
 	},
 	{
 		updateWordPress,
-		trackSiteDisconnect: siteId => {
-			recordGoogleEvent( 'Jetpack', 'Clicked in site indicator to start Jetpack Disconnect flow' );
-			recordTracksEvent( 'calypso_jetpack_site_indicator_disconnect_start', { siteId } );
-		},
+		recordGoogleEvent,
+		recordTracksEvent,
 	}
 )( localize( SiteIndicator ) );

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -19,13 +19,13 @@ import Animate from 'components/animate';
 import ProgressIndicator from 'components/progress-indicator';
 import Button from 'components/button';
 import analytics from 'lib/analytics';
-import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import QuerySiteConnectionStatus from 'components/data/query-site-connection-status';
-import { canCurrentUser } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getUpdatesBySiteId } from 'state/sites/updates/selectors';
 import { updateWordPress } from 'state/sites/updates/actions';
 import {
+	canCurrentUser,
 	getSiteConnectionStatus,
 	isRequestingSiteConnectionStatus,
 	isSiteAutomatedTransfer,
@@ -242,15 +242,6 @@ class SiteIndicator extends Component {
 		};
 	};
 
-	trackSiteDisconnect = () => {
-		const siteId = this.props.site.ID;
-		this.props.recordGoogleEvent(
-			'Jetpack',
-			'Clicked in site indicator to start Jetpack Disconnect flow'
-		);
-		this.props.recordTracksEvent( 'calypso_jetpack_site_indicator_disconnect_start', { siteId } );
-	};
-
 	errorAccessing() {
 		const { site, translate } = this.props;
 		let accessFailedMessage;
@@ -265,7 +256,7 @@ class SiteIndicator extends Component {
 						compact
 						scary
 						href={ `/settings/disconnect-site/${ site.slug }` }
-						onClick={ this.trackSiteDisconnect }
+						onClick={ this.props.trackSiteDisconnect }
 					>
 						{ translate( 'Remove Site' ) }
 					</Button>
@@ -424,7 +415,13 @@ export default connect(
 	},
 	{
 		updateWordPress,
-		recordGoogleEvent,
-		recordTracksEvent,
+		trackSiteDisconnect: () =>
+			composeAnalytics(
+				recordGoogleEvent(
+					'Jetpack',
+					'Clicked in site indicator to start Jetpack Disconnect flow'
+				),
+				recordTracksEvent( 'calypso_jetpack_site_indicator_disconnect_start' )
+			),
 	}
 )( localize( SiteIndicator ) );


### PR DESCRIPTION
Fixes #22794

Fixes problems that were introduced by PRs #22362 and #22724. The `mapDispatchToProps` arg of `connect()` can only contain action creators, not local methods as was happening here.

@eliorivero can you check that the changes intended by the above PRs are still working ok, in particular the rewind redirect and tracks events?

## Testing
* test as-per #22794
