### PR TITLE
Framework: Add .prettierignore to exclude README.md files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
This allows me to 'Format Files on Save' in Atom without messing up README files.

To test:
* Enable formatting on files on save in your editor.
* Verify that on `master`, this will mess up `README.md`s upon saving.
* Verify that on this branch, it won't. Also verify that `.js` files continue to be prettified on save.