### PR TITLE
JP Onboarding: Don't Commit JPO Credentials to JP Settings State

### DIFF
--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -88,7 +88,9 @@ export const announceRequestFailure = ( { dispatch, getState }, { siteId } ) => 
 export const saveJetpackOnboardingSettings = ( { dispatch }, action ) => {
 	const { settings, siteId } = action;
 
-	dispatch( updateJetpackOnboardingSettings( siteId, action.settings ) );
+	// We don't want JP Onboarding specific things in our JP Settings Redux state
+	const { jpoUser, token, ...settingsWithoutCredentials } = settings; // eslint-disable-line no-unused-vars
+	dispatch( updateJetpackOnboardingSettings( siteId, settingsWithoutCredentials ) );
 
 	return dispatch(
 		http(

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { get, startsWith } from 'lodash';
+import { get, omit, startsWith } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -89,7 +89,7 @@ export const saveJetpackOnboardingSettings = ( { dispatch }, action ) => {
 	const { settings, siteId } = action;
 
 	// We don't want JP Onboarding specific things in our JP Settings Redux state
-	const { jpoUser, token, ...settingsWithoutCredentials } = settings; // eslint-disable-line no-unused-vars
+	const settingsWithoutCredentials = omit( settings, [ 'onboarding.jpUser', 'onboarding.token' ] );
 	dispatch( updateJetpackOnboardingSettings( siteId, settingsWithoutCredentials ) );
 
 	return dispatch(

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -33,7 +33,12 @@ export const fromApi = response => {
 	return response.data;
 };
 
-const receiveJetpackOnboardingSettings = ( { dispatch }, { siteId }, settings ) => {
+const receiveJetpackOnboardingSettings = (
+	{ dispatch },
+	{ siteId },
+	// We don't want JP Onboarding specific things in our JP Settings Redux state
+	{ jpoUser, token, ...settings } // eslint-disable-line no-unused-vars
+) => {
 	dispatch( updateJetpackOnboardingSettings( siteId, settings ) );
 };
 

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -33,12 +33,7 @@ export const fromApi = response => {
 	return response.data;
 };
 
-const receiveJetpackOnboardingSettings = (
-	{ dispatch },
-	{ siteId },
-	// We don't want JP Onboarding specific things in our JP Settings Redux state
-	{ jpoUser, token, ...settings } // eslint-disable-line no-unused-vars
-) => {
+const receiveJetpackOnboardingSettings = ( { dispatch }, { siteId }, settings ) => {
 	dispatch( updateJetpackOnboardingSettings( siteId, settings ) );
 };
 

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -88,7 +88,7 @@ export const announceRequestFailure = ( { dispatch, getState }, { siteId } ) => 
 export const saveJetpackOnboardingSettings = ( { dispatch }, action ) => {
 	const { settings, siteId } = action;
 
-	// We don't want JP Onboarding specific things in our JP Settings Redux state
+	// We don't want Jetpack Onboarding credentials in our Jetpack Settings Redux state.
 	const settingsWithoutCredentials = omit( settings, [ 'onboarding.jpUser', 'onboarding.token' ] );
 	dispatch( updateJetpackOnboardingSettings( siteId, settingsWithoutCredentials ) );
 

--- a/client/state/data-layer/wpcom/jetpack/settings/test/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/test/index.js
@@ -147,10 +147,13 @@ describe( 'saveJetpackOnboardingSettings()', () => {
 	const token = 'abcd1234';
 	const userEmail = 'example@yourgroovydomain.com';
 	const siteId = 12345678;
+	const onboardingSettings = {
+		siteTitle: 'My Awesome Site',
+		siteDescription: 'Not just another WordPress Site',
+	};
 	const settings = {
 		onboarding: {
-			siteTitle: 'My Awesome Site',
-			siteDescription: 'Not just another WordPress Site',
+			...onboardingSettings,
 			token,
 			jpUser: userEmail,
 		},
@@ -162,7 +165,7 @@ describe( 'saveJetpackOnboardingSettings()', () => {
 		settings,
 	};
 
-	test( 'should dispatch an action for POST HTTP request to save Jetpack settings', () => {
+	test( 'should dispatch an action for POST HTTP request to save Jetpack settings, omitting JPO credentials', () => {
 		saveJetpackOnboardingSettings( { dispatch }, action );
 
 		expect( dispatch ).toHaveBeenCalledWith(
@@ -180,7 +183,9 @@ describe( 'saveJetpackOnboardingSettings()', () => {
 				action
 			)
 		);
-		expect( dispatch ).toHaveBeenCalledWith( updateJetpackOnboardingSettings( siteId, settings ) );
+		expect( dispatch ).toHaveBeenCalledWith(
+			updateJetpackOnboardingSettings( siteId, { onboarding: onboardingSettings } )
+		);
 	} );
 } );
 


### PR DESCRIPTION
To test: Clean your persisted Redux state, start JPO flow with an unconnected site, change & save site title. Verify that no schema validation errors are reported.