### PR TITLE
 Jetpack Onboarding: Move JPC intro in a separate component

### DIFF
--- a/client/jetpack-onboarding/connect-intro.jsx
+++ b/client/jetpack-onboarding/connect-intro.jsx
@@ -1,0 +1,78 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Fragment, PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Tile from 'components/tile-grid/tile';
+import TileGrid from 'components/tile-grid';
+import { addQueryArgs } from 'lib/route';
+import { getUnconnectedSiteUrl } from 'state/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+
+class ConnectIntro extends PureComponent {
+	static propTypes = {
+		buttonLabel: PropTypes.string,
+		description: PropTypes.string,
+		e2eType: PropTypes.string,
+		header: PropTypes.node,
+		illustration: PropTypes.string,
+		onClick: PropTypes.func,
+		siteId: PropTypes.number.isRequired,
+
+		// Connected props
+		isConnected: PropTypes.bool,
+		siteUrl: PropTypes.string,
+	};
+
+	render() {
+		const {
+			buttonLabel,
+			description,
+			e2eType,
+			header,
+			illustration,
+			isConnected,
+			onClick,
+			siteUrl,
+		} = this.props;
+		const connectUrl = addQueryArgs(
+			{
+				url: siteUrl,
+				// TODO: add a parameter to the JPC to redirect back to this step after completion
+				// and in the redirect URL include the ?action=SOMEACTION parameter
+				// to actually trigger the action after getting back to JPO
+			},
+			'/jetpack/connect'
+		);
+		const href = ! isConnected ? connectUrl : null;
+
+		return (
+			<Fragment>
+				{ header }
+
+				<TileGrid>
+					<Tile
+						buttonLabel={ buttonLabel }
+						description={ description }
+						e2eType={ e2eType }
+						image={ illustration }
+						onClick={ onClick }
+						href={ href }
+					/>
+				</TileGrid>
+			</Fragment>
+		);
+	}
+}
+
+export default connect( ( state, { siteId } ) => ( {
+	isConnected: isJetpackSite( state, siteId ),
+	siteUrl: getUnconnectedSiteUrl( state, siteId ),
+} ) )( ConnectIntro );

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import ConnectIntro from '../connect-intro';
 import ConnectSuccess from '../connect-success';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
@@ -21,10 +22,6 @@ import FormTextInput from 'components/forms/form-text-input';
 import JetpackLogo from 'components/jetpack-logo';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySites from 'components/data/query-sites';
-import Tile from 'components/tile-grid/tile';
-import TileGrid from 'components/tile-grid';
-import { addQueryArgs } from 'lib/route';
-import { getUnconnectedSiteUrl } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
@@ -153,33 +150,17 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 	}
 
 	renderActionTile() {
-		const { isConnected, siteUrl, translate } = this.props;
-
-		const connectUrl = addQueryArgs(
-			{
-				url: siteUrl,
-				// TODO: add a parameter to the JPC to redirect back to this step after completion
-				// and in the redirect URL include the ?action=add_business_address parameter
-				// to actually trigger the form display action after getting back to JPO
-			},
-			'/jetpack/connect'
-		);
-		const href = ! isConnected ? connectUrl : null;
+		const { siteId, translate } = this.props;
 
 		return (
-			<Fragment>
-				{ this.renderHeader() }
-
-				<TileGrid>
-					<Tile
-						buttonLabel={ translate( 'Add a business address' ) }
-						image="/calypso/images/illustrations/business-address.svg"
-						onClick={ this.handleAddBusinessAddressClick }
-						href={ href }
-						e2eType={ 'business-address' }
-					/>
-				</TileGrid>
-			</Fragment>
+			<ConnectIntro
+				buttonLabel={ translate( 'Add a business address' ) }
+				e2eType="business-address"
+				header={ this.renderHeader() }
+				illustration="/calypso/images/illustrations/business-address.svg"
+				onClick={ this.handleAddBusinessAddressClick }
+				siteId={ siteId }
+			/>
 		);
 	}
 
@@ -257,5 +238,4 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 export default connect( ( state, { settings, siteId } ) => ( {
 	hasBusinessAddress: get( settings, 'businessAddress' ) !== false,
 	isConnected: isJetpackSite( state, siteId ),
-	siteUrl: getUnconnectedSiteUrl( state, siteId ),
 } ) )( localize( JetpackOnboardingBusinessAddressStep ) );

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -11,16 +11,14 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import ConnectIntro from '../connect-intro';
 import ConnectSuccess from '../connect-success';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import JetpackLogo from 'components/jetpack-logo';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySites from 'components/data/query-sites';
