### PR TITLE
Stats: d3base component: reference new props on componentWillReceiveP…

### DIFF
--- a/client/extensions/woocommerce/components/d3/base/index.js
+++ b/client/extensions/woocommerce/components/d3/base/index.js
@@ -28,8 +28,8 @@ export default class D3Base extends Component {
 		this.updateParams();
 	}
 
-	componentWillReceiveProps() {
-		this.updateParams();
+	componentWillReceiveProps( nextProps ) {
+		this.updateParams( nextProps );
 	}
 
 	componentDidUpdate() {
@@ -41,8 +41,8 @@ export default class D3Base extends Component {
 		delete this.node;
 	}
 
-	updateParams() {
-		const { getParams } = this.props;
+	updateParams( nextProps ) {
+		const getParams = ( nextProps && nextProps.getParams ) || this.props.getParams;
 		this.setState( getParams( this.node ), this.draw );
 	}
 


### PR DESCRIPTION
### Issue: Base Component not updating on new props
As new props are passed down, old `props.drawChart` functions are executed with outdated parameters. As a result, the UI does not reflect changes.

### Fix: Update with nextProps
`updateParams` to use `nextProps` instead of current props, if available. `nextProps` holds a reference to the latest parameters calculated