### PR TITLE
CartItem: Fix key required prop warning

### DIFF
--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -123,7 +123,9 @@ export class CartItem extends React.Component {
 		let info = null;
 
 		if ( isGoogleApps( cartItem ) && cartItem.extra.google_apps_users ) {
-			info = cartItem.extra.google_apps_users.map( user => <div>{ user.email }</div> );
+			info = cartItem.extra.google_apps_users.map( user => (
+				<div key={ `user-${ user.email }` }>{ user.email }</div>
+			) );
 		} else if ( isCredits( cartItem ) ) {
 			info = null;
 		} else if ( getIncludedDomain( cartItem ) ) {


### PR DESCRIPTION
### Summary

I came across the ol' key-required dev warning while working within the checkout.
It turns out there was a slight oversight in the CartItem component where a unique key wasn't provided.
This PR aims to squish this warning by using the users email as a unique reference for the list of divs here (Note: in this collection an ID is not available, just the email, and first and last names).

### Test
- Go to the checkout after adding a google apps product to your cart.
- Note that you do not see the warning in the console as before.