### PR TITLE
Framework: Add *.json to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
+*.json
 README.md


### PR DESCRIPTION
Follow-up to #22904. Looks like this is our best option, since `prettier` just isn't made for dealing with `.json` files: https://github.com/prettier/prettier/issues/322

To test:
* Enable formatting on files on save in your editor.
* Verify that on `master`, this will mess up `.json` files upon saving.
* Verify that on this branch, it won't. Also verify that `.js` files continue to be prettified on save.