### PR TITLE
Domain WHOIS details: passing empty state field for stateless countries

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -144,6 +144,8 @@ export class ContactDetailsFormFields extends Component {
 		const mainFieldValues = formState.getAllFieldValues( this.state.form );
 		return {
 			...mainFieldValues,
+			// domains registered according to ancient validation rules may have state set even though not required
+			state: this.props.hasCountryStates ? mainFieldValues.state : '',
 			phone: toIcannFormat( mainFieldValues.phone, countries[ this.state.phoneCountryCode ] ),
 		};
 	}
@@ -434,8 +436,8 @@ export class ContactDetailsFormFields extends Component {
 	}
 }
 
-export default connect( state => {
-	const contactDetails = state.contactDetails;
+export default connect( ( state, props ) => {
+	const contactDetails = props.contactDetails;
 	const hasCountryStates =
 		contactDetails && contactDetails.countryCode
 			? ! isEmpty( getCountryStates( state, contactDetails.countryCode ) )

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -151,4 +151,31 @@ describe( 'ContactDetailsFormFields', () => {
 			expect( wrapper.find( '.contact-details-form-fields__cancel-button' ) ).toHaveLength( 1 );
 		} );
 	} );
+
+	describe( 'Addresses with no province/state', () => {
+		test( 'should return province/state value when the country has states', () => {
+			const onContactDetailsChange = jest.fn();
+			const wrapper = shallow(
+				<ContactDetailsFormFields
+					{ ...defaultProps }
+					onContactDetailsChange={ onContactDetailsChange }
+				/>
+			);
+			wrapper.setProps( { hasCountryStates: true } );
+			expect( wrapper.instance().getMainFieldValues().state ).toEqual(
+				defaultProps.contactDetails.state
+			);
+		} );
+		test( 'should return empty province/state value when the country does not have states', () => {
+			const onContactDetailsChange = jest.fn();
+			const wrapper = shallow(
+				<ContactDetailsFormFields
+					{ ...defaultProps }
+					onContactDetailsChange={ onContactDetailsChange }
+				/>
+			);
+			wrapper.setProps( { hasCountryStates: false } );
+			expect( wrapper.instance().getMainFieldValues().state ).toEqual( '' );
+		} );
+	} );
 } );

--- a/client/state/country-states/selectors.js
+++ b/client/state/country-states/selectors.js
@@ -1,3 +1,11 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { get } from 'lodash';
+
 /**
  * Returns an array of states objects for the specified country code, or null
  * if there are not states for the country.
@@ -9,7 +17,7 @@
  */
 
 export function getCountryStates( state, countryCode ) {
-	return state.countryStates.items[ countryCode.toLowerCase() ] || null;
+	return get( state.countryStates, [ 'items', countryCode.toLowerCase() ], null );
 }
 
 /**
@@ -21,5 +29,5 @@ export function getCountryStates( state, countryCode ) {
  * @return {Boolean}             Whether a request is in progress
  */
 export function isCountryStatesFetching( state, countryCode ) {
-	return state.countryStates.isFetching[ countryCode.toLowerCase() ] || false;
+	return get( state.countryStates, [ 'isFetching', countryCode.toLowerCase() ], false );
 }


### PR DESCRIPTION
Older registered EU/UK/IE domains have a state recorded in their contact addresses, which does not confirm to domain validation rules.

This PR checks if the backend returns any valid state codes for a particular country. If not we empty the state field (assigning it to `''`) before posting the contact details to the server.

See: p2MSmN-6p4-p2

props to @klimeryk for raising the issue 🙇 

## Testing

1. Add a domain to your cart and head to checkout

2. In the console, update your address details via the store (notice the state value)
```
dispatch({ type: 'DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_UPDATE', data: {"firstName":"Jan","lastName":"Van CurryWurst","organization":"","email":"test@test.de","phone":"+49.44444444","address1":"Test 123","address2":"","city":"Berlin","state":"Berlin.ist.geil","postalCode":"10435","countryCode":"DE"} });
```
3. Click continue

4. In the console, check the value of the state field in the store

```
state.domains.management.items._contactDetailsCache.state
```

### Expectations
`state.domains.management.items._contactDetailsCache.state` should be equal to `''`