### PR TITLE
Activity Log: Continue fetching multi-page results

### DIFF
--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -25,6 +25,12 @@ export const DEFAULT_GRIDICON = 'info-outline';
  */
 export function transformer( apiResponse ) {
 	const orderedItems = get( apiResponse, [ 'current', 'orderedItems' ], [] );
+	const nextPage =
+		apiResponse.page &&
+		apiResponse.totalPages &&
+		apiResponse.page < apiResponse.totalPages &&
+		apiResponse.page + 1;
+
 	return Object.assign(
 		{
 			items: map( orderedItems, processItem ),
@@ -32,6 +38,7 @@ export function transformer( apiResponse ) {
 			totalItems: get( apiResponse, [ 'totalItems' ], orderedItems.length ),
 		},
 		apiResponse.nextAfter && { nextAfter: apiResponse.nextAfter },
+		nextPage && { nextPage },
 		apiResponse.prevBefore && { prevBefore: apiResponse.prevBefore }
 	);
 }

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -25,11 +25,6 @@ export const DEFAULT_GRIDICON = 'info-outline';
  */
 export function transformer( apiResponse ) {
 	const orderedItems = get( apiResponse, [ 'current', 'orderedItems' ], [] );
-	const nextPage =
-		apiResponse.page &&
-		apiResponse.totalPages &&
-		apiResponse.page < apiResponse.totalPages &&
-		apiResponse.page + 1;
 
 	return Object.assign(
 		{
@@ -37,9 +32,7 @@ export function transformer( apiResponse ) {
 			oldestItemTs: get( apiResponse, [ 'oldestItemTs' ], Infinity ),
 			totalItems: get( apiResponse, [ 'totalItems' ], orderedItems.length ),
 		},
-		apiResponse.nextAfter && { nextAfter: apiResponse.nextAfter },
-		nextPage && { nextPage },
-		apiResponse.prevBefore && { prevBefore: apiResponse.prevBefore }
+		apiResponse.nextAfter && { nextAfter: apiResponse.nextAfter }
 	);
 }
 

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -130,7 +130,7 @@ export const continuePolling = ( { dispatch, getState }, action ) => {
 
 			const meta = { meta: { dataLayer: { isWatching: true } } };
 			const searchAfter = nextAfter || thisState.nextAfter;
-			const number = nextAfter ? 100 : 1;
+			const number = nextAfter ? 100 : 1; // if we didn't get a new `nextAfter` then force one through the limit
 			const sortOrder = 'asc';
 
 			if ( searchAfter ) {

--- a/client/state/data-layer/wpcom/sites/activity/index.js
+++ b/client/state/data-layer/wpcom/sites/activity/index.js
@@ -15,7 +15,6 @@ import { dispatchRequestEx, getData, getError } from 'state/data-layer/wpcom-htt
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getActivityLogs } from 'state/selectors';
 
 const POLL_INTERVAL = 8000;
 const pollingSites = new Map();
@@ -47,11 +46,18 @@ export const togglePolling = ( { dispatch, getState }, { isWatching, siteId } ) 
 	pollingSites.set( siteId, {} );
 
 	// kick off the first polling
+	//
+	// we start by grabbing one event - this is a result of the way
+	// that the backend is currently sending events with truncated
+	// timestamps. we end up always getting the latest event in the
+	// response. therefore, by setting a number of one we'll get that
+	// event initially and it will return a `nextAfter` value which
+	// we'll subsequently use to poll with a higher `number` value
 	dispatch(
 		merge(
 			activityLogRequest( siteId, {
 				dateStart: Date.now(),
-				number: 100,
+				number: 1,
 				sortOrder: 'asc',
 			} ),
 			{ meta: { dataLayer: { isWatching: true } } }
@@ -85,9 +91,7 @@ export const togglePolling = ( { dispatch, getState }, { isWatching, siteId } ) 
  */
 export const continuePolling = ( { dispatch, getState }, action ) => {
 	// ignore any updates which weren't triggered by the polling system
-	// and don't let page X of Y updates reset our polling state;
-	// they are continuations of previous activity here
-	if ( ! get( action, 'meta.dataLayer.isWatching' ) || get( action, 'params.page', 1 ) > 1 ) {
+	if ( ! get( action, 'meta.dataLayer.isWatching' ) ) {
 		return;
 	}
 
@@ -126,34 +130,18 @@ export const continuePolling = ( { dispatch, getState }, action ) => {
 
 			const meta = { meta: { dataLayer: { isWatching: true } } };
 			const searchAfter = nextAfter || thisState.nextAfter;
+			const number = nextAfter ? 100 : 1;
+			const sortOrder = 'asc';
 
 			if ( searchAfter ) {
-				dispatch(
-					merge(
-						activityLogRequest( siteId, { searchAfter, number: 100, sortOrder: 'asc' } ),
-						meta
-					)
-				);
+				dispatch( merge( activityLogRequest( siteId, { searchAfter, number, sortOrder } ), meta ) );
 				return;
 			}
 
-			// use a specific value from the returned sort order
-			// right now this is highly coupled to the API response
-			// @TODO make sort order work properly here
-			const newestActivity = ( newest, next ) => Math.max( newest, next.activityTs );
-			const events = getActivityLogs( getState(), siteId ) || [];
-			const dateStart = events.reduce( newestActivity, -Infinity );
-
-			dispatch(
-				merge(
-					activityLogRequest( siteId, {
-						dateStart: dateStart > -Infinity ? dateStart : Date.now(),
-						number: 100,
-						sortOrder: 'asc',
-					} ),
-					meta
-				)
-			);
+			// if we have no sort order after which to search
+			// then we resort to the previous timestamp
+			const { dateStart } = action.params;
+			dispatch( merge( activityLogRequest( siteId, { dateStart, number, sortOrder } ), meta ) );
 		}, POLL_INTERVAL );
 
 		pollingSites.set( siteId, {
@@ -180,7 +168,6 @@ export const handleActivityLogRequest = action => {
 					group: params.group,
 					name: params.name,
 					number: params.number,
-					page: params.page,
 					search_after: JSON.stringify( params.searchAfter ),
 					sort_order: params.sortOrder,
 				},
@@ -200,12 +187,18 @@ export const receiveActivityLog = ( action, data ) => {
 		action.params
 	);
 
-	if ( ! data.hasOwnProperty( 'nextPage' ) ) {
+	// if we have no further pages to fetch (nothing more to do)
+	// or if we are receiving a polling action (polling will handle next action)
+	// then let it be and inject into state
+	if ( ! data.hasOwnProperty( 'nextAfter' ) || get( action, 'meta.dataLayer.isWatching' ) ) {
 		return stateUpdate;
 	}
 
 	return [
-		activityLogRequest( action.siteId, merge( {}, action.params, { page: data.nextPage } ) ),
+		activityLogRequest(
+			action.siteId,
+			merge( {}, action.params, { searchAfter: data.nextAfter } )
+		),
 		stateUpdate,
 	];
 };


### PR DESCRIPTION
It has been possible that we have more results in a request to
the Activity Log than would fit in the requests number of events
for a single page. Previously we have been ignoring everything
past the first page.

In this patch we're looking at the API results and if there are
more pages of results we will start a loop to fetch those in
sequence by passing the `page` parameter for what should be the
next page.

**Testing**

Modify the source to page for results with `number: 10` in the
`sites/activity/index.js` file in the data layer. I used the following to
enforce that for testing: `number: Math.min( 10, params.number )`
around line 175.

When loading results with more than one page this branch should
sent out the requests sequentially as soon as one comes back. In
**master** only the first page should ever load.

---

In the process of working on this PR I discovered a bug in the server
which would send string values for pages when a specific page above
the first was requested. That was resolved in r170668-wpcom.