### PR TITLE
Checkout: Ensure late renewal fee is applied when upgrading to a plan

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -27,6 +27,7 @@ import {
  */
 import {
 	formatProduct,
+	getDomain,
 	isCustomDesign,
 	isDependentProduct,
 	isDomainMapping,
@@ -140,7 +141,7 @@ export function remove( cartItemToRemove ) {
 			if (
 				isPlan( existingCartItem ) &&
 				isRemovingDomainProduct &&
-				cartItemToRemove.meta === get( existingCartItem, 'extra.domain_to_bundle', '' )
+				getDomain( cartItemToRemove ) === getDomain( existingCartItem )
 			) {
 				return update( existingCartItem, { extra: { $merge: { domain_to_bundle: '' } } } );
 			}

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -38,6 +38,15 @@ const productDependencies = {
 		gapps_unlimited: true,
 		private_whois: true,
 	},
+	[ PLAN_BUSINESS ]: {
+		domain_redemption: true,
+	},
+	[ PLAN_PERSONAL ]: {
+		domain_redemption: true,
+	},
+	[ PLAN_PREMIUM ]: {
+		domain_redemption: true,
+	},
 	[ domainProductSlugs.TRANSFER_IN ]: {
 		[ domainProductSlugs.TRANSFER_IN_PRIVACY ]: true,
 	},

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, difference, isEmpty, pick } from 'lodash';
+import { assign, difference, get, isEmpty, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,8 +11,11 @@ import { assign, difference, isEmpty, pick } from 'lodash';
 import {
 	JETPACK_PLANS,
 	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
 	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
 	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
 	PLAN_FREE,
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PREMIUM,
@@ -41,10 +44,19 @@ const productDependencies = {
 	[ PLAN_BUSINESS ]: {
 		domain_redemption: true,
 	},
+	[ PLAN_BUSINESS_2_YEARS ]: {
+		domain_redemption: true,
+	},
 	[ PLAN_PERSONAL ]: {
 		domain_redemption: true,
 	},
+	[ PLAN_PERSONAL_2_YEARS ]: {
+		domain_redemption: true,
+	},
 	[ PLAN_PREMIUM ]: {
+		domain_redemption: true,
+	},
+	[ PLAN_PREMIUM_2_YEARS ]: {
 		domain_redemption: true,
 	},
 	[ domainProductSlugs.TRANSFER_IN ]: {
@@ -302,6 +314,18 @@ export function getDomainProductRanking( product ) {
 	}
 }
 
+export function getDomain( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	const domainToBundle = get( product, 'extra.domain_to_bundle', false );
+	if ( domainToBundle ) {
+		return domainToBundle;
+	}
+
+	return product.meta;
+}
+
 export function isDependentProduct( product, dependentProduct, domainsWithPlansOnly ) {
 	let isPlansOnlyDependent = false;
 
@@ -323,7 +347,7 @@ export function isDependentProduct( product, dependentProduct, domainsWithPlansO
 		isPlansOnlyDependent ||
 		( productDependencies[ slug ] &&
 			productDependencies[ slug ][ dependentSlug ] &&
-			product.meta === dependentProduct.meta )
+			getDomain( product ) === getDomain( dependentProduct ) )
 	);
 }
 export function isFreeWordPressComDomain( product ) {

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -119,7 +120,10 @@ export class CartItem extends React.Component {
 	getProductInfo() {
 		const { cartItem, selectedSite } = this.props;
 
-		const domain = cartItem.meta || ( selectedSite && selectedSite.domain );
+		const domain =
+			cartItem.meta ||
+			get( cartItem, 'extra.domain_to_bundle' ) ||
+			( selectedSite && selectedSite.domain );
 		let info = null;
 
 		if ( isGoogleApps( cartItem ) && cartItem.extra.google_apps_users ) {

--- a/client/my-sites/checkout/cart/cart-plan-ad.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-ad.jsx
@@ -25,7 +25,9 @@ import { PLAN_PREMIUM } from 'lib/plans/constants';
 class CartPlanAd extends Component {
 	addToCartAndRedirect = event => {
 		event.preventDefault();
-		addItem( cartItems.premiumPlan( PLAN_PREMIUM, { isFreeTrial: false } ) );
+		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart );
+		const domainToBundle = get( domainRegistrations, '[0].meta', '' );
+		addItem( cartItems.premiumPlan( PLAN_PREMIUM, { domainToBundle } ) );
 		page( '/checkout/' + this.props.selectedSite.slug );
 	};
 


### PR DESCRIPTION
If a user on a free plan has a domain that is in redemption, upgrading to a paid plan did not redeemed the domain. This patch addresses that (needs D10503-code on the backend) by explicitly storing the domain to be bundled in `extra.domain_to_bundle`.

### Testing
Requires `D10503-code` on the backend.

The path that it tries to fix:
 * Have a domain in redemption (see the backend patch for instructions) on a _free_ site.
 * Go to Calypso, and click on any Renew link (in the Site warnings section, in Domain Management or in `/me/purchases`)
   * If you're a non-DWPO user, the upsell for Premium plan should be shown in the cart.
   * Make sure you have the redemption product in cart, without the possibility to remove it. If you remove the domain from cart, the redemption product should be removed too. If you add a new domain to cart, it should clear the old cart, including the redemption product.
   * Click the Premium plan upsell - the plan should be added to cart, replacing the domain subs, _except_ the redemption product, which _should_ be in the cart. It still should not be allowed to be removed - and if the plan is removed, it should be removed too.
   * Make sure the plan's cart item mentions explicitly the domain you're renewing.
 * If you're a DWPO user, a plan should be auto-added to your cart. The rest should behave as above.

Try also other flows:
 * Renewing a domain _not_ in redemption.
 * Buying a plan for free site you have a custom domain already.
 * Buy a plan without a domain for a free site _without_ a domain.
 * Maybe try buying a premium theme?

In video form:
#### Before 
  ![before](https://user-images.githubusercontent.com/3392497/38050257-b150e572-32ca-11e8-9307-3d7035f7ddd9.gif)
#### After 
  ![after](https://user-images.githubusercontent.com/3392497/38050269-b872b204-32ca-11e8-87a6-72f38b35ef85.gif)

