### PR TITLE
Implement domain search filters: "More Filters"

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -110,6 +110,7 @@
 @import 'components/domains/map-domain-step/style';
 @import 'components/domains/transfer-domain-step/style';
 @import 'components/domains/register-domain-step/style';
+@import 'components/domains/search-filters/style';
 @import 'components/domains/registrant-extra-info/style';
 @import 'components/drop-zone/style';
 @import 'components/ellipsis-menu/style';

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -15,6 +15,7 @@ import {
 	includes,
 	isEmpty,
 	noop,
+	pickBy,
 	reject,
 	startsWith,
 	times,
@@ -28,6 +29,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import wpcom from 'lib/wp';
 import Notice from 'components/notice';
 import { checkDomainAvailability, getFixedDomainSearch } from 'lib/domains';
@@ -39,6 +41,7 @@ import DomainTransferSuggestion from 'components/domains/domain-transfer-suggest
 import DomainSuggestion from 'components/domains/domain-suggestion';
 import DomainSearchResults from 'components/domains/domain-search-results';
 import ExampleDomainSuggestions from 'components/domains/example-domain-suggestions';
+import SearchFilters from 'components/domains/search-filters';
 import { getCurrentUser } from 'state/current-user/selectors';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
@@ -63,6 +66,10 @@ let searchStackTimer = null;
 let lastSearchTimestamp = null;
 let searchCount = 0;
 let recordSearchFormSubmitWithDispatch;
+
+function isNumberString( string ) {
+	return /^[0-9_]+$/.test( string );
+}
 
 function getQueryObject( props ) {
 	if ( ! props.selectedSite || ! props.selectedSite.domain ) {
@@ -163,6 +170,7 @@ class RegisterDomainStep extends React.Component {
 
 		return {
 			clickedExampleSuggestion: false,
+			filters: this.getInitialFiltersState(),
 			lastQuery: suggestion,
 			lastDomainSearched: null,
 			lastDomainStatus: null,
@@ -172,6 +180,14 @@ class RegisterDomainStep extends React.Component {
 			notice: null,
 			searchResults: null,
 			subdomainSearchResults: null,
+		};
+	}
+
+	getInitialFiltersState() {
+		return {
+			excludeDashes: true,
+			maxCharacters: null,
+			showExactMatchesOnly: false,
 		};
 	}
 
@@ -279,9 +295,10 @@ class RegisterDomainStep extends React.Component {
 
 	render() {
 		const queryObject = getQueryObject( this.props );
+		const isKrackenUI = config.isEnabled( 'domains/kracken-ui' );
 
 		return (
-			<div className="register-domain-step">
+			<div className={ `register-domain-step ${ isKrackenUI ? 'is-kracken-ui' : '' }` }>
 				<div className="register-domain-step__search">
 					<SearchCard
 						ref={ this.bindSearchCardReference }
@@ -298,6 +315,16 @@ class RegisterDomainStep extends React.Component {
 						maxLength={ 60 }
 					/>
 				</div>
+				{ isKrackenUI && (
+					<div className="register-domain-step__filter">
+						<SearchFilters
+							filters={ this.state.filters }
+							onChange={ this.onFiltersChange }
+							onFiltersReset={ this.onFiltersReset }
+							onFiltersSubmit={ this.repeatSearch }
+						/>
+					</div>
+				) }
 				{ this.state.notice && (
 					<Notice
 						text={ this.state.notice }
@@ -334,7 +361,33 @@ class RegisterDomainStep extends React.Component {
 		this.props.onSave( this.state );
 	};
 
-	onSearchChange = searchQuery => {
+	repeatSearch = () => {
+		this.onSearchChange( this.state.lastQuery, () => this.onSearch( this.state.lastQuery ) );
+	};
+
+	getSetFilters() {
+		const { filters } = this.state;
+		return {
+			...pickBy( filters, value => isNumberString( value ) || typeof value === 'boolean' ),
+		};
+	}
+
+	onFiltersChange = newFilters => {
+		this.setState( {
+			filters: newFilters,
+		} );
+	};
+
+	onFiltersReset = () => {
+		this.setState(
+			{
+				filters: this.getInitialFiltersState(),
+			},
+			this.repeatSearch
+		);
+	};
+
+	onSearchChange = ( searchQuery, callback = noop ) => {
 		if ( ! this._isMounted ) {
 			return;
 		}
@@ -342,16 +395,20 @@ class RegisterDomainStep extends React.Component {
 		const loadingResults = Boolean( getFixedDomainSearch( searchQuery ) );
 
 		this.props.onDomainSearchChange( searchQuery );
-		this.setState( {
-			exactMatchDomain: null,
-			lastQuery: searchQuery,
-			lastDomainSearched: null,
-			loadingResults: loadingResults,
-			loadingSubdomainResults: loadingResults,
-			notice: null,
-			searchResults: null,
-			subdomainSearchResults: null,
-		} );
+
+		this.setState(
+			{
+				exactMatchDomain: null,
+				lastQuery: searchQuery,
+				lastDomainSearched: null,
+				loadingResults: loadingResults,
+				loadingSubdomainResults: loadingResults,
+				notice: null,
+				searchResults: null,
+				subdomainSearchResults: null,
+			},
+			callback
+		);
 	};
 
 	getTldWeightOverrides() {
@@ -426,6 +483,7 @@ class RegisterDomainStep extends React.Component {
 			tld_weight_overrides: this.getTldWeightOverrides(),
 			vendor: searchVendor,
 			vertical: this.props.surveyVertical,
+			...this.getSetFilters(),
 		};
 
 		domains
@@ -527,6 +585,7 @@ class RegisterDomainStep extends React.Component {
 			tld_weight_overrides: null,
 			vendor: 'wpcom',
 			vertical: this.props.surveyVertical,
+			...this.getSetFilters(),
 		};
 
 		domains

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -14,9 +14,11 @@ import {
 	get,
 	includes,
 	isEmpty,
+	mapKeys,
 	noop,
 	pickBy,
 	reject,
+	snakeCase,
 	startsWith,
 	times,
 	uniqBy,
@@ -365,10 +367,13 @@ class RegisterDomainStep extends React.Component {
 		this.onSearchChange( this.state.lastQuery, () => this.onSearch( this.state.lastQuery ) );
 	};
 
-	getSetFilters() {
+	getSetFiltersForAPI() {
 		const { filters } = this.state;
 		return {
-			...pickBy( filters, value => isNumberString( value ) || typeof value === 'boolean' ),
+			...mapKeys(
+				pickBy( filters, value => isNumberString( value ) || typeof value === 'boolean' ),
+				( value, key ) => snakeCase( key )
+			),
 		};
 	}
 
@@ -483,7 +488,7 @@ class RegisterDomainStep extends React.Component {
 			tld_weight_overrides: this.getTldWeightOverrides(),
 			vendor: searchVendor,
 			vertical: this.props.surveyVertical,
-			...this.getSetFilters(),
+			...this.getSetFiltersForAPI(),
 		};
 
 		domains
@@ -585,7 +590,7 @@ class RegisterDomainStep extends React.Component {
 			tld_weight_overrides: null,
 			vendor: 'wpcom',
 			vertical: this.props.surveyVertical,
-			...this.getSetFilters(),
+			...this.getSetFiltersForAPI(),
 		};
 
 		domains

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -186,7 +186,7 @@ class RegisterDomainStep extends React.Component {
 	getInitialFiltersState() {
 		return {
 			excludeDashes: true,
-			maxCharacters: null,
+			maxCharacters: '',
 			showExactMatchesOnly: false,
 		};
 	}

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -26,6 +26,15 @@
 	}
 }
 
+.register-domain-step.is-kracken-ui {
+	.register-domain-step__search {
+		padding-bottom: 10px;
+	}
+	.register-domain-step__filter {
+		padding-bottom: 20px;
+	}
+}
+
 @keyframes shake {
 	0%, 100% {
 	    transform: translate3d( 0, 0, 0 );

--- a/client/components/domains/search-filters/index.jsx
+++ b/client/components/domains/search-filters/index.jsx
@@ -18,7 +18,7 @@ export default class SearchFilters extends Component {
 	static propTypes = {
 		filters: PropTypes.shape( {
 			excludeDashes: PropTypes.bool,
-			maxCharacters: PropTypes.number,
+			maxCharacters: PropTypes.string,
 			showExactMatchesOnly: PropTypes.bool,
 		} ).isRequired,
 		onChange: PropTypes.func,

--- a/client/components/domains/search-filters/index.jsx
+++ b/client/components/domains/search-filters/index.jsx
@@ -1,0 +1,59 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { pick, noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+
+import MoreFiltersControl from './more-filters';
+
+export default class SearchFilters extends Component {
+	static propTypes = {
+		filters: PropTypes.shape( {
+			excludeDashes: PropTypes.bool,
+			maxCharacters: PropTypes.number,
+			showExactMatchesOnly: PropTypes.bool,
+		} ).isRequired,
+		onChange: PropTypes.func,
+		onFiltersReset: PropTypes.func,
+		onFiltersSubmit: PropTypes.func,
+	};
+
+	static defaultProps = {
+		onChange: noop,
+		onFiltersReset: noop,
+		onFiltersSubmit: noop,
+	};
+
+	updateFilterValues = ( name, value ) => {
+		const newFilters = {
+			...this.props.filters,
+			[ name ]: value,
+		};
+		this.props.onChange( newFilters );
+	};
+
+	render() {
+		return (
+			<div className="search-filters">
+				<MoreFiltersControl
+					{ ...pick( this.props.filters, [
+						'excludeDashes',
+						'maxCharacters',
+						'showExactMatchesOnly',
+						'onFiltersReset',
+					] ) }
+					onChange={ this.updateFilterValues }
+					{ ...pick( this.props, [ 'onFiltersReset', 'onFiltersSubmit' ] ) }
+				/>
+			</div>
+		);
+	}
+}

--- a/client/components/domains/search-filters/more-filters.jsx
+++ b/client/components/domains/search-filters/more-filters.jsx
@@ -1,0 +1,169 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormTextInput from 'components/forms/form-text-input';
+import FormLabel from 'components/forms/form-label';
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormFieldset from 'components/forms/form-fieldset';
+import Popover from 'components/popover';
+import Button from 'components/button';
+
+export class MoreFiltersControl extends Component {
+	static propTypes = {
+		excludeDashes: PropTypes.bool,
+		maxCharacters: PropTypes.number,
+		onChange: PropTypes.func,
+		onFiltersReset: PropTypes.func,
+		onFiltersSubmit: PropTypes.func,
+		showExactMatchesOnly: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		excludeDashes: true,
+		showExactMatchesOnly: false,
+	};
+
+	state = {
+		showPopover: false,
+	};
+
+	bindButton = button => ( this.button = button );
+
+	togglePopover = () => {
+		this.setState( {
+			showPopover: ! this.state.showPopover,
+		} );
+	};
+
+	hasFilterValues() {
+		return (
+			! this.props.excludeDashes ||
+			this.props.showExactMatchesOnly ||
+			Number.isFinite( this.props.maxCharacters )
+		);
+	}
+
+	getFiltercounts() {
+		return (
+			( ! this.props.excludeDashes && 1 ) +
+			( this.props.showExactMatchesOnly && 1 ) +
+			Number.isFinite( this.props.maxCharacters && 1 )
+		);
+	}
+
+	handleOnChange = event => {
+		const { currentTarget } = event;
+		if ( currentTarget.type === 'checkbox' ) {
+			this.props.onChange( currentTarget.name, currentTarget.checked );
+		} else if ( currentTarget.type === 'text' ) {
+			this.props.onChange( currentTarget.name, currentTarget.value );
+		}
+	};
+
+	handleFiltersReset = () => {
+		this.togglePopover();
+		this.props.onFiltersReset();
+	};
+	handleFiltersSubmit = () => {
+		this.togglePopover();
+		this.props.onFiltersSubmit();
+	};
+
+	render() {
+		const { translate } = this.props;
+		return (
+			<div className="search-filters__more-filters">
+				<Button
+					primary={ this.hasFilterValues() }
+					ref={ this.bindButton }
+					onClick={ this.togglePopover }
+				>
+					{ translate( 'More Filters' ) }
+					{ this.hasFilterValues() ? ` • ${ this.getFiltercounts() } ` : ' ' }
+					<Gridicon icon="chevron-down" size={ 24 } />
+				</Button>
+
+				{ this.renderPopover() }
+			</div>
+		);
+	}
+
+	renderPopover() {
+		const { excludeDashes, maxCharacters, showExactMatchesOnly, translate } = this.props;
+
+		return (
+			<Popover
+				className="search-filters__popover"
+				context={ this.button }
+				isVisible={ this.state.showPopover }
+				position="bottom right"
+			>
+				<FormFieldset className="search-filters__text-input-fieldset">
+					<FormLabel className="search-filters__label" htmlFor="search-filters-max-characters">
+						{ translate( 'Max Characters' ) }:
+					</FormLabel>
+					<FormTextInput
+						className="search-filters__input"
+						value={ maxCharacters }
+						id="search-filters-max-characters"
+						name="maxCharacters"
+						onChange={ this.handleOnChange }
+						placeholder="14"
+					/>
+				</FormFieldset>
+
+				<FormFieldset className="search-filters__checkboxes-fieldset">
+					<FormLabel
+						className="search-filters__label"
+						htmlFor="search-filters-show-exact-matches-only"
+					>
+						<FormInputCheckbox
+							className="search-filters__checkbox"
+							checked={ showExactMatchesOnly }
+							id="search-filters-show-exact-matches-only"
+							name="showExactMatchesOnly"
+							onChange={ this.handleOnChange }
+							value="showExactMatchesOnly"
+						/>
+						<span className="search-filters__checkbox-label">
+							{ translate( 'Show exact matches only' ) }
+						</span>
+					</FormLabel>
+
+					<FormLabel className="search-filters__label" htmlFor="search-filters-exclude-dashes">
+						<FormInputCheckbox
+							className="search-filters__checkbox"
+							checked={ excludeDashes }
+							id="search-filters-exclude-dashes"
+							name="excludeDashes"
+							onChange={ this.handleOnChange }
+							value="excludeDashes"
+						/>
+						<span className="search-filters__checkbox-label">
+							{ translate( 'Exclude dashes' ) }
+						</span>
+					</FormLabel>
+				</FormFieldset>
+				<div className="search-filters__buttons">
+					<Button onClick={ this.handleFiltersReset }>Reset</Button>
+					<Button primary onClick={ this.handleFiltersSubmit }>
+						Apply
+					</Button>
+				</div>
+			</Popover>
+		);
+	}
+}
+
+export default localize( MoreFiltersControl );

--- a/client/components/domains/search-filters/more-filters.jsx
+++ b/client/components/domains/search-filters/more-filters.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import ValidationFieldset from 'signup/validation-fieldset';
 import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import FormInputCheckbox from 'components/forms/form-checkbox';
@@ -22,7 +23,7 @@ import Button from 'components/button';
 export class MoreFiltersControl extends Component {
 	static propTypes = {
 		excludeDashes: PropTypes.bool,
-		maxCharacters: PropTypes.number,
+		maxCharacters: PropTypes.string,
 		onChange: PropTypes.func,
 		onFiltersReset: PropTypes.func,
 		onFiltersSubmit: PropTypes.func,
@@ -30,15 +31,15 @@ export class MoreFiltersControl extends Component {
 	};
 
 	static defaultProps = {
+		maxCharacters: '',
 		excludeDashes: true,
 		showExactMatchesOnly: false,
 	};
 
 	state = {
 		showPopover: false,
+		showOverallValidationError: false,
 	};
-
-	bindButton = button => ( this.button = button );
 
 	togglePopover = () => {
 		this.setState( {
@@ -46,51 +47,72 @@ export class MoreFiltersControl extends Component {
 		} );
 	};
 
-	hasFilterValues() {
-		return (
-			! this.props.excludeDashes ||
-			this.props.showExactMatchesOnly ||
-			Number.isFinite( this.props.maxCharacters )
-		);
-	}
-
 	getFiltercounts() {
 		return (
 			( ! this.props.excludeDashes && 1 ) +
 			( this.props.showExactMatchesOnly && 1 ) +
-			Number.isFinite( this.props.maxCharacters && 1 )
+			( this.props.maxCharacters !== '' && 1 )
 		);
+	}
+
+	getMaxCharactersValidationErrors() {
+		const { maxCharacters, translate } = this.props;
+		const isValid = /^-?\d*$/.test( maxCharacters );
+		return ! isValid ? [ translate( 'Value must be a whole number' ) ] : null;
+	}
+
+	getOverallValidationErrors() {
+		const isValid = this.getMaxCharactersValidationErrors() === null;
+		const { showOverallValidationError } = this.state;
+		return ! isValid && showOverallValidationError
+			? [ this.props.translate( 'Please correct any errors above' ) ]
+			: null;
+	}
+
+	hasValidationErrors() {
+		return this.getOverallValidationErrors() !== null;
 	}
 
 	handleOnChange = event => {
 		const { currentTarget } = event;
 		if ( currentTarget.type === 'checkbox' ) {
 			this.props.onChange( currentTarget.name, currentTarget.checked );
-		} else if ( currentTarget.type === 'text' ) {
+		} else if ( currentTarget.type === 'number' ) {
+			window.currentTarget = currentTarget;
 			this.props.onChange( currentTarget.name, currentTarget.value );
 		}
 	};
 
 	handleFiltersReset = () => {
-		this.togglePopover();
-		this.props.onFiltersReset();
+		this.setState( { showOverallValidationError: false }, () => {
+			this.togglePopover();
+			this.props.onFiltersReset();
+		} );
 	};
 	handleFiltersSubmit = () => {
-		this.togglePopover();
-		this.props.onFiltersSubmit();
+		if ( this.hasValidationErrors() ) {
+			this.setState( { showOverallValidationError: true } );
+			return;
+		}
+
+		this.setState( { showOverallValidationError: false }, () => {
+			this.togglePopover();
+			this.props.onFiltersSubmit();
+		} );
 	};
 
 	render() {
 		const { translate } = this.props;
+		const hasFilterValues = this.getFiltercounts() > 0;
 		return (
 			<div className="search-filters__more-filters">
 				<Button
-					primary={ this.hasFilterValues() }
-					ref={ this.bindButton }
+					primary={ hasFilterValues }
+					ref={ button => ( this.button = button ) } // eslint-disable-line react/jsx-no-bind
 					onClick={ this.togglePopover }
 				>
 					{ translate( 'More Filters' ) }
-					{ this.hasFilterValues() ? ` • ${ this.getFiltercounts() } ` : ' ' }
+					{ hasFilterValues ? ` • ${ this.getFiltercounts() } ` : ' ' }
 					<Gridicon icon="chevron-down" size={ 24 } />
 				</Button>
 
@@ -108,20 +130,26 @@ export class MoreFiltersControl extends Component {
 				context={ this.button }
 				isVisible={ this.state.showPopover }
 				position="bottom right"
+				onClose={ this.togglePopover }
 			>
-				<FormFieldset className="search-filters__text-input-fieldset">
+				<ValidationFieldset
+					className="search-filters__text-input-fieldset"
+					errorMessages={ this.getMaxCharactersValidationErrors() }
+				>
 					<FormLabel className="search-filters__label" htmlFor="search-filters-max-characters">
 						{ translate( 'Max Characters' ) }:
 					</FormLabel>
 					<FormTextInput
 						className="search-filters__input"
-						value={ maxCharacters }
 						id="search-filters-max-characters"
+						min="1"
 						name="maxCharacters"
 						onChange={ this.handleOnChange }
 						placeholder="14"
+						type="number"
+						value={ maxCharacters }
 					/>
-				</FormFieldset>
+				</ValidationFieldset>
 
 				<FormFieldset className="search-filters__checkboxes-fieldset">
 					<FormLabel
@@ -155,12 +183,18 @@ export class MoreFiltersControl extends Component {
 						</span>
 					</FormLabel>
 				</FormFieldset>
-				<div className="search-filters__buttons">
-					<Button onClick={ this.handleFiltersReset }>Reset</Button>
-					<Button primary onClick={ this.handleFiltersSubmit }>
-						Apply
-					</Button>
-				</div>
+
+				<ValidationFieldset
+					className="search-filters__buttons-fieldset"
+					errorMessages={ this.getOverallValidationErrors() }
+				>
+					<div className="search-filters__buttons">
+						<Button onClick={ this.handleFiltersReset }>Reset</Button>
+						<Button primary onClick={ this.handleFiltersSubmit }>
+							Apply
+						</Button>
+					</div>
+				</ValidationFieldset>
 			</Popover>
 		);
 	}

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -8,6 +8,13 @@
 	.form-fieldset {
 		text-align: left;
 	}
+
+	.validation-fieldset {
+		margin-bottom: 1em;
+	}
+	.validation-fieldset__validation-message {
+		min-height: initial;
+	}
 }
 
 .search-filters__buttons {

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -1,0 +1,37 @@
+.search-filters__popover {
+	width: 28em;
+
+	.popover__inner {
+		padding: 2em;
+	}
+
+	.form-fieldset {
+		text-align: left;
+	}
+}
+
+.search-filters__buttons {
+	display: flex;
+	justify-content: space-between;
+
+	.button {
+		flex: 1 0 auto;
+		padding: 0.5em 3em 0.5em 3em;
+		margin-right: 1em;
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+}
+
+.search-filters__text-input-fieldset .search-filters__label {
+	margin-bottom: 0.25em;
+}
+
+.search-filters__checkboxes-fieldset .search-filters__label {
+	margin-bottom: 1em;
+
+	&:last-of-type {
+		margin-bottom: 0;
+	}
+}


### PR DESCRIPTION
This change adds the first domain filters to the `/start/domains` section of the user signup experience. It adds a `<SearchFilters>` component to `<RegisterDomainStep>` signup component. `SearchFilters` is designed to hold multiple search filter components and currently holds `<MoreFiltersControl>` for managing max character, exact match, and exclude dashes filters.

![domain_search_filters](https://user-images.githubusercontent.com/4044428/37312070-32aa483e-260f-11e8-9619-2a06754922ba.png)
 
### Testing instructions
1. Spin up this branch locally.
2. Navigate to [`/start/domains`](http://calypso.localhost:3000/start/domains).
3. Ensure presence of the `More Filters` popover button.
4. Ensure that clicking the button spawns a popover with the following controls:
    - Max characters filter, defaulting to empty.
    - Exact matches filter, defaulting to unchecked (false).
    - Exclude dashes filter, defaulting to checked (true).
5. Ensure that enacting any of the filters by clicking `Apply` refreshes the domain search with a corresponding network request. Two things to note:
    - The results will not actually be filtered since such functionality has not yet been implemented in the server.
    - In its current design, the network request will only contain filter values that are defined. Currently, that means either a true/false boolean or a lengthy string containing numbers.

![wordpress_com](https://user-images.githubusercontent.com/4044428/37430149-e71eff52-2796-11e8-8164-f91c40e5c0fd.png)

6. Ensure that resetting the filters by clicking `Reset` refreshes the domain search results with a corresponding network request.

7. Ensure that no other behavioral changes have been introduced to the page.