### PR TITLE
Stats: StatsError: Allow children to be rendered

### DIFF
--- a/client/my-sites/stats/stats-error/index.jsx
+++ b/client/my-sites/stats/stats-error/index.jsx
@@ -18,13 +18,15 @@ class StatsError extends React.PureComponent {
 	};
 
 	render() {
-		const message =
-			this.props.message ||
-			this.props.translate( "Some stats didn't load in time. Please try again later." );
+		const { className, message, children } = this.props;
+		const defaultMessage = this.props.translate(
+			"Some stats didn't load in time. Please try again later."
+		);
 
 		return (
-			<div className={ classNames( 'module-content-text', 'is-error', this.props.className ) }>
-				<p>{ message }</p>
+			<div className={ classNames( 'module-content-text', 'is-error', className ) }>
+				<p>{ message || defaultMessage }</p>
+				{ children }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/stats-error/index.jsx
+++ b/client/my-sites/stats/stats-error/index.jsx
@@ -18,14 +18,13 @@ class StatsError extends React.PureComponent {
 	};
 
 	render() {
-		const { className, message, children } = this.props;
-		const defaultMessage = this.props.translate(
-			"Some stats didn't load in time. Please try again later."
-		);
+		const { children, className, message, translate } = this.props;
+		const displayedMessage =
+			message || translate( "Some stats didn't load in time. Please try again later." );
 
 		return (
 			<div className={ classNames( 'module-content-text', 'is-error', className ) }>
-				<p>{ message || defaultMessage }</p>
+				<p>{ displayedMessage }</p>
 				{ children }
 			</div>
 		);


### PR DESCRIPTION
If we'd like to display an error message with markup or something other than a string, we can give the ability to the `StatsError` component to render children, if supplied.

For example, https://github.com/Automattic/wp-calypso/pull/21752 would like to render a link
![screen shot 2018-03-01 at 11 43 20 am](https://user-images.githubusercontent.com/1922453/36891631-27d7f96a-1e67-11e8-8e61-063d63b4fdc9.png)
