### PR TITLE
Reader: Add back missing Comment, Like, Follow, Visit buttons

### DIFF
--- a/assets/stylesheets/sections/reader-full-post.scss
+++ b/assets/stylesheets/sections/reader-full-post.scss
@@ -1,5 +1,6 @@
 @import '../shared/colors';
 @import '../shared/mixins/mixins'; // we use the noticon-style mixin from here
 @import '../shared/typography';
+@import '../shared/functions/z-index';
 
 @import 'blocks/reader-full-post/style';

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -235,7 +235,8 @@ $z-layers: (
 	),
 	'.reader-full-post__sidebar-comment-like': (
 		'.reader-full-post .back-button': 1,
-		'.author-compact-profile__follow .follow-button': 1
+		'.author-compact-profile__follow .follow-button': 1,
+		'.reader-full-post__visit-site-container': 1
 	),
 	'.reader-related-card.card': (
 		'.reader-related-card__meta': 1

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -47,6 +47,7 @@ $z-layers: (
 		'.reader-feed-header': 0,
 		'.reader-feed-header__back-and-follow': 0,
 		'.reader-related-card.card': 0,
+		'.reader-full-post__sidebar-comment-like': 0,
 		'.list-stream__header-follow': 0,
 		'.following__intro-close-icon-bg' : 0,
 		'.media-library .search.is-expanded-to-container': 1,
@@ -231,6 +232,10 @@ $z-layers: (
 	'.reader-feed-header__back-and-follow': (
 		'.card.header-cake': 1,
 		'.reader-feed-header__follow': 1
+	),
+	'.reader-full-post__sidebar-comment-like': (
+		'.reader-full-post .back-button': 1,
+		'.author-compact-profile__follow .follow-button': 1
 	),
 	'.reader-related-card.card': (
 		'.reader-related-card__meta': 1

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -47,7 +47,7 @@ $z-layers: (
 		'.reader-feed-header': 0,
 		'.reader-feed-header__back-and-follow': 0,
 		'.reader-related-card.card': 0,
-		'.reader-full-post__sidebar-comment-like': 0,
+		'.reader-full-post__sidebar-comment-like': 1,
 		'.list-stream__header-follow': 0,
 		'.following__intro-close-icon-bg' : 0,
 		'.media-library .search.is-expanded-to-container': 1,
@@ -234,9 +234,9 @@ $z-layers: (
 		'.reader-feed-header__follow': 1
 	),
 	'.reader-full-post__sidebar-comment-like': (
-		'.reader-full-post .back-button': 1,
-		'.author-compact-profile__follow .follow-button': 1,
-		'.reader-full-post__visit-site-container': 1
+		'.reader-full-post .back-button': 2,
+		'.author-compact-profile__follow .follow-button': 2,
+		'.reader-full-post__visit-site-container': 2
 	),
 	'.reader-related-card.card': (
 		'.reader-related-card__meta': 1

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -33,5 +33,5 @@
 
 .comment-button__icon {
 	position: relative;
-		top: 1px;
+		top: 2px;
 }

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -361,22 +361,24 @@ export class FullPostView extends React.Component {
 									post={ post }
 								/>
 							) }
-						{ shouldShowComments( post ) && (
-							<CommentButton
-								key="comment-button"
-								commentCount={ commentCount }
-								onClick={ this.handleCommentClick }
-								tagName="div"
-							/>
-						) }
-						{ shouldShowLikes( post ) && (
-							<LikeButton
-								siteId={ +post.site_ID }
-								postId={ +post.ID }
-								fullPost={ true }
-								tagName="div"
-							/>
-						) }
+						<div className="reader-full-post__sidebar-comment-like">
+							{ shouldShowComments( post ) && (
+								<CommentButton
+									key="comment-button"
+									commentCount={ commentCount }
+									onClick={ this.handleCommentClick }
+									tagName="div"
+								/>
+							) }
+							{ shouldShowLikes( post ) && (
+								<LikeButton
+									siteId={ +post.site_ID }
+									postId={ +post.ID }
+									fullPost={ true }
+									tagName="div"
+								/>
+							) }
+						</div>
 					</div>
 					<Emojify>
 						<article className="reader-full-post__story" ref="article">

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -57,6 +57,13 @@
 	text-transform: uppercase;
 	z-index: z-index( '.reader-full-post__sidebar-comment-like', '.reader-full-post__visit-site-container' );
 
+	@include breakpoint( ">660px" ) {
+		border: 0;
+		position: absolute;
+			top: 47px;
+		z-index: 0;
+	}
+
 	.external-link .gridicons-external {
 		fill: $gray-darken-10;
 		top: 5px;
@@ -66,12 +73,8 @@
 		}
 	}
 
-	@include breakpoint( ">660px" ) {
-		top: 47px;
-	}
-
 	.external-link {
-		color: $blue-medium;
+		color: $gray-darken-10;
 		display: block;
 		padding: 10px 10px 15px 6px;
 
@@ -80,10 +83,10 @@
 		}
 
 		&:hover {
-			color: $gray-dark;
+			color: $blue-medium;
 
 			.gridicons-external {
-				fill: $gray-dark;
+				fill: $blue-medium;
 			}
 		}
 	}
@@ -93,12 +96,6 @@
 		@include breakpoint( "<660px" ) {
 			display: none;
 		}
-	}
-
-	@include breakpoint( ">660px" ) {
-		border: 0;
-		position: absolute;
-		z-index: 0;
 	}
 }
 
@@ -121,8 +118,8 @@
 
 	@include breakpoint( "<660px" ) {
 		position: static;
-		width: auto;
 		text-align: left;
+		width: auto;
 	}
 }
 
