### PR TITLE
Fix: Checklist should show up to users who abort the G Suite purchase.

### DIFF
--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -36,7 +36,7 @@ export class GsuiteNudge extends React.Component {
 
 		// DO NOT assign the test here.
 		if ( 'show' === getABTestVariation( 'checklistThankYouForPaidUser' ) ) {
-			page( `/checklist/${ siteSlug }/gsuite` );
+			page( `/checklist/${ siteSlug }/paid` );
 		} else {
 			page( `/checkout/thank-you/${ siteSlug }/${ receiptId }` );
 		}

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -21,6 +21,7 @@ import { getSiteSlug, getSiteTitle } from 'state/sites/selectors';
 import { addItem, removeItem } from 'lib/upgrades/actions';
 import { cartItems } from 'lib/cart-values';
 import { isDotComPlan } from 'lib/products-values';
+import { getABTestVariation } from 'lib/abtest';
 
 export class GsuiteNudge extends React.Component {
 	static propTypes = {
@@ -33,7 +34,12 @@ export class GsuiteNudge extends React.Component {
 	handleClickSkip = () => {
 		const { siteSlug, receiptId } = this.props;
 
-		page( `/checkout/thank-you/${ siteSlug }/${ receiptId }` );
+		// DO NOT assign the test here.
+		if ( 'show' === getABTestVariation( 'checklistThankYouForPaidUser' ) ) {
+			page( `/checklist/${ siteSlug }/gsuite` );
+		} else {
+			page( `/checkout/thank-you/${ siteSlug }/${ receiptId }` );
+		}
 	};
 
 	handleAddGoogleApps = googleAppsCartItem => {


### PR DESCRIPTION
The checklist doesn't show up to users who create a site with a custom domain and then click on the skip link on the G Suite registration form. This PR fixes the problem, so the checklist will appear for the case.

## How to test

1. Set `checklistThankYouForPaidUser` test to `show`.
2. Create a website with any paid plan and a custom domain.
3. You should be able to see the checklist page when you successfully complete the transaction.
4. When G Suite registration form appears, click on the "No thanks" link to skip the G Suite.
5. See if the checklist shows up as below.

<img width="972" alt="2018-03-02 11 00 34" src="https://user-images.githubusercontent.com/212034/36902385-a2b131e6-1e6d-11e8-936f-2bed3e0798d8.png">

Related: #22810 

cc @fditrapani 