### PR TITLE
JP Onboarding: Bump required version to 5.9

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -100,7 +100,7 @@ export function redirectWithoutLocaleIfLoggedIn( context, next ) {
 
 export function maybeOnboard( { query, store }, next ) {
 	if ( ! isEmpty( query ) && query.onboarding ) {
-		if ( query.site_url && query.jp_version && versionCompare( query.jp_version, '5.8', '<' ) ) {
+		if ( query.site_url && query.jp_version && versionCompare( query.jp_version, '5.9', '<' ) ) {
 			return externalRedirect( query.site_url + '/wp-admin/admin.php?page=jetpack#/dashboard' );
 		}
 


### PR DESCRIPTION
In order to make testers' lives easier, we shouldn't merge this before JP 5.9 is actually released.

To test:
* With a JP sandbox that has JP >= v5.8, land at `http://Yourwpsandbox.me/wp-admin/admin.php?page=jetpack&action=onboard&calypso_env=development` and verify you're redirected to `http://calypso.localhost:3000/jetpack/onboarding/Yourwpsandbox.me`, as before.
* Downgrade to JP < 5.9 (or change the version check in the code to 5.10 😛). Start at the same URL as above, and verify that this time, you're redirected to the site's wp-admin JP dashboard.

Fixes #22582.