### PR TITLE
Signup: make theme items accessible via VoiceOver commands

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -120,6 +120,10 @@ export class Theme extends Component {
 		if ( this.props.screenshotClickUrl || this.props.onScreenshotClick ) {
 			return (
 				<a
+					role="link"
+					tabIndex="0"
+					aria-label={ this.props.theme.name }
+					title={ this.props.theme.description }
 					className="theme__active-focus"
 					href={ this.props.screenshotClickUrl }
 					onClick={ this.onScreenshotClick }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -120,12 +120,10 @@ export class Theme extends Component {
 		if ( this.props.screenshotClickUrl || this.props.onScreenshotClick ) {
 			return (
 				<a
-					role="link"
-					tabIndex="0"
 					aria-label={ this.props.theme.name }
 					title={ this.props.theme.description }
 					className="theme__active-focus"
-					href={ this.props.screenshotClickUrl }
+					href={ this.props.screenshotClickUrl || '#' }
 					onClick={ this.onScreenshotClick }
 				>
 					<span>{ this.props.actionLabel }</span>

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -139,7 +139,8 @@ $theme-info-height: 54px;
 	opacity: 0.0;
 	transition: all 200ms ease-in-out;
 
-	&:hover {
+	&:hover,
+	&:focus {
 		opacity: 1.0;
 
 		span {

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -11,7 +11,9 @@ exports[`Theme rendering with default display buttonContents should match snapsh
     className="theme__content"
   >
     <a
+      aria-label="Twenty Seventeen"
       className="theme__active-focus"
+      href="#"
       onClick={[Function]}
     >
       <span />


### PR DESCRIPTION
Fixes #21656 

After trying a few different things, I've found that this was the simplest way to make the theme elements on the _Sign Up_ flow selectable using the VoiceOver shortcuts and having the text make sense.
Other options (doing a larger refactor for example) would have caused regressions on the _Theme_ page, where this component is also used.

How to test:

Using the VoiceOver utility (or other OS equivalent) start the signup flow. A safe flow that includes themes is `/start/free`. You can navigate inside the web area elements using the `Tab` key.
The items on the Theme page should be keyboard selectable and the VoiceOver should make sense.

![screen shot 2018-02-27 at 16 44 19](https://user-images.githubusercontent.com/233601/36751334-b3308206-1bde-11e8-8470-8a9a5d1a8437.png)
![screen shot 2018-02-27 at 16 44 08](https://user-images.githubusercontent.com/233601/36751340-b8a6e036-1bde-11e8-9a22-3603e845acf3.png)
