### PR TITLE
Enable scrolling to Google Analytics and Search settings from plan info page

### DIFF
--- a/client/blocks/product-purchase-features/product-purchase-features-list/google-analytics-stats.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/google-analytics-stats.jsx
@@ -22,7 +22,7 @@ export default localize( ( { selectedSite, translate } ) => {
 					"Complement WordPress.com's stats with Google's in-depth look at your visitors and traffic patterns."
 				) }
 				buttonText={ translate( 'Connect Google Analytics' ) }
-				href={ '/settings/analytics/' + selectedSite.slug }
+				href={ '/settings/traffic/' + selectedSite.slug + '#google-analytics' }
 			/>
 		</div>
 	);

--- a/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-search.jsx
+++ b/client/blocks/product-purchase-features/product-purchase-features-list/jetpack-search.jsx
@@ -23,7 +23,7 @@ export default localize( ( { selectedSite, translate } ) => {
 						'and filtering that will help your users find what they are looking for.'
 				) }
 				buttonText={ translate( 'Enable Search in Traffic Settings' ) }
-				href={ '/settings/traffic/' + selectedSite.slug }
+				href={ '/settings/traffic/' + selectedSite.slug + '/#search' }
 			/>
 		</div>
 	);

--- a/client/lib/scroll-to/index.js
+++ b/client/lib/scroll-to/index.js
@@ -49,6 +49,17 @@ function animate() {
 	TWEEN.update();
 }
 
+/**
+ * Scrolls to the specified window location
+ * @param {Object} options - options object (see below)
+ * @param {number} options.x - desired left or x coordinate
+ * @param {number} options.y - desired top or y coordinate
+ * @param {function} options.easing - easing function, defaults to TWEEN.Easing.Circular.Out
+ * @param {number} options.duration - duration in ms, default 500
+ * @param {function} options.onStart - callback before start is called
+ * @param {function} options.onComplete - callback when scroll is finished
+ * @param {HTMLElement} options.container - the container to scroll instead of window, if any
+ */
 function scrollTo( options ) {
 	const currentScroll = getCurrentScroll( options.container ),
 		tween = new TWEEN.Tween( currentScroll )
@@ -70,7 +81,13 @@ function scrollTo( options ) {
 	}
 }
 
-// test
+/**
+ * Scroll to the wrapped component if the page has a URL anchor like #namedAnchor
+ *
+ * @param {React.Component} WrappedComponent - the component to scroll to
+ * @param {string} namedAnchor - the anchor name
+ * @returns {React.Component} - the component with scrollTo behaviour enabled
+ */
 function scrollToComponent( WrappedComponent, namedAnchor ) {
 	return class extends React.Component {
 		componentDidMount() {
@@ -142,16 +159,5 @@ function scrollToComponent( WrappedComponent, namedAnchor ) {
 	};
 }
 
-/**
- * Scrolls to the specified window location
- * @param {Object} options - options object (see below)
- * @param {number} options.x - desired left or x coordinate
- * @param {number} options.y - desired top or y coordinate
- * @param {function} options.easing - easing function, defaults to TWEEN.Easing.Circular.Out
- * @param {number} options.duration - duration in ms, default 500
- * @param {function} options.onStart - callback before start is called
- * @param {function} options.onComplete - callback when scroll is finished
- * @param {HTMLElement} options.container - the container to scroll instead of window, if any
- */
 export { scrollToComponent };
 export default scrollTo;

--- a/client/lib/scroll-to/index.js
+++ b/client/lib/scroll-to/index.js
@@ -151,7 +151,7 @@ function scrollToComponent( WrappedComponent, namedAnchor ) {
 				<WrappedComponent
 					ref={ function( wrapped ) {
 						this.wrappedComponentInstance = wrapped;
-					} }
+					}.bind( this ) }
 					{ ...this.props }
 				/>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -82,7 +82,7 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purcha
 					"Complement WordPress.com's stats with Google's in-depth look at your visitors and traffic patterns."
 				) }
 				buttonText={ i18n.translate( 'Connect Google Analytics' ) }
-				href={ '/settings/analytics/' + selectedSite.slug }
+				href={ '/settings/traffic/' + selectedSite.slug + '#google-analytics' }
 			/>
 		</div>
 	);

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -44,6 +44,7 @@ import {
 	PLAN_JETPACK_BUSINESS,
 } from 'lib/plans/constants';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
+import { scrollToComponent } from 'lib/scroll-to';
 
 const validateGoogleAnalyticsCode = code => ! code || code.match( /^UA-\d+-\d+$/i );
 const hasBusinessPlan = overSome( isBusiness, isEnterprise, isJetpackBusiness );
@@ -349,5 +350,5 @@ const connectComponent = connect(
 const getFormSettings = partialRight( pick, [ 'wga' ] );
 
 export default flowRight( connectComponent, wrapSettingsForm( getFormSettings ) )(
-	GoogleAnalyticsForm
+	scrollToComponent( GoogleAnalyticsForm, 'google-analytics' )
 );

--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -35,6 +35,7 @@ import {
 	isJetpackModuleUnavailableInDevelopmentMode,
 	isJetpackSiteInDevelopmentMode,
 } from 'state/selectors';
+import { scrollToComponent } from 'lib/scroll-to';
 
 class JetpackSiteStats extends Component {
 	static defaultProps = {
@@ -265,4 +266,4 @@ export default connect(
 	{
 		activateModule,
 	}
-)( localize( JetpackSiteStats ) );
+)( localize( scrollToComponent( JetpackSiteStats, 'site-stats' ) ) );

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -30,6 +30,7 @@ import {
 } from 'state/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import { isBusiness, isEnterprise, isVipPlan, isJetpackBusiness } from 'lib/products-values';
+import { scrollToComponent } from 'lib/scroll-to';
 
 const hasBusinessPlan = overSome( isJetpackBusiness, isBusiness, isEnterprise );
 
@@ -165,4 +166,4 @@ export default connect( state => {
 		searchModule: getJetpackModule( state, siteId, 'search' ),
 		searchModuleActive: !! isJetpackModuleActive( state, siteId, 'search' ),
 	};
-} )( localize( Search ) );
+} )( localize( scrollToComponent( Search, 'search' ) ) );


### PR DESCRIPTION
Fixes #22694
Fixes #22692 

If ported to Jetpack, could fix https://github.com/Automattic/jetpack/issues/8727

This PR is partly an example of a prototype "scroll to" component wrapper.

#### To test

GA:

* Get a professional plan
* Go to your plan page at `/plans/my-plan/{site-url}`
* Click the "Connect Google Analytics" button
* You should be on `/settings/traffic/{site-url}#google-analytics`
* Once components have loaded the page should smooth-scroll to the Google Analytics card

Search:

* Get a professional plan
* Go to your plan page at `/plans/my-plan/{site-url}`
* Click the "Enable Search in Traffic Settings" button
* You should be on `/settings/traffic/{site-url}#search`
* Once components have loaded the page should smooth-scroll to the Search card

#### A note about the implementation and design

This is a deliberately very simple solution. Longer term, I know there is a desire for fading out sibling components, unique pages for settings cards, etc. but those all require large refactors. This technique at least gets the desired component onto the screen so the user can complete the task, and does so without requiring the parent component to be "scrollTo-aware" so that it can fade out siblings, etc.

#### Further Work

We could add a border highlight to the component being scrolled to. I didn't do this because there's no design for it right now :)