### PR TITLE
Return to wp-admin button tracking

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -7,7 +7,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { partial } from 'lodash';
 
 /**
  * Internal dependencies
@@ -144,7 +143,11 @@ class ProductPurchaseFeaturesList extends Component {
 
 		return [
 			<JetpackWordPressCom selectedSite={ selectedSite } key="jetpackWordPressCom" />,
-			<JetpackReturnToDashboard selectedSite={ selectedSite } key="jetpackReturnToDashboard" />,
+			<JetpackReturnToDashboard
+				onClick={ this.props.recordReturnToDashboardClick }
+				selectedSite={ selectedSite }
+				key="jetpackReturnToDashboard"
+			/>,
 		];
 	}
 
@@ -241,9 +244,11 @@ export default connect(
 		};
 	},
 	{
-		recordBusinessOnboardingClick: partial(
-			recordTracksEvent,
-			'calypso_plan_features_onboarding_click'
-		),
+		recordBusinessOnboardingClick: function( eventProps ) {
+			recordTracksEvent( 'calypso_plan_features_onboarding_click', eventProps );
+		},
+		recordReturnToDashboardClick: function( eventProps ) {
+			recordTracksEvent( 'calypso_plan_features_returnToDashboard_click', eventProps );
+		},
 	}
 )( ProductPurchaseFeaturesList );

--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { partial } from 'lodash';
 
 /**
  * Internal dependencies
@@ -244,11 +245,15 @@ export default connect(
 		};
 	},
 	{
-		recordBusinessOnboardingClick: function( eventProps ) {
-			recordTracksEvent( 'calypso_plan_features_onboarding_click', eventProps );
-		},
-		recordReturnToDashboardClick: function( eventProps ) {
-			recordTracksEvent( 'calypso_plan_features_returnToDashboard_click', eventProps );
-		},
+		recordBusinessOnboardingClick: partial(
+			recordTracksEvent,
+			'calypso_plan_features_onboarding_click',
+			{}
+		),
+		recordReturnToDashboardClick: partial(
+			recordTracksEvent,
+			'calypso_plan_features_returnToDashboard_click',
+			{}
+		),
 	}
 )( ProductPurchaseFeaturesList );

--- a/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/index.jsx
@@ -252,7 +252,7 @@ export default connect(
 		),
 		recordReturnToDashboardClick: partial(
 			recordTracksEvent,
-			'calypso_plan_features_returnToDashboard_click',
+			'calypso_plan_features_returntodashboard_click',
 			{}
 		),
 	}

--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-return-to-dashboard.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-return-to-dashboard.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
+import { get, noop } from 'lodash';
 import { untrailingslashit } from 'lib/route';
 
 /**
@@ -14,7 +14,7 @@ import { untrailingslashit } from 'lib/route';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { selectedSite, translate } ) => {
+export default localize( ( { selectedSite, translate, onClick = noop } ) => {
 	let adminURL = get( selectedSite, 'options.admin_url', '' );
 	if ( adminURL ) {
 		adminURL = untrailingslashit( adminURL ) + '/admin.php?page=jetpack';
@@ -27,6 +27,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				title={ translate( 'Return to your Jetpack dashboard' ) }
 				buttonText={ translate( 'Go back to %(site)s', { args: { site: selectedSite.name } } ) }
 				href={ adminURL }
+				onClick={ onClick }
 			/>
 		</div>
 	);


### PR DESCRIPTION
This PR adds a new event `calypso_plan_features_returnToDashboard_click` that triggers once the user clicks on the "return to [site]" button in /plans/my-plan

![image](https://user-images.githubusercontent.com/1554855/36851178-eda7d598-1d68-11e8-9428-861b4d583ec2.png)

![image](https://user-images.githubusercontent.com/1554855/36851185-f30a6384-1d68-11e8-9bbf-8861a5813fc5.png)

Incidentally, it also fixes the `calypso_plan_features_onboarding_click` event that was not being recorded properly because of a missing param (well, more exactly, because it was receiving the click event param instead of a proper track eventProps param).

How to test
=========
1. go to https://wordpress.com/plans/ and select a jetpack site
2. go to "my plan"
3. In the developer tools, paste `localStorage.setItem('debug', 'calypso:analytics:tracks')` to enable tracks console output
4. Click in the "return to ..." button. You should see tracks firing the event in your console before the redirection kicks in
