### PR TITLE
Add missing z-layer definition

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -84,6 +84,7 @@ $z-layers: (
 		'.comment-detail.card.accessible-focus:focus': 1,
 		'.web-preview__inner .spinner-line': 1,
 		'.google-my-business__close-icon': 1,
+		'.google-my-business__stats-nudge.dismissible-card__close-icon': 1,
 		'.editor-sidebar': 2,
 		'.editor-action-bar .editor-status-label': 2,
 		'.is-installing .theme': 2,


### PR DESCRIPTION
Add missing z-layer definition

This PR fixes:

```
WARNING: No layer found for `.google-my-business__stats-nudge.dismissible-card__close-icon` of `[root, .google-my-business__stats-nudge.dismissible-card__close-icon]` in $z-layers map. Property omitted.
Backtrace:
        assets/stylesheets/shared/functions/_z-index.scss:280, in function `map-deep-get`
        assets/stylesheets/shared/functions/_z-index.scss:289, in function `z-index`
        client/blocks/google-my-business-stats-nudge/style.scss:6
```


#### Testing instructions
  
1. Run `git checkout add/missing-z-index-def` and start your server, or open a [live branch](https://calypso.live/?branch=add/missing-z-index-def)
2. Open the [`Stats` page](http://calypso.localhost:3000/) for a site that has GMB nudge
3. Check that the nudge displayed correctly and you can indeed click the `X` button
  
#### Reviews
  
- [ ] Code
- [ ] Product

