### PR TITLE
JPC: restart the remote install flow for empty site data.

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -56,6 +56,14 @@ export class OrgCredentialsForm extends Component {
 		this.props.jetpackRemoteInstall( siteToConnect, this.state.username, this.state.password );
 	};
 
+	componentWillMount() {
+		const { siteToConnect } = this.props;
+
+		if ( ! siteToConnect ) {
+			page.redirect( '/jetpack/connect' );
+		}
+	}
+
 	componentDidUpdate() {
 		const { installError, isResponseCompleted, siteToConnect } = this.props;
 

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -3,6 +3,7 @@
  * Component which handle remote credentials for installing Jetpack
  */
 import React, { Component } from 'react';
+import config from 'config';
 import Gridicon from 'gridicons';
 import page from 'page';
 import { connect } from 'react-redux';
@@ -57,10 +58,12 @@ export class OrgCredentialsForm extends Component {
 	};
 
 	componentWillMount() {
-		const { siteToConnect } = this.props;
+		if ( config.isEnabled( 'jetpack/connect/remote-install' ) ) {
+			const { siteToConnect } = this.props;
 
-		if ( ! siteToConnect ) {
-			page.redirect( '/jetpack/connect' );
+			if ( ! siteToConnect ) {
+				page.redirect( '/jetpack/connect' );
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR prevents access to the remote credentials form when accessing `/jetpack/connect/install` route directly and redirects to the start of the remote install flow.

**To test:**
- Checkout this branch on local Calypso,
- Access `calypso.localhost:3000/jetpack/connect/install`
- Verify immediate redirect to `calypso.localhost:3000/jetpack/connect`