### PR TITLE
Extract credit card list item into reusable component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -98,6 +98,7 @@
 @import 'components/checklist/style';
 @import 'components/clipboard-button-input/style';
 @import 'components/count/style';
+@import 'components/credit-card/style';
 @import 'components/credit-card-form-fields/style';
 @import 'components/date-picker/style';
 @import 'components/dialog/style';
@@ -451,7 +452,6 @@
 @import 'my-sites/themes/themes-banner/style';
 @import 'my-sites/upgrade-nudge/style';
 @import 'my-sites/checkout/cart/style';
-@import 'my-sites/checkout/checkout/stored-card';
 @import 'my-sites/checkout/checkout/style';
 @import 'my-sites/checkout/checkout/subscription-text';
 @import 'my-sites/checkout/checkout-thank-you/style';

--- a/client/components/credit-card/README.md
+++ b/client/components/credit-card/README.md
@@ -1,0 +1,4 @@
+CreditCard
+==============
+
+The `CreditCard` React component serves as a container for a selectable credit card list item, and can display a stored credit card (passed as `card` prop).

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -1,0 +1,40 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import StoredCard from './stored-card';
+
+class CreditCard extends React.Component {
+	handleKeyPress = event => {
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			this.props.onClick && this.props.onClick( event );
+		}
+	};
+
+	render() {
+		const { card, selected, onClick, className, children } = this.props;
+		const classes = classNames( 'credit-card', className, { selected } );
+		const content = card ? <StoredCard card={ card } /> : children;
+		const role = onClick ? 'radio' : 'listitem';
+
+		return (
+			<div
+				className={ classes }
+				role={ role }
+				onClick={ onClick }
+				onKeyPress={ this.handleKeyPress }
+			>
+				{ content }
+			</div>
+		);
+	}
+}
+
+export default CreditCard;

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -5,13 +5,21 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
-import StoredCard from './stored-card';
+import StoredCard, { cardType } from './stored-card';
 
 class CreditCard extends React.Component {
+	static propTypes = {
+		card: cardType,
+		selected: PropTypes.bool,
+		onClick: PropTypes.func,
+		className: PropTypes.string,
+	};
+
 	handleKeyPress = event => {
 		if ( event.key === 'Enter' || event.key === ' ' ) {
 			this.props.onClick && this.props.onClick( event );

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -16,27 +16,27 @@ class CreditCard extends React.Component {
 	static propTypes = {
 		card: cardType,
 		selected: PropTypes.bool,
-		onClick: PropTypes.func,
+		onSelect: PropTypes.func,
 		className: PropTypes.string,
 	};
 
 	handleKeyPress = event => {
 		if ( event.key === 'Enter' || event.key === ' ' ) {
-			this.props.onClick && this.props.onClick( event );
+			this.props.onSelect && this.props.onSelect( event );
 		}
 	};
 
 	render() {
-		const { card, selected, onClick, className, children } = this.props;
-		const classes = classNames( 'credit-card', className, { selected, selectable: onClick } );
+		const { card, selected, onSelect, className, children } = this.props;
+		const classes = classNames( 'credit-card', className, { selected, selectable: onSelect } );
 		const content = card ? <StoredCard card={ card } /> : children;
-		const role = onClick ? 'radio' : 'listitem';
+		const role = onSelect ? 'radio' : 'listitem';
 
 		return (
 			<div
 				className={ classes }
 				role={ role }
-				onClick={ onClick }
+				onClick={ onSelect }
 				onKeyPress={ this.handleKeyPress }
 			>
 				{ content }

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -29,17 +29,15 @@ class CreditCard extends React.Component {
 	render() {
 		const { card, selected, onSelect, className, children } = this.props;
 		const classes = classNames( 'credit-card', className, { selected, selectable: onSelect } );
-		const content = card ? <StoredCard card={ card } /> : children;
-		const role = onSelect ? 'radio' : 'listitem';
 
 		return (
 			<div
 				className={ classes }
-				role={ role }
+				role={ onSelect ? 'radio' : 'listitem' }
 				onClick={ onSelect }
 				onKeyPress={ this.handleKeyPress }
 			>
-				{ content }
+				{ card ? <StoredCard card={ card } /> : children }
 			</div>
 		);
 	}

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -33,6 +33,7 @@ class CreditCard extends React.Component {
 		return onSelect ? (
 			<div
 				className={ classes }
+				tabIndex={ -1 }
 				role="radio"
 				aria-checked={ selected }
 				onClick={ onSelect }

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -22,7 +22,7 @@ class CreditCard extends React.Component {
 
 	handleKeyPress = event => {
 		if ( event.key === 'Enter' || event.key === ' ' ) {
-			this.props.onSelect && this.props.onSelect( event );
+			this.props.onSelect( event );
 		}
 	};
 
@@ -30,15 +30,18 @@ class CreditCard extends React.Component {
 		const { card, selected, onSelect, className, children } = this.props;
 		const classes = classNames( 'credit-card', className, { selected, selectable: onSelect } );
 
-		return (
+		return onSelect ? (
 			<div
 				className={ classes }
-				role={ onSelect ? 'radio' : 'listitem' }
+				role="radio"
+				aria-checked={ selected }
 				onClick={ onSelect }
 				onKeyPress={ this.handleKeyPress }
 			>
 				{ card ? <StoredCard card={ card } /> : children }
 			</div>
+		) : (
+			<div className={ classes }>{ card ? <StoredCard card={ card } /> : children }</div>
 		);
 	}
 }

--- a/client/components/credit-card/index.jsx
+++ b/client/components/credit-card/index.jsx
@@ -20,7 +20,7 @@ class CreditCard extends React.Component {
 
 	render() {
 		const { card, selected, onClick, className, children } = this.props;
-		const classes = classNames( 'credit-card', className, { selected } );
+		const classes = classNames( 'credit-card', className, { selected, selectable: onClick } );
 		const content = card ? <StoredCard card={ card } /> : children;
 		const role = onClick ? 'radio' : 'listitem';
 

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -13,7 +13,7 @@ export const getCreditCardSummary = ( translate, type, digits ) => {
 	const supportedTypes = {
 		amex: translate( 'American Express' ),
 		discover: translate( 'Discover' ),
-		mastercard: translate( 'MasterCard' ),
+		mastercard: translate( 'Mastercard' ),
 		visa: translate( 'VISA' ),
 		diners: translate( 'Diners Club' ),
 		jcb: translate( 'JCB' ),

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -5,10 +5,22 @@
  */
 
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
+export const cardType = PropTypes.shape( {
+	stored_details_id: PropTypes.string,
+	card: PropTypes.string,
+	card_type: PropTypes.string,
+	name: PropTypes.string,
+	expiry: PropTypes.string,
+} );
+
 class StoredCard extends React.Component {
+	static propTypes = {
+		card: cardType,
+	};
+
 	render() {
 		var card = this.props.card,
 			expirationDate = this.props.moment( card.expiry ).format( 'MM/YY' ),

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -9,8 +9,6 @@ import React from 'react';
 import { localize } from 'i18n-calypso';
 
 class StoredCard extends React.Component {
-	static displayName = 'StoredCard';
-
 	render() {
 		var card = this.props.card,
 			expirationDate = this.props.moment( card.expiry ).format( 'MM/YY' ),

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -44,17 +44,20 @@ class StoredCard extends React.Component {
 	};
 
 	render() {
-		var card = this.props.card,
-			expirationDate = this.props.moment( card.expiry ).format( 'MM/YY' ),
-			cardClasses = classNames( 'stored-card', card.card_type && card.card_type.toLowerCase() );
+		const card = this.props.card;
+		const expirationDate = this.props.moment( card.expiry ).format( 'MM/YY' );
+		const cardClasses = classNames(
+			'credit-card__stored-card',
+			card.card_type && card.card_type.toLowerCase()
+		);
 
 		return (
 			<div className={ cardClasses }>
-				<span className="stored-card__number">
+				<span className="credit-card__stored-card-number">
 					{ getCreditCardSummary( this.props.translate, card.card_type, card.card ) }
 				</span>
-				<span className="stored-card__name">{ card.name }</span>
-				<span className="stored-card__expiration-date">
+				<span className="credit-card__stored-card-name">{ card.name }</span>
+				<span className="credit-card__stored-card-expiration-date">
 					{ this.props.translate( 'Expires %(date)s', {
 						args: { date: expirationDate },
 						context: 'date is of the form MM/YY',

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
@@ -46,7 +47,7 @@ class StoredCard extends React.Component {
 	render() {
 		var card = this.props.card,
 			expirationDate = this.props.moment( card.expiry ).format( 'MM/YY' ),
-			cardClasses = 'stored-card ' + card.card_type.toLowerCase();
+			cardClasses = classNames( 'stored-card', card.card_type && card.card_type.toLowerCase() );
 
 		return (
 			<div className={ cardClasses }>

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -8,6 +8,26 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
+export const getPaymentMethodTitle = ( translate, paymentType, digits ) => {
+	const supportedTypes = {
+		amex: translate( 'American Express' ),
+		discover: translate( 'Discover' ),
+		mastercard: translate( 'MasterCard' ),
+		visa: translate( 'VISA' ),
+	};
+
+	if ( ! digits ) {
+		return supportedTypes[ paymentType ];
+	}
+
+	return translate( '%(card_type)s ****%(digits)s', {
+		args: {
+			card_type: supportedTypes[ paymentType ] || paymentType,
+			digits,
+		},
+	} );
+};
+
 export const cardType = PropTypes.shape( {
 	stored_details_id: PropTypes.string,
 	card: PropTypes.string,
@@ -29,7 +49,7 @@ class StoredCard extends React.Component {
 		return (
 			<div className={ cardClasses }>
 				<span className="stored-card__number">
-					{ card.card_type } ****{ card.card }
+					{ getPaymentMethodTitle( this.props.translate, card.card_type, card.card ) }
 				</span>
 				<span className="stored-card__name">{ card.name }</span>
 				<span className="stored-card__expiration-date">

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -8,23 +8,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
-export const getPaymentMethodTitle = ( translate, paymentType, digits ) => {
+export const getCreditCardSummary = ( translate, type, digits ) => {
 	const supportedTypes = {
 		amex: translate( 'American Express' ),
 		discover: translate( 'Discover' ),
 		mastercard: translate( 'MasterCard' ),
 		visa: translate( 'VISA' ),
+		diners: translate( 'Diners Club' ),
+		jcb: translate( 'JCB' ),
+		unionpay: translate( 'UnionPay' ),
 	};
 
+	const displayType = supportedTypes[ type && type.toLowerCase() ] || type;
+
 	if ( ! digits ) {
-		return supportedTypes[ paymentType ];
+		return displayType;
 	}
 
-	return translate( '%(card_type)s ****%(digits)s', {
-		args: {
-			card_type: supportedTypes[ paymentType ] || paymentType,
-			digits,
-		},
+	return translate( '%(displayType)s ****%(digits)s', {
+		args: { displayType, digits },
 	} );
 };
 
@@ -49,7 +51,7 @@ class StoredCard extends React.Component {
 		return (
 			<div className={ cardClasses }>
 				<span className="stored-card__number">
-					{ getPaymentMethodTitle( this.props.translate, card.card_type, card.card ) }
+					{ getCreditCardSummary( this.props.translate, card.card_type, card.card ) }
 				</span>
 				<span className="stored-card__name">{ card.name }</span>
 				<span className="stored-card__expiration-date">

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -32,7 +32,6 @@ export const getCreditCardSummary = ( translate, type, digits ) => {
 };
 
 export const cardType = PropTypes.shape( {
-	stored_details_id: PropTypes.string,
 	card: PropTypes.string,
 	card_type: PropTypes.string,
 	name: PropTypes.string,

--- a/client/components/credit-card/stored-card.scss
+++ b/client/components/credit-card/stored-card.scss
@@ -57,7 +57,7 @@
 	background-image: url('/calypso/images/upgrades/cc-unionpay-disabled.svg');
 }
 
-.selected > .payment-box-section-inner {
+.credit-card.selected {
 	.stored-card.visa {
 		background-image: url('/calypso/images/upgrades/cc-visa.svg');
 	}
@@ -73,7 +73,6 @@
 	.stored-card.discover {
 		background-image: url('/calypso/images/upgrades/cc-discover.svg');
 	}
-
 
 	.stored-card.diners {
 		background-image: url('/calypso/images/upgrades/cc-diners.svg');

--- a/client/components/credit-card/stored-card.scss
+++ b/client/components/credit-card/stored-card.scss
@@ -13,6 +13,7 @@
 
 	.stored-card__name {
 		color: $gray-darken-10;
+		margin-right: 10px;
 	}
 
 	.stored-card__number {

--- a/client/components/credit-card/stored-card.scss
+++ b/client/components/credit-card/stored-card.scss
@@ -1,7 +1,7 @@
 // Credit Card Payment Box
 // -----------------------------------
 
-.stored-card {
+.credit-card__stored-card {
 	background-image: url('/calypso/images/upgrades/cc-visa-disabled.svg');
 	background-position: 18px center;
 	background-repeat: no-repeat;
@@ -11,18 +11,18 @@
 	justify-content: space-between;
 	padding: 15px 15px 15px 95px;
 
-	.stored-card__name {
+	.credit-card__stored-card-name {
 		color: $gray-darken-10;
 		margin-right: 10px;
 	}
 
-	.stored-card__number {
+	.credit-card__stored-card-number {
 		color: $gray-dark;
 		flex-basis: 100%;
 		font-weight: 600;
 	}
 
-	.stored-card__expiration-date {
+	.credit-card__stored-card-expiration-date {
 		color: $gray-darken-10;
 		font-style: italic;
 		opacity: 0.7;
@@ -30,60 +30,60 @@
 	}
 }
 
-.stored-card.visa {
+.credit-card__stored-card.visa {
 	background-image: url('/calypso/images/upgrades/cc-visa-disabled.svg');
 }
 
-.stored-card.mastercard {
+.credit-card__stored-card.mastercard {
 	background-image: url('/calypso/images/upgrades/cc-mastercard-disabled.svg');
 }
 
-.stored-card.amex {
+.credit-card__stored-card.amex {
 	background-image: url('/calypso/images/upgrades/cc-amex-disabled.svg');
 }
 
-.stored-card.discover {
+.credit-card__stored-card.discover {
 	background-image: url('/calypso/images/upgrades/cc-discover-disabled.svg');
 }
 
-.stored-card.diners {
+.credit-card__stored-card.diners {
 	background-image: url('/calypso/images/upgrades/cc-diners-disabled.svg');
 }
 
-.stored-card.jcb {
+.credit-card__stored-card.jcb {
 	background-image: url('/calypso/images/upgrades/cc-jcb-disabled.svg');
 }
 
-.stored-card.unionpay {
+.credit-card__stored-card.unionpay {
 	background-image: url('/calypso/images/upgrades/cc-unionpay-disabled.svg');
 }
 
 .credit-card.selected {
-	.stored-card.visa {
+	.credit-card__stored-card.visa {
 		background-image: url('/calypso/images/upgrades/cc-visa.svg');
 	}
 
-	.stored-card.mastercard {
+	.credit-card__stored-card.mastercard {
 		background-image: url('/calypso/images/upgrades/cc-mastercard.svg');
 	}
 
-	.stored-card.amex {
+	.credit-card__stored-card.amex {
 		background-image: url('/calypso/images/upgrades/cc-amex.svg');
 	}
 
-	.stored-card.discover {
+	.credit-card__stored-card.discover {
 		background-image: url('/calypso/images/upgrades/cc-discover.svg');
 	}
 
-	.stored-card.diners {
+	.credit-card__stored-card.diners {
 		background-image: url('/calypso/images/upgrades/cc-diners.svg');
 	}
 
-	.stored-card.jcb {
+	.credit-card__stored-card.jcb {
 		background-image: url('/calypso/images/upgrades/cc-jcb.svg');
 	}
 
-	.stored-card.unionpay {
+	.credit-card__stored-card.unionpay {
 		background-image: url('/calypso/images/upgrades/cc-unionpay.svg');
 	}
 }

--- a/client/components/credit-card/style.scss
+++ b/client/components/credit-card/style.scss
@@ -1,0 +1,20 @@
+@import './stored-card';
+
+.credit-card {
+    cursor: pointer;
+    border: 1px solid $gray-lighten-30;
+    border-top: none;
+    padding-left: 2px;
+    min-height: 50px;
+
+    &:first-of-type {
+        border-top: 1px solid $gray-lighten-30;
+    }
+
+    &.selected {
+        cursor: default;
+        border-left: 3px solid $alert-green;
+        background-color: #fafdf6;
+        padding-left: 0;
+    }
+}

--- a/client/components/credit-card/style.scss
+++ b/client/components/credit-card/style.scss
@@ -1,7 +1,6 @@
 @import './stored-card';
 
 .credit-card {
-    cursor: pointer;
     border: 1px solid $gray-lighten-30;
     border-top: none;
     padding-left: 2px;
@@ -9,6 +8,10 @@
 
     &:first-of-type {
         border-top: 1px solid $gray-lighten-30;
+    }
+
+    &.selectable:not(.selected) {
+        cursor: pointer;
     }
 
     &.selected {

--- a/client/components/credit-card/style.scss
+++ b/client/components/credit-card/style.scss
@@ -1,6 +1,6 @@
 @import './stored-card';
 
-.credit-card {
+div.credit-card {
     border: 1px solid $gray-lighten-30;
     border-top: none;
     padding-left: 2px;

--- a/client/me/purchases/credit-cards/credit-card-delete.jsx
+++ b/client/me/purchases/credit-cards/credit-card-delete.jsx
@@ -14,7 +14,7 @@ import React from 'react';
 import { deleteStoredCard } from 'state/stored-cards/actions';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { isDeletingStoredCard } from 'state/stored-cards/selectors';
-import StoredCard from 'my-sites/checkout/checkout/stored-card';
+import StoredCard from 'components/credit-card/stored-card';
 
 class CreditCardDelete extends React.Component {
 	handleClick = () => {

--- a/client/me/purchases/credit-cards/credit-card-delete.scss
+++ b/client/me/purchases/credit-cards/credit-card-delete.scss
@@ -7,7 +7,7 @@
 			top: 15px;
 	}
 
-	.stored-card {
+	.credit-card__stored-card {
 		padding-right: 120px;
 	}
 }

--- a/client/me/purchases/credit-cards/credit-cards.scss
+++ b/client/me/purchases/credit-cards/credit-cards.scss
@@ -6,12 +6,3 @@
 		padding: 8px;
 	}
 }
-
-.credit-cards__single-card {
-	border: 1px solid $gray-lighten-30;
-	border-top: none;
-
-	&:first-child {
-		border-top: 1px solid $gray-lighten-30;
-	}
-}

--- a/client/me/purchases/credit-cards/index.jsx
+++ b/client/me/purchases/credit-cards/index.jsx
@@ -16,6 +16,7 @@ import Button from 'components/button';
 import Card from 'components/card';
 import config from 'config';
 import CreditCardDelete from './credit-card-delete';
+import CreditCard from 'components/credit-card';
 import {
 	getStoredCards,
 	hasLoadedStoredCardsFromServer,
@@ -39,13 +40,13 @@ class CreditCards extends Component {
 			);
 		}
 
-		return this.props.cards.map( function( card ) {
+		return this.props.cards.map( card => {
 			return (
-				<div className="credit-cards__single-card" key={ card.stored_details_id }>
+				<CreditCard key={ card.stored_details_id }>
 					<CreditCardDelete card={ card } />
-				</div>
+				</CreditCard>
 			);
-		}, this );
+		} );
 	}
 
 	goToAddCreditCard() {

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -10,7 +10,7 @@ import { find } from 'lodash';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import StoredCard from './stored-card';
+import CreditCard from 'components/credit-card';
 import NewCardForm from './new-card-form';
 import { newCardPayment, storedCardPayment } from 'lib/store-transactions';
 import { setPayment } from 'lib/upgrades/actions';
@@ -35,38 +35,37 @@ class CreditCardSelector extends React.Component {
 	}
 
 	storedCards = () => {
-		return this.props.cards.map( function( card ) {
-			const storedCard = <StoredCard card={ card } />;
-			return this.section( card.stored_details_id, storedCard );
-		}, this );
+		return this.props.cards.map( card => {
+			return (
+				<CreditCard
+					key={ card.stored_details_id }
+					className="payment-box-section"
+					card={ card }
+					selected={ card.stored_details_id === this.state.section }
+					onClick={ this.handleClickedSection.bind( this, card.stored_details_id ) }
+				/>
+			);
+		} );
 	};
 
 	newCardForm = () => {
-		const cardForm = (
-			<NewCardForm
-				countriesList={ this.props.countriesList }
-				transaction={ this.props.transaction }
-				hasStoredCards={ this.props.cards.length > 0 }
-			/>
-		);
-
-		return this.section( 'new-card', cardForm );
-	};
-
-	section = ( name, content ) => {
 		const classes = classNames( 'payment-box-section', {
-			selected: this.state.section === name,
-			'no-stored-cards': name === 'new-card' && this.props.cards.length === 0,
+			'no-stored-cards': this.props.cards.length === 0,
 		} );
 
 		return (
-			<div
+			<CreditCard
+				key="new-card"
 				className={ classes }
-				onClick={ this.handleClickedSection.bind( this, name ) }
-				key={ name }
+				selected={ 'new-card' === this.state.section }
+				onClick={ this.handleClickedSection.bind( this, 'new-card' ) }
 			>
-				<div className="payment-box-section-inner">{ content }</div>
-			</div>
+				<NewCardForm
+					countriesList={ this.props.countriesList }
+					transaction={ this.props.transaction }
+					hasStoredCards={ this.props.cards.length > 0 }
+				/>
+			</CreditCard>
 		);
 	};
 

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -42,7 +42,7 @@ class CreditCardSelector extends React.Component {
 					className="payment-box-section"
 					card={ card }
 					selected={ card.stored_details_id === this.state.section }
-					onClick={ this.handleClickedSection.bind( this, card.stored_details_id ) }
+					onSelect={ this.handleClickedSection.bind( this, card.stored_details_id ) }
 				/>
 			);
 		} );
@@ -58,7 +58,7 @@ class CreditCardSelector extends React.Component {
 				key="new-card"
 				className={ classes }
 				selected={ 'new-card' === this.state.section }
-				onClick={ this.handleClickedSection.bind( this, 'new-card' ) }
+				onSelect={ this.handleClickedSection.bind( this, 'new-card' ) }
 			>
 				<NewCardForm
 					countriesList={ this.props.countriesList }

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -36,20 +36,22 @@ class CreditCardSelector extends React.Component {
 
 	storedCards = () => {
 		return this.props.cards.map( card => {
+			const onSelect = this.handleClickedSection.bind( this, card.stored_details_id );
 			return (
 				<CreditCard
 					key={ card.stored_details_id }
-					className="payment-box-section"
+					className="checkout__payment-box-section"
 					card={ card }
 					selected={ card.stored_details_id === this.state.section }
-					onSelect={ this.handleClickedSection.bind( this, card.stored_details_id ) }
+					onSelect={ onSelect }
 				/>
 			);
 		} );
 	};
 
 	newCardForm = () => {
-		const classes = classNames( 'payment-box-section', {
+		const onSelect = this.handleClickedSection.bind( this, 'new-card' );
+		const classes = classNames( 'checkout__payment-box-section', {
 			'no-stored-cards': this.props.cards.length === 0,
 		} );
 
@@ -58,7 +60,7 @@ class CreditCardSelector extends React.Component {
 				key="new-card"
 				className={ classes }
 				selected={ 'new-card' === this.state.section }
-				onSelect={ this.handleClickedSection.bind( this, 'new-card' ) }
+				onSelect={ onSelect }
 			>
 				<NewCardForm
 					countriesList={ this.props.countriesList }

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -294,39 +294,12 @@
 			}
 		}
 
-		.payment-box-section {
-			cursor: pointer;
-			border-bottom: 1px solid $gray-lighten-30;
-
-			&:first-of-type {
-				border-top: 1px solid $gray-lighten-30;
-			}
-
-			&.selected {
-				cursor: default;
-			}
-		}
-
-		.payment-box-section-inner {
+		.payment-box-section.selected.no-stored-cards {
 			border-left: 1px solid $gray-lighten-30;
-			padding-left: 2px;
-			position: relative;
-			border-right: 1px solid $gray-lighten-30;
-			min-height: 50px;
 		}
 
-		.payment-box-section.selected .payment-box-section-inner {
+		.payment-box-section.selected:not( .no-stored-cards ) .checkout__new-card-fields {
 			background-color: #fafdf6;
-			padding-left: 0;
-		}
-
-		.payment-box-section.selected:not( .no-stored-cards ) {
-			.payment-box-section-inner {
-				border-left: 3px solid $alert-green;
-			}
-			.checkout__new-card-fields {
-				background-color: #fafdf6;
-			}
 		}
 
 		.no-stored-cards .checkout__new-card-fields > .checkout-field:first-child {

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -294,11 +294,11 @@
 			}
 		}
 
-		.payment-box-section.selected.no-stored-cards {
+		.checkout__payment-box-section.selected.no-stored-cards {
 			border-left: 1px solid $gray-lighten-30;
 		}
 
-		.payment-box-section.selected:not( .no-stored-cards ) .checkout__new-card-fields {
+		.checkout__payment-box-section.selected:not( .no-stored-cards ) .checkout__new-card-fields {
 			background-color: #fafdf6;
 		}
 
@@ -306,14 +306,14 @@
 			margin-top: 0;
 		}
 
-		.payment-box-section .checkout__new-card-toggle {
+		.checkout__payment-box-section .checkout__new-card-toggle {
 			box-shadow: none;
 			cursor: pointer;
 			font-size: 13px;
 			position: absolute;
 		}
 
-		.payment-box-section .checkout__new-card-fields {
+		.checkout__payment-box-section .checkout__new-card-fields {
 			background-color: $white;
 			max-height: 0;
 			overflow: hidden;
@@ -322,7 +322,7 @@
 			transition: all 500ms ease-in-out;
 		}
 
-		.payment-box-section.selected .checkout__new-card-fields {
+		.checkout__payment-box-section.selected .checkout__new-card-fields {
 			max-height: 100%;
 			margin-bottom: 0;
 			padding-top: 15px;


### PR DESCRIPTION
Refactor to extract credit card list item component out of `my-sites` and into `components`.

- `my-sites/checkout/checkout/stored-card` — already being used outside of `my-sites` in `me/purchases/credit-cards` — is moved into `components/credit-card/stored-card`
- `components/credit-card` is a parent component that can either render a `<StoredCard>` if passed a `card` prop, or serve as a wrapper for passed `children` (e.g. `<NewCardForm>`). Equivalent to the now-removed `section` method of `my-sites/checkout/checkout/credit-card-selector`
- removed some unnecessary markup and duplicate markup + styling

Display changes:
- Use display name for credit card type (e.g. "American Express" instead of "amex"), generalized from existing implementation in `woocommerce/woocommerce-services/views/label-settings/label-payment-method`
- Added some margin between name and expiration to trigger wrapping before getting too close