### PR TITLE
Domains: Checkout form State and Post Code fields merge at narrow widths

### DIFF
--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -2,16 +2,14 @@
 
 	margin-bottom: 0;
 
-
 	.contact-details-form-fields__container.country-code,
 	.contact-details-form-fields__container.state {
-
 		label + select {
 			width: 100%;
 		}
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint( '>660px' ) {
 		.contact-details-form-fields__container {
 			position: relative;
 			float: left;
@@ -43,13 +41,13 @@
 		.contact-details-form-fields__field.city,
 		.contact-details-form-fields__field.postal-code,
 		.contact-details-form-fields__field.state {
-			width: calc( 33% - 8px );
+			width: calc( 33% - 7px );
 			float: left;
 		}
 
 		.contact-details-form-fields__field.postal-code,
 		.contact-details-form-fields__field.state {
-			margin-left: 14px;
+			margin-left: 12px;
 		}
 
 		.domain-management-form-footer {
@@ -110,7 +108,7 @@
 	select {
 		font-size: 15px;
 		width: 100%;
-		min-width: 180px;
+		min-width: 100px;
 	}
 
 }

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -11,7 +11,7 @@
 		}
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint( '>960px' ) {
 		.contact-details-form-fields__container {
 			position: relative;
 			float: left;
@@ -57,7 +57,6 @@
 		}
 
 		.g-apps-fieldset {
-
 			.country {
 				margin-top: 15px;
 				width: calc( 66% - 8px  );
@@ -111,6 +110,7 @@
 	select {
 		font-size: 15px;
 		width: 100%;
+		min-width: 180px;
 	}
 
 }

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -146,17 +146,19 @@ export class DomainDetailsForm extends PureComponent {
 		);
 	}
 
-	renderSubmitButton() {
-		const continueText = this.hasAnotherStep()
+	getSubmitButtonText() {
+		return this.hasAnotherStep()
 			? this.props.translate( 'Continue' )
 			: this.props.translate( 'Continue to Checkout' );
+	}
 
+	renderSubmitButton() {
 		return (
 			<FormButton
 				className="checkout__domain-details-form-submit-button"
 				onClick={ this.handleSubmitButtonClick }
 			>
-				{ continueText }
+				{ this.getSubmitButtonText() }
 			</FormButton>
 		);
 	}
@@ -179,7 +181,7 @@ export class DomainDetailsForm extends PureComponent {
 	renderDomainContactDetailsFields() {
 		const { contactDetails, translate } = this.props;
 		const labelTexts = {
-			submitButton: translate( 'Continue' ),
+			submitButton: this.getSubmitButtonText(),
 			organization: translate(
 				'Registering this domain for a company? + Add Organization Name',
 				'Registering these domains for a company? + Add Organization Name',


### PR DESCRIPTION
This PR address #22833 by:

1. Reintroducing the correct button label when there are no further steps in the checkout process (_Continue to Checkout_)
2. Adjusting the breakpoint to ensure that the form fields and their contents fit in the viewport

<img width="760" alt="screen shot 2018-02-27 at 12 13 52 pm" src="https://user-images.githubusercontent.com/6458278/36705282-69e91534-1bb8-11e8-9a54-97090ad44062.png">


## Testing
1. Add a `.com` domain to your cart and head to checkout
2. Adjust the viewport width to `<960px`
3. Add a `.ca` domain to your cart and head to checkout

### Expectations
**At 1:** The button text should read _Continue to Checkout_
**At 2:** The form fields should fit the container and not overlap one another
**At 3:** The button text should read _Continue_ since there is another step in the checkout process

