### PR TITLE
Fix changing the store country after the store is setup.

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
+++ b/client/extensions/woocommerce/app/dashboard/store-location-setup-view.js
@@ -23,6 +23,7 @@ import BasicWidget from 'woocommerce/components/basic-widget';
 import { bumpStat } from 'woocommerce/lib/analytics';
 import { errorNotice } from 'state/notices/actions';
 import { getContactDetailsCache } from 'state/selectors';
+import { getCountryData } from 'woocommerce/lib/countries';
 import {
 	areLocationsLoaded,
 	getCountriesWithStates,
@@ -124,6 +125,11 @@ class StoreLocationSetupView extends Component {
 
 		const address = this.state.address;
 		address[ addressKey ] = newValue;
+		// Did they change the country? Force an appropriate state default
+		if ( 'country' === addressKey ) {
+			const countryData = getCountryData( newValue );
+			address.state = countryData ? countryData.defaultState : '';
+		}
 
 		this.setState( { address, userBeganEditing: true } );
 	};

--- a/client/extensions/woocommerce/app/order/order-customer/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-customer/dialog.js
@@ -29,6 +29,7 @@ import FormLegend from 'components/forms/form-legend';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import FormTextInput from 'components/forms/form-text-input';
 import getAddressViewFormat from 'woocommerce/lib/get-address-view-format';
+import { getCountryData } from 'woocommerce/lib/countries';
 // @todo Update this to use our store countries list
 import { forPayments as countriesList } from 'lib/countries-list';
 
@@ -148,7 +149,8 @@ class CustomerAddressDialog extends Component {
 			const newState = { address: { ...address, [ name ]: value } };
 			// If country changed, we should also reset the state & phoneCountry
 			if ( 'country' === name ) {
-				newState.address.state = '';
+				const countryData = getCountryData( value );
+				newState.address.state = countryData ? countryData.defaultState : '';
 				newState.phoneCountry = value;
 			}
 			return newState;

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -66,14 +66,6 @@ class AddressView extends Component {
 		}
 	};
 
-	onChangeCountry = event => {
-		// First, always forward the country event through
-		this.props.onChange( event );
-
-		// Then, send a second onChange to clear state
-		this.props.onChange( { target: { name: 'state', value: '' } } );
-	};
-
 	getCountryData = () => {
 		const { country } = this.props.address;
 		let countryData = find( getCountries(), { code: country || 'US' } );
@@ -87,18 +79,18 @@ class AddressView extends Component {
 	};
 
 	renderCountry = () => {
-		const { address: { country }, showAllLocations, translate } = this.props;
+		const { address: { country }, showAllLocations, translate, onChange } = this.props;
 		if ( showAllLocations ) {
 			return (
 				<FormFieldSet className="address-view__country">
-					<FormCountrySelectFromApi value={ country } onChange={ this.onChangeCountry } />
+					<FormCountrySelectFromApi value={ country } onChange={ onChange } />
 				</FormFieldSet>
 			);
 		}
 		return (
 			<FormFieldSet className="address-view__country">
 				<FormLabel>{ translate( 'Country' ) }</FormLabel>
-				<FormSelect name="country" onChange={ this.onChangeCountry } value={ country || 'US' }>
+				<FormSelect name="country" onChange={ onChange } value={ country || 'US' }>
 					{ getCountries().map( option => {
 						return (
 							<option key={ option.code } value={ option.code }>


### PR DESCRIPTION
Fixes #22822
Closes #22825 (if this solution is accepted, the other PR is redundant)

@timmyc @allendav I encountered this problem a few days ago so I fixed it before realizing you already made a PR for it. This one cleans up a bit more though.

In some places, when changing the country of the store, the "state" field would reset to the empty string. In other places, the `state` would reset to the `defaultState` for the country. I believe the latter option is "more correct", so I've changed all the usages of `<AddressView>` so they work the same way.