### PR TITLE
Domains Checkout: prevent default submission of validation steps

### DIFF
--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -220,7 +220,10 @@ export class DomainDetailsForm extends PureComponent {
 		this.setPrivacyProtectionSubscriptions( enable );
 	};
 
-	handleSubmitButtonClick = () => {
+	handleSubmitButtonClick = event => {
+		if ( event && event.preventDefault ) {
+			event.preventDefault();
+		}
 		if ( this.hasAnotherStep() ) {
 			return this.switchToNextStep();
 		}


### PR DESCRIPTION
This PR fixes a bug in IE11+ whereby the extra step validation in the domains checkout form causes the page to refresh. (See 986975-zen)

![mar-02-2018 10-20-04](https://user-images.githubusercontent.com/6458278/36875259-53bf0f82-1e03-11e8-891d-caeac804f1ae.gif)

We check for `event.preventDefault` in the submit handler because we're reusing the callback for both `<ContactDetailsFormFields />` and each validation form, each of which passes different args.

I tried `event.persist` to normalize these args but React complained. A user is blocked at the moment so the priority is getting it working.

## Tests
In Internet Explorer 11+:

1. Add a `.uk` domain to your cart, and head to checkout
2. Enter valid contact details (Example UK postcode: `W9 2JL`)
3. On the next step select 'Sole trader' and enter a trading name
4. Continue to checkout

### Expectations
The page should not refresh and you should be able to reach the credit card form.