### PR TITLE
Site Renamer: Add Tracks events for user interactions:

### DIFF
--- a/client/blocks/simple-site-rename-form/dialog.jsx
+++ b/client/blocks/simple-site-rename-form/dialog.jsx
@@ -14,6 +14,7 @@ import Gridicon from 'gridicons';
 import Dialog from 'components/dialog';
 import FormLabel from 'components/forms/form-label';
 import FormInputCheckbox from 'components/forms/form-checkbox';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 class SiteRenamerConfirmationDialog extends PureComponent {
 	static propTypes = {
@@ -84,6 +85,10 @@ class SiteRenamerConfirmationDialog extends PureComponent {
 				buttons={ buttons }
 				onClose={ this.onClose }
 			>
+				<TrackComponentView
+					eventName="calypso_siterename_areyousure_view"
+					eventProperties={ { new_domain: newDomainName } }
+				/>
 				<h1>{ translate( "Let's Review" ) }</h1>
 				<p>
 					{ translate(

--- a/client/blocks/simple-site-rename-form/index.jsx
+++ b/client/blocks/simple-site-rename-form/index.jsx
@@ -18,6 +18,7 @@ import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affi
 import FormInputValidation from 'components/forms/form-input-validation';
 import ConfirmationDialog from './dialog';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import TrackComponentView from 'lib/analytics/track-component-view';
 import { requestSiteRename } from 'state/site-rename/actions';
 import { isRequestingSiteRename } from 'state/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -131,6 +132,7 @@ export class SimpleSiteRenameForm extends Component {
 					onConfirm={ this.onConfirm }
 				/>
 				<form onSubmit={ this.onSubmit }>
+					<TrackComponentView eventName="calypso_siterename_form_view" />
 					<Card className="simple-site-rename-form__content">
 						<FormSectionHeading>{ translate( 'Edit Site Address' ) }</FormSectionHeading>
 						<FormTextInputWithAffixes


### PR DESCRIPTION
* Component views for:
  * The renamer UI
  * The "areyousure" modal
* Actions taken:
  * Request a site to be renamed
  * Receive an error when attempting to rename
  * Successfully rename a site

In addition, I combined the identical error handling functions for brevity.

## To Test:

* Run this branch
* Open your network inspector
* Filter on requests like "t.gif"
* Make sure to select `Preserve log` (so requests do not disappear on a route change)
* Run through applicable flows
* You should see appropriate tracks event pixels
* You should see events get recorded (eventually)

## Questions:

* Did I capture all the appropriate interactions?
* Are any additional props required?
* Does the combined error handler work and dispatch appropriate props