### PR TITLE
Jetpack: Fix vaultpress support link

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -52,7 +52,7 @@ export const IMPORT = `${ root }/import`;
 export const INSTAGRAM_WIDGET = `${ root }/instagram/instagram-widget`;
 export const JETPACK_SUPPORT = 'https://jetpack.com/support/';
 export const JETPACK_CONTACT_SUPPORT = 'https://jetpack.com/contact-support/?rel=support';
-export const JETPACK_SERVICE_VAULTPRESS = 'https://help.vaultpress.com/';
+export const JETPACK_SERVICE_VAULTPRESS = 'https://help.vaultpress.com/install-vaultpress/';
 export const JETPACK_SERVICE_AKISMET = 'https://akismet.com/support/';
 export const JETPACK_SERVICE_POLLDADDY = 'https://support.polldaddy.com/';
 export const LIVE_CHAT = `${ root }/live-chat`;


### PR DESCRIPTION
fixes https://github.com/Automattic/wp-calypso/issues/22068

Update for the vaultpress install help. The link is shown when the autoinstall process fails and the user needs to complete the install manually.

Well, I can't make it fail ATM, so I can't tell you how to test it. But it's literally a string update :)