### PR TITLE
Themes Showcase: Stop themes banner CTA button appearing above sticky search bar

### DIFF
--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -8,11 +8,11 @@
 	padding: 0.8em;
 	overflow: hidden;
 	user-select: none;
-	
+
 	&:hover, &:focus, &:visited {
 		color: white !important;
 	}
-	
+
 	&:before {
 		position: absolute;
 		display: block;
@@ -24,13 +24,13 @@
 		left: 0;
 		z-index: 1;
 	}
-	
+
 	h1, p, .button.themes-banner__cta {
 		position: relative;
 		color: inherit;
 		z-index: 2;
 	}
-	
+
 	h1 {
 		font-weight: bold;
 		font-size: 1.6em;
@@ -44,12 +44,12 @@
 			margin-top: 0.6em;
 		}
 	}
-	
+
 	p {
 		margin: 0;
 		text-shadow: 0 1px 1px rgba(black, 0.4);
 	}
-	
+
 	img {
 		position: absolute;
 		transform-origin: top right;
@@ -58,14 +58,13 @@
 		user-select: none;
 		top: 0;
 		right: 0;
-		
+
 		@media (max-width: 1440px) {
 			opacity: 0.5;
 		}
 	}
-	
+
 	.button.themes-banner__cta {
 		margin-top: 1em;
-		z-index: 101;
 	}
 }


### PR DESCRIPTION
When the themes banner is displayed on the themes showcase and you scroll down so that the theme search bar sticks to the top of the page, the button on the themes banner appears above the search bar because it has a high z index.

This PR removes the `z-index: 101` from the button style. The button inherits a z index of 2 from an earlier style and the high value doesn't seem to be necessary - the banner continues to render OK at all breakpoints.

https://github.com/Automattic/wp-calypso/issues/22976

cc @mendezcode