### PR TITLE
Fix the wrong chunk name reported in calypso_chunk_waiting stat bump

### DIFF
--- a/client/components/pulsing-dot/index.jsx
+++ b/client/components/pulsing-dot/index.jsx
@@ -7,47 +7,7 @@
 import React from 'react';
 import classnames from 'classnames';
 
-/**
- * Internal dependencies
- */
-import analytics from 'lib/analytics';
-
-class PulsingDot extends React.Component {
-	static defaultProps = {
-		active: false,
-	};
-
-	_loadingStatTimeout = null;
-
-	componentWillUnmount() {
-		if ( this._loadingStatTimeout ) {
-			clearTimeout( this._loadingStatTimeout );
-			this._loadingStatTimeout = null;
-		}
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.active === this.props.active || ! this.props.chunkName ) {
-			return;
-		}
-
-		if ( nextProps.active ) {
-			this._loadingStatTimeout = setTimeout( () => {
-				analytics.mc.bumpStat( 'calypso_chunk_waiting', this.props.chunkName );
-			}, 400 );
-		} else {
-			clearTimeout( this._loadingStatTimeout );
-			this._loadingStatTimeout = null;
-		}
-	}
-
-	render() {
-		var className = classnames( {
-			'pulsing-dot': true,
-			'is-active': this.props.active,
-		} );
-		return <div className={ className } />;
-	}
+export default function PulsingDot( { active } ) {
+	const className = classnames( 'pulsing-dot', { 'is-active': active } );
+	return <div className={ className } />;
 }
-
-export default PulsingDot;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -163,7 +163,7 @@ const Layout = createReactClass( {
 				{ this.renderMasterbar() }
 				{ config.isEnabled( 'support-user' ) && <SupportUser /> }
 				<div className={ loadingClass }>
-					<PulsingDot active={ this.props.isLoading } chunkName={ this.props.section.name } />
+					<PulsingDot active={ this.props.isLoading } />
 				</div>
 				{ this.props.isOffline && <OfflineStatus /> }
 				<div id="content" className="layout__content">

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -10,6 +10,7 @@ import { find, filter, isEmpty } from 'lodash';
  * Internal dependencies
  */
 import { activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
+import { bumpStat } from 'state/analytics/actions';
 import * as LoadingError from 'layout/error';
 import * as controller from './controller/index.web';
 import { restoreLastSession } from 'lib/restore-last-path';
@@ -74,6 +75,13 @@ function createPageDefinition( path, sectionDefinition ) {
 			return;
 		}
 		dispatch( { type: 'SECTION_SET', isLoading: true } );
+
+		// If the section chunk is not loaded within 400ms, report it to analytics
+		const loadReportTimeout = setTimeout(
+			() => dispatch( bumpStat( 'calypso_chunk_waiting', sectionDefinition.name ) ),
+			400
+		);
+
 		preload( sectionDefinition.name )
 			.then( requiredModules => {
 				if ( ! _loadedSections[ sectionDefinition.module ] ) {
@@ -90,6 +98,10 @@ function createPageDefinition( path, sectionDefinition ) {
 					dispatch( { type: 'SECTION_SET', isLoading: false } );
 					LoadingError.show( context, sectionDefinition.name );
 				}
+			} )
+			.then( () => {
+				// If the load was faster than the timeout, this will cancel the analytics reporting
+				clearTimeout( loadReportTimeout );
 			} );
 	} );
 }


### PR DESCRIPTION
When bumping the `calypso_chunk_waiting` when a chunk load takes more than 400ms, a wrong chunk name is reported. The value in `state.ui.section.name` is used, but that's the name of the previous chunk, i.e., the one that the navigation was initiated from. The new chunk name is set only in the `SECTION_SET` action (dispatched from `activateSection`) after the load is finished.

This PR moves the stat-bumping code to `sections-middleware.js` and uses the right chunk name there. The functionality from `PulsingDot` is removed and `PulsingDot` becomes a simple component with just one responsibility: render the dot 😄 

**How to test:**
- enable network throttling in your devtools (I used "Fast 3G" in Chrome)
- enable analytics debug logging (type `localStorage.debug = 'calypso:analytics:mc'` in console and reload)
- watch if slow chunk downloads are property reported
