### PR TITLE
Set a source on Add Invite requests so we can see where they come from.

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -369,6 +369,7 @@ Undocumented.prototype.sendInvites = function( siteId, usernamesOrEmails, role, 
 			invitees: usernamesOrEmails,
 			role: role,
 			message: message,
+			source: 'calypso',
 		},
 		fn
 	);


### PR DESCRIPTION
See p3btAN-Th for more info and D10635-code

Ideally we would also be able to differentiate desktop app versus calypso using something like the `readerFollowingSource` config option - maybe we should rename that to be more generic and use it here too in a future PR.