### PR TITLE
GMB: Update nudge styles

### DIFF
--- a/client/blocks/google-my-business-stats-nudge/style.scss
+++ b/client/blocks/google-my-business-stats-nudge/style.scss
@@ -28,30 +28,25 @@
 	@include breakpoint( ">960px" ) {
 		// the image has about 12 px of whitespace, this helps "balance" the block
 		padding-right: 12px;
-		// compensate for the parent card missing padding
-		padding-bottom: 11px;
 	}
 }
 
 .google-my-business-stats-nudge__title {
-	font-size: 18px;
+	font-size: 21px;
 	font-weight: 400;
-	@include breakpoint( ">960px" ) {
-		font-size: 20px;
-	}
+	margin: 10px 0 5px;
 }
 
 .google-my-business-stats-nudge__description {
 	font-size: 16px;
 	font-weight: 400;
-	margin: 10px 0;
 }
 
 .google-my-business-stats-nudge__button-row {
 	align-content: center;
 	display: flex;
 	flex-direction: row;
-	margin: 16px 0;
+	margin: 20px 0;
 	.button {
 		// space out buttons
 		margin-right: 16px;
@@ -63,12 +58,12 @@
 	padding: 0 40px;
 	@include breakpoint( ">960px" ) {
 		display: flex;
-		margin-right: 24px;
 		min-width: 250px;
 	}
 }
 
 .google-my-business-stats-nudge__image {
+	flex: 1;
 	flex-shrink: 0;
 	max-height: 250px;
 }


### PR DESCRIPTION
This pull request updates the nudge styles to make them more aesthetically pleasing.

<img width="433" alt="screen shot 2018-02-28 at 17 14 43" src="https://user-images.githubusercontent.com/275961/36802301-7195ecb8-1cac-11e8-9e3e-33ec26d15271.png">
<img width="704" alt="screen shot 2018-02-28 at 17 14 29" src="https://user-images.githubusercontent.com/275961/36802303-71b23116-1cac-11e8-991b-8a1ab2f103c8.png">
<img width="684" alt="screen shot 2018-02-28 at 17 14 15" src="https://user-images.githubusercontent.com/275961/36802305-71e414ba-1cac-11e8-864e-996f76f042f8.png">
<img width="1097" alt="screen shot 2018-02-28 at 17 13 54" src="https://user-images.githubusercontent.com/275961/36802306-720c1a78-1cac-11e8-8273-667a2ff7f78d.png">
  
#### Testing instructions
  
1. Run `git checkout update/gmb-nudge` and start your server
2. Open the [`Stats` page](http://calypso.localhost:3000/stats/day/) for a site which has a GMB nudge
3. Check that it matches the screenshots above

#### Reviews
  
- [x] Code
- [x] Product
 