### PR TITLE
Sidebar: Update switcher icon and line things up

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -39,6 +39,7 @@
 .sidebar__heading {
 	color: var( --sidebar-heading-color );
 	font-size: 14px;
+	font-weight: 600;
 	margin: 16px 8px 6px 16px;
 	display: flex;
 }
@@ -91,10 +92,10 @@
 	}
 
 	a {
-		font-size: 14px;
+		font-size: 15px;
 		line-height: 1;
 		position: relative;
-		padding: 11px 16px 11px 18px;
+		padding: 11px 16px 11px 20px;
 		color: var( --sidebar-color );
 		box-sizing: border-box;
 		white-space: nowrap;
@@ -133,7 +134,7 @@
 		fill: var( --sidebar-gridicon-fill );
 		height: 24px;
 		width: 24px;
-		margin-right: 6px;
+		margin-right: 12px;
 		flex-shrink: 0;
 
 		// External indicator for sections that aren't available in Calypso

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -114,9 +114,11 @@ class CurrentSite extends Component {
 			<Card className="current-site">
 				{ this.props.siteCount > 1 && (
 					<span className="current-site__switch-sites">
-						<Button compact borderless onClick={ this.switchSites }>
-							<Gridicon icon={ rtlOn ? 'arrow-right' : 'arrow-left' } size={ 18 } />
-							{ translate( 'Switch Site' ) }
+						<Button borderless onClick={ this.switchSites }>
+							<Gridicon icon={ rtlOn ? 'chevron-right' : 'chevron-left' } />
+							<span className="current-site__switch-sites-label">
+								{ translate( 'Switch Site' ) }
+							</span>
 						</Button>
 					</span>
 				) }

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -50,74 +50,58 @@
 	}
 }
 
-.current-site__view-site {
-	padding: 11px 16px;
-	color: $gray-dark;
-	box-sizing: border-box;
-	white-space: nowrap;
-	overflow: hidden;
-	display: flex;
-	border-top: 1px solid darken( $gray-light, 10% );
-
-	&:focus {
-		outline: none;
-	}
-
-	-webkit-tap-highlight-color: rgba( $gray-dark, .2 );
-
-	.gridicon {
-		fill: $gray;
-	}
-
-	.notouch &:hover:not(.selected) {
-		background-color: $gray-light;
-
-		.current-site__view-site-text {
-			color: $blue-medium;
-		}
-		.gridicon {
-			fill: $blue-medium;
-		}
-	}
-
-	&.selected {
-		background-color: $sidebar-selected-color;
-
-		.current-site__view-site-text {
-			color: $white;
-		}
-
-		.gridicon {
-			fill: $white;
-		}
-	}
-}
-
-.current-site__view-site-text {
-	display: flex;
-	align-self: center;
-	color: $gray-dark;
-	font-size: 14px;
-	width: 100%;
-}
-
 .current-site__switch-sites {
+	display: block;
 	background: var( --current-site-switch-sites-background );
 	border-bottom: 1px solid darken( $sidebar-bg-color, 5% );
-	display: block;
+
+	.button.is-borderless {
+		display: block;
+		width: 100%;
+		text-align: left;
+		padding: 12px 8px 12px 44px;
+		position: relative;
+		font-weight: normal;
+		color: $gray-text;
+
+		.gridicon {
+			height: auto;
+			width: auto;
+			fill: $gray-text;
+			position: absolute;
+				top: 12px;
+				left: 14px;
+		}
+	}
+
+	&:hover {
+		background-color: lighten( $sidebar-bg-color, 3% );
+
+		.button.is-borderless:hover,
+		.button.is-borderless:focus {
+			color: $blue-medium;
+
+			.gridicon {
+				fill: $blue-medium;
+			}
+		}
+	}
+
+	/*
+	
+	
+	
 	box-sizing: border-box;
-	cursor: pointer;
+	
 	position: relative;
 
-	.button {
+	.button.is-borderless {
 		text-align: left;
 		padding: 16px;
 		width: 100%;
 		height: 46px;
-	}
 
-	@include breakpoint( "<660px" ) {
-		background-color: $gray-light;
+
 	}
 
 	&:hover {
@@ -128,6 +112,7 @@
 			color: $sidebar-text-color;
 		}
 	}
+	*/
 }
 
 .current-site .notice {

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -65,8 +65,8 @@
 		color: $gray-text;
 
 		.gridicon {
-			height: auto;
-			width: auto;
+			height: 24px;
+			width: 24px;
 			fill: $gray-text;
 			position: absolute;
 				top: 12px;

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -86,33 +86,6 @@
 			}
 		}
 	}
-
-	/*
-	
-	
-	
-	box-sizing: border-box;
-	
-	position: relative;
-
-	.button.is-borderless {
-		text-align: left;
-		padding: 16px;
-		width: 100%;
-		height: 46px;
-
-
-	}
-
-	&:hover {
-		background-color: lighten( $sidebar-bg-color, 3% );
-
-		.button.is-borderless:hover,
-		.button.is-borderless:focus {
-			color: $sidebar-text-color;
-		}
-	}
-	*/
 }
 
 .current-site .notice {


### PR DESCRIPTION
Some subtle changes in this PR:
* Using the chevron for the site switcher, matching the pattern we have for the store (and the upcoming nested sidebar).
* Made the site switcher label darker
* Lined up the menu labels with the site title/url
* Centered the menu icons with the site icon

![slice](https://user-images.githubusercontent.com/191598/36756040-f82bf618-1bdb-11e8-923d-327ed1f94f10.png)

![slice 2](https://user-images.githubusercontent.com/191598/36756057-ffdd069a-1bdb-11e8-95e2-c7faf43a69a3.png)
