### PR TITLE
Devdocs: fix Timezone styles in PostSchedule example

### DIFF
--- a/client/components/post-schedule/docs/example.jsx
+++ b/client/components/post-schedule/docs/example.jsx
@@ -119,15 +119,8 @@ const PostScheduleExample = localize(
 
 		render() {
 			return (
-				<div>
-					<Card
-						style={ {
-							width: '300px',
-							verticalAlign: 'top',
-							display: 'inline-block',
-							margin: 0,
-						} }
-					>
+				<div className="docs__post-schedule">
+					<Card className="docs__post-schedule-card">
 						<PostSchedule
 							events={ this.state.events }
 							onDateChange={ this.setDate }
@@ -146,14 +139,7 @@ const PostScheduleExample = localize(
 						/>
 					</Card>
 
-					<div
-						style={ {
-							width: '260px',
-							display: 'inline-block',
-							verticalAlign: 'top',
-							margin: ' 0 0 0 30px',
-						} }
-					>
+					<div className="docs__post-schedule-timezone-card-wrapper">
 						<Card className="card__component-instance">
 							<h3>
 								<span>owner</span>
@@ -167,14 +153,14 @@ const PostScheduleExample = localize(
 									{ this.state.timezone || 'not defined' }
 								</div>
 
-								<Timezone selectedZone={ this.state.timezone } onSelect={ this.setTimezone } />
+								<Timezone
+									className="post-schedule__component-timezone"
+									selectedZone={ this.state.timezone }
+									onSelect={ this.setTimezone }
+								/>
 
 								<a
 									className="card__property-action"
-									style={ {
-										top: '-8px',
-										position: 'relative',
-									} }
 									onClick={ this.clearState.bind( this, 'timezone' ) }
 									href="#"
 								>

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -138,6 +138,10 @@ input[type="text"].post-schedule__clock-time {
 	border-top: 1px solid lighten( $gray, 25% );
 }
 
+.post-schedule__component-timezone {
+	width: 100%;
+}
+
 .post-schedule__timezone-info {
 	display: inline-block;
 	vertical-align: middle;

--- a/client/components/timezone/index.jsx
+++ b/client/components/timezone/index.jsx
@@ -7,6 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import classnames from 'classnames';
 import { map, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -60,9 +61,16 @@ class Timezone extends Component {
 	}
 
 	render() {
-		const { selectedZone } = this.props;
+		const { className, selectedZone } = this.props;
 		return (
-			<select onChange={ this.onSelect } value={ selectedZone || '' }>
+			// Changing this to onBlur will not work, so we ignore this
+			// warning.
+			/* eslint-disable jsx-a11y/no-onchange */
+			<select
+				className={ classnames( 'timezone__component', className ) }
+				onChange={ this.onSelect }
+				value={ selectedZone || '' }
+			>
 				<QueryTimezones />
 				{ this.renderOptionsByContinent() }
 				<optgroup label="UTC">
@@ -70,6 +78,7 @@ class Timezone extends Component {
 				</optgroup>
 				{ this.props.includeManualOffsets && this.renderManualUtcOffsets() }
 			</select>
+			/* eslint-enable jsx-a11y/no-onchange */
 		);
 	}
 }
@@ -80,6 +89,7 @@ Timezone.defaultProps = {
 };
 
 Timezone.propTypes = {
+	className: PropTypes.string,
 	selectedZone: PropTypes.string,
 	onSelect: PropTypes.func,
 	includeManualOffsets: PropTypes.bool,

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -199,3 +199,28 @@
 		}
 	}
 }
+
+.docs__post-schedule {
+	@include breakpoint( ">480px" ) {
+		display: flex;
+		justify-content: space-between;
+	}
+}
+
+.docs__post-schedule-card {
+	display: inline-block;
+	margin: 0;
+	vertical-align: top;
+}
+
+.docs__post-schedule-timezone-card-wrapper {
+	display: inline-block;
+	margin: 15px 0 0;
+	vertical-align: top;
+
+	@include breakpoint( ">480px" ) {
+		margin: 0 0 0 10px;
+		width: calc(50% - 10px);
+	}
+}
+


### PR DESCRIPTION
Fixes #22966

Note there were a few hard-code `style` props here as well messing up the padding. I removed those too, but I didn't make a separate issue for it as I didn't notice until mid-way through the patch 😄 

### Before
<img width="735" alt="screenshot 2018-03-03 10 18 56" src="https://user-images.githubusercontent.com/90871/36938691-31bff2aa-1f1d-11e8-99b7-b27fee82ef41.png">

### After
<img width="623" alt="screenshot 2018-03-03 19 05 11" src="https://user-images.githubusercontent.com/90871/36938689-2d9a16ec-1f1d-11e8-9bdf-4f63a3c062d1.png">
