### PR TITLE
Added pagination to the billing history page

### DIFF
--- a/client/components/pagination/index.jsx
+++ b/client/components/pagination/index.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
@@ -18,6 +18,7 @@ class Pagination extends Component {
 		perPage: PropTypes.number.isRequired,
 		total: PropTypes.number,
 		pageClick: PropTypes.func.isRequired,
+		className: PropTypes.string,
 	};
 
 	getPageList = ( page, pageCount ) => {
@@ -51,7 +52,7 @@ class Pagination extends Component {
 	};
 
 	render() {
-		const { page, pageClick, perPage, total } = this.props;
+		const { page, pageClick, perPage, total, className } = this.props;
 		const pageCount = Math.ceil( total / perPage );
 
 		if ( pageCount <= 1 ) {
@@ -72,7 +73,7 @@ class Pagination extends Component {
 		} );
 
 		return (
-			<div className="pagination">
+			<div className={ classNames( 'pagination', className ) }>
 				<ul className="pagination__list">{ pageListRendered }</ul>
 			</div>
 		);

--- a/client/components/pagination/index.jsx
+++ b/client/components/pagination/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
@@ -18,7 +17,6 @@ class Pagination extends Component {
 		perPage: PropTypes.number.isRequired,
 		total: PropTypes.number,
 		pageClick: PropTypes.func.isRequired,
-		className: PropTypes.string,
 	};
 
 	getPageList = ( page, pageCount ) => {
@@ -52,7 +50,7 @@ class Pagination extends Component {
 	};
 
 	render() {
-		const { page, pageClick, perPage, total, className } = this.props;
+		const { page, pageClick, perPage, total } = this.props;
 		const pageCount = Math.ceil( total / perPage );
 
 		if ( pageCount <= 1 ) {
@@ -73,7 +71,7 @@ class Pagination extends Component {
 		} );
 
 		return (
-			<div className={ classNames( 'pagination', className ) }>
+			<div className="pagination">
 				<ul className="pagination__list">{ pageListRendered }</ul>
 			</div>
 		);

--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -79,7 +79,7 @@ class BillingHistoryTable extends React.Component {
 		return (
 			<TransactionsTable
 				{ ...this.props }
-				initialFilter={ { date: { newest: 5 } } }
+				initialFilter={ { date: { newest: true } } }
 				header
 				emptyTableText={ emptyTableText }
 				noFilterResultsText={ noFilterResultsText }

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -21,7 +21,6 @@ import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
-import { purchasesRoot } from 'me/purchases/paths';
 import { getPastBillingTransactions, getUpcomingBillingTransactions } from 'state/selectors';
 
 const BillingHistory = ( { pastTransactions, upcomingTransactions, translate } ) => (
@@ -33,9 +32,6 @@ const BillingHistory = ( { pastTransactions, upcomingTransactions, translate } )
 		<PurchasesHeader section={ 'billing' } />
 		<Card className="billing-history__receipts">
 			<BillingHistoryTable transactions={ pastTransactions } />
-		</Card>
-		<Card href={ purchasesRoot }>
-			{ translate( 'Go to "Purchases" to add or cancel a plan.' ) }
 		</Card>
 		{ pastTransactions && (
 			<div>

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -103,6 +103,10 @@
 	width: 110px;
 }
 
+.billing-history__pagination {
+	margin: 12px 0;
+}
+
 .billing-history__trans-wrap {
 	@include clear-fix;
 }

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -103,10 +103,6 @@
 	width: 110px;
 }
 
-.billing-history__pagination {
-	margin: 12px 0;
-}
-
 .billing-history__trans-wrap {
 	@include clear-fix;
 }

--- a/client/me/billing-history/table-rows.js
+++ b/client/me/billing-history/table-rows.js
@@ -41,20 +41,16 @@ function filter( transactions, params ) {
 		transactions = search( transactions, params.search );
 	}
 
-	if ( params.date ) {
-		if ( params.date.newest ) {
-			transactions = transactions.slice( 0, params.date.newest );
-		} else if ( params.date.month || params.date.before ) {
-			transactions = transactions.filter( function( transaction ) {
-				const date = moment( transaction.date );
+	if ( params.date && ( params.date.month || params.date.before ) ) {
+		transactions = transactions.filter( function( transaction ) {
+			const date = moment( transaction.date );
 
-				if ( params.date.month ) {
-					return date.isSame( params.date.month, 'month' );
-				} else if ( params.date.before ) {
-					return date.isBefore( params.date.before, 'month' );
-				}
-			} );
-		}
+			if ( params.date.month ) {
+				return date.isSame( params.date.month, 'month' );
+			} else if ( params.date.before ) {
+				return date.isBefore( params.date.before, 'month' );
+			}
+		} );
 	}
 
 	if ( params.app && params.app !== 'all' ) {

--- a/client/me/billing-history/table-rows.js
+++ b/client/me/billing-history/table-rows.js
@@ -22,14 +22,12 @@ function getSearchableStrings( transaction ) {
 function search( transactions, searchQuery ) {
 	return transactions.filter( function( transaction ) {
 		return some( getSearchableStrings( transaction ), function( val ) {
-			var haystack, needle;
-
 			if ( isDate( val ) ) {
 				val = formatDate( val );
 			}
 
-			haystack = val.toString().toLowerCase();
-			needle = searchQuery.toLowerCase();
+			const haystack = val.toString().toLowerCase();
+			const needle = searchQuery.toLowerCase();
 
 			return haystack.indexOf( needle ) !== -1;
 		} );

--- a/client/me/billing-history/transactions-header.jsx
+++ b/client/me/billing-history/transactions-header.jsx
@@ -89,7 +89,7 @@ class TransactionsHeader extends React.Component {
 
 	setFilter( filter ) {
 		this.setState( { activePopover: '' } );
-		this.props.onNewFilter( filter );
+		this.props.onNewFilter( filter, 1 );
 	}
 
 	renderDatePopover() {
@@ -136,11 +136,8 @@ class TransactionsHeader extends React.Component {
 								</tr>
 							</thead>
 							<tbody>
-								{ this.renderDatePicker( '5 Newest', this.props.translate( '5 Newest' ), {
-									newest: 5,
-								} ) }
-								{ this.renderDatePicker( '10 Newest', this.props.translate( '10 Newest' ), {
-									newest: 10,
+								{ this.renderDatePicker( 'newest', this.props.translate( 'Newest' ), {
+									newest: true,
 								} ) }
 							</tbody>
 							<thead>
@@ -180,8 +177,8 @@ class TransactionsHeader extends React.Component {
 		const currentDate = this.props.filter.date || {};
 		let isSelected;
 
-		if ( date.newest ) {
-			isSelected = date.newest === currentDate.newest;
+		if ( date.newest && currentDate.newest ) {
+			isSelected = true;
 		} else if ( date.month && currentDate.month ) {
 			isSelected = date.month.isSame( currentDate.month, 'month' );
 		} else if ( date.before ) {
@@ -212,7 +209,10 @@ class TransactionsHeader extends React.Component {
 	}
 
 	handlePickerSelection( filter ) {
-		this.setFilter( filter );
+		this.setFilter( {
+			...this.props.filter,
+			...filter,
+		} );
 		this.setState( { searchValue: '' } );
 	}
 

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -19,7 +19,7 @@ import TransactionsHeader from './transactions-header';
 import tableRows from './table-rows';
 import SearchCard from 'components/search-card';
 
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 5;
 
 class TransactionsTable extends React.Component {
 	static displayName = 'TransactionsTable';

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -125,7 +125,7 @@ class TransactionsTable extends React.Component {
 	}
 
 	serviceName = transaction => {
-		var item, name;
+		let item, name;
 
 		if ( ! transaction.items ) {
 			name = this.serviceNameDescription( transaction );
@@ -141,7 +141,7 @@ class TransactionsTable extends React.Component {
 	};
 
 	serviceNameDescription = transaction => {
-		var description;
+		let description;
 		if ( transaction.domain ) {
 			description = (
 				<div>
@@ -215,7 +215,7 @@ class TransactionsTable extends React.Component {
 		}
 
 		return this.state.transactions.map( function( transaction ) {
-			var date = tableRows.formatDate( transaction.date );
+			const date = tableRows.formatDate( transaction.date );
 
 			return (
 				<tr key={ transaction.id } className="billing-history__transaction">

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -13,12 +13,13 @@ import { capitalPDangit } from 'lib/formatting';
 /**
  * Internal dependencies
  */
+import CompactCard from 'components/card/compact';
 import Pagination from 'components/pagination';
 import TransactionsHeader from './transactions-header';
 import tableRows from './table-rows';
 import SearchCard from 'components/search-card';
 
-const pageSize = 10;
+const PAGE_SIZE = 10;
 
 class TransactionsTable extends React.Component {
 	static displayName = 'TransactionsTable';
@@ -75,8 +76,8 @@ class TransactionsTable extends React.Component {
 		const filteredTransactions = tableRows.filter( this.props.transactions, newFilter );
 		const newTransactions = slice(
 			filteredTransactions,
-			pageIndex * pageSize,
-			pageIndex * pageSize + pageSize
+			pageIndex * PAGE_SIZE,
+			pageIndex * PAGE_SIZE + PAGE_SIZE
 		);
 
 		return {
@@ -118,13 +119,7 @@ class TransactionsTable extends React.Component {
 					{ header }
 					<tbody>{ this.renderRows() }</tbody>
 				</table>
-				<Pagination
-					className="billing-history__pagination"
-					page={ this.state.page }
-					perPage={ pageSize }
-					total={ this.state.total }
-					pageClick={ this.onPageClick }
-				/>
+				{ this.renderPagination() }
 			</div>
 		);
 	}
@@ -178,6 +173,23 @@ class TransactionsTable extends React.Component {
 					<div className="billing-history__transaction-text" />
 				</td>
 			</tr>
+		);
+	};
+
+	renderPagination = () => {
+		if ( this.state.total < PAGE_SIZE ) {
+			return null;
+		}
+
+		return (
+			<CompactCard>
+				<Pagination
+					page={ this.state.page }
+					perPage={ PAGE_SIZE }
+					total={ this.state.total }
+					pageClick={ this.onPageClick }
+				/>
+			</CompactCard>
 		);
 	};
 

--- a/client/me/billing-history/upcoming-charges-table.jsx
+++ b/client/me/billing-history/upcoming-charges-table.jsx
@@ -51,7 +51,7 @@ class UpcomingChargesTable extends Component {
 		return (
 			<TransactionsTable
 				transactions={ this.props.transactions }
-				initialFilter={ { date: { newest: 20 } } }
+				initialFilter={ { date: { newest: true } } }
 				emptyTableText={ emptyTableText }
 				noFilterResultsText={ noFilterResultsText }
 				transactionRenderer={ this.renderTransaction }


### PR DESCRIPTION
Adds the pagination component to the receipts list and pending purchases list. Removes the "5 Newest" and "10 Newest" date filters with one "Newest" filter. The page size is 10 and applying any filters (date, app or text search) will still show the paginated list (before it would just show all items that pass the filter).

This is just an improvement of the existing functionality. It doesn't fetch more receipts if someone has  more than 200 of them.

Screen:
![screen shot 2018-02-28 at 16 04 58](https://user-images.githubusercontent.com/800604/36798037-6e6a83b0-1ca1-11e8-96f9-f15b006c58e4.png)
