### PR TITLE
Jetpack Onboarding: Change skip link text on success screens

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -4,8 +4,9 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { compact, get } from 'lodash';
+import { compact, get, includes } from 'lodash';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
@@ -21,6 +22,7 @@ import {
 	JETPACK_ONBOARDING_STEPS as STEPS,
 } from './constants';
 import {
+	getJetpackOnboardingCompletedSteps,
 	getJetpackOnboardingSettings,
 	getRequest,
 	getUnconnectedSite,
@@ -78,6 +80,16 @@ class JetpackOnboardingMain extends React.PureComponent {
 		} );
 	};
 
+	getSkipLinkText() {
+		const { stepName, stepsCompleted, translate } = this.props;
+		const steps = [ STEPS.CONTACT_FORM, STEPS.BUSINESS_ADDRESS, STEPS.STATS ];
+
+		if ( includes( steps, stepName ) && get( stepsCompleted, stepName ) ) {
+			return translate( 'Next' );
+		}
+		return null;
+	}
+
 	render() {
 		const {
 			action,
@@ -92,6 +104,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 			stepName,
 			steps,
 		} = this.props;
+
 		return (
 			<Main className="jetpack-onboarding">
 				{ /* We only allow querying of site settings once we know that we have finished
@@ -107,6 +120,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 						basePath="/jetpack/start"
 						baseSuffix={ siteSlug }
 						components={ COMPONENTS }
+						forwardText={ this.getSkipLinkText() }
 						hideNavigation={ stepName === STEPS.SUMMARY }
 						isRequestingSettings={ isRequestingSettings }
 						isRequestingWhetherConnected={ isRequestingWhetherConnected }
@@ -155,7 +169,6 @@ export default connect(
 		).isLoading;
 
 		const userIdHashed = getUnconnectedSiteUserHash( state, siteId );
-		// Note: here we can select which steps to display, based on user's input
 		const steps = compact( [
 			STEPS.SITE_TITLE,
 			STEPS.SITE_TYPE,
@@ -166,6 +179,8 @@ export default connect(
 			STEPS.STATS,
 			STEPS.SUMMARY,
 		] );
+		const stepsCompleted = getJetpackOnboardingCompletedSteps( state, siteId, steps );
+
 		return {
 			jpoAuth,
 			isRequestingSettings,
@@ -174,6 +189,7 @@ export default connect(
 			siteSlug,
 			settings,
 			steps,
+			stepsCompleted,
 			userIdHashed,
 		};
 	},
@@ -203,4 +219,4 @@ export default connect(
 			} ),
 		...ownProps,
 	} )
-)( JetpackOnboardingMain );
+)( localize( JetpackOnboardingMain ) );

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { compact, get, includes } from 'lodash';
+import { compact, get } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -82,9 +82,8 @@ class JetpackOnboardingMain extends React.PureComponent {
 
 	getSkipLinkText() {
 		const { stepName, stepsCompleted, translate } = this.props;
-		const steps = [ STEPS.CONTACT_FORM, STEPS.BUSINESS_ADDRESS, STEPS.STATS ];
 
-		if ( includes( steps, stepName ) && get( stepsCompleted, stepName ) ) {
+		if ( get( stepsCompleted, stepName ) ) {
 			return translate( 'Next' );
 		}
 		return null;


### PR DESCRIPTION
This PR updates the text of  "Skip" links on all success screens in JPO, as it feels odd to have a Skip link on a success screen. In those cases we change the text to "Next", so it makes more sense.

Fixes #22641.

To test:
* Checkout this branch.
* Get a fresh site, connect it to WP.com.
* Start the onboarding flow.
* In the site type step, select "Business".
* Go to the contact form step.
* Verify you can see the original text on the Skip button ("Skip for now").
* Add a contact form.
* Verify you can see the skip button with the updated text ("Next") when you see the contact form success screen.
* Go to the business address step.
* Verify you can see the original text on the Skip button ("Skip for now").
* Add a business address.
* Verify you can see the skip button with the updated text ("Next") when you see the business address success screen.
* Go to the stats step.
* Verify you can see the original text on the Skip button ("Skip for now").
* Click the button to activate stats.
* Verify you can see the skip button with the updated text ("Next") when you see the stats success screen.
* Verify you can see the original text on the Skip button ("Skip for now") in all cases, except for when the whole navigation is hidden (this would be the case for the last step - Summary).