### PR TITLE
Remove concierge available times limit

### DIFF
--- a/client/me/concierge/shared/available-time-picker.js
+++ b/client/me/concierge/shared/available-time-picker.js
@@ -13,20 +13,8 @@ import { moment } from 'i18n-calypso';
 import AvailableTimeCard from './available-time-card';
 import { isDefaultLocale } from 'lib/i18n-utils';
 
-const NUMBER_OF_DAYS_TO_SHOW = 10;
-
 const groupAvailableTimesByDate = ( availableTimes, timezone ) => {
 	const dates = {};
-
-	// Stub an object of { date: X, times: [] } for each day we care about
-	for ( let x = 0; x < NUMBER_OF_DAYS_TO_SHOW; x++ ) {
-		const startOfDay = moment()
-			.tz( timezone )
-			.startOf( 'day' )
-			.add( x, 'days' )
-			.valueOf();
-		dates[ startOfDay ] = { date: startOfDay, times: [] };
-	}
 
 	// Go through all available times and bundle them into each date object
 	availableTimes.forEach( beginTimestamp => {
@@ -36,6 +24,8 @@ const groupAvailableTimesByDate = ( availableTimes, timezone ) => {
 			.valueOf();
 		if ( dates.hasOwnProperty( startOfDay ) ) {
 			dates[ startOfDay ].times.push( beginTimestamp );
+		} else {
+			dates[ startOfDay ] = { date: startOfDay, times: [ beginTimestamp ] };
 		}
 	} );
 


### PR DESCRIPTION
## Summary
Currently we have a timeframe of 10 days ahead to book concierge schedules, in an attempt to make this more flexible we are going to add a setting in MC so we should not limit the number of days on the client.

We are not going to create placeholders for the days with no available times anymore.

**Context: 588-gh-gh**

## Testing
**Set development config field "wpcom_concierge_schedule_id": 1938, to use the lighthouse internal schedule**
1. Go to `me/concierge/<business-site-url>/book`
2. Available times should be displayed correctly
3. Book a session