### PR TITLE
Activate google-my-business for production and other env

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -31,6 +31,7 @@
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
+		"google-my-business": true,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -30,6 +30,7 @@
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
+		"google-my-business": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -33,6 +33,7 @@
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
+		"google-my-business": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/test.json
+++ b/config/test.json
@@ -35,6 +35,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"devdocs/components-usage-stats": false,
+		"google-my-business": true,
 		"help": true,
 		"jetpack/happychat": true,
 		"jetpack/onboarding": true,


### PR DESCRIPTION
This activates Google My Business in stage and production (as well as test and horizon).

Google My Business is currently only a nudge in the stats page (limited to business sites which selected the promote option) with a call to action redirecting to a simple google my business page at `/google-my-business/:site`. This page has an external link to the Google My Business site.

### Testing instructions
- Test that Google My Business works as expected locally or on wpcalypso
- Optional: test a production env locally (either with docker or by setting a local server, see fg)
- Optional: run the full e2e tests on this branch

### Reviews
- [ ] Code
- [ ] Product