### PR TITLE
NPS Survey: Fix padding of dialog

### DIFF
--- a/client/layout/nps-survey-notice/style.scss
+++ b/client/layout/nps-survey-notice/style.scss
@@ -1,4 +1,7 @@
 .dialog.card.nps-survey-notice {
 	max-width: 480px;
+}
+
+.dialog.card.nps-survey-notice .dialog__content {
 	padding: 0;
 }


### PR DESCRIPTION
#15718 inadvertently broke the styling of the NPS survey dialog. This PR fixes it.

Before:

<img width="529" alt="screencapture at thu mar 1 20 34 20 est 2018" src="https://user-images.githubusercontent.com/2098816/36879508-27d72e98-1d92-11e8-90f1-6b13d195bd96.png">

After:

<img width="501" alt="screencapture at thu mar 1 20 41 40 est 2018" src="https://user-images.githubusercontent.com/2098816/36879510-2bc2ddae-1d92-11e8-9348-00b8dfd690d3.png">

To test:
- In dev console, call `npsSurvey()` to bring up the NPS survey and verify that it looks correct.