### PR TITLE
Store: Fix Country change issue in Settings

### DIFF
--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -69,9 +69,6 @@ class AddressView extends Component {
 	onChangeCountry = event => {
 		// First, always forward the country event through
 		this.props.onChange( event );
-
-		// Then, send a second onChange to clear state
-		this.props.onChange( { target: { name: 'state', value: '' } } );
 	};
 
 	getCountryData = () => {


### PR DESCRIPTION
This branch fixes #22822 

In my testing, the second call to `props.onChange()` was un-setting the country value change, and resulting in the new country never being selected. Since the parent component [has logic](https://github.com/Automattic/wp-calypso/blob/master/client/extensions/woocommerce/components/store-address/index.js#L57) to reset the state also, seems like the solution here should be fine.

__To Test__
- Open a store settings page
- Click Edit Address
- Change the country and verify it is updated in the form.

@allendav we don't have to merge this if you want to incorporate the fix in one of your PRs, just figured i'd push this up just in case.