### PR TITLE
Add momentum scrolling for plans screen

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -440,7 +440,9 @@ $plan-features-sidebar-width: 272px;
 
 .plans-wrapper {
 	margin: 0 auto;
-	overflow-y: auto;
+	overflow-y: scroll;
+	-webkit-overflow-scrolling: touch;
+	height: 100%;
 	padding: 20px 0 10px;
     transform: translateY(-20px);
 }


### PR DESCRIPTION
Related to this: https://github.com/Automattic/wp-calypso/issues/22774

This PR improves plan scrolling on iOS devices. 

## Testing
- Visit `https://calypso.live/?branch=fix/plan-scrolling` on a iOs device
- Start the signup process: `/start`
- Make your way to the plans screen and scroll the plans left/right. 

I will address some of the other issues documented [here]( https://github.com/Automattic/wp-calypso/issues/22774) in other PRs

cc @lancewillett @shaunandrews 