### PR TITLE
Invites: display a friendlier error when user cannot view people list

### DIFF
--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -30,6 +30,7 @@ import {
 	didInviteDeletionSucceed,
 } from 'state/invites/selectors';
 import { deleteInvite } from 'state/invites/actions';
+import { canCurrentUser } from 'state/selectors';
 
 export class PeopleInviteDetails extends React.PureComponent {
 	static propTypes = {
@@ -167,11 +168,24 @@ export class PeopleInviteDetails extends React.PureComponent {
 	}
 
 	render() {
-		const { site, translate } = this.props;
+		const { canViewPeople, site, translate } = this.props;
+		const siteId = site && site.ID;
+
+		if ( siteId && ! canViewPeople ) {
+			return (
+				<Main>
+					<SidebarNavigation />
+					<EmptyContent
+						title={ this.props.translate( 'You are not authorized to view this page' ) }
+						illustration={ '/calypso/images/illustrations/illustration-404.svg' }
+					/>
+				</Main>
+			);
+		}
 
 		return (
 			<Main className="people-invite-details">
-				{ site && site.ID && <QuerySiteInvites siteId={ site.ID } /> }
+				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
 				<SidebarNavigation />
 
 				<HeaderCake isCompact onClick={ this.goBack }>
@@ -195,6 +209,7 @@ export default connect(
 			deleting: isDeletingInvite( state, siteId, ownProps.inviteKey ),
 			deleteSuccess: didInviteDeletionSucceed( state, siteId, ownProps.inviteKey ),
 			invite: getInviteForSite( state, siteId, ownProps.inviteKey ),
+			canViewPeople: canCurrentUser( state, siteId, 'list_users' ),
 		};
 	},
 	{ deleteInvite }

--- a/client/my-sites/people/people-invite-details/test/index.jsx
+++ b/client/my-sites/people/people-invite-details/test/index.jsx
@@ -90,6 +90,7 @@ describe( 'PeopleInviteDetails', () => {
 				deleteInvite={ mockDeleteInvite }
 				translate={ mockTranslate }
 				moment={ moment }
+				canViewPeople={ true }
 			/>
 		);
 
@@ -118,6 +119,7 @@ describe( 'PeopleInviteDetails', () => {
 				deleteInvite={ mockDeleteInvite }
 				translate={ mockTranslate }
 				moment={ moment }
+				canViewPeople={ true }
 			/>
 		);
 
@@ -143,6 +145,7 @@ describe( 'PeopleInviteDetails', () => {
 				invite={ acceptedInviteObject }
 				translate={ mockTranslate }
 				moment={ moment }
+				canViewPeople={ true }
 			/>
 		);
 

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -26,7 +26,7 @@ import Dialog from 'components/dialog';
 import InvitesListEnd from './invites-list-end';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
-import { isPrivateSite } from 'state/selectors';
+import { isPrivateSite, canCurrentUser } from 'state/selectors';
 import {
 	isRequestingInvitesForSite,
 	getPendingInvitesForSite,
@@ -35,7 +35,6 @@ import {
 	isDeletingAnyInvite,
 } from 'state/invites/selectors';
 import { deleteInvites } from 'state/invites/actions';
-import { canCurrentUser } from 'state/selectors';
 
 class PeopleInvites extends React.PureComponent {
 	static propTypes = {

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -35,6 +35,7 @@ import {
 	isDeletingAnyInvite,
 } from 'state/invites/selectors';
 import { deleteInvites } from 'state/invites/actions';
+import { canCurrentUser } from 'state/selectors';
 
 class PeopleInvites extends React.PureComponent {
 	static propTypes = {
@@ -66,8 +67,20 @@ class PeopleInvites extends React.PureComponent {
 	};
 
 	render() {
-		const { site, isJetpack, isPrivate, jetpackPeopleSupported } = this.props;
+		const { site, canViewPeople, isJetpack, isPrivate, jetpackPeopleSupported } = this.props;
 		const siteId = site && site.ID;
+
+		if ( siteId && ! canViewPeople ) {
+			return (
+				<Main>
+					<SidebarNavigation />
+					<EmptyContent
+						title={ this.props.translate( 'You are not authorized to view this page' ) }
+						illustration={ '/calypso/images/illustrations/illustration-404.svg' }
+					/>
+				</Main>
+			);
+		}
 
 		return (
 			<Main className="people-invites">
@@ -233,6 +246,7 @@ export default connect(
 			acceptedInvites: getAcceptedInvitesForSite( state, siteId ),
 			totalInvitesFound: getNumberOfInvitesFoundForSite( state, siteId ),
 			deleting: isDeletingAnyInvite( state, siteId ),
+			canViewPeople: canCurrentUser( state, siteId, 'list_users' ),
 		};
 	},
 	{ deleteInvites }


### PR DESCRIPTION
This PR updates the error message displayed when you try to access the invites path for a site for which you do not have permissions to list users.

Before:

![image](https://user-images.githubusercontent.com/363749/36810541-9bd4f3fa-1c90-11e8-8328-ea6bc62d3d91.png)

![image](https://user-images.githubusercontent.com/363749/36810573-b50e9bdc-1c90-11e8-92c5-a03676f40716.png)

After:

![image](https://user-images.githubusercontent.com/363749/36810591-c2cdfef2-1c90-11e8-984c-0fa43188d93a.png)


This brings the messaging inline with the other pages within people management.

To test:
* With a user that does not have permissions to create invites, navigate directly to the url `http://calypso.localhost:3000/people/invites/example.wordpress.com`, replacing `example.wordpress.com` with your test site.
* Verify that instead of a message saying you have no invites, the updated messaging about not having authorization appears.
* Navigate directly to an invite details url, such as `https://wordpress.com/people/invites/example.wordpress.com/abc123def456`, again replacing `example.wordpress.com`.
* Verify that instead of a message saying the invite wasn't found, that the updated messaging about not having authorization appears.