### PR TITLE
Update Google My Business Events

### DIFF
--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -111,15 +111,15 @@ export default connect(
 	} ),
 	{
 		trackNudgeView: dismissCount =>
-			recordTracksEvent( 'calypso_test_google_my_business_stats_nudge_view', {
+			recordTracksEvent( 'calypso_google_my_business_stats_nudge_view', {
 				dismiss_count: dismissCount,
 			} ),
 		trackNudgeDismissClick: dismissCount =>
-			recordTracksEvent( 'calypso_test_google_my_business_stats_nudge_dismiss_icon_click', {
+			recordTracksEvent( 'calypso_google_my_business_stats_nudge_dismiss_icon_click', {
 				dismiss_count: dismissCount,
 			} ),
 		trackNudgeStartNowClick: dismissCount =>
-			recordTracksEvent( 'calypso_test_google_my_business_stats_nudge_start_now_button_click', {
+			recordTracksEvent( 'calypso_google_my_business_stats_nudge_start_now_button_click', {
 				dismiss_count: dismissCount,
 			} ),
 		dismissNudge,

--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -111,14 +111,16 @@ export default connect(
 	} ),
 	{
 		trackNudgeView: dismissCount =>
-			recordTracksEvent( 'calypso_test_google_my_business_stats_nudge_view', { dismissCount } ),
+			recordTracksEvent( 'calypso_test_google_my_business_stats_nudge_view', {
+				dismiss_count: dismissCount,
+			} ),
 		trackNudgeDismissClick: dismissCount =>
 			recordTracksEvent( 'calypso_test_google_my_business_stats_nudge_dismiss_icon_click', {
-				dismissCount,
+				dismiss_count: dismissCount,
 			} ),
 		trackNudgeStartNowClick: dismissCount =>
 			recordTracksEvent( 'calypso_test_google_my_business_stats_nudge_start_now_button_click', {
-				dismissCount,
+				dismiss_count: dismissCount,
 			} ),
 		dismissNudge,
 	}


### PR DESCRIPTION
This PR makes the final changes to events for Google My Business M1 by removing the `test_` designation. It also fixes a few misspellings in the event names and properties.

## Testing
- Boot this branch locally or use the calypso.live link below
- Enable debug of tracks in Calypso by typing this in your browser console:  `localStorage.setItem('debug', 'calypso:analytics:tracks' )`
- Create a site with a `promote` siteGoals if you don't have one. This can be done from the `http://calypso.localhost:3000/start/about` page by selecting at least the "Promote your business, skills, organization, or events" option.
- Upgrade your site plan to business or premium
- Navigate to this site stats page `/stats/day/:site_slug`
- Notice the Google My Business nudge
- For the following three events notice that they have the `dismiss_count` property with a value of 0
- Notice in the console if a `calypso_google_my_business_stats_nudge_shown` event was recorded
- Dismiss the Nudge vie the x in the corner and notice that  a `calypso_google_my_business_stats_nudge_dismiss_icon_click` event was recorded
- Clear the `google-my-business-dismissible-nudge` preference via the dev menu
- Click the "Start Now" Button and notice a `calypso_google_my_business_stats_nudge_start_now_button_click` event was recorded
- On the Business type page click the "Create My Listing" button and notice that a `calypso_google_my_business_select_business_type_create_my_listing_button_click` event was recorded.
- Navigate back to the previous tab and click the "Optimize Your SEO" button and notice a `calypso_google_my_business_select_business_type_optimize_your_seo_button_click` event was recorded.
- Navigate back to the site stats page `/stats/day/:site_slug`
- Dismiss the Nudge via the X
- Inspect the preference in the dev menu and take note of your siteId
- Place it into the following action and dispatch via Redux Dev Tools
```
{
  type: 'PREFERENCES_SET',
  key: 'google-my-business-dismissible-nudge',
  value: {
    'SITE_ID': [
      {
        dismissedAt: 1519407992903,
        type: 'dismiss'
      }
    ]
  }
}
```
(replace SITE_ID with your site id)
- It simulates the same action but make it so it happened 2 weeks ago.
- The nudge should appear again
- Dismiss the Nudge again via the X
- notice that a `calypso_google_my_business_stats_nudge_dismiss_icon_click` event was recorded with a `dismiss_count` of 1.

`localStorage.removeItem(  'debug' )` will stop the event logging