### PR TITLE
Jetpack Onboarding: Allow connected sites to onboard without credentials

### DIFF
--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -154,6 +154,9 @@ export default connect(
 	( state, { siteSlug } ) => {
 		let siteId = getUnconnectedSiteIdBySlug( state, siteSlug );
 		if ( ! siteId ) {
+			// We rely on the fact that all sites are being requested automatically early in <Layout />.
+			// If sites aren't loaded, we'll consider that the site is not connected,
+			// which will always result in redirecting to wp-admin to obtain the onboarding credentials.
 			siteId = getSiteId( state, siteSlug );
 		}
 


### PR DESCRIPTION
This PR allows connected sites to go through the onboarding flow without the necessity to obtain onboarding credentials. Fixes #22945.

To test:
* Checkout this branch
* Go to `http://calypso.localhost:3000/jetpack/start/:site` for a connected site.
* Verify JPO flow works (retrieving and saving).
* Go to `http://calypso.localhost:3000/jetpack/start/:site` for a fresh JN site.
* Verify JPO flow works (retrieving and saving).
* Try both of the above cases with a clean Redux state.
* Try both of the above cases when both logged in and logged out.