@@ -170,9 +167,9 @@
 
 	@include breakpoint( "<660px" ) {
 		margin-bottom: 35px;
-		text-overflow: clip;
 		padding-right: 10px;
 		position: relative;
+		text-overflow: clip;
 		white-space: nowrap;
 
 		&::after {
@@ -314,8 +311,8 @@
 
 // Action buttons in full-post
 .reader-full-post .reader-post-actions {
-	margin-bottom: 20px;
 	clear: both;
+	margin-bottom: 20px;
 
 	.post-edit-button__label,
 	.reader-share__button-label,
@@ -483,7 +480,7 @@
 .reader-full-post__header-tags {
 	display: inline-flex;
 	flex: 1;
-	width: calc(100% - 120px);
+	width: calc( 100% - 120px );
 
 	.gridicon {
 		fill: $gray;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -4,7 +4,10 @@
 .is-group-reader.has-no-sidebar {
 
 	.masterbar {
-		display: none; // Hides masterbar in fullpost
+
+		@include breakpoint( "<660px" ) {
+			display: none; // Hides masterbar in fullpost mobile
+		}
 	}
 }
 
@@ -52,7 +55,7 @@
 		right: 0;
 		top: 0;
 	text-transform: uppercase;
-	z-index: z-index( '.masterbar', '.reader-visit-site' );
+	z-index: z-index( '.reader-full-post__sidebar-comment-like', '.reader-full-post__visit-site-container' );
 
 	.external-link .gridicons-external {
 		fill: $gray-darken-10;
@@ -68,7 +71,7 @@
 	}
 
 	.external-link {
-		color: $gray-darken-10;
+		color: $blue-medium;
 		display: block;
 		padding: 10px 10px 15px 6px;
 
@@ -150,13 +153,23 @@
 	margin-bottom: 0;
 }
 
+.reader-full-post .back-button {
+
+	@include breakpoint( "<660px" ) {
+		background: transparent;
+		border-bottom: 0;
+		position: fixed;
+		width: 100px;
+		z-index: z-index( '.reader-full-post__sidebar-comment-like', '.reader-full-post .back-button' );
+	}
+}
+
 .reader-full-post .author-compact-profile {
 	display: inline-flex;
 	flex-direction: column;
 
 	@include breakpoint( "<660px" ) {
 		margin-bottom: 35px;
-		overflow: hidden;
 		text-overflow: clip;
 		padding-right: 10px;
 		position: relative;
@@ -257,8 +270,20 @@
 
 		.author-compact-profile__follow .follow-button {
 			position: fixed;
-				left: calc( 100% - 320px );
+				left: calc( 100% - 270px );
 				top: 5px;
+
+			@include breakpoint( "<660px" ) {
+				background: transparent;
+				position: fixed;
+				z-index: z-index( '.reader-full-post__sidebar-comment-like', '.author-compact-profile__follow .follow-button' );
+
+				.gridicon {
+					height: 24px;
+					top: 7px;
+					width: 24px;
+				}
+			}
 		}
 
 		.author-compact-profile__follow-count {
@@ -305,26 +330,27 @@
 }
 
 .reader-full-post__sidebar-comment-like {
-	align-items: flex-start;
-	background: white;
-	display: flex;
-	border-bottom: 1px solid $gray;
-	flex-direction: row;
-	height: 40px;
-	justify-content: flex-end;
-	position: fixed;
-		left: 0;
-		top: 0;
-	width: 100%;
-	z-index: 10000000;
+
+	 @include breakpoint( "<660px" ) {
+		align-items: flex-start;
+		background: white;
+		display: flex;
+		border-bottom: 1px solid $gray-lighten-30;
+		flex-direction: row;
+		height: 47px;
+		justify-content: flex-end;
+		position: fixed;
+			left: 0;
+			top: 0;
+		width: 100%;
+	 }
 }
 
 .reader-full-post__sidebar .like-button {
 
 	@include breakpoint( "<660px" ) {
-		position: fixed;
-			right: 80px;
-			top: 5px;
+		margin-right: 60px;
+			top: 9px;
 	}
 
 	.like-button__label-status {
@@ -341,8 +367,7 @@
 	margin-right: 18px;
 
 	@include breakpoint( "<660px" ) {
-		right: 130px;
-		top: 5px;
+		top: 9px;
 	}
 
 	.comment-button__label-status {
@@ -356,7 +381,11 @@
 }
 
 .reader-full-post .has-author-link.has-author-icon {
-	margin-top: 5px;
+	margin-top: 25px;
+
+	@include breakpoint( ">660px" ) {
+		margin-top: 5px;
+	}
 
 	.reader-author-link {
 		margin-top: 0;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -340,6 +340,7 @@
 			left: 0;
 			top: 0;
 		width: 100%;
+		z-index: z-index( 'root', '.reader-full-post__sidebar-comment-like' );
 	 }
 }
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -1,6 +1,13 @@
 // Styles targeted at story content
 @import 'content';
 
+.is-group-reader.has-no-sidebar {
+
+	.masterbar {
+		display: none; // Hides masterbar in fullpost
+	}
+}
+
 .reader-full-post.main {
 	max-width: none;
 	// Turns off the implicit positioning context set up by the normal main styles
@@ -250,13 +257,19 @@
 
 		.author-compact-profile__follow .follow-button {
 			position: fixed;
-				top: 10px;
-				right: 48px;
-			z-index: z-index( '.masterbar', '.reader-profile' );
+				left: calc( 100% - 320px );
+				top: 5px;
 		}
 
 		.author-compact-profile__follow-count {
 			display: none;
+		}
+
+		.author-compact-profile__follow .follow-button__label {
+
+			@include breakpoint( "<660px" ) {
+				display: none;
+			}
 		}
 	}
 }
@@ -291,13 +304,27 @@
 	top: 4px;
 }
 
+.reader-full-post__sidebar-comment-like {
+	align-items: flex-start;
+	background: white;
+	display: flex;
+	border-bottom: 1px solid $gray;
+	flex-direction: row;
+	height: 40px;
+	justify-content: flex-end;
+	position: fixed;
+		left: 0;
+		top: 0;
+	width: 100%;
+	z-index: 10000000;
+}
+
 .reader-full-post__sidebar .like-button {
 
 	@include breakpoint( "<660px" ) {
 		position: fixed;
-			right: 160px;
-			top: 10px;
-		z-index: z-index( '.masterbar', '.reader-profile' );
+			right: 80px;
+			top: 5px;
 	}
 
 	.like-button__label-status {
@@ -314,11 +341,8 @@
 	margin-right: 18px;
 
 	@include breakpoint( "<660px" ) {
-		position: fixed;
-			top: 10px;
-			right: 232px;
-		z-index: z-index( '.masterbar', '.reader-profile' );
-		margin-right: 0;
+		right: 130px;
+		top: 5px;
 	}
 
 	.comment-button__label-status {


### PR DESCRIPTION
This PR fixes: https://github.com/Automattic/wp-calypso/issues/22740

I changed the order of the action buttons if <660px. Original order is Back, Comment, Like, Follow(ing), Visit:
![screenshot 2018-03-02 13 42 39](https://user-images.githubusercontent.com/4924246/36923285-9e008320-1e1f-11e8-9334-a2e7dc624a2f.png)

Changed it to Back, Follow(ing), Comment, Like, Visit:
![screenshot 2018-03-02 13 44 00](https://user-images.githubusercontent.com/4924246/36923324-c7a74f7e-1e1f-11e8-8692-9fe9e18966ef.png)
