### PR TITLE
Activity Log: align the item type with the top of the foldable card

### DIFF
--- a/client/my-sites/stats/activity-log-item/style.scss
+++ b/client/my-sites/stats/activity-log-item/style.scss
@@ -79,7 +79,7 @@
 	align-self: flex-start;
 	background: $gray-light;
 	text-align: center;
-	margin: -2px 22px 0 10px;
+	margin: 1px 22px 0 10px;
 	padding: 4px 0 6px;
 	z-index: 1;
 


### PR DESCRIPTION
This PR corrects the top margin for the AL item type so it aligns with the upper edge of the foldable card.

### Before

<img width="280" alt="captura de pantalla 2018-02-26 a la s 19 25 44" src="https://user-images.githubusercontent.com/1041600/36699404-4217cf7e-1b2b-11e8-9441-d957527635aa.png">

### After

<img width="265" alt="captura de pantalla 2018-02-26 a la s 19 26 55" src="https://user-images.githubusercontent.com/1041600/36699407-44e4dfee-1b2b-11e8-88d7-5021b23fda3f.png">

### Notes

While I tested with 0 for top margin, it was too on the edge, so for a little optical correction, I used 1. Feel free to set it to 0 if you consider it's better.

<img width="275" alt="captura de pantalla 2018-02-26 a la s 19 26 28" src="https://user-images.githubusercontent.com/1041600/36699456-6e5fca6e-1b2b-11e8-8359-ea19371980b3.png">
