### PR TITLE
Activity Log: use server local time to determine today

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -454,9 +454,7 @@ class ActivityLog extends Component {
 			'active' !== rewindState.state;
 		const disableBackup = 0 <= get( this.props, [ 'backupProgress', 'progress' ], -Infinity );
 
-		const today = moment()
-			.utc()
-			.startOf( 'day' );
+		const today = moment().startOf( 'day' );
 
 		// Content shown when there are no logs.
 		// The network request either finished with no events or is still ongoing.
@@ -519,12 +517,7 @@ class ActivityLog extends Component {
 					<section className="activity-log__wrapper">
 						{ intoVisualGroups( moment, logs, this.getStartMoment(), this.applySiteOffset ).map(
 							( [ type, [ start, end ], events ] ) => {
-								const isToday = today.isSame(
-									end
-										.clone()
-										.utc()
-										.startOf( 'day' )
-								);
+								const isToday = today.isSame( end.clone().startOf( 'day' ) );
 
 								switch ( type ) {
 									case 'empty-day':


### PR DESCRIPTION
Fixes #21317

This PR fixes an issue where if you're not exactly in the UTC time zone, the foldable card for the current day will no longer be expanded ahead of time.

For example, without this PR, a site with local time UTC-3 will stop expanding the current day at 09:00 pm. With this PR, the current day continues to be correctly expanded until 00:00 hs.