### PR TITLE
Jetpack Onboarding: Require JPC and introduce intro & success for Business Address

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -225,7 +225,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 							primary
 							type="submit"
 						>
-							{ translate( 'Next Step' ) }
+							{ translate( 'Add address' ) }
 						</Button>
 					</form>
 				</Card>

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -20,6 +20,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormInputValidation from 'components/forms/form-input-validation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QuerySites from 'components/data/query-sites';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
 import { addQueryArgs } from 'lib/route';
@@ -242,7 +243,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 	}
 
 	render() {
-		const { basePath, getForwardUrl, hasBusinessAddress, translate } = this.props;
+		const { basePath, getForwardUrl, hasBusinessAddress, siteId, translate } = this.props;
 
 		return (
 			<div className="steps__main">
@@ -251,6 +252,8 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 					path={ [ basePath, STEPS.BUSINESS_ADDRESS, ':site' ].join( '/' ) }
 					title="Business Address ‹ Jetpack Start"
 				/>
+
+				<QuerySites siteId={ siteId } />
 
 				{ hasBusinessAddress ? (
 					<ConnectSuccess

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -22,7 +22,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
 class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
-	static emptyState = {
+	static emptyFields = {
 		city: '',
 		name: '',
 		state: '',
@@ -31,16 +31,25 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		country: '',
 	};
 
-	state = get( this.props.settings, 'businessAddress' ) || this.constructor.emptyState;
+	state = {
+		fields: get( this.props.settings, 'businessAddress' ) || this.constructor.emptyFields,
+	};
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.isRequestingSettings && ! nextProps.isRequestingSettings ) {
-			this.setState( get( nextProps.settings, 'businessAddress' ) || this.constructor.emptyState );
+			this.setState( {
+				fields: get( nextProps.settings, 'businessAddress' ) || this.constructor.emptyFields,
+			} );
 		}
 	}
 
 	getChangeHandler = field => event => {
-		this.setState( { [ field ]: event.target.value } );
+		this.setState( {
+			fields: {
+				...this.state.fields,
+				[ field ]: event.target.value,
+			},
+		} );
 	};
 
 	fields = this.getFields();
@@ -71,7 +80,8 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 			reduce(
 				this.fields,
 				( eventProps, value, field ) => {
-					const changed = get( settings, [ 'businessAddress', field ] ) !== this.state[ field ];
+					const changed =
+						get( settings, [ 'businessAddress', field ] ) !== this.state.fields[ field ];
 					eventProps[ `${ field }_changed` ] = changed;
 					return eventProps;
 				},
@@ -79,13 +89,13 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 			)
 		);
 
-		this.props.saveJpoSettings( siteId, { businessAddress: this.state } );
+		this.props.saveJpoSettings( siteId, { businessAddress: this.state.fields } );
 
 		page( this.props.getForwardUrl() );
 	};
 
 	hasEmptyFields = () => {
-		return some( omit( this.state, 'state' ), val => val === '' );
+		return some( omit( this.state.fields, 'state' ), val => val === '' );
 	};
 
 	renderForm() {
@@ -110,7 +120,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 					<form onSubmit={ this.handleSubmit }>
 						{ map( this.fields, ( fieldLabel, fieldName ) => {
 							const isValidatingField = ! isRequestingSettings && fieldName !== 'state';
-							const isValidField = this.state[ fieldName ] !== '';
+							const isValidField = this.state.fields[ fieldName ] !== '';
 
 							return (
 								<FormFieldset key={ fieldName }>
@@ -122,7 +132,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 										isError={ isValidatingField && ! isValidField }
 										isValid={ isValidatingField && isValidField }
 										onChange={ this.getChangeHandler( fieldName ) }
-										value={ this.state[ fieldName ] || '' }
+										value={ this.state.fields[ fieldName ] || '' }
 									/>
 									{ isValidatingField &&
 										! isValidField && (

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -140,13 +140,20 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		return some( omit( this.state.fields, 'state' ), val => val === '' );
 	};
 
-	renderActionTile() {
-		const { isConnected, siteUrl, translate } = this.props;
+	renderHeader() {
+		const { translate } = this.props;
 		const headerText = translate( 'Help your customers find you with Jetpack.' );
 		const subHeaderText = translate(
 			"Add your business address and a map of your location with Jetpack's business address widget. " +
 				"You can adjust the widget's location later."
 		);
+
+		return <FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />;
+	}
+
+	renderActionTile() {
+		const { isConnected, siteUrl, translate } = this.props;
+
 		const connectUrl = addQueryArgs(
 			{
 				url: siteUrl,
@@ -160,7 +167,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 
 		return (
 			<Fragment>
-				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+				{ this.renderHeader() }
 
 				<TileGrid>
 					<Tile
@@ -176,14 +183,10 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 
 	renderForm() {
 		const { isRequestingSettings, translate } = this.props;
-		const headerText = translate( 'Help your customers find you with Jetpack.' );
-		const subHeaderText = translate(
-			"Add your business address and a map of your location with Jetpack's business address widget. " +
-				"You can adjust the widget's location later."
-		);
+
 		return (
 			<Fragment>
-				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
+				{ this.renderHeader() }
 
 				<Card className="steps__form">
 					<form onSubmit={ this.handleSubmit }>

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -88,8 +88,8 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		return some( omit( this.state, 'state' ), val => val === '' );
 	};
 
-	render() {
-		const { basePath, isRequestingSettings, translate } = this.props;
+	renderForm() {
+		const { isRequestingSettings, translate } = this.props;
 		const headerText = translate( 'Add a business address.' );
 		const subHeaderText = (
 			<Fragment>
@@ -103,13 +103,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 			</Fragment>
 		);
 		return (
-			<div className="steps__main">
-				<DocumentHead title={ translate( 'Business Address ‹ Jetpack Start' ) } />
-				<PageViewTracker
-					path={ [ basePath, STEPS.BUSINESS_ADDRESS, ':site' ].join( '/' ) }
-					title="Business Address ‹ Jetpack Start"
-				/>
-
+			<Fragment>
 				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
 
 				<Card className="steps__form">
@@ -151,6 +145,22 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 						</Button>
 					</form>
 				</Card>
+			</Fragment>
+		);
+	}
+
+	render() {
+		const { basePath, translate } = this.props;
+
+		return (
+			<div className="steps__main">
+				<DocumentHead title={ translate( 'Business Address ‹ Jetpack Start' ) } />
+				<PageViewTracker
+					path={ [ basePath, STEPS.BUSINESS_ADDRESS, ':site' ].join( '/' ) }
+					title="Business Address ‹ Jetpack Start"
+				/>
+
+				{ this.renderForm() }
 			</div>
 		);
 	}

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -19,6 +19,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormInputValidation from 'components/forms/form-input-validation';
+import JetpackLogo from 'components/jetpack-logo';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySites from 'components/data/query-sites';
 import Tile from 'components/tile-grid/tile';
@@ -252,8 +253,9 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 					path={ [ basePath, STEPS.BUSINESS_ADDRESS, ':site' ].join( '/' ) }
 					title="Business Address ‹ Jetpack Start"
 				/>
-
 				<QuerySites siteId={ siteId } />
+
+				<JetpackLogo full size={ 45 } />
 
 				{ hasBusinessAddress ? (
 					<ConnectSuccess


### PR DESCRIPTION
### Purpose

This PR updates the business address form step to add an intro screen (see #22528), require Jetpack Connect (see #22529) and introduces a success screen (see #22531), as suggested in p6TEKc-1Rd-p2. Uses some of the logic we applied in #22621.

Fixes #22528
Fixes #22529 
Fixes #22531 

### How it works

* The user loads the business address step and sees the intro screen with a CTA.
* Clicking the button will behave differently, depending on whether the site is currently connected or not:
  * If connected, will display the business address form.
  * If not connected, will redirect to Jetpack Connect and will start the connection flow. After finishing connection, will redirect back to same step, but will show the business address form.
* After submitting the business address form successfully, the success screen is presented to the user.
* The success screen will be presented to the user in the event they already have input their business address.

### Notes

**Note 1:** right now, after connecting, Jetpack Connect will not redirect to the business address step. This requires additional changes to Jetpack Connect that we'll handle in a separate PR. This will work by passing a URL parameter to JPC so it knows where to redirect to. That URL will consist of the JPO business address page URL with a `action=add_business_address` parameter, which will update the flow to directly show the form, following the user's original intent to click the "Add a business address" button.

**Note 2:** right now the PR will display the "Skip" links in the footer, contrary to the design mockups - this will be addressed separately, see #22641.

**Note 3:** now it seems to me that the error states that we display initially when showing the business address form are a little counter-intuitive. It would probably make sense for them to appear only when the user has tried to submit the form with 1 or more empty required fields. What do you think @rickybanister @joanrho?

### Preview:

**Business Address step - intro screen**
![](https://cldup.com/iMT8_eHqx2.png)

**Business Address step - form initially displayed**
![](https://cldup.com/cGLg651c_M.png)

**Business Address step - form with filled data**
![](https://cldup.com/clgqBZEVsV.png)

**Business Address step - success screen**
![](https://cldup.com/tfK17VdAUZ.png)

### Testing
* Checkout this branch on your local Calypso.
* Start with a fresh Jetpack site with the latest **Jetpack master**
* Head to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` on the Jetpack site to start the onboarding flow.
* In the site type step, select **Business**.
* Skip steps until you reach the Business Address step.
* Verify the step appears properly as shown on the screenshots.
* Click the **Add a business address** button.
* You will be redirected to Jetpack Connect and connection process will start automatically.
* After connecting, it will redirect you to the default redirection place of JPC (this is expected, see the note above).
* Visit `http://calypso.localhost:3000/jetpack/start/business-address/YOURJETPACKSITE.COM?action=add_business_address` to simulate coming back from Jetpack Connect after a successful connection.
* Verify you can see the business address form.
* Input some data in all of the fields and submit the form.
* Verify you can see the success screen (as shown on the screenshot)
* Verify the contact info widget was inserted in the main sidebar on your remote site.
* Refresh the page and verify you can still see the success screen.
* Verify the **Continue** button leads to the next step.
* Go back to other steps and visit the Business Address step; verify you can still see the success screen.