### PR TITLE
PostEditor Help: add missing formatting shortcuts to the help modal

### DIFF
--- a/client/components/tinymce/plugins/wpcom-help/help-modal.jsx
+++ b/client/components/tinymce/plugins/wpcom-help/help-modal.jsx
@@ -26,51 +26,128 @@ class HelpModal extends React.Component {
 	};
 
 	defaultShortcuts = () => {
+		const { translate } = this.props;
 		return [
-			{ c: this.props.translate( 'Copy' ), x: this.props.translate( 'Cut' ) },
-			{ v: this.props.translate( 'Paste' ), a: this.props.translate( 'Select all' ) },
-			{ z: this.props.translate( 'Undo' ), y: this.props.translate( 'Redo' ) },
-			{ b: this.props.translate( 'Bold' ), i: this.props.translate( 'Italic' ) },
-			{ u: this.props.translate( 'Underline' ), k: this.props.translate( 'Insert/edit link' ) },
+			[
+				{ shortcut: 'c', action: translate( 'Copy' ) },
+				{ shortcut: 'x', action: translate( 'Cut' ) },
+			],
+			[
+				{ shortcut: 'v', action: translate( 'Paste' ) },
+				{ shortcut: 'a', action: translate( 'Select all' ) },
+			],
+			[
+				{ shortcut: 'z', action: translate( 'Undo' ) },
+				{ shortcut: 'y', action: translate( 'Redo' ) },
+			],
+			[
+				{ shortcut: 'b', action: translate( 'Bold' ) },
+				{ shortcut: 'i', action: translate( 'Italic' ) },
+			],
+			[
+				{ shortcut: 'u', action: translate( 'Underline' ) },
+				{ shortcut: 'k', action: translate( 'Insert/edit link' ) },
+			],
 		];
 	};
 
 	additionalShortcuts = () => {
+		const { translate } = this.props;
 		return [
-			{ 1: this.props.translate( 'Heading 1' ), 2: this.props.translate( 'Heading 2' ) },
-			{ 3: this.props.translate( 'Heading 3' ), 4: this.props.translate( 'Heading 4' ) },
-			{ 5: this.props.translate( 'Heading 5' ), 6: this.props.translate( 'Heading 6' ) },
-			{ l: this.props.translate( 'Align left' ), c: this.props.translate( 'Align center' ) },
-			{ r: this.props.translate( 'Align right' ), j: this.props.translate( 'Justify' ) },
-			{ d: this.props.translate( 'Strikethrough' ), q: this.props.translate( 'Blockquote' ) },
-			{ u: this.props.translate( 'Bullet list' ), o: this.props.translate( 'Numbered list' ) },
-			{ a: this.props.translate( 'Insert/edit link' ), s: this.props.translate( 'Remove link' ) },
-			{
-				m: this.props.translate( 'Insert/edit image' ),
-				t: this.props.translate( 'Insert Read More tag' ),
-			},
-			{ h: this.props.translate( 'Keyboard Shortcuts' ), x: this.props.translate( 'Code' ) },
-			{ p: this.props.translate( 'Insert Page Break tag' ) },
+			[
+				{ shortcut: 1, action: translate( 'Heading 1' ) },
+				{ shortcut: 2, action: translate( 'Heading 2' ) },
+			],
+			[
+				{ shortcut: 3, action: translate( 'Heading 3' ) },
+				{ shortcut: 4, action: translate( 'Heading 4' ) },
+			],
+			[
+				{ shortcut: 5, action: translate( 'Heading 5' ) },
+				{ shortcut: 6, action: translate( 'Heading 6' ) },
+			],
+			[
+				{ shortcut: 'l', action: translate( 'Align left' ) },
+				{ shortcut: 'c', action: translate( 'Align center' ) },
+			],
+			[
+				{ shortcut: 'r', action: translate( 'Align right' ) },
+				{ shortcut: 'j', action: translate( 'Justify' ) },
+			],
+			[
+				{ shortcut: 'd', action: translate( 'Strikethrough' ) },
+				{ shortcut: 'q', action: translate( 'Blockquote' ) },
+			],
+			[
+				{ shortcut: 'u', action: translate( 'Bulleted list' ) },
+				{ shortcut: 'o', action: translate( 'Numbered list' ) },
+			],
+			[
+				{ shortcut: 'a', action: translate( 'Insert/edit link' ) },
+				{ shortcut: 's', action: translate( 'Remove link' ) },
+			],
+			[
+				{ shortcut: 'm', action: translate( 'Insert/edit image' ) },
+				{ shortcut: 't', action: translate( 'Insert Read More tag' ) },
+			],
+			[
+				{ shortcut: 'h', action: translate( 'Keyboard Shortcuts' ) },
+				{ shortcut: 'x', action: translate( 'Code' ) },
+			],
+			[ { shortcut: 'p', action: translate( 'Insert Page Break tag' ) } ],
 		];
 	};
 
-	renderRow = ( row, index ) => {
+	spaceFormatShortcuts = () => {
+		const { translate } = this.props;
+		return [
+			[
+				{ shortcut: '*', action: translate( 'Bulleted list' ) },
+				{ shortcut: '1.', action: translate( 'Numbered list' ) },
+			],
+			[
+				{ shortcut: '-', action: translate( 'Bulleted list' ) },
+				{ shortcut: '1)', action: translate( 'Numbered list' ) },
+			],
+		];
+	};
+
+	enterFormatShortcuts = () => {
+		const { translate } = this.props;
+		return [
+			[
+				{ shortcut: '>', action: translate( 'Blockquote' ) },
+				{ shortcut: '##', action: translate( 'Heading 2' ) },
+			],
+			[
+				{ shortcut: '###', action: translate( 'Heading 3' ) },
+				{ shortcut: '####', action: translate( 'Heading 4' ) },
+			],
+			[
+				{ shortcut: '#####', action: translate( 'Heading 5' ) },
+				{ shortcut: '######', action: translate( 'Heading 6' ) },
+			],
+			[ { shortcut: '---', action: translate( 'Horizontal line' ) } ],
+		];
+	};
+
+	renderRow = ( row, rowIndex ) => {
 		let columns = [];
 
-		forEach( row, ( text, key ) => {
+		forEach( row, cellPair => {
 			columns.push(
-				<th className="wpcom-help__key" key={ key }>
-					<kbd>{ key }</kbd>
+				<th className="wpcom-help__key" key={ cellPair.shortcut }>
+					<kbd>{ cellPair.shortcut }</kbd>
 				</th>
 			);
 			columns.push(
-				<td className="wpcom-help__action" key={ text }>
-					{ text }
+				<td className="wpcom-help__action" key={ cellPair.action }>
+					{ cellPair.action }
 				</td>
 			);
 		} );
 
-		return <tr key={ index }>{ columns }</tr>;
+		return <tr key={ rowIndex }>{ columns }</tr>;
 	};
 
 	getButtons = () => {
@@ -105,17 +182,21 @@ class HelpModal extends React.Component {
 	};
 
 	render() {
+		const translate = this.props.translate;
+
 		const defaultText = this.props.macosx
-			? this.props.translate( 'Default shortcuts, Command + key:', { context: 'Mac shortcuts' } )
-			: this.props.translate( 'Default shortcuts, Ctrl + key:', { context: 'Windows shortcuts' } );
+			? translate( 'Default shortcuts. Command + key:', { context: 'Mac shortcuts' } )
+			: translate( 'Default shortcuts. Ctrl + key:', { context: 'Windows shortcuts' } );
 
 		const additionalText = this.props.macosx
-			? this.props.translate( 'Additional shortcuts, Control + Option + key:', {
+			? translate( 'Additional shortcuts. Control + Option + key:', {
 					context: 'Mac shortcuts',
 				} )
-			: this.props.translate( 'Additional shortcuts, Shift + Alt + key:', {
+			: translate( 'Additional shortcuts. Shift + Alt + key:', {
 					context: 'Windows shortcuts',
 				} );
+
+		const tableHead = this.getTableHead();
 
 		return (
 			<Dialog
@@ -124,16 +205,32 @@ class HelpModal extends React.Component {
 				additionalClassNames="wpcom-help__dialog"
 				onClose={ this.props.onClose }
 			>
-				<h2 className="wpcom-help__heading">{ this.props.translate( 'Keyboard Shortcuts' ) }</h2>
+				<h2 className="wpcom-help__heading">{ translate( 'Keyboard Shortcuts' ) }</h2>
 				<p>{ defaultText }</p>
 				<table className="wpcom-help__table">
-					{ this.getTableHead() }
+					{ tableHead }
 					<tbody>{ this.defaultShortcuts().map( this.renderRow, this ) }</tbody>
 				</table>
 				<p>{ additionalText }</p>
 				<table className="wpcom-help__table">
-					{ this.getTableHead() }
+					{ tableHead }
 					<tbody>{ this.additionalShortcuts().map( this.renderRow, this ) }</tbody>
+				</table>
+				<p>
+					{ translate(
+						'Formatting shortcuts. Start a new paragraph with the shortcut and press Space to apply the formatting.'
+					) }
+				</p>
+				<table className="wpcom-help__table">
+					<tbody>{ this.spaceFormatShortcuts().map( this.renderRow, this ) }</tbody>
+				</table>
+				<p>
+					{ translate(
+						'Formatting shortcuts. These shortcuts are turned into formatting when you press Enter.'
+					) }
+				</p>
+				<table className="wpcom-help__table">
+					<tbody>{ this.enterFormatShortcuts().map( this.renderRow, this ) }</tbody>
 				</table>
 			</Dialog>
 		);

--- a/client/components/tinymce/plugins/wpcom-help/style.scss
+++ b/client/components/tinymce/plugins/wpcom-help/style.scss
@@ -1,6 +1,9 @@
-.wpcom-help__dialog.dialog.card {
-	@include breakpoint( ">660px" ) {
-		max-width: 700px;
+.wpcom-help__dialog {
+	&.dialog.card {
+		@include breakpoint('>660px') {
+			flex: 1 0 100%;
+			max-width: 700px;
+		}
 	}
 }
 
@@ -8,7 +11,6 @@
 	font-size: 24px;
 }
 
-.wpcom-help__key,
 .wpcom-help__action {
 	border: 1px solid lighten( $gray, 20 );
 	font-weight: normal;
@@ -17,10 +19,17 @@
 
 .wpcom-help__key {
 	width: 48px;
+	padding: 4px 6px 4px 4px;
+	border: 1px solid lighten( $gray, 20 );
+	border-width: 0 0 1px;
 	text-align: center;
-	border-width: 0 0 1px 0;
 	font-weight: 700;
+	@include breakpoint( '>480px' ) {
+		width: 60px;
+		padding: 4px;
+	}
 }
+
 .wpcom-help__action {
 	border-width: 0 1px 1px 0;
 }


### PR DESCRIPTION
The post editor help modal is missing some information about formatting shortcuts which appears in the corresponding help modal in wp-admin. This PR adds them to the bottom of the list.

![help-modal](https://user-images.githubusercontent.com/1647564/36965660-3e11122e-2052-11e8-8469-7c4a16216af7.png)

https://github.com/Automattic/wp-calypso/issues/4829