### PR TITLE
Jetpack Connect: Dedicated component + route for install steps

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -15,13 +15,14 @@ import { translate } from 'i18n-calypso';
 import analytics from 'lib/analytics';
 import CheckoutData from 'components/data/checkout';
 import config from 'config';
-import OrgCredentialsForm from './remote-credentials';
+import InstallInstructions from './install-instructions';
 import JetpackAuthorize from './authorize';
 import JetpackConnect from './main';
 import JetpackNewSite from './jetpack-new-site/index';
 import JetpackSignup from './signup';
 import JetpackSsoForm from './sso';
 import NoDirectAccessError from './no-direct-access-error';
+import OrgCredentialsForm from './remote-credentials';
 import Plans from './plans';
 import PlansLanding from './plans-landing';
 import versionCompare from 'lib/version-compare';
@@ -174,6 +175,11 @@ export function connect( context, next ) {
 		ctaId: query.cta_id, // origin tracking params
 		ctaFrom: query.cta_from,
 	} );
+	next();
+}
+
+export function instructions( context, next ) {
+	context.primary = <InstallInstructions />;
 	next();
 }
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -179,7 +179,11 @@ export function connect( context, next ) {
 }
 
 export function instructions( context, next ) {
-	context.primary = <InstallInstructions />;
+	const url = context.query.url;
+	if ( ! url ) {
+		return page.redirect( '/jetpack/connect' );
+	}
+	context.primary = <InstallInstructions remoteSiteUrl={ url } />;
 	next();
 }
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -179,6 +179,11 @@ export function connect( context, next ) {
 }
 
 export function instructions( context, next ) {
+	analytics.pageView.record(
+		'jetpack/connect/instructions',
+		'Jetpack Manual Install Instructions'
+	);
+
 	const url = context.query.url;
 	if ( ! url ) {
 		return page.redirect( '/jetpack/connect' );

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -97,6 +97,14 @@ export default function() {
 	}
 
 	page(
+		'/jetpack/connect/instructions',
+		controller.setMasterbar,
+		controller.instructions,
+		makeLayout,
+		clientRender
+	);
+
+	page(
 		'/jetpack/connect/store/:interval(yearly|monthly)?',
 		controller.plansLanding,
 		makeLayout,

--- a/client/jetpack-connect/install-instructions.jsx
+++ b/client/jetpack-connect/install-instructions.jsx
@@ -77,9 +77,6 @@ class InstallInstructions extends Component {
 		const { remoteSiteData, remoteSiteUrl, translate } = this.props;
 
 		const jetpackVersion = remoteSiteData.jetpackVersion;
-
-		// todo: get this from cookie
-		const isInstall = true;
 		const instructionsData = this.getInstructionsData();
 
 		return (
@@ -97,7 +94,6 @@ class InstallInstructions extends Component {
 									key={ 'instructions-step-' + key }
 									stepName={ stepName }
 									jetpackVersion={ jetpackVersion }
-									isInstall={ isInstall }
 									currentUrl={ remoteSiteUrl }
 									confirmJetpackInstallStatus={ this.props.confirmJetpackInstallStatus }
 									onClick={ instructionsData.buttonOnClick }

--- a/client/jetpack-connect/install-instructions.jsx
+++ b/client/jetpack-connect/install-instructions.jsx
@@ -1,0 +1,140 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import Gridicon from 'gridicons';
+import page from 'page';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import FormattedHeader from 'components/formatted-header';
+import HelpButton from './help-button';
+import JetpackInstallStep from './install-step';
+import LocaleSuggestions from 'components/locale-suggestions';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
+import MainWrapper from './main-wrapper';
+import { addCalypsoEnvQueryArg } from './utils';
+import { confirmJetpackInstallStatus } from 'state/jetpack-connect/actions';
+import { externalRedirect } from 'lib/route';
+import { getConnectingSite } from 'state/jetpack-connect/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { REMOTE_PATH_ACTIVATE, REMOTE_PATH_INSTALL } from './constants';
+
+class InstallInstructions extends Component {
+	getInstructionsData() {
+		const { remoteSiteData, translate } = this.props;
+		const notJetpack = ! remoteSiteData.hasJetpack;
+
+		return {
+			headerTitle: notJetpack
+				? translate( 'Ready for installation' )
+				: translate( 'Ready for activation' ),
+			headerSubtitle: translate( "We'll need you to complete a few manual steps." ),
+			steps: notJetpack
+				? [ 'installJetpack', 'activateJetpackAfterInstall', 'connectJetpackAfterInstall' ]
+				: [ 'activateJetpack', 'connectJetpack' ],
+			buttonOnClick: notJetpack ? this.installJetpack : this.activateJetpack,
+			buttonText: notJetpack ? translate( 'Install Jetpack' ) : translate( 'Activate Jetpack' ),
+		};
+	}
+
+	installJetpack = () => {
+		const { remoteSiteUrl } = this.props;
+
+		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
+			jetpack_funnel: remoteSiteUrl,
+			type: 'install_jetpack',
+		} );
+
+		externalRedirect( addCalypsoEnvQueryArg( remoteSiteUrl + REMOTE_PATH_INSTALL ) );
+	};
+
+	activateJetpack = () => {
+		const { remoteSiteUrl } = this.props;
+
+		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
+			jetpack_funnel: remoteSiteUrl,
+			type: 'activate_jetpack',
+		} );
+
+		externalRedirect( addCalypsoEnvQueryArg( remoteSiteUrl + REMOTE_PATH_ACTIVATE ) );
+	};
+
+	renderLocaleSuggestions() {
+		if ( this.props.isLoggedIn || ! this.props.locale ) {
+			return;
+		}
+
+		return <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />;
+	}
+
+	render() {
+		const { remoteSiteData, remoteSiteUrl, translate } = this.props;
+
+		const jetpackVersion = remoteSiteData.jetpackVersion;
+
+		// todo: get this from cookie
+		const isInstall = true;
+		const instructionsData = this.getInstructionsData();
+
+		return (
+			<MainWrapper isWide>
+				{ this.renderLocaleSuggestions() }
+				<div className="jetpack-connect__install">
+					<FormattedHeader
+						headerText={ instructionsData.headerTitle }
+						subHeaderText={ instructionsData.headerSubtitle }
+					/>
+					<div className="jetpack-connect__install-steps">
+						{ instructionsData.steps.map( ( stepName, key ) => {
+							return (
+								<JetpackInstallStep
+									key={ 'instructions-step-' + key }
+									stepName={ stepName }
+									jetpackVersion={ jetpackVersion }
+									isInstall={ isInstall }
+									currentUrl={ remoteSiteUrl }
+									confirmJetpackInstallStatus={ this.props.confirmJetpackInstallStatus }
+									onClick={ instructionsData.buttonOnClick }
+								/>
+							);
+						} ) }
+					</div>
+					<Button onClick={ instructionsData.buttonOnClick } primary>
+						{ instructionsData.buttonText }
+					</Button>
+					<div className="jetpack-connect__navigation">
+						<Button
+							compact
+							borderless
+							className="jetpack-connect__back-button"
+							onClick={ page.back }
+						>
+							<Gridicon icon="arrow-left" size={ 18 } />
+							{ translate( 'Back' ) }
+						</Button>
+					</div>
+				</div>
+				<LoggedOutFormLinks>
+					<HelpButton />
+				</LoggedOutFormLinks>
+			</MainWrapper>
+		);
+	}
+}
+
+export default connect(
+	state => ( {
+		remoteSiteData: getConnectingSite( state ).data || {},
+		remoteSiteUrl: getConnectingSite( state ).url,
+	} ),
+	{
+		confirmJetpackInstallStatus,
+		recordTracksEvent,
+	}
+)( localize( InstallInstructions ) );

--- a/client/jetpack-connect/install-instructions.jsx
+++ b/client/jetpack-connect/install-instructions.jsx
@@ -128,7 +128,7 @@ export default connect(
 		}
 
 		return {
-			jetpackVersion: remoteSiteData.jetpackVersion,
+			jetpackVersion: remoteSiteData.jetpackVersion || false,
 			notJetpack,
 		};
 	},

--- a/client/jetpack-connect/install-instructions.jsx
+++ b/client/jetpack-connect/install-instructions.jsx
@@ -2,8 +2,6 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
-import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -78,7 +76,7 @@ class InstallInstructions extends Component {
 	}
 
 	render() {
-		const { jetpackVersion, remoteSiteUrl, translate } = this.props;
+		const { jetpackVersion, remoteSiteUrl } = this.props;
 		const instructionsData = this.getInstructionsData();
 
 		return (
@@ -106,17 +104,6 @@ class InstallInstructions extends Component {
 					<Button onClick={ instructionsData.buttonOnClick } primary>
 						{ instructionsData.buttonText }
 					</Button>
-					<div className="jetpack-connect__navigation">
-						<Button
-							compact
-							borderless
-							className="jetpack-connect__back-button"
-							onClick={ page.back }
-						>
-							<Gridicon icon="arrow-left" size={ 18 } />
-							{ translate( 'Back' ) }
-						</Button>
-					</div>
 				</div>
 				<LoggedOutFormLinks>
 					<HelpButton />

--- a/client/jetpack-connect/install-instructions.jsx
+++ b/client/jetpack-connect/install-instructions.jsx
@@ -32,8 +32,7 @@ class InstallInstructions extends Component {
 	};
 
 	getInstructionsData() {
-		const { remoteSiteData, translate } = this.props;
-		const notJetpack = ! remoteSiteData.hasJetpack;
+		const { notJetpack, translate } = this.props;
 
 		return {
 			headerTitle: notJetpack
@@ -79,9 +78,7 @@ class InstallInstructions extends Component {
 	}
 
 	render() {
-		const { remoteSiteData, remoteSiteUrl, translate } = this.props;
-
-		const jetpackVersion = remoteSiteData.jetpackVersion;
+		const { jetpackVersion, remoteSiteUrl, translate } = this.props;
 		const instructionsData = this.getInstructionsData();
 
 		return (
@@ -130,9 +127,24 @@ class InstallInstructions extends Component {
 }
 
 export default connect(
-	state => ( {
-		remoteSiteData: getConnectingSite( state ).data || {},
-	} ),
+	state => {
+		const remoteSite = getConnectingSite( state );
+		const remoteSiteData = remoteSite.data || {};
+		let notJetpack = ! remoteSiteData.hasJetpack;
+
+		const { installConfirmedByUser } = remoteSite;
+		if ( installConfirmedByUser === false ) {
+			notJetpack = true;
+		}
+		if ( installConfirmedByUser === true ) {
+			notJetpack = false;
+		}
+
+		return {
+			jetpackVersion: remoteSiteData.jetpackVersion,
+			notJetpack,
+		};
+	},
 	{
 		confirmJetpackInstallStatus,
 		recordTracksEvent,

--- a/client/jetpack-connect/install-instructions.jsx
+++ b/client/jetpack-connect/install-instructions.jsx
@@ -4,6 +4,7 @@
  */
 import Gridicon from 'gridicons';
 import page from 'page';
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -26,6 +27,10 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { REMOTE_PATH_ACTIVATE, REMOTE_PATH_INSTALL } from './constants';
 
 class InstallInstructions extends Component {
+	static propTypes = {
+		remoteSiteUrl: PropTypes.string.isRequired,
+	};
+
 	getInstructionsData() {
 		const { remoteSiteData, translate } = this.props;
 		const notJetpack = ! remoteSiteData.hasJetpack;
@@ -127,7 +132,6 @@ class InstallInstructions extends Component {
 export default connect(
 	state => ( {
 		remoteSiteData: getConnectingSite( state ).data || {},
-		remoteSiteUrl: getConnectingSite( state ).url,
 	} ),
 	{
 		confirmJetpackInstallStatus,

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -172,11 +172,12 @@ export class JetpackConnectMain extends Component {
 	} );
 
 	goToInstallInstructions = this.makeSafeRedirectionFunction( url => {
+		const urlWithQuery = addQueryArgs( { url: this.state.currentUrl }, url );
 		this.props.recordTracksEvent( 'calypso_jpc_success_redirect', {
-			url: url,
+			url: urlWithQuery,
 			type: 'install_instructions',
 		} );
-		page( url );
+		page( urlWithQuery );
 	} );
 
 	redirectToMobileApp = this.makeSafeRedirectionFunction( reason => {

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -7,19 +7,16 @@ import config from 'config';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Gridicon from 'gridicons';
 import { concat, flowRight, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import Card from 'components/card';
 import FormattedHeader from 'components/formatted-header';
 import HelpButton from './help-button';
 import JetpackConnectNotices from './jetpack-connect-notices';
-import JetpackInstallStep from './install-step';
 import LocaleSuggestions from 'components/locale-suggestions';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
@@ -29,7 +26,7 @@ import SiteUrlInput from './site-url-input';
 import versionCompare from 'lib/version-compare';
 import { addCalypsoEnvQueryArg } from './utils';
 import { addQueryArgs, externalRedirect, untrailingslashit } from 'lib/route';
-import { checkUrl, confirmJetpackInstallStatus, dismissUrl } from 'state/jetpack-connect/actions';
+import { checkUrl, dismissUrl } from 'state/jetpack-connect/actions';
 import { FLOW_TYPES } from 'state/jetpack-connect/constants';
 import { getConnectingSite, getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -41,9 +38,7 @@ import {
 	JPC_PATH_PLANS,
 	JPC_PATH_REMOTE_INSTALL,
 	MINIMUM_JETPACK_VERSION,
-	REMOTE_PATH_ACTIVATE,
 	REMOTE_PATH_AUTH,
-	REMOTE_PATH_INSTALL,
 } from './constants';
 import {
 	ALREADY_CONNECTED,
@@ -131,9 +126,11 @@ export class JetpackConnectMain extends Component {
 			this.checkUrl( this.state.currentUrl );
 		}
 
-		if ( config.isEnabled( 'jetpack/connect/remote-install' ) ) {
-			if ( includes( [ NOT_JETPACK, NOT_ACTIVE_JETPACK ], this.getStatus() ) ) {
+		if ( includes( [ NOT_JETPACK, NOT_ACTIVE_JETPACK ], this.getStatus() ) ) {
+			if ( config.isEnabled( 'jetpack/connect/remote-install' ) ) {
 				this.goToRemoteInstall( JPC_PATH_REMOTE_INSTALL );
+			} else {
+				this.goToInstallInstructions( '/jetpack/connect/instructions' );
 			}
 		}
 	}
@@ -166,30 +163,20 @@ export class JetpackConnectMain extends Component {
 		externalRedirect( addCalypsoEnvQueryArg( url + REMOTE_PATH_AUTH ) );
 	} );
 
-	goToPluginInstall = this.makeSafeRedirectionFunction( url => {
-		this.props.recordTracksEvent( 'calypso_jpc_success_redirect', {
-			url: url,
-			type: 'plugin_install',
-		} );
-
-		externalRedirect( addCalypsoEnvQueryArg( url + REMOTE_PATH_INSTALL ) );
-	} );
-
-	goToPluginActivation = this.makeSafeRedirectionFunction( url => {
-		this.props.recordTracksEvent( 'calypso_jpc_success_redirect', {
-			url: url,
-			type: 'plugin_activation',
-		} );
-
-		externalRedirect( addCalypsoEnvQueryArg( url + REMOTE_PATH_ACTIVATE ) );
-	} );
-
 	goToRemoteInstall = this.makeSafeRedirectionFunction( url => {
 		this.props.recordTracksEvent( 'calypso_jpc_success_redirect', {
 			url: url,
 			type: 'remote_install',
 		} );
 		page.redirect( url );
+	} );
+
+	goToInstallInstructions = this.makeSafeRedirectionFunction( url => {
+		this.props.recordTracksEvent( 'calypso_jpc_success_redirect', {
+			url: url,
+			type: 'install_instructions',
+		} );
+		page( url );
 	} );
 
 	redirectToMobileApp = this.makeSafeRedirectionFunction( reason => {
@@ -245,23 +232,6 @@ export class JetpackConnectMain extends Component {
 		} else {
 			this.checkUrl( this.state.currentUrl );
 		}
-	};
-
-	installJetpack = () => {
-		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
-			jetpack_funnel: this.state.currentUrl,
-			type: 'install_jetpack',
-		} );
-
-		this.goToPluginInstall( this.state.currentUrl );
-	};
-
-	activateJetpack = () => {
-		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
-			jetpack_funnel: this.state.currentUrl,
-			type: 'activate_jetpack',
-		} );
-		this.goToPluginActivation( this.state.currentUrl );
 	};
 
 	checkProperty( propName ) {
@@ -397,24 +367,6 @@ export class JetpackConnectMain extends Component {
 		return includes( FLOW_TYPES, this.props.type );
 	}
 
-	getInstructionsData( status ) {
-		const { translate } = this.props;
-		return {
-			headerTitle:
-				NOT_JETPACK === status
-					? translate( 'Ready for installation' )
-					: translate( 'Ready for activation' ),
-			headerSubtitle: translate( "We'll need you to complete a few manual steps." ),
-			steps:
-				NOT_JETPACK === status
-					? [ 'installJetpack', 'activateJetpackAfterInstall', 'connectJetpackAfterInstall' ]
-					: [ 'activateJetpack', 'connectJetpack' ],
-			buttonOnClick: NOT_JETPACK === status ? this.installJetpack : this.activateJetpack,
-			buttonText:
-				NOT_JETPACK === status ? translate( 'Install Jetpack' ) : translate( 'Activate Jetpack' ),
-		};
-	}
-
 	renderFooter() {
 		const { translate } = this.props;
 		return (
@@ -470,7 +422,7 @@ export class JetpackConnectMain extends Component {
 		return <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />;
 	}
 
-	renderSiteEntry() {
+	render() {
 		const status = this.getStatus();
 		return (
 			<MainWrapper>
@@ -500,71 +452,6 @@ export class JetpackConnectMain extends Component {
 			</a>
 		);
 	}
-
-	renderBackButton() {
-		const { translate } = this.props;
-		return (
-			<Button
-				compact
-				borderless
-				className="jetpack-connect__back-button"
-				onClick={ this.dismissUrl }
-			>
-				<Gridicon icon="arrow-left" size={ 18 } />
-				{ translate( 'Back' ) }
-			</Button>
-		);
-	}
-
-	renderInstructions( instructionsData ) {
-		const jetpackVersion = this.checkProperty( 'jetpackVersion' );
-		const { currentUrl } = this.state;
-
-		return (
-			<MainWrapper isWide>
-				{ this.renderLocaleSuggestions() }
-				<div className="jetpack-connect__install">
-					<FormattedHeader
-						headerText={ instructionsData.headerTitle }
-						subHeaderText={ instructionsData.headerSubtitle }
-					/>
-					<div className="jetpack-connect__install-steps">
-						{ instructionsData.steps.map( ( stepName, key ) => {
-							return (
-								<JetpackInstallStep
-									key={ 'instructions-step-' + key }
-									stepName={ stepName }
-									jetpackVersion={ jetpackVersion }
-									currentUrl={ currentUrl }
-									confirmJetpackInstallStatus={ this.props.confirmJetpackInstallStatus }
-									onClick={ instructionsData.buttonOnClick }
-								/>
-							);
-						} ) }
-					</div>
-					<Button onClick={ instructionsData.buttonOnClick } primary>
-						{ instructionsData.buttonText }
-					</Button>
-					<div className="jetpack-connect__navigation">{ this.renderBackButton() }</div>
-				</div>
-				<LoggedOutFormLinks>
-					<HelpButton />
-				</LoggedOutFormLinks>
-			</MainWrapper>
-		);
-	}
-
-	render() {
-		const status = this.getStatus();
-		if (
-			includes( [ NOT_JETPACK, NOT_ACTIVE_JETPACK ], status ) &&
-			! this.props.jetpackConnectSite.isDismissed &&
-			! config.isEnabled( 'jetpack/connect/remote-install' )
-		) {
-			return this.renderInstructions( this.getInstructionsData( status ) );
-		}
-		return this.renderSiteEntry();
-	}
 }
 
 const connectComponent = connect(
@@ -586,7 +473,6 @@ const connectComponent = connect(
 	},
 	{
 		checkUrl,
-		confirmJetpackInstallStatus,
 		dismissUrl,
 		recordTracksEvent,
 	}

--- a/client/jetpack-connect/test/__snapshots__/main.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/main.js.snap
@@ -10,38 +10,6 @@ Array [
 ]
 `;
 
-exports[`JetpackConnectMain goToPluginActivation should dispatch analytics 1`] = `
-Array [
-  "calypso_jpc_success_redirect",
-  Object {
-    "type": "plugin_activation",
-    "url": "example.com",
-  },
-]
-`;
-
-exports[`JetpackConnectMain goToPluginActivation should fire redirect 1`] = `
-Array [
-  "example.com/wp-admin/plugins.php?calypso_env=test",
-]
-`;
-
-exports[`JetpackConnectMain goToPluginInstall should dispatch analytics 1`] = `
-Array [
-  "calypso_jpc_success_redirect",
-  Object {
-    "type": "plugin_install",
-    "url": "example.com",
-  },
-]
-`;
-
-exports[`JetpackConnectMain goToPluginInstall should fire redirect 1`] = `
-Array [
-  "example.com/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack&calypso_env=test",
-]
-`;
-
 exports[`JetpackConnectMain goToRemoteAuth should dispatch analytics 1`] = `
 Array [
   "calypso_jpc_success_redirect",

--- a/client/jetpack-connect/test/main.js
+++ b/client/jetpack-connect/test/main.js
@@ -78,52 +78,6 @@ describe( 'JetpackConnectMain', () => {
 		} );
 	} );
 
-	describe( 'goToPluginActivation', () => {
-		test( 'should fire redirect', () => {
-			const component = shallow( <JetpackConnectMain { ...REQUIRED_PROPS } /> );
-			component.instance().goToPluginActivation( 'example.com' );
-
-			expect( externalRedirect ).toHaveBeenCalledTimes( 1 );
-			expect( externalRedirect.mock.calls[ 0 ] ).toMatchSnapshot();
-		} );
-
-		test( 'should dispatch analytics', () => {
-			const url = 'example.com';
-			const spy = jest.fn();
-			const component = shallow(
-				<JetpackConnectMain { ...REQUIRED_PROPS } recordTracksEvent={ spy } />
-			);
-			spy.mockReset();
-			component.instance().goToPluginActivation( url );
-
-			expect( spy ).toHaveBeenCalledTimes( 1 );
-			expect( spy.mock.calls[ 0 ] ).toMatchSnapshot();
-		} );
-	} );
-
-	describe( 'goToPluginInstall', () => {
-		test( 'should fire redirect', () => {
-			const component = shallow( <JetpackConnectMain { ...REQUIRED_PROPS } /> );
-			component.instance().goToPluginInstall( 'example.com' );
-
-			expect( externalRedirect ).toHaveBeenCalledTimes( 1 );
-			expect( externalRedirect.mock.calls[ 0 ] ).toMatchSnapshot();
-		} );
-
-		test( 'should dispatch analytics', () => {
-			const url = 'example.com';
-			const spy = jest.fn();
-			const component = shallow(
-				<JetpackConnectMain { ...REQUIRED_PROPS } recordTracksEvent={ spy } />
-			);
-			spy.mockReset();
-			component.instance().goToPluginInstall( url );
-
-			expect( spy ).toHaveBeenCalledTimes( 1 );
-			expect( spy.mock.calls[ 0 ] ).toMatchSnapshot();
-		} );
-	} );
-
 	describe( 'goToRemoteAuth', () => {
 		test( 'should fire redirect', () => {
 			const component = shallow( <JetpackConnectMain { ...REQUIRED_PROPS } /> );

--- a/config/development.json
+++ b/config/development.json
@@ -61,7 +61,7 @@
 		"help/courses": true,
 		"jetpack/api-cache": true,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
-		"jetpack/connect/remote-install": true,
+		"jetpack/connect/remote-install": false,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/happychat": true,
 		"jetpack/google-analytics-anonymize-ip": true,

--- a/config/development.json
+++ b/config/development.json
@@ -61,7 +61,7 @@
 		"help/courses": true,
 		"jetpack/api-cache": true,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
-		"jetpack/connect/remote-install": false,
+		"jetpack/connect/remote-install": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/happychat": true,
 		"jetpack/google-analytics-anonymize-ip": true,


### PR DESCRIPTION
Give the Jetpack Install Instructions page its own route (and component), making it possible to navigate away-from and back-to. Previously, it was the same page as the initial URL entry form at /jetpack/connect. With this change, we will be able to link directly to these instructions from the new remote-install credentials entry page.

**Before**

<img width="1274" alt="screen shot 2018-03-13 at 11 17 09" src="https://user-images.githubusercontent.com/7767559/37338776-5d729e76-26b0-11e8-9497-d3bdd116d5eb.png">

**After**

<img width="1271" alt="screen shot 2018-03-13 at 11 17 19" src="https://user-images.githubusercontent.com/7767559/37338791-67792b2e-26b0-11e8-89ae-a6ac52728ebf.png">


Some notes:
* The URL of the remote site is now stored as a query arg, instead of redux state
* Because it is now possible to go back and forth from this page with the browser buttons, the _Back_ footer button has been removed, since it is redundant and hard to implement.
* It is now possible to come back to the instructions from half-way through the install process, so for example a user can get as far as installing the plugin in wp-admin, then hit browser _Back_ a couple of times to arrive back at the instructions
* In the above scenario, the instructions do not update to account for the now-installed plugin. This can be addressed in another PR by making this new component fetch the latest data from the site on arrival

## Reviewing Note
This is a large PR, but most of the change is moving UI logic out of `main.jsx` and into a new component `install-instructions.jsx`, so it might help to compare those two files when reviewing.

## Testing
* Go to  https://calypso.live/jetpack/connect?branch=update/jetpack-connect/install-instructinos-route
* Enter the URL of a site _without jetpack installed_
* Check that the displayed instructions make sense and can be followed
* Again, go to  https://calypso.live/jetpack/connect?branch=update/jetpack-connect/install-instructinos-route
* This time, enter URL of a site with Jetpack installed, but not activated
* Check that the displayed instructions make sense and can be followed

NOTE: To use a local build rather than calypso.live, you'll need to disable the remote-install feature by building with:
`DISABLE_FEATURES=jetpack/connect/remote-install npm start`


