### PR TITLE
Analytics: Refactor user identification for server side analytics

### DIFF
--- a/server/lib/analytics/index.js
+++ b/server/lib/analytics/index.js
@@ -35,12 +35,18 @@ function getUserFromRequest( request ) {
 
 	// if user doesn't have a cookie, and we had the user identification passed to us on query params
 	// we'll use that, otherwise, we'll just use anonymous.
-	const userType = get( request, 'query._ut', 'anon' );
-	const userId = get( request, 'query._ui', uuid() );
+	let userIdType = get( request, 'query._ut', 'anon' );
+	let userId = get( request, 'query._ui', null );
+
+	// if user ID not set, even though userIdType is set, we revert to anonymous
+	if ( ! userId ) {
+		userIdType = 'anon';
+		userId = uuid();
+	}
 
 	return {
 		_ui: userId,
-		_ut: userType,
+		_ut: userIdType,
 	};
 }
 

--- a/server/lib/analytics/index.js
+++ b/server/lib/analytics/index.js
@@ -4,14 +4,45 @@
  */
 
 import superagent from 'superagent';
+import { v4 as uuid } from 'uuid';
+import { isUndefined, omit, assign, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import config from 'config';
 import { statsdTimingUrl } from '../../../client/lib/analytics/statsd';
-import { isUndefined, omit, assign } from 'lodash';
 const URL = require( 'url' );
+
+function getUserFromRequest( request ) {
+	// if user has a cookie, lets use that
+	const encodedUserCookie = get( request, 'cookies.wordpress_logged_in', null );
+
+	if ( encodedUserCookie ) {
+		try {
+			const userCookieParts = decodeURIComponent( encodedUserCookie ).split( '|' );
+
+			// We don't trust it, but for analytics this is enough
+			return {
+				_ul: userCookieParts[ 0 ],
+				_ui: parseInt( userCookieParts[ 1 ], 10 ),
+				_ut: 'wpcom:user_id',
+			};
+		} catch ( ex ) {
+			// ignore the error and let it fallback to anonymous below
+		}
+	}
+
+	// if user doesn't have a cookie, and we had the user identification passed to us on query params
+	// we'll use that, otherwise, we'll just use anonymous.
+	const userType = get( request, 'query._ut', 'anon' );
+	const userId = get( request, 'query._ui', uuid() );
+
+	return {
+		_ui: userId,
+		_ut: userType,
+	};
+}
 
 const analytics = {
 	statsd: {
@@ -57,14 +88,13 @@ const analytics = {
 						_en: eventName,
 						_ts: date.getTime(),
 						_tz: date.getTimezoneOffset() / 60,
-						_ui: req.query._ui,
-						_ut: req.query._ut,
 						_dl: req.get( 'Referer' ),
 						_lg: acceptLanguageHeader.split( ',' )[ 0 ],
 						_pf: req.useragent.platform,
 						_via_ip: req.get( 'x-forwarded-for' ) || req.connection.remoteAddress,
 						_via_ua: req.useragent.source,
 					},
+					getUserFromRequest( req ),
 					eventProperties
 				)
 			);

--- a/server/lib/analytics/index.js
+++ b/server/lib/analytics/index.js
@@ -5,7 +5,7 @@
 
 import superagent from 'superagent';
 import { v4 as uuid } from 'uuid';
-import { isUndefined, omit, assign, get } from 'lodash';
+import { isUndefined, omit, assign, get, has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,18 +35,19 @@ function getUserFromRequest( request ) {
 
 	// if user doesn't have a cookie, and we had the user identification passed to us on query params
 	// we'll use that, otherwise, we'll just use anonymous.
-	let userIdType = get( request, 'query._ut', 'anon' );
-	let userId = get( request, 'query._ui', null );
 
-	// if user ID not set, even though userIdType is set, we revert to anonymous
-	if ( ! userId ) {
-		userIdType = 'anon';
-		userId = uuid();
+	// If we have a full identity on query params - use it
+	if ( has( request, 'query._ut' ) && has( request, 'query._ui' ) ) {
+		return {
+			_ui: request.query._ui,
+			_ut: request.query._ut,
+		};
 	}
 
+	// We didn't get a full identity, create an anon ID
 	return {
-		_ui: userId,
-		_ut: userIdType,
+		_ut: 'anon',
+		_ui: uuid(),
 	};
 }
 


### PR DESCRIPTION
Tracks expect `_ut` and `_ui` set to record the event.

In certain scenarios, on server-side, those were missing.
This PR refactors the user identification to work as follows:

1. If a user has an auth cookie set, we get user identification for tracks from it.
else
2. if the request has query params `_ut` and `_ui` set, we get user identification for tracks from it.
3. If we don't have any of the above, we set `_ut` to 'anon' and `_ui` to a UUID v4.

 
#### Testing instructions
  
1. Run `git checkout update/csp-tracks` and start your server, or open a [live branch](https://calypso.live/?branch=update/csp-tracks)
2. Open the [`Login` page](http://calypso.localhost:3000/log-in)
3. Make sure a CSP report is triggered ( a POST to `/cspreport` )
4. Assert a tracks event was indeed recorded with the correct user
5. Assert a tracks event `calypso_stats_blocked` is recorded for a request to `calypso.localhost:3000/nostats.js?_ut=wpcom:user_id&_ui=12345` for a user type `wpcom:user_id` id `<your user id>` ( make sure you don't have the auth cookie set for this one )
  
#### Reviews
  
- [ ] Code
- [ ] Product



