### PR TITLE
Notice: Remove redundant css rule

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -83,8 +83,6 @@
 }
 
 .notice__text {
-	max-width: 680px;
-
 	a,
 	a:visited {
 		text-decoration: underline;


### PR DESCRIPTION
Remove a redundant css rule from the Notice component.

Fixes #14164

This rule has no impact because the element is now a `span`.