### PR TITLE
Jetpack Onboarding: Update Contact Form step copy

### DIFF
--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -69,10 +69,12 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 		const headerText = translate( "Let's grow your audience with Jetpack." );
 		const subHeaderText = (
 			<Fragment>
-				{ translate( "A great first step is adding Jetpack's contact form." ) }
+				{ translate(
+					'A great first step is adding a Contact Us page that includes Jetpack’s contact form.'
+				) }
 				<br />
 				{ translate(
-					'Create a Jetpack account to get started and unlock this and dozens of other features.'
+					'Create a Jetpack account to unlock this and dozens of other Jetpack features.'
 				) }
 			</Fragment>
 		);
@@ -135,11 +137,9 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 	}
 }
 
-export default connect(
-	( state, { settings, siteId, steps } ) => ( {
-		hasContactForm: !! get( settings, 'addContactForm' ),
-		isConnected: isJetpackSite( state, siteId ),
-		siteUrl: getUnconnectedSiteUrl( state, siteId ),
-		stepsPending: getJetpackOnboardingPendingSteps( state, siteId, steps ),
-	} ),
-)( localize( JetpackOnboardingContactFormStep ) );
+export default connect( ( state, { settings, siteId, steps } ) => ( {
+	hasContactForm: !! get( settings, 'addContactForm' ),
+	isConnected: isJetpackSite( state, siteId ),
+	siteUrl: getUnconnectedSiteUrl( state, siteId ),
+	stepsPending: getJetpackOnboardingPendingSteps( state, siteId, steps ),
+} ) )( localize( JetpackOnboardingContactFormStep ) );


### PR DESCRIPTION
This PR updates the copy of the contact form step, as suggested in #22824.

Fixes #22824.

Before:
![](https://cldup.com/oGRnNzXTHR.png)

After:
![](https://cldup.com/obr75-OHRr.png)

To test:
* Checkout this branch
* Pick a Jetpack site.
* Head to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` on the Jetpack site to start the onboarding flow.
* Jump to the Contact Form step.
* Verify the copy looks good, as shown on the screenshot.