### PR TITLE
Enable stats previous/next navigation in small screens

### DIFF
--- a/client/my-sites/stats/stats-period-navigation/style.scss
+++ b/client/my-sites/stats/stats-period-navigation/style.scss
@@ -18,10 +18,6 @@
 		cursor: pointer;
 		color: $gray-darken-20;
 
-		@include breakpoint( "<660px" ) {
-			display: none;
-		}
-
 		&:hover {
 			color: $blue-medium;
 		}


### PR DESCRIPTION
This re-enables `stats-period-navigation` previous and next navigation arrows in small screens below 660px.

This component is used in several places:

- Stats
  - [client/my-sites/stats/site.jsx](https://github.com/Automattic/wp-calypso/blob/bbca5a5980208106bca67711ee1487d8845c66e6/client/my-sites/stats/site.jsx)
- Store Stats
  - [client/extensions/woocommerce/app/store-stats/listview.js](https://github.com/Automattic/wp-calypso/blob/c6a1401c7fb1271dfce9cedd5c2a97bcb9dabb18/client/extensions/woocommerce/app/store-stats/listview.js)
  - [client/extensions/woocommerce/app/store-stats/index.js](https://github.com/Automattic/wp-calypso/blob/5f15f3365213253724ca0d8798c6cb8160f00bc9/client/extensions/woocommerce/app/store-stats/index.js)
- Activity Log
  - [client/my-sites/stats/activity-log/index.jsx](https://github.com/Automattic/wp-calypso/blob/842999d6b5a81e3670f17ee8fc80a768068546cb/client/my-sites/stats/activity-log/index.jsx)

Fixes task in https://github.com/Automattic/wp-calypso/issues/22869

### Before

![image](https://user-images.githubusercontent.com/390760/36905556-95b6b016-1e2b-11e8-8cf8-bdbcdb85cc04.png)

### After

**Stats**

![image](https://user-images.githubusercontent.com/390760/36905595-a91404a6-1e2b-11e8-9946-942385b4b16f.png)

**Store**

![image](https://user-images.githubusercontent.com/390760/36905676-d8eb51e8-1e2b-11e8-9414-335bf0536dea.png)

**Activity Log**

![image](https://user-images.githubusercontent.com/390760/36905703-ec24cd7a-1e2b-11e8-84e3-0a9604f1f8c7.png)
