### PR TITLE
ContactForm: constrain width of elements when field legend contains long words

### DIFF
--- a/client/components/tinymce/plugins/contact-form/dialog/field-header.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/field-header.jsx
@@ -78,14 +78,16 @@ class ContactFormDialogFieldHeader extends React.Component {
 	};
 
 	render() {
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<div>
+			<div className="editor-contact-form-modal-field-header">
 				<div>{ this.props.label }</div>
 				<div>
 					<small>{ this.getLegend() }</small>
 				</div>
 			</div>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 

--- a/client/components/tinymce/plugins/contact-form/style.scss
+++ b/client/components/tinymce/plugins/contact-form/style.scss
@@ -73,6 +73,14 @@
 	.card {
 		border-radius: 4px;
 	}
+	.foldable-card__main {
+		min-width: 0;
+		word-wrap: break-word;
+	}
+}
+
+.editor-contact-form-modal-field-header {
+	width: 100%;
 }
 
 .editor-contact-form-modal-settings {

--- a/public/tinymce/skins/wordpress/wp-content.css
+++ b/public/tinymce/skins/wordpress/wp-content.css
@@ -426,6 +426,7 @@ audio {
 	border: none;
 	padding: 0;
 	width: 300px;
+	min-width: 0;
 	margin: 0 auto 10px;
 }
 
@@ -433,6 +434,7 @@ audio {
 .wpview-type-contact-form-field legend {
 	text-align: left;
 	width: 100%;
+	word-wrap: break-word;
 }
 
 .wpview-type-contact-form-field label {


### PR DESCRIPTION
This PR addresses https://github.com/Automattic/wp-calypso/issues/22926, where long words can cause the content to overflow the width of containing elements. In the preview mode the text overflows the `legend`; in edit mode it overflows the first child of the `.foldable-card__main` element.

* `word-wrap: break-word` allows long words to break.
* `min-width: 0` on the fieldset element and the `.foldable-card__main` span fixes rendering in Firefox, which applies `min-width: auto` as the default minimum size of fieldsets and flex items. This is the approach recommended for flex items in https://www.w3.org/TR/css-flexbox/#flex-common. See https://stackoverflow.com/questions/17408815/fieldset-resizes-wrong-appears-to-have-unremovable-min-width-min-content.
* `width: 100%` is required on the first child of the `.foldable-card__main` span to correct IE11's implementation of text wrapping in a flex element. See https://stackoverflow.com/questions/35111090/text-in-a-flex-container-doesnt-wrap-in-ie11.

Tested in 
* IE11 Win 7
* Safari 11 macOS
* Chrome 64 macOS
* Chrome Android v8

cc @samouri 