### PR TITLE
Excerpt Tooltip: Reword tooltip to be more like the wp-admin version.

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -188,7 +188,10 @@ class EditorDrawer extends Component {
 			<AccordionSection>
 				<EditorDrawerLabel
 					labelText={ translate( 'Excerpt' ) }
-					helpText={ translate( 'Excerpts are optional hand-crafted summaries of your content.' ) }
+					helpText={ translate(
+						'An excerpt is a short summary you can add to your posts. ' +
+							"Some themes show excerpts alongside post titles on your site's homepage and archive pages."
+					) }
 				>
 					<TrackInputChanges onNewValue={ this.recordExcerptChangeStats }>
 						<FormTextarea


### PR DESCRIPTION
In `wp-admin`, the tooltip on the excerpt textarea better communicates that the excerpt may or may not be displayed. The Calypso wording is

> Excerpts are optional hand-crafted summaries of your content.

The `wp-admin` wording is 

> Excerpts are optional hand-crafted summaries of your content that can be used in your theme.

This PR improves the wording of the Calypso tooltip so users aren't surprised if their theme does not display the excerpt.

https://github.com/Automattic/wp-calypso/issues/1580

![excerpt-tooltip](https://user-images.githubusercontent.com/1647564/36950112-1f49753e-1fe9-11e8-832d-9480700c4610.png)
