### PR TITLE
Settings: fix photon description typo

### DIFF
--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -64,7 +64,7 @@ class SpeedUpSiteSettings extends Component {
 							moduleSlug="photon"
 							label={ translate( 'Serve images from our servers' ) }
 							description={ translate(
-								'Jetpack will optimize your images and server them from the server ' +
+								'Jetpack will optimize your images and serve them from the server ' +
 									'location nearest to your visitors. Using our global content delivery ' +
 									'network will boost the loading speed of your site.'
 							) }


### PR DESCRIPTION
Fixes typo in photon settings description.

H/T to @danjjohnson 

### Before

`Jetpack will optimize your images and server them from the server`

<img width="737" alt="screen shot 2018-02-28 at 12 35 11" src="https://user-images.githubusercontent.com/390760/36788014-3a054c44-1c84-11e8-9fc3-b26a6ad6775b.png">


### After

`Jetpack will optimize your images and serve them from the server`

<img width="744" alt="screen shot 2018-02-28 at 12 34 55" src="https://user-images.githubusercontent.com/390760/36788001-326c679c-1c84-11e8-9dad-a37e62b61f41.png">
