### PR TITLE
Jetpack Connect: Remove NOT_JETPACK notice

### DIFF
--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -113,10 +113,8 @@ export class JetpackConnectNotices extends Component {
 				return noticeValues;
 
 			case NOT_JETPACK:
-				noticeValues.status = 'is-notice';
-				noticeValues.icon = 'status';
-				noticeValues.text = translate( "Jetpack couldn't be found." );
-				return noticeValues;
+				// Not a problem
+				return null;
 
 			case WORDPRESS_DOT_COM:
 				noticeValues.text = translate( "Oops, that's us." );

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -113,7 +113,7 @@ export class JetpackConnectNotices extends Component {
 				return noticeValues;
 
 			case NOT_JETPACK:
-				// Not a problem
+				// Not notice required, we will move on to installation
 				return null;
 
 			case WORDPRESS_DOT_COM:


### PR DESCRIPTION
No visual changes.

The notice for NOT_JETPACK is never shown. It is not an error at the connect step, because we move on to install instructions or (soon) remote install. It is not used as an error at the auth step.

It causes a flash of notice in the remote-install feature and the refactor of instructions into a separate route.

Also, it had in invalid status type of `is-notice`.

## Testing
* Attempt to connect a .org site without Jetpack installed at /jetpack/connect
* You should see the manual install instructions as usual
