### PR TITLE
Store Services - fixed the package dimensions input units

### DIFF
--- a/client/extensions/woocommerce/components/form-dimensions-input/index.jsx
+++ b/client/extensions/woocommerce/components/form-dimensions-input/index.jsx
@@ -26,7 +26,7 @@ class FormDimensionsInput extends Component {
 		className: PropTypes.string,
 		dimensions: PropTypes.shape( {
 			width: PropTypes.string,
-			height: PropTypes.sting,
+			height: PropTypes.string,
 			length: PropTypes.string,
 		} ),
 		dimensionsUnit: PropTypes.string,

--- a/client/extensions/woocommerce/components/form-dimensions-input/index.jsx
+++ b/client/extensions/woocommerce/components/form-dimensions-input/index.jsx
@@ -29,6 +29,7 @@ class FormDimensionsInput extends Component {
 			height: PropTypes.sting,
 			length: PropTypes.string,
 		} ),
+		dimensionsUnit: PropTypes.string,
 		onChange: PropTypes.func.isRequired,
 		noWrap: PropTypes.bool,
 	};
@@ -91,10 +92,12 @@ class FormDimensionsInput extends Component {
 	}
 }
 
-function mapStateToProps( state ) {
+function mapStateToProps( state, { dimensionsUnit } ) {
 	const site = getSelectedSiteWithFallback( state );
-	const dimensionsUnitSetting = site && getDimensionsUnitSetting( state, site.ID );
-	const dimensionsUnit = ( dimensionsUnitSetting && dimensionsUnitSetting.value ) || 'in';
+	if ( ! dimensionsUnit ) {
+		const dimensionsUnitSetting = site && getDimensionsUnitSetting( state, site.ID );
+		dimensionsUnit = ( dimensionsUnitSetting && dimensionsUnitSetting.value ) || 'in';
+	}
 
 	return {
 		siteId: site && site.ID,

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
@@ -22,7 +22,7 @@ import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affi
 import FieldError from '../../components/field-error';
 import inputFilters from './input-filters';
 
-const renderDimensionsInput = ( dimensionsName, dimensionsStr, updateField ) => {
+const renderDimensionsInput = ( dimensionsName, dimensionsStr, dimensionsUnit, updateField ) => {
 	const { length, width, height } = inputFilters.parseDimensions( dimensionsStr );
 	const onChange = event => {
 		const name = event.target.name;
@@ -35,7 +35,13 @@ const renderDimensionsInput = ( dimensionsName, dimensionsStr, updateField ) => 
 		updateField( dimensionsName, allDimensions.join( ' x ' ) );
 	};
 
-	return <FormDimensionsInput dimensions={ { width, height, length } } onChange={ onChange } />;
+	return (
+		<FormDimensionsInput
+			dimensionsUnit={ dimensionsUnit }
+			dimensions={ { width, height, length } }
+			onChange={ onChange }
+		/>
+	);
 };
 
 const OuterDimensionsToggle = ( { siteId, toggleOuterDimensions, translate } ) => {
@@ -132,7 +138,12 @@ const EditPackage = props => {
 						args: { dimensionUnit },
 					} ) }
 				</FormLabel>
-				{ renderDimensionsInput( 'inner_dimensions', inner_dimensions, updateField ) }
+				{ renderDimensionsInput(
+					'inner_dimensions',
+					inner_dimensions,
+					dimensionUnit,
+					updateField
+				) }
 				{ fieldInfo( 'inner_dimensions' ) }
 				{ ! isOuterDimensionsVisible ? (
 					<OuterDimensionsToggle { ...{ siteId, toggleOuterDimensions, translate } } />
@@ -145,7 +156,12 @@ const EditPackage = props => {
 							args: { dimensionUnit },
 						} ) }
 					</FormLabel>
-					{ renderDimensionsInput( 'outer_dimensions', outer_dimensions, updateField ) }
+					{ renderDimensionsInput(
+						'outer_dimensions',
+						outer_dimensions,
+						dimensionUnit,
+						updateField
+					) }
 					{ fieldInfo( 'outer_dimensions' ) }
 				</FormFieldset>
 			) : null }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-services/issues/1314

Added an optional `dimensionsUnit` prop to `FormDimensionsInput`. If it's not provided, then the component will retrieve the units from the WooCommerce extension state tree. Otherwise the passed units will be used.

To test:
* everything should work the same on Calypso. The dimensions input on packages dialog and product pages should display the right units.
* `npm link` Calypso to the local WooCommerce Services
* Set the store length unit to something other than inches
* The packages dialog should display the right length unit