### PR TITLE
Remove the ambugity from the login form by explicity mentioning that Usernames work too.

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -297,7 +297,7 @@ export class LoginForm extends Component {
 										: this.props.translate( 'Change Username' ) }
 								</a>
 							) : (
-								this.props.translate( 'Email Address' )
+								this.props.translate( 'Email Address or Username' )
 							) }
 						</label>
 


### PR DESCRIPTION
As mentioned in #22289, excluding the mention of Usernames from the form is confusing to users who are used to using a Username to log in.

It also becomes more confusion when we require them to do so for security reasons.

<img width="483" alt="screen shot 2018-02-26 at 08 32 40" src="https://user-images.githubusercontent.com/551898/36679311-2883cc94-1ad0-11e8-9ab9-f350969008ec.png">

I put Username second to keep the emphasis on trying an Email Address first

Fixes #22289