### PR TITLE
Layout: Add skip navigation button to sidebar, avoid stats page issue

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -175,11 +175,11 @@ const Layout = createReactClass( {
 						forcePinned={ 'post' === this.props.section.name }
 					/>
 
-					<div id="primary" className="layout__primary">
-						{ this.props.primary }
-					</div>
 					<div id="secondary" className="layout__secondary">
 						{ this.props.secondary }
+					</div>
+					<div id="primary" className="layout__primary">
+						{ this.props.primary }
 					</div>
 				</div>
 				<TranslatorLauncher

--- a/client/layout/sidebar/region.jsx
+++ b/client/layout/sidebar/region.jsx
@@ -7,8 +7,16 @@
 import React from 'react';
 import classNames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import SkipNavigation from './skip-navigation';
+
 const SidebarRegion = ( { children, className } ) => (
-	<div className={ classNames( 'sidebar__region', className ) }>{ children }</div>
+	<div className={ classNames( 'sidebar__region', className ) }>
+		<SkipNavigation skipToElementId="primary" />
+		{ children }
+	</div>
 );
 
 export default SidebarRegion;

--- a/client/layout/sidebar/skip-navigation.jsx
+++ b/client/layout/sidebar/skip-navigation.jsx
@@ -1,23 +1,37 @@
 /** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
 
 class SkipNavigation extends React.Component {
 	static propTypes = {
 		skipToElementId: PropTypes.string,
 	};
 
+	onClick = event => {
+		event.preventDefault();
+		const element = document.getElementById( this.props.skipToElementId );
+		// Make the element focusable
+		if ( ! /^(?:a|select|input|button|textarea)$/i.test( element.tagName ) ) {
+			element.tabIndex = -1;
+		}
+
+		element.focus();
+	};
+
 	render() {
 		return (
-			<a href={ '#' + this.props.skipToElementId } className="sidebar__skip-navigation">
+			<Button onClick={ this.onClick } className="sidebar__skip-navigation">
 				{ this.props.translate( 'Skip navigation' ) }
-			</a>
+			</Button>
 		);
 	}
 }

--- a/client/layout/sidebar/skip-navigation.jsx
+++ b/client/layout/sidebar/skip-navigation.jsx
@@ -1,0 +1,25 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+import React from 'react';
+
+class SkipNavigation extends React.Component {
+	static propTypes = {
+		skipToElementId: PropTypes.string,
+	};
+
+	render() {
+		return (
+			<a href={ '#' + this.props.skipToElementId } className="sidebar__skip-navigation">
+				{ this.props.translate( 'Skip navigation' ) }
+			</a>
+		);
+	}
+}
+
+export default localize( SkipNavigation );

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -422,6 +422,39 @@ form.sidebar__button input {
 	-webkit-overflow-scrolling: touch;
 }
 
+.sidebar__skip-navigation {
+	position: absolute;
+	left: -10000px;
+	top: auto;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+	flex-shrink: 0;
+
+	&:focus {
+		position: static;
+		width: auto;
+		height: auto;
+		padding: 11px 16px 11px 18px;
+		outline: none;
+		box-shadow: inset 0 0 0 2px $blue-light;
+		font-size: 14px;
+		line-height: 1;
+		color: var( --sidebar-color );
+		box-sizing: border-box;
+		white-space: nowrap;
+		overflow: hidden;
+		display: flex;
+		align-items: center;
+
+		&:after {
+			top: 2px;
+			right: 2px;
+			bottom: 2px;
+		}
+	}
+}
+
 .sidebar__menu {
 	.is-placeholder {
 		cursor: default;

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -170,8 +170,8 @@ export default {
 
 		const activeFilter = find( filters(), filter => {
 			return (
-				context.pathname === filter.path ||
-				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
+				context.path === filter.path ||
+				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.path ) )
 			);
 		} );
 
@@ -187,7 +187,7 @@ export default {
 
 			const props = {
 				period: activeFilter.period,
-				path: context.pathname,
+				path: context.path,
 			};
 			context.primary = <StatsOverview { ...props } />;
 			next();
@@ -213,8 +213,8 @@ export default {
 
 		const activeFilter = find( filters, filter => {
 			return (
-				context.pathname === filter.path ||
-				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
+				context.path === filter.path ||
+				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.path ) )
 			);
 		} );
 
@@ -260,7 +260,7 @@ export default {
 			chartTab = queryOptions.tab || 'views';
 
 			const props = {
-				path: context.pathname,
+				path: context.path,
 				date,
 				chartTab,
 				context,
@@ -311,8 +311,8 @@ export default {
 
 		const activeFilter = find( filters, filter => {
 			return (
-				context.pathname === filter.path ||
-				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
+				context.path === filter.path ||
+				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.path ) )
 			);
 		} );
 
@@ -356,7 +356,7 @@ export default {
 			);
 
 			const props = {
-				path: context.pathname,
+				path: context.path,
 				statsQueryOptions,
 				date,
 				context,

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -170,8 +170,8 @@ export default {
 
 		const activeFilter = find( filters(), filter => {
 			return (
-				context.path === filter.path ||
-				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.path ) )
+				context.pathname === filter.path ||
+				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
 			);
 		} );
 
@@ -187,7 +187,7 @@ export default {
 
 			const props = {
 				period: activeFilter.period,
-				path: context.path,
+				path: context.pathname,
 			};
 			context.primary = <StatsOverview { ...props } />;
 			next();
@@ -213,8 +213,8 @@ export default {
 
 		const activeFilter = find( filters, filter => {
 			return (
-				context.path === filter.path ||
-				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.path ) )
+				context.pathname === filter.path ||
+				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
 			);
 		} );
 
@@ -260,7 +260,7 @@ export default {
 			chartTab = queryOptions.tab || 'views';
 
 			const props = {
-				path: context.path,
+				path: context.pathname,
 				date,
 				chartTab,
 				context,
@@ -311,8 +311,8 @@ export default {
 
 		const activeFilter = find( filters, filter => {
 			return (
-				context.path === filter.path ||
-				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.path ) )
+				context.pathname === filter.path ||
+				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
 			);
 		} );
 
@@ -356,7 +356,7 @@ export default {
 			);
 
 			const props = {
-				path: context.path,
+				path: context.pathname,
 				statsQueryOptions,
 				date,
 				context,


### PR DESCRIPTION
This PR builds off what @omidfi started in #22791, but that PR had to be reverted due to an issue with the stats day page. The element ID link was messing with the page routing, which caused a whitescreen when using the skip link. The difference in this PR is the switch to a `Button` + `onClick`, rather than linking to an element ID. 

This uses a modified version of the skip link code from [the _s theme](https://github.com/Automattic/_s/blob/master/js/skip-link-focus-fix.js), to directly focus into the specified element. This also keeps the component a little more general, in case we want to use it to add skip links to other areas of Calypso.

<img width="285" alt="screen shot 2018-02-28 at 11 11 43 am" src="https://user-images.githubusercontent.com/541093/36798290-3219b6de-1c78-11e8-96c9-cd8ef181dbb3.png">

**To test**

- Attempt to navigate into the content area of Calypso with just your keyboard
- Specifically try on a past day's stats page
- Try anywhere else you know of Calypso using query strings