### PR TITLE
Remove `productsList` flux store from `/domain-management`

### DIFF
--- a/client/components/data/domain-management/email/index.jsx
+++ b/client/components/data/domain-management/email/index.jsx
@@ -51,7 +51,6 @@ class EmailData extends React.Component {
 	static propTypes = {
 		component: PropTypes.func.isRequired,
 		context: PropTypes.object.isRequired,
-		productsList: PropTypes.object.isRequired,
 		selectedDomainName: PropTypes.string,
 		selectedSite: PropTypes.object.isRequired,
 		sitePlans: PropTypes.object.isRequired,

--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -13,12 +13,13 @@ import { connect } from 'react-redux';
 import StoreConnection from 'components/data/store-connection';
 import DomainsStore from 'lib/domains/store';
 import CartStore from 'lib/cart/store';
-import observe from 'lib/mixins/data-observe';
 import { fetchDomains } from 'lib/upgrades/actions';
+import QueryProducts from 'components/data/query-products-list';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
+import { getProductsList } from 'state/products-list/selectors';
 
 const stores = [ DomainsStore, CartStore ];
 
@@ -45,8 +46,6 @@ const DomainManagementData = createReactClass( {
 		sitePlans: PropTypes.object.isRequired,
 	},
 
-	mixins: [ observe( 'productsList' ) ],
-
 	componentWillMount: function() {
 		const { selectedSite } = this.props;
 
@@ -67,11 +66,12 @@ const DomainManagementData = createReactClass( {
 	render: function() {
 		return (
 			<div>
+				<QueryProducts />
 				<StoreConnection
 					component={ this.props.component }
 					stores={ stores }
 					getStateFromStores={ getStateFromStores }
-					products={ this.props.productsList.get() }
+					products={ this.props.productsList }
 					selectedDomainName={ this.props.selectedDomainName }
 					selectedSite={ this.props.selectedSite }
 					sitePlans={ this.props.sitePlans }
@@ -87,10 +87,12 @@ const DomainManagementData = createReactClass( {
 
 const mapStateToProps = state => {
 	const selectedSite = getSelectedSite( state );
+	const productsList = getProductsList( state );
 
 	return {
 		sitePlans: getPlansBySite( state, selectedSite ),
 		selectedSite,
+		productsList,
 	};
 };
 

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -30,15 +30,12 @@ import {
 	domainManagementPrivacyProtection,
 	domainManagementRedirectSettings,
 } from 'my-sites/domains/paths';
-import ProductsList from 'lib/products-list';
 import SiteRedirectData from 'components/data/domain-management/site-redirect';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import TransferData from 'components/data/domain-management/transfer';
 import WhoisData from 'components/data/domain-management/whois';
 import { decodeURIComponentIfValid } from 'lib/url';
-
-const productsList = new ProductsList();
 
 export default {
 	domainManagementList( pageContext, next ) {
@@ -122,7 +119,6 @@ export default {
 		pageContext.primary = (
 			<EmailData
 				component={ DomainManagement.Email }
-				productsList={ productsList }
 				selectedDomainName={ pageContext.params.domain }
 				context={ pageContext }
 			/>

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -45,11 +45,7 @@ export default {
 		analytics.pageView.record( domainManagementList( ':site' ), 'Domain Management' );
 
 		pageContext.primary = (
-			<DomainManagementData
-				component={ DomainManagement.List }
-				context={ pageContext }
-				productsList={ productsList }
-			/>
+			<DomainManagementData component={ DomainManagement.List } context={ pageContext } />
 		);
 		next();
 	},
@@ -67,7 +63,6 @@ export default {
 			<DomainManagementData
 				component={ component }
 				context={ pageContext }
-				productsList={ productsList }
 				selectedDomainName={ decodeURIComponentIfValid( pageContext.params.domain ) }
 			/>
 		);
@@ -205,7 +200,6 @@ export default {
 			<DomainManagementData
 				component={ DomainManagement.AddGoogleApps }
 				context={ pageContext }
-				productsList={ productsList }
 				selectedDomainName={ pageContext.params.domain }
 			/>
 		);


### PR DESCRIPTION
About to ✈️, so a better description will come once I land.

It seems that we have redux state ready to go here, allowing us to replace the usage of flux & the `observe` mixin throughout domain-management.
I'll also be looking at other areas to see if we can remove it completely (my guess is that we can).