### PR TITLE
Notes Formatted Block: Render `link` type ranges

### DIFF
--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -34,6 +34,7 @@ export const FormattedBlock = ( { content = {} } ) => {
 
 	switch ( type ) {
 		case 'a':
+		case 'link':
 			return <a href={ content.url }>{ descent }</a>;
 
 		case 'b':


### PR DESCRIPTION
Previously when the `FormattedBlock` was introduced it was built
to render links denoted as type `a` blocks, however the parser renders
blocks with `url`s as a `link` type block.

This change allows the formatter to treat both types of ranges as the
same thing because they should both have a `url` property intended to
create a link.

**Testing**

The way I tested this was by injecting a fake Activity Log event into Calypso
which had the link range. The parser converted it to a `link` type which is
probably more right than `a`.

In **master** there was no link where there should have been. In this branch
the link appeared.

```js
fakeContent = {
    "text": "This is A LINK",
    "ranges": [ { "url": "https://wordpress.com", "indices": [ 8, 12 ]  } ]
}

dispatch( {
	type: 'ACTIVITY_LOG_REQUEST',
	params: { number: 100 },
	siteId: YOUR_SITE_HERE,
	meta: {
		dataLayer: {
			data: {
				// FAKE DATA HERE
				// use the API response of an actual call for data
				// prune `body.current.orderedItems` to last event
				// and replace `content` with the fakeContent
			}
		},
	}
})
```