### PR TITLE
Jetpack Onboarding: Update contact form header copy

### DIFF
--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -70,12 +70,10 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 		const subHeaderText = (
 			<Fragment>
 				{ translate(
-					'A great first step is adding a Contact Us page that includes Jetpack’s contact form.'
+					'A great first step is adding a Contact Us page that includes a contact form.'
 				) }
 				<br />
-				{ translate(
-					'Create a Jetpack account to unlock this and dozens of other Jetpack features.'
-				) }
+				{ translate( 'Create a Jetpack account to unlock this and dozens of other features.' ) }
 			</Fragment>
 		);
 		const connectUrl = addQueryArgs(


### PR DESCRIPTION
This PR updates the contact form header copy to remove some `Jetpack` occurrences, as suggested in https://github.com/Automattic/wp-calypso/pull/22843#discussion_r171012848.

Before:
![](https://cldup.com/tdTQn_6iEP.png)

After:
![](https://cldup.com/rSPF339sKY.png)

* Checkout this branch.
* Pick a Jetpack site.
* Head to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` on the Jetpack site to start the onboarding flow.
* Skip to the Contact Form step.
* Verify you can see the updated copy in the header of the step.