### PR TITLE
Notice: Add new "Inline" variation with a more subdued design

### DIFF
--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -17,6 +17,7 @@ export class Notice extends Component {
 		duration: 0,
 		icon: null,
 		isCompact: false,
+		isInline: false,
 		onDismissClick: noop,
 		status: null,
 		text: null,
@@ -27,6 +28,7 @@ export class Notice extends Component {
 		duration: PropTypes.number,
 		icon: PropTypes.string,
 		isCompact: PropTypes.bool,
+		isInline: PropTypes.bool,
 		onDismissClick: PropTypes.func,
 		showDismiss: PropTypes.bool,
 		status: PropTypes.oneOf( [ 'is-error', 'is-info', 'is-success', 'is-warning', 'is-plain' ] ),
@@ -81,14 +83,16 @@ export class Notice extends Component {
 			className,
 			icon,
 			isCompact,
+			isInline,
 			onDismissClick,
-			showDismiss = ! isCompact, // by default, show on normal notices, don't show on compact ones
+			showDismiss = ! ( isCompact || isInline ), // by default, show on normal notices, don't show on compact or inline ones
 			status,
 			text,
 			translate,
 		} = this.props;
 		const classes = classnames( 'notice', status, className, {
 			'is-compact': isCompact,
+			'is-inline': isInline,
 			'is-dismissable': showDismiss,
 		} );
 

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -267,3 +267,30 @@ a.notice__action {
 		}
 	}
 }
+
+// Inline notices
+.notice.is-inline {
+	background: lighten( $gray, 33 );
+	color: darken( $gray, 33 );
+	box-shadow: 0 0 0 1px $gray inset;
+
+	// Success!
+	&.is-success {
+		box-shadow: 0 0 0 1px $alert-green inset;
+	}
+
+	// Warning
+	&.is-warning {
+		box-shadow: 0 0 0 1px $alert-yellow inset;
+	}
+
+	// Error! OHNO!
+	&.is-error {
+		box-shadow: 0 0 0 1px $alert-red inset;
+	}
+
+	// General notice
+	&.is-info {
+		box-shadow: 0 0 0 1px $blue-medium inset;
+	}
+}

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -185,6 +185,7 @@ class PluginItem extends Component {
 			return (
 				<Notice
 					isCompact
+					isInline
 					icon="checkmark"
 					status="is-success"
 					inline={ true }
@@ -205,6 +206,7 @@ class PluginItem extends Component {
 		return (
 			<Notice
 				isCompact
+				isInline
 				icon="sync"
 				status="is-warning"
 				inline={ true }
@@ -220,7 +222,7 @@ class PluginItem extends Component {
 		if ( progress.length ) {
 			const message = this.doing();
 			if ( message ) {
-				return <Notice isCompact status="is-info" text={ message } inline={ true } />;
+				return <Notice isCompact isInline status="is-info" text={ message } inline={ true } />;
 			}
 		}
 		if ( this.props.isAutoManaged ) {


### PR DESCRIPTION
Sometimes the `<Notice>` component is used inline on a page. `/plugins/` is a prime example:

<img width="978" alt="screen shot 2018-03-01 at 4 04 48 pm" src="https://user-images.githubusercontent.com/191598/36869642-7c4711dc-1d6a-11e8-8e41-60160571e214.png">

The problem here is that these notices tend to really stand out. Maybe thats the point, and they should be acted upon. But I thought I'd try to see if we could offer a more subdued variant of notices that better "fit" in these types of use cases:

<img width="971" alt="screen shot 2018-03-01 at 4 04 25 pm" src="https://user-images.githubusercontent.com/191598/36869678-9a64fe22-1d6a-11e8-8e22-7ca0dcb9a97a.png">

--

I add a new prop to `<Notice>` called `isInline` which toggles a class `is-inline` to add a more subdued variation of the notice design. Its currently only updated to be used on `/plans/`.

This should help fix #20017