### PR TITLE
Me: Fix sidebar and sidebar-footer scrolling behavior

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -118,10 +118,10 @@ class MeSidebar extends React.Component {
 				<SidebarRegion>
 					<ProfileGravatar user={ this.props.currentUser } />
 
-					<div className="me-sidebar__signout">
+					<div className="sidebar__me-signout">
 						<Button
 							compact
-							className="me-sidebar__signout-button"
+							className="sidebar__me-signout-button"
 							onClick={ this.onSignOut }
 							title={ translate( 'Sign out of WordPress.com', { textOnly: true } ) }
 						>

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -19,6 +19,7 @@ import SidebarFooter from 'layout/sidebar/footer';
 import SidebarHeading from 'layout/sidebar/heading';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
+import SidebarRegion from 'layout/sidebar/region';
 import userFactory from 'lib/user';
 import userUtilities from 'lib/user/utils';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -114,97 +115,103 @@ class MeSidebar extends React.Component {
 
 		return (
 			<Sidebar>
-				<ProfileGravatar user={ this.props.currentUser } />
-				<div className="me-sidebar__signout">
-					<Button
-						compact
-						className="me-sidebar__signout-button"
-						onClick={ this.onSignOut }
-						title={ translate( 'Sign out of WordPress.com', { textOnly: true } ) }
-					>
-						{ translate( 'Sign Out' ) }
-					</Button>
-				</div>
-				<SidebarMenu>
-					<SidebarHeading>{ translate( 'Profile' ) }</SidebarHeading>
-					<ul>
-						<SidebarItem
-							selected={ selected === 'profile' }
-							link={
-								config.isEnabled( 'me/my-profile' ) ? '/me' : '//wordpress.com/me/public-profile'
-							}
-							label={ translate( 'My Profile' ) }
-							icon="user"
-							onNavigate={ this.onNavigate }
-						/>
+				<SidebarRegion>
+					<ProfileGravatar user={ this.props.currentUser } />
 
-						<SidebarItem
-							selected={ selected === 'account' }
-							link={
-								config.isEnabled( 'me/account' ) ? '/me/account' : '//wordpress.com/me/account'
-							}
-							label={ translate( 'Account Settings' ) }
-							icon="cog"
-							onNavigate={ this.onNavigate }
-							preloadSectionName="account"
-						/>
+					<div className="me-sidebar__signout">
+						<Button
+							compact
+							className="me-sidebar__signout-button"
+							onClick={ this.onSignOut }
+							title={ translate( 'Sign out of WordPress.com', { textOnly: true } ) }
+						>
+							{ translate( 'Sign Out' ) }
+						</Button>
+					</div>
 
-						<SidebarItem
-							selected={ selected === 'purchases' }
-							link={ purchasesRoot }
-							label={ translate( 'Manage Purchases' ) }
-							icon="credit-card"
-							onNavigate={ this.onNavigate }
-							preloadSectionName="purchases"
-						/>
-
-						<SidebarItem
-							selected={ selected === 'security' }
-							link={ '/me/security' }
-							label={ translate( 'Security' ) }
-							icon="lock"
-							onNavigate={ this.onNavigate }
-							preloadSectionName="security"
-						/>
-
-						{ config.isEnabled( 'me/privacy' ) && (
+					<SidebarMenu>
+						<SidebarHeading>{ translate( 'Profile' ) }</SidebarHeading>
+						<ul>
 							<SidebarItem
-								selected={ selected === 'privacy' }
-								link={ '/me/privacy' }
-								label={ translate( 'Privacy' ) }
-								icon="visible"
+								selected={ selected === 'profile' }
+								link={
+									config.isEnabled( 'me/my-profile' ) ? '/me' : '//wordpress.com/me/public-profile'
+								}
+								label={ translate( 'My Profile' ) }
+								icon="user"
 								onNavigate={ this.onNavigate }
-								preloadSectionName="privacy"
 							/>
-						) }
 
-						<SidebarItem
-							selected={ selected === 'notifications' }
-							link={
-								config.isEnabled( 'me/notifications' )
-									? '/me/notifications'
-									: '//wordpress.com/me/notifications'
-							}
-							label={ translate( 'Notification Settings' ) }
-							icon="bell"
-							onNavigate={ this.onNavigate }
-							preloadSectionName="notification-settings"
-						/>
-					</ul>
-				</SidebarMenu>
-				<SidebarMenu>
-					<SidebarHeading>{ translate( 'Special' ) }</SidebarHeading>
-					<ul>
-						<SidebarItem
-							selected={ selected === 'get-apps' }
-							link={ '/me/get-apps' }
-							label={ translate( 'Get Apps' ) }
-							icon="my-sites"
-							onNavigate={ this.onNavigate }
-						/>
-						{ this.renderNextStepsItem( selected ) }
-					</ul>
-				</SidebarMenu>
+							<SidebarItem
+								selected={ selected === 'account' }
+								link={
+									config.isEnabled( 'me/account' ) ? '/me/account' : '//wordpress.com/me/account'
+								}
+								label={ translate( 'Account Settings' ) }
+								icon="cog"
+								onNavigate={ this.onNavigate }
+								preloadSectionName="account"
+							/>
+
+							<SidebarItem
+								selected={ selected === 'purchases' }
+								link={ purchasesRoot }
+								label={ translate( 'Manage Purchases' ) }
+								icon="credit-card"
+								onNavigate={ this.onNavigate }
+								preloadSectionName="purchases"
+							/>
+
+							<SidebarItem
+								selected={ selected === 'security' }
+								link={ '/me/security' }
+								label={ translate( 'Security' ) }
+								icon="lock"
+								onNavigate={ this.onNavigate }
+								preloadSectionName="security"
+							/>
+
+							{ config.isEnabled( 'me/privacy' ) && (
+								<SidebarItem
+									selected={ selected === 'privacy' }
+									link={ '/me/privacy' }
+									label={ translate( 'Privacy' ) }
+									icon="visible"
+									onNavigate={ this.onNavigate }
+									preloadSectionName="privacy"
+								/>
+							) }
+
+							<SidebarItem
+								selected={ selected === 'notifications' }
+								link={
+									config.isEnabled( 'me/notifications' )
+										? '/me/notifications'
+										: '//wordpress.com/me/notifications'
+								}
+								label={ translate( 'Notification Settings' ) }
+								icon="bell"
+								onNavigate={ this.onNavigate }
+								preloadSectionName="notification-settings"
+							/>
+						</ul>
+					</SidebarMenu>
+
+					<SidebarMenu>
+						<SidebarHeading>{ translate( 'Special' ) }</SidebarHeading>
+						<ul>
+							<SidebarItem
+								selected={ selected === 'get-apps' }
+								link={ '/me/get-apps' }
+								label={ translate( 'Get Apps' ) }
+								icon="my-sites"
+								onNavigate={ this.onNavigate }
+							/>
+							{ this.renderNextStepsItem( selected ) }
+						</ul>
+					</SidebarMenu>
+				</SidebarRegion>
+
 				<SidebarFooter />
 			</Sidebar>
 		);

--- a/client/me/sidebar/style.scss
+++ b/client/me/sidebar/style.scss
@@ -1,8 +1,5 @@
 .sidebar__me-signout {
 	flex-shrink: 0;	// these are required for the flexed sidebar to not implode in Safari
-}
-
-.sidebar__me-signout {
 	display: flex;
 	justify-content: center;
 	margin: 0 0 16px;

--- a/client/me/sidebar/style.scss
+++ b/client/me/sidebar/style.scss
@@ -1,8 +1,8 @@
-.me-sidebar__signout {
+.sidebar__me-signout {
 	flex-shrink: 0;	// these are required for the flexed sidebar to not implode in Safari
 }
 
-.me-sidebar__signout {
+.sidebar__me-signout {
 	display: flex;
 	justify-content: center;
 	margin: 0 0 16px;

--- a/client/me/sidebar/style.scss
+++ b/client/me/sidebar/style.scss
@@ -1,7 +1,3 @@
-.is-group-me .sidebar {
-	padding-top: 16px;
-}
-
 .me-sidebar__signout {
 	flex-shrink: 0;	// these are required for the flexed sidebar to not implode in Safari
 }
@@ -14,6 +10,7 @@
 
 .sidebar .profile-gravatar {
 	flex-shrink: 0;
+	margin-top: 16px;
 }
 
 // Hide Support Chat link, the item intentionally only exists for mobile users, and is accessible from the footer


### PR DESCRIPTION
The sidebar on `/me` doesn't behave like the rest of the sidebars in Calypso — specifically, the sidebar-footer isn't fixed to the bottom of the browser. Here's a GIF from production:

![me sidebar before](https://user-images.githubusercontent.com/191598/36682303-c16684f2-1ae8-11e8-8501-e8a893ceb8fc.gif)

This PR fixes it by adding `SidebarRegion` to the `/me` sidebar, which adds the magic to allow for a fixed sidebar-footer. Here's a GIF of the after:

![me sidebar after](https://user-images.githubusercontent.com/191598/36682353-d83ad138-1ae8-11e8-81b7-c98ba3a8cf33.gif)
