### PR TITLE
Jetpack Connect: remote install- introduce new JP branding to the creds form step.

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -149,10 +149,6 @@ export class OrgCredentialsForm extends Component {
 		);
 	}
 
-	formHeader() {
-		return <div>{ this.renderHeadersText() }</div>;
-	}
-
 	onClickBack() {
 		page.redirect( '/jetpack/connect' );
 	}
@@ -192,7 +188,7 @@ export class OrgCredentialsForm extends Component {
 	render() {
 		return (
 			<MainWrapper>
-				{ this.formHeader() }
+				{ this.renderHeadersText() }
 				<Card className="jetpack-connect__site-url-input-container">
 					<div onSubmit={ this.handleSubmit }>
 						{ this.formFields() }

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -19,7 +19,6 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormattedHeader from 'components/formatted-header';
 import FormPasswordInput from 'components/forms/form-password-input';
 import HelpButton from './help-button';
-import JetpackLogo from 'components/jetpack-logo';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import MainWrapper from './main-wrapper';
@@ -81,14 +80,6 @@ export class OrgCredentialsForm extends Component {
 	getChangeHandler = field => event => {
 		this.setState( { [ field ]: event.target.value } );
 	};
-
-	getHeaderImage() {
-		return (
-			<div className="jetpack-connect__jetpack-logo">
-				<JetpackLogo full size={ 45 } />
-			</div>
-		);
-	}
 
 	getHeaderText() {
 		const { translate } = this.props;
@@ -159,12 +150,7 @@ export class OrgCredentialsForm extends Component {
 	}
 
 	formHeader() {
-		return (
-			<div>
-				{ this.getHeaderImage() }
-				{ this.renderHeadersText() }
-			</div>
-		);
+		return <div>{ this.renderHeadersText() }</div>;
 	}
 
 	onClickBack() {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -656,11 +656,3 @@
 .jetpack-connect__navigation {
 	text-align: center;
 }
-
-.jetpack-connect__jetpack-logo {
-	text-align: center;
-}
-
-.jetpack-logo__icon {
-	fill: $green-jetpack;
-}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -624,6 +624,11 @@
 	&[type='password'] {
 		margin-bottom: 0;
 	}
+
+	&.is-primary {
+		background-color: #00be28;
+		border-color: #007218;
+	}
 }
 
 .jetpack-connect__password-container {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -626,8 +626,8 @@
 	}
 
 	&.is-primary {
-		background-color: #00be28;
-		border-color: #007218;
+		background-color: $green-jetpack;
+		border-color: darken($green-jetpack, 5%);
 	}
 }
 


### PR DESCRIPTION
Style the "Install Jetpack" button in the credentials form screen of the remote install flow according to the new Jetpack branding.

**To test:**
- checkout this branch on your local Calypso
- go to `http://calypso.localhost:3000/jetpack/connect/`, input url to land in `http://calypso.localhost:3000/jetpack/connect/install`
- verify that the `Install Jetpack` becomes enabled upon inputting text in the fields, and is of the right color.

NOTE:  hide icon will be moved inside the field box 

disabled:
![screen shot 2018-03-02 at 13 04 19](https://user-images.githubusercontent.com/13561163/36900153-064308aa-1e1a-11e8-9549-a75b25c91acf.png)

enabled:
![screen shot 2018-03-02 at 00 58 05](https://user-images.githubusercontent.com/13561163/36877941-aa5c25ea-1db4-11e8-8203-a042a520d033.png)
