### PR TITLE
Foldable card: fixes flex-grow in smaller screens

### DIFF
--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -95,6 +95,10 @@ button.foldable-card__action {
 	align-items: center;
 	flex: 1 1;
 	justify-content: flex-end;
+
+	@include breakpoint( '<480px' ) {
+		flex: 0 1;
+	}
 }
 
 .foldable-card__expand {


### PR DESCRIPTION
This fixes https://github.com/Automattic/wp-calypso/issues/21333 by changing the `flex-grow` of `foldable-card__secondary` in screens below 480px.

### Before

![image](https://user-images.githubusercontent.com/390760/36907109-996b47ae-1e2f-11e8-91f9-da5af0458c16.png)

### After

![image](https://user-images.githubusercontent.com/390760/36907133-aa1393d6-1e2f-11e8-878e-0084f5d15076.png)
