### PR TITLE
Fix Automated Transfer reducer persistence

### DIFF
--- a/client/state/automated-transfer/eligibility/reducer.js
+++ b/client/state/automated-transfer/eligibility/reducer.js
@@ -10,19 +10,25 @@ import { property, sortBy } from 'lodash';
  * Internal dependencies
  */
 import { AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE as UPDATE } from 'state/action-types';
-import { combineReducers } from 'state/utils';
 
-export const eligibilityHolds = ( state = [], action ) =>
-	UPDATE === action.type ? sortBy( action.eligibilityHolds ) : state;
+const initialState = {
+	eligibilityHolds: [],
+	eligibilityWarnings: [],
+	lastUpdate: 0,
+};
 
-export const eligibilityWarnings = ( state = [], action ) =>
-	UPDATE === action.type ? sortBy( action.eligibilityWarnings, property( 'name' ) ) : state;
+const eligibilityReducer = ( state = initialState, action ) => {
+	switch ( action.type ) {
+		case UPDATE:
+			return {
+				eligibilityHolds: sortBy( action.eligibilityHolds ),
+				eligibilityWarnings: sortBy( action.eligibilityWarnings, property( 'name' ) ),
+				lastUpdate: action.lastUpdate,
+			};
+	}
 
-export const lastUpdate = ( state = 0, action ) =>
-	UPDATE === action.type ? action.lastUpdate : state;
+	return state;
+};
+eligibilityReducer.hasCustomPersistence = true; // the parent reducer will verify the schema
 
-export default combineReducers( {
-	eligibilityHolds,
-	eligibilityWarnings,
-	lastUpdate,
-} );
+export default eligibilityReducer;

--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -10,12 +10,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import eligibility from './eligibility/reducer';
-import {
-	combineReducers,
-	keyedReducer,
-	withSchemaValidation,
-	withoutPersistence,
-} from 'state/utils';
+import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
 import { transferStates } from './constants';
 import { automatedTransfer as schema } from './schema';
 import {
@@ -40,8 +35,9 @@ export const status = ( state = null, action ) =>
 		action.type,
 		state
 	);
+status.hasCustomPersistence = true;
 
-export const fetchingStatus = withoutPersistence( ( state = false, action ) => {
+export const fetchingStatus = ( state = false, action ) => {
 	switch ( action.type ) {
 		case REQUEST_STATUS:
 			return true;
@@ -52,7 +48,7 @@ export const fetchingStatus = withoutPersistence( ( state = false, action ) => {
 		default:
 			return state;
 	}
-} );
+};
 
 export const siteReducer = combineReducers( {
 	eligibility,

--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -1,12 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import eligibility from './eligibility/reducer';
@@ -23,18 +17,22 @@ import {
 	THEME_TRANSFER_STATUS_RECEIVE as TRANSFER_UPDATE,
 } from 'state/action-types';
 
-export const status = ( state = null, action ) =>
-	get(
-		{
-			[ ELIGIBILITY_UPDATE ]: state || transferStates.INQUIRING,
-			[ INITIATE ]: transferStates.START,
-			[ INITIATE_FAILURE ]: transferStates.FAILURE,
-			[ SET_STATUS ]: action.status,
-			[ TRANSFER_UPDATE ]: 'complete' === action.status ? transferStates.COMPLETE : state,
-		},
-		action.type,
-		state
-	);
+export const status = ( state = null, action ) => {
+	switch ( action.type ) {
+		case ELIGIBILITY_UPDATE:
+			return state || transferStates.INQUIRING;
+		case INITIATE:
+			return transferStates.START;
+		case INITIATE_FAILURE:
+			return transferStates.FAILURE;
+		case SET_STATUS:
+			return action.status;
+		case TRANSFER_UPDATE:
+			return 'complete' === action.status ? transferStates.COMPLETE : state;
+	}
+
+	return state;
+};
 status.hasCustomPersistence = true;
 
 export const fetchingStatus = ( state = false, action ) => {

--- a/client/state/automated-transfer/test/reducer.js
+++ b/client/state/automated-transfer/test/reducer.js
@@ -9,7 +9,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { transferStates } from '../constants';
-import { status, fetchingStatus } from '../reducer';
+import reducer, { status, fetchingStatus } from '../reducer';
 import {
 	AUTOMATED_TRANSFER_ELIGIBILITY_UPDATE as ELIGIBILITY_UPDATE,
 	AUTOMATED_TRANSFER_STATUS_REQUEST as REQUEST_STATUS,
@@ -47,20 +47,32 @@ describe( 'state', () => {
 
 					expect( fetchingStatus( null, action ) ).to.be.true;
 				} );
+			} );
 
-				test( "should never persist whether it's fetching status", () => {
-					expect(
-						fetchingStatus( true, {
-							type: SERIALIZE,
-						} )
-					).to.be.undefined;
+			test( 'should persist all state keys except fetchingStatus', () => {
+				const SITE_ID = 12345;
+				const AT_STATE = {
+					[ SITE_ID ]: {
+						status: 'backfilling',
+						eligibility: {
+							eligibilityHolds: [],
+							eligibilityWarnings: [],
+							lastUpdate: 1000000000,
+						},
+						fetchingStatus: true,
+					},
+				};
 
-					expect(
-						fetchingStatus( true, {
-							type: DESERIALIZE,
-						} )
-					).to.be.false;
-				} );
+				const serialized = reducer( AT_STATE, { type: SERIALIZE } );
+				expect( serialized[ SITE_ID ] ).to.have.property( 'status' );
+				expect( serialized[ SITE_ID ] ).to.have.property( 'eligibility' );
+				expect( serialized[ SITE_ID ] ).to.not.have.property( 'fetchingStatus' );
+
+				const deserialized = reducer( AT_STATE, { type: DESERIALIZE } );
+				expect( deserialized[ SITE_ID ] ).to.have.property( 'status' );
+				expect( deserialized[ SITE_ID ] ).to.have.property( 'eligibility' );
+				// The non-persisted property has default value, persisted value is ignored
+				expect( deserialized[ SITE_ID ] ).to.have.property( 'fetchingStatus', false );
 			} );
 		} );
 	} );


### PR DESCRIPTION
When working on the persistence optimizations, I discovered that the AT reducer doesn't have the expected persistence behavior, i.e., ignoring the `fetchingStatus` property and persisting everything else. This PR fixes that.

First, I update the unit test for the reducer to correctly test the behavior and start failing accordingly.

Then I fix the persistence in a few easy steps.

**How to test:**
- run the unit tests
- run an automated transfer on a site... @lamosty will hopefully remember the gotchas to watch for. Part of the functionality is coming from the Store NUX project, isn't it?