### PR TITLE
Infinite List: Fix the isMounted warning

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -32,6 +32,7 @@ export default createReactClass( {
 	scrollRAFHandle: false,
 	scrollHelper: null,
 	isScrolling: false,
+	_isMounted: false,
 
 	propTypes: {
 		items: PropTypes.array.isRequired,
@@ -96,6 +97,7 @@ export default createReactClass( {
 	},
 
 	componentDidMount() {
+		this._isMounted = true;
 		if ( this._contextLoaded() ) {
 			this._setContainerY( this.state.scrollTop );
 		}
@@ -188,6 +190,7 @@ export default createReactClass( {
 		this._scrollContainer.removeEventListener( 'scroll', this.onScroll );
 		this._scrollContainer.removeEventListener( 'scroll', this._resetScroll );
 		this.cancelAnimationFrame();
+		this._isMounted = false;
 	},
 
 	cancelAnimationFrame() {
@@ -223,7 +226,7 @@ export default createReactClass( {
 	scrollChecks() {
 		// isMounted is necessary to prevent running this before it is mounted,
 		// which could be triggered by data-observe mixin.
-		if ( ! this.isMounted() || this.getCurrentScrollTop() === this.lastScrollTop ) {
+		if ( ! this._isMounted || this.getCurrentScrollTop() === this.lastScrollTop ) {
 			this.scrollRAFHandle = null;
 			return;
 		}


### PR DESCRIPTION
Instead of using isMounted(), use our own custom property. This kills the warning when inifinite list mounts.

To test, pull up any Reader stream in development. It should still work, and you should no longer see a warning about using isMounted in the console.