### PR TITLE
JPC: hide `Start with a new WP site` footer for Jetpack remote install flow.

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -428,7 +428,7 @@ export class JetpackConnectMain extends Component {
 				<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">
 					{ translate( 'Install Jetpack manually' ) }
 				</LoggedOutFormLinkItem>
-				{ this.isInstall() ? null : (
+				{ this.isInstall() || config.isEnabled( 'jetpack/connect/remote-install' ) ? null : (
 					<LoggedOutFormLinkItem href="/start">
 						{ translate( 'Start a new site on WordPress.com' ) }
 					</LoggedOutFormLinkItem>


### PR DESCRIPTION
This patch removes the footer link pointing to starting a new site in the Jetpack remote install flow.

**To test:**
- checkout this branch in your local Calypso
- go to `http://calypso.localhost:3000/jetpack/connect`
- verify that the footer link is absent 👇 

![screen shot 2018-03-01 at 23 11 04](https://user-images.githubusercontent.com/13561163/36875009-0ee24cec-1da6-11e8-8622-34530401dfca.png)

