### PR TITLE
Remove all references to global in client code

### DIFF
--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -73,14 +73,14 @@ class ReaderFeaturedVideo extends React.Component {
 	};
 
 	componentDidMount() {
-		if ( this.props.allowPlaying ) {
-			global.window && global.window.addEventListener( 'resize', this.throttledUpdateVideoSize );
+		if ( this.props.allowPlaying && typeof window !== 'undefined' ) {
+			window && window.addEventListener( 'resize', this.throttledUpdateVideoSize );
 		}
 	}
 
 	componentWillUnmount() {
-		if ( this.props.allowPlaying ) {
-			global.window && global.window.removeEventListener( 'resize', this.throttledUpdateVideoSize );
+		if ( this.props.allowPlaying && typeof window !== 'undefined' ) {
+			window && window.removeEventListener( 'resize', this.throttledUpdateVideoSize );
 		}
 	}
 

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -85,7 +85,7 @@ function embedInstagram( domNode ) {
 	debug( 'processing instagram for', domNode );
 	if ( typeof instgrm !== 'undefined' ) {
 		try {
-			global.instgrm.Embeds.process();
+			window.instgrm.Embeds.process();
 		} catch ( e ) {}
 		return;
 	}
@@ -101,7 +101,7 @@ function embedTwitter( domNode ) {
 
 	if ( typeof twttr !== 'undefined' ) {
 		try {
-			global.twttr.widgets.load( domNode );
+			window.twttr.widgets.load( domNode );
 		} catch ( e ) {}
 		return;
 	}

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -131,7 +131,7 @@ export class WebPreviewContent extends Component {
 	removeSelection = () => {
 		// remove all textual selections when user gives focus to preview iframe
 		// they might be confusing
-		if ( global.window ) {
+		if ( typeof window !== 'undefined' ) {
 			if ( isFunction( window.getSelection ) ) {
 				const selection = window.getSelection();
 				if ( isFunction( selection.empty ) ) {

--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -82,7 +82,8 @@ export default class Step extends Component {
 			this.setStepSection( this.context, { init: true } );
 			debug( 'Step#componentWillMount: stepSection:', this.stepSection );
 			this.skipIfInvalidContext( this.props, this.context );
-			this.scrollContainer = query( this.props.scrollContainer )[ 0 ] || global.window;
+			this.scrollContainer =
+				query( this.props.scrollContainer )[ 0 ] || ( typeof window !== 'undefined' && window );
 			this.setStepPosition( this.props );
 			this.safeSetState( { initialized: true } );
 		} );
@@ -91,7 +92,9 @@ export default class Step extends Component {
 	componentDidMount() {
 		this.mounted = true;
 		this.wait( this.props, this.context ).then( () => {
-			global.window.addEventListener( 'resize', this.onScrollOrResize );
+			if ( typeof window !== 'undefined' ) {
+				window.addEventListener( 'resize', this.onScrollOrResize );
+			}
 		} );
 	}
 
@@ -101,7 +104,8 @@ export default class Step extends Component {
 			this.quitIfInvalidRoute( nextProps, nextContext );
 			this.skipIfInvalidContext( nextProps, nextContext );
 			this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
-			this.scrollContainer = query( nextProps.scrollContainer )[ 0 ] || global.window;
+			this.scrollContainer =
+				query( nextProps.scrollContainer )[ 0 ] || ( typeof window !== 'undefined' && window );
 			this.scrollContainer.addEventListener( 'scroll', this.onScrollOrResize );
 			const shouldScrollTo = nextProps.shouldScrollTo && this.props.name !== nextProps.name;
 			this.setStepPosition( nextProps, shouldScrollTo );
@@ -112,7 +116,9 @@ export default class Step extends Component {
 		this.mounted = false;
 		this.safeSetState( { initialized: false } );
 
-		global.window.removeEventListener( 'resize', this.onScrollOrResize );
+		if ( typeof window !== 'undefined' ) {
+			window.removeEventListener( 'resize', this.onScrollOrResize );
+		}
 		if ( this.scrollContainer ) {
 			this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
 		}

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -75,8 +75,7 @@ const dialogPositioners = {
 	} ),
 };
 
-export const query = selector =>
-	[].slice.call( global.window.document.querySelectorAll( selector ) );
+export const query = selector => [].slice.call( window.document.querySelectorAll( selector ) );
 
 export const posToCss = ( { x, y } ) => ( {
 	top: y ? y + 'px' : undefined,
@@ -105,7 +104,7 @@ export function getValidatedArrowPosition( { targetSlug, arrow, stepPos } ) {
 	const rect =
 		target && target.getBoundingClientRect
 			? target.getBoundingClientRect()
-			: global.window.document.body.getBoundingClientRect();
+			: window.document.body.getBoundingClientRect();
 
 	if (
 		stepPos.y >= rect.top &&
@@ -141,7 +140,7 @@ export function getStepPosition( {
 	const rect =
 		target && target.getBoundingClientRect
 			? target.getBoundingClientRect()
-			: global.window.document.body.getBoundingClientRect();
+			: window.document.body.getBoundingClientRect();
 	const position = dialogPositioners[ validatePlacement( placement, target ) ]( rect );
 
 	return {

--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -26,7 +26,8 @@ const REGEXP_VALID_PROTOCOL = /^https?:$/;
  *
  * @type {Number}
  */
-const IMAGE_SCALE_FACTOR = get( global.window, 'devicePixelRatio', 1 ) > 1 ? 2 : 1;
+const IMAGE_SCALE_FACTOR =
+	get( typeof window !== 'undefined' && window, 'devicePixelRatio', 1 ) > 1 ? 2 : 1;
 
 /**
  * Query parameters to be treated as image dimensions

--- a/client/lib/viewport/index.js
+++ b/client/lib/viewport/index.js
@@ -44,10 +44,8 @@ export function isWithinBreakpoint( breakpoint ) {
 
 	if ( ! breakpoints.hasOwnProperty( breakpoint ) ) {
 		try {
-			global.window.console.warn(
-				'Undefined breakpoint used in `mobile-first-breakpoint`',
-				breakpoint
-			);
+			// eslint-disable-next-line no-console
+			console.warn( 'Undefined breakpoint used in `mobile-first-breakpoint`', breakpoint );
 		} catch ( e ) {}
 		return undefined;
 	}
@@ -65,5 +63,5 @@ export function isDesktop() {
 // FIXME: We can't detect window size on the server, so until we have more intelligent detection,
 // use 769, which is just above the general maximum mobile screen width.
 export function getWindowInnerWidth() {
-	return global.window ? global.window.innerWidth : 769;
+	return typeof window !== 'undefined' ? window.innerWidth : 769;
 }

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -48,11 +48,15 @@ class PreviewMain extends React.Component {
 	debouncedUpdateLayout = debounce( this.updateLayout, 50 );
 
 	componentDidMount() {
-		global.window && global.window.addEventListener( 'resize', this.debouncedUpdateLayout );
+		if ( typeof window !== 'undefined' ) {
+			window && window.addEventListener( 'resize', this.debouncedUpdateLayout );
+		}
 	}
 
 	componentWillUnmount() {
-		global.window && global.window.removeEventListener( 'resize', this.debouncedUpdateLayout );
+		if ( typeof window !== 'undefined' ) {
+			window && window.removeEventListener( 'resize', this.debouncedUpdateLayout );
+		}
 	}
 
 	updateUrl() {

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -181,7 +181,7 @@ class ThemesMagicSearchCard extends React.Component {
 
 	searchTokens = input => {
 		//We are not able to scroll overlay on Edge so just create empty div
-		if ( global.window && /(Edge)/.test( global.window.navigator.userAgent ) ) {
+		if ( typeof window !== 'undefined' && /(Edge)/.test( window.navigator.userAgent ) ) {
 			return <div />;
 		}
 

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -131,8 +131,8 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 		{ leading: false, trailing: true }
 	);
 
-	if ( global.window ) {
-		global.window.addEventListener( 'beforeunload', throttledSaveState.flush );
+	if ( typeof window !== 'undefined' ) {
+		window.addEventListener( 'beforeunload', throttledSaveState.flush );
 	}
 
 	reduxStore.subscribe( throttledSaveState );


### PR DESCRIPTION
`global` is a nodejs-ism that has no place in browser code. This PR is an attempt at getting rid of all of our usages of `global` within client.

I'm not confident about this approach yet, very likely I end up closing this.