### PR TITLE
Simplify and optimize Post Taxonomies Redux code

### DIFF
--- a/client/state/post-types/taxonomies/reducer.js
+++ b/client/state/post-types/taxonomies/reducer.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { keyBy, merge } from 'lodash';
+import { merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -57,7 +57,7 @@ export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) =
 				...state,
 				[ action.siteId ]: {
 					...state[ action.siteId ],
-					[ action.postType ]: keyBy( action.taxonomies, 'name' ),
+					[ action.postType ]: action.taxonomies,
 				},
 			};
 

--- a/client/state/post-types/taxonomies/schema.js
+++ b/client/state/post-types/taxonomies/schema.js
@@ -8,24 +8,20 @@ export const itemsSchema = {
 			patternProperties: {
 				// Post Type
 				'^.*$': {
-					type: 'object',
-					patternProperties: {
-						// Taxonomy name
-						'^.*$': {
-							type: 'object',
-							required: [ 'name' ],
-							properties: {
-								name: { type: 'string' },
-								label: { type: 'string' },
-								labels: { type: 'object' },
-								description: { type: 'string' },
-								hierarchical: { type: 'boolean' },
-								public: { type: 'boolean' },
-								capabilities: { type: 'object' },
-							},
+					type: 'array',
+					items: {
+						type: 'object',
+						required: [ 'name' ],
+						properties: {
+							name: { type: 'string' },
+							label: { type: 'string' },
+							labels: { type: 'object' },
+							description: { type: 'string' },
+							hierarchical: { type: 'boolean' },
+							public: { type: 'boolean' },
+							capabilities: { type: 'object' },
 						},
 					},
-					additionalProperties: false,
 				},
 			},
 			additionalProperties: false,

--- a/client/state/post-types/taxonomies/selectors.js
+++ b/client/state/post-types/taxonomies/selectors.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { find, get, values } from 'lodash';
+import { find, get } from 'lodash';
 
 /**
  * Returns true if a network request is in-progress for the specified site ID,
@@ -29,12 +29,7 @@ export function isRequestingPostTypeTaxonomies( state, siteId, postType ) {
  * @return {Array?}           Post type taxonomies
  */
 export function getPostTypeTaxonomies( state, siteId, postType ) {
-	const taxonomies = get( state.postTypes.taxonomies.items, [ siteId, postType ] );
-	if ( ! taxonomies ) {
-		return null;
-	}
-
-	return values( taxonomies );
+	return get( state.postTypes.taxonomies.items, [ siteId, postType ], null );
 }
 
 /**
@@ -49,9 +44,5 @@ export function getPostTypeTaxonomies( state, siteId, postType ) {
  */
 export function getPostTypeTaxonomy( state, siteId, postType, taxonomyName ) {
 	const taxonomies = getPostTypeTaxonomies( state, siteId, postType );
-	if ( ! taxonomies ) {
-		return null;
-	}
-
 	return find( taxonomies, { name: taxonomyName } ) || null;
 }

--- a/client/state/post-types/taxonomies/test/reducer.js
+++ b/client/state/post-types/taxonomies/test/reducer.js
@@ -170,16 +170,7 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				2916284: {
-					post: {
-						category: {
-							name: 'category',
-							label: 'Categories',
-						},
-						post_tag: {
-							name: 'post_tag',
-							label: 'Tags',
-						},
-					},
+					post: [ { name: 'category', label: 'Categories' }, { name: 'post_tag', label: 'Tags' } ],
 				},
 			} );
 		} );
@@ -201,27 +192,27 @@ describe( 'reducer', () => {
 
 			expect( updatedState ).to.eql( {
 				2916284: {
-					page: {},
+					page: [],
 				},
 			} );
 		} );
 
 		test( 'should accumulate items for multiple sites and post types', () => {
 			const actions = [
-				receivePostTypeTaxonomies( 2916284, 'page', [] ),
-				receivePostTypeTaxonomies( 2916285, 'page', [] ),
-				receivePostTypeTaxonomies( 2916284, 'post', [] ),
+				receivePostTypeTaxonomies( 2916284, 'page', [ { name: 'page_tag1', label: 'Tag 1' } ] ),
+				receivePostTypeTaxonomies( 2916285, 'page', [ { name: 'page_tag2', label: 'Tag 2' } ] ),
+				receivePostTypeTaxonomies( 2916284, 'post', [ { name: 'post_tag', label: 'Tag' } ] ),
 			];
 
 			const finalState = actions.reduce( items, undefined );
 
 			expect( finalState ).to.eql( {
 				2916284: {
-					page: {},
-					post: {},
+					page: [ { name: 'page_tag1', label: 'Tag 1' } ],
+					post: [ { name: 'post_tag', label: 'Tag' } ],
 				},
 				2916285: {
-					page: {},
+					page: [ { name: 'page_tag2', label: 'Tag 2' } ],
 				},
 			} );
 		} );
@@ -229,16 +220,16 @@ describe( 'reducer', () => {
 		test( 'should persist state', () => {
 			const original = deepFreeze( {
 				2916284: {
-					post: {
-						category: {
+					post: [
+						{
 							name: 'category',
 							label: 'Categories',
 						},
-						post_tag: {
+						{
 							name: 'post_tag',
 							label: 'Tags',
 						},
-					},
+					],
 				},
 			} );
 			const state = items( original, { type: SERIALIZE } );
@@ -249,16 +240,16 @@ describe( 'reducer', () => {
 		test( 'should load valid persisted state', () => {
 			const original = deepFreeze( {
 				2916284: {
-					post: {
-						category: {
+					post: [
+						{
 							name: 'category',
 							label: 'Categories',
 						},
-						post_tag: {
+						{
 							name: 'post_tag',
 							label: 'Tags',
 						},
-					},
+					],
 				},
 			} );
 			const state = items( original, { type: DESERIALIZE } );
@@ -269,9 +260,7 @@ describe( 'reducer', () => {
 		test( 'should not load invalid persisted state', () => {
 			const original = deepFreeze( {
 				2916284: {
-					post: {
-						category: true,
-					},
+					post: [ true ],
 				},
 			} );
 			const state = items( original, { type: DESERIALIZE } );

--- a/client/state/post-types/taxonomies/test/selectors.js
+++ b/client/state/post-types/taxonomies/test/selectors.js
@@ -119,16 +119,16 @@ describe( 'selectors', () => {
 						taxonomies: {
 							items: {
 								2916284: {
-									post: {
-										category: {
+									post: [
+										{
 											name: 'category',
 											label: 'Categories',
 										},
-										post_tag: {
+										{
 											name: 'post_tag',
 											label: 'Tags',
 										},
-									},
+									],
 								},
 							},
 						},


### PR DESCRIPTION
When storing post taxonomies data into Redux state, we receive a REST response that is an array of objects:
```js
[ { name, label }, { name, label } ]
```
The reducer uses `_.keyBy` to convert this to an object keyed by name:
```js
{ name1: { name: 'name1', ... }, name2: { name: 'name2' } }
```
and stores it to Redux state in this shape.

The `getPostTypeTaxonomies` selector then uses `_.values` to convert the object back to the original array. It's not memoized, so a new return value is created on each invocation.

This PR removes all this extra complexity and just stores the original array into Redux.

I also improved the reducer's accumulation tests as was suggested by the reviewers of #22309 (and I didn't implement their suggestions back then).