### PR TITLE
Sidebar: Update notices to look more like notices

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -131,9 +131,8 @@ class CurrentSite extends Component {
 					<AllSites />
 				) }
 
-				<AsyncLoad require="my-sites/current-site/domain-warnings" placeholder={ null } />
-
 				<SiteNotice site={ selectedSite } allSitesPath={ this.props.allSitesPath } />
+				<AsyncLoad require="my-sites/current-site/domain-warnings" placeholder={ null } />
 			</Card>
 		);
 	}

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -139,11 +139,11 @@ class SiteNotice extends React.Component {
 		return (
 			<div className="site__notices">
 				{ this.freeToPaidPlanNotice() }
+				<DomainToPaidPlanNotice />
 				{ this.getSiteRedirectNotice( site ) }
 				<QuerySitePlans siteId={ site.ID } />
 				{ this.domainCreditNotice() }
 				{ this.jetpackPluginsSetupNotice() }
-				<DomainToPaidPlanNotice />
 			</div>
 		);
 	}

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -138,11 +138,11 @@ class SiteNotice extends React.Component {
 		}
 		return (
 			<div className="site__notices">
+				{ this.freeToPaidPlanNotice() }
 				{ this.getSiteRedirectNotice( site ) }
 				<QuerySitePlans siteId={ site.ID } />
 				{ this.domainCreditNotice() }
 				{ this.jetpackPluginsSetupNotice() }
-				{ this.freeToPaidPlanNotice() }
 				<DomainToPaidPlanNotice />
 			</div>
 		);

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -88,18 +88,8 @@
 	}
 }
 
-.current-site .notice {
-	margin: 0 8px 8px;
-}
-
-.current-site .notice.is-compact {
+.sidebar .notice.is-compact {
 	display: flex;
-	margin: 0;
-	border-radius: 0;
-
-	@include breakpoint( "<660px" ) {
-		padding: 0 24px;
-	}
 
 	.notice__text {
 		width: 100%;
@@ -109,9 +99,5 @@
 
 	.notice__action {
 		margin-left: auto;
-	}
-
-	.notice__icon-wrapper {
-		border-radius: 0;
 	}
 }

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -90,6 +90,7 @@
 
 .sidebar .notice.is-compact {
 	display: flex;
+	margin: 4px;
 
 	.notice__text {
 		width: 100%;


### PR DESCRIPTION
Currently, we display notices in a different way in the sidebar. They don't have rounded borders, and when they stack, they tend to "meld" together.

<img width="311" alt="screen shot 2018-02-28 at 12 08 46 pm" src="https://user-images.githubusercontent.com/191598/36801733-df80b298-1c80-11e8-9394-2c64c378e30f.png">

This PR aims to make sidebar notices look more standard with rounded borders and adds a 4px margin:

<img width="299" alt="screen shot 2018-02-28 at 12 08 40 pm" src="https://user-images.githubusercontent.com/191598/36801776-fb4dafda-1c80-11e8-870b-b36d4b334920.png">

<img width="294" alt="screen shot 2018-03-01 at 2 22 31 pm" src="https://user-images.githubusercontent.com/191598/36865080-7782b448-1d5c-11e8-9d86-d514d919ba65.png">

<img width="290" alt="screen shot 2018-03-01 at 2 22 37 pm" src="https://user-images.githubusercontent.com/191598/36865081-7969a0fa-1d5c-11e8-9b27-d606528c5106.png">
