### PR TITLE
Editor: Do not scroll to top on save failure

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -938,8 +938,6 @@ export const PostEditor = createReactClass( {
 				message,
 			},
 		} );
-
-		window.scrollTo( 0, 0 );
 	},
 
 	setPostDate: function( date ) {


### PR DESCRIPTION
After losing connection while writing with our editor I noticed that as every autosave would fail, the scroll position of the editor would skip to the top. This gets in the way of an otherwise workable offline writing experience.

To remedy this, I've simply just removed the line that sets the scroll position to 0.
This solution may be a little naive - I'm not sure why this scroll position was being set on failure in the first place, but there doesn't seem to be any obvious drawback to removing it. I have the feeling that this is a vestige of some old behaviour (blaming on this line shows that this addition was pre-OSS.

As discussed in #21484, there could be a more sophisticated fix put in place, avoiding even attempting to autosave while offline but I think that's best fixed in a follow up, if at all.

Fixes #21484