### PR TITLE
Defer initializing the Guided Tours UI until it's actually displayed

### DIFF
--- a/bin/codemods/src/guided-tours-render.js
+++ b/bin/codemods/src/guided-tours-render.js
@@ -1,0 +1,55 @@
+/** @format */
+
+/**
+ * Guided Tours Rendering Codemod
+ * Transform directly inlined JSX markup into render props. That makes initial load
+ * faster and the Guided Tours get properly translated.
+ */
+
+const config = require( './config' );
+const prettier = require( 'prettier' );
+
+export default function transformer( file, api ) {
+	const j = api.jscodeshift;
+	const root = j( file.source );
+
+	/* Does the file have any <Step> JSX instances? */
+	const stepEls = root.findJSXElements( 'Step' );
+	if ( stepEls.size() === 0 ) {
+		// nothing to transform here
+		return null;
+	}
+
+	stepEls.forEach( stepEl => {
+		/* Extract the children */
+		const stepElValue = stepEl.get().value;
+		const { children } = stepElValue;
+
+		/* Wrap them in a functional component with Fragment */
+		const trIden = j.identifier( 'translate' );
+		const trProp = j.property( 'init', trIden, trIden );
+		trProp.shorthand = true;
+		const fragmentIden = j.jsxIdentifier( 'Fragment' );
+		const childrenFunc = j.arrowFunctionExpression(
+			[ j.objectPattern( [ trProp ] ) ],
+			j.jsxElement(
+				j.jsxOpeningElement( fragmentIden ),
+				j.jsxClosingElement( fragmentIden ),
+				children
+			)
+		);
+
+		/* Replace the children JSX with the functional component */
+		stepElValue.children = [ j.jsxExpressionContainer( childrenFunc ) ];
+	} );
+
+	/* Add `Fragment` to React imports */
+	const reactImport = root.find( j.ImportDeclaration, { source: { value: 'react' } } );
+	reactImport.get().value.specifiers.push( j.importSpecifier( j.identifier( 'Fragment' ) ) );
+
+	/* Remove the i18n import */
+	const i18nImport = root.find( j.ImportDeclaration, { source: { value: 'i18n-calypso' } } );
+	i18nImport.remove();
+
+	return prettier.format( root.toSource( config.recastOptions ), {} );
+}

--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { defer, get, isFunction } from 'lodash';
 import debugFactory from 'debug';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -61,6 +62,7 @@ export default class Step extends Component {
 		canSkip: PropTypes.bool,
 		wait: PropTypes.func,
 		onTargetDisappear: PropTypes.func,
+		children: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -326,7 +328,9 @@ export default class Step extends Component {
 	}
 
 	render() {
-		const { when, children } = this.props;
+		// `children` is a render prop where the value is not the usual JSX markup,
+		// but a React component to render, i.e., function or a class.
+		const { when, children: ContentComponent } = this.props;
 		const { isLastStep } = this.context;
 
 		if ( ! this.state.initialized ) {
@@ -366,7 +370,7 @@ export default class Step extends Component {
 
 		return (
 			<Card className={ classNames( ...classes ) } style={ style }>
-				{ children }
+				<ContentComponent translate={ translate } />
 			</Card>
 		);
 	}

--- a/client/layout/guided-tours/docs/API.md
+++ b/client/layout/guided-tours/docs/API.md
@@ -19,9 +19,9 @@ Tour is a React component that declares the top-level of a tour. It consists of 
 ```jsx
 // tour with a single step
 <Tour path="/me" name="exampleTour" when={ isNewUser }>
-  <Step>
-    …
-  </Step>
+	<Step>
+		…
+	</Step>
 </Tour>
 ```
 
@@ -42,7 +42,7 @@ Step is a React component that defines a single Step of a tour. It is represente
 * `when`: (function, optional) This is a Redux selector that can prevent a step from showing when it evaluates to false. When using `when` you should also set the `next` prop to tell Guided Tours the name of the step it should skip to. If you omit this prop, step will be rendered as expected. Example usage would be to show a certain step only for non-mobile environments: `when={ not( isMobile ) }`
 * `next`: (string, optional) Define this to tell Guided Tours the name of the step it should skip to when `when` evaluates to false.
 * `scrollContainer`: (string, optional) This is a CSS selector for the container that the framework should attempt to scroll in case the target isn't visible. E.g. if the target is a menu item that could be invisible because of a scrolled sidebar, we'd want the framework to scroll the sidebar until the target is visible. The CSS selector to pass would then be `.sidebar__region`. Note: there were some differences for the sidebar between desktop and tablet that don't seem to be a problem anymore, but in any case have been [documented in  this issue](https://github.com/Automattic/wp-calypso/issues/7208).
-* `children`: (node) Contents of the step. Usually a paragraph of instructions and some controls for the tour. See below for available options. Note that all text content needs to be wrapped in `<p>` so it gets proper styling.
+* `children`: (component) Content of the step. Unlike most other components' children, this one takes a so called render prop as a single child. It's a component (function or class) to be rendered when the step is actually displayed. The `translate` function is passed as a prop to the child component. The content is usually a paragraph of instructions and some controls for the tour. See below for available options. Note that all text content needs to be wrapped in `<p>` so it gets proper styling.
 
 ### Example
 
@@ -54,32 +54,40 @@ Here is the code used:
 
 ```jsx
 <Step name="example" placement="below" target="my-sites" arrow="top-left">
-  <p>Plain text description.</p>
-  <p>Multiple lines.</p>
-  <Continue step="next-step" click target="my-sites" icon="my-sites" />
-  <ButtonRow>
-    <Next step="next-step" />
-    <Quit />
-  </ButtonRow>
-  <Link href="https://learn.wordpress.com">
-    { translate( 'Learn more about WordPress.com' ) }
-  </Link>
+	{ ( { translate } ) => (
+		<Fragment>
+			<p>Plain text description.</p>
+			<p>Multiple lines.</p>
+			<Continue step="next-step" click target="my-sites" icon="my-sites" />
+			<ButtonRow>
+				<Next step="next-step" />
+				<Quit />
+			</ButtonRow>
+			<Link href="https://learn.wordpress.com">
+				{ translate( 'Learn more about WordPress.com' ) }
+			</Link>
+		</Fragment>
+	) }
 </Step>
 ```
 
 ## ButtonRow
 
-ButtonRow is a React component to display button controls in Step and takes care of their proper styling. Usually used as the last child of Step to contain all available controls.
+ButtonRow is a React component to display button controls in Step and takes care of their proper styling. Usually used as the last element of Step content to contain all available controls.
 
 ### Example
 
 ```jsx
 <Step>
-  <p>ButtonRow Example</p>
-  <ButtonRow>
-    <Next step="next-step" />
-    <Quit />
-  </ButtonRow>
+	{ () => (
+		<Fragment>
+			<p>ButtonRow Example</p>
+			<ButtonRow>
+				<Next step="next-step" />
+				<Quit />
+			</ButtonRow>
+		</Fragment>
+	) }
 </Step>
 ```
 
@@ -178,13 +186,17 @@ Place Link after ButtonRow (if present) for correct styling.
 ```jsx
 // last step of tour with option to quit or visit learn.wordpress.com
 <Step>
-  <p>This is the last step!</p>
-  <ButtonRow>
-    <Quit />
-  </ButtonRow>
-  <Link href="https://learn.wordpress.com">
-    { translate( 'Learn more about WordPress.com' ) }
-  </Link>
+	{ ( { translate } ) => (
+		<Fragment>
+			<p>This is the last step!</p>
+			<ButtonRow>
+				<Quit />
+			</ButtonRow>
+			<Link href="https://learn.wordpress.com">
+				{ translate( 'Learn more about WordPress.com' ) }
+			</Link>
+		</Fragment>
+	) }
 </Step>
 ```
 
@@ -198,9 +210,9 @@ In the file where the tour is defined, wrap the `Tour` declaration with `makeTou
 
 ```jsx
 export const MyTour = makeTour(
-  <Tour name="my" …>
-    …
-  </Tour>
+	<Tour name="my" …>
+		…
+	</Tour>
 );
 ```
 
@@ -212,9 +224,9 @@ This is a factory for the top-level component of Guided Tours. You shouldn't be 
 
 ```jsx
 combineTours( {
-  main: MainTour,
-  anotherTour: AnotherTour,
-  thirdTour: ThirdTour,
+	main: MainTour,
+	anotherTour: AnotherTour,
+	thirdTour: ThirdTour,
 } );
 ```
 
@@ -269,7 +281,7 @@ We treat the `target` prop as a CSS selector if it contains `.`, `#`, or a space
 
 ```jsx
 // target element
-<Step target=" body">
+<Step target="body">
 ```
 
 Notice the space before "body" in the last example. **This is a hack** that forces the framework to use the value directly as a CSS selector and not as `[data-tip-target="body"]`. Please consider using any other way (CSS class, ID, custom attribute…) before settling with this one.

--- a/client/layout/guided-tours/docs/TUTORIAL.md
+++ b/client/layout/guided-tours/docs/TUTORIAL.md
@@ -59,7 +59,6 @@ First we'll need to create a file for our tour, then add our essential boilerpla
  * External dependencies
  */
 import React from 'react';
-import { translate } from 'i18n-calypso';
 import {
 	overEvery as and,
 } from 'lodash';
@@ -93,14 +92,14 @@ Now add that tour to the [tour list](../config.js):
 +import { TutorialSitePreviewTour } from 'layout/guided-tours/tours/tutorial-site-preview-tour';
 
  export default combineTours( {
-     …
-     siteTitle: SiteTitleTour,
+		 …
+		 siteTitle: SiteTitleTour,
 +    tutorialSitePreview: TutorialSitePreviewTour,
 ```
 
 And add a [feature flag](https://github.com/Automattic/wp-calypso/blob/master/config/development.json) for the appropriate environment(s), such as `"guided-tours/tutorial-site-preview": true,`.
 
-**Important:** use the feature flag to ensure that the tour is only triggered in environments where all the required features are available. E.g. especially the `desktop` environment may differ from general Calypso because of the different context that it runs in and the different release cycles. 
+**Important:** use the feature flag to ensure that the tour is only triggered in environments where all the required features are available. E.g. especially the `desktop` environment may differ from general Calypso because of the different context that it runs in and the different release cycles.
 
 ### The Tour element
 
@@ -114,7 +113,7 @@ export const TutorialSitePreviewTour = makeTour(
 	path="/stats"
 	when={ and(
 		isEnabled( 'guided-tours/main' ),
-        isSelectedSitePreviewable,
+				isSelectedSitePreviewable,
 		isNewUser,
 		) }
 	>
@@ -171,36 +170,37 @@ Now let's insert the first `<Step>` element into the `<Tour>`. It looks like thi
 
 ```JSX
 <Step
-    name="init"
-    target="sitePreview"
-    arrow="top-left"
-    placement="below"
-    scrollContainer=".sidebar__region"
+	name="init"
+	target="sitePreview"
+	arrow="top-left"
+	placement="below"
+	scrollContainer=".sidebar__region"
 >
-    <p>
-        { translate(
-            '{{strong}}View Site{{/strong}} shows you what your site looks like to visitors. Click it to continue.',
-            {
-                components: {
-                    strong: <strong />,
-                },
-            }
-        ) }
-    </p>
-    <Continue hidden click step="finish" target="sitePreview" />
-    <ButtonRow>
-        <Quit subtle>{ translate( 'No, thanks.' ) }</Quit>
-    </ButtonRow>
+	{ ( { translate } ) => (
+		<Fragment>
+			<p>
+				{ translate(
+					'{{strong}}View Site{{/strong}} shows you what your site looks like to visitors. Click it to continue.',
+					{ components: { strong: <strong /> } },
+				) }
+			</p>
+			<Continue hidden click step="finish" target="sitePreview" />
+			<ButtonRow>
+					<Quit subtle>{ translate( 'No, thanks.' ) }</Quit>
+			</ButtonRow>
+		</Fragment>
+	) }
 </Step>
 ```
 
 A few notes:
 
+- the `children` of the `Step` component is not a regular JSX markup. It's a so-called render prop: a component (function or class) to be rendered. The component will be passed the `translate` function as a prop. The reason for this design is performance: we don't need to instantiate all the JSX markup and translate all strings for all steps for all tours statically when loading the modules: they are hidden inside a component and evaluated only when a particular step is actually rendered.
 - The first step of a tour needs to have a name of `init` to be recognizable as the first step by the framework.
 - The `target` is the DOM element the step should be "glued" to or will point at. There are two ways to do that: either the element has a `data-tip-target` attribute, and we pass that name, or we pass a CSS selector that selects that element (cf. method `targetForSlug`). In this case, it's a `data-tip-target`.
 - The `scrollContainer` tells the framework which container it should attempt to scroll in case the `target` isn't visible. In this case, the framework will attempt to scroll the sidebar until the site preview button is in view.
 - `translate` calls: we'd add those only after multiple iterations over the copy. Once you merge something with a `translate` call into `master`, the strings will be translated -- and we don't want to waste anyone's time with translating strings that will still change a few times.
-- The `Continue` steps attributes basically say: when the user `click`s the `target`, proceed to the step called `close-preview` (the next step, below). The `hidden` attribute tells the framework to not add an explanatory text below the step. 
+- The `Continue` steps attributes basically say: when the user `click`s the `target`, proceed to the step called `close-preview` (the next step, below). The `hidden` attribute tells the framework to not add an explanatory text below the step.
 - The `ButtonRow` with the `Quit` button doesn't really look nice, but it's important to provide a way for the user to get out of the tour. The framework will quit a tour if it believes that the user is trying to navigate away from it, but in this case we thought an explicit way to quit would be good to provide.
 
 ## Adding the Second Step
@@ -209,14 +209,18 @@ Now we add the second step after the first one:
 
 ```JSX
 <Step name="finish" placement="center">
-    <p>
-        { translate(
-            "Take a look around — and when you're done, explore the rest of WordPress.com."
-        ) }
-    </p>
-    <ButtonRow>
-        <Quit primary>{ translate( 'Got it.' ) }</Quit>
-    </ButtonRow>
+	{ ( { translate } ) => (
+		<Fragment>
+			<p>
+				{ translate(
+					"Take a look around — and when you're done, explore the rest of WordPress.com."
+				) }
+			</p>
+			<ButtonRow>
+				<Quit primary>{ translate( 'Got it.' ) }</Quit>
+			</ButtonRow>
+		</Fragment>
+	) }
 </Step>
 ```
 

--- a/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
+++ b/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
@@ -1,9 +1,10 @@
 /**
  * External dependencies
+ *
+ * @format
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { overEvery as and } from 'lodash';
 import Gridicon from 'gridicons';
 
@@ -44,30 +45,34 @@ export const SimplePaymentsEndOfYearGuide = makeTour(
 		when={ and( isDesktop, hasSelectedSitePremiumOrBusinessPlan ) }
 	>
 		<Step name="init" placement="right">
-			<p>
-				{ translate(
-					'Prepare for holiday shopping and end-of-year donations: ' +
-						'add a {{strong}}payment button{{/strong}} to sell products and services or accept donations on your site!',
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				) }
-			</p>
-			<div style={ { textAlign: 'center' } }>
-				<img
-					src="/calypso/images/illustrations/illustration-shopping-bags.svg"
-					style={ { width: '210px', height: '160px', marginBottom: '10px' } }
-				/>
-			</div>
-			<ButtonRow>
-				<Next step="add-new-page">{ translate( 'Get started!' ) }</Next>
-				<Quit>{ translate( 'No thanks.' ) }</Quit>
-			</ButtonRow>
-			<Link href="https://en.support.wordpress.com/simple-payments/">
-				{ translate( 'Learn more about Simple Payments.' ) }
-			</Link>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Prepare for holiday shopping and end-of-year donations: ' +
+								'add a {{strong}}payment button{{/strong}} to sell products and services or accept donations on your site!',
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+					<div style={ { textAlign: 'center' } }>
+						<img
+							src="/calypso/images/illustrations/illustration-shopping-bags.svg"
+							style={ { width: '210px', height: '160px', marginBottom: '10px' } }
+						/>
+					</div>
+					<ButtonRow>
+						<Next step="add-new-page">{ translate( 'Get started!' ) }</Next>
+						<Quit>{ translate( 'No thanks.' ) }</Quit>
+					</ButtonRow>
+					<Link href="https://en.support.wordpress.com/simple-payments/">
+						{ translate( 'Learn more about Simple Payments.' ) }
+					</Link>
+				</Fragment>
+			) }
 		</Step>
 		<Step
 			name="add-new-page"
@@ -76,28 +81,36 @@ export const SimplePaymentsEndOfYearGuide = makeTour(
 			placement="beside"
 			style={ { marginTop: '-15px' } }
 		>
-			<p>{ translate( 'To add a payment button, create a page.' ) }</p>
-			<Continue click step="editor-intro" target="li[data-post-type=page] a.sidebar__button">
-				{ translate( 'Click {{strong}}Add{{/strong}} to continue.', {
-					components: {
-						strong: <strong />,
-					},
-				} ) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'To add a payment button, create a page.' ) }</p>
+					<Continue click step="editor-intro" target="li[data-post-type=page] a.sidebar__button">
+						{ translate( 'Click {{strong}}Add{{/strong}} to continue.', {
+							components: {
+								strong: <strong />,
+							},
+						} ) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 		<Step name="editor-intro" placement="center">
-			<p>{ translate( 'Welcome to the Editor! ' ) }</p>
-			<p>
-				{ translate( 'Click {{strong}}Next{{/strong}} to learn how to add a payment button.', {
-					components: {
-						strong: <strong />,
-					},
-				} ) }
-			</p>
-			<ButtonRow>
-				<Next step="editor-insert-button" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Welcome to the Editor! ' ) }</p>
+					<p>
+						{ translate( 'Click {{strong}}Next{{/strong}} to learn how to add a payment button.', {
+							components: {
+								strong: <strong />,
+							},
+						} ) }
+					</p>
+					<ButtonRow>
+						<Next step="editor-insert-button" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 		<Step
 			name="editor-insert-button"
@@ -109,22 +122,26 @@ export const SimplePaymentsEndOfYearGuide = makeTour(
 				zIndex: 'auto',
 			} }
 		>
-			<p>
-				{ translate(
-					'Click the {{icon/}} and choose the {{strong}}Payment Button{{/strong}}. ' +
-						'You will be able to set a price, upload a photo, and describe your product or cause.',
-					{
-						components: {
-							strong: <strong />,
-							icon: <Gridicon icon="add-outline" />,
-						},
-					}
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="editor-set-title" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Click the {{icon/}} and choose the {{strong}}Payment Button{{/strong}}. ' +
+								'You will be able to set a price, upload a photo, and describe your product or cause.',
+							{
+								components: {
+									strong: <strong />,
+									icon: <Gridicon icon="add-outline" />,
+								},
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="editor-set-title" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 		<Step
 			name="editor-set-title"
@@ -133,11 +150,15 @@ export const SimplePaymentsEndOfYearGuide = makeTour(
 			placement="below"
 			style={ { marginTop: '-30px' } }
 		>
-			<p>{ translate( 'Give your page a title here.' ) }</p>
-			<ButtonRow>
-				<Next step="publish" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Give your page a title here.' ) }</p>
+					<ButtonRow>
+						<Next step="publish" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 		<Step
 			name="publish"
@@ -146,27 +167,31 @@ export const SimplePaymentsEndOfYearGuide = makeTour(
 			placement="beside"
 			style={ { marginTop: '-12px' } }
 		>
-			<p>
-				{ translate(
-					'Happy with your new page? Click {{strong}}Publish{{/strong}} to start collecting payments!',
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				) }
-			</p>
-			<p>
-				{ translate(
-					'Remember: add your page to your site navigation so visitors can find it easily'
-				) }
-			</p>
-			<ButtonRow>
-				<Quit primary>{ translate( 'Got it, thanks!' ) }</Quit>
-			</ButtonRow>
-			<Link href="https://en.support.wordpress.com/menus/">
-				{ translate( 'Learn about managing menus' ) }
-			</Link>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Happy with your new page? Click {{strong}}Publish{{/strong}} to start collecting payments!',
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+					<p>
+						{ translate(
+							'Remember: add your page to your site navigation so visitors can find it easily'
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( 'Got it, thanks!' ) }</Quit>
+					</ButtonRow>
+					<Link href="https://en.support.wordpress.com/menus/">
+						{ translate( 'Learn about managing menus' ) }
+					</Link>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/activity-log-tour.js
+++ b/client/layout/guided-tours/tours/activity-log-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { overEvery as and } from 'lodash';
 
 /**
@@ -31,18 +30,22 @@ export const ActivityLogTour = makeTour(
 		when={ and( isDesktop, isNotNewUser ) }
 	>
 		<Step name="init" style={ { animationDelay: '5s' } }>
-			<p>
-				{ translate(
-					'{{strong}}Need a hand?{{/strong}} ' +
-						"We'd love to show you around the Activity Log, " +
-						'and tell you how you can use it to restore a previous state of your site.',
-					{ components: { strong: <strong /> } }
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="rewind">{ translate( "Let's go!" ) }</Next>
-				<Quit>{ translate( 'No, thanks.' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'{{strong}}Need a hand?{{/strong}} ' +
+								"We'd love to show you around the Activity Log, " +
+								'and tell you how you can use it to restore a previous state of your site.',
+							{ components: { strong: <strong /> } }
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="rewind">{ translate( "Let's go!" ) }</Next>
+						<Quit>{ translate( 'No, thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 		<Step
 			name="rewind"
@@ -50,39 +53,53 @@ export const ActivityLogTour = makeTour(
 			target=".has-expanded-summary .activity-log-day__day"
 			placement="below"
 		>
-			<p>
-				{ translate(
-					'Each block collects all the activities performed on your site ' +
-						'like publishing a post or updating a plugin. ' +
-						'To restore your site to a particular day, click its rewind button.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="expand" />
-				<Quit>{ translate( 'Do this later.' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Each block collects all the activities performed on your site ' +
+								'like publishing a post or updating a plugin. ' +
+								'To restore your site to a particular day, click its rewind button.'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="expand" />
+						<Quit>{ translate( 'Do this later.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 		<Step name="expand" arrow="top-left" target=".has-expanded-summary" placement="below">
-			<p>
-				{ translate(
-					'You can click on each block to show more details. ' +
-						'When expanded, it will display every event that happened on that day.'
-				) }
-			</p>
-			<ButtonRow>
-				<Continue click step="events" target=".activity-log-day:not(.is-empty)">
-					{ translate( 'Click on the block to expand it and continue.' ) }
-				</Continue>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'You can click on each block to show more details. ' +
+								'When expanded, it will display every event that happened on that day.'
+						) }
+					</p>
+					<ButtonRow>
+						<Continue click step="events" target=".activity-log-day:not(.is-empty)">
+							{ translate( 'Click on the block to expand it and continue.' ) }
+						</Continue>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 		<Step name="events" arrow="top-left" target=".activity-log-item__card" placement="below">
-			<p>
-				{ translate( 'Each of these events represent an action that took place in your site.' ) }
-			</p>
-			<ButtonRow>
-				<Next step="actions" />
-				<Quit>{ translate( 'Do this later.' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Each of these events represent an action that took place in your site.'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="actions" />
+						<Quit>{ translate( 'Do this later.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 		<Step
 			name="actions"
@@ -94,12 +111,18 @@ export const ActivityLogTour = makeTour(
 			placement="below"
 			style={ { marginLeft: '-18px' } }
 		>
-			<p>
-				{ translate( "In here you'll find each event's options, such as rewinding one by one." ) }
-			</p>
-			<ButtonRow>
-				<Quit primary>{ translate( 'Got it, thanks!' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"In here you'll find each event's options, such as rewinding one by one."
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( 'Got it, thanks!' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/checklist-about-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { noop } from 'lodash';
 import Gridicon from 'gridicons';
 
@@ -25,30 +24,38 @@ import { SetFeaturedImageButton, UpdateButton } from '../button-labels';
 export const ChecklistAboutPageTour = makeTour(
 	<Tour name="checklistAboutPage" version="20171205" path="/non-existent-route" when={ noop }>
 		<Step name="init" target="page-about" arrow="top-left" placement="below">
-			<p>
-				{ translate( 'Click {{b}}About{{/b}} to edit this page.', {
-					components: { b: <strong /> },
-				} ) }
-			</p>
-			<Continue target="page-about" step="about-page" click hidden />
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate( 'Click {{b}}About{{/b}} to edit this page.', {
+							components: { b: <strong /> },
+						} ) }
+					</p>
+					<Continue target="page-about" step="about-page" click hidden />
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="about-page" placement="right">
-			<p>
-				{ translate(
-					'The About Page is often the most visited page on a site. You might find ' +
-						'that it never feels quite done - that’s OK. This is the internet and ' +
-						'we can update it as many times as we want. The key is to just get it started.'
-				) }
-			</p>
-			<p>
-				{ translate(
-					'Let’s change the default text with a new introduction. Here are some questions ' +
-						'to help you out: Who are you and where are you based? Why did you start this site? ' +
-						'What can visitors expect to get out of it?'
-				) }
-			</p>
-			<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'The About Page is often the most visited page on a site. You might find ' +
+								'that it never feels quite done - that’s OK. This is the internet and ' +
+								'we can update it as many times as we want. The key is to just get it started.'
+						) }
+					</p>
+					<p>
+						{ translate(
+							'Let’s change the default text with a new introduction. Here are some questions ' +
+								'to help you out: Who are you and where are you based? Why did you start this site? ' +
+								'What can visitors expect to get out of it?'
+						) }
+					</p>
+					<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -57,14 +64,18 @@ export const ChecklistAboutPageTour = makeTour(
 			arrow="top-left"
 			placement="below"
 		>
-			<p>
-				{ translate(
-					'Featured images are a great way to add more personality to your pages. ' +
-						'Let’s add something a little more relevant to your About page text.'
-				) }
-			</p>
-			<p>{ translate( 'Press anywhere on this image so we can change it.' ) }</p>
-			<Continue target="editor-featured-image-current-image" step="choose-image" click hidden />
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Featured images are a great way to add more personality to your pages. ' +
+								'Let’s add something a little more relevant to your About page text.'
+						) }
+					</p>
+					<p>{ translate( 'Press anywhere on this image so we can change it.' ) }</p>
+					<Continue target="editor-featured-image-current-image" step="choose-image" click hidden />
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -73,8 +84,12 @@ export const ChecklistAboutPageTour = makeTour(
 			placement="beside"
 			arrow="left-top"
 		>
-			<p>{ translate( 'Either pick an image below or add a new one from your computer.' ) }</p>
-			<Next step="click-set-featured-image">{ translate( 'All done, continue' ) }</Next>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Either pick an image below or add a new one from your computer.' ) }</p>
+					<Next step="click-set-featured-image">{ translate( 'All done, continue' ) }</Next>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -83,42 +98,54 @@ export const ChecklistAboutPageTour = makeTour(
 			arrow="right-top"
 			placement="beside"
 		>
-			<Continue target="dialog-base-action-confirm" step="click-update" click>
-				{ translate(
-					'We’re all set, press {{setFeaturedImageButton/}} to add this image to your page.',
-					{
-						components: {
-							setFeaturedImageButton: <SetFeaturedImageButton />,
-						},
-					}
-				) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue target="dialog-base-action-confirm" step="click-update" click>
+						{ translate(
+							'We’re all set, press {{setFeaturedImageButton/}} to add this image to your page.',
+							{
+								components: {
+									setFeaturedImageButton: <SetFeaturedImageButton />,
+								},
+							}
+						) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="click-update" target="editor-publish-button" arrow="right-top" placement="beside">
-			<Continue target="editor-publish-button" step="finish" click>
-				{ translate( 'Almost done, press the {{updateButton/}} button to save your changes.', {
-					components: { updateButton: <UpdateButton /> },
-				} ) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue target="editor-publish-button" step="finish" click>
+						{ translate( 'Almost done, press the {{updateButton/}} button to save your changes.', {
+							components: { updateButton: <UpdateButton /> },
+						} ) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="finish" placement="right">
-			<h1 className="tours__title">
-				<span className="tours__completed-icon-wrapper">
-					<Gridicon icon="checkmark" className="tours__completed-icon" />
-				</span>
-				{ translate( 'Good job, looks great!' ) }
-			</h1>
-			<p>
-				{ translate(
-					'The updates to your About page are being saved. When the page is done saving, let’s ' +
-						'return to our checklist and see what’s next.'
-				) }
-			</p>
-			<SiteLink isButton href={ '/checklist/:site' }>
-				{ translate( 'Return to the checklist' ) }
-			</SiteLink>
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Good job, looks great!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'The updates to your About page are being saved. When the page is done saving, let’s ' +
+								'return to our checklist and see what’s next.'
+						) }
+					</p>
+					<SiteLink isButton href={ '/checklist/:site' }>
+						{ translate( 'Return to the checklist' ) }
+					</SiteLink>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { noop } from 'lodash';
 import Gridicon from 'gridicons';
 
@@ -40,18 +39,22 @@ export const ChecklistContactPageTour = makeTour(
 			when={ isPostEditorSection }
 			canSkip={ false }
 		>
-			<p>
-				{ translate(
-					'Your contact page makes it easy for people to get in touch. Let’s personalize ' +
-						'this page by adding some explaining when and how people can contact you. ' +
-						'Click in the text area below to get started.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
-				<Continue step="featured-images" hidden />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Your contact page makes it easy for people to get in touch. Let’s personalize ' +
+								'this page by adding some explaining when and how people can contact you. ' +
+								'Click in the text area below to get started.'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
+						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+						<Continue step="featured-images" hidden />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -60,14 +63,18 @@ export const ChecklistContactPageTour = makeTour(
 			arrow="top-left"
 			placement="below"
 		>
-			<p>
-				{ translate(
-					'Featured images are a great way to add more personality to your pages. ' +
-						'Let’s add something a little more relevant to you and your site.'
-				) }
-			</p>
-			<p>{ translate( 'Press anywhere on this image so we can change it.' ) }</p>
-			<Continue target="editor-featured-image-current-image" step="choose-image" click hidden />
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Featured images are a great way to add more personality to your pages. ' +
+								'Let’s add something a little more relevant to you and your site.'
+						) }
+					</p>
+					<p>{ translate( 'Press anywhere on this image so we can change it.' ) }</p>
+					<Continue target="editor-featured-image-current-image" step="choose-image" click hidden />
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -80,8 +87,12 @@ export const ChecklistContactPageTour = makeTour(
 				marginLeft: '-40px',
 			} }
 		>
-			<p>{ translate( 'Either pick an image below or add a new one from your computer.' ) }</p>
-			<Next step="click-set-featured-image">{ translate( 'All done, continue' ) }</Next>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Either pick an image below or add a new one from your computer.' ) }</p>
+					<Next step="click-set-featured-image">{ translate( 'All done, continue' ) }</Next>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -91,16 +102,20 @@ export const ChecklistContactPageTour = makeTour(
 			placement="beside"
 			style={ { marginTop: '-10px' } }
 		>
-			<Continue target="dialog-base-action-confirm" step="click-update" click>
-				{ translate(
-					'We’re all set, press {{setFeaturedImageButton/}} to add this image to your page.',
-					{
-						components: {
-							setFeaturedImageButton: <SetFeaturedImageButton />,
-						},
-					}
-				) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue target="dialog-base-action-confirm" step="click-update" click>
+						{ translate(
+							'We’re all set, press {{setFeaturedImageButton/}} to add this image to your page.',
+							{
+								components: {
+									setFeaturedImageButton: <SetFeaturedImageButton />,
+								},
+							}
+						) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -110,29 +125,37 @@ export const ChecklistContactPageTour = makeTour(
 			placement="beside"
 			style={ { marginTop: '-10px' } }
 		>
-			<Continue target="editor-publish-button" step="finish" click>
-				{ translate( 'Almost done, press the {{updateButton/}} button to save your changes.', {
-					components: { updateButton: <UpdateButton /> },
-				} ) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue target="editor-publish-button" step="finish" click>
+						{ translate( 'Almost done, press the {{updateButton/}} button to save your changes.', {
+							components: { updateButton: <UpdateButton /> },
+						} ) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="finish" placement="right">
-			<h1 className="tours__title">
-				<span className="tours__completed-icon-wrapper">
-					<Gridicon icon="checkmark" className="tours__completed-icon" />
-				</span>
-				{ translate( 'Good job, looks great!' ) }
-			</h1>
-			<p>
-				{ translate(
-					'The updates to your Contact page are being saved. When the page is done saving, let’s return ' +
-						'to our checklist and see what’s next.'
-				) }
-			</p>
-			<SiteLink isButton href={ '/checklist/:site' }>
-				{ translate( 'Return to the checklist' ) }
-			</SiteLink>
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Good job, looks great!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'The updates to your Contact page are being saved. When the page is done saving, let’s return ' +
+								'to our checklist and see what’s next.'
+						) }
+					</p>
+					<SiteLink isButton href={ '/checklist/:site' }>
+						{ translate( 'Return to the checklist' ) }
+					</SiteLink>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { delay, noop, negate as not } from 'lodash';
 import Gridicon from 'gridicons';
 
@@ -72,19 +71,23 @@ export const ChecklistPublishPostTour = makeTour(
 			when={ inSection( 'post-editor' ) }
 			canSkip={ false }
 		>
-			<p>
-				{ translate(
-					'It’s time to get your blog rolling with your first post. Let’s replace the copy ' +
-						'below with a brief introduction. Here are some questions that can help you out: ' +
-						'Who are you and where are you based? Why did you start this site? What can ' +
-						'visitors expect to get out of it?'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="categories-tags">{ translate( 'All done, continue' ) }</Next>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
-				<Continue step="categories-tags" hidden />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'It’s time to get your blog rolling with your first post. Let’s replace the copy ' +
+								'below with a brief introduction. Here are some questions that can help you out: ' +
+								'Who are you and where are you based? Why did you start this site? What can ' +
+								'visitors expect to get out of it?'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="categories-tags">{ translate( 'All done, continue' ) }</Next>
+						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+						<Continue step="categories-tags" hidden />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -98,19 +101,22 @@ export const ChecklistPublishPostTour = makeTour(
 			} }
 			wait={ openSidebar }
 		>
-			<p>
-				{ translate(
-					'Categories and Tags not only help organize your content but also bring people to ' +
-						'your site via the Reader. Click on the {{b}}Categories and Tags{{/b}} section ' +
-						'to expand it and pick one or two descriptive tags like "blogging" or "welcome" ' +
-						'for it to start showing up to other users in the Reader.',
-					{
-						components: { b: <strong /> },
-					}
-				) }
-			</p>
-
-			<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Categories and Tags not only help organize your content but also bring people to ' +
+								'your site via the Reader. Click on the {{b}}Categories and Tags{{/b}} section ' +
+								'to expand it and pick one or two descriptive tags like "blogging" or "welcome" ' +
+								'for it to start showing up to other users in the Reader.',
+							{
+								components: { b: <strong /> },
+							}
+						) }
+					</p>
+					<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -120,15 +126,19 @@ export const ChecklistPublishPostTour = makeTour(
 			placement="below"
 			when={ isFeaturedImageSet }
 		>
-			<Continue target="editor-featured-image-current-image" step="choose-image" click>
-				<p>
-					{ translate(
-						'Featured images are a great way to add more personality to your pages. ' +
-							'Let’s add something a little more relevant to your blog post.'
-					) }
-				</p>
-				<p>{ translate( 'Press anywhere on this image so we can change it.' ) }</p>
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue target="editor-featured-image-current-image" step="choose-image" click>
+						<p>
+							{ translate(
+								'Featured images are a great way to add more personality to your pages. ' +
+									'Let’s add something a little more relevant to your blog post.'
+							) }
+						</p>
+						<p>{ translate( 'Press anywhere on this image so we can change it.' ) }</p>
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -139,16 +149,20 @@ export const ChecklistPublishPostTour = makeTour(
 			style={ { marginTop: '-10px' } }
 			wait={ openFeatureImageUploadDialog }
 		>
-			<ConditionalBlock when={ not( isFeaturedImageSet ) }>
-				<p>
-					{ translate(
-						'Featured images are a great way to add more personality to your pages. ' +
-							'Let’s add something a little more relevant to your blog post.'
-					) }
-				</p>
-			</ConditionalBlock>
-			<p>{ translate( 'Either pick an image below or add a new one from your computer.' ) }</p>
-			<Next step="click-set-featured-image">{ translate( 'All done, continue' ) }</Next>
+			{ ( { translate } ) => (
+				<Fragment>
+					<ConditionalBlock when={ not( isFeaturedImageSet ) }>
+						<p>
+							{ translate(
+								'Featured images are a great way to add more personality to your pages. ' +
+									'Let’s add something a little more relevant to your blog post.'
+							) }
+						</p>
+					</ConditionalBlock>
+					<p>{ translate( 'Either pick an image below or add a new one from your computer.' ) }</p>
+					<Next step="click-set-featured-image">{ translate( 'All done, continue' ) }</Next>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -159,14 +173,18 @@ export const ChecklistPublishPostTour = makeTour(
 			style={ { marginTop: '-10px' } }
 			when={ isSidebarOpen }
 		>
-			<Continue target="dialog-base-action-confirm" step="click-update" click>
-				{ translate(
-					'We’re all set, press {{b}}Set Featured Image{{/b}} to add this image to your blog post.',
-					{
-						components: { b: <strong /> },
-					}
-				) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue target="dialog-base-action-confirm" step="click-update" click>
+						{ translate(
+							'We’re all set, press {{b}}Set Featured Image{{/b}} to add this image to your blog post.',
+							{
+								components: { b: <strong /> },
+							}
+						) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -176,29 +194,37 @@ export const ChecklistPublishPostTour = makeTour(
 			placement="beside"
 			style={ { marginTop: '-10px' } }
 		>
-			<Continue target="editor-publish-button" step="finish" click>
-				{ translate( 'Almost done, press the {{b}}Update{{/b}} button to save your changes.', {
-					components: { b: <strong /> },
-				} ) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue target="editor-publish-button" step="finish" click>
+						{ translate( 'Almost done, press the {{b}}Update{{/b}} button to save your changes.', {
+							components: { b: <strong /> },
+						} ) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="finish" placement="right">
-			<h1 className="tours__title">
-				<span className="tours__completed-icon-wrapper">
-					<Gridicon icon="checkmark" className="tours__completed-icon" />
-				</span>
-				{ translate( 'You did it!' ) }
-			</h1>
-			<p>
-				{ translate(
-					'You published your first blog post. ' +
-						'Let’s move on and see what’s next on our checklist.'
-				) }
-			</p>
-			<SiteLink isButton href={ '/checklist/:site' }>
-				{ translate( 'Return to the checklist' ) }
-			</SiteLink>
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'You did it!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'You published your first blog post. ' +
+								'Let’s move on and see what’s next on our checklist.'
+						) }
+					</p>
+					<SiteLink isButton href={ '/checklist/:site' }>
+						{ translate( 'Return to the checklist' ) }
+					</SiteLink>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/checklist-site-icon-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour.js
@@ -47,7 +47,8 @@ export const ChecklistSiteIconTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							'Press {{changeButton/}} to upload your own image or icon that can help people identify your site in the browser.',
+							'Press {{changeButton/}} to upload your own image or icon ' +
+								'that can help people identify your site in the browser.',
 							{
 								components: { changeButton: <ChangeButton /> },
 							}

--- a/client/layout/guided-tours/tours/checklist-site-icon-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import Gridicon from 'gridicons';
 import { noop } from 'lodash';
 
@@ -44,20 +43,24 @@ export const ChecklistSiteIconTour = makeTour(
 				zIndex: 1,
 			} }
 		>
-			<p>
-				{ translate(
-					'Press {{changeButton/}} to upload your own image or icon that can help people identify your site in the browser.',
-					{
-						components: { changeButton: <ChangeButton /> },
-					}
-				) }
-			</p>
-			<ButtonRow>
-				<Continue target="settings-site-icon-change" step="choose-image" click hidden />
-				<SiteLink isButton={ false } href="/checklist/:site">
-					{ translate( 'Return to the checklist' ) }
-				</SiteLink>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Press {{changeButton/}} to upload your own image or icon that can help people identify your site in the browser.',
+							{
+								components: { changeButton: <ChangeButton /> },
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Continue target="settings-site-icon-change" step="choose-image" click hidden />
+						<SiteLink isButton={ false } href="/checklist/:site">
+							{ translate( 'Return to the checklist' ) }
+						</SiteLink>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -71,10 +74,16 @@ export const ChecklistSiteIconTour = makeTour(
 			} }
 			onTargetDisappear={ handleTargetDisappear }
 		>
-			<p>
-				{ translate( 'Pick or drag a file from your computer to add it to your media library.' ) }
-			</p>
-			<Next step="click-continue">{ translate( 'All done, continue' ) }</Next>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Pick or drag a file from your computer to add it to your media library.'
+						) }
+					</p>
+					<Next step="click-continue">{ translate( 'All done, continue' ) }</Next>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -85,11 +94,15 @@ export const ChecklistSiteIconTour = makeTour(
 			style={ { marginTop: '40px', marginLeft: '60px' } }
 			onTargetDisappear={ handleTargetDisappear }
 		>
-			<Continue target="dialog-base-action-confirm" step="click-done" click>
-				{ translate( 'Good choice, press {{continueButton/}} to use it as your Site Icon.', {
-					components: { continueButton: <ContinueButton /> },
-				} ) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue target="dialog-base-action-confirm" step="click-done" click>
+						{ translate( 'Good choice, press {{continueButton/}} to use it as your Site Icon.', {
+							components: { continueButton: <ContinueButton /> },
+						} ) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -99,29 +112,37 @@ export const ChecklistSiteIconTour = makeTour(
 			placement="above"
 			style={ { marginTop: '30px', marginLeft: '90px' } }
 		>
-			<Continue target="image-editor-button-done" step="finish" click>
-				{ translate(
-					'Let’s make sure it looks right before you press {{doneButton/}} to save your changes.',
-					{ components: { doneButton: <DoneButton /> } }
-				) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue target="image-editor-button-done" step="finish" click>
+						{ translate(
+							'Let’s make sure it looks right before you press {{doneButton/}} to save your changes.',
+							{ components: { doneButton: <DoneButton /> } }
+						) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="finish" placement="right">
-			<h1 className="tours__title">
-				<span className="tours__completed-icon-wrapper">
-					<Gridicon icon="checkmark" className="tours__completed-icon" />
-				</span>
-				{ translate( 'Excellent, you’re done!' ) }
-			</h1>
-			<p>
-				{ translate(
-					'Your Site Icon has been saved. Let’s move on and see what’s next on our checklist.'
-				) }
-			</p>
-			<SiteLink isButton href={ '/checklist/:site' }>
-				{ translate( 'Return to the checklist' ) }
-			</SiteLink>
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Excellent, you’re done!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'Your Site Icon has been saved. Let’s move on and see what’s next on our checklist.'
+						) }
+					</p>
+					<SiteLink isButton href={ '/checklist/:site' }>
+						{ translate( 'Return to the checklist' ) }
+					</SiteLink>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { noop } from 'lodash';
 import Gridicon from 'gridicons';
 
@@ -34,45 +33,57 @@ export const ChecklistSiteTaglineTour = makeTour(
 				animationDelay: '0.7s',
 			} }
 		>
-			<p>
-				{ translate(
-					'First impressions last - a tagline tells visitors what your site is all about without ' +
-						'having to read all your content. Enter a short descriptive phrase about your site into ' +
-						'the {{siteTaglineButton/}} field.',
-					{ components: { siteTaglineButton: <SiteTaglineButton /> } }
-				) }
-			</p>
-			<ButtonRow>
-				<Continue target="settings-site-profile-save" step="finish" click hidden />
-				<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'First impressions last - a tagline tells visitors what your site is all about without ' +
+								'having to read all your content. Enter a short descriptive phrase about your site into ' +
+								'the {{siteTaglineButton/}} field.',
+							{ components: { siteTaglineButton: <SiteTaglineButton /> } }
+						) }
+					</p>
+					<ButtonRow>
+						<Continue target="settings-site-profile-save" step="finish" click hidden />
+						<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
+						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="click-save" target="settings-site-profile-save" arrow="top-left" placement="below">
-			<Continue target="settings-site-profile-save" step="finish" click>
-				{ translate(
-					'Almost done — press {{saveSettingsButton/}} to save your changes and then see what’s next on our list.',
-					{ components: { saveSettingsButton: <SaveSettingsButton /> } }
-				) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue target="settings-site-profile-save" step="finish" click>
+						{ translate(
+							'Almost done — press {{saveSettingsButton/}} to save your changes and then see what’s next on our list.',
+							{ components: { saveSettingsButton: <SaveSettingsButton /> } }
+						) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="finish" placement="right">
-			<h1 className="tours__title">
-				<span className="tours__completed-icon-wrapper">
-					<Gridicon icon="checkmark" className="tours__completed-icon" />
-				</span>
-				{ translate( 'Way to go!' ) }
-			</h1>
-			<p>
-				{ translate(
-					'Your tagline has been saved! Let’s move on and see what’s next on our checklist.'
-				) }
-			</p>
-			<SiteLink isButton href={ '/checklist/:site' }>
-				{ translate( 'Return to the checklist' ) }
-			</SiteLink>
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Way to go!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'Your tagline has been saved! Let’s move on and see what’s next on our checklist.'
+						) }
+					</p>
+					<SiteLink isButton href={ '/checklist/:site' }>
+						{ translate( 'Return to the checklist' ) }
+					</SiteLink>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/checklist-site-title-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { noop } from 'lodash';
 import Gridicon from 'gridicons';
 
@@ -34,45 +33,57 @@ export const ChecklistSiteTitleTour = makeTour(
 				animationDelay: '0.7s',
 			} }
 		>
-			<p>
-				{ translate(
-					'Update the {{siteTitleButton/}} field with a descriptive name to let your visitors know which site they’re visiting.',
-					{
-						components: { siteTitleButton: <SiteTitleButton /> },
-					}
-				) }
-			</p>
-			<ButtonRow>
-				<Continue target="settings-site-profile-save" step="finish" click hidden />
-				<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
-				<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Update the {{siteTitleButton/}} field with a descriptive name to let your visitors know which site they’re visiting.',
+							{
+								components: { siteTitleButton: <SiteTitleButton /> },
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Continue target="settings-site-profile-save" step="finish" click hidden />
+						<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
+						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="click-save" target="settings-site-profile-save" arrow="top-left" placement="below">
-			<Continue target="settings-site-profile-save" step="finish" click>
-				{ translate(
-					'Almost done — every time you make a change, it needs to be saved. ' +
-						'Let’s save your changes and then see what’s next on our list.'
-				) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue target="settings-site-profile-save" step="finish" click>
+						{ translate(
+							'Almost done — every time you make a change, it needs to be saved. ' +
+								'Let’s save your changes and then see what’s next on our list.'
+						) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="finish" placement="right">
-			<h1 className="tours__title">
-				<span className="tours__completed-icon-wrapper">
-					<Gridicon icon="checkmark" className="tours__completed-icon" />
-				</span>
-				{ translate( 'Good job, looks great!' ) }
-			</h1>
-			<p>
-				{ translate(
-					'Your changes have been saved. Let’s move on and see what’s next on our checklist.'
-				) }
-			</p>
-			<SiteLink isButton href={ '/checklist/:site' }>
-				{ translate( 'Return to the checklist' ) }
-			</SiteLink>
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Good job, looks great!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'Your changes have been saved. Let’s move on and see what’s next on our checklist.'
+						) }
+					</p>
+					<SiteLink isButton href={ '/checklist/:site' }>
+						{ translate( 'Return to the checklist' ) }
+					</SiteLink>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/checklist-site-title-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour.js
@@ -37,7 +37,8 @@ export const ChecklistSiteTitleTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							'Update the {{siteTitleButton/}} field with a descriptive name to let your visitors know which site they’re visiting.',
+							'Update the {{siteTitleButton/}} field with a descriptive name ' +
+								'to let your visitors know which site they’re visiting.',
 							{
 								components: { siteTitleButton: <SiteTitleButton /> },
 							}

--- a/client/layout/guided-tours/tours/checklist-user-avatar-tour.js
+++ b/client/layout/guided-tours/tours/checklist-user-avatar-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { noop } from 'lodash';
 import Gridicon from 'gridicons';
 
@@ -33,50 +32,66 @@ export const ChecklistUserAvatarTour = makeTour(
 				animationDelay: '0.7s',
 			} }
 		>
-			<p>
-				{ translate(
-					'Personalize your posts and comments with a profile picture. ' +
-						'Click on this image to upload your new image.'
-				) }
-			</p>
-			<ButtonRow>
-				<Continue target="edit-gravatar" step="image-notice" click hidden />
-				<SiteLink isButton={ false } href="/checklist/:site">
-					{ translate( 'Return to the checklist' ) }
-				</SiteLink>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Personalize your posts and comments with a profile picture. ' +
+								'Click on this image to upload your new image.'
+						) }
+					</p>
+					<ButtonRow>
+						<Continue target="edit-gravatar" step="image-notice" click hidden />
+						<SiteLink isButton={ false } href="/checklist/:site">
+							{ translate( 'Return to the checklist' ) }
+						</SiteLink>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="image-notice" placement="right">
-			<p>{ translate( "Let's make sure it looks right before we proceed." ) }</p>
-			<Next step="crop-image">{ translate( 'Looks good, continue' ) }</Next>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( "Let's make sure it looks right before we proceed." ) }</p>
+					<Next step="crop-image">{ translate( 'Looks good, continue' ) }</Next>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="crop-image" placement="right">
-			<p>
-				{ translate( 'Alright! Press {{b}}Change My Photo{{/b}} to save your changes.', {
-					components: { b: <strong /> },
-				} ) }
-			</p>
-			<Continue target="image-editor-button-done" step="finish" click hidden />
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate( 'Alright! Press {{b}}Change My Photo{{/b}} to save your changes.', {
+							components: { b: <strong /> },
+						} ) }
+					</p>
+					<Continue target="image-editor-button-done" step="finish" click hidden />
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="finish" placement="right">
-			<h1 className="tours__title">
-				<span className="tours__completed-icon-wrapper">
-					<Gridicon icon="checkmark" className="tours__completed-icon" />
-				</span>
-				{ translate( 'Well done!' ) }
-			</h1>
-			<p>
-				{ translate(
-					'Your profile picture has been saved. ' +
-						"Let's move on and see what's next on our checklist."
-				) }
-			</p>
-			<SiteLink isButton href="/checklist/:site">
-				{ translate( 'Return to the checklist' ) }
-			</SiteLink>
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Well done!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'Your profile picture has been saved. ' +
+								"Let's move on and see what's next on our checklist."
+						) }
+					</p>
+					<SiteLink isButton href="/checklist/:site">
+						{ translate( 'Return to the checklist' ) }
+					</SiteLink>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/design-showcase-welcome-tour.js
+++ b/client/layout/guided-tours/tours/design-showcase-welcome-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { overEvery as and, negate as not } from 'lodash';
 import Gridicon from 'gridicons';
 
@@ -48,16 +47,20 @@ export const DesignShowcaseWelcomeTour = makeTour(
 		) }
 	>
 		<Step name="init" placement="right" next="search">
-			<p>
-				{ translate(
-					'On this page, you can explore our many themes. ' +
-						"Want to learn how to find the design that fits the site you're building?"
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="search">{ translate( "Let's go!" ) }</Next>
-				<Quit>{ translate( 'No, thanks.' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'On this page, you can explore our many themes. ' +
+								"Want to learn how to find the design that fits the site you're building?"
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="search">{ translate( "Let's go!" ) }</Next>
+						<Quit>{ translate( 'No, thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -67,15 +70,19 @@ export const DesignShowcaseWelcomeTour = makeTour(
 			placement="below"
 			next="theme-options"
 		>
-			<p>
-				{ translate(
-					'Search for your ideal theme by feature, look, or topic — you can use words like "business", "photography", or "food".'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="theme-options" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Search for your ideal theme by feature, look, or topic — you can use words like "business", "photography", or "food".'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="theme-options" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -86,30 +93,40 @@ export const DesignShowcaseWelcomeTour = makeTour(
 			scrollContainer="body"
 			shouldScrollTo
 		>
-			<p>
-				{ translate(
-					'Scroll down to discover more themes. Found anything you like? ' +
-						'Try clicking the three dots — {{icon/}} — for more theme options.',
-					{
-						components: { icon: <Gridicon icon="ellipsis" /> },
-					}
-				) }
-			</p>
-			<Continue
-				icon="ellipsis"
-				step="finish"
-				target=".card.theme:nth-child(4) .theme__more-button"
-				when={ anyThemeMoreButtonClicked }
-			/>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Scroll down to discover more themes. Found anything you like? ' +
+								'Try clicking the three dots — {{icon/}} — for more theme options.',
+							{
+								components: { icon: <Gridicon icon="ellipsis" /> },
+							}
+						) }
+					</p>
+					<Continue
+						icon="ellipsis"
+						step="finish"
+						target=".card.theme:nth-child(4) .theme__more-button"
+						when={ anyThemeMoreButtonClicked }
+					/>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="finish" target=".popover" placement="beside">
-			<p>
-				{ translate( 'This menu lets you preview and set up any theme, or learn more about it.' ) }
-			</p>
-			<ButtonRow>
-				<Quit primary>{ translate( "We're all done!" ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'This menu lets you preview and set up any theme, or learn more about it.'
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( "We're all done!" ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/design-showcase-welcome-tour.js
+++ b/client/layout/guided-tours/tours/design-showcase-welcome-tour.js
@@ -74,7 +74,8 @@ export const DesignShowcaseWelcomeTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							'Search for your ideal theme by feature, look, or topic — you can use words like "business", "photography", or "food".'
+							'Search for your ideal theme by feature, look, or topic — ' +
+								'you can use words like "business", "photography", or "food".'
 						) }
 					</p>
 					<ButtonRow>

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -62,6 +62,7 @@ export const EditorBasicsTour = makeTour(
 					<img
 						src="https://i0.wp.com/en-support.files.wordpress.com/2017/03/editor-content-area_360.gif"
 						style={ { marginBottom: '10px', border: '3px solid #00AADC', borderRadius: '4px' } }
+						alt=""
 					/>
 					<ButtonRow>
 						<Next step="add-things" />

--- a/client/layout/guided-tours/tours/editor-basics-tour.js
+++ b/client/layout/guided-tours/tours/editor-basics-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { overEvery as and } from 'lodash';
 import Gridicon from 'gridicons';
 
@@ -40,11 +39,15 @@ export const EditorBasicsTour = makeTour(
 			placement="below"
 			style={ { animationDelay: '5s' } }
 		>
-			<p>{ translate( 'Welcome to the editor! Add a title here.' ) }</p>
-			<ButtonRow>
-				<Next step="write" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Welcome to the editor! Add a title here.' ) }</p>
+					<ButtonRow>
+						<Next step="write" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 		<Step
 			name="write"
@@ -53,15 +56,19 @@ export const EditorBasicsTour = makeTour(
 			placement="below"
 			style={ { marginTop: '40px' } }
 		>
-			<p>{ translate( 'Write your post in the content area.' ) }</p>
-			<img
-				src="https://i0.wp.com/en-support.files.wordpress.com/2017/03/editor-content-area_360.gif"
-				style={ { marginBottom: '10px', border: '3px solid #00AADC', borderRadius: '4px' } }
-			/>
-			<ButtonRow>
-				<Next step="add-things" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Write your post in the content area.' ) }</p>
+					<img
+						src="https://i0.wp.com/en-support.files.wordpress.com/2017/03/editor-content-area_360.gif"
+						style={ { marginBottom: '10px', border: '3px solid #00AADC', borderRadius: '4px' } }
+					/>
+					<ButtonRow>
+						<Next step="add-things" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 		<Step
 			name="add-things"
@@ -70,23 +77,27 @@ export const EditorBasicsTour = makeTour(
 			placement="below"
 			style={ { marginLeft: '-7px', zIndex: 'auto' } }
 		>
-			<p>
-				{ translate(
-					'Click the {{icon/}} to add images and other things, like a contact form. ' +
-						'Sites on the Premium and Business plans can add {{strong}}payment buttons{{/strong}} — ' +
-						'sell tickets, collect donations, accept tips, and more.',
-					{
-						components: {
-							strong: <strong />,
-							icon: <Gridicon icon="add-outline" />,
-						},
-					}
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="sidebar-options" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Click the {{icon/}} to add images and other things, like a contact form. ' +
+								'Sites on the Premium and Business plans can add {{strong}}payment buttons{{/strong}} — ' +
+								'sell tickets, collect donations, accept tips, and more.',
+							{
+								components: {
+									strong: <strong />,
+									icon: <Gridicon icon="add-outline" />,
+								},
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="sidebar-options" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 		<Step
 			name="sidebar-options"
@@ -95,18 +106,22 @@ export const EditorBasicsTour = makeTour(
 			placement="beside"
 			style={ { marginTop: '-9px' } }
 		>
-			<p>{ translate( 'Add tags, categories, and a featured image from the sidebar.' ) }</p>
-			<p>
-				{ translate( 'Click the {{icon/}} to show or hide these settings.', {
-					components: {
-						icon: <Gridicon icon="cog" />,
-					},
-				} ) }
-			</p>
-			<ButtonRow>
-				<Next step="publish" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Add tags, categories, and a featured image from the sidebar.' ) }</p>
+					<p>
+						{ translate( 'Click the {{icon/}} to show or hide these settings.', {
+							components: {
+								icon: <Gridicon icon="cog" />,
+							},
+						} ) }
+					</p>
+					<ButtonRow>
+						<Next step="publish" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 		<Step
 			name="publish"
@@ -115,23 +130,27 @@ export const EditorBasicsTour = makeTour(
 			placement="beside"
 			style={ { marginTop: '-17px' } }
 		>
-			<p>
-				{ translate(
-					'Your changes are saved automatically. ' +
-						'Click {{publishButton/}} to share your work with the world!',
-					{
-						components: {
-							publishButton: <PublishButton />,
-						},
-					}
-				) }
-			</p>
-			<ButtonRow>
-				<Quit primary>{ translate( "Got it, I'm ready to write!" ) }</Quit>
-			</ButtonRow>
-			<Link href="https://learn.wordpress.com/get-published/">
-				{ translate( 'Learn more about publishing content.' ) }
-			</Link>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Your changes are saved automatically. ' +
+								'Click {{publishButton/}} to share your work with the world!',
+							{
+								components: {
+									publishButton: <PublishButton />,
+								},
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( "Got it, I'm ready to write!" ) }</Quit>
+					</ButtonRow>
+					<Link href="https://learn.wordpress.com/get-published/">
+						{ translate( 'Learn more about publishing content.' ) }
+					</Link>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/gdocs-integration-tour.js
+++ b/client/layout/guided-tours/tours/gdocs-integration-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { overEvery as and } from 'lodash';
 
 /**
@@ -35,18 +34,22 @@ export const GDocsIntegrationTour = makeTour(
 		when={ and( isCurrentUserEmailVerified, hasUserPastedFromGoogleDocs ) }
 	>
 		<Step name="init" placement="right">
-			<p>{ translate( 'Did you know you can create drafts from Google Docs?' ) }</p>
-			<ButtonRow>
-				<LinkQuit
-					primary
-					target="_blank"
-					onClick={ trackUserInterest }
-					href="https://apps.wordpress.com/google-docs/"
-				>
-					{ translate( 'Learn more' ) }
-				</LinkQuit>
-				<Quit>{ translate( 'No thanks' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Did you know you can create drafts from Google Docs?' ) }</p>
+					<ButtonRow>
+						<LinkQuit
+							primary
+							target="_blank"
+							onClick={ trackUserInterest }
+							href="https://apps.wordpress.com/google-docs/"
+						>
+							{ translate( 'Learn more' ) }
+						</LinkQuit>
+						<Quit>{ translate( 'No thanks' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/main-tour.js
+++ b/client/layout/guided-tours/tours/main-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { overEvery as and } from 'lodash';
 
 /**
@@ -43,48 +42,60 @@ export const MainTour = makeTour(
 		when={ and( isNewUser, isEnabled( 'guided-tours/main' ) ) }
 	>
 		<Step name="init" placement="right">
-			<p>
-				{ translate(
-					"{{strong}}Need a hand?{{/strong}} We'd love to show you around the place, " +
-						'and give you some ideas for what to do next.',
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="my-sites">{ translate( "Let's go!" ) }</Next>
-				<Quit>{ translate( 'No thanks.' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"{{strong}}Need a hand?{{/strong}} We'd love to show you around the place, " +
+								'and give you some ideas for what to do next.',
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="my-sites">{ translate( "Let's go!" ) }</Next>
+						<Quit>{ translate( 'No thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="my-sites" target="my-sites" placement="below" arrow="top-left">
-			<p>
-				{ translate(
-					"{{strong}}First things first.{{/strong}} Up here, you'll find tools for managing " +
-						"your site's content and design.",
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				) }
-			</p>
-			<Continue click icon="my-sites" step="sidebar" target="my-sites" />
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"{{strong}}First things first.{{/strong}} Up here, you'll find tools for managing " +
+								"your site's content and design.",
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+					<Continue click icon="my-sites" step="sidebar" target="my-sites" />
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="sidebar" target="sidebar" arrow="left-middle" placement="beside">
-			<p>
-				{ translate(
-					'This menu lets you navigate around, and will adapt to give you the tools you need when you need them.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="click-preview" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'This menu lets you navigate around, and will adapt to give you the tools you need when you need them.'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="click-preview" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -95,25 +106,33 @@ export const MainTour = makeTour(
 			when={ isSelectedSitePreviewable }
 			scrollContainer=".sidebar__region"
 		>
-			<p>{ translate( 'Want to take a look at your site?' ) }</p>
-			<Continue click step="view-site" target="sitePreview">
-				{ translate( 'Click {{viewSiteButton/}} to continue.', {
-					components: {
-						viewSiteButton: <ViewSiteButton />,
-					},
-				} ) }
-			</Continue>
-			<ButtonRow>
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Want to take a look at your site?' ) }</p>
+					<Continue click step="view-site" target="sitePreview">
+						{ translate( 'Click {{viewSiteButton/}} to continue.', {
+							components: {
+								viewSiteButton: <ViewSiteButton />,
+							},
+						} ) }
+					</Continue>
+					<ButtonRow>
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="view-site" placement="center" when={ isSelectedSitePreviewable }>
-			<p>{ translate( 'This is what your site looks like to visitors.' ) }</p>
-			<ButtonRow>
-				<Next step="themes" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'This is what your site looks like to visitors.' ) }</p>
+					<ButtonRow>
+						<Next step="themes" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -125,42 +144,50 @@ export const MainTour = makeTour(
 			scrollContainer=".sidebar__region"
 			shouldScrollTo
 		>
-			<p>
-				{ translate(
-					'Change your {{strong}}Theme{{/strong}} to choose a new layout, or {{strong}}Customize{{/strong}} ' +
-						"your theme's colors, fonts, and more.",
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="finish" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Change your {{strong}}Theme{{/strong}} to choose a new layout, or {{strong}}Customize{{/strong}} ' +
+								"your theme's colors, fonts, and more.",
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="finish" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="finish" placement="center">
-			<p>
-				{ translate(
-					"{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around.",
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				) }
-			</p>
-			<ButtonRow>
-				<Quit onClick={ scrollSidebarToTop } primary>
-					{ translate( "We're all done!" ) }
-				</Quit>
-			</ButtonRow>
-			<Link href="https://learn.wordpress.com">
-				{ translate( 'Learn more about WordPress.com' ) }
-			</Link>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around.",
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Quit onClick={ scrollSidebarToTop } primary>
+							{ translate( "We're all done!" ) }
+						</Quit>
+					</ButtonRow>
+					<Link href="https://learn.wordpress.com">
+						{ translate( 'Learn more about WordPress.com' ) }
+					</Link>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/media-basics-tour.js
+++ b/client/layout/guided-tours/tours/media-basics-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { overEvery as and } from 'lodash';
 
 /**
@@ -32,39 +31,46 @@ export const MediaBasicsTour = makeTour(
 		when={ and( isDesktop, isNewUser ) }
 	>
 		<Step name="init" arrow="top-left" target=".media-library__upload-buttons" placement="below">
-			<p>{ translate( 'Welcome to your media libary!' ) }</p>
-			<p>
-				{ translate(
-					'Upload media — photos, documents, audio files, and more — ' +
-						'by clicking the {{addNewButton/}} button.',
-					{
-						components: {
-							addNewButton: <AddNewButton />,
-						},
-					}
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="drag-and-drop" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Welcome to your media libary!' ) }</p>
+					<p>
+						{ translate(
+							'Upload media — photos, documents, audio files, and more — ' +
+								'by clicking the {{addNewButton/}} button.',
+							{
+								components: {
+									addNewButton: <AddNewButton />,
+								},
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="drag-and-drop" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="drag-and-drop" placement="right">
-			<p>
-				{ translate(
-					'You can also drag-and-drop image and video files from your computer into your media library.'
-				) }
-			</p>
-			<img
-				src="https://i0.wp.com/en-support.files.wordpress.com/2017/07/media-drag-and-drop.gif"
-				style={ { marginBottom: '10px', border: '3px solid #00AADC', borderRadius: '4px' } }
-			/>
-
-			<ButtonRow>
-				<Next step="select-image" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'You can also drag-and-drop image and video files from your computer into your media library.'
+						) }
+					</p>
+					<img
+						src="https://i0.wp.com/en-support.files.wordpress.com/2017/07/media-drag-and-drop.gif"
+						style={ { marginBottom: '10px', border: '3px solid #00AADC', borderRadius: '4px' } }
+					/>
+					<ButtonRow>
+						<Next step="select-image" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -76,18 +82,22 @@ export const MediaBasicsTour = makeTour(
 			when={ doesSelectedSiteHaveMediaFiles }
 			next="done-no-media"
 		>
-			<p>
-				{ translate(
-					'Once you upload a file, you can edit its title, add a caption, and even do basic photo editing.'
-				) }
-			</p>
-			<Continue
-				click
-				step="click-to-edit"
-				target=".media-library__list-item:not(.is-selected) .media-library__list-item-figure, .media-library__list-item-figure"
-			>
-				{ translate( 'To find these options, click on this file to select it.' ) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Once you upload a file, you can edit its title, add a caption, and even do basic photo editing.'
+						) }
+					</p>
+					<Continue
+						click
+						step="click-to-edit"
+						target=".media-library__list-item:not(.is-selected) .media-library__list-item-figure, .media-library__list-item-figure"
+					>
+						{ translate( 'To find these options, click on this file to select it.' ) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -97,60 +107,79 @@ export const MediaBasicsTour = makeTour(
 			target=".editor-media-modal__secondary-action"
 			style={ { marginLeft: '-8px' } }
 		>
-			<Continue click step="launch-modal" target=".editor-media-modal__secondary-action">
-				{ translate( 'Now click the {{editButton/}} button.', {
-					components: {
-						editButton: <EditButton />,
-					},
-				} ) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue click step="launch-modal" target=".editor-media-modal__secondary-action">
+						{ translate( 'Now click the {{editButton/}} button.', {
+							components: {
+								editButton: <EditButton />,
+							},
+						} ) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="launch-modal" placement="center">
-			<p>
-				{ translate(
-					'Here you can edit the title, add a caption, find the media URL, and see other details.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="done" />
-				<Quit />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Here you can edit the title, add a caption, find the media URL, and see other details.'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="done" />
+						<Quit />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="done" placement="center">
-			<p>
-				{ translate(
-					'Need to adjust your image? Click {{editImageButton/}} to perform basic tweaks.',
-					{
-						components: {
-							editImageButton: <EditImageButton />,
-						},
-					}
-				) }
-			</p>
-			<p>
-				{ translate( 'Click {{doneButton /}} to go back to your full library. Happy uploading!', {
-					components: {
-						doneButton: <DoneButton />,
-					},
-				} ) }
-			</p>
-			<ButtonRow>
-				<Quit primary>{ translate( "Got it, I'm ready to explore!" ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Need to adjust your image? Click {{editImageButton/}} to perform basic tweaks.',
+							{
+								components: {
+									editImageButton: <EditImageButton />,
+								},
+							}
+						) }
+					</p>
+					<p>
+						{ translate(
+							'Click {{doneButton /}} to go back to your full library. Happy uploading!',
+							{
+								components: {
+									doneButton: <DoneButton />,
+								},
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( "Got it, I'm ready to explore!" ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="done-no-media" placement="center">
-			<p>
-				{ translate(
-					'Once you upload media files, you can edit them — change titles, do basic image editing, and more — ' +
-						"and they'll be ready and waiting for you to add to posts and pages."
-				) }
-			</p>
-			<ButtonRow>
-				<Quit primary>{ translate( "Got it, I'm ready to explore!" ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Once you upload media files, you can edit them — change titles, do basic image editing, and more — ' +
+								"and they'll be ready and waiting for you to add to posts and pages."
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( "Got it, I'm ready to explore!" ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/media-basics-tour.js
+++ b/client/layout/guided-tours/tours/media-basics-tour.js
@@ -64,6 +64,7 @@ export const MediaBasicsTour = makeTour(
 					<img
 						src="https://i0.wp.com/en-support.files.wordpress.com/2017/07/media-drag-and-drop.gif"
 						style={ { marginBottom: '10px', border: '3px solid #00AADC', borderRadius: '4px' } }
+						alt=""
 					/>
 					<ButtonRow>
 						<Next step="select-image" />
@@ -92,7 +93,10 @@ export const MediaBasicsTour = makeTour(
 					<Continue
 						click
 						step="click-to-edit"
-						target=".media-library__list-item:not(.is-selected) .media-library__list-item-figure, .media-library__list-item-figure"
+						target={
+							'.media-library__list-item:not(.is-selected) .media-library__list-item-figure, ' +
+							'.media-library__list-item-figure'
+						}
 					>
 						{ translate( 'To find these options, click on this file to select it.' ) }
 					</Continue>

--- a/client/layout/guided-tours/tours/simple-payments-tour.js
+++ b/client/layout/guided-tours/tours/simple-payments-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { overEvery as and } from 'lodash';
 
 /**
@@ -30,24 +29,28 @@ export const SimplePaymentsTour = makeTour(
 			placement="below"
 			style={ { marginLeft: '-10px', zIndex: 'auto' } }
 		>
-			<p>
-				{ translate(
-					'Did you know? ' +
-						'Sites on the Premium and Business plans can add {{strong}}payment buttons{{/strong}} — ' +
-						'sell tickets, collect donations, accept tips, and more.',
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				) }
-			</p>
-			<ButtonRow>
-				<Quit primary>{ translate( 'Got it, thanks!' ) }</Quit>
-			</ButtonRow>
-			<Link href="https://en.support.wordpress.com/simple-payments">
-				{ translate( 'Learn more about Simple Payments.' ) }
-			</Link>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Did you know? ' +
+								'Sites on the Premium and Business plans can add {{strong}}payment buttons{{/strong}} — ' +
+								'sell tickets, collect donations, accept tips, and more.',
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( 'Got it, thanks!' ) }</Quit>
+					</ButtonRow>
+					<Link href="https://en.support.wordpress.com/simple-payments">
+						{ translate( 'Learn more about Simple Payments.' ) }
+					</Link>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/site-title-tour.js
+++ b/client/layout/guided-tours/tours/site-title-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { overEvery as and } from 'lodash';
 
 /**
@@ -48,20 +47,24 @@ export const SiteTitleTour = makeTour(
 		) }
 	>
 		<Step name="init" placement="right" next="click-settings">
-			<p>
-				{ translate(
-					"Hey there! We noticed you haven't changed the title of your site yet. Want to change it?"
-				) }
-			</p>
-			<p>
-				{ translate(
-					'The site title appears in places like the top of your web browser and in search results.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="click-settings">{ translate( 'Yes, please!' ) }</Next>
-				<Quit>{ translate( 'No, thanks.' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"Hey there! We noticed you haven't changed the title of your site yet. Want to change it?"
+						) }
+					</p>
+					<p>
+						{ translate(
+							'The site title appears in places like the top of your web browser and in search results.'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="click-settings">{ translate( 'Yes, please!' ) }</Next>
+						<Quit>{ translate( 'No, thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -72,63 +75,83 @@ export const SiteTitleTour = makeTour(
 			scrollContainer=".sidebar__region"
 			shouldScrollTo
 		>
-			<Continue target="settings" step="site-title-input" click>
-				{ translate( 'Click {{settingsButton/}} to continue.', {
-					components: {
-						settingsButton: <SettingsButton />,
-					},
-				} ) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue target="settings" step="site-title-input" click>
+						{ translate( 'Click {{settingsButton/}} to continue.', {
+							components: {
+								settingsButton: <SettingsButton />,
+							},
+						} ) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="site-title-input" target="site-title-input" arrow="top-left" placement="below">
-			<p>
-				{ translate(
-					'You can change the site title here. A good title can help others find your site.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="site-tagline-input">{ translate( 'Looks Good!' ) }</Next>
-				<Quit>{ translate( 'Cancel' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'You can change the site title here. A good title can help others find your site.'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="site-tagline-input">{ translate( 'Looks Good!' ) }</Next>
+						<Quit>{ translate( 'Cancel' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="site-tagline-input" target="site-tagline-input" arrow="top-left" placement="below">
-			<p>
-				{ translate(
-					"While you're at it, why not add a tagline? It should explain what your site is about in a few words. " +
-						'It usually appears right below your site title.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="click-save">{ translate( 'Great!' ) }</Next>
-				<Quit>{ translate( 'Cancel' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"While you're at it, why not add a tagline? It should explain what your site is about in a few words. " +
+								'It usually appears right below your site title.'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="click-save">{ translate( 'Great!' ) }</Next>
+						<Quit>{ translate( 'Cancel' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="click-save" target="settings-site-profile-save" arrow="top-right" placement="below">
-			<Continue target="settings-site-profile-save" step="finish" click>
-				{ translate( "Don't forget to save your changes." ) }
-			</Continue>
+			{ ( { translate } ) => (
+				<Fragment>
+					<Continue target="settings-site-profile-save" step="finish" click>
+						{ translate( "Don't forget to save your changes." ) }
+					</Continue>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="finish" placement="center">
-			<p>
-				{ translate(
-					"{{strong}}That's it!{{/strong}} Your visitors can now easily identify your website by its title.",
-					{
-						components: {
-							strong: <strong />,
-						},
-					}
-				) }
-			</p>
-			<ButtonRow>
-				<Quit primary>{ translate( "We're all done!" ) }</Quit>
-			</ButtonRow>
-			<Link href="https://en.support.wordpress.com/start">
-				{ translate( 'Learn more about WordPress.com' ) }
-			</Link>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"{{strong}}That's it!{{/strong}} Your visitors can now easily identify your website by its title.",
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( "We're all done!" ) }</Quit>
+					</ButtonRow>
+					<Link href="https://en.support.wordpress.com/start">
+						{ translate( 'Learn more about WordPress.com' ) }
+					</Link>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
+++ b/client/layout/guided-tours/tours/theme-sheet-welcome-tour.js
@@ -4,9 +4,8 @@
  * External dependencies
  */
 
-import React from 'react';
+import React, { Fragment } from 'react';
 import { overEvery as and, negate as not } from 'lodash';
-import { translate } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
 /**
@@ -39,15 +38,20 @@ export const ThemeSheetWelcomeTour = makeTour(
 		) }
 	>
 		<Step name="init" placement="right" next="live-preview">
-			<p>
-				{ translate(
-					'This page shows all the details about a specific theme. ' + 'Ready for a little tour?'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="live-preview">{ translate( "Let's go!" ) }</Next>
-				<Quit>{ translate( 'No, thanks.' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'This page shows all the details about a specific theme. ' +
+								'Ready for a little tour?'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="live-preview">{ translate( "Let's go!" ) }</Next>
+						<Quit>{ translate( 'No, thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -57,10 +61,14 @@ export const ThemeSheetWelcomeTour = makeTour(
 			arrow="top-left"
 			next="close-preview"
 		>
-			<p>{ translate( 'Nothing beats seeing a theme in action. Try the live demo!' ) }</p>
-			<ButtonRow>
-				<Continue icon="themes" step="close-preview" target="theme-sheet-preview" click />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Nothing beats seeing a theme in action. Try the live demo!' ) }</p>
+					<ButtonRow>
+						<Continue icon="themes" step="close-preview" target="theme-sheet-preview" click />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -70,18 +78,22 @@ export const ThemeSheetWelcomeTour = makeTour(
 			arrow="left-top"
 			when={ isPreviewShowing }
 		>
-			<p>
-				{ translate(
-					"This is what this theme looks like in action. Move around, click on things. Do you like what you're seeing?"
-				) }
-			</p>
-			<ButtonRow>
-				<Continue when={ not( isPreviewShowing ) } step="theme-docs">
-					{ translate( 'Tap {{icon/}} to close the live demo.', {
-						components: { icon: <Gridicon icon="cross" /> },
-					} ) }
-				</Continue>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"This is what this theme looks like in action. Move around, click on things. Do you like what you're seeing?"
+						) }
+					</p>
+					<ButtonRow>
+						<Continue when={ not( isPreviewShowing ) } step="theme-docs">
+							{ translate( 'Tap {{icon/}} to close the live demo.', {
+								components: { icon: <Gridicon icon="cross" /> },
+							} ) }
+						</Continue>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -90,15 +102,19 @@ export const ThemeSheetWelcomeTour = makeTour(
 			placement="beside"
 			arrow="left-top"
 		>
-			<p>
-				{ translate(
-					'Each theme comes with a range of powerful features. ' +
-						'Learn more about unlocking its full potential and setting it up on your site.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="pick-activate-wide" />
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Each theme comes with a range of powerful features. ' +
+								'Learn more about unlocking its full potential and setting it up on your site.'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="pick-activate-wide" />
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -108,15 +124,19 @@ export const ThemeSheetWelcomeTour = makeTour(
 			placement="below"
 			next="back-to-list"
 		>
-			<p>
-				{ translate(
-					'Is this the right theme for you? This button would pick the design for your site.'
-				) }
-			</p>
-			<ButtonRow>
-				<Next step="back-to-list">{ translate( 'Maybe later' ) }</Next>
-			</ButtonRow>
-			<Continue step="back-to-list" target=".theme__sheet-primary-button" click hidden />
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Is this the right theme for you? This button would pick the design for your site.'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="back-to-list">{ translate( 'Maybe later' ) }</Next>
+					</ButtonRow>
+					<Continue step="back-to-list" target=".theme__sheet-primary-button" click hidden />
+				</Fragment>
+			) }
 		</Step>
 
 		<Step
@@ -126,18 +146,22 @@ export const ThemeSheetWelcomeTour = makeTour(
 			arrow="left-top"
 			style={ { marginTop: '-15px', zIndex: 1 } }
 		>
-			<p>
-				{ translate(
-					"That's it! " +
-						'You can click on {{allThemesButton/}} at any time to return to our design showcase.',
-					{
-						components: { allThemesButton: <AllThemesButton /> },
-					}
-				) }
-			</p>
-			<ButtonRow>
-				<Quit primary>{ translate( 'Done' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"That's it! " +
+								'You can click on {{allThemesButton/}} at any time to return to our design showcase.',
+							{
+								components: { allThemesButton: <AllThemesButton /> },
+							}
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( 'Done' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );

--- a/client/layout/guided-tours/tours/tutorial-site-preview-tour.js
+++ b/client/layout/guided-tours/tours/tutorial-site-preview-tour.js
@@ -4,8 +4,7 @@
  * External dependencies
  */
 
-import React from 'react';
-import { translate } from 'i18n-calypso';
+import React, { Fragment } from 'react';
 import { overEvery as and } from 'lodash';
 
 /**
@@ -40,31 +39,39 @@ export const TutorialSitePreviewTour = makeTour(
 			placement="below"
 			scrollContainer=".sidebar__region"
 		>
-			<p>
-				{ translate(
-					'{{viewSiteButton/}} shows you what your site looks like to visitors. Click it to continue.',
-					{
-						components: {
-							viewSiteButton: <ViewSiteButton />,
-						},
-					}
-				) }
-			</p>
-			<Continue hidden click step="finish" target="sitePreview" />
-			<ButtonRow>
-				<Quit subtle>{ translate( 'No, thanks.' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'{{viewSiteButton/}} shows you what your site looks like to visitors. Click it to continue.',
+							{
+								components: {
+									viewSiteButton: <ViewSiteButton />,
+								},
+							}
+						) }
+					</p>
+					<Continue hidden click step="finish" target="sitePreview" />
+					<ButtonRow>
+						<Quit subtle>{ translate( 'No, thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 
 		<Step name="finish" placement="center">
-			<p>
-				{ translate(
-					"Take a look around — and when you're done, explore the rest of WordPress.com."
-				) }
-			</p>
-			<ButtonRow>
-				<Quit primary>{ translate( 'Got it.' ) }</Quit>
-			</ButtonRow>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"Take a look around — and when you're done, explore the rest of WordPress.com."
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( 'Got it.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
 		</Step>
 	</Tour>
 );


### PR DESCRIPTION
When profiling the initial load of Calypso, a very visible amount of time is consumed initializing the Guided Tours UI when processing the `makeTour` calls. Their structure is like this:
```jsx
export const EditorBasicsTour = makeTour(
  <Tour>
    <Step name="firstStep">
      <p>{ translate( 'UI of the first step' ) }</p>
    </Step>
    <Step>
      <p>{ translate( 'UI of the first step' ) }</p>
    </Step>
  </Tour>
);
```
That means that the JSX elements for each and every step of each and every tour are created and strings are translated during Calypso initialization, statically, when the `build.js` file is evaluated.

This PR defers part of the initialization by converting the UI part into a "render prop":
```jsx
<Step>
  { props => <p>{ props.translate( 'UI of the step' ) }</p> }
</Step>
```

The initialization of Guided Tours in now faster on the scale of 10-20ms. Not astonishing, but every bit helps.

In addition to the performance benefits, this PR also fixes a bug where the Guided Tours were never localized properly: because the translations are loaded async after initialization, the static `translate` calls at boot time would always work with the `en` locale (fixes #22284).

There are plenty of `Step`s to modify, so I wrote a codemod for that.

**How to test:**
1. Change your user's language to non-English, i.e., Deutsch.
2. Force start of the editor tour by going to post editor URL with a query string:
```
/post/:site/:post?tour=editorBasicsTour
```

Before patch, the UI is partially English:
<img width="424" alt="guided-tour-before" src="https://user-images.githubusercontent.com/664258/36753706-4dd9f1f2-1c07-11e8-8a58-9c5c2c475d71.png">

After the patch, the UI is 💯🇩🇪 :
<img width="417" alt="guided-tour-after" src="https://user-images.githubusercontent.com/664258/36753755-7109bc52-1c07-11e8-953d-3a566e8ab253.png">
