### PR TITLE
People: fix 'viewers' tab for invites.

### DIFF
--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -25,6 +25,8 @@ import QuerySiteInvites from 'components/data/query-site-invites';
 import Dialog from 'components/dialog';
 import InvitesListEnd from './invites-list-end';
 import { getSelectedSite } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import { isPrivateSite } from 'state/selectors';
 import {
 	isRequestingInvitesForSite,
 	getPendingInvitesForSite,
@@ -64,14 +66,19 @@ class PeopleInvites extends React.PureComponent {
 	};
 
 	render() {
-		const { site } = this.props;
+		const { site, isJetpack, isPrivate } = this.props;
 		const siteId = site && site.ID;
 
 		return (
 			<Main className="people-invites">
 				{ siteId && <QuerySiteInvites siteId={ siteId } /> }
 				<SidebarNavigation />
-				<PeopleSectionNav filter="invites" site={ site } />
+				<PeopleSectionNav
+					filter="invites"
+					site={ site }
+					isJetpack={ isJetpack }
+					isPrivate={ isPrivate }
+				/>
 				{ this.renderInvitesList() }
 			</Main>
 		);
@@ -217,6 +224,8 @@ export default connect(
 
 		return {
 			site,
+			isJetpack: isJetpackSite( state, siteId ),
+			isPrivate: isPrivateSite( state, siteId ),
 			requesting: isRequestingInvitesForSite( state, siteId ),
 			pendingInvites: getPendingInvitesForSite( state, siteId ),
 			acceptedInvites: getAcceptedInvitesForSite( state, siteId ),

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -25,7 +25,7 @@ import QuerySiteInvites from 'components/data/query-site-invites';
 import Dialog from 'components/dialog';
 import InvitesListEnd from './invites-list-end';
 import { getSelectedSite } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
+import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { isPrivateSite } from 'state/selectors';
 import {
 	isRequestingInvitesForSite,
@@ -66,7 +66,7 @@ class PeopleInvites extends React.PureComponent {
 	};
 
 	render() {
-		const { site, isJetpack, isPrivate } = this.props;
+		const { site, isJetpack, isPrivate, jetpackPeopleSupported } = this.props;
 		const siteId = site && site.ID;
 
 		return (
@@ -78,6 +78,7 @@ class PeopleInvites extends React.PureComponent {
 					site={ site }
 					isJetpack={ isJetpack }
 					isPrivate={ isPrivate }
+					jetpackPeopleSupported={ jetpackPeopleSupported }
 				/>
 				{ this.renderInvitesList() }
 			</Main>
@@ -226,6 +227,7 @@ export default connect(
 			site,
 			isJetpack: isJetpackSite( state, siteId ),
 			isPrivate: isPrivateSite( state, siteId ),
+			jetpackPeopleSupported: isJetpackMinimumVersion( state, siteId, '3.7.0-beta' ),
 			requesting: isRequestingInvitesForSite( state, siteId ),
 			pendingInvites: getPendingInvitesForSite( state, siteId ),
 			acceptedInvites: getAcceptedInvitesForSite( state, siteId ),


### PR DESCRIPTION
Fixes #22865.

<img width="814" alt="36757369-3dd58852-1bc6-11e8-92c1-5f2ad111156f" src="https://user-images.githubusercontent.com/942359/36811536-28fc9232-1c9c-11e8-94e4-9708f3361d11.png">

**To test:**
- For a private site with viewers, the 'Viewers' filter should be available in all tabs of the People section
- ~~For a private Jetpack site, there should not be a 'Viewers' filter in the People section~~
- For a public site, there should not be a 'Viewers' filter in the People section