### PR TITLE
Jetpack Onboarding: Edit business address header copy

### DIFF
--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -146,7 +146,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 		const headerText = translate( 'Help your customers find you with Jetpack.' );
 		const subHeaderText = translate(
 			"Add your business address and a map of your location with Jetpack's business address widget. " +
-				"You can adjust the widget's location later."
+				"You can edit the widget's content and position later."
 		);
 
 		return <FormattedHeader headerText={ headerText } subHeaderText={ subHeaderText } />;


### PR DESCRIPTION
This PR updates the copy of the JPO business address step, as suggested here: https://github.com/Automattic/wp-calypso/issues/22842#issuecomment-369070988

Before:
![](https://cldup.com/Jhalx62Wgm.png)

After:
![](https://cldup.com/Q-f5AGMWEg.png)

To test:
* Checkout this branch.
* Pick a Jetpack site.
* Head to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` on the Jetpack site to start the onboarding flow.
* In the site type step, select **Business**
* Skip to the Business Address step.
* Verify you can see the updated copy in the header of the step.
