### PR TITLE
JPO: Have JPC redirect back after connecting

### DIFF
--- a/client/jetpack-onboarding/connect-intro.jsx
+++ b/client/jetpack-onboarding/connect-intro.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import Tile from 'components/tile-grid/tile';
 import TileGrid from 'components/tile-grid';
 import { addQueryArgs } from 'lib/route';
@@ -18,6 +19,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 
 class ConnectIntro extends PureComponent {
 	static propTypes = {
+		action: PropTypes.string,
 		buttonLabel: PropTypes.string,
 		description: PropTypes.string,
 		e2eType: PropTypes.string,
@@ -33,6 +35,7 @@ class ConnectIntro extends PureComponent {
 
 	render() {
 		const {
+			action,
 			buttonLabel,
 			description,
 			e2eType,
@@ -44,12 +47,16 @@ class ConnectIntro extends PureComponent {
 		} = this.props;
 		const connectUrl = addQueryArgs(
 			{
-				url: siteUrl,
-				// TODO: add a parameter to the JPC to redirect back to this step after completion
-				// and in the redirect URL include the ?action=SOMEACTION parameter
-				// to actually trigger the action after getting back to JPO
+				connect_url_redirect: true,
+				calypso_env: config( 'env_id' ),
+				from: 'jpo',
+				page: 'jetpack',
+				// TODO: Pass current URL as prop, have consumer generate it from host and port
+				// config values plus `[ basePath, stepName, siteSlug ].join( '/' )`.
+				// (We need an absolute URL here.)
+				redirect_after_auth: addQueryArgs( { action }, window.location.href ),
 			},
-			'/jetpack/connect'
+			siteUrl + '/wp-admin/admin.php'
 		);
 		const href = ! isConnected ? connectUrl : null;
 

--- a/client/jetpack-onboarding/steps/business-address.jsx
+++ b/client/jetpack-onboarding/steps/business-address.jsx
@@ -154,6 +154,7 @@ class JetpackOnboardingBusinessAddressStep extends React.PureComponent {
 
 		return (
 			<ConnectIntro
+				action="add_business_address"
 				buttonLabel={ translate( 'Add a business address' ) }
 				e2eType="business-address"
 				header={ this.renderHeader() }

--- a/client/jetpack-onboarding/steps/contact-form.jsx
+++ b/client/jetpack-onboarding/steps/contact-form.jsx
@@ -81,6 +81,7 @@ class JetpackOnboardingContactFormStep extends React.PureComponent {
 
 		return (
 			<ConnectIntro
+				action="add_contact_form"
 				buttonLabel={ ! hasContactForm ? translate( 'Add a contact form' ) : null }
 				description={ hasContactForm ? translate( 'Your contact form has been created.' ) : null }
 				e2eType="contact-form"

--- a/client/jetpack-onboarding/steps/stats.jsx
+++ b/client/jetpack-onboarding/steps/stats.jsx
@@ -76,6 +76,7 @@ class JetpackOnboardingStatsStep extends React.Component {
 
 		return (
 			<ConnectIntro
+				action="activate_stats"
 				buttonLabel={ translate( 'Activate stats' ) }
 				e2eType="activate-stats"
 				header={ header }


### PR DESCRIPTION
Includes #22948 ([diff](https://github.com/Automattic/wp-calypso/compare/update/jpo-connected-sites-without-redirections...add/jpo-jpc-back-redirect))-- rebase after merging!

### Testing (important part highlighted)
* Checkout this branch on your local Calypso.
* Start with a fresh Jetpack site with the latest **Jetpack master** (Use https://jurassic.ninja/create/?jetpack-beta)
* Head to `/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` on the Jetpack site to start the onboarding flow.
* Skip steps until you reach the new Contact form step.
* Verify the step appears properly as shown on the screenshots.
* Click the **Add a contact form** button.
* You will be redirected to Jetpack Connect and connection process will start automatically.
* _After connecting, verify that you are redirected back to `http://calypso.localhost:3000/jetpack/start/contact-form/YOURJETPACKSITE.COM?action=add_contact_form`._
* Verify you can see the success screen (as shown on the screenshot)
* Verify the Contact Us page was created on your remote site.
* Refresh the page and verify you can still see the success screen.
* Verify the **Continue** button leads to the next step.
* Go back to other steps and visit the Contact Form step; verify you can still see the success screen.

Get a fresh JN site, and try the same for the Business Address step (where `?action=add_business_address`; skip thru the Contact Form step), and another to check the Stats step (where `?action= activate_stats `; skip thru both the Contact Form and Business Address steps).

Supersedes #22668.