### PR TITLE
Jetpack Onboarding: Remove validation in BA step

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -18,7 +18,6 @@ import FormattedHeader from 'components/formatted-header';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
-import FormInputValidation from 'components/forms/form-input-validation';
 import JetpackLogo from 'components/jetpack-logo';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySites from 'components/data/query-sites';
@@ -193,9 +192,6 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 				<Card className="steps__form">
 					<form onSubmit={ this.handleSubmit }>
 						{ map( this.fields, ( fieldLabel, fieldName ) => {
-							const isValidatingField = ! isRequestingSettings && fieldName !== 'state';
-							const isValidField = this.state.fields[ fieldName ] !== '';
-
 							return (
 								<FormFieldset key={ fieldName }>
 									<FormLabel htmlFor={ fieldName }>{ fieldLabel }</FormLabel>
@@ -203,20 +199,9 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 										autoFocus={ fieldName === 'name' }
 										disabled={ isRequestingSettings }
 										id={ fieldName }
-										isError={ isValidatingField && ! isValidField }
-										isValid={ isValidatingField && isValidField }
 										onChange={ this.getChangeHandler( fieldName ) }
 										value={ this.state.fields[ fieldName ] || '' }
 									/>
-									{ isValidatingField &&
-										! isValidField && (
-											<FormInputValidation
-												isError
-												text={ translate( 'Please enter a %(fieldLabel)s', {
-													args: { fieldLabel },
-												} ) }
-											/>
-										) }
 								</FormFieldset>
 							);
 						} ) }

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-import { get, map, omit, reduce, some } from 'lodash';
+import { every, get, map, reduce } from 'lodash';
 import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
@@ -137,8 +137,8 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		this.props.saveJpoSettings( siteId, { businessAddress: this.state.fields } );
 	};
 
-	hasEmptyFields = () => {
-		return some( omit( this.state.fields, 'state' ), val => val === '' );
+	isFormEmpty = () => {
+		return every( this.state.fields, val => val === '' );
 	};
 
 	renderHeader() {
@@ -205,11 +205,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 								</FormFieldset>
 							);
 						} ) }
-						<Button
-							disabled={ isRequestingSettings || this.hasEmptyFields() }
-							primary
-							type="submit"
-						>
+						<Button disabled={ isRequestingSettings || this.isFormEmpty() } primary type="submit">
 							{ translate( 'Add address' ) }
 						</Button>
 					</form>


### PR DESCRIPTION
This PR removes the validation altogether from the business address step - something we've been discussing for a while - see #22842. It didn't use to help a lot, and was basically taking too much space, and had the potential to scare users away.

It also updates the submit button to be available in case any of the fields is NOT empty. This is recommended, because it could feel odd if we insert a completely empty contact form widget in the user's sidebar.

Fixes #22842.

Before:
![](https://cldup.com/LFiI_JCv7i.png)

After:
![](https://cldup.com/I7iqUHIO_a.png)

To test:
* Checkout this branch.
* Pick a Jetpack site.
* Head to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` on the Jetpack site to start the onboarding flow.
* In the site type step, select **Business**
* Skip to the Business Address step.
* Verify you don't see any errors or success indications anymore.
* Verify the submit button is enabled if at least one of the fields is not empty.