### PR TITLE
Me: Update ApplicationPasswords to use Redux analytics

### DIFF
--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -29,14 +29,14 @@ import FormLabel from 'components/forms/form-label';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormSectionHeading from 'components/forms/form-section-heading';
-import eventRecorder from 'me/event-recorder';
 import Card from 'components/card';
 import classNames from 'classnames';
 import { errorNotice } from 'state/notices/actions';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 const ApplicationPasswords = createReactClass( {
 	displayName: 'ApplicationPasswords',
-	mixins: [ observe( 'appPasswordsData' ), eventRecorder ],
+	mixins: [ observe( 'appPasswordsData' ) ],
 
 	componentDidMount: function() {
 		debug( this.displayName + ' React component is mounted.' );
@@ -52,6 +52,20 @@ const ApplicationPasswords = createReactClass( {
 			addingPassword: false,
 			submittingForm: false,
 		};
+	},
+
+	getClickHandler( action, callback ) {
+		return event => {
+			this.props.recordGoogleEvent( 'Me', 'Clicked on ' + action );
+
+			if ( callback ) {
+				callback( event );
+			}
+		};
+	},
+
+	getFocusHandler( action ) {
+		return () => this.props.recordGoogleEvent( 'Me', 'Focused on ' + action );
 	},
 
 	createApplicationPassword: function( event ) {
@@ -110,7 +124,7 @@ const ApplicationPasswords = createReactClass( {
 							disabled={ this.state.submittingForm }
 							id="application-name"
 							name="applicationName"
-							onFocus={ this.recordFocusEvent( 'Application Name Field' ) }
+							onFocus={ this.getFocusHandler( 'Application Name Field' ) }
 							value={ this.state.applicationName }
 							onChange={ this.handleChange }
 						/>
@@ -119,7 +133,7 @@ const ApplicationPasswords = createReactClass( {
 					<FormButtonsBar>
 						<FormButton
 							disabled={ this.state.submittingForm || '' === this.state.applicationName }
-							onClick={ this.recordClickEvent( 'Generate New Application Password Button' ) }
+							onClick={ this.getClickHandler( 'Generate New Application Password Button' ) }
 						>
 							{ this.state.submittingForm
 								? this.props.translate( 'Generating Password…' )
@@ -128,7 +142,7 @@ const ApplicationPasswords = createReactClass( {
 						{ this.props.appPasswordsData.get().length ? (
 							<FormButton
 								isPrimary={ false }
-								onClick={ this.recordClickEvent(
+								onClick={ this.getClickHandler(
 									'Cancel Generate New Application Password Button',
 									this.toggleNewPassword
 								) }
@@ -166,7 +180,7 @@ const ApplicationPasswords = createReactClass( {
 
 				<FormButtonsBar>
 					<FormButton
-						onClick={ this.recordClickEvent(
+						onClick={ this.getClickHandler(
 							'New Application Password Done Button',
 							this.clearNewApplicationPassword
 						) }
@@ -209,7 +223,7 @@ const ApplicationPasswords = createReactClass( {
 				<SectionHeader label={ this.props.translate( 'Application Passwords' ) }>
 					<Button
 						compact
-						onClick={ this.recordClickEvent(
+						onClick={ this.getClickHandler(
 							'Create Application Password Button',
 							this.toggleNewPassword
 						) }
@@ -243,6 +257,6 @@ const ApplicationPasswords = createReactClass( {
 	},
 } );
 
-export default connect( null, dispatch => bindActionCreators( { errorNotice }, dispatch ) )(
-	localize( ApplicationPasswords )
-);
+export default connect( null, dispatch =>
+	bindActionCreators( { errorNotice, recordGoogleEvent }, dispatch )
+)( localize( ApplicationPasswords ) );

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -9,7 +9,6 @@ import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:application-passwords' );
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 /**
@@ -257,6 +256,6 @@ const ApplicationPasswords = createReactClass( {
 	},
 } );
 
-export default connect( null, dispatch =>
-	bindActionCreators( { errorNotice, recordGoogleEvent }, dispatch )
-)( localize( ApplicationPasswords ) );
+export default connect( null, { errorNotice, recordGoogleEvent } )(
+	localize( ApplicationPasswords )
+);

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -63,8 +63,8 @@ const ApplicationPasswords = createReactClass( {
 		};
 	},
 
-	getFocusHandler( action ) {
-		return () => this.props.recordGoogleEvent( 'Me', 'Focused on ' + action );
+	handleApplicationNameFocus() {
+		this.props.recordGoogleEvent( 'Me', 'Focused on Application Name Field' );
 	},
 
 	createApplicationPassword: function( event ) {
@@ -123,7 +123,7 @@ const ApplicationPasswords = createReactClass( {
 							disabled={ this.state.submittingForm }
 							id="application-name"
 							name="applicationName"
-							onFocus={ this.getFocusHandler( 'Application Name Field' ) }
+							onFocus={ this.handleApplicationNameFocus }
 							value={ this.state.applicationName }
 							onChange={ this.handleChange }
 						/>


### PR DESCRIPTION
This PR refactors `ApplicationPasswords` to:

* Use Redux analytics instead of `eventRecorder`.
* Remove unnecessary `bindActionCreators` usage.

This PR should not introduce any visual or behavioral changes.

Part of #20053.

To test:
* Checkout this branch
* Make sure your ga debug is enabled: `localStorage.debug = 'calypso:analytics:ga,calypso:analytics:utils'`
* Go to http://calypso.localhost:3000/me/security/two-step and scroll to the "Application Passwords" section.
* Verify the right event is being dispatched when clicking the "Add New Application Password" button.
* Verify the right event is being dispatched when focusing the "Application Name" field.
* Verify the right event is being dispatched when clicking the "Generate Password" button (you need to type something in the field to get it enabled).
* Verify the right event is being dispatched when clicking the "Cancel" button (you need to have at least 1 app password created, and type something in the field to have that button revealed).
* Verify the right event is being dispatched when clicking the "Done" button (revealed after generating an account password).