### PR TITLE
Me: Update Account to use Redux analytics

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -11,7 +11,6 @@ import debugFactory from 'debug';
 import emailValidator from 'email-validator';
 import { debounce, flowRight as compose, get, has, map, size, update } from 'lodash';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -796,11 +795,7 @@ export default compose(
 		state => ( {
 			requestingMissingSites: isRequestingMissingSites( state ),
 		} ),
-		dispatch =>
-			bindActionCreators(
-				{ successNotice, errorNotice, recordGoogleEvent, recordTracksEvent },
-				dispatch
-			)
+		{ successNotice, errorNotice, recordGoogleEvent, recordTracksEvent }
 	),
 	localize,
 	protectForm

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -283,11 +283,13 @@ const Account = createReactClass( {
 		};
 	},
 
-	getRadioHandler( radioName ) {
-		return event => {
-			const action = 'Clicked ' + radioName + ' radio';
-			this.props.recordGoogleEvent( 'Me', action, 'checked', event.target.value );
-		};
+	handleUsernameChangeBlogRadio( event ) {
+		this.props.recordGoogleEvent(
+			'Me',
+			'Clicked Username Change Blog Action radio',
+			'checked',
+			event.target.value
+		);
 	},
 
 	cancelUsernameChange() {
@@ -626,7 +628,7 @@ const Account = createReactClass( {
 						<FormRadio
 							name="usernameAction"
 							onChange={ this.handleRadioChange }
-							onClick={ this.getRadioHandler( 'Username Change Blog Action' ) }
+							onClick={ this.handleUsernameChangeBlogRadio }
 							value={ key }
 							checked={ key === this.state.usernameAction }
 						/>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -34,13 +34,12 @@ import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormRadio from 'components/forms/form-radio';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import observe from 'lib/mixins/data-observe';
-import eventRecorder from 'me/event-recorder';
 import Main from 'components/main';
 import SitesDropdown from 'components/sites-dropdown';
 import ColorSchemePicker from 'blocks/color-scheme-picker';
@@ -61,7 +60,7 @@ const Account = createReactClass( {
 	displayName: 'Account',
 
 	// form-base mixin is needed for getDisabledState() (and possibly other uses?)
-	mixins: [ formBase, observe( 'userSettings', 'username' ), eventRecorder ],
+	mixins: [ formBase, observe( 'userSettings', 'username' ) ],
 
 	propTypes: {
 		userSettings: PropTypes.object.isRequired,
@@ -164,7 +163,7 @@ const Account = createReactClass( {
 							disabled={ this.getDisabledState() }
 							id="enable_translator"
 							name="enable_translator"
-							onClick={ this.recordCheckboxEvent( 'Community Translator' ) }
+							onClick={ this.getCheckboxHandler( 'Community Translator' ) }
 						/>
 						<span>
 							{ translate( 'Enable the in-page translator where available. {{a}}Learn more{{/a}}', {
@@ -174,7 +173,7 @@ const Account = createReactClass( {
 											target="_blank"
 											rel="noopener noreferrer"
 											href="https://en.support.wordpress.com/community-translator/"
-											onClick={ this.recordClickEvent( 'Community Translator Learn More Link' ) }
+											onClick={ this.getClickHandler( 'Community Translator Learn More Link' ) }
 										/>
 									),
 								},
@@ -258,6 +257,40 @@ const Account = createReactClass( {
 		this.setState( { usernameAction: null } );
 	},
 
+	recordClickEvent( action ) {
+		this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
+	},
+
+	getClickHandler( action, callback ) {
+		return () => {
+			this.recordClickEvent( action );
+
+			if ( callback ) {
+				callback();
+			}
+		};
+	},
+
+	getFocusHandler( action ) {
+		return () => this.props.recordGoogleEvent( 'Me', 'Focused on ' + action );
+	},
+
+	getCheckboxHandler( checkboxName ) {
+		return event => {
+			const action = 'Clicked ' + checkboxName + ' checkbox';
+			const value = event.target.checked ? 1 : 0;
+
+			this.props.recordGoogleEvent( 'Me', action, 'checked', value );
+		};
+	},
+
+	getRadioHandler( radioName ) {
+		return event => {
+			const action = 'Clicked ' + radioName + ' radio';
+			this.props.recordGoogleEvent( 'Me', action, 'checked', event.target.value );
+		};
+	},
+
 	cancelUsernameChange() {
 		this.setState( {
 			userLoginConfirm: null,
@@ -326,7 +359,7 @@ const Account = createReactClass( {
 						disabled={ this.getDisabledState() }
 						id="holidaysnow"
 						name="holidaysnow"
-						onClick={ this.recordCheckboxEvent( 'Holiday Snow' ) }
+						onClick={ this.getCheckboxHandler( 'Holiday Snow' ) }
 					/>
 					<span>{ translate( 'Show snowfall on WordPress.com sites.' ) }</span>
 				</FormLabel>
@@ -432,7 +465,7 @@ const Account = createReactClass( {
 				<a
 					className="button"
 					href={ config( 'signup_url' ) }
-					onClick={ this.recordClickEvent( 'Primary Site Add New WordPress Button' ) }
+					onClick={ this.getClickHandler( 'Primary Site Add New WordPress Button' ) }
 				>
 					{ translate( 'Add New Site' ) }
 				</a>
@@ -496,7 +529,7 @@ const Account = createReactClass( {
 						id="user_email"
 						name="user_email"
 						isError={ !! this.state.emailValidationError }
-						onFocus={ this.recordFocusEvent( 'Email Address Field' ) }
+						onFocus={ this.getFocusHandler( 'Email Address Field' ) }
 						value={ this.getEmailAddress() || '' }
 						onChange={ this.updateEmailAddress }
 					/>
@@ -519,7 +552,7 @@ const Account = createReactClass( {
 						id="user_URL"
 						name="user_URL"
 						type="url"
-						onFocus={ this.recordFocusEvent( 'Web Address Field' ) }
+						onFocus={ this.getFocusHandler( 'Web Address Field' ) }
 						value={ this.getUserSetting( 'user_URL' ) || '' }
 						onChange={ this.updateUserSettingInput }
 					/>
@@ -533,7 +566,7 @@ const Account = createReactClass( {
 					<LanguagePicker
 						disabled={ this.getDisabledState() }
 						languages={ config( 'languages' ) }
-						onClick={ this.recordClickEvent( 'Interface Language Field' ) }
+						onClick={ this.getClickHandler( 'Interface Language Field' ) }
 						valueKey="langSlug"
 						value={
 							this.getUserSetting( 'locale_variant' ) || this.getUserSetting( 'language' ) || ''
@@ -594,7 +627,7 @@ const Account = createReactClass( {
 						<FormRadio
 							name="usernameAction"
 							onChange={ this.handleRadioChange }
-							onClick={ this.recordRadioEvent( 'Username Change Blog Action' ) }
+							onClick={ this.getRadioHandler( 'Username Change Blog Action' ) }
 							value={ key }
 							checked={ key === this.state.usernameAction }
 						/>
@@ -627,7 +660,7 @@ const Account = createReactClass( {
 					<FormTextInput
 						id="username_confirm"
 						name="username_confirm"
-						onFocus={ this.recordFocusEvent( 'Username Confirm Field' ) }
+						onFocus={ this.getFocusHandler( 'Username Confirm Field' ) }
 						value={ this.state.userLoginConfirm }
 						onChange={ this.updateUserLoginConfirm }
 					/>
@@ -666,7 +699,7 @@ const Account = createReactClass( {
 								myProfileLink: (
 									<a
 										href="/me"
-										onClick={ this.recordClickEvent(
+										onClick={ this.getClickHandler(
 											'My Profile Link in Username Change',
 											this.props.markSaved
 										) }
@@ -694,7 +727,7 @@ const Account = createReactClass( {
 					<FormButton
 						disabled={ isSaveButtonDisabled }
 						type="button"
-						onClick={ this.recordClickEvent( 'Change Username Button', this.submitUsernameForm ) }
+						onClick={ this.getClickHandler( 'Change Username Button', this.submitUsernameForm ) }
 					>
 						{ translate( 'Save Username' ) }
 					</FormButton>
@@ -702,7 +735,7 @@ const Account = createReactClass( {
 					<FormButton
 						isPrimary={ false }
 						type="button"
-						onClick={ this.recordClickEvent(
+						onClick={ this.getClickHandler(
 							'Cancel Username Change Button',
 							this.cancelUsernameChange
 						) }
@@ -735,7 +768,7 @@ const Account = createReactClass( {
 								}
 								id="user_login"
 								name="user_login"
-								onFocus={ this.recordFocusEvent( 'Username Field' ) }
+								onFocus={ this.getFocusHandler( 'Username Field' ) }
 								onChange={ this.handleUsernameChange }
 								value={ this.getUserSetting( 'user_login' ) || '' }
 							/>
@@ -763,7 +796,11 @@ export default compose(
 		state => ( {
 			requestingMissingSites: isRequestingMissingSites( state ),
 		} ),
-		dispatch => bindActionCreators( { successNotice, errorNotice, recordTracksEvent }, dispatch )
+		dispatch =>
+			bindActionCreators(
+				{ successNotice, errorNotice, recordGoogleEvent, recordTracksEvent },
+				dispatch
+			)
 	),
 	localize,
 	protectForm

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -797,7 +797,7 @@ export default compose(
 		state => ( {
 			requestingMissingSites: isRequestingMissingSites( state ),
 		} ),
-		{ successNotice, errorNotice, recordGoogleEvent, recordTracksEvent }
+		{ errorNotice, recordGoogleEvent, recordTracksEvent, successNotice }
 	),
 	localize,
 	protectForm


### PR DESCRIPTION
This PR refactors `AccountPassword` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove unnecessary `bindActionCreators` usage.

This PR should not introduce any visual or behavioral changes.

Part of #20053.

To test:
* Checkout this branch
* Make sure your ga debug is enabled: `localStorage.debug = 'calypso:analytics:ga,calypso:analytics:utils'`
* Go to http://calypso.localhost:3000/me/account
* Verify the right event is being dispatched when checking the Community Translator checkbox (you need to select a different interface language than English to reveal this setting).
* Verify the right event is being dispatched when clicking the Community Translator "Learn More" link (you need to select a different interface language than English to reveal this setting).
* Verify the right event is being dispatched when checking the Holiday Snow checkbox (you need to set your current system date to any day in the December month to reveal this setting).
* Verify the right event is being dispatched when clicking the "Add New Site" link in the "Primary Site" field (you need to have no sites to reveal this setting).
* Verify the right event is being dispatched when focusing the "Email Address" field.
* Verify the right event is being dispatched when focusing the "Web Address" field.
* Verify the right event is being dispatched when clicking the "Interface Language" field.
* Verify the right event is being dispatched when ticking a radio button in the "Would you like a matching blog address too?" field (you need to be using a non-a11n account and input a different username in the username field to reveal this setting).
* Verify the right event is being dispatched when focusing the "Confirm Username" field (you need to be using a non-a11n account and input a different username in the username field to reveal this setting).
* Verify the right event is being dispatched when clicking the "My Profile" link in the "Please Read Carefully" section (you need to be using a non-a11n account and input a different username in the username field to reveal this setting).
* Verify the right event is being dispatched when clicking the "Save Username" button (you need to be using a non-a11n account and input a different username in the username field to reveal this setting).
* Verify the right event is being dispatched when clicking the "Cancel" button (you need to be using a non-a11n account and input a different username in the username field to reveal this setting).
* Verify the right event is being dispatched when focusing the username field (you need to be using a non-a11n account and input a different username in the username field to reveal this setting).
* Verify there are no regressions in the account page by testing as a11n and non-a11n.