### PR TITLE
Do not translate the concierge forms and add more visible notice

### DIFF
--- a/client/me/concierge/README.md
+++ b/client/me/concierge/README.md
@@ -4,6 +4,10 @@ Concierge
 These components are used to render Business Concierge Sessions flows for booking, cancelling and 
 rescheduling appointments.
 
+## Important note
+Components aren't localized on purpose because we only support english speaking concierge sessions.
+
+
 ## Supported routes
 
 ```js

--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -5,7 +5,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
 /**
@@ -14,7 +13,7 @@ import { connect } from 'react-redux';
 import HeaderCake from 'components/header-cake';
 import CompactCard from 'components/card/compact';
 import { getConciergeSignupForm } from 'state/selectors';
-import { getCurrentUserId, getCurrentUserLocale } from 'state/current-user/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
 import { bookConciergeAppointment, requestConciergeAvailableTimes } from 'state/concierge/actions';
 import AvailableTimePicker from '../shared/available-time-picker';
 import {
@@ -29,7 +28,6 @@ class CalendarStep extends Component {
 	static propTypes = {
 		availableTimes: PropTypes.array.isRequired,
 		currentUserId: PropTypes.number.isRequired,
-		currentUserLocale: PropTypes.string.isRequired,
 		onBack: PropTypes.func.isRequired,
 		onComplete: PropTypes.func.isRequired,
 		site: PropTypes.object.isRequired,
@@ -69,19 +67,16 @@ class CalendarStep extends Component {
 	}
 
 	render() {
-		const { availableTimes, currentUserLocale, onBack, signupForm, site, translate } = this.props;
+		const { availableTimes, onBack, signupForm, site } = this.props;
 
 		return (
 			<div>
-				<HeaderCake onClick={ onBack }>{ translate( 'Choose Concierge Session' ) }</HeaderCake>
-				<CompactCard>
-					{ translate( 'Please select a day to have your Concierge session.' ) }
-				</CompactCard>
+				<HeaderCake onClick={ onBack }>Choose Concierge Session</HeaderCake>
+				<CompactCard>Please select a day to have your Concierge session.</CompactCard>
 
 				<AvailableTimePicker
-					actionText={ translate( 'Book this session' ) }
+					actionText={ 'Book this session' }
 					availableTimes={ availableTimes }
-					currentUserLocale={ currentUserLocale }
 					disabled={ signupForm.status === CONCIERGE_STATUS_BOOKING }
 					onSubmit={ this.onSubmit }
 					site={ site }
@@ -94,9 +89,8 @@ class CalendarStep extends Component {
 
 export default connect(
 	state => ( {
-		signupForm: getConciergeSignupForm( state ),
 		currentUserId: getCurrentUserId( state ),
-		currentUserLocale: getCurrentUserLocale( state ),
+		signupForm: getConciergeSignupForm( state ),
 	} ),
 	{ bookConciergeAppointment, recordTracksEvent, requestConciergeAvailableTimes }
-)( localize( CalendarStep ) );
+)( CalendarStep );

--- a/client/me/concierge/book/confirmation-step.js
+++ b/client/me/concierge/book/confirmation-step.js
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Confirmation from '../shared/confirmation';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -20,25 +19,25 @@ class ConfirmationStep extends Component {
 	}
 
 	render() {
-		const { site, translate } = this.props;
+		const { site } = this.props;
 
 		return (
 			<Confirmation
-				description={ translate(
+				description={
 					'We will send you a calendar invitation and an email with information on how to prepare.'
-				) }
-				title={ translate( 'Your Concierge session is booked!' ) }
+				}
+				title={ 'Your Concierge session is booked!' }
 			>
 				<Button
 					className="book__schedule-button"
 					href={ `/stats/day/${ site.slug }` }
 					primary={ true }
 				>
-					{ translate( 'Return to your dashboard' ) }
+					{ 'Return to your dashboard' }
 				</Button>
 			</Confirmation>
 		);
 	}
 }
 
-export default connect( null, { recordTracksEvent } )( localize( ConfirmationStep ) );
+export default connect( null, { recordTracksEvent } )( ConfirmationStep );

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import Notice from 'components/notice';
 import CompactCard from 'components/card/compact';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -19,14 +20,16 @@ import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 import Timezone from 'components/timezone';
 import Site from 'blocks/site';
-import { localize } from 'i18n-calypso';
 import { updateConciergeSignupForm } from 'state/concierge/actions';
 import { getConciergeSignupForm, getUserSettings } from 'state/selectors';
+import { getCurrentUserLocale } from 'state/current-user/selectors';
 import PrimaryHeader from '../shared/primary-header';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { isDefaultLocale } from 'lib/i18n-utils';
 
 class InfoStep extends Component {
 	static propTypes = {
+		currentUserLocale: PropTypes.string.isRequired,
 		signupForm: PropTypes.object,
 		userSettings: PropTypes.object,
 		onComplete: PropTypes.func.isRequired,
@@ -66,56 +69,59 @@ class InfoStep extends Component {
 	}
 
 	render() {
-		const { signupForm: { firstname, lastname, message, timezone }, translate } = this.props;
+		const {
+			currentUserLocale,
+			signupForm: { firstname, lastname, message, timezone },
+		} = this.props;
+		const notice = ! isDefaultLocale( currentUserLocale )
+			? 'Sessions are 30 minutes long and in English.'
+			: null;
 
 		return (
 			<div>
 				<PrimaryHeader />
+				{ notice && <Notice showDismiss={ false } text={ notice } /> }
 				<CompactCard className="book__info-step-site-block">
 					<Site siteId={ this.props.site.ID } />
 				</CompactCard>
 
 				<CompactCard>
 					<FormFieldset>
-						<FormLabel htmlFor="firstname">{ translate( 'First Name' ) }</FormLabel>
+						<FormLabel htmlFor="firstname">{ 'First Name' }</FormLabel>
 						<FormTextInput
 							name="firstname"
-							placeholder={ translate( 'What may we call you?' ) }
+							placeholder={ 'What may we call you?' }
 							onChange={ this.setFieldValue }
 							value={ firstname }
 						/>
 					</FormFieldset>
 					<FormFieldset>
-						<FormLabel htmlFor="lastname">{ translate( 'Last Name' ) }</FormLabel>
+						<FormLabel htmlFor="lastname">{ 'Last Name' }</FormLabel>
 						<FormTextInput
 							name="lastname"
-							placeholder={ translate( 'Optionally, please tell us your last name.' ) }
+							placeholder={ 'Optionally, please tell us your last name.' }
 							onChange={ this.setFieldValue }
 							value={ lastname }
 						/>
 					</FormFieldset>
 					<FormFieldset>
-						<FormLabel>{ translate( "What's your timezone?" ) }</FormLabel>
+						<FormLabel>{ "What's your timezone?" }</FormLabel>
 						<Timezone
 							includeManualOffsets={ false }
 							name="timezone"
 							onSelect={ this.setTimezone }
 							selectedZone={ timezone }
 						/>
-						<FormSettingExplanation>
-							{ translate( 'Choose a city in your timezone.' ) }
-						</FormSettingExplanation>
+						<FormSettingExplanation>{ 'Choose a city in your timezone.' }</FormSettingExplanation>
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel>
-							{ translate( 'What are you hoping to accomplish with your site?' ) }
-						</FormLabel>
+						<FormLabel>{ 'What are you hoping to accomplish with your site?' }</FormLabel>
 						<FormTextarea
-							placeholder={ translate(
+							placeholder={
 								'Sell products and services? Generate leads? Something else entirely?' +
-									" Be as specific as you can! It helps us provide the information you're looking for."
-							) }
+								" Be as specific as you can! It helps us provide the information you're looking for."
+							}
 							name="message"
 							onChange={ this.setFieldValue }
 							value={ message }
@@ -128,7 +134,7 @@ class InfoStep extends Component {
 						type="button"
 						onClick={ this.props.onComplete }
 					>
-						{ translate( 'Continue to calendar' ) }
+						{ 'Continue to calendar' }
 					</FormButton>
 				</CompactCard>
 			</div>
@@ -138,6 +144,7 @@ class InfoStep extends Component {
 
 export default connect(
 	state => ( {
+		currentUserLocale: getCurrentUserLocale( state ),
 		signupForm: getConciergeSignupForm( state ),
 		userSettings: getUserSettings( state ),
 	} ),
@@ -145,4 +152,4 @@ export default connect(
 		updateConciergeSignupForm,
 		recordTracksEvent,
 	}
-)( localize( InfoStep ) );
+)( InfoStep );

--- a/client/me/concierge/cancel/index.js
+++ b/client/me/concierge/cancel/index.js
@@ -14,7 +14,6 @@ import { includes } from 'lodash';
 import QueryConciergeAppointmentDetails from 'components/data/query-concierge-appointment-details';
 import Button from 'components/button';
 import Main from 'components/main';
-import { localize } from 'i18n-calypso';
 import Confirmation from '../shared/confirmation';
 import { cancelConciergeAppointment } from 'state/concierge/actions';
 import {
@@ -40,21 +39,21 @@ class ConciergeCancel extends Component {
 	};
 
 	getDisplayComponent = () => {
-		const { appointmentId, appointmentDetails, siteSlug, signupForm, translate } = this.props;
+		const { appointmentId, appointmentDetails, siteSlug, signupForm } = this.props;
 
 		switch ( signupForm.status ) {
 			case CONCIERGE_STATUS_CANCELLED:
 				return (
 					<Confirmation
-						description={ translate( 'Would you like to schedule a new session?' ) }
-						title={ translate( 'Your Concierge session has been cancelled.' ) }
+						description={ 'Would you like to schedule a new session?' }
+						title={ 'Your Concierge session has been cancelled.' }
 					>
 						<Button
 							className="cancel__schedule-button"
 							href={ `/me/concierge/${ siteSlug }/book` }
 							primary={ true }
 						>
-							{ translate( 'Schedule' ) }
+							{ 'Schedule' }
 						</Button>
 					</Confirmation>
 				);
@@ -77,17 +76,15 @@ class ConciergeCancel extends Component {
 						/>
 
 						<Confirmation
-							description={ translate(
-								'You can also reschedule your session. What would you like to do?'
-							) }
-							title={ translate( 'Cancel your Concierge session' ) }
+							description={ 'You can also reschedule your session. What would you like to do?' }
+							title={ 'Cancel your Concierge session' }
 						>
 							<Button
 								className="cancel__reschedule-button"
 								disabled={ disabledRescheduling }
 								href={ `/me/concierge/${ siteSlug }/${ appointmentId }/reschedule` }
 							>
-								{ translate( 'Reschedule session' ) }
+								{ 'Reschedule session' }
 							</Button>
 
 							<Button
@@ -97,7 +94,7 @@ class ConciergeCancel extends Component {
 								primary={ true }
 								scary={ true }
 							>
-								{ translate( 'Cancel session' ) }
+								{ 'Cancel session' }
 							</Button>
 						</Confirmation>
 					</div>
@@ -116,4 +113,4 @@ export default connect(
 		signupForm: getConciergeSignupForm( state ),
 	} ),
 	{ cancelConciergeAppointment, recordTracksEvent }
-)( localize( ConciergeCancel ) );
+)( ConciergeCancel );

--- a/client/me/concierge/cancel/skeleton.js
+++ b/client/me/concierge/cancel/skeleton.js
@@ -9,17 +9,15 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import { localize } from 'i18n-calypso';
 
 class Skeleton extends Component {
 	render() {
-		const { translate } = this.props;
 		return (
 			<div>
-				<CompactCard> { translate( 'Cancelling your Concierge session…' ) } </CompactCard>
+				<CompactCard> { 'Cancelling your Concierge session…' } </CompactCard>
 			</div>
 		);
 	}
 }
 
-export default localize( Skeleton );
+export default Skeleton;

--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -17,7 +17,6 @@ import BookSkeleton from './book/skeleton';
 import RescheduleCalendarStep from './reschedule/calendar-step';
 import RescheduleConfirmationStep from './reschedule/confirmation-step';
 import RescheduleSkeleton from './reschedule/skeleton';
-import i18n from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 const book = ( context, next ) => {
@@ -56,11 +55,9 @@ const reschedule = ( context, next ) => {
 const siteSelector = ( context, next ) => {
 	context.store.dispatch( recordTracksEvent( 'calypso_concierge_site_selection_step' ) );
 
-	context.getSiteSelectionHeaderText = () =>
-		i18n.translate(
-			'Please select a site for your {{strong}}Business Concierge Session{{/strong}}',
-			{ components: { strong: <strong /> } }
-		);
+	context.getSiteSelectionHeaderText = () => {
+		'Please select a site for your <strong>Business Concierge Session<strong />';
+	};
 	next();
 };
 

--- a/client/me/concierge/reschedule/calendar-step.js
+++ b/client/me/concierge/reschedule/calendar-step.js
@@ -5,7 +5,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { without } from 'lodash';
 
@@ -80,14 +79,7 @@ class CalendarStep extends Component {
 	}
 
 	render() {
-		const {
-			appointmentDetails,
-			appointmentId,
-			currentUserLocale,
-			signupForm,
-			site,
-			translate,
-		} = this.props;
+		const { appointmentDetails, appointmentId, currentUserLocale, signupForm, site } = this.props;
 
 		return (
 			<div>
@@ -97,16 +89,14 @@ class CalendarStep extends Component {
 				/>
 
 				<CompactCard>
-					{ translate(
-						'To reschedule your Concierge session, let us know your timezone and preferred day.'
-					) }
+					{ 'To reschedule your Concierge session, let us know your timezone and preferred day.' }
 				</CompactCard>
 
 				{ appointmentDetails && (
 					<div>
 						<CompactCard>
 							<FormFieldset>
-								<FormLabel>{ translate( "What's your timezone?" ) }</FormLabel>
+								<FormLabel>{ "What's your timezone?" }</FormLabel>
 								<Timezone
 									includeManualOffsets={ false }
 									name="timezone"
@@ -114,13 +104,13 @@ class CalendarStep extends Component {
 									selectedZone={ appointmentDetails.meta.timezone }
 								/>
 								<FormSettingExplanation>
-									{ translate( 'Choose a city in your timezone.' ) }
+									{ 'Choose a city in your timezone.' }
 								</FormSettingExplanation>
 							</FormFieldset>
 						</CompactCard>
 
 						<AvailableTimePicker
-							actionText={ translate( 'Reschedule to this date' ) }
+							actionText={ 'Reschedule to this date' }
 							availableTimes={ this.getFilteredTimeSlots() }
 							currentUserLocale={ currentUserLocale }
 							disabled={ signupForm.status === CONCIERGE_STATUS_BOOKING || ! appointmentDetails }
@@ -143,4 +133,4 @@ export default connect(
 		signupForm: getConciergeSignupForm( state ),
 	} ),
 	{ recordTracksEvent, rescheduleConciergeAppointment, updateConciergeAppointmentDetails }
-)( localize( CalendarStep ) );
+)( CalendarStep );

--- a/client/me/concierge/reschedule/confirmation-step.js
+++ b/client/me/concierge/reschedule/confirmation-step.js
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Confirmation from '../shared/confirmation';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -20,25 +19,25 @@ class ConfirmationStep extends Component {
 	}
 
 	render() {
-		const { site, translate } = this.props;
+		const { site } = this.props;
 
 		return (
 			<Confirmation
-				description={ translate(
+				description={
 					'We will send you a calendar invitation and an email with information on how to prepare.'
-				) }
-				title={ translate( 'Your Concierge session has been rescheduled!' ) }
+				}
+				title={ 'Your Concierge session has been rescheduled!' }
 			>
 				<Button
 					className="reschedule__schedule-button"
 					href={ `/stats/day/${ site.slug }` }
 					primary={ true }
 				>
-					{ translate( 'Return to your dashboard' ) }
+					{ 'Return to your dashboard' }
 				</Button>
 			</Confirmation>
 		);
 	}
 }
 
-export default connect( null, { recordTracksEvent } )( localize( ConfirmationStep ) );
+export default connect( null, { recordTracksEvent } )( ConfirmationStep );

--- a/client/me/concierge/reschedule/skeleton.js
+++ b/client/me/concierge/reschedule/skeleton.js
@@ -9,17 +9,15 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import { localize } from 'i18n-calypso';
 
 class Skeleton extends Component {
 	render() {
-		const { translate } = this.props;
 		return (
 			<div>
-				<CompactCard> { translate( 'Loading…' ) } </CompactCard>
+				<CompactCard> { 'Loading…' } </CompactCard>
 			</div>
 		);
 	}
 }
 
-export default localize( Skeleton );
+export default Skeleton;

--- a/client/me/concierge/shared/available-time-card.js
+++ b/client/me/concierge/shared/available-time-card.js
@@ -14,8 +14,7 @@ import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { isEmpty } from 'lodash';
-import { localize, moment } from 'i18n-calypso';
-import config from 'config';
+import { moment } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -25,16 +24,12 @@ import FoldableCard from 'components/foldable-card';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import { getLanguage } from 'lib/i18n-utils';
-const defaultLanguage = getLanguage( config( 'i18n_default_locale_slug' ) ).name;
 
 class CalendarCard extends Component {
 	static propTypes = {
 		actionText: PropTypes.string.isRequired,
 		date: PropTypes.number.isRequired,
 		disabled: PropTypes.bool.isRequired,
-		isDefaultLocale: PropTypes.bool.isRequired,
 		onSubmit: PropTypes.func.isRequired,
 		times: PropTypes.arrayOf( PropTypes.number ).isRequired,
 		timezone: PropTypes.string.isRequired,
@@ -87,15 +82,14 @@ class CalendarCard extends Component {
 	 * @returns {String} The name for the day of the week
 	 */
 	getDayOfWeekString = date => {
-		const { translate } = this.props;
 		const today = this.withTimezone().startOf( 'day' );
 		const dayOffset = today.diff( date.startOf( 'day' ), 'days' );
 
 		switch ( dayOffset ) {
 			case 0:
-				return translate( 'Today' );
+				return 'Today';
 			case -1:
-				return translate( 'Tomorrow' );
+				return 'Tomorrow';
 		}
 		return date.format( 'dddd' );
 	};
@@ -123,12 +117,7 @@ class CalendarCard extends Component {
 	};
 
 	render() {
-		const { actionText, disabled, isDefaultLocale, times, translate } = this.props;
-		const description = isDefaultLocale
-			? translate( 'Sessions are 30 minutes long.' )
-			: translate( 'Sessions are 30 minutes long and in %(defaultLanguage)s.', {
-					args: { defaultLanguage },
-				} );
+		const { actionText, disabled, times } = this.props;
 
 		return (
 			<FoldableCard
@@ -136,13 +125,11 @@ class CalendarCard extends Component {
 				clickableHeader={ ! isEmpty( times ) }
 				compact
 				disabled={ isEmpty( times ) }
-				summary={ isEmpty( times ) ? translate( 'No sessions available' ) : null }
+				summary={ isEmpty( times ) ? 'No sessions available' : null }
 				header={ this.renderHeader() }
 			>
 				<FormFieldset>
-					<FormLabel htmlFor="concierge-start-time">
-						{ translate( 'Choose a starting time' ) }
-					</FormLabel>
+					<FormLabel htmlFor="concierge-start-time">{ 'Choose a starting time' }</FormLabel>
 					<FormSelect
 						id="concierge-start-time"
 						disabled={ disabled }
@@ -155,7 +142,6 @@ class CalendarCard extends Component {
 							</option>
 						) ) }
 					</FormSelect>
-					<FormSettingExplanation>{ description }</FormSettingExplanation>
 				</FormFieldset>
 
 				<FormFieldset>
@@ -168,4 +154,4 @@ class CalendarCard extends Component {
 	}
 }
 
-export default localize( CalendarCard );
+export default CalendarCard;

--- a/client/me/concierge/shared/available-time-card.js
+++ b/client/me/concierge/shared/available-time-card.js
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { isEmpty } from 'lodash';
 import { moment } from 'i18n-calypso';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -72,7 +73,13 @@ class CalendarCard extends Component {
 		};
 	}
 
-	withTimezone = dateTime => moment( dateTime ).tz( this.props.timezone );
+	withTimezone = dateTime => {
+		// force local moment instance to use default locale (en)
+		// https://github.com/automattic/hg/issues/587
+		const momentInstance = moment( dateTime );
+		momentInstance.locale( config( 'i18n_default_locale_slug' ) );
+		return momentInstance.tz( this.props.timezone );
+	};
 
 	/**
 	 * Returns a string representing the day of the week, with certain dates using natural

--- a/client/me/concierge/shared/available-time-picker.js
+++ b/client/me/concierge/shared/available-time-picker.js
@@ -11,7 +11,6 @@ import { moment } from 'i18n-calypso';
  * Internal dependencies
  */
 import AvailableTimeCard from './available-time-card';
-import { isDefaultLocale } from 'lib/i18n-utils';
 
 const groupAvailableTimesByDate = ( availableTimes, timezone ) => {
 	const dates = {};
@@ -45,14 +44,7 @@ class AvailableTimePicker extends Component {
 	};
 
 	render() {
-		const {
-			actionText,
-			availableTimes,
-			currentUserLocale,
-			disabled,
-			onSubmit,
-			timezone,
-		} = this.props;
+		const { actionText, availableTimes, disabled, onSubmit, timezone } = this.props;
 		const availability = groupAvailableTimesByDate( availableTimes, timezone );
 
 		return (
@@ -62,7 +54,6 @@ class AvailableTimePicker extends Component {
 						actionText={ actionText }
 						date={ date }
 						disabled={ disabled }
-						isDefaultLocale={ isDefaultLocale( currentUserLocale ) }
 						key={ date }
 						onSubmit={ onSubmit }
 						times={ times }

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -11,13 +11,10 @@ import React, { Component } from 'react';
 import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
 import ExternalLink from 'components/external-link';
-import { localize } from 'i18n-calypso';
 import { CONCIERGE_SUPPORT } from 'lib/url/support';
 
 class PrimaryHeader extends Component {
 	render() {
-		const { translate } = this.props;
-
 		return (
 			<Card>
 				<img
@@ -26,10 +23,8 @@ class PrimaryHeader extends Component {
 					src={ '/calypso/images/illustrations/illustration-start.svg' }
 				/>
 				<FormattedHeader
-					headerText={ translate( 'WordPress.com Business Concierge Session' ) }
-					subHeaderText={ translate(
-						"In this 30-minute session we'll help you get started with your site."
-					) }
+					headerText={ 'WordPress.com Business Concierge Session' }
+					subHeaderText={ "In this 30-minute session we'll help you get started with your site." }
 				/>
 				<ExternalLink
 					className="shared__info-link"
@@ -37,11 +32,11 @@ class PrimaryHeader extends Component {
 					href={ CONCIERGE_SUPPORT }
 					target="_blank"
 				>
-					{ translate( 'Learn more' ) }
+					{ 'Learn more' }
 				</ExternalLink>
 			</Card>
 		);
 	}
 }
 
-export default localize( PrimaryHeader );
+export default PrimaryHeader;

--- a/client/me/concierge/shared/upsell.js
+++ b/client/me/concierge/shared/upsell.js
@@ -5,7 +5,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -21,7 +20,6 @@ class Upsell extends Component {
 	};
 
 	render() {
-		const { translate } = this.props;
 		return (
 			<div>
 				<PrimaryHeader />
@@ -29,11 +27,9 @@ class Upsell extends Component {
 					<Site siteId={ this.props.site.ID } />
 				</CompactCard>
 				<CompactCard>
-					<p>
-						{ translate( 'Only sites on a Business plan are eligible for a Concierge session.' ) }
-					</p>
+					<p>{ 'Only sites on a Business plan are eligible for a Concierge session.' }</p>
 					<Button href={ `/plans/${ this.props.site.slug }` } primary>
-						{ translate( 'Upgrade to Business' ) }
+						{ 'Upgrade to Business' }
 					</Button>
 				</CompactCard>
 			</div>
@@ -41,4 +37,4 @@ class Upsell extends Component {
 	}
 }
 
-export default localize( Upsell );
+export default Upsell;

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/book/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/book/index.js
@@ -1,11 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { translate } from 'i18n-calypso';
-
-/**
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -58,8 +53,8 @@ export const onError = ( { type }, error ) => {
 
 	const errorMessage =
 		CONCIERGE_ERROR_NO_AVAILABLE_STAFF === error.code
-			? translate( 'This session is no longer available. Please select a different time.' )
-			: translate( 'We could not book your appointment. Please try again later.' );
+			? 'This session is no longer available. Please select a different time.'
+			: 'We could not book your appointment. Please try again later.';
 
 	return [
 		withAnalytics(

--- a/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/appointments/detail/index.js
@@ -1,11 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { translate } from 'i18n-calypso';
-
-/**
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -34,7 +29,7 @@ export const onSuccess = ( { appointmentId }, appointmentDetails ) =>
 	updateConciergeAppointmentDetails( appointmentId, appointmentDetails );
 
 export const onError = () =>
-	errorNotice( translate( 'We could not find your appointment. Please try again later.' ) );
+	errorNotice( 'We could not find your appointment. Please try again later.' );
 
 export default {
 	[ CONCIERGE_APPOINTMENT_DETAILS_REQUEST ]: [

--- a/client/state/data-layer/wpcom/concierge/schedules/available-times/index.js
+++ b/client/state/data-layer/wpcom/concierge/schedules/available-times/index.js
@@ -1,11 +1,6 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { translate } from 'i18n-calypso';
-
-/**
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
@@ -34,7 +29,7 @@ export const storeFetchedConciergeAvailableTimes = ( { dispatch }, action, avail
 	dispatch( updateConciergeAvailableTimes( availableTimes ) );
 
 export const conciergeAvailableTimesFetchError = () =>
-	errorNotice( translate( "We couldn't load our Concierge schedule. Please try again later." ) );
+	errorNotice( "We couldn't load our Concierge schedule. Please try again later." );
 
 export const showConciergeAvailableTimesFetchError = ( { dispatch } ) =>
 	dispatch( conciergeAvailableTimesFetchError() );


### PR DESCRIPTION
## Summary
This PR disables the translation of concierge forms because we are only accepting english speakers. Also adds a more visible notice that the session will be held in english.

Before for `es` customers: https://cloudup.com/cCSfyghGCSc
After for `es` customers: https://cloudup.com/c4AhWlstlEK

More context: 587-hg-gh

## Testing
1. Make sure booking, rescheduling and cancelling a session works & looks as expected
2. Change your language
3. Make sure concierge forms are shown in english and there is a notice on the first step