### PR TITLE
Update Google My Business designs

### DIFF
--- a/client/my-sites/google-my-business/select-business-type/cta-card.js
+++ b/client/my-sites/google-my-business/select-business-type/cta-card.js
@@ -35,7 +35,7 @@ const CTACard = ( {
 				target={ buttonTarget }
 				onClick={ buttonOnClick }
 			>
-				{ buttonText } <Gridicon icon={ buttonIcon } />
+				{ buttonText } { buttonIcon && <Gridicon icon={ buttonIcon } /> }
 			</Button>
 		</div>
 	</CompactCard>
@@ -46,7 +46,7 @@ CTACard.propTypes = {
 	mainText: PropTypes.string.isRequired,
 	buttonPrimary: PropTypes.bool,
 	buttonText: PropTypes.string.isRequired,
-	buttonIcon: PropTypes.string.isRequired,
+	buttonIcon: PropTypes.string,
 	buttonOnClick: PropTypes.func,
 	buttonHref: PropTypes.string,
 	buttonTarget: PropTypes.string.isRequired,

--- a/client/my-sites/google-my-business/select-business-type/cta-card.js
+++ b/client/my-sites/google-my-business/select-business-type/cta-card.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import Button from 'components/button';
 
 const CTACard = ( {
@@ -23,7 +23,7 @@ const CTACard = ( {
 	buttonHref,
 	buttonOnClick,
 } ) => (
-	<Card className="select-business-type__cta-card">
+	<CompactCard className="select-business-type__cta-card">
 		<div className="select-business-type__cta-card-main">
 			<h2>{ headerText }</h2>
 			<p>{ mainText }</p>
@@ -38,7 +38,7 @@ const CTACard = ( {
 				{ buttonText } <Gridicon icon={ buttonIcon } />
 			</Button>
 		</div>
-	</Card>
+	</CompactCard>
 );
 
 CTACard.propTypes = {

--- a/client/my-sites/google-my-business/select-business-type/cta-card.js
+++ b/client/my-sites/google-my-business/select-business-type/cta-card.js
@@ -25,7 +25,7 @@ const CTACard = ( {
 } ) => (
 	<CompactCard className="select-business-type__cta-card">
 		<div className="select-business-type__cta-card-main">
-			<h2>{ headerText }</h2>
+			<h2 className="select-business-type__cta-card-heading">{ headerText }</h2>
 			<p>{ mainText }</p>
 		</div>
 		<div className="select-business-type__cta-card-button-container">

--- a/client/my-sites/google-my-business/select-business-type/cta-card.js
+++ b/client/my-sites/google-my-business/select-business-type/cta-card.js
@@ -49,7 +49,7 @@ CTACard.propTypes = {
 	buttonIcon: PropTypes.string,
 	buttonOnClick: PropTypes.func,
 	buttonHref: PropTypes.string,
-	buttonTarget: PropTypes.string.isRequired,
+	buttonTarget: PropTypes.string,
 };
 
 export default CTACard;

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -93,7 +93,6 @@ class SelectBusinessType extends Component {
 						"Don't provide in-person services? Learn more about reaching your customers online."
 					) }
 					buttonText={ translate( 'Optimize Your SEO', { comment: 'Call to Action button' } ) }
-					buttonIcon="external"
 					buttonHref={ '/settings/traffic/' + siteId }
 					buttonOnClick={ this.trackOptimizeYourSEOClick }
 				/>

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -15,6 +15,7 @@ import page from 'page';
 import HeaderCake from 'components/header-cake';
 import CompactCard from 'components/card/compact';
 import CTACard from './cta-card';
+import Main from 'components/main';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class SelectBusinessType extends Component {
@@ -44,7 +45,7 @@ class SelectBusinessType extends Component {
 		const { translate, siteId } = this.props;
 
 		return (
-			<div className="select-business-type">
+			<Main className="select-business-type">
 				<HeaderCake isCompact={ false } alwaysShowActionText={ false } onClick={ this.goBack }>
 					{ translate( 'Google My Business' ) }
 				</HeaderCake>
@@ -99,7 +100,7 @@ class SelectBusinessType extends Component {
 					buttonHref={ '/settings/traffic/' + siteId }
 					buttonOnClick={ this.trackOptimizeYourSEOClick }
 				/>
-			</div>
+			</Main>
 		);
 	}
 }

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -13,7 +13,7 @@ import page from 'page';
  * Internal dependencies
  */
 import HeaderCake from 'components/header-cake';
-import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import CTACard from './cta-card';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -49,7 +49,7 @@ class SelectBusinessType extends Component {
 					{ translate( 'Google My Business' ) }
 				</HeaderCake>
 
-				<Card className="select-business-type__explanation">
+				<CompactCard className="select-business-type__explanation">
 					<div className="select-business-type__explanation-main">
 						<h1 className="select-business-type__explanation-heading">
 							{ translate( 'Which type of business are you?' ) }
@@ -68,7 +68,7 @@ class SelectBusinessType extends Component {
 						src="/calypso/images/google-my-business/business-local.svg"
 						alt="Local business illustration"
 					/>
-				</Card>
+				</CompactCard>
 
 				<CTACard
 					headerText={ translate( 'Physical Location or Service Area', {

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -51,7 +51,9 @@ class SelectBusinessType extends Component {
 
 				<Card className="select-business-type__explanation">
 					<div className="select-business-type__explanation-main">
-						<h1>{ translate( 'Which type of business are you?' ) }</h1>
+						<h1 className="select-business-type__explanation-heading">
+							{ translate( 'Which type of business are you?' ) }
+						</h1>
 
 						<p>
 							{ translate(
@@ -62,6 +64,7 @@ class SelectBusinessType extends Component {
 					</div>
 
 					<img
+						className="select-business-type__explanation-image"
 						src="/calypso/images/google-my-business/business-local.svg"
 						alt="Local business illustration"
 					/>

--- a/client/my-sites/google-my-business/select-business-type/style.scss
+++ b/client/my-sites/google-my-business/select-business-type/style.scss
@@ -7,47 +7,41 @@
 
 .select-business-type__cta-card-main {
 	flex: 2 1;
-	padding: 0 15px;
-
-	h2 {
-		font-size: 21px;
-		font-weight: 400;
-		margin: 10px 0;
-	}
 }
 
 .select-business-type__cta-card-button-container {
 	align-self: center;
 	flex: 1;
-	text-align: right;
-	margin: 0 20px;
-	@include breakpoint( '<960px' ) {
-		text-align: left;
+	margin-bottom: 16px;
+	text-align: left;
+
+	@include breakpoint( '>960px' ) {
+		margin-bottom: 0;
+		text-align: right;
 	}
-	max-width: 540px;
 }
 
 .select-business-type__cta-card-heading {
 	font-size: 21px;
-	margin-bottom: 10px;
+	margin: 5px 0;
 
 	@include breakpoint( '>960px' ) {
-		margin-bottom: 10px;
+		margin: 10px 0;
 	}
 }
 
 .select-business-type {
-	.header-cake {
-		margin-bottom: 10px;
+	margin: auto;
+	max-width: 720px;
 
-		@include breakpoint( '>960px' ) {
-			margin-bottom: 0;
-		}
+	.header-cake {
+		margin-bottom: 0;
 	}
 }
 
-.select-business-type__explanation {
+.select-business-type__explanation.card {
 	display: flex;
+	margin-bottom: 16px;
 
 	@include breakpoint( '<960px' ) {
 		flex-direction: column-reverse;
@@ -57,21 +51,20 @@
 
 .select-business-type__explanation-heading {
 	font-size: 21px;
-	margin-bottom: 5px;
+	margin: 5px 0;
 
 	@include breakpoint( '>960px' ) {
-		margin-bottom: 16px;
+		margin: 10px 0;
 	}
 }
 
 .select-business-type__explanation-image {
 	max-width: 200px;
 	margin-bottom: 10px;
-	width: 150%;
-	align-self: center;
 
 	@include breakpoint( '>960px' ) {
-		max-width: 400px;
+		align-self: center;
+		max-width: 300px;
 	}
 }
 

--- a/client/my-sites/google-my-business/select-business-type/style.scss
+++ b/client/my-sites/google-my-business/select-business-type/style.scss
@@ -1,6 +1,6 @@
 .select-business-type__cta-card {
 	display: flex;
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		display: block;
 	}
 }
@@ -27,21 +27,21 @@
 	flex: 1;
 	text-align: right;
 	margin: 0 20px;
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		text-align: left;
 	}
 }
 
 .select-business-type {
 	.header-cake {
-		margin-bottom: 0px;
+		margin-bottom: 0;
 	}
 }
 
 .select-business-type__explanation {
 	display: flex;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( '<960px' ) {
 		flex-direction: column-reverse;
 	}
 
@@ -59,13 +59,13 @@
 	}
 
 	img {
-		max-width: 300px;
-		width: 100%;
+		max-width: 400px;
+		width: 150%;
 		align-self: center;
 
-		@include breakpoint( ">1040px" ) {
-			max-width: 400px;
-			width: 150%;
+		@include breakpoint( '<1040px' ) {
+			max-width: 300px;
+			width: 100%;
 		}
 	}
 }

--- a/client/my-sites/google-my-business/select-business-type/style.scss
+++ b/client/my-sites/google-my-business/select-business-type/style.scss
@@ -6,7 +6,6 @@
 }
 
 .select-business-type__cta-card-main {
-<<<<<<< HEAD
 	flex: 2 1;
 	padding: 0 15px;
 
@@ -24,25 +23,25 @@
 	margin: 0 20px;
 	@include breakpoint( '<960px' ) {
 		text-align: left;
-=======
+	}
 	max-width: 540px;
 }
 
 .select-business-type__cta-card-heading {
 	font-size: 21px;
 	margin-bottom: 10px;
-	@include breakpoint( '<960px' ) {
-		margin-bottom: 5px;
->>>>>>> 9ce94c23d8... replace nested CSS with class names
+
+	@include breakpoint( '>960px' ) {
+		margin-bottom: 10px;
 	}
 }
 
 .select-business-type {
 	.header-cake {
-		margin-bottom: 0;
+		margin-bottom: 10px;
 
-		@include breakpoint( '<960px' ) {
-			margin-bottom: 10px;
+		@include breakpoint( '>960px' ) {
+			margin-bottom: 0;
 		}
 	}
 }
@@ -55,36 +54,28 @@
 	}
 }
 
-<<<<<<< HEAD
-	h1 {
-		font-size: 21px;
-		margin: 16px 0;
-=======
+
 .select-business-type__explanation-heading {
 	font-size: 21px;
-	margin-bottom: 16px;
-	@include breakpoint( '<960px' ) {
-		margin-bottom: 5px;
->>>>>>> 9ce94c23d8... replace nested CSS with class names
+	margin-bottom: 5px;
+
+	@include breakpoint( '>960px' ) {
+		margin-bottom: 16px;
 	}
 }
 
 .select-business-type__explanation-image {
-	max-width: 400px;
+	max-width: 200px;
 	width: 150%;
 	align-self: center;
 
-	@include breakpoint( '<960px' ) {
-		max-width: 200px;
+	@include breakpoint( '>960px' ) {
+		max-width: 400px;
 	}
 }
 
 .select-business-type__explanation-main {
-<<<<<<< HEAD
-	margin: 0 50px 0 15px;
-=======
 	margin-right: 50px;
 	max-width: 540px;
->>>>>>> 9ce94c23d8... replace nested CSS with class names
 	flex: 2 1;
 }

--- a/client/my-sites/google-my-business/select-business-type/style.scss
+++ b/client/my-sites/google-my-business/select-business-type/style.scss
@@ -66,6 +66,7 @@
 
 .select-business-type__explanation-image {
 	max-width: 200px;
+	margin-bottom: 10px;
 	width: 150%;
 	align-self: center;
 

--- a/client/my-sites/google-my-business/select-business-type/style.scss
+++ b/client/my-sites/google-my-business/select-business-type/style.scss
@@ -1,5 +1,6 @@
 .select-business-type__cta-card {
 	display: flex;
+
 	@include breakpoint( '<960px' ) {
 		display: block;
 	}
@@ -31,9 +32,6 @@
 }
 
 .select-business-type {
-	margin: auto;
-	max-width: 720px;
-
 	.header-cake {
 		margin-bottom: 0;
 	}

--- a/client/my-sites/google-my-business/select-business-type/style.scss
+++ b/client/my-sites/google-my-business/select-business-type/style.scss
@@ -6,6 +6,7 @@
 }
 
 .select-business-type__cta-card-main {
+<<<<<<< HEAD
 	flex: 2 1;
 	padding: 0 15px;
 
@@ -23,12 +24,26 @@
 	margin: 0 20px;
 	@include breakpoint( '<960px' ) {
 		text-align: left;
+=======
+	max-width: 540px;
+}
+
+.select-business-type__cta-card-heading {
+	font-size: 21px;
+	margin-bottom: 10px;
+	@include breakpoint( '<960px' ) {
+		margin-bottom: 5px;
+>>>>>>> 9ce94c23d8... replace nested CSS with class names
 	}
 }
 
 .select-business-type {
 	.header-cake {
 		margin-bottom: 0;
+
+		@include breakpoint( '<960px' ) {
+			margin-bottom: 10px;
+		}
 	}
 }
 
@@ -38,25 +53,38 @@
 	@include breakpoint( '<960px' ) {
 		flex-direction: column-reverse;
 	}
+}
 
+<<<<<<< HEAD
 	h1 {
 		font-size: 21px;
 		margin: 16px 0;
+=======
+.select-business-type__explanation-heading {
+	font-size: 21px;
+	margin-bottom: 16px;
+	@include breakpoint( '<960px' ) {
+		margin-bottom: 5px;
+>>>>>>> 9ce94c23d8... replace nested CSS with class names
 	}
+}
 
-	img {
-		max-width: 400px;
-		width: 150%;
-		align-self: center;
+.select-business-type__explanation-image {
+	max-width: 400px;
+	width: 150%;
+	align-self: center;
 
-		@include breakpoint( '<1040px' ) {
-			max-width: 300px;
-			width: 100%;
-		}
+	@include breakpoint( '<960px' ) {
+		max-width: 200px;
 	}
 }
 
 .select-business-type__explanation-main {
+<<<<<<< HEAD
 	margin: 0 50px 0 15px;
+=======
+	margin-right: 50px;
+	max-width: 540px;
+>>>>>>> 9ce94c23d8... replace nested CSS with class names
 	flex: 2 1;
 }

--- a/client/my-sites/google-my-business/select-business-type/style.scss
+++ b/client/my-sites/google-my-business/select-business-type/style.scss
@@ -11,14 +11,8 @@
 
 	h2 {
 		font-size: 21px;
-		color: $gray-dark;
 		font-weight: 400;
 		margin: 10px 0;
-	}
-
-	p {
-		font-size: 16px;
-		color: $gray-dark;
 	}
 }
 
@@ -46,16 +40,8 @@
 	}
 
 	h1 {
-		color: $gray-dark;
-		font-size: 24px;
-		font-weight: 400;
+		font-size: 21px;
 		margin: 16px 0;
-	}
-
-	p {
-		color: $gray-dark;
-		font-size: 18px;
-		font-weight: 400;
 	}
 
 	img {


### PR DESCRIPTION
This pull request updates several things on the Google My Business page.

1. The buttons are now always beneath the text, rather than moving to the right. This keeps the experience consistent between different screen sizes.

2. The font headings and body text are consistent in each section, which reduces visual clutter

3. Declarations which were already inherited have been removed

4. Removes rules which made this page deviate from Calypso patterns (like additional padding)

5. Added a max-width rule on the text for legibility

6. Removes element level selectors in favour of class names as this is what we prefer in Calypso (it generates smaller CSS and reduces inheritance issues)

7. Removes the gap between CTA cards

<img width="1146" alt="screen shot 2018-02-28 at 10 56 46" src="https://user-images.githubusercontent.com/275961/36784101-1b218e9a-1c76-11e8-93ce-e0dde07223a7.png">

<img width="445" alt="screen shot 2018-02-28 at 11 03 46" src="https://user-images.githubusercontent.com/275961/36784380-142771d0-1c77-11e8-9c95-b83d17bed56c.png">


#### Testing instructions
  
1. Run `git checkout update/gmb-select` and start your server
2. Open the [`Google My Business` page](http://calypso.localhost:3000/google-my-business)
3. Check that the layout matches the screenshot above
  
#### Reviews
  
- [ ] Code
- [x] Product
   
@cburton4 