### PR TITLE
Me: Update AccountPassword to use Redux analytics

### DIFF
--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -30,6 +30,7 @@ import observe from 'lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
 import eventRecorder from 'me/event-recorder';
 import { errorNotice } from 'state/notices/actions';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 const AccountPassword = createReactClass( {
 	displayName: 'AccountPassword',
@@ -81,6 +82,19 @@ const AccountPassword = createReactClass( {
 			pendingValidation: true,
 			isUnsaved: '' !== newPassword,
 		} );
+	},
+
+	handleSaveButtonClick() {
+		this.props.recordGoogleEvent( 'Me', 'Clicked on Save Password Button' );
+	},
+
+	handleGenerateButtonClick() {
+		this.props.recordGoogleEvent( 'Me', 'Clicked on Generate Strong Password Button' );
+		this.generateStrongPassword();
+	},
+
+	handleNewPasswordFieldFocus() {
+		this.props.recordGoogleEvent( 'Me', 'Focused on New Password Field' );
 	},
 
 	submitForm: function( event ) {
@@ -149,7 +163,7 @@ const AccountPassword = createReactClass( {
 						id="password"
 						name="password"
 						onChange={ this.handlePasswordChange }
-						onFocus={ this.recordFocusEvent( 'New Password Field' ) }
+						onFocus={ this.handleNewPasswordFieldFocus }
 						value={ this.state.password }
 						submitting={ this.state.savingPassword }
 					/>
@@ -169,7 +183,7 @@ const AccountPassword = createReactClass( {
 							this.state.pendingValidation ||
 							this.props.accountPasswordData.passwordValidationFailed()
 						}
-						onClick={ this.recordClickEvent( 'Save Password Button' ) }
+						onClick={ this.handleSaveButtonClick }
 					>
 						{ this.state.savingPassword ? translate( 'Saving…' ) : translate( 'Save Password' ) }
 					</FormButton>
@@ -177,10 +191,7 @@ const AccountPassword = createReactClass( {
 					<FormButton
 						className="button"
 						isPrimary={ false }
-						onClick={ this.recordClickEvent(
-							'Generate Strong Password Button',
-							this.generateStrongPassword
-						) }
+						onClick={ this.handleGenerateButtonClick }
 						type="button"
 					>
 						{ translate( 'Generate strong password' ) }
@@ -192,6 +203,6 @@ const AccountPassword = createReactClass( {
 } );
 
 export default compose(
-	connect( null, dispatch => bindActionCreators( { errorNotice }, dispatch ) ),
+	connect( null, dispatch => bindActionCreators( { errorNotice, recordGoogleEvent }, dispatch ) ),
 	localize
 )( AccountPassword );

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -26,15 +26,13 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormInputValidation from 'components/forms/form-input-validation';
 /* eslint-disable no-restricted-imports */
 import observe from 'lib/mixins/data-observe';
-/* eslint-enable no-restricted-imports */
-import eventRecorder from 'me/event-recorder';
 import { errorNotice } from 'state/notices/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 const AccountPassword = createReactClass( {
 	displayName: 'AccountPassword',
 
-	mixins: [ observe( 'accountPasswordData' ), eventRecorder ],
+	mixins: [ observe( 'accountPasswordData' ) ],
 
 	componentDidMount: function() {
 		this.debouncedPasswordValidate = debounce( this.validatePassword, 300 );

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -6,7 +6,6 @@
 
 import { localize } from 'i18n-calypso';
 import { debounce, flowRight as compose, head, isEmpty } from 'lodash';
-import { bindActionCreators } from 'redux';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import debugFactory from 'debug';
@@ -202,7 +201,6 @@ const AccountPassword = createReactClass( {
 	},
 } );
 
-export default compose(
-	connect( null, dispatch => bindActionCreators( { errorNotice, recordGoogleEvent }, dispatch ) ),
-	localize
-)( AccountPassword );
+export default compose( connect( null, { errorNotice, recordGoogleEvent } ), localize )(
+	AccountPassword
+);


### PR DESCRIPTION
This PR refactors `AccountPassword` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove unnecessary `bindActionCreators` usage.

This PR should not introduce any visual or behavioral changes.

Part of #20053.

To test:
* Checkout this branch
* Make sure your ga debug is enabled: `localStorage.debug = 'calypso:analytics:ga,calypso:analytics:utils'`
* Go to http://calypso.localhost:3000/me/security
* Verify the right event is being dispatched when focusing the password field.
* Verify the right event is being dispatched when clicking the **Generate strong password** button.
* Verify the right event is being dispatched when clicking the **Save password** button.
* Verify there are no regressions in the account password page.