### PR TITLE
Disconnect: move tracking logic to connect

### DIFF
--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -10,7 +10,6 @@ import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -22,9 +21,10 @@ import QueryRewindState from 'components/data/query-rewind-state';
 import {
 	recordGoogleEvent as recordGoogleEventAction,
 	recordTracksEvent as recordTracksEventAction,
+	withAnalytics,
 } from 'state/analytics/actions';
 import { disconnect } from 'state/jetpack/connection/actions';
-import { setAllSitesSelected } from 'state/ui/actions';
+import { setAllSitesSelected, navigate } from 'state/ui/actions';
 import { successNotice, errorNotice, infoNotice, removeNotice } from 'state/notices/actions';
 import { getPlanClass } from 'lib/plans/constants';
 import { getSiteSlug, getSiteTitle, getSitePlanSlug } from 'state/sites/selectors';
@@ -203,14 +203,7 @@ class DisconnectJetpack extends PureComponent {
 		);
 	};
 
-	handleTryRewind = () => {
-		this.props.recordTracksEvent( 'calypso_disconnect_jetpack_try_rewind' );
-		page.redirect( `/stats/activity/${ this.props.siteSlug }` );
-	};
-
-	trackTryRewindHelp = () => {
-		this.props.recordTracksEvent( 'calypso_disconnect_jetpack_try_rewind_help' );
-	};
+	handleTryRewind = () => this.props.trackTryRewind( this.props.siteSlug );
 
 	render() {
 		const {
@@ -286,10 +279,8 @@ class DisconnectJetpack extends PureComponent {
 						{ translate( 'Experiencing connection issues? Try to go back and rewind your site.' ) }
 					</p>
 					<div className="disconnect-jetpack__try-rewind-button-wrap">
-						<Button href={ `/stats/activity/${ siteSlug }` } onClick={ this.handleTryRewind }>
-							{ translate( 'Rewind site' ) }
-						</Button>
-						<HappychatButton borderless={ false } onClick={ this.trackTryRewindHelp } primary>
+						<Button onClick={ this.handleTryRewind }>{ translate( 'Rewind site' ) }</Button>
+						<HappychatButton borderless={ false } onClick={ this.props.trackTryRewindHelp } primary>
 							<Gridicon icon="chat" size={ 18 } />
 							{ translate( 'Get help' ) }
 						</HappychatButton>
@@ -321,5 +312,12 @@ export default connect(
 		errorNotice,
 		infoNotice,
 		removeNotice,
+		trackTryRewind: siteSlug =>
+			withAnalytics(
+				recordTracksEventAction( 'calypso_disconnect_jetpack_try_rewind' ),
+				navigate( `/stats/activity/${ siteSlug }` )
+			),
+		trackTryRewindHelp: () =>
+			recordTracksEventAction( 'calypso_disconnect_jetpack_try_rewind_help' ),
 	}
 )( localize( DisconnectJetpack ) );


### PR DESCRIPTION
#### Testing

1. create a new site in [jurassic.ninja](https://jurassic.ninja)
2. connect Jetpack
3. in the connection process, choose a Personal plan so you get Rewind and pay with credits
4. get the SSH creds for the jurassic site in the WP Admin
5. go to `/settings/security/YOUR-SITE.jurassic.ninja` and enter the creds in the Backups and Security scans form
6. finally, go to `/settings/disconnect-site/confirm/YOUR-SITE.jurassic.ninja`

You should get a block like this (Happychat button won't be shown in calypso.localhost:3000 but it's working fine and tracking the event):

<img width="416" alt="captura de pantalla 2018-02-26 a la s 16 20 39" src="https://user-images.githubusercontent.com/1041600/36690418-02f30d78-1b11-11e8-95b2-1082ac1f3b7a.png">

Clicking the button should track the event and navigate to Activity Log again