### PR TITLE
Reader: Sidebar cleanup and make lists look consistent

### DIFF
--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -50,14 +50,12 @@
 		}
 
 		.sidebar__heading {
-			margin: 0;
-			font-weight: normal;
-			padding: 10px 16px 10px 20px;
 			color: $gray-darken-30;
 			cursor: pointer;
-			position: relative;
-			transition: background-color 0.15s ease-in-out,
-				box-shadow 0.15s ease-in-out;
+			font-weight: normal;
+			margin: 0;
+			padding: 10px 16px 10px 20px;
+			transition: background-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 
 			.gridicon {
 				position: relative;
@@ -89,14 +87,15 @@
 		}
 
 		.sidebar__menu-item {
+			opacity: 0;
 			transition: transform 0.15s cubic-bezier(0.230, 1.000, 0.320, 1.000),
 				opacity 0.15s ease-in-out;
 			transition-delay: 0.05s;
-			opacity: 0;
 			transform: translateY( -100px );
 		}
 
 		&.is-toggle-open {
+
 			.sidebar__heading {
 				background-color: $gray-light;
 				box-shadow: 0 1px 0 lighten( $gray, 20 ),
@@ -138,16 +137,8 @@
 				}
 			}
 
-			.sidebar__menu-list {
-
-				.sidebar__menu-item,
-				.sidebar-dynamic-menu__tag {
-
-					@include breakpoint( "<660px" ) {
-						background: none;
-						border-top: 0;
-					}
-				}
+			.sidebar__menu-list .sidebar__menu-item,
+			.sidebar__menu-list .sidebar-dynamic-menu__tag {
 
 				li {
 
@@ -166,32 +157,37 @@
 			}
 		}
 
-		.is-add-open {
-			.sidebar__menu-add {
-				opacity: 1;
-				pointer-events: auto;
-				transform: translateX( 0 );
+		.is-add-open .sidebar__menu-add {
+			opacity: 1;
+			pointer-events: auto;
+			transform: translateX( 0 );
+		}
+
+		.selected .sidebar__menu-item-label {
+
+			@include breakpoint( "<660px" ) {
+				color: $blue-medium;
 			}
 		}
 	}
 
 	.sidebar__menu-empty,
 	.sidebar__menu-empty:hover {
+		background-color: transparent !important; // needs to be more specific
+		color: $gray-dark;
+		font-size: 13px;
 		max-width: 60%;
 		padding-right: 32px;
 		padding-left: 55px;
-		font-size: 13px;
-		color: $gray-dark;
-		background-color: transparent !important; // needs to be more specific
 	}
 
 	.sidebar__menu-item {
 
 		a.sidebar__button {
-			margin-top: 5px;
+			margin-top: 10px;
 
-			@include breakpoint( "<660px" ) {
-				margin-top: 10px;
+			@include breakpoint( ">660px" ) {
+				margin-top: 5px;
 			}
 		}
 	}
@@ -221,13 +217,12 @@
 	}
 
 	.sidebar__menu-add-button {
-		position: absolute;
-			top: 7px;
-			right: 8px;
-		border-width: 1px;
-		border-color: $gray-lighten-20;
-		padding: 6px 7px;
+		border: 1px solid $gray-lighten-20;
 		border-radius: 3px;
+		padding: 6px 7px;
+		position: absolute;
+			right: 8px;
+			top: 7px;
 		text-transform: none;
 
 		// Disabled by default
@@ -240,13 +235,13 @@
 
 	.sidebar__menu-add {
 		opacity: 0;
-		transition: all 0.15s ease-in;
 		pointer-events: none;
 		padding: 0;
 		position: absolute;
 			top: -1px;
 			left: -1px;
 			right: -1px;
+		transition: all 0.15s ease-in;
 
 		input {
 			font-size: 13px;
@@ -256,18 +251,18 @@
 		.gridicon {
 			cursor: pointer;
 			position: absolute;
-				top: 0;
-				right: 0;
 				left: auto;
+				right: 0;
+				top: 0;
 			padding: 8px 13px;
 		}
 	}
 
-	.selected {
-		.sidebar__menu-action {
-			.gridicon {
-				fill: #fff !important;
-			}
+	.selected .sidebar__menu-action .gridicon {
+		fill: $white !important;
+
+		@include breakpoint( "<660px" ) {
+			fill: $gray !important;
 		}
 	}
 
@@ -276,31 +271,14 @@
 			top: 3px;
 			right: 8px;
 		line-height: 15px;
-		padding: 3px 4px 2px 4px;
+		padding: 3px 4px 2px;
 
 		.gridicon {
 			position: relative;
-				top: 0;
+				top: -2px;
 				left: auto;
 			fill: $gray !important; // this needs to be more specific
 			margin-right: 0;
-		}
-
-
-		&:hover {
-			cursor: pointer;
-
-			.gridicon {
-				fill: $alert-red !important; // this needs to be more specific
-			}
-		}
-
-		@include breakpoint( "<660px" ) {
-			top: -40px;
-
-			.gridicon {
-				top: 6px;
-			}
 		}
 	}
 


### PR DESCRIPTION
This PR:

- Fixes "x" alignment in Tags.
- Makes Lists and Tags look consistent on mobile.
- Adds a selected/active state to lists on mobile so you know which list you are on.
- Cleans up some CSS.

**Before:**
![screenshot 2018-03-01 15 12 47](https://user-images.githubusercontent.com/4924246/36876089-208662fa-1d68-11e8-87e8-1d8466b332ad.png)

![screenshot 2018-03-01 15 50 25](https://user-images.githubusercontent.com/4924246/36876126-4db69b5a-1d68-11e8-8f39-38b17aa67f94.png)

**After:**
![screenshot 2018-03-01 15 12 51](https://user-images.githubusercontent.com/4924246/36876091-22ca103e-1d68-11e8-9034-d8b932688d53.png)

![screenshot 2018-03-01 15 50 31](https://user-images.githubusercontent.com/4924246/36876129-51fb67a4-1d68-11e8-8ed1-ec1201d14dc7.png)

Some of the alignment is off, but those have been fixed separately in: https://github.com/Automattic/wp-calypso/pull/22921

