### PR TITLE
Site Address Changer: Show a notice if logged in user cannot manage the domain

### DIFF
--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -122,6 +122,22 @@ export class SimpleSiteRenameForm extends Component {
 		const isDisabled =
 			! domainFieldValue || !! domainFieldError || domainFieldValue === currentDomainPrefix;
 
+		if ( ! currentDomain.currentUserCanManage ) {
+			return (
+				<div className="simple-site-rename-form simple-site-rename-form__only-owner-info">
+					<Gridicon icon="info" />
+					{ translate( 'Only the site owner%(ownerInfo)s can edit this domain name.', {
+						args: {
+							ownerInfo: isEmpty( currentDomain.owner )
+								? ''
+								: ` ({{strong}}${ currentDomain.owner }{{/strong}})`,
+						},
+						components: { strong: <strong /> },
+					} ) }
+				</div>
+			);
+		}
+
 		return (
 			<div className="simple-site-rename-form">
 				<ConfirmationDialog

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -125,15 +125,16 @@ export class SimpleSiteRenameForm extends Component {
 		if ( ! currentDomain.currentUserCanManage ) {
 			return (
 				<div className="simple-site-rename-form simple-site-rename-form__only-owner-info">
-					<Gridicon icon="info" />
-					{ translate( 'Only the site owner%(ownerInfo)s can edit this domain name.', {
-						args: {
-							ownerInfo: isEmpty( currentDomain.owner )
-								? ''
-								: ` ({{strong}}${ currentDomain.owner }{{/strong}})`,
-						},
-						components: { strong: <strong /> },
-					} ) }
+					<Gridicon icon="info-outline" />
+					{ isEmpty( currentDomain.owner )
+						? translate( 'Only the site owner can edit this domain name.' )
+						: translate(
+								'Only the site owner ({{strong}}%(ownerInfo)s{{/strong}}) can edit this domain name.',
+								{
+									args: { ownerInfo: currentDomain.owner },
+									components: { strong: <strong /> },
+								}
+							) }
 				</div>
 			);
 		}

--- a/client/blocks/simple-site-rename-form/style.scss
+++ b/client/blocks/simple-site-rename-form/style.scss
@@ -50,6 +50,13 @@
 	}
 }
 
+.simple-site-rename-form__only-owner-info {
+	.gridicon {
+		float: left;
+		margin-right: 5px;
+	}
+}
+
 .simple-site-rename-form__footer {
 	align-items: center;
 	border-top-color: $gray-light;

--- a/client/blocks/simple-site-rename-form/style.scss
+++ b/client/blocks/simple-site-rename-form/style.scss
@@ -51,9 +51,20 @@
 }
 
 .simple-site-rename-form__only-owner-info {
+	margin: 0 auto 10px;
+	padding: 16px;
+
+	@include breakpoint( '<660px' ) {
+		margin: 0;
+	}
+
 	.gridicon {
 		float: left;
-		margin-right: 5px;
+		margin: auto 12px auto 10px;
+
+		@include breakpoint( '<660px' ) {
+			margin: auto 6px auto 4px;
+		}
 	}
 }
 

--- a/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
@@ -57,7 +57,7 @@ const WpcomDomain = createReactClass( {
 						status="is-info"
 						showDismiss={ false }
 						text={ translate(
-							'The site name can only be changed by the site owner. Please contact them if you would like to change it.'
+							'The site address can only be changed by the site owner. Please contact them if you would like to change it.'
 						) }
 					/>
 				);

--- a/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { flow, get } from 'lodash';
+import { flow, get, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -46,20 +46,21 @@ const WpcomDomain = createReactClass( {
 		if ( isEnabled( 'site-address-editor' ) && get( domain, 'type' ) === domainTypes.WPCOM ) {
 			if ( ! domain.currentUserCanManage ) {
 				return (
-					/**
-					 * See: `NonOwnerCard` for other `domain.currentUserCanManage` usage
-					 * Unfortunately, we don't know the domain owner here & the above component takes an annotated list of domains.
-					 * @TODO Derive the owner from the state tree and display them so customers know who to contact.
-					 * @TODO Should this be a more basic `<Card />` instead of a `<Notice />` or wrapped in one?
-					 * @TODO Finalize copy
-					 */
-					<Notice
-						status="is-info"
-						showDismiss={ false }
-						text={ translate(
-							'The site address can only be changed by the site owner. Please contact them if you would like to change it.'
+					<Notice status="is-info" showDismiss={ false }>
+						{ translate(
+							'The site address can only be changed by the site owner. ' +
+								'Please contact them if you would like to change it.',
+							{ components: { br: <br /> } }
 						) }
-					/>
+						{ ! isEmpty( domain.owner ) && (
+							<p>
+								{ translate( 'Owner: {{em}}%(owner)s{{/em}}', {
+									args: { owner: domain.owner },
+									components: { em: <em /> },
+								} ) }
+							</p>
+						) }
+					</Notice>
 				);
 			}
 

--- a/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { flow, get, isEmpty } from 'lodash';
+import { flow, get } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -16,7 +16,6 @@ import { isEnabled } from 'config';
 import analyticsMixin from 'lib/mixins/analytics';
 import Card from 'components/card';
 import Header from './card/header';
-import Notice from 'components/notice';
 import Property from './card/property';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
@@ -34,7 +33,7 @@ const WpcomDomain = createReactClass( {
 	},
 
 	getEditSiteAddressBlock() {
-		const { domain, translate } = this.props;
+		const { domain } = this.props;
 
 		/**
 		 * Hide Edit site address for .blog subdomains as this is unsupported for now.
@@ -44,26 +43,6 @@ const WpcomDomain = createReactClass( {
 		}
 
 		if ( isEnabled( 'site-address-editor' ) && get( domain, 'type' ) === domainTypes.WPCOM ) {
-			if ( ! domain.currentUserCanManage ) {
-				return (
-					<Notice status="is-info" showDismiss={ false }>
-						{ translate(
-							'The site address can only be changed by the site owner. ' +
-								'Please contact them if you would like to change it.',
-							{ components: { br: <br /> } }
-						) }
-						{ ! isEmpty( domain.owner ) && (
-							<p>
-								{ translate( 'Owner: {{em}}%(owner)s{{/em}}', {
-									args: { owner: domain.owner },
-									components: { em: <em /> },
-								} ) }
-							</p>
-						) }
-					</Notice>
-				);
-			}
-
 			return <SiteRenamer currentDomain={ domain } />;
 		}
 

--- a/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
@@ -16,6 +16,7 @@ import { isEnabled } from 'config';
 import analyticsMixin from 'lib/mixins/analytics';
 import Card from 'components/card';
 import Header from './card/header';
+import Notice from 'components/notice';
 import Property from './card/property';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
@@ -33,7 +34,7 @@ const WpcomDomain = createReactClass( {
 	},
 
 	getEditSiteAddressBlock() {
-		const { domain } = this.props;
+		const { domain, translate } = this.props;
 
 		/**
 		 * Hide Edit site address for .blog subdomains as this is unsupported for now.
@@ -43,6 +44,25 @@ const WpcomDomain = createReactClass( {
 		}
 
 		if ( isEnabled( 'site-address-editor' ) && get( domain, 'type' ) === domainTypes.WPCOM ) {
+			if ( ! domain.currentUserCanManage ) {
+				return (
+					/**
+					 * See: `NonOwnerCard` for other `domain.currentUserCanManage` usage
+					 * Unfortunately, we don't know the domain owner here & the above component takes an annotated list of domains.
+					 * @TODO Derive the owner from the state tree and display them so customers know who to contact.
+					 * @TODO Should this be a more basic `<Card />` instead of a `<Notice />` or wrapped in one?
+					 * @TODO Finalize copy
+					 */
+					<Notice
+						status="is-info"
+						showDismiss={ false }
+						text={ translate(
+							'The site name can only be changed by the site owner. Please contact them if you would like to change it.'
+						) }
+					/>
+				);
+			}
+
 			return <SiteRenamer currentDomain={ domain } />;
 		}
 


### PR DESCRIPTION
When the logged-in user does not have the appropriate capabilities, we let them know:

<img width="745" alt="screen shot 2018-03-23 at 3 45 41 pm" src="https://user-images.githubusercontent.com/1587282/37851189-50c69586-2eb4-11e8-8e7a-daab5e5a89db.png">

## To Test

* Run D11173-code & sandbox the API
* Run this branch in the dev env
* Visit http://calypso.localhost:3000/domains/manage/
* Select a *.wordpress.com site your account owns
* Drill into the domain to manage it
* You should see the UI to rename the site

* Repeat the above with a site where you're an admin, but do not own
* You should **Not** see the rename UI & see a notice instead. **

~~** This is not currently the case. On sites where I'm an admin, but not an owner, `domain. currentUserCanManage` is `true`. Investigating why.~~