### PR TITLE
Activity Log: fix issue that caused the current day to remain collapsed

### DIFF
--- a/client/my-sites/stats/activity-log/index.jsx
+++ b/client/my-sites/stats/activity-log/index.jsx
@@ -454,7 +454,7 @@ class ActivityLog extends Component {
 			'active' !== rewindState.state;
 		const disableBackup = 0 <= get( this.props, [ 'backupProgress', 'progress' ], -Infinity );
 
-		const today = moment().startOf( 'day' );
+		const today = this.applySiteOffset( moment().utc() ).startOf( 'day' );
 
 		// Content shown when there are no logs.
 		// The network request either finished with no events or is still ongoing.


### PR DESCRIPTION
Currently there's an issue where if you're in a time zone different from the site timezone, even if it's half hour, it won't expand the current day. This was first noticed when the site timezone was UTC+0, different from my local timezone, but happens even when setting the site timezone half hour different from my local timezone.

<img width="1038" alt="captura de pantalla 2018-03-01 a la s 09 40 48" src="https://user-images.githubusercontent.com/1041600/36846432-5a059bec-1d39-11e8-8881-e86f7219e450.png">

This PR now fixes this and as long as the site timezone falls under today, it will expand the current day. It also adds the "— Today" suffix at the end.

<img width="1044" alt="captura de pantalla 2018-03-01 a la s 09 41 01" src="https://user-images.githubusercontent.com/1041600/36846437-5fe95a80-1d39-11e8-90a3-aee253bf2da6.png">

#### Testing

Go to Activity Log and ensure that the current day is expanded with this PR.
In Settings, change the site timezone (just a little, not as much as to switch to another day) and verify in AL that it still expands.