### PR TITLE
Jetpack connect: Enable branding without flag

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -37,7 +37,6 @@ import PushNotificationApprovalPoller from './two-factor-authentication/push-not
 import userFactory from 'lib/user';
 import SocialConnectPrompt from './social-connect-prompt';
 import JetpackLogo from 'components/jetpack-logo';
-import { isEnabled } from 'config';
 
 const user = userFactory();
 
@@ -190,7 +189,7 @@ class Login extends Component {
 					</p>
 				);
 			}
-		} else if ( isJetpack && isEnabled( 'jetpack/connection-rebranding' ) ) {
+		} else if ( isJetpack ) {
 			headerText = translate( 'Log in to your WordPress.com account to set up Jetpack.' );
 			preHeader = (
 				<div>
@@ -278,11 +277,7 @@ class Login extends Component {
 	render() {
 		const { isJetpack } = this.props;
 		return (
-			<div
-				className={ classNames( 'login', {
-					'is-jetpack': isJetpack && isEnabled( 'jetpack/connection-rebranding' ),
-				} ) }
-			>
+			<div className={ classNames( 'login', { 'is-jetpack': isJetpack } ) }>
 				{ this.renderHeader() }
 
 				<ErrorNotice />

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -11,23 +11,18 @@ import classNames from 'classnames';
  */
 import JetpackLogo from 'components/jetpack-logo';
 import Main from 'components/main';
-import { isEnabled } from 'config';
 import { retrieveMobileRedirect } from './persistence-utils';
 
 const JetpackConnectMainWrapper = ( { isWide, className, children } ) => {
-	const jetpackBranded = isEnabled( 'jetpack/connection-rebranding' );
 	const wrapperClassName = classNames( 'jetpack-connect__main', {
 		'is-wide': isWide,
 		'is-mobile-app-flow': !! retrieveMobileRedirect(),
-		'jetpack-branded': jetpackBranded,
 	} );
 	return (
 		<Main className={ classNames( className, wrapperClassName ) }>
-			{ jetpackBranded && (
-				<div className="jetpack-connect__main-logo">
-					<JetpackLogo full size={ 45 } />
-				</div>
-			) }
+			<div className="jetpack-connect__main-logo">
+				<JetpackLogo full size={ 45 } />
+			</div>
 			{ children }
 		</Main>
 	);

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -20,28 +20,24 @@
 		}
 	}
 
-	// @todo
-	// Remove extra .jetpack-branded class when feature flag is removed.
-	&.jetpack-branded {
-		.button.is-primary {
-			background-color: $green-jetpack;
-			border-color: darken($green-jetpack, 5%);
+	.button.is-primary {
+		background-color: $green-jetpack;
+		border-color: darken($green-jetpack, 5%);
 
-			&:hover,
-			&:focus {
-				border-color: darken($green-jetpack, 30%);
-			}
+		&:hover,
+		&:focus {
+			border-color: darken($green-jetpack, 30%);
+		}
 
-			&:focus {
-				box-shadow: 0 0 0 2px lighten($green-jetpack, 25%);
-			}
+		&:focus {
+			box-shadow: 0 0 0 2px lighten($green-jetpack, 25%);
+		}
 
-			&[disabled],
-			&:disabled {
-				background: tint($green-jetpack, 50%);
-				border-color: tint($green-jetpack, 35%);
-				color: $white;
-			}
+		&[disabled],
+		&:disabled {
+			background: tint($green-jetpack, 50%);
+			border-color: tint($green-jetpack, 35%);
+			color: $white;
 		}
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -63,7 +63,6 @@
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/mobile-app-flow": true,
-		"jetpack/connection-rebranding": true,
 		"jetpack/happychat": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,7 +44,6 @@
 		"help/courses": true,
 		"jetpack/api-cache": true,
 		"jetpack/connect/mobile-app-flow": true,
-		"jetpack/connection-rebranding": true,
 		"jetpack/happychat": true,
 		"jetpack/google-analytics-anonymize-ip": true,
 		"jetpack/google-analytics-for-stores": true,


### PR DESCRIPTION
Remove the feature flag
Apply branding in all environments

## Testing
- Visit https://calypso.live/log-in/jetpack?branch=update/jetpack/brand-without-flag
- Ensure you see the branded log-in
- Visit https://calypso.live/jetpack/connect?branch=update/jetpack/brand-without-flag
- Ensure you see the branded flow.
- Start a connection with Jurassic.ninja
- When you're sent to the log-in or authorize step on WordPress.com, change the url to be calypso.live (no need to add the branch, it will be persisted).
- Ensure you see the branded flow.