### PR TITLE
Adding data attributes to tiles for e2e testing

### DIFF
--- a/client/components/tile-grid/tile.jsx
+++ b/client/components/tile-grid/tile.jsx
@@ -23,6 +23,7 @@ export default class extends React.PureComponent {
 		href: PropTypes.string,
 		image: PropTypes.string,
 		onClick: PropTypes.func,
+		e2eType: PropTypes.string,
 	};
 
 	render() {
@@ -35,6 +36,7 @@ export default class extends React.PureComponent {
 			href,
 			image,
 			onClick,
+			e2eType,
 		} = this.props;
 		const tileClassName = classNames(
 			'tile-grid__item',
@@ -45,7 +47,13 @@ export default class extends React.PureComponent {
 		);
 
 		return (
-			<Card className={ tileClassName } href={ href } onClick={ onClick } tabIndex="-1">
+			<Card
+				className={ tileClassName }
+				href={ href }
+				onClick={ onClick }
+				tabIndex="-1"
+				data-e2e-type={ e2eType }
+			>
 				{ image && (
 					<div className="tile-grid__image">
 						<img src={ image } />

--- a/client/jetpack-onboarding/connect-success.jsx
+++ b/client/jetpack-onboarding/connect-success.jsx
@@ -37,6 +37,7 @@ class ConnectSuccess extends PureComponent {
 						image={ illustration }
 						onClick={ onClick }
 						href={ href }
+						e2eType={ 'continue' }
 					/>
 				</TileGrid>
 			</Fragment>

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -177,6 +177,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 						image="/calypso/images/illustrations/illustration-layout.svg"
 						onClick={ this.handleAddBusinessAddressClick }
 						href={ href }
+						e2eType={ 'business-address' }
 					/>
 				</TileGrid>
 			</Fragment>

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -102,6 +102,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 						image={ '/calypso/images/illustrations/contact-us.svg' }
 						onClick={ this.handleAddContactForm }
 						href={ href }
+						e2eType={ 'contact-form' }
 					/>
 				</TileGrid>
 			</Fragment>

--- a/client/jetpack-onboarding/steps/homepage.jsx
+++ b/client/jetpack-onboarding/steps/homepage.jsx
@@ -55,6 +55,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 						highlighted={ homepageFormat === 'posts' }
 						href={ forwardUrl }
 						onClick={ this.handleHomepageSelection( 'posts' ) }
+						e2eType={ 'posts' }
 					/>
 					<Tile
 						buttonLabel={ translate( 'A static welcome page' ) }
@@ -63,6 +64,7 @@ class JetpackOnboardingHomepageStep extends React.PureComponent {
 						highlighted={ homepageFormat === 'page' }
 						href={ forwardUrl }
 						onClick={ this.handleHomepageSelection( 'page' ) }
+						e2eType={ 'page' }
 					/>
 				</TileGrid>
 			</div>

--- a/client/jetpack-onboarding/steps/site-type.jsx
+++ b/client/jetpack-onboarding/steps/site-type.jsx
@@ -54,6 +54,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 						highlighted={ siteType === 'personal' }
 						href={ forwardUrl }
 						onClick={ this.handleSiteTypeSelection( 'personal' ) }
+						e2eType={ 'personal' }
 					/>
 					<Tile
 						buttonLabel={ translate( 'Business site' ) }
@@ -64,6 +65,7 @@ class JetpackOnboardingSiteTypeStep extends React.PureComponent {
 						highlighted={ siteType === 'business' }
 						href={ forwardUrl }
 						onClick={ this.handleSiteTypeSelection( 'business' ) }
+						e2eType={ 'business' }
 					/>
 				</TileGrid>
 			</div>

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -92,6 +92,7 @@ class JetpackOnboardingStatsStep extends React.Component {
 						image="/calypso/images/illustrations/type-business.svg"
 						onClick={ this.handleActivateStats }
 						href={ href }
+						e2eType={ 'activate-stats' }
 					/>
 				</TileGrid>
 			</Fragment>


### PR DESCRIPTION
I have added the data-e2e-type attribute to the tiles used in the Jetpack Onboarding flow. This will give us something to key off of as we're writing automated tests.

Example:
<img width="481" alt="2018-02-27_0952" src="https://user-images.githubusercontent.com/31110506/36745357-1909a2c8-1ba4-11e8-815e-bd778da8c6b1.png">


@Automattic/flowpatrol 