### PR TITLE
Use Happychat Staging environment for wpcalypso environment

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -3,6 +3,7 @@
 	"env_id": "wpcalypso",
 	"client_slug": "browser",
 	"directly_rtm_widget_environment": "sandbox",
+	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"hostname": "wpcalypso.wordpress.com",
 	"i18n_default_locale_slug": "en",
 	"rtl": false,


### PR DESCRIPTION
Currently the only way to access Happychat's staging environment is by spinning up a local development environment. This change points the `wpcalypso` test environment at HC staging to make it easier to test changes in our staged Happychat.