### PR TITLE
JP Remote Install: Adjust API/state for new error returns

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -25,7 +25,7 @@ import MainWrapper from './main-wrapper';
 import { addCalypsoEnvQueryArg } from './utils';
 import { externalRedirect } from 'lib/route';
 import { jetpackRemoteInstall } from 'state/jetpack-remote-install/actions';
-import { getJetpackRemoteInstallError, isJetpackRemoteInstallComplete } from 'state/selectors';
+import { getJetpackRemoteInstallErrorCode, isJetpackRemoteInstallComplete } from 'state/selectors';
 import { getConnectingSite } from 'state/jetpack-connect/selectors';
 import { REMOTE_PATH_AUTH } from './constants';
 
@@ -212,7 +212,7 @@ export default connect(
 	state => {
 		const jetpackConnectSite = getConnectingSite( state );
 		const siteToConnect = jetpackConnectSite.url;
-		const installError = getJetpackRemoteInstallError( state, siteToConnect );
+		const installError = getJetpackRemoteInstallErrorCode( state, siteToConnect );
 		const isResponseCompleted = isJetpackRemoteInstallComplete( state, siteToConnect );
 		return {
 			installError,

--- a/client/state/data-layer/wpcom/jetpack-install/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/index.js
@@ -32,7 +32,7 @@ export const handleResponse = ( { url }, data ) => {
 	if ( data.status ) {
 		return jetpackRemoteInstallComplete( url );
 	}
-	return jetpackRemoteInstallUpdateError( url, data.error );
+	return jetpackRemoteInstallUpdateError( url, data.error.code, data.error.message );
 };
 
 export default {

--- a/client/state/data-layer/wpcom/jetpack-install/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack-install/test/index.js
@@ -16,7 +16,10 @@ const password = 'hGhrskf145kst';
 const SUCCESS_RESPONSE = { status: true };
 const FAILURE_RESPONSE = {
 	status: false,
-	error: 'COULD_NOT_LOGIN',
+	error: {
+		code: 'COULD_NOT_LOGIN',
+		message: 'extra info',
+	},
 };
 
 describe( 'installJetpackPlugin', () => {
@@ -34,6 +37,8 @@ describe( 'handleResponse', () => {
 
 	test( 'should return JetpackRemoteInstallUpdateError on failure', () => {
 		const result = handleResponse( { url }, FAILURE_RESPONSE );
-		expect( result ).toEqual( jetpackRemoteInstallUpdateError( url, 'COULD_NOT_LOGIN' ) );
+		expect( result ).toEqual(
+			jetpackRemoteInstallUpdateError( url, 'COULD_NOT_LOGIN', 'extra info' )
+		);
 	} );
 } );

--- a/client/state/jetpack-remote-install/actions.js
+++ b/client/state/jetpack-remote-install/actions.js
@@ -35,12 +35,14 @@ export const jetpackRemoteInstall = ( url, user, password ) => ( {
  *
  * @param {string} url - remote site url
  * @param {string} errorCode - the error returned from the installation attempt
+ * @param {string} errorMessage - additional error info
  * @return {Object} action object
  */
-export const jetpackRemoteInstallUpdateError = ( url, errorCode ) => ( {
+export const jetpackRemoteInstallUpdateError = ( url, errorCode, errorMessage ) => ( {
 	type: JETPACK_REMOTE_INSTALL_FAILURE,
 	url,
 	errorCode,
+	errorMessage,
 } );
 
 /**

--- a/client/state/jetpack-remote-install/reducer.js
+++ b/client/state/jetpack-remote-install/reducer.js
@@ -21,7 +21,7 @@ export const isComplete = keyedReducer( 'url', ( state = false, { type } ) => {
 	}
 } );
 
-export const error = keyedReducer( 'url', ( state = null, { type, errorCode } ) => {
+export const errorCodeReducer = keyedReducer( 'url', ( state = null, { type, errorCode } ) => {
 	switch ( type ) {
 		case JETPACK_REMOTE_INSTALL_FAILURE:
 			return errorCode;
@@ -34,6 +34,6 @@ export const error = keyedReducer( 'url', ( state = null, { type, errorCode } ) 
 } );
 
 export default combineReducers( {
-	error,
+	errorCode: errorCodeReducer,
 	isComplete,
 } );

--- a/client/state/jetpack-remote-install/test/reducer.js
+++ b/client/state/jetpack-remote-install/test/reducer.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import reducer, { error, isComplete } from '../reducer';
+import reducer, { errorCodeReducer, isComplete } from '../reducer';
 import {
 	JETPACK_REMOTE_INSTALL,
 	JETPACK_REMOTE_INSTALL_FAILURE,
@@ -10,14 +10,14 @@ import {
 } from 'state/action-types';
 
 const url = 'https://yourgroovydomain.com';
-const errorCode = 'INVALID_CREDENTIALS';
+const errorCodeString = 'INVALID_CREDENTIALS';
 
 describe( 'reducer', () => {
 	test( 'should export expected reducer keys', () => {
 		const state = reducer( undefined, {} );
 
 		expect( state ).toHaveProperty( 'isComplete' );
-		expect( state ).toHaveProperty( 'error' );
+		expect( state ).toHaveProperty( 'errorCode' );
 	} );
 
 	describe( 'isComplete', () => {
@@ -37,25 +37,29 @@ describe( 'reducer', () => {
 		} );
 	} );
 
-	describe( 'error', () => {
+	describe( 'errorCode', () => {
 		const errorState = {
 			[ url ]: {
-				error: errorCode,
+				errorCode: errorCodeString,
 			},
 		};
 
 		test( 'should store error by url', () => {
-			const state = error( undefined, { type: JETPACK_REMOTE_INSTALL_FAILURE, url, errorCode } );
-			expect( state[ url ] ).toEqual( errorCode );
+			const state = errorCodeReducer( undefined, {
+				type: JETPACK_REMOTE_INSTALL_FAILURE,
+				url,
+				errorCode: errorCodeString,
+			} );
+			expect( state[ url ] ).toEqual( errorCodeString );
 		} );
 
 		test( 'should be cleared on successful install', () => {
-			const state = error( errorState, { type: JETPACK_REMOTE_INSTALL_SUCCESS, url } );
+			const state = errorCodeReducer( errorState, { type: JETPACK_REMOTE_INSTALL_SUCCESS, url } );
 			expect( state[ url ] ).not.toBeDefined();
 		} );
 
 		test( 'should be cleared on install request', () => {
-			const state = error( errorState, { type: JETPACK_REMOTE_INSTALL, url } );
+			const state = errorCodeReducer( errorState, { type: JETPACK_REMOTE_INSTALL, url } );
 			expect( state[ url ] ).not.toBeDefined();
 		} );
 	} );

--- a/client/state/selectors/get-jetpack-remote-install-error-code.js
+++ b/client/state/selectors/get-jetpack-remote-install-error-code.js
@@ -6,7 +6,7 @@
 import { get } from 'lodash';
 
 /**
- * Returns any error that has resulted from requesting
+ * Returns any error code that has resulted from requesting
  * a remote install of the jetpack plugin on the .org
  * site at the given url.
  *
@@ -15,5 +15,5 @@ import { get } from 'lodash';
  * @return {?String} Error code, if any
  */
 export default function getJetpackRemoteInstallError( state, url ) {
-	return get( state.jetpackRemoteInstall.error, url, null );
+	return get( state.jetpackRemoteInstall.errorCode, url, null );
 }

--- a/client/state/selectors/test/get-jetpack-remote-install-error-code.js
+++ b/client/state/selectors/test/get-jetpack-remote-install-error-code.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { getJetpackRemoteInstallError } from 'state/selectors';
+import { getJetpackRemoteInstallErrorCode } from 'state/selectors';
 
 const url = 'https://yourgroovydomain.com';
 
@@ -11,19 +11,19 @@ describe( 'getJetpackRemoteInstallError()', () => {
 	test( 'should return null if no errors', () => {
 		const state = {
 			jetpackRemoteInstall: {
-				error: {},
+				errorCode: {},
 			},
 		};
-		expect( getJetpackRemoteInstallError( state, url ) ).toBeNull();
+		expect( getJetpackRemoteInstallErrorCode( state, url ) ).toBeNull();
 	} );
 	test( 'should return any existing error', () => {
 		const state = {
 			jetpackRemoteInstall: {
-				error: {
+				errorCode: {
 					[ url ]: 'SOME_ERROR',
 				},
 			},
 		};
-		expect( getJetpackRemoteInstallError( state, url ) ).toBe( 'SOME_ERROR' );
+		expect( getJetpackRemoteInstallErrorCode( state, url ) ).toBe( 'SOME_ERROR' );
 	} );
 } );


### PR DESCRIPTION
Tweak the state code to account for the updated error returns from the jetpack-install API endpoint.

**Before**
We were speculating that an error return from the API might look like:
```
{
    status: false,
    error: 'SOME_ERROR',
}
```

**After**
The API actually returns more detail:
```
{
    "status":false,
    "error":{
        "code":"INSTALL_FAILURE",
        "message":"Jetpack installation failed",
        "data":404
    }
}
```

This PR updates existing data-layer to pull out the `error.code` and `error.message`, and updates the existing selector to return `error.code`.

We can add additional reducers and selectors in subsequent PRs, should we need the extra detail for the UI.

## Testing
* Run this from the browser console
`dispatch( { type: 'JETPACK_REMOTE_INSTALL', url: 'someurl', user: 'me', password: 'xxx' } );`
* Then inspect the state with
`state.jetpackRemoteInstall`
* Check that an error is stored for the url `someurl`, like:
<img width="311" alt="screen shot 2018-03-01 at 13 19 37" src="https://user-images.githubusercontent.com/7767559/36846606-386eb580-1d53-11e8-9656-42e35dd2e1f3.png">
