### PR TITLE
Purchases: allow adding payment details when renewing but not a card purchase

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -29,6 +29,7 @@ import {
 	isExpired,
 	isExpiring,
 	isOneTimePurchase,
+	isPaidWithCreditCard,
 	isRefundable,
 	isRenewable,
 	isRenewal,
@@ -195,7 +196,11 @@ class ManagePurchase extends Component {
 			const path = getEditCardDetailsPath( this.props.selectedSite, purchase );
 			const renewing = isRenewing( purchase );
 
-			if ( renewing && ! cardProcessorSupportsUpdates( purchase ) ) {
+			if (
+				renewing &&
+				isPaidWithCreditCard( purchase ) &&
+				! cardProcessorSupportsUpdates( purchase )
+			) {
 				return null;
 			}
 


### PR DESCRIPTION
Only return null from ManagePurchase.renderEditPaymentMethodNavItem when is actually a card purchase.

In some occasions (when, for example, a plan has been removed and the bundled domain is kept), the user needs to be able to update its payment method. The current condition won't allow that because it assumes a card payment when the bundled domain doesn't actually have the payment info (but is still marked as renewing).

See pNPgK-3pE-p2