-import Tile from 'components/tile-grid/tile';
-import TileGrid from 'components/tile-grid';
-import { addQueryArgs } from 'lib/route';
-import { getJetpackOnboardingPendingSteps, getUnconnectedSiteUrl } from 'state/selectors';
+import { getJetpackOnboardingPendingSteps } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
@@ -65,45 +63,32 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 	}
 
 	renderActionTile() {
-		const { hasContactForm, isConnected, siteUrl, translate } = this.props;
-		const headerText = translate( "Let's grow your audience with Jetpack." );
-		const subHeaderText = (
-			<Fragment>
-				{ translate(
-					'A great first step is adding a Contact Us page that includes a contact form.'
-				) }
-				<br />
-				{ translate( 'Create a Jetpack account to unlock this and dozens of other features.' ) }
-			</Fragment>
+		const { hasContactForm, siteId, translate } = this.props;
+		const header = (
+			<FormattedHeader
+				headerText={ translate( "Let's grow your audience with Jetpack." ) }
+				subHeaderText={
+					<Fragment>
+						{ translate(
+							'A great first step is adding a Contact Us page that includes a contact form.'
+						) }
+						<br />
+						{ translate( 'Create a Jetpack account to unlock this and dozens of other features.' ) }
+					</Fragment>
+				}
+			/>
 		);
-		const connectUrl = addQueryArgs(
-			{
-				url: siteUrl,
-				// TODO: add a parameter to the JPC to redirect back to this step after completion
-				// and in the redirect URL include the ?action=add_contact_form parameter
-				// to actually trigger the page and form creation action after getting back to JPO
-			},
-			'/jetpack/connect'
-		);
-		const href = ! isConnected ? connectUrl : null;
 
 		return (
-			<Fragment>
-				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
-
-				<TileGrid>
-					<Tile
-						buttonLabel={ ! hasContactForm ? translate( 'Add a contact form' ) : null }
-						description={
-							hasContactForm ? translate( 'Your contact form has been created.' ) : null
-						}
-						image={ '/calypso/images/illustrations/contact-us.svg' }
-						onClick={ this.handleAddContactForm }
-						href={ href }
-						e2eType={ 'contact-form' }
-					/>
-				</TileGrid>
-			</Fragment>
+			<ConnectIntro
+				buttonLabel={ ! hasContactForm ? translate( 'Add a contact form' ) : null }
+				description={ hasContactForm ? translate( 'Your contact form has been created.' ) : null }
+				e2eType="contact-form"
+				header={ header }
+				illustration="/calypso/images/illustrations/contact-us.svg"
+				onClick={ this.handleAddContactForm }
+				siteId={ siteId }
+			/>
 		);
 	}
 
@@ -139,6 +124,5 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 export default connect( ( state, { settings, siteId, steps } ) => ( {
 	hasContactForm: !! get( settings, 'addContactForm' ),
 	isConnected: isJetpackSite( state, siteId ),
-	siteUrl: getUnconnectedSiteUrl( state, siteId ),
 	stepsPending: getJetpackOnboardingPendingSteps( state, siteId, steps ),
 } ) )( localize( JetpackOnboardingContactFormStep ) );

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -11,16 +11,14 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import ConnectIntro from '../connect-intro';
 import ConnectSuccess from '../connect-success';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import JetpackLogo from 'components/jetpack-logo';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySites from 'components/data/query-sites';
-import Tile from 'components/tile-grid/tile';
-import TileGrid from 'components/tile-grid';
-import { addQueryArgs } from 'lib/route';
-import { getJetpackOnboardingPendingSteps, getUnconnectedSiteUrl } from 'state/selectors';
+import { getJetpackOnboardingPendingSteps } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { JETPACK_ONBOARDING_STEPS as STEPS } from '../constants';
 
@@ -65,37 +63,26 @@ class JetpackOnboardingStatsStep extends React.Component {
 	}
 
 	renderActionTile() {
-		const { isConnected, siteUrl, translate } = this.props;
-		const headerText = translate( 'Keep track of your visitors with Jetpack.' );
-		const subHeaderText = translate(
-			'Keep an eye on your success with simple, concise, and mobile-friendly stats. ' +
-				'Get updates on site traffic, successful posts, site searches, and comments, all in real time.'
+		const { siteId, translate } = this.props;
+		const header = (
+			<FormattedHeader
+				headerText={ translate( 'Keep track of your visitors with Jetpack.' ) }
+				subHeaderText={ translate(
+					'Keep an eye on your success with simple, concise, and mobile-friendly stats. ' +
+						'Get updates on site traffic, successful posts, site searches, and comments, all in real time.'
+				) }
+			/>
 		);
-		const connectUrl = addQueryArgs(
-			{
-				url: siteUrl,
-				// TODO: add a parameter to the JPC to redirect back to this step after completion
-				// and in the redirect URL include the ?action=activate_stats parameter
-				// to actually trigger the stats activation action after getting back to JPO
-			},
-			'/jetpack/connect'
-		);
-		const href = ! isConnected ? connectUrl : null;
 
 		return (
-			<Fragment>
-				<FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />
-
-				<TileGrid>
-					<Tile
-						buttonLabel={ translate( 'Activate stats' ) }
-						image="/calypso/images/illustrations/jetpack-stats.svg"
-						onClick={ this.handleActivateStats }
-						href={ href }
-						e2eType={ 'activate-stats' }
-					/>
-				</TileGrid>
-			</Fragment>
+			<ConnectIntro
+				buttonLabel={ translate( 'Activate stats' ) }
+				e2eType="activate-stats"
+				header={ header }
+				illustration="/calypso/images/illustrations/jetpack-stats.svg"
+				onClick={ this.handleActivateStats }
+				siteId={ siteId }
+			/>
 		);
 	}
 
@@ -131,6 +118,5 @@ class JetpackOnboardingStatsStep extends React.Component {
 export default connect( ( state, { settings, siteId, steps } ) => ( {
 	activatedStats: get( settings, 'stats' ) === true,
 	isConnected: isJetpackSite( state, siteId ),
-	siteUrl: getUnconnectedSiteUrl( state, siteId ),
 	stepsPending: getJetpackOnboardingPendingSteps( state, siteId, steps ),
 } ) )( localize( JetpackOnboardingStatsStep ) );


### PR DESCRIPTION
This PR introduces a `ConnectIntro` component that allows us to reduce some of the logic that we duplicated for cases where we require Jetpack Connect in certain steps. In addition, it applies the component to all those steps - contact form, business address and stats.

No visual or functional differences should be introduced by this PR.

To test:
* Checkout this branch
* Start the onboarding flow.
* Verify the intro section looks and works like before when both connected and not connected in all of the following steps:
  * Contact form
  * Business address
  * Stats